### PR TITLE
fix(docker): drop reslug build removed in 7fd5e84c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/hire ./cmd/server
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/reindex ./cmd/reindex \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/tg-ingest ./cmd/tg-ingest \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/tg-extract ./cmd/tg-extract \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/reslug ./cmd/reslug \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-derive ./cmd/backfill-derive \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/liveness ./cmd/liveness \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/notify ./cmd/notify \
@@ -50,7 +49,7 @@ RUN apt-get update \
  && groupadd --system --gid 65532 nonroot \
  && useradd --system --uid 65532 --gid nonroot --home-dir /app nonroot \
  && pdftotext -v
-COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /out/backfill-derive /out/liveness /out/notify /out/import-collections /out/recount-companies /out/backfill-company-info /app/
+COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/backfill-derive /out/liveness /out/notify /out/import-collections /out/recount-companies /out/backfill-company-info /app/
 # CV PDF rendering: the typst binary + the env that points the server at it. Absent this
 # the CV builder still works and the PDF endpoint returns 501 (config resolves via LookPath).
 COPY --from=typst /usr/local/bin/typst /app/typst


### PR DESCRIPTION
`7fd5e84c` folded `cmd/reslug` into `cmd/backfill-derive` and deleted the directory, but the Dockerfile still ran `go build ./cmd/reslug` → image build (and the `pr-smoke` gate that builds it) fails on main with `cmd/reslug: directory not found`. Removes the reslug build + COPY. Prod's native `release.sh` never built reslug, so it's unaffected.