### PR TITLE
feat(classify): second non-tech mining wave — 190k rows leave the unclassified mass

### DIFF
--- a/internal/classify/nontech.go
+++ b/internal/classify/nontech.go
@@ -125,6 +125,61 @@ var nonTechTitleTerms = []string{
 	"cuidador", "enfermeiro", "técnico de enfermagem", "auxiliar de enfermagem",
 	"babá", "motorista", "motoboy", "entregador", "vigilante", "camareira",
 	"recepcionista",
+
+	// ---- Second mining wave (cmd/mine-titles over the residual mass, 2026-07-28) ----
+	//
+	// The report ranks clusters by volume, and volume alone would have wrecked the
+	// catalogue: its largest groups were "team member", "systems engineer" (80
+	// sources), "team lead" (93), "tech lead" (78), "technical lead" (65),
+	// "software engineering" (55), "product management", "data center", and the bare
+	// seniorities "vice president"/"senior director"/"senior associate". Those name
+	// the roles this board exists to carry and are deliberately absent. So are the
+	// borderline "quality/process/project/service engineer" and "service technician",
+	// which are mostly industrial but collide with QA and IT field-service titles;
+	// they need their own decision, not a bulk import.
+	//
+	// Absent for a different reason: "banco de talentos" (29 sources), "general
+	// application" (34), "ausbildung zum" (18), "jovem aprendiz", "sökes till". These
+	// are not non-technical roles but ABSENT ones — speculative-application
+	// placeholders — and a technical company's talent pool matches them exactly.
+	// "são paulo" (23 sources) is a city, and "and older" is the tail of an age
+	// requirement; neither is a role at all.
+	//
+	// Non-software engineering. Anchored to a physical discipline, so a software role
+	// in the same domain ("Manufacturing Execution Systems Engineer") does not contain
+	// the phrase. "maintenance engineer" is deliberately NOT here: "Software
+	// Maintenance Engineer" already stands as a negative in this file's tests.
+	"electrical engineer", "mechanical engineer", "civil engineer",
+	"structural engineer", "manufacturing engineer", "quantity surveyor",
+	// Healthcare, continued. "mental health", "clinical research", "primary care" and
+	// "advanced practice" are domain words health-tech companies put in their own
+	// engineering titles, so only the anchored role forms are listed.
+	"mental health technician", "mental health counselor", "mental health therapist",
+	"mental health associate", "clinical research coordinator",
+	"clinical research associate", "primary care physician", "primary care provider",
+	"advanced practice provider", "advanced practice nurse",
+	"physician assistant", "family medicine", "medical director", "care coordinator",
+	"dietary aide", "radiology technologist", "mri technologist",
+	// Hospitality & food service, continued. Bare "chef" stays absent (Progress Chef,
+	// the config-management tool); the anchored brigade titles do not collide.
+	"sous chef", "chef de partie", "restaurant team", "room attendant", "guest service",
+	// Automotive service
+	"automotive technician", "automotive service", "service advisor", "auto body",
+	"oil change", "lube technician",
+	// Production & heavy equipment. Bare "production" names an SRE-adjacent role
+	// ("Production Engineer"), so only the anchored non-engineering forms are listed.
+	"production operator", "production associate", "production supervisor",
+	"maintenance supervisor", "equipment operator", "heavy equipment",
+	// Banking, insurance & the retail floor. "wealth management" and "client advisor"
+	// are absent: both are ordinary fintech engineering-title words.
+	"personal banker", "relationship banker", "associate banker", "financial advisor",
+	"insurance agent", "merchandise associate", "retail keyholder", "beauty advisor",
+	"store mgr", "store manager",
+	// Education, laboratory & facilities
+	"adjunct faculty", "assistant professor", "lab technician",
+	"environmental services", "community liaison",
+	// The Spanish/Portuguese and Russian tails of the same wave
+	"auxiliar administrativo", "охране труда", "охрана труда",
 }
 
 // ConfirmedNonTech reports whether a title states a non-technical role AND nothing

--- a/internal/classify/nontech_pruning_test.go
+++ b/internal/classify/nontech_pruning_test.go
@@ -50,3 +50,71 @@ func TestPruningTermsDoNotMatchTechnicalTitles(t *testing.T) {
 		}
 	}
 }
