### PR TITLE
feat(web): mobile tab bar for CV tailor workspace

### DIFF
--- a/openspec/changes/add-tailor-mobile-tabs/.openspec.yaml
+++ b/openspec/changes/add-tailor-mobile-tabs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/add-tailor-mobile-tabs/design.md
+++ b/openspec/changes/add-tailor-mobile-tabs/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The workspace lays out three columns, each with its own selector: the left
+panel toggles `leftTab` (Editor/Chat); the centre is the always-on preview; the
+right `ArtifactPanel` owns its own tab (Templates/Job/Verdict). On desktop all
+three are visible at once, so two independent selectors + the always-on preview
+coexist. On mobile only one view fits at a time, which needs a *single* choice
+across all six — a different shape from the desktop's two-independent-selectors
+model.
+
+## Decision
+
+Add one page-level state, `mobileView`
+(`'chat' | 'editor' | 'preview' | 'templates' | 'jd' | 'verdict'`), as the sole
+source of truth for per-region visibility **on mobile**. Desktop ignores it —
+`lg:flex` re-shows every region regardless of the mobile `hidden`.
+
+`pickMobile(v)` sets `mobileView` and syncs the matching column's existing
+selector (`leftTab` for chat/editor, the lifted `artifactTab` for
+templates/jd/verdict) so desktop and mobile never disagree. The centre preview
+has no sub-selector, so `preview` only toggles visibility.
+
+Region visibility uses the existing repo pattern already proven in this file:
+a conditional `flex`/`hidden` plus a static `lg:flex`. At `lg` the `lg:flex`
+utility wins (Tailwind emits responsive variants after base utilities, and the
+`@media` rule wins at equal specificity as the later rule), so every column is
+shown; below `lg` the conditional class decides.
+
+`ArtifactPanel`'s tab is lifted to a `$bindable` prop so the page's flat bar can
+drive it while its own desktop tab bar keeps setting it via the same binding.
+Its fixed pixel width moves from an inline `width:` to a `--w` CSS variable
+(`w-full lg:w-[var(--w)]`), mirroring how the left panel already handles its
+width, so the panel fills the screen on mobile rather than staying a narrow
+column.
+
+## Alternatives considered
+
+- **Two-level mobile tabs** (3 primary column tabs, nested sub-tabs inside
+  Edit/Context): fewer top-level tabs but nested navigation on a small screen;
+  rejected for the flat six-tab bar per the product call.
+- **Unifying all selection into one enum** (dropping `leftTab`/`artifactTab`):
+  breaks the desktop model where two selectors must be independently active at
+  once. Rejected — `mobileView` layered on top keeps desktop untouched.
+
+## Known limitation
+
+The "Saving/Saved" indicator sits in the left panel's header, which is
+desktop-only, so it does not render on mobile. Autosave itself is unaffected.
+Restoring a mobile indicator (e.g. in the flat bar) is a deliberate follow-up,
+left out to keep the change minimal.

--- a/openspec/changes/add-tailor-mobile-tabs/proposal.md
+++ b/openspec/changes/add-tailor-mobile-tabs/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+On a phone the tailoring workspace only ever showed the left panel (Editor /
+Chat). The centre CV preview and the right context panel (Templates / Job
+description / Verdict) are gated behind `lg:` and are simply absent below the
+breakpoint — there is no control that reveals them. A mobile user tailoring a CV
+can talk to the agent and edit fields but can never see the live preview, switch
+a template, re-read the job description, or review the verdict.
+
+## What Changes
+
+- Below `lg`, the three columns collapse to a single full-screen view driven by
+  one flat, horizontally-scrollable tab bar: **Chat · Editor · Preview ·
+  Templates · Job · Verdict**. Tapping a tab shows that view full-width.
+- At `lg` and up nothing changes: all three columns render side by side with
+  their own splitters and per-column tab bars exactly as before.
+- The per-column tab bars (Editor/Chat in the left panel, Templates/Job/Verdict
+  in the context panel) become desktop-only; on mobile the single flat bar is
+  the sole navigation, so tabs are never duplicated.
+- The right context panel's active tab is lifted to the page so the mobile bar
+  can drive it; its fixed pixel width moves to a CSS variable so it fills the
+  screen on mobile instead of staying a narrow column.
+
+No breaking changes; desktop behaviour is untouched. Purely a frontend layout
+change.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `tailor-workspace`: gains a mobile navigation requirement — below `lg` the
+  three columns collapse to one flat tab bar switching between all six views,
+  while the existing three-column requirement continues to govern wide
+  viewports.
+
+## Impact
+
+- **Frontend only:** `web/src/routes/tailor/[slug]/+page.svelte` (mobile tab
+  bar, `mobileView` state + `pickMobile` sync, per-breakpoint region
+  visibility) and `web/src/lib/tailor/ArtifactPanel.svelte` (`tab` lifted to a
+  bindable prop, `mobileVisible` prop, width on a CSS var, desktop-only tab
+  bar).
+- **Known limitation:** the "Saving/Saved" indicator lives in the left panel's
+  desktop-only header, so it is not shown on mobile. Autosave still runs; only
+  the status text is absent below `lg`.

