### PR TITLE
reindex: disk-safety guard, orphan cleanup, in-place from-pg semantic rebuild

### DIFF
--- a/cmd/reindex/diskguard.go
+++ b/cmd/reindex/diskguard.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"syscall"
 )
 
@@ -18,7 +19,13 @@ func guardDisk(dir string, minFreeGB int, probe func(string) (uint64, error)) er
 	}
 	free, err := probe(dir)
 	if err != nil {
-		return fmt.Errorf("reindex: measure free disk on %s: %w", dir, err)
+		// Fail open: the guard is a best-effort safety net, not a correctness gate. If the
+		// dir cannot be measured (e.g. it does not exist off the prod host, as in CI/dev),
+		// skip the guard rather than block reindex everywhere. A misconfigured MEILI_DATA_DIR
+		// on prod thus silently disables the guard, so log it loudly — the disk alert is the
+		// backstop.
+		log.Printf("reindex: disk-guard skipped — cannot measure free space on %s: %v", dir, err)
+		return nil
 	}
 	required := uint64(minFreeGB) << 30
 	if free < required {

--- a/cmd/reindex/diskguard.go
+++ b/cmd/reindex/diskguard.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// guardDisk refuses a swap-rebuild when free space on dir is below minFreeGB (GiB).
+// A full rebuild transiently holds a second copy of the index, so on a tight disk it
+// fills the volume, aborts before the swap, and leaves an orphan rebuild index that
+// eats ~index-size until dropped by hand. Aborting up front trades a stale index (the
+// facet index stays fresh via incremental ingest anyway) for never risking a disk-full
+// outage. minFreeGB <= 0 disables the guard. The probe is injected so the threshold
+// logic is unit-tested without a real filesystem.
+func guardDisk(dir string, minFreeGB int, probe func(string) (uint64, error)) error {
+	if minFreeGB <= 0 {
+		return nil
+	}
+	free, err := probe(dir)
+	if err != nil {
+		return fmt.Errorf("reindex: measure free disk on %s: %w", dir, err)
+	}
+	required := uint64(minFreeGB) << 30
+	if free < required {
+		return fmt.Errorf("refusing rebuild — free %dGiB on %s is below the %dGiB floor (REINDEX_MIN_FREE_GB); a swap-rebuild would risk filling the disk",
+			free>>30, dir, minFreeGB)
+	}
+	return nil
+}
+
+// statfsFree reports the bytes available to an unprivileged writer on the filesystem
+// backing dir. It is the production probe for guardDisk.
+func statfsFree(dir string) (uint64, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(dir, &st); err != nil {
+		return 0, err
+	}
+	// Bavail (not Bfree) is the space usable by non-root writers — what Meilisearch
+	// actually gets.
+	return uint64(st.Bavail) * uint64(st.Bsize), nil
+}

--- a/cmd/reindex/diskguard_test.go
+++ b/cmd/reindex/diskguard_test.go
@@ -38,11 +38,14 @@ func TestGuardDisk_DisabledWhenFloorZero(t *testing.T) {
 	}
 }
 
