### PR TITLE
feat(web): collapse tailor account rail into a burger drawer on mobile

### DIFF
--- a/openspec/changes/add-tailor-nav-drawer/.openspec.yaml
+++ b/openspec/changes/add-tailor-nav-drawer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/add-tailor-nav-drawer/proposal.md
+++ b/openspec/changes/add-tailor-nav-drawer/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+On the tailoring workspace the account icon rail (`AccountNavRail`) is pinned to
+the left edge at every width. On a phone that fixed ~56px column steals space
+from the already-cramped single-column view and is redundant with the new mobile
+tab bar. The rail should get out of the way on mobile and be reachable on demand,
+the way a mobile app hides its nav behind a burger.
+
+## What Changes
+
+- `AccountNavRail` gains an opt-in `collapsible` mode. Without it the rail renders
+  exactly as before at every width (so `/my/assistant` is unaffected). With it:
+  - at `lg` and up the icon rail shows as today;
+  - below `lg` the rail is hidden (freeing the width) and instead opens as a
+    labelled slide-in drawer over a dimmed backdrop, driven by a bindable `open`
+    flag. The drawer closes on backdrop click, `Escape`, its close button, or
+    following a link.
+- The tailoring workspace opts in (`collapsible bind:open`) and renders the
+  trigger — a burger button at the start of the mobile tab bar.
+
+Scoped to the tailoring workspace; `/my/assistant` keeps the always-on rail.
+No breaking changes — `collapsible`/`open` are additive and default to the prior
+behaviour.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `tailor-workspace`: below `lg` the account icon rail collapses into a
+  burger-triggered drawer instead of occupying a fixed left column.
+
+## Impact
+
+- **Frontend only:** `web/src/lib/components/AccountNavRail.svelte` (opt-in
+  `collapsible` + bindable `open`, desktop rail + mobile drawer, shared link
+  snippet) and `web/src/routes/tailor/[slug]/+page.svelte` (burger trigger in the
+  mobile tab bar, `collapsible bind:open`).
+- **Known limitation:** the burger lives in the mobile tab bar, which only
+  renders in the workspace's ready state, so during the brief loading/error
+  states there is no mobile nav trigger (the error state keeps its own back
+  link). `/my/assistant` is intentionally out of scope.

--- a/openspec/changes/add-tailor-nav-drawer/specs/tailor-workspace/spec.md
+++ b/openspec/changes/add-tailor-nav-drawer/specs/tailor-workspace/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: The account nav collapses to a drawer on mobile
+
+The tailoring workspace SHALL, below the `lg` breakpoint, hide the fixed account
+icon rail and instead expose the account sections through a burger button in the
+mobile tab bar that opens a labelled slide-in drawer over a dimmed backdrop. The
+drawer SHALL close on backdrop click, on `Escape`, on its close button, and after
+a nav link is followed. At `lg` and up the account icon rail SHALL render as
+before and no burger SHALL be shown.
+
+#### Scenario: The burger opens the account drawer on mobile
+
+- **WHEN** the workspace renders below `lg` and the user taps the burger in the mobile tab bar
+- **THEN** a labelled drawer of account sections slides in over a dimmed backdrop, and the fixed icon rail is not shown
+
+#### Scenario: The drawer dismisses
+
+- **WHEN** the drawer is open and the user taps the backdrop, presses `Escape`, taps the close button, or follows a link
+- **THEN** the drawer closes
+
+#### Scenario: The rail is unchanged at lg
+
+- **WHEN** the workspace renders at `lg` or wider
+- **THEN** the account icon rail shows on the left edge as before and no burger button is present

--- a/openspec/changes/add-tailor-nav-drawer/tasks.md
+++ b/openspec/changes/add-tailor-nav-drawer/tasks.md
@@ -1,0 +1,14 @@
+## 1. AccountNavRail — opt-in collapsible drawer
+
+- [x] 1.1 Add `open = $bindable(false)` and `collapsible = false` props; extract the rail link into a shared snippet (icon-only vs icon+label).
+- [x] 1.2 With `collapsible`: render the desktop icon rail `hidden … lg:flex`, and below `lg` a backdrop + labelled slide-in drawer gated on `open`; close on backdrop/Escape/close-button/link.
+- [x] 1.3 Without `collapsible`: render the rail exactly as before (assistant unaffected).
+
+## 2. Tailor page — burger trigger
+
+- [x] 2.1 Add `navOpen` state; render a burger button at the start of the mobile tab bar toggling it; pass `collapsible bind:open={navOpen}` to `AccountNavRail`.
+
+## 3. Verify
+
+- [x] 3.1 `npm run check` — 0 errors; `eslint` — clean on both files.
+- [ ] 3.2 Visual-verify on mobile (throwaway route + headless Chrome): burger opens the drawer, backdrop/Escape/link close it, desktop rail unchanged at `lg`, `/my/assistant` rail unchanged.

