### PR TITLE
perf(ci): pr-smoke builds only the server binary it boots

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -34,6 +34,10 @@ jobs:
   pr-smoke:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      # Every `docker compose` below picks up the overlay, which builds the app
+      # image without the twelve worker binaries this smoke never invokes.
+      COMPOSE_FILE: docker-compose.yml:perf/docker-compose.smoke.yml
     steps:
       - uses: actions/checkout@v7
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,18 @@ COPY . .
 # Two invocations rather than one per binary: with `-o /out/` (a directory) Go
 # names each binary after its cmd dir — which is already how they're named — and
 # building them together shares one dependency compile and links them in
-# parallel. Cold-cache: 26s -> 17s locally, 72s -> ~50s on a CI runner. Only the
+# parallel. Cold-cache: 26s -> 17s locally, 72s -> 66s on a CI runner. Only the
 # server needs an output name of its own.
+#
+# WORKER_PKGS is the full list by default, so an ordinary `docker build` still
+# produces the complete image. The ONLY thing that overrides it is the CI page
+# smoke (perf/docker-compose.smoke.yml), which boots nothing but the server and
+# has no use for the workers' compile time.
+ARG WORKER_PKGS="./cmd/ingest ./cmd/enrich ./cmd/reindex ./cmd/tg-ingest ./cmd/tg-extract ./cmd/backfill-derive ./cmd/liveness ./cmd/notify ./cmd/import-collections ./cmd/recount-companies ./cmd/migrate ./cmd/backfill-company-info"
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/hire ./cmd/server \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/ \
-      ./cmd/ingest ./cmd/enrich ./cmd/reindex ./cmd/tg-ingest ./cmd/tg-extract \
-      ./cmd/backfill-derive ./cmd/liveness ./cmd/notify ./cmd/import-collections \
-      ./cmd/recount-companies ./cmd/migrate ./cmd/backfill-company-info
+ && if [ -n "$WORKER_PKGS" ]; then \
+      CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/ $WORKER_PKGS; \
+    fi
 
 # --- typst stage: fetch the pinned, statically-linked typst binary used to render CV
 # PDFs (internal/cv). The musl build is fully static, so it runs on distroless/static;
@@ -48,7 +53,8 @@ RUN apt-get update \
  && groupadd --system --gid 65532 nonroot \
  && useradd --system --uid 65532 --gid nonroot --home-dir /app nonroot \
  && pdftotext -v
-COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/backfill-derive /out/liveness /out/notify /out/import-collections /out/recount-companies /out/migrate /out/backfill-company-info /app/
+# The whole /out, not a list of names: WORKER_PKGS decides what's in it.
+COPY --from=build /out/ /app/
 # The migration runner reads its *.sql files from the image (WORKDIR /app, default
 # -dir migrations), so /app/migrate works the same as `go run ./cmd/migrate` on the host.
 COPY --from=build /src/migrations /app/migrations

--- a/perf/docker-compose.smoke.yml
+++ b/perf/docker-compose.smoke.yml
@@ -1,0 +1,14 @@
+# Overlay for the CI page smoke (.github/workflows/perf.yml), applied via
+# COMPOSE_FILE. The smoke boots the server and hits pages through it; the twelve
+# run-once workers in the image are never invoked, so building them is time the
+# gate can't spend. Everything else about the image is untouched — same base,
+# same runtime stage, same server binary — so what the smoke boots still
+# differs from the prod image only by binaries it would never run.
+#
+# WORKER_PKGS lives in the Dockerfile with the full list as its default: nothing
+# outside this file shortens it.
+services:
+  app:
+    build:
+      args:
+        WORKER_PKGS: ""


### PR DESCRIPTION
The lever left over from #1170. The app image's `go build` was **66.5 s of pr-smoke's 131 s** stack build, and twelve of the thirteen binaries it produces are run-once workers the smoke never invokes.

## How

`WORKER_PKGS` is a build arg whose **default is the full list**, so an ordinary `docker build` — prod deploys, `make up` — still produces the complete image. The one override lives in `perf/docker-compose.smoke.yml` and is applied through `COMPOSE_FILE`, so:

- every `docker compose` call in the job picks it up without touching a single command in the workflow, and
- compose keeps building `app` and `web` **concurrently**. A separate build step would serialize them and hand back more than this saves — that's what went wrong in #1170's first attempt.

## The trade, stated plainly

The smoke no longer boots a byte-identical prod image. Same base image, same runtime stage, same server binary, same `migrations/` and `typst` — it differs only by binaries that image would never run during the smoke. "Does every cmd package still compile" is already covered by `go vet ./...` in the backend job, and releases build the real image.

## Verified locally

| build | `/app` contents |
|---|---|
| `docker build .` (prod path) | all 13 binaries + `migrations/` + `typst` |
| with the overlay | `hire`, `migrations/`, `typst` — and the server starts (fails fast on the missing JWT_SECRET) |

Note the fail-safe direction: if compose ever stopped passing the empty arg through, the Dockerfile default takes over and the smoke just builds everything, as it does today.

**The CI number is what decides this.** Expected ~25–30 s off the step, not the full ~40 s — `web`'s image path (~90–105 s: two `pnpm install`s + a 53 s `pnpm run build`) becomes the constraint. If the run says otherwise, this goes the way of #1170's cache experiment.