### PR TITLE
feat(web): drop the floating swipe tab, keep Swipe inline

### DIFF
--- a/web/src/lib/components/ListToolbar.svelte
+++ b/web/src/lib/components/ListToolbar.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
-  import { fade } from 'svelte/transition';
   import { Layers } from '@lucide/svelte';
   import type { Snippet } from 'svelte';
 
   // The mobile controls for a list page (jobs, companies, …): an inline toolbar at the
   // top of the list — the results total on the left, and (on the jobs list) a Swipe entry
-  // on the right. Once that toolbar scrolls out of view, the Swipe entry re-reveals as a
-  // floating edge tab so it stays reachable deep in the list. Filters are opened from the
-  // header search box's All-filters trigger (see HeaderListSearch), not from here. Mobile-
-  // only; the desktop sidebar aside carries filters there, so this shows only the total
-  // (right-aligned) at md+. Render it at the top of the list column, outside the view's
-  // status branches, so the controls stay reachable while the list is loading/empty/errored.
+  // on the right. Filters are opened from the header search box's All-filters trigger (see
+  // HeaderListSearch), not from here. Mobile-only; the desktop sidebar aside carries filters
+  // there, so this shows only the total (right-aligned) at md+. Render it at the top of the
+  // list column, outside the view's status branches, so the controls stay reachable while
+  // the list is loading/empty/errored.
   //
   // `total` is null until the list is ready (then the count appears); `unit` is the
   // already-pluralised noun ("jobs" / "companies"). `onSwipe` is optional — pass it only
@@ -33,32 +31,12 @@
     showDesktopTotal?: boolean;
     sortControl?: Snippet;
   } = $props();
-
-  // Reveal the floating Swipe edge tab once the inline toolbar leaves the viewport. The
-  // toolbar is `md:hidden`, so on desktop it never intersects and this stays true — but
-  // the revealed tab is `md:hidden` too, so nothing shows there. Only the Swipe tab reads
-  // `pinned`, so skip the observer entirely on lists without a swipe deck.
-  let toolbarEl = $state<HTMLElement>();
-  let pinned = $state(false);
-  $effect(() => {
-    const el = toolbarEl;
-    if (!el || !onSwipe) return;
-    const io = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        if (entry) pinned = !entry.isIntersecting;
-      },
-      { threshold: 0 },
-    );
-    io.observe(el);
-    return () => io.disconnect();
-  });
 </script>
 
 <!-- Mobile inline toolbar: total on the left, controls on the right. The Swipe entry is
      icon-only here (labelled for a11y) so the row stays on one line with the count and the
      sort control; the word would crowd it out on a narrow phone. -->
-<div bind:this={toolbarEl} class="mb-3 flex items-center gap-2 md:hidden">
+<div class="mb-3 flex items-center gap-2 md:hidden">
   {#if total !== null}
     <span class="shrink-0 whitespace-nowrap text-sm text-muted-foreground" aria-live="polite">
       <span class="font-semibold tabular-nums text-foreground">{total.toLocaleString()}</span>
@@ -94,19 +72,4 @@
     {/if}
     {@render sortControl?.()}
   </div>
-{/if}
-
-<!-- Scroll-revealed floating control: Swipe (right), where present. Filters are reached
-     from the header search box's trigger, which stays visible while scrolling. -->
-{#if pinned && onSwipe}
-  <button
-    type="button"
-    onclick={onSwipe}
-    aria-label="Swipe mode"
-    title="Swipe mode"
-    transition:fade={{ duration: 150 }}
-    class="fixed right-0 top-16 z-30 flex items-center py-2 pl-2 pr-3 text-muted-foreground transition-colors hover:text-foreground md:hidden"
-  >
-    <Layers class="size-4 shrink-0" />
-  </button>
 {/if}


### PR DESCRIPTION
## Summary
- Remove the scroll-revealed **floating** Swipe edge tab from `ListToolbar`. The Swipe entry now lives only in the inline toolbar row at the top of the list (beside the sort control), per request.
- With the filter trigger already hosted in the header (#1018), the `IntersectionObserver`/`pinned` scroll-reveal machinery no longer served anything, so it's removed — along with the now-unused `fade` import.

No behavior change to the inline Swipe button, sort control, or desktop total.

## Test Plan
- [x] `npm run check` — 0 errors
- [x] `npm test` — 324 passing
- [x] `npm run build` — clean
- [x] Visual: inline Swipe present at top of the mobile feed toolbar; no floating tab on scroll