### PR TITLE
feat(sources): onboard Paylocity board SLEQ Solutions

### DIFF
--- a/sources/paylocity.yml
+++ b/sources/paylocity.yml
@@ -18951,3 +18951,5 @@
   board: 859650c7-8f4e-445e-a1b7-c43bbf4fbafa
 - company: Highlands Recreation District
   board: Highlands-Recreation-District
+- company: SLEQ Solutions
+  board: 8647530b-0297-4ce9-b492-ab48db343a7f


### PR DESCRIPTION
Mined from the contribution recognizer-miss log. A user contributed `recruiting.paylocity.com/Recruiting/Jobs/Apply/4299892/SLEQ-Solutions`; the URL recognizer couldn't map it (the Apply URL carries a job id, not the company GUID it namespaces on). Resolved the board GUID `8647530b-…` from the job detail page and live-validated the listing ("SLEQ Solutions - Job Opportunities", 1 open role).

Other log links triaged: **Avenga** already tracked (teamtailor `career.avenga.com`); **Qualcomm** is Eightfold (skipped — prod-IP block); the rest (wellhub, llamaindex, itransition, honeytech, techtree, totvs, enzrossi) show no known-ATS signature and need deeper resolve / a new adapter.