### PR TITLE
feat(web): host the filter trigger in the header search box

### DIFF
--- a/openspec/changes/filter-in-search-input/.openspec.yaml
+++ b/openspec/changes/filter-in-search-input/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/filter-in-search-input/design.md
+++ b/openspec/changes/filter-in-search-input/design.md
@@ -1,0 +1,65 @@
+## Context
+
+The shared header (`TopBar.svelte`, mounted once in `+layout.svelte`) hosts a
+context-dependent search box. On jobs-backed lists and the companies list it renders
+`HeaderListSearch.svelte`, which proxies its text input into the active page's store via
+the `listSearch.svelte.ts` registry (`setListSearchTarget`/`listSearchTarget`) and
+already carries a left scope-prefix trigger (`HeaderLocationFilter`, globe/region).
+
+The **All filters** trigger lives elsewhere: `ListToolbar.svelte` renders it twice — an
+inline button in the sort row and a floating edge button revealed by an
+`IntersectionObserver` once the toolbar scrolls out of view. `JobsView`/`CompaniesView`
+own the filter state and modal, passing `active` (count) and `onOpenFilters` down to
+`ListToolbar`. The `/my/profile` Market-coverage tab uses a separate `FilterEdgeTab` and
+is out of scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Host the All-filters trigger in the header search box on `/`, `/companies/[slug]`, and
+  `/companies`, on all viewports, opening each page's existing modal with an active-count
+  badge.
+- Remove both `ListToolbar` filter variants (inline + floating) without disturbing sort
+  or Swipe.
+- Keep filter ownership (state, count, modal) in the page views; the header only triggers.
+
+**Non-Goals:**
+- No change to the filter modal internals, facet logic, or URL sync.
+- No change to `/my/profile` `FilterEdgeTab` or the desktop `FilterSummary` sidebar.
+- No backend/API/database change.
+
+## Decisions
+
+**Extend the list-search registry rather than lift filter state into a shared store.**
+`listSearch.svelte.ts` is the established seam connecting the shared header to the active
+page. We add two optional fields to the registered target: `openFilters?: () => void` and
+`activeFilters?: () => number` (a getter, so Svelte 5 reactivity flows without copying
+state). The page views keep owning the modal and count; the header reads the callbacks.
+- *Alternative — a dedicated filter store:* rejected; it would duplicate state that
+  already lives in each view and blur module boundaries.
+- *Alternative — pass props through TopBar:* rejected; TopBar is mounted in the layout and
+  has no reference to the per-route view. The registry already exists for exactly this.
+
+**Render the trigger in `HeaderListSearch` gated on `openFilters` presence.** The button
+appears only when the active target exposes `openFilters`, so launcher/listless pages and
+any target without a modal render nothing — matching the existing pattern for the location
+prefix. Placement: right edge, after the clear button.
+
+**Delete the `ListToolbar` filter variants and their props.** Remove the inline filter
+button and the floating filter block; drop the now-unused `active`/`onOpenFilters` props
+and update `JobsView`/`CompaniesView` call sites. Retain the `IntersectionObserver`/
+`pinned` logic only if the floating Swipe affordance still needs it — otherwise remove it.
+
+## Risks / Trade-offs
+
+- [Embedded `JobsView` on `/companies/[slug]` may not register its target] → Verify
+  `setListSearchTarget` runs in the non-standalone (`scope` set) path; if it was gated on
+  `standalone`, un-gate the filter fields so the header trigger wires up on the company
+  page.
+- [Desktop now has two entry points to the modal (sidebar button + header trigger)] →
+  Accepted per design; both open the same modal, no state divergence.
+- [Reactivity of the badge] → Use a getter (`activeFilters: () => number`) in the
+  registration so the count tracks the view's reactive filter state; a plain number
+  snapshot would go stale.
+- [Component-render coverage is thin in `web/`] → Unit-test the registry contract; verify
+  the rendered trigger and removed toolbar buttons via headless-Chrome visual check.

--- a/openspec/changes/filter-in-search-input/proposal.md
+++ b/openspec/changes/filter-in-search-input/proposal.md
@@ -14,7 +14,10 @@ duplicated floating affordance.
   location/work-format scope-prefix on the left. It opens the active page's existing
   filter modal.
 - Show this trigger on all viewports across the jobs feed (`/`), the individual
-  company page (`/companies/[slug]`), and the companies list (`/companies`).
+  company page (`/companies/[slug]`), a collection landing page (`/collections/[slug]`),
+  and the companies list (`/companies`). The collection page previously showed the global
+  search launcher; it now hosts the list search box (like the company page) so its scoped
+  jobs list is both text-searchable and filterable from the header.
 - **BREAKING (UI)**: Remove both the inline toolbar filter button and the floating
   scroll-revealed filter edge button from `ListToolbar`. The sort control and the
   Swipe (Layers) affordance stay.
