### PR TITLE
docs(web): point the agent story at the CLI, and let /cli show the whole CLI

### DIFF
--- a/docs/superpowers/specs/2026-07-28-experience-bank-assistant-entry-design.md
+++ b/docs/superpowers/specs/2026-07-28-experience-bank-assistant-entry-design.md
@@ -1,0 +1,128 @@
+# The experience bank's way into the assistant
+
+**Date:** 2026-07-28
+**Status:** approved, not yet implemented
+
+## Problem
+
+The experience bank offers one route into the interviewer that fills it — a button reading
+"Add more with the assistant", carrying a `Sparkles` icon, linking to
+`/my/assistant?preset=profile` (`web/src/lib/components/ExperienceBankView.svelte:120`).
+
+Three things are wrong with it.
+
+1. **It names the tool, not the outcome.** "Add more with the assistant" tells someone
+   which machine to talk to, never what to say or in what shape. The `Sparkles` glyph — the
+   only one in the whole frontend — adds nothing but the house style of every AI feature
+   shipped in the last two years.
+2. **The chat opens empty.** `?preset=profile` creates a session under the interviewer's
+   system prompt and then waits. The prompt (`internal/assistant/prompt.go:69`) already
+   tells the agent to call `get_profile` + `experience_employments`, find the thinnest gap
+   and ask one question — but no turn runs until a user message arrives, so the person who
+   clicked "add an achievement" lands on a blank composer and has to invent an opening line.
+3. **There is no entry at all when the bank is empty.** At zero records the view renders a
+   bare `States` message (`ExperienceBankView.svelte:106-110`) with no button — the state
+   where the interviewer is most useful is the state that hides it.
+
+## The routing trap
+
+The obvious fix — pass the existing `kickoff` prop (`AssistantChat.svelte:228`) from
+`/my/assistant` — does not work, and fails in a way that is worse than the current
+behaviour.
+
+`/my/assistant` and `/my/assistant/[id]` are two separate `+page.svelte` files, each
+mounting its own `<AssistantChat>`. Arriving with `?preset=profile` runs:
+
+```
+boot() → createAndOpen() → openSession() → onSessionChange(id)
+       → goto('/my/assistant/<id>', {replaceState:true})   [async]
+       → phase = 'ready' → dispatch(kickoff)               [SSE turn starts]
+       ⋯ navigation lands: old page unmounts
+       → onMount cleanup: cancelTurn() → turn aborted
+```
+
+The backend persists the user prompt before the abort lands, so the freshly mounted page
+replays a transcript holding the candidate's own message and no answer. This is the same
+class of race fixed in 7a7b70fc ("a new chat is no longer evicted by the URL it just
+left"); its root is one surface living in two route nodes.
+
+## Design
+
+### 1. Copy
+
+In `ExperienceBankView.svelte`, drop the `Sparkles` import and its element. The button
+reads **"Add an achievement"** and is followed by an example line:
+
+> Tell the assistant what you did — "I cut checkout latency by 40% in one quarter."
+
+The example carries the work: it shows the expected grain of an answer (one concrete
+result, ideally with a number) before the chat is even open, which is exactly what the
+interviewer will ask for. The word "assistant" survives, demoted from the button label to
+the hint.
+
+The empty state keeps its explanatory sentence and gains the same button + hint pair
+beneath it, so a bank with nothing in it offers the same way out as a bank with twelve
+entries.
+
+### 2. The kickoff line
+
+One shared constant in `web/src/lib/assistant/presets.ts`, so the button and the chat quote
+the same source:
+
+> Walk through my experience with me — start with whatever is thinnest, and help me fill in
+> the achievements that are missing.
+
+Deliberately short. It is not a second system prompt: `profilePrompt` already carries the
+method (start from `get_profile` + `experience_employments`, pick ONE gap, ask one question
+at a time). The kickoff exists so a turn starts at all.
+
+### 3. Merge the two assistant pages into `/my/assistant/[[id]]`
+
+`web/src/routes/my/assistant/[id]/+page.svelte` and `.../+page.svelte` collapse into a
+single optional-parameter route. One route node means the component is no longer
+remounted when the entry URL is rewritten to the session's own address, which:
+
+- makes the kickoff survive the rewrite (the whole point);
+- removes the second, wasted `boot()` that runs on every visit to `/my/assistant` today;
+- removes the source of the URL-versus-active-session race rather than guarding it again.
+
+Behaviour to preserve exactly:
+
+- **No id in the path** → open the newest session, else create one; rewrite the URL to that
+  session with `replaceState` (landing on `/my/assistant` is a redirect, not a history
+  step).
+- **Id in the path** → open that session; switching sessions from the rail pushes a new
+  history entry so Back returns to the previous chat.
+- `?preset=profile` still forces a NEW session rather than resuming the newest
+  (`AssistantChat.svelte:205`), and now also supplies `kickoff`. Every other way into the
+  assistant — the nav rail, a bookmarked session, the rail's "New chat" — passes no
+  kickoff and opens silent, exactly as today.
+
+Call sites to update: `resolve('/my/assistant/[id]', …)` in both page files (one survives),
+and `resolve('/my/assistant')` in `AssistantChat.svelte:453`. The plain `'/my/assistant'`
+href in `accountNav.ts` needs no change — the optional-parameter route matches it.
+
+### Re-entry
+
+`kickoff` is dispatched only when `chat.messages.length === 0` (already the guard). A reload
+of a session that has history re-sends nothing. A second click of "Add an achievement"
+creates a second session and starts a second interview, which is the intended reading of
+the button.
+
+## Non-goals
+
+- The spinner glyphs (`✢ ✳ ✶ ✻ ✽`) in the chat's thinking indicator stay. They were
+  considered and explicitly kept.
+- No new preset, no backend change. `PresetProfile` and `profilePrompt` are untouched.
+- No starter-prompt chips in the empty chat. That would serve every entry into the
+  assistant, not this one, and belongs to its own change.
+
+## Testing
+
+- `web/src/lib/assistant/presets.test.ts` — the preset map resolves `profile` to a kickoff
+  and `chat` to none.
+- Existing `sessions.test.ts` and `accountNav.test.ts` must stay green (the latter asserts
+  the `/my/assistant` href, which the route merge must not break).
+- Manual: `/my/profile` → Experience tab → "Add an achievement" → the chat opens on a new
+  session, the kickoff appears as the candidate's message, and the agent answers with a
+  single question about a thin part of the bank. Reload mid-answer must not re-send it.

--- a/web/src/lib/components/CliView.svelte
+++ b/web/src/lib/components/CliView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { Button } from '$lib/ui';
+  import SectionLabel from '$lib/components/SectionLabel.svelte';
 
   const CLI_REPO = 'https://github.com/strelov1/freehire-cli';
   const MCP_REPO = 'https://github.com/strelov1/freehire-mcp';
@@ -27,6 +28,25 @@
     { cmd: 'stage <slug> <stage>', desc: 'Set the application stage.' },
     { cmd: 'note <slug> <text>', desc: 'Attach a free-text note.' },
     { cmd: 'my --filter applied', desc: 'Your tracked jobs (all|viewed|saved|applied).' },
+    { cmd: 'profile', desc: 'Your saved search profile — skills, seniority, regions.' },
+  ];
+
+  // Application mail. The whole inbox surface is here because freehire fetches
+  // nothing on this tier: your own client does, and `inbox push` hands it over.
+  const inbox = [
+    { cmd: 'inbox push --file mail.json', desc: 'Upload a batch your own client fetched (keyed by Message-ID, so a re-sync updates instead of duplicating).' },
+    { cmd: 'inbox list --unclassified --body', desc: "The agent's work queue: unjudged mail with bodies inline, and nothing gets marked read." },
+    { cmd: 'inbox triage <id> <signal>', desc: 'Record what a message is; a confident verdict moves the application forward.' },
+    { cmd: 'inbox list --link suggested', desc: 'Proposed links awaiting your word — inbox confirm / inbox reject.' },
+    { cmd: 'inbox list --link unlinked', desc: 'Mail with no application to attach to — inbox application records one from the message.' },
+  ];
+
+  // Widening the catalogue, and the moderator queue behind it.
+  const contribute = [
+    { cmd: 'contribute <url>', desc: "Hand freehire a job link; a board we don't track yet earns a credit." },
+    { cmd: 'contributions', desc: "The boards you've contributed and their state." },
+    { cmd: 'submissions', desc: 'Jobs you submitted; the review queue with pending/approve/reject (moderator).' },
+    { cmd: 'jobs add | edit <slug>', desc: 'Create or edit a job posting (moderator).' },
   ];
 
   // Tasteful micro-interaction: copy the install one-liner, flash a confirmation.
