### PR TITLE
feat(web): lift Discussion link into the job/company header top row

### DIFF
--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -48,20 +48,19 @@
       {/if}
     </div>
     <!-- flex-1 above lets the name/tagline use the full width; the follow CTA stays
-         top-right and never shrinks (it collapses to an icon on mobile itself). -->
-    <div class="shrink-0">
+         top-right and never shrinks (it collapses to an icon on mobile itself).
+         The Discussion link sits right below it, right-aligned. -->
+    <div class="flex shrink-0 flex-col items-end gap-2">
       <CompanyFollowButton {slug} companyName={company.name} />
+      <a
+        class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+        href={resolve('/companies/[slug]/discussion', { slug })}
+      >
+        <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
+          ? ` · ${threadCount}`
+          : ''}
+      </a>
     </div>
-  </div>
-  <div class="mt-3">
-    <a
-      class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-      href={resolve('/companies/[slug]/discussion', { slug })}
-    >
-      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
-        ? ` · ${threadCount}`
-        : ''}
-    </a>
   </div>
   {#if hasMeta}
     <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-3">

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -209,17 +209,29 @@
 <article
   class="flex flex-col gap-4 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)] lg:grid-rows-[auto_auto_minmax(0,1fr)] lg:gap-x-6 lg:gap-y-4"
 >
-  <div class="flex items-center gap-3 lg:col-start-2 lg:row-start-1">
-    <CompanyLogo name={job.company} size="size-8" />
-    <p class="text-sm text-muted-foreground">
-      {#if job.company_slug}
-        <a href={resolve('/companies/[slug]', { slug: job.company_slug })} class="hover:text-foreground hover:underline">
+  <div class="flex items-center justify-between gap-3 lg:col-start-2 lg:row-start-1">
+    <div class="flex items-center gap-3">
+      <CompanyLogo name={job.company} size="size-8" />
+      <p class="text-sm text-muted-foreground">
+        {#if job.company_slug}
+          <a href={resolve('/companies/[slug]', { slug: job.company_slug })} class="hover:text-foreground hover:underline">
+            {job.company || 'Unknown company'}
+          </a>
+        {:else}
           {job.company || 'Unknown company'}
-        </a>
-      {:else}
-        {job.company || 'Unknown company'}
-      {/if}
-    </p>
+        {/if}
+      </p>
+    </div>
+
+    <a
+      class="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
+      onclick={onDiscussionClick}
+    >
+      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
+        ? ` · ${threadCount}`
+        : ''}
+    </a>
   </div>
 
   <header class="flex flex-col gap-3 lg:col-start-2 lg:row-start-2">


### PR DESCRIPTION
Job card: the Discussion link moves up beside the company name (right-aligned), instead of sitting under the Show button.

Company header: the Discussion link now sits directly under the Subscribe button (right-aligned), instead of below the company name on the left.

Pure markup reposition; `svelte-check` clean (0 errors).