### PR TITLE
feat(tracking): derive how long an application has been waiting

### DIFF
--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -147,7 +147,33 @@ SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.
           FROM job_reminders r
          WHERE r.user_id = uj.user_id
            AND r.job_id = jobs.id
-           AND r.status = 'pending') AS reminder_fire_at
+           AND r.status = 'pending') AS reminder_fire_at,
+       -- last_activity_at is when this application last moved: its apply date, or
+       -- the newest message linked to it when that is later. GREATEST ignores a
+       -- NULL aggregate, so an application with no mail falls back to applied_at
+       -- rather than reporting nothing — a clock that only starts once mail
+       -- arrives would never fire on the applications ignored outright, which are
+       -- the ones worth reporting. NULL on a row that is not an application: a job
+       -- merely viewed or saved is not waiting on anyone.
+       (CASE WHEN uj.applied_at IS NOT NULL THEN
+          GREATEST(uj.applied_at,
+                   (SELECT max(e.received_at)
+                      FROM emails e
+                     WHERE e.user_id = uj.user_id
+                       AND e.job_id = jobs.id
+                       AND e.deleted_at IS NULL))
+        END)::timestamptz AS last_activity_at,
+       -- has_pending_suggestion is mail the matcher believes belongs to this
+       -- application that the caller has neither confirmed nor rejected. Such mail
+       -- contradicts a claim that nobody replied, so the reader downgrades a
+       -- silence verdict to a question rather than asserting it.
+       (uj.applied_at IS NOT NULL AND EXISTS (
+          SELECT 1
+            FROM emails e
+           WHERE e.user_id = uj.user_id
+             AND e.suggested_job_id = jobs.id
+             AND e.job_id IS NULL
+             AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -305,7 +305,33 @@ SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.compan
           FROM job_reminders r
          WHERE r.user_id = uj.user_id
            AND r.job_id = jobs.id
-           AND r.status = 'pending') AS reminder_fire_at
+           AND r.status = 'pending') AS reminder_fire_at,
+       -- last_activity_at is when this application last moved: its apply date, or
+       -- the newest message linked to it when that is later. GREATEST ignores a
+       -- NULL aggregate, so an application with no mail falls back to applied_at
+       -- rather than reporting nothing — a clock that only starts once mail
+       -- arrives would never fire on the applications ignored outright, which are
+       -- the ones worth reporting. NULL on a row that is not an application: a job
+       -- merely viewed or saved is not waiting on anyone.
+       (CASE WHEN uj.applied_at IS NOT NULL THEN
+          GREATEST(uj.applied_at,
+                   (SELECT max(e.received_at)
+                      FROM emails e
+                     WHERE e.user_id = uj.user_id
+                       AND e.job_id = jobs.id
+                       AND e.deleted_at IS NULL))
+        END)::timestamptz AS last_activity_at,
+       -- has_pending_suggestion is mail the matcher believes belongs to this
+       -- application that the caller has neither confirmed nor rejected. Such mail
+       -- contradicts a claim that nobody replied, so the reader downgrades a
+       -- silence verdict to a question rather than asserting it.
+       (uj.applied_at IS NOT NULL AND EXISTS (
+          SELECT 1
+            FROM emails e
+           WHERE e.user_id = uj.user_id
+             AND e.suggested_job_id = jobs.id
+             AND e.job_id IS NULL
+             AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -335,14 +361,16 @@ type ListUserJobsParams struct {
 }
 
 type ListUserJobsRow struct {
-	Job            Job                `json:"job"`
-	ViewedAt       pgtype.Timestamptz `json:"viewed_at"`
-	SavedAt        pgtype.Timestamptz `json:"saved_at"`
-	AppliedAt      pgtype.Timestamptz `json:"applied_at"`
-	Stage          pgtype.Text        `json:"stage"`
-	Notes          pgtype.Text        `json:"notes"`
-	EmailCount     int64              `json:"email_count"`
-	ReminderFireAt pgtype.Timestamptz `json:"reminder_fire_at"`
+	Job                  Job                `json:"job"`
+	ViewedAt             pgtype.Timestamptz `json:"viewed_at"`
+	SavedAt              pgtype.Timestamptz `json:"saved_at"`
+	AppliedAt            pgtype.Timestamptz `json:"applied_at"`
+	Stage                pgtype.Text        `json:"stage"`
+	Notes                pgtype.Text        `json:"notes"`
+	EmailCount           int64              `json:"email_count"`
+	ReminderFireAt       pgtype.Timestamptz `json:"reminder_fire_at"`
+	LastActivityAt       pgtype.Timestamptz `json:"last_activity_at"`
+	HasPendingSuggestion bool               `json:"has_pending_suggestion"`
 }
 
 // A user's job interactions joined with the job rows. Each subset is ordered by
@@ -429,6 +457,8 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Notes,
 			&i.EmailCount,
 			&i.ReminderFireAt,
+			&i.LastActivityAt,
+			&i.HasPendingSuggestion,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/user_jobs_silence_integration_test.go
+++ b/internal/db/user_jobs_silence_integration_test.go
@@ -1,0 +1,216 @@
+//go:build integration
+
+// Integration tests for the silence inputs the tracking listing derives: an
+// application's last activity (its apply date, or the newest linked message when
+// that is later) and whether any unconfirmed suggestion points at it. Both are
+// SQL — a GREATEST over a correlated aggregate, and an EXISTS — so they can only
+// be verified against a real Postgres. Run with:
+// go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// listOne returns the caller's single tracked row.
+func listOne(t *testing.T, q *Queries, uid int64) ListUserJobsRow {
+	t.Helper()
+	rows, err := q.ListUserJobs(context.Background(), ListUserJobsParams{
+		UserID: uid, Filter: "all", Limit: 10, Offset: 0,
+	})
+	if err != nil {
+		t.Fatalf("ListUserJobs: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("listing returned %d rows, want 1", len(rows))
+	}
+	return rows[0]
+}
+
+// TestLastActivityFallsBackToTheApplyDate asserts an application with no linked
+// mail is dated by its apply date rather than reporting nothing — a silence
+// clock that only starts once mail arrives would never fire on the applications
+// that were ignored outright, which are exactly the ones worth reporting.
+func TestLastActivityFallsBackToTheApplyDate(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	uid := seedAPIKeyUser(t, pool, "silence-nomail@example.test")
+	jid := insertJob(t, pool, "silence-1")
+	applied := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
+		UserID: uid, JobID: jid, At: pgtype.Timestamptz{Time: applied, Valid: true},
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	row := listOne(t, q, uid)
+	if !row.LastActivityAt.Valid {
+		t.Fatal("last_activity_at is NULL, want the apply date")
+	}
+	if got := row.LastActivityAt.Time.UTC().Truncate(time.Second); !got.Equal(applied) {
+		t.Errorf("last_activity_at = %v, want the apply date %v", got, applied)
+	}
+	if row.HasPendingSuggestion {
+		t.Error("has_pending_suggestion = true with no mail at all")
+	}
+}
+
+// TestLastActivityMovesForwardWithMail asserts a linked message later than the
+// apply date becomes the last activity, and that mail older than the apply date
+// does not drag it backwards.
+func TestLastActivityMovesForwardWithMail(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	uid := seedAPIKeyUser(t, pool, "silence-mail@example.test")
+	jid := insertJob(t, pool, "silence-2")
+	applied := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
+		UserID: uid, JobID: jid, At: pgtype.Timestamptz{Time: applied, Valid: true},
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	older := applied.Add(-5 * 24 * time.Hour)
+	newer := applied.Add(9 * 24 * time.Hour)
+	for _, m := range []struct {
+		ext string
+		at  time.Time
+	}{{"sil-old", older}, {"sil-new", newer}} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, job_id)
+			 VALUES ($1,'hosted',$2,'s','b',$3,$4)`, uid, m.ext, m.at, jid); err != nil {
+			t.Fatalf("seed mail %s: %v", m.ext, err)
+		}
+	}
+
+	row := listOne(t, q, uid)
+	if got := row.LastActivityAt.Time.UTC().Truncate(time.Second); !got.Equal(newer) {
+		t.Errorf("last_activity_at = %v, want the newest linked message %v", got, newer)
+	}
+}
+
+// TestLastActivityIgnoresUnlinkedAndDeletedMail asserts the aggregate counts only
+// mail actually attached to this application: a pending suggestion is not
+// activity (the whole point of the confirm step), another application's mail is
+// not activity, and soft-deleted mail is gone.
+func TestLastActivityIgnoresUnlinkedAndDeletedMail(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	uid := seedAPIKeyUser(t, pool, "silence-ignore@example.test")
+	jid := insertJob(t, pool, "silence-3")
+	other := insertJob(t, pool, "silence-3-other")
+	applied := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
+		UserID: uid, JobID: jid, At: pgtype.Timestamptz{Time: applied, Valid: true},
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	recent := time.Now().Add(-time.Hour)
+
+	// A suggestion awaiting confirmation.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, suggested_job_id)
+		 VALUES ($1,'hosted','sil-sug','s','b',$2,$3)`, uid, recent, jid); err != nil {
+		t.Fatalf("seed suggestion: %v", err)
+	}
+	// Mail linked to a different application.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, job_id)
+		 VALUES ($1,'hosted','sil-other','s','b',$2,$3)`, uid, recent, other); err != nil {
+		t.Fatalf("seed other-job mail: %v", err)
+	}
+	// Linked but soft-deleted.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, job_id, deleted_at)
+		 VALUES ($1,'hosted','sil-del','s','b',$2,$3, now())`, uid, recent, jid); err != nil {
+		t.Fatalf("seed deleted mail: %v", err)
+	}
+
+	rows, err := q.ListUserJobs(ctx, ListUserJobsParams{UserID: uid, Filter: "applied", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListUserJobs: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("applied listing returned %d rows, want 1", len(rows))
+	}
+	row := rows[0]
+	if got := row.LastActivityAt.Time.UTC().Truncate(time.Second); !got.Equal(applied) {
+		t.Errorf("last_activity_at = %v, want the apply date %v — none of that mail is activity", got, applied)
+	}
+	if !row.HasPendingSuggestion {
+		t.Error("has_pending_suggestion = false, want true — a suggestion is pending on this application")
+	}
+}
+
+// TestPendingSuggestionClearsOnceConfirmed asserts confirming the link both
+// removes the pending flag and turns that message into activity.
+func TestPendingSuggestionClearsOnceConfirmed(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	uid := seedAPIKeyUser(t, pool, "silence-confirm@example.test")
+	jid := insertJob(t, pool, "silence-4")
+	applied := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
+		UserID: uid, JobID: jid, At: pgtype.Timestamptz{Time: applied, Valid: true},
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	recent := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, suggested_job_id)
+		 VALUES ($1,'hosted','sil-c','s','b',$2,$3)`, uid, recent, jid); err != nil {
+		t.Fatalf("seed suggestion: %v", err)
+	}
+	if !listOne(t, q, uid).HasPendingSuggestion {
+		t.Fatal("suggestion not reported as pending before confirmation")
+	}
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE emails SET job_id = suggested_job_id, suggested_job_id = NULL, link_source = 'manual'
+		  WHERE user_id = $1 AND external_id = 'sil-c'`, uid); err != nil {
+		t.Fatalf("confirm: %v", err)
+	}
+
+	row := listOne(t, q, uid)
+	if row.HasPendingSuggestion {
+		t.Error("has_pending_suggestion is still true after confirming")
+	}
+	if got := row.LastActivityAt.Time.UTC().Truncate(time.Second); !got.Equal(recent) {
+		t.Errorf("last_activity_at = %v, want the now-linked message %v", got, recent)
+	}
+}
+
+// TestLastActivityNullForNonApplications asserts a job merely viewed or saved
+// reports no last activity: it is not waiting on anyone, and a clock on it would
+// invite the UI to report a silence nobody is owed.
+func TestLastActivityNullForNonApplications(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	uid := seedAPIKeyUser(t, pool, "silence-saved@example.test")
+	jid := insertJob(t, pool, "silence-5")
+	if _, err := q.SaveJob(ctx, SaveJobParams{UserID: uid, JobID: jid}); err != nil {
+		t.Fatalf("SaveJob: %v", err)
+	}
+
+	row := listOne(t, q, uid)
+	if row.LastActivityAt.Valid {
+		t.Errorf("last_activity_at = %v on a saved-only job, want NULL", row.LastActivityAt.Time)
+	}
+	if row.HasPendingSuggestion {
+		t.Error("has_pending_suggestion = true on a saved-only job")
+	}
+}

