### PR TITLE
fix(assistant): the cv_edit patch is a typed schema, not a shape sketched in prose

### DIFF
--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -42,7 +42,8 @@ Start by calling ` + "`cv_context`" + ` (the fit analysis for this vacancy) and 
 Never invent, inflate or imply experience the candidate has not confirmed. That is the one rule that outranks making the CV look good.
 
 Mechanics:
-- ` + "`cv_edit`" + ` applies ONE patch per call: set_summary, set_header_field, add_bullet, replace_bullet, remove_bullet, reorder_bullets, set_skill_group. Make several calls for several edits.
+- ` + "`cv_edit`" + ` applies ONE patch per call; its schema lists the ops and the fields each one reads. Make several calls for several edits.
+- Address an experience entry and a bullet by their 0-based index in what ` + "`cv_get`" + ` returned — ` + "`bullet`" + ` is that index, never the bullet's text; the new text always goes in ` + "`value`" + `.
 - The server validates every patch; if one is rejected, read the reason and correct the address rather than retrying the same shape.
 - Contact details cannot be edited here — do not try.
 - Keep the CV to one or two pages. Prefer sharpening existing bullets over adding new ones.

--- a/internal/cv/patch.go
+++ b/internal/cv/patch.go
@@ -30,6 +30,21 @@ const (
 	PatchSetStack       PatchOp = "set_stack"
 )
 
+// PatchOps is the closed vocabulary of ops, in the order a caller meets them. LLM-facing
+// callers render it as the enum of their patch schema rather than restating the list in
+// prose — a hand-written list drifts (set_stack was missing from one for a release), and a
+// model that cannot see an op cannot use it.
+var PatchOps = []string{
+	string(PatchSetSummary),
+	string(PatchSetHeaderField),
+	string(PatchAddBullet),
+	string(PatchReplaceBullet),
+	string(PatchRemoveBullet),
+	string(PatchReorderBullets),
+	string(PatchSetSkillGroup),
+	string(PatchSetStack),
+}
+
 // Patch is one field-level edit to a CV Document. Op selects the operation; the remaining
 // fields are its address and payload, and only the ones an op needs are read. A patch names
 // the single field it changes rather than re-emitting the document, so an LLM tailoring a CV

--- a/internal/cv/patch_test.go
+++ b/internal/cv/patch_test.go
@@ -259,3 +259,15 @@ func TestApply_DoesNotMutateInput(t *testing.T) {
 		t.Errorf("Apply mutated its input: got %+v, want %+v", in, before)
 	}
 }
+
+func TestPatchOps_AreAllAcceptedByApply(t *testing.T) {
+	// PatchOps is what the tailoring tool advertises to the model. An op listed there
+	// that Apply does not know would be an invitation to spend a turn on a call that
+	// can only fail.
+	for _, op := range PatchOps {
+		_, err := Apply(sampleDoc(), Patch{Op: PatchOp(op)})
+		if err != nil && strings.Contains(err.Error(), "unknown op") {
+			t.Errorf("PatchOps advertises %q but Apply rejects it as unknown", op)
+		}
+	}
+}

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/google/uuid"
 
@@ -72,23 +71,81 @@ func (h *assistantHandlers) cvGetTool(cvID uuid.UUID) assistant.Tool {
 	}
 }
 
