### PR TITLE
feat(autofillagent): drive custom widgets, counting only a verified commit

### DIFF
--- a/internal/autofillagent/agent.go
+++ b/internal/autofillagent/agent.go
@@ -12,7 +12,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
+	"unicode"
 )
 
 // Field is one control as `read_form` reported it.
@@ -56,6 +58,15 @@ type Tools interface {
 // Planner maps the observed form onto the profile.
 type Planner interface {
 	Plan(ctx context.Context, fields []Field, profile Profile) ([]Fill, error)
+	// Choose picks one of a widget's options for the question it answers, or ""
+	// when the profile does not answer it.
+	//
+	// Separate from Plan because a custom widget renders no options until it is
+	// opened — measured on two live Greenhouse forms, not one of their 40
+	// comboboxes carries an option list while closed. So Plan cannot name a value
+	// it has never seen; it names which widgets are worth opening, and the choice
+	// is made here against the list actually read from the page.
+	Choose(ctx context.Context, question Field, options []string, profile Profile) (string, error)
 }
 
 // Run drives one autofill turn: read the form, plan, fill, report.
@@ -72,13 +83,36 @@ func Run(ctx context.Context, tools Tools, planner Planner, profile Profile) (Re
 	if err != nil {
 		return Report{}, err
 	}
-	fills := groundedIn(profile, planned)
+	typed, widgets := splitByKind(fields, planned)
 
-	outcomes, err := fillSimple(ctx, tools, fills)
+	outcomes, err := fillSimple(ctx, tools, groundedIn(profile, typed))
 	if err != nil {
 		return Report{}, err
 	}
-	return report(fields, outcomes), nil
+	driven, err := driveWidgets(ctx, tools, planner, profile, widgets)
+	if err != nil {
+		return Report{}, err
+	}
+	return report(fields, outcomes, driven), nil
+}
+
+// splitByKind separates the plan into values that can simply be written and the
+// widgets that have to be driven. Only widgets the plan named are driven: a form
+// with 27 of them would otherwise cost 27 needless round trips and 27 needless
+// model calls to discover the profile answers none of them.
+func splitByKind(fields []Field, planned []Fill) (typed []Fill, widgets []Field) {
+	byLabel := make(map[string]Field, len(fields))
+	for _, field := range fields {
+		byLabel[field.Label] = field
+	}
+	for _, fill := range planned {
+		if field, ok := byLabel[fill.Label]; ok && field.Combo {
+			widgets = append(widgets, field)
+			continue
+		}
+		typed = append(typed, fill)
+	}
+	return typed, widgets
 }
 
 func readForm(ctx context.Context, tools Tools) ([]Field, error) {
@@ -117,6 +151,113 @@ func fillSimple(ctx context.Context, tools Tools, fills []Fill) ([]outcome, erro
 	return result.Outcomes, nil
 }
 
+// Widget outcomes this package decides itself, alongside the statuses the
+// extension's primitives report (opened, no_option, verified, mismatch, …).
+const (
+	// The profile answers nothing the widget offers.
+	widgetUnanswered = "not_answered"
+	// The model's pick is not traceable to the profile.
+	widgetUngrounded = "not_grounded"
+	// The model's pick is not among the options the widget offers.
+	widgetNotOffered = "not_offered"
+	// Open, and offering nothing: a typeahead that fetches over the network.
+	widgetNoOptions = "no_options"
+)
+
+// driveWidgets works each named widget the way a person does — open it, read what
+// it offers, choose, commit, confirm — and reports what became of each. A step
+// that does not do what it should stops that widget rather than pressing on:
+// nothing is written into a widget whose state is not understood.
+func driveWidgets(ctx context.Context, tools Tools, planner Planner, profile Profile, questions []Field) (map[string]string, error) {
+	driven := make(map[string]string, len(questions))
+	for _, question := range questions {
+		status, err := driveWidget(ctx, tools, planner, profile, question)
+		if err != nil {
+			return nil, err
+		}
+		driven[question.Label] = status
+	}
+	return driven, nil
+}
+
+func driveWidget(ctx context.Context, tools Tools, planner Planner, profile Profile, question Field) (string, error) {
+	opened, err := comboStep(ctx, tools, "combobox.open", question.Label, "")
+	if err != nil {
+		return "", err
+	}
+	if opened.Status != "opened" {
+		return opened.Status, nil
+	}
+
+	offered, err := comboStep(ctx, tools, "combobox.options", question.Label, "")
+	if err != nil {
+		return "", err
+	}
+	if len(offered.Options) == 0 {
+		return widgetNoOptions, nil
+	}
+
+	choice, err := planner.Choose(ctx, question, offered.Options, profile)
+	if err != nil {
+		return "", err
+	}
+	if choice == "" {
+		return widgetUnanswered, nil
+	}
+	// The widget's own list is the authority: a pick that is merely close is not
+	// approximated, because committing the nearest option is how a question
+	// wanting "No" ends up holding "Norfolk Island".
+	if !offers(offered.Options, choice) {
+		return widgetNotOffered, nil
+	}
+	if !groundedValue(profile, choice) {
+		return widgetUngrounded, nil
+	}
+
+	selected, err := comboStep(ctx, tools, "combobox.select", question.Label, choice)
+	if err != nil {
+		return "", err
+	}
+	if selected.Status != "selected" {
+		return selected.Status, nil
+	}
+
+	// The commit is only real once the widget says so; `verified` is the single
+	// status the report is allowed to count as filled.
+	verified, err := comboStep(ctx, tools, "combobox.verify", question.Label, choice)
+	if err != nil {
+		return "", err
+	}
+	return verified.Status, nil
+}
+
+type comboReply struct {
+	Status    string   `json:"status"`
+	Options   []string `json:"options"`
+	Committed string   `json:"committed"`
+}
+
+func comboStep(ctx context.Context, tools Tools, tool, label, value string) (comboReply, error) {
+	raw, err := tools.Call(ctx, tool, map[string]any{"label": label, "value": value})
+	if err != nil {
+		return comboReply{}, err
+	}
+	var reply comboReply
+	if err := json.Unmarshal(raw, &reply); err != nil {
+		return comboReply{}, fmt.Errorf("%s returned an unreadable reply: %w", tool, err)
+	}
+	return reply, nil
+}
+
+func offers(options []string, choice string) bool {
+	for _, option := range options {
+		if normalize(option) == normalize(choice) {
+			return true
+		}
+	}
+	return false
+}
+
 // groundedIn drops any planned value that cannot be traced back to the profile.
 // A model asked to fill a form will happily supply a plausible answer to a
 // question the profile never answered; this is what keeps "no fabricated values"
@@ -124,39 +265,60 @@ func fillSimple(ctx context.Context, tools Tools, fills []Fill) ([]outcome, erro
 // grounded when it appears within one of the profile's own values (so "Berlin"
 // from "Berlin, Germany" survives) or contains one.
 func groundedIn(profile Profile, fills []Fill) []Fill {
-	known := make([]string, 0, len(profile))
-	for _, value := range profile {
-		if v := normalize(value); v != "" {
-			known = append(known, v)
-		}
-	}
-
 	kept := make([]Fill, 0, len(fills))
 	for _, fill := range fills {
-		if grounded(normalize(fill.Value), known) {
+		if groundedValue(profile, fill.Value) {
 			kept = append(kept, fill)
 		}
 	}
 	return kept
 }
 
-func grounded(value string, known []string) bool {
-	if value == "" {
+// groundedValue reports whether the profile actually supports this answer.
+//
+// Matching is on whole words, in either direction, so "Germany" is supported by
+// "Berlin, Germany" and "Berlin" is supported by it too. Comparing raw substrings
+// instead would be far too generous once the answer is short: "no" sits inside
+// "norway", so a candidate living in Oslo would have the answer "No" grounded for
+// any question at all — and a widget's options are routinely this short.
+func groundedValue(profile Profile, value string) bool {
+	want := words(value)
+	if len(want) == 0 {
 		return false
 	}
-	for _, k := range known {
-		if strings.Contains(k, value) || strings.Contains(value, k) {
+	for _, known := range profile {
+		have := words(known)
+		if runOf(have, want) || runOf(want, have) {
 			return true
 		}
 	}
 	return false
 }
 
+// runOf reports whether needle appears in haystack as a consecutive run of words.
+func runOf(haystack, needle []string) bool {
+	if len(needle) == 0 || len(needle) > len(haystack) {
+		return false
+	}
+	for start := 0; start+len(needle) <= len(haystack); start++ {
+		if slices.Equal(haystack[start:start+len(needle)], needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func words(s string) []string {
+	return strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+}
+
 func normalize(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
 }
 
-func report(fields []Field, outcomes []outcome) Report {
+func report(fields []Field, outcomes []outcome, driven map[string]string) Report {
 	byLabel := make(map[string]string, len(outcomes))
 	for _, o := range outcomes {
 		byLabel[o.Label] = o.Status
@@ -173,15 +335,12 @@ func report(fields []Field, outcomes []outcome) Report {
 		if strings.TrimSpace(field.Label) == "" {
 			continue
 		}
-		switch {
-		case byLabel[field.Label] == "filled":
+		switch place(field, byLabel[field.Label], driven[field.Label]) {
+		case wasFilled:
 			rep.Filled = append(rep.Filled, field.Label)
-		case field.Combo || byLabel[field.Label] == "deferred_combobox":
+		case notFillableYet:
 			rep.Deferred = append(rep.Deferred, field.Label)
-		default:
-			// Never planned, or planned and the browser could not write it (no
-			// matching option, the control vanished) — either way the user still
-			// has to fill it themselves.
+		case leftForUser:
 			if field.Required {
 				rep.Unmapped = append(rep.Unmapped, field.Label)
 			} else {
@@ -191,4 +350,46 @@ func report(fields []Field, outcomes []outcome) Report {
 	}
 	rep.Unmapped = append(rep.Unmapped, optional...)
 	return rep
+}
+
+// placement is the three-way distinction the report makes: what the agent filled,
+// what it cannot fill yet, and what is left for the user to answer.
+type placement int
+
+const (
+	wasFilled placement = iota
+	notFillableYet
+	leftForUser
+)
+
+// place decides where one field belongs. `written` is what fill_simple reported
+// for it, `driven` what the widget loop reported.
+//
+// Only a verified commit counts as filled — an unverified write is a failure and
+// never a fill, or the user is told a field is done while it is still empty.
+func place(field Field, written, driven string) placement {
+	if written == "filled" {
+		return wasFilled
+	}
+	if field.Combo {
+		switch driven {
+		case "verified":
+			return wasFilled
+		case widgetUnanswered, widgetUngrounded, widgetNotOffered:
+			// The widget works; it is the answer that is missing.
+			return leftForUser
+		default:
+			// Never targeted, would not open, committed something else, or offers
+			// its options only over the network.
+			return notFillableYet
+		}
+	}
+	// A control the form did not present as a widget but the browser found to be
+	// one — the page re-rendered between reading it and writing to it.
+	if written == "deferred_combobox" {
+		return notFillableYet
+	}
+	// Never planned, or planned and the browser could not write it (no matching
+	// option, the control vanished) — either way the user still has to fill it.
+	return leftForUser
 }

--- a/internal/autofillagent/agent_test.go
+++ b/internal/autofillagent/agent_test.go
@@ -58,6 +58,12 @@ func (p plannerFunc) Plan(_ context.Context, f []autofillagent.Field, pr autofil
 	return p(f, pr)
 }
 
+// None of the forms in this file has a widget the plan targets, so reaching
+// Choose means the loop drove something it was not asked to.
+func (p plannerFunc) Choose(context.Context, autofillagent.Field, []string, autofillagent.Profile) (string, error) {
+	return "", errors.New("Choose was called for a form with no widget targets")
+}
+
 func profile() autofillagent.Profile {
 	return autofillagent.Profile{
 		"full_name": "Ilya Strelov",

--- a/internal/autofillagent/planner.go
+++ b/internal/autofillagent/planner.go
@@ -19,14 +19,40 @@ custom-widget combobox) and the candidate's profile. Return the values to write.
 Rules:
 - Only use values present in the profile. If a field has no basis in the profile,
   leave it out. Never invent, guess, or write a placeholder.
-- Skip fields where "combo" is true: they are custom dropdowns that cannot be
-  filled yet.
+- Where "combo" is true the field is a custom dropdown whose options are not
+  visible yet. Include it, with an empty value, only if you expect the profile to
+  answer it; the real options will be read from the page and you will be asked to
+  pick one. Leave it out entirely if the profile plainly cannot answer it.
 - For a native select, the value must be one of its listed options exactly.
-- For a checkbox, the value is "true" or "false".
+- For a checkbox, the value is "true" or "false". A field carrying "options" is a
+  group of checkboxes: the value is one of those options, or several separated by
+  commas.
 - A field may take part of a profile value (e.g. the city out of a location).
 - Address each field by its label, copied exactly as given.
 
 Respond with JSON: {"fills":[{"label":"...","value":"..."}]}`
+
+// choosePrompt is asked once per widget, with the options the page actually
+// offered. Kept separate from the planning prompt because the question is
+// narrower — one question, a closed list — and a narrower question is answered
+// more reliably. "Answer nothing" is spelled out as the expected outcome so that
+// declining does not read as failure.
+const choosePrompt = `You are answering ONE question on a job-application form by
+picking from the options it offers.
+
+You are given the question, the exact options available, and the candidate's
+profile. Pick the single option the profile supports.
+
+Rules:
+- Return an option copied exactly from the list. Never return anything else.
+- If the profile does not answer the question, return an empty choice. Most
+  questions about visa sponsorship, notice periods, salary or willingness to
+  relocate are NOT answered by a profile — declining is the correct answer.
+- A location option is supported by the candidate's location (a profile of
+  "Berlin, Germany" supports the option "Germany").
+- Never infer a claim the profile does not state.
+
+Respond with JSON: {"choice":"..."}`
 
 // Planner backed by the LLM. Its client is nil when the LLM is unconfigured;
 // Plan then reports the feature is off rather than silently filling nothing.
@@ -47,6 +73,36 @@ func (p LLMPlanner) Plan(ctx context.Context, fields []Field, profile Profile) (
 		return nil, err
 	}
 	return parsePlan(raw)
+}
+
+// Choose picks one of the widget's real options. An unreadable answer, or one
+// naming something outside the list, comes back as "" — the caller then reports
+// the question as unanswered, which leaves it for the user rather than committing
+// a guess.
+func (p LLMPlanner) Choose(ctx context.Context, question Field, options []string, profile Profile) (string, error) {
+	if p.Client == nil {
+		return "", fmt.Errorf("agent autofill is unavailable: no language model is configured")
+	}
+	user, err := json.Marshal(map[string]any{
+		"question": question.Label,
+		"required": question.Required,
+		"options":  options,
+		"profile":  profile,
+	})
+	if err != nil {
+		return "", err
+	}
+	raw, err := p.Client.GenerateJSON(ctx, choosePrompt, string(user))
+	if err != nil {
+		return "", err
+	}
+	var answer struct {
+		Choice string `json:"choice"`
+	}
+	if err := json.Unmarshal([]byte(raw), &answer); err != nil {
+		return "", fmt.Errorf("the model's choice is not valid JSON: %w", err)
+	}
+	return answer.Choice, nil
 }
 
 // parsePlan reads the model's answer. Entries without a label are dropped rather

--- a/internal/autofillagent/widget_test.go
+++ b/internal/autofillagent/widget_test.go
@@ -1,0 +1,344 @@
+package autofillagent_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/autofillagent"
+)
+
+// fakeWidgets answers read_form plus the four combobox primitives, recording the
+// tool calls in order so a test can assert the widget was *driven* rather than
+// written into.
+type fakeWidgets struct {
+	fields  []autofillagent.Field
+	offers  map[string][]string // label -> the options the widget reveals once open
+	opens   map[string]string   // label -> combobox.open status, default "opened"
+	commits map[string]string   // label -> what the widget commits, default the selected option
+
+	calls     []string
+	selected  map[string]string
+	committed map[string]string
+}
+
+func (f *fakeWidgets) Call(_ context.Context, tool string, args any) (json.RawMessage, error) {
+	label, value := readArgs(args)
+	f.calls = append(f.calls, tool+" "+label)
+
+	switch tool {
+	case "read_form":
+		return json.Marshal(map[string]any{"fields": f.fields})
+
+	case "fill_simple":
+		return json.Marshal(map[string]any{"outcomes": fillOutcomes(args)})
+
+	case "combobox.open":
+		status := f.opens[label]
+		if status == "" {
+			status = "opened"
+		}
+		return json.Marshal(map[string]string{"status": status})
+
+	case "combobox.options":
+		offered, ok := f.offers[label]
+		if !ok {
+			return json.Marshal(map[string]any{"status": "not_found"})
+		}
+		return json.Marshal(map[string]any{"status": "open", "options": offered})
+
+	case "combobox.select":
+		if f.selected == nil {
+			f.selected = map[string]string{}
+			f.committed = map[string]string{}
+		}
+		f.selected[label] = value
+		f.committed[label] = value
+		if forced, ok := f.commits[label]; ok {
+			f.committed[label] = forced
+		}
+		return json.Marshal(map[string]string{"status": "selected"})
+
+	case "combobox.verify":
+		got := f.committed[label]
+		if got == "" {
+			return json.Marshal(map[string]any{"status": "empty", "committed": ""})
+		}
+		status := "mismatch"
+		if got == value {
+			status = "verified"
+		}
+		return json.Marshal(map[string]any{"status": status, "committed": got})
+
+	default:
+		return nil, errors.New("unknown tool: " + tool)
+	}
+}
+
+func readArgs(args any) (label, value string) {
+	raw, _ := json.Marshal(args)
+	var call struct {
+		Label string `json:"label"`
+		Value string `json:"value"`
+	}
+	_ = json.Unmarshal(raw, &call)
+	return call.Label, call.Value
+}
+
+func fillOutcomes(args any) []map[string]string {
+	raw, _ := json.Marshal(args)
+	var call struct {
+		Fills []autofillagent.Fill `json:"fills"`
+	}
+	_ = json.Unmarshal(raw, &call)
+	out := make([]map[string]string, 0, len(call.Fills))
+	for _, fill := range call.Fills {
+		out = append(out, map[string]string{"label": fill.Label, "status": "filled"})
+	}
+	return out
+}
+
+// widgetPlanner plans the given fills and answers Choose from a fixed table.
+type widgetPlanner struct {
+	fills   []autofillagent.Fill
+	choices map[string]string
+	seen    map[string][]string // what options Choose was shown, per question
+}
+
+func (p *widgetPlanner) Plan(context.Context, []autofillagent.Field, autofillagent.Profile) ([]autofillagent.Fill, error) {
+	return p.fills, nil
+}
+
+func (p *widgetPlanner) Choose(_ context.Context, question autofillagent.Field, options []string, _ autofillagent.Profile) (string, error) {
+	if p.seen == nil {
+		p.seen = map[string][]string{}
+	}
+	p.seen[question.Label] = options
+	return p.choices[question.Label], nil
+}
+
+func TestRunDrivesAWidgetTheProfileAnswers(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{{Label: "Country", Type: "text", Combo: true}},
+		offers: map[string][]string{"Country": {"France", "Germany", "Poland"}},
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "Country"}},
+		choices: map[string]string{"Country": "Germany"},
+	}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !contains(rep.Filled, "Country") {
+		t.Fatalf("filled = %v, want the widget", rep.Filled)
+	}
+	// The widget was driven, not written at: the option list was read before a
+	// choice was made, and the commit was verified afterwards.
+	want := []string{"read_form ", "combobox.open Country", "combobox.options Country", "combobox.select Country", "combobox.verify Country"}
+	if len(tools.calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", tools.calls, want)
+	}
+	for i, call := range want {
+		if tools.calls[i] != call {
+			t.Fatalf("calls = %v, want %v", tools.calls, want)
+		}
+	}
+	if got := planner.seen["Country"]; len(got) != 3 {
+		t.Fatalf("Choose saw %v, want the widget's real options", got)
+	}
+}
+
+func TestRunDoesNotCountAnUnverifiedWidgetWriteAsFilled(t *testing.T) {
+	tools := &fakeWidgets{
+		fields:  []autofillagent.Field{{Label: "Country", Type: "text", Combo: true, Required: true}},
+		offers:  map[string][]string{"Country": {"Germany", "Norfolk Island"}},
+		commits: map[string]string{"Country": "Norfolk Island"}, // the widget commits something else
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "Country"}},
+		choices: map[string]string{"Country": "Germany"},
+	}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if contains(rep.Filled, "Country") {
+		t.Fatal("a widget that committed the wrong value was reported as filled")
+	}
+	if !contains(rep.Deferred, "Country") {
+		t.Fatalf("deferred = %v, want the widget whose write did not verify", rep.Deferred)
+	}
+}
+
+func TestRunReportsAWidgetThatWillNotOpen(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{{Label: "Country", Type: "text", Combo: true}},
+		offers: map[string][]string{"Country": {"Germany"}},
+		opens:  map[string]string{"Country": "did_not_open"},
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "Country"}},
+		choices: map[string]string{"Country": "Germany"},
+	}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(tools.selected) != 0 {
+		t.Fatalf("selected %v into a widget that never opened", tools.selected)
+	}
+	if !contains(rep.Deferred, "Country") {
+		t.Fatalf("deferred = %v, want the undrivable widget", rep.Deferred)
+	}
+}
+
+func TestRunLeavesAWidgetTheProfileDoesNotAnswer(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{{Label: "Do you require sponsorship?", Type: "text", Combo: true, Required: true}},
+		offers: map[string][]string{"Do you require sponsorship?": {"Yes", "No"}},
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "Do you require sponsorship?"}},
+		choices: map[string]string{}, // nothing in the profile answers it
+	}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(tools.selected) != 0 {
+		t.Fatalf("selected %v for a question the profile does not answer", tools.selected)
+	}
+	// Left for the user to answer, not reported as a widget we cannot drive.
+	if !contains(rep.Unmapped, "Do you require sponsorship?") {
+		t.Fatalf("unmapped = %v, want the unanswered question", rep.Unmapped)
+	}
+}
+
+// The chosen option goes through the same grounding filter as a typed value: a
+// model asked to pick from a list will happily pick a plausible answer to a
+// question the profile never addressed.
+func TestRunDropsAChosenOptionThatTheProfileDoesNotSupport(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{{Label: "Visa status", Type: "text", Combo: true}},
+		offers: map[string][]string{"Visa status": {"Citizen", "Permanent resident", "Requires sponsorship"}},
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "Visa status"}},
+		choices: map[string]string{"Visa status": "Requires sponsorship"},
+	}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(tools.selected) != 0 {
+		t.Fatalf("selected %v, a claim the profile does not make", tools.selected)
+	}
+	if !contains(rep.Unmapped, "Visa status") {
+		t.Fatalf("unmapped = %v, want the ungrounded question", rep.Unmapped)
+	}
+}
+
+// Grounding by raw substring is far too loose for a short option: "no" sits
+// inside "norway", so a profile mentioning Oslo would otherwise ground the answer
+// "No" to a question about visa sponsorship — the very class of wrong answer this
+// whole capability exists to prevent.
+func TestRunDoesNotGroundAShortOptionInAnUnrelatedProfileWord(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{{Label: "Are you authorized to work?", Type: "text", Combo: true}},
+		offers: map[string][]string{"Are you authorized to work?": {"Yes", "No"}},
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "Are you authorized to work?"}},
+		choices: map[string]string{"Are you authorized to work?": "No"},
+	}
+	norway := autofillagent.Profile{"full_name": "Ilya Strelov", "location": "Oslo, Norway"}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, norway)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(tools.selected) != 0 {
+		t.Fatalf("selected %v — \"No\" is not answered by living in Norway", tools.selected)
+	}
+	if !contains(rep.Unmapped, "Are you authorized to work?") {
+		t.Fatalf("unmapped = %v, want the question handed back", rep.Unmapped)
+	}
+}
+
+// The widget's own list is the authority on what can be picked. A model that
+// returns something close but absent must not have it approximated.
+func TestRunNeverSelectsAnOptionTheWidgetDoesNotOffer(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{{Label: "Country", Type: "text", Combo: true}},
+		offers: map[string][]string{"Country": {"Germany", "Poland"}},
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "Country"}},
+		choices: map[string]string{"Country": "Berlin, Germany"}, // grounded, but not on offer
+	}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(tools.selected) != 0 {
+		t.Fatalf("selected %v, which the widget never offered", tools.selected)
+	}
+	if contains(rep.Filled, "Country") {
+		t.Fatal("a widget nothing was written into was reported as filled")
+	}
+}
+
+func TestRunLeavesWidgetsTheePlanDidNotTargetAlone(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{
+			{Label: "Country", Type: "text", Combo: true},
+			{Label: "Degree", Type: "text", Combo: true},
+		},
+		offers: map[string][]string{"Country": {"Germany"}, "Degree": {"BSc"}},
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "Country"}},
+		choices: map[string]string{"Country": "Germany"},
+	}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, call := range tools.calls {
+		if call == "combobox.open Degree" {
+			t.Fatal("opened a widget the plan never targeted — 27 widgets would be 27 needless round trips")
+		}
+	}
+	if !contains(rep.Deferred, "Degree") && !contains(rep.Unmapped, "Degree") {
+		t.Fatalf("Degree fell out of the report entirely: %+v", rep)
+	}
+}
+
+// A grouped question arrives from read_form as one field carrying its options, so
+// the report names the question rather than each of its 29 countries.
+func TestRunNamesAGroupedQuestionOnceInTheReport(t *testing.T) {
+	tools := &fakeWidgets{fields: []autofillagent.Field{{
+		Label:    "Which countries do you anticipate working in?",
+		Type:     "checkbox",
+		Required: true,
+		Options:  []string{"Australia", "Belgium", "Germany", "Poland"},
+	}}}
+	planner := &widgetPlanner{}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(rep.Unmapped) != 1 || rep.Unmapped[0] != "Which countries do you anticipate working in?" {
+		t.Fatalf("unmapped = %v, want the question named once", rep.Unmapped)
+	}
+}


### PR DESCRIPTION
Task group 4 of the `combobox-actuation` change (tracked in freehire-extension's openspec, per the precedent set by `agent-autofill-wire`).

The agent read a form, planned, and wrote text. Every custom-widget dropdown was skipped — the planning prompt said so outright — which on the two Greenhouse forms we measure against is most of the substantive questions: country, work authorization, visa sponsorship, education.

It now drives them: open, read what the widget actually offers, choose, commit, confirm. Only `verified` counts as filled.

**Choosing had to become a second model call.** No widget renders its options until opened — measured live, not one of the two forms' 40 comboboxes carries a list while closed — so the plan cannot name a value it has never seen. It names which widgets are worth opening; the choice is made against the list read from the page. That also bounds the cost: a 27-widget form does not cost 27 model calls for questions the profile cannot answer.

**Grounding had to be tightened, and this is the part worth reviewing hardest.** Reusing the existing filter unchanged was wrong: it compared raw substrings both ways, and a widget's options are short — `no` sits inside `norway`, so a candidate living in Oslo would have "No" grounded for *any* question, including visa sponsorship. That is this change's own failure mode one layer down. Grounding now matches whole words in both directions: still accepts "Germany" from "Berlin, Germany", no longer accepts "No" from Norway.

## Verification

- `go build ./internal/... ./cmd/server`, `go vet`, and `go test` on `autofillagent` + `handler` + `browsertools` all green, after merging current `main` in.
- No migration: this is pure logic, the schema is untouched.
- No new dependency, no new permission, no relay change — the relay forwards frames verbatim.

## Not done

The code-review pass over this was cancelled before it reported, so unlike the extension side this carries no reviewed-clean stamp. The riskiest area is `place()` and `driveWidget()` against statuses they do not name explicitly (`ambiguous`, `not_found`), and whether one dead widget should abort the whole run as it currently does.