### PR TITLE
fix(sources): drop the VeeFriends lever board — it only buys a duplicate

### DIFF
--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4395,5 +4395,3 @@
 # a16z Speedrun talent-network (harvested 2026-07)
 - company: Management Leadership for Tomorrow
   board: ml4t
-- company: VeeFriends
-  board: VeeFriends


### PR DESCRIPTION
Follow-up to #1188, from a dupe audit against the live catalogue.

The lever `VeeFriends` board was added for **provenance, not coverage** — its single posting is already in the catalogue as a `jobstash` mirror of that very Lever URL. The company's live ATS is `rippling` (`veefriends-llc`, 10 roles), untouched by this.

That provenance is not worth what it costs. The aggregator suppression pass (`internal/db/queries/jobs.sql`) has three match paths — exact normalized title, entity-decoded + suffix-stripped, and word-subset containment — and none of them stem plurals:

| | normalized title |
|---|---|
| lever | `livestream hosts live streamer live commerce multiple temporary part time` |
| jobstash | `livestream host live streamer live commerce temporary part time` |

`host` vs `hosts`: not equal, and not a subset. All three paths miss, so the pair would have stayed **two visible rows for one job**.

Verified on prod before deciding: the other 14 postings from #1188 have no twin anywhere in the catalogue (checked by `company_slug` join across all sources, and by `role_fingerprint`). Same-company hits were all genuinely distinct roles — Infragrid and Lekondo each list two, and the lever posting overlaps none of rippling's ten.

Zero postings lost: the jobstash copy stays. The already-ingested lever row is closed on prod by hand — with its board gone from the file, the ingest sweep (scoped to the crawled companies) would never reach it.

Not done here: teaching the dedup to stem plurals would fix this case and every one like it across the catalogue, but it risks over-merging distinct roles and wants its own tests. Left as a separate change.