### PR TITLE
fix(sources): a shouting apply suffix is cut, not silently kept

### DIFF
--- a/internal/sources/postingurl.go
+++ b/internal/sources/postingurl.go
@@ -121,8 +121,12 @@ func CanonicalPostingURL(raw string) string {
 	if !strings.HasSuffix(strings.ToLower(trimmed), suffix) {
 		return raw
 	}
+	// Cut by length rather than by value: the match above ignored case, so cutting
+	// the literal would leave a shouting suffix in place and hand back a URL that
+	// was altered (its trailing slash gone) but not canonicalised.
+	//
 	// A bare "/apply" is not a posting with a form; it is a page named apply.
-	stripped := strings.TrimSuffix(trimmed, suffix)
+	stripped := trimmed[:len(trimmed)-len(suffix)]
 	if stripped == "" {
 		return raw
 	}

--- a/internal/sources/postingurl_test.go
+++ b/internal/sources/postingurl_test.go
@@ -116,6 +116,14 @@ func TestCanonicalPostingURL_DropsTheApplyForm(t *testing.T) {
 			want: "https://apply.workable.com/1kosmos/j/435C7BA5E4",
 		},
 		{
+			// The check that got us here is case-insensitive, so the cut must be too —
+			// otherwise the suffix matches, nothing is removed, and the URL comes back
+			// quietly altered instead of untouched.
+			name: "a shouting suffix is still the apply form",
+			url:  "https://jobs.ashbyhq.com/truelogic/c6d2719d/APPLICATION",
+			want: "https://jobs.ashbyhq.com/truelogic/c6d2719d",
+		},
+		{
 			name: "a query string survives — the caller's normalisation drops it",
 			url:  "https://jobs.ashbyhq.com/truelogic/c6d2719d/application?utm_source=freehire.me",
 			want: "https://jobs.ashbyhq.com/truelogic/c6d2719d?utm_source=freehire.me",


### PR DESCRIPTION
Quality pass over the canonicalisation that shipped in #1234, which turned up a
real defect rather than only tidying.

The suffix check lowercases before comparing, so `/APPLICATION` matches. The cut
did not — `TrimSuffix` compares literally, removed nothing, and the function
returned a URL that *had* been altered (its trailing slash gone) but not
canonicalised.

That is the one outcome this function must not have: the caller matches its result
against a stored URL, so "neither canonical nor untouched" is a lookup that fails
for a posting we have.

Cutting by length instead of by value keeps the two halves in agreement by
construction — the match already established the suffix is present, so its length
is what to remove. It also drops the second `TrimSuffix`.

Reachable in the wild: nothing normalises the case of a path before this runs, and
an ATS is free to serve `/Apply`.

`go build`, `go vet`, `gofmt`, `go test ./...` (109 packages).