### PR TITLE
fix(llm-json): tolerate scalar type slips across 4 LLM-decode sites (flexjson)

### DIFF
--- a/internal/atscheck/flexdecode.go
+++ b/internal/atscheck/flexdecode.go
@@ -1,0 +1,24 @@
+package atscheck
+
+import (
+	"encoding/json"
+
+	"github.com/strelov1/freehire/internal/flexjson"
+)
+
+// UnmarshalJSON tolerates a content-quality score the model returns as a string ("85") or
+// "85/100" instead of an integer, then delegates the rest via an alias (no recursion).
+// encoding/json would otherwise abort the whole review over one such slip. The exported
+// ContentQuality stays int; sanitize clamps it as before.
+func (r *Review) UnmarshalJSON(b []byte) error {
+	type alias Review
+	aux := struct {
+		ContentQuality flexjson.Int `json:"content_quality"`
+		*alias
+	}{alias: (*alias)(r)}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	r.ContentQuality = int(aux.ContentQuality)
+	return nil
+}

--- a/internal/atscheck/flexdecode_test.go
+++ b/internal/atscheck/flexdecode_test.go
@@ -1,0 +1,23 @@
+package atscheck
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The review is prompted for an integer content-quality score, but the model can return
+// it as "85" or "85/100". A string there would abort the whole review (score + all
+// suggestions), silently dropping the qualitative CV review.
+func TestReview_StringContentQualityDecodes(t *testing.T) {
+	raw := `{"content_quality": "85", "suggestions": ["tighten the summary"]}`
+	var r Review
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		t.Fatalf("unmarshal review with string score failed: %v", err)
+	}
+	if r.ContentQuality != 85 {
+		t.Errorf("ContentQuality = %d, want 85", r.ContentQuality)
+	}
+	if len(r.Suggestions) != 1 || r.Suggestions[0] != "tighten the summary" {
+		t.Errorf("Suggestions = %v, want [tighten the summary]", r.Suggestions)
+	}
+}

