### PR TITLE
perf(ci): one Postgres container per test binary, a cloned database per test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,8 @@ jobs:
       - name: Install poppler-utils
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends poppler-utils
 
-      - name: Build
-        run: go build ./...
-
+      # No separate `go build ./...`: vet type-checks every package and the test
+      # steps compile them, including the test-less cmd/* binaries.
       - name: Vet
         run: go vet ./...
 
@@ -91,7 +90,9 @@ jobs:
 
   web:
     runs-on: ubuntu-latest
-    needs: [design-system]
+    # Not gated on design-system: web consumes the package's *source* (its
+    # "svelte" export is ./src/index.ts) plus the two committed dist/tokens-*.css,
+    # so nothing here waits on that job's build.
     defaults:
       run:
         working-directory: web

--- a/cmd/embed/embed_integration_test.go
+++ b/cmd/embed/embed_integration_test.go
@@ -18,16 +18,15 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 	"time"
 	"unicode"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -105,34 +104,7 @@ func startMeili(t *testing.T) (url, key string) {
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations dir: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"), postgres.WithUsername("hire"), postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...), postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 // meiliDocExists reports whether the semantic index holds a document with the given id.

--- a/cmd/ingest/board_health_integration_test.go
+++ b/cmd/ingest/board_health_integration_test.go
@@ -8,46 +8,19 @@ package main
 
 import (
 	"context"
-	"path/filepath"
-	"sort"
 	"testing"
 	"time"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/strelov1/freehire/internal/db"
 )
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (%d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"), postgres.WithUsername("hire"), postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...), postgres.BasicWaitStrategies())
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("dsn: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 func TestBoardHealth_FailureCooldownSelfHeal(t *testing.T) {

--- a/cmd/rollup-views/main_test.go
+++ b/cmd/rollup-views/main_test.go
@@ -14,51 +14,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/strelov1/freehire/internal/viewlog"
 )
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations dir: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"),
-		postgres.WithUsername("hire"),
-		postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 func seedJob(t *testing.T, pool *pgxpool.Pool, slug string) int64 {

--- a/internal/accounts/oauth_merge_integration_test.go
+++ b/internal/accounts/oauth_merge_integration_test.go
@@ -10,12 +10,11 @@ package accounts_test
 
 import (
 	"context"
-	"path/filepath"
-	"sort"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/strelov1/freehire/internal/accounts"
 	"github.com/strelov1/freehire/internal/db"
@@ -23,43 +22,7 @@ import (
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-
-	// Apply every migration, in name order — the same way Postgres initdb runs
-	// the mounted migrations/ dir — so a new migration is never silently missing
-	// from the test schema.
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations dir: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"),
-		postgres.WithUsername("hire"),
-		postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 // accountRow is the state assertions read back after a link.

--- a/internal/contribution/repository_integration_test.go
+++ b/internal/contribution/repository_integration_test.go
@@ -11,53 +11,19 @@ package contribution
 import (
 	"context"
 	"errors"
-	"path/filepath"
-	"sort"
 	"sync"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/strelov1/freehire/internal/db"
 )
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations dir: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"),
-		postgres.WithUsername("hire"),
-		postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 func insertUser(t *testing.T, pool *pgxpool.Pool, email string) int64 {

--- a/internal/credits/store_integration_test.go
+++ b/internal/credits/store_integration_test.go
@@ -10,53 +10,19 @@ package credits
 import (
 	"context"
 	"errors"
-	"path/filepath"
-	"sort"
 	"sync"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/strelov1/freehire/internal/db"
 )
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations dir: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"),
-		postgres.WithUsername("hire"),
-		postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 func insertUser(t *testing.T, pool *pgxpool.Pool, email string) int64 {

--- a/internal/db/enrichment_integration_test.go
+++ b/internal/db/enrichment_integration_test.go
@@ -8,55 +8,19 @@ package db
 
 import (
 	"context"
-	"path/filepath"
 	"sort"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 const targetVersion int32 = 1
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-
-	// Apply every migration, in name order — the same way Postgres initdb runs
-	// the mounted migrations/ dir — so a new migration is never silently missing
-	// from the test schema.
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations dir: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"),
-		postgres.WithUsername("hire"),
-		postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 func insertJob(t *testing.T, pool *pgxpool.Pool, externalID string) int64 {

--- a/internal/handler/companies_integration_test.go
+++ b/internal/handler/companies_integration_test.go
@@ -13,57 +13,21 @@ import (
 	"errors"
 	"io"
 	"net/http/httptest"
-	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/strelov1/freehire/internal/db"
 )
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-
-	// Apply every migration, in name order — the same way Postgres initdb runs the
-	// mounted migrations/ dir — so a new migration is never silently missing from
-	// the test schema (this helper previously hardcoded a list and drifted).
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations dir: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"),
-		postgres.WithUsername("hire"),
-		postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 func TestListCompaniesSearchEndpoint(t *testing.T) {

--- a/internal/linkimport/import_integration_test.go
+++ b/internal/linkimport/import_integration_test.go
@@ -10,13 +10,12 @@ package linkimport
 import (
 	"context"
 	"fmt"
-	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/testdb"
+
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"golang.org/x/net/html"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -24,40 +23,7 @@ import (
 
 func startPostgres(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	ctx := context.Background()
-
-	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
-	if err != nil {
-		t.Fatalf("resolve migrations dir: %v", err)
-	}
-	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
-	if err != nil || len(scripts) == 0 {
-		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
-	}
-	sort.Strings(scripts)
-
-	pg, err := postgres.Run(ctx, "postgres:18-alpine",
-		postgres.WithDatabase("hire"),
-		postgres.WithUsername("hire"),
-		postgres.WithPassword("hire"),
-		postgres.WithInitScripts(scripts...),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("start postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = pg.Terminate(ctx) })
-
-	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return testdb.Pool(t)
 }
 
 // pageClient is a test linksource.Client serving one canned HTML body for any URL.

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -1,0 +1,178 @@
+// Package testdb is the Postgres harness for the integration tests: one
+// throwaway container per test binary, and a pristine database per test cloned
+// from a template that carries every migration.
+//
+// The obvious alternative — a container per test — cost ~4.5s each (~3s to boot
+// the container, ~1.5s to replay the 57 migrations) while the assertions
+// themselves took milliseconds. At ~226 calls per CI run that was 8 of the
+// backend job's 9.5 minutes. `CREATE DATABASE ... TEMPLATE` is a file copy of an
+// already-migrated database, ~0.2s, and buys the same isolation: every test
+// still gets its own database with its own sequences, so a test may freely
+// mutate rows, indexes, or the schema.
+//
+// The container is reaped by the testcontainers ryuk sidecar when the test
+// binary exits (nothing outlives the run unless TESTCONTAINERS_RYUK_DISABLED
+// is set).
+package testdb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+const (
+	image = "postgres:18-alpine"
+
+	// templateDB holds the migrated schema that per-test databases are cloned
+	// from. Nothing may hold a connection to it — CREATE DATABASE ... TEMPLATE
+	// requires an idle source.
+	templateDB = "hire_template"
+
+	// adminDB is initdb's own database, used only to run CREATE/DROP DATABASE.
+	adminDB = "postgres"
+
+	user     = "hire"
+	password = "hire"
+)
+
+type container struct {
+	admin *pgxpool.Pool
+	host  string
+	port  string
+}
+
+var (
+	once      sync.Once
+	shared    *container
+	bootErr   error
+	dbCounter atomic.Uint64
+)
+
+// Pool hands the test its own migrated database. Both the pool and the database
+// go away when the test ends.
+func Pool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+	c := start(t)
+
+	name := fmt.Sprintf("hire_test_%d", dbCounter.Add(1))
+	if _, err := c.admin.Exec(ctx, `CREATE DATABASE "`+name+`" TEMPLATE `+templateDB); err != nil {
+		t.Fatalf("clone %s: %v", templateDB, err)
+	}
+
+	// Cleanups are LIFO, so this drop runs after the pool below is closed. FORCE
+	// evicts whatever connection a test left open, so one leak can't wedge the
+	// rest of the suite.
+	t.Cleanup(func() {
+		_, _ = c.admin.Exec(context.Background(), `DROP DATABASE IF EXISTS "`+name+`" WITH (FORCE)`)
+	})
+
+	pool, err := pgxpool.New(ctx, c.dsn(name))
+	if err != nil {
+		t.Fatalf("connect %s: %v", name, err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func start(t *testing.T) *container {
+	t.Helper()
+	once.Do(func() { shared, bootErr = boot() })
+	if bootErr != nil {
+		t.Fatalf("start postgres: %v", bootErr)
+	}
+	return shared
+}
+
+func boot() (*container, error) {
+	ctx := context.Background()
+
+	scripts, err := migrationScripts()
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err := postgres.Run(ctx, image,
+		postgres.WithDatabase(templateDB),
+		postgres.WithUsername(user),
+		postgres.WithPassword(password),
+		postgres.WithInitScripts(scripts...),
+		postgres.BasicWaitStrategies(),
+		// The data is thrown away, so drop the durability the postgres module
+		// doesn't already drop (it passes fsync=off itself).
+		testcontainers.WithCmdArgs("-c", "full_page_writes=off", "-c", "synchronous_commit=off"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("run container: %w", err)
+	}
+
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("container host: %w", err)
+	}
+	port, err := ctr.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		return nil, fmt.Errorf("container port: %w", err)
+	}
+
+	c := &container{host: host, port: port.Port()}
+	admin, err := pgxpool.New(ctx, c.dsn(adminDB))
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", adminDB, err)
+	}
+	c.admin = admin
+	return c, nil
+}
+
+func (c *container) dsn(database string) string {
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		user, password, c.host, c.port, database)
+}
+
+// migrationScripts lists migrations/*.sql in name order — the order Postgres
+// initdb runs a mounted migrations/ dir in — so a new migration is never
+// silently missing from the test schema.
+func migrationScripts() ([]string, error) {
+	root, err := repoRoot()
+	if err != nil {
+		return nil, err
+	}
+	scripts, err := filepath.Glob(filepath.Join(root, "migrations", "*.sql"))
+	if err != nil {
+		return nil, fmt.Errorf("list migrations: %w", err)
+	}
+	if len(scripts) == 0 {
+		return nil, fmt.Errorf("no migrations under %s", filepath.Join(root, "migrations"))
+	}
+	sort.Strings(scripts)
+	return scripts, nil
+}
+
+// repoRoot walks up from the test's working directory to the module root, so the
+// harness doesn't care how deep the package under test sits.
+func repoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod above the working directory")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Why

The backend CI job takes 9.5 min and **493 s of that is a single step** — `go test -tags=integration ./...`. Measured on run 30325617625 (main, green):

```
internal/db       464 s   ← critical path
internal/handler  316 s   (parallel with it)
internal/credits   53 s ... embed 20s, search 17s, contribution 17s, linkimport 16s, ingest 16s, rollup-views 12s
```

Nine packages each carried a byte-for-byte copy of `startPostgres(t)`, which booted **a throwaway Postgres per test** with all 57 migrations as initdb scripts — ~226 containers per run. Measured cost per call:

| | |
|---|---|
| container up | 3.05 s |
| replay 57 migrations | 1.43 s |
| the SQL the test actually asserts on | milliseconds |

## What

`internal/testdb`: one container per test binary, migrations applied **once** into a `hire_template` database, and each test gets its own database via `CREATE DATABASE … TEMPLATE` — **0.17 s** measured. Isolation is identical (pristine schema, own sequences, schema-mutating tests still safe), so the nine helpers keep their signature and none of the ~226 call sites move; the drop is `WITH (FORCE)` so a leaked connection can't wedge the suite.

Also drops two steps that cost time without adding signal:
- `go build ./...` — `go vet ./...` type-checks every package and the test steps compile them; verified by planting a compile error in a test-less `cmd/*` package (both `go test` and `go vet` fail on it).
- web's `needs: [design-system]` — web consumes the package's *source* (`"svelte": "./src/index.ts"`) plus the committed `dist/tokens-*.css`, so it never waited on that build.

## Measured, locally (8 cores, all green)

| | before | after |
|---|---|---|
| `internal/db` | ~576 s (128 × 4.5 s) | **24.6 s** |
| `internal/handler` | ~324 s (72 × 4.5 s) | **23.2 s** |
| `go test -tags=integration ./...` | ~8 min | **66 s** |

`go test ./...` and `go test -tags=integration ./...` both pass with zero failures.