--- a/openspec/changes/add-tailor-mobile-tabs/specs/tailor-workspace/spec.md
+++ b/openspec/changes/add-tailor-mobile-tabs/specs/tailor-workspace/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: The workspace collapses to a single tabbed view on mobile
+
+The workspace SHALL, below the `lg` breakpoint, collapse its three columns into
+a single full-screen view selected by one flat, horizontally-scrollable tab bar
+offering all six views: Chat, Editor, Preview, Templates, Job description, and
+Verdict. Selecting a tab SHALL show that view full-width and hide the others.
+At `lg` and up the workspace SHALL render all three columns side by side as
+before, and the flat mobile tab bar SHALL NOT be shown. The per-column tab bars
+(Editor/Chat, Templates/Job/Verdict) SHALL be desktop-only so mobile navigation
+is not duplicated.
+
+#### Scenario: The flat tab bar switches views on mobile
+
+- **WHEN** the workspace renders on a narrow (below `lg`) viewport and the user taps a tab (e.g. Preview or Verdict)
+- **THEN** that single view fills the screen and the other views are hidden, with the tab bar offering Chat, Editor, Preview, Templates, Job, and Verdict
+
+#### Scenario: Mobile selection stays consistent with the columns
+
+- **WHEN** the user taps a mobile tab that corresponds to a column sub-tab (Editor, Chat, Templates, Job, or Verdict)
+- **THEN** the matching column's own tab is selected too, so switching to a wide viewport shows the same content selected
+
+#### Scenario: The desktop layout is unchanged at lg
+
+- **WHEN** the workspace renders at `lg` or wider
+- **THEN** the three columns show side by side with their own tab bars and splitters, and the flat mobile tab bar is not shown

--- a/openspec/changes/add-tailor-mobile-tabs/tasks.md
+++ b/openspec/changes/add-tailor-mobile-tabs/tasks.md
@@ -1,0 +1,17 @@
+## 1. Right context panel — lift tab, mobile visibility
+
+- [x] 1.1 In `web/src/lib/tailor/ArtifactPanel.svelte`, lift `tab` to a `$bindable('templates')` prop and add a `mobileVisible = false` prop.
+- [x] 1.2 Drive the `aside` visibility from `mobileVisible` (conditional `flex`/`hidden`) with a static `lg:flex`; move its fixed pixel width from inline `width:` to a `--w` CSS variable (`w-full lg:w-[var(--w)]`) so it fills the screen on mobile.
+- [x] 1.3 Make the panel's own tab bar desktop-only (`hidden … lg:flex`).
+
+## 2. Page — mobile tab bar + region visibility
+
+- [x] 2.1 In `web/src/routes/tailor/[slug]/+page.svelte`, add `mobileView` state and an `artifactTab` state (bound into `ArtifactPanel`), plus a `pickMobile(v)` that sets `mobileView` and syncs `leftTab` / `artifactTab`.
+- [x] 2.2 Make the inner container `flex-col lg:flex-row` and add a `lg:hidden` flat, horizontally-scrollable tab bar with the six tabs (Chat, Editor, Preview, Templates, Job, Verdict).
+- [x] 2.3 Gate the left panel and centre preview visibility on `mobileView` (conditional `flex`/`hidden` + static `lg:flex`); pass `mobileVisible` and `bind:tab` to `ArtifactPanel`.
+- [x] 2.4 Make the left panel's own header (Editor/Chat tabs + save status) desktop-only (`hidden … lg:flex`).
+
+## 3. Verify
+
+- [x] 3.1 `npm run check` (svelte-check) — 0 errors; `npx eslint` on both changed files — clean.
+- [ ] 3.2 Visual-verify the mobile layout (throwaway route + headless Chrome per repo convention): confirm each tab shows its view full-width below `lg` and the desktop three-column layout is unchanged at `lg`.

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -12,25 +12,32 @@
   import type { Analysis } from '$lib/generated/contracts';
   import type { Job, MatchAnalysisResponse } from '$lib/types';
 
