### PR TITLE
feat(sources): onboard contributed boards (DMED, KIS Solutions, Stealth Physical AI)

### DIFF
--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -693,6 +693,8 @@
   board: squer
 - company: stanley-stella
   board: stanley-stella
+- company: Stealth Physical AI
+  board: stealthphysicalai
 - company: steinhuber
   board: steinhuber
 - company: suitepad

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -51,6 +51,8 @@
   board: devoted-studios-1
 - company: Devsu
   board: devsu
+- company: DMED
+  board: dmed
 - company: Double Eleven
   board: double-eleven
 - company: Drake cooper

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -1049,6 +1049,8 @@
   board: kienbaum.zohorecruit.com
 - company: Kinatex Sports Physio
   board: kinatex-physio.zohorecruit.ca
+- company: KIS Solutions
+  board: kissolutions.zohorecruit.com
 - company: KKSK International
   board: kksktannery.zohorecruit.com
 - company: KN International


### PR DESCRIPTION
Drains the recognized `pending` rows in prod `link_contributions` into the source board files (the manual version of the deferred ingest-onboard worker).

## Onboarded (new boards, validated live)
| source | company | board | check |
|---|---|---|---|
| workable | DMED | `dmed` | widget API returns jobs |
| zohorecruit | KIS Solutions | `kissolutions.zohorecruit.com` | `/jobs/Careers` 200 |
| personio | Stealth Physical AI | `stealthphysicalai` | careers page 200 |

## Already tracked (marked onboarded, no change)
Six pending contributions turned out to be re-submissions of boards already in `sources/`, under a case or host variant. Both the Workday cxs endpoint and the Ashby posting API are case-insensitive, so the existing lowercase entries already crawl these:

- `workday` salesforce/**Slack** → existing `.../slack`
- `workday` walmart/**WalmartExternal** → existing `.../walmartexternal`
- `workday` availity/**Availity_Careers_US** → existing `.../availity_careers_us`
- `ashby` **Blackpoint Cyber** → existing `blackpoint cyber` entry
- `ashby` **Crusoe** → existing `crusoe`
- `teamtailor` **app.teamtailor.com** (mis-recognized generic host) → real board `career.avenga.com` already in file

Adding the CamelCase Workday variants would have **doubled** jobs (Workday namespaces `external_id` by the board string), so they were deliberately not added.

Prod `link_contributions` rows will be flipped to `onboarded` after merge + sources deploy. Crawling of the three new boards begins on the next ingest cycle.