+
+// The second mining wave. Same contract as the first: every term deletes permanently,
+// so each family carries a real title it must place and a real technical title that
+// shares a word with it and must survive.
+func TestSecondWaveTermsMatchTheirCluster(t *testing.T) {
+	positive := []string{
+		"Electrical Engineer - Substation Design",
+		"Senior Mechanical Engineer (HVAC)",
+		"Civil Engineer, Roads and Drainage",
+		"Structural Engineer - Bridges",
+		"Quantity Surveyor - Commercial",
+		"Mental Health Technician - Night Shift",
+		"Clinical Research Coordinator II",
+		"Physician Assistant - Family Medicine",
+		"Primary Care Provider (APP)",
+		"MRI Technologist PRN",
+		"Care Coordinator, Community Health",
+		"Sous Chef - Fine Dining",
+		"Chef de Partie (Pastry)",
+		"Room Attendant - Housekeeping",
+		"Automotive Technician / Mechanic",
+		"Express Lube Technician",
+		"Heavy Equipment Operator - Class A",
+		"Production Supervisor, 2nd Shift",
+		"Personal Banker - Downtown Branch",
+		"Licensed Insurance Agent",
+		"Retail Keyholder (Part Time)",
+		"Store Mgr - Store 4471",
+		"Asst Store Mgr",
+		"Adjunct Faculty - Nursing",
+		"Lab Technician, Microbiology",
+		"Auxiliar Administrativo",
+		"Специалист по охране труда",
+	}
+	for _, title := range positive {
+		if !IsNonTech(title) {
+			t.Errorf("IsNonTech(%q) = false, want true", title)
+		}
+	}
+}
+
+func TestSecondWaveTermsDoNotMatchTechnicalTitles(t *testing.T) {
+	// Each shares a word with a second-wave term. These are the titles the volume
+	// ranking would have swept up had the clusters been imported as reported.
+	negative := []string{
+		"Manufacturing Execution Systems Engineer", // manufacturing engineer
+		"Electrical Grid Data Platform Engineer",   // electrical engineer
+		"Mechanical Design Automation Developer",   // mechanical engineer
+		"Structural Analysis Software Developer",   // structural engineer
+		"Backend Engineer - Mental Health Startup", // mental health technician
+		"Clinical Research Data Platform Engineer", // clinical research coordinator
+		"Site Reliability Engineer, Production",    // production supervisor/operator
+		"Production Engineer (Platform)",           // production supervisor/operator
+		"Equipment Telemetry Software Engineer",    // equipment operator
+		"App Store Release Engineer",               // store manager
+		"Data Engineer - Retail Analytics",         // retail keyholder
+		"Machine Learning Engineer, Primary Care",  // primary care physician/provider
+		"Full Stack Developer - Guest Experience",  // guest service
+		"Automotive Embedded Software Engineer",    // automotive technician
+		"Laboratory Information Systems Developer", // lab technician
+		"Медицинский информационный аналитик",      // охране труда (control, Cyrillic)
+	}
+	for _, title := range negative {
+		if IsNonTech(title) {
+			t.Errorf("IsNonTech(%q) = true, want false — a technical title must never match a pruning term", title)
+		}
+	}
+}

