### PR TITLE
feat(sources): crawl the a16z talent network only where it isn't a mirror

### DIFF
--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -161,6 +161,9 @@ func All(c HTTPClient) map[string]Source {
 		NewCrelate(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
+		// VC talent network, board = portfolio company slug: listed only for the early-stage
+		// companies that host their application there instead of on an ATS of their own.
+		NewSpeedrun(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.
 		NewTecla(c),
 		NewTeamex(c),

--- a/internal/sources/speedrun.go
+++ b/internal/sources/speedrun.go
@@ -1,0 +1,148 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// speedrunBaseURL is the a16z speedrun talent-network public API root.
+const speedrunBaseURL = "https://speedrun-talent-network.com/api/v1"
+
+// speedrunSourceTag identifies our crawler to the API, which asks every integration to name
+// itself so it can tell agent traffic apart.
+const speedrunSourceTag = "freehire"
+
+// speedrun adapts the a16z speedrun talent-network API. The network is mostly a federating
+// directory — a portfolio company's roles usually live on its own Ashby/Greenhouse/Lever board,
+// which we crawl natively — so the boards listed here are the early-stage companies that have
+// no ATS of their own yet and host their application on the network itself. Those roles exist
+// nowhere else.
+//
+// Board is the company slug. The company endpoint enumerates its live roles (the ?company=
+// filter takes the display name, which makes a poor board key), and each role's body, work
+// arrangement and application target come from its own detail endpoint.
+type speedrun struct {
+	http JSONGetter
+}
+
+// NewSpeedrun builds the speedrun talent-network adapter over the given HTTP client.
+func NewSpeedrun(c JSONGetter) Source { return speedrun{http: c} }
+
+func (speedrun) Provider() string { return "speedrun" }
+
+// speedrunCompany is a company page: the directory record plus the ids of its live roles. Only
+// the ids matter — every field we map comes from the role's own detail payload.
+type speedrunCompany struct {
+	Company struct {
+		Jobs []speedrunListItem `json:"jobs"`
+	} `json:"company"`
+}
+
+// speedrunListItem is one listed role: the id that addresses its detail endpoint.
+type speedrunListItem struct {
+	ID string `json:"id"`
+}
+
+// speedrunJob is one role's detail record. Status flags a role taken down since the listing;
+// description_text is the body as plain text; apply carries the application target, which is
+// the company's own ATS for a federated role and the network's page for a hosted one.
+type speedrunJob struct {
+	Job struct {
+		ID             string `json:"id"`
+		Status         string `json:"status"`
+		URL            string `json:"url"`
+		Title          string `json:"title"`
+		Location       string `json:"location"`
+		WorkplaceType  string `json:"workplace_type"`
+		EmploymentType string `json:"employment_type"`
+		Remote         bool   `json:"remote"`
+		CompSummary    string `json:"comp_summary"`
+		PublishedAt    string `json:"published_at"`
+		Apply          struct {
+			URL string `json:"url"`
+		} `json:"apply"`
+		DescriptionText string `json:"description_text"`
+	} `json:"job"`
+}
+
+func (s speedrun) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	listURL := fmt.Sprintf("%s/companies/%s?source=%s", speedrunBaseURL, url.PathEscape(e.Board), speedrunSourceTag)
+
+	var company speedrunCompany
+	if err := s.http.GetJSON(ctx, listURL, &company); err != nil {
+		return nil, fmt.Errorf("speedrun: company %s: %w", e.Board, err)
+	}
+
+	return fetchDetails(company.Company.Jobs, defaultDetailWorkers, func(it speedrunListItem) (Job, bool) {
+		return s.detail(ctx, e, it.ID)
+	}), nil
+}
+
+// detail fetches one role and maps it, returning ok=false when the id is missing, the fetch
+// fails, or the role has since closed — so the caller drops just that role.
+func (s speedrun) detail(ctx context.Context, e CompanyEntry, id string) (Job, bool) {
+	if id = strings.TrimSpace(id); id == "" {
+		return Job{}, false
+	}
+	var detail speedrunJob
+	jobURL := fmt.Sprintf("%s/jobs/%s?source=%s", speedrunBaseURL, url.PathEscape(id), speedrunSourceTag)
+	if err := s.http.GetJSON(ctx, jobURL, &detail); err != nil {
+		return Job{}, false
+	}
+	j := detail.Job
+	if j.Status == "closed" || strings.TrimSpace(j.Title) == "" {
+		return Job{}, false
+	}
+
+	location := strings.TrimSpace(j.Location)
+	workMode := workplaceTypeMode(j.WorkplaceType)
+	return Job{
+		ExternalID: id,
+		// Where one actually applies: the company's own ATS when the role federates out,
+		// the network's own page when it hosts the application.
+		URL:            firstNonEmpty(strings.TrimSpace(j.Apply.URL), strings.TrimSpace(j.URL)),
+		Title:          strings.TrimSpace(j.Title),
+		Company:        e.Company,
+		Location:       location,
+		Description:    speedrunDescription(j.CompSummary, j.DescriptionText),
+		Remote:         j.Remote || isRemote(location),
+		WorkMode:       workMode,
+		EmploymentType: speedrunEmploymentType(j.EmploymentType),
+		PostedAt:       parseRFC3339OrDate(j.PublishedAt),
+	}, true
+	// Seniority and Category stay unset on purpose: the API's function/seniority labels are
+	// the network's own normalization of the title, not a field the employer filled in, and
+	// an adapter-set facet outranks the pipeline's dictionaries. Its coarse "engineering"
+	// would overwrite a precise backend/ml_ai classification, so the dictionaries decide.
+}
+
+// speedrunDescription renders the body, leading with the compensation band because Job has no
+// salary field. The body is plain text, so it is rebuilt into the paragraphs and lists the
+// renderer expects before sanitizing.
+func speedrunDescription(compSummary, text string) string {
+	var b strings.Builder
+	if c := strings.TrimSpace(compSummary); c != "" {
+		b.WriteString(plainTextToHTML(c))
+	}
+	b.WriteString(plainTextToHTML(text))
+	return sanitizeHTML(b.String())
+}
+
+// speedrunEmploymentType maps the network's employmentType enum onto the freehire vocabulary,
+// returning "" for an unknown/absent value so the description parser decides.
+func speedrunEmploymentType(t string) string {
+	switch t {
+	case "FullTime":
+		return "full_time"
+	case "PartTime":
+		return "part_time"
+	case "Contract", "Temporary":
+		return "contract"
+	case "Intern", "Internship":
+		return "internship"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/speedrun_test.go
+++ b/internal/sources/speedrun_test.go
@@ -1,0 +1,174 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// speedrunCompanyJSON is a company page's payload: the directory record plus the ids of its
+// live roles, which the adapter uses to address each detail endpoint.
+func speedrunCompanyJSON(ids ...string) string {
+	var items []string
+	for _, id := range ids {
+		items = append(items, `{"id":"`+id+`","title":"listed title"}`)
+	}
+	return `{"company":{"slug":"brief","name":"Brief","jobs":[` + strings.Join(items, ",") + `]}}`
+}
+
+// speedrunDetailJSON is one role's detail payload. description_text is plain text — blank
+// lines separate blocks and "- " marks bullets — and apply carries the hosted/federated
+// application target.
+func speedrunDetailJSON(id, status, applyKind, applyURL string) string {
+	return `{"job":{"id":"` + id + `","status":"` + status + `",` +
+		`"url":"https://speedrun-talent-network.com/jobs/product-builder-brief-41dac67e",` +
+		`"title":"Product Builder","company":"Brief","company_slug":"brief","tier":"speedrun",` +
+		`"location":"San Francisco, CA","workplace_type":"OnSite","employment_type":"FullTime",` +
+		`"function":"other","seniority":null,"remote":false,` +
+		`"comp_summary":"$150K – $200K • 0.5% – 1.5%","comp_min":150000,"comp_max":200000,` +
+		`"published_at":"2026-07-15",` +
+		`"apply":{"kind":"` + applyKind + `","url":"` + applyURL + `"},` +
+		`"description_text":"Brief is the context navigator.\n\nWhat you will do\n- Ship product\n- Talk to users"}}`
+}
+
+func TestSpeedrunProvider(t *testing.T) {
+	if got := NewSpeedrun(nil).Provider(); got != "speedrun" {
+		t.Errorf("Provider() = %q, want %q", got, "speedrun")
+	}
+}
+
+func TestSpeedrunFetchCompanyThenDetailAndMaps(t *testing.T) {
+	const id = "41dac67e-5caa-44c5-9e00-8f64b48d7c0a"
+	fake := (&routedHTTP{}).
+		route("/api/v1/jobs/"+id, speedrunDetailJSON(id, "open", "onsite",
+			"https://speedrun-talent-network.com/jobs/product-builder-brief-41dac67e")).
+		route("/api/v1/companies/brief", speedrunCompanyJSON(id))
+
+	jobs, err := NewSpeedrun(fake).Fetch(context.Background(), CompanyEntry{Company: "Brief", Provider: "speedrun", Board: "brief"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != id {
+		t.Errorf("ExternalID = %q, want the role UUID %q", j.ExternalID, id)
+	}
+	if j.URL != "https://speedrun-talent-network.com/jobs/product-builder-brief-41dac67e" {
+		t.Errorf("URL = %q, want the application target", j.URL)
+	}
+	if j.Title != "Product Builder" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Brief" {
+		t.Errorf("Company = %q, want the board display name", j.Company)
+	}
+	if j.Location != "San Francisco, CA" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.WorkMode != "onsite" || j.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want onsite and not remote", j.WorkMode, j.Remote)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want the published_at date", j.PostedAt)
+	}
+	// The structured band has no Job field of its own, so it leads the description.
+	if !strings.Contains(j.Description, "$150K") {
+		t.Errorf("Description drops the compensation band: %q", j.Description)
+	}
+	// Plain text: blank lines are blocks, "- " lines are a list. Rendered raw it would
+	// collapse into one wall of text.
+	if !strings.Contains(j.Description, "<p>Brief is the context navigator.</p>") {
+		t.Errorf("Description lost its paragraph structure: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "<li>Ship product</li>") {
+		t.Errorf("Description lost its bullets: %q", j.Description)
+	}
+	// The platform's own function/seniority labels are its normalization, not a first-party
+	// field, so the pipeline's title dictionaries stay in charge.
+	if j.Category != "" || j.Seniority != "" {
+		t.Errorf("Category=%q Seniority=%q, want both left to the dictionaries", j.Category, j.Seniority)
+	}
+}
+
+func TestSpeedrunPrefersTheFederatedApplyURL(t *testing.T) {
+	const id = "6745c6f2-0b9e-4a18-a721-94b1cc1f136c"
+	fake := (&routedHTTP{}).
+		route("/api/v1/jobs/"+id, speedrunDetailJSON(id, "open", "external",
+			"https://jobs.ashbyhq.com/Bastion/6745c6f2/application")).
+		route("/api/v1/companies/brief", speedrunCompanyJSON(id))
+
+	jobs, err := NewSpeedrun(fake).Fetch(context.Background(), CompanyEntry{Company: "Brief", Board: "brief"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].URL != "https://jobs.ashbyhq.com/Bastion/6745c6f2/application" {
+		t.Fatalf("got %v, want the role to point at where one actually applies", jobs)
+	}
+}
+
+func TestSpeedrunDropsClosedAndUnreachableRoles(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/api/v1/jobs/live", speedrunDetailJSON("live", "open", "onsite", "https://speedrun-talent-network.com/jobs/live")).
+		route("/api/v1/jobs/gone", speedrunDetailJSON("gone", "closed", "onsite", "https://speedrun-talent-network.com/jobs/gone")).
+		// "vanished" has no detail route at all → its fetch fails.
+		route("/api/v1/companies/brief", speedrunCompanyJSON("live", "gone", "vanished"))
+
+	jobs, err := NewSpeedrun(fake).Fetch(context.Background(), CompanyEntry{Company: "Brief", Board: "brief"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "live" {
+		t.Fatalf("got %v, want only the open, reachable role", jobs)
+	}
+}
+
+func TestSpeedrunUnknownCompanyIsABoardFailure(t *testing.T) {
+	fake := &routedHTTP{} // no routes: the company endpoint 404s
+	if _, err := NewSpeedrun(fake).Fetch(context.Background(), CompanyEntry{Company: "Brief", Board: "brief"}); err == nil {
+		t.Fatal("Fetch: want an error when the company page cannot be read, got nil")
+	}
+}
+
+func TestSpeedrunEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"FullTime": "full_time", "PartTime": "part_time",
+		"Contract": "contract", "Temporary": "contract",
+		"Intern": "internship", "": "", "Seasonal": "",
+	}
+	for in, want := range cases {
+		if got := speedrunEmploymentType(in); got != want {
+			t.Errorf("speedrunEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSpeedrunBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/speedrun.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/speedrun.yml fails validation: %v", err)
+	}
+}
+
+func TestSpeedrunRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["speedrun"]
+	if !ok {
+		t.Fatal("All() missing provider speedrun")
+	}
+	if s.Provider() != "speedrun" {
+		t.Errorf("All()[speedrun].Provider() = %q", s.Provider())
+	}
+	// Board-based (one board per portfolio company): it belongs in the source facet.
+	if !slices.Contains(FilterableProviders(), "speedrun") {
+		t.Error("FilterableProviders() should include board-based speedrun")
+	}
+}

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7618,3 +7618,7 @@
   board: method.security
 - company: Orchestra Bio
   board: orchestra-bio
+- company: Walrus Foundation
+  board: walrus
+- company: XMTP Labs
+  board: XMTP Labs

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4395,3 +4395,5 @@
 # a16z Speedrun talent-network (harvested 2026-07)
 - company: Management Leadership for Tomorrow
   board: ml4t
+- company: VeeFriends
+  board: VeeFriends

--- a/sources/speedrun.yml
+++ b/sources/speedrun.yml
@@ -1,0 +1,35 @@
+# speedrun talent-network boards (a16z). Provider is the filename; each entry is company + board.
+# board = the company slug on speedrun-talent-network.com (see internal/sources/speedrun.go).
+#
+# The network federates: nearly every portfolio company's roles live on its own Ashby /
+# Greenhouse / Lever board, which we already crawl natively — listing those here would only
+# duplicate them. Listed below are the early-stage companies that host their application on
+# the network itself, so their roles reach us nowhere else. When one of them adopts a real
+# ATS, move it to that provider's board file.
+#
+# A hosted application is not proof we lack the company: Brief (briefhq) and Bead AI (gem)
+# apply on the network yet run a board we already crawl. Check the catalogue by company, not
+# just the apply URL, before adding an entry here.
+
+- company: Cascade
+  board: cascade
+- company: ElectroKare
+  board: electrokare
+- company: Infragrid
+  board: infragrid
+- company: Lekondo
+  board: lekondo
+- company: Maestro
+  board: maestro
+- company: Primitive Labs
+  board: primitive-labs
+- company: Snag
+  board: snag
+- company: Sourcerer AI
+  board: sourcerer-ai
+- company: Taya
+  board: taya
+- company: Tenera
+  board: tenera
+- company: URSA Mining
+  board: ursa-mining


### PR DESCRIPTION
## What

`speedrun-talent-network.com` (the a16z / Speedrun portfolio job board) now exposes a **public read-only JSON API** — `/api/v1/jobs`, `/companies`, `/collections`, per-role detail with the body, the comp band and the application target, plus `jobs.rss` and `openapi.json`. When it was harvested in July it was a Cloudflare-fronted Astro site with no API, and we deliberately shipped no adapter (#1070).

The API changed the cost, not the conclusion. A fresh coverage sweep — one apply-URL mined per company, 315 companies, matched against `sources/*.yml`:

| ATS behind the listing | companies | not in our board files |
|---|---:|---:|
| Ashby | 217 | 3 |
| Greenhouse | 63 | 0 |
| Lever | 22 | 1 |
| none — application hosted on the network | 13 | 13 |

**302 of 315 companies are already crawled natively.** Ingesting the network's 10,293 roles wholesale would be ~99% duplicates of boards we already hold. So this PR takes only the two slices that are genuinely new.

## The adapter — `internal/sources/speedrun.go`

`board` = the company slug. Listed **only** for the 13 early-stage companies that host their application on the network itself; their 16 roles reach us through no other source. All 13 are Speedrun-cohort companies — this is the early-discovery seam the July harvest called out: a cohort startup surfaces here before it adopts an ATS, and moves to that provider's board file when it does.

- Reads `/api/v1/companies/{slug}` for the live role ids, then each role's `/api/v1/jobs/{id}` for the body and apply URL. The `?company=` filter keys on the **display name** (`Brief`, not `brief`), which makes a poor board id — hence the company endpoint.
- `URL` is the application target: the company's own ATS when the role federates out, the network's page when it hosts it.
- `description_text` is plain text, so it goes through `plainTextToHTML` (blank lines → paragraphs, `- ` → `<ul>`) before `sanitizeHTML`; rendered raw it would collapse into one wall of text.
- The comp band leads the description, the way `hhru.salaryParagraph` does — `Job` has no salary field.
- `Seniority` and `Category` stay **unset on purpose**. The API's `function`/`seniority` labels are the network's own normalization of the title, not a field an employer filled in, and an adapter-set facet outranks the pipeline's dictionaries — a coarse `engineering` would overwrite a precise `backend`/`ml_ai` classification.
- A role the detail endpoint reports `status: "closed"`, or whose detail fetch fails, is dropped; an unreadable company page fails the board.

## The four missing native boards

Found by the sweep, each validated live against its own ATS API and through our own adapter: `Sui Foundation`, `walrus`, `XMTP Labs` (ashby) and `VeeFriends` (lever). Two carry a space in the board id — 36 existing ashby boards already do, and Go escapes the path.

## Verification

- `go test ./...` green; `go vet`, `gofmt` clean.
- Unit tests cover the two-phase fetch, the federated-vs-hosted apply URL, closed/unreachable roles, the employment-type enum, registry + facet registration, and that `sources/speedrun.yml` parses and validates (mutation-checked: a bogus provider in the file does fail it).
- Live smoke against the real API through the registry: all 13 boards resolve, 16 roles, every one with a non-empty description; all 4 native boards resolve through `ashby`/`lever`.

## Ops

`sources/speedrun.yml` is a new board file, so it needs its own ingest cron entry on prod (one schedule per file) — it is not picked up by any existing unit.