### PR TITLE
feat(sources): add TalentHR adapter

### DIFF
--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -44,6 +44,7 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"jobs.gem.com", "gem", modePath},
 	{"jobs.jobvite.com", "jobvite", modePath},
 	{"jobs.quickin.io", "quickin", modePath},
+	{"jobs.talenthr.io", "talenthr", modePath},
 	{"careers.pageuppeople.com", "pageup", modePath},
 	{"oportunidades.mindsight.com.br", "mindsight", modePath},
 	{"careers.hireology.com", "hireology", modePath},

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -21,6 +21,7 @@ func TestRecognizeBoard(t *testing.T) {
 		{"lever strips /apply", "https://jobs.lever.co/offchainlabs/52c01c91/apply", "lever", "offchainlabs", "https://jobs.lever.co/offchainlabs/52c01c91", true},
 		{"lever eu data-residency host", "https://jobs.eu.lever.co/coinspaid/244123b5-ffbb/apply?x=1", "lever", "coinspaid", "https://jobs.eu.lever.co/coinspaid/244123b5-ffbb", true},
 		{"ashby vacancy", "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799", "ashby", "blitzy", "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799", true},
+		{"talenthr vacancy", "https://jobs.talenthr.io/dnext/senior-backend-developer-2/22", "talenthr", "dnext", "https://jobs.talenthr.io/dnext/senior-backend-developer-2/22", true},
 		{"deel path", "https://jobs.deel.com/acme/jobs/123", "deel", "acme", "https://jobs.deel.com/acme/jobs/123", true},
 		{"jobvite path", "https://jobs.jobvite.com/acme/job/oABC", "jobvite", "acme", "https://jobs.jobvite.com/acme/job/oABC", true},
 

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -346,6 +346,7 @@ func All(c HTTPClient) map[string]Source {
 		NewDataArt(c),
 		NewOnstrider(c),
 		NewAlignerr(c),
+		NewTalentHR(c),
 		NewMicro1(c),
 		NewBairesDev(c),
 		// RU federal open-data aggregator: board-based, sharded per region (board = OKATO code).

--- a/internal/sources/talenthr.go
+++ b/internal/sources/talenthr.go
@@ -1,0 +1,173 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// talenthr adapts TalentHR (talenthr.io), a multi-tenant ATS. Each tenant's public careers
+// site is a Next.js app at https://jobs.talenthr.io/<board> (board = the tenant slug)
+// embedding its data in the __NEXT_DATA__ script: the listing carries every open position's id
+// and slug, and each position's own detail page carries the full record (description,
+// structured location, a work-mode and an employment enum, and the publish date). The body and
+// facets therefore come from a per-posting detail fetch, fanned out like the other Next.js
+// detail adapters (alignerr/micro1). The native posting id namespaces external_id.
+type talenthr struct {
+	http TextGetter
+}
+
+// NewTalentHR builds the TalentHR adapter over the given HTTP client.
+func NewTalentHR(c TextGetter) Source { return talenthr{http: c} }
+
+func (talenthr) Provider() string { return "talenthr" }
+
+// talenthrBaseURL is the shared host serving every tenant's careers site.
+const talenthrBaseURL = "https://jobs.talenthr.io"
+
+// talenthrNextData is the slice of __NEXT_DATA__ we read: the listing exposes positions, a
+// detail page exposes the single job under data.
+type talenthrNextData struct {
+	Props struct {
+		PageProps struct {
+			Positions []talenthrListItem `json:"positions"`
+			Data      *talenthrJob       `json:"data"`
+		} `json:"pageProps"`
+	} `json:"props"`
+}
+
+// talenthrListItem is one posting from the listing: the id and slug that build its detail URL.
+type talenthrListItem struct {
+	ID   json.Number `json:"id"`
+	Slug string      `json:"slug"`
+}
+
+// talenthrJob is a detail page's job record. job_description is the full HTML body; is_remote
+// and employment_type carry structured work-mode signal; employment_status_name is the
+// full-time/part-time enum; publish_date (created_at fallback) is the post date.
+type talenthrJob struct {
+	Title                string `json:"job_position_title"`
+	Description          string `json:"job_description"`
+	IsRemote             bool   `json:"is_remote"`
+	EmploymentType       string `json:"employment_type"`
+	EmploymentStatusName string `json:"employment_status_name"`
+	City                 string `json:"city"`
+	Region               string `json:"region"`
+	Country              string `json:"country"`
+	LocationName         string `json:"location_name"`
+	LocationAddress      string `json:"location_address"`
+	PublishDate          string `json:"publish_date"`
+	CreatedAt            string `json:"created_at"`
+}
+
+func (s talenthr) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	listURL := talenthrBaseURL + "/" + e.Board
+	body, err := s.http.GetText(ctx, listURL)
+	if err != nil {
+		return nil, fmt.Errorf("talenthr: listing %s: %w", e.Board, err)
+	}
+	raw, ok := bracketSlice(body, "__NEXT_DATA__", '{', '}')
+	if !ok {
+		return nil, fmt.Errorf("talenthr: no __NEXT_DATA__ in listing %s", e.Board)
+	}
+	var data talenthrNextData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return nil, fmt.Errorf("talenthr: decode listing %s: %w", e.Board, err)
+	}
+
+	// Each posting's body and structured fields come from its own detail page, fanned out
+	// under a bounded pool.
+	return fetchDetails(data.Props.PageProps.Positions, defaultDetailWorkers, func(it talenthrListItem) (Job, bool) {
+		return s.detail(ctx, e, it)
+	}), nil
+}
+
+// detail fetches one position's detail page and maps its record to a Job, returning ok=false
+// when the id/slug is missing, the fetch fails, or the page carries no job — so the caller
+// skips just that posting.
+func (s talenthr) detail(ctx context.Context, e CompanyEntry, it talenthrListItem) (Job, bool) {
+	id := strings.TrimSpace(it.ID.String())
+	slug := strings.TrimSpace(it.Slug)
+	if id == "" || id == "0" || slug == "" {
+		return Job{}, false // no stable id/slug → can't address the posting; skip it
+	}
+	jobURL := fmt.Sprintf("%s/%s/%s/%s", talenthrBaseURL, e.Board, slug, id)
+	body, err := s.http.GetText(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	raw, ok := bracketSlice(body, "__NEXT_DATA__", '{', '}')
+	if !ok {
+		return Job{}, false
+	}
+	var data talenthrNextData
+	if json.Unmarshal([]byte(raw), &data) != nil {
+		return Job{}, false
+	}
+	j := data.Props.PageProps.Data
+	if j == nil || strings.TrimSpace(j.Title) == "" {
+		return Job{}, false
+	}
+
+	location := talenthrLocation(j)
+	workMode := talenthrWorkMode(j.EmploymentType, j.IsRemote)
+	return Job{
+		ExternalID:     id,
+		URL:            jobURL,
+		Title:          strings.TrimSpace(j.Title),
+		Company:        e.Company,
+		Location:       location,
+		Description:    sanitizeHTML(j.Description),
+		Remote:         workMode == "remote" || isRemote(location),
+		WorkMode:       workMode,
+		EmploymentType: talenthrEmploymentType(j.EmploymentStatusName),
+		PostedAt:       parseLayout("2006-01-02 15:04:05", firstNonEmpty(j.PublishDate, j.CreatedAt)),
+	}, true
+}
+
+// talenthrLocation composes the free-text location from the structured parts, most specific
+// first, falling back to the location name/address the tenant configured.
+func talenthrLocation(j *talenthrJob) string {
+	var parts []string
+	for _, p := range []string{j.City, j.Region, j.Country} {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, ", ")
+	}
+	return firstNonEmpty(strings.TrimSpace(j.LocationAddress), strings.TrimSpace(j.LocationName))
+}
+
+// talenthrWorkMode maps TalentHR's employment_type work-arrangement enum onto freehire's
+// work-mode vocabulary, falling back to the is_remote flag; "" when neither is decisive so the
+// pipeline's location heuristic decides.
+func talenthrWorkMode(employmentType string, isRemote bool) string {
+	switch strings.ToLower(strings.TrimSpace(employmentType)) {
+	case "remote":
+		return "remote"
+	case "hybrid":
+		return "hybrid"
+	case "onsite", "on-site", "on site":
+		return "onsite"
+	}
+	return workModeFromRemote(isRemote)
+}
+
+// talenthrEmploymentType maps TalentHR's employment_status_name enum onto the freehire
+// vocabulary, returning "" for an unknown/absent value so the description parser decides.
+func talenthrEmploymentType(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "full-time", "full time", "fulltime":
+		return "full_time"
+	case "part-time", "part time", "parttime":
+		return "part_time"
+	case "contract", "contractor", "temporary", "freelance":
+		return "contract"
+	case "internship", "intern", "trainee":
+		return "internship"
+	}
+	return ""
+}

