### PR TITLE
feat(classify): detect Russian & Portuguese-BR non-tech titles

### DIFF
--- a/internal/classify/nontech.go
+++ b/internal/classify/nontech.go
@@ -71,7 +71,59 @@ var nonTechTitleTerms = []string{
 	"security guard", "truck driver", "delivery driver", "bus driver", "courier",
 	// Front-of-house administration
 	"receptionist", "front desk",
+	// Russian non-technical roles (the trudvsem/hh tail arrives in Russian, so the
+	// English terms above never fire and these jobs fall to unknown instead of
+	// non-tech). Same doctrine: unambiguous role nouns only, whole-word (Cyrillic
+	// boundaries handled by wordmatch.UnicodeBoundary). Deliberately ABSENT — the
+	// Russian ambiguous words that mirror the English exclusions: bare "инженер"
+	// (engineer), "техник" (IT/field technician), "оператор" (operator), bare
+	// "администратор"/"директор"/"менеджер"/"аналитик"/"специалист"/"мастер".
+	// "бухгалтер" is absent too — it already resolves to the finance category.
+	// Healthcare & care
+	"медсестра", "медицинская сестра", "медбрат", "фельдшер", "санитар", "санитарка",
+	"сиделка", "няня",
+	// Skilled trades
+	"сварщик", "электрогазосварщик", "слесарь", "сантехник", "электромонтер",
+	"электромонтёр", "электрик", "токарь", "фрезеровщик", "маляр", "штукатур",
+	"каменщик", "бетонщик", "арматурщик", "стропальщик", "монтажник", "машинист",
+	"тракторист",
+	// Food service
+	"повар", "пекарь", "кондитер", "официант", "официантка", "бармен",
+	"посудомойщик", "кухонный рабочий",
+	// Retail & warehouse
+	"продавец", "кассир", "продавец-кассир", "продавец-консультант", "кладовщик",
+	"комплектовщик", "грузчик", "упаковщик", "фасовщик", "приёмщик", "товаровед",
+	"мерчендайзер", "администратор магазина", "директор магазина",
+	// Cleaning, facilities & security
+	"уборщик", "уборщица", "дворник", "разнорабочий", "подсобный рабочий", "вахтер",
+	"вахтёр", "сторож", "охранник", "консьерж",
+	// Education & personal care
+	"воспитатель", "учитель", "логопед", "парикмахер", "маникюрша", "косметолог",
+	// Transport
+	"водитель", "курьер", "экспедитор",
+	// Portuguese (BR) non-technical roles (the gupy/BR tail). Same doctrine; bare
+	// ambiguous words absent: "técnico" (technician), "operador" (operator),
+	// "analista"/"assistente"/"vendedor"/"professor"/"segurança" (infosec collision).
+	// Retail & warehouse
+	"operador de caixa", "operador de loja", "repositor", "estoquista", "frentista",
+	"atendente de loja",
+	// Cleaning & facilities
+	"auxiliar de limpeza", "faxineiro", "zelador", "porteiro",
+	// Food service
+	"cozinheiro", "auxiliar de cozinha", "padeiro", "açougueiro", "garçom", "copeiro",
+	// Trades
+	"pedreiro", "pintor", "soldador", "eletricista", "encanador", "mecânico",
+	"servente", "ajudante geral", "jardineiro",
+	// Care, transport & front-of-house
+	"cuidador", "enfermeiro", "técnico de enfermagem", "auxiliar de enfermagem",
+	"babá", "motorista", "motoboy", "entregador", "vigilante", "camareira",
+	"recepcionista",
 }
+
+// ptGenderSuffix strips the Brazilian-Portuguese inclusive gender parentheticals
+// ("operador(a)", "enfermeiro(a)") so a phrase term matches the common written form.
+// Without it "operador(a) de caixa" would not match "operador de caixa".
+var ptGenderSuffix = strings.NewReplacer("(a)", "", "(o)", "", "(as)", "", "(os)", "", "(a/o)", "")
 
 // IsNonTech reports whether a job title states a confidently non-technical role,
 // matching any nonTechTitleTerms term on word boundaries. It never guesses: a
