### PR TITLE
feat(views): count SvelteKit __data.json SPA navigations as page views

### DIFF
--- a/internal/viewlog/AGENTS.md
+++ b/internal/viewlog/AGENTS.md
@@ -11,9 +11,10 @@ SSR→backend boundary) — lets us filter bots and cover anonymous + API unifor
 
 - `ParseLine(line) (Record, ok)` — one nginx `combined`-format line → `Record`
   (IP, timestamp, method, path, status, UA). Unparseable/bad-request lines → `ok=false`.
-- `Classify(Record) (Signal, ok)` — a 2xx GET of exactly `/jobs/<slug>` (`KindPage`)
-  or `/api/v1/jobs/<slug>` (`KindAPI`) → the slug; everything else ignored (a slug is
-  one path segment, so lists and sub-resources like `/similar`, `/fit` don't count).
+- `Classify(Record) (Signal, ok)` — a 2xx GET of `/jobs/<slug>` or its SvelteKit SPA
+  data request `/jobs/<slug>/__data.json` (`KindPage`), or `/api/v1/jobs/<slug>`
+  (`KindAPI`) → the slug; everything else ignored (a slug is one path segment, so
+  lists and sub-resources like `/similar`, `/fit` don't count).
 - `Aggregate(reader) map[day]map[slug]int` — dedups by `(hash(IP+UA), slug, day)`,
   the day taken from each line's timestamp (UTC); page opens from known bots are
   dropped, API reads are not bot-filtered.

--- a/internal/viewlog/classify.go
+++ b/internal/viewlog/classify.go
@@ -30,6 +30,12 @@ func Classify(rec Record) (Signal, bool) {
 	if i := strings.IndexByte(path, '?'); i >= 0 {
 		path = path[:i]
 	}
+	// A SvelteKit client-side (SPA) navigation to the detail page fetches the load
+	// data at /jobs/<slug>/__data.json instead of re-requesting the HTML; count it
+	// as the same page view. A full/direct load hits /jobs/<slug> — the two are
+	// mutually exclusive per view, and the (visitor, slug, day) dedup collapses any
+	// overlap, so this never double-counts.
+	path = strings.TrimSuffix(path, "/__data.json")
 	if slug, ok := singleSegment(path, "/jobs/"); ok {
 		return Signal{Slug: slug, Kind: KindPage}, true
 	}

--- a/internal/viewlog/classify_test.go
+++ b/internal/viewlog/classify_test.go
@@ -32,6 +32,27 @@ func TestClassify(t *testing.T) {
 			wantKind: KindPage,
 		},
 		{
+			// SvelteKit client-side (SPA) navigation to the detail page fetches the
+			// load data, not the HTML — this is how in-app clicks show up.
+			name:     "sveltekit __data.json navigation counts as a page view",
+			rec:      Record{Method: "GET", Path: "/jobs/acme-eng-123/__data.json", Status: 200},
+			wantOK:   true,
+			wantSlug: "acme-eng-123",
+			wantKind: KindPage,
+		},
+		{
+			name:     "__data.json with sveltekit query strips both",
+			rec:      Record{Method: "GET", Path: "/jobs/acme-eng-123/__data.json?x-sveltekit-invalidated=01", Status: 200},
+			wantOK:   true,
+			wantSlug: "acme-eng-123",
+			wantKind: KindPage,
+		},
+		{
+			name:   "sub-resource __data.json is not a detail-page view",
+			rec:    Record{Method: "GET", Path: "/jobs/acme-eng-123/similar/__data.json", Status: 200},
+			wantOK: false,
+		},
+		{
 			name:   "job list is not a view",
 			rec:    Record{Method: "GET", Path: "/jobs", Status: 200},
 			wantOK: false,

--- a/openspec/changes/view-count-from-nginx-logs/specs/view-count-aggregation/spec.md
+++ b/openspec/changes/view-count-from-nginx-logs/specs/view-count-aggregation/spec.md
@@ -25,8 +25,10 @@ counting or write as a side effect of serving a job.
 The worker SHALL count exactly two request signals, both requiring a successful
 (2xx) response:
 
-- a page open: `GET /jobs/<slug>` (the SSR detail page) — the worker SHALL skip
-  lines whose User-Agent matches a known-bot list;
+- a page open: `GET /jobs/<slug>` (a full/direct SSR load) or
+  `GET /jobs/<slug>/__data.json` (a SvelteKit client-side navigation, which fetches
+  the load data instead of the HTML) — the worker SHALL treat both as the same page
+  view and SHALL skip lines whose User-Agent matches a known-bot list;
 - an API read: `GET /api/v1/jobs/<slug>` — the worker SHALL NOT apply bot
   filtering to this signal.
 
@@ -38,6 +40,12 @@ counted.
 - **WHEN** the log contains `GET /jobs/acme-engineer-123 HTTP/2.0` with status 200
   and a non-bot User-Agent
 - **THEN** the worker counts one page-open view for that job's slug
+
+#### Scenario: SvelteKit SPA navigation is counted for the same slug
+
+- **WHEN** the log contains `GET /jobs/acme-engineer-123/__data.json` (with any
+  query) with status 200 and a non-bot User-Agent
+- **THEN** the worker counts one page-open view for `acme-engineer-123`
 
 #### Scenario: Known bot on the page path is skipped
 


### PR DESCRIPTION
Follow-up to #1024. Real prod access logs on host2 show that in-app clicks to a job (SvelteKit client-side navigation) hit `GET /jobs/<slug>/__data.json` — the load-data request — **not** the HTML `GET /jobs/<slug>`. The initial worker counted only full/direct HTML loads, so it silently missed SPA navigations, which are likely the majority of real views.

## Change
- `Classify` strips a trailing `/__data.json` before the slug match, so `/jobs/<slug>` and `/jobs/<slug>/__data.json` both count as one page view. Sub-resources (`/jobs/<slug>/similar/__data.json`, `/fit`, `/og.png`) stay excluded.
- The two request shapes are mutually exclusive per view (inlined data on SSR vs `__data.json` on client nav), and the `(visitor, slug, day)` dedup collapses any overlap — so counting both never double-counts.

## Test Plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/viewlog/` — new `Classify` cases for `__data.json` (with/without sveltekit query) and the sub-resource rejection
- [x] Verified against real host2 log lines (format confirmed `combined`)