### PR TITLE
fix: a 25 MB compiled binary is not a source file, and it blocks every deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,33 @@
 /bin/
 /out/
 hire
+# Worker binaries. release.sh builds every cmd/ target into the checkout ROOT, so each
+# one lands here as an untracked file — and one committed by accident (prune, 25 MB, in
+# #1212) blocks `git pull` on every deploy host that already has its own build sitting
+# there. Named individually rather than by a glob: these are real, expected artifacts,
+# and a blanket rule would also swallow a source file someone adds with the same name.
+backfill-company-info
+backfill-company-names
+backfill-derive
+backfill-descriptions
+backfill-experience
+backfill-resume-structured
+backfill-semantic-vectors
+classify-mail
+embed
+enrich
+gmail-sync
+hire-api
+ingest
+liveness
+mail-ingest
+migrate
+mine-titles
+notify
+prune
+recount-companies
+reindex
+remind
 # Root-level build output of `go build ./cmd/<name>/` — never commit these artifacts.
 /backfill-company-info
 /backfill-derive


### PR DESCRIPTION
## What broke

`release.sh` aborted on both colors:

```
prune
Please move or remove them before you merge.
Aborting
```

#1212 committed the built `prune` worker binary (25.7 MB) into the repo root. `release.sh` builds every `cmd/` target into the checkout root, so every deploy host already has its own untracked `prune` there — and `git pull` refuses to overwrite an untracked file with a newly-tracked one. **No deploy can land until this is out of the tree.**

## Fix

- `git rm --cached prune` — removed from the index
- `.gitignore` gains every worker `release.sh` builds, so a stray `git add -A` in a dirty checkout cannot repeat it

Listed individually rather than by a glob: these are real artifacts with known names, and a blanket rule would also swallow a source file someone later adds under the same name — a much quieter failure than this one was.

## Note

The blob stays in history; this only stops it reaching new checkouts. Purging it would need a rewrite, which is not worth it for one object unless the clone size becomes a problem.