### PR TITLE
feat(web): a landing for CV tailoring, the feature described nowhere

### DIFF
--- a/web/src/lib/components/CliView.svelte
+++ b/web/src/lib/components/CliView.svelte
@@ -220,7 +220,7 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
         >
       </h3>
       <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
-        After a fit analysis, reframe your CV toward one job — grounded in what you actually did, never
+        After a fit analysis, <a href={resolve('/features/tailor')} class="font-medium text-foreground underline-offset-4 hover:underline">reframe your CV</a> toward one job — grounded in what you actually did, never
         fabricated — then export an ATS-ready PDF. <code class="font-mono text-foreground">cv context</code>
         is the honest part: it splits the job's requirements into the ones your history already covers but
         buries (reframe those) and the ones it doesn't (ask, don't invent), so an agent editing your CV

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -20,6 +20,7 @@
       title: 'Features',
       links: [
         { label: 'Inbox', href: resolve('/features/inbox') },
+        { label: 'CV tailoring', href: resolve('/features/tailor') },
         { label: 'Referrals', href: resolve('/features/referrals') },
       ],
     },

--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -109,6 +109,12 @@
       cta: 'How the inbox works',
     },
     {
+      href: resolve('/features/tailor'),
+      title: 'CV tailoring',
+      body: 'Reframe your CV toward one vacancy — pulling forward the experience you already have but buried, and asking about anything your history does not support.',
+      cta: 'How tailoring works',
+    },
+    {
       href: resolve('/features/referrals'),
       title: 'Referrals',
       body: 'Ask an employee inside the company to put your name forward — anonymously and for free — instead of applying cold.',

--- a/web/src/lib/components/TailorLandingView.svelte
+++ b/web/src/lib/components/TailorLandingView.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { Button } from '$lib/ui';
+  import NumberedGrid from '$lib/components/NumberedGrid.svelte';
+  import SectionLabel from '$lib/components/SectionLabel.svelte';
+  import { TAILOR_FAQ } from '$lib/tailorFaq';
+
+  // The requirement split the tailoring context hands the agent. This is the
+  // whole honesty argument of the feature, so it leads the page: what your
+  // history covers is reframed, what it doesn't is asked about, never written.
+  const split = [
+    {
+      key: 'have',
+      title: 'Already yours, buried',
+      body: 'Requirements your history covers but the CV states in passing, or three roles down. These get pulled forward and said plainly.',
+      sample: ['Kafka at scale', 'Payments migrations', 'Mentoring'],
+    },
+    {
+      key: 'gap',
+      title: 'Not yours yet',
+      body: "Requirements nothing in your history supports. The agent asks you before anything is written — it cannot fill these in on its own.",
+      sample: ['Kubernetes operators', 'Rust'],
+    },
+  ];
+
+  // The one-operation-at-a-time patch vocabulary (internal/cv/patch.go). Listed
+  // so the page's "you can see every edit" claim is concrete rather than a mood.
+  const ops = [
+    'set_summary',
+    'set_header_field',
+    'add_bullet',
+    'replace_bullet',
+    'remove_bullet',
+    'reorder_bullets',
+    'set_skill_group',
+    'set_stack',
+  ];
+
+  const steps = [
+    {
+      n: '01',
+      title: 'Analyse the fit',
+      body: 'Run the AI fit analysis on the vacancy. It scores the match dimension by dimension and names what is missing — the reasoning the tailored CV will work from.',
+    },
+    {
+      n: '02',
+      title: 'Tailor from the result',
+      body: 'One click copies your base CV into a new one bound to that vacancy. Your original is untouched; each job gets its own copy, so nothing you tailor bleeds into the next application.',
+    },
+    {
+      n: '03',
+      title: 'Edit with the agent, or by hand',
+      body: 'The agent reads the analysis and your CV before it says anything, then proposes edits one at a time. The editor is right there — you can overrule any of it and type your own.',
+    },
+    {
+      n: '04',
+      title: 'Export',
+      body: 'Pick a template and download the PDF. Switching templates never touches the content, so you can see the same CV three ways before you send it.',
+    },
+  ];
+</script>
+
+<div class="flex flex-col">
+  <!-- Hero. Left: the pitch. Right: the workspace, as three columns. -->
+  <section class="dot-grid -mx-4 grid items-center gap-12 px-4 pb-16 pt-8 lg:grid-cols-[1.05fr_0.95fr]">
+    <div>
+      <SectionLabel text="cv tailoring" />
+      <h1 class="mt-6 max-w-2xl text-balance text-4xl font-semibold leading-[1.0] tracking-tighter sm:text-6xl">
+        Rewrite your CV for one job. Invent nothing.
+      </h1>
+      <p class="mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground">
+        A generic CV loses to a specific one, and a fabricated one loses the interview. freehire
+        reframes what you have actually done toward the vacancy in front of you — pulling the
+        relevant work forward, saying it in the job's own terms, and asking you about anything it
+        cannot find in your history.
+      </p>
+      <div class="mt-9 flex flex-wrap items-center gap-3">
+        <Button href={resolve('/')} variant="primary" size="lg">Find a job to tailor for</Button>
+        <Button href={resolve('/my/cvs')} variant="outline" size="lg">Your CVs</Button>
+      </div>
+    </div>
+
+    <!-- Workspace preview: the real three-column layout, in miniature. -->
+    <figure class="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+        <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+        freehire · Tailoring
+      </figcaption>
+      <div class="grid gap-px bg-border sm:grid-cols-[1fr_1.1fr_0.85fr]">
+        <div class="bg-background p-3">
+          <div class="flex gap-2 text-[11px]">
+            <span class="rounded-full bg-secondary px-2 py-0.5 font-medium">Chat</span>
+            <span class="text-muted-foreground">Editor</span>
+          </div>
+          <div class="mt-3 flex flex-col gap-2">
+            <p class="rounded-lg border border-border px-2.5 py-2 text-[11px] leading-relaxed text-muted-foreground">
+              Your Acme role already covers the event-bus requirement — want me to lead with it?
+            </p>
+            <p class="ml-4 rounded-lg bg-secondary px-2.5 py-2 text-[11px] leading-relaxed">Yes, and drop the CMS line.</p>
+          </div>
+        </div>
+        <div class="bg-background p-3">
+          <p class="text-[11px] text-muted-foreground">Preview</p>
+          <div class="mt-3 space-y-1.5">
+            <div class="h-2 w-2/3 rounded bg-foreground/70"></div>
+            <div class="h-1.5 w-1/3 rounded bg-muted-foreground/30"></div>
+            <div class="mt-3 h-1.5 w-full rounded bg-muted-foreground/25"></div>
+            <div class="h-1.5 w-11/12 rounded bg-muted-foreground/25"></div>
+            <div class="h-1.5 w-4/5 rounded bg-brand/40"></div>
+            <div class="h-1.5 w-full rounded bg-muted-foreground/25"></div>
+            <div class="h-1.5 w-3/4 rounded bg-muted-foreground/25"></div>
+          </div>
+        </div>
+        <div class="bg-background p-3">
+          <div class="flex gap-2 text-[11px]">
+            <span class="rounded-full bg-secondary px-2 py-0.5 font-medium">Verdict</span>
+            <span class="text-muted-foreground">Job</span>
+          </div>
+          <div class="mt-3">
+            <p class="text-2xl font-semibold tabular-nums">72</p>
+            <p class="text-[11px] text-muted-foreground">worth applying</p>
+            <div class="mt-3 space-y-1.5">
+              <div class="h-1.5 w-full rounded bg-emerald-500/40"></div>
+              <div class="h-1.5 w-2/3 rounded bg-amber-500/40"></div>
+              <div class="h-1.5 w-1/3 rounded bg-destructive/40"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </figure>
+  </section>
+
+  <!-- The split. The argument for why this isn't a lying machine. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="reframe, don't fabricate" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">
+        It knows the difference between burying something and not having it.
+      </h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        Before the agent writes a word, it reads the fit analysis for this vacancy and sorts the
+        job's requirements into two piles. That split is the whole feature: one pile is editing,
+        the other is a question.
+      </p>
+    </div>
+
+    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each split as s (s.key)}
+        <div class="bg-background p-6 sm:p-7">
+          <h3 class="text-lg font-semibold tracking-tight">{s.title}</h3>
+          <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{s.body}</p>
+          <div class="mt-4 flex flex-wrap gap-2">
+            {#each s.sample as item (item)}
+              <span
+                class="rounded-md border px-2 py-0.5 font-mono text-xs {s.key === 'have'
+                  ? 'border-emerald-400/50 text-emerald-600 dark:text-emerald-400'
+                  : 'border-amber-400/50 text-amber-600 dark:text-amber-400'}"
+              >
+                {item}
+              </span>
+            {/each}
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <p class="mt-6 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+      The rule holds below the interface too: an achievement a model inferred is stored marked as
+      the model's, and cannot be written into a CV until you confirm it. That check lives in the
+      code, not in the agent's instructions — which is the difference between a safeguard and a
+      request.
+    </p>
+  </section>
+
+  <!-- How it works. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="how it works" />
+    <NumberedGrid items={steps} class="mt-10 sm:grid-cols-2" />
+  </section>
+
+  <!-- Edits you can see. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="every edit, one at a time" />
+    <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+      <div>
+        <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+          No wholesale rewrite to proofread.
+        </h2>
+        <p class="mt-5 max-w-md leading-relaxed text-muted-foreground">
+          The agent cannot replace your CV in one move. It edits through a deliberately narrow
+          vocabulary — one field, one bullet, one ordering at a time — so every change is visible in
+          the live preview as it lands, and reversible if you disagree. Type over any of it: the
+          editor and the agent write to the same document.
+        </p>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <Button href={resolve('/my/cvs')} variant="primary" size="lg">Open your CVs</Button>
+          <Button href={resolve('/cli')} variant="ghost" size="lg">Drive it from the CLI</Button>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        {#each ops as op (op)}
+          <span class="rounded-md border border-border bg-background/60 px-2.5 py-1 font-mono text-xs text-muted-foreground">
+            {op}
+          </span>
+        {/each}
+      </div>
+    </div>
+  </section>
+
+  <!-- Export. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="export" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">A PDF a parser can read.</h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        The CV is typeset into a clean single-column PDF with real text — no tables, no side
+        columns, no words baked into an image — so the ATS on the other end reads what you see.
+        Templates change the typography, never the content, so you can look at the same CV three
+        ways before sending it.
+      </p>
+    </div>
+  </section>
+
+  <!-- Terminal. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="from the terminal" />
+    <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+      <div>
+        <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+          Or hand the loop to your own agent.
+        </h2>
+        <p class="mt-5 max-w-md leading-relaxed text-muted-foreground">
+          The same flow runs on the freehire CLI with one API key, so a harness you wrote can tailor
+          the CV instead: read the analysis, read the document, apply patches, render. Same rules —
+          the split is in the context it reads, so your agent inherits the honesty constraint rather
+          than being trusted with it.
+        </p>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <Button href={resolve('/cli')} variant="primary" size="lg">Get the CLI</Button>
+          <Button href={resolve('/docs/api')} variant="ghost" size="lg">API reference</Button>
+        </div>
+      </div>
+
+      <figure class="overflow-hidden rounded-xl border border-border bg-secondary/60 font-mono text-sm shadow-sm">
+        <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+          <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+          terminal
+        </figcaption>
+        <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># what to reframe toward, and what to ask about</span>
+freehire <span class="text-foreground">cv context &lt;cv-id&gt;</span>
+
+<span class="text-muted-foreground"># the document as JSON</span>
+freehire <span class="text-foreground">cv get &lt;cv-id&gt;</span>
+
+<span class="text-muted-foreground"># one field-level edit</span>
+freehire <span class="text-foreground">cv edit &lt;cv-id&gt; --patch '&lbrace;"op":"replace_bullet",…&rbrace;'</span>
+
+<span class="text-muted-foreground"># the PDF</span>
+freehire <span class="text-foreground">cv render &lt;cv-id&gt; --out cv.pdf</span></pre>
+      </figure>
+    </div>
+  </section>
+
+  <!-- FAQ. Visible answers and the FAQPage JSON-LD share TAILOR_FAQ. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="faq" />
+    <h2 class="mt-6 max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+      Frequently asked questions.
+    </h2>
+    <dl class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each TAILOR_FAQ as item (item.question)}
+        <div class="bg-background p-6 sm:p-7">
+          <dt class="text-lg font-semibold tracking-tight">{item.question}</dt>
+          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
+  </section>
+
+  <!-- Closing CTA. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <div class="flex flex-col items-start gap-4 rounded-xl border border-border bg-secondary/40 p-6 sm:p-8">
+      <h2 class="text-2xl font-semibold tracking-tight">Stop sending the same CV everywhere.</h2>
+      <p class="max-w-xl leading-relaxed text-muted-foreground">
+        Find a job worth the effort, run the fit analysis, and tailor from it. Ten minutes per
+        application, and nothing on the page that you did not do.
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <Button href={resolve('/')} variant="primary" size="lg">Browse jobs</Button>
+        <Button href={resolve('/my/cvs')} variant="outline" size="lg">Your CVs</Button>
+      </div>
+    </div>
+  </section>
+</div>

