### PR TITLE
fix(cv): restore the narrow cv-scope gate the tailoring agent authenticates with

### DIFF
--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -61,21 +61,23 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 	api.Get("/cv-templates", mw.cookie, h.ListCVTemplates)
 	api.Get("/me/cvs", mw.cookie, h.ListCVs)
 	api.Post("/me/cvs", mw.cookie, h.CreateCV)
-	// Read + render accept a key too (keyAuth), so the tailoring agent's CLI can fetch a CV
-	// and its PDF; mutations stay cookie-only (POST/PUT/DELETE — the browser owns authoring).
-	api.Get("/me/cvs/:id", mw.key, h.GetCV)
+	// Read + render accept a key too, so the tailoring agent's CLI can fetch a CV and its
+	// PDF; mutations stay cookie-only (POST/PUT/DELETE — the browser owns authoring).
+	// cvKey, not key: the bootstrap mints the agent a narrow `cv`-scoped key, and key
+	// (RequireAuthOrKey) admits full-scope keys only — it would answer the agent 403.
+	api.Get("/me/cvs/:id", mw.cvKey, h.GetCV)
 	api.Put("/me/cvs/:id", mw.cookie, h.UpdateCV)
 	// Change only the template (the gallery's one-field switch); cookie-only like other mutations.
 	api.Put("/me/cvs/:id/template", mw.cookie, h.SetCVTemplate)
 	api.Delete("/me/cvs/:id", mw.cookie, h.DeleteCV)
-	api.Get("/me/cvs/:id/pdf", mw.key, h.RenderCVPDF)
+	api.Get("/me/cvs/:id/pdf", mw.cvKey, h.RenderCVPDF)
 	// Tailoring: the browser starts a session (cookie-only bootstrap); the agent's CLI drives
-	// the edit + context/get/render reads with its minted API key (keyAuth = cookie or Bearer).
+	// the edit + context/get/render reads with its minted `cv`-scoped key.
 	api.Post("/me/cvs/tailor", mw.cookie, h.TailorCV)
 	api.Post("/me/cvs/:id/tailor-session", mw.cookie, h.StartTailorSession)
-	api.Patch("/me/cvs/:id", mw.key, h.PatchCV)
-	api.Put("/me/cvs/:id/session", mw.key, h.SetCVSession)
-	api.Get("/me/cvs/:id/tailor-context", mw.key, h.TailorContext)
+	api.Patch("/me/cvs/:id", mw.cvKey, h.PatchCV)
+	api.Put("/me/cvs/:id/session", mw.cvKey, h.SetCVSession)
+	api.Get("/me/cvs/:id/tailor-context", mw.cvKey, h.TailorContext)
 }
 
 const maxCVTitleRunes = 200

--- a/internal/handler/cv_routes_test.go
+++ b/internal/handler/cv_routes_test.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// gateProbe is a middleware that answers with its own name instead of calling the
+// handler, so a request reveals which gate a route was registered behind.
+func gateProbe(name string) fiber.Handler {
+	return func(c *fiber.Ctx) error { return c.SendString(name) }
+}
+
+// TestCVRegister_TailoringRoutesAdmitTheNarrowCVKey pins the gate each CV route is
+// registered behind, against the real register() — not a hand-wired app.
+//
+// The tailoring bootstrap mints a key at the narrow `cv` scope, and mw.key
+// (RequireAuthOrKey) admits full-scope keys only, answering anything narrower with
+// 403. So every route the tailoring agent drives has to sit on mw.cvKey. The existing
+// integration test cannot catch a slip here: it mounts its own app with the scoped
+// middleware, asserting the intent rather than the wiring.
+func TestCVRegister_TailoringRoutesAdmitTheNarrowCVKey(t *testing.T) {
+	app := fiber.New()
+	api := app.Group("/api/v1")
+	(&cvHandlers{}).register(api, middleware{
+		key:    gateProbe("key"),
+		cvKey:  gateProbe("cvKey"),
+		cookie: gateProbe("cookie"),
+	})
+
+	for _, tc := range []struct {
+		method, path, want string
+	}{
+		// Driven by the tailoring agent's narrow key.
+		{http.MethodGet, "/api/v1/me/cvs/1", "cvKey"},
+		{http.MethodGet, "/api/v1/me/cvs/1/pdf", "cvKey"},
+		{http.MethodPatch, "/api/v1/me/cvs/1", "cvKey"},
+		{http.MethodPut, "/api/v1/me/cvs/1/session", "cvKey"},
+		{http.MethodGet, "/api/v1/me/cvs/1/tailor-context", "cvKey"},
+		// Authoring stays with the browser.
+		{http.MethodPut, "/api/v1/me/cvs/1", "cookie"},
+		{http.MethodDelete, "/api/v1/me/cvs/1", "cookie"},
+		{http.MethodPost, "/api/v1/me/cvs", "cookie"},
+		{http.MethodPost, "/api/v1/me/cvs/1/tailor-session", "cookie"},
+	} {
+		resp, err := app.Test(httptest.NewRequest(tc.method, tc.path, nil))
+		if err != nil {
+			t.Fatalf("%s %s: %v", tc.method, tc.path, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if got := string(body); got != tc.want {
+			t.Errorf("%s %s is gated by %q, want %q", tc.method, tc.path, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What broke

The handler split (#1158) moved the CV routes from `cvKeyAuth` onto `mw.key`.
`mw.key` is `RequireAuthOrKey`, which is `RequireAuthOrScopedKey` with **no**
admitted scopes — so only a full-scope key passes, and anything narrower gets
`403 insufficient scope`.

The tailoring bootstrap mints its agent a key at the narrow `cv` scope
(`mintTailoringKey`, `cv_tailor.go`). Every request that agent makes has
therefore been rejected since the split:

| Route | Driven by |
|---|---|
| `GET /me/cvs/:id` | `freehire cv get` |
| `GET /me/cvs/:id/pdf` | `freehire cv render` |
| `PATCH /me/cvs/:id` | `freehire cv edit` |
| `PUT /me/cvs/:id/session` | session bookkeeping |
| `GET /me/cvs/:id/tailor-context` | `freehire cv context` |

CV tailoring over the CLI is broken in production. Authoring in the browser is
unaffected — those routes are cookie-gated and were not touched.

## Why the tests missed it

`cv_tailor_integration_test.go` builds its own app and mounts the routes on
`RequireAuthOrScopedKey(..., ScopeCV)`. Its comment states the intent plainly —
"a harness on the full-scope-only middleware would reject the very credential
the flow issues" — but because it never exercises the real router, it asserts
the intent rather than the wiring, and stayed green while production diverged.

## The fix

Five routes back onto `mw.cvKey`, plus a test that drives `register()` itself
and pins the gate behind each CV route, so a future move shows up as a failure
instead of a 403 in production.

Test plan: `go test ./...` green; the new `TestCVRegister_TailoringRoutesAdmitTheNarrowCVKey`
fails on `main` with exactly those five routes and passes here.