### PR TITLE
fix(jobs): resolve a posting by the URL the catalog stored for it

### DIFF
--- a/internal/db/find_job_by_url_integration_test.go
+++ b/internal/db/find_job_by_url_integration_test.go
@@ -1,0 +1,208 @@
+//go:build integration
+
+// Integration tests for resolving a job page URL to the catalog posting stored under it —
+// the second tier of /api/v1/jobs/find, used when no source identity can be read out of
+// the URL. Both the normalization (an IMMUTABLE SQL function shared by the query and its
+// index) and the open/canonical gate are SQL behaviors verifiable only against a real
+// Postgres.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// urlJob builds an open posting that stores the given detail URL.
+func urlJob(externalID, url string) UpsertJobParams {
+	p := ingestParams(externalID, "Staff Java Backend Developer")
+	p.Source = "himalayas"
+	p.URL = url
+	return p
+}
+
+// findByURL runs the lookup under test.
+func findByURL(t *testing.T, q *Queries, url string) (string, error) {
+	t.Helper()
+	return q.FindOpenJobByURL(context.Background(), url)
+}
+
+const himalayasPosting = "https://himalayas.app/companies/mindera/jobs/staff-java-backend-developer"
+
+func TestNormalizeJobURL_CollapsesCosmeticVariants(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	// Every variant of the same posting address must normalize alike: scheme, host case,
+	// a www. prefix, a tracking query, a fragment, and trailing slashes are all noise.
+	variants := []string{
+		himalayasPosting,
+		"http://himalayas.app/companies/mindera/jobs/staff-java-backend-developer",
+		"https://www.himalayas.app/companies/mindera/jobs/staff-java-backend-developer",
+		"https://Himalayas.app/companies/mindera/jobs/Staff-Java-Backend-Developer",
+		himalayasPosting + "?utm_source=freehire.me",
+		himalayasPosting + "#apply",
+		himalayasPosting + "///",
+	}
+	var want string
+	if err := pool.QueryRow(ctx, "SELECT normalize_job_url($1)", himalayasPosting).Scan(&want); err != nil {
+		t.Fatalf("normalize base URL: %v", err)
+	}
+	if strings.HasPrefix(want, "http") {
+		t.Errorf("normalize_job_url kept the scheme: %q", want)
+	}
+	for _, v := range variants {
+		var got string
+		if err := pool.QueryRow(ctx, "SELECT normalize_job_url($1)", v).Scan(&got); err != nil {
+			t.Fatalf("normalize %q: %v", v, err)
+		}
+		if got != want {
+			t.Errorf("normalize_job_url(%q) = %q, want %q", v, got, want)
+		}
+	}
+
+	// A genuinely different posting must not collapse into the same key.
+	var other string
+	if err := pool.QueryRow(ctx,
+		"SELECT normalize_job_url($1)", "https://himalayas.app/companies/mindera/jobs/staff-go-developer").Scan(&other); err != nil {
+		t.Fatalf("normalize sibling URL: %v", err)
+	}
+	if other == want {
+		t.Errorf("two different postings normalized alike: %q", other)
+	}
+}
+
+func TestFindOpenJobByURL_ResolvesDespiteURLNoise(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, urlJob("himalayas:mindera", himalayasPosting))
+
+	// The link the user followed off freehire carries our own tracking tag; the stored
+	// URL does not. They are the same himalayasPosting.
+	for _, requested := range []string{
+		himalayasPosting,
+		himalayasPosting + "?utm_source=freehire.me",
+		"https://www.himalayas.app/companies/mindera/jobs/staff-java-backend-developer/",
+		"http://himalayas.app/companies/mindera/jobs/staff-java-backend-developer",
+	} {
+		slug, err := findByURL(t, q, requested)
+		if err != nil {
+			t.Errorf("find %q: %v", requested, err)
+			continue
+		}
+		if slug != "pslug-himalayas:mindera" {
+			t.Errorf("find %q = %q, want the seeded himalayasPosting", requested, slug)
+		}
+	}
+}
+
+func TestFindOpenJobByURL_SkipsClosedAndDuplicatePostings(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	t.Run("closed", func(t *testing.T) {
+		truncate(t, pool)
+		mustUpsert(t, q, urlJob("himalayas:closed", himalayasPosting))
+		if _, err := pool.Exec(ctx,
+			"UPDATE jobs SET closed_at = now() WHERE external_id = $1", "himalayas:closed"); err != nil {
+			t.Fatalf("close himalayasPosting: %v", err)
+		}
+		if slug, err := findByURL(t, q, himalayasPosting); !errors.Is(err, pgx.ErrNoRows) {
+			t.Errorf("closed posting resolved to %q (err %v), want no rows", slug, err)
+		}
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		truncate(t, pool)
+		mustUpsert(t, q, urlJob("himalayas:canonical", "https://himalayas.app/companies/mindera/jobs/other"))
+		mustUpsert(t, q, urlJob("himalayas:dup", himalayasPosting))
+		canonicalID, _ := dupOf(t, pool, "himalayas:canonical")
+		if _, err := pool.Exec(ctx,
+			"UPDATE jobs SET duplicate_of = $1 WHERE external_id = $2", canonicalID, "himalayas:dup"); err != nil {
+			t.Fatalf("suppress himalayasPosting: %v", err)
+		}
+		if slug, err := findByURL(t, q, himalayasPosting); !errors.Is(err, pgx.ErrNoRows) {
+			t.Errorf("suppressed posting resolved to %q (err %v), want no rows", slug, err)
+		}
+	})
+}
+
+func TestFindOpenJobByURL_UnknownPageHasNoRow(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, urlJob("himalayas:mindera", himalayasPosting))
+
+	if slug, err := findByURL(t, q, "https://example.test/careers/some-job"); !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("unknown page resolved to %q (err %v), want no rows", slug, err)
+	}
+}
+
+func TestFindOpenJobByURL_PrefersTheMostRecentlySeenPosting(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// Two open canonical rows can legitimately link to the same page (an aggregator and
+	// an ATS row that the dedup passes have not collapsed). The card shows the row we
+	// confirmed most recently.
+	mustUpsert(t, q, urlJob("himalayas:stale", himalayasPosting))
+	mustUpsert(t, q, urlJob("himalayas:fresh", himalayasPosting))
+	if _, err := pool.Exec(ctx,
+		"UPDATE jobs SET last_seen_at = now() - interval '10 days' WHERE external_id = $1", "himalayas:stale"); err != nil {
+		t.Fatalf("age the stale row: %v", err)
+	}
+
+	slug, err := findByURL(t, q, himalayasPosting)
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if slug != "pslug-himalayas:fresh" {
+		t.Errorf("find = %q, want the most recently seen himalayasPosting", slug)
+	}
+}
+
+func TestFindOpenJobByURL_UsesTheExpressionIndex(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	mustUpsert(t, q, urlJob("himalayas:mindera", himalayasPosting))
+	// The planner picks a sequential scan on a table this small no matter what, so ask it
+	// to cost the index path: what this asserts is that the query's expression matches the
+	// index's, which is the property that silently breaks if the two definitions drift.
+	if _, err := pool.Exec(ctx, "SET enable_seqscan = off"); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+
+	// EXPLAIN the generated query itself, not a copy of it — a copy would keep passing
+	// after the real query changed.
+	rows, err := pool.Query(ctx, "EXPLAIN "+findOpenJobByURL, himalayasPosting)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan plan: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteString("\n")
+	}
+	if !strings.Contains(plan.String(), "jobs_normalized_url_idx") {
+		t.Errorf("plan does not use jobs_normalized_url_idx:\n%s", plan.String())
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -265,6 +265,32 @@ func (q *Queries) ExistingExternalIDs(ctx context.Context, source string) ([]str
 	return items, nil
 }
 
+const findOpenJobByURL = `-- name: FindOpenJobByURL :one
+SELECT public_slug
+FROM jobs
+WHERE normalize_job_url(url) = normalize_job_url($1)
+  AND closed_at IS NULL
+  AND duplicate_of IS NULL
+ORDER BY last_seen_at DESC, id DESC
+LIMIT 1
+`
+
+// Resolve a job page URL to the posting stored under it — the second tier of
+// /api/v1/jobs/find, used when no (source, external_id) identity can be read out of the
+// URL. Both sides go through normalize_job_url (migration 0042), so a link differing only
+// by scheme, www., tracking query, fragment, case or trailing slash still matches; the
+// same expression backs jobs_normalized_url_idx, so this is an index lookup.
+// Scoped to open canonical rows, matching that partial index: a closed or suppressed
+// posting is not one to show a match card for. Two open rows may share a URL (an
+// aggregator and an ATS row the dedup passes have not collapsed), so the most recently
+// confirmed one wins, with id as the deterministic tiebreak.
+func (q *Queries) FindOpenJobByURL(ctx context.Context, url string) (string, error) {
+	row := q.db.QueryRow(ctx, findOpenJobByURL, url)
+	var public_slug string
+	err := row.Scan(&public_slug)
+	return public_slug, err
+}
+
 const getJob = `-- name: GetJob :one
 SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding, salary_min_manual, salary_max_manual, salary_currency_manual, salary_period_manual, upvote_count, downvote_count
 FROM jobs

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -468,6 +468,16 @@ type Querier interface {
 	// Record a failed attempt: bump attempts, release the lease, store the error, and
 	// dead-letter (set failed_at) once attempts reach max_attempts.
 	FailEmailClassification(ctx context.Context, arg FailEmailClassificationParams) error
+	// Resolve a job page URL to the posting stored under it — the second tier of
+	// /api/v1/jobs/find, used when no (source, external_id) identity can be read out of the
+	// URL. Both sides go through normalize_job_url (migration 0042), so a link differing only
+	// by scheme, www., tracking query, fragment, case or trailing slash still matches; the
+	// same expression backs jobs_normalized_url_idx, so this is an index lookup.
+	// Scoped to open canonical rows, matching that partial index: a closed or suppressed
+	// posting is not one to show a match card for. Two open rows may share a URL (an
+	// aggregator and an ATS row the dedup passes have not collapsed), so the most recently
+	// confirmed one wins, with id as the deterministic tiebreak.
+	FindOpenJobByURL(ctx context.Context, url string) (string, error)
 	// Read-only balance for display (no lock, no LLM). Returns no rows for a user who has never
 	// had credit activity; the caller treats that as a full monthly grant remaining.
 	GetBalance(ctx context.Context, userID int64) (GetBalanceRow, error)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -115,6 +115,24 @@ SELECT *
 FROM jobs
 WHERE source = $1 AND external_id = $2;
 
+-- name: FindOpenJobByURL :one
+-- Resolve a job page URL to the posting stored under it — the second tier of
+-- /api/v1/jobs/find, used when no (source, external_id) identity can be read out of the
+-- URL. Both sides go through normalize_job_url (migration 0042), so a link differing only
+-- by scheme, www., tracking query, fragment, case or trailing slash still matches; the
+-- same expression backs jobs_normalized_url_idx, so this is an index lookup.
+-- Scoped to open canonical rows, matching that partial index: a closed or suppressed
+-- posting is not one to show a match card for. Two open rows may share a URL (an
+-- aggregator and an ATS row the dedup passes have not collapsed), so the most recently
+-- confirmed one wins, with id as the deterministic tiebreak.
+SELECT public_slug
+FROM jobs
+WHERE normalize_job_url(url) = normalize_job_url(@url)
+  AND closed_at IS NULL
+  AND duplicate_of IS NULL
+ORDER BY last_seen_at DESC, id DESC
+LIMIT 1;
+
 -- name: GetJobIDBySlug :one
 -- Slim slug->id lookup for the view/apply interaction path, which needs only the
 -- internal id (the user_jobs FK) and must not drag the wide description/enrichment

--- a/internal/handler/find_job.go
+++ b/internal/handler/find_job.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
@@ -15,31 +16,49 @@ import (
 // already carry and switch from the ad-hoc text match to the curated card.
 // Public; returns {"data": null} whenever the posting cannot be identified.
 //
-// The lookup is by the catalog's own dedup identity — (source, external_id),
-// recovered from the URL — which is exact and served by a unique index. It
-// replaced a company+title match that compared the page title against every
-// catalog title: that could not use an index at all (the LIKE pattern was built
+// Two tiers, exact first. The catalog's own dedup identity — (source,
+// external_id), recovered from the URL — is served by a unique index, but only a
+// handful of ATS URL shapes carry an identity a parser can read. So a URL that
+// names no identity, or names one we have no row for, falls through to matching
+// the page against the detail URL each source stored in jobs.url (normalized on
+// both sides, see migration 0042): for aggregators and most boards that IS the
+// page the user is standing on.
+//
+// Neither tier guesses. An earlier version matched the page title against every
+// catalog title, which could not use an index at all (the LIKE pattern was built
 // from the column), so it degenerated into a sequential scan of millions of rows
-// and timed out in production. It was also guesswork, and a page title is not
-// something to guess from — the extension was sending "reCAPTCHA".
+// and timed out in production — and it was guesswork besides, on a page title
+// that is not something to guess from (the extension was sending "reCAPTCHA").
 func (a *API) FindJob(c *fiber.Ctx) error {
-	ref, ok := sources.RefFromURL(c.Query("url"))
-	if !ok {
+	pageURL := strings.TrimSpace(c.Query("url"))
+	// Nothing to resolve — and an empty URL must not reach the second tier, where it
+	// would normalize to "" and match a posting stored with an empty url.
+	if pageURL == "" {
 		return c.JSON(fiber.Map{"data": nil})
 	}
 
-	job, err := a.queries.GetJobBySourceExternalID(c.Context(), db.GetJobBySourceExternalIDParams{
-		Source:     ref.Source,
-		ExternalID: ref.ExternalID,
-	})
+	if ref, ok := sources.RefFromURL(pageURL); ok {
+		job, err := a.queries.GetJobBySourceExternalID(c.Context(), db.GetJobBySourceExternalIDParams{
+			Source:     ref.Source,
+			ExternalID: ref.ExternalID,
+		})
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+		if err == nil && job.PublicSlug != "" {
+			return c.JSON(fiber.Map{"data": fiber.Map{"public_slug": job.PublicSlug}})
+		}
+	}
+
+	slug, err := a.queries.FindOpenJobByURL(c.Context(), pageURL)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return c.JSON(fiber.Map{"data": nil})
 		}
 		return err
 	}
-	if job.PublicSlug == "" {
+	if slug == "" {
 		return c.JSON(fiber.Map{"data": nil})
 	}
-	return c.JSON(fiber.Map{"data": fiber.Map{"public_slug": job.PublicSlug}})
+	return c.JSON(fiber.Map{"data": fiber.Map{"public_slug": slug}})
 }

--- a/internal/handler/find_job_integration_test.go
+++ b/internal/handler/find_job_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+// Integration tests for GET /api/v1/jobs/find, the endpoint the browser extension asks
+// "is the page I am on a posting you carry?". Both tiers need a real Postgres: the
+// identity lookup by (source, external_id), and the fall-through that compares the page
+// URL against jobs.url through normalize_job_url.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// findSlug calls the endpoint and returns the resolved slug, or "" for {"data": null}.
+func findSlug(t *testing.T, app *fiber.App, url string) string {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/jobs/find?url="+url, nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("GET find?url=%s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET find?url=%s: status %d, want 200", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var out struct {
+		Data *struct {
+			PublicSlug string `json:"public_slug"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+	if out.Data == nil {
+		return ""
+	}
+	return out.Data.PublicSlug
+}
+
+func TestFindJobResolvesByIdentityAndByURL(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	// A Greenhouse posting, whose identity the URL parser can recover, and an aggregator
+	// posting, whose identity it cannot — the latter is only reachable by its stored URL.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, public_slug) VALUES
+		 ('greenhouse', 'vgw-eu:8617539002', 'https://job-boards.greenhouse.io/vgw-eu/jobs/8617539002', 'Engineer', 'engineer-vgw-eu'),
+		 ('himalayas', ':https://himalayas.app/companies/mindera/jobs/staff-java-backend-developer',
+		  'https://himalayas.app/companies/mindera/jobs/staff-java-backend-developer', 'Staff Java Backend Developer', 'staff-java-mindera')`); err != nil {
+		t.Fatalf("seed jobs: %v", err)
+	}
+
+	h := &API{pool: pool, queries: db.New(pool)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/jobs/find", h.FindJob)
+
+	t.Run("greenhouse URL resolves by identity", func(t *testing.T) {
+		if slug := findSlug(t, app, "https%3A%2F%2Fjob-boards.greenhouse.io%2Fvgw-eu%2Fjobs%2F8617539002"); slug != "engineer-vgw-eu" {
+			t.Errorf("slug = %q, want engineer-vgw-eu", slug)
+		}
+	})
+
+	t.Run("aggregator page resolves by its stored URL", func(t *testing.T) {
+		// Carrying the tracking tag freehire stamps on its own outbound links.
+		const page = "https%3A%2F%2Fhimalayas.app%2Fcompanies%2Fmindera%2Fjobs%2Fstaff-java-backend-developer%3Futm_source%3Dfreehire.me"
+		if slug := findSlug(t, app, page); slug != "staff-java-mindera" {
+			t.Errorf("slug = %q, want staff-java-mindera", slug)
+		}
+	})
+
+	t.Run("unknown page is unresolved", func(t *testing.T) {
+		if slug := findSlug(t, app, "https%3A%2F%2Fexample.test%2Fcareers%2Fsome-job"); slug != "" {
+			t.Errorf("slug = %q, want no match", slug)
+		}
+	})
+
+	t.Run("recognised identity with no posting falls through to the URL lookup", func(t *testing.T) {
+		if slug := findSlug(t, app, "https%3A%2F%2Fjob-boards.greenhouse.io%2Fnobody%2Fjobs%2F1"); slug != "" {
+			t.Errorf("slug = %q, want no match", slug)
+		}
+	})
+
+	t.Run("an empty url matches nothing", func(t *testing.T) {
+		// A posting can carry an empty url (nothing constrains the column), and an empty
+		// query would otherwise normalize to the same "" and resolve to it.
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, public_slug)
+			 VALUES ('test', 'blank-url', '', 'Nameless', 'nameless-job')`); err != nil {
+			t.Fatalf("seed blank-url job: %v", err)
+		}
+		if slug := findSlug(t, app, ""); slug != "" {
+			t.Errorf("slug = %q, want no match", slug)
+		}
+	})
+}

