### PR TITLE
feat(cv): take CV builder + AI tailoring out of beta

### DIFF
--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -13,8 +13,9 @@ import (
 // CV-builder HTTP surface: per-user structured CVs (CRUD + seed) and on-demand PDF
 // rendering. Mutations are cookie-only (RequireAuth); the read + render endpoints also
 // accept an API key (RequireAuthOrKey) so the tailoring agent's CLI can fetch a CV and its
-// PDF. All routes are gated to beta testers / moderators (RequireModeratorOrBeta) at
-// registration. Every operation is owner-scoped — a foreign id is a 404, never a leak.
+// PDF. All routes are open to every signed-in user (the beta gate was lifted when tailoring
+// went public; AI credits meter the LLM spend). Every operation is owner-scoped — a foreign
+// id is a 404, never a leak.
 
 const maxCVTitleRunes = 200
 

--- a/internal/handler/cv_integration_test.go
+++ b/internal/handler/cv_integration_test.go
@@ -1,9 +1,9 @@
 //go:build integration
 
 // Integration tests for the CV-builder HTTP surface (add-cv-builder): CRUD round-trip,
-// owner isolation (foreign id → 404), beta-tester gating (403), the 501 gate when no
-// renderer is configured, and seeding a new CV from the stored résumé structure.
-// Run with: go test -tags=integration ./internal/handler/
+// owner isolation (foreign id → 404), open access to every signed-in user (no beta gate),
+// the 501 gate when no renderer is configured, and seeding a new CV from the stored résumé
+// structure. Run with: go test -tags=integration ./internal/handler/
 package handler
 
 import (
@@ -37,19 +37,19 @@ func seedAccount(t *testing.T, h *API, email string, beta bool) int64 {
 	return id
 }
 
-// buildCVApp wires just the CV routes with the real beta gate onto a fresh fiber app.
+// buildCVApp wires just the CV routes onto a fresh fiber app. The routes are open to every
+// signed-in user (cookie auth only) — the beta gate was lifted when CV tailoring went public.
 func buildCVApp(h *API, iss *auth.Issuer) *fiber.App {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	saved := auth.RequireAuth(iss)
-	gate := auth.RequireModeratorOrBeta(h.queries, h.queries)
-	app.Get("/api/v1/cv-templates", saved, gate, h.ListCVTemplates)
-	app.Get("/api/v1/me/cvs", saved, gate, h.ListCVs)
-	app.Post("/api/v1/me/cvs", saved, gate, h.CreateCV)
-	app.Get("/api/v1/me/cvs/:id", saved, gate, h.GetCV)
-	app.Put("/api/v1/me/cvs/:id", saved, gate, h.UpdateCV)
-	app.Put("/api/v1/me/cvs/:id/template", saved, gate, h.SetCVTemplate)
-	app.Delete("/api/v1/me/cvs/:id", saved, gate, h.DeleteCV)
-	app.Get("/api/v1/me/cvs/:id/pdf", saved, gate, h.RenderCVPDF)
+	app.Get("/api/v1/cv-templates", saved, h.ListCVTemplates)
+	app.Get("/api/v1/me/cvs", saved, h.ListCVs)
+	app.Post("/api/v1/me/cvs", saved, h.CreateCV)
+	app.Get("/api/v1/me/cvs/:id", saved, h.GetCV)
+	app.Put("/api/v1/me/cvs/:id", saved, h.UpdateCV)
+	app.Put("/api/v1/me/cvs/:id/template", saved, h.SetCVTemplate)
+	app.Delete("/api/v1/me/cvs/:id", saved, h.DeleteCV)
+	app.Get("/api/v1/me/cvs/:id/pdf", saved, h.RenderCVPDF)
 	return app
 }
 
@@ -74,9 +74,10 @@ func doCV(t *testing.T, app *fiber.App, method, path, token string, body any) *h
 	return resp
 }
 
-// TestCVTemplatesEndpoint_Gating checks the static templates list is behind the beta gate:
-// a beta user gets every registered template, a non-beta user is forbidden.
-func TestCVTemplatesEndpoint_Gating(t *testing.T) {
+// TestCVTemplatesEndpoint_OpenToAuthed checks the static templates list is open to every
+// signed-in user: an unauthenticated request is 401, while a plain (non-beta) user gets every
+// registered template.
+func TestCVTemplatesEndpoint_OpenToAuthed(t *testing.T) {
 	pool := startPostgres(t)
 	queries := db.New(pool)
 	if _, err := pool.Exec(context.Background(), "TRUNCATE cvs, users RESTART IDENTITY CASCADE"); err != nil {
@@ -88,16 +89,15 @@ func TestCVTemplatesEndpoint_Gating(t *testing.T) {
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
 	app := buildCVApp(h, iss)
 
-	betaTok, _ := iss.Issue(seedAccount(t, h, "beta@example.test", true))
 	plainTok, _ := iss.Issue(seedAccount(t, h, "plain@example.test", false))
 
-	if resp := doCV(t, app, fiber.MethodGet, "/api/v1/cv-templates", plainTok, nil); resp.StatusCode != fiber.StatusForbidden {
-		t.Fatalf("non-beta templates = %d, want 403", resp.StatusCode)
+	if resp := doCV(t, app, fiber.MethodGet, "/api/v1/cv-templates", "", nil); resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("unauthenticated templates = %d, want 401", resp.StatusCode)
 	}
 
-	resp := doCV(t, app, fiber.MethodGet, "/api/v1/cv-templates", betaTok, nil)
+	resp := doCV(t, app, fiber.MethodGet, "/api/v1/cv-templates", plainTok, nil)
 	if resp.StatusCode != fiber.StatusOK {
-		t.Fatalf("beta templates = %d, want 200", resp.StatusCode)
+		t.Fatalf("non-beta templates = %d, want 200", resp.StatusCode)
 	}
 	var body struct {
 		Data []cv.TemplateInfo `json:"data"`
@@ -171,7 +171,7 @@ func TestSetCVTemplateEndpoint(t *testing.T) {
 	}
 }
 
-func TestCVEndpoints_CRUDIsolationAndGating(t *testing.T) {
+func TestCVEndpoints_CRUDAndIsolation(t *testing.T) {
 	pool := startPostgres(t)
 	queries := db.New(pool)
 	if _, err := pool.Exec(context.Background(), "TRUNCATE cvs, users RESTART IDENTITY CASCADE"); err != nil {
@@ -190,9 +190,9 @@ func TestCVEndpoints_CRUDIsolationAndGating(t *testing.T) {
 	otherTok, _ := iss.Issue(other)
 	plainTok, _ := iss.Issue(plain)
 
-	// Non-beta is forbidden everywhere.
-	if resp := doCV(t, app, fiber.MethodGet, "/api/v1/me/cvs", plainTok, nil); resp.StatusCode != fiber.StatusForbidden {
-		t.Fatalf("non-beta list = %d, want 403", resp.StatusCode)
+	// A plain (non-beta) user now has full access — the CV builder is public.
+	if resp := doCV(t, app, fiber.MethodGet, "/api/v1/me/cvs", plainTok, nil); resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("non-beta list = %d, want 200", resp.StatusCode)
 	}
 
 	// Create (no seed → empty document).

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -47,16 +47,16 @@ func newTailorAPI(t *testing.T) (*API, *auth.Issuer) {
 	return h, iss
 }
 
-// buildTailorApp wires the CV + tailoring routes with the real beta gate.
+// buildTailorApp wires the CV + tailoring routes. They are open to every signed-in user (the
+// beta gate was lifted when CV tailoring went public); credits meter the LLM spend instead.
 func buildTailorApp(h *API, iss *auth.Issuer) *fiber.App {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	saved := auth.RequireAuth(iss)
 	keyAuth := auth.RequireAuthOrKey(iss, h.queries)
-	gate := auth.RequireModeratorOrBeta(h.queries, h.queries)
-	app.Get("/api/v1/me/cvs/:id", keyAuth, gate, h.GetCV)
-	app.Post("/api/v1/me/cvs/tailor", saved, gate, h.TailorCV)
-	app.Patch("/api/v1/me/cvs/:id", keyAuth, gate, h.PatchCV)
-	app.Get("/api/v1/me/cvs/:id/tailor-context", keyAuth, gate, h.TailorContext)
+	app.Get("/api/v1/me/cvs/:id", keyAuth, h.GetCV)
+	app.Post("/api/v1/me/cvs/tailor", saved, h.TailorCV)
+	app.Patch("/api/v1/me/cvs/:id", keyAuth, h.PatchCV)
+	app.Get("/api/v1/me/cvs/:id/tailor-context", keyAuth, h.TailorContext)
 	return app
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -561,30 +561,27 @@ func Register(app *fiber.App, cfg Config) {
 	api.Put("/me/profile", saved, a.PutProfile)
 	api.Delete("/me/profile", saved, a.DeleteProfile)
 
-	// CV builder: cookie-only and gated to beta testers / moderators (restricted
-	// rollout). Owner-scoped (a foreign id is a 404). The PDF endpoint 501s when no
-	// typst binary is configured; the rest still works.
-	cvGate := auth.RequireModeratorOrBeta(a.queries, a.queries)
-	// The template registry is static (no per-user data); listed behind the same beta gate
-	// so the gallery is only reachable where the CV builder itself is.
-	api.Get("/cv-templates", saved, cvGate, a.ListCVTemplates)
-	api.Get("/me/cvs", saved, cvGate, a.ListCVs)
-	api.Post("/me/cvs", saved, cvGate, a.CreateCV)
+	// CV builder + AI tailoring: open to every signed-in user (AI credits meter the LLM spend).
+	// Cookie-only, owner-scoped (a foreign id is a 404). The PDF endpoint 501s when no typst
+	// binary is configured; the rest still works.
+	api.Get("/cv-templates", saved, a.ListCVTemplates)
+	api.Get("/me/cvs", saved, a.ListCVs)
+	api.Post("/me/cvs", saved, a.CreateCV)
 	// Read + render accept a key too (keyAuth), so the tailoring agent's CLI can fetch a CV
 	// and its PDF; mutations stay cookie-only (POST/PUT/DELETE — the browser owns authoring).
-	api.Get("/me/cvs/:id", keyAuth, cvGate, a.GetCV)
-	api.Put("/me/cvs/:id", saved, cvGate, a.UpdateCV)
+	api.Get("/me/cvs/:id", keyAuth, a.GetCV)
+	api.Put("/me/cvs/:id", saved, a.UpdateCV)
 	// Change only the template (the gallery's one-field switch); cookie-only like other mutations.
-	api.Put("/me/cvs/:id/template", saved, cvGate, a.SetCVTemplate)
-	api.Delete("/me/cvs/:id", saved, cvGate, a.DeleteCV)
-	api.Get("/me/cvs/:id/pdf", keyAuth, cvGate, a.RenderCVPDF)
+	api.Put("/me/cvs/:id/template", saved, a.SetCVTemplate)
+	api.Delete("/me/cvs/:id", saved, a.DeleteCV)
+	api.Get("/me/cvs/:id/pdf", keyAuth, a.RenderCVPDF)
 	// Tailoring: the browser starts a session (cookie-only bootstrap); the agent's CLI drives
 	// the edit + context/get/render reads with its minted API key (keyAuth = cookie or Bearer).
-	api.Post("/me/cvs/tailor", saved, cvGate, a.TailorCV)
-	api.Post("/me/cvs/:id/tailor-session", saved, cvGate, a.StartTailorSession)
-	api.Patch("/me/cvs/:id", keyAuth, cvGate, a.PatchCV)
-	api.Put("/me/cvs/:id/session", keyAuth, cvGate, a.SetCVSession)
-	api.Get("/me/cvs/:id/tailor-context", keyAuth, cvGate, a.TailorContext)
+	api.Post("/me/cvs/tailor", saved, a.TailorCV)
+	api.Post("/me/cvs/:id/tailor-session", saved, a.StartTailorSession)
+	api.Patch("/me/cvs/:id", keyAuth, a.PatchCV)
+	api.Put("/me/cvs/:id/session", keyAuth, a.SetCVSession)
+	api.Get("/me/cvs/:id/tailor-context", keyAuth, a.TailorContext)
 
 	// Mail inbox (Gmail connect + hosted mailbox). Open to every signed-in user.
 	// The read + disconnect routes are always registered (empty/no-op when not

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -25,16 +25,21 @@ describe('accountNav config', () => {
 });
 
 describe('visibleAccountNav', () => {
-  it('hides the beta-only Assistant and CV builder from a plain user but shows the Inbox', () => {
+  it('hides the beta-only Assistant from a plain user but shows the Inbox and CV builder', () => {
     const hrefs = visibleAccountNav(false, false).map((i) => i.href);
     expect(hrefs).not.toContain('/my/assistant');
-    expect(hrefs).not.toContain('/my/cvs');
     expect(hrefs).toContain('/my/inbox'); // Inbox is open to everyone now
+    expect(hrefs).toContain('/my/cvs'); // CV builder is public now (credits meter the AI spend)
   });
 
-  it('shows the beta-only CV builder to a beta tester, not a plain moderator', () => {
-    expect(visibleAccountNav(false, true).map((i) => i.href)).toContain('/my/cvs');
-    expect(visibleAccountNav(true, false).map((i) => i.href)).not.toContain('/my/cvs');
+  it('shows the CV builder to every signed-in user, gate-free', () => {
+    for (const [mod, beta] of [
+      [false, false],
+      [true, false],
+      [false, true],
+    ] as const) {
+      expect(visibleAccountNav(mod, beta).map((i) => i.href)).toContain('/my/cvs');
+    }
   });
 
   it('gates the Assistant on beta membership, not the moderator role', () => {

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -18,9 +18,8 @@ export const accountNav = [
   // The agent is a restricted rollout — beta testers only (a group separate from
   // the moderator role; see `beta_tester` on the user). `beta` shows a nav badge.
   { href: '/my/assistant', label: 'Agent', betaOnly: true, beta: true },
-  // CV builder is a restricted rollout — beta testers only (the server re-checks via
-  // RequireModeratorOrBeta). `beta` shows a nav badge.
-  { href: '/my/cvs', label: 'CV builder', betaOnly: true, beta: true },
+  // CV builder + AI tailoring: open to every signed-in user (credits meter the AI spend).
+  { href: '/my/cvs', label: 'CV builder' },
   // Employee referrals: request a referral, offer to refer (moderated), and — for
   // referrers — manage incoming requests. Open to every signed-in user.
   { href: '/my/referrals', label: 'Referrals' },

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -57,31 +57,37 @@
 
   type Phase = 'connecting' | 'ready';
 
-  // The agent is a beta-tester-only rollout. The nav hides it for others, but
-  // guard the route directly too — the agent backend only checks the freehire
-  // cookie, not the group, so a non-beta user reaching this URL must be stopped
-  // here (never connect / spawn a session for them).
-  const isBeta = $derived(currentUser()?.beta_tester ?? false);
-
   // Reusable chat: the host (/my/assistant or /tailor) composes the layout around it.
   //  - session: open this specific session id (else the newest, else a fresh chat).
   //  - kickoff: auto-send this as the first message of a fresh session (agent starts on its own).
   //  - sessionLabel: name the session in the rail (kept separate from the kickoff text).
   //  - onTurnComplete: called when a turn finishes (the tailor host refreshes the CV preview).
   //  - showSessionRail: whether to render the session sidebar (off on the focused /tailor surface).
+  //  - requireBeta: gate the chat behind beta membership (default). The /tailor host sets this
+  //    false — CV tailoring is public, so its embedded chat must connect for non-beta users too,
+  //    while the standalone Agent (/my/assistant) keeps the default beta gate.
   let {
     session = undefined,
     kickoff = undefined,
     sessionLabel = undefined,
     onTurnComplete = undefined,
     showSessionRail = true,
+    requireBeta = true,
   }: {
     session?: string;
     kickoff?: string;
     sessionLabel?: string;
     onTurnComplete?: () => void;
     showSessionRail?: boolean;
+    requireBeta?: boolean;
   } = $props();
+
+  // The standalone Agent is a beta-tester-only rollout. The nav hides it for others, but
+  // guard the route directly too — the agent backend only checks the freehire cookie, not the
+  // group, so a non-beta user reaching /my/assistant must be stopped here (never connect / spawn
+  // a session for them). Hosts that are already public (the /tailor workspace) pass
+  // requireBeta=false to lift this UI gate.
+  const allowed = $derived(!requireBeta || (currentUser()?.beta_tester ?? false));
 
   let phase = $state<Phase>('connecting');
   let error = $state<string | null>(null);
@@ -597,7 +603,7 @@
   }
 
   onMount(() => {
-    if (!isBeta) return;
+    if (!allowed) return;
     void boot();
     return teardown;
   });
@@ -639,7 +645,7 @@
   </div>
 {/if}
 
-{#if !isBeta}
+{#if !allowed}
   <div class="m-3 rounded-xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
     The agent is a limited beta and isn't available for your account yet.
   </div>

--- a/web/src/lib/tailor/CvHtmlPreview.svelte
+++ b/web/src/lib/tailor/CvHtmlPreview.svelte
@@ -111,72 +111,73 @@
   {/if}
 {/snippet}
 
-<!-- A4 page (794px ≈ 210mm @96dpi), scaled by zoom from the top. The serif/sans + black-on-white
-     styling reads like the printed PDF; the look tracks the selected template. -->
-<div class="flex justify-center">
-  <div style="transform: scale({zoom}); transform-origin: top center;">
-    <article
-      class={[
-        'w-[794px] bg-white px-14 py-12 text-[13px] leading-snug text-neutral-900 shadow-sm',
-        isSans ? 'font-sans' : 'font-serif',
-      ]}
-    >
-      <!-- Header -->
-      <header class={['mb-3', isCentered ? 'text-center' : '']}>
-        <h1 class={['text-2xl font-bold', isSans ? 'uppercase tracking-wider' : 'tracking-tight']}>
-          {header.full_name || 'Your Name'}
-        </h1>
-        {#if !isSidebar && contacts.length}
-          <div class="mt-1">{@render contactLine()}</div>
-        {/if}
-        {#if (doc.summary ?? '').trim()}
-          <p
-            class={[
-              'mt-2 text-[12.5px] text-neutral-800',
-              isCentered ? 'mx-auto max-w-[62ch] italic' : '',
-              isSidebar ? 'italic' : '',
-            ]}
-          >
-            {doc.summary}
-          </p>
-        {/if}
-      </header>
+<!-- A4 page (794px ≈ 210mm @96dpi). The CSS `zoom` property scales the whole page box — layout
+     included — so the scroll container reserves the scaled size. (transform: scale keeps the
+     794px box, so with justify-center the left edge overflows unreachably and clips on first
+     paint.) `mx-auto` centres the page when it fits and left-aligns it when it overflows, so it
+     never clips. The serif/sans + black-on-white styling reads like the printed PDF; the look
+     tracks the selected template. -->
+<article
+  class={[
+    'mx-auto w-[794px] bg-white px-14 py-12 text-[13px] leading-snug text-neutral-900 shadow-sm',
+    isSans ? 'font-sans' : 'font-serif',
+  ]}
+  style="zoom: {zoom};"
+>
+  <!-- Header -->
+  <header class={['mb-3', isCentered ? 'text-center' : '']}>
+    <h1 class={['text-2xl font-bold', isSans ? 'uppercase tracking-wider' : 'tracking-tight']}>
+      {header.full_name || 'Your Name'}
+    </h1>
+    {#if !isSidebar && contacts.length}
+      <div class="mt-1">{@render contactLine()}</div>
+    {/if}
+    {#if (doc.summary ?? '').trim()}
+      <p
+        class={[
+          'mt-2 text-[12.5px] text-neutral-800',
+          isCentered ? 'mx-auto max-w-[62ch] italic' : '',
+          isSidebar ? 'italic' : '',
+        ]}
+      >
+        {doc.summary}
+      </p>
+    {/if}
+  </header>
 
-      <hr class={['my-2', isSans || isSidebar ? 'border-neutral-500' : 'border-neutral-300']} />
+  <hr class={['my-2', isSans || isSidebar ? 'border-neutral-500' : 'border-neutral-300']} />
 
-      {#if isSidebar}
-        <!-- Two-column body: narrow left (contact/links/skills/languages), wide right (experience/education/projects). -->
-        <div class="grid grid-cols-[35%_1fr] gap-6">
-          <div>
-            {#if contacts.length}
-              <section class="mb-3">
-                {@render sectionHeading('Contact')}
-                {#each contacts as c, i (i)}
-                  {#if isLink(c)}
-                    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external URL from the user's CV, not an internal route -->
-                    <p class="mb-0.5 break-words"><a href={c} target="_blank" rel="noopener" class="text-[#2b6cb0] hover:underline">{c}</a></p>
-                  {:else}<p class="mb-0.5 break-words">{c}</p>{/if}
-                {/each}
-              </section>
-            {/if}
-            {@render listBlock('Skills', skills, ', ')}
-            {@render listBlock('Languages', languages, ', ')}
-            {@render listBlock('Certifications', certifications, '; ')}
-          </div>
-          <div>
-            {@render experienceBlock()}
-            {@render educationBlock()}
-            {@render projectsBlock()}
-          </div>
-        </div>
-      {:else}
-        {@render experienceBlock()}
-        {@render projectsBlock()}
-        {@render educationBlock()}
+  {#if isSidebar}
+    <!-- Two-column body: narrow left (contact/links/skills/languages), wide right (experience/education/projects). -->
+    <div class="grid grid-cols-[35%_1fr] gap-6">
+      <div>
+        {#if contacts.length}
+          <section class="mb-3">
+            {@render sectionHeading('Contact')}
+            {#each contacts as c, i (i)}
+              {#if isLink(c)}
+                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external URL from the user's CV, not an internal route -->
+                <p class="mb-0.5 break-words"><a href={c} target="_blank" rel="noopener" class="text-[#2b6cb0] hover:underline">{c}</a></p>
+              {:else}<p class="mb-0.5 break-words">{c}</p>{/if}
+            {/each}
+          </section>
+        {/if}
         {@render listBlock('Skills', skills, ', ')}
         {@render listBlock('Languages', languages, ', ')}
         {@render listBlock('Certifications', certifications, '; ')}
-      {/if}
-    </article>
-  </div>
-</div>
+      </div>
+      <div>
+        {@render experienceBlock()}
+        {@render educationBlock()}
+        {@render projectsBlock()}
+      </div>
+    </div>
+  {:else}
+    {@render experienceBlock()}
+    {@render projectsBlock()}
+    {@render educationBlock()}
+    {@render listBlock('Skills', skills, ', ')}
+    {@render listBlock('Languages', languages, ', ')}
+    {@render listBlock('Certifications', certifications, '; ')}
+  {/if}
+</article>

--- a/web/src/routes/match/[slug]/+page.svelte
+++ b/web/src/routes/match/[slug]/+page.svelte
@@ -2,20 +2,17 @@
   import { resolve } from '$app/paths';
   import { goto } from '$app/navigation';
   import { ArrowLeft, SquarePen } from '@lucide/svelte';
-  import { currentUser } from '$lib/auth.svelte';
   import { Button } from '$lib/ui';
   import CompanyLogo from '$lib/components/CompanyLogo.svelte';
   import MatchAnalysisFull from '$lib/components/MatchAnalysisFull.svelte';
 
   let { data } = $props();
 
-  // Tailoring is a beta-tester feature; the CTA shows once an analysis exists for a stored
-  // CV. A stale analysis (CV or job changed since) still tailors — we nudge a recompute for
-  // the sharpest reframing (see below) rather than block, since any CV re-upload marks every
-  // past analysis stale and blocking would hide the feature too often.
-  const canTailor = $derived(
-    !!data.fit?.analysis && data.fit?.has_cv === true && currentUser()?.beta_tester === true,
-  );
+  // The tailoring CTA shows once an analysis exists for a stored CV (credits meter the AI spend).
+  // A stale analysis (CV or job changed since) still tailors — we nudge a recompute for the
+  // sharpest reframing (see below) rather than block, since any CV re-upload marks every past
+  // analysis stale and blocking would hide the feature too often.
+  const canTailor = $derived(!!data.fit?.analysis && data.fit?.has_cv === true);
 
   let tailoring = $state(false);
 

--- a/web/src/routes/my/cvs/+page.svelte
+++ b/web/src/routes/my/cvs/+page.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-  import { currentUser } from '$lib/auth.svelte';
   import CvList from '$lib/components/cv/CvList.svelte';
-
-  // Beta-tester-gated in the UI (the server still admits moderators via RequireModeratorOrBeta
-  // as an admin override). This just keeps a non-beta user who navigates here directly from
-  // hitting a raw 403.
-  const eligible = $derived(currentUser()?.beta_tester === true);
 </script>
 
 <svelte:head>
@@ -13,9 +7,5 @@
 </svelte:head>
 
 <div class="max-w-3xl">
-  {#if eligible}
-    <CvList />
-  {:else}
-    <p class="text-muted-foreground">The CV builder is in beta and not available on your account yet.</p>
-  {/if}
+  <CvList />
 </div>

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -22,13 +22,11 @@
   import AccountNavRail from '$lib/components/AccountNavRail.svelte';
   import { clampWidth } from '$lib/tailor/geometry';
   import { toEditable, type CvRecord } from '$lib/cv';
-  import { currentUser } from '$lib/auth.svelte';
   import type { Analysis, Document } from '$lib/generated/contracts';
   import type { Job } from '$lib/types';
 
   const slug = $derived(page.params.slug ?? '');
   const cvParam = $derived(page.url.searchParams.get('cv'));
-  const eligible = $derived(currentUser()?.beta_tester === true);
 
   let status = $state<'loading' | 'ready' | 'error'>('loading');
   let errorMsg = $state('');
@@ -82,11 +80,6 @@
   const loadCv = async () => hydrate(await api.getCv(cvId));
 
   onMount(async () => {
-    if (!eligible) {
-      status = 'error';
-      errorMsg = 'CV tailoring is in beta and not available on your account yet.';
-      return;
-    }
     try {
       if (cvParam) {
         // Resume an existing tailored CV. If it already has a bound session, re-attach it with
@@ -280,12 +273,13 @@
           <div class="h-full overflow-auto p-4" class:hidden={leftTab !== 'editor'}>
             <CvSectionForm bind:doc bind:title />
           </div>
-          <div class="h-full" class:hidden={leftTab !== 'chat'}>
+          <div class="flex min-h-0 h-full" class:hidden={leftTab !== 'chat'}>
             <AssistantChat
               session={sessionId}
               kickoff={resuming ? undefined : kickoff}
               {sessionLabel}
               showSessionRail={false}
+              requireBeta={false}
               {onTurnComplete}
             />
           </div>


### PR DESCRIPTION
## What

Takes the **CV builder + AI CV-tailoring** feature out of beta — open to every signed-in user now. AI credits (3/tailor, 20/month) remain the sole limiter.

### Un-gating
- **Backend** (`handler.go`, `cv.go`): removed the `RequireModeratorOrBeta` gate from all CV/tailor routes; `saved`/`keyAuth` retained, so routes still require auth and stay owner-scoped.
- **Frontend**: dropped beta conditions on the tailor CTA (`match/[slug]`), the tailor workspace (`tailor/[slug]`), the CV-builder nav item (`accountNav.ts`), and the `/my/cvs` landing page.
- **AssistantChat**: new `requireBeta` prop (default `true`) — the standalone Agent (`/my/assistant`) stays beta-gated; the `/tailor` workspace passes `requireBeta={false}` so its embedded chat connects for non-beta users.

### Bug fixes (tailor workspace)
- **CvHtmlPreview**: `transform: scale()` + `flex justify-center` → CSS `zoom` + `mx-auto`, so the CV preview no longer clips on the left at first open (the scaled layout box now matches the visual size and start-aligns when it overflows).
- **tailor page**: chat wrapper `h-full` → `flex min-h-0 h-full`, so `AssistantChat`'s `flex-1` root stretches and its message-list scroll + pinned composer work.

### Tests
- Integration tests (`cv_integration_test.go`, `cv_tailor_integration_test.go`) updated to the ungated contract (401 unauthenticated / 200 for a plain non-beta user; `buildCVApp`/`buildTailorApp` drop the gate).
- `accountNav.test.ts` updated: CV builder visible to every signed-in user.

## No migration
Pure route/gate + layout change — no schema migration, no new systemd timers.

## Verification
- `go build` / `go vet` / `gofmt` — clean
- `npm run check` (svelte-check) — 0 errors
- vitest `accountNav` — 12/12
- Not run: `-tags=integration` (needs Docker), in-browser visual confirmation of the two layout fixes