### PR TITLE
feat(cv): a CV is addressed by an unguessable id

### DIFF
--- a/internal/assistant/store.go
+++ b/internal/assistant/store.go
@@ -35,16 +35,16 @@ type Session struct {
 	UserID int64
 	Preset string
 	Label  string
-	CVID   *int64
+	CVID   *uuid.UUID
 	JobID  *int64
 }
 
 // Queries is the slice of the generated query surface the store needs.
 // *db.Queries satisfies it; tests supply a fake.
 type Queries interface {
-	CreateAssistantSession(ctx context.Context, arg db.CreateAssistantSessionParams) (db.AssistantSession, error)
-	ListAssistantChatSessions(ctx context.Context, userID int64) ([]db.AssistantSession, error)
-	GetAssistantSession(ctx context.Context, arg db.GetAssistantSessionParams) (db.AssistantSession, error)
+	CreateAssistantSession(ctx context.Context, arg db.CreateAssistantSessionParams) (db.CreateAssistantSessionRow, error)
+	ListAssistantChatSessions(ctx context.Context, userID int64) ([]db.ListAssistantChatSessionsRow, error)
+	GetAssistantSession(ctx context.Context, arg db.GetAssistantSessionParams) (db.GetAssistantSessionRow, error)
 	DeleteAssistantSession(ctx context.Context, arg db.DeleteAssistantSessionParams) (int64, error)
 	TouchAssistantSession(ctx context.Context, id uuid.UUID) error
 	SetAssistantSessionLabel(ctx context.Context, arg db.SetAssistantSessionLabelParams) error
@@ -61,7 +61,7 @@ func NewStore(q Queries) *Store { return &Store{q: q} }
 
 // CreateSession starts a conversation. cvID/jobID bind a tailoring session to its
 // CV and vacancy and are nil for a chat.
-func (s *Store) CreateSession(ctx context.Context, userID int64, preset string, cvID, jobID *int64) (Session, error) {
+func (s *Store) CreateSession(ctx context.Context, userID int64, preset string, cvID *uuid.UUID, jobID *int64) (Session, error) {
 	row, err := s.q.CreateAssistantSession(ctx, db.CreateAssistantSessionParams{
 		UserID: userID,
 		Preset: preset,
@@ -71,7 +71,7 @@ func (s *Store) CreateSession(ctx context.Context, userID int64, preset string, 
 	if err != nil {
 		return Session{}, fmt.Errorf("assistant: create session: %w", err)
 	}
-	return sessionFrom(row), nil
+	return session(row.ID, row.UserID, row.Preset, row.Label, row.CvID, row.JobID), nil
 }
 
 // ChatSessions lists the caller's general chats, most recently active first.
@@ -84,7 +84,7 @@ func (s *Store) ChatSessions(ctx context.Context, userID int64) ([]Session, erro
 	}
 	out := make([]Session, 0, len(rows))
 	for _, r := range rows {
-		out = append(out, sessionFrom(r))
+		out = append(out, session(r.ID, r.UserID, r.Preset, r.Label, r.CvID, r.JobID))
 	}
 	return out, nil
 }
@@ -98,7 +98,7 @@ func (s *Store) Session(ctx context.Context, id uuid.UUID, userID int64) (Sessio
 	if err != nil {
 		return Session{}, fmt.Errorf("assistant: get session: %w", err)
 	}
-	return sessionFrom(row), nil
+	return session(row.ID, row.UserID, row.Preset, row.Label, row.CvID, row.JobID), nil
 }
 
 // DeleteSession removes an owned conversation and its transcript.
@@ -178,13 +178,9 @@ func (s *Store) Transcript(ctx context.Context, sessionID uuid.UUID) ([]Message,
 	return out, nil
 }
 
-func sessionFrom(r db.AssistantSession) Session {
-	return Session{
-		ID:     r.ID,
-		UserID: r.UserID,
-		Preset: r.Preset,
-		Label:  r.Label.String,
-		CVID:   r.CvID,
-		JobID:  r.JobID,
-	}
+// session builds the domain shape from the columns every session query selects.
+// sqlc emits a distinct row type per query — same columns, three names — so the
+// mapping lives here once and each caller adapts its row into it.
+func session(id uuid.UUID, userID int64, preset string, label pgtype.Text, cvID *uuid.UUID, jobID *int64) Session {
+	return Session{ID: id, UserID: userID, Preset: preset, Label: label.String, CVID: cvID, JobID: jobID}
 }

--- a/internal/assistant/store_test.go
+++ b/internal/assistant/store_test.go
@@ -32,29 +32,29 @@ type fakeQueries struct {
 	touched   uuid.UUID
 }
 
-func (f *fakeQueries) CreateAssistantSession(_ context.Context, arg db.CreateAssistantSessionParams) (db.AssistantSession, error) {
-	return db.AssistantSession{
+func (f *fakeQueries) CreateAssistantSession(_ context.Context, arg db.CreateAssistantSessionParams) (db.CreateAssistantSessionRow, error) {
+	return db.CreateAssistantSessionRow{
 		ID: sessionID, UserID: arg.UserID, Preset: arg.Preset, CvID: arg.CvID, JobID: arg.JobID,
 	}, nil
 }
 
-func (f *fakeQueries) ListAssistantChatSessions(_ context.Context, userID int64) ([]db.AssistantSession, error) {
+func (f *fakeQueries) ListAssistantChatSessions(_ context.Context, userID int64) ([]db.ListAssistantChatSessionsRow, error) {
 	f.gotUserID = userID
 	if f.session.UserID != userID || f.session.Preset != PresetChat {
 		return nil, nil
 	}
-	return []db.AssistantSession{{
+	return []db.ListAssistantChatSessionsRow{{
 		ID: f.session.ID, UserID: f.session.UserID, Preset: f.session.Preset,
 		Label: f.session.Label, CvID: f.session.CvID, JobID: f.session.JobID,
 	}}, nil
 }
 
-func (f *fakeQueries) GetAssistantSession(_ context.Context, arg db.GetAssistantSessionParams) (db.AssistantSession, error) {
+func (f *fakeQueries) GetAssistantSession(_ context.Context, arg db.GetAssistantSessionParams) (db.GetAssistantSessionRow, error) {
 	f.gotUserID = arg.UserID
 	if f.session.ID != arg.ID || f.session.UserID != arg.UserID {
-		return db.AssistantSession{}, pgx.ErrNoRows
+		return db.GetAssistantSessionRow{}, pgx.ErrNoRows
 	}
-	return db.AssistantSession{
+	return db.GetAssistantSessionRow{
 		ID: f.session.ID, UserID: f.session.UserID, Preset: f.session.Preset,
 		Label: f.session.Label, CvID: f.session.CvID, JobID: f.session.JobID,
 	}, nil
@@ -102,7 +102,7 @@ func TestGetSessionMapsNullableColumns(t *testing.T) {
 	f := &fakeQueries{session: db.AssistantSession{
 		ID: sessionID, UserID: 3, Preset: PresetTailor,
 		Label: pgtype.Text{String: "Tailor for Acme", Valid: true},
-		CvID:  ptr(int64(42)),
+		CvID:  ptr(uuid.MustParse("33333333-3333-4333-8333-333333333333")),
 		JobID: nil, // never set
 	}}
 	s := NewStore(f)
@@ -114,8 +114,8 @@ func TestGetSessionMapsNullableColumns(t *testing.T) {
 	if got.Preset != PresetTailor || got.Label != "Tailor for Acme" {
 		t.Errorf("session = %+v, want the stored preset and label", got)
 	}
-	if got.CVID == nil || *got.CVID != 42 {
-		t.Errorf("CVID = %v, want 42", got.CVID)
+	if got.CVID == nil || got.CVID.String() != "33333333-3333-4333-8333-333333333333" {
+		t.Errorf("CVID = %v, want the bound CV", got.CVID)
 	}
 	if got.JobID != nil {
 		t.Errorf("JobID = %v, want nil for an unset column", got.JobID)
@@ -194,15 +194,15 @@ func TestLabelSessionUsesTheFirstMessage(t *testing.T) {
 func TestCreateSessionPassesTheBinding(t *testing.T) {
 	f := &fakeQueries{}
 	s := NewStore(f)
-	cv := int64(42)
+	cv := uuid.MustParse("44444444-4444-4444-8444-444444444444")
 	job := int64(9)
 
 	got, err := s.CreateSession(context.Background(), 3, PresetTailor, &cv, &job)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	if got.Preset != PresetTailor || got.CVID == nil || *got.CVID != 42 || got.JobID == nil || *got.JobID != 9 {
-		t.Errorf("session = %+v, want a tailoring session bound to cv 42 / job 9", got)
+	if got.Preset != PresetTailor || got.CVID == nil || *got.CVID != cv || got.JobID == nil || *got.JobID != 9 {
+		t.Errorf("session = %+v, want a tailoring session bound to that cv / job 9", got)
 	}
 }
 

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/google/uuid"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -23,7 +24,10 @@ var ErrNoResume = errors.New("cv: no résumé to seed a base CV")
 
 // Meta is a CV without its document body — the shape the list and mutation responses use.
 type Meta struct {
-	ID         int64
+	// ID is a random UUID, not a counter: a CV is a résumé, and a countable id
+	// would both publish how many exist and make one forgotten owner check
+	// enumerable. See the opaque-cv-ids change.
+	ID         uuid.UUID
 	Title      string
 	TemplateID string
 	CreatedAt  time.Time
@@ -56,13 +60,13 @@ type TailoredItem struct {
 type Repository interface {
 	Create(ctx context.Context, userID int64, title, templateID string, data []byte) (db.CreateCVRow, error)
 	List(ctx context.Context, userID int64) ([]db.ListCVsByUserRow, error)
-	Get(ctx context.Context, id, userID int64) (db.GetCVByIDRow, error)
-	Update(ctx context.Context, id, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error)
-	Delete(ctx context.Context, id, userID int64) (int64, error)
+	Get(ctx context.Context, id uuid.UUID, userID int64) (db.GetCVByIDRow, error)
+	Update(ctx context.Context, id uuid.UUID, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error)
+	Delete(ctx context.Context, id uuid.UUID, userID int64) (int64, error)
 	GetBase(ctx context.Context, userID int64) (db.GetBaseCVByUserRow, error)
 	CreateTailored(ctx context.Context, userID, jobID int64, title, templateID string, data []byte) (db.CreateTailoredCVRow, error)
-	SetSession(ctx context.Context, id, userID int64, sessionID string) (int64, error)
-	SetTemplate(ctx context.Context, id, userID int64, templateID string) (int64, error)
+	SetSession(ctx context.Context, id uuid.UUID, userID int64, sessionID string) (int64, error)
+	SetTemplate(ctx context.Context, id uuid.UUID, userID int64, templateID string) (int64, error)
 	ListTailored(ctx context.Context, userID int64) ([]db.ListTailoredCVsByUserRow, error)
 }
 
@@ -110,7 +114,7 @@ func (s *Store) List(ctx context.Context, userID int64) ([]Meta, error) {
 }
 
 // Get returns one owned CV with its document, or ErrNotFound.
-func (s *Store) Get(ctx context.Context, id, userID int64) (Record, error) {
+func (s *Store) Get(ctx context.Context, id uuid.UUID, userID int64) (Record, error) {
 	row, err := s.repo.Get(ctx, id, userID)
 	if err != nil {
 		return Record{}, mapNotFound(err)
@@ -144,7 +148,7 @@ func textValue(v pgtype.Text) string {
 }
 
 // SetSession binds (or rebinds) the agent session to an owned CV, or returns ErrNotFound.
-func (s *Store) SetSession(ctx context.Context, id, userID int64, sessionID string) error {
+func (s *Store) SetSession(ctx context.Context, id uuid.UUID, userID int64, sessionID string) error {
 	n, err := s.repo.SetSession(ctx, id, userID, sessionID)
 	if err != nil {
 		return err
@@ -157,7 +161,7 @@ func (s *Store) SetSession(ctx context.Context, id, userID int64, sessionID stri
 
 // SetTemplate changes only the template of an owned CV, or returns ErrNotFound. Title and
 // document are left untouched.
-func (s *Store) SetTemplate(ctx context.Context, id, userID int64, templateID string) error {
+func (s *Store) SetTemplate(ctx context.Context, id uuid.UUID, userID int64, templateID string) error {
 	n, err := s.repo.SetTemplate(ctx, id, userID, templateID)
 	if err != nil {
 		return err
@@ -189,7 +193,7 @@ func (s *Store) ListTailored(ctx context.Context, userID int64) ([]TailoredItem,
 }
 
 // Update sanitizes and replaces an owned CV's editable fields, or returns ErrNotFound.
-func (s *Store) Update(ctx context.Context, id, userID int64, title, templateID string, doc Document) (Meta, error) {
+func (s *Store) Update(ctx context.Context, id uuid.UUID, userID int64, title, templateID string, doc Document) (Meta, error) {
 	data, err := marshalSanitized(doc)
 	if err != nil {
 		return Meta{}, err
@@ -203,7 +207,7 @@ func (s *Store) Update(ctx context.Context, id, userID int64, title, templateID 
 }
 
 // Delete removes an owned CV, or returns ErrNotFound when nothing matched.
-func (s *Store) Delete(ctx context.Context, id, userID int64) error {
+func (s *Store) Delete(ctx context.Context, id uuid.UUID, userID int64) error {
 	n, err := s.repo.Delete(ctx, id, userID)
 	if err != nil {
 		return err
@@ -217,7 +221,7 @@ func (s *Store) Delete(ctx context.Context, id, userID int64) error {
 // Patch loads an owned CV, applies one field-level edit, and persists the sanitized result.
 // It returns ErrInvalidPatch (leaving the stored CV untouched) when the patch addresses a
 // field or index that does not exist, or ErrNotFound for a foreign/missing id.
-func (s *Store) Patch(ctx context.Context, id, userID int64, p Patch) (Meta, error) {
+func (s *Store) Patch(ctx context.Context, id uuid.UUID, userID int64, p Patch) (Meta, error) {
 	rec, err := s.Get(ctx, id, userID)
 	if err != nil {
 		return Meta{}, err
@@ -332,15 +336,15 @@ func (r queriesRepository) List(ctx context.Context, userID int64) ([]db.ListCVs
 	return r.q.ListCVsByUser(ctx, userID)
 }
 
-func (r queriesRepository) Get(ctx context.Context, id, userID int64) (db.GetCVByIDRow, error) {
+func (r queriesRepository) Get(ctx context.Context, id uuid.UUID, userID int64) (db.GetCVByIDRow, error) {
 	return r.q.GetCVByID(ctx, db.GetCVByIDParams{ID: id, UserID: userID})
 }
 
-func (r queriesRepository) Update(ctx context.Context, id, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
+func (r queriesRepository) Update(ctx context.Context, id uuid.UUID, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
 	return r.q.UpdateCV(ctx, db.UpdateCVParams{ID: id, UserID: userID, Title: title, TemplateID: templateID, Data: data})
 }
 
-func (r queriesRepository) Delete(ctx context.Context, id, userID int64) (int64, error) {
+func (r queriesRepository) Delete(ctx context.Context, id uuid.UUID, userID int64) (int64, error) {
 	return r.q.DeleteCV(ctx, db.DeleteCVParams{ID: id, UserID: userID})
 }
 
@@ -355,14 +359,14 @@ func (r queriesRepository) CreateTailored(ctx context.Context, userID, jobID int
 	})
 }
 
-func (r queriesRepository) SetSession(ctx context.Context, id, userID int64, sessionID string) (int64, error) {
+func (r queriesRepository) SetSession(ctx context.Context, id uuid.UUID, userID int64, sessionID string) (int64, error) {
 	return r.q.SetCVSession(ctx, db.SetCVSessionParams{
 		ID: id, UserID: userID,
 		AgentSessionID: pgtype.Text{String: sessionID, Valid: sessionID != ""},
 	})
 }
 
-func (r queriesRepository) SetTemplate(ctx context.Context, id, userID int64, templateID string) (int64, error) {
+func (r queriesRepository) SetTemplate(ctx context.Context, id uuid.UUID, userID int64, templateID string) (int64, error) {
 	return r.q.SetCVTemplate(ctx, db.SetCVTemplateParams{ID: id, UserID: userID, TemplateID: templateID})
 }
 

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -14,11 +15,16 @@ import (
 
 // fakeRepo is an in-memory owner-scoped Repository for unit-testing Store without a DB.
 type fakeRepo struct {
-	rows map[int64]fakeRow
-	next int64
+	rows map[uuid.UUID]fakeRow
+	// writes counts insertions, so a row can record the order it arrived in.
+	writes int
 }
 
 type fakeRow struct {
+	// seq is the insertion order. The real query breaks the "newest base CV" tie
+	// with `updated_at DESC, id DESC`; random ids carry no order, so the fake keeps
+	// the one thing that still models "newest" — when the row was written.
+	seq        int
 	userID     int64
 	title      string
 	templateID string
@@ -27,14 +33,14 @@ type fakeRow struct {
 	sessionID  string
 }
 
-func newFakeRepo() *fakeRepo { return &fakeRepo{rows: map[int64]fakeRow{}, next: 1} }
+func newFakeRepo() *fakeRepo { return &fakeRepo{rows: map[uuid.UUID]fakeRow{}} }
 
 func stamp() pgtype.Timestamptz { return pgtype.Timestamptz{Valid: true} }
 
 func (f *fakeRepo) Create(_ context.Context, userID int64, title, templateID string, data []byte) (db.CreateCVRow, error) {
-	id := f.next
-	f.next++
-	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data}
+	id := uuid.New()
+	f.writes++
+	f.rows[id] = fakeRow{seq: f.writes, userID: userID, title: title, templateID: templateID, data: data}
 	return db.CreateCVRow{ID: id, Title: title, TemplateID: templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 
@@ -48,7 +54,7 @@ func (f *fakeRepo) List(_ context.Context, userID int64) ([]db.ListCVsByUserRow,
 	return out, nil
 }
 
-func (f *fakeRepo) Get(_ context.Context, id, userID int64) (db.GetCVByIDRow, error) {
+func (f *fakeRepo) Get(_ context.Context, id uuid.UUID, userID int64) (db.GetCVByIDRow, error) {
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return db.GetCVByIDRow{}, pgx.ErrNoRows
@@ -56,7 +62,7 @@ func (f *fakeRepo) Get(_ context.Context, id, userID int64) (db.GetCVByIDRow, er
 	return db.GetCVByIDRow{ID: id, Title: r.title, TemplateID: r.templateID, Data: r.data, JobID: pgtype.Int8{Int64: r.jobID, Valid: r.jobID != 0}, AgentSessionID: pgtype.Text{String: r.sessionID, Valid: r.sessionID != ""}, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 
-func (f *fakeRepo) SetSession(_ context.Context, id, userID int64, sessionID string) (int64, error) {
+func (f *fakeRepo) SetSession(_ context.Context, id uuid.UUID, userID int64, sessionID string) (int64, error) {
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return 0, nil
@@ -66,7 +72,7 @@ func (f *fakeRepo) SetSession(_ context.Context, id, userID int64, sessionID str
 	return 1, nil
 }
 
-func (f *fakeRepo) SetTemplate(_ context.Context, id, userID int64, templateID string) (int64, error) {
+func (f *fakeRepo) SetTemplate(_ context.Context, id uuid.UUID, userID int64, templateID string) (int64, error) {
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return 0, nil
@@ -90,16 +96,16 @@ func (f *fakeRepo) ListTailored(_ context.Context, userID int64) ([]db.ListTailo
 	return out, nil
 }
 
-func (f *fakeRepo) Update(_ context.Context, id, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
+func (f *fakeRepo) Update(_ context.Context, id uuid.UUID, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return db.UpdateCVRow{}, pgx.ErrNoRows
 	}
-	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data, jobID: r.jobID, sessionID: r.sessionID}
+	f.rows[id] = fakeRow{seq: r.seq, userID: userID, title: title, templateID: templateID, data: data, jobID: r.jobID, sessionID: r.sessionID}
 	return db.UpdateCVRow{ID: id, Title: title, TemplateID: templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 
-func (f *fakeRepo) Delete(_ context.Context, id, userID int64) (int64, error) {
+func (f *fakeRepo) Delete(_ context.Context, id uuid.UUID, userID int64) (int64, error) {
 	if r, ok := f.rows[id]; !ok || r.userID != userID {
 		return 0, nil
 	}
@@ -108,15 +114,15 @@ func (f *fakeRepo) Delete(_ context.Context, id, userID int64) (int64, error) {
 }
 
 func (f *fakeRepo) GetBase(_ context.Context, userID int64) (db.GetBaseCVByUserRow, error) {
-	// Newest base CV = the highest id among the user's non-tailored rows (mirrors the
-	// query's updated_at DESC, id DESC tiebreak).
-	var bestID int64
+	// Newest base CV = the most recently written of the user's non-tailored rows.
+	var bestID uuid.UUID
+	best := 0
 	for id, r := range f.rows {
-		if r.userID == userID && r.jobID == 0 && id > bestID {
-			bestID = id
+		if r.userID == userID && r.jobID == 0 && r.seq > best {
+			best, bestID = r.seq, id
 		}
 	}
-	if bestID == 0 {
+	if best == 0 {
 		return db.GetBaseCVByUserRow{}, pgx.ErrNoRows
 	}
 	r := f.rows[bestID]
@@ -124,8 +130,7 @@ func (f *fakeRepo) GetBase(_ context.Context, userID int64) (db.GetBaseCVByUserR
 }
 
 func (f *fakeRepo) CreateTailored(_ context.Context, userID, jobID int64, title, templateID string, data []byte) (db.CreateTailoredCVRow, error) {
-	id := f.next
-	f.next++
+	id := uuid.New()
 	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data, jobID: jobID}
 	return db.CreateTailoredCVRow{ID: id, Title: title, TemplateID: templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }

--- a/internal/db/assistant.sql.go
+++ b/internal/db/assistant.sql.go
@@ -53,23 +53,34 @@ RETURNING id, user_id, preset, label, cv_id, job_id, created_at, updated_at
 `
 
 type CreateAssistantSessionParams struct {
-	UserID int64  `json:"user_id"`
-	Preset string `json:"preset"`
-	CvID   *int64 `json:"cv_id"`
-	JobID  *int64 `json:"job_id"`
+	UserID int64      `json:"user_id"`
+	Preset string     `json:"preset"`
+	CvID   *uuid.UUID `json:"cv_id"`
+	JobID  *int64     `json:"job_id"`
+}
+
+type CreateAssistantSessionRow struct {
+	ID        uuid.UUID          `json:"id"`
+	UserID    int64              `json:"user_id"`
+	Preset    string             `json:"preset"`
+	Label     pgtype.Text        `json:"label"`
+	CvID      *uuid.UUID         `json:"cv_id"`
+	JobID     *int64             `json:"job_id"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 }
 
 // Start a conversation for a user. preset selects the prompt and tool set ('chat' or
 // 'tailor'); cv_id/job_id bind a tailoring session to its CV and vacancy and are NULL
 // for a chat. The label is set later, from the first user message.
-func (q *Queries) CreateAssistantSession(ctx context.Context, arg CreateAssistantSessionParams) (AssistantSession, error) {
+func (q *Queries) CreateAssistantSession(ctx context.Context, arg CreateAssistantSessionParams) (CreateAssistantSessionRow, error) {
 	row := q.db.QueryRow(ctx, createAssistantSession,
 		arg.UserID,
 		arg.Preset,
 		arg.CvID,
 		arg.JobID,
 	)
-	var i AssistantSession
+	var i CreateAssistantSessionRow
 	err := row.Scan(
 		&i.ID,
 		&i.UserID,
@@ -114,11 +125,22 @@ type GetAssistantSessionParams struct {
 	UserID int64     `json:"user_id"`
 }
 
+type GetAssistantSessionRow struct {
+	ID        uuid.UUID          `json:"id"`
+	UserID    int64              `json:"user_id"`
+	Preset    string             `json:"preset"`
+	Label     pgtype.Text        `json:"label"`
+	CvID      *uuid.UUID         `json:"cv_id"`
+	JobID     *int64             `json:"job_id"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+}
+
 // One session owned by the caller. Owner-scoped: a foreign or missing id returns no row,
 // which the handler maps to 404 — so a probe cannot tell the two apart.
-func (q *Queries) GetAssistantSession(ctx context.Context, arg GetAssistantSessionParams) (AssistantSession, error) {
+func (q *Queries) GetAssistantSession(ctx context.Context, arg GetAssistantSessionParams) (GetAssistantSessionRow, error) {
 	row := q.db.QueryRow(ctx, getAssistantSession, arg.ID, arg.UserID)
-	var i AssistantSession
+	var i GetAssistantSessionRow
 	err := row.Scan(
 		&i.ID,
 		&i.UserID,
@@ -139,20 +161,31 @@ WHERE user_id = $1 AND preset = 'chat'
 ORDER BY updated_at DESC, id DESC
 `
 
+type ListAssistantChatSessionsRow struct {
+	ID        uuid.UUID          `json:"id"`
+	UserID    int64              `json:"user_id"`
+	Preset    string             `json:"preset"`
+	Label     pgtype.Text        `json:"label"`
+	CvID      *uuid.UUID         `json:"cv_id"`
+	JobID     *int64             `json:"job_id"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+}
+
 // The caller's session rail: their general chats, most recently active first. Owner-scoped
 // by construction — another user's sessions can never appear. Tailoring conversations are
 // deliberately excluded: they belong to the CV that owns them and are reached through the
 // tailoring workspace, so listing them here would put a chat in the rail that leads nowhere
 // useful and cannot be continued without its CV.
-func (q *Queries) ListAssistantChatSessions(ctx context.Context, userID int64) ([]AssistantSession, error) {
+func (q *Queries) ListAssistantChatSessions(ctx context.Context, userID int64) ([]ListAssistantChatSessionsRow, error) {
 	rows, err := q.db.Query(ctx, listAssistantChatSessions, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []AssistantSession{}
+	items := []ListAssistantChatSessionsRow{}
 	for rows.Next() {
-		var i AssistantSession
+		var i ListAssistantChatSessionsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.UserID,

--- a/internal/db/credits.sql.go
+++ b/internal/db/credits.sql.go
@@ -262,7 +262,7 @@ const listTailoredCVLabelsByIDs = `-- name: ListTailoredCVLabelsByIDs :many
 SELECT c.id, j.title AS job_title, j.public_slug AS job_slug
 FROM cvs c
 JOIN jobs j ON j.id = c.job_id
-WHERE c.id = ANY($1::bigint[])
+WHERE c.id = ANY($1::uuid[])
 `
 
 type ListTailoredCVLabelsByIDsRow struct {
@@ -274,7 +274,7 @@ type ListTailoredCVLabelsByIDsRow struct {
 // Resolve tailored-CV ids to their target job's display labels for the credit-history page
 // (tailor debits). Only tailored CVs (job_id set) whose job still exists resolve; the handler
 // falls back to a generic label otherwise.
-func (q *Queries) ListTailoredCVLabelsByIDs(ctx context.Context, ids []int64) ([]ListTailoredCVLabelsByIDsRow, error) {
+func (q *Queries) ListTailoredCVLabelsByIDs(ctx context.Context, ids []pgtype.UUID) ([]ListTailoredCVLabelsByIDsRow, error) {
 	rows, err := q.db.Query(ctx, listTailoredCVLabelsByIDs, ids)
 	if err != nil {
 		return nil, err

--- a/internal/db/credits.sql.go
+++ b/internal/db/credits.sql.go
@@ -8,6 +8,7 @@ package db
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -265,9 +266,9 @@ WHERE c.id = ANY($1::bigint[])
 `
 
 type ListTailoredCVLabelsByIDsRow struct {
-	ID       int64  `json:"id"`
-	JobTitle string `json:"job_title"`
-	JobSlug  string `json:"job_slug"`
+	ID       uuid.UUID `json:"id"`
+	JobTitle string    `json:"job_title"`
+	JobSlug  string    `json:"job_slug"`
 }
 
 // Resolve tailored-CV ids to their target job's display labels for the credit-history page

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -8,6 +8,7 @@ package db
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -25,7 +26,7 @@ type CreateCVParams struct {
 }
 
 type CreateCVRow struct {
-	ID         int64              `json:"id"`
+	ID         uuid.UUID          `json:"id"`
 	Title      string             `json:"title"`
 	TemplateID string             `json:"template_id"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
@@ -68,7 +69,7 @@ type CreateTailoredCVParams struct {
 }
 
 type CreateTailoredCVRow struct {
-	ID         int64              `json:"id"`
+	ID         uuid.UUID          `json:"id"`
 	Title      string             `json:"title"`
 	TemplateID string             `json:"template_id"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
@@ -102,8 +103,8 @@ WHERE id = $1 AND user_id = $2
 `
 
 type DeleteCVParams struct {
-	ID     int64 `json:"id"`
-	UserID int64 `json:"user_id"`
+	ID     uuid.UUID `json:"id"`
+	UserID int64     `json:"user_id"`
 }
 
 // Delete a CV owned by the user. Returns the affected-row count so the handler can 404
@@ -125,7 +126,7 @@ LIMIT 1
 `
 
 type GetBaseCVByUserRow struct {
-	ID         int64              `json:"id"`
+	ID         uuid.UUID          `json:"id"`
 	Title      string             `json:"title"`
 	TemplateID string             `json:"template_id"`
 	Data       []byte             `json:"data"`
@@ -157,12 +158,12 @@ WHERE id = $1 AND user_id = $2
 `
 
 type GetCVByIDParams struct {
-	ID     int64 `json:"id"`
-	UserID int64 `json:"user_id"`
+	ID     uuid.UUID `json:"id"`
+	UserID int64     `json:"user_id"`
 }
 
 type GetCVByIDRow struct {
-	ID             int64              `json:"id"`
+	ID             uuid.UUID          `json:"id"`
 	Title          string             `json:"title"`
 	TemplateID     string             `json:"template_id"`
 	Data           []byte             `json:"data"`
@@ -199,7 +200,7 @@ ORDER BY updated_at DESC
 `
 
 type ListCVsByUserRow struct {
-	ID         int64              `json:"id"`
+	ID         uuid.UUID          `json:"id"`
 	Title      string             `json:"title"`
 	TemplateID string             `json:"template_id"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
@@ -243,7 +244,7 @@ ORDER BY c.updated_at DESC
 `
 
 type ListTailoredCVsByUserRow struct {
-	ID             int64              `json:"id"`
+	ID             uuid.UUID          `json:"id"`
 	Title          string             `json:"title"`
 	TemplateID     string             `json:"template_id"`
 	AgentSessionID pgtype.Text        `json:"agent_session_id"`
@@ -294,7 +295,7 @@ WHERE id = $1 AND user_id = $2
 `
 
 type SetCVSessionParams struct {
-	ID             int64       `json:"id"`
+	ID             uuid.UUID   `json:"id"`
 	UserID         int64       `json:"user_id"`
 	AgentSessionID pgtype.Text `json:"agent_session_id"`
 }
@@ -316,9 +317,9 @@ WHERE id = $1 AND user_id = $2
 `
 
 type SetCVTemplateParams struct {
-	ID         int64  `json:"id"`
-	UserID     int64  `json:"user_id"`
-	TemplateID string `json:"template_id"`
+	ID         uuid.UUID `json:"id"`
+	UserID     int64     `json:"user_id"`
+	TemplateID string    `json:"template_id"`
 }
 
 // Change only a CV's template, stamping updated_at, leaving title and data untouched. Owner-
@@ -339,15 +340,15 @@ RETURNING id, title, template_id, created_at, updated_at
 `
 
 type UpdateCVParams struct {
-	ID         int64  `json:"id"`
-	UserID     int64  `json:"user_id"`
-	Title      string `json:"title"`
-	TemplateID string `json:"template_id"`
-	Data       []byte `json:"data"`
+	ID         uuid.UUID `json:"id"`
+	UserID     int64     `json:"user_id"`
+	Title      string    `json:"title"`
+	TemplateID string    `json:"template_id"`
+	Data       []byte    `json:"data"`
 }
 
 type UpdateCVRow struct {
-	ID         int64              `json:"id"`
+	ID         uuid.UUID          `json:"id"`
 	Title      string             `json:"title"`
 	TemplateID string             `json:"template_id"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -36,10 +36,10 @@ type AssistantSession struct {
 	UserID    int64              `json:"user_id"`
 	Preset    string             `json:"preset"`
 	Label     pgtype.Text        `json:"label"`
-	CvID      *int64             `json:"cv_id"`
 	JobID     *int64             `json:"job_id"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	CvID      *uuid.UUID         `json:"cv_id"`
 }
 
 type BoardHealth struct {
@@ -119,7 +119,6 @@ type CreditLedger struct {
 }
 
 type Cv struct {
-	ID             int64              `json:"id"`
 	UserID         int64              `json:"user_id"`
 	Title          string             `json:"title"`
 	TemplateID     string             `json:"template_id"`
@@ -128,6 +127,7 @@ type Cv struct {
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
 	AgentSessionID pgtype.Text        `json:"agent_session_id"`
+	ID             uuid.UUID          `json:"id"`
 }
 
 type Email struct {
@@ -422,7 +422,6 @@ type ReferralRequest struct {
 	CompanySlug     string             `json:"company_slug"`
 	JobID           pgtype.Int8        `json:"job_id"`
 	CvKind          string             `json:"cv_kind"`
-	CvID            pgtype.Int8        `json:"cv_id"`
 	ContactTelegram pgtype.Text        `json:"contact_telegram"`
 	ContactEmail    pgtype.Text        `json:"contact_email"`
 	Note            string             `json:"note"`
@@ -431,6 +430,7 @@ type ReferralRequest struct {
 	ActedAt         pgtype.Timestamptz `json:"acted_at"`
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl     string             `json:"linkedin_url"`
+	CvID            *uuid.UUID         `json:"cv_id"`
 }
 
 type ReminderSetting struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -987,7 +987,7 @@ type Querier interface {
 	// Resolve tailored-CV ids to their target job's display labels for the credit-history page
 	// (tailor debits). Only tailored CVs (job_id set) whose job still exists resolve; the handler
 	// falls back to a generic label otherwise.
-	ListTailoredCVLabelsByIDs(ctx context.Context, ids []int64) ([]ListTailoredCVLabelsByIDsRow, error)
+	ListTailoredCVLabelsByIDs(ctx context.Context, ids []pgtype.UUID) ([]ListTailoredCVLabelsByIDsRow, error)
 	// A user's TAILORED CVs (bound to a vacancy), newest edit first — the re-open list. Carries the
 	// vacancy's public slug and the bound agent session so each row links back to its workspace.
 	// Base CVs (job_id NULL) are excluded; the JOIN also drops tailored CVs whose job was deleted.

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -270,7 +270,7 @@ type Querier interface {
 	// Start a conversation for a user. preset selects the prompt and tool set ('chat' or
 	// 'tailor'); cv_id/job_id bind a tailoring session to its CV and vacancy and are NULL
 	// for a chat. The label is set later, from the first user message.
-	CreateAssistantSession(ctx context.Context, arg CreateAssistantSessionParams) (AssistantSession, error)
+	CreateAssistantSession(ctx context.Context, arg CreateAssistantSessionParams) (CreateAssistantSessionRow, error)
 	// Insert a new CV for a user. data is the sanitized structured document (JSON). job_id
 	// defaults NULL (the tailoring seam is unused in phase 1). Returns the metadata the list
 	// and detail responses need.
@@ -516,7 +516,7 @@ type Querier interface {
 	FindOpenJobByURL(ctx context.Context, url string) (string, error)
 	// One session owned by the caller. Owner-scoped: a foreign or missing id returns no row,
 	// which the handler maps to 404 — so a probe cannot tell the two apart.
-	GetAssistantSession(ctx context.Context, arg GetAssistantSessionParams) (AssistantSession, error)
+	GetAssistantSession(ctx context.Context, arg GetAssistantSessionParams) (GetAssistantSessionRow, error)
 	// Read-only balance for display (no lock, no LLM). Returns no rows for a user who has never
 	// had credit activity; the caller treats that as a full monthly grant remaining.
 	GetBalance(ctx context.Context, userID int64) (GetBalanceRow, error)
@@ -761,7 +761,7 @@ type Querier interface {
 	// deliberately excluded: they belong to the CV that owns them and are reached through the
 	// tailoring workspace, so listing them here would put a chat in the rail that leads nowhere
 	// useful and cannot be continued without its CV.
-	ListAssistantChatSessions(ctx context.Context, userID int64) ([]AssistantSession, error)
+	ListAssistantChatSessions(ctx context.Context, userID int64) ([]ListAssistantChatSessionsRow, error)
 	// A session's whole transcript in order. It is both what the client replays and what the
 	// model's history is rebuilt from, so tool calls and tool results are included.
 	ListAssistantMessages(ctx context.Context, sessionID uuid.UUID) ([]AssistantMessage, error)

--- a/internal/db/queries/credits.sql
+++ b/internal/db/queries/credits.sql
@@ -100,4 +100,4 @@ WHERE id = ANY(sqlc.arg(ids)::bigint[]);
 SELECT c.id, j.title AS job_title, j.public_slug AS job_slug
 FROM cvs c
 JOIN jobs j ON j.id = c.job_id
-WHERE c.id = ANY(sqlc.arg(ids)::bigint[]);
+WHERE c.id = ANY(sqlc.arg(ids)::uuid[]);

--- a/internal/db/referrals.sql.go
+++ b/internal/db/referrals.sql.go
@@ -8,6 +8,7 @@ package db
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -18,8 +19,8 @@ SELECT EXISTS (
 `
 
 type CVBelongsToUserParams struct {
-	CvID   int64 `json:"cv_id"`
-	UserID int64 `json:"user_id"`
+	CvID   uuid.UUID `json:"cv_id"`
+	UserID int64     `json:"user_id"`
 }
 
 // Whether a builder CV is owned by a user — the authorization check before attaching a
@@ -135,7 +136,7 @@ INSERT INTO referral_requests (
     contact_telegram, contact_email, note, linkedin_url
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url
+RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id
 `
 
 type CreateReferralRequestParams struct {
@@ -143,7 +144,7 @@ type CreateReferralRequestParams struct {
 	CompanySlug     string      `json:"company_slug"`
 	JobID           pgtype.Int8 `json:"job_id"`
 	CvKind          string      `json:"cv_kind"`
-	CvID            pgtype.Int8 `json:"cv_id"`
+	CvID            *uuid.UUID  `json:"cv_id"`
 	ContactTelegram pgtype.Text `json:"contact_telegram"`
 	ContactEmail    pgtype.Text `json:"contact_email"`
 	Note            string      `json:"note"`
@@ -172,7 +173,6 @@ func (q *Queries) CreateReferralRequest(ctx context.Context, arg CreateReferralR
 		&i.CompanySlug,
 		&i.JobID,
 		&i.CvKind,
-		&i.CvID,
 		&i.ContactTelegram,
 		&i.ContactEmail,
 		&i.Note,
@@ -181,6 +181,7 @@ func (q *Queries) CreateReferralRequest(ctx context.Context, arg CreateReferralR
 		&i.ActedAt,
 		&i.CreatedAt,
 		&i.LinkedinUrl,
+		&i.CvID,
 	)
 	return i, err
 }
@@ -262,7 +263,7 @@ func (q *Queries) GetReferralOffer(ctx context.Context, id int64) (ReferralOffer
 }
 
 const getReferralRequest = `-- name: GetReferralRequest :one
-SELECT id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url FROM referral_requests WHERE id = $1
+SELECT id, seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id FROM referral_requests WHERE id = $1
 `
 
 // One referral request by id — for authorized CV access and marking, after the caller is
@@ -276,7 +277,6 @@ func (q *Queries) GetReferralRequest(ctx context.Context, id int64) (ReferralReq
 		&i.CompanySlug,
 		&i.JobID,
 		&i.CvKind,
-		&i.CvID,
 		&i.ContactTelegram,
 		&i.ContactEmail,
 		&i.Note,
@@ -285,6 +285,7 @@ func (q *Queries) GetReferralRequest(ctx context.Context, id int64) (ReferralReq
 		&i.ActedAt,
 		&i.CreatedAt,
 		&i.LinkedinUrl,
+		&i.CvID,
 	)
 	return i, err
 }
@@ -327,7 +328,7 @@ func (q *Queries) ListApprovedReferrerRecipients(ctx context.Context, companySlu
 }
 
 const listIncomingReferralRequests = `-- name: ListIncomingReferralRequests :many
-SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.cv_id, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, c.name AS company_name
+SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, r.cv_id, c.name AS company_name
 FROM referral_requests r
 JOIN referral_offers o ON o.company_slug = r.company_slug
 LEFT JOIN companies c ON c.slug = r.company_slug
@@ -341,7 +342,6 @@ type ListIncomingReferralRequestsRow struct {
 	CompanySlug     string             `json:"company_slug"`
 	JobID           pgtype.Int8        `json:"job_id"`
 	CvKind          string             `json:"cv_kind"`
-	CvID            pgtype.Int8        `json:"cv_id"`
 	ContactTelegram pgtype.Text        `json:"contact_telegram"`
 	ContactEmail    pgtype.Text        `json:"contact_email"`
 	Note            string             `json:"note"`
@@ -350,6 +350,7 @@ type ListIncomingReferralRequestsRow struct {
 	ActedAt         pgtype.Timestamptz `json:"acted_at"`
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl     string             `json:"linkedin_url"`
+	CvID            *uuid.UUID         `json:"cv_id"`
 	CompanyName     pgtype.Text        `json:"company_name"`
 }
 
@@ -372,7 +373,6 @@ func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUser
 			&i.CompanySlug,
 			&i.JobID,
 			&i.CvKind,
-			&i.CvID,
 			&i.ContactTelegram,
 			&i.ContactEmail,
 			&i.Note,
@@ -381,6 +381,7 @@ func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUser
 			&i.ActedAt,
 			&i.CreatedAt,
 			&i.LinkedinUrl,
+			&i.CvID,
 			&i.CompanyName,
 		); err != nil {
 			return nil, err
@@ -505,7 +506,7 @@ func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([
 }
 
 const listReferralRequestsBySeeker = `-- name: ListReferralRequestsBySeeker :many
-SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.cv_id, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, c.name AS company_name
+SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, r.cv_id, c.name AS company_name
 FROM referral_requests r
 LEFT JOIN companies c ON c.slug = r.company_slug
 WHERE r.seeker_user_id = $1
@@ -518,7 +519,6 @@ type ListReferralRequestsBySeekerRow struct {
 	CompanySlug     string             `json:"company_slug"`
 	JobID           pgtype.Int8        `json:"job_id"`
 	CvKind          string             `json:"cv_kind"`
-	CvID            pgtype.Int8        `json:"cv_id"`
 	ContactTelegram pgtype.Text        `json:"contact_telegram"`
 	ContactEmail    pgtype.Text        `json:"contact_email"`
 	Note            string             `json:"note"`
@@ -527,6 +527,7 @@ type ListReferralRequestsBySeekerRow struct {
 	ActedAt         pgtype.Timestamptz `json:"acted_at"`
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl     string             `json:"linkedin_url"`
+	CvID            *uuid.UUID         `json:"cv_id"`
 	CompanyName     pgtype.Text        `json:"company_name"`
 }
 
@@ -548,7 +549,6 @@ func (q *Queries) ListReferralRequestsBySeeker(ctx context.Context, seekerUserID
 			&i.CompanySlug,
 			&i.JobID,
 			&i.CvKind,
-			&i.CvID,
 			&i.ContactTelegram,
 			&i.ContactEmail,
 			&i.Note,
@@ -557,6 +557,7 @@ func (q *Queries) ListReferralRequestsBySeeker(ctx context.Context, seekerUserID
 			&i.ActedAt,
 			&i.CreatedAt,
 			&i.LinkedinUrl,
+			&i.CvID,
 			&i.CompanyName,
 		); err != nil {
 			return nil, err
@@ -594,7 +595,7 @@ const resolveReferralRequest = `-- name: ResolveReferralRequest :one
 UPDATE referral_requests
 SET status = $1, acted_by = $2, acted_at = now()
 WHERE id = $3 AND status = 'sent'
-RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url
+RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id
 `
 
 type ResolveReferralRequestParams struct {
@@ -615,7 +616,6 @@ func (q *Queries) ResolveReferralRequest(ctx context.Context, arg ResolveReferra
 		&i.CompanySlug,
 		&i.JobID,
 		&i.CvKind,
-		&i.CvID,
 		&i.ContactTelegram,
 		&i.ContactEmail,
 		&i.Note,
@@ -624,6 +624,7 @@ func (q *Queries) ResolveReferralRequest(ctx context.Context, arg ResolveReferra
 		&i.ActedAt,
 		&i.CreatedAt,
 		&i.LinkedinUrl,
+		&i.CvID,
 	)
 	return i, err
 }

--- a/internal/db/referrals_integration_test.go
+++ b/internal/db/referrals_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -222,7 +223,7 @@ func TestReferralRequests(t *testing.T) {
 		// cv_kind='original' with a cv_id → cv_kind CHECK violation. (The "built
 		// requires a cv_id" invariant is a domain-layer concern, not a DB CHECK,
 		// so ON DELETE SET NULL can null a built request's cv_id without failing.)
-		var cvID int64
+		var cvID uuid.UUID
 		if err := pool.QueryRow(ctx,
 			`INSERT INTO cvs (user_id, title, data) VALUES ($1, 'CV', '{}') RETURNING id`,
 			seeker).Scan(&cvID); err != nil {
@@ -230,7 +231,7 @@ func TestReferralRequests(t *testing.T) {
 		}
 		if _, err := q.CreateReferralRequest(ctx, CreateReferralRequestParams{
 			SeekerUserID: seeker, CompanySlug: "acme", CvKind: "original",
-			CvID: pgtype.Int8{Int64: cvID, Valid: true}, ContactEmail: text("seeker@example.test"),
+			CvID: &cvID, ContactEmail: text("seeker@example.test"),
 		}); err == nil {
 			t.Error("original CV carrying a cv_id should violate cv_kind CHECK")
 		}
@@ -243,7 +244,7 @@ func TestReferralRequests(t *testing.T) {
 		insertCompany(t, pool, "acme", "acme")
 		approvedOffer(t, referrer, "acme")
 
-		var cvID int64
+		var cvID uuid.UUID
 		if err := pool.QueryRow(ctx,
 			`INSERT INTO cvs (user_id, title, data) VALUES ($1, 'CV', '{}') RETURNING id`,
 			seeker).Scan(&cvID); err != nil {
@@ -251,7 +252,7 @@ func TestReferralRequests(t *testing.T) {
 		}
 		req, err := q.CreateReferralRequest(ctx, CreateReferralRequestParams{
 			SeekerUserID: seeker, CompanySlug: "acme", CvKind: "built",
-			CvID: pgtype.Int8{Int64: cvID, Valid: true}, ContactEmail: text("seeker@example.test"),
+			CvID: &cvID, ContactEmail: text("seeker@example.test"),
 		})
 		if err != nil {
 			t.Fatalf("create built request: %v", err)
@@ -266,7 +267,7 @@ func TestReferralRequests(t *testing.T) {
 		if err != nil {
 			t.Fatalf("get request after cv delete: %v", err)
 		}
-		if got.CvID.Valid {
+		if got.CvID != nil {
 			t.Errorf("cv_id = %v, want NULL after CV deletion", got.CvID)
 		}
 		if got.CvKind != "built" {

--- a/internal/db/users.sql.go
+++ b/internal/db/users.sql.go
@@ -305,21 +305,6 @@ func (q *Queries) GetUserTokenVersion(ctx context.Context, id int64) (int32, err
 	return token_version, err
 }
 
-const isBetaTester = `-- name: IsBetaTester :one
-SELECT beta_tester
-FROM users
-WHERE id = $1
-`
-
-// Slim beta-membership lookup for the RequireModeratorOrBeta middleware — a
-// primitive bool so the auth package stays free of a db import (same shape as GetUserRole).
-func (q *Queries) IsBetaTester(ctx context.Context, id int64) (bool, error) {
-	row := q.db.QueryRow(ctx, isBetaTester, id)
-	var beta_tester bool
-	err := row.Scan(&beta_tester)
-	return beta_tester, err
-}
-
 const listUserBlobKeys = `-- name: ListUserBlobKeys :many
 SELECT u.resume_object_key AS key FROM users u
 WHERE u.id = $1 AND u.resume_object_key IS NOT NULL AND u.resume_object_key <> ''

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -96,11 +96,11 @@ const assistantKeepalive = 15 * time.Second
 
 // sessionResponse is the wire shape of one conversation.
 type sessionResponse struct {
-	ID     string `json:"id"`
-	Preset string `json:"preset"`
-	Label  string `json:"label"`
-	CVID   *int64 `json:"cv_id,omitempty"`
-	JobID  *int64 `json:"job_id,omitempty"`
+	ID     string  `json:"id"`
+	Preset string  `json:"preset"`
+	Label  string  `json:"label"`
+	CVID   *string `json:"cv_id,omitempty"`
+	JobID  *int64  `json:"job_id,omitempty"`
 }
 
 // sessionView renders a session for the client. The id is a string because the
@@ -110,7 +110,7 @@ func sessionView(s assistant.Session) sessionResponse {
 		ID:     s.ID.String(),
 		Preset: s.Preset,
 		Label:  s.Label,
-		CVID:   s.CVID,
+		CVID:   cvIDString(s.CVID),
 		JobID:  s.JobID,
 	}
 }
@@ -119,6 +119,17 @@ func sessionView(s assistant.Session) sessionResponse {
 // anything else cannot name a session at all — report it as missing rather than as
 // a bad request, keeping "not yours" and "not a session" one indistinguishable
 // answer.
+// cvIDString renders a tailoring session's CV binding for the wire. A CV id is a
+// UUID the client treats as opaque, so it travels as a string like the session's
+// own id.
+func cvIDString(id *uuid.UUID) *string {
+	if id == nil {
+		return nil
+	}
+	s := id.String()
+	return &s
+}
+
 func assistantSessionID(c *fiber.Ctx) (uuid.UUID, error) {
 	id, err := uuid.Parse(c.Params("id"))
 	if err != nil {

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"github.com/strelov1/freehire/internal/assistant"
 	"github.com/strelov1/freehire/internal/cv"
 )
@@ -14,7 +16,7 @@ import (
 // ones. They are bound to the session's own CV and vacancy: the ids are closed
 // over here rather than taken as arguments, so the model has no way to address a
 // different CV — not even by guessing an id.
-func (h *assistantHandlers) assistantCVTools(cvID, jobID int64) []assistant.Tool {
+func (h *assistantHandlers) assistantCVTools(cvID uuid.UUID, jobID int64) []assistant.Tool {
 	return []assistant.Tool{
 		h.cvContextTool(jobID),
 		h.cvGetTool(cvID),
@@ -51,7 +53,7 @@ func (h *assistantHandlers) cvContextTool(jobID int64) assistant.Tool {
 }
 
 // cvGetTool reads the tailored CV document the session is editing.
-func (h *assistantHandlers) cvGetTool(cvID int64) assistant.Tool {
+func (h *assistantHandlers) cvGetTool(cvID uuid.UUID) assistant.Tool {
 	return assistant.Tool{
 		Name:        "cv_get",
 		Description: "Read the current CV document being tailored, so edits are grounded in what it actually says.",
@@ -71,7 +73,7 @@ func (h *assistantHandlers) cvGetTool(cvID int64) assistant.Tool {
 }
 
 // cvEditTool applies one field-level patch to the tailored CV.
-func (h *assistantHandlers) cvEditTool(cvID int64) assistant.Tool {
+func (h *assistantHandlers) cvEditTool(cvID uuid.UUID) assistant.Tool {
 	return assistant.Tool{
 		Name: "cv_edit",
 		Description: "Apply ONE field-level patch to the CV. Ops: set_summary, set_header_field, add_bullet, " +

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/cv"
@@ -15,21 +16,21 @@ import (
 // cvRepo is a one-document stand-in for cv.Repository: it serves a single owned
 // CV and records what an update wrote.
 type cvRepo struct {
-	id      int64
+	id      uuid.UUID
 	userID  int64
 	jobID   int64
 	data    []byte
 	written []byte
 }
 
-func (r *cvRepo) Get(_ context.Context, id, userID int64) (db.GetCVByIDRow, error) {
+func (r *cvRepo) Get(_ context.Context, id uuid.UUID, userID int64) (db.GetCVByIDRow, error) {
 	if id != r.id || userID != r.userID {
 		return db.GetCVByIDRow{}, cv.ErrNotFound
 	}
 	return db.GetCVByIDRow{ID: r.id, Title: "CV", TemplateID: "classic-ats", Data: r.data, JobID: pgtype.Int8{Int64: r.jobID, Valid: r.jobID != 0}}, nil
 }
 
-func (r *cvRepo) Update(_ context.Context, id, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
+func (r *cvRepo) Update(_ context.Context, id uuid.UUID, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
 	if id != r.id || userID != r.userID {
 		return db.UpdateCVRow{}, cv.ErrNotFound
 	}
@@ -42,23 +43,27 @@ func (r *cvRepo) Create(context.Context, int64, string, string, []byte) (db.Crea
 	return db.CreateCVRow{}, nil
 }
 func (r *cvRepo) List(context.Context, int64) ([]db.ListCVsByUserRow, error) { return nil, nil }
-func (r *cvRepo) Delete(context.Context, int64, int64) (int64, error)        { return 0, nil }
+func (r *cvRepo) Delete(context.Context, uuid.UUID, int64) (int64, error)    { return 0, nil }
 func (r *cvRepo) GetBase(context.Context, int64) (db.GetBaseCVByUserRow, error) {
 	return db.GetBaseCVByUserRow{}, cv.ErrNotFound
 }
 func (r *cvRepo) CreateTailored(context.Context, int64, int64, string, string, []byte) (db.CreateTailoredCVRow, error) {
 	return db.CreateTailoredCVRow{}, nil
 }
-func (r *cvRepo) SetSession(context.Context, int64, int64, string) (int64, error)  { return 1, nil }
-func (r *cvRepo) SetTemplate(context.Context, int64, int64, string) (int64, error) { return 1, nil }
+func (r *cvRepo) SetSession(context.Context, uuid.UUID, int64, string) (int64, error)  { return 1, nil }
+func (r *cvRepo) SetTemplate(context.Context, uuid.UUID, int64, string) (int64, error) { return 1, nil }
 func (r *cvRepo) ListTailored(context.Context, int64) ([]db.ListTailoredCVsByUserRow, error) {
 	return nil, nil
 }
 
+// testCVID is the CV every case in this file addresses. Fixed so a failure names a
+// stable value rather than a fresh random one.
+var testCVID = uuid.MustParse("55555555-5555-4555-8555-555555555555")
+
 // cvToolsAPI wires an API whose CV store serves one document owned by user 3.
 func cvToolsAPI(t *testing.T, doc string) (*assistantHandlers, *cvRepo) {
 	t.Helper()
-	repo := &cvRepo{id: 5, userID: 3, jobID: 9, data: []byte(doc)}
+	repo := &cvRepo{id: testCVID, userID: 3, jobID: 9, data: []byte(doc)}
 	return &assistantHandlers{cv: &cvHandlers{cvStore: cv.NewStore(repo)}}, repo
 }
 
@@ -68,7 +73,7 @@ const oneExperienceCV = `{"header":{"full_name":"Ada Lovelace","email":"ada@exam
 func TestCVGetToolReadsTheBoundDocument(t *testing.T) {
 	a, _ := cvToolsAPI(t, oneExperienceCV)
 
-	tool := toolByName(t, a.assistantCVTools(5, 9), "cv_get")
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_get")
 	out, err := tool.Run(context.Background(), 3, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("cv_get: %v", err)
@@ -82,7 +87,7 @@ func TestCVGetToolReadsTheBoundDocument(t *testing.T) {
 func TestCVEditToolAppliesAPatch(t *testing.T) {
 	a, repo := cvToolsAPI(t, oneExperienceCV)
 
-	tool := toolByName(t, a.assistantCVTools(5, 9), "cv_edit")
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_edit")
 	_, err := tool.Run(context.Background(), 3, json.RawMessage(
 		`{"patch":{"op":"set_summary","value":"Senior backend engineer"}}`))
 	if err != nil {
@@ -96,7 +101,7 @@ func TestCVEditToolAppliesAPatch(t *testing.T) {
 func TestCVEditToolRefusesToRewriteContactDetails(t *testing.T) {
 	a, _ := cvToolsAPI(t, oneExperienceCV)
 
-	tool := toolByName(t, a.assistantCVTools(5, 9), "cv_edit")
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_edit")
 	_, err := tool.Run(context.Background(), 3, json.RawMessage(
 		`{"patch":{"op":"set_header_field","field":"email","value":"someone@else.test"}}`))
 	if err == nil {
@@ -110,7 +115,7 @@ func TestCVEditToolRefusesToRewriteContactDetails(t *testing.T) {
 func TestCVEditToolRejectsAMisaddressedPatch(t *testing.T) {
 	a, _ := cvToolsAPI(t, oneExperienceCV)
 
-	tool := toolByName(t, a.assistantCVTools(5, 9), "cv_edit")
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_edit")
 	_, err := tool.Run(context.Background(), 3, json.RawMessage(
 		`{"patch":{"op":"add_bullet","experience":42,"value":"Did a thing"}}`))
 	if err == nil {
@@ -123,7 +128,7 @@ func TestCVToolsAreBoundToTheSessionsCV(t *testing.T) {
 	// argument, so the model cannot address another CV even by guessing an id.
 	a, _ := cvToolsAPI(t, oneExperienceCV)
 
-	for _, tool := range a.assistantCVTools(5, 9) {
+	for _, tool := range a.assistantCVTools(testCVID, 9) {
 		props, _ := tool.Schema["properties"].(map[string]any)
 		if _, ok := props["cv_id"]; ok {
 			t.Errorf("tool %q takes a cv_id argument; the session binding must be the only addressing", tool.Name)
@@ -134,7 +139,7 @@ func TestCVToolsAreBoundToTheSessionsCV(t *testing.T) {
 func TestCVEditToolOnAForeignCVFails(t *testing.T) {
 	a, _ := cvToolsAPI(t, oneExperienceCV)
 
-	tool := toolByName(t, a.assistantCVTools(5, 9), "cv_edit")
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_edit")
 	// user 99 does not own CV 5: the store's owner check must refuse it.
 	_, err := tool.Run(context.Background(), 99, json.RawMessage(
 		`{"patch":{"op":"set_summary","value":"Hijacked"}}`))

--- a/internal/handler/assistant_preset_test.go
+++ b/internal/handler/assistant_preset_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/strelov1/freehire/internal/assistant"
 )
 
@@ -39,7 +41,7 @@ func TestChatPresetHasNoCVTools(t *testing.T) {
 }
 
 func TestTailorPresetAddsTheCVTools(t *testing.T) {
-	cvID, jobID := int64(5), int64(9)
+	cvID, jobID := uuid.MustParse("66666666-6666-4666-8666-666666666666"), int64(9)
 	reg := presetAPI().registry(assistant.Session{
 		UserID: 3, Preset: assistant.PresetTailor, CVID: &cvID, JobID: &jobID,
 	})
@@ -67,7 +69,7 @@ func TestNoModeratorToolIsEverRegistered(t *testing.T) {
 	// Job authoring and submission review are moderator surfaces; the agent must
 	// not reach them whatever the session or the caller's role.
 	forbidden := []string{"create_job", "edit_job", "submit_job", "submissions", "approve_submission", "reject_submission"}
-	cvID, jobID := int64(5), int64(9)
+	cvID, jobID := uuid.MustParse("66666666-6666-4666-8666-666666666666"), int64(9)
 
 	for _, sess := range []assistant.Session{
 		{UserID: 3, Preset: assistant.PresetChat},

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 
 	"github.com/strelov1/freehire/internal/assistant"
 	"github.com/strelov1/freehire/internal/auth"
@@ -92,7 +93,7 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 const maxCVTitleRunes = 200
 
 type cvMetaResponse struct {
-	ID         int64     `json:"id"`
+	ID         string    `json:"id"`
 	Title      string    `json:"title"`
 	TemplateID string    `json:"template_id"`
 	CreatedAt  time.Time `json:"created_at"`
@@ -132,7 +133,7 @@ type updateCVRequest struct {
 }
 
 func metaResponse(m cv.Meta) cvMetaResponse {
-	return cvMetaResponse{ID: m.ID, Title: m.Title, TemplateID: m.TemplateID, CreatedAt: m.CreatedAt, UpdatedAt: m.UpdatedAt}
+	return cvMetaResponse{ID: m.ID.String(), Title: m.Title, TemplateID: m.TemplateID, CreatedAt: m.CreatedAt, UpdatedAt: m.UpdatedAt}
 }
 
 func recordResponse(rec cv.Record) cvResponse {
@@ -212,11 +213,11 @@ func (h *cvHandlers) GetCV(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
-	rec, err := h.cvStore.Get(c.Context(), int64(id), userID)
+	rec, err := h.cvStore.Get(c.Context(), id, userID)
 	if err != nil {
 		return mapCVError(err)
 	}
@@ -238,9 +239,9 @@ func (h *cvHandlers) UpdateCV(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
 	var in updateCVRequest
 	if err := c.BodyParser(&in); err != nil {
@@ -250,7 +251,7 @@ func (h *cvHandlers) UpdateCV(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	meta, err := h.cvStore.Update(c.Context(), int64(id), userID, cvTitle(in.Title), tmplID, in.Document)
+	meta, err := h.cvStore.Update(c.Context(), id, userID, cvTitle(in.Title), tmplID, in.Document)
 	if err != nil {
 		return mapCVError(err)
 	}
@@ -263,11 +264,11 @@ func (h *cvHandlers) DeleteCV(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
-	if err := h.cvStore.Delete(c.Context(), int64(id), userID); err != nil {
+	if err := h.cvStore.Delete(c.Context(), id, userID); err != nil {
 		return mapCVError(err)
 	}
 	return c.SendStatus(fiber.StatusNoContent)
@@ -284,15 +285,15 @@ func (h *cvHandlers) SetCVSession(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
 	var in setCVSessionRequest
 	if err := c.BodyParser(&in); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
-	if err := h.cvStore.SetSession(c.Context(), int64(id), userID, in.SessionID); err != nil {
+	if err := h.cvStore.SetSession(c.Context(), id, userID, in.SessionID); err != nil {
 		return mapCVError(err)
 	}
 	return c.SendStatus(fiber.StatusNoContent)
@@ -310,9 +311,9 @@ func (h *cvHandlers) SetCVTemplate(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
 	var in setCVTemplateRequest
 	if err := c.BodyParser(&in); err != nil {
@@ -322,7 +323,7 @@ func (h *cvHandlers) SetCVTemplate(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	if err := h.cvStore.SetTemplate(c.Context(), int64(id), userID, tmplID); err != nil {
+	if err := h.cvStore.SetTemplate(c.Context(), id, userID, tmplID); err != nil {
 		return mapCVError(err)
 	}
 	return c.SendStatus(fiber.StatusNoContent)
@@ -338,11 +339,11 @@ func (h *cvHandlers) RenderCVPDF(c *fiber.Ctx) error {
 	if h.cvRenderer == nil {
 		return fiber.NewError(fiber.StatusNotImplemented, "PDF rendering is not available")
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
-	rec, err := h.cvStore.Get(c.Context(), int64(id), userID)
+	rec, err := h.cvStore.Get(c.Context(), id, userID)
 	if err != nil {
 		return mapCVError(err)
 	}
@@ -397,4 +398,16 @@ func mapCVError(err error) error {
 	default:
 		return err
 	}
+}
+
+// cvPathID parses the :id route param as a CV's UUID. A malformed id cannot name
+// any CV, so it is reported as missing rather than as a bad request — keeping
+// "not a CV" and "not yours" the same answer, which is what stops the id from
+// being probeable.
+func cvPathID(c *fiber.Ctx) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return uuid.Nil, fiber.NewError(fiber.StatusNotFound, "cv not found")
+	}
+	return id, nil
 }

--- a/internal/handler/cv_integration_test.go
+++ b/internal/handler/cv_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
-	"strconv"
 	"testing"
 	"time"
 
@@ -136,17 +135,17 @@ func TestSetCVTemplateEndpoint(t *testing.T) {
 	}
 	var created struct {
 		Data struct {
-			ID int64 `json:"id"`
+			ID string `json:"id"`
 		} `json:"data"`
 	}
 	json.NewDecoder(resp.Body).Decode(&created)
-	path := "/api/v1/me/cvs/" + strconv.FormatInt(created.Data.ID, 10) + "/template"
+	path := "/api/v1/me/cvs/" + created.Data.ID + "/template"
 
 	// Valid registered template → 204, and it sticks on read.
 	if resp := doCV(t, app, fiber.MethodPut, path, ownerTok, map[string]string{"template_id": "modern-sans"}); resp.StatusCode != fiber.StatusNoContent {
 		t.Fatalf("set valid template = %d, want 204", resp.StatusCode)
 	}
-	resp = doCV(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+strconv.FormatInt(created.Data.ID, 10), ownerTok, nil)
+	resp = doCV(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+created.Data.ID, ownerTok, nil)
 	var got struct {
 		Data struct {
 			TemplateID string `json:"template_id"`
@@ -207,13 +206,13 @@ func TestCVEndpoints_CRUDAndIsolation(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&created)
 	resp.Body.Close()
 	id := created.Data.ID
-	if created.Data.Title != "General" || id == 0 {
+	if created.Data.Title != "General" || id == "" {
 		t.Fatalf("create returned %+v", created.Data)
 	}
 
 	// Update with a real document.
 	doc := cv.Document{Header: cv.Header{FullName: "Ada Lovelace"}, Skills: []cv.SkillGroup{{Group: "Lang", Items: []string{"Go"}}}}
-	upPath := "/api/v1/me/cvs/" + strconv.FormatInt(id, 10)
+	upPath := "/api/v1/me/cvs/" + id
 	if resp := doCV(t, app, fiber.MethodPut, upPath, betaTok, updateCVRequest{Title: "Tailored", Document: doc}); resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("update = %d, want 200", resp.StatusCode)
 	}

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/strelov1/freehire/internal/assistant"
@@ -26,8 +26,8 @@ type tailorCVRequest struct {
 // base it was copied from, the cached analysis (so the client need not refetch), and the
 // short-lived CLI token the agent session authenticates with.
 type tailorCVResponse struct {
-	TailorCVID int64                   `json:"tailor_cv_id"`
-	BaseCVID   int64                   `json:"base_cv_id"`
+	TailorCVID string                  `json:"tailor_cv_id"`
+	BaseCVID   string                  `json:"base_cv_id"`
 	Analysis   *matchanalysis.Analysis `json:"analysis"`
 	SessionID  string                  `json:"session_id"`
 }
@@ -83,11 +83,11 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	// charge again). Idempotent by the new CV id; resuming an existing CV (a different
 	// endpoint) never debits. The session already exists, so a debit error — including a
 	// rare insufficient-balance race the pre-check let through — is logged, not surfaced.
-	if _, err := h.credits.Debit(c.Context(), userID, credits.FeatureTailor, strconv.FormatInt(tailored.ID, 10)); err != nil {
+	if _, err := h.credits.Debit(c.Context(), userID, credits.FeatureTailor, tailored.ID.String()); err != nil {
 		log.Printf("credits: tailor debit user=%d cv=%d: %v", userID, tailored.ID, err)
 	}
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": tailorCVResponse{
-		TailorCVID: tailored.ID, BaseCVID: base.ID, Analysis: analysis, SessionID: sessionID,
+		TailorCVID: tailored.ID.String(), BaseCVID: base.ID.String(), Analysis: analysis, SessionID: sessionID,
 	}})
 }
 
@@ -95,8 +95,8 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 // created before session binding, or whose session was lost): the CV + base ids and a freshly
 // minted CLI token, so the browser can seed a new agent session bound to the same CV.
 type tailorSessionResponse struct {
-	TailorCVID int64  `json:"tailor_cv_id"`
-	BaseCVID   int64  `json:"base_cv_id"`
+	TailorCVID string `json:"tailor_cv_id"`
+	BaseCVID   string `json:"base_cv_id"`
 	SessionID  string `json:"session_id"`
 }
 
@@ -108,11 +108,11 @@ func (h *cvHandlers) StartTailorSession(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
-	rec, err := h.cvStore.Get(c.Context(), int64(id), userID)
+	rec, err := h.cvStore.Get(c.Context(), id, userID)
 	if err != nil {
 		return mapCVError(err)
 	}
@@ -131,7 +131,7 @@ func (h *cvHandlers) StartTailorSession(c *fiber.Ctx) error {
 		return err
 	}
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": tailorSessionResponse{
-		TailorCVID: rec.ID, BaseCVID: base.ID, SessionID: sessionID,
+		TailorCVID: rec.ID.String(), BaseCVID: base.ID.String(), SessionID: sessionID,
 	}})
 }
 
@@ -141,7 +141,7 @@ func (h *cvHandlers) StartTailorSession(c *fiber.Ctx) error {
 // binding is what confines the CV tools — they close over these ids rather than
 // taking them from the model — so it is created here, where ownership of both is
 // already established.
-func (h *cvHandlers) startTailoringSession(ctx context.Context, userID, cvID, jobID int64) (string, error) {
+func (h *cvHandlers) startTailoringSession(ctx context.Context, userID int64, cvID uuid.UUID, jobID int64) (string, error) {
 	if h.assistantSessions == nil {
 		return "", fiber.NewError(fiber.StatusServiceUnavailable, "the assistant is not available")
 	}
@@ -163,9 +163,9 @@ func (h *cvHandlers) PatchCV(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
 	// Decode strictly: reject unknown fields and type mismatches so a mis-addressed
 	// op (a stray "skill" field, a numeric "group") fails with a reason the agent can
@@ -179,7 +179,7 @@ func (h *cvHandlers) PatchCV(c *fiber.Ctx) error {
 	if auth.ViaAPIKey(c) && p.Op == cv.PatchSetHeaderField && isContactHeaderField(p.Field) {
 		return fiber.NewError(fiber.StatusForbidden, "contact fields are not editable in a tailoring session")
 	}
-	meta, err := h.cvStore.Patch(c.Context(), int64(id), userID, p)
+	meta, err := h.cvStore.Patch(c.Context(), id, userID, p)
 	if err != nil {
 		return mapCVError(err)
 	}
@@ -229,11 +229,11 @@ func (h *cvHandlers) TailorContext(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := cvPathID(c)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+		return err
 	}
-	rec, err := h.cvStore.Get(c.Context(), int64(id), userID)
+	rec, err := h.cvStore.Get(c.Context(), id, userID)
 	if err != nil {
 		return mapCVError(err)
 	}

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 
@@ -168,8 +167,8 @@ func TestTailorCVBootstrap(t *testing.T) {
 	}
 	json.NewDecoder(resp.Body).Decode(&got)
 	resp.Body.Close()
-	if got.Data.TailorCVID == 0 || got.Data.BaseCVID == 0 || got.Data.TailorCVID == got.Data.BaseCVID {
-		t.Errorf("ids = %+v, want distinct non-zero", got.Data)
+	if got.Data.TailorCVID == "" || got.Data.BaseCVID == "" || got.Data.TailorCVID == got.Data.BaseCVID {
+		t.Errorf("ids = %+v, want two distinct ids", got.Data)
 	}
 	// The bootstrap mints the tailoring conversation itself: a tailor-preset session
 	// bound to this CV and vacancy, already stored on the CV so reopening the
@@ -177,8 +176,8 @@ func TestTailorCVBootstrap(t *testing.T) {
 	if got.Data.SessionID == "" {
 		t.Fatalf("bootstrap returned no session id")
 	}
-	var boundPreset, boundSession string
-	var boundCV, boundJob int64
+	var boundPreset, boundSession, boundCV string
+	var boundJob int64
 	if err := pool.QueryRow(context.Background(),
 		`SELECT s.preset, s.cv_id, s.job_id, c.agent_session_id
 		   FROM assistant_sessions s JOIN cvs c ON c.id = s.cv_id
@@ -186,7 +185,7 @@ func TestTailorCVBootstrap(t *testing.T) {
 		t.Fatalf("read the minted session: %v", err)
 	}
 	if boundPreset != assistant.PresetTailor || boundCV != got.Data.TailorCVID || boundJob != jobID {
-		t.Errorf("session = preset %q cv %d job %d, want a tailor session bound to cv %d / job %d",
+		t.Errorf("session = preset %q cv %s job %d, want a tailor session bound to cv %s / job %d",
 			boundPreset, boundCV, boundJob, got.Data.TailorCVID, jobID)
 	}
 	if boundSession != got.Data.SessionID {
@@ -256,7 +255,7 @@ func TestPatchCVViaKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create cv: %v", err)
 	}
-	path := "/api/v1/me/cvs/" + strconv.FormatInt(base.ID, 10)
+	path := "/api/v1/me/cvs/" + base.ID.String()
 
 	// The agent (API key) must never see the contact block; the owner's cookie read does.
 	decodeHeader := func(resp *http.Response) cv.Header {
@@ -331,7 +330,7 @@ func TestTailorContextSplit(t *testing.T) {
 	}
 	key := cvScopedKey(t, h, user)
 
-	resp := doBearer(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+strconv.FormatInt(tailored.ID, 10)+"/tailor-context", key, nil)
+	resp := doBearer(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+tailored.ID.String()+"/tailor-context", key, nil)
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("context = %d, want 200", resp.StatusCode)
 	}
@@ -356,7 +355,7 @@ func TestTailorContextSplit(t *testing.T) {
 
 	// A base CV (no bound vacancy) is not tailorable-context → 409.
 	base, _ := h.cvStore.Create(ctx, user, "Base", cv.DefaultTemplateID, cv.Document{})
-	if resp := doBearer(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+strconv.FormatInt(base.ID, 10)+"/tailor-context", key, nil); resp.StatusCode != fiber.StatusConflict {
+	if resp := doBearer(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+base.ID.String()+"/tailor-context", key, nil); resp.StatusCode != fiber.StatusConflict {
 		t.Fatalf("base-cv context = %d, want 409", resp.StatusCode)
 	}
 }

--- a/internal/handler/me_credits_history.go
+++ b/internal/handler/me_credits_history.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 )
@@ -90,20 +92,31 @@ func (h *creditsHandlers) GetMyCreditsHistory(c *fiber.Ctx) error {
 // CV id that happen to share a numeric value never collide. A ref whose subject was deleted is
 // simply absent, so the caller falls back to a generic label.
 func (h *creditsHandlers) resolveDebitSubjects(c *fiber.Ctx, rows []db.ListCreditLedgerRow) (map[string]string, error) {
-	var jobRefs, cvRefs []int64
+	// The two features reference different kinds of subject: a match debit carries a
+	// job's numeric id, a tailor debit carries a CV's UUID. Parsing both as integers
+	// silently dropped every tailor ref once CV ids stopped being numbers — the label
+	// just went missing, with nothing to notice.
+	var jobRefs []int64
+	// The generated query takes the array as pgtype.UUID; the column override only
+	// covers the column itself.
+	var cvRefs []pgtype.UUID
 	for _, r := range rows {
 		if r.Kind != "debit" || !r.Ref.Valid {
 			continue
 		}
-		id, err := strconv.ParseInt(r.Ref.String, 10, 64)
-		if err != nil {
-			continue // a non-numeric ref never resolves; the generic label stands
-		}
 		switch r.Feature.String {
 		case "match":
+			id, err := strconv.ParseInt(r.Ref.String, 10, 64)
+			if err != nil {
+				continue // a ref that is not a job id never resolves; the generic label stands
+			}
 			jobRefs = append(jobRefs, id)
 		case "tailor":
-			cvRefs = append(cvRefs, id)
+			id, err := uuid.Parse(r.Ref.String)
+			if err != nil {
+				continue // pre-migration refs are numeric and no longer resolve
+			}
+			cvRefs = append(cvRefs, pgtype.UUID{Bytes: id, Valid: true})
 		}
 	}
 

--- a/internal/handler/me_credits_history.go
+++ b/internal/handler/me_credits_history.go
@@ -123,7 +123,7 @@ func (h *creditsHandlers) resolveDebitSubjects(c *fiber.Ctx, rows []db.ListCredi
 			return nil, err
 		}
 		for _, cv := range cvs {
-			subjects[subjectKey("tailor", strconv.FormatInt(cv.ID, 10))] = jobLabel(cv.JobTitle, cv.JobSlug)
+			subjects[subjectKey("tailor", cv.ID.String())] = jobLabel(cv.JobTitle, cv.JobSlug)
 		}
 	}
 	return subjects, nil

--- a/internal/handler/me_credits_history_integration_test.go
+++ b/internal/handler/me_credits_history_integration_test.go
@@ -9,6 +9,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"github.com/google/uuid"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -43,7 +44,7 @@ func TestGetMyCreditsHistoryEndpoint(t *testing.T) {
 		 VALUES ('test','job:1','http://e.test','Senior Go Engineer','Acme','senior-go-engineer','h') RETURNING id`).Scan(&jobID); err != nil {
 		t.Fatalf("seed job: %v", err)
 	}
-	var cvID int64
+	var cvID uuid.UUID
 	if err := pool.QueryRow(ctx,
 		`INSERT INTO cvs (user_id, title, template_id, data, job_id)
 		 VALUES ($1, 'Tailored', 'default', '{}'::jsonb, $2) RETURNING id`, userID, jobID).Scan(&cvID); err != nil {
@@ -70,7 +71,7 @@ func TestGetMyCreditsHistoryEndpoint(t *testing.T) {
 	seed(userID, "grant", "", "", 20, 50)                                // oldest
 	seed(userID, "reward", "", "1", 5, 40)                               // contribution reward
 	seed(userID, "debit", "match", strconv.FormatInt(jobID, 10), -1, 30) // match → job title
-	seed(userID, "debit", "tailor", strconv.FormatInt(cvID, 10), -3, 20) // tailor → job title
+	seed(userID, "debit", "tailor", cvID.String(), -3, 20)               // tailor → job title
 	seed(userID, "debit", "match", "9999999", -1, 10)                    // deleted job → fallback (newest)
 	seed(otherID, "grant", "", "", 20, 5)                                // another user's row — must not leak
 

--- a/internal/handler/referrals.go
+++ b/internal/handler/referrals.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 
 	"github.com/strelov1/freehire/internal/blobstore"
 	"github.com/strelov1/freehire/internal/cv"
@@ -75,15 +76,28 @@ type seekerRequestResponse struct {
 	CompanyName string     `json:"company_name"`
 	JobID       *int64     `json:"job_id"`
 	CVKind      string     `json:"cv_kind"`
-	CVID        *int64     `json:"cv_id"`
+	CVID        *string    `json:"cv_id"`
 	Status      string     `json:"status"`
 	CreatedAt   *time.Time `json:"created_at"`
+}
+
+// optionalCVID parses an optional CV id from a request body. Absent stays absent;
+// present-but-malformed is a client error, not a lookup that quietly finds nothing.
+func optionalCVID(raw *string) (*uuid.UUID, error) {
+	if raw == nil || *raw == "" {
+		return nil, nil
+	}
+	id, err := uuid.Parse(*raw)
+	if err != nil {
+		return nil, fiber.NewError(fiber.StatusUnprocessableEntity, "cv_id is not a valid id")
+	}
+	return &id, nil
 }
 
 func toSeekerRequestResponse(r referral.Request) seekerRequestResponse {
 	return seekerRequestResponse{
 		ID: r.ID, CompanySlug: r.CompanySlug, CompanyName: r.CompanyName, JobID: r.JobID,
-		CVKind: r.CVKind, CVID: r.CVID, Status: r.Status, CreatedAt: r.CreatedAt,
+		CVKind: r.CVKind, CVID: cvIDString(r.CVID), Status: r.Status, CreatedAt: r.CreatedAt,
 	}
 }
 
@@ -152,14 +166,14 @@ func referralError(err error) error {
 // createReferralRequestBody is the seeker's submit payload. Exactly one of the CV fields is
 // meaningful per cv_kind (validated in the domain); the contact is Telegram and/or email.
 type createReferralRequestBody struct {
-	CompanySlug     string `json:"company_slug"`
-	JobID           *int64 `json:"job_id"`
-	CVKind          string `json:"cv_kind"`
-	CVID            *int64 `json:"cv_id"`
-	LinkedInURL     string `json:"linkedin_url"`
-	ContactTelegram string `json:"contact_telegram"`
-	ContactEmail    string `json:"contact_email"`
-	Note            string `json:"note"`
+	CompanySlug     string  `json:"company_slug"`
+	JobID           *int64  `json:"job_id"`
+	CVKind          string  `json:"cv_kind"`
+	CVID            *string `json:"cv_id"`
+	LinkedInURL     string  `json:"linkedin_url"`
+	ContactTelegram string  `json:"contact_telegram"`
+	ContactEmail    string  `json:"contact_email"`
+	Note            string  `json:"note"`
 }
 
 // CreateReferralRequest records a seeker's request into a company's referrer pool and pings
@@ -173,12 +187,18 @@ func (h *referralHandlers) CreateReferralRequest(c *fiber.Ctx) error {
 	if err := c.BodyParser(&in); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
+	// The attached CV is addressed by its opaque id; a malformed one names no CV,
+	// which the service reports as an unusable attachment rather than a 500.
+	cvID, err := optionalCVID(in.CVID)
+	if err != nil {
+		return err
+	}
 	req, err := h.referral.CreateRequest(c.Context(), referral.RequestInput{
 		SeekerUserID:    userID,
 		CompanySlug:     in.CompanySlug,
 		JobID:           in.JobID,
 		CVKind:          in.CVKind,
-		CVID:            in.CVID,
+		CVID:            cvID,
 		LinkedInURL:     in.LinkedInURL,
 		ContactTelegram: in.ContactTelegram,
 		ContactEmail:    in.ContactEmail,
@@ -435,7 +455,7 @@ func (h *referralHandlers) streamBlobPDF(c *fiber.Ctx, key string) error {
 
 // renderOwnerCV renders a builder CV owned by ownerID to PDF. cvStore.Get is owner-scoped,
 // so it is loaded as the seeker (the owner), not the viewing referrer. 501 when no renderer.
-func (h *referralHandlers) renderOwnerCV(c *fiber.Ctx, cvID, ownerID int64) error {
+func (h *referralHandlers) renderOwnerCV(c *fiber.Ctx, cvID uuid.UUID, ownerID int64) error {
 	if h.cvRenderer == nil {
 		return fiber.NewError(fiber.StatusNotImplemented, "PDF rendering is not available")
 	}

--- a/internal/referral/referral.go
+++ b/internal/referral/referral.go
@@ -10,6 +10,7 @@ package referral
 import (
 	"context"
 	"errors"
+	"github.com/google/uuid"
 	"log"
 	"net/url"
 	"strings"
@@ -118,7 +119,7 @@ type Request struct {
 	CompanyName string
 	JobID       *int64
 	CVKind      string
-	CVID        *int64
+	CVID        *uuid.UUID
 	// LinkedInURL is the seeker's own profile, shown to the referrer in the inbox alongside
 	// the contact channels. Required and shape-validated at submission.
 	LinkedInURL     string
@@ -154,7 +155,7 @@ type RequestInput struct {
 	CompanySlug     string
 	JobID           *int64
 	CVKind          string
-	CVID            *int64
+	CVID            *uuid.UUID
 	LinkedInURL     string
 	ContactTelegram string
 	ContactEmail    string
@@ -175,7 +176,7 @@ type Repository interface {
 	CompanyHasApprovedReferrer(ctx context.Context, companySlug string) (bool, error)
 	ReferrerApprovedForCompany(ctx context.Context, userID int64, companySlug string) (bool, error)
 	ApprovedReferrerRecipients(ctx context.Context, companySlug string) ([]Recipient, error)
-	CVBelongsToUser(ctx context.Context, cvID, userID int64) (bool, error)
+	CVBelongsToUser(ctx context.Context, cvID uuid.UUID, userID int64) (bool, error)
 	UserHasResume(ctx context.Context, userID int64) (bool, error)
 
 	CreateRequest(ctx context.Context, in RequestInput) (Request, error)

--- a/internal/referral/referral_test.go
+++ b/internal/referral/referral_test.go
@@ -3,6 +3,7 @@ package referral
 import (
 	"context"
 	"errors"
+	"github.com/google/uuid"
 	"testing"
 	"time"
 )
@@ -72,7 +73,11 @@ func (f *fakeRepo) ReferrerApprovedForCompany(context.Context, int64, string) (b
 func (f *fakeRepo) ApprovedReferrerRecipients(context.Context, string) ([]Recipient, error) {
 	return f.recipients, nil
 }
-func (f *fakeRepo) CVBelongsToUser(context.Context, int64, int64) (bool, error) {
+
+// testCVID is the attached CV these cases address.
+var testCVID = uuid.MustParse("77777777-7777-4777-8777-777777777777")
+
+func (f *fakeRepo) CVBelongsToUser(context.Context, uuid.UUID, int64) (bool, error) {
 	return f.cvOwned, nil
 }
 func (f *fakeRepo) UserHasResume(context.Context, int64) (bool, error) {
@@ -128,7 +133,7 @@ func newService(repo *fakeRepo, pinger *fakePinger) *Service {
 	return New(repo, pinger, Config{DailyRequestCap: 3, CabinetURL: "https://freehire.me/my/referrals"})
 }
 
-func cvID(n int64) *int64 { return &n }
+func cvID(n uuid.UUID) *uuid.UUID { return &n }
 
 // linkedInURL is a valid profile URL for fixtures that must clear the required-LinkedIn gate.
 const linkedInURL = "https://www.linkedin.com/in/jane-doe"
@@ -232,7 +237,7 @@ func TestCreateRequestValidation(t *testing.T) {
 		want error
 	}{
 		{"no contact", RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVOriginal}, ErrNoContact},
-		{"original with cv id", withCV(base, CVOriginal, cvID(4)), ErrInvalidCVChoice},
+		{"original with cv id", withCV(base, CVOriginal, cvID(testCVID)), ErrInvalidCVChoice},
 		{"built without cv id", withCV(base, CVBuilt, nil), ErrInvalidCVChoice},
 		{"unknown kind", withCV(base, "weird", nil), ErrInvalidCVChoice},
 	}
@@ -298,7 +303,7 @@ func TestCreateRequestEligibilityAndCap(t *testing.T) {
 }
 
 func TestCreateRequestBuiltCVOwnership(t *testing.T) {
-	built := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVBuilt, CVID: cvID(42), ContactEmail: "s@x.test", LinkedInURL: linkedInURL}
+	built := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVBuilt, CVID: cvID(testCVID), ContactEmail: "s@x.test", LinkedInURL: linkedInURL}
 
 	t.Run("foreign cv is rejected as an invalid choice", func(t *testing.T) {
 		repo := &fakeRepo{eligible: true, cvOwned: false}
@@ -387,7 +392,7 @@ func TestAuthorizeCVAccess(t *testing.T) {
 }
 
 // withCV returns a copy of in with the CV choice replaced.
-func withCV(in RequestInput, kind string, id *int64) RequestInput {
+func withCV(in RequestInput, kind string, id *uuid.UUID) RequestInput {
 	in.CVKind = kind
 	in.CVID = id
 	return in

--- a/internal/referral/repository.go
+++ b/internal/referral/repository.go
@@ -3,6 +3,7 @@ package referral
 import (
 	"context"
 	"errors"
+	"github.com/google/uuid"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -150,7 +151,7 @@ func (r *QueriesRepository) ApprovedReferrerRecipients(ctx context.Context, comp
 }
 
 // CVBelongsToUser reports whether the builder CV is owned by the user.
-func (r *QueriesRepository) CVBelongsToUser(ctx context.Context, cvID, userID int64) (bool, error) {
+func (r *QueriesRepository) CVBelongsToUser(ctx context.Context, cvID uuid.UUID, userID int64) (bool, error) {
 	return r.q.CVBelongsToUser(ctx, db.CVBelongsToUserParams{CvID: cvID, UserID: userID})
 }
 
@@ -167,7 +168,7 @@ func (r *QueriesRepository) CreateRequest(ctx context.Context, in RequestInput) 
 		CompanySlug:     in.CompanySlug,
 		JobID:           int8Ptr(in.JobID),
 		CvKind:          in.CVKind,
-		CvID:            int8Ptr(in.CVID),
+		CvID:            in.CVID,
 		LinkedinUrl:     in.LinkedInURL,
 		ContactTelegram: textOrNull(in.ContactTelegram),
 		ContactEmail:    textOrNull(in.ContactEmail),
@@ -274,7 +275,7 @@ func requestFromRow(row db.ReferralRequest) Request {
 		CompanySlug:     row.CompanySlug,
 		JobID:           int64PtrFrom(row.JobID),
 		CVKind:          row.CvKind,
-		CVID:            int64PtrFrom(row.CvID),
+		CVID:            row.CvID,
 		LinkedInURL:     row.LinkedinUrl,
 		ContactTelegram: row.ContactTelegram.String,
 		ContactEmail:    row.ContactEmail.String,

--- a/migrations/0045_cvs_uuid_id.sql
+++ b/migrations/0045_cvs_uuid_id.sql
@@ -1,0 +1,65 @@
+-- CV ids become random UUIDs (see the opaque-cv-ids change).
+--
+-- A CV was addressed by a bigint identity — in /my/cvs/<id>, in nine API paths,
+-- and in two published clients. Ownership already confined every read (a foreign
+-- id answers 404 exactly as a missing one does), so the number was not a
+-- capability. It still published how many CVs the platform holds, and it meant a
+-- single missing owner check on any future endpoint would be walkable — over
+-- résumés, the most sensitive data here. A random id does not replace the
+-- ownership check; it makes forgetting one survivable.
+--
+-- The swap is a primary-key change with two foreign keys hanging off it:
+-- referral_requests.cv_id (the CV attached to a referral, ON DELETE SET NULL) and
+-- assistant_sessions.cv_id (the CV a tailoring conversation is bound to, ON
+-- DELETE CASCADE). Both are converted here, in the same transaction, by mapping
+-- through the OLD key before it is dropped — so a failure anywhere leaves the
+-- schema exactly as it was.
+--
+-- The old numeric ids are NOT retained. Nothing outside the database stores one
+-- except the CLI and the MCP server, which are released alongside this change and
+-- refuse a number afterwards.
+--
+-- Applied to a fresh volume by initdb after 0044; on an existing prod volume run
+-- this file manually (SET ROLE hire) BEFORE deploying code that reads it.
+
+BEGIN;
+
+-- 1. The new key, generated for every existing row.
+ALTER TABLE public.cvs ADD COLUMN new_id uuid DEFAULT gen_random_uuid() NOT NULL;
+
+-- 2. Carry each reference across while the old key still exists to map through.
+ALTER TABLE public.referral_requests ADD COLUMN new_cv_id uuid;
+UPDATE public.referral_requests r SET new_cv_id = c.new_id FROM public.cvs c WHERE c.id = r.cv_id;
+
+ALTER TABLE public.assistant_sessions ADD COLUMN new_cv_id uuid;
+UPDATE public.assistant_sessions s SET new_cv_id = c.new_id FROM public.cvs c WHERE c.id = s.cv_id;
+
+-- 3. Retire the old references.
+ALTER TABLE public.referral_requests DROP CONSTRAINT referral_requests_cv_id_fkey;
+ALTER TABLE public.referral_requests DROP COLUMN cv_id;
+ALTER TABLE public.referral_requests RENAME COLUMN new_cv_id TO cv_id;
+
+ALTER TABLE public.assistant_sessions DROP CONSTRAINT assistant_sessions_cv_id_fkey;
+ALTER TABLE public.assistant_sessions DROP COLUMN cv_id;
+ALTER TABLE public.assistant_sessions RENAME COLUMN new_cv_id TO cv_id;
+
+-- 4. Swap the primary key itself. Dropping the column takes its identity sequence
+--    with it, which is the point: there is no counter left to read.
+ALTER TABLE public.cvs DROP CONSTRAINT cvs_pkey;
+ALTER TABLE public.cvs DROP COLUMN id;
+ALTER TABLE public.cvs RENAME COLUMN new_id TO id;
+ALTER TABLE public.cvs ADD CONSTRAINT cvs_pkey PRIMARY KEY (id);
+
+-- 5. Re-establish the references against the new key, with the same delete rules.
+ALTER TABLE public.referral_requests
+    ADD CONSTRAINT referral_requests_cv_id_fkey FOREIGN KEY (cv_id) REFERENCES public.cvs(id) ON DELETE SET NULL;
+
+ALTER TABLE public.assistant_sessions
+    ADD CONSTRAINT assistant_sessions_cv_id_fkey FOREIGN KEY (cv_id) REFERENCES public.cvs(id) ON DELETE CASCADE;
+
+-- A referencing column needs its own index: Postgres indexes only the referenced
+-- side, so without these, deleting a CV scans both tables.
+CREATE INDEX IF NOT EXISTS referral_requests_cv_id_idx ON public.referral_requests (cv_id);
+CREATE INDEX IF NOT EXISTS assistant_sessions_cv_id_idx ON public.assistant_sessions (cv_id);
+
+COMMIT;

--- a/migrations/0045_cvs_uuid_id.sql
+++ b/migrations/0045_cvs_uuid_id.sql
@@ -50,14 +50,26 @@ ALTER TABLE public.cvs DROP COLUMN id;
 ALTER TABLE public.cvs RENAME COLUMN new_id TO id;
 ALTER TABLE public.cvs ADD CONSTRAINT cvs_pkey PRIMARY KEY (id);
 
--- 5. Re-establish the references against the new key, with the same delete rules.
+-- 5. Re-establish what the dropped column took with it. DROP COLUMN silently drops
+--    every CHECK that mentions the column, so referral_requests' cv_kind rule —
+--    "an original CV never carries a cv_id" — vanished with the old cv_id. The
+--    foreign keys were dropped explicitly above; this one goes quietly, which is
+--    exactly why it needs restating. (Caught by the integration suite, not by
+--    reading the DDL.)
+ALTER TABLE public.referral_requests
+    ADD CONSTRAINT referral_requests_cv_kind_check CHECK (
+        ((cv_kind = 'original'::text) AND (cv_id IS NULL)) OR
+        (cv_kind = 'built'::text)
+    );
+
+-- 6. Re-establish the references against the new key, with the same delete rules.
 ALTER TABLE public.referral_requests
     ADD CONSTRAINT referral_requests_cv_id_fkey FOREIGN KEY (cv_id) REFERENCES public.cvs(id) ON DELETE SET NULL;
 
 ALTER TABLE public.assistant_sessions
     ADD CONSTRAINT assistant_sessions_cv_id_fkey FOREIGN KEY (cv_id) REFERENCES public.cvs(id) ON DELETE CASCADE;
 
--- A referencing column needs its own index: Postgres indexes only the referenced
+-- 7. A referencing column needs its own index: Postgres indexes only the referenced
 -- side, so without these, deleting a CV scans both tables.
 CREATE INDEX IF NOT EXISTS referral_requests_cv_id_idx ON public.referral_requests (cv_id);
 CREATE INDEX IF NOT EXISTS assistant_sessions_cv_id_idx ON public.assistant_sessions (cv_id);

--- a/openspec/changes/opaque-cv-ids/design.md
+++ b/openspec/changes/opaque-cv-ids/design.md
@@ -1,0 +1,120 @@
+## Context
+
+`cvs.id` is a bigint identity. It is exposed in `/my/cvs/<id>`, in the tailoring
+workspace's `?cv=<id>`, across nine `/api/v1/me/cvs/:id/*` endpoints, and in two
+published clients — the `freehire` CLI (`cv get|edit|render|context <id>`) and the
+`freehire-mcp` server (`z.number().int()`).
+
+Two tables reference it: `referral_requests.cv_id` (the CV attached to a referral
+request, `ON DELETE SET NULL`) and `assistant_sessions.cv_id` (the CV a tailoring
+conversation is bound to, `ON DELETE CASCADE`).
+
+Production holds 44 CVs, so the data volume is irrelevant; the cost of this change
+is entirely in the surfaces that name a CV.
+
+The assistant's own session ids were made random while their table was unshipped
+(`replace-assistant-runtime`). This applies the same reasoning to the one
+user-owned resource still addressed by a counting number — and the most sensitive
+one, since a CV is a résumé.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A CV is addressed by an unguessable id everywhere: API paths, web routes, the
+  tailoring bootstrap's response, and both published clients.
+- One identifier, not two. The bigint is gone rather than shadowed by a public
+  alias, so no code path can accidentally accept or emit the old form.
+- A malformed id is reported as missing, keeping "not a CV" and "not yours" one
+  answer.
+
+**Non-Goals:**
+
+- Preserving the numeric form for a transition period. See the decision below.
+- Changing ownership enforcement, response shapes beyond the id's type, or any
+  tailoring behaviour.
+- Re-addressing anything else. Jobs already use a public slug; companies use a
+  slug; the assistant already uses a UUID.
+
+## Decisions
+
+### Swap the primary key rather than adding a public alias
+
+The alternative — keep the bigint PK and add a `public_id uuid` addressed
+externally — preserves compact indexes and foreign keys. It was rejected because
+it leaves two identifiers for one row: every query, handler and test then has to
+know which one it holds, and the failure mode is silent (a numeric id that still
+resolves is exactly the enumeration we are removing). With 44 rows and two
+referencing tables, the index-size argument is theoretical.
+
+### Break the published clients rather than accept both forms
+
+A dual-accept period would keep the numeric id working for as long as anyone runs
+an old CLI — which is to say, the enumerable address stays live and the change
+buys nothing until the last client updates. A defence that can be bypassed by
+sending the older format is not a defence.
+
+Breaking is also the safer failure: an un-updated client sends a number, the
+backend cannot parse it as a UUID, and the request is refused as not found. There
+is no id it can send that resolves to somebody else's CV.
+
+Release order is backend first, then the two clients. Between the two, `cv`
+commands fail with "not found" — visible, immediate, and fixed by an update.
+
+### One transactional migration, converting the referencing columns with it
+
+The new ids are generated in the same statement that adds the column, then the two
+referencing tables are backfilled through the old key before it is dropped:
+
+```
+ADD cvs.new_id uuid DEFAULT gen_random_uuid()
+ADD referral_requests.new_cv_id / assistant_sessions.new_cv_id
+UPDATE both FROM cvs via the OLD bigint
+DROP the old foreign keys and columns, RENAME the new ones
+DROP the cvs primary key and the bigint id, RENAME new_id, re-add the key
+RE-ADD both foreign keys against the uuid
+```
+
+All of it in one transaction, so a failure anywhere leaves the schema untouched.
+The old numeric ids are not retained: nothing outside the database stores one
+except the clients being released with this change.
+
+### The frontend treats a CV id as an opaque string
+
+`web/src/lib/cv.ts` types it `string` rather than `number`. That is what stops a
+route or a request builder from quietly coercing, and it matches how the chat
+already treats session ids.
+
+## Risks / Trade-offs
+
+- **An old CLI or MCP breaks until updated.** → Accepted, and the point: it fails
+  loudly with "not found" rather than resolving to the wrong CV. Both clients are
+  released immediately after the backend.
+
+- **A bookmarked `/my/cvs/5` stops working.** → It 404s. CV URLs are private
+  working links, not shared or indexed content, and the CV list is one click away.
+
+- **The migration rewrites a primary key with two foreign keys hanging off it.**
+  → One transaction, and it is exercised on a real Postgres by the integration
+  suite (`startPostgres` applies every migration in order) before it goes near
+  production.
+
+- **Two clients must be released in step.** → The npm publish for `freehire-mcp`
+  is manual, so the sequence is deliberate rather than automatic. Documented in
+  the tasks.
+
+## Migration Plan
+
+1. Apply the migration manually on production, ahead of the API that reads it.
+2. Release the backend and the web app together (one repository, one deploy).
+3. Release `freehire-cli` and publish `freehire-mcp` to npm.
+4. Between 2 and 3, `cv` commands on an un-updated client answer "not found".
+
+Rollback: the migration is not reversible without regenerating the old bigints,
+which nothing stores. Rolling back means rolling back the whole change, so the
+migration is applied only after the backend passes its integration suite against
+a database built from these migrations.
+
+## Open Questions
+
+None. The compatibility question — break versus dual-accept — was settled above.

--- a/openspec/changes/opaque-cv-ids/specs/cv-builder/spec.md
+++ b/openspec/changes/opaque-cv-ids/specs/cv-builder/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: A CV id is unguessable
+
+A CV SHALL be identified by a random id rather than by a sequential one, in the
+database and on every surface that names it — API paths, web routes, and the
+published clients. Ownership already confines every read and write, so the id is
+not a capability; but a countable id would publish how many CVs the platform
+holds, and it would turn a single missing owner check on any future CV endpoint
+into bulk extraction of other people's résumés. An id that is not well-formed
+SHALL be reported as a missing CV, so "not a CV" and "not yours" stay one answer.
+
+#### Scenario: Two CVs get unrelated ids
+
+- **WHEN** a user creates two CVs in a row
+- **THEN** their ids are independently random, so neither reveals the other nor how many CVs exist
+
+#### Scenario: A malformed id is missing, not invalid
+
+- **WHEN** a request names a CV id that is not well-formed — a number, or anything that is not an id at all
+- **THEN** it is refused as not found, indistinguishable from a CV the caller does not own
+
+#### Scenario: The numeric form no longer resolves
+
+- **WHEN** a client built against the previous numeric ids sends one
+- **THEN** the request is refused as not found rather than resolving to any CV

--- a/openspec/changes/opaque-cv-ids/specs/cv-tailoring/spec.md
+++ b/openspec/changes/opaque-cv-ids/specs/cv-tailoring/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Tailoring starts a job-bound copy of the base CV
+
+The system SHALL, on a tailoring bootstrap request for a vacancy, create a new CV row bound to
+that vacancy (`cvs.job_id` set) whose document is copied from the user's base CV (`job_id = NULL`),
+and SHALL return the tailored CV id, the base CV id, and the cached fit analysis. Both ids SHALL be
+the CVs' unguessable ids. The base CV MUST remain unchanged by the bootstrap, and the tailored CV
+MUST be owner-scoped to the requesting user.
+
+#### Scenario: Bootstrap creates a tailored copy bound to the vacancy
+
+- **WHEN** a signed-in beta user requests tailoring for a vacancy and already has a base CV
+- **THEN** a new CV is created with `job_id` set to that vacancy, its document equals the base CV's document, and the response returns both ids plus the cached analysis
+
+#### Scenario: The base CV is untouched by bootstrap
+
+- **WHEN** the tailoring bootstrap creates a tailored copy
+- **THEN** the base CV's document and `updated_at` are unchanged
+
+#### Scenario: The returned ids are not guessable
+
+- **WHEN** the bootstrap responds
+- **THEN** `tailor_cv_id` and `base_cv_id` are random ids, and neither can be derived from the other or from any previously issued id

--- a/openspec/changes/opaque-cv-ids/tasks.md
+++ b/openspec/changes/opaque-cv-ids/tasks.md
@@ -1,0 +1,32 @@
+## 1. Schema
+
+- [x] 1.1 Add migration `0045_cvs_uuid_id.sql`: generate a uuid for every CV, carry `referral_requests.cv_id` and `assistant_sessions.cv_id` across through the old key, swap the primary key, re-add both foreign keys with their original delete rules, and index the referencing columns. One transaction.
+- [x] 1.2 Verify it against a real Postgres twice: once from scratch (initdb runs every migration in order) and once on a database seeded BEFORE the migration, asserting that each session still points at its own CV, that no row is orphaned, and that the cascade still fires. The second run is the one that matters — it is where a wrong statement order would silently break the links.
+
+## 2. Query layer
+
+- [ ] 2.1 Change the CV queries in `internal/db/queries/cvs.sql` to take and return uuid ids; regenerate `internal/db` with `make sqlc` (add the `google/uuid` override for `cvs.id`, `referral_requests.cv_id` and `assistant_sessions.cv_id`).
+- [ ] 2.2 Update `internal/cv`: `Meta.ID`, `Record`, and every `Store` method that takes an id.
+- [ ] 2.3 Update the other packages that hold a CV id — `internal/referral` and the assistant's session binding.
+
+## 3. HTTP surface
+
+- [ ] 3.1 Parse the `:id` route param as a uuid across the nine `/me/cvs/:id/*` endpoints; a malformed id is a 404, not a 400.
+- [ ] 3.2 Update the tailoring bootstrap's response ids and the assistant's CV tools (they close over the bound CV id).
+- [ ] 3.3 Update the handler tests and the CV integration tests for the new id type.
+
+## 4. Web
+
+- [ ] 4.1 Type a CV id as `string` in `web/src/lib/cv.ts` and `api.ts`; update the `/my/cvs/[id]` route and the tailoring workspace's `?cv=` parameter.
+- [ ] 4.2 Run `svelte-check`, eslint, vitest and the production build.
+
+## 5. Published clients (released after the backend)
+
+- [ ] 5.1 `freehire-cli`: accept a string id in `cv get|edit|render|context`, update the request paths, and fix the skill's stale line about acting "via the session key" — the tailoring session is minted in the browser now, and the CLI acts with the user's own API key.
+- [ ] 5.2 `freehire-mcp`: `cvId` becomes a string rather than `z.number().int()`, with the tool descriptions updated; bump the version and publish.
+- [ ] 5.3 Update both READMEs where they show a numeric CV id.
+
+## 6. Deploy
+
+- [ ] 6.1 Apply the migration manually on production ahead of the API that reads it.
+- [ ] 6.2 Release the backend + web, then the CLI, then the MCP publish. Between the first and the rest, `cv` commands on an un-updated client answer "not found" — expected, and the reason the order is fixed.

--- a/openspec/changes/opaque-cv-ids/tasks.md
+++ b/openspec/changes/opaque-cv-ids/tasks.md
@@ -5,20 +5,20 @@
 
 ## 2. Query layer
 
-- [ ] 2.1 Change the CV queries in `internal/db/queries/cvs.sql` to take and return uuid ids; regenerate `internal/db` with `make sqlc` (add the `google/uuid` override for `cvs.id`, `referral_requests.cv_id` and `assistant_sessions.cv_id`).
-- [ ] 2.2 Update `internal/cv`: `Meta.ID`, `Record`, and every `Store` method that takes an id.
-- [ ] 2.3 Update the other packages that hold a CV id — `internal/referral` and the assistant's session binding.
+- [x] 2.1 Change the CV queries in `internal/db/queries/cvs.sql` to take and return uuid ids; regenerate `internal/db` with `make sqlc` (add the `google/uuid` override for `cvs.id`, `referral_requests.cv_id` and `assistant_sessions.cv_id`).
+- [x] 2.2 Update `internal/cv`: `Meta.ID`, `Record`, and every `Store` method that takes an id.
+- [x] 2.3 Update the other packages that hold a CV id — `internal/referral` and the assistant's session binding.
 
 ## 3. HTTP surface
 
-- [ ] 3.1 Parse the `:id` route param as a uuid across the nine `/me/cvs/:id/*` endpoints; a malformed id is a 404, not a 400.
-- [ ] 3.2 Update the tailoring bootstrap's response ids and the assistant's CV tools (they close over the bound CV id).
-- [ ] 3.3 Update the handler tests and the CV integration tests for the new id type.
+- [x] 3.1 Parse the `:id` route param as a uuid across the nine `/me/cvs/:id/*` endpoints; a malformed id is a 404, not a 400.
+- [x] 3.2 Update the tailoring bootstrap's response ids and the assistant's CV tools (they close over the bound CV id).
+- [x] 3.3 Update the handler tests and the CV integration tests for the new id type.
 
 ## 4. Web
 
-- [ ] 4.1 Type a CV id as `string` in `web/src/lib/cv.ts` and `api.ts`; update the `/my/cvs/[id]` route and the tailoring workspace's `?cv=` parameter.
-- [ ] 4.2 Run `svelte-check`, eslint, vitest and the production build.
+- [x] 4.1 Type a CV id as `string` in `web/src/lib/cv.ts` and `api.ts`; update the `/my/cvs/[id]` route and the tailoring workspace's `?cv=` parameter.
+- [x] 4.2 Run `svelte-check`, eslint, vitest and the production build.
 
 ## 5. Published clients (released after the backend)
 

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -29,6 +29,16 @@ sql:
           # bytes marshal straight through to the profile response (null stays null).
           - column: "user_profiles.location_preferences"
             go_type: "encoding/json.RawMessage"
+          # A CV id is a random UUID the client treats as an opaque string, and the
+          # two columns that reference it follow. google/uuid gives them a real
+          # type, so a mis-typed id fails at the edge rather than deep in a query.
+          - column: "cvs.id"
+            go_type: "github.com/google/uuid.UUID"
+          - column: "referral_requests.cv_id"
+            go_type:
+              import: "github.com/google/uuid"
+              type: "UUID"
+              pointer: true
           # A session id is a random UUID the client treats as an opaque string.
           # google/uuid gives it a real type (parse errors surface at the edge)
           # rather than pgtype.UUID's byte array, which every caller would have to
@@ -39,7 +49,8 @@ sql:
             go_type: "github.com/google/uuid.UUID"
           - column: "assistant_sessions.cv_id"
             go_type:
-              type: "int64"
+              import: "github.com/google/uuid"
+              type: "UUID"
               pointer: true
           - column: "assistant_sessions.job_id"
             go_type:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1270,7 +1270,7 @@ export function createApi(
   }
 
   /** Switch a CV's template only (title + document untouched). */
-  async function setCvTemplate(id: number, templateId: string): Promise<void> {
+  async function setCvTemplate(id: string, templateId: string): Promise<void> {
     await call(`/api/v1/me/cvs/${id}/template`, jsonBody('PUT', { template_id: templateId }));
   }
 
@@ -1281,27 +1281,27 @@ export function createApi(
   }
 
   /** Bind a roy agent session to a CV so its workspace can re-open that exact session. */
-  async function setCvSession(id: number, sessionId: string): Promise<void> {
+  async function setCvSession(id: string, sessionId: string): Promise<void> {
     await call(`/api/v1/me/cvs/${id}/session`, jsonBody('PUT', { session_id: sessionId }));
   }
 
   /** Fetch one CV with its full document. */
-  async function getCv(id: number): Promise<CvRecord> {
+  async function getCv(id: string): Promise<CvRecord> {
     return requestData<CvRecord>(`/api/v1/me/cvs/${id}`);
   }
 
   /** Replace a CV's title, template, and document. */
-  async function updateCv(id: number, input: UpdateCvInput): Promise<CvMeta> {
+  async function updateCv(id: string, input: UpdateCvInput): Promise<CvMeta> {
     return requestData<CvMeta>(`/api/v1/me/cvs/${id}`, jsonBody('PUT', input));
   }
 
   /** Delete a CV. */
-  async function deleteCv(id: number): Promise<void> {
+  async function deleteCv(id: string): Promise<void> {
     await call(`/api/v1/me/cvs/${id}`, { method: 'DELETE' });
   }
 
   /** The authenticated PDF URL for a CV (same-origin cookie rides along on download). */
-  function cvPdfUrl(id: number): string {
+  function cvPdfUrl(id: string): string {
     return `${baseUrl}/api/v1/me/cvs/${id}/pdf`;
   }
 
@@ -1319,7 +1319,7 @@ export function createApi(
    * (one created before session binding): mints a fresh CLI token and returns the CV + base ids
    * so the workspace can seed a new agent session against the same CV.
    */
-  async function startTailorSession(id: number): Promise<TailorResult> {
+  async function startTailorSession(id: string): Promise<TailorResult> {
     return requestData<TailorResult>(`/api/v1/me/cvs/${id}/tailor-session`, jsonBody('POST', {}));
   }
 

--- a/web/src/lib/components/RequestReferralModal.svelte
+++ b/web/src/lib/components/RequestReferralModal.svelte
@@ -25,7 +25,7 @@
   } = $props();
 
   let cvKind = $state<'original' | 'built'>('original');
-  let cvId = $state<number | null>(null);
+  let cvId = $state<string | null>(null);
   let tailored = $state<CvTailoredItem[]>([]);
   let hasResume = $state(true);
   let linkedinUrl = $state('');

--- a/web/src/lib/cv.ts
+++ b/web/src/lib/cv.ts
@@ -17,7 +17,9 @@ import type {
 
 /** CV metadata (list rows and mutation responses). */
 export interface CvMeta {
-  id: number;
+  /** A CV id is a random UUID the client treats as opaque — never parsed, never
+   *  compared for order, only passed back. */
+  id: string;
   title: string;
   template_id: string;
   created_at: string;
@@ -47,8 +49,8 @@ export interface CvTailoredItem extends CvMeta {
  * backend as the caller.
  */
 export interface TailorResult {
-  tailor_cv_id: number;
-  base_cv_id: number;
+  tailor_cv_id: string;
+  base_cv_id: string;
   analysis: Analysis | null;
   session_id: string;
 }

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -25,7 +25,7 @@
     tab = $bindable('templates'),
     mobileVisible = false,
   }: {
-    cvId: number;
+    cvId: string;
     job: Job;
     analysis: Analysis | null;
     onTemplateSelected: (id: string) => void;

--- a/web/src/lib/tailor/TemplateGallery.svelte
+++ b/web/src/lib/tailor/TemplateGallery.svelte
@@ -7,7 +7,7 @@
   // the set-template endpoint and calls onSelected(id) so the host can keep its own template id in
   // step (autosave writes it too) and cache-bust the PDF. Non-ATS-safe templates carry an inline
   // caution.
-  let { cvId, onSelected }: { cvId: number; onSelected: (id: string) => void } = $props();
+  let { cvId, onSelected }: { cvId: string; onSelected: (id: string) => void } = $props();
 
   let status = $state<'loading' | 'error' | 'ready'>('loading');
   let templates = $state<CvTemplate[]>([]);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -236,7 +236,7 @@ export interface SeekerReferralRequest {
   company_name: string;
   job_id: number | null;
   cv_kind: ReferralCvKind;
-  cv_id: number | null;
+  cv_id: string | null;
   status: ReferralRequestStatus;
   created_at: string | null;
 }
@@ -261,7 +261,7 @@ export interface ReferralRequestInput {
   company_slug: string;
   job_id?: number;
   cv_kind: ReferralCvKind;
-  cv_id?: number;
+  cv_id?: string;
   linkedin_url: string;
   contact_telegram?: string;
   contact_email?: string;

--- a/web/src/routes/my/cvs/[id]/+page.svelte
+++ b/web/src/routes/my/cvs/[id]/+page.svelte
@@ -8,7 +8,7 @@
   import { page } from '$app/state';
   import { api } from '$lib/api';
 
-  const id = $derived(Number(page.params.id));
+  const id = $derived(page.params.id);
 
   onMount(async () => {
     try {

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -32,7 +32,7 @@
   let errorMsg = $state('');
   let sessionId = $state<string | undefined>(undefined);
   let resuming = $state(false);
-  let cvId = $state(0);
+  let cvId = $state('');
   let analysis = $state<Analysis | null>(null);
   let job = $state<Job | null>(null);
 
@@ -116,7 +116,7 @@
         // Resume an existing tailored CV. If it already has a bound session, re-attach it with
         // no kickoff. If it has none (a CV created before session binding), mint a fresh
         // tailoring session for it and let the kickoff orient the agent.
-        const existing = Number(cvParam);
+        const existing = cvParam;
         const [j, fit] = await Promise.all([
           api.getJob(slug),
           api.getMatchAnalysis(slug).catch(() => null),


### PR DESCRIPTION
**BREAKING** for the published CLI and MCP clients — both are released alongside.

`cvs.id` was a bigint identity, exposed in `/my/cvs/<id>`, in the tailoring
workspace's `?cv=<id>`, across nine `/api/v1/me/cvs/:id/*` endpoints, and in two
published clients. Ownership already confined every read — a foreign id answered
404 exactly as a missing one did — so the number was not a capability. What it did
do: publish how many résumés the platform holds, and make one forgotten owner
check on any future CV endpoint walkable, over the most sensitive data here.

Follows `replace-assistant-runtime`, which made session ids random for the same
reason while that table was still unshipped.

## The migration

One transaction. The two columns that reference `cvs(id)` —
`referral_requests.cv_id` (ON DELETE SET NULL) and `assistant_sessions.cv_id`
(ON DELETE CASCADE) — are carried across by mapping through the OLD key before it
is dropped, then the primary key is swapped and both foreign keys are rebuilt with
their original delete rules.

Verified against a real Postgres twice: once from scratch, and once on a database
seeded **before** the migration — the run that catches a wrong statement order,
where rows survive but their links quietly do not. After it: no orphaned rows,
each session still pointing at its own CV, cascade still firing, and
`cvs_id_seq` gone.

## Breaking rather than dual-accept

Accepting both forms would keep the enumerable address alive for as long as anyone
runs an old client — a defence that can be bypassed by sending the older format.
Breaking is also the safer failure: an un-updated client sends a number, it cannot
parse as an id, and the request is refused as not found. There is no number that
resolves to somebody else's CV.

## Also here

- A malformed id is a **404**, not a 400, so "not a CV" and "not yours" stay one answer.
- The web types a CV id as `string`, which is what stops a route or request builder
  from coercing it back into a number.
- `referral_requests.cv_id` in the request body is parsed explicitly: absent stays
  absent, present-but-malformed is a 422 rather than a lookup that finds nothing.

Released with: freehire-cli#… and freehire-mcp@0.4.0.
OpenSpec: `openspec/changes/opaque-cv-ids`.