### PR TITLE
feat(web): move the Tailor CTA into the verdict card (bottom-right)

### DIFF
--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, type Snippet } from 'svelte';
   import { resolve } from '$app/paths';
   import { RefreshCw, FileText, Check, Loader, TriangleAlert } from '@lucide/svelte';
   import { api } from '$lib/api';
@@ -23,21 +23,20 @@
   // `stacked` forces every multi-column section into a single column regardless of viewport
   // width — for the narrow tailoring artifact panel, where the viewport-based `lg:`/`sm:`
   // breakpoints would otherwise cram two columns into ~480px.
-  // `onState` surfaces the live analysis + running flag to a host (the /match page) so its Tailor
-  // CTA can unlock the moment the streamed analysis lands — the SSR fit is null on a cold match,
-  // so the page can't observe the result otherwise (it would need a reload).
+  // `tailorCta` is an optional button the /match page hands down; it renders in the verdict hero
+  // card (bottom-right), so it appears exactly when the analysis lands. Other callers omit it.
   let {
     job,
     initial = null,
     autoRun = true,
     stacked = false,
-    onState = undefined,
+    tailorCta = undefined,
   }: {
     job: Job;
     initial?: MatchAnalysisResponse | null;
     autoRun?: boolean;
     stacked?: boolean;
-    onState?: (analysis: MatchAnalysisResponse['analysis'], running: boolean) => void;
+    tailorCta?: Snippet;
   } = $props();
 
   let fit = $state<MatchAnalysisResponse | null>(initial);
@@ -72,10 +71,6 @@
   });
 
   const analysis = $derived(stream.analysis);
-  // Push the analysis + running flag up to the host on every change (and on first paint).
-  $effect(() => {
-    onState?.(analysis, streaming || recovering);
-  });
   const isStale = $derived(fit?.stale ?? false);
   // Only auto-run when there is NO cached analysis at all (cold). A stale cache still
   // paints instantly and offers a manual Recompute — so a refresh never silently burns
@@ -324,6 +319,11 @@
             </Button>
           </div>
         </div>
+        {#if tailorCta}
+          <div class="relative mt-6 flex justify-center sm:justify-end">
+            {@render tailorCta()}
+          </div>
+        {/if}
       </section>
     {/if}
 

--- a/web/src/routes/match/[slug]/+page.svelte
+++ b/web/src/routes/match/[slug]/+page.svelte
@@ -8,20 +8,6 @@
 
   let { data } = $props();
 
-  // The Tailor CTA sits above the analysis and unlocks the moment the fit result lands. On a cold
-  // match the SSR `data.fit.analysis` is null and MatchAnalysisFull streams the result client-side,
-  // so we track its live state (pushed up via `onState`) instead of the SSR prop — otherwise the
-  // button would only enable after a full reload. Credits meter the AI spend; a stale analysis
-  // still tailors (we nudge a recompute rather than block).
-  const hasCv = $derived(data.fit?.has_cv === true);
-  // The streamed signal from MatchAnalysisFull (null until it first reports); once set it wins,
-  // otherwise fall back to the SSR-cached fit (present on a warm revisit). Keeping `data` inside a
-  // $derived (not a one-shot $state seed) means it also reacts to a client-side navigation.
-  let streamedReady = $state<boolean | null>(null);
-  let analyzing = $state(false);
-  const analysisReady = $derived(streamedReady ?? !!data.fit?.analysis);
-  const canTailor = $derived(analysisReady && hasCv);
-
   let tailoring = $state(false);
 
   async function startTailoring() {
@@ -51,42 +37,24 @@
     </div>
   </header>
 
-  {#if hasCv}
-    <div class="flex flex-col gap-2">
-      <Button
-        variant="outline"
-        size="lg"
-        onclick={startTailoring}
-        disabled={!canTailor || tailoring}
-        aria-busy={tailoring || (analyzing && !analysisReady)}
-        class="w-full gap-2 rounded-xl border-transparent bg-brand-muted font-semibold text-brand-strong transition hover:bg-brand-muted hover:text-brand-strong hover:opacity-80 disabled:opacity-60 sm:w-fit sm:self-start sm:px-6"
-      >
-        {#if tailoring}
-          <Loader class="size-[1.15rem] animate-spin" />Preparing…
-        {:else if analyzing && !analysisReady}
-          <Loader class="size-[1.15rem] animate-spin" />Analyzing your fit…
-        {:else}
-          <SquarePen class="size-[1.15rem]" />Tailor my CV
-        {/if}
-      </Button>
-      {#if analyzing && !analysisReady}
-        <p class="text-xs text-muted-foreground">
-          The tailor button unlocks the moment your fit analysis is ready.
-        </p>
-      {:else if data.fit?.stale}
-        <p class="text-xs text-amber-600 dark:text-amber-500">
-          This analysis is out of date — recompute below for the sharpest tailoring.
-        </p>
+  <!-- The Tailor CTA renders inside the verdict card (bottom-right), so it appears exactly when
+       the analysis lands. MatchAnalysisFull owns the card; the page owns the button + navigation
+       and hands it down as a snippet. -->
+  {#snippet tailorCta()}
+    <Button
+      variant="outline"
+      size="lg"
+      onclick={startTailoring}
+      disabled={tailoring}
+      class="gap-2 rounded-xl border-transparent bg-brand-muted font-semibold text-brand-strong transition hover:bg-brand-muted hover:text-brand-strong hover:opacity-80 disabled:opacity-60"
+    >
+      {#if tailoring}
+        <Loader class="size-[1.15rem] animate-spin" />Preparing…
+      {:else}
+        <SquarePen class="size-[1.15rem]" />Tailor my CV
       {/if}
-    </div>
-  {/if}
+    </Button>
+  {/snippet}
 
-  <MatchAnalysisFull
-    job={data.job}
-    initial={data.fit}
-    onState={(a, running) => {
-      streamedReady = !!a;
-      analyzing = running;
-    }}
-  />
+  <MatchAnalysisFull job={data.job} initial={data.fit} {tailorCta} />
 </div>


### PR DESCRIPTION
Iteration on #1066: instead of a standalone button above the analysis, the **Tailor my CV** CTA now sits inside the verdict hero card, bottom-right (right-aligned row on desktop, centred on mobile). It renders via a `tailorCta` snippet the /match page hands to `MatchAnalysisFull` — the page keeps the navigation + preparing state, the component just slots it into the card. The `onState` callback from #1066 is removed (no longer needed — the card only renders when the analysis is ready, so the button naturally appears then). Frontend-only. `npm run check`: 0 errors.