### PR TITLE
fix(web): resolve findings from a comprehensive web/ review

### DIFF
--- a/web/src/lib/actions/focusTrap.test.ts
+++ b/web/src/lib/actions/focusTrap.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { nextTrapIndex } from './focusTrap';
+
+describe('nextTrapIndex', () => {
+  it('pulls escaped focus (current -1) back to the first item', () => {
+    expect(nextTrapIndex(-1, 3, false)).toBe(0);
+    expect(nextTrapIndex(-1, 3, true)).toBe(0);
+  });
+
+  it('wraps forward Tab from the last item to the first', () => {
+    expect(nextTrapIndex(2, 3, false)).toBe(0);
+  });
+
+  it('wraps backward Shift+Tab from the first item to the last', () => {
+    expect(nextTrapIndex(0, 3, true)).toBe(2);
+  });
+
+  it('does not intervene on normal in-bounds tabbing', () => {
+    expect(nextTrapIndex(1, 3, false)).toBeNull(); // middle forward
+    expect(nextTrapIndex(1, 3, true)).toBeNull(); // middle backward
+    expect(nextTrapIndex(0, 3, false)).toBeNull(); // first forward → browser handles
+    expect(nextTrapIndex(2, 3, true)).toBeNull(); // last backward → browser handles
+  });
+
+  it('no-ops with no focusable items', () => {
+    expect(nextTrapIndex(-1, 0, false)).toBeNull();
+    expect(nextTrapIndex(0, 0, true)).toBeNull();
+  });
+});

--- a/web/src/lib/actions/focusTrap.ts
+++ b/web/src/lib/actions/focusTrap.ts
@@ -1,0 +1,67 @@
+import type { Attachment } from 'svelte/attachments';
+
+/**
+ * The focusable index a Tab press should move to inside a focus trap, or `null`
+ * when the browser's own tabbing already keeps focus in-bounds. Pure so the wrap
+ * logic is unit-testable in Node (the DOM glue in `focusTrap` is verified via
+ * svelte-check + visually).
+ *
+ * - focus escaped the trap (`current === -1`) → pull it to the first item
+ * - forward Tab on the last item → wrap to the first
+ * - backward Shift+Tab on the first item → wrap to the last
+ * - anything else → `null`, let the browser move focus normally
+ */
+export function nextTrapIndex(current: number, count: number, shift: boolean): number | null {
+  if (count <= 0) return null;
+  if (current === -1) return 0;
+  if (!shift && current === count - 1) return 0;
+  if (shift && current === 0) return count - 1;
+  return null;
+}
+
+const FOCUSABLE =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+/**
+ * A modal focus trap for a `role="dialog"` root, applied with `{@attach focusTrap()}`.
+ * On mount it moves focus to the dialog container (making it programmatically
+ * focusable) so screen readers announce the dialog and Tab starts inside it; while
+ * open it keeps Tab/Shift+Tab within the dialog; on close (the element leaving the
+ * DOM) it restores focus to whatever was focused when the dialog opened — usually
+ * the trigger. This backs the `aria-modal="true"` promise the markup makes.
+ */
+export function focusTrap(): Attachment<HTMLElement> {
+  return (node) => {
+    const trigger = document.activeElement as HTMLElement | null;
+
+    const focusables = () =>
+      Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+        (el) => el.getClientRects().length > 0,
+      );
+
+    // Focus the container itself (not a specific control), so we neither steal focus
+    // to an arbitrary button nor fight any inner autofocus. Needs a tabindex to be
+    // programmatically focusable.
+    if (!node.hasAttribute('tabindex')) node.setAttribute('tabindex', '-1');
+    node.focus();
+
+    const onKeydown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      const current = items.indexOf(document.activeElement as HTMLElement);
+      const next = nextTrapIndex(current, items.length, e.shiftKey);
+      if (next === null) return;
+      e.preventDefault();
+      items[next]?.focus();
+    };
+
+    node.addEventListener('keydown', onKeydown);
+
+    return () => {
+      node.removeEventListener('keydown', onKeydown);
+      // Restore focus to the opener, but only if focus is still inside the dialog —
+      // if the app already moved it elsewhere (e.g. a navigation), leave it be.
+      if (node.contains(document.activeElement)) trigger?.focus?.();
+    };
+  };
+}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -6,7 +6,12 @@
 // Only the pure/guarded surface (isPrivateRoute, track no-op, isFeatureEnabled
 // fallback) is unit-tested; the SDK side effects (identify/reset/replay) are
 // exercised via visual verification, per the frontend testing convention.
