### PR TITLE
fix(contribution): a rejected board stops claiming its identity forever

### DIFF
--- a/internal/contribution/AGENTS.md
+++ b/internal/contribution/AGENTS.md
@@ -35,12 +35,16 @@ contributions are URL-only, auto-validated, unmoderated.
 - **Checks run cheapest-first.** unsupported ATS (`ErrUnsupportedATS`, 422) before any DB read;
   board already crawled (`ErrBoardAlreadyTracked`, 409 — a job exists with `external_id`
   prefixed by `<board>:`, via `starts_with`) before any write; the record+point transaction
-  last, where a duplicate board (the `UNIQUE (source, board)` on `link_contributions`) surfaces
-  as `ErrBoardAlreadyContributed` (409).
+  last, where a duplicate board (the partial unique index on `link_contributions (source, board)
+  WHERE status <> 'rejected'`) surfaces as `ErrBoardAlreadyContributed` (409).
 - **`Record` is a single insert** (`QueriesRepository.Record`, the `accounts` repo pattern): it
-  persists the contribution row and maps the `UNIQUE (source, board)` violation — including the
+  persists the contribution row and maps the unique violation — including the
   concurrent-duplicate race — to `ErrBoardAlreadyContributed`. Verified by the build-tagged
   integration test.
+- **A rejected board releases its identity.** The uniqueness covers the LIVE statuses only
+  (`pending`/`review`/`onboarded`), so a board turned down as dead can be contributed again once
+  the employer resumes posting — which opens a new pending row. Spanning `rejected` too would
+  have made a single bad day permanent (migration 0049).
 - **The reward is AI credits, granted separately by the handler** (keyed by the contribution id,
   not inside `Record`). The legacy `users.points` counter was dropped in migration
   `0034_drop_users_points.sql`; the credit balance is the unified per-user reward now.

--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -23,8 +23,9 @@ var (
 	// ErrBoardAlreadyTracked is a board the catalogue already crawls (a job exists for it) —
 	// contributing it adds nothing, so no reward (409).
 	ErrBoardAlreadyTracked = errors.New("contribution: board already in catalogue")
-	// ErrBoardAlreadyContributed is a board already recorded by any user — the repository maps
-	// the unique violation to this (409).
+	// ErrBoardAlreadyContributed is a board already recorded by any user and still live in the
+	// queue (pending/review/onboarded) — the repository maps the unique violation to this (409).
+	// A rejected row does not reserve its board: that one can be contributed again.
 	ErrBoardAlreadyContributed = errors.New("contribution: board already contributed")
 )
 

--- a/internal/contribution/repository_integration_test.go
+++ b/internal/contribution/repository_integration_test.go
@@ -1,8 +1,9 @@
 //go:build integration
 
 // Integration tests for the contribution repository against a real Postgres: the
-// UNIQUE (source, board) constraint rejects a duplicate identity (mapped to
-// ErrBoardAlreadyContributed) and — under a concurrent race — records exactly one board.
+// uniqueness on (source, board) rejects a duplicate identity (mapped to
+// ErrBoardAlreadyContributed) and — under a concurrent race — records exactly one board, while
+// a rejected row releases its board so it can be contributed again.
 // The AI-credits reward is granted by the handler, not the repository, so it is not
 // exercised here. Run with: go test -tags=integration ./internal/contribution/
 // Requires Docker (testcontainers spins up a throwaway Postgres with the migrations).
