### PR TITLE
feat(sources): crawl self-hosted OpenCATS career portals

### DIFF
--- a/cmd/harvest-boards/opencats_prober.go
+++ b/cmd/harvest-boards/opencats_prober.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// opencatsListingPath is the portal's "show all" route, appended to a board (mirrors the
+// unexported constant in the sources package; this tool lives outside it).
+const opencatsListingPath = "index.php?m=careers&p=showAll"
+
+// opencatsPostingLink matches a portal link that is a posting. It is the liveness signal: a
+// portal serving at least one is a live board.
+var opencatsPostingLink = regexp.MustCompile(`p=showJob`)
+
+// opencatsDiscoveryQueries are the signatures an install leaves in a public scan index. The
+// stock page title is by far the richest (66 hosts against 13 for the URL routing) because
+// administrators move the portal or put it behind a rewrite far more often than they rename
+// the page; the routing queries add the installs that did rename it.
+var opencatsDiscoveryQueries = []string{
+	`page.title:"OpenCATS"`,
+	`page.url:"careers/index.php"`,
+	`page.url:"m=careers"`,
+}
+
+// opencatsSearchURL builds a urlscan.io search request for one signature.
+func opencatsSearchURL(q string) string {
+	return "https://urlscan.io/api/v1/search/?q=" + url.QueryEscape(q) + "&size=100"
+}
+
+// opencatsMounts are the paths an install serves its portal under, in the order they are
+// tried. Most installs nest it; a rewritten portal (G4S) serves it at the web root.
+var opencatsMounts = []string{"/careers", ""}
+
+// opencatsProber probes and discovers self-hosted OpenCATS portals. OpenCATS has no vendor
+// API and no tenant catalogue — every install is somebody's own domain — so candidates come
+// from a public index of scanned hosts rather than from a seed list or a platform feed.
+type opencatsProber struct{}
+
+// probe requests the board's portal listing and counts its postings. An unreachable host, a
+// host serving no portal, and a portal with no postings are all a skip — ("", 0, nil) — so one
+// dead candidate cannot abort the harvest.
+func (opencatsProber) probe(ctx context.Context, c httpClient, board string) (string, int, error) {
+	root, err := c.GetHTML(ctx, opencatsListingURL(board))
+	if err != nil {
+		return "", 0, nil
+	}
+	jobs := countMatchingLinks(root, opencatsPostingLink)
+	if jobs == 0 {
+		return "", 0, nil
+	}
+	return opencatsCompanyName(root, board), jobs, nil
+}
+
+// discover unions the signature queries into one candidate host list, then resolves each host
+// to the single board it serves. Resolving here rather than in probe is deliberate: a board is
+// its mount point, so a host emitted at two mounts would namespace one posting under two
+// external ids, and only discovery sees the whole host.
+func (p opencatsProber) discover(ctx context.Context, c httpClient) ([]string, error) {
+	seen := map[string]struct{}{}
+	var hosts []string
+	failures := 0
+	for _, q := range opencatsDiscoveryQueries {
+		var resp struct {
+			Results []struct {
+				Task struct {
+					Domain string `json:"domain"`
+				} `json:"task"`
+			} `json:"results"`
+		}
+		if err := c.GetJSON(ctx, opencatsSearchURL(q), &resp); err != nil {
+			failures++
+			continue
+		}
+		for _, r := range resp.Results {
+			h := strings.ToLower(strings.TrimSpace(r.Task.Domain))
+			if h == "" || !opencatsEligibleHost(h) {
+				continue
+			}
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			hosts = append(hosts, h)
+		}
+	}
+	// Every query failing means the index is unreachable or has changed, not that no installs
+	// exist. Say so, rather than returning an empty list that reads as an exhausted search.
+	if failures == len(opencatsDiscoveryQueries) {
+		return nil, fmt.Errorf("opencats: all %d discovery queries failed", failures)
+	}
+
+	var boards []string
+	for _, h := range hosts {
+		if b := opencatsResolveMount(ctx, c, h); b != "" {
+			boards = append(boards, b)
+		}
+	}
+	return boards, nil
+}
+
+// opencatsResolveMount returns the single board a host serves its portal as, or "" when the
+// host serves no portal with postings. A host answering at more than one mount yields the
+// first, so one host is always one board.
+func opencatsResolveMount(ctx context.Context, c httpClient, host string) string {
+	for _, mount := range opencatsMounts {
+		board := host + mount
+		root, err := c.GetHTML(ctx, opencatsListingURL(board))
+		if err != nil {
+			continue
+		}
+		if countMatchingLinks(root, opencatsPostingLink) > 0 {
+			return board
+		}
+	}
+	return ""
+}
+
+// opencatsListingURL builds the portal listing URL for a board (host plus optional mount).
+func opencatsListingURL(board string) string {
+	return "https://" + strings.Trim(board, "/") + "/" + opencatsListingPath
+}
+
+// opencatsIneligibleSuffixes name hosts that must never enter the board file: commercial CATS
+// shares the URL scheme with its open-source descendant and is already crawled under its own
+// provider — admitting it creates the same posting under two providers, which the
+// (source, external_id) dedup key cannot detect — and the project's own sites are
+// documentation and demos, not an employer's portal.
+var opencatsIneligibleSuffixes = []string{"catsone.com", "opencats.org"}
+
+// opencatsEligibleHost reports whether a discovered host can be a company's portal.
+func opencatsEligibleHost(host string) bool {
+	if net.ParseIP(host) != nil {
+		return false
+	}
+	for _, s := range opencatsIneligibleSuffixes {
+		if host == s || strings.HasSuffix(host, "."+s) {
+			return false
+		}
+	}
+	return true
+}
+
+// opencatsTitleSuffix matches the "- Careers" tail installs append to the portal title.
+var opencatsTitleSuffix = regexp.MustCompile(`(?i)\s*[-–—|]\s*careers\s*$`)
+
+// opencatsCompanyName proposes a company name from the portal page title, falling back to the
+// host. The proposal is reviewed by hand in the harvest diff: an install that never changed
+// its title yields the hostname again, which reads as a name but is not one.
+func opencatsCompanyName(root *html.Node, board string) string {
+	name := strings.TrimSpace(opencatsTitleSuffix.ReplaceAllString(opencatsPageTitle(root), ""))
+	if name == "" {
+		return strings.Split(board, "/")[0]
+	}
+	return name
+}
+
+// opencatsPageTitle returns the document's <title> text, or "".
+func opencatsPageTitle(root *html.Node) string {
+	var title string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if title != "" {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "title" && n.FirstChild != nil {
+			title = strings.TrimSpace(n.FirstChild.Data)
+			return
+		}
+		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
+			walk(ch)
+		}
+	}
+	walk(root)
+	return title
+}

