### PR TITLE
fix(backfill-descriptions): repair entity-encoded descriptions too

### DIFF
--- a/cmd/backfill-descriptions/main.go
+++ b/cmd/backfill-descriptions/main.go
@@ -6,11 +6,18 @@
 // decodes leniently (internal/sources.LenientPercentUnescape); this one-off worker fixes the
 // rows already in the catalogue.
 //
-// It pages by keyset and re-decodes every row whose description still carries the "%3C"
-// (encoded "<") marker, re-running the same sanitize+decode pipeline the fixed adapter uses and
-// refreshing content_hash so the row re-indexes. The marker is source-agnostic: any
-// percent-encoded description is repaired the same way, open or closed. Idempotent — a
-// re-decoded row no longer matches the marker, so a second run rewrites nothing.
+// It also repairs the other way a source can store markup as text: HTML entity-encoding
+// ("&lt;p&gt;"), which arbeitnow serves for part of its feed. sanitizeHTML cannot recover that on
+// its own — bluemonday reads "&lt;p&gt;" as a text node and re-encodes it — so the adapter now
+// decodes it (internal/sources.UnescapeEncodedHTML). Because the arbeitnow job-board API is a
+// rolling window of recent postings, rows that aged out of it can never be reached by a
+// re-ingest; in-place repair is the only route.
+//
+// It pages by keyset and re-decodes every row whose description still carries an encoding marker
+// ("%3C" or "&lt;"), re-running the same sanitize+decode pipeline the fixed adapters use and
+// refreshing content_hash so the row re-indexes. The markers are source-agnostic: any encoded
+// description is repaired the same way, open or closed. Idempotent — a re-decoded row no longer
+// decodes to anything different, so a second run rewrites nothing.
 //
 // With no argument it sweeps the whole catalogue (universal). Pass a source name as the first
 // argument (e.g. `backfill-descriptions taleo`) to scope the sweep to that provider — the
@@ -37,10 +44,15 @@ import (
 // backfillBatchSize bounds how many rows are read per keyset page.
 const backfillBatchSize = 500
 
-// encodedMarker is the fingerprint of a still-percent-encoded description: the encoded "<"
-// ("%3C") that opens every mangled HTML blob. A cleanly decoded description never contains it,
-// so it precisely selects the rows to repair without a content-scanning SQL predicate.
-const encodedMarker = "%3C"
+// A description stored still encoded carries its "<" encoded one of two ways, each the
+// signature of a different upstream habit: percent-encoded ("%3C", the strict-PathUnescape
+// fallback the Taleo adapter used to hit) or HTML entity-encoded ("&lt;", which arbeitnow
+// serves for part of its feed). Either marker selects candidate rows cheaply, without a
+// content-scanning SQL predicate.
+const (
+	percentEncodedMarker = "%3C"
+	entityEncodedMarker  = "&lt;"
+)
 
 // jobStore is the slice of the data layer the backfill needs: page rows by keyset (whole table or
 // one source) and rewrite a row's description + content_hash. *db.Queries satisfies it; the test
@@ -100,12 +112,9 @@ func backfillAll(ctx context.Context, store jobStore, source string) (scanned, u
 
 		for _, j := range jobs {
 			scanned++
-			if !strings.Contains(j.Description, encodedMarker) {
-				continue
-			}
-			desc := sources.SanitizeHTML(sources.LenientPercentUnescape(j.Description))
+			desc := repairDescription(j.Description)
 			if desc == j.Description {
-				continue // nothing recovered — leave it be (defensive; a marker row always changes)
+				continue // clean row, or an encoding marker that turned out to be real prose
 			}
 			hash := jobhash.Of(hashParams(j, desc))
 			if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
@@ -123,6 +132,30 @@ func backfillAll(ctx context.Context, store jobStore, source string) (scanned, u
 		}
 	}
 	return scanned, updated, nil
+}
+
+// repairDescription reproduces the fixed adapters' pipeline for a stored description: decode
+// whichever encoding the row was stored with, then re-sanitize. It returns stored unchanged when
+// nothing decoded, so a clean row is never rewritten (and never re-sanitized, keeping the pass
+// free of any dependence on sanitizeHTML being byte-for-byte idempotent).
+//
+// Each decoder runs only when its own marker is present, so a row mangled by one encoding is
+// never put through the other's decoder — percent-decoding an entity-encoded body would rewrite
+// unrelated "%NN"-looking prose. The entity decode is itself conditional on encoded markup
+// outweighing live markup (see sources.UnescapeEncodedHTML), which is what leaves a posting that
+// merely writes "&lt;" as a less-than sign alone.
+func repairDescription(stored string) string {
+	decoded := stored
+	if strings.Contains(decoded, percentEncodedMarker) {
+		decoded = sources.LenientPercentUnescape(decoded)
+	}
+	if strings.Contains(decoded, entityEncodedMarker) {
+		decoded = sources.UnescapeEncodedHTML(decoded)
+	}
+	if decoded == stored {
+		return stored
+	}
+	return sources.SanitizeHTML(decoded)
 }
 
 // pageJobs fetches one keyset page after afterID — from the whole table when source is empty, or

--- a/cmd/backfill-descriptions/main_test.go
+++ b/cmd/backfill-descriptions/main_test.go
@@ -119,3 +119,44 @@ func TestBackfillScopedToSource(t *testing.T) {
 		t.Fatalf("updates = %+v, want only taleo job 1", store.updates)
 	}
 }
