### PR TITLE
fix(views): sum /open viewed from job_daily_views, not the 6M-row jobs table

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -459,12 +459,15 @@ type Querier interface {
 	// Aggregate interaction counts for the public engagement endpoint. Aggregate-only:
 	// every column is a scalar total, so no user identifier or row-level field is
 	// selected. saved / applied are user_jobs interaction-row totals across all users.
-	// "viewed" is the all-traffic view total — SUM(jobs.view_count), maintained by the
-	// nginx-log aggregation worker (anonymous + signed-in + API), not a user_jobs count,
-	// so it reflects every visitor, not only signed-in interactions. The remaining three
-	// mirror event-total semantics from their own tables: cvs_uploaded is the count of
-	// users holding a stored résumé (one per user, so also a people count), fit_checks is
-	// every job-fit analysis ever run, and saved_searches is every saved search.
+	// "viewed" is the all-traffic view total (anonymous + signed-in + API) produced by
+	// the nginx-log aggregation worker. It sums the worker's per-day rollup
+	// (job_daily_views), NOT jobs.view_count — a SUM over the 6M-row jobs table seqscans
+	// for ~90s and times the endpoint out, while the rollup is small and fast. (The
+	// per-job "N views" on the job card still reads jobs.view_count directly, no scan.)
+	// The remaining three mirror event-total semantics from their own tables:
+	// cvs_uploaded is the count of users holding a stored résumé (one per user, so also a
+	// people count), fit_checks is every job-fit analysis ever run, and saved_searches is
+	// every saved search.
 	GetEngagementStats(ctx context.Context) (GetEngagementStatsRow, error)
 	GetGmailConnection(ctx context.Context, userID int64) (GetGmailConnectionRow, error)
 	GetGmailRefreshToken(ctx context.Context, userID int64) (GetGmailRefreshTokenRow, error)

--- a/internal/db/queries/stats.sql
+++ b/internal/db/queries/stats.sql
@@ -58,16 +58,19 @@ ORDER BY d;
 -- Aggregate interaction counts for the public engagement endpoint. Aggregate-only:
 -- every column is a scalar total, so no user identifier or row-level field is
 -- selected. saved / applied are user_jobs interaction-row totals across all users.
--- "viewed" is the all-traffic view total — SUM(jobs.view_count), maintained by the
--- nginx-log aggregation worker (anonymous + signed-in + API), not a user_jobs count,
--- so it reflects every visitor, not only signed-in interactions. The remaining three
--- mirror event-total semantics from their own tables: cvs_uploaded is the count of
--- users holding a stored résumé (one per user, so also a people count), fit_checks is
--- every job-fit analysis ever run, and saved_searches is every saved search.
+-- "viewed" is the all-traffic view total (anonymous + signed-in + API) produced by
+-- the nginx-log aggregation worker. It sums the worker's per-day rollup
+-- (job_daily_views), NOT jobs.view_count — a SUM over the 6M-row jobs table seqscans
+-- for ~90s and times the endpoint out, while the rollup is small and fast. (The
+-- per-job "N views" on the job card still reads jobs.view_count directly, no scan.)
+-- The remaining three mirror event-total semantics from their own tables:
+-- cvs_uploaded is the count of users holding a stored résumé (one per user, so also a
+-- people count), fit_checks is every job-fit analysis ever run, and saved_searches is
+-- every saved search.
 SELECT
     count(*) FILTER (WHERE saved_at IS NOT NULL)::int   AS saved,
     count(*) FILTER (WHERE applied_at IS NOT NULL)::int AS applied,
-    (SELECT COALESCE(sum(view_count), 0) FROM jobs)::int AS viewed,
+    (SELECT COALESCE(sum(uniques), 0) FROM job_daily_views)::int AS viewed,
     (SELECT count(*) FROM users WHERE resume_object_key IS NOT NULL)::int AS cvs_uploaded,
     (SELECT count(*) FROM user_job_analysis)::int AS fit_checks,
     (SELECT count(*) FROM saved_searches)::int AS saved_searches

--- a/internal/db/stats.sql.go
+++ b/internal/db/stats.sql.go
@@ -28,7 +28,7 @@ const getEngagementStats = `-- name: GetEngagementStats :one
 SELECT
     count(*) FILTER (WHERE saved_at IS NOT NULL)::int   AS saved,
     count(*) FILTER (WHERE applied_at IS NOT NULL)::int AS applied,
-    (SELECT COALESCE(sum(view_count), 0) FROM jobs)::int AS viewed,
+    (SELECT COALESCE(sum(uniques), 0) FROM job_daily_views)::int AS viewed,
     (SELECT count(*) FROM users WHERE resume_object_key IS NOT NULL)::int AS cvs_uploaded,
     (SELECT count(*) FROM user_job_analysis)::int AS fit_checks,
     (SELECT count(*) FROM saved_searches)::int AS saved_searches
@@ -47,12 +47,15 @@ type GetEngagementStatsRow struct {
 // Aggregate interaction counts for the public engagement endpoint. Aggregate-only:
 // every column is a scalar total, so no user identifier or row-level field is
 // selected. saved / applied are user_jobs interaction-row totals across all users.
-// "viewed" is the all-traffic view total — SUM(jobs.view_count), maintained by the
-// nginx-log aggregation worker (anonymous + signed-in + API), not a user_jobs count,
-// so it reflects every visitor, not only signed-in interactions. The remaining three
-// mirror event-total semantics from their own tables: cvs_uploaded is the count of
-// users holding a stored résumé (one per user, so also a people count), fit_checks is
-// every job-fit analysis ever run, and saved_searches is every saved search.
+// "viewed" is the all-traffic view total (anonymous + signed-in + API) produced by
+// the nginx-log aggregation worker. It sums the worker's per-day rollup
+// (job_daily_views), NOT jobs.view_count — a SUM over the 6M-row jobs table seqscans
+// for ~90s and times the endpoint out, while the rollup is small and fast. (The
+// per-job "N views" on the job card still reads jobs.view_count directly, no scan.)
+// The remaining three mirror event-total semantics from their own tables:
+// cvs_uploaded is the count of users holding a stored résumé (one per user, so also a
+// people count), fit_checks is every job-fit analysis ever run, and saved_searches is
+// every saved search.
 func (q *Queries) GetEngagementStats(ctx context.Context) (GetEngagementStatsRow, error) {
 	row := q.db.QueryRow(ctx, getEngagementStats)
 	var i GetEngagementStatsRow

--- a/internal/handler/engagement_integration_test.go
+++ b/internal/handler/engagement_integration_test.go
@@ -113,12 +113,17 @@ func TestEngagementStatsEndpoint(t *testing.T) {
 		t.Fatalf("seed saved search: %v", err)
 	}
 
-	// "viewed" is the all-traffic total: SUM(jobs.view_count), maintained by the
-	// nginx-log worker, not derived from user_jobs. Seed counts 5 + 3 + 0 = 8.
+	// "viewed" is the all-traffic total: SUM(job_daily_views.uniques), the nginx-log
+	// worker's rollup, not derived from user_jobs. Summed from the small rollup (not
+	// SUM over the 6M-row jobs table, which seqscans for ~90s). Seed 5 + 2 + 1 = 8
+	// across days/jobs.
 	if _, err := pool.Exec(ctx,
-		`UPDATE jobs SET view_count = CASE id WHEN $1 THEN 5 WHEN $2 THEN 3 ELSE 0 END`,
+		`INSERT INTO job_daily_views (day, job_id, uniques) VALUES
+		   (DATE '2026-07-20', $1, 5),
+		   (DATE '2026-07-20', $2, 2),
+		   (DATE '2026-07-19', $1, 1)`,
 		j1, j2); err != nil {
-		t.Fatalf("seed view_count: %v", err)
+		t.Fatalf("seed job_daily_views: %v", err)
 	}
 
 	if c := get(); c.Saved != 1 || c.Applied != 1 || c.Viewed != 8 ||

--- a/openspec/changes/view-count-from-nginx-logs/specs/engagement-stats/spec.md
+++ b/openspec/changes/view-count-from-nginx-logs/specs/engagement-stats/spec.md
@@ -4,16 +4,18 @@
 The system SHALL expose an unauthenticated `GET /api/v1/stats/engagement` endpoint
 returning aggregate interaction counts. `saved` and `applied` are computed
 directly from `user_jobs` (rows whose respective timestamp is set). `viewed` is
-the total job views across all traffic, computed as `SUM(jobs.view_count)` so it
+the total job views across all traffic, computed as `SUM(job_daily_views.uniques)`
+(the worker's per-day rollup — a `SUM` over the multi-million-row `jobs` table would
+seqscan and time the endpoint out) so it
 reflects anonymous, signed-in, and API views (see `view-count-aggregation` and
 `job-engagement-counts`). No rollup precomputation is required.
 
 #### Scenario: Counts returned
 - **WHEN** a client requests `GET /api/v1/stats/engagement`
-- **THEN** the response is `{"data": {"saved": <n>, "applied": <n>, "viewed": <n>}}` where `saved` and `applied` are counts of `user_jobs` rows with the respective timestamp set, and `viewed` is `SUM(jobs.view_count)`
+- **THEN** the response is `{"data": {"saved": <n>, "applied": <n>, "viewed": <n>}}` where `saved` and `applied` are counts of `user_jobs` rows with the respective timestamp set, and `viewed` is `SUM(job_daily_views.uniques)`
 
 #### Scenario: viewed reflects all traffic
-- **WHEN** views have been aggregated from nginx logs into `jobs.view_count`
+- **WHEN** views have been aggregated from nginx logs into `job_daily_views`
 - **THEN** the `viewed` figure includes those anonymous and API views, not only signed-in interactions
 
 #### Scenario: No authentication required


### PR DESCRIPTION
Hotfix for a perf regression from #1024.

`GetEngagementStats` (public `GET /api/v1/stats/engagement`, feeds `/open`) computed `viewed` as `SUM(jobs.view_count)`. `jobs` has **~6M rows**, and an un-indexable full-table `SUM` **seqscans for ~90s**, timing the endpoint out (504 observed on prod).

Fix: sum the worker's small per-day rollup `SUM(job_daily_views.uniques)` — the same all-traffic number, but milliseconds. The per-job "N views" on the job card is unaffected (it reads `jobs.view_count` from a single row, no scan).

## Test Plan
- [x] `go build ./... && go vet ./...`
- [x] `go test -tags=integration ./internal/handler/ -run TestEngagementStatsEndpoint` — seeds `job_daily_views`, asserts `viewed` sums it
- [ ] Post-deploy: `curl https://freehire.dev/api/v1/stats/engagement` returns fast with a sane `viewed`