### PR TITLE
fix(web): resolve() typed routes for community navigation

### DIFF
--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import { MessageSquare } from '@lucide/svelte';
   import { api } from '$lib/api';
   import type { Company } from '$lib/types';
@@ -55,7 +56,7 @@
   <div class="mt-3">
     <a
       class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-      href={`/companies/${slug}/discussion`}
+      href={resolve('/companies/[slug]/discussion', { slug })}
     >
       <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
         ? ` · ${threadCount}`

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -231,7 +231,7 @@
 
     <a
       class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-      href={`/jobs/${job.public_slug}/discussion`}
+      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
     >
       <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
         ? ` · ${threadCount}`

--- a/web/src/lib/components/community/DiscussionIndex.svelte
+++ b/web/src/lib/components/community/DiscussionIndex.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import type { CommunityThread } from '$lib/types';
   import { Button } from '$lib/ui';
@@ -7,17 +8,22 @@
   let {
     subjectType,
     subjectSlug,
-    basePath,
     initialThreads,
     initialCursor,
   }: {
     subjectType: string;
     subjectSlug: string;
-    /** Route prefix a thread links off, e.g. "/companies/acme/discussion". */
-    basePath: string;
     initialThreads: CommunityThread[];
     initialCursor?: string;
   } = $props();
+
+  // Typed route links built from the subject, so route validity and base-path
+  // resolution are checked at compile time (mirrors DiscussionThread/NewTopic).
+  const newHref = $derived(
+    subjectType === 'company'
+      ? resolve('/companies/[slug]/discussion/new', { slug: subjectSlug })
+      : resolve('/jobs/[slug]/discussion/new', { slug: subjectSlug }),
+  );
 
   let threads = $state<CommunityThread[]>([...initialThreads]);
   let cursor = $state<string | undefined>(initialCursor);
@@ -42,7 +48,7 @@
       <h2>Discussion</h2>
       <p class="discussion__sub">Anonymous — you post under a pseudonym, not your name.</p>
     </div>
-    <Button href={`${basePath}/new`}>Start a topic</Button>
+    <Button href={newHref}>Start a topic</Button>
   </header>
 
   {#if threads.length === 0}
@@ -51,7 +57,11 @@
     <ul class="thread-list">
       {#each threads as t (t.id)}
         <li class="thread-list__item">
-          <a class="thread-list__link" href={`${basePath}/${t.id}`}>
+          <a
+            class="thread-list__link"
+            href={subjectType === 'company'
+              ? resolve('/companies/[slug]/discussion/[threadId]', { slug: subjectSlug, threadId: String(t.id) })
+              : resolve('/jobs/[slug]/discussion/[threadId]', { slug: subjectSlug, threadId: String(t.id) })}>
             <span class="thread-list__title">{t.title}</span>
             <span class="thread-list__meta">
               {t.author} · {t.reply_count} {t.reply_count === 1 ? 'reply' : 'replies'} · {timeAgo(t.created_at)}

--- a/web/src/lib/components/community/DiscussionNewTopic.svelte
+++ b/web/src/lib/components/community/DiscussionNewTopic.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
@@ -9,13 +10,17 @@
   let {
     subjectType,
     subjectSlug,
-    listPath,
   }: {
     subjectType: string;
     subjectSlug: string;
-    /** Route of the thread list this topic belongs to, e.g. "/companies/acme/discussion". */
-    listPath: string;
   } = $props();
+
+  // The thread list this topic belongs to, as a typed (compile-checked) route.
+  const listHref = $derived(
+    subjectType === 'company'
+      ? resolve('/companies/[slug]/discussion', { slug: subjectSlug })
+      : resolve('/jobs/[slug]/discussion', { slug: subjectSlug }),
+  );
 
   let title = $state('');
   let body = $state('');
@@ -37,7 +42,11 @@
         body: body.trim(),
       });
       // Land on the freshly created thread.
-      await goto(`${listPath}/${created.id}`);
+      await goto(
+        subjectType === 'company'
+          ? resolve('/companies/[slug]/discussion/[threadId]', { slug: subjectSlug, threadId: String(created.id) })
+          : resolve('/jobs/[slug]/discussion/[threadId]', { slug: subjectSlug, threadId: String(created.id) }),
+      );
     } catch (err) {
       formError = communityFormError(err);
       submitting = false;
@@ -45,7 +54,13 @@
   }
 </script>
 
-<a class="crumb" href={listPath}>← Back to discussion</a>
+<a
+  class="crumb"
+  href={subjectType === 'company'
+    ? resolve('/companies/[slug]/discussion', { slug: subjectSlug })
+    : resolve('/jobs/[slug]/discussion', { slug: subjectSlug })}>← Back to discussion</a
+>
+
 <h1 class="title">Start a topic</h1>
 <p class="sub">Anonymous — you post under a pseudonym, not your name.</p>
 
@@ -55,7 +70,7 @@
     <textarea bind:value={body} rows="6" placeholder="Say more…" class="topic-form__body"></textarea>
     {#if formError}<p class="topic-form__error">{formError}</p>{/if}
     <div class="topic-form__actions">
-      <Button variant="ghost" href={listPath}>Cancel</Button>
+      <Button variant="ghost" href={listHref}>Cancel</Button>
       <Button type="submit" disabled={!canSubmit}>{submitting ? 'Posting…' : 'Post topic'}</Button>
     </div>
   </form>

--- a/web/src/lib/components/community/DiscussionThread.svelte
+++ b/web/src/lib/components/community/DiscussionThread.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
@@ -12,12 +13,14 @@
     thread,
     initialReplies,
     initialCursor,
-    backPath,
+    subjectType,
+    subjectSlug,
   }: {
     thread: CommunityThread;
     initialReplies: CommunityReply[];
     initialCursor?: string;
-    backPath: string;
+    subjectType: string;
+    subjectSlug: string;
   } = $props();
 
   let replies = $state<CommunityReply[]>([...initialReplies]);
