### PR TITLE
feat(sources): crawl Booking.com's careers site, which is Jibe

### DIFF
--- a/sources/jibe.yml
+++ b/sources/jibe.yml
@@ -27,3 +27,5 @@
   board: jobs.statefarm.com
 - company: Ulta Beauty
   board: careers.ulta.com
+- company: Booking.com
+  board: jobs.booking.com


### PR DESCRIPTION
`jobs.booking.com` sat in the contribution review queue as an unrecognized link — the recognizer keys on host, and a Jibe site on a vanity domain gives it nothing to match.

Its `/api/jobs` returns the Jibe listing shape the adapter already reads: **135 postings**, descriptions inline, no per-job detail fetch.

Not a duplicate of the `smartrecruiters/Bookingcom1` board we already track — that tenant holds 4 postings and is a different pipeline.