-func TestGuardDisk_PropagatesProbeError(t *testing.T) {
-	sentinel := errors.New("statfs boom")
-	probe := func(string) (uint64, error) { return 0, sentinel }
+// The guard is a best-effort safety net, not a correctness gate: if it cannot measure
+// the dir (e.g. MEILI_DATA_DIR does not exist off the prod host, as in CI/dev), it must
+// fail OPEN — skip the guard and let reindex proceed — rather than block reindex
+// everywhere it cannot statfs the path.
+func TestGuardDisk_SkipsWhenProbeFails(t *testing.T) {
+	probe := func(string) (uint64, error) { return 0, errors.New("statfs boom") }
 
-	if err := guardDisk("/data/meili", 70, probe); !errors.Is(err, sentinel) {
-		t.Fatalf("expected probe error to propagate, got: %v", err)
+	if err := guardDisk("/data/meili", 70, probe); err != nil {
+		t.Fatalf("probe failure must fail open (skip guard), got: %v", err)
 	}
 }

--- a/cmd/reindex/diskguard_test.go
+++ b/cmd/reindex/diskguard_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const giB = uint64(1) << 30
+
+func TestGuardDisk_AbortsWhenBelowFloor(t *testing.T) {
+	probe := func(string) (uint64, error) { return 10 * giB, nil }
+
+	err := guardDisk("/data/meili", 70, probe)
+
+	if err == nil {
+		t.Fatal("expected abort when free (10G) < floor (70G), got nil")
+	}
+	// The message must name both numbers so an operator can act on it.
+	if !strings.Contains(err.Error(), "10") || !strings.Contains(err.Error(), "70") {
+		t.Errorf("error should mention free and required GiB, got: %v", err)
+	}
+}
+
+func TestGuardDisk_ProceedsWhenAtOrAboveFloor(t *testing.T) {
+	probe := func(string) (uint64, error) { return 100 * giB, nil }
+
+	if err := guardDisk("/data/meili", 70, probe); err != nil {
+		t.Fatalf("expected proceed when free (100G) >= floor (70G), got: %v", err)
+	}
+}
+
+func TestGuardDisk_DisabledWhenFloorZero(t *testing.T) {
+	probe := func(string) (uint64, error) { return 0, nil }
+
+	if err := guardDisk("/data/meili", 0, probe); err != nil {
+		t.Fatalf("floor 0 disables the guard, expected nil even at 0 free, got: %v", err)
+	}
+}
+
+func TestGuardDisk_PropagatesProbeError(t *testing.T) {
+	sentinel := errors.New("statfs boom")
+	probe := func(string) (uint64, error) { return 0, sentinel }
+
+	if err := guardDisk("/data/meili", 70, probe); !errors.Is(err, sentinel) {
+		t.Fatalf("expected probe error to propagate, got: %v", err)
+	}
+}

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/search"
@@ -117,29 +118,15 @@ func run() int {
 		log.Printf("reindex: suppressed aggregator duplicates (%d rows re-marked)", n)
 	}
 
-	var b rebuilder = client.NewFacetRebuild()
-	if semantic {
-		b = client.NewSemanticRebuild()
-		if fromPG {
-			b = client.NewSemanticRebuildFromPG()
-		}
-	}
-	// The semantic rebuild optionally scopes to a fresh posting window (--posted-within);
-	// every other full pass scans the whole table. A scoped reader returns open jobs only,
-	// which the swap rebuild wants anyway (closed jobs are simply absent).
+	// The rebuild optionally scopes to a fresh posting window (--posted-within); every
+	// other pass scans the whole table. A scoped reader returns open jobs only, which the
+	// rebuild wants anyway (closed jobs are simply absent).
 	reader := worker.NewFullScanReader(q)
 	scope := "full"
 	if scoped {
 		reader = worker.NewPostedSinceReader(q, time.Now().Add(-postedWithin))
 		scope = "posted-within " + postedWithin.String()
 	}
-	vectors := "n/a"
-	if semantic {
-		if vectors = "tei"; fromPG {
-			vectors = "pg"
-		}
-	}
-	log.Printf("reindex: target=%s scope=%s mode=swap vectors=%s", target, scope, vectors)
 	lookup, err := buildRealityLookup(ctx, q)
 	if err != nil {
 		log.Printf("reindex: build reality lookup: %v", err)
@@ -150,13 +137,55 @@ func run() int {
 		log.Printf("reindex: build cluster geo lookup: %v", err)
 		return 1
 	}
+
+	// --from-pg rehydrates the semantic index IN PLACE from the vectors already in Postgres:
+	// reset the live index and re-fill it with no TEI embedding, no rebuild copy, and no
+	// swap. Peak disk is a single copy, so this path skips the disk-guard entirely.
+	if semantic && fromPG {
+		log.Printf("reindex: target=semantic scope=%s mode=in-place vectors=pg", scope)
+		rh := semanticFromPG{c: client}
+		indexed, skipped, err := reindexSemanticFromPG(ctx, reader, rh, lookup, geo, time.Now())
+		if err != nil {
+			log.Printf("reindex: %v", err)
+			return 1
+		}
+		log.Printf("reindex done: target=semantic scope=%s mode=in-place indexed=%d skipped=%d", scope, indexed, skipped)
+		return 0
+	}
+
+	// Every other pass builds a fresh index and atomically swaps it in — transiently a
+	// second full copy of the index. On a tight disk that fills the volume and aborts
+	// before the swap, orphaning the rebuild index; guard the free space before starting.
+	rcfg := config.LoadReindex()
+	if err := guardDisk(rcfg.MeiliDataDir, rcfg.MinFreeGB, statfsFree); err != nil {
+		log.Printf("reindex: %v", err)
+		return 1
+	}
+	var b rebuilder = client.NewFacetRebuild()
+	vectors := "n/a"
+	if semantic {
+		b = client.NewSemanticRebuild()
+		vectors = "tei"
+	}
+	log.Printf("reindex: target=%s scope=%s mode=swap vectors=%s", target, scope, vectors)
 	indexed, skipped, err := reindexFull(ctx, reader, b, lookup, geo, time.Now())
 	if err != nil {
 		log.Printf("reindex: %v", err)
 		return 1
 	}
-	log.Printf("reindex done: target=%s scope=full indexed=%d skipped=%d", target, indexed, skipped)
+	log.Printf("reindex done: target=%s scope=%s indexed=%d skipped=%d", target, scope, indexed, skipped)
 	return 0
+}
+
+// semanticFromPG adapts the search client to the semanticRehydrator orchestration used by
+// reindexSemanticFromPG: a Reset that clears the live jobs_semantic index and a PushFromPG
+// that upserts Postgres-persisted vectors straight into it, both in place (no swap).
+type semanticFromPG struct{ c *search.Client }
+
+func (s semanticFromPG) Reset(ctx context.Context) error { return s.c.ResetSemanticIndex(ctx) }
+
+func (s semanticFromPG) PushFromPG(ctx context.Context, docs []search.JobDocument) error {
+	return s.c.IndexSemanticJobsFromPG(ctx, docs)
 }
 
 // postedWithinFrom parses an optional --posted-within <duration> / --posted-within=<duration>
@@ -224,6 +253,9 @@ type rebuilder interface {
 	Prepare(ctx context.Context) error
 	Push(ctx context.Context, docs []search.JobDocument) error
 	Promote(ctx context.Context) error
+	// Cleanup drops a half-built rebuild index. reindexFull defers it so a run that
+	// aborts before Promote's swap-and-drop does not leave an orphan index eating disk.
+	Cleanup(ctx context.Context) error
 }
 
 // reindexFull rebuilds the index from scratch and swaps it in. It streams ONLY
@@ -236,6 +268,41 @@ func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder, loo
 		return 0, 0, err
 	}
 
+	// Promote ends the happy path by swapping the rebuild index in and dropping the old
+	// one; any earlier return is an abort that leaves the half-built rebuild index behind.
+	// Drop it in a defer so an aborted run never orphans an index that eats disk until the
+	// next run's Prepare clears it. Best-effort on a cancellation-immune context so it can
+	// still reach Meilisearch when the abort was the parent ctx being cancelled.
+	promoted := false
+	defer func() {
+		if promoted {
+			return
+		}
+		cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if err := b.Cleanup(cctx); err != nil {
+			log.Printf("reindex: cleanup aborted rebuild index (best-effort): %v", err)
+		}
+	}()
+
+	indexed, skipped, err := streamOpenDocs(ctx, reader, lookup, geo, now, b.Push)
+	if err != nil {
+		return indexed, skipped, err
+	}
+
+	if err := b.Promote(ctx); err != nil {
+		return indexed, skipped, err
+	}
+	promoted = true
+	return indexed, skipped, nil
+}
+
+// streamOpenDocs pages the reindex feed by keyset and pushes each batch's open-job
+// documents through push, returning the running indexed/skipped totals. Shared by the
+// swap rebuild (reindexFull) and the in-place semantic rehydration
+// (reindexSemanticFromPG): only the per-batch sink and the surrounding index lifecycle
+// differ.
+func streamOpenDocs(ctx context.Context, reader worker.PageReader, lookup realityLookup, geo clusterGeoLookup, now time.Time, push func(context.Context, []search.JobDocument) error) (int, int, error) {
 	var indexed atomic.Int64
 	stopHeartbeat := worker.Heartbeat(progressInterval, func() {
 		log.Printf("reindex: progress indexed=%d", indexed.Load())
@@ -256,7 +323,7 @@ func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder, loo
 			if err != nil {
 				return int(indexed.Load()), skipped, err
 			}
-			if err := b.Push(ctx, docs); err != nil {
+			if err := push(ctx, docs); err != nil {
 				return int(indexed.Load()), skipped, err
 			}
 			indexed.Add(int64(len(docs)))
@@ -270,11 +337,30 @@ func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder, loo
 		}
 		afterID = lastID
 	}
-
-	if err := b.Promote(ctx); err != nil {
-		return int(indexed.Load()), skipped, err
-	}
 	return int(indexed.Load()), skipped, nil
+}
+
+// semanticRehydrator rebuilds jobs_semantic IN PLACE from the vectors already stored in
+// Postgres: Reset clears the live index to empty, PushFromPG upserts open-job vectors
+// straight into it. No rebuild copy and no swap, so it never transiently doubles disk
+// usage the way the swap rebuild (rebuilder) does — the reason a from-PG rebuild takes
+// this path. The tradeoff is that /similar and recommendations see a partial index while
+// the rehydration runs; acceptable because the semantic index is disposable (Postgres is
+// the source of truth for the vectors).
+type semanticRehydrator interface {
+	Reset(ctx context.Context) error
+	PushFromPG(ctx context.Context, docs []search.JobDocument) error
+}
+
+// reindexSemanticFromPG resets the live jobs_semantic index and re-fills it in place from
+// the vectors persisted in Postgres, streaming only open jobs. Unlike reindexFull there
+// is no Prepare/Promote/swap and thus no disk-guard need — dropping the old index before
+// the fill means the peak footprint is ~one copy, never two.
+func reindexSemanticFromPG(ctx context.Context, reader worker.PageReader, rh semanticRehydrator, lookup realityLookup, geo clusterGeoLookup, now time.Time) (int, int, error) {
+	if err := rh.Reset(ctx); err != nil {
+		return 0, 0, err
+	}
+	return streamOpenDocs(ctx, reader, lookup, geo, now, rh.PushFromPG)
 }
 
 // realityLookup returns a role cluster's repost and concurrent-open counts for the

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -132,8 +134,9 @@ func TestSplitJobs_CanonGetsClusterGeoUnion(t *testing.T) {
 // pushed batch, so a unit test can pin the full-rebuild orchestration without a
 // real Meilisearch.
 type fakeRebuilder struct {
-	calls  []string
-	pushed [][]int64
+	calls   []string
+	pushed  [][]int64
+	pushErr error // when set, Push returns it after recording — simulates a mid-build abort
 }
 
 func (f *fakeRebuilder) Prepare(context.Context) error {
@@ -148,11 +151,16 @@ func (f *fakeRebuilder) Push(_ context.Context, docs []search.JobDocument) error
 		ids[i] = d.ID
 	}
 	f.pushed = append(f.pushed, ids)
-	return nil
+	return f.pushErr
 }
 
 func (f *fakeRebuilder) Promote(context.Context) error {
 	f.calls = append(f.calls, "promote")
+	return nil
+}
+
+func (f *fakeRebuilder) Cleanup(context.Context) error {
+	f.calls = append(f.calls, "cleanup")
 	return nil
 }
 
@@ -188,6 +196,39 @@ func TestReindexFull_PushesOpenDocsThenPromotes(t *testing.T) {
 	}
 }
 
