### PR TITLE
feat(sources): onboard 7 a16z Speedrun boards (6 Ashby, 1 Lever)

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7605,3 +7605,16 @@
   board: watney
 - company: Linro
   board: linro
+# a16z Speedrun talent-network (harvested 2026-07)
+- company: Forgepoint
+  board: forgepoint
+- company: Fundamental Research Labs
+  board: fundamentalresearchlabs
+- company: Ghost
+  board: ghost
+- company: Maniac
+  board: maniac
+- company: Method Security
+  board: method.security
+- company: Orchestra Bio
+  board: orchestra-bio

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4392,3 +4392,6 @@
   board: manaycpa.com
 - company: robbinsrecruiting
   board: robbinsrecruiting
+# a16z Speedrun talent-network (harvested 2026-07)
+- company: Management Leadership for Tomorrow
+  board: ml4t


### PR DESCRIPTION
## What

Adds 7 native ATS boards discovered by harvesting the [a16z Speedrun talent-network](https://speedrun-talent-network.com/companies).

## How it was found

The Speedrun site is an **aggregator** (custom Astro app, Cloudflare-fronted) — each job federates out to the portfolio company's own ATS apply URL. Harvested all **314 companies**, extracted the ATS token from each apply URL, and diffed against our existing sources:

| Platform | In network | Already tracked | New |
|---|---|---|---|
| Ashby | 212 | 205 | **6 live** |
| Greenhouse | 60 | 60 | 0 |
| Lever | 22 | 19 | **1 live** |

**~98% of the network was already covered** — so a dedicated aggregator adapter would be almost all duplicates and is intentionally *not* added. 14 early-stage companies apply on-site (no external ATS) and can't be ingested yet.

## Boards added (validated live via Ashby/Lever posting APIs)

**Ashby:** `forgepoint`, `fundamentalresearchlabs`, `ghost`, `maniac`, `method.security`, `orchestra-bio`
**Lever:** `ml4t` (Management Leadership for Tomorrow)

## Verification

- `go test ./internal/sources/` (config/board validation) — pass
- Each token confirmed to return open postings from its ATS API