### PR TITLE
fix(sources): drop dead personio board stealthphysicalai

### DIFF
--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -693,8 +693,6 @@
   board: squer
 - company: stanley-stella
   board: stanley-stella
-- company: Stealth Physical AI
-  board: stealthphysicalai
 - company: steinhuber
   board: steinhuber
 - company: suitepad


### PR DESCRIPTION
`stealthphysicalai` was onboarded in #1106 on the strength of a careers-page `200`, but the Personio **XML feed** the adapter actually consumes — `https://stealthphysicalai.jobs.personio.com/xml` — returns **404** (verified; a known-good board like `4screen` returns 200). Every crawl fails, so the board sits in `board_health` cooldown and never ingests.

The tenant keeps a careers page up with the XML feed disabled → not ingestable via our adapter. Removing it. The contribution row (#78) is flipped to `rejected` on prod; the submit-time point is not revoked (per the onboarding guardrail).

Lesson: validate personio boards against the `/xml` feed, not the careers page.