### PR TITLE
feat(sources): onboard Rippling board LegitScript

### DIFF
--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -165,3 +165,5 @@
   board: rippling
 - company: Satomic
   board: satomic
+- company: LegitScript
+  board: legitscript-careers


### PR DESCRIPTION
Contributed `ats.rippling.com/en-US/legitscript-careers/jobs/<uuid>`. The Rippling public API `api.rippling.com/platform/api/ats/v1/board/legitscript-careers/jobs` returns 6 open roles and fits the existing `rippling` adapter (board = the board slug `legitscript-careers`).