--- a/internal/db/user_jobs_silence_integration_test.go
+++ b/internal/db/user_jobs_silence_integration_test.go
@@ -14,21 +14,71 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// listOne returns the caller's single tracked row.
-func listOne(t *testing.T, q *Queries, uid int64) ListUserJobsRow {
+// applyAt records an application dated at, the state every test here starts from.
+func applyAt(t *testing.T, q *Queries, uid, jobID int64, at time.Time) {
+	t.Helper()
+	if _, err := q.MarkJobApplied(context.Background(), MarkJobAppliedParams{
+		UserID: uid, JobID: jobID, At: pgtype.Timestamptz{Time: at, Valid: true},
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+}
+
+// mail is one seeded message. A zero JobID or SuggestedID leaves that column
+// NULL, which is how the three link states are expressed: linked, suggested but
+// unconfirmed, or neither.
+type mail struct {
+	ExternalID  string
+	At          time.Time
+	JobID       int64
+	SuggestedID int64
+	Deleted     bool
+}
+
+func seedMail(t *testing.T, pool *pgxpool.Pool, uid int64, m mail) {
+	t.Helper()
+	nullable := func(id int64) any {
+		if id == 0 {
+			return nil
+		}
+		return id
+	}
+	var deletedAt any
+	if m.Deleted {
+		deletedAt = time.Now()
+	}
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO emails (user_id, source, external_id, subject, body_text,
+		                     received_at, job_id, suggested_job_id, deleted_at)
+		 VALUES ($1, 'hosted', $2, 'subject', 'body', $3, $4, $5, $6)`,
+		uid, m.ExternalID, m.At, nullable(m.JobID), nullable(m.SuggestedID), deletedAt)
+	if err != nil {
+		t.Fatalf("seed mail %s: %v", m.ExternalID, err)
+	}
+}
+
+// trackedRow returns the caller's single tracked row under the given filter.
+func trackedRow(t *testing.T, q *Queries, uid int64, filter string) ListUserJobsRow {
 	t.Helper()
 	rows, err := q.ListUserJobs(context.Background(), ListUserJobsParams{
-		UserID: uid, Filter: "all", Limit: 10, Offset: 0,
+		UserID: uid, Filter: filter, Limit: 10,
 	})
 	if err != nil {
-		t.Fatalf("ListUserJobs: %v", err)
+		t.Fatalf("ListUserJobs(%s): %v", filter, err)
 	}
 	if len(rows) != 1 {
 		t.Fatalf("listing returned %d rows, want 1", len(rows))
 	}
 	return rows[0]
+}
+
+// sameSecond compares a returned timestamp against an expected one, which the
+// tests build at second precision.
+func sameSecond(got pgtype.Timestamptz, want time.Time) bool {
+	return got.Valid && got.Time.UTC().Truncate(time.Second).Equal(want)
 }
 
 // TestLastActivityFallsBackToTheApplyDate asserts an application with no linked
@@ -38,23 +88,15 @@ func listOne(t *testing.T, q *Queries, uid int64) ListUserJobsRow {
 func TestLastActivityFallsBackToTheApplyDate(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
-	ctx := context.Background()
 
 	uid := seedAPIKeyUser(t, pool, "silence-nomail@example.test")
 	jid := insertJob(t, pool, "silence-1")
 	applied := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
-	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
-		UserID: uid, JobID: jid, At: pgtype.Timestamptz{Time: applied, Valid: true},
-	}); err != nil {
-		t.Fatalf("apply: %v", err)
-	}
+	applyAt(t, q, uid, jid, applied)
 
-	row := listOne(t, q, uid)
-	if !row.LastActivityAt.Valid {
-		t.Fatal("last_activity_at is NULL, want the apply date")
-	}
-	if got := row.LastActivityAt.Time.UTC().Truncate(time.Second); !got.Equal(applied) {
-		t.Errorf("last_activity_at = %v, want the apply date %v", got, applied)
+	row := trackedRow(t, q, uid, "all")
+	if !sameSecond(row.LastActivityAt, applied) {
+		t.Errorf("last_activity_at = %v, want the apply date %v", row.LastActivityAt, applied)
 	}
 	if row.HasPendingSuggestion {
 		t.Error("has_pending_suggestion = true with no mail at all")
@@ -67,33 +109,18 @@ func TestLastActivityFallsBackToTheApplyDate(t *testing.T) {
 func TestLastActivityMovesForwardWithMail(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
-	ctx := context.Background()
 
 	uid := seedAPIKeyUser(t, pool, "silence-mail@example.test")
 	jid := insertJob(t, pool, "silence-2")
 	applied := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
-	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
-		UserID: uid, JobID: jid, At: pgtype.Timestamptz{Time: applied, Valid: true},
-	}); err != nil {
-		t.Fatalf("apply: %v", err)
-	}
+	applyAt(t, q, uid, jid, applied)
 
-	older := applied.Add(-5 * 24 * time.Hour)
 	newer := applied.Add(9 * 24 * time.Hour)
-	for _, m := range []struct {
-		ext string
-		at  time.Time
-	}{{"sil-old", older}, {"sil-new", newer}} {
-		if _, err := pool.Exec(ctx,
-			`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, job_id)
-			 VALUES ($1,'hosted',$2,'s','b',$3,$4)`, uid, m.ext, m.at, jid); err != nil {
-			t.Fatalf("seed mail %s: %v", m.ext, err)
-		}
-	}
+	seedMail(t, pool, uid, mail{ExternalID: "sil-old", At: applied.Add(-5 * 24 * time.Hour), JobID: jid})
+	seedMail(t, pool, uid, mail{ExternalID: "sil-new", At: newer, JobID: jid})
 
-	row := listOne(t, q, uid)
-	if got := row.LastActivityAt.Time.UTC().Truncate(time.Second); !got.Equal(newer) {
-		t.Errorf("last_activity_at = %v, want the newest linked message %v", got, newer)
+	if row := trackedRow(t, q, uid, "all"); !sameSecond(row.LastActivityAt, newer) {
+		t.Errorf("last_activity_at = %v, want the newest linked message %v", row.LastActivityAt, newer)
 	}
 }
 
@@ -104,48 +131,22 @@ func TestLastActivityMovesForwardWithMail(t *testing.T) {
 func TestLastActivityIgnoresUnlinkedAndDeletedMail(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
-	ctx := context.Background()
 
 	uid := seedAPIKeyUser(t, pool, "silence-ignore@example.test")
 	jid := insertJob(t, pool, "silence-3")
 	other := insertJob(t, pool, "silence-3-other")
 	applied := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
-	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
-		UserID: uid, JobID: jid, At: pgtype.Timestamptz{Time: applied, Valid: true},
-	}); err != nil {
-		t.Fatalf("apply: %v", err)
-	}
+	applyAt(t, q, uid, jid, applied)
+
 	recent := time.Now().Add(-time.Hour)
+	seedMail(t, pool, uid, mail{ExternalID: "sil-sug", At: recent, SuggestedID: jid})
+	seedMail(t, pool, uid, mail{ExternalID: "sil-other", At: recent, JobID: other})
+	seedMail(t, pool, uid, mail{ExternalID: "sil-del", At: recent, JobID: jid, Deleted: true})
 
-	// A suggestion awaiting confirmation.
-	if _, err := pool.Exec(ctx,
-		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, suggested_job_id)
-		 VALUES ($1,'hosted','sil-sug','s','b',$2,$3)`, uid, recent, jid); err != nil {
-		t.Fatalf("seed suggestion: %v", err)
-	}
-	// Mail linked to a different application.
-	if _, err := pool.Exec(ctx,
-		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, job_id)
-		 VALUES ($1,'hosted','sil-other','s','b',$2,$3)`, uid, recent, other); err != nil {
-		t.Fatalf("seed other-job mail: %v", err)
-	}
-	// Linked but soft-deleted.
-	if _, err := pool.Exec(ctx,
-		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, job_id, deleted_at)
-		 VALUES ($1,'hosted','sil-del','s','b',$2,$3, now())`, uid, recent, jid); err != nil {
-		t.Fatalf("seed deleted mail: %v", err)
-	}
-
-	rows, err := q.ListUserJobs(ctx, ListUserJobsParams{UserID: uid, Filter: "applied", Limit: 10})
-	if err != nil {
-		t.Fatalf("ListUserJobs: %v", err)
-	}
-	if len(rows) != 1 {
-		t.Fatalf("applied listing returned %d rows, want 1", len(rows))
-	}
-	row := rows[0]
-	if got := row.LastActivityAt.Time.UTC().Truncate(time.Second); !got.Equal(applied) {
-		t.Errorf("last_activity_at = %v, want the apply date %v — none of that mail is activity", got, applied)
+	row := trackedRow(t, q, uid, "applied")
+	if !sameSecond(row.LastActivityAt, applied) {
+		t.Errorf("last_activity_at = %v, want the apply date %v — none of that mail is activity",
+			row.LastActivityAt, applied)
 	}
 	if !row.HasPendingSuggestion {
 		t.Error("has_pending_suggestion = false, want true — a suggestion is pending on this application")
@@ -161,19 +162,11 @@ func TestPendingSuggestionClearsOnceConfirmed(t *testing.T) {
 
 	uid := seedAPIKeyUser(t, pool, "silence-confirm@example.test")
 	jid := insertJob(t, pool, "silence-4")
-	applied := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
-	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
-		UserID: uid, JobID: jid, At: pgtype.Timestamptz{Time: applied, Valid: true},
-	}); err != nil {
-		t.Fatalf("apply: %v", err)
-	}
+	applyAt(t, q, uid, jid, time.Now().Add(-30*24*time.Hour).UTC().Truncate(time.Second))
+
 	recent := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
-	if _, err := pool.Exec(ctx,
-		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, suggested_job_id)
-		 VALUES ($1,'hosted','sil-c','s','b',$2,$3)`, uid, recent, jid); err != nil {
-		t.Fatalf("seed suggestion: %v", err)
-	}
-	if !listOne(t, q, uid).HasPendingSuggestion {
+	seedMail(t, pool, uid, mail{ExternalID: "sil-c", At: recent, SuggestedID: jid})
+	if !trackedRow(t, q, uid, "all").HasPendingSuggestion {
 		t.Fatal("suggestion not reported as pending before confirmation")
 	}
 
@@ -183,12 +176,12 @@ func TestPendingSuggestionClearsOnceConfirmed(t *testing.T) {
 		t.Fatalf("confirm: %v", err)
 	}
 
-	row := listOne(t, q, uid)
+	row := trackedRow(t, q, uid, "all")
 	if row.HasPendingSuggestion {
 		t.Error("has_pending_suggestion is still true after confirming")
 	}
-	if got := row.LastActivityAt.Time.UTC().Truncate(time.Second); !got.Equal(recent) {
-		t.Errorf("last_activity_at = %v, want the now-linked message %v", got, recent)
+	if !sameSecond(row.LastActivityAt, recent) {
+		t.Errorf("last_activity_at = %v, want the now-linked message %v", row.LastActivityAt, recent)
 	}
 }
 
@@ -198,15 +191,14 @@ func TestPendingSuggestionClearsOnceConfirmed(t *testing.T) {
 func TestLastActivityNullForNonApplications(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
-	ctx := context.Background()
 
 	uid := seedAPIKeyUser(t, pool, "silence-saved@example.test")
 	jid := insertJob(t, pool, "silence-5")
-	if _, err := q.SaveJob(ctx, SaveJobParams{UserID: uid, JobID: jid}); err != nil {
+	if _, err := q.SaveJob(context.Background(), SaveJobParams{UserID: uid, JobID: jid}); err != nil {
 		t.Fatalf("SaveJob: %v", err)
 	}
 
-	row := listOne(t, q, uid)
+	row := trackedRow(t, q, uid, "all")
 	if row.LastActivityAt.Valid {
 		t.Errorf("last_activity_at = %v on a saved-only job, want NULL", row.LastActivityAt.Time)
 	}

--- a/internal/handler/AGENTS.md
+++ b/internal/handler/AGENTS.md
@@ -46,6 +46,7 @@ Fiber HTTP handlers: feature handler structs, route registration, auth surface, 
 
 - `view`/`apply`/`save`/`track` interaction endpoints. Addressed by job's public `:slug` (resolved to internal id before write). All writes are idempotent upserts behind `RequireAuthOrKey`.
 - Return `{"data": interaction}` with `user_id` omitted; public job reads stay unauthenticated.
+- **The `/me/tracking` silence fields are null together or set together.** `last_activity_at`, `days_silent` and `silence_state` describe an application awaiting a reply; a row that is merely viewed or saved, or one in a settled stage, carries all three as null. Null means "nothing is owed here", which the board must be able to tell apart from "owed and answered promptly" — so never substitute a zero-day `active`. The derivation lives on `jobtracking.TrackedJob.Silence`; the handler takes **one** `now()` for the whole page, so two rows cannot disagree about when the page was rendered.
 
 ## Mail Inbox + Agent Surface (`gmail.go`, `inbox.go`, `inbox_linking.go`, `inbox_agent.go`)
 

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -20,6 +20,13 @@ type myJobResponse struct {
 	Notes          *string     `json:"notes"`
 	EmailCount     int         `json:"email_count"`
 	ReminderFireAt *time.Time  `json:"reminder_fire_at"`
+	// The silence fields are null together on any row that is not an application
+	// awaiting a reply — a job merely viewed or saved, or one in a settled stage.
+	// Null means "nothing is owed here", which the board must be able to tell
+	// apart from "owed and answered promptly".
+	LastActivityAt *time.Time `json:"last_activity_at"`
+	DaysSilent     *int       `json:"days_silent"`
+	SilenceState   *string    `json:"silence_state"`
 }
 
 // ListTrackedJobs returns the authenticated user's job interactions joined with the
@@ -42,9 +49,12 @@ func (h *trackingHandlers) ListTrackedJobs(c *fiber.Ctx) error {
 		return trackingError(err)
 	}
 
+	// One clock for the whole page: silence is derived against now(), and two rows
+	// read a moment apart must not disagree about what "now" was.
+	now := time.Now()
 	items := make([]myJobResponse, 0, len(listing.Items))
 	for _, it := range listing.Items {
-		items = append(items, myJobResponse{
+		item := myJobResponse{
 			Job:            it.Job,
 			ViewedAt:       it.ViewedAt,
 			SavedAt:        it.SavedAt,
@@ -53,7 +63,13 @@ func (h *trackingHandlers) ListTrackedJobs(c *fiber.Ctx) error {
 			Notes:          it.Notes,
 			EmailCount:     it.EmailCount,
 			ReminderFireAt: it.ReminderFireAt,
-		})
+		}
+		if s := it.Silence(now); s != nil {
+			item.LastActivityAt = &s.LastActivityAt
+			item.DaysSilent = &s.DaysSilent
+			item.SilenceState = &s.State
+		}
+		items = append(items, item)
 	}
 
 	return c.JSON(fiber.Map{

--- a/internal/handler/me_tracking_silence_test.go
+++ b/internal/handler/me_tracking_silence_test.go
@@ -1,0 +1,157 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/jobtracking"
+	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/userjob"
+)
+
+// silenceRepo serves a fixed page of tracked rows, so the test pins what the
+// handler makes of them rather than how they were stored.
+type silenceRepo struct {
+	stubTrackingRepo
+	items []jobtracking.TrackedJob
+}
+
+func (r silenceRepo) ListInteractions(context.Context, int64, jobtracking.Filter, int32, int32) ([]jobtracking.TrackedJob, error) {
+	return r.items, nil
+}
+
+func (r silenceRepo) CountInteractions(context.Context, int64) (jobtracking.Counts, error) {
+	return jobtracking.Counts{All: int64(len(r.items))}, nil
+}
+
+// trackingRow is one decoded listing item, narrowed to the silence fields.
+type trackingRow struct {
+	Stage          *string    `json:"stage"`
+	AppliedAt      *time.Time `json:"applied_at"`
+	LastActivityAt *time.Time `json:"last_activity_at"`
+	DaysSilent     *int       `json:"days_silent"`
+	SilenceState   *string    `json:"silence_state"`
+}
+
+func listSilence(t *testing.T, items []jobtracking.TrackedJob) []trackingRow {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret-that-is-long-enough-0001", time.Hour)
+	token, _ := iss.Issue(1, testTokenVersion)
+	h := &trackingHandlers{tracking: jobtracking.New(silenceRepo{items: items})}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/me/tracking", auth.RequireAuth(iss, testVersions), h.ListTrackedJobs)
+
+	req := httptest.NewRequest(http.MethodGet, "/me/tracking", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list = %d, want 200 (%s)", resp.StatusCode, raw)
+	}
+	var body struct {
+		Data []trackingRow `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Data
+}
+
+func row(stage string, appliedAgo, activityAgo time.Duration, pending bool) jobtracking.TrackedJob {
+	j := jobtracking.TrackedJob{
+		Job:                  jobview.Job{PublicSlug: "a-job"},
+		HasPendingSuggestion: pending,
+	}
+	if appliedAgo > 0 {
+		at := time.Now().Add(-appliedAgo)
+		j.AppliedAt = &at
+	}
+	if stage != "" {
+		j.Stage = &stage
+	}
+	if activityAgo > 0 {
+		at := time.Now().Add(-activityAgo)
+		j.LastActivityAt = &at
+	}
+	return j
+}
+
+const oneDay = 24 * time.Hour
+
+// TestTrackingSilenceFieldsOnApplications asserts an application carries all
+// three silence fields, and that the state reflects its stage rather than the
+// raw elapsed time.
+func TestTrackingSilenceFieldsOnApplications(t *testing.T) {
+	rows := listSilence(t, []jobtracking.TrackedJob{
+		row("applied", 40*oneDay, 30*oneDay, false),   // 30 days silent, threshold 21
+		row("applied", 40*oneDay, 5*oneDay, false),    // 5 days silent
+		row("interview", 40*oneDay, 13*oneDay, false), // 13 days silent, threshold 12
+	})
+	if len(rows) != 3 {
+		t.Fatalf("listing returned %d rows, want 3", len(rows))
+	}
+	want := []struct {
+		days  int
+		state string
+	}{
+		{30, userjob.SilenceSilent},
+		{5, userjob.SilenceActive},
+		{13, userjob.SilenceSilent},
+	}
+	for i, w := range want {
+		got := rows[i]
+		if got.LastActivityAt == nil || got.DaysSilent == nil || got.SilenceState == nil {
+			t.Fatalf("row %d is missing silence fields: %+v", i, got)
+		}
+		if *got.DaysSilent != w.days {
+			t.Errorf("row %d days_silent = %d, want %d", i, *got.DaysSilent, w.days)
+		}
+		if *got.SilenceState != w.state {
+			t.Errorf("row %d silence_state = %q, want %q", i, *got.SilenceState, w.state)
+		}
+	}
+}
+
+// TestTrackingSilenceNullOffApplications asserts every row that is not an
+// application awaiting a reply carries all three fields as null — a saved job,
+// and a settled application. Null is how the board tells "nothing owed" from
+// "owed and answered promptly"; a zero-day active state would blur them.
+func TestTrackingSilenceNullOffApplications(t *testing.T) {
+	rows := listSilence(t, []jobtracking.TrackedJob{
+		row("", 0, 0, false),                         // saved only, never applied
+		row("rejected", 40*oneDay, 40*oneDay, false), // settled
+		row("accepted", 40*oneDay, 40*oneDay, false), // settled
+	})
+	for i, got := range rows {
+		if got.LastActivityAt != nil || got.DaysSilent != nil || got.SilenceState != nil {
+			t.Errorf("row %d carries silence fields, want all null: %+v", i, got)
+		}
+	}
+}
+
+// TestTrackingSilenceUnconfirmed asserts mail awaiting confirmation turns the
+// verdict into a question rather than an assertion.
+func TestTrackingSilenceUnconfirmed(t *testing.T) {
+	rows := listSilence(t, []jobtracking.TrackedJob{
+		row("applied", 40*oneDay, 30*oneDay, true),
+	})
+	if len(rows) != 1 || rows[0].SilenceState == nil {
+		t.Fatalf("unexpected listing: %+v", rows)
+	}
+	if *rows[0].SilenceState != userjob.SilenceUnconfirmed {
+		t.Errorf("silence_state = %q, want %q", *rows[0].SilenceState, userjob.SilenceUnconfirmed)
+	}
+}

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -96,6 +96,11 @@ type TrackedJob struct {
 	// job has no pending reminder — the saved list renders its "remind in N days"
 	// chip from it.
 	ReminderFireAt *time.Time
+	// LastActivityAt and HasPendingSuggestion are the raw silence inputs the
+	// repository supplies; Silence turns them into a verdict. They are kept
+	// separate so the adapter carries facts and the domain does the judging.
+	LastActivityAt       *time.Time
+	HasPendingSuggestion bool
 }
 
 // Listing is the result of ListTracked: a page of tracked jobs for the active

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -205,8 +205,10 @@ func (r *QueriesRepository) ListInteractions(
 				Stage:     textPtr(row.Stage),
 				Notes:     textPtr(row.Notes),
 			},
-			EmailCount:     int(row.EmailCount),
-			ReminderFireAt: pgconv.TimePtr(row.ReminderFireAt),
+			EmailCount:           int(row.EmailCount),
+			ReminderFireAt:       pgconv.TimePtr(row.ReminderFireAt),
+			LastActivityAt:       pgconv.TimePtr(row.LastActivityAt),
+			HasPendingSuggestion: row.HasPendingSuggestion,
 		})
 	}
 	return items, nil

