### PR TITLE
fix(prune): the board report needs a verdict, not the absence of one

### DIFF
--- a/cmd/prune/boards_test.go
+++ b/cmd/prune/boards_test.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
 )
 
 func writeBoardFile(t *testing.T, dir, name, body string) {
@@ -129,5 +135,85 @@ func TestLoadBoardsIgnoresRetiredSubdirectory(t *testing.T) {
 	}
 	if b.crawls("greenhouse", "gone:1") {
 		t.Error("a retired board must not read as crawled — moving it out of sources/ is what retires it")
+	}
+}
+
+// boardRow builds one candidate on a board, carrying the tri-state is_tech the
+// derivation writes: a nil isTech is the "unknown" the dictionaries leave behind.
+func boardRow(id int64, source, externalID string, isTech *bool, hasSkills bool) db.PruneCandidatesRow {
+	r := db.PruneCandidatesRow{ID: id, Source: source, ExternalID: externalID, HasSkills: hasSkills}
+	if isTech != nil {
+		r.IsTech = pgtype.Bool{Bool: *isTech, Valid: true}
+	}
+	return r
+}
+
+func boolp(v bool) *bool { return &v }
+
+// The report's premise is "this board has never posted anything technical", and that
+// only follows where something was actually classified. is_tech is tri-state by design
+// — jobderive leaves it NULL rather than coercing, "so the unclassified mass stays
+// measurable" — but the report collapsed NULL into false, so a board nobody had
+// classified read exactly like one determined to be non-technical.
+//
+// Measured on prod this was not an edge case: 11023 of the 17841 listed boards, 62% of
+// the report, had no verdict on a single posting, against 10.6% among the boards the
+// same report kept. Absence of a signal was doing the work of evidence.
+func TestReportBoardsWithholdsBoardsWithNoVerdict(t *testing.T) {
+	brd := boards{
+		listed: map[boardKey]bool{
+			{"greenhouse", "determined"}: true, {"greenhouse", "unknown"}: true,
+			{"greenhouse", "technical"}: true, {"greenhouse", "skilled"}: true,
+		},
+		byProvider: map[string]map[string]bool{"greenhouse": {
+			"determined": true, "unknown": true, "technical": true, "skilled": true,
+		}},
+	}
+	q := &fakeCandidates{rows: []db.PruneCandidatesRow{
+		// Classified, and the verdict was "not technical": the report may act on it.
+		boardRow(1, "greenhouse", "determined:1", boolp(false), false),
+		// Never classified either way — the 62% case. Nothing is known about it.
+		boardRow(2, "greenhouse", "unknown:1", nil, false),
+		// A verdict of "technical" keeps a board off the list, as before.
+		boardRow(3, "greenhouse", "technical:1", boolp(true), false),
+		// So does a tagged skill, even with no verdict on the row.
+		boardRow(4, "greenhouse", "skilled:1", nil, true),
+	}}
+
+	var out strings.Builder
+	if err := reportBoards(context.Background(), &out, q, brd); err != nil {
+		t.Fatalf("reportBoards: %v", err)
+	}
+	got := out.String()
+
+	if !strings.Contains(got, "determined") {
+		t.Errorf("a board whose postings were classified non-technical must be listed; got:\n%s", got)
+	}
+	for _, board := range []string{"unknown", "technical", "skilled"} {
+		if strings.Contains(got, board+"\n") {
+			t.Errorf("board %q must not be listed for retirement; got:\n%s", board, got)
+		}
+	}
+}
+
+// A guard that silently shrinks the report is worse than one that does not exist: the
+// operator reads a short list as "this is everything", and the withheld boards never
+// come back into view. The scan already reports what its source gate turned down, and
+// this gate owes the same accounting.
+func TestReportBoardsCountsWhatItWithheld(t *testing.T) {
+	brd := boards{
+		listed:     map[boardKey]bool{{"greenhouse", "unknown"}: true},
+		byProvider: map[string]map[string]bool{"greenhouse": {"unknown": true}},
+	}
+	q := &fakeCandidates{rows: []db.PruneCandidatesRow{
+		boardRow(1, "greenhouse", "unknown:1", nil, false),
+	}}
+
+	var out strings.Builder
+	if err := reportBoards(context.Background(), &out, q, brd); err != nil {
+		t.Fatalf("reportBoards: %v", err)
+	}
+	if !strings.Contains(out.String(), "1") || !strings.Contains(out.String(), "classified") {
+		t.Errorf("the report must say how many boards it withheld for want of a verdict; got:\n%s", out.String())
 	}
 }

