### PR TITLE
fix(skilltag): drop dictionary terms that match posting boilerplate

### DIFF
--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -849,6 +849,17 @@ var phraseAliases = []phraseAlias{
 	{"e commerce", "ecommerce"},
 	// IT-company role skills (expand-role-taxonomy) — multi-word phrases only, so they
 	// stay precision-safe (no false match inside a larger word). Seed set; expand later.
+	//
+	// Two kinds of term are deliberately absent, because a job description is not only
+	// its requirements:
+	//   - Boilerplate sections. The pay-transparency block ("Compensation and
+	//     Benefits"), the GDPR notice ("Data Privacy Notice"), the ATS footer
+	//     ("Powered by Greenhouse", "Apply via Lever") and the culture blurb
+	//     ("employee engagement", "due diligence") appear for EVERY role, so matching
+	//     them tags the whole corpus instead of describing the job.
+	//   - ATS product names whose bare token is an English word (lever, workday) —
+	//     "a key lever", "a flexible workday". Same doctrine as burp/druid above: such
+	//     a name may only return through a qualifying phrase, never as a bare token.
 	// recruiting
 	{"boolean search", "boolean-search"},
 	{"talent sourcing", "talent-sourcing"},
@@ -857,16 +868,14 @@ var phraseAliases = []phraseAlias{
 	{"employer branding", "employer-branding"},
 	{"full-cycle recruiting", "full-cycle-recruiting"}, {"full cycle recruiting", "full-cycle-recruiting"},
 	{"linkedin recruiter", "linkedin-recruiter"},
-	{"greenhouse", "greenhouse"}, {"lever", "lever"}, {"smartrecruiters", "smartrecruiters"},
+	{"smartrecruiters", "smartrecruiters"},
 	// hr / people
 	{"employee relations", "employee-relations"},
 	{"performance management", "performance-management"},
 	{"talent management", "talent-management"},
 	{"succession planning", "succession-planning"},
-	{"compensation and benefits", "compensation-and-benefits"},
 	{"people analytics", "people-analytics"},
-	{"employee engagement", "employee-engagement"},
-	{"workday", "workday"}, {"bamboohr", "bamboohr"}, {"successfactors", "successfactors"},
+	{"bamboohr", "bamboohr"}, {"successfactors", "successfactors"},
 	// finance
 	{"financial modeling", "financial-modeling"},
 	{"revenue recognition", "revenue-recognition"},
@@ -879,10 +888,8 @@ var phraseAliases = []phraseAlias{
 	{"contract negotiation", "contract-negotiation"},
 	{"contract drafting", "contract-drafting"},
 	{"contract lifecycle management", "contract-lifecycle-management"},
-	{"due diligence", "due-diligence"},
 	{"legal research", "legal-research"},
 	{"regulatory compliance", "regulatory-compliance"},
-	{"data privacy", "data-privacy"},
 	// operations
 	{"process improvement", "process-improvement"},
 	{"vendor management", "vendor-management"},

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -63,12 +63,40 @@ func TestParse_ITCompanyRoleSkills(t *testing.T) {
 		in   string
 		want []string
 	}{
-		{"recruiting", "Sourcing with boolean search and employer branding on Greenhouse", []string{"boolean-search", "employer-branding", "greenhouse"}},
+		{"recruiting", "Sourcing with boolean search and employer branding", []string{"boolean-search", "employer-branding"}},
 		{"finance", "Own financial modeling and revenue recognition in NetSuite", []string{"financial-modeling", "netsuite", "revenue-recognition"}},
 		{"business analysis", "Requirements gathering, process modeling and user stories", []string{"process-modeling", "requirements-gathering", "user-stories"}},
 		{"customer success", "Drive customer onboarding and churn prevention via Gainsight", []string{"churn-prevention", "customer-onboarding", "gainsight"}},
 		{"technical writing", "API documentation with a docs-as-code workflow", []string{"api", "api-documentation", "docs-as-code"}},
 		{"unknown emits nothing", "great communicator and team player", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Parse(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Parse(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Boilerplate sections — the pay-transparency block, the GDPR notice, the ATS
+// footer — appear in postings for EVERY role, so a dictionary term that matches
+// them tags the whole corpus instead of describing the job (an ML Platform
+// Engineer came back with "compensation-and-benefits"). Such a term is not a
+// requirement signal at all, so it is out of the vocabulary entirely; the same
+// applies to an ATS name whose bare token doubles as an English word
+// ("a key lever", "a flexible workday").
+func TestParse_BoilerplateSectionsAreNotSkills(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"pay transparency block", "Compensation and Benefits: we offer a competitive salary and equity.", nil},
+		{"privacy notice", "Data Privacy Notice: we process your application data as described here.", nil},
+		{"ats footer", "Powered by Greenhouse. Apply via Lever.", nil},
+		{"culture blurb", "We invest in employee engagement and do our due diligence.", nil},
+		{"boilerplate does not pollute a real stack", "We use Python and Kafka. A flexible workday, applications via Greenhouse.", []string{"kafka", "python"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of `6afe263c` from `fix/skilltag-boilerplate-terms` onto current `main`. The original branch had drifted 59 commits behind and a PR from it would have reverted account-deletion, pruning and the security hardening — only this commit was worth keeping.

## Why

An ML Platform Engineer came back tagged "compensation-and-benefits". The term is real for an HR role, but it does not come from the requirements — it comes from the pay-transparency block that US postings must carry. A dictionary term that matches boilerplate tags the whole corpus instead of describing the job.

## What

Removed from the role-taxonomy batch: the pay-transparency block ("compensation and benefits"), the GDPR notice ("data privacy"), the culture blurb ("employee engagement", "due diligence"), and the ATS names greenhouse/lever/workday — whose bare token is also an English word ("a key lever", "a flexible workday") and whose product mention sits in the apply footer of every posting we crawl.

`workday` was also a contradiction inside the file: the `wordAliases` note already records that "workday" is withheld because it collides with "a work day", while the phrase entry matched exactly the same way (single token + word boundary).

The header comment now states the rule, so the next mined batch does not reintroduce them.

## Note

Reaching existing rows needs `cmd/backfill-derive` + `cmd/reindex` — not part of this PR.

`go test ./internal/skilltag/...` passes.