--- a/internal/sources/talenthr_test.go
+++ b/internal/sources/talenthr_test.go
@@ -1,0 +1,152 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// talenthrListingJSON is a tenant listing page's __NEXT_DATA__: positions carries each open
+// posting's id and slug, which the adapter uses to address the detail page.
+func talenthrListingJSON(items ...talenthrListItem) string {
+	var parts []string
+	for _, it := range items {
+		parts = append(parts, `{"id":`+it.ID.String()+`,"slug":"`+it.Slug+`"}`)
+	}
+	return `<script id="__NEXT_DATA__" type="application/json">` +
+		`{"props":{"pageProps":{"positions":[` + strings.Join(parts, ",") + `]}}}` +
+		`</script>`
+}
+
+// talenthrDetailJSON is a detail page's __NEXT_DATA__ data record. The description embeds a
+// <script> that sanitizeHTML must strip; employment_type is the work-mode enum and
+// employment_status_name the full-time/part-time enum.
+func talenthrDetailJSON(title, employmentType, status string) string {
+	return `<script id="__NEXT_DATA__" type="application/json">` +
+		`{"props":{"pageProps":{"data":{"job_position_title":"` + title + `",` +
+		`"job_description":"<p>Own the backend.</p><script>alert(1)</script>",` +
+		`"is_remote":false,"employment_type":"` + employmentType + `",` +
+		`"employment_status_name":"` + status + `",` +
+		`"city":"","region":"","country":"CH","location_name":"CH",` +
+		`"publish_date":"2026-07-17 10:33:19","created_at":"2026-07-17 10:33:18"}}}}` +
+		`</script>`
+}
+
+func TestTalentHRProvider(t *testing.T) {
+	if got := NewTalentHR(nil).Provider(); got != "talenthr" {
+		t.Errorf("Provider() = %q, want %q", got, "talenthr")
+	}
+}
+
+func TestTalentHRFetchListingThenDetailAndMaps(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/dnext/senior-backend-developer-2/22", talenthrDetailJSON("Senior Backend Developer", "Remote", "Full-Time")).
+		route("jobs.talenthr.io/dnext", talenthrListingJSON(talenthrListItem{ID: "22", Slug: "senior-backend-developer-2"}))
+
+	jobs, err := NewTalentHR(fake).Fetch(context.Background(), CompanyEntry{Company: "Dnext Intelligence", Provider: "talenthr", Board: "dnext"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "22" {
+		t.Errorf("ExternalID = %q, want 22", j.ExternalID)
+	}
+	if j.URL != "https://jobs.talenthr.io/dnext/senior-backend-developer-2/22" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Senior Backend Developer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Dnext Intelligence" {
+		t.Errorf("Company = %q, want the board display name", j.Company)
+	}
+	if j.Location != "CH" {
+		t.Errorf("Location = %q, want CH", j.Location)
+	}
+	if j.WorkMode != "remote" || !j.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want remote", j.WorkMode, j.Remote)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Own the backend") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 17, 10, 33, 19, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want publish_date 2026-07-17 10:33:19", j.PostedAt)
+	}
+}
+
+func TestTalentHRDropsMissingSlugAndMissingDetail(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/dnext/live-role/10", talenthrDetailJSON("Live Role", "Onsite", "Full-Time")).
+		// "gone" has a slug but no detail route → its detail fetch fails
+		route("jobs.talenthr.io/dnext", talenthrListingJSON(
+			talenthrListItem{ID: "10", Slug: "live-role"},
+			talenthrListItem{ID: "11", Slug: ""}, // no slug → cannot address the posting
+			talenthrListItem{ID: "12", Slug: "gone"},
+		))
+
+	jobs, err := NewTalentHR(fake).Fetch(context.Background(), CompanyEntry{Company: "Dnext Intelligence", Board: "dnext"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "10" {
+		t.Fatalf("got %v, want only the posting with a slug and a reachable detail", jobs)
+	}
+}
+
+func TestTalentHRWorkMode(t *testing.T) {
+	cases := []struct {
+		employmentType string
+		isRemote       bool
+		want           string
+	}{
+		{"Remote", false, "remote"},
+		{"Hybrid", false, "hybrid"},
+		{"Onsite", false, "onsite"},
+		{"On-site", false, "onsite"},
+		{"", true, "remote"},
+		{"", false, ""},
+		{"Weird", false, ""},
+	}
+	for _, c := range cases {
+		if got := talenthrWorkMode(c.employmentType, c.isRemote); got != c.want {
+			t.Errorf("talenthrWorkMode(%q, %v) = %q, want %q", c.employmentType, c.isRemote, got, c.want)
+		}
+	}
+}
+
+func TestTalentHREmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"Full-Time": "full_time", "Part-Time": "part_time",
+		"Contract": "contract", "Internship": "internship", "": "", "Seasonal": "",
+	}
+	for in, want := range cases {
+		if got := talenthrEmploymentType(in); got != want {
+			t.Errorf("talenthrEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestTalentHRRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["talenthr"]
+	if !ok {
+		t.Fatal("All() missing provider talenthr")
+	}
+	if s.Provider() != "talenthr" {
+		t.Errorf("All()[talenthr].Provider() = %q", s.Provider())
+	}
+	// Multi-tenant, board-based: it belongs in the source facet.
+	if !slices.Contains(FilterableProviders(), "talenthr") {
+		t.Error("FilterableProviders() should include board-based talenthr")
+	}
+}

--- a/sources/talenthr.yml
+++ b/sources/talenthr.yml
@@ -1,0 +1,7 @@
+# talenthr boards. Provider is the filename; each entry is company + board.
+# board = the tenant slug (see internal/sources/talenthr.go); the adapter reads
+# https://jobs.talenthr.io/<board>, enumerates its __NEXT_DATA__ positions, and fetches
+# each position's own detail page. Each board validated live (>0 jobs) before adding.
+
+- company: Dnext Intelligence
+  board: dnext


### PR DESCRIPTION
New ATS adapter for **TalentHR** (`talenthr.io`), a multi-tenant applicant-tracking system — from the review-queue triage (group B, new-adapter candidates).

## How it works
Each tenant's careers site is a Next.js app at `https://jobs.talenthr.io/<board>` (board = tenant slug) embedding its data in the `__NEXT_DATA__` script:
- **Listing** → `pageProps.positions[]` gives each open position's `id` + `slug`.
- **Detail** (`/<board>/<slug>/<id>`) → `pageProps.data` gives the full record: `job_description` (HTML), structured `city/region/country`, `employment_type` (work-mode enum), `employment_status_name` (FT/PT enum), and `publish_date`.

Body and facets come from a bounded per-posting detail fan-out (`fetchDetails`), the same pattern as `alignerr`/`micro1`. Structured **WorkMode** and **EmploymentType** are mapped into freehire's vocabularies (never guessed); the native posting id namespaces `external_id`.

## Wiring
- `internal/sources/talenthr.go` + `talenthr_test.go` (mapping, drop-on-missing-detail, enum mappers, registry membership)
- one line in `sources.All`
- recognizer entry `jobs.talenthr.io → talenthr` in `internal/contribution/board.go` (so future contributed TalentHR links auto-recognize + earn credit)
- `sources/talenthr.yml` seeded with **Dnext Intelligence** (`dnext`), validated live

Onboards the review-queue contribution `jobs.talenthr.io/dnext/…`. `go build`, `go vet`, `gofmt`, and the sources + contribution test suites all pass locally.