### PR TITLE
fix(sources): workable's other host serves postings too

### DIFF
--- a/internal/sources/postingurl.go
+++ b/internal/sources/postingurl.go
@@ -93,6 +93,7 @@ var applyFormSuffix = map[string]string{
 	"jobs.lever.co":      "/apply",
 	"jobs.eu.lever.co":   "/apply",
 	"apply.workable.com": "/apply",
+	"jobs.workable.com":  "/apply",
 }
 
 // CanonicalPostingURL rewrites a posting's application-form URL to the posting


### PR DESCRIPTION
Follow-up to #1234 / #1235, found by listing the hosts the catalogue *stores*
rather than the ones each adapter fetches from:

| host | open postings | was in the map |
| --- | --- | --- |
| `jobs.lever.co` | 64,244 | yes |
| `jobs.ashbyhq.com` | 60,935 | yes |
| `apply.workable.com` | 19,177 | yes |
| **`jobs.workable.com`** | **385** | **no** |
| `jobs.eu.lever.co` | 372 | yes |

Workable serves both hosts and the catalogue has postings under each, so an apply
form under the second still reported a posting freehire does not have.

That same listing is the argument for keeping this an explicit map rather than a
substring rule: `unilever.wd3.myworkdayjobs.com` has 583 postings and is Workday.

`go build`, `go test ./internal/sources/ -run TestCanonicalPostingURL`.

Note, unrelated: `TestInstaffoDropsPostingsOlderThanMaxAge` fails on `main` at the
moment of writing, independently of this change. Its "fresh" fixture is
`instaffoMaxAge - 24h` but `datePosted` carries only a date, so rounding to whole
days pushes it over the edge depending on the hour the suite runs. Not touched
here.