### PR TITLE
feat(sources): crawl Compleo, taking one tenant's slice of a platform sitemap

### DIFF
--- a/internal/sources/compleo.go
+++ b/internal/sources/compleo.go
@@ -1,0 +1,105 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// compleo adapts jobs.compleo.app, a Brazilian ATS. The board is the tenant's path segment
+// (e.g. "wafx"). Compleo publishes one sitemap for the whole platform rather than one per
+// tenant, so a board is a slice of it: the postings under that tenant's segment. Each job page
+// server-renders a schema.org JobPosting ld+json, so the description comes from a per-job
+// detail fetch (bounded-concurrency), like the other HTML detail adapters.
+//
+// The platform is mostly non-technical hiring — a board is worth adding only when the tenant
+// itself is (an IT consultancy, say), which is why boards are curated rather than harvested
+// wholesale.
+
+// compleoHTTP is the transport compleo needs: an XML sitemap plus HTML detail pages.
+type compleoHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+type compleo struct {
+	http compleoHTTP
+}
+
+// NewCompleo builds the Compleo adapter over the given HTTP client.
+func NewCompleo(c compleoHTTP) Source { return compleo{http: c} }
+
+func (compleo) Provider() string { return "compleo" }
+
+func (s compleo) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	locs, err := sitemapJobLocs(ctx, s.http, "https://jobs.compleo.app/sitemap.xml", compleoJobID)
+	if err != nil {
+		return nil, fmt.Errorf("compleo: sitemap: %w", err)
+	}
+
+	// The sitemap covers every tenant, so keep this board's postings. The prefix carries both
+	// slashes: "wafx" must not swallow "wafxpro".
+	prefix := "https://jobs.compleo.app/" + e.Board + "/jobdetail/"
+	var mine []string
+	for _, loc := range locs {
+		if strings.HasPrefix(loc, prefix) {
+			mine = append(mine, loc)
+		}
+	}
+
+	return fetchDetails(mine, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, loc)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false when
+// the page fetch fails, carries no JobPosting, or lacks an employer (which would break the
+// company slug). The employer comes from the posting, not the board file: a Compleo tenant may
+// be a recruiter posting on behalf of the hiring company.
+func (s compleo) detail(ctx context.Context, loc string) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	var p compleoPosting
+	if !ldJobPosting(root, &p) || p.HiringOrganization.Name == "" {
+		return Job{}, false
+	}
+
+	location := p.JobLocation.Address.Location()
+
+	return Job{
+		ExternalID:  compleoJobID(loc),
+		URL:         loc,
+		Title:       strings.TrimSpace(p.Title),
+		Company:     p.HiringOrganization.Name,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      isRemote(location) || isRemote(p.Title),
+		PostedAt:    parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// compleoPosting is the schema.org JobPosting decoded from a Compleo job page. jobLocation is a
+// single Place (not an array), and datePosted is RFC3339.
+type compleoPosting struct {
+	Title              string      `json:"title"`
+	Description        string      `json:"description"`
+	DatePosted         string      `json:"datePosted"`
+	JobLocation        schemaPlace `json:"jobLocation"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+}
+
+// compleoJobIDPattern captures the native posting code from a /<tenant>/jobdetail/<code> URL.
+var compleoJobIDPattern = regexp.MustCompile(`/jobdetail/([A-Za-z0-9]+)/?$`)
+
+// compleoJobID extracts the native posting id from a job page URL, or "" when the URL is not a
+// job posting (so the platform's other pages are dropped from the sitemap).
+func compleoJobID(loc string) string {
+	return firstSubmatch(compleoJobIDPattern, loc)
+}

--- a/internal/sources/compleo_test.go
+++ b/internal/sources/compleo_test.go
@@ -1,0 +1,108 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+const compleoDetailHTML = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"Java Tech Lead - Lisboa",
+"description":"<p>Java &amp; Spring.</p><script>alert(1)<\/script>",
+"hiringOrganization":{"@type":"Organization","name":"WA FENIX Serviços e Soluções em TI Ltda"},
+"datePosted":"2026-05-25T03:00:00.000Z",
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"PT"}},
+"url":"https://jobs.compleo.app/wafx/jobdetail/HJ06276A",
+"identifier":{"@type":"PropertyValue","name":"Compleo Job ID","value":"HJ06276A"}}
+</script></head><body></body></html>`
+
+func compleoSitemapXML(locs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+	for _, l := range locs {
+		b.WriteString(`<url><loc>` + l + `</loc></url>`)
+	}
+	b.WriteString(`</urlset>`)
+	return b.String()
+}
+
+func TestCompleoProvider(t *testing.T) {
+	if got := NewCompleo(nil).Provider(); got != "compleo" {
+		t.Errorf("Provider() = %q, want compleo", got)
+	}
+}
+
+func TestCompleoRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["compleo"]; !ok {
+		t.Error("All() should register provider compleo")
+	}
+	if !slices.Contains(FilterableProviders(), "compleo") {
+		t.Error("FilterableProviders() should include compleo")
+	}
+}
+
+func TestCompleoBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/compleo.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/compleo.yml fails validation: %v", err)
+	}
+}
+
+// Compleo publishes one sitemap for the whole platform, so a board is a slice of it: only the
+// postings under this tenant's path segment belong to the configured company.
+func TestCompleoFetchTakesOnlyTheBoardsPostings(t *testing.T) {
+	mine := "https://jobs.compleo.app/wafx/jobdetail/HJ06276A"
+	theirs := "https://jobs.compleo.app/agiliza/jobdetail/BA00898A"
+	// A tenant whose name merely starts with the board's must not be swept in with it.
+	neighbour := "https://jobs.compleo.app/wafxpro/jobdetail/CC00111B"
+
+	fake := (&routedHTTP{}).
+		route("/wafx/jobdetail/HJ06276A", compleoDetailHTML).
+		route("/sitemap.xml", compleoSitemapXML(mine, theirs, neighbour, "https://jobs.compleo.app/wafx/home"))
+
+	jobs, err := NewCompleo(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "WA FENIX", Provider: "compleo", Board: "wafx",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (other tenants and non-posting pages filtered)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "HJ06276A" || j.URL != mine {
+		t.Errorf("id/url wrong: %q %q", j.ExternalID, j.URL)
+	}
+	if j.Company != "WA FENIX Serviços e Soluções em TI Ltda" {
+		t.Errorf("Company = %q, want the employer from the posting", j.Company)
+	}
+	if j.Title != "Java Tech Lead - Lisboa" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 5, 25, 3, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v", j.PostedAt)
+	}
+}
+
+func TestCompleoJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://jobs.compleo.app/wafx/jobdetail/HJ06276A":        "HJ06276A",
+		"https://jobs.compleo.app/huntrh.huntit/jobdetail/CI102I": "CI102I",
+		"https://jobs.compleo.app/wafx/home":                      "",
+	}
+	for u, want := range cases {
+		if got := compleoJobID(u); got != want {
+			t.Errorf("compleoJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -186,6 +186,7 @@ func All(c HTTPClient) map[string]Source {
 		NewFourDayWeek(c),
 		NewFunctionalWorks(c),
 		NewTheHub(c),
+		NewCompleo(c),
 		NewInstaffo(c),
 		NewGetonbrd(c),
 		NewVagas(c),

--- a/sources/compleo.yml
+++ b/sources/compleo.yml
@@ -4,3 +4,9 @@
 # each board was checked to be an IT employer before adding.
 - company: WA FENIX
   board: wafx
+- company: Provider IT
+  board: providerit
+- company: Moot It Consulting
+  board: mootit
+- company: Harpia IT
+  board: harpiait

--- a/sources/compleo.yml
+++ b/sources/compleo.yml
@@ -1,0 +1,6 @@
+# Compleo (jobs.compleo.app), a Brazilian ATS. board = the tenant path segment.
+# One sitemap covers the whole platform, so a board is the slice of it under that tenant.
+# The platform is mostly non-technical hiring, so tenants are curated, not harvested:
+# each board was checked to be an IT employer before adding.
+- company: WA FENIX
+  board: wafx


### PR DESCRIPTION
`jobs.compleo.app` came in through the contribution review queue. Brazilian ATS; board = the tenant path segment.

## The shape

Compleo publishes **one sitemap for the whole platform**, not one per tenant, so a board is the slice of it under that tenant's segment. Each job page server-renders a clean schema.org `JobPosting` with its own `hiringOrganization` — which is taken from the posting, not the board file, since a Compleo tenant may be a recruiter posting for someone else.

## Why boards are curated, not harvested

The platform holds **1901 postings across ~50 tenants**, and the volume is tempting. Sampling says don't: it is overwhelmingly non-technical hiring — cashiers, butchers, warehouse operators, accountants. Onboarding it wholesale would spend 1901 detail fetches and the enrichment budget for the non-tech gate to discard most of the result.

Sampling every tenant whose identity suggests IT leaves four that pay for themselves — **179 postings**, near-entirely technical:

| board | company | postings |
|---|---|---|
| `wafx` | WA FENIX | 78 |
| `mootit` | Moot It Consulting | 37 |
| `harpiait` | Harpia IT | 37 |
| `providerit` | Provider IT | 27 |

`providerit` is the tenant the contribution actually pointed at.

## Tests

TDD; 5 tests. The board-slicing test includes a `wafxpro` neighbour, so a tenant whose name merely starts with the board's can't be swept in with it.