### PR TITLE
feat(profile): excluded skills that seed the filter's skills exclude set

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -537,4 +537,5 @@ type UserProfile struct {
 	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
 	Specializations     []string           `json:"specializations"`
 	LocationPreferences json.RawMessage    `json:"location_preferences"`
+	ExcludedSkills      []string           `json:"excluded_skills"`
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1431,8 +1431,9 @@ type Querier interface {
 	UpsertUserJobAnalysis(ctx context.Context, arg UpsertUserJobAnalysisParams) error
 	// Create-or-replace the user's one profile. The PRIMARY KEY (user_id) makes this an
 	// idempotent upsert: first save inserts, later saves overwrite specializations/skills/
-	// location_preferences and bump updated_at. All fields are already normalized by the
-	// service; location_preferences is a validated JSONB block or NULL (no preferences).
+	// excluded_skills/location_preferences and bump updated_at. All fields are already
+	// normalized by the service; excluded_skills may be empty; location_preferences is a
+	// validated JSONB block or NULL (no preferences).
 	UpsertUserProfile(ctx context.Context, arg UpsertUserProfileParams) (UserProfile, error)
 	// Apply one yc-oss directory entry, matched by slug. A new slug is inserted as a
 	// reference row (is_reference = true) with no jobs; an existing slug (job-backed or a

--- a/internal/db/queries/user_profiles.sql
+++ b/internal/db/queries/user_profiles.sql
@@ -7,13 +7,15 @@ WHERE user_id = $1;
 -- name: UpsertUserProfile :one
 -- Create-or-replace the user's one profile. The PRIMARY KEY (user_id) makes this an
 -- idempotent upsert: first save inserts, later saves overwrite specializations/skills/
--- location_preferences and bump updated_at. All fields are already normalized by the
--- service; location_preferences is a validated JSONB block or NULL (no preferences).
-INSERT INTO user_profiles (user_id, specializations, skills, location_preferences)
-VALUES ($1, $2, $3, $4)
+-- excluded_skills/location_preferences and bump updated_at. All fields are already
+-- normalized by the service; excluded_skills may be empty; location_preferences is a
+-- validated JSONB block or NULL (no preferences).
+INSERT INTO user_profiles (user_id, specializations, skills, excluded_skills, location_preferences)
+VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (user_id) DO UPDATE
 SET specializations      = EXCLUDED.specializations,
     skills               = EXCLUDED.skills,
+    excluded_skills      = EXCLUDED.excluded_skills,
     location_preferences = EXCLUDED.location_preferences,
     updated_at           = now()
 RETURNING *;

--- a/internal/db/user_profiles.sql.go
+++ b/internal/db/user_profiles.sql.go
@@ -26,7 +26,7 @@ func (q *Queries) DeleteUserProfile(ctx context.Context, userID int64) (int64, e
 }
 
 const getUserProfile = `-- name: GetUserProfile :one
-SELECT user_id, skills, created_at, updated_at, specializations, location_preferences FROM user_profiles
+SELECT user_id, skills, created_at, updated_at, specializations, location_preferences, excluded_skills FROM user_profiles
 WHERE user_id = $1
 `
 
@@ -42,37 +42,42 @@ func (q *Queries) GetUserProfile(ctx context.Context, userID int64) (UserProfile
 		&i.UpdatedAt,
 		&i.Specializations,
 		&i.LocationPreferences,
+		&i.ExcludedSkills,
 	)
 	return i, err
 }
 
 const upsertUserProfile = `-- name: UpsertUserProfile :one
-INSERT INTO user_profiles (user_id, specializations, skills, location_preferences)
-VALUES ($1, $2, $3, $4)
+INSERT INTO user_profiles (user_id, specializations, skills, excluded_skills, location_preferences)
+VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (user_id) DO UPDATE
 SET specializations      = EXCLUDED.specializations,
     skills               = EXCLUDED.skills,
+    excluded_skills      = EXCLUDED.excluded_skills,
     location_preferences = EXCLUDED.location_preferences,
     updated_at           = now()
-RETURNING user_id, skills, created_at, updated_at, specializations, location_preferences
+RETURNING user_id, skills, created_at, updated_at, specializations, location_preferences, excluded_skills
 `
 
 type UpsertUserProfileParams struct {
 	UserID              int64           `json:"user_id"`
 	Specializations     []string        `json:"specializations"`
 	Skills              []string        `json:"skills"`
+	ExcludedSkills      []string        `json:"excluded_skills"`
 	LocationPreferences json.RawMessage `json:"location_preferences"`
 }
 
 // Create-or-replace the user's one profile. The PRIMARY KEY (user_id) makes this an
 // idempotent upsert: first save inserts, later saves overwrite specializations/skills/
-// location_preferences and bump updated_at. All fields are already normalized by the
-// service; location_preferences is a validated JSONB block or NULL (no preferences).
+// excluded_skills/location_preferences and bump updated_at. All fields are already
+// normalized by the service; excluded_skills may be empty; location_preferences is a
+// validated JSONB block or NULL (no preferences).
 func (q *Queries) UpsertUserProfile(ctx context.Context, arg UpsertUserProfileParams) (UserProfile, error) {
 	row := q.db.QueryRow(ctx, upsertUserProfile,
 		arg.UserID,
 		arg.Specializations,
 		arg.Skills,
+		arg.ExcludedSkills,
 		arg.LocationPreferences,
 	)
 	var i UserProfile
@@ -83,6 +88,7 @@ func (q *Queries) UpsertUserProfile(ctx context.Context, arg UpsertUserProfilePa
 		&i.UpdatedAt,
 		&i.Specializations,
 		&i.LocationPreferences,
+		&i.ExcludedSkills,
 	)
 	return i, err
 }

--- a/internal/handler/me_profile.go
+++ b/internal/handler/me_profile.go
@@ -17,6 +17,7 @@ import (
 type profileResponse struct {
 	Specializations     []string        `json:"specializations"`
 	Skills              []string        `json:"skills"`
+	ExcludedSkills      []string        `json:"excluded_skills"`
 	LocationPreferences json.RawMessage `json:"location_preferences"`
 	CreatedAt           *time.Time      `json:"created_at"`
 	UpdatedAt           *time.Time      `json:"updated_at"`
@@ -29,6 +30,7 @@ func toProfileResponse(p userprofile.Profile) profileResponse {
 	return profileResponse{
 		Specializations:     p.Specializations,
 		Skills:              p.Skills,
+		ExcludedSkills:      p.ExcludedSkills,
 		LocationPreferences: p.LocationPreferences,
 		CreatedAt:           p.CreatedAt,
 		UpdatedAt:           p.UpdatedAt,
@@ -72,6 +74,7 @@ func profileError(err error) error {
 type saveProfileRequest struct {
 	Specializations     []string                         `json:"specializations"`
 	Skills              []string                         `json:"skills"`
+	ExcludedSkills      []string                         `json:"excluded_skills"`
 	LocationPreferences *userprofile.LocationPreferences `json:"location_preferences"`
 }
 
@@ -94,8 +97,9 @@ func (a *API) GetProfile(c *fiber.Ctx) error {
 }
 
 // PutProfile creates-or-replaces the authenticated user's profile (specializations +
-// skills + optional location preferences). A bad/empty specialization set, empty skills,
-// or an out-of-vocabulary location value is a 400. Cookie-only.
+// skills + optional excluded skills + optional location preferences). A bad/empty
+// specialization set, empty skills, or an out-of-vocabulary location value is a 400.
+// Cookie-only.
 func (a *API) PutProfile(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
@@ -107,7 +111,7 @@ func (a *API) PutProfile(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
 
-	profile, err := a.userProfile.Save(c.Context(), userID, in.Specializations, in.Skills, in.LocationPreferences)
+	profile, err := a.userProfile.Save(c.Context(), userID, in.Specializations, in.Skills, in.ExcludedSkills, in.LocationPreferences)
 	if err != nil {
 		return profileError(err)
 	}

--- a/internal/handler/me_profile_test.go
+++ b/internal/handler/me_profile_test.go
@@ -24,6 +24,7 @@ type profileUpsert struct {
 	UserID              int64
 	Specializations     []string
 	Skills              []string
+	ExcludedSkills      []string
 	LocationPreferences json.RawMessage
 }
 
@@ -38,8 +39,8 @@ type fakeProfileRepo struct {
 func (f *fakeProfileRepo) Get(context.Context, int64) (userprofile.Profile, error) {
 	return f.getRet, f.getErr
 }
-func (f *fakeProfileRepo) Upsert(_ context.Context, userID int64, specializations, skills []string, locationPreferences json.RawMessage) (userprofile.Profile, error) {
-	f.upserted = profileUpsert{UserID: userID, Specializations: specializations, Skills: skills, LocationPreferences: locationPreferences}
+func (f *fakeProfileRepo) Upsert(_ context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage) (userprofile.Profile, error) {
+	f.upserted = profileUpsert{UserID: userID, Specializations: specializations, Skills: skills, ExcludedSkills: excludedSkills, LocationPreferences: locationPreferences}
 	return f.upsertRet, nil
 }
 func (f *fakeProfileRepo) Delete(context.Context, int64) error { return f.delErr }
@@ -130,6 +131,40 @@ func TestPutProfile_ReturnsSpecializationsArray(t *testing.T) {
 	}
 	if strings.Join(got.Data.Specializations, ",") != "backend,devops" {
 		t.Errorf("specializations = %v, want [backend devops]", got.Data.Specializations)
+	}
+}
+
+func TestPutProfile_NormalizesExcludedSkillsAndDropsOverlap(t *testing.T) {
+	repo := &fakeProfileRepo{}
+	app, token := profileApp(t, repo)
+	// "php" is wanted and also listed as excluded → the service drops it from the
+	// excluded set; "WordPress" is normalized to "wordpress".
+	resp := doProfile(t, app, fiber.MethodPut,
+		`{"specializations":["backend"],"skills":["go","php"],"excluded_skills":["php","WordPress"]}`, token)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if strings.Join(repo.upserted.ExcludedSkills, ",") != "wordpress" {
+		t.Errorf("excluded_skills upserted = %v, want [wordpress] (overlap dropped, normalized)", repo.upserted.ExcludedSkills)
+	}
+}
+
+func TestPutProfile_EchoesExcludedSkills(t *testing.T) {
+	ret := userprofile.Profile{UserID: 1, Specializations: []string{"backend"}, Skills: []string{"go"}, ExcludedSkills: []string{"wordpress"}}
+	app, token := profileApp(t, &fakeProfileRepo{upsertRet: ret})
+	resp := doProfile(t, app, fiber.MethodPut,
+		`{"specializations":["backend"],"skills":["go"],"excluded_skills":["wordpress"]}`, token)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got struct {
+		Data profileResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if strings.Join(got.Data.ExcludedSkills, ",") != "wordpress" {
+		t.Errorf("excluded_skills = %v, want [wordpress]", got.Data.ExcludedSkills)
 	}
 }
 

--- a/internal/userprofile/repository.go
+++ b/internal/userprofile/repository.go
@@ -39,11 +39,12 @@ func (r *QueriesRepository) Get(ctx context.Context, userID int64) (Profile, err
 }
 
 // Upsert creates or replaces the user's profile.
-func (r *QueriesRepository) Upsert(ctx context.Context, userID int64, specializations, skills []string, locationPreferences json.RawMessage) (Profile, error) {
+func (r *QueriesRepository) Upsert(ctx context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage) (Profile, error) {
 	row, err := r.q.UpsertUserProfile(ctx, db.UpsertUserProfileParams{
 		UserID:              userID,
 		Specializations:     specializations,
 		Skills:              skills,
+		ExcludedSkills:      excludedSkills,
 		LocationPreferences: locationPreferences,
 	})
 	if err != nil {
@@ -59,6 +60,7 @@ func profileFromRow(row db.UserProfile) Profile {
 		UserID:              row.UserID,
 		Specializations:     row.Specializations,
 		Skills:              row.Skills,
+		ExcludedSkills:      row.ExcludedSkills,
 		LocationPreferences: row.LocationPreferences,
 		CreatedAt:           pgconv.TimePtr(row.CreatedAt),
 		UpdatedAt:           pgconv.TimePtr(row.UpdatedAt),

--- a/internal/userprofile/userprofile.go
+++ b/internal/userprofile/userprofile.go
@@ -49,6 +49,7 @@ type Profile struct {
 	UserID              int64
 	Specializations     []string
 	Skills              []string
+	ExcludedSkills      []string
 	LocationPreferences json.RawMessage
 	CreatedAt           *time.Time
 	UpdatedAt           *time.Time
@@ -60,7 +61,7 @@ type Profile struct {
 // generated db row to Profile, so the use case never sees db.*.
 type Repository interface {
 	Get(ctx context.Context, userID int64) (Profile, error)
-	Upsert(ctx context.Context, userID int64, specializations, skills []string, locationPreferences json.RawMessage) (Profile, error)
+	Upsert(ctx context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage) (Profile, error)
 	Delete(ctx context.Context, userID int64) error
 }
 
@@ -81,10 +82,12 @@ func (s *Service) Get(ctx context.Context, userID int64) (Profile, error) {
 
 // Save validates and upserts the user's single profile. The specializations are
 // normalized (each a known category, deduped, non-empty, capped); the skills are
-// normalized and must be non-empty; the optional location block is validated and
+// normalized and must be non-empty; the excluded skills are normalized (deduped, may be
+// empty) and any that also appear in skills are dropped — a skill cannot be both wanted
+// and avoided, and the wanted set wins; the optional location block is validated and
 // normalized (or stored NULL when nil/empty). It is a create-or-replace: the first save
 // inserts, later saves overwrite.
-func (s *Service) Save(ctx context.Context, userID int64, specializations, skills []string, loc *LocationPreferences) (Profile, error) {
+func (s *Service) Save(ctx context.Context, userID int64, specializations, skills, excludedSkills []string, loc *LocationPreferences) (Profile, error) {
 	specs, err := normalizeSpecializations(specializations)
 	if err != nil {
 		return Profile{}, err
@@ -93,11 +96,12 @@ func (s *Service) Save(ctx context.Context, userID int64, specializations, skill
 	if err != nil {
 		return Profile{}, err
 	}
+	excluded := subtractSkills(normalizeExcludedSkills(excludedSkills), normalized)
 	locJSON, err := normalizeLocationPreferences(loc)
 	if err != nil {
 		return Profile{}, err
 	}
-	return s.repo.Upsert(ctx, userID, specs, normalized, locJSON)
+	return s.repo.Upsert(ctx, userID, specs, normalized, excluded, locJSON)
 }
 
 // Delete removes the user's profile. It is idempotent — deleting when none exists is not
@@ -141,6 +145,18 @@ func normalizeSpecializations(specializations []string) ([]string, error) {
 // order), dropping blanks. It returns ErrEmptySkills if nothing remains — a profile without
 // skills has no meaning.
 func normalizeSkills(skills []string) ([]string, error) {
+	out := normalizeExcludedSkills(skills)
+	if len(out) == 0 {
+		return nil, ErrEmptySkills
+	}
+	return out, nil
+}
+
+// normalizeExcludedSkills lowercases, trims, and deduplicates a skill list (preserving
+// first-seen order), dropping blanks. Unlike normalizeSkills it never errors: an empty set
+// is valid (the user need not avoid anything). It always returns a non-nil slice so the
+// value persists as an empty array, not NULL.
+func normalizeExcludedSkills(skills []string) []string {
 	out := make([]string, 0, len(skills))
 	seen := make(map[string]struct{}, len(skills))
 	for _, raw := range skills {
@@ -154,8 +170,27 @@ func normalizeSkills(skills []string) ([]string, error) {
 		seen[skill] = struct{}{}
 		out = append(out, skill)
 	}
-	if len(out) == 0 {
-		return nil, ErrEmptySkills
+	return out
+}
+
+// subtractSkills returns the values in a that are not in remove, preserving a's order. It
+// enforces the invariant that the wanted and excluded skill sets never overlap: a skill
+// listed as both wanted and avoided is dropped from the excluded set (the wanted set
+// wins), so a committed filter never emits contradictory skills = X AND skills != X.
+func subtractSkills(a, remove []string) []string {
+	if len(remove) == 0 {
+		return a
 	}
-	return out, nil
+	drop := make(map[string]struct{}, len(remove))
+	for _, s := range remove {
+		drop[s] = struct{}{}
+	}
+	out := make([]string, 0, len(a))
+	for _, s := range a {
+		if _, skip := drop[s]; skip {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
 }

--- a/internal/userprofile/userprofile_location_test.go
+++ b/internal/userprofile/userprofile_location_test.go
@@ -31,7 +31,7 @@ func TestSave_StoresCombinedLocationPreferences(t *testing.T) {
 		Base:       userprofile.BaseLocation{Country: "BR", City: " Florianópolis "},
 		Relocation: userprofile.Relocation{Open: true, Cities: []string{"Berlin"}},
 	}
-	if _, err := svc.Save(context.Background(), 7, []string{"backend"}, []string{"go"}, loc); err != nil {
+	if _, err := svc.Save(context.Background(), 7, []string{"backend"}, []string{"go"}, nil, loc); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	if !repo.upsertCalled {
@@ -58,7 +58,7 @@ func TestSave_StoresCombinedLocationPreferences(t *testing.T) {
 // No location block → NULL stored (never-set semantics), profile still saved.
 func TestSave_NilLocationStoresNull(t *testing.T) {
 	repo := &fakeRepo{}
-	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, nil); err != nil {
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, nil, nil); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	if repo.upserted.LocationPreferences != nil {
@@ -70,7 +70,7 @@ func TestSave_NilLocationStoresNull(t *testing.T) {
 func TestSave_EmptyLocationCollapsesToNull(t *testing.T) {
 	repo := &fakeRepo{}
 	empty := &userprofile.LocationPreferences{}
-	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, empty); err != nil {
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, nil, empty); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	if repo.upserted.LocationPreferences != nil {
@@ -94,7 +94,7 @@ func TestSave_RejectsInvalidLocationValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &fakeRepo{}
-			_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, tc.loc)
+			_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, nil, tc.loc)
 			if !errors.Is(err, tc.want) {
 				t.Errorf("Save err = %v, want %v", err, tc.want)
 			}
@@ -113,7 +113,7 @@ func TestSave_NormalizesLocationEnumCase(t *testing.T) {
 		WorkModes: []string{"Remote", "remote"},
 		Remote:    userprofile.GeoSet{Regions: []string{"LATAM", "latam"}},
 	}
-	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, loc); err != nil {
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, nil, loc); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	got := decodeLoc(t, repo.upserted.LocationPreferences)
@@ -135,7 +135,7 @@ func TestSave_NormalizesLocationCountriesAndCities(t *testing.T) {
 			Cities: []string{" Berlin ", "berlin ", "", "Lisbon"},
 		},
 	}
-	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, loc); err != nil {
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, nil, loc); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	got := decodeLoc(t, repo.upserted.LocationPreferences)

--- a/internal/userprofile/userprofile_test.go
+++ b/internal/userprofile/userprofile_test.go
@@ -16,6 +16,7 @@ type upsertArgs struct {
 	UserID              int64
 	Specializations     []string
 	Skills              []string
+	ExcludedSkills      []string
 	LocationPreferences json.RawMessage
 }
 
@@ -41,8 +42,8 @@ func (f *fakeRepo) Get(_ context.Context, userID int64) (userprofile.Profile, er
 	return f.getRet, f.getErr
 }
 
-func (f *fakeRepo) Upsert(_ context.Context, userID int64, specializations, skills []string, locationPreferences json.RawMessage) (userprofile.Profile, error) {
-	f.upserted = upsertArgs{UserID: userID, Specializations: specializations, Skills: skills, LocationPreferences: locationPreferences}
+func (f *fakeRepo) Upsert(_ context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage) (userprofile.Profile, error) {
+	f.upserted = upsertArgs{UserID: userID, Specializations: specializations, Skills: skills, ExcludedSkills: excludedSkills, LocationPreferences: locationPreferences}
 	f.upsertCalled = true
 	return f.upsertRet, f.upsertErr
 }
@@ -57,7 +58,7 @@ func TestSave_UpsertsWithOwnerNormalizedSpecializationsAndSkills(t *testing.T) {
 	svc := userprofile.New(repo)
 
 	_, err := svc.Save(context.Background(), 7,
-		[]string{" backend ", "devops", "backend"}, []string{"Go", " PostgreSQL ", "go"}, nil)
+		[]string{" backend ", "devops", "backend"}, []string{"Go", " PostgreSQL ", "go"}, nil, nil)
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestSave_UpsertsWithOwnerNormalizedSpecializationsAndSkills(t *testing.T) {
 
 func TestSave_RejectsUnknownSpecialization(t *testing.T) {
 	repo := &fakeRepo{}
-	_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend", "wizardry"}, []string{"go"}, nil)
+	_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend", "wizardry"}, []string{"go"}, nil, nil)
 	if !errors.Is(err, userprofile.ErrInvalidSpecialization) {
 		t.Errorf("err = %v, want ErrInvalidSpecialization", err)
 	}
@@ -100,7 +101,7 @@ func TestSave_RejectsEmptySpecializations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &fakeRepo{}
-			_, err := userprofile.New(repo).Save(context.Background(), 7, tc.in, []string{"go"}, nil)
+			_, err := userprofile.New(repo).Save(context.Background(), 7, tc.in, []string{"go"}, nil, nil)
 			if !errors.Is(err, userprofile.ErrEmptySpecializations) {
 				t.Errorf("err = %v, want ErrEmptySpecializations", err)
 			}
@@ -114,7 +115,7 @@ func TestSave_RejectsEmptySpecializations(t *testing.T) {
 func TestSave_RejectsTooManySpecializations(t *testing.T) {
 	repo := &fakeRepo{}
 	six := []string{"backend", "frontend", "fullstack", "mobile", "devops", "sre"}
-	_, err := userprofile.New(repo).Save(context.Background(), 7, six, []string{"go"}, nil)
+	_, err := userprofile.New(repo).Save(context.Background(), 7, six, []string{"go"}, nil, nil)
 	if !errors.Is(err, userprofile.ErrTooManySpecializations) {
 		t.Errorf("err = %v, want ErrTooManySpecializations", err)
 	}
@@ -135,7 +136,7 @@ func TestSave_RejectsEmptySkills(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &fakeRepo{}
-			_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, tc.in, nil)
+			_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, tc.in, nil, nil)
 			if !errors.Is(err, userprofile.ErrEmptySkills) {
 				t.Errorf("err = %v, want ErrEmptySkills", err)
 			}
@@ -143,6 +144,48 @@ func TestSave_RejectsEmptySkills(t *testing.T) {
 				t.Error("repo.Upsert should not be called on empty skills")
 			}
 		})
+	}
+}
+
+func TestSave_NormalizesExcludedSkills(t *testing.T) {
+	repo := &fakeRepo{upsertRet: userprofile.Profile{UserID: 7}}
+	_, err := userprofile.New(repo).Save(context.Background(), 7,
+		[]string{"backend"}, []string{"go"}, []string{" PHP ", "php", "WordPress"}, nil)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	want := []string{"php", "wordpress"}
+	if strings.Join(repo.upserted.ExcludedSkills, ",") != strings.Join(want, ",") {
+		t.Errorf("ExcludedSkills = %v, want lowercased/trimmed/deduped %v", repo.upserted.ExcludedSkills, want)
+	}
+}
+
+func TestSave_DropsExcludedSkillAlsoInSkills(t *testing.T) {
+	repo := &fakeRepo{upsertRet: userprofile.Profile{UserID: 7}}
+	_, err := userprofile.New(repo).Save(context.Background(), 7,
+		[]string{"backend"}, []string{"Go", "php"}, []string{"go", "wordpress"}, nil)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// "go" is wanted, so it is dropped from the excluded set; "wordpress" survives.
+	want := []string{"wordpress"}
+	if strings.Join(repo.upserted.ExcludedSkills, ",") != strings.Join(want, ",") {
+		t.Errorf("ExcludedSkills = %v, want %v (wanted skill dropped)", repo.upserted.ExcludedSkills, want)
+	}
+}
+
+func TestSave_EmptyExcludedSkillsStoresEmptySet(t *testing.T) {
+	repo := &fakeRepo{upsertRet: userprofile.Profile{UserID: 7}}
+	_, err := userprofile.New(repo).Save(context.Background(), 7,
+		[]string{"backend"}, []string{"go"}, nil, nil)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if repo.upserted.ExcludedSkills == nil {
+		t.Error("ExcludedSkills = nil, want non-nil empty set (persists as '{}', not NULL)")
+	}
+	if len(repo.upserted.ExcludedSkills) != 0 {
+		t.Errorf("ExcludedSkills = %v, want empty", repo.upserted.ExcludedSkills)
 	}
 }
 

--- a/migrations/0039_user_profile_excluded_skills.sql
+++ b/migrations/0039_user_profile_excluded_skills.sql
@@ -1,0 +1,13 @@
+-- Add an optional "skills to avoid" set to the single user profile. Empty by default
+-- (unlike skills, which has a cardinality CHECK): a user need not exclude anything.
+-- Stored as canonical lowercase tokens, trimmed and deduplicated by internal/userprofile,
+-- and — on the frontend — seeded into the jobs filter's skills EXCLUDE set by "Apply my
+-- profile" (rendering ?skills_exclude=… → Meili skills != "X").
+--
+-- APPLY TO PROD MANUALLY BEFORE DEPLOY: initdb runs migrations only on first volume
+-- init, so on a persistent volume this ALTER does not auto-apply. The new binary's
+-- GetUserProfile/UpsertUserProfile SELECT/RETURN excluded_skills, so deploying before
+-- running this ALTER makes every profile read and write fail with 42703 (undefined
+-- column) → 500. Run it first (same as 0005-0010).
+ALTER TABLE public.user_profiles
+    ADD COLUMN excluded_skills text[] NOT NULL DEFAULT '{}'::text[];

--- a/openspec/changes/add-profile-excluded-skills/.openspec.yaml
+++ b/openspec/changes/add-profile-excluded-skills/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/add-profile-excluded-skills/design.md
+++ b/openspec/changes/add-profile-excluded-skills/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The user profile (`user_profiles`, one row per user) already stores `skills`,
+`specializations`, and `location_preferences`. The jobs filter already supports
+excluding facet values end-to-end: `FacetState` holds separate `include`/`exclude`
+sets, `filtersToParams` serializes excludes as `?<param>_exclude=…`, and the Meili
+filter builder (`internal/search/query_filter.go`) turns them into `skills != "X"`.
+The **Apply my profile** action (`filtersFromProfile` in `web/src/lib/facetModel.ts`)
+seeds only the *include* side today.
+
+The gap is a place to record which skills a user wants to avoid, and one line of
+seeding to push them into the existing exclude machinery. Nothing in the search
+layer changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persist an optional `excluded_skills` set on the profile, normalized exactly like
+  `skills` (canonical lowercase, trimmed, deduplicated), empty allowed.
+- Guarantee the wanted and excluded sets never overlap (a skill in both is dropped
+  from excluded), so a committed filter never emits contradictory `skills = X AND
+  skills != X`.
+- Make **Apply my profile** seed excluded skills into the `skills` facet's exclude
+  set.
+- Let the user edit excluded skills in the profile form via a dictionary-constrained
+  control mirroring the wanted-skills control.
+
+**Non-Goals:**
+- Feeding excluded skills into AI match analysis or the résumé verdict (future seam).
+- Any change to the search/filter/exclude serialization or Meili filter builder.
+- Excluding by category, company, or any facet other than `skills`.
+
+## Decisions
+
+**1. Store on `user_profiles`, not a new table.** `excluded_skills` is one-per-user,
+same lifecycle as `skills`; a `text[]` column mirrors the existing shape. Alternative
+(separate table) adds joins and lifecycle for zero benefit.
+
+- Migration: `ALTER TABLE user_profiles ADD COLUMN excluded_skills text[] NOT NULL
+  DEFAULT '{}'::text[];` — no cardinality CHECK (empty is valid, unlike `skills`).
+  Standalone migration file; **applied manually to prod before deploy** (Postgres
+  initdb only runs migrations on first volume init — the 0010 precedent).
+
+**2. Overlap resolved by silent subtraction, wanted wins.** On save, after both sets
+are normalized, `excluded_skills := excluded_skills \ skills`. Rationale: include and
+exclude land in the *same* `skills` facet; overlap would self-cancel the filter. A
+user who lists a skill as both wanted and avoided most likely means to keep it — and a
+silent fix is friendlier than a 400 for a non-destructive conflict. Alternative
+(reject with 400) was considered and rejected as user-hostile for a resolvable case.
+
+**3. Normalization reuses the `skills` shape, but empty is allowed.** A dedicated
+`normalizeExcludedSkills` mirrors `normalizeSkills` (trim/lower/dedup) minus the
+non-empty requirement, keeping the two rules independent so future divergence is cheap.
+
+**4. Seed on the existing `skills` facet.** In `filtersFromProfile`, after seeding the
+include side from `profile.skills`, seed the exclude side from `profile.excluded_skills`
+on the same `skills` facet (via the existing `facetSetSign(..., 'exclude')` /
+exclude-set path). No new facet, no URL-format change.
+
+**5. UI: a separate dictionary-constrained control.** The profile form gains a "Skills
+to avoid" control that reuses the same canonical-skill typeahead source as the wanted
+skills, so every excluded value matches a real `skills` facet token (a free-text value
+could silently match nothing). The two controls exclude each other's current selections
+from their own options to keep the sets visually disjoint; the backend subtraction is
+the authoritative guarantee.
+
+## Risks / Trade-offs
+
+- **[Prod migration not auto-applied]** → The `ALTER TABLE` must be run manually on
+  prod before the deploy that reads the column, per the 0010 header convention; note it
+  in the migration file and the finish step.
+- **[UI dictionary constraint frustrates power users]** → Excluded skills are limited
+  to known skill tags. This is intentional (free text wouldn't filter anything) and
+  matches the existing wanted-skills control; acceptable.
+- **[Stale profiles pre-migration]** → Existing rows get the `DEFAULT '{}'`, so fetch
+  returns an empty set and Apply-my-profile seeds no excludes — safe, no backfill.
+
+## Migration Plan
+
+1. Ship migration file; apply the `ALTER TABLE` manually on prod before deploying the
+   backend that references `excluded_skills`.
+2. Deploy backend (tolerates empty set for all existing profiles).
+3. Deploy frontend.
+
+Rollback: the column is additive and defaulted; reverting the app code leaves the
+column unused and harmless. Drop the column only if fully abandoning the feature.
+
+## Open Questions
+
+None — the overlap rule (silent subtraction, wanted wins) is settled per brainstorming.

--- a/openspec/changes/add-profile-excluded-skills/proposal.md
+++ b/openspec/changes/add-profile-excluded-skills/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Users can list the skills they *want*, but not the technologies they want to
+avoid. A user who never wants PHP work has to exclude it by hand in the filter
+every time. Letting the profile carry an "excluded skills" list — and having
+**Apply my profile** seed those as negative filters — removes that repeated
+manual step and makes the profile a truer statement of what the user wants.
+
+## What Changes
+
+- Add an optional `excluded_skills` list to the user profile (stored alongside
+  the existing `skills` / `specializations` / `location_preferences`). Empty by
+  default; canonical lowercase skill tokens, trimmed and deduplicated like
+  `skills`.
+- On save, drop any excluded skill that also appears in `skills` — a skill
+  cannot be both wanted and avoided; the wanted set wins (silent subtraction,
+  no error).
+- Extend the **Apply my profile** action so each excluded skill is seeded into
+  the `skills` facet's **exclude** set (rendering `?skills_exclude=…` →
+  Meili `skills != "X"`). The search/filter/exclude machinery already exists
+  end-to-end; only the profile-to-filter seeding is new.
+- Profile form gains a "Skills to avoid" input mirroring the existing "Skills"
+  typeahead (dictionary-constrained to known skill tags).
+
+No breaking changes: `excluded_skills` is additive and optional; existing
+profiles and API clients are unaffected.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `search-profiles`: the profile entity gains an optional `excluded_skills`
+  set with its own normalization rule (canonicalized like `skills`, and
+  subtracted against `skills` so the two sets never overlap).
+- `filter-modal`: the **Apply my profile** action additionally seeds each
+  profile excluded skill into the `skills` facet's exclude set.
+
+## Impact
+
+- **Database:** new `user_profiles.excluded_skills text[] NOT NULL DEFAULT '{}'`
+  column (standalone migration; manual apply on prod before deploy, per the
+  0010 precedent).
+- **Backend:** `internal/db/queries/user_profiles.sql` (+ sqlc regen),
+  `internal/userprofile` (Profile struct, normalization, repository),
+  `internal/handler/me_profile.go` (request/response).
+- **Frontend:** `web/src/lib/types.ts` (`UserProfile`), `web/src/lib/api.ts`
+  (`saveProfile`), `web/src/lib/profile.svelte.ts`, `web/src/lib/facetModel.ts`
+  (`filtersFromProfile`), `web/src/lib/components/ProfileForm.svelte`.
+- **Out of scope:** match analysis / résumé verdict do not yet consume excluded
+  skills (noted as a future seam).

--- a/openspec/changes/add-profile-excluded-skills/specs/filter-modal/spec.md
+++ b/openspec/changes/add-profile-excluded-skills/specs/filter-modal/spec.md
@@ -1,0 +1,69 @@
+# filter-modal Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: The filter modal can apply the signed-in user's profile
+
+The jobs filter modal SHALL offer, in its header, an **Apply my profile** action for a
+signed-in user who has a saved profile. Activating it SHALL reset the staged filters and
+then seed them from the user's profile: each profile specialization SHALL be staged as a
+`category` value and each profile skill SHALL be staged as an included `skills` value.
+Each profile excluded skill SHALL be staged as an **excluded** `skills` value (into the
+`skills` facet's exclude set, so it commits as `?skills_exclude=…`). When the
+profile carries a `location_preferences` block, the action SHALL additionally seed the
+location facets by flattening the three blocks: `work_mode` from `work_modes`; `regions`
+from the union of `remote.regions` and `relocation.regions`; `countries` from the union of
+`remote.countries`, `base.country`, and `relocation.countries`; `cities` from the union of
+`base.city` and `relocation.cities`; and `relocation` staged as `supported` and `required`
+when `relocation.open` is true. Empty or absent parts contribute nothing. The action
+SHALL only stage — it SHALL NOT change the live job list; the seeded selection is applied
+through the existing **Show results** commit, so the user previews (and MAY adjust) the
+profile-derived filters before applying.
+
+The action SHALL appear only on the full jobs filter modal (not on reuses that restrict
+the rail to a facet subset, such as the profile-comparison modal). When the signed-in
+user has no saved profile, the header SHALL instead present a link to create one at
+`/my/profile`. When no user is signed in, neither the action nor the link SHALL appear.
+
+#### Scenario: Applying the profile resets and seeds the staged filters
+- **WHEN** a signed-in user with a saved profile (specializations `A`, `B`; skills `x`,
+  `y`) has some unrelated staged filters and activates **Apply my profile**
+- **THEN** the previously staged filters are cleared, the `category` facet is staged with
+  `A` and `B`, the `skills` facet is staged with `x` and `y`, and the job list is
+  unchanged until **Show results** is activated
+
+#### Scenario: Applying a profile with excluded skills seeds the skills exclude set
+- **WHEN** a signed-in user whose profile has skills `[go]` and excluded skills `[php]`
+  activates **Apply my profile**
+- **THEN** the `skills` facet is staged with `go` included and `php` excluded, and on
+  **Show results** the committed filter carries `?skills=go` and `?skills_exclude=php`
+
+#### Scenario: Applying a profile with location preferences seeds the location facets
+- **WHEN** a signed-in user whose profile has `work_modes` `[remote, onsite]`,
+  `remote.regions` `[latam]`, `base` `{country: br, city: "Florianópolis"}`, and
+  `relocation` `{open: true, cities: ["Berlin"]}` activates **Apply my profile**
+- **THEN** the staged filters include `work_mode` `[remote, onsite]`, `regions` `[latam]`,
+  `countries` `[br]`, `cities` `["Florianópolis", "Berlin"]`, and `relocation`
+  `[supported, required]`, and the job list is unchanged until **Show results** is activated
+
+#### Scenario: Applying a profile without location preferences seeds no location facets
+- **WHEN** a signed-in user whose profile has no `location_preferences` block activates
+  **Apply my profile**
+- **THEN** only the `category` and `skills` facets are staged and the location facets
+  (`work_mode`, `regions`, `countries`, `cities`, `relocation`) remain empty
+
+#### Scenario: Show results commits the profile-derived filters
+- **WHEN** the user has applied their profile in the modal and then activates **Show
+  results**
+- **THEN** the staged selections become the live (URL-synced) filter state and the modal
+  closes
+
+#### Scenario: No profile shows a create-profile link instead
+- **WHEN** a signed-in user who has no saved profile opens the jobs filter modal
+- **THEN** the header shows a link to create a profile at `/my/profile` and no
+  **Apply my profile** action
+
+#### Scenario: Signed-out users see neither action nor link
+- **WHEN** a signed-out user opens the jobs filter modal
+- **THEN** the header shows neither the **Apply my profile** action nor the
+  create-profile link

--- a/openspec/changes/add-profile-excluded-skills/specs/search-profiles/spec.md
+++ b/openspec/changes/add-profile-excluded-skills/specs/search-profiles/spec.md
@@ -1,0 +1,88 @@
+# search-profiles Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Retrieve the profile
+
+A signed-in user SHALL be able to fetch their single profile via
+`GET /api/v1/me/profile`. When the user has saved a profile the system responds
+`200` with `{"data": {specializations, skills, excluded_skills, location_preferences, created_at, updated_at}}`,
+where `excluded_skills` is the saved set (an empty array when the user set none) and
+`location_preferences` is the saved block or `null` when the user set none; when
+the user has no profile yet it responds `200` with `{"data": null}`.
+
+#### Scenario: Fetch an existing profile
+- **WHEN** an authenticated user who has a saved profile sends `GET /api/v1/me/profile`
+- **THEN** the system responds `200` with `{"data": {...}}` containing that user's `specializations`, `skills`, `excluded_skills` (the saved set or an empty array), `location_preferences` (the saved block or `null`), and timestamps
+
+#### Scenario: Fetch when no profile exists
+- **WHEN** an authenticated user who has never saved a profile sends `GET /api/v1/me/profile`
+- **THEN** the system responds `200` with `{"data": null}`
+
+### Requirement: Save the profile
+
+A signed-in user SHALL be able to create-or-replace their single profile via
+`PUT /api/v1/me/profile` with a non-empty set of `specializations` (job
+categories), a non-empty set of `skills`, an optional set of `excluded_skills`,
+and an optional `location_preferences` block. The write is an upsert keyed by the
+calling user: it creates the profile if none exists and overwrites it otherwise.
+All skill sets are stored trimmed and deduplicated as canonical lowercase tokens;
+`excluded_skills` MAY be empty and defaults to empty when omitted; the location
+block is validated and normalized per the Location & work-mode preferences
+requirement, or stored as absent when omitted. Any skill that appears in both
+`skills` and `excluded_skills` after normalization SHALL be dropped from
+`excluded_skills` — a skill cannot be both wanted and avoided, and the wanted set
+wins (no error is raised). The system does NOT create an empty profile — a profile
+exists only once saved with valid content.
+
+#### Scenario: Create the profile on first save
+- **WHEN** an authenticated user with no profile sends `PUT /api/v1/me/profile` with a non-empty `specializations` array drawn from the category vocabulary and a non-empty `skills` array
+- **THEN** the system stores the profile for that user and responds `200` with `{"data": {specializations, skills, excluded_skills, location_preferences, updated_at}}`
+
+#### Scenario: Overwrite an existing profile
+- **WHEN** an authenticated user who already has a profile sends `PUT /api/v1/me/profile` with new valid `specializations`, `skills`, `excluded_skills`, and `location_preferences`
+- **THEN** the system replaces the stored values (including the excluded-skills set and the location block), bumps `updated_at`, and responds `200`
+
+#### Scenario: Specializations are deduplicated
+- **WHEN** an authenticated user saves a profile whose `specializations` contain duplicate categories
+- **THEN** the system stores each category once, preserving first-seen order
+
+#### Scenario: Skills are normalized
+- **WHEN** an authenticated user saves a profile with skills containing mixed case, surrounding whitespace, or duplicates
+- **THEN** the system stores each skill lowercased, trimmed, and deduplicated
+
+#### Scenario: Excluded skills are normalized
+- **WHEN** an authenticated user saves a profile with `excluded_skills` containing mixed case, surrounding whitespace, or duplicates
+- **THEN** the system stores each excluded skill lowercased, trimmed, and deduplicated
+
+#### Scenario: A skill present in both sets is dropped from excluded skills
+- **WHEN** an authenticated user saves a profile whose `skills` contain `go` and whose `excluded_skills` contain `go` and `php`
+- **THEN** the system stores `excluded_skills` as `[php]` (the overlapping `go` is dropped) and the save succeeds
+
+#### Scenario: Excluded skills may be empty
+- **WHEN** an authenticated user saves a profile with valid `specializations` and `skills` and no `excluded_skills`
+- **THEN** the system stores an empty `excluded_skills` set and the save succeeds
+
+## ADDED Requirements
+
+### Requirement: Edit excluded skills in the profile UI
+
+The profile edit UI SHALL present a "skills to avoid" control, separate from the
+wanted-skills control, that lets a signed-in user add and remove excluded skills.
+The control SHALL be dictionary-constrained to canonical skill tokens (the same
+skill vocabulary the wanted-skills control uses), so every excluded value matches
+a real `skills` facet value. Excluded skills SHALL be optional — an empty set is
+valid and does not affect the Save control's enabled state. The control SHALL be
+pre-seeded with the user's currently saved excluded skills when editing.
+
+#### Scenario: Add an excluded skill and save
+- **WHEN** a signed-in user opens the profile editor, adds `php` to the "skills to avoid" control, and saves
+- **THEN** the app calls `PUT /api/v1/me/profile` with `php` in `excluded_skills` and the saved profile reflects it
+
+#### Scenario: Excluded skills are pre-seeded when editing
+- **WHEN** a signed-in user who has saved excluded skills `[php]` reopens the profile editor
+- **THEN** the "skills to avoid" control is pre-seeded with `php`
+
+#### Scenario: Excluded skills do not gate saving
+- **WHEN** a signed-in user has at least one specialization and one skill but no excluded skills
+- **THEN** the Save control is enabled

--- a/openspec/changes/add-profile-excluded-skills/tasks.md
+++ b/openspec/changes/add-profile-excluded-skills/tasks.md
@@ -1,36 +1,36 @@
 ## 1. Database & sqlc
 
-- [ ] 1.1 Add migration `migrations/00NN_user_profile_excluded_skills.sql`: `ALTER TABLE user_profiles ADD COLUMN excluded_skills text[] NOT NULL DEFAULT '{}'::text[];` with the standard header noting manual prod apply (mirror `0010_user_profile_location.sql`).
-- [ ] 1.2 Add `excluded_skills` to the `UpsertUserProfile` INSERT columns/values in `internal/db/queries/user_profiles.sql` (SELECT `*` already picks it up for GET).
-- [ ] 1.3 Regenerate sqlc (`make sqlc`) and confirm `UpsertUserProfileParams` and the `UserProfile` model gain `ExcludedSkills`.
+- [x] 1.1 Add migration `migrations/0039_user_profile_excluded_skills.sql`: `ALTER TABLE user_profiles ADD COLUMN excluded_skills text[] NOT NULL DEFAULT '{}'::text[];` with the standard header noting manual prod apply (mirror `0010_user_profile_location.sql`).
+- [x] 1.2 Add `excluded_skills` to the `UpsertUserProfile` INSERT columns/values in `internal/db/queries/user_profiles.sql` (SELECT `*` already picks it up for GET).
+- [x] 1.3 Regenerate sqlc (`make sqlc`) and confirm `UpsertUserProfileParams` and the `UserProfile` model gain `ExcludedSkills`.
 
 ## 2. Backend domain — userprofile (TDD)
 
-- [ ] 2.1 RED: add a test for `normalizeExcludedSkills` (trim/lower/dedup, empty allowed) in `internal/userprofile`; write the normalizer to green.
-- [ ] 2.2 RED: add a `Service.Save` test asserting the overlap rule — a skill present in both `skills` and `excluded_skills` is dropped from `excluded_skills` (wanted wins), empty excluded set is valid. GREEN: implement the subtraction in `Save`.
-- [ ] 2.3 Add `ExcludedSkills []string` to the `Profile` struct and thread it through the `Repository.Upsert` signature.
-- [ ] 2.4 Map `ExcludedSkills` in `QueriesRepository.Upsert` (→ sqlc params) and in `profileFromRow` (`internal/userprofile/repository.go`).
+- [x] 2.1 RED: add a test for `normalizeExcludedSkills` (trim/lower/dedup, empty allowed) in `internal/userprofile`; write the normalizer to green.
+- [x] 2.2 RED: add a `Service.Save` test asserting the overlap rule — a skill present in both `skills` and `excluded_skills` is dropped from `excluded_skills` (wanted wins), empty excluded set is valid. GREEN: implement the subtraction in `Save`.
+- [x] 2.3 Add `ExcludedSkills []string` to the `Profile` struct and thread it through the `Repository.Upsert` signature.
+- [x] 2.4 Map `ExcludedSkills` in `QueriesRepository.Upsert` (→ sqlc params) and in `profileFromRow` (`internal/userprofile/repository.go`).
 
 ## 3. Backend handler — me_profile
 
-- [ ] 3.1 Add `ExcludedSkills` to `profileResponse` + `toProfileResponse` and to `saveProfileRequest`, and pass it into `Service.Save` (`internal/handler/me_profile.go`). Response key `excluded_skills`.
-- [ ] 3.2 Add/extend a handler-level test (or integration test) covering PUT-then-GET round-trip of `excluded_skills`, including the overlap-drop case.
+- [x] 3.1 Add `ExcludedSkills` to `profileResponse` + `toProfileResponse` and to `saveProfileRequest`, and pass it into `Service.Save` (`internal/handler/me_profile.go`). Response key `excluded_skills`.
+- [x] 3.2 Add/extend a handler-level test (or integration test) covering PUT-then-GET round-trip of `excluded_skills`, including the overlap-drop case.
 
 ## 4. Frontend — types & API
 
-- [ ] 4.1 Add `excluded_skills: string[]` to `UserProfile` in `web/src/lib/types.ts`.
-- [ ] 4.2 Include `excluded_skills` in the `saveProfile` PUT body in `web/src/lib/api.ts`, and thread it through `ProfileStore.save(...)` in `web/src/lib/profile.svelte.ts`.
+- [x] 4.1 Add `excluded_skills: string[]` to `UserProfile` in `web/src/lib/types.ts`.
+- [x] 4.2 Include `excluded_skills` in the `saveProfile` PUT body in `web/src/lib/api.ts`, and thread it through `ProfileStore.save(...)` in `web/src/lib/profile.svelte.ts`.
 
 ## 5. Frontend — apply-profile seeding (TDD)
 
-- [ ] 5.1 RED: add a vitest for `filtersFromProfile` asserting `profile.excluded_skills` seeds the `skills` facet's `exclude` set (and `filtersToParams` emits `skills_exclude=…`). GREEN: seed the exclude side in `filtersFromProfile` (`web/src/lib/facetModel.ts`).
+- [x] 5.1 RED: add a vitest for `filtersFromProfile` asserting `profile.excluded_skills` seeds the `skills` facet's `exclude` set (and `filtersToParams` emits `skills_exclude=…`). GREEN: seed the exclude side in `filtersFromProfile` (`web/src/lib/facetModel.ts`).
 
 ## 6. Frontend — profile form UI
 
-- [ ] 6.1 Add a "Skills to avoid" control to `web/src/lib/components/ProfileForm.svelte` mirroring the existing skills control (same canonical-skill typeahead source): `excludedSkills` state, toggle handler, pre-seed from the loaded profile, and include it in the `submit()` save call. Exclude each control's current selections from the other's options.
-- [ ] 6.2 Visual-verify the profile form (throwaway route + headless Chrome per repo convention): add/remove an excluded skill, save, reload, confirm persistence.
+- [x] 6.1 Add a "Skills to avoid" control to `web/src/lib/components/ProfileForm.svelte` mirroring the existing skills control (same canonical-skill typeahead source): `excludedSkills` state, toggle handler, pre-seed from the loaded profile, and include it in the `submit()` save call. Exclude each control's current selections from the other's options.
+- [ ] 6.2 Visual-verify the profile form (throwaway route + headless Chrome per repo convention): add/remove an excluded skill, save, reload, confirm persistence. _(Deferred to manual QA — requires the running stack; the field wiring is type-checked and the production build passes.)_
 
 ## 7. Verify
 
-- [ ] 7.1 `go build ./... && go vet ./... && go test ./...` green; web `svelte-check` + vitest green.
-- [ ] 7.2 End-to-end: save a profile with an excluded skill, open the jobs filter, click **Apply my profile**, and confirm the excluded skill lands in the `skills` exclude set and the committed URL carries `?skills_exclude=…`.
+- [x] 7.1 `go build ./... && go vet ./... && go test ./...` green; web `svelte-check` + vitest green.
+- [ ] 7.2 End-to-end: save a profile with an excluded skill, open the jobs filter, click **Apply my profile**, and confirm the excluded skill lands in the `skills` exclude set and the committed URL carries `?skills_exclude=…`. _(Deferred to manual QA — requires the running stack; the exact `skills_exclude` param is already asserted by `profileFilters.test.ts` and the PUT/round-trip by the handler test.)_

--- a/openspec/changes/add-profile-excluded-skills/tasks.md
+++ b/openspec/changes/add-profile-excluded-skills/tasks.md
@@ -1,0 +1,36 @@
+## 1. Database & sqlc
+
+- [ ] 1.1 Add migration `migrations/00NN_user_profile_excluded_skills.sql`: `ALTER TABLE user_profiles ADD COLUMN excluded_skills text[] NOT NULL DEFAULT '{}'::text[];` with the standard header noting manual prod apply (mirror `0010_user_profile_location.sql`).
+- [ ] 1.2 Add `excluded_skills` to the `UpsertUserProfile` INSERT columns/values in `internal/db/queries/user_profiles.sql` (SELECT `*` already picks it up for GET).
+- [ ] 1.3 Regenerate sqlc (`make sqlc`) and confirm `UpsertUserProfileParams` and the `UserProfile` model gain `ExcludedSkills`.
+
+## 2. Backend domain — userprofile (TDD)
+
+- [ ] 2.1 RED: add a test for `normalizeExcludedSkills` (trim/lower/dedup, empty allowed) in `internal/userprofile`; write the normalizer to green.
+- [ ] 2.2 RED: add a `Service.Save` test asserting the overlap rule — a skill present in both `skills` and `excluded_skills` is dropped from `excluded_skills` (wanted wins), empty excluded set is valid. GREEN: implement the subtraction in `Save`.
+- [ ] 2.3 Add `ExcludedSkills []string` to the `Profile` struct and thread it through the `Repository.Upsert` signature.
+- [ ] 2.4 Map `ExcludedSkills` in `QueriesRepository.Upsert` (→ sqlc params) and in `profileFromRow` (`internal/userprofile/repository.go`).
+
+## 3. Backend handler — me_profile
+
+- [ ] 3.1 Add `ExcludedSkills` to `profileResponse` + `toProfileResponse` and to `saveProfileRequest`, and pass it into `Service.Save` (`internal/handler/me_profile.go`). Response key `excluded_skills`.
+- [ ] 3.2 Add/extend a handler-level test (or integration test) covering PUT-then-GET round-trip of `excluded_skills`, including the overlap-drop case.
+
+## 4. Frontend — types & API
+
+- [ ] 4.1 Add `excluded_skills: string[]` to `UserProfile` in `web/src/lib/types.ts`.
+- [ ] 4.2 Include `excluded_skills` in the `saveProfile` PUT body in `web/src/lib/api.ts`, and thread it through `ProfileStore.save(...)` in `web/src/lib/profile.svelte.ts`.
+
+## 5. Frontend — apply-profile seeding (TDD)
+
+- [ ] 5.1 RED: add a vitest for `filtersFromProfile` asserting `profile.excluded_skills` seeds the `skills` facet's `exclude` set (and `filtersToParams` emits `skills_exclude=…`). GREEN: seed the exclude side in `filtersFromProfile` (`web/src/lib/facetModel.ts`).
+
+## 6. Frontend — profile form UI
+
+- [ ] 6.1 Add a "Skills to avoid" control to `web/src/lib/components/ProfileForm.svelte` mirroring the existing skills control (same canonical-skill typeahead source): `excludedSkills` state, toggle handler, pre-seed from the loaded profile, and include it in the `submit()` save call. Exclude each control's current selections from the other's options.
+- [ ] 6.2 Visual-verify the profile form (throwaway route + headless Chrome per repo convention): add/remove an excluded skill, save, reload, confirm persistence.
+
+## 7. Verify
+
+- [ ] 7.1 `go build ./... && go vet ./... && go test ./...` green; web `svelte-check` + vitest green.
+- [ ] 7.2 End-to-end: save a profile with an excluded skill, open the jobs filter, click **Apply my profile**, and confirm the excluded skill lands in the `skills` exclude set and the committed URL carries `?skills_exclude=…`.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -811,17 +811,23 @@ export function createApi(
   }
 
   /** Create-or-replace the user's profile from a non-empty set of specializations (job
-   *  categories), a non-empty set of skills, and an optional location-preferences block
-   *  (null clears it). A bad specialization, empty skills, or an out-of-vocabulary location
-   *  value is a 400. */
+   *  categories), a non-empty set of skills, an optional set of excluded skills (skills to
+   *  avoid; may be empty), and an optional location-preferences block (null clears it). A
+   *  bad specialization, empty skills, or an out-of-vocabulary location value is a 400. */
   async function saveProfile(
     specializations: string[],
     skills: string[],
+    excludedSkills: string[],
     location: LocationPreferences | null,
   ): Promise<UserProfile> {
     return requestData<UserProfile>(
       '/api/v1/me/profile',
-      jsonBody('PUT', { specializations, skills, location_preferences: location }),
+      jsonBody('PUT', {
+        specializations,
+        skills,
+        excluded_skills: excludedSkills,
+        location_preferences: location,
+      }),
     );
   }
 

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -154,6 +154,16 @@
     showReport = true;
   }
 
+  // The discussion is members-only: a signed-out click is held back (the link
+  // does not navigate) and the sign-in dialog opens instead. The href stays put
+  // so the route is still SSR-linkable for signed-in visitors.
+  function onDiscussionClick(e: MouseEvent) {
+    if (!isAuthenticated()) {
+      e.preventDefault();
+      openAuthDialog('login');
+    }
+  }
+
   // The toggle flips on the server's answer, not optimistically: both endpoints
   // return the full interaction, so the button can never drift from the truth.
   async function toggleSave() {
@@ -230,8 +240,9 @@
     <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
 
     <a
-      class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      class="inline-flex items-center gap-1.5 self-end text-sm font-medium text-primary hover:underline"
       href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
+      onclick={onDiscussionClick}
     >
       <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
         ? ` · ${threadCount}`

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -43,6 +43,11 @@
   let specializations = $state.raw<string[]>(profile ? [...profile.specializations] : []);
   // svelte-ignore state_referenced_locally
   let skills = $state.raw<string[]>(profile ? [...profile.skills] : []);
+  // Skills to avoid — seeded into the jobs filter's skills EXCLUDE set by "Apply my
+  // profile". Optional (an empty set is valid), kept disjoint from `skills` (a skill can't
+  // be both wanted and avoided — the server enforces this too, dropping any overlap).
+  // svelte-ignore state_referenced_locally
+  let excludedSkills = $state.raw<string[]>(profile ? [...(profile.excluded_skills ?? [])] : []);
   let formError = $state<string | null>(null);
   let busy = $state(false);
   // Which form section is shown — the profile is long, so split it into two tabs sharing
@@ -90,12 +95,18 @@
 
   // The skills typeahead: filter the loaded distribution locally (dictionary-only, so
   // only known skills are addable). With no query, show just the popular top few; typing
-  // widens to the full match list — so the field is not a wall of skills on open.
-  function searchSkills(query: string): Promise<FacetOption[]> {
+  // widens to the full match list — so the field is not a wall of skills on open. `avoid`
+  // hides tokens already picked in the other skills control, keeping wanted and excluded
+  // disjoint.
+  function searchSkillsExcept(query: string, avoid: string[]): Promise<FacetOption[]> {
     const q = query.trim().toLowerCase();
-    const matches = q ? skillDist.filter((o) => o.label.toLowerCase().includes(q)) : skillDist;
+    const pool = skillDist.filter((o) => !avoid.includes(o.value));
+    const matches = q ? pool.filter((o) => o.label.toLowerCase().includes(q)) : pool;
     return Promise.resolve(matches.slice(0, q ? 50 : 8));
   }
+
+  const searchSkills = (query: string) => searchSkillsExcept(query, excludedSkills);
+  const searchExcludedSkills = (query: string) => searchSkillsExcept(query, skills);
 
   async function loadSkills() {
     try {
@@ -203,6 +214,12 @@
     skills = skills.includes(value) ? skills.filter((s) => s !== value) : [...skills, value];
   }
 
+  function toggleExcludedSkill(value: string) {
+    excludedSkills = excludedSkills.includes(value)
+      ? excludedSkills.filter((s) => s !== value)
+      : [...excludedSkills, value];
+  }
+
   // Toggle a value in a multi-select list (work modes, regions, countries), returning a new
   // array so $state.raw readers re-run.
   function toggleIn(list: string[], value: string): string[] {
@@ -250,7 +267,7 @@
     busy = true;
     formError = null;
     try {
-      await profileStore.save(specializations, skills, buildLocation());
+      await profileStore.save(specializations, skills, excludedSkills, buildLocation());
       onSaved?.();
     } catch (err) {
       formError =
@@ -391,6 +408,26 @@
       fallbackLabel={(v) => v}
       clearOnSelect
     />
+  </div>
+
+  <!-- Skills to avoid — optional; seeded into the filter's skills exclude set by "Apply my
+       profile". Same dictionary source as Skills, kept disjoint from it. -->
+  <div class="flex flex-col gap-2">
+    <div class="flex items-baseline justify-between">
+      <span class="text-sm font-medium">Skills to avoid</span>
+      <span class="text-xs tabular-nums text-muted-foreground">{excludedSkills.length}</span>
+    </div>
+    <RemoteSearchSelect
+      search={searchExcludedSkills}
+      include={excludedSkills}
+      placeholder="Search skills to exclude"
+      onToggle={toggleExcludedSkill}
+      fallbackLabel={(v) => v}
+      clearOnSelect
+    />
+    <span class="text-xs text-muted-foreground">
+      Filtered out when you apply your profile to the job filters.
+    </span>
   </div>
 
   <!-- Role / specializations -->

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -192,8 +192,11 @@ export function facetRemove(st: FacetState, v: string): FacetState {
 }
 
 /** Build a fresh filter set seeded from a user profile — the reset-and-seed behind
- *  "Apply my profile". Specializations become `category` values and skills become `skills`.
- *  The optional location block flattens into the location facets: work_modes → `work_mode`;
+ *  "Apply my profile". Specializations become `category` values, skills become included
+ *  `skills` values, and excluded skills become EXCLUDED `skills` values (rendering
+ *  `skills_exclude=…` → `skills != "X"`). A skill that is somehow both wanted and avoided
+ *  stays wanted (include wins), mirroring the server's overlap rule so the two never
+ *  self-cancel. The optional location block flattens into the location facets: work_modes → `work_mode`;
  *  regions from the remote reach ∪ relocation targets; countries from the remote reach ∪
  *  base ∪ relocation targets; cities from the base ∪ relocation targets; and `relocation`
  *  staged as supported+required when the user is open to relocating. The flatten is lossy
@@ -203,7 +206,15 @@ export function filtersFromProfile(profile: UserProfile): JobFilters {
   const seed = (values: string[]) => values.reduce(facetAdd, emptyFacet());
   const f = emptyFilters();
   f.facets.category = seed(profile.specializations);
-  f.facets.skills = seed(profile.skills);
+  // Skills: wanted → include, avoided → exclude. Only stage an exclude for a token not
+  // already wanted (signOf === 'off'), so a stray overlap keeps the wanted value.
+  f.facets.skills = (profile.excluded_skills ?? []).reduce(
+    (st, raw) => {
+      const v = raw.trim();
+      return v && signOf(st, v) === 'off' ? facetSetSign(st, v, 'exclude') : st;
+    },
+    seed(profile.skills),
+  );
 
   const loc = profile.location_preferences;
   if (loc) {

--- a/web/src/lib/profile.svelte.ts
+++ b/web/src/lib/profile.svelte.ts
@@ -33,15 +33,17 @@ class ProfileStore extends UserResource<UserProfile | null> {
     this.#profile = null;
   }
 
-  /** Create-or-replace the profile. `location` is the optional location-preferences block
-   *  (null clears it). Throws on a bad specialization, empty skills, or an out-of-vocabulary
-   *  location value (the caller shows the error). */
+  /** Create-or-replace the profile. `excludedSkills` are the skills to avoid (may be empty).
+   *  `location` is the optional location-preferences block (null clears it). Throws on a bad
+   *  specialization, empty skills, or an out-of-vocabulary location value (the caller shows
+   *  the error). */
   async save(
     specializations: string[],
     skills: string[],
+    excludedSkills: string[],
     location: LocationPreferences | null,
   ): Promise<UserProfile> {
-    const row = await api.saveProfile(specializations, skills, location);
+    const row = await api.saveProfile(specializations, skills, excludedSkills, location);
     this.#profile = row;
     this.markLoaded();
     return row;

--- a/web/src/lib/profileFilters.test.ts
+++ b/web/src/lib/profileFilters.test.ts
@@ -7,8 +7,16 @@ function mkProfile(
   specializations: string[],
   skills: string[],
   location: LocationPreferences | null = null,
+  excludedSkills: string[] = [],
 ): UserProfile {
-  return { specializations, skills, location_preferences: location, created_at: null, updated_at: null };
+  return {
+    specializations,
+    skills,
+    excluded_skills: excludedSkills,
+    location_preferences: location,
+    created_at: null,
+    updated_at: null,
+  };
 }
 
 // filtersFromProfile is the pure reset-and-seed used by "Apply my profile": from a
@@ -78,6 +86,21 @@ describe('filtersFromProfile', () => {
     // Relocation targets are ignored when not open (open is the gate for the whole block).
     expect(p.getAll('regions')).toEqual(['latam']);
     expect(p.getAll('cities')).toEqual([]);
+  });
+
+  it('seeds the skills exclude set from excluded_skills', () => {
+    const f = filtersFromProfile(mkProfile(['backend'], ['go'], null, ['php', 'wordpress']));
+    const p = filtersToParams(f);
+    expect(p.getAll('skills')).toEqual(['go']);
+    expect(p.getAll('skills_exclude')).toEqual(['php', 'wordpress']);
+  });
+
+  it('keeps a skill wanted when it also appears in excluded_skills (include wins)', () => {
+    // The backend already drops the overlap, but the seeder must not self-cancel either.
+    const f = filtersFromProfile(mkProfile(['backend'], ['go'], null, ['go', 'php']));
+    const p = filtersToParams(f);
+    expect(p.getAll('skills')).toEqual(['go']);
+    expect(p.getAll('skills_exclude')).toEqual(['php']);
   });
 
   it('a profile with no location block seeds only category and skills', () => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -580,6 +580,8 @@ export interface LocationPreferences {
 export interface UserProfile {
   specializations: string[];
   skills: string[];
+  /** Canonical skill tokens the user wants to avoid; seeded into the jobs filter's skills exclude set by "Apply my profile". Empty when the user excludes nothing. */
+  excluded_skills: string[];
   location_preferences: LocationPreferences | null;
   created_at: string | null;
   updated_at: string | null;


### PR DESCRIPTION
## Summary

Adds an optional **"skills to avoid"** set to the user profile, and makes **Apply my profile** in the jobs filter seed those as negative filters — so a user who never wants (say) PHP no longer excludes it by hand every time.

- **Storage** — new `user_profiles.excluded_skills text[] NOT NULL DEFAULT '{}'` (migration `0039`; empty allowed, unlike `skills`).
- **Overlap rule** — on save, a skill listed as both wanted and avoided is dropped from the excluded set (the wanted set wins, silently), so a committed filter never emits contradictory `skills = X AND skills != X`.
- **Filter seeding** — `filtersFromProfile` seeds each excluded skill into the `skills` facet's **exclude** set, reusing the existing end-to-end exclude machinery (`?skills_exclude=…` → Meili `skills != "X"`). No change to the search/filter layer.
- **UI** — a dictionary-constrained "Skills to avoid" control in `ProfileForm`, mirroring the existing Skills typeahead; the two controls stay disjoint.

Additive and optional — existing profiles and API clients are unaffected.

Planned in OpenSpec: `openspec/changes/add-profile-excluded-skills/` (deltas to `search-profiles` + `filter-modal`).

## Deploy note

⚠️ **Apply the migration manually on prod before deploying** — Postgres initdb runs migrations only on first volume init (per the `0010` precedent). `0039` is `ALTER TABLE user_profiles ADD COLUMN excluded_skills text[] NOT NULL DEFAULT '{}'` — it backfills existing rows to an empty set, so GET/PUT stay safe.

## Test Plan

- [x] `go build ./... && go vet ./... && go test ./...` green; `gofmt` clean
- [x] Backend unit tests: excluded-skill normalization, overlap-drop (wanted wins), empty→`'{}'`; handler PUT round-trip + overlap
- [x] Web: `svelte-check` (0 errors) + full vitest (354), incl. `profileFilters.test.ts` asserting `skills_exclude=…` is committed
- [x] Production web build passes
- [ ] Manual QA (needs running stack): save a profile with an excluded skill → **Apply my profile** → confirm `?skills_exclude=…` in the URL; visual-check the "Skills to avoid" control