@@ -70,6 +71,68 @@ func TestRecordAndDedups(t *testing.T) {
 	}
 	if n := countContributions(t, pool, userID); n != 1 {
 		t.Errorf("contributions after duplicate = %d, want still 1 — rejected insert must not record", n)
+	}
+}
+
+// A rejected board is not a claim on the identity: a board turned down as dead can come back
+// (the employer starts posting again), and the flow's own documentation promises it can be
+// re-contributed. The uniqueness that guards the onboarding queue therefore covers the live
+// statuses only.
+func TestRecordReopensARejectedBoard(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	repo := NewQueriesRepository(db.New(pool))
+	first := insertUser(t, pool, "rejected-first@example.com")
+	second := insertUser(t, pool, "rejected-second@example.com")
+
+	in := RecordInput{SubmittedBy: first, URL: "https://jobs.ashbyhq.com/dormant", Source: "ashby", Board: "dormant"}
+	rec, err := repo.Record(ctx, in)
+	if err != nil {
+		t.Fatalf("first Record: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE link_contributions SET status = 'rejected' WHERE id = $1`, rec.ID); err != nil {
+		t.Fatalf("reject the row: %v", err)
+	}
+
+	// The board is alive again and somebody else pastes it.
+	again := RecordInput{SubmittedBy: second, URL: "https://jobs.ashbyhq.com/dormant/a-uuid", Source: "ashby", Board: "dormant"}
+	reopened, err := repo.Record(ctx, again)
+	if err != nil {
+		t.Fatalf("re-contributing a rejected board: %v, want it recorded", err)
+	}
+	if reopened.Status != "pending" || reopened.ID == rec.ID {
+		t.Errorf("reopened row = %+v, want a new pending row", reopened)
+	}
+	if n := countContributions(t, pool, second); n != 1 {
+		t.Errorf("contributions for the second user = %d, want 1", n)
+	}
+}
+
+// The live statuses still hold the identity: an onboarded board is in the catalogue, so a
+// second contribution of it adds nothing and must not be rewarded.
+func TestRecordStillRejectsDuplicateOfAnOnboardedBoard(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	repo := NewQueriesRepository(db.New(pool))
+	userID := insertUser(t, pool, "onboarded-dup@example.com")
+
+	rec, err := repo.Record(ctx, RecordInput{
+		SubmittedBy: userID, URL: "https://jobs.ashbyhq.com/live", Source: "ashby", Board: "live",
+	})
+	if err != nil {
+		t.Fatalf("first Record: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE link_contributions SET status = 'onboarded' WHERE id = $1`, rec.ID); err != nil {
+		t.Fatalf("onboard the row: %v", err)
+	}
+
+	_, err = repo.Record(ctx, RecordInput{
+		SubmittedBy: userID, URL: "https://jobs.ashbyhq.com/live/uuid", Source: "ashby", Board: "live",
+	})
+	if !errors.Is(err, ErrBoardAlreadyContributed) {
+		t.Fatalf("duplicate of an onboarded board err = %v, want ErrBoardAlreadyContributed", err)
 	}
 }
 

--- a/migrations/0049_link_contributions_rejected_reopens.sql
+++ b/migrations/0049_link_contributions_rejected_reopens.sql
@@ -1,0 +1,25 @@
+-- A rejected board contribution must not claim the board's identity forever.
+--
+-- 0025 guarded the onboarding queue with UNIQUE (source, board): one company board can be
+-- contributed at most once, which dedups a second vacancy on the same board and makes the
+-- concurrent-duplicate race safe. That constraint spans every status, including 'rejected' —
+-- so a board turned down as dead (its listing returned nothing the day it was checked) could
+-- never be contributed again, even after the employer resumed posting. The contribution flow
+-- documents the opposite ("a rejected real board can be re-contributed"), and the reject path
+-- deliberately keeps the submitter's reward for exactly that reason: the link was real.
+--
+-- Narrowing the uniqueness to the live statuses keeps every guarantee that matters — 'pending',
+-- 'review' and 'onboarded' still hold the identity, so a duplicate of a queued or already
+-- onboarded board is still refused (ErrBoardAlreadyContributed, 409) and the reward is still
+-- paid once per board — while a rejected row stops blocking anything. Re-contributing then
+-- opens a NEW pending row, which is what the onboarding queue should see.
+--
+-- Applied to a fresh volume by initdb after 0048; on an existing prod volume this must be run
+-- manually BEFORE deploying code that relies on it.
+
+ALTER TABLE public.link_contributions
+    DROP CONSTRAINT link_contributions_source_board_key;
+
+CREATE UNIQUE INDEX link_contributions_source_board_active_key
+    ON public.link_contributions USING btree (source, board)
+    WHERE status <> 'rejected';


### PR DESCRIPTION
`UNIQUE (source, board)` on `link_contributions` spanned **every** status, including `rejected`.

## The defect

A board turned down as dead — its listing happened to return nothing the day a maintainer checked it — could never be contributed again, even after the employer resumed posting. The row holds the identity forever, and the next person pasting that link gets a 409.

The flow's own documentation promises the opposite ("a rejected real board can be re-contributed"), and the reject path deliberately **keeps** the submitter's reward for exactly that reason: the link was real, a stale board isn't their fault. 29 rejected pairs are currently locked this way.

## The change

Migration 0049 narrows the uniqueness to the live statuses:

```sql
CREATE UNIQUE INDEX link_contributions_source_board_active_key
    ON link_contributions (source, board)
    WHERE status <> 'rejected';
```

Everything that mattered is kept: `pending`, `review` and `onboarded` still hold the identity, so a duplicate of a queued or already-onboarded board is still refused (409), the concurrent-duplicate race still records exactly one row, and the reward is still paid once per board. Re-contributing a rejected board now opens a fresh `pending` row.

## Deliberately not changed

The reward stays **one per board**. Paying every later contributor for a board already in the catalogue buys nothing and invites farming a single board from several accounts.

## Deploy

Prod volume needs 0049 run manually **before** deploying.

## Tests

TDD against real Postgres (build-tagged integration). The new re-contribution test failed with `board already contributed` before the migration; a second new test pins that an *onboarded* board still refuses duplicates, so the narrowing can't silently widen.