+// cvPatchSchema mirrors cv.Patch field by field: every field's name, type, and which op
+// reads it. cv_edit used to advertise the patch as a bare object carrying one example in
+// prose, and the model filled the rest in by analogy — replace_bullet arrived with the
+// bullet's new TEXT in `bullet`, the index field, and no `value` at all. DecodePatch
+// caught it, but a rejected call still costs a whole turn, so the shape belongs in the
+// schema the model reads before it writes. additionalProperties mirrors the decoder's
+// DisallowUnknownFields, and the op enum comes from the cv package so the two cannot drift.
+var cvPatchSchema = map[string]any{
+	"type": "object",
+	"description": "One patch: an `op` plus the address and payload that op reads. Indices are 0-based, " +
+		"counted over what cv_get returned. Send only the fields the op needs.",
+	"properties": map[string]any{
+		"op": map[string]any{
+			"type":        "string",
+			"enum":        cv.PatchOps,
+			"description": "Which edit to make.",
+		},
+		"experience": map[string]any{
+			"type": "integer",
+			"description": "Index of the experience entry to edit, into the `experience` list cv_get returned. " +
+				"Read by add_bullet, replace_bullet, remove_bullet, reorder_bullets and set_stack.",
+		},
+		"bullet": map[string]any{
+			"type": "integer",
+			"description": "Index of the bullet WITHIN that experience entry — a number, never the bullet's text. " +
+				"Read by replace_bullet and remove_bullet; the new text goes in `value`.",
+		},
+		"field": map[string]any{
+			"type": "string",
+			"enum": []string{"location"},
+			"description": "Which header field set_header_field writes. Only location is editable here; the " +
+				"candidate's name, email and phone stay their own.",
+		},
+		"value": map[string]any{
+			"type": "string",
+			"description": "The new text: the summary (set_summary), the bullet's text (add_bullet, " +
+				"replace_bullet) or the header field's value (set_header_field).",
+		},
+		"order": map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "integer"},
+			"description": "A permutation of the entry's bullet indices for reorder_bullets — the bullets end " +
+				"up in the order listed here.",
+		},
+		"group": map[string]any{
+			"type": "string",
+			"description": `The skill group's NAME for set_skill_group (e.g. "Languages"), not an index. ` +
+				"A name no group has appends a new group.",
+		},
+		"items": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "The skill group's full item list for set_skill_group; it replaces the group's current items.",
+		},
+		"stack": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "The experience entry's full technology line for set_stack; it replaces the current one.",
+		},
+	},
+	"required":             []string{"op"},
+	"additionalProperties": false,
+}
+
 // cvEditTool applies one field-level patch to the tailored CV.
 func (h *assistantHandlers) cvEditTool(cvID uuid.UUID) assistant.Tool {
 	return assistant.Tool{
 		Name: "cv_edit",
-		Description: "Apply ONE field-level patch to the CV. Ops: set_summary, set_header_field, add_bullet, " +
-			"replace_bullet, remove_bullet, reorder_bullets, set_skill_group. Never write a claim the candidate " +
-			"has not confirmed; contact details cannot be edited here.",
+		Description: "Apply ONE field-level patch to the CV — the patch schema lists the ops and the fields " +
+			"each one reads. Address experience entries and bullets by their index from cv_get. Never write a " +
+			"claim the candidate has not confirmed; contact details cannot be edited here.",
 		Schema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"patch": map[string]any{
-					"type": "object",
-					"description": "One cv.Patch object: an `op` plus its address and payload, e.g. " +
-						`{"op":"add_bullet","experience":0,"value":"Cut p99 latency 40%"}.`,
-				},
-			},
-			"required": []string{"patch"},
+			"type":       "object",
+			"properties": map[string]any{"patch": cvPatchSchema},
+			"required":   []string{"patch"},
 		},
 		Run: func(ctx context.Context, userID int64, raw json.RawMessage) (any, error) {
 			var in struct {
@@ -102,7 +159,7 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID) assistant.Tool {
 			// silently editing the wrong part of the document.
 			p, err := cv.DecodePatch(in.Patch)
 			if err != nil {
-				return nil, fmt.Errorf("invalid patch: %w", err)
+				return nil, err // already reads "cv: invalid patch: <reason>"
 			}
 			// The tailoring agent never sees the contact block and must not be able to
 			// write it either, so the stored identifiers stay the candidate's own.

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -123,6 +123,78 @@ func TestCVEditToolRejectsAMisaddressedPatch(t *testing.T) {
 	}
 }
 
+// cvEditPatchSchema returns the JSON Schema cv_edit advertises for its patch argument.
+func cvEditPatchSchema(t *testing.T) map[string]any {
+	t.Helper()
+	a, _ := cvToolsAPI(t, oneExperienceCV)
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_edit")
+	props, _ := tool.Schema["properties"].(map[string]any)
+	patch, _ := props["patch"].(map[string]any)
+	fields, _ := patch["properties"].(map[string]any)
+	if len(fields) == 0 {
+		t.Fatal("cv_edit advertises the patch as a bare object; the model has to guess its fields")
+	}
+	return fields
+}
+
+func TestCVEditToolSchemaTypesEveryPatchField(t *testing.T) {
+	// A patch advertised as a shapeless object made the model fill it in by analogy:
+	// it sent replace_bullet with the new TEXT in `bullet` — the index field — and no
+	// `value` at all. Typing each field is what stops that before the call is spent.
+	fields := cvEditPatchSchema(t)
+
+	for field, want := range map[string]string{
+		"op":         "string",
+		"experience": "integer",
+		"bullet":     "integer",
+		"field":      "string",
+		"value":      "string",
+		"group":      "string",
+		"order":      "array",
+		"items":      "array",
+		"stack":      "array",
+	} {
+		spec, ok := fields[field].(map[string]any)
+		if !ok {
+			t.Errorf("patch schema does not declare %q", field)
+			continue
+		}
+		if spec["type"] != want {
+			t.Errorf("patch field %q is typed %v, want %s", field, spec["type"], want)
+		}
+	}
+}
+
+func TestCVEditToolSchemaOffersEveryPatchOp(t *testing.T) {
+	// The prose list drifted once already: it named seven ops while Apply accepted
+	// eight, so set_stack was unreachable. The enum comes from the cv package so the
+	// two cannot diverge again.
+	fields := cvEditPatchSchema(t)
+
+	op, _ := fields["op"].(map[string]any)
+	enum, _ := op["enum"].([]string)
+	if len(enum) != len(cv.PatchOps) {
+		t.Fatalf("op enum = %v, want every op in cv.PatchOps (%v)", enum, cv.PatchOps)
+	}
+	for i, want := range cv.PatchOps {
+		if enum[i] != want {
+			t.Errorf("op enum[%d] = %q, want %q", i, enum[i], want)
+		}
+	}
+}
+
+func TestCVEditToolSchemaOffersOnlyTheEditableHeaderField(t *testing.T) {
+	// Contact identifiers are refused at runtime, so advertising them only buys a
+	// wasted turn: location is the one header field a tailoring session can write.
+	fields := cvEditPatchSchema(t)
+
+	field, _ := fields["field"].(map[string]any)
+	enum, _ := field["enum"].([]string)
+	if len(enum) != 1 || enum[0] != "location" {
+		t.Errorf("field enum = %v, want only location", enum)
+	}
+}
+
 func TestCVToolsAreBoundToTheSessionsCV(t *testing.T) {
 	// The CV id is closed over by the session's binding, never taken as an
 	// argument, so the model cannot address another CV even by guessing an id.


### PR DESCRIPTION
## What went wrong

A live tailoring session ([CV chat](https://freehire.me/tailor/staff-backend-engineer-grafana-second-horizon-ireland-remote-grafanalabs-jd7yozel)) burned two turns on rejected `cv_edit` calls. The stored transcript shows what the model actually sent:

```json
{"op": "replace_bullet", "experience": 0,
 "bullet": "Built a white-label SaaS chat platform serving 600K+ businesses…"}
```

The bullet's **new text** went into `bullet` — the index field — and `value` was omitted entirely. `DecodePatch` rejected it (`cannot unmarshal string into Go struct field Patch.bullet of type int`), the model read the reason and self-corrected on the retry, and the intended edit did land. But the candidate watched two failures scroll past in their chat.

## Why

`cv_edit` was the only assistant tool that advertised its argument as an opaque object:

```go
"patch": map[string]any{"type": "object", "description": "One cv.Patch object: … e.g. " +
    `{"op":"add_bullet","experience":0,"value":"Cut p99 latency 40%"}`}
```

No `properties`, no types. The single example used `add_bullet`, which has a `value` and no `bullet`, so the model reconstructed `replace_bullet` by analogy and collapsed address into payload. Strict decoding catches that after the fact; only a schema prevents it.

A second, quieter defect surfaced alongside: the prose listed seven ops while `Apply` accepts eight, leaving `set_stack` unreachable to the agent.

## The change

- `cv.PatchOps` — the closed op vocabulary next to the constants, the way `userjob.Stages` backs `track_job`'s enum.
- `cvPatchSchema` — every `cv.Patch` field with its type and which op reads it. `bullet` states it is an index and never the text; `field` narrows to `location` (the runtime already refuses the contact identifiers, so advertising them only bought a doomed turn); `additionalProperties: false` mirrors `DisallowUnknownFields`.
- The tailoring prompt drops its op list — the source of the drift — and gains a line on 0-based indices from `cv_get`.
- Dropped a doubled prefix: errors read `invalid patch: cv: invalid patch: json: …`.

**Not** added: number↔string coercion on the index fields. The evidence shows prose, not a stringified index, and `set_skill_group`'s `group` takes a **name** — a number there must keep failing rather than silently create a group called `"0"`.

## Tests

Four in `internal/handler` (field types, op enum equals `cv.PatchOps`, `field` offers only `location`, patch is not a bare object) and one in `internal/cv` (`Apply` knows every op `PatchOps` advertises). Written first, watched fail. `go build ./... && go vet && gofmt -l && go test ./...` clean.