### PR TITLE
feat(contribution): record unrecognized links for manual review

### DIFF
--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -28,6 +28,13 @@ var (
 	ErrBoardAlreadyContributed = errors.New("contribution: board already contributed")
 )
 
+// Contribution statuses. A recognized novel board is recorded StatusPending (credit awarded);
+// an unrecognized-but-valid link is recorded StatusReview (no credit) for manual triage.
+const (
+	StatusPending = "pending"
+	StatusReview  = "review"
+)
+
 // Contribution is a stored contribution row, decoupled from the generated db row. CreatedAt
 // is *time.Time because the handler serializes it.
 type Contribution struct {
@@ -56,6 +63,7 @@ type Repository interface {
 	BoardByGreenhouseJobID(ctx context.Context, jobID string) (board string, ok bool, err error)
 	BoardByAshbyJobID(ctx context.Context, jobID string) (board string, ok bool, err error)
 	Record(ctx context.Context, in RecordInput) (Contribution, error)
+	RecordReview(ctx context.Context, submittedBy int64, url string) (Contribution, error)
 	ListByUser(ctx context.Context, userID int64) ([]Contribution, error)
 }
 
@@ -87,10 +95,15 @@ func New(repo Repository, resolver Resolver) *Service {
 func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) (rec Contribution, source, board string, err error) {
 	source, board, canonical, ok := s.resolveBoard(ctx, rawURL)
 	if !ok {
-		// Log an unrecognized-but-plausible link (a valid http(s) URL) so a maintainer can
-		// review the feed and add support for a missed ATS. Garbage (non-URLs) is skipped.
+		// No board resolved. A non-URL is garbage → 422. A valid http(s) link is a plausible
+		// missed ATS: log it for maintainer visibility and record it in the review queue (no
+		// board, no credit) so it can be triaged by hand instead of being lost.
+		if !isHTTPURL(rawURL) {
+			return Contribution{}, "", "", ErrUnsupportedATS
+		}
 		logUnrecognized(submittedBy, rawURL)
-		return Contribution{}, "", "", ErrUnsupportedATS
+		rec, err = s.repo.RecordReview(ctx, submittedBy, stripQueryFragment(rawURL))
+		return rec, "", "", err
 	}
 
 	tracked, err := s.repo.BoardTracked(ctx, source, board)
@@ -142,12 +155,18 @@ func (s *Service) ListMine(ctx context.Context, userID int64) ([]Contribution, e
 	return s.repo.ListByUser(ctx, userID)
 }
 
-// logUnrecognized emits a log line for a rejected link that parses as an http(s) URL — a
+// isHTTPURL reports whether rawURL parses as an http(s) URL with a host. It is the review-queue
+// gate: a valid link is recorded for triage, non-URL garbage is rejected (422).
+func isHTTPURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
+// logUnrecognized emits a log line for an unrecognized link that parses as an http(s) URL — a
 // review feed for missed ATS. Grep prod for "contribution: unrecognized". Non-URL garbage is
 // skipped so the feed stays signal.
 func logUnrecognized(submittedBy int64, rawURL string) {
-	u, err := url.Parse(rawURL)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+	if !isHTTPURL(rawURL) {
 		return
 	}
 	log.Printf("contribution: unrecognized link (user=%d): %s", submittedBy, rawURL)

--- a/internal/contribution/contribution_test.go
+++ b/internal/contribution/contribution_test.go
@@ -17,6 +17,9 @@ type fakeRepo struct {
 	recordErr     error
 	recorded      RecordInput
 	recordCalls   int
+	reviewErr     error
+	reviewedURL   string
+	reviewCalls   int
 	listByUserRet []Contribution
 	companyName   string
 	companySlug   string
@@ -52,6 +55,15 @@ func (f *fakeRepo) Record(_ context.Context, in RecordInput) (Contribution, erro
 	}, nil
 }
 
+func (f *fakeRepo) RecordReview(_ context.Context, submittedBy int64, url string) (Contribution, error) {
+	f.reviewCalls++
+	f.reviewedURL = url
+	if f.reviewErr != nil {
+		return Contribution{}, f.reviewErr
+	}
+	return Contribution{ID: 2, SubmittedBy: submittedBy, URL: url, Status: StatusReview}, nil
+}
+
 func (f *fakeRepo) ListByUser(_ context.Context, _ int64) ([]Contribution, error) {
 	return f.listByUserRet, nil
 }
@@ -73,29 +85,56 @@ func newService(repo Repository) *Service {
 	return New(repo, nil)
 }
 
-func TestSubmitRejectsUnsupportedATS(t *testing.T) {
+func TestSubmitRecordsUnknownHostForReview(t *testing.T) {
+	// An unknown host yields no board, but the link is a valid URL — record it for manual
+	// review (no board record, no credit) rather than rejecting it.
 	repo := &fakeRepo{}
-	_, _, _, err := newService(repo).Submit(context.Background(), 7, "https://example.com/careers/123")
-	if !errors.Is(err, ErrUnsupportedATS) {
-		t.Fatalf("err = %v, want ErrUnsupportedATS", err)
+	got, source, board, err := newService(repo).Submit(context.Background(), 7, "https://example.com/careers/123")
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
 	}
-	if repo.recordCalls != 0 {
-		t.Errorf("recorded %d times, want 0 — nothing should be written", repo.recordCalls)
+	if got.Status != StatusReview || source != "" || board != "" {
+		t.Errorf("got = (status %q, %q, %q), want (review, empty, empty)", got.Status, source, board)
+	}
+	if repo.reviewCalls != 1 || repo.recordCalls != 0 {
+		t.Errorf("reviewCalls=%d recordCalls=%d, want 1 and 0", repo.reviewCalls, repo.recordCalls)
+	}
+	if repo.reviewedURL != "https://example.com/careers/123" {
+		t.Errorf("reviewed URL = %q, want the pasted link", repo.reviewedURL)
 	}
 }
 
-func TestSubmitRejectsSingleTenantSource(t *testing.T) {
-	// geekjob is a single-tenant aggregator — not a per-company board.
-	_, _, _, err := newService(&fakeRepo{}).Submit(context.Background(), 7, "https://geekjob.ru/vacancy/6a1ebb85")
-	if !errors.Is(err, ErrUnsupportedATS) {
-		t.Fatalf("err = %v, want ErrUnsupportedATS", err)
+func TestSubmitRecordsSingleTenantSourceForReview(t *testing.T) {
+	// geekjob is a single-tenant aggregator — no per-company board, but a valid URL, so it
+	// enters the review queue for a maintainer to judge.
+	repo := &fakeRepo{}
+	got, _, _, err := newService(repo).Submit(context.Background(), 7, "https://geekjob.ru/vacancy/6a1ebb85")
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if got.Status != StatusReview || repo.reviewCalls != 1 {
+		t.Errorf("got status %q, reviewCalls %d, want review and 1", got.Status, repo.reviewCalls)
 	}
 }
 
 func TestSubmitRejectsNonURL(t *testing.T) {
-	_, _, _, err := newService(&fakeRepo{}).Submit(context.Background(), 7, "not a url")
+	repo := &fakeRepo{}
+	_, _, _, err := newService(repo).Submit(context.Background(), 7, "not a url")
 	if !errors.Is(err, ErrUnsupportedATS) {
 		t.Fatalf("err = %v, want ErrUnsupportedATS", err)
+	}
+	if repo.reviewCalls != 0 || repo.recordCalls != 0 {
+		t.Errorf("wrote something (review=%d record=%d), want nothing for non-URL garbage", repo.reviewCalls, repo.recordCalls)
+	}
+}
+
+func TestSubmitDeduplicatesReviewLink(t *testing.T) {
+	// A url already in the review queue surfaces the unique violation as the same
+	// "already contributed" outcome as a duplicate board.
+	repo := &fakeRepo{reviewErr: ErrBoardAlreadyContributed}
+	_, _, _, err := newService(repo).Submit(context.Background(), 7, "https://example.com/careers/123")
+	if !errors.Is(err, ErrBoardAlreadyContributed) {
+		t.Fatalf("err = %v, want ErrBoardAlreadyContributed", err)
 	}
 }
 
@@ -193,9 +232,9 @@ func TestSubmitResolvesGreenhouseJobIDForServerSideVanity(t *testing.T) {
 			t.Errorf("Submit(%q) = (%q,%q), want (greenhouse, sumup)", raw, source, board)
 		}
 	}
-	// No id in the URL → not resolved.
-	if _, _, _, err := New(repo, nil).Submit(context.Background(), 7, "https://example.com/careers/about"); !errors.Is(err, ErrUnsupportedATS) {
-		t.Errorf("err = %v, want ErrUnsupportedATS for a URL with no job id", err)
+	// No id in the URL → not resolved to a board, so it enters the review queue.
+	if got, _, _, err := New(repo, nil).Submit(context.Background(), 7, "https://example.com/careers/about"); err != nil || got.Status != StatusReview {
+		t.Errorf("got = (status %q, err %v), want (review, nil) for a URL with no job id", got.Status, err)
 	}
 }
 
@@ -212,9 +251,9 @@ func TestSubmitResolvesAshbyJobIDForEmbeddedVanity(t *testing.T) {
 	if source != "ashby" || board != "valon" {
 		t.Errorf("= (%q,%q), want (ashby, valon)", source, board)
 	}
-	// A non-UUID ashby_jid (or none) → not resolved.
-	if _, _, _, err := New(repo, nil).Submit(context.Background(), 7, "https://www.valon.ai/about?ashby_jid=not-a-uuid"); !errors.Is(err, ErrUnsupportedATS) {
-		t.Errorf("err = %v, want ErrUnsupportedATS for a non-UUID ashby_jid", err)
+	// A non-UUID ashby_jid (or none) → not resolved to a board, so it enters the review queue.
+	if got, _, _, err := New(repo, nil).Submit(context.Background(), 7, "https://www.valon.ai/about?ashby_jid=not-a-uuid"); err != nil || got.Status != StatusReview {
+		t.Errorf("got = (status %q, err %v), want (review, nil) for a non-UUID ashby_jid", got.Status, err)
 	}
 }
 

--- a/internal/contribution/repository.go
+++ b/internal/contribution/repository.go
@@ -86,8 +86,26 @@ func (r *QueriesRepository) Record(ctx context.Context, in RecordInput) (Contrib
 	row, err := r.q.CreateContribution(ctx, db.CreateContributionParams{
 		SubmittedBy: in.SubmittedBy,
 		URL:         in.URL,
-		Source:      in.Source,
-		Board:       in.Board,
+		Source:      pgconv.Text(in.Source),
+		Board:       pgconv.Text(in.Board),
+	})
+	if err != nil {
+		if pgerr.IsUniqueViolation(err) {
+			return Contribution{}, ErrBoardAlreadyContributed
+		}
+		return Contribution{}, err
+	}
+	return fromRow(row), nil
+}
+
+// RecordReview inserts an unrecognized-but-valid link for manual review: source/board unset,
+// status 'review', no AI credit. The partial unique index on (url) WHERE source IS NULL
+// rejects a duplicate submission of the same url, mapped to ErrBoardAlreadyContributed so a
+// re-paste surfaces the same "already contributed" outcome as a duplicate board.
+func (r *QueriesRepository) RecordReview(ctx context.Context, submittedBy int64, url string) (Contribution, error) {
+	row, err := r.q.CreateReviewContribution(ctx, db.CreateReviewContributionParams{
+		SubmittedBy: submittedBy,
+		URL:         url,
 	})
 	if err != nil {
 		if pgerr.IsUniqueViolation(err) {
@@ -117,8 +135,8 @@ func fromRow(row db.LinkContribution) Contribution {
 		ID:          row.ID,
 		SubmittedBy: row.SubmittedBy,
 		URL:         row.URL,
-		Source:      row.Source,
-		Board:       row.Board,
+		Source:      pgconv.TextString(row.Source),
+		Board:       pgconv.TextString(row.Board),
 		Status:      row.Status,
 		CreatedAt:   pgconv.TimePtr(row.CreatedAt),
 	}

--- a/internal/contribution/repository.go
+++ b/internal/contribution/repository.go
@@ -89,13 +89,7 @@ func (r *QueriesRepository) Record(ctx context.Context, in RecordInput) (Contrib
 		Source:      pgconv.Text(in.Source),
 		Board:       pgconv.Text(in.Board),
 	})
-	if err != nil {
-		if pgerr.IsUniqueViolation(err) {
-			return Contribution{}, ErrBoardAlreadyContributed
-		}
-		return Contribution{}, err
-	}
-	return fromRow(row), nil
+	return recordResult(row, err)
 }
 
 // RecordReview inserts an unrecognized-but-valid link for manual review: source/board unset,
@@ -107,6 +101,13 @@ func (r *QueriesRepository) RecordReview(ctx context.Context, submittedBy int64,
 		SubmittedBy: submittedBy,
 		URL:         url,
 	})
+	return recordResult(row, err)
+}
+
+// recordResult maps an insert result to the domain type: a unique violation (a duplicate board
+// or a re-submitted review url) becomes ErrBoardAlreadyContributed, keeping that mapping in one
+// place for both insert paths.
+func recordResult(row db.LinkContribution, err error) (Contribution, error) {
 	if err != nil {
 		if pgerr.IsUniqueViolation(err) {
 			return Contribution{}, ErrBoardAlreadyContributed

--- a/internal/db/link_contributions.sql.go
+++ b/internal/db/link_contributions.sql.go
@@ -7,6 +7,8 @@ package db
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const boardByAshbyJobID = `-- name: BoardByAshbyJobID :one
@@ -78,10 +80,10 @@ RETURNING id, submitted_by, url, source, board, status, created_at
 `
 
 type CreateContributionParams struct {
-	SubmittedBy int64  `json:"submitted_by"`
-	URL         string `json:"url"`
-	Source      string `json:"source"`
-	Board       string `json:"board"`
+	SubmittedBy int64       `json:"submitted_by"`
+	URL         string      `json:"url"`
+	Source      pgtype.Text `json:"source"`
+	Board       pgtype.Text `json:"board"`
 }
 
 // Record a contribution of a novel company board. The UNIQUE (source, board) constraint
@@ -95,6 +97,36 @@ func (q *Queries) CreateContribution(ctx context.Context, arg CreateContribution
 		arg.Source,
 		arg.Board,
 	)
+	var i LinkContribution
+	err := row.Scan(
+		&i.ID,
+		&i.SubmittedBy,
+		&i.URL,
+		&i.Source,
+		&i.Board,
+		&i.Status,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const createReviewContribution = `-- name: CreateReviewContribution :one
+INSERT INTO link_contributions (submitted_by, url, status)
+VALUES ($1::bigint, $2, 'review')
+RETURNING id, submitted_by, url, source, board, status, created_at
+`
+
+type CreateReviewContributionParams struct {
+	SubmittedBy int64  `json:"submitted_by"`
+	URL         string `json:"url"`
+}
+
+// Record an unrecognized-but-valid link for manual review: source/board unset, status
+// 'review', no AI credit. The partial unique index on (url) WHERE source IS NULL rejects a
+// duplicate submission of the same url; the repository maps that violation to
+// ErrBoardAlreadyContributed. A maintainer later resolves source/board and promotes the row.
+func (q *Queries) CreateReviewContribution(ctx context.Context, arg CreateReviewContributionParams) (LinkContribution, error) {
+	row := q.db.QueryRow(ctx, createReviewContribution, arg.SubmittedBy, arg.URL)
 	var i LinkContribution
 	err := row.Scan(
 		&i.ID,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -330,8 +330,8 @@ type LinkContribution struct {
 	ID          int64              `json:"id"`
 	SubmittedBy int64              `json:"submitted_by"`
 	URL         string             `json:"url"`
-	Source      string             `json:"source"`
-	Board       string             `json:"board"`
+	Source      pgtype.Text        `json:"source"`
+	Board       pgtype.Text        `json:"board"`
 	Status      string             `json:"status"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -236,6 +236,11 @@ type Querier interface {
 	// unique index on (reported_by, job_id) WHERE status='pending' rejects a second open report
 	// of the same job by the same user (the repository maps that unique violation to a 409).
 	CreateReport(ctx context.Context, arg CreateReportParams) (JobReport, error)
+	// Record an unrecognized-but-valid link for manual review: source/board unset, status
+	// 'review', no AI credit. The partial unique index on (url) WHERE source IS NULL rejects a
+	// duplicate submission of the same url; the repository maps that violation to
+	// ErrBoardAlreadyContributed. A maintainer later resolves source/board and promotes the row.
+	CreateReviewContribution(ctx context.Context, arg CreateReviewContributionParams) (LinkContribution, error)
 	// Create a saved search for a user. The UNIQUE (user_id, name) constraint rejects a
 	// duplicate name (surfaced by the repository as a duplicate-name error). Returns the row.
 	CreateSavedSearch(ctx context.Context, arg CreateSavedSearchParams) (SavedSearch, error)

--- a/internal/db/queries/link_contributions.sql
+++ b/internal/db/queries/link_contributions.sql
@@ -7,6 +7,15 @@ INSERT INTO link_contributions (submitted_by, url, source, board)
 VALUES (sqlc.arg(submitted_by)::bigint, sqlc.arg(url), sqlc.arg(source), sqlc.arg(board))
 RETURNING *;
 
+-- name: CreateReviewContribution :one
+-- Record an unrecognized-but-valid link for manual review: source/board unset, status
+-- 'review', no AI credit. The partial unique index on (url) WHERE source IS NULL rejects a
+-- duplicate submission of the same url; the repository maps that violation to
+-- ErrBoardAlreadyContributed. A maintainer later resolves source/board and promotes the row.
+INSERT INTO link_contributions (submitted_by, url, status)
+VALUES (sqlc.arg(submitted_by)::bigint, sqlc.arg(url), 'review')
+RETURNING *;
+
 -- name: JobsExistForBoard :one
 -- Whether the catalogue already crawls this board — any job whose external_id is "<board>:…".
 -- Matched with a LIKE-prefix so the (source, external_id text_pattern_ops) index serves it as

--- a/internal/handler/contributions.go
+++ b/internal/handler/contributions.go
@@ -84,7 +84,11 @@ func (a *API) CreateContribution(c *fiber.Ctx) error {
 		}
 		return contributionError(err)
 	}
-	a.rewardContribution(c.Context(), userID, rec.ID)
+	// Credit is exclusive to a recognized novel board (status pending). An unrecognized link is
+	// recorded for manual review (status review) and earns nothing until a maintainer promotes it.
+	if rec.Status == contribution.StatusPending {
+		a.rewardContribution(c.Context(), userID, rec.ID)
+	}
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": toContributionResponse(rec)})
 }
 

--- a/internal/handler/contributions_integration_test.go
+++ b/internal/handler/contributions_integration_test.go
@@ -79,9 +79,36 @@ func TestContributionsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("unsupported host is 422", func(t *testing.T) {
-		if resp := submit(t, "https://example.com/careers/1", true); resp.StatusCode != fiber.StatusUnprocessableEntity {
+	t.Run("non-URL garbage is 422", func(t *testing.T) {
+		if resp := submit(t, "not a url", true); resp.StatusCode != fiber.StatusUnprocessableEntity {
 			t.Errorf("status = %d, want 422", resp.StatusCode)
+		}
+	})
+
+	t.Run("unrecognized valid link is recorded for review (201, no credit)", func(t *testing.T) {
+		resp := submit(t, "https://example.com/careers/1", true)
+		if resp.StatusCode != fiber.StatusCreated {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 201 (body %s)", resp.StatusCode, body)
+		}
+		var created struct {
+			Data contributionResponse `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if created.Data.Status != contribution.StatusReview || created.Data.Source != "" || created.Data.Board != "" {
+			t.Errorf("created = %+v, want status review with no source/board", created.Data)
+		}
+		// No credit was awarded: no reward ledger entry exists for the review row. (The novel-board
+		// subtest below confirms the balance lands at exactly 25 — grant 20 + one reward — proving
+		// the review submission added nothing.)
+		var rewards int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM credit_ledger WHERE user_id = $1`, userID).Scan(&rewards); err != nil {
+			t.Fatalf("read ledger: %v", err)
+		}
+		if rewards != 0 {
+			t.Errorf("credit ledger entries after review submit = %d, want 0", rewards)
 		}
 	})
 
@@ -150,8 +177,21 @@ func TestContributionsEndToEnd(t *testing.T) {
 		if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if len(list.Data) != 1 || list.Data[0].Board != "acme" || list.Data[0].Source != "ashby" {
-			t.Errorf("list = %+v, want the one recorded ashby/acme board", list.Data)
+		// Two rows: the recognized ashby/acme board and the earlier review-queue submission.
+		var board, review *contributionResponse
+		for i := range list.Data {
+			switch list.Data[i].Status {
+			case contribution.StatusReview:
+				review = &list.Data[i]
+			default:
+				board = &list.Data[i]
+			}
+		}
+		if len(list.Data) != 2 || board == nil || board.Board != "acme" || board.Source != "ashby" {
+			t.Errorf("list = %+v, want the recorded ashby/acme board", list.Data)
+		}
+		if review == nil || review.Source != "" || review.Board != "" {
+			t.Errorf("list = %+v, want a review row with no source/board", list.Data)
 		}
 	})
 }

--- a/internal/handler/telegram.go
+++ b/internal/handler/telegram.go
@@ -200,6 +200,10 @@ func (a *API) processTelegramContribution(chatID int64, rawURL string) {
 	case err != nil:
 		log.Printf("telegram: submit user=%d: %v", userID, err)
 		a.sendTelegram(ctx, chatID, "⚠️ Something went wrong. Please try again.")
+	case rec.Status == contribution.StatusReview:
+		// An unrecognized-but-valid link: recorded for manual review, no credit until a
+		// maintainer confirms it's ingestable (mirrors the site's review-queue message).
+		a.sendTelegram(ctx, chatID, "🤔 That doesn't look like a known ATS. We'll check by hand whether we can pull its jobs — if we can, you'll get a credit. Not credited yet.")
 	default:
 		a.rewardContribution(ctx, userID, rec.ID)
 		a.sendTelegram(ctx, chatID, "🎉 <b>"+rec.Board+"</b> ("+rec.Source+") is a new board — we'll start crawling it. +1 AI credit!")

--- a/internal/handler/telegram_contribution_integration_test.go
+++ b/internal/handler/telegram_contribution_integration_test.go
@@ -168,4 +168,21 @@ func TestTelegramContribution(t *testing.T) {
 			t.Errorf("reply = %q, want the company name + /companies/acme-co link", reply)
 		}
 	})
+
+	t.Run("an unrecognized valid link is queued for review, no reward", func(t *testing.T) {
+		post(chatID, "https://example.com/careers/1")
+		reply := waitReply(t)
+		if !strings.Contains(reply, "Not credited") {
+			t.Errorf("reply = %q, want a not-credited review message", reply)
+		}
+		// No reward: the review row earns nothing, so the balance is unchanged from the one
+		// earlier reward (25).
+		if got := balance(); got != 25 {
+			t.Errorf("credit balance = %d, want still 25 (review credits nothing)", got)
+		}
+		var status string
+		if err := pool.QueryRow(ctx, `SELECT status FROM link_contributions WHERE submitted_by=$1 AND source IS NULL`, userID).Scan(&status); err != nil || status != contribution.StatusReview {
+			t.Errorf("review row status = %q (%v), want review", status, err)
+		}
+	})
 }

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -59,3 +59,22 @@ func Bool(b *bool) pgtype.Bool {
 	}
 	return pgtype.Bool{Bool: *b, Valid: true}
 }
+
+// Text maps a string to the pgtype the generated params expect, treating the empty
+// string as NULL. It is the write-side adapter for a nullable text column whose domain
+// zero value is "" — e.g. link_contributions.source/board, unset on a review-queue row.
+func Text(s string) pgtype.Text {
+	if s == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: s, Valid: true}
+}
+
+// TextString maps a nullable DB text to a plain string: NULL becomes "", a valid value
+// its content. The read-side inverse of Text.
+func TextString(t pgtype.Text) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.String
+}

--- a/migrations/0037_link_contributions_review.sql
+++ b/migrations/0037_link_contributions_review.sql
@@ -1,0 +1,27 @@
+-- Contribution review queue: a contributed link that resolves to no supported board is no
+-- longer rejected. When it is a well-formed http(s) URL we record it here for manual review
+-- (status 'review', source/board unset) so a maintainer can check whether the source is
+-- ingestable — no AI credit is awarded until that manual check promotes the row.
+--
+-- Three schema changes:
+--   1. source/board become nullable — a review row has neither until a maintainer resolves it.
+--   2. the status CHECK gains 'review'.
+--   3. a partial unique index dedups the review queue by url (the existing UNIQUE (source,
+--      board) can't: NULLs are distinct, so it would allow the same url many times over).
+--
+-- Applied to a fresh volume by initdb after 0036; on an existing prod volume run these
+-- statements manually (SET ROLE hire) BEFORE deploying code that writes review rows.
+
+ALTER TABLE public.link_contributions ALTER COLUMN source DROP NOT NULL;
+ALTER TABLE public.link_contributions ALTER COLUMN board DROP NOT NULL;
+
+ALTER TABLE public.link_contributions
+    DROP CONSTRAINT link_contributions_status_check;
+ALTER TABLE public.link_contributions
+    ADD CONSTRAINT link_contributions_status_check
+    CHECK ((status = ANY (ARRAY['pending'::text, 'onboarded'::text, 'rejected'::text, 'review'::text])));
+
+-- Review-queue dedup: a given unrecognized url can sit in the queue at most once. Scoped to
+-- review rows (source IS NULL) so recognized boards keep using UNIQUE (source, board).
+CREATE UNIQUE INDEX link_contributions_review_url_key
+    ON public.link_contributions (url) WHERE source IS NULL;

--- a/openspec/changes/contribution-review-queue/.openspec.yaml
+++ b/openspec/changes/contribution-review-queue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/contribution-review-queue/design.md
+++ b/openspec/changes/contribution-review-queue/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`link_contributions` records crowdsourced company boards, keyed on `UNIQUE (source, board)`
+with `source`/`board` `NOT NULL` and status `pending | onboarded | rejected`. `Submit`
+resolves a pasted URL to `(source, board)`; on failure it calls `logUnrecognized` and returns
+`ErrUnsupportedATS` (handler → 422), storing nothing. The handler awards an AI credit after any
+successful `Record`. We want unrecognized-but-plausible links captured for manual triage
+without polluting the credit ledger.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persist every well-formed unrecognized link as a `review` row instead of dropping it.
+- Keep credit exclusive to recognized novel boards; a review row credits nothing at submit.
+- Surface review rows in the contribute UI with an explicit "not credited yet" state.
+- Dedup the review queue by URL.
+
+**Non-Goals:**
+- No automated adapter generation or ingestion of review links.
+- No new binary/worker/CLI. Manual promotion + credit top-up is a human step, documented in
+  the `onboard-contributions` skill.
+- No change to the recognized-board or already-tracked paths.
+
+## Decisions
+
+**One table, nullable source/board (per user).** Reuse `link_contributions` rather than a
+separate `link_submissions` table. `source`/`board` drop `NOT NULL`; a `review` row leaves them
+NULL. Alternative (separate table) was cleaner for the invariant but the user chose one table to
+keep everything in one place and reuse `ListByUser`/reward-by-id.
+
+**Dedup review rows by URL via a partial unique index.** `UNIQUE (source, board)` can't dedup
+NULL/NULL rows (Postgres treats NULLs as distinct). Add
+`CREATE UNIQUE INDEX ... ON link_contributions (url) WHERE source IS NULL`. Recognized rows keep
+their `(source, board)` uniqueness. `Submit` checks for an existing review row by URL first and
+returns `ErrBoardAlreadyContributed` (409) on a hit, so the collision surfaces as a clean error
+rather than a raw constraint violation.
+
+**Credit gate moves to the recognized path.** The handler currently rewards after any `Record`.
+Change it to reward only when the recorded row is a recognized board. `Submit` already returns
+the recorded `Contribution`; the handler gates on `rec.Status == "pending"` (recognized) vs
+`"review"`. Alternative — a separate `awardable bool` return — is redundant with the status.
+
+**Garbage still 422.** The existing `logUnrecognized` URL guard (valid `http(s)`, non-empty
+host) becomes the gate: valid URL → review row; otherwise → `ErrUnsupportedATS` (422). This
+keeps non-URL noise out of the queue.
+
+## Risks / Trade-offs
+
+- [Review queue fills with single-tenant / junk links] → Acceptable: no credit is spent on
+  them, dedup caps repeats, and manual triage rejects them. Keeps the recognizer simple (no
+  "known-but-unsupported host" distinction).
+- [Table invariant weakened — some rows have no board] → Contained: `review` is the only such
+  status; existing board queries filter by `source`/`board` and are unaffected by NULL rows.
+- [Manual credit top-up could double-credit] → The existing reward is idempotent by contribution
+  id; a manual award uses the same key, so a retry is safe.
+
+## Migration Plan
+
+- New migration file alters `link_contributions`: drop `NOT NULL` on `source`/`board`, replace
+  the status CHECK to include `review`, add the partial unique index on `url`.
+- Prod: apply by hand under `SET ROLE hire` (repo convention; migrations are initdb-only on
+  fresh volumes). No backfill — existing rows already satisfy the looser constraints.
+- Rollback: revert the code; the added `review` status and NULL columns are backward-compatible,
+  so the schema can stay.
+
+## Open Questions
+
+None — scope and storage model settled with the user.

--- a/openspec/changes/contribution-review-queue/proposal.md
+++ b/openspec/changes/contribution-review-queue/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+When a user contributes a job link the backend can't map to a known ATS, we return 422
+and only write a log line — the link is lost unless a maintainer greps prod, and the
+contributor gets nothing back but "not a supported ATS board". Real, ingestable sources
+hide in that rejected feed (e.g. a Paylocity URL whose pattern the recognizer doesn't know
+yet). We want to capture every plausible link so it can be reviewed by hand, while keeping
+credit honest — only boards we actually crawl earn a credit.
+
+## What Changes
+
+- An unrecognized-but-valid `http(s)` contribution link is now **recorded** in
+  `link_contributions` with a new `review` status (source/board unset) instead of being
+  rejected with 422. Non-URL garbage still 422; a link already in the review queue is 409.
+- **No credit** is awarded for a `review` row. Credit is still granted only for a novel,
+  recognized board (`pending`), exactly as today.
+- The contribute UI confirms a review submission with a "we'll check this by hand, not
+  credited yet" message, and lists review rows with an "under review · not credited" badge.
+- Manual top-up stays a human step (no new binary): once a review link gets an adapter and
+  board, a maintainer awards the credit and promotes the row to `onboarded`. The exact SQL
+  is documented in the `onboard-contributions` skill.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `link-contributions`: the submit contract gains a third outcome — an unrecognized valid
+  link is recorded for manual review (status `review`, no credit) rather than rejected;
+  credit is awarded only for recognized novel boards.
+
+## Impact
+
+- Schema: `link_contributions` — `source`/`board` become nullable, status CHECK gains
+  `review`, new partial unique index on `url` for the review queue. Prod migration applied
+  manually (`SET ROLE hire`).
+- Backend: `internal/contribution` (Submit, repository, queries), `internal/handler`
+  (CreateContribution reward gate).
+- Frontend: `ContributeView.svelte`, `types.ts`.
+- Docs: `onboard-contributions` skill gains a review-queue drain + manual-award section.

--- a/openspec/changes/contribution-review-queue/specs/link-contributions/spec.md
+++ b/openspec/changes/contribution-review-queue/specs/link-contributions/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Supported-ATS board recognition
+
+The system SHALL accept a link as a board contribution only when its host belongs to a
+supported multi-tenant ATS and the URL yields a board slug, determined without any network
+request. A link from an unknown host, a single-tenant source, or a URL with no board segment
+SHALL NOT be recorded as a board; instead, when it is a well-formed `http(s)` URL it SHALL be
+recorded for manual review (see "Record an unrecognized link for manual review"), and only a
+value that is not a well-formed `http(s)` URL SHALL be rejected with the "unsupported ATS"
+error. Both a vacancy URL and a bare board-listing URL for the same company SHALL yield the
+same board.
+
+#### Scenario: Non-URL garbage is rejected
+
+- **WHEN** a user submits a value that is not a well-formed `http(s)` URL
+- **THEN** the system responds 422 with an "unsupported ATS" error and records nothing
+
+#### Scenario: Unknown host is recorded for review
+
+- **WHEN** a user submits `https://example.com/careers/123`
+- **THEN** no board is derived, so the link is recorded for manual review rather than rejected
+
+#### Scenario: Vacancy URL and board-listing URL yield the same board
+
+- **WHEN** a user submits `https://jobs.ashbyhq.com/blitzy/<uuid>` and another submits `https://jobs.ashbyhq.com/blitzy`
+- **THEN** both derive source `ashby`, board `blitzy`, so the second is a duplicate of the first
+
+### Requirement: My contributions view
+
+The system SHALL let an authenticated user list their own contributions, newest first, each
+carrying its canonical URL, status, and — for a recognized board — its source and board slug;
+a review-queue row carries no source or board. The list SHALL be scoped to the caller and
+never reveal another user's contributions.
+
+#### Scenario: User lists their own contributions
+
+- **WHEN** an authenticated user requests their contributions
+- **THEN** the response contains only that user's contributions, newest first, each with its status
+
+#### Scenario: A review-queue submission is listed without a board
+
+- **WHEN** an authenticated user who submitted an unrecognized link requests their contributions
+- **THEN** that row appears with status `review` and no source or board
+
+## ADDED Requirements
+
+### Requirement: Record an unrecognized link for manual review
+
+When a submitted link is a well-formed `http(s)` URL but yields no supported board, the system
+SHALL record it as a review-queue contribution — owner and canonical URL, status `review`, no
+source or board — and SHALL NOT award any AI credits. A URL already in the review queue SHALL
+be rejected with the "board already contributed" error and SHALL NOT create a second row. Credit
+for such a link is granted only later, by hand, once a maintainer confirms the source is
+ingestable and promotes the row.
+
+#### Scenario: Unrecognized valid link is recorded without credit
+
+- **WHEN** an authenticated user submits a well-formed link that yields no supported board
+- **THEN** a row is recorded with status `review` and no source or board, and the user's AI-credits balance is unchanged
+
+#### Scenario: Duplicate review link is rejected
+
+- **WHEN** a user submits a link already present in the review queue
+- **THEN** the system responds 409 and records no second row
+
+#### Scenario: Review row earns no credit at submit time
+
+- **WHEN** a review-queue row is created
+- **THEN** no AI-credits reward is applied — credit remains exclusive to recognized novel boards

--- a/openspec/changes/contribution-review-queue/tasks.md
+++ b/openspec/changes/contribution-review-queue/tasks.md
@@ -1,31 +1,31 @@
 ## 1. Schema
 
-- [ ] 1.1 Add migration: `link_contributions` drop `NOT NULL` on `source`/`board`, replace status CHECK to add `review`, add partial unique index `ON (url) WHERE source IS NULL`.
+- [x] 1.1 Add migration: `link_contributions` drop `NOT NULL` on `source`/`board`, replace status CHECK to add `review`, add partial unique index `ON (url) WHERE source IS NULL`.
 
 ## 2. Data access (sqlc)
 
-- [ ] 2.1 Add a query to record a review row (`url`, `submitted_by`, status `review`, source/board NULL) and a query to detect an existing review row by URL; regenerate sqlc.
-- [ ] 2.2 Extend the contribution repository with `RecordReview` and `ReviewExists` (or equivalent), mapping the nullable `source`/`board` columns to the domain `Contribution`.
+- [x] 2.1 Add a query to record a review row (`url`, `submitted_by`, status `review`, source/board NULL) and a query to detect an existing review row by URL; regenerate sqlc.
+- [x] 2.2 Extend the contribution repository with `RecordReview` and `ReviewExists` (or equivalent), mapping the nullable `source`/`board` columns to the domain `Contribution`.
 
 ## 3. Contribution service
 
-- [ ] 3.1 RED: test `Submit` — a valid unknown URL returns a `review` Contribution (status `review`, empty source/board, no error); non-URL garbage returns `ErrUnsupportedATS`; a URL already in the review queue returns `ErrBoardAlreadyContributed`.
-- [ ] 3.2 GREEN: change `Submit`'s unrecognized branch to record a review row (guarded by the valid-`http(s)`-URL check) instead of returning `ErrUnsupportedATS`; keep garbage → 422.
+- [x] 3.1 RED: test `Submit` — a valid unknown URL returns a `review` Contribution (status `review`, empty source/board, no error); non-URL garbage returns `ErrUnsupportedATS`; a URL already in the review queue returns `ErrBoardAlreadyContributed`.
+- [x] 3.2 GREEN: change `Submit`'s unrecognized branch to record a review row (guarded by the valid-`http(s)`-URL check) instead of returning `ErrUnsupportedATS`; keep garbage → 422.
 
 ## 4. HTTP handler
 
-- [ ] 4.1 RED: handler test — an unknown valid link returns 201 with status `review` and awards no credit; a non-URL returns 422; a recognized novel board still 201 + credit.
-- [ ] 4.2 GREEN: gate `rewardContribution` on the recorded row being a recognized board (`status == "pending"`); return the review row as 201.
+- [x] 4.1 RED: handler test — an unknown valid link returns 201 with status `review` and awards no credit; a non-URL returns 422; a recognized novel board still 201 + credit.
+- [x] 4.2 GREEN: gate `rewardContribution` on the recorded row being a recognized board (`status == "pending"`); return the review row as 201.
 
 ## 5. Frontend
 
-- [ ] 5.1 `types.ts`: make `Contribution.source`/`board` nullable and add `review` to the status union.
-- [ ] 5.2 `ContributeView.svelte`: on a `review` result show the "not a known ATS, we'll check by hand, not credited yet" confirmation; render review rows in the list with the URL host and an "under review · not credited" badge.
+- [x] 5.1 `types.ts`: make `Contribution.source`/`board` nullable and add `review` to the status union.
+- [x] 5.2 `ContributeView.svelte`: on a `review` result show the "not a known ATS, we'll check by hand, not credited yet" confirmation; render review rows in the list with the URL host and an "under review · not credited" badge.
 
 ## 6. Docs
 
-- [ ] 6.1 Add a review-queue section to the `onboard-contributions` skill: how to drain `status='review'` rows, and the exact SQL to award the credit by contribution id + promote the row to `onboarded` once an adapter/board exists.
+- [x] 6.1 Add a review-queue section to the `onboard-contributions` skill: how to drain `status='review'` rows, and the exact SQL to award the credit by contribution id + promote the row to `onboarded` once an adapter/board exists.
 
 ## 7. Verify
 
-- [ ] 7.1 `go build ./... && go vet ./... && go test ./...`; run the contribution + handler tests; confirm the contribute page renders the review state.
+- [x] 7.1 `go build ./... && go vet ./... && go test ./...`; run the contribution + handler tests; confirm the contribute page renders the review state.

--- a/openspec/changes/contribution-review-queue/tasks.md
+++ b/openspec/changes/contribution-review-queue/tasks.md
@@ -1,0 +1,31 @@
+## 1. Schema
+
+- [ ] 1.1 Add migration: `link_contributions` drop `NOT NULL` on `source`/`board`, replace status CHECK to add `review`, add partial unique index `ON (url) WHERE source IS NULL`.
+
+## 2. Data access (sqlc)
+
+- [ ] 2.1 Add a query to record a review row (`url`, `submitted_by`, status `review`, source/board NULL) and a query to detect an existing review row by URL; regenerate sqlc.
+- [ ] 2.2 Extend the contribution repository with `RecordReview` and `ReviewExists` (or equivalent), mapping the nullable `source`/`board` columns to the domain `Contribution`.
+
+## 3. Contribution service
+
+- [ ] 3.1 RED: test `Submit` — a valid unknown URL returns a `review` Contribution (status `review`, empty source/board, no error); non-URL garbage returns `ErrUnsupportedATS`; a URL already in the review queue returns `ErrBoardAlreadyContributed`.
+- [ ] 3.2 GREEN: change `Submit`'s unrecognized branch to record a review row (guarded by the valid-`http(s)`-URL check) instead of returning `ErrUnsupportedATS`; keep garbage → 422.
+
+## 4. HTTP handler
+
+- [ ] 4.1 RED: handler test — an unknown valid link returns 201 with status `review` and awards no credit; a non-URL returns 422; a recognized novel board still 201 + credit.
+- [ ] 4.2 GREEN: gate `rewardContribution` on the recorded row being a recognized board (`status == "pending"`); return the review row as 201.
+
+## 5. Frontend
+
+- [ ] 5.1 `types.ts`: make `Contribution.source`/`board` nullable and add `review` to the status union.
+- [ ] 5.2 `ContributeView.svelte`: on a `review` result show the "not a known ATS, we'll check by hand, not credited yet" confirmation; render review rows in the list with the URL host and an "under review · not credited" badge.
+
+## 6. Docs
+
+- [ ] 6.1 Add a review-queue section to the `onboard-contributions` skill: how to drain `status='review'` rows, and the exact SQL to award the credit by contribution id + promote the row to `onboarded` once an adapter/board exists.
+
+## 7. Verify
+
+- [ ] 7.1 `go build ./... && go vet ./... && go test ./...`; run the contribution + handler tests; confirm the contribute page renders the review state.

--- a/web/src/lib/components/ContributeView.svelte
+++ b/web/src/lib/components/ContributeView.svelte
@@ -27,6 +27,15 @@
   const status = $derived(contribData.status);
   const contributions = $derived(contribData.value);
 
+  // A review row carries no board — show the link's host as its label instead.
+  function hostOf(u: string): string {
+    try {
+      return new URL(u).host;
+    } catch {
+      return u;
+    }
+  }
+
   async function submit(e: SubmitEvent) {
     e.preventDefault();
     if (!canSubmit) return;
@@ -72,7 +81,12 @@
       </p>
     </div>
 
-    {#if accepted}
+    {#if accepted && accepted.status === 'review'}
+      <div class="rounded-lg border border-border bg-secondary/40 p-4 text-sm" role="status">
+        This doesn't look like a known ATS. We'll check by hand whether we can pull its jobs — if
+        we can, we'll award you a credit. <span class="font-medium">Not credited yet.</span>
+      </div>
+    {:else if accepted}
       <div class="rounded-lg border border-border bg-secondary/40 p-4 text-sm" role="status">
         Thanks — <span class="font-medium">{accepted.board}</span> ({accepted.source}) is a new
         board for us. We'll start crawling it. <span class="font-medium">+1 AI credit.</span>
@@ -121,10 +135,15 @@
                   rel="noopener noreferrer"
                   class="truncate text-sm font-medium hover:underline"
                 >
-                  {c.board}
+                  {c.board || hostOf(c.url)}
                 </a>
                 <span class="truncate text-xs text-muted-foreground">
-                  {c.source} · contributed {timeAgo(c.created_at)}
+                  {#if c.status === 'review'}
+                    <span class="font-medium text-foreground">Under review</span> · not credited yet
+                    · {timeAgo(c.created_at)}
+                  {:else}
+                    {c.source} · contributed {timeAgo(c.created_at)}
+                  {/if}
                 </span>
               </div>
             </li>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -173,12 +173,16 @@ export interface User {
 /** A crowdsourced board contribution: a job link a user pasted for a company board we do
  *  not crawl yet. The unit is the board — `source` (ATS) + `board` (company slug) — not a
  *  single vacancy; the ingest side later scrapes all its vacancies. */
+export type ContributionStatus = 'pending' | 'onboarded' | 'rejected' | 'review';
+
 export interface Contribution {
   id: number;
   url: string;
+  // Empty for a `review` row (an unrecognized link awaiting manual triage); set once a board is
+  // recognized or a maintainer promotes the review row.
   source: string;
   board: string;
-  status: string;
+  status: ContributionStatus;
   created_at: string | null;
 }
 


### PR DESCRIPTION
Captures crowdsourced links the recognizer can't map to an ATS instead of dropping them. Implements the `contribution-review-queue` OpenSpec change.

## Behavior
- An unrecognized-but-valid `http(s)` contribution link is recorded in `link_contributions` with **status `review`** (source/board unset) instead of a 422. Non-URL garbage is still 422; a url already in the review queue is 409.
- **No AI credit** for a review row — credit stays exclusive to a recognized novel board (`pending`). Gated on **both** the HTTP handler and the Telegram webhook (the TG path awarded on any `err==nil` before — see the fix commit).
- Contribute UI: a review submission shows a "we'll check by hand, not credited yet" message and lists review rows with an "Under review · not credited" badge (labelled by URL host).

## Schema (migration 0037 — apply manually on prod, `SET ROLE hire`)
- `source`/`board` become nullable; status CHECK gains `review`; partial unique index on `(url) WHERE source IS NULL` dedups the queue.

## Manual triage (no new binary)
Documented in the local `onboard-contributions` skill: drain `status='review'` rows, reject non-ingestable ones, and — once a promoted link gets an adapter/board — award the credit + promote the row via a single idempotent SQL transaction.

## Tests
- Unit: `Submit` (unknown/single-tenant valid → review; garbage → 422; duplicate → 409).
- Integration (pass against real Postgres): HTTP review submit → 201, no credit; `/me/contributions` lists the review row; **Telegram** review submit → not-credited reply, balance unchanged, review row recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)