### PR TITLE
test(assistant): pin get_profile end-to-end, and announce it

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -73,6 +73,27 @@ func RequireAuth(iss *Issuer, versions TokenVersionLoader) fiber.Handler {
 	}
 }
 
+// OptionalCookieAuth returns middleware that attaches the caller's user id when a
+// valid session cookie is present and otherwise passes through anonymously. It is
+// OptionalAuth without the Bearer path: for a surface a leaked API key must not
+// reach (the mail inbox), admitting a key here would widen that key's reach for no
+// gain — the only caller is a browser returning from a provider redirect, which
+// carries a cookie or nothing.
+//
+// The OAuth-style callbacks mount this rather than RequireAuth: they are top-level
+// navigations, so a 401 renders JSON into the browser and strands the user, while an
+// anonymous pass-through lets the handler redirect back with an error marker.
+func OptionalCookieAuth(iss *Issuer, versions TokenVersionLoader) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if token := c.Cookies(CookieName); token != "" {
+			if id, ok := resolveSession(c, iss, versions, token); ok {
+				c.Locals(LocalsUserID, id)
+			}
+		}
+		return c.Next()
+	}
+}
+
 // resolveSession validates a cookie token and confirms it was not revoked, returning the
 // user id it authenticates. A version-load failure (deleted account, database trouble)
 // fails closed, matching RequireRole: an unverifiable session is not a session.

