### PR TITLE
feat(web): a landing page for the inbox, and a /features space to hold it

### DIFF
--- a/openspec/changes/inbox-feature-landing/.openspec.yaml
+++ b/openspec/changes/inbox-feature-landing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/inbox-feature-landing/design.md
+++ b/openspec/changes/inbox-feature-landing/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The site already has three feature landings — `/contribute`, `/cli`, `/chatgpt` —
+plus `/about`, and they share one unwritten template: a route file that carries
+only `<Seo>` and a `max-w-6xl px-4 py-6` wrapper, with the whole page living in a
+`*View` component. Their visual vocabulary is equally settled: a mono
+`// section` label above each block, hairline grids built as `gap-px` on a
+`bg-border` background, `01/02/03` numbering, and `figure` elements framed like a
+browser or terminal window.
+
+The inbox feature this page describes is implemented across six packages
+(`docs/agents/mail-stack.md`). Two of its rules constrain the copy directly:
+only a deterministic tier auto-links an email, and stage advance is strictly
+forward. A landing page that flattens those into "we sort your mail for you"
+would be describing a product we did not build.
+
+A tracking landing (`/features/tracking`) is planned next and will reuse this
+page's shape.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One public page that a stranger can read and understand the inbox from.
+- Copy that survives a reading by someone with the source open.
+- Previews that stay correct across light/dark, viewport widths, and future
+  redesigns of the real UI.
+- Leave the next feature landing cheaper to build than this one was.
+
+**Non-Goals:**
+
+- No `/features` index page. One child does not justify a hub.
+- No live data. The page renders no API call; the previews are illustrative,
+  exactly as `HomeView`'s board and funnel previews already are.
+- No generalized "feature landing" framework. Two shared primitives, not a
+  page-builder.
+- No new backend surface, no changes to the mail stack.
+
+## Decisions
+
+**Markup previews over screenshots.** The carousel's PNGs are light-theme, carry
+a real address (`strelov1@gmail.com`), and freeze a UI that changes. Rebuilding
+the three previews — inbox list, connect settings, application card with an
+Emails tab — from divs and theme tokens costs more markup but yields a page that
+is theme-correct, responsive, PII-free and weightless. `HomeView` already proves
+the approach with its board and funnel previews.
+
+**Two primitives extracted, not a framework.** `SectionLabel` (the
+`// section` mono label) and `NumberedGrid` (the `01/02/03` hairline grid) each
+appear verbatim in three existing components. Extracting them is deduplication of
+what exists; anything beyond that would be inventing an abstraction for one
+future page. `HomeView`, `AboutValues` and `ContributeLandingView` are migrated
+onto them so there is a single definition, not a fourth copy.
+
+*Alternative considered:* a `FeatureLandingLayout` component taking sections as
+props. Rejected — every landing so far has a different section order and mix, so
+the layout would be a parameter bag with no behaviour.
+
+**FAQ content in a module, mirroring `homeFaq.ts`.** Google requires the visible
+answers to match the `FAQPage` payload. A shared `inboxFaq.ts` makes drift
+impossible by construction and is directly unit-testable, unlike markup.
+
+**Hosted mailbox is the primary CTA.** Gmail sync runs under an unverified
+restricted-scope OAuth app, so it works for test users only until Google's
+review completes. Leading with "Connect Gmail" would send most visitors into a
+consent screen that rejects them. The hosted address works for everyone, so it
+leads; Gmail is presented second.
+
+**The status section lists the vocabulary, not a marketing subset.** All nine
+`mailclassify` signals, including `incomplete_application` (an actionable to-do,
+deliberately not a stage) and the `other` fallback. Showing the real vocabulary
+is also the honest way to explain why nothing gets silently mislabelled: an
+out-of-vocabulary model answer is sanitized to `other` before it is stored.
+
+**Testing follows what the repo can test.** `web/` runs vitest over `.ts`
+modules; there is no component test runner. So the testable units are
+`inboxFaq.ts` (shape, non-empty, unique questions) and `STATIC_PATHS` (the
+sitemap entry). Everything visual is verified by build + lint + a headless-Chrome
+screenshot pass, which is how the other landings were verified.
+
+## Risks / Trade-offs
+
+- **Markup previews drift from the real UI** → They are illustrative by
+  construction, like the existing home-page previews, and are labelled as
+  product views rather than live data. A redesign makes them dated, not wrong.
+- **Copy drifts from `mailclassify` if the vocabulary changes** → The spec pins
+  the claim to the code, and the FAQ/status list is small and localized. A
+  vocabulary change is already a change that touches specs.
+- **Extracting primitives touches three shipped components** → Pure
+  presentational extraction with identical output; verified by build and a
+  visual pass on `/`, `/about` and `/contribute`.
+- **Gmail positioning could look like under-selling** → It reflects the actual
+  access state. When Google verification lands, promoting Gmail is a one-line
+  copy change.
+
+## Migration Plan
+
+Additive, frontend-only. Deploy is the normal web build; rollback is reverting
+the commit. No migration, no config, no backend release ordering.
+
+## Open Questions
+
+None.