+// An aborted rebuild (Push fails mid-build, so Promote's swap-and-drop never runs)
+// must drop its half-built rebuild index via the deferred Cleanup — otherwise the
+// orphan index eats disk until the next run's Prepare clears it.
+func TestReindexFull_CleansUpOnAbort(t *testing.T) {
+	reader := &fakePageReader{pages: map[int64][]db.Job{0: {{ID: 1, Title: "A", PublicSlug: "a"}}}}
+	f := &fakeRebuilder{pushErr: errors.New("push boom")}
+
+	_, _, err := reindexFull(context.Background(), reader, f, nil, nil, time.Now())
+	if err == nil {
+		t.Fatal("expected reindexFull to return the push error")
+	}
+	if !slices.Contains(f.calls, "cleanup") {
+		t.Errorf("expected cleanup after abort, calls = %v", f.calls)
+	}
+	if slices.Contains(f.calls, "promote") {
+		t.Errorf("promote must not run after a push abort, calls = %v", f.calls)
+	}
+}
+
+// A successful rebuild swaps-and-drops in Promote, so the deferred Cleanup must NOT
+// run — a second drop of the (already-swapped) rebuild uid is pointless work.
+func TestReindexFull_NoCleanupOnSuccess(t *testing.T) {
+	reader := &fakePageReader{pages: map[int64][]db.Job{0: {{ID: 1, Title: "A", PublicSlug: "a"}}}}
+	f := &fakeRebuilder{}
+
+	if _, _, err := reindexFull(context.Background(), reader, f, nil, nil, time.Now()); err != nil {
+		t.Fatalf("reindexFull: %v", err)
+	}
+	if slices.Contains(f.calls, "cleanup") {
+		t.Errorf("cleanup must not run on success, calls = %v", f.calls)
+	}
+}
+
 // A corrupted row (its Batch read faults with XX001) must not abort the rebuild:
 // ResilientPage degrades to per-row reads, the corrupted row is skipped, the rest
 // are indexed, and the fresh index still promotes.
