### PR TITLE
feat(dedup): fingerprint on visible text, stripping HTML markup

### DIFF
--- a/internal/jobhash/rolefingerprint.go
+++ b/internal/jobhash/rolefingerprint.go
@@ -3,6 +3,7 @@ package jobhash
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"html"
 	"regexp"
 	"strings"
 
@@ -32,10 +33,23 @@ func RoleFingerprint(p db.UpsertJobParams) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// normalizeRoleText lower-cases and collapses runs of whitespace so cosmetic case or
-// spacing differences in a re-post do not split one role. The normalization stays
-// narrow (no stemming/punctuation stripping) to avoid over-merging distinct roles.
+// htmlTag matches a single HTML tag. Descriptions are stored as sanitized HTML (an
+// ingest-time bluemonday prose allowlist, see internal/sources.SanitizeHTML), so tags
+// are well-formed and their text is entity-escaped — there is no stray "<"/">" in
+// visible text for this to over-strip.
+var htmlTag = regexp.MustCompile(`<[^>]*>`)
+
+// normalizeRoleText reduces s to its visible text — HTML tags removed and HTML entities
+// decoded — then lower-cases and collapses runs of whitespace, so a re-post whose only
+// difference is markup, entity encoding, or cosmetic case/spacing still clusters to one
+// role. Tags are replaced with a space (not deleted) so words separated only by a block
+// element ("a</p><p>b") keep their boundary. The tag strip runs before entity decoding,
+// so an escaped angle bracket in visible text ("a &lt; b") is decoded only after real
+// tags are gone and is never mistaken for a tag. The normalization stays narrow beyond
+// this (no stemming/punctuation stripping) to avoid over-merging distinct roles.
 func normalizeRoleText(s string) string {
+	s = htmlTag.ReplaceAllString(s, " ")
+	s = html.UnescapeString(s)
 	return strings.Join(strings.Fields(strings.ToLower(s)), " ")
 }
 

--- a/internal/jobhash/rolefingerprint_test.go
+++ b/internal/jobhash/rolefingerprint_test.go
@@ -157,6 +157,81 @@ func TestRoleFingerprint_DifferentDescriptionStaysSeparate(t *testing.T) {
 	}
 }
 
