### PR TITLE
ci(web): gate PRs on eslint and vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Type check
         run: npm run check
+
+      - name: Unit tests
+        run: npm run test
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
Follow-up to #1039. The `web` CI job ran svelte-check and the build, but **not the linter or the unit tests** — so eslint errors and failing frontend tests could merge unnoticed (they had quietly accumulated to 44 lint errors, cleared in #1039).

Adds two required steps to the `web` job, fail-fast before the build:
- **Lint** — `npm run lint` (oxlint + eslint)
- **Unit tests** — `npm run test` (vitest)

Verified locally against current `main`: lint exits clean (oxlint warnings only), 341 vitest tests pass.