### PR TITLE
fix(mailmatch): an ATS relay's display name is not the employer

### DIFF
--- a/docs/agents/mail-stack.md
+++ b/docs/agents/mail-stack.md
@@ -45,6 +45,15 @@ the point: it is the tier that costs us nothing. See the `external` bullets belo
   (`ashbyhq.com`, `greenhouse-mail.io`, …), not from employer domains. `mailmatch` matches on
   thread continuity and the company name carried in the sender *name* / subject. A
   domain-based shortcut looks obvious and is wrong.
+- **The sender *name* is a relay too, and `atsPseudoNames` is the only thing saying so.**
+  The rule above bans the domain but not the display name, and relays sign mail with their
+  own brand: a message reading `From: Workable` / `Subject: Thanks for applying to Derq` is
+  about Derq. Because `ExtractCompany` prefers the sender name over the subject, a brand
+  missing from that list wins over the employer the subject names. `workable` was missing,
+  and one catalog company called Workable auto-collected 23 acknowledgements belonging to 23
+  other employers — an application that then could never look silent, while the real ones
+  lost their mail. Adding a brand there is deliberately lossy (that brand's own mail stops
+  auto-linking, degrading to a suggestion) and that trade is always worth taking.
 - **Read the body via `readableBody(text, html)`, never `body_text` alone.** Many ATS senders
   (Gem, Ashby, Greenhouse) send **HTML-only** mail with no `text/plain` part, so `body_text`
   is empty and a classifier fed only that judges from the subject line — which once turned a

--- a/internal/mailmatch/mailmatch.go
+++ b/internal/mailmatch/mailmatch.go
@@ -14,11 +14,32 @@ import (
 // atsPseudoNames are ATS platform brand names that surface where a company name
 // is expected ("Thank you for applying to Greenhouse!", "Your Workday
 // Application"). They are not employers and must never be treated as a company.
+//
+// Blocking a name here is deliberately lossy: some of these brands are also real
+// employers people apply to, and their own mail will no longer auto-link. That
+// asymmetry is the point. A missed auto-link degrades to an LLM suggestion the
+// caller confirms — a moment's work. A wrong auto-link silently hands one
+// application everyone else's mail, and the damage compounds: on a live mailbox
+// `workable` was absent from this list, and one catalog company named Workable
+// collected 23 acknowledgements meant for 23 other employers, leaving it
+// permanently unable to look silent.
+//
+// The list is sender *display names*, not the provider slugs in sources/ — a new
+// board file does not automatically belong here, and a brand that never appears
+// as a display name does not need to be. When adding an ATS board, ask whether
+// its relay signs mail with its own brand.
 var atsPseudoNames = map[string]bool{
 	"greenhouse": true, "workday": true, "myworkday": true, "lever": true,
 	"ashby": true, "smartrecruiters": true, "teamtailor": true, "recruitee": true,
 	"icims": true, "gem": true, "eightfold": true, "rippling": true,
-	"bamboohr": true, "wellfound": true,
+	"bamboohr": true, "wellfound": true, "workable": true, "jobvite": true,
+	"taleo": true, "breezy": true, "breezyhr": true, "jazzhr": true,
+	"comeet": true, "personio": true, "pinpoint": true, "freshteam": true,
+	"zoho recruit": true, "zohorecruit": true, "manatal": true, "traffit": true,
+	"phenom": true, "avature": true, "cornerstone": true, "successfactors": true,
+	"bullhorn": true, "jobylon": true, "loxo": true, "neogov": true,
+	"softgarden": true, "talentlyft": true, "trakstar": true, "applicantpro": true,
+	"catsone": true, "crelate": true, "jobscore": true, "hireology": true,
 }
 
 // nameSuffixes are the recruiting-team suffixes ATS "from" names carry.

--- a/internal/mailmatch/mailmatch_test.go
+++ b/internal/mailmatch/mailmatch_test.go
@@ -20,6 +20,16 @@ func TestExtractCompany(t *testing.T) {
 		{"ats pseudo-name from subject dropped", "", "Thank you for applying to Greenhouse!", ""},
 		{"ats pseudo-name your-x-application dropped", "", "Your Greenhouse Application", ""},
 		{"nothing extractable", "", "Ilya, we've received your resume", ""},
+		// A relay whose display name is the ATS brand must not shadow the employer
+		// the subject names. Observed on a live mailbox: 23 acknowledgements from
+		// "Workable", each about a different employer, all resolved to the one
+		// catalog company literally called Workable — so one application collected
+		// everyone else's mail and could never look silent again.
+		{"ats relay display name falls through to the subject",
+			"Workable", "Thanks for applying to Derq", "derq"},
+		{"ats relay display name alone extracts nothing", "Workable", "", ""},
+		{"employer named in both still wins",
+			"Sardine Hiring Team", "Thanks for applying to Sardine", "sardine"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## The bug

`mailmatch` refuses to match on the sender *domain* — mail arrives from relay domains, not employer ones. It did not extend that suspicion to the display **name**, and relays sign mail with their own brand.

`atsPseudoNames` exists for exactly this and held `greenhouse`, `workday`, `lever` and eleven more. It did not hold `workable`. Since `ExtractCompany` prefers the sender name over the subject, every one of these resolved to the wrong employer:

```
From:    Workable
Subject: Thanks for applying to Derq      →  matched "workable", not "derq"
```

Found while measuring silence for the parked ghosting change, on a live mailbox: **23 acknowledgements belonging to 23 different employers**, all auto-linked (`link_source = 'auto'`) to the single catalog company named Workable.

## Why it matters more than it looks

That application received a fresh message most days, so its last-activity clock reset constantly — it could **never** register as silent. A feature whose whole job is to notice silence would have been permanently blind to it, on the one application that looked healthiest.

The applications the mail was really about lost their acknowledgements. That part is mild: an acknowledgement lands within hours of applying, so it barely moves `GREATEST(applied_at, …)`.

## The fix

Add the brand — and note this does not merely suppress the wrong link. With the sender name blanked, extraction falls through to the subject and produces the **right** one. The test pins that.

The list now covers the ATS brands we ingest from that sign mail under their own name. Blocking a brand is deliberately lossy: that brand's own recruiting mail stops auto-linking and degrades to an LLM suggestion the caller confirms. A missed auto-link costs a click; a wrong one compounds daily.

Scoped to sender display names, not the provider slugs in `sources/` — a new board file does not automatically belong here.

## Verification

`gofmt`, `go build`, `go vet`, full unit suite green. Three new cases in `TestExtractCompany`; the eleven existing ones still pass.

Prod data cleanup of the 23 stale links is a separate step, since the code fix alone does not unlink what is already linked.