### PR TITLE
DS Phase 6: Documentation

### DIFF
--- a/design-system/AGENTS.md
+++ b/design-system/AGENTS.md
@@ -5,8 +5,8 @@
 surface, so app code imports from `$lib/ui` and never reaches into the package directly.
 
 Being extracted from `web/` in phases by an external contributor; the phase inventory lives
-in `design-system/docs/`. A script that still `echo`s a placeholder (`validate:docs`) is an
-unfinished phase, not breakage.
+in `design-system/docs/`. A script that still `echo`s a placeholder is an unfinished phase,
+not breakage.
 
 ## Always true
 
@@ -74,6 +74,20 @@ to the bundler's JS parser and dies on the markup. The cost is the autodocs prop
 the Docs tab renders thin, and `argTypes` are hand-maintained: they drift from a component's
 actual variants with nothing to catch it. `Button`'s list already did, losing `destructive`.
 
+## DSDS docs
+
+`docs/dsds/*.json` describes the system as entities a docs site can render: `foundation.json`
+(one entity per token family, each listing its token names), `theme.json` (the dark mode and
+its `.dark` selector), `components.json` (one entity per primitive — props, defaults, and
+links to its source and story).
+
+`pnpm validate:docs` (`scripts/validate-docs.mjs`, run in CI) parses every file and checks
+that each entity carries `id`, `type` and `name`. **That is structure only — nothing compares
+an entity against the component or token it claims to describe.** A variant added to a `tv()`
+call, a token added to `tokens/*.tokens.json`, or a story file added under `src/` leaves the
+JSON stale and CI green, the same way hand-maintained `argTypes` drift. Touch a primitive or a
+token family, update its entity in the same commit.
+
 ## Limitations
 
-- The DSDS docs site is not configured yet.
+- The DSDS docs site itself is not configured yet — only the entity JSON it would consume.

--- a/design-system/AGENTS.md
+++ b/design-system/AGENTS.md
@@ -81,12 +81,18 @@ actual variants with nothing to catch it. `Button`'s list already did, losing `d
 its `.dark` selector), `components.json` (one entity per primitive — props, defaults, and
 links to its source and story).
 
-`pnpm validate:docs` (`scripts/validate-docs.mjs`, run in CI) parses every file and checks
-that each entity carries `id`, `type` and `name`. **That is structure only — nothing compares
-an entity against the component or token it claims to describe.** A variant added to a `tv()`
-call, a token added to `tokens/*.tokens.json`, or a story file added under `src/` leaves the
-JSON stale and CI green, the same way hand-maintained `argTypes` drift. Touch a primitive or a
-token family, update its entity in the same commit.
+`pnpm validate:docs` (`scripts/validate-docs.mjs`, run in CI) checks structure — every entity
+carries `id`, `type`, `name` — and then the two things that actually rot: every `source.file`
+and `stories[].file` resolves, a foundation entity's `tokens` list matches the keys of the
+token file it names **in both directions**, and no `src/*.stories.ts` goes unclaimed. Phase 6
+shipped with all three broken (every foundation path off by a directory, `destructive-foreground`
+undocumented, five story files orphaned) and the structural check passed, which is why they are
+checked now.
+
+**What is still hand-maintained: `props`, their `values`, and every `description`.** A variant
+added to a `tv()` call leaves the entity stale with CI green — the same drift that costs
+`argTypes` their accuracy, and for the same reason: the values live inside a Svelte module
+script that only a compiler can read. Touch a primitive, update its entity in the same commit.
 
 ## Limitations
 

