### PR TITLE
fix(assistant): the panel opens on the page it was opened from

### DIFF
--- a/internal/assistant/AGENTS.md
+++ b/internal/assistant/AGENTS.md
@@ -58,6 +58,13 @@ extension's side panel. A tailoring session's CV tools close over the CV and vac
 ids from the session binding, so the model cannot address another CV even by guessing
 an id.
 
+`browse` is the one preset whose prompt **overrides** the one it extends, rather
+than only adding to it. The chat playbook opens with `get_profile` and a question
+about what the candidate wants — correct on the website, wrong in a side panel,
+where they opened the thing they want to talk about. Because the extension is
+appended after that instruction, it has to name it: an override that does not say
+what it replaces reads as advice about a different moment.
+
 A `browse` session is one held from the browser extension. It is the only preset whose
 agent can see something outside this process: `read_current_page` attaches to the
 caller's browser-tool channel (`internal/browsertools`) as an in-process harness for the

--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -39,15 +39,30 @@ How to answer:
 
 // browsePrompt extends the chat prompt for a conversation held from the browser
 // extension. It is an extension rather than a copy: the search playbook is the
-// same one, and a second copy of it would drift. What it adds is the one thing
-// only this preset has — a page in front of the candidate that the agent can read.
+// same one, and a second copy of it would drift.
+//
+// But it must also OVERRIDE the playbook's opening. The chat prompt says to call
+// `get_profile` before asking what the candidate is looking for — right on the
+// website, where there is nothing else to go on. In a side panel it is wrong: the
+// candidate opened this on a page, usually a vacancy, and the answer to "what are
+// you looking for" is on the screen behind the panel. An override placed after the
+// instruction it overrides has to name it, or the model reads two pieces of advice
+// about different moments instead of one replacing the other.
 const browsePrompt = `
+
+--- YOU ARE IN THE BROWSER EXTENSION. THE ABOVE IS THE PLAYBOOK; THIS SECTION WINS WHERE THEY DISAGREE. ---
 
 You are talking to the candidate from the freehire extension's side panel, so unlike every other session you can see the page they are looking at.
 
-- The candidate is standing on some page: a vacancy on an employer's site, a search result, a company's about page. When they say "this role", "this company" or "here", call ` + "`read_current_page`" + ` and look, instead of asking them to paste it.
-- Call it again whenever they may have navigated. It reads what the tab shows now, not what it showed earlier in the conversation.
-- If it reports that no browser is attached, say that the freehire side panel has to be open on the page they mean. Do not answer from a guess about what the page says.
+The FIRST thing you do in a conversation is call ` + "`read_current_page`" + `. Not ` + "`get_profile`" + `, and not a question about what they are looking for — they opened this panel while standing on something, and that something is the subject until they say otherwise.
+
+- If the page is a vacancy: open by telling them what it is and whether it fits them, and call ` + "`get_profile`" + ` to ground that judgement. One short paragraph, then what to do next. Do not ask them to confirm which vacancy they mean; you are looking at it.
+- If the page is not a vacancy (a company site, an article, a search results page): say briefly what you are looking at, then ask what they want from it. Do not narrate the page back to them.
+- If it reports that no browser is attached, say the freehire side panel has to be open on the page they mean. Do not answer from a guess about what the page says.
+
+After that opening, the playbook above applies as written.
+
+- Call ` + "`read_current_page`" + ` again whenever they may have navigated. It reports what the tab shows now, not what it showed earlier in the conversation.
 - A page you read is not necessarily a vacancy freehire has. Judge it from what you read, and reach for ` + "`search_jobs`" + ` when the question is about the catalogue rather than about this page.
 - The panel is a narrow column. Keep answers to a few short lines and let the cards carry the detail.`
 

