### PR TITLE
feat(sources): crawl a Workday site whose host is shared between tenants

### DIFF
--- a/internal/sources/workday.go
+++ b/internal/sources/workday.go
@@ -32,23 +32,45 @@ func NewWorkday(c workdayHTTP) Source { return workday{http: c} }
 
 func (workday) Provider() string { return "workday" }
 
-// workdayBoard is a configured board parsed into the parts the CXS endpoints need.
+// workdayBoard is a configured board parsed into the parts the CXS endpoints need, plus the
+// board's prefix on the public careers site — which is not the CXS path, and differs between
+// the two host shapes.
 type workdayBoard struct {
 	host, tenant, site string
+	publicPath         string
 }
 
-// parseWorkdayBoard splits "host/site" (e.g. "acme.wd1.myworkdayjobs.com/Careers") into
-// the host, the tenant (the host's first label), and the site.
+// parseWorkdayBoard splits a board into the host, tenant, site and public path. Workday
+// publishes a career site under either of two host shapes:
+//
+//	acme.wd1.myworkdayjobs.com/Careers  — a per-tenant host; the tenant is its first label,
+//	                                      and the public site is served at /<site>.
+//	wd1.myworkdaysite.com/snapchat/snap — a host shared between tenants, so the board spells
+//	                                      the tenant out as a middle segment and the public
+//	                                      site is served at /recruiting/<tenant>/<site>.
+//
+// Both address the same CXS endpoints at /wday/cxs/<tenant>/<site>/.
 func parseWorkdayBoard(board string) (workdayBoard, error) {
-	host, site, ok := strings.Cut(board, "/")
-	if !ok || host == "" || site == "" {
+	host, rest, ok := strings.Cut(board, "/")
+	if !ok || host == "" || rest == "" {
 		return workdayBoard{}, fmt.Errorf("workday: board %q must be \"host/site\"", board)
 	}
+
+	if tenant, site, spelledOut := strings.Cut(rest, "/"); spelledOut {
+		if tenant == "" || site == "" {
+			return workdayBoard{}, fmt.Errorf("workday: board %q must be \"host/tenant/site\"", board)
+		}
+		return workdayBoard{
+			host: host, tenant: tenant, site: site,
+			publicPath: "recruiting/" + tenant + "/" + site,
+		}, nil
+	}
+
 	tenant, _, ok := strings.Cut(host, ".")
 	if !ok || tenant == "" {
 		return workdayBoard{}, fmt.Errorf("workday: board host %q has no tenant label", host)
 	}
-	return workdayBoard{host: host, tenant: tenant, site: site}, nil
+	return workdayBoard{host: host, tenant: tenant, site: rest, publicPath: rest}, nil
 }
 
 // workdayPosting is one item from the jobs listing (no description here).
@@ -140,7 +162,7 @@ func (s workday) detail(ctx context.Context, e CompanyEntry, b workdayBoard, p w
 	location := firstNonEmpty(info.Location, p.LocationsText)
 	jobURL := info.ExternalURL
 	if jobURL == "" {
-		jobURL = fmt.Sprintf("https://%s/%s%s", b.host, b.site, p.ExternalPath)
+		jobURL = fmt.Sprintf("https://%s/%s%s", b.host, b.publicPath, p.ExternalPath)
 	}
 	remote := isRemote(location) || strings.Contains(strings.ToLower(info.RemoteType), "remote")
 

--- a/internal/sources/workday_test.go
+++ b/internal/sources/workday_test.go
@@ -186,3 +186,55 @@ func TestParseWorkdayBoardRejectsMalformed(t *testing.T) {
 		}
 	}
 }
