### PR TITLE
feat(web): right-align job Discussion link and gate it behind auth

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -154,6 +154,16 @@
     showReport = true;
   }
 
+  // The discussion is members-only: a signed-out click is held back (the link
+  // does not navigate) and the sign-in dialog opens instead. The href stays put
+  // so the route is still SSR-linkable for signed-in visitors.
+  function onDiscussionClick(e: MouseEvent) {
+    if (!isAuthenticated()) {
+      e.preventDefault();
+      openAuthDialog('login');
+    }
+  }
+
   // The toggle flips on the server's answer, not optimistically: both endpoints
   // return the full interaction, so the button can never drift from the truth.
   async function toggleSave() {
@@ -230,8 +240,9 @@
     <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
 
     <a
-      class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      class="inline-flex items-center gap-1.5 self-end text-sm font-medium text-primary hover:underline"
       href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
+      onclick={onDiscussionClick}
     >
       <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
         ? ` · ${threadCount}`


### PR DESCRIPTION
## What

On the job detail header (`JobView.svelte`):

- **Right-align** the `Discussion` link to the right edge (via `self-end` — works on desktop and mobile in the single `flex-col` header).
- **Auth-gate** the navigation: a signed-out click is intercepted (`e.preventDefault()`) and opens the sign-in dialog instead of navigating. `href` is kept so signed-in visitors navigate normally and the route stays SSR-linkable.

Follows the existing `onApplyClick` / `onSaveClick` / `onReportClick` auth-gate pattern in the same component.

## Notes

This is a client-side gate (mirrors the existing Apply gate) — it does not block middle-click / direct URL. A hard server-side gate on the `/jobs/[slug]/discussion` route can be added separately if desired.

## Verification

- `npm run check` — 0 errors (pre-existing warnings only, none in this file).