### PR TITLE
feat(sources): onboard bamboohr board xlabsystems1 (X-Lab Systems)

### DIFF
--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -18697,3 +18697,5 @@
   board: dzengi
 - company: Koombea
   board: koombea
+- company: X-Lab Systems
+  board: xlabsystems1


### PR DESCRIPTION
Drains the last pending `link_contributions` row: **xlabsystems1** (X-Lab Systems), contributed via `https://xlabsystems1.bamboohr.com`. Validated live (careers page 200) before adding. Status flipped to `onboarded` on prod after merge.