@@ -51,9 +71,7 @@
   <section class="grid-bg relative -mx-4 px-4 pb-16 pt-12 sm:pt-16">
     <div class="grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
       <div>
-        <p class="reveal font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground" style="--d:0ms">
-          // freehire on the command line
-        </p>
+        <SectionLabel text="freehire on the command line" class="reveal" style="--d:0ms" />
 
         <h1
           class="reveal mt-6 max-w-2xl text-balance text-4xl font-semibold leading-[0.98] tracking-tighter sm:text-6xl"
@@ -66,9 +84,13 @@
           <code class="font-mono text-foreground">freehire</code> is a small CLI — and an
           <a href="#mcp" class="text-foreground underline-offset-4 hover:underline">MCP server</a> — over the
           same job API the site runs on. One <span class="text-foreground">API key</span> lets an
-          <span class="text-foreground">AI agent</span> or a script search and open jobs, then track
-          applications and notes without a browser. (You still apply on the employer's site; the CLI records
-          that you did.)
+          <span class="text-foreground">AI agent</span> or a script search and open jobs, track
+          applications, work through your
+          <a href={resolve('/features/inbox')} class="text-foreground underline-offset-4 hover:underline"
+            >application mail</a
+          >
+          and tailor a CV to a vacancy — all without a browser. (You still apply on the employer's site;
+          the CLI records that you did.)
         </p>
 
         <div class="reveal mt-9 flex flex-wrap items-center gap-3" style="--d:240ms">
