### PR TITLE
feat(web): consent-gate GA + PostHog behind an EU/UK cookie banner

### DIFF
--- a/openspec/changes/add-cookie-consent-banner/.openspec.yaml
+++ b/openspec/changes/add-cookie-consent-banner/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/add-cookie-consent-banner/design.md
+++ b/openspec/changes/add-cookie-consent-banner/design.md
@@ -1,0 +1,110 @@
+## Context
+
+Two non-essential trackers ship today with no consent gate:
+
+- **Google Analytics** — an inline `<script>` in `web/src/app.html` that fires on
+  every non-localhost load. It is explicitly allow-listed in the CSP
+  (`web/svelte.config.js`: the gtag bootstrap's SHA-256 hash plus the
+  `https://www.googletagmanager.com` host), so it is live and sets `_ga` cookies.
+- **PostHog** — initialized in `web/src/hooks.client.ts` via the guarded wrapper
+  in `web/src/lib/analytics.ts`, with session recording started per-route in
+  `web/src/routes/+layout.svelte`.
+
+There is no consent banner anywhere in `web/src`. The privacy policy
+(`web/src/routes/privacy/+page.svelte`) claims cookies load only "if you opt in"
+and that we keep "no tracking profiles" — both false today.
+
+Constraints: nginx on bare metal, no Cloudflare, no `cf-ipcountry`, no server-side
+geo signal. The project is frontend-SSR (SvelteKit) fronting a Go API. House style
+(analytics.ts) is a guarded, env-gated wrapper whose call sites are safe no-ops.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Block GA and PostHog for consent-required (EU/EEA/UK) visitors until they accept.
+- Show the banner only where legally required; leave non-region visitors untouched.
+- No new infrastructure, no IP handling, no ops/nginx change.
+- Consent is withdrawable as easily as it is given.
+- Reconcile the privacy policy with what the code actually does.
+
+**Non-Goals:**
+
+- Per-category consent toggles (only two trackers, no advertising → binary
+  Accept/Reject is sufficient).
+- Server-side / IP-based geolocation, GeoIP databases, a nginx country header.
+- A US-style "Do Not Sell/Share" opt-out flow (tracked separately if ever needed).
+- Any backend, API, or database change.
+
+## Decisions
+
+### D1 — Region signal from browser timezone, client-side
+
+Use `Intl.DateTimeFormat().resolvedOptions().timeZone`; classify `Europe/*` and
+the EEA Atlantic zones (e.g. `Atlantic/Canary`, `Atlantic/Madeira`,
+`Atlantic/Reykjavik`) as consent-required. Unresolvable/unknown → consent-required.
+
+- *Why:* zero infrastructure, no IP processing (privacy-friendlier), available at
+  boot. Errs conservative — a few non-EU visitors (Ukraine, Turkey) may see the
+  banner, which is harmless, while EU visitors are reliably caught.
+- *Alternatives:* nginx GeoIP2 (accurate, but needs an ops-repo change + GeoLite2
+  DB + SSR plumbing) — deferred as a possible future upgrade; Accept-Language
+  parsing — rejected, English is ambiguous across US/UK/global.
+
+### D2 — Move GA out of the inline `app.html` bootstrap
+
+Delete the inline gtag `<script>` from `app.html` and its SHA-256 hash from the
+CSP `script-src`. GA init moves into `analytics.ts` next to PostHog under a single
+`initTrackers()`; the `https://www.googletagmanager.com` host stays in the CSP so
+the dynamically-injected `gtag.js` still loads, and the config code now runs from
+the same-origin bundle (`'self'`).
+
+- *Why:* while GA lives inline it executes before anything can ask for consent —
+  gating is impossible without this move. Post-hydration start costs a negligible
+  delay for analytics accuracy and removes the brittle inline-hash coupling.
+- *Alternative:* inject an "is EU" flag into `app.html` via `transformPageChunk`
+  and keep GA inline — rejected as more moving parts for no benefit, and it would
+  reintroduce a server-side region signal we deliberately avoid.
+
+### D3 — Consent store as a small reactive module
+
+`web/src/lib/consent.svelte.ts` owns `localStorage['hire.consent']` (`granted` /
+`denied` / absent) and exposes reactive `$state` plus pure helpers
+(`regionNeedsConsent(tz)`, `needsBanner(...)`, `grant()`, `deny()`, `reopen()`).
+
+- *Why:* mirrors the existing guarded-wrapper posture; the pure helpers are
+  unit-testable in plain Node (per the frontend testing convention), while the
+  SDK/`localStorage` side effects are exercised by visual verification.
+
+### D4 — Banner in the root layout, gated centrally
+
+`CookieConsent.svelte` mounts in `+layout.svelte`, rendered only when
+`needsBanner` is true. `initTrackers()` is called from the same central place when
+`!regionNeedsConsent || consent === 'granted'`. A footer "Cookie settings" link
+calls `reopen()`.
+
+- *Why:* one decision point for both "should the banner show" and "should
+  trackers start", both fed by the same consent module — no logic duplicated
+  across GA and PostHog paths.
+
+## Risks / Trade-offs
+
+- **Timezone spoofing / VPN with mismatched TZ** → a determined EU visitor could
+  present a non-EU timezone and skip the banner. Accepted: consent law targets
+  good-faith detection, and the conservative default (unknown → ask) covers the
+  common cases; upgrade path to GeoIP exists (D1) if ever needed.
+- **Analytics starts slightly later** (post-hydration vs pre-paint) for all
+  visitors → negligible for pageview/session accuracy; GA/PostHog both tolerate a
+  late first event.
+- **Editing the remaining inline theme script in `app.html`** still requires
+  recomputing its CSP hash → unchanged risk, documented already; we only remove the
+  GA hash, not the theme one.
+- **Denied consent loses EU analytics** → by design and legally required; a known
+  reduction in EU coverage, not a defect.
+
+## Migration Plan
+
+Pure frontend deploy (web rebuild). No data migration. Rollback = revert the
+change; GA returns to inline boot and PostHog to unconditional init. No persisted
+state beyond the per-browser `localStorage` key, which is inert if the feature is
+rolled back.

