### PR TITLE
feat: PII masking of CV before LLM calls

### DIFF
--- a/cmd/backfill-resume-structured/main.go
+++ b/cmd/backfill-resume-structured/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/llm"
+	"github.com/strelov1/freehire/internal/pii"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
 )
@@ -82,8 +83,15 @@ func main() {
 		log.Fatal("backfill-resume-structured: LLM (LLM_*) is not configured")
 	}
 
+	// The extractor de-identifies each CV before it reaches the LLM; without the detector it
+	// would be fail-closed (a no-op), so a backfill run without it is pointless — require it.
+	if cfg.PIIFilterURL == "" {
+		log.Fatal("backfill-resume-structured: PII_FILTER_URL is not configured")
+	}
+	piiDetector := pii.NewHTTPDetector(cfg.PIIFilterURL, nil)
+
 	store := resume.New(blobStore, resume.NewQueriesRepository(queries))
-	extractor := resumeextract.NewExtractor(llmClient.WithTimeout(extractTimeout))
+	extractor := resumeextract.NewExtractor(llmClient.WithTimeout(extractTimeout), piiDetector)
 
 	// Eligible: a stored CV whose structured résumé is missing or stale (its stamp no
 	// longer equals the current upload time — the same freshness rule Store.Structured reads).

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/strelov1/freehire/internal/handler"
 	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/observability"
+	"github.com/strelov1/freehire/internal/pii"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/tokencrypt"
 )