@@ -41,7 +44,10 @@ duplicated floating affordance.
 
 - `web/src/lib/listSearch.svelte.ts` — registered-target contract gains `activeFilters`
   and `openFilters`.
-- `web/src/lib/components/HeaderListSearch.svelte` — renders the trailing filter trigger.
+- `web/src/lib/components/HeaderListSearch.svelte` — renders the trailing filter trigger;
+  gains `min-w-0` so the search box shrinks to fit and never overflows the header row.
+- `web/src/lib/components/TopBar.svelte` — routes `/collections/[slug]` through the list
+  search box (`listKind`), so the collection page gains the header search + filter trigger.
 - `web/src/lib/components/ListToolbar.svelte` — drops the filter button (both variants)
   and its `active`/`onOpenFilters` props.
 - `web/src/lib/components/JobsView.svelte`, `web/src/lib/components/CompaniesView.svelte`

--- a/openspec/changes/filter-in-search-input/proposal.md
+++ b/openspec/changes/filter-in-search-input/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+The **All filters** trigger for the jobs and companies lists currently lives in the
+`ListToolbar` — an inline button in the sort row plus a floating edge button that the
+scroll reveals once the toolbar leaves the viewport. Because the header search box is
+sticky and always visible, hosting the filter trigger there instead makes filters
+reachable at every scroll position from one consistent place, and removes the
+duplicated floating affordance.
+
+## What Changes
+
+- Add an **All filters** trigger (sliders icon + active-count badge) to the right edge
+  of the shared header search box (`HeaderListSearch`), mirroring the existing
+  location/work-format scope-prefix on the left. It opens the active page's existing
+  filter modal.
+- Show this trigger on all viewports across the jobs feed (`/`), the individual
+  company page (`/companies/[slug]`), and the companies list (`/companies`).
+- **BREAKING (UI)**: Remove both the inline toolbar filter button and the floating
+  scroll-revealed filter edge button from `ListToolbar`. The sort control and the
+  Swipe (Layers) affordance stay.
+- Extend the shared list-search registration seam (`listSearch.svelte.ts`) so a page
+  publishes its active-filter count and a modal-open callback for the header to consume.
+- Leave the `/my/profile` **Market coverage** filter tab (`FilterEdgeTab`) and the
+  desktop `FilterSummary` sidebar untouched; the in-box trigger is an additional entry
+  point on desktop, not a replacement for the sidebar.
+
+## Capabilities
+
+### New Capabilities
+
+- `header-filter-trigger`: The **All filters** modal trigger is hosted in the shared
+  header search box on jobs-backed and companies list pages, showing an active-filter
+  badge and opening the page's own filter modal, on every viewport.
+
+### Modified Capabilities
+
+- `web-frontend`: The companies list's narrow-viewport filter affordance moves from a
+  pinned left-edge tab to the header-search-box trigger.
+
+## Impact
+
+- `web/src/lib/listSearch.svelte.ts` — registered-target contract gains `activeFilters`
+  and `openFilters`.
+- `web/src/lib/components/HeaderListSearch.svelte` — renders the trailing filter trigger.
+- `web/src/lib/components/ListToolbar.svelte` — drops the filter button (both variants)
+  and its `active`/`onOpenFilters` props.
+- `web/src/lib/components/JobsView.svelte`, `web/src/lib/components/CompaniesView.svelte`
+  — publish `activeFilters`/`openFilters` into the target; stop passing them to
+  `ListToolbar`.
+- No backend, API, or database changes.

