### PR TITLE
feat(web): Worldwide label + globe icon for the global region pill

### DIFF
--- a/web/src/lib/components/filters/LocationPane.svelte
+++ b/web/src/lib/components/filters/LocationPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ChevronDown, Search, X } from '@lucide/svelte';
+  import { ChevronDown, Globe, Search, X } from '@lucide/svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import { countryLabel, REGION_UNSPECIFIED, type FacetStore } from '$lib/facets';
   import { REGION_LABELS } from '$lib/labels';
@@ -170,8 +170,9 @@
         type="button"
         onclick={() => store.cycle('regions', code)}
         title={pillTitle(rInc, rExc, true)}
-        class={pillClass(rInc || rExc, rExc, 'px-3 py-1.5 text-sm')}
+        class={pillClass(rInc || rExc, rExc, 'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm')}
       >
+        {#if code === 'global'}<Globe class="size-4 shrink-0" />{/if}
         {regionLabel(code)}
       </button>
     {/each}

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -7,7 +7,7 @@
 // in sync with the backend vocabulary.
 
 export const REGION_LABELS: Record<string, string> = {
-  global: 'Global/Worldwide',
+  global: 'Worldwide',
   north_america: 'North America',
   latam: 'LATAM',
   eu: 'Europe',


### PR DESCRIPTION
## What

- Region label `global` renamed from **Global/Worldwide** → **Worldwide** in the shared `REGION_LABELS` map (`labels.ts`), so the shorter label propagates everywhere it's read (location filter, card tags, job-detail Region row, header scope).
- A lucide `Globe` icon (SVG, not an emoji) now renders before the **Worldwide** pill in the Location filter, mirroring how country pills show a flag — same `inline-flex items-center gap-1.5` idiom already used for the neighbouring country pills in `LocationPane`.

## Why

The `Global/Worldwide` double label was redundant, and the pill sat icon-less right beside flag-bearing country pills. `code === 'global'` gates the globe so the neighbouring `Not specified` flat pill stays plain.

## Verify

- `eslint` clean on both files.
- No remaining `Global/Worldwide` references.