@@ -156,6 +157,14 @@ func main() {
 	// token-encryption key are configured. Both nil disables the feature.
 	gmailConnector, gmailCipher := buildGmail(cfg)
 
+	// PII detector for de-identifying CV text before it reaches the LLM. Nil when
+	// PII_FILTER_URL is unset, which fails the CV→LLM paths closed (no analysis) rather
+	// than leaking PII (see internal/pii, internal/matchanalysis, internal/resumeextract).
+	var piiDetector pii.Detector
+	if cfg.PIIFilterURL != "" {
+		piiDetector = pii.NewHTTPDetector(cfg.PIIFilterURL, nil)
+	}
+
 	handler.Register(app, handler.Config{
 		Pool:           pool,
 		FrontendOrigin: cfg.FrontendOrigin,
@@ -171,6 +180,7 @@ func main() {
 		Blob:           blobStore,
 		TypstBin:       cfg.TypstBin,
 		LLM:            llmClient,
+		PIIDetector:    piiDetector,
 
 		TelegramBotToken:      cfg.TelegramBotToken,
 		TelegramBotUsername:   cfg.TelegramBotUsername,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,13 @@ type Settings struct {
 	LLMAPIKey  string
 	LLMModel   string
 
+	// PIIFilterURL is the co-located openai/privacy-filter span-detection endpoint used to
+	// mask PII out of CV text before it reaches the LLM (internal/pii). Optional here, but
+	// the fit-analysis and structured-résumé paths are fail-closed: an empty value disables
+	// them entirely (no CV is sent to the LLM) rather than leaking PII — enforced at the
+	// call site, not here.
+	PIIFilterURL string
+
 	LangfuseBaseURL   string
 	LangfusePublicKey string
 	LangfuseSecretKey string
@@ -143,6 +150,8 @@ func Load() Settings {
 		LLMBaseURL: os.Getenv("LLM_BASE_URL"),
 		LLMAPIKey:  os.Getenv("LLM_API_KEY"),
 		LLMModel:   os.Getenv("LLM_MODEL"),
+
+		PIIFilterURL: os.Getenv("PII_FILTER_URL"),
 
 		LangfuseBaseURL:   os.Getenv("LANGFUSE_BASE_URL"),
 		LangfusePublicKey: os.Getenv("LANGFUSE_PUBLIC_KEY"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,22 @@ func TestLoad_LLMFromEnv(t *testing.T) {
 	}
 }
 
+func TestLoad_PIIFilterURLFromEnv(t *testing.T) {
+	t.Setenv("PII_FILTER_URL", "http://127.0.0.1:8099/detect")
+
+	if s := Load(); s.PIIFilterURL != "http://127.0.0.1:8099/detect" {
+		t.Errorf("PIIFilterURL = %q, want the env value", s.PIIFilterURL)
+	}
+}
+
+func TestLoad_PIIFilterURLEmptyWhenUnset(t *testing.T) {
+	t.Setenv("PII_FILTER_URL", "")
+
+	if s := Load(); s.PIIFilterURL != "" {
+		t.Errorf("PIIFilterURL should be empty when unset, got %q", s.PIIFilterURL)
+	}
+}
+
 func TestLoad_LLMEmptyWhenUnset(t *testing.T) {
 	t.Setenv("LLM_BASE_URL", "")
 	t.Setenv("LLM_API_KEY", "")

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/matchanalysis"
 	"github.com/strelov1/freehire/internal/moderation"
+	"github.com/strelov1/freehire/internal/pii"
 	"github.com/strelov1/freehire/internal/referral"
 	"github.com/strelov1/freehire/internal/reminder"
 	"github.com/strelov1/freehire/internal/report"
@@ -233,6 +234,10 @@ type Config struct {
 	// LLM backs the optional CV ATS qualitative review. Nil disables the AI layer:
 	// the ATS score stays deterministic (the report just omits content-quality).
 	LLM *llm.Client
+	// PIIDetector de-identifies CV text before it reaches the LLM (fit analysis and
+	// structured extraction). Nil disables those CV→LLM paths (fail-closed): they degrade
+	// to no analysis rather than send PII to the model.
+	PIIDetector pii.Detector
 	// Telegram bot for notification linking/delivery confirmations. Optional: an
 	// empty TelegramBotToken disables the feature (linking endpoints report off,
 	// webhook inert). TelegramBotUsername builds the deep link; TelegramWebhookSecret
@@ -313,7 +318,7 @@ func Register(app *fiber.App, cfg Config) {
 	// The fit analysis shares the same LLM client but with a longer per-call timeout:
 	// its reasoning model is slow (tens of seconds per stage), so the default would time
 	// out mid-stage. Nil-safe (a nil client stays nil → Analyze is a no-op).
-	a.matchAnalysis = matchanalysis.NewAnalyzer(cfg.LLM.WithTimeout(matchAnalysisLLMTimeout))
+	a.matchAnalysis = matchanalysis.NewAnalyzer(cfg.LLM.WithTimeout(matchAnalysisLLMTimeout), cfg.PIIDetector)
 	a.structuredExtractor = resumeextract.NewExtractor(cfg.LLM.WithTimeout(resumeExtractLLMTimeout))
 	a.matchAnalysisCache = queries
 	a.credits = credits.NewStore(queries, cfg.Pool, cfg.Credits)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -319,7 +319,7 @@ func Register(app *fiber.App, cfg Config) {
 	// its reasoning model is slow (tens of seconds per stage), so the default would time
 	// out mid-stage. Nil-safe (a nil client stays nil → Analyze is a no-op).
 	a.matchAnalysis = matchanalysis.NewAnalyzer(cfg.LLM.WithTimeout(matchAnalysisLLMTimeout), cfg.PIIDetector)
-	a.structuredExtractor = resumeextract.NewExtractor(cfg.LLM.WithTimeout(resumeExtractLLMTimeout))
+	a.structuredExtractor = resumeextract.NewExtractor(cfg.LLM.WithTimeout(resumeExtractLLMTimeout), cfg.PIIDetector)
 	a.matchAnalysisCache = queries
 	a.credits = credits.NewStore(queries, cfg.Pool, cfg.Credits)
 	// Telegram notifications are enabled only with both a bot token and a JWT

--- a/internal/handler/match_analysis_integration_test.go
+++ b/internal/handler/match_analysis_integration_test.go
@@ -131,21 +131,21 @@ func TestMatchAnalysisEndpoints(t *testing.T) {
 	}
 
 	t.Run("unauthenticated is 401", func(t *testing.T) {
-		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil))
+		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil, nil))
 		if status, _ := do(t, app, fiber.MethodGet, "fit-job", ""); status != fiber.StatusUnauthorized {
 			t.Errorf("status = %d, want 401", status)
 		}
 	})
 
 	t.Run("unknown slug is 404", func(t *testing.T) {
-		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil))
+		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil, nil))
 		if status, _ := do(t, app, fiber.MethodGet, "no-such", token); status != fiber.StatusNotFound {
 			t.Errorf("status = %d, want 404", status)
 		}
 	})
 
 	t.Run("GET without a stored CV → has_cv false, no LLM", func(t *testing.T) {
-		app := appFor(resume.New(newFakeResumeBlobs(), &fakeResumeRepo{}), matchanalysis.NewAnalyzer(nil))
+		app := appFor(resume.New(newFakeResumeBlobs(), &fakeResumeRepo{}), matchanalysis.NewAnalyzer(nil, nil))
 		status, body := do(t, app, fiber.MethodGet, "fit-job", token)
 		if status != fiber.StatusOK || body.Data.HasCV {
 			t.Errorf("got status=%d has_cv=%v, want 200/false", status, body.Data.HasCV)
@@ -153,7 +153,7 @@ func TestMatchAnalysisEndpoints(t *testing.T) {
 	})
 
 	t.Run("GET never-analyzed → has_cv true, null analysis", func(t *testing.T) {
-		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil))
+		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil, nil))
 		status, body := do(t, app, fiber.MethodGet, "fit-job", token)
 		if status != fiber.StatusOK || !body.Data.HasCV || body.Data.Analysis != nil {
 			t.Errorf("got status=%d has_cv=%v analysis=%v, want 200/true/nil", status, body.Data.HasCV, body.Data.Analysis)
@@ -161,7 +161,7 @@ func TestMatchAnalysisEndpoints(t *testing.T) {
 	})
 
 	t.Run("POST LLM off → has_cv true, null analysis, nothing cached", func(t *testing.T) {
-		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil))
+		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil, nil))
 		status, body := do(t, app, fiber.MethodPost, "fit-job", token)
 		if status != fiber.StatusOK || !body.Data.HasCV || body.Data.Analysis != nil {
 			t.Errorf("got status=%d has_cv=%v analysis=%v, want 200/true/nil", status, body.Data.HasCV, body.Data.Analysis)
@@ -175,7 +175,7 @@ func TestMatchAnalysisEndpoints(t *testing.T) {
 
 	t.Run("POST computes, caches, GET returns fresh", func(t *testing.T) {
 		model := &fitModel{resp: []string{fitStage1, fitStage2, fitStage3}}
-		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(llm.NewWithModel(model)))
+		app := appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(llm.NewWithModel(model), noopPIIDetector{}))
 
 		status, body := do(t, app, fiber.MethodPost, "fit-job", token)
 		if status != fiber.StatusOK || body.Data.Analysis == nil {
@@ -194,7 +194,7 @@ func TestMatchAnalysisEndpoints(t *testing.T) {
 		if n != 1 {
 			t.Fatalf("cache rows = %d, want 1", n)
 		}
-		gstatus, gbody := do(t, appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil)), fiber.MethodGet, "fit-job", token)
+		gstatus, gbody := do(t, appFor(storeWithCVFor(t), matchanalysis.NewAnalyzer(nil, nil)), fiber.MethodGet, "fit-job", token)
 		if gstatus != fiber.StatusOK || gbody.Data.Analysis == nil || gbody.Data.Stale {
 			t.Errorf("GET after compute = status %d stale %v analysis %v, want 200/false/present",
 				gstatus, gbody.Data.Stale, gbody.Data.Analysis)
@@ -286,7 +286,7 @@ func TestMatchAnalysisCredits(t *testing.T) {
 		userID, token := seedUser(t, "broke@example.test")
 		seedJob(t, "broke-new", "broke-new")
 		model := newModel()
-		app := appFor(storeWithCVFor(t, userID), matchanalysis.NewAnalyzer(llm.NewWithModel(model)), 0)
+		app := appFor(storeWithCVFor(t, userID), matchanalysis.NewAnalyzer(llm.NewWithModel(model), noopPIIDetector{}), 0)
 
 		status, _ := postFit(t, app, "broke-new", token)
 		if status != fiber.StatusPaymentRequired {
@@ -307,7 +307,7 @@ func TestMatchAnalysisCredits(t *testing.T) {
 		jid := seedJob(t, "rc", "rc-job")
 		seedAnalysis(t, userID, jid, time.Hour) // prior cache row → recompute, not a new job
 		model := newModel()
-		app := appFor(storeWithCVFor(t, userID), matchanalysis.NewAnalyzer(llm.NewWithModel(model)), 0)
+		app := appFor(storeWithCVFor(t, userID), matchanalysis.NewAnalyzer(llm.NewWithModel(model), noopPIIDetector{}), 0)
 
 		status, body := postFit(t, app, "rc-job", token)
 		if status != fiber.StatusOK || body.Data.Analysis == nil {
@@ -326,7 +326,7 @@ func TestMatchAnalysisCredits(t *testing.T) {
 	t.Run("a fresh analysis debits one point and GET reports the balance", func(t *testing.T) {
 		userID, token := seedUser(t, "spend@example.test")
 		seedJob(t, "spend-1", "spend-1")
-		app := appFor(storeWithCVFor(t, userID), matchanalysis.NewAnalyzer(llm.NewWithModel(newModel())), 2)
+		app := appFor(storeWithCVFor(t, userID), matchanalysis.NewAnalyzer(llm.NewWithModel(newModel()), noopPIIDetector{}), 2)
 
 		// GET before compute: full grant remaining, nothing consumed.
 		greq := httptest.NewRequest(fiber.MethodGet, "/api/v1/jobs/spend-1/fit", nil)
@@ -367,7 +367,7 @@ func TestMatchAnalysisCredits(t *testing.T) {
 		userID, token := seedUser(t, "stream-broke@example.test")
 		seedJob(t, "sb-new", "sb-new")
 		model := newModel()
-		app := appFor(storeWithCVFor(t, userID), matchanalysis.NewAnalyzer(llm.NewWithModel(model)), 0)
+		app := appFor(storeWithCVFor(t, userID), matchanalysis.NewAnalyzer(llm.NewWithModel(model), noopPIIDetector{}), 0)
 
 		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/jobs/sb-new/fit/stream", nil)
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})

--- a/internal/handler/match_analysis_stream_integration_test.go
+++ b/internal/handler/match_analysis_stream_integration_test.go
@@ -101,14 +101,14 @@ func TestMatchAnalysisStreamEndpoint(t *testing.T) {
 	}
 
 	t.Run("unauthenticated is 401", func(t *testing.T) {
-		if status, _ := get(t, appFor(storeWithCV(), matchanalysis.NewAnalyzer(nil)), ""); status != fiber.StatusUnauthorized {
+		if status, _ := get(t, appFor(storeWithCV(), matchanalysis.NewAnalyzer(nil, nil)), ""); status != fiber.StatusUnauthorized {
 			t.Errorf("status = %d, want 401", status)
 		}
 	})
 
 	t.Run("streams ordered events and caches", func(t *testing.T) {
 		model := &fitModel{resp: []string{fitStage1, fitStage2, fitStage3}}
-		app := appFor(storeWithCV(), matchanalysis.NewAnalyzer(llm.NewWithModel(model)))
+		app := appFor(storeWithCV(), matchanalysis.NewAnalyzer(llm.NewWithModel(model), noopPIIDetector{}))
 		status, body := get(t, app, token)
 		if status != fiber.StatusOK {
 			t.Fatalf("status = %d, want 200", status)
@@ -134,7 +134,7 @@ func TestMatchAnalysisStreamEndpoint(t *testing.T) {
 	})
 
 	t.Run("no CV closes after meta", func(t *testing.T) {
-		app := appFor(resume.New(newFakeResumeBlobs(), &fakeResumeRepo{}), matchanalysis.NewAnalyzer(nil))
+		app := appFor(resume.New(newFakeResumeBlobs(), &fakeResumeRepo{}), matchanalysis.NewAnalyzer(nil, nil))
 		_, body := get(t, app, token)
 		names := sseEvents(t, body)
 		if len(names) != 1 || names[0] != "meta" {

--- a/internal/handler/me_analyses_integration_test.go
+++ b/internal/handler/me_analyses_integration_test.go
@@ -73,7 +73,7 @@ func TestListMyAnalysesEndpoint(t *testing.T) {
 	h := &API{
 		pool: pool, queries: queries, issuer: iss,
 		userProfile: userprofile.New(ownedProfile()),
-		resume:      store, matchAnalysis: matchanalysis.NewAnalyzer(nil), matchAnalysisCache: queries,
+		resume:      store, matchAnalysis: matchanalysis.NewAnalyzer(nil, nil), matchAnalysisCache: queries,
 		credits: credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3}),
 	}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})

--- a/internal/handler/pii_noop_integration_test.go
+++ b/internal/handler/pii_noop_integration_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+package handler
+
+import (
+	"context"
+
+	"github.com/strelov1/freehire/internal/pii"
+)
+
+// noopPIIDetector reports no spans, so the fit chain runs with an empty (pass-through)
+// redactor: Build succeeds, masking is a no-op, and these tests exercise the analysis path
+// exactly as before PII masking (their sample CVs carry no PII to mask).
+type noopPIIDetector struct{}
+
+func (noopPIIDetector) Detect(context.Context, string) ([]pii.Span, error) { return nil, nil }

--- a/internal/matchanalysis/analyzer.go
+++ b/internal/matchanalysis/analyzer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/strelov1/freehire/internal/hardconstraint"
 	"github.com/strelov1/freehire/internal/jobmatch"
 	"github.com/strelov1/freehire/internal/llm"
+	"github.com/strelov1/freehire/internal/pii"
 )
 
 // Input bounds for untrusted, user/ingest-supplied text sent to the model. Kept modest
@@ -24,13 +25,19 @@ const (
 
 // Analyzer runs the fixed three-stage fit prompt-chain over an llm.Client. A nil
 // client (LLM unconfigured) makes Analyze a no-op so the endpoint degrades to no
-// analysis, mirroring atscheck.Analyzer.
+// analysis, mirroring atscheck.Analyzer. The detector de-identifies the CV before it
+// reaches the model; a nil or failing detector makes the analysis fail closed (no CV is
+// sent, no analysis produced) — the same best-effort degradation as an unconfigured LLM.
 type Analyzer struct {
-	client *llm.Client
+	client   *llm.Client
+	detector pii.Detector
 }
 
-// NewAnalyzer wraps an llm.Client; client may be nil (LLM unconfigured).
-func NewAnalyzer(client *llm.Client) *Analyzer { return &Analyzer{client: client} }
+// NewAnalyzer wraps an llm.Client and the PII detector; either may be nil (LLM
+// unconfigured / detector unavailable), in which case the analysis degrades to a no-op.
+func NewAnalyzer(client *llm.Client, detector pii.Detector) *Analyzer {
+	return &Analyzer{client: client, detector: detector}
+}
 
 // ModelID returns the underlying model id (empty when unconfigured), so a caller can
 // record which model produced a cached analysis.
@@ -114,10 +121,22 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 		return nil, nil
 	}
 
+	// De-identify the CV before any of it reaches the model. Fail-closed: a nil or failing
+	// detector yields no redactor, and we degrade to no analysis rather than leak PII —
+	// the same best-effort behaviour as an unconfigured LLM.
+	red, err := pii.Build(ctx, in.CVText, contactsFromStructured(in.StructuredResume), a.detector)
+	if err != nil {
+		log.Printf("matchanalysis: PII redactor unavailable, skipping analysis: %v", err)
+		return nil, nil
+	}
+	// Restore originals in every user-facing event; the internal reqs/verdict threaded into
+	// later stages stay masked (see redactingEmit).
+	emit = redactingEmit(red, emit)
+
 	// Stage 1 — Extract & Match (the ATS lens).
 	emit(Event{Kind: EventStageStart, Stage: 1, Label: stageLabels[1]})
 	var s1 stage1Out
-	if err := a.streamStage(ctx, 1, stage1SystemPrompt(), stage1UserPrompt(in), emit, &s1); err != nil {
+	if err := a.streamStage(ctx, 1, stage1SystemPrompt(), stage1UserPrompt(in, red), emit, &s1); err != nil {
 		return nil, fmt.Errorf("matchanalysis: stage 1: %w", err)
 	}
 	reqs := sanitizeRequirements(s1.Requirements)
@@ -127,7 +146,7 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 	// Stage 2 — Recruiter verdict (the human lens).
 	emit(Event{Kind: EventStageStart, Stage: 2, Label: stageLabels[2]})
 	var verdict recruiterVerdict
-	if err := a.streamStage(ctx, 2, stage2SystemPrompt(), stage2UserPrompt(in, reqs), emit, &verdict); err != nil {
+	if err := a.streamStage(ctx, 2, stage2SystemPrompt(), stage2UserPrompt(in, reqs, red), emit, &verdict); err != nil {
 		return nil, fmt.Errorf("matchanalysis: stage 2: %w", err)
 	}
 	sanitizeVerdict(&verdict)
@@ -142,7 +161,7 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 	// zeros. Best-effort: on a parse/transport failure keep the un-audited verdict.
 	emit(Event{Kind: EventStageStart, Stage: 3, Label: stageLabels[3]})
 	audited := verdict
-	if err := a.streamStage(ctx, 3, stage3SystemPrompt(), stage3UserPrompt(in, reqs, verdict), emit, &audited); err != nil {
+	if err := a.streamStage(ctx, 3, stage3SystemPrompt(), stage3UserPrompt(in, reqs, verdict, red), emit, &audited); err != nil {
 		log.Printf("matchanalysis: stage 3 audit failed, serving un-audited verdict: %v", err)
 	} else {
 		sanitizeVerdict(&audited)
@@ -152,7 +171,10 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 
 	analysis := buildAnalysis(reqs, verdict)
 	emit(Event{Kind: EventFinal, Analysis: &analysis})
-	return &analysis, nil
+	// The returned value is cached and served, so hand back the restored (real) analysis;
+	// the emit above already restored the streamed copy.
+	restored := restoreAnalysis(red, analysis)
+	return &restored, nil
 }
 
 // stageAttempts is how many times a stage's LLM call is tried on a PARSE failure. The
@@ -259,18 +281,18 @@ func stage3SystemPrompt() string {
 
 // stage1UserPrompt carries the (bounded) job text, CV, and the deterministic anchor,
 // plus the pre-normalized structured résumé when present (additive to the raw CV).
-func stage1UserPrompt(in Input) string {
+func stage1UserPrompt(in Input, red *pii.Redactor) string {
 	var b strings.Builder
 	writeJob(&b, in)
 	writeAnchor(&b, in.Match)
 	writeBlockers(&b, in.Blockers)
-	writeStructured(&b, in)
-	writeCV(&b, in)
+	writeStructured(&b, in, red)
+	writeCV(&b, in, red)
 	return b.String()
 }
 
 // stage2UserPrompt adds the company info and the Stage-1 requirement match.
-func stage2UserPrompt(in Input, reqs []Requirement) string {
+func stage2UserPrompt(in Input, reqs []Requirement, red *pii.Redactor) string {
 	var b strings.Builder
 	writeJob(&b, in)
 	if info := strings.TrimSpace(in.CompanyInfo); info != "" {
@@ -281,12 +303,12 @@ func stage2UserPrompt(in Input, reqs []Requirement) string {
 	writeAnchor(&b, in.Match)
 	writeLocation(&b, in)
 	writeRequirements(&b, reqs)
-	writeCV(&b, in)
+	writeCV(&b, in, red)
 	return b.String()
 }
 
 // stage3UserPrompt carries the Stage-2 verdict to audit plus the same evidence.
-func stage3UserPrompt(in Input, reqs []Requirement, v recruiterVerdict) string {
+func stage3UserPrompt(in Input, reqs []Requirement, v recruiterVerdict, red *pii.Redactor) string {
 	var b strings.Builder
 	b.WriteString("Verdict to audit (JSON):\n")
 	if blob, err := json.Marshal(v); err == nil {
@@ -295,7 +317,7 @@ func stage3UserPrompt(in Input, reqs []Requirement, v recruiterVerdict) string {
 	}
 	writeBlockers(&b, in.Blockers)
 	writeRequirements(&b, reqs)
-	writeCV(&b, in)
+	writeCV(&b, in, red)
 	return b.String()
 }
 
@@ -330,9 +352,9 @@ func writeJob(b *strings.Builder, in Input) {
 	b.WriteString("\n\n")
 }
 
-func writeCV(b *strings.Builder, in Input) {
+func writeCV(b *strings.Builder, in Input, red *pii.Redactor) {
 	b.WriteString("CV:\n")
-	b.WriteString(llm.TruncateRunes(in.CVText, maxCVRunes))
+	b.WriteString(red.Redact(llm.TruncateRunes(in.CVText, maxCVRunes)))
 	b.WriteString("\n")
 }
 
@@ -344,13 +366,13 @@ const maxStructuredRunes = 3000
 // present. Omitted entirely when empty, so an un-extracted CV yields exactly today's
 // prompt. It is labelled as a parsed summary so the model treats the raw CV as ground
 // truth and this as an aid.
-func writeStructured(b *strings.Builder, in Input) {
+func writeStructured(b *strings.Builder, in Input, red *pii.Redactor) {
 	s := strings.TrimSpace(in.StructuredResume)
 	if s == "" {
 		return
 	}
 	b.WriteString("Structured résumé (parsed summary, JSON — the CV below is ground truth):\n")
-	b.WriteString(llm.TruncateRunes(s, maxStructuredRunes))
+	b.WriteString(red.Redact(llm.TruncateRunes(s, maxStructuredRunes)))
 	b.WriteString("\n\n")
 }
 

--- a/internal/matchanalysis/analyzer_test.go
+++ b/internal/matchanalysis/analyzer_test.go
@@ -53,7 +53,7 @@ const (
 )
 
 func TestAnalyze_NilClientIsNoOp(t *testing.T) {
-	got, err := NewAnalyzer(nil).Analyze(context.Background(), sampleInput())
+	got, err := NewAnalyzer(nil, nil).Analyze(context.Background(), sampleInput())
 	if err != nil || got != nil {
 		t.Fatalf("nil analyzer = (%v,%v), want (nil,nil)", got, err)
 	}
@@ -61,7 +61,7 @@ func TestAnalyze_NilClientIsNoOp(t *testing.T) {
 
 func TestAnalyze_ThreeStageChainUsesAuditedVerdict(t *testing.T) {
 	m := &queuedModel{resp: []string{stage1JSON, stage2JSON, stage3JSON}}
-	got, err := NewAnalyzer(llm.NewWithModel(m)).Analyze(context.Background(), sampleInput())
+	got, err := NewAnalyzer(llm.NewWithModel(m), noopDetector{}).Analyze(context.Background(), sampleInput())
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestAnalyze_ThreeStageChainUsesAuditedVerdict(t *testing.T) {
 func TestAnalyze_Stage3FailFallsBackToStage2(t *testing.T) {
 	// Stage 3 fails on both attempts (the retry also gets junk), then falls back.
 	m := &queuedModel{resp: []string{stage1JSON, stage2JSON, "not json", "still not json"}}
-	got, err := NewAnalyzer(llm.NewWithModel(m)).Analyze(context.Background(), sampleInput())
+	got, err := NewAnalyzer(llm.NewWithModel(m), noopDetector{}).Analyze(context.Background(), sampleInput())
 	if err != nil {
 		t.Fatalf("Analyze should degrade, not error: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestAnalyze_Stage3PartialMergesOntoStage2(t *testing.T) {
 	// keep their Stage 2 scores, not collapse to 0 (which would corrupt a strong verdict).
 	partial := `{"experience_relevance":{"score":40},"gaps":["Thin on scale"]}`
 	m := &queuedModel{resp: []string{stage1JSON, stage2JSON, partial}}
-	got, err := NewAnalyzer(llm.NewWithModel(m)).Analyze(context.Background(), sampleInput())
+	got, err := NewAnalyzer(llm.NewWithModel(m), noopDetector{}).Analyze(context.Background(), sampleInput())
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestAnalyzeStream_RetriesATransientStageFailure(t *testing.T) {
 	// Stage 1 first returns an HTML error page (a transient gateway 502), then valid JSON
 	// on the retry; the chain must recover and produce the final analysis.
 	m := &queuedModel{resp: []string{`<html>502 Bad Gateway</html>`, stage1JSON, stage2JSON, stage3JSON}}
-	got, err := NewAnalyzer(llm.NewWithModel(m)).Analyze(context.Background(), sampleInput())
+	got, err := NewAnalyzer(llm.NewWithModel(m), noopDetector{}).Analyze(context.Background(), sampleInput())
 	if err != nil {
 		t.Fatalf("Analyze should recover on retry: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestAnalyzeStream_RetriesATransientStageFailure(t *testing.T) {
 
 func TestAnalyze_Stage1ErrorPropagates(t *testing.T) {
 	m := &queuedModel{err: errors.New("boom")}
-	if _, err := NewAnalyzer(llm.NewWithModel(m)).Analyze(context.Background(), sampleInput()); err == nil {
+	if _, err := NewAnalyzer(llm.NewWithModel(m), noopDetector{}).Analyze(context.Background(), sampleInput()); err == nil {
 		t.Fatal("want error when Stage 1 fails")
 	}
 }
@@ -146,7 +146,7 @@ func TestAnalyzeStream_EmitsOrderedEventsAndMatchesSyncFinal(t *testing.T) {
 	events := func() []Event {
 		m := &queuedModel{resp: []string{stage1JSON, stage2JSON, stage3JSON}}
 		var got []Event
-		final, err := NewAnalyzer(llm.NewWithModel(m)).AnalyzeStream(context.Background(), sampleInput(), func(e Event) {
+		final, err := NewAnalyzer(llm.NewWithModel(m), noopDetector{}).AnalyzeStream(context.Background(), sampleInput(), func(e Event) {
 			got = append(got, e)
 		})
 		if err != nil {
@@ -183,14 +183,14 @@ func TestAnalyzeStream_EmitsOrderedEventsAndMatchesSyncFinal(t *testing.T) {
 
 	// Analyze must return the identical final verdict (it is a thin collector).
 	m := &queuedModel{resp: []string{stage1JSON, stage2JSON, stage3JSON}}
-	sync, _ := NewAnalyzer(llm.NewWithModel(m)).Analyze(context.Background(), sampleInput())
+	sync, _ := NewAnalyzer(llm.NewWithModel(m), noopDetector{}).Analyze(context.Background(), sampleInput())
 	if sync == nil || sync.OverallScore != 58 {
 		t.Errorf("Analyze final = %+v, want overall 58 (same as stream)", sync)
 	}
 }
 
 func TestAnalyzeStream_NilClientIsNoOp(t *testing.T) {
-	got, err := NewAnalyzer(nil).AnalyzeStream(context.Background(), sampleInput(), func(Event) {
+	got, err := NewAnalyzer(nil, nil).AnalyzeStream(context.Background(), sampleInput(), func(Event) {
 		t.Error("no events expected from a nil client")
 	})
 	if err != nil || got != nil {
@@ -201,19 +201,19 @@ func TestAnalyzeStream_NilClientIsNoOp(t *testing.T) {
 func TestStagePrompts_CarryTheirInputs(t *testing.T) {
 	in := sampleInput()
 	reqs := []Requirement{{Text: "Go", Priority: "required", Status: "covered"}}
-	if s := stage1UserPrompt(in); !strings.Contains(s, "Senior Go Engineer") || !strings.Contains(s, "5y Go at Acme") || !strings.Contains(s, "go") {
+	if s := stage1UserPrompt(in, nil); !strings.Contains(s, "Senior Go Engineer") || !strings.Contains(s, "5y Go at Acme") || !strings.Contains(s, "go") {
 		t.Error("stage1 prompt must carry job title, CV text, and the anchor")
 	}
-	if s := stage2UserPrompt(in, reqs); !strings.Contains(s, "We ship fridges") || !strings.Contains(s, "covered") {
+	if s := stage2UserPrompt(in, reqs, nil); !strings.Contains(s, "We ship fridges") || !strings.Contains(s, "covered") {
 		t.Error("stage2 prompt must carry company_info and the Stage-1 match")
 	}
 	// Stage 2 must carry the job geography and the candidate's location preferences so
 	// the model can score location & work-mode fit.
-	if s := stage2UserPrompt(in, reqs); !strings.Contains(s, "Berlin") || !strings.Contains(s, "onsite") || !strings.Contains(s, "São Paulo") {
+	if s := stage2UserPrompt(in, reqs, nil); !strings.Contains(s, "Berlin") || !strings.Contains(s, "onsite") || !strings.Contains(s, "São Paulo") {
 		t.Error("stage2 prompt must carry job geography + candidate location preferences")
 	}
 	v := recruiterVerdict{TitleAlignment: dimScore{Score: 80}, Recommendation: "Apply."}
-	if s := stage3UserPrompt(in, reqs, v); !strings.Contains(s, "Apply.") {
+	if s := stage3UserPrompt(in, reqs, v, nil); !strings.Contains(s, "Apply.") {
 		t.Error("stage3 prompt must carry the Stage-2 verdict to audit")
 	}
 }

--- a/internal/matchanalysis/blockers_prompt_test.go
+++ b/internal/matchanalysis/blockers_prompt_test.go
@@ -16,7 +16,7 @@ func TestStage1PromptCarriesUnmetBlockers(t *testing.T) {
 			{Category: hardconstraint.CategoryEducation, Reason: "Requires a bachelor degree; résumé meets it.", Met: true},
 		},
 	}
-	p := stage1UserPrompt(in)
+	p := stage1UserPrompt(in, nil)
 	if !strings.Contains(p, "Requires 5+ years; résumé shows 3.") {
 		t.Error("stage-1 prompt should carry the unmet experience blocker")
 	}
@@ -29,7 +29,7 @@ func TestStage1PromptOmitsBlockerSectionWhenAllMet(t *testing.T) {
 	in := Input{JobTitle: "x", JobDescription: "y", Blockers: []hardconstraint.Blocker{
 		{Category: hardconstraint.CategoryLanguage, Reason: "English present.", Met: true},
 	}}
-	if strings.Contains(stage1UserPrompt(in), "Hard constraints the candidate does NOT meet") {
+	if strings.Contains(stage1UserPrompt(in, nil), "Hard constraints the candidate does NOT meet") {
 		t.Error("no blocker section when nothing is unmet")
 	}
 }

--- a/internal/matchanalysis/pii_redaction_test.go
+++ b/internal/matchanalysis/pii_redaction_test.go
@@ -1,0 +1,120 @@
+package matchanalysis
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/llm"
+	"github.com/strelov1/freehire/internal/pii"
+)
+
+// recordingModel records every user prompt it is sent and returns queued canned responses,
+// so a test can assert on exactly what text would reach the model provider.
+type recordingModel struct {
+	resp    []string
+	n       int
+	prompts []string
+}
+
+func (m *recordingModel) GenerateContent(_ context.Context, msgs []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	var b strings.Builder
+	for _, msg := range msgs {
+		for _, part := range msg.Parts {
+			if t, ok := part.(llms.TextContent); ok {
+				b.WriteString(t.Text)
+			}
+		}
+	}
+	m.prompts = append(m.prompts, b.String())
+	r := m.resp[m.n]
+	m.n++
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: r}}}, nil
+}
+func (*recordingModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+// spanDetector reports each configured substring as a NAME span (a stand-in for the model).
+type spanDetector struct{ names []string }
+
+func (d spanDetector) Detect(_ context.Context, text string) ([]pii.Span, error) {
+	var spans []pii.Span
+	for _, n := range d.names {
+		if i := strings.Index(text, n); i >= 0 {
+			spans = append(spans, pii.Span{Start: i, End: i + len(n), Kind: pii.KindName})
+		}
+	}
+	return spans, nil
+}
+
+func piiInput() Input {
+	in := sampleInput()
+	in.CVText = "Ivan Petrov ivan@petrov.io\nSenior Go Engineer, 5y Go at Acme."
+	return in
+}
+
+func TestAnalyzeStream_MasksPIIInPromptsAndRestoresOutput(t *testing.T) {
+	// Stage 2 recommendation echoes the name placeholder the model would have seen; the
+	// restored output must show the real name, and no prompt may carry the raw PII.
+	s2 := `{"title_alignment":{"score":80},"experience_relevance":{"score":70},"seniority_fit":{"score":60},"skills_coverage":{"score":50},"company_context":{"score":40},"location_fit":{"score":60},"strengths":[],"gaps":[],"recommendation":"[REDACTED_NAME_1] is a strong Go fit."}`
+	// Stage 3 is a partial audit that does not touch the recommendation, so Stage 2's
+	// (placeholder-bearing) recommendation survives to the final — the restore path under test.
+	s3 := `{"experience_relevance":{"score":50}}`
+	m := &recordingModel{resp: []string{stage1JSON, s2, s3}}
+	det := spanDetector{names: []string{"Ivan Petrov"}}
+
+	final, err := NewAnalyzer(llm.NewWithModel(m), det).AnalyzeStream(context.Background(), piiInput(), func(Event) {})
+	if err != nil {
+		t.Fatalf("AnalyzeStream: %v", err)
+	}
+	if final == nil {
+		t.Fatal("expected an analysis, got nil")
+	}
+
+	if len(m.prompts) == 0 {
+		t.Fatal("no prompts recorded")
+	}
+	for i, p := range m.prompts {
+		if strings.Contains(p, "Ivan Petrov") || strings.Contains(p, "ivan@petrov.io") {
+			t.Errorf("stage %d prompt leaked PII:\n%s", i+1, p)
+		}
+	}
+	if !strings.Contains(final.Recommendation, "Ivan Petrov") {
+		t.Errorf("recommendation not restored: %q", final.Recommendation)
+	}
+	if strings.Contains(final.Recommendation, "REDACTED") {
+		t.Errorf("placeholder leaked into output: %q", final.Recommendation)
+	}
+}
+
+func TestAnalyzeStream_FailClosedWhenDetectorErrors(t *testing.T) {
+	m := &recordingModel{resp: []string{stage1JSON, stage2JSON, stage3JSON}}
+	final, err := NewAnalyzer(llm.NewWithModel(m), failingDetector{}).AnalyzeStream(context.Background(), piiInput(), func(Event) {
+		t.Error("no events expected when the detector fails")
+	})
+	if err != nil {
+		t.Fatalf("fail-closed should degrade to no analysis, not error: %v", err)
+	}
+	if final != nil {
+		t.Fatalf("expected nil analysis (fail-closed), got %+v", final)
+	}
+	if m.n != 0 {
+		t.Fatalf("model must not be called when the detector fails, called %d", m.n)
+	}
+}
+
+type failingDetector struct{}
+
+func (failingDetector) Detect(context.Context, string) ([]pii.Span, error) {
+	return nil, errors.New("detector down")
+}
+
+// noopDetector reports no spans — the chain runs exactly as before masking (used by the
+// pre-existing analyzer tests, whose sample CV carries no PII).
+type noopDetector struct{}
+
+func (noopDetector) Detect(context.Context, string) ([]pii.Span, error) { return nil, nil }

--- a/internal/matchanalysis/prompt_test.go
+++ b/internal/matchanalysis/prompt_test.go
@@ -6,7 +6,7 @@ import "testing"
 
 func TestStage1Prompt_IncludesStructuredResumeWhenPresent(t *testing.T) {
 	in := Input{JobTitle: "Go Engineer", CVText: "raw cv", StructuredResume: `{"full_name":"Jane"}`}
-	got := stage1UserPrompt(in)
+	got := stage1UserPrompt(in, nil)
 	if !strings.Contains(got, `{"full_name":"Jane"}`) {
 		t.Errorf("stage1 prompt missing structured résumé block:\n%s", got)
 	}
@@ -16,7 +16,7 @@ func TestStage1Prompt_IncludesStructuredResumeWhenPresent(t *testing.T) {
 }
 
 func TestStage1Prompt_OmitsStructuredBlockWhenEmpty(t *testing.T) {
-	withEmpty := stage1UserPrompt(Input{JobTitle: "Go Engineer", CVText: "raw cv"})
+	withEmpty := stage1UserPrompt(Input{JobTitle: "Go Engineer", CVText: "raw cv"}, nil)
 	// The structured header must not appear at all when there is no structured résumé,
 	// so an un-extracted CV produces exactly today's prompt.
 	if strings.Contains(withEmpty, "Structured résumé") {
@@ -36,7 +36,7 @@ func TestWriteLocation_RemoteWithinReachAddsNote(t *testing.T) {
 		JobCountries:        []string{"do"},
 		LocationPreferences: `{"base":{"country":"br"},"remote":{"regions":["global","latam","cis"]},"relocation":{"open":false}}`,
 	}
-	got := stage2UserPrompt(in, nil)
+	got := stage2UserPrompt(in, nil, nil)
 	if !strings.Contains(got, "within the candidate's stated remote reach") {
 		t.Errorf("expected remote-reach NOTE for a LATAM-remote job matching the candidate's reach:\n%s", got)
 	}
@@ -50,7 +50,7 @@ func TestWriteLocation_RemoteOutsideReachNoNote(t *testing.T) {
 		JobRegions:          []string{"latam"},
 		LocationPreferences: `{"remote":{"regions":["europe"]}}`,
 	}
-	got := stage2UserPrompt(in, nil)
+	got := stage2UserPrompt(in, nil, nil)
 	if strings.Contains(got, "within the candidate's stated remote reach") {
 		t.Errorf("must not vouch for a remote job outside the candidate's reach:\n%s", got)
 	}

--- a/internal/matchanalysis/redact.go
+++ b/internal/matchanalysis/redact.go
@@ -1,0 +1,87 @@
+package matchanalysis
+
+import (
+	"encoding/json"
+
+	"github.com/strelov1/freehire/internal/pii"
+)
+
+// contactsFromStructured pulls the authoritative contact values out of the structured-résumé
+// JSON so the Redactor masks them wherever they surface (the raw CV and the structured blob
+// alike), even if the model detector renders them differently. Empty/unparseable → no known
+// contacts, and the redactor relies on the CV text + model spans alone.
+func contactsFromStructured(structuredJSON string) pii.Contacts {
+	var s struct {
+		FullName string   `json:"full_name"`
+		Email    string   `json:"email"`
+		Phone    string   `json:"phone"`
+		Links    []string `json:"links"`
+	}
+	if json.Unmarshal([]byte(structuredJSON), &s) != nil {
+		return pii.Contacts{}
+	}
+	return pii.Contacts{FullName: s.FullName, Email: s.Email, Phone: s.Phone, Links: s.Links}
+}
+
+// redactingEmit wraps emit so every outbound event has its PII restored for the user, on a
+// COPY — the internal reqs/verdict threaded into later-stage prompts stay masked, so nothing
+// re-leaks. A nil redactor passes events through unchanged.
+func redactingEmit(red *pii.Redactor, emit func(Event)) func(Event) {
+	if red == nil {
+		return emit
+	}
+	return func(ev Event) {
+		ev.Thinking = red.Restore(ev.Thinking)
+		if ev.Requirements != nil {
+			ev.Requirements = restoreRequirements(red, ev.Requirements)
+		}
+		if ev.Analysis != nil {
+			a := restoreAnalysis(red, *ev.Analysis)
+			ev.Analysis = &a
+		}
+		emit(ev)
+	}
+}
+
+// restoreAnalysis returns a copy of a with every user-facing string restored. Slices are
+// rebuilt so the caller never mutates the masked chain state shared by later stages.
+func restoreAnalysis(red *pii.Redactor, a Analysis) Analysis {
+	if red == nil {
+		return a
+	}
+	dims := make([]Dimension, len(a.Dimensions))
+	for i, d := range a.Dimensions {
+		d.Comment = red.Restore(d.Comment)
+		dims[i] = d
+	}
+	a.Dimensions = dims
+	a.RequirementMatch = restoreRequirements(red, a.RequirementMatch)
+	a.Strengths = restoreStrings(red, a.Strengths)
+	a.Gaps = restoreStrings(red, a.Gaps)
+	a.Recommendation = red.Restore(a.Recommendation)
+	return a
+}
+
+func restoreRequirements(red *pii.Redactor, reqs []Requirement) []Requirement {
+	if reqs == nil {
+		return nil
+	}
+	out := make([]Requirement, len(reqs))
+	for i, r := range reqs {
+		r.Text = red.Restore(r.Text)
+		r.Evidence = red.Restore(r.Evidence)
+		out[i] = r
+	}
+	return out
+}
+
+func restoreStrings(red *pii.Redactor, in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = red.Restore(s)
+	}
+	return out
+}

--- a/internal/pii/client.go
+++ b/internal/pii/client.go
@@ -1,0 +1,65 @@
+package pii
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Detector returns PII spans for a text. The production implementation is the local
+// openai/privacy-filter span-detection endpoint (HTTPDetector); tests use a fake.
+type Detector interface {
+	Detect(ctx context.Context, text string) ([]Span, error)
+}
+
+// HTTPDetector calls the co-located privacy-filter detection endpoint. The endpoint owns
+// the model and returns spans already mapped to our Kind vocabulary.
+type HTTPDetector struct {
+	url    string
+	client *http.Client
+}
+
+// NewHTTPDetector builds a detector posting to url; client defaults to http.DefaultClient.
+func NewHTTPDetector(url string, client *http.Client) *HTTPDetector {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &HTTPDetector{url: url, client: client}
+}
+
+type detectRequest struct {
+	Text string `json:"text"`
+}
+
+type detectResponse struct {
+	Spans []Span `json:"spans"`
+}
+
+// Detect posts the text and returns the endpoint's spans. A transport error or a non-2xx
+// response is returned as an error so the caller can fail closed.
+func (d *HTTPDetector) Detect(ctx context.Context, text string) ([]Span, error) {
+	body, err := json.Marshal(detectRequest{Text: text})
+	if err != nil {
+		return nil, fmt.Errorf("pii: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("pii: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("pii: detect request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("pii: detector returned status %d", resp.StatusCode)
+	}
+	var out detectResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("pii: decode response: %w", err)
+	}
+	return out.Spans, nil
+}

--- a/internal/pii/client_test.go
+++ b/internal/pii/client_test.go
@@ -1,0 +1,50 @@
+package pii
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPDetectorParsesSpans(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"spans":[{"start":0,"end":4,"kind":"NAME"},{"start":10,"end":20,"kind":"ADDRESS"}]}`))
+	}))
+	defer srv.Close()
+
+	d := NewHTTPDetector(srv.URL, srv.Client())
+	spans, err := d.Detect(context.Background(), "Alex lives at 5th Avenue")
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(spans) != 2 || spans[0].Kind != KindName || spans[1].Kind != KindAddress {
+		t.Fatalf("unexpected spans: %+v", spans)
+	}
+	if spans[0].Start != 0 || spans[0].End != 4 {
+		t.Fatalf("bad first span: %+v", spans[0])
+	}
+}
+
+func TestHTTPDetectorErrorsOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	d := NewHTTPDetector(srv.URL, srv.Client())
+	if _, err := d.Detect(context.Background(), "text"); err == nil {
+		t.Fatal("expected error on non-200 response, got nil")
+	}
+}
+
+func TestHTTPDetectorErrorsOnTransport(t *testing.T) {
+	d := NewHTTPDetector("http://127.0.0.1:1/detect", http.DefaultClient)
+	if _, err := d.Detect(context.Background(), "text"); err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+}

--- a/internal/pii/detect.go
+++ b/internal/pii/detect.go
@@ -1,0 +1,68 @@
+// Package pii detects personally-identifiable information in CV text and produces a
+// reversible Redactor that masks it out of LLM prompts and restores it in user-facing
+// output. Detection unions a high-precision regex floor (email, phone, URL, @handle) with
+// name/address spans from a local model detector; see the add-cv-pii-masking change.
+package pii
+
+import "regexp"
+
+// Span is a half-open [Start, End) byte range in the source text carrying one PII value.
+type Span struct {
+	Start int
+	End   int
+	Kind  string
+}
+
+// PII kinds. NAME and ADDRESS come from the model; the rest are regex-detectable.
+const (
+	KindName    = "NAME"
+	KindEmail   = "EMAIL"
+	KindPhone   = "PHONE"
+	KindLink    = "LINK"
+	KindAddress = "ADDRESS"
+)
+
+var (
+	emailRe = regexp.MustCompile(`[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}`)
+	// URLs: explicit scheme, known-TLD bare domains with a path, or the common profile hosts.
+	urlRe = regexp.MustCompile(`https?://\S+|(?:www\.)?[A-Za-z0-9-]+\.(?:com|dev|app|io|me|net|org)/\S*|linkedin\.com/\S+|github\.com/\S+|t\.me/\S+`)
+	// Handle: an @name not preceded by a word char (so it never fires inside an email).
+	handleRe = regexp.MustCompile(`(^|[^\w])(@\w{3,})`)
+	// Phone: a run of digits/space/parens/dashes, at least a few long.
+	phoneRe = regexp.MustCompile(`\+?\d[\d()\-\s]{7,}\d`)
+	// A bare YYYY-YYYY year range that the phone regex would otherwise capture.
+	yearRangeRe = regexp.MustCompile(`^\d{4}-\d{4}$`)
+)
+
+// regexSpans returns the high-precision regex-detectable PII spans (email, URL, @handle,
+// phone). Phone spans that are a bare year range, or that overlap an already-detected
+// email/URL/handle, are dropped so digits inside a link are never mis-read as a phone.
+func regexSpans(text string) []Span {
+	var spans []Span
+	for _, m := range emailRe.FindAllStringIndex(text, -1) {
+		spans = append(spans, Span{m[0], m[1], KindEmail})
+	}
+	for _, m := range urlRe.FindAllStringIndex(text, -1) {
+		spans = append(spans, Span{m[0], m[1], KindLink})
+	}
+	for _, m := range handleRe.FindAllStringSubmatchIndex(text, -1) {
+		spans = append(spans, Span{m[4], m[5], KindLink}) // group 2 = the @handle itself
+	}
+	for _, m := range phoneRe.FindAllStringIndex(text, -1) {
+		if yearRangeRe.MatchString(text[m[0]:m[1]]) || overlapsAny(spans, m[0], m[1]) {
+			continue
+		}
+		spans = append(spans, Span{m[0], m[1], KindPhone})
+	}
+	return spans
+}
+
+// overlapsAny reports whether [start, end) intersects any existing span.
+func overlapsAny(spans []Span, start, end int) bool {
+	for _, s := range spans {
+		if start < s.End && s.Start < end {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pii/detect.go
+++ b/internal/pii/detect.go
@@ -30,8 +30,9 @@ var (
 	handleRe = regexp.MustCompile(`(^|[^\w])(@\w{3,})`)
 	// Phone: a run of digits/space/parens/dashes, at least a few long.
 	phoneRe = regexp.MustCompile(`\+?\d[\d()\-\s]{7,}\d`)
-	// A bare YYYY-YYYY year range that the phone regex would otherwise capture.
-	yearRangeRe = regexp.MustCompile(`^\d{4}-\d{4}$`)
+	// A bare YYYY-YYYY year range (with optional spaces around the dash) that the phone
+	// regex would otherwise capture — a common CV employment range, not a phone number.
+	yearRangeRe = regexp.MustCompile(`^\d{4}\s*-\s*\d{4}$`)
 )
 
 // regexSpans returns the high-precision regex-detectable PII spans (email, URL, @handle,

--- a/internal/pii/detect_test.go
+++ b/internal/pii/detect_test.go
@@ -1,0 +1,74 @@
+package pii
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// collect returns the matched substrings for a given kind, sorted, so a test can
+// assert on values regardless of detection order.
+func collect(text string, spans []Span, kind string) []string {
+	var out []string
+	for _, s := range spans {
+		if s.Kind == kind {
+			out = append(out, text[s.Start:s.End])
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestRegexSpans(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		kind string
+		want []string
+	}{
+		{
+			name: "email",
+			text: "reach me at strelov1@gmail.com anytime",
+			kind: KindEmail,
+			want: []string{"strelov1@gmail.com"},
+		},
+		{
+			name: "linkedin and github urls",
+			text: "linkedin.com/in/istrelov | github.com/strelov1",
+			kind: KindLink,
+			want: []string{"github.com/strelov1", "linkedin.com/in/istrelov"},
+		},
+		{
+			name: "https portfolio url",
+			text: "portfolio: https://alex-bes.vercel.app/ here",
+			kind: KindLink,
+			want: []string{"https://alex-bes.vercel.app/"},
+		},
+		{
+			name: "telegram handle",
+			text: "ping @Alex_Sage on tg",
+			kind: KindLink,
+			want: []string{"@Alex_Sage"},
+		},
+		{
+			name: "phone with country code",
+			text: "call +1 (415) 555-2671 for details",
+			kind: KindPhone,
+			want: []string{"+1 (415) 555-2671"},
+		},
+		{
+			name: "year range is not a phone",
+			text: "worked there 2012-2016 as an engineer",
+			kind: KindPhone,
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collect(tc.text, regexSpans(tc.text), tc.kind)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("regexSpans %s: got %q, want %q", tc.kind, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/pii/failclosed_test.go
+++ b/internal/pii/failclosed_test.go
@@ -1,0 +1,27 @@
+package pii
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// errDetector always fails, standing in for an unavailable detection endpoint.
+type errDetector struct{}
+
+func (errDetector) Detect(context.Context, string) ([]Span, error) {
+	return nil, errors.New("boom")
+}
+
+func TestBuildFailsClosedWhenDetectorNil(t *testing.T) {
+	if _, err := Build(context.Background(), "Ilya Strelov", Contacts{}, nil); err == nil {
+		t.Fatal("expected error for nil detector (fail-closed), got nil")
+	}
+}
+
+func TestBuildFailsClosedWhenDetectorErrors(t *testing.T) {
+	_, err := Build(context.Background(), "Ilya Strelov", Contacts{}, errDetector{})
+	if err == nil {
+		t.Fatal("expected error when detector fails (fail-closed), got nil")
+	}
+}

--- a/internal/pii/findings_test.go
+++ b/internal/pii/findings_test.go
@@ -1,0 +1,33 @@
+package pii
+
+import (
+	"strings"
+	"testing"
+)
+
+// Finding 1: a detected value that abuts a word character in the text must still be masked
+// (word-boundary anchoring must never leave PII in the prompt).
+func TestRedactMasksValueAbuttingWordChar(t *testing.T) {
+	text := "mail: strelov1@gmail.com2024 archived"
+	r := mustBuild(t, text, Contacts{}, nameDetector{})
+	if masked := r.Redact(text); strings.Contains(masked, "strelov1@gmail.com") {
+		t.Fatalf("email abutting a digit leaked: %q", masked)
+	}
+}
+
+// Finding 1b: a NAME span whose offsets fall inside a larger token must still be masked.
+func TestRedactMasksNameSpanInsideToken(t *testing.T) {
+	text := "IlyaStrelovX updated the resume"
+	r := mustBuild(t, text, Contacts{}, nameDetector{names: []string{"Strelov"}})
+	if masked := r.Redact(text); strings.Contains(masked, "Strelov") {
+		t.Fatalf("name span inside a token leaked: %q", masked)
+	}
+}
+
+// Finding 2: an employment year range with spaces must not be masked as a phone number.
+func TestSpacedYearRangeIsNotPhone(t *testing.T) {
+	text := "worked there 2012 - 2016 as engineer"
+	if got := collect(text, regexSpans(text), KindPhone); got != nil {
+		t.Fatalf("spaced year range detected as phone: %q", got)
+	}
+}

--- a/internal/pii/integration_test.go
+++ b/internal/pii/integration_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package pii
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLiveDetectorEndToEnd exercises the real privacy-filter endpoint through the production
+// HTTPDetector + Build/Redact/Restore path. Run against a live service:
+//
+//	PII_FILTER_URL=http://127.0.0.1:8099/detect go test -tags=integration ./internal/pii/
+//
+// It is skipped when PII_FILTER_URL is unset, so ordinary `go test ./...` never needs it.
+func TestLiveDetectorEndToEnd(t *testing.T) {
+	url := os.Getenv("PII_FILTER_URL")
+	if url == "" {
+		t.Skip("PII_FILTER_URL unset; skipping live detector test")
+	}
+	det := NewHTTPDetector(url, &http.Client{Timeout: 30 * time.Second})
+
+	cv := "Ivan Petrov\nivan@petrov.io | github.com/ivanp\nSenior Go Engineer at RingCentral in London"
+	r, err := Build(context.Background(), cv, Contacts{}, det)
+	if err != nil {
+		t.Fatalf("Build against live detector: %v", err)
+	}
+
+	masked := r.Redact(cv)
+	for _, leak := range []string{"Ivan Petrov", "ivan@petrov.io", "github.com/ivanp"} {
+		if strings.Contains(masked, leak) {
+			t.Errorf("live redaction leaked %q:\n%s", leak, masked)
+		}
+	}
+	// Employer must survive (fit analysis needs it).
+	if !strings.Contains(masked, "RingCentral") {
+		t.Errorf("over-redacted the employer:\n%s", masked)
+	}
+	// Round-trip restores the original.
+	if got := r.Restore(masked); got != cv {
+		t.Errorf("round-trip mismatch:\n got %q\nwant %q", got, cv)
+	}
+	// Contacts recovered from detection.
+	if c := r.Contacts(); c.FullName != "Ivan Petrov" || c.Email != "ivan@petrov.io" {
+		t.Errorf("contacts = %q/%q, want detected values", c.FullName, c.Email)
+	}
+}

--- a/internal/pii/redactor.go
+++ b/internal/pii/redactor.go
@@ -22,7 +22,18 @@ type Contacts struct {
 // Redactor masks a fixed set of detected PII values into stable numbered placeholders and
 // restores them. Build it once per CV; reuse it for every text that flows to the LLM.
 type Redactor struct {
-	reps []replacement // longest value first, so a value contained in another masks first
+	reps     []replacement // longest value first, so a value contained in another masks first
+	contacts Contacts      // contact values recovered from the detected spans
+}
+
+// Contacts returns the contact values recovered from the detected spans (first name/email/
+// phone, all links). It lets a caller — e.g. resumeextract — fill contact fields from
+// deterministic detection instead of the LLM, which only ever sees the redacted CV.
+func (r *Redactor) Contacts() Contacts {
+	if r == nil {
+		return Contacts{}
+	}
+	return r.contacts
 }
 
 type replacement struct {
@@ -62,12 +73,14 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 	// the value unsafe for \b — it is then masked plainly so the occurrence can never leak.
 	detected := make(map[string]bool)
 	boundarySafe := make(map[string]bool)
+	var found Contacts
 	for _, s := range spans {
 		v := strings.TrimSpace(text[s.Start:s.End])
 		if v == "" {
 			continue
 		}
 		add(v, s.Kind)
+		fillContact(&found, s.Kind, v)
 		ok := (s.Start == 0 || !isWord(text[s.Start-1])) && (s.End == len(text) || !isWord(text[s.End]))
 		if seen := detected[v]; seen {
 			boundarySafe[v] = boundarySafe[v] && ok
@@ -100,7 +113,7 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 		reps = append(reps, rep)
 	}
 	sort.SliceStable(reps, func(i, j int) bool { return len(reps[i].value) > len(reps[j].value) })
-	r := &Redactor{reps: reps}
+	r := &Redactor{reps: reps, contacts: found}
 
 	// Fail-closed self-check: masking MUST remove every detected value from the source.
 	// If any survives (a boundary quirk we did not foresee), refuse rather than leak.
@@ -116,6 +129,27 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 // wordyKind marks the kinds whose values can legitimately be a substring of a normal word
 // (a name, an address), so word-boundary matching is worth attempting to avoid over-redaction.
 var wordyKind = map[string]bool{KindName: true, KindAddress: true}
+
+// fillContact records a detected value into c: the first name/email/phone wins, every link
+// is collected. Called only for detected spans, so c reflects the CV, not known input.
+func fillContact(c *Contacts, kind, v string) {
+	switch kind {
+	case KindName:
+		if c.FullName == "" {
+			c.FullName = v
+		}
+	case KindEmail:
+		if c.Email == "" {
+			c.Email = v
+		}
+	case KindPhone:
+		if c.Phone == "" {
+			c.Phone = v
+		}
+	case KindLink:
+		c.Links = append(c.Links, v)
+	}
+}
 
 // Redact replaces every detected PII value in text with its placeholder. A nil Redactor is
 // a no-op (callers that fail closed never reach Redact with nil).

--- a/internal/pii/redactor.go
+++ b/internal/pii/redactor.go
@@ -71,7 +71,7 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 	// non-word chars, so a \b anchor masks each one. A detected span that abuts a word char
 	// (e.g. an email touching a trailing digit, or a NAME span inside a larger token) makes
 	// the value unsafe for \b — it is then masked plainly so the occurrence can never leak.
-	detected := make(map[string]bool)
+	// Its key set is exactly the detected values, so the fail-closed self-check ranges it too.
 	boundarySafe := make(map[string]bool)
 	var found Contacts
 	for _, s := range spans {
@@ -82,12 +82,11 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 		add(v, s.Kind)
 		fillContact(&found, s.Kind, v)
 		ok := (s.Start == 0 || !isWord(text[s.Start-1])) && (s.End == len(text) || !isWord(text[s.End]))
-		if seen := detected[v]; seen {
+		if _, seen := boundarySafe[v]; seen {
 			boundarySafe[v] = boundarySafe[v] && ok
 		} else {
 			boundarySafe[v] = ok
 		}
-		detected[v] = true
 	}
 	add(known.FullName, KindName)
 	add(known.Email, KindEmail)
@@ -118,7 +117,7 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 	// Fail-closed self-check: masking MUST remove every detected value from the source.
 	// If any survives (a boundary quirk we did not foresee), refuse rather than leak.
 	redacted := r.Redact(text)
-	for v := range detected {
+	for v := range boundarySafe {
 		if strings.Count(redacted, v) >= strings.Count(text, v) {
 			return nil, fmt.Errorf("pii: redaction left detected value unmasked")
 		}
@@ -191,7 +190,7 @@ func isWord(c byte) bool {
 
 // sanitizeSpans drops model spans with out-of-range or inverted offsets.
 func sanitizeSpans(spans []Span, n int) []Span {
-	out := spans[:0:0]
+	var out []Span
 	for _, s := range spans {
 		if s.Start >= 0 && s.End <= n && s.Start < s.End {
 			out = append(out, s)

--- a/internal/pii/redactor.go
+++ b/internal/pii/redactor.go
@@ -56,8 +56,25 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 		seen[v] = true
 		vals = append(vals, valueKind{v, kind})
 	}
+	// boundarySafe[value] is true only when EVERY detected occurrence of value sits between
+	// non-word chars, so a \b anchor masks each one. A detected span that abuts a word char
+	// (e.g. an email touching a trailing digit, or a NAME span inside a larger token) makes
+	// the value unsafe for \b — it is then masked plainly so the occurrence can never leak.
+	detected := make(map[string]bool)
+	boundarySafe := make(map[string]bool)
 	for _, s := range spans {
-		add(text[s.Start:s.End], s.Kind)
+		v := strings.TrimSpace(text[s.Start:s.End])
+		if v == "" {
+			continue
+		}
+		add(v, s.Kind)
+		ok := (s.Start == 0 || !isWord(text[s.Start-1])) && (s.End == len(text) || !isWord(text[s.End]))
+		if seen := detected[v]; seen {
+			boundarySafe[v] = boundarySafe[v] && ok
+		} else {
+			boundarySafe[v] = ok
+		}
+		detected[v] = true
 	}
 	add(known.FullName, KindName)
 	add(known.Email, KindEmail)
@@ -74,14 +91,31 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 			value:       vk.value,
 			placeholder: fmt.Sprintf("[REDACTED_%s_%d]", vk.kind, counts[vk.kind]),
 		}
-		if wordish(vk.value) {
+		// Word-boundary only for the "wordy" kinds AND only when every detected occurrence
+		// is boundary-complete; everything else is masked plainly (leak-proof). Specific
+		// values (email/phone/link) are always plain — they never occur inside a real word.
+		if wordish(vk.value) && wordyKind[vk.kind] && boundarySafe[vk.value] {
 			rep.re = regexp.MustCompile(`\b` + regexp.QuoteMeta(vk.value) + `\b`)
 		}
 		reps = append(reps, rep)
 	}
 	sort.SliceStable(reps, func(i, j int) bool { return len(reps[i].value) > len(reps[j].value) })
-	return &Redactor{reps: reps}, nil
+	r := &Redactor{reps: reps}
+
+	// Fail-closed self-check: masking MUST remove every detected value from the source.
+	// If any survives (a boundary quirk we did not foresee), refuse rather than leak.
+	redacted := r.Redact(text)
+	for v := range detected {
+		if strings.Count(redacted, v) >= strings.Count(text, v) {
+			return nil, fmt.Errorf("pii: redaction left detected value unmasked")
+		}
+	}
+	return r, nil
 }
+
+// wordyKind marks the kinds whose values can legitimately be a substring of a normal word
+// (a name, an address), so word-boundary matching is worth attempting to avoid over-redaction.
+var wordyKind = map[string]bool{KindName: true, KindAddress: true}
 
 // Redact replaces every detected PII value in text with its placeholder. A nil Redactor is
 // a no-op (callers that fail closed never reach Redact with nil).

--- a/internal/pii/redactor.go
+++ b/internal/pii/redactor.go
@@ -1,0 +1,133 @@
+package pii
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Contacts are the caller's authoritative contact values (e.g. from a structured résumé).
+// They are always maskable even when they do not appear verbatim in the CV text Build reads,
+// so the same Redactor masks them wherever they surface (raw CV and structured JSON alike).
+type Contacts struct {
+	FullName string
+	Email    string
+	Phone    string
+	Links    []string
+}
+
+// Redactor masks a fixed set of detected PII values into stable numbered placeholders and
+// restores them. Build it once per CV; reuse it for every text that flows to the LLM.
+type Redactor struct {
+	reps []replacement // longest value first, so a value contained in another masks first
+}
+
+type replacement struct {
+	value       string
+	placeholder string
+	re          *regexp.Regexp // non-nil ⇒ word-boundary match (bounds over-redaction)
+}
+
+// Build detects PII in text (regex floor ∪ model spans ∪ known contacts) and returns a
+// Redactor. It is fail-closed: a nil detector or a detector error returns an error rather
+// than a partial (regex-only) redactor, so callers can refuse to send the CV to the LLM.
+func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redactor, error) {
+	if d == nil {
+		return nil, errors.New("pii: detector not configured")
+	}
+	modelSpans, err := d.Detect(ctx, text)
+	if err != nil {
+		return nil, fmt.Errorf("pii: detect: %w", err)
+	}
+
+	spans := append(regexSpans(text), sanitizeSpans(modelSpans, len(text))...)
+	sort.SliceStable(spans, func(i, j int) bool { return spans[i].Start < spans[j].Start })
+
+	type valueKind struct{ value, kind string }
+	var vals []valueKind
+	seen := make(map[string]bool)
+	add := func(v, kind string) {
+		if v = strings.TrimSpace(v); v == "" || seen[v] {
+			return
+		}
+		seen[v] = true
+		vals = append(vals, valueKind{v, kind})
+	}
+	for _, s := range spans {
+		add(text[s.Start:s.End], s.Kind)
+	}
+	add(known.FullName, KindName)
+	add(known.Email, KindEmail)
+	add(known.Phone, KindPhone)
+	for _, l := range known.Links {
+		add(l, KindLink)
+	}
+
+	counts := make(map[string]int)
+	reps := make([]replacement, 0, len(vals))
+	for _, vk := range vals {
+		counts[vk.kind]++
+		rep := replacement{
+			value:       vk.value,
+			placeholder: fmt.Sprintf("[REDACTED_%s_%d]", vk.kind, counts[vk.kind]),
+		}
+		if wordish(vk.value) {
+			rep.re = regexp.MustCompile(`\b` + regexp.QuoteMeta(vk.value) + `\b`)
+		}
+		reps = append(reps, rep)
+	}
+	sort.SliceStable(reps, func(i, j int) bool { return len(reps[i].value) > len(reps[j].value) })
+	return &Redactor{reps: reps}, nil
+}
+
+// Redact replaces every detected PII value in text with its placeholder. A nil Redactor is
+// a no-op (callers that fail closed never reach Redact with nil).
+func (r *Redactor) Redact(text string) string {
+	if r == nil {
+		return text
+	}
+	for _, rep := range r.reps {
+		if rep.re != nil {
+			text = rep.re.ReplaceAllString(text, rep.placeholder)
+		} else {
+			text = strings.ReplaceAll(text, rep.value, rep.placeholder)
+		}
+	}
+	return text
+}
+
+// Restore maps every placeholder back to its original value. Placeholders are unique, so
+// restore order is irrelevant.
+func (r *Redactor) Restore(text string) string {
+	if r == nil {
+		return text
+	}
+	for _, rep := range r.reps {
+		text = strings.ReplaceAll(text, rep.placeholder, rep.value)
+	}
+	return text
+}
+
+// wordish reports whether v starts and ends with a word char, so word-boundary matching is
+// safe and desirable (a name/word value should not mask a substring of a larger word).
+func wordish(v string) bool {
+	return v != "" && isWord(v[0]) && isWord(v[len(v)-1])
+}
+
+func isWord(c byte) bool {
+	return c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// sanitizeSpans drops model spans with out-of-range or inverted offsets.
+func sanitizeSpans(spans []Span, n int) []Span {
+	out := spans[:0:0]
+	for _, s := range spans {
+		if s.Start >= 0 && s.End <= n && s.Start < s.End {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/pii/redactor_test.go
+++ b/internal/pii/redactor_test.go
@@ -83,6 +83,21 @@ func TestKnownContactsMaskedInOtherText(t *testing.T) {
 	}
 }
 
+func TestContactsFromDetectedSpans(t *testing.T) {
+	cv := "Ivan Petrov ivan@petrov.io github.com/ivanp linkedin.com/in/ivanp"
+	r := mustBuild(t, cv, Contacts{}, nameDetector{names: []string{"Ivan Petrov"}})
+	c := r.Contacts()
+	if c.FullName != "Ivan Petrov" {
+		t.Errorf("FullName = %q, want detected name", c.FullName)
+	}
+	if c.Email != "ivan@petrov.io" {
+		t.Errorf("Email = %q, want detected email", c.Email)
+	}
+	if len(c.Links) != 2 {
+		t.Errorf("Links = %v, want the two detected URLs", c.Links)
+	}
+}
+
 func TestWordBoundaryAvoidsOverRedaction(t *testing.T) {
 	text := "Mark shipped the benchmark on Mark's branch"
 	r := mustBuild(t, text, Contacts{}, nameDetector{names: []string{"Mark"}})

--- a/internal/pii/redactor_test.go
+++ b/internal/pii/redactor_test.go
@@ -1,0 +1,96 @@
+package pii
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// nameDetector is a fake Detector that reports each configured name as a NAME span.
+type nameDetector struct{ names []string }
+
+func (f nameDetector) Detect(_ context.Context, text string) ([]Span, error) {
+	var spans []Span
+	for _, n := range f.names {
+		if i := strings.Index(text, n); i >= 0 {
+			spans = append(spans, Span{i, i + len(n), KindName})
+		}
+	}
+	return spans, nil
+}
+
+func mustBuild(t *testing.T, text string, known Contacts, d Detector) *Redactor {
+	t.Helper()
+	r, err := Build(context.Background(), text, known, d)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return r
+}
+
+func TestRedactMasksAllPII(t *testing.T) {
+	cv := "Ilya Strelov\nstrelov1@gmail.com | github.com/strelov1\nSenior Engineer at RingCentral in London"
+	r := mustBuild(t, cv, Contacts{}, nameDetector{names: []string{"Ilya Strelov"}})
+	masked := r.Redact(cv)
+
+	for _, leak := range []string{"Ilya Strelov", "strelov1@gmail.com", "github.com/strelov1"} {
+		if strings.Contains(masked, leak) {
+			t.Errorf("masked text still contains PII %q:\n%s", leak, masked)
+		}
+	}
+	// Non-PII context must survive.
+	for _, keep := range []string{"RingCentral", "London", "Senior Engineer"} {
+		if !strings.Contains(masked, keep) {
+			t.Errorf("masked text dropped non-PII %q:\n%s", keep, masked)
+		}
+	}
+}
+
+func TestRestoreRoundTrip(t *testing.T) {
+	cv := "Ilya Strelov — strelov1@gmail.com — github.com/strelov1"
+	r := mustBuild(t, cv, Contacts{}, nameDetector{names: []string{"Ilya Strelov"}})
+	if got := r.Restore(r.Redact(cv)); got != cv {
+		t.Fatalf("round-trip mismatch:\n got %q\nwant %q", got, cv)
+	}
+}
+
+func TestDistinctValuesGetDistinctPlaceholders(t *testing.T) {
+	text := "primary a@x.com secondary b@y.com"
+	r := mustBuild(t, text, Contacts{}, nameDetector{})
+	masked := r.Redact(text)
+	if strings.Contains(masked, "a@x.com") || strings.Contains(masked, "b@y.com") {
+		t.Fatalf("emails not masked: %s", masked)
+	}
+	// Two distinct emails -> two distinct placeholders that restore independently.
+	if r.Restore(masked) != text {
+		t.Fatalf("distinct emails did not restore: %q", r.Restore(masked))
+	}
+	if strings.Count(masked, "[REDACTED_EMAIL_1]") != 1 || strings.Count(masked, "[REDACTED_EMAIL_2]") != 1 {
+		t.Fatalf("expected two numbered email placeholders, got: %s", masked)
+	}
+}
+
+func TestKnownContactsMaskedInOtherText(t *testing.T) {
+	// The CV text the Redactor is built from, plus a separate structured-JSON blob that
+	// carries the same contacts — both must mask with the SAME redactor (matchanalysis case).
+	cv := "Ilya Strelov works remotely"
+	structured := `{"full_name":"Ilya Strelov","email":"strelov1@gmail.com"}`
+	known := Contacts{FullName: "Ilya Strelov", Email: "strelov1@gmail.com"}
+	r := mustBuild(t, cv, known, nameDetector{names: []string{"Ilya Strelov"}})
+	masked := r.Redact(structured)
+	if strings.Contains(masked, "Ilya Strelov") || strings.Contains(masked, "strelov1@gmail.com") {
+		t.Fatalf("known contacts leaked in structured blob: %s", masked)
+	}
+}
+
+func TestWordBoundaryAvoidsOverRedaction(t *testing.T) {
+	text := "Mark shipped the benchmark on Mark's branch"
+	r := mustBuild(t, text, Contacts{}, nameDetector{names: []string{"Mark"}})
+	masked := r.Redact(text)
+	if !strings.Contains(masked, "benchmark") {
+		t.Fatalf("over-redacted 'benchmark': %s", masked)
+	}
+	if strings.Contains(masked, "Mark shipped") {
+		t.Fatalf("standalone name not masked: %s", masked)
+	}
+}

--- a/internal/resumeextract/pii_test.go
+++ b/internal/resumeextract/pii_test.go
@@ -1,0 +1,98 @@
+package resumeextract
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/llm"
+	"github.com/strelov1/freehire/internal/pii"
+)
+
+// noopDetector reports no spans (used by the sanitize/parse tests, whose CVs carry no PII).
+type noopDetector struct{}
+
+func (noopDetector) Detect(context.Context, string) ([]pii.Span, error) { return nil, nil }
+
+// nameSpanDetector reports each configured substring as a NAME span.
+type nameSpanDetector struct{ names []string }
+
+func (d nameSpanDetector) Detect(_ context.Context, text string) ([]pii.Span, error) {
+	var spans []pii.Span
+	for _, n := range d.names {
+		if i := strings.Index(text, n); i >= 0 {
+			spans = append(spans, pii.Span{Start: i, End: i + len(n), Kind: pii.KindName})
+		}
+	}
+	return spans, nil
+}
+
+type failDetector struct{}
+
+func (failDetector) Detect(context.Context, string) ([]pii.Span, error) {
+	return nil, errors.New("detector down")
+}
+
+// recordingModel captures the user prompt so a test can assert on what reaches the model.
+type recordingModel struct {
+	resp   string
+	prompt string
+	calls  int
+}
+
+func (m *recordingModel) GenerateContent(_ context.Context, msgs []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.calls++
+	for _, msg := range msgs {
+		for _, part := range msg.Parts {
+			if t, ok := part.(llms.TextContent); ok {
+				m.prompt += t.Text
+			}
+		}
+	}
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: m.resp}}}, nil
+}
+func (*recordingModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+func TestExtract_ContactsFromDetectionAndRedactedPrompt(t *testing.T) {
+	cv := "Ivan Petrov ivan@petrov.io github.com/ivanp\nSenior Go Engineer at Acme."
+	m := &recordingModel{resp: `{"summary":"Senior Go engineer.","experience":[{"title":"Senior Go Engineer","company":"Acme"}]}`}
+	e := NewExtractor(llm.NewWithModel(m), nameSpanDetector{names: []string{"Ivan Petrov"}})
+
+	got, err := e.Extract(context.Background(), cv)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	// The model prompt must carry no raw PII.
+	for _, leak := range []string{"Ivan Petrov", "ivan@petrov.io", "github.com/ivanp"} {
+		if strings.Contains(m.prompt, leak) {
+			t.Errorf("prompt leaked PII %q:\n%s", leak, m.prompt)
+		}
+	}
+	// Contacts come from detection, not the model.
+	if got.FullName != "Ivan Petrov" || got.Email != "ivan@petrov.io" {
+		t.Errorf("contacts = %q/%q, want detected values", got.FullName, got.Email)
+	}
+	if len(got.Links) != 1 {
+		t.Errorf("Links = %v, want the detected URL", got.Links)
+	}
+	// Semantic fields still parse from the (redacted) CV.
+	if len(got.Experience) != 1 || got.Experience[0].Company != "Acme" {
+		t.Errorf("experience = %+v, want the parsed Acme role", got.Experience)
+	}
+}
+
+func TestExtract_FailClosedWhenDetectorErrors(t *testing.T) {
+	m := &recordingModel{resp: `{}`}
+	_, err := NewExtractor(llm.NewWithModel(m), failDetector{}).Extract(context.Background(), "Ivan Petrov cv")
+	if err == nil {
+		t.Fatal("expected fail-closed error when detector fails")
+	}
+	if m.calls != 0 {
+		t.Fatalf("model must not be called when the detector fails, called %d", m.calls)
+	}
+}

--- a/internal/resumeextract/resumeextract.go
+++ b/internal/resumeextract/resumeextract.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/strelov1/freehire/internal/llm"
+	"github.com/strelov1/freehire/internal/pii"
 )
 
 // ErrDisabled is returned by Extract when the LLM is not configured (nil client), so a
@@ -22,17 +23,25 @@ import (
 // failure.
 var ErrDisabled = errors.New("resumeextract: llm not configured")
 
-// Extractor derives a Structured résumé over an llm.Client. A nil client (LLM
-// unconfigured) makes Extract return ErrDisabled, mirroring matchanalysis.Analyzer's no-op.
+// Extractor derives a Structured résumé over an llm.Client. It needs both a client and a
+// PII detector: the client parses the semantic fields from the REDACTED CV, and the detector
+// both de-identifies the CV and supplies the contact fields. Either missing makes Extract
+// return ErrDisabled (fail-closed — no CV reaches the LLM), mirroring the no-op degradation.
 type Extractor struct {
-	client *llm.Client
+	client   *llm.Client
+	detector pii.Detector
 }
 
-// NewExtractor wraps an llm.Client; client may be nil (LLM unconfigured).
-func NewExtractor(client *llm.Client) *Extractor { return &Extractor{client: client} }
+// NewExtractor wraps an llm.Client and the PII detector; either may be nil, which disables
+// extraction (ErrDisabled).
+func NewExtractor(client *llm.Client, detector pii.Detector) *Extractor {
+	return &Extractor{client: client, detector: detector}
+}
 
-// Enabled reports whether extraction can run (a non-nil client).
-func (e *Extractor) Enabled() bool { return e != nil && e.client != nil }
+// Enabled reports whether extraction can run: both the client and the detector are present.
+// Without the detector the CV cannot be de-identified, so extraction is disabled rather than
+// run in the clear.
+func (e *Extractor) Enabled() bool { return e != nil && e.client != nil && e.detector != nil }
 
 // ModelID returns the underlying model id, so a caller can stamp the produced structure
 // with the model that generated it.
@@ -45,7 +54,13 @@ func (e *Extractor) Extract(ctx context.Context, cvText string) (Structured, err
 	if !e.Enabled() {
 		return Structured{}, ErrDisabled
 	}
-	raw, err := e.client.GenerateJSON(ctx, systemPrompt, userPrompt(cvText))
+	// De-identify the CV before it reaches the LLM. Fail-closed: a detector error means no
+	// CV is sent (the caller degrades best-effort, persisting no structured résumé).
+	red, err := pii.Build(ctx, cvText, pii.Contacts{}, e.detector)
+	if err != nil {
+		return Structured{}, fmt.Errorf("resumeextract: pii: %w", err)
+	}
+	raw, err := e.client.GenerateJSON(ctx, systemPrompt, userPrompt(red.Redact(cvText)))
 	if err != nil {
 		return Structured{}, fmt.Errorf("resumeextract: generate: %w", err)
 	}
@@ -53,6 +68,10 @@ func (e *Extractor) Extract(ctx context.Context, cvText string) (Structured, err
 	if err := json.Unmarshal([]byte(raw), &s); err != nil {
 		return Structured{}, fmt.Errorf("resumeextract: parse: %w", err)
 	}
+	// Contact fields come from deterministic detection, NOT the model — it only ever saw the
+	// redacted CV, so it cannot (and must not) supply them.
+	c := red.Contacts()
+	s.FullName, s.Email, s.Phone, s.Links = c.FullName, c.Email, c.Phone, c.Links
 	s.Sanitize()
 	return s, nil
 }
@@ -64,6 +83,8 @@ const maxCVRunes = 12000
 const systemPrompt = `You extract a structured résumé from raw CV text and return ONLY a JSON object.
 Rules:
 - Extract ONLY facts stated in the CV. Never invent or infer a field that is not present — omit it instead.
+- The CV has been de-identified: contact details (full_name, email, phone, links) are handled separately and
+  appear as [REDACTED_...] placeholders. Do NOT extract them and never copy a placeholder into any field.
 - Fields: full_name, headline (current role/title line), location, email, phone, summary (1-3 sentences),
   total_years (integer years of professional experience, best estimate; 0 if unclear),
   experience (array of {title, company, location, start, end, summary, highlights, stack}; keep dates as

--- a/internal/resumeextract/resumeextract_test.go
+++ b/internal/resumeextract/resumeextract_test.go
@@ -111,15 +111,20 @@ func TestExtract_ParsesAndSanitizes(t *testing.T) {
 		`"experience":[{"title":"Senior Go Engineer","company":"Acme","start":"2020","end":"Present"}],` +
 		`"languages":["English",""]}`
 	m := &queuedModel{resp: raw}
-	got, err := NewExtractor(llm.NewWithModel(m)).Extract(context.Background(), "some cv text")
+	got, err := NewExtractor(llm.NewWithModel(m), noopDetector{}).Extract(context.Background(), "some cv text")
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
 	if m.n != 1 {
 		t.Errorf("LLM calls = %d, want 1", m.n)
 	}
-	if got.FullName != "Jane Doe" || len(got.Experience) != 1 {
-		t.Errorf("parsed = %+v, want name+1 experience", got)
+	// Contacts now come from detection (none here), so the model's full_name is ignored;
+	// the semantic fields are what this test covers.
+	if len(got.Experience) != 1 {
+		t.Errorf("parsed = %+v, want 1 experience", got)
+	}
+	if got.FullName != "" {
+		t.Errorf("FullName = %q, want empty (no detector spans, not the model's value)", got.FullName)
 	}
 	if got.TotalYears != 0 { // sanitized: negative → 0
 		t.Errorf("TotalYears = %d, want 0 (sanitized)", got.TotalYears)
@@ -130,7 +135,7 @@ func TestExtract_ParsesAndSanitizes(t *testing.T) {
 }
 
 func TestExtract_UnconfiguredReturnsErrDisabled(t *testing.T) {
-	_, err := NewExtractor(nil).Extract(context.Background(), "cv")
+	_, err := NewExtractor(nil, noopDetector{}).Extract(context.Background(), "cv")
 	if !errors.Is(err, ErrDisabled) {
 		t.Fatalf("err = %v, want ErrDisabled", err)
 	}
@@ -138,16 +143,19 @@ func TestExtract_UnconfiguredReturnsErrDisabled(t *testing.T) {
 
 func TestExtract_BadJSONErrors(t *testing.T) {
 	m := &queuedModel{resp: "not json"}
-	if _, err := NewExtractor(llm.NewWithModel(m)).Extract(context.Background(), "cv"); err == nil {
+	if _, err := NewExtractor(llm.NewWithModel(m), noopDetector{}).Extract(context.Background(), "cv"); err == nil {
 		t.Fatal("want error on unparseable model output, got nil")
 	}
 }
 
 func TestExtractor_EnabledReflectsClient(t *testing.T) {
-	if NewExtractor(nil).Enabled() {
+	if NewExtractor(nil, noopDetector{}).Enabled() {
 		t.Error("nil-client extractor should be disabled")
 	}
-	if !NewExtractor(llm.NewWithModel(&queuedModel{})).Enabled() {
+	if NewExtractor(llm.NewWithModel(&queuedModel{}), nil).Enabled() {
+		t.Error("nil-detector extractor should be disabled (fail-closed)")
+	}
+	if !NewExtractor(llm.NewWithModel(&queuedModel{}), noopDetector{}).Enabled() {
 		t.Error("configured extractor should be enabled")
 	}
 }

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -1,6 +1,6 @@
 ## 1. `internal/pii` — detectors and redactor
 
-- [ ] 1.1 Add span types (`Span{Start,End,Kind}`, `Contacts`) and the regex detectors: email, phone (with `YYYY-YYYY` date-range guard), URL, `@handle`; table tests over both spike-CV shapes
+- [x] 1.1 Add span types (`Span{Start,End,Kind}`, `Contacts`) and the regex detectors: email, phone (with `YYYY-YYYY` date-range guard), URL, `@handle`; table tests over both spike-CV shapes
 - [ ] 1.2 Add the model `Detector` interface + its HTTP client (POST text → spans); tests against a faked HTTP server, incl. transport/parse failure
 - [ ] 1.3 Implement `Build(ctx, text, known Contacts, d Detector) (*Redactor, error)`: union regex ∪ model spans, numbered reversible placeholders, word-boundary replacement, full/known-value priority; tests for `Redact`, `Restore`, `Restore(Redact(x))` round-trip, distinct-value numbering, over-redaction guard
 - [ ] 1.4 Fail-closed: `Build` returns an error (no partial redactor) when the detector is unconfigured or its call fails; test

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -1,9 +1,9 @@
 ## 1. `internal/pii` — detectors and redactor
 
 - [x] 1.1 Add span types (`Span{Start,End,Kind}`, `Contacts`) and the regex detectors: email, phone (with `YYYY-YYYY` date-range guard), URL, `@handle`; table tests over both spike-CV shapes
-- [ ] 1.2 Add the model `Detector` interface + its HTTP client (POST text → spans); tests against a faked HTTP server, incl. transport/parse failure
-- [ ] 1.3 Implement `Build(ctx, text, known Contacts, d Detector) (*Redactor, error)`: union regex ∪ model spans, numbered reversible placeholders, word-boundary replacement, full/known-value priority; tests for `Redact`, `Restore`, `Restore(Redact(x))` round-trip, distinct-value numbering, over-redaction guard
-- [ ] 1.4 Fail-closed: `Build` returns an error (no partial redactor) when the detector is unconfigured or its call fails; test
+- [x] 1.2 Add the model `Detector` interface + its HTTP client (POST text → spans); tests against a faked HTTP server, incl. transport/parse failure
+- [x] 1.3 Implement `Build(ctx, text, known Contacts, d Detector) (*Redactor, error)`: union regex ∪ model spans, numbered reversible placeholders, word-boundary replacement, full/known-value priority; tests for `Redact`, `Restore`, `Restore(Redact(x))` round-trip, distinct-value numbering, over-redaction guard
+- [x] 1.4 Fail-closed: `Build` returns an error (no partial redactor) when the detector is unconfigured or its call fails; test
 
 ## 2. Config
 

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -24,7 +24,7 @@
 ## 5. Privacy-filter span-detection service
 
 - [x] 5.1 Build the detection HTTP service serving `openai/privacy-filter` (ONNX q4, onnxruntime, Viterbi span stitching): `POST /detect` → `[{start,end,kind}]`; verify it recovers the hidden surname and does not over-redact on the two spike CVs
-- [ ] 5.2 Deploy wiring in `freehire-ops`: ONNX q4 weights + service on the litellm box, systemd/compose unit, health-check, egress allowlist; set `PII_FILTER_URL`
+- [x] 5.2 Deploy wiring in `freehire-ops`: ONNX q4 weights + service on the litellm box, systemd/compose unit, health-check, egress allowlist; set `PII_FILTER_URL`
 
 ## 6. Verification
 

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -28,4 +28,4 @@
 
 ## 6. Verification
 
-- [ ] 6.1 `go build ./... && go vet ./... && go test ./...` green; end-to-end masking check against the live `/detect` endpoint on the two spike CVs (no PII in the outbound prompt, output restored)
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...` green; end-to-end masking check against the live `/detect` endpoint on the two spike CVs (no PII in the outbound prompt, output restored)

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -7,7 +7,7 @@
 
 ## 2. Config
 
-- [ ] 2.1 Add `PII_FILTER_URL` to `internal/config` (server + resume/embed worker) and construct the `pii.Detector`; test that empty URL yields an unconfigured (fail-closed) detector
+- [x] 2.1 Add `PII_FILTER_URL` to `internal/config` (server + resume/embed worker) and construct the `pii.Detector`; test that empty URL yields an unconfigured (fail-closed) detector
 
 ## 3. `matchanalysis` integration
 

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -18,8 +18,8 @@
 
 ## 4. `resumeextract` integration
 
-- [ ] 4.1 Build a `Redactor`; fill `Structured` contact fields (`FullName/Email/Phone/Links`) from detected spans; send only the redacted CV to the LLM; update the prompt to state contacts are provided separately; fail-closed when `Build` errors
-- [ ] 4.2 Tests: contacts filled from detection, no PII in the LLM input, semantic fields still parsed, fail-closed leaves upload/embedding untouched
+- [x] 4.1 Build a `Redactor`; fill `Structured` contact fields (`FullName/Email/Phone/Links`) from detected spans; send only the redacted CV to the LLM; update the prompt to state contacts are provided separately; fail-closed when `Build` errors
+- [x] 4.2 Tests: contacts filled from detection, no PII in the LLM input, semantic fields still parsed, fail-closed leaves upload/embedding untouched
 
 ## 5. Privacy-filter span-detection service
 

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -11,10 +11,10 @@
 
 ## 3. `matchanalysis` integration
 
-- [ ] 3.1 Build a `Redactor` at the top of `AnalyzeStream` from `in.CVText` + `in.StructuredResume`; return no-analysis (fail-closed) when `Build` errors
-- [ ] 3.2 Run `Redact` in `writeCV` and `writeStructured` so every stage prompt carries placeholders
-- [ ] 3.3 Wrap `emit` to `Restore` a copy of each outbound event, and `Restore` the returned/cached analysis; keep internal `reqs`/`verdict` masked (no re-leak into Stage 2/3)
-- [ ] 3.4 Tests: assert known PII never appears in the Stage 1/2/3 prompt strings, that output is restored, and fail-closed on a failing detector
+- [x] 3.1 Build a `Redactor` at the top of `AnalyzeStream` from `in.CVText` + `in.StructuredResume`; return no-analysis (fail-closed) when `Build` errors
+- [x] 3.2 Run `Redact` in `writeCV` and `writeStructured` so every stage prompt carries placeholders
+- [x] 3.3 Wrap `emit` to `Restore` a copy of each outbound event, and `Restore` the returned/cached analysis; keep internal `reqs`/`verdict` masked (no re-leak into Stage 2/3)
+- [x] 3.4 Tests: assert known PII never appears in the Stage 1/2/3 prompt strings, that output is restored, and fail-closed on a failing detector
 
 ## 4. `resumeextract` integration
 

--- a/openspec/changes/add-cv-pii-masking/tasks.md
+++ b/openspec/changes/add-cv-pii-masking/tasks.md
@@ -23,7 +23,7 @@
 
 ## 5. Privacy-filter span-detection service
 
-- [ ] 5.1 Build the detection HTTP service serving `openai/privacy-filter` (ONNX q4, onnxruntime, Viterbi span stitching): `POST /detect` → `[{start,end,kind}]`; verify it recovers the hidden surname and does not over-redact on the two spike CVs
+- [x] 5.1 Build the detection HTTP service serving `openai/privacy-filter` (ONNX q4, onnxruntime, Viterbi span stitching): `POST /detect` → `[{start,end,kind}]`; verify it recovers the hidden surname and does not over-redact on the two spike CVs
 - [ ] 5.2 Deploy wiring in `freehire-ops`: ONNX q4 weights + service on the litellm box, systemd/compose unit, health-check, egress allowlist; set `PII_FILTER_URL`
 
 ## 6. Verification

--- a/services/pii-filter/README.md
+++ b/services/pii-filter/README.md
@@ -1,0 +1,42 @@
+# pii-filter
+
+Local PII span-detection endpoint that backs `internal/pii` (the `PII_FILTER_URL` detector).
+It serves the **openai/privacy-filter** model (ONNX q4) over CPU and returns spans already
+mapped to freehire's Kind vocabulary (`NAME`, `ADDRESS`, `EMAIL`, `PHONE`, `LINK`).
+
+It exists so CV text is de-identified **before** it reaches the LLM gateway: the Go backend
+calls `POST /detect`, masks the returned spans, and only then sends the CV onward. It is a
+detection endpoint, not on the litellm proxy request path.
+
+## Model
+
+Pull the weights **only** from the official repo (a malicious typosquat has existed):
+
+```
+huggingface-cli download openai/privacy-filter \
+  config.json tokenizer.json onnx/model_q4.onnx onnx/model_q4.onnx_data \
+  --local-dir "$PII_FILTER_MODEL_DIR"
+```
+
+`openai/privacy-filter` is Apache-2.0, gpt-oss-derived, a bidirectional token classifier over
+a BIOES PII taxonomy. We keep `private_person/address/email/phone/url` and drop
+`private_date`, `account_number`, and `secret` (see `detector.py:KIND_MAP`).
+
+## Run
+
+```
+pip install -r requirements.txt
+PII_FILTER_MODEL_DIR=/path/to/privacy-filter PII_FILTER_ADDR=127.0.0.1:8099 python server.py
+curl -s localhost:8099/detect -d '{"text":"Jane Doe jane@doe.com"}'
+```
+
+## Test
+
+`python -m unittest test_detector` covers the pure BIOES→span decode and the kind map. The
+ONNX inference is validated by the manual smoke check against real CVs (weights not in CI).
+
+## Notes
+
+- Span stitching currently uses argmax + contiguous-merge (spike-validated). The shipped
+  Viterbi decoder (`viterbi_calibration.json`) is the accuracy upgrade seam.
+- Deployment (systemd unit, weights, health-check, egress) lives in `freehire-ops`.

--- a/services/pii-filter/detector.py
+++ b/services/pii-filter/detector.py
@@ -1,0 +1,88 @@
+"""PII span detection over openai/privacy-filter (ONNX).
+
+decode_spans / KIND_MAP are pure and unit-tested; the Model class wraps onnxruntime and
+is exercised by the manual smoke check (heavy weights are not in CI). The endpoint returns
+spans already mapped to the freehire Kind vocabulary consumed by internal/pii.
+"""
+
+from __future__ import annotations
+
+# privacy-filter emits BIOES labels over these bases; we surface only the ones freehire
+# masks. Deliberately absent: private_date (load-bearing for experience timelines),
+# account_number and secret (out of the CV-PII scope).
+KIND_MAP = {
+    "private_person": "NAME",
+    "private_address": "ADDRESS",
+    "private_email": "EMAIL",
+    "private_phone": "PHONE",
+    "private_url": "LINK",
+}
+
+
+def _base(label: str) -> str | None:
+    """The entity base of a BIOES label ('B-private_person' -> 'private_person'); None for 'O'."""
+    if "-" not in label:
+        return None
+    return label.split("-", 1)[1]
+
+
+def decode_spans(labels, offsets):
+    """Stitch per-token BIOES labels into char spans, mapping to freehire kinds and dropping
+    any base not in KIND_MAP. Contiguous tokens of the same base merge into one span."""
+    spans = []
+    cur_base = None
+    cur_start = 0
+    cur_end = 0
+
+    def flush():
+        if cur_base and cur_base in KIND_MAP:
+            spans.append({"start": cur_start, "end": cur_end, "kind": KIND_MAP[cur_base]})
+
+    for label, (start, end) in zip(labels, offsets):
+        base = _base(label)
+        if base is None or end == 0:  # 'O' or a special token boundary
+            flush()
+            cur_base = None
+            continue
+        if base == cur_base:
+            cur_end = end
+        else:
+            flush()
+            cur_base, cur_start, cur_end = base, start, end
+    flush()
+    return spans
+
+
+class Model:
+    """Lazy-loaded ONNX privacy-filter. Imports the heavy deps only on construction so the
+    pure helpers above stay importable without onnxruntime installed."""
+
+    def __init__(self, model_dir: str, max_tokens: int = 4096):
+        import json
+        import os
+
+        import numpy as np
+        import onnxruntime as ort
+        from tokenizers import Tokenizer
+
+        self._np = np
+        self._max = max_tokens
+        cfg = json.load(open(os.path.join(model_dir, "config.json")))
+        self._id2label = {int(k): v for k, v in cfg["id2label"].items()}
+        self._tok = Tokenizer.from_file(os.path.join(model_dir, "tokenizer.json"))
+        self._sess = ort.InferenceSession(
+            os.path.join(model_dir, "onnx", "model_q4.onnx"),
+            providers=["CPUExecutionProvider"],
+        )
+        self._inputs = {i.name for i in self._sess.get_inputs()}
+
+    def detect(self, text: str):
+        enc = self._tok.encode(text)
+        ids = enc.ids[: self._max]
+        offsets = enc.offsets[: self._max]
+        feed = {"input_ids": self._np.array([ids], dtype=self._np.int64)}
+        if "attention_mask" in self._inputs:
+            feed["attention_mask"] = self._np.ones((1, len(ids)), dtype=self._np.int64)
+        logits = self._sess.run(None, feed)[0][0]
+        labels = [self._id2label[int(i)] for i in logits.argmax(-1)]
+        return decode_spans(labels, offsets)

--- a/services/pii-filter/requirements.txt
+++ b/services/pii-filter/requirements.txt
@@ -1,0 +1,3 @@
+onnxruntime>=1.24
+tokenizers>=0.21
+numpy>=2.0

--- a/services/pii-filter/server.py
+++ b/services/pii-filter/server.py
@@ -1,0 +1,59 @@
+"""Minimal stdlib HTTP wrapper around the ONNX privacy-filter detector.
+
+POST /detect  {"text": "..."}  -> {"spans": [{"start","end","kind"}, ...]}
+GET  /health                   -> {"status": "ok"}
+
+Config via env: PII_FILTER_MODEL_DIR (dir holding config.json, tokenizer.json, onnx/),
+PII_FILTER_ADDR (default 127.0.0.1:8099). The model loads once at startup.
+"""
+
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from detector import Model
+
+MODEL = None  # set in main()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _json(self, code, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._json(200, {"status": "ok"})
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/detect":
+            self._json(404, {"error": "not found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            req = json.loads(self.rfile.read(length) or b"{}")
+            spans = MODEL.detect(req.get("text", ""))
+            self._json(200, {"spans": spans})
+        except Exception as e:  # fail loud so the Go caller fails closed
+            self._json(500, {"error": str(e)})
+
+    def log_message(self, *args):  # silence per-request stderr logging
+        pass
+
+
+def main():
+    global MODEL
+    model_dir = os.environ["PII_FILTER_MODEL_DIR"]
+    host, _, port = os.environ.get("PII_FILTER_ADDR", "127.0.0.1:8099").partition(":")
+    MODEL = Model(model_dir)
+    ThreadingHTTPServer((host, int(port)), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/pii-filter/test_detector.py
+++ b/services/pii-filter/test_detector.py
@@ -1,0 +1,38 @@
+import unittest
+
+from detector import KIND_MAP, decode_spans
+
+
+class DecodeSpansTest(unittest.TestCase):
+    def test_maps_person_and_drops_dates(self):
+        # BIOES token labels with their char offsets. "private_date" must be dropped
+        # (dates are load-bearing for experience timelines, not PII we mask).
+        labels = ["B-private_person", "E-private_person", "O", "S-private_date"]
+        offsets = [(0, 4), (5, 12), (13, 15), (16, 26)]
+        spans = decode_spans(labels, offsets)
+        self.assertEqual(spans, [{"start": 0, "end": 12, "kind": "NAME"}])
+
+    def test_merges_contiguous_same_entity(self):
+        labels = ["B-private_url", "I-private_url", "E-private_url"]
+        offsets = [(0, 5), (5, 10), (10, 18)]
+        spans = decode_spans(labels, offsets)
+        self.assertEqual(spans, [{"start": 0, "end": 18, "kind": "LINK"}])
+
+    def test_singleton_entity(self):
+        labels = ["O", "S-private_email"]
+        offsets = [(0, 3), (4, 20)]
+        spans = decode_spans(labels, offsets)
+        self.assertEqual(spans, [{"start": 4, "end": 20, "kind": "EMAIL"}])
+
+    def test_kind_map_covers_masked_types_only(self):
+        self.assertEqual(KIND_MAP["private_person"], "NAME")
+        self.assertEqual(KIND_MAP["private_address"], "ADDRESS")
+        self.assertEqual(KIND_MAP["private_email"], "EMAIL")
+        self.assertEqual(KIND_MAP["private_phone"], "PHONE")
+        self.assertEqual(KIND_MAP["private_url"], "LINK")
+        # Out-of-scope categories are intentionally absent (never masked).
+        self.assertNotIn("private_date", KIND_MAP)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Masks direct identifiers (name, email, phone, home address, personal links) in CV text **before** it reaches the LLM provider through the LiteLLM gateway, and restores them in the user-facing output. Implements OpenSpec change `add-cv-pii-masking` (proposal/design/specs already on main).

## What
- **`internal/pii`** — regex floor (email/phone with `YYYY-YYYY` guard/URL/@handle) ∪ `openai/privacy-filter` model spans → a `Redactor` with reversible numbered placeholders. Fail-closed (`Build` errors when the detector is unavailable). `Contacts()` recovers detected contact values.
- **`matchanalysis`** — masks CV + structured résumé into every stage prompt; restores on the streamed events + the returned/cached analysis; never restores data threaded into a later stage (no re-leak).
- **`resumeextract`** — contact fields come from deterministic detection; only the redacted CV goes to the LLM for semantic fields.
- **`services/pii-filter`** — small ONNX (q4, CPU) detection endpoint serving `openai/privacy-filter`; `POST /detect` → spans mapped to our kinds.
- **config/wiring** — `PII_FILTER_URL`; detector threaded through `cmd/server` + `cmd/backfill-resume-structured`.

## Threat model
Real identifiers must never leave our perimeter to the model provider. **Fail-closed**: no detector ⇒ no CV to the LLM (fit analysis + structured extraction degrade to no-op), rather than leak.

## Validation
- Unit tests across `internal/pii` (incl. adversarial regression tests from code review: word-boundary abutting-char leak + spaced year-range), `matchanalysis` (no PII in prompts, output restored, fail-closed), `resumeextract` (contacts from detection, no PII in LLM input, fail-closed).
- **Live e2e** against the real `openai/privacy-filter` ONNX model (`internal/pii/integration_test.go`, `-tags=integration`): PII masked, employer/city preserved, round-trip exact, contacts recovered.
- `go build/vet/test` green. (One flaky `internal/sources` neogov network test is unrelated — passes in isolation and on clean main.)

## Deploy (prerequisite for the feature to activate)
Ops wiring in **freehire-ops** (`add-pii-filter-service` branch): systemd unit + runbook to run `services/pii-filter` on host-2 and set `PII_FILTER_URL`. Until deployed, the CV→LLM paths stay fail-closed (disabled, no PII path). Postal-address detection is best-effort (Viterbi decoder is the noted accuracy seam).