--- a/internal/jobtracking/silence.go
+++ b/internal/jobtracking/silence.go
@@ -1,0 +1,57 @@
+package jobtracking
+
+import (
+	"time"
+
+	"github.com/strelov1/freehire/internal/userjob"
+)
+
+// Silence is how long an application has been waiting and what that means at the
+// stage it is in. It is derived on read against the caller's clock, never
+// stored: the value changes as time passes with nothing about the application
+// changing, so it must never be cached apart from the instant it was taken.
+type Silence struct {
+	// LastActivityAt is the application's apply date, or the newest message
+	// linked to it when that is later.
+	LastActivityAt time.Time
+	// DaysSilent is the whole days elapsed since. A part-day does not count.
+	DaysSilent int
+	// State is one of userjob.SilenceActive / SilenceSilent / SilenceUnconfirmed.
+	State string
+}
+
+// Silence derives the waiting state of a tracked row as of now, or nil when the
+// row has nothing to report: a job merely viewed or saved is not waiting on
+// anyone, and neither is an application in a settled stage. Returning nil rather
+// than a zero-day `active` keeps "nothing owed" distinguishable from "owed and
+// fine" — a distinction the board's marker depends on.
+//
+// An application whose LastActivityAt is missing falls back to its apply date.
+// The query already guarantees that fallback; repeating it here keeps the domain
+// from reintroducing a hole the SQL closed.
+func (j TrackedJob) Silence(now time.Time) *Silence {
+	if j.AppliedAt == nil {
+		return nil
+	}
+	stage := ""
+	if j.Stage != nil {
+		stage = *j.Stage
+	}
+	if _, accrues := userjob.SilenceThresholdDays(stage); !accrues {
+		return nil
+	}
+
+	last := *j.AppliedAt
+	if j.LastActivityAt != nil && j.LastActivityAt.After(last) {
+		last = *j.LastActivityAt
+	}
+	days := int(now.Sub(last).Hours() / 24)
+	if days < 0 {
+		days = 0
+	}
+	return &Silence{
+		LastActivityAt: last,
+		DaysSilent:     days,
+		State:          userjob.SilenceStateFor(stage, days, j.HasPendingSuggestion),
+	}
+}

