### PR TITLE
fix(ds): a11y and correctness follow-ups on the phase-4 primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,11 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # The primitives live in the package, so web's svelte-check never sees
+      # them — it skips node_modules, which is where web resolves them from.
+      - name: Check
+        run: pnpm check
+
       - name: Test
         run: pnpm test
 

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "pnpm tokens:build",
+    "check": "svelte-check --tsconfig ./tsconfig.json",
     "test": "echo \"test: no tests yet\"",
     "tokens:build": "node scripts/build-tokens.mjs",
     "validate:docs": "echo \"validate:docs: nothing to validate yet (phase 06 adds DSDS)\"",
@@ -24,12 +25,18 @@
     "build-storybook": "echo \"build-storybook: not configured yet (phase 05)\""
   },
   "devDependencies": {
-    "style-dictionary": "^5.5.0"
+    "style-dictionary": "^5.5.0",
+    "svelte": "^5.56.7",
+    "svelte-check": "^4.7.2",
+    "typescript": "^6.0.3"
+  },
+  "peerDependencies": {
+    "svelte": "^5",
+    "tailwindcss": "^4"
   },
   "dependencies": {
     "@lucide/svelte": "^1.25.0",
     "clsx": "^2.1.1",
-    "svelte": "^5.56.7",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2"
   }

--- a/design-system/pnpm-lock.yaml
+++ b/design-system/pnpm-lock.yaml
@@ -14,19 +14,28 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      svelte:
-        specifier: ^5.56.7
-        version: 5.56.7
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
+      tailwindcss:
+        specifier: ^4
+        version: 4.3.3
     devDependencies:
       style-dictionary:
         specifier: ^5.5.0
         version: 5.5.0(tslib@2.8.1)