--- a/migrations/0042_jobs_normalized_url_idx.sql
+++ b/migrations/0042_jobs_normalized_url_idx.sql
@@ -1,0 +1,36 @@
+-- Resolving a job page URL to the posting it is, for the browser extension's
+-- /api/v1/jobs/find. The first tier reads the catalog identity (source, external_id) out
+-- of the URL (internal/sources.RefFromURL), which only a handful of ATS URL shapes allow.
+-- This is the second tier: the catalog already stores each posting's detail URL in
+-- jobs.url, and for aggregators and most boards that is the very page the user is on.
+--
+-- normalize_job_url strips the noise two links to the same posting differ by: the scheme,
+-- a leading www., the query string (our own outbound links carry ?utm_source=freehire.me),
+-- the fragment, and trailing slashes. It exists as a function rather than an inline
+-- expression so the index below and the query in internal/db/queries/jobs.sql share ONE
+-- definition — an expression index is only used when the query's expression matches it
+-- exactly, and a drift between two hand-copied expressions fails silently, degrading the
+-- lookup into the sequential scan this endpoint was rewritten to escape.
+--
+-- IMMUTABLE (required to index it) holds: lower and regexp_replace are immutable, and the
+-- rewrite depends on nothing but its argument. STRICT keeps a NULL url out of the index.
+CREATE FUNCTION public.normalize_job_url(text) RETURNS text
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+    AS $$
+        SELECT regexp_replace(
+                   regexp_replace(
+                       regexp_replace(lower($1), '^https?://(www\.)?', ''),
+                   '[?#].*$', ''),
+               '/+$', '')
+    $$;
+
+-- Partial on the rows the lookup can answer with: a curated match card is for a vacancy
+-- the user can still apply to, and a duplicate_of row is by definition not the one we
+-- serve. That also keeps the index to the open catalogue rather than every posting we
+-- have ever seen.
+--
+-- On a fresh initdb volume this plain CREATE INDEX is fine; on the live prod DB it is
+-- applied manually as CREATE INDEX CONCURRENTLY.
+CREATE INDEX jobs_normalized_url_idx
+    ON public.jobs (public.normalize_job_url(url))
+    WHERE closed_at IS NULL AND duplicate_of IS NULL;

