### PR TITLE
fix(web): GA sent no hits — dataLayer needs `arguments`, not an Array

### DIFF
--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isPrivateRoute, track, isFeatureEnabled } from './analytics';
+import { initTrackers, isPrivateRoute, track, isFeatureEnabled } from './analytics';
 
-// These tests exercise only the pure/guarded surface — no PostHog init happens,
-// so the module is in its uninitialized state throughout.
+// These tests exercise the pure/guarded surface — no PostHog init happens (the
+// config below carries no key), so the module is in its uninitialized state
+// throughout — plus the shape of what the GA bootstrap queues, which is the one
+// SDK side effect worth asserting: getting it wrong fails silently (see below).
 
 describe('isPrivateRoute', () => {
   it('treats /my and its subtree as private', () => {
@@ -30,5 +32,29 @@ describe('isFeatureEnabled (uninitialized)', () => {
   it('returns the caller-supplied fallback when PostHog is inert', () => {
     expect(isFeatureEnabled('some-flag', true)).toBe(true);
     expect(isFeatureEnabled('other-flag', false)).toBe(false);
+  });
+});
+
+describe('Google Analytics bootstrap', () => {
+  it('queues gtag commands as Arguments, not as a plain Array', () => {
+    // The bootstrap only needs a non-localhost hostname, a <script> object to
+    // fill in, and a head to append it to — stubbed here so it can run in the
+    // plain-node test environment.
+    Object.assign(globalThis, {
+      window: globalThis,
+      location: { hostname: 'freehire.me' },
+      document: { createElement: () => ({}), head: { appendChild: () => {} } },
+    });
+
+    initTrackers({ key: '', apiHost: '/ingest' });
+
+    const queued = (globalThis as { dataLayer?: unknown[] }).dataLayer ?? [];
+    expect(queued).toHaveLength(2); // gtag('js', …) and gtag('config', …)
+    // gtag.js recognizes a dataLayer entry as a command ONLY when it is an
+    // Arguments object; a plain Array is silently treated as a GTM-style push
+    // and ignored, so the tag loads and registers but never sends a hit.
+    for (const entry of queued) {
+      expect(Object.prototype.toString.call(entry)).toBe('[object Arguments]');
+    }
   });
 });

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -79,9 +79,17 @@ let gaLoaded = false;
 
 // Push a command onto GA's dataLayer, creating it on first use. At module scope (it
 // captures no locals) so it isn't recreated on each init.
-function gtag(...args: unknown[]): void {
-  (window.dataLayer ??= []).push(args);
-}
+//
+// WARNING: pushing `arguments` is load-bearing, not legacy style — it is the wire
+// format gtag.js expects. It reads a dataLayer entry as a command only when the
+// entry is an Arguments object; a plain Array (what rest parameters give) is taken
+// for a GTM-style push and silently dropped, so gtag.js loads and registers the
+// container but never sends a hit. Hence the untyped implementation behind an
+// explicit call signature: callers keep `(...args: unknown[]) => void`.
+const gtag: (...args: unknown[]) => void = function () {
+  // eslint-disable-next-line prefer-rest-params
+  (window.dataLayer ??= []).push(arguments);
+};
 
 /** Inject gtag.js and configure GA once. Skipped on localhost so dev traffic stays
  *  out of the property — matching the old app.html bootstrap. */


### PR DESCRIPTION
## What

Google Analytics has collected **nothing since 2026-07-22**. Root cause is a single line in `web/src/lib/analytics.ts`.

#1074 moved the gtag bootstrap out of the inline `app.html` snippet into `$lib/analytics` to put it behind the consent gate. The move was faithful except for one modernization:

```diff
-function gtag() { dataLayer.push(arguments); }        // app.html, verbatim Google snippet
+function gtag(...args: unknown[]) { dataLayer.push(args); }   // analytics.ts
```

`gtag.js` reads a `dataLayer` entry as a command (`js`, `config`, `event`) **only when that entry is an `Arguments` object**. A plain Array — what rest parameters give — is taken for a GTM-style push and silently dropped. `arguments` here is not legacy style; it is the wire format.

## Why it went unnoticed

Every liveness signal still looked right on prod:

- `gtag.js` returns 200
- the `G-6P1PZ719T0` container registers in `window.google_tag_manager`
- `window.gtag` is a function, `dataLayer` has entries

No console error, no warning. The only tells are the absent `/g/collect` request and the absent `_ga` cookie.

Nothing else could have caught it either: TypeScript accepts both shapes as `unknown[]`, `prefer-rest-params` actively pushes toward the broken form, and the change's spec only required that trackers **do not** fire without consent — never that they do fire with it.

## Verification

Single variable isolated on the live measurement ID, same browser and origin, everything else identical (dynamic script injection, same call order):

| dataLayer push | `/g/collect` hits | `_ga` cookie |
|---|---|---|
| `push(arguments)` | **2** | set |
| `push(args)` (current `main`) | **0** | none |

Also ruled out: CSP on prod is correct (`googletagmanager.com` allow-listed, theme hash matches), Consent Mode is inactive, the measurement ID is valid (its `gtag/js` payload is 73 KB larger than a bogus ID's and carries the stream config), and PostHog + Sentry ship from the same page fine.

> Note: `gtag.js` filters `HeadlessChrome` by UA and sends nothing, so a headless check gives a false negative here. The numbers above come from a non-headless UA, against a control page running the verbatim Google snippet.

## Test

`analytics.test.ts` gains a regression test asserting the queued entries are `[object Arguments]`. It fails on `main` with `[object Array]`.

This is the one gtag side effect worth unit-testing despite the module's "SDK side effects are verified visually" convention: `initGoogleAnalytics` skips `localhost` by design, so this branch of code has no local feedback at all and cannot be caught in dev.

## Follow-ups (not in this PR)

- The GA4 data stream URL still points at `freehire.dev`, which now 301s. Harmless for collection, but Google's "data collection isn't active" diagnostic probes that URL — worth updating in the GA admin.
- The consent gate blocks GA for every `Europe/*` timezone until Accept. By design, but numbers will not return to pre-July levels.