+
+// TestBackfillDecodesEntityEncodedDescriptions covers the second way a source can store its
+// markup as text: HTML entity-encoding ("&lt;p&gt;") rather than percent-encoding. arbeitnow
+// served bodies this way, and its feed is a rolling window, so rows that aged out of it can
+// never be repaired by a re-ingest — only in place.
+func TestBackfillDecodesEntityEncodedDescriptions(t *testing.T) {
+	store := &fakeStore{jobs: []db.Job{
+		// The arbeitnow shape: entity-encoded body plus the board's live-HTML promo footer.
+		{ID: 1, Source: "arbeitnow", Title: "A", Description: `&lt;h2&gt;Role&lt;/h2&gt;&lt;ul&gt;&lt;li&gt;Go&lt;/li&gt;&lt;/ul&gt;<p>Find more <a href="https://x.test/jobs">jobs</a></p>`},
+		// Prose that deliberately encodes a less-than sign: live tags dominate, so decoding
+		// it would corrupt the row. Must be left alone.
+		{ID: 2, Source: "arbeitnow", Title: "B", Description: `<p>Standort Düsseldorf</p><p>--&gt; Let´s go Live &lt;--</p><p>Wir suchen dich.</p>`},
+		// Already clean.
+		{ID: 3, Source: "arbeitnow", Title: "C", Description: "<p>Clean HTML.</p>"},
+	}}
+
+	scanned, updated, err := backfillAll(context.Background(), store, "arbeitnow")
+	if err != nil {
+		t.Fatalf("backfillAll: %v", err)
+	}
+	if scanned != 3 || updated != 1 {
+		t.Fatalf("scanned=%d updated=%d, want 3/1 (only the entity-encoded body)", scanned, updated)
+	}
+	if len(store.updates) != 1 || store.updates[0].ID != 1 {
+		t.Fatalf("updates = %+v, want only job 1", store.updates)
+	}
+
+	u := store.updates[0]
+	for _, want := range []string{"<h2>Role</h2>", "<li>Go</li>", `href="https://x.test/jobs"`} {
+		if !strings.Contains(u.Description, want) {
+			t.Errorf("job 1 missing decoded markup %q: %q", want, u.Description)
+		}
+	}
+	if strings.Contains(u.Description, "&lt;") {
+		t.Errorf("job 1 still entity-encoded: %q", u.Description)
+	}
+	want := jobhash.Of(hashParams(store.jobs[0], u.Description))
+	if !u.ContentHash.Valid || u.ContentHash.String != want {
+		t.Errorf("job 1 ContentHash = %+v, want %q", u.ContentHash, want)
+	}
+}

--- a/internal/sources/sanitize.go
+++ b/internal/sources/sanitize.go
@@ -77,6 +77,10 @@ var (
 // turned into real tags and then stripped, silently losing the content — whereas a wholly
 // encoded body stays dominated by encoded openers even when the feed wraps it in live HTML of
 // its own (arbeitnow appends a promo footer).
+// UnescapeEncodedHTML is the exported form of the entity-encoding repair, for the
+// description backfill worker that re-runs the adapter pipeline over stored rows.
+func UnescapeEncodedHTML(s string) string { return unescapeEncodedHTML(s) }
+
 func unescapeEncodedHTML(s string) string {
 	// Fast path: no encoded markup to weigh.
 	if !strings.Contains(s, "&lt;") {


### PR DESCRIPTION
Follow-up to #1143. That PR fixed the arbeitnow adapter, and a prod re-ingest repaired **146 of 157** encoded rows. This PR reaches the remaining ones.

## Why re-ingest can't finish the job

The arbeitnow job-board API is a **rolling window of recent postings** (~1442 at the moment). Ten encoded rows — all Prolific, including the originally reported [Senior Cloud Platform Engineer](https://freehire.me/jobs/senior-cloud-platform-engineer-prolific-tw5jwf5t) — have aged out of it. Their postings are still live at the source (HTTP 200), so closing them would be wrong; they simply can never be rewritten by a crawl. In-place repair is the only route.

## Change

`cmd/backfill-descriptions` already existed for exactly this class of bug (Taleo's percent-encoded bodies): keyset pass, same sanitize+decode pipeline as the adapter, refreshed `content_hash`, idempotent, scopable to one source. This teaches it the second encoding.

- `sources.UnescapeEncodedHTML` exported (was unexported, used only by the adapter)
- one marker constant becomes two: `%3C` and `&lt;`
- new `repairDescription` applies **each decoder only when its own marker is present** — percent-decoding an entity-encoded body would rewrite unrelated `%NN`-looking prose
- it returns the stored value unchanged when nothing decoded, so clean rows are neither rewritten nor re-sanitized (the pass no longer depends on `sanitizeHTML` being byte-for-byte idempotent)

## Verification

Dry-run of `repairDescription` against the **12 real prod rows** that still carried `&lt;`:

| rows | outcome |
|---|---|
| 10 encoded Prolific postings | repaired, 0 encoded markers left, `style` attributes stripped by the policy |
| 2 postings that merely write `&lt;` in prose (`--&gt; Let´s go Live &lt;--`) | left alone |

New test `TestBackfillDecodesEntityEncodedDescriptions` covers the arbeitnow shape (encoded body + live footer), the prose false-positive, and a clean row.

`go build ./... && go vet ./... && go test ./...` clean.

## Rollout

`backfill-descriptions arbeitnow`, then the descriptions are correct in Postgres immediately (the job page reads `GetJobBySlug` from PG). Meili picks them up on the next scheduled `reindexw` run.