### PR TITLE
fix(web): retry navigation-cancelled feed loads instead of erroring

### DIFF
--- a/web/src/lib/paginated.svelte.test.ts
+++ b/web/src/lib/paginated.svelte.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { loadWithRetry } from './paginated.svelte';
+import { ApiError } from './api';
+
+// The reactive Paginator can't be instantiated here — its `$state` fields need a
+// Svelte runtime this test env doesn't provide — so we cover the retry decision at
+// its pure core: `loadWithRetry` (which `Paginator.start` wraps 1:1).
+
+describe('loadWithRetry', () => {
+  it('returns the value on first success, no retry', async () => {
+    const fetch = vi.fn(async () => 42);
+    await expect(loadWithRetry(fetch)).resolves.toBe(42);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows a server ApiError immediately, without retrying', async () => {
+    const err = new ApiError(500, 'boom');
+    const fetch = vi.fn(async () => {
+      throw err;
+    });
+    await expect(loadWithRetry(fetch)).rejects.toBe(err);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a cancelled fetch and self-heals', async () => {
+    vi.useFakeTimers();
+    const fetch = vi
+      .fn<() => Promise<number>>()
+      .mockRejectedValueOnce(new TypeError('Load failed'))
+      .mockResolvedValueOnce(7);
+    const done = loadWithRetry(fetch);
+    await vi.runAllTimersAsync();
+    await expect(done).resolves.toBe(7);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('gives up after exhausting retries on a persistent network failure', async () => {
+    vi.useFakeTimers();
+    const err = new TypeError('Failed to fetch');
+    const fetch = vi.fn(async () => {
+      throw err;
+    });
+    const done = loadWithRetry(fetch);
+    const assertion = expect(done).rejects.toBe(err);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+    vi.useRealTimers();
+  });
+});

--- a/web/src/lib/paginated.svelte.ts
+++ b/web/src/lib/paginated.svelte.ts
@@ -3,9 +3,34 @@
 // "has more" rule — total count, short page, cursor — lives in the caller, not
 // here. Owns the load / append / in-flight / error state; views only render.
 
-import type { Slice } from './api';
+import { ApiError, type Slice } from './api';
 
 type FetchSlice<T> = (limit: number, offset: number) => Promise<Slice<T>>;
+
+// A fetch rejected without an HTTP response — an AbortError from an in-flight
+// navigation cancelling the request, or a transient network drop (iOS WebKit
+// surfaces this as `TypeError: Load failed`, Chrome as `TypeError: Failed to
+// fetch`). Unlike an `ApiError` (a real 4xx/5xx the server answered with), this
+// isn't a genuine load failure: it's worth a silent retry so the feed self-heals
+// instead of flashing "Failed to load jobs" when the user simply tapped a nav link.
+function isTransient(err: unknown): boolean {
+  return !(err instanceof ApiError);
+}
+
+/** Run `fetch`, silently retrying a transient (navigation-cancelled / network-drop)
+ *  rejection up to `maxRetries` times with a short backoff; an `ApiError` — a real
+ *  server response — or an exhausted budget rejects. Kept as a free function (no
+ *  `$state`) so it's unit-testable without a Svelte runtime. */
+export async function loadWithRetry<T>(fetch: () => Promise<T>, maxRetries = 2): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fetch();
+    } catch (err) {
+      if (!isTransient(err) || attempt >= maxRetries) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)));
+    }
+  }
+}
 
 export class Paginator<T> {
   // Slices are whole API responses, only ever reassigned (never mutated in
@@ -39,10 +64,13 @@ export class Paginator<T> {
     this.status = 'ready';
   }
 
-  /** Load the first page. Call once from the view's onMount (or an effect). */
+  /** Load the first page. Call once from the view's onMount (or an effect). A
+   *  request cancelled by a navigation (or a transient network drop) isn't a real
+   *  failure — retry a couple of times so the feed just reloads rather than showing
+   *  an error; only a genuine server error (or exhausted retries) flips to 'error'. */
   async start() {
     try {
-      const slice = await this.#fetch(this.#limit, 0);
+      const slice = await loadWithRetry(() => this.#fetch(this.#limit, 0));
       this.items = slice.items;
       this.total = slice.total ?? 0;
       this.hasMore = slice.hasMore;


### PR DESCRIPTION
## Problem
On mobile Chrome (iOS/WebKit), tapping the logo showed **"Failed to load jobs."** on the home feed. Sentry: `telagon/tg-catalog` → `TG-CATALOG-3P` `TypeError: Load failed (freehire.dev)` (37 events, active), url `https://freehire.dev/`.

Root cause: `Paginator.start()` flipped to the visible error state on **any** rejection — including a fetch cancelled by an in-flight navigation (iOS WebKit reports this as `TypeError: Load failed`, Chrome as `Failed to fetch`). Large *apply-my-profile* filters (~70 skills → slow request) widened the race window, making it reproducible.

## Fix
Distinguish a real server response (`ApiError`, i.e. an answered 4xx/5xx) from a transient navigation/network abort:
- transient → silently retry with a short backoff (up to 2×), so the feed just reloads;
- only a genuine failure (or exhausted retries) shows the error.

Retry logic extracted to a pure `loadWithRetry` and unit-tested (the reactive `Paginator` can't be instantiated under the current vitest env). Fixes the shared `Paginator`, so **all** lists benefit (feed, companies, saved, history, /b/[slug]) and it cuts the matching Sentry noise from benign navigation aborts.

## Verification
- `vitest`: 4/4 green (`paginated.svelte.test.ts`)
- `svelte-check`: 0 errors