--- a/design-system/docs/dsds/components.json
+++ b/design-system/docs/dsds/components.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://designsystemds.org/schema/component.json",
+  "entities": [
+    {
+      "id": "component.button",
+      "type": "component",
+      "name": "Button",
+      "description": "Action button with variant (primary/secondary/outline/ghost) and size (sm/md/lg/icon) props. Supports href for link rendering.",
+      "source": { "file": "../../src/button.svelte" },
+      "props": [
+        { "name": "variant", "type": "ButtonVariant", "default": "secondary", "values": ["primary", "secondary", "outline", "ghost"] },
+        { "name": "size", "type": "ButtonSize", "default": "md", "values": ["sm", "md", "lg", "icon"] },
+        { "name": "href", "type": "string", "default": "undefined", "description": "If set, renders an <a> instead of a <button>." },
+        { "name": "class", "type": "string", "default": "undefined" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ],
+      "story": { "file": "../../src/button.stories.ts" }
+    },
+    {
+      "id": "component.badge",
+      "type": "component",
+      "name": "Badge",
+      "description": "Small status label with variant (secondary/outline/brand/missing).",
+      "source": { "file": "../../src/badge.svelte" },
+      "props": [
+        { "name": "variant", "type": "BadgeVariant", "default": "secondary", "values": ["secondary", "outline", "brand", "missing"] },
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ],
+      "story": { "file": "../../src/badge.stories.ts" }
+    },
+    {
+      "id": "component.input",
+      "type": "component",
+      "name": "Input",
+      "description": "Styled text input with bindable value, focus ring, and dark-mode support.",
+      "source": { "file": "../../src/input.svelte" },
+      "props": [
+        { "name": "value", "type": "string", "bindable": true },
+        { "name": "class", "type": "string" }
+      ],
+      "story": { "file": "../../src/input.stories.ts" }
+    },
+    {
+      "id": "component.card",
+      "type": "component",
+      "name": "Card",
+      "description": "Surface container with border, bg-card, and shadow-sm.",
+      "source": { "file": "../../src/card.svelte" },
+      "props": [
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ],
+      "story": { "file": "../../src/card.stories.ts" }
+    },
+    {
+      "id": "component.dialog",
+      "type": "component",
+      "name": "Dialog",
+      "description": "Modal with backdrop, Escape to close, and focus-visible close button. Uses z-modal/z-popover tokens.",
+      "source": { "file": "../../src/dialog.svelte" },
+      "props": [
+        { "name": "open", "type": "boolean", "bindable": true, "default": false },
+        { "name": "title", "type": "string" },
+        { "name": "description", "type": "string" },
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ],
+      "story": { "file": "../../src/dialog.stories.ts" }
+    },
+    {
+      "id": "component.tabs",
+      "type": "component",
+      "name": "Tabs",
+      "description": "Tab list with arrow-key navigation and ARIA roles. Active tab styled via tailwind-variants.",
+      "source": { "file": "../../src/tabs.svelte" },
+      "props": [
+        { "name": "value", "type": "string", "bindable": true },
+        { "name": "tabs", "type": "{ value: string; label: string }[]", "required": true },
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ]
+    },
+    {
+      "id": "component.tooltip",
+      "type": "component",
+      "name": "Tooltip",
+      "description": "Hover/focus tooltip with 4 positions (top/right/bottom/left).",
+      "source": { "file": "../../src/tooltip.svelte" },
+      "props": [
+        { "name": "content", "type": "Snippet", "required": true },
+        { "name": "side", "type": "'top' | 'right' | 'bottom' | 'left'", "default": "top" },
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ]
+    },
+    {
+      "id": "component.alert",
+      "type": "component",
+      "name": "Alert",
+      "description": "Inline alert with default/destructive/brand variants.",
+      "source": { "file": "../../src/alert.svelte" },
+      "props": [
+        { "name": "variant", "type": "AlertVariant", "default": "default", "values": ["default", "destructive", "brand"] },
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ],
+      "story": { "file": "../../src/alert.stories.ts" }
+    },
+    {
+      "id": "component.chip",
+      "type": "component",
+      "name": "Chip",
+      "description": "Pill/tag with default/primary/secondary/brand/destructive variants.",
+      "source": { "file": "../../src/chip.svelte" },
+      "props": [
+        { "name": "variant", "type": "ChipVariant", "default": "default", "values": ["default", "primary", "secondary", "brand", "destructive"] },
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ],
+      "story": { "file": "../../src/chip.stories.ts" }
+    },
+    {
+      "id": "component.avatar",
+      "type": "component",
+      "name": "Avatar",
+      "description": "Image-or-initials avatar with deterministic hue from name.",
+      "source": { "file": "../../src/avatar.svelte" },
+      "props": [
+        { "name": "name", "type": "string" },
+        { "name": "src", "type": "string" },
+        { "name": "size", "type": "'sm' | 'md' | 'lg'", "default": "md" },
+        { "name": "class", "type": "string" }
+      ],
+      "story": { "file": "../../src/avatar.stories.ts" }
+    },
+    {
+      "id": "component.empty-state",
+      "type": "component",
+      "name": "EmptyState",
+      "description": "Loading/empty placeholder with optional icon, description, and action slot.",
+      "source": { "file": "../../src/empty-state.svelte" },
+      "props": [
+        { "name": "title", "type": "string", "default": "Nothing here yet" },
+        { "name": "description", "type": "string" },
+        { "name": "icon", "type": "Snippet" },
+        { "name": "action", "type": "Snippet" },
+        { "name": "class", "type": "string" }
+      ],
+      "story": { "file": "../../src/empty-state.stories.ts" }
+    },
+    {
+      "id": "component.skeleton",
+      "type": "component",
+      "name": "Skeleton",
+      "description": "Animated placeholder div (animate-pulse + bg-muted).",
+      "source": { "file": "../../src/skeleton.svelte" },
+      "props": [
+        { "name": "class", "type": "string" }
+      ],
+      "story": { "file": "../../src/skeleton.stories.ts" }
+    },
+    {
+      "id": "component.pagination",
+      "type": "component",
+      "name": "Pagination",
+      "description": "Prev/next pagination with page count and ARIA nav label.",
+      "source": { "file": "../../src/pagination.svelte" },
+      "props": [
+        { "name": "page", "type": "number", "bindable": true, "default": 1 },
+        { "name": "total", "type": "number", "required": true },
+        { "name": "perPage", "type": "number", "default": 20 },
+        { "name": "class", "type": "string" }
+      ],
+      "story": { "file": "../../src/pagination.stories.ts" }
+    },
+    {
+      "id": "component.form-field",
+      "type": "component",
+      "name": "FormField",
+      "description": "Label + error + hint wrapper with auto-generated id and required indicator.",
+      "source": { "file": "../../src/form-field.svelte" },
+      "props": [
+        { "name": "label", "type": "string" },
+        { "name": "error", "type": "string" },
+        { "name": "hint", "type": "string" },
+        { "name": "required", "type": "boolean", "default": false },
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ]
+    },
+    {
+      "id": "component.table",
+      "type": "component",
+      "name": "Table",
+      "description": "Styled table with slots for thead/tbody/tr/th/td.",
+      "source": { "file": "../../src/table.svelte" },
+      "props": [
+        { "name": "header", "type": "Snippet" },
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "required": true }
+      ]
+    }
+  ]
+}

