### PR TITLE
feat(web): reactive Tailor CTA + wider tailor preview + CV empty-state guide

### DIFF
--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -23,12 +23,22 @@
   // `stacked` forces every multi-column section into a single column regardless of viewport
   // width — for the narrow tailoring artifact panel, where the viewport-based `lg:`/`sm:`
   // breakpoints would otherwise cram two columns into ~480px.
+  // `onState` surfaces the live analysis + running flag to a host (the /match page) so its Tailor
+  // CTA can unlock the moment the streamed analysis lands — the SSR fit is null on a cold match,
+  // so the page can't observe the result otherwise (it would need a reload).
   let {
     job,
     initial = null,
     autoRun = true,
     stacked = false,
-  }: { job: Job; initial?: MatchAnalysisResponse | null; autoRun?: boolean; stacked?: boolean } = $props();
+    onState = undefined,
+  }: {
+    job: Job;
+    initial?: MatchAnalysisResponse | null;
+    autoRun?: boolean;
+    stacked?: boolean;
+    onState?: (analysis: MatchAnalysisResponse['analysis'], running: boolean) => void;
+  } = $props();
 
   let fit = $state<MatchAnalysisResponse | null>(initial);
 
@@ -62,6 +72,10 @@
   });
 
   const analysis = $derived(stream.analysis);
+  // Push the analysis + running flag up to the host on every change (and on first paint).
+  $effect(() => {
+    onState?.(analysis, streaming || recovering);
+  });
   const isStale = $derived(fit?.stale ?? false);
   // Only auto-run when there is NO cached analysis at all (cold). A stale cache still
   // paints instantly and offers a manual Recompute — so a refresh never silently burns

--- a/web/src/lib/components/cv/CvList.svelte
+++ b/web/src/lib/components/cv/CvList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { resolve } from '$app/paths';
-  import { FileText, Download, Trash2 } from '@lucide/svelte';
+  import { FileText, Download, Trash2, ArrowRight } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import CompanyLogo from '$lib/components/CompanyLogo.svelte';
   import { type CvTailoredItem } from '$lib/cv';
@@ -54,12 +54,36 @@
   {#if status === 'loading'}
     <p class="text-muted-foreground">Loading…</p>
   {:else if status === 'ready' && items.length === 0}
-    <div class="rounded-lg border border-dashed border-border p-10 text-center">
-      <FileText class="mx-auto h-8 w-8 text-muted-foreground" />
-      <p class="mt-2 font-medium">No tailored CVs yet</p>
-      <p class="text-sm text-muted-foreground">
-        Open a vacancy, run the match analysis, and choose “Tailor my CV” to build one here.
-      </p>
+    <div class="rounded-lg border border-dashed border-border p-8 sm:p-10">
+      <div class="mx-auto max-w-md">
+        <FileText class="mx-auto h-8 w-8 text-muted-foreground" />
+        <p class="mt-3 text-center font-medium">No tailored CVs yet</p>
+        <p class="mt-1 text-center text-sm text-muted-foreground">
+          A tailored CV starts from a vacancy’s fit analysis. Here’s how:
+        </p>
+        <ol class="mx-auto mt-5 flex max-w-sm flex-col gap-3 text-left text-sm">
+          <li class="flex items-start gap-3">
+            <span class="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">1</span>
+            <span>Open a vacancy you want to apply to.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">2</span>
+            <span>Run the fit check — press <strong class="font-medium text-foreground">Analyze match</strong> on the job page.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">3</span>
+            <span>On the result, choose <strong class="font-medium text-foreground">Tailor my CV</strong> — your tailored copy appears here.</span>
+          </li>
+        </ol>
+        <div class="mt-6 text-center">
+          <a
+            href={resolve('/')}
+            class="inline-flex items-center gap-1.5 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90"
+          >
+            Browse jobs <ArrowRight class="size-4" />
+          </a>
+        </div>
+      </div>
     </div>
   {:else}
     <ul class="flex flex-col gap-3">

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -31,7 +31,7 @@
     ['verdict', 'Verdict'],
   ];
   let tab = $state<Tab>('templates');
-  let width = $state(420);
+  let width = $state(340);
   let resizing = false;
 
   // Seed MatchAnalysisFull from the already-cached analysis so it paints read-only (no recompute burn).

--- a/web/src/routes/match/[slug]/+page.svelte
+++ b/web/src/routes/match/[slug]/+page.svelte
@@ -1,18 +1,26 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { goto } from '$app/navigation';
-  import { ArrowLeft, SquarePen } from '@lucide/svelte';
+  import { ArrowLeft, SquarePen, Loader } from '@lucide/svelte';
   import { Button } from '$lib/ui';
   import CompanyLogo from '$lib/components/CompanyLogo.svelte';
   import MatchAnalysisFull from '$lib/components/MatchAnalysisFull.svelte';
 
   let { data } = $props();
 