--- a/openspec/changes/add-cookie-consent-banner/proposal.md
+++ b/openspec/changes/add-cookie-consent-banner/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Google Analytics (inline in `web/src/app.html`, allow-listed in the CSP) and
+PostHog with session recording (`web/src/lib/analytics.ts`) both start on page
+load with no consent mechanism and no banner. For EU/EEA/UK visitors this
+violates ePrivacy/GDPR, which require prior opt-in before non-essential trackers
+run. The privacy policy compounds the gap: it claims cookies load "if you opt in"
+(there is no opt-in) and that we use "no tracking profiles" (GA + session replay
+are exactly that). We need a consent gate that blocks both trackers until the
+visitor agrees — shown only where it is legally required.
+
+## What Changes
+
+- Detect whether a visitor is in a consent-required region (EU/EEA/UK) from the
+  browser timezone — no IP geolocation, no nginx/ops change.
+- Persist the visitor's choice (`granted` / `denied`) in `localStorage` and gate
+  both trackers on it.
+- **BREAKING (behavioral):** Google Analytics no longer boots from the inline
+  `app.html` bootstrap. GA init moves into `analytics.ts` alongside PostHog
+  behind a single `initTrackers()`, and its now-obsolete inline SHA-256 hash is
+  removed from the CSP `script-src`.
+- Neither GA nor PostHog initializes for a consent-required visitor until they
+  click **Accept**; a **Reject** loads nothing. Visitors outside the region keep
+  analytics-on-load with no banner.
+- Add a `CookieConsent` banner (root layout) with equal-prominence Accept/Reject
+  buttons, no pre-selected default, and a link to the privacy policy.
+- Add a footer "Cookie settings" entry point to re-open the banner so consent can
+  be withdrawn as easily as it was given.
+- Fix the privacy policy Cookies section: list GA and PostHog explicitly, describe
+  the consent mechanism, and remove the now-false "if you opt in" and "no tracking
+  profiles" claims.
+
+## Capabilities
+
+### New Capabilities
+
+- `cookie-consent`: region detection (timezone-based), consent persistence and
+  state, the banner UI and its withdrawal entry point, and the gating of every
+  non-essential tracker (GA + PostHog) behind a granted consent — for
+  consent-required visitors only.
+
+### Modified Capabilities
+
+- `product-analytics`: PostHog initialization gains a second precondition. Today
+  it initializes whenever `PUBLIC_POSTHOG_KEY` is set; it must now also require
+  that a consent-required visitor has granted consent (visitors outside the
+  region are unaffected).
+
+## Impact
+
+- Frontend only (`web/`); no backend, no API, no database, no ops/nginx change.
+- Touched files: `web/src/app.html` (remove inline GA), `web/svelte.config.js`
+  (drop GA inline hash from CSP), `web/src/lib/analytics.ts` (add GA + gated
+  `initTrackers()`), `web/src/hooks.client.ts` and `web/src/routes/+layout.svelte`
+  (wire the gate + mount the banner), plus new `web/src/lib/consent.svelte.ts` and
+  `web/src/lib/components/CookieConsent.svelte`, and edits to
+  `web/src/routes/privacy/+page.svelte` and the footer component.
+- Existing GA analytics on non-EU traffic is unchanged in coverage; EU traffic
+  that rejects consent drops out of GA and PostHog by design.