@@ -111,7 +133,7 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
 
   <!-- Commands — the whole reference, compact. -->
   <section class="border-t border-border py-14 sm:py-16">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// commands</p>
+    <SectionLabel text="commands" />
     <div class="mt-8 grid gap-x-12 gap-y-8 sm:grid-cols-2">
       <div>
         <h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Discover</h2>
@@ -132,6 +154,36 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
         </h2>
         <dl class="mt-4 space-y-3">
           {#each track as row (row.cmd)}
+            <div>
+              <dt class="font-mono text-sm">
+                <span class="text-muted-foreground">freehire</span> {row.cmd}
+              </dt>
+              <dd class="text-sm leading-relaxed text-muted-foreground">{row.desc}</dd>
+            </div>
+          {/each}
+        </dl>
+      </div>
+      <div>
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Application mail
+        </h2>
+        <dl class="mt-4 space-y-3">
+          {#each inbox as row (row.cmd)}
+            <div>
+              <dt class="font-mono text-sm">
+                <span class="text-muted-foreground">freehire</span> {row.cmd}
+              </dt>
+              <dd class="text-sm leading-relaxed text-muted-foreground">{row.desc}</dd>
+            </div>
+          {/each}
+        </dl>
+      </div>
+      <div>
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Contribute &amp; moderate
+        </h2>
+        <dl class="mt-4 space-y-3">
+          {#each contribute as row (row.cmd)}
             <div>
               <dt class="font-mono text-sm">
                 <span class="text-muted-foreground">freehire</span> {row.cmd}
@@ -169,18 +221,22 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
       </h3>
       <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
         After a fit analysis, reframe your CV toward one job — grounded in what you actually did, never
-        fabricated — then export an ATS-ready PDF.
+        fabricated — then export an ATS-ready PDF. <code class="font-mono text-foreground">cv context</code>
+        is the honest part: it splits the job's requirements into the ones your history already covers but
+        buries (reframe those) and the ones it doesn't (ask, don't invent), so an agent editing your CV
+        knows which is which.
       </p>
       <pre
         class="mt-3 overflow-x-auto rounded-md border border-border bg-background/60 p-3 font-mono text-sm leading-relaxed"><span class="text-muted-foreground">freehire</span> cv context &lt;id&gt;        <span class="text-muted-foreground"># the fit analysis to reframe toward</span>
-<span class="text-muted-foreground">freehire</span> cv edit &lt;id&gt; --patch …  <span class="text-muted-foreground"># apply a field-level edit</span>
+<span class="text-muted-foreground">freehire</span> cv get &lt;id&gt;            <span class="text-muted-foreground"># the CV document as JSON</span>
+<span class="text-muted-foreground">freehire</span> cv edit &lt;id&gt; --patch …  <span class="text-muted-foreground"># apply one field-level edit</span>
 <span class="text-muted-foreground">freehire</span> cv render &lt;id&gt; --out cv.pdf</pre>
     </div>
   </section>
 
   <!-- MCP — the second surface over the same API and the same key. -->
   <section id="mcp" class="scroll-mt-20 border-t border-border py-14 sm:py-16">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// mcp</p>
+    <SectionLabel text="mcp" />
     <div class="mt-8 grid gap-x-12 gap-y-8 lg:grid-cols-[0.95fr_1.05fr]">
       <div>
         <h2 class="text-2xl font-semibold tracking-tight">Same key, any AI host</h2>
@@ -231,7 +287,7 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
 
   <!-- For AI agents — the drop-in skill and the machine-readable conventions. -->
   <section class="border-t border-border py-14 sm:py-16">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// for ai agents</p>
+    <SectionLabel text="for ai agents" />
     <p class="mt-6 max-w-2xl leading-relaxed text-muted-foreground">
       A drop-in
       <a
@@ -253,7 +309,7 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
 
   <!-- Moderators — gated authoring, kept to one line + two commands. -->
   <section class="border-t border-border py-14 sm:py-16">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// moderators</p>
+    <SectionLabel text="moderators" />
     <p class="mt-6 max-w-2xl leading-relaxed text-muted-foreground">
       With the <code class="font-mono text-foreground">moderator</code> role you can author postings:
     </p>

--- a/web/src/lib/components/InboxLandingView.svelte
+++ b/web/src/lib/components/InboxLandingView.svelte
@@ -310,15 +310,23 @@
           Bring your own mail client.
         </h2>
         <p class="mt-5 max-w-md leading-relaxed text-muted-foreground">
-          If your own harness already fetches mail, push it to
-          <code class="font-mono text-foreground">POST /me/emails</code> and triage it yourself.
-          freehire stores it, links it and shows it on the board like any other message — but never
-          classifies it, so that tier costs nothing to run and nothing to use. Ask the listing for
-          <code class="font-mono text-foreground">?unclassified=1</code> and your harness has its own backlog.
+          The whole inbox is in the freehire CLI, so your own client — himalaya, mbsync, anything
+          that speaks IMAP — can fetch the mail and hand it over with
+          <code class="font-mono text-foreground">inbox push</code>. Each message is keyed by its
+          Message-ID, so a nightly re-sync updates rather than duplicates. freehire stores it, links
+          it and shows it on the board like any other message, but never classifies it: that tier
+          costs nothing to run and nothing to use.
+        </p>
+        <p class="mt-4 max-w-md leading-relaxed text-muted-foreground">
+          <code class="font-mono text-foreground">inbox list --unclassified --body</code> is then
+          your agent's work queue — a whole page of messages to judge in one call, and unlike
+          <code class="font-mono text-foreground">inbox read</code> it marks nothing read.
+          <code class="font-mono text-foreground">inbox triage</code> records the verdict and moves
+          the application's stage.
         </p>
         <div class="mt-8 flex flex-wrap gap-3">
-          <Button href={resolve('/docs')} variant="primary" size="lg">Read the API docs</Button>
-          <Button href={resolve('/cli')} variant="ghost" size="lg">Explore the CLI</Button>
+          <Button href={resolve('/cli')} variant="primary" size="lg">Get the CLI</Button>
+          <Button href={resolve('/docs/api')} variant="ghost" size="lg">API reference</Button>
         </div>
       </div>
 
@@ -327,13 +335,19 @@
           <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
           terminal
         </figcaption>
-        <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># push a message your own client fetched</span>
-curl -X POST <span class="text-foreground">https://freehire.me/api/v1/me/emails</span> \
-  -H <span class="text-foreground">"Authorization: Bearer fhk_…"</span> \
-  -d <span class="text-foreground">'&lbrace;"subject":"…","from":"…"&rbrace;'</span>
+        <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># hand over a batch your client fetched (external_id = Message-ID,</span>
+<span class="text-muted-foreground"># so re-pushing updates instead of duplicating)</span>
+freehire <span class="text-foreground">inbox push --file mail.json</span>
 
-<span class="text-muted-foreground"># then work through what you haven't triaged</span>
-curl <span class="text-foreground">".../me/emails?unclassified=1&amp;body=1"</span></pre>
+<span class="text-muted-foreground"># the work queue: unjudged mail, bodies inline, nothing marked read</span>
+freehire <span class="text-foreground">inbox list --unclassified --body</span>
+
+<span class="text-muted-foreground"># record the verdict; the application's stage follows</span>
+freehire <span class="text-foreground">inbox triage &lt;id&gt; interview_invitation --slug &lt;job&gt;</span>
+
+<span class="text-muted-foreground"># the queues the matcher won't guess at</span>
+freehire <span class="text-foreground">inbox list --link suggested</span>   <span class="text-muted-foreground"># confirm / reject</span>
+freehire <span class="text-foreground">inbox list --link unlinked</span>    <span class="text-muted-foreground"># inbox application</span></pre>
       </figure>
     </div>
   </section>


### PR DESCRIPTION
First of three follow-ups after #1219.

## The inbox landing's agent section

Was a curl transcript. The API is fine, but the CLI is what we want people to reach for — and it already carries the entire inbox surface, including the parts the raw endpoints make you assemble by hand:

- `inbox list --unclassified --body` — the agent's work queue, bodies inline, marks nothing read
- `--link suggested` / `--link unlinked` — the two queues the matcher deliberately won't guess at

The push example also now says what `inbox push` actually wants (a JSON batch keyed by Message-ID, so a re-sync updates instead of duplicating) rather than implying a mail client's output pipes straight in.

## /cli

Listed 10 commands out of ~40 — `inbox`, `profile`, `contribute`, `contributions`, `submissions` and the moderator job authoring were invisible to anyone reading the page. Adds two groups (Application mail, Contribute & moderate) and expands the CV-tailoring block to explain what `cv context` is for: the split between requirements your history already covers but buries, and the ones it doesn't — the line between reframing and inventing.

Four `// section` labels migrate onto `SectionLabel` from #1219.

## Still to come

2. `/docs/api` — 58 of 168 routes are documented; the whole mail surface is missing
3. A landing for CV tailoring, which is currently described nowhere but this page

## Verification

`pnpm test` (414), `pnpm lint`, `svelte-check` (0 errors) green; both pages checked in headless Chrome.