### PR TITLE
test(handler): a 2xx body that does not decode fails the test

### DIFF
--- a/internal/handler/gmail_integration_test.go
+++ b/internal/handler/gmail_integration_test.go
@@ -8,9 +8,7 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,10 +68,8 @@ func TestGmailInboxEndToEnd(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s %s: %v", method, path, err)
 		}
-		b, _ := io.ReadAll(resp.Body)
 		var body map[string]any
-		_ = json.Unmarshal(b, &body)
-		return resp.StatusCode, body
+		return decodeJSON(t, resp, &body), body
 	}
 
 	// Status: connected.

--- a/internal/handler/inbox_integration_test.go
+++ b/internal/handler/inbox_integration_test.go
@@ -8,7 +8,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -70,10 +69,8 @@ func TestInboxReadSideEndToEnd(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s %s: %v", method, path, err)
 		}
-		b, _ := io.ReadAll(resp.Body)
 		var body map[string]any
-		_ = json.Unmarshal(b, &body)
-		return resp.StatusCode, body
+		return decodeJSON(t, resp, &body), body
 	}
 	listLen := func(path string) int {
 		_, body := do("GET", path)

--- a/internal/handler/jsonbody_test.go
+++ b/internal/handler/jsonbody_test.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// decodeJSON reads resp's body into v and returns the status code.
+//
+// A 2xx whose body is non-empty and does not decode fails the test. Discarding
+// that error — `_ = json.Unmarshal(b, &v)` — is what let a handler answer 200 with
+// Fiber's bare "OK" body for weeks: the assertions that followed only read the
+// status, so nothing ever looked at the payload, and the helper was more forgiving
+// than any real client (see #1186).
+//
+// An empty 2xx body is not an error: that is a 204, which several endpoints here
+// answer by design. A non-2xx body is not decoded strictly either — an error
+// response may legitimately be plain text, and those tests assert on the status.
+func decodeJSON(t *testing.T, resp *http.Response, v any) int {
+	t.Helper()
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	ok2xx := resp.StatusCode >= 200 && resp.StatusCode < 300
+	if len(b) > 0 {
+		if uerr := json.Unmarshal(b, v); uerr != nil && ok2xx {
+			t.Fatalf("status %d body does not decode as JSON: %v (body %q)", resp.StatusCode, uerr, b)
+		}
+	}
+	return resp.StatusCode
+}

--- a/internal/handler/mailbox_integration_test.go
+++ b/internal/handler/mailbox_integration_test.go
@@ -8,8 +8,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -54,10 +52,8 @@ func TestHostedMailboxEndToEnd(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s %s: %v", method, path, err)
 		}
-		b, _ := io.ReadAll(resp.Body)
 		var body map[string]any
-		_ = json.Unmarshal(b, &body)
-		return resp.StatusCode, body
+		return decodeJSON(t, resp, &body), body
 	}
 
 	// Status: no mailbox yet, feature available.

--- a/internal/handler/match_analysis_integration_test.go
+++ b/internal/handler/match_analysis_integration_test.go
@@ -11,7 +11,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -119,10 +118,8 @@ func TestMatchAnalysisEndpoints(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s fit: %v", method, err)
 		}
-		defer resp.Body.Close()
 		var body fitBody
-		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return resp.StatusCode, body
+		return decodeJSON(t, resp, &body), body
 	}
 
 	appFor := func(store *resume.Store, an *matchanalysis.Analyzer) *fiber.App {
@@ -282,10 +279,8 @@ func TestMatchAnalysisCredits(t *testing.T) {
 		if err != nil {
 			t.Fatalf("POST fit: %v", err)
 		}
-		defer resp.Body.Close()
 		var body fitBody
-		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return resp.StatusCode, body
+		return decodeJSON(t, resp, &body), body
 	}
 	newModel := func() *fitModel { return &fitModel{resp: []string{fitStage1, fitStage2, fitStage3}} }
 
@@ -344,8 +339,7 @@ func TestMatchAnalysisCredits(t *testing.T) {
 				Credits *credits.Balance `json:"credits"`
 			} `json:"data"`
 		}
-		_ = json.NewDecoder(gresp.Body).Decode(&gbody)
-		gresp.Body.Close()
+		decodeJSON(t, gresp, &gbody)
 		if gbody.Data.Credits == nil || gbody.Data.Credits.Remaining != 2 {
 			t.Fatalf("GET credits = %+v, want remaining=2", gbody.Data.Credits)
 		}

--- a/internal/handler/search_test.go
+++ b/internal/handler/search_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -67,8 +66,7 @@ func doGet(t *testing.T, app *fiber.App, target string) (int, map[string]any) {
 		t.Fatalf("request: %v", err)
 	}
 	var body map[string]any
-	_ = json.NewDecoder(resp.Body).Decode(&body)
-	return resp.StatusCode, body
+	return decodeJSON(t, resp, &body), body
 }
 
 func TestSearchJobs_DisabledReturns503(t *testing.T) {

--- a/internal/handler/swipe_test.go
+++ b/internal/handler/swipe_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -47,8 +46,7 @@ func deckGet(t *testing.T, app *fiber.App, iss *auth.Issuer, target string) (int
 		t.Fatalf("request: %v", err)
 	}
 	var body map[string]any
-	_ = json.NewDecoder(resp.Body).Decode(&body)
-	return resp.StatusCode, body
+	return decodeJSON(t, resp, &body), body
 }
 
 func TestSwipeDeck_ExcludesJudgedJobsAndForwardsFilters(t *testing.T) {


### PR DESCRIPTION
Follow-up to #1186, which fixed a handler that answered `200` with Fiber's bare
`OK` body. This closes the hole that let it ship.

## The hole

Seven handler tests hand-rolled the same helper:

```go
b, _ := io.ReadAll(resp.Body)
var body map[string]any
_ = json.Unmarshal(b, &body)      // <- error discarded
return resp.StatusCode, body
```

Callers that assert only on the status never look at the payload, so a success
response could carry anything at all and stay green. The test helper was more
forgiving than any real client — the freehire CLI caught in one call what the
suite had missed for weeks.

## The rule

`decodeJSON` centralises what the CLI already does:

| Response | Behaviour |
|---|---|
| 2xx, non-empty body that will not decode | **fail the test** |
| 2xx, empty body | fine — that is a `204`, answered by design |
| non-2xx | decoded leniently; an error may be plain text and those tests assert on the status |

It lives in an untagged file so both the unit and `-tags=integration` builds see it.

## Proof it bites

Reverting #1186's one-line handler fix locally makes `TestInboxReadSideEndToEnd`
— which passed straight through the original bug — fail:

```
inbox_integration_test.go:73: status 200 body does not decode as JSON:
    invalid character 'O' looking for beginning of value (body "OK")
```

## Scope

Converted the seven `(status, body)` sites: inbox, gmail, mailbox,
match_analysis (×3), swipe, search. The other `_ = json.Decode` sites in the
package decode into a struct the test then asserts on field-by-field, so a
garbage body already fails them; they are left alone.

`gofmt`/`build`/`vet` clean in both build modes; `go test ./...` and
`go test -tags=integration ./internal/handler/ ./internal/db/` green.