### PR TITLE
ci(perf): make pr-smoke API-not-ready failures diagnosable

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -79,7 +79,12 @@ jobs:
             [ "$api" = "200" ] && [ "$meili" = "200" ] && exit 0
             sleep 3
           done
-          echo "API/search did not become ready"; docker compose ps; docker compose logs --tail=100; exit 1
+          # Dump the app + db logs specifically: a combined `logs` is drowned by
+          # Meilisearch, which logs every /health poll and floods the tail.
+          echo "API/search did not become ready"; docker compose ps
+          echo "=== app logs ==="; docker compose logs app --tail=100
+          echo "=== db logs ===";  docker compose logs db --tail=30
+          exit 1
 
       - name: Initialise the search index
         # The homepage feed reads Meilisearch, so the jobs index must exist BEFORE


### PR DESCRIPTION
## Why

PR #1055 (a frontend-only change) had its `pr-smoke` job fail at **Wait for API and search to be ready** — the Go API never returned 200. The on-failure dump was useless: it ran `docker compose logs --tail=100`, but Meilisearch logs **every** `/health` poll (the wait loop hits it ~78 times over 60 attempts), flooding the tail and pushing the `app` container's logs out entirely. The actual reason the API didn't start was invisible.

## What

Dump logs **per service** on failure — `app` (the thing that failed) plus a little `db` context — so a chatty neighbour can't drown the signal.

No behavioural change to the smoke itself; only the failure diagnostics.

```yaml
echo "API/search did not become ready"; docker compose ps
echo "=== app logs ==="; docker compose logs app --tail=100
echo "=== db logs ===";  docker compose logs db --tail=30
exit 1
```