--- a/openspec/changes/add-cookie-consent-banner/specs/cookie-consent/spec.md
+++ b/openspec/changes/add-cookie-consent-banner/specs/cookie-consent/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Consent-required region detection
+
+The frontend SHALL determine, on the client, whether a visitor is in a
+consent-required region (EU/EEA/UK) from the browser timezone
+(`Intl.DateTimeFormat().resolvedOptions().timeZone`), treating `Europe/*` and the
+EEA Atlantic zones as consent-required. The determination MUST NOT use the
+visitor's IP address and MUST NOT depend on any server-side geolocation. When the
+timezone is unavailable or unrecognized, the visitor SHALL be treated as
+consent-required (fail toward asking).
+
+#### Scenario: Visitor in a European timezone
+
+- **WHEN** the browser timezone is `Europe/Berlin`
+- **THEN** the visitor is classified as consent-required
+
+#### Scenario: Visitor outside the region
+
+- **WHEN** the browser timezone is `America/New_York`
+- **THEN** the visitor is classified as not consent-required
+
+#### Scenario: Timezone unavailable
+
+- **WHEN** the browser timezone cannot be resolved
+- **THEN** the visitor is treated as consent-required
+
+### Requirement: Consent persistence
+
+The frontend SHALL persist a visitor's cookie choice in `localStorage` under a
+single key holding one of `granted` or `denied`, and SHALL treat the absence of
+that key as "no choice made". The stored choice SHALL survive reloads and be
+readable synchronously at boot.
+
+#### Scenario: Choice recorded
+
+- **WHEN** the visitor accepts or rejects
+- **THEN** the corresponding value (`granted` / `denied`) is written to the
+  `localStorage` key
+
+#### Scenario: Returning visitor
+
+- **WHEN** the app boots and the key already holds `granted` or `denied`
+- **THEN** the stored choice is used and the banner is not shown again
+
+### Requirement: Non-essential trackers gated on consent
+
+For a consent-required visitor, the frontend SHALL NOT initialize any
+non-essential tracker (Google Analytics or PostHog) until consent is `granted`.
+A visitor who is not consent-required SHALL have trackers initialized on load
+without a banner. When consent is `denied`, no non-essential tracker SHALL load
+and no tracking cookie SHALL be set.
+
+#### Scenario: Consent-required, no choice yet
+
+- **WHEN** a consent-required visitor boots the app with no stored choice
+- **THEN** neither Google Analytics nor PostHog is initialized
+
+#### Scenario: Consent-required, granted
+
+- **WHEN** a consent-required visitor has (or gives) `granted` consent
+- **THEN** both Google Analytics and PostHog are initialized
+
+#### Scenario: Consent-required, denied
+
+- **WHEN** a consent-required visitor has `denied` consent
+- **THEN** no non-essential tracker initializes and no tracking cookie is set
+
+#### Scenario: Not consent-required
+
+- **WHEN** a visitor outside the region boots the app
+- **THEN** trackers initialize on load and no banner is shown
+
+### Requirement: Consent banner
+
+The frontend SHALL render a consent banner only when the visitor is
+consent-required and has made no choice. The banner SHALL present an Accept and a
+Reject control of equal visual prominence, with no option pre-selected, and a
+link to the privacy policy. Accepting SHALL record `granted` and start the
+trackers immediately; rejecting SHALL record `denied` and start nothing.
+
+#### Scenario: Banner shown
+
+- **WHEN** a consent-required visitor has made no choice
+- **THEN** the banner is rendered with equal-prominence Accept and Reject
+  controls, neither pre-selected, and a privacy-policy link
+
+#### Scenario: Accept
+
+- **WHEN** the visitor clicks Accept
+- **THEN** consent is recorded as `granted`, the trackers initialize, and the
+  banner is dismissed
+
+#### Scenario: Reject
+
+- **WHEN** the visitor clicks Reject
+- **THEN** consent is recorded as `denied`, no tracker initializes, and the banner
+  is dismissed
+
+### Requirement: Consent withdrawal entry point
+
+The frontend SHALL provide a persistent entry point (a footer "Cookie settings"
+link) that re-opens the banner so a visitor can change a previously recorded
+choice, making withdrawal as easy as granting.
+
+#### Scenario: Re-open from footer
+
+- **WHEN** a visitor who previously chose activates the footer "Cookie settings"
+  link
+- **THEN** the banner re-opens allowing them to change their choice

--- a/openspec/changes/add-cookie-consent-banner/specs/product-analytics/spec.md
+++ b/openspec/changes/add-cookie-consent-banner/specs/product-analytics/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Env-gated PostHog initialization
+
+The frontend SHALL initialize the PostHog client only when `PUBLIC_POSTHOG_KEY`
+is set, and SHALL remain fully inert (no network calls, no globals mutated) when
+it is absent. Initialization SHALL configure a same-origin API host and
+`identified_only` person profiles. For a consent-required visitor (see the
+`cookie-consent` capability), initialization SHALL additionally require that
+consent is `granted`; a consent-required visitor without granted consent SHALL
+leave PostHog inert even when `PUBLIC_POSTHOG_KEY` is present.
+
+#### Scenario: Key present
+
+- **WHEN** the client app boots with `PUBLIC_POSTHOG_KEY` set and the visitor is
+  not consent-required (or has granted consent)
+- **THEN** PostHog is initialized with `api_host` pointing at the same-origin
+  reverse-proxy path and `person_profiles: 'identified_only'`
+
+#### Scenario: Key absent
+
+- **WHEN** the client app boots without `PUBLIC_POSTHOG_KEY` (e.g. local dev)
+- **THEN** PostHog is not initialized and no analytics network requests are made
+
+#### Scenario: Consent-required without consent
+
+- **WHEN** the client app boots with `PUBLIC_POSTHOG_KEY` set but the visitor is
+  consent-required and has not granted consent
+- **THEN** PostHog is not initialized and no analytics network requests are made

--- a/openspec/changes/add-cookie-consent-banner/tasks.md
+++ b/openspec/changes/add-cookie-consent-banner/tasks.md
@@ -1,0 +1,30 @@
+## 1. Consent module (pure logic — TDD)
+
+- [x] 1.1 Create `web/src/lib/consent.svelte.ts` with pure helper `regionNeedsConsent(tz: string): boolean` — true for `Europe/*` + EEA Atlantic zones, and for empty/unknown input (fail toward asking). Write the failing unit test first (`web/src/lib/consent.test.ts`).
+- [x] 1.2 Add consent read/write over `localStorage['hire.consent']` (`granted` | `denied` | absent) and a pure `needsBanner(region: boolean, choice: string | null): boolean` (true only when region && no choice). Unit-test `needsBanner` truth table and the stored-value round-trip guards.
+- [x] 1.3 Add reactive `$state` for the current choice plus `grant()`, `deny()`, `reopen()` mutators. (State runes can't be unit-tested per the frontend convention — cover the pure branch logic in 1.1/1.2; verify the runes via the banner visual pass in group 6.)
+
+## 2. Tracker gating (analytics.ts — TDD where pure)
+
+- [x] 2.1 Add a guarded GA loader to `web/src/lib/analytics.ts` (inject `gtag.js` from `googletagmanager.com`, config `G-6P1PZ719T0`) alongside PostHog, exposed via a single `initTrackers(config)` that starts both and is idempotent. Keep the localhost skip that `app.html` had. Unit-test the guard/no-op branches that don't touch the DOM.
+- [x] 2.2 Change the caller in `web/src/hooks.client.ts` (and/or `+layout.svelte`) to call `initTrackers()` only when `!regionNeedsConsent(tz) || choice === 'granted'`, reading region + choice from the consent module. PostHog env-gating (`PUBLIC_POSTHOG_KEY`) is preserved as an additional precondition.
+
+## 3. CSP + inline cleanup
+
+- [x] 3.1 Remove the inline GA `<script>` bootstrap from `web/src/app.html` (leave the anti-FOUC theme script untouched).
+- [x] 3.2 Remove the now-obsolete GA inline-bootstrap SHA-256 hash from `script-src` in `web/svelte.config.js`; keep the `https://www.googletagmanager.com` host and the theme-script hash. Update the surrounding CSP comment to match.
+
+## 4. Banner + wiring
+
+- [x] 4.1 Create `web/src/lib/components/CookieConsent.svelte`: shown only when `needsBanner`; terminal aesthetic; equal-prominence Accept/Reject, no pre-selected default; short text + link to `/privacy`. Accept → `grant()` + `initTrackers()`; Reject → `deny()`.
+- [x] 4.2 Mount `CookieConsent` in `web/src/routes/+layout.svelte` and ensure the central gate starts trackers on grant.
+- [x] 4.3 Add a footer "Cookie settings" link (in the Footer component) that calls `reopen()` to re-open the banner.
+
+## 5. Privacy policy reconciliation
+
+- [x] 5.1 Update the Cookies section (and the "Technical data" / "How we use it" lines) in `web/src/routes/privacy/+page.svelte`: list Google Analytics and PostHog explicitly as consent-gated for EU/EEA/UK visitors, describe the banner + withdrawal, and remove the now-false "if you opt in" and "no tracking profiles" claims. Bump `lastUpdated`.
+
+## 6. Verification
+
+- [x] 6.1 Run the web unit suite (`vitest`) — consent pure-logic tests green.
+- [x] 6.2 Visual verify via headless Chrome: (a) EU timezone → banner shows, no `_ga`/`ph_*` cookies and no gtag/PostHog network before choice; (b) Accept → both trackers load + cookies set, banner gone; (c) Reject → nothing loads; (d) non-EU timezone → no banner, trackers load; (e) footer "Cookie settings" re-opens the banner.

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -19,24 +19,8 @@
         } catch (e) {}
       })();
     </script>