--- a/design-system/docs/dsds/components.json
+++ b/design-system/docs/dsds/components.json
@@ -5,16 +5,19 @@
       "id": "component.button",
       "type": "component",
       "name": "Button",
-      "description": "Action button with variant (primary/secondary/outline/ghost) and size (sm/md/lg/icon) props. Supports href for link rendering.",
+      "description": "Action button with variant (primary/secondary/outline/ghost/destructive) and size (sm/md/lg/icon) props. Supports href for link rendering.",
       "source": { "file": "../../src/button.svelte" },
       "props": [
-        { "name": "variant", "type": "ButtonVariant", "default": "secondary", "values": ["primary", "secondary", "outline", "ghost"] },
+        { "name": "variant", "type": "ButtonVariant", "default": "secondary", "values": ["primary", "secondary", "outline", "ghost", "destructive"], "description": "destructive is filled, for the action that cannot be undone; a ghost button with destructive text is the right weight for reversible ones." },
         { "name": "size", "type": "ButtonSize", "default": "md", "values": ["sm", "md", "lg", "icon"] },
         { "name": "href", "type": "string", "default": "undefined", "description": "If set, renders an <a> instead of a <button>." },
         { "name": "class", "type": "string", "default": "undefined" },
         { "name": "children", "type": "Snippet", "required": true }
       ],
-      "story": { "file": "../../src/button.stories.ts" }
+      "stories": [
+        { "file": "../../src/button.stories.ts" },
+        { "file": "../../src/button-icon.stories.ts" }
+      ]
     },
     {
       "id": "component.badge",
@@ -27,7 +30,7 @@
         { "name": "class", "type": "string" },
         { "name": "children", "type": "Snippet", "required": true }
       ],
-      "story": { "file": "../../src/badge.stories.ts" }
+      "stories": [{ "file": "../../src/badge.stories.ts" }]
     },
     {
       "id": "component.input",
@@ -37,9 +40,10 @@
       "source": { "file": "../../src/input.svelte" },
       "props": [
         { "name": "value", "type": "string", "bindable": true },
-        { "name": "class", "type": "string" }
+        { "name": "class", "type": "string" },
+        { "name": "...rest", "type": "HTMLInputAttributes", "description": "Spread onto the <input>, so type, placeholder, disabled and the rest go straight through." }
       ],
-      "story": { "file": "../../src/input.stories.ts" }
+      "stories": [{ "file": "../../src/input.stories.ts" }]
     },
     {
       "id": "component.card",
@@ -51,13 +55,13 @@
         { "name": "class", "type": "string" },
         { "name": "children", "type": "Snippet", "required": true }
       ],
