### PR TITLE
fix(inbox): delete and restore answer 204, not a body reading "OK"

### DIFF
--- a/internal/handler/inbox.go
+++ b/internal/handler/inbox.go
@@ -240,6 +240,10 @@ func (h *inboxHandlers) RestoreEmail(c *fiber.Ctx) error {
 
 // setEmailDeleted flips one message's soft-delete flag (delete or restore),
 // scoped to the caller. A message that is not theirs matches no row → 404.
+//
+// It answers 204, not Fiber's SendStatus(200): that helper writes the status text
+// "OK" as the body, which is neither of this API's response shapes, and a client
+// that decodes a 2xx body fails on a call that actually succeeded.
 func (h *inboxHandlers) setEmailDeleted(c *fiber.Ctx, deleted bool) error {
 	userID, err := requireUserID(c)
 	if err != nil {
@@ -261,5 +265,5 @@ func (h *inboxHandlers) setEmailDeleted(c *fiber.Ctx, deleted bool) error {
 	if n == 0 {
 		return fiber.NewError(fiber.StatusNotFound, "not found")
 	}
-	return c.SendStatus(fiber.StatusOK)
+	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/handler/inbox_integration_test.go
+++ b/internal/handler/inbox_integration_test.go
@@ -110,7 +110,7 @@ func TestInboxReadSideEndToEnd(t *testing.T) {
 	}
 
 	// Soft-delete the rejection: it drops out of the listing.
-	if code, _ := do("POST", "/api/v1/me/emails/"+strconv.FormatInt(rejID, 10)+"/delete"); code != 200 {
+	if code, _ := do("POST", "/api/v1/me/emails/"+strconv.FormatInt(rejID, 10)+"/delete"); code != 204 {
 		t.Errorf("delete status = %d", code)
 	}
 	if n := listLen("/api/v1/me/inbox"); n != 2 {
@@ -122,7 +122,7 @@ func TestInboxReadSideEndToEnd(t *testing.T) {
 		t.Errorf("GET deleted email = %d, want 404", code)
 	}
 	// Restore brings it back.
-	if code, _ := do("POST", "/api/v1/me/emails/"+strconv.FormatInt(rejID, 10)+"/restore"); code != 200 {
+	if code, _ := do("POST", "/api/v1/me/emails/"+strconv.FormatInt(rejID, 10)+"/restore"); code != 204 {
 		t.Errorf("restore status = %d", code)
 	}
 	if n := listLen("/api/v1/me/inbox"); n != 3 {
@@ -138,6 +138,57 @@ func TestInboxReadSideEndToEnd(t *testing.T) {
 		 VALUES ($1, 'hosted', 'x1', 'Theirs', 'body', now()) RETURNING id`, otherUID).Scan(&otherID)
 	if code, _ := do("POST", "/api/v1/me/emails/"+strconv.FormatInt(otherID, 10)+"/delete"); code != 404 {
 		t.Errorf("cross-user delete = %d, want 404", code)
+	}
+}
+
+// Delete and restore change state and return nothing, so they answer 204 with an
+// empty body — the shape every other void mutation here uses (saved searches,
+// referrals, logout, the Telegram unlink).
+//
+// The body is the point, not just the status. Fiber's SendStatus(200) writes the
+// status text "OK" as the payload, which is neither of this API's two documented
+// shapes, and any client that decodes a 2xx body chokes on it: the freehire CLI's
+// `inbox delete` reported `decode response: invalid character 'O'` on a delete that
+// had in fact succeeded. The browser client never noticed because it discards the
+// body. This asserts on the bytes so the next non-browser caller is safe.
+func TestSoftDeleteAndRestoreReturnNoBody(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var uid int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('nobody@example.test') RETURNING id`).Scan(&uid); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	var id int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at)
+		 VALUES ($1, 'hosted', 'm-nobody', 'Subject', 'body', now()) RETURNING id`, uid).Scan(&id); err != nil {
+		t.Fatalf("seed email: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret-that-is-long-enough-0001", time.Hour)
+	cookie, _ := iss.Issue(uid, testTokenVersion)
+	h := &inboxHandlers{queries: db.New(pool)}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	ra := auth.RequireAuth(iss, testVersions)
+	app.Post("/api/v1/me/emails/:id/delete", ra, h.DeleteEmail)
+	app.Post("/api/v1/me/emails/:id/restore", ra, h.RestoreEmail)
+
+	for _, action := range []string{"delete", "restore"} {
+		r := httptest.NewRequest("POST", "/api/v1/me/emails/"+strconv.FormatInt(id, 10)+"/"+action, nil)
+		r.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+		resp, err := app.Test(r, -1)
+		if err != nil {
+			t.Fatalf("%s: %v", action, err)
+		}
+		if resp.StatusCode != fiber.StatusNoContent {
+			t.Errorf("%s status = %d, want %d", action, resp.StatusCode, fiber.StatusNoContent)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		if len(b) != 0 {
+			t.Errorf("%s body = %q, want empty — a JSON client cannot decode it", action, b)
+		}
 	}
 }
 


### PR DESCRIPTION
## What broke

`POST /me/emails/:id/delete` and `/restore` ended in `c.SendStatus(fiber.StatusOK)`.
Fiber writes the status *text* as the payload, so both answered `200` with a
two-byte body `OK` — neither `{"data": ...}` nor `{"error": ...}`.

Found by running the freehire CLI's new `inbox` commands against prod:

```
$ freehire inbox delete 2337
error: decode response: invalid character 'O' looking for beginning of value
```

The delete had **succeeded**. The CLI decodes every 2xx body on purpose — so a
silently broken API surfaces rather than being swallowed — and exits non-zero on a
malformed one. An agent harness reads that as a failed call and retries.

## Why it hid for so long

The browser was the only caller, and the SPA's `deleteEmail`/`restoreEmail` use
`call()`, which checks `res.ok` and never touches the body.

The integration test did not catch it either: its `do` helper is
`_ = json.Unmarshal(b, &body)` — the error is discarded, so the helper is more
forgiving than any real client. The new test asserts on the raw bytes instead.

## The fix

`204 No Content`, which is what every other void mutation in `internal/handler`
already answers — `me_searches.go`, `referrals.go`, `auth.go`, `resume.go`,
`DELETE /me/telegram`. `inbox.go` was the only non-webhook outlier. (The five
`SendStatus(200)` in `telegram.go` stay: a webhook must answer 200 to Telegram.)

Safe for both callers: the SPA ignores the body, and the CLI's decoder skips an
empty one — no CLI release needed.

## Testing

`gofmt`/`build`/`vet` clean; `go test ./...` green; `go test -tags=integration
./internal/handler/` green. The new test fails on `main` with
`delete body = "OK", want empty`.

No spec delta — `openspec/specs/email-inbox` pins the 404 and the soft-delete
semantics, never a success status.