--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -8,7 +8,13 @@
 // --boards is the report the company-scoped rules depend on. Those rules have no
 // counterpart at crawl time, so a deletion under one is undone by the next hourly crawl
 // unless the board leaves sources/ in the same step. This lists the candidates: boards
-// still listed whose company shows no technical evidence across its entire history.
+// still listed whose postings were classified and none of them came out technical.
+//
+// Boards nothing of which has been classified are withheld and counted, not listed. Most
+// of the catalogue carries no is_tech verdict — 62% of rows when this was measured — and
+// a board whose postings the dictionaries could not place has shown no technical signal
+// for want of any signal at all. Reading that as "never posted anything technical" struck
+// live IT employers on the first run of this report.
 //
 // Retiring a board means MOVING its entry to sources/retired/<provider>.yml, not
 // deleting it. Ingest takes one file by path and a glob does not descend, so an entry
@@ -331,17 +337,42 @@ type (
 	}
 )
 
-// reportBoards lists the boards still in the source files whose postings have never
-// shown anything technical — no technical title or category, and not one tagged skill.
-// Each is a candidate for the retirement PR — move the entry to
+// boardVerdict is what one board's postings collectively said about it.
+//
+// The two fields answer different questions and the report needs both. A board is a
+// retirement candidate only when something was classified AND none of it was technical;
+// with only the first field, "nothing was classified" is indistinguishable from
+// "everything was classified as non-technical".
+type boardVerdict struct {
+	// technical is the evidence that keeps a board: a posting resolved as technical,
+	// or one carrying a tagged skill.
+	technical bool
+	// determined is whether ANY posting got an is_tech verdict either way. is_tech is
+	// tri-state on purpose — jobderive leaves it NULL rather than coercing, so that the
+	// unclassified mass stays measurable — and this is where that third state is read.
+	determined bool
+}
+
+// reportBoards lists the boards still in the source files whose postings were classified
+// and none of them came out technical — no technical title or category, and not one
+// tagged skill. Each is a candidate for the retirement PR — move the entry to
 // sources/retired/<provider>.yml — which is the precondition for pruning its jobs under
 // a company-scoped rule.
+//
+// A board no posting of which has been classified is WITHHELD, not listed. The report's
+// premise is "this board has never posted anything technical", and absence of a
+// technical signal only carries that meaning where a signal was possible at all: a
+// posting the dictionaries could not place leaves is_tech NULL, which is not evidence of
+// anything. Measured on prod the distinction decided most of the report — 11023 of 17841
+// listed boards had no verdict on a single posting, 62% of the list, against 10.6% among
+// the boards the same run kept. Retiring on that basis would have struck live IT
+// employers whose only fault was a title the dictionary does not carry.
 //
 // It groups by BOARD rather than by company because that is the identity the source
 // files and the catalogue share exactly; the company slug diverges wherever an adapter
 // takes the name from the posting payload, which on some providers is most of them.
 func reportBoards(ctx context.Context, w io.Writer, q candidateSource, brd boards) error {
-	evidence := map[boardKey]bool{}
+	evidence := map[boardKey]boardVerdict{}
 	var after int64
 	for {
 		rows, err := q.PruneCandidates(ctx, db.PruneCandidatesParams{AfterID: after, PageSize: scanPage})
@@ -358,18 +389,37 @@ func reportBoards(ctx context.Context, w io.Writer, q candidateSource, brd board
 				continue // not from a listed board: nothing to retire
 			}
 			key := boardKey{Provider: row.Source, Board: board}
-			evidence[key] = evidence[key] || (row.IsTech.Valid && row.IsTech.Bool) || row.HasSkills
+			v := evidence[key]
+			v.technical = v.technical || (row.IsTech.Valid && row.IsTech.Bool) || row.HasSkills
+			v.determined = v.determined || row.IsTech.Valid
+			evidence[key] = v
 		}
 	}
 
 	var retire []boardKey
