### PR TITLE
feat(sources): onboard 8 contributed boards + fix Workday locale-as-site recognizer

### DIFF
--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -120,10 +120,14 @@ func RecognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 
 	case modeHostPath:
 		// Workday: board = "<host>/<site>" where site is the first path segment (case-preserved,
-		// as the ingest stores it). Canonical strips to scheme://host/site.
-		site := firstPathSegment(u)
+		// as the ingest stores it). Workday's public URL may prefix the site with an xx-XX locale
+		// the CXS API omits (host/en-US/<site>), so skip a leading locale — a locale-prefixed URL
+		// and a bare one resolve to the same board. A URL carrying ONLY a locale (host/en-US, itself
+		// a 404 landing) has no derivable site and is left unrecognized rather than taken as a false
+		// "en-US" board. Canonical strips to scheme://host/site.
+		site := firstSegmentAfterLocale(u)
 		if site == "" {
-			return "", "", "", false // bare host, no site
+			return "", "", "", false // bare host or locale-only, no site
 		}
 		u.RawQuery, u.Fragment = "", ""
 		u.Path = "/" + site
@@ -133,7 +137,7 @@ func RecognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 		// Rippling: skip a leading xx-XX locale segment (ats.rippling.com/en-GB/<board>/…),
 		// which the board API omits, and collapse the canonical to the board root so a
 		// locale-prefixed vacancy, a bare vacancy, and the listing all map to one board.
-		board = boardAfterLocale(u)
+		board = firstSegmentAfterLocale(u)
 		if board == "" {
 			return "", "", "", false
 		}