--- a/internal/flexjson/flexjson.go
+++ b/internal/flexjson/flexjson.go
@@ -1,0 +1,145 @@
+// Package flexjson provides tolerant JSON scalar types for decoding LLM output. Models
+// non-deterministically pick the wrong JSON type for a scalar — a number as a string
+// ("85"), a string as a number, a bool as "true"/1 — and encoding/json aborts the WHOLE
+// unmarshal on the first mismatch, so one slip silently discards the entire decoded
+// record. These types coerce number<->string<->bool at the decode boundary; use them in a
+// shadow struct's UnmarshalJSON and copy into the plain exported fields, so the contract
+// and every consumer stay untouched. Non-numeric or empty input yields the zero value
+// rather than an error (a best-effort field is better dropped than crashing the record).
+//
+// Siblings internal/enrich and internal/resumeextract keep their own package-local flex*
+// types (working, tested, on hot/critical paths); consolidating them here is a future
+// cleanup, not required for correctness.
+package flexjson
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Int decodes from a JSON number (rounded to nearest) OR a string, taking the leading
+// integer ("85" → 85, "85%" → 85, "8/10" → 8). Empty/non-numeric input yields 0.
+type Int int
+
+func (f *Int) UnmarshalJSON(b []byte) error {
+	n, err := decodeNumber(b)
+	if err != nil {
+		return err
+	}
+	*f = Int(int(math.Round(n)))
+	return nil
+}
+
+// Int64 is Int for 64-bit ids/counts (e.g. a matched job id the model may quote as "42").
+type Int64 int64
+
+func (f *Int64) UnmarshalJSON(b []byte) error {
+	n, err := decodeNumber(b)
+	if err != nil {
+		return err
+	}
+	*f = Int64(int64(math.Round(n)))
+	return nil
+}
+
+// Float decodes from a JSON number OR a string, taking the leading float ("0.8" → 0.8).
+// Empty/non-numeric input yields 0.
+type Float float64
+
+func (f *Float) UnmarshalJSON(b []byte) error {
+	n, err := decodeNumber(b)
+	if err != nil {
+		return err
+	}
+	*f = Float(n)
+	return nil
+}
+
+// Bool decodes from a JSON bool, a string ("true"/"yes"/"y"/"t"/"1" → true), or a number
+// (non-zero → true). Empty/unrecognized input yields false.
+type Bool bool
+
+func (f *Bool) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		*f = false
+		return nil
+	}
+	var bo bool
+	if err := json.Unmarshal(b, &bo); err == nil {
+		*f = Bool(bo)
+		return nil
+	}
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		switch strings.ToLower(strings.TrimSpace(s)) {
+		case "true", "yes", "y", "t", "1":
+			*f = true
+		default:
+			*f = false
+		}
+		return nil
+	}
+	var n float64
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*f = Bool(n != 0)
+	return nil
+}
+
+// decodeNumber extracts a float64 from a JSON number or a string carrying a leading
+// numeric token. Empty, null, or non-numeric input yields 0 (not an error), so a single
+// unparseable field never aborts the surrounding record.
+func decodeNumber(b []byte) (float64, error) {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		return 0, nil
+	}
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return 0, err
+		}
+		return leadingFloat(s), nil
+	}
+	var n float64
+	if err := json.Unmarshal(b, &n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// leadingFloat parses the leading numeric token of s (optional sign, digits, one decimal
+// point), e.g. "0.9 ok" → 0.9, "85%" → 85, "n/a" → 0.
+func leadingFloat(s string) float64 {
+	s = strings.TrimSpace(s)
+	end, seenDot := 0, false
+	for end < len(s) {
+		c := s[end]
+		switch {
+		case c >= '0' && c <= '9':
+		case c == '-' && end == 0:
+		case c == '.' && !seenDot:
+			seenDot = true
+		default:
+			goto done
+		}
+		end++
+	}
+done:
+	if end == 0 {
+		return 0
+	}
+	n, err := strconv.ParseFloat(s[:end], 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/flexjson/flexjson_test.go
+++ b/internal/flexjson/flexjson_test.go
@@ -1,0 +1,103 @@
+package flexjson
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInt_NumberOrString(t *testing.T) {
+	cases := map[string]int{
+		`85`:      85,
+		`85.0`:    85,
+		`84.6`:    85, // rounds
+		`"85"`:    85,
+		`"85%"`:   85,
+		`"8/10"`:  8,
+		`"-3"`:    -3,
+		`""`:      0,
+		`"n/a"`:   0,
+		`null`:    0,
+		`"  12 "`: 12,
+	}
+	for raw, want := range cases {
+		var v Int
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			t.Errorf("Int %s: unexpected error %v", raw, err)
+			continue
+		}
+		if int(v) != want {
+			t.Errorf("Int %s = %d, want %d", raw, int(v), want)
+		}
+	}
+}
+
+func TestInt64_NumberOrString(t *testing.T) {
+	cases := map[string]int64{
+		`42`:     42,
+		`"42"`:   42,
+		`"none"`: 0,
+		`""`:     0,
+		`null`:   0,
+	}
+	for raw, want := range cases {
+		var v Int64
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			t.Errorf("Int64 %s: unexpected error %v", raw, err)
+			continue
+		}
+		if int64(v) != want {
+			t.Errorf("Int64 %s = %d, want %d", raw, int64(v), want)
+		}
+	}
+}
+
+func TestFloat_NumberOrString(t *testing.T) {
+	cases := map[string]float64{
+		`0.8`:      0.8,
+		`"0.8"`:    0.8,
+		`1`:        1,
+		`"0.85 "`:  0.85,
+		`""`:       0,
+		`"high"`:   0,
+		`null`:     0,
+		`"85%"`:    85,
+		`"0.9 ok"`: 0.9,
+	}
+	for raw, want := range cases {
+		var v Float
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			t.Errorf("Float %s: unexpected error %v", raw, err)
+			continue
+		}
+		if float64(v) != want {
+			t.Errorf("Float %s = %v, want %v", raw, float64(v), want)
+		}
+	}
+}
+
+func TestBool_BoolStringOrNumber(t *testing.T) {
+	cases := map[string]bool{
+		`true`:    true,
+		`false`:   false,
+		`"true"`:  true,
+		`"yes"`:   true,
+		`"1"`:     true,
+		`"Y"`:     true,
+		`1`:       true,
+		`0`:       false,
+		`"false"`: false,
+		`"no"`:    false,
+		`""`:      false,
+		`null`:    false,
+	}
+	for raw, want := range cases {
+		var v Bool
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			t.Errorf("Bool %s: unexpected error %v", raw, err)
+			continue
+		}
+		if bool(v) != want {
+			t.Errorf("Bool %s = %v, want %v", raw, bool(v), want)
+		}
+	}
+}