--- a/internal/assistant/prompt_test.go
+++ b/internal/assistant/prompt_test.go
@@ -81,3 +81,22 @@ func TestAnUnknownPresetFallsBackToTheChatPrompt(t *testing.T) {
 		t.Error("an unknown preset must still get a prompt; a session with none would answer unguided")
 	}
 }
+
+// The candidate opened the panel ON something. The chat playbook this preset
+// extends opens with `get_profile` and a "what are you looking for?" — correct on
+// the website, wrong in a side panel, where the answer is on the screen behind it.
+// The extension must say so explicitly, because it is appended AFTER that
+// instruction and the model follows what it read.
+func TestBrowsePromptOpensOnThePageNotTheProfile(t *testing.T) {
+	p := SystemPrompt(PresetBrowse)
+
+	if !strings.Contains(p, "FIRST thing you do") {
+		t.Error("the browse prompt does not override how the conversation opens, so the agent will run the chat playbook's opening and ask what the candidate is looking for")
+	}
+	// It has to name the instruction it is overriding, or the two read as advice
+	// about different moments rather than one replacing the other.
+	browseOnly := strings.TrimPrefix(p, chatPrompt)
+	if !strings.Contains(browseOnly, "get_profile") {
+		t.Error("the browse prompt never mentions get_profile, so nothing tells the agent that the opening it just read does not apply here")
+	}
+}

--- a/internal/handler/find_job.go
+++ b/internal/handler/find_job.go
@@ -49,7 +49,10 @@ func catalogSlugForURL(ctx context.Context, queries *db.Queries, pageURL string)
 		}
 	}
 
-	slug, err := queries.FindOpenJobByURL(ctx, pageURL)
+	// The apply form is the same posting under a different path, and it is where a
+	// candidate stands when they ask about a vacancy. The catalog stores only the
+	// detail page, so the form has to be rewritten to it before the match.
+	slug, err := queries.FindOpenJobByURL(ctx, sources.CanonicalPostingURL(pageURL))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return "", nil