--- a/openspec/changes/filter-in-search-input/specs/header-filter-trigger/spec.md
+++ b/openspec/changes/filter-in-search-input/specs/header-filter-trigger/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: All-filters trigger in the header search box
+
+On list pages backed by a filter modal — the jobs feed (`/`), a company's jobs list
+(`/companies/[slug]`), and the companies list (`/companies`) — the shared header search
+box SHALL render an **All filters** trigger at its right edge, after the clear control
+and mirroring the location scope-prefix on the left. The trigger SHALL be shown on every
+viewport. Activating it SHALL open that page's own filter modal (the jobs `FilterModal`
+or the companies `CompanyFilterModal`) without changing the search text or its focus
+hotkey. The trigger SHALL NOT appear on pages served by the global search launcher or on
+the `/my/profile` page, whose Market-coverage filter tab is unaffected.
+
+#### Scenario: Trigger shown on the jobs feed
+
+- **WHEN** a user views the jobs feed (`/`) or a company's jobs list (`/companies/:slug`)
+- **THEN** the header search box shows an All-filters trigger at its right edge on every
+  viewport
+
+#### Scenario: Trigger shown on the companies list
+
+- **WHEN** a user views the companies list (`/companies`)
+- **THEN** the header search box shows an All-filters trigger that opens the companies
+  filter modal
+
+#### Scenario: Activating the trigger opens the page's modal
+
+- **WHEN** the user activates the All-filters trigger
+- **THEN** the active page's filter modal opens, and the search text and its `/` focus
+  hotkey are unchanged
+
+#### Scenario: Trigger hidden where no filterable list exists
+
+- **WHEN** a user is on a page served by the global search launcher, or on `/my/profile`
+- **THEN** no All-filters trigger is shown in the header search box
+
+### Requirement: The trigger reflects the active-filter count
+
+The All-filters trigger SHALL display a badge with the number of currently active filters
+for the page, and SHALL show no badge when no filters are active. The count SHALL update
+reactively as filters are applied or cleared.
+
+#### Scenario: Badge shows the active count
+
+- **WHEN** two filters are active on the current list
+- **THEN** the trigger's badge shows `2`
+
+#### Scenario: No badge when nothing is filtered
+
+- **WHEN** no filters are active on the current list
+- **THEN** the trigger shows no count badge
+
+### Requirement: The list toolbar no longer hosts a filter trigger
+
+The list toolbar (`ListToolbar`) SHALL NOT render a filter trigger in either its inline
+sort row or its scroll-revealed floating edge variant; the All-filters trigger is hosted
+solely by the header search box. The toolbar's sort control and Swipe affordance SHALL
+remain.
+
+#### Scenario: No filter button in the toolbar row
+
+- **WHEN** a user views the jobs or companies list
+- **THEN** the toolbar row shows the sort control and, where applicable, the Swipe
+  affordance, but no filter button
+
+#### Scenario: No floating filter button on scroll
+
+- **WHEN** the user scrolls the list so the toolbar leaves the viewport
+- **THEN** no floating filter edge button appears; the header search box's trigger
+  remains the way to open filters

--- a/openspec/changes/filter-in-search-input/specs/header-filter-trigger/spec.md
+++ b/openspec/changes/filter-in-search-input/specs/header-filter-trigger/spec.md
@@ -3,17 +3,19 @@
 ### Requirement: All-filters trigger in the header search box
 
 On list pages backed by a filter modal — the jobs feed (`/`), a company's jobs list
-(`/companies/[slug]`), and the companies list (`/companies`) — the shared header search
-box SHALL render an **All filters** trigger at its right edge, after the clear control
-and mirroring the location scope-prefix on the left. The trigger SHALL be shown on every
-viewport. Activating it SHALL open that page's own filter modal (the jobs `FilterModal`
-or the companies `CompanyFilterModal`) without changing the search text or its focus
-hotkey. The trigger SHALL NOT appear on pages served by the global search launcher or on
-the `/my/profile` page, whose Market-coverage filter tab is unaffected.
+(`/companies/[slug]`), a collection landing page (`/collections/[slug]`), and the
+companies list (`/companies`) — the shared header search box SHALL render an **All
+filters** trigger at its right edge, after the clear control and mirroring the location
+scope-prefix on the left. The trigger SHALL be shown on every viewport. Activating it
+SHALL open that page's own filter modal (the jobs `FilterModal` or the companies
+`CompanyFilterModal`) without changing the search text or its focus hotkey. The trigger
+SHALL NOT appear on pages served by the global search launcher or on the `/my/profile`
+page, whose Market-coverage filter tab is unaffected.
 
-#### Scenario: Trigger shown on the jobs feed
+#### Scenario: Trigger shown on a jobs-backed list
 
-- **WHEN** a user views the jobs feed (`/`) or a company's jobs list (`/companies/:slug`)
+- **WHEN** a user views the jobs feed (`/`), a company's jobs list (`/companies/:slug`),
+  or a collection landing page (`/collections/:slug`)
 - **THEN** the header search box shows an All-filters trigger at its right edge on every
   viewport
 