@@ -69,7 +72,12 @@
 </script>
 
 <article class="thread">
-  <a class="thread__back" href={backPath}>← Back to discussion</a>
+  <a
+    class="thread__back"
+    href={subjectType === 'company'
+      ? resolve('/companies/[slug]/discussion', { slug: subjectSlug })
+      : resolve('/jobs/[slug]/discussion', { slug: subjectSlug })}>← Back to discussion</a
+  >
 
   <header class="thread__head">
     <h1 class="thread__title">{thread.title}</h1>

--- a/web/src/routes/companies/[slug]/discussion/+page.svelte
+++ b/web/src/routes/companies/[slug]/discussion/+page.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import DiscussionIndex from '$lib/components/community/DiscussionIndex.svelte';
   let { data } = $props();
-  const basePath = $derived(`/companies/${data.slug}/discussion`);
 </script>
 
 <div class="mx-auto w-full max-w-3xl px-4 py-6">
-  <a class="crumb" href={`/companies/${data.slug}`}>← {data.slug}</a>
+  <a class="crumb" href={resolve('/companies/[slug]', { slug: data.slug })}>← {data.slug}</a>
   <DiscussionIndex
     subjectType="company"
     subjectSlug={data.slug}
-    {basePath}
     initialThreads={data.threads}
     initialCursor={data.nextCursor}
   />

--- a/web/src/routes/companies/[slug]/discussion/[threadId]/+page.svelte
+++ b/web/src/routes/companies/[slug]/discussion/[threadId]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import DiscussionThread from '$lib/components/community/DiscussionThread.svelte';
   let { data } = $props();
-  const backPath = $derived(`/companies/${data.slug}/discussion`);
 </script>
 
 <div class="mx-auto w-full max-w-3xl px-4 py-6">
@@ -9,6 +8,7 @@
     thread={data.thread}
     initialReplies={data.replies}
     initialCursor={data.nextCursor}
-    {backPath}
+    subjectType="company"
+    subjectSlug={data.slug}
   />
 </div>

--- a/web/src/routes/companies/[slug]/discussion/new/+page.svelte
+++ b/web/src/routes/companies/[slug]/discussion/new/+page.svelte
@@ -5,5 +5,5 @@
 </script>
 
 <div class="mx-auto w-full max-w-3xl px-4 py-6">
-  <DiscussionNewTopic subjectType="company" subjectSlug={slug} listPath={`/companies/${slug}/discussion`} />
+  <DiscussionNewTopic subjectType="company" subjectSlug={slug} />
 </div>

--- a/web/src/routes/jobs/[slug]/discussion/+page.svelte
+++ b/web/src/routes/jobs/[slug]/discussion/+page.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import DiscussionIndex from '$lib/components/community/DiscussionIndex.svelte';
   let { data } = $props();
-  const basePath = $derived(`/jobs/${data.slug}/discussion`);
 </script>
 
 <div class="mx-auto w-full max-w-3xl px-4 py-6">
-  <a class="crumb" href={`/jobs/${data.slug}`}>← Back to vacancy</a>
+  <a class="crumb" href={resolve('/jobs/[slug]', { slug: data.slug })}>← Back to vacancy</a>
   <DiscussionIndex
     subjectType="job"
     subjectSlug={data.slug}
-    {basePath}
     initialThreads={data.threads}
     initialCursor={data.nextCursor}
   />

--- a/web/src/routes/jobs/[slug]/discussion/[threadId]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/discussion/[threadId]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import DiscussionThread from '$lib/components/community/DiscussionThread.svelte';
   let { data } = $props();
-  const backPath = $derived(`/jobs/${data.slug}/discussion`);
 </script>
 
 <div class="mx-auto w-full max-w-3xl px-4 py-6">
@@ -9,6 +8,7 @@
     thread={data.thread}
     initialReplies={data.replies}
     initialCursor={data.nextCursor}
-    {backPath}
+    subjectType="job"
+    subjectSlug={data.slug}
   />
 </div>

--- a/web/src/routes/jobs/[slug]/discussion/new/+page.svelte
+++ b/web/src/routes/jobs/[slug]/discussion/new/+page.svelte
@@ -5,5 +5,5 @@
 </script>
 
 <div class="mx-auto w-full max-w-3xl px-4 py-6">
-  <DiscussionNewTopic subjectType="job" subjectSlug={slug} listPath={`/jobs/${slug}/discussion`} />
+  <DiscussionNewTopic subjectType="job" subjectSlug={slug} />
 </div>


### PR DESCRIPTION
## Summary

`svelte/no-navigation-without-resolve` (tightened in #1039) fires on the community discussion links that shipped in #1036, leaving **main's `web` lint red** and blocking every PR. #1036's own lint was green off a stale pre-#1039 run, so the squash merge carried the violation in.

Fixed the type-safe way — **no rule suppression** (per request, `eslint-disable` is not acceptable):

- Every discussion link is now a typed `resolve('/companies/[slug]/discussion/[threadId]', { slug, threadId })` call → route validity + base-path handling are compile-checked.
- The polymorphic components (`DiscussionIndex`/`NewTopic`/`Thread`) build their own routes from `subjectType` + `subjectSlug`; the precomputed `basePath`/`listPath`/`backPath` string props are removed. `DiscussionThread` now takes `subjectType`/`subjectSlug` like its siblings.

## Test Plan

- [x] `npm run lint` — 0 errors (was 8: `no-navigation-without-resolve`)
- [x] `npm run check` (svelte-check) — 0 errors
- [x] No `eslint-disable` added