### PR TITLE
fix(resumeextract): tolerate numeric year/dates & string total_years from LLM

### DIFF
--- a/internal/resumeextract/flexstring.go
+++ b/internal/resumeextract/flexstring.go
@@ -1,0 +1,125 @@
+package resumeextract
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// flexString decodes from a JSON string OR a bare number. The model is asked to keep
+// years and dates as written (strings), but it routinely emits them as numbers
+// (e.g. "year": 2019). encoding/json aborts the whole unmarshal on the first type
+// mismatch, so a single numeric date would otherwise silently discard the entire
+// structured résumé. Used only for the free-form date/year fields via the UnmarshalJSON
+// shims below; the exported struct fields stay plain string so the contract, Sanitize,
+// and every consumer are untouched.
+type flexString string
+
+func (f *flexString) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		*f = ""
+		return nil
+	}
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*f = flexString(s)
+		return nil
+	}
+	// Bare number (or other scalar token) — keep it verbatim as the string value.
+	*f = flexString(b)
+	return nil
+}
+
+// flexInt decodes from a JSON number OR a string ("5", "5+ years"). total_years is
+// prompted as an integer, but the model can return it as a string or a phrase; a string
+// there would abort the whole decode. Non-numeric or empty input yields 0.
+type flexInt int
+
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		*f = 0
+		return nil
+	}
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*f = flexInt(leadingInt(s))
+		return nil
+	}
+	// JSON number: parse as float first so "5.0" (or a stray decimal) truncates cleanly.
+	n, err := strconv.ParseFloat(string(b), 64)
+	if err != nil {
+		return err
+	}
+	*f = flexInt(int(n))
+	return nil
+}
+
+// leadingInt returns the integer formed by the leading digits of s (e.g. "5+ years" → 5),
+// or 0 if s has no leading digits.
+func leadingInt(s string) int {
+	s = strings.TrimSpace(s)
+	end := 0
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0
+	}
+	n, _ := strconv.Atoi(s[:end])
+	return n
+}
+
+// UnmarshalJSON tolerates a string/phrase "total_years" (e.g. "5+ years") via flexInt,
+// then delegates the rest to the normal struct decode via an alias (no recursion).
+func (s *Structured) UnmarshalJSON(b []byte) error {
+	type alias Structured
+	aux := struct {
+		TotalYears flexInt `json:"total_years"`
+		*alias
+	}{alias: (*alias)(s)}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	s.TotalYears = int(aux.TotalYears)
+	return nil
+}
+
+// UnmarshalJSON tolerates a numeric "year" (e.g. 2019) by decoding it through flexString,
+// then delegates the rest to the normal struct decode via an alias (no recursion).
+func (e *Education) UnmarshalJSON(b []byte) error {
+	type alias Education
+	aux := struct {
+		Year flexString `json:"year"`
+		*alias
+	}{alias: (*alias)(e)}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	e.Year = string(aux.Year)
+	return nil
+}
+
+// UnmarshalJSON tolerates numeric "start"/"end" dates (e.g. 2019) the same way.
+func (x *Experience) UnmarshalJSON(b []byte) error {
+	type alias Experience
+	aux := struct {
+		Start flexString `json:"start"`
+		End   flexString `json:"end"`
+		*alias
+	}{alias: (*alias)(x)}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	x.Start = string(aux.Start)
+	x.End = string(aux.End)
+	return nil
+}