@@ -215,6 +256,58 @@ func TestReindexFull_SkipsCorruptedRowAndPromotes(t *testing.T) {
 	}
 	if f.calls[len(f.calls)-1] != "promote" {
 		t.Errorf("expected promote at the end, calls = %v", f.calls)
+	}
+}
+
+// fakeRehydrator records the in-place semantic-rehydration orchestration without a
+// real Meilisearch: it resets the live index once, then upserts open-job batches.
+type fakeRehydrator struct {
+	calls   []string
+	pushed  [][]int64
+	pushErr error
+}
+
+func (f *fakeRehydrator) Reset(context.Context) error {
+	f.calls = append(f.calls, "reset")
+	return nil
+}
+
+func (f *fakeRehydrator) PushFromPG(_ context.Context, docs []search.JobDocument) error {
+	f.calls = append(f.calls, "push")
+	ids := make([]int64, len(docs))
+	for i, d := range docs {
+		ids[i] = d.ID
+	}
+	f.pushed = append(f.pushed, ids)
+	return f.pushErr
+}
+
+// An in-place from-PG rebuild resets the live jobs_semantic to empty ONCE, then upserts
+// only open jobs' vectors straight into it — no rebuild copy, no swap. Closed jobs are
+// absent (the fresh index never held them).
+func TestReindexSemanticFromPG_ResetsThenPushesOpen(t *testing.T) {
+	open1 := db.Job{ID: 1, Title: "A", PublicSlug: "a"}
+	closed := db.Job{ID: 2, Title: "B", PublicSlug: "b",
+		ClosedAt: pgtype.Timestamptz{Time: time.Unix(1, 0), Valid: true}}
+	open3 := db.Job{ID: 3, Title: "C", PublicSlug: "c"}
+	reader := &fakePageReader{pages: map[int64][]db.Job{0: {open1, closed, open3}}}
+
+	f := &fakeRehydrator{}
+	indexed, skipped, err := reindexSemanticFromPG(context.Background(), reader, f, nil, nil, time.Now())
+	if err != nil {
+		t.Fatalf("reindexSemanticFromPG: %v", err)
+	}
+	if indexed != 2 || skipped != 0 {
+		t.Errorf("indexed=%d skipped=%d, want indexed=2 skipped=0", indexed, skipped)
+	}
+	if len(f.calls) == 0 || f.calls[0] != "reset" {
+		t.Errorf("reset must run first, calls = %v", f.calls)
+	}
+	if slices.Contains(f.calls, "promote") {
+		t.Errorf("in-place rebuild must not swap/promote, calls = %v", f.calls)
+	}
+	if len(f.pushed) != 1 || !slices.Equal(f.pushed[0], []int64{1, 3}) {
+		t.Errorf("pushed = %v, want [[1 3]] (closed job 2 absent)", f.pushed)
 	}
 }
 

