### PR TITLE
Let an OAuth-only account set a password; guard SERVED_HOSTS

### DIFF
--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -235,6 +235,10 @@ func (s *Service) Login(ctx context.Context, email, password string) (User, erro
 	if s.hasher.Check(hash, password) != nil {
 		return User{}, ErrInvalidCredentials
 	}
+	// The caller just proved a password exists, but the lookup row does not carry the
+	// flag — set it so login answers the same shape as /auth/me and a client cannot be
+	// told the account is passwordless right after it signed in with a password.
+	user.HasPassword = true
 	return user, nil
 }
 

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -500,11 +500,15 @@ func TestLogin_WrongPassword(t *testing.T) {
 	}
 }
 
-// Login success → returns user.
+// Login success → returns user, flagged as password-backed.
 func TestLogin_Happy(t *testing.T) {
-	wantUser := User{ID: 5, Email: "user@example.com"}
+	stored := User{ID: 5, Email: "user@example.com"}
+	// The lookup row does not carry HasPassword; Login sets it, because authenticating
+	// by password is itself the proof that one exists.
+	wantUser := stored
+	wantUser.HasPassword = true
 	repo := &fakeRepo{
-		userByEmailResults: []userByEmailResult{{user: wantUser, passwordHash: "hashed:correct", hasPassword: true}},
+		userByEmailResults: []userByEmailResult{{user: stored, passwordHash: "hashed:correct", hasPassword: true}},
 	}
 	svc := New(repo, &fakeHasher{})
 
@@ -548,5 +552,22 @@ func TestUserByID_NotFound(t *testing.T) {
 	_, err := svc.UserByID(context.Background(), 99)
 	if !errors.Is(err, ErrUserNotFound) {
 		t.Errorf("want ErrUserNotFound, got %v", err)
+	}
+}
+
+// Login answers with the same wire shape as /auth/me, so a client that renders the
+// password UI from it must not be told the account is passwordless when it is not.
+func TestLoginReportsThatTheAccountHasAPassword(t *testing.T) {
+	repo := &fakeRepo{userByEmailResults: []userByEmailResult{
+		{user: User{ID: 7, Email: "user@example.test"}, passwordHash: "hashed:pw", hasPassword: true},
+	}}
+	s := New(repo, &fakeHasher{})
+
+	user, err := s.Login(context.Background(), "user@example.test", "pw")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !user.HasPassword {
+		t.Error("login returned HasPassword false for an account that just authenticated by password")
 	}
 }

--- a/internal/accounts/recovery.go
+++ b/internal/accounts/recovery.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 )
 
-// RequestPasswordReset mails a reset code for the address, if it has a password-backed
-// account. It reports nil for every well-formed address — unknown, passwordless, or real —
-// so the endpoint cannot be used to discover which addresses have accounts. The caller
-// answers 202 either way.
+// RequestPasswordReset mails a reset code for the address, if it has an account. It
+// reports nil for every well-formed address — known or not — so the endpoint cannot be
+// used to discover which addresses have accounts. The caller answers 202 either way.
+//
+// A passwordless (OAuth-only) account is served too, so its owner can set a password and
+// gain a second way in. Receiving the code proves control of the address, which is the
+// same proof the provider offers, so refusing would strand the user without buying safety.
 //
 // It reports an error only for conditions the caller itself must act on: mail being
 // unconfigured, or the resend cooldown. Neither leaks whether the account exists, because
@@ -21,10 +24,8 @@ func (s *Service) RequestPasswordReset(ctx context.Context, email string) error 
 	if err != nil {
 		return nil // a malformed address has no account either; stay silent
 	}