@@ -79,7 +131,7 @@ var nonTechTitleTerms = []string{
 // roles — a technical title yields false — so it can feed the is_tech derivation
 // without risking a technical job being mislabelled.
 func IsNonTech(title string) bool {
-	lower := strings.ToLower(title)
+	lower := ptGenderSuffix.Replace(strings.ToLower(title))
 	for _, term := range nonTechTitleTerms {
 		if wordmatch.Contains(lower, term, wordmatch.UnicodeBoundary) {
 			return true

--- a/internal/classify/nontech_test.go
+++ b/internal/classify/nontech_test.go
@@ -25,6 +25,30 @@ func TestIsNonTech(t *testing.T) {
 		{"security guard", "Overnight Security Guard", true},
 		{"teacher", "Preschool Teacher", true},
 
+		// Russian non-tech roles (the trudvsem/hh tail) — must now flag as non-tech
+		// instead of falling to unknown.
+		{"ru cashier", "Продавец-кассир", true},
+		{"ru cleaner", "Уборщик производственных и служебных помещений", true},
+		{"ru driver", "Водитель автомобиля", true},
+		{"ru cook", "Повар", true},
+		{"ru welder", "Электрогазосварщик", true},
+		{"ru nurse", "Медицинская сестра", true},
+		{"ru loader", "Грузчик", true},
+		{"ru teacher", "Учитель математики", true},
+		{"ru courier", "Курьер", true},
+		// Portuguese (BR) non-tech roles (the gupy tail).
+		{"br cashier", "Operador(a) de Caixa", true},
+		{"br store", "Operador(a) de Loja", true},
+		{"br cleaner", "Auxiliar de Limpeza", true},
+		{"br driver", "Motorista Entregador", true},
+		{"br cook", "Cozinheiro", true},
+		// Russian/Portuguese trap negatives — ambiguous words must NOT flag.
+		{"ru engineer bare", "Инженер-программист", false},
+		{"ru technician bare", "Системный техник", false},
+		{"ru analyst bare", "Аналитик данных", false},
+		{"br analyst bare", "Analista de Sistemas", false},
+		{"br technician bare", "Técnico de TI", false},
+
 		// Trap negatives — technical titles that must NOT be flagged, including
 		// shared words ("engineer") and non-tech-adjacent substrings from real data.
 		{"software engineer", "Software Engineer II, AWS DynamoDB", false},


### PR DESCRIPTION
## What
The non-tech title detector (`IsNonTech`) was **English-only**, so the large non-English non-IT tail fell to `is_tech=null` (unknown) instead of `false`:
- **trudvsem/hh (RU):** продавец-кассир, уборщик, водитель, повар, электрогазосварщик, медсестра, грузчик, учитель…
- **gupy (BR):** operador(a) de caixa/loja, auxiliar de limpeza, motorista, cozinheiro…

This adds curated, whole-word **RU + PT-BR** non-technical role nouns to `nonTechTitleTerms`, and strips the BR inclusive gender parenthetical (`operador(a)` → `operador`) before matching.

Same never-guess doctrine — ambiguous words deliberately excluded: bare `инженер`/`техник`/`оператор`/`администратор`/`analista`/`vendedor`/`professor`/`segurança` (infosec). `бухгалтер` omitted (already resolves to the `finance` category).

## Why
Audit of the live catalogue (6M jobs): **55.6% of open jobs are is_tech=null**, and sampling shows the top unclassified titles are overwhelmingly non-IT roles arriving in Russian/Portuguese. They were invisible as "unknown" purely because the detector was English-only. Flipping them to a measurable `is_tech=false` sharpens the source/company cleanup ("focus on IT") decisions — e.g. trudvsem shows 2.6% non-tech / 96.7% unknown today, which is really ~all non-tech in Russian.

## Verification
- `go build/vet/test ./...` green; classify tests cover RU/PT positives + ambiguous-word trap negatives (Инженер-программист, Técnico de TI → not flagged).

## Deploy
Follows the same path as the taxonomy change: release → `BACKFILL_CONCURRENCY=8 backfill-derive` → reindex. (Sequence after the in-flight expand-role-taxonomy backfill completes.)