### PR TITLE
fix(himalayas): strip the aggregator's own branding from mirrored bodies

### DIFF
--- a/cmd/backfill-descriptions/main.go
+++ b/cmd/backfill-descriptions/main.go
@@ -13,6 +13,13 @@
 // rolling window of recent postings, rows that aged out of it can never be reached by a
 // re-ingest; in-place repair is the only route.
 //
+// A third kind of damage is not an encoding at all: Himalayas brands the bodies it mirrors,
+// ending every posting with an "Originally posted on Himalayas" trailer and rewriting each
+// mention of the hiring company into a backlink to its own page. The adapter now strips both
+// (internal/sources.StripHimalayasSelfPromo); because the feed is a recency-ordered window the
+// crawl only ever revisits its freshest slice, so the rows already in the catalogue can only be
+// repaired in place. Scope this one to its provider (`backfill-descriptions himalayas`).
+//
 // It pages by keyset and re-decodes every row whose description still carries an encoding marker
 // ("%3C" or "&lt;"), re-running the same sanitize+decode pipeline the fixed adapters use and
 // refreshing content_hash so the row re-indexes. The markers are source-agnostic: any encoded
@@ -24,7 +31,9 @@
 // affected rows are known to be a single provider's, and scoping skips detoasting every other
 // row, so a targeted repair does not read the whole table.
 //