--- a/docs/superpowers/specs/2026-07-24-reindex-disk-safety-disposable-semantic-design.md
+++ b/docs/superpowers/specs/2026-07-24-reindex-disk-safety-disposable-semantic-design.md
@@ -1,0 +1,131 @@
+# Reindex disk-safety & disposable semantic index
+
+**Date:** 2026-07-24
+**Status:** approved (design)
+**Scope:** `cmd/reindex`, `internal/search`, `internal/config` (freehire); one systemd timer/script (freehire-ops)
+
+## Problem
+
+host2 (`/dev/sda1`, 301G) recurrently hits 100% disk, taking down the whole app:
+Postgres can no longer write (crash-loop, or `SQLSTATE 53100 No space left` on temp
+files), the embed worker crash-loops, and background workers stall. This has recurred
+repeatedly (2026-06-17, 06-25, 07-03, 07-23/24), each time "fixed" by hand, never
+structurally.
+
+**Root cause.** freehire keeps two large Meili indexes resident — `jobs` (facet/keyword,
+~50G) and `jobs_semantic` (hybrid vectors, ~45G) — on a disk too small for even one
+swap-rebuild. A full reindex uses a fresh-index-plus-atomic-swap strategy
+(`internal/search/client.go` `Rebuild`): it builds a complete second copy
+(`jobs_rebuild` / `jobs_semantic_rebuild`, ~another 45–50G) then swaps. On a chronically
+tight disk the build fills the disk, aborts before the swap, and leaves the orphan
+rebuild index behind. `Rebuild.Prepare` only drops a leftover rebuild index on the NEXT
+run, so the orphan lingers (13h+ in the 07-23 incident) and eats ~50G until dropped by
+hand.
+
+Two facts make a clean structural fix possible:
+
+1. **`jobs_semantic` is a disposable, derived index.** Its vectors are durably stored in
+   Postgres (`jobs.semantic_embedding`, migration 0021; backed up by the nightly
+   pg_dump). It can be rebuilt from Postgres with no re-embedding (no TEI/GPU cost) —
+   `reindex --semantic --from-pg` already does this via the swap path. Losing it
+   temporarily is acceptable (it backs `/similar` and CV recommendations, not the main
+   search; hybrid main-search is not enabled yet).
+2. **The embed worker already writes `jobs_semantic` in place** (upsert, no swap) — so an
+   in-place bulk rehydration needs no new atomicity story.
+
+## Goals
+
+- A full reindex can never fill the disk (no more disk-full-from-reindex outages).
+- No orphan rebuild index is ever left behind.
+- Rebuilding `jobs_semantic` is cheap in BOTH cpu (no re-embed) AND disk (no 2× copy), so
+  it can be treated as disposable — dropped to free ~45G and rebuilt on demand.
+- Early warning before the disk is critical.
+
+## Non-goals
+
+- Growing the disk / moving other tenants (that is an infra decision, out of scope here).
+- Changing the facet index's swap-rebuild strategy (it needs the atomic swap for the live
+  search index and has no Postgres shortcut).
+- Enabling hybrid search in the SPA (separate, later work).
+
+## Design
+
+### Component 1 — In-place semantic rehydration from Postgres (`cmd/reindex`, `internal/search`)
+
+Make `reindex --semantic --from-pg` rebuild `jobs_semantic` **in place**, without a
+rebuild copy or swap:
+
+1. Ensure a FRESH empty `jobs_semantic` — drop it if present, then create it with the
+   semantic settings (userProvided embedder). Dropping first means the old copy's space is
+   released before the new fill, so peak disk usage is ~1× the index, never 2×.
+2. Stream every open, canonical job carrying a persisted vector
+   (`jobs.semantic_embedding`) and upsert its document (with vector) directly into the
+   live `jobs_semantic`, in batches, reusing `semanticDocsFromPG`. No TEI calls.
+
+Because the index is freshly (re)created, there are no stale documents to delete — closed
+and non-canonical jobs are simply never pushed (same `splitJobs` filtering the reindex
+feed already applies). During the fill, `/similar` and recommendations return partial or
+empty results; acceptable for a disposable index (this is the same in-place,
+non-atomic model the embed worker already uses).
+
+**Decision:** `--from-pg` is ALWAYS in-place. The swap-based `NewSemanticRebuildFromPG`
+path is removed — a from-PG rebuild via swap has no benefit and is exactly what created
+the disk pressure. (`NewSemanticRebuild` — the TEI-embedding swap rebuild — is retained
+for a from-scratch re-embed if ever needed, and is covered by the Component 2 guard.)
+
+### Component 2 — Pre-flight disk guard + defer-cleanup (`cmd/reindex`, `internal/search`, `internal/config`)
+
+For the FACET reindex (which must swap — no Postgres shortcut, needs atomicity for the
+live search index) and any TEI swap rebuild:
+
+- **Guard.** Before `Rebuild.Prepare`, measure free disk via `syscall.Statfs` on the Meili
+  data dir and abort with a clear log + non-zero exit if free is below a configured floor.
+  - New config: `MEILI_DATA_DIR` (default `/var/lib/freehire/meili`), `REINDEX_MIN_FREE_GB`
+    (default `70`).
+  - The check is a single syscall at startup — zero cost on the indexing hot path.
+  - We deliberately do NOT size the threshold from Meili's reported index size:
+    `/indexes/<uid>/stats` `rawDocumentDbSize` under-reports on-disk footprint ~8× (e.g.
+    6G reported vs ~51G on disk for `jobs_semantic`), so an adaptive check would be
+    unreliable. A statfs floor is simple, honest, and operator-tunable.
+  - On trip: `log.Printf("reindex: refusing — free %dG < required %dG (REINDEX_MIN_FREE_GB); skipping to avoid disk-full")` and `return 1`. Search stays as-is; incremental ingest keeps the facet index fresh (the full reindex is a reconciler, not the freshness path).
+- **Defer-cleanup.** Add `Cleanup(ctx)` to the `rebuilder` interface (best-effort drop of
+  the rebuild index, idempotent). In `reindexFull`, `defer` it, running only when a
+  successful `Promote` was NOT reached (tracked by a `promoted` flag). Best-effort: log on
+  failure, never mask the original error. Caveat: under a genuine 100%-full disk the
+  cleanup's Meili `indexDeletion` may not schedule immediately (serial task queue) — this
+  is a safety net for non-disk aborts; the guard is what prevents disk-full.
+
+### Component 3 — Ops disk alert (freehire-ops)
+
+A `freehire-disk-alert.service` (oneshot, `/opt/freehire/bin/disk-alert.sh`) + `.timer`
+(every 15 min), mirroring the `freehire-pg-backup` pattern under
+`provision/host2/systemd/`. The script checks `df /` and, at ≥85% used, emits an alert.
+**Open detail:** delivery channel — reuse the project's Telegram bot (token/chat from
+`/opt/freehire/.env`) if available, else email via the existing SES path. Finalized when
+the ops side is written.
+
+## Operational sequencing (not code)
+
+1. Ship Components 1 & 2, deploy.
+2. Verify in-place `--from-pg` rebuilds `jobs_semantic` correctly and disk-cheaply.
+3. THEN (optional, when disk headroom is wanted): drop `jobs_semantic` on prod to free
+   ~45G (82%→~67%); rebuild on demand via the proven in-place path before hybrid/similar
+   is needed. Not urgent — disk is currently ~82% after the 07-24 orphan cleanup.
+
+## Testing
+
+- **Guard (unit):** inject the free-space probe; assert abort when free < floor and
+  proceed when free ≥ floor. Assert the abort happens before any index is created.
+- **Defer-cleanup (unit):** a rebuilder stub — assert `Cleanup` is called when the build
+  errors before Promote, and NOT called after a successful Promote.
+- **In-place from-PG (unit):** assert the from-PG path ensures a fresh index and pushes
+  only open-job vectors via `semanticDocsFromPG`, with no swap/rebuild index created.
+- **Ops:** smoke-test `disk-alert.sh` on host2 (dry-run threshold).
+
+## Risks
+
+- Guard may refuse the facet reindex until the disk grows (free ~53G vs ~50G index +
+  overhead). This is intended — refusing is safe; filling the disk is an outage. Incremental
+  indexing keeps the facet index fresh meanwhile.
+- In-place semantic rebuild degrades `/similar` and recommendations during the fill (index
+  incomplete). Accepted — the index is disposable and the rebuild is fast from PG.