-	user, _, hasPassword, err := s.repo.UserByEmail(ctx, addr)
-	if errors.Is(err, ErrUserNotFound) || !hasPassword {
-		// No account, or an OAuth-only one. Mailing a code for a passwordless account
-		// would be a way to bolt a password onto an account whose owner never chose one.
+	user, _, _, err := s.repo.UserByEmail(ctx, addr)
+	if errors.Is(err, ErrUserNotFound) {
 		return nil
 	}
 	if err != nil {
@@ -38,8 +39,8 @@ func (s *Service) RequestPasswordReset(ctx context.Context, email string) error 
 	return s.mailer.SendPasswordResetCode(ctx, user.Email, code)
 }
 
-// ResetPassword sets a new password when the presented code matches the outstanding one
-// for the address. A completed reset proves control of the address, so it also marks the
+// ResetPassword sets a password when the presented code matches the outstanding one for
+// the address — replacing an existing one, or giving an OAuth-only account its first. A completed reset proves control of the address, so it also marks the
 // account verified, and it revokes every existing session — a reset is exactly the moment
 // a user suspects someone else is signed in.
 func (s *Service) ResetPassword(ctx context.Context, email, code, newPassword string) error {
@@ -50,8 +51,8 @@ func (s *Service) ResetPassword(ctx context.Context, email, code, newPassword st
 	if err != nil {
 		return ErrInvalidCode // no account, so no code can match
 	}
-	user, _, hasPassword, err := s.repo.UserByEmail(ctx, addr)
-	if errors.Is(err, ErrUserNotFound) || !hasPassword {
+	user, _, _, err := s.repo.UserByEmail(ctx, addr)
+	if errors.Is(err, ErrUserNotFound) {
 		return ErrInvalidCode
 	}
 	if err != nil {

--- a/internal/accounts/recovery_test.go
+++ b/internal/accounts/recovery_test.go
@@ -45,9 +45,10 @@ func TestRequestPasswordResetIsSilentAboutUnknownAddresses(t *testing.T) {
 	}
 }
 
-// An OAuth-only account has no password to reset; mailing a code would be a way to
-// bolt a password onto an account whose owner never chose one.
-func TestRequestPasswordResetSkipsPasswordlessAccounts(t *testing.T) {
+// An OAuth-only account can set a password through this flow. Receiving the mailed code
+// proves control of the address — the same proof the provider offers — so refusing would
+// only strand a user who wants a second way in, without buying any safety.
+func TestRequestPasswordResetServesPasswordlessAccounts(t *testing.T) {
 	repo := &fakeRepo{userByEmailResults: []userByEmailResult{
 		{user: User{ID: 7, Email: "oauth@example.test"}, hasPassword: false},
 	}}
@@ -55,10 +56,31 @@ func TestRequestPasswordResetSkipsPasswordlessAccounts(t *testing.T) {
 	s := recoveryService(repo, newFakeCodes(), mailer)
 
 	if err := s.RequestPasswordReset(context.Background(), "oauth@example.test"); err != nil {
-		t.Errorf("err = %v, want nil (same answer as every other address)", err)
+		t.Fatalf("RequestPasswordReset: %v", err)
 	}
-	if len(mailer.reset) != 0 {
-		t.Error("a reset code was mailed for a passwordless account")
+	if len(mailer.reset) != 1 {
+		t.Fatalf("mailed %d codes, want 1 — a passwordless account may set a password", len(mailer.reset))
+	}
+}
+
+// Setting the first password on an OAuth-only account works the same way as replacing
+// an existing one.
+func TestResetPasswordSetsAFirstPassword(t *testing.T) {
+	repo := &fakeRepo{userByEmailResults: []userByEmailResult{
+		{user: User{ID: 7, Email: "oauth@example.test"}, hasPassword: false},
+		{user: User{ID: 7, Email: "oauth@example.test"}, hasPassword: false},
+	}}
+	codes, mailer := newFakeCodes(), &fakeMailer{}
+	s := recoveryService(repo, codes, mailer)
+
+	if err := s.RequestPasswordReset(context.Background(), "oauth@example.test"); err != nil {
+		t.Fatalf("RequestPasswordReset: %v", err)
+	}
+	if err := s.ResetPassword(context.Background(), "oauth@example.test", mailer.reset[0], "first-password"); err != nil {
+		t.Fatalf("ResetPassword: %v", err)
+	}
+	if repo.resetHash != "hashed:first-password" {
+		t.Errorf("stored hash = %q, want the new password's hash", repo.resetHash)
 	}
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -338,6 +338,13 @@ func Register(app *fiber.App, cfg Config) {
 	// submission approval mints through the same moderation service, so derivation,
 	// dedup, and the enrichment enqueue are reused rather than duplicated.
 	a.submission = submission.New(submission.NewQueriesRepository(queries), a.moderation)
+	if needsExplicitServedHosts(cfg.ServedHosts, cfg.CookieDomains) {
+		log.Printf("oauth: COOKIE_DOMAIN is set (%v) but SERVED_HOSTS is not — "+
+			"the redirect origin falls back to %s for every other host, which breaks "+
+			"sign-in on them (state mismatch). List every served host in SERVED_HOSTS.",
+			cfg.CookieDomains, cfg.FrontendOrigin)
+	}
+
 	// Contributions detect the ATS board from the URL alone (network-free, board.go), with a
 	// network fallback (boardresolve) that fetches a company careers page and detects an
 	// embedded ATS — so vanity-domain links (company.com/careers?gh_jid=…) resolve too.

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -32,6 +32,16 @@ func (a *API) requestOrigin(c *fiber.Ctx) string {
 	return a.frontendOrigin
 }
 
+// needsExplicitServedHosts reports a deployment that answers on several hosts while
+// leaving SERVED_HOSTS unset. A configured COOKIE_DOMAIN is that signal: the session
+// cookie is only ever scoped to a registrable domain when more than one host shares it.
+// The default (the frontend origin's host alone) then silently breaks sign-in on every
+// other domain — the state cookie is set on the host the flow started from, while the
+// callback is sent to the canonical origin, so the state can never match.
+func needsExplicitServedHosts(configured, cookieDomains []string) bool {
+	return len(configured) == 0 && len(cookieDomains) > 0
+}
+
 // servedHostsOrDefault falls back to the frontend origin's own host when SERVED_HOSTS
 // is unset, so a deployment that never sets it keeps working on its canonical domain
 // (and every other Host simply gets the canonical origin).

--- a/internal/handler/served_hosts_test.go
+++ b/internal/handler/served_hosts_test.go
@@ -1,0 +1,27 @@
+package handler
+
+import "testing"
+
+// Leaving SERVED_HOSTS unset narrows the OAuth redirect origin to the frontend origin's
+// own host. That is right for a single-domain deployment and wrong for one that answers
+// on several — where it silently breaks sign-in on every other domain, because the state
+// cookie is set on the host the flow started from and the callback lands elsewhere. A
+// configured COOKIE_DOMAIN is exactly the signal that more than one host is served, so
+// that combination has to be called out at startup rather than discovered in production.
+func TestNeedsExplicitServedHosts(t *testing.T) {
+	cases := []struct {
+		name          string
+		served        []string
+		cookieDomains []string
+		want          bool
+	}{
+		{"multi-domain deployment with no allowlist", nil, []string{"freehire.dev", "freehire.me"}, true},
+		{"single-domain dev deployment", nil, nil, false},
+		{"allowlist configured", []string{"freehire.dev"}, []string{"freehire.dev"}, false},
+	}
+	for _, tc := range cases {
+		if got := needsExplicitServedHosts(tc.served, tc.cookieDomains); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/openspec/changes/harden-account-security/deploy.md
+++ b/openspec/changes/harden-account-security/deploy.md
@@ -36,53 +36,69 @@ SELECT DISTINCT scope FROM api_keys;    -- expect only 'full'
 \dt user_email_codes                    -- Owner must be hire
 ```
 
-## 2. Do NOT set SERVED_HOSTS on this deploy
+## 2. SERVED_HOSTS must list every served host
 
-An earlier draft of this runbook said to set `SERVED_HOSTS=freehire.me,apply.freehire.me`.
-That was written from the code's own docs, not from prod, and it is wrong here.
+**This one bit in production.** An earlier draft said to leave `SERVED_HOSTS` unset,
+reasoning that prod runs a single origin. That was checked against `/opt/freehire/.env`
+alone — but the API also reads `/opt/freehire/env/hire-api.env`, and the cookie domain
+lives there:
 
-Prod has `FRONTEND_ORIGIN=https://freehire.dev` and **no** `COOKIE_DOMAIN`, so today
-`requestOrigin` returns the canonical frontend origin for *every* request. Leaving
-`SERVED_HOSTS` unset reproduces that behaviour exactly (it defaults to the frontend
-origin's own host). Setting it to include `freehire.me` would make an OAuth flow started
-on `freehire.me` use `https://freehire.me` as its `redirect_uri` for the first time — which
-fails unless that URI is registered with Google, GitHub and LinkedIn.
+```
+COOKIE_DOMAIN=.freehire.dev,.freehire.me
+FRONTEND_ORIGIN=https://freehire.dev
+```
 
-Set it only as part of a deliberate multi-domain OAuth change, after registering the
-redirect URIs with each provider.
+So prod answers on **both** domains. The old suffix rule trusted any host under either;
+the exact allowlist, left unset, narrows to `freehire.dev` alone. Sign-in on
+`freehire.me` then sets its state cookie on `freehire.me`, while the provider is told to
+call back to `freehire.dev` — the state can never match, and every OAuth attempt fails
+with `state mismatch`.
+
+Set it to every host the app serves (nginx `server_name`s minus the sibling services):
+
+```
+SERVED_HOSTS=freehire.dev,www.freehire.dev,freehire.me,www.freehire.me
+```
+
+in `/opt/freehire/env/hire-api.env`, then restart the active colour
+(`systemctl restart freehire-api@blue`). Verify per host:
+
+```bash
+for h in freehire.dev freehire.me; do
+  curl -sD - -o /dev/null "https://$h/api/v1/auth/oauth/google/start" | grep -i '^location'
+done   # each redirect_uri must name the host it was requested on
+```
+
+The server now logs this misconfiguration at startup (`COOKIE_DOMAIN is set but
+SERVED_HOSTS is not`), so it surfaces in seconds rather than as a broken sign-in.
+
+Adding a **new** domain still needs its redirect URI registered with Google, GitHub and
+LinkedIn before it is listed here.
 
 `TELEGRAM_WEBHOOK_SECRET` is present on prod (verified: the webhook answers 403 to an
 unauthenticated POST), so the feature survives its new enable condition.
 
-## 3. Account email needs the us-east-1 path
+## 3. Account email (DONE 2026-07-25)
 
-The verification and password-reset flows are **inert** until the API can send mail. As of
-2026-07-25 it cannot, for two independent reasons:
+Account mail sends through **us-east-1**, not the `eu-west-1` the rest of the stack uses.
+`eu-west-1` is sandboxed and its production-access request was DENIED (case
+`178385855400669`); `us-east-1` already has production access (50k/day).
 
-- **SES in `eu-west-1` is sandboxed and its production-access request was DENIED**
-  (case `178385855400669`). Only `strelov1@gmail.com` can receive there.
-- The API reads `/opt/freehire/.env`, whose `AWS_*` key belongs to apply's mail worker
-  (S3+SQS only) and cannot call `ses:SendEmail`.
+What was wired, for the record:
 
-`us-east-1` **does** have production access (50k/day). The fix, once
-`mail.freehire.me` is DKIM-verified there:
+- `mail.freehire.me` verified for sending in us-east-1 (Easy DKIM; three CNAMEs plus an
+  SPF TXT at Namecheap, which holds DNS manually — it is not in terraform).
+- `/opt/freehire/.env.notify` gained `AWS_REGION=us-east-1`, and its
+  `NOTIFY_EMAIL_FROM` was corrected from `notifications@mail.freehire.dev` to
+  `…@mail.freehire.me`. The IAM policy only ever allowed the `.me` address, so the
+  notify worker could not have delivered a single digest either — that bug is fixed by
+  the same line.
+- A drop-in (`/etc/systemd/system/freehire-api@.service.d/mail.conf`) loads that file on
+  the API **after** the shared `.env`, so only the API moves region. Safe because the API
+  builds exactly one AWS client (SES); its S3 use is static MinIO-style credentials.
 
-```bash
-# One region line, in the file that already holds the SES-capable key and sender.
-ssh root@89.167.94.146 "grep -q '^AWS_REGION=' /opt/freehire/.env.notify \
-  || echo 'AWS_REGION=us-east-1' >> /opt/freehire/.env.notify"
-```
-
-Then add that file as a **second** `EnvironmentFile` on `freehire-api@.service` (systemd
-applies them in order, so it overrides `AWS_REGION` for the API alone and leaves the other
-twelve units on `eu-west-1` for their SQS/S3 work), and `daemon-reload`.
-
-The notify IAM key is already scoped to `ses:SendEmail` with
-`ses:FromAddress = notifications@mail.freehire.me` and carries no region condition, so no
-new IAM user or policy is needed.
-
-Until this is done, `/auth/verify/request` and `/auth/password/forgot` answer 503 and the
-SPA's confirm-email banner offers a button that reports delivery is unavailable.
+No new IAM user was needed: the notify key is scoped to `ses:SendEmail` with
+`ses:FromAddress = notifications@mail.freehire.me` and carries no region condition.
 
 ## 4. Deploy
 

--- a/openspec/changes/harden-account-security/specs/password-recovery/spec.md
+++ b/openspec/changes/harden-account-security/specs/password-recovery/spec.md
@@ -8,8 +8,10 @@ an account-enumeration oracle.
 
 - A reset code SHALL be six decimal digits from a cryptographically secure source, stored
   only as a hash, single-use, and valid for 15 minutes.
-- A code SHALL be mailed only when the address has an account with a password; a
-  passwordless (OAuth-only) account SHALL receive no code.
+- A code SHALL be mailed whenever the address has an account, including a passwordless
+  (OAuth-only) one — its owner may use this flow to set a first password and gain a
+  second way in. Receiving the code proves control of the address, the same proof the
+  provider offers, so refusing would strand the user without buying safety.
 - Requests SHALL be rate-limited per address and per client IP.
 
 #### Scenario: Known address receives a code
@@ -22,10 +24,10 @@ an account-enumeration oracle.
 - **WHEN** a client POSTs an address that has no account
 - **THEN** the system responds `202` with the same body and timing class as for a known address, and mails nothing
 
-#### Scenario: OAuth-only account gets no reset code
+#### Scenario: OAuth-only account may set a first password
 
 - **WHEN** a client requests a reset for an address whose account has no password
-- **THEN** the system responds `202`, mails no code, and leaves the account untouched
+- **THEN** the system responds `202` and mails a code, and completing the reset gives that account its first password
 
 ### Requirement: Password reset by code
 
@@ -33,6 +35,7 @@ The system SHALL set a new password when presented with a valid, unexpired reset
 address, and SHALL treat a successful reset as proof of email ownership.
 
 - The new password SHALL satisfy the same rules as registration (8–72 characters).
+- The account MAY have had no password before; the reset then sets its first one.
 - A successful reset SHALL mark the account's email verified.
 - A successful reset SHALL revoke every existing session for that account.
 - The code SHALL be consumed on success and invalidated after 5 failed attempts.

--- a/web/src/routes/my/security/+page.svelte
+++ b/web/src/routes/my/security/+page.svelte
@@ -80,7 +80,9 @@
 
   {#if !hasPassword}
     <p class="text-sm text-muted-foreground">
-      This account signs in with a provider and has no password.
+      This account signs in with a provider and has no password. To add one — a second way
+      in, independent of the provider — sign out, choose “Forgot your password?” on the
+      sign-in screen, and set it with the code we email you.
     </p>
   {:else}
     <form class="flex max-w-sm flex-col gap-3" onsubmit={changePassword}>


### PR DESCRIPTION
Follow-ups from running #1119 against production.

## An OAuth-only account could not add a password

`POST /auth/password/forgot` mailed nothing for a passwordless account and returned the
same `202` it returns for everything, so the owner got a silent dead end. The original
reasoning was that mailing a code would "bolt a password onto an account whose owner
never chose one" — but receiving the code proves control of the address, which is the
same proof the provider offers. Refusing bought no safety and stranded the user.

The flow now serves those accounts; completing the reset sets their first password and
gives them a second way in, independent of the provider. The security page explains how
to get there.

## Login under-reported the account

`Login` answers with the same wire shape as `/auth/me` but built it from the
`UserByEmail` row, which does not carry `has_password`. So a client was told the account
was passwordless *immediately after it authenticated with a password* — hiding the
change-password form on `/my/security` until `/auth/me` refreshed.

## SERVED_HOSTS could narrow silently

**This one broke sign-in in production.** Leaving `SERVED_HOSTS` unset defaults the OAuth
redirect origin to the frontend origin's host. On a deployment answering on several hosts
— which a configured `COOKIE_DOMAIN` is precisely the signal for — every other host then
fails with `state mismatch`: the state cookie is set on the host the flow started from,
while the provider is told to call back to the canonical origin.

Prod runs `COOKIE_DOMAIN=.freehire.dev,.freehire.me` with
`FRONTEND_ORIGIN=https://freehire.dev`, so sign-in on `freehire.me` broke until
`SERVED_HOSTS` was set to all four served hosts. The server now logs the combination at
startup, so the next occurrence surfaces in seconds instead of as a broken login.

The runbook is corrected accordingly (it had said the opposite), and the deployed-state
notes for the SES wiring are recorded there.

## Verification

`go build` / `go vet` / `gofmt` clean, `go test ./...` green, recovery integration tests
green. Web: `svelte-check` 0 errors, eslint clean, 385 tests, production build succeeds.