### PR TITLE
fix(jobs): resolve a posting by its URL, not by guessing company + title

### DIFF
--- a/internal/handler/find_job.go
+++ b/internal/handler/find_job.go
@@ -2,39 +2,44 @@ package handler
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/sources"
 )
 
-// FindJob resolves an external job posting to a freehire catalog slug by exact,
-// case-insensitive company + title. It lets the browser extension recognise that
-// the page it's on is a job already in the catalog and switch from the text
-// match to the rich curated card. Public; returns {"data": null} on no match.
+// FindJob resolves the URL of a job posting in the wild to a freehire catalog
+// slug, so the browser extension can tell that the page it is on is a job we
+// already carry and switch from the ad-hoc text match to the curated card.
+// Public; returns {"data": null} whenever the posting cannot be identified.
 //
-// NOTE: raw pgx query for prototype speed — promote to a sqlc query before merge.
+// The lookup is by the catalog's own dedup identity — (source, external_id),
+// recovered from the URL — which is exact and served by a unique index. It
+// replaced a company+title match that compared the page title against every
+// catalog title: that could not use an index at all (the LIKE pattern was built
+// from the column), so it degenerated into a sequential scan of millions of rows
+// and timed out in production. It was also guesswork, and a page title is not
+// something to guess from — the extension was sending "reCAPTCHA".
 func (a *API) FindJob(c *fiber.Ctx) error {
-	company := strings.TrimSpace(c.Query("company"))
-	title := strings.TrimSpace(c.Query("title"))
-	if company == "" || title == "" {
+	ref, ok := sources.RefFromURL(c.Query("url"))
+	if !ok {
 		return c.JSON(fiber.Map{"data": nil})
 	}
-	// The catalog title must appear within the page title (real page titles carry
-	// noise like "Remote … Job at Stripe"), scoped to an exact company match.
-	// Prefer the longest (most specific) catalog title.
-	var slug string
-	err := a.pool.QueryRow(c.Context(),
-		`SELECT public_slug FROM jobs
-		 WHERE company ILIKE $1 AND $2 ILIKE '%' || title || '%'
-		   AND public_slug IS NOT NULL AND length(title) >= 6
-		 ORDER BY length(title) DESC, posted_at DESC NULLS LAST
-		 LIMIT 1`, company, title).Scan(&slug)
+
+	job, err := a.queries.GetJobBySourceExternalID(c.Context(), db.GetJobBySourceExternalIDParams{
+		Source:     ref.Source,
+		ExternalID: ref.ExternalID,
+	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return c.JSON(fiber.Map{"data": nil})
 		}
 		return err
 	}
-	return c.JSON(fiber.Map{"data": fiber.Map{"public_slug": slug}})
+	if job.PublicSlug == "" {
+		return c.JSON(fiber.Map{"data": nil})
+	}
+	return c.JSON(fiber.Map{"data": fiber.Map{"public_slug": job.PublicSlug}})
 }

--- a/internal/sources/postingurl.go
+++ b/internal/sources/postingurl.go
@@ -1,0 +1,80 @@
+package sources
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// PostingRef is a catalog identity — the (source, external_id) key jobs are
+// deduplicated by — recovered from the URL of a job posting in the wild.
+//
+// It exists so a client that is *looking at* a posting can ask which catalog job
+// it is, exactly, instead of describing it and hoping: matching a page title
+// against catalog titles is both unreliable (an ATS page title is full of noise)
+// and expensive (no index can serve it).
+type PostingRef struct {
+	Source     string
+	ExternalID string
+}
+
+// greenhouseJobPath matches the job-detail form, /<board>/jobs/<id>.
+var greenhouseJobPath = regexp.MustCompile(`^/([^/]+)/jobs/(\d+)/?$`)
+
+// RefFromURL recovers the catalog identity from a posting URL, reporting false
+// when the URL is not one we can resolve — an unknown ATS, or a link that
+// carries the job id but not the board it belongs to (a company's own careers
+// page, say). A false answer is the honest one: the caller should then leave the
+// posting unrecognised rather than guess.
+//
+// Only Greenhouse is understood today. Each ATS numbers and addresses its
+// postings differently, and the board segment of the URL has to be the same
+// token the ingest board file uses, so support is added per provider against
+// real links rather than inferred from a pattern.
+func RefFromURL(raw string) (PostingRef, bool) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return PostingRef{}, false
+	}
+
+	switch strings.ToLower(u.Hostname()) {
+	case "job-boards.greenhouse.io", "boards.greenhouse.io":
+		return greenhouseRef(u)
+	default:
+		return PostingRef{}, false
+	}
+}
+
+// greenhouseRef reads a Greenhouse link in either of its two shapes: the
+// embedded application form (/embed/job_app?for=<board>&token=<id>) and the job
+// detail page (/<board>/jobs/<id>). The form's `jr_id` is Greenhouse's internal
+// requisition id, which the catalog does not store — the job id is `token`.
+func greenhouseRef(u *url.URL) (PostingRef, bool) {
+	if strings.HasPrefix(u.Path, "/embed/job_app") {
+		board := u.Query().Get("for")
+		id := u.Query().Get("token")
+		return greenhousePosting(board, id)
+	}
+	if m := greenhouseJobPath.FindStringSubmatch(u.Path); m != nil {
+		return greenhousePosting(m[1], m[2])
+	}
+	return PostingRef{}, false
+}
+
+func greenhousePosting(board, jobID string) (PostingRef, bool) {
+	board = strings.ToLower(strings.TrimSpace(board))
+	jobID = strings.TrimSpace(jobID)
+	if board == "" || jobID == "" || !isDigits(jobID) {
+		return PostingRef{}, false
+	}
+	return PostingRef{Source: "greenhouse", ExternalID: NamespaceExternalID(board, jobID)}, true
+}
+
+func isDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return s != ""
+}