--- a/internal/handler/assistant_profile_tool_integration_test.go
+++ b/internal/handler/assistant_profile_tool_integration_test.go
@@ -1,0 +1,161 @@
+//go:build integration
+
+// Integration test for the get_profile tool against a real Postgres: a whole turn in
+// which the model calls the tool, and the transcript that turn leaves behind.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/assistant"
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/resume"
+	"github.com/strelov1/freehire/internal/userprofile"
+)
+
+// callReplyChoice is a model reply that calls one tool. (runner_test.go has the same
+// shape, but in package assistant — not reachable from here.)
+func callReplyChoice(name, args string) *llms.ContentChoice {
+	return &llms.ContentChoice{ToolCalls: []llms.ToolCall{{
+		ID: "call_" + name, Type: "function",
+		FunctionCall: &llms.FunctionCall{Name: name, Arguments: args},
+	}}}
+}
+
+// seedProfileAndCV gives a user the two things get_profile reads: a saved profile and
+// a structured résumé current with their stored CV. The structure carries contacts,
+// because the point of the test is that they do not come back out.
+func seedProfileAndCV(t *testing.T, pool *pgxpool.Pool, userID int64) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO user_profiles (user_id, specializations, skills, excluded_skills)
+		 VALUES ($1, ARRAY['backend'], ARRAY['go','kubernetes'], ARRAY['php'])`, userID); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	structured := `{
+		"full_name":"Ada Lovelace","email":"ada@example.test","phone":"+351900000000",
+		"links":["https://github.com/ada-example"],
+		"headline":"Staff Backend Engineer","total_years":11,
+		"skills":["Go","Kafka"],
+		"experience":[{"title":"Staff Engineer","company":"Analytical Engines","stack":["Go"]}]
+	}`
+	// The structure serves only while its stamp equals the résumé upload time, so both
+	// columns take the same instant — passed in, not `now()`, because within one UPDATE
+	// the right-hand side of an assignment reads the column's OLD value.
+	uploadedAt := time.Now().UTC()
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'cv/ada.pdf', resume_uploaded_at = $3,
+		        resume_structured = $2::jsonb, resume_structured_uploaded_at = $3,
+		        resume_structured_model = 'test-model'
+		 WHERE id = $1`, userID, structured, uploadedAt); err != nil {
+		t.Fatalf("seed structured résumé: %v", err)
+	}
+}
+
+// newProfileAssistantApp is newAssistantApp with the profile handlers wired, which is
+// what get_profile is built on.
+func newProfileAssistantApp(pool *pgxpool.Pool, iss *auth.Issuer, model assistant.Model) *fiber.App {
+	queries := db.New(pool)
+	profileH := newProfileHandlers(
+		userprofile.New(userprofile.NewQueriesRepository(queries)),
+		resume.New(nil, resume.NewQueriesRepository(queries)),
+	)
+	h := &assistantHandlers{store: assistant.NewStore(queries), queries: queries, profile: profileH}
+	h.runner = assistant.NewRunner(model, h.store, assistant.RunnerConfig{MaxSteps: 3})
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	h.register(app.Group("/api/v1"), middleware{cookie: auth.RequireAuth(iss, testVersions)})
+	return app
+}
+
+// TestGetProfileToolGroundsATurnWithoutLeakingContacts drives the whole chain the
+// feature rests on: the model calls get_profile, the tool reads real rows, and the
+// result is written into the stored transcript.
+//
+// The transcript is the reason this is worth an integration test. It is replayed into
+// the model's context on every later turn, so a contact that reaches it is not a
+// one-off disclosure — it is a permanent passenger in the conversation.
+func TestGetProfileToolGroundsATurnWithoutLeakingContacts(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	model := &turnModel{replies: []*llms.ContentChoice{
+		callReplyChoice("get_profile", `{}`),
+		{Content: "You are a backend engineer working in Go — searching on that."},
+	}}
+	app := newProfileAssistantApp(pool, iss, model)
+	userID, cookie := assistantUser(t, pool, iss, "grounded@example.test", true)
+	seedProfileAndCV(t, pool, userID)
+
+	id := createSession(t, app, cookie)
+	resp := assistantRequest(t, app, fiber.MethodPost, "/api/v1/assistant/sessions/"+id+"/messages", cookie,
+		map[string]string{"text": "help me find work"})
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("turn: status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	assertGroundedWithoutContacts(t, "stream", string(body))
+
+	// And again from the stored transcript, which is what later turns actually read.
+	resp = assistantRequest(t, app, fiber.MethodGet, "/api/v1/assistant/sessions/"+id, cookie, nil)
+	transcript, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	assertGroundedWithoutContacts(t, "transcript", string(transcript))
+}
+
+// assertGroundedWithoutContacts checks one rendering of the turn: the profile the
+// agent was grounded in is present, and none of the four contact fields are.
+func assertGroundedWithoutContacts(t *testing.T, where, payload string) {
+	t.Helper()
+	for _, want := range []string{"backend", "kubernetes", "Staff Backend Engineer"} {
+		if !strings.Contains(payload, want) {
+			t.Errorf("%s does not carry %q from the profile:\n%s", where, want, payload)
+		}
+	}
+	for _, leaked := range []string{"Ada Lovelace", "ada@example.test", "+351900000000", "github.com/ada-example"} {
+		if strings.Contains(payload, leaked) {
+			t.Errorf("%s leaks the contact %q — it would be replayed into the model's context on every later turn:\n%s", where, leaked, payload)
+		}
+	}
+}
+
+// TestGetProfileToolSendsAProfilelessUserToTheProfilePage covers the other half: a
+// user who never saved a profile is directed to the page that persists one, rather
+// than interviewed in a conversation whose answers evaporate.
+func TestGetProfileToolSendsAProfilelessUserToTheProfilePage(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	userID, _ := assistantUser(t, pool, iss, "blank@example.test", true)
+
+	h := &assistantHandlers{profile: newProfileHandlers(
+		userprofile.New(userprofile.NewQueriesRepository(queries)),
+		resume.New(nil, resume.NewQueriesRepository(queries)),
+	)}
+
+	out, err := toolByName(t, h.assistantDiscoveryTools(), "get_profile").
+		Run(context.Background(), userID, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("a missing profile is an answer, not a tool failure: %v", err)
+	}
+	payload, _ := json.Marshal(out)
+	if !strings.Contains(string(payload), "/my/profile") {
+		t.Errorf("result should point the agent at the profile page:\n%s", payload)
+	}
+}

--- a/internal/handler/gmail.go
+++ b/internal/handler/gmail.go
@@ -62,7 +62,12 @@ func (h *inboxHandlers) register(api fiber.Router, mw middleware) {
 	api.Post("/me/emails/:id/reject", mw.cookie, h.RejectEmailLink)
 	if h.gmailReady() {
 		api.Get("/me/gmail/connect", mw.cookie, h.GmailConnect)
-		api.Get("/me/gmail/callback", mw.cookie, h.GmailCallback)
+		// The callback is the browser returning from Google, not an XHR — so it is
+		// mounted on optionalCookie, not cookie. Under RequireAuth a session that did
+		// not survive the round-trip (expired mid-consent, or a callback landing on a
+		// host the cookie is not scoped to) renders a JSON 401 into the address bar and
+		// strands the user; GmailCallback answers that case itself with a redirect.
+		api.Get("/me/gmail/callback", mw.optionalCookie, h.GmailCallback)
 		api.Post("/me/gmail/sync", mw.cookie, h.SyncGmail)
 	}
 	// Hosted-mailbox option: status is always available (reports unavailable when

--- a/internal/handler/gmail_callback_test.go
+++ b/internal/handler/gmail_callback_test.go
@@ -1,0 +1,84 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/gmailsync"
+	"github.com/strelov1/freehire/internal/tokencrypt"
+)
+
+// The Gmail callback is a top-level browser navigation returning from Google, not
+// an XHR: a caller whose session cookie did not survive the round-trip must land
+// back on the inbox with an error marker, never on a JSON 401 with no way forward.
+// This is the shape the handler was written for — RequireAuth on the route made its
+// own unauthenticated branch unreachable and rendered `{"error":"not authenticated"}`
+// into the browser instead.
+func TestGmailCallbackWithoutSessionRedirectsInsteadOfJSON(t *testing.T) {
+	app, frontend := newGmailCallbackApp(t)
+
+	// No auth cookie: the state the browser carried back is irrelevant, the session
+	// is what is missing.
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/me/gmail/callback?state=abc&code=xyz", nil), -1)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want %d (a redirect, not a JSON error)", resp.StatusCode, fiber.StatusFound)
+	}
+	if got, want := resp.Header.Get("Location"), frontend+"/my/inbox?gmail_error=auth"; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+// A signed-in caller whose state cookie is missing or mismatched is the CSRF case:
+// it must be refused, and refused the same way — a redirect carrying the marker, so
+// the SPA can explain what happened.
+func TestGmailCallbackStateMismatchRedirects(t *testing.T) {
+	app, frontend := newGmailCallbackApp(t)
+
+	iss := auth.NewIssuer(testGmailSecret, time.Hour)
+	token, err := iss.Issue(1, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	r := httptest.NewRequest("GET", "/api/v1/me/gmail/callback?state=abc&code=xyz", nil)
+	r.Header.Set("Cookie", auth.CookieName+"="+token)
+	resp, err := app.Test(r, -1)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, fiber.StatusFound)
+	}
+	if got, want := resp.Header.Get("Location"), frontend+"/my/inbox?gmail_error=state"; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+const testGmailSecret = "test-secret-that-is-long-enough-0001"
+
+// newGmailCallbackApp mounts the real route table (register), so the middleware the
+// callback is actually served behind is what these tests exercise.
+func newGmailCallbackApp(t *testing.T) (*fiber.App, string) {
+	t.Helper()
+	cipher, err := tokencrypt.New([]byte(strings.Repeat("k", 32)))
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	const frontend = "https://freehire.me"
+	h := newInboxHandlers(nil, gmailsync.NewConnector("id", "secret", frontend), cipher, frontend, true, "")
+
+	iss := auth.NewIssuer(testGmailSecret, time.Hour)
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	h.register(app.Group("/api/v1"), middleware{
+		cookie:         auth.RequireAuth(iss, testVersions),
+		optionalCookie: auth.OptionalCookieAuth(iss, testVersions),
+	})
+	return app, frontend
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -92,9 +92,13 @@ type middleware struct {
 	// the caller's own identity read) mounts it; every other key-accepting route stays
 	// on key, which is full-scope-only — so a new endpoint is out of a leaked agent
 	// credential's reach unless it opts in.
-	cvKey     fiber.Handler
-	cookie    fiber.Handler
-	moderator fiber.Handler
+	cvKey  fiber.Handler
+	cookie fiber.Handler
+	// optionalCookie attaches a cookie session when there is one but never rejects.
+	// It exists for provider callbacks, which are browser navigations: a 401 there
+	// renders JSON into the address bar instead of sending the user back to the app.
+	optionalCookie fiber.Handler
+	moderator      fiber.Handler
 	// outboundFetch throttles every endpoint that makes the server fetch a
 	// caller-supplied URL, so one user's budget is spent across them rather than
 	// granted once per route.
@@ -344,12 +348,13 @@ func Register(app *fiber.App, cfg Config) {
 	cookieAuth := auth.RequireAuth(a.issuer, a.queries)
 	requireModerator := auth.RequireRole(a.queries, "moderator")
 	mw := middleware{
-		optional:      optionalAuth,
-		key:           keyAuth,
-		cvKey:         cvKeyAuth,
-		cookie:        cookieAuth,
-		moderator:     requireModerator,
-		outboundFetch: contributionLimiter(),
+		optional:       optionalAuth,
+		key:            keyAuth,
+		cvKey:          cvKeyAuth,
+		cookie:         cookieAuth,
+		optionalCookie: auth.OptionalCookieAuth(a.issuer, a.queries),
+		moderator:      requireModerator,
+		outboundFetch:  contributionLimiter(),
 	}
 
 	// Job search surfaces first: their literal /jobs/* routes must precede the

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { page } from '$app/state';
+  import { replaceState } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import type {
@@ -78,8 +80,42 @@
   const hasAnySource = $derived(hasGmail || hasMailbox);
   const bothConnected = $derived(hasGmail && hasMailbox);
 
+  // The Gmail connect flow ends as a top-level browser navigation back to this page
+  // carrying its verdict in the URL: ?gmail=connected, or ?gmail_error=<reason> when
+  // the backend gave up. It is a banner and not the fatal `error` screen — the inbox
+  // itself is fine, only the connect attempt is not. The URL is cleaned afterwards so
+  // a reload does not replay a stale verdict. onMount (not afterNavigate, as in
+  // TopBar) is enough: this page is only ever reached from the callback by a cold
+  // load, never by an in-app navigation.
+  const GMAIL_CONNECT_ERRORS: Record<string, string> = {
+    auth: 'Your session ended before Gmail finished connecting. Sign in, then try again.',
+    state: 'That connect link expired or was opened out of order. Start the connection again.',
+    exchange: 'Google did not finish handing over access. Try connecting again.',
+  };
+  let connectNotice = $state<{ ok: boolean; text: string } | null>(null);
+
+  function readConnectVerdict() {
+    const params = page.url.searchParams;
+    const failed = params.get('gmail_error');
+    if (failed) {
+      connectNotice = {
+        ok: false,
+        text: GMAIL_CONNECT_ERRORS[failed] ?? 'Connecting Gmail failed. Try again.',
+      };
+    } else if (params.get('gmail') === 'connected') {
+      connectNotice = { ok: true, text: 'Gmail connected — your ATS mail will show up here shortly.' };
+    } else {
+      return;
+    }
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- shallow same-page URL clean-up to the current pathname; nothing to resolve
+    replaceState(page.url.pathname, {});
+  }
+
   let destroyed = false;
-  onMount(load);
+  onMount(() => {
+    readConnectVerdict();
+    void load();
+  });
   onDestroy(() => {
     destroyed = true;
   });
@@ -429,6 +465,15 @@
   <p class="text-sm text-destructive">{error}</p>
 {:else}
   <div class="flex flex-col gap-4">
+    {#if connectNotice}
+      <p
+        class="rounded-md border px-3 py-2 text-sm {connectNotice.ok
+          ? 'border-brand/30 bg-brand/10 text-foreground'
+          : 'border-destructive/30 bg-destructive/10 text-destructive'}"
+      >
+        {connectNotice.text}
+      </p>
+    {/if}
     <!-- Tabs: keep the mail list and the account setup on separate panes. -->
     <div class="flex gap-4 border-b border-border text-sm">
       {#each [{ id: 'inbox', label: 'Inbox' }, { id: 'settings', label: 'Settings' }] as t (t.id)}

--- a/web/src/posts/2026-07-28-the-assistant-reads-your-profile-first.svx
+++ b/web/src/posts/2026-07-28-the-assistant-reads-your-profile-first.svx
@@ -1,0 +1,33 @@
+---
+title: The assistant reads your profile instead of asking you again
+date: 2026-07-28
+summary: Ask the in-app assistant for help finding work and it now starts from the roles, skills and locations you already saved, rather than opening with a questionnaire about them.
+type: changelog
+tags:
+  - assistant
+  - profile
+draft: false
+---
+
+Until now, "help me find a job" got you a list of questions: which role, which stack,
+remote or office, what seniority, what salary. Every one of those you had already answered
+on [your profile](/my/profile) — the assistant simply had no way to look. It could search
+the market, open a vacancy, score your skills against demand, but it could not read the one
+thing that was about *you*.
+
+**Now it reads the profile before it asks anything.** It takes your specializations, your
+skills, the skills you would rather avoid, and where and how you want to work, then searches
+on that and tells you what it searched on. Your CV goes in too — the headline, the years,
+the roles you have held — so it can judge seniority without asking. Questions are for what
+the profile genuinely does not answer.
+
+**Your contact details are not part of it.** The assistant is handed your CV's substance —
+what you have done — and never your name, email, phone or links. That is deliberate:
+anything a tool hands the model stays in the conversation, so contacts are kept out of it
+from the start rather than trimmed afterwards.
+
+If you have not filled the profile in yet, the assistant will say so and point you at
+[the profile page](/my/profile) instead of collecting the same answers in chat. Worth doing
+once: what you save there also drives your recommendations, your saved-search alerts and
+the fit analysis on every vacancy — where an answer typed into a conversation helps that
+conversation only.


### PR DESCRIPTION
Follow-ups to #1174.

**An integration test that reaches the transcript.** The unit tests cover the
tool's own output; they cannot reach the place the risk actually lives. A tool
result is persisted and replayed into the model's context on every later turn,
so a contact landing there is a permanent passenger rather than a one-off
disclosure. This drives a whole turn against a real Postgres — the model calls
`get_profile`, the tool reads real rows — and asserts on both renderings the
user's data takes: the SSE stream and the stored transcript read back. It also
covers the profile-less user, whose result must name the profile page rather
than fail.

Writing it caught a seeding trap worth knowing: within one `UPDATE`, the
right-hand side of an assignment reads the column's **old** value, so
`resume_uploaded_at = now(), resume_structured_uploaded_at = resume_uploaded_at`
stamps the structure with `NULL` — and `resume.Store.Structured` correctly
withholds a structure whose stamp does not match. The code was right; the seed
was not.

**A changelog entry** for the feature, which is user-facing.

Test plan: `go test ./...`, `go test -tags=integration ./internal/handler/`,
`pnpm check` (0 errors), `pnpm build`.