### PR TITLE
feat(gmailsync): drop LinkedIn + booking/calendar from inbox recall query

### DIFF
--- a/internal/gmailsync/senders.go
+++ b/internal/gmailsync/senders.go
@@ -51,60 +51,40 @@ var ATSDomains = []string{
 // hardcoded; they enter the query via the self-learning cache (see learn.go), so
 // the allowlist grows from real classifications instead of curation-by-anecdote.
 
-// Recall signals beyond the ATS sender allowlist, each measured as a class the
-// allowlist alone misses. Adding one is a single line, mirroring ATSDomains.
-// Everything the query pulls is LLM-classified downstream, so the query is
-// recall-first; precision is the classifier's job, not the gate's.
-var (
-	// bookingDomains are interview-scheduling senders whose mail carries the
-	// interview signal without ATS markers or application boilerplate.
-	bookingDomains = []string{
-		"cal.com",
-		"oncehub.com",
-		"calendly.com",
-	}
-	// inmailSenders are recruiter-outreach senders (LinkedIn InMail), listed as
-	// exact addresses to exclude LinkedIn's job-alert digests, which are not
-	// applications (jobalerts-noreply@, jobs-noreply@).
-	inmailSenders = []string{
-		"inmail-hit-reply@linkedin.com",         // InMail
-		"messaging-digest-noreply@linkedin.com", // "X just messaged you" (recruiter DMs)
-	}
-	// recallPhrases are strong application/interview phrases matched by Gmail
-	// full-text, catching job mail from senders on no allowlist (direct company
-	// domains, personal recruiters). Multilingual for a multilingual inbox.
-	recallPhrases = []string{
-		"thank you for applying",
-		"thanks for applying",
-		"your application at",
-		"we regret to inform",
-		"invite you to interview",
-		"complete your interview",
-		"recebemos sua candidatura",  // pt: we received your application
-		"convite para entrevista",    // pt: interview invitation
-		"ваш отклик",                 // ru: your application
-		"приглашаем вас",             // ru: we invite you
-		"hemos recibido tu",          // es: we have received your
-		"invitación a la entrevista", // es: interview invitation
-	}
-)
+// recallPhrases are strong application/interview phrases matched by Gmail
+// full-text, catching job mail from senders on no allowlist (direct company
+// domains, personal recruiters) that the ATS sender allowlist alone misses.
+// Multilingual for a multilingual inbox. Everything the query pulls is
+// LLM-classified downstream, so the query is recall-first; precision is the
+// classifier's job, not the gate's.
+var recallPhrases = []string{
+	"thank you for applying",
+	"thanks for applying",
+	"your application at",
+	"we regret to inform",
+	"invite you to interview",
+	"complete your interview",
+	"recebemos sua candidatura",  // pt: we received your application
+	"convite para entrevista",    // pt: interview invitation
+	"ваш отклик",                 // ru: your application
+	"приглашаем вас",             // ru: we invite you
+	"hemos recibido tu",          // es: we have received your
+	"invitación a la entrevista", // es: interview invitation
+}
 
 // BuildQuery builds a Gmail search query for job-application mail newer than the
-// given Unix watermark. It ORs the hardcoded universal core (ATS/booking/InMail
-// senders) with any learned domains (extraDomains, promoted by the self-learning
-// cache), calendar invites, and multilingual application phrases, so non-ATS-domain
-// mail is still synced; the whole union is time-bounded by after:. A zero watermark
-// omits the time clause for a first-run backfill.
+// given Unix watermark. It ORs the hardcoded ATS sender core with any learned
+// domains (extraDomains, promoted by the self-learning cache) and multilingual
+// application phrases, so non-ATS-domain mail is still synced; the whole union is
+// time-bounded by after:. A zero watermark omits the time clause for a first-run
+// backfill.
 func BuildQuery(afterUnix int64, extraDomains []string) string {
-	senders := make([]string, 0, len(ATSDomains)+len(bookingDomains)+len(inmailSenders)+len(extraDomains))
+	senders := make([]string, 0, len(ATSDomains)+len(extraDomains))
 	senders = append(senders, ATSDomains...)
-	senders = append(senders, bookingDomains...)
-	senders = append(senders, inmailSenders...)
 	senders = append(senders, extraDomains...)
 
 	clauses := []string{
 		"from:(" + strings.Join(senders, " OR ") + ")",
-		"filename:ics", // calendar invites from any organizer (e.g. Google "Приглашение")
 	}
 	for _, p := range recallPhrases {
 		clauses = append(clauses, `"`+p+`"`)

--- a/internal/gmailsync/senders_test.go
+++ b/internal/gmailsync/senders_test.go
@@ -86,19 +86,15 @@ func TestBuildQueryLearnedDomains(t *testing.T) {
 	}
 }
 
-// TestBuildQueryRecallSignals locks in the non-ATS-domain recall classes measured
-// as missed by the sender allowlist alone: interview-scheduling senders, LinkedIn
-// InMail, calendar invites, and multilingual application phrases. Everything the
-// query pulls is LLM-classified downstream, so the query is recall-first.
+// TestBuildQueryRecallSignals locks in the non-ATS-domain recall class measured as
+// missed by the sender allowlist alone: multilingual application phrases matched by
+// Gmail full-text. Everything the query pulls is LLM-classified downstream, so the
+// query is recall-first.
 func TestBuildQueryRecallSignals(t *testing.T) {
 	q := BuildQuery(1_700_000_000, nil)
 	wants := []string{
-		"cal.com",                       // booking domain (interview scheduling)
-		"oncehub.com",                   // booking domain
-		"inmail-hit-reply@linkedin.com", // LinkedIn InMail (not jobalerts)
-		"filename:ics",                  // calendar invites from any organizer
-		`"thank you for applying"`,      // strong English phrase
-		`"recebemos sua candidatura"`,   // pt: multilingual recall
+		`"thank you for applying"`,    // strong English phrase
+		`"recebemos sua candidatura"`, // pt: multilingual recall
 	}
 	for _, w := range wants {
 		if !strings.Contains(q, w) {
@@ -110,8 +106,8 @@ func TestBuildQueryRecallSignals(t *testing.T) {
 	if !strings.HasPrefix(q, "(") || !strings.Contains(q, ") after:1700000000") {
 		t.Errorf("after: must apply to the whole OR-group: %q", q)
 	}
-	// LinkedIn job-alert digests are not applications and must not be pulled.
-	if strings.Contains(q, "jobalerts-noreply") || strings.Contains(q, "jobs-noreply") {
-		t.Errorf("query should not pull LinkedIn job alerts: %q", q)
+	// LinkedIn is no longer a recall source — no linkedin.com senders in the query.
+	if strings.Contains(q, "linkedin.com") {
+		t.Errorf("query should not reference LinkedIn: %q", q)
 	}
 }


### PR DESCRIPTION
## What

Narrows the Gmail inbox sync query to just the signals that carry real job-application value:

- **Removed LinkedIn** — `inmail-hit-reply@linkedin.com` (InMail) and `messaging-digest-noreply@linkedin.com` ("X just messaged you" recruiter digests). These are outreach/DMs, not applications.
- **Removed booking domains** — `cal.com`, `oncehub.com`, `calendly.com`.
- **Removed calendar invites** — the `filename:ics` clause.

The query is now: **ATS sender domains (+ self-learned domains) OR multilingual application phrases**.

## Why

These sources added noise to the inbox without carrying application/interview outcomes worth surfacing. Narrowing the *hardcoded* seed costs no adaptivity: the self-learning cache (`learn.go`) still promotes new sender domains from real, LLM-confirmed mail.

## Notes

- This changes only the **sync query going forward**. Mail already synced from these sources stays in the inbox (no backfill cleanup here).
- Tests updated: `TestBuildQueryRecallSignals` now asserts the phrase recall class and guards against LinkedIn re-entering the query.

## Verification

`go build`, `go vet`, `go test ./internal/gmailsync/` — all green. `gofmt` clean.