--- a/openspec/changes/inbox-feature-landing/proposal.md
+++ b/openspec/changes/inbox-feature-landing/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+The mail stack — Gmail sync, the hosted mailbox, LLM classification, application
+linking and automatic stage advance — is live, but nothing on the public site
+explains it. A visitor who is not signed in cannot discover the feature at all,
+and a signed-in user meets `/my/inbox` with no account connected and no
+explanation of what connecting one buys them. The five-slide carousel that
+announced the feature (`freehire-carousel`) already carries a working narrative;
+this change turns that narrative into a durable page on the site.
+
+## What Changes
+
+- A new public page at `/features/inbox` explaining the inbox: how mail gets in,
+  what the classifier tags, how a tagged email links to an application and moves
+  its card on the tracking board, what we do and do not read, and how an agent
+  harness can push its own mail.
+- The page follows the established landing vocabulary of `/about` and
+  `/contribute`: a route that carries only `<Seo>` plus the page wrapper, all
+  markup in a `*LandingView` component, mono `// section` labels, hairline
+  (`gap-px` on `bg-border`) grids, numbered `01/02/03` blocks.
+- Product previews are built from markup and theme tokens, not screenshots — so
+  they hold up in dark mode, stay responsive, carry no PII, and cannot silently
+  drift out of date as image files.
+- A FAQ block backed by a `FAQPage` JSON-LD payload, sharing one source with the
+  visible text (mirroring `homeFaq.ts`).
+- Discovery: a footer link, a sentence with a link from the `HomeView`
+  "track your search" section (which renders on both `/` and `/about`), and the
+  URL added to `sitemap-pages.xml`.
+- `/features/*` is introduced as the home for feature landings. The existing
+  referrals landing moves there too (`/referrals` → `/features/referrals`, with a
+  301 on the old address), so the space has the two pages it describes rather
+  than one page and a promise. No `/features` index page until the set is big
+  enough to need a hub.
+- Two presentational primitives that already repeat verbatim across `HomeView`,
+  `AboutValues` and `ContributeLandingView` — the mono section label and the
+  numbered hairline grid — are extracted so the planned tracking landing can be
+  assembled from them rather than copy-pasted a fourth time.
+
+## Capabilities
+
+### New Capabilities
+- `inbox-feature-landing`: the public `/features/inbox` page — its sections,
+  the claims it is allowed to make about classification and stage advance, its
+  SEO payload, and the links that lead to it.
+
+### Modified Capabilities
+
+None. This adds a marketing surface; no existing requirement changes. The
+existing `email-inbox`, `application-from-mail` and `email-body-classification`
+specs describe the behaviour the page documents, and stay as they are.
+
+## Impact
+
+- **New:** `web/src/routes/features/inbox/+page.svelte`,
+  `web/src/lib/components/InboxLandingView.svelte`, `web/src/lib/inboxFaq.ts`,
+  and two extracted primitives under `web/src/lib/components/`.
+- **Moved:** `web/src/routes/referrals/+page.svelte` →
+  `web/src/routes/features/referrals/+page.svelte`, with a 301 left behind at the
+  old path.
+- **Modified:** `web/src/lib/components/Footer.svelte` (a new "Features" group,
+  four columns instead of three), `web/src/lib/components/HomeView.svelte` (a
+  sentence in "track your search" plus a features section),
+  `web/src/lib/sitemap.ts` (`STATIC_PATHS`).
+- **No backend change.** The page is static marketing copy; it reads no API and
+  needs no new endpoint. It does depend on the accuracy of
+  `internal/mailclassify` (the status vocabulary and the forward-only stage
+  rules) — the copy must match that code, not overstate it.
+- **Honesty constraints carried from the code:** only a deterministic match
+  (`TierThread`/`TierName`) auto-links an email; a confident model verdict is a
+  *suggestion* the user confirms. Stage advance is strictly forward, never out of
+  a settled stage, and rejection never moves a card automatically. Gmail sync
+  runs under an unverified restricted-scope OAuth app (test users only), so the
+  hosted mailbox — which works for everyone — is the primary call to action and
+  Gmail is the secondary one.

--- a/openspec/changes/inbox-feature-landing/specs/inbox-feature-landing/spec.md
+++ b/openspec/changes/inbox-feature-landing/specs/inbox-feature-landing/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+### Requirement: Public inbox feature landing page
+
+The frontend SHALL serve a public, unauthenticated page at `/features/inbox`
+that explains the inbox feature to a visitor who is not signed in. The page
+SHALL render its copy server-side, so the initial HTML carries the explanatory
+text without client JavaScript.
+
+#### Scenario: Page is public and server-rendered
+
+- **WHEN** an anonymous visitor requests `GET /features/inbox`
+- **THEN** the response is 200 and its HTML body already contains the page
+  headline and section copy, with no sign-in redirect
+
+#### Scenario: Sections present
+
+- **WHEN** the page renders
+- **THEN** it contains, in order: a hero, a connect section covering both mail
+  channels, a status-vocabulary section, a board-linking section, a privacy
+  section, an agent-harness section, a FAQ, and a closing call to action
+
+#### Scenario: Previews are markup, not screenshots
+
+- **WHEN** the page renders its product previews
+- **THEN** each preview is built from markup and theme tokens, and the page
+  references no screenshot image file
+
+### Requirement: Copy matches the classifier's behaviour
+
+The page SHALL describe classification and stage advance exactly as
+`internal/mailclassify` implements them, and SHALL NOT claim behaviour the code
+does not have.
+
+#### Scenario: Status vocabulary matches the code
+
+- **WHEN** the page lists the statuses an email can be tagged with
+- **THEN** the listed statuses are drawn from the `mailclassify` vocabulary —
+  acknowledgement, screening, interview invitation, assessment, offer,
+  rejection, info request, incomplete application — and the page states that an
+  unrecognised signal is recorded as `other`
+
+#### Scenario: Stage advance is described as forward-only
+
+- **WHEN** the page explains how a classified email affects the tracking board
+- **THEN** it states that a card only ever moves forward through
+  applied → screening → responded → interview → offer, that a settled
+  application is never moved automatically, and that a rejection does not move
+  the card by itself
+
+#### Scenario: Auto-linking is not overstated
+
+- **WHEN** the page explains how an email is attached to an application
+- **THEN** it states that automatic linking happens on a deterministic match
+  (the mail thread, or the company name in the sender or subject) and that a
+  model's pick is offered as a suggestion for the user to confirm
+
+#### Scenario: Both mail channels are described
+
+- **WHEN** the page renders the connect section
+- **THEN** it describes the hosted freehire address as the primary way in and
+  the Gmail connection as the secondary one, and states that Gmail access is
+  read-only and revocable
+
+### Requirement: Agent harness tier is documented
+
+The page SHALL document the bring-your-own-harness tier: a caller's own client
+pushes mail through `POST /me/emails` and triages it itself, and freehire never
+classifies that mail.
+
+#### Scenario: Harness section renders
+
+- **WHEN** the page renders the agent section
+- **THEN** it names the `POST /me/emails` endpoint and states that mail pushed
+  this way is not classified by freehire
+
+### Requirement: FAQ is backed by structured data
+
+The page SHALL emit a `FAQPage` JSON-LD payload whose questions and answers are
+generated from the same source as the visible FAQ text, so the structured data
+can never drift from what the page shows.
+
+#### Scenario: JSON-LD mirrors the visible FAQ
+
+- **WHEN** the page renders
+- **THEN** its `FAQPage` JSON-LD contains exactly the questions and answers
+  rendered in the visible FAQ section
+
+#### Scenario: Canonical and meta tags
+
+- **WHEN** the page renders
+- **THEN** it emits a canonical URL of `<origin>/features/inbox` together with a
+  page title and description describing the inbox feature
+
+### Requirement: The landing page is discoverable
+
+The site SHALL link to `/features/inbox` from a dedicated "Features" group in the
+footer and from the home/about pages, and SHALL list the URL in the static-pages
+sitemap.
+
+#### Scenario: Footer group
+
+- **WHEN** any page renders its footer
+- **THEN** the footer shows a "Features" group listing every feature landing,
+  `/features/inbox` among them
+
+#### Scenario: Link from the home and about pages
+
+- **WHEN** `/` or `/about` renders
+- **THEN** the "track your search" section links to `/features/inbox`, and a
+  features section links to each feature landing
+
+#### Scenario: Sitemap entry
+
+- **WHEN** `GET /sitemap-pages.xml` is requested
+- **THEN** the returned urlset contains `<origin>/features/inbox`
+
+### Requirement: The referrals landing lives under /features
+
+The referrals landing SHALL be served at `/features/referrals`, and its previous
+address SHALL keep answering with a permanent redirect so shared links and
+accumulated ranking survive the move.
+
+#### Scenario: New address serves the page
+
+- **WHEN** an anonymous visitor requests `GET /features/referrals`
+- **THEN** the response is 200 and carries the referrals landing content with a
+  canonical URL of `<origin>/features/referrals`
+
+#### Scenario: Old address redirects
+
+- **WHEN** a visitor or crawler requests `GET /referrals`
+- **THEN** the response is a 301 to `/features/referrals`
+
+#### Scenario: Sitemap lists only the new address
+
+- **WHEN** `GET /sitemap-pages.xml` is requested
+- **THEN** the returned urlset contains `<origin>/features/referrals` and does
+  not contain `<origin>/referrals`

