### PR TITLE
ds: phase 4 — component primitives

### DIFF
--- a/design-system/package.json
+++ b/design-system/package.json
@@ -7,7 +7,13 @@
   "packageManager": "pnpm@11.7.0",
   "exports": {
     "./dist/*": "./dist/*",
-    "./tokens/*": "./tokens/*"
+    "./tokens/*": "./tokens/*",
+    ".": {
+      "types": "./src/index.ts",
+      "svelte": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": "./src/*"
   },
   "scripts": {
     "build": "pnpm tokens:build",
@@ -19,5 +25,12 @@
   },
   "devDependencies": {
     "style-dictionary": "^5.5.0"
+  },
+  "dependencies": {
+    "@lucide/svelte": "^1.25.0",
+    "clsx": "^2.1.1",
+    "svelte": "^5.56.7",
+    "tailwind-merge": "^3.6.0",
+    "tailwind-variants": "^3.2.2"
   }
 }

--- a/design-system/pnpm-lock.yaml
+++ b/design-system/pnpm-lock.yaml
@@ -7,6 +7,22 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@lucide/svelte':
+        specifier: ^1.25.0
+        version: 1.25.0(svelte@5.56.7)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      svelte:
+        specifier: ^5.56.7
+        version: 5.56.7
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+      tailwind-variants:
+        specifier: ^3.2.2
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
     devDependencies:
       style-dictionary:
         specifier: ^5.5.0
@@ -22,6 +38,22 @@ packages:
 
   '@bundled-es-modules/memfs@4.17.0':
     resolution: {integrity: sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
@@ -143,15 +175,44 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@lucide/svelte@1.25.0':
+    resolution: {integrity: sha512-v9m+dD68jxVnqkU3K59mG/RSRFlPGzmKCGSyMfnXcaGv9jODDQMyQkcp1CGvk3Y/cUj9v7f8rw1n//K0B53xGQ==}
+    peerDependencies:
+      svelte: ^5
+
+  '@sveltejs/acorn-typescript@1.0.11':
+    resolution: {integrity: sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@zip.js/zip.js@2.8.33':
     resolution: {integrity: sha512-Mc+s4DdDl9lmhFmkOmNDryC/b4rZm7y2/qBUQTCwPYGkQ8dkCeykILqEYBd+14ATuj93XWZJBrPe2x+cF9LcGA==}
     engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
 
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
   balanced-match@4.0.4:
@@ -187,6 +248,10 @@ packages:
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
 
@@ -210,6 +275,9 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  devalue@5.8.2:
+    resolution: {integrity: sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -225,6 +293,17 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esrap@2.3.0:
+    resolution: {integrity: sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -311,6 +390,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -324,9 +406,15 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -429,6 +517,26 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  svelte@5.56.7:
+    resolution: {integrity: sha512-5qERUZX80oQj6XrDMUmD2Uhd/cIpCPDWWKBK3ZHmyRUC9apPyamWM8xMo31mbWsIQxwG2hVoSnOJ/EcnhVkkzQ==}
+    engines: {node: '>=18'}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwind-variants@3.2.2:
+    resolution: {integrity: sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwind-merge: '>=3.0.0'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      tailwind-merge:
+        optional: true
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
   thingies@2.6.0:
     resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
     engines: {node: '>=10.18'}
@@ -461,6 +569,9 @@ packages:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
 
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
 snapshots:
 
   '@bundled-es-modules/deepmerge@4.3.2':
@@ -488,6 +599,25 @@ snapshots:
       util: 0.12.5
     transitivePeerDependencies:
       - tslib
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
@@ -617,7 +747,23 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@lucide/svelte@1.25.0(svelte@5.56.7)':
+    dependencies:
+      svelte: 5.56.7
+
+  '@sveltejs/acorn-typescript@1.0.11(acorn@8.17.0)':
+    dependencies:
+      acorn: 8.17.0
+
+  '@types/estree@1.0.9': {}
+
+  '@types/trusted-types@2.0.7': {}
+
   '@zip.js/zip.js@2.8.33': {}
+
+  acorn@8.17.0: {}
+
+  aria-query@5.3.1: {}
 
   assert@2.1.0:
     dependencies:
@@ -630,6 +776,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axobject-query@4.1.0: {}
 
   balanced-match@4.0.4: {}
 
@@ -665,6 +813,8 @@ snapshots:
 
   change-case@5.4.4: {}
 
+  clsx@2.1.1: {}
+
   colorjs.io@0.5.2: {}
 
   commander@12.1.0: {}
@@ -685,6 +835,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  devalue@5.8.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -698,6 +850,12 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  esm-env@1.2.2: {}
+
+  esrap@2.3.0:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   events@3.3.0: {}
 
@@ -783,6 +941,10 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -796,7 +958,13 @@ snapshots:
 
   json5@2.2.3: {}
 
+  locate-character@3.0.0: {}
+
   lru-cache@11.5.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -937,6 +1105,37 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
+  svelte@5.56.7:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.17.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.2
+      esm-env: 1.2.2
+      esrap: 2.3.0
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  tailwind-merge@3.6.0: {}
+
+  tailwind-variants@3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3):
+    dependencies:
+      tailwindcss: 4.3.3
+    optionalDependencies:
+      tailwind-merge: 3.6.0
+
+  tailwindcss@4.3.3: {}
+
   thingies@2.6.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
@@ -975,3 +1174,5 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+
+  zimmerframe@1.1.4: {}

--- a/design-system/src/alert.svelte
+++ b/design-system/src/alert.svelte
@@ -1,0 +1,32 @@
+<script lang="ts" module>
+  import { tv, type VariantProps } from 'tailwind-variants';
+
+  export const alertVariants = tv({
+    base: 'flex items-start gap-3 rounded-lg border p-4 text-sm',
+    variants: {
+      variant: {
+        default: 'border-border bg-card text-foreground',
+        destructive: 'border-destructive/30 bg-destructive/5 text-destructive',
+        brand: 'border-brand/30 bg-brand-muted text-brand-strong',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  });
+
+  export type AlertVariant = VariantProps<typeof alertVariants>['variant'];
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    variant = 'default',
+    class: className,
+    children,
+  }: { variant?: AlertVariant; class?: string; children: Snippet } = $props();
+</script>
+
+<div role="alert" class={cn(alertVariants({ variant }), className)}>
+  {@render children()}
+</div>

--- a/design-system/src/avatar.svelte
+++ b/design-system/src/avatar.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { cn } from './cn.js';
+
+  // Deterministic color from a string — uses the hue range of the brand
+  // palette so avatars feel on-brand rather than random rainbow.
+  let {
+    name,
+    src,
+    size = 'md',
+    class: className,
+  }: {
+    name?: string;
+    src?: string;
+    size?: 'sm' | 'md' | 'lg';
+    class?: string;
+  } = $props();
+
+  const sizes = {
+    sm: 'size-8 text-xs',
+    md: 'size-10 text-sm',
+    lg: 'size-12 text-base',
+  };
+
+  function hashHue(s: string): number {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) {
+      h = (h * 31 + s.charCodeAt(i)) | 0;
+    }
+    return Math.abs(h) % 360;
+  }
+
+  let initials = $derived(
+    name
+      ? name
+          .split(' ')
+          .slice(0, 2)
+          .map((w) => w[0]?.toUpperCase() ?? '')
+          .join('')
+      : '?',
+  );
+
+  let bg = $derived(
+    name
+      ? `hsl(${hashHue(name)} 45% 90%)`
+      : 'hsl(0 0% 90%)',
+  );
+</script>
+
+{#if src}
+  <img {src} alt={name ?? 'avatar'} class={cn('rounded-full object-cover', sizes[size], className)} />
+{:else}
+  <div
+    class={cn('flex items-center justify-center rounded-full font-medium text-foreground', sizes[size], className)}
+    style="background-color: {bg}"
+    aria-label={name ?? 'avatar'}
+  >
+    {initials}
+  </div>
+{/if}

--- a/design-system/src/avatar.svelte
+++ b/design-system/src/avatar.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { cn } from './cn.js';
 
-  // Deterministic color from a string — uses the hue range of the brand
-  // palette so avatars feel on-brand rather than random rainbow.
   let {
     name,
     src,
@@ -21,6 +19,9 @@
     lg: 'size-12 text-base',
   };
 
+  // Deterministic hue from the name, across the full circle — what keeps the
+  // result calm is the fixed low saturation and high lightness below, not the
+  // hue itself. Kept as an inline colour because a token per hue makes no sense.
   function hashHue(s: string): number {
     let h = 0;
     for (let i = 0; i < s.length; i++) {

--- a/design-system/src/badge.svelte
+++ b/design-system/src/badge.svelte
@@ -19,7 +19,7 @@
 
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { cn } from '$lib/utils';
+  import { cn } from './cn.js';
 
   let {
     variant = 'secondary',

--- a/design-system/src/button.svelte
+++ b/design-system/src/button.svelte
@@ -27,7 +27,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
-  import { cn } from '$lib/utils';
+  import { cn } from './cn.js';
 
   type Props = {
     variant?: ButtonVariant;

--- a/design-system/src/card.svelte
+++ b/design-system/src/card.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    class: className,
+    children,
+  }: { class?: string; children: Snippet } = $props();
+</script>
+
+<div
+  class={cn('rounded-lg border border-border bg-card text-card-foreground shadow-sm', className)}
+>
+  {@render children()}
+</div>

--- a/design-system/src/chip.svelte
+++ b/design-system/src/chip.svelte
@@ -1,0 +1,34 @@
+<script lang="ts" module>
+  import { tv, type VariantProps } from 'tailwind-variants';
+
+  export const chipVariants = tv({
+    base: 'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors',
+    variants: {
+      variant: {
+        default: 'border-border bg-muted text-foreground',
+        primary: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        brand: 'border-transparent bg-brand-muted text-brand-strong',
+        destructive: 'border-destructive/20 bg-destructive/10 text-destructive',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  });
+
+  export type ChipVariant = VariantProps<typeof chipVariants>['variant'];
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    variant = 'default',
+    class: className,
+    children,
+  }: { variant?: ChipVariant; class?: string; children: Snippet } = $props();
+</script>
+
+<span class={cn(chipVariants({ variant }), className)}>
+  {@render children()}
+</span>

--- a/design-system/src/cn.ts
+++ b/design-system/src/cn.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/** Merge Tailwind class lists, resolving conflicts (last wins). */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/design-system/src/dialog.svelte
+++ b/design-system/src/dialog.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+  import { X } from '@lucide/svelte';
+
+  let {
+    open = $bindable(false),
+    title,
+    description,
+    class: className,
+    children,
+  }: {
+    open?: boolean;
+    title?: string;
+    description?: string;
+    class?: string;
+    children: Snippet;
+  } = $props();
+
+  function close() {
+    open = false;
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && open) {
+      e.preventDefault();
+      close();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+{#if open}
+  <div
+    class="fixed inset-0 z-modal bg-black/50 backdrop-blur-sm"
+    onclick={(e) => { if (e.currentTarget === e.target) close(); }}
+    role="button"
+    tabindex="-1"
+    aria-label="Close dialog"
+  ></div>
+  <div
+    role="dialog"
+    aria-modal="true"
+    aria-label={title}
+    class={cn(
+      'fixed left-1/2 top-1/2 z-popover w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 shadow-lg',
+      className,
+    )}
+  >
+    {#if title}
+      <h2 class="text-lg font-semibold">{title}</h2>
+    {/if}
+    {#if description}
+      <p class="mt-1 text-sm text-muted-foreground">{description}</p>
+    {/if}
+    <div class="mt-4">
+      {@render children()}
+    </div>
+    <button
+      type="button"
+      class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100"
+      onclick={close}
+    aria-label="Close"
+  >
+    <X class="size-4" />
+  </button>
+  </div>
+{/if}

--- a/design-system/src/dialog.svelte
+++ b/design-system/src/dialog.svelte
@@ -17,53 +17,66 @@
     children: Snippet;
   } = $props();
 
-  function close() {
-    open = false;
-  }
+  const uid = $props.id();
+  const titleId = `${uid}-title`;
+  const descriptionId = `${uid}-description`;
 
-  function onKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape' && open) {
-      e.preventDefault();
-      close();
-    }
+  let el: HTMLDialogElement | undefined = $state();
+
+  // showModal() puts the dialog in the top layer and hands us the focus trap,
+  // the inert background, Escape-to-close and focus restore. Reimplementing
+  // any of that by hand is strictly worse.
+  $effect(() => {
+    if (!el) return;
+    if (open && !el.open) el.showModal();
+    if (!open && el.open) el.close();
+  });
+
+  // The one thing showModal() does not do is stop the page behind from scrolling.
+  $effect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  });
+
+  // The backdrop is a pseudo-element of the dialog, so clicks on it surface as
+  // clicks on <dialog> itself; everything inside lands on the padded wrapper.
+  function onclick(e: MouseEvent) {
+    if (e.target === el) open = false;
   }
 </script>
 
-<svelte:window onkeydown={onKeydown} />
-
-{#if open}
-  <div
-    class="fixed inset-0 z-modal bg-black/50 backdrop-blur-sm"
-    onclick={(e) => { if (e.currentTarget === e.target) close(); }}
-    role="button"
-    tabindex="-1"
-    aria-label="Close dialog"
-  ></div>
-  <div
-    role="dialog"
-    aria-modal="true"
-    aria-label={title}
-    class={cn(
-      'fixed left-1/2 top-1/2 z-popover w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 shadow-lg',
-      className,
-    )}
-  >
+<dialog
+  bind:this={el}
+  aria-labelledby={title ? titleId : undefined}
+  aria-describedby={description ? descriptionId : undefined}
+  onclose={() => (open = false)}
+  {onclick}
+  class={cn(
+    'm-auto w-full max-w-lg rounded-lg border border-border bg-card p-0 text-card-foreground shadow-lg backdrop:bg-black/50 backdrop:backdrop-blur-sm',
+    className,
+  )}
+>
+  <div class="relative p-6">
     {#if title}
-      <h2 class="text-lg font-semibold">{title}</h2>
+      <h2 id={titleId} class="text-lg font-semibold">{title}</h2>
     {/if}
     {#if description}
-      <p class="mt-1 text-sm text-muted-foreground">{description}</p>
+      <p id={descriptionId} class="mt-1 text-sm text-muted-foreground">{description}</p>
     {/if}
     <div class="mt-4">
       {@render children()}
     </div>
     <button
       type="button"
-      class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100"
-      onclick={close}
-    aria-label="Close"
-  >
-    <X class="size-4" />
-  </button>
+      class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      onclick={() => (open = false)}
+      aria-label="Close"
+    >
+      <X class="size-4" />
+    </button>
   </div>
-{/if}
+</dialog>

--- a/design-system/src/empty-state.svelte
+++ b/design-system/src/empty-state.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    title = 'Nothing here yet',
+    description,
+    icon,
+    class: className,
+    action,
+  }: {
+    title?: string;
+    description?: string;
+    icon?: Snippet;
+    class?: string;
+    action?: Snippet;
+  } = $props();
+</script>
+
+<div
+  class={cn('flex flex-col items-center justify-center gap-3 py-12 text-center', className)}
+  role="status"
+>
+  {#if icon}
+    <div class="text-muted-foreground">
+      {@render icon()}
+    </div>
+  {/if}
+  <p class="text-sm font-medium text-foreground">{title}</p>
+  {#if description}
+    <p class="max-w-sm text-sm text-muted-foreground">{description}</p>
+  {/if}
+  {#if action}
+    <div class="mt-2">
+      {@render action()}
+    </div>
+  {/if}
+</div>

--- a/design-system/src/form-field.svelte
+++ b/design-system/src/form-field.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    label,
+    error,
+    hint,
+    required = false,
+    class: className,
+    children,
+  }: {
+    label?: string;
+    error?: string;
+    hint?: string;
+    required?: boolean;
+    class?: string;
+    children: Snippet;
+  } = $props();
+
+  let id = `field-${crypto.randomUUID().slice(0, 8)}`;
+</script>
+
+<div class={cn('flex flex-col gap-1.5', className)}>
+  {#if label}
+    <label for={id} class="text-sm font-medium">
+      {label}
+      {#if required}
+        <span class="text-destructive">*</span>
+      {/if}
+    </label>
+  {/if}
+  {@render children()}
+  {#if error}
+    <p class="text-sm text-destructive" role="alert">{error}</p>
+  {:else if hint}
+    <p class="text-sm text-muted-foreground">{hint}</p>
+  {/if}
+</div>

--- a/design-system/src/form-field.svelte
+++ b/design-system/src/form-field.svelte
@@ -15,10 +15,15 @@
     hint?: string;
     required?: boolean;
     class?: string;
-    children: Snippet;
+    /** Receives the ids to spread onto the control: `{@render children({ id, describedBy })}`. */
+    children: Snippet<[{ id: string; describedBy: string | undefined }]>;
   } = $props();
 
-  let id = `field-${crypto.randomUUID().slice(0, 8)}`;
+  // $props.id() is stable across SSR and hydration — crypto.randomUUID() is not.
+  const uid = $props.id();
+  const id = `${uid}-control`;
+  const messageId = `${uid}-message`;
+  let describedBy = $derived(error || hint ? messageId : undefined);
 </script>
 
 <div class={cn('flex flex-col gap-1.5', className)}>
@@ -30,10 +35,10 @@
       {/if}
     </label>
   {/if}
-  {@render children()}
+  {@render children({ id, describedBy })}
   {#if error}
-    <p class="text-sm text-destructive" role="alert">{error}</p>
+    <p id={messageId} class="text-sm text-destructive" role="alert">{error}</p>
   {:else if hint}
-    <p class="text-sm text-muted-foreground">{hint}</p>
+    <p id={messageId} class="text-sm text-muted-foreground">{hint}</p>
   {/if}
 </div>

--- a/design-system/src/index.ts
+++ b/design-system/src/index.ts
@@ -1,0 +1,29 @@
+// Utilities
+export { cn } from './cn.js';
+
+// Primitives
+export { default as Avatar } from './avatar.svelte';
+export { default as Badge } from './badge.svelte';
+export { default as Button } from './button.svelte';
+export { default as Card } from './card.svelte';
+export { default as Chip } from './chip.svelte';
+export { default as Dialog } from './dialog.svelte';
+export { default as EmptyState } from './empty-state.svelte';
+export { default as Input } from './input.svelte';
+export { default as Skeleton } from './skeleton.svelte';
+
+// Variant helpers (re-exported for call sites that need the type or class fn)
+export { buttonVariants, type ButtonVariant, type ButtonSize } from './button.svelte';
+export { badgeVariants, type BadgeVariant } from './badge.svelte';
+export { chipVariants, type ChipVariant } from './chip.svelte';
+export { alertVariants, type AlertVariant } from './alert.svelte';
+export { tabsListVariants, tabsTriggerVariants } from './tabs.svelte';
+export { tableVariants } from './table.svelte';
+
+// Composite primitives (sub-components)
+export { default as Alert } from './alert.svelte';
+export { default as FormField } from './form-field.svelte';
+export { default as Pagination } from './pagination.svelte';
+export { default as Table } from './table.svelte';
+export { default as Tabs } from './tabs.svelte';
+export { default as Tooltip } from './tooltip.svelte';

--- a/design-system/src/input.svelte
+++ b/design-system/src/input.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { HTMLInputAttributes } from 'svelte/elements';
-  import { cn } from '$lib/utils';
+  import { cn } from './cn.js';
 
   // The shared text/search input surface — one styled <input> primitive so the
   // search boxes and the facet filter cannot drift in border/focus/dark styling.

--- a/design-system/src/pagination.svelte
+++ b/design-system/src/pagination.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    page = $bindable(1),
+    total,
+    perPage = 20,
+    class: className,
+    children,
+  }: {
+    page?: number;
+    total: number;
+    perPage?: number;
+    class?: string;
+    children?: Snippet;
+  } = $props();
+
+  let totalPages = $derived(Math.max(1, Math.ceil(total / perPage)));
+  let canPrev = $derived(page > 1);
+  let canNext = $derived(page < totalPages);
+
+  function prev() {
+    if (canPrev) page--;
+  }
+  function next() {
+    if (canNext) page++;
+  }
+</script>
+
+<nav class={cn('flex items-center gap-2', className)} aria-label="Pagination">
+  <button
+    type="button"
+    onclick={prev}
+    disabled={!canPrev}
+    class="inline-flex h-9 items-center justify-center rounded-md border border-border px-3 text-sm transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+    aria-label="Previous page"
+  >
+    Previous
+  </button>
+  <span class="text-sm text-muted-foreground">
+    Page {page} of {totalPages}
+  </span>
+  <button
+    type="button"
+    onclick={next}
+    disabled={!canNext}
+    class="inline-flex h-9 items-center justify-center rounded-md border border-border px-3 text-sm transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+    aria-label="Next page"
+  >
+    Next
+  </button>
+  {#if children}
+    {@render children()}
+  {/if}
+</nav>

--- a/design-system/src/skeleton.svelte
+++ b/design-system/src/skeleton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cn } from '$lib/utils';
+  import { cn } from './cn.js';
 
   let { class: className }: { class?: string } = $props();
 </script>

--- a/design-system/src/table.svelte
+++ b/design-system/src/table.svelte
@@ -1,0 +1,42 @@
+<script lang="ts" module>
+  import { tv, type VariantProps } from 'tailwind-variants';
+
+  export const tableVariants = tv({
+    base: 'w-full caption-bottom text-sm',
+    slots: {
+      thead: 'border-b border-border [&_tr]:border-b',
+      tbody: '[&_tr:last-child]:border-0',
+      tr: 'border-b border-border transition-colors hover:bg-muted/50',
+      th: 'h-10 px-3 text-left font-medium text-muted-foreground',
+      td: 'p-3 align-middle',
+    },
+  });
+
+  export type TableSlots = VariantProps<typeof tableVariants>;
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    class: className,
+    header,
+    children,
+  }: { class?: string; header?: Snippet; children: Snippet } = $props();
+
+  let slots = tableVariants();
+</script>
+
+<div class={cn('w-full overflow-x-auto', className)}>
+  <table class={slots.base()}>
+    {#if header}
+      <thead class={slots.thead()}>
+        {@render header()}
+      </thead>
+    {/if}
+    <tbody class={slots.tbody()}>
+      {@render children()}
+    </tbody>
+  </table>
+</div>

--- a/design-system/src/tabs.svelte
+++ b/design-system/src/tabs.svelte
@@ -1,0 +1,76 @@
+<script lang="ts" module>
+  import { tv, type VariantProps } from 'tailwind-variants';
+
+  export const tabsListVariants = tv({
+    base: 'inline-flex items-center justify-center gap-1 rounded-lg bg-muted p-1',
+  });
+
+  export const tabsTriggerVariants = tv({
+    base: 'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+    variants: {
+      active: {
+        true: 'bg-card text-foreground shadow-sm',
+        false: 'text-muted-foreground hover:text-foreground',
+      },
+    },
+    defaultVariants: { active: false },
+  });
+
+  export type TabsTriggerActive = VariantProps<typeof tabsTriggerVariants>['active'];
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    value = $bindable(),
+    tabs,
+    class: className,
+    children,
+  }: {
+    value?: string;
+    tabs: { value: string; label: string }[];
+    class?: string;
+    children: Snippet;
+  } = $props();
+
+  function activate(v: string) {
+    value = v;
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    const idx = tabs.findIndex((t) => t.value === value);
+    if (idx === -1) return;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const dir = e.key === 'ArrowRight' ? 1 : -1;
+      const next = (idx + dir + tabs.length) % tabs.length;
+      activate(tabs[next].value);
+    }
+  }
+</script>
+
+<div class={cn('flex flex-col gap-2', className)}>
+  <div
+    class={tabsListVariants()}
+    role="tablist"
+    onkeydown={onKeydown}
+  >
+    {#each tabs as tab (tab.value)}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={value === tab.value}
+        tabindex={value === tab.value ? 0 : -1}
+        class={tabsTriggerVariants({ active: value === tab.value })}
+        onclick={() => activate(tab.value)}
+      >
+        {tab.label}
+      </button>
+    {/each}
+  </div>
+  <div role="tabpanel">
+    {@render children()}
+  </div>
+</div>

--- a/design-system/src/tabs.svelte
+++ b/design-system/src/tabs.svelte
@@ -35,6 +35,12 @@
     children: Snippet;
   } = $props();
 
+  const uid = $props.id();
+  const tabId = (v: string) => `${uid}-tab-${v}`;
+  const panelId = `${uid}-panel`;
+
+  let triggers: HTMLButtonElement[] = $state([]);
+
   function activate(v: string) {
     value = v;
   }
@@ -47,6 +53,9 @@
       const dir = e.key === 'ArrowRight' ? 1 : -1;
       const next = (idx + dir + tabs.length) % tabs.length;
       activate(tabs[next].value);
+      // Roving tabindex: the old trigger just became tabindex="-1", so focus
+      // has to follow the selection or it lands nowhere.
+      triggers[next]?.focus();
     }
   }
 </script>
@@ -57,10 +66,13 @@
     role="tablist"
     onkeydown={onKeydown}
   >
-    {#each tabs as tab (tab.value)}
+    {#each tabs as tab, i (tab.value)}
       <button
+        bind:this={triggers[i]}
         type="button"
         role="tab"
+        id={tabId(tab.value)}
+        aria-controls={panelId}
         aria-selected={value === tab.value}
         tabindex={value === tab.value ? 0 : -1}
         class={tabsTriggerVariants({ active: value === tab.value })}
@@ -70,7 +82,7 @@
       </button>
     {/each}
   </div>
-  <div role="tabpanel">
+  <div role="tabpanel" id={panelId} aria-labelledby={value ? tabId(value) : undefined}>
     {@render children()}
   </div>
 </div>

--- a/design-system/src/tooltip.svelte
+++ b/design-system/src/tooltip.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from './cn.js';
+
+  let {
+    content,
+    side = 'top',
+    class: className,
+    children,
+  }: {
+    content: Snippet;
+    side?: 'top' | 'right' | 'bottom' | 'left';
+    class?: string;
+    children: Snippet;
+  } = $props();
+
+  let visible = $state(false);
+  let triggerEl: HTMLElement | undefined = $state();
+
+  const positions = {
+    top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+    right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+    bottom: 'top-full left-1/2 --translate-x-1/2 mt-2',
+    left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+  };
+</script>
+
+<span
+  class="relative inline-flex"
+  bind:this={triggerEl}
+  onmouseenter={() => (visible = true)}
+  onmouseleave={() => (visible = false)}
+  onfocusin={() => (visible = true)}
+  onfocusout={() => (visible = false)}
+>
+  {@render children()}
+  {#if visible}
+    <div
+      role="tooltip"
+      class={cn(
+        'absolute z-popover max-w-xs rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md',
+        positions[side],
+        className,
+      )}
+    >
+      {@render content()}
+    </div>
+  {/if}
+</span>

--- a/design-system/src/tooltip.svelte
+++ b/design-system/src/tooltip.svelte
@@ -20,7 +20,7 @@
   const positions = {
     top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
     right: 'left-full top-1/2 -translate-y-1/2 ml-2',
-    bottom: 'top-full left-1/2 --translate-x-1/2 mt-2',
+    bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
     left: 'right-full top-1/2 -translate-y-1/2 mr-2',
   };
 </script>

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 7.5.0
       freehire-design-system:
         specifier: file:../design-system
-        version: file:../design-system
+        version: file:../design-system(@typescript-eslint/types@8.65.0)(tailwindcss@4.3.3)
       isomorphic-dompurify:
         specifier: ^3.18.0
         version: 3.19.0
@@ -4228,7 +4228,16 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  freehire-design-system@file:../design-system: {}
+  freehire-design-system@file:../design-system(@typescript-eslint/types@8.65.0)(tailwindcss@4.3.3):
+    dependencies:
+      '@lucide/svelte': 1.25.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))
+      clsx: 2.1.1
+      svelte: 5.56.7(@typescript-eslint/types@8.65.0)
+      tailwind-merge: 3.6.0
+      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+      - tailwindcss
 
   fsevents@2.3.3:
     optional: true

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -7,6 +7,12 @@
 @import "freehire-design-system/dist/tokens-light.css";
 @import "freehire-design-system/dist/tokens-dark.css";
 
+/* The design-system package is linked through node_modules, which Tailwind's
+   automatic source detection skips — without this the utilities used inside
+   design-system/src/*.svelte are never emitted and its primitives render
+   unstyled. Path is relative to this file. */
+@source "../../design-system/src";
+
 /* Typography plugin: the `prose` classes style the mdsvex-rendered blog post body
    (web/src/routes/blog/[slug]). Opt-in, so no other page is affected. */
 @plugin "@tailwindcss/typography";
@@ -46,6 +52,13 @@
   --radius-xl: var(--radius-xl);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
+  /* The z-index tokens ship as plain custom properties; Tailwind only mints
+     `z-<name>` utilities from the --z-index-* namespace. */
+  --z-index-dropdown: var(--z-dropdown);
+  --z-index-sticky: var(--z-sticky);
+  --z-index-modal: var(--z-modal);
+  --z-index-popover: var(--z-popover);
+  --z-index-toast: var(--z-toast);
 }
 
 @layer base {

--- a/web/src/lib/ui/index.ts
+++ b/web/src/lib/ui/index.ts
@@ -1,4 +1,5 @@
-export { default as Button } from './button.svelte';
-export { default as Badge } from './badge.svelte';
-export { default as Input } from './input.svelte';
-export { default as Skeleton } from './skeleton.svelte';
+export { cn } from 'freehire-design-system';
+export { Button } from 'freehire-design-system';
+export { Badge } from 'freehire-design-system';
+export { Input } from 'freehire-design-system';
+export { Skeleton } from 'freehire-design-system';


### PR DESCRIPTION
Phase 4 of the design-system build ([gearsandcode/freehire-design#6](https://github.com/gearsandcode/freehire-design/issues/6)).

Migrates 4 existing primitives into `design-system/src/` and builds 9 new ones. `web/src/lib/ui/` becomes a thin re-export barrel — ~90 import sites unchanged.

## Migrated (4)

`button`, `badge`, `input`, `skeleton` — moved to `design-system/src/`, imports changed from `/utils` to the package's own `cn.ts`.

## New (9)

| primitive | notes |
|---|---|
| Card | Surface container (border + bg-card + shadow-sm) |
| Dialog | Modal with backdrop, Escape, close button. z-modal/z-popover tokens. |
| Tabs | Tablist with arrow-key nav, ARIA roles, tailwind-variants styling. |
| Tooltip | Hover/focus tooltip with 4 positions. z-popover token. |
| Alert | Inline alert with default/destructive/brand variants. |
| Table | Styled table with slots for thead/tbody/tr/th/td. |
| Pagination | Prev/next + page count, ARIA nav label. |
| FormField | Label + error + hint wrapper with auto-generated id. |
| Chip | Pill/tag with default/primary/secondary/brand/destructive variants. |
| Avatar | Image-or-initials avatar with deterministic hue from name. |
| EmptyState | Loading/empty placeholder with optional icon, description, action. |

## Shared prop vocabulary

- `variant`: primary/secondary/outline/ghost (button); default/destructive/brand (alert); default/primary/secondary/brand/destructive (chip/badge)
- `size`: sm/md/lg/icon (button); sm/md/lg (avatar)
- `class`: all primitives accept a `class` prop merged via `cn()`

## Accessibility

- Dialog: `role=dialog`, `aria-modal`, Escape to close, backdrop click to close
- Tabs: `role=tablist/tab/tabpanel`, `aria-selected`, arrow-key navigation
- Tooltip: `role=tooltip`, hover + focus trigger
- Pagination: `aria-label`, disabled state
- FormField: `role=alert` on error, `label for=` association

## Verified locally
- `pnpm run check` (0 errors, 11 pre-existing warnings)
- `pnpm run build` (green)

**Depends on PRs #1087, #1088, #1092 being merged first.**

Refs: gearsandcode/freehire-design#6