--- a/internal/mailclassify/flexdecode.go
+++ b/internal/mailclassify/flexdecode.go
@@ -1,0 +1,26 @@
+package mailclassify
+
+import (
+	"encoding/json"
+
+	"github.com/strelov1/freehire/internal/flexjson"
+)
+
+// UnmarshalJSON tolerates a confidence the model quotes ("0.8") and a matched job id it
+// answers as "none"/"0", then delegates the rest via an alias (no recursion). encoding/json
+// would otherwise abort the whole classification over one such slip, silently leaving the
+// email unclassified. The exported fields stay float64/int64; Sanitize runs as before.
+func (c *Classification) UnmarshalJSON(b []byte) error {
+	type alias Classification
+	aux := struct {
+		Confidence   flexjson.Float `json:"confidence"`
+		MatchedJobID flexjson.Int64 `json:"matched_job_id"`
+		*alias
+	}{alias: (*alias)(c)}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	c.Confidence = float64(aux.Confidence)
+	c.MatchedJobID = int64(aux.MatchedJobID)
+	return nil
+}

--- a/internal/mailclassify/flexdecode_test.go
+++ b/internal/mailclassify/flexdecode_test.go
@@ -1,0 +1,26 @@
+package mailclassify
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The classifier is prompted for a numeric confidence and a matched job id, but the model
+// can quote them ("0.8") or answer "none" for the id. Either would abort the whole
+// classification, silently leaving the email unclassified/unlinked.
+func TestClassification_StringConfidenceAndIDDecode(t *testing.T) {
+	raw := `{"signal": "applied", "confidence": "0.8", "matched_job_id": "none"}`
+	var c Classification
+	if err := json.Unmarshal([]byte(raw), &c); err != nil {
+		t.Fatalf("unmarshal classification with string confidence/id failed: %v", err)
+	}
+	if c.Confidence != 0.8 {
+		t.Errorf("Confidence = %v, want 0.8", c.Confidence)
+	}
+	if c.MatchedJobID != 0 {
+		t.Errorf("MatchedJobID = %d, want 0", c.MatchedJobID)
+	}
+	if c.Signal != "applied" {
+		t.Errorf("Signal = %q, want applied", c.Signal)
+	}
+}

--- a/internal/matchanalysis/flexdecode.go
+++ b/internal/matchanalysis/flexdecode.go
@@ -1,0 +1,24 @@
+package matchanalysis
+
+import (
+	"encoding/json"
+
+	"github.com/strelov1/freehire/internal/flexjson"
+)
+
+// UnmarshalJSON tolerates a dimension score the model returns as a string ("85") or a
+// ratio ("8/10") instead of an integer, then delegates the rest via an alias (no
+// recursion). encoding/json would otherwise abort the whole recruiter verdict over one
+// such slip. The exported Score stays int; sanitizeVerdict clamps it as before.
+func (d *dimScore) UnmarshalJSON(b []byte) error {
+	type alias dimScore
+	aux := struct {
+		Score flexjson.Int `json:"score"`
+		*alias
+	}{alias: (*alias)(d)}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	d.Score = int(aux.Score)
+	return nil
+}

--- a/internal/matchanalysis/flexdecode_test.go
+++ b/internal/matchanalysis/flexdecode_test.go
@@ -1,0 +1,33 @@
+package matchanalysis
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The recruiter stage is prompted for integer dimension scores, but the model can return
+// them as strings ("85") or ratios ("8/10"). A string score would abort the whole verdict
+// decode (six dimensions + free-text) — this is the user-visible fit-analysis path.
+func TestRecruiterVerdict_StringScoreDecodes(t *testing.T) {
+	raw := `{
+		"title_alignment": {"score": "85", "comment": "strong"},
+		"skills_coverage": {"score": "8/10", "comment": "partial"},
+		"seniority_fit":   {"score": 70, "comment": "ok"}
+	}`
+	var v recruiterVerdict
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("unmarshal verdict with string scores failed: %v", err)
+	}
+	if v.TitleAlignment.Score != 85 {
+		t.Errorf("TitleAlignment.Score = %d, want 85", v.TitleAlignment.Score)
+	}
+	if v.SkillsCoverage.Score != 8 {
+		t.Errorf("SkillsCoverage.Score = %d, want 8", v.SkillsCoverage.Score)
+	}
+	if v.SeniorityFit.Score != 70 {
+		t.Errorf("SeniorityFit.Score = %d, want 70", v.SeniorityFit.Score)
+	}
+	if v.TitleAlignment.Comment != "strong" {
+		t.Errorf("TitleAlignment.Comment = %q, want %q", v.TitleAlignment.Comment, "strong")
+	}
+}

