### PR TITLE
feat(search): public agent jobs search endpoint with full descriptions + format

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 # freehire API
 
-Base URL: `https://freehire.dev/api/v1`
+Base URL: `https://freehire.me/api/v1`
 
 ## Contents
 
@@ -27,7 +27,7 @@ Base URL: `https://freehire.dev/api/v1`
 
 ## Base URL
 
-All endpoints are served under `https://freehire.dev/api/v1`. The API is read-first and open: the job, search, facet, and company endpoints need no authentication and may be called cross-origin.
+All endpoints are served under `https://freehire.me/api/v1`. The API is read-first and open: the job, search, facet, and company endpoints need no authentication and may be called cross-origin.
 
 Authenticated endpoints accept either the browser session cookie (set by sign-in, same-origin) or a personal API key sent as a Bearer token — see Authentication and API keys below.
 
@@ -135,7 +135,7 @@ List jobs, newest first, with limit/offset pagination.
 | `offset` | integer | no | Rows to skip. (e.g. `0`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/jobs?limit=20&offset=0"
+curl "https://freehire.me/api/v1/jobs?limit=20&offset=0"
 ```
 
 ```json
@@ -221,7 +221,7 @@ Combine free-text `q` with any of the filter params below. Repeated facet params
 Plus every filter in [Filtering jobs](#filtering-jobs).
 
 ```bash
-curl "https://freehire.dev/api/v1/jobs/search?q=golang&seniority=senior&work_mode=remote&regions=cis&sort=posted_at"
+curl "https://freehire.me/api/v1/jobs/search?q=golang&seniority=senior&work_mode=remote&regions=cis&sort=posted_at"
 ```
 
 ```json
@@ -254,7 +254,7 @@ Same query and filters as `/jobs/search`, but each result carries the `descripti
 Plus every filter in [Filtering jobs](#filtering-jobs).
 
 ```bash
-curl "https://freehire.dev/api/v1/agent/jobs/search?q=golang&work_mode=remote&description_format=markdown"
+curl "https://freehire.me/api/v1/agent/jobs/search?q=golang&work_mode=remote&description_format=markdown"
 ```
 
 ```json
@@ -280,7 +280,7 @@ Takes the same `q` and filter params as search, but returns the distribution of 
 | `(any filter)` | string | no | Any search filter param narrows the counted set. (e.g. `work_mode=remote`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/jobs/facets?work_mode=remote"
+curl "https://freehire.me/api/v1/jobs/facets?work_mode=remote"
 ```
 
 ```json
@@ -311,7 +311,7 @@ A single job by its public slug (serves closed jobs too).
 | `slug` | string | yes | The job `public_slug`. (e.g. `senior-go-engineer-acme-1a2b`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/jobs/senior-go-engineer-acme-1a2b"
+curl "https://freehire.me/api/v1/jobs/senior-go-engineer-acme-1a2b"
 ```
 
 ```json
@@ -339,7 +339,7 @@ Backed by the optional semantic index. Returns an empty list (not an error) when
 | `limit` | integer | no | Max similar jobs. (e.g. `10`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/jobs/senior-go-engineer-acme-1a2b/similar?limit=10"
+curl "https://freehire.me/api/v1/jobs/senior-go-engineer-acme-1a2b/similar?limit=10"
 ```
 
 ```json
@@ -368,7 +368,7 @@ The per-city openings folded under one canonical card by content-dedup — each 
 | `offset` | integer | no | Rows to skip. (e.g. `0`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/jobs/senior-go-engineer-acme-1a2b/copies"
+curl "https://freehire.me/api/v1/jobs/senior-go-engineer-acme-1a2b/copies"
 ```
 
 ```json
@@ -404,7 +404,7 @@ How well the job’s skills are covered by your profile skills — exact, adjace
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl "https://freehire.dev/api/v1/jobs/<slug>/match" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/jobs/<slug>/match" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -436,7 +436,7 @@ Returns the cached analysis, flagged `stale` when your CV or the job changed sin
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl "https://freehire.dev/api/v1/jobs/<slug>/fit" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/jobs/<slug>/fit" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -473,7 +473,7 @@ Runs the fit prompt-chain over your stored CV and the job, caches the result, an
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/jobs/<slug>/fit" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X POST "https://freehire.me/api/v1/jobs/<slug>/fit" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -501,7 +501,7 @@ The same three-stage chain as `POST /jobs/{slug}/fit`, streamed as SSE (`text/ev
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -N "https://freehire.dev/api/v1/jobs/<slug>/fit/stream" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -N "https://freehire.me/api/v1/jobs/<slug>/fit/stream" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -528,7 +528,7 @@ Ranks jobs by your persisted CV embedding, constrained by the same facet filter 
 | `offset` | integer | no | Rows to skip; `offset + limit` ≤ 10000. (e.g. `0`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/me/recommendations" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/me/recommendations" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -559,7 +559,7 @@ Stateless sibling of the CV verdict: skills come from the request body, the mark
 | `skills` | string[] | yes | The skill list to score (max 100). (e.g. `["go","postgresql"]`) |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/market/coverage?category=backend" \
+curl -X POST "https://freehire.me/api/v1/market/coverage?category=backend" \
   -H "Authorization: Bearer $FREEHIRE_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"skills":["go","postgresql"]}'
@@ -615,7 +615,7 @@ Most active first. Facet params are repeatable and filter by array overlap (OR w
 | `offset` | integer | no | Rows to skip. (e.g. `0`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/companies?q=acme&collections=yc"
+curl "https://freehire.me/api/v1/companies?q=acme&collections=yc"
 ```
 
 ```json
@@ -670,7 +670,7 @@ A company and a page of its open jobs.
 | `offset` | integer | no | Rows to skip in the jobs list. (e.g. `0`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/companies/acme"
+curl "https://freehire.me/api/v1/companies/acme"
 ```
 
 ```json
@@ -714,7 +714,7 @@ Distinct company subindustry vocabulary with company counts.
 Backs the searchable “Industry” facet’s option list, most common first. Counts are unconditional (they do not reflect other active list filters).
 
 ```bash
-curl "https://freehire.dev/api/v1/companies/subindustries"
+curl "https://freehire.me/api/v1/companies/subindustries"
 ```
 
 ```json
@@ -739,7 +739,7 @@ Create an account and start a session.
 | `password` | string | yes | Account password. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/auth/register" \
+curl -X POST "https://freehire.me/api/v1/auth/register" \
   -H 'Content-Type: application/json' \
   -c cookies.txt \
   -d '{"email":"me@example.com","password":"hunter2hunter2"}'
@@ -763,7 +763,7 @@ Sign in and start a session.
 | `password` | string | yes | Account password. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/auth/login" \
+curl -X POST "https://freehire.me/api/v1/auth/login" \
   -H 'Content-Type: application/json' \
   -c cookies.txt \
   -d '{"email":"me@example.com","password":"hunter2hunter2"}'
@@ -780,7 +780,7 @@ curl -X POST "https://freehire.dev/api/v1/auth/login" \
 Clear the session cookie.
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/auth/logout" -b cookies.txt
+curl -X POST "https://freehire.me/api/v1/auth/logout" -b cookies.txt
 ```
 
 ```json
@@ -794,7 +794,7 @@ curl -X POST "https://freehire.dev/api/v1/auth/logout" -b cookies.txt
 The current user (cookie or API key).
 
 ```bash
-curl "https://freehire.dev/api/v1/auth/me" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/auth/me" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -808,7 +808,7 @@ curl "https://freehire.dev/api/v1/auth/me" -H "Authorization: Bearer $FREEHIRE_A
 List the enabled OAuth providers.
 
 ```bash
-curl "https://freehire.dev/api/v1/auth/oauth/providers"
+curl "https://freehire.me/api/v1/auth/oauth/providers"
 ```
 
 ```json
@@ -831,7 +831,7 @@ Browser-only: redirects to the provider, then back to `/auth/oauth/{provider}/ca
 
 ```bash
 # open in a browser:
-https://freehire.dev/api/v1/auth/oauth/google/start
+https://freehire.me/api/v1/auth/oauth/google/start
 ```
 
 ## API keys
@@ -852,7 +852,7 @@ Create a key; returns the plaintext token once.
 | `expires_at` | string (RFC3339) | no | Optional expiry; omit for no expiry. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/me/api-keys" \
+curl -X POST "https://freehire.me/api/v1/me/api-keys" \
   -H 'Content-Type: application/json' \
   -b cookies.txt \
   -d '{"name":"cli-laptop"}'
@@ -869,7 +869,7 @@ curl -X POST "https://freehire.dev/api/v1/me/api-keys" \
 List your keys (metadata only, never the token).
 
 ```bash
-curl "https://freehire.dev/api/v1/me/api-keys" -b cookies.txt
+curl "https://freehire.me/api/v1/me/api-keys" -b cookies.txt
 ```
 
 ```json
@@ -889,7 +889,7 @@ Revoke a key.
 | `id` | integer | yes | The key id. (e.g. `7`) |
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/me/api-keys/7" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/api-keys/7" -b cookies.txt
 ```
 
 ```json
@@ -913,7 +913,7 @@ Record that you viewed the job.
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/jobs/<slug>/view" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X POST "https://freehire.me/api/v1/jobs/<slug>/view" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -933,7 +933,7 @@ Mark the job as applied to.
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/jobs/<slug>/apply" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X POST "https://freehire.me/api/v1/jobs/<slug>/apply" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -953,7 +953,7 @@ Save (bookmark) the job.
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/jobs/<slug>/save" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X POST "https://freehire.me/api/v1/jobs/<slug>/save" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -973,7 +973,7 @@ Unsave the job (no-op if not saved).
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/jobs/<slug>/save" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/save" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1002,7 +1002,7 @@ A null field is left unchanged. `stage` is a controlled vocabulary: `applied`, `
 | `notes` | string | no | Free-text notes. |
 
 ```bash
-curl -X PATCH "https://freehire.dev/api/v1/jobs/<slug>/track" \
+curl -X PATCH "https://freehire.me/api/v1/jobs/<slug>/track" \
   -H "Authorization: Bearer $FREEHIRE_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"stage":"interview","notes":"call on Friday"}'
@@ -1025,7 +1025,7 @@ Clear the application stage.
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/jobs/<slug>/stage" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/stage" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1045,7 +1045,7 @@ Remove the interaction record entirely.
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/jobs/<slug>/track" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/track" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1067,7 +1067,7 @@ Only keeps the job out of the swipe deck; it stays visible in the public `/jobs`
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/jobs/<slug>/dismiss" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X POST "https://freehire.me/api/v1/jobs/<slug>/dismiss" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1087,7 +1087,7 @@ Undismiss the job (no-op if not dismissed).
 | `slug` | string | yes | The job `public_slug`. |
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/jobs/<slug>/dismiss" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/dismiss" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1111,7 +1111,7 @@ Each item carries the job in the shared wire shape with your interaction timesta
 | `offset` | integer | no | Rows to skip. (e.g. `0`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/me/tracking?filter=applied" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/me/tracking?filter=applied" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1142,7 +1142,7 @@ curl "https://freehire.dev/api/v1/me/tracking?filter=applied" -H "Authorization:
 Slugs of jobs you have viewed.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/tracking/viewed" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/me/tracking/viewed" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1158,7 +1158,7 @@ Jobs you have run the AI fit analysis on.
 Newest first, closed jobs included (with `closed: true`). Each item carries the overall score and verdict; `stale` marks an analysis whose CV, job, or model has changed since. `meta.quota` reports your monthly fit-analysis usage. Never runs the LLM.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/tracking/analyses" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/me/tracking/analyses" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1188,7 +1188,7 @@ Slugs of jobs you have saved.
 Lets the SPA render the save toggle as filled without authenticating the public job reads.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/tracking/saved" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/me/tracking/saved" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1204,7 +1204,7 @@ Your application-pipeline snapshot (counts per stage bucket).
 The total application count and its distribution across the seven status buckets, aggregated server-side over all of your applications.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/tracking/pipeline" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/me/tracking/pipeline" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1241,7 +1241,7 @@ Runs the same query as search (same facets, `q`, and sort), then excludes the jo
 | `offset` | integer | no | Rows to skip; `offset + limit` ≤ 10000. (e.g. `0`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/me/tracking/swipe" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/me/tracking/swipe" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1275,7 +1275,7 @@ Submit a vacancy for review.
 | `posted_at` | string (RFC3339) | no | Original posting date (optional). |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/submissions" \
+curl -X POST "https://freehire.me/api/v1/submissions" \
   -H "Authorization: Bearer $FREEHIRE_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"url":"https://acme.com/careers/123","title":"Senior Go Engineer","company":"Acme","remote":true}'
@@ -1292,7 +1292,7 @@ curl -X POST "https://freehire.dev/api/v1/submissions" \
 Your own submission queue.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/submissions" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+curl "https://freehire.me/api/v1/me/submissions" -H "Authorization: Bearer $FREEHIRE_API_KEY"
 ```
 
 ```json
@@ -1306,7 +1306,7 @@ curl "https://freehire.dev/api/v1/me/submissions" -H "Authorization: Bearer $FRE
 The pending submission queue (moderators).
 
 ```bash
-curl "https://freehire.dev/api/v1/submissions" -H "Authorization: Bearer $MODERATOR_API_KEY"
+curl "https://freehire.me/api/v1/submissions" -H "Authorization: Bearer $MODERATOR_API_KEY"
 ```
 
 ```json
@@ -1326,7 +1326,7 @@ Approve a submission, minting a live job.
 | `id` | integer | yes | The submission id. (e.g. `9`) |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/submissions/9/approve" -H "Authorization: Bearer $MODERATOR_API_KEY"
+curl -X POST "https://freehire.me/api/v1/submissions/9/approve" -H "Authorization: Bearer $MODERATOR_API_KEY"
 ```
 
 ```json
@@ -1352,7 +1352,7 @@ Reject a submission with a reason.
 | `reason` | string | no | Why it was rejected. (e.g. `duplicate`) |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/submissions/9/reject" \
+curl -X POST "https://freehire.me/api/v1/submissions/9/reject" \
   -H "Authorization: Bearer $MODERATOR_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"reason":"duplicate"}'
@@ -1387,7 +1387,7 @@ Report a problem with a job.
 | `contact_telegram` | string | no | Optional contact handle. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/jobs/<slug>/reports" \
+curl -X POST "https://freehire.me/api/v1/jobs/<slug>/reports" \
   -H "Authorization: Bearer $FREEHIRE_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"reason":"expired","details":"posting returns 404"}'
@@ -1404,7 +1404,7 @@ curl -X POST "https://freehire.dev/api/v1/jobs/<slug>/reports" \
 The pending report queue (moderators).
 
 ```bash
-curl "https://freehire.dev/api/v1/reports" -H "Authorization: Bearer $MODERATOR_API_KEY"
+curl "https://freehire.me/api/v1/reports" -H "Authorization: Bearer $MODERATOR_API_KEY"
 ```
 
 ```json
@@ -1430,7 +1430,7 @@ Resolve a report, optionally closing the job.
 | `close_job` | boolean | no | Soft-close the reported job. (e.g. `true`) |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/reports/3/resolve" \
+curl -X POST "https://freehire.me/api/v1/reports/3/resolve" \
   -H "Authorization: Bearer $MODERATOR_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"close_job":true}'
@@ -1459,7 +1459,7 @@ Dismiss a report with a reason.
 | `reason` | string | no | Why it was dismissed. (e.g. `not an issue`) |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/reports/3/dismiss" \
+curl -X POST "https://freehire.me/api/v1/reports/3/dismiss" \
   -H "Authorization: Bearer $MODERATOR_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"reason":"not an issue"}'
@@ -1493,7 +1493,7 @@ Create a curated job.
 | `posted_at` | string (RFC3339) | no | Posting date. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/jobs" \
+curl -X POST "https://freehire.me/api/v1/jobs" \
   -H "Authorization: Bearer $MODERATOR_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"url":"https://acme.com/careers/123","title":"Senior Go Engineer","company":"Acme"}'
@@ -1522,7 +1522,7 @@ Edit a curated job.
 | `(any job field)` | varies | no | Same fields as create; provided fields are updated. |
 
 ```bash
-curl -X PATCH "https://freehire.dev/api/v1/jobs/<slug>" \
+curl -X PATCH "https://freehire.me/api/v1/jobs/<slug>" \
   -H "Authorization: Bearer $MODERATOR_API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"title":"Staff Go Engineer"}'
@@ -1543,7 +1543,7 @@ Your career profile and stored CV, session-only (a browser feature, like saved s
 Your career profile, or null if you have not saved one.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/profile" -b cookies.txt
+curl "https://freehire.me/api/v1/me/profile" -b cookies.txt
 ```
 
 ```json
@@ -1575,7 +1575,7 @@ The whole profile is replaced on each save. An unknown specialization (must be a
 | `location_preferences` | object | no | Optional location block (`work_modes`, `remote`, `base`, `relocation`); omit or null to clear. |
 
 ```bash
-curl -X PUT "https://freehire.dev/api/v1/me/profile" \
+curl -X PUT "https://freehire.me/api/v1/me/profile" \
   -H 'Content-Type: application/json' -b cookies.txt \
   -d '{"specializations":["backend"],"skills":["go","postgresql"]}'
 ```
@@ -1593,7 +1593,7 @@ Clear your profile (idempotent).
 Returns `204 No Content`.
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/me/profile" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/profile" -b cookies.txt
 ```
 
 ### `GET /me/profile/verdict`
@@ -1611,7 +1611,7 @@ How many of your selected role’s open vacancies your skills reach, and which m
 | `(any search filter)` | string | no | Any search facet param scopes the role (the `skills` facet is ignored; your profile skills are the measured set). (e.g. `category=backend`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/me/profile/verdict" -b cookies.txt
+curl "https://freehire.me/api/v1/me/profile/verdict" -b cookies.txt
 ```
 
 ```json
@@ -1637,7 +1637,7 @@ CV ATS-readiness report (deterministic + any cached LLM review).
 Scores your stored CV’s structure and its keyword match against the selected role. `has_cv` is false when no CV is stored; no profile is a `404`; `503` when search is unavailable.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/profile/ats-report" -b cookies.txt
+curl "https://freehire.me/api/v1/me/profile/ats-report" -b cookies.txt
 ```
 
 ```json
@@ -1665,7 +1665,7 @@ Run the optional LLM qualitative ATS review and cache it.
 Runs the LLM review over your stored CV and folds it into the report (`reviewed: true`). Best-effort: an unconfigured or failing LLM returns the deterministic report (200).
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/me/profile/ats-report" -b cookies.txt
+curl -X POST "https://freehire.me/api/v1/me/profile/ats-report" -b cookies.txt
 ```
 
 ```json
@@ -1687,7 +1687,7 @@ Accepts a PDF (`multipart/form-data` field `file`) or plain text (`application/j
 | `text` | string | no | Résumé plain text (JSON path); or send a PDF as multipart field `file`. |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/me/resume/extract" \
+curl -X POST "https://freehire.me/api/v1/me/resume/extract" \
   -H 'Content-Type: application/json' -b cookies.txt \
   -d '{"text":"Senior Go engineer, 6 years..."}'
 ```
@@ -1711,7 +1711,7 @@ Accepts a PDF (multipart `file`) or JSON `{ "text": ... }`. Returns the résumé
 | `text` | string | no | Résumé plain text (JSON path); or send a PDF as multipart field `file`. |
 
 ```bash
-curl -X PUT "https://freehire.dev/api/v1/me/resume" \
+curl -X PUT "https://freehire.me/api/v1/me/resume" \
   -H 'Content-Type: application/json' -b cookies.txt \
   -d '{"text":"Senior Go engineer, 6 years..."}'
 ```
@@ -1729,7 +1729,7 @@ Your résumé status (enabled / present / uploaded_at).
 Always `200`: unconfigured storage or no résumé is a normal state. `structured` carries the read-only structured résumé, or null when none is current.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/resume" -b cookies.txt
+curl "https://freehire.me/api/v1/me/resume" -b cookies.txt
 ```
 
 ```json
@@ -1745,7 +1745,7 @@ Delete your stored résumé.
 Returns `204 No Content`. `501` when object storage is unconfigured.
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/me/resume" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/resume" -b cookies.txt
 ```
 
 ## Trends & Insights
@@ -1768,7 +1768,7 @@ Roles (category × seniority) ranked by the number of open jobs, with a growth m
 | `limit` | integer | no | Result cap, 1–200 (default 20). |
 
 ```bash
-curl "https://freehire.dev/api/v1/insights/roles?category=backend&sort=growth"
+curl "https://freehire.me/api/v1/insights/roles?category=backend&sort=growth"
 ```
 
 ```json
@@ -1796,7 +1796,7 @@ Skills ranked by the number of open jobs that list them, with the same growth me
 | `limit` | integer | no | Result cap, 1–200 (default 20). |
 
 ```bash
-curl "https://freehire.dev/api/v1/insights/skills?category=backend"
+curl "https://freehire.me/api/v1/insights/skills?category=backend"
 ```
 
 ```json
@@ -1824,7 +1824,7 @@ Added vs. removed vacancies per period, optionally scoped to a single facet. Sam
 | `country` | string | no | Facet scope (ISO 3166-1 alpha-2). |
 
 ```bash
-curl "https://freehire.dev/api/v1/insights/velocity?granularity=week&category=backend"
+curl "https://freehire.me/api/v1/insights/velocity?granularity=week&category=backend"
 ```
 
 ```json
@@ -1852,9 +1852,9 @@ Passing `category` alone (no `seniority`, no `country`) returns the **per-senior
 
 ```bash
 # Exact scope (one grade):
-curl "https://freehire.dev/api/v1/insights/salary?category=backend&seniority=senior"
+curl "https://freehire.me/api/v1/insights/salary?category=backend&seniority=senior"
 # Per-seniority breakdown for a category (the salary page's read):
-curl "https://freehire.dev/api/v1/insights/salary?category=backend"
+curl "https://freehire.me/api/v1/insights/salary?category=backend"
 ```
 
 ```json
@@ -1886,9 +1886,9 @@ The company hiring-signal leaderboard: companies ranked by how their number of o
 
 ```bash
 # Companies ramping up hiring the fastest:
-curl "https://freehire.dev/api/v1/insights/companies?sort=growth"
+curl "https://freehire.me/api/v1/insights/companies?sort=growth"
 # Companies pulling back:
-curl "https://freehire.dev/api/v1/insights/companies?sort=-growth&min_open=10"
+curl "https://freehire.me/api/v1/insights/companies?sort=-growth&min_open=10"
 ```
 
 ```json
@@ -1921,7 +1921,7 @@ Aggregated to the requested granularity over a date range; the series is dense (
 | `to` | string (YYYY-MM-DD) | no | End date (UTC). Defaults to today. (e.g. `2026-06-30`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/stats/jobs-activity?granularity=week"
+curl "https://freehire.me/api/v1/stats/jobs-activity?granularity=week"
 ```
 
 ```json
@@ -1949,7 +1949,7 @@ Public, no owner-scoping — returns only display fields (`name`, the canonical 
 | `slug` | string | yes | The board public slug. (e.g. `senior-go-remote-3f9a`) |
 
 ```bash
-curl "https://freehire.dev/api/v1/boards/senior-go-remote-3f9a"
+curl "https://freehire.me/api/v1/boards/senior-go-remote-3f9a"
 ```
 
 ```json
@@ -1977,7 +1977,7 @@ Mints (or keeps) the board slug and sets the optional author label. Owner-scoped
 | `author_label` | string | no | Label shown on the board; blank/omitted renders it anonymously. (e.g. `Jane D.`) |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/me/searches/2/share" \
+curl -X POST "https://freehire.me/api/v1/me/searches/2/share" \
   -H 'Content-Type: application/json' -b cookies.txt \
   -d '{"author_label":"Jane D."}'
 ```
@@ -2001,7 +2001,7 @@ Owner-scoped and idempotent (already-private is a no-op). Returns `204 No Conten
 | `id` | integer | yes | The saved-search id. (e.g. `2`) |
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/me/searches/2/share" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/searches/2/share" -b cookies.txt
 ```
 
 ## Saved searches & subscriptions
@@ -2015,7 +2015,7 @@ Browser conveniences, session-only. A saved search stores a canonical filter que
 List your saved searches.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/searches" -b cookies.txt
+curl "https://freehire.me/api/v1/me/searches" -b cookies.txt
 ```
 
 ```json
@@ -2036,7 +2036,7 @@ Save a search.
 | `query` | string | yes | Canonical filter query string. (e.g. `q=go&seniority=senior&work_mode=remote`) |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/me/searches" \
+curl -X POST "https://freehire.me/api/v1/me/searches" \
   -H 'Content-Type: application/json' -b cookies.txt \
   -d '{"name":"Senior Go remote","query":"q=go&seniority=senior&work_mode=remote"}'
 ```
@@ -2065,7 +2065,7 @@ Rename or re-query a saved search.
 | `query` | string | no | New query (optional). |
 
 ```bash
-curl -X PATCH "https://freehire.dev/api/v1/me/searches/2" \
+curl -X PATCH "https://freehire.me/api/v1/me/searches/2" \
   -H 'Content-Type: application/json' -b cookies.txt \
   -d '{"name":"Senior Go — EU remote"}'
 ```
@@ -2087,7 +2087,7 @@ Delete a saved search.
 | `id` | integer | yes | The saved-search id. (e.g. `2`) |
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/me/searches/2" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/searches/2" -b cookies.txt
 ```
 
 ```json
@@ -2101,7 +2101,7 @@ curl -X DELETE "https://freehire.dev/api/v1/me/searches/2" -b cookies.txt
 List your subscriptions.
 
 ```bash
-curl "https://freehire.dev/api/v1/me/subscriptions" -b cookies.txt
+curl "https://freehire.me/api/v1/me/subscriptions" -b cookies.txt
 ```
 
 ```json
@@ -2122,7 +2122,7 @@ Subscribe a saved search to a digest channel.
 | `channel` | string | yes | Delivery channel. (e.g. `telegram`) |
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/me/subscriptions" \
+curl -X POST "https://freehire.me/api/v1/me/subscriptions" \
   -H 'Content-Type: application/json' -b cookies.txt \
   -d '{"saved_search_id":2,"channel":"telegram"}'
 ```
@@ -2150,7 +2150,7 @@ Pause or resume a subscription.
 | `active` | boolean | yes | Whether the subscription is active. (e.g. `false`) |
 
 ```bash
-curl -X PATCH "https://freehire.dev/api/v1/me/subscriptions/1" \
+curl -X PATCH "https://freehire.me/api/v1/me/subscriptions/1" \
   -H 'Content-Type: application/json' -b cookies.txt \
   -d '{"active":false}'
 ```
@@ -2172,7 +2172,7 @@ Delete a subscription.
 | `id` | integer | yes | The subscription id. (e.g. `1`) |
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/me/subscriptions/1" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/subscriptions/1" -b cookies.txt
 ```
 
 ```json
@@ -2186,7 +2186,7 @@ curl -X DELETE "https://freehire.dev/api/v1/me/subscriptions/1" -b cookies.txt
 Your Telegram link status (for digests).
 
 ```bash
-curl "https://freehire.dev/api/v1/me/telegram" -b cookies.txt
+curl "https://freehire.me/api/v1/me/telegram" -b cookies.txt
 ```
 
 ```json
@@ -2200,7 +2200,7 @@ curl "https://freehire.dev/api/v1/me/telegram" -b cookies.txt
 Start linking your Telegram account.
 
 ```bash
-curl -X POST "https://freehire.dev/api/v1/me/telegram/link" -b cookies.txt
+curl -X POST "https://freehire.me/api/v1/me/telegram/link" -b cookies.txt
 ```
 
 ```json
@@ -2214,7 +2214,7 @@ curl -X POST "https://freehire.dev/api/v1/me/telegram/link" -b cookies.txt
 Unlink your Telegram account.
 
 ```bash
-curl -X DELETE "https://freehire.dev/api/v1/me/telegram" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/telegram" -b cookies.txt
 ```
 
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -231,6 +231,39 @@ curl "https://freehire.dev/api/v1/jobs/search?q=golang&seniority=senior&work_mod
 }
 ```
 
+### `GET /agent/jobs/search`
+
+**Auth:** Public
+
+Search with full descriptions, for programmatic/agent consumers.
+
+Same query and filters as `/jobs/search`, but each result carries the `description` in full (verbatim from the database) instead of the truncated index preview. Use `description_format` to choose how it is rendered.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `q` | string | no | Full-text query over title, company, and description. (e.g. `golang`) |
+| `description_format` | string | no | One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`. (e.g. `markdown`) |
+| `sort` | string | no | One of `created_at`, `posted_at`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
+| `order` | string | no | `asc` or `desc` (default `desc`). (e.g. `desc`) |
+| `semantic_ratio` | number | no | Opt-in hybrid search, 0–1 (default 0 = pure keyword). Needs the optional semantic index. (e.g. `0`) |
+| `limit` | integer | no | Page size, 1–100. (e.g. `20`) |
+| `offset` | integer | no | Rows to skip; `offset + limit` ≤ 10000. (e.g. `0`) |
+
+Plus every filter in [Filtering jobs](#filtering-jobs).
+
+```bash
+curl "https://freehire.dev/api/v1/agent/jobs/search?q=golang&work_mode=remote&description_format=markdown"
+```
+
+```json
+{
+  "data": [ { "public_slug": "...", "title": "Senior Go Engineer", "description": "## About the role\n...", "...": "..." } ],
+  "meta": { "total": 137, "limit": 20, "offset": 0 }
+}
+```
+
 ### `GET /jobs/facets`
 
 **Auth:** Public

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/strelov1/freehire
 go 1.25.12
 
 require (
+	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2
 	github.com/abadojack/whatlanggo v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.30
@@ -41,6 +42,7 @@ require (
 require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/JohannesKaufmann/dom v0.3.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/JohannesKaufmann/dom v0.3.1 h1:J16l9JAHWgkFPR3VIPbQ1gvS0cWab6laK1q7PFL3qh0=
+github.com/JohannesKaufmann/dom v0.3.1/go.mod h1:BZPkf8ZeYrBgABjwJn9iiKt8aiCtkxpHkevms+Yp2DE=
+github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2 h1:XFJZFWESIWlUEHHjzBuv8RvrtCWnSGlimEX17ysSDb8=
+github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2/go.mod h1:BHWO8lJzttJLqwuV8Rb1B3OG2OSzLbssZDI1FRg2eAA=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
@@ -231,6 +235,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/sebdah/goldie/v2 v2.8.0 h1:dZb9wR8q5++oplmEiJT+U/5KyotVD+HNGCAc5gNr8rc=
+github.com/sebdah/goldie/v2 v2.8.0/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
+github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
+github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shirou/gopsutil/v4 v4.26.5 h1:RPcBXkpz7kOj9PqGFQOlBPZHsyaPvPVQc098y9RmCNM=
 github.com/shirou/gopsutil/v4 v4.26.5/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -464,6 +464,41 @@ func (q *Queries) GetJobBySourceExternalID(ctx context.Context, arg GetJobBySour
 	return i, err
 }
 
+const getJobDescriptionsByIDs = `-- name: GetJobDescriptionsByIDs :many
+SELECT id, description
+FROM jobs
+WHERE id = ANY($1::bigint[])
+`
+
+type GetJobDescriptionsByIDsRow struct {
+	ID          int64  `json:"id"`
+	Description string `json:"description"`
+}
+
+// Batch-load full descriptions by internal id to rehydrate the truncated preview
+// the search index serves — the agent search endpoint replaces each hit's preview
+// with the full text. Narrow projection (no SELECT *) so it drags only the one
+// field it patches, not the whole wide row, for a page of at most maxLimit ids.
+func (q *Queries) GetJobDescriptionsByIDs(ctx context.Context, ids []int64) ([]GetJobDescriptionsByIDsRow, error) {
+	rows, err := q.db.Query(ctx, getJobDescriptionsByIDs, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetJobDescriptionsByIDsRow{}
+	for rows.Next() {
+		var i GetJobDescriptionsByIDsRow
+		if err := rows.Scan(&i.ID, &i.Description); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getJobIDBySlug = `-- name: GetJobIDBySlug :one
 SELECT id
 FROM jobs

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -504,6 +504,11 @@ type Querier interface {
 	// Load a job by its dedup identity (source, external_id) — the key the Job
 	// aggregate's repository loads by, mirroring the CloseJobBySourceExternalID key.
 	GetJobBySourceExternalID(ctx context.Context, arg GetJobBySourceExternalIDParams) (Job, error)
+	// Batch-load full descriptions by internal id to rehydrate the truncated preview
+	// the search index serves — the agent search endpoint replaces each hit's preview
+	// with the full text. Narrow projection (no SELECT *) so it drags only the one
+	// field it patches, not the whole wide row, for a page of at most maxLimit ids.
+	GetJobDescriptionsByIDs(ctx context.Context, ids []int64) ([]GetJobDescriptionsByIDsRow, error)
 	// Slim slug->id lookup for the view/apply interaction path, which needs only the
 	// internal id (the user_jobs FK) and must not drag the wide description/enrichment
 	// columns over the wire on every silent view. GetJobBySlug (SELECT *) stays for the

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -124,6 +124,15 @@ SELECT id
 FROM jobs
 WHERE public_slug = $1;
 
+-- name: GetJobDescriptionsByIDs :many
+-- Batch-load full descriptions by internal id to rehydrate the truncated preview
+-- the search index serves — the agent search endpoint replaces each hit's preview
+-- with the full text. Narrow projection (no SELECT *) so it drags only the one
+-- field it patches, not the whole wide row, for a page of at most maxLimit ids.
+SELECT id, description
+FROM jobs
+WHERE id = ANY(sqlc.arg(ids)::bigint[]);
+
 -- name: EstimateOpenJobs :one
 -- Fast approximate open-job total for the DB-backed /jobs list's meta.total. An
 -- exact count(*) over ~millions of open rows was a per-request full scan; the

--- a/internal/handler/agent_search.go
+++ b/internal/handler/agent_search.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/htmltext"
+	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/search"
+)
+
+// jobDescriptions loads full job descriptions by internal id, to rehydrate the
+// truncated preview the search index serves. *db.Queries satisfies it; tests
+// inject a fake.
+type jobDescriptions interface {
+	GetJobDescriptionsByIDs(ctx context.Context, ids []int64) ([]db.GetJobDescriptionsByIDsRow, error)
+}
+
+// AgentSearchJobs is the programmatic-consumer variant of SearchJobs: it runs the
+// exact same query (via the shared runJobSearch core) but returns each job's full
+// description, read verbatim from Postgres, in a selectable format. Public and
+// unauthenticated like the other job reads; full descriptions are already public
+// via the detail endpoint.
+func (a *API) AgentSearchJobs(c *fiber.Ctx) error {
+	res, limit, offset, err := a.runJobSearch(c)
+	if err != nil {
+		return err
+	}
+
+	if len(res.Hits) > 0 {
+		if err := a.hydrateDescriptions(c.Context(), res.Hits); err != nil {
+			return err
+		}
+	}
+
+	format := c.Query("description_format")
+	views := make([]jobview.Job, len(res.Hits))
+	for i, hit := range res.Hits {
+		hit.Description = formatDescription(hit.Description, format)
+		views[i] = hit.Job
+	}
+
+	return listResponse(c, views, res.Total, limit, offset)
+}
+
+// hydrateDescriptions replaces each hit's truncated preview description with the
+// job's full description read from Postgres, keyed by internal id. Best-effort: a
+// hit whose id has no row (index lag vs a just-removed job) keeps its preview
+// rather than being dropped.
+func (a *API) hydrateDescriptions(ctx context.Context, hits []search.JobDocument) error {
+	ids := make([]int64, len(hits))
+	for i := range hits {
+		ids[i] = hits[i].ID
+	}
+	rows, err := a.descriptions.GetJobDescriptionsByIDs(ctx, ids)
+	if err != nil {
+		return err
+	}
+	byID := make(map[int64]string, len(rows))
+	for _, r := range rows {
+		byID[r.ID] = r.Description
+	}
+	for i := range hits {
+		if full, ok := byID[hits[i].ID]; ok {
+			hits[i].Description = full
+		}
+	}
+	return nil
+}
+
+// formatDescription renders a job description in the requested format. Any value
+// other than "text" or "markdown" — including the empty default and unrecognized
+// values — yields the stored verbatim HTML, so the endpoint never fails on a bad
+// format param.
+func formatDescription(html, format string) string {
+	switch format {
+	case "text":
+		return htmltext.ToText(html)
+	case "markdown":
+		return htmltext.ToMarkdown(html)
+	default:
+		return html
+	}
+}

--- a/internal/handler/agent_search_test.go
+++ b/internal/handler/agent_search_test.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/search"
+)
+
+type fakeDescriptions struct {
+	called bool
+	gotIDs []int64
+	rows   []db.GetJobDescriptionsByIDsRow
+	err    error
+}
+
+func (f *fakeDescriptions) GetJobDescriptionsByIDs(_ context.Context, ids []int64) ([]db.GetJobDescriptionsByIDsRow, error) {
+	f.called = true
+	f.gotIDs = ids
+	return f.rows, f.err
+}
+
+func agentSearchApp(s searcher, d jobDescriptions) *fiber.App {
+	h := &API{search: s, descriptions: d}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/agent/jobs/search", h.AgentSearchJobs)
+	return app
+}
+
+func TestFormatDescription(t *testing.T) {
+	html := "<ul><li>alpha</li><li>beta</li></ul>"
+	if got := formatDescription(html, ""); got != html {
+		t.Errorf("default: got %q, want verbatim html", got)
+	}
+	if got := formatDescription(html, "xml"); got != html {
+		t.Errorf("unknown format: got %q, want html fallback", got)
+	}
+	if got := formatDescription(html, "text"); strings.Contains(got, "<li>") {
+		t.Errorf("text: tags not stripped: %q", got)
+	}
+	if got := formatDescription(html, "markdown"); strings.Contains(got, "<li>") || !strings.Contains(got, "alpha") {
+		t.Errorf("markdown: got %q", got)
+	}
+}
+
+func TestAgentSearchJobs_HydratesFullDescription(t *testing.T) {
+	fake := &fakeSearcher{res: search.SearchResult{
+		Hits:  []search.JobDocument{{ID: 7, Job: jobview.Job{PublicSlug: "go-dev-x", Description: "<p>trunc…</p>"}}},
+		Total: 3,
+	}}
+	desc := &fakeDescriptions{rows: []db.GetJobDescriptionsByIDsRow{{ID: 7, Description: "<p>the full verbatim description</p>"}}}
+	app := agentSearchApp(fake, desc)
+
+	status, body := doGet(t, app, "/agent/jobs/search?q=go")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !desc.called || len(desc.gotIDs) != 1 || desc.gotIDs[0] != 7 {
+		t.Errorf("loader called=%v ids=%v, want [7]", desc.called, desc.gotIDs)
+	}
+	data, _ := body["data"].([]any)
+	first, _ := data[0].(map[string]any)
+	if first["description"] != "<p>the full verbatim description</p>" {
+		t.Errorf("description = %v, want full verbatim html", first["description"])
+	}
+	if _, leaked := first["id"]; leaked {
+		t.Errorf("internal id leaked: %v", first)
+	}
+	meta, _ := body["meta"].(map[string]any)
+	if meta["total"].(float64) != 3 {
+		t.Errorf("meta.total = %v, want 3", meta["total"])
+	}
+}
+
+func TestAgentSearchJobs_BestEffortKeepsStaleHit(t *testing.T) {
+	fake := &fakeSearcher{res: search.SearchResult{Hits: []search.JobDocument{
+		{ID: 1, Job: jobview.Job{PublicSlug: "a", Description: "full-a-src"}},
+		{ID: 2, Job: jobview.Job{PublicSlug: "b", Description: "preview-b"}},
+	}}}
+	desc := &fakeDescriptions{rows: []db.GetJobDescriptionsByIDsRow{{ID: 1, Description: "FULL-a"}}}
+	app := agentSearchApp(fake, desc)
+
+	status, body := doGet(t, app, "/agent/jobs/search")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	data, _ := body["data"].([]any)
+	if len(data) != 2 {
+		t.Fatalf("data len = %d, want 2 (stale hit not dropped)", len(data))
+	}
+	stale, _ := data[1].(map[string]any)
+	if stale["description"] != "preview-b" {
+		t.Errorf("stale hit description = %v, want preview-b (kept)", stale["description"])
+	}
+}
+
+func TestAgentSearchJobs_FormatApplies(t *testing.T) {
+	fake := &fakeSearcher{res: search.SearchResult{
+		Hits: []search.JobDocument{{ID: 1, Job: jobview.Job{PublicSlug: "a", Description: "x"}}},
+	}}
+	desc := &fakeDescriptions{rows: []db.GetJobDescriptionsByIDsRow{{ID: 1, Description: "<ul><li>alpha</li></ul>"}}}
+	app := agentSearchApp(fake, desc)
+
+	status, body := doGet(t, app, "/agent/jobs/search?description_format=text")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	data, _ := body["data"].([]any)
+	first, _ := data[0].(map[string]any)
+	got, _ := first["description"].(string)
+	if strings.Contains(got, "<li>") || !strings.Contains(got, "alpha") {
+		t.Errorf("text format not applied to hydrated description: %q", got)
+	}
+}

--- a/internal/handler/agent_search_test.go
+++ b/internal/handler/agent_search_test.go
@@ -56,9 +56,17 @@ func TestAgentSearchJobs_HydratesFullDescription(t *testing.T) {
 	desc := &fakeDescriptions{rows: []db.GetJobDescriptionsByIDsRow{{ID: 7, Description: "<p>the full verbatim description</p>"}}}
 	app := agentSearchApp(fake, desc)
 
-	status, body := doGet(t, app, "/agent/jobs/search?q=go")
+	status, body := doGet(t, app, "/agent/jobs/search?q=go&seniority=senior&semantic_ratio=0.4&limit=10&offset=20")
 	if status != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
+	}
+	// Parity: the same query/filters/paging reach the search backend as the public
+	// endpoint would send — the shared runJobSearch core, verified at the agent layer.
+	if fake.got.Query != "go" || fake.got.Limit != 10 || fake.got.Offset != 20 || fake.got.SemanticRatio != 0.4 {
+		t.Errorf("search params not forwarded: %#v", fake.got)
+	}
+	if groups, ok := fake.got.Filter.([][]string); !ok || !filterHas(groups, `enrichment.seniority = "senior"`) {
+		t.Errorf("facet filter not forwarded: %#v", fake.got.Filter)
 	}
 	if !desc.called || len(desc.gotIDs) != 1 || desc.gotIDs[0] != 7 {
 		t.Errorf("loader called=%v ids=%v, want [7]", desc.called, desc.gotIDs)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -106,6 +106,10 @@ type API struct {
 	// search is the job-search backend. Nil when Meilisearch is unconfigured —
 	// the search endpoint then reports 503 and the rest of the API is unaffected.
 	search searcher
+	// descriptions loads full job descriptions by internal id, to rehydrate the
+	// truncated search preview on the agent search endpoint. *db.Queries in
+	// production; a fake in tests.
+	descriptions jobDescriptions
 	// companySearch is the company-search backend backing GET /api/v1/companies,
 	// kept separate from `search` so the companies index stays fully decoupled from
 	// jobs search. Nil when Meilisearch is unconfigured, or on any query error, the
@@ -287,6 +291,7 @@ func Register(app *fiber.App, cfg Config) {
 	a := &API{
 		pool:           cfg.Pool,
 		queries:        queries,
+		descriptions:   queries,
 		issuer:         auth.NewIssuer(cfg.JWTSecret, cfg.JWTTTL),
 		cookieSecure:   cfg.CookieSecure,
 		cookieDomains:  cfg.CookieDomains,
@@ -397,6 +402,9 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/jobs", a.ListJobs)
 	// Literal routes before the :slug param route so they are not read as slugs.
 	api.Get("/jobs/search", a.SearchJobs)
+	// Agent search: same query as /jobs/search but full descriptions in a
+	// selectable format, for programmatic consumers. Public, like the other reads.
+	api.Get("/agent/jobs/search", a.AgentSearchJobs)
 	api.Get("/jobs/facets", a.JobFacets)
 	api.Get("/jobs/sitemap", a.JobSitemap)
 	// optionalAuth attaches the caller when signed in (cookie or key) but never

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -51,13 +51,33 @@ var searchSortable = map[string]string{
 // "meta": {total, limit, offset}} — results carry public_slug and never the
 // internal id.
 func (a *API) SearchJobs(c *fiber.Ctx) error {
+	res, limit, offset, err := a.runJobSearch(c)
+	if err != nil {
+		return err
+	}
+
+	views := make([]jobview.Job, len(res.Hits))
+	for i, hit := range res.Hits {
+		views[i] = hit.Job
+	}
+
+	return listResponse(c, views, res.Total, limit, offset)
+}
+
+// runJobSearch performs the request handling shared by both job-search endpoints:
+// the availability check, the pagination-window guard, the semantic ratio, and the
+// index query. It is the single place the query is built, so the public and agent
+// search endpoints cannot drift. The availability and deep-pagination guards return
+// a fiber *Error the caller can return directly; on success it returns the raw hits
+// and the applied limit/offset.
+func (a *API) runJobSearch(c *fiber.Ctx) (search.SearchResult, int, int, error) {
 	if a.search == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
+		return search.SearchResult{}, 0, 0, fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
 	}
 
 	limit, offset := pageParams(c)
 	if offset+limit > maxSearchWindow {
-		return fiber.NewError(fiber.StatusBadRequest, "pagination too deep")
+		return search.SearchResult{}, 0, 0, fiber.NewError(fiber.StatusBadRequest, "pagination too deep")
 	}
 	ratio := min(max(c.QueryFloat("semantic_ratio", defaultSemanticRatio), 0), 1)
 
@@ -72,15 +92,10 @@ func (a *API) SearchJobs(c *fiber.Ctx) error {
 	if err != nil {
 		// RenderError renders a generic 500; returning the error keeps the
 		// Meilisearch failure cause visible to logging instead of swallowing it.
-		return err
+		return search.SearchResult{}, 0, 0, err
 	}
 
-	views := make([]jobview.Job, len(res.Hits))
-	for i, hit := range res.Hits {
-		views[i] = hit.Job
-	}
-
-	return listResponse(c, views, res.Total, limit, offset)
+	return res, limit, offset, nil
 }
 
 // searchSort builds the Meilisearch sort directive from ?sort=<field>&order=<dir>.

--- a/internal/htmltext/htmltext.go
+++ b/internal/htmltext/htmltext.go
@@ -1,0 +1,30 @@
+// Package htmltext converts stored job-description HTML into alternative
+// representations for API consumers: plain text and Markdown. Each converter is
+// lenient — a conversion error degrades to returning the input unchanged rather
+// than failing the caller.
+package htmltext
+
+import (
+	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
+	"github.com/jaytaylor/html2text"
+)
+
+// ToText renders HTML as plain text with tags removed. On a conversion error it
+// returns the input unchanged.
+func ToText(html string) string {
+	out, err := html2text.FromString(html, html2text.Options{OmitLinks: true})
+	if err != nil {
+		return html
+	}
+	return out
+}
+
+// ToMarkdown converts HTML to Markdown, preserving block structure such as lists
+// and headings. On a conversion error it returns the input unchanged.
+func ToMarkdown(html string) string {
+	out, err := htmltomarkdown.ConvertString(html)
+	if err != nil {
+		return html
+	}
+	return out
+}

--- a/internal/htmltext/htmltext_test.go
+++ b/internal/htmltext/htmltext_test.go
@@ -1,0 +1,41 @@
+package htmltext
+
+import "testing"
+
+func TestToText_StripsTags(t *testing.T) {
+	got := ToText("<p>Hello <strong>world</strong></p>")
+	if got == "" {
+		t.Fatal("ToText returned empty")
+	}
+	if containsAngle(got) {
+		t.Errorf("ToText left HTML tags: %q", got)
+	}
+	if !contains(got, "Hello") || !contains(got, "world") {
+		t.Errorf("ToText dropped content: %q", got)
+	}
+}
+
+func TestToMarkdown_PreservesListStructure(t *testing.T) {
+	got := ToMarkdown("<ul><li>first</li><li>second</li></ul>")
+	if !contains(got, "first") || !contains(got, "second") {
+		t.Errorf("ToMarkdown dropped content: %q", got)
+	}
+	// A Markdown list marker for at least one item.
+	if !contains(got, "- first") && !contains(got, "* first") {
+		t.Errorf("ToMarkdown did not render a list marker: %q", got)
+	}
+	if containsAngle(got) {
+		t.Errorf("ToMarkdown left HTML tags: %q", got)
+	}
+}
+
+func containsAngle(s string) bool { return contains(s, "<") || contains(s, ">") }
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/openspec/changes/add-agent-jobs-search/.openspec.yaml
+++ b/openspec/changes/add-agent-jobs-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-agent-jobs-search/design.md
+++ b/openspec/changes/add-agent-jobs-search/design.md
@@ -1,0 +1,86 @@
+## Context
+
+`GET /api/v1/jobs/search` (`internal/handler/search.go`) runs a Meilisearch query
+and maps each hit's `jobview.Job` into the list envelope. The indexed document
+caps `description` at `maxIndexedDescriptionRunes` (`internal/search/document.go`),
+so search hits carry a truncated preview; the full text lives in Postgres and is
+served by the DB-backed list and detail endpoints. Each `search.JobDocument` hit
+carries the internal `ID` (the Meili primary key = `jobs.id`), so the returned ids
+are available in rank order for a follow-up read.
+
+The public search endpoint's request handling (filter build, sort, pagination
+window, semantic ratio) is the contract this new endpoint must match exactly.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A public search endpoint that returns full descriptions with a selectable
+  format (`html`/`text`/`markdown`), running the identical query/filter/sort/paging
+  as the public search.
+- Keep the public `/jobs/search` unchanged: still Meili-only, still preview-only.
+- Structure the shared search logic so the two endpoints cannot drift.
+
+**Non-Goals:**
+- No auth/API key (public, keyless) — full descriptions are already public via the
+  detail endpoint.
+- No field selection, cursor pagination, or JSON:API envelope — same `{data, meta}`
+  shape; those remain a future seam if a concrete need appears.
+- No change to the index, the truncation cap, or the public search endpoint.
+
+## Decisions
+
+**Extract the shared search core; both endpoints call it.** Factor the public
+`SearchJobs` body (parse params → `buildSearchFilter`/`searchSort`/`pageParams`/
+window guard → `a.search.Search` → `SearchResult`) into one internal helper that
+returns the hits and total. `SearchJobs` maps hits to views as today; the new
+`AgentSearchJobs` calls the same helper, then hydrates + formats. This makes "runs
+the same search" a structural guarantee, not a copy that can drift. Chosen over
+duplicating the request handling (the spec requires parity, and drift is the
+obvious failure mode).
+
+**Hydrate full descriptions from Postgres by id.** Reuse the batch pattern: collect
+the hits' ids, run a narrow `GetJobDescriptionsByIDs(ids) -> (id, description)`
+query, and replace each hit's `Description` with the full text. Best-effort by id
+(a missing row keeps the index value, never drops the hit). Narrow projection
+avoids detoasting the wide row and re-deriving the view. Bounded by the page limit,
+so it is at most a page of primary-key lookups — an indexed batch.
+
+**Format conversion in a small dedicated helper.** `description_format` maps to a
+pure `formatDescription(html, format) string`:
+- `html` → identity (verbatim stored HTML).
+- `text` → strip tags to plain text.
+- `markdown` → convert HTML to Markdown, preserving block structure.
+Isolating this behind one function keeps the handler thin and the conversion
+independently testable. An unrecognized value falls back to `html` (lenient, never
+errors — consistent with how the search endpoint ignores unknown sort params).
+The HTML→Markdown/text conversion uses a small library; the choice is an
+implementation detail of this helper and does not leak into the handler.
+
+**Route placement.** Register `GET /api/v1/agent/jobs/search` alongside the public
+search route, public (no auth middleware). The `/agent` path segment names the
+programmatic surface without implying authentication.
+
+## Risks / Trade-offs
+
+- [The agent endpoint reads Postgres on every request] → It is a separate endpoint;
+  the public `/jobs/search` stays Meili-only. The read is bounded by the page limit
+  and is by primary key. Acceptable for a full-fidelity programmatic surface.
+- [Refactoring `SearchJobs` to share a core could regress the public endpoint] →
+  The existing `search_test.go` suite pins the public endpoint's behavior; the
+  refactor must keep it green. Extract-and-reuse, do not rewrite request handling.
+- [Format conversion cost per response] → Bounded by page size (≤ the search page
+  limit); `markdown`/`text` convert only the returned page. `html` (default) is a
+  no-op. Negligible relative to the Meili + Postgres round-trips already on the path.
+- [A new dependency for HTML conversion] → Small, well-scoped library used only in
+  the format helper. If undesirable, `text` can fall back to a standard-library
+  tag strip; `markdown` is the only format that genuinely needs a converter.
+
+## Migration Plan
+
+Additive: a new endpoint and a new capability, no change to existing endpoints,
+schema, or the index. No data migration. Rollback is removing the route, handler,
+query, and helper; nothing persisted depends on it.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-agent-jobs-search/proposal.md
+++ b/openspec/changes/add-agent-jobs-search/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+`GET /api/v1/jobs/search` returns a truncated `description` — the Meilisearch
+document caps the indexed text so the index (and a reindex's transient disk) stays
+small; on the production catalogue the full text would add tens of GiB to the
+index. That default is correct for the website, which renders only a preview card,
+but it leaves programmatic/agent consumers ([#1104](https://github.com/strelov1/freehire/issues/1104))
+without the full description from search — their only workaround is a per-result
+follow-up fetch by slug.
+
+Rather than bolt a `full_description` flag (and, inevitably, format flags) onto the
+SPA-facing search endpoint, this introduces a dedicated agent-oriented search
+surface: the same query and filters, but full descriptions and a choice of output
+format. The website's search stays lean and Meili-only; the full-fidelity path
+lives on its own endpoint.
+
+## What Changes
+
+- New public endpoint `GET /api/v1/agent/jobs/search` (no auth), accepting the
+  same free-text query, facet filters, sort, semantic ratio, and `limit`/`offset`
+  as the public `/jobs/search`.
+- Each result carries the job's **full** `description` (verbatim from Postgres,
+  hydrated in one batch query keyed by internal id), never the truncated index
+  preview. Hydration is best-effort: a hit whose id has no Postgres row (index lag
+  vs a just-removed job) keeps whatever the index served rather than being dropped.
+- A `description_format` parameter selects the description representation:
+  `html` (default — the stored verbatim HTML), `text` (tags stripped to plain
+  text), or `markdown` (HTML converted to Markdown, preserving list/heading
+  structure — the friendliest form for LLM consumers).
+- Response uses the standard list envelope `{"data": [...], "meta": {...}}` — the
+  same wire shape and public-slug identity as the other job reads, not a new
+  JSON:API-style envelope.
+
+## Capabilities
+
+### New Capabilities
+- `agent-jobs-search`: a dedicated public search endpoint for programmatic/agent
+  consumers that returns full job descriptions with a selectable output format.
+
+### Modified Capabilities
+<!-- none — the existing job-search endpoint and its truncated preview are unchanged -->
+
+## Impact
+
+- **API**: adds `GET /api/v1/agent/jobs/search`. Additive; no change to
+  `/jobs/search` or any existing caller.
+- **Code**: `internal/handler` (new handler + route, reusing the existing
+  `buildSearchFilter`/`searchSort`/`pageParams` and the search backend), a batch
+  description loader in `internal/db` (narrow `id, description` query), and an
+  HTML→text/markdown conversion helper.
+- **Dependencies**: a small HTML-to-text/Markdown conversion library (for the
+  `text`/`markdown` formats).
+- **Data stores**: the endpoint reads Postgres for the returned page's
+  descriptions (bounded by the page limit) in addition to the Meili query; the
+  public `/jobs/search` remains Meili-only.
+- **Docs**: the `api-documentation` surface gains the new endpoint and its
+  `description_format` parameter.

--- a/openspec/changes/add-agent-jobs-search/specs/agent-jobs-search/spec.md
+++ b/openspec/changes/add-agent-jobs-search/specs/agent-jobs-search/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Agent job search endpoint
+
+The system SHALL expose `GET /api/v1/agent/jobs/search` as a public
+(unauthenticated) endpoint that runs the same job search as `GET /api/v1/jobs/search`:
+it SHALL accept the same free-text query `q`, the same facet filters, sort,
+semantic ratio, and `limit`/`offset` pagination, and SHALL apply the same
+pagination-window guard. Ranking, faceting, pagination, and the estimated total
+SHALL be produced by the search index exactly as the public search endpoint
+produces them. The response SHALL use the standard list envelope
+`{"data": [...], "meta": {...}}`, where `data` is the matched jobs and `meta`
+carries at least the estimated total hit count and the applied `limit`/`offset`.
+Each result SHALL identify its job by `public_slug` and SHALL NOT include the
+internal numeric `id`.
+
+Unlike the public search endpoint, each result's `description` SHALL be the job's
+**full** description, read verbatim from Postgres and keyed by the result's
+internal id — never the truncated index preview. The hydration SHALL be
+best-effort per result: a returned hit whose id has no corresponding Postgres row
+(e.g. the index lags a just-removed job) SHALL retain whatever description the
+index served and SHALL NOT be dropped from the response.
+
+#### Scenario: Runs the same search as the public endpoint
+
+- **WHEN** a client requests
+  `GET /api/v1/agent/jobs/search?q=engineer&seniority=senior&regions=eu&limit=10`
+- **THEN** the matched, ranked, paginated results and the `meta` totals are those
+  the search index produces for the same query and filters, in the standard
+  `{"data": [...], "meta": {...}}` envelope
+
+#### Scenario: Results carry the full description, not the preview
+
+- **WHEN** a job whose description exceeds the index preview cap is returned by
+  `GET /api/v1/agent/jobs/search`
+- **THEN** the result's `description` equals the full description that
+  `GET /api/v1/jobs/{slug}` returns for the same job, not the truncated preview
+
+#### Scenario: Results identify jobs by public slug, not internal id
+
+- **WHEN** a job is returned by `GET /api/v1/agent/jobs/search`
+- **THEN** the result carries the job's `public_slug` and omits the internal
+  numeric `id`
+
+#### Scenario: Hydration is best-effort on a stale hit
+
+- **WHEN** a returned hit's id has no matching Postgres row (the index lags a
+  just-removed job)
+- **THEN** that hit is still present in the response rather than being dropped
+
+### Requirement: Selectable description format
+
+The endpoint SHALL accept a `description_format` parameter selecting how each
+result's full description is represented:
+
+- `html` (the default when the parameter is absent, empty, or unrecognized): the
+  stored verbatim HTML.
+- `text`: the description with HTML tags removed, as plain text.
+- `markdown`: the description with its HTML converted to Markdown, preserving
+  block structure such as lists and headings.
+
+The selected format SHALL apply uniformly to every result in the response. The
+format SHALL affect only the `description` field; all other fields SHALL be
+unchanged.
+
+#### Scenario: Default format is verbatim HTML
+
+- **WHEN** a client requests `GET /api/v1/agent/jobs/search?q=go` without
+  `description_format`
+- **THEN** each result's `description` is the stored verbatim HTML
+
+#### Scenario: text format strips HTML
+
+- **WHEN** a client requests `GET /api/v1/agent/jobs/search?q=go&description_format=text`
+- **THEN** each result's `description` contains the description's text with HTML
+  tags removed
+
+#### Scenario: markdown format converts HTML to Markdown
+
+- **WHEN** a client requests `GET /api/v1/agent/jobs/search?q=go&description_format=markdown`
+- **THEN** each result's `description` is the description rendered as Markdown,
+  with block structure such as lists and headings preserved
+
+#### Scenario: Unrecognized format falls back to the default
+
+- **WHEN** a client requests `GET /api/v1/agent/jobs/search?description_format=xml`
+- **THEN** the response is served with the default `html` representation rather
+  than failing

--- a/openspec/changes/add-agent-jobs-search/tasks.md
+++ b/openspec/changes/add-agent-jobs-search/tasks.md
@@ -1,0 +1,46 @@
+## 1. Shared search core
+
+- [ ] 1.1 Extract the public `SearchJobs` request handling (filter/sort/pagination
+  window/semantic ratio → `a.search.Search`) into one internal helper returning the
+  `search.SearchResult` (hits + total), and have `SearchJobs` call it.
+- [ ] 1.2 Confirm the existing `internal/handler/search_test.go` suite stays green
+  after the extraction (the public endpoint's behavior is unchanged).
+
+## 2. Description hydration
+
+- [ ] 2.1 Add `GetJobDescriptionsByIDs :many` (`SELECT id, description ... WHERE id
+  = ANY($ids)`) to `internal/db/queries/jobs.sql`; regenerate sqlc.
+- [ ] 2.2 Add a handler helper that, given the hits, batch-loads full descriptions
+  by id and patches each hit best-effort (missing id keeps the index value, never
+  drops the hit).
+
+## 3. Format conversion
+
+- [ ] 3.1 Add a pure `formatDescription(html string, format string) string` helper:
+  `html` (identity), `text` (strip tags), `markdown` (HTML→Markdown preserving
+  block structure); unrecognized → `html`.
+- [ ] 3.2 Add the HTML→text/markdown conversion dependency (or std-lib strip for
+  `text`); keep it behind the helper.
+- [ ] 3.3 Unit-test the helper for all three formats plus the fallback.
+
+## 4. Endpoint
+
+- [ ] 4.1 Add `AgentSearchJobs` handler: run the shared search core, hydrate full
+  descriptions, apply `description_format`, respond with the `{data, meta}` envelope
+  (public_slug, no internal id).
+- [ ] 4.2 Register `GET /api/v1/agent/jobs/search` as a public (no-auth) route.
+- [ ] 4.3 Unit-test the endpoint with a fake searcher + fake description loader:
+  full description replaces the preview; best-effort keeps a stale hit; each format
+  transforms `description`; default is verbatim html.
+
+## 5. Verification & docs
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` pass; gofmt clean.
+- [ ] 5.2 Document `GET /api/v1/agent/jobs/search` and its `description_format`
+  parameter in the `api-documentation` surface (`web/src/lib/docs/api-spec.ts`,
+  regenerate `docs/API.md`).
+
+## 6. Close the loop
+
+- [ ] 6.1 Offer a `/blog` changelog entry (user-facing API addition) per the
+  announce-shipped-work convention.

--- a/openspec/changes/add-agent-jobs-search/tasks.md
+++ b/openspec/changes/add-agent-jobs-search/tasks.md
@@ -1,42 +1,42 @@
 ## 1. Shared search core
 
-- [ ] 1.1 Extract the public `SearchJobs` request handling (filter/sort/pagination
+- [x] 1.1 Extract the public `SearchJobs` request handling (filter/sort/pagination
   window/semantic ratio → `a.search.Search`) into one internal helper returning the
   `search.SearchResult` (hits + total), and have `SearchJobs` call it.
-- [ ] 1.2 Confirm the existing `internal/handler/search_test.go` suite stays green
+- [x] 1.2 Confirm the existing `internal/handler/search_test.go` suite stays green
   after the extraction (the public endpoint's behavior is unchanged).
 
 ## 2. Description hydration
 
-- [ ] 2.1 Add `GetJobDescriptionsByIDs :many` (`SELECT id, description ... WHERE id
+- [x] 2.1 Add `GetJobDescriptionsByIDs :many` (`SELECT id, description ... WHERE id
   = ANY($ids)`) to `internal/db/queries/jobs.sql`; regenerate sqlc.
-- [ ] 2.2 Add a handler helper that, given the hits, batch-loads full descriptions
+- [x] 2.2 Add a handler helper that, given the hits, batch-loads full descriptions
   by id and patches each hit best-effort (missing id keeps the index value, never
   drops the hit).
 
 ## 3. Format conversion
 
-- [ ] 3.1 Add a pure `formatDescription(html string, format string) string` helper:
+- [x] 3.1 Add a pure `formatDescription(html string, format string) string` helper:
   `html` (identity), `text` (strip tags), `markdown` (HTML→Markdown preserving
   block structure); unrecognized → `html`.
-- [ ] 3.2 Add the HTML→text/markdown conversion dependency (or std-lib strip for
+- [x] 3.2 Add the HTML→text/markdown conversion dependency (or std-lib strip for
   `text`); keep it behind the helper.
-- [ ] 3.3 Unit-test the helper for all three formats plus the fallback.
+- [x] 3.3 Unit-test the helper for all three formats plus the fallback.
 
 ## 4. Endpoint
 
-- [ ] 4.1 Add `AgentSearchJobs` handler: run the shared search core, hydrate full
+- [x] 4.1 Add `AgentSearchJobs` handler: run the shared search core, hydrate full
   descriptions, apply `description_format`, respond with the `{data, meta}` envelope
   (public_slug, no internal id).
-- [ ] 4.2 Register `GET /api/v1/agent/jobs/search` as a public (no-auth) route.
-- [ ] 4.3 Unit-test the endpoint with a fake searcher + fake description loader:
+- [x] 4.2 Register `GET /api/v1/agent/jobs/search` as a public (no-auth) route.
+- [x] 4.3 Unit-test the endpoint with a fake searcher + fake description loader:
   full description replaces the preview; best-effort keeps a stale hit; each format
   transforms `description`; default is verbatim html.
 
 ## 5. Verification & docs
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` pass; gofmt clean.
-- [ ] 5.2 Document `GET /api/v1/agent/jobs/search` and its `description_format`
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` pass; gofmt clean.
+- [x] 5.2 Document `GET /api/v1/agent/jobs/search` and its `description_format`
   parameter in the `api-documentation` surface (`web/src/lib/docs/api-spec.ts`,
   regenerate `docs/API.md`).
 

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -227,6 +227,31 @@ export const GROUPS: Group[] = [
       },
       {
         method: 'GET',
+        path: '/agent/jobs/search',
+        auth: 'none',
+        summary: 'Search with full descriptions, for programmatic/agent consumers.',
+        description:
+          'Same query and filters as `/jobs/search`, but each result carries the ' +
+          '`description` in full (verbatim from the database) instead of the truncated ' +
+          'index preview. Use `description_format` to choose how it is rendered.',
+        filterable: true,
+        query: [
+          { name: 'q', type: 'string', description: 'Full-text query over title, company, and description.', example: 'golang' },
+          { name: 'description_format', type: 'string', description: 'One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`.', example: 'markdown' },
+          { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },
+          { name: 'order', type: 'string', description: '`asc` or `desc` (default `desc`).', example: 'desc' },
+          { name: 'semantic_ratio', type: 'number', description: 'Opt-in hybrid search, 0–1 (default 0 = pure keyword). Needs the optional semantic index.', example: '0' },
+          { name: 'limit', type: 'integer', description: 'Page size, 1–100.', example: '20' },
+          { name: 'offset', type: 'integer', description: 'Rows to skip; `offset + limit` ≤ 10000.', example: '0' },
+        ],
+        curl: `curl "${BASE_URL}/agent/jobs/search?q=golang&work_mode=remote&description_format=markdown"`,
+        responseExample: `{
+  "data": [ { "public_slug": "...", "title": "Senior Go Engineer", "description": "## About the role\\n...", "...": "..." } ],
+  "meta": { "total": 137, "limit": 20, "offset": 0 }
+}`,
+      },
+      {
+        method: 'GET',
         path: '/jobs/facets',
         auth: 'none',
         summary: 'Count of matching jobs per facet value (and numeric stats).',

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -5,7 +5,7 @@
 // the generated contracts so it stays in lock-step with the Go StringFacets.
 
 /** Production base URL for every path below. */
-export const BASE_URL = 'https://freehire.dev/api/v1';
+export const BASE_URL = 'https://freehire.me/api/v1';
 
 /** Authentication requirement for an endpoint, rendered as a badge. */
 export type Auth = 'none' | 'cookie-or-key' | 'cookie' | 'moderator';


### PR DESCRIPTION
## Summary

Adds a dedicated public, keyless search endpoint for programmatic/agent consumers:

- **`GET /api/v1/agent/jobs/search`** — runs the exact same query/filters/sort/paging as `/jobs/search`, but returns each job's **full** `description` (verbatim from Postgres, hydrated best-effort by internal id) instead of the truncated index preview.
- **`description_format`** param: `html` (default, verbatim) · `text` (tags stripped) · `markdown` (HTML→Markdown, structure preserved). Unknown values fall back to `html`.
- The public `/jobs/search` is **unchanged** — still Meili-only, still a truncated preview. The full-fidelity path lives on its own surface, so the website's hot path pays nothing.

Resolves the need behind #1104 (search returning truncated descriptions), which we closed in favor of this dedicated endpoint rather than bolting a `full_description` (and, inevitably, format) flag onto the SPA-facing search.

### Design notes
- Extracted a shared `runJobSearch` core so the public and agent search endpoints **cannot drift** — "same search" is structurally enforced, not copied.
- New `internal/htmltext` package wraps HTML→text (`jaytaylor/html2text`, already a dep) and HTML→Markdown (`JohannesKaufmann/html-to-markdown/v2`, the one genuinely new dep). Both lenient: a conversion error degrades to the input unchanged.
- Narrow `GetJobDescriptionsByIDs` query (`id, description`), bounded by the page limit (≤100), by primary key — no wide-row detoast. Best-effort: a hit whose id has no row (index lag) keeps its preview, never dropped.
- Zero additional Meilisearch storage; the Postgres read is only on this endpoint.

Planned + tracked under OpenSpec change `add-agent-jobs-search` (proposal/design/specs/tasks in `openspec/changes/`).

## Test Plan

- [x] `go build ./... && go vet ./... && go test ./...` pass; gofmt clean
- [x] Public `/jobs/search` behavior unchanged (existing `search_test.go` green after the refactor)
- [x] New unit tests cover all 8 spec scenarios: full-description hydration, public_slug/no-id, best-effort stale hit, param parity to the searcher, and `html`/`text`/`markdown`/unknown→`html` formats (using the real `htmltext` package)
- [x] New `GetJobDescriptionsByIDs` verified against the real Postgres schema
- [ ] Manual smoke on a deployed build: `curl ".../api/v1/agent/jobs/search?q=golang&description_format=markdown"`