### PR TITLE
feat(web): CV margins in a Settings tab + fix editor field overflow

### DIFF
--- a/web/src/lib/components/cv/CvSectionForm.svelte
+++ b/web/src/lib/components/cv/CvSectionForm.svelte
@@ -11,7 +11,6 @@
     blankCertification,
   } from '$lib/cv';
   import StringListEditor from './StringListEditor.svelte';
-  import MarginSettings from './MarginSettings.svelte';
 
   // The controlled section form for one CV: binds directly to a caller-owned Document (and CV
   // title) and adds/removes rows per section. It does no data-fetching and no saving — the host
@@ -44,16 +43,10 @@
     <Input id="cv-title" bind:value={title} placeholder="e.g. Backend Engineer — general" class="w-full" />
   </section>
 
-  <!-- Page margins -->
-  <section class="space-y-3">
-    <h2 class="text-lg font-semibold">Margins <span class="text-sm font-normal text-muted-foreground">(in inches)</span></h2>
-    <MarginSettings bind:margins={doc.margins} />
-  </section>
-
   <!-- Header -->
   <section class="space-y-3">
     <h2 class="text-lg font-semibold">Header</h2>
-    <div class="grid gap-3 sm:grid-cols-2">
+    <div class="grid gap-3 sm:grid-cols-2 [&>*]:w-full">
       <Input bind:value={doc.header.full_name} placeholder="Full name" />
       <Input bind:value={doc.header.email} placeholder="Email" />
       <Input bind:value={doc.header.phone} placeholder="Phone" />
