### PR TITLE
fix(inbox): the Gmail callback is a browser navigation, not an XHR

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -73,6 +73,27 @@ func RequireAuth(iss *Issuer, versions TokenVersionLoader) fiber.Handler {
 	}
 }
 
+// OptionalCookieAuth returns middleware that attaches the caller's user id when a
+// valid session cookie is present and otherwise passes through anonymously. It is
+// OptionalAuth without the Bearer path: for a surface a leaked API key must not
+// reach (the mail inbox), admitting a key here would widen that key's reach for no
+// gain — the only caller is a browser returning from a provider redirect, which
+// carries a cookie or nothing.
+//
+// The OAuth-style callbacks mount this rather than RequireAuth: they are top-level
+// navigations, so a 401 renders JSON into the browser and strands the user, while an
+// anonymous pass-through lets the handler redirect back with an error marker.
+func OptionalCookieAuth(iss *Issuer, versions TokenVersionLoader) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if token := c.Cookies(CookieName); token != "" {
+			if id, ok := resolveSession(c, iss, versions, token); ok {
+				c.Locals(LocalsUserID, id)
+			}
+		}
+		return c.Next()
+	}
+}
+
 // resolveSession validates a cookie token and confirms it was not revoked, returning the
 // user id it authenticates. A version-load failure (deleted account, database trouble)
 // fails closed, matching RequireRole: an unverifiable session is not a session.

