### PR TITLE
docs(agents): retune the agent docs for Opus 5 — cut what the model already does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,165 +4,92 @@ Guidance for AI agents working in this repository.
 
 ## Working principles
 
-Non-negotiable. Bias toward caution over speed; use judgment on trivial tasks.
-
-- **Think before coding.** Surface assumptions. If multiple interpretations exist, present them — don't pick silently. If something is unclear, ask.
-- **Simplicity first.** Minimum code that solves the problem. No features, abstractions, or error handling that wasn't asked for. Prefer a library's intended API over a clever shim.
-- **Surgical changes.** Touch only what the task requires; don't refactor unbroken things or rework formatting. Match existing style. Clean up what your change orphaned; leave pre-existing dead code alone. Exception: do the real refactor when a clean change genuinely requires reshaping existing code.
-- **Fix root causes, not symptoms.**
 - **No overengineering, and no MVP shortcuts.** Hold the middle path: don't build infrastructure before there's a concrete need (note the seam for later instead), and don't ship quick-and-dirty or "for now" hacks. Build each feature correctly and idiomatically — neither gold-plated nor a placeholder.
-- **MVP stage — keep the architecture fluid.** The project is early/MVP; the current structure is not load-bearing legacy. When a new feature doesn't fit the existing architecture cleanly, prefer reshaping or refactoring the affected part over bolting on an awkward special case — re-architect freely to keep the design clean rather than accumulating legacy.
-- **English only.** All code, comments, identifiers, docs, and commits are in English.
-- **Announce shipped work.** When a user-facing feature or fix lands, close the loop by offering a changelog entry on the `/blog` feed, then a longer blog post if it warrants one (posts are `.svx` files in `web/src/posts/`; the `write-changelog` skill drafts them). Skip for internal-only changes.
+- **MVP stage — keep the architecture fluid.** The current structure is not load-bearing legacy. When a new feature doesn't fit cleanly, prefer reshaping the affected part over bolting on an awkward special case.
+- **Surgical changes.** Clean up what your change orphaned; leave pre-existing dead code alone. Prefer a library's intended API over a clever shim.
+- **English only.** All code, comments, identifiers, docs, and commits.
+- **Announce shipped work.** When a user-facing feature or fix lands, offer a changelog entry on the `/blog` feed, then a longer post if it warrants one (`.svx` files in `web/src/posts/`; the `write-changelog` skill drafts them). Skip for internal-only changes.
 
 ## What this is
 