--- a/openspec/changes/find-job-by-page-url/.openspec.yaml
+++ b/openspec/changes/find-job-by-page-url/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/find-job-by-page-url/design.md
+++ b/openspec/changes/find-job-by-page-url/design.md
@@ -1,0 +1,130 @@
+## Context
+
+`GET /api/v1/jobs/find?url=` answers one question for the browser extension: *is the page
+in front of the user a posting we carry, and which one?* Today it answers by recovering
+the catalog's dedup identity `(source, external_id)` from the URL (`sources.RefFromURL`)
+and loading that row by its unique index. That path is exact and cheap, and it replaced a
+company+title `ILIKE` match that could not use an index and timed out in production on
+millions of rows. Keeping it first is not negotiable.
+
+Its coverage, though, is one ATS out of 175 adapters. The identity of a posting is
+provider-specific (Greenhouse numbers jobs, Ashby uses UUIDs, aggregators key on their own
+page URL), so every additional provider is a hand-written parser that has to agree with
+what that provider's ingest adapter writes into `external_id`.
+
+Meanwhile the catalog already stores each posting's detail URL in `jobs.url`, written by
+the source adapter from the feed. For aggregators and most ATS boards that is the same
+page the user is standing on — the same string, modulo a tracking query and the usual
+scheme/host noise.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Resolve a page URL to its catalog posting for any source whose stored `url` is the
+  posting's own detail page, without a parser per provider.
+- Keep the exact-identity path first and unchanged.
+- One definition of URL normalization, shared by the index and the query, so the lookup
+  cannot silently stop using its index.
+- Stay a single indexed equality lookup — no scan, no fetch, no LIKE.
+
+**Non-Goals:**
+- Resolving a page whose posting we do not carry (that is the contribute/import change).
+- Resolving to a closed or duplicate posting.
+- Fuzzy URL matching (path prefixes, id extraction from arbitrary paths).
+
+## Decisions
+
+### Normalization lives in SQL, as one IMMUTABLE function
+
+An expression index is only used when the query's expression matches the index's
+*exactly*. If normalization were written in Go and the index in SQL, the two would be
+independent definitions of the same rule — and the failure mode of a drift is silent: the
+query still returns correct rows, it just stops using the index and degrades into the
+sequential scan this endpoint was rewritten to escape.
+
+So the migration defines:
+
+```sql
+CREATE FUNCTION normalize_job_url(text) RETURNS text
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+AS $$ SELECT regexp_replace(
+                 regexp_replace(
+                     regexp_replace(lower($1), '^https?://(www\.)?', ''),
+                 '[?#].*$', ''),
+             '/+$', '') $$;
+```
+
+and the query applies the same function to the column and to the parameter. The rule is
+therefore stated once: lowercase, drop the scheme and a leading `www.`, drop query and
+fragment, drop trailing slashes.
+
+`lower`, `regexp_replace` and `SELECT` over them are immutable, which is what makes the
+function indexable. `STRICT` keeps a NULL url out of the index.
+
+Dropping the query string is what makes the freehire-tagged link the user followed
+(`?utm_source=freehire.me`) resolve to the row it came from — and it is safe here because
+no source in the catalog distinguishes two postings by query parameters alone. The
+Greenhouse embed form does exactly that (`?for=…&token=…`), which is why it is served by
+`RefFromURL` — the first tier — and never reaches this one.
+
+### The index is partial over open, canonical rows
+
+```sql
+CREATE INDEX jobs_normalized_url_idx
+    ON public.jobs (normalize_job_url(url))
+    WHERE closed_at IS NULL AND duplicate_of IS NULL;
+```
+
+`jobs` holds several million rows; a full expression index over `text` is a few hundred
+megabytes of it we would never query. Restricting to open canonical rows is not only
+cheaper — it is the correct semantic: a curated match card exists to tell the user how
+they fit a vacancy they can still apply to, and a duplicate row is by definition not the
+one we serve. When the posting is closed or suppressed, `find` answers `null` and the
+extension's text-match fallback takes over, exactly as it does for an unknown page.
+
+Following `0027_jobs_greenhouse_jobid_idx.sql`, the migration ships the plain
+`CREATE INDEX` (correct on a fresh initdb volume) and notes that prod takes it as
+`CREATE INDEX CONCURRENTLY` by hand.
+
+### Ties are broken by recency
+
+Two open canonical rows can share a normalized URL — an aggregator and an ATS row that
+link to the same page, say. The query orders by `last_seen_at DESC, id DESC` and takes
+one: the most recently confirmed row, deterministically. This is a display choice, not a
+dedup one; collapsing such pairs stays the ingest passes' job.
+
+### RefFromURL stays, and stays Greenhouse-only
+
+The two tiers answer different questions. `RefFromURL` reads the *identity out of the
+URL*, which works even when the page the user is on is not what `jobs.url` holds — the
+Greenhouse embedded application form is a different URL from the board's job page, and
+only a parser can bridge them. The URL fallback reads the *URL out of the catalog*, which
+works for every source that stores the page it scraped. Adding a provider to the first
+tier is worth it only when its pages are addressed differently from what its adapter
+stores; for himalayas they are identical, so the fallback covers it and no adapter is
+written.
+
+## Risks / Trade-offs
+
+- **Sources whose `url` is not the page the user sees.** Some adapters store an apply-form
+  or external URL, so their postings stay unresolved by this tier. The outcome is today's
+  outcome (`null` → text match), and the first tier remains the escape hatch for those
+  providers.
+- **Index write cost.** One more expression index on the hottest write table (`ingest`
+  upserts). It is partial and narrow; the same shape already exists on `jobs` twice
+  (`0026`, `0027`, `0035`).
+- **A URL is user-controlled input.** It is a query parameter compared as a bound
+  parameter through sqlc — no interpolation, and the normalization is pure string
+  rewriting.
+- **Query-string-significant hosts.** Any future source that distinguishes postings by
+  query alone would resolve to the wrong sibling. No such source exists in the catalog
+  today; the Greenhouse case that does is handled a tier earlier.
+
+## Migration Plan
+
+One forward migration; no backfill (the index is built from existing rows). Nothing reads
+the function besides the new query, so a rollback is dropping the index and the function.
+
+## Open Questions
+
+None.