--- a/internal/telegram/flexdecode.go
+++ b/internal/telegram/flexdecode.go
@@ -1,0 +1,24 @@
+package telegram
+
+import (
+	"encoding/json"
+
+	"github.com/strelov1/freehire/internal/flexjson"
+)
+
+// UnmarshalJSON tolerates a "remote" flag the model returns as "true"/"yes" or 1 instead
+// of a bool, then delegates the rest via an alias (no recursion). encoding/json would
+// otherwise abort the whole post's extraction over one such slip. The exported Remote
+// stays bool; Validate runs on the canonical shape as before.
+func (j *ExtractedJob) UnmarshalJSON(b []byte) error {
+	type alias ExtractedJob
+	aux := struct {
+		Remote flexjson.Bool `json:"remote"`
+		*alias
+	}{alias: (*alias)(j)}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	j.Remote = bool(aux.Remote)
+	return nil
+}

--- a/internal/telegram/flexdecode_test.go
+++ b/internal/telegram/flexdecode_test.go
@@ -1,0 +1,32 @@
+package telegram
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The extraction prompt says remote is a boolean, but the model can emit "true"/"yes" or
+// 1. A string/number there would abort the whole post's extraction (every job in it).
+func TestExtractedJob_RemoteFromStringOrNumber(t *testing.T) {
+	raw := `{"jobs": [
+		{"title": "Go dev", "description": "d1", "remote": "true"},
+		{"title": "JS dev", "description": "d2", "remote": 1},
+		{"title": "QA",     "description": "d3", "remote": false}
+	]}`
+	var ex Extraction
+	if err := json.Unmarshal([]byte(raw), &ex); err != nil {
+		t.Fatalf("unmarshal extraction with string/number remote failed: %v", err)
+	}
+	if len(ex.Jobs) != 3 {
+		t.Fatalf("jobs = %d, want 3", len(ex.Jobs))
+	}
+	if !ex.Jobs[0].Remote || !ex.Jobs[1].Remote {
+		t.Errorf("remote flags = %v/%v, want true/true", ex.Jobs[0].Remote, ex.Jobs[1].Remote)
+	}
+	if ex.Jobs[2].Remote {
+		t.Errorf("jobs[2].Remote = true, want false")
+	}
+	if ex.Jobs[0].Title != "Go dev" {
+		t.Errorf("jobs[0].Title = %q, want %q", ex.Jobs[0].Title, "Go dev")
+	}
+}


### PR DESCRIPTION
**PR 2 of 2** (follow-up to #1075). Same bug class, swept across the rest of the codebase.

## Problem

An LLM emits a scalar in the wrong JSON type — a number as a string (`"85"`), a bool as `"true"`/`1` — and `encoding/json` aborts the **whole** unmarshal on the first mismatch, silently discarding the decoded record. #1075 fixed `resumeextract`; an audit found 4 more vulnerable sites (all plain `json.Unmarshal`, whole-record abort, with `Sanitize`/`Validate` running only *after* decode so they don't protect against it).

## Fix

New `internal/flexjson` — shared tolerant scalar types (`Int`, `Int64`, `Float`, `Bool`) that coerce number↔string↔bool at the decode boundary (generalizes the local `flex*` convention in `internal/enrich`). Applied via `UnmarshalJSON` shims so **exported field types are unchanged** — the generated TS contract, `Sanitize`/`Validate`, and every consumer are untouched:

| Site | Field | Tolerates | Visibility |
|---|---|---|---|
| `matchanalysis` | `dimScore.Score int` | `"85"`, `"8/10"` | **user-visible** (SSE fit) |
| `telegram` | `ExtractedJob.Remote bool` | `"true"`, `1` | background worker |
| `atscheck` | `Review.ContentQuality int` | `"85"`, `"85/100"` | graceful-degrade |
| `mailclassify` | `Classification.Confidence float64` / `MatchedJobID int64` | `"0.8"` / `"none"` | background worker |

## Not in scope

`enrich` and `resumeextract` keep their package-local `flex*` types — working, tested, on hot/critical paths. Consolidating all three onto `flexjson` is a noted future cleanup, not required for correctness.

## Tests (TDD)

Each site has a test that reproduced its exact type-mismatch abort before the shim, plus a full `flexjson` unit suite (number/string/ratio/empty/null cases). `go build ./...`, `go vet`, `gofmt`, and all five package suites clean.

## Coordination

`matchanalysis` also has in-flight work on `docs/pii-masking-cv-design` — this PR only adds a shim file + one `UnmarshalJSON`; should rebase cleanly, but worth sequencing.