--- a/openspec/changes/filter-in-search-input/specs/web-frontend/spec.md
+++ b/openspec/changes/filter-in-search-input/specs/web-frontend/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Companies list
+
+The frontend SHALL present companies from `GET /api/v1/companies`, showing each
+company's name and its job count, with each row linking to the company detail.
+
+The page SHALL provide a name-search input. Typing SHALL filter the list against
+the API's `q` parameter (debounced), and the current query SHALL be mirrored into
+the URL query string (`?q=`) so a search survives reload, sharing, and
+back/forward navigation. The page SHALL show the count of matching companies and
+a distinct empty state when a search matches nothing.
+
+The page SHALL present filters through the same two-pane "All filters" modal and
+chip-summary sidebar the jobs list uses (the reusable filter shells), over the
+company facet set: **collection**, **region**, **country**, **industry** (domains),
+**company type**, and **company size**, reusing the jobs filter controls and
+closed-vocabulary option registries (country is a searchable select over the country
+list; the others are pill/select controls over their fixed vocabularies). On desktop
+the sidebar SHALL show the applied-facet chips plus an **All filters** button opening
+the modal; the modal SHALL also be opened from the header search box's filter trigger
+(see the `header-filter-trigger` capability) on every viewport. As
+in the jobs modal, facet edits SHALL be staged and applied on **Show results**;
+applying SHALL refetch the list against the corresponding repeatable API facet
+parameters and mirror the active facets into the URL query string, so a filtered view
+survives reload, sharing, and back/forward navigation, composably with the `q` search.
+The summary sidebar SHALL offer a **Reset all** control.
+
+#### Scenario: Companies are listed
+
+- **WHEN** a user opens `/companies`
+- **THEN** a page of companies is fetched and rendered with job counts
+
+#### Scenario: User searches companies by name
+
+- **WHEN** a user types a query into the companies search input
+- **THEN** the list is refetched filtered by that query and the URL query string
+  is updated to `?q=<query>`
+
+#### Scenario: Search restored from the URL
+
+- **WHEN** a user opens `/companies?q=acme` directly or via back/forward
+- **THEN** the search input is prefilled with `acme` and the filtered list is
+  shown
+
+#### Scenario: Search matches nothing
+
+- **WHEN** a search returns no companies
+- **THEN** an empty state ("No matching companies.") is shown instead of an empty
+  list
+
+#### Scenario: User filters companies by a facet
+
+- **WHEN** a user opens the **All filters** modal, selects a region, and activates
+  **Show results**
+- **THEN** the list is refetched against `?regions=<value>` and the URL query
+  string reflects the active facet
+
+#### Scenario: Filters restored from the URL
+
+- **WHEN** a user opens `/companies?collections=yc&regions=europe` directly or via
+  back/forward
+- **THEN** the summary sidebar shows those facets active and the list is filtered to
+  match
+
+#### Scenario: Clearing filters
+
+- **WHEN** a user activates **Reset all**
+- **THEN** the facet parameters are removed from the URL and the full list (for the
+  current `q`, if any) is shown

--- a/openspec/changes/filter-in-search-input/tasks.md
+++ b/openspec/changes/filter-in-search-input/tasks.md
@@ -1,34 +1,34 @@
 ## 1. List-search registry seam
 
-- [ ] 1.1 Extend the `listSearch.svelte.ts` target contract with optional
+- [x] 1.1 Extend the `listSearch.svelte.ts` target contract with optional
   `openFilters?: () => void` and `activeFilters?: () => number`; unit-test that a
   registered target exposes them via `listSearchTarget()` and that they clear on unregister
 
 ## 2. Header trigger
 
-- [ ] 2.1 Render an All-filters trigger (sliders icon + active-count badge) at the right
+- [x] 2.1 Render an All-filters trigger (sliders icon + active-count badge) at the right
   edge of `HeaderListSearch.svelte`, shown only when the active target exposes
   `openFilters`; clicking calls `openFilters()`, badge reads `activeFilters()`, and the
   search text/`/`-hotkey are untouched
 
 ## 3. Wire the page views into the seam
 
-- [ ] 3.1 In `JobsView.svelte`, publish `openFilters` (open `FilterModal`) and
+- [x] 3.1 In `JobsView.svelte`, publish `openFilters` (open `FilterModal`) and
   `activeFilters` (`filters.active`) into the registered target; confirm the registration
   runs in the embedded/non-standalone path so `/companies/[slug]` wires up, un-gating if
   needed
-- [ ] 3.2 In `CompaniesView.svelte`, publish `openFilters` (open `CompanyFilterModal`) and
+- [x] 3.2 In `CompaniesView.svelte`, publish `openFilters` (open `CompanyFilterModal`) and
   `activeFilters` into the registered target
 
 ## 4. Remove the toolbar filter trigger
 
-- [ ] 4.1 Remove the inline and floating filter buttons from `ListToolbar.svelte`, drop the
+- [x] 4.1 Remove the inline and floating filter buttons from `ListToolbar.svelte`, drop the
   now-unused `active`/`onOpenFilters` props (and any observer logic no longer needed by the
   Swipe affordance), and update the `JobsView`/`CompaniesView` call sites; keep the sort
   control and Swipe affordance
 
 ## 5. Verify
 
-- [ ] 5.1 Run `svelte-check` and the web build; visually verify (headless Chrome) the
+- [x] 5.1 Run `svelte-check` and the web build; visually verify (headless Chrome) the
   trigger + badge on `/`, `/companies`, and `/companies/[slug]`, that the toolbar shows no
   filter button at any scroll position, and that `/my/profile` Market-coverage is unchanged