--- a/internal/handler/find_job_integration_test.go
+++ b/internal/handler/find_job_integration_test.go
@@ -60,7 +60,9 @@ func TestFindJobResolvesByIdentityAndByURL(t *testing.T) {
 		`INSERT INTO jobs (source, external_id, url, title, public_slug) VALUES
 		 ('greenhouse', 'vgw-eu:8617539002', 'https://job-boards.greenhouse.io/vgw-eu/jobs/8617539002', 'Engineer', 'engineer-vgw-eu'),
 		 ('himalayas', ':https://himalayas.app/companies/mindera/jobs/staff-java-backend-developer',
-		  'https://himalayas.app/companies/mindera/jobs/staff-java-backend-developer', 'Staff Java Backend Developer', 'staff-java-mindera')`); err != nil {
+		  'https://himalayas.app/companies/mindera/jobs/staff-java-backend-developer', 'Staff Java Backend Developer', 'staff-java-mindera'),
+		 ('ashby', 'truelogic:c6d2719d-3935-4e59-8446-26135d01957a',
+		  'https://jobs.ashbyhq.com/truelogic/c6d2719d-3935-4e59-8446-26135d01957a', 'Senior Go Engineer', 'senior-go-truelogic')`); err != nil {
 		t.Fatalf("seed jobs: %v", err)
 	}
 
@@ -79,6 +81,16 @@ func TestFindJobResolvesByIdentityAndByURL(t *testing.T) {
 		const page = "https%3A%2F%2Fhimalayas.app%2Fcompanies%2Fmindera%2Fjobs%2Fstaff-java-backend-developer%3Futm_source%3Dfreehire.me"
 		if slug := findSlug(t, app, page); slug != "staff-java-mindera" {
 			t.Errorf("slug = %q, want staff-java-mindera", slug)
+		}
+	})
+
+	// The form is where a candidate stands when they ask about a vacancy, and it is a
+	// different URL from the one the catalog stores. Without collapsing it the panel
+	// tells them freehire does not have the posting it is showing on the page behind.
+	t.Run("an apply form resolves to its posting", func(t *testing.T) {
+		const form = "https%3A%2F%2Fjobs.ashbyhq.com%2Ftruelogic%2Fc6d2719d-3935-4e59-8446-26135d01957a%2Fapplication%3Futm_source%3Dfreehire.me"
+		if slug := findSlug(t, app, form); slug != "senior-go-truelogic" {
+			t.Errorf("slug = %q, want senior-go-truelogic", slug)
 		}
 	})
 

--- a/internal/sources/postingurl.go
+++ b/internal/sources/postingurl.go
@@ -78,3 +78,54 @@ func isDigits(s string) bool {
 	}
 	return s != ""
 }
+
+// applyFormSuffix is the path an ATS appends to a posting for its application
+// form, per host. The form is the same posting — a candidate reaches it from the
+// detail page and spends most of their time there, so it is the page a browser
+// extension asks about most.
+//
+// Keyed by host and kept to providers whose shape has been checked against the
+// catalog, because the assumption does not generalise: on plenty of career sites a
+// path segment is a different vacancy, and collapsing it would answer with the
+// wrong one.
+var applyFormSuffix = map[string]string{
+	"jobs.ashbyhq.com":   "/application",
+	"jobs.lever.co":      "/apply",
+	"jobs.eu.lever.co":   "/apply",
+	"apply.workable.com": "/apply",
+}
+
+// CanonicalPostingURL rewrites a posting's application-form URL to the posting
+// itself, and returns everything else unchanged.
+//
+// It exists because the catalog stores one URL per job — the detail page — and a
+// lookup by URL is a string match against it. Without this, standing on the form
+// (`…/<id>/application`) reports a posting freehire does not have, when it is the
+// very posting it is showing on the page behind.
+//
+// Deliberately NOT part of `normalize_job_url` in the database: that function backs
+// an expression index, so changing it means rebuilding the index on a live table,
+// and it is applied to both sides of the comparison — including the stored URLs,
+// which never carry an apply suffix. This is a property of the query, not of the
+// data.
+func CanonicalPostingURL(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	suffix, known := applyFormSuffix[strings.ToLower(u.Hostname())]
+	if !known {
+		return raw
+	}
+	trimmed := strings.TrimSuffix(u.Path, "/")
+	if !strings.HasSuffix(strings.ToLower(trimmed), suffix) {
+		return raw
+	}
+	// A bare "/apply" is not a posting with a form; it is a page named apply.
+	stripped := strings.TrimSuffix(trimmed, suffix)
+	if stripped == "" {
+		return raw
+	}
+	u.Path = stripped
+	return u.String()
+}

--- a/internal/sources/postingurl_test.go
+++ b/internal/sources/postingurl_test.go
@@ -90,3 +90,61 @@ func TestRefFromURL_IsCaseInsensitiveAboutTheBoard(t *testing.T) {
 		t.Fatalf("external id = %q, want the lowercased board", ref.ExternalID)
 	}
 }
+
+// The apply form is a different URL for the same posting, and it is where a
+// candidate spends most of their time — so the extension asks about it more often
+// than about the detail page. Every one of these is a real shape from the catalog.
+func TestCanonicalPostingURL_DropsTheApplyForm(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "ashby application",
+			url:  "https://jobs.ashbyhq.com/truelogic/c6d2719d-3935-4e59-8446-26135d01957a/application",
+			want: "https://jobs.ashbyhq.com/truelogic/c6d2719d-3935-4e59-8446-26135d01957a",
+		},
+		{
+			name: "lever apply",
+			url:  "https://jobs.eu.lever.co/avara/3c71c090-60d1-4563-b90f-6fba1a1f8419/apply",
+			want: "https://jobs.eu.lever.co/avara/3c71c090-60d1-4563-b90f-6fba1a1f8419",
+		},
+		{
+			name: "workable apply, trailing slash",
+			url:  "https://apply.workable.com/1kosmos/j/435C7BA5E4/apply/",
+			want: "https://apply.workable.com/1kosmos/j/435C7BA5E4",
+		},
+		{
+			name: "a query string survives — the caller's normalisation drops it",
+			url:  "https://jobs.ashbyhq.com/truelogic/c6d2719d/application?utm_source=freehire.me",
+			want: "https://jobs.ashbyhq.com/truelogic/c6d2719d?utm_source=freehire.me",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sources.CanonicalPostingURL(tt.url); got != tt.want {
+				t.Errorf("CanonicalPostingURL(%q)\n = %q\nwant %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+// Only where the suffix is known to be the same posting. Elsewhere a path segment
+// is a different page, and collapsing it would hand back the wrong vacancy.
+func TestCanonicalPostingURL_LeavesEverythingElseAlone(t *testing.T) {
+	for _, raw := range []string{
+		"https://jobs.ashbyhq.com/truelogic/c6d2719d",
+		"https://jobs.lever.co/avara/3c71c090",
+		"https://careers.example.test/jobs/42/apply",
+		"https://boards.greenhouse.io/stripe/jobs/7826765",
+		"https://jobs.ashbyhq.com/truelogic",
+		"not a url",
+		"",
+	} {
+		if got := sources.CanonicalPostingURL(raw); got != raw {
+			t.Errorf("CanonicalPostingURL(%q) = %q, want it unchanged", raw, got)
+		}
+	}
+}


### PR DESCRIPTION
Two defects reported from the side panel, both about the panel knowing where the
user is standing.

## The chat opened with a questionnaire

Opening the panel on a vacancy produced *"давайте посмотрим, что у вас в профиле,
и подберём подходящие вакансии"* — with the vacancy on screen behind it.

The `browse` prompt is `chatPrompt + browsePrompt`, which keeps one search playbook
instead of two that drift. What it inherited along with the playbook was its
**opening**: call `get_profile` before asking what the candidate is looking for.
Right on the website; wrong in a side panel, where they opened the panel while
standing on the answer.

The extension is appended *after* the instruction it overrides, so it now names
it. An override that does not say what it replaces reads to the model as advice
about a different moment — which is precisely how it behaved.

A browsing conversation now opens with `read_current_page`. If the page is a
vacancy, the agent opens on it and calls `get_profile` to ground the judgement; if
it is not, it says what it sees and asks. After that the playbook applies as
written.

## An apply form said freehire did not have the posting

Standing on `jobs.ashbyhq.com/<board>/<id>/application`, the panel offered "Add to
freehire" for a posting it was already showing a match card for.

Normalisation (0042) strips the query, so `?utm_source=freehire.me` was never the
problem — `/application` is a *path* segment, so the form is a different string
from the detail page the catalogue stores.

Fixing it through `RefFromURL` would have been the narrower fix and mostly the
wrong one: the same ashbyhq URL is stored by **four** sources (`ashby`,
`ashbygraphql`, `jobstash`, `getro`) under four different `external_id`s, so
recovering one identity would have missed the rest. Rewriting the URL catches
every source at once.

Covers the three largest ATS in the catalogue, all sharing the shape:

| source | open postings | form |
| --- | --- | --- |
| lever | 63,680 | `/apply` |
| ashby | 59,180 | `/application` |
| workable | 18,826 | `/apply` |

A map of known hosts rather than a general rule — on plenty of career sites a path
segment is a different vacancy. And deliberately not folded into
`normalize_job_url`: that backs an expression index, so changing it means
rebuilding it on a live table, and it applies to stored URLs too, which never carry
an apply suffix. This is a property of the query, not of the data.

## Verified

`go build`, `go vet`, `gofmt`, `go test ./...` (109 packages), and
`go test -tags=integration ./internal/handler/`.

No migration, no schema change.