### PR TITLE
feat(web): overlapping country-flag stack + Discussion link in job/company header

### DIFF
--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -48,20 +48,19 @@
       {/if}
     </div>
     <!-- flex-1 above lets the name/tagline use the full width; the follow CTA stays
-         top-right and never shrinks (it collapses to an icon on mobile itself). -->
-    <div class="shrink-0">
+         top-right and never shrinks (it collapses to an icon on mobile itself).
+         The Discussion link sits right below it, right-aligned. -->
+    <div class="flex shrink-0 flex-col items-end gap-2">
       <CompanyFollowButton {slug} companyName={company.name} />
+      <a
+        class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+        href={resolve('/companies/[slug]/discussion', { slug })}
+      >
+        <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
+          ? ` · ${threadCount}`
+          : ''}
+      </a>
     </div>
-  </div>
-  <div class="mt-3">
-    <a
-      class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-      href={resolve('/companies/[slug]/discussion', { slug })}
-    >
-      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
-        ? ` · ${threadCount}`
-        : ''}
-    </a>
   </div>
   {#if hasMeta}
     <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-3">

--- a/web/src/lib/components/CountryFlagStack.svelte
+++ b/web/src/lib/components/CountryFlagStack.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { filterHref } from '$lib/enrichment';
+  import CountryFlag from './CountryFlag.svelte';
+
+  // An overlapping cluster of round country flags (an avatar-stack). Collapses a
+  // long country list into a compact, space-saving row: each flag laps over the
+  // previous one, capped at `max` with a "+N" chip for the remainder. Used on the
+  // browse card (display-only) and the job sidebar (`link` on), where a wide remote
+  // role can list a dozen eligible countries.
+  //
+  // The flags overlap by `--lap` (an em fraction of a flag's width) via a negative
+  // left margin, and each carries a `ring-card` outline so neighbours stay legible
+  // where they touch. Earlier flags sit on top (descending z-index) so the row reads
+  // left-to-right; hovering a flag raises it above its neighbours.
+  let {
+    codes,
+    max = 6,
+    link = false,
+    class: className = '',
+  }: {
+    codes: string[];
+    max?: number;
+    link?: boolean;
+    class?: string;
+  } = $props();
+
+  const shown = $derived(codes.slice(0, max));
+  const extra = $derived(codes.length - shown.length);
+</script>
+
+{#if codes.length}
+  <div class={['flex items-center', className]} style:--lap="0.4em">
+    {#each shown as code, i (code)}
+      <span
+        class={[
+          'relative inline-flex rounded-full ring-2 ring-card transition hover:z-10 hover:-translate-y-px',
+          i > 0 && '-ml-[var(--lap)]',
+        ]}
+        style:z-index={shown.length - i}
+      >
+        {#if link}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
+          <a href={filterHref('countries', code)} class="inline-flex"><CountryFlag {code} /></a>
+        {:else}
+          <CountryFlag {code} />
+        {/if}
+      </span>
+    {/each}
+    {#if extra > 0}
+      <span class="ml-1.5 text-xs font-medium text-muted-foreground">+{extra}</span>
+    {/if}
+  </div>
+{/if}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
   import { Bookmark, Eye, EyeOff, X } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CountryFlagStack from './CountryFlagStack.svelte';
   import JobMatchBar from './JobMatchBar.svelte';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -244,12 +245,17 @@
 
   <!-- Signal row: reality chip + the region/employment facets, grouped under the
        title as quiet outline chips so they read as metadata, not decoration. -->
-  {#if job.reality || tags.length > 0}
+  {#if job.reality || tags.length > 0 || job.countries?.length}
     <div class="mt-2 flex flex-wrap items-center gap-1.5">
       <RealityBadge reality={job.reality} />
       {#each tags as tag (tag)}
         <Badge variant="outline">{tag}</Badge>
       {/each}
+      <!-- Eligible countries as an overlapping flag cluster. Display-only here: the
+           whole card is a link, so the flags carry no nested filter links. -->
+      {#if job.countries?.length}
+        <CountryFlagStack codes={job.countries} max={5} class="ml-0.5 text-base" />
+      {/if}
     </div>
   {/if}
 

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -12,7 +12,7 @@
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
-  import CountryFlag from './CountryFlag.svelte';
+  import CountryFlagStack from './CountryFlagStack.svelte';
   import JobDescription from './JobDescription.svelte';
   import JobMatch from './JobMatch.svelte';
   import RealityBadge from './RealityBadge.svelte';
@@ -325,16 +325,12 @@
             <div class="flex items-baseline justify-between gap-3">
               <dt class="shrink-0 text-muted-foreground">{facet.label}</dt>
               {#if facet.values.every((v) => v.flag)}
-                <!-- Flag facet (Country): a wrapping row of round flags, right-aligned,
-                     each linking to its filter. No comma separators — the gap reads the
-                     list on its own and stays compact for many-country remote jobs. -->
-                <dd class="flex min-w-0 flex-wrap justify-end gap-1.5 text-base">
-                  {#each facet.values as v (v.text)}
-                    {#if v.href}
-                      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
-                      <a href={v.href} class="transition hover:opacity-80"><CountryFlag code={v.flag ?? ''} /></a>
-                    {:else}<CountryFlag code={v.flag ?? ''} />{/if}
-                  {/each}
+                <!-- Flag facet (Country): an overlapping cluster of round flags,
+                     right-aligned, each linking to its filter. The stack laps the
+                     flags over one another so a many-country remote role stays a
+                     single compact row instead of wrapping. -->
+                <dd class="flex min-w-0 justify-end text-base">
+                  <CountryFlagStack codes={facet.values.map((v) => v.flag ?? '')} link />
                 </dd>
               {:else}
                 <dd class="min-w-0 break-words text-right font-medium"

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -251,16 +251,6 @@
 
     <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
 
-    <a
-      class="inline-flex items-center gap-1.5 self-end text-sm font-medium text-primary hover:underline"
-      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
-      onclick={onDiscussionClick}
-    >
-      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
-        ? ` · ${threadCount}`
-        : ''}
-    </a>
-
     {#if job.referral_available && job.company_slug}
       <ReferralBlock companySlug={job.company_slug} companyName={job.company} />
     {/if}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -209,17 +209,29 @@
 <article
   class="flex flex-col gap-4 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)] lg:grid-rows-[auto_auto_minmax(0,1fr)] lg:gap-x-6 lg:gap-y-4"
 >
-  <div class="flex items-center gap-3 lg:col-start-2 lg:row-start-1">
-    <CompanyLogo name={job.company} size="size-8" />
-    <p class="text-sm text-muted-foreground">
-      {#if job.company_slug}
-        <a href={resolve('/companies/[slug]', { slug: job.company_slug })} class="hover:text-foreground hover:underline">
+  <div class="flex items-center justify-between gap-3 lg:col-start-2 lg:row-start-1">
+    <div class="flex items-center gap-3">
+      <CompanyLogo name={job.company} size="size-8" />
+      <p class="text-sm text-muted-foreground">
+        {#if job.company_slug}
+          <a href={resolve('/companies/[slug]', { slug: job.company_slug })} class="hover:text-foreground hover:underline">
+            {job.company || 'Unknown company'}
+          </a>
+        {:else}
           {job.company || 'Unknown company'}
-        </a>
-      {:else}
-        {job.company || 'Unknown company'}
-      {/if}
-    </p>
+        {/if}
+      </p>
+    </div>
+
+    <a
+      class="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
+      onclick={onDiscussionClick}
+    >
+      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
+        ? ` · ${threadCount}`
+        : ''}
+    </a>
   </div>
 
   <header class="flex flex-col gap-4 lg:col-start-2 lg:row-start-2">


### PR DESCRIPTION
## What

- **CountryFlagStack** — avatar-style cluster of round country flags that overlap (leftmost on top, ring-card separators, `+N` overflow), so a many-country remote role stays a compact row instead of wrapping.
  - JobRow: eligible-country flags in the signal row (display-only — the card is a link).
  - JobView sidebar: replaces the wrapping country flag row with the stack (linked to per-country filters).
- **Discussion link** lifted into the job/company header top row (right-aligned beside the company name; under Subscribe on the company header); removed the duplicate that rendered in the header body.

## Notes
3 web-only commits. No API/DB changes.