-      "story": { "file": "../../src/card.stories.ts" }
+      "stories": [{ "file": "../../src/card.stories.ts" }]
     },
     {
       "id": "component.dialog",
       "type": "component",
       "name": "Dialog",
-      "description": "Modal with backdrop, Escape to close, and focus-visible close button. Uses z-modal/z-popover tokens.",
+      "description": "Native <dialog> opened with showModal(), so the browser supplies the top layer, focus trap, inert background and Escape-to-close. Adds the backdrop styling, a scroll lock and a close button. Stacks without a z-index — the top layer is above every one of them.",
       "source": { "file": "../../src/dialog.svelte" },
       "props": [
         { "name": "open", "type": "boolean", "bindable": true, "default": false },
@@ -66,7 +70,7 @@
         { "name": "class", "type": "string" },
         { "name": "children", "type": "Snippet", "required": true }
       ],
-      "story": { "file": "../../src/dialog.stories.ts" }
+      "stories": [{ "file": "../../src/dialog.stories.ts" }]
     },
     {
       "id": "component.tabs",
@@ -79,7 +83,8 @@
         { "name": "tabs", "type": "{ value: string; label: string }[]", "required": true },
         { "name": "class", "type": "string" },
         { "name": "children", "type": "Snippet", "required": true }
-      ]
+      ],
+      "stories": [{ "file": "../../src/tabs.stories.ts" }]
     },
     {
       "id": "component.tooltip",
@@ -92,7 +97,8 @@
         { "name": "side", "type": "'top' | 'right' | 'bottom' | 'left'", "default": "top" },
         { "name": "class", "type": "string" },
         { "name": "children", "type": "Snippet", "required": true }
-      ]
+      ],
+      "stories": [{ "file": "../../src/tooltip.stories.ts" }]
     },
     {
       "id": "component.alert",
@@ -105,7 +111,7 @@
         { "name": "class", "type": "string" },
         { "name": "children", "type": "Snippet", "required": true }
       ],
-      "story": { "file": "../../src/alert.stories.ts" }
+      "stories": [{ "file": "../../src/alert.stories.ts" }]
     },
     {
       "id": "component.chip",
@@ -118,7 +124,7 @@
         { "name": "class", "type": "string" },
         { "name": "children", "type": "Snippet", "required": true }
       ],
-      "story": { "file": "../../src/chip.stories.ts" }
+      "stories": [{ "file": "../../src/chip.stories.ts" }]
     },
     {
       "id": "component.avatar",
@@ -132,13 +138,13 @@
         { "name": "size", "type": "'sm' | 'md' | 'lg'", "default": "md" },
         { "name": "class", "type": "string" }
       ],
-      "story": { "file": "../../src/avatar.stories.ts" }
+      "stories": [{ "file": "../../src/avatar.stories.ts" }]
     },
     {
       "id": "component.empty-state",
       "type": "component",
       "name": "EmptyState",
-      "description": "Loading/empty placeholder with optional icon, description, and action slot.",
+      "description": "Empty-result placeholder with optional icon, description, and action slot.",
       "source": { "file": "../../src/empty-state.svelte" },
       "props": [
         { "name": "title", "type": "string", "default": "Nothing here yet" },
@@ -147,7 +153,7 @@
         { "name": "action", "type": "Snippet" },
         { "name": "class", "type": "string" }
       ],
-      "story": { "file": "../../src/empty-state.stories.ts" }
+      "stories": [{ "file": "../../src/empty-state.stories.ts" }]
     },
     {
       "id": "component.skeleton",
@@ -158,7 +164,7 @@
       "props": [
         { "name": "class", "type": "string" }
       ],
-      "story": { "file": "../../src/skeleton.stories.ts" }
+      "stories": [{ "file": "../../src/skeleton.stories.ts" }]
     },
     {
       "id": "component.pagination",
@@ -170,9 +176,10 @@
         { "name": "page", "type": "number", "bindable": true, "default": 1 },
         { "name": "total", "type": "number", "required": true },
         { "name": "perPage", "type": "number", "default": 20 },
-        { "name": "class", "type": "string" }
+        { "name": "class", "type": "string" },
+        { "name": "children", "type": "Snippet", "description": "Rendered between the prev and next controls, in place of the default page count." }
       ],
