### PR TITLE
feat(sources): add betterteam adapter + 15 teamtailor boards

### DIFF
--- a/internal/sources/betterteam.go
+++ b/internal/sources/betterteam.go
@@ -1,0 +1,112 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// betterteam adapts Betterteam career sites. The board is the tenant subdomain (e.g.
+// "110grill"), so the career site is "<board>.betterteam.com". The root page lists each
+// posting at /<slug>-<id> (e.g. /bartender-21); each job page carries a schema.org
+// JobPosting ld+json block, so the description comes from a per-job detail fetch
+// (bounded-concurrency), like the other schema.org detail adapters (freshteam/softgarden).
+//
+// The listing is a single page: Betterteam renders the whole board on the site root, so a
+// tenant with more postings than the root holds is truncated. In practice Betterteam
+// tenants (small businesses) are small.
+type betterteam struct {
+	http HTMLGetter
+}
+
+// NewBetterteam builds the Betterteam adapter over the given HTTP client.
+func NewBetterteam(c HTMLGetter) Source { return betterteam{http: c} }
+
+func (betterteam) Provider() string { return "betterteam" }
+
+func (b betterteam) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	// base carries the scheme+host; the listing's relative "/<slug>-<id>" hrefs resolve
+	// against it into fetchable absolute URLs.
+	base, err := url.Parse(fmt.Sprintf("https://%s.betterteam.com/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("betterteam: board %q: %w", e.Board, err)
+	}
+
+	root, err := b.http.GetHTML(ctx, base.String())
+	if err != nil {
+		return nil, fmt.Errorf("betterteam: listing %s: %w", e.Board, err)
+	}
+	urls := jobLinks(base, root, func(href string) bool { return btJobID(href) != "" })
+
+	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return b.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the page fetch fails, carries no JobPosting, or has no parseable id, so the caller
+// skips just that posting.
+func (b betterteam) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := btJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := b.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p btPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	location := p.JobLocation.Address.Location()
+	// Betterteam's JobPosting carries no explicit remote flag, so remote is inferred from the
+	// location only (never the title, which false-positives on "Remote …" role names).
+	remote := isRemote(location)
+
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      remote,
+		WorkMode:    workModeFromRemote(remote),
+		PostedAt:    parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// btJobIDPattern captures the native posting id from a job URL's path. A posting permalink
+// is a single "/<slug>-<id>" segment ending in the numeric id (e.g. /bartender-21); the id
+// stored is the whole slug-id segment, which Betterteam echoes as the ld+json identifier.
+var btJobIDPattern = regexp.MustCompile(`^/([a-z0-9][a-z0-9-]*-\d+)$`)
+
+// btJobID extracts the native posting id (the slug-id path segment) from a job URL, or ""
+// when the URL is not a job permalink. Only the path is matched, so absolute and relative
+// hrefs on the tenant host both resolve.
+func btJobID(u string) string {
+	p := u
+	if parsed, err := url.Parse(u); err == nil {
+		p = parsed.Path
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return firstSubmatch(btJobIDPattern, p)
+}
+
+// btPosting is the schema.org JobPosting decoded from a Betterteam job page's
+// application/ld+json block. jobLocation is a single Place object.
+type btPosting struct {
+	Title       string      `json:"title"`
+	Description string      `json:"description"`
+	DatePosted  string      `json:"datePosted"`
+	JobLocation schemaPlace `json:"jobLocation"`
+}

--- a/internal/sources/betterteam_test.go
+++ b/internal/sources/betterteam_test.go
@@ -1,0 +1,137 @@
+package sources
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// btListingHTML builds a Betterteam root listing page linking each given job href.
+func btListingHTML(jobHrefs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><ul class="jobs">`)
+	for _, h := range jobHrefs {
+		b.WriteString(`<li><a href="` + h + `">A job</a></li>`)
+	}
+	b.WriteString(`</ul></body></html>`)
+	return b.String()
+}
+
+// btDetailHTML builds a Betterteam job page carrying a schema.org JobPosting ld+json block.
+// jobLocation is a single Place object and there is no remote flag.
+func btDetailHTML(title, encodedDescription, datePosted, locality, country string) string {
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + encodedDescription + `",` +
+		`"datePosted":"` + datePosted + `",` +
+		`"employmentType":"FULL_TIME",` +
+		`"hiringOrganization":{"@type":"Organization","name":"110 Grill"},` +
+		`"jobLocation":{"@type":"Place","address":{"addressLocality":"` + locality + `","addressCountry":"` + country + `"}}}` +
+		`</script></head><body></body></html>`
+}
+
+func TestBetterteamProvider(t *testing.T) {
+	if got := NewBetterteam(nil).Provider(); got != "betterteam" {
+		t.Errorf("Provider() = %q, want %q", got, "betterteam")
+	}
+}
+
+func TestBTJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://110grill.betterteam.com/bartender-21": "bartender-21",
+		"/culinary-manager-39":                         "culinary-manager-39",
+		"https://x.betterteam.com/line-cook-113":       "line-cook-113",
+		"https://x.betterteam.com/":                    "", // listing root, no id
+		"/about-us":                                    "", // no trailing numeric id
+		"/careers":                                     "", // no trailing id
+		"https://x.betterteam.com/a/b-12":              "", // not a single segment
+	}
+	for u, want := range cases {
+		if got := btJobID(u); got != want {
+			t.Errorf("btJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestBTJobLinksResolvesRelativeHrefs(t *testing.T) {
+	// The live listing emits relative "/<slug>-<id>" hrefs; each must resolve to an
+	// absolute, fetchable URL against the root, and a repeated job de-dups to one.
+	h := btListingHTML("/bartender-21", "/bartender-21", "/culinary-manager-39") +
+		`<a href="/about-us">About</a>`
+	base := mustURL(t, "https://110grill.betterteam.com/")
+	got := jobLinks(base, parseHTML(t, h), func(href string) bool { return btJobID(href) != "" })
+	want := []string{
+		"https://110grill.betterteam.com/bartender-21",
+		"https://110grill.betterteam.com/culinary-manager-39",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("jobLinks() = %v, want %v", got, want)
+	}
+}
+
+func TestBetterteamFetchListingThenDetailAndMaps(t *testing.T) {
+	jobURL := "https://110grill.betterteam.com/bartender-21"
+	detail := btDetailHTML(
+		"Bartender",
+		"&lt;div&gt;Pour &lt;b&gt;drinks&lt;/b&gt;.&lt;/div&gt;&lt;script&gt;alert(1)&lt;/script&gt;",
+		"2026-06-09T15:07:41.914471Z", "North Conway", "US")
+	fake := (&routedHTTP{}).
+		route("/bartender-21", detail). // detail route first: the listing root has no slug-id
+		route("110grill.betterteam.com/", btListingHTML("/bartender-21"))
+
+	jobs, err := NewBetterteam(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "110 Grill", Provider: "betterteam", Board: "110grill",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "bartender-21" {
+		t.Errorf("ExternalID = %q, want bartender-21", j.ExternalID)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q, want %q", j.URL, jobURL)
+	}
+	if j.Title != "Bartender" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "110 Grill" {
+		t.Errorf("Company = %q, want '110 Grill'", j.Company)
+	}
+	if j.Location != "North Conway, US" {
+		t.Errorf("Location = %q, want 'North Conway, US'", j.Location)
+	}
+	if strings.Contains(j.Description, "<script>") ||
+		!strings.Contains(j.Description, "<div>") || !strings.Contains(j.Description, "<b>drinks</b>") {
+		t.Errorf("Description not unescaped/sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 9, 15, 7, 41, 914471000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-09T15:07:41.914471Z", j.PostedAt)
+	}
+}
+
+func TestBetterteamDropsDetailWithoutJobPosting(t *testing.T) {
+	// A job page carrying no schema.org JobPosting drops just that posting; the rest of the
+	// board still ingests.
+	d := btDetailHTML("Cook", "&lt;div&gt;x&lt;/div&gt;", "2026-06-09T15:07:41Z", "Boston", "US")
+	fake := (&routedHTTP{}).
+		route("/line-cook-113", d).
+		route("/line-cook-114", `<html><body>no ld+json here</body></html>`).
+		route("110grill.betterteam.com/", btListingHTML("/line-cook-113", "/line-cook-114"))
+
+	jobs, err := NewBetterteam(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "110 Grill", Board: "110grill",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (one detail dropped)", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -272,6 +272,7 @@ func All(c HTTPClient) map[string]Source {
 		NewEightfold(c),
 		NewFreshteam(c),
 		NewSoftgarden(c),
+		NewBetterteam(c),
 		NewEarcu(c),
 		NewPageUp(c),
 		NewNeogov(c),

--- a/sources/betterteam.yml
+++ b/sources/betterteam.yml
@@ -1,0 +1,355 @@
+# betterteam boards. Provider is the filename; each entry is company + board.
+# board = tenant subdomain (see internal/sources/betterteam.go).
+
+- company: A-Apollo Windows & Doors Ltd
+  board: apollowindows
+- company: AAA Club Alliance
+  board: aaa-7
+- company: AAA USA
+  board: aaa-usainc
+- company: ABM College
+  board: abmcollege
+- company: Acton ADU
+  board: actonconstruction
+- company: AiLO Logistics
+  board: ailo
+- company: Al Fattan Properties
+  board: alfattan
+- company: Alpha Better Landscaping
+  board: alphabetterlands
+- company: Alphanumeric Systems Inc.
+  board: alphanumericsystemsinc
+- company: Amera Trail
+  board: ameratrail
+- company: American Fleet Service, Inc
+  board: americanfleetservice
+- company: American Tax Defense
+  board: amityonetax-2
+- company: AMK Global Staffing
+  board: amkglobalstaffing
+- company: ANC Solutions
+  board: ancsolutions
+- company: Aspiration International School
+  board: aspirationis
+- company: Avis Budget Group
+  board: abg-2
+- company: Barrister Title
+  board: barristertitle
+- company: Behavior Nation
+  board: aba-5
+- company: Borden Dairy
+  board: bordendairy-6
+- company: Breathe Easy Automotive
+  board: breatheeasyauto
+- company: Building Connections Behavioral Health
+  board: bcbhinc
+- company: Burghardt Sporting Goods
+  board: bsg1881
+- company: Business Support Services of Salem
+  board: businesssupportservicesinc
+- company: C&J Automotive & Tire of Sewell
+  board: cjautomotivetireofsewell
+- company: C&J Automotive of Cherry Hill
+  board: cjautomotiveofcherryhill
+- company: Caffe Luxxe
+  board: caffeluxxe
+- company: CalTex Cashflow
+  board: truckandtrailerstorage
+- company: Canuck Express
+  board: canuckexpress
+- company: Car Lux Inc.
+  board: carluxlax
+- company: Choice in Aging
+  board: choiceinaging
+- company: City Ambulance Service
+  board: cityambu
+- company: City of North Las Vegas
+  board: cityofnorthlasvegas-2
+- company: Clean Harbors
+  board: lightfoot
+- company: Clint Wilson State Farm
+  board: clintwilsonstatefarm
+- company: Community Assessment & Treatment Services
+  board: communityassessment
+- company: Community Health Centers
+  board: chcfl
+- company: Cortica
+  board: corticacare
+- company: Coury & Buehler Physical Therapy
+  board: cbphysicaltherapy
+- company: Cox Fleet
+  board: coxfleet
+- company: D&D Automotive Repair, Inc.
+  board: ddautomotiverepair
+- company: Dal-Tile
+  board: daltile
+- company: Dali Transportation LLC dba Prime One
+  board: callprimeone
+- company: Dependable Truck & Tank Ltd
+  board: dependable
+- company: Desert Face Trading LLC
+  board: desertfacetradingllc
+- company: DiscoverU Health
+  board: discoveruhealth
+- company: Dodd Camera
+  board: doddcamera
+- company: Dr Nutrition UAE
+  board: drnutritioncenterllc
+- company: Duc de Lorraine
+  board: ducdelorraine
+- company: Dynamix Agitators
+  board: dynamixinc
+- company: Eden Foods
+  board: edenfoodsinc
+- company: Ehvert Inc
+  board: ehvert
+- company: Elite Auto Experts
+  board: eliteautoexperts
+- company: Ellis Machinery & Equipment, Inc.
+  board: ellismachineryequipmentinc
+- company: Entertainment Technology Partners
+  board: etp
+- company: Equation Staffing Solutions
+  board: eqstaffingsolutions
+- company: Equity Trust
+  board: trustetc
+- company: European Service Center
+  board: escautogroup
+- company: ExpenseAnywhere
+  board: expenseanywhere
+- company: Far East Motors Auto Repair
+  board: fareastmotors
+- company: Fatsoma Ltd
+  board: fatsoma
+- company: FC Duct Cleaning
+  board: fcduct
+- company: Ferguson Enterprises, Inc.
+  board: manpowerferguson
+- company: Flamingo Appliance Service
+  board: flamingoappliance
+- company: FleetPride, Inc.
+  board: fleetpride-6
+- company: FreshTax
+  board: freshtaxsolutions
+- company: G&H Towing
+  board: gandhtowing
+- company: GCW Engineering, Inc.
+  board: gcwengineering
+- company: Geeky Tech Ltd
+  board: geekytech
+- company: Generations Cleaning
+  board: generationscleaning
+- company: Girl Scouts of Central Indiana
+  board: girlscoutsofcentralindiana
+- company: Grassi
+  board: grassiadvisors
+- company: Greenlife Healthcare Staffing
+  board: glhstaffing
+- company: Gulbahar Tobacco International Fze
+  board: gulbahartobacco
+- company: HaloMD
+  board: halomd
+- company: Handcrafted Wines
+  board: handcraftedwines
+- company: Harris Civil Engineers
+  board: harriscivilengineers
+- company: Hawaii Senior Care
+  board: hawaiiseniorcare
+- company: Heart CPR
+  board: heartcpr
+- company: Hertz
+  board: hertz-1
+- company: Hertz
+  board: hertz-59
+- company: Hertz
+  board: hertz-62
+- company: Honda and Toyota of Seattle
+  board: hondaandtoyotaofseattle
+- company: HR Alliance
+  board: hragroup-1
+- company: Huisong Pharmaceuticals
+  board: huisong
+- company: ICI Metals
+  board: icimetals
+- company: Indeck Power Equipment Company
+  board: indeckpowerequipment
+- company: Integrated Autism Centers
+  board: integratedautismcenterllc
+- company: Jax Spine & Pain Centers
+  board: jaxspine
+- company: JK TECHNOLOGY PTE LTD
+  board: jktechnologypteltd
+- company: Kaleidoscope ABA
+  board: kfsaba
+- company: Kaleidoscope Education Solutions
+  board: kaleidoscopeeducationsolutions
+- company: Kaltire
+  board: kaltire
+- company: Kathleen M Flynn, LLC
+  board: kathleenmflynnllc-2
+- company: KGPCo
+  board: kgpco-2
+- company: Kinetic Medical Group
+  board: kineticmedicalgrp
+- company: Kroger Mountain View Foods
+  board: krogermountainviewfoods
+- company: KwikKar Automotive Services
+  board: kwikkargroup
+- company: L & R Automotive
+  board: lrautorepair
+- company: LeadAdvisors
+  board: leadadvisors
+- company: LidWorks
+  board: lidworks
+- company: Louisiana Medical Management Corporation
+  board: louisianamedicalmanagementcorporation
+- company: Mary Henry Insurance Agcy Inc
+  board: insurememary
+- company: "Master's Transportation"
+  board: masterstransportation
+- company: Medlife
+  board: medlifemovement
+- company: "Meet Me At Madison's"
+  board: meetmeatmadisons
+- company: Meineke Car Care Service 232
+  board: meinekecarcareservice232
+- company: Merit Asphalt
+  board: meritasphalt
+- company: Miami Dade College
+  board: miamidadecollege
+- company: MK Auto Group
+  board: carstarab
+- company: Motorenn
+  board: motorenn
+- company: "MrKitt's Service Center & Towing"
+  board: mrkittsservicecenerinc
+- company: MSP Diesel Solutions
+  board: mspdieselsolutions
+- company: New Leaf Behavioral Health
+  board: nlbh
+- company: North Carolina Community Health Center Association
+  board: ncchca
+- company: Nova Construction Management, LLC.
+  board: buildwithnovacm
+- company: Oakridge Landscape Contractors
+  board: oakridgelandscape
+- company: Oneflow
+  board: oneflow
+- company: OPC Contracting, Inc.
+  board: opc-inc
+- company: Openwork
+  board: openworkllc
+- company: Papyrus Software USA
+  board: isis-papyrus
+- company: Peak Technologies
+  board: peaktech
+- company: PML Sound International
+  board: pmlsound
+- company: Potawatomi Federal Solutions
+  board: pfssbu
+- company: PPG
+  board: ppg-6
+- company: Presbyterian Villages of Michigan
+  board: pvm
+- company: Prestige Transportation
+  board: prestigekc
+- company: Printerpix
+  board: printerpix-2
+- company: Protrans Automotive & Transmission
+  board: protransautomotivetransmission
+- company: PSEG
+  board: pseg-1
+- company: Q10 Property Advisors
+  board: q10pa
+- company: Quality Car Care
+  board: qualitycarcare
+- company: Rail Management Services
+  board: railmanagementservices
+- company: RBC Bearings Incorporated
+  board: rbcbearings
+- company: RE Global
+  board: re-global
+- company: Regional Federal Credit Union
+  board: regionalfcu
+- company: Reli Electric
+  board: relielectric
+- company: RJ Lieb NYC Staffing Inc.
+  board: rjliebnycstaffinginc
+- company: Rockwell Development Center
+  board: rdckids
+- company: Rosenberg Fans Canada Ltd.
+  board: rosenbergcanada
+- company: SafeTech
+  board: safetech-usa
+- company: "Salem's Fresh Eats"
+  board: salemsfresheats
+- company: SamTech Group
+  board: samtech-me
+- company: SELF Inc.
+  board: selfincorp-3
+- company: Serco
+  board: serco-1
+- company: "Southern Glazer's Wine & Spirits"
+  board: sgws-2
+- company: "Southern Glazer's Wine & Spirits"
+  board: sgws-63
+- company: Stage Windows & Doors
+  board: stagewindows
+- company: Stellar Transport
+  board: stellar-transport
+- company: Summit Placement Service, Inc.
+  board: hiresps
+- company: SuperbTech, Inc
+  board: superbtechinc-2
+- company: Swan & Gardiner CPAs
+  board: swanandgardiner
+- company: Sysco
+  board: sysco-26
+- company: Sysco
+  board: sysco-3
+- company: Sysco
+  board: sysco-30
+- company: Talis Group, Inc.
+  board: talisgroupinc
+- company: The All Star Agency LLC
+  board: theallstaragencyllc
+- company: The Club at 12 Oaks
+  board: theclubat12oaks
+- company: The Krill Co., Inc.
+  board: krill
+- company: The Surplus Line Association of California
+  board: thesurpluslineassociationofcalifornia
+- company: The V Shop
+  board: thevshopfl
+- company: Tinley Auto Repair & Towing, Inc.
+  board: tinleyautorepair
+- company: "TRACY'S AUTOMOTIVE"
+  board: tracysautomotive3
+- company: "Trad's Pest Control"
+  board: tradspestcontrol
+- company: Tsubaki of Canada Limited
+  board: tsubaki
+- company: U.S. Army
+  board: armyrecruitingohio
+- company: Universal Transportation Systems
+  board: universaltransportationsystems
+- company: University Tire & Auto Service
+  board: universitytirecenter
+- company: VIP Staffing
+  board: vip-staffing-13
+- company: VirTra, Inc.
+  board: virtra
+- company: Voda Medical Clinic
+  board: vodamedicalclinic
+- company: VSSI LLC Staffing Services
+  board: vssistaffingagency
+- company: We Achieve ABA
+  board: weachieveaba
+- company: Westin Dallas Downtown
+  board: westindallasdowntown
+- company: White Cap Canada Inc.
+  board: whitecapcanada
+- company: Williams-Sonoma Inc.
+  board: wsgc-2
+- company: WomanCare Centers
+  board: womancarecenters

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3054,3 +3054,34 @@
   board: cadpool.teamtailor.com
 - company: On That Ass
   board: jobs.onthatass.com
+# --- aggregator-harvested + live-validated 15 boards ---
+- company: Adaptive Teams
+  board: adaptiveteams.teamtailor.com
+- company: Atticus Advisory Solutions
+  board: atticusadvisorysolutions.teamtailor.com
+- company: Coody
+  board: coody.teamtailor.com
+- company: David Kennedy Recruitment
+  board: davidkennedyrecruitment.teamtailor.com
+- company: Heads
+  board: heads.teamtailor.com
+- company: InstaGroup
+  board: instagroup-1713781469.teamtailor.com
+- company: LRG
+  board: lrgcareers.teamtailor.com
+- company: Make Events
+  board: makeevents-1747990244.teamtailor.com
+- company: NAFFCO
+  board: naffco.teamtailor.com
+- company: Orbio World
+  board: orbioworld.teamtailor.com
+- company: Spiko
+  board: spiko.teamtailor.com
+- company: Synmatch AI
+  board: synmatchai.teamtailor.com
+- company: Tendios
+  board: tendios.teamtailor.com
+- company: TOPPAN Security
+  board: toppansecurity.teamtailor.com
+- company: Veoneer Safety Systems USA
+  board: veoneerus.teamtailor.com


### PR DESCRIPTION
## What

Second harvest round — adds the last remaining source gaps found on the aggregator:

1. **betterteam adapter** (new) — the only multi-tenant ATS platform without an adapter. 176 live tenants.
2. **15 teamtailor boards** — existing adapter already handles `*.teamtailor.com`; these tenants were live-validated and added (no new adapter).

## betterteam

Board = tenant subdomain (`<board>.betterteam.com`). Root listing links each posting at `/<slug>-<id>`; each job page carries a schema.org `JobPosting` ld+json, so detail is a per-job fetch reusing the shared `jobLinks`/`fetchDetails`/`ldJobPosting`/`schemaPlace` primitives (same shape as freshteam/softgarden). Single-page listing.

**Heads-up:** Betterteam tenants are predominantly **non-tech** (hospitality, retail, trades — e.g. line cooks, general managers). The ingest non-tech gate will drop most postings, so the net IT-relevant contribution is small. Added per explicit request.

## Verification

- Unit tests for both (id extraction, relative-href resolution, listing→detail mapping incl. fractional-second RFC3339 dates, drop-on-missing-JobPosting).
- End-to-end against live tenants: betterteam `110grill` → 44 jobs parsed; teamtailor set → ~585 jobs across the 15 boards.
- Both board files load + validate against the registry (betterteam 176 entries, teamtailor 1537).