### PR TITLE
feat(assistant): take the Agent out of beta

### DIFF
--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -29,10 +29,12 @@ describe('accountNav config', () => {
 });
 
 describe('visibleAccountNav', () => {
-  it('hides the beta-only Assistant from a plain user but shows the Inbox and CV builder', () => {
+  it('shows the Assistant, Inbox and CV builder to a plain user', () => {
     const hrefs = visibleAccountNav(false, false).map((i) => i.href);
-    expect(hrefs).not.toContain('/my/assistant');
-    expect(hrefs).toContain('/my/inbox'); // Inbox is open to everyone now
+    // The Assistant left its beta rollout: it runs on the user's own machine
+    // with their own Claude, so there is nothing left to ration.
+    expect(hrefs).toContain('/my/assistant');
+    expect(hrefs).toContain('/my/inbox');
     expect(hrefs).toContain('/my/cvs'); // CV builder is public now (credits meter the AI spend)
   });
 
@@ -46,17 +48,16 @@ describe('visibleAccountNav', () => {
     }
   });
 
-  it('gates the Assistant on beta membership, not the moderator role', () => {
-    // A moderator who is not a beta tester sees the Inbox but NOT the Assistant.
-    const modOnly = visibleAccountNav(true, false).map((i) => i.href);
-    expect(modOnly).toContain('/my/inbox');
-    expect(modOnly).not.toContain('/my/assistant');
-
-    // A beta tester who is not a moderator sees the Assistant (and, like everyone,
-    // the Inbox).
-    const betaOnly = visibleAccountNav(false, true).map((i) => i.href);
-    expect(betaOnly).toContain('/my/assistant');
-    expect(betaOnly).toContain('/my/inbox');
+  it('shows the Assistant regardless of role or beta membership', () => {
+    for (const [mod, beta] of [
+      [false, false],
+      [true, false],
+      [false, true],
+    ] as const) {
+      const hrefs = visibleAccountNav(mod, beta).map((i) => i.href);
+      expect(hrefs).toContain('/my/assistant');
+      expect(hrefs).toContain('/my/inbox');
+    }
   });
 
   it('shows every section to a moderator who is also a beta tester', () => {

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -15,9 +15,9 @@ export const accountNav = [
   // Mail inbox: connect Gmail and/or claim a freehire mailbox to track application
   // replies. Open to every signed-in user.
   { href: '/my/inbox', label: 'Inbox' },
-  // The agent is a restricted rollout — beta testers only (a group separate from
-  // the moderator role; see `beta_tester` on the user). `beta` shows a nav badge.
-  { href: '/my/assistant', label: 'Agent', betaOnly: true, beta: true },
+  // Out of restricted rollout: the assistant now runs on the user's own machine
+  // with their own Claude subscription, so it costs us nothing to open up.
+  { href: '/my/assistant', label: 'Agent' },
   // CV builder + AI tailoring: open to every signed-in user (credits meter the AI spend).
   { href: '/my/cvs', label: 'CV builder' },
   // Employee referrals: request a referral, offer to refer (moderated), and — for

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -71,16 +71,16 @@
   //  - sessionLabel: name the session in the rail (kept separate from the kickoff text).
   //  - onTurnComplete: called when a turn finishes (the tailor host refreshes the CV preview).
   //  - showSessionRail: whether to render the session sidebar (off on the focused /tailor surface).
-  //  - requireBeta: gate the chat behind beta membership (default). The /tailor host sets this
-  //    false — CV tailoring is public, so its embedded chat must connect for non-beta users too,
-  //    while the standalone Agent (/my/assistant) keeps the default beta gate.
+  //  - requireBeta: kept so an embedder can still gate the chat, but the
+  //    standalone Agent no longer does. The assistant runs on the user's own
+  //    machine with their own Claude, so there is nothing to ration.
   let {
     session = undefined,
     kickoff = undefined,
     sessionLabel = undefined,
     onTurnComplete = undefined,
     showSessionRail = true,
-    requireBeta = true,
+    requireBeta = false,
   }: {
     session?: string;
     kickoff?: string;


### PR DESCRIPTION
The restricted rollout existed because every session ran on our servers and our model budget. With BYOK the assistant runs on the user's own machine with their own Claude subscription, so there is nothing left to ration.

- Drops `betaOnly` and the nav badge from `/my/assistant`
- `requireBeta` defaults to false; the prop stays for embedders that still want to gate
- Nav tests asserted the old gating and now assert the new behaviour

Depends on the BYOK work already shipped (#1138–#1140 here, freehire-agent #17–#23).