--- a/openspec/changes/inbox-feature-landing/tasks.md
+++ b/openspec/changes/inbox-feature-landing/tasks.md
@@ -1,0 +1,36 @@
+## 1. Shared primitives
+
+- [x] 1.1 Add `SectionLabel.svelte` (the `// section` mono label) and migrate `HomeView`, `AboutValues` and `ContributeLandingView` onto it
+- [x] 1.2 Add `NumberedGrid.svelte` (the `01/02/03` hairline grid) and migrate the `sourced`/`steps` blocks in `HomeView` onto it
+
+## 2. FAQ content module
+
+- [x] 2.1 Write `web/src/lib/inboxFaq.test.ts` covering: the export is non-empty, every question is unique, every answer is non-empty (RED)
+- [x] 2.2 Add `web/src/lib/inboxFaq.ts` exporting `INBOX_FAQ: FaqItem[]` with answer-first entries (GREEN)
+
+## 3. The landing page
+
+- [x] 3.1 Add `InboxLandingView.svelte` — hero with the inbox-list preview
+- [x] 3.2 Add the connect section: hosted address first, Gmail second
+- [x] 3.3 Add the status-vocabulary section, driven by a tested `inboxStatusGuide.ts` pinned to `emailStatus.ts` (RED→GREEN)
+- [x] 3.4 Add the board section: deterministic auto-link vs suggestion, forward-only stage ladder, application-card preview with an Emails tab, link to `/my/tracking`
+- [x] 3.5 Add the privacy section and the agent-harness section (`POST /me/emails`, never classified by freehire)
+- [x] 3.6 Add the FAQ section rendering `INBOX_FAQ`, and the closing call to action
+- [x] 3.7 Add `web/src/routes/features/inbox/+page.svelte` — `<Seo>`, canonical, `faqPageJsonLd(INBOX_FAQ)`, page wrapper
+
+## 4. Move the referrals landing under /features
+
+- [x] 4.1 `git mv` the referrals page to `web/src/routes/features/referrals/`, updating its canonical
+- [x] 4.2 Leave a 301 at `/referrals` so shared links and ranking survive
+
+## 5. Discovery
+
+- [x] 5.1 Extend `web/src/lib/sitemap.test.ts` for both feature landings and the dropped `/referrals` (RED), then update `STATIC_PATHS` (GREEN)
+- [x] 5.2 Add a "Features" group to the footer (Inbox, Referrals) and widen the grid to four columns
+- [x] 5.3 Link both landings from `HomeView` — a sentence in "track your search" plus a features section
+
+## 6. Verification
+
+- [x] 6.1 `pnpm test`, `pnpm lint`, `pnpm build` all green
+- [x] 6.2 Visual pass in headless Chrome on `/features/inbox` (light + dark) and a regression check of `/`, `/about`, `/contribute` after the primitive extraction
+- [x] 6.3 `simplify` pass over the diff, tests still green

--- a/web/src/lib/components/AboutValues.svelte
+++ b/web/src/lib/components/AboutValues.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import SectionLabel from '$lib/components/SectionLabel.svelte';
+
   // The About page's values block — the promises behind the mission, shown only
   // on /about (HomeView carries the mission and renders on / too, so these live
   // in a standalone component to keep them off the landing page).
@@ -32,7 +34,7 @@
 </script>
 
 <section class="border-t border-border py-16 sm:py-20">
-  <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// values</p>
+  <SectionLabel text="values" />
   <dl class="mt-10 divide-y divide-border border-y border-border">
     {#each values as v (v.n)}
       <div class="grid gap-2 py-6 sm:grid-cols-[auto_1fr] sm:gap-8">

--- a/web/src/lib/components/ContributeLandingView.svelte
+++ b/web/src/lib/components/ContributeLandingView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { Button } from '$lib/ui';
+  import SectionLabel from '$lib/components/SectionLabel.svelte';
 
   const repoUrl = 'https://github.com/strelov1/freehire';
   const telegramUrl = 'https://t.me/freehiredev';
@@ -47,9 +48,7 @@
 <div class="flex flex-col gap-16">
   <!-- Hero -->
   <section class="dot-grid -mx-4 flex flex-col gap-7 px-4 pb-4 pt-2">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
-      // contribute
-    </p>
+    <SectionLabel text="contribute" />
     <h1 class="max-w-3xl text-balance text-4xl font-semibold leading-[1.0] tracking-tighter sm:text-6xl">
       A search engine is only as good as its coverage.
     </h1>

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -13,8 +13,14 @@
         { label: 'Jobs', href: resolve('/') },
         { label: 'Companies', href: resolve('/companies') },
         { label: 'Collections', href: resolve('/collections') },
-        { label: 'Referrals', href: resolve('/referrals') },
         { label: 'Recruiters', href: resolve('/recruiters') },
+      ],
+    },
+    {
+      title: 'Features',
+      links: [
+        { label: 'Inbox', href: resolve('/features/inbox') },
+        { label: 'Referrals', href: resolve('/features/referrals') },
       ],
     },
     {
@@ -56,7 +62,7 @@
 
 <footer class="border-t border-border">
   <div class="mx-auto max-w-6xl px-4 py-8 sm:py-12">
-    <div class="grid grid-cols-3 gap-x-6 gap-y-7 sm:gap-6">
+    <div class="grid grid-cols-2 gap-x-6 gap-y-7 sm:grid-cols-4 sm:gap-6">
       <!-- Navigation groups. Each is a named landmark (aria-label) so screen readers
            get a title without adding headings to the page outline. -->
       {#each groups as group (group.title)}

--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -2,6 +2,8 @@
   import { resolve } from '$app/paths';
   import { Button } from '$lib/ui';
   import HomeFunnel from '$lib/components/HomeFunnel.svelte';
+  import NumberedGrid from '$lib/components/NumberedGrid.svelte';
+  import SectionLabel from '$lib/components/SectionLabel.svelte';
   import { HOME_FAQ } from '$lib/homeFaq';
 
   // Live catalogue totals from the page's server load; either may be null on an
@@ -97,6 +99,23 @@
     },
   };
 
