### PR TITLE
feat(sources): crawl Instaffo, a German hiring marketplace

### DIFF
--- a/internal/sources/instaffo.go
+++ b/internal/sources/instaffo.go
@@ -1,0 +1,126 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// instaffo adapts jobs.instaffo.com, a German hiring marketplace. Boardless (one site, no
+// per-tenant board) and multi-company, so it stays in the source facet and takes each
+// posting's employer from the page. The sitemap index points to a "jobs" sub-sitemap; each
+// job page server-renders a schema.org JobPosting ld+json block, so the description comes
+// from a per-job detail fetch (bounded-concurrency), like the other HTML detail adapters.
+//
+// Every posting is listed twice, once per locale, under one native id and with identical
+// ld+json — the locale only swaps the surrounding chrome. instaffoJobID answers for the
+// canonical /de/ URL alone, which drops each /en/ twin before it costs a fetch.
+
+// instaffoHTTP is the transport instaffo needs: an XML sitemap plus HTML detail pages.
+type instaffoHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+type instaffo struct {
+	http instaffoHTTP
+}
+
+// NewInstaffo builds the Instaffo adapter over the given HTTP client.
+func NewInstaffo(c instaffoHTTP) Source { return instaffo{http: c} }
+
+func (instaffo) Provider() string { return "instaffo" }
+
+func (instaffo) boardless() {}
+
+func (instaffo) aggregator() {}
+
+func (s instaffo) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	// The needle is the full "sitemap-jobs" stem, not "jobs": the site's own host carries
+	// "jobs", so a bare needle matches every sub-sitemap and picks whichever comes first.
+	jobSitemap, err := resolveSubSitemap(ctx, s.http, "https://jobs.instaffo.com/sitemap.xml", "sitemap-jobs")
+	if err != nil {
+		return nil, fmt.Errorf("instaffo: %w", err)
+	}
+	if jobSitemap == "" {
+		return nil, nil
+	}
+
+	locs, err := sitemapJobLocs(ctx, s.http, jobSitemap, instaffoJobID)
+	if err != nil {
+		return nil, fmt.Errorf("instaffo: job sitemap: %w", err)
+	}
+
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, loc)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the page fetch fails, carries no JobPosting, or lacks an employer (which would break
+// the company slug). The ld+json carries no url, so the page loc is the canonical link.
+func (s instaffo) detail(ctx context.Context, loc string) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	var p instaffoPosting
+	if !ldJobPosting(root, &p) || p.HiringOrganization.Name == "" {
+		return Job{}, false
+	}
+
+	// Instaffo never retires a posting from its sitemap — validThrough is stamped a year out
+	// on every fetch, so it carries no signal, and the 48h unseen sweep never fires because
+	// the posting never goes unseen. Age is the only staleness signal, so it gates on the way
+	// in: a posting older than the window would otherwise sit open in the catalogue forever.
+	posted := parseDate(p.DatePosted)
+	if posted == nil || time.Since(*posted) > instaffoMaxAge {
+		return Job{}, false
+	}
+
+	location := p.JobLocation.Address.Location()
+
+	return Job{
+		ExternalID:  instaffoJobID(loc),
+		URL:         loc,
+		Title:       p.Title,
+		Company:     p.HiringOrganization.Name,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      isRemote(location) || isRemote(p.Title),
+		PostedAt:    posted,
+	}, true
+}
+
+// instaffoMaxAge is how old a posting may be and still be ingested. Instaffo keeps postings
+// in its sitemap indefinitely (the catalogue holds ads from two years back), and nothing
+// downstream can close one, so this is the only thing standing between the catalogue and a
+// permanent tail of dead ads. A year is deliberately generous: German mid-market vacancies
+// do legitimately stay open for months.
+const instaffoMaxAge = 365 * 24 * time.Hour
+
+// instaffoPosting is the schema.org JobPosting decoded from an Instaffo job page. jobLocation
+// is a single Place (not an array), and datePosted is date-only.
+type instaffoPosting struct {
+	Title              string      `json:"title"`
+	Description        string      `json:"description"`
+	DatePosted         string      `json:"datePosted"`
+	JobLocation        schemaPlace `json:"jobLocation"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+}
+
+// instaffoJobIDPattern captures the posting slug from a canonical /de/job/<slug> URL, where
+// the slug ends in the native hex id. The locale is part of the pattern on purpose: it is
+// what makes the /en/ twin of every posting answer "" and drop out.
+var instaffoJobIDPattern = regexp.MustCompile(`/de/job/([^/?#]+-[0-9a-f]{12})$`)
+
+// instaffoJobID extracts the native posting id from a job page URL, or "" when the URL is not
+// a canonical job posting (so locale twins and non-job sitemap entries are dropped).
+func instaffoJobID(loc string) string {
+	return firstSubmatch(instaffoJobIDPattern, loc)
+}

--- a/internal/sources/instaffo_test.go
+++ b/internal/sources/instaffo_test.go
@@ -1,0 +1,177 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+const instaffoDetailHTML = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"Senior Software Engineer API (f/m/d)",
+"description":"<p>Node.js &amp; SQL.</p><script>alert(1)<\/script>",
+"datePosted":"2026-07-20",
+"hiringOrganization":{"@type":"Organization","name":"smartclip Europe GmbH"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Berlin","addressCountry":"DE"}}}
+</script></head><body></body></html>`
+
+const instaffoIndexXML = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://jobs.instaffo.com/sitemap-static.xml</loc></sitemap>
+<sitemap><loc>https://jobs.instaffo.com/sitemap-jobs.xml</loc></sitemap>
+</sitemapindex>`
+
+func instaffoJobsXML(locs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+	for _, l := range locs {
+		b.WriteString(`<url><loc>` + l + `</loc></url>`)
+	}
+	b.WriteString(`</urlset>`)
+	return b.String()
+}
+
+func TestInstaffoProvider(t *testing.T) {
+	if got := NewInstaffo(nil).Provider(); got != "instaffo" {
+		t.Errorf("Provider() = %q, want instaffo", got)
+	}
+}
+
+func TestInstaffoIsBoardlessAggregator(t *testing.T) {
+	s := NewInstaffo(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("instaffo should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("instaffo should implement the aggregator marker")
+	}
+}
+
+func TestInstaffoRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["instaffo"]; !ok {
+		t.Error("All() should register provider instaffo")
+	}
+	if !slices.Contains(FilterableProviders(), "instaffo") {
+		t.Error("FilterableProviders() should include instaffo")
+	}
+}
+
+func TestInstaffoBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/instaffo.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/instaffo.yml fails validation: %v", err)
+	}
+}
+
+// Instaffo lists every posting twice — once per locale — under the same native id. Only the
+// canonical /de/ URL yields an id, so the /en/ twin is dropped before it is ever fetched.
+func TestInstaffoJobIDTakesCanonicalLocaleOnly(t *testing.T) {
+	cases := map[string]string{
+		"https://jobs.instaffo.com/de/job/java-entwickler-backend-m-w-430f12a0768e": "java-entwickler-backend-m-w-430f12a0768e",
+		"https://jobs.instaffo.com/en/job/java-entwickler-backend-m-w-430f12a0768e": "",
+		"https://jobs.instaffo.com/de/talent/berlin":                                "",
+	}
+	for u, want := range cases {
+		if got := instaffoJobID(u); got != want {
+			t.Errorf("instaffoJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestInstaffoFetchResolvesJobSitemapThenMaps(t *testing.T) {
+	job := "https://jobs.instaffo.com/de/job/software-engineer-api-f-m-d-8394973d2c35"
+	twin := "https://jobs.instaffo.com/en/job/software-engineer-api-f-m-d-8394973d2c35"
+	fake := (&routedHTTP{}).
+		route("/de/job/software-engineer-api-f-m-d-8394973d2c35", instaffoDetailHTML).
+		route("/sitemap-jobs.xml", instaffoJobsXML(job, twin, "https://jobs.instaffo.com/de/talent/berlin")).
+		route("/sitemap.xml", instaffoIndexXML)
+
+	jobs, err := NewInstaffo(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (locale twin and non-job entry filtered)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "software-engineer-api-f-m-d-8394973d2c35" || j.URL != job {
+		t.Errorf("id/url wrong: %s %s", j.ExternalID, j.URL)
+	}
+	if j.Company != "smartclip Europe GmbH" || j.Title != "Senior Software Engineer API (f/m/d)" {
+		t.Errorf("bad mapping: company=%q title=%q", j.Company, j.Title)
+	}
+	if j.Location != "Berlin, DE" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v", j.PostedAt)
+	}
+}
+
+// Instaffo never retires a posting from its sitemap, so the unseen sweep can never close
+// one — age is the only staleness signal there is, and it is applied on the way in.
+func TestInstaffoDropsPostingsOlderThanMaxAge(t *testing.T) {
+	postingAged := func(d time.Duration) string {
+		return `<html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting","title":"Entwickler",
+"hiringOrganization":{"@type":"Organization","name":"Acme GmbH"},
+"datePosted":"` + time.Now().Add(-d).Format("2006-01-02") + `"}
+</script></head><body></body></html>`
+	}
+
+	fresh := "https://jobs.instaffo.com/de/job/fresh-aaaaaaaaaaaa"
+	stale := "https://jobs.instaffo.com/de/job/stale-bbbbbbbbbbbb"
+	undated := "https://jobs.instaffo.com/de/job/undated-cccccccccccc"
+
+	fake := (&routedHTTP{}).
+		route("/de/job/fresh-aaaaaaaaaaaa", postingAged(instaffoMaxAge-24*time.Hour)).
+		route("/de/job/stale-bbbbbbbbbbbb", postingAged(instaffoMaxAge+24*time.Hour)).
+		route("/de/job/undated-cccccccccccc", `<html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting","title":"Entwickler",
+"hiringOrganization":{"@type":"Organization","name":"Acme GmbH"}}
+</script></head><body></body></html>`).
+		route("/sitemap-jobs.xml", instaffoJobsXML(fresh, stale, undated)).
+		route("/sitemap.xml", instaffoIndexXML)
+
+	jobs, err := NewInstaffo(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (only the posting inside the age window)", len(jobs))
+	}
+	if jobs[0].URL != fresh {
+		t.Errorf("kept %q, want the fresh posting", jobs[0].URL)
+	}
+}
+
+// A posting with no company would slug to nothing downstream, so it is skipped rather than
+// carried with an empty employer.
+func TestInstaffoSkipsPostingWithoutCompany(t *testing.T) {
+	const noCompany = `<html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting","title":"Ghost","datePosted":"2026-07-20"}
+</script></head><body></body></html>`
+
+	job := "https://jobs.instaffo.com/de/job/ghost-000000000000"
+	fake := (&routedHTTP{}).
+		route("/de/job/ghost-000000000000", noCompany).
+		route("/sitemap-jobs.xml", instaffoJobsXML(job)).
+		route("/sitemap.xml", instaffoIndexXML)
+
+	jobs, err := NewInstaffo(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (posting without hiringOrganization)", len(jobs))
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -186,6 +186,7 @@ func All(c HTTPClient) map[string]Source {
 		NewFourDayWeek(c),
 		NewFunctionalWorks(c),
 		NewTheHub(c),
+		NewInstaffo(c),
 		NewGetonbrd(c),
 		NewVagas(c),
 		NewWantedKR(c),

--- a/sources/instaffo.yml
+++ b/sources/instaffo.yml
@@ -1,0 +1,4 @@
+# Instaffo (jobs.instaffo.com), a German hiring marketplace. Boardless and multi-company:
+# one entry drives the whole site, and each posting carries its own employer.
+- company: Instaffo
+  provider: instaffo


### PR DESCRIPTION
`jobs.instaffo.com` came in through the contribution review queue as an unrecognized link. Boardless and multi-company, so it follows the `thehub` shape: sitemap index → `sitemap-jobs.xml` → per-job page with a schema.org `JobPosting` carrying its own `hiringOrganization`.

## Volume, honestly

**1983 postings**, not the 3966 the sitemap's `<loc>` count suggests — every posting is listed twice, once per locale, under one native id with byte-identical ld+json. Roughly 45% are technical by title; the rest (Steuerberater, Buchhalter, Sales) meet the existing non-tech gate downstream.

## Two platform quirks the adapter answers for

**Locale twins.** `instaffoJobID` matches the canonical `/de/` URL only, so each `/en/` twin drops during sitemap filtering rather than costing a detail fetch. Verified against all 1983 live URLs: 1983 matched, 1983 unique ids, 0 missed.

**Postings are never retired.** The sitemap still carries ads from 2024-08, and `validThrough` is stamped `today + 1y` on every fetch, so it carries no signal. Nothing downstream can close one — the 48h unseen sweep never fires because the posting never goes unseen. Age is therefore gated on the way in at a generous year (a sampled 40: 70% ≤6mo, 10% 6–12mo, 20% >12mo).

## Note for the sources deploy

New board file — prod's ingest schedule needs an entry for `sources/instaffo.yml`; nothing in-repo wires it.

## Tests

8 tests, TDD. Worth flagging one they caught: `resolveSubSitemap` with needle `"jobs"` silently selected `sitemap-static.xml`, because the site's own host is `jobs.instaffo.com`. The needle is the full `"sitemap-jobs"` stem now.