-      "story": { "file": "../../src/pagination.stories.ts" }
+      "stories": [{ "file": "../../src/pagination.stories.ts" }]
     },
     {
       "id": "component.form-field",
@@ -186,8 +193,9 @@
         { "name": "hint", "type": "string" },
         { "name": "required", "type": "boolean", "default": false },
         { "name": "class", "type": "string" },
-        { "name": "children", "type": "Snippet", "required": true }
-      ]
+        { "name": "children", "type": "Snippet<[{ id: string; describedBy: string | undefined; required: boolean; invalid: boolean }]>", "required": true, "description": "The field owns the label and the message and hands the control everything it needs to announce itself — render it as {@render children({ id, describedBy, required, invalid })}." }
+      ],
+      "stories": [{ "file": "../../src/form-field.stories.ts" }]
     },
     {
       "id": "component.table",
@@ -199,7 +207,8 @@
         { "name": "header", "type": "Snippet" },
         { "name": "class", "type": "string" },
         { "name": "children", "type": "Snippet", "required": true }
-      ]
+      ],
+      "stories": [{ "file": "../../src/table.stories.ts" }]
     }
   ]
 }

--- a/design-system/docs/dsds/foundation.json
+++ b/design-system/docs/dsds/foundation.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://designsystemds.org/schema/foundation.json",
+  "entities": [
+    {
+      "id": "foundation.color",
+      "type": "foundation",
+      "category": "color",
+      "name": "Color",
+      "description": "Semantic color tokens — background, foreground, surfaces, brand family, destructive, border, input, ring.",
+      "source": {
+        "file": "../tokens/color.tokens.json",
+        "path": ""
+      },
+      "tokens": [
+        "background", "foreground", "card", "card-foreground", "popover", "popover-foreground",
+        "primary", "primary-foreground", "secondary", "secondary-foreground",
+        "muted", "muted-foreground", "accent", "accent-foreground",
+        "destructive", "border", "input", "ring",
+        "brand", "brand-foreground", "brand-strong", "brand-muted", "brand-ring"
+      ]
+    },
+    {
+      "id": "foundation.spacing",
+      "type": "foundation",
+      "category": "spacing",
+      "name": "Spacing",
+      "description": "13-step spacing scale aligned with Tailwind's default (1 unit = 0.25rem = 4px).",
+      "source": {
+        "file": "../tokens/spacing.tokens.json",
+        "path": ""
+      },
+      "tokens": ["spacing-0", "spacing-1", "spacing-2", "spacing-3", "spacing-4", "spacing-5", "spacing-6", "spacing-8", "spacing-10", "spacing-12", "spacing-16", "spacing-20", "spacing-24"]
+    },
+    {
+      "id": "foundation.typography",
+      "type": "foundation",
+      "category": "typography",
+      "name": "Typography",
+      "description": "Font families, 8 font sizes, 4 font weights, 3 line heights.",
+      "source": {
+        "file": "../tokens/typography.tokens.json",
+        "path": ""
+      },
+      "tokens": ["font-sans", "font-mono", "font-size-xs", "font-size-sm", "font-size-base", "font-size-lg", "font-size-xl", "font-size-2xl", "font-size-3xl", "font-size-4xl", "font-weight-normal", "font-weight-medium", "font-weight-semibold", "font-weight-bold", "line-height-tight", "line-height-normal", "line-height-relaxed"]
+    },
+    {
+      "id": "foundation.radius",
+      "type": "foundation",
+      "category": "radius",
+      "name": "Radius",
+      "description": "Base radius (0.625rem) with sm/md/lg/xl derivations.",
+      "source": {
+        "file": "../tokens/radius.tokens.json",
+        "path": ""
+      },
+      "tokens": ["radius", "radius-sm", "radius-md", "radius-lg", "radius-xl"]
+    },
+    {
+      "id": "foundation.shadow",
+      "type": "foundation",
+      "category": "shadow",
+      "name": "Shadow",
+      "description": "4-step elevation scale: sm (dropdowns), md (cards), lg (dialogs), xl (overlays).",
+      "source": {
+        "file": "../tokens/shadow.tokens.json",
+        "path": ""
+      },
+      "tokens": ["shadow-sm", "shadow-md", "shadow-lg", "shadow-xl"]
+    },
+    {
+      "id": "foundation.motion",
+      "type": "foundation",
+      "category": "motion",
+      "name": "Motion",
+      "description": "3 durations (fast/normal/slow) + 3 easing curves (ease-in/ease-out/ease-in-out).",
+      "source": {
+        "file": "../tokens/motion.tokens.json",
+        "path": ""
+      },
+      "tokens": ["duration-fast", "duration-normal", "duration-slow", "ease-in", "ease-out", "ease-in-out"]
+    },
+    {
+      "id": "foundation.z-index",
+      "type": "foundation",
+      "category": "z-index",
+      "name": "Z-index",
+      "description": "6-step stacking scale: base, dropdown, sticky, modal, popover, toast.",
+      "source": {
+        "file": "../tokens/z-index.tokens.json",
+        "path": ""
+      },
+      "tokens": ["z-base", "z-dropdown", "z-sticky", "z-modal", "z-popover", "z-toast"]
+    }
+  ]
+}

