### PR TITLE
fix(sources): recognise an OpenCATS posting by its route carrier, not by its anchor

### DIFF
--- a/internal/sources/opencats.go
+++ b/internal/sources/opencats.go
@@ -215,30 +215,29 @@ func opencatsJobID(loc string) string {
 
 // opencatsListings parses each posting from a portal listing. Installs customise the template
 // freely — CSS classes, element types, column order, and column count differ between them — so
-// this reads the two things a rewrite cannot change without breaking the portal itself: the
-// showJob route, which carries the id, and the anchor text, which is the title. Postings are
-// de-duplicated by id, keeping the first anchor, because a listing commonly links one posting
-// twice (its title and an apply button) and the title link comes first.
+// this reads the one thing a rewrite cannot change without breaking the portal itself: the
+// showJob route. Postings are de-duplicated by id, keeping the first carrier, because a
+// listing commonly points at one posting twice (its title and an apply button) and the title
+// comes first.
 func opencatsListings(base *url.URL, root *html.Node) []opencatsListing {
 	var out []opencatsListing
 	seen := map[string]struct{}{}
 	walk(root, func(n *html.Node) bool {
-		if n.Type != html.ElementNode || n.Data != "a" {
+		if n.Type != html.ElementNode {
 			return true
 		}
-		href := attr(n, "href")
-		id := opencatsJobID(href)
+		loc, title := opencatsRouteCarrier(n)
+		id := opencatsJobID(loc)
 		if id == "" {
 			return true
 		}
 		if _, ok := seen[id]; ok {
 			return true
 		}
-		title := strings.TrimSpace(textContent(n))
 		if opencatsIsGeneralApplication(title) {
 			return true
 		}
-		ref, err := url.Parse(href)
+		ref, err := url.Parse(loc)
 		if err != nil {
 			return true
 		}
@@ -251,4 +250,30 @@ func opencatsListings(base *url.URL, root *html.Node) []opencatsListing {
 		return true
 	})
 	return out
+}
+
+// opencatsRouteCarrier returns the posting URL an element points at and the title that goes
+// with it, or ("", "") when the element points at no posting. Two carriers exist in the wild:
+// an anchor, whose own text is the title, and a clickable table row, which navigates from an
+// onclick handler and has no anchor text — there the title is the row's first cell. Both are
+// the same routing invariant; only the carrier differs.
+func opencatsRouteCarrier(n *html.Node) (loc, title string) {
+	if n.Data == "a" {
+		return attr(n, "href"), strings.TrimSpace(textContent(n))
+	}
+	if target := opencatsClickTarget(attr(n, "onclick")); target != "" {
+		return target, strings.TrimSpace(nodeText(firstElementChild(n)))
+	}
+	return "", ""
+}
+
+// opencatsClickTargetPattern captures the URL a row's onclick handler navigates to.
+var opencatsClickTargetPattern = regexp.MustCompile(`location\.href\s*=\s*['"]([^'"]+)['"]`)
+
+// opencatsClickTarget extracts the navigation target from an onclick handler, or "".
+func opencatsClickTarget(onclick string) string {
+	if onclick == "" {
+		return ""
+	}
+	return firstSubmatch(opencatsClickTargetPattern, onclick)
 }

--- a/internal/sources/opencats_test.go
+++ b/internal/sources/opencats_test.go
@@ -339,3 +339,50 @@ func TestOpencatsListingsCollapseRepeatedLinks(t *testing.T) {
 		t.Errorf("URL = %q, want %q", got[0].URL, want)
 	}
 }
+
+// opencatsOnclickListingHTML is a listing from an install that makes the whole table row
+// clickable instead of linking the title — rms.adgonline.ca (Vancouver Police Department)
+// ships this. The careers route is intact, but it rides an onclick handler, so there is no
+// anchor and therefore no anchor text: the title is the row's first cell.
+func opencatsOnclickListingHTML(rows ...[3]string) string { // row = {id, title, location}
+	var b strings.Builder
+	b.WriteString(`<html><body><table><tr><th>Job Title</th><th>Location</th></tr>`)
+	for _, r := range rows {
+		b.WriteString(`<tr class="oddTableRow" style="cursor: pointer;" ` +
+			`onclick="window.location.href='index.php?m=careers&amp;p=showJob&amp;ID=` + r[0] + `';">` +
+			`<td>` + r[1] + `</td><td>` + r[2] + `</td></tr>`)
+	}
+	b.WriteString(`</table></body></html>`)
+	return b.String()
+}
+
+// TestOpencatsListingsReadClickableRows covers a portal that carries the posting route on a
+// row handler rather than an anchor. The routing invariant still holds, so the postings must
+// still be found — an anchor is one carrier of the route, not the definition of a posting.
+func TestOpencatsListingsReadClickableRows(t *testing.T) {
+	base, err := url.Parse("https://rms.adgonline.ca/careers/")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	rows := [][3]string{
+		{"11", "Home Guard Recruitment 2024", "Vancouver, Vancouver"},
+		{"12", "Police Constable", "Vancouver, Vancouver"},
+	}
+
+	got := opencatsListings(base, parseHTML(t, opencatsOnclickListingHTML(rows...)))
+	if len(got) != 2 {
+		t.Fatalf("got %d postings, want 2: %+v", len(got), got)
+	}
+	for i, want := range rows {
+		if got[i].ID != want[0] {
+			t.Errorf("posting %d: ID = %q, want %q", i, got[i].ID, want[0])
+		}
+		if got[i].Title != want[1] {
+			t.Errorf("posting %d: Title = %q, want the row's first cell %q", i, got[i].Title, want[1])
+		}
+		wantURL := "https://rms.adgonline.ca/careers/index.php?m=careers&p=showJob&ID=" + want[0]
+		if got[i].URL != wantURL {
+			t.Errorf("posting %d: URL = %q, want %q", i, got[i].URL, wantURL)
+		}
+	}
+}

--- a/openspec/changes/opencats-clickable-rows/.openspec.yaml
+++ b/openspec/changes/opencats-clickable-rows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/opencats-clickable-rows/proposal.md
+++ b/openspec/changes/opencats-clickable-rows/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The OpenCATS adapter recognises a posting by its anchor, but an install in the wild carries
+the same route on a clickable table row instead: `rms.adgonline.ca` (Vancouver Police
+Department) navigates from `onclick="window.location.href='…p=showJob&ID=11'"` and has no
+anchor at all. Its 5 postings were invisible — the listing has zero `<a>` elements carrying
+the route.
+
+This is the routing invariant holding while the carrier changes, which is exactly the case
+the adapter claims to handle, so the requirement needs to say carrier rather than anchor.
+
+## What Changes
+
+- Recognise a posting whose route rides an element's `onclick` handler, not only an `<a href>`.
+- Take the title from the row's first cell when there is no anchor text to read.
+- Add the board to `sources/opencats.yml` (5 postings, live-verified).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `opencats-source`: posting recognition is defined in terms of an anchor and its text; it
+  must be defined in terms of whatever element carries the route, since an install may carry
+  it on a row handler and then no anchor text exists.
+
+## Impact
+
+- `internal/sources/opencats.go` (+ tests), `sources/opencats.yml`.
+- No schema change, no migration. Existing anchor-carried listings parse unchanged.

--- a/openspec/changes/opencats-clickable-rows/specs/opencats-source/spec.md
+++ b/openspec/changes/opencats-clickable-rows/specs/opencats-source/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Postings are identified by routing, not by markup
+
+Installs customise the portal template freely — CSS classes, column order, and column count
+differ between them — so the adapter SHALL identify postings by the portal's routing
+invariants alone. A posting SHALL be recognised by any element carrying the route
+`index.php?m=careers&p=showJob&ID=<n>`, whose captured `<n>` is the posting's `ExternalID`.
+The route SHALL be read from an anchor's `href` and from an element's `onclick` navigation
+target alike, because an install may make a whole table row clickable instead of linking its
+title. The job title SHALL be the anchor's own text when the carrier is an anchor, and the
+row's first cell when it is not, since a clickable row has no anchor text to read. The
+adapter SHALL NOT depend on CSS classes, on the position of a listing column, or on the
+number of listing columns.
+
+#### Scenario: A rewritten template is parsed identically
+
+- **WHEN** two boards serve listings with different markup, column counts, and CSS classes,
+  but both link postings as `index.php?m=careers&p=showJob&ID=<n>`
+- **THEN** both yield the same set of postings, with ids and titles taken from those links
+
+#### Scenario: Duplicate links collapse to one posting
+
+- **WHEN** a listing links the same posting id more than once (for example a title link and a
+  separate "apply" link)
+- **THEN** the adapter returns that posting once
+
+#### Scenario: A clickable row is a posting
+
+- **WHEN** a listing carries the posting route on a row's `onclick` handler and the listing
+  contains no anchor carrying that route
+- **THEN** the postings are still returned, each with the id from the route and the title from
+  the row's first cell

--- a/openspec/changes/opencats-clickable-rows/tasks.md
+++ b/openspec/changes/opencats-clickable-rows/tasks.md
@@ -1,0 +1,19 @@
+## 1. Recognise clickable rows
+
+- [x] 1.1 Add a failing test for a listing whose postings ride an `onclick` handler with no
+      anchor carrying the route (the `rms.adgonline.ca` shape).
+- [x] 1.2 Generalise posting recognition from "anchor" to "route carrier": read the route from
+      an anchor's `href` or an element's `onclick` navigation target.
+- [x] 1.3 Take the title from the row's first cell when the carrier is not an anchor.
+- [x] 1.4 Confirm anchor-carried listings still parse unchanged (existing tests stay green).
+
+## 2. Board
+
+- [x] 2.1 Add `rms.adgonline.ca/careers` to `sources/opencats.yml` as Vancouver Police
+      Department.
+- [x] 2.2 Verify the live board through the adapter: postings, titles, locations, descriptions.
+
+## 3. Verification
+
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green.
+- [x] 3.2 Re-crawl every opencats board and confirm no regression on the other nine.

--- a/sources/opencats.yml
+++ b/sources/opencats.yml
@@ -24,3 +24,5 @@
   board: opencats.gorgany.com/careers
 - company: 411hawks
   board: opencats.vikisoft.com.ua/careers
+- company: Vancouver Police Department
+  board: rms.adgonline.ca/careers


### PR DESCRIPTION
Follow-up to #1197. A tenth OpenCATS portal existed but was invisible.

`rms.adgonline.ca` (Vancouver Police Department) makes the table row clickable instead of linking the title:

```html
<tr onclick="window.location.href='index.php?m=careers&p=showJob&ID=11';">
  <td>Home Guard Recruitment 2024</td><td>Vancouver, Vancouver</td></tr>
```

`p=showJob` appears 5 times in that listing; `<a>` elements carrying it appear **zero** times. The routing invariant the adapter is built on held perfectly — only the carrier changed — so recognition is now defined by the carrier (anchor `href` **or** `onclick` target) rather than by the anchor. Where there is no anchor text, the title is the row's first cell.

Also sweeps the discovery channel: of 69 currently-surfaced candidate hosts not already in the board file, this was the **only** live one — so the catalogue is complete against what the channel can see today.

Live-verified: 5 postings with titles, locations and 4–5k-character descriptions; the other nine boards unchanged (261 total, was 256). OpenSpec: `opencats-clickable-rows` modifies the recognition requirement accordingly.