+      svelte:
+        specifier: ^5.56.7
+        version: 5.56.7
+      svelte-check:
+        specifier: ^4.7.2
+        version: 4.7.3(svelte@5.56.7)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -185,6 +194,10 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
+  '@sveltejs/load-config@0.2.0':
+    resolution: {integrity: sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==}
+    engines: {node: '>= 18.0.0'}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -248,6 +261,10 @@ packages:
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -308,6 +325,15 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -433,6 +459,10 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -459,6 +489,9 @@ packages:
   path@0.12.7:
     resolution: {integrity: sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -478,6 +511,14 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -517,6 +558,14 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  svelte-check@4.7.3:
+    resolution: {integrity: sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=5.0.0'
+
   svelte@5.56.7:
     resolution: {integrity: sha512-5qERUZX80oQj6XrDMUmD2Uhd/cIpCPDWWKBK3ZHmyRUC9apPyamWM8xMo31mbWsIQxwG2hVoSnOJ/EcnhVkkzQ==}
     engines: {node: '>=18'}
@@ -554,6 +603,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
@@ -755,6 +809,8 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
+  '@sveltejs/load-config@0.2.0': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/trusted-types@2.0.7': {}
@@ -813,6 +869,10 @@ snapshots:
 
   change-case@5.4.4: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   clsx@2.1.1: {}
 
   colorjs.io@0.5.2: {}
@@ -858,6 +918,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   events@3.3.0: {}
+
+  fdir@6.5.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -991,6 +1053,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mri@1.2.0: {}
+
   object-inspect@1.13.4: {}
 
   object-is@1.1.6:
@@ -1021,6 +1085,8 @@ snapshots:
       process: 0.11.10
       util: 0.10.4
 
+  picocolors@1.1.1: {}
+
   possible-typed-array-names@1.1.0: {}
 
   prettier@3.9.6: {}
@@ -1033,6 +1099,12 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
+
+  readdirp@4.1.2: {}
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-buffer@5.2.1: {}
 
@@ -1105,6 +1177,19 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
+  svelte-check@4.7.3(svelte@5.56.7)(typescript@6.0.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@sveltejs/load-config': 0.2.0
+      chokidar: 4.0.3
+      fdir: 6.5.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.56.7
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - picomatch
+
   svelte@5.56.7:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1147,6 +1232,8 @@ snapshots:
       tslib: 2.8.1
 
   tslib@2.8.1: {}
+
+  typescript@6.0.3: {}
 
   url@0.11.4:
     dependencies:

--- a/design-system/src/alert.svelte
+++ b/design-system/src/alert.svelte
@@ -25,8 +25,14 @@
     class: className,
     children,
   }: { variant?: AlertVariant; class?: string; children: Snippet } = $props();
+
+  // role="alert" is an assertive live region: it interrupts whatever the screen
+  // reader is saying. Right for a failure the user needs now, wrong for the
+  // informational variants, which are usually static page furniture and would
+  // barge in on every render.
+  let role = $derived(variant === 'destructive' ? 'alert' : undefined);
 </script>
 
-<div role="alert" class={cn(alertVariants({ variant }), className)}>
+<div {role} class={cn(alertVariants({ variant }), className)}>
   {@render children()}
 </div>

--- a/design-system/src/avatar.svelte
+++ b/design-system/src/avatar.svelte
@@ -20,8 +20,8 @@
   };
 
   // Deterministic hue from the name, across the full circle — what keeps the
-  // result calm is the fixed low saturation and high lightness below, not the
-  // hue itself. Kept as an inline colour because a token per hue makes no sense.
+  // result calm is the fixed low saturation below, not the hue itself. Kept as
+  // an inline colour because a token per hue makes no sense.
   function hashHue(s: string): number {
     let h = 0;
     for (let i = 0; i < s.length; i++) {
@@ -40,20 +40,27 @@
       : '?',
   );
 
-  let bg = $derived(
-    name
-      ? `hsl(${hashHue(name)} 45% 90%)`
-      : 'hsl(0 0% 90%)',
-  );
+  // Fill and ink both come from the hue and are both fixed, so the pair carries
+  // its own contrast (>= 6:1 on every hue) in either theme. Borrowing
+  // --foreground for the ink would invert under the dark theme and leave
+  // near-white initials on this near-white fill.
+  let hue = $derived(name ? hashHue(name) : 0);
+  let bg = $derived(name ? `hsl(${hue} 45% 90%)` : 'hsl(0 0% 90%)');
+  let fg = $derived(name ? `hsl(${hue} 45% 25%)` : 'hsl(0 0% 25%)');
 </script>
 
 {#if src}
-  <img {src} alt={name ?? 'avatar'} class={cn('rounded-full object-cover', sizes[size], className)} />
+  <img {src} alt={name ?? ''} class={cn('rounded-full object-cover', sizes[size], className)} />
 {:else}
+  <!-- role=img so the label is honoured — a bare <div> is role=generic, which
+       prohibits naming, and the initials would be spelled out instead of the
+       name. Without a name it conveys nothing, so keep it out of the tree. -->
   <div
-    class={cn('flex items-center justify-center rounded-full font-medium text-foreground', sizes[size], className)}
-    style="background-color: {bg}"
-    aria-label={name ?? 'avatar'}
+    class={cn('flex items-center justify-center rounded-full font-medium', sizes[size], className)}
+    style="background-color: {bg}; color: {fg}"
+    role={name ? 'img' : undefined}
+    aria-label={name}
+    aria-hidden={name ? undefined : true}
   >
     {initials}
   </div>

--- a/design-system/src/avatar.svelte
+++ b/design-system/src/avatar.svelte
@@ -40,13 +40,14 @@
       : '?',
   );
 
-  // Fill and ink both come from the hue and are both fixed, so the pair carries
-  // its own contrast (>= 6:1 on every hue) in either theme. Borrowing
-  // --foreground for the ink would invert under the dark theme and leave
-  // near-white initials on this near-white fill.
+  // One hue at two lightnesses: both halves fixed, so the pair carries its own
+  // contrast (>= 6:1 on every hue) in either theme. Borrowing --foreground for
+  // the ink would invert under the dark theme and leave near-white initials on
+  // this near-white fill. Nameless falls to grey through the saturation.
   let hue = $derived(name ? hashHue(name) : 0);
-  let bg = $derived(name ? `hsl(${hue} 45% 90%)` : 'hsl(0 0% 90%)');
-  let fg = $derived(name ? `hsl(${hue} 45% 25%)` : 'hsl(0 0% 25%)');
+  let saturation = $derived(name ? 45 : 0);
+  let bg = $derived(`hsl(${hue} ${saturation}% 90%)`);
+  let fg = $derived(`hsl(${hue} ${saturation}% 25%)`);
 </script>
 
 {#if src}

--- a/design-system/src/form-field.svelte
+++ b/design-system/src/form-field.svelte
@@ -16,9 +16,8 @@
     required?: boolean;
     class?: string;
     /**
-     * Receives everything the control has to carry itself — the field only owns
-     * the label and the message, so `required` and the error state are the
-     * control's to announce:
+     * The field owns the label and the message; everything the control has to
+     * announce itself is handed to it:
      * `{@render children({ id, describedBy, required, invalid })}`.
      */
     children: Snippet<

--- a/design-system/src/form-field.svelte
+++ b/design-system/src/form-field.svelte
@@ -15,8 +15,15 @@
     hint?: string;
     required?: boolean;
     class?: string;
-    /** Receives the ids to spread onto the control: `{@render children({ id, describedBy })}`. */
-    children: Snippet<[{ id: string; describedBy: string | undefined }]>;
+    /**
+     * Receives everything the control has to carry itself — the field only owns
+     * the label and the message, so `required` and the error state are the
+     * control's to announce:
+     * `{@render children({ id, describedBy, required, invalid })}`.
+     */
+    children: Snippet<
+      [{ id: string; describedBy: string | undefined; required: boolean; invalid: boolean }]
+    >;
   } = $props();
 
   // $props.id() is stable across SSR and hydration — crypto.randomUUID() is not.
@@ -24,6 +31,7 @@
   const id = `${uid}-control`;
   const messageId = `${uid}-message`;
   let describedBy = $derived(error || hint ? messageId : undefined);
+  let invalid = $derived(Boolean(error));
 </script>
 
 <div class={cn('flex flex-col gap-1.5', className)}>
@@ -31,11 +39,13 @@
     <label for={id} class="text-sm font-medium">
       {label}
       {#if required}
-        <span class="text-destructive">*</span>
+        <!-- Decorative: the control carries `required`, so reading "asterisk" here
+             would only duplicate it. -->
+        <span class="text-destructive" aria-hidden="true">*</span>
       {/if}
     </label>
   {/if}
-  {@render children({ id, describedBy })}
+  {@render children({ id, describedBy, required, invalid })}
   {#if error}
     <p id={messageId} class="text-sm text-destructive" role="alert">{error}</p>
   {:else if hint}

--- a/design-system/src/index.ts
+++ b/design-system/src/index.ts
@@ -2,6 +2,7 @@
 export { cn } from './cn.js';
 
 // Primitives
+export { default as Alert } from './alert.svelte';
 export { default as Avatar } from './avatar.svelte';
 export { default as Badge } from './badge.svelte';
 export { default as Button } from './button.svelte';
@@ -9,21 +10,18 @@ export { default as Card } from './card.svelte';
 export { default as Chip } from './chip.svelte';
 export { default as Dialog } from './dialog.svelte';
 export { default as EmptyState } from './empty-state.svelte';
-export { default as Input } from './input.svelte';
-export { default as Skeleton } from './skeleton.svelte';
-
-// Variant helpers (re-exported for call sites that need the type or class fn)
-export { buttonVariants, type ButtonVariant, type ButtonSize } from './button.svelte';
-export { badgeVariants, type BadgeVariant } from './badge.svelte';
-export { chipVariants, type ChipVariant } from './chip.svelte';
-export { alertVariants, type AlertVariant } from './alert.svelte';
-export { tabsListVariants, tabsTriggerVariants } from './tabs.svelte';
-export { tableVariants } from './table.svelte';
-
-// Composite primitives (sub-components)
-export { default as Alert } from './alert.svelte';
 export { default as FormField } from './form-field.svelte';
+export { default as Input } from './input.svelte';
 export { default as Pagination } from './pagination.svelte';
+export { default as Skeleton } from './skeleton.svelte';
 export { default as Table } from './table.svelte';
 export { default as Tabs } from './tabs.svelte';
 export { default as Tooltip } from './tooltip.svelte';
+
+// Variant helpers (re-exported for call sites that need the type or class fn)
+export { alertVariants, type AlertVariant } from './alert.svelte';
+export { badgeVariants, type BadgeVariant } from './badge.svelte';
+export { buttonVariants, type ButtonVariant, type ButtonSize } from './button.svelte';
+export { chipVariants, type ChipVariant } from './chip.svelte';
+export { tableVariants } from './table.svelte';
+export { tabsListVariants, tabsTriggerVariants } from './tabs.svelte';

--- a/design-system/src/pagination.svelte
+++ b/design-system/src/pagination.svelte
@@ -20,6 +20,14 @@
   let canPrev = $derived(page > 1);
   let canNext = $derived(page < totalPages);
 
+  // `total` shrinks whenever a filter narrows the result set, which can strand
+  // `page` past the end — "Page 7 of 3", with Next disabled and nothing to show.
+  // Clamping here keeps the bound value honest for the consumer's query too.
+  $effect(() => {
+    const clamped = Math.min(Math.max(page, 1), totalPages);
+    if (clamped !== page) page = clamped;
+  });
+
   function prev() {
     if (canPrev) page--;
   }

--- a/design-system/src/table.svelte
+++ b/design-system/src/table.svelte
@@ -1,6 +1,12 @@
 <script lang="ts" module>
-  import { tv, type VariantProps } from 'tailwind-variants';
+  import { tv } from 'tailwind-variants';
 
+  /**
+   * The component renders `table`/`thead`/`tbody`; rows and cells stay with the
+   * caller, since only the caller knows the columns. Hence `tr`/`th`/`td` are
+   * exported as classes to apply by hand:
+   * `<td class={tableVariants().td()}>`.
+   */
   export const tableVariants = tv({
     base: 'w-full caption-bottom text-sm',
     slots: {
@@ -11,8 +17,6 @@
       td: 'p-3 align-middle',
     },
   });
-
-  export type TableSlots = VariantProps<typeof tableVariants>;
 </script>
 
 <script lang="ts">
@@ -25,7 +29,7 @@
     children,
   }: { class?: string; header?: Snippet; children: Snippet } = $props();
 
-  let slots = tableVariants();
+  const slots = tableVariants();
 </script>
 
 <div class={cn('w-full overflow-x-auto', className)}>

--- a/design-system/src/tabs.svelte
+++ b/design-system/src/tabs.svelte
@@ -41,31 +41,34 @@
 
   let triggers: HTMLButtonElement[] = $state([]);
 
+  // A tablist always has exactly one selected tab, so an unset `value` reads as
+  // the first one. Keying the roving tabindex off `value` directly would leave
+  // every trigger at tabindex="-1" until the consumer picked a tab: the tablist
+  // unreachable by keyboard, and the arrow keys with no index to move from.
+  let selected = $derived(value ?? tabs[0]?.value);
+
   function activate(v: string) {
     value = v;
   }
 
   function onKeydown(e: KeyboardEvent) {
-    const idx = tabs.findIndex((t) => t.value === value);
+    if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+    const idx = tabs.findIndex((t) => t.value === selected);
     if (idx === -1) return;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-      e.preventDefault();
-      const dir = e.key === 'ArrowRight' ? 1 : -1;
-      const next = (idx + dir + tabs.length) % tabs.length;
-      activate(tabs[next].value);
-      // Roving tabindex: the old trigger just became tabindex="-1", so focus
-      // has to follow the selection or it lands nowhere.
-      triggers[next]?.focus();
-    }
+    const dir = e.key === 'ArrowRight' ? 1 : -1;
+    const nextIdx = (idx + dir + tabs.length) % tabs.length;
+    const next = tabs[nextIdx];
+    if (!next) return;
+    e.preventDefault();
+    activate(next.value);
+    // Roving tabindex: the old trigger just became tabindex="-1", so focus
+    // has to follow the selection or it lands nowhere.
+    triggers[nextIdx]?.focus();
   }
 </script>
 
 <div class={cn('flex flex-col gap-2', className)}>
-  <div
-    class={tabsListVariants()}
-    role="tablist"
-    onkeydown={onKeydown}
-  >
+  <div class={tabsListVariants()} role="tablist">
     {#each tabs as tab, i (tab.value)}
       <button
         bind:this={triggers[i]}
@@ -73,16 +76,17 @@
         role="tab"
         id={tabId(tab.value)}
         aria-controls={panelId}
-        aria-selected={value === tab.value}
-        tabindex={value === tab.value ? 0 : -1}
-        class={tabsTriggerVariants({ active: value === tab.value })}
+        aria-selected={selected === tab.value}
+        tabindex={selected === tab.value ? 0 : -1}
+        class={tabsTriggerVariants({ active: selected === tab.value })}
         onclick={() => activate(tab.value)}
+        onkeydown={onKeydown}
       >
         {tab.label}
       </button>
     {/each}
   </div>
-  <div role="tabpanel" id={panelId} aria-labelledby={value ? tabId(value) : undefined}>
+  <div role="tabpanel" id={panelId} aria-labelledby={selected ? tabId(selected) : undefined}>
     {@render children()}
   </div>
 </div>

--- a/design-system/src/tabs.svelte
+++ b/design-system/src/tabs.svelte
@@ -53,9 +53,9 @@
 
   function onKeydown(e: KeyboardEvent) {
     if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+    const dir = e.key === 'ArrowRight' ? 1 : -1;
     const idx = tabs.findIndex((t) => t.value === selected);
     if (idx === -1) return;
-    const dir = e.key === 'ArrowRight' ? 1 : -1;
     const nextIdx = (idx + dir + tabs.length) % tabs.length;
     const next = tabs[nextIdx];
     if (!next) return;

--- a/design-system/src/tooltip.svelte
+++ b/design-system/src/tooltip.svelte
@@ -22,11 +22,10 @@
 
   const FOCUSABLE = 'a[href],button,input,select,textarea,[tabindex]:not([tabindex="-1"])';
 
-  // role="tooltip" associates nothing on its own — the description link has to
-  // be an aria-describedby on the trigger, and the trigger is the consumer's
-  // snippet, so it can only be wired imperatively. Scoped to while the tooltip
-  // is mounted: an aria-describedby pointing at a missing id reads as no
-  // description at all, and axe flags it.
+  // role="tooltip" associates nothing on its own — the link is an
+  // aria-describedby on the trigger, and the trigger is the consumer's snippet,
+  // so it can only be wired imperatively. Only while the tooltip is mounted: an
+  // aria-describedby pointing at a missing id reads as no description at all.
   $effect(() => {
     if (!visible || !triggerEl) return;
     const target = triggerEl.querySelector<HTMLElement>(FOCUSABLE) ?? triggerEl;
@@ -51,12 +50,10 @@
 
 <svelte:window onkeydown={visible ? dismiss : undefined} />
 
-<!-- The wrapper is a positioning box, not a control: it carries the pointer
-     handlers only because the trigger itself is the consumer's snippet, and it
-     has to enclose the tooltip so moving the pointer onto the tooltip keeps it
-     open (WCAG 2.1 SC 1.4.13, hoverable). Keyboard users get the same reveal
-     from focusin/focusout, so there is no keyboard-equivalence gap to fix — the
-     rule's heuristic simply does not apply here. -->
+<!-- The pointer handlers sit on the wrapper, not the trigger: the trigger is the
+     consumer's snippet, and the wrapper has to enclose the tooltip so moving the
+     pointer onto it keeps it open (WCAG 2.1 SC 1.4.13, hoverable). focusin and
+     focusout give keyboard users the same reveal, so nothing is gated on hover. -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <span
   class="relative inline-flex"

--- a/design-system/src/tooltip.svelte
+++ b/design-system/src/tooltip.svelte
@@ -17,6 +17,30 @@
   let visible = $state(false);
   let triggerEl: HTMLElement | undefined = $state();
 
+  const uid = $props.id();
+  const tooltipId = `${uid}-tooltip`;
+
+  const FOCUSABLE = 'a[href],button,input,select,textarea,[tabindex]:not([tabindex="-1"])';
+
+  // role="tooltip" associates nothing on its own — the description link has to
+  // be an aria-describedby on the trigger, and the trigger is the consumer's
+  // snippet, so it can only be wired imperatively. Scoped to while the tooltip
+  // is mounted: an aria-describedby pointing at a missing id reads as no
+  // description at all, and axe flags it.
+  $effect(() => {
+    if (!visible || !triggerEl) return;
+    const target = triggerEl.querySelector<HTMLElement>(FOCUSABLE) ?? triggerEl;
+    target.setAttribute('aria-describedby', tooltipId);
+    return () => target.removeAttribute('aria-describedby');
+  });
+
+  // WCAG 2.1 SC 1.4.13: content shown on hover must be dismissible without
+  // moving the pointer. Hovering keeps it dismissed until the pointer leaves
+  // and comes back, which is the intent.
+  function dismiss(e: KeyboardEvent) {
+    if (e.key === 'Escape') visible = false;
+  }
+
   const positions = {
     top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
     right: 'left-full top-1/2 -translate-y-1/2 ml-2',
@@ -25,6 +49,15 @@
   };
 </script>
 
+<svelte:window onkeydown={visible ? dismiss : undefined} />
+
+<!-- The wrapper is a positioning box, not a control: it carries the pointer
+     handlers only because the trigger itself is the consumer's snippet, and it
+     has to enclose the tooltip so moving the pointer onto the tooltip keeps it
+     open (WCAG 2.1 SC 1.4.13, hoverable). Keyboard users get the same reveal
+     from focusin/focusout, so there is no keyboard-equivalence gap to fix — the
+     rule's heuristic simply does not apply here. -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <span
   class="relative inline-flex"
   bind:this={triggerEl}
@@ -35,7 +68,10 @@
 >
   {@render children()}
   {#if visible}
-    <div
+    <!-- A <span>, not a <div>: the wrapper is a <span>, which only accepts
+         phrasing content. Absolute positioning blockifies it either way. -->
+    <span
+      id={tooltipId}
       role="tooltip"
       class={cn(
         'absolute z-popover max-w-xs rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md',
@@ -44,6 +80,6 @@
       )}
     >
       {@render content()}
-    </div>
+    </span>
   {/if}
 </span>

--- a/design-system/tsconfig.json
+++ b/design-system/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  // Mirrors web/tsconfig.json's strictness so a primitive cannot pass here and
+  // fail once web imports it. No SvelteKit base to extend — this package is a
+  // plain Svelte library, so the compiler options are spelled out.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "scripts/**/*.mjs"]
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 7.5.0
       freehire-design-system:
         specifier: file:../design-system
-        version: file:../design-system(@typescript-eslint/types@8.65.0)(tailwindcss@4.3.3)
+        version: file:../design-system(svelte@5.56.7(@typescript-eslint/types@8.65.0))(tailwindcss@4.3.3)
       isomorphic-dompurify:
         specifier: ^3.18.0
         version: 3.19.0
@@ -1734,6 +1734,9 @@ packages:
 
   freehire-design-system@file:../design-system:
     resolution: {directory: ../design-system, type: directory}
+    peerDependencies:
+      svelte: ^5
+      tailwindcss: ^4
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4228,16 +4231,14 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  freehire-design-system@file:../design-system(@typescript-eslint/types@8.65.0)(tailwindcss@4.3.3):
+  freehire-design-system@file:../design-system(svelte@5.56.7(@typescript-eslint/types@8.65.0))(tailwindcss@4.3.3):
     dependencies:
       '@lucide/svelte': 1.25.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))
       clsx: 2.1.1
       svelte: 5.56.7(@typescript-eslint/types@8.65.0)
       tailwind-merge: 3.6.0
       tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
-    transitivePeerDependencies:
-      - '@typescript-eslint/types'
-      - tailwindcss
+      tailwindcss: 4.3.3
 
   fsevents@2.3.3:
     optional: true


### PR DESCRIPTION
Review follow-ups on #1098. None of the 15 primitives has a call site yet, so this fixes the contract before phase 5 starts building on it.

## Blockers

| | |
|---|---|
| **Avatar unreadable in the dark theme** | The fill was a hardcoded `hsl(H 45% 90%)` but the ink came from `text-foreground`, which inverts by theme — dark mode put near-white initials on a near-white circle. Worst case **1.11:1** across the hue circle. Ink is now derived from the same hue and equally fixed (`hsl(H 45% 25%)`): **>= 6.05:1 on every hue**, in either theme. |
| **Tabs unreachable by keyboard** | The roving tabindex was keyed off `value` directly, so with no `value` set every trigger was `tabindex="-1"` and `onKeydown` bailed on `idx === -1`: Tab could not enter the tablist and the arrow keys had nothing to move from. An unset `value` now reads as the first tab, which is what a tablist means. |
| **Tooltip announced nothing** | `role="tooltip"` associates nothing on its own — the link is an `aria-describedby` on the trigger. Since the trigger is the consumer's snippet, it is wired imperatively through the already-bound `triggerEl` (previously dead state), and only while the tooltip is mounted: a dangling `aria-describedby` reads as no description and axe flags it. |

Two more things came with the Tooltip fix: **Escape-to-dismiss** (WCAG 2.1 SC 1.4.13 — content on hover must be dismissible without moving the pointer) and the tooltip is now a `<span>`, since its wrapper is a `<span>` and only accepts phrasing content.

`Avatar` also gets `role="img"`: a bare `<div>` is `role=generic`, which prohibits naming, so the `aria-label` was inert and the initials would have been spelled out instead of the name.

## Also

- **Alert** takes `role="alert"` only for `destructive`. It is an *assertive* live region — the informational variants were interrupting the screen reader on every render.
- **FormField** passes `required` and `invalid` to the control snippet. The asterisk was cosmetic: nothing was marked `required` or `aria-invalid`. The asterisk itself is now `aria-hidden`, since the control carries the fact.
- **Pagination** clamps `page` into range. Any narrowing filter shrinks `total` and stranded it past the end — "Page 7 of 3", Next disabled, nothing to show — and the clamp keeps the bound value honest for the consumer's own query.
- **Table** documents that rows and cells stay with the caller (only `table`/`thead`/`tbody` are rendered, so `tr`/`th`/`td` are classes to apply by hand). Drops `TableSlots`, which was `{}` for a slots-only `tv()` and exported nowhere.
- **index.ts** is one alphabetical primitive list — the "composite primitives (sub-components)" group held `Alert`, `FormField` and `Tooltip`, which are none of those things.

## Nothing was type-checking these files

`web`'s `svelte-check` skips `node_modules`, which is exactly where it resolves the package from, and the `design-system` CI job only built tokens and echoed a test stub. So the primitives shipped unchecked.

This adds `pnpm check` (svelte-check + a `tsconfig.json` mirroring web's strictness) to the package and to the CI job. It paid off on the first run, catching two things I had not spotted by reading:

- `tabs[next].value` unguarded under `noUncheckedIndexedAccess` — a real error, from the original PR
- *"Elements with the 'tablist' interactive role must have a tabindex value"* — which pointed at the better structure: `onkeydown` belongs on the tabs, not the container, as ARIA APG has it

`svelte-check` covers the a11y compiler warnings, which is where most of the value is, so I did not also add `eslint-plugin-svelte` — it would largely overlap.

## svelte -> peerDependencies

`svelte` was a hard `dependency`, which invites a second copy of Svelte into the tree and breaks context and reactivity when it happens. It is now a peer (plus `tailwindcss`, which `tailwind-variants` needs and the package never declared); `web/pnpm-lock.yaml` now resolves it to web's own instance instead of a private one.

## Verified locally

| | |
|---|---|
| `design-system`: `pnpm check` / `build` / `test` | green — 0 errors, 0 warnings |
| `web`: `pnpm check` | 0 errors, 14 pre-existing warnings (all `state_referenced_locally`, none in touched files) |
| `web`: `pnpm build` / `pnpm test` / `pnpm lint` | green — 384 tests passed |
| `pnpm install --frozen-lockfile` in both packages | clean |

## Left deliberately

- **No unit tests.** The package has no runner, and standing up vitest + testing-library is its own change; phase 5 (Storybook) is the natural home. The keyboard nav in `Tabs`, the two effects in `Dialog` and the `Pagination` clamp are the parts that will regress silently, so this is a real gap, not a non-issue.
- **`EmptyState` keeps `role="status"`.** A polite live region on a "no results" placeholder is the conventional pattern; unlike `Alert`'s assertive one, it does not interrupt.
- **`Chip` still overlaps `Badge`** heavily (near-identical variant vocabulary, both pills). Worth deciding whether both should exist, but that is an API question for phase 5, not a fix.
- **`Dialog`'s nested-dialog case**: two open dialogs both capture `body.style.overflow` and the inner one restores `hidden`, leaving the page locked. Needs a shared counter; no call site nests dialogs today.

Refs: #1098, gearsandcode/freehire-design#6