@@ -87,11 +80,11 @@
     {#each doc.experience ?? [] as entry, i (entry)}
       <div class="space-y-3 rounded-lg border border-border p-4">
         <div class="flex items-start justify-between gap-2">
-          <div class="grid flex-1 gap-3 sm:grid-cols-2">
+          <div class="grid flex-1 gap-3 sm:grid-cols-2 [&>*]:w-full">
             <Input bind:value={entry.role} placeholder="Role" />
             <Input bind:value={entry.company} placeholder="Company" />
             <Input bind:value={entry.location} placeholder="Location" />
-            <div class="grid grid-cols-2 gap-3">
+            <div class="grid grid-cols-2 gap-3 [&>*]:w-full">
               <Input bind:value={entry.start} placeholder="Start (e.g. 2021)" />
               <Input bind:value={entry.end} placeholder="End / Present" />
             </div>
@@ -123,11 +116,11 @@
     </div>
     {#each doc.education ?? [] as entry, i (entry)}
       <div class="flex items-start justify-between gap-2 rounded-lg border border-border p-4">
-        <div class="grid flex-1 gap-3 sm:grid-cols-2">
+        <div class="grid flex-1 gap-3 sm:grid-cols-2 [&>*]:w-full">
           <Input bind:value={entry.institution} placeholder="Institution" />
           <Input bind:value={entry.degree} placeholder="Degree" />
           <Input bind:value={entry.field} placeholder="Field" />
-          <div class="grid grid-cols-2 gap-3">
+          <div class="grid grid-cols-2 gap-3 [&>*]:w-full">
             <Input bind:value={entry.start} placeholder="Start" />
             <Input bind:value={entry.end} placeholder="End" />
           </div>

--- a/web/src/lib/ui/input.svelte
+++ b/web/src/lib/ui/input.svelte
@@ -17,7 +17,7 @@
 <input
   bind:value
   class={cn(
-    'h-9 rounded-lg border border-input bg-transparent px-3 transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-input/30',
+    'h-9 min-w-0 rounded-lg border border-input bg-transparent px-3 transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-input/30',
     className,
   )}
   {...rest}

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -19,6 +19,7 @@
   import ArtifactPanel from '$lib/tailor/ArtifactPanel.svelte';
   import CvHtmlPreview from '$lib/tailor/CvHtmlPreview.svelte';
   import CvSectionForm from '$lib/components/cv/CvSectionForm.svelte';
+  import MarginSettings from '$lib/components/cv/MarginSettings.svelte';
   import AccountNavRail from '$lib/components/AccountNavRail.svelte';
   import { clampWidth } from '$lib/tailor/geometry';
   import { toEditable, emptyDocument, type CvRecord } from '$lib/cv';
@@ -50,7 +51,7 @@
 
   // Left panel: which tab is shown, and its resizable width. The chat stays mounted across tab
   // switches (hidden, not unmounted) so its live session is never dropped.
-  let leftTab = $state<'chat' | 'editor'>('chat');
+  let leftTab = $state<'chat' | 'editor' | 'settings'>('chat');
   let leftWidth = $state(380);
   let leftPanelEl = $state<HTMLElement>();
   let leftResizing = false;
@@ -65,10 +66,11 @@
   // syncs the matching column's own selector (mobile → column) so the wide layout shows the same
   // content once revealed. The reverse (a desktop tab change updating mobileView) is not wired —
   // switching a column tab then narrowing across lg resets the mobile view to that tab's default.
-  type MobileView = 'chat' | 'editor' | 'preview' | 'templates' | 'jd' | 'verdict';
+  type MobileView = 'chat' | 'editor' | 'settings' | 'preview' | 'templates' | 'jd' | 'verdict';
   const mobileTabs: [MobileView, string][] = [
     ['chat', 'Chat'],
     ['editor', 'Editor'],
+    ['settings', 'Settings'],
     ['preview', 'Preview'],
     ['templates', 'Templates'],
     ['jd', 'Job'],
@@ -81,7 +83,7 @@
   let navOpen = $state(false);
   function pickMobile(v: MobileView) {
     mobileView = v;
-    if (v === 'chat' || v === 'editor') leftTab = v;
+    if (v === 'chat' || v === 'editor' || v === 'settings') leftTab = v;
     else if (v !== 'preview') artifactTab = v;
   }
 
@@ -297,7 +299,7 @@
         bind:this={leftPanelEl}
         class={[
           'w-full min-h-0 flex-1 flex-col border-r border-border bg-background lg:w-[var(--lw)] lg:flex-none lg:flex',
-          mobileView === 'chat' || mobileView === 'editor' ? 'flex' : 'hidden',
+          mobileView === 'chat' || mobileView === 'editor' || mobileView === 'settings' ? 'flex' : 'hidden',
         ]}
         style="--lw: {leftWidth}px"
       >
@@ -313,13 +315,20 @@
             </button>
             <button
               type="button"
+              onclick={() => (leftTab = 'settings')}
+              class={['rounded px-2 py-1 transition-colors', leftTab === 'settings' ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
+            >
+              Settings
+            </button>
+            <button
+              type="button"
               onclick={() => (leftTab = 'chat')}
               class={['rounded px-2 py-1 transition-colors', leftTab === 'chat' ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
             >
               Chat
             </button>
           </div>
-          {#if leftTab === 'editor'}
+          {#if leftTab === 'editor' || leftTab === 'settings'}
             <span
               class={['pr-1 text-xs', saveState === 'error' ? 'text-destructive' : 'text-muted-foreground']}
               aria-live="polite"
@@ -332,6 +341,15 @@
         <div class="min-h-0 flex-1">
           <div class="h-full overflow-auto p-4" class:hidden={leftTab !== 'editor'}>
             <CvSectionForm bind:doc bind:title />
+          </div>
+          <div class="h-full overflow-auto p-4" class:hidden={leftTab !== 'settings'}>
+            <section class="space-y-3">
+              <div>
+                <h2 class="text-lg font-semibold">Margins <span class="text-sm font-normal text-muted-foreground">(in inches)</span></h2>
+                <p class="mt-0.5 text-sm text-muted-foreground">Page margins applied to the preview and the downloaded PDF.</p>
+              </div>
+              <MarginSettings bind:margins={doc.margins} />
+            </section>
           </div>
           <div class="flex min-h-0 h-full" class:hidden={leftTab !== 'chat'}>
             <AssistantChat


### PR DESCRIPTION
## Summary
- Move the page-**Margins** steppers out of the Editor form into a dedicated **Settings** tab in the tailor workspace's left panel (Editor / Settings / Chat), leaving room to grow page-setup controls. Autosave + live preview repagination are unchanged (margins still live in `doc.margins`).
- Fix editor **inputs clipping** past the narrow left panel: the shared `Input` had no `min-width`, so a bare `<input>`'s intrinsic width overflowed the resized panel. Add `min-w-0` to the `Input` base (safe — only permits shrinking; fixes clipping app-wide) and `w-full` to the two-column grid children so fields fill and shrink within the panel.

Follow-up to #1097.

## Test Plan
- [x] `eslint` 0 errors, `svelte-check` 0 errors, `vitest` 383 pass, production `build` green
- [x] Visual verify (headless Chrome, 360px panel): editor fields no longer clip; Settings tab renders the Left/Right/Top/Bottom steppers