### PR TITLE
feat(web): overlapping country-flag stack on cards + job sidebar

### DIFF
--- a/web/src/lib/components/CountryFlagStack.svelte
+++ b/web/src/lib/components/CountryFlagStack.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { filterHref } from '$lib/enrichment';
+  import CountryFlag from './CountryFlag.svelte';
+
+  // An overlapping cluster of round country flags (an avatar-stack). Collapses a
+  // long country list into a compact, space-saving row: each flag laps over the
+  // previous one, capped at `max` with a "+N" chip for the remainder. Used on the
+  // browse card (display-only) and the job sidebar (`link` on), where a wide remote
+  // role can list a dozen eligible countries.
+  //
+  // The flags overlap by `--lap` (an em fraction of a flag's width) via a negative
+  // left margin, and each carries a `ring-card` outline so neighbours stay legible
+  // where they touch. Earlier flags sit on top (descending z-index) so the row reads
+  // left-to-right; hovering a flag raises it above its neighbours.
+  let {
+    codes,
+    max = 6,
+    link = false,
+    class: className = '',
+  }: {
+    codes: string[];
+    max?: number;
+    link?: boolean;
+    class?: string;
+  } = $props();
+
+  const shown = $derived(codes.slice(0, max));
+  const extra = $derived(codes.length - shown.length);
+</script>
+
+{#if codes.length}
+  <div class={['flex items-center', className]} style:--lap="0.4em">
+    {#each shown as code, i (code)}
+      <span
+        class={[
+          'relative inline-flex rounded-full ring-2 ring-card transition hover:z-10 hover:-translate-y-px',
+          i > 0 && '-ml-[var(--lap)]',
+        ]}
+        style:z-index={shown.length - i}
+      >
+        {#if link}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
+          <a href={filterHref('countries', code)} class="inline-flex"><CountryFlag {code} /></a>
+        {:else}
+          <CountryFlag {code} />
+        {/if}
+      </span>
+    {/each}
+    {#if extra > 0}
+      <span class="ml-1.5 text-xs font-medium text-muted-foreground">+{extra}</span>
+    {/if}
+  </div>
+{/if}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
   import { Bookmark, Eye, EyeOff, X } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CountryFlagStack from './CountryFlagStack.svelte';
   import JobMatchBar from './JobMatchBar.svelte';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -244,12 +245,17 @@
 
   <!-- Signal row: reality chip + the region/employment facets, grouped under the
        title as quiet outline chips so they read as metadata, not decoration. -->
-  {#if job.reality || tags.length > 0}
+  {#if job.reality || tags.length > 0 || job.countries?.length}
     <div class="mt-2 flex flex-wrap items-center gap-1.5">
       <RealityBadge reality={job.reality} />
       {#each tags as tag (tag)}
         <Badge variant="outline">{tag}</Badge>
       {/each}
+      <!-- Eligible countries as an overlapping flag cluster. Display-only here: the
+           whole card is a link, so the flags carry no nested filter links. -->
+      {#if job.countries?.length}
+        <CountryFlagStack codes={job.countries} max={5} class="ml-0.5 text-base" />
+      {/if}
     </div>
   {/if}
 

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -12,7 +12,7 @@
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
-  import CountryFlag from './CountryFlag.svelte';
+  import CountryFlagStack from './CountryFlagStack.svelte';
   import JobDescription from './JobDescription.svelte';
   import JobMatch from './JobMatch.svelte';
   import RealityBadge from './RealityBadge.svelte';
@@ -325,16 +325,12 @@
             <div class="flex items-baseline justify-between gap-3">
               <dt class="shrink-0 text-muted-foreground">{facet.label}</dt>
               {#if facet.values.every((v) => v.flag)}
-                <!-- Flag facet (Country): a wrapping row of round flags, right-aligned,
-                     each linking to its filter. No comma separators — the gap reads the
-                     list on its own and stays compact for many-country remote jobs. -->
-                <dd class="flex min-w-0 flex-wrap justify-end gap-1.5 text-base">
-                  {#each facet.values as v (v.text)}
-                    {#if v.href}
-                      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
-                      <a href={v.href} class="transition hover:opacity-80"><CountryFlag code={v.flag ?? ''} /></a>
-                    {:else}<CountryFlag code={v.flag ?? ''} />{/if}
-                  {/each}
+                <!-- Flag facet (Country): an overlapping cluster of round flags,
+                     right-aligned, each linking to its filter. The stack laps the
+                     flags over one another so a many-country remote role stays a
+                     single compact row instead of wrapping. -->
+                <dd class="flex min-w-0 justify-end text-base">
+                  <CountryFlagStack codes={facet.values.map((v) => v.flag ?? '')} link />
                 </dd>
               {:else}
                 <dd class="min-w-0 break-words text-right font-medium"


### PR DESCRIPTION
## What

Adds `CountryFlagStack` — an avatar-style cluster of round country flags that lap over one another so a many-country remote role stays a compact single row instead of wrapping.

- **JobRow (browse card):** eligible-country flags in the signal row, next to the region/employment badges. Display-only — the whole card is a link, so the flags carry no nested filter links.
- **JobView sidebar:** replaces the wrapping `Country` flag row with the overlapping stack; each flag still links to its per-country filter.

Behaviour: leftmost flag on top (descending z-index), `ring-card` outline separates neighbours on any theme, hover raises a flag, and the tail past `max` collapses into a `+N` chip.

## Verification

- `svelte-check` — 0 errors.
- Visual check via a throwaway route + headless Chrome (few/many, linked/display, inline-with-badges) — overlap and `+N` render correctly in dark mode.