### PR TITLE
fix(prune): a tagged skill is not proof the employer is technical

### DIFF
--- a/cmd/prune/boards_test.go
+++ b/cmd/prune/boards_test.go
@@ -140,8 +140,8 @@ func TestLoadBoardsIgnoresRetiredSubdirectory(t *testing.T) {
 
 // boardRow builds one candidate on a board, carrying the tri-state is_tech the
 // derivation writes: a nil isTech is the "unknown" the dictionaries leave behind.
-func boardRow(id int64, source, externalID string, isTech *bool, hasSkills bool) db.PruneCandidatesRow {
-	r := db.PruneCandidatesRow{ID: id, Source: source, ExternalID: externalID, HasSkills: hasSkills}
+func boardRow(id int64, source, externalID string, isTech *bool, skills []string) db.PruneCandidatesRow {
+	r := db.PruneCandidatesRow{ID: id, Source: source, ExternalID: externalID, Skills: skills}
 	if isTech != nil {
 		r.IsTech = pgtype.Bool{Bool: *isTech, Valid: true}
 	}
@@ -171,13 +171,13 @@ func TestReportBoardsWithholdsBoardsWithNoVerdict(t *testing.T) {
 	}
 	q := &fakeCandidates{rows: []db.PruneCandidatesRow{
 		// Classified, and the verdict was "not technical": the report may act on it.
-		boardRow(1, "greenhouse", "determined:1", boolp(false), false),
+		boardRow(1, "greenhouse", "determined:1", boolp(false), nil),
 		// Never classified either way — the 62% case. Nothing is known about it.
-		boardRow(2, "greenhouse", "unknown:1", nil, false),
+		boardRow(2, "greenhouse", "unknown:1", nil, nil),
 		// A verdict of "technical" keeps a board off the list, as before.
-		boardRow(3, "greenhouse", "technical:1", boolp(true), false),
+		boardRow(3, "greenhouse", "technical:1", boolp(true), nil),
 		// So does a tagged skill, even with no verdict on the row.
-		boardRow(4, "greenhouse", "skilled:1", nil, true),
+		boardRow(4, "greenhouse", "skilled:1", nil, []string{"python"}),
 	}}
 
 	var out strings.Builder
@@ -206,7 +206,7 @@ func TestReportBoardsCountsWhatItWithheld(t *testing.T) {
 		byProvider: map[string]map[string]bool{"greenhouse": {"unknown": true}},
 	}
 	q := &fakeCandidates{rows: []db.PruneCandidatesRow{
-		boardRow(1, "greenhouse", "unknown:1", nil, false),
+		boardRow(1, "greenhouse", "unknown:1", nil, nil),
 	}}
 
 	var out strings.Builder
@@ -215,5 +215,46 @@ func TestReportBoardsCountsWhatItWithheld(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "1") || !strings.Contains(out.String(), "classified") {
 		t.Errorf("the report must say how many boards it withheld for want of a verdict; got:\n%s", out.String())
+	}
+}
+
+// "Carries a tagged skill" is not the claim the report needs. The skills dictionary
+// deliberately covers the non-engineering roles a technical company hires for —
+// recruiting, HR, finance, legal, operations, customer success — because the facet
+// describes every posting. Reading any tag as technical evidence therefore let a
+// recruiting coordinator tagged {stakeholder-management, candidate-experience} vouch
+// for a whole board, and a road-maintenance description vouch for its own.
+//
+// Measured on a 0.5% prod sample: of the postings the classifier calls non-technical
+// yet that still carry skills, 37% carry nothing but non-engineering ones.
+func TestReportBoardsIgnoresNonEngineeringSkills(t *testing.T) {
+	brd := boards{
+		listed: map[boardKey]bool{
+			{"greenhouse", "staffing"}: true, {"greenhouse", "software"}: true,
+		},
+		byProvider: map[string]map[string]bool{"greenhouse": {
+			"staffing": true, "software": true,
+		}},
+	}
+	q := &fakeCandidates{rows: []db.PruneCandidatesRow{
+		// Classified non-technical, and every tag on it names a non-engineering craft.
+		boardRow(1, "greenhouse", "staffing:1", boolp(false),
+			[]string{"stakeholder-management", "candidate-experience"}),
+		// One engineering tag is evidence, exactly as before.
+		boardRow(2, "greenhouse", "software:1", boolp(false),
+			[]string{"talent-sourcing", "kubernetes"}),
+	}}
+
+	var out strings.Builder
+	if err := reportBoards(context.Background(), &out, q, brd); err != nil {
+		t.Fatalf("reportBoards: %v", err)
+	}
+	got := out.String()
+
+	if !strings.Contains(got, "staffing") {
+		t.Errorf("a board whose only tags name non-engineering craft must be listed; got:\n%s", got)
+	}
+	if strings.Contains(got, "software\n") {
+		t.Errorf("a board with an engineering tag must stay off the list; got:\n%s", got)
 	}
 }

--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -49,6 +49,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/skilltag"
 	"github.com/strelov1/freehire/internal/worker"
 )
 
@@ -345,7 +346,10 @@ type (
 // "everything was classified as non-technical".
 type boardVerdict struct {
 	// technical is the evidence that keeps a board: a posting resolved as technical,
-	// or one carrying a tagged skill.
+	// or one carrying a tagged ENGINEERING skill. Any tag will not do — the dictionary
+	// covers the recruiting, HR, finance, legal and operations craft a technical company
+	// hires for, so a recruiting coordinator carries skills without saying anything
+	// about the employer.
 	technical bool
 	// determined is whether ANY posting got an is_tech verdict either way. is_tech is
 	// tri-state on purpose — jobderive leaves it NULL rather than coercing, so that the
@@ -355,7 +359,7 @@ type boardVerdict struct {
 
 // reportBoards lists the boards still in the source files whose postings were classified
 // and none of them came out technical — no technical title or category, and not one
-// tagged skill. Each is a candidate for the retirement PR — move the entry to
+// tagged engineering skill. Each is a candidate for the retirement PR — move the entry to
 // sources/retired/<provider>.yml — which is the precondition for pruning its jobs under
 // a company-scoped rule.
 //
@@ -390,7 +394,7 @@ func reportBoards(ctx context.Context, w io.Writer, q candidateSource, brd board
 			}
 			key := boardKey{Provider: row.Source, Board: board}
 			v := evidence[key]
-			v.technical = v.technical || (row.IsTech.Valid && row.IsTech.Bool) || row.HasSkills
+			v.technical = v.technical || (row.IsTech.Valid && row.IsTech.Bool) || skilltag.HasEngineering(row.Skills)
 			v.determined = v.determined || row.IsTech.Valid
 			evidence[key] = v
 		}

--- a/internal/db/pruning.sql.go
+++ b/internal/db/pruning.sql.go
@@ -68,8 +68,7 @@ func (q *Queries) CompanyTechEvidence(ctx context.Context) ([]CompanyTechEvidenc
 }
 
 const pruneCandidates = `-- name: PruneCandidates :many
-SELECT id, source, external_id, company_slug, title, category, is_tech,
-       cardinality(skills) > 0 AS has_skills
+SELECT id, source, external_id, company_slug, title, category, is_tech, skills
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -89,7 +88,7 @@ type PruneCandidatesRow struct {
 	Title       string      `json:"title"`
 	Category    string      `json:"category"`
 	IsTech      pgtype.Bool `json:"is_tech"`
-	HasSkills   bool        `json:"has_skills"`
+	Skills      []string    `json:"skills"`
 }
 
 // One keyset page of rows the prune rule evaluates, ordered by id.
@@ -105,6 +104,11 @@ type PruneCandidatesRow struct {
 // and the board is what the source files are keyed on. Matching on it is exact, where
 // matching on company_slug is not — many adapters take the company name from the
 // posting payload rather than the board entry, so the two spellings diverge.
+// skills comes back whole rather than as a cardinality test: whether a posting is
+// technical depends on WHICH skills it carries, and only skilltag knows that. The
+// dictionary covers the recruiting, HR, finance, legal and operations craft a technical
+// company hires for, so "has any skill" answers a different question than the caller
+// is asking.
 func (q *Queries) PruneCandidates(ctx context.Context, arg PruneCandidatesParams) ([]PruneCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, pruneCandidates, arg.AfterID, arg.PageSize)
 	if err != nil {
@@ -122,7 +126,7 @@ func (q *Queries) PruneCandidates(ctx context.Context, arg PruneCandidatesParams
 			&i.Title,
 			&i.Category,
 			&i.IsTech,
-			&i.HasSkills,
+			&i.Skills,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1231,6 +1231,11 @@ type Querier interface {
 	// and the board is what the source files are keyed on. Matching on it is exact, where
 	// matching on company_slug is not — many adapters take the company name from the
 	// posting payload rather than the board entry, so the two spellings diverge.
+	// skills comes back whole rather than as a cardinality test: whether a posting is
+	// technical depends on WHICH skills it carries, and only skilltag knows that. The
+	// dictionary covers the recruiting, HR, finance, legal and operations craft a technical
+	// company hires for, so "has any skill" answers a different question than the caller
+	// is asking.
 	PruneCandidates(ctx context.Context, arg PruneCandidatesParams) ([]PruneCandidatesRow, error)
 	// Permanently remove a batch of jobs and record what was removed, in ONE statement.
 	// Splitting the two would let the archive drift from the deletion, and the archive is

--- a/internal/db/queries/pruning.sql
+++ b/internal/db/queries/pruning.sql
@@ -184,8 +184,12 @@ GROUP BY source, company_slug;
 -- and the board is what the source files are keyed on. Matching on it is exact, where
 -- matching on company_slug is not — many adapters take the company name from the
 -- posting payload rather than the board entry, so the two spellings diverge.
-SELECT id, source, external_id, company_slug, title, category, is_tech,
-       cardinality(skills) > 0 AS has_skills
+-- skills comes back whole rather than as a cardinality test: whether a posting is
+-- technical depends on WHICH skills it carries, and only skilltag knows that. The
+-- dictionary covers the recruiting, HR, finance, legal and operations craft a technical
+-- company hires for, so "has any skill" answers a different question than the caller
+-- is asking.
+SELECT id, source, external_id, company_slug, title, category, is_tech, skills
 FROM jobs
 WHERE id > sqlc.arg(after_id)
 ORDER BY id

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -595,7 +595,7 @@ var wordAliases = map[string]string{
 
 // ambiguousWords marks the wordAliases keys whose word-pass match is "weak": Parse
 // tags it ONLY when the same text carries at least one strong tech token
-// (corroboration). Two groups qualify:
+// (corroboration). Three groups qualify:
 //
 //   - English-word collisions — a common word that doubles as a tech name
 //     (react/swift/spring/rust/ruby/…). Alone it is noise: a cook's "must react to
@@ -606,6 +606,8 @@ var wordAliases = map[string]string{
 //     they are too low-precision to stand alone AND too low-precision to corroborate
 //     one another — only a concrete named technology (python, kubernetes, typescript,
 //     a phrase, an acronym) is a trustworthy corroborator.
+//   - Job-posting boilerplate — words that recur in the prose of NON-technical
+//     postings in particular, listed below.
 //
 // The unambiguous alias forms of the collision canonicals stay strong (reactjs,
 // "react native", "spring boot", expressjs, "ruby on rails"), so a genuinely-named
@@ -649,6 +651,27 @@ var ambiguousWords = map[string]bool{
 	"seo":        true,
 	"ecommerce":  true,
 	"fintech":    true,
+	// job-posting boilerplate — the word belongs to the prose of NON-tech postings
+	// (an "agile" supervisor, the drivers who are "the backbone", a "restful" night in
+	// a care home, the "assembly" line, the rugby "scrum", tree "sap", a "sentry" post,
+	// a bank "vault", the fire-code "firewall", a "rancher", a "postman", "braze"d
+	// copper). As strong aliases they did double damage: each tagged its posting on its
+	// own, AND lifted the gate off every weak word beside it — one "sap" on a road-
+	// maintenance description turned "guard rails" into Ruby on Rails. The real roles
+	// name their stack (SAP→ABAP, REST→the "rest api" phrase), so nothing is lost.
+	"agile":     true,
+	"backbone":  true,
+	"restful":   true,
+	"assembly":  true,
+	"scrum":     true,
+	"sap":       true,
+	"sentry":    true,
+	"vault":     true,
+	"firewall":  true,
+	"firewalls": true,
+	"rancher":   true,
+	"postman":   true,
+	"braze":     true,
 }
 
 // phraseAlias is a punctuated or multi-word term matched against the normalized
@@ -680,6 +703,10 @@ var phraseAliases = []phraseAlias{
 	{"machine learning", "machine-learning"},
 	// additional phrases
 	{"rest api", "rest"}, {"rest apis", "rest"},
+	// The bare word "restful" is gated (a care home offers a restful night), so the
+	// spelled-out form carries the real postings that say "RESTful API" rather than
+	// "REST API" — it is the phrase, not the adjective, that names the style.
+	{"restful api", "rest"}, {"restful apis", "rest"},
 	{"github actions", "github-actions"},
 	{"cloudformation", "cloudformation"},
 	{"scikit-learn", "scikit-learn"},

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -1,6 +1,9 @@
 package skilltag
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // trimLower is the canonical-slug normal form used by the invariant test: lowercase
 // with no surrounding or internal spaces. A canonical equal to its trimLower form is
@@ -682,10 +685,15 @@ type phraseAlias struct {
 	canonical string
 }
 
-// phraseAliases covers terms the word pass cannot see because they contain
+// phraseAliases is every phrase the engine matches — the engineering vocabulary plus
+// the non-engineering professional one. The two are declared separately only so
+// HasEngineering can tell them apart; Parse treats them identically.
+var phraseAliases = slices.Concat(engineeringPhraseAliases, professionalPhraseAliases)
+
+// engineeringPhraseAliases covers terms the word pass cannot see because they contain
 // non-alphanumeric characters or spaces. Includes the ONLY routes by which an
 // ambiguous canonical (c) may be emitted.
-var phraseAliases = []phraseAlias{
+var engineeringPhraseAliases = []phraseAlias{
 	{"c++", "cpp"}, {"c/c++", "cpp"},
 	{"c#", "csharp"},
 	{".net", "dotnet"}, {"asp.net", "dotnet"},
@@ -887,6 +895,48 @@ var phraseAliases = []phraseAlias{
 	//   - ATS product names whose bare token is an English word (lever, workday) —
 	//     "a key lever", "a flexible workday". Same doctrine as burp/druid above: such
 	//     a name may only return through a qualifying phrase, never as a bare token.
+	//
+	// The recruiting/HR/finance/legal/operations/customer-success half of this seed set
+	// lives in professionalPhraseAliases below — same matching, separate list.
+	// business analysis
+	{"requirements gathering", "requirements-gathering"},
+	{"requirements elicitation", "requirements-elicitation"},
+	{"process modeling", "process-modeling"},
+	{"gap analysis", "gap-analysis"},
+	{"user stories", "user-stories"},
+	{"acceptance criteria", "acceptance-criteria"},
+	// solutions / pre-sales
+	{"pre-sales", "pre-sales"}, {"presales", "pre-sales"},
+	{"sales engineering", "sales-engineering"},
+	{"proof of concept", "proof-of-concept"},
+	{"technical discovery", "technical-discovery"},
+	{"solution design", "solution-design"},
+	// developer relations
+	{"developer advocacy", "developer-advocacy"},
+	{"technical evangelism", "technical-evangelism"},
+	{"community management", "community-management"},
+	{"developer experience", "developer-experience"},
+	// technical writing
+	{"technical writing", "technical-writing"},
+	{"api documentation", "api-documentation"},
+	{"docs-as-code", "docs-as-code"}, {"docs as code", "docs-as-code"},
+	{"structured authoring", "structured-authoring"},
+	{"information architecture", "information-architecture"},
+	{"madcap flare", "madcap-flare"},
+}
+
+// professionalPhraseAliases is the non-engineering half of the IT-company role
+// vocabulary: the recruiting, HR, finance, legal, operations and customer-success
+// craft a technical company hires for without hiring an engineer. Parse matches these
+// exactly like any other phrase — a skills facet describes every posting, not only the
+// technical ones — but they are declared apart so a caller can ask the narrower
+// question HasEngineering answers.
+//
+// What is NOT here is the point: developer relations, technical writing, business
+// analysis and pre-sales stay in engineeringPhraseAliases. They are tech-industry
+// craft, posted by technical employers, and the conservative error for every caller of
+// HasEngineering is to keep a board rather than retire a live one.
+var professionalPhraseAliases = []phraseAlias{
 	// recruiting
 	{"boolean search", "boolean-search"},
 	{"talent sourcing", "talent-sourcing"},
@@ -929,32 +979,18 @@ var phraseAliases = []phraseAlias{
 	{"churn prevention", "churn-prevention"},
 	{"customer health score", "customer-health-score"},
 	{"gainsight", "gainsight"}, {"churnzero", "churnzero"},
-	// business analysis
-	{"requirements gathering", "requirements-gathering"},
-	{"requirements elicitation", "requirements-elicitation"},
-	{"process modeling", "process-modeling"},
-	{"gap analysis", "gap-analysis"},
-	{"user stories", "user-stories"},
-	{"acceptance criteria", "acceptance-criteria"},
-	// solutions / pre-sales
-	{"pre-sales", "pre-sales"}, {"presales", "pre-sales"},
-	{"sales engineering", "sales-engineering"},
-	{"proof of concept", "proof-of-concept"},
-	{"technical discovery", "technical-discovery"},
-	{"solution design", "solution-design"},
-	// developer relations
-	{"developer advocacy", "developer-advocacy"},
-	{"technical evangelism", "technical-evangelism"},
-	{"community management", "community-management"},
-	{"developer experience", "developer-experience"},
-	// technical writing
-	{"technical writing", "technical-writing"},
-	{"api documentation", "api-documentation"},
-	{"docs-as-code", "docs-as-code"}, {"docs as code", "docs-as-code"},
-	{"structured authoring", "structured-authoring"},
-	{"information architecture", "information-architecture"},
-	{"madcap flare", "madcap-flare"},
 }
+
+// nonEngineeringCanonicals is derived from professionalPhraseAliases, never written by
+// hand: a term added to that list is non-engineering by construction, so the two cannot
+// drift apart.
+var nonEngineeringCanonicals = func() map[string]bool {
+	out := make(map[string]bool, len(professionalPhraseAliases))
+	for _, p := range professionalPhraseAliases {
+		out[p.canonical] = true
+	}
+	return out
+}()
 
 // sharedAcronyms resolve in ALL text (jobs and résumés). They are matched by their
 // exact UPPERCASE surface form as a whole word (case-preserved pass), because their

--- a/internal/skilltag/dictionaries_test.go
+++ b/internal/skilltag/dictionaries_test.go
@@ -48,3 +48,66 @@ func assertSlug(t *testing.T, what, s string) {
 		t.Errorf("%s: canonical %q is not a lowercase no-space slug", what, s)
 	}
 }
+
+// The dictionary deliberately covers the NON-engineering roles an IT company hires
+// for — recruiting, HR, finance, legal, operations, customer success. That is right
+// for a skills facet, which describes any posting. It is wrong as evidence that a
+// board is a technical employer: cmd/prune's board report treated "has any skill" as
+// "has posted something technical", so a recruiting coordinator tagged
+// {stakeholder-management, candidate-experience} vouched for the whole board.
+//
+// HasEngineering is the narrower question that report should have been asking.
+// Tech-industry craft that is not software engineering — developer relations,
+// technical writing, business analysis, pre-sales — counts as engineering here on
+// purpose: it is posted by technical employers, and the conservative error is to keep
+// a board, never to retire a live one.
+func TestHasEngineering(t *testing.T) {
+	cases := []struct {
+		name   string
+		skills []string
+		want   bool
+	}{
+		{"nothing tagged", nil, false},
+		{"pure recruiting", []string{"talent-sourcing", "candidate-experience"}, false},
+		{"pure hr", []string{"employee-relations", "performance-management"}, false},
+		{"pure finance", []string{"accounts-payable", "financial-reporting"}, false},
+		{"pure legal", []string{"contract-negotiation", "regulatory-compliance"}, false},
+		{"pure operations", []string{"stakeholder-management", "process-improvement"}, false},
+		{"pure customer success", []string{"customer-onboarding", "churn-prevention"}, false},
+		// One engineering canonical is enough — the board has posted something technical.
+		{"recruiter who also names a stack", []string{"talent-sourcing", "python"}, true},
+		{"plain engineering", []string{"kubernetes"}, true},
+		// Tech-industry craft counts, deliberately.
+		{"developer relations", []string{"developer-advocacy"}, true},
+		{"technical writing", []string{"docs-as-code"}, true},
+		{"business analysis", []string{"user-stories"}, true},
+		{"pre-sales", []string{"solution-design"}, true},
+		// An unknown canonical is not evidence of absence: keep the board.
+		{"unknown canonical", []string{"something-new"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := HasEngineering(c.skills); got != c.want {
+				t.Errorf("HasEngineering(%v) = %v, want %v", c.skills, got, c.want)
+			}
+		})
+	}
+}
+
+// Every non-engineering canonical must be one the dictionary actually emits — a
+// marker on a canonical no alias resolves to would be dead config, and would hide a
+// typo that silently reclassifies nothing.
+func TestNonEngineeringCanonicalsAreReal(t *testing.T) {
+	emitted := map[string]bool{}
+	for _, c := range wordAliases {
+		emitted[c] = true
+	}
+	for _, p := range phraseAliases {
+		emitted[p.canonical] = true
+	}
+	for c := range nonEngineeringCanonicals {
+		if !emitted[c] {
+			t.Errorf("nonEngineeringCanonicals[%q] is not a canonical any alias resolves to", c)
+		}
+	}
+}

--- a/internal/skilltag/skilltag.go
+++ b/internal/skilltag/skilltag.go
@@ -199,6 +199,26 @@ func Parse(text string, opts ...Option) []string {
 	return stringset.Sorted(strong)
 }
 
+// HasEngineering reports whether any of the canonicals in skills names engineering
+// work. It exists because "carries a tagged skill" is not the same claim as "is a
+// technical posting": the dictionary deliberately covers the recruiting, HR, finance,
+// legal, operations and customer-success roles a technical company hires for, so a
+// recruiting coordinator comes back tagged {stakeholder-management,
+// candidate-experience} — a correct facet, and no evidence at all about the employer.
+//
+// A canonical the dictionary does not place is treated as engineering. Every caller so
+// far is deciding whether to act against a company on the grounds that it has never
+// posted anything technical, and for that decision an unrecognised skill must not read
+// as proof of absence.
+func HasEngineering(skills []string) bool {
+	for _, s := range skills {
+		if !nonEngineeringCanonicals[s] {
+			return true
+		}
+	}
+	return false
+}
+
 // matchAcronyms adds the canonical of each acronym whose exact surface form occurs
 // as a standalone token in cased (case-preserved) text.
 func matchAcronyms(cased string, acronyms map[string]string, set map[string]struct{}) {

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -591,6 +591,84 @@ func TestParse_AmbiguousCorroboration(t *testing.T) {
 	}
 }
 
+// Job-posting boilerplate that happens to spell a tech name. Unlike the collisions
+// above — which read as ordinary English anywhere — these are the words that recur in
+// the prose of NON-TECHNICAL postings specifically: an "agile" retail supervisor, the
+// drivers who are "the backbone" of a haulier, a "restful" night in a care home, the
+// factory "assembly" line, the rugby "scrum", tree "sap" on a guard rail, a "sentry"
+// post, a bank "vault", the fire-code "firewall", a "rancher", a "postman", "braze"d
+// copper joints.
+//
+// Each was a strong alias, so one of them alone tagged the posting — and worse, a
+// strong match lifts the corroboration gate off EVERY weak word in the same text, so a
+// single boilerplate hit also legitimises the react/rust/spring collisions beside it.
+// That is how a Highway Maintenance Supervisor came out of the pipeline tagged
+// {react, sap}. Measured on prod, 20855 boards holding 475625 postings were kept off
+// the retirement report by the skills dictionary alone, with no technical posting
+// anywhere.
+//
+// Gating them costs nothing a real posting needs: a genuine SAP role names ABAP, a
+// REST role says "REST API" (a strong phrase), a security role names its stack.
+func TestParse_BoilerplateWordsNeedCorroboration(t *testing.T) {
+	contains := func(hay []string, needle string) bool {
+		for _, h := range hay {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+	cases := []struct {
+		name   string
+		in     string
+		want   []string
+		absent []string
+	}{
+		// Boilerplate in non-technical prose, no other tech token → dropped.
+		{"agile as a temperament", "We want an agile, hands-on retail supervisor.", nil, []string{"agile"}},
+		{"backbone of the team", "Our drivers are the backbone of this haulage firm.", nil, []string{"backbone"}},
+		{"restful care home", "Help residents enjoy a restful night in our care home.", nil, []string{"rest"}},
+		{"assembly line", "Work the assembly line fitting door panels.", nil, []string{"assembly"}},
+		{"rugby scrum", "Coach the scrum and play tight-head prop.", nil, []string{"scrum"}},
+		{"tree sap", "Clear vegetation and wash tree sap off the guard rails.", nil, []string{"sap"}},
+		{"sentry duty", "Stand sentry at the north gate on night shifts.", nil, []string{"sentry"}},
+		{"bank vault", "Count the drawer and lock the vault at close.", nil, []string{"vault"}},
+		{"fire-code firewall", "Inspect the firewall between the garage and the dwelling.", nil, []string{"firewall"}},
+		{"ranch hand", "Assist the rancher with calving and fence repair.", nil, []string{"rancher"}},
+		{"postal round", "Cover the postman's round while they are on leave.", nil, []string{"postman"}},
+		{"brazing copper", "Braze copper joints on refrigeration units.", nil, []string{"braze"}},
+		// Corroborated by an unambiguous tech token → kept, exactly as before.
+		{"agile + jira", "Agile delivery tracked in Jira and Kubernetes.", []string{"agile", "jira", "kubernetes"}, nil},
+		{"sap + abap", "SAP ABAP developer for our finance modules.", []string{"sap", "abap"}, nil},
+		{"assembly + c", "Assembly and C programming for embedded targets.", []string{"assembly", "c"}, nil},
+		{"firewall + linux", "Configure firewalls and BGP on Linux.", []string{"firewall", "bgp", "linux"}, nil},
+		{"sentry + typescript", "Error tracking with Sentry in a TypeScript app.", []string{"sentry", "typescript"}, nil},
+		{"vault + kubernetes", "HashiCorp Vault secrets on Kubernetes.", []string{"vault", "kubernetes"}, nil},
+		{"scrum + jira", "Scrum ceremonies tracked in Jira.", []string{"scrum", "jira"}, nil},
+		{"rancher + kubernetes", "Rancher-managed Kubernetes clusters.", []string{"rancher", "kubernetes"}, nil},
+		{"backbone + jquery", "A legacy Backbone and jQuery front end.", []string{"backbone", "jquery"}, nil},
+		{"braze + typescript", "Braze lifecycle campaigns instrumented in TypeScript.", []string{"braze", "typescript"}, nil},
+		// The unambiguous phrase form still tags on its own — "REST API" is not prose.
+		{"rest api phrase", "Design REST APIs in Python.", []string{"rest", "python"}, nil},
+		{"postman + rest api", "API testing with Postman against our REST APIs.", []string{"postman", "rest"}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Parse(c.in)
+			for _, w := range c.want {
+				if !contains(got, w) {
+					t.Errorf("Parse(%q) = %v, missing %q", c.in, got, w)
+				}
+			}
+			for _, a := range c.absent {
+				if contains(got, a) {
+					t.Errorf("Parse(%q) = %v, must NOT contain %q", c.in, got, a)
+				}
+			}
+		})
+	}
+}
+
 // Every ambiguousWords key must be a real wordAliases entry — an ambiguous marker
 // on a token the word pass never emits would be dead config.
 func TestAmbiguousWordsSubsetOfAliases(t *testing.T) {

--- a/sources/retired/README.md
+++ b/sources/retired/README.md
@@ -19,9 +19,15 @@ the rules that need a retired board would stop firing.
 ## How an entry gets here
 
 `cmd/prune --boards` lists the boards whose postings were classified and none of them
-came out technical — no technical title or category, and not one tagged skill, across
-their whole history. Move those entries out of `sources/<provider>.yml` and into
-`sources/retired/<provider>.yml`, in the same PR that prunes their jobs.
+came out technical — no technical title or category, and not one tagged **engineering**
+skill, across their whole history. Move those entries out of `sources/<provider>.yml`
+and into `sources/retired/<provider>.yml`, in the same PR that prunes their jobs.
+
+Engineering is the operative word. The skills dictionary deliberately covers the
+recruiting, HR, finance, legal, operations and customer-success craft a technical
+company hires for, because the facet describes every posting. Counting any tag as
+technical evidence let a recruiting coordinator vouch for a whole board; the report
+asks `skilltag.HasEngineering` instead.
 
 Boards no posting of which has been classified are withheld from that list and counted
 at the top of the report. They are not safe to retire; nothing is known about them.


### PR DESCRIPTION
Two commits, both aimed at the same thing: `cmd/prune --boards` was shielded from listing boards by the skills dictionary, so the retirement list has never been trustworthy.

## What was wrong

`reportBoards` treated *any* tagged skill as evidence that a board is a technical employer:

```go
v.technical = v.technical || (row.IsTech.Valid && row.IsTech.Bool) || row.HasSkills
```

`has_skills` is `cardinality(skills) > 0`. But the dictionary deliberately covers the **non-engineering** roles a technical company hires for — recruiting, HR, finance, legal, operations, customer success — because a skills facet describes every posting. A recruiting coordinator tagged `{stakeholder-management, candidate-experience}` therefore vouched for its whole board.

Separately, twelve strong aliases spell words belonging to the prose of non-technical postings: an "agile" supervisor, drivers who are "the backbone", a "restful" night in a care home, the "assembly" line, the rugby "scrum", tree "sap", a "sentry" post, a bank "vault", the fire-code "firewall", a "rancher", a "postman", "braze"d copper. Each tagged its posting alone — and because a strong match lifts the corroboration gate off every weak word in the same text, one `sap` on a road-maintenance description turned "guard rails" into Ruby on Rails. That is how a Highway Maintenance Supervisor came out tagged `{react, sap}`.

## Measured on a 0.5% prod sample

Of the postings the classifier calls **non-technical** that still carry skills (2 633 sampled):

| Shield | Share |
|---|---|
| boilerplate English words | 194 (7%) |
| nothing but non-engineering skills | 978 (37%) cumulative |

41.7% of all non-technical postings carry skills at all — that is the mechanism keeping ~20 855 boards off the report.

## What changed

- **`internal/skilltag`** — the twelve boilerplate aliases join `ambiguousWords`, so they tag only when a concrete technology corroborates them. `restful api` / `restful apis` are added as strong phrases so real REST postings keep the tag; it is the phrase, not the adjective, that names the style.
- **`internal/skilltag`** — the professional half of the vocabulary moves into `professionalPhraseAliases`, and `nonEngineeringCanonicals` is *derived* from it, never hand-written, so the two cannot drift. New exported `HasEngineering`.
- **`cmd/prune`** — `PruneCandidates` returns `skills` whole rather than a cardinality test, and the report asks `skilltag.HasEngineering`.

Developer relations, technical writing, business analysis and pre-sales stay on the engineering side deliberately: they are tech-industry craft, and the conservative error is to keep a board, never to retire a live one. An unrecognised canonical counts as engineering for the same reason.

## Deliberately not in scope

`ruleUnknown` reads the same any-skill signal (`cmd/prune/rule.go:95`), but there it is a veto that **protects** a job from deletion. Making it stricter widens the only hard-delete path in the system and deserves its own measurement.

## Follow-up this unblocks

`--boards` must be re-run after this ships **and** after a `backfill-derive` — `skills` is a stored column, so the dictionary change only reaches the catalogue through a backfill. That output is the input for the retirement PR, which still has not been made.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean; full `go test ./...` green (107 packages). Both behaviours were driven test-first: the 12 negatives failed for the right reason before the gate existed, and the prune test failed to compile against the old row shape.