### PR TITLE
refactor: align four identifiers with Go naming conventions

### DIFF
--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -13,7 +13,7 @@ import (
 
 // errMissing is the sentinel a test getter returns for an unmapped URL. In production the
 // real client returns its own transport error for a missing board, treated identically.
-var errMissing = errors.New("not found")
+var errMissing = errors.New("harvest: not found")
 
 // greenhouseBoardsAPI is the public boards API root (mirrors sources.greenhouseBaseURL,
 // which is unexported; this tool lives outside the sources package).

--- a/internal/handler/inbox.go
+++ b/internal/handler/inbox.go
@@ -66,10 +66,10 @@ type emailBody struct {
 // inboxFilters are the shared listing filters carried by the query string:
 // ?source=(gmail|hosted), ?unread=1, ?status=<signal>, ?q=<term>.
 type inboxFilters struct {
-	Source string
-	Unread bool
-	Status string
-	Q      string
+	Source   string
+	IsUnread bool
+	Status   string
+	Q        string
 }
 
 // parseInboxFilters reads and validates the inbox filter query params. Source and
@@ -84,7 +84,7 @@ func parseInboxFilters(c *fiber.Ctx) (inboxFilters, error) {
 	if status != "" && !mailclassify.IsValidSignal(status) {
 		return inboxFilters{}, fiber.NewError(fiber.StatusBadRequest, "unknown label")
 	}
-	return inboxFilters{Source: src, Unread: c.QueryBool("unread"), Status: status, Q: c.Query("q")}, nil
+	return inboxFilters{Source: src, IsUnread: c.QueryBool("unread"), Status: status, Q: c.Query("q")}, nil
 }
 
 // GetInbox returns the caller's mail as a flat list, newest first, excluding
@@ -102,14 +102,14 @@ func (a *API) GetInbox(c *fiber.Ctx) error {
 	}
 	limit, offset := pageParams(c) // default 20, clamped
 	rows, err := a.queries.ListEmails(c.Context(), db.ListEmailsParams{
-		UserID: userID, Src: f.Source, Unread: f.Unread, Status: f.Status, Q: f.Q,
+		UserID: userID, Src: f.Source, Unread: f.IsUnread, Status: f.Status, Q: f.Q,
 		Lim: int32(limit), Off: int32(offset),
 	})
 	if err != nil {
 		return err
 	}
 	total, err := a.queries.CountEmails(c.Context(), db.CountEmailsParams{
-		UserID: userID, Src: f.Source, Unread: f.Unread, Status: f.Status, Q: f.Q,
+		UserID: userID, Src: f.Source, Unread: f.IsUnread, Status: f.Status, Q: f.Q,
 	})
 	if err != nil {
 		return err

--- a/internal/jobreality/classify.go
+++ b/internal/jobreality/classify.go
@@ -27,7 +27,7 @@ const (
 // Input is the history + text facts a classification reads. RepostCount is the number
 // of distinct external_ids of any status sharing the role fingerprint (repost
 // history); MassPostingCount is the same restricted to open jobs (concurrent
-// mass-posting). Both are at least 1 (the job itself). EvergreenText is the dictionary
+// mass-posting). Both are at least 1 (the job itself). HasEvergreenText is the dictionary
 // result (see HasEvergreenMarker). PostedAt is honored only when HasPostedAt is set.
 type Input struct {
 	Now              time.Time
@@ -36,7 +36,7 @@ type Input struct {
 	HasPostedAt      bool
 	RepostCount      int
 	MassPostingCount int
-	EvergreenText    bool
+	HasEvergreenText bool
 }
 
 // Evidence is the observable facts behind a classification — surfaced so the UI states
@@ -45,7 +45,7 @@ type Evidence struct {
 	AgeDays          int
 	RepostCount      int
 	MassPostingCount int
-	FakeFreshness    bool
+	IsFakeFreshness  bool
 }
 
 // Result is a classification and the evidence that produced it.
@@ -70,7 +70,7 @@ func Classify(in Input) Result {
 	reposted := in.RepostCount-in.MassPostingCount >= repostThreshold
 
 	signals := 0
-	for _, on := range []bool{old, reposted, massPosted, in.EvergreenText} {
+	for _, on := range []bool{old, reposted, massPosted, in.HasEvergreenText} {
 		if on {
 			signals++
 		}
@@ -82,7 +82,7 @@ func Classify(in Input) Result {
 	switch {
 	case signals >= convergence:
 		class = ClassLikelyEvergreen
-	case ageDays <= freshWindowDays && !in.EvergreenText:
+	case ageDays <= freshWindowDays && !in.HasEvergreenText:
 		class = ClassFresh
 	}
 
@@ -92,7 +92,7 @@ func Classify(in Input) Result {
 			AgeDays:          ageDays,
 			RepostCount:      in.RepostCount,
 			MassPostingCount: in.MassPostingCount,
-			FakeFreshness:    fakeFreshness,
+			IsFakeFreshness:  fakeFreshness,
 		},
 	}
 }

--- a/internal/jobreality/classify_test.go
+++ b/internal/jobreality/classify_test.go
@@ -16,7 +16,7 @@ func base() Input {
 		HasPostedAt:      true,
 		RepostCount:      1,
 		MassPostingCount: 1,
-		EvergreenText:    false,
+		HasEvergreenText: false,
 	}
 }
 
@@ -55,7 +55,7 @@ func TestClassify_LikelyEvergreenOnConvergence(t *testing.T) {
 	in := base()
 	in.CreatedAt, in.PostedAt = daysAgo(240), daysAgo(240)
 	in.RepostCount = 6
-	in.EvergreenText = true
+	in.HasEvergreenText = true
 	res := Classify(in)
 	if res.Class != ClassLikelyEvergreen {
 		t.Errorf("class = %q, want %q", res.Class, ClassLikelyEvergreen)
@@ -95,7 +95,7 @@ func TestClassify_FakeFreshnessRecordedNotVerdict(t *testing.T) {
 	in.CreatedAt = daysAgo(240)
 	in.PostedAt, in.HasPostedAt = daysAgo(1), true
 	res := Classify(in)
-	if !res.Evidence.FakeFreshness {
+	if !res.Evidence.IsFakeFreshness {
 		t.Error("expected FakeFreshness evidence when posted recent but first-seen old")
 	}
 	if res.Class == ClassLikelyEvergreen {
@@ -106,7 +106,7 @@ func TestClassify_FakeFreshnessRecordedNotVerdict(t *testing.T) {
 func TestClassify_NoFakeFreshnessWhenPostedMatchesFirstSeen(t *testing.T) {
 	in := base()
 	in.CreatedAt, in.PostedAt = daysAgo(240), daysAgo(240)
-	if res := Classify(in); res.Evidence.FakeFreshness {
+	if res := Classify(in); res.Evidence.IsFakeFreshness {
 		t.Error("did not expect FakeFreshness when posted date matches first-seen")
 	}
 }
@@ -114,7 +114,7 @@ func TestClassify_NoFakeFreshnessWhenPostedMatchesFirstSeen(t *testing.T) {
 func TestClassify_Deterministic(t *testing.T) {
 	in := base()
 	in.CreatedAt = daysAgo(200)
-	in.RepostCount, in.MassPostingCount, in.EvergreenText = 4, 6, true
+	in.RepostCount, in.MassPostingCount, in.HasEvergreenText = 4, 6, true
 	if Classify(in) != Classify(in) {
 		t.Error("classification not deterministic for identical input")
 	}

--- a/internal/jobview/reality.go
+++ b/internal/jobview/reality.go
@@ -17,7 +17,7 @@ type Reality struct {
 	AgeDays          int    `json:"age_days"`
 	RepostCount      int    `json:"repost_count"`
 	MassPostingCount int    `json:"mass_posting_count"`
-	FakeFreshness    bool   `json:"fake_freshness"`
+	IsFakeFreshness  bool   `json:"fake_freshness"`
 }
 
 // ClassifyReality derives a job's reality signal from its row, the current time, and
@@ -31,13 +31,13 @@ func ClassifyReality(j db.Job, now time.Time, repostCount, massPostingCount int)
 		HasPostedAt:      j.PostedAt.Valid,
 		RepostCount:      repostCount,
 		MassPostingCount: massPostingCount,
-		EvergreenText:    jobreality.HasEvergreenMarker(j.Description),
+		HasEvergreenText: jobreality.HasEvergreenMarker(j.Description),
 	})
 	return Reality{
 		Class:            res.Class,
 		AgeDays:          res.Evidence.AgeDays,
 		RepostCount:      res.Evidence.RepostCount,
 		MassPostingCount: res.Evidence.MassPostingCount,
-		FakeFreshness:    res.Evidence.FakeFreshness,
+		IsFakeFreshness:  res.Evidence.IsFakeFreshness,
 	}
 }

--- a/internal/jobview/reality_test.go
+++ b/internal/jobview/reality_test.go
@@ -28,7 +28,7 @@ func TestClassifyReality_MapsConvergentSignalsToVerdict(t *testing.T) {
 	if r.RepostCount != 6 {
 		t.Errorf("repostCount = %d, want 6", r.RepostCount)
 	}
-	if !r.FakeFreshness {
+	if !r.IsFakeFreshness {
 		t.Error("expected FakeFreshness (posted 1d over first-seen 240d)")
 	}
 }
@@ -44,7 +44,7 @@ func TestClassifyReality_FreshJobHasNoEvidence(t *testing.T) {
 	if r.Class != "fresh" {
 		t.Errorf("class = %q, want fresh", r.Class)
 	}
-	if r.FakeFreshness {
+	if r.IsFakeFreshness {
 		t.Error("did not expect FakeFreshness on a genuinely new job")
 	}
 }

--- a/openspec/changes/rename-go-naming-idents/.openspec.yaml
+++ b/openspec/changes/rename-go-naming-idents/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/rename-go-naming-idents/design.md
+++ b/openspec/changes/rename-go-naming-idents/design.md
@@ -1,0 +1,40 @@
+## Context
+
+A Go naming review flagged four identifier deviations. All are local to a single
+declaration plus its references; the only one that crosses a module boundary is
+`FakeFreshness`, which is copied from `jobreality.Evidence` into the public
+`jobview.Reality` wire struct.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Bring the four identifiers in line with the project's Go naming conventions.
+- Keep the change purely mechanical — no behavior change, verified by the
+  existing tests that already reference these fields.
+
+**Non-Goals:**
+- The wider set of borderline boolean fields (mostly external-API DTOs whose
+  names mirror a foreign JSON schema) — left untouched deliberately.
+- Any change to JSON wire tags or HTTP responses.
+
+## Decisions
+
+- **Rename the Go field, keep the JSON tag.** `jobview.Reality.FakeFreshness`
+  serializes as `json:"fake_freshness"`. Renaming the Go field to
+  `IsFakeFreshness` while leaving the tag string unchanged keeps the emitted
+  wire contract byte-identical. Chosen over renaming the tag (which would be a
+  breaking API change) and over leaving the field as-is (which would keep the
+  deviation on a public type).
+- **Rename in dependency order, compile between fields.** `jobreality` is the
+  source of truth; `jobview` reads from it. Rename the `jobreality` field first,
+  then update the `jobview` consumer, so `go build` stays meaningful at each
+  step.
+
+## Risks / Trade-offs
+
+- [A stray reference is missed and the build breaks] → `grep` enumerated every
+  reference up front (8 for `EvergreenText`, the `jobview` + `jobreality` sites
+  for `FakeFreshness`, 4 for `Unread`); `go build ./...` + `go vet ./...` is the
+  backstop.
+- [Someone assumes the JSON key changed with the Go field] → the design note and
+  the retained `json:"fake_freshness"` tag make the invariant explicit.

--- a/openspec/changes/rename-go-naming-idents/proposal.md
+++ b/openspec/changes/rename-go-naming-idents/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+A Go naming review of `internal/` + `cmd/` found the codebase almost entirely
+clean, with four small identifier-naming deviations from the project's Go
+conventions. Fixing them keeps the naming baseline consistent so the deviations
+don't get copied as precedent.
+
+## What Changes
+
+- Prefix the `errMissing` sentinel string in `cmd/harvest-boards/prober.go` with
+  the package name: `"not found"` → `"harvest: not found"` (sentinel errors
+  identify their origin when wrapped).
+- Rename boolean field `jobreality.Input.EvergreenText` → `HasEvergreenText`
+  (boolean fields take an `is`/`has`/`can` prefix).
+- Rename boolean field `jobreality.Evidence.FakeFreshness` → `IsFakeFreshness`.
+  This value flows through the `jobview.Reality` wire struct; the JSON tag stays
+  `fake_freshness`, so the wire contract is unchanged.
+- Rename boolean field `inboxFilters.Unread` → `IsUnread` in
+  `internal/handler/inbox.go`.
+
+All four are mechanical renames covered by existing tests. No behavior change,
+no API/wire-contract change.
+
+## Capabilities
+
+### New Capabilities
+<!-- none — refactor only -->
+
+### Modified Capabilities
+<!-- none — no spec-level behavior changes; identifier renames only -->
+
+## Impact
+
+- Code only: `cmd/harvest-boards/prober.go`, `internal/jobreality/classify.go`,
+  `internal/jobview/reality.go`, `internal/handler/inbox.go`, plus the tests
+  that reference the renamed fields.
+- No database, migration, API response, or JSON wire-tag changes.

--- a/openspec/changes/rename-go-naming-idents/tasks.md
+++ b/openspec/changes/rename-go-naming-idents/tasks.md
@@ -1,0 +1,16 @@
+## 1. Sentinel error
+
+- [x] 1.1 In `cmd/harvest-boards/prober.go`, change the `errMissing` string from `"not found"` to `"harvest: not found"`; confirm `go test ./cmd/harvest-boards/` stays green.
+
+## 2. jobreality boolean fields
+
+- [x] 2.1 Rename `jobreality.Input.EvergreenText` → `HasEvergreenText` in `internal/jobreality/classify.go` and update the `jobview/reality.go` producer, the doc comment, and `classify_test.go` references; `go build ./... && go test ./internal/jobreality/ ./internal/jobview/`.
+- [x] 2.2 Rename `jobreality.Evidence.FakeFreshness` → `IsFakeFreshness` in `internal/jobreality/classify.go`, update the `jobview.Reality` consumer in `internal/jobview/reality.go` (keep JSON tag `fake_freshness`), and the tests in both packages; verify build + tests.
+
+## 3. handler inbox filter
+
+- [x] 3.1 Rename `inboxFilters.Unread` → `IsUnread` in `internal/handler/inbox.go` and its three references; `go build ./... && go test ./internal/handler/`.
+
+## 4. Verify
+
+- [x] 4.1 Run `go build ./... && go vet ./... && go test ./...`; confirm no residual references to the old identifiers and that emitted JSON keys are unchanged.


### PR DESCRIPTION
## Summary

Four small identifier fixes surfaced by a Go naming review of `internal/` + `cmd/`. All are mechanical renames covered by existing tests — no behavior change, no JSON wire-contract change.

- `errMissing` sentinel string → package-prefixed `"harvest: not found"` (`cmd/harvest-boards/prober.go`)
- `jobreality.Input.EvergreenText` → `HasEvergreenText` (boolean `has`-prefix)
- `jobreality.Evidence.FakeFreshness` → `IsFakeFreshness`; flows through the `jobview.Reality` wire struct with the `json:"fake_freshness"` tag **kept byte-identical**, so the emitted API key is unchanged
- `inboxFilters.Unread` → `IsUnread` (`internal/handler/inbox.go`); the sqlc `ListEmailsParams.Unread` key is untouched

Tracked in OpenSpec change `rename-go-naming-idents` (deltaless refactor — archive with `--skip-specs`).

## Test Plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (no FAIL/panic; affected packages `jobreality`, `jobview`, `handler`, `harvest-boards` green)
- [x] `gofmt` clean on all touched files
- [x] Repo-wide grep: no residual old identifiers in non-test code; frontend `fake_freshness` key consumers unaffected (tag preserved)