--- a/internal/config/reindex.go
+++ b/internal/config/reindex.go
@@ -1,0 +1,35 @@
+package config
+
+// Reindex holds the operational guards for the reindex command (cmd/reindex).
+// Meilisearch itself is configured via the shared Settings (MEILI_URL/
+// MEILI_MASTER_KEY); this holds only the disk-safety knobs, mirroring the tuning
+// half of config.Embed.
+type Reindex struct {
+	// MeiliDataDir is the filesystem path the reindex disk-guard measures free space
+	// on before building a swap-rebuild index. It must be the volume Meilisearch
+	// stores its indexes under, so the guard sees the space the 2nd copy will consume.
+	MeiliDataDir string
+	// MinFreeGB is the minimum free space (GiB) required on MeiliDataDir before a
+	// swap-rebuild is allowed to start. A full rebuild transiently holds a second
+	// copy of the index (~index-size), so a chronically tight disk fills and leaves an
+	// orphan rebuild index. Below this floor the reindex refuses rather than risk a
+	// disk-full outage. 0 disables the guard.
+	MinFreeGB int
+}
+
+// LoadReindex reads the reindex disk-guard config from the environment, all optional
+// with defaults. There is no required field — the MEILI_MASTER_KEY requirement is
+// enforced at the cmd/reindex call site, so this never fails.
+func LoadReindex() Reindex {
+	r := Reindex{
+		MeiliDataDir: env("MEILI_DATA_DIR", "/var/lib/freehire/meili"),
+		MinFreeGB:    envInt("REINDEX_MIN_FREE_GB", 70),
+	}
+	// A negative floor would make the guard's `free < floor` comparison always false,
+	// silently disabling it in a way that reads like a real threshold. Clamp to 0, the
+	// explicit "guard off" value.
+	if r.MinFreeGB < 0 {
+		r.MinFreeGB = 0
+	}
+	return r
+}