--- a/design-system/docs/dsds/foundation.json
+++ b/design-system/docs/dsds/foundation.json
@@ -8,14 +8,14 @@
       "name": "Color",
       "description": "Semantic color tokens — background, foreground, surfaces, brand family, destructive, border, input, ring.",
       "source": {
-        "file": "../tokens/color.tokens.json",
+        "file": "../../tokens/color.tokens.json",
         "path": ""
       },
       "tokens": [
         "background", "foreground", "card", "card-foreground", "popover", "popover-foreground",
         "primary", "primary-foreground", "secondary", "secondary-foreground",
         "muted", "muted-foreground", "accent", "accent-foreground",
-        "destructive", "border", "input", "ring",
+        "destructive", "destructive-foreground", "border", "input", "ring",
         "brand", "brand-foreground", "brand-strong", "brand-muted", "brand-ring"
       ]
     },
@@ -26,7 +26,7 @@
       "name": "Spacing",
       "description": "13-step spacing scale aligned with Tailwind's default (1 unit = 0.25rem = 4px).",
       "source": {
-        "file": "../tokens/spacing.tokens.json",
+        "file": "../../tokens/spacing.tokens.json",
         "path": ""
       },
       "tokens": ["spacing-0", "spacing-1", "spacing-2", "spacing-3", "spacing-4", "spacing-5", "spacing-6", "spacing-8", "spacing-10", "spacing-12", "spacing-16", "spacing-20", "spacing-24"]
@@ -38,7 +38,7 @@
       "name": "Typography",
       "description": "Font families, 8 font sizes, 4 font weights, 3 line heights.",
       "source": {
-        "file": "../tokens/typography.tokens.json",
+        "file": "../../tokens/typography.tokens.json",
         "path": ""
       },
       "tokens": ["font-sans", "font-mono", "font-size-xs", "font-size-sm", "font-size-base", "font-size-lg", "font-size-xl", "font-size-2xl", "font-size-3xl", "font-size-4xl", "font-weight-normal", "font-weight-medium", "font-weight-semibold", "font-weight-bold", "line-height-tight", "line-height-normal", "line-height-relaxed"]
@@ -50,7 +50,7 @@
       "name": "Radius",
       "description": "Base radius (0.625rem) with sm/md/lg/xl derivations.",
       "source": {
-        "file": "../tokens/radius.tokens.json",
+        "file": "../../tokens/radius.tokens.json",
         "path": ""
       },
       "tokens": ["radius", "radius-sm", "radius-md", "radius-lg", "radius-xl"]
@@ -62,7 +62,7 @@
       "name": "Shadow",
       "description": "4-step elevation scale: sm (dropdowns), md (cards), lg (dialogs), xl (overlays).",
       "source": {
-        "file": "../tokens/shadow.tokens.json",
+        "file": "../../tokens/shadow.tokens.json",
         "path": ""
       },
       "tokens": ["shadow-sm", "shadow-md", "shadow-lg", "shadow-xl"]
@@ -74,7 +74,7 @@
       "name": "Motion",
       "description": "3 durations (fast/normal/slow) + 3 easing curves (ease-in/ease-out/ease-in-out).",
       "source": {
-        "file": "../tokens/motion.tokens.json",
+        "file": "../../tokens/motion.tokens.json",
         "path": ""
       },
       "tokens": ["duration-fast", "duration-normal", "duration-slow", "ease-in", "ease-out", "ease-in-out"]
@@ -86,7 +86,7 @@
       "name": "Z-index",
       "description": "6-step stacking scale: base, dropdown, sticky, modal, popover, toast.",
       "source": {
-        "file": "../tokens/z-index.tokens.json",
+        "file": "../../tokens/z-index.tokens.json",
         "path": ""
       },
       "tokens": ["z-base", "z-dropdown", "z-sticky", "z-modal", "z-popover", "z-toast"]

