### PR TITLE
feat(sources): add softgarden ATS adapter

### DIFF
--- a/internal/sources/softgarden.go
+++ b/internal/sources/softgarden.go
@@ -1,0 +1,103 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// softgarden adapts softgarden career sites. The board is the tenant subdomain (e.g.
+// "bundesdruckerei"), so the career site is "<board>.softgarden.io". The root page is a
+// server-rendered (Apache Wicket) listing whose anchors link each posting at
+// /job/<id>/<slug>?jobDbPVId=<n>; each job page carries a schema.org JobPosting ld+json
+// block, so the description comes from a per-job detail fetch (bounded-concurrency), like
+// the other schema.org detail adapters.
+//
+// The listing is a single page: softgarden paginates via a Wicket AJAX callback rather than
+// a stable ?page=N URL, so a tenant with more postings than the first page holds is truncated
+// to that page. In practice softgarden tenants are small; the seam for AJAX pagination is here
+// if a large tenant ever needs it.
+type softgarden struct {
+	http HTMLGetter
+}
+
+// NewSoftgarden builds the softgarden adapter over the given HTTP client.
+func NewSoftgarden(c HTMLGetter) Source { return softgarden{http: c} }
+
+func (softgarden) Provider() string { return "softgarden" }
+
+func (s softgarden) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	// base carries the scheme+host; the listing's relative job hrefs ("../job/…") resolve
+	// against it into fetchable absolute URLs.
+	base, err := url.Parse(fmt.Sprintf("https://%s.softgarden.io/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("softgarden: board %q: %w", e.Board, err)
+	}
+
+	root, err := s.http.GetHTML(ctx, base.String())
+	if err != nil {
+		return nil, fmt.Errorf("softgarden: listing %s: %w", e.Board, err)
+	}
+	urls := jobLinks(base, root, func(href string) bool { return sgJobID(href) != "" })
+
+	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return s.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the page fetch fails, carries no JobPosting, or has no parseable id, so the caller
+// skips just that posting.
+func (s softgarden) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := sgJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := s.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p sgPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	location := p.JobLocation.Address.Location()
+	// softgarden's JobPosting carries no explicit remote flag, so remote is inferred from the
+	// location only (never the title, which false-positives on "Remote …" role names).
+	remote := isRemote(location)
+
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      remote,
+		WorkMode:    workModeFromRemote(remote),
+		PostedAt:    parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// sgJobIDPattern captures the native posting id from a job URL's /job/<id> segment. The
+// permalink is /job/<id>/<slug>?jobDbPVId=<n>; the id is the numeric segment right after
+// /job/, and the trailing boundary keeps non-job paths from matching.
+var sgJobIDPattern = regexp.MustCompile(`/job/(\d+)(?:[/?#]|$)`)
+
+// sgJobID extracts the native posting id from a job page URL, or "" when the URL is not a
+// job permalink.
+func sgJobID(u string) string { return firstSubmatch(sgJobIDPattern, u) }
+
+// sgPosting is the schema.org JobPosting decoded from a softgarden job page's
+// application/ld+json block. jobLocation is a single Place object.
+type sgPosting struct {
+	Title       string      `json:"title"`
+	Description string      `json:"description"`
+	DatePosted  string      `json:"datePosted"`
+	JobLocation schemaPlace `json:"jobLocation"`
+}

--- a/internal/sources/softgarden_test.go
+++ b/internal/sources/softgarden_test.go
@@ -1,0 +1,143 @@
+package sources
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// sgListingHTML builds a softgarden root listing page linking each given job href (the live
+// markup emits relative "../job/…" hrefs).
+func sgListingHTML(jobHrefs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="jobList">`)
+	for _, h := range jobHrefs {
+		b.WriteString(`<div class="matchValue title"><a href="` + h + `" target="_blank">A job</a></div>`)
+	}
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// sgDetailHTML builds a softgarden job page carrying a schema.org JobPosting ld+json block.
+// jobLocation is a single Place object and there is no remote flag.
+func sgDetailHTML(title, encodedDescription, datePosted, locality, country string) string {
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"http://schema.org/","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + encodedDescription + `",` +
+		`"datePosted":"` + datePosted + `",` +
+		`"employmentType":["FULL_TIME"],` +
+		`"hiringOrganization":{"@type":"Organization","name":"Bundesdruckerei"},` +
+		`"jobLocation":{"@type":"Place","address":{"addressLocality":"` + locality + `","addressCountry":"` + country + `"}}}` +
+		`</script></head><body></body></html>`
+}
+
+func TestSoftgardenProvider(t *testing.T) {
+	if got := NewSoftgarden(nil).Provider(); got != "softgarden" {
+		t.Errorf("Provider() = %q, want %q", got, "softgarden")
+	}
+}
+
+func TestSGJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://bundesdruckerei.softgarden.io/job/66221618/creative-producer?jobDbPVId=279489843&l=en": "66221618",
+		"../job/66221618/creative-producer?jobDbPVId=279489843":                                         "66221618",
+		"https://b.softgarden.io/job/12345":                                                             "12345", // bare id, no slug/query
+		"https://b.softgarden.io/":                                                                      "",      // listing root, no id
+		"https://b.softgarden.io/imprint":                                                               "",
+		"https://b.softgarden.io/job/abc/x":                                                             "", // non-numeric id
+	}
+	for u, want := range cases {
+		if got := sgJobID(u); got != want {
+			t.Errorf("sgJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestSGJobLinksResolvesRelativeHrefs(t *testing.T) {
+	// The live listing emits relative "../job/…" hrefs; each must resolve to an absolute,
+	// fetchable URL against the root, and a repeated job de-dups to one.
+	h := sgListingHTML(
+		"../job/66221618/creative-producer?jobDbPVId=279489843&l=en",
+		"../job/66221618/creative-producer?jobDbPVId=279489843&l=en",
+		"../job/70000001/data-engineer?jobDbPVId=280000000",
+	) + `<a href="../imprint">Imprint</a>`
+	base := mustURL(t, "https://bundesdruckerei.softgarden.io/")
+	got := jobLinks(base, parseHTML(t, h), func(href string) bool { return sgJobID(href) != "" })
+	want := []string{
+		"https://bundesdruckerei.softgarden.io/job/66221618/creative-producer?jobDbPVId=279489843&l=en",
+		"https://bundesdruckerei.softgarden.io/job/70000001/data-engineer?jobDbPVId=280000000",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("jobLinks() = %v, want %v", got, want)
+	}
+}
+
+func TestSoftgardenFetchListingThenDetailAndMaps(t *testing.T) {
+	jobURL := "https://bundesdruckerei.softgarden.io/job/66221618/creative-producer?jobDbPVId=279489843"
+	detail := sgDetailHTML(
+		"Creative Producer",
+		"&lt;p&gt;Build &lt;b&gt;it&lt;/b&gt;.&lt;/p&gt;&lt;script&gt;alert(1)&lt;/script&gt;",
+		"2026-07-21T12:43:08.524+02:00", "Berlin", "Deutschland")
+	fake := (&routedHTTP{}).
+		route("/job/66221618", detail). // detail route first: the listing root has no /job/
+		route("bundesdruckerei.softgarden.io/", sgListingHTML(
+			"../job/66221618/creative-producer?jobDbPVId=279489843"))
+
+	jobs, err := NewSoftgarden(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Bundesdruckerei", Provider: "softgarden", Board: "bundesdruckerei",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "66221618" {
+		t.Errorf("ExternalID = %q, want 66221618", j.ExternalID)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q, want %q", j.URL, jobURL)
+	}
+	if j.Title != "Creative Producer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Bundesdruckerei" {
+		t.Errorf("Company = %q, want Bundesdruckerei", j.Company)
+	}
+	if j.Location != "Berlin, Deutschland" {
+		t.Errorf("Location = %q, want 'Berlin, Deutschland'", j.Location)
+	}
+	if strings.Contains(j.Description, "<script>") ||
+		!strings.Contains(j.Description, "<p>") || !strings.Contains(j.Description, "<b>it</b>") {
+		t.Errorf("Description not unescaped/sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 21, 10, 43, 8, 524_000_000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-07-21T12:43:08.524+02:00", j.PostedAt)
+	}
+}
+
+func TestSoftgardenDropsDetailWithoutJobPosting(t *testing.T) {
+	// A job page carrying no schema.org JobPosting drops just that posting; the rest of the
+	// board still ingests.
+	d := sgDetailHTML("Role", "&lt;p&gt;x&lt;/p&gt;", "2026-07-21T12:43:08.524+02:00", "Oslo", "Norway")
+	fake := (&routedHTTP{}).
+		route("/job/111", d).                                           // first posting resolves
+		route("/job/222", `<html><body>no ld+json here</body></html>`). // second has no JobPosting → drops
+		route("bundesdruckerei.softgarden.io/", sgListingHTML(
+			"../job/111/role-a",
+			"../job/222/role-b"))
+
+	jobs, err := NewSoftgarden(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "B", Board: "bundesdruckerei",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (one detail dropped)", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -271,6 +271,7 @@ func All(c HTTPClient) map[string]Source {
 		NewOracle(c),
 		NewEightfold(c),
 		NewFreshteam(c),
+		NewSoftgarden(c),
 		NewEarcu(c),
 		NewPageUp(c),
 		NewNeogov(c),

--- a/sources/softgarden.yml
+++ b/sources/softgarden.yml
@@ -1,0 +1,39 @@
+# softgarden boards. Provider is the filename; each entry is company + board.
+# board = tenant subdomain (see internal/sources/softgarden.go).
+
+- company: Autohaus Adelbert Moll GmbH & Co. KG
+  board: moll
+- company: B&O Bau GmbH
+  board: buojobs
+- company: Bundesdruckerei-Gruppe
+  board: bundesdruckerei
+- company: Contipark Parkgaragengesellschaft mbH
+  board: contipark-jobs
+- company: Damovo Deutschland GmbH & Co. KG
+  board: damovo
+- company: Dassbach Küchen Werksverkauf GmbH & Co. KG
+  board: dassbach-kuechen
+- company: diakonia Dienstleistungsbetriebe GmbH
+  board: diakonia
+- company: G. Staehle GmbH u. Co. KG - Staehle Blechpackungen
+  board: staehle-jobs
+- company: GAN Assurances Agences
+  board: ganjobs
+- company: Holtzbrinck
+  board: holtzbrinck-careers
+- company: Karl Bögner GmbH & Co. KG
+  board: holzland
+- company: Kraftanlagen Gruppe
+  board: kraftanlagen
+- company: Kulturveranstaltungen des Bundes in Berlin (KBB) GmbH
+  board: kbbjobs
+- company: L.I.T. chemical & contract logistics GmbH
+  board: litjobs
+- company: Next Kraftwerke GmbH
+  board: next-kraftwerke
+- company: STF Gruppe GmbH
+  board: stf-gruppe
+- company: Urgo GmbH
+  board: urgo
+- company: Wikimedia Deutschland - Gesellschaft zur Förderung Freien Wissens e.V.
+  board: wikimedia-deutschland


### PR DESCRIPTION
## What

Adds a **softgarden** (softgarden.io) source adapter — a German/EU ATS surfaced by an aggregator harvest with 18 live tenants and no existing adapter.

## How

Board is the tenant subdomain (`<board>.softgarden.io`). The server-rendered (Apache Wicket) root listing links each posting at `/job/<id>/…`, and each job page carries a schema.org `JobPosting` ld+json — so detail is a per-job fetch mapping the ld+json, exactly like the other schema.org detail adapters (freshteam/teamtailor). Reuses the shared `jobLinks`/`fetchDetails`/`ldJobPosting`/`schemaPlace` primitives.

**Single-page listing limitation:** softgarden paginates via a Wicket AJAX callback rather than a stable `?page=N` URL, so a tenant larger than the first page is truncated. The seam for AJAX pagination is documented in the adapter; in practice softgarden tenants are small.

## Verification

- Unit tests (`softgarden_test.go`): provider, id extraction, relative-href resolution, listing→detail mapping (incl. fractional-second RFC3339 dates), and drop-on-missing-JobPosting.
- End-to-end against a live tenant (`urgo.softgarden.io`): 12 jobs parsed with correct id/title/location/date/description.

Ships `sources/softgarden.yml` with the 18 live tenants (each validated >0 jobs).