### PR TITLE
fix(contribution): stop a portal slug and a platform host from passing as boards

### DIFF
--- a/internal/contribution/AGENTS.md
+++ b/internal/contribution/AGENTS.md
@@ -13,9 +13,15 @@ contributions are URL-only, auto-validated, unmoderated.
   we know the board, the ingest side onboards it and crawls ALL its vacancies — a second
   vacancy from the same board adds nothing.
 - **Board recognition is a pure, network-free URL parse** (`board.go`, `recognizeBoard`): the
-  host maps to a source + extraction `mode` via the `atsBoards` table. Two modes: `path` (board
-  = first path segment, e.g. `jobs.lever.co/<board>`) and `subdomain` (board = leftmost DNS
-  label, e.g. `<board>.recruitee.com` — the canonical URL collapses to the bare host). This is
+  host maps to a source + extraction `mode` via the `atsBoards` table. `path` (first path
+  segment, `jobs.lever.co/<board>`), `pathlocale` (same, skipping a leading `xx-XX` locale —
+  Rippling), `pathportal` (the segment before the posting, because SmartRecruiters also serves a
+  posting behind a portal segment), `subdomain` (leftmost DNS label, `<board>.recruitee.com`),
+  `host` (the whole careers host, whose regional TLD varies — Zoho, Teamtailor), and `hostpath`
+  (`<host>/<site>` — Workday). For subdomain/host/hostpath the canonical URL collapses to the
+  board itself. Whatever a mode yields, the platform's **own** product hosts (`app.`,
+  `dashboard.`, …) are never a tenant — a career site links to them, and `boardresolve` takes
+  the first recognized ATS URL it finds in a page. This is
   deliberately a small local table, NOT a per-adapter method on `linksource` — adding an ATS is
   one row + a test. Covers ~37 multi-tenant ATS (greenhouse, lever, ashby, workable, recruitee,
   smartrecruiters, bamboohr, personio, peopleforce, gupy, freshteam, jazzhr, huntflow, deel,

--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -11,6 +11,9 @@ import (
 //   - pathlocale: like path, but a leading xx-XX locale segment is skipped first — Rippling's
 //     public site prefixes the board with a locale (ats.rippling.com/en-GB/<board>/…) that its
 //     board API omits, so both URL shapes must resolve to the same board.
+//   - pathportal: board = the segment before the posting segment, because SmartRecruiters serves
+//     the same posting both bare (<company>/<posting>) and behind a portal segment
+//     (<portal>/<company>/<posting>). Taking the first segment reads the portal slug as a board.
 //   - subdomain: board = the leftmost DNS label under a fixed apex (<board>.recruitee.com).
 //   - host:      board = the whole careers host (the tenant identity IS the host, and the TLD
 //     varies by region, e.g. <tenant>.zohorecruit.eu / .com / .in).
@@ -22,6 +25,7 @@ import (
 const (
 	modePath       = "path"
 	modePathLocale = "pathlocale"
+	modePathPortal = "pathportal"
 	modeSubdomain  = "subdomain"
 	modeHost       = "host"
 	modeHostPath   = "hostpath"
@@ -48,9 +52,11 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"careers.pageuppeople.com", "pageup", modePath},
 	{"oportunidades.mindsight.com.br", "mindsight", modePath},
 	{"careers.hireology.com", "hireology", modePath},
-	{"jobs.smartrecruiters.com", "smartrecruiters", modePath},
-	{"careers.smartrecruiters.com", "smartrecruiters", modePath},
 	{"recruiting.ultipro.com", "ukg", modePath},
+
+	// --- pathportal: board = the segment before the posting segment ---
+	{"jobs.smartrecruiters.com", "smartrecruiters", modePathPortal},
+	{"careers.smartrecruiters.com", "smartrecruiters", modePathPortal},
 
 	// --- pathlocale: like path, skipping a leading xx-XX locale segment ---
 	{"ats.rippling.com", "rippling", modePathLocale},
@@ -112,7 +118,7 @@ func RecognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 	case modeSubdomain, modeHost:
 		if mode == modeSubdomain {
 			board = subdomainLabel(host, apex)
-		} else {
+		} else if !platformHost(host) {
 			board = host // the whole careers host is the tenant identity
 		}
 		if board == "" {
@@ -137,6 +143,18 @@ func RecognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 		u.RawQuery, u.Fragment = "", ""
 		u.Path = "/" + site
 		return src, host + "/" + site, u.String(), true
+
+	case modePathPortal:
+		// SmartRecruiters: the employer is the segment immediately before the posting, which is
+		// the first segment on a bare URL and the second behind a portal segment. Only a
+		// recognizable posting segment shifts the board along; any other shape falls through to
+		// the first segment, so an unknown URL shape can't invent a board.
+		board = segmentBeforePosting(u, smartrecruitersPosting)
+		if board == "" {
+			return "", "", "", false
+		}
+		u.RawQuery, u.Fragment = "", ""
+		return src, board, u.String(), true
 
 	case modePathLocale:
 		// Rippling: skip a leading xx-XX locale segment (ats.rippling.com/en-GB/<board>/…),
@@ -193,6 +211,41 @@ func subdomainLabel(host, apex string) string {
 		return sub[:i]
 	}
 	return sub
+}
+
+// platformLabels are the leftmost DNS labels a multi-tenant ATS uses for its own product hosts
+// rather than for a tenant. In host mode the whole host is the board, so without this a link to
+// the platform's own app (which every tenant career site carries) reads as a tenant — and
+// boardresolve, which accepts the first recognized ATS URL found in a page, then records that
+// as the employer's board.
+var platformLabels = map[string]bool{
+	"app": true, "dashboard": true, "admin": true, "api": true,
+	"support": true, "help": true, "blog": true, "docs": true,
+}
+
+// platformHost reports whether host is the ATS's own product host rather than a tenant's.
+func platformHost(host string) bool {
+	label, _, ok := strings.Cut(host, ".")
+	return ok && platformLabels[label]
+}
+
+// smartrecruitersPosting matches a SmartRecruiters posting segment: the posting id (numeric or a
+// UUID) followed by the title slug.
+var smartrecruitersPosting = regexp.MustCompile(`^(?:[0-9]{6,}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-`)
+
+// segmentBeforePosting returns the path segment immediately before the last segment when that
+// last segment is a posting (per isPosting), and the first segment otherwise — a board listing
+// URL carries no posting, and an unfamiliar shape must not shift the board off the first segment.
+func segmentBeforePosting(u *url.URL, isPosting *regexp.Regexp) string {
+	p := strings.Trim(u.Path, "/")
+	if p == "" {
+		return ""
+	}
+	segs := strings.Split(p, "/")
+	if n := len(segs); n >= 2 && isPosting.MatchString(segs[n-1]) {
+		return segs[n-2]
+	}
+	return segs[0]
 }
 
 // localeSegment matches an xx-XX language-COUNTRY locale (e.g. en-GB) — the optional leading

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -25,6 +25,13 @@ func TestRecognizeBoard(t *testing.T) {
 		{"deel path", "https://jobs.deel.com/acme/jobs/123", "deel", "acme", "https://jobs.deel.com/acme/jobs/123", true},
 		{"jobvite path", "https://jobs.jobvite.com/acme/job/oABC", "jobvite", "acme", "https://jobs.jobvite.com/acme/job/oABC", true},
 
+		// SmartRecruiters serves a posting either bare (<company>/<posting>) or behind a portal
+		// segment (<portal>/<company>/<posting>). The employer is the segment before the
+		// posting, never the first one — reading the first turned a portal slug into a board.
+		{"smartrecruiters bare posting", "https://jobs.smartrecruiters.com/BHFT/744000139104759-senior-compliance-officer", "smartrecruiters", "BHFT", "https://jobs.smartrecruiters.com/BHFT/744000139104759-senior-compliance-officer", true},
+		{"smartrecruiters posting behind a portal segment", "https://jobs.smartrecruiters.com/ni/BHFT/6fc8fa0d-1447-4887-9bae-945406ca8500-talent-acquisition-manager", "smartrecruiters", "BHFT", "https://jobs.smartrecruiters.com/ni/BHFT/6fc8fa0d-1447-4887-9bae-945406ca8500-talent-acquisition-manager", true},
+		{"smartrecruiters board listing", "https://jobs.smartrecruiters.com/BHFT", "smartrecruiters", "BHFT", "https://jobs.smartrecruiters.com/BHFT", true},
+
 		// pathlocale — Rippling: an optional leading xx-XX locale segment is skipped; canonical
 		// collapses to the board root so a locale-prefixed vacancy, a bare vacancy, and the
 		// listing all map to one board.
@@ -68,6 +75,11 @@ func TestRecognizeBoard(t *testing.T) {
 		{"personio bare apex no tenant", "https://jobs.personio.com", "", "", "", false},
 		{"single-tenant geekjob", "https://geekjob.ru/vacancy/6a1e", "", "", "", false},
 		{"teamtailor custom domain not derivable", "https://careers.arrive.com/jobs/1", "", "", "", false},
+		// A Teamtailor career site links to the platform's own app host. In host mode the whole
+		// host is the board, so app.teamtailor.com passed as a tenant — and boardresolve, which
+		// takes the first recognized ATS URL in a page, recorded it as the employer's board.
+		{"teamtailor platform app host not a tenant", "https://app.teamtailor.com/companies/1/jobs", "", "", "", false},
+		{"teamtailor platform dashboard host not a tenant", "https://dashboard.teamtailor.com/", "", "", "", false},
 		{"unknown host", "https://example.com/careers/1", "", "", "", false},
 		{"not http", "ftp://acme.recruitee.com", "", "", "", false},
 		{"garbage", "not a url", "", "", "", false},


### PR DESCRIPTION
Two rows in the contribution queue recorded a `board` that was never an employer. Worse than cosmetic: `UNIQUE (source, board)` consecrates the mistake, so the next person pasting a link of the same shape collides with a junk row and gets no credit.

## SmartRecruiters — a portal slug read as the board

`jobs.smartrecruiters.com/ni/BHFT/6fc8fa0d-…-talent-acquisition-manager` recorded board `ni`. SmartRecruiters serves the same posting two ways:

- `/<company>/<posting>` — 12 of 12 sampled prod URLs
- `/<portal>/<company>/<posting>` — the contributed link

The employer is the segment **before** the posting, not the first one. An unfamiliar shape still falls back to the first segment, so an unknown URL can't invent a board.

## Teamtailor — the platform's own app host read as a tenant

`careers.arrive.com` recorded board `app.teamtailor.com`. In `host` mode the whole host is the board, and every Teamtailor career site links to the platform's app — so `boardresolve`, which accepts the **first** recognized ATS URL it finds in a page, took it as the employer's board. Platform product labels (`app.`, `dashboard.`, …) are no longer tenants.

Rippling's locale prefix (`/en-GB/satomic/…` → board `en-GB`) is the same class of bug and was already fixed in #902 — both bad contributions predate it, which is why the queue still shows it.

## Tests

TDD; three SmartRecruiters cases and two platform-host cases added to the table test, each reproducing a real queue row before the fix.