### PR TITLE
fix(prune): the board report names the providers it would empty

### DIFF
--- a/cmd/prune/boards_test.go
+++ b/cmd/prune/boards_test.go
@@ -258,3 +258,56 @@ func TestReportBoardsIgnoresNonEngineeringSkills(t *testing.T) {
 		t.Errorf("a board with an engineering tag must stay off the list; got:\n%s", got)
 	}
 }
+
+// Retiring every board a provider has is a one-way door, and the report is where it
+// has to be caught. Ingest takes one board file by path, so a provider with nothing
+// left in sources/ is never crawled again — and the company-scoped rules refuse a job
+// they cannot re-crawl, so its postings can never be pruned either. The dead weight
+// becomes permanent. sources/retired/README.md states the order (prune the jobs first,
+// move the last entry after), but stating it in prose leaves it to whoever reads the
+// report at 2am.
+//
+// The boards are still listed — they are genuine candidates — but the report names the
+// providers it would empty, so the entry that empties one is moved last, deliberately.
+func TestReportBoardsNamesProvidersItWouldEmpty(t *testing.T) {
+	brd := boards{
+		listed: map[boardKey]bool{
+			// Every board this provider has is about to be retired.
+			{"tinyats", "one"}: true, {"tinyats", "two"}: true,
+			// This one keeps a board, so it is not emptied.
+			{"greenhouse", "dead"}: true, {"greenhouse", "alive"}: true,
+		},
+		byProvider: map[string]map[string]bool{
+			"tinyats":    {"one": true, "two": true},
+			"greenhouse": {"dead": true, "alive": true},
+		},
+	}
+	q := &fakeCandidates{rows: []db.PruneCandidatesRow{
+		boardRow(1, "tinyats", "one:1", boolp(false), nil),
+		boardRow(2, "tinyats", "two:1", boolp(false), nil),
+		boardRow(3, "greenhouse", "dead:1", boolp(false), nil),
+		boardRow(4, "greenhouse", "alive:1", boolp(true), nil),
+	}}
+
+	var out strings.Builder
+	if err := reportBoards(context.Background(), &out, q, brd); err != nil {
+		t.Fatalf("reportBoards: %v", err)
+	}
+	got := out.String()
+
+	if !strings.Contains(got, "tinyats") {
+		t.Fatalf("the provider's boards must still be listed; got:\n%s", got)
+	}
+	// The warning has to name the provider AND say what the hazard is, or it reads as
+	// decoration and gets moved with everything else.
+	if !strings.Contains(got, "every listed board") {
+		t.Fatalf("the report must warn that a provider would be left with no boards; got:\n%s", got)
+	}
+	warning := got[strings.Index(got, "every listed board"):]
+	if !strings.Contains(warning, "tinyats") {
+		t.Errorf("the warning must name tinyats; got:\n%s", warning)
+	}
+	if strings.Contains(warning, "greenhouse") {
+		t.Errorf("greenhouse keeps a board and must not be named as emptied; got:\n%s", warning)
+	}
+}

--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -44,6 +44,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -445,5 +446,44 @@ func reportBoards(ctx context.Context, w io.Writer, q candidateSource, brd board
 			return err
 		}
 	}
-	return tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	return warnDrainedProviders(w, retire, brd)
+}
+
+// warnDrainedProviders names the providers the list above would leave with no boards at
+// all. Those entries are still genuine candidates, but the order in which they move is
+// load-bearing and irreversible: cmd/ingest takes one board file by path, so a provider
+// with nothing left in sources/ is never crawled again — and the company-scoped rules
+// refuse a job they cannot re-crawl, so its postings can never be pruned either. Move
+// such an entry and the dead weight is permanent.
+//
+// sources/retired/README.md states the rule (prune the provider's jobs first, move its
+// last entry after), but a rule that lives only in prose is enforced by whoever happens
+// to read it. The report is the thing an operator actually has in front of them.
+func warnDrainedProviders(w io.Writer, retire []boardKey, brd boards) error {
+	retiring := map[string]int{}
+	for _, k := range retire {
+		retiring[k.Provider]++
+	}
+	var drained []string
+	for provider, n := range retiring {
+		if n == len(brd.byProvider[provider]) {
+			drained = append(drained, provider)
+		}
+	}
+	if len(drained) == 0 {
+		return nil
+	}
+	sort.Strings(drained)
+	_, err := fmt.Fprintf(w,
+		"\nCAUTION — every listed board of these providers is above, so moving them all "+
+			"empties the provider: %s\n"+
+			"Prune their jobs FIRST. A provider with no entry in sources/ is never crawled "+
+			"again, and the company-scoped rules refuse a job they cannot re-crawl — its\n"+
+			"postings would become permanently un-prunable. Move the last entry of each only "+
+			"after its jobs are gone.\n",
+		strings.Join(drained, ", "))
+	return err
 }

--- a/sources/retired/README.md
+++ b/sources/retired/README.md
@@ -42,6 +42,11 @@ Order matters: **prune first, then move the provider's last entry.** Once a prov
 no entries left in `sources/`, none of its jobs are re-crawlable, and every pruning rule
 refuses them — the dead weight becomes permanent.
 
+The report enforces the reminder rather than leaving it here: when its list covers every
+board a provider has, it prints a `CAUTION` line naming that provider. The entries are
+still genuine candidates — move them, but move the ones that empty a provider last, once
+its jobs are gone.
+
 ## Why keep them
 
 They cost nothing, they record what was considered and rejected, and a board that turns


### PR DESCRIPTION
Retiring every board a provider has is a one-way door, and the board report is the only place it can be caught.

`cmd/ingest` takes one board file by path, so a provider with nothing left in `sources/` is never crawled again — and the company-scoped pruning rules refuse a job they cannot re-crawl. Move that last entry and its postings become **permanently un-prunable**.

`sources/retired/README.md` already stated the order (prune the provider's jobs first, move its last entry after). But a rule that lives only in prose is enforced by whoever happens to read it. Twice this evening a rule guarded by memory alone failed on prod: a watchdog serialising on a hardcoded pid was defeated by the very timer it existed to avoid, and a hand-built worker binary was silently reverted by a deploy flipping colour.

## What changed

The retire list is unchanged — those entries are genuine candidates. The report now appends a `CAUTION` line naming the providers its own list would empty:

```
CAUTION — every listed board of these providers is above, so moving them all empties the provider: tinyats
Prune their jobs FIRST. A provider with no entry in sources/ is never crawled again, and the
company-scoped rules refuse a job they cannot re-crawl — its postings would become permanently
un-prunable. Move the last entry of each only after its jobs are gone.
```

Same doctrine as the existing withheld counter: a report that silently omits something reads as "this is everything".

## Verification

Test-first — `TestReportBoardsNamesProvidersItWouldEmpty` asserts the provider whose every board is listed is named, and that a provider keeping one board is not. It failed for the right reason (no warning emitted) before the change. `go build`, `go vet`, `gofmt -l` clean; full `go test ./...` green.

## Context

Part of the catalogue-pruning campaign, after #1200. The board report has still never been acted on — the retirement PR is the campaign's outstanding item, and this is the guard it needs before entries start moving.