--- a/web/src/lib/sitemap.test.ts
+++ b/web/src/lib/sitemap.test.ts
@@ -10,6 +10,7 @@ describe('sitemap static paths', () => {
   it('includes the feature landings', () => {
     expect(STATIC_PATHS).toContain('/features/inbox');
     expect(STATIC_PATHS).toContain('/features/referrals');
+    expect(STATIC_PATHS).toContain('/features/tailor');
   });
 
   // /referrals now answers with a 301 to its new home. Listing a redirect in the

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -22,6 +22,7 @@ export const STATIC_PATHS = [
   '/recruiters',
   '/features/inbox',
   '/features/referrals',
+  '/features/tailor',
 ];
 
 /** The curated collection landing pages (`/collections/:slug`), one per collection.

--- a/web/src/lib/tailorFaq.test.ts
+++ b/web/src/lib/tailorFaq.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { TAILOR_FAQ } from './tailorFaq';
+import { faqPageJsonLd } from './seo';
+
+describe('TAILOR_FAQ', () => {
+  it('carries entries', () => {
+    expect(TAILOR_FAQ.length).toBeGreaterThan(0);
+  });
+
+  it('asks each question once', () => {
+    const questions = TAILOR_FAQ.map((f) => f.question);
+    expect(new Set(questions).size).toBe(questions.length);
+  });
+
+  it('answers every question', () => {
+    for (const { question, answer } of TAILOR_FAQ) {
+      expect(question.trim(), `question: ${question}`).not.toBe('');
+      expect(answer.trim(), `answer to: ${question}`).not.toBe('');
+    }
+  });
+
+  // The page renders this same array into its FAQPage payload, so the structured
+  // data cannot drift from the visible text.
+  it('feeds the FAQPage payload', () => {
+    const jsonLd = faqPageJsonLd(TAILOR_FAQ) as { mainEntity: { name: string }[] };
+    expect(jsonLd.mainEntity.map((e) => e.name)).toEqual(TAILOR_FAQ.map((f) => f.question));
+  });
+});

--- a/web/src/lib/tailorFaq.ts
+++ b/web/src/lib/tailorFaq.ts
@@ -1,0 +1,40 @@
+// CV-tailoring landing FAQ — the single source for both the visible section
+// (TailorLandingView.svelte) and the FAQPage JSON-LD (routes/features/tailor).
+// Google requires the schema's answers to match the on-page text, so they share
+// this. Answers are written answer-first and stay honest to what the product
+// does (internal/cv, internal/experience, internal/matchanalysis).
+
+import type { FaqItem } from './seo';
+
+export const TAILOR_FAQ: FaqItem[] = [
+  {
+    question: 'Does it invent experience I do not have?',
+    answer:
+      'No, and the design is what stops it rather than a promise. The tailoring context splits the job\'s requirements in two: the ones your history already covers but your CV buries, which the agent reframes, and the ones it does not, which the agent has to ask you about. Anything a model merely inferred is marked as such and cannot be written into a CV until you confirm it — the check lives in the service, not in a prompt.',
+  },
+  {
+    question: 'How do I start tailoring?',
+    answer:
+      'From a job. Run the AI fit analysis on a vacancy, then tailor from its result — the analysis is what the tailored CV reframes toward, so the flow needs one first. freehire copies your base CV into a new one bound to that vacancy; your original is never edited.',
+  },
+  {
+    question: 'What does it actually change?',
+    answer:
+      'One field at a time: the summary, a header field, a bullet, the order of bullets within a role, a skill group, or a role\'s technology line. Each edit is a single operation you can see and undo, not a wholesale rewrite you have to proofread against the original.',
+  },
+  {
+    question: 'Is the PDF ATS-friendly?',
+    answer:
+      'Yes. The CV renders through a typesetting engine into a clean, single-column PDF with real text — no tables, no columns, no images behind the words — so a parser reads the same content you see. Pick from the template gallery; switching templates never touches the content.',
+  },
+  {
+    question: 'Can I do this from the terminal?',
+    answer:
+      'Yes. The freehire CLI drives the same flow: `cv context` prints the analysis to reframe toward, `cv get` dumps the document, `cv edit` applies one patch, and `cv render` downloads the PDF. Your own agent can run the whole loop with an API key.',
+  },
+  {
+    question: 'What does it cost?',
+    answer:
+      'AI credits, the same currency the fit analysis uses. Every account gets a monthly grant, and contributing a company board we do not track yet earns more. Your balance and what each action spent are on your credits page.',
+  },
+];

--- a/web/src/routes/features/tailor/+page.svelte
+++ b/web/src/routes/features/tailor/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import TailorLandingView from '$lib/components/TailorLandingView.svelte';
+  import { faqPageJsonLd, jsonLdScript } from '$lib/seo';
+  import { TAILOR_FAQ } from '$lib/tailorFaq';
+
+  const canonical = $derived(`${page.url.origin}/features/tailor`);
+  // The FAQ block and this payload render from the same TAILOR_FAQ array, so the
+  // structured data can never disagree with what the page shows.
+  const jsonLd = $derived(jsonLdScript([faqPageJsonLd(TAILOR_FAQ)]));
+</script>
+
+<Seo
+  title="CV tailoring — rewrite your CV for one job, inventing nothing | freehire"
+  description="freehire reframes your CV toward a single vacancy: it reads the fit analysis, pulls forward the experience you already have but buried, asks about anything your history doesn't support, and exports an ATS-readable PDF. Drive it in the browser or from the CLI."
+  {canonical}
+/>
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <TailorLandingView />
+</div>


### PR DESCRIPTION
Third and last of the follow-ups after #1219 (#1223, #1226 were the first two).

## Why

CV tailoring has been live and reachable exactly two ways: a box on `/cli`, and a button on a fit analysis you already ran. Nobody who hadn't already found it could learn what it does — and for the feature most likely to be mistaken for a lying machine, that's the wrong thing to leave unexplained.

## What it says

The page leads with the honesty argument rather than the workflow. The tailoring context sorts the vacancy's requirements into two piles: what your history covers but your CV buries (reframe those) and what it doesn't (ask, never write). That split gets its own section, with the note that the provenance check lives in the service rather than in the agent's prompt — a safeguard, not a request.

Then what a reader needs to judge it: four steps from fit analysis to PDF, the patch vocabulary spelled out so "you can see every edit" is concrete rather than a mood, why the PDF parses, and the CLI loop for anyone who'd rather drive it themselves.

Claims are pinned to the code — the ops list is `internal/cv/patch.go`, the split is `tailorContextResponse`, the provenance rule is `internal/experience`. Prices are deliberately absent from the copy: the costs are env-configured, so naming a number would date the page.

## Wiring

Footer, the features section on `/` and `/about`, the sitemap, and a link from the `/cli` tailoring box — which is where people currently discover this by accident.

## Verification

`pnpm test` 418 (4 new, FAQ↔JSON-LD pinned like the inbox one), `pnpm lint`, `svelte-check` (0 errors), `pnpm build` green; page checked in headless Chrome.