### PR TITLE
feat(prune): --retire performs the move the board report describes

### DIFF
--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -30,6 +30,12 @@
 //	go run ./cmd/prune                       # dry run: what would go, and why
 //	go run ./cmd/prune --apply --limit=50000 # remove at most 50k rows
 //	go run ./cmd/prune --boards              # board-retirement report
+//	go run ./cmd/prune --retire              # perform the move the report describes
+//
+// --retire edits the board files rather than the database, and the edit is line-based
+// so the files keep their comments and the diff stays reviewable. It never moves a
+// provider's last entry: that is the one irreversible step here, because a job nobody
+// can re-crawl can never be pruned either.
 //
 // Needs DATABASE_URL; MEILI_URL/MEILI_MASTER_KEY when applying, so the search index
 // loses the documents in the same step.
@@ -82,6 +88,7 @@ const (
 
 func run() int {
 	boardReport := flag.Bool("boards", false, "report board entries whose company has never posted anything technical")
+	retire := flag.Bool("retire", false, "move the boards --boards lists into sources/retired/ (edits the source files; review the diff)")
 	sourcesDir := flag.String("sources", "sources", "directory holding the board files")
 	apply := flag.Bool("apply", false, "actually delete; without it the run only reports")
 	flag.Bool("dry-run", false, "no-op: reporting is the default, --apply is what deletes")
@@ -131,6 +138,35 @@ func run() int {
 		if err := reportBoards(ctx, os.Stdout, q, brd); err != nil {
 			log.Printf("prune: write report: %v", err)
 			return 1
+		}
+		return 0
+	}
+
+	// --retire performs the move the report describes. It edits source files, not the
+	// database, and it is reversible by moving a line back — but it is still the step
+	// that stops a board being crawled, so it prints the whole list before acting and
+	// leaves the review to the diff.
+	if *retire {
+		list, withheld, err := boardsToRetire(ctx, q, brd)
+		if err != nil {
+			log.Printf("prune: board evidence: %v", err)
+			return 1
+		}
+		log.Printf("prune: %d boards to retire (%d withheld for want of a verdict)", len(list), withheld)
+		if len(list) == 0 {
+			return 0
+		}
+		moved, held, err := retireBoards(*sourcesDir, list)
+		if err != nil {
+			log.Printf("prune: retire: %v (files already written stay written)", err)
+			return 1
+		}
+		log.Printf("prune: moved %d entries into %s/retired/", moved, *sourcesDir)
+		if len(held) > 0 {
+			// Not a failure: the entries are real candidates whose turn has not come.
+			log.Printf("prune: held back every entry of %s — moving them would leave the provider "+
+				"with no board at all, and a job that cannot be re-crawled can never be pruned. "+
+				"Prune their jobs first, then move these deliberately.", strings.Join(held, ", "))
 		}
 		return 0
 	}
@@ -358,31 +394,17 @@ type boardVerdict struct {
 	determined bool
 }
 
-// reportBoards lists the boards still in the source files whose postings were classified
-// and none of them came out technical — no technical title or category, and not one
-// tagged engineering skill. Each is a candidate for the retirement PR — move the entry to
-// sources/retired/<provider>.yml — which is the precondition for pruning its jobs under
-// a company-scoped rule.
-//
-// A board no posting of which has been classified is WITHHELD, not listed. The report's
-// premise is "this board has never posted anything technical", and absence of a
-// technical signal only carries that meaning where a signal was possible at all: a
-// posting the dictionaries could not place leaves is_tech NULL, which is not evidence of
-// anything. Measured on prod the distinction decided most of the report — 11023 of 17841
-// listed boards had no verdict on a single posting, 62% of the list, against 10.6% among
-// the boards the same run kept. Retiring on that basis would have struck live IT
-// employers whose only fault was a title the dictionary does not carry.
-//
-// It groups by BOARD rather than by company because that is the identity the source
-// files and the catalogue share exactly; the company slug diverges wherever an adapter
-// takes the name from the posting payload, which on some providers is most of them.
-func reportBoards(ctx context.Context, w io.Writer, q candidateSource, brd boards) error {
+// boardsToRetire walks the catalogue once and sorts every listed board into the three
+// states boardVerdict describes, returning the retirement candidates and how many were
+// withheld for want of any verdict. Both --boards and --retire go through it, so the
+// list an operator reads and the list the mover acts on cannot diverge.
+func boardsToRetire(ctx context.Context, q candidateSource, brd boards) ([]boardKey, int, error) {
 	evidence := map[boardKey]boardVerdict{}
 	var after int64
 	for {
 		rows, err := q.PruneCandidates(ctx, db.PruneCandidatesParams{AfterID: after, PageSize: scanPage})
 		if err != nil {
-			return err
+			return nil, 0, err
 		}
 		if len(rows) == 0 {
 			break
@@ -413,6 +435,38 @@ func reportBoards(ctx context.Context, w io.Writer, q candidateSource, brd board
 			withheld++
 		}
 	}
+	sort.Slice(retire, func(i, j int) bool {
+		if retire[i].Provider != retire[j].Provider {
+			return retire[i].Provider < retire[j].Provider
+		}
+		return retire[i].Board < retire[j].Board
+	})
+	return retire, withheld, nil
+}
+
+// reportBoards lists the boards still in the source files whose postings were classified
+// and none of them came out technical — no technical title or category, and not one
+// tagged engineering skill. Each is a candidate for the retirement PR — move the entry to
+// sources/retired/<provider>.yml — which is the precondition for pruning its jobs under
+// a company-scoped rule.
+//
+// A board no posting of which has been classified is WITHHELD, not listed. The report's
+// premise is "this board has never posted anything technical", and absence of a
+// technical signal only carries that meaning where a signal was possible at all: a
+// posting the dictionaries could not place leaves is_tech NULL, which is not evidence of
+// anything. Measured on prod the distinction decided most of the report — 11023 of 17841
+// listed boards had no verdict on a single posting, 62% of the list, against 10.6% among
+// the boards the same run kept. Retiring on that basis would have struck live IT
+// employers whose only fault was a title the dictionary does not carry.
+//
+// It groups by BOARD rather than by company because that is the identity the source
+// files and the catalogue share exactly; the company slug diverges wherever an adapter
+// takes the name from the posting payload, which on some providers is most of them.
+func reportBoards(ctx context.Context, w io.Writer, q candidateSource, brd boards) error {
+	retire, withheld, err := boardsToRetire(ctx, q, brd)
+	if err != nil {
+		return err
+	}
 	// Say what the guard held back. A report that silently shrinks reads as "this is
 	// everything", and the withheld boards never come back into view — the same reason
 	// the scan counts its own refusals rather than dropping them.
@@ -427,13 +481,6 @@ func reportBoards(ctx context.Context, w io.Writer, q candidateSource, brd board
 		_, err := fmt.Fprintln(w, "every listed board that has been classified has posted something technical")
 		return err
 	}
-	sort.Slice(retire, func(i, j int) bool {
-		if retire[i].Provider != retire[j].Provider {
-			return retire[i].Provider < retire[j].Provider
-		}
-		return retire[i].Board < retire[j].Board
-	})
-
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	if _, err := fmt.Fprint(w, "move these entries to sources/retired/<provider>.yml:\n\n"); err != nil {
 		return err

--- a/cmd/prune/retire.go
+++ b/cmd/prune/retire.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// retireBoards moves the named entries out of sources/<file>.yml and into
+// sources/retired/<file>.yml — the move IS the retirement, since cmd/ingest takes a
+// board file by path and cmd/prune globs one level, so neither sees what lives in the
+// subdirectory. It returns how many entries it moved.
+//
+// The edit is line-based rather than a YAML round-trip, and deliberately so: the board
+// files are hand-maintained, carrying a header that records where a provider's board id
+// comes from and group comments above runs of entries. Re-serialising the parsed config
+// would drop every one of them and reflow the rest, burying the actual change in a
+// diff nobody can review. Here an entry's own lines leave and the file is otherwise
+// untouched, byte for byte.
+//
+// It refuses to move a provider's last entries. That is the one irreversible step in a
+// reversible operation: a provider with nothing left in sources/ is never crawled again,
+// and the company-scoped rules refuse a job they cannot re-crawl, so its postings become
+// permanently un-prunable. Prune those jobs first, then move the last entry deliberately.
+// It returns those files' names alongside the count, because a silent refusal reads as
+// "there was nothing to do" — and the answer is not "never move it", it is "later".
+func retireBoards(dir string, retire []boardKey) (int, []string, error) {
+	paths, err := filepath.Glob(filepath.Join(dir, "*.y*ml"))
+	if err != nil {
+		return 0, nil, fmt.Errorf("prune: scan %s: %w", dir, err)
+	}
+	wanted := map[boardKey]bool{}
+	for _, k := range retire {
+		wanted[k] = true
+	}
+
+	moved := 0
+	var held []string
+	for _, path := range paths {
+		if notBoardFiles[filepath.Base(path)] {
+			continue
+		}
+		n, wouldEmpty, err := retireFromFile(dir, path, wanted)
+		if err != nil {
+			return moved, held, err
+		}
+		if wouldEmpty {
+			held = append(held, strings.TrimSuffix(strings.TrimSuffix(filepath.Base(path), ".yml"), ".yaml"))
+		}
+		moved += n
+	}
+	sort.Strings(held)
+	return moved, held, nil
+}
+
+// retireFromFile rewrites one board file, moving out the entries the caller wants.
+func retireFromFile(dir, path string, wanted map[boardKey]bool) (moved int, wouldEmpty bool, err error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false, fmt.Errorf("prune: read %s: %w", path, err)
+	}
+	lines := strings.Split(string(body), "\n")
+	// A trailing newline splits to a final empty element; drop it and restore it on
+	// write, so a file does not gain or lose one on every pass.
+	trailing := len(lines) > 0 && lines[len(lines)-1] == ""
+	if trailing {
+		lines = lines[:len(lines)-1]
+	}
+
+	fileProvider := strings.TrimSuffix(strings.TrimSuffix(filepath.Base(path), ".yml"), ".yaml")
+	entries := splitEntries(lines)
+
+	var going []entryBlock
+	total := 0
+	for _, e := range entries {
+		provider := e.provider
+		if provider == "" {
+			provider = fileProvider
+		}
+		if e.board == "" {
+			continue // not an entry we can key on; leave it exactly where it is
+		}
+		total++
+		if wanted[boardKey{Provider: provider, Board: e.board}] {
+			going = append(going, e)
+		}
+	}
+	if len(going) == 0 {
+		return 0, false, nil
+	}
+	// The one-way door: never leave a file with no entries at all.
+	if len(going) == total {
+		return 0, true, nil
+	}
+
+	keep := make([]string, 0, len(lines))
+	cut := map[int]bool{}
+	for _, e := range going {
+		for i := e.start; i < e.end; i++ {
+			cut[i] = true
+		}
+	}
+	for i, line := range lines {
+		if !cut[i] {
+			keep = append(keep, line)
+		}
+	}
+	out := strings.Join(keep, "\n")
+	if trailing {
+		out += "\n"
+	}
+	if err := os.WriteFile(path, []byte(out), 0o600); err != nil {
+		return 0, false, fmt.Errorf("prune: write %s: %w", path, err)
+	}
+
+	if err := appendRetired(dir, filepath.Base(path), going, lines); err != nil {
+		return 0, false, err
+	}
+	return len(going), false, nil
+}
+
+// entryBlock is one list item and the lines it owns: the "- " line plus the indented
+// continuation lines under it. A blank line, a column-0 comment or the next item ends
+// it, which is what keeps a group comment with the group rather than with an entry.
+type entryBlock struct {
+	start, end int
+	provider   string
+	board      string
+}
+
+func splitEntries(lines []string) []entryBlock {
+	var out []entryBlock
+	for i := 0; i < len(lines); i++ {
+		if !strings.HasPrefix(lines[i], "- ") {
+			continue
+		}
+		e := entryBlock{start: i, end: i + 1}
+		for e.end < len(lines) {
+			l := lines[e.end]
+			if l == "" || !strings.HasPrefix(l, " ") {
+				break
+			}
+			e.end++
+		}
+		for _, l := range lines[e.start:e.end] {
+			if v, ok := scalarField(l, "provider"); ok {
+				e.provider = v
+			}
+			if v, ok := scalarField(l, "board"); ok {
+				e.board = v
+			}
+		}
+		out = append(out, e)
+		i = e.end - 1
+	}
+	return out
+}
+
+// scalarField reads `key: value` off a list-item line, tolerating the "- key: value"
+// form of the first line and the quoting the files use for names with punctuation.
+func scalarField(line, key string) (string, bool) {
+	s := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "- "))
+	rest, ok := strings.CutPrefix(s, key+":")
+	if !ok {
+		return "", false
+	}
+	v := strings.TrimSpace(rest)
+	v = strings.Trim(v, `"'`)
+	return v, v != ""
+}
+
+// appendRetired adds the moved entries to sources/retired/<same file name>, creating it
+// with a header when it does not exist. The file name mirrors the source file rather
+// than the provider: provider resolution is "the entry's own provider, else the file
+// name", so mirroring keeps a custom.yml entry meaningful where it lands.
+func appendRetired(dir, name string, going []entryBlock, lines []string) error {
+	retiredDir := filepath.Join(dir, "retired")
+	if err := os.MkdirAll(retiredDir, 0o755); err != nil {
+		return fmt.Errorf("prune: create %s: %w", retiredDir, err)
+	}
+	path := filepath.Join(retiredDir, name)
+
+	var b strings.Builder
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		fmt.Fprintf(&b, "# Retired %s boards: no longer crawled, kept so they can be picked up again.\n"+
+			"# See README.md — a file here has the same shape as one in sources/ and is never read.\n\n", strings.TrimSuffix(name, filepath.Ext(name)))
+	}
+	sort.Slice(going, func(i, j int) bool { return going[i].board < going[j].board })
+	for _, e := range going {
+		for _, l := range lines[e.start:e.end] {
+			b.WriteString(l)
+			b.WriteString("\n")
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("prune: open %s: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(b.String()); err != nil {
+		return fmt.Errorf("prune: append %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/prune/retire_test.go
+++ b/cmd/prune/retire_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// retireBoards edits the source files in place, so every property here is about NOT
+// losing something: the file's own comments, the entries that stay, and the provider
+// whose last entry must not leave before its jobs do.
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// A board file is hand-maintained YAML: a header explaining where the board id comes
+// from, and group comments above runs of entries. A YAML round-trip would silently
+// drop all of it, so the move is line-based — the entry's own lines leave, everything
+// else stays byte for byte.
+func TestRetireBoardsPreservesCommentsAndOtherEntries(t *testing.T) {
+	dir := t.TempDir()
+	writeBoardFile(t, dir, "greenhouse.yml", `# greenhouse boards. Provider is the filename.
+# board = the tenant slug.
+
+- company: Live Co
+  board: live
+- company: Dead Co
+  board: dead
+- company: Other Co
+  board: other
+`)
+
+	moved, _, err := retireBoards(dir, []boardKey{{"greenhouse", "dead"}})
+	if err != nil {
+		t.Fatalf("retireBoards: %v", err)
+	}
+	if moved != 1 {
+		t.Errorf("moved %d entries, want 1", moved)
+	}
+
+	src := readFile(t, filepath.Join(dir, "greenhouse.yml"))
+	if !strings.Contains(src, "# greenhouse boards. Provider is the filename.") {
+		t.Errorf("the file header must survive; got:\n%s", src)
+	}
+	if strings.Contains(src, "Dead Co") || strings.Contains(src, "board: dead") {
+		t.Errorf("the retired entry must be gone from sources/; got:\n%s", src)
+	}
+	for _, keep := range []string{"Live Co", "board: live", "Other Co", "board: other"} {
+		if !strings.Contains(src, keep) {
+			t.Errorf("%q must stay; got:\n%s", keep, src)
+		}
+	}
+
+	got := readFile(t, filepath.Join(dir, "retired", "greenhouse.yml"))
+	if !strings.Contains(got, "company: Dead Co") || !strings.Contains(got, "board: dead") {
+		t.Errorf("the entry must arrive whole in retired/; got:\n%s", got)
+	}
+}
+
+// An entry naming its own provider (custom.yml) keeps that line, and lands in the
+// retired file mirroring its SOURCE FILE — provider resolution is "the entry's own
+// provider, else the filename", so mirroring the filename keeps the entry valid where
+// it lands.
+func TestRetireBoardsKeepsAnEntrysOwnProvider(t *testing.T) {
+	dir := t.TempDir()
+	writeBoardFile(t, dir, "custom.yml", `# single-source configs
+- company: Chainlink Labs
+  provider: ashbygraphql
+  board: chainlink-labs
+- company: Toggl
+  provider: ashbygraphql
+  board: toggl
+`)
+
+	if _, _, err := retireBoards(dir, []boardKey{{"ashbygraphql", "toggl"}}); err != nil {
+		t.Fatalf("retireBoards: %v", err)
+	}
+
+	got := readFile(t, filepath.Join(dir, "retired", "custom.yml"))
+	if !strings.Contains(got, "provider: ashbygraphql") || !strings.Contains(got, "board: toggl") {
+		t.Errorf("the entry must keep its own provider line; got:\n%s", got)
+	}
+	if strings.Contains(readFile(t, filepath.Join(dir, "custom.yml")), "board: toggl") {
+		t.Error("the retired entry must leave custom.yml")
+	}
+	if !strings.Contains(readFile(t, filepath.Join(dir, "custom.yml")), "board: chainlink-labs") {
+		t.Error("the other entry must stay")
+	}
+}
+
+// The one-way door. cmd/ingest takes a board file by path, so a provider with nothing
+// left in sources/ is never crawled again — and the company-scoped rules refuse a job
+// they cannot re-crawl, so its postings can never be pruned either. Moving the last
+// entry before its jobs are gone makes the dead weight permanent, so the mover refuses
+// and says so; the report's CAUTION line names the same providers.
+func TestRetireBoardsRefusesToEmptyAProvider(t *testing.T) {
+	dir := t.TempDir()
+	writeBoardFile(t, dir, "tinyats.yml", "- company: One\n  board: one\n- company: Two\n  board: two\n")
+
+	moved, _, err := retireBoards(dir, []boardKey{{"tinyats", "one"}, {"tinyats", "two"}})
+	if err != nil {
+		t.Fatalf("retireBoards: %v", err)
+	}
+	if moved != 0 {
+		t.Errorf("moved %d entries, want 0 — emptying a provider is irreversible", moved)
+	}
+	src := readFile(t, filepath.Join(dir, "tinyats.yml"))
+	for _, keep := range []string{"board: one", "board: two"} {
+		if !strings.Contains(src, keep) {
+			t.Errorf("%q must stay until the provider's jobs are pruned; got:\n%s", keep, src)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "retired", "tinyats.yml")); !os.IsNotExist(err) {
+		t.Error("nothing was moved, so no retired file should have been created")
+	}
+}
+
+// A second wave appends to the file the first wave created rather than replacing it —
+// the point of retired/ is that it accumulates what was considered.
+func TestRetireBoardsAppendsToAnExistingRetiredFile(t *testing.T) {
+	dir := t.TempDir()
+	writeBoardFile(t, dir, "greenhouse.yml", "- company: A\n  board: a\n- company: B\n  board: b\n- company: C\n  board: c\n")
+	if err := os.MkdirAll(filepath.Join(dir, "retired"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeBoardFile(t, filepath.Join(dir, "retired"), "greenhouse.yml", "- company: Earlier\n  board: earlier\n")
+
+	if _, _, err := retireBoards(dir, []boardKey{{"greenhouse", "a"}}); err != nil {
+		t.Fatalf("retireBoards: %v", err)
+	}
+
+	got := readFile(t, filepath.Join(dir, "retired", "greenhouse.yml"))
+	if !strings.Contains(got, "board: earlier") {
+		t.Errorf("the earlier wave must survive; got:\n%s", got)
+	}
+	if !strings.Contains(got, "board: a") {
+		t.Errorf("the new entry must be appended; got:\n%s", got)
+	}
+}
+
+// A board named in the list but absent from the files is not an error — the report and
+// the move can be minutes apart, and another PR may have retired it already. It must
+// not take the run down with it, and it must not be counted as moved.
+func TestRetireBoardsIgnoresAnEntryThatIsAlreadyGone(t *testing.T) {
+	dir := t.TempDir()
+	writeBoardFile(t, dir, "greenhouse.yml", "- company: A\n  board: a\n- company: B\n  board: b\n")
+
+	moved, _, err := retireBoards(dir, []boardKey{{"greenhouse", "vanished"}})
+	if err != nil {
+		t.Fatalf("a board that is already gone must not be an error: %v", err)
+	}
+	if moved != 0 {
+		t.Errorf("moved %d, want 0", moved)
+	}
+}
+
+// A refusal that does not say so is indistinguishable from "there was nothing to do".
+// The operator has to learn WHICH provider was held back, because the answer is not
+// "never move it" — it is "prune its jobs first, then move it deliberately".
+func TestRetireBoardsReportsWhatItRefusedToEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeBoardFile(t, dir, "tinyats.yml", "- company: One\n  board: one\n- company: Two\n  board: two\n")
+	writeBoardFile(t, dir, "greenhouse.yml", "- company: A\n  board: a\n- company: B\n  board: b\n")
+
+	moved, held, err := retireBoards(dir, []boardKey{
+		{"tinyats", "one"}, {"tinyats", "two"}, {"greenhouse", "a"},
+	})
+	if err != nil {
+		t.Fatalf("retireBoards: %v", err)
+	}
+	if moved != 1 {
+		t.Errorf("moved %d, want 1 — greenhouse keeps a board, so its entry moves", moved)
+	}
+	if len(held) != 1 || held[0] != "tinyats" {
+		t.Errorf("held back %v, want [tinyats] — the caller cannot explain the refusal otherwise", held)
+	}
+}
+
+// Fixtures prove the algorithm; the real directory proves the assumptions. These files
+// are 140-odd hand-maintained YAML documents, some of them 400KB, with headers, group
+// comments, quoted company names containing "&" and ":", and custom.yml entries that
+// name their own provider. The strongest check is a round trip: whatever the move
+// leaves behind must still load through the real parser, because a file that stops
+// parsing takes the whole prune run down with it — loadBoards fails closed.
+func TestRetireBoardsOnACopyOfTheRealSources(t *testing.T) {
+	src := "../../sources"
+	if _, err := os.Stat(src); err != nil {
+		t.Skipf("real sources not available: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.CopyFS(dir, os.DirFS(src)); err != nil {
+		t.Fatalf("copy sources: %v", err)
+	}
+
+	before, err := loadBoards(dir)
+	if err != nil {
+		t.Fatalf("loadBoards on the copy: %v", err)
+	}
+	// Two entries of different shapes: a plain one whose provider is the file name, and
+	// a custom.yml one carrying its own provider line.
+	var plain, own boardKey
+	for k := range before.listed {
+		if k.Provider == "betterteam" && plain.Board == "" {
+			plain = k
+		}
+		if k.Provider == "ashbygraphql" && own.Board == "" {
+			own = k
+		}
+	}
+	if plain.Board == "" || own.Board == "" {
+		t.Skip("the real files no longer carry the shapes this test samples")
+	}
+
+	moved, _, err := retireBoards(dir, []boardKey{plain, own})
+	if err != nil {
+		t.Fatalf("retireBoards: %v", err)
+	}
+	if moved != 2 {
+		t.Fatalf("moved %d entries, want 2", moved)
+	}
+
+	after, err := loadBoards(dir)
+	if err != nil {
+		t.Fatalf("the edited files must still parse: %v", err)
+	}
+	if after.listed[plain] || after.listed[own] {
+		t.Error("a moved entry must no longer read as listed")
+	}
+	if got, want := len(after.listed), len(before.listed)-2; got != want {
+		t.Errorf("listed %d entries after the move, want %d — nothing else may leave", got, want)
+	}
+	// The retired copies live beside, not instead: a glob one level up must not see them,
+	// which is exactly what makes the move a retirement.
+	for _, name := range []string{"betterteam.yml", "custom.yml"} {
+		if _, err := os.Stat(filepath.Join(dir, "retired", name)); err != nil {
+			t.Errorf("retired/%s must exist: %v", name, err)
+		}
+	}
+}

--- a/sources/retired/README.md
+++ b/sources/retired/README.md
@@ -47,6 +47,12 @@ board a provider has, it prints a `CAUTION` line naming that provider. The entri
 still genuine candidates — move them, but move the ones that empty a provider last, once
 its jobs are gone.
 
+`cmd/prune --retire` performs the move. It computes the same list the report prints (both
+go through one function, so the list you read and the list it acts on cannot diverge),
+edits the files line by line so their headers and group comments survive, and **refuses**
+the entries that would empty a provider — naming them, so the refusal reads as "later",
+not as "nothing to do". Review the diff; that is the gate.
+
 ## Why keep them
 
 They cost nothing, they record what was considered and rejected, and a board that turns


### PR DESCRIPTION
The board report has named its candidates since #1162 and **nobody has ever acted on it**, because the move itself was manual: find each entry across 140-odd YAML files, cut its lines, paste them under `sources/retired/`, don't slip. That is the campaign's outstanding item.

`--retire` does it.

## How

- Computes the same list `--boards` prints. Both now go through `boardsToRetire`, so the list an operator reads and the list the mover acts on **cannot diverge**.
- Edits the files **line by line**, not via a YAML round trip. These are hand-maintained documents: a header recording where each provider's board id comes from, group comments above runs of entries, quoted company names carrying `&` and `:`. Re-serialising the parsed config would drop all of it and reflow the rest, burying the actual change in a diff nobody can review. Here an entry's own lines leave and the file is otherwise untouched, byte for byte.
- An entry keeps its own `provider:` line and lands in the retired file mirroring its **source file** — provider resolution is "the entry's own provider, else the file name", so mirroring keeps a `custom.yml` entry meaningful where it lands.
- Appends to an existing retired file rather than replacing it: the point of `retired/` is that it accumulates what was considered.
- A board named in the list but already absent is not an error — report and move can be minutes apart.

## The refusal

It never moves a provider's last entries, and **names** the ones it held back:

```
prune: held back every entry of tinyats — moving them would leave the provider with no
board at all, and a job that cannot be re-crawled can never be pruned. Prune their jobs
first, then move these deliberately.
```

That is the one irreversible step in an otherwise reversible operation (`cmd/ingest` takes a board file by path, so a provider with nothing left in `sources/` is never crawled again). A silent refusal would read as "there was nothing to do", when the answer is "later" — same doctrine as the withheld counter and the `CAUTION` line from #1210.

## Verification

Test-first throughout; each test failed for the right reason before its code existed. Beyond fixtures, `TestRetireBoardsOnACopyOfTheRealSources` runs the mover against a **copy of the real `sources/` tree** and asserts the result still loads through `loadBoards` — which fails closed, so a file that stops parsing would take the whole prune run down. It also asserts exactly two entries left and nothing else did.

`go build ./...`, `go vet ./...`, `gofmt -l` clean; full `go test ./...` green.

## What still needs a human

The diff. `--retire` proposes; the PR review disposes. And `prune --apply` — the actual deletion — remains a separate, explicitly-flagged step that nothing here automates.