--- a/internal/sources/postingurl_test.go
+++ b/internal/sources/postingurl_test.go
@@ -1,0 +1,92 @@
+package sources_test
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+func TestRefFromURL_Greenhouse(t *testing.T) {
+	tests := []struct {
+		name, url, wantExternalID string
+	}{
+		{
+			// What an application form on job-boards.greenhouse.io looks like. The
+			// job id rides `token`; `jr_id` is Greenhouse's internal requisition id,
+			// which the catalog does not carry.
+			name:           "embedded application form",
+			url:            "https://job-boards.greenhouse.io/embed/job_app?for=stripe&jr_id=6a2444ad757ade085b6affd5&token=7826765",
+			wantExternalID: "stripe:7826765",
+		},
+		{
+			name:           "embedded form on the legacy boards host",
+			url:            "https://boards.greenhouse.io/embed/job_app?for=stripe&token=7826765",
+			wantExternalID: "stripe:7826765",
+		},
+		{
+			name:           "job detail page",
+			url:            "https://job-boards.greenhouse.io/stripe/jobs/7826765",
+			wantExternalID: "stripe:7826765",
+		},
+		{
+			name:           "job detail page on the legacy host, with tracking query",
+			url:            "https://boards.greenhouse.io/stripe/jobs/7826765?gh_src=abc123",
+			wantExternalID: "stripe:7826765",
+		},
+		{
+			name:           "trailing slash",
+			url:            "https://job-boards.greenhouse.io/stripe/jobs/7826765/",
+			wantExternalID: "stripe:7826765",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, ok := sources.RefFromURL(tt.url)
+			if !ok {
+				t.Fatalf("RefFromURL(%q) did not resolve", tt.url)
+			}
+			if ref.Source != "greenhouse" {
+				t.Errorf("source = %q, want greenhouse", ref.Source)
+			}
+			if ref.ExternalID != tt.wantExternalID {
+				t.Errorf("external id = %q, want %q", ref.ExternalID, tt.wantExternalID)
+			}
+		})
+	}
+}
+
+func TestRefFromURL_Unresolvable(t *testing.T) {
+	tests := []struct{ name, url string }{
+		{"empty", ""},
+		{"not a url", "reCAPTCHA"},
+		{"a board we do not recognise", "https://jobs.lever.co/acme/1234"},
+		{"greenhouse board listing, no job", "https://job-boards.greenhouse.io/stripe"},
+		{"embedded form without the job id", "https://job-boards.greenhouse.io/embed/job_app?for=stripe"},
+		{"embedded form without the board", "https://job-boards.greenhouse.io/embed/job_app?token=7826765"},
+		{"a non-numeric job id", "https://job-boards.greenhouse.io/stripe/jobs/not-an-id"},
+		// The company's own careers page carries the job id but not the board
+		// token, and the board is not derivable from the host — so this stays
+		// unresolved rather than guessing a board from the domain.
+		{"company careers page with gh_jid", "https://stripe.com/jobs/search?gh_jid=7954688"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if ref, ok := sources.RefFromURL(tt.url); ok {
+				t.Fatalf("RefFromURL(%q) resolved to %+v, want no match", tt.url, ref)
+			}
+		})
+	}
+}
+
+func TestRefFromURL_IsCaseInsensitiveAboutTheBoard(t *testing.T) {
+	ref, ok := sources.RefFromURL("https://job-boards.greenhouse.io/embed/job_app?for=Stripe&token=7826765")
+	if !ok {
+		t.Fatal("did not resolve")
+	}
+	// Board tokens are lowercase in the catalog; a link that shouts still matches.
+	if ref.ExternalID != "stripe:7826765" {
+		t.Fatalf("external id = %q, want the lowercased board", ref.ExternalID)
+	}
+}