-    <!-- Google Analytics (gtag.js). Skipped on localhost so dev traffic stays
-    out of the property; the measurement ID is public by design. -->
-    <script>
-      (function () {
-        if (/^(localhost|127\.0\.0\.1)$/.test(location.hostname)) return;
-        var s = document.createElement('script');
-        s.async = true;
-        s.src = 'https://www.googletagmanager.com/gtag/js?id=G-6P1PZ719T0';
-        document.head.appendChild(s);
-        window.dataLayer = window.dataLayer || [];
-        function gtag() {
-          dataLayer.push(arguments);
-        }
-        window.gtag = gtag;
-        gtag('js', new Date());
-        gtag('config', 'G-6P1PZ719T0');
-      })();
-    </script>
+    <!-- Google Analytics is no longer bootstrapped inline here: it now loads via
+    $lib/analytics (initTrackers), gated on cookie consent alongside PostHog. -->
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/web/src/hooks.client.ts
+++ b/web/src/hooks.client.ts
@@ -1,6 +1,6 @@
 import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
-import { initAnalytics } from '$lib/analytics';
+import { startTrackersIfAllowed } from '$lib/trackers';
 
 // Error tracking is opt-in and env-gated: without PUBLIC_SENTRY_DSN Sentry stays
 // uninitialized and the app runs unchanged (mirrors the backend integration).
@@ -15,14 +15,12 @@ if (env.PUBLIC_SENTRY_DSN) {
   });
 }
 
-// Product analytics is likewise opt-in and env-gated. This hook is client-only,
-// so no browser guard is needed; ingestion goes through the same-origin /ingest
-// reverse proxy (overridable via PUBLIC_POSTHOG_HOST). initAnalytics is inert
-// when the key is absent.
-initAnalytics({
-  key: env.PUBLIC_POSTHOG_KEY ?? '',
-  apiHost: env.PUBLIC_POSTHOG_HOST || '/ingest',
-});
+// Non-essential trackers (PostHog + Google Analytics) are gated on cookie consent:
+// this starts them at boot only for visitors who are not consent-required or who
+// have already granted consent. Consent-required visitors with no choice start
+// nothing until they Accept in the banner (which calls startTrackers itself).
+// Still env-gated end to end — inert when PUBLIC_POSTHOG_KEY is absent.
+startTrackersIfAllowed();
 
 // Reports uncaught client-side errors to Sentry; inert when init was skipped above.
 export const handleError = Sentry.handleErrorWithSentry();

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,14 +1,15 @@
-// PostHog product analytics — a thin, guarded wrapper so call sites never touch
-// the SDK directly and every entry point is a safe no-op when PostHog is not
-// initialized (no key in dev, or SSR). Mirrors the Sentry env-gating posture:
-// without PUBLIC_POSTHOG_KEY nothing initializes and no events are sent.
+// Non-essential trackers — a thin, guarded wrapper (PostHog + Google Analytics) so
+// call sites never touch the SDKs directly and every entry point is a safe no-op
+// when nothing is initialized (no key in dev, or SSR). Mirrors the Sentry env-gating
+// posture: without PUBLIC_POSTHOG_KEY PostHog stays inert. Both trackers start only
+// through initTrackers, which the caller gates on cookie consent.
 //
 // Only the pure/guarded surface (isPrivateRoute, track no-op, isFeatureEnabled
-// fallback) is unit-tested; the SDK side effects (identify/reset/replay) are
+// fallback) is unit-tested; the SDK side effects (identify/reset/replay, gtag) are
 // exercised via visual verification, per the frontend testing convention.
 //
-// The SDK (~40KB gzip) is dynamically imported inside initAnalytics, so it only
-// downloads when a key is actually configured — it never weighs down the entry
+// The PostHog SDK (~40KB gzip) is dynamically imported inside initPostHog, so it
+// only downloads when a key is actually configured — it never weighs down the entry
 // chunk for visitors where analytics is inert (no key, or SSR). Same lazy posture
 // as shiki/easymde elsewhere.
 import type { PostHog } from 'posthog-js';
