### PR TITLE
feat(sources): crawl HiBob careers boards

### DIFF
--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -89,6 +89,7 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"portaldetalentos.senior.com.br", "senior", modeSubdomain},
 	{"vagas.solides.com.br", "solides", modeSubdomain},
 	{"softgarden.io", "softgarden", modeSubdomain},
+	{"careers.hibob.com", "hibob", modeSubdomain}, // HiBob's careers module: <tenant>.careers.hibob.com
 
 	// --- host: board = the whole careers host (regional TLD varies) ---
 	{"zohorecruit", "zohorecruit", modeHost},

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -47,6 +47,8 @@ func TestRecognizeBoard(t *testing.T) {
 		{"personio nested apex subdomain", "https://acme.jobs.personio.com/job/9", "personio", "acme", "https://acme.jobs.personio.com", true},
 		{"personio de host", "https://reflex-aerospace-gmbh.jobs.personio.de/job/2679152?display=en#apply", "personio", "reflex-aerospace-gmbh", "https://reflex-aerospace-gmbh.jobs.personio.de", true},
 		{"softgarden subdomain", "https://moll.softgarden.io/job/123/apply", "softgarden", "moll", "https://moll.softgarden.io", true},
+		{"hibob careers subdomain", "https://qogita.careers.hibob.com/jobs/ceb6c947-c906-44d1-a56b-bb33ae5599fa", "hibob", "qogita", "https://qogita.careers.hibob.com", true},
+		{"hibob apply tail collapses to the same board", "https://unique.careers.hibob.com/jobs/f8d9a0bc/apply", "hibob", "unique", "https://unique.careers.hibob.com", true},
 
 		// host mode — board is the whole careers host, regional TLD varies
 		{"zoho eu vacancy strips encoded path + query", "https://be-exec.zohorecruit.eu/jobs/Careers/73534000009044079/%D0%9F%D1%80%D0%BE?source=CareerSite", "zohorecruit", "be-exec.zohorecruit.eu", "https://be-exec.zohorecruit.eu", true},
@@ -73,6 +75,7 @@ func TestRecognizeBoard(t *testing.T) {
 		{"ashby bare host no board", "https://jobs.ashbyhq.com", "", "", "", false},
 		{"recruitee bare apex no tenant", "https://recruitee.com/", "", "", "", false},
 		{"personio bare apex no tenant", "https://jobs.personio.com", "", "", "", false},
+		{"hibob bare apex no tenant", "https://careers.hibob.com", "", "", "", false},
 		{"single-tenant geekjob", "https://geekjob.ru/vacancy/6a1e", "", "", "", false},
 		{"teamtailor custom domain not derivable", "https://careers.arrive.com/jobs/1", "", "", "", false},
 		// A Teamtailor career site links to the platform's own app host. In host mode the whole

--- a/internal/sources/hibob.go
+++ b/internal/sources/hibob.go
@@ -1,0 +1,115 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"strings"
+)
+
+// hibob adapts the careers module of HiBob ("Bob"), the HR platform. A board is the tenant
+// slug, which is also its careers subdomain (<board>.careers.hibob.com). One keyless call
+// returns the tenant's whole job board with descriptions inline, so there is no per-posting
+// detail fetch.
+//
+// The call needs a Referer naming that tenant's own careers page — no cookie, no token, no
+// key, just that header; without it the API answers 401. It is the only thing standing between
+// this adapter and an empty board, which is why a test asserts it.
+type hibob struct {
+	http HeaderJSONGetter
+}
+
+const (
+	hibobJobAdURL   = "https://%s.careers.hibob.com/api/job-ad"
+	hibobJobsURL    = "https://%s.careers.hibob.com/jobs"
+	hibobPostingURL = "https://%s.careers.hibob.com/jobs/%s"
+)
+
+// NewHiBob builds the HiBob adapter over the given HTTP client.
+func NewHiBob(c HeaderJSONGetter) Source { return hibob{http: c} }
+
+func (hibob) Provider() string { return "hibob" }
+
+// hibobJobAd is one posting from the job-ad response. HiBob splits the ad's body across four
+// HTML fields rather than carrying one description.
+type hibobJobAd struct {
+	ID               string `json:"id"`
+	Title            string `json:"title"`
+	Site             string `json:"site"`
+	Country          string `json:"country"`
+	Description      string `json:"description"`
+	Responsibilities string `json:"responsibilities"`
+	Requirements     string `json:"requirements"`
+	Benefits         string `json:"benefits"`
+	PublishedAt      string `json:"publishedAt"`
+	WorkspaceType    string `json:"workspaceType"`
+}
+
+func (h hibob) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var resp struct {
+		JobAdDetails []hibobJobAd `json:"jobAdDetails"`
+	}
+	url := fmt.Sprintf(hibobJobAdURL, e.Board)
+	headers := map[string]string{"Referer": fmt.Sprintf(hibobJobsURL, e.Board)}
+	if err := h.http.GetJSONWithHeaders(ctx, url, headers, &resp); err != nil {
+		return nil, fmt.Errorf("hibob: list board %s: %w", e.Board, err)
+	}
+
+	jobs := make([]Job, 0, len(resp.JobAdDetails))
+	for _, ad := range resp.JobAdDetails {
+		if ad.ID == "" {
+			continue // no native id → no dedup key; every id-less posting would collide
+		}
+		jobs = append(jobs, h.job(e, ad))
+	}
+	return jobs, nil
+}
+
+// job maps one job ad to a Job.
+func (hibob) job(e CompanyEntry, ad hibobJobAd) Job {
+	mode := workplaceTypeMode(ad.WorkspaceType)
+
+	return Job{
+		ExternalID:  ad.ID,
+		URL:         fmt.Sprintf(hibobPostingURL, e.Board, ad.ID),
+		Title:       strings.TrimSpace(ad.Title),
+		Company:     e.Company,
+		Location:    joinNonEmpty(ad.Site, ad.Country),
+		Description: hibobDescription(ad),
+		Remote:      mode == "remote",
+		PostedAt:    parseRFC3339(ad.PublishedAt),
+		WorkMode:    mode,
+	}
+}
+
+// hibobDescription assembles the posting's four body fields into one description. All four are
+// the job ad — the requirements section in particular is where the skills live, so dropping it
+// would starve skill tagging and enrichment.
+//
+// The sections are kept as separate blocks rather than concatenated: sanitizeHTML strips tags,
+// and adjacent blocks whose text ran together would glue the last word of one section to the
+// first of the next (see role_fingerprint, which hashes the visible text).
+//
+// HiBob also carries a sectionLabels object for tenants that rename the section headings. Every
+// tenant seen so far leaves it empty, so the headings are the platform's own defaults; the seam
+// to honour custom labels is this function.
+func hibobDescription(ad hibobJobAd) string {
+	sections := []struct{ heading, body string }{
+		{"", ad.Description},
+		{"Responsibilities", ad.Responsibilities},
+		{"Requirements", ad.Requirements},
+		{"Benefits", ad.Benefits},
+	}
+
+	var b strings.Builder
+	for _, s := range sections {
+		if strings.TrimSpace(s.body) == "" {
+			continue
+		}
+		if s.heading != "" {
+			b.WriteString("<h3>" + s.heading + "</h3>")
+		}
+		b.WriteString(s.body)
+	}
+	return sanitizeHTML(html.UnescapeString(b.String()))
+}

