### PR TITLE
fix(skilltag): drop URLs before matching so link path extensions don't leak as skills

### DIFF
--- a/internal/skilltag/skilltag.go
+++ b/internal/skilltag/skilltag.go
@@ -43,13 +43,21 @@ var wordTokenRE = regexp.MustCompile(`[a-z0-9]+`)
 // guards (a leading '-' is not a word start) are preserved.
 var sepRE = regexp.MustCompile(`[-_\s]+`)
 
+// urlRE matches an absolute URL — a scheme-prefixed or bare "www." link — up to the
+// next whitespace. Descriptions embed apply-links whose host and path segments
+// tokenize into skill aliases: the ".html" in "about-us.html", a ".php" query. Those
+// name a location, not a tech requirement, so URLs are dropped before matching (after
+// HTML tags, so hrefs inside <a …> are already gone and only visible link text remains).
+var urlRE = regexp.MustCompile(`(?i)\b(?:https?://|www\.)\S+`)
+
 // normalize strips HTML tags, lowercases the text, and trims. Tags are replaced
 // with a space (not empty) to preserve word boundaries so "<b>Go</b>Engineer"
 // cannot fuse. Separators are deliberately left intact — the phrase matcher makes
 // '-'/'_'/space equivalent inside multi-word terms without losing the boundary
 // information that keeps "objective-c" from leaking a bare "c".
 func normalize(text string) string {
-	return strings.TrimSpace(strings.ToLower(htmlTagRE.ReplaceAllString(text, " ")))
+	stripped := urlRE.ReplaceAllString(htmlTagRE.ReplaceAllString(text, " "), " ")
+	return strings.TrimSpace(strings.ToLower(stripped))
 }
 
 // phraseMatcher resolves one phrase alias against normalized text. A multi-word
@@ -154,7 +162,7 @@ func Parse(text string, opts ...Option) []string {
 	// UPPERCASE acronym resolves while its ambiguous lowercase form does not. Uses a
 	// Unicode word boundary because the text is not lowercased here (ASCIIBoundary's
 	// word test is lowercase-only and would misjudge uppercase neighbours).
-	cased := htmlTagRE.ReplaceAllString(text, " ")
+	cased := urlRE.ReplaceAllString(htmlTagRE.ReplaceAllString(text, " "), " ")
 	matchAcronyms(cased, sharedAcronyms, strong)
 	if o.resumeAcronyms {
 		matchAcronyms(cased, resumeAcronyms, strong)

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -406,6 +406,10 @@ func TestParse_ExpansionBatch2(t *testing.T) {
 		// ambiguity guards: deliberately-omitted tokens must NOT tag on common uses.
 		{"windows office trap", "A bright office with big windows and a great team.", nil, []string{"windows"}},
 		{"http url trap", "Apply via http://careers.example.com by Friday.", nil, []string{"http"}},
+		// URL path extensions must not leak as skills on non-tech jobs: a retail post
+		// linking to "about-us.html" (or a ".php" page) tokenizes to html/php otherwise.
+		{"html extension in link text", "Learn more at www.dollargeneral.com/about-us.html today.", nil, []string{"html"}},
+		{"php extension in url", "See https://jobs.example.com/apply.php for details.", nil, []string{"php"}},
 		{"s3 trap", "We finished the S3 phase of the roadmap.", nil, []string{"s3"}},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## Problem

A retail job (Store Manager, Dollar General) surfaced `html` in its skills facet. Root cause is not a dictionary typo but **URL leakage**: the description embeds an apply-link whose *visible text* repeats the URL — `www.dollargeneral.com/about-us.html`. After HTML tags are stripped, that text tokenizes on `.`/`-` and the trailing `html` matches the skill dictionary as an unconditional (strong) alias, tagging non-tech jobs.

This is a whole class of bug — a `.php` link would falsely tag `php` the same way.

## Fix

Strip absolute URLs (scheme- or `www.`-prefixed, up to whitespace) **after** HTML-tag removal, in both `normalize()` (phrase + word passes) and the case-preserved acronym pass. Host/path segments of links never reach the matcher. URLs name a location, not a tech requirement, so this aligns with the dict-only 'never guess' philosophy.

## Tests

Regression cases: `about-us.html` and `apply.php` in link text no longer tag `html`/`php`.

## Follow-up (ops)

Already-stored `jobs.skills` need re-derivation to clear existing false tags: `cmd/backfill-derive` + `make reindex`.