--- a/design-system/docs/dsds/theme.json
+++ b/design-system/docs/dsds/theme.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://designsystemds.org/schema/theme.json",
+  "entities": [
+    {
+      "id": "theme.dark",
+      "type": "theme",
+      "name": "Dark",
+      "description": "Dark-mode color overrides — same token paths as light, different values for all 23 color tokens.",
+      "source": {
+        "file": "../tokens/color-dark.tokens.json",
+        "path": ""
+      },
+      "mode": "dark",
+      "selector": ".dark"
+    }
+  ]
+}

--- a/design-system/docs/dsds/theme.json
+++ b/design-system/docs/dsds/theme.json
@@ -5,9 +5,9 @@
       "id": "theme.dark",
       "type": "theme",
       "name": "Dark",
-      "description": "Dark-mode color overrides — same token paths as light, different values for all 23 color tokens.",
+      "description": "Dark-mode color overrides — same token paths as light, different values for all 24 color tokens.",
       "source": {
-        "file": "../tokens/color-dark.tokens.json",
+        "file": "../../tokens/color-dark.tokens.json",
         "path": ""
       },
       "mode": "dark",

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -20,7 +20,7 @@
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "test": "vitest run",
     "tokens:build": "node scripts/build-tokens.mjs",
-    "validate:docs": "echo \"validate:docs: nothing to validate yet (phase 06 adds DSDS)\"",
+    "validate:docs": "node scripts/validate-docs.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/design-system/scripts/validate-docs.mjs
+++ b/design-system/scripts/validate-docs.mjs
@@ -1,0 +1,38 @@
+// Validates that all DSDS JSON docs are well-formed and have the required fields.
+// No external schema dependency — just structural checks.
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const docsDir = join(import.meta.dirname, '..', 'docs', 'dsds');
+let errors = 0;
+
+for (const file of readdirSync(docsDir)) {
+  if (!file.endsWith('.json')) continue;
+  const path = join(docsDir, file);
+  let data;
+  try {
+    data = JSON.parse(readFileSync(path, 'utf-8'));
+  } catch (e) {
+    console.error(`✗ ${file}: invalid JSON — ${e.message}`);
+    errors++;
+    continue;
+  }
+  if (!Array.isArray(data.entities)) {
+    console.error(`✗ ${file}: missing "entities" array`);
+    errors++;
+    continue;
+  }
+  for (const entity of data.entities) {
+    if (!entity.id) { console.error(`✗ ${file}: entity missing "id"`); errors++; }
+    if (!entity.type) { console.error(`✗ ${file}: entity "${entity.id}" missing "type"`); errors++; }
+    if (!entity.name) { console.error(`✗ ${file}: entity "${entity.id}" missing "name"`); errors++; }
+  }
+  console.log(`✓ ${file}: ${data.entities.length} entities valid`);
+}
+
+if (errors > 0) {
+  console.error(`\n${errors} error(s) found.`);
+  process.exit(1);
+} else {
+  console.log('\nAll DSDS docs valid.');
+}

--- a/design-system/scripts/validate-docs.mjs
+++ b/design-system/scripts/validate-docs.mjs
@@ -1,34 +1,87 @@
-// Validates that all DSDS JSON docs are well-formed and have the required fields.
-// No external schema dependency — just structural checks.
-import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+// Validates the DSDS entity JSON in docs/dsds/. Two classes of check: that the
+// files are structurally what a docs site would expect, and that what they claim
+// about the package is still true. The second is the one that earns its keep — an
+// entity is a hand-written copy of a component or a token family, and nothing but
+// this script notices when the original moves.
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 
-const docsDir = join(import.meta.dirname, '..', 'docs', 'dsds');
+const root = join(import.meta.dirname, '..');
+const docsDir = join(root, 'docs', 'dsds');
+const srcDir = join(root, 'src');
+
 let errors = 0;
+function fail(message) {
+  console.error(`✗ ${message}`);
+  errors++;
+}
 
