### PR TITLE
chore/eastern roots idagent coverage

### DIFF
--- a/internal/collections/eastern_roots.txt
+++ b/internal/collections/eastern_roots.txt
@@ -7,6 +7,7 @@
 1inch
 1password
 3commas
+4a-games
 abbyy
 acronis
 action1
@@ -46,6 +47,7 @@ betterme
 bigid
 birch
 bitfury
+bitrix24
 bolt
 brainrocket
 bumble
@@ -78,9 +80,11 @@ data-driven-lab
 dataart
 datafold
 dbeaver
+depositphotos
 dwelly
 easybrain
 ecommpay
+ecwid
 eleks
 emcd
 emerging-travel-group
@@ -99,6 +103,7 @@ exinity
 exness
 faceapp
 farel
+fibery
 findev
 finom
 fjor-health
@@ -127,6 +132,7 @@ gradient
 grammarly
 grid-dynamics
 group-ib
+gsc-game-world
 haut-ai
 headway-inc
 helio-games
@@ -183,6 +189,7 @@ moon-active
 moonpay
 movavi
 mundfish
+murka
 muse-group
 n-ix
 nebius
@@ -273,6 +280,7 @@ spotware
 spryker
 stackadapt
 stape
+starwind-software
 sumsub
 superannotate
 surfshark
@@ -323,5 +331,6 @@ xsolla
 xtx-markets
 yandex
 zeptolab
+zerion
 zero
 zimad

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -154,6 +154,16 @@
     showReport = true;
   }
 
+  // The discussion is members-only: a signed-out click is held back (the link
+  // does not navigate) and the sign-in dialog opens instead. The href stays put
+  // so the route is still SSR-linkable for signed-in visitors.
+  function onDiscussionClick(e: MouseEvent) {
+    if (!isAuthenticated()) {
+      e.preventDefault();
+      openAuthDialog('login');
+    }
+  }
+
   // The toggle flips on the server's answer, not optimistically: both endpoints
   // return the full interaction, so the button can never drift from the truth.
   async function toggleSave() {
@@ -230,8 +240,9 @@
     <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
 
     <a
-      class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      class="inline-flex items-center gap-1.5 self-end text-sm font-medium text-primary hover:underline"
       href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
+      onclick={onDiscussionClick}
     >
       <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
         ? ` · ${threadCount}`


### PR DESCRIPTION
- **feat(web): right-align job Discussion link and gate it behind auth**
- **chore(collections): add 9 idagent eastern-roots company slugs**