--- a/internal/jobtracking/silence_test.go
+++ b/internal/jobtracking/silence_test.go
@@ -1,0 +1,112 @@
+package jobtracking_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/jobtracking"
+	"github.com/strelov1/freehire/internal/userjob"
+)
+
+// tracked builds a tracked row with the silence inputs the repository supplies.
+func tracked(stage string, appliedAt, lastActivity *time.Time, pending bool) jobtracking.TrackedJob {
+	return jobtracking.TrackedJob{
+		Interaction: jobtracking.Interaction{
+			AppliedAt: appliedAt,
+			Stage:     &stage,
+		},
+		LastActivityAt:       lastActivity,
+		HasPendingSuggestion: pending,
+	}
+}
+
+// A row that is not an application is not waiting on anyone, so it derives no
+// silence at all — the UI must be able to tell "nothing owed" from "owed and
+// fine", which a zero-day active state would blur.
+func TestSilenceNilForNonApplications(t *testing.T) {
+	now := time.Now()
+	ago := now.Add(-40 * 24 * time.Hour)
+
+	if got := tracked("", nil, nil, false).Silence(now); got != nil {
+		t.Errorf("saved-only row derived %+v, want nil", got)
+	}
+	// Applied but with a settled stage: still nothing to report.
+	for _, stage := range []string{"rejected", "accepted", "withdrawn"} {
+		if got := tracked(stage, &ago, &ago, false).Silence(now); got != nil {
+			t.Errorf("stage %q derived %+v, want nil", stage, got)
+		}
+	}
+}
+
+// Days silent counts whole elapsed days from the last activity, and the state is
+// the stage's verdict on that number.
+func TestSilenceCountsWholeDays(t *testing.T) {
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	applied := now.Add(-30 * 24 * time.Hour)
+
+	cases := []struct {
+		name      string
+		stage     string
+		last      time.Time
+		wantDays  int
+		wantState string
+	}{
+		{"fresh application", "applied", now.Add(-10 * 24 * time.Hour), 10, userjob.SilenceActive},
+		{"part of a day does not count", "applied", now.Add(-10*24*time.Hour - 13*time.Hour), 10, userjob.SilenceActive},
+		{"exactly at the threshold", "applied", now.Add(-21 * 24 * time.Hour), 21, userjob.SilenceActive},
+		{"past the threshold", "applied", now.Add(-22 * 24 * time.Hour), 22, userjob.SilenceSilent},
+		{"same wait, later stage", "interview", now.Add(-13 * 24 * time.Hour), 13, userjob.SilenceSilent},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := tracked(c.stage, &applied, &c.last, false).Silence(now)
+			if got == nil {
+				t.Fatal("derived nil, want a silence")
+			}
+			if got.DaysSilent != c.wantDays {
+				t.Errorf("DaysSilent = %d, want %d", got.DaysSilent, c.wantDays)
+			}
+			if got.State != c.wantState {
+				t.Errorf("State = %q, want %q", got.State, c.wantState)
+			}
+			if !got.LastActivityAt.Equal(c.last) {
+				t.Errorf("LastActivityAt = %v, want %v", got.LastActivityAt, c.last)
+			}
+		})
+	}
+}
+
+// Mail awaiting confirmation contradicts the claim that nobody replied, so the
+// verdict softens into a question — but only where there was a verdict to soften.
+func TestSilencePendingSuggestion(t *testing.T) {
+	now := time.Now()
+	applied := now.Add(-30 * 24 * time.Hour)
+
+	past := now.Add(-22 * 24 * time.Hour)
+	if got := tracked("applied", &applied, &past, true).Silence(now); got == nil || got.State != userjob.SilenceUnconfirmed {
+		t.Errorf("past the threshold with a pending suggestion = %+v, want %q", got, userjob.SilenceUnconfirmed)
+	}
+	inside := now.Add(-3 * 24 * time.Hour)
+	if got := tracked("applied", &applied, &inside, true).Silence(now); got == nil || got.State != userjob.SilenceActive {
+		t.Errorf("inside the threshold with a pending suggestion = %+v, want %q", got, userjob.SilenceActive)
+	}
+}
+
+// An application whose last activity the repository could not supply falls back
+// to its apply date rather than deriving nothing — the SQL already guarantees
+// this, and the domain must not reintroduce a hole the query closed.
+func TestSilenceFallsBackToAppliedAt(t *testing.T) {
+	now := time.Now()
+	applied := now.Add(-25 * 24 * time.Hour)
+
+	got := tracked("applied", &applied, nil, false).Silence(now)
+	if got == nil {
+		t.Fatal("derived nil for an application with no last activity, want a silence from applied_at")
+	}
+	if got.DaysSilent != 25 {
+		t.Errorf("DaysSilent = %d, want 25", got.DaysSilent)
+	}
+	if got.State != userjob.SilenceSilent {
+		t.Errorf("State = %q, want %q", got.State, userjob.SilenceSilent)
+	}
+}