--- a/openspec/changes/filter-in-search-input/tasks.md
+++ b/openspec/changes/filter-in-search-input/tasks.md
@@ -1,0 +1,34 @@
+## 1. List-search registry seam
+
+- [ ] 1.1 Extend the `listSearch.svelte.ts` target contract with optional
+  `openFilters?: () => void` and `activeFilters?: () => number`; unit-test that a
+  registered target exposes them via `listSearchTarget()` and that they clear on unregister
+
+## 2. Header trigger
+
+- [ ] 2.1 Render an All-filters trigger (sliders icon + active-count badge) at the right
+  edge of `HeaderListSearch.svelte`, shown only when the active target exposes
+  `openFilters`; clicking calls `openFilters()`, badge reads `activeFilters()`, and the
+  search text/`/`-hotkey are untouched
+
+## 3. Wire the page views into the seam
+
+- [ ] 3.1 In `JobsView.svelte`, publish `openFilters` (open `FilterModal`) and
+  `activeFilters` (`filters.active`) into the registered target; confirm the registration
+  runs in the embedded/non-standalone path so `/companies/[slug]` wires up, un-gating if
+  needed
+- [ ] 3.2 In `CompaniesView.svelte`, publish `openFilters` (open `CompanyFilterModal`) and
+  `activeFilters` into the registered target
+
+## 4. Remove the toolbar filter trigger
+
+- [ ] 4.1 Remove the inline and floating filter buttons from `ListToolbar.svelte`, drop the
+  now-unused `active`/`onOpenFilters` props (and any observer logic no longer needed by the
+  Swipe affordance), and update the `JobsView`/`CompaniesView` call sites; keep the sort
+  control and Swipe affordance
+
+## 5. Verify
+
+- [ ] 5.1 Run `svelte-check` and the web build; visually verify (headless Chrome) the
+  trigger + badge on `/`, `/companies`, and `/companies/[slug]`, that the toolbar shows no
+  filter button at any scroll position, and that `/my/profile` Market-coverage is unchanged

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -59,6 +59,8 @@
       },
       setQuery: (q) => filters.setQuery(q),
       filterScope: { store: filters, counts: () => null, variant: 'companies' },