--- a/openspec/changes/find-job-by-page-url/proposal.md
+++ b/openspec/changes/find-job-by-page-url/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+`GET /api/v1/jobs/find?url=` is how the browser extension recognises that the page in
+front of the user is a job we already carry, so it can show the curated match card
+instead of an ad-hoc text match scraped off the page. It resolves the URL to the
+catalog's dedup identity `(source, external_id)` via `sources.RefFromURL`, which
+understands exactly one ATS: Greenhouse. Every other host answers `{"data": null}`.
+
+The catalog has 175 source adapters. Measured on prod today:
+
+```
+find?url=…himalayas.app/companies/mindera/jobs/staff-java-backend-developer  → null
+```
+
+— while that very posting is in the catalog as
+`staff-java-backend-developer-mindera-oxtftzij` (source `himalayas`). The extension
+therefore falls back to scraping the page and matching its text, which on that page
+yields a card titled "This page" at 0%. The posting is ours; we just cannot see it.
+
+Growing `RefFromURL` one provider at a time does not close this: each ATS numbers and
+addresses postings differently, so 174 hand-written URL parsers is the price of full
+coverage. But the catalog already stores the posting's own detail URL in `jobs.url` —
+for most sources that is the very page the user is standing on.
+
+## What Changes
+
+- `FindJob` gains a **second-tier lookup**: when `RefFromURL` cannot name an identity,
+  resolve the page URL against `jobs.url` compared in a normalized form (scheme, `www.`,
+  query, fragment and trailing slashes removed, lowercased). The exact-identity path stays
+  first — it is unaffected by whatever a source chose to store in `url`.
+- Normalization is defined **once**, as an `IMMUTABLE` SQL function
+  `normalize_job_url(text)`, used by both the index expression and the query — applied to
+  the column and to the caller's URL alike, so the two can never drift apart.
+- A partial expression index over open, canonical rows
+  (`closed_at IS NULL AND duplicate_of IS NULL`) serves the lookup.
+- A closed or duplicate posting stays unresolved: the curated card is for a vacancy the
+  user can still apply to, and the extension's text-match fallback already covers the rest.
+
+## Capabilities
+
+### New Capabilities
+- `posting-url-resolution`: resolving the URL of a job page in the wild to the catalog
+  posting it is, by exact source identity first and by the posting's stored detail URL
+  second.
+
+### Modified Capabilities
+<!-- none — /jobs/find keeps its wire shape ({"data": {"public_slug"}} or {"data": null});
+     only the set of URLs it can answer for grows. -->
+
+## Impact
+
+- `migrations/` — one migration: the `normalize_job_url` function plus the partial
+  expression index on `jobs`.
+- `internal/db/queries/jobs.sql` — new `FindOpenJobByURL` query; regenerate sqlc.
+- `internal/handler/find_job.go` — fall through to the URL lookup when no identity is
+  recognised.
+- No wire change, no change to ingest, search, or dedup.
+
+## Non-Goals
+
+- **No new per-provider URL parser, himalayas included.** Himalayas' `external_id` *is*
+  the posting's page URL (its feed `guid`), and `jobs.url` holds the same value, so the
+  fallback already resolves it — a hand-written adapter would be a second way to compute
+  an answer we now get for free. `RefFromURL` keeps its Greenhouse entry and stays the
+  place for URLs whose page address is *not* what `jobs.url` holds (the Greenhouse embed
+  form `/embed/job_app?for=…&token=…` is exactly that case).
+- **Importing a posting we do not carry.** The extension will offer to contribute an
+  unknown page; that is a separate change built on `internal/linksource`.

