### PR TITLE
fix(arbeitnow): decode entity-encoded posting bodies

### DIFF
--- a/internal/sources/arbeitnow.go
+++ b/internal/sources/arbeitnow.go
@@ -73,6 +73,8 @@ func (a arbeitnow) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 // toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
 // native id, which would collide on the dedup key, or no company, which would break the
 // slug). The structured remote flag sets the work mode; the location text is a fallback.
+// The feed is inconsistent about the body: most postings carry live HTML, but a minority
+// arrive entity-encoded, so the description passes through unescapeEncodedHTML first.
 func (p arbeitnowPosting) toJob() (Job, bool) {
 	if p.Slug == "" || p.CompanyName == "" {
 		return Job{}, false
@@ -83,7 +85,7 @@ func (p arbeitnowPosting) toJob() (Job, bool) {
 		Title:       p.Title,
 		Company:     p.CompanyName,
 		Location:    p.Location,
-		Description: sanitizeHTML(p.Description),
+		Description: sanitizeHTML(unescapeEncodedHTML(p.Description)),
 		Remote:      p.Remote || isRemote(p.Location),
 		WorkMode:    workModeFromRemote(p.Remote),
 		PostedAt:    parseEpochSeconds(p.CreatedAt),

--- a/internal/sources/arbeitnow_test.go
+++ b/internal/sources/arbeitnow_test.go
@@ -73,3 +73,42 @@ func TestArbeitnowFetchPaginatesAndMaps(t *testing.T) {
 		t.Error("PostedAt nil, want parsed epoch")
 	}
 }
+
+// About a tenth of the arbeitnow feed serves the employer's body with its HTML
+// entity-encoded, then appends the board's own live-HTML promo footer. sanitizeHTML alone
+// cannot recover that: bluemonday reads "&lt;h2&gt;" as a text node and re-encodes it, so
+// the tags used to reach the catalogue as literals visible to the reader.
+func TestArbeitnowDecodesEntityEncodedDescription(t *testing.T) {
+	page1 := `{"data":[
+{"slug":"senior-cloud-platform-engineer-140883","company_name":"Prolific","title":"Senior Cloud Platform Engineer","description":"&lt;h2 style=&quot;text-align: center;&quot;&gt;&lt;strong&gt;Senior Cloud Platform Engineer&lt;/strong&gt;&lt;/h2&gt;\n&lt;p&gt;&amp;nbsp;&lt;/p&gt;\n&lt;ul&gt;&lt;li&gt;Kubernetes at scale&lt;/li&gt;&lt;/ul&gt;<p>Find more <a href=\"https://www.arbeitnow.co.uk/english-speaking-jobs\">jobs</a> on Arbeitnow</p>","remote":true,"url":"https://www.arbeitnow.co.uk/jobs/companies/prolific/senior-cloud-platform-engineer-140883","location":"Remote","created_at":1781713837}
+],"links":{"next":null}}`
+	fake := (&routedHTTP{}).route("job-board-api", page1)
+
+	jobs, err := NewArbeitnow(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	got := jobs[0].Description
+
+	// The encoded body is now real markup the browser renders as structure.
+	for _, want := range []string{"<h2>", "<strong>Senior Cloud Platform Engineer</strong>", "<li>Kubernetes at scale</li>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Description missing decoded markup %q\ngot: %s", want, got)
+		}
+	}
+	// No encoded tag may survive, or the reader sees the tag text itself.
+	if strings.Contains(got, "&lt;") {
+		t.Errorf("Description still carries encoded markup\ngot: %s", got)
+	}
+	// Decoding turns style="..." into a real attribute, which the policy then drops.
+	if strings.Contains(got, "text-align") {
+		t.Errorf("Description kept a disallowed style attribute\ngot: %s", got)
+	}
+	// The board's live-HTML footer passes through untouched.
+	if !strings.Contains(got, `href="https://www.arbeitnow.co.uk/english-speaking-jobs"`) {
+		t.Errorf("Description lost the live footer link\ngot: %s", got)
+	}
+}

--- a/internal/sources/sanitize.go
+++ b/internal/sources/sanitize.go
@@ -1,6 +1,8 @@
 package sources
 
 import (
+	"html"
+	"regexp"
 	"strings"
 
 	"github.com/microcosm-cc/bluemonday"
@@ -54,6 +56,37 @@ func sanitizeHTML(s string) string {
 // SanitizeHTML is the exported description sanitizer, for sibling packages that build
 // sources.Job values outside this package (e.g. internal/linksource).
 func SanitizeHTML(s string) string { return sanitizeHTML(s) }
+
+// encodedTagOpener and liveTagOpener count tag openers in their entity-encoded ("&lt;div",
+// "&lt;/div") and live ("<div", "</div") forms. Both require a letter after the bracket, so a
+// lone "<" or "&lt;" standing in for a less-than sign in prose counts as neither.
+var (
+	encodedTagOpener = regexp.MustCompile(`&lt;/?[a-zA-Z]`)
+	liveTagOpener    = regexp.MustCompile(`</?[a-zA-Z]`)
+)
+
+// unescapeEncodedHTML undoes one layer of HTML entity-encoding when s carries its markup as
+// text ("&lt;p&gt;Role&lt;/p&gt;") rather than as live HTML. Some feeds encode a posting's
+// body before serving it, and sanitizeHTML cannot recover that on its own: bluemonday reads
+// "&lt;p&gt;" as a text node and re-encodes it on output, so the tags reach the catalogue as
+// literals the reader sees instead of the structure they describe.
+//
+// The decision is by weight, not by presence: encoding is undone only when encoded tag
+// openers outnumber live ones. Decoding unconditionally would corrupt the healthy majority of
+// such a feed — a posting that deliberately shows markup as an example would have that example
+// turned into real tags and then stripped, silently losing the content — whereas a wholly
+// encoded body stays dominated by encoded openers even when the feed wraps it in live HTML of
+// its own (arbeitnow appends a promo footer).
+func unescapeEncodedHTML(s string) string {
+	// Fast path: no encoded markup to weigh.
+	if !strings.Contains(s, "&lt;") {
+		return s
+	}
+	if len(encodedTagOpener.FindAllStringIndex(s, -1)) <= len(liveTagOpener.FindAllStringIndex(s, -1)) {
+		return s
+	}
+	return html.UnescapeString(s)
+}
 
 // IsRemote is the exported form of the shared location-based remote heuristic, so sibling
 // packages flag remote jobs consistently with the ATS adapters.

--- a/internal/sources/sanitize_test.go
+++ b/internal/sources/sanitize_test.go
@@ -71,3 +71,37 @@ func TestLenientPercentUnescape(t *testing.T) {
 		}
 	}
 }
+
+func TestUnescapeEncodedHTML(t *testing.T) {
+	cases := map[string]struct{ in, want string }{
+		// Live markup is the common case and must survive byte for byte: unescaping it
+		// would decode entities the posting meant literally.
+		"live markup":        {"<p>Build &amp; ship.</p>", "<p>Build &amp; ship.</p>"},
+		"entities, no tags":  {"R&amp;D team", "R&amp;D team"},
+		"plain text":         {"Just text", "Just text"},
+		"encoded body":       {"&lt;p&gt;Hi&lt;/p&gt;", "<p>Hi</p>"},
+		"encoded attributes": {"&lt;p class=&quot;x&quot;&gt;Hi&lt;/p&gt;", `<p class="x">Hi</p>`},
+		// The shape arbeitnow actually serves: an encoded employer body followed by the
+		// board's own live-HTML promo footer. Encoded openers dominate, so the whole
+		// string is decoded — a no-op on the footer, which carries no entities.
+		"encoded body, live footer": {
+			`&lt;p&gt;Role&lt;/p&gt;&lt;ul&gt;&lt;li&gt;Go&lt;/li&gt;&lt;/ul&gt;<p>Find more <a href="x">jobs</a></p>`,
+			`<p>Role</p><ul><li>Go</li></ul><p>Find more <a href="x">jobs</a></p>`,
+		},
+		// A posting that deliberately shows markup as an example: live openers outnumber
+		// encoded ones, so the example is left encoded instead of becoming real tags
+		// (which sanitizeHTML would then strip, silently losing the content).
+		"escaped code sample": {
+			"<p>Use <code>&lt;div&gt;&lt;/div&gt;</code> in JSX</p>",
+			"<p>Use <code>&lt;div&gt;&lt;/div&gt;</code> in JSX</p>",
+		},
+		// A bare "<" or "&lt;" used as a less-than sign is not a tag opener, so it never
+		// tips the decision either way.
+		"less-than in prose": {"<p>salary &lt; 100k</p>", "<p>salary &lt; 100k</p>"},
+	}
+	for name, c := range cases {
+		if got := unescapeEncodedHTML(c.in); got != c.want {
+			t.Errorf("%s: unescapeEncodedHTML(%q) = %q, want %q", name, c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

[Senior Cloud Platform Engineer @ Prolific](https://freehire.me/jobs/senior-cloud-platform-engineer-prolific-tw5jwf5t) renders its description as visible HTML tags instead of formatted text.

Root cause is **not** in our code. About a tenth of the arbeitnow feed serves the employer's body with its HTML entity-encoded, then appends the board's own live-HTML promo footer:

```
&lt;h2 style=&quot;text-align: center;&quot;&gt;...&lt;/h2&gt;   <- encoded employer body
<p>Find more <a href="...">jobs</a> on Arbeitnow</p>      <- live footer
```

`sanitizeHTML` cannot recover this on its own: bluemonday reads `&lt;h2&gt;` as a *text node* and re-encodes it on output, so the tags reach the catalogue as literals. That also explains the stored `style="..."` surviving a policy that never allowed the attribute — it was never an attribute, it was text.

## Fix

`unescapeEncodedHTML` undoes one layer of encoding, applied before sanitizing in the arbeitnow adapter.

The decision is **by weight, not by presence**: encoding is undone only when encoded tag openers outnumber live ones. This matters — an unconditional `html.UnescapeString` (the idiom ~30 other adapters use) would corrupt this feed's healthy majority, and a posting that deliberately shows markup as an example would have that example turned into real tags and then stripped, silently losing content.

Both counters require a letter after the bracket, so a bare `<`/`&lt;` used as a less-than sign in prose tips the decision neither way.

## Evidence

Measured on **610 live postings** across 8 feed pages:

| | count |
|---|---|
| decoded (previously broken) | 65 |
| unchanged (healthy) | 545 |
| regressions | **0** |

Healthy postings carry 0 encoded openers and 4–1024 live ones; broken postings carry 54–282 encoded and exactly 4 live (the footer). Smallest margin is 13.5x — no ambiguous case in the sample.

Also verified against **stored prod rows** (1200 sampled via the public API): 135 broken (11.2%), 134 repaired by this logic. The one exception is the logic working as intended — a posting containing `<p>--&gt; Let´s go Live &lt;--</p>`, prose typography the author encoded deliberately, correctly left alone.

## Secondary effect

`jobhash.RoleFingerprint` normalizes the description with its HTML *stripped*. For these postings the tags were not tags, so the tag text polluted the repost-identity fingerprint. Re-ingest recomputes it correctly.

## Follow-up (ops, not in this PR)

- `systemctl start freehire-ingest@arbeitnow` after release — the feed exhausts at ~27 pages (~2710 postings) vs 2725 open arbeitnow jobs in prod, so one run covers essentially the whole open set. `description` is part of `content_hash`, so the incremental Meili push carries the repaired docs; no full reindex needed.
- Re-enqueue the affected jobs for enrichment — their current enrichment was derived from tag-polluted text.

## Test plan

- `go test ./internal/sources/` — new `TestUnescapeEncodedHTML` (7 cases incl. the protective escaped-code-sample and less-than-in-prose cases) and `TestArbeitnowDecodesEntityEncodedDescription` (real feed shape end-to-end through `Fetch`)
- `go build ./... && go vet ./... && go test ./...` clean