### PR TITLE
feat(auth): browser-extension "Sign in with freehire" connect flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ cmd/backfill-company-names/main.go  resolves real display names for slug-named c
 cmd/import-yc/main.go      enriches companies from yc-oss directory
 sources/                   board files + sources/custom.yml + sources/telegram.yml
 internal/
-  config/            env config (server: PORT, DATABASE_URL, FRONTEND_ORIGIN, JWT_SECRET/JWT_TTL, COOKIE_SECURE, MEILI_URL/MEILI_MASTER_KEY, OAUTH_*, SENTRY_*; workers: LLM_BASE_URL/LLM_API_KEY/LLM_MODEL, EMBED_*)
+  config/            env config (server: PORT, DATABASE_URL, FRONTEND_ORIGIN, JWT_SECRET/JWT_TTL, COOKIE_SECURE, MEILI_URL/MEILI_MASTER_KEY, OAUTH_*, EXTENSION_REDIRECT_ALLOWLIST, SENTRY_*; workers: LLM_BASE_URL/LLM_API_KEY/LLM_MODEL, EMBED_*)
   observability/     optional Sentry error reporting (see observability/AGENTS.md)
   database/          pgxpool connection pool
   db/                GENERATED sqlc code + queries/*.sql (see db/AGENTS.md)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -191,6 +191,8 @@ func main() {
 
 		AWSRegion:       cfg.AWSRegion,
 		NotifyEmailFrom: cfg.NotifyEmailFrom,
+
+		ExtensionRedirectAllowlist: cfg.ExtensionRedirectAllowlist,
 	})
 
 	// Run the server in a goroutine so main can wait for a shutdown signal.

--- a/internal/auth/AGENTS.md
+++ b/internal/auth/AGENTS.md
@@ -28,6 +28,28 @@ OAuth sign-in (`internal/auth/oauth/`) adds a provider registry (Google/GitHub/L
 
 `internal/handler/oauth.go` owns the OAuth HTTP handlers.
 
+### Browser-extension connect flow
+
+The browser extension signs in with `chrome.identity.launchWebAuthFlow`, which
+opens `GET /api/v1/auth/extension/connect` **in the freehire origin** (so the
+session cookie is present) and waits for a redirect to
+`https://<extension-id>.chromiumapp.org/`. Handlers live in
+`internal/handler/extension_connect.go`, both **cookie-only (`RequireAuth`)** like
+key management — a leaked key must not mint further keys:
+
+- `GET` validates `redirect_uri` (`validateExtensionRedirect`: https +
+  `<id>.chromiumapp.org` + `<id>` on the allowlist) and renders a consent page.
+- `POST` re-validates, then on `decision=allow` **mints an ordinary named API key**
+  (`extensionKeyName`, via `GenerateAPIKey`/`CreateAPIKey`) and 302s to
+  `redirect_uri#token=…&state=…` — the token rides the **fragment**, never the
+  query, so it is not logged or sent in `Referer`. Any other decision mints
+  nothing and 302s `#error=access_denied`.
+
+The redirect target is bounded by `EXTENSION_REDIRECT_ALLOWLIST` (comma-separated
+extension ids, parsed in `internal/config`); an empty allowlist disables the flow.
+The minted key is a normal revocable key — it shows up in `/me/api-keys` and
+authenticates per-user endpoints via `Authorization: Bearer`.
+
 ## Limitations
 - No token revocation/refresh (logout clears the cookie but the JWT lives until `exp`; modest TTL instead).
 - No CSRF token — only `SameSite=Lax` + same-origin defense; a CSRF token is needed only if a future need forces `SameSite=None`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,6 +124,11 @@ type Settings struct {
 	// sender address (e.g. notifications@freehire.dev).
 	AWSRegion       string
 	NotifyEmailFrom string
+
+	// ExtensionRedirectAllowlist bounds where the browser-extension connect flow
+	// may hand back a minted token: only https://<id>.chromiumapp.org redirects
+	// whose <id> is listed here are accepted. Empty disables the connect flow.
+	ExtensionRedirectAllowlist []string
 }
 
 // OAuthCredentials is one OAuth provider's client id/secret pair.
@@ -178,7 +183,21 @@ func Load() Settings {
 
 		AWSRegion:       os.Getenv("AWS_REGION"),
 		NotifyEmailFrom: os.Getenv("NOTIFY_EMAIL_FROM"),
+
+		ExtensionRedirectAllowlist: splitCSV(os.Getenv("EXTENSION_REDIRECT_ALLOWLIST")),
 	}
+}
+
+// splitCSV parses a comma-separated env value into trimmed, non-empty entries.
+// An empty or all-blank value yields nil.
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // decodeKey base64-decodes an AES key, returning nil unless it is exactly 32

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"slices"
 	"testing"
 	"time"
 )
@@ -185,5 +186,33 @@ func TestLoad_EmailNotifyEmptyWhenUnset(t *testing.T) {
 	s := Load()
 	if s.AWSRegion != "" || s.NotifyEmailFrom != "" {
 		t.Errorf("email-notify settings should be empty when unset, got %q/%q", s.AWSRegion, s.NotifyEmailFrom)
+	}
+}
+
+func TestLoad_ExtensionRedirectAllowlistFromEnv(t *testing.T) {
+	t.Setenv("EXTENSION_REDIRECT_ALLOWLIST", "abcdefghijklmnop, qrstuvwxyzabcdef")
+
+	got := Load().ExtensionRedirectAllowlist
+	want := []string{"abcdefghijklmnop", "qrstuvwxyzabcdef"}
+	if !slices.Equal(got, want) {
+		t.Errorf("ExtensionRedirectAllowlist = %v, want %v", got, want)
+	}
+}
+
+func TestLoad_ExtensionRedirectAllowlistDropsBlankEntries(t *testing.T) {
+	t.Setenv("EXTENSION_REDIRECT_ALLOWLIST", " , abcdefghijklmnop ,,  ")
+
+	got := Load().ExtensionRedirectAllowlist
+	want := []string{"abcdefghijklmnop"}
+	if !slices.Equal(got, want) {
+		t.Errorf("ExtensionRedirectAllowlist = %v, want %v", got, want)
+	}
+}
+
+func TestLoad_ExtensionRedirectAllowlistNilWhenUnset(t *testing.T) {
+	t.Setenv("EXTENSION_REDIRECT_ALLOWLIST", "")
+
+	if got := Load().ExtensionRedirectAllowlist; got != nil {
+		t.Errorf("ExtensionRedirectAllowlist should be nil when unset, got %v", got)
 	}
 }

--- a/internal/handler/extension_connect.go
+++ b/internal/handler/extension_connect.go
@@ -1,0 +1,148 @@
+package handler
+
+import (
+	"fmt"
+	"html"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// chromiumappSuffix is the host suffix Chrome's identity redirect URLs carry:
+// launchWebAuthFlow only resolves a redirect to https://<extension-id>.chromiumapp.org.
+const chromiumappSuffix = ".chromiumapp.org"
+
+// extensionKeyName is the display name given to keys minted through the connect
+// flow, so they are recognizable and revocable in the user's key list.
+const extensionKeyName = "Browser extension"
+
+// validateExtensionRedirect reports whether redirectURI is a safe target for the
+// browser-extension connect flow to hand a minted token to. It accepts only an
+// https://<extension-id>.chromiumapp.org URL whose <extension-id> is a single
+// host label present in allowlist. An empty allowlist disables the flow entirely.
+func validateExtensionRedirect(redirectURI string, allowlist []string) error {
+	if len(allowlist) == 0 {
+		return fmt.Errorf("extension connect is disabled (empty allowlist)")
+	}
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		return fmt.Errorf("invalid redirect_uri: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("redirect_uri must be https, got %q", u.Scheme)
+	}
+	if u.Port() != "" {
+		return fmt.Errorf("redirect_uri must not carry a port")
+	}
+	host := u.Hostname()
+	if !strings.HasSuffix(host, chromiumappSuffix) {
+		return fmt.Errorf("redirect_uri host must be *%s, got %q", chromiumappSuffix, host)
+	}
+	id := strings.TrimSuffix(host, chromiumappSuffix)
+	if id == "" || strings.Contains(id, ".") {
+		return fmt.Errorf("redirect_uri must be a single <id>%s label, got %q", chromiumappSuffix, host)
+	}
+	if !slices.Contains(allowlist, id) {
+		return fmt.Errorf("extension id %q is not allowlisted", id)
+	}
+	return nil
+}
+
+// redirectWithFragment returns base with vals encoded into its URL fragment,
+// replacing any existing fragment. The connect flow carries the minted token in
+// the fragment (never the query) so it is not sent to servers, logged, or leaked
+// via Referer.
+func redirectWithFragment(base string, vals url.Values) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	u.Fragment = ""
+	return u.String() + "#" + vals.Encode(), nil
+}
+
+// ExtensionConnect renders the consent screen for the browser-extension sign-in.
+// Cookie-only (RequireAuth): a leaked API key must not drive it. It validates the
+// redirect target before showing anything, so an invalid redirect never reaches a
+// consent step.
+func (a *API) ExtensionConnect(c *fiber.Ctx) error {
+	if _, err := requireUserID(c); err != nil {
+		return err
+	}
+	redirectURI := c.Query("redirect_uri")
+	state := c.Query("state")
+	if err := validateExtensionRedirect(redirectURI, a.extensionRedirectAllowlist); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid redirect_uri")
+	}
+	c.Type("html")
+	return c.SendString(consentPage(redirectURI, state))
+}
+
+// ExtensionConnectSubmit acts on the consent decision. On approval it mints a
+// named API key and 302-redirects the token back in the fragment; on anything
+// else it mints nothing and 302-redirects an error. Cookie-only (RequireAuth).
+func (a *API) ExtensionConnectSubmit(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	redirectURI := c.FormValue("redirect_uri")
+	state := c.FormValue("state")
+	// Re-validate: never trust that the GET consent step ran, and never redirect
+	// to an unvetted target.
+	if err := validateExtensionRedirect(redirectURI, a.extensionRedirectAllowlist); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid redirect_uri")
+	}
+	redirect := func(vals url.Values) error {
+		location, err := redirectWithFragment(redirectURI, vals)
+		if err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, "invalid redirect_uri")
+		}
+		return c.Redirect(location, fiber.StatusFound)
+	}
+
+	if c.FormValue("decision") != "allow" {
+		return redirect(url.Values{"error": {"access_denied"}, "state": {state}})
+	}
+
+	token, hash, prefix, err := auth.GenerateAPIKey()
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "failed to generate key")
+	}
+	if _, err := a.queries.CreateAPIKey(c.Context(), db.CreateAPIKeyParams{
+		UserID:      userID,
+		Name:        extensionKeyName,
+		TokenHash:   hash,
+		TokenPrefix: prefix,
+	}); err != nil {
+		return err
+	}
+
+	return redirect(url.Values{"token": {token}, "state": {state}})
+}
+
+// consentPage is the minimal server-rendered approval screen. The redirect and
+// state ride hidden fields back to the POST; both are HTML-escaped into attribute
+// values to keep them inert.
+func consentPage(redirectURI, state string) string {
+	return fmt.Sprintf(`<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Connect the freehire extension</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem">
+  <h1>Connect the freehire extension</h1>
+  <p>Allow the freehire browser extension to access your account? It will act as
+     you — reading your profile, CV, and saved jobs.</p>
+  <form method="post" action="/api/v1/auth/extension/connect">
+    <input type="hidden" name="redirect_uri" value="%s">
+    <input type="hidden" name="state" value="%s">
+    <button type="submit" name="decision" value="allow">Allow</button>
+    <button type="submit" name="decision" value="cancel">Cancel</button>
+  </form>
+</body>
+</html>`, html.EscapeString(redirectURI), html.EscapeString(state))
+}

--- a/internal/handler/extension_connect_integration_test.go
+++ b/internal/handler/extension_connect_integration_test.go
@@ -1,0 +1,218 @@
+//go:build integration
+
+// Integration tests for the browser-extension connect flow against a real
+// Postgres: the endpoint is cookie-only, it rejects unlisted redirects, approval
+// mints a named key and returns the token in the redirect fragment, decline mints
+// nothing, and the minted token behaves as an ordinary revocable API key. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobtracking"
+)
+
+func TestExtensionConnectEndToEnd(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var userID int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('ext@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, public_slug)
+		 VALUES ('test', 'ext-1', 'http://example.test', 'Go Dev', 'go-dev-acme-t35nijto')`); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	const applyPath = "/api/v1/jobs/go-dev-acme-t35nijto/apply"
+
+	const extID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	redirectURI := "https://" + extID + ".chromiumapp.org/"
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	cookie, _ := iss.Issue(userID)
+	queries := db.New(pool)
+	h := &API{
+		pool:                       pool,
+		queries:                    queries,
+		issuer:                     iss,
+		tracking:                   jobtracking.New(jobtracking.NewQueriesRepository(queries)),
+		extensionRedirectAllowlist: []string{extID},
+	}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	cookieAuth := auth.RequireAuth(iss)
+	keyAuth := auth.RequireAuthOrKey(iss, queries)
+	app.Get("/api/v1/auth/extension/connect", cookieAuth, h.ExtensionConnect)
+	app.Post("/api/v1/auth/extension/connect", cookieAuth, h.ExtensionConnectSubmit)
+	app.Get("/api/v1/me/api-keys", cookieAuth, h.ListAPIKeys)
+	app.Delete("/api/v1/me/api-keys/:id", cookieAuth, h.RevokeAPIKey)
+	app.Post("/api/v1/jobs/:slug/apply", keyAuth, h.MarkApplied)
+
+	const connectPath = "/api/v1/auth/extension/connect"
+
+	withCookie := func(r *http.Request) *http.Request {
+		r.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+		return r
+	}
+	form := func(vals url.Values) *http.Request {
+		r := httptest.NewRequest(fiber.MethodPost, connectPath, strings.NewReader(vals.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return r
+	}
+	keyCount := func() int {
+		rows, err := queries.ListAPIKeysByUser(ctx, userID)
+		if err != nil {
+			t.Fatalf("count keys: %v", err)
+		}
+		return len(rows)
+	}
+
+	// 4.1 Session-only: no cookie and Bearer-only are both rejected; nothing minted.
+	t.Run("anonymous GET is rejected", func(t *testing.T) {
+		resp, _ := app.Test(httptest.NewRequest(fiber.MethodGet, connectPath+"?redirect_uri="+url.QueryEscape(redirectURI), nil))
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+	t.Run("bearer-only POST is rejected and mints nothing", func(t *testing.T) {
+		before := keyCount()
+		r := form(url.Values{"redirect_uri": {redirectURI}, "decision": {"allow"}})
+		r.Header.Set("Authorization", "Bearer some-key-value")
+		resp, _ := app.Test(r)
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+		if after := keyCount(); after != before {
+			t.Fatalf("keys changed %d -> %d, want no mint", before, after)
+		}
+	})
+
+	// 4.2 Redirect validation: an unlisted redirect is refused with 400, no mint.
+	t.Run("unlisted redirect is rejected and mints nothing", func(t *testing.T) {
+		before := keyCount()
+		resp, _ := app.Test(withCookie(form(url.Values{
+			"redirect_uri": {"https://evil.example.com/"},
+			"decision":     {"allow"},
+		})))
+		if resp.StatusCode != fiber.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", resp.StatusCode)
+		}
+		if after := keyCount(); after != before {
+			t.Fatalf("keys changed %d -> %d, want no mint", before, after)
+		}
+	})
+
+	// 4.4 Decline: mints nothing, redirects an error (not a token).
+	t.Run("decline redirects an error and mints nothing", func(t *testing.T) {
+		before := keyCount()
+		resp, _ := app.Test(withCookie(form(url.Values{
+			"redirect_uri": {redirectURI},
+			"state":        {"s1"},
+			"decision":     {"cancel"},
+		})))
+		if resp.StatusCode != fiber.StatusFound {
+			t.Fatalf("status = %d, want 302", resp.StatusCode)
+		}
+		frag := fragmentValues(t, resp.Header.Get("Location"))
+		if frag.Get("token") != "" {
+			t.Fatalf("decline returned a token: %q", frag.Get("token"))
+		}
+		if frag.Get("error") == "" {
+			t.Fatalf("decline missing error indication, fragment = %q", resp.Header.Get("Location"))
+		}
+		if after := keyCount(); after != before {
+			t.Fatalf("keys changed %d -> %d, want no mint", before, after)
+		}
+	})
+
+	// 4.3 + 4.5 Approve mints a named key and returns the token in the fragment;
+	// the token then behaves as an ordinary revocable API key.
+	var mintedToken string
+	var mintedKeyID int64
+	t.Run("approve mints a key and returns the token in the fragment", func(t *testing.T) {
+		resp, _ := app.Test(withCookie(form(url.Values{
+			"redirect_uri": {redirectURI},
+			"state":        {"abc"},
+			"decision":     {"allow"},
+		})))
+		if resp.StatusCode != fiber.StatusFound {
+			t.Fatalf("status = %d, want 302", resp.StatusCode)
+		}
+		frag := fragmentValues(t, resp.Header.Get("Location"))
+		if frag.Get("state") != "abc" {
+			t.Fatalf("state = %q, want abc", frag.Get("state"))
+		}
+		mintedToken = frag.Get("token")
+		if mintedToken == "" {
+			t.Fatalf("no token in fragment: %q", resp.Header.Get("Location"))
+		}
+		// The token must be in the fragment, never the query.
+		loc, _ := url.Parse(resp.Header.Get("Location"))
+		if loc.Query().Get("token") != "" {
+			t.Fatalf("token leaked into the query string")
+		}
+
+		rows, err := queries.ListAPIKeysByUser(ctx, userID)
+		if err != nil {
+			t.Fatalf("list keys: %v", err)
+		}
+		var found bool
+		for _, r := range rows {
+			if r.Name == extensionKeyName {
+				found, mintedKeyID = true, r.ID
+			}
+		}
+		if !found {
+			t.Fatalf("no key named %q after approve", extensionKeyName)
+		}
+	})
+
+	t.Run("minted token authenticates as the user", func(t *testing.T) {
+		r := httptest.NewRequest(fiber.MethodPost, applyPath, nil)
+		r.Header.Set("Authorization", "Bearer "+mintedToken)
+		resp, _ := app.Test(r)
+		if resp.StatusCode != fiber.StatusOK && resp.StatusCode != fiber.StatusNoContent {
+			t.Fatalf("apply with minted token = %d, want 2xx", resp.StatusCode)
+		}
+	})
+
+	t.Run("revoking the key stops the token", func(t *testing.T) {
+		resp, _ := app.Test(withCookie(httptest.NewRequest(fiber.MethodDelete,
+			"/api/v1/me/api-keys/"+itoa(mintedKeyID), nil)))
+		if resp.StatusCode != fiber.StatusNoContent && resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("revoke = %d, want 2xx", resp.StatusCode)
+		}
+		r := httptest.NewRequest(fiber.MethodPost, applyPath, nil)
+		r.Header.Set("Authorization", "Bearer "+mintedToken)
+		resp2, _ := app.Test(r)
+		if resp2.StatusCode != fiber.StatusUnauthorized {
+			t.Fatalf("revoked token = %d, want 401", resp2.StatusCode)
+		}
+	})
+}
+
+func fragmentValues(t *testing.T, location string) url.Values {
+	t.Helper()
+	u, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse Location %q: %v", location, err)
+	}
+	vals, err := url.ParseQuery(u.Fragment)
+	if err != nil {
+		t.Fatalf("parse fragment %q: %v", u.Fragment, err)
+	}
+	return vals
+}

--- a/internal/handler/extension_connect_test.go
+++ b/internal/handler/extension_connect_test.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestRedirectWithFragment(t *testing.T) {
+	t.Run("puts values in the fragment, not the query", func(t *testing.T) {
+		got, err := redirectWithFragment("https://abc.chromiumapp.org/cb", url.Values{
+			"token": {"secret-123"},
+			"state": {"s1"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "https://abc.chromiumapp.org/cb#state=s1&token=secret-123"
+		if got != want {
+			t.Errorf("redirectWithFragment = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("replaces any pre-existing fragment", func(t *testing.T) {
+		got, err := redirectWithFragment("https://abc.chromiumapp.org/#old", url.Values{
+			"token": {"t"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "https://abc.chromiumapp.org/#token=t"; got != want {
+			t.Errorf("redirectWithFragment = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("percent-encodes special characters", func(t *testing.T) {
+		got, err := redirectWithFragment("https://abc.chromiumapp.org/", url.Values{
+			"state": {"a b&c"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "https://abc.chromiumapp.org/#state=a+b%26c"; got != want {
+			t.Errorf("redirectWithFragment = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestValidateExtensionRedirect(t *testing.T) {
+	allow := []string{"abcdefghijklmnop", "qrstuvwxyzabcdef"}
+
+	cases := []struct {
+		name    string
+		uri     string
+		allow   []string
+		wantErr bool
+	}{
+		{"allowlisted id", "https://abcdefghijklmnop.chromiumapp.org/", allow, false},
+		{"allowlisted id with path", "https://abcdefghijklmnop.chromiumapp.org/cb", allow, false},
+		{"second allowlisted id", "https://qrstuvwxyzabcdef.chromiumapp.org/", allow, false},
+		{"unknown id", "https://zzzzzzzzzzzzzzzz.chromiumapp.org/", allow, true},
+		{"wrong scheme", "http://abcdefghijklmnop.chromiumapp.org/", allow, true},
+		{"wrong host", "https://abcdefghijklmnop.evil.com/", allow, true},
+		{"id as sibling label only", "https://abcdefghijklmnop.chromiumapp.org.evil.com/", allow, true},
+		{"multi-label before suffix", "https://a.abcdefghijklmnop.chromiumapp.org/", allow, true},
+		{"port present", "https://abcdefghijklmnop.chromiumapp.org:8080/", allow, true},
+		{"malformed url", "https://%zz", allow, true},
+		{"empty allowlist disables", "https://abcdefghijklmnop.chromiumapp.org/", nil, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateExtensionRedirect(tc.uri, tc.allow)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateExtensionRedirect(%q) = nil, want error", tc.uri)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateExtensionRedirect(%q) = %v, want nil", tc.uri, err)
+			}
+		})
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -94,6 +94,9 @@ type API struct {
 	oauthCodes *oauth.CodeStore
 	// frontendOrigin is where OAuth callbacks send the browser back to.
 	frontendOrigin string
+	// extensionRedirectAllowlist bounds the browser-extension connect flow to the
+	// chromiumapp.org redirect ids listed here. Empty refuses every redirect.
+	extensionRedirectAllowlist []string
 	// gmailConnector + gmailCipher back the "Connect Gmail" inbox. Both nil when
 	// the feature is unconfigured (Google creds / token key absent) — the connect
 	// routes are then not registered and the inbox reads empty.
@@ -275,6 +278,10 @@ type Config struct {
 	// Telegram-only (email disabled). NotifyEmailFrom is the verified SES sender address.
 	AWSRegion       string
 	NotifyEmailFrom string
+	// ExtensionRedirectAllowlist bounds the browser-extension connect flow: only
+	// https://<id>.chromiumapp.org redirects whose <id> is listed may receive a
+	// minted token. Empty leaves the connect endpoint refusing every redirect.
+	ExtensionRedirectAllowlist []string
 }
 
 // Register wires all routes onto the application from cfg. Auth is same-origin
@@ -293,6 +300,9 @@ func Register(app *fiber.App, cfg Config) {
 		oauth:          cfg.OAuthRegistry,
 		oauthCodes:     oauth.NewCodeStore(60 * time.Second),
 		frontendOrigin: cfg.FrontendOrigin,
+
+		extensionRedirectAllowlist: cfg.ExtensionRedirectAllowlist,
+
 		gmailConnector: cfg.GmailConnector,
 		gmailCipher:    cfg.GmailCipher,
 		mailDomain:     cfg.MailboxDomain,
@@ -716,4 +726,13 @@ func Register(app *fiber.App, cfg Config) {
 	// Mobile-only: redeem the one-time code from the custom-scheme callback for a
 	// session. Public; the code is the credential.
 	authGroup.Post("/oauth/exchange", a.OAuthExchange)
+
+	// Browser-extension sign-in ("Sign in with freehire"): the extension opens
+	// this in the freehire origin via launchWebAuthFlow. Cookie-only (RequireAuth)
+	// like key management — a leaked key must not mint further keys. GET shows the
+	// consent screen; POST mints a named key and redirects the token in the
+	// fragment. Both refuse any redirect outside the configured allowlist.
+	extAuth := auth.RequireAuth(a.issuer)
+	authGroup.Get("/extension/connect", extAuth, a.ExtensionConnect)
+	authGroup.Post("/extension/connect", extAuth, a.ExtensionConnectSubmit)
 }

--- a/openspec/changes/add-extension-connect-auth/.openspec.yaml
+++ b/openspec/changes/add-extension-connect-auth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-extension-connect-auth/design.md
+++ b/openspec/changes/add-extension-connect-auth/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The freehire browser extension needs a durable credential to call hire as the
+signed-in user, but its `chrome-extension://` side panel cannot read hire's
+`HttpOnly; SameSite=Lax` session cookie. hire already has everything needed to
+issue such a credential: `api_keys` (hashed at rest, `name` column, revocable),
+`GenerateAPIKey`/`HashAPIKey`, the `CreateAPIKey` query, and `RequireAuthOrKey`,
+which already authenticates `Authorization: Bearer <key>` on per-user endpoints.
+
+The missing piece is a bridge that runs **in the `freehire.me` origin** (so it
+sees the session cookie) and hands a freshly minted key back to the extension.
+Chrome's `chrome.identity.launchWebAuthFlow` is built for exactly this: it opens
+an auth URL and waits for a redirect to `https://<extension-id>.chromiumapp.org/`,
+then returns that URL to the extension.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let the extension obtain a hire credential with no password re-entry when a
+  session already exists, and a normal login when it does not.
+- Never expose the `HttpOnly` session cookie to extension code.
+- Reuse the existing API-key facility; no new credential type, no schema change.
+- Bound where tokens can be delivered (no open redirect).
+
+**Non-Goals:**
+- The extension client (`launchWebAuthFlow`, token storage, authed fetch) —
+  separate repo, driven by this endpoint.
+- The agent/chat, page context, form-filling — later specs.
+- A polished SPA consent screen — a minimal server-rendered page is enough now.
+- Token refresh/rotation — the key is long-lived and revocable, like any key.
+
+## Decisions
+
+### D1: The credential is an ordinary named API key
+Reuse `api_keys` + `GenerateAPIKey`/`HashAPIKey`/`CreateAPIKey`. The minted key
+is created with a recognizable, constant `name` (e.g. `"Browser extension"`) so
+it is obvious in `/me/api-keys`. **Why:** the key is already hashed-at-rest,
+revocable, and accepted by `RequireAuthOrKey`; a bespoke "extension token" would
+duplicate all of that. Alternative (opaque short-lived + refresh) rejected as
+premature — no requirement forces rotation yet, and it multiplies surface area.
+
+### D2: Server-rendered consent, backend-only
+Two cookie-only routes under the auth surface:
+- `GET /api/v1/auth/extension/connect?redirect_uri=…&state=…` — validates the
+  redirect, then renders a minimal consent page ("Allow the freehire extension
+  to access your account?" with Allow / Cancel).
+- `POST /api/v1/auth/extension/connect` (same query carried through) — on Allow,
+  mints the key and `302`s to the redirect with the token in the fragment; on
+  Cancel, `302`s with an error and no token.
+
+Both use `RequireAuth` (cookie only), matching the rule that key management is
+never reachable by an API key. **Why server-rendered:** keeps this change
+hire-backend-only (as scoped) and avoids coupling to the SvelteKit SPA build. A
+prettier SPA route can replace the page later without changing the contract.
+
+### D3: Token travels in the URL fragment, never the query
+The `302` target is `redirect_uri#token=<plaintext>&state=<state>`. **Why:**
+fragments are not sent to servers, not written to access logs, and not leaked via
+`Referer`. `launchWebAuthFlow` still delivers the full URL (fragment included) to
+the extension, which parses the token client-side.
+
+### D4: Strict `redirect_uri` allowlist
+Accept only `https://<extension-id>.chromiumapp.org/…` where `<extension-id>` is
+on a server-configured allowlist (`EXTENSION_REDIRECT_ALLOWLIST`, parsed in
+`internal/config`). Validation happens **before** consent or minting. **Why:**
+prevents an open redirect from turning the mint endpoint into a token-exfiltration
+gadget. Alternative (any `chromiumapp.org`) rejected — any published extension
+could then harvest tokens for a tricked user.
+
+### D5: CSRF posture inherits hire's model
+The consent `POST` is same-origin (form served by hire, submitted to hire), so
+the `SameSite=Lax` session cookie rides it; a cross-site forced POST carries no
+cookie and gets `401`. No CSRF token is added, consistent with the rest of hire.
+The `redirect_uri` allowlist is the second layer: even a coerced consent can only
+deliver a token to an extension id the operator explicitly trusts.
+
+## Risks / Trade-offs
+
+- **Open redirect / token exfiltration** → strict `chromiumapp.org` + allowlist
+  validation before any minting (D4); token in fragment (D3).
+- **Forced-consent (CSRF-style)** → `SameSite=Lax` same-origin defense (D5) plus
+  the allowlist bounding the blast radius to trusted extension ids.
+- **Key accumulation** — each successful connect mints a new key, so repeated
+  re-connects leave stale keys. Trade-off accepted for now: they are named,
+  visible, and revocable. A later refinement can revoke-and-replace by name.
+- **Token in browser history** — the fragment could linger in the auth popup's
+  history, but `launchWebAuthFlow` runs in a throwaway auth window that Chrome
+  discards; and the token is revocable regardless.
+
+## Migration Plan
+
+- No schema change (`api_keys.name` already exists).
+- Deploy: set `EXTENSION_REDIRECT_ALLOWLIST` to the extension id(s). Until the
+  extension calls the endpoint, the feature is inert.
+- Rollback: remove the routes / unset the env; existing extension keys keep
+  working as ordinary API keys and can be revoked normally.
+
+## Open Questions
+
+- Exact key naming and whether to revoke-and-replace by name on re-connect
+  (leaning: constant name now, dedup later if it becomes noisy).
+- Whether to later promote the consent page to a styled SPA route at
+  `/extension/connect` (contract stays identical).

--- a/openspec/changes/add-extension-connect-auth/proposal.md
+++ b/openspec/changes/add-extension-connect-auth/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The freehire browser extension must act as the signed-in hire user — read their
+profile, CV, and job pipeline — but a `chrome-extension://` side panel is a
+foreign origin that cannot read hire's `HttpOnly` session cookie. It needs a way
+to obtain a durable credential of its own without ever handling the cookie, and
+without the user re-typing a password when they already have a live hire session.
+
+## What Changes
+
+- Add a **cookie-authenticated connect flow** the extension drives via
+  `chrome.identity.launchWebAuthFlow`. Because it runs in the `freehire.me`
+  origin, an already-signed-in user reaches it with their session intact.
+- On explicit user consent, the server **mints a named API key** (reusing the
+  existing `api_keys` infrastructure — `GenerateAPIKey` + `HashAPIKey`, stored
+  hashed, plaintext shown once) and **302-redirects** to the extension's
+  `redirect_uri` with the plaintext token in the URL **fragment**.
+- The `redirect_uri` is **validated**: it must be an
+  `https://<extension-id>.chromiumapp.org/...` URL whose extension id is on a
+  configured allowlist. An invalid `redirect_uri` is rejected before any key is
+  minted.
+- The extension then authenticates existing per-user endpoints (`/auth/me`,
+  `/me/...`) with `Authorization: Bearer <token>` — already accepted by
+  `RequireAuthOrKey`. The `HttpOnly` cookie is never exposed to extension code.
+- Minted keys are ordinary revocable API keys with a recognizable name, so they
+  appear in `/me/api-keys` and can be revoked like any other key.
+
+## Capabilities
+
+### New Capabilities
+- `extension-auth`: the browser-extension connect flow — a cookie-only endpoint
+  that validates an extension `redirect_uri`, obtains user consent, mints a
+  named API key, and redirects the token back to the extension via the URL
+  fragment; plus the redirect-target allowlist that bounds it.
+
+### Modified Capabilities
+<!-- None. api-keys already supports named keys, hashed-at-rest storage, and
+     Bearer authentication (RequireAuthOrKey); the connect flow only creates a
+     normal key, so no api-keys requirement changes. -->
+
+## Impact
+
+- **New code:** one HTTP handler (connect + consent + mint + redirect) wired
+  under the auth surface in `internal/handler`, behind `RequireAuth` (cookie
+  only, like other key management); reuses `internal/auth` `GenerateAPIKey` /
+  `HashAPIKey` and the existing `CreateAPIKey` query.
+- **Config:** an allowlist of permitted extension ids (or exact
+  `chromiumapp.org` redirect origins) via env, consumed by `internal/config`.
+- **No schema change:** `api_keys` already has a `name` column; no migration.
+- **No change to** `RequireAuthOrKey`, `/auth/me`, or the cookie transport.
+- **Out of scope (later specs / separate repo):** the extension client code
+  (`launchWebAuthFlow`, token storage, authed fetch), the agent/chat, page
+  context, and form-filling.

--- a/openspec/changes/add-extension-connect-auth/specs/extension-auth/spec.md
+++ b/openspec/changes/add-extension-connect-auth/specs/extension-auth/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Extension connect is session-only
+
+The connect endpoint SHALL authenticate by session cookie only, exactly like
+other key-management endpoints. A request without a valid session cookie SHALL be
+rejected and no API key SHALL be minted. Presenting an `Authorization: Bearer`
+API key SHALL NOT authorize the connect flow — a leaked key MUST NOT be able to
+mint further keys.
+
+#### Scenario: Anonymous request is rejected
+- **WHEN** the connect endpoint is called without a valid session cookie
+- **THEN** the server responds `401` and mints no key
+
+#### Scenario: An API key cannot drive connect
+- **WHEN** the connect endpoint is called with only `Authorization: Bearer <key>` and no session cookie
+- **THEN** the server responds `401` and mints no key
+
+### Requirement: Redirect target is validated against an allowlist
+
+Before doing anything else, the server SHALL validate the supplied `redirect_uri`.
+It SHALL accept only an `https://<extension-id>.chromiumapp.org/` URL whose
+`<extension-id>` is on a server-configured allowlist. Any other scheme, host, or
+a non-allowlisted extension id SHALL be rejected with `400` and SHALL mint no key.
+
+#### Scenario: Allowlisted extension redirect is accepted
+- **WHEN** connect is called with `redirect_uri=https://<allowlisted-id>.chromiumapp.org/` and a valid session
+- **THEN** the flow proceeds to the consent step
+
+#### Scenario: Non-allowlisted or malformed redirect is rejected
+- **WHEN** connect is called with a `redirect_uri` that is not an allowlisted `chromiumapp.org` extension URL (wrong host, wrong scheme, or unknown extension id)
+- **THEN** the server responds `400` and mints no key
+
+### Requirement: Consent mints a named key and returns it via the fragment
+
+The flow SHALL require an explicit user consent action before minting. On consent,
+the server SHALL mint a named API key using the existing API-key facility (stored
+hashed, plaintext generated once) and SHALL `302`-redirect to the validated
+`redirect_uri` with the plaintext token and the caller's opaque `state` placed in
+the URL **fragment** (not the query string or path), so the token is not carried
+in request lines, `Referer` headers, or server logs.
+
+#### Scenario: Approval returns the token in the fragment
+- **WHEN** a signed-in user approves consent for an allowlisted `redirect_uri` carrying `state=abc`
+- **THEN** the server mints a named API key
+- **AND** it `302`-redirects to the `redirect_uri` with the plaintext token and `state=abc` in the URL fragment
+
+#### Scenario: The minted key is attributed to the extension
+- **WHEN** a key is minted through the connect flow
+- **THEN** it is created with a recognizable name and belongs to the consenting user
+
+### Requirement: Declining consent mints nothing
+
+The user SHALL be able to decline. On decline, the server SHALL mint no key and
+SHALL return control to the extension with an error indication rather than a token,
+so the extension's auth flow resolves deterministically instead of hanging.
+
+#### Scenario: Decline yields an error, not a token
+- **WHEN** a signed-in user declines consent
+- **THEN** no key is minted
+- **AND** the redirect (or response) carries an error indication and no token
+
+### Requirement: The minted token is an ordinary revocable API key
+
+A token minted by the connect flow SHALL be a normal API key: it SHALL authenticate
+per-user endpoints via `Authorization: Bearer <token>`, SHALL appear in the user's
+key listing, and SHALL be revocable. After revocation the token MUST no longer
+authenticate any request.
+
+#### Scenario: The token authenticates as the user
+- **WHEN** the extension calls a per-user endpoint with `Authorization: Bearer <minted-token>`
+- **THEN** the request is authenticated as the consenting user
+
+#### Scenario: The token is listed and revocable
+- **WHEN** the user lists their API keys after connecting
+- **THEN** the extension key appears in the list
+- **AND** revoking it causes the minted token to stop authenticating

--- a/openspec/changes/add-extension-connect-auth/tasks.md
+++ b/openspec/changes/add-extension-connect-auth/tasks.md
@@ -1,0 +1,28 @@
+## 1. Config: extension redirect allowlist
+
+- [ ] 1.1 Write a failing unit test for parsing `EXTENSION_REDIRECT_ALLOWLIST` (comma-separated extension ids → normalized set; empty/whitespace entries dropped)
+- [ ] 1.2 Add the field + parsing to `internal/config` to pass the test
+- [ ] 1.3 Thread the allowlist into the handler App dependencies (wherever config already flows into `internal/handler`)
+
+## 2. Redirect validation (pure)
+
+- [ ] 2.1 Write failing unit tests for `validateExtensionRedirect(redirectURI, allowlist)`: accepts `https://<allowlisted-id>.chromiumapp.org/…`; rejects wrong scheme, wrong host, unknown extension id, and malformed URLs
+- [ ] 2.2 Implement `validateExtensionRedirect` to pass the tests (pure function, no Fiber context)
+
+## 3. Connect handler
+
+- [ ] 3.1 Implement `GET /api/v1/auth/extension/connect` behind `RequireAuth`: validate `redirect_uri` (400 on invalid, no key minted), then render a minimal consent page (Allow / Cancel) carrying `redirect_uri` and `state`
+- [ ] 3.2 Implement `POST /api/v1/auth/extension/connect` behind `RequireAuth`: on Allow, mint a named API key via the existing `CreateAPIKey` facility and `302` to `redirect_uri#token=<plaintext>&state=<state>`; on Cancel, `302` to `redirect_uri#error=access_denied&state=<state>` and mint nothing
+- [ ] 3.3 Wire both routes into the auth route group in `internal/handler/handler.go` with `RequireAuth`
+
+## 4. Integration tests (end-to-end flow)
+
+- [ ] 4.1 Session-only: anonymous request → `401`; `Authorization: Bearer <key>` with no cookie → `401`; neither mints a key
+- [ ] 4.2 Redirect validation: a non-allowlisted / malformed `redirect_uri` → `400`, no key minted
+- [ ] 4.3 Approve: signed-in `POST` with allowlisted `redirect_uri` and `state=abc` → `302` whose `Location` fragment carries the plaintext token and `state=abc`; a named key is created for that user
+- [ ] 4.4 Decline: signed-in Cancel → `302` with an error in the fragment and no token; no key minted
+- [ ] 4.5 Token is a real key: the minted token authenticates a per-user endpoint via `Authorization: Bearer`; it appears in `/me/api-keys`; revoking it stops it authenticating
+
+## 5. Docs
+
+- [ ] 5.1 Document the connect flow and `EXTENSION_REDIRECT_ALLOWLIST` in `internal/auth/AGENTS.md` (and the config env list in the root `CLAUDE.md`/`AGENTS.md` if that is where env vars are catalogued)

--- a/openspec/changes/add-extension-connect-auth/tasks.md
+++ b/openspec/changes/add-extension-connect-auth/tasks.md
@@ -1,28 +1,28 @@
 ## 1. Config: extension redirect allowlist
 
-- [ ] 1.1 Write a failing unit test for parsing `EXTENSION_REDIRECT_ALLOWLIST` (comma-separated extension ids → normalized set; empty/whitespace entries dropped)
-- [ ] 1.2 Add the field + parsing to `internal/config` to pass the test
-- [ ] 1.3 Thread the allowlist into the handler App dependencies (wherever config already flows into `internal/handler`)
+- [x] 1.1 Write a failing unit test for parsing `EXTENSION_REDIRECT_ALLOWLIST` (comma-separated extension ids → normalized set; empty/whitespace entries dropped)
+- [x] 1.2 Add the field + parsing to `internal/config` to pass the test
+- [x] 1.3 Thread the allowlist into the handler App dependencies (wherever config already flows into `internal/handler`)
 
 ## 2. Redirect validation (pure)
 
-- [ ] 2.1 Write failing unit tests for `validateExtensionRedirect(redirectURI, allowlist)`: accepts `https://<allowlisted-id>.chromiumapp.org/…`; rejects wrong scheme, wrong host, unknown extension id, and malformed URLs
-- [ ] 2.2 Implement `validateExtensionRedirect` to pass the tests (pure function, no Fiber context)
+- [x] 2.1 Write failing unit tests for `validateExtensionRedirect(redirectURI, allowlist)`: accepts `https://<allowlisted-id>.chromiumapp.org/…`; rejects wrong scheme, wrong host, unknown extension id, and malformed URLs
+- [x] 2.2 Implement `validateExtensionRedirect` to pass the tests (pure function, no Fiber context)
 
 ## 3. Connect handler
 
-- [ ] 3.1 Implement `GET /api/v1/auth/extension/connect` behind `RequireAuth`: validate `redirect_uri` (400 on invalid, no key minted), then render a minimal consent page (Allow / Cancel) carrying `redirect_uri` and `state`
-- [ ] 3.2 Implement `POST /api/v1/auth/extension/connect` behind `RequireAuth`: on Allow, mint a named API key via the existing `CreateAPIKey` facility and `302` to `redirect_uri#token=<plaintext>&state=<state>`; on Cancel, `302` to `redirect_uri#error=access_denied&state=<state>` and mint nothing
-- [ ] 3.3 Wire both routes into the auth route group in `internal/handler/handler.go` with `RequireAuth`
+- [x] 3.1 Implement `GET /api/v1/auth/extension/connect` behind `RequireAuth`: validate `redirect_uri` (400 on invalid, no key minted), then render a minimal consent page (Allow / Cancel) carrying `redirect_uri` and `state`
+- [x] 3.2 Implement `POST /api/v1/auth/extension/connect` behind `RequireAuth`: on Allow, mint a named API key via the existing `CreateAPIKey` facility and `302` to `redirect_uri#token=<plaintext>&state=<state>`; on Cancel, `302` to `redirect_uri#error=access_denied&state=<state>` and mint nothing
+- [x] 3.3 Wire both routes into the auth route group in `internal/handler/handler.go` with `RequireAuth`
 
 ## 4. Integration tests (end-to-end flow)
 
-- [ ] 4.1 Session-only: anonymous request → `401`; `Authorization: Bearer <key>` with no cookie → `401`; neither mints a key
-- [ ] 4.2 Redirect validation: a non-allowlisted / malformed `redirect_uri` → `400`, no key minted
-- [ ] 4.3 Approve: signed-in `POST` with allowlisted `redirect_uri` and `state=abc` → `302` whose `Location` fragment carries the plaintext token and `state=abc`; a named key is created for that user
-- [ ] 4.4 Decline: signed-in Cancel → `302` with an error in the fragment and no token; no key minted
-- [ ] 4.5 Token is a real key: the minted token authenticates a per-user endpoint via `Authorization: Bearer`; it appears in `/me/api-keys`; revoking it stops it authenticating
+- [x] 4.1 Session-only: anonymous request → `401`; `Authorization: Bearer <key>` with no cookie → `401`; neither mints a key
+- [x] 4.2 Redirect validation: a non-allowlisted / malformed `redirect_uri` → `400`, no key minted
+- [x] 4.3 Approve: signed-in `POST` with allowlisted `redirect_uri` and `state=abc` → `302` whose `Location` fragment carries the plaintext token and `state=abc`; a named key is created for that user
+- [x] 4.4 Decline: signed-in Cancel → `302` with an error in the fragment and no token; no key minted
+- [x] 4.5 Token is a real key: the minted token authenticates a per-user endpoint via `Authorization: Bearer`; it appears in `/me/api-keys`; revoking it stops it authenticating
 
 ## 5. Docs
 
-- [ ] 5.1 Document the connect flow and `EXTENSION_REDIRECT_ALLOWLIST` in `internal/auth/AGENTS.md` (and the config env list in the root `CLAUDE.md`/`AGENTS.md` if that is where env vars are catalogued)
+- [x] 5.1 Document the connect flow and `EXTENSION_REDIRECT_ALLOWLIST` in `internal/auth/AGENTS.md` (and the config env list in the root `CLAUDE.md`/`AGENTS.md` if that is where env vars are catalogued)


### PR DESCRIPTION
## Why

The freehire browser extension must act as the signed-in hire user, but a
`chrome-extension://` side panel is a foreign origin that cannot read hire's
`HttpOnly` session cookie. It needs a durable credential of its own without ever
handling the cookie, and without the user re-typing a password when they already
have a live hire session.

## What

A cookie-authenticated connect flow the extension drives via
`chrome.identity.launchWebAuthFlow`. On explicit consent the server mints a
**named, revocable API key** (reusing the existing `api_keys` infra) and
`302`-redirects the token in the URL **fragment** to a validated
`https://<extension-id>.chromiumapp.org` target. The extension then calls per-user
endpoints with `Authorization: Bearer` — already accepted by `RequireAuthOrKey`.
The `HttpOnly` cookie is never exposed to extension code.

- `GET/POST /api/v1/auth/extension/connect` — both `RequireAuth` (cookie-only,
  like key management: a leaked key must not mint keys). GET renders consent; POST
  mints + redirects (token in fragment) or `#error=access_denied` on decline.
- `validateExtensionRedirect` — https + `<id>.chromiumapp.org` + `<id>` on the
  `EXTENSION_REDIRECT_ALLOWLIST` config allowlist. Rejects suffix-spoofing,
  multi-label, port, and userinfo tricks.
- No schema change (`api_keys.name` already exists); no change to
  `RequireAuthOrKey`, `/auth/me`, or the cookie transport.

## New capability

`extension-auth` (OpenSpec change `add-extension-connect-auth`) — proposal,
design, spec, and tasks included.

## Testing

- Unit: `validateExtensionRedirect` (11 cases incl. bypass attempts),
  `redirectWithFragment`, config allowlist parsing.
- Integration (`-tags=integration`): session-only rejection, allowlist rejection,
  approve → token+state in fragment + named key minted, decline → error + no mint,
  minted token authenticates via Bearer, is listed, and dies on revoke.
- `go build`, `gofmt`, `go vet` clean; independent security review found no
  high-confidence issues.

## Config

`EXTENSION_REDIRECT_ALLOWLIST` — comma-separated extension ids; empty disables the
flow.

## Out of scope

The extension client itself (separate repo) and the job match-card endpoints
(`/me/match-text`, `/jobs/find`) built during prototyping — those are held back
for a follow-up PR once they have tests and are promoted from raw pgx to sqlc.