-  // The tailoring CTA shows once an analysis exists for a stored CV (credits meter the AI spend).
-  // A stale analysis (CV or job changed since) still tailors — we nudge a recompute for the
-  // sharpest reframing (see below) rather than block, since any CV re-upload marks every past
-  // analysis stale and blocking would hide the feature too often.
-  const canTailor = $derived(!!data.fit?.analysis && data.fit?.has_cv === true);
+  // The Tailor CTA sits above the analysis and unlocks the moment the fit result lands. On a cold
+  // match the SSR `data.fit.analysis` is null and MatchAnalysisFull streams the result client-side,
+  // so we track its live state (pushed up via `onState`) instead of the SSR prop — otherwise the
+  // button would only enable after a full reload. Credits meter the AI spend; a stale analysis
+  // still tailors (we nudge a recompute rather than block).
+  const hasCv = $derived(data.fit?.has_cv === true);
+  // The streamed signal from MatchAnalysisFull (null until it first reports); once set it wins,
+  // otherwise fall back to the SSR-cached fit (present on a warm revisit). Keeping `data` inside a
+  // $derived (not a one-shot $state seed) means it also reacts to a client-side navigation.
+  let streamedReady = $state<boolean | null>(null);
+  let analyzing = $state(false);
+  const analysisReady = $derived(streamedReady ?? !!data.fit?.analysis);
+  const canTailor = $derived(analysisReady && hasCv);
 
   let tailoring = $state(false);
 
@@ -43,29 +51,42 @@
     </div>
   </header>
 
-  <MatchAnalysisFull job={data.job} initial={data.fit} />
-
-  {#if canTailor}
-    <section
-      class="flex flex-col gap-3 rounded-xl border border-border bg-muted/30 p-5 sm:flex-row sm:items-center sm:justify-between"
-    >
-      <div class="flex flex-col gap-1">
-        <h2 class="flex items-center gap-2 text-sm font-semibold">
-          <SquarePen class="size-4 text-primary" />Tailor your CV to this role
-        </h2>
-        <p class="text-sm text-muted-foreground">
-          Create a copy of your CV reframed toward this vacancy — starting from the gaps this
-          analysis found. You can keep editing it after.
-        </p>
-        {#if data.fit?.stale}
-          <p class="text-xs text-amber-600 dark:text-amber-500">
-            This analysis is out of date — recompute above for the sharpest tailoring.
-          </p>
+  {#if hasCv}
+    <div class="flex flex-col gap-2">
+      <Button
+        variant="outline"
+        size="lg"
+        onclick={startTailoring}
+        disabled={!canTailor || tailoring}
+        aria-busy={tailoring || (analyzing && !analysisReady)}
+        class="w-full gap-2 rounded-xl border-transparent bg-brand-muted font-semibold text-brand-strong transition hover:bg-brand-muted hover:text-brand-strong hover:opacity-80 disabled:opacity-60 sm:w-fit sm:self-start sm:px-6"
+      >
+        {#if tailoring}
+          <Loader class="size-[1.15rem] animate-spin" />Preparing…
+        {:else if analyzing && !analysisReady}
+          <Loader class="size-[1.15rem] animate-spin" />Analyzing your fit…
+        {:else}
+          <SquarePen class="size-[1.15rem]" />Tailor my CV
         {/if}
-      </div>
-      <Button onclick={startTailoring} disabled={tailoring} class="shrink-0">
-        {tailoring ? 'Preparing…' : 'Tailor my CV'}
       </Button>
-    </section>
+      {#if analyzing && !analysisReady}
+        <p class="text-xs text-muted-foreground">
+          The tailor button unlocks the moment your fit analysis is ready.
+        </p>
+      {:else if data.fit?.stale}
+        <p class="text-xs text-amber-600 dark:text-amber-500">
+          This analysis is out of date — recompute below for the sharpest tailoring.
+        </p>
+      {/if}
+    </div>
   {/if}
+
+  <MatchAnalysisFull
+    job={data.job}
+    initial={data.fit}
+    onState={(a, running) => {
+      streamedReady = !!a;
+      analyzing = running;
+    }}
+  />
 </div>

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -51,7 +51,7 @@
   // Left panel: which tab is shown, and its resizable width. The chat stays mounted across tab
   // switches (hidden, not unmounted) so its live session is never dropped.
   let leftTab = $state<'chat' | 'editor'>('chat');
-  let leftWidth = $state(440);
+  let leftWidth = $state(380);
   let leftPanelEl = $state<HTMLElement>();
   let leftResizing = false;
 


### PR DESCRIPTION
Follow-up polish to the just-shipped *CV tailoring out of beta* (#1063), all UI:

### Fit page — Tailor CTA (`match/[slug]`, `MatchAnalysisFull`)
- **Reacts to the live fit.** On a cold match the SSR `data.fit.analysis` is `null` and the analysis streams client-side, so the old `canTailor` (which read the SSR prop) only enabled after a full reload. `MatchAnalysisFull` now exposes an optional `onState(analysis, running)` callback; the page tracks that, so the button unlocks the moment the analysis lands.
- **Moved above the analysis** (was a section at the bottom).
- **State-aware:** disabled with an “Analyzing your fit…” spinner while streaming; enabled “Tailor my CV” when done.
- **Restyled** as a prominent green pill (`size=lg`, `rounded-xl`, `bg-brand-muted`/`text-brand-strong`) mirroring the sidebar Save action.
- `onState` is optional → no-op for the other `MatchAnalysisFull` callers (JobDrawer, tailor panel).

### Tailor workspace proportions (`tailor/[slug]`, `ArtifactPanel`)
- Narrow the side panels (left 440→380, right 420→340) so the centre CV preview gets more room. Both stay drag-resizable.

### `/my/cvs` empty state (`CvList`)
- Replace the one-liner with a 3-step guide (open a vacancy → **Analyze match** → **Tailor my CV**) + a **Browse jobs** CTA. Labels match the real UI.

## No migration / backend change — frontend only.

## Verification
- `npm run check` (svelte-check) — 0 errors.
- Not browser-verified (needs auth + a job + CV + credits); button-state logic traced across cold/warm/no-CV/no-credits.