### PR TITLE
feat(sources): add GSC Game World peopleforce board

### DIFF
--- a/sources/peopleforce.yml
+++ b/sources/peopleforce.yml
@@ -128,3 +128,7 @@
   board: trafficconnect
 - company: Akvelon
   board: akvelon
+# GSC Game World (S.T.A.L.K.E.R. 2 studio, gsc-game.com). Careers SPA apply-links point
+# at gscgameworld.peopleforce.io; eastern-roots `gsc-game-world` slug tags it once it posts.
+- company: GSC Game World
+  board: gscgameworld


### PR DESCRIPTION
idagent eastern-roots audit: GSC Game World (S.T.A.L.K.E.R. 2 studio) is the
only one of the 9 uncovered companies with an onboardable ATS. Its careers SPA
apply-links resolve to gscgameworld.peopleforce.io/careers (8 live roles). The
eastern-roots `gsc-game-world` slug is already seeded, so ingest tags the
company into the collection automatically once postings land.

The other 8: StarWind/4A Games/Fibery — self-hosted, no ATS; Bitrix24 —
self-hosted CMS + hh role-only; Ecwid/Depositphotos — absorbed into Lightspeed/
Vista group boards (no brand-specific board); Murka — custom in-house API, 1 role;
Zerion — already onboarded (lever/zerion).
