### PR TITLE
chore(privacy): anonymize real PII in the blog + tests; fix detected-contact quality

### DIFF
--- a/docs/superpowers/specs/2026-07-22-pii-masking-cv-llm-design.md
+++ b/docs/superpowers/specs/2026-07-22-pii-masking-cv-llm-design.md
@@ -30,7 +30,7 @@ Ran the deterministic detectors against two real CVs (single-column and two-colu
 - **Plain-text name detection by "top-of-CV header" heuristic — INVALIDATED for
   multi-column layouts.** `pdftotext -layout` puts a section header (`ABOUT ME`) on the
   first line and pushes the visible name far down; worse, the full surname often appears
-  **only inside the email local-part / URL slug** (`alexbessmelcev`, `alex-bessmelcev`),
+  **only inside the email local-part / URL slug** (`jordanprice`, `jordan-price`),
   never as plain text. A regex/heuristic cannot reliably recover the name.
 
 **Consequence:** robust name/address detection needs a model that reads context. We use
@@ -43,9 +43,9 @@ Ran the real `openai/privacy-filter` (ONNX **q4**, `onnxruntime` on CPU, no torc
 the same two CVs. Labels are BIOES over 8 types (`private_person/email/phone/url/address`,
 `account_number`, `secret`, `private_date`).
 
-- **Ilya (single-column, 1542 tok, 2.2s):** `private_person: Ilya Strelov`, email, github/linkedin URLs.
+- **Ilya (single-column, 1542 tok, 2.2s):** `private_person: Ada Lovelace`, email, github/linkedin URLs.
 - **Alex (two-column, 1166 tok, 0.9s):** recovered the hidden surname — `private_person:
-  alex-bessmelcev`, `/alex-bessmelcev`, `@Alex_Sage`; email + portfolio URL. (Bare
+  jordan-price`, `/jordan-price`, `@jprice_dev`; email + portfolio URL. (Bare
   first-name "Alex" alone was not tagged — a weak identifier, and it is covered by the
   caught spans anyway.)
 - **No over-redaction:** employers (RingCentral, Informa, emcd.io), universities, and

--- a/internal/pii/detect_test.go
+++ b/internal/pii/detect_test.go
@@ -28,27 +28,27 @@ func TestRegexSpans(t *testing.T) {
 	}{
 		{
 			name: "email",
-			text: "reach me at strelov1@gmail.com anytime",
+			text: "reach me at ada.lovelace@example.com anytime",
 			kind: KindEmail,
-			want: []string{"strelov1@gmail.com"},
+			want: []string{"ada.lovelace@example.com"},
 		},
 		{
 			name: "linkedin and github urls",
-			text: "linkedin.com/in/istrelov | github.com/strelov1",
+			text: "linkedin.com/in/adalovelace | github.com/adalovelace",
 			kind: KindLink,
-			want: []string{"github.com/strelov1", "linkedin.com/in/istrelov"},
+			want: []string{"github.com/adalovelace", "linkedin.com/in/adalovelace"},
 		},
 		{
 			name: "https portfolio url",
-			text: "portfolio: https://alex-bes.vercel.app/ here",
+			text: "portfolio: https://portfolio.example.dev/ here",
 			kind: KindLink,
-			want: []string{"https://alex-bes.vercel.app/"},
+			want: []string{"https://portfolio.example.dev/"},
 		},
 		{
 			name: "telegram handle",
-			text: "ping @Alex_Sage on tg",
+			text: "ping @jprice_dev on tg",
 			kind: KindLink,
-			want: []string{"@Alex_Sage"},
+			want: []string{"@jprice_dev"},
 		},
 		{
 			name: "phone with country code",

--- a/internal/pii/failclosed_test.go
+++ b/internal/pii/failclosed_test.go
@@ -14,13 +14,13 @@ func (errDetector) Detect(context.Context, string) ([]Span, error) {
 }
 
 func TestBuildFailsClosedWhenDetectorNil(t *testing.T) {
-	if _, err := Build(context.Background(), "Ilya Strelov", Contacts{}, nil); err == nil {
+	if _, err := Build(context.Background(), "Ada Lovelace", Contacts{}, nil); err == nil {
 		t.Fatal("expected error for nil detector (fail-closed), got nil")
 	}
 }
 
 func TestBuildFailsClosedWhenDetectorErrors(t *testing.T) {
-	_, err := Build(context.Background(), "Ilya Strelov", Contacts{}, errDetector{})
+	_, err := Build(context.Background(), "Ada Lovelace", Contacts{}, errDetector{})
 	if err == nil {
 		t.Fatal("expected error when detector fails (fail-closed), got nil")
 	}

--- a/internal/pii/findings_test.go
+++ b/internal/pii/findings_test.go
@@ -8,9 +8,9 @@ import (
 // Finding 1: a detected value that abuts a word character in the text must still be masked
 // (word-boundary anchoring must never leave PII in the prompt).
 func TestRedactMasksValueAbuttingWordChar(t *testing.T) {
-	text := "mail: strelov1@gmail.com2024 archived"
+	text := "mail: ada.lovelace@example.com2024 archived"
 	r := mustBuild(t, text, Contacts{}, nameDetector{})
-	if masked := r.Redact(text); strings.Contains(masked, "strelov1@gmail.com") {
+	if masked := r.Redact(text); strings.Contains(masked, "ada.lovelace@example.com") {
 		t.Fatalf("email abutting a digit leaked: %q", masked)
 	}
 }

--- a/internal/pii/redactor.go
+++ b/internal/pii/redactor.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 // Contacts are the caller's authoritative contact values (e.g. from a structured résumé).
@@ -129,12 +130,15 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 // (a name, an address), so word-boundary matching is worth attempting to avoid over-redaction.
 var wordyKind = map[string]bool{KindName: true, KindAddress: true}
 
-// fillContact records a detected value into c: the first name/email/phone wins, every link
-// is collected. Called only for detected spans, so c reflects the CV, not known input.
+// fillContact records a detected value into c: the first plausible name/email/phone wins,
+// and each distinct clean link is collected. Called only for detected spans, so c reflects
+// the CV, not known input. It is defensive because the model mis-tags handles/slugs as a
+// person and its URL spans sometimes swallow neighbouring text — the redactor still masks
+// every span, but only well-formed values become the caller's stored contact fields.
 func fillContact(c *Contacts, kind, v string) {
 	switch kind {
 	case KindName:
-		if c.FullName == "" {
+		if c.FullName == "" && isPlausibleName(v) {
 			c.FullName = v
 		}
 	case KindEmail:
@@ -146,8 +150,46 @@ func fillContact(c *Contacts, kind, v string) {
 			c.Phone = v
 		}
 	case KindLink:
-		c.Links = append(c.Links, v)
+		if isCleanLink(v) && !containsString(c.Links, v) {
+			c.Links = append(c.Links, v)
+		}
 	}
+}
+
+// isPlausibleName reports whether v reads like a real full name: at least two
+// whitespace-separated tokens of letters (and name punctuation), and none of the @ / :
+// characters that mark a handle, slug, or URL the model sometimes classifies as a person.
+func isPlausibleName(v string) bool {
+	if strings.ContainsAny(v, "@/:") {
+		return false
+	}
+	fields := strings.Fields(v)
+	if len(fields) < 2 {
+		return false
+	}
+	for _, f := range fields {
+		for _, r := range f {
+			if !unicode.IsLetter(r) && r != '-' && r != '.' && r != '\'' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// isCleanLink rejects a link/handle carrying internal whitespace — the sign of a model span
+// that grabbed surrounding text (a well-formed URL or @handle has none).
+func isCleanLink(v string) bool {
+	return v != "" && !strings.ContainsAny(v, " \t\n\r")
+}
+
+func containsString(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 // Redact replaces every detected PII value in text with its placeholder. A nil Redactor is

--- a/internal/pii/redactor_test.go
+++ b/internal/pii/redactor_test.go
@@ -29,11 +29,11 @@ func mustBuild(t *testing.T, text string, known Contacts, d Detector) *Redactor 
 }
 
 func TestRedactMasksAllPII(t *testing.T) {
-	cv := "Ilya Strelov\nstrelov1@gmail.com | github.com/strelov1\nSenior Engineer at RingCentral in London"
-	r := mustBuild(t, cv, Contacts{}, nameDetector{names: []string{"Ilya Strelov"}})
+	cv := "Ada Lovelace\nada.lovelace@example.com | github.com/adalovelace\nSenior Engineer at RingCentral in London"
+	r := mustBuild(t, cv, Contacts{}, nameDetector{names: []string{"Ada Lovelace"}})
 	masked := r.Redact(cv)
 
-	for _, leak := range []string{"Ilya Strelov", "strelov1@gmail.com", "github.com/strelov1"} {
+	for _, leak := range []string{"Ada Lovelace", "ada.lovelace@example.com", "github.com/adalovelace"} {
 		if strings.Contains(masked, leak) {
 			t.Errorf("masked text still contains PII %q:\n%s", leak, masked)
 		}
@@ -47,8 +47,8 @@ func TestRedactMasksAllPII(t *testing.T) {
 }
 
 func TestRestoreRoundTrip(t *testing.T) {
-	cv := "Ilya Strelov — strelov1@gmail.com — github.com/strelov1"
-	r := mustBuild(t, cv, Contacts{}, nameDetector{names: []string{"Ilya Strelov"}})
+	cv := "Ada Lovelace — ada.lovelace@example.com — github.com/adalovelace"
+	r := mustBuild(t, cv, Contacts{}, nameDetector{names: []string{"Ada Lovelace"}})
 	if got := r.Restore(r.Redact(cv)); got != cv {
 		t.Fatalf("round-trip mismatch:\n got %q\nwant %q", got, cv)
 	}
@@ -73,12 +73,12 @@ func TestDistinctValuesGetDistinctPlaceholders(t *testing.T) {
 func TestKnownContactsMaskedInOtherText(t *testing.T) {
 	// The CV text the Redactor is built from, plus a separate structured-JSON blob that
 	// carries the same contacts — both must mask with the SAME redactor (matchanalysis case).
-	cv := "Ilya Strelov works remotely"
-	structured := `{"full_name":"Ilya Strelov","email":"strelov1@gmail.com"}`
-	known := Contacts{FullName: "Ilya Strelov", Email: "strelov1@gmail.com"}
-	r := mustBuild(t, cv, known, nameDetector{names: []string{"Ilya Strelov"}})
+	cv := "Ada Lovelace works remotely"
+	structured := `{"full_name":"Ada Lovelace","email":"ada.lovelace@example.com"}`
+	known := Contacts{FullName: "Ada Lovelace", Email: "ada.lovelace@example.com"}
+	r := mustBuild(t, cv, known, nameDetector{names: []string{"Ada Lovelace"}})
 	masked := r.Redact(structured)
-	if strings.Contains(masked, "Ilya Strelov") || strings.Contains(masked, "strelov1@gmail.com") {
+	if strings.Contains(masked, "Ada Lovelace") || strings.Contains(masked, "ada.lovelace@example.com") {
 		t.Fatalf("known contacts leaked in structured blob: %s", masked)
 	}
 }

--- a/internal/pii/redactor_test.go
+++ b/internal/pii/redactor_test.go
@@ -83,6 +83,37 @@ func TestKnownContactsMaskedInOtherText(t *testing.T) {
 	}
 }
 
+// spansDetector returns a fixed span set, to reproduce messy real-CV detections.
+type spansDetector struct{ spans []Span }
+
+func (d spansDetector) Detect(_ context.Context, _ string) ([]Span, error) { return d.spans, nil }
+
+func TestContacts_RejectsHandleNameAndCleansLinks(t *testing.T) {
+	// A handle the model mis-tags as a person, a duplicate link, and a garbled model link
+	// span that swallowed surrounding text — as seen on a real two-column CV.
+	text := "@jprice_dev github.com/alex CONTACTS\n https://x.io"
+	det := spansDetector{spans: []Span{
+		{Start: 0, End: 10, Kind: KindName},         // "@jprice_dev" — not a real name
+		{Start: 11, End: 26, Kind: KindLink},        // "github.com/alex" (dup of regex)
+		{Start: 27, End: len(text), Kind: KindLink}, // "CONTACTS\n https://x.io" — garbled
+	}}
+	c := mustBuild(t, text, Contacts{}, det).Contacts()
+
+	if c.FullName != "" {
+		t.Errorf("FullName = %q, want empty (a @handle is not a name)", c.FullName)
+	}
+	seen := map[string]bool{}
+	for _, l := range c.Links {
+		if seen[l] {
+			t.Errorf("duplicate link %q in %v", l, c.Links)
+		}
+		seen[l] = true
+		if strings.ContainsAny(l, " \t\n") {
+			t.Errorf("garbled link with whitespace: %q", l)
+		}
+	}
+}
+
 func TestContactsFromDetectedSpans(t *testing.T) {
 	cv := "Ivan Petrov ivan@petrov.io github.com/ivanp linkedin.com/in/ivanp"
 	r := mustBuild(t, cv, Contacts{}, nameDetector{names: []string{"Ivan Petrov"}})

--- a/openspec/changes/archive/2026-07-14-assistant-multi-session/design.md
+++ b/openspec/changes/archive/2026-07-14-assistant-multi-session/design.md
@@ -125,7 +125,7 @@ page.
    column) — apply to prod **manually before deploying** the hire backend, per
    the migrations convention. Then grant the first members out-of-band:
    ```sql
-   UPDATE users SET beta_tester = true WHERE lower(email) = 'strelov1@gmail.com';
+   UPDATE users SET beta_tester = true WHERE lower(email) = 'ada.lovelace@example.com';
    ```
    (Repeat the `UPDATE` per email to add more testers.) No new env.
 4. Rollback = revert each repo independently (the frontend guard makes the

--- a/openspec/changes/archive/2026-07-14-assistant-multi-session/tasks.md
+++ b/openspec/changes/archive/2026-07-14-assistant-multi-session/tasks.md
@@ -30,7 +30,7 @@
 - [x] 6.4 `internal/handler/auth.go`: add `BetaTester bool \`json:"beta_tester"\`` to `userResponse` and map it in `toUserResponse` (unit test the mapping, mirroring `TestToUserResponse_IncludesRole`).
 - [x] 6.5 Frontend: add `beta_tester: boolean` to the `User` type (`web/src/lib/types.ts`); change the assistant `accountNav` item from `moderatorOnly` to `betaOnly` and extend `visibleAccountNav(isModerator, isBetaTester)` — RED-first in `accountNav.test.ts` (beta-only Assistant vs moderator-only Inbox); update the `my/+layout.svelte` caller.
 - [x] 6.6 Gate the page: `+page.svelte` guards on `currentUser()?.beta_tester` (not `role === 'moderator'`); adjust the restricted-rollout copy.
-- [x] 6.7 Grant SQL documented in `design.md` Migration Plan (`UPDATE users SET beta_tester = true WHERE lower(email) = 'strelov1@gmail.com';`). Local-DB apply + grant verification pending (needs the stack up).
+- [x] 6.7 Grant SQL documented in `design.md` Migration Plan (`UPDATE users SET beta_tester = true WHERE lower(email) = 'ada.lovelace@example.com';`). Local-DB apply + grant verification pending (needs the stack up).
 
 ## 5. Verify & finish
 

--- a/web/src/posts/2026-07-22-ai-reads-your-cv-without-your-name.svx
+++ b/web/src/posts/2026-07-22-ai-reads-your-cv-without-your-name.svx
@@ -26,12 +26,12 @@ if we can't de-identify it, we don't send it.
 Email, phone and URLs are easy: a handful of patterns catches them cleanly. We tested it, and
 it held.
 
-The name is the hard part. We ran the same detector against two real CVs. On a single-column
-layout it found the name fine. On a two-column CV it fell apart: the layout put a section
-header on the first line and pushed the name down, and the person's surname appeared **nowhere
-as plain text** — it lived only inside their email (`alexbessmelcev@gmail.com`) and a profile
-URL (`/alex-bessmelcev`). No pattern-matching rule recovers a name that the document never
-spells out.
+The name is the hard part. We ran the same detector against two real CVs (anonymized here).
+On a single-column layout it found the name fine. On a two-column CV it fell apart: the layout
+put a section header on the first line and pushed the name down, and the person's surname
+appeared **nowhere as plain text** — it lived only inside their email (`jordanprice@example.com`)
+and a profile URL (`/jordan-price`). No pattern-matching rule recovers a name that the document
+never spells out.
 
 That's the verdict that shaped the design: a pattern-matcher is a floor, not the whole
 solution. Names need a model that reads context.


### PR DESCRIPTION
Two things:

1. **Anonymize real people's data (urgent — it's in the published blog).** The privacy article `2026-07-22-ai-reads-your-cv-without-your-name` quoted a real person's email/URL, and the `internal/pii` spike tests + design doc hardcoded real names/emails/handles (mine + a spike CV's). This is an **open-source repo**, so all of it was public. Replaced with fake placeholders (`Ada Lovelace`, `jordanprice@example.com`, etc.) everywhere; also scrubbed an archived change's grant SQL.
2. **Fix detected-contact quality** (`pii.fillContact`). Verified against real CVs: the model mis-tags `@handles`/URL slugs as a person (so `FullName` became a handle) and its URL spans sometimes swallow neighbouring text (garbled/duplicate links). `fillContact` now only accepts a plausible full name (≥2 letter tokens, no `@/:`) and collects distinct, whitespace-free links.

`go build/vet/test` green; web build green (blog compiles).