### PR TITLE
feat(referrals): offers and requests are named by opaque UUIDs

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -405,7 +405,6 @@ type PrunedJob struct {
 }
 
 type ReferralOffer struct {
-	ID             int64              `json:"id"`
 	UserID         int64              `json:"user_id"`
 	CompanySlug    string             `json:"company_slug"`
 	ProofObjectKey string             `json:"proof_object_key"`
@@ -414,10 +413,10 @@ type ReferralOffer struct {
 	DecidedAt      pgtype.Timestamptz `json:"decided_at"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl    string             `json:"linkedin_url"`
+	ID             uuid.UUID          `json:"id"`
 }
 
 type ReferralRequest struct {
-	ID              int64              `json:"id"`
 	SeekerUserID    int64              `json:"seeker_user_id"`
 	CompanySlug     string             `json:"company_slug"`
 	JobID           pgtype.Int8        `json:"job_id"`
@@ -431,6 +430,7 @@ type ReferralRequest struct {
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl     string             `json:"linkedin_url"`
 	CvID            *uuid.UUID         `json:"cv_id"`
+	ID              uuid.UUID          `json:"id"`
 }
 
 type ReminderSetting struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -605,10 +605,10 @@ type Querier interface {
 	// never equals the param, so private sets are unreachable. No row → 404.
 	GetPublicBoardBySlug(ctx context.Context, publicSlug pgtype.Text) (GetPublicBoardBySlugRow, error)
 	// One offer by id — for the moderator's proof-CV view after role authorization.
-	GetReferralOffer(ctx context.Context, id int64) (ReferralOffer, error)
+	GetReferralOffer(ctx context.Context, id uuid.UUID) (ReferralOffer, error)
 	// One referral request by id — for authorized CV access and marking, after the caller is
 	// verified as an approved referrer of the request's company.
-	GetReferralRequest(ctx context.Context, id int64) (ReferralRequest, error)
+	GetReferralRequest(ctx context.Context, id uuid.UUID) (ReferralRequest, error)
 	// The delivery context for one reminder: the job display fields, the channel set,
 	// the user's live destinations (account email; linked Telegram chat, NULL when
 	// unlinked -> that channel soft-skips), and the fire-time re-check flags. job_open

--- a/internal/db/referrals.sql.go
+++ b/internal/db/referrals.sql.go
@@ -95,7 +95,7 @@ func (q *Queries) CountReferralRequestsSince(ctx context.Context, arg CountRefer
 const createReferralOffer = `-- name: CreateReferralOffer :one
 INSERT INTO referral_offers (user_id, company_slug, proof_object_key, linkedin_url)
 VALUES ($1, $2, $3, $4)
-RETURNING id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url
+RETURNING user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url, id
 `
 
 type CreateReferralOfferParams struct {
@@ -117,7 +117,6 @@ func (q *Queries) CreateReferralOffer(ctx context.Context, arg CreateReferralOff
 	)
 	var i ReferralOffer
 	err := row.Scan(
-		&i.ID,
 		&i.UserID,
 		&i.CompanySlug,
 		&i.ProofObjectKey,
@@ -126,6 +125,7 @@ func (q *Queries) CreateReferralOffer(ctx context.Context, arg CreateReferralOff
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.LinkedinUrl,
+		&i.ID,
 	)
 	return i, err
 }
@@ -136,7 +136,7 @@ INSERT INTO referral_requests (
     contact_telegram, contact_email, note, linkedin_url
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id
+RETURNING seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id, id
 `
 
 type CreateReferralRequestParams struct {
@@ -168,7 +168,6 @@ func (q *Queries) CreateReferralRequest(ctx context.Context, arg CreateReferralR
 	)
 	var i ReferralRequest
 	err := row.Scan(
-		&i.ID,
 		&i.SeekerUserID,
 		&i.CompanySlug,
 		&i.JobID,
@@ -182,6 +181,7 @@ func (q *Queries) CreateReferralRequest(ctx context.Context, arg CreateReferralR
 		&i.CreatedAt,
 		&i.LinkedinUrl,
 		&i.CvID,
+		&i.ID,
 	)
 	return i, err
 }
@@ -190,13 +190,13 @@ const decideReferralOffer = `-- name: DecideReferralOffer :one
 UPDATE referral_offers
 SET status = $1, decided_by = $2, decided_at = now()
 WHERE id = $3 AND status = 'pending'
-RETURNING id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url
+RETURNING user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url, id
 `
 
 type DecideReferralOfferParams struct {
 	Status    string      `json:"status"`
 	DecidedBy pgtype.Int8 `json:"decided_by"`
-	ID        int64       `json:"id"`
+	ID        uuid.UUID   `json:"id"`
 }
 
 // Approve or reject a pending offer, recording the deciding moderator and time. The
@@ -206,7 +206,6 @@ func (q *Queries) DecideReferralOffer(ctx context.Context, arg DecideReferralOff
 	row := q.db.QueryRow(ctx, decideReferralOffer, arg.Status, arg.DecidedBy, arg.ID)
 	var i ReferralOffer
 	err := row.Scan(
-		&i.ID,
 		&i.UserID,
 		&i.CompanySlug,
 		&i.ProofObjectKey,
@@ -215,6 +214,7 @@ func (q *Queries) DecideReferralOffer(ctx context.Context, arg DecideReferralOff
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.LinkedinUrl,
+		&i.ID,
 	)
 	return i, err
 }
@@ -224,8 +224,8 @@ DELETE FROM referral_offers WHERE id = $1 AND user_id = $2
 `
 
 type DeleteReferralOfferParams struct {
-	ID     int64 `json:"id"`
-	UserID int64 `json:"user_id"`
+	ID     uuid.UUID `json:"id"`
+	UserID int64     `json:"user_id"`
 }
 
 // Withdraw ("stop being a referrer"): the owner deletes their own offer. The user_id
@@ -241,15 +241,14 @@ func (q *Queries) DeleteReferralOffer(ctx context.Context, arg DeleteReferralOff
 }
 
 const getReferralOffer = `-- name: GetReferralOffer :one
-SELECT id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url FROM referral_offers WHERE id = $1
+SELECT user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url, id FROM referral_offers WHERE id = $1
 `
 
 // One offer by id — for the moderator's proof-CV view after role authorization.
-func (q *Queries) GetReferralOffer(ctx context.Context, id int64) (ReferralOffer, error) {
+func (q *Queries) GetReferralOffer(ctx context.Context, id uuid.UUID) (ReferralOffer, error) {
 	row := q.db.QueryRow(ctx, getReferralOffer, id)
 	var i ReferralOffer
 	err := row.Scan(
-		&i.ID,
 		&i.UserID,
 		&i.CompanySlug,
 		&i.ProofObjectKey,
@@ -258,21 +257,21 @@ func (q *Queries) GetReferralOffer(ctx context.Context, id int64) (ReferralOffer
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.LinkedinUrl,
+		&i.ID,
 	)
 	return i, err
 }
 
 const getReferralRequest = `-- name: GetReferralRequest :one
-SELECT id, seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id FROM referral_requests WHERE id = $1
+SELECT seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id, id FROM referral_requests WHERE id = $1
 `
 
 // One referral request by id — for authorized CV access and marking, after the caller is
 // verified as an approved referrer of the request's company.
-func (q *Queries) GetReferralRequest(ctx context.Context, id int64) (ReferralRequest, error) {
+func (q *Queries) GetReferralRequest(ctx context.Context, id uuid.UUID) (ReferralRequest, error) {
 	row := q.db.QueryRow(ctx, getReferralRequest, id)
 	var i ReferralRequest
 	err := row.Scan(
-		&i.ID,
 		&i.SeekerUserID,
 		&i.CompanySlug,
 		&i.JobID,
@@ -286,6 +285,7 @@ func (q *Queries) GetReferralRequest(ctx context.Context, id int64) (ReferralReq
 		&i.CreatedAt,
 		&i.LinkedinUrl,
 		&i.CvID,
+		&i.ID,
 	)
 	return i, err
 }
@@ -328,7 +328,7 @@ func (q *Queries) ListApprovedReferrerRecipients(ctx context.Context, companySlu
 }
 
 const listIncomingReferralRequests = `-- name: ListIncomingReferralRequests :many
-SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, r.cv_id, c.name AS company_name
+SELECT r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, r.cv_id, r.id, c.name AS company_name
 FROM referral_requests r
 JOIN referral_offers o ON o.company_slug = r.company_slug
 LEFT JOIN companies c ON c.slug = r.company_slug
@@ -337,7 +337,6 @@ ORDER BY r.created_at DESC
 `
 
 type ListIncomingReferralRequestsRow struct {
-	ID              int64              `json:"id"`
 	SeekerUserID    int64              `json:"seeker_user_id"`
 	CompanySlug     string             `json:"company_slug"`
 	JobID           pgtype.Int8        `json:"job_id"`
@@ -351,6 +350,7 @@ type ListIncomingReferralRequestsRow struct {
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl     string             `json:"linkedin_url"`
 	CvID            *uuid.UUID         `json:"cv_id"`
+	ID              uuid.UUID          `json:"id"`
 	CompanyName     pgtype.Text        `json:"company_name"`
 }
 
@@ -368,7 +368,6 @@ func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUser
 	for rows.Next() {
 		var i ListIncomingReferralRequestsRow
 		if err := rows.Scan(
-			&i.ID,
 			&i.SeekerUserID,
 			&i.CompanySlug,
 			&i.JobID,
@@ -382,6 +381,7 @@ func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUser
 			&i.CreatedAt,
 			&i.LinkedinUrl,
 			&i.CvID,
+			&i.ID,
 			&i.CompanyName,
 		); err != nil {
 			return nil, err
@@ -395,7 +395,7 @@ func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUser
 }
 
 const listPendingReferralOffers = `-- name: ListPendingReferralOffers :many
-SELECT o.id, o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, o.linkedin_url, c.name AS company_name
+SELECT o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, o.linkedin_url, o.id, c.name AS company_name
 FROM referral_offers o
 LEFT JOIN companies c ON c.slug = o.company_slug
 WHERE o.status = 'pending'
@@ -404,7 +404,6 @@ LIMIT 500
 `
 
 type ListPendingReferralOffersRow struct {
-	ID             int64              `json:"id"`
 	UserID         int64              `json:"user_id"`
 	CompanySlug    string             `json:"company_slug"`
 	ProofObjectKey string             `json:"proof_object_key"`
@@ -413,6 +412,7 @@ type ListPendingReferralOffersRow struct {
 	DecidedAt      pgtype.Timestamptz `json:"decided_at"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl    string             `json:"linkedin_url"`
+	ID             uuid.UUID          `json:"id"`
 	CompanyName    pgtype.Text        `json:"company_name"`
 }
 
@@ -429,7 +429,6 @@ func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ListPendingR
 	for rows.Next() {
 		var i ListPendingReferralOffersRow
 		if err := rows.Scan(
-			&i.ID,
 			&i.UserID,
 			&i.CompanySlug,
 			&i.ProofObjectKey,
@@ -438,6 +437,7 @@ func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ListPendingR
 			&i.DecidedAt,
 			&i.CreatedAt,
 			&i.LinkedinUrl,
+			&i.ID,
 			&i.CompanyName,
 		); err != nil {
 			return nil, err
@@ -451,7 +451,7 @@ func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ListPendingR
 }
 
 const listReferralOffersByUser = `-- name: ListReferralOffersByUser :many
-SELECT o.id, o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, o.linkedin_url, c.name AS company_name
+SELECT o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, o.linkedin_url, o.id, c.name AS company_name
 FROM referral_offers o
 LEFT JOIN companies c ON c.slug = o.company_slug
 WHERE o.user_id = $1
@@ -459,7 +459,6 @@ ORDER BY o.created_at DESC
 `
 
 type ListReferralOffersByUserRow struct {
-	ID             int64              `json:"id"`
 	UserID         int64              `json:"user_id"`
 	CompanySlug    string             `json:"company_slug"`
 	ProofObjectKey string             `json:"proof_object_key"`
@@ -468,6 +467,7 @@ type ListReferralOffersByUserRow struct {
 	DecidedAt      pgtype.Timestamptz `json:"decided_at"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl    string             `json:"linkedin_url"`
+	ID             uuid.UUID          `json:"id"`
 	CompanyName    pgtype.Text        `json:"company_name"`
 }
 
@@ -484,7 +484,6 @@ func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([
 	for rows.Next() {
 		var i ListReferralOffersByUserRow
 		if err := rows.Scan(
-			&i.ID,
 			&i.UserID,
 			&i.CompanySlug,
 			&i.ProofObjectKey,
@@ -493,6 +492,7 @@ func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([
 			&i.DecidedAt,
 			&i.CreatedAt,
 			&i.LinkedinUrl,
+			&i.ID,
 			&i.CompanyName,
 		); err != nil {
 			return nil, err
@@ -506,7 +506,7 @@ func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([
 }
 
 const listReferralRequestsBySeeker = `-- name: ListReferralRequestsBySeeker :many
-SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, r.cv_id, c.name AS company_name
+SELECT r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, r.cv_id, r.id, c.name AS company_name
 FROM referral_requests r
 LEFT JOIN companies c ON c.slug = r.company_slug
 WHERE r.seeker_user_id = $1
@@ -514,7 +514,6 @@ ORDER BY r.created_at DESC
 `
 
 type ListReferralRequestsBySeekerRow struct {
-	ID              int64              `json:"id"`
 	SeekerUserID    int64              `json:"seeker_user_id"`
 	CompanySlug     string             `json:"company_slug"`
 	JobID           pgtype.Int8        `json:"job_id"`
@@ -528,6 +527,7 @@ type ListReferralRequestsBySeekerRow struct {
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	LinkedinUrl     string             `json:"linkedin_url"`
 	CvID            *uuid.UUID         `json:"cv_id"`
+	ID              uuid.UUID          `json:"id"`
 	CompanyName     pgtype.Text        `json:"company_name"`
 }
 
@@ -544,7 +544,6 @@ func (q *Queries) ListReferralRequestsBySeeker(ctx context.Context, seekerUserID
 	for rows.Next() {
 		var i ListReferralRequestsBySeekerRow
 		if err := rows.Scan(
-			&i.ID,
 			&i.SeekerUserID,
 			&i.CompanySlug,
 			&i.JobID,
@@ -558,6 +557,7 @@ func (q *Queries) ListReferralRequestsBySeeker(ctx context.Context, seekerUserID
 			&i.CreatedAt,
 			&i.LinkedinUrl,
 			&i.CvID,
+			&i.ID,
 			&i.CompanyName,
 		); err != nil {
 			return nil, err
@@ -595,13 +595,13 @@ const resolveReferralRequest = `-- name: ResolveReferralRequest :one
 UPDATE referral_requests
 SET status = $1, acted_by = $2, acted_at = now()
 WHERE id = $3 AND status = 'sent'
-RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id
+RETURNING seeker_user_id, company_slug, job_id, cv_kind, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url, cv_id, id
 `
 
 type ResolveReferralRequestParams struct {
 	Status  string      `json:"status"`
 	ActedBy pgtype.Int8 `json:"acted_by"`
-	ID      int64       `json:"id"`
+	ID      uuid.UUID   `json:"id"`
 }
 
 // Mark a sent request contacted or declined, recording the acting referrer and time. The
@@ -611,7 +611,6 @@ func (q *Queries) ResolveReferralRequest(ctx context.Context, arg ResolveReferra
 	row := q.db.QueryRow(ctx, resolveReferralRequest, arg.Status, arg.ActedBy, arg.ID)
 	var i ReferralRequest
 	err := row.Scan(
-		&i.ID,
 		&i.SeekerUserID,
 		&i.CompanySlug,
 		&i.JobID,
@@ -625,6 +624,7 @@ func (q *Queries) ResolveReferralRequest(ctx context.Context, arg ResolveReferra
 		&i.CreatedAt,
 		&i.LinkedinUrl,
 		&i.CvID,
+		&i.ID,
 	)
 	return i, err
 }

--- a/internal/handler/referrals.go
+++ b/internal/handler/referrals.go
@@ -51,7 +51,7 @@ func (h *referralHandlers) register(api fiber.Router, mw middleware) {
 // referralOfferResponse is the public shape of an offer. user_id is omitted (ownership,
 // internal); proof_object_key is never exposed (it points at a private S3 object).
 type referralOfferResponse struct {
-	ID          int64      `json:"id"`
+	ID          string     `json:"id"`
 	CompanySlug string     `json:"company_slug"`
 	CompanyName string     `json:"company_name"`
 	LinkedInURL string     `json:"linkedin_url"`
@@ -62,7 +62,7 @@ type referralOfferResponse struct {
 
 func toReferralOfferResponse(o referral.Offer) referralOfferResponse {
 	return referralOfferResponse{
-		ID: o.ID, CompanySlug: o.CompanySlug, CompanyName: o.CompanyName,
+		ID: o.ID.String(), CompanySlug: o.CompanySlug, CompanyName: o.CompanyName,
 		LinkedInURL: o.LinkedInURL, Status: o.Status,
 		DecidedAt: o.DecidedAt, CreatedAt: o.CreatedAt,
 	}
@@ -71,7 +71,7 @@ func toReferralOfferResponse(o referral.Offer) referralOfferResponse {
 // seekerRequestResponse is what a seeker sees of their own request: no referrer identity
 // (there is none to show — the request targets a pool), just the target and status.
 type seekerRequestResponse struct {
-	ID          int64      `json:"id"`
+	ID          string     `json:"id"`
 	CompanySlug string     `json:"company_slug"`
 	CompanyName string     `json:"company_name"`
 	JobID       *int64     `json:"job_id"`
@@ -96,7 +96,7 @@ func optionalCVID(raw *string) (*uuid.UUID, error) {
 
 func toSeekerRequestResponse(r referral.Request) seekerRequestResponse {
 	return seekerRequestResponse{
-		ID: r.ID, CompanySlug: r.CompanySlug, CompanyName: r.CompanyName, JobID: r.JobID,
+		ID: r.ID.String(), CompanySlug: r.CompanySlug, CompanyName: r.CompanyName, JobID: r.JobID,
 		CVKind: r.CVKind, CVID: cvIDString(r.CVID), Status: r.Status, CreatedAt: r.CreatedAt,
 	}
 }
@@ -105,7 +105,7 @@ func toSeekerRequestResponse(r referral.Request) seekerRequestResponse {
 // contact and CV choice to act on, plus the source vacancy. The seeker's user id stays
 // hidden — the referrer reaches out over the contact the seeker chose to share.
 type incomingRequestResponse struct {
-	ID              int64      `json:"id"`
+	ID              string     `json:"id"`
 	CompanySlug     string     `json:"company_slug"`
 	CompanyName     string     `json:"company_name"`
 	JobID           *int64     `json:"job_id"`
@@ -120,7 +120,7 @@ type incomingRequestResponse struct {
 
 func toIncomingRequestResponse(r referral.Request) incomingRequestResponse {
 	return incomingRequestResponse{
-		ID: r.ID, CompanySlug: r.CompanySlug, CompanyName: r.CompanyName, JobID: r.JobID,
+		ID: r.ID.String(), CompanySlug: r.CompanySlug, CompanyName: r.CompanyName, JobID: r.JobID,
 		CVKind: r.CVKind, LinkedInURL: r.LinkedInURL,
 		ContactTelegram: r.ContactTelegram, ContactEmail: r.ContactEmail, Note: r.Note,
 		Status: r.Status, CreatedAt: r.CreatedAt,
@@ -283,11 +283,11 @@ func (h *referralHandlers) WithdrawReferralOffer(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := referralPathID(c, "offer not found")
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid offer id")
+		return err
 	}
-	if err := h.referral.WithdrawOffer(c.Context(), int64(id), userID); err != nil {
+	if err := h.referral.WithdrawOffer(c.Context(), id, userID); err != nil {
 		return referralError(err)
 	}
 	return c.SendStatus(fiber.StatusNoContent)
@@ -323,9 +323,9 @@ func (h *referralHandlers) ResolveReferralRequest(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := referralPathID(c, "referral request not found")
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid request id")
+		return err
 	}
 	var in resolveReferralRequestBody
 	if err := c.BodyParser(&in); err != nil {
@@ -340,7 +340,7 @@ func (h *referralHandlers) ResolveReferralRequest(c *fiber.Ctx) error {
 	default:
 		return fiber.NewError(fiber.StatusBadRequest, "status must be contacted or declined")
 	}
-	req, err := h.referral.ResolveRequest(c.Context(), int64(id), userID, contacted)
+	req, err := h.referral.ResolveRequest(c.Context(), id, userID, contacted)
 	if err != nil {
 		return referralError(err)
 	}
@@ -371,15 +371,15 @@ func (h *referralHandlers) DecideReferralOffer(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := referralPathID(c, "offer not found")
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid offer id")
+		return err
 	}
 	var in decideReferralOfferBody
 	if err := c.BodyParser(&in); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
-	offer, err := h.referral.DecideOffer(c.Context(), int64(id), moderatorID, in.Approve)
+	offer, err := h.referral.DecideOffer(c.Context(), id, moderatorID, in.Approve)
 	if err != nil {
 		return referralError(err)
 	}
@@ -395,11 +395,11 @@ func (h *referralHandlers) ViewReferralRequestCV(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	id, err := c.ParamsInt("id")
+	id, err := referralPathID(c, "referral request not found")
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid request id")
+		return err
 	}
-	req, err := h.referral.AuthorizeCVAccess(c.Context(), int64(id), userID)
+	req, err := h.referral.AuthorizeCVAccess(c.Context(), id, userID)
 	if err != nil {
 		return referralError(err)
 	}
@@ -419,11 +419,11 @@ func (h *referralHandlers) ViewReferralRequestCV(c *fiber.Ctx) error {
 // ViewReferralOfferProof streams a member's proof CV to a moderator reviewing the offer.
 // Moderator-gated at the route; the proof key never leaves the server.
 func (h *referralHandlers) ViewReferralOfferProof(c *fiber.Ctx) error {
-	id, err := c.ParamsInt("id")
+	id, err := referralPathID(c, "offer not found")
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid offer id")
+		return err
 	}
-	offer, ok, err := h.referral.GetOffer(c.Context(), int64(id))
+	offer, ok, err := h.referral.GetOffer(c.Context(), id)
 	if err != nil {
 		return err
 	}
@@ -480,4 +480,18 @@ func (h *referralHandlers) renderOwnerCV(c *fiber.Ctx, cvID uuid.UUID, ownerID i
 // (user, company) makes it stable, so a re-upload overwrites the same object.
 func referralProofKey(userID int64, companySlug string) string {
 	return fmt.Sprintf("referral-proof/%d/%s.pdf", userID, companySlug)
+}
+
+// referralPathID parses the :id route param as a referral's UUID. A malformed id
+// cannot name any referral, so it answers exactly as a missing one does, down to
+// the message referralError would render. That matters more here than elsewhere:
+// an incoming request's CV is read by an approved referrer rather than by the
+// owner, so "not visible to you" is a membership answer, and none of the ways to
+// miss should be told apart.
+func referralPathID(c *fiber.Ctx, notFound string) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return uuid.Nil, fiber.NewError(fiber.StatusNotFound, notFound)
+	}
+	return id, nil
 }

--- a/internal/handler/referrals_integration_test.go
+++ b/internal/handler/referrals_integration_test.go
@@ -113,7 +113,7 @@ func TestReferralEndpoints(t *testing.T) {
 		if code != http.StatusCreated {
 			t.Fatalf("create request: status %d body %v, want 201", code, body)
 		}
-		reqID := int64(body["data"].(map[string]any)["id"].(float64))
+		reqID := body["data"].(map[string]any)["id"].(string)
 
 		// Duplicate active request → 409.
 		if code, _ := do(http.MethodPost, "/api/v1/me/referrals/requests", token(seeker), reqBody); code != http.StatusConflict {
@@ -140,17 +140,24 @@ func TestReferralEndpoints(t *testing.T) {
 		}
 
 		// CV access is cabinet-only: the seeker (not an approved referrer) is refused.
-		if code, _ := do(http.MethodGet, "/api/v1/me/referrals/incoming/"+itoa(reqID)+"/cv", token(seeker), nil); code != http.StatusForbidden {
+		if code, _ := do(http.MethodGet, "/api/v1/me/referrals/incoming/"+reqID+"/cv", token(seeker), nil); code != http.StatusForbidden {
 			t.Errorf("seeker viewing CV: status %d, want 403", code)
 		}
 		// The referrer is authorized; with no blob store wired the stream reports 503,
 		// which proves the request reached the storage path past the gate.
-		if code, _ := do(http.MethodGet, "/api/v1/me/referrals/incoming/"+itoa(reqID)+"/cv", token(refUser), nil); code != http.StatusServiceUnavailable {
+		if code, _ := do(http.MethodGet, "/api/v1/me/referrals/incoming/"+reqID+"/cv", token(refUser), nil); code != http.StatusServiceUnavailable {
 			t.Errorf("referrer viewing original CV (no blob): status %d, want 503", code)
 		}
 
+		// An id that is not a uuid cannot name a request; it reads as missing, with
+		// the same body a request the caller may not see would produce.
+		code, missing := do(http.MethodGet, "/api/v1/me/referrals/incoming/9/cv", token(refUser), nil)
+		if code != http.StatusNotFound || missing["error"] != "referral request not found" {
+			t.Errorf("malformed request id: status %d body %v, want 404 referral request not found", code, missing)
+		}
+
 		// Referrer marks it contacted.
-		code, marked := do(http.MethodPost, "/api/v1/me/referrals/incoming/"+itoa(reqID)+"/resolve",
+		code, marked := do(http.MethodPost, "/api/v1/me/referrals/incoming/"+reqID+"/resolve",
 			token(refUser), map[string]any{"status": "contacted"})
 		if code != http.StatusOK {
 			t.Fatalf("resolve: status %d body %v, want 200", code, marked)
@@ -202,13 +209,13 @@ func TestReferralEndpoints(t *testing.T) {
 	})
 
 	t.Run("moderator decides a pending offer", func(t *testing.T) {
-		var offerID int64
+		var offerID string
 		if err := pool.QueryRow(ctx,
 			`INSERT INTO referral_offers (user_id, company_slug, proof_object_key) VALUES ($1,'acme','k2') RETURNING id`,
 			seeker).Scan(&offerID); err != nil {
 			t.Fatalf("seed pending offer: %v", err)
 		}
-		code, body := do(http.MethodPost, "/api/v1/referrals/offers/"+itoa(offerID)+"/decide",
+		code, body := do(http.MethodPost, "/api/v1/referrals/offers/"+offerID+"/decide",
 			token(mod), map[string]any{"approve": true})
 		if code != http.StatusOK {
 			t.Fatalf("decide: status %d body %v, want 200", code, body)

--- a/internal/referral/referral.go
+++ b/internal/referral/referral.go
@@ -89,7 +89,9 @@ var (
 // Offer is a stored referral offer, decoupled from the generated db row. The pointer
 // timestamps and DecidedBy are nil until a moderator decides.
 type Offer struct {
-	ID          int64
+	// ID is a random UUID: these ids name resources whose reader is not always their
+	// owner, so a countable one would make a single authorization slip enumerable.
+	ID          uuid.UUID
 	UserID      int64
 	CompanySlug string
 	// CompanyName is the catalogue display name for CompanySlug, empty when the offer
@@ -110,7 +112,7 @@ type Offer struct {
 // CVID are nil for "no source vacancy" and an original-CV attachment respectively; ActedBy
 // and ActedAt are nil until a referrer marks it.
 type Request struct {
-	ID           int64
+	ID           uuid.UUID
 	SeekerUserID int64
 	CompanySlug  string
 	// CompanyName is the catalogue display name for CompanySlug, empty on paths that don't
@@ -168,9 +170,9 @@ type RequestInput struct {
 // no-row update (the status guard) to ErrOfferNotPending / ErrRequestNotOpen.
 type Repository interface {
 	CreateOffer(ctx context.Context, in OfferInput) (Offer, error)
-	DecideOffer(ctx context.Context, offerID, moderatorID int64, status string) (Offer, error)
-	GetOffer(ctx context.Context, offerID int64) (Offer, bool, error)
-	DeleteOffer(ctx context.Context, offerID, userID int64) error
+	DecideOffer(ctx context.Context, offerID uuid.UUID, moderatorID int64, status string) (Offer, error)
+	GetOffer(ctx context.Context, offerID uuid.UUID) (Offer, bool, error)
+	DeleteOffer(ctx context.Context, offerID uuid.UUID, userID int64) error
 	ListOffersByUser(ctx context.Context, userID int64) ([]Offer, error)
 	ListPendingOffers(ctx context.Context) ([]Offer, error)
 	CompanyHasApprovedReferrer(ctx context.Context, companySlug string) (bool, error)
@@ -181,8 +183,8 @@ type Repository interface {
 
 	CreateRequest(ctx context.Context, in RequestInput) (Request, error)
 	CountRequestsSince(ctx context.Context, seekerID int64, since time.Time) (int64, error)
-	GetRequest(ctx context.Context, id int64) (Request, bool, error)
-	ResolveRequest(ctx context.Context, id, actorID int64, status string) (Request, error)
+	GetRequest(ctx context.Context, id uuid.UUID) (Request, bool, error)
+	ResolveRequest(ctx context.Context, id uuid.UUID, actorID int64, status string) (Request, error)
 	ListRequestsBySeeker(ctx context.Context, seekerID int64) ([]Request, error)
 	ListIncomingRequests(ctx context.Context, referrerID int64) ([]Request, error)
 }
@@ -241,7 +243,7 @@ func (s *Service) SubmitOffer(ctx context.Context, in OfferInput) (Offer, error)
 
 // DecideOffer approves or rejects a pending offer, recording the moderator. A decision on an
 // already-decided or absent offer returns ErrOfferNotPending.
-func (s *Service) DecideOffer(ctx context.Context, offerID, moderatorID int64, approve bool) (Offer, error) {
+func (s *Service) DecideOffer(ctx context.Context, offerID uuid.UUID, moderatorID int64, approve bool) (Offer, error) {
 	status := OfferApproved
 	if !approve {
 		status = OfferRejected
@@ -251,14 +253,14 @@ func (s *Service) DecideOffer(ctx context.Context, offerID, moderatorID int64, a
 
 // GetOffer returns one offer by id — for the moderator's proof-CV view. ok is false when
 // the offer does not exist.
-func (s *Service) GetOffer(ctx context.Context, offerID int64) (Offer, bool, error) {
+func (s *Service) GetOffer(ctx context.Context, offerID uuid.UUID) (Offer, bool, error) {
 	return s.repo.GetOffer(ctx, offerID)
 }
 
 // WithdrawOffer lets a member stop being a referrer: it hard-deletes their own offer,
 // owner-scoped by userID. A missing offer or one owned by someone else returns
 // ErrOfferNotFound. Deleting frees the (user, company) slot so they can offer again later.
-func (s *Service) WithdrawOffer(ctx context.Context, offerID, userID int64) error {
+func (s *Service) WithdrawOffer(ctx context.Context, offerID uuid.UUID, userID int64) error {
 	return s.repo.DeleteOffer(ctx, offerID, userID)
 }
 
@@ -333,7 +335,7 @@ func (s *Service) CreateRequest(ctx context.Context, in RequestInput) (Request, 
 // ResolveRequest marks a sent request contacted or declined on behalf of a referrer, after
 // verifying they are an approved referrer of the request's company. A missing request is
 // ErrRequestNotFound; a request already resolved by another referrer is ErrRequestNotOpen.
-func (s *Service) ResolveRequest(ctx context.Context, requestID, referrerID int64, contacted bool) (Request, error) {
+func (s *Service) ResolveRequest(ctx context.Context, requestID uuid.UUID, referrerID int64, contacted bool) (Request, error) {
 	if _, err := s.authorizedRequest(ctx, requestID, referrerID); err != nil {
 		return Request{}, err
 	}
@@ -347,7 +349,7 @@ func (s *Service) ResolveRequest(ctx context.Context, requestID, referrerID int6
 // AuthorizeCVAccess returns the request when referrerID is an approved referrer of its
 // company, so the handler can serve the attached CV — the authorization gate that keeps CV
 // access cabinet-only. ErrNotAuthorized otherwise; ErrRequestNotFound for a missing request.
-func (s *Service) AuthorizeCVAccess(ctx context.Context, requestID, referrerID int64) (Request, error) {
+func (s *Service) AuthorizeCVAccess(ctx context.Context, requestID uuid.UUID, referrerID int64) (Request, error) {
 	return s.authorizedRequest(ctx, requestID, referrerID)
 }
 
@@ -363,7 +365,7 @@ func (s *Service) ListIncoming(ctx context.Context, referrerID int64) ([]Request
 
 // authorizedRequest fetches a request and verifies the caller is an approved referrer of its
 // company, the shared gate behind acting on and viewing a request.
-func (s *Service) authorizedRequest(ctx context.Context, requestID, referrerID int64) (Request, error) {
+func (s *Service) authorizedRequest(ctx context.Context, requestID uuid.UUID, referrerID int64) (Request, error) {
 	req, ok, err := s.repo.GetRequest(ctx, requestID)
 	if err != nil {
 		return Request{}, err

--- a/internal/referral/referral_test.go
+++ b/internal/referral/referral_test.go
@@ -33,17 +33,20 @@ type fakeRepo struct {
 }
 
 type decidedOffer struct {
-	id, moderator int64
-	status        string
+	id        uuid.UUID
+	moderator int64
+	status    string
 }
 
 type deletedOffer struct {
-	id, user int64
+	id   uuid.UUID
+	user int64
 }
 
 type resolvedRequest struct {
-	id, actor int64
-	status    string
+	id     uuid.UUID
+	actor  int64
+	status string
 }
 
 func (f *fakeRepo) CreateOffer(_ context.Context, in OfferInput) (Offer, error) {
@@ -51,10 +54,10 @@ func (f *fakeRepo) CreateOffer(_ context.Context, in OfferInput) (Offer, error) 
 	if f.createErr != nil {
 		return Offer{}, f.createErr
 	}
-	return Offer{ID: 1, UserID: in.UserID, CompanySlug: in.CompanySlug, Status: OfferPending}, nil
+	return Offer{ID: testOfferID, UserID: in.UserID, CompanySlug: in.CompanySlug, Status: OfferPending}, nil
 }
 
-func (f *fakeRepo) DecideOffer(_ context.Context, offerID, moderatorID int64, status string) (Offer, error) {
+func (f *fakeRepo) DecideOffer(_ context.Context, offerID uuid.UUID, moderatorID int64, status string) (Offer, error) {
 	f.decided = &decidedOffer{offerID, moderatorID, status}
 	if f.resolveErr != nil {
 		return Offer{}, f.resolveErr
@@ -74,6 +77,12 @@ func (f *fakeRepo) ApprovedReferrerRecipients(context.Context, string) ([]Recipi
 	return f.recipients, nil
 }
 
+// The ids these cases address. Fixed so a failure names a stable value.
+var (
+	testOfferID   = uuid.MustParse("aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa")
+	testRequestID = uuid.MustParse("bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb")
+)
+
 // testCVID is the attached CV these cases address.
 var testCVID = uuid.MustParse("77777777-7777-4777-8777-777777777777")
 
@@ -83,10 +92,10 @@ func (f *fakeRepo) CVBelongsToUser(context.Context, uuid.UUID, int64) (bool, err
 func (f *fakeRepo) UserHasResume(context.Context, int64) (bool, error) {
 	return f.hasResume, nil
 }
-func (f *fakeRepo) GetOffer(context.Context, int64) (Offer, bool, error) {
+func (f *fakeRepo) GetOffer(context.Context, uuid.UUID) (Offer, bool, error) {
 	return Offer{}, false, nil
 }
-func (f *fakeRepo) DeleteOffer(_ context.Context, offerID, userID int64) error {
+func (f *fakeRepo) DeleteOffer(_ context.Context, offerID uuid.UUID, userID int64) error {
 	f.deleted = &deletedOffer{offerID, userID}
 	return f.deleteErr
 }
@@ -96,18 +105,18 @@ func (f *fakeRepo) CreateRequest(_ context.Context, in RequestInput) (Request, e
 	if f.createErr != nil {
 		return Request{}, f.createErr
 	}
-	return Request{ID: 7, SeekerUserID: in.SeekerUserID, CompanySlug: in.CompanySlug, Status: RequestSent}, nil
+	return Request{ID: testRequestID, SeekerUserID: in.SeekerUserID, CompanySlug: in.CompanySlug, Status: RequestSent}, nil
 }
 
 func (f *fakeRepo) CountRequestsSince(_ context.Context, _ int64, _ time.Time) (int64, error) {
 	return f.countSince, nil
 }
 
-func (f *fakeRepo) GetRequest(context.Context, int64) (Request, bool, error) {
+func (f *fakeRepo) GetRequest(context.Context, uuid.UUID) (Request, bool, error) {
 	return f.getRequest, f.getRequestOK, nil
 }
 
-func (f *fakeRepo) ResolveRequest(_ context.Context, id, actorID int64, status string) (Request, error) {
+func (f *fakeRepo) ResolveRequest(_ context.Context, id uuid.UUID, actorID int64, status string) (Request, error) {
 	f.resolved = &resolvedRequest{id, actorID, status}
 	if f.resolveErr != nil {
 		return Request{}, f.resolveErr
@@ -198,7 +207,7 @@ func TestDecideOfferMapsApproveReject(t *testing.T) {
 	}{{true, OfferApproved}, {false, OfferRejected}} {
 		repo := &fakeRepo{}
 		s := newService(repo, &fakePinger{})
-		if _, err := s.DecideOffer(context.Background(), 5, 9, tc.approve); err != nil {
+		if _, err := s.DecideOffer(context.Background(), testOfferID, 9, tc.approve); err != nil {
 			t.Fatalf("decide: %v", err)
 		}
 		if repo.decided == nil || repo.decided.status != tc.want || repo.decided.moderator != 9 {
@@ -210,10 +219,10 @@ func TestDecideOfferMapsApproveReject(t *testing.T) {
 func TestWithdrawOfferIsOwnerScoped(t *testing.T) {
 	repo := &fakeRepo{}
 	s := newService(repo, &fakePinger{})
-	if err := s.WithdrawOffer(context.Background(), 5, 42); err != nil {
+	if err := s.WithdrawOffer(context.Background(), testOfferID, 42); err != nil {
 		t.Fatalf("withdraw: %v", err)
 	}
-	if repo.deleted == nil || repo.deleted.id != 5 || repo.deleted.user != 42 {
+	if repo.deleted == nil || repo.deleted.id != testOfferID || repo.deleted.user != 42 {
 		t.Errorf("deleted = %+v, want offer 5 by user 42", repo.deleted)
 	}
 }
@@ -221,7 +230,7 @@ func TestWithdrawOfferIsOwnerScoped(t *testing.T) {
 func TestWithdrawOfferPropagatesNotFound(t *testing.T) {
 	repo := &fakeRepo{deleteErr: ErrOfferNotFound}
 	s := newService(repo, &fakePinger{})
-	if err := s.WithdrawOffer(context.Background(), 5, 42); !errors.Is(err, ErrOfferNotFound) {
+	if err := s.WithdrawOffer(context.Background(), testOfferID, 42); !errors.Is(err, ErrOfferNotFound) {
 		t.Errorf("err = %v, want ErrOfferNotFound", err)
 	}
 }
@@ -346,15 +355,15 @@ func TestResolveRequestAuthorization(t *testing.T) {
 	t.Run("missing request", func(t *testing.T) {
 		repo := &fakeRepo{getRequestOK: false}
 		s := newService(repo, &fakePinger{})
-		if _, err := s.ResolveRequest(context.Background(), 7, 9, true); !errors.Is(err, ErrRequestNotFound) {
+		if _, err := s.ResolveRequest(context.Background(), testRequestID, 9, true); !errors.Is(err, ErrRequestNotFound) {
 			t.Fatalf("err = %v, want ErrRequestNotFound", err)
 		}
 	})
 
 	t.Run("not an approved referrer", func(t *testing.T) {
-		repo := &fakeRepo{getRequestOK: true, getRequest: Request{ID: 7, CompanySlug: "acme"}, approved: false}
+		repo := &fakeRepo{getRequestOK: true, getRequest: Request{ID: testRequestID, CompanySlug: "acme"}, approved: false}
 		s := newService(repo, &fakePinger{})
-		if _, err := s.ResolveRequest(context.Background(), 7, 9, true); !errors.Is(err, ErrNotAuthorized) {
+		if _, err := s.ResolveRequest(context.Background(), testRequestID, 9, true); !errors.Is(err, ErrNotAuthorized) {
 			t.Fatalf("err = %v, want ErrNotAuthorized", err)
 		}
 		if repo.resolved != nil {
@@ -363,9 +372,9 @@ func TestResolveRequestAuthorization(t *testing.T) {
 	})
 
 	t.Run("authorized decline maps status", func(t *testing.T) {
-		repo := &fakeRepo{getRequestOK: true, getRequest: Request{ID: 7, CompanySlug: "acme"}, approved: true}
+		repo := &fakeRepo{getRequestOK: true, getRequest: Request{ID: testRequestID, CompanySlug: "acme"}, approved: true}
 		s := newService(repo, &fakePinger{})
-		if _, err := s.ResolveRequest(context.Background(), 7, 9, false); err != nil {
+		if _, err := s.ResolveRequest(context.Background(), testRequestID, 9, false); err != nil {
 			t.Fatalf("resolve: %v", err)
 		}
 		if repo.resolved == nil || repo.resolved.status != RequestDeclined || repo.resolved.actor != 9 {
@@ -375,18 +384,18 @@ func TestResolveRequestAuthorization(t *testing.T) {
 }
 
 func TestAuthorizeCVAccess(t *testing.T) {
-	repo := &fakeRepo{getRequestOK: true, getRequest: Request{ID: 7, CompanySlug: "acme", CVKind: CVOriginal}, approved: true}
+	repo := &fakeRepo{getRequestOK: true, getRequest: Request{ID: testRequestID, CompanySlug: "acme", CVKind: CVOriginal}, approved: true}
 	s := newService(repo, &fakePinger{})
-	got, err := s.AuthorizeCVAccess(context.Background(), 7, 9)
+	got, err := s.AuthorizeCVAccess(context.Background(), testRequestID, 9)
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	if got.ID != 7 {
-		t.Errorf("request id = %d, want 7", got.ID)
+	if got.ID != testRequestID {
+		t.Errorf("request id = %s, want %s", got.ID, testRequestID)
 	}
 
 	repo.approved = false
-	if _, err := s.AuthorizeCVAccess(context.Background(), 7, 9); !errors.Is(err, ErrNotAuthorized) {
+	if _, err := s.AuthorizeCVAccess(context.Background(), testRequestID, 9); !errors.Is(err, ErrNotAuthorized) {
 		t.Fatalf("err = %v, want ErrNotAuthorized", err)
 	}
 }

--- a/internal/referral/repository.go
+++ b/internal/referral/repository.go
@@ -52,7 +52,7 @@ func (r *QueriesRepository) CreateOffer(ctx context.Context, in OfferInput) (Off
 
 // DecideOffer applies a moderator decision, mapping the no-row update (offer absent or
 // already decided) to ErrOfferNotPending.
-func (r *QueriesRepository) DecideOffer(ctx context.Context, offerID, moderatorID int64, status string) (Offer, error) {
+func (r *QueriesRepository) DecideOffer(ctx context.Context, offerID uuid.UUID, moderatorID int64, status string) (Offer, error) {
 	row, err := r.q.DecideReferralOffer(ctx, db.DecideReferralOfferParams{
 		ID: offerID, Status: status, DecidedBy: int8Val(moderatorID),
 	})
@@ -66,7 +66,7 @@ func (r *QueriesRepository) DecideOffer(ctx context.Context, offerID, moderatorI
 }
 
 // GetOffer returns one offer by id; ok is false when it does not exist.
-func (r *QueriesRepository) GetOffer(ctx context.Context, offerID int64) (Offer, bool, error) {
+func (r *QueriesRepository) GetOffer(ctx context.Context, offerID uuid.UUID) (Offer, bool, error) {
 	row, err := r.q.GetReferralOffer(ctx, offerID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Offer{}, false, nil
@@ -113,7 +113,7 @@ func (r *QueriesRepository) ListPendingOffers(ctx context.Context) ([]Offer, err
 
 // DeleteOffer hard-deletes a member's own offer, owner-scoped by userID. A zero-row
 // delete (absent id or another owner) maps to ErrOfferNotFound.
-func (r *QueriesRepository) DeleteOffer(ctx context.Context, offerID, userID int64) error {
+func (r *QueriesRepository) DeleteOffer(ctx context.Context, offerID uuid.UUID, userID int64) error {
 	n, err := r.q.DeleteReferralOffer(ctx, db.DeleteReferralOfferParams{ID: offerID, UserID: userID})
 	if err != nil {
 		return err
@@ -191,7 +191,7 @@ func (r *QueriesRepository) CountRequestsSince(ctx context.Context, seekerID int
 }
 
 // GetRequest returns a request by id; ok is false when it does not exist.
-func (r *QueriesRepository) GetRequest(ctx context.Context, id int64) (Request, bool, error) {
+func (r *QueriesRepository) GetRequest(ctx context.Context, id uuid.UUID) (Request, bool, error) {
 	row, err := r.q.GetReferralRequest(ctx, id)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Request{}, false, nil
@@ -204,7 +204,7 @@ func (r *QueriesRepository) GetRequest(ctx context.Context, id int64) (Request, 
 
 // ResolveRequest applies a referrer's mark, mapping the no-row update (already resolved) to
 // ErrRequestNotOpen.
-func (r *QueriesRepository) ResolveRequest(ctx context.Context, id, actorID int64, status string) (Request, error) {
+func (r *QueriesRepository) ResolveRequest(ctx context.Context, id uuid.UUID, actorID int64, status string) (Request, error) {
 	row, err := r.q.ResolveReferralRequest(ctx, db.ResolveReferralRequestParams{
 		ID: id, Status: status, ActedBy: int8Val(actorID),
 	})

--- a/migrations/0046_referral_uuid_ids.sql
+++ b/migrations/0046_referral_uuid_ids.sql
@@ -1,0 +1,41 @@
+-- Referral offers and requests become addressable by random UUIDs (see the
+-- opaque-referral-ids change).
+--
+-- Both were bigint identities, named in /me/referrals/offers/<id>,
+-- /me/referrals/incoming/<id>/cv and /referrals/offers/<id>/proof. This is the
+-- last user-owned resource still addressed by a counter.
+--
+-- The stakes are higher here than for a CV, and differently shaped: an incoming
+-- request's CV is deliberately served to SOMEONE ELSE — an approved referrer of
+-- the company the request is addressed to. That authorization is a membership
+-- question, not an ownership one, and the harder a check is, the more expensive
+-- it is to get wrong once. A countable id turns one mistake there into "download
+-- every attached résumé"; a random one leaves it a single failed request.
+--
+-- Simpler than 0045: nothing references either table, so there are no dependent
+-- columns to carry across and no foreign keys to rebuild. Dropping each column
+-- takes its identity sequence with it, which is the point — no counter is left to
+-- read. Both CHECK constraints on these tables reference other columns, not id,
+-- so they survive; only a CHECK naming the dropped column would vanish with it
+-- (the lesson from 0045, where referral_requests' cv_kind rule went quietly).
+--
+-- Applied to a fresh volume by initdb after 0045; on an existing prod volume run
+-- this file manually (SET ROLE hire) BEFORE deploying code that reads it. Run it
+-- with a lock_timeout: a DDL request for ACCESS EXCLUSIVE parks at the head of the
+-- lock queue, so a blocked migration takes the table's traffic down with it.
+
+BEGIN;
+
+ALTER TABLE public.referral_offers ADD COLUMN new_id uuid DEFAULT gen_random_uuid() NOT NULL;
+ALTER TABLE public.referral_offers DROP CONSTRAINT referral_offers_pkey;
+ALTER TABLE public.referral_offers DROP COLUMN id;
+ALTER TABLE public.referral_offers RENAME COLUMN new_id TO id;
+ALTER TABLE public.referral_offers ADD CONSTRAINT referral_offers_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.referral_requests ADD COLUMN new_id uuid DEFAULT gen_random_uuid() NOT NULL;
+ALTER TABLE public.referral_requests DROP CONSTRAINT referral_requests_pkey;
+ALTER TABLE public.referral_requests DROP COLUMN id;
+ALTER TABLE public.referral_requests RENAME COLUMN new_id TO id;
+ALTER TABLE public.referral_requests ADD CONSTRAINT referral_requests_pkey PRIMARY KEY (id);
+
+COMMIT;

--- a/openspec/changes/opaque-referral-ids/.openspec.yaml
+++ b/openspec/changes/opaque-referral-ids/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/opaque-referral-ids/proposal.md
+++ b/openspec/changes/opaque-referral-ids/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+A referral offer and a referral request are each addressed by a sequential
+number — `/me/referrals/offers/<id>`, `/me/referrals/incoming/<id>/cv`,
+`/referrals/offers/<id>/proof`. This is the last user-owned resource in the
+codebase still named by a counter; CVs and assistant sessions were made
+unguessable earlier (`opaque-cv-ids`, `replace-assistant-runtime`).
+
+The stakes here are higher than for a CV, and in an unusual way. A CV is read
+only by its owner, so its authorization is "are you the owner". A referral
+request is deliberately read by **someone else** — `GET /me/referrals/incoming/:id/cv`
+streams the seeker's CV to an approved referrer of that company. That check is
+not "is this yours" but "are you an approved referrer of the company this request
+is addressed to", which is a genuinely more complicated question. The harder the
+check, the more expensive it is to get wrong once — and a countable id turns one
+mistake into "download every attached résumé" rather than one failed request.
+
+The id also publishes volume: a seeker who files a request and sees `31` learns
+how many referral requests the platform has ever received.
+
+## What Changes
+
+- **BREAKING** (internal surfaces only): `referral_offers.id` and
+  `referral_requests.id` become random UUIDs. Every route that names one carries
+  the UUID instead of a number, and the responses carry it as a string.
+- A malformed id is reported as **not found** rather than as a bad request, so
+  "not an id" and "not visible to you" stay one answer.
+- **Unchanged:** who may see what. The moderator gate on offer review and the
+  approved-referrer gate on an incoming request are exactly as before — this
+  changes what a referral is called, not who may read it.
+
+## Capabilities
+
+### New Capabilities
+<!-- none: this changes how an existing capability addresses its resources -->
+
+### Modified Capabilities
+- `employee-referrals`: offers and requests are addressed by unguessable ids, and
+  a malformed id is reported as missing.
+
+## Impact
+
+**Backend:** a migration swapping both primary keys (nothing references either
+table, so no dependent columns to carry); the referral queries and generated
+code; `internal/referral`'s `Offer`/`Request` ids and repository signatures; the
+referral handlers' `:id` parsing and response shapes.
+
+**Frontend:** the referral id types in `web/src/lib/types.ts` and the calls in
+`ReferralsView.svelte` / `api.ts`.
+
+**Not affected:** the published CLI, the MCP server and the Claude Code plugin —
+none of them touch referrals. Unlike `opaque-cv-ids`, this ships as one deploy of
+one repository.

--- a/openspec/changes/opaque-referral-ids/specs/employee-referrals/spec.md
+++ b/openspec/changes/opaque-referral-ids/specs/employee-referrals/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: A referral is addressed by an unguessable id
+
+A referral offer and a referral request SHALL each be identified by a random id
+rather than a sequential one. An id that is not well-formed SHALL be reported as
+not found, so "not an id" and "not visible to you" remain one answer.
+
+This matters more here than for a resource read only by its owner. An incoming
+request's CV is deliberately served to **another person** — an approved referrer
+of the company the request is addressed to — so its authorization is a
+membership question rather than an ownership one. A countable id would turn a
+single mistake in that check into bulk retrieval of other seekers' résumés
+instead of one failed request.
+
+#### Scenario: Two referrals get unrelated ids
+
+- **WHEN** a seeker files two referral requests in a row
+- **THEN** their ids are independently random, so neither reveals the other nor how many requests exist
+
+#### Scenario: A malformed id is missing, not invalid
+
+- **WHEN** a request names a referral id that is not well-formed — a number, or anything that is not an id
+- **THEN** it is refused as not found, indistinguishable from one the caller may not see
+
+#### Scenario: Who may read what is unchanged
+
+- **WHEN** an approved referrer of the company opens an incoming request's CV, and a signed-in user who is not one attempts the same
+- **THEN** the referrer receives the CV and the other is refused, exactly as before the ids changed

--- a/openspec/changes/opaque-referral-ids/tasks.md
+++ b/openspec/changes/opaque-referral-ids/tasks.md
@@ -1,0 +1,25 @@
+## 1. Schema
+
+- [x] 1.1 Add migration `0046_referral_uuid_ids.sql`: swap `referral_offers.id` and `referral_requests.id` to random uuids in one transaction. Simpler than 0045 — nothing references either table, so there is no dependent column to carry and no foreign key to rebuild.
+- [x] 1.2 Verify it against a real Postgres on a database seeded BEFORE the migration: both rows survive with uuid ids, the identity sequences are gone with the dropped columns, both primary keys are rebuilt, and all four CHECK constraints are still in place (the 0045 lesson — a CHECK naming a dropped column vanishes with it).
+
+## 2. Query layer
+
+- [x] 2.1 Add the `google/uuid` overrides for `referral_offers.id` and `referral_requests.id` and regenerate `internal/db`.
+- [x] 2.2 Update `internal/referral`: `Offer.ID`, `Request.ID` and every repository and service signature that takes an id.
+
+## 3. HTTP surface
+
+- [x] 3.1 Parse `:id` as a uuid across the referral routes through a `referralPathID` helper; a malformed id is a 404, not a 400 — an unparseable opaque id is indistinguishable from one that does not exist.
+- [x] 3.2 Render the ids as strings in the offer, request and incoming-request responses.
+- [x] 3.3 Update the referral unit tests and the integration tests for the new id type.
+
+## 4. Web
+
+- [x] 4.1 Type a referral id as `string` in `web/src/lib/types.ts`; update `api.ts` (`withdrawReferralOffer`, `resolveReferral`, `decideReferralOffer`, `referralCvUrl`, `referralProofUrl`) to escape the id into the path, and the busy/withdrawing state in the two referral views.
+- [x] 4.2 Run `svelte-check`, eslint, vitest and the production build.
+
+## 5. Deploy
+
+- [ ] 5.1 Apply the migration manually on production ahead of the API that reads it, under a `lock_timeout`.
+- [ ] 5.2 Release the backend + web together. No published client addresses a referral, so nothing follows.

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -29,6 +29,14 @@ sql:
           # bytes marshal straight through to the profile response (null stays null).
           - column: "user_profiles.location_preferences"
             go_type: "encoding/json.RawMessage"
+          # Referral ids are random UUIDs for the same reason CV ids are, and with
+          # a sharper edge: an incoming request's CV is served to an approved
+          # referrer rather than to the owner, so its check is a membership
+          # question — the kind that is expensive to get wrong once.
+          - column: "referral_offers.id"
+            go_type: "github.com/google/uuid.UUID"
+          - column: "referral_requests.id"
+            go_type: "github.com/google/uuid.UUID"
           # A CV id is a random UUID the client treats as an opaque string, and the
           # two columns that reference it follow. google/uuid gives them a real
           # type, so a mis-typed id fails at the edge rather than deep in a query.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1074,8 +1074,8 @@ export function createApi(
   }
 
   /** Stop being a referrer: delete one of the caller's own offers. */
-  async function withdrawReferralOffer(id: number): Promise<void> {
-    await call(`/api/v1/me/referrals/offers/${id}`, { method: 'DELETE' });
+  async function withdrawReferralOffer(id: string): Promise<void> {
+    await call(`/api/v1/me/referrals/offers/${encodeURIComponent(id)}`, { method: 'DELETE' });
   }
 
   /** The referrer inbox: open requests for the companies the caller is approved for. */
@@ -1085,18 +1085,18 @@ export function createApi(
 
   /** Mark an incoming request contacted or declined on the caller's behalf. */
   async function resolveReferral(
-    id: number,
+    id: string,
     status: 'contacted' | 'declined',
   ): Promise<IncomingReferralRequest> {
     return requestData<IncomingReferralRequest>(
-      `/api/v1/me/referrals/incoming/${id}/resolve`,
+      `/api/v1/me/referrals/incoming/${encodeURIComponent(id)}/resolve`,
       jsonBody('POST', { status }),
     );
   }
 
   /** The URL that streams an incoming request's attached CV (opened in a new tab). */
-  function referralCvUrl(id: number): string {
-    return `${baseUrl}/api/v1/me/referrals/incoming/${id}/cv`;
+  function referralCvUrl(id: string): string {
+    return `${baseUrl}/api/v1/me/referrals/incoming/${encodeURIComponent(id)}/cv`;
   }
 
   /** The moderator queue: referral offers awaiting a decision, oldest first. */
@@ -1105,13 +1105,13 @@ export function createApi(
   }
 
   /** Approve or reject a pending offer. Moderator-only. */
-  async function decideReferralOffer(id: number, approve: boolean): Promise<ReferralOffer> {
-    return requestData<ReferralOffer>(`/api/v1/referrals/offers/${id}/decide`, jsonBody('POST', { approve }));
+  async function decideReferralOffer(id: string, approve: boolean): Promise<ReferralOffer> {
+    return requestData<ReferralOffer>(`/api/v1/referrals/offers/${encodeURIComponent(id)}/decide`, jsonBody('POST', { approve }));
   }
 
   /** The URL that streams an offer's proof CV (moderator-only, opened in a new tab). */
-  function referralProofUrl(id: number): string {
-    return `${baseUrl}/api/v1/referrals/offers/${id}/proof`;
+  function referralProofUrl(id: string): string {
+    return `${baseUrl}/api/v1/referrals/offers/${encodeURIComponent(id)}/proof`;
   }
 
   /** The moderator review queue: pending submissions, with submitter emails. */

--- a/web/src/lib/components/ReferralReviewView.svelte
+++ b/web/src/lib/components/ReferralReviewView.svelte
@@ -10,7 +10,7 @@
   import States from './States.svelte';
 
   const pending = new AsyncData<ReferralOffer[]>([]);
-  let busy = $state<number | null>(null);
+  let busy = $state<string | null>(null);
 
   onMount(() => void pending.run(() => api.listPendingReferralOffers()));
 

--- a/web/src/lib/components/ReferralsView.svelte
+++ b/web/src/lib/components/ReferralsView.svelte
@@ -107,7 +107,7 @@
 
   // Stop being a referrer: delete the offer after a confirm, then drop it optimistically
   // (reloading on failure to resurface it). `withdrawing` disables the acting row's button.
-  let withdrawing = $state<number | null>(null);
+  let withdrawing = $state<string | null>(null);
   async function withdrawOffer(o: ReferralOffer) {
     if (withdrawing !== null) return;
     const name = o.company_name || o.company_slug;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -221,7 +221,7 @@ export type ReferralRequestStatus = 'sent' | 'contacted' | 'declined';
 export type ReferralCvKind = 'original' | 'built';
 
 export interface ReferralOffer {
-  id: number;
+  id: string;
   company_slug: string;
   company_name: string;
   linkedin_url: string;
@@ -232,7 +232,7 @@ export interface ReferralOffer {
 
 /** What a seeker sees of their own request — no referrer identity (the request targets a pool). */
 export interface SeekerReferralRequest {
-  id: number;
+  id: string;
   company_slug: string;
   company_name: string;
   job_id: number | null;
@@ -244,7 +244,7 @@ export interface SeekerReferralRequest {
 
 /** What a referrer sees of an incoming request — the seeker's chosen contact and CV, no identity. */
 export interface IncomingReferralRequest {
-  id: number;
+  id: string;
   company_slug: string;
   company_name: string;
   job_id: number | null;


### PR DESCRIPTION
## Why

`referral_offers.id` and `referral_requests.id` were the last user-owned resources still addressed by a counter — `/me/referrals/offers/<id>`, `/me/referrals/incoming/<id>/cv`, `/referrals/offers/<id>/proof`.

The stakes are shaped differently from a CV's. An incoming request's CV is deliberately served to **someone else** — an approved referrer of the company the request names. That check answers a membership question, not an ownership one, and the harder a check is, the more expensive it is to get wrong once. A countable id turns one mistake there into "walk the range and download every attached CV"; a random one leaves it a single failed request.

## What

- `migrations/0046_referral_uuid_ids.sql` — swaps both ids to `gen_random_uuid()` in one transaction. Simpler than 0045: nothing references either table, so no dependent column is carried and no FK is rebuilt. Dropping each old column takes its identity sequence with it, which is the point. All four CHECK constraints reference other columns, so they survive (the 0045 lesson: a CHECK naming the dropped column vanishes with it).
- sqlc overrides for both columns; `internal/referral` and `internal/handler/referrals.go` carry `uuid.UUID` through.
- `referralPathID` answers **404** on a malformed id, with the same body a missing one produces — none of the ways to miss should be told apart. Previously 400.
- Web: a referral id is a `string`; ids are escaped into paths.

## Verification

- `go test ./...`, `go vet ./...`, `go vet -tags=integration ./...` — green.
- `go test -tags=integration ./internal/handler/ ./internal/db/` — green (run sequentially; running both at once races two testcontainer Postgres instances).
- The migration verified on a database seeded **before** it: both rows survive with uuid ids, sequences gone, both PKs rebuilt, all four CHECKs intact.
- Web: `svelte-check` 0 errors, eslint 0 errors, 408 vitest tests, production build.

## Deploy order

Apply the migration manually on production (under `lock_timeout`) **before** releasing the API that reads it. No published client addresses a referral, so nothing follows the release.