--- a/web/src/lib/components/AccountNavRail.svelte
+++ b/web/src/lib/components/AccountNavRail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
+  import { X } from '@lucide/svelte';
   import { isAuthenticated, currentUser } from '$lib/auth.svelte';
   import { visibleAccountNav, isSectionActive } from '$lib/accountNav';
   import { accountNavIcons } from '$lib/accountNavIcons';
@@ -8,39 +9,105 @@
 
   // A compact, icon-only mirror of the account-section navigation (see
   // my/+layout.svelte), pinned to the left edge of full-width surfaces that reset
-  // past the account shell — currently the Agent page. Same items, gating, order,
-  // and active rule as the sidebar; no labels, no collapse. Reuses the shared
-  // visible-nav model and icon map so there's one source of truth. Renders nothing
-  // for a signed-out visitor.
+  // past the account shell. Same items, gating, order, and active rule as the
+  // sidebar; reuses the shared visible-nav model and icon map so there's one source
+  // of truth. Renders nothing for a signed-out visitor.
+  //
+  // `collapsible` opts a host into responsive behaviour: at lg+ the icon rail shows
+  // as usual, but below lg it disappears (freeing the width) and instead opens as a
+  // labelled slide-in drawer driven by `open` — the host renders its own trigger
+  // (e.g. a burger in its header) and binds `open`. Without `collapsible` the rail
+  // renders exactly as before at every width.
+
+  let { open = $bindable(false), collapsible = false }: { open?: boolean; collapsible?: boolean } =
+    $props();
 
   const path = $derived(page.url.pathname);
   const navItems = $derived(
     visibleAccountNav(currentUser()?.role === 'moderator', currentUser()?.beta_tester ?? false),
   );
+
+  const close = () => (open = false);
+  const onKey = (e: KeyboardEvent) => {
+    if (open && e.key === 'Escape') close();
+  };
 </script>
 