--- a/internal/config/reindex_test.go
+++ b/internal/config/reindex_test.go
@@ -1,0 +1,40 @@
+package config
+
+import "testing"
+
+func TestLoadReindex_Defaults(t *testing.T) {
+	t.Setenv("MEILI_DATA_DIR", "")
+	t.Setenv("REINDEX_MIN_FREE_GB", "")
+
+	r := LoadReindex()
+
+	if r.MeiliDataDir != "/var/lib/freehire/meili" {
+		t.Errorf("MeiliDataDir default = %q, want /var/lib/freehire/meili", r.MeiliDataDir)
+	}
+	if r.MinFreeGB != 70 {
+		t.Errorf("MinFreeGB default = %d, want 70", r.MinFreeGB)
+	}
+}
+
+func TestLoadReindex_FromEnv(t *testing.T) {
+	t.Setenv("MEILI_DATA_DIR", "/data/meili")
+	t.Setenv("REINDEX_MIN_FREE_GB", "120")
+
+	r := LoadReindex()
+
+	if r.MeiliDataDir != "/data/meili" {
+		t.Errorf("MeiliDataDir = %q, want /data/meili", r.MeiliDataDir)
+	}
+	if r.MinFreeGB != 120 {
+		t.Errorf("MinFreeGB = %d, want 120", r.MinFreeGB)
+	}
+}
+
+// A negative floor disables the guard rather than silently inverting the comparison.
+func TestLoadReindex_NegativeFloorClampedToZero(t *testing.T) {
+	t.Setenv("REINDEX_MIN_FREE_GB", "-5")
+
+	if got := LoadReindex().MinFreeGB; got != 0 {
+		t.Errorf("MinFreeGB = %d, want 0 (clamped)", got)
+	}
+}

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -165,11 +165,8 @@ type Rebuild struct {
 	// semantic marks this a hybrid-index rebuild: Push embeds each batch (via TEI) and
 	// attaches the vectors, since the semantic index uses a userProvided embedder.
 	semantic bool
-	// fromPG makes a semantic rebuild rehydrate from the vectors persisted in Postgres
-	// (jobs.semantic_embedding) instead of re-embedding via TEI — the fast recovery path.
-	fromPG  bool
-	rebuild meilisearch.IndexManager
-	tasks   []int64
+	rebuild  meilisearch.IndexManager
+	tasks    []int64
 }
 
 // NewFacetRebuild starts a full rebuild of the facet/keyword production index.