+  type Tab = 'templates' | 'jd' | 'verdict';
+
   let {
     cvId,
     job,
     analysis,
     onTemplateSelected,
+    // Which tab is active — bindable so the page's mobile tab bar can drive it (on desktop the
+    // panel's own tab bar sets it). mobileVisible is the page's per-breakpoint show/hide on mobile;
+    // at lg the aside is always shown regardless (lg:flex overrides the mobile hidden).
+    tab = $bindable('templates'),
+    mobileVisible = false,
   }: {
     cvId: number;
     job: Job;
     analysis: Analysis | null;
     onTemplateSelected: (id: string) => void;
+    tab?: Tab;
+    mobileVisible?: boolean;
   } = $props();
 
-  type Tab = 'templates' | 'jd' | 'verdict';
   const tabs: [Tab, string][] = [
     ['templates', 'Templates'],
     ['jd', 'Job description'],
     ['verdict', 'Verdict'],
   ];
-  let tab = $state<Tab>('templates');
   let width = $state(340);
   let resizing = false;
 
@@ -63,10 +70,14 @@
 ></div>
 
 <aside
-  class="hidden shrink-0 flex-col border-l border-border bg-background lg:flex"
-  style="width: {width}px"
+  class={[
+    'w-full min-h-0 flex-1 flex-col border-l border-border bg-background lg:w-[var(--w)] lg:flex-none lg:flex',
+    mobileVisible ? 'flex' : 'hidden',
+  ]}
+  style="--w: {width}px"
 >