+      openFilters: () => (modalOpen = true),
+      activeFilters: () => filters.active,
     });
     return () => {
       setListSearchTarget(null);
@@ -100,8 +102,6 @@
     <ListToolbar
       total={companies.status === 'ready' && companies.items.length > 0 ? companies.total : null}
       unit={companies.total === 1 ? 'company' : 'companies'}
-      active={filters.active}
-      onOpenFilters={() => (modalOpen = true)}
     />
     {#if companies.status === 'loading'}
       <States state="loading" />

--- a/web/src/lib/components/HeaderListSearch.svelte
+++ b/web/src/lib/components/HeaderListSearch.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { Search, X } from '@lucide/svelte';
+  import { Search, SlidersHorizontal, X } from '@lucide/svelte';
   import { listSearchTarget } from '$lib/listSearch.svelte';
+  import { headerFilterTrigger } from '$lib/headerFilterTrigger';
   import HeaderLocationFilter from './HeaderLocationFilter.svelte';
 
   // The header's list-mode input: on /jobs and /companies it IS the page's text
@@ -16,6 +17,10 @@
   // Fall back to the URL's `q` before the view registers (SSR + first paint), so a
   // shared /jobs?q=… link shows its query immediately.
   const q = $derived(target?.value.q ?? page.url.searchParams.get('q') ?? '');
+  // The All-filters trigger: shown (with its active-filter badge) only on list pages
+  // that published `openFilters`; the count getter is called inside this $derived so
+  // the badge tracks the view's live filter state.
+  const filterTrigger = $derived(headerFilterTrigger(target));
 
   // Same global hotkeys as the launcher: Cmd/Ctrl+K always, `/` unless typing.
   function onWindowKeydown(e: KeyboardEvent) {
@@ -77,6 +82,29 @@
         class="hidden shrink-0 rounded border border-border px-1.5 text-xs text-muted-foreground sm:inline"
         >/</kbd
       >
+    {/if}
+    <!-- All-filters trigger, mirroring the Location scope-prefix on the left: divided
+         from the input and pinned to the right edge. Opens the active page's own filter
+         modal; the badge shows the active-filter count. Hidden where no list owns a
+         modal (launcher/listless pages register no `openFilters`). -->
+    {#if filterTrigger.visible}
+      <div class="h-5 w-px shrink-0 bg-border"></div>
+      <button
+        type="button"
+        onclick={() => target?.openFilters?.()}
+        aria-label="Filters"
+        title="Filters"
+        class="relative flex shrink-0 items-center text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <SlidersHorizontal class="size-4 shrink-0" />
+        {#if filterTrigger.count > 0}
+          <span
+            class="absolute -right-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-[10px] font-semibold leading-none text-brand-foreground"
+          >
+            {filterTrigger.count}
+          </span>
+        {/if}
+      </button>
     {/if}
   </div>
 </div>

--- a/web/src/lib/components/HeaderListSearch.svelte
+++ b/web/src/lib/components/HeaderListSearch.svelte
@@ -41,7 +41,10 @@
 
 <svelte:window onkeydown={onWindowKeydown} />
 
-<div class="relative flex-1">
+<!-- `min-w-0` lets this flex item shrink below its content's intrinsic width (flex-1
+     alone keeps min-width:auto), so the box narrows to fit the header row instead of
+     overflowing it — the inner input (also min-w-0) absorbs the shrink. -->
+<div class="relative min-w-0 flex-1">
   <div
     class="flex h-11 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring"
   >

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -253,6 +253,8 @@
       },
       setQuery: (q) => filters.setQuery(q),
       filterScope: { store: filters, counts: () => counts, variant: 'jobs' },
+      openFilters: () => (modalOpen = true),
+      activeFilters: () => filters.active,
     });
     return () => {
       setListSearchTarget(null);
@@ -414,8 +416,6 @@
     <ListToolbar
       total={!cvSignInPrompt && jobs.items.length > 0 ? jobs.total : null}
       unit={jobs.total === 1 ? 'job' : 'jobs'}
-      active={filters.active}
-      onOpenFilters={() => (modalOpen = true)}
       onSwipe={standalone ? openSwipe : undefined}
       showDesktopTotal={standalone}
       sortControl={standalone && isAuthenticated() ? sortSelect : undefined}

--- a/web/src/lib/components/ListToolbar.svelte
+++ b/web/src/lib/components/ListToolbar.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import { fade } from 'svelte/transition';
-  import { Layers, SlidersHorizontal } from '@lucide/svelte';
+  import { Layers } from '@lucide/svelte';
   import type { Snippet } from 'svelte';
 
   // The mobile controls for a list page (jobs, companies, …): an inline toolbar at the
-  // top of the list — the results total on the left, the Filters entry (and, on the jobs
-  // list, a Swipe entry) on the right. Once that toolbar scrolls out of view, the entries
-  // re-reveal as floating edge tabs so they stay reachable deep in the list. Mobile-only;
-  // the desktop sidebar aside carries filters there, so this shows only the total (right-
-  // aligned) at md+. Render it at the top of the list column, outside the view's status
-  // branches, so filters stay reachable while the list is loading/empty/errored.
+  // top of the list — the results total on the left, and (on the jobs list) a Swipe entry
+  // on the right. Once that toolbar scrolls out of view, the Swipe entry re-reveals as a
+  // floating edge tab so it stays reachable deep in the list. Filters are opened from the
+  // header search box's All-filters trigger (see HeaderListSearch), not from here. Mobile-
+  // only; the desktop sidebar aside carries filters there, so this shows only the total
+  // (right-aligned) at md+. Render it at the top of the list column, outside the view's
+  // status branches, so the controls stay reachable while the list is loading/empty/errored.
   //
   // `total` is null until the list is ready (then the count appears); `unit` is the
   // already-pluralised noun ("jobs" / "companies"). `onSwipe` is optional — pass it only
@@ -22,29 +23,26 @@
   let {
     total,
     unit,
-    active = 0,
-    onOpenFilters,
     onSwipe,
     showDesktopTotal = true,
     sortControl,
   }: {
     total: number | null;
     unit: string;
-    active?: number;
-    onOpenFilters: () => void;
     onSwipe?: () => void;
     showDesktopTotal?: boolean;
     sortControl?: Snippet;
   } = $props();
 
-  // Reveal the floating edge tabs once the inline toolbar leaves the viewport. The
+  // Reveal the floating Swipe edge tab once the inline toolbar leaves the viewport. The
   // toolbar is `md:hidden`, so on desktop it never intersects and this stays true — but
-  // the revealed tabs are `md:hidden` too, so nothing shows there.
+  // the revealed tab is `md:hidden` too, so nothing shows there. Only the Swipe tab reads
+  // `pinned`, so skip the observer entirely on lists without a swipe deck.
   let toolbarEl = $state<HTMLElement>();
   let pinned = $state(false);
   $effect(() => {
     const el = toolbarEl;
-    if (!el) return;
+    if (!el || !onSwipe) return;
     const io = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
@@ -57,9 +55,9 @@
   });
 </script>
 
-<!-- Mobile inline toolbar: total on the left, controls on the right. The Filters/Swipe
-     entries are icon-only here (labelled for a11y) so the row stays on one line with the
-     count and the sort control; the words would crowd it out on a narrow phone. -->
+<!-- Mobile inline toolbar: total on the left, controls on the right. The Swipe entry is
+     icon-only here (labelled for a11y) so the row stays on one line with the count and the
+     sort control; the word would crowd it out on a narrow phone. -->
 <div bind:this={toolbarEl} class="mb-3 flex items-center gap-2 md:hidden">
   {#if total !== null}
     <span class="shrink-0 whitespace-nowrap text-sm text-muted-foreground" aria-live="polite">
@@ -69,22 +67,6 @@
   {/if}
   <div class="ml-auto flex items-center gap-2">
     {@render sortControl?.()}
-    <button
-      type="button"
-      onclick={onOpenFilters}
-      aria-label="Filters"
-      title="Filters"
-      class="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 py-2 text-sm font-medium transition-colors hover:bg-accent"
-    >
-      <SlidersHorizontal class="size-4 shrink-0" />
-      {#if active > 0}
-        <span
-          class="flex h-5 min-w-5 items-center justify-center rounded-full bg-brand px-1 text-[11px] font-semibold leading-none text-brand-foreground"
-        >
-          {active}
-        </span>
-      {/if}
-    </button>
     {#if onSwipe}
       <button
         type="button"
@@ -114,35 +96,17 @@
   </div>
 {/if}
 
-<!-- Scroll-revealed floating controls: Filters (left) and, where present, Swipe (right). -->
-{#if pinned}
+<!-- Scroll-revealed floating control: Swipe (right), where present. Filters are reached
+     from the header search box's trigger, which stays visible while scrolling. -->
+{#if pinned && onSwipe}
   <button
     type="button"
-    onclick={onOpenFilters}
-    aria-label="Filters"
-    title="Filters"
+    onclick={onSwipe}
+    aria-label="Swipe mode"
+    title="Swipe mode"
     transition:fade={{ duration: 150 }}
-    class="fixed left-0 top-16 z-30 flex items-center py-2 pl-3 pr-2 text-muted-foreground transition-colors hover:text-foreground md:hidden"
+    class="fixed right-0 top-16 z-30 flex items-center py-2 pl-2 pr-3 text-muted-foreground transition-colors hover:text-foreground md:hidden"
   >
-    <SlidersHorizontal class="size-4 shrink-0" />
-    {#if active > 0}
-      <span
-        class="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-[10px] font-semibold leading-none text-brand-foreground"
-      >
-        {active}
-      </span>
-    {/if}
+    <Layers class="size-4 shrink-0" />
   </button>
-  {#if onSwipe}
-    <button
-      type="button"
-      onclick={onSwipe}
-      aria-label="Swipe mode"
-      title="Swipe mode"
-      transition:fade={{ duration: 150 }}
-      class="fixed right-0 top-16 z-30 flex items-center py-2 pl-2 pr-3 text-muted-foreground transition-colors hover:text-foreground md:hidden"
-    >
-      <Layers class="size-4 shrink-0" />
-    </button>
-  {/if}
 {/if}

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -17,15 +17,16 @@
   // (the homepage feed `/`, /companies, and a company's own /companies/:slug jobs
   // list) it IS that page's filter (HeaderListSearch drives the list, so there's no
   // duplicate box); everywhere else it's the global launcher with the instant
-  // dropdown (HeaderSearch). A company detail page is a jobs list scoped to that
-  // company, so the header search filters its postings — hence 'company' shares the
-  // jobs proxy.
+  // dropdown (HeaderSearch). A company detail page and a collection landing page are
+  // both jobs lists scoped to that entity, so the header search filters their postings
+  // (and hosts the All-filters trigger) — hence they share the 'company' jobs proxy.
   const listKind = $derived(
     page.url.pathname === '/'
       ? 'jobs'
       : page.url.pathname === '/companies'
         ? 'companies'
-        : /^\/companies\/[^/]+$/.test(page.url.pathname)
+        : /^\/companies\/[^/]+$/.test(page.url.pathname) ||
+            /^\/collections\/[^/]+$/.test(page.url.pathname)
           ? 'company'
           : null,
   );

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -25,8 +25,7 @@
       ? 'jobs'
       : page.url.pathname === '/companies'
         ? 'companies'
-        : /^\/companies\/[^/]+$/.test(page.url.pathname) ||
-            /^\/collections\/[^/]+$/.test(page.url.pathname)
+        : /^\/(companies|collections)\/[^/]+$/.test(page.url.pathname)
           ? 'company'
           : null,
   );

--- a/web/src/lib/headerFilterTrigger.test.ts
+++ b/web/src/lib/headerFilterTrigger.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { headerFilterTrigger } from './headerFilterTrigger';
+import type { ListSearchTarget } from './listSearch.svelte';
+
+// A minimal target stub; only the fields the trigger reads matter. The rune-backed
+// store is irrelevant here — the header consumes the plain `openFilters`/`activeFilters`
+// callbacks, so a plain object exercises the contract without Svelte compilation.
+function target(over: Partial<ListSearchTarget> = {}): ListSearchTarget {
+  return { value: { q: '' }, setQuery: () => {}, ...over };
+}
+
+describe('headerFilterTrigger', () => {
+  it('is hidden when there is no target (launcher/listless page)', () => {
+    expect(headerFilterTrigger(null)).toEqual({ visible: false, count: 0 });
+  });
+
+  it('is hidden when the target owns no filter modal', () => {
+    expect(headerFilterTrigger(target())).toEqual({ visible: false, count: 0 });
+  });
+
+  it('is visible with the active-filter count when the target exposes openFilters', () => {
+    const t = target({ openFilters: () => {}, activeFilters: () => 2 });
+    expect(headerFilterTrigger(t)).toEqual({ visible: true, count: 2 });
+  });
+
+  it('defaults the badge count to 0 when activeFilters is absent', () => {
+    const t = target({ openFilters: () => {} });
+    expect(headerFilterTrigger(t)).toEqual({ visible: true, count: 0 });
+  });
+});

--- a/web/src/lib/headerFilterTrigger.ts
+++ b/web/src/lib/headerFilterTrigger.ts
@@ -1,0 +1,18 @@
+import type { ListSearchTarget } from './listSearch.svelte';
+
+// Derives whether the header search box should host the All-filters trigger, and its
+// badge count, from the active list-search target. Kept as a pure function (not inline
+// in HeaderListSearch) so the visibility gate and badge count are unit-testable without
+// a Svelte/rune runtime — the template just renders this. The trigger shows only where a
+// page owns a filter modal (it published `openFilters`); the launcher and listless pages
+// register no such target, so no trigger appears.
+
+export interface HeaderFilterTrigger {
+  visible: boolean;
+  count: number;
+}
+
+export function headerFilterTrigger(target: ListSearchTarget | null): HeaderFilterTrigger {
+  if (!target?.openFilters) return { visible: false, count: 0 };
+  return { visible: true, count: target.activeFilters?.() ?? 0 };
+}

--- a/web/src/lib/listSearch.svelte.ts
+++ b/web/src/lib/listSearch.svelte.ts
@@ -24,6 +24,14 @@ export interface ListSearchTarget {
     counts(): FacetCounts | null;
     variant: 'jobs' | 'companies';
   };
+
+  /** Opens the page's own filter modal, and reports its active-filter count, so the
+   *  header can host the All-filters trigger. Present on list pages that own a filter
+   *  modal (jobs feed, company page, companies list); absent on the launcher, where the
+   *  header renders no trigger. `activeFilters` is a getter so the badge tracks the
+   *  view's reactive filter state across the bridge. */
+  readonly openFilters?: () => void;
+  readonly activeFilters?: () => number;
 }
 
 let active = $state<ListSearchTarget | null>(null);


### PR DESCRIPTION
## Summary
- Move the jobs/companies **All filters** trigger (sliders icon + active-filter badge) out of `ListToolbar` and into the shared header search box (`HeaderListSearch`), pinned to the right edge, on **all viewports**. Because the header is sticky, filters stay reachable at any scroll position — the inline and floating `ListToolbar` filter buttons are removed (sort + Swipe stay).
- Surface it across the jobs feed (`/`), the company page (`/companies/[slug]`), the **collection** landing pages (`/collections/[slug]`, which now use the list search box like the company page), and the companies list (`/companies`). `/my/profile` Market-coverage (`FilterEdgeTab`) and the desktop `FilterSummary` sidebar are untouched.
- Seam: `listSearch.svelte.ts` gains `openFilters`/`activeFilters` callbacks published by each view; the header derives visibility + badge via a pure, unit-tested `headerFilterTrigger.ts`.
- Fix a flexbox overflow the trigger exposed: the search box was `flex-1` without `min-w-0`, forcing the header row to a 407px minimum (horizontal scroll on narrow phones). Added `min-w-0` so it shrinks to fit.

Planned/tracked in OpenSpec change `filter-in-search-input` (new `header-filter-trigger` capability + `web-frontend` delta).

## Test Plan
- [x] `npm run check` — 0 errors
- [x] `npm test` — 324 passing (incl. 4 new for `headerFilterTrigger`)
- [x] `npm run build` — clean
- [x] Horizontal-overflow measured (CDP) at 360/390/768/1280px on `/`, `/companies`, `/companies/[slug]`, `/collections/[slug]` — none
- [x] Visual check: trigger + badge render in the search box on all four surfaces; hamburger present; `/my/profile` launcher unchanged