--- a/internal/handler/gmail.go
+++ b/internal/handler/gmail.go
@@ -62,7 +62,12 @@ func (h *inboxHandlers) register(api fiber.Router, mw middleware) {
 	api.Post("/me/emails/:id/reject", mw.cookie, h.RejectEmailLink)
 	if h.gmailReady() {
 		api.Get("/me/gmail/connect", mw.cookie, h.GmailConnect)
-		api.Get("/me/gmail/callback", mw.cookie, h.GmailCallback)
+		// The callback is the browser returning from Google, not an XHR — so it is
+		// mounted on optionalCookie, not cookie. Under RequireAuth a session that did
+		// not survive the round-trip (expired mid-consent, or a callback landing on a
+		// host the cookie is not scoped to) renders a JSON 401 into the address bar and
+		// strands the user; GmailCallback answers that case itself with a redirect.
+		api.Get("/me/gmail/callback", mw.optionalCookie, h.GmailCallback)
 		api.Post("/me/gmail/sync", mw.cookie, h.SyncGmail)
 	}
 	// Hosted-mailbox option: status is always available (reports unavailable when

--- a/internal/handler/gmail_callback_test.go
+++ b/internal/handler/gmail_callback_test.go
@@ -1,0 +1,84 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/gmailsync"
+	"github.com/strelov1/freehire/internal/tokencrypt"
+)
+
+// The Gmail callback is a top-level browser navigation returning from Google, not
+// an XHR: a caller whose session cookie did not survive the round-trip must land
+// back on the inbox with an error marker, never on a JSON 401 with no way forward.
+// This is the shape the handler was written for — RequireAuth on the route made its
+// own unauthenticated branch unreachable and rendered `{"error":"not authenticated"}`
+// into the browser instead.
+func TestGmailCallbackWithoutSessionRedirectsInsteadOfJSON(t *testing.T) {
+	app, frontend := newGmailCallbackApp(t)
+
+	// No auth cookie: the state the browser carried back is irrelevant, the session
+	// is what is missing.
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/me/gmail/callback?state=abc&code=xyz", nil), -1)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want %d (a redirect, not a JSON error)", resp.StatusCode, fiber.StatusFound)
+	}
+	if got, want := resp.Header.Get("Location"), frontend+"/my/inbox?gmail_error=auth"; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+// A signed-in caller whose state cookie is missing or mismatched is the CSRF case:
+// it must be refused, and refused the same way — a redirect carrying the marker, so
+// the SPA can explain what happened.
+func TestGmailCallbackStateMismatchRedirects(t *testing.T) {
+	app, frontend := newGmailCallbackApp(t)
+
+	iss := auth.NewIssuer(testGmailSecret, time.Hour)
+	token, err := iss.Issue(1, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	r := httptest.NewRequest("GET", "/api/v1/me/gmail/callback?state=abc&code=xyz", nil)
+	r.Header.Set("Cookie", auth.CookieName+"="+token)
+	resp, err := app.Test(r, -1)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, fiber.StatusFound)
+	}
+	if got, want := resp.Header.Get("Location"), frontend+"/my/inbox?gmail_error=state"; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+const testGmailSecret = "test-secret-that-is-long-enough-0001"
+
+// newGmailCallbackApp mounts the real route table (register), so the middleware the
+// callback is actually served behind is what these tests exercise.
+func newGmailCallbackApp(t *testing.T) (*fiber.App, string) {
+	t.Helper()
+	cipher, err := tokencrypt.New([]byte(strings.Repeat("k", 32)))
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	const frontend = "https://freehire.me"
+	h := newInboxHandlers(nil, gmailsync.NewConnector("id", "secret", frontend), cipher, frontend, true, "")
+
+	iss := auth.NewIssuer(testGmailSecret, time.Hour)
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	h.register(app.Group("/api/v1"), middleware{
+		cookie:         auth.RequireAuth(iss, testVersions),
+		optionalCookie: auth.OptionalCookieAuth(iss, testVersions),
+	})
+	return app, frontend
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -92,9 +92,13 @@ type middleware struct {
 	// the caller's own identity read) mounts it; every other key-accepting route stays
 	// on key, which is full-scope-only — so a new endpoint is out of a leaked agent
 	// credential's reach unless it opts in.
-	cvKey     fiber.Handler
-	cookie    fiber.Handler
-	moderator fiber.Handler
+	cvKey  fiber.Handler
+	cookie fiber.Handler
+	// optionalCookie attaches a cookie session when there is one but never rejects.
+	// It exists for provider callbacks, which are browser navigations: a 401 there
+	// renders JSON into the address bar instead of sending the user back to the app.
+	optionalCookie fiber.Handler
+	moderator      fiber.Handler
 	// outboundFetch throttles every endpoint that makes the server fetch a
 	// caller-supplied URL, so one user's budget is spent across them rather than
 	// granted once per route.
@@ -344,12 +348,13 @@ func Register(app *fiber.App, cfg Config) {
 	cookieAuth := auth.RequireAuth(a.issuer, a.queries)
 	requireModerator := auth.RequireRole(a.queries, "moderator")
 	mw := middleware{
-		optional:      optionalAuth,
-		key:           keyAuth,
-		cvKey:         cvKeyAuth,
-		cookie:        cookieAuth,
-		moderator:     requireModerator,
-		outboundFetch: contributionLimiter(),
+		optional:       optionalAuth,
+		key:            keyAuth,
+		cvKey:          cvKeyAuth,
+		cookie:         cookieAuth,
+		optionalCookie: auth.OptionalCookieAuth(a.issuer, a.queries),
+		moderator:      requireModerator,
+		outboundFetch:  contributionLimiter(),
 	}
 
 	// Job search surfaces first: their literal /jobs/* routes must precede the

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { page } from '$app/state';
+  import { replaceState } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import type {
@@ -78,8 +80,42 @@
   const hasAnySource = $derived(hasGmail || hasMailbox);
   const bothConnected = $derived(hasGmail && hasMailbox);
 
+  // The Gmail connect flow ends as a top-level browser navigation back to this page
+  // carrying its verdict in the URL: ?gmail=connected, or ?gmail_error=<reason> when
+  // the backend gave up. It is a banner and not the fatal `error` screen — the inbox
+  // itself is fine, only the connect attempt is not. The URL is cleaned afterwards so
+  // a reload does not replay a stale verdict. onMount (not afterNavigate, as in
+  // TopBar) is enough: this page is only ever reached from the callback by a cold
+  // load, never by an in-app navigation.
+  const GMAIL_CONNECT_ERRORS: Record<string, string> = {
+    auth: 'Your session ended before Gmail finished connecting. Sign in, then try again.',
+    state: 'That connect link expired or was opened out of order. Start the connection again.',
+    exchange: 'Google did not finish handing over access. Try connecting again.',
+  };
+  let connectNotice = $state<{ ok: boolean; text: string } | null>(null);
+
+  function readConnectVerdict() {
+    const params = page.url.searchParams;
+    const failed = params.get('gmail_error');
+    if (failed) {
+      connectNotice = {
+        ok: false,
+        text: GMAIL_CONNECT_ERRORS[failed] ?? 'Connecting Gmail failed. Try again.',
+      };
+    } else if (params.get('gmail') === 'connected') {
+      connectNotice = { ok: true, text: 'Gmail connected — your ATS mail will show up here shortly.' };
+    } else {
+      return;
+    }
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- shallow same-page URL clean-up to the current pathname; nothing to resolve
+    replaceState(page.url.pathname, {});
+  }
+
   let destroyed = false;
-  onMount(load);
+  onMount(() => {
+    readConnectVerdict();
+    void load();
+  });
   onDestroy(() => {
     destroyed = true;
   });
@@ -429,6 +465,15 @@
   <p class="text-sm text-destructive">{error}</p>
 {:else}
   <div class="flex flex-col gap-4">
+    {#if connectNotice}
+      <p
+        class="rounded-md border px-3 py-2 text-sm {connectNotice.ok
+          ? 'border-brand/30 bg-brand/10 text-foreground'
+          : 'border-destructive/30 bg-destructive/10 text-destructive'}"
+      >
+        {connectNotice.text}
+      </p>
+    {/if}
     <!-- Tabs: keep the mail list and the account setup on separate panes. -->
     <div class="flex gap-4 border-b border-border text-sm">
       {#each [{ id: 'inbox', label: 'Inbox' }, { id: 'settings', label: 'Settings' }] as t (t.id)}


### PR DESCRIPTION
## The report

```
GET https://freehire.dev/api/v1/me/gmail/callback?state=…&code=…
→ {"error": "not authenticated"}
```

A user pressed **Connect Gmail**, consented at Google, and landed on a JSON error page with no way back into the app.

## Root cause

Two separate faults, one of them not in this repo.

**1. The dead end (fixed here).** `/me/gmail/callback` was mounted on `mw.cookie` (`RequireAuth`), which answers 401 *before* the handler runs. `GmailCallback` has always handled the unauthenticated case itself — `redirect("gmail_error=auth", …)` — but that branch has been unreachable since the feature landed in #618. An OAuth callback is a top-level browser navigation; it must never render JSON.

**2. The trigger (ops, NOT in this PR).** Prod builds the Gmail `redirect_uri` from a fixed `FRONTEND_ORIGIN` (`internal/gmailsync/connector.go:42`), which still points at the legacy `freehire.dev` origin. Sessions are scoped `.freehire.me` (`internal/auth/cookie.go:59`) and the state cookie is host-only — so neither cookie survives the hop to `.dev`, and the callback arrives anonymous.

Evidence gathered against prod:

| Probe | Result |
|---|---|
| `GET https://freehire.dev/` | `301 → https://freehire.me/` — the SPA is not browsable on `.dev` |
| `GET https://freehire.dev/api/v1/me/gmail` | `401` — `/api/` on `.dev` is **not** redirected, it reaches the app |
| `/api/v1/auth/oauth/google/start` on both hosts | `redirect_uri` is per-host — sign-in already solved this (`requestOrigin`, `internal/handler/oauth.go:25`) |

The codebase documents this exact failure class at `internal/handler/oauth.go:35-43` — "the state cookie is set on the host the flow started from, while the callback is sent to the canonical origin, so the state can never match." Sign-in was taught the lesson; the Gmail connector never was.

## What changed

- **`auth.OptionalCookieAuth`** — attaches a cookie session when present, passes through anonymously otherwise. Cookie-only on purpose: `handler.go:343` declares the inbox a surface a leaked API key must not reach, and a browser returning from a provider redirect carries a cookie or nothing, so admitting Bearer would widen a key's reach for no gain.
- **The callback route** moves to it, which brings the handler's own `gmail_error=auth` redirect back to life.
- **`InboxView.svelte`** finally reads the outcome markers. `?gmail=connected` and `?gmail_error=` have been arriving at `/my/inbox` since #618 and going nowhere — even a *successful* connect returned the user to a silent page. Now both surface as a banner (not the fatal `error` screen — the inbox itself is fine), then the URL is cleaned, mirroring `TopBar`'s `?auth_error` handling.
- **Two tests** mounting the real `register()` route table, so the middleware the callback is actually served behind is what is exercised. Both failed before the fix.

## Still required to actually close the bug

This PR fixes the dead end, not the trigger. Ordered, because the first step is a prerequisite:

1. **Google Cloud Console** — confirm `https://freehire.me/api/v1/me/gmail/callback` is an Authorized redirect URI. If only `.dev` is registered, changing env below fails earlier with `redirect_uri_mismatch`.
2. **Prod env** — `FRONTEND_ORIGIN=https://freehire.me`, `SERVED_HOSTS=freehire.me`, `COOKIE_DOMAIN=.freehire.me`.
3. **nginx on the host** — fold `/api/` on `.dev` into the 301 the rest of that domain already gets.

Narrowing `COOKIE_DOMAIN` signs out anyone still holding a `.freehire.dev` cookie (and `ClearTokenCookie` cannot purge it — the domain no longer matches), and breaks any client with `.dev` hardcoded.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean · `go test ./...` no failures · `pnpm lint` exit 0 (the two InboxView warnings are pre-existing, lines 391/394) · `pnpm build` exit 0.