+// The fingerprint compares VISIBLE text, not markup: two postings whose rendered
+// title and description are identical must share a fingerprint even when their HTML
+// differs (a stray tag, a different wrapper, or an entity vs its literal). Descriptions
+// are stored as sanitized HTML, so markup churn from a re-post or a second source must
+// not split one role.
+func TestRoleFingerprint_IgnoresDescriptionMarkup(t *testing.T) {
+	base := sample()
+	base.Description = "<p>Build <strong>smart</strong> fridges. Q&amp;A included.</p>"
+	baseFP := RoleFingerprint(base)
+	cases := map[string]string{
+		"extra_br":        "<p>Build <strong>smart</strong> fridges. Q&amp;A included.</p><br>",
+		"different_wrap":  "<div>Build <b>smart</b> fridges. Q&amp;A included.</div>",
+		"entity_vs_liter": "<p>Build <strong>smart</strong> fridges. Q&A included.</p>",
+		"no_markup":       "Build smart fridges. Q&A included.",
+	}
+	for name, desc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := sample()
+			p.Description = desc
+			if got := RoleFingerprint(p); got != baseFP {
+				t.Errorf("markup-only difference %s split the fingerprint (should collapse)", name)
+			}
+		})
+	}
+}
+
+// Entity decoding applies to the title too, so a source that HTML-encodes an ampersand
+// in the title clusters with one that does not.
+func TestRoleFingerprint_DecodesEntitiesInTitle(t *testing.T) {
+	literal := sample()
+	literal.Title = "R&D Platform Engineer"
+	encoded := sample()
+	encoded.Title = "R&amp;D Platform Engineer"
+	if RoleFingerprint(literal) != RoleFingerprint(encoded) {
+		t.Error("entity-encoded title did not cluster with its decoded form")
+	}
+}
+
+// An `&nbsp;` entity folds to a plain space, so a posting that glues words with the
+// no-break-space entity clusters with one that uses a regular space.
+func TestRoleFingerprint_FoldsNonBreakingSpaceEntity(t *testing.T) {
+	nbsp := sample()
+	nbsp.Description = "Build&nbsp;smart&nbsp;fridges."
+	plain := sample()
+	plain.Description = "Build smart fridges."
+	if RoleFingerprint(nbsp) != RoleFingerprint(plain) {
+		t.Error("&nbsp;-glued description did not cluster with its space-separated form")
+	}
+}
+
+// Markup that carries no visible text (an empty or tags-only description) normalizes to
+// the same empty text, so two such postings with an equal title still share a fingerprint.
+func TestRoleFingerprint_EmptyAndTagsOnlyDescriptionCollapse(t *testing.T) {
+	empty := sample()
+	empty.Description = ""
+	tagsOnly := sample()
+	tagsOnly.Description = "<p></p><br>"
+	if RoleFingerprint(empty) != RoleFingerprint(tagsOnly) {
+		t.Error("empty and tags-only descriptions produced different fingerprints")
+	}
+}
+
+// The over-merge guard survives visible-text normalization: two postings with the same
+// markup shape but a real visible-text difference (e.g. a city-specific legal clause in
+// one and not the other, like the Austrian Kollektivvertrag case) must stay separate.
+func TestRoleFingerprint_VisibleTextDifferenceStaysSeparate(t *testing.T) {
+	withClause := sample()
+	withClause.Description = "<p>Build smart fridges.</p><p>Kollektivvertrag Wien applies.</p>"
+	without := sample()
+	without.Description = "<p>Build smart fridges.</p>"
+	if RoleFingerprint(withClause) == RoleFingerprint(without) {
+		t.Error("distinct visible descriptions collapsed: over-merge across a real text difference")
+	}
+}
+
 // Field-boundary guard: title/description content must not shift across the boundary
 // and collide.
 func TestRoleFingerprint_FieldsAreDelimited(t *testing.T) {

--- a/openspec/changes/dedup-fingerprint-html-strip/.openspec.yaml
+++ b/openspec/changes/dedup-fingerprint-html-strip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/dedup-fingerprint-html-strip/design.md
+++ b/openspec/changes/dedup-fingerprint-html-strip/design.md
@@ -1,0 +1,55 @@
+## Context
+
+`role_fingerprint` (`internal/jobhash/rolefingerprint.go`) is the repost-identity key: `sha256(company_slug ⋮ normalizeRoleText(stripTrailingClause(title)) ⋮ normalizeRoleText(description))`. `normalizeRoleText` today is `strings.Join(strings.Fields(strings.ToLower(s)), " ")` — lowercase + whitespace fold only. Job descriptions are stored as **sanitized HTML** (an ingest-time `bluemonday` prose allowlist in `internal/sources/sanitize.go`), so the hashed text still contains tags (`<p>`, `<br>`, `<li>`, …) and entities (`&amp;`, `&#39;`). Any markup difference between two otherwise-identical postings produces different fingerprints and a duplicate card.
+
+Prod measurement (2026-07-21): within `(company, title)` groups that already carry >1 fingerprint, stripping tags before hashing collapses **~29k fingerprints across ~18k groups** — postings whose only difference is markup. (The measurement stripped tags only, no entity decode, so it is a conservative floor.) The Towa "Senior Fullstack Engineer" case that motivated this is NOT one of these: Bregenz vs Wien differ by a real visible sentence (an Austrian Kollektivvertrag clause), so they legitimately stay separate under exact-match — fuzzy matching for that class is deferred.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `role_fingerprint` compare the **visible text** of title and description, not their markup, so markup-only duplicates collapse.
+- Reuse the project's existing sanitizer stack; add no new dependency and no new heuristic threshold.
+- Keep the change to a single pure function (`normalizeRoleText`) so `UpsertJob`, `cmd/ingest`, and `cmd/backfill-role-fingerprint` all pick it up unchanged.
+
+**Non-Goals:**
+- No fuzzy / Jaccard / similarity-threshold matching — the fingerprint stays an exact-match on normalized visible text (separate future change).
+- No change to `stripTrailingClause` (title city-suffix), the two-word guard, the field delimiter, or the geography-union reindex behavior.
+- No re-sanitizing or rewriting of the stored `description` column — normalization happens only inside the fingerprint computation.
+
+## Decisions
+
+**1. Normalize to visible text inside `normalizeRoleText`, applied to both fields.**
+`normalizeRoleText` already runs on both the stripped title and the description, so adding the HTML→text step there keeps one code path and one contract. Titles are usually plain, but running the same step folds entity-encoded titles (`R&amp;D` → `r&d`) consistently and costs nothing measurable (fingerprints are computed at ingest, not on a hot path). Alternative — description-only — was rejected as an asymmetric special case with no benefit.
+
+**2. Strip tags with a `<[^>]*>` regex replaced by a SPACE, then decode entities with `html.UnescapeString`.**
+The tag strip replaces each tag with a space (not the empty string) so words separated only by a block element keep their boundary; entity decoding then converts `&amp;`→`&`, `&#39;`→`'`, and `&nbsp;`→U+00A0 (which `strings.Fields` folds to a space). Order: **strip tags first on the raw HTML, then unescape** — so an escaped angle bracket in visible text (`a &lt; b`) is decoded to a literal only after real tags are gone and is never mistaken for a tag. This matches the prod measurement exactly (which inserted spaces at tag positions and yielded ~29k), so the shipped collapse equals the measured one.
+- _Alternative — `bluemonday.StrictPolicy().Sanitize()`:_ the project's existing text-extraction idiom (`internal/sources/gupy.go`), but empirically it **deletes** tags without inserting a boundary, gluing words across blocks (`word1<br>word2`→`word1word2`, `<li>a</li><li>b</li>`→`ab`). That both diverges from the measurement and would *fail* to collapse the very markup-only dupes this change targets (a `<br>`-separated posting would not match its space-separated twin). Rejected.
+- _Alternative — `html2text.FromString`:_ preserves boundaries but adds layout opinions (table formatting, inline link URLs) that widen the hash surface for no dedup benefit. Rejected; the regex is a pure, boundary-preserving text projection.
+- _Over-strip safety:_ a greedy `<…>` could in principle eat visible text between a stray unescaped `<` and a later `>`. This vector does not exist here: descriptions are **already** sanitized at ingest (`internal/sources.SanitizeHTML`, a bluemonday prose allowlist), so stored HTML is well-formed and any `<`/`>` in visible text is entity-escaped. Titles are plain text and do not contain `<…>`.
+
+**3. The tag regex is compiled once at package scope.**
+`var htmlTag = regexp.MustCompile("<[^>]*>")` — like the existing `trailingClause` regex — so no per-hash recompilation. No new dependency is added (`html` is stdlib; `bluemonday` remains only the ingest-time sanitizer).
+
+**4. The description stays in the key (over-merge guard unchanged).**
+Two postings collapse only when both the stripped title AND the visible description match exactly. Normalization narrows what "match" means (visible text, not markup) but does not relax exactness — postings with any visible-text difference still diverge.
+
+## Risks / Trade-offs
+
+- **[Over-merge from too-aggressive stripping]** → the tag regex only strips well-formed tags from already-sanitized HTML (no stray `<`/`>` in visible text) and merges still require byte-identical visible text, which is a genuine duplicate. No similarity fuzz is introduced.
+- **[Inline mid-word tag fails to merge]** → replacing every tag with a space means a word split by an inline tag (`wo<b>rd</b>` → `wo rd`) will not collapse with a plain `word` twin. This is the flip side of space-insertion (which correctly fixes the dominant block-separated case); it only ever causes a failure-to-merge, never an over-merge, so it stays on the conservative side. Mid-word inline tags are rare in prose descriptions and not represented in the measured ~29k block-separated dupes.
+- **[Stale fingerprints until backfill runs]** → the code change only affects rows written after deploy; existing rows keep old fingerprints and would show a transient split between old and re-crawled rows. Mitigation: run `cmd/backfill-role-fingerprint` immediately after deploy, before the next reindex, so the whole table is recomputed in one shot.
+- **[Reindex contention]** → the follow-up `make reindex` must not stack with the semantic or companies reindex (shared flock rules). Mitigation: run in a low-traffic window on its own flock, per existing reindex ops.
+- **[Normalization drift on a future change]** → fingerprints are internally consistent (all rows rehashed by the same code) and reconciled by the backfill, so any future change to the strip just triggers another backfill; there is no external contract on the hash value.
+
+## Migration Plan
+
+1. Merge + deploy the code change (new `normalizeRoleText`). New/re-crawled rows immediately hash on visible text.
+2. Run `cmd/backfill-role-fingerprint` (tune `BACKFILL_CONCURRENCY`) to recompute every row; the `UpdateJobRoleFingerprint` guard writes only moved rows, so it is idempotent and re-runnable.
+3. Run `make reindex` (own flock, low-traffic window) — its `duplicate_of` recompute collapses the newly-clustered reposts and unions their geography onto each canon.
+4. Spot-check the Towa cluster and a sampled set of the ~18k affected groups: markup-only variants collapsed, visible-text-distinct postings (Krakau PLN; Bregenz/Wien KV clause) stayed separate.
+
+**Rollback:** revert the code and re-run `cmd/backfill-role-fingerprint` + reindex; the fingerprint returns to its previous value deterministically (no data loss — only the derived `role_fingerprint` column and search index change).
+
+## Open Questions
+
+None blocking. Fuzzy near-duplicate matching (the Bregenz/Wien class) is tracked as a separate future change.

--- a/openspec/changes/dedup-fingerprint-html-strip/proposal.md
+++ b/openspec/changes/dedup-fingerprint-html-strip/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`role_fingerprint` keys the role cluster that collapses reposts and per-city variants of one job into a single card. It is a hash of `company_slug` + city-stripped title + normalized description, but the text normalization only lowercases and collapses whitespace — so any HTML markup difference splits the fingerprint. The same posting re-emitted with a stray `<br>`, a different entity encoding (`&amp;` vs `&`), or a different wrapper structure (e.g. the same job surfaced by a second source) resolves to a different fingerprint and shows as a duplicate card. Measured on prod (2026-07-21): **~29,000 duplicate fingerprints across ~18,000 `(company, title)` groups differ ONLY by markup** and would collapse if the hash compared visible text instead of raw markup.
+
+## What Changes
+
+- The `role_fingerprint` text normalization strips HTML tags and decodes HTML entities before hashing, so the fingerprint compares the **visible text** of a posting rather than its markup. Two postings whose rendered title and description are identical now collapse even if their HTML differs.
+- Normalization strips HTML tags (a `<[^>]*>` regex, tags replaced by a space to preserve word boundaries) then decodes HTML entities (`html.UnescapeString`), applied to both the title and the description via the shared `normalizeRoleText`, before the existing lowercase + whitespace fold. No new dependency (`html` is stdlib).
+- A one-shot `cmd/backfill-role-fingerprint` run followed by `make reindex` re-applies the new fingerprint to the live catalogue, collapsing the newly-clustered reposts and unioning their geography onto each canon.
+- **Out of scope (separate future change):** fuzzy / Jaccard matching of near-identical-but-unequal descriptions (e.g. an Austrian Kollektivvertrag legal clause naming one city that another city's posting lacks). This change keeps the fingerprint an exact-match on normalized visible text; it does not introduce a similarity threshold.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `ingest-content-dedup`: the role-fingerprint normalization requirement is strengthened — the title and description are reduced to visible text (HTML tags stripped, entities decoded) before the lowercase/whitespace fold, so postings that differ only by markup share a fingerprint. The over-merge guard is unchanged: the description stays in the key, so postings with different visible text still stay separate.
+
+## Impact
+
+- **Code:** `internal/jobhash/rolefingerprint.go` (`normalizeRoleText`) — the only behavioral change. `cmd/backfill-role-fingerprint` and `cmd/ingest`/`UpsertJob` pick it up automatically because they call `jobhash.RoleFingerprint`.
+- **Data:** every job's `role_fingerprint` is recomputed. All markup-only duplicate clusters merge; downstream `duplicate_of` / `job_cluster_copies` and repost counts shift accordingly. Requires the backfill + reindex rollout (deploy code → `cmd/backfill-role-fingerprint` → `make reindex`, own flock, low-traffic window) — until the backfill runs, existing rows keep their old fingerprint and only re-cluster as they re-crawl.
+- **Dependencies:** no new dependencies — the strip uses only the standard library (`regexp`, `html`). (The ingest-time sanitizer that guarantees well-formed stored HTML is `bluemonday`, unchanged by this change.)
+- **Risk:** merging direction only (never splits a currently-clustered role). Over-merge is bounded to postings with byte-identical visible text, which are genuine duplicates.

--- a/openspec/changes/dedup-fingerprint-html-strip/specs/ingest-content-dedup/spec.md
+++ b/openspec/changes/dedup-fingerprint-html-strip/specs/ingest-content-dedup/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: The role fingerprint ignores a location-bearing title suffix
+
+The `role_fingerprint` that keys a role cluster SHALL normalize the title by
+stripping a single trailing separator clause — the text after the last ` , `,
+` | `, ` @ `, or space-delimited ` - ` / ` — ` / ` – ` — before hashing, so a role
+whose only difference is a city (or other qualifier) appended to the title
+resolves to the same fingerprint as its siblings. The strip SHALL remove only a
+trailing clause (never a prefix, so a seniority grade like `Senior …` is
+preserved) and SHALL leave the title unchanged when stripping would drop it below
+two words.
+
+Before the case/whitespace fold, the title and the description SHALL be reduced to
+their **visible text** — HTML tags stripped and HTML entities decoded — so two
+postings whose rendered text is identical share a fingerprint even when their
+markup differs (a stray tag, a different entity encoding, or a different wrapper
+structure from another source). The description SHALL remain part of the
+fingerprint, so two postings collapse only when both the stripped title AND the
+visible description match; postings whose visible text differs still resolve to
+different fingerprints.
+
+#### Scenario: Per-city title variants share one fingerprint
+
+- **WHEN** a company posts one role in several cities and each posting appends the
+  city to the title (e.g. `"… Engineer, Krakau"`, `"… Engineer, Wien"`) with an
+  identical description
+- **THEN** all the postings resolve to the same `role_fingerprint` and collapse to
+  one canonical card
+
+#### Scenario: Markup-only differences share one fingerprint
+
+- **WHEN** two postings have the same company, the same stripped title, and the
+  same visible description text, but their description HTML differs only in markup
+  (e.g. one has an extra `<br>`, or encodes `&` as `&amp;`)
+- **THEN** they resolve to the same `role_fingerprint` and collapse to one
+  canonical card
+
+#### Scenario: Distinct roles with different descriptions stay separate
+
+- **WHEN** two postings share a stripped title but carry different visible
+  descriptions (e.g. two engineering specialties, or a city-specific legal clause
+  present in one and absent in the other)
+- **THEN** they resolve to different `role_fingerprint`s and are not collapsed
+
+#### Scenario: A seniority prefix is never stripped
+
+- **WHEN** a title carries a leading grade (e.g. `"Senior Software Engineer"`)
+- **THEN** the grade is retained in the fingerprint, so it does not collapse into
+  the ungraded role

--- a/openspec/changes/dedup-fingerprint-html-strip/tasks.md
+++ b/openspec/changes/dedup-fingerprint-html-strip/tasks.md
@@ -1,0 +1,12 @@
+## 1. Fingerprint normalization
+
+- [x] 1.1 Add failing tests to `internal/jobhash/rolefingerprint_test.go`: (a) two params with the same company + stripped title + same visible description but markup-only differences (extra `<br>`, `&amp;` vs `&`) produce the SAME fingerprint; (b) a real visible-text difference (a city-specific clause present in one, absent in the other) still produces DIFFERENT fingerprints; (c) an entity-encoded title (`R&amp;D …`) matches its decoded form.
+- [x] 1.2 Implement the HTML→visible-text step in `normalizeRoleText` (strip tags via a package-level `<[^>]*>` regex, replacing each tag with a space, then `html.UnescapeString`, then the existing lowercase + `strings.Fields` fold). Strip tags before unescaping. Update the doc comment to state the fingerprint compares visible text.
+- [x] 1.3 Run `go test ./internal/jobhash/...` — new tests pass AND all existing `TestRoleFingerprint_*` (case/whitespace/city-suffix/seniority/two-word-guard/field-delimiter) stay green.
+- [x] 1.4 Run `go build ./... && go vet ./...` to confirm the shared callers (`cmd/ingest`, `cmd/backfill-role-fingerprint`, `internal/job`) still compile.
+
+## 2. Rollout (ops — executed at Finish, low-traffic window)
+
+- [ ] 2.1 After deploy, run `cmd/backfill-role-fingerprint` (tune `BACKFILL_CONCURRENCY`) to recompute every row's `role_fingerprint`; confirm `scanned`/`updated` counts are logged.
+- [ ] 2.2 Run `make reindex` on its own flock (not stacked with the semantic or companies reindex) to collapse newly-clustered reposts and union their geography.
+- [ ] 2.3 Verify on prod: the Towa "Senior Fullstack Engineer" cluster collapses its markup-only variants while Krakau (PLN) and the KV-clause Vienna posting stay distinct; spot-check a sample of the ~18k affected `(company, title)` groups.


### PR DESCRIPTION
## Summary

`role_fingerprint` (the repost-identity key that collapses reposts and per-city variants into one card) hashed the **raw sanitized-HTML** description, so a posting re-emitted with a stray `<br>`, `&amp;` vs `&`, or a different wrapper split into a duplicate card. `normalizeRoleText` now reduces the title and description to **visible text** — tags stripped (each replaced by a space to preserve word boundaries across block elements), HTML entities decoded — before the existing lowercase + whitespace fold.

- Tag-strip via a package-level `<[^>]*>` regex → space, then `html.UnescapeString`, then the pre-existing `ToLower`/`Fields` fold. Tag-strip runs **before** entity-decode so an escaped bracket in visible text (`a &lt; b`) is never mistaken for a tag.
- Over-merge guard unchanged: the description stays in the key, so postings whose **visible** text differs (e.g. an Austrian Kollektivvertrag clause naming one city) still stay separate.
- No new dependency (stdlib `regexp`/`html`). Stored descriptions are already sanitized at ingest (`internal/sources.SanitizeHTML`), so the strip only ever sees well-formed HTML — no over-strip vector.
- `bluemonday.StrictPolicy()` was rejected: it deletes tags without a boundary and glues words across blocks (`word1<br>word2` → `word1word2`), which would fail the very dupes this targets.

**Impact:** every `role_fingerprint` is recomputed. Prod measurement (2026-07-21): ~29k markup-only duplicate fingerprints across ~18k `(company, title)` groups collapse. Merge-direction only — never splits a currently-clustered role.

**Out of scope:** fuzzy/Jaccard matching for near-identical-but-unequal descriptions (the Bregenz/Wien case) — a separate future change.

OpenSpec: `dedup-fingerprint-html-strip` (modifies `ingest-content-dedup`).

## Rollout (after merge, low-traffic window)

The code only affects rows written after deploy, so existing rows must be recomputed:
1. Deploy
2. `cmd/backfill-role-fingerprint` (tune `BACKFILL_CONCURRENCY`) — recompute every row
3. `make reindex` (own flock, **not** stacked with semantic/companies reindex) — collapse newly-clustered reposts + union geography

## Test Plan

- [x] `go test ./internal/jobhash/` — markup-only collapse (×4), entity title, `&nbsp;` fold, empty/tags-only, and the visible-text-difference over-merge guard; all pre-existing tests (city-suffix, seniority, two-word guard, whitespace, delimiter) green
- [x] `go test ./cmd/backfill-role-fingerprint/` (shares the function)
- [x] `go build ./... && go vet ./...` clean; `gofmt` clean
- [ ] Post-deploy: Towa "Senior Fullstack Engineer" cluster collapses markup-only variants while Krakau (PLN) and the KV-clause Vienna posting stay distinct; spot-check a sample of the ~18k affected groups