### PR TITLE
fix(web): serve /install.sh from static/, where adapter-node can find it

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -52,8 +52,6 @@ WORKDIR /app
 COPY --from=build /src/build ./build
 COPY --from=build /src/node_modules ./node_modules
 COPY --from=build /src/package.json ./package.json
-# The CLI install script is served as a static file by nginx (see nginx.conf).
-COPY --from=build /src/public/install.sh /usr/share/nginx/html/install.sh
 COPY web/nginx.conf /etc/nginx/http.d/default.conf
 COPY web/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -48,15 +48,6 @@ server {
         proxy_pass $backend;
     }
 
-    # The CLI install script (web/public/install.sh, copied into the image), served
-    # by nginx as plain text so `curl -fsSL https://freehire.me/install.sh | sh`
-    # works and a browser can read it before piping to a shell. Kept on nginx so it
-    # stays independent of the Node server.
-    location = /install.sh {
-        root /usr/share/nginx/html;
-        default_type text/plain;
-    }
-
     # Everything else → the SvelteKit Node SSR server (adapter-node) in this
     # container. X-Forwarded-* let adapter-node reconstruct the public origin.
     location / {

--- a/web/static/install.sh
+++ b/web/static/install.sh
@@ -3,8 +3,9 @@
 # latest GitHub release and place it on PATH.
 #   curl -fsSL https://freehire.me/install.sh | sh
 #
-# Served at https://freehire.me/install.sh (Vite copies web/public/ into the SPA
-# build). Kept in sync with the canonical script in the freehire-cli repo.
+# Served at https://freehire.me/install.sh as a SvelteKit static asset — it must
+# live in web/static/, the only directory adapter-node serves. Kept in sync with
+# the canonical script in the freehire-cli repo.
 set -eu
 
 REPO="strelov1/freehire-cli"


### PR DESCRIPTION
`https://freehire.me/install.sh` returns **404**, and `freehire.dev/install.sh` 301s to that same 404 — so the documented install one-liner is dead on both domains. Found while cutting freehire-cli v0.8.0, whose release notes point at that URL.

## Why it broke

The script lived in `web/public/` — **a directory SvelteKit does not serve** (its static dir is `web/static/`). It only ever reached the internet because `web/Dockerfile` copied it into the container nginx's html root and `web/nginx.conf` had a `location = /install.sh` for it.

Prod left that topology behind at the host2 migration: `release.sh` builds with `npm run build` and runs adapter-node under systemd (`freehire-web@blue/green`), with the host's nginx proxying `location /` straight to it. No container, no container nginx — so the only thing that served `/install.sh` disappeared, silently.

Confirmed by probing prod: `llms.txt`, `openapi.yaml`, `favicon.svg` (all in `web/static/`) return 200; `install.sh` alone 404s.

## Fix

Move the script to `web/static/`, so one mechanism serves it in Docker and on bare metal, and drop the two now-dead Docker-only hooks. `web/public/` held nothing else, so the directory is gone. The stale comment in the script ("Vite copies web/public/ into the SPA build") was simply wrong and is corrected.

## Verification

Built the app and ran the real artifact:

- `pnpm run build` → `build/client/install.sh` present (1441 B).
- `node build/index.js` → `GET /install.sh` **200**, body **byte-identical** to the repo file, `sh -n` parses it.
- `llms.txt` still 200, so nothing else regressed.

Still in sync with the canonical copy in the freehire-cli repo (only the header self-reference differs, as before).

**Note:** `Content-Type` is no longer forced to `text/plain` — adapter-node sends no type for `.sh`. `curl -fsSL … | sh` is unaffected; a browser may download rather than render it.

Needs a web deploy to take effect.