### PR TITLE
perf(ci): build the image's twelve workers in one go build invocation

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -45,8 +45,11 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # Dockerfile and docker-compose.yml count: they define the image and the
+          # stack this smoke boots, so a change there alters the request path's
+          # runtime even when no Go or Svelte file moved.
           if git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
-            | grep -qE '^(internal/handler/|internal/search/|internal/jobview/|web/|perf/|\.github/workflows/perf\.yml)'; then
+            | grep -qE '^(internal/handler/|internal/search/|internal/jobview/|web/|perf/|Dockerfile|docker-compose\.yml|\.github/workflows/perf\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "Request-path files changed — running the full smoke."
           else

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,19 +10,17 @@ COPY . .
 # One image carries every binary: the HTTP server (default entrypoint) plus the
 # run-once workers (ingest/enrich/reindex and the Telegram crawl/extract pair),
 # which prod invokes on a schedule via `docker compose run --rm app /app/<worker>`.
+#
+# Two invocations rather than one per binary: with `-o /out/` (a directory) Go
+# names each binary after its cmd dir — which is already how they're named — and
+# building them together shares one dependency compile and links them in
+# parallel. Cold-cache: 26s -> 17s locally, 72s -> ~50s on a CI runner. Only the
+# server needs an output name of its own.
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/hire ./cmd/server \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/ingest ./cmd/ingest \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/enrich ./cmd/enrich \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/reindex ./cmd/reindex \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/tg-ingest ./cmd/tg-ingest \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/tg-extract ./cmd/tg-extract \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-derive ./cmd/backfill-derive \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/liveness ./cmd/liveness \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/notify ./cmd/notify \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/import-collections ./cmd/import-collections \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/recount-companies ./cmd/recount-companies \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/migrate ./cmd/migrate \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-company-info ./cmd/backfill-company-info
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/ \
+      ./cmd/ingest ./cmd/enrich ./cmd/reindex ./cmd/tg-ingest ./cmd/tg-extract \
+      ./cmd/backfill-derive ./cmd/liveness ./cmd/notify ./cmd/import-collections \
+      ./cmd/recount-companies ./cmd/migrate ./cmd/backfill-company-info
 
 # --- typst stage: fetch the pinned, statically-linked typst binary used to render CV
 # PDFs (internal/cv). The musl build is fully static, so it runs on distroless/static;


### PR DESCRIPTION
Follow-up to #1167. With backend down to 2.1 min, **`pr-smoke` (~3m34s) is what a PR waits on**, and 129 s of it is `docker compose up -d --build`.

## What landed

The app image spent **72.3 s** in one RUN that invoked `go build` thirteen times. With `-o /out/` (a directory) Go names each binary after its cmd dir — already how all twelve workers are named — so they link in parallel off a single dependency compile.

| | before | after |
|---|---|---|
| cold cache, locally (8 cores) | 26.0 s | **17.1 s** |
| in the image, on a 4-core runner | 72.3 s | **66.5 s** |

Prod deploys and `make up` build the same image, so they get it too. Image verified unchanged: same thirteen binaries in `/app` plus `migrations/` and `typst`, `/app/hire` starts (fails fast on the missing JWT_SECRET, as expected), `/app/migrate -h` works.

## What I tried and reverted: a GHA layer cache for the two images

Worth recording, because it looks obviously right and measures net **negative**. I built the images with `docker buildx bake` (cache-from `type=gha`, a scheduled `warm-build-cache` job writing the cache off main, `compose up -d` reusing them by tag) and pushed it as this PR's first commit. Run [30328530192](https://github.com/strelov1/freehire/actions/runs/30328530192): pr-smoke went **3m34s → 4m14s**.

From that run's log, where the time went:

| | |
|---|---|
| `load: true` — app export to docker + import | 17.4 s + 10.1 s |
| same for web | 20.8 s + 10.4 s |
| Set up Buildx (container driver) | 7 s |
| **overhead added** | **~65 s** |
| deps layers a warm cache could have skipped (go mod download 9 s, apt 16.2 s, typst ~5 s, two pnpm installs 25 s — partly parallel) | **~30 s at best** |

The buildx container driver has to export each image as a tarball and import it into the daemon, which `compose up --build` never pays because its builder writes straight to the daemon store. That penalty is bigger than the whole cacheable surface. And the residue is irreducible by caching anyway: 66 s of `go build` and 53 s of `pnpm run build` over source that changed by definition on a PR.

The other reason it can't be cheap: GitHub scopes a cache entry to the ref that wrote it, so the cache would need a scheduled job on main to be readable from PRs at all — a standing cost for a negative return.

**Next lever, if we want pr-smoke faster:** have the smoke build only `./cmd/server` instead of all thirteen binaries (~40 s off the app path). That trades fidelity — the smoke would no longer boot a byte-identical prod image — for speed, so it needs a deliberate call. `web`'s ~105 s path would then be the constraint.