-// Follow it with `make reindex` so the search/recommendation index picks up the fixed text.
+// Follow it with `cmd/backfill-derive` — the rewritten body changes what the deterministic
+// columns derive from, and role_fingerprint hashes the description — and then `make reindex` so
+// the search/recommendation index picks up the fixed text.
 package main
 
 import (
@@ -53,6 +62,11 @@ const (
 	percentEncodedMarker = "%3C"
 	entityEncodedMarker  = "&lt;"
 )
+
+// himalayasSource is the one provider whose stored bodies carry the aggregator's own branding
+// (a promo trailer plus self-backlinks over every company mention). Unlike the encoding markers
+// this repair is not source-agnostic: the same links under another provider are the employer's.
+const himalayasSource = "himalayas"
 
 // jobStore is the slice of the data layer the backfill needs: page rows by keyset (whole table or
 // one source) and rewrite a row's description + content_hash. *db.Queries satisfies it; the test
@@ -112,7 +126,7 @@ func backfillAll(ctx context.Context, store jobStore, source string) (scanned, u
 
 		for _, j := range jobs {
 			scanned++
-			desc := repairDescription(j.Description)
+			desc := repairDescription(j.Source, j.Description)
 			if desc == j.Description {
 				continue // clean row, or an encoding marker that turned out to be real prose
 			}
@@ -135,16 +149,22 @@ func backfillAll(ctx context.Context, store jobStore, source string) (scanned, u
 }
 
 // repairDescription reproduces the fixed adapters' pipeline for a stored description: decode
-// whichever encoding the row was stored with, then re-sanitize. It returns stored unchanged when
-// nothing decoded, so a clean row is never rewritten (and never re-sanitized, keeping the pass
-// free of any dependence on sanitizeHTML being byte-for-byte idempotent).
+// whichever encoding the row was stored with, then re-sanitize, then drop the branding the
+// serving aggregator added. It returns stored unchanged when there was nothing to repair, so a
+// clean row is never rewritten (and never re-sanitized, keeping the pass free of any dependence
+// on sanitizeHTML being byte-for-byte idempotent).
 //
 // Each decoder runs only when its own marker is present, so a row mangled by one encoding is
 // never put through the other's decoder — percent-decoding an entity-encoded body would rewrite
 // unrelated "%NN"-looking prose. The entity decode is itself conditional on encoded markup
 // outweighing live markup (see sources.UnescapeEncodedHTML), which is what leaves a posting that
 // merely writes "&lt;" as a less-than sign alone.
-func repairDescription(stored string) string {
+//
+// The de-branding is keyed on source, not on a marker: the markers are the aggregator's own
+// links, and a posting from any other provider that links to them wrote that link itself. It
+// also runs on a body nothing decoded, which is the normal case — branding rides on well-formed
+// HTML — so it sits outside the decode gate.
+func repairDescription(source, stored string) string {
 	decoded := stored
 	if strings.Contains(decoded, percentEncodedMarker) {
 		decoded = sources.LenientPercentUnescape(decoded)
@@ -152,10 +172,14 @@ func repairDescription(stored string) string {
 	if strings.Contains(decoded, entityEncodedMarker) {
 		decoded = sources.UnescapeEncodedHTML(decoded)
 	}
-	if decoded == stored {
-		return stored
+	repaired := stored
+	if decoded != stored {
+		repaired = sources.SanitizeHTML(decoded)
 	}
-	return sources.SanitizeHTML(decoded)
+	if source == himalayasSource {
+		repaired = sources.StripHimalayasSelfPromo(repaired)
+	}
+	return repaired
 }
 
 // pageJobs fetches one keyset page after afterID — from the whole table when source is empty, or

--- a/cmd/backfill-descriptions/main_test.go
+++ b/cmd/backfill-descriptions/main_test.go
@@ -160,3 +160,59 @@ func TestBackfillDecodesEntityEncodedDescriptions(t *testing.T) {
 		t.Errorf("job 1 ContentHash = %+v, want %q", u.ContentHash, want)
 	}
 }
+
+// TestBackfillStripsHimalayasSelfPromo covers the third way a stored body carries text the
+// employer never wrote: Himalayas brands what it mirrors. Unlike the encoding repairs this one
+// is provider-scoped — the markers are Himalayas' own links, and only its rows may be rewritten
+// on sight of them. It is also the only repair that must fire on an otherwise well-formed body,
+// so it cannot ride on the "did anything decode?" gate the encoding repairs share.
+func TestBackfillStripsHimalayasSelfPromo(t *testing.T) {
+	promo := `<p>Join <a href="https://himalayas.app/companies/x" rel="nofollow">X</a>.</p>` +
+		`<p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`
+	store := &fakeStore{jobs: []db.Job{
+		{ID: 1, Source: "himalayas", Title: "A", Description: promo},
+		// Same body under another provider: not ours to rewrite. A greenhouse posting that
+		// genuinely links to himalayas.app is the employer's own text.
+		{ID: 2, Source: "greenhouse", Title: "B", Description: promo},
+		// A himalayas row already cleaned by an earlier run must not be rewritten again.
+		{ID: 3, Source: "himalayas", Title: "C", Description: `<p>Join X.</p>`},
+	}}
+
+	scanned, updated, err := backfillAll(context.Background(), store, "")
+	if err != nil {
+		t.Fatalf("backfillAll: %v", err)
+	}
+	if scanned != 3 || updated != 1 {
+		t.Fatalf("scanned=%d updated=%d, want 3/1 (only the himalayas promo row)", scanned, updated)
+	}
+	if len(store.updates) != 1 || store.updates[0].ID != 1 {
+		t.Fatalf("updates = %+v, want only himalayas job 1", store.updates)
+	}
+	if want := `<p>Join X.</p>`; store.updates[0].Description != want {
+		t.Errorf("Description = %q, want %q", store.updates[0].Description, want)
+	}
+	// The row re-indexes only if content_hash moves with the text.
+	want := jobhash.Of(hashParams(store.jobs[0], store.updates[0].Description))
+	if !store.updates[0].ContentHash.Valid || store.updates[0].ContentHash.String != want {
+		t.Errorf("ContentHash = %+v, want %q", store.updates[0].ContentHash, want)
+	}
+}
+
+// TestBackfillRepairsEncodedHimalayasBody asserts the repairs compose: a himalayas row that is
+// also entity-encoded is decoded, re-sanitized, and then stripped of the branding the decode
+// just made visible.
+func TestBackfillRepairsEncodedHimalayasBody(t *testing.T) {
+	store := &fakeStore{jobs: []db.Job{{ID: 1, Source: "himalayas", Title: "A",
+		Description: `&lt;p&gt;Join us.&lt;/p&gt;&lt;p&gt;Originally posted on &lt;a href="https://himalayas.app"&gt;Himalayas&lt;/a&gt;&lt;/p&gt;`}}}
+
+	if _, updated, err := backfillAll(context.Background(), store, "himalayas"); err != nil || updated != 1 {
+		t.Fatalf("backfillAll: updated=%d err=%v, want 1/nil", updated, err)
+	}
+	got := store.updates[0].Description
+	if strings.Contains(got, "himalayas.app") || strings.Contains(got, "Originally posted on") {
+		t.Errorf("branding survived the decode: %q", got)
+	}
+	if !strings.Contains(got, "Join us.") {
+		t.Errorf("body lost: %q", got)
+	}
+}

--- a/internal/sources/himalayas.go
+++ b/internal/sources/himalayas.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"regexp"
 )
 
 // himalayas adapts himalayas.app, a remote-jobs aggregator. Boardless (one public API, no
@@ -101,9 +102,40 @@ func (p himalayasPosting) toJob() (Job, bool) {
 		Title:       p.Title,
 		Company:     p.CompanyName,
 		Location:    joinNonEmpty(p.LocationRestrictions...),
-		Description: sanitizeHTML(p.Description),
+		Description: StripHimalayasSelfPromo(sanitizeHTML(p.Description)),
 		Remote:      true,
 		WorkMode:    "remote",
 		PostedAt:    parseEpochSeconds(p.PubDate),
 	}, true
+}
+
+// Himalayas brands the bodies it serves: every posting ends with a promo trailer, and each
+// mention of the hiring company is rewritten into a backlink to the company's himalayas.app
+// page. Neither is the employer's text. Both are removed, for two reasons: rendering them
+// would point a reader at a competing aggregator instead of the employer, and the extra
+// visible text is what stops a mirrored posting from fingerprinting to the same role as the
+// copy we already hold from the company's own ATS (see internal/jobhash.RoleFingerprint,
+// which hashes visible text).
+//
+// himalayasPromoTrailer matches only the bare-host link, so a company backlink can never be
+// mistaken for the trailer. himalayasSelfLink then unwraps the backlinks to their visible
+// text — the anchor carries nothing the body does not already say.
+var (
+	himalayasPromoTrailer = regexp.MustCompile(`(?is)\s*<p>\s*Originally posted on\s*<a\b[^>]*href="https?://himalayas\.app/?"[^>]*>\s*Himalayas\s*</a>\s*</p>\s*$`)
+	himalayasSelfLink     = regexp.MustCompile(`(?is)<a\b[^>]*href="https?://himalayas\.app[^"]*"[^>]*>(.*?)</a>`)
+)
+
+// StripHimalayasSelfPromo removes Himalayas' own branding from a posting body: the trailing
+// "Originally posted on Himalayas" paragraph and the self-backlinks wrapping company mentions.
+// It expects sanitized HTML (the shape both the adapter and the stored catalogue carry) but
+// also matches the raw feed's un-defanged anchors, so either input cleans the same way.
+//
+// The trailer is stripped BEFORE the backlinks: it is recognised by the anchor it contains,
+// which unwrapping would have already dissolved. Unwrapping deletes the tags rather than
+// replacing them with a space, so `<a>Acme</a>.` keeps its punctuation glued exactly as the
+// employer wrote it. A body carrying neither is returned unchanged, and a cleaned body is
+// unchanged by a second pass, so the backfill can re-run over rows it already fixed.
+func StripHimalayasSelfPromo(s string) string {
+	s = himalayasPromoTrailer.ReplaceAllString(s, "")
+	return himalayasSelfLink.ReplaceAllString(s, "$1")
 }

--- a/internal/sources/himalayas_test.go
+++ b/internal/sources/himalayas_test.go
@@ -111,3 +111,94 @@ func TestHimalayasErrorsWhenFirstPageFails(t *testing.T) {
 		t.Error("Fetch should return an error when the first page fails")
 	}
 }
+
+func TestStripHimalayasSelfPromo(t *testing.T) {
+	// Bodies are stored post-sanitize, so the anchors carry the rel="nofollow" bluemonday
+	// adds; the raw feed serves them without it. Both shapes must strip.
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "trailer as stored (sanitized, rel=nofollow)",
+			in:   `<p>Apply today.</p><p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`,
+			want: `<p>Apply today.</p>`,
+		},
+		{
+			name: "trailer as served (raw feed, no rel)",
+			in:   `<p>Apply today.</p><p>Originally posted on <a href="https://himalayas.app">Himalayas</a></p>`,
+			want: `<p>Apply today.</p>`,
+		},
+		{
+			name: "company mention rewritten into a self-backlink is unwrapped to its text",
+			in:   `<p>At <a href="https://himalayas.app/companies/ptc" rel="nofollow">PTC</a>, we build things.</p>`,
+			want: `<p>At PTC, we build things.</p>`,
+		},
+		{
+			name: "unwrapping keeps the punctuation glued, which is what defeats fingerprinting",
+			in:   `<p>a signed agreement with <a href="https://himalayas.app/companies/oasis" rel="nofollow">Oasis</a>.</p>`,
+			want: `<p>a signed agreement with Oasis.</p>`,
+		},
+		{
+			name: "markup nested inside the self-backlink survives the unwrap",
+			in:   `<p><a href="https://himalayas.app/companies/x" rel="nofollow"><strong>Acme</strong></a> hires.</p>`,
+			want: `<p><strong>Acme</strong> hires.</p>`,
+		},
+		{
+			name: "the posting's own outbound links are left alone",
+			in:   `<p>Read our <a href="https://ptc.com/privacy" rel="nofollow">Privacy Policy</a>.</p>`,
+			want: `<p>Read our <a href="https://ptc.com/privacy" rel="nofollow">Privacy Policy</a>.</p>`,
+		},
+		{
+			name: "a body that merely names the mountains is not a promo trailer",
+			in:   `<p>Lead treks across the Himalayas.</p>`,
+			want: `<p>Lead treks across the Himalayas.</p>`,
+		},
+		{
+			name: "a clean body is returned byte-for-byte",
+			in:   `<p>Build web.</p>`,
+			want: `<p>Build web.</p>`,
+		},
+		{
+			name: "trailer and self-backlinks in the same body both go",
+			in:   `<p>Join <a href="https://himalayas.app/companies/x" rel="nofollow">X</a>.</p><p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`,
+			want: `<p>Join X.</p>`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StripHimalayasSelfPromo(tc.in); got != tc.want {
+				t.Errorf("StripHimalayasSelfPromo():\n got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripHimalayasSelfPromoIsIdempotent(t *testing.T) {
+	// The backfill re-runs over rows a previous run already cleaned, so a second pass must
+	// rewrite nothing.
+	in := `<p>At <a href="https://himalayas.app/companies/ptc" rel="nofollow">PTC</a>, we build.</p><p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`
+	once := StripHimalayasSelfPromo(in)
+	if twice := StripHimalayasSelfPromo(once); twice != once {
+		t.Errorf("second pass changed the body:\n got %q\nwant %q", twice, once)
+	}
+}
+
+func TestHimalayasFetchStripsSelfPromo(t *testing.T) {
+	// The adapter must yield an already-clean body, so a re-crawl writes the same text the
+	// backfill leaves behind.
+	page := `{"totalCount":1,"jobs":[
+{"title":"Web Engineer","companyName":"KraftPixel","applicationLink":"https://himalayas.app/x","guid":"https://himalayas.app/x","description":"<p>Join <a href=\"https://himalayas.app/companies/kraftpixel\">KraftPixel</a>.</p><p>Originally posted on <a href=\"https://himalayas.app\">Himalayas</a></p>","pubDate":1747699200}
+]}`
+	jobs, err := NewHimalayas((&routedHTTP{}).route("offset=0", page)).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if want := `<p>Join KraftPixel.</p>`; jobs[0].Description != want {
+		t.Errorf("Description = %q, want %q", jobs[0].Description, want)
+	}
+}


### PR DESCRIPTION
## What

Himalayas brands every body it mirrors:

- a trailer on **100% of postings** — `<p>Originally posted on <a href="https://himalayas.app">Himalayas</a></p>`
- every mention of the hiring company inside the body rewritten into a backlink to that company's `himalayas.app` page (13 of them in one PTC posting, 7 in an oasis-security one)

We stored and rendered all of it. That is ~15k catalogue pages handing outbound link equity to a competing aggregator, on top of text the employer never wrote.

## Change

- `internal/sources.StripHimalayasSelfPromo` — removes the trailer, then unwraps the self-backlinks to their visible text. The trailer is matched on the bare-host link only, so a company backlink can never be mistaken for it; it is stripped first, because unwrapping would dissolve the anchor that identifies it.
- The adapter applies it, so a re-crawl writes the same text the backfill leaves behind.
- `cmd/backfill-descriptions` gains the repair for rows already stored. The feed is a recency-ordered window and the crawl budget is 120 pages, so the back catalogue is never revisited — in-place repair is the only route. Unlike the two encoding repairs this one is keyed on `source`: the same links under another provider are the employer's own text.

## Verification on real production data

Corpus: 115 title-matched pairs of the *same role* — the Himalayas mirror and the copy from the company's own ATS — across 54 companies and 22 different ATS providers, fetched from prod with full bodies.

| | |
|---|---|
| himalayas bodies changed | 115 / 115 (100%) |
| over-stripped a direct-ATS body | **0** |
| non-idempotent | **0** |
| residual `himalayas.app` link | **0** |
| exact `role_fingerprint` agreement, before | 0 |
| exact `role_fingerprint` agreement, after | **36** |

The other 79 pairs differ in prose, not markup — Himalayas mirrors an older revision of the posting (one had `seeking senior software engineers` where iCIMS has `staff software engineers`). No normalization reaches those, so this PR does not try.

### What was measured and rejected

Making `jobhash.normalizeRoleText` inline/block aware (delete inline tags, space block ones) was the obvious companion fix. On the same corpus it gains **nothing** (36 → 36) and **breaks 5 pairs** that already matched: Workday sometimes puts the word-separating space *inside* an inline tag, so deleting the tag glues `employees,including`. It would also have moved every fingerprint in the 3.5M-row catalogue. Not done.

## Ops after merge

```
go run ./cmd/backfill-descriptions himalayas   # ~15k rows, idempotent
go run ./cmd/backfill-derive                   # role_fingerprint hashes the description
make reindex
```

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`, `gofmt -l`
- [x] table-driven cover for both stored (`rel="nofollow"`) and raw anchor shapes, nested markup inside the backlink, the employer's own outbound links left alone, a body that merely names the mountain range, idempotency
- [x] backfill: himalayas row repaired, identical body under another provider untouched, already-clean row not rewritten, `content_hash` moves with the text, composes with the entity-decode repair