### PR DESCRIPTION
**Production incident.** `GET /jobs/find` times out. It is called on every side-panel open and tab switch, so it has been holding connections since the last deploy.

## Root cause

```sql
WHERE company ILIKE $1 AND $2 ILIKE '%' || title || '%'
```

The LIKE pattern is built **from the column**, compared against the parameter. That inverts the usual `column LIKE 'pattern'` and makes an index impossible in principle: every row has to have its own pattern assembled and matched. Against 3.7M jobs that is a sequential scan.

Reproduced on production, and *not* only with junk input — a correct title times out the same way:

```
find(stripe, "Backend Engineer, AI Security") → 000 in 8.0s
find(stripe, "reCAPTCHA")                     → 000 in 25.0s
```

The file carried `NOTE: raw pgx query for prototype speed — promote to a sqlc query before merge`. It reached main in the browser-tool wire stack; that is on me.

## The second half of the bug

The extension guessed the company and title from the page headline. On a Greenhouse application form the headline it found was **"reCAPTCHA"** — so the scan ran for a title no job could ever have. Guessing was never going to be right: an ATS page title is noise.

## The fix

Resolve the posting's URL to the catalog's own dedup identity, `(source, external_id)` — exact, and served by the existing `UNIQUE (source, external_id)`.

`sources.RefFromURL` reads a Greenhouse link in either shape:

| URL | → |
|---|---|
| `/embed/job_app?for=stripe&token=7826765` | `greenhouse`, `stripe:7826765` |
| `/stripe/jobs/7826765` | `greenhouse`, `stripe:7826765` |

The job id is `token`; `jr_id` is Greenhouse's internal requisition id, which the catalog does not store. Verified against the live index — `token=7826765` is `backend-engineer-ai-security-stripe-jbhikpck`, "Backend Engineer, AI Security".

**Only Greenhouse for now.** Each ATS numbers postings differently and the board segment has to be the same token the ingest board file uses, so support is added per provider against real links rather than inferred from a pattern. Everything else resolves to null immediately — the same answer the old query eventually gave, minus the scan.

Why not Meilisearch: `url` and `external_id` are in the document but in neither `SearchableAttributes` nor `FilterableAttributes`, so filtering on them needs a 3.7M-document reindex (and risks 500s on `/jobs` until it completes). Postgres already has the exact index this needs. Meili stays for full text.

Pairs with strelov1/freehire-extension#3, which sends the URL and drops the guesser.