### PR TITLE
feat(assistant): BYOK — setup instructions and a where-it-runs badge

### DIFF
--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -14,7 +14,15 @@
     RefreshCw,
   } from '@lucide/svelte';
   import { currentUser } from '$lib/auth.svelte';
-  import { createSession, listSessions, deleteSession, assistantWsUrl } from '$lib/assistant/api';
+  import {
+    createSession,
+    listSessions,
+    deleteSession,
+    assistantWsUrl,
+    NoDeviceError,
+  } from '$lib/assistant/api';
+  import RunnerSetup from '$lib/assistant/RunnerSetup.svelte';
+  import RunnerBadge from '$lib/assistant/RunnerBadge.svelte';
   import { RoyClient } from '$lib/assistant/client';
   import { initChat, reduceTurnEvent, type ChatState } from '$lib/assistant/chat';
   import { parseJobSegments } from '$lib/assistant/unfurl';
@@ -91,6 +99,9 @@
 
   let phase = $state<Phase>('connecting');
   let error = $state<string | null>(null);
+  // Distinct from `error`: the assistant runs on the user's machine and no
+  // runner is connected. A setup step, not a failure, so it gets instructions.
+  let needsRunner = $state(false);
   // Set when the socket drops after we were live AND auto-reconnect has given up — the composer
   // disables and offers a manual Reconnect button (never a full page reload).
   let connectionLost = $state(false);
@@ -445,6 +456,10 @@
     try {
       await createAndOpen();
     } catch (err) {
+      if (err instanceof NoDeviceError) {
+        needsRunner = true;
+        return;
+      }
       error = err instanceof Error ? err.message : 'Could not start a new chat.';
     }
   }
@@ -645,6 +660,10 @@
   </div>
 {/if}
 