--- a/openspec/changes/find-job-by-page-url/specs/posting-url-resolution/spec.md
+++ b/openspec/changes/find-job-by-page-url/specs/posting-url-resolution/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: A page URL resolves to the catalog posting stored under that URL
+
+The system SHALL resolve the URL of a job page to a catalog posting when no source
+identity can be recovered from the URL, by comparing the URL to `jobs.url` in a normalized
+form. Only open, canonical postings (`closed_at IS NULL` and `duplicate_of IS NULL`) are
+eligible. When several eligible postings share a normalized URL, the system SHALL answer
+with the most recently seen one (`last_seen_at DESC`, then `id DESC`), and SHALL answer
+with exactly one posting.
+
+The normalized form of a URL is: lowercased, with the `http://` or `https://` scheme and a
+leading `www.` removed, with the query string and fragment removed, and with trailing
+slashes removed. The same normalization SHALL be applied to the stored URL and to the
+requested URL.
+
+#### Scenario: An aggregator posting is resolved by its page URL
+
+- **WHEN** `/api/v1/jobs/find` is called with the URL of a page that an open canonical
+  posting stores as its `url`, and no source identity can be recovered from that URL
+- **THEN** the response carries that posting's `public_slug`
+
+#### Scenario: Tracking parameters do not prevent resolution
+
+- **WHEN** the requested URL differs from the stored one only by query string, fragment,
+  `www.` prefix, scheme, letter case, or trailing slashes
+- **THEN** the posting is resolved as if the URLs were identical
+
+#### Scenario: A closed or duplicate posting is not resolved
+
+- **WHEN** the only postings matching the normalized URL are closed (`closed_at` set) or
+  suppressed (`duplicate_of` set)
+- **THEN** the response is `{"data": null}`
+
+#### Scenario: An unknown page stays unresolved
+
+- **WHEN** no posting stores the requested URL and no source identity can be recovered
+  from it
+- **THEN** the response is `{"data": null}`
+
+### Requirement: Source identity resolution takes precedence over the URL lookup
+
+The system SHALL first attempt to recover the catalog identity `(source, external_id)`
+from the requested URL and load the posting by that identity. The URL comparison SHALL be
+attempted only when no identity is recovered. A posting found by identity SHALL be
+answered with regardless of whether its stored `url` matches the requested URL.
+
+#### Scenario: A recognised ATS URL is answered from its identity
+
+- **WHEN** the requested URL is one an identity parser recognises, and a posting exists
+  under that identity
+- **THEN** the response carries that posting's `public_slug`, without consulting `jobs.url`
+
+#### Scenario: A recognised URL with no catalog posting falls through
+
+- **WHEN** the requested URL yields an identity but no posting exists under it
+- **THEN** the URL comparison runs, and the response is `{"data": null}` unless a posting
+  stores that URL