-import posthog from 'posthog-js';
+//
+// The SDK (~40KB gzip) is dynamically imported inside initAnalytics, so it only
+// downloads when a key is actually configured — it never weighs down the entry
+// chunk for visitors where analytics is inert (no key, or SSR). Same lazy posture
+// as shiki/easymde elsewhere.
+import type { PostHog } from 'posthog-js';
 
 export interface AnalyticsConfig {
   /** PostHog project key; empty/absent leaves analytics inert. */
@@ -15,23 +20,36 @@ export interface AnalyticsConfig {
   apiHost: string;
 }
 
-let initialized = false;
+// Null until the dynamic import resolves and init runs; every entry point below
+// guards on it, so calls before/without load are safe no-ops. `loading` coalesces
+// concurrent init calls.
+let ph: PostHog | null = null;
+let loading = false;
 
 // The runtime env read and browser guard live in the caller (hooks.client.ts,
 // which is client-only) so this module stays free of SvelteKit runtime imports
 // and unit-testable in a plain node environment.
 
-/** Initialize PostHog once, only when a key is configured. */
+/** Load and initialize PostHog once, only when a key is configured. Best-effort:
+ *  a failed dynamic import must never break the app, so the SDK download is fired
+ *  and forgotten with errors swallowed. */
 export function initAnalytics(config: AnalyticsConfig): void {
-  if (initialized || !config.key) return;
-  posthog.init(config.key, {
-    api_host: config.apiHost,
-    ui_host: 'https://eu.posthog.com',
-    capture_pageview: false, // SPA navigation is captured manually (see layout)
-    person_profiles: 'identified_only', // no anonymous profiles → saves quota
-    session_recording: { maskAllInputs: true },
-  });
-  initialized = true;
+  if (ph || loading || !config.key) return;
+  loading = true;
+  void import('posthog-js')
+    .then(({ default: posthog }) => {
+      posthog.init(config.key, {
+        api_host: config.apiHost,
+        ui_host: 'https://eu.posthog.com',
+        capture_pageview: false, // SPA navigation is captured manually (see layout)
+        person_profiles: 'identified_only', // no anonymous profiles → saves quota
+        session_recording: { maskAllInputs: true },
+      });
+      ph = posthog;
+    })
+    .catch(() => {
+      loading = false; // let a later call retry the load
+    });
 }
 
 /** Routes whose DOM must never be recorded (résumé, tracking, inbox all live
@@ -40,41 +58,37 @@ export function isPrivateRoute(path: string): boolean {
   return path === '/my' || path.startsWith('/my/');
 }
 
-/** Capture an explicit funnel event. No-op until initialized. */
+/** Capture an explicit funnel event. No-op until the SDK has loaded. */
 export function track(event: string, props?: Record<string, unknown>): void {
-  if (!initialized) return;
-  posthog.capture(event, props);
+  ph?.capture(event, props);
 }
 
 /** Bind analytics identity to a signed-in user by id only — never PII. */
 export function identifyUser(user: { id: number }): void {
-  if (!initialized) return;
-  posthog.identify(String(user.id));
+  ph?.identify(String(user.id));
 }
 
 /** Drop identity so subsequent events are anonymous (on sign-out). */
 export function resetIdentity(): void {
-  if (!initialized) return;
-  posthog.reset();
+  ph?.reset();
 }
 
 /** Start or stop session recording based on route privacy. */
 export function syncReplayForRoute(path: string): void {
-  if (!initialized) return;
-  if (isPrivateRoute(path)) posthog.stopSessionRecording();
-  else posthog.startSessionRecording();
+  if (!ph) return;
+  if (isPrivateRoute(path)) ph.stopSessionRecording();
+  else ph.startSessionRecording();
 }
 
 /** Capture a pageview for the current SPA route. */
 export function capturePageview(): void {
-  if (!initialized) return;
-  posthog.capture('$pageview');
+  ph?.capture('$pageview');
 }
 
 /** Generic feature-flag reader: the flag's value when loaded, else the fallback.
  *  Wiring a concrete product default to a flag is left to the caller. */
 export function isFeatureEnabled(flag: string, fallback: boolean): boolean {
-  if (!initialized) return fallback;
-  const value = posthog.isFeatureEnabled(flag);
+  if (!ph) return fallback;
+  const value = ph.isFeatureEnabled(flag);
   return value === undefined ? fallback : value;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -294,7 +294,9 @@ export function createApi(
     const res = await request<{ data: JobCopy[]; meta: { total: number } }>(
       `/api/v1/jobs/${slug}/copies${suffix}`,
     );
-    return { copies: res.data, total: res.meta?.total ?? res.data.length };
+    // Every list endpoint returns a `meta` envelope (see the backend contract), so
+    // access it directly — same convention as toSlice/listMyJobs/getInbox.
+    return { copies: res.data, total: res.meta.total };
   }
 
   /** How well the job addressed by `slug` is covered by the caller's profile skills:

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -3,7 +3,6 @@
   import { Marked } from 'marked';
   import DOMPurify from 'isomorphic-dompurify';
   import {
-    Bot,
     AlertTriangle,
     Terminal,
     ChevronRight,

--- a/web/src/lib/components/ActivityBars.svelte
+++ b/web/src/lib/components/ActivityBars.svelte
@@ -59,7 +59,6 @@
   <p class="py-16 text-center text-sm text-muted-foreground">No activity in this range yet.</p>
 {:else}
   <figure class="flex flex-col gap-3">
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="relative"
       role="img"

--- a/web/src/lib/components/ApplicationLinkPicker.svelte
+++ b/web/src/lib/components/ApplicationLinkPicker.svelte
@@ -59,11 +59,12 @@
       {:else if applications.length === 0}
         <p class="p-3 text-xs text-muted-foreground">No applications yet — track a job first.</p>
       {:else}
-        <div class="flex items-center gap-1.5 border-b border-border px-2.5 py-1.5">
+        <div class="flex items-center gap-1.5 border-b border-border px-2.5 py-1.5 focus-within:ring-2 focus-within:ring-ring">
           <Search class="size-3.5 shrink-0 text-muted-foreground" />
           <input
             bind:value={q}
             placeholder="Search applications…"
+            aria-label="Search applications"
             class="w-full bg-transparent text-xs outline-none placeholder:text-muted-foreground"
           />
         </div>

--- a/web/src/lib/components/AuthDialog.svelte
+++ b/web/src/lib/components/AuthDialog.svelte
@@ -6,6 +6,7 @@
   import { api, ApiError } from '$lib/api';
   import { Button } from '$lib/ui';
   import ProviderIcon from './ProviderIcon.svelte';
+  import { focusTrap } from '$lib/actions/focusTrap';
 
   // `mode` is bindable so the in-dialog toggle can switch between sign in and
   // register without the parent re-opening it. `initialError` lets the layout
@@ -97,6 +98,7 @@
     aria-modal="true"
     aria-label={title}
     class="relative w-full max-w-sm rounded-lg border border-border bg-background p-6 shadow-lg"
+    {@attach focusTrap()}
   >
     <h2 class="mb-4 text-base font-semibold tracking-tight">{title}</h2>
 

--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -42,20 +42,24 @@
         <span class="rounded-full bg-secondary px-2.5 py-0.5 text-xs text-secondary-foreground">{industry}</span>
       {/each}
       {#if website}
+        <!-- eslint-disable svelte/no-navigation-without-resolve -- external company website, not an internal route -->
         <a
           class="text-sm font-medium text-primary hover:underline"
           href={websiteHref}
           target="_blank"
           rel="noopener noreferrer">{website} ↗</a
         >
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
       {/if}
       {#if linkedin}
+        <!-- eslint-disable svelte/no-navigation-without-resolve -- external LinkedIn URL, not an internal route -->
         <a
           class="text-sm font-medium text-primary hover:underline"
           href={linkedin}
           target="_blank"
           rel="noopener noreferrer">LinkedIn ↗</a
         >
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
       {/if}
     </div>
   {/if}

--- a/web/src/lib/components/DocsCodeBlock.svelte
+++ b/web/src/lib/components/DocsCodeBlock.svelte
@@ -38,6 +38,7 @@
     </button>
   </figcaption>
   {#if html}
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- Shiki-highlighted HTML from the server-side highlighter over static doc code; no user data -->
     <div class="docs-shiki overflow-x-auto p-3 leading-relaxed">{@html html}</div>
   {:else}
     <pre class="overflow-x-auto p-3 leading-relaxed">{code}</pre>

--- a/web/src/lib/components/DocsEndpoint.svelte
+++ b/web/src/lib/components/DocsEndpoint.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Badge } from '$lib/ui';
+  import { resolve } from '$app/paths';
   import DocsCodeBlock from './DocsCodeBlock.svelte';
   import { BASE_URL, AUTH_LABELS, type Auth, type Endpoint, type Param } from '$lib/docs/api-spec';
   import { METHOD_CHIP, inlineCode } from '$lib/docs/format';
@@ -69,6 +70,7 @@
 
   <p class="mt-5 text-lg leading-relaxed text-foreground">{ep.summary}</p>
   {#if ep.description}
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- inlineCode escapes &<> then wraps static api-spec constants; no user data -->
     <p class="mt-3 leading-relaxed text-muted-foreground">{@html inlineCode(ep.description)}</p>
   {/if}
 
@@ -81,7 +83,8 @@
   {#if ep.filterable}
     <p class="mt-4 text-sm text-muted-foreground">
       Plus every filter in
-      <a href="/docs/api#filtering-jobs" class="font-medium text-brand-strong underline-offset-4 hover:underline"
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() applied to the /docs/api path; the rule can't see through the appended #fragment -->
+      <a href={`${resolve('/docs/api')}#filtering-jobs`} class="font-medium text-brand-strong underline-offset-4 hover:underline"
         >Filtering jobs</a
       >.
     </p>
@@ -115,6 +118,7 @@
             {/if}
           </dt>
           <dd class="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -- inlineCode escapes &<> then wraps static api-spec constants; no user data -->
             {@html inlineCode(p.description)}{#if p.example}<span class="ml-1">Example
                 <code class="rounded bg-secondary px-1 py-0.5 font-mono text-[12px] text-foreground/80">{p.example}</code
                 ></span

--- a/web/src/lib/components/DocsNav.svelte
+++ b/web/src/lib/components/DocsNav.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { CONCEPTS, NAV } from '$lib/docs/nav';
   import { METHOD_TEXT } from '$lib/docs/format';
@@ -73,8 +74,9 @@
   {#if visibleConcepts.length}
     <div class="space-y-0.5">
       {#each visibleConcepts as item (item.id)}
+        <!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() applied to the /docs/api path; the rule can't see through the appended #fragment -->
         <a
-          href={`/docs/api#${item.id}`}
+          href={`${resolve('/docs/api')}#${item.id}`}
           class={`block rounded-md px-2 py-1 transition-colors ${
             onLanding && activeSpy === item.id
               ? 'bg-brand-muted/60 text-brand-strong'
@@ -83,6 +85,7 @@
         >
           {item.title}
         </a>
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
       {/each}
     </div>
   {/if}
@@ -94,7 +97,7 @@
       </p>
       {#each group.endpoints as ep (ep.slug)}
         <a
-          href={ep.href}
+          href={resolve('/docs/api/[group]/[endpoint]', { group: group.slug, endpoint: ep.slug })}
           class={`flex items-center gap-2 rounded-md px-2 py-1 transition-colors ${
             pathname === ep.href
               ? 'bg-brand-muted/60 text-brand-strong'

--- a/web/src/lib/components/GithubStars.svelte
+++ b/web/src/lib/components/GithubStars.svelte
@@ -21,6 +21,7 @@
   const count = $derived(githubStars.count);
 </script>
 
+<!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an internal route -->
 <a
   href={GITHUB_URL}
   target="_blank"
@@ -33,6 +34,7 @@
     className,
   )}
 >
+  <!-- eslint-enable svelte/no-navigation-without-resolve -->
   <ProviderIcon provider="github" />
   {#if variant === 'row'}
     <span>GitHub</span>

--- a/web/src/lib/components/GmailConnectDialog.svelte
+++ b/web/src/lib/components/GmailConnectDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Mail, X, Lock, ExternalLink } from '@lucide/svelte';
   import { Button } from '$lib/ui';
+  import { focusTrap } from '$lib/actions/focusTrap';
 
   // The parent owns open/close; onConnect proceeds to the Google OAuth redirect.
   let { onClose, onConnect }: { onClose: () => void; onConnect: () => void } = $props();
@@ -42,6 +43,7 @@
     aria-modal="true"
     aria-label="Connect Gmail"
     class="relative z-10 flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-xl"
+    {@attach focusTrap()}
   >
     <div class="flex items-start gap-3 border-b border-border p-5">
       <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-brand-muted">
@@ -75,12 +77,14 @@
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
                 <span class="text-sm font-medium">{step.title}</span>
+                <!-- eslint-disable svelte/no-navigation-without-resolve -- external setup-doc link, not an internal route -->
                 <a
                   href={step.href}
                   target="_blank"
                   rel="noopener noreferrer"
                   class="inline-flex items-center gap-0.5 text-xs text-brand-strong hover:underline"
                 >
+                  <!-- eslint-enable svelte/no-navigation-without-resolve -->
                   source <ExternalLink class="size-3" />
                 </a>
               </div>

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
+  import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import type {
     GmailStatus,
@@ -732,9 +733,9 @@
                 {#if statusLabel(s.status_signal)}
                   <Badge variant="outline" class={statusClass(s.status_signal)}>{statusLabel(s.status_signal)}</Badge>
                 {/if}
-                {#if linkState === 'linked'}
+                {#if linkState === 'linked' && s.linked_slug}
                   <a
-                    href="/my/tracking/{s.linked_slug}"
+                    href={resolve('/my/tracking/[slug]', { slug: s.linked_slug })}
                     class="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-0.5 text-xs text-muted-foreground transition-colors hover:border-brand-ring hover:text-foreground"
                   >
                     Linked to {s.linked_company || 'application'} ↗
@@ -761,12 +762,13 @@
 
               {#if s.source === 'gmail'}
                 <div class="mt-2 flex shrink-0 justify-end">
+                  <!-- eslint-disable svelte/no-navigation-without-resolve -- external Gmail deep-link, not an internal route -->
                   <a
                     href={gmailUrl(s.external_id)}
                     target="_blank"
                     rel="noopener noreferrer"
                     class="text-xs font-medium text-brand-strong hover:underline"
-                  >
+                  ><!-- eslint-enable svelte/no-navigation-without-resolve -->
                     Open in Gmail ↗
                   </a>
                 </div>

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { pushState } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import type { MyJob } from '$lib/types';
@@ -207,14 +208,14 @@
       void load();
     }
     openItem = null;
-    pushState('/my/tracking', {}); // drop the per-application slug from the URL
+    pushState(resolve('/my/tracking'), {}); // drop the per-application slug from the URL
   }
 
   function openDrawer(item: MyJob) {
     openItem = item as BoardItem;
     pendingOutcome = false;
     // Give the open application its own shareable URL without a full navigation.
-    pushState(`/my/tracking/${item.job.public_slug}`, {});
+    pushState(resolve('/my/tracking/[slug]', { slug: item.job.public_slug }), {});
   }
 </script>
 

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -17,6 +17,7 @@
   import { statusLabel, statusClass } from '$lib/emailStatus';
   import { avatarInitials, avatarColor } from '$lib/avatar';
   import type { MyJob, ApplicationEmail } from '$lib/types';
+  import { focusTrap } from '$lib/actions/focusTrap';
 
   let {
     item,
@@ -147,7 +148,13 @@
 
 <!-- Fullscreen job panel (like the swipe deck): a centered column with a fixed
      header + pill tabs, a scrolling tab body, and a pinned View-job footer. -->
-<aside class="fixed inset-0 z-50 flex flex-col bg-background text-foreground" aria-label="Job details">
+<div
+  class="fixed inset-0 z-50 flex flex-col bg-background text-foreground"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Job details"
+  {@attach focusTrap()}
+>
   <!-- Header: logo · title · company · close, then meta pills and tabs -->
   <div class="shrink-0 border-b border-border">
     <div class="mx-auto flex w-full max-w-2xl flex-col gap-4 px-5 pb-3 pt-5 sm:px-6">
@@ -379,7 +386,7 @@
       </Button>
     </div>
   </div>
-</aside>
+</div>
 
 <style>
   /* Tab rail scrolls horizontally on narrow screens without a visible scrollbar. */

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -218,6 +218,7 @@
   // and the "Show N jobs" total — match the list. Disjunctive so a selected facet
   // still shows its siblings' counts.
   const stagedCounts = (params: URLSearchParams) => {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient: built, mutated, passed to the API once; not reactive state
     const p = new URLSearchParams(params);
     for (const [k, v] of Object.entries(scope)) p.set(k, v);
     return api.facetCounts(p, { disjunctive: true });
@@ -304,6 +305,7 @@
   function openSwipe() {
     const params = scopedParams();
     const qs = params.toString();
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() applied to the path; the rule can't see through the appended query string
     goto(resolve('/jobs/swipe') + (qs ? `?${qs}` : ''));
   }
 

--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -113,7 +113,19 @@
     // EventSource's own reserved connection-error event (handled by onerror below).
     for (const name of ['meta', 'stage_start', 'stage_done', 'thinking', 'requirements', 'dimensions', 'final', 'stream_error']) {
       source.addEventListener(name, (e) => {
-        stream = reduceMatchEvent(stream, name, JSON.parse((e as MessageEvent).data));
+        // A malformed/truncated frame must not throw out of the listener: an
+        // uncaught error here would skip the stop() below, so a bad `final` frame
+        // would hang the UI in `streaming` and leak the EventSource. Degrade to
+        // stream_error — the same terminal path as a connection drop.
+        let data: unknown;
+        try {
+          data = JSON.parse((e as MessageEvent).data);
+        } catch {
+          stream = reduceMatchEvent(stream, 'stream_error', { message: 'Analysis failed' });
+          stop();
+          return;
+        }
+        stream = reduceMatchEvent(stream, name, data);
         if (name === 'final' || name === 'stream_error') stop();
       });
     }

--- a/web/src/lib/components/ModerationView.svelte
+++ b/web/src/lib/components/ModerationView.svelte
@@ -153,12 +153,14 @@
             {#each queue as s (s.id)}
               <li class="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
                 <div class="flex min-w-0 flex-col gap-0.5">
+                  <!-- eslint-disable svelte/no-navigation-without-resolve -- external job posting URL, not an internal route -->
                   <a
                     href={s.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     class="truncate text-sm font-medium hover:underline"
                   >
+                    <!-- eslint-enable svelte/no-navigation-without-resolve -->
                     {s.title}
                   </a>
                   <span class="truncate text-xs text-muted-foreground">

--- a/web/src/lib/components/ReferralsView.svelte
+++ b/web/src/lib/components/ReferralsView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { replaceState } from '$app/navigation';
   import { FileText } from '@lucide/svelte';
@@ -123,7 +124,7 @@
   }
 
   // ── Incoming: mark contacted / declined ─────────────────────────────────
-  async function resolve(req: IncomingReferralRequest, status: 'contacted' | 'declined') {
+  async function resolveRequest(req: IncomingReferralRequest, status: 'contacted' | 'declined') {
     try {
       await api.resolveReferral(req.id, status);
       // Drop it from the open inbox — resolved requests leave the pool.
@@ -181,7 +182,7 @@
         {#each requests.value as r (r.id)}
           <tr class="border-t border-border">
             <td class="py-3 pr-4 font-medium">
-              <a href="/companies/{r.company_slug}" class="flex items-center gap-2 hover:underline">
+              <a href={resolve('/companies/[slug]', { slug: r.company_slug })} class="flex items-center gap-2 hover:underline">
                 <CompanyLogo name={r.company_name || r.company_slug} size="size-6" />
                 <span class="min-w-0 truncate">{r.company_name || r.company_slug}</span>
               </a>
@@ -300,6 +301,7 @@
             {#if req.contact_telegram}<code class="rounded bg-muted px-1.5 py-0.5 text-xs">{req.contact_telegram}</code>{/if}
             {#if req.contact_email}<code class="rounded bg-muted px-1.5 py-0.5 text-xs">{req.contact_email}</code>{/if}
             {#if req.linkedin_url}
+              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external LinkedIn URL, not an internal route -->
               <a href={req.linkedin_url} target="_blank" rel="noopener" class="text-brand-strong hover:underline">LinkedIn ↗</a>
             {/if}
           </div>
@@ -309,8 +311,8 @@
               <FileText class="size-4" /> View CV
             </Button>
             <span class="flex-1"></span>
-            <Button variant="primary" size="sm" onclick={() => resolve(req, 'contacted')}>Mark contacted</Button>
-            <Button variant="outline" size="sm" onclick={() => resolve(req, 'declined')}>Decline</Button>
+            <Button variant="primary" size="sm" onclick={() => resolveRequest(req, 'contacted')}>Mark contacted</Button>
+            <Button variant="outline" size="sm" onclick={() => resolveRequest(req, 'declined')}>Decline</Button>
           </div>
         </div>
       {/each}

--- a/web/src/lib/components/ReportDialog.svelte
+++ b/web/src/lib/components/ReportDialog.svelte
@@ -4,6 +4,7 @@
   import { reportReasons } from '$lib/reports';
   import type { ReportReason } from '$lib/types';
   import { Button } from '$lib/ui';
+  import { focusTrap } from '$lib/actions/focusTrap';
 
   // Reports are filed against a single job, addressed by its public slug. The
   // parent owns open/close; this component owns the two-step flow within.
@@ -75,6 +76,7 @@
     aria-modal="true"
     aria-label="Report this job"
     class="relative w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg"
+    {@attach focusTrap()}
   >
     <div class="mb-4 flex items-center justify-between gap-4">
       <h2 class="text-base font-semibold tracking-tight">Report this job</h2>

--- a/web/src/lib/components/RequestReferralModal.svelte
+++ b/web/src/lib/components/RequestReferralModal.svelte
@@ -6,6 +6,7 @@
   import type { ReferralRequestInput } from '$lib/types';
   import { Button } from '$lib/ui';
   import { isLinkedInUrl } from '$lib/utils';
+  import { focusTrap } from '$lib/actions/focusTrap';
 
   // The parent owns open/close; this component owns the request form. jobId is the
   // optional source-vacancy context recorded with the request.
@@ -108,6 +109,7 @@
     aria-modal="true"
     aria-label="Ask for a referral"
     class="relative w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg"
+    {@attach focusTrap()}
   >
     <div class="mb-4 flex items-center justify-between gap-4">
       <h2 class="text-base font-semibold tracking-tight">Ask for a referral · {companyName}</h2>

--- a/web/src/lib/components/ResumeStructuredView.svelte
+++ b/web/src/lib/components/ResumeStructuredView.svelte
@@ -111,6 +111,7 @@
       <ul class="flex flex-col gap-1">
         {#each links as link (link)}
           <li>
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external link from the parsed résumé, not an internal route -->
             <a href={link} target="_blank" rel="noopener noreferrer" class="text-sm text-primary hover:underline break-all">{link}</a>
           </li>
         {/each}

--- a/web/src/lib/components/SavedSearchesView.svelte
+++ b/web/src/lib/components/SavedSearchesView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Check, Pencil, Share2, Trash2 } from '@lucide/svelte';
+  import { resolve } from '$app/paths';
   import { ApiError } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
@@ -287,7 +288,7 @@
               <!-- Shared: the public link, its author label, copy, and unshare. -->
               <div class="mt-3 flex flex-wrap items-center gap-2 rounded-lg bg-secondary/50 px-3 py-2">
                 <a
-                  href={`/b/${s.public_slug}`}
+                  href={resolve('/b/[slug]', { slug: s.public_slug })}
                   class="min-w-0 truncate text-xs text-brand-strong underline-offset-4 hover:underline"
                 >
                   /b/{s.public_slug}

--- a/web/src/lib/components/SwipeDeck.svelte
+++ b/web/src/lib/components/SwipeDeck.svelte
@@ -38,6 +38,7 @@
   // slug so a prefetch that races a just-sent save/dismiss can't re-add a card.
   // Reassigned wholesale (never mutated in place), so raw skips per-item proxying.
   let queue = $state.raw<Job[]>([]);
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deliberately non-reactive dedup registry; never read in a reactive context
   const seen = new Set<string>();
   // Single-step undo: the last judged card and how it was judged.
   let last = $state<{ job: Job; kind: Judgement } | null>(null);
@@ -182,6 +183,7 @@
   // reflects what the swipe session ended on.
   function close() {
     const qs = deckParams().toString();
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() applied to the path; the rule can't see through the appended query string
     goto(resolve('/') + (qs ? `?${qs}` : ''));
   }
 

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -8,6 +8,7 @@
   import HeaderListSearch from './HeaderListSearch.svelte';
   import HeaderMenu from './HeaderMenu.svelte';
   import BrandMark from './BrandMark.svelte';
+  import { safeRedirect } from '$lib/safeRedirect';
 
   // The header is three slots — logo | search | menu — identical on every
   // viewport. Nav links, the account items, the theme toggle, and the auth
@@ -43,13 +44,10 @@
   // afterNavigate covers both the initial load and every later navigation, and
   // stays off the SSR path. The replaceState clean-up below removes the params, so
   // the immediate re-run sees none and no loop forms.
-  // Only accept a same-origin rooted path as the post-login redirect — never a
-  // scheme-relative "//host" or absolute URL — mirroring the backend's
-  // SafeReturnPath, so a crafted link can't bounce the user off-site.
-  function safeRedirect(raw: string | null): string | null {
-    if (!raw || !raw.startsWith('/') || raw.startsWith('//')) return null;
-    return raw;
-  }
+  // safeRedirect (in $lib/safeRedirect) accepts only a same-origin rooted path as
+  // the post-login redirect — never a scheme-relative "//host", absolute URL, or a
+  // backslash/control-char trick — mirroring the backend's SafeReturnPath, so a
+  // crafted link can't bounce the user off-site.
 
   afterNavigate(() => {
     const params = page.url.searchParams;

--- a/web/src/lib/components/VerdictView.svelte
+++ b/web/src/lib/components/VerdictView.svelte
@@ -141,6 +141,7 @@
               <span class="w-6 shrink-0 text-sm tabular-nums text-muted-foreground">{i + 1}</span>
               <div class="flex min-w-0 flex-1 flex-col">
                 {#if gapHref}
+                  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href built by the gapHref prop (a job-search query), not a static route -->
                   <a href={gapHref(gap.name)} class="truncate text-sm font-medium hover:underline">{gap.name}</a>
                 {:else}
                   <span class="truncate text-sm font-medium">{gap.name}</span>
@@ -170,6 +171,7 @@
               <span class="w-6 shrink-0 text-sm tabular-nums text-muted-foreground">{i + 1}</span>
               <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                 {#if gapHref && skill.status !== 'strong'}
+                  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href built by the gapHref prop (a job-search query), not a static route -->
                   <a href={gapHref(skill.name)} class="truncate text-sm font-medium hover:underline">{skill.name}</a>
                 {:else}
                   <span class="truncate text-sm font-medium">{skill.name}</span>

--- a/web/src/lib/components/cv/CvEditor.svelte
+++ b/web/src/lib/components/cv/CvEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { resolve } from '$app/paths';
   import { ArrowLeft, Plus, Trash2 } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { Button, Input } from '$lib/ui';
@@ -120,7 +121,7 @@
       {#if embedded}
         <span></span>
       {:else}
-        <a href="/my/cvs" class="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <a href={resolve('/my/cvs')} class="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
           <ArrowLeft class="h-4 w-4" /> All CVs
         </a>
       {/if}
@@ -175,7 +176,7 @@
           <Plus class="mr-1 h-4 w-4" /> Add role
         </Button>
       </div>
-      {#each doc.experience ?? [] as entry, i (i)}
+      {#each doc.experience ?? [] as entry, i (entry)}
         <div class="space-y-3 rounded-lg border border-border p-4">
           <div class="flex items-start justify-between gap-2">
             <div class="grid flex-1 gap-3 sm:grid-cols-2">
@@ -212,7 +213,7 @@
           <Plus class="mr-1 h-4 w-4" /> Add education
         </Button>
       </div>
-      {#each doc.education ?? [] as entry, i (i)}
+      {#each doc.education ?? [] as entry, i (entry)}
         <div class="flex items-start justify-between gap-2 rounded-lg border border-border p-4">
           <div class="grid flex-1 gap-3 sm:grid-cols-2">
             <Input bind:value={entry.institution} placeholder="Institution" />
@@ -238,7 +239,7 @@
           <Plus class="mr-1 h-4 w-4" /> Add group
         </Button>
       </div>
-      {#each doc.skills ?? [] as entry, i (i)}
+      {#each doc.skills ?? [] as entry, i (entry)}
         <div class="space-y-3 rounded-lg border border-border p-4">
           <div class="flex items-center justify-between gap-2">
             <Input bind:value={entry.group} placeholder="Group (e.g. Languages)" class="flex-1" />
@@ -259,7 +260,7 @@
           <Plus class="mr-1 h-4 w-4" /> Add language
         </Button>
       </div>
-      {#each doc.languages ?? [] as entry, i (i)}
+      {#each doc.languages ?? [] as entry, i (entry)}
         <div class="flex items-center gap-2">
           <Input bind:value={entry.name} placeholder="Language" class="flex-1" />
           <Input bind:value={entry.level} placeholder="Level (e.g. C1)" class="flex-1" />
@@ -278,7 +279,7 @@
           <Plus class="mr-1 h-4 w-4" /> Add project
         </Button>
       </div>
-      {#each doc.projects ?? [] as entry, i (i)}
+      {#each doc.projects ?? [] as entry, i (entry)}
         <div class="space-y-3 rounded-lg border border-border p-4">
           <div class="flex items-center gap-2">
             <Input bind:value={entry.name} placeholder="Project name" class="flex-1" />
@@ -300,7 +301,7 @@
           <Plus class="mr-1 h-4 w-4" /> Add certification
         </Button>
       </div>
-      {#each doc.certifications ?? [] as entry, i (i)}
+      {#each doc.certifications ?? [] as entry, i (entry)}
         <div class="flex items-center gap-2">
           <Input bind:value={entry.name} placeholder="Name" class="flex-1" />
           <Input bind:value={entry.issuer} placeholder="Issuer" class="flex-1" />

--- a/web/src/lib/components/cv/CvList.svelte
+++ b/web/src/lib/components/cv/CvList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { resolve } from '$app/paths';
   import { FileText, Download, Trash2 } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import CompanyLogo from '$lib/components/CompanyLogo.svelte';
@@ -67,7 +68,8 @@
           class="group relative flex items-center gap-4 rounded-xl border border-border bg-card p-4 transition-colors hover:border-border/80 hover:bg-muted/30"
         >
           <!-- The whole card opens the workspace; the action buttons stop propagation below. -->
-          <a href="/tailor/{cv.job_slug}?cv={cv.id}" class="absolute inset-0" aria-label="Open {cv.job_title}"></a>
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() applied to the path; the rule can't see through the appended ?cv= query -->
+          <a href={`${resolve('/tailor/[slug]', { slug: cv.job_slug })}?cv=${cv.id}`} class="absolute inset-0" aria-label="Open {cv.job_title}"></a>
           <CompanyLogo name={cv.job_company} size="size-11" />
           <div class="min-w-0 flex-1">
             <p class="truncate font-medium">{cv.job_title}</p>
@@ -75,6 +77,7 @@
             <p class="mt-0.5 text-xs text-muted-foreground/80">Updated {fmt(cv.updated_at)}</p>
           </div>
           <div class="relative z-10 flex items-center gap-1">
+            <!-- eslint-disable svelte/no-navigation-without-resolve -- external CV PDF API URL, not an internal route -->
             <a
               href={api.cvPdfUrl(cv.id)}
               target="_blank"
@@ -83,6 +86,7 @@
               title="Open PDF"
               class="flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
+              <!-- eslint-enable svelte/no-navigation-without-resolve -->
               <Download class="h-4 w-4" />
             </a>
             <button

--- a/web/src/lib/components/cv/StringListEditor.svelte
+++ b/web/src/lib/components/cv/StringListEditor.svelte
@@ -10,16 +10,26 @@
     addLabel = 'Add',
   }: { items: string[]; placeholder?: string; addLabel?: string } = $props();
 
+  // Stable per-row keys. String values aren't unique (duplicate or empty rows) and
+  // rows are removed from the middle, so an index key would rebind surviving inputs
+  // by position — jumping focus/cursor/IME onto the wrong row. A parallel id array,
+  // mutated in lockstep with `items`, gives each row a stable identity. All
+  // structural edits go through add/remove here, so ids.length === items.length holds.
+  let ids = $state<number[]>(items.map((_, i) => i));
+  let nextId = items.length;
+
   function add() {
     items = [...items, ''];
+    ids = [...ids, nextId++];
   }
   function remove(i: number) {
     items = items.filter((_, idx) => idx !== i);
+    ids = ids.filter((_, idx) => idx !== i);
   }
 </script>
 
 <div class="space-y-2">
-  {#each items as _, i (i)}
+  {#each items as _, i (ids[i])}
     <div class="flex items-center gap-2">
       <Input bind:value={items[i]} {placeholder} class="flex-1" />
       <Button variant="ghost" size="icon" onclick={() => remove(i)} aria-label="Remove">

--- a/web/src/lib/components/filters/CategoryPane.svelte
+++ b/web/src/lib/components/filters/CategoryPane.svelte
@@ -33,11 +33,12 @@
 
 <FacetHeader {store} param="category" label="Specialization" />
 
-<div class="mb-4 flex items-center gap-2 rounded-lg border border-input px-3">
+<div class="mb-4 flex items-center gap-2 rounded-lg border border-input px-3 focus-within:ring-2 focus-within:ring-ring">
   <Search class="size-4 shrink-0 text-muted-foreground" />
   <input
     bind:value={query}
     placeholder="Search specializations…"
+    aria-label="Search specializations"
     class="h-9 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
   />
 </div>

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { resolve } from '$app/paths';
   import { Bell, UserRound } from '@lucide/svelte';
   import { FACETS } from '$lib/facets';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -201,7 +202,7 @@
     </button>
   {:else}
     <a
-      href="/my/profile"
+      href={resolve('/my/profile')}
       class="flex h-9 items-center gap-1.5 rounded-lg border border-dashed border-border px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
     >
       <UserRound class="size-4 shrink-0" aria-hidden="true" />

--- a/web/src/lib/components/filters/FilterModalShell.svelte
+++ b/web/src/lib/components/filters/FilterModalShell.svelte
@@ -3,6 +3,7 @@
   import { ArrowRight, LoaderCircle, X } from '@lucide/svelte';
   import type { RailEntry, RailSection } from '$lib/filterSections';
   import type { FacetCounts } from '$lib/types';
+  import { focusTrap } from '$lib/actions/focusTrap';
 
   // The reusable two-pane filter-modal chrome: backdrop, header, the sectioned left
   // rail, and the deferred footer (Clear all / Apply / live preview). It knows nothing
@@ -177,6 +178,7 @@
       role="dialog"
       aria-modal="true"
       aria-label={title}
+      {@attach focusTrap()}
     >
       <!-- header -->
       <div class="flex items-center gap-3 border-b border-border px-4 py-3">

--- a/web/src/lib/components/filters/LocationPane.svelte
+++ b/web/src/lib/components/filters/LocationPane.svelte
@@ -133,11 +133,12 @@
   {/if}
 </div>
 
-<div class="mb-4 flex items-center gap-2 rounded-lg border border-input px-3">
+<div class="mb-4 flex items-center gap-2 rounded-lg border border-input px-3 focus-within:ring-2 focus-within:ring-ring">
   <Search class="size-4 shrink-0 text-muted-foreground" />
   <input
     bind:value={query}
     placeholder="Search country or city…"
+    aria-label="Search country or city"
     class="h-9 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
   />
 </div>

--- a/web/src/lib/components/onboarding/OnboardingWizard.svelte
+++ b/web/src/lib/components/onboarding/OnboardingWizard.svelte
@@ -13,6 +13,7 @@
   import type { FacetCounts } from '$lib/types';
   import { emptySelection, selectionsToQuery, type OnboardingSelection } from '$lib/onboarding';
   import SearchSelect from '../facets/SearchSelect.svelte';
+  import { focusTrap } from '$lib/actions/focusTrap';
 
   // The /jobs onboarding wizard: a skippable overlay that captures coarse feed
   // preferences and emits the equivalent filter query. It owns only its staged
@@ -197,6 +198,7 @@
       role="dialog"
       aria-modal="true"
       aria-label="Set up your feed"
+      {@attach focusTrap()}
     >
       <!-- header: step dots + skip -->
       <div class="flex items-center gap-3 border-b border-border px-5 py-3">

--- a/web/src/lib/filterStorage.test.ts
+++ b/web/src/lib/filterStorage.test.ts
@@ -27,9 +27,9 @@ describe('filterStorage', () => {
   afterEach(() => {
     // @ts-expect-error - clean up the globals we install per test
     delete globalThis.localStorage;
-    // @ts-expect-error
+    // @ts-expect-error - test-only global, not an optional property
     delete globalThis.document;
-    // @ts-expect-error
+    // @ts-expect-error - test-only global, not an optional property
     delete globalThis.location;
   });
 

--- a/web/src/lib/matchAnalysis.test.ts
+++ b/web/src/lib/matchAnalysis.test.ts
@@ -67,4 +67,28 @@ describe('reduceMatchEvent', () => {
     expect(prev.stages[0]?.state).toBe('pending');
     expect(next).not.toBe(prev);
   });
+
+  it('ignores a malformed requirements payload (not an array)', () => {
+    const seeded = reduceMatchEvent(
+      initMatchStream(),
+      'requirements',
+      { requirements: [{ text: 'Go', priority: 'required', status: 'covered', evidence: '' }] },
+    );
+    // A present-but-wrong-typed frame must not overwrite good data with a non-array
+    // that a component would then .filter() on and crash.
+    const next = reduceMatchEvent(seeded, 'requirements', { requirements: { bogus: true } });
+    expect(Array.isArray(next.requirements)).toBe(true);
+    expect(next.requirements).toEqual(seeded.requirements);
+  });
+
+  it('ignores a malformed analysis payload (not an object)', () => {
+    const seeded = reduceMatchEvent(
+      initMatchStream(),
+      'dimensions',
+      { analysis: { overall_score: 50, verdict: 'Moderate Fit', dimensions: [], requirement_match: [], strengths: [], gaps: [], recommendation: '' } },
+    );
+    const next = reduceMatchEvent(seeded, 'final', { analysis: 'nope' });
+    expect(next.analysis).toEqual(seeded.analysis);
+    expect(next.done).toBe(true); // final is still terminal
+  });
 });

--- a/web/src/lib/matchAnalysis.ts
+++ b/web/src/lib/matchAnalysis.ts
@@ -97,13 +97,15 @@ export function reduceMatchEvent(prev: MatchStreamState, name: string, data: unk
       s.thinking = prev.thinking + String(d.thinking ?? '');
       return s;
     case 'requirements':
-      s.requirements = (d.requirements as MatchRequirement[]) ?? [];
+      // Guard the shape, not just null: a present-but-wrong-typed frame must not
+      // replace good data with a value a component would then .filter() and crash on.
+      if (Array.isArray(d.requirements)) s.requirements = d.requirements as MatchRequirement[];
       return s;
     case 'dimensions':
-      s.analysis = (d.analysis as MatchAnalysis) ?? prev.analysis;
+      if (isObject(d.analysis)) s.analysis = d.analysis as MatchAnalysis;
       return s;
     case 'final':
-      s.analysis = (d.analysis as MatchAnalysis) ?? prev.analysis;
+      if (isObject(d.analysis)) s.analysis = d.analysis as MatchAnalysis;
       s.done = true;
       s.stages = s.stages.map((x) => ({ ...x, state: 'done' as StageState }));
       return s;
@@ -119,4 +121,11 @@ export function reduceMatchEvent(prev: MatchStreamState, name: string, data: unk
 function setStage(s: MatchStreamState, n: number, state: StageState) {
   const stage = s.stages.find((x) => x.n === n);
   if (stage) stage.state = state;
+}
+
+/** Whether a value is a non-null, non-array plain object — the shape an `analysis`
+ *  payload must have. Returns a plain boolean (not a type predicate) so the caller's
+ *  value stays `unknown`, keeping the single boundary cast to MatchAnalysis honest. */
+function isObject(v: unknown): boolean {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
 }

--- a/web/src/lib/safeRedirect.test.ts
+++ b/web/src/lib/safeRedirect.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { safeRedirect } from './safeRedirect';
+
+describe('safeRedirect', () => {
+  it('accepts a plain rooted path', () => {
+    expect(safeRedirect('/my/tracking')).toBe('/my/tracking');
+  });
+
+  it('preserves query and hash on an accepted path', () => {
+    expect(safeRedirect('/jobs?q=go#top')).toBe('/jobs?q=go#top');
+  });
+
+  it('rejects null / empty / relative input', () => {
+    expect(safeRedirect(null)).toBeNull();
+    expect(safeRedirect('')).toBeNull();
+    expect(safeRedirect('jobs')).toBeNull();
+  });
+
+  it('rejects a scheme-relative //host', () => {
+    expect(safeRedirect('//evil.com')).toBeNull();
+  });
+
+  it('rejects an absolute off-origin URL', () => {
+    expect(safeRedirect('https://evil.com/phish')).toBeNull();
+  });
+
+  // The bypass the old startsWith('//') guard missed: a backslash is normalized to
+  // a slash by the URL parser, so /\evil.com resolves to //evil.com → off-origin.
+  it('rejects a backslash scheme-relative bypass', () => {
+    expect(safeRedirect('/\\evil.com')).toBeNull();
+    expect(safeRedirect('/\\/evil.com')).toBeNull();
+  });
+
+  it('rejects a tab/control-character bypass', () => {
+    expect(safeRedirect('/\t/evil.com')).toBeNull();
+  });
+});

--- a/web/src/lib/safeRedirect.ts
+++ b/web/src/lib/safeRedirect.ts
@@ -1,0 +1,19 @@
+// Validates a post-login return path: only a same-origin rooted path is allowed,
+// never a scheme-relative "//host", an absolute URL, or a backslash/control-char
+// trick that the URL parser normalizes into one. Mirrors the backend's
+// SafeReturnPath. Kept pure (a fixed base, not location) so it is unit-testable and
+// identical on server and client.
+const BASE = 'https://freehire.dev';
+
+export function safeRedirect(raw: string | null): string | null {
+  if (!raw || !raw.startsWith('/')) return null;
+  try {
+    // Resolving against a fixed origin catches every off-origin bypass: "//host",
+    // "/\host" and "/\t/host" all parse to a different origin than BASE.
+    const url = new URL(raw, BASE);
+    if (url.origin !== BASE) return null;
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/lib/stagedFilters.svelte.ts
+++ b/web/src/lib/stagedFilters.svelte.ts
@@ -104,6 +104,7 @@ export class StagedFilters implements FacetStore {
    *  seeds the staged copy so selecting a set previews (and applies on Show results)
    *  rather than committing to the live URL immediately. */
   apply(query: string): void {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient: parsed inline into #f, never stored as reactive state
     this.#f = filtersFromParams(new URLSearchParams(query));
   }
 

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -97,6 +97,7 @@
         <RefreshCw class="size-4" />
         <span class="hidden xl:inline">Refresh</span>
       </button>
+      <!-- eslint-disable svelte/no-navigation-without-resolve -- external CV PDF API URL, not an internal route -->
       <a
         href={cvUrl}
         target="_blank"
@@ -104,6 +105,7 @@
         title="Open the CV PDF in a new tab"
         class="inline-flex items-center gap-1 rounded px-2 py-1 text-muted-foreground transition-colors hover:text-foreground"
       >
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
         <ExternalLink class="size-4" />
         <span class="hidden xl:inline">Open PDF</span>
       </a>

--- a/web/src/lib/urlSynced.svelte.ts
+++ b/web/src/lib/urlSynced.svelte.ts
@@ -74,6 +74,7 @@ export class UrlSyncedState<T> {
     // bar still shows the filter. Seeding from location makes a restored view mirror
     // the real URL. On the server location is unavailable; the passed page.url params
     // are correct there and match the client for every non-shallow navigation.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient: parsed immediately into `seeded`, never stored as reactive state
     const params = browser ? new URLSearchParams(location.search) : initial;
     const seeded = codec.parse(params);
     this.value = seeded;
@@ -109,6 +110,7 @@ export class UrlSyncedState<T> {
     // Read the browser's address bar, not page.url: after a shallow-routing (replaceState)
     // back/forward, page.url lags to the pre-filter URL while location.search is correct.
     // Reading page.url here would revert the constructor's location-seeded value to empty.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient: compared/parsed inline, never stored as reactive state
     const current = browser ? new URLSearchParams(location.search) : page.url.searchParams;
     if (current.toString() === this.#codec.serialize(this.value).toString()) return;
     clearTimeout(this.#timer);

--- a/web/src/routes/docs/api/+page.svelte
+++ b/web/src/routes/docs/api/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { resolve } from '$app/paths';
   import Seo from '$lib/components/Seo.svelte';
   import DocsCodeBlock from '$lib/components/DocsCodeBlock.svelte';
   import { BASE_URL, OVERVIEW } from '$lib/docs/api-spec';
@@ -37,6 +38,7 @@
   <section id={slugify(section.title)} data-spy class="mb-12 scroll-mt-24">
     <h2 class="text-xl font-semibold tracking-tight">{section.title}</h2>
     {#each section.paragraphs as p (p)}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- inlineCode escapes &<> then wraps static doc constants; no user data -->
       <p class="mt-3 max-w-2xl leading-relaxed text-muted-foreground">{@html inlineCode(p)}</p>
     {/each}
     {#if section.code}
@@ -61,6 +63,7 @@
     <p class="text-xs font-semibold uppercase tracking-wide text-brand-strong">Modifiers — apply to every facet</p>
     <ul class="mt-3 space-y-2 text-sm leading-relaxed text-foreground/90">
       {#each FILTER_MODIFIERS as m (m)}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- inlineCode escapes &<> then wraps static doc constants; no user data -->
         <li class="flex gap-2"><span class="mt-0.5 text-brand-strong/70">›</span><span>{@html inlineCode(m)}</span></li>
       {/each}
     </ul>
@@ -104,7 +107,7 @@
           {#each group.endpoints as ep (ep.slug)}
             <li>
               <a
-                href={ep.href}
+                href={resolve('/docs/api/[group]/[endpoint]', { group: group.slug, endpoint: ep.slug })}
                 class="group flex items-baseline gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-secondary"
               >
                 <span class={`w-10 shrink-0 text-[10px] font-bold tracking-wide ${METHOD_TEXT[ep.method]}`}>{ep.method}</span>

--- a/web/src/routes/match/[slug]/+page.svelte
+++ b/web/src/routes/match/[slug]/+page.svelte
@@ -22,7 +22,7 @@
   async function startTailoring() {
     // The /tailor/[slug] surface owns the bootstrap + seeded agent session; this just goes there.
     tailoring = true;
-    await goto(`/tailor/${data.job.public_slug}`);
+    await goto(resolve('/tailor/[slug]', { slug: data.job.public_slug }));
   }
 </script>
 

--- a/web/src/routes/my/cvs/[id]/+page.svelte
+++ b/web/src/routes/my/cvs/[id]/+page.svelte
@@ -3,6 +3,7 @@
   // this CV's vacancy slug from the tailored list and redirect into /tailor/<slug>?cv=<id>. A CV
   // that isn't tied to a vacancy (or a load failure) falls back to the tailored-CV list.
   import { onMount } from 'svelte';
+  import { resolve } from '$app/paths';
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import { api } from '$lib/api';
@@ -13,9 +14,10 @@
     try {
       const items = await api.listCvs();
       const match = items.find((cv) => cv.id === id);
-      await goto(match ? `/tailor/${match.job_slug}?cv=${id}` : '/my/cvs', { replaceState: true });
+      // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() applied to both paths; the rule can't see through the appended ?cv= query
+      await goto(match ? `${resolve('/tailor/[slug]', { slug: match.job_slug })}?cv=${id}` : resolve('/my/cvs'), { replaceState: true });
     } catch {
-      await goto('/my/cvs', { replaceState: true });
+      await goto(resolve('/my/cvs'), { replaceState: true });
     }
   });
 </script>

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -73,6 +73,7 @@
   // carries a category) — so it opens on the profile's own role, which the user can then
   // change to compare against another position without touching the saved profile.
   function buildFilters(specializations: string[]): FilterStore {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient: seeds a FilterStore once, never stored as reactive state
     const seed = new URLSearchParams(page.url.searchParams);
     if (!seed.getAll('category').some((c) => c !== '')) {
       for (const spec of specializations) seed.append('category', spec);
@@ -165,6 +166,7 @@
 
   // Link a gap skill to the job search under the current comparison role plus that skill.
   function gapHref(skill: string): string {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient: builds an href string once, never stored as reactive state
     const params = filters ? filtersToParams(filters.applied) : new URLSearchParams();
     params.append('skills', skill);
     return `/?${params}`;

--- a/web/src/routes/open/+page.server.ts
+++ b/web/src/routes/open/+page.server.ts
@@ -25,7 +25,7 @@ async function fetchGithub(fetchImpl: typeof fetch): Promise<GithubStats | null>
   if (ghCache && Date.now() - ghCache.at < GH_TTL_MS) return ghCache.data;
 
   const headers = { Accept: 'application/vnd.github+json' };
-  let data: GithubStats | null = null;
+  let data: GithubStats | null; // assigned on both the success and catch paths below
   try {
     const res = await fetchImpl(`https://api.github.com/repos/${GH_REPO}`, { headers });
     if (!res.ok) throw new Error(`github repo ${res.status}`);

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -108,10 +108,11 @@
 {/snippet}
 
 {#snippet sourceLink(href: string, label: string)}
+  <!-- eslint-disable svelte/no-navigation-without-resolve -- renders a caller-provided href (JSON API paths on /open), not an internal route -->
   <a
     {href}
     class="font-mono text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-  >
+  ><!-- eslint-enable svelte/no-navigation-without-resolve -->
     {label} ↗
   </a>
 {/snippet}
@@ -143,6 +144,7 @@
           <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{s.label}</dt>
           <dd class="mt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">
             {#if s.href}
+              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- links to the JSON API endpoint, not a SvelteKit route -->
               <a href={s.href} class="hover:underline">{s.value}</a>
             {:else}
               {s.value}

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -5,6 +5,7 @@
   //    store the session id on the CV so it can be re-opened.
   //  - resume (?cv=<id>): reuse the existing CV + its stored session — re-attach, NO kickoff.
   import { onMount } from 'svelte';
+  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { api, ApiError } from '$lib/api';
   import { createSession } from '$lib/assistant/api';
@@ -107,7 +108,7 @@
   {:else if status === 'error'}
     <div class="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
       <p class="max-w-md text-sm text-destructive">{errorMsg}</p>
-      <a href={`/match/${slug}`} class="text-sm text-brand hover:underline">Back to the fit analysis</a>
+      <a href={resolve('/match/[slug]', { slug })} class="text-sm text-brand hover:underline">Back to the fit analysis</a>
     </div>
   {:else}
     <div class="flex min-w-0 flex-1">


### PR DESCRIPTION
Comprehensive review of the SvelteKit frontend (`web/`), then all findings fixed in one PR. Everything is verified: **eslint 0 errors, svelte-check 0 errors, 338 tests pass, production build ok.**

## Real bugs
- **SSE JSON.parse guard** (`MatchAnalysisFull.svelte`): a malformed/truncated frame threw out of the listener, skipping `stop()` — hanging the UI in `streaming` and leaking the `EventSource`. Now degrades to `stream_error`.
- **CV editor `{#each}` keys**: keyed by index while rows use `bind:value` + mid-list removal, misattributing focus/edits to the wrong row. Now keyed by entry identity (`CvEditor`) and stable parallel ids (`StringListEditor`).

## Accessibility
- Reusable modal **focus-trap** `{@attach}` (focus in / trap Tab / restore on close), applied to all seven `role="dialog"` surfaces; **`JobDrawer`** is now exposed as a dialog.
- Filter search inputs (`CategoryPane`, `LocationPane`, `ApplicationLinkPicker`) get a `focus-within` ring + `aria-label`.

## Robustness / perf / security
- **SSE reducer** validates payload shapes (`Array.isArray` / object) so a wrong-typed frame can't crash a downstream `.filter()`.
- **`api.ts`** meta-envelope access made consistent.
- **`posthog-js` lazy-loaded** — SDK now leaves the entry bundle (its own async chunk).
- **`safeRedirect`** hardened against the `/\host` backslash open-redirect bypass (extracted to a pure, unit-tested module). Note: not live-exploitable today (SvelteKit's `goto` rejects external URLs) — defense-in-depth.

## Strictness / eslint → 0
- Internal navigations wrapped in typed `resolve()` (verified by svelte-check).
- External URLs (company sites, LinkedIn, GitHub, Gmail, apply URLs, PDF/JSON-API) and reviewed-safe `{@html}` (Shiki / escaped static docs) and transient `URLSearchParams`/dedup `Set` documented with scoped `eslint-disable` + reasons.
- Dead code removed (unused import, stale svelte-ignore, useless assignment).

## New tests
`safeRedirect`, `focusTrap` wrap logic, SSE shape validation.

## Notes
`eslint` is **not** in CI (memory: web CI = check-contributor only), which is how 44 lint errors had accumulated — worth gating in a follow-up. Code review surfaced only low-severity, intentional/guarded items (no P1).