--- a/cmd/harvest-boards/opencats_prober_test.go
+++ b/cmd/harvest-boards/opencats_prober_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+// opencatsPortalHTML is a portal listing carrying n postings, titled as an install titles it.
+func opencatsPortalHTML(title string, ids ...string) string {
+	body := `<html><head><title>` + title + `</title></head><body><table>`
+	for _, id := range ids {
+		body += `<tr><td><a href="index.php?m=careers&amp;p=showJob&amp;ID=` + id + `">Engineer ` + id + `</a></td></tr>`
+	}
+	return body + `</table></body></html>`
+}
+
+func TestOpencatsProberKeepsPortalWithPostings(t *testing.T) {
+	f := fakeGetter{
+		"https://careers.crewlogix.com/careers/index.php?m=careers&p=showAll": opencatsPortalHTML(
+			"Crewlogix Technologies - Careers", "114", "113"),
+	}
+
+	name, jobs, err := (opencatsProber{}).probe(context.Background(), f, "careers.crewlogix.com/careers")
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if jobs != 2 {
+		t.Errorf("openJobs = %d, want 2", jobs)
+	}
+	if name != "Crewlogix Technologies" {
+		t.Errorf("company = %q, want the portal title without its Careers suffix", name)
+	}
+}
+
+// TestOpencatsProberNamesFromHostWhenTitleIsUseless covers the common install that never
+// changed its title, so the title is just the hostname again.
+func TestOpencatsProberNamesFromHostWhenTitleIsUseless(t *testing.T) {
+	f := fakeGetter{
+		"https://careers.boomit.pt/careers/index.php?m=careers&p=showAll": opencatsPortalHTML(
+			"careers.boomit.pt - Careers", "51"),
+	}
+
+	name, jobs, err := (opencatsProber{}).probe(context.Background(), f, "careers.boomit.pt/careers")
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if jobs != 1 {
+		t.Errorf("openJobs = %d, want 1", jobs)
+	}
+	if name != "careers.boomit.pt" {
+		t.Errorf("company = %q, want the host as the fallback name", name)
+	}
+}
+
+func TestOpencatsProberSkipsUnreachableOrEmpty(t *testing.T) {
+	f := fakeGetter{
+		"https://empty.example.com/index.php?m=careers&p=showAll": opencatsPortalHTML("Empty - Careers"),
+	}
+
+	for _, board := range []string{"empty.example.com", "missing.example.com"} {
+		name, jobs, err := (opencatsProber{}).probe(context.Background(), f, board)
+		if err != nil {
+			t.Errorf("board %q: probe returned an error, want a silent skip: %v", board, err)
+		}
+		if name != "" || jobs != 0 {
+			t.Errorf("board %q: got (%q, %d), want a skip", board, name, jobs)
+		}
+	}
+}
+
+// TestOpencatsDiscoveryRejectsIneligibleHosts guards the two ways discovery poisons the board
+// file: commercial CATS hosts, already crawled under their own provider (a cross-provider
+// duplicate the (source, external_id) key cannot catch), and hosts that are not a company
+// portal at all.
+func TestOpencatsDiscoveryRejectsIneligibleHosts(t *testing.T) {
+	rejected := []string{
+		"gulfstream.catsone.com",
+		"kommlink.catsone.com",
+		"email.catsone.com",
+		"44.224.147.179",
+		"opencats.org",
+		"www.opencats.org",
+		"documentation.opencats.org",
+	}
+	for _, h := range rejected {
+		if opencatsEligibleHost(h) {
+			t.Errorf("host %q was accepted, want it rejected", h)
+		}
+	}
+
+	accepted := []string{
+		"careers.crewlogix.com",
+		"atscareers.g4s.com",
+		"itsource.indovisionglobal.com",
+		"opencats.gorgany.com",
+	}
+	for _, h := range accepted {
+		if !opencatsEligibleHost(h) {
+			t.Errorf("host %q was rejected, want it accepted", h)
+		}
+	}
+}
+
+// TestOpencatsResolveMountPicksOneBoardPerHost is what keeps a host from entering the board
+// file twice. Installs mount the portal differently, and a board is the mount point, so the
+// same portal reachable at two mounts would namespace one posting under two external ids.
+func TestOpencatsResolveMountPicksOneBoardPerHost(t *testing.T) {
+	f := fakeGetter{
+		"https://careers.boomit.pt/careers/index.php?m=careers&p=showAll": opencatsPortalHTML("Boomit", "51"),
+		"https://atscareers.g4s.com/index.php?m=careers&p=showAll":        opencatsPortalHTML("G4S", "30156"),
+		// A host answering at both mounts must still yield exactly one board.
+		"https://both.example.com/careers/index.php?m=careers&p=showAll": opencatsPortalHTML("Both", "1"),
+		"https://both.example.com/index.php?m=careers&p=showAll":         opencatsPortalHTML("Both", "1"),
+	}
+
+	cases := map[string]string{
+		"careers.boomit.pt":     "careers.boomit.pt/careers",
+		"atscareers.g4s.com":    "atscareers.g4s.com",
+		"both.example.com":      "both.example.com/careers",
+		"nonportal.example.com": "",
+	}
+	for host, want := range cases {
+		if got := opencatsResolveMount(context.Background(), f, host); got != want {
+			t.Errorf("resolveMount(%q) = %q, want %q", host, got, want)
+		}
+	}
+}
+
+// TestOpencatsDiscoverUnionsSignatures checks the discovery contract: several signature
+// queries, one de-duplicated candidate list, each entry already resolved to its mount.
+func TestOpencatsDiscoverUnionsSignatures(t *testing.T) {
+	f := fakeGetter{}
+	for _, q := range opencatsDiscoveryQueries {
+		f[opencatsSearchURL(q)] = `{"results":[
+			{"task":{"domain":"careers.boomit.pt"}},
+			{"task":{"domain":"gulfstream.catsone.com"}},
+			{"task":{"domain":"atscareers.g4s.com"}}
+		]}`
+	}
+	f["https://careers.boomit.pt/careers/index.php?m=careers&p=showAll"] = opencatsPortalHTML("Boomit", "51")
+	f["https://atscareers.g4s.com/index.php?m=careers&p=showAll"] = opencatsPortalHTML("G4S", "30156")
+
+	got, err := (opencatsProber{}).discover(context.Background(), f)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	slices.Sort(got)
+	want := []string{"atscareers.g4s.com", "careers.boomit.pt/careers"}
+	if !slices.Equal(got, want) {
+		t.Errorf("discover() = %v, want %v (de-duplicated across queries, CATS excluded)", got, want)
+	}
+}
+
+func TestOpencatsProberRegistered(t *testing.T) {
+	p, ok := probers["opencats"]
+	if !ok {
+		t.Fatal("probers missing opencats")
+	}
+	if _, ok := p.(discoverer); !ok {
+		t.Error("opencats prober must support discovery: it has no seed list to fall back on")
+	}
+}

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -558,6 +558,7 @@ var probers = map[string]prober{
 	"deel":            deelProber{},
 	"freshteam":       freshteamProber{},
 	"jobvite":         jobviteProber{},
+	"opencats":        opencatsProber{},
 	"join":            joinProber{},
 	"oracle":          oracleProber{},
 	"jazzhr":          jazzhrProber{},

--- a/docs/superpowers/specs/2026-07-28-opencats-adapter-harvest-design.md
+++ b/docs/superpowers/specs/2026-07-28-opencats-adapter-harvest-design.md
@@ -1,0 +1,156 @@
+# OpenCATS source adapter and portal harvest
+
+Date: 2026-07-28
+Status: approved design, not yet implemented
+
+## Problem
+
+`freehire` crawls ~150 ATS providers, all of them multi-tenant SaaS: one adapter plus a list
+of slugs yields thousands of boards. OpenCATS is the opposite shape — a self-hosted PHP ATS
+that each company installs on its own domain. There is no tenant catalogue to enumerate, so
+the platform is invisible to the existing harvest, which resolves candidates either from a
+seed slug list or from a provider API (`resolveCandidates`, `cmd/harvest-boards/main.go`).
+
+The question this design answers is whether self-hosted OpenCATS installs carry enough live
+postings to be worth a provider at all, and if so, how to find them repeatably.
+
+## Reconnaissance (completed 2026-07-28)
+
+Candidate discovery through the urlscan.io search API, by signature:
+
+| Query | Results | Unique hosts |
+|---|---|---|
+| `page.title:"OpenCATS"` | 144 | 66 |
+| `page.url:"careers/index.php"` | 32 | 19 |
+| `page.url:"m=careers"` | 17 | 13 |
+
+The default `<title>` is by far the richest signal: most administrators change the portal
+path or put it behind a rewrite, but leave the page title alone.
+
+Probing the 78 deduplicated candidate hosts found **9 live portals carrying 260 open jobs**:
+
+| Host | Jobs |
+|---|---|
+| `atscareers.g4s.com` | 108 |
+| `itsource.indovisionglobal.com` | 95 |
+| `opencats.gorgany.com` | 33 |
+| `careers.crewlogix.com` | 8 |
+| `careers.boomit.pt` | 6 |
+| `rms.adgonline.ca` | 5 |
+| `dwrs.mggroup.lk` | 2 |
+| `ats.thomasstewartbuilders.com` | 2 |
+| `opencats.vikisoft.com.ua` | 1 |
+
+All nine answer over HTTPS, so the adapter is https-only — no cleartext fallback.
+
+Common Crawl was evaluated and rejected as a discovery channel: its CDX index is sorted by
+SURT (domain first), so a global search by URL path returns nothing.
+
+FreeATS is **out of scope**. Its README documents only self-hosted Docker deployment, with
+no public career-page pattern or API, and a urlscan sweep finds zero public installs
+(`free-ats.ru` and `freeats.ca` are unrelated companies of a similar name). The seam is
+noted here; no code is written for it.
+
+## Design
+
+### Board identity
+
+`board` is the portal root: host plus an optional path prefix, because installs differ in
+where the portal sits — `atscareers.g4s.com` serves it at the web root while
+`careers.boomit.pt/careers` nests it. The listing URL is
+`https://<board>/index.php?m=careers&p=showAll`.
+
+This reuses the shape `sources/catsone.yml` already proves in production, where `board` is a
+careers host and is sometimes a customer's own domain (`jobs.evoplay.com.ua`). No change to
+the board-file format.
+
+### Dedup key
+
+An OpenCATS job `ID` is unique only within one install: `ID=24` exists on both
+`careers.boomit.pt` and `careers.crewlogix.com`. Under `jobs UNIQUE (source, external_id)`
+with a shared `source = "opencats"` these would collide and overwrite each other.
+
+No special handling is required in the adapter. `pipeline.jobIdentity`
+(`internal/pipeline/pipeline.go:539`) routes every id through
+`sources.NamespaceExternalID(e.Board, j.ExternalID)`, producing `<board>:<id>`. The adapter
+emits the raw numeric id and the pipeline namespaces it — the same single door used by
+link-source resolution, so a job reached by either path dedups against the other.
+
+### Parsing strategy: routing, not markup
+
+Installs customise the template freely. G4S has rewritten it (HTML5, custom assets),
+boomit and crewlogix run the stock XHTML 1.0 template, and indovision has added "education"
+and "experience" columns. CSS classes, column order, and column count agree nowhere.
+
+Two invariants hold across every install inspected, and they are sufficient:
+
+1. A job links as `index.php?m=careers&p=showJob&ID=<n>` — this yields `ExternalID`.
+2. **The anchor's text is the job title** — verified on all four installs inspected.
+
+Location and description therefore come from the detail page, never from the listing row:
+row columns are positional and differ per install, while detail-page fields are labelled.
+
+### Components
+
+**`internal/sources/opencats.go`** — the adapter, modelled on `catsone.go`. `Fetch` reads the
+listing, collects `(id, title, detail URL)` per anchor, then fans out over detail pages via
+the existing `fetchDetails` helper at `defaultDetailWorkers`. Registered as one line in
+`sources.All`. Description passes through `sanitizeHTML`.
+
+**`cmd/harvest-boards/opencats_prober.go`** — a `prober` that also implements the existing
+`discoverer` interface, so `go run ./cmd/harvest-boards opencats` runs with no seed file.
+`discover` queries urlscan for the signatures above, unions and deduplicates hosts, and
+drops noise. `probe` tries the known portal paths, counts `showJob` anchors, and returns
+`("", 0, nil)` for anything absent or empty — a silent skip, never fatal.
+
+The prober MUST exclude two classes, both observed in the real data:
+
+- **`*.catsone.com` hosts.** Commercial CATS shares the URL scheme with its open-source
+  descendant and is already covered by `sources/catsone.yml`. Admitting them creates a
+  cross-provider duplicate, which the `(source, external_id)` key cannot catch.
+- **Non-job anchors**, e.g. boomit `ID=24` "Can't find what you're looking for? Apply here",
+  a general-application form rather than a position.
+
+**`sources/opencats.yml`** — a new provider file, one entry per validated board, following
+the one-file-per-provider convention. The company name is proposed by the prober from
+`<title>` with a domain fallback, then corrected by a human reviewing the harvest diff.
+
+### Failure handling
+
+A listing that will not load is a board failure: `stats.Failed` plus the `board_health`
+sidecar, which cools the host off after three consecutive failures (`6h·2^(f-3)`, capped at
+24h) and self-heals on success. A detail page that will not load skips that one posting
+(`ok=false`), matching `catsone.detail`. One dead install never aborts the run.
+
+The provider is **not** self-closing — it is absent from `sources.SelfClosingProviders`, so
+withdrawn postings close through the 48-hour unseen-job sweep.
+
+### Testing
+
+Table-driven tests with builder functions producing fixture HTML inline, per the convention
+in `catsone_test.go` (not `testdata/` files). Cases:
+
+- stock XHTML template (boomit/crewlogix shape) and rewritten template (g4s shape);
+- extra listing columns (indovision shape) — asserts no positional column assumptions;
+- the "Apply here" pseudo-job is excluded;
+- a detail page that 404s skips one job and keeps the rest;
+- `<script>` inside a description is stripped by `sanitizeHTML`;
+- prober unit test: `*.catsone.com` candidates are rejected.
+
+## Out of scope
+
+- Submitting applications through the portal — the adapter is read-only, as all adapters are.
+- FreeATS — zero public installs; revisit only if that changes.
+- Self-closing support.
+
+## Risks
+
+- **Small absolute volume.** 260 jobs is a fraction of a mid-size SaaS provider. The
+  justification is the marginal cost, not the count: one adapter plus one prober, reusing
+  every existing pipeline facility.
+- **Template drift.** An install may rewrite the portal past recognition. Mitigation: parse
+  routing invariants only; a broken install degrades to zero jobs and cools off rather than
+  producing garbage.
+- **Discovery ceiling.** urlscan only knows hosts someone has scanned. This finds the
+  publicly visible tail, not every install — an accepted limit, recorded here so an empty
+  future harvest is not misread as "no new installs exist".

--- a/internal/sources/opencats.go
+++ b/internal/sources/opencats.go
@@ -19,6 +19,9 @@ type opencats struct {
 	http HTMLGetter
 }
 
+// opencatsListingQuery is the portal's "show all" route, appended to the board root.
+const opencatsListingQuery = "index.php?m=careers&p=showAll"
+
 // NewOpencats builds the OpenCATS adapter over the given HTML client.
 func NewOpencats(c HTMLGetter) Source { return opencats{http: c} }
 
@@ -38,13 +41,10 @@ func (s opencats) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	}), nil
 }
 