+  // The feature landings, each of which explains one surface in depth. Kept here
+  // rather than only in the footer so the story on / and /about has a doorway.
+  const features = [
+    {
+      href: resolve('/features/inbox'),
+      title: 'Inbox',
+      body: 'Connect your mail and every recruiter reply is tagged with what it says, attached to the application it belongs to, and walked forward on your board.',
+      cta: 'How the inbox works',
+    },
+    {
+      href: resolve('/features/referrals'),
+      title: 'Referrals',
+      body: 'Ask an employee inside the company to put your name forward — anonymously and for free — instead of applying cold.',
+      cta: 'How referrals work',
+    },
+  ];
+
   const steps = [
     {
       n: '01',
@@ -122,9 +141,7 @@
   <section class="grid-bg relative -mx-4 px-4 pb-16 pt-14 sm:pt-20">
     <div class="grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
       <div>
-        <p class="reveal font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground" style="--d:0ms">
-          // open-source · free &amp; transparent
-        </p>
+        <SectionLabel text="open-source · free &amp; transparent" class="reveal" style="--d:0ms" />
 
         <h1
           class="reveal mt-6 max-w-2xl text-balance text-5xl font-semibold leading-[0.95] tracking-tighter sm:text-7xl"
@@ -181,7 +198,7 @@
   <!-- Catalogue scale, right under the fold: two live totals (server-loaded, with
        a static "+" fallback) and two constants. The first proof of the hero's claim. -->
   <section class="py-10 sm:py-12">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// the catalogue</p>
+    <SectionLabel text="the catalogue" />
     <dl class="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-4">
       {#each figures as f (f.label)}
         <div class="bg-background p-5 sm:p-6">
@@ -194,18 +211,8 @@
 
   <!-- Straight from the source — what separates freehire from an aggregator. -->
   <section class="border-t border-border py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// straight from the source</p>
-    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3">
-      {#each sourced as item (item.n)}
-        <div class="group bg-background p-6 transition-colors hover:bg-secondary/40 sm:p-7">
-          <span class="font-mono text-sm text-muted-foreground transition-colors group-hover:text-foreground">
-            {item.n}
-          </span>
-          <h3 class="mt-4 text-lg font-semibold tracking-tight">{item.title}</h3>
-          <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.body}</p>
-        </div>
-      {/each}
-    </div>
+    <SectionLabel text="straight from the source" />
+    <NumberedGrid items={sourced} class="mt-10 sm:grid-cols-3" />
   </section>
 
   <!-- Sourced-from marquee: the real adapters, scrolling. Honest list only. -->
@@ -225,7 +232,7 @@
 
   <!-- Mission. A single large statement carries this section. -->
   <section class="py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// mission</p>
+    <SectionLabel text="mission" />
     <p class="mt-6 max-w-3xl text-2xl font-medium leading-snug tracking-tight sm:text-3xl">
       A job board that works for you, not for recruiters. No paywalls, no sponsored listings, no CV
       harvesting. Free to use, and free to fork.
@@ -234,24 +241,14 @@
 
   <!-- How it works — three steps that mirror the actual ingest pipeline. -->
   <section class="border-t border-border py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// how it works</p>
-    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3">
-      {#each steps as step (step.n)}
-        <div class="group bg-background p-6 transition-colors hover:bg-secondary/40 sm:p-7">
-          <span class="font-mono text-sm text-muted-foreground transition-colors group-hover:text-foreground">
-            {step.n}
-          </span>
-          <h3 class="mt-4 text-lg font-semibold tracking-tight">{step.title}</h3>
-          <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{step.body}</p>
-        </div>
-      {/each}
-    </div>
+    <SectionLabel text="how it works" />
+    <NumberedGrid items={steps} class="mt-10 sm:grid-cols-3" />
   </section>
 
   <!-- Track your search — the per-user My jobs board. A polished, hero-style
        preview of the real kanban; the board data is illustrative, not live. -->
   <section class="border-t border-border py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// track your search</p>
+    <SectionLabel text="track your search" />
     <div class="mt-6 max-w-2xl">
       <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">
         Track every application on your board.
@@ -265,6 +262,12 @@
         <code class="font-mono text-foreground">save</code>,
         <code class="font-mono text-foreground">stage</code> and
         <code class="font-mono text-foreground">note</code> any job from a script or an agent.
+      </p>
+      <p class="mt-4 leading-relaxed text-muted-foreground">
+        You don't have to move the cards by hand either: connect your mail and the
+        <a href={resolve('/features/inbox')} class="font-medium text-foreground underline-offset-4 hover:underline">freehire inbox</a>
+        tags each recruiter reply, attaches it to the application it belongs to, and walks the card
+        forward for you.
       </p>
       <div class="mt-8 flex flex-wrap gap-3">
         <Button href={resolve('/my/tracking')} variant="primary" size="lg">Open Tracking</Button>
@@ -317,7 +320,7 @@
        Sankey snapshot of where applications land. The counts are illustrative,
        not live data (see `funnel` above). -->
   <section class="border-t border-border py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// your pipeline</p>
+    <SectionLabel text="your pipeline" />
     <div class="mt-6 max-w-2xl">
       <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">
         See where every application lands.
@@ -344,9 +347,26 @@
     </figure>
   </section>
 
+  <!-- The feature landings. Each has a page of its own; this is the doorway. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="features" />
+    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each features as f (f.href)}
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal route already passed through resolve() when building `features`; the linter can't trace it via the variable -->
+        <a href={f.href} class="group bg-background p-6 transition-colors hover:bg-secondary/40 sm:p-7">
+          <h3 class="text-lg font-semibold tracking-tight">{f.title}</h3>
+          <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{f.body}</p>
+          <span class="mt-4 inline-block text-sm font-medium text-foreground underline-offset-4 group-hover:underline">
+            {f.cta} →
+          </span>
+        </a>
+      {/each}
+    </div>
+  </section>
+
   <!-- Notifications — save a filter, get matching jobs pushed to Telegram. -->
   <section class="border-t border-border py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// stay in the loop</p>
+    <SectionLabel text="stay in the loop" />
     <div class="mt-6 max-w-2xl">
       <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">New jobs, straight to Telegram.</h2>
       <p class="mt-5 leading-relaxed text-muted-foreground">
@@ -366,7 +386,7 @@
   <!-- CLI / agents — the same API from the terminal. Mirrors the open-source
        section's two-column copy + terminal figure. -->
   <section class="border-t border-border py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// for agents</p>
+    <SectionLabel text="for agents" />
     <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
       <div>
         <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
@@ -408,7 +428,7 @@ freehire save <span class="text-foreground">&lt;slug&gt;</span></pre>
 
   <!-- Open source / contribute. -->
   <section class="border-t border-border py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// open source</p>
+    <SectionLabel text="open source" />
     <div class="mt-6">
       <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
         Built in the open. Add your own source.
@@ -431,7 +451,7 @@ freehire save <span class="text-foreground">&lt;slug&gt;</span></pre>
   <!-- FAQ. Visible answers mirror the FAQPage JSON-LD (see homeFaq.ts) so the
        structured data always matches what's on the page. -->
   <section class="border-t border-border py-16 sm:py-20">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// faq</p>
+    <SectionLabel text="faq" />
     <h2 class="mt-6 max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
       Frequently asked questions.
     </h2>

--- a/web/src/lib/components/InboxLandingView.svelte
+++ b/web/src/lib/components/InboxLandingView.svelte
@@ -1,0 +1,371 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { Button } from '$lib/ui';
+  import NumberedGrid from '$lib/components/NumberedGrid.svelte';
+  import SectionLabel from '$lib/components/SectionLabel.svelte';
+  import { statusClass, statusLabel } from '$lib/emailStatus';
+  import { INBOX_FAQ } from '$lib/inboxFaq';
+  import { INBOX_STATUS_GUIDE } from '$lib/inboxStatusGuide';
+
+  // Illustrative inbox — decorative, not live data. Every sender is an ATS relay
+  // of the kind that really writes (the matcher deliberately never trusts those
+  // domains; it reads the thread and the company name instead), and every status
+  // is a real `mailclassify` signal rendered with the product's own chip.
+  const mail = [
+    {
+      from: 'Avenga Careers',
+      subject: 'We have received your application!',
+      when: 'yesterday',
+      signal: 'acknowledgement',
+      unread: true,
+    },
+    {
+      from: 'Fingerprint Recruiting',
+      subject: 'Regarding your application to Fingerprint',
+      when: '2 days ago',
+      signal: 'rejection',
+    },
+    {
+      from: 'Gabrielle Loureiro',
+      subject: 'Interview for Senior Full-Stack Engineer',
+      when: '2 days ago',
+      signal: 'interview_invitation',
+    },
+    {
+      from: 'Pack.com Recruiting',
+      subject: 'A few questions about your experience',
+      when: '3 days ago',
+      signal: 'info_request',
+    },
+  ];
+
+  // The two messages hanging off one application in the board preview: the ATS
+  // acknowledgement that opened the thread, and the reply that moved the card.
+  const linked = [
+    {
+      from: 'no-reply@us.greenhouse-mail.io',
+      subject: 'Thank you for applying to Speechify',
+      signal: 'acknowledgement',
+    },
+    {
+      from: 'Gabrielle Loureiro',
+      subject: 'Interview for Senior Full-Stack Engineer',
+      signal: 'interview_invitation',
+    },
+  ];
+
+  // The stage ladder an email can push a card along — `mailclassify.stageOrder`,
+  // in its own order. Terminal outcomes are absent on purpose: nothing automatic
+  // ever moves a card into or out of one.
+  const ladder = ['Applied', 'Screening', 'Responded', 'Interview', 'Offer'];
+
+  const promises = [
+    {
+      n: '01',
+      title: 'Only the mail you point at us',
+      body: 'The freehire address receives what you forward and what employers reply to — nothing else. Connect Gmail instead and the sync is read-only and scoped to job mail: freehire learns which senders write about your applications and leaves the rest of your mailbox alone.',
+    },
+    {
+      n: '02',
+      title: 'A guess is a suggestion, not a decision',
+      body: "An email is linked on its own only when the match is certain — the same thread, or the company's name in the sender or subject. The AI classifier can propose a match, but its pick waits for your confirmation. Read the asymmetry the other way: model output never silently rewrites your board.",
+    },
+    {
+      n: '03',
+      title: 'Leave whenever, in one click',
+      body: 'Disconnect Gmail and the sync stops. Release the freehire address and it stops receiving. Delete a message and it stays deleted — a later re-sync will not resurrect it, because read, deleted and triaged are your state, not the mail server’s.',
+    },
+    {
+      n: '04',
+      title: 'Open, so you can check',
+      body: 'The classifier, the matcher and the stage rules are in the repository. Every claim on this page is a file you can read — including the one that says an out-of-vocabulary answer is stored as “other” instead of being taken at face value.',
+    },
+  ];
+</script>
+
+<!-- The two marks the previews repeat: the initial tile that stands in for a
+     sender's avatar, and the status chip in the product's own colours. -->
+{#snippet initial(name: string, size: string)}
+  <div
+    class="grid {size} shrink-0 place-items-center rounded-lg border border-border font-mono font-medium"
+  >
+    {name.charAt(0).toUpperCase()}
+  </div>
+{/snippet}
+
+{#snippet chip(signal: string, size: string)}
+  <span class="inline-block rounded border px-1.5 {size} {statusClass(signal)}">
+    {statusLabel(signal)}
+  </span>
+{/snippet}
+
+<div class="flex flex-col">
+  <!-- Hero. Left: the pitch. Right: the inbox itself, chips and all. -->
+  <section class="dot-grid -mx-4 grid items-center gap-12 px-4 pb-16 pt-8 lg:grid-cols-[1.05fr_0.95fr]">
+    <div>
+      <SectionLabel text="inbox" />
+      <h1 class="mt-6 max-w-2xl text-balance text-4xl font-semibold leading-[1.0] tracking-tighter sm:text-6xl">
+        Your recruiter replies, sorted automatically.
+      </h1>
+      <p class="mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground">
+        Job mail arrives in one place, tagged with what it actually says — received, rejected,
+        interview, information requested — and attached to the application it belongs to. No folders,
+        no digging through a mailbox to work out where you stand.
+      </p>
+      <div class="mt-9 flex flex-wrap items-center gap-3">
+        <Button href={resolve('/my/inbox')} variant="primary" size="lg">Open your inbox</Button>
+        <Button href={resolve('/my/tracking')} variant="outline" size="lg">See your board</Button>
+      </div>
+    </div>
+
+    <figure class="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+        <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+        freehire · Inbox
+      </figcaption>
+      <ul class="divide-y divide-border">
+        {#each mail as m (m.subject)}
+          <li class="flex items-start gap-3 p-4">
+            {@render initial(m.from, 'size-9 text-sm')}
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2">
+                {#if m.unread}
+                  <span class="size-1.5 shrink-0 rounded-full bg-brand" aria-label="unread"></span>
+                {/if}
+                <p class="truncate text-sm font-medium">{m.from}</p>
+                <span class="ml-auto shrink-0 text-xs text-muted-foreground">{m.when}</span>
+              </div>
+              <p class="mt-0.5 truncate text-sm text-muted-foreground">{m.subject}</p>
+              <span class="mt-2 inline-block">
+                {@render chip(m.signal, 'text-[10px] leading-4')}
+              </span>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    </figure>
+  </section>
+
+  <!-- Connect. The hosted address leads because it works for everyone; Gmail is
+       second while its OAuth app is still in Google review (test users only). -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="connect" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">Two ways to get mail in.</h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        Pick either, or run both — they feed the same inbox.
+      </p>
+    </div>
+
+    <div class="mt-10 grid gap-6 lg:grid-cols-2">
+      <div class="flex flex-col gap-4 rounded-xl border border-border bg-secondary/40 p-6">
+        <div class="flex flex-col gap-1">
+          <span class="font-mono text-sm text-muted-foreground">Recommended</span>
+          <h3 class="text-lg font-semibold tracking-tight">Claim a freehire address</h3>
+        </div>
+        <p class="text-sm leading-relaxed text-muted-foreground">
+          You get an address like <code
+            class="rounded bg-background/70 px-1.5 py-0.5 font-mono text-xs text-foreground">you@mail.freehire.me</code
+          >. Use it when you apply and the replies land here directly, or forward the job mail you
+          already have. Nothing else reaches it, and you can release it at any time.
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-4 rounded-xl border border-border p-6">
+        <div class="flex flex-col gap-1">
+          <span class="font-mono text-sm text-muted-foreground">Or</span>
+          <h3 class="text-lg font-semibold tracking-tight">Connect Gmail, read-only</h3>
+        </div>
+        <p class="text-sm leading-relaxed text-muted-foreground">
+          Sign in with Google once and freehire syncs the job-related mail it finds — it learns the
+          senders that write about your applications rather than reading your whole mailbox.
+          Disconnecting stops the sync immediately. Google is still reviewing the app, so this route
+          is open to test users for now.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Statuses. Rendered from the product's own vocabulary and chip styles. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="statuses" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">It reads each message and tags it.</h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        Every message is classified into one controlled vocabulary — the same eight labels the inbox
+        filters on. Anything that doesn't clearly fit is stored as
+        <code class="font-mono text-foreground">other</code>, never as a guess dressed up as a fact.
+      </p>
+    </div>
+
+    <dl class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each INBOX_STATUS_GUIDE as s (s.signal)}
+        <!-- The chip column is fixed-width so the descriptions line up down the
+             grid instead of stepping in and out with each label's length. -->
+        <div class="flex items-baseline gap-3 bg-background p-5 sm:p-6">
+          <dt class="w-28 shrink-0">{@render chip(s.signal, 'py-0.5 text-xs')}</dt>
+          <dd class="text-sm leading-relaxed text-muted-foreground">{s.description}</dd>
+        </div>
+      {/each}
+    </dl>
+  </section>
+
+  <!-- The board. Where the mail stops being mail and becomes your pipeline. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="on your board" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">
+        Every reply lands on the application it belongs to.
+      </h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        A message is attached automatically when the match is certain — the same thread, or the
+        company's name in the sender or the subject. Otherwise it waits as a suggestion you confirm
+        with one click. Either way the correspondence for a role ends up in one place, on the card,
+        instead of scattered across a mailbox.
+      </p>
+      <div class="mt-8 flex flex-wrap gap-3">
+        <Button href={resolve('/my/tracking')} variant="primary" size="lg">Open Tracking</Button>
+        <Button href={resolve('/my/inbox')} variant="ghost" size="lg">Go to the inbox</Button>
+      </div>
+    </div>
+
+    <figure class="mt-10 overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+        <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+        My jobs · Application
+      </figcaption>
+      <div class="p-5 sm:p-6">
+        <div class="flex flex-wrap items-center gap-3">
+          {@render initial('Speechify', 'size-10 text-sm')}
+          <div class="min-w-0">
+            <p class="truncate font-medium">Tech Lead, Web Core Product</p>
+            <p class="truncate text-sm text-muted-foreground">Speechify</p>
+          </div>
+          <span class="ml-auto">{@render chip('interview_invitation', 'py-0.5 text-xs')}</span>
+        </div>
+
+        <div class="mt-5 flex items-center gap-2 border-b border-border pb-3 text-sm">
+          <span class="text-muted-foreground">Application</span>
+          <span class="text-muted-foreground">Job Match</span>
+          <span class="rounded-full bg-secondary px-2.5 py-1 font-medium">Emails (2)</span>
+        </div>
+
+        <ul class="mt-4 flex flex-col gap-2">
+          {#each linked as m (m.subject)}
+            <li class="flex items-start gap-3 rounded-lg border border-border bg-background p-3">
+              {@render initial(m.from, 'size-8 text-xs')}
+              <div class="min-w-0 flex-1">
+                <p class="truncate text-sm">{m.from}</p>
+                <p class="truncate text-xs text-muted-foreground">{m.subject}</p>
+              </div>
+              <span class="shrink-0">{@render chip(m.signal, 'text-[10px] leading-4')}</span>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    </figure>
+
+    <!-- The stage ladder, and the two rules that keep it honest. The ladder gets
+         a full row of its own so it never wraps mid-arrow. -->
+    <div class="mt-10 flex flex-col gap-6">
+      <ol class="flex flex-wrap items-center gap-x-2 gap-y-3">
+        {#each ladder as stage, i (stage)}
+          <li class="flex items-center gap-2">
+            <span class="rounded-full border border-border px-3 py-1 text-sm">{stage}</span>
+            {#if i < ladder.length - 1}
+              <span class="text-muted-foreground" aria-hidden="true">→</span>
+            {/if}
+          </li>
+        {/each}
+      </ol>
+      <p class="max-w-3xl text-sm leading-relaxed text-muted-foreground">
+        A confident reply nudges the card forward along that ladder, and only forward. It never walks
+        a card back, never touches an application you already settled as rejected, accepted or
+        withdrawn, and a rejection email never moves a card by itself — the outcome stays yours to
+        record.
+      </p>
+    </div>
+  </section>
+
+  <!-- Privacy: the objection this feature has to answer before anything else. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="what we don't do" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">
+        Handing over your mail is a big ask.
+      </h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        So here is the shape of it, written down.
+      </p>
+    </div>
+    <NumberedGrid items={promises} class="mt-10 sm:grid-cols-2" />
+  </section>
+
+  <!-- Agents: the third, unmetered tier. Mirrors HomeView's terminal figure. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="for agents" />
+    <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+      <div>
+        <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+          Bring your own mail client.
+        </h2>
+        <p class="mt-5 max-w-md leading-relaxed text-muted-foreground">
+          If your own harness already fetches mail, push it to
+          <code class="font-mono text-foreground">POST /me/emails</code> and triage it yourself.
+          freehire stores it, links it and shows it on the board like any other message — but never
+          classifies it, so that tier costs nothing to run and nothing to use. Ask the listing for
+          <code class="font-mono text-foreground">?unclassified=1</code> and your harness has its own backlog.
+        </p>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <Button href={resolve('/docs')} variant="primary" size="lg">Read the API docs</Button>
+          <Button href={resolve('/cli')} variant="ghost" size="lg">Explore the CLI</Button>
+        </div>
+      </div>
+
+      <figure class="overflow-hidden rounded-xl border border-border bg-secondary/60 font-mono text-sm shadow-sm">
+        <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+          <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+          terminal
+        </figcaption>
+        <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># push a message your own client fetched</span>
+curl -X POST <span class="text-foreground">https://freehire.me/api/v1/me/emails</span> \
+  -H <span class="text-foreground">"Authorization: Bearer fhk_…"</span> \
+  -d <span class="text-foreground">'&lbrace;"subject":"…","from":"…"&rbrace;'</span>
+
+<span class="text-muted-foreground"># then work through what you haven't triaged</span>
+curl <span class="text-foreground">".../me/emails?unclassified=1&amp;body=1"</span></pre>
+      </figure>
+    </div>
+  </section>
+
+  <!-- FAQ. The visible answers and the FAQPage JSON-LD share INBOX_FAQ. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="faq" />
+    <h2 class="mt-6 max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+      Frequently asked questions.
+    </h2>
+    <dl class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each INBOX_FAQ as item (item.question)}
+        <div class="bg-background p-6 sm:p-7">
+          <dt class="text-lg font-semibold tracking-tight">{item.question}</dt>
+          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
+  </section>
+
+  <!-- Closing CTA. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <div class="flex flex-col items-start gap-4 rounded-xl border border-border bg-secondary/40 p-6 sm:p-8">
+      <h2 class="text-2xl font-semibold tracking-tight">Stop guessing where you stand.</h2>
+      <p class="max-w-xl leading-relaxed text-muted-foreground">
+        Claim your freehire address, apply with it, and watch the replies sort themselves onto your
+        board. It's free, like the rest of freehire.
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <Button href={resolve('/my/inbox')} variant="primary" size="lg">Open your inbox</Button>
+        <Button href={resolve('/')} variant="outline" size="lg">Find jobs to apply to</Button>
+      </div>
+    </div>
+  </section>
+</div>

--- a/web/src/lib/components/NumberedGrid.svelte
+++ b/web/src/lib/components/NumberedGrid.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  // The numbered hairline grid the landing pages use for "01 / 02 / 03" blocks:
+  // cells sit on a `bg-border` grid with `gap-px`, so the one-pixel gaps read as
+  // hairline rules instead of borders that double up between cells.
+  interface NumberedItem {
+    n: string;
+    title: string;
+    body: string;
+  }
+
+  let { items, class: className = '' }: { items: NumberedItem[]; class?: string } = $props();
+</script>
+
+<div class="grid gap-px overflow-hidden rounded-xl border border-border bg-border {className}">
+  {#each items as item (item.n)}
+    <div class="group bg-background p-6 transition-colors hover:bg-secondary/40 sm:p-7">
+      <span class="font-mono text-sm text-muted-foreground transition-colors group-hover:text-foreground">
+        {item.n}
+      </span>
+      <h3 class="mt-4 text-lg font-semibold tracking-tight">{item.title}</h3>
+      <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.body}</p>
+    </div>
+  {/each}
+</div>

--- a/web/src/lib/components/SectionLabel.svelte
+++ b/web/src/lib/components/SectionLabel.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  // The mono `// section` label that heads every section on the landing pages
+  // (home/about, contribute, the feature landings). The `//` is part of the
+  // label, so callers pass the bare section name.
+  let {
+    text,
+    class: className = '',
+    style = '',
+  }: { text: string; class?: string; style?: string } = $props();
+</script>
+
+<p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground {className}" {style}>
+  // {text}
+</p>

--- a/web/src/lib/inboxFaq.test.ts
+++ b/web/src/lib/inboxFaq.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { INBOX_FAQ } from './inboxFaq';
+import { faqPageJsonLd } from './seo';
+
+describe('INBOX_FAQ', () => {
+  it('carries entries', () => {
+    expect(INBOX_FAQ.length).toBeGreaterThan(0);
+  });
+
+  it('asks each question once', () => {
+    const questions = INBOX_FAQ.map((f) => f.question);
+    expect(new Set(questions).size).toBe(questions.length);
+  });
+
+  it('answers every question', () => {
+    for (const { question, answer } of INBOX_FAQ) {
+      expect(question.trim(), `question: ${question}`).not.toBe('');
+      expect(answer.trim(), `answer to: ${question}`).not.toBe('');
+    }
+  });
+
+  // Google drops the rich result when the structured data and the visible text
+  // disagree, so the page renders this same array — the JSON-LD is derived, not
+  // written twice.
+  it('feeds the FAQPage payload', () => {
+    const jsonLd = faqPageJsonLd(INBOX_FAQ) as { mainEntity: { name: string }[] };
+    expect(jsonLd.mainEntity.map((e) => e.name)).toEqual(INBOX_FAQ.map((f) => f.question));
+  });
+});

--- a/web/src/lib/inboxFaq.ts
+++ b/web/src/lib/inboxFaq.ts
@@ -1,0 +1,40 @@
+// Inbox landing FAQ — the single source for both the visible section
+// (InboxLandingView.svelte) and the FAQPage JSON-LD (routes/features/inbox).
+// Google requires the schema's answers to match the on-page text, so they share
+// this. Answers are written answer-first and stay honest to what the mail stack
+// actually does (internal/mailclassify, internal/maillink).
+
+import type { FaqItem } from './seo';
+
+export const INBOX_FAQ: FaqItem[] = [
+  {
+    question: 'How does freehire get my job emails?',
+    answer:
+      'Two ways. Every account can claim a freehire address — you forward recruiter mail to it, or use it when you apply, and replies land there directly. Or you connect Gmail read-only, and freehire syncs the job-related mail it finds. Both feed the same inbox; you can use either or both.',
+  },
+  {
+    question: 'Does freehire read all of my email?',
+    answer:
+      'No. The hosted address only ever receives what you forward or what employers send to it — freehire never sees the rest of your mailbox. The Gmail connection is read-only and scoped to job-related mail: freehire learns which senders write about your applications and syncs those. You can disconnect Gmail or release the freehire address at any time.',
+  },
+  {
+    question: 'How does an email get attached to the right application?',
+    answer:
+      'By matching the mail thread, or the company name carried in the sender name or subject. When that match is certain, the email is linked to the application automatically. When it is not, freehire offers it as a suggestion for you to confirm — the AI classifier can propose a match, but it never links one on its own.',
+  },
+  {
+    question: 'What statuses can an email be tagged with?',
+    answer:
+      'Acknowledgement, screening, interview invitation, assessment, offer, rejection, information request, and an unfinished application you started but never submitted. Anything that does not fit one of those is recorded as "other" rather than guessed at.',
+  },
+  {
+    question: 'What if an email is attached to the wrong application?',
+    answer:
+      'Unlink it and pick the right one — every link is reversible from the message itself. If the mail is about a job you never recorded, one action creates the application from it and links it in the same step, dated by the email rather than by today.',
+  },
+  {
+    question: 'Will it move cards on my tracking board by itself?',
+    answer:
+      'Only forward, and only for a linked email it is confident about: applied, then screening, responded, interview, offer. A card never moves backwards, an application you already marked as rejected, accepted or withdrawn is never touched automatically, and a rejection email never moves a card on its own — you stay in control of the outcome.',
+  },
+];

--- a/web/src/lib/inboxStatusGuide.test.ts
+++ b/web/src/lib/inboxStatusGuide.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { STATUS_LABELS } from './emailStatus';
+import { INBOX_STATUS_GUIDE } from './inboxStatusGuide';
+
+describe('INBOX_STATUS_GUIDE', () => {
+  // The landing page claims to list what the classifier can tag. If a signal is
+  // added to the vocabulary and not explained here, the page quietly becomes a
+  // partial list that reads as a complete one.
+  it('explains every signal the product labels', () => {
+    const labelled = Object.keys(STATUS_LABELS).filter((s) => STATUS_LABELS[s] !== '');
+    expect(INBOX_STATUS_GUIDE.map((s) => s.signal).sort()).toEqual(labelled.sort());
+  });
+
+  it('describes each signal', () => {
+    for (const { signal, description } of INBOX_STATUS_GUIDE) {
+      expect(description.trim(), `description for: ${signal}`).not.toBe('');
+    }
+  });
+});

--- a/web/src/lib/inboxStatusGuide.ts
+++ b/web/src/lib/inboxStatusGuide.ts
@@ -1,0 +1,24 @@
+// The status vocabulary as the inbox landing page explains it: one entry per
+// signal the classifier can label an email with, in pipeline order. The labels
+// and badge colours come from `emailStatus.ts` — the same source the real inbox
+// renders from — so the page shows the product's own chips, and a test pins this
+// list to that vocabulary so a new signal can't leave the page silently partial.
+//
+// `other` is deliberately absent: it is the sanitizer's fallback for anything
+// out of vocabulary, not a status worth advertising. The page says so in prose.
+
+export interface InboxStatusEntry {
+  signal: string;
+  description: string;
+}
+
+export const INBOX_STATUS_GUIDE: InboxStatusEntry[] = [
+  { signal: 'acknowledgement', description: 'They got your application.' },
+  { signal: 'screening', description: 'A recruiter screen or first call.' },
+  { signal: 'assessment', description: 'A take-home or a test to complete.' },
+  { signal: 'interview_invitation', description: 'An interview is on the table.' },
+  { signal: 'offer', description: 'An offer arrived.' },
+  { signal: 'rejection', description: 'A no — recorded, never guessed at.' },
+  { signal: 'info_request', description: 'They need something from you.' },
+  { signal: 'incomplete_application', description: 'You started an application and never sent it.' },
+];

--- a/web/src/lib/sitemap.test.ts
+++ b/web/src/lib/sitemap.test.ts
@@ -6,6 +6,17 @@ describe('sitemap static paths', () => {
     expect(STATIC_PATHS).toContain('/collections');
     expect(STATIC_PATHS).toContain('/for-companies');
   });
+
+  it('includes the feature landings', () => {
+    expect(STATIC_PATHS).toContain('/features/inbox');
+    expect(STATIC_PATHS).toContain('/features/referrals');
+  });
+
+  // /referrals now answers with a 301 to its new home. Listing a redirect in the
+  // sitemap tells crawlers to index the address that no longer serves the page.
+  it('drops the moved referrals URL', () => {
+    expect(STATIC_PATHS).not.toContain('/referrals');
+  });
 });
 
 describe('collectionPaths', () => {

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -20,7 +20,8 @@ export const STATIC_PATHS = [
   '/cli',
   '/chatgpt',
   '/recruiters',
-  '/referrals',
+  '/features/inbox',
+  '/features/referrals',
 ];
 
 /** The curated collection landing pages (`/collections/:slug`), one per collection.

--- a/web/src/routes/features/inbox/+page.svelte
+++ b/web/src/routes/features/inbox/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import InboxLandingView from '$lib/components/InboxLandingView.svelte';
+  import Seo from '$lib/components/Seo.svelte';
+  import { INBOX_FAQ } from '$lib/inboxFaq';
+  import { faqPageJsonLd, jsonLdScript } from '$lib/seo';
+
+  const canonical = $derived(`${page.url.origin}/features/inbox`);
+  // The FAQ block and this payload render from the same INBOX_FAQ array, so the
+  // structured data can never disagree with what the page shows.
+  const jsonLd = $derived(jsonLdScript([faqPageJsonLd(INBOX_FAQ)]));
+</script>
+
+<Seo
+  title="Inbox — recruiter replies, sorted onto your board | freehire"
+  description="freehire reads your job mail and tags what it says — received, rejected, interview, information requested — then attaches each reply to the application it belongs to and moves the card forward. Connect Gmail read-only, or claim a freehire address and apply with it."
+  {canonical}
+/>
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <InboxLandingView />
+</div>

--- a/web/src/routes/features/referrals/+page.svelte
+++ b/web/src/routes/features/referrals/+page.svelte
@@ -3,7 +3,7 @@
   import ReferralsLandingView from '$lib/components/ReferralsLandingView.svelte';
   import Seo from '$lib/components/Seo.svelte';
 
-  const canonical = $derived(`${page.url.origin}/referrals`);
+  const canonical = $derived(`${page.url.origin}/features/referrals`);
 </script>
 
 <Seo

--- a/web/src/routes/referrals/+page.server.ts
+++ b/web/src/routes/referrals/+page.server.ts
@@ -1,0 +1,9 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+// The referrals landing moved under /features. The old URL is public — it has
+// been in the sitemap and shared externally — so it keeps answering, with a
+// permanent redirect that hands the ranking to the new address.
+export const load: PageServerLoad = () => {
+  redirect(301, '/features/referrals');
+};


### PR DESCRIPTION
## Why

The mail stack has been live with nothing public explaining it. A visitor who isn't signed in can't discover the inbox at all; a signed-in one meets `/my/inbox` with no account connected and no reason given to connect one. The five-slide carousel that announced the feature already carried a working narrative — this turns it into a page on the site.

## What's here

**`/features/inbox`** — how mail gets in (hosted address / Gmail), what the classifier tags, how a tagged email links to an application and moves its card, what we don't read, and how an agent harness pushes its own mail. Plus a FAQ with `FAQPage` JSON-LD.

**Claims pinned to code, not written freehand:**

- The status section renders from `emailStatus.ts` — the same source the real inbox filter uses — and `inboxStatusGuide.test.ts` fails if a signal joins the vocabulary without being explained on the page.
- The copy says auto-linking happens on a *deterministic* match and that a model's pick is only a suggestion, because that asymmetry is what `maillink` implements.
- It says a card moves only forward and never out of a settled stage, because that's `AdvanceStage`.
- The hosted address leads and Gmail is second: Gmail sync runs under an unverified restricted-scope OAuth app, so leading with it would send most visitors into a consent screen that rejects them.

**Previews are markup, not screenshots.** The carousel's PNGs are light-theme, carry a real address, and freeze a UI that changes.

**`/referrals` moves to `/features/referrals`** (301 left behind), so `/features` holds the two pages it describes rather than one page and a promise. The footer grows a Features group (three columns → four), and the home/about pages link both.

**`SectionLabel` and `NumberedGrid`** come out of `HomeView`/`AboutValues`/`ContributeLandingView`, where they were repeated verbatim — deduplication of what exists, not a landing-page framework.

## Verification

- `pnpm test` — 42 files, 414 tests green (8 new)
- `pnpm lint`, `svelte-check` (0 errors), `pnpm build` green
- Visual pass in headless Chrome, light and dark; `/`, `/about`, `/contribute` checked for regressions after the primitive extraction
- `/referrals` → 301 → `/features/referrals` verified

OpenSpec change: `openspec/changes/inbox-feature-landing/`