-  <div class="flex items-center gap-1 border-b border-border px-2 py-1.5 text-sm">
+  <!-- Own tab bar is desktop-only; on mobile the page's flat tab bar drives the tab. -->
+  <div class="hidden items-center gap-1 border-b border-border px-2 py-1.5 text-sm lg:flex">
     {#each tabs as [id, label] (id)}
       <button
         type="button"

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -55,6 +55,32 @@
   let leftPanelEl = $state<HTMLElement>();
   let leftResizing = false;
 
+  // The right context panel's tab, lifted here so the mobile tab bar can drive it (on desktop the
+  // panel's own tab bar sets it via the same binding).
+  let artifactTab = $state<'templates' | 'jd' | 'verdict'>('templates');
+
+  // Mobile-only navigation: below lg the three columns collapse to one, so a single flat tab bar
+  // picks which view fills the screen. At lg it's hidden and every column shows at once as before.
+  // mobileView is the sole source of truth for per-region visibility on mobile; picking a tab also
+  // syncs the matching column's own selector (mobile → column) so the wide layout shows the same
+  // content once revealed. The reverse (a desktop tab change updating mobileView) is not wired —
+  // switching a column tab then narrowing across lg resets the mobile view to that tab's default.
+  type MobileView = 'chat' | 'editor' | 'preview' | 'templates' | 'jd' | 'verdict';
+  const mobileTabs: [MobileView, string][] = [
+    ['chat', 'Chat'],
+    ['editor', 'Editor'],
+    ['preview', 'Preview'],
+    ['templates', 'Templates'],
+    ['jd', 'Job'],
+    ['verdict', 'Verdict'],
+  ];
+  let mobileView = $state<MobileView>('chat');
+  function pickMobile(v: MobileView) {
+    mobileView = v;
+    if (v === 'chat' || v === 'editor') leftTab = v;
+    else if (v !== 'preview') artifactTab = v;
+  }
+
   // Centre preview zoom, clamped to 50–150% in 10% steps. Starts at 90% so the full A4 page
   // fits the centre column on load.
   let zoom = $state(0.9);
@@ -233,16 +259,35 @@
       <a href={resolve('/match/[slug]', { slug })} class="text-sm text-brand hover:underline">Back to the fit analysis</a>
     </div>
   {:else}
-    <div class="flex min-w-0 flex-1">
-      <!-- LEFT: Editor / Chat tabs (chat stays mounted across tab switches). Full-width below lg
-           (the centre preview + right panel are lg-only), a splitter-sized column at lg+. The
-           width rides a CSS var so the inline style never overrides the mobile w-full. -->
+    <div class="flex min-w-0 flex-1 flex-col lg:flex-row">
+      <!-- MOBILE TAB BAR: below lg the three columns collapse to one full-screen view; this flat,
+           horizontally-scrollable bar switches between all of them. Hidden at lg (columns stack). -->
+      <nav class="flex items-center gap-1 overflow-x-auto border-b border-border bg-background px-2 py-1.5 text-sm lg:hidden">
+        {#each mobileTabs as [id, label] (id)}
+          <button
+            type="button"
+            onclick={() => pickMobile(id)}
+            aria-current={mobileView === id ? 'page' : undefined}
+            class={['shrink-0 rounded px-2 py-1 transition-colors', mobileView === id ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
+          >
+            {label}
+          </button>
+        {/each}
+      </nav>
+
+      <!-- LEFT: Editor / Chat tabs (chat stays mounted across tab switches). On mobile it shows only
+           when its tab is picked; at lg it's a splitter-sized column always shown. The width rides a
+           CSS var so the inline style never overrides the mobile w-full. -->
       <section
         bind:this={leftPanelEl}
-        class="flex w-full shrink-0 flex-col border-r border-border bg-background lg:w-[var(--lw)]"
+        class={[
+          'w-full min-h-0 flex-1 flex-col border-r border-border bg-background lg:w-[var(--lw)] lg:flex-none lg:flex',
+          mobileView === 'chat' || mobileView === 'editor' ? 'flex' : 'hidden',
+        ]}
         style="--lw: {leftWidth}px"
       >
-        <div class="flex items-center justify-between gap-2 border-b border-border px-2 py-1.5 text-sm">
+        <!-- Own tab bar (and save status) is desktop-only; the mobile bar drives the tab there. -->
+        <div class="hidden items-center justify-between gap-2 border-b border-border px-2 py-1.5 text-sm lg:flex">
           <div class="flex items-center gap-1">
             <button
               type="button"
@@ -297,9 +342,11 @@
         onpointerup={stopLeftResize}
       ></div>
 
-      <!-- CENTRE: live HTML preview + zoom + Download PDF. lg-only — below lg the left panel
-           (chat + editor) takes the whole surface. -->
-      <div class="hidden min-w-0 flex-1 flex-col bg-muted/30 lg:flex">
+      <!-- CENTRE: live HTML preview + zoom + Download PDF. On mobile it shows only when the Preview
+           tab is picked; at lg it's always shown as the middle column. -->
+      <div
+        class={['min-w-0 min-h-0 flex-1 flex-col bg-muted/30 lg:flex', mobileView === 'preview' ? 'flex' : 'hidden']}
+      >
         <div class="flex items-center justify-between gap-2 border-b border-border bg-background px-3 py-1.5 text-sm">
           <div class="flex items-center gap-1">
             <button type="button" onclick={zoomOut} aria-label="Zoom out" class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground">
@@ -326,8 +373,16 @@
         </div>
       </div>
 
-      <!-- RIGHT: Templates / Job description / Verdict (renders its own splitter). -->
-      <ArtifactPanel {cvId} job={job!} {analysis} {onTemplateSelected} />
+      <!-- RIGHT: Templates / Job description / Verdict (renders its own splitter). Shown on mobile
+           only when one of its tabs is picked; always shown at lg. -->
+      <ArtifactPanel
+        {cvId}
+        job={job!}
+        {analysis}
+        {onTemplateSelected}
+        bind:tab={artifactTab}
+        mobileVisible={mobileView === 'templates' || mobileView === 'jd' || mobileView === 'verdict'}
+      />
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## What

Below the \`lg\` breakpoint the CV tailoring workspace only ever showed the left panel (Editor/Chat) — the centre CV preview and the right context panel (Templates/Job description/Verdict) were \`lg:\`-gated and simply absent on mobile. This adds a single flat, horizontally-scrollable tab bar that collapses the three columns into one full-screen view on mobile: **Chat · Editor · Preview · Templates · Job · Verdict**.

Desktop (\`lg+\`) layout is unchanged.

## How

- New page state \`mobileView\` is the sole source of truth for per-region visibility on mobile; \`pickMobile()\` sets it and syncs the existing per-column selectors (\`leftTab\`, and the lifted \`artifactTab\`) so the wide layout shows the same content once revealed.
- \`ArtifactPanel\`'s \`tab\` lifted to a \`$bindable\` prop (flat bar drives it); its fixed width moved to a \`--w\` CSS var so it fills the screen on mobile; its own tab bar is now desktop-only.
- Region visibility uses the repo's existing \`conditional flex/hidden\` + static \`lg:flex\` pattern.

## Known limitation

The autosave "Saving/Saved" indicator lives in the left panel's desktop-only header, so it isn't shown on mobile (autosave still runs). Restoring a mobile indicator is a deliberate follow-up.

## Verification

- \`svelte-check\` 0 errors; \`eslint\` clean on both files.
- Independent code review: 0 Critical / 0 Important.
- Live mobile screenshot not captured (route is behind auth + beta gate).

OpenSpec: \`add-tailor-mobile-tabs\`.