-	for key, hasEvidence := range evidence {
-		if !hasEvidence {
+	var withheld int
+	for key, v := range evidence {
+		switch {
+		case v.technical:
+			// Something technical: the board stays, as before.
+		case v.determined:
 			retire = append(retire, key)
+		default:
+			withheld++
+		}
+	}
+	// Say what the guard held back. A report that silently shrinks reads as "this is
+	// everything", and the withheld boards never come back into view — the same reason
+	// the scan counts its own refusals rather than dropping them.
+	if withheld > 0 {
+		if _, err := fmt.Fprintf(w,
+			"withheld %d boards: no posting of theirs has been classified either way, so nothing is known about them\n\n",
+			withheld); err != nil {
+			return err
 		}
 	}
 	if len(retire) == 0 {
-		_, err := fmt.Fprintln(w, "every listed board has posted something technical")
+		_, err := fmt.Fprintln(w, "every listed board that has been classified has posted something technical")
 		return err
 	}
 	sort.Slice(retire, func(i, j int) bool {

--- a/openspec/changes/fix-board-retirement-verdict/.openspec.yaml
+++ b/openspec/changes/fix-board-retirement-verdict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/fix-board-retirement-verdict/proposal.md
+++ b/openspec/changes/fix-board-retirement-verdict/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The board-retirement report reads absence of a technical signal as evidence that a
+board has none to give. For most of the catalogue there is no signal either way:
+`is_tech` is tri-state, and `jobderive` leaves it NULL rather than coercing, "so the
+unclassified mass stays measurable". The report collapsed that third state into
+`false`, so a board nobody had classified was indistinguishable from one determined
+to be non-technical.
+
+Measured on prod against the first full run of the report: of 17841 listed boards it
+named, 11023 — 62% — had no verdict on a single posting, against 10.6% among the
+boards the same run kept. The bias is structural rather than incidental, because the
+`is_tech IS TRUE` half of the evidence test needs a verdict to fire at all, so an
+unclassified board can only escape the list through the weaker tagged-skill signal.
+
+The consequence is not theoretical. `bamboohr/irishtitan` was listed while its only
+posting was the placeholder "No Positions Open"; a genuine `Associate Digital Project
+Manager` appeared hours later. `teamtailor/hypehype` — a game studio — was listed on
+the strength of one "Open Application" entry. Retiring a board stops it being crawled,
+and the company-scoped prune rules then become armed against its postings, so acting
+on those rows removes live IT employers from the catalogue for no observation at all.
+
+## What Changes
+
+- `cmd/prune --boards` lists a board only when at least one of its postings carries an
+  `is_tech` verdict and none of them came out technical. A board no posting of which
+  has been classified is withheld.
+- The report states how many boards it withheld and why, so a silently shorter list
+  cannot read as "this is everything" — the same accounting the scan already gives for
+  what its source gate turns down.
+
+## Impact
+
+- Affected specs: `catalog-pruning`
+- Affected code: `cmd/prune/main.go` (`reportBoards`), `cmd/prune/boards_test.go`
+- No schema change: `PruneCandidates` already returns the tri-state `is_tech`, and the
+  third state was being discarded at the point of use.
+- Operationally the report shrinks. That is the point: the withheld boards are not
+  safe, they are unmeasured, and they return to the report as classification reaches
+  them.

--- a/openspec/changes/fix-board-retirement-verdict/specs/catalog-pruning/spec.md
+++ b/openspec/changes/fix-board-retirement-verdict/specs/catalog-pruning/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Company-scoped removal requires retiring the board
+
+The system SHALL apply the company-scoped rules — non-technical category at a company without technical evidence, and unknown at a company with no evidence at all — only to companies whose board entries are removed from the source board files in the same step. Boards are re-crawled hourly on the unchanged dedup key, so a company-scoped deletion that leaves the board in place is undone within one crawl cycle; the ingest-time rejection covers only the title rule and cannot substitute for board retirement.
+
+The board-retirement report SHALL name a board only where its postings were classified and none of them resolved as technical. A board no posting of which carries an `is_tech` verdict MUST be withheld from the report rather than named, because `is_tech` is tri-state and the absence of a technical signal from an unclassified posting is not evidence about the board. The report MUST state how many boards it withheld on that ground, so a shorter list is not read as a complete one.
+
+#### Scenario: Company-scoped deletion without board retirement is refused
+
+- **WHEN** a run would apply a company-scoped rule to a company whose board is still listed in the source board files
+- **THEN** the run reports those companies and does not delete their jobs
+
+#### Scenario: Retirement candidates are reported
+
+- **WHEN** the operator requests the board-retirement report
+- **THEN** the system lists the board-file entries whose postings were classified and none resolved as technical, identified by the board the write path namespaces into `external_id`
+
+#### Scenario: An unclassified board is withheld, not retired
+
+- **WHEN** no posting of a listed board carries an `is_tech` verdict either way
+- **THEN** the board is absent from the retirement list and counted among the boards withheld for want of a classification
+
+#### Scenario: The report accounts for what it held back
+
+- **WHEN** the report withholds one or more boards for want of a classification
+- **THEN** it states how many, so the operator cannot mistake the remaining list for the whole of what the catalogue offers

--- a/openspec/changes/fix-board-retirement-verdict/tasks.md
+++ b/openspec/changes/fix-board-retirement-verdict/tasks.md
@@ -1,0 +1,13 @@
+## 1. Three-state evidence in the board report
+
+- [x] 1.1 Add a failing test: a board whose only posting has no `is_tech` verdict must not be listed, while a board whose postings were classified non-technical still is, and a technical verdict or a tagged skill still keeps a board off the list
+- [x] 1.2 Add a failing test that the report states how many boards it withheld
+- [x] 1.3 Replace the boolean evidence map with a `boardVerdict{technical, determined}`, listing a board only when `determined && !technical`
+- [x] 1.4 Print the withheld count above the list, and reword the empty-list line so it no longer claims every listed board posted something technical
+- [x] 1.5 Update the command's package documentation, which described the old rule
+
+## 2. Verification
+
+- [x] 2.1 `go build ./... && go vet ./... && gofmt -l` clean
+- [x] 2.2 `go test ./cmd/... ./internal/...` green
+- [ ] 2.3 Rebuild `prune` on prod and re-run `--boards`; confirm the withheld count lands near the measured 11023 of 17841 and the list near 6818

--- a/sources/retired/README.md
+++ b/sources/retired/README.md
@@ -18,10 +18,19 @@ the rules that need a retired board would stop firing.
 
 ## How an entry gets here
 
-`cmd/prune --boards` lists the boards whose companies have never posted anything
-technical — no technical title or category, and not one tagged skill, across their whole
-history. Move those entries out of `sources/<provider>.yml` and into
+`cmd/prune --boards` lists the boards whose postings were classified and none of them
+came out technical — no technical title or category, and not one tagged skill, across
+their whole history. Move those entries out of `sources/<provider>.yml` and into
 `sources/retired/<provider>.yml`, in the same PR that prunes their jobs.
+
+Boards no posting of which has been classified are withheld from that list and counted
+at the top of the report. They are not safe to retire; nothing is known about them.
+`is_tech` is tri-state and most of the catalogue carries no verdict, so a board whose
+titles the dictionaries could not place shows no technical signal for want of any
+signal — the first full run of this report named 11023 such boards out of 17841, and
+among them live IT employers whose only listed posting was "Open Application". A
+withheld board returns to the list when classification reaches it, which is what
+expanding the dictionaries (see `cmd/mine-titles`) is for.
 
 Order matters: **prune first, then move the provider's last entry.** Once a provider has
 no entries left in `sources/`, none of its jobs are re-crawlable, and every pruning rule


### PR DESCRIPTION
## Why

`cmd/prune --boards` read *absence of a technical signal* as evidence that a board has none to give. But `is_tech` is tri-state — `jobderive` leaves it NULL rather than coercing, "so the unclassified mass stays measurable" — and the report collapsed that third state into `false`. A board nobody had classified was indistinguishable from one determined to be non-technical.

## What the measurement showed

Against the first full run on prod, of the **17 841** listed boards the report named:

| | Boards | No verdict on any posting |
|---|---|---|
| Named for retirement | 17 276 | **10 731 (62.1%)** |
| Kept by the same run | 59 294 | 6 260 (10.6%) |

The bias is structural, not incidental: the `is_tech IS TRUE` half of the evidence test needs a verdict to fire at all, so an unclassified board could only escape the list through the weaker tagged-skill signal. Catalogue-wide, 3 290 133 of 5 325 786 rows (61.8%) carry no verdict.

Two boards it named, both live IT employers:

- `bamboohr/irishtitan` — named while its only posting was the placeholder `No Positions Open`. A genuine `Associate Digital Project Manager` (`is_tech = true`) appeared hours later.
- `teamtailor/hypehype` — a game studio, named on the strength of one `Open Application` entry.

Retiring a board stops it being crawled *and* arms the company-scoped prune rules against its postings, so acting on those rows removes the employer for no observation at all.

## What changes

- A board is named only when at least one of its postings carries an `is_tech` verdict and none of them resolved as technical.
- Boards nothing of which has been classified are **withheld and counted** at the top of the report. A report that silently shrinks reads as "this is everything" — the same accounting `scan` already gives for what its source gate turns down.
- No schema change: `PruneCandidates` already returned the tri-state; the third state was discarded at the point of use.

Expect the list to shrink from ~17 800 to ~6 800. The withheld boards are not safe, they are unmeasured, and they return to the report as classification reaches them — which is what expanding the dictionaries via `cmd/mine-titles` is for.

## Verification

- Two tests written first, both failing on the old behaviour (the unclassified board was listed), green after.
- `go build ./... && go vet ./... && gofmt -l` clean; `go test ./cmd/... ./internal/...` green.
- `openspec validate fix-board-retirement-verdict` passes.
- Not yet done: rebuild `prune` on prod and re-run `--boards` to confirm the counts land near 11 023 withheld / 6 818 listed.