### PR TITLE
feat(sources): onboard three contributed boards

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14221,3 +14221,5 @@
   board: xebiafrance
 - company: Zephyr
   board: zephyrhome
+- company: Venice AI
+  board: veniceai

--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -744,3 +744,5 @@
   board: jobler
 - company: VAAS
   board: vaas
+- company: "ed"
+  board: somosed

--- a/sources/successfactors.yml
+++ b/sources/successfactors.yml
@@ -25,3 +25,7 @@
   board: jobs.gft.com
 - company: Volkswagen Group
   board: jobs.volkswagen-group.com
+- company: Vaillant Group
+  board: jobs.vaillant-group.com
+- company: Foundever
+  board: jobs.foundever.com

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -12867,3 +12867,5 @@
   board: wwecorp.wd5.myworkdayjobs.com/PRIVATE_Postings
 - company: xavier
   board: xavier.wd108.myworkdayjobs.com/XavierCareers
+- company: Unity
+  board: unitytech.wd1.myworkdayjobs.com/Unity


### PR DESCRIPTION
Drains the recognized `pending` rows in `link_contributions` (the manual run of the deferred ingest worker the contribution flow was designed around).

## Onboarded — validated live before adding

| source | board | company | evidence |
|---|---|---|---|
| greenhouse | `veniceai` | Venice AI | `boards-api.greenhouse.io/v1/boards/veniceai/jobs` → postings |
| workday | `unitytech.wd1.myworkdayjobs.com/Unity` | Unity | CXS `/jobs` → `total: 123` |
| inhire | `somosed` | ed | `X-Tenant: somosed` → 7 postings |

## No source change needed

- `ashby/Solvd`, `ashby/Hatch` — already tracked as `solvd` / `hatch`.
- `workday/…/AE-Careers`, `workday/…/Vantor` — already tracked with the site in lower case (Workday's CXS endpoint is case-insensitive on the site).
- `teamtailor/app.teamtailor.com`, `smartrecruiters/ni` — the recognizer mistook a path/host segment for a board. The real boards (`careers.arrive.com`, `BHFT`) are already tracked; these rows get rejected.

Contribution rows are flipped on prod after this merges.