-{#if isAuthenticated()}
-  <nav
-    aria-label="Account sections"
-    class="flex w-14 shrink-0 flex-col gap-1 overflow-y-auto border-r border-border bg-background p-2"
+{#snippet navLink(item: ReturnType<typeof visibleAccountNav>[number], withLabel: boolean)}
+  {@const active = isSectionActive(path, item.href)}
+  {@const Icon = accountNavIcons[item.href]}
+  <a
+    href={resolve(item.href)}
+    aria-current={active ? 'page' : undefined}
+    title={withLabel ? undefined : item.label}
+    onclick={withLabel ? close : undefined}
+    class={cn(
+      'flex items-center rounded-md transition-colors',
+      withLabel ? 'gap-3 px-3 py-2' : 'justify-center p-2',
+      active
+        ? 'bg-secondary text-secondary-foreground'
+        : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+    )}
   >
-    {#each navItems as item (item.href)}
-      {@const active = isSectionActive(path, item.href)}
-      {@const Icon = accountNavIcons[item.href]}
-      <a
-        href={resolve(item.href)}
-        aria-current={active ? 'page' : undefined}
-        title={item.label}
-        class={cn(
-          'flex items-center justify-center rounded-md p-2 transition-colors',
-          active
-            ? 'bg-secondary text-secondary-foreground'
-            : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-        )}
+    <Icon class="size-4 shrink-0" />
+    {#if withLabel}
+      <span class="text-sm">{item.label}</span>
+    {:else}
+      <span class="sr-only">{item.label}</span>
+    {/if}
+  </a>
+{/snippet}
+
+<svelte:window onkeydown={onKey} />
+
+{#if isAuthenticated()}
+  {#if collapsible}
+    <!-- Desktop icon rail (lg+): identical to the non-collapsible rail. -->
+    <nav
+      aria-label="Account sections"
+      class="hidden w-14 shrink-0 flex-col gap-1 overflow-y-auto border-r border-border bg-background p-2 lg:flex"
+    >
+      {#each navItems as item (item.href)}
+        {@render navLink(item, false)}
+      {/each}
+    </nav>
+
+    <!-- Mobile drawer (<lg): a labelled slide-in over a dimmed backdrop. -->
+    {#if open}
+      <button
+        type="button"
+        aria-label="Close menu"
+        onclick={close}
+        class="fixed inset-0 z-40 bg-black/40 lg:hidden"
+      ></button>
+      <nav
+        aria-label="Account sections"
+        class="fixed left-0 top-0 z-50 flex h-full w-64 flex-col gap-1 overflow-y-auto border-r border-border bg-background p-2 lg:hidden"
       >
-        <Icon class="size-4 shrink-0" />
-        <span class="sr-only">{item.label}</span>
-      </a>
-    {/each}
-  </nav>
+        <div class="mb-1 flex items-center justify-between px-2 py-1.5">
+          <span class="text-sm font-semibold text-foreground">Menu</span>
+          <button
+            type="button"
+            aria-label="Close menu"
+            onclick={close}
+            class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            <X class="size-4" />
+          </button>
+        </div>
+        {#each navItems as item (item.href)}
+          {@render navLink(item, true)}
+        {/each}
+      </nav>
+    {/if}
+  {:else}
+    <nav
+      aria-label="Account sections"
+      class="flex w-14 shrink-0 flex-col gap-1 overflow-y-auto border-r border-border bg-background p-2"
+    >
+      {#each navItems as item (item.href)}
+        {@render navLink(item, false)}
+      {/each}
+    </nav>
+  {/if}
 {/if}

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -12,7 +12,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import { ZoomIn, ZoomOut, Download } from '@lucide/svelte';
+  import { ZoomIn, ZoomOut, Download, Menu } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { createSession } from '$lib/assistant/api';
   import AssistantChat from '$lib/assistant/AssistantChat.svelte';
@@ -75,6 +75,10 @@
     ['verdict', 'Verdict'],
   ];
   let mobileView = $state<MobileView>('chat');
+
+  // Below lg the account icon rail collapses into a drawer opened by the burger in the mobile tab
+  // bar; AccountNavRail owns the drawer and binds this open flag.
+  let navOpen = $state(false);
   function pickMobile(v: MobileView) {
     mobileView = v;
     if (v === 'chat' || v === 'editor') leftTab = v;
@@ -248,7 +252,7 @@
 <!-- Full-width workspace loses the account shell nav; the same left-edge icon rail as
      the Agent page brings the account sections back. It stays put across every state. -->
 <div class="flex h-[calc(100svh-3.5rem)]">
-  <AccountNavRail />
+  <AccountNavRail collapsible bind:open={navOpen} />
   {#if status === 'loading'}
     <div class="flex min-w-0 flex-1 items-center justify-center text-sm text-muted-foreground">
       {resuming ? 'Re-opening your tailoring session…' : 'Preparing your tailoring session…'}
@@ -263,6 +267,17 @@
       <!-- MOBILE TAB BAR: below lg the three columns collapse to one full-screen view; this flat,
            horizontally-scrollable bar switches between all of them. Hidden at lg (columns stack). -->
       <nav class="flex items-center gap-1 overflow-x-auto border-b border-border bg-background px-2 py-1.5 text-sm lg:hidden">
+        <!-- Burger opens the account nav drawer (the icon rail is hidden below lg). -->
+        <button
+          type="button"
+          onclick={() => (navOpen = true)}
+          aria-label="Open menu"
+          aria-expanded={navOpen}
+          class="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Menu class="size-5" />
+        </button>
+        <span class="mr-0.5 h-5 w-px shrink-0 bg-border" aria-hidden="true"></span>
         {#each mobileTabs as [id, label] (id)}
           <button
             type="button"


### PR DESCRIPTION
## What

On the CV tailoring workspace the account icon rail (\`AccountNavRail\`) occupied a fixed ~56px left column at every width. On a phone that steals space from the single-column view and is redundant with the mobile tab bar. Below \`lg\` the rail now hides and is reachable on demand through a **burger button in the mobile tab bar** that opens a labelled slide-in **drawer** over a dimmed backdrop — like a mobile app's nav.

Scoped to the tailoring workspace. \`/my/assistant\` keeps its always-on rail.

## How

- \`AccountNavRail\` gains an opt-in \`collapsible\` mode + a bindable \`open\`. Without \`collapsible\` it renders exactly as before at every width (assistant unaffected). With it: desktop icon rail at \`lg+\`; below \`lg\` a backdrop + labelled slide-in drawer gated on \`open\`, closing on backdrop / \`Escape\` / close button / link-follow. The rail link is a shared snippet (icon-only vs icon+label).
- The tailor page renders the trigger (a \`Menu\` burger at the start of the mobile tab bar) and passes \`collapsible bind:open\`.

## Known limitation

The burger lives in the mobile tab bar, which only renders in the ready state, so the brief loading/error states have no mobile nav trigger (error keeps its own back link).

## Verification

- \`svelte-check\` 0 errors; \`eslint\` clean on both files.
- Live mobile screenshot not captured (route is behind auth + beta gate).

OpenSpec: \`add-tailor-nav-drawer\`. Follows #1083 (mobile tab bar).