### PR TITLE
fix(insights): label the 10 new categories on /insights pages

### DIFF
--- a/web/src/lib/insights.ts
+++ b/web/src/lib/insights.ts
@@ -38,6 +38,16 @@ export const CATEGORY_LABELS: Record<string, string> = {
   marketing: 'Marketing',
   sales: 'Sales',
   support: 'Support',
+  business_analysis: 'Business Analysis',
+  solutions_engineering: 'Solutions Engineering',
+  developer_relations: 'Developer Relations',
+  technical_writing: 'Technical Writing',
+  recruiting: 'Recruiting',
+  hr: 'HR',
+  finance: 'Finance',
+  legal: 'Legal',
+  operations: 'Operations',
+  customer_success: 'Customer Success',
 };
 
 /** Seniority tokens in rank order, with labels. '' is the category-wide band. */


### PR DESCRIPTION
Follow-up to the role-taxonomy expansion. `insights.ts` keeps its own `CATEGORY_LABELS` map (separate from `labels.ts`); the 10 new categories were missing, so they fell back to a title-cased slug — rendering `hr` as "Hr". Adds explicit labels (HR, Finance, Business Analysis, …) so the auto-generated `/insights/{salary,roles,skills}/[category]` pages read correctly once each new category clears the volume gate.