--- a/internal/sources/hibob_test.go
+++ b/internal/sources/hibob_test.go
@@ -1,0 +1,180 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// hibobFake answers the job-ad call, recording the headers it was called with — the Referer is
+// load-bearing, not cosmetic (see hibob.go), so a test has to be able to see it.
+type hibobFake struct {
+	body    string
+	url     string
+	headers map[string]string
+	err     error
+}
+
+func (f *hibobFake) GetJSONWithHeaders(_ context.Context, url string, headers map[string]string, v any) error {
+	f.url, f.headers = url, headers
+	if f.err != nil {
+		return f.err
+	}
+	return json.Unmarshal([]byte(f.body), v)
+}
+
+const hibobJobAdBody = `{"filterGroups":{"departments":[]},"jobAdDetails":[
+{"id":"04e764ae-fb6c-4303-ba2f-509b917804c2",
+ "title":"Data Scientist, Client Facing",
+ "department":"Customer",
+ "employmentType":"Employee",
+ "site":"New York",
+ "country":"United States",
+ "language":"en",
+ "description":"<p>We build AI &amp; finance tooling.</p><script>alert(1)<\/script>",
+ "requirements":"<ul><li>4+ years as a data scientist</li></ul>",
+ "responsibilities":"<ul><li>Work on-site with clients</li></ul>",
+ "benefits":"<ul><li>$140-170k DOE</li></ul>",
+ "sectionLabels":{},
+ "publishedAt":"2026-04-22T07:20:46.518438210Z",
+ "workspaceTypeId":"hybrid",
+ "workspaceType":"Hybrid"}]}`
+
+func TestHiBobProvider(t *testing.T) {
+	if got := NewHiBob(nil).Provider(); got != "hibob" {
+		t.Errorf("Provider() = %q, want hibob", got)
+	}
+}
+
+func TestHiBobRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["hibob"]; !ok {
+		t.Error("All() should register provider hibob")
+	}
+	if !slices.Contains(FilterableProviders(), "hibob") {
+		t.Error("FilterableProviders() should include hibob")
+	}
+}
+
+func TestHiBobBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/hibob.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/hibob.yml fails validation: %v", err)
+	}
+}
+
+// The API answers 401 without a Referer naming the tenant's own careers page — no cookie, no
+// token, just that header. Losing it silently empties every board, so it is asserted.
+func TestHiBobSendsTenantRefererElseTheAPIRefuses(t *testing.T) {
+	fake := &hibobFake{body: hibobJobAdBody}
+	if _, err := NewHiBob(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Qogita", Provider: "hibob", Board: "qogita",
+	}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if want := "https://qogita.careers.hibob.com/api/job-ad"; fake.url != want {
+		t.Errorf("called %q, want %q", fake.url, want)
+	}
+	if want := "https://qogita.careers.hibob.com/jobs"; fake.headers["Referer"] != want {
+		t.Errorf("Referer = %q, want %q", fake.headers["Referer"], want)
+	}
+}
+
+func TestHiBobMapsThePosting(t *testing.T) {
+	fake := &hibobFake{body: hibobJobAdBody}
+	jobs, err := NewHiBob(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Qogita", Provider: "hibob", Board: "qogita",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "04e764ae-fb6c-4303-ba2f-509b917804c2" {
+		t.Errorf("ExternalID = %q", j.ExternalID)
+	}
+	if want := "https://qogita.careers.hibob.com/jobs/04e764ae-fb6c-4303-ba2f-509b917804c2"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if j.Title != "Data Scientist, Client Facing" || j.Company != "Qogita" {
+		t.Errorf("title/company: %q %q", j.Title, j.Company)
+	}
+	if j.Location != "New York, United States" {
+		t.Errorf("Location = %q, want site and country joined", j.Location)
+	}
+	if j.WorkMode != "hybrid" || j.Remote {
+		t.Errorf("WorkMode = %q, Remote = %v", j.WorkMode, j.Remote)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 4, 22, 7, 20, 46, 518438210, time.UTC)) {
+		t.Errorf("PostedAt = %v", j.PostedAt)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+}
+
+// HiBob splits a posting's body across four fields. All of them are the job ad, so all of them
+// have to reach the description — enrichment and skill tagging read that text, and the
+// requirements section is where the skills live.
+func TestHiBobDescriptionCarriesEverySection(t *testing.T) {
+	fake := &hibobFake{body: hibobJobAdBody}
+	jobs, err := NewHiBob(fake).Fetch(context.Background(), CompanyEntry{Company: "Qogita", Board: "qogita"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	d := jobs[0].Description
+	for _, want := range []string{
+		"We build AI", "4+ years as a data scientist", "Work on-site with clients", "$140-170k DOE",
+	} {
+		if !strings.Contains(d, want) {
+			t.Errorf("description is missing %q:\n%s", want, d)
+		}
+	}
+	// Sections must not run together: role_fingerprint hashes the visible text, and glued
+	// words ("clients4+ years") would change the hash for no real difference.
+	if strings.Contains(d, "clients4+") || strings.Contains(d, "tooling4+") {
+		t.Errorf("sections glued together: %q", d)
+	}
+}
+
+func TestHiBobRemotePostingIsFlagged(t *testing.T) {
+	body := strings.ReplaceAll(hibobJobAdBody, `"workspaceType":"Hybrid"`, `"workspaceType":"Remote"`)
+	jobs, err := NewHiBob(&hibobFake{body: body}).Fetch(context.Background(), CompanyEntry{Board: "qogita"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !jobs[0].Remote || jobs[0].WorkMode != "remote" {
+		t.Errorf("Remote = %v, WorkMode = %q", jobs[0].Remote, jobs[0].WorkMode)
+	}
+}
+
+func TestHiBobOnSiteMapsToOnsite(t *testing.T) {
+	body := strings.ReplaceAll(hibobJobAdBody, `"workspaceType":"Hybrid"`, `"workspaceType":"On site"`)
+	jobs, err := NewHiBob(&hibobFake{body: body}).Fetch(context.Background(), CompanyEntry{Board: "qogita"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if jobs[0].WorkMode != "onsite" || jobs[0].Remote {
+		t.Errorf("WorkMode = %q, Remote = %v", jobs[0].WorkMode, jobs[0].Remote)
+	}
+}
+
+// A posting with no id has no dedup key, so it would collide with every other id-less posting
+// on the board rather than being stored.
+func TestHiBobSkipsPostingWithoutID(t *testing.T) {
+	body := `{"jobAdDetails":[{"id":"","title":"Ghost","description":"<p>x</p>"}]}`
+	jobs, err := NewHiBob(&hibobFake{body: body}).Fetch(context.Background(), CompanyEntry{Board: "qogita"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0", len(jobs))
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -92,6 +92,7 @@ func All(c HTTPClient) map[string]Source {
 		NewWorkday(c),
 		NewHuntflow(c),
 		NewInhire(c),
+		NewHiBob(c),
 		NewGem(c),
 		NewSuccessFactors(c),
 		NewTeamtailor(c),

--- a/sources/hibob.yml
+++ b/sources/hibob.yml
@@ -1,0 +1,39 @@
+# HiBob (Bob) careers boards. Provider is the filename; board = the tenant slug, which is
+# also its careers subdomain (<board>.careers.hibob.com); see internal/sources/hibob.go.
+# One keyless call returns the whole board with descriptions inline — no per-posting fetch.
+# Each board validated live (/api/job-ad returned postings) before adding; the company name is
+# the tenant's own companyName from /api/career-site.
+- company: 50 Sport
+  board: 50sport
+- company: ATP Tour, Inc.
+  board: atptourinc
+- company: Atticus
+  board: atticus
+- company: Bjarke Ingels Group
+  board: bjarkeingelsgroup
+- company: Cubico Sustainable Investments
+  board: cubicojobs
+- company: Dixa
+  board: dixa
+- company: Imex Dental und Technik GmbH
+  board: imexdental
+- company: IREN
+  board: iren
+- company: Numerical Algorithms Group
+  board: n2group
+- company: ONE group solutions
+  board: onegroupsolutions
+- company: Oviva
+  board: oviva
+- company: Projective Group
+  board: projectivegroup
+- company: Qogita
+  board: qogita
+- company: Samskip
+  board: samskip
+- company: Talent Systems
+  board: talentsystems
+- company: The Gap Partnership
+  board: thegappartnership
+- company: Unique
+  board: unique


### PR DESCRIPTION
The careers module of HiBob ("Bob") came in through the contribution review queue **twice** and resisted the usual reconnaissance: an Angular SPA whose API path is not extractable from `front.hibob.com/.../careers/main.*.js`, with every guessed path answering the SPA fallback as `text/html`. Capturing the page's XHR with CDP found it.

## The catch: it authenticates on `Referer`

```
GET https://<tenant>.careers.hibob.com/api/job-ad
Referer: https://<tenant>.careers.hibob.com/jobs   → 200
(no Referer)                                       → 401
```

No cookie, no token, no key. A test asserts the header, because losing it would silently empty every board rather than fail loudly.

## The shape

Best of any source added lately: **one keyless call returns the tenant's whole board with descriptions inline** — no per-posting detail fetch — plus a structured workspace-type enum (`On site`/`Hybrid`/`Remote`) that feeds `WorkMode` directly, and pay-transparency fields.

HiBob splits the ad's body across four HTML fields (`description`, `responsibilities`, `requirements`, `benefits`). All four are the job ad — and `requirements` is where the skills live — so the description assembles all of them, as separate blocks: concatenating would glue one section's last word to the next section's first, which `role_fingerprint` hashes as a difference.

## Boards

**17 boards, 395 postings**, each validated live (`/api/job-ad` returned postings) before adding; company names are the tenants' own `companyName` from `/api/career-site`. Largest: IREN 186, Projective Group 42, Bjarke Ingels Group 35, Oviva 34.

## Recognizer

`<tenant>.careers.hibob.com` is now a recognized ATS host (subdomain mode), so the next such contribution resolves to a board instead of landing in the review queue.

## Tests

TDD; 9 adapter tests plus 3 recognizer cases. Full suite green.