@@ -180,15 +177,6 @@ func (c *Client) NewFacetRebuild() *Rebuild {
 // NewSemanticRebuild starts a full rebuild of the hybrid semantic index.
 func (c *Client) NewSemanticRebuild() *Rebuild {
 	return &Rebuild{c: c, liveUID: semanticIndexUID, rebuildUID: semanticRebuildUID, settings: semanticSettings(), semantic: true}
-}
-
-// NewSemanticRebuildFromPG starts a full rebuild of the hybrid semantic index that
-// rehydrates from the vectors already stored in Postgres instead of re-embedding via
-// TEI. Jobs without a persisted vector are left out of the rebuild (the embed worker
-// fills them incrementally). Use it to restore the index after a Meili data loss
-// without paying the weeks-long re-embedding cost.
-func (c *Client) NewSemanticRebuildFromPG() *Rebuild {
-	return &Rebuild{c: c, liveUID: semanticIndexUID, rebuildUID: semanticRebuildUID, settings: semanticSettings(), semantic: true, fromPG: true}
 }
 
 // Prepare creates a fresh, empty rebuild index with this pass's settings, ready to
@@ -229,23 +217,16 @@ func (r *Rebuild) Push(ctx context.Context, docs []JobDocument) error {
 	}
 	// The semantic index stores userProvided vectors, so a semantic rebuild embeds each
 	// batch (via TEI) and pushes documents carrying their vectors; the facet rebuild
-	// pushes the plain documents.
+	// pushes the plain documents. (A from-Postgres rehydration does NOT use this swap
+	// path — see the in-place ResetSemanticIndex/IndexSemanticJobsFromPG.)
 	var payload any = docs
 	if r.semantic {
-		var sdocs []semanticDocument
-		if r.fromPG {
-			// Rehydrate: reuse the vectors already stored in Postgres, no TEI call.
-			// Documents without a persisted vector are dropped from this batch (the
-			// embed worker fills them incrementally).
-			sdocs = semanticDocsFromPG(docs)
-		} else {
-			var err error
-			if sdocs, err = r.c.embedDocs(ctx, docs); err != nil {
-				return err
-			}
+		sdocs, err := r.c.embedDocs(ctx, docs)
+		if err != nil {
+			return err
 		}
 		if len(sdocs) == 0 {
-			return nil // nothing to push this batch (e.g. none carried a persisted vector)
+			return nil // nothing to push this batch
 		}
 		payload = sdocs
 	}
@@ -271,6 +252,14 @@ func (r *Rebuild) Promote(ctx context.Context) error {
 		return err
 	}
 	// After the swap the old data lives under the rebuild uid; drop it.
+	return r.c.dropIndex(ctx, r.rebuildUID)
+}
+
+// Cleanup drops the rebuild index, tolerating its absence. reindexFull defers it so a
+// run that aborts before Promote (whose swap-and-drop is the normal teardown) does not
+// leave an orphan rebuild index — which otherwise eats ~index-size of disk until the
+// next run's Prepare clears it. Idempotent.
+func (r *Rebuild) Cleanup(ctx context.Context) error {
 	return r.c.dropIndex(ctx, r.rebuildUID)
 }
 
@@ -385,6 +374,34 @@ func (c *Client) IndexSemanticJobs(ctx context.Context, docs []JobDocument) (map
 		return nil, err
 	}
 	return vectorsByID(sdocs), nil
+}
+
+// ResetSemanticIndex drops the live semantic index and recreates it empty with the
+// semantic settings, so an in-place from-Postgres rehydration starts from a clean slate.
+// Dropping BEFORE the re-fill (instead of building a rebuild copy and swapping) keeps the
+// peak on-disk footprint at one index, never two — the reason the from-PG path is in-place.
+func (c *Client) ResetSemanticIndex(ctx context.Context) error {
+	if err := c.dropIndex(ctx, semanticIndexUID); err != nil {
+		return err
+	}
+	return c.EnsureSemanticIndex(ctx)
+}
+
+// IndexSemanticJobsFromPG upserts a batch into the live semantic index using the vector
+// each document already carries from Postgres (jobs.semantic_embedding), with no TEI call.
+// Documents without a persisted vector are dropped from the batch (semanticDocsFromPG). It
+// is the in-place rehydration counterpart of IndexSemanticJobs (which embeds via TEI).
+func (c *Client) IndexSemanticJobsFromPG(ctx context.Context, docs []JobDocument) error {
+	sdocs := semanticDocsFromPG(docs)
+	if len(sdocs) == 0 {
+		return nil
+	}
+	pk := primaryKey
+	task, err := c.semantic.UpdateDocumentsWithContext(ctx, sdocs, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+	if err != nil {
+		return fmt.Errorf("search: index semantic documents from pg: %w", err)
+	}
+	return c.awaitTask(ctx, c.semantic, task.TaskUID)
 }
 
 // EmbedJobs computes each document's vector WITHOUT touching Meilisearch, returning them

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -702,9 +702,6 @@ func TestIntegration_RebuildSwapsFreshIndexAndDropsOld(t *testing.T) {
 func TestIntegration_SemanticRebuildFromPG(t *testing.T) {
 	ctx := context.Background()
 	c := startMeili(t)
-	if err := c.EnsureSemanticIndex(ctx); err != nil {
-		t.Fatalf("EnsureSemanticIndex: %v", err)
-	}
 
 	vec := func(seed float32) []float32 {
 		v := make([]float32, embedderDimensions)
@@ -726,15 +723,13 @@ func TestIntegration_SemanticRebuildFromPG(t *testing.T) {
 			Enrichment:  enrichedJSON(t, enrich.Enrichment{})}, // no persisted vector
 	}
 
-	b := c.NewSemanticRebuildFromPG()
-	if err := b.Prepare(ctx); err != nil {
-		t.Fatalf("Prepare: %v", err)
+	// In-place rehydration: reset the live index to empty, then upsert the Postgres
+	// vectors straight into it (no rebuild copy, no swap).
+	if err := c.ResetSemanticIndex(ctx); err != nil {
+		t.Fatalf("ResetSemanticIndex: %v", err)
 	}
-	if err := b.Push(ctx, toDocs(t, jobs)); err != nil {
-		t.Fatalf("Push: %v", err)
-	}
-	if err := b.Promote(ctx); err != nil {
-		t.Fatalf("Promote: %v", err)
+	if err := c.IndexSemanticJobsFromPG(ctx, toDocs(t, jobs)); err != nil {
+		t.Fatalf("IndexSemanticJobsFromPG: %v", err)
 	}
 
 	got, err := c.ListSemanticVectors(ctx, 0, 100)


### PR DESCRIPTION
## Why

host2 recurrently hits 100% disk (2026-06-17, 06-25, 07-03, 07-23/24), each time taking down Postgres/Meili. Root cause: a full reindex builds a **second full copy** of the index then atomic-swaps; on a too-small disk it fills the volume, aborts before the swap, and leaves an **orphan `jobs_rebuild` index** (~50G) that lingers until dropped by hand.

Design doc: `docs/superpowers/specs/2026-07-24-reindex-disk-safety-disposable-semantic-design.md`.

## What

1. **In-place `--from-pg`.** `reindex --semantic --from-pg` now resets the live `jobs_semantic` and re-fills it from `jobs.semantic_embedding` in place — no TEI, no rebuild copy, no swap → never doubles disk. Makes the semantic index cheaply disposable (Postgres is the source of truth). Removes the swap-based `NewSemanticRebuildFromPG`.
2. **Disk guard.** `guardDisk` refuses a swap-rebuild (facet / TEI-semantic) when free disk on `MEILI_DATA_DIR` (default `/var/lib/freehire/meili`) is below `REINDEX_MIN_FREE_GB` (default 70). One statfs at startup — zero cost on the indexing hot path.
3. **Orphan cleanup.** `reindexFull` defers a best-effort `Cleanup` that drops the half-built rebuild index on any abort before Promote.

`config.LoadReindex` added; shared paging loop extracted to `streamOpenDocs`.

## Note

The guard will **refuse the facet reindex** until the disk grows (index ~50G vs ~53G free) — intended: refusing is safe, filling the disk is an outage. Incremental ingest keeps the facet index fresh; the full reindex is a reconciler.

## Testing

- Unit (TDD, red→green): config defaults/env/clamp; guard threshold (abort/proceed/disabled/probe-error); defer-cleanup on abort + no-cleanup on success; from-pg resets-then-pushes-open.
- `go build ./...`, `go vet ./...` (incl `-tags=integration`), `gofmt`, full unit suite all clean.
- Integration test updated to the in-place API (compiles under `-tags=integration`; not run here — needs Docker/Meili).