### PR TITLE
fix(server): raise Fiber ReadBufferSize so large filter feeds don't 431

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -59,6 +59,15 @@ func main() {
 		AppName:      "hire",
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
+		// Buffer for reading the request head (request line + all headers). Fiber's
+		// 4KB default is too small for our largest legitimate GET: a filter feed
+		// carrying dozens of facets (a "use my whole profile" search is 70+ skills)
+		// puts a ~1.3KB query string in BOTH the request line AND the same-page
+		// Referer, and on top of that ride the auth cookie and Chrome's sec-ch-ua
+		// client hints — together over 4KB, so fasthttp rejected the request with a
+		// 431 before it ever reached a handler (the feed then showed "Failed to load
+		// jobs"). 16KB comfortably fits even an unusually broad filter set.
+		ReadBufferSize: 16 * 1024,
 		// Cap request bodies at 8MB: résumé PDF uploads are the largest write (design-heavy
 		// CVs run past 1MB), and Fiber's BodyLimit is global — there is no per-route limit —
 		// so this ceiling applies to every endpoint. Keep it as tight as the résumé path


### PR DESCRIPTION
## Problem
Mobile Chrome constantly showed **"Failed to load jobs."** on the home feed when a large filter was applied (a *use-my-whole-profile* search — the reporter had **74** filter elements). Safari on the **same device** worked.

Root cause (confirmed against prod): the requests returned **HTTP 431 Request Header Fields Too Large**. A 70+-facet filter puts a ~1.3KB query string in **both** the request line and the same-page `Referer`; with the auth cookie and Chrome's `sec-ch-ua*` client hints on top, the request head crosses fasthttp's default **4KB `ReadBufferSize`**, so the server rejects it with 431 before any handler runs.

- Chrome fails / Safari passes on the same phone because Chrome holds the large filter state (localStorage) **and** sends client-hint headers Safari doesn't.
- Reproduced on prod: same query is 200 with minimal headers, flips to **431** once realistic `Referer` + a ~1.6KB cookie push the head over 4KB.

## Fix
Set `ReadBufferSize: 16 * 1024` in the Fiber config — comfortably fits an unusually broad filter set (request line + duplicated Referer + cookie + client hints).

## Notes
- nginx already passes these requests (the 431 came from fasthttp, not nginx), so no proxy change is needed.
- Complements #1055 (the client-side retry), which only covered transient navigation aborts; this 431 is a real response and was never a retry case.

## Verification
- `go build ./cmd/server` + `go vet`: clean.