@@ -18,6 +19,18 @@ export interface AnalyticsConfig {
   key: string;
   /** Same-origin reverse-proxy path events are sent through (e.g. `/ingest`). */
   apiHost: string;
+}
+
+// Google Analytics measurement ID (public by design). Moved here from the inline
+// app.html bootstrap so GA can be gated on consent alongside PostHog; the CSP still
+// allow-lists the googletagmanager.com host it injects.
+const GA_MEASUREMENT_ID = 'G-6P1PZ719T0';
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
 }
 
 // Null until the dynamic import resolves and init runs; every entry point below
@@ -30,10 +43,18 @@ let loading = false;
 // which is client-only) so this module stays free of SvelteKit runtime imports
 // and unit-testable in a plain node environment.
 
+/** Start every non-essential tracker: PostHog (when a key is configured) and
+ *  Google Analytics. Idempotent, and the single entry point gated on consent by
+ *  the caller — nothing here runs until consent allows it. */
+export function initTrackers(config: AnalyticsConfig): void {
+  initPostHog(config);
+  initGoogleAnalytics();
+}
+
 /** Load and initialize PostHog once, only when a key is configured. Best-effort:
  *  a failed dynamic import must never break the app, so the SDK download is fired
  *  and forgotten with errors swallowed. */
-export function initAnalytics(config: AnalyticsConfig): void {
+function initPostHog(config: AnalyticsConfig): void {
   if (ph || loading || !config.key) return;
   loading = true;
   void import('posthog-js')
@@ -50,6 +71,31 @@ export function initAnalytics(config: AnalyticsConfig): void {
     .catch(() => {
       loading = false; // let a later call retry the load
     });
+}
+
+// True once GA has been injected, so a repeated initTrackers() (e.g. Accept after a
+// re-open) does not load gtag.js twice.
+let gaLoaded = false;
+
+// Push a command onto GA's dataLayer, creating it on first use. At module scope (it
+// captures no locals) so it isn't recreated on each init.
+function gtag(...args: unknown[]): void {
+  (window.dataLayer ??= []).push(args);
+}
+
+/** Inject gtag.js and configure GA once. Skipped on localhost so dev traffic stays
+ *  out of the property — matching the old app.html bootstrap. */
+function initGoogleAnalytics(): void {
+  if (gaLoaded) return;
+  if (/^(localhost|127\.0\.0\.1)$/.test(location.hostname)) return;
+  gaLoaded = true;
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+  document.head.appendChild(script);
+  window.gtag = gtag;
+  gtag('js', new Date());
+  gtag('config', GA_MEASUREMENT_ID);
 }
 
 /** Routes whose DOM must never be recorded (résumé, tracking, inbox all live

--- a/web/src/lib/components/CookieConsent.svelte
+++ b/web/src/lib/components/CookieConsent.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { bannerVisible, deny, grant, trackersAllowed } from '$lib/consent.svelte';
+  import { startTrackers } from '$lib/trackers';
+
+  // Accept records consent and starts the trackers immediately; Reject records the
+  // refusal and starts nothing. The two are deliberately equal in prominence — no
+  // pre-selected default — so the choice is freely given (ePrivacy/GDPR).
+  function accept() {
+    grant();
+    startTrackers();
+  }
+
+  // Reject records the refusal. If trackers were already running this session (a
+  // withdrawal via the footer re-open), reload so GA/PostHog actually stop — they
+  // cannot be fully torn down in place. A first-time rejection starts nothing, so
+  // no reload is needed.
+  function reject() {
+    const wasRunning = trackersAllowed();
+    deny();
+    if (wasRunning) location.reload();
+  }
+</script>
+
+{#if bannerVisible()}
+  <div
+    role="dialog"
+    aria-modal="false"
+    aria-label="Cookie consent"
+    class="fixed inset-x-4 bottom-4 z-50 rounded-lg border border-border bg-background/95 px-4 py-3 shadow-lg backdrop-blur sm:inset-x-auto sm:left-4 sm:max-w-md"
+  >
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+      <p class="font-mono text-sm font-semibold text-foreground">Cookies?</p>
+      <p class="min-w-0 flex-1 text-xs leading-relaxed text-muted-foreground">
+        We use Google Analytics and PostHog to understand usage.
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal route via resolve() -->
+        <a
+          href={resolve('/privacy')}
+          class="font-mono underline underline-offset-2 transition-colors hover:text-foreground"
+        >
+          Learn more
+        </a>
+      </p>
+      <div class="flex shrink-0 gap-2">
+        <button
+          type="button"
+          onclick={accept}
+          class="rounded border border-border px-3 py-1 font-mono text-sm text-foreground transition-colors hover:bg-muted"
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          onclick={reject}
+          class="rounded border border-border px-3 py-1 font-mono text-sm text-foreground transition-colors hover:bg-muted"
+        >
+          Reject
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { reopen } from '$lib/consent.svelte';
   import ProviderIcon from './ProviderIcon.svelte';
 
   // Grouped navigation over existing routes only — kept deliberately small so the
@@ -88,6 +89,15 @@
     >
       <div class="flex items-center gap-4">
         <p>© {year}</p>
+        <!-- Re-opens the consent banner so a prior cookie choice can be changed —
+             withdrawal as easy as granting (GDPR). -->
+        <button
+          type="button"
+          onclick={reopen}
+          class="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Cookie settings
+        </button>
         <div class="flex items-center gap-3">
           {#each socials as social (social.provider)}
             <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external profile URL opened in a new tab; not an internal route -->

--- a/web/src/lib/consent.svelte.ts
+++ b/web/src/lib/consent.svelte.ts
@@ -1,0 +1,60 @@
+// Reactive cookie-consent state: the single source of truth for "may trackers
+// start" and "should the banner show". Pure classification and persistence live in
+// consent.ts (unit-tested); this module adds the $state runes on top, so it is
+// verified visually rather than in the plain-node vitest environment.
+import { browser } from '$app/environment';
+import { type ConsentChoice, needsBanner, readConsent, regionNeedsConsent, writeConsent } from './consent';
+
+function resolveTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? '';
+  } catch {
+    return '';
+  }
+}
+
+// The region is fixed for the session (a visitor's timezone does not change
+// mid-visit), so it is a plain const. The choice and the forced-open flag are
+// reactive so the banner and the tracker gate react to Accept/Reject and to a
+// footer-driven re-open. On the server nothing is consent-required and no choice
+// exists — the banner and gate resolve entirely on the client.
+const regionRequired = browser ? regionNeedsConsent(resolveTimezone()) : false;
+
+let choice = $state<ConsentChoice | null>(browser ? readConsent() : null);
+let forcedOpen = $state(false);
+
+/** Whether non-essential trackers may run now. An explicit choice is authoritative
+ *  for everyone: `denied` always blocks (so a rejection is honoured even outside the
+ *  consent-required region), `granted` always allows. With no choice yet, trackers
+ *  run only for a visitor who is not consent-required. */
+export function trackersAllowed(): boolean {
+  if (choice === 'denied') return false;
+  if (choice === 'granted') return true;
+  return !regionRequired;
+}
+
+/** Whether the consent banner should render — a consent-required visitor with no
+ *  choice, or one who re-opened it from the footer to change a prior choice. */
+export function bannerVisible(): boolean {
+  return forcedOpen || needsBanner(regionRequired, choice);
+}
+
+/** Record consent and close the banner. The caller starts the trackers. */
+export function grant(): void {
+  choice = 'granted';
+  forcedOpen = false;
+  writeConsent('granted');
+}
+
+/** Record refusal and close the banner. No tracker starts. */
+export function deny(): void {
+  choice = 'denied';
+  forcedOpen = false;
+  writeConsent('denied');
+}
+
+/** Re-open the banner so a previously recorded choice can be changed
+ *  (withdrawal as easy as granting). */
+export function reopen(): void {
+  forcedOpen = true;
+}

--- a/web/src/lib/consent.test.ts
+++ b/web/src/lib/consent.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CONSENT_KEY, needsBanner, readConsent, regionNeedsConsent, writeConsent } from './consent';
+
+// A minimal in-memory localStorage stub for the read/write round-trip tests. The
+// pure functions must degrade to a no-op / null when storage is unavailable (SSR),
+// which the "no storage" cases below assert.
+function stubLocalStorage(): Storage {
+  const map = new Map<string, string>();
+  const storage = {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size;
+    },
+  } as Storage;
+  vi.stubGlobal('localStorage', storage);
+  return storage;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Pure region classification from a browser timezone. No runes, no localStorage —
+// exercised in the plain-node vitest environment, per the frontend convention.
+
+describe('regionNeedsConsent', () => {
+  it('treats European timezones as consent-required', () => {
+    expect(regionNeedsConsent('Europe/Berlin')).toBe(true);
+    expect(regionNeedsConsent('Europe/London')).toBe(true);
+    expect(regionNeedsConsent('Europe/Paris')).toBe(true);
+  });
+
+  it('treats EEA Atlantic zones as consent-required', () => {
+    expect(regionNeedsConsent('Atlantic/Canary')).toBe(true);
+    expect(regionNeedsConsent('Atlantic/Madeira')).toBe(true);
+    expect(regionNeedsConsent('Atlantic/Reykjavik')).toBe(true);
+  });
+
+  it('treats non-European timezones as not consent-required', () => {
+    expect(regionNeedsConsent('America/New_York')).toBe(false);
+    expect(regionNeedsConsent('Asia/Tokyo')).toBe(false);
+    expect(regionNeedsConsent('Australia/Sydney')).toBe(false);
+    // A US Atlantic-coast-sounding zone must not be misread as an EEA Atlantic one.
+    expect(regionNeedsConsent('America/Halifax')).toBe(false);
+  });
+
+  it('fails toward asking when the timezone is missing or unknown', () => {
+    expect(regionNeedsConsent('')).toBe(true);
+    expect(regionNeedsConsent('Not/AZone')).toBe(true);
+  });
+});
+
+describe('needsBanner', () => {
+  it('is true only for a consent-required visitor who has made no choice', () => {
+    expect(needsBanner(true, null)).toBe(true);
+  });
+
+  it('is false once a choice exists, regardless of region', () => {
+    expect(needsBanner(true, 'granted')).toBe(false);
+    expect(needsBanner(true, 'denied')).toBe(false);
+  });
+
+  it('is false for a visitor who is not consent-required', () => {
+    expect(needsBanner(false, null)).toBe(false);
+    expect(needsBanner(false, 'granted')).toBe(false);
+  });
+});
+
+describe('readConsent / writeConsent', () => {
+  it('round-trips a granted choice', () => {
+    stubLocalStorage();
+    writeConsent('granted');
+    expect(readConsent()).toBe('granted');
+    expect(localStorage.getItem(CONSENT_KEY)).toBe('granted');
+  });
+
+  it('round-trips a denied choice', () => {
+    stubLocalStorage();
+    writeConsent('denied');
+    expect(readConsent()).toBe('denied');
+  });
+
+  it('returns null when no choice has been stored', () => {
+    stubLocalStorage();
+    expect(readConsent()).toBe(null);
+  });
+
+  it('treats an unrecognized stored value as no choice', () => {
+    const storage = stubLocalStorage();
+    storage.setItem(CONSENT_KEY, 'garbage');
+    expect(readConsent()).toBe(null);
+  });
+
+  it('degrades to null and never throws when storage is unavailable', () => {
+    vi.stubGlobal('localStorage', undefined);
+    expect(() => readConsent()).not.toThrow();
+    expect(readConsent()).toBe(null);
+    expect(() => writeConsent('granted')).not.toThrow();
+  });
+});

--- a/web/src/lib/consent.ts
+++ b/web/src/lib/consent.ts
@@ -1,0 +1,64 @@
+// Cookie-consent pure logic: region classification and consent persistence, kept
+// free of Svelte runes and SvelteKit imports so it unit-tests in the plain-node
+// vitest environment. The reactive wrapper (grant/deny/reopen over $state) lives
+// in consent.svelte.ts; this module holds only pure functions and localStorage IO.
+
+/** The visitor's recorded cookie choice; absence means no choice made yet. */
+export type ConsentChoice = 'granted' | 'denied';
+
+/** localStorage key holding the consent choice. */
+export const CONSENT_KEY = 'hire.consent';
+
+// EEA/EU territories that sit outside the `Europe/*` timezone prefix. Kept explicit
+// and small; erring toward inclusion only ever shows the banner to a few extra
+// visitors, which is harmless.
+const EEA_ATLANTIC_ZONES = new Set([
+  'Atlantic/Canary', // Spain
+  'Atlantic/Madeira', // Portugal
+  'Atlantic/Azores', // Portugal
+  'Atlantic/Reykjavik', // Iceland (EEA)
+  'Atlantic/Faroe', // Denmark
+]);
+
+/** True when a browser timezone places the visitor in a consent-required region
+ *  (EU/EEA/UK). Unknown or empty input fails toward asking (returns true), so a
+ *  visitor we cannot classify is treated conservatively. */
+export function regionNeedsConsent(timezone: string): boolean {
+  if (!timezone) return true;
+  if (timezone.startsWith('Europe/')) return true;
+  if (EEA_ATLANTIC_ZONES.has(timezone)) return true;
+  // A valid IANA zone that is neither European nor an EEA Atlantic one is not
+  // consent-required; anything Intl rejects as unknown fails toward asking.
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/** True when the banner should be shown: a consent-required visitor who has not
+ *  yet made a choice. Any recorded choice (or a non-required region) suppresses it. */
+export function needsBanner(regionRequired: boolean, choice: ConsentChoice | null): boolean {
+  return regionRequired && choice === null;
+}
+
+/** Read the stored choice, or null when none is recorded, the value is
+ *  unrecognized, or storage is unavailable (SSR). Never throws. */
+export function readConsent(): ConsentChoice | null {
+  try {
+    const value = localStorage.getItem(CONSENT_KEY);
+    return value === 'granted' || value === 'denied' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the visitor's choice. A no-op when storage is unavailable. Never throws. */
+export function writeConsent(choice: ConsentChoice): void {
+  try {
+    localStorage.setItem(CONSENT_KEY, choice);
+  } catch {
+    // Storage unavailable or full (SSR, private mode) — consent simply won't persist.
+  }
+}

--- a/web/src/lib/trackers.ts
+++ b/web/src/lib/trackers.ts
@@ -1,0 +1,27 @@
+// Client orchestration seam between env config, consent state, and the analytics
+// wrapper. Kept out of analytics.ts so that module stays free of SvelteKit runtime
+// imports and unit-testable; this file is client-only and verified via the banner
+// visual pass. Both the boot hook and the banner's Accept action route through here
+// so the PostHog config is assembled in exactly one place.
+import { env } from '$env/dynamic/public';
+import { type AnalyticsConfig, initTrackers } from './analytics';
+import { trackersAllowed } from './consent.svelte';
+
+function config(): AnalyticsConfig {
+  return {
+    key: env.PUBLIC_POSTHOG_KEY ?? '',
+    apiHost: env.PUBLIC_POSTHOG_HOST || '/ingest',
+  };
+}
+
+/** Start every non-essential tracker with the app's env config. Called on Accept
+ *  and, at boot, only when consent already allows it. */
+export function startTrackers(): void {
+  initTrackers(config());
+}
+
+/** Start trackers only when consent currently allows it: the visitor is not
+ *  consent-required, or has already granted consent. */
+export function startTrackersIfAllowed(): void {
+  if (trackersAllowed()) startTrackers();
+}

--- a/web/src/posts/2026-07-22-a-cookie-choice-for-those-who-need-one.svx
+++ b/web/src/posts/2026-07-22-a-cookie-choice-for-those-who-need-one.svx
@@ -1,0 +1,19 @@
+---
+title: We ask before loading analytics cookies now
+date: 2026-07-22
+summary: Visitors from the EU, EEA, and UK get a cookie banner and choose whether analytics load — and anyone can change that choice from the footer.
+type: changelog
+tags:
+  - privacy
+draft: false
+---
+
+freehire uses two analytics tools — Google Analytics and PostHog — to see which pages get
+used and fix what's rough. Until now they loaded for everyone the moment a page opened. For
+visitors in the EU, EEA, or UK, that's meant to be a choice, not a default.
+
+Now it is. If you're in one of those regions, a small banner asks first — Accept and Reject
+side by side, nothing pre-ticked — and no analytics load until you say yes. Everyone else is
+unchanged. Changed your mind? **Cookie settings** in the footer reopens the banner any time,
+and rejecting stops what was running. The [privacy policy](/privacy) now spells out exactly
+what runs and when.

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
   } from '$lib/analytics';
   import TopBar from '$lib/components/TopBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
+  import CookieConsent from '$lib/components/CookieConsent.svelte';
   import '../app.css';
   // Country-flag icon sheet (used by $lib/components/Flag.svelte). References its
   // SVGs by URL, so the browser only fetches flags actually rendered.
@@ -95,6 +96,10 @@
     <Footer />
   {/if}
 </div>
+
+<!-- Consent banner: fixed-position, self-gating (renders only for a
+     consent-required visitor with no choice, or when re-opened from the footer). -->
+<CookieConsent />
 
 <style>
   /* Indeterminate sweep: the segment slides across the track on repeat while a

--- a/web/src/routes/privacy/+page.svelte
+++ b/web/src/routes/privacy/+page.svelte
@@ -11,7 +11,7 @@
 
   // Static effective date — freehire has no Date.now-driven content, and a hard
   // date is what a privacy policy needs. Bump this whenever the policy changes.
-  const lastUpdated = 'July 11, 2026';
+  const lastUpdated = 'July 22, 2026';
 </script>
 
 <Seo
@@ -67,8 +67,8 @@
         </li>
         <li>
           <span class="font-medium text-foreground">Technical data.</span> Standard request logs
-          (IP address, user agent, timestamps) and, if you opt in via your browser, cookies. We do
-          not use tracking or advertising profiles.
+          (IP address, user agent, timestamps) and, where you allow it, product-analytics cookies
+          (see “Cookies”). We do not sell your data or build advertising profiles.
         </li>
       </ul>
     </section>
@@ -88,7 +88,14 @@
         When you sign in, we set a single <code class="font-mono text-foreground">HttpOnly</code>,
         <code class="font-mono text-foreground">SameSite=Lax</code> session cookie holding a signed
         token. It is strictly necessary for keeping you logged in and cannot be read by JavaScript.
-        Logging out clears it.
+        Logging out clears it. This cookie is always set and needs no consent.
+      </p>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        For product analytics we use Google Analytics and PostHog, which set their own cookies and,
+        in PostHog's case, may record a session replay with all inputs masked. These are
+        non-essential. If you visit from the EU, EEA, or UK, they load only after you accept them in
+        the cookie banner — reject and nothing loads. You can change your choice at any time via
+        “Cookie settings” in the footer.
       </p>
     </section>
 
@@ -110,6 +117,11 @@
         <li>
           <span class="font-medium text-foreground">A language-model provider</span> — processes CV
           and job text to produce AI fit analysis, only when you request it.
+        </li>
+        <li>
+          <span class="font-medium text-foreground">Product analytics (Google Analytics, PostHog)</span>
+          — measure aggregate usage to improve the product; loaded only with your consent where
+          required (see “Cookies”). PostHog runs on its EU instance.
         </li>
         <li>
           <span class="font-medium text-foreground">Error monitoring (Sentry)</span> — captures

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -33,11 +33,9 @@ export default {
           'self',
           // Anti-FOUC theme script in app.html (see WARNING above).
           'sha256-qvzE1AlG+fDQlxleonlMQaOrsjjgE6qfHfnkE0pD/bo=',
-          // Google Analytics: SHA-256 of the inline gtag bootstrap in app.html,
-          // plus the gtag.js host it injects. Same hash caveat as the theme
-          // script — editing that <script> changes this hash and silently
-          // breaks GA data collection.
-          'sha256-tf1xyFn3XkSa3dEPltHXXh1gwP9PXgX19twcwLYVszU=',
+          // Google Analytics: the gtag.js host. GA now loads from the same-origin
+          // bundle ($lib/analytics, consent-gated), so no inline-script hash is
+          // needed — only the external host it injects.
           'https://www.googletagmanager.com',
         ],
         // Cheap defence-in-depth: pin the document base (no <base> injection) and


### PR DESCRIPTION
## Summary
Google Analytics and PostHog (with session recording) currently fire on page load with no consent mechanism and no banner — an ePrivacy/GDPR gap for EU/EEA/UK visitors. The privacy policy also claimed opt-in cookies that didn't exist and "no tracking profiles" while running exactly those. This adds a consent gate, shown only where legally required.

- **Region by timezone (client-side)** — `Intl` timezone `Europe/*` + EEA Atlantic zones ⇒ consent-required; unknown ⇒ fail toward asking. No IP/geo infra, no nginx/ops change.
- **`consent.ts`** (pure, unit-tested) — region classification, `localStorage` persistence (`hire.consent` ∈ {granted,denied}), `needsBanner`. **`consent.svelte.ts`** — reactive state + `trackersAllowed`/`grant`/`deny`/`reopen`.
- **Trackers gated** — GA moved out of the inline `app.html` bootstrap into `$lib/analytics` (`initTrackers`); its inline SHA-256 hash dropped from the CSP (`googletagmanager.com` host kept). Neither GA nor PostHog starts for a consent-required visitor until Accept.
- **`CookieConsent.svelte`** — equal-prominence Accept/Reject, no pre-selected default, link to `/privacy`. Footer **Cookie settings** re-opens it; a rejection after trackers ran reloads so withdrawal is effective. An explicit `denied` is honoured globally.
- **Privacy policy** reconciled: lists GA + PostHog, describes the consent mechanism, drops the now-false claims.

Non-EU visitors keep analytics-on-load with no banner. Frontend-only (`web/`), no backend.

Planned/tracked in OpenSpec: `openspec/changes/add-cookie-consent-banner/`.

## Test Plan
- [x] `vitest` — 366 pass (12 new pure-logic tests: region classification, `needsBanner`, consent round-trip, SSR-safe degradation)
- [x] `svelte-check` — 0 errors; `oxlint`/`eslint` — clean on touched files
- [x] `vite build` — production build passes (SSR + CSP)
- [x] Headless-browser verification: non-EU (São Paulo) ⇒ no banner; banner UI (equal buttons, Learn more → /privacy); Accept ⇒ hides + persists `granted`; Reject-after-grant ⇒ persists `denied` + reload; footer "Cookie settings" re-opens
- [ ] Reviewer: confirm no EU tracker fire before Accept in prod (GA is localhost-skipped, so not observable locally)