### PR TITLE
feat(web): surface CLI facets/market-fit/cv, MCP, and agent skill on /cli

### DIFF
--- a/docs/superpowers/specs/2026-07-22-pii-masking-cv-llm-design.md
+++ b/docs/superpowers/specs/2026-07-22-pii-masking-cv-llm-design.md
@@ -1,8 +1,8 @@
 # PII masking for CV in LLM calls — design
 
 **Date:** 2026-07-22
-**Status:** design (awaiting review)
-**Scope:** `internal/pii` (new), `internal/matchanalysis`, `internal/resumeextract`, plus a local PII-model sidecar.
+**Status:** design — spike VALIDATED, ready to plan
+**Scope:** `internal/pii` (new), `internal/matchanalysis`, `internal/resumeextract`, plus a co-located `openai/privacy-filter` span-detection endpoint.
 
 ## Goal & threat model
 
@@ -37,6 +37,26 @@ Ran the deterministic detectors against two real CVs (single-column and two-colu
 a **local** PII model (never leaves our perimeter) for `PERSON`/`ADDRESS`/`LOCATION`
 spans, with the regex layer kept as a high-precision floor.
 
+### Model spike (2026-07-22) — VALIDATED
+
+Ran the real `openai/privacy-filter` (ONNX **q4**, `onnxruntime` on CPU, no torch) against
+the same two CVs. Labels are BIOES over 8 types (`private_person/email/phone/url/address`,
+`account_number`, `secret`, `private_date`).
+
+- **Ilya (single-column, 1542 tok, 2.2s):** `private_person: Ilya Strelov`, email, github/linkedin URLs.
+- **Alex (two-column, 1166 tok, 0.9s):** recovered the hidden surname — `private_person:
+  alex-bessmelcev`, `/alex-bessmelcev`, `@Alex_Sage`; email + portfolio URL. (Bare
+  first-name "Alex" alone was not tagged — a weak identifier, and it is covered by the
+  caught spans anyway.)
+- **No over-redaction:** employers (RingCentral, Informa, emcd.io), universities, and
+  cities (London, Belmont, Florianópolis) were left untouched on both CVs — exactly the
+  context the fit analysis needs stays visible.
+
+Verdict: **VALIDATED** — fast on CPU (<2.5s/CV, one call per analysis/upload), recovers the
+name the deterministic layer could not, and does not touch employer/geo context. Production
+uses the shipped Viterbi decoder (`viterbi_calibration.json`) for span stitching; the spike
+used plain argmax and still succeeded.
+
 ## Architecture
 
 ### New package `internal/pii`
@@ -70,16 +90,28 @@ func (r *Redactor) Restore(text string) string  // unmask on the way OUT to the 
   word boundaries; known/full-value matches take priority over short single tokens to
   bound over-redaction.
 
-### Local PII-model sidecar
+### Privacy-filter detection endpoint (integration form B)
 
-- **Model:** `openai/privacy-filter` (Apache-2.0, 1.5B MoE, ~50M active params, CPU-OK,
-  ~96% F1, 128K context). Pulled **only** from the official repo (a malicious typosquat
-  existed).
-- **Shape:** a small HTTP service (Python) co-located with the backend; `internal/pii`'s
-  model `Detector` calls it over localhost. One call per CV per analysis / per upload —
-  not per stage.
+Decision: the model is served as a **span-detection HTTP endpoint**, and freehire does the
+masking/restoring in Go — NOT a litellm masking guardrail. Rationale:
+
+- `resumeextract`'s whole job is to *obtain* contacts; a proxy guardrail masks the CV so the
+  LLM can't return them and does not hand the detected spans back to freehire — so a callable
+  detector is needed regardless. Once it exists, `matchanalysis` uses it too, and the proxy
+  guardrail becomes redundant.
+- In-Go masking keeps the scope surgical (CV only — `enrich` of public job text is never
+  touched, no per-request guardrail opt-in), keeps restore fully under our control (litellm's
+  `output_parse_pii` has documented streaming-restore bugs and `matchanalysis` is SSE), and
+  keeps freehire's privacy self-contained rather than coupled to the litellm repo/deploy.
+
+- **Model:** `openai/privacy-filter` (Apache-2.0, ONNX q4, `onnxruntime`, CPU-OK, ~96% F1,
+  128K context). Pulled **only** from the official repo (a malicious typosquat existed).
+- **Shape:** a small HTTP detection service that returns PII spans (`{start,end,kind}`) for a
+  text. Co-located on the litellm box (`204.168.137.149`) so the weights "live" beside the
+  gateway, but freehire calls it directly — it is NOT on the litellm proxy request path.
+  `internal/pii`'s model `Detector` is the HTTP client. One call per CV per analysis / upload.
 - **Configuration:** a new env (e.g. `PII_FILTER_URL`) on the server/worker config. When
-  unset the detector is considered unconfigured.
+  unset the detector is considered unconfigured (→ fail-closed, below).
 
 ## Data-flow invariant (most important)
 
@@ -137,9 +169,7 @@ sufficient for the name, so regex-only is not a fallback.
   detector.
 - `resumeextract`: assert contacts are filled from detection and that the LLM input
   carries no PII; assert fail-closed.
-- **Implementation-time model spike:** run the actual Privacy Filter against the two spike
-  CVs and confirm it recovers the buried surname (`Bessmelcev`) and the `Alex` name before
-  wiring it in.
+- Model already spiked and VALIDATED (see above); wiring tests use a faked `Detector`.
 
 ## Known trade-offs / seams
 
@@ -148,6 +178,9 @@ sufficient for the name, so regex-only is not a fallback.
   input-semantics hit — accepted, monitored.
 - **Address:** modern CVs rarely carry a postal address (only a city, which we keep). The
   model covers the rare real address; no separate deterministic address detector.
-- **Sidecar is new infra:** one Python service + weights to deploy and monitor. Deployment
-  host (co-locate on the backend host vs beside the litellm proxy) is an ops decision to
-  settle during implementation; CPU inference is sufficient.
+- **Detection endpoint is new infra:** one small HTTP service + ONNX q4 weights (~900MB),
+  co-located on the litellm box (`204.168.137.149`), CPU inference (<2.5s/CV). It serves
+  span detection only; it is not on the litellm proxy request path. To monitor and health-
+  check like the other model-path infra.
+- **Streaming restore is NOT a concern here** (unlike the litellm-guardrail form): restore
+  runs in Go on the emitted/returned analysis, so the SSE path is unaffected.

--- a/docs/superpowers/specs/2026-07-22-pii-masking-cv-llm-design.md
+++ b/docs/superpowers/specs/2026-07-22-pii-masking-cv-llm-design.md
@@ -1,0 +1,153 @@
+# PII masking for CV in LLM calls — design
+
+**Date:** 2026-07-22
+**Status:** design (awaiting review)
+**Scope:** `internal/pii` (new), `internal/matchanalysis`, `internal/resumeextract`, plus a local PII-model sidecar.
+
+## Goal & threat model
+
+When a user's CV is sent to an LLM, real direct identifiers must **never leave our
+perimeter and reach the model provider**. Our LLM traffic flows through a self-hosted
+litellm proxy, but the proxy forwards to external model providers (OpenAI/Anthropic/…),
+so masking must happen **before** the request leaves us.
+
+The analysis output is served back to the **same** user (it is their own CV), so within
+our system the data is not sensitive — the concern is strictly the outbound provider hop.
+
+**PII in scope (mask):** full name, email, phone, home/postal address, personal links
+(portfolio/LinkedIn/GitHub/Telegram handle).
+**Explicitly out of scope (keep visible to the model):** employer names, universities,
+job titles, skills, city/country context — these are load-bearing for fit scoring
+(`experience_relevance`, `company_context`, `location_fit`) and are not direct identifiers.
+
+## Spike findings (2026-07-22) that shaped this design
+
+Ran the deterministic detectors against two real CVs (single-column and two-column):
+
+- **Regex layer (email / phone / URL / @handle) — VALIDATED.** Caught the crisp
+  identifiers on both layouts. One fix required: the phone regex matched a `YYYY-YYYY`
+  date range as a phone number — needs a date-range guard.
+- **Plain-text name detection by "top-of-CV header" heuristic — INVALIDATED for
+  multi-column layouts.** `pdftotext -layout` puts a section header (`ABOUT ME`) on the
+  first line and pushes the visible name far down; worse, the full surname often appears
+  **only inside the email local-part / URL slug** (`alexbessmelcev`, `alex-bessmelcev`),
+  never as plain text. A regex/heuristic cannot reliably recover the name.
+
+**Consequence:** robust name/address detection needs a model that reads context. We use
+a **local** PII model (never leaves our perimeter) for `PERSON`/`ADDRESS`/`LOCATION`
+spans, with the regex layer kept as a high-precision floor.
+
+## Architecture
+
+### New package `internal/pii`
+
+Pure orchestration + the deterministic detectors; the model call is behind a small
+client interface so `internal/pii` stays testable without the sidecar.
+
+```
+type Contacts struct{ FullName, Email, Phone string; Links []string } // known, authoritative
+
+type Span struct{ Start, End int; Kind string } // NAME|EMAIL|PHONE|LINK|ADDRESS
+
+type Detector interface { Detect(ctx, text string) ([]Span, error) } // model sidecar impl
+
+type Redactor struct { /* value->placeholder and placeholder->value maps */ }
+
+func Build(ctx, text string, known Contacts, d Detector) (*Redactor, error)
+func (r *Redactor) Redact(text string) string   // mask on the way INTO a prompt
+func (r *Redactor) Restore(text string) string  // unmask on the way OUT to the user
+```
+
+- **Regex detectors (in-process, always run):** email, phone (with `YYYY-YYYY` date
+  guard), URL (http/https, bare `domain.tld/…`, `linkedin.com/…`, `github.com/…`,
+  `t.me/…`), `@handle`.
+- **Model detector (sidecar):** OpenAI Privacy Filter returns token-level PII spans;
+  we keep `PERSON`/`ADDRESS`/`LOCATION`(home) and drop categories we deliberately allow.
+- **Merge:** regex spans ∪ model spans → one span set → the `Redactor`. Regex insures the
+  crisp identifiers; the model adds name/address the regex cannot.
+- **Placeholders** are numbered and reversible: `[REDACTED_NAME]`, `[REDACTED_EMAIL_1]`,
+  `[REDACTED_PHONE_1]`, `[REDACTED_LINK_2]`, `[REDACTED_ADDRESS]`. Replacement is on
+  word boundaries; known/full-value matches take priority over short single tokens to
+  bound over-redaction.
+
+### Local PII-model sidecar
+
+- **Model:** `openai/privacy-filter` (Apache-2.0, 1.5B MoE, ~50M active params, CPU-OK,
+  ~96% F1, 128K context). Pulled **only** from the official repo (a malicious typosquat
+  existed).
+- **Shape:** a small HTTP service (Python) co-located with the backend; `internal/pii`'s
+  model `Detector` calls it over localhost. One call per CV per analysis / per upload —
+  not per stage.
+- **Configuration:** a new env (e.g. `PII_FILTER_URL`) on the server/worker config. When
+  unset the detector is considered unconfigured.
+
+## Data-flow invariant (most important)
+
+> **Mask on the way INTO every prompt; restore ONLY on the way OUT to the user. Data that
+> is threaded into a later stage is NEVER restored** — otherwise PII re-leaks into
+> Stage 2/3.
+
+## Integration: `matchanalysis`
+
+- At the top of `AnalyzeStream`, build a `Redactor` from `in.CVText` + `in.StructuredResume`
+  (authoritative contacts) via `pii.Build`.
+- `writeCV` and `writeStructured` pass their text through `Redactor.Redact` — the provider
+  sees `[REDACTED_*]`.
+- Wrap `emit` in a decorator that runs `Restore` over each outbound `Event`'s user-facing
+  strings (requirements / dimensions / final) — on a **copy**, leaving the internal
+  `reqs`/`verdict` (which feed Stage 2/3 prompts) masked.
+- The final `Analysis` returned to the handler and cached is `Restore`d (it is the user's
+  own data in their `user_job_analysis` row; storing real values there is correct).
+- The handler is unchanged — masking is entirely internal to the chain.
+
+## Integration: `resumeextract` (removes the upload-time leak)
+
+Today the LLM extracts contacts, which leaks them on upload. New flow:
+
+- Build a `Redactor` from the CV via `pii.Build` (regex + model).
+- Fill `Structured.FullName/Email/Phone/Links` from the **detected** identifiers, not from
+  the model's answer.
+- Send the **redacted** CV to the LLM only for the semantic fields (summary, experience,
+  education, skills — no PII there; employer/university names remain visible). Adjust the
+  prompt: "contacts are provided separately, do not extract them."
+- Because `Structured` now carries the real contacts, `matchanalysis.writeStructured` will
+  re-mask them with the same `Redactor` (same string → same placeholder) — consistent.
+
+## Failure mode: **fail-closed**
+
+If the sidecar is unconfigured or unavailable, `pii.Build` returns an error and we do **not**
+send the CV to the LLM:
+
+- `matchanalysis`: no analysis produced (same best-effort degradation as an unconfigured
+  LLM — the deterministic `jobmatch` bar is untouched).
+- `resumeextract`: behaves like `ErrDisabled` — upload, embedding, and deterministic
+  extractors are untouched; no structured résumé is produced this run.
+
+This preserves the "provider never sees PII" guarantee strictly, at the cost of the
+LLM features when masking is unavailable. The regex layer alone is **not** treated as
+sufficient for the name, so regex-only is not a fallback.
+
+## Testing
+
+- `internal/pii` (no sidecar): table tests over email/phone/URL/@handle, `YYYY-YYYY`
+  phone guard, numbered multi-value placeholders, word-boundary replacement,
+  `Restore(Redact(x))` round-trip, over-redaction guard. Model `Detector` is faked.
+- `matchanalysis`: assert known PII never appears in the Stage 1/2/3 prompt strings, and
+  that PII is restored in emitted + returned output; assert fail-closed on a failing
+  detector.
+- `resumeextract`: assert contacts are filled from detection and that the LLM input
+  carries no PII; assert fail-closed.
+- **Implementation-time model spike:** run the actual Privacy Filter against the two spike
+  CVs and confirm it recovers the buried surname (`Bessmelcev`) and the `Alex` name before
+  wiring it in.
+
+## Known trade-offs / seams
+
+- **Over-redaction:** a name equal to a common word could touch the body; mitigated by
+  word-boundary + full/known-value priority. Restore fixes output readability but not an
+  input-semantics hit — accepted, monitored.
+- **Address:** modern CVs rarely carry a postal address (only a city, which we keep). The
+  model covers the rare real address; no separate deterministic address detector.
+- **Sidecar is new infra:** one Python service + weights to deploy and monitor. Deployment
+  host (co-locate on the backend host vs beside the litellm proxy) is an ops decision to
+  settle during implementation; CPU inference is sufficient.

--- a/openspec/changes/add-cv-pii-masking/.openspec.yaml
+++ b/openspec/changes/add-cv-pii-masking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/add-cv-pii-masking/design.md
+++ b/openspec/changes/add-cv-pii-masking/design.md
@@ -1,0 +1,78 @@
+## Context
+
+CV text reaches the LLM in two places over the shared `internal/llm` client: the
+`matchanalysis` three-stage fit chain (raw CV + structured-résumé JSON, in every stage
+prompt, streamed over SSE) and the `resumeextract` upload-time extraction (whole CV). Both
+flow through the self-hosted litellm gateway (`204.168.137.149`, the py `:4000` proxy — the
+`litellm-rust` `:4001` path has no guardrails), which forwards to external providers.
+
+Two spikes shaped this design: (1) a deterministic-only detector VALIDATED regex for
+email/phone/URL/`@handle` but was INVALIDATED for names on multi-column CVs (the surname
+lives only inside the email/URL); (2) the real `openai/privacy-filter` (ONNX q4, CPU) was
+VALIDATED — it recovered the hidden surname, ran <2.5s/CV, and did not over-redact employers
+or cities. Full detail: `docs/superpowers/specs/2026-07-22-pii-masking-cv-llm-design.md`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Direct identifiers (name, email, phone, home address, personal links) never leave our
+  perimeter to the model provider.
+- User-facing analysis output shows the real values (restore), and PII never re-leaks into a
+  later stage's prompt.
+- Surgical scope: only CV-bearing calls are masked; `enrich` of public job text is untouched.
+
+**Non-Goals:**
+- Masking employer/university/title/skill/city context (needed for fit scoring).
+- A litellm masking guardrail (evaluated and rejected — see Decisions).
+- Reversible masking of anything other than the detected CV PII.
+
+## Decisions
+
+**D1 — Detection = regex floor ∪ local model.** Regex is high-precision for the crisp
+identifiers and free; the model adds name/address the regex cannot. Union both into one span
+set. *Alternative:* model-only — rejected: regex insures the crisp identifiers if the model
+misses and needs no weights.
+
+**D2 — Model served as a span-detection HTTP endpoint (form B), NOT a litellm guardrail.**
+`resumeextract` must *obtain* contacts; a proxy guardrail masks the CV so the LLM cannot
+return them and does not hand the detected spans back — so a callable detector is required
+regardless, and once it exists `matchanalysis` uses it too, making the guardrail redundant.
+In-Go masking keeps scope surgical (no per-request guardrail opt-in), keeps restore under our
+control (litellm `output_parse_pii` has documented streaming-restore bugs; `matchanalysis` is
+SSE), and keeps freehire's privacy self-contained. The weights live on the litellm box; the
+endpoint is off the proxy request path. *Alternatives:* guardrail-only (breaks resumeextract,
+streaming risk); A+B hybrid (two mechanisms) — rejected for surface area.
+
+**D3 — Mask-in / restore-out invariant.** `internal/pii.Redactor` masks text into every stage
+prompt; a decorator around `emit` restores a copy of each outbound event, and the returned +
+cached analysis is restored. Internal `reqs`/`verdict` threaded into later stages stay masked.
+
+**D4 — Fail-closed.** No detector ⇒ no CV to the LLM. `matchanalysis` degrades to no analysis
+(like an unconfigured LLM); `resumeextract` behaves like `ErrDisabled`. Regex-only is not an
+accepted fallback for the name.
+
+**D5 — Model = `openai/privacy-filter` (ONNX q4, onnxruntime, CPU).** Purpose-built, Apache-2.0,
+BIOES over 8 PII types, ~96% F1, 128K context, <2.5s/CV on CPU. Pulled only from the official
+repo (a typosquat existed). Production uses the shipped Viterbi decoder for span stitching.
+
+## Risks / Trade-offs
+
+- **Over-redaction** (a name equal to a common word) → word-boundary + full/known-value
+  priority; spike showed no employer/city false positives.
+- **Bare first-name missed** (e.g. standalone "Alex") → accepted: weak identifier, and it is
+  covered by the person/email/handle spans that ARE caught.
+- **New infra hard-dependency** (detector on the CV path, fail-closed) → health-check and
+  monitor it like the other model-path infra; an outage disables fit analysis + structured
+  extraction (but not uploads, embeddings, deterministic extractors, or enrich).
+- **Detector latency on the CV path** (<2.5s/CV) → one call per analysis/upload, not per
+  stage; acceptable against the multi-stage LLM cost.
+- **resumeextract prompt change** (contacts no longer LLM-extracted) → the merge fills
+  contacts from detection; the LLM prompt is told contacts are handled separately.
+
+## Migration Plan
+
+1. Deploy the privacy-filter span-detection endpoint + ONNX q4 weights on the litellm box via
+   `freehire-ops`; set `PII_FILTER_URL` on the server and the resume/embed worker.
+2. Ship `internal/pii` + the two integrations. Until `PII_FILTER_URL` is set, fail-closed
+   leaves fit analysis and structured extraction as no-ops (safe default; no PII leak).
+3. Rollback: unset `PII_FILTER_URL` (fail-closed no-op) or revert the code; no schema change.

--- a/openspec/changes/add-cv-pii-masking/proposal.md
+++ b/openspec/changes/add-cv-pii-masking/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+When a user's CV is sent to an LLM (fit analysis and structured extraction), real direct
+identifiers — name, email, phone, home address, personal links — travel through our
+self-hosted litellm gateway to external model providers. They are not needed to judge fit,
+and they must never leave our perimeter. Deterministic detection alone cannot reliably find
+the name (a spike showed it fails on multi-column CVs where the surname lives only inside the
+email/URL); a local, context-aware PII model can, and was spike-VALIDATED.
+
+## What Changes
+
+- New `internal/pii` package: a high-precision regex floor (email / phone with a `YYYY-YYYY`
+  date guard / URL / `@handle`) unioned with `PERSON`/`ADDRESS`/`LOCATION` spans from a local
+  `openai/privacy-filter` detector, producing a `Redactor` with reversible numbered
+  placeholders (`[REDACTED_NAME]`, `[REDACTED_EMAIL_1]`, …).
+- New span-detection HTTP endpoint serving `openai/privacy-filter` (ONNX q4, CPU), co-located
+  on the litellm box; `internal/pii` calls it. New env `PII_FILTER_URL`.
+- `job-fit-analysis`: mask CV + structured résumé on the way into every stage prompt; restore
+  only on the outbound emit + the returned/cached analysis; never restore data threaded into a
+  later stage.
+- `resume-structured-profile`: fill contact fields (name/email/phone/links) deterministically
+  from detected spans; send only the redacted CV to the LLM for the semantic fields.
+- **Fail-closed**: when the detector is unconfigured or unavailable, the CV is not sent to the
+  LLM (fit analysis / structured extraction degrade to no-op, exactly like an unconfigured LLM).
+
+## Capabilities
+
+### New Capabilities
+- `cv-pii-masking`: detect PII in CV text (regex floor ∪ local model spans) and produce a
+  reversible `Redactor` that masks text into LLM prompts and restores it in user-facing output;
+  fail-closed when the detector is unavailable.
+
+### Modified Capabilities
+- `job-fit-analysis`: CV and structured-résumé text sent to the LLM MUST be PII-masked, and
+  user-facing output MUST be restored, without re-leaking PII into later stages.
+- `resume-structured-profile`: contact fields MUST be derived from deterministic detection, and
+  only redacted CV text may be sent to the LLM.
+
+## Impact
+
+- Code: new `internal/pii`; `internal/matchanalysis` (`AnalyzeStream`, `writeCV`,
+  `writeStructured`, emit path); `internal/resumeextract` (`Extract`, prompt, contact fill);
+  `internal/config` (`PII_FILTER_URL`).
+- Infra: new privacy-filter span-detection service + ONNX q4 weights (~900MB) on the litellm
+  box (`204.168.137.149`); ops health-check/monitoring. Deployed via `freehire-ops`.
+- Behavior: fit analysis and structured extraction now hard-depend on the detector
+  (fail-closed); `enrich` and all non-CV LLM traffic are untouched.

--- a/openspec/changes/add-cv-pii-masking/specs/cv-pii-masking/spec.md
+++ b/openspec/changes/add-cv-pii-masking/specs/cv-pii-masking/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: PII detection combines a regex floor with a local model
+
+The system SHALL detect PII spans in CV text by unioning a deterministic regex layer with
+spans returned by a local `openai/privacy-filter` detector. The regex layer SHALL detect
+email addresses, phone numbers, URLs, and `@handle`s; the model SHALL contribute
+`PERSON`/`ADDRESS`/`LOCATION` spans that the regex layer cannot reliably find. A phone match
+that is a bare `YYYY-YYYY` year range MUST NOT be treated as a phone number.
+
+#### Scenario: Regex catches direct contact identifiers
+
+- **WHEN** CV text contains an email, phone, URL, or `@handle`
+- **THEN** each is detected as a PII span regardless of the model result
+
+#### Scenario: Model recovers a name the regex cannot
+
+- **WHEN** the CV surname appears only inside the email local-part or a URL slug (no plain-text name line)
+- **THEN** the model detector contributes a `PERSON` span that covers it
+
+#### Scenario: Date range is not a phone number
+
+- **WHEN** CV text contains `2012-2016`
+- **THEN** it is not detected as a phone span
+
+### Requirement: Redaction is reversible via numbered placeholders
+
+The system SHALL produce a `Redactor` from the detected spans that replaces each distinct PII
+value with a stable, numbered placeholder (e.g. `[REDACTED_NAME]`, `[REDACTED_EMAIL_1]`).
+`Redact` SHALL replace values on the way into a prompt and `Restore` SHALL map placeholders
+back to the originals, such that `Restore(Redact(text))` reproduces the original for every
+detected value. Replacement SHALL occur on word boundaries, and a known/full value SHALL take
+priority over a shorter overlapping token to bound over-redaction.
+
+#### Scenario: Round-trip restores the original
+
+- **WHEN** a text is masked with `Redact` and then passed through `Restore`
+- **THEN** every detected PII value is returned to its original form
+
+#### Scenario: Distinct values get distinct placeholders
+
+- **WHEN** two different emails appear in the CV
+- **THEN** they receive distinct numbered placeholders that restore independently
+
+### Requirement: Non-PII context is preserved
+
+The redactor SHALL NOT mask employer names, universities, job titles, skills, or city/country
+context, so downstream fit reasoning retains the signals it needs.
+
+#### Scenario: Employers and cities stay visible
+
+- **WHEN** a CV names employers and cities alongside the candidate's contact block
+- **THEN** only the contact identifiers and the person/address spans are masked; employers and cities are left intact
+
+### Requirement: Detection is fail-closed
+
+When the detector is unconfigured or unavailable, building a `Redactor` SHALL return an error
+rather than a partial (regex-only) redactor, so callers can refuse to send the CV to the LLM.
+The regex layer alone is NOT a sufficient fallback for the name.
+
+#### Scenario: Unavailable detector yields an error
+
+- **WHEN** the `PII_FILTER_URL` detector is unset or the call fails
+- **THEN** `Build` returns an error and no redactor is produced

--- a/openspec/changes/add-cv-pii-masking/specs/job-fit-analysis/spec.md
+++ b/openspec/changes/add-cv-pii-masking/specs/job-fit-analysis/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: CV and structured résumé are PII-masked in the prompt-chain
+
+The fit chain SHALL mask PII in the CV text and the structured-résumé JSON on the way into
+every stage prompt (Extract & Match, Recruiter verdict, Adversarial audit), so no direct
+identifier reaches the model provider. It SHALL restore the original values only in the
+user-facing output — the streamed sections and the returned/cached analysis — and MUST NOT
+restore any data that is threaded back into a later stage's prompt.
+
+#### Scenario: Provider never sees CV PII
+
+- **WHEN** a fit analysis runs for a user with a CV containing name/email/phone/links
+- **THEN** the text sent to the LLM in every stage carries placeholders, not the real identifiers
+
+#### Scenario: Output is restored for the user
+
+- **WHEN** the model echoes a masked value in an evidence or comment field
+- **THEN** the emitted and returned/cached analysis show the real value, restored from the redactor
+
+#### Scenario: No re-leak into later stages
+
+- **WHEN** Stage 1 requirements are fed into the Stage 2 and Stage 3 prompts
+- **THEN** the threaded requirement text remains masked (restore applies only to the outbound copy)
+
+## MODIFIED Requirements
+
+### Requirement: Best-effort degradation
+
+The feature SHALL degrade gracefully: when the LLM is unconfigured or the call fails, the endpoint
+MUST NOT error the request and MUST leave the deterministic profile-match unaffected. When the
+caller has no stored CV, the response MUST indicate `has_cv: false` and prompt an upload instead of
+running the LLM. When the PII detector is unconfigured or unavailable, the chain SHALL be
+fail-closed: it MUST NOT send the CV to the LLM and MUST degrade to no analysis, exactly as when
+the LLM is unconfigured.
+
+#### Scenario: LLM unconfigured
+
+- **WHEN** a user POSTs the fit endpoint while the LLM is not configured
+- **THEN** the system responds `200` with no analysis and does not persist a cache row
+
+#### Scenario: Caller has no stored CV
+
+- **WHEN** a user without a stored CV requests the fit
+- **THEN** the system responds `200` with `has_cv: false` and no analysis, and does not invoke the LLM
+
+#### Scenario: PII detector unavailable is fail-closed
+
+- **WHEN** a user POSTs the fit endpoint while the PII detector is unconfigured or failing
+- **THEN** the system responds `200` with no analysis, does not send the CV to the LLM, and does not persist a cache row

--- a/openspec/changes/add-cv-pii-masking/specs/resume-structured-profile/spec.md
+++ b/openspec/changes/add-cv-pii-masking/specs/resume-structured-profile/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Structured résumé is extracted best-effort on upload
+
+The system SHALL, on every résumé upload (both the `PUT /api/v1/me/resume` storage path and the `POST /api/v1/me/resume/extract` path), derive a typed **structured résumé** from the uploaded CV text and persist it per user. The **contact fields** (`full_name`, `email`, `phone`, `links`) SHALL be filled from deterministic PII detection over the CV, NOT from the LLM; only the **redacted** CV text SHALL be sent to the LLM, which extracts the semantic fields (summary, experience, education, skills, …). The extraction SHALL run **off the upload response path** (in the background, like the existing CV embedding) and SHALL be **best-effort**: when the LLM is not configured, when the PII detector is unconfigured or unavailable, or when extraction fails, the upload, the CV embedding, and the deterministic extractors (`cv-autofill`, skilltag) MUST be unaffected and no structured résumé is persisted for that attempt. The CV bytes and text MUST NOT be logged.
+
+#### Scenario: Upload derives and stores the structured résumé
+
+- **WHEN** a signed-in user uploads a résumé and both the LLM and the PII detector are configured
+- **THEN** the system fills the contact fields from PII detection, sends only the redacted CV to the LLM for the semantic fields, and persists the merged structured résumé stamped with the producing model and the résumé's upload time
+
+#### Scenario: LLM unconfigured leaves upload unaffected
+
+- **WHEN** a résumé is uploaded and the LLM integration is not configured
+- **THEN** the résumé is stored and embedded exactly as before and no structured résumé is persisted, with no error surfaced to the upload
+
+#### Scenario: PII detector unavailable is fail-closed
+
+- **WHEN** a résumé is uploaded while the PII detector is unconfigured or failing
+- **THEN** no CV text is sent to the LLM and no structured résumé is persisted, leaving the upload and embedding unaffected
+
+#### Scenario: Extraction failure is swallowed
+
+- **WHEN** the LLM call fails or returns unparseable output during extraction
+- **THEN** the failure is logged without the CV contents and the upload response is unaffected, leaving any previously stored structured résumé in place

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -1,0 +1,31 @@
+## 1. `internal/pii` — detectors and redactor
+
+- [ ] 1.1 Add span types (`Span{Start,End,Kind}`, `Contacts`) and the regex detectors: email, phone (with `YYYY-YYYY` date-range guard), URL, `@handle`; table tests over both spike-CV shapes
+- [ ] 1.2 Add the model `Detector` interface + its HTTP client (POST text → spans); tests against a faked HTTP server, incl. transport/parse failure
+- [ ] 1.3 Implement `Build(ctx, text, known Contacts, d Detector) (*Redactor, error)`: union regex ∪ model spans, numbered reversible placeholders, word-boundary replacement, full/known-value priority; tests for `Redact`, `Restore`, `Restore(Redact(x))` round-trip, distinct-value numbering, over-redaction guard
+- [ ] 1.4 Fail-closed: `Build` returns an error (no partial redactor) when the detector is unconfigured or its call fails; test
+
+## 2. Config
+
+- [ ] 2.1 Add `PII_FILTER_URL` to `internal/config` (server + resume/embed worker) and construct the `pii.Detector`; test that empty URL yields an unconfigured (fail-closed) detector
+
+## 3. `matchanalysis` integration
+
+- [ ] 3.1 Build a `Redactor` at the top of `AnalyzeStream` from `in.CVText` + `in.StructuredResume`; return no-analysis (fail-closed) when `Build` errors
+- [ ] 3.2 Run `Redact` in `writeCV` and `writeStructured` so every stage prompt carries placeholders
+- [ ] 3.3 Wrap `emit` to `Restore` a copy of each outbound event, and `Restore` the returned/cached analysis; keep internal `reqs`/`verdict` masked (no re-leak into Stage 2/3)
+- [ ] 3.4 Tests: assert known PII never appears in the Stage 1/2/3 prompt strings, that output is restored, and fail-closed on a failing detector
+
+## 4. `resumeextract` integration
+
+- [ ] 4.1 Build a `Redactor`; fill `Structured` contact fields (`FullName/Email/Phone/Links`) from detected spans; send only the redacted CV to the LLM; update the prompt to state contacts are provided separately; fail-closed when `Build` errors
+- [ ] 4.2 Tests: contacts filled from detection, no PII in the LLM input, semantic fields still parsed, fail-closed leaves upload/embedding untouched
+
+## 5. Privacy-filter span-detection service
+
+- [ ] 5.1 Build the detection HTTP service serving `openai/privacy-filter` (ONNX q4, onnxruntime, Viterbi span stitching): `POST /detect` → `[{start,end,kind}]`; verify it recovers the hidden surname and does not over-redact on the two spike CVs
+- [ ] 5.2 Deploy wiring in `freehire-ops`: ONNX q4 weights + service on the litellm box, systemd/compose unit, health-check, egress allowlist; set `PII_FILTER_URL`
+
+## 6. Verification
+
+- [ ] 6.1 `go build ./... && go vet ./... && go test ./...` green; end-to-end masking check against the live `/detect` endpoint on the two spike CVs (no PII in the outbound prompt, output restored)

--- a/web/src/lib/components/CliView.svelte
+++ b/web/src/lib/components/CliView.svelte
@@ -4,7 +4,8 @@
 
   const CLI_REPO = 'https://github.com/strelov1/freehire-cli';
   const MCP_REPO = 'https://github.com/strelov1/freehire-mcp';
-  const SKILL_URL = `${CLI_REPO}/blob/main/skills/using-freehire/SKILL.md`;
+  const SKILL_URL =
+    'https://github.com/strelov1/freehire-cli/blob/main/skills/using-freehire/SKILL.md';
   const INSTALL = 'curl -fsSL https://freehire.dev/install.sh | sh';
 
   // Command reference, mirroring the freehire-cli README/SKILL.md (the source of

--- a/web/src/lib/components/CliView.svelte
+++ b/web/src/lib/components/CliView.svelte
@@ -3,11 +3,18 @@
   import { Button } from '$lib/ui';
 
   const CLI_REPO = 'https://github.com/strelov1/freehire-cli';
+  const MCP_REPO = 'https://github.com/strelov1/freehire-mcp';
+  const SKILL_URL = `${CLI_REPO}/blob/main/skills/using-freehire/SKILL.md`;
   const INSTALL = 'curl -fsSL https://freehire.dev/install.sh | sh';
 
-  // Command reference, mirroring the freehire-cli README verbatim. Two groups:
-  // first you find jobs, then you track your interaction with them.
+  // Command reference, mirroring the freehire-cli README/SKILL.md (the source of
+  // truth). Discover the market and its jobs first, then track your interaction.
   const discover = [
+    { cmd: 'facets', desc: "Every filter's live values + counts — the vocabulary to filter by." },
+    {
+      cmd: 'market-fit --skills go,react',
+      desc: 'How much of the live market your skills cover, and the gaps.',
+    },
     { cmd: 'search <query>', desc: 'List matching jobs (add --remote, --region, --company).' },
     { cmd: 'job <slug>', desc: "Show a job's full content." },
     { cmd: 'company <slug>', desc: 'Show a company and its open jobs.' },
@@ -55,10 +62,12 @@
         </h1>
 
         <p class="reveal mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground" style="--d:160ms">
-          <code class="font-mono text-foreground">freehire</code> is a small CLI over the same job API the
-          site runs on — so an <span class="text-foreground">AI agent</span> or a script can search and open
-          jobs, then track applications and notes without a browser. (You still apply on the employer's
-          site; the CLI records that you did.)
+          <code class="font-mono text-foreground">freehire</code> is a small CLI — and an
+          <a href="#mcp" class="text-foreground underline-offset-4 hover:underline">MCP server</a> — over the
+          same job API the site runs on. One <span class="text-foreground">API key</span> lets an
+          <span class="text-foreground">AI agent</span> or a script search and open jobs, then track
+          applications and notes without a browser. (You still apply on the employer's site; the CLI records
+          that you did.)
         </p>
 
         <div class="reveal mt-9 flex flex-wrap items-center gap-3" style="--d:240ms">
@@ -92,7 +101,8 @@ curl -fsSL <span class="text-foreground">https://freehire.dev/install.sh</span> 
 <span class="text-muted-foreground"># authenticate once (key from /my/api-keys)</span>
 freehire auth login --token <span class="text-foreground">fhk_…</span>
 
-<span class="text-muted-foreground"># search</span>
+<span class="text-muted-foreground"># discover the market, then search</span>
+freehire facets
 freehire search <span class="text-foreground">"golang"</span> --remote --region eu</pre>
       </figure>
     </div>
@@ -131,17 +141,109 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
         </dl>
       </div>
     </div>
+
     <p class="mt-8 max-w-2xl text-sm leading-relaxed text-muted-foreground">
-      Everything you save, apply to and stage shows up on your
-      <a href={resolve('/my/tracking')} class="font-medium text-foreground underline-offset-4 hover:underline">Tracking</a>
-      board.
-      <code class="font-mono text-foreground">stage</code> takes a controlled value:
+      Start from <code class="font-mono text-foreground">freehire facets</code> — it lists every filter's live
+      values so <code class="font-mono text-foreground">search</code> and
+      <code class="font-mono text-foreground">market-fit</code> use real values, not guesses. Everything you
+      save, apply to and stage shows up on your
+      <a href={resolve('/my/tracking')} class="font-medium text-foreground underline-offset-4 hover:underline"
+        >Tracking</a
+      >
+      board. <code class="font-mono text-foreground">stage</code> takes a controlled value:
       <span class="font-mono text-foreground"
         >applied → screening → responded → interview → offer → accepted</span
       >, plus <span class="font-mono text-foreground">rejected</span> /
-      <span class="font-mono text-foreground">withdrawn</span>. For scripts and agents, add
-      <code class="font-mono text-foreground">--json</code> for the raw API payload; results go to stdout,
-      errors to stderr, and a non-zero exit code signals failure. The same endpoints are documented in the
+      <span class="font-mono text-foreground">withdrawn</span>.
+    </p>
+
+    <!-- CV tailoring — a real feature, but CLI-only (no MCP tools yet). -->
+    <div class="mt-8 max-w-2xl rounded-lg border border-border bg-secondary/40 p-4">
+      <h3 class="flex items-center gap-2 text-sm font-semibold">
+        Tailor a CV to a vacancy
+        <span
+          class="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground"
+          >CLI only</span
+        >
+      </h3>
+      <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
+        After a fit analysis, reframe your CV toward one job — grounded in what you actually did, never
+        fabricated — then export an ATS-ready PDF.
+      </p>
+      <pre
+        class="mt-3 overflow-x-auto rounded-md border border-border bg-background/60 p-3 font-mono text-sm leading-relaxed"><span class="text-muted-foreground">freehire</span> cv context &lt;id&gt;        <span class="text-muted-foreground"># the fit analysis to reframe toward</span>
+<span class="text-muted-foreground">freehire</span> cv edit &lt;id&gt; --patch …  <span class="text-muted-foreground"># apply a field-level edit</span>
+<span class="text-muted-foreground">freehire</span> cv render &lt;id&gt; --out cv.pdf</pre>
+    </div>
+  </section>
+
+  <!-- MCP — the second surface over the same API and the same key. -->
+  <section id="mcp" class="scroll-mt-20 border-t border-border py-14 sm:py-16">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// mcp</p>
+    <div class="mt-8 grid gap-x-12 gap-y-8 lg:grid-cols-[0.95fr_1.05fr]">
+      <div>
+        <h2 class="text-2xl font-semibold tracking-tight">Same key, any AI host</h2>
+        <p class="mt-4 max-w-md leading-relaxed text-muted-foreground">
+          <code class="font-mono text-foreground">freehire-mcp</code> exposes the same search, market-fit and
+          tracking tools over the
+          <a
+            href="https://modelcontextprotocol.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-foreground underline-offset-4 hover:underline">Model Context Protocol</a
+          > — so Claude Desktop, Claude Code or any MCP host can drive freehire directly. It runs via
+          <code class="font-mono text-foreground">npx</code>; no global install.
+        </p>
+        <p class="mt-4 max-w-md text-sm leading-relaxed text-muted-foreground">
+          It shares the CLI's credentials: if you've run
+          <code class="font-mono text-foreground">freehire auth login</code>, omit
+          <code class="font-mono text-foreground">env</code> and it reads
+          <code class="font-mono text-foreground">~/.freehire/creds.json</code>.
+        </p>
+        <div class="mt-6">
+          <Button href={MCP_REPO} target="_blank" rel="noopener noreferrer" variant="outline" size="md">
+            MCP source ↗
+          </Button>
+        </div>
+      </div>
+      <figure
+        class="overflow-hidden rounded-xl border border-border bg-secondary/60 font-mono text-sm shadow-sm"
+      >
+        <figcaption
+          class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground"
+        >
+          <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+          ~/.claude.json
+        </figcaption>
+        <pre class="overflow-x-auto p-4 leading-relaxed">{`{
+  "mcpServers": {
+    "freehire": {
+      "command": "npx",
+      "args": ["-y", "freehire-mcp"],
+      "env": { "FREEHIRE_TOKEN": "fhk_…" }
+    }
+  }
+}`}</pre>
+      </figure>
+    </div>
+  </section>
+
+  <!-- For AI agents — the drop-in skill and the machine-readable conventions. -->
+  <section class="border-t border-border py-14 sm:py-16">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// for ai agents</p>
+    <p class="mt-6 max-w-2xl leading-relaxed text-muted-foreground">
+      A drop-in
+      <a
+        href={SKILL_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="font-medium text-foreground underline-offset-4 hover:underline">agent skill</a
+      >
+      teaches the discover → search → apply loop; drop it into a Claude Code (or compatible) skills directory.
+      Every command takes <code class="font-mono text-foreground">--json</code> for the raw API payload —
+      results go to <span class="font-mono text-foreground">stdout</span>, errors to
+      <span class="font-mono text-foreground">stderr</span>, and a non-zero exit code signals failure. The
+      same endpoints are documented in the
       <a href={resolve('/docs/api')} class="font-medium text-foreground underline-offset-4 hover:underline"
         >API reference</a
       >.
@@ -162,13 +264,20 @@ freehire jobs edit &lt;slug&gt; --title "Staff Go Developer"</pre>
   <!-- Free / open-source / transparent — the project's promise, with the source. -->
   <section class="border-t border-border py-10">
     <p class="text-sm leading-relaxed text-muted-foreground">
-      Free and open source — no tracking, no lock-in. Read every line on
+      Free and open source — no tracking, no lock-in. Read every line of the
       <a
         href={CLI_REPO}
         target="_blank"
         rel="noopener noreferrer"
-        class="font-medium text-foreground underline-offset-4 hover:underline">GitHub ↗</a
-      >.
+        class="font-medium text-foreground underline-offset-4 hover:underline">CLI ↗</a
+      >
+      and the
+      <a
+        href={MCP_REPO}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="font-medium text-foreground underline-offset-4 hover:underline">MCP server ↗</a
+      > on GitHub.
     </p>
   </section>
 </div>

--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -48,20 +48,19 @@
       {/if}
     </div>
     <!-- flex-1 above lets the name/tagline use the full width; the follow CTA stays
-         top-right and never shrinks (it collapses to an icon on mobile itself). -->
-    <div class="shrink-0">
+         top-right and never shrinks (it collapses to an icon on mobile itself).
+         The Discussion link sits right below it, right-aligned. -->
+    <div class="flex shrink-0 flex-col items-end gap-2">
       <CompanyFollowButton {slug} companyName={company.name} />
+      <a
+        class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+        href={resolve('/companies/[slug]/discussion', { slug })}
+      >
+        <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
+          ? ` · ${threadCount}`
+          : ''}
+      </a>
     </div>
-  </div>
-  <div class="mt-3">
-    <a
-      class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-      href={resolve('/companies/[slug]/discussion', { slug })}
-    >
-      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
-        ? ` · ${threadCount}`
-        : ''}
-    </a>
   </div>
   {#if hasMeta}
     <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-3">

--- a/web/src/lib/components/CountryFlagStack.svelte
+++ b/web/src/lib/components/CountryFlagStack.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { filterHref } from '$lib/enrichment';
+  import CountryFlag from './CountryFlag.svelte';
+
+  // An overlapping cluster of round country flags (an avatar-stack). Collapses a
+  // long country list into a compact, space-saving row: each flag laps over the
+  // previous one, capped at `max` with a "+N" chip for the remainder. Used on the
+  // browse card (display-only) and the job sidebar (`link` on), where a wide remote
+  // role can list a dozen eligible countries.
+  //
+  // The flags overlap by `--lap` (an em fraction of a flag's width) via a negative
+  // left margin, and each carries a `ring-card` outline so neighbours stay legible
+  // where they touch. Earlier flags sit on top (descending z-index) so the row reads
+  // left-to-right; hovering a flag raises it above its neighbours.
+  let {
+    codes,
+    max = 6,
+    link = false,
+    class: className = '',
+  }: {
+    codes: string[];
+    max?: number;
+    link?: boolean;
+    class?: string;
+  } = $props();
+
+  const shown = $derived(codes.slice(0, max));
+  const extra = $derived(codes.length - shown.length);
+</script>
+
+{#if codes.length}
+  <div class={['flex items-center', className]} style:--lap="0.4em">
+    {#each shown as code, i (code)}
+      <span
+        class={[
+          'relative inline-flex rounded-full ring-2 ring-card transition hover:z-10 hover:-translate-y-px',
+          i > 0 && '-ml-[var(--lap)]',
+        ]}
+        style:z-index={shown.length - i}
+      >
+        {#if link}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
+          <a href={filterHref('countries', code)} class="inline-flex"><CountryFlag {code} /></a>
+        {:else}
+          <CountryFlag {code} />
+        {/if}
+      </span>
+    {/each}
+    {#if extra > 0}
+      <span class="ml-1.5 text-xs font-medium text-muted-foreground">+{extra}</span>
+    {/if}
+  </div>
+{/if}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
   import { Bookmark, Eye, EyeOff, X } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CountryFlagStack from './CountryFlagStack.svelte';
   import JobMatchBar from './JobMatchBar.svelte';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -244,12 +245,17 @@
 
   <!-- Signal row: reality chip + the region/employment facets, grouped under the
        title as quiet outline chips so they read as metadata, not decoration. -->
-  {#if job.reality || tags.length > 0}
+  {#if job.reality || tags.length > 0 || job.countries?.length}
     <div class="mt-2 flex flex-wrap items-center gap-1.5">
       <RealityBadge reality={job.reality} />
       {#each tags as tag (tag)}
         <Badge variant="outline">{tag}</Badge>
       {/each}
+      <!-- Eligible countries as an overlapping flag cluster. Display-only here: the
+           whole card is a link, so the flags carry no nested filter links. -->
+      {#if job.countries?.length}
+        <CountryFlagStack codes={job.countries} max={5} class="ml-0.5 text-base" />
+      {/if}
     </div>
   {/if}
 

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -12,7 +12,7 @@
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
-  import CountryFlag from './CountryFlag.svelte';
+  import CountryFlagStack from './CountryFlagStack.svelte';
   import JobDescription from './JobDescription.svelte';
   import JobMatch from './JobMatch.svelte';
   import RealityBadge from './RealityBadge.svelte';
@@ -325,16 +325,12 @@
             <div class="flex items-baseline justify-between gap-3">
               <dt class="shrink-0 text-muted-foreground">{facet.label}</dt>
               {#if facet.values.every((v) => v.flag)}
-                <!-- Flag facet (Country): a wrapping row of round flags, right-aligned,
-                     each linking to its filter. No comma separators — the gap reads the
-                     list on its own and stays compact for many-country remote jobs. -->
-                <dd class="flex min-w-0 flex-wrap justify-end gap-1.5 text-base">
-                  {#each facet.values as v (v.text)}
-                    {#if v.href}
-                      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
-                      <a href={v.href} class="transition hover:opacity-80"><CountryFlag code={v.flag ?? ''} /></a>
-                    {:else}<CountryFlag code={v.flag ?? ''} />{/if}
-                  {/each}
+                <!-- Flag facet (Country): an overlapping cluster of round flags,
+                     right-aligned, each linking to its filter. The stack laps the
+                     flags over one another so a many-country remote role stays a
+                     single compact row instead of wrapping. -->
+                <dd class="flex min-w-0 justify-end text-base">
+                  <CountryFlagStack codes={facet.values.map((v) => v.flag ?? '')} link />
                 </dd>
               {:else}
                 <dd class="min-w-0 break-words text-right font-medium"

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -251,16 +251,6 @@
 
     <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
 
-    <a
-      class="inline-flex items-center gap-1.5 self-end text-sm font-medium text-primary hover:underline"
-      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
-      onclick={onDiscussionClick}
-    >
-      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
-        ? ` · ${threadCount}`
-        : ''}
-    </a>
-
     {#if job.referral_available && job.company_slug}
       <ReferralBlock companySlug={job.company_slug} companyName={job.company} />
     {/if}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -209,17 +209,29 @@
 <article
   class="flex flex-col gap-4 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)] lg:grid-rows-[auto_auto_minmax(0,1fr)] lg:gap-x-6 lg:gap-y-4"
 >
-  <div class="flex items-center gap-3 lg:col-start-2 lg:row-start-1">
-    <CompanyLogo name={job.company} size="size-8" />
-    <p class="text-sm text-muted-foreground">
-      {#if job.company_slug}
-        <a href={resolve('/companies/[slug]', { slug: job.company_slug })} class="hover:text-foreground hover:underline">
+  <div class="flex items-center justify-between gap-3 lg:col-start-2 lg:row-start-1">
+    <div class="flex items-center gap-3">
+      <CompanyLogo name={job.company} size="size-8" />
+      <p class="text-sm text-muted-foreground">
+        {#if job.company_slug}
+          <a href={resolve('/companies/[slug]', { slug: job.company_slug })} class="hover:text-foreground hover:underline">
+            {job.company || 'Unknown company'}
+          </a>
+        {:else}
           {job.company || 'Unknown company'}
-        </a>
-      {:else}
-        {job.company || 'Unknown company'}
-      {/if}
-    </p>
+        {/if}
+      </p>
+    </div>
+
+    <a
+      class="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
+      onclick={onDiscussionClick}
+    >
+      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
+        ? ` · ${threadCount}`
+        : ''}
+    </a>
   </div>
 
   <header class="flex flex-col gap-4 lg:col-start-2 lg:row-start-2">

--- a/web/src/posts/2026-07-22-freehire-cli-and-mcp.svx
+++ b/web/src/posts/2026-07-22-freehire-cli-and-mcp.svx
@@ -1,0 +1,30 @@
+---
+title: Use freehire from your terminal — or any AI assistant
+date: 2026-07-22
+summary: One API key now drives freehire two ways — a small CLI for your terminal and an MCP server for Claude Desktop, Claude Code, or any AI host — to search, measure your skills against the market, and track applications without a browser.
+type: changelog
+tags:
+  - cli
+  - mcp
+  - agents
+draft: false
+---
+
+The [freehire CLI](/cli) has grown up, and it now has a sibling.
+
+The **CLI** lets you search jobs, browse companies, and track what you've applied to —
+straight from the terminal. Two newer commands make it more than a job list:
+`freehire facets` shows every filter's live values so you search with real terms, and
+`freehire market-fit --skills go,react` measures how much of the open market your skills
+already reach, and which missing skills would unlock the most vacancies. You can even
+tailor a CV toward a specific job and export an ATS-ready PDF.
+
+New alongside it: an **MCP server**. Add `freehire-mcp` to Claude Desktop, Claude Code, or
+any [Model Context Protocol](https://modelcontextprotocol.io) host, and your assistant can
+search and track jobs for you directly — same tools, same account. Both share one
+`fhk_…` [API key](/my/api-keys): authenticate once and the CLI and the MCP server use the
+same credentials.
+
+Everything you apply to or save shows up on your [Tracking](/my/tracking) board, exactly as
+it does on the site. Setup and the full command list are on the [CLI page](/cli); both the
+CLI and the MCP server are open source.

--- a/web/src/routes/cli/+page.svelte
+++ b/web/src/routes/cli/+page.svelte
@@ -7,8 +7,8 @@
 </script>
 
 <Seo
-  title="freehire CLI — search and track jobs from the terminal"
-  description="A small Go CLI over the freehire job API, built so an AI agent or a script can search, open and track jobs from the terminal — no browser. Authenticate once with an API key."
+  title="freehire CLI & MCP — search and track jobs from the terminal"
+  description="A small Go CLI and an MCP server over the freehire job API, built so an AI agent or a script can search, open and track jobs — no browser. One API key drives both CLI and MCP."
   {canonical}
 />
 


### PR DESCRIPTION
## What

The `/cli` landing mirrored an older version of the CLI and showed neither the **MCP server** nor the **agent skill**. This brings the page up to date with freehire's three agent surfaces — CLI, MCP, API — all sharing one `fhk_` key.

### Changes
- **Discover** now lists `facets` and `market-fit` alongside `search`/`job`/`company`.
- New **CV-tailoring** card (marked `CLI only` — no MCP tools for it yet) covering `cv context/edit/render`.
- New **MCP section** ("Same key, any AI host") with the `npx freehire-mcp` config and a note that it shares `~/.freehire/creds.json`.
- New **"for AI agents"** block linking the drop-in `SKILL.md` and the `--json`/stdout/stderr/exit-code conventions.
- Hero copy + `<Seo>` title/description now mention MCP.
- `/blog` changelog entry announcing the CLI + MCP surfaces.

## Verification
- `svelte-check` — 0 errors in changed files.
- Dev server: `/cli`, `/blog`, and the new post page all render 200 (the blog frontmatter loader accepts the post).
- Visually screenshotted `/cli`.

## Out of scope (follow-ups, separate repos)
- MCP lacks `cv` tools (parity with the CLI) — `../freehire-mcp`.
- The agent skill isn't packaged as a Claude Code plugin marketplace — `../freehire-cli`.