### PR TITLE
feat(sources): onboard review-queue boards (Realco, Phorest, INEXTO)

### DIFF
--- a/sources/gupy.yml
+++ b/sources/gupy.yml
@@ -2910,3 +2910,6 @@
 # --- aggregator-harvested + live-validated 1 boards ---
 - company: Swapfinancial
   board: 87487
+# --- contributed boards ---
+- company: Realco Soluções em Gestão de Pessoas
+  board: "21289"

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3085,3 +3085,8 @@
   board: toppansecurity.teamtailor.com
 - company: Veoneer Safety Systems USA
   board: veoneerus.teamtailor.com
+# --- contributed boards ---
+- company: Phorest
+  board: careers.phorest.com
+- company: INEXTO
+  board: careers.inexto.com


### PR DESCRIPTION
Second drain pass — the **review queue** (unrecognized `link_contributions` with source/board NULL). Triaged 31 rows; this PR onboards the ones that map to an already-supported adapter.

## Onboarded (new boards, validated live)
| source | company | board | check |
|---|---|---|---|
| gupy | Realco Soluções em Gestão de Pessoas | `21289` | portal API returns jobs |
| teamtailor | Phorest | `careers.phorest.com` | listing serves jobs |
| teamtailor | INEXTO | `careers.inexto.com` | listing serves jobs |

## Resolved without a source change
- **Grupo Boticário** (gupy `295`) — already tracked
- **SCOR** (oracle `fa-errt-…/CX_2001` + `/jobsearch`) — already tracked; adding `CX_1` would risk doubling SCOR requisitions

## Rejected (no derivable board)
- `www.careers-page.com/nearshore-business-solutions` — the `<tenant>.careers-page.com` host 404s
- `workforcenow.adp.com/…/recruitment.html` — bare URL, no `cid:ccId` tenant identity
- `dreamgroup.com/comeet-positions/…` — Comeet custom-domain embed, companyUID not derivable

## Left in review
- `careers-americas.icims.com` — serves an iCIMS listing but the employer identity couldn't be confirmed; needs a manual name before onboarding.

Prod `link_contributions` rows will be promoted (+5 credits, idempotent) after merge; rejects flipped to `rejected`.