-// opencatsListingQuery is the portal's "show all" route, appended to the board root.
-const opencatsListingQuery = "index.php?m=careers&p=showAll"
-
 // detail fetches one posting's page for the fields the listing cannot be trusted to carry,
-// returning ok=false when the fetch fails so the caller skips just that posting. Location comes
-// from the labelled details table rather than a listing column: column order and count differ
-// per install, but the label does not.
+// returning ok=false when the fetch fails so the caller skips just that posting. Location and
+// body come from the detail page rather than a listing column because listing columns are
+// positional and differ per install; the detail page names its fields.
 func (s opencats) detail(ctx context.Context, e CompanyEntry, c opencatsListing) (Job, bool) {
 	root, err := s.http.GetHTML(ctx, c.URL)
 	if err != nil {
@@ -82,7 +82,7 @@ var opencatsBodyContainers = []string{
 // container we do not know.
 func opencatsBody(root *html.Node) *html.Node {
 	for _, name := range opencatsBodyContainers {
-		if n := firstByAttr(root, "id", name); n != nil {
+		if n := firstByID(root, name); n != nil {
 			return n
 		}
 		if n := firstByClass(root, name); n != nil {
@@ -105,7 +105,7 @@ func opencatsLocation(root *html.Node) string {
 
 // opencatsFirstDetailValue returns the value cell of the details table's first row, or "".
 func opencatsFirstDetailValue(root *html.Node) string {
-	table := firstByAttr(root, "id", "detailsTable")
+	table := firstByID(root, "detailsTable")
 	if table == nil {
 		return ""
 	}

--- a/internal/sources/opencats.go
+++ b/internal/sources/opencats.go
@@ -1,0 +1,186 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// opencats adapts a self-hosted OpenCATS career portal. The board is the portal root — a host,
+// optionally followed by the path the portal is mounted under, since installs differ on that
+// (atscareers.g4s.com serves it at the web root, careers.boomit.pt/careers nests it). The
+// listing at index.php?m=careers&p=showAll links every open posting; the showJob detail page
+// carries the labelled fields and the body. There is no pagination — the listing is complete.
+type opencats struct {
+	http HTMLGetter
+}
+
+// NewOpencats builds the OpenCATS adapter over the given HTML client.
+func NewOpencats(c HTMLGetter) Source { return opencats{http: c} }
+
+func (opencats) Provider() string { return "opencats" }
+
+func (s opencats) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse("https://" + strings.Trim(e.Board, "/") + "/")
+	if err != nil {
+		return nil, fmt.Errorf("opencats: board %q: %w", e.Board, err)
+	}
+	root, err := s.http.GetHTML(ctx, base.String()+opencatsListingQuery)
+	if err != nil {
+		return nil, fmt.Errorf("opencats: listing %s: %w", e.Board, err)
+	}
+	return fetchDetails(opencatsListings(base, root), defaultDetailWorkers, func(c opencatsListing) (Job, bool) {
+		return s.detail(ctx, e, c)
+	}), nil
+}
+
+// opencatsListingQuery is the portal's "show all" route, appended to the board root.
+const opencatsListingQuery = "index.php?m=careers&p=showAll"
+
+// detail fetches one posting's page for the fields the listing cannot be trusted to carry,
+// returning ok=false when the fetch fails so the caller skips just that posting. Location comes
+// from the labelled details table rather than a listing column: column order and count differ
+// per install, but the label does not.
+func (s opencats) detail(ctx context.Context, e CompanyEntry, c opencatsListing) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, c.URL)
+	if err != nil {
+		return Job{}, false
+	}
+	location := opencatsLabelledField(root, "location")
+	description := ""
+	if body := firstByAttr(root, "id", "descriptive"); body != nil {
+		description = sanitizeHTML(innerHTML(body))
+	}
+	return Job{
+		ExternalID:  c.ID,
+		URL:         c.URL,
+		Title:       c.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: description,
+		Remote:      isRemote(location),
+	}, true
+}
+
+// opencatsLabelledField reads a value from the posting's details table by its label, matching
+// case-insensitively on a substring so a template that renames "Location" to "Work Location"
+// still resolves. The value is the next element cell after the label cell.
+func opencatsLabelledField(root *html.Node, label string) string {
+	var value string
+	walk(root, func(n *html.Node) bool {
+		if value != "" || n.Type != html.ElementNode || (n.Data != "td" && n.Data != "th") {
+			return true
+		}
+		if !strings.Contains(strings.ToLower(textContent(n)), label) {
+			return true
+		}
+		if next := nextElement(n); next != nil {
+			value = strings.TrimSpace(textContent(next))
+		}
+		return true
+	})
+	return value
+}
+
+// opencatsGeneralApplicationMarkers name the talent-pool entries installs park in the portal
+// alongside real openings ("Can't find what you're looking for? Apply here" is the one seen in
+// the wild). They use the posting route but are a standing form, not a position. The markers
+// are phrases rather than single words so a genuine role — an Application Security Engineer, a
+// General Manager — is not swallowed with them.
+var opencatsGeneralApplicationMarkers = []string{
+	"apply here",
+	"general application",
+	"open application",
+	"spontaneous application",
+}
+
+// opencatsIsGeneralApplication reports whether a posting title names a standing application
+// form rather than an open position.
+func opencatsIsGeneralApplication(title string) bool {
+	t := strings.ToLower(title)
+	for _, m := range opencatsGeneralApplicationMarkers {
+		if strings.Contains(t, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// nextElement returns the next sibling that is an element, skipping the whitespace text nodes a
+// server-rendered table is full of.
+func nextElement(n *html.Node) *html.Node {
+	for s := n.NextSibling; s != nil; s = s.NextSibling {
+		if s.Type == html.ElementNode {
+			return s
+		}
+	}
+	return nil
+}
+
+// opencatsListing is one posting read from a portal listing: its absolute detail URL, the
+// native numeric id, and the title carried by the anchor text.
+type opencatsListing struct {
+	URL   string
+	ID    string
+	Title string
+}
+
+// opencatsJobIDPattern captures the native posting id from a careers-route URL. The id is
+// matched independently of parameter order, since a rewritten template may emit them in any
+// sequence.
+var opencatsJobIDPattern = regexp.MustCompile(`[?&]ID=(\d+)`)
+
+// opencatsJobID extracts the native posting id from a portal URL, or "" when the URL is not a
+// job posting. A URL only counts as a posting when it carries the showJob route: the portal
+// reuses the same id on other routes (candidateRegistration, for one), which are actions on a
+// posting rather than postings themselves.
+func opencatsJobID(loc string) string {
+	if !strings.Contains(loc, "p=showJob") {
+		return ""
+	}
+	return firstSubmatch(opencatsJobIDPattern, loc)
+}
+
+// opencatsListings parses each posting from a portal listing. Installs customise the template
+// freely — CSS classes, element types, column order, and column count differ between them — so
+// this reads the two things a rewrite cannot change without breaking the portal itself: the
+// showJob route, which carries the id, and the anchor text, which is the title. Postings are
+// de-duplicated by id, keeping the first anchor, because a listing commonly links one posting
+// twice (its title and an apply button) and the title link comes first.
+func opencatsListings(base *url.URL, root *html.Node) []opencatsListing {
+	var out []opencatsListing
+	seen := map[string]struct{}{}
+	walk(root, func(n *html.Node) bool {
+		if n.Type != html.ElementNode || n.Data != "a" {
+			return true
+		}
+		href := attr(n, "href")
+		id := opencatsJobID(href)
+		if id == "" {
+			return true
+		}
+		if _, ok := seen[id]; ok {
+			return true
+		}
+		title := strings.TrimSpace(textContent(n))
+		if opencatsIsGeneralApplication(title) {
+			return true
+		}
+		ref, err := url.Parse(href)
+		if err != nil {
+			return true
+		}
+		seen[id] = struct{}{}
+		out = append(out, opencatsListing{
+			URL:   base.ResolveReference(ref).String(),
+			ID:    id,
+			Title: title,
+		})
+		return true
+	})
+	return out
+}

--- a/internal/sources/opencats.go
+++ b/internal/sources/opencats.go
@@ -50,9 +50,9 @@ func (s opencats) detail(ctx context.Context, e CompanyEntry, c opencatsListing)
 	if err != nil {
 		return Job{}, false
 	}
-	location := opencatsLabelledField(root, "location")
+	location := opencatsLocation(root)
 	description := ""
-	if body := firstByAttr(root, "id", "descriptive"); body != nil {
+	if body := opencatsBody(root); body != nil {
 		description = sanitizeHTML(innerHTML(body))
 	}
 	return Job{
@@ -64,6 +64,74 @@ func (s opencats) detail(ctx context.Context, e CompanyEntry, c opencatsListing)
 		Description: description,
 		Remote:      isRemote(location),
 	}, true
+}
+
+// opencatsBodyContainers name the elements installs put the posting body in, as an id or a
+// class. The shipped template uses "descriptive"; installs that rebuilt the page rename it, and
+// one carries the rename's typo (careers.crewlogix.com ships "job-decription"). This is a
+// dictionary rather than a fuzzy match on purpose: an unknown container yields no description,
+// which is visible and fixable, where guessing yields navigation chrome stored as a job body.
+var opencatsBodyContainers = []string{
+	"descriptive",
+	"job-description",
+	"job-decription",
+	"description",
+}
+
+// opencatsBody returns the element holding the posting body, or nil when the install uses a
+// container we do not know.
+func opencatsBody(root *html.Node) *html.Node {
+	for _, name := range opencatsBodyContainers {
+		if n := firstByAttr(root, "id", name); n != nil {
+			return n
+		}
+		if n := firstByClass(root, name); n != nil {
+			return n
+		}
+	}
+	return nil
+}
+
+// opencatsLocation reads the posting's location, preferring the labelled field and falling back
+// to the first row of the details table. The fallback exists because installs serve the portal
+// in their own language (opencats.gorgany.com labels it "Місцезнаходження"), and while the label
+// text is translated, the shipped template's row order is not: location is the first row.
+func opencatsLocation(root *html.Node) string {
+	if v := opencatsLabelledField(root, "location"); v != "" {
+		return v
+	}
+	return opencatsFirstDetailValue(root)
+}
+
+// opencatsFirstDetailValue returns the value cell of the details table's first row, or "".
+func opencatsFirstDetailValue(root *html.Node) string {
+	table := firstByAttr(root, "id", "detailsTable")
+	if table == nil {
+		return ""
+	}
+	var value string
+	walk(table, func(n *html.Node) bool {
+		if value != "" || n.Type != html.ElementNode || n.Data != "tr" {
+			return true
+		}
+		if label := firstElementChild(n); label != nil {
+			if next := nextElement(label); next != nil {
+				value = strings.TrimSpace(textContent(next))
+			}
+		}
+		return false
+	})
+	return value
+}
+
+// firstElementChild returns the node's first element child, skipping text nodes.
+func firstElementChild(n *html.Node) *html.Node {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode {
+			return c
+		}
+	}
+	return nil
 }
 
 // opencatsLabelledField reads a value from the posting's details table by its label, matching

--- a/internal/sources/opencats_test.go
+++ b/internal/sources/opencats_test.go
@@ -63,6 +63,81 @@ func opencatsStockDetailHTML() string {
 </div></body></html>`
 }
 
+// opencatsLocalisedDetailHTML is a posting page from an install serving a non-English portal
+// (opencats.gorgany.com serves Ukrainian): the shipped template's row order survives, but the
+// field labels are translated, so an English label match finds nothing.
+func opencatsLocalisedDetailHTML() string {
+	return `<html><body><div id="careerContent">
+<h1>Position Details: Адміністратор магазину</h1>
+<table id="detailsTable">
+<tr><td class="detailsHeader"><strong>Місцезнаходження:</strong></td><td>Київ, Україна</td></tr>
+<tr><td class="detailsHeader"><strong>Openings:</strong></td><td>2</td></tr>
+<tr><td class="detailsHeader"><strong>Зарплата:</strong></td><td></td></tr>
+</table>
+<div id="descriptive"><p>Робота в магазині.</p></div>
+</div></body></html>`
+}
+
+// opencatsRenamedBodyDetailHTML is a posting page from an install that renamed the body
+// container — careers.crewlogix.com ships it as "job-decription", typo and all — and dropped
+// the table id. The labels survive, so only the body lookup has to cope.
+func opencatsRenamedBodyDetailHTML() string {
+	return `<html><body><div id="careerContent">
+<h1>Position Details: Sr. PHP Developer</h1>
+<table>
+<tr><td class="detailsHeader"><strong>Location:</strong></td><td>Gulberg 3, Lahore</td></tr>
+<tr><td class="detailsHeader"><strong>Openings:</strong></td><td>1</td></tr>
+</table>
+<div class="job-decription"><p>Build and maintain PHP services.</p></div>
+</div></body></html>`
+}
+
+// TestOpencatsDetailReadsLocalisedLocation covers the 33 postings on the Ukrainian install that
+// a label-only lookup silently dropped: the label is translated, but the shipped template's row
+// order is not, so the first row of the details table is still the location.
+func TestOpencatsDetailReadsLocalisedLocation(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("p=showJob&ID=406", opencatsLocalisedDetailHTML()).
+		route("p=showAll", opencatsStockListingHTML([3]string{"406", "Адміністратор магазину", "Київ"}))
+
+	jobs, err := NewOpencats(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Gorgany", Board: "opencats.gorgany.com/careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].Location != "Київ, Україна" {
+		t.Errorf("Location = %q, want the first details row when the label is not English", jobs[0].Location)
+	}
+}
+
+// TestOpencatsDetailReadsRenamedBody covers the 8 postings that came back with an empty
+// description because the install renamed the body container.
+func TestOpencatsDetailReadsRenamedBody(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("p=showJob&ID=114", opencatsRenamedBodyDetailHTML()).
+		route("p=showAll", opencatsStockListingHTML([3]string{"114", "Sr. PHP Developer", "Lahore"}))
+
+	jobs, err := NewOpencats(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Crewlogix Technologies", Board: "careers.crewlogix.com/careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "Build and maintain PHP services") {
+		t.Errorf("Description = %q, want the renamed body container's text", jobs[0].Description)
+	}
+	if jobs[0].Location != "Gulberg 3, Lahore" {
+		t.Errorf("Location = %q", jobs[0].Location)
+	}
+}
+
 func TestOpencatsFetchMapsListingAndDetail(t *testing.T) {
 	fake := (&routedHTTP{}).
 		route("p=showJob&ID=51", opencatsStockDetailHTML()).

--- a/internal/sources/opencats_test.go
+++ b/internal/sources/opencats_test.go
@@ -1,0 +1,266 @@
+package sources
+
+import (
+	"context"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// opencatsStockListingHTML is the listing an install running the shipped OpenCATS template
+// serves: an XHTML table whose rows link each posting by the careers route, with the title as
+// the anchor text. Columns are department, title, location.
+func opencatsStockListingHTML(rows ...[3]string) string { // row = {id, title, location}
+	var b strings.Builder
+	b.WriteString(`<html><body><table class="careerPortalListing"><tr>` +
+		`<th>Department</th><th>Job Title</th><th>Location</th></tr>`)
+	for _, r := range rows {
+		b.WriteString(`<tr class="careerPortalListItem">` +
+			`<td>Engineering</td>` +
+			`<td><a href="index.php?m=careers&amp;p=showJob&amp;ID=` + r[0] + `">` + r[1] + `</a></td>` +
+			`<td>` + r[2] + `</td></tr>`)
+	}
+	b.WriteString(`</table></body></html>`)
+	return b.String()
+}
+
+// opencatsRewrittenListingHTML is the same listing from an install that replaced the template
+// wholesale (as G4S has): different element types, different classes, extra columns in a
+// different order, and a second link to the same posting for the apply action. Only the
+// careers route and the anchor text survive the rewrite — which is exactly what the adapter
+// is allowed to depend on.
+func opencatsRewrittenListingHTML(rows ...[3]string) string { // row = {id, title, location}
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="jobs-grid">`)
+	for _, r := range rows {
+		b.WriteString(`<div class="job-card" data-kind="posting">` +
+			`<span class="loc">` + r[2] + `</span>` +
+			`<span class="entity">Acme Holdings Ltd.</span>` +
+			`<h3><a class="ttl" href="/index.php?m=careers&amp;p=showJob&amp;ID=` + r[0] + `">` + r[1] + `</a></h3>` +
+			`<a class="btn" href="/index.php?m=careers&amp;p=showJob&amp;ID=` + r[0] + `">APPLY NOW</a>` +
+			`</div>`)
+	}
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// opencatsStockDetailHTML is a posting page from the shipped template: the title follows a
+// "Position Details:" prefix in the h1, the labelled fields sit in #detailsTable, and the body
+// is #descriptive. The body carries a character entity (est&aacute;) because real portals
+// serve accented prose that way — the tags themselves are live, so the shared sanitiser must
+// leave readable text, not a re-encoded entity. The embedded script must not survive.
+func opencatsStockDetailHTML() string {
+	return `<html><body><div id="careerContent">
+<h1>Position Details: MuleSoft Platform Support Engineer (L2)</h1>
+<table id="detailsTable">
+<tr><td class="detailsHeader"><strong>Location:</strong></td><td>Lisboa, Lisboa</td></tr>
+<tr><td class="detailsHeader"><strong>Openings:</strong></td><td>1</td></tr>
+<tr><td class="detailsHeader"><strong>Work Model:</strong></td><td>Hybrid</td></tr>
+</table>
+<div id="descriptive"><p><strong>Description:</strong></p>
+<p>A equipa est&aacute; a crescer.</p><ul><li>Suporte L2.</li></ul><script>alert(1)</script></div>
+</div></body></html>`
+}
+
+func TestOpencatsFetchMapsListingAndDetail(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("p=showJob&ID=51", opencatsStockDetailHTML()).
+		route("p=showAll", opencatsStockListingHTML(
+			[3]string{"51", "MuleSoft Platform Support Engineer (L2)", "Lisbon"}))
+
+	jobs, err := NewOpencats(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Boomit", Provider: "opencats", Board: "careers.boomit.pt/careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "51" {
+		t.Errorf("ExternalID = %q, want the native posting id 51", j.ExternalID)
+	}
+	if j.Title != "MuleSoft Platform Support Engineer (L2)" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Boomit" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if want := "https://careers.boomit.pt/careers/index.php?m=careers&p=showJob&ID=51"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if j.Location != "Lisboa, Lisboa" {
+		t.Errorf("Location = %q, want the detail page's Location field", j.Location)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Suporte L2") {
+		t.Errorf("Description lost the body: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "está") {
+		t.Errorf("Description should carry readable accented text, got %q", j.Description)
+	}
+}
+
+// TestOpencatsFetchResolvesRootMountedBoard covers the other mount shape: a portal served from
+// the web root rather than under a /careers prefix.
+func TestOpencatsFetchResolvesRootMountedBoard(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("p=showJob&ID=30156", opencatsStockDetailHTML()).
+		route("https://atscareers.g4s.com/index.php?m=careers&p=showAll",
+			opencatsStockListingHTML([3]string{"30156", "Security Analyst", "Chennai"}))
+
+	jobs, err := NewOpencats(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "G4S", Provider: "opencats", Board: "atscareers.g4s.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 — the listing URL was probably built wrong", len(jobs))
+	}
+}
+
+// TestOpencatsListingsSkipGeneralApplication guards a real posting seen on careers.boomit.pt:
+// installs park a "Can't find what you're looking for? Apply here" entry in the portal, which
+// uses the posting route but is a talent-pool form, not an open position.
+func TestOpencatsListingsSkipGeneralApplication(t *testing.T) {
+	base, err := url.Parse("https://careers.boomit.pt/careers/")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+
+	for _, title := range []string{
+		"Can’t find what you’re looking for? Apply here",
+		"Can't find what you're looking for? Apply here",
+		"General Application",
+		"Open Application",
+		"Spontaneous application",
+	} {
+		got := opencatsListings(base, parseHTML(t, opencatsStockListingHTML([3]string{"24", title, "Various"})))
+		if len(got) != 0 {
+			t.Errorf("title %q: got %d postings, want it excluded as a general-application entry", title, len(got))
+		}
+	}
+}
+
+// TestOpencatsListingsKeepRealPostingsThatMentionApplications is the other half of the filter:
+// the exclusion must not swallow genuine roles whose titles happen to contain the same words.
+func TestOpencatsListingsKeepRealPostingsThatMentionApplications(t *testing.T) {
+	base, err := url.Parse("https://careers.boomit.pt/careers/")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+
+	for _, title := range []string{
+		"Senior Application Security Engineer",
+		"Application Support Analyst",
+		"General Manager, Engineering",
+	} {
+		got := opencatsListings(base, parseHTML(t, opencatsStockListingHTML([3]string{"77", title, "Lisbon"})))
+		if len(got) != 1 {
+			t.Errorf("title %q: got %d postings, want it kept as a real posting", title, len(got))
+		}
+	}
+}
+
+func TestOpencatsListingErrorIsBoardError(t *testing.T) {
+	if _, err := NewOpencats(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{
+		Board: "careers.boomit.pt/careers",
+	}); err == nil {
+		t.Fatal("want a board-level error when the listing fails, not an empty success")
+	}
+}
+
+// TestOpencatsFailedDetailSkipsOnlyThatPosting keeps one broken posting from costing the board:
+// self-hosted installs are individually flaky, so isolation is the difference between losing a
+// job and losing an employer.
+func TestOpencatsFailedDetailSkipsOnlyThatPosting(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("p=showJob&ID=51", opencatsStockDetailHTML()). // ID=50 has no route: its detail fails
+		route("p=showAll", opencatsStockListingHTML(
+			[3]string{"51", "MuleSoft Platform Support Engineer (L2)", "Lisbon"},
+			[3]string{"50", "Data Engineer (Fabric + Power BI)", "Porto"}))
+
+	jobs, err := NewOpencats(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Boomit", Board: "careers.boomit.pt/careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "51" {
+		t.Fatalf("got %+v, want only posting 51 — a failed detail must not drop the board", jobs)
+	}
+}
+
+func TestOpencatsRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["opencats"]
+	if !ok {
+		t.Fatal("All() missing provider opencats")
+	}
+	if s.Provider() != "opencats" {
+		t.Errorf("Provider() = %q", s.Provider())
+	}
+	if slices.Contains(SelfClosingProviders(All(nil)), "opencats") {
+		t.Error("opencats must not be self-closing: the portal gives no removal signal")
+	}
+}
+
+// TestOpencatsListingsReadRoutingNotMarkup is the adapter's central contract: installs
+// customise the portal template freely, so two listings with nothing in common but the
+// careers route must yield the same postings.
+func TestOpencatsListingsReadRoutingNotMarkup(t *testing.T) {
+	rows := [][3]string{
+		{"51", "MuleSoft Platform Support Engineer (L2)", "Lisbon"},
+		{"50", "Data Engineer (Fabric + Power BI)", "Remote"},
+	}
+	base, err := url.Parse("https://careers.boomit.pt/careers/")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+
+	for name, doc := range map[string]string{
+		"stock template":     opencatsStockListingHTML(rows...),
+		"rewritten template": opencatsRewrittenListingHTML(rows...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := opencatsListings(base, parseHTML(t, doc))
+			if len(got) != 2 {
+				t.Fatalf("got %d postings, want 2: %+v", len(got), got)
+			}
+			for i, want := range rows {
+				if got[i].ID != want[0] {
+					t.Errorf("posting %d: ID = %q, want %q", i, got[i].ID, want[0])
+				}
+				if got[i].Title != want[1] {
+					t.Errorf("posting %d: Title = %q, want the anchor text %q", i, got[i].Title, want[1])
+				}
+			}
+		})
+	}
+}
+
+// TestOpencatsListingsCollapseRepeatedLinks guards the rewritten-template case where a
+// posting is linked twice (title plus an apply button): the portal offers one position, so
+// the adapter must offer one job.
+func TestOpencatsListingsCollapseRepeatedLinks(t *testing.T) {
+	base, err := url.Parse("https://atscareers.g4s.com/")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	doc := opencatsRewrittenListingHTML([3]string{"30156", "Security Analyst", "Chennai, India"})
+
+	got := opencatsListings(base, parseHTML(t, doc))
+	if len(got) != 1 {
+		t.Fatalf("got %d postings, want 1 (the title link and the apply link are one posting): %+v", len(got), got)
+	}
+	if got[0].Title != "Security Analyst" {
+		t.Errorf("Title = %q, want the title anchor's text, not the apply button's", got[0].Title)
+	}
+	if want := "https://atscareers.g4s.com/index.php?m=careers&p=showJob&ID=30156"; got[0].URL != want {
+		t.Errorf("URL = %q, want %q", got[0].URL, want)
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -83,6 +83,7 @@ func All(c HTTPClient) map[string]Source {
 		NewPersonio(c),
 		NewPeopleForce(c),
 		NewCatsone(c),
+		NewOpencats(c),
 		NewOdoo(c),
 		NewTalentLyft(c),
 		NewPinpoint(c),

--- a/openspec/changes/opencats-source-adapter/.openspec.yaml
+++ b/openspec/changes/opencats-source-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/opencats-source-adapter/design.md
+++ b/openspec/changes/opencats-source-adapter/design.md
@@ -1,0 +1,99 @@
+## Context
+
+The full reconnaissance record lives in
+`docs/superpowers/specs/2026-07-28-opencats-adapter-harvest-design.md`; this document carries
+the decisions that shape the implementation.
+
+Every provider crawled today is multi-tenant SaaS: one adapter plus a slug list yields
+thousands of boards. OpenCATS inverts that — a self-hosted PHP ATS, one install per company,
+on the company's own domain. `cmd/harvest-boards` resolves candidates either from a seed slug
+list or from a provider API (`resolveCandidates`, `main.go`), and neither exists here.
+
+Measured on 2026-07-28: 78 candidate hosts from urlscan.io yielded **9 live portals with 260
+open jobs**, all reachable over HTTPS. Common Crawl was tried and rejected — its CDX index is
+sorted by SURT (domain first), so a global search by URL path returns nothing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Crawl self-hosted OpenCATS portals as an ordinary provider, inheriting `board_health`,
+  cooldown, the unseen-job sweep, and incremental search indexing without special-casing.
+- Make discovery repeatable, so installs that appear later are found by re-running the tool
+  rather than by remembering to look.
+- Survive template drift: an install that rewrites its portal must degrade to zero jobs, not
+  to garbage jobs.
+
+**Non-Goals:**
+- Application submission — the adapter is read-only, as all adapters are.
+- FreeATS — zero public installs found; the seam is recorded, no code is written.
+- Self-closing support — withdrawn postings close via the 48-hour sweep.
+- Exhaustive discovery — urlscan knows only hosts someone has scanned.
+
+## Decisions
+
+**Board is host plus optional path prefix, not a new board-file field.**
+Installs mount the portal differently: `atscareers.g4s.com` at the web root,
+`careers.boomit.pt/careers` nested. Encoding both in the existing `board` string keeps the
+board-file format untouched and reuses the shape `sources/catsone.yml` already proves in
+production, where `board` is a careers host and is sometimes a customer's own domain
+(`jobs.evoplay.com.ua`). *Alternative rejected:* a separate `path` field in the board file —
+changes a format shared by ~150 providers to serve one.
+
+**Parse routing invariants, never markup.**
+G4S rewrote the template (HTML5, custom assets); boomit and crewlogix run stock XHTML 1.0;
+indovision added "education" and "experience" columns. CSS classes, column order, and column
+count agree nowhere. Two things hold everywhere: postings link as
+`index.php?m=careers&p=showJob&ID=<n>`, and the anchor's text is the job title. Location and
+description therefore come from the labelled detail page, never from a positional listing
+column. *Alternative rejected:* per-install parsing profiles — unbounded maintenance for a
+260-job provider.
+
+**Let the pipeline namespace the id.**
+An OpenCATS `ID` is unique only within one install — `ID=24` exists on both boomit and
+crewlogix — so under `jobs UNIQUE (source, external_id)` with a shared `source` these would
+overwrite each other. No adapter-side handling is needed: `pipeline.jobIdentity`
+(`internal/pipeline/pipeline.go:539`) already routes every id through
+`sources.NamespaceExternalID(e.Board, j.ExternalID)`. The adapter emits the raw id.
+*Alternative rejected:* building a composite id inside the adapter — would double-namespace
+and diverge from the link-source path that dedups against the same key.
+
+**Discover from urlscan.io, in the harvest tool only.**
+The stock `<title>` is the richest signature (66 hosts) because administrators change the
+portal path far more often than the page title; URL-routing signatures add the rest. The
+dependency is confined to `cmd/harvest-boards`, a run-once host tool — no production worker
+reaches urlscan, so an outage there cannot affect ingest. *Alternatives rejected:* Common
+Crawl (cannot search by path), Censys/Shodan (API key, tight free tier), search-engine dorks
+(no bulk API, ends in captchas).
+
+**Exclude `*.catsone.com` at discovery.**
+Commercial CATS shares the URL scheme and is already crawled under its own provider. A shared
+posting admitted under both providers is a cross-provider duplicate, which the
+`(source, external_id)` key cannot detect — dedup is scoped within a source.
+
+## Risks / Trade-offs
+
+- **Small absolute volume (260 jobs).** → Justified by marginal cost, not by count: one
+  adapter plus one prober, every pipeline facility reused. If the harvest had found fewer
+  than 5 boards the change would have been dropped; it found 9.
+- **Template drift breaks an install's parse.** → Routing-only parsing; a broken install
+  yields zero jobs, and `board_health` cools it off after 3 consecutive failures rather than
+  emitting malformed postings.
+- **urlscan changes or rate-limits its API.** → Host-tool only; a failed discovery run
+  reports and exits, ingest is untouched.
+- **Discovery ceiling mistaken for exhaustion.** → Recorded in the spec: an empty future
+  harvest means "no newly *scanned* installs", not "no new installs".
+- **Industry mix is broader than tech** (e.g. `opencats.gorgany.com` is an outdoor retailer).
+  → No special handling; the existing `is_tech` enrichment gate already governs this.
+- **Portal pages are un-escaped by upstream's own admission** (`modules/careers/CareersUI.php`
+  carries an escaping TODO). → We read and sanitise; description HTML goes through the shared
+  sanitiser, as every HTML adapter already does.
+
+## Migration Plan
+
+No schema change, no migration, no backfill. Deployment is the ordinary path: merge, then add
+a cron schedule for `sources/opencats.yml` alongside the other provider schedules. Rollback is
+removing the schedule; jobs already ingested close through the normal sweep.
+
+## Open Questions
+
+None. Scope, threshold, and discovery channel were settled before implementation.

--- a/openspec/changes/opencats-source-adapter/proposal.md
+++ b/openspec/changes/opencats-source-adapter/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Every one of the ~150 crawled providers is multi-tenant SaaS, so the whole ingest fleet is
+blind to self-hosted ATS installs — there is no tenant catalogue to enumerate. Reconnaissance
+on 2026-07-28 confirmed the gap is real and fillable: 9 live OpenCATS career portals carrying
+**260 open jobs** (including 108 at G4S and 95 at Indovision Global), none of them reachable
+today. The marginal cost is one adapter plus one prober, reusing the entire existing pipeline.
+
+## What Changes
+
+- Add an `opencats` source adapter that crawls a self-hosted OpenCATS career portal, registered
+  in the source registry under provider key `opencats`.
+- Add `sources/opencats.yml`, populated by a live harvest run.
+- Add an OpenCATS harvest prober with discovery support, so
+  `go run ./cmd/harvest-boards opencats` needs no seed file.
+- Extend board harvest so a provider without any vendor API can discover candidates from a
+  third-party scan index and validate them against the portal's own HTML.
+
+## Capabilities
+
+### New Capabilities
+- `opencats-source`: crawling a self-hosted OpenCATS career portal — board identity as
+  host plus optional path prefix, routing-invariant parsing, per-posting failure isolation.
+
+### Modified Capabilities
+- `board-harvest`: candidate discovery and live-validation currently require the platform's
+  official public API. A self-hosted platform has no such API, so the requirement must admit
+  a third-party discovery index and portal-HTML validation, including the exclusion of
+  candidates that belong to an already-covered sibling provider.
+
+## Impact
+
+- **New code:** `internal/sources/opencats.go` (+ tests),
+  `cmd/harvest-boards/opencats_prober.go` (+ tests), `sources/opencats.yml`.
+- **Modified:** one registry line in `sources.All`; the prober registry in
+  `cmd/harvest-boards`.
+- **Unchanged by design:** no migration, no schema change. Cross-install id collisions are
+  already handled — `pipeline.jobIdentity` namespaces every `external_id` by board.
+- **New external dependency (host tooling only):** the urlscan.io public search API, used by
+  the harvest tool. Not reachable from, and not required by, any production worker.
+- **Lifecycle:** provider is not self-closing; withdrawn postings close via the 48-hour
+  unseen-job sweep.
+- **Out of scope:** FreeATS (zero public installs found), application submission.

--- a/openspec/changes/opencats-source-adapter/specs/board-harvest/spec.md
+++ b/openspec/changes/opencats-source-adapter/specs/board-harvest/spec.md
@@ -1,0 +1,118 @@
+## MODIFIED Requirements
+
+### Requirement: The harvest tool validates candidate boards against the live platform API
+
+The `harvest-boards` host tool SHALL expand a board file (`sources/<provider>.yml`)
+only with boards it has live-validated: each candidate board SHALL be probed
+against the platform's own live surface — its official public API, or, for a
+self-hosted platform that exposes no API, the portal's own served pages — and kept
+only if that surface reports at least one open job, so the committed file is the
+project's own validated fact set rather than a redistributed dataset. A candidate
+that is absent, closed, or unreachable SHALL be skipped, never abort the run. A
+kept board SHALL be appended to the provider's board file with the company name
+the platform reports (or the board id when the platform exposes none),
+de-duplicated against the boards already in the file.
+
+#### Scenario: A candidate with open jobs is kept
+
+- **WHEN** a candidate board is probed and the platform API reports one or more
+  open jobs
+- **THEN** the board is appended to `sources/<provider>.yml` with the reported
+  company name (or the board id as a fallback)
+
+#### Scenario: A candidate with no open jobs is skipped
+
+- **WHEN** a candidate board is probed and the platform API reports zero jobs or
+  is unreachable
+- **THEN** the board is not appended and the run continues with the other
+  candidates
+
+#### Scenario: An already-known board is not duplicated
+
+- **WHEN** a candidate board id already appears in `sources/<provider>.yml`
+- **THEN** it is filtered out before probing and not appended again
+
+#### Scenario: A self-hosted portal is validated against its own pages
+
+- **WHEN** a candidate belongs to a platform that publishes no vendor API, and its
+  portal page lists one or more open postings
+- **THEN** the candidate is validated from that page and kept exactly as an
+  API-validated candidate would be
+
+### Requirement: A provider may supply its own candidate boards by discovery
+
+The harvest tool SHALL allow a provider whose boards are not available as a seed
+list to discover its candidate boards, by implementing an opt-in discovery
+capability. Discovery SHALL draw candidates from the platform API where one
+exists, and MAY draw them from a third-party index of publicly scanned hosts when
+the platform is self-hosted and therefore has no tenant catalogue to enumerate.
+When a provider supports discovery and the tool is run with no seed file, the tool
+SHALL obtain the candidate boards from discovery instead of from a seed list;
+every discovered candidate SHALL then pass through the same live-validation,
+de-duplication, and append steps as a seeded candidate. A provider that does not
+support discovery SHALL continue to require a seed file.
+
+#### Scenario: Discovery supplies candidates when no seed is given
+
+- **WHEN** the tool is run for a provider that supports discovery and no seed file
+  is given
+- **THEN** the candidate boards come from the provider's discovery, and each is
+  live-validated, de-duplicated, and appended exactly as a seeded candidate would be
+
+#### Scenario: A provider without discovery still needs a seed
+
+- **WHEN** the tool is run for a provider that does not support discovery and no
+  seed file is given
+- **THEN** the tool reports a usage error and makes no changes
+
+#### Scenario: A self-hosted platform discovers from a third-party index
+
+- **WHEN** discovery runs for a self-hosted platform that has no tenant catalogue
+- **THEN** the candidate hosts come from a third-party index of publicly scanned
+  hosts, and each is live-validated before it can be appended
+
+## ADDED Requirements
+
+### Requirement: OpenCATS portals are discovered from a public scan index
+
+The harvest tool SHALL support discovering OpenCATS boards from a public index of
+scanned hosts, querying it by the signatures an install exposes — the stock page
+title and the portal's URL routing — and unioning the results into one
+de-duplicated candidate host list. Discovery SHALL drop hosts that cannot be a
+company portal, namely bare IP addresses and the project's own documentation and
+demo sites. Each surviving host SHALL be probed by requesting the portal's listing
+and counting its posting links, and kept only when that count is at least one,
+with the proposed company name read from the portal page title and falling back to
+the host.
+
+#### Scenario: Signatures are unioned into one candidate list
+
+- **WHEN** discovery queries the index by page title and by URL routing, and a host
+  appears in both result sets
+- **THEN** that host appears exactly once in the candidate list
+
+#### Scenario: A host serving postings is kept and named
+
+- **WHEN** a candidate host's portal listing links one or more postings
+- **THEN** the host is kept with the company name taken from its portal page title,
+  or the host itself when the title yields no usable name
+
+#### Scenario: A host serving no postings is skipped
+
+- **WHEN** a candidate host is unreachable, serves no portal, or serves a portal
+  with zero postings
+- **THEN** it is not appended and the run continues with the other candidates
+
+### Requirement: Candidates belonging to a covered sibling provider are excluded
+
+Commercial CATS shares its URL scheme with its open-source descendant and is already
+crawled under its own provider, so OpenCATS discovery SHALL exclude any candidate
+host belonging to that sibling platform. Admitting such a host would create the same
+posting under two providers, which the `(source, external_id)` dedup key cannot
+detect.
+
+#### Scenario: A commercial CATS host is rejected
+
+- **WHEN** discovery surfaces a host on the commercial CATS platform
+- **THEN** that host is excluded from the candidate list and never appended to
+  `sources/opencats.yml`

--- a/openspec/changes/opencats-source-adapter/specs/opencats-source/spec.md
+++ b/openspec/changes/opencats-source-adapter/specs/opencats-source/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Self-hosted OpenCATS portal crawl
+
+The system SHALL crawl a self-hosted OpenCATS career portal over HTTPS, reading the portal's
+"show all" listing for one configured board and returning one `Job` per open posting. The
+adapter SHALL be registered under provider key `opencats` in the source registry. The adapter
+SHALL be read-only: it never submits an application or registers a candidate.
+
+#### Scenario: Listing yields one job per posting
+
+- **WHEN** the adapter fetches a board whose portal listing links several open postings
+- **THEN** it requests `https://<board>/index.php?m=careers&p=showAll` and returns one `Job`
+  per posting, each carrying the posting's native numeric id as `ExternalID`
+
+#### Scenario: An unreachable listing fails the board
+
+- **WHEN** the portal listing cannot be fetched
+- **THEN** the adapter returns an error for that board, so the run counts it as a board
+  failure rather than an empty success
+
+### Requirement: Board identity is host plus optional path prefix
+
+The board SHALL be the portal root: a host, optionally followed by a path prefix, because
+installs differ in where the portal is mounted. The adapter SHALL build every portal URL by
+appending to that root, so both a root-mounted portal (`atscareers.g4s.com`) and a nested one
+(`careers.boomit.pt/careers`) are addressable without a per-install code path.
+
+#### Scenario: Root-mounted portal
+
+- **WHEN** the board is `atscareers.g4s.com`
+- **THEN** the listing is fetched from `https://atscareers.g4s.com/index.php?m=careers&p=showAll`
+
+#### Scenario: Portal nested under a path prefix
+
+- **WHEN** the board is `careers.boomit.pt/careers`
+- **THEN** the listing is fetched from
+  `https://careers.boomit.pt/careers/index.php?m=careers&p=showAll`
+
+### Requirement: Postings are identified by routing, not by markup
+
+Installs customise the portal template freely — CSS classes, column order, and column count
+differ between them — so the adapter SHALL identify postings by the portal's routing
+invariants alone. A posting SHALL be recognised by a link of the form
+`index.php?m=careers&p=showJob&ID=<n>`, whose captured `<n>` is the posting's `ExternalID` and
+whose anchor text is the job title. The adapter SHALL NOT depend on CSS classes, on the
+position of a listing column, or on the number of listing columns.
+
+#### Scenario: A rewritten template is parsed identically
+
+- **WHEN** two boards serve listings with different markup, column counts, and CSS classes,
+  but both link postings as `index.php?m=careers&p=showJob&ID=<n>`
+- **THEN** both yield the same set of postings, with ids and titles taken from those links
+
+#### Scenario: Duplicate links collapse to one posting
+
+- **WHEN** a listing links the same posting id more than once (for example a title link and a
+  separate "apply" link)
+- **THEN** the adapter returns that posting once
+
+### Requirement: Non-posting portal links are excluded
+
+A portal listing SHALL contribute only real postings. Links that use the posting route but do
+not represent an open position — notably a general-application entry such as "Can't find what
+you're looking for? Apply here" — SHALL NOT be returned as jobs.
+
+#### Scenario: General-application entry is skipped
+
+- **WHEN** a listing contains a general-application link alongside real postings
+- **THEN** only the real postings are returned
+
+### Requirement: Location and description come from the detail page
+
+Listing rows are positional and differ per install, so the adapter SHALL read each posting's
+location and description from its detail page rather than from the listing row. Description
+HTML SHALL pass through the shared sanitiser before it is stored. Detail pages SHALL be
+fetched concurrently through the shared detail-fetch helper.
+
+#### Scenario: Detail supplies location and sanitised description
+
+- **WHEN** a posting's detail page is fetched
+- **THEN** the returned `Job` carries the location and the description read from that page,
+  with any embedded script stripped by the sanitiser
+
+#### Scenario: A failed detail page skips only that posting
+
+- **WHEN** one posting's detail page cannot be fetched or carries no usable id
+- **THEN** that posting is skipped and every other posting on the board is still returned

--- a/openspec/changes/opencats-source-adapter/tasks.md
+++ b/openspec/changes/opencats-source-adapter/tasks.md
@@ -31,16 +31,16 @@
 
 ## 3. Harvest prober
 
-- [ ] 3.1 Add `cmd/harvest-boards/opencats_prober_test.go`: probing a host whose portal lists
+- [x] 3.1 Add `cmd/harvest-boards/opencats_prober_test.go`: probing a host whose portal lists
       postings returns the company name and a positive count; a host with an unreachable or
       empty portal returns a silent skip (`"", 0, nil`).
-- [ ] 3.2 Add `cmd/harvest-boards/opencats_prober.go` implementing `prober` to satisfy 3.1,
+- [x] 3.2 Add `cmd/harvest-boards/opencats_prober.go` implementing `prober` to satisfy 3.1,
       including company name from the portal page title with a host fallback.
-- [ ] 3.3 Test and implement candidate filtering: `*.catsone.com` hosts, bare IP addresses,
+- [x] 3.3 Test and implement candidate filtering: `*.catsone.com` hosts, bare IP addresses,
       and the project's own documentation/demo sites are rejected.
-- [ ] 3.4 Test and implement `discoverer`: results from the page-title and URL-routing
+- [x] 3.4 Test and implement `discoverer`: results from the page-title and URL-routing
       signature queries are unioned and de-duplicated into one candidate host list.
-- [ ] 3.5 Register the prober in the `probers` map so `go run ./cmd/harvest-boards opencats`
+- [x] 3.5 Register the prober in the `probers` map so `go run ./cmd/harvest-boards opencats`
       runs without a seed file.
 
 ## 4. Harvest run and board file

--- a/openspec/changes/opencats-source-adapter/tasks.md
+++ b/openspec/changes/opencats-source-adapter/tasks.md
@@ -1,0 +1,60 @@
+## 1. Adapter — listing
+
+- [ ] 1.1 Add `internal/sources/opencats_test.go` with builder functions for two fixture
+      shapes: the stock XHTML template and a rewritten template with different classes and
+      column order. Assert the listing yields one posting per `p=showJob&ID=<n>` link, with
+      the anchor text as title and the captured `<n>` as `ExternalID`, identically for both
+      shapes.
+- [ ] 1.2 Add `internal/sources/opencats.go` with `NewOpencats`, `Provider() == "opencats"`,
+      and listing parsing that satisfies 1.1.
+- [ ] 1.3 Test and implement board resolution: a root-mounted board
+      (`atscareers.g4s.com`) and a path-prefixed board (`careers.boomit.pt/careers`) both
+      build the correct listing URL over HTTPS.
+- [ ] 1.4 Test and implement de-duplication of repeated posting links within one listing
+      (title link plus separate apply link → one posting).
+- [ ] 1.5 Test and implement exclusion of the general-application entry ("Can't find what
+      you're looking for? Apply here").
+- [ ] 1.6 Test and implement listing-fetch failure: an unreachable listing returns an error
+      for the board.
+
+## 2. Adapter — detail
+
+- [ ] 2.1 Test and implement detail-page parsing: location and description read from the
+      detail page, description passed through `sanitizeHTML` (assert an embedded `<script>`
+      is stripped).
+- [ ] 2.2 Test and implement per-posting failure isolation: one failing detail page skips
+      that posting and leaves the rest of the board intact.
+- [ ] 2.3 Wire the detail fan-out through the shared `fetchDetails` helper at
+      `defaultDetailWorkers`.
+- [ ] 2.4 Register the adapter in `sources.All` under key `opencats`; confirm it is absent
+      from `sources.SelfClosingProviders`.
+
+## 3. Harvest prober
+
+- [ ] 3.1 Add `cmd/harvest-boards/opencats_prober_test.go`: probing a host whose portal lists
+      postings returns the company name and a positive count; a host with an unreachable or
+      empty portal returns a silent skip (`"", 0, nil`).
+- [ ] 3.2 Add `cmd/harvest-boards/opencats_prober.go` implementing `prober` to satisfy 3.1,
+      including company name from the portal page title with a host fallback.
+- [ ] 3.3 Test and implement candidate filtering: `*.catsone.com` hosts, bare IP addresses,
+      and the project's own documentation/demo sites are rejected.
+- [ ] 3.4 Test and implement `discoverer`: results from the page-title and URL-routing
+      signature queries are unioned and de-duplicated into one candidate host list.
+- [ ] 3.5 Register the prober in the `probers` map so `go run ./cmd/harvest-boards opencats`
+      runs without a seed file.
+
+## 4. Harvest run and board file
+
+- [ ] 4.1 Run `go run ./cmd/harvest-boards opencats` and review the resulting diff.
+- [ ] 4.2 Correct the proposed company names by hand where the portal title is unhelpful
+      (e.g. a title that is just the hostname), and add the provider header comment to
+      `sources/opencats.yml` describing the board format.
+- [ ] 4.3 Verify the board file loads: `sources.LoadConfig` validation passes for every entry.
+
+## 5. Verification
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` all green.
+- [ ] 5.2 Crawl one real board end-to-end against the live portal and confirm titles,
+      locations, and descriptions are populated and sane.
+- [ ] 5.3 Confirm no cross-provider duplication: no board in `sources/opencats.yml` also
+      appears in `sources/catsone.yml`.

--- a/openspec/changes/opencats-source-adapter/tasks.md
+++ b/openspec/changes/opencats-source-adapter/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Adapter — listing
 
-- [ ] 1.1 Add `internal/sources/opencats_test.go` with builder functions for two fixture
+- [x] 1.1 Add `internal/sources/opencats_test.go` with builder functions for two fixture
       shapes: the stock XHTML template and a rewritten template with different classes and
       column order. Assert the listing yields one posting per `p=showJob&ID=<n>` link, with
       the anchor text as title and the captured `<n>` as `ExternalID`, identically for both
       shapes.
-- [ ] 1.2 Add `internal/sources/opencats.go` with `NewOpencats`, `Provider() == "opencats"`,
+- [x] 1.2 Add `internal/sources/opencats.go` with `NewOpencats`, `Provider() == "opencats"`,
       and listing parsing that satisfies 1.1.
-- [ ] 1.3 Test and implement board resolution: a root-mounted board
+- [x] 1.3 Test and implement board resolution: a root-mounted board
       (`atscareers.g4s.com`) and a path-prefixed board (`careers.boomit.pt/careers`) both
       build the correct listing URL over HTTPS.
-- [ ] 1.4 Test and implement de-duplication of repeated posting links within one listing
+- [x] 1.4 Test and implement de-duplication of repeated posting links within one listing
       (title link plus separate apply link → one posting).
-- [ ] 1.5 Test and implement exclusion of the general-application entry ("Can't find what
+- [x] 1.5 Test and implement exclusion of the general-application entry ("Can't find what
       you're looking for? Apply here").
-- [ ] 1.6 Test and implement listing-fetch failure: an unreachable listing returns an error
+- [x] 1.6 Test and implement listing-fetch failure: an unreachable listing returns an error
       for the board.
 
 ## 2. Adapter — detail
 
-- [ ] 2.1 Test and implement detail-page parsing: location and description read from the
+- [x] 2.1 Test and implement detail-page parsing: location and description read from the
       detail page, description passed through `sanitizeHTML` (assert an embedded `<script>`
       is stripped).
-- [ ] 2.2 Test and implement per-posting failure isolation: one failing detail page skips
+- [x] 2.2 Test and implement per-posting failure isolation: one failing detail page skips
       that posting and leaves the rest of the board intact.
-- [ ] 2.3 Wire the detail fan-out through the shared `fetchDetails` helper at
+- [x] 2.3 Wire the detail fan-out through the shared `fetchDetails` helper at
       `defaultDetailWorkers`.
-- [ ] 2.4 Register the adapter in `sources.All` under key `opencats`; confirm it is absent
+- [x] 2.4 Register the adapter in `sources.All` under key `opencats`; confirm it is absent
       from `sources.SelfClosingProviders`.
 
 ## 3. Harvest prober

--- a/openspec/changes/opencats-source-adapter/tasks.md
+++ b/openspec/changes/opencats-source-adapter/tasks.md
@@ -45,16 +45,16 @@
 
 ## 4. Harvest run and board file
 
-- [ ] 4.1 Run `go run ./cmd/harvest-boards opencats` and review the resulting diff.
-- [ ] 4.2 Correct the proposed company names by hand where the portal title is unhelpful
+- [x] 4.1 Run `go run ./cmd/harvest-boards opencats` and review the resulting diff.
+- [x] 4.2 Correct the proposed company names by hand where the portal title is unhelpful
       (e.g. a title that is just the hostname), and add the provider header comment to
       `sources/opencats.yml` describing the board format.
-- [ ] 4.3 Verify the board file loads: `sources.LoadConfig` validation passes for every entry.
+- [x] 4.3 Verify the board file loads: `sources.LoadConfig` validation passes for every entry.
 
 ## 5. Verification
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` all green.
-- [ ] 5.2 Crawl one real board end-to-end against the live portal and confirm titles,
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` all green.
+- [x] 5.2 Crawl one real board end-to-end against the live portal and confirm titles,
       locations, and descriptions are populated and sane.
-- [ ] 5.3 Confirm no cross-provider duplication: no board in `sources/opencats.yml` also
+- [x] 5.3 Confirm no cross-provider duplication: no board in `sources/opencats.yml` also
       appears in `sources/catsone.yml`.

--- a/sources/opencats.yml
+++ b/sources/opencats.yml
@@ -1,0 +1,26 @@
+# Self-hosted OpenCATS career portals. Provider is the filename; each entry is company + board.
+# board = the portal root: a host, optionally followed by the path the portal is mounted under
+# (installs differ — atscareers.g4s.com serves it at the web root, careers.boomit.pt/careers
+# nests it). See internal/sources/opencats.go. The listing at index.php?m=careers&p=showAll
+# links every open posting; there is no pagination. Boards come from
+# `go run ./cmd/harvest-boards opencats`, which discovers candidates from a public scan index
+# and keeps only the hosts serving postings — review the diff, and fix any company name the
+# tool proposed from a portal title that is just the hostname.
+- company: Thomas Stewart Builders
+  board: ats.thomasstewartbuilders.com/careers
+- company: G4S
+  board: atscareers.g4s.com
+- company: Boomit
+  board: careers.boomit.pt/careers
+- company: Crewlogix Technologies
+  board: careers.crewlogix.com/careers
+- company: Citizen Home Care
+  board: citizenhomecare.org/careers
+- company: MG Group
+  board: dwrs.mggroup.lk/careers
+- company: Indovision Services Pvt Ltd
+  board: itsource.indovisionglobal.com/careers
+- company: Gorgany
+  board: opencats.gorgany.com/careers
+- company: 411hawks
+  board: opencats.vikisoft.com.ua/careers


### PR DESCRIPTION
Every provider we crawl is multi-tenant SaaS, so the fleet is blind to self-hosted
installs: there is no tenant catalogue to enumerate. This adds OpenCATS as an
ordinary provider, plus the discovery needed to find installs at all.

## What the reconnaissance found

urlscan signatures surfaced 78 candidate hosts; probing them found **9 live portals
carrying 260 open jobs**, all over HTTPS — including 108 at G4S and 95 at Indovision
Global. Common Crawl was evaluated and rejected: its CDX index is sorted by SURT, so
a global search by URL path returns nothing.

The stock page title is the richest signature (66 hosts, against 13 for URL routing):
administrators move the portal far more often than they rename the page.

## Design

**Parse routing, not markup.** Installs customise the template freely — G4S rewrote it
wholesale, others run stock XHTML with extra columns — so the adapter reads only what a
rewrite cannot change: the `showJob` route carries the id, and the anchor text is the
title. Listing columns are positional and differ per install, so location and body come
from the detail page.

**Board is the portal root** — host plus the optional mount path, reusing the shape
`sources/catsone.yml` already proves in production. Discovery resolves each host to
exactly one mount: a board *is* its mount point, so a host emitted at both `/careers`
and the root would namespace one posting under two external ids.

**No adapter-side id handling.** An OpenCATS id is unique only within an install
(`ID=24` exists on two of these boards); `pipeline.jobIdentity` already namespaces every
external_id by board.

**Commercial CATS hosts are excluded at discovery** — they are crawled under their own
provider, and a cross-provider duplicate is invisible to the `(source, external_id)` key.

## What the live run taught us

Fixtures could not have caught either of these; both were found by crawling the real
portals and both are fixed:

- crewlogix returned 8 postings with **no description** — the install renamed the body
  container to `job-decription`, typo included. Handled with a dictionary of known
  containers rather than a fuzzy match: an unknown container yields an empty description,
  which is visible and fixable, where guessing stores navigation chrome as a job body.
- gorgany returned 33 postings with **no location** — the portal is served in Ukrainian
  (`Місцезнаходження:`). The label is translated but the shipped template's row order is
  not, so an unlabelled lookup falls back to the details table's first row.

Verified against the live portals afterwards: location 161/161, description 160/161.

`PostedAt` is deliberately left nil — no portal publishes a date on the detail page, and
the one listing that shows one puts it in a positional column.

## Scope

Not self-closing (withdrawn postings close via the 48-hour sweep). No schema change, no
migration. FreeATS is out of scope: zero public installs exist.

OpenSpec: `openspec/changes/opencats-source-adapter/`