--- a/internal/resumeextract/flexstring_test.go
+++ b/internal/resumeextract/flexstring_test.go
@@ -1,0 +1,74 @@
+package resumeextract
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The model is asked to keep years/dates as written, but it frequently emits a bare
+// number (e.g. "year": 2019) instead of a string. encoding/json aborts the WHOLE
+// unmarshal on the first type mismatch, so one numeric year silently kills the entire
+// structured résumé (prod: user 291 — resume_structured never persisted). Number-or-string
+// free-form fields must decode either way.
+func TestUnmarshal_NumericDateFieldsDecodeAsStrings(t *testing.T) {
+	raw := `{
+		"full_name": "Ada Lovelace",
+		"experience": [{"title": "Engineer", "company": "Acme", "start": 2019, "end": 2021}],
+		"education": [{"degree": "BSc", "institution": "MIT", "year": 2015}]
+	}`
+
+	var s Structured
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		t.Fatalf("unmarshal with numeric year/dates failed: %v", err)
+	}
+
+	if len(s.Education) != 1 || s.Education[0].Year != "2015" {
+		t.Errorf("Education[0].Year = %q, want %q", educationYear(s), "2015")
+	}
+	if len(s.Experience) != 1 || s.Experience[0].Start != "2019" || s.Experience[0].End != "2021" {
+		t.Errorf("Experience start/end = %q/%q, want %q/%q",
+			experienceStart(s), experienceEnd(s), "2019", "2021")
+	}
+}
+
+// total_years is prompted as an integer, but the model can return it as a string
+// ("5") or a phrase ("5+ years"). A string there aborts the whole decode just like a
+// numeric year does, so it must coerce to the leading integer.
+func TestUnmarshal_TotalYearsFromString(t *testing.T) {
+	cases := map[string]int{
+		`{"total_years": 5}`:          5,
+		`{"total_years": "5"}`:        5,
+		`{"total_years": "5+ years"}`: 5,
+		`{"total_years": ""}`:         0,
+	}
+	for raw, want := range cases {
+		var s Structured
+		if err := json.Unmarshal([]byte(raw), &s); err != nil {
+			t.Fatalf("unmarshal %s failed: %v", raw, err)
+		}
+		if s.TotalYears != want {
+			t.Errorf("%s: TotalYears = %d, want %d", raw, s.TotalYears, want)
+		}
+	}
+}
+
+func educationYear(s Structured) string {
+	if len(s.Education) == 0 {
+		return ""
+	}
+	return s.Education[0].Year
+}
+
+func experienceStart(s Structured) string {
+	if len(s.Experience) == 0 {
+		return ""
+	}
+	return s.Experience[0].Start
+}
+
+func experienceEnd(s Structured) string {
+	if len(s.Experience) == 0 {
+		return ""
+	}
+	return s.Experience[0].End
+}


### PR DESCRIPTION
## Problem (prod incident)

A user (id 291, `fragnatt@gmail.com`) reported "CV won't upload". The upload actually **succeeded** — file stored, PDF text extracted, embedding built. What failed was the **background structured-résumé parse**, twice, with:

```
resume structured: user 291: resumeextract: parse:
json: cannot unmarshal number into Go struct field Education.education.year of type string
```

The LLM returned the education `year` as a bare number (`2019`) where `Education.Year` is `string`. `encoding/json` aborts the **whole** unmarshal on the first type mismatch, so one numeric year silently discarded the entire structured résumé (`resume_structured` stayed NULL) — which the profile renders as "nothing loaded".

## Fix

Package-local `flexString` / `flexInt` with `UnmarshalJSON` shims on `Education`, `Experience`, and `Structured` that coerce number↔string for the number-prone free-form fields:

- `education.year`, `experience.start`, `experience.end` — tolerate a bare number.
- `total_years` — tolerate a string / phrase (`"5"`, `"5+ years"`).

Exported field types stay `string` / `int`, so the generated TS contract, `Sanitize`, and every consumer are untouched. Mirrors the existing tolerant-decode convention in `internal/enrich`.

## Tests (TDD)

- `TestUnmarshal_NumericDateFieldsDecodeAsStrings` — numeric year/start/end decode as strings (this test reproduced the exact prod error before the fix).
- `TestUnmarshal_TotalYearsFromString` — `5` / `"5"` / `"5+ years"` / `""` → `5/5/5/0`.

`go test ./internal/resumeextract/`, `go build ./...`, `go vet`, `gofmt` all clean.

## Scope note

This is **PR 1 of 2**. An audit found the same decode-abort class in 4 more LLM-JSON sites (`matchanalysis` dimScore.Score — user-visible; `telegram` Remote; `atscheck` ContentQuality; `mailclassify` Confidence/MatchedJobID). PR 2 will generalize the `flex*` types into a shared `internal/flexjson` helper and retype those fields.

## Follow-up

After deploy, re-run structured extraction for user 291 (one-off backfill) — the fix does not retroactively rebuild their `resume_structured`.