+
+// Workday publishes a career site under either of two host shapes. On myworkdayjobs.com the
+// tenant is the host's own first label; on myworkdaysite.com the host is shared across
+// tenants (wd1.myworkdaysite.com) and the tenant lives in the path instead, so the board
+// spells it out as a third segment.
+func TestParseWorkdayBoardTakesTenantFromPathWhenSpelledOut(t *testing.T) {
+	cases := map[string]workdayBoard{
+		"acme.wd1.myworkdayjobs.com/Careers": {
+			host: "acme.wd1.myworkdayjobs.com", tenant: "acme", site: "Careers",
+			publicPath: "Careers",
+		},
+		"wd1.myworkdaysite.com/snapchat/snap": {
+			host: "wd1.myworkdaysite.com", tenant: "snapchat", site: "snap",
+			publicPath: "recruiting/snapchat/snap",
+		},
+	}
+	for board, want := range cases {
+		got, err := parseWorkdayBoard(board)
+		if err != nil {
+			t.Errorf("parseWorkdayBoard(%q): %v", board, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseWorkdayBoard(%q) = %+v, want %+v", board, got, want)
+		}
+	}
+}
+
+// The routes below are the assertion: routedHTTP answers by URL substring, so the board only
+// yields a posting if the adapter addressed the shared host with the path tenant — i.e. built
+// /wday/cxs/snapchat/snap/jobs rather than /wday/cxs/wd1/snapchat%2Fsnap/jobs.
+func TestWorkdayFetchesPathTenantBoard(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("https://wd1.myworkdaysite.com/wday/cxs/snapchat/snap/jobs",
+			`{"total":1,"jobPostings":[{"title":"Engineer","externalPath":"/job/X/JR-1","locationsText":"Berlin"}]}`).
+		route("/job/X/JR-1", `{"jobPostingInfo":{"title":"Engineer","jobDescription":"<p>ok</p>","location":"Berlin"}}`)
+
+	jobs, err := NewWorkday(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Snap", Provider: "workday", Board: "wd1.myworkdaysite.com/snapchat/snap",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	// The public site is not served at the CXS path: /snap/job/... answers 500, the posting
+	// lives under /recruiting/<tenant>/<site>.
+	if jobs[0].URL != "https://wd1.myworkdaysite.com/recruiting/snapchat/snap/job/X/JR-1" {
+		t.Errorf("URL = %q, want the posting's public /recruiting path", jobs[0].URL)
+	}
+}

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -1,5 +1,7 @@
 # workday boards. Provider is the filename; each entry is company + board.
-# board = platform-specific id (see internal/sources/workday.go).
+# board = platform-specific id (see internal/sources/workday.go): "host/site" for a
+# per-tenant host, or "host/tenant/site" when the host is shared between tenants
+# (wd1.myworkdaysite.com) and the tenant has to be spelled out.
 
 - company: Carbon Health
   board: carbonhealth.wd1.myworkdayjobs.com/Careers
@@ -12869,3 +12871,5 @@
   board: xavier.wd108.myworkdayjobs.com/XavierCareers
 - company: Unity
   board: unitytech.wd1.myworkdayjobs.com/Unity
+- company: Snap
+  board: wd1.myworkdaysite.com/snapchat/snap


### PR DESCRIPTION
`careers.snap.com` came in through the contribution review queue. It is Workday — but a shape we could not crawl at all.

## The gap

Workday publishes a career site under two host shapes:

| shape | tenant | public site |
|---|---|---|
| `acme.wd1.myworkdayjobs.com/Careers` | host's first label | `/<site>` |
| `wd1.myworkdaysite.com/snapchat/snap` | **in the path** — host is shared | `/recruiting/<tenant>/<site>` |

`parseWorkdayBoard` took the tenant from the host's first label unconditionally, so on the second shape it read `wd1` and addressed `/wday/cxs/wd1/snapchat%2Fsnap/jobs`. No such board was crawlable, and we tracked none.

## The change

A board may now spell the tenant out as a middle segment; two-segment boards are untouched. Because the public site is **not** served at the CXS path on that shape (`/snap/job/…` answers 500, `/recruiting/snapchat/snap/job/…` answers 200), `workdayBoard` also carries the public prefix that the posting URL is built from.

Both verified against live Snap: CXS list/detail at `/wday/cxs/snapchat/snap/`, public posting at `/recruiting/snapchat/snap<externalPath>`.

## Tests

TDD; two new tests plus the existing Workday suite green. The parse test asserts both shapes side by side so the distinction stays visible.