--- a/internal/jobderive/istech_test.go
+++ b/internal/jobderive/istech_test.go
@@ -39,8 +39,18 @@ func TestDerive_IsTech(t *testing.T) {
 			want: boolp(true),
 		},
 		{
-			name: "non-software engineer stays unknown → nil",
+			// The second mining wave anchors the named physical disciplines, so these
+			// leave the unclassified mass instead of sitting in it forever.
+			name: "named non-software discipline → false",
 			in:   Input{Title: "Senior Mechanical Engineer"},
+			want: boolp(false),
+		},
+		{
+			// A discipline neither dictionary names still stays unknown rather than
+			// being coerced: the tech detector is software-anchored and the non-tech
+			// one carries no bare "engineer".
+			name: "unnamed non-software engineer stays unknown → nil",
+			in:   Input{Title: "Drainage Engineer"},
 			want: nil,
 		},
 	}

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -181,7 +181,9 @@ func Derive(in Input) Derived {
 // unclassified mass stays measurable. The tech title detector is the symmetric
 // counterpart to IsNonTech — it rescues generic software titles ("Software
 // Engineer", "COBOL Programmer") that resolve no sub-category. A non-software
-// "…Engineer" (mechanical, drainage) matches neither detector and stays unknown.
+// "…Engineer" matches the non-tech detector only where its discipline is named
+// outright — "mechanical engineer", "civil engineer" and the rest of that anchored
+// family — so "Drainage Engineer" still matches neither detector and stays unknown.
 func deriveIsTech(category, title string) *bool {
 	if TechEvidence(category, title) {
 		t := true


### PR DESCRIPTION
## Why

61.8% of the catalogue — 3 290 133 of 5 325 786 rows — carries no `is_tech` verdict at all. Not "determined non-technical": *unclassified*. That residual is what makes the pruning campaign stall, and it is what a search like [`?q=florianopolis`](https://freehire.me/?q=florianopolis) surfaces — 697 of its 821 open jobs (85%) have no verdict.

`cmd/mine-titles` over the current residual mass returned 150 clusters. This adds the terms that survived two filters the report cannot apply itself.

## What was rejected, and why that matters more than what was added

Ranking by volume alone would have wrecked the catalogue. Its largest clusters were:

| Cluster | Jobs | Sources |
|---|---|---|
| `team lead` | 5 146 | 93 |
| `systems engineer` | 6 473 | 80 |
| `tech lead` | 1 319 | 78 |
| `technical lead` | 1 440 | 65 |
| `software engineering` | 1 538 | 55 |
| `vice president` | 7 457 | 59 |

These name the roles the board exists to carry. They are deliberately absent, along with the borderline `quality`/`process`/`project`/`service engineer` and `service technician` — mostly industrial, but they collide with QA and IT field-service titles and need their own decision rather than a bulk import.

A second rejected class is not about seniority at all: `banco de talentos` (29 sources), `general application` (34), `ausbildung zum`, `jovem aprendiz`, `sökes till`. Those are not non-technical roles but **absent** ones — speculative-application placeholders — and a technical company's talent pool matches them exactly. `são paulo` (23 sources) is a city; `and older` is the tail of an age requirement.

## Doctrine held

Where the head word also names a software role, the term is anchored, per the standing rule in `nontech.go`:

- `mental health technician`/`counselor`/`therapist`, not bare `mental health` — health-tech puts that phrase in its own engineering titles
- `primary care provider`/`physician`, not `primary care`
- `production supervisor`/`operator`/`associate`, not `production` (`Production Engineer` is SRE-adjacent)
- `maintenance engineer` absent outright: `Software Maintenance Engineer` already stands as a negative in this file's tests, and adding it would have broken them
- `wealth management`, `client advisor` absent as ordinary fintech engineering-title words

## Measured impact (prod)

| | Rows |
|---|---|
| Match the new terms | 239 903 |
| Already resolve as technical — vetoed by `TechEvidence`, unchanged | 2 669 |
| **Carried no verdict — the mass this wave determines** | **190 452** |
| …of those, open | 139 693 |

## One invariant changes

A non-software `…Engineer` no longer stays unknown *where its discipline is named outright*. `TestDerive_IsTech` asserted `Senior Mechanical Engineer → nil`; it now asserts `false`, and a new case pins `Drainage Engineer → nil` so the general rule still holds. The comment on `deriveIsTech` is updated to match.

## Verification

- `TestSecondWaveTermsMatchTheirCluster` / `TestSecondWaveTermsDoNotMatchTechnicalTitles` follow the first wave's contract: every family carries a real title it must place and a real technical title sharing a word with it that must survive.
- `go build ./... && go vet ./... && gofmt -l` clean; `go test ./...` green.
- No OpenSpec delta: `catalog-pruning` already specifies the removal as iterative dictionary expansion, and this is one iteration of it.
- Not yet done: `cmd/prune` dry run on prod with the new dictionary before any `--apply`.