-for (const file of readdirSync(docsDir)) {
-  if (!file.endsWith('.json')) continue;
+// Every story file some entity claims, so the sweep at the end can name the ones
+// nobody claims.
+const claimedStories = new Set();
+
+const files = readdirSync(docsDir).filter((file) => file.endsWith('.json'));
+if (files.length === 0) fail('docs/dsds/: no JSON files — the docs are gone, not valid');
+
+for (const file of files) {
   const path = join(docsDir, file);
   let data;
   try {
     data = JSON.parse(readFileSync(path, 'utf-8'));
   } catch (e) {
-    console.error(`✗ ${file}: invalid JSON — ${e.message}`);
-    errors++;
+    fail(`${file}: invalid JSON — ${e.message}`);
     continue;
   }
   if (!Array.isArray(data.entities)) {
-    console.error(`✗ ${file}: missing "entities" array`);
-    errors++;
+    fail(`${file}: missing "entities" array`);
     continue;
   }
+
   for (const entity of data.entities) {
-    if (!entity.id) { console.error(`✗ ${file}: entity missing "id"`); errors++; }
-    if (!entity.type) { console.error(`✗ ${file}: entity "${entity.id}" missing "type"`); errors++; }
-    if (!entity.name) { console.error(`✗ ${file}: entity "${entity.id}" missing "name"`); errors++; }
+    if (!entity.id) fail(`${file}: entity missing "id"`);
+    if (!entity.type) fail(`${file}: entity "${entity.id}" missing "type"`);
+    if (!entity.name) fail(`${file}: entity "${entity.id}" missing "name"`);
+
+    // File references are relative to the JSON that holds them.
+    const stories = entity.stories ?? [];
+    for (const ref of [entity.source, ...stories]) {
+      if (!ref?.file) continue;
+      const target = resolve(dirname(path), ref.file);
+      if (existsSync(target)) continue;
+      fail(`${file}: entity "${entity.id}" points at a missing file — ${ref.file}`);
+    }
+    for (const story of stories) {
+      if (story.file) claimedStories.add(resolve(dirname(path), story.file));
+    }
+
+    // A token list is a copy of the token file's keys. Drift either way means the
+    // docs describe a palette the package no longer ships.
+    if (entity.tokens && entity.source?.file) {
+      const target = resolve(dirname(path), entity.source.file);
+      if (existsSync(target)) {
+        const authored = Object.keys(JSON.parse(readFileSync(target, 'utf-8')));
+        const shipped = authored.filter((name) => !name.startsWith('$'));
+        const documented = new Set(entity.tokens);
+        const undocumented = shipped.filter((name) => !documented.has(name));
+        const gone = entity.tokens.filter((name) => !shipped.includes(name));
+        if (undocumented.length) {
+          fail(`${file}: entity "${entity.id}" does not document ${undocumented.join(', ')}`);
+        }
+        if (gone.length) {
+          fail(`${file}: entity "${entity.id}" documents tokens that no longer exist — ${gone.join(', ')}`);
+        }
+      }
+    }
   }
-  console.log(`✓ ${file}: ${data.entities.length} entities valid`);
+
+  console.log(`✓ ${file}: ${data.entities.length} entities`);
 }
+
+// The other direction: a story file added to the package and never documented.
+const unclaimed = readdirSync(srcDir)
+  .filter((file) => file.endsWith('.stories.ts'))
+  .filter((file) => !claimedStories.has(join(srcDir, file)));
+if (unclaimed.length) fail(`src/: story files no entity claims — ${unclaimed.join(', ')}`);
 
 if (errors > 0) {
   console.error(`\n${errors} error(s) found.`);


### PR DESCRIPTION
Phase 6 of the design-system build ([gearsandcode/freehire-design#8](https://github.com/gearsandcode/freehire-design/issues/8)).

DSDS entity JSON docs, Storybook autodocs (enabled in phase 05 via `tags: ['autodocs']`), and `design-system/AGENTS.md`.

## Deliverables

- **`docs/dsds/foundation.json`** — 7 foundation entities (color, spacing, typography, radius, shadow, motion, z-index) with source file linking and token name lists.
- **`docs/dsds/theme.json`** — dark theme entity (mode: dark, selector: .dark).
- **`docs/dsds/components.json`** — 15 component entities with props, defaults, story links, and source file references.
- **`scripts/validate-docs.mjs`** — structural validation: checks every JSON file in `docs/dsds/` for valid JSON, entities array, and required fields (id, type, name). Replaces the phase 02 placeholder.
- **`AGENTS.md`** — documents the two-package boundary, DTCG token authoring, primitive conventions, CSF story format, DSDS docs structure, and the full architecture tree.

## Verified locally
- `pnpm validate:docs` — all 23 entities valid across 3 files
- `pnpm build-storybook` — green (autodocs generated)
- `pnpm run check` (0 errors) + `pnpm run build` (green) in `web/`

**Depends on PRs #1087, #1088, #1092, #1098, #1099 being merged first.**

Refs: gearsandcode/freehire-design#8