--- a/openspec/changes/find-job-by-page-url/tasks.md
+++ b/openspec/changes/find-job-by-page-url/tasks.md
@@ -1,0 +1,46 @@
+## 1. Normalization function and index
+
+- [x] 1.1 Add the migration defining `normalize_job_url(text)` as an `IMMUTABLE PARALLEL
+  SAFE STRICT` SQL function (lowercase; strip `http(s)://` and a leading `www.`; strip
+  query and fragment; strip trailing slashes) and the partial expression index
+  `jobs_normalized_url_idx ON jobs (normalize_job_url(url)) WHERE closed_at IS NULL AND
+  duplicate_of IS NULL`. Comment it in the style of `0027_jobs_greenhouse_jobid_idx.sql`,
+  including the note that prod applies the index as `CREATE INDEX CONCURRENTLY`.
+- [x] 1.2 Integration test (build-tag `integration`, testcontainers) asserting the function
+  itself: scheme, `www.`, case, query, fragment and trailing-slash variants of one URL all
+  normalize to the same string; two genuinely different paths do not.
+
+## 2. Catalog lookup by URL
+
+- [x] 2.1 Write `FindOpenJobByURL` in `internal/db/queries/jobs.sql`: select the
+  `public_slug` of the open canonical posting whose `normalize_job_url(url)` equals
+  `normalize_job_url(@url)`, ordered `last_seen_at DESC, id DESC`, `LIMIT 1`. Regenerate
+  sqlc (`make sqlc`).
+- [x] 2.2 Integration test covering: resolution by exact URL; resolution despite a
+  `?utm_source=` tail, a `www.` prefix, a scheme difference and a trailing slash; no
+  resolution for a closed posting; no resolution for a `duplicate_of` posting; the most
+  recently seen row wins when two open canonical rows share a URL.
+- [x] 2.3 Confirm with `EXPLAIN` in the integration test's database that the query uses
+  `jobs_normalized_url_idx` rather than a sequential scan.
+
+## 3. Handler fall-through
+
+- [x] 3.1 Extend `internal/handler/find_job.go`: when `sources.RefFromURL` reports no
+  identity, or reports one that matches no row, fall through to `FindOpenJobByURL`; keep
+  the `{"data": null}` shape for a miss and the identity path first for a hit.
+- [x] 3.2 Handler integration test: a Greenhouse URL still resolves by identity; an
+  aggregator page URL resolves by the URL fallback; an unknown page answers
+  `{"data": null}`.
+- [x] 3.3 Reject an empty `url` before the second tier: an empty query normalizes to `""`
+  and would otherwise resolve to a posting stored with an empty `url` (found by review,
+  covered by a regression test).
+
+## 4. Verification
+
+- [x] 4.1 Against a database seeded with a himalayas posting, call
+  `/api/v1/jobs/find?url=https://himalayas.app/companies/mindera/jobs/staff-java-backend-developer?utm_source=freehire.me`
+  and confirm it answers that posting's slug — the case this change exists for. (Covered
+  by the handler integration test's "aggregator page resolves by its stored URL".)
+- [x] 4.2 Run the repo's checks and confirm green: `go build ./...`, `go vet`, `go test
+  ./...` (unit, whole repo) and `go test -tags=integration ./internal/db/
+  ./internal/handler/` (525s + 384s, both ok).


### PR DESCRIPTION
## Why

`GET /api/v1/jobs/find?url=` is how the browser extension recognises that the page in front of the user is a posting we carry. It resolves the URL to `(source, external_id)` via `sources.RefFromURL`, which understands exactly one ATS — Greenhouse. Every other host answers `{"data": null}`, so the extension falls back to scraping the page.

Measured on prod:

```
find?url=…himalayas.app/companies/mindera/jobs/staff-java-backend-developer  → null
find?url=…job-boards.greenhouse.io/vgw-eu/jobs/8617539002                    → engineer-vgw-eu-d5joynzu
```

The himalayas posting **is** in the catalog (`staff-java-backend-developer-mindera-oxtftzij`). The side panel rendered it as a card titled "This page" at 0%.

## What

A second tier on the same endpoint: when no identity can be read out of the URL — or none we have a row for — compare the page URL against `jobs.url`, which every source adapter fills with the posting's own detail page.

- `normalize_job_url(text)` (migration `0042`), `IMMUTABLE`, strips scheme, `www.`, query, fragment, trailing slashes and case. Defined **once** and used by both the query and its index: two hand-copied expressions would drift silently, and the failure mode is the query quietly abandoning the index for the seq scan this endpoint was rewritten to escape.
- `jobs_normalized_url_idx`, partial on `closed_at IS NULL AND duplicate_of IS NULL` — both cheaper and the right semantics (a match card is for a vacancy you can still apply to).
- Exact identity stays first and unchanged.
- An empty `?url=` is rejected before the second tier: it normalizes to `""` and would otherwise resolve to a posting stored with an empty `url`.

No new per-provider parser, himalayas included: its `external_id` **is** the page URL (the feed `guid`), and `jobs.url` holds the same value, so the fallback covers it. `RefFromURL` stays for URLs whose address is not what `jobs.url` holds — the Greenhouse embed form `?for=…&token=…` is exactly that.

## Tests

- `internal/db/find_job_by_url_integration_test.go` — normalization collapses cosmetic variants; resolution despite `utm_source`/`www.`/scheme/trailing slash; closed and `duplicate_of` postings skipped; most recently seen row wins on a tie; `EXPLAIN` over the generated query confirms the index is used.
- `internal/handler/find_job_integration_test.go` — Greenhouse still resolves by identity, an aggregator page resolves by its stored URL, unknown page and empty URL resolve to nothing.
- Green: `go test ./...` (whole repo) and `go test -tags=integration ./internal/db/ ./internal/handler/`.

## Deploy note

The migration needs applying by hand, and on the live table the index should go in as `CREATE INDEX CONCURRENTLY` (noted in the migration, mirroring `0027`).

Planned as OpenSpec change `find-job-by-page-url`.