--- a/internal/userjob/AGENTS.md
+++ b/internal/userjob/AGENTS.md
@@ -14,7 +14,11 @@ Per-user job interactions: view/apply/save/track endpoints backed by the `user_j
 
 The per-user job-tracking use cases — **`RecordView`** (touches `viewed_at`), **`MarkApplied`** (sets `applied_at`; runs in a transaction that takes `LockJobForApply` first, so concurrent applies serialize and `jobs.applied_count` cannot double-bump — same pattern as `LockJobForVote` on the vote path), **`SaveJob`/`UnsaveJob`** (toggles the saved mark), **`TrackJob`** (sets application `stage` and/or `notes`) — live in **`internal/jobtracking`** (Fiber/pgx-free service; the HTTP handlers in `internal/handler/user_jobs.go` translate the wire format). The SPA records views silently — failures are swallowed and must not break the page.
 
-`internal/userjob` itself keeps the shared tracking vocabulary: `stages.go` defines the controlled stage vocabulary with validation (`ValidStage`), and `buckets.go` provides the job-status buckets (saved, viewed, applied, etc.) used by the tracking UI and the pipeline aggregation.
+`internal/userjob` itself keeps the shared tracking vocabulary: `stages.go` defines the controlled stage vocabulary with validation (`ValidStage`), `buckets.go` provides the job-status buckets (saved, viewed, applied, etc.) used by the tracking UI and the pipeline aggregation, and `silence.go` holds the stage→threshold ladder plus the pure state mapping behind the tracking board's silence marker.
+
+**Silence thresholds carry their provenance at the point of definition.** Five specific numbers read as measurement whether or not they are one, and only two of these are: `applied` 21 is measured over 92 observed applications, `interview` 12 over six, `screening` 18 and `responded` 15 are interpolation stepping evenly between those anchors, and `offer` 5 is judgement — no application in the sample has ever reached that stage. Keep the per-value comments when tuning; a bare table invites the next reader to trust all five equally.
+
+Two invariants worth knowing before touching it: a threshold is the **last tolerated day**, not the first offending one, and a settled application reports **no state at all** rather than `active` — the board must be able to tell "nothing owed" from "owed and answered promptly". `TestSilenceThresholdsGrowStricter` guards the ladder's direction, which no individual scenario would catch if it inverted.
 
 The `/me/tracking` read joins the caller's interactions with the jobs they touch. View history = all rows; applications = `applied_at IS NOT NULL`.
 

--- a/internal/userjob/silence.go
+++ b/internal/userjob/silence.go
@@ -1,0 +1,84 @@
+package userjob
+
+// Silence states. An application reports one of these, or the empty string when
+// it is settled and so waiting on nobody — a caller must be able to tell "not
+// waiting" from "waiting and fine", which a reassuring `active` would hide.
+const (
+	// SilenceActive is an application inside its stage's tolerated silence.
+	SilenceActive = "active"
+	// SilenceSilent is an application past it.
+	SilenceSilent = "silent"
+	// SilenceUnconfirmed is an application that would read as silent but has mail
+	// awaiting the user's confirmation — a question to answer, not a verdict.
+	SilenceUnconfirmed = "unconfirmed"
+)
+
+// silenceThresholds is how many days of silence each active stage tolerates,
+// growing stricter as the application advances (TestSilenceThresholdsGrowStricter
+// pins that direction). Terminal stages are absent: a settled application never
+// accrues silence.
+//
+// The values do not share a provenance, and a table of five specific numbers
+// reads as measurement whether or not it is one, so each carries its own:
+//
+//	applied   21  measured — 92 observed applications, marks 16% of them
+//	screening 18  interpolated between the measured anchors
+//	responded 15  interpolated between the measured anchors
+//	interview 12  measured — 6 observed applications, marks 3. Raised from 7,
+//	              which marked 5 of the 6: a badge on nearly every card is one
+//	              nobody reads.
+//	offer      5  judgement, from a job seeker's experience. No application in
+//	              the sample has reached this stage; the single message ever
+//	              classified an offer is genuine but from a job search three
+//	              years earlier and informs nothing.
+//
+// The interpolated pair steps evenly by three days between 21 and 12 rather than
+// taking distinct-looking values, so the shape of the ladder shows at a glance
+// which rungs were derived rather than observed. Revisit the middle three once
+// the sample grows.
+//
+// All values are calendar days, which sets a floor under the strictest: five is
+// the shortest span that always contains two working days, while three can be
+// consumed entirely by a weekend. Going below five needs business-day
+// arithmetic — its own calendar, holidays and employer time zone.
+var silenceThresholds = map[string]int{
+	"applied":   21,
+	"screening": 18,
+	"responded": 15,
+	"interview": 12,
+	"offer":     5,
+}
+
+// SilenceThresholdDays returns how many days of silence `stage` tolerates, and
+// whether it accrues silence at all. An unset stage is judged as `applied`: an
+// application with no stage recorded is still an application. Terminal and
+// unknown stages report false.
+func SilenceThresholdDays(stage string) (int, bool) {
+	if stage == "" {
+		stage = "applied"
+	}
+	days, ok := silenceThresholds[stage]
+	return days, ok
+}
+
+// SilenceStateFor maps an application's stage, its elapsed silence, and whether
+// any unconfirmed suggestion points at it, to a silence state — or "" when the
+// stage never accrues silence.
+//
+// The threshold is the last tolerated day, not the first offending one. A
+// pending suggestion only ever softens a silence claim into a question: mail
+// awaiting confirmation on an application that is answering promptly is not a
+// problem to report, so it never turns `active` into anything.
+func SilenceStateFor(stage string, daysSilent int, pendingSuggestion bool) string {
+	threshold, ok := SilenceThresholdDays(stage)
+	if !ok {
+		return ""
+	}
+	if daysSilent <= threshold {
+		return SilenceActive
+	}
+	if pendingSuggestion {
+		return SilenceUnconfirmed
+	}
+	return SilenceSilent
+}

--- a/internal/userjob/silence_test.go
+++ b/internal/userjob/silence_test.go
@@ -1,0 +1,113 @@
+package userjob
+
+import "testing"
+
+// Every active stage has a threshold, terminal stages have none, and an unset
+// stage is judged as `applied` — an application with no stage recorded is still
+// an application.
+func TestSilenceThresholdDays(t *testing.T) {
+	cases := []struct {
+		stage    string
+		wantDays int
+		wantOK   bool
+	}{
+		{"applied", 21, true},
+		{"screening", 18, true},
+		{"responded", 15, true},
+		{"interview", 12, true},
+		{"offer", 5, true},
+		{"", 21, true}, // unset reads as applied
+		{"accepted", 0, false},
+		{"rejected", 0, false},
+		{"withdrawn", 0, false},
+		{"banana", 0, false},
+	}
+	for _, c := range cases {
+		days, ok := SilenceThresholdDays(c.stage)
+		if ok != c.wantOK || days != c.wantDays {
+			t.Errorf("SilenceThresholdDays(%q) = (%d, %v), want (%d, %v)",
+				c.stage, days, ok, c.wantDays, c.wantOK)
+		}
+	}
+}
+
+// The ladder must never invert: an application that has advanced is waiting on a
+// conversation already underway, and tolerating *more* silence there than at the
+// application stage would invert the whole point of the feature.
+func TestSilenceThresholdsGrowStricter(t *testing.T) {
+	ordered := []string{"applied", "screening", "responded", "interview", "offer"}
+	prev := 1 << 30
+	for _, stage := range ordered {
+		days, ok := SilenceThresholdDays(stage)
+		if !ok {
+			t.Fatalf("stage %q has no threshold", stage)
+		}
+		if days >= prev {
+			t.Errorf("threshold for %q is %d, want less than the previous stage's %d",
+				stage, days, prev)
+		}
+		prev = days
+	}
+}
+
+// A threshold is the last tolerated day, not the first offending one: at exactly
+// the threshold the application is still active.
+func TestSilenceStateForBoundary(t *testing.T) {
+	cases := []struct {
+		name  string
+		stage string
+		days  int
+		want  string
+	}{
+		{"well inside", "applied", 10, SilenceActive},
+		{"exactly at the threshold", "applied", 21, SilenceActive},
+		{"one day past", "applied", 22, SilenceSilent},
+		{"interview well past", "interview", 18, SilenceSilent},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SilenceStateFor(c.stage, c.days, false); got != c.want {
+				t.Errorf("SilenceStateFor(%q, %d, false) = %q, want %q",
+					c.stage, c.days, got, c.want)
+			}
+		})
+	}
+}
+
+// The same elapsed silence means different things at different stages — the
+// reason the ladder exists at all.
+func TestSilenceStateForIsStageAware(t *testing.T) {
+	const days = 13
+	if got := SilenceStateFor("applied", days, false); got != SilenceActive {
+		t.Errorf("applied at %d days = %q, want %q", days, got, SilenceActive)
+	}
+	if got := SilenceStateFor("interview", days, false); got != SilenceSilent {
+		t.Errorf("interview at %d days = %q, want %q", days, got, SilenceSilent)
+	}
+}
+
+// A settled application is not waiting on anyone, so it reports no state at all
+// rather than a reassuring "active" — the caller must be able to tell "not
+// waiting" from "waiting and fine".
+func TestSilenceStateForTerminalStages(t *testing.T) {
+	for _, stage := range []string{"accepted", "rejected", "withdrawn"} {
+		if got := SilenceStateFor(stage, 365, false); got != "" {
+			t.Errorf("SilenceStateFor(%q, 365, false) = %q, want the empty state", stage, got)
+		}
+		if got := SilenceStateFor(stage, 365, true); got != "" {
+			t.Errorf("SilenceStateFor(%q, 365, true) = %q, want the empty state", stage, got)
+		}
+	}
+}
+
+// A pending suggestion only ever softens a silence claim into a question. It
+// must not raise one: mail awaiting confirmation on an application that is
+// answering promptly is not a problem to report.
+func TestSilenceStateForPendingSuggestion(t *testing.T) {
+	if got := SilenceStateFor("applied", 22, true); got != SilenceUnconfirmed {
+		t.Errorf("past threshold with a pending suggestion = %q, want %q", got, SilenceUnconfirmed)
+	}
+	if got := SilenceStateFor("applied", 10, true); got != SilenceActive {
+		t.Errorf("inside threshold with a pending suggestion = %q, want %q", got, SilenceActive)
+	}
+}

--- a/openspec/changes/application-ghosting-signal/.openspec.yaml
+++ b/openspec/changes/application-ghosting-signal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/application-ghosting-signal/design.md
+++ b/openspec/changes/application-ghosting-signal/design.md
@@ -1,0 +1,128 @@
+## Context
+
+`/me/tracking` shows a stage and an apply date and leaves the reader to do the
+subtraction. Silence — the most common outcome of a job search — is the thing the
+product says nothing about.
+
+Every input already exists. `user_jobs.applied_at` gives the floor,
+`emails.job_id` gives the mail, and `emails_job_id_idx` (partial, linked rows
+only) already covers the lookup. This is a read model, not new collection.
+
+It deliberately waited for the data underneath it. When first drafted, 43% of
+applications carried any linked mail; it is now written against 64%, after the
+suggestion queue was drained by hand and an `atsPseudoNames` gap was closed that
+had let one application absorb 23 other employers' acknowledgements — an
+application that, precisely because it collected fresh mail daily, could never
+have registered as silent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Say how long an application has been waiting, and whether that is unusual for
+  the stage it is in.
+- Be wrong in the forgiving direction when wrong at all.
+- Make the provenance of every threshold visible, so nobody later mistakes a
+  guess for a measurement.
+
+**Non-Goals:**
+
+- Notification delivery. `internal/reminder` is the natural second consumer once
+  the thresholds have been watched against live data.
+- Follow-up drafting and PDF export — separate capabilities.
+- Business-day arithmetic. Every threshold is calendar days, which is why none
+  goes below five.
+
+## Decisions
+
+### Last activity is a read-side aggregate, not a column
+
+`GREATEST(user_jobs.applied_at, max(emails.received_at))` over the application's
+linked mail, computed on read. No migration, no write path to keep in sync, and
+no possibility of the stored value disagreeing with the mail it summarises.
+
+*Alternative considered:* a `last_activity_at` column maintained by the mail
+linker. Rejected — it adds a second source of truth for something one aggregate
+already answers, and every link, unlink, confirm, reject and delete would have to
+maintain it. If the aggregate ever becomes a measured cost at this scale, the
+column is still available later; nothing about the wire shape would change.
+
+### Any linked mail counts, not only stage-advancing mail
+
+Restricting the maximum to mail that advanced a stage was measured against the
+alternative and changed the outcome by one application out of 118. The reason is
+worth recording, because the intuition points the other way: an
+auto-acknowledgement arrives within *hours* of applying, so it never moves
+`GREATEST(applied_at, …)` — the apply timestamp already dominates it. The
+theoretical worry about robot mail resetting the clock is real and empirically
+almost nil.
+
+The simpler rule is chosen on that evidence, not on convenience.
+
+### A pending suggestion outranks a silence claim
+
+An application with mail the matcher believes belongs to it, still unconfirmed,
+reports `unconfirmed` rather than `silent`. The surface asks for a confirmation
+instead of asserting a silence the unconfirmed mail may contradict.
+
+This rule currently fires on nothing: the queue was drained to zero. It stays,
+because the queue refills on every classification run and the measurement that
+motivated it stands — when 74 suggestions were pending, 7 of the 23 applications
+that would have been marked silent had mail sitting unconfirmed. A rule justified
+by a backlog that happens to be empty today has not stopped being true.
+
+It also gives the false alarm somewhere to go: instead of "you were ignored", the
+card says "two messages may be from them — is this yours?", which is a question
+the user can actually answer.
+
+### Thresholds carry their provenance in the source
+
+Five specific numbers read as measurement whether or not they are one. Two are:
+`applied` 21 (n=92) and `interview` 12 (n=6). `screening` and `responded` are
+linear interpolation between those anchors, stepping evenly by three days so the
+shape of the ladder shows which rungs were derived. `offer` 5 is judgement from a
+job seeker's experience — no application in the sample has reached that stage,
+and the single message ever classified an offer is genuine but from a job search
+three years earlier.
+
+The project's dictionaries never guess: an unknown value emits nothing. A
+threshold cannot do that — a stage with no threshold cannot be judged — so the
+next best thing is to make the guessing visible at the point of definition rather
+than let it hide inside a plausible table.
+
+### Errors lean toward under-reporting
+
+Where a choice exists, the design prefers to miss a ghost than to invent one. The
+`applied_at` of an application recorded from mail is that mail's timestamp, which
+is an upper bound and therefore under-reports elapsed silence. A pending
+suggestion suppresses the claim entirely. Terminal stages never accrue silence.
+
+A missed ghost is a non-event. A fabricated one tells a person they were ignored
+when they were not, on the product's most emotionally loaded surface.
+
+## Risks / Trade-offs
+
+- **Three of five thresholds rest on little or no data.** Recorded per value
+  rather than smoothed over → revisit once the sample grows; the interpolated
+  rungs are expected to move.
+
+- **Coverage is 64%, so a third of applications are judged on `applied_at`
+  alone.** Their clock is honest but coarse → they can only ever look *more*
+  silent than they are, which is the safe direction. Coverage rises as the mail
+  surface is used.
+
+- **A read-side aggregate over per-application mail is O(applications) subqueries
+  per page.** At a personal mailbox's scale with the partial index this is
+  immaterial → if a page ever measures slow, the aggregate becomes a lateral join
+  before it becomes a column.
+
+- **Silence is computed against `now()` at read time**, so two requests a day
+  apart can report different states for an unchanged application. That is correct
+  — the silence really did grow — but it means the value must never be cached
+  without its timestamp.
+
+## Open Questions
+
+- Should `days_silent` count from the last *inbound* message only, once outbound
+  mail exists in the system? Today every linked message is inbound, so the
+  question is not yet answerable.

--- a/openspec/changes/application-ghosting-signal/proposal.md
+++ b/openspec/changes/application-ghosting-signal/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+A tracked application that goes quiet is indistinguishable from one still in
+progress: `/me/tracking` shows a stage and an apply date, and the reader is left
+to do the subtraction and guess whether "applied 3 weeks ago" still means
+anything. Silence is the single most common outcome of a job search and the one
+the product currently says nothing about.
+
+The signal is already in the database — `user_jobs.applied_at` plus the linked
+mail in `emails` — so this is a read model over data we already store, not new
+collection.
+
+It waited for that data to be worth reading. Drafted when 43% of applications
+carried any linked mail, it is now written against 64%, after the suggestion
+queue was drained and an `atsPseudoNames` gap was closed that had one application
+collecting 23 other employers' acknowledgements.
+
+## What Changes
+
+- `/me/tracking` gains, per application, a **last activity timestamp**, the
+  **days silent** derived from it, and a **silence state** computed against a
+  stage-aware threshold.
+- Last activity is `GREATEST(user_jobs.applied_at, max(emails.received_at))` over
+  that application's linked mail. Measured on real data, restricting the maximum
+  to stage-advancing mail changes the outcome by one application out of 118 —
+  auto-acknowledgements arrive within hours of applying, so they never move the
+  maximum. The simpler rule is used deliberately.
+- Thresholds vary by stage: `applied` 21, `screening` 16, `responded` 14,
+  `interview` 12, `offer` 5 days. Terminal stages (`rejected`, `accepted`,
+  `withdrawn`) never accrue silence at all. On the current data this marks 15 of
+  92 applications at `applied` and 3 of 6 at `interview`.
+- **An application with a pending link suggestion is never reported as silent.**
+  It reports a distinct "unconfirmed mail" state instead, so the surface asks the
+  user to confirm the link rather than asserting a silence that the unconfirmed
+  mail may contradict.
+
+  This rule fires on nothing today — the queue was drained to zero by hand — and
+  it is kept anyway. The queue refills with every classification run, and the
+  measurement that motivated the rule still stands: when 74 suggestions were
+  pending, 7 of the 23 applications that would have been marked silent had mail
+  sitting unconfirmed. A rule justified by a backlog that is currently empty is
+  not a rule that stopped being true.
+- The tracking board renders the state as a per-card marker.
+
+Not in this change: notification delivery for silent applications, follow-up
+message drafting, and PDF export of applications. The first is a natural second
+consumer of `internal/reminder` once the thresholds have been watched against
+live data for a while; the other two are separate capabilities.
+
+Also not here: business-day arithmetic. Every threshold is calendar days, which
+is why none goes below five — three days can be entirely weekend. Counting
+working days needs a calendar, holidays and the employer's time zone, and earns
+its own change if the offer threshold ever proves too blunt.
+
+## Capabilities
+
+### New Capabilities
+- `application-silence-signal`: derives and exposes how long a tracked
+  application has been without activity, the stage-aware threshold it is judged
+  against, and the resulting state — including the precedence of an unconfirmed
+  link suggestion over a silence claim.
+
+### Modified Capabilities
+- `user-job-tracking`: the `/me/tracking` projection gains the silence fields, so
+  the response contract for a tracked application changes.
+
+## Impact
+
+- **Read path only.** No migration: `user_jobs` and `emails` already carry every
+  input, and `emails_job_id_idx` (partial, `job_id IS NOT NULL`) already covers
+  the per-application mail lookup.
+- `internal/db/queries` — the `/me/tracking` query gains the activity aggregation.
+- `internal/userjob` — a new stage→threshold table, alongside the existing stage
+  vocabulary in `stages.go`.
+- `internal/handler/user_jobs.go` and the tracking board in `web/` — wire shape
+  and rendering.
+- Nothing in the mail stack changes: this is a consumer of `emails.job_id` and
+  `emails.suggested_job_id`, not a change to how either is decided.

--- a/openspec/changes/application-ghosting-signal/specs/application-silence-signal/spec.md
+++ b/openspec/changes/application-ghosting-signal/specs/application-silence-signal/spec.md
@@ -1,0 +1,167 @@
+## ADDED Requirements
+
+### Requirement: Deriving an application's last activity
+
+The system SHALL derive, for each tracked application, a last-activity timestamp
+as the later of the application's `applied_at` and the most recent `received_at`
+among the emails linked to that application for that user. Only linked mail
+counts: an email carrying a suggestion that the user has not confirmed is not
+activity. Soft-deleted emails are excluded. An application with no linked mail
+takes its `applied_at` as its last activity, so the derived value is never null
+for an application.
+
+#### Scenario: Application with no linked mail
+
+- **WHEN** an application has `applied_at` set and no linked emails
+- **THEN** its last activity equals `applied_at`
+
+#### Scenario: Linked mail moves the last activity forward
+
+- **WHEN** an application has a linked email received after `applied_at`
+- **THEN** its last activity equals that email's `received_at`
+
+#### Scenario: Mail linked to another application is ignored
+
+- **WHEN** a user has a linked email belonging to a different application
+- **THEN** that email does not affect this application's last activity
+
+#### Scenario: Unconfirmed suggestion is not activity
+
+- **WHEN** an email carries `suggested_job_id` for the application but has no
+  `job_id`
+- **THEN** the application's last activity is unchanged by that email
+
+#### Scenario: Deleted mail is ignored
+
+- **WHEN** a linked email has been soft-deleted by the user
+- **THEN** it does not contribute to the application's last activity
+
+### Requirement: Stage-aware silence thresholds
+
+The system SHALL judge an application's silence against a threshold determined by
+its current stage, growing stricter as the application advances: `applied` 21
+days, `screening` 18 days, `responded` 15 days, `interview` 12 days, `offer` 5
+days. An application whose stage is unset is judged as `applied`. The days-silent
+value is the whole days elapsed between the application's last activity and now.
+
+Each value SHALL carry its provenance in the source, because a table of five
+specific numbers reads as measurement whether or not it is one, and only two of
+these are:
+
+| Stage | Days | Source |
+|---|---|---|
+| `applied` | 21 | measured — 92 observed applications, marks 16% of them |
+| `screening` | 18 | interpolated between the two measured anchors |
+| `responded` | 15 | interpolated between the two measured anchors |
+| `interview` | 12 | measured — 6 observed applications, marks 3; raised from 7, which marked 5 of 6 |
+| `offer` | 5 | judgement, from a job seeker's experience — no application in the sample has reached this stage. Exactly one message was ever classified an offer, and it is genuine but from a job search three years earlier, in the archive cohort this work deliberately left unlabelled. It informs nothing |
+
+The interpolated pair steps evenly by three days between 21 and 12 rather than
+taking distinct-looking values, so the shape of the ladder shows at a glance
+which rungs were derived. This mirrors the dictionaries rule elsewhere in the
+project — never guess, emit nothing for an unknown — as closely as a threshold
+can, since a stage with no threshold cannot be judged at all.
+
+The thresholds are calendar days, which sets a floor under the strictest of them.
+Five is the shortest span that always contains at least two working days; three
+can be consumed entirely by a weekend, so an offer arriving on a Friday evening
+would be reported as ignored before anyone had a working day to answer. Anything
+below five needs business-day arithmetic — a separate concern, with its own
+calendar, holidays and employer time zone.
+
+#### Scenario: Below the threshold
+
+- **WHEN** an application at stage `applied` has been silent for 10 days
+- **THEN** its silence state is `active` and its days-silent is 10
+
+#### Scenario: Past the threshold
+
+- **WHEN** an application at stage `applied` has been silent for 22 days
+- **THEN** its silence state is `silent`
+
+#### Scenario: The same silence is judged differently by stage
+
+- **WHEN** two applications have both been silent for 13 days, one at stage
+  `applied` and one at stage `interview`
+- **THEN** the `applied` one is `active` and the `interview` one is `silent`
+
+#### Scenario: Unset stage is judged as applied
+
+- **WHEN** an application has `applied_at` set and a null stage
+- **THEN** it is judged against the `applied` threshold of 21 days
+
+### Requirement: Terminal applications never accrue silence
+
+The system SHALL report no silence state and no days-silent for an application in
+a terminal stage — `rejected`, `accepted`, or `withdrawn`. A settled outcome is
+not awaiting a reply, so counting its silence would manufacture an alarm about a
+closed matter.
+
+#### Scenario: Rejected application
+
+- **WHEN** an application at stage `rejected` has had no activity for a year
+- **THEN** its silence state and days-silent are both null
+
+#### Scenario: Accepted application
+
+- **WHEN** an application at stage `accepted` has had no activity for 90 days
+- **THEN** its silence state and days-silent are both null
+
+### Requirement: An unconfirmed suggestion outranks a silence claim
+
+The system SHALL report the silence state `unconfirmed`, rather than `silent`,
+for an application that has at least one email suggesting it that the user has
+not yet confirmed or rejected. Mail the matcher believes belongs to this
+application contradicts the claim that nobody replied, so the surface asks for a
+confirmation instead of asserting a silence that may be false.
+
+#### Scenario: Past the threshold with a pending suggestion
+
+- **WHEN** an application is past its stage's silence threshold and has an
+  unconfirmed email suggesting it
+- **THEN** its silence state is `unconfirmed`, not `silent`
+
+#### Scenario: Below the threshold with a pending suggestion
+
+- **WHEN** an application is below its silence threshold and has an unconfirmed
+  email suggesting it
+- **THEN** its silence state is `active` — a pending suggestion only suppresses a
+  silence claim, it does not raise one
+
+#### Scenario: Confirming the suggestion resolves the state
+
+- **WHEN** the user confirms the suggested link and the email's `received_at` is
+  recent enough to clear the threshold
+- **THEN** the application's silence state becomes `active` and its last activity
+  is that email's `received_at`
+
+#### Scenario: Rejecting the suggestion restores the silence claim
+
+- **WHEN** the user rejects the suggestion, leaving the application with no
+  pending suggestion and no new linked mail
+- **THEN** the application's silence state becomes `silent`
+
+### Requirement: Tracking board marks a silent application
+
+The web SPA's tracking board SHALL mark each application card with its silence
+state, showing the days silent for an application that is `silent` and an
+invitation to confirm the pending mail for one that is `unconfirmed`. A card in
+the `active` state and a card for a terminal application SHALL carry no silence
+marker, so the marker means something when it appears.
+
+#### Scenario: Silent card
+
+- **WHEN** a signed-in user opens the tracking board with an application whose
+  silence state is `silent` at 24 days
+- **THEN** that card shows a silence marker reading 24 days
+
+#### Scenario: Unconfirmed card
+
+- **WHEN** a card's application has the silence state `unconfirmed`
+- **THEN** the card invites the user to confirm the pending mail rather than
+  reporting a silence
+
+#### Scenario: Active and terminal cards are unmarked
+
+- **WHEN** a card's application is `active` or in a terminal stage
+- **THEN** the card shows no silence marker

--- a/openspec/changes/application-ghosting-signal/specs/user-job-tracking/spec.md
+++ b/openspec/changes/application-ghosting-signal/specs/user-job-tracking/spec.md
@@ -1,0 +1,71 @@
+## MODIFIED Requirements
+
+### Requirement: Listing a user's job interactions
+
+The system SHALL expose `GET /api/v1/me/tracking` (auth required) returning the
+authenticated user's interactions joined with the public job view shape,
+ordered by most recent interaction activity first, with limit/offset
+pagination. A `filter` query parameter SHALL narrow the list: `all` (default —
+every interaction), `viewed` (view-only rows: neither saved nor applied),
+`saved` (`saved_at` set), `applied` (`applied_at` set). The list `meta` SHALL
+carry `total/limit/offset` for the active filter plus `counts` with the row
+counts of all four filters. Closed jobs SHALL remain in
+the listing (their job view carries `closed_at`). An unknown `filter` value
+SHALL be a `400`.
+
+Each row that represents an application SHALL additionally carry its
+`last_activity_at`, its `days_silent`, and its `silence_state`. A row that is not
+an application — no `applied_at` — carries all three as null: a job merely viewed
+or saved is not waiting on anyone.
+
+#### Scenario: Listing all interactions
+
+- **WHEN** an authenticated user requests `GET /api/v1/me/tracking`
+- **THEN** the response is `200` with
+  `{"data": [{job, viewed_at, saved_at, applied_at}, ...], "meta": {...}}`
+- **AND** each `job` is the shared job view shape (no internal id)
+- **AND** items are ordered by the most recent of the interaction timestamps,
+  descending
+
+#### Scenario: Filtering to applications
+
+- **WHEN** the user requests `GET /api/v1/me/tracking?filter=applied`
+- **THEN** only interactions with non-null `applied_at` are returned
+- **AND** `meta.total` counts only those
+
+#### Scenario: Filtering to viewed-only
+
+- **WHEN** the user requests `GET /api/v1/me/tracking?filter=viewed`
+- **THEN** only interactions with null `saved_at` and null `applied_at` are
+  returned — the passive view history, without the jobs already acted on
+
+#### Scenario: Tab counts in meta
+
+- **WHEN** the user requests the listing with any filter
+- **THEN** `meta.counts` reports `{all, viewed, saved, applied}` for that user
+
+#### Scenario: Closed job stays in the history
+
+- **WHEN** a job the user applied to is later closed
+- **THEN** it still appears in the listing and its job view has `closed_at` set
+
+#### Scenario: Unknown filter
+
+- **WHEN** the user requests `GET /api/v1/me/tracking?filter=bogus`
+- **THEN** the system responds `400`
+
+#### Scenario: Listing requires authentication
+
+- **WHEN** a request to `GET /api/v1/me/tracking` carries no valid auth cookie
+- **THEN** the system responds `401`
+
+#### Scenario: An application carries its silence fields
+
+- **WHEN** the listing returns a row whose `applied_at` is set
+- **THEN** that row carries `last_activity_at`, `days_silent` and
+  `silence_state`
+
+#### Scenario: A non-application carries none of them
+
+- **WHEN** the listing returns a row the user only viewed or saved
+- **THEN** its `last_activity_at`, `days_silent` and `silence_state` are all null

--- a/openspec/changes/application-ghosting-signal/tasks.md
+++ b/openspec/changes/application-ghosting-signal/tasks.md
@@ -1,0 +1,30 @@
+## 1. The silence vocabulary and thresholds
+
+- [ ] 1.1 Add the stage→threshold table to `internal/userjob`, alongside the existing stage vocabulary in `stages.go`, with each value's provenance recorded at the point of definition (measured / interpolated / judgement)
+- [ ] 1.2 Add the silence-state vocabulary (`active`, `silent`, `unconfirmed`) and the pure function mapping (stage, days silent, has-pending-suggestion) to a state
+- [ ] 1.3 Cover the pure mapping: below/at/past each threshold, the same silence judged differently by stage, unset stage judged as `applied`, and terminal stages yielding no state at all
+- [ ] 1.4 Cover the precedence rule: a pending suggestion turns what would be `silent` into `unconfirmed`, but never turns `active` into anything
+
+## 2. Deriving last activity
+
+- [ ] 2.1 Extend the `/me/tracking` query with the last-activity aggregate — `GREATEST(applied_at, max(received_at))` over linked, non-deleted mail — and a flag for whether any unconfirmed suggestion points at the application
+- [ ] 2.2 Cover the aggregate against a real Postgres: no linked mail falls back to `applied_at`; linked mail moves it forward; another application's mail is ignored; an unconfirmed suggestion is not activity; soft-deleted mail is excluded
+- [ ] 2.3 Confirm the partial `emails_job_id_idx` serves the aggregate and record the plan in the task notes; do not add an index speculatively
+
+## 3. Wire shape
+
+- [ ] 3.1 Add `last_activity_at`, `days_silent` and `silence_state` to the `/me/tracking` row, null on any row that is not an application
+- [ ] 3.2 Cover the wire shape: an application carries all three; a viewed-or-saved-only row carries none
+- [ ] 3.3 Regenerate the API contract and check the new fields appear
+- [ ] 3.4 Update `internal/userjob/AGENTS.md` and `internal/handler/AGENTS.md`
+
+## 4. Tracking board
+
+- [ ] 4.1 Render the silence marker on the application card: days silent when `silent`, an invitation to confirm the pending mail when `unconfirmed`, nothing when `active` or terminal
+- [ ] 4.2 Verify visually that a board of mixed states reads correctly, and that a board with no silent applications shows no markers at all
+- [ ] 4.3 Confirm the `unconfirmed` card links to the mail awaiting confirmation, so the question it asks can be answered in one step
+
+## 5. Verification
+
+- [ ] 5.1 `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...`, and the integration suites for `./internal/db/` and `./internal/handler/`
+- [ ] 5.2 Compare the live account's flagged applications against the measurement in the proposal (15 of 92 at `applied`, 3 of 6 at `interview`); an unexplained divergence means the implementation and the measurement disagree about what silence is

--- a/openspec/changes/application-ghosting-signal/tasks.md
+++ b/openspec/changes/application-ghosting-signal/tasks.md
@@ -1,15 +1,15 @@
 ## 1. The silence vocabulary and thresholds
 
-- [ ] 1.1 Add the stage→threshold table to `internal/userjob`, alongside the existing stage vocabulary in `stages.go`, with each value's provenance recorded at the point of definition (measured / interpolated / judgement)
-- [ ] 1.2 Add the silence-state vocabulary (`active`, `silent`, `unconfirmed`) and the pure function mapping (stage, days silent, has-pending-suggestion) to a state
-- [ ] 1.3 Cover the pure mapping: below/at/past each threshold, the same silence judged differently by stage, unset stage judged as `applied`, and terminal stages yielding no state at all
-- [ ] 1.4 Cover the precedence rule: a pending suggestion turns what would be `silent` into `unconfirmed`, but never turns `active` into anything
+- [x] 1.1 Add the stage→threshold table to `internal/userjob`, alongside the existing stage vocabulary in `stages.go`, with each value's provenance recorded at the point of definition (measured / interpolated / judgement)
+- [x] 1.2 Add the silence-state vocabulary (`active`, `silent`, `unconfirmed`) and the pure function mapping (stage, days silent, has-pending-suggestion) to a state
+- [x] 1.3 Cover the pure mapping: below/at/past each threshold, the same silence judged differently by stage, unset stage judged as `applied`, and terminal stages yielding no state at all
+- [x] 1.4 Cover the precedence rule: a pending suggestion turns what would be `silent` into `unconfirmed`, but never turns `active` into anything
 
 ## 2. Deriving last activity
 
-- [ ] 2.1 Extend the `/me/tracking` query with the last-activity aggregate — `GREATEST(applied_at, max(received_at))` over linked, non-deleted mail — and a flag for whether any unconfirmed suggestion points at the application
-- [ ] 2.2 Cover the aggregate against a real Postgres: no linked mail falls back to `applied_at`; linked mail moves it forward; another application's mail is ignored; an unconfirmed suggestion is not activity; soft-deleted mail is excluded
-- [ ] 2.3 Confirm the partial `emails_job_id_idx` serves the aggregate and record the plan in the task notes; do not add an index speculatively
+- [x] 2.1 Extend the `/me/tracking` query with the last-activity aggregate — `GREATEST(applied_at, max(received_at))` over linked, non-deleted mail — and a flag for whether any unconfirmed suggestion points at the application
+- [x] 2.2 Cover the aggregate against a real Postgres: no linked mail falls back to `applied_at`; linked mail moves it forward; another application's mail is ignored; an unconfirmed suggestion is not activity; soft-deleted mail is excluded
+- [x] 2.3 Confirmed against prod: `EXPLAIN (ANALYZE)` on the last-activity aggregate takes a `Bitmap Index Scan on emails_job_id_idx`, 16ms on the busiest application. The existing partial index serves it; no index added
 
 ## 3. Wire shape
 

--- a/openspec/changes/application-ghosting-signal/tasks.md
+++ b/openspec/changes/application-ghosting-signal/tasks.md
@@ -13,18 +13,18 @@
 
 ## 3. Wire shape
 
-- [ ] 3.1 Add `last_activity_at`, `days_silent` and `silence_state` to the `/me/tracking` row, null on any row that is not an application
-- [ ] 3.2 Cover the wire shape: an application carries all three; a viewed-or-saved-only row carries none
-- [ ] 3.3 Regenerate the API contract and check the new fields appear
-- [ ] 3.4 Update `internal/userjob/AGENTS.md` and `internal/handler/AGENTS.md`
+- [x] 3.1 Add `last_activity_at`, `days_silent` and `silence_state` to the `/me/tracking` row, null on any row that is not an application
+- [x] 3.2 Cover the wire shape: an application carries all three; a viewed-or-saved-only row carries none
+- [x] 3.3 Regenerated the API contract: no diff — `MyJob` in `web/src/lib/types.ts` is hand-maintained rather than generated, so the three fields were added there directly
+- [x] 3.4 Update `internal/userjob/AGENTS.md` and `internal/handler/AGENTS.md`
 
 ## 4. Tracking board
 
-- [ ] 4.1 Render the silence marker on the application card: days silent when `silent`, an invitation to confirm the pending mail when `unconfirmed`, nothing when `active` or terminal
-- [ ] 4.2 Verify visually that a board of mixed states reads correctly, and that a board with no silent applications shows no markers at all
-- [ ] 4.3 Confirm the `unconfirmed` card links to the mail awaiting confirmation, so the question it asks can be answered in one step
+- [x] 4.1 Render the silence marker on the application card: days silent when `silent`, an invitation to confirm the pending mail when `unconfirmed`, nothing when `active` or terminal
+- [ ] 4.2 **Not done — blocked.** Visual verification of a mixed-state board needs the API deployed; prod does not serve these fields yet. Only the absent-fields case is provable by reading: `silence_state` is `undefined` there, every branch tests `=== 'silent'` / `=== 'unconfirmed'`, so no marker renders and nothing dereferences `days_silent`
+- [ ] 4.3 **Not done.** The `unconfirmed` marker explains itself in a tooltip but is not a link; answering the question still means opening the card and finding the mail. Worth doing, and deliberately not claimed
 
 ## 5. Verification
 
-- [ ] 5.1 `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...`, and the integration suites for `./internal/db/` and `./internal/handler/`
-- [ ] 5.2 Compare the live account's flagged applications against the measurement in the proposal (15 of 92 at `applied`, 3 of 6 at `interview`); an unexplained divergence means the implementation and the measurement disagree about what silence is
+- [x] 5.1 `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...`, and the integration suites for `./internal/db/` and `./internal/handler/`
+- [x] 5.2 Verified against prod with the shipped ladder: 15 of 92 at `applied`, 3 of 6 at `interview`, 0 of 1 at `screening` — matching the proposal exactly, using the same floor-to-whole-days rule the code applies

--- a/web/src/lib/components/BoardCard.svelte
+++ b/web/src/lib/components/BoardCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Mail } from '@lucide/svelte';
+  import { Clock, Mail, MessageSquare } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import { Badge } from '$lib/ui';
   import { humanizeStage } from '$lib/stages';
@@ -23,6 +23,25 @@
   <span class="flex items-center gap-1.5">
     {#if item.stage}
       <Badge variant="secondary">{humanizeStage(item.stage)}</Badge>
+    {/if}
+    {#if item.silence_state === 'silent'}
+      <span
+        class="flex items-center gap-0.5 text-xs tabular-nums text-amber-600"
+        title="No reply for {item.days_silent} days"
+        aria-label="No reply for {item.days_silent} days"
+      >
+        <Clock class="size-3 shrink-0" aria-hidden="true" />
+        {item.days_silent}d
+      </span>
+    {:else if item.silence_state === 'unconfirmed'}
+      <span
+        class="flex items-center gap-0.5 text-xs text-muted-foreground"
+        title="Mail may be from them — confirm the link to know"
+        aria-label="Mail awaiting confirmation"
+      >
+        <MessageSquare class="size-3 shrink-0" aria-hidden="true" />
+        ?
+      </span>
     {/if}
     {#if item.email_count > 0}
       <span

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -381,6 +381,17 @@ export interface MyJob {
   /** The pending saved-job reminder's deadline (RFC3339), or null when the job
    *  has no pending reminder. Drives the saved list's "remind in N days" chip. */
   reminder_fire_at: string | null;
+  /** When this application last moved: its apply date, or the newest message
+   *  linked to it when that is later. Null on any row that is not an
+   *  application awaiting a reply. */
+  last_activity_at: string | null;
+  /** Whole days since last_activity_at. Null together with the others. */
+  days_silent: number | null;
+  /** 'active' — inside the tolerated silence for its stage; 'silent' — past it;
+   *  'unconfirmed' — it would read as silent, but mail awaiting confirmation may
+   *  say otherwise. Null means nothing is owed here (viewed/saved only, or a
+   *  settled application), which is not the same as owed-and-answered-promptly. */
+  silence_state: 'active' | 'silent' | 'unconfirmed' | null;
 }
 
 /** The account-level saved-job reminder rule: whether reminders are on, the


### PR DESCRIPTION
**Draft — 7 of 16 tasks.** The inputs for the silence signal, without the surface that reads them. Groups 3–5 (wire shape, tracking-board marker, final verification) follow on this branch.

Plan: `openspec/changes/application-ghosting-signal/`.

## Why now

Drafted when 43% of applications carried any linked mail, and deliberately parked until that number was worth building on. It is now **64%**, after the suggestion queue was drained by hand (#1189, #1192) and an `atsPseudoNames` gap was found that had one application absorbing 23 other employers' acknowledgements (#1193, still open).

## The ladder, and what each number rests on

| Stage | Days | Source |
|---|---|---|
| `applied` | 21 | measured — 92 observed applications, marks 16% |
| `screening` | 18 | interpolated between the anchors |
| `responded` | 15 | interpolated between the anchors |
| `interview` | 12 | measured — 6 applications, marks 3. Raised from 7, which marked 5 of 6 |
| `offer` | 5 | judgement — **no** application in the sample has reached this stage |

Five specific numbers read as measurement whether or not they are one, and only two of these are. The provenance sits in the source next to the values, and the interpolated pair steps evenly by three days rather than taking distinct-looking values, so the shape of the ladder shows which rungs were derived.

This is as close as a threshold can get to the project's dictionaries rule — never guess, emit nothing for an unknown — since a stage with no threshold cannot be judged at all.

Calendar days throughout, which is why none goes below five: three days can be entirely weekend, so an offer arriving Friday evening would read as ignored before anyone had a working day to answer.

## Semantics worth pinning

- A threshold is the **last tolerated day**, not the first offending one.
- A pending suggestion only ever softens `silent` into `unconfirmed`. It never raises a claim on an application answering promptly.
- A settled application reports **no state**, not `active` — a caller must be able to tell "not waiting" from "waiting and fine".
- `GREATEST` ignores a NULL aggregate, so an application with no linked mail falls back to its apply date. A clock that only started once mail arrived would never fire on applications ignored outright — exactly the ones worth reporting.

## Notes from the build

- The `CASE` needed an explicit `::timestamptz`; sqlc otherwise inferred `interface{}`, which compiles fine and pushes a type assertion into every caller. Caught by the test expecting `pgtype.Timestamptz`.
- `EXPLAIN (ANALYZE)` on prod takes a `Bitmap Index Scan on emails_job_id_idx` for the aggregate (16ms on the busiest application). No index added.
- `TestSilenceThresholdsGrowStricter` guards the one failure no individual scenario catches: a later stage tolerating *more* silence than an earlier one inverts the feature's meaning without breaking anything.

## Verification

`gofmt`, `go build`, `go vet`, full unit suite, and `-tags=integration ./internal/db/` — all green. No migration.