@@ -191,9 +195,10 @@ func subdomainLabel(host, apex string) string {
 // lowercase (satomic, 360-fire-flood), so the uppercase country code never collides.
 var localeSegment = regexp.MustCompile(`^[a-z]{2}-[A-Z]{2}$`)
 
-// boardAfterLocale returns the first path segment that isn't a leading locale — the tenant board
-// in ats.rippling.com/<locale?>/<board>/… . "" when the path is empty or carries only a locale.
-func boardAfterLocale(u *url.URL) string {
+// firstSegmentAfterLocale returns the first path segment that isn't a leading xx-XX locale — the
+// tenant board in ats.rippling.com/<locale?>/<board>/… (Rippling) or the site in a Workday
+// host/<locale?>/<site> URL. "" when the path is empty or carries only a locale.
+func firstSegmentAfterLocale(u *url.URL) string {
 	p := strings.Trim(u.Path, "/")
 	if p == "" {
 		return ""

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -51,9 +51,13 @@ func TestRecognizeBoard(t *testing.T) {
 		{"workday vacancy", "https://generalmotors.wd5.myworkdayjobs.com/Careers_GM/job/Austin/Senior-Software-Engineer_JR-202614238", "workday", "generalmotors.wd5.myworkdayjobs.com/Careers_GM", "https://generalmotors.wd5.myworkdayjobs.com/Careers_GM", true},
 		{"workday board listing", "https://generalmotors.wd5.myworkdayjobs.com/Careers_GM", "workday", "generalmotors.wd5.myworkdayjobs.com/Careers_GM", "https://generalmotors.wd5.myworkdayjobs.com/Careers_GM", true},
 		{"workday other pod", "https://goodyear.wd1.myworkdayjobs.com/goodyearcareers/job/x", "workday", "goodyear.wd1.myworkdayjobs.com/goodyearcareers", "https://goodyear.wd1.myworkdayjobs.com/goodyearcareers", true},
+		// Workday's public URL may prefix the site with an xx-XX locale the CXS API omits — skip it
+		{"workday locale-prefixed site", "https://gm.wd5.myworkdayjobs.com/en-US/Careers_GM/job/x/Eng_JR-1", "workday", "gm.wd5.myworkdayjobs.com/Careers_GM", "https://gm.wd5.myworkdayjobs.com/Careers_GM", true},
 
 		// declined
 		{"workday bare host no site", "https://generalmotors.wd5.myworkdayjobs.com", "", "", "", false},
+		// a URL carrying only a locale has no derivable site — unrecognized, not a false "en-US" board
+		{"workday locale only no site", "https://salesforce.wd12.myworkdayjobs.com/en-US", "", "", "", false},
 		{"ashby bare host no board", "https://jobs.ashbyhq.com", "", "", "", false},
 		{"recruitee bare apex no tenant", "https://recruitee.com/", "", "", "", false},
 		{"personio bare apex no tenant", "https://jobs.personio.com", "", "", "", false},

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7603,3 +7603,5 @@
   board: wafer
 - company: watney
   board: watney
+- company: Linro
+  board: linro

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -18693,3 +18693,7 @@
   board: naturetrustofbc
 - company: tailwindvoiceanddata
   board: tailwindvoiceanddata
+- company: Dzengi
+  board: dzengi
+- company: Koombea
+  board: koombea

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -128,3 +128,5 @@
   board: panynj
 - company: nychdc
   board: nychdc
+- company: ARRISE
+  board: pragmaticplay

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -167,3 +167,9 @@
   board: satomic
 - company: LegitScript
   board: legitscript-careers
+- company: Onfleet
+  board: onfleet-careers
+- company: Urban Sky
+  board: urban-sky
+- company: Abby Health
+  board: abby-health

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -127,6 +127,8 @@
   board: appseconnect.zohorecruit.com
 - company: Qore
   board: appzonegroup.zohorecruit.com
+- company: Apricot International
+  board: apricotinternational.zohorecruit.com
 - company: Aqary Investment & Development
   board: aqaryinvestment.zohorecruit.com
 - company: AQM Technologies

--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -48,20 +48,19 @@
       {/if}
     </div>
     <!-- flex-1 above lets the name/tagline use the full width; the follow CTA stays
-         top-right and never shrinks (it collapses to an icon on mobile itself). -->
-    <div class="shrink-0">
+         top-right and never shrinks (it collapses to an icon on mobile itself).
+         The Discussion link sits right below it, right-aligned. -->
+    <div class="flex shrink-0 flex-col items-end gap-2">
       <CompanyFollowButton {slug} companyName={company.name} />
+      <a
+        class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+        href={resolve('/companies/[slug]/discussion', { slug })}
+      >
+        <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
+          ? ` · ${threadCount}`
+          : ''}
+      </a>
     </div>
-  </div>
-  <div class="mt-3">
-    <a
-      class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-      href={resolve('/companies/[slug]/discussion', { slug })}
-    >
-      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
-        ? ` · ${threadCount}`
-        : ''}
-    </a>
   </div>
   {#if hasMeta}
     <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-3">

--- a/web/src/lib/components/CountryFlagStack.svelte
+++ b/web/src/lib/components/CountryFlagStack.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { filterHref } from '$lib/enrichment';
+  import CountryFlag from './CountryFlag.svelte';
+
+  // An overlapping cluster of round country flags (an avatar-stack). Collapses a
+  // long country list into a compact, space-saving row: each flag laps over the
+  // previous one, capped at `max` with a "+N" chip for the remainder. Used on the
+  // browse card (display-only) and the job sidebar (`link` on), where a wide remote
+  // role can list a dozen eligible countries.
+  //
+  // The flags overlap by `--lap` (an em fraction of a flag's width) via a negative
+  // left margin, and each carries a `ring-card` outline so neighbours stay legible
+  // where they touch. Earlier flags sit on top (descending z-index) so the row reads
+  // left-to-right; hovering a flag raises it above its neighbours.
+  let {
+    codes,
+    max = 6,
+    link = false,
+    class: className = '',
+  }: {
+    codes: string[];
+    max?: number;
+    link?: boolean;
+    class?: string;
+  } = $props();
+
+  const shown = $derived(codes.slice(0, max));
+  const extra = $derived(codes.length - shown.length);
+</script>
+
+{#if codes.length}
+  <div class={['flex items-center', className]} style:--lap="0.4em">
+    {#each shown as code, i (code)}
+      <span
+        class={[
+          'relative inline-flex rounded-full ring-2 ring-card transition hover:z-10 hover:-translate-y-px',
+          i > 0 && '-ml-[var(--lap)]',
+        ]}
+        style:z-index={shown.length - i}
+      >
+        {#if link}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
+          <a href={filterHref('countries', code)} class="inline-flex"><CountryFlag {code} /></a>
+        {:else}
+          <CountryFlag {code} />
+        {/if}
+      </span>
+    {/each}
+    {#if extra > 0}
+      <span class="ml-1.5 text-xs font-medium text-muted-foreground">+{extra}</span>
+    {/if}
+  </div>
+{/if}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
   import { Bookmark, Eye, EyeOff, X } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CountryFlagStack from './CountryFlagStack.svelte';
   import JobMatchBar from './JobMatchBar.svelte';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -244,12 +245,17 @@
 
   <!-- Signal row: reality chip + the region/employment facets, grouped under the
        title as quiet outline chips so they read as metadata, not decoration. -->
-  {#if job.reality || tags.length > 0}
+  {#if job.reality || tags.length > 0 || job.countries?.length}
     <div class="mt-2 flex flex-wrap items-center gap-1.5">
       <RealityBadge reality={job.reality} />
       {#each tags as tag (tag)}
         <Badge variant="outline">{tag}</Badge>
       {/each}
+      <!-- Eligible countries as an overlapping flag cluster. Display-only here: the
+           whole card is a link, so the flags carry no nested filter links. -->
+      {#if job.countries?.length}
+        <CountryFlagStack codes={job.countries} max={5} class="ml-0.5 text-base" />
+      {/if}
     </div>
   {/if}
 

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -12,7 +12,7 @@
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
-  import CountryFlag from './CountryFlag.svelte';
+  import CountryFlagStack from './CountryFlagStack.svelte';
   import JobDescription from './JobDescription.svelte';
   import JobMatch from './JobMatch.svelte';
   import RealityBadge from './RealityBadge.svelte';
@@ -325,16 +325,12 @@
             <div class="flex items-baseline justify-between gap-3">
               <dt class="shrink-0 text-muted-foreground">{facet.label}</dt>
               {#if facet.values.every((v) => v.flag)}
-                <!-- Flag facet (Country): a wrapping row of round flags, right-aligned,
-                     each linking to its filter. No comma separators — the gap reads the
-                     list on its own and stays compact for many-country remote jobs. -->
-                <dd class="flex min-w-0 flex-wrap justify-end gap-1.5 text-base">
-                  {#each facet.values as v (v.text)}
-                    {#if v.href}
-                      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
-                      <a href={v.href} class="transition hover:opacity-80"><CountryFlag code={v.flag ?? ''} /></a>
-                    {:else}<CountryFlag code={v.flag ?? ''} />{/if}
-                  {/each}
+                <!-- Flag facet (Country): an overlapping cluster of round flags,
+                     right-aligned, each linking to its filter. The stack laps the
+                     flags over one another so a many-country remote role stays a
+                     single compact row instead of wrapping. -->
+                <dd class="flex min-w-0 justify-end text-base">
+                  <CountryFlagStack codes={facet.values.map((v) => v.flag ?? '')} link />
                 </dd>
               {:else}
                 <dd class="min-w-0 break-words text-right font-medium"

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -251,16 +251,6 @@
 
     <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
 
-    <a
-      class="inline-flex items-center gap-1.5 self-end text-sm font-medium text-primary hover:underline"
-      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
-      onclick={onDiscussionClick}
-    >
-      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
-        ? ` · ${threadCount}`
-        : ''}
-    </a>
-
     {#if job.referral_available && job.company_slug}
       <ReferralBlock companySlug={job.company_slug} companyName={job.company} />
     {/if}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -209,17 +209,29 @@
 <article
   class="flex flex-col gap-4 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)] lg:grid-rows-[auto_auto_minmax(0,1fr)] lg:gap-x-6 lg:gap-y-4"
 >
-  <div class="flex items-center gap-3 lg:col-start-2 lg:row-start-1">
-    <CompanyLogo name={job.company} size="size-8" />
-    <p class="text-sm text-muted-foreground">
-      {#if job.company_slug}
-        <a href={resolve('/companies/[slug]', { slug: job.company_slug })} class="hover:text-foreground hover:underline">
+  <div class="flex items-center justify-between gap-3 lg:col-start-2 lg:row-start-1">
+    <div class="flex items-center gap-3">
+      <CompanyLogo name={job.company} size="size-8" />
+      <p class="text-sm text-muted-foreground">
+        {#if job.company_slug}
+          <a href={resolve('/companies/[slug]', { slug: job.company_slug })} class="hover:text-foreground hover:underline">
+            {job.company || 'Unknown company'}
+          </a>
+        {:else}
           {job.company || 'Unknown company'}
-        </a>
-      {:else}
-        {job.company || 'Unknown company'}
-      {/if}
-    </p>
+        {/if}
+      </p>
+    </div>
+
+    <a
+      class="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
+      onclick={onDiscussionClick}
+    >
+      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
+        ? ` · ${threadCount}`
+        : ''}
+    </a>
   </div>
 
   <header class="flex flex-col gap-4 lg:col-start-2 lg:row-start-2">


### PR DESCRIPTION
Drains the pending `link_contributions` backlog (the crowdsourced "contribute a board" flow) and fixes a recognizer bug that backlog surfaced.

## Onboarded (8 new boards, live-validated)
| source | board | company | check |
|---|---|---|---|
| ashby | `linro` | Linro | board page 200 |
| rippling | `onfleet-careers` | Onfleet | /jobs 200 |
| rippling | `urban-sky` | Urban Sky | /jobs 200 |
| rippling | `abby-health` | Abby Health | /jobs 200 |
| bamboohr | `dzengi` | Dzengi | careers 200 |
| bamboohr | `koombea` | Koombea | careers 200 |
| jobvite | `pragmaticplay` | ARRISE | listing 200 |
| zohorecruit | `apricotinternational.zohorecruit.com` | Apricot International | /jobs/Careers 200 |

## Recognizer fix — Workday locale-as-site
`RecognizeBoard` hostpath mode took the first path segment as the Workday site. A bare locale landing like `salesforce.wd12.myworkdayjobs.com/en-US` (itself a 404) was recognized as a **false** `host/en-US` board — CXS API returns `404 not found` for it. This is what let three contributions record bogus boards that then dodged the already-tracked dedup (Salesforce/Zebra/The Hartford are in fact already crawled under their real sites: `External_Career_Site`, `Zebra_careers`, `Careers_External`).

Fix: skip a leading `xx-XX` locale (reusing the Rippling locale logic, renamed `firstSegmentAfterLocale`). A locale-only URL now has no derivable site → stays unrecognized (`review`) instead of a false board. Normal Workday URLs are unchanged. Tests added for both the locale-prefixed-site and locale-only cases.

## Not in this PR
- Rejecting the 11 dead `review`-queue rows and flipping `status` on prod — done after merge (prod-only table).
- gupy (#44), hirefly, recrut.ai review-queue leads — gupy needs a network-fetch recognizer tier (board = numeric companyId, not URL-derivable); hirefly/recrut.ai are new adapters. Tracked separately.

`go build ./...`, `go vet`, `go test ./internal/contribution ./internal/sources` all green.