### PR TITLE
feat(assistant): show how to connect, not just that nothing is connected

### DIFF
--- a/web/src/lib/assistant/RunnerBadge.svelte
+++ b/web/src/lib/assistant/RunnerBadge.svelte
@@ -2,7 +2,6 @@
   import { onMount, onDestroy } from 'svelte';
   import { Laptop, CloudOff } from '@lucide/svelte';
   import { runnerStatus, type RunnerStatus } from '$lib/assistant/api';
-  import { BYOK_DOCS } from '$lib/assistant/api';
 
   /** Whether this machine is running the assistant's harness.
    *
@@ -52,7 +51,7 @@
         >freehire runner</code
       >
       <a
-        href={BYOK_DOCS}
+        href="https://github.com/strelov1/freehire-cli#bring-your-own-claude-byok"
         target="_blank"
         rel="noreferrer"
         class="text-muted-foreground underline underline-offset-2 hover:text-foreground"

--- a/web/src/lib/assistant/RunnerBadge.svelte
+++ b/web/src/lib/assistant/RunnerBadge.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { Laptop, CloudOff } from '@lucide/svelte';
   import { runnerStatus, type RunnerStatus } from '$lib/assistant/api';
+  import { BYOK_DOCS } from '$lib/assistant/api';
 
   /** Whether this machine is running the assistant's harness.
    *
@@ -38,12 +39,26 @@
       Running on your computer
     </span>
   {:else}
-    <span
-      class="inline-flex items-center gap-1.5 rounded-full border border-amber-600/30 bg-amber-600/10 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-400"
-      title="Start `freehire runner` on your computer to use your own Claude"
-    >
-      <CloudOff class="size-3.5" />
-      Computer not connected
+    <span class="inline-flex items-center gap-2 text-xs">
+      <span
+        class="inline-flex items-center gap-1.5 rounded-full border border-amber-600/30 bg-amber-600/10 px-2 py-0.5 text-amber-700 dark:text-amber-400"
+      >
+        <CloudOff class="size-3.5" />
+        Computer not connected
+      </span>
+      <!-- The badge alone tells the user something is off without telling them
+           what to do about it, so the fix travels with it. -->
+      <code class="hidden rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] sm:inline"
+        >freehire runner</code
+      >
+      <a
+        href={BYOK_DOCS}
+        target="_blank"
+        rel="noreferrer"
+        class="text-muted-foreground underline underline-offset-2 hover:text-foreground"
+      >
+        how to connect
+      </a>
     </span>
   {/if}
 {/if}

--- a/web/src/lib/assistant/RunnerSetup.svelte
+++ b/web/src/lib/assistant/RunnerSetup.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Copy, Check, Terminal } from '@lucide/svelte';
+  import { BYOK_DOCS } from '$lib/assistant/api';
 
   /** Shown when the assistant has nowhere to run: it executes on the user's own
    *  machine, and no runner is connected. This is a setup step, not a failure,
@@ -78,6 +79,12 @@
       Keep the last command running while you use the assistant — it is idle until you send a
       message. Stop it with Ctrl-C when you are done. Your chats, CVs and applications stay here;
       only the AI runs on your machine.
+      <a
+        href={BYOK_DOCS}
+        target="_blank"
+        rel="noreferrer"
+        class="underline underline-offset-2 hover:text-foreground">Full documentation</a
+      >.
     </p>
   {/if}
 </div>

--- a/web/src/lib/assistant/RunnerSetup.svelte
+++ b/web/src/lib/assistant/RunnerSetup.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Copy, Check, Terminal } from '@lucide/svelte';
-  import { BYOK_DOCS } from '$lib/assistant/api';
 
   /** Shown when the assistant has nowhere to run: it executes on the user's own
    *  machine, and no runner is connected. This is a setup step, not a failure,
@@ -80,7 +79,7 @@
       message. Stop it with Ctrl-C when you are done. Your chats, CVs and applications stay here;
       only the AI runs on your machine.
       <a
-        href={BYOK_DOCS}
+        href="https://github.com/strelov1/freehire-cli#bring-your-own-claude-byok"
         target="_blank"
         rel="noreferrer"
         class="underline underline-offset-2 hover:text-foreground">Full documentation</a

--- a/web/src/lib/assistant/api.ts
+++ b/web/src/lib/assistant/api.ts
@@ -62,6 +62,10 @@ export async function createSession(tailoring?: TailoringSession): Promise<strin
   return body.session_id;
 }
 
+/** Where a user goes to read how to run the assistant on their own machine. */
+export const BYOK_DOCS =
+  'https://github.com/strelov1/freehire-cli#bring-your-own-claude-byok';
+
 export type RunnerStatus = {
   /** Whether the caller has a machine connected right now. */
   connected: boolean;

--- a/web/src/lib/assistant/api.ts
+++ b/web/src/lib/assistant/api.ts
@@ -62,10 +62,6 @@ export async function createSession(tailoring?: TailoringSession): Promise<strin
   return body.session_id;
 }
 
-/** Where a user goes to read how to run the assistant on their own machine. */
-export const BYOK_DOCS =
-  'https://github.com/strelov1/freehire-cli#bring-your-own-claude-byok';
-
 export type RunnerStatus = {
   /** Whether the caller has a machine connected right now. */
   connected: boolean;


### PR DESCRIPTION
The badge reported a problem without telling the user how to solve it.

Now, whenever no computer is connected, the chat header shows the command (`freehire runner`) and links to the BYOK section of the CLI README. Previously the instructions only appeared after a session was refused — which never happens while `ROY_REQUIRE_DEVICE` is off, so in practice nobody saw them.