### PR TITLE
fix(workers): the two longest passes say where they are

### DIFF
--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -52,6 +52,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -64,6 +65,13 @@ import (
 
 // backfillBatchSize bounds how many jobs are read per keyset page.
 const backfillBatchSize = 500
+
+// progressEvery is how many rows pass between progress lines. A full pass covers over
+// five million rows and used to print nothing between "starting" and "done" — hours in
+// which a working run and a wedged one were indistinguishable, and "how much longer"
+// had no answer short of reading pg_stat_activity. 100k is roughly a line every few
+// minutes at prod's rate: enough to see movement, not enough to bury the log.
+const progressEvery = 100_000
 
 // deriveStore is the slice of the data layer the concurrent pass needs: page the
 // table by keyset and rewrite a row's derived columns. *db.Queries satisfies it;
@@ -197,6 +205,20 @@ func deriveRow(j db.Job) (params db.UpdateJobDerivedParams, changed, slugMoved b
 // so the caller knows whether to reconcile companies. The first store error cancels the
 // run and is returned.
 func backfillAll(ctx context.Context, store deriveStore, concurrency int) (scanned, updated, slugsMoved int, err error) {
+	start := time.Now()
+	return backfillProgress(ctx, store, concurrency, progressEvery, func(scanned, updated, slugs int64) {
+		log.Printf("backfill-derive: scanned %d, updated %d, slugs_moved %d, %s elapsed",
+			scanned, updated, slugs, time.Since(start).Round(time.Second))
+	})
+}
+
+// backfillProgress is backfillAll with the reporting cadence and sink injected, so the
+// cadence is a tested property rather than something only prod can demonstrate.
+//
+// report fires ON each multiple of every, from whichever worker happens to cross it —
+// the counter is atomic, so exactly one goroutine observes each multiple whatever the
+// concurrency. It runs on the worker's goroutine, so it must stay cheap.
+func backfillProgress(ctx context.Context, store deriveStore, concurrency int, every int64, report func(scanned, updated, slugsMoved int64)) (scanned, updated, slugsMoved int, err error) {
 	if concurrency < 1 {
 		concurrency = 1
 	}
@@ -252,7 +274,10 @@ func backfillAll(ctx context.Context, store deriveStore, concurrency int) (scann
 		go func() {
 			defer workerWG.Done()
 			for j := range jobsCh {
-				atomic.AddInt64(&scannedN, 1)
+				n := atomic.AddInt64(&scannedN, 1)
+				if every > 0 && n%every == 0 && report != nil {
+					report(n, atomic.LoadInt64(&updatedN), atomic.LoadInt64(&slugsN))
+				}
 				params, changed, slugMoved := deriveRow(j)
 				if !changed {
 					continue

--- a/cmd/backfill-derive/main_test.go
+++ b/cmd/backfill-derive/main_test.go
@@ -212,3 +212,63 @@ func TestBackfill_Concurrent(t *testing.T) {
 		}
 	}
 }
+
+// A full pass rewrites five million rows and, until now, said nothing at all between
+// "starting" and "done" — a silence measured in hours during which a run that was
+// working and a run that had wedged looked identical. The only way to tell them apart
+// was pg_stat_activity, and the only way to answer "how much longer" was to guess.
+//
+// cmd/prune's scan already learned this ("the first prod run was impossible to
+// distinguish from a hang"); this is the same fix on the other long worker.
+func TestBackfill_ReportsProgressWhileItRuns(t *testing.T) {
+	jobs := make([]db.Job, 0, 25)
+	for i := 1; i <= 25; i++ {
+		jobs = append(jobs, db.Job{
+			ID: int64(i), Title: "Senior Go Developer", Company: "Acme",
+			Source: "manual", ExternalID: "x", Location: "Berlin, Germany",
+			Description: backfillJobDescription,
+		})
+	}
+	store := &fakeStore{jobs: jobs}
+
+	var mu sync.Mutex
+	var seen []int64
+	// One worker, so the cadence is deterministic; the counter itself is atomic, so
+	// exactly one goroutine observes each multiple whatever the concurrency.
+	scanned, _, _, err := backfillProgress(context.Background(), store, 1, 10,
+		func(n, updated, slugs int64) {
+			mu.Lock()
+			defer mu.Unlock()
+			seen = append(seen, n)
+		})
+	if err != nil {
+		t.Fatalf("backfillProgress: %v", err)
+	}
+	if scanned != 25 {
+		t.Fatalf("scanned=%d, want 25", scanned)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("reported at %v, want two reports (at 10 and 20) for 25 rows every 10", seen)
+	}
+	if seen[0] != 10 || seen[1] != 20 {
+		t.Errorf("reported at %v, want [10 20] — the report must fire ON the multiple", seen)
+	}
+}
+
+// Progress reporting must not change what a pass does. The default entry point keeps
+// its signature and its counts.
+func TestBackfill_ProgressDoesNotChangeTheResult(t *testing.T) {
+	job := db.Job{
+		ID: 7, Title: "Senior Go Developer", Company: "Acme",
+		Source: "manual", ExternalID: "x", Location: "Berlin, Germany",
+		Description: backfillJobDescription,
+	}
+	store := &fakeStore{jobs: []db.Job{job}}
+	scanned, updated, slugsMoved, err := backfillAll(context.Background(), store, 1)
+	if err != nil {
+		t.Fatalf("backfillAll: %v", err)
+	}
+	if scanned != 1 || updated != 1 || slugsMoved != 1 {
+		t.Errorf("scanned=%d updated=%d slugsMoved=%d, want 1/1/1", scanned, updated, slugsMoved)
+	}
+}

--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -401,6 +401,11 @@ type boardVerdict struct {
 func boardsToRetire(ctx context.Context, q candidateSource, brd boards) ([]boardKey, int, error) {
 	evidence := map[boardKey]boardVerdict{}
 	var after int64
+	// Same accounting the scan above keeps, and for the same reason: this walks the
+	// whole catalogue too, so without it the report is twenty silent minutes in which
+	// a working run and a wedged one look identical.
+	var scanned, reported int64
+	start := time.Now()
 	for {
 		rows, err := q.PruneCandidates(ctx, db.PruneCandidatesParams{AfterID: after, PageSize: scanPage})
 		if err != nil {
@@ -408,6 +413,12 @@ func boardsToRetire(ctx context.Context, q candidateSource, brd boards) ([]board
 		}
 		if len(rows) == 0 {
 			break
+		}
+		scanned += int64(len(rows))
+		if scanned-reported >= progressEvery {
+			reported = scanned
+			log.Printf("prune: board report scanned %d rows, %d boards seen, %s elapsed",
+				scanned, len(evidence), time.Since(start).Round(time.Second))
 		}
 		for _, row := range rows {
 			after = row.ID


### PR DESCRIPTION
`backfill-derive` rewrites over five million rows and printed **nothing** between `starting` and `done`.

That is not a cosmetic gap. Tonight it made a live question unanswerable — *how much longer until the catalogue carries the new dictionary?* — with no recourse but `pg_stat_activity`, and even that only says "it is doing something", never "it is 60% through". A run that is working and a run that has wedged look identical for hours.

`prune --boards` has the same shape and the same silence: it keyset-walks the whole catalogue accumulating verdicts in memory, twenty-odd minutes, mute.

`cmd/prune`'s scan already learned this. Its `progressEvery` comment records why: *"the first prod run was impossible to distinguish from a hang."* This is that fix on the other two passes.

## What changed

- **`backfill-derive`** — `backfillAll` delegates to `backfillProgress`, which takes the cadence and the sink as parameters. The cadence is therefore a *tested* property rather than something only production can demonstrate. The counter is atomic, so exactly one worker observes each multiple whatever the concurrency; the test pins that the report fires **on** the multiple, and a second test pins that reporting does not change the counts.
- **`prune --boards`** — the same four lines as the scan 150 lines above it, `log.Printf` and all.

The asymmetry is deliberate: for the board report, consistency with its immediate neighbour is worth more than a harness for a single log line — and the neighbour is untested for the same reason. `backfill-derive` had no such neighbour, so the injectable shape costs nothing and buys a test.

## Verification

Test-first: `TestBackfill_ReportsProgressWhileItRuns` failed to compile against the missing seam, then asserted `[10 20]` for 25 rows at a cadence of 10. `go build ./...`, `go vet ./...`, `gofmt -l` clean; full `go test ./...` green.