### PR TITLE
fix(assistant): a chat started in the extension opens at the desk

### DIFF
--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -29,7 +29,7 @@
     type SessionItem,
   } from '$lib/assistant/sessions';
   import { eventsFromTranscript, type TurnEvent } from '$lib/assistant/wire';
-  import type { ChatPreset } from '$lib/assistant/presets';
+  import { opensInRail, type ChatPreset } from '$lib/assistant/presets';
 
   // The agent chat. The agent runs inside the freehire backend, so this is an
   // ordinary authenticated API surface: the session list, one session's stored
@@ -229,9 +229,7 @@
           });
         }
         await openSession(session);
-      } else if (sessions[0]) {
-        await openSession(sessions[0].id);
-      } else {
+      } else if (!(await openNewestOpenable())) {
         await createAndOpen();
       }
       phase = 'ready';
@@ -323,7 +321,7 @@
       // sense beside it. Opening one here would show a conversation the rail cannot list
       // and the user cannot get back to. The unbound presets — chat and the experience
       // interviewer — are both at home here.
-      if (showSessionRail && meta.preset !== 'chat' && meta.preset !== 'profile') {
+      if (showSessionRail && !opensInRail(meta.preset)) {
         notFound = true;
         return;
       }
@@ -336,6 +334,29 @@
       switching = false;
     }
     void scrollToBottom();
+  }
+
+  /**
+   * Open the most recent conversation that will actually open, newest first.
+   *
+   * Nobody asked for a SPECIFIC chat here — we picked one on their behalf — so a chat
+   * that will not open is our problem to route around, not a dead link to report. Saying
+   * "this chat no longer exists" for a pick they never made replaces the rail with a
+   * panel, and its only way out lands on this same code, which picks the same chat: a
+   * loop with no exit but a manual URL.
+   *
+   * Returns false when the caller has nothing openable, so boot() can start them a chat.
+   */
+  async function openNewestOpenable(): Promise<boolean> {
+    for (const candidate of sessions) {
+      // Sequential on purpose: we want the FIRST one that opens, and opening them in
+      // parallel would race several transcripts into the same pane.
+      // eslint-disable-next-line no-await-in-loop
+      await openSession(candidate.id);
+      if (!notFound) return true;
+      notFound = false;
+    }
+    return false;
   }
 
   async function createAndOpen() {

--- a/web/src/lib/assistant/presets.test.ts
+++ b/web/src/lib/assistant/presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { entryFromQuery, historyModeFor } from './presets';
+import { entryFromQuery, historyModeFor, opensInRail } from './presets';
 
 const entry = (query: string) => entryFromQuery(new URLSearchParams(query));
 
@@ -29,6 +29,30 @@ describe('entryFromQuery', () => {
 
   it('matches the preset exactly', () => {
     expect(entry('preset=Profile')).toEqual({ preset: 'chat' });
+  });
+});
+
+describe('opensInRail', () => {
+  it('opens every conversation the rail lists', () => {
+    // These are the presets ListAssistantSessions returns. A browsing conversation
+    // started in the extension's side panel is meant to be picked up here — refusing it
+    // stranded anyone whose newest chat came from the extension, because boot() opens
+    // the newest and the dead-link panel replaces the rail that would let them escape.
+    expect(opensInRail('chat')).toBe(true);
+    expect(opensInRail('profile')).toBe(true);
+    expect(opensInRail('browse')).toBe(true);
+  });
+
+  it('refuses a conversation bound to an artifact', () => {
+    // A tailoring chat belongs to the CV that owns it and is reached through the
+    // tailoring workspace; opening one here shows a conversation the rail cannot list.
+    expect(opensInRail('tailor')).toBe(false);
+  });
+
+  it('admits a preset it has not heard of', () => {
+    // Deliberately open by default. The rail's contents are the backend's decision, and
+    // a client whitelist that lags a new preset is exactly the bug this replaces.
+    expect(opensInRail('something-new')).toBe(true);
   });
 });
 

--- a/web/src/lib/assistant/presets.ts
+++ b/web/src/lib/assistant/presets.ts
@@ -33,6 +33,24 @@ export function entryFromQuery(params: URLSearchParams): AssistantEntry {
 }
 
 /**
+ * Whether this surface may open a conversation running under `preset`.
+ *
+ * Stated as a refusal, not a whitelist, and that is the point: `ListAssistantSessions`
+ * decides what the rail carries (chat, profile and browse today), and a client that
+ * whitelists presets goes stale the moment the backend gains one. It did — `browse`
+ * arrived with the extension's side panel and this check did not follow, so anyone whose
+ * newest conversation came from the extension landed on the dead-link panel, which
+ * replaces the rail they would have escaped through.
+ *
+ * Only a conversation BOUND to another artifact is refused: a tailoring chat belongs to
+ * the CV that owns it, is reached through the tailoring workspace, and its tools close
+ * over ids this surface knows nothing about.
+ */
+export function opensInRail(preset: string): boolean {
+  return preset !== 'tailor';
+}
+
+/**
  * How the address should follow the chat that just opened. Arriving without an id is a
  * redirect to where the caller belongs, so it replaces the entry rather than becoming a
  * step they can press Back into; choosing another chat is a real move and pushes one.


### PR DESCRIPTION
Reported from production: `/my/assistant` shows **"This chat no longer exists, or it belongs to a CV you are tailoring"**, the rail lists nothing, and **"Open your chats"** lands back on the same screen.

## Cause

The session rail deliberately carries every conversation that binds to nothing. `ListAssistantSessions` says so outright (`internal/db/queries/assistant.sql`):

> The rail carries every preset that binds to NOTHING: chat, profile and browse alike. […] a browsing conversation begun in the extension's side panel is one the candidate can pick up at their desk.

The client never followed. `openSession` still gated on a whitelist written before `browse` existed:

```js
if (showSessionRail && meta.preset !== 'chat' && meta.preset !== 'profile') { notFound = true; }
```

So a `browse` conversation — one the backend lists, and intends to be resumable here — was reported as a dead link. Anyone whose newest chat came from the extension hit it on arrival: `boot()` opens the newest, the panel replaces the entire surface *including the rail* that would let them pick another, and its only way out re-runs the same pick. A loop with no exit but a hand-edited URL.

Note #1229 did not cause this and does not fix it: it made "Open your chats" actually re-run, which faithfully returns to the same chat.

## Fix

**The check is a refusal, not a whitelist.** Only a conversation BOUND to another artifact is turned away — a tailoring chat belongs to the CV that owns it and its tools close over ids this surface has no idea about. A future preset the backend gains cannot go stale here the same way.

**And the failure mode is gone.** Nobody asked for the chat `boot()` picks — we picked it for them — so one that will not open is ours to route around, not a dead link to report. It now walks the rail newest-first until one opens, and starts a fresh chat if none will. A dead link the caller *actually followed* still explains itself.

## Verification

Reproduced and fixed against a local stack seeded with a `browse` session as the newest:

| | before | after |
|---|---|---|
| `/my/assistant` with a `browse` session newest | dead-link panel, empty rail | opens "Looking at a Stripe job", both chats in the rail |
| "Open your chats" from that panel | same panel again (loop) | n/a — no panel |
| `/my/assistant/<tailoring-id>` | dead-link panel | dead-link panel (unchanged, correct) |
| "Open your chats" from a real dead link | — | recovers into a chat |

`pnpm test` 429 passing, `pnpm run build`, `pnpm run lint` (no new warnings), plus three unit tests pinning `opensInRail` — including one asserting an unknown preset is admitted, which is the regression that started this.