+{#if needsRunner}
+  <RunnerSetup />
+{/if}
+
 {#if !allowed}
   <div class="m-3 rounded-xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
     The agent is a limited beta and isn't available for your account yet.
@@ -719,6 +738,9 @@
               <Plus class="size-4" />New chat
             </button>
           {/if}
+          <!-- Where the assistant is running. Visible before a message is sent,
+               so "my machine or theirs?" is never a guess. -->
+          <div class="ml-auto"><RunnerBadge /></div>
         </div>
       {/if}
       <!-- Mobile session switcher -->

--- a/web/src/lib/assistant/RunnerBadge.svelte
+++ b/web/src/lib/assistant/RunnerBadge.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { Laptop, Server, CloudOff } from '@lucide/svelte';
+  import { runnerStatus, type RunnerStatus } from '$lib/assistant/api';
+
+  /** Whether this machine is running the assistant's harness.
+   *
+   *  Polled rather than pushed: the runner connects to the agent backend, not
+   *  to this page, so there is nothing to subscribe to. Ten seconds is fast
+   *  enough to notice a runner starting while someone reads the instructions,
+   *  and cheap enough to leave running. */
+  let status = $state<RunnerStatus | null>(null);
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  async function refresh() {
+    try {
+      status = await runnerStatus();
+    } catch {
+      // Leave the last known state rather than flickering to "disconnected"
+      // on a transient failure.
+    }
+  }
+
+  onMount(() => {
+    void refresh();
+    timer = setInterval(refresh, 10_000);
+  });
+  onDestroy(() => clearInterval(timer));
+</script>
+
+{#if status}
+  {#if status.connected}
+    <span
+      class="inline-flex items-center gap-1.5 rounded-full border border-green-600/30 bg-green-600/10 px-2 py-0.5 text-xs text-green-700 dark:text-green-400"
+      title={`Running on your machine (${status.devices.join(', ')})`}
+    >
+      <Laptop class="size-3.5" />
+      Your machine
+    </span>
+  {:else if status.required}
+    <span
+      class="inline-flex items-center gap-1.5 rounded-full border border-amber-600/30 bg-amber-600/10 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-400"
+      title="Start `freehire runner` to use the assistant"
+    >
+      <CloudOff class="size-3.5" />
+      No machine connected
+    </span>
+  {:else}
+    <span
+      class="inline-flex items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground"
+      title="Running on freehire's servers. Start `freehire runner` to use your own Claude."
+    >
+      <Server class="size-3.5" />
+      Our servers
+    </span>
+  {/if}
+{/if}

--- a/web/src/lib/assistant/RunnerSetup.svelte
+++ b/web/src/lib/assistant/RunnerSetup.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import { Copy, Check, Terminal } from '@lucide/svelte';
+
+  /** Shown when the assistant has nowhere to run: it executes on the user's own
+   *  machine, and no runner is connected. This is a setup step, not a failure,
+   *  so it reads as instructions rather than an error. */
+  let { compact = false }: { compact?: boolean } = $props();
+
+  const steps = [
+    { label: 'Install the CLI', cmd: 'curl -fsSL https://freehire.me/install.sh | sh' },
+    { label: 'Sign in', cmd: 'freehire auth login' },
+    { label: 'Install the coding agent', cmd: 'npm i -g @zed-industries/claude-code-acp' },
+    { label: 'Log in to Claude', cmd: 'claude' },
+    { label: 'Connect this machine', cmd: 'freehire runner' },
+  ];
+
+  let copied = $state<number | null>(null);
+
+  async function copy(i: number, cmd: string) {
+    try {
+      await navigator.clipboard.writeText(cmd);
+      copied = i;
+      setTimeout(() => (copied === i ? (copied = null) : null), 1500);
+    } catch {
+      // Clipboard can be blocked; the command is visible and selectable anyway.
+    }
+  }
+</script>
+
+<div class="m-3 rounded-xl border border-border bg-card p-6">
+  <div class="flex items-start gap-3">
+    <Terminal class="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+    <div class="min-w-0">
+      <h2 class="text-base font-medium">Run the assistant on your own machine</h2>
+      <p class="mt-1 text-sm text-muted-foreground">
+        The assistant works with your own Claude subscription. It runs on your computer, so your
+        Claude credentials never reach our servers — and the work is billed to your account, not
+        ours.
+      </p>
+    </div>
+  </div>
+
+  <ol class="mt-5 space-y-3">
+    {#each steps as step, i (step.cmd)}
+      <li class="flex items-start gap-3">
+        <span
+          class="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground"
+        >
+          {i + 1}
+        </span>
+        <div class="min-w-0 flex-1">
+          <div class="text-sm">{step.label}</div>
+          <div class="mt-1 flex items-center gap-2">
+            <code
+              class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded-md bg-muted px-2.5 py-1.5 font-mono text-xs"
+              >{step.cmd}</code
+            >
+            <button
+              type="button"
+              onclick={() => copy(i, step.cmd)}
+              aria-label={`Copy: ${step.cmd}`}
+              class="inline-flex size-7 shrink-0 items-center justify-center rounded-md border border-border transition-colors hover:bg-muted"
+            >
+              {#if copied === i}
+                <Check class="size-3.5 text-green-600" />
+              {:else}
+                <Copy class="size-3.5" />
+              {/if}
+            </button>
+          </div>
+        </div>
+      </li>
+    {/each}
+  </ol>
+
+  {#if !compact}
+    <p class="mt-5 border-t border-border pt-4 text-xs text-muted-foreground">
+      Keep the last command running while you use the assistant — it is idle until you send a
+      message. Stop it with Ctrl-C when you are done. Your chats, CVs and applications stay here;
+      only the AI runs on your machine.
+    </p>
+  {/if}
+</div>

--- a/web/src/lib/assistant/api.ts
+++ b/web/src/lib/assistant/api.ts
@@ -34,6 +34,17 @@ export interface TailoringSession {
 /** Create the assistant session. For a normal chat the client sends an empty body and the
  *  backend decides everything (harness, persona, sandbox, scope). Passing `tailoring` seeds
  *  a CV-tailoring session instead (persona + FREEHIRE_TOKEN); the backend still owns the rest. */
+/** Thrown when the assistant runs on the user's own machine and no runner is
+ *  connected. Carried as its own type so the UI can show setup instructions
+ *  instead of an error banner — this is a "you have not finished setting up"
+ *  state, not a failure. */
+export class NoDeviceError extends Error {
+  constructor() {
+    super('no runner connected');
+    this.name = 'NoDeviceError';
+  }
+}
+
 export async function createSession(tailoring?: TailoringSession): Promise<string> {
   const res = await fetch(`${BASE}/sessions`, {
     method: 'POST',
@@ -41,10 +52,32 @@ export async function createSession(tailoring?: TailoringSession): Promise<strin
     credentials: 'include',
     body: JSON.stringify(tailoring ? { tailoring } : {}),
   });
+  if (res.status === 409) {
+    const body = await res.text();
+    if (body.includes('no_device')) throw new NoDeviceError();
+  }
   if (!res.ok) throw new Error(`could not create session (${res.status})`);
   const body = (await res.json()) as { session_id?: string };
   if (!body?.session_id) throw new Error('session response missing session_id');
   return body.session_id;
+}
+
+export type RunnerStatus = {
+  /** Whether the caller has a machine connected right now. */
+  connected: boolean;
+  /** Their device ids. */
+  devices: string[];
+  /** Whether sessions are required to run on the caller's own machine. */
+  required: boolean;
+};
+
+/** Whether the caller's own machine is connected and running the harness.
+ *  Polled by the UI so the state is visible before a message is sent, not
+ *  after one fails. */
+export async function runnerStatus(): Promise<RunnerStatus> {
+  const res = await fetch(`${BASE}/runners`, { credentials: 'include' });
+  if (!res.ok) throw new Error(`could not read runner status (${res.status})`);
+  return (await res.json()) as RunnerStatus;
 }
 
 /** List the caller's held sessions from the agent backend. The list is

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -14,7 +14,8 @@
   import { page } from '$app/state';
   import { ZoomIn, ZoomOut, Download, Menu } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
-  import { createSession } from '$lib/assistant/api';
+  import { createSession, NoDeviceError } from '$lib/assistant/api';
+  import RunnerSetup from '$lib/assistant/RunnerSetup.svelte';
   import AssistantChat from '$lib/assistant/AssistantChat.svelte';
   import ArtifactPanel from '$lib/tailor/ArtifactPanel.svelte';
   import CvHtmlPreview from '$lib/tailor/CvHtmlPreview.svelte';
@@ -29,7 +30,7 @@
   const slug = $derived(page.params.slug ?? '');
   const cvParam = $derived(page.url.searchParams.get('cv'));
 
-  let status = $state<'loading' | 'ready' | 'error'>('loading');
+  let status = $state<'loading' | 'ready' | 'error' | 'needs-runner'>('loading');
   let errorMsg = $state('');
   let sessionId = $state<string | undefined>(undefined);
   let resuming = $state(false);
@@ -155,6 +156,12 @@
       }
       status = 'ready';
     } catch (e) {
+      if (e instanceof NoDeviceError) {
+        // Tailoring runs on the user's own machine and none is connected. Show
+        // how to connect one rather than an error — nothing is broken.
+        status = 'needs-runner';
+        return;
+      }
       if (e instanceof ApiError && e.status === 402) {
         // Out of AI credits: surface the message plus when the monthly grant renews.
         const resetsAt = typeof e.body?.resets_at === 'string' ? e.body.resets_at : null;
@@ -258,6 +265,15 @@
   {#if status === 'loading'}
     <div class="flex min-w-0 flex-1 items-center justify-center text-sm text-muted-foreground">
       {resuming ? 'Re-opening your tailoring session…' : 'Preparing your tailoring session…'}
+    </div>
+  {:else if status === 'needs-runner'}
+    <div class="flex min-w-0 flex-1 items-start justify-center overflow-y-auto p-4">
+      <div class="w-full max-w-2xl">
+        <RunnerSetup />
+        <p class="px-3 pb-6 text-center text-xs text-muted-foreground">
+          Once it is running, reload this page to start tailoring.
+        </p>
+      </div>
     </div>
   {:else if status === 'error'}
     <div class="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">


### PR DESCRIPTION
Frontend for the assistant running on the user's own machine. Server side is deployed (freehire-agent #17, #19–#23).

Replaces #1137, which was branched off an unrelated feature branch and dragged its `design-system/` changes along. This one is cut from `main` and touches five files.

## What changes

**A badge in the chat header** showing where the assistant runs: *Your machine* when a runner is connected, *Our servers* otherwise, and a warning when one is required but missing. Polled every 10s — the runner connects to the agent backend, not to this page, so there is nothing to subscribe to. A failed poll keeps the last known state rather than flickering to disconnected.

**Setup instructions instead of an error.** When a session may only run on the user's machine and none is connected, the backend answers `409 no_device`. That is unfinished setup, not a failure, so the UI shows the commands to run. Wired into both surfaces that open a session: the assistant chat and the tailoring workspace.

## One detail worth the extra type

`NoDeviceError` is its own class rather than a message check. Otherwise the two cases would be distinguished by string matching at the call site, and sooner or later someone would see installation instructions in response to a network blip.

## Checks

`svelte-check` 0 errors, 385 tests pass, production build succeeds — against current `main`.