-`freehire` ([freehire.me](https://freehire.me)) is an open-source IT job aggregator backend. Intended shape: many source parsers feed a pipeline that normalizes jobs into one schema, deduplicates them, and enriches them with AI; served over an HTTP API with rich filters.
+`freehire` ([freehire.me](https://freehire.me)) is an open-source IT job aggregator. Many source parsers feed a pipeline that normalizes jobs into one schema, deduplicates them, and enriches them with AI; served over an HTTP API with rich filters, consumed by a SvelteKit app under `web/`.
 
-**Current state: working backend.** Fiber HTTP server with `/health`, `/api/v1/jobs[/:slug]`, Meilisearch-backed `/api/v1/jobs/search`, companies endpoints, a `/api/v1/auth` surface (register/login/me with stateless JWT + OAuth sign-in), per-user job-interaction endpoints (view/apply/save/track, behind auth, addressed by slug), and API-key management under `/api/v1/me`; Postgres via sqlc with `jobs`, `companies`, `users`, `user_jobs`, `user_identities`, and `api_keys` tables; a typed, versioned enrichment schema on `jobs`; and a family of standalone, run-once-and-exit workers: `cmd/ingest` (crawls one board file, normalizes and upserts, enqueues new postings for enrichment), `cmd/enrich` (drains the enrichment outbox via an LLM), `cmd/embed` (incremental semantic-embedding worker), `cmd/tg-ingest`/`cmd/tg-extract` (Telegram crawl + LLM-extract), `cmd/liveness` (URL-probes orphan jobs, closes dead ones), `cmd/reindex`/`cmd/backfill-derive` (maintenance; `backfill-derive` re-derives every deterministic column — facets, role_fingerprint, slugs — in one pass), `cmd/rollup-stats` (activity rollup), `cmd/rollup-facets` (daily /open facet snapshot), `cmd/rollup-company` (per-company hiring-signal rollup), `cmd/import-yc` (YC directory enrichment). A Svelte SPA lives under `web/` and consumes the API.
-
-Stack: **Go + Fiber v2**, **PostgreSQL**, **sqlc**, **Docker Compose**, **langchaingo**.
+Stack: **Go + Fiber v2**, **PostgreSQL**, **sqlc**, **Meilisearch**, **Docker Compose**, **langchaingo**.
 
 ## Layout
 
-```
-cmd/server/main.go        entry point: Fiber startup + graceful shutdown
-cmd/ingest/main.go         source-ingest worker (crawls one board file per run)
-cmd/enrich/main.go         AI enrichment worker (drains outbox queue)
-cmd/embed/main.go          incremental semantic-embedding worker
-cmd/tg-ingest/main.go      Telegram crawl worker
-cmd/tg-extract/main.go     LLM-extracts Telegram vacancies
-cmd/liveness/main.go       URL-probes orphan jobs, closes dead ones
-cmd/reindex/main.go        rebuilds the Meilisearch jobs index
-cmd/reindex-companies/main.go  rebuilds the Meilisearch companies index (ranked company search behind GET /api/v1/companies)
-cmd/rollup-stats/main.go   recomputes the job_daily_stats rollup
-cmd/rollup-facets/main.go  recomputes the insights_facet_stats snapshot (/open facets)
-cmd/rollup-company/main.go recomputes insights_company_stats + insights_company_growth (per-company hiring-signal rollups; the latter backs GET /insights/companies)
-cmd/rollup-views/main.go   aggregates nginx access logs into jobs.view_count + job_daily_views (all-traffic views, off the read path)
-cmd/backfill-derive/main.go  re-derives every deterministic column in one keyset pass — dictionary facets, role_fingerprint (repost-identity), and public_slug/company_slug — matching what ingest writes for the same raw fields
-cmd/backfill-company-names/main.go  resolves real display names for slug-named companies
-cmd/import-yc/main.go      enriches companies from yc-oss directory
-cmd/migrate/main.go        versioned migration runner — applies pending migrations/*.sql, records them in schema_migrations, auto-baselines pre-runner databases (see db/AGENTS.md)
-sources/                   board files + sources/custom.yml + sources/telegram.yml
-internal/
-  config/            env config (server: PORT, DATABASE_URL, FRONTEND_ORIGIN, SERVED_HOSTS, JWT_SECRET/JWT_TTL, COOKIE_SECURE, MEILI_URL/MEILI_MASTER_KEY, OAUTH_*, EXTENSION_REDIRECT_ALLOWLIST, SENTRY_*; workers: LLM_BASE_URL/LLM_API_KEY/LLM_MODEL, EMBED_*)
-  observability/     optional Sentry error reporting (see observability/AGENTS.md)
-  database/          pgxpool connection pool
-  db/                GENERATED sqlc code + queries/*.sql (see db/AGENTS.md)
-  migrate/           versioned migration runner (schema_migrations, baseline, advisory lock; see db/AGENTS.md)
-  handler/           HTTP handlers + route wiring (see handler/AGENTS.md)
-  auth/              auth primitives: bcrypt, JWT Issuer, API-key hashing, cookie transport (see auth/AGENTS.md)
-  auth/oauth/        OAuth sign-in: Provider interface, registry, CSRF state cookie (see auth/oauth/AGENTS.md)
-  sources/           ATS source adapters + registry + HTTP client + board-file parsing (see sources/AGENTS.md)
-  linksource/        resolves outbound job-detail URLs (see linksource/AGENTS.md)
-  browsertools/      relays browser-tool frames between a user's agent harness and their browser extension (see browsertools/AGENTS.md)
-  telegram/          Telegram crawl + LLM vacancy extraction (see telegram/AGENTS.md)
-  pipeline/          ingest Runner (fetch → normalize → dedup → upsert) (see pipeline/AGENTS.md)
-  enrich/            enrichment contract + LLM Provider + queue-draining Runner (see enrich/AGENTS.md)
-  vocab/             shared controlled vocabularies for enum facets (seniority, category, regions, …) — neutral, dependency-free
-  embed/             incremental semantic embedding (see embed/AGENTS.md)
-  search/            Meilisearch-backed job search
-  location/          curated dictionary deriving country/region codes + work-mode hint (see location/AGENTS.md)
-  ycdir/             yc-oss directory to company-info mapping (see ycdir/AGENTS.md)
-  job/               Job domain aggregate: sealed type built only through job.New
-  jobview/           single public wire shape of a job, projected from Job aggregate (see jobview/AGENTS.md)
-  normalize/         slug normalization
-  companyname/       resolves real display names for slug-named companies (see companyname/AGENTS.md)
-  matchanalysis/     AI match analysis: three-stage LLM prompt-chain (see matchanalysis/AGENTS.md)
-  resumeextract/     structured résumé extraction from stored CV (see resumeextract/AGENTS.md)
-  userjob/           per-user job tracking (see userjob/AGENTS.md)
-  classify/          seniority/category tagging from job title (see classify/AGENTS.md)
-  skilltag/          deterministic skill tagging dictionary (see skilltag/AGENTS.md)
-  viewlog/           parses nginx access logs into per-job view counts (see viewlog/AGENTS.md)
-migrations/          SQL schema — source for BOTH sqlc and Postgres initdb
-design-system/         design system package (tokens, primitives, Storybook, docs) — pnpm, sibling to web/, linked via file:../design-system (see design-system/AGENTS.md)
-```
+`internal/<domain>/` — domain packages, the substantial ones carry their own AGENTS.md (see the table below).
+`cmd/<name>/` — every binary is a **run-once-and-exit** worker except `cmd/server`. They are cron-driven, not daemons; they need `DATABASE_URL` and exit non-zero on failure.
+
+Non-obvious:
+
+- `migrations/` — the source for **both** sqlc codegen and Postgres initdb. Never edit an applied migration; add a new file.
+- `sources/` — YAML board files, not Go. One file per ATS provider, plus `custom.yml` and `telegram.yml`.
+- `design-system/` — a separate pnpm package, sibling to `web/`, linked via `file:../design-system`.
+- `internal/db/` — **generated**; edit `internal/db/queries/*.sql` and run `make sqlc`.
+- `services/pii-filter` — a standalone service, not a Go package.
 
 ## Commands
 
 ```bash
 make up / make down / make logs       # start / stop / tail app + postgres in Docker
 make run / make psql / make sqlc      # run server on host / psql into DB / regenerate internal/db
-make reindex                          # rebuild the Meilisearch index from Postgres
+make reindex                          # rebuild the Meilisearch jobs index from Postgres
 go build ./...  &&  go vet ./...
-go test ./...                              # unit tests (no external deps)
+go test ./...                             # unit tests (no external deps)
 go test -tags=integration ./internal/db/  # queue integration tests (needs Docker; testcontainers)
-# run-once-and-exit cron workers (all need DATABASE_URL):
-go run ./cmd/ingest sources/<provider>.yml # crawl one board file (path as arg or SOURCES_FILE)
-go run ./cmd/enrich                        # + LLM_BASE_URL/LLM_API_KEY/LLM_MODEL
-go run ./cmd/embed                         # + MEILI_URL/MEILI_MASTER_KEY (+ EMBED_* to tune)
-go run ./cmd/tg-ingest                     # crawl sources/telegram.yml (path via CHANNELS_FILE)
-go run ./cmd/tg-extract                    # + LLM_* — drain telegram_posts into the catalogue
-go run ./cmd/liveness                      # URL-probe orphan jobs, close dead ones
-go run ./cmd/migrate                       # apply pending migrations (run BEFORE deploying code that reads new schema; -baseline records all on-disk files without executing; first run on a pre-runner database auto-baselines)
-go run ./cmd/backfill-derive               # re-derive every deterministic column (facets + role_fingerprint + slugs) in one pass; BACKFILL_CONCURRENCY tunes the worker pool; follow with make reindex (collapses newly-clustered reposts + unions their geography)
-go run ./cmd/backfill-company-names [--dry-run]  # resolve real names for slug-named companies; follow with make reindex
-go run ./cmd/rollup-stats                  # recompute job_daily_stats (run-once, cron ~every 3h)
-go run ./cmd/rollup-facets                 # + MEILI_URL/MEILI_MASTER_KEY — recompute insights_facet_stats (run-once, cron ~daily)
-go run ./cmd/rollup-company                 # recompute insights_company_stats + insights_company_growth (run-once, cron ~daily)
-go run ./cmd/rollup-views                    # aggregate nginx logs into jobs.view_count (+ VIEW_LOG_DIR/VIEW_LOG_BASE; --backfill for .gz history; run-once, cron ~daily, own flock)
-go run ./cmd/reindex-companies             # + MEILI_URL/MEILI_MASTER_KEY — rebuild the companies search index (run-once, cron ~daily; own flock, NOT stacked with make reindex)
 ```
 
-For the full architecture and conventions, see the **module files** below. Each module is self-contained and can be read independently.
+Worker gotchas (`go run ./cmd/<name>`, all need `DATABASE_URL`; run `ls cmd/` for the full list):
+
+- `migrate` — run **before** deploying code that reads new schema. `-baseline` records on-disk files without executing; a pre-runner database auto-baselines on first run.
+- `ingest` — takes one board file: `go run ./cmd/ingest sources/<provider>.yml` (or `SOURCES_FILE`).
+- `enrich` / `tg-extract` — need `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL`.
+- `embed` / `rollup-facets` / `reindex-companies` — need `MEILI_URL` / `MEILI_MASTER_KEY`.
+- `backfill-derive` — re-derives every deterministic column (facets, `role_fingerprint`, slugs) in one keyset pass; `BACKFILL_CONCURRENCY` tunes the pool. Follow with `make reindex` — it collapses newly-clustered reposts and unions their geography.
+- `reindex-companies` and `rollup-views` hold their own flock. **Never stack `reindex-companies` with `make reindex`** — Meilisearch deadlocks.
+- `prune` — the **only** hard-delete path. Dry-run by default; archives every removal to `pruned_jobs`.
 
 ## Module files
 
-### Backend core
+Each is self-contained and can be read independently.
 
 | Area | Reference |
 |---|---|
 | **HTTP handlers** (response shapes, error rendering, routes) | [internal/handler/AGENTS.md](internal/handler/AGENTS.md) |
 | **SQL layer** (sqlc, queries, migrations) | [internal/db/AGENTS.md](internal/db/AGENTS.md) |
+| **Search** (Meili index topology, rebuild swap, reindex hazards) | [internal/search/AGENTS.md](internal/search/AGENTS.md) |
+| **Accounts** (identity resolution, seizure rule, mailed codes) | [internal/accounts/AGENTS.md](internal/accounts/AGENTS.md) |
 | **Auth primitives** (JWT, API keys, cookie transport, middleware) | [internal/auth/AGENTS.md](internal/auth/AGENTS.md) |
 | **OAuth sign-in** (provider registry, state cookie, identity resolution) | [internal/auth/oauth/AGENTS.md](internal/auth/oauth/AGENTS.md) |
 | **Per-user job tracking** (view/apply/save/track, stages, /me/tracking) | [internal/userjob/AGENTS.md](internal/userjob/AGENTS.md) |
-
-### Ingest pipeline
-
-| Area | Reference |
-|---|---|
-| **Source ingest** (board files, provider registry, validation, USAJobs) | [internal/sources/AGENTS.md](internal/sources/AGENTS.md) |
+| **Job wire shape** (the single public projection of a job) | [internal/jobview/AGENTS.md](internal/jobview/AGENTS.md) |
+| **Browser tools** (relays tool frames between agent harness and extension) | [internal/browsertools/AGENTS.md](internal/browsertools/AGENTS.md) |
+| **Source ingest** (board files, provider registry, validation) | [internal/sources/AGENTS.md](internal/sources/AGENTS.md) |
 | **Pipeline** (Runner, dedup, UpsertJob, board health, search indexing) | [internal/pipeline/AGENTS.md](internal/pipeline/AGENTS.md) |
 | **Link resolution** (outbound job URL → destination's own identity) | [internal/linksource/AGENTS.md](internal/linksource/AGENTS.md) |
 | **Board contributions** (crowdsourced URL → (source, board) onboarding) | [internal/contribution/AGENTS.md](internal/contribution/AGENTS.md) |
-
-### AI enrichment
-
-| Area | Reference |
-|---|---|
-| **Enrichment** (Enrichment contract, LLM Provider; enum vocabularies live in `internal/vocab`) | [internal/enrich/AGENTS.md](internal/enrich/AGENTS.md) |
+| **Telegram** (crawl + LLM vacancy extraction) | [internal/telegram/AGENTS.md](internal/telegram/AGENTS.md) |
+| **Company names** (real display names for slug-named companies) | [internal/companyname/AGENTS.md](internal/companyname/AGENTS.md) |
+| **Enrichment** (Enrichment contract, LLM Provider; enums live in `internal/vocab`) | [internal/enrich/AGENTS.md](internal/enrich/AGENTS.md) |
 | **Semantic embedding** (semantic_outbox, incremental embeds, reconciler) | [internal/embed/AGENTS.md](internal/embed/AGENTS.md) |
 | **AI fit analysis** (three-stage LLM prompt-chain, score, verdict, stream) | [internal/matchanalysis/AGENTS.md](internal/matchanalysis/AGENTS.md) |
-| **Structured résumé** (LLM parse of stored CV, stamp-and-compare) | [internal/resumeextract/AGENTS.md](internal/resumeextract/AGENTS.md) |
-
-### Dictionary facets
-
-| Area | Reference |
-|---|---|
+| **Structured CV** (LLM parse of stored CV, stamp-and-compare) | [internal/resumeextract/AGENTS.md](internal/resumeextract/AGENTS.md) |
+| **CV rendering** (templates, fonts, previews) | [internal/cv/AGENTS.md](internal/cv/AGENTS.md) |
 | **Geography** (country/region codes, work-mode hint, dict-only vs hybrid) | [internal/location/AGENTS.md](internal/location/AGENTS.md) |
 | **Skill tagging** (alias→canonical dictionary, jobs.skills facet) | [internal/skilltag/AGENTS.md](internal/skilltag/AGENTS.md) |
 | **Seniority & category** (title→seniority/category, dict-only) | [internal/classify/AGENTS.md](internal/classify/AGENTS.md) |
-
-### Cross-cutting
-
-| Area | Reference |
-|---|---|
+| **View counts** (nginx access logs → per-job views) | [internal/viewlog/AGENTS.md](internal/viewlog/AGENTS.md) |
+| **YC directory** (import-yc, curated facets, matching by former names) | [internal/ycdir/AGENTS.md](internal/ycdir/AGENTS.md) |
+| **Sentry error tracking** (backend, workers, frontend — env-gated) | [internal/observability/AGENTS.md](internal/observability/AGENTS.md) |
+| **Mail stack** (Gmail + SES inbound → classify → link → stage advance) | [docs/agents/mail-stack.md](docs/agents/mail-stack.md) |
+| **Notifications** (subscription digests, saved-job reminders, channels) | [docs/agents/notifications.md](docs/agents/notifications.md) |
 | **Job lifecycle** (soft-close, ingest sweep, self-close, liveness probe) | [docs/agents/job-lifecycle.md](docs/agents/job-lifecycle.md) |
 | **Company facets** (remote_regions vs yc_* curated facets) | [docs/agents/company-facets.md](docs/agents/company-facets.md) |
-| **Sentry error tracking** (backend, workers, frontend — env-gated) | [internal/observability/AGENTS.md](internal/observability/AGENTS.md) |
-| **YC directory** (import-yc, curated facets, matching by former names) | [internal/ycdir/AGENTS.md](internal/ycdir/AGENTS.md) |
-
-### Frontend
-
-| Area | Reference |
-|---|---|
 | **SPA sub-context** (SvelteKit, auth flow, API conventions) | [web/AGENTS.md](web/AGENTS.md) |
-| **Design system** (tokens, primitives, Storybook, DSDS docs) | [design-system/AGENTS.md](design-system/AGENTS.md) |
+| **Design system** (pnpm package, tokens, Tailwind @source trap) | [design-system/AGENTS.md](design-system/AGENTS.md) |
 
-## Conventions (quick reference)
-
-> **Full details in the module files above.** This section is a quick-reference only.
+## Conventions
 
 - **Response shapes:** Lists: `{"data": ..., "meta": {...}}`; single items: `{"data": ...}`; errors: `{"error": msg}`
 - **Dedup key:** `jobs.UNIQUE (source, external_id)` — `UpsertJob` is `ON CONFLICT` on it
@@ -171,8 +98,7 @@ For the full architecture and conventions, see the **module files** below. Each 
 - **API keys:** Hashed at rest (SHA-256), scoped `full` or `cv`. Key management (create/list/revoke) and password change are cookie-only
 - **Enrichment:** Queue-driven (`enrichment_outbox`), provider-agnostic LLM, `Sanitize` + `Validate` gate
 - **Embeddings:** Queue-driven (`semantic_outbox`), incremental, reconciled by `reindex --semantic`
-- **Dictionaries:** All facet dictionaries are dict-only in production (never guess, emit nothing for unknowns)
-- **Migrations:** `cmd/migrate` applies pending `migrations/*.sql` in filename order and records them in `schema_migrations` (version = filename, one tx per file, advisory lock). Fresh volumes still get the full dir via Postgres initdb; a pre-runner database is auto-baselined on first run. Never edit an applied migration — add a new file.
-- **Job deletion:** The lifecycle only soft-closes. `cmd/prune` is the sole hard-delete path — an operator-driven catalogue-pruning campaign, dry-run by default, archiving every removal to `pruned_jobs`
+- **Dictionaries:** All facet dictionaries are dict-only in production — never guess, emit nothing for unknowns
+- **Job deletion:** The lifecycle only soft-closes; `cmd/prune` is the sole hard-delete path
 - **Sentry:** Opt-in, env-gated, errors-only — `sentry.Init` with `SendDefaultPII:false`
-- **Naming — "CV", not "résumé":** Prefer **CV** over "résumé"/"resume" in user-facing copy, new identifiers, comments, and docs — the term is currently mixed and that inconsistency is the thing to stop. Don't mass-rename the existing `resume`/`resumeextract` packages and columns (churn without value); just default new surfaces to "CV".
+- **Naming — "CV", not "résumé":** Default new surfaces to **CV**. Don't mass-rename the existing `resume`/`resumeextract` packages and columns — churn without value

--- a/design-system/AGENTS.md
+++ b/design-system/AGENTS.md
@@ -1,0 +1,41 @@
+# Design system
+
+`freehire-design-system` — tokens and Svelte primitives, a **pnpm** package sibling to
+`web/`, linked in as `file:../design-system`. `web/src/lib/ui/index.ts` is a thin re-export
+surface, so app code imports from `$lib/ui` and never reaches into the package directly.
+
+Being extracted from `web/` in phases by an external contributor; the phase inventory lives
+in `design-system/docs/`. Scripts that still `echo` a placeholder (`storybook`,
+`validate:docs`) are unfinished phases, not breakage.
+
+## Always true
+
+- **pnpm, not npm.** `pnpm install && pnpm build` here, then `pnpm install` in `web/`.
+  Corepack activates the pinned version. There is no `package-lock.json` anywhere — adding
+  one breaks the CI `design-system` → `web` job chain.
+- **A new utility class used inside `design-system/src/*.svelte` needs `web/src/app.css` to
+  cover it.** The package resolves under `node_modules/`, which **Tailwind v4's automatic
+  source detection ignores**, so its classes are dropped from web's built CSS unless
+  `@source "../../design-system/src/**/*.svelte";` (already present, line 16) matches the
+  file. Move a component into a path that line doesn't cover and its unique classes vanish.
+- **Nothing in CI catches a dropped class.** Tailwind discards unknown classes silently, the
+  build stays green, and the component just renders untinted. This is how
+  `<Badge variant="missing">` lost its destructive tint in phase 4. Verify a moved or new
+  primitive **visually**, not by a passing build.
+- **Token custom properties are not automatically Tailwind utilities.** The z-index tokens
+  ship from `dist/tokens-*.css` as plain `--z-modal` etc., but Tailwind mints `z-<name>` only
+  from the `--z-index-*` namespace — hence the `@theme inline` aliases in `app.css`
+  (`--z-index-modal: var(--z-modal);`). A new token family needs the same bridge or its
+  utilities silently no-op.
+- Tokens are authored as `tokens/*.tokens.json` and compiled by Style Dictionary
+  (`scripts/build-tokens.mjs`) into `dist/`. Edit the JSON, run `pnpm build` — never hand-edit
+  `dist/`.
+- `svelte` and `tailwindcss` are **peer** dependencies; the package must not bundle its own
+  copy.
+
+## Limitations
+
+- `web/pnpm-workspace.yaml` still carries unfilled `allowBuilds` placeholders
+  (`'@sentry/cli': set this to true or false`). Harmless — `strictDepBuilds: false` governs
+  the skip — but they should become real booleans.
+- Storybook and the DSDS docs site are not configured yet.

--- a/docs/agents/mail-stack.md
+++ b/docs/agents/mail-stack.md
@@ -1,0 +1,74 @@
+# Mail stack
+
+Six packages and three workers turn inbound recruiter mail into linked, stage-advancing
+applications. Each package has a package doc explaining *what* it does; this file explains
+how they compose and where the traps are.
+
+## The pipeline
+
+```
+                 ┌── Gmail OAuth ──→ internal/gmailsync ──┐
+inbound mail ────┤                                        ├──→ emails table
+                 └── SES→S3→SQS ──→ internal/mailingest ──┘    (source = gmail|hosted)
+                                                                      │
+                                          email_classification_outbox │
+                                                                      ▼
+                                                        internal/maillink (runner)
+                                                          ├─ internal/mailmatch   deterministic
+                                                          └─ internal/mailclassify  LLM + vocabulary
+                                                                      │
+                                                        link + monotonic stage advance
+```
+
+| Package | Role |
+|---|---|
+| `internal/gmailsync` | Incremental Gmail OAuth connect + per-user sync worker (`cmd/gmail-sync`) |
+| `internal/mailingest` | SES inbound: parse MIME → resolve recipient → store (`cmd/mail-ingest`, a daemon) |
+| `internal/mailbox` | Derives `<handle>@<MAILBOX_DOMAIN>`; pure — allocation lives in the handler |
+| `internal/maillink` | Drains the classification outbox, decides link + stage (`cmd/classify-mail`) |
+| `internal/mailmatch` | Deterministic match: thread continuity, company name in sender/subject |
+| `internal/mailclassify` | Status vocabulary, sanitizer, LLM adapter |
+
+## Always true
+
+- **Never match on the sender-address domain.** Inbox mail arrives from ATS relay domains
+  (`ashbyhq.com`, `greenhouse-mail.io`, …), not from employer domains. `mailmatch` matches on
+  thread continuity and the company name carried in the sender *name* / subject. A
+  domain-based shortcut looks obvious and is wrong.
+- **Read the body via `readableBody(text, html)`, never `body_text` alone.** Many ATS senders
+  (Gem, Ashby, Greenhouse) send **HTML-only** mail with no `text/plain` part, so `body_text`
+  is empty and a classifier fed only that judges from the subject line — which once turned a
+  plain rejection into `screening`. Bounded downstream by `TruncateRunes(4000)`.
+- **Two confidence gates, two different decisions** (`maillink/decide.go`): `autoLink`
+  decides auto-link vs. a suggestion the user confirms; `stage` decides automatic
+  advancement. Only a *linked* email, at or above the stage threshold, whose signal maps
+  **strictly forward**, advances a stage — never backward, never sideways.
+- **Only a deterministic tier (`TierThread` / `TierName`) can auto-link.** A confident LLM
+  pick becomes a *suggestion*, never a link. Keep that asymmetry: the LLM reads untrusted
+  text.
+- **`mailclassify` is the prompt-injection and out-of-vocabulary guard.** Email bodies are
+  attacker-controlled. An unknown signal is sanitized to `other` before anything is
+  persisted or served — do not persist a raw model string.
+- **`MAILBOX_DOMAIN` ≠ `MAIL_DOMAIN`.** The first is the *receiving* domain (mailbox
+  addresses; read by both the API's `mailboxReady` gate and `cmd/mail-ingest`); the second is
+  the SES *sending* identity for notifications. They may point at the same host — they are
+  still separate settings with separate IAM.
+- Recipient lookup in `mailingest` is **case-insensitive**; addresses are allocated
+  lowercase.
+- The whole `/me/gmail|inbox|emails|mailbox` surface is `RequireRole("moderator")` — exact
+  match, admin is *not* admitted.
+
+## Infrastructure notes
+
+The SES inbound pipeline is inherited from the retired `apply` app, so the AWS resources
+still carry `freehire-apply-*` names (`freehire-apply-inbound-mail` queue,
+`freehire-apply-mail-raw-*` bucket). **Do not rename them in terraform** — it would recreate
+the queue and bucket. `cmd/mail-ingest` runs as a long-lived unit (`Restart=always`), unlike
+every other worker in this repo.
+
+## Limitations
+
+- Gmail sync runs under an unverified restricted-scope OAuth app — test users only until
+  Google verification.
+- `internal/gmailsync/learn.go` self-learns confident job-mail sender domains; promotion is
+  count-based and has no decay.

--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -1,0 +1,47 @@
+# Notifications
+
+Two independent delivery use cases share one channel abstraction:
+
+| Package | Use case | Worker |
+|---|---|---|
+| `internal/notify` | Filter subscriptions — new jobs matching a saved search | `cmd/notify` |
+| `internal/reminder` | Saved-job nudges — come back before the vacancy goes stale | `cmd/remind` |
+| `internal/emailnotify` | Email channel (SES) — implements both `Notifier` interfaces | — |
+| `internal/telegramnotify` | Telegram channel (Bot API, deep-link token) | — |
+
+## Always true
+
+- **A new channel is a new `Notifier` implementation, never an engine change.** Both engines
+  depend only on their `Notifier` interface plus a `Router` (a `map[channel]Notifier`).
+  Adding webhooks means adding a package, not touching `notify` or `reminder`.
+- **`notify.Channels` is the single source of truth** for the channel vocabulary, shared by
+  the router's dispatch and the subscription use case's create-time allowlist so the two
+  cannot drift. Add a channel there or it will be creatable but undeliverable.
+- **An unconfigured channel is a soft-skip, not a failure.** `Router.Send` returns
+  `ErrChannelNotConfigured` (e.g. email while SES is unset) and the engine skips it. Don't
+  promote that to a delivery error — it would fail every run in environments without SES.
+- **Matching is O(distinct queries), not O(subscribers).** `notify.Runner.Run` groups
+  subscriptions sharing a saved-search query so the search index is hit once regardless of
+  how many people subscribed to it. A per-subscription loop would multiply index load by
+  subscriber count.
+- **The dedup ledger's primary key is what makes matching idempotent.** MATCH records
+  matched jobs, DELIVER leases them and marks them notified — so re-scanning recent jobs
+  never delivers twice. Preserve the two-stage split; merging match and send loses the
+  guarantee.
+- `Digest.Jobs` is capped to the configured digest size while `Digest.Total` carries the true
+  count, so a renderer can show the "and N more" tail. Don't derive the count from `len(Jobs)`.
+- `DigestJob` deliberately carries **no internal job id** — only the public slug and URL.
+- Salary fields are projected from enrichment; zero min/max or an empty currency means
+  unknown, and the renderer omits the line rather than printing a zero.
+
+## Note on naming
+
+`internal/telegramnotify` (outbound, notifications) is the sibling of `internal/telegram`
+(inbound, channel crawling for vacancies). They are unrelated concerns that both talk to the
+Bot API — check which one you're in.
+
+## Limitations
+
+- Delivery is cron-driven and run-once; there is no retry queue. A channel outage means that
+  pass's digests are skipped, and the ledger redelivers them on the next pass only if they
+  were never marked notified.

--- a/internal/accounts/AGENTS.md
+++ b/internal/accounts/AGENTS.md
@@ -1,0 +1,50 @@
+# Accounts conventions
+
+Account resolution and the credential lifecycle: password register/login, mailed six-digit
+codes, password reset/change, and mapping an external sign-in identity onto a local user.
+
+## Scope boundary
+
+Three packages split this surface — keep the split:
+
+- **`internal/accounts`** (here) — the *policy*: who an identity resolves to, what a valid
+  password is, when a code is burnt.
+- **`internal/auth`** — the *primitives*: bcrypt, JWT issue/verify, cookie transport,
+  middleware. See [../auth/AGENTS.md](../auth/AGENTS.md).
+- **`internal/auth/oauth`** — provider registry and the authorization-code flow.
+- **`internal/handler`** — HTTP shape and rate limiting; handlers never re-implement policy.
+
+## Always true
+
+- **Identity-first, then verified-email, never anything else.** `ResolveOAuthAccount` tries
+  `(provider, provider_user_id)` first, and only then falls back to email — and only when
+  the provider reports it **verified**. An unverified or empty email is `ErrNoVerifiedEmail`
+  and resolves to nothing. This is the anti-takeover gate; do not add a path around it.
+- **The seizure rule.** When a provider-verified identity arrives for an address held by an
+  *unverified, password-backed* account, that account is **seized**: `password_hash = NULL`,
+  `email_verified = true`, `token_version + 1` (see `migrations`/`users.sql`). The password
+  someone set on an address they never proved is destroyed rather than silently joined —
+  otherwise registering against a stranger's address would pre-hijack their future OAuth
+  sign-in.
+- **Every credential change bumps `token_version`.** Set/reset password and seizure all
+  increment it, which strands every outstanding JWT. That coupling is the entire revocation
+  story for a stateless token — a new credential write path that skips the bump silently
+  leaves old sessions alive.
+- **Login is constant-work.** An unknown email still spends a bcrypt check against
+  `dummyPasswordHash`, so response timing doesn't disclose whether an account exists.
+  `TestLogin_UserNotFound_SpendsDummyCheck` pins it.
+- **Password bounds are bcrypt's, not a style choice.** `maxPasswordLen = 72` because bcrypt
+  silently truncates past 72 bytes — accepting a longer one would ignore its tail.
+- **Codes are keyed `(user_id, purpose)`**, at most one outstanding per purpose, so a pending
+  email verification and a pending password reset never overwrite each other. TTL 15 min,
+  5 wrong guesses, 60 s resend cooldown.
+- `ErrInvalidCode` deliberately covers wrong / consumed / burnt without distinguishing them.
+- OAuth callbacks race: `ResolveOAuthAccount` handles both `ErrIdentityConflict` (same
+  identity, concurrent callback) and `ErrEmailRace` (different identity, same verified
+  email) by retrying rather than failing. Both paths are unit-tested — preserve them if you
+  touch the resolution order.
+
+## Limitations
+
+- No magic-link sign-in, no identity unlinking (the repository seam exists, the UI doesn't).
+- The rate limiter on credential endpoints is per-instance, in-memory (`internal/handler`).

--- a/internal/db/AGENTS.md
+++ b/internal/db/AGENTS.md
@@ -11,16 +11,32 @@ The `internal/db` package — generated sqlc code, hand-written SQL queries, and
 - `jobs.UNIQUE (source, external_id)` is the dedup key; `UpsertJob` is `ON CONFLICT` on it.
 - Fresh volumes get the whole `migrations/` dir via Postgres initdb (mounted into `/docker-entrypoint-initdb.d`, applied once on first init, in filename order). Every existing database (prod included) is migrated by `cmd/migrate` (`go run ./cmd/migrate`), which applies only files not yet recorded in `schema_migrations` (version = filename) — one transaction per file, under a session advisory lock. Changing an already-applied migration does NOT re-apply it; add a new file instead.
 - A new column referencing `users` needs its **own index** — Postgres indexes only the referenced side, so an unindexed reference makes every account deletion scan that table (this is what timed out account deletion against the 19 GB `jobs` table). `TestEveryUserForeignKeyIsIndexed` enforces it.
-- Response shapes: lists are `{"data": ..., "meta": {...}}`, single items are `{"data": ...}`, errors are `{"error": msg}`.
-- Handlers signal failure by returning an error — `fiber.NewError(status, msg)` for specific codes, or a bare error (e.g. `pgx.ErrNoRows`). The central `handler.RenderError` maps `*fiber.Error`→its code, `pgx.ErrNoRows`→404, FK violation (SQLSTATE 23503)→404, everything else→500. Don't hand-roll per-handler error JSON.
+
+Response shapes and error rendering are the handler layer's concern — see
+[../handler/AGENTS.md](../handler/AGENTS.md).
 
 ## How it works
 
-sqlc generates Go types and methods from hand-written SQL in `internal/db/queries/*.sql`. The migration files in `migrations/` define the schema; sqlc reads them to generate `models.go` (types) and `*.sql.go` (queries). The generated `*db.Queries` struct holds all DB methods. Handlers receive a pointer to this struct — created once during route registration in `handler.Register` — and never touch pgx directly.
+sqlc reads `migrations/` for the schema and the hand-written SQL in
+`internal/db/queries/*.sql` for the operations, generating `models.go` (types) and
+`*.sql.go` (queries). The connection pool is owned by `internal/database/pgxpool`; the
+server and every worker get `DATABASE_URL` via `config.Load`.
 
-Migrations are raw SQL files. On a fresh Docker volume Postgres's entrypoint applies the whole dir once (initdb); on every existing database `cmd/migrate` (package `internal/migrate`) applies pending files in filename order and records them in `schema_migrations (version text PK, applied_at)`. Deploy rule: run `go run ./cmd/migrate` BEFORE deploying code that reads new schema (the same rule migration comments already state). Bootstrap of a pre-runner database is automatic: an empty `schema_migrations` with the `jobs` table present means the schema is already current, so the runner baselines — records all on-disk files as applied without executing them (`-baseline` forces this explicitly). A file that must run outside a transaction (e.g. `CREATE INDEX CONCURRENTLY`) opts out with `-- migrate: no-transaction` in its leading comment block; write such files idempotently (`IF NOT EXISTS` / `IF EXISTS`).
+Two migration paths, one ordering rule (filename order, always):
 
-The connection pool is owned by `internal/database/pgxpool`. Each worker and the server load config via `config.Load` to get `DATABASE_URL`.
+- **Fresh Docker volume** — Postgres's entrypoint applies the whole `migrations/` dir once
+  via initdb.
+- **Every existing database, prod included** — `cmd/migrate` (package `internal/migrate`)
+  applies only files absent from `schema_migrations (version text PK, applied_at)`, one
+  transaction per file, under a session advisory lock.
+
+A pre-runner database baselines itself: an empty `schema_migrations` plus an existing
+`jobs` table means the schema is already current, so the runner records every on-disk file
+as applied without executing it (`-baseline` forces this).
+
+A file that must run outside a transaction (e.g. `CREATE INDEX CONCURRENTLY`) opts out with
+`-- migrate: no-transaction` in its leading comment block — write those idempotently
+(`IF NOT EXISTS` / `IF EXISTS`).
 
 ## Limitations
 - Historical parallel branches produced duplicate number prefixes (`0009_*`×2, `0034_*`×4, …). Harmless: initdb and the runner both order by full filename, and `schema_migrations.version` is the filename, not the number. New files take the next free number; never renumber old files (their versions are already recorded on migrated databases).

--- a/internal/handler/AGENTS.md
+++ b/internal/handler/AGENTS.md
@@ -10,32 +10,16 @@ Fiber HTTP handlers: feature handler structs, route registration, auth surface, 
   in an order that keeps literal routes before param routes (e.g. `/jobs/search` before
   `/jobs/:slug`, `/threads/count` before `/threads/:id`, the static `/me/tracking/*`
   before `/me/tracking/:slug`).
-- Each feature area owns a struct with its own dependencies, a constructor
-  (`newXHandlers`), and a `register(api fiber.Router, mw middleware)` method that mounts
-  its routes. Handlers are thin — auth primitives, user job operations, API key
-  management, errors live in separate files. The features and their files:
-  - `authHandlers` — auth.go (register/login/logout/me), oauth.go, api_keys.go,
-    extension_connect.go
-  - `jobsHandlers` — jobs.go, copies.go, jobs_moderation.go (moderator-authored writes)
-  - `searchHandlers` — search.go, agent_search.go, similar.go, facets.go
-  - `companiesHandlers` — companies.go
-  - `sitemapHandlers` — sitemap.go; `statsHandlers` — stats.go, stats_facets.go,
-    status.go, insights.go
-  - `trackingHandlers` — user_jobs.go, me_tracking.go, me_reminders.go, swipe.go
-  - `voteHandlers` — votes.go; `communityHandlers` — community.go
-  - `submissionHandlers` — submissions.go; `contributionHandlers` — contributions.go;
-    `reportHandlers` — reports.go; `referralHandlers` — referrals.go
-  - `savedSearchHandlers` — me_searches.go, boards.go; `subscriptionHandlers` —
-    me_subscriptions.go; `profileHandlers` — me_profile.go; `creditsHandlers` —
-    me_credits.go, me_credits_history.go
-  - `matchHandlers` — match_analysis.go, match_analysis_stream.go, me_analyses.go,
-    job_match.go, hardconstraint_inputs.go
-  - `cvHandlers` — cv.go, cv_tailor.go (holds a `*matchHandlers` for the blocker/credits
-    helpers tailoring reuses)
-  - `resumeHandlers` — resume.go, resume_verdict.go, ats_report.go, recommendations.go,
-    market_coverage.go
-  - `inboxHandlers` — inbox.go, inbox_linking.go, gmail.go, mailbox.go;
-    `telegramHandlers` — telegram.go
+- Each feature area owns a `<feature>Handlers` struct with its own dependencies, a
+  `new<Feature>Handlers` constructor, and a `register(api fiber.Router, mw middleware)`
+  method that mounts its routes — `grep 'Handlers struct' *.go` lists them all. Files are
+  named after the routes they serve, so a feature spans several files (`matchHandlers` →
+  `match_analysis.go`, `match_analysis_stream.go`, `job_match.go`, …). Handlers are thin;
+  auth primitives, user job operations, API key management and error rendering live in
+  their own files.
+- Two couplings worth knowing: `cvHandlers` holds a `*matchHandlers` (it reuses the
+  blocker/credits helpers for tailoring), and `jobs_moderation.go` carries the
+  moderator-authored writes behind the `moderator` gate.
 - The `middleware` bundle (`handler.go`) carries the shared auth gates features mount
   behind: `optional` (attach caller, never reject), `key` (cookie or API key), `cookie`
   (cookie-only), `moderator` (role gate, stacked after `key`/`cookie`).

--- a/internal/search/AGENTS.md
+++ b/internal/search/AGENTS.md
@@ -1,0 +1,51 @@
+# Search conventions
+
+Meilisearch-backed keyword and hybrid search over jobs and companies. The package doc in
+`client.go` explains the index topology; this file covers what the code can't tell you.
+
+## Always true
+
+- **Meilisearch has ONE serial task queue.** Two rebuilds do not run concurrently — the
+  second queues behind the first and looks like a hang while the engine is genuinely busy.
+  Before triggering any rebuild, check `ps aux | grep reindex` and
+  `GET /tasks?statuses=processing`. Never stack `reindex-companies` with `make reindex`, and
+  never stack anything with a `--semantic` pass.
+- **Killing the reindex client does not cancel enqueued Meili tasks.** To actually stop:
+  `POST /tasks/cancel?indexUids=<uid>&statuses=enqueued,processing`. That cancelation itself
+  queues, and it is irreversible — don't fire it on an unconfirmed diagnosis.
+- **A failed rebuild leaves an orphan `*_rebuild` index.** `Rebuild.Promote` drops the old
+  data only *after* a successful swap, so an aborted run leaves a full-size index on disk
+  (~55 GB at catalogue scale). That has filled the production disk and put rebuilds into a
+  death spiral: ENOSPC → orphan → less disk → ENOSPC. Reclaim with
+  `DELETE /indexes/<uid>_rebuild`. `Rebuild.Prepare` also drops a leftover before starting.
+- **Live reads are never affected by a rebuild** — the swap is atomic.
+- Full rebuilds are **content_hash-incremental even at `scope=full`**: `cmd/reindex` scans
+  every row but pushes only documents whose `content_hash` differs (`indexed=X skipped=Y`).
+  A field absent from `jobhash.Of()` therefore never reaches the index on its own —
+  **`is_tech` is deliberately not hashed**, so an is_tech-only flip is invisible to search
+  until the document is pushed for some other reason. There is no `--force` flag; the only
+  way to surface it immediately is a rebuild from empty.
+- `SubmitJobs` submits **without awaiting** the Meili task (the ingest hot path — awaiting
+  stalled board goroutines); `IndexJobs` awaits (the reindex path). Pick deliberately.
+- `swapIndexes` calls `POST /swap-indexes` over raw HTTP, not the SDK: the pinned
+  meilisearch-go always serializes a `rename` field that engine v1.13 rejects.
+- Indexed descriptions are capped at `maxIndexedDescriptionRunes`; `maxTotalHits` is the
+  count-honesty cap, **not** the pagination guard (that's `maxSearchWindow` in the handler).
+
+## Adding a filterable attribute
+
+Adding one creates a hard-500 window: the app emits the new filter the moment the image
+rolls out, but the attribute only becomes filterable when the rebuild swaps in — ~26 min at
+catalogue scale. Meili answers `invalid_search_filter` (400), and the handler maps any Meili
+error to 500, so the whole filtered page breaks rather than degrading.
+
+Either run the reindex **before** rolling out the app image, or push the new index settings
+to the **live** index first (settings updates are cheap; documents lag, so results are stale
+or empty — never a 500).
+
+## Limitations
+
+- A Meili filter error 500s the page instead of degrading. That's the robustness seam.
+- `jobs_semantic` is built by a separate, much slower pass and is only queried when
+  `SemanticRatio > 0`. Always scope a semantic rebuild (`--posted-within 30d`); a bare full
+  embed of the whole catalogue takes hours and monopolizes the queue.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,31 +1,44 @@
 # SPA conventions
 
-## Scope
-Svelte SPA under `web/` consuming the freehire API (same-origin; Vite proxy forwards `/api` in dev).
+SvelteKit app under `web/`, consuming the freehire API at `/api/v1/*`. Same-origin in
+production; in dev the Vite proxy (`web/vite.config.ts`) forwards `/api` to the backend.
 
 ## Always true
-- Auth is cookie-based via `HttpOnly; SameSite=Lax` — never a Bearer header or `localStorage`. The SPA cannot read the token (XSS-safe); the browser attaches it automatically.
-- Same-origin in dev: the Vite proxy (`web/vite.config.ts`) forwards `/api` to the backend. `SameSite=Lax` + same-origin is the CSRF defense (no CSRF token needed).
-- OAuth buttons render from `GET /api/v1/auth/oauth/providers` (lists enabled providers). OAuth callbacks 302 back to the SPA; failures 302 with `?auth_error=oauth`, never JSON.
-- `stage` in job tracking mirrors the backend controlled vocabulary (`internal/userjob/stages.go`): applied/screening/responded/interview/offer/accepted/rejected/withdrawn.
-- The SPA records a view silently when a signed-in user opens a job — failure is swallowed and must not break the page.
-- `MatchSummary.svelte` is a compact summary (overall % + verdict + top gap) linking to the full `/match/[slug]/` page; it never computes inline.
-- `ResumeStructuredView.svelte` is read-only — the structured resume is display-only, never editable.
-- Sentry is gated on `PUBLIC_SENTRY_DSN` (+ `PUBLIC_SENTRY_ENVIRONMENT`); source map upload only when `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` are set (build succeeds without them).
-- PostHog product analytics is gated on `PUBLIC_POSTHOG_KEY` (inert without it — no init, no events); ingestion goes through the same-origin `/ingest` reverse proxy (nginx → `eu.i.posthog.com`), overridable via `PUBLIC_POSTHOG_HOST` (default `/ingest`). Both are injected by `freehire-ops`, never committed, and unset in dev.
 
-## How it works
-The SPA is built with SvelteKit and consumes the API at `/api/v1/*`. Auth is handled via httpOnly cookies, transported transparently by the browser (no client-side token management). The Vite proxy forwards `/api` to the backend in dev; in production the SPA and API are same-origin.
+- Auth is cookie-based via `HttpOnly; SameSite=Lax` — never a Bearer header or
+  `localStorage`. The SPA cannot read the token (XSS-safe); the browser attaches it
+  automatically. `SameSite=Lax` + same-origin **is** the CSRF defence — no CSRF token.
+- OAuth buttons render from `GET /api/v1/auth/oauth/providers`. Callbacks 302 back to the
+  SPA; failures 302 with `?auth_error=oauth`, never JSON.
+- `stage` in job tracking mirrors the backend vocabulary (`internal/userjob/stages.go`):
+  applied/screening/responded/interview/offer/accepted/rejected/withdrawn.
+- A view is recorded silently when a signed-in user opens a job — failure is swallowed and
+  must not break the page.
+- `MatchSummary.svelte` is the compact sidebar summary (overall % + verdict + top gap)
+  linking to the full `/match/[slug]/` page — it never computes inline.
+- `ResumeStructuredView.svelte` is read-only; the backend serves the structured CV from
+  `GET /api/v1/me/resume` (`structured` field, null when absent/stale/unconfigured).
+- Sentry is gated on `PUBLIC_SENTRY_DSN` (+ `PUBLIC_SENTRY_ENVIRONMENT`); source-map upload
+  only when `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` are set (build succeeds
+  without them).
+- PostHog is gated on `PUBLIC_POSTHOG_KEY` (inert without it — no init, no events);
+  ingestion goes through the same-origin `/ingest` reverse proxy (nginx → `eu.i.posthog.com`),
+  overridable via `PUBLIC_POSTHOG_HOST`. Injected by `freehire-ops`, never committed, unset
+  in dev.
 
-**Auth surface:** `register`/`login`/`logout`/`me` endpoints set and clear the session cookie. OAuth sign-in buttons are driven by the `/api/v1/auth/oauth/providers` list. The callback flow redirects back to the SPA on success or with `?auth_error=oauth` on failure.
+## Worth knowing
 
-**Job-fit analysis page** (`web/src/routes/match/[slug]/`): `+page.server.ts` SSRs a fresh cached analysis for an instant paint; otherwise the page opens an `EventSource` and renders a stepper + a thinking panel + progressive sections. The pure SSE reducer `reduceMatchEvent` lives in `web/src/lib/matchAnalysis.ts` (unit-tested). `MatchSummary.svelte` (`web/src/lib/components/`) is the compact sidebar summary that links to the full page — it never computes inline.
-
-**Structured resume** (`ResumeStructuredView.svelte`): rendered read-only in the profile's readiness tab. The backend serves it from `GET /api/v1/me/resume` (the `structured` field, null when absent/stale/unconfigured).
-
-**Filters:** the companies FilterModal uses `COMPANY_FACETS` from `web/src/lib/facets.ts`, including a "Remote hiring" pill that reuses the shared `REGION` vocabulary for the `remote_regions` overlap facet.
+- **Job-fit analysis** (`web/src/routes/match/[slug]/`): `+page.server.ts` SSRs a fresh
+  cached analysis for an instant paint; otherwise the page opens an `EventSource` and
+  renders a stepper + thinking panel + progressive sections. The pure SSE reducer
+  `reduceMatchEvent` lives in `web/src/lib/matchAnalysis.ts` (unit-tested).
+- **Filters**: the companies FilterModal uses `COMPANY_FACETS` from `web/src/lib/facets.ts`,
+  including a "Remote hiring" pill that reuses the shared `REGION` vocabulary for the
+  `remote_regions` overlap facet.
 
 ## Limitations
-- Announcing shipped work via the `/blog` changelog (the `write-changelog` skill) is an agent-level concern documented in the root `AGENTS.md` — out of scope for the frontend module.
-- No CSP `connect-src` restriction is set — a comment in `web/svelte.config.js` records the ingest host for any future `connect-src` if one is added.
-- OAuth identity unlinking/management UI is not implemented (backend seam mirrored on the frontend).
+
+- No CSP `connect-src` restriction is set — a comment in `web/svelte.config.js` records the
+  ingest host for any future `connect-src`.
+- OAuth identity unlinking/management UI is not implemented (backend seam mirrored on the
+  frontend).


### PR DESCRIPTION
Anthropic shipped an [Opus 5 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5) and a [Claude 5 context-engineering post](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) whose advice is mostly subtractive: *"Keep your CLAUDE.md lightweight … spend most of the tokens on gotchas inside of the codebase."* Anthropic cut 80% of Claude Code's own system prompt with no eval regression. This applies that rule to ours.

## Removed

- **The root Layout tree** — 52 lines of directory listing that had drifted badly: 22 of 40 `cmd/*` undocumented, ~20 `internal/*` packages missing (including `internal/search` at 4610 loc). A stale listing is worse than none — an agent trusts it and stops looking. Replaced by a short "non-obvious" block; `ls` answers the rest and can't go stale.
- **Four Working principles** ("Think before coding", "Fix root causes", …) that are verbatim default agent behaviour now.
- **`internal/handler`'s hand-maintained "struct → its files" index**, already wrong about 11 files. Structs follow a naming rule, so the rule replaces the list.
- **Duplicated prose** in `web/` and `internal/db` — an "Always true" bullet and a "How it works" paragraph saying the same thing — plus response-shape and error-rendering conventions restated in the SQL doc.

## Fixed

- `design-system/AGENTS.md` was linked from the root table but **never existed**.
- **Six `AGENTS.md` files existed but were linked from nowhere**, so progressive disclosure couldn't reach them: `viewlog`, `browsertools`, `companyname`, `jobview`, `telegram`, `cv`.

## Added

Five docs for the largest undocumented areas, written to the same rule — contracts and traps only:

| File | What it captures |
|---|---|
| `internal/search` | Meilisearch's single serial task queue; the orphaned `*_rebuild` index that has filled the production disk; `is_tech`'s absence from `content_hash`; the hard-500 window a new filterable attribute opens |
| `internal/accounts` | The boundary against `internal/auth`; the account seizure rule; why every credential write must bump `token_version` |
| `docs/agents/mail-stack.md` | Why matching on the sender domain is wrong (ATS relay domains); why `body_text` alone misclassifies HTML-only ATS mail; `MAILBOX_DOMAIN` vs `MAIL_DOMAIN` |
| `docs/agents/notifications.md` | O(distinct queries) matching; ledger idempotency; unconfigured channels as soft-skips |
| `design-system` | The Tailwind `@source` trap that drops classes silently with a green build; the `--z-index-*` bridge |

## Net

The four rewritten files shrink **34%** (29.4 → 19.1 KB). Every `AGENTS.md` in the tree is now reachable from the root, and every link resolves.

Docs only — no code touched.