### PR TITLE
fix(auth): an account taken back from a squatter takes its API keys back too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,8 @@ Each is self-contained and can be read independently.
 - **Response shapes:** Lists: `{"data": ..., "meta": {...}}`; single items: `{"data": ...}`; errors: `{"error": msg}`
 - **Dedup key:** `jobs.UNIQUE (source, external_id)` — `UpsertJob` is `ON CONFLICT` on it
 - **Auth:** JWT in httpOnly cookie, same-origin, carrying the account's `token_version` so sessions are revocable. `RequireAuth` (cookie only) / `RequireAuthOrKey` (cookie or full-scope Bearer) / `RequireAuthOrScopedKey` (also admits a narrow key)
-- **Email ownership:** `users.email_verified`; a password registration starts unverified and is confirmed by a mailed six-digit code. An unverified, password-backed account is **seized** (password cleared, sessions revoked) when a provider-verified OAuth identity arrives for its address — the account-pre-hijacking defence
-- **API keys:** Hashed at rest (SHA-256), scoped `full` or `cv`. Key management (create/list/revoke) and password change are cookie-only
+- **Email ownership:** `users.email_verified`; a password registration starts unverified and is confirmed by a mailed six-digit code. An unverified, password-backed account is **seized** (password cleared, sessions revoked, API keys deleted) when a provider-verified OAuth identity arrives for its address — the account-pre-hijacking defence
+- **API keys:** Hashed at rest (SHA-256), scoped `full` or `cv`, and mintable only by an account with a verified address. Key management (create/list/revoke) and password change are cookie-only. A key does not carry the session generation, so a `token_version` bump does not revoke it — that is intentional for sign-out-everywhere and wrong for a takeover, so the seizure and the mailed-code password reset delete the rows in the same statement
 - **Enrichment:** Queue-driven (`enrichment_outbox`), provider-agnostic LLM, `Sanitize` + `Validate` gate
 - **Embeddings:** Queue-driven (`semantic_outbox`), incremental, reconciled by `reindex --semantic`
 - **Dictionaries:** All facet dictionaries are dict-only in production — never guess, emit nothing for unknowns

--- a/internal/accounts/AGENTS.md
+++ b/internal/accounts/AGENTS.md
@@ -22,10 +22,18 @@ Three packages split this surface — keep the split:
   and resolves to nothing. This is the anti-takeover gate; do not add a path around it.
 - **The seizure rule.** When a provider-verified identity arrives for an address held by an
   *unverified, password-backed* account, that account is **seized**: `password_hash = NULL`,
-  `email_verified = true`, `token_version + 1` (see `migrations`/`users.sql`). The password
-  someone set on an address they never proved is destroyed rather than silently joined —
-  otherwise registering against a stranger's address would pre-hijack their future OAuth
-  sign-in.
+  `email_verified = true`, `token_version + 1`, **and every row in `api_keys` deleted** (see
+  `migrations`/`users.sql`). The password someone set on an address they never proved is
+  destroyed rather than silently joined — otherwise registering against a stranger's address
+  would pre-hijack their future OAuth sign-in.
+- **`token_version` does not reach API keys — the takeover statements delete them.** A key is
+  matched against `api_keys.token_hash` and `expires_at` and never joins `users`, so bumping
+  the generation leaves it live. That is intentional for `logout-all` and a password change
+  (a key is a durable programmatic credential, not a session), and wrong for the two events
+  where the account changes hands: `SeizeUnverifiedAccount` and `ResetUserPassword` therefore
+  carry a `DELETE FROM api_keys` as a data-modifying CTE, so the revocation cannot be
+  separated from the takeover. A new takeover-shaped path must do the same; bumping the
+  version alone would leave a never-expiring bearer credential in the previous holder's hands.
 - **Every credential change bumps `token_version`.** Set/reset password and seizure all
   increment it, which strands every outstanding JWT. That coupling is the entire revocation
   story for a stateless token — a new credential write path that skips the bump silently

--- a/internal/accounts/credential_revocation_integration_test.go
+++ b/internal/accounts/credential_revocation_integration_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+// Integration tests for the OTHER half of revoking an account's credentials: its API
+// keys. Advancing token_version strands every session, but an API key authenticates by
+// its own hash against api_keys and never consults users, so a session revocation alone
+// leaves it live. These tests pin the two events where the account is understood to have
+// changed hands — a seizure and a mailed-code password reset — to also destroying the
+// keys. They need a real Postgres because the guarantee lives in the SQL statement.
+// Run with: go test -tags=integration ./internal/accounts/
+package accounts_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// seedAPIKey stores a never-expiring, full-scope key for the user, as POST /me/api-keys
+// mints one, and returns its hash.
+func seedAPIKey(t *testing.T, pool *pgxpool.Pool, userID int64, hash string) string {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO api_keys (user_id, name, token_hash, token_prefix, scope, expires_at)
+		 VALUES ($1, 'squatter cli', $2, 'fh_test', 'full', NULL)`,
+		userID, hash); err != nil {
+		t.Fatalf("seed api key: %v", err)
+	}
+	return hash
+}
+
+// liveKeys counts the keys that would still authenticate for the user.
+func liveKeys(t *testing.T, pool *pgxpool.Pool, userID int64) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM api_keys WHERE user_id = $1`, userID).Scan(&n); err != nil {
+		t.Fatalf("count api keys: %v", err)
+	}
+	return n
+}
+
+func TestSeizureDestroysTheSquattersAPIKeys(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	repo := oauthRepo(pool)
+
+	// The squatter registered the victim's address, never proved it, and — because
+	// key creation is only guarded by a session — minted a bearer credential that
+	// outlives any cookie.
+	const email = "keyed-squatter@example.test"
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO users (email, password_hash, email_verified) VALUES ($1, 'squatter-hash', false)`,
+		email); err != nil {
+		t.Fatalf("seed squatted account: %v", err)
+	}
+	user := readAccount(t, pool, email)
+	seedAPIKey(t, pool, user.id, "squatter-key-hash")
+
+	// The real owner arrives with a provider-verified identity.
+	if _, err := repo.LinkOrCreateByEmail(ctx, "google", "google-keyed-victim", email); err != nil {
+		t.Fatalf("LinkOrCreateByEmail: %v", err)
+	}
+
+	if n := liveKeys(t, pool, user.id); n != 0 {
+		t.Errorf("%d API key(s) survived the seizure: the squatter keeps bearer access to "+
+			"the account they just lost the password and sessions to", n)
+	}
+}
+
+func TestSeizureLeavesOtherAccountsKeysAlone(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	repo := oauthRepo(pool)
+
+	const seized = "narrow-seizure@example.test"
+	const bystander = "bystander@example.test"
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO users (email, password_hash, email_verified) VALUES ($1, 'hash', false), ($2, 'hash', true)`,
+		seized, bystander); err != nil {
+		t.Fatalf("seed accounts: %v", err)
+	}
+	seizedUser := readAccount(t, pool, seized)
+	otherUser := readAccount(t, pool, bystander)
+	seedAPIKey(t, pool, seizedUser.id, "doomed-key-hash")
+	seedAPIKey(t, pool, otherUser.id, "innocent-key-hash")
+
+	if _, err := repo.LinkOrCreateByEmail(ctx, "google", "google-narrow", seized); err != nil {
+		t.Fatalf("LinkOrCreateByEmail: %v", err)
+	}
+
+	if n := liveKeys(t, pool, otherUser.id); n != 1 {
+		t.Errorf("a bystander account lost %d key(s): the delete is not scoped to the seized user", 1-n)
+	}
+}
+
+func TestPasswordResetDestroysTheAccountsAPIKeys(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	repo := oauthRepo(pool)
+
+	// A reset by mailed code is how an owner takes an account back. Whoever knew the
+	// old password may have minted a key from it; leaving that key live makes the
+	// recovery cosmetic.
+	const email = "recovering@example.test"
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO users (email, password_hash, email_verified) VALUES ($1, 'stolen-hash', true)`,
+		email); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	user := readAccount(t, pool, email)
+	seedAPIKey(t, pool, user.id, "attacker-key-hash")
+
+	if _, err := repo.ResetPassword(ctx, user.id, "fresh-hash"); err != nil {
+		t.Fatalf("ResetPassword: %v", err)
+	}
+
+	if n := liveKeys(t, pool, user.id); n != 0 {
+		t.Errorf("%d API key(s) survived the password reset: an attacker who held the old "+
+			"password keeps programmatic access after the owner recovers", n)
+	}
+}

--- a/internal/auth/AGENTS.md
+++ b/internal/auth/AGENTS.md
@@ -13,6 +13,8 @@ Auth primitives: bcrypt password hashing, JWT cookie transport, API-key hashing/
 - Credential endpoints (`register`/`login`) are throttled by a per-instance rate limiter (10/min, keyed on client IP).
 - **API keys are hashed at rest:** the row stores only the `HashAPIKey(token)` SHA-256 (i.e. `SHA-256(token)`) plus a short non-secret `token_prefix` (enough to tell keys apart in a list); the plaintext (minted by `GenerateAPIKey`) is shown exactly once at create time and is unrecoverable.
 - **Key management is cookie-only (`RequireAuth`)** — a leaked key must not be able to create, list, or revoke keys.
+- **Minting a key requires a proven address.** `CreateAPIKey` is an `INSERT ... SELECT ... WHERE users.email_verified`; no row means `403`. The gate lives in the statement because registration hands out a session before the address is proven, so a squatter on someone else's email could otherwise walk away with a never-expiring, full-scope credential.
+- **A key does not carry `tv`, so a version bump does not revoke it.** `AuthenticateAPIKey` matches `token_hash` + `expires_at` and never joins `users`. This is deliberate for `logout-all` and a password change — a key is a durable programmatic credential, not a session — but it means a *takeover* must delete the rows: `SeizeUnverifiedAccount` and `ResetUserPassword` do so in the same statement. Do not "fix" this by joining `tv` into `AuthenticateAPIKey`; that would make every key die with every sign-out-everywhere and leave dead rows listed as live.
 - **Per-user job endpoints and `/auth/me` accept either credential** (`RequireAuthOrKey`).
 
 ## How it works

--- a/internal/db/account_security_integration_test.go
+++ b/internal/db/account_security_integration_test.go
@@ -270,7 +270,12 @@ func TestAPIKeyScope(t *testing.T) {
 	q := New(pool)
 	ctx := context.Background()
 
+	// Verified: CreateAPIKey refuses an account whose address was never proven, so a
+	// scope test has to start from an account that is allowed to hold keys at all.
 	user := seedAccount(t, pool, "scoped@example.test")
+	if _, err := pool.Exec(ctx, `UPDATE users SET email_verified = true WHERE id = $1`, user); err != nil {
+		t.Fatalf("verify account: %v", err)
+	}
 
 	t.Run("authentication reports the key's scope", func(t *testing.T) {
 		if _, err := q.CreateAPIKey(ctx, CreateAPIKeyParams{

--- a/internal/db/api_keys.sql.go
+++ b/internal/db/api_keys.sql.go
@@ -37,7 +37,9 @@ func (q *Queries) AuthenticateAPIKey(ctx context.Context, tokenHash string) (Aut
 
 const createAPIKey = `-- name: CreateAPIKey :one
 INSERT INTO api_keys (user_id, name, token_hash, token_prefix, expires_at, scope)
-VALUES ($1, $2, $3, $4, $5, $6)
+SELECT $1, $2, $3, $4, $5, $6
+FROM users
+WHERE users.id = $1 AND users.email_verified
 RETURNING id, name, token_prefix, scope, created_at, last_used_at, expires_at
 `
 
@@ -65,6 +67,13 @@ type CreateAPIKeyRow struct {
 // expires_at NULL means the key never expires. scope confines the credential to a
 // surface ('full' for a user-created key, 'cv' for the tailoring agent's); it comes
 // from the server, never from client input. Returns display fields only, never the hash.
+//
+// The INSERT ... SELECT is the verified-address gate, not a style choice: registration
+// hands out a session before the address is proven, so a squatter on someone else's
+// email could otherwise mint a never-expiring, full-scope bearer credential and keep it
+// past the seizure that hands the account to its real owner. Putting the condition in
+// the statement means no call site can mint around it. Inserting nothing yields no row,
+// which the caller reads as "not allowed" (403).
 func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (CreateAPIKeyRow, error) {
 	row := q.db.QueryRow(ctx, createAPIKey,
 		arg.UserID,

--- a/internal/db/api_keys_integration_test.go
+++ b/internal/db/api_keys_integration_test.go
@@ -17,11 +17,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// seedAPIKeyUser creates an account that may hold API keys — verified, because
+// CreateAPIKey refuses an address that was never proven.
 func seedAPIKeyUser(t *testing.T, pool *pgxpool.Pool, email string) int64 {
 	t.Helper()
 	var id int64
 	if err := pool.QueryRow(context.Background(),
-		`INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&id); err != nil {
+		`INSERT INTO users (email, email_verified) VALUES ($1, true) RETURNING id`, email).Scan(&id); err != nil {
 		t.Fatalf("seed user %s: %v", email, err)
 	}
 	return id

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -276,6 +276,13 @@ type Querier interface {
 	// expires_at NULL means the key never expires. scope confines the credential to a
 	// surface ('full' for a user-created key, 'cv' for the tailoring agent's); it comes
 	// from the server, never from client input. Returns display fields only, never the hash.
+	//
+	// The INSERT ... SELECT is the verified-address gate, not a style choice: registration
+	// hands out a session before the address is proven, so a squatter on someone else's
+	// email could otherwise mint a never-expiring, full-scope bearer credential and keep it
+	// past the seizure that hands the account to its real owner. Putting the condition in
+	// the statement means no call site can mint around it. Inserting nothing yields no row,
+	// which the caller reads as "not allowed" (403).
 	CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (CreateAPIKeyRow, error)
 	// Start a conversation for a user. preset selects the prompt and tool set ('chat' or
 	// 'tailor'); cv_id/job_id bind a tailoring session to its CV and vacancy and are NULL
@@ -1450,6 +1457,14 @@ type Querier interface {
 	// Complete a reset-by-emailed-code: set the new hash, revoke every session, and mark
 	// the address verified — receiving the code IS proof of control, so a reset doubles as
 	// verification and an unverified account stops being a merge target.
+	//
+	// The account's API keys are destroyed in the same statement. A reset is how an owner
+	// takes an account back, so whoever knew the old password must lose every credential
+	// minted under it — and a key authenticates against api_keys alone, so bumping
+	// token_version does not reach it. The DELETE is a data-modifying CTE rather than a
+	// second statement on purpose: Postgres runs it exactly once and to completion whether
+	// or not the primary query reads its output, which welds the revocation to the reset so
+	// no call site can perform one without the other.
 	ResetUserPassword(ctx context.Context, arg ResetUserPasswordParams) (int32, error)
 	// Catalogue pruning: the queries that find, and eventually remove, jobs that do not
 	// belong on an IT job board. See the catalog-pruning capability spec.
@@ -1534,8 +1549,13 @@ type Querier interface {
 	// it inserts the row (viewed_at defaults) or refreshes saved_at in place.
 	SaveJob(ctx context.Context, arg SaveJobParams) (UserJob, error)
 	// Hand an unverified, password-backed account to the proven owner of its address when a
-	// provider-verified OAuth identity arrives for it: the password is destroyed and every
-	// session revoked, so a squatter who registered the address first loses both ways in.
+	// provider-verified OAuth identity arrives for it: the password is destroyed, every
+	// session revoked, and every API key deleted, so a squatter who registered the address
+	// first loses all three ways in. The keys matter most of the three: they are the only
+	// credential that survives a token_version bump (a key is matched against api_keys by
+	// its own hash and never consults users), and one minted with expires_at NULL would
+	// otherwise outlive the takeover forever. Same data-modifying-CTE reasoning as
+	// ResetUserPassword — the revocation cannot be separated from the seizure.
 	// Returns the new generation for the session the sign-in is about to mint.
 	SeizeUnverifiedAccount(ctx context.Context, id int64) (int32, error)
 	// Orphan-job liveness (probe-orphan-job-liveness): open jobs whose source is NOT a

--- a/internal/db/queries/api_keys.sql
+++ b/internal/db/queries/api_keys.sql
@@ -4,8 +4,17 @@
 -- expires_at NULL means the key never expires. scope confines the credential to a
 -- surface ('full' for a user-created key, 'cv' for the tailoring agent's); it comes
 -- from the server, never from client input. Returns display fields only, never the hash.
+--
+-- The INSERT ... SELECT is the verified-address gate, not a style choice: registration
+-- hands out a session before the address is proven, so a squatter on someone else's
+-- email could otherwise mint a never-expiring, full-scope bearer credential and keep it
+-- past the seizure that hands the account to its real owner. Putting the condition in
+-- the statement means no call site can mint around it. Inserting nothing yields no row,
+-- which the caller reads as "not allowed" (403).
 INSERT INTO api_keys (user_id, name, token_hash, token_prefix, expires_at, scope)
-VALUES ($1, $2, $3, $4, $5, $6)
+SELECT $1, $2, $3, $4, $5, $6
+FROM users
+WHERE users.id = $1 AND users.email_verified
 RETURNING id, name, token_prefix, scope, created_at, last_used_at, expires_at;
 
 -- name: ListAPIKeysByUser :many

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -74,19 +74,38 @@ RETURNING token_version;
 -- Complete a reset-by-emailed-code: set the new hash, revoke every session, and mark
 -- the address verified — receiving the code IS proof of control, so a reset doubles as
 -- verification and an unverified account stops being a merge target.
+--
+-- The account's API keys are destroyed in the same statement. A reset is how an owner
+-- takes an account back, so whoever knew the old password must lose every credential
+-- minted under it — and a key authenticates against api_keys alone, so bumping
+-- token_version does not reach it. The DELETE is a data-modifying CTE rather than a
+-- second statement on purpose: Postgres runs it exactly once and to completion whether
+-- or not the primary query reads its output, which welds the revocation to the reset so
+-- no call site can perform one without the other.
+WITH revoked_keys AS (
+    DELETE FROM api_keys WHERE user_id = $1
+)
 UPDATE users
 SET password_hash = $2, email_verified = true, token_version = token_version + 1
-WHERE id = $1
+WHERE users.id = $1
 RETURNING token_version;
 
 -- name: SeizeUnverifiedAccount :one
 -- Hand an unverified, password-backed account to the proven owner of its address when a
--- provider-verified OAuth identity arrives for it: the password is destroyed and every
--- session revoked, so a squatter who registered the address first loses both ways in.
+-- provider-verified OAuth identity arrives for it: the password is destroyed, every
+-- session revoked, and every API key deleted, so a squatter who registered the address
+-- first loses all three ways in. The keys matter most of the three: they are the only
+-- credential that survives a token_version bump (a key is matched against api_keys by
+-- its own hash and never consults users), and one minted with expires_at NULL would
+-- otherwise outlive the takeover forever. Same data-modifying-CTE reasoning as
+-- ResetUserPassword — the revocation cannot be separated from the seizure.
 -- Returns the new generation for the session the sign-in is about to mint.
+WITH revoked_keys AS (
+    DELETE FROM api_keys WHERE user_id = $1
+)
 UPDATE users
 SET password_hash = NULL, email_verified = true, token_version = token_version + 1
-WHERE id = $1
+WHERE users.id = $1
 RETURNING token_version;
 
 -- name: GetUserResume :one

--- a/internal/db/users.sql.go
+++ b/internal/db/users.sql.go
@@ -343,9 +343,12 @@ func (q *Queries) ListUserBlobKeys(ctx context.Context, id int64) ([]pgtype.Text
 }
 
 const resetUserPassword = `-- name: ResetUserPassword :one
+WITH revoked_keys AS (
+    DELETE FROM api_keys WHERE user_id = $1
+)
 UPDATE users
 SET password_hash = $2, email_verified = true, token_version = token_version + 1
-WHERE id = $1
+WHERE users.id = $1
 RETURNING token_version
 `
 
@@ -357,6 +360,14 @@ type ResetUserPasswordParams struct {
 // Complete a reset-by-emailed-code: set the new hash, revoke every session, and mark
 // the address verified — receiving the code IS proof of control, so a reset doubles as
 // verification and an unverified account stops being a merge target.
+//
+// The account's API keys are destroyed in the same statement. A reset is how an owner
+// takes an account back, so whoever knew the old password must lose every credential
+// minted under it — and a key authenticates against api_keys alone, so bumping
+// token_version does not reach it. The DELETE is a data-modifying CTE rather than a
+// second statement on purpose: Postgres runs it exactly once and to completion whether
+// or not the primary query reads its output, which welds the revocation to the reset so
+// no call site can perform one without the other.
 func (q *Queries) ResetUserPassword(ctx context.Context, arg ResetUserPasswordParams) (int32, error) {
 	row := q.db.QueryRow(ctx, resetUserPassword, arg.ID, arg.PasswordHash)
 	var token_version int32
@@ -365,15 +376,23 @@ func (q *Queries) ResetUserPassword(ctx context.Context, arg ResetUserPasswordPa
 }
 
 const seizeUnverifiedAccount = `-- name: SeizeUnverifiedAccount :one
+WITH revoked_keys AS (
+    DELETE FROM api_keys WHERE user_id = $1
+)
 UPDATE users
 SET password_hash = NULL, email_verified = true, token_version = token_version + 1
-WHERE id = $1
+WHERE users.id = $1
 RETURNING token_version
 `
 
 // Hand an unverified, password-backed account to the proven owner of its address when a
-// provider-verified OAuth identity arrives for it: the password is destroyed and every
-// session revoked, so a squatter who registered the address first loses both ways in.
+// provider-verified OAuth identity arrives for it: the password is destroyed, every
+// session revoked, and every API key deleted, so a squatter who registered the address
+// first loses all three ways in. The keys matter most of the three: they are the only
+// credential that survives a token_version bump (a key is matched against api_keys by
+// its own hash and never consults users), and one minted with expires_at NULL would
+// otherwise outlive the takeover forever. Same data-modifying-CTE reasoning as
+// ResetUserPassword — the revocation cannot be separated from the seizure.
 // Returns the new generation for the session the sign-in is about to mint.
 func (q *Queries) SeizeUnverifiedAccount(ctx context.Context, id int64) (int32, error) {
 	row := q.db.QueryRow(ctx, seizeUnverifiedAccount, id)

--- a/internal/handler/api_keys.go
+++ b/internal/handler/api_keys.go
@@ -2,10 +2,12 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/auth"
@@ -60,6 +62,15 @@ func (h *authHandlers) mintAPIKey(ctx context.Context, userID int64, name string
 		Scope:     auth.ScopeFull,
 		ExpiresAt: expiresAt,
 	})
+	// The statement inserts nothing — and so returns no row — when the account's address
+	// was never proven. The caller is authenticated (a session cookie got them here), so
+	// this is an authorization refusal, not a failed lookup: 403, not 404. The SPA reads
+	// email_verified from /auth/me and hides the button, so this is the guard for a
+	// direct API call rather than the message a user normally meets.
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", db.CreateAPIKeyRow{}, fiber.NewError(fiber.StatusForbidden,
+			"confirm your email address before creating an API key")
+	}
 	if err != nil {
 		return "", db.CreateAPIKeyRow{}, err
 	}

--- a/internal/handler/api_keys_integration_test.go
+++ b/internal/handler/api_keys_integration_test.go
@@ -30,10 +30,11 @@ func TestAPIKeysEndToEnd(t *testing.T) {
 	ctx := context.Background()
 
 	var ownerID, otherID int64
-	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('keys@example.test') RETURNING id`).Scan(&ownerID); err != nil {
+	// Both accounts are verified: minting a key requires a proven address.
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email, email_verified) VALUES ('keys@example.test', true) RETURNING id`).Scan(&ownerID); err != nil {
 		t.Fatalf("seed owner: %v", err)
 	}
-	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('other@example.test') RETURNING id`).Scan(&otherID); err != nil {
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email, email_verified) VALUES ('other@example.test', true) RETURNING id`).Scan(&otherID); err != nil {
 		t.Fatalf("seed other user: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
@@ -169,4 +170,48 @@ func TestAPIKeysEndToEnd(t *testing.T) {
 			t.Errorf("revoked key apply status = %d, want 401", after.StatusCode)
 		}
 	})
+}
+
+// An account whose address was never proven cannot mint an API key. Registration hands
+// out a session immediately, so without this gate a squatter who registered someone
+// else's address could take a durable, full-scope bearer credential away with them —
+// one that the later seizure of the account has to chase down.
+func TestCreateAPIKeyRequiresAVerifiedAddress(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, email_verified)
+		 VALUES ('unverified@example.test', 'hash', false) RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed unverified account: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	cookie, _ := iss.Issue(userID, testTokenVersion)
+	h := &authHandlers{queries: db.New(pool)}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Post("/api/v1/me/api-keys", auth.RequireAuth(iss, testVersions), h.CreateAPIKey)
+
+	req := httptest.NewRequest(fiber.MethodPost, "/api/v1/me/api-keys", bytes.NewBufferString(`{"name":"squatter cli"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create status = %d, want 403 (body %s)", resp.StatusCode, body)
+	}
+
+	var n int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM api_keys WHERE user_id = $1`, userID).Scan(&n); err != nil {
+		t.Fatalf("count keys: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("%d key(s) persisted for an unverified account", n)
+	}
 }

--- a/internal/handler/cv_integration_test.go
+++ b/internal/handler/cv_integration_test.go
@@ -31,7 +31,9 @@ func seedAccount(t *testing.T, pool *pgxpool.Pool, email string, beta bool) int6
 	t.Helper()
 	var id int64
 	if err := pool.QueryRow(context.Background(),
-		`INSERT INTO users (email, beta_tester) VALUES ($1, $2) RETURNING id`, email, beta).Scan(&id); err != nil {
+		// Verified, like every real account these surfaces see: an unproven address
+		// cannot mint the API key some of these fixtures need.
+		`INSERT INTO users (email, beta_tester, email_verified) VALUES ($1, $2, true) RETURNING id`, email, beta).Scan(&id); err != nil {
 		t.Fatalf("seed user %s: %v", email, err)
 	}
 	return id

--- a/internal/handler/inbox_agent_integration_test.go
+++ b/internal/handler/inbox_agent_integration_test.go
@@ -48,7 +48,8 @@ func newAgentInboxFixture(t *testing.T, email string) *agentInboxFixture {
 	queries := db.New(pool)
 
 	var uid int64
-	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&uid); err != nil {
+	// Verified: the fixture mints an API key, which an unproven address cannot do.
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email, email_verified) VALUES ($1, true) RETURNING id`, email).Scan(&uid); err != nil {
 		t.Fatalf("seed user: %v", err)
 	}
 

--- a/internal/handler/market_coverage_integration_test.go
+++ b/internal/handler/market_coverage_integration_test.go
@@ -29,9 +29,10 @@ func TestMarketCoverageEndpoint(t *testing.T) {
 	ctx := context.Background()
 	queries := db.New(pool)
 
+	// Verified: minting an API key requires a proven address.
 	var userID int64
 	if err := pool.QueryRow(ctx,
-		`INSERT INTO users (email) VALUES ('coverage@example.test') RETURNING id`).Scan(&userID); err != nil {
+		`INSERT INTO users (email, email_verified) VALUES ('coverage@example.test', true) RETURNING id`).Scan(&userID); err != nil {
 		t.Fatalf("seed user: %v", err)
 	}
 

--- a/openspec/changes/revoke-api-keys-on-account-takeover/.openspec.yaml
+++ b/openspec/changes/revoke-api-keys-on-account-takeover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/revoke-api-keys-on-account-takeover/proposal.md
+++ b/openspec/changes/revoke-api-keys-on-account-takeover/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The account-pre-hijacking defence has a credential it never revokes. When a provider-verified
+OAuth identity arrives for an unverified, password-backed account, `SeizeUnverifiedAccount`
+clears the password and bumps `token_version` — but an API key does not authenticate through
+`token_version`. `AuthenticateAPIKey` matches a presented token against `api_keys.token_hash`
+and `expires_at` alone and never joins `users`, so nothing about the seizure reaches it. The
+only `DELETE FROM api_keys` in the codebase is the owner-scoped single-key revoke.
+
+That the two are decoupled is deliberate and specified: `user-auth` carries the scenario "API
+keys survive a session revocation", so a `logout-all` leaves a user's CLI credential working.
+What the rule does not distinguish is a *session revocation* from a *change of account holder*.
+
+The gap is reachable end to end. Registration issues a session cookie before the address is
+proven, `POST /me/api-keys` has no verified-address gate, and the mint hard-codes `scope=full`
+with `expires_at` NULL when the body omits it. So a squatter who registers `victim@corp.com`
+takes away a never-expiring, full-scope bearer credential; the victim's later Google sign-in
+destroys the password and the squatter's cookie, and leaves that key untouched. It reaches the
+91 routes behind `RequireAuthOrKey` — including `/me/inbox` and `/me/emails/:id` (the victim's
+mail), `/me/cvs/:id/pdf`, `/me/profile`, `/me/experience`, `/me/tracking*`, `/me/credits`.
+
+The same hole sits behind `ResetUserPassword`. A reset by mailed code is how an owner takes an
+account back after a compromise; leaving keys minted under the old password alive makes the
+recovery cosmetic.
+
+## What Changes
+
+- **A seizure and a password reset destroy the account's API keys.** Both statements gain a
+  data-modifying CTE (`WITH revoked_keys AS (DELETE FROM api_keys WHERE user_id = $1)`), so the
+  revocation is welded to the takeover rather than left to a call site to remember. Postgres
+  runs such a CTE exactly once and to completion whether or not the outer query reads it.
+- **`logout-all` and a password change are unchanged.** They are the account holder's own
+  actions, not a change of holder; the existing "API keys survive a session revocation" rule
+  keeps a user's CLI and agent integrations working across "sign out everywhere". The rule is
+  narrowed to say which events are the exception.
+- **An account whose address was never proven cannot mint an API key.** `CreateAPIKey` becomes
+  `INSERT ... SELECT ... WHERE users.id = $1 AND users.email_verified`; no row inserted means
+  `403`. This closes the vector at the issuing end, so it does not depend on a future revocation
+  path remembering `api_keys` — and no call site can mint around it.
+
+## Impact
+
+- Specs: `user-auth` (identity resolution, global session revocation), `password-recovery`
+  (reset by code), `api-keys` (creating a key).
+- Code: `internal/db/queries/users.sql`, `internal/db/queries/api_keys.sql` (+ `make sqlc`),
+  `internal/handler/api_keys.go`.
+- No migration. `CreateAPIKeyParams` is unchanged, so no call site churns.
+- Behaviour change for clients: `POST /api/v1/me/api-keys` now answers `403` for an unverified
+  account. Migration `0041` grandfathered every pre-existing account as verified, so only
+  accounts registered by password and not yet confirmed are affected. The SPA already reads
+  `email_verified` from `/auth/me`.

--- a/openspec/changes/revoke-api-keys-on-account-takeover/specs/api-keys/spec.md
+++ b/openspec/changes/revoke-api-keys-on-account-takeover/specs/api-keys/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Creating an API key
+
+The system SHALL let a signed-in user with a **proven email address** create a named API key,
+and SHALL refuse the request when the account's address was never proven. The server SHALL
+generate an opaque, high-entropy token, return the plaintext token **exactly once** in the
+creation response, and persist only a SHA-256 hash of it plus a short non-secret display prefix
+— never the plaintext. Creation SHALL accept an optional expiry; absent an expiry the key SHALL
+never expire.
+
+The verified-address condition SHALL be enforced in the statement that inserts the key, not in
+a check a call site could bypass. Registration issues a session before the address is proven,
+so without this gate someone who registered another person's address could take away a
+never-expiring, full-scope credential and keep it past the seizure that hands the account to
+its proven owner.
+
+#### Scenario: Create returns the secret once
+
+- **WHEN** a signed-in user with a verified address sends `POST /api/v1/me/api-keys` with a `name`
+- **THEN** the system responds `201` with `{"data": {id, name, token_prefix,
+  created_at, expires_at, token}}` where `token` is the full plaintext key
+- **AND** the stored row holds only the token's SHA-256 hash and `token_prefix`,
+  not the plaintext
+
+#### Scenario: An unverified address cannot mint a key
+
+- **WHEN** a signed-in user whose email is not verified sends `POST /api/v1/me/api-keys`
+- **THEN** the system responds `403` and persists no key
+
+#### Scenario: The secret is never returned again
+
+- **WHEN** the key is later listed or otherwise read
+- **THEN** no endpoint returns the plaintext token or its hash again
+
+#### Scenario: Optional expiry is honored
+
+- **WHEN** a user creates a key with an `expires_at` in the future
+- **THEN** the key authenticates until that moment and `expires_at` is reflected
+  in the key's metadata
+- **AND** a key created without an expiry has a null `expires_at` and does not
+  expire

--- a/openspec/changes/revoke-api-keys-on-account-takeover/specs/password-recovery/spec.md
+++ b/openspec/changes/revoke-api-keys-on-account-takeover/specs/password-recovery/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Password reset by code
+
+The system SHALL set a new password when presented with a valid, unexpired reset code for the
+address, SHALL treat a successful reset as proof of email ownership, and SHALL destroy every
+credential minted under the old password.
+
+- The new password SHALL satisfy the same rules as registration (8–72 characters).
+- The account MAY have had no password before; the reset then sets its first one.
+- A successful reset SHALL mark the account's email verified.
+- A successful reset SHALL revoke every existing session for that account.
+- A successful reset SHALL delete every API key of that account, atomically with the reset.
+  A reset by mailed code is how an owner takes an account back after a compromise, and an API
+  key authenticates against its own stored hash rather than the account's session generation,
+  so revoking the sessions alone would leave whoever knew the old password with programmatic
+  access to the recovered account.
+- The code SHALL be consumed on success and invalidated after 5 failed attempts.
+
+#### Scenario: Valid code sets the password
+
+- **WHEN** a client POSTs the address, the mailed code, and an 8+ character password to `/api/v1/auth/password/reset`
+- **THEN** the system stores the new bcrypt hash, marks the email verified, and responds `200`
+
+#### Scenario: Reset kills existing sessions
+
+- **WHEN** a reset succeeds while another client holds a session cookie for the same account
+- **THEN** that client's next authenticated request responds `401`
+
+#### Scenario: Reset kills the account's API keys
+
+- **WHEN** a reset succeeds while an API key exists for the account
+- **THEN** the key is deleted and its next request responds `401`
+
+#### Scenario: Wrong or expired code
+
+- **WHEN** a client submits an incorrect or expired code
+- **THEN** the system responds `400`, the stored password is unchanged, and the failed attempt counts toward the attempt limit
+
+#### Scenario: Weak new password
+
+- **WHEN** a client submits a valid code with a password shorter than 8 or longer than 72 characters
+- **THEN** the system responds `400` and the stored password is unchanged

--- a/openspec/changes/revoke-api-keys-on-account-takeover/specs/user-auth/spec.md
+++ b/openspec/changes/revoke-api-keys-on-account-takeover/specs/user-auth/spec.md
@@ -1,0 +1,97 @@
+## MODIFIED Requirements
+
+### Requirement: External identity account resolution
+
+The system SHALL key external identities by `(provider, provider_user_id)` in
+a `user_identities` table referencing `users`, resolving each OAuth sign-in to
+exactly one account, and SHALL never merge a provider identity into an account
+whose email ownership was never proven without first destroying every credential
+that account's previous holder may hold.
+
+- A sign-in matching an existing identity SHALL resolve to its linked user.
+- A first-time identity whose **verified** provider email matches an existing
+  **verified** account (case-insensitive) SHALL be linked to that account,
+  leaving its password and its API keys intact.
+- A first-time identity whose **verified** provider email matches an existing
+  **unverified**, password-backed account SHALL be linked to that account, and
+  the system SHALL clear that account's `password_hash`, mark it verified,
+  revoke its existing sessions, and delete its API keys — the address's proven
+  owner takes the account and every way the squatter had in stops working.
+  Deleting the keys is not covered by revoking the sessions: an API key
+  authenticates against its own stored hash and never consults the account's
+  session generation, so a key minted before the seizure would otherwise
+  outlive it indefinitely.
+- The seizure and the key deletion SHALL be atomic with each other, so no path
+  can perform one without the other.
+- A first-time identity with no matching account SHALL create a new
+  passwordless user (`password_hash` NULL), marked verified, plus the identity,
+  in one transaction.
+- An identity whose provider email is unverified or absent SHALL NOT be linked
+  by email and SHALL NOT create an account keyed to that email; the sign-in
+  fails.
+
+#### Scenario: Returning OAuth user
+
+- **WHEN** a user signs in via a provider identity that already exists
+- **THEN** the system starts a session for the linked user without touching `users` or creating rows
+
+#### Scenario: First OAuth sign-in linking an existing password account
+
+- **WHEN** a user signs in via a new provider identity whose verified email matches an existing **verified** account
+- **THEN** the system adds the identity linked to that account and starts a session for it, leaving the password intact
+
+#### Scenario: First OAuth sign-in seizing an unverified account
+
+- **WHEN** a user signs in via a new provider identity whose verified email matches an existing unverified account that has a password
+- **THEN** the system links the identity, clears the stored password hash, marks the account verified, bumps its token version, and starts a session — so the previous password and any session minted with it no longer authenticate
+
+#### Scenario: Seizure destroys the previous holder's API keys
+
+- **WHEN** the seized account held an API key, including one minted with no expiry
+- **THEN** the key is deleted and its next request responds `401`, so the squatter keeps no bearer access to the account they just lost the password and sessions to
+
+#### Scenario: Seizure touches no other account's keys
+
+- **WHEN** an account is seized while another account holds its own API keys
+- **THEN** only the seized account's keys are deleted
+
+#### Scenario: First OAuth sign-in creating a new account
+
+- **WHEN** a user signs in via a new provider identity whose verified email matches no account
+- **THEN** the system creates a passwordless, verified user and the identity in one transaction and starts a session
+
+#### Scenario: Unverified provider email never links
+
+- **WHEN** a provider returns an identity whose email is unverified or missing
+- **THEN** the system links nothing, creates nothing, and redirects to the SPA with `auth_error`
+
+### Requirement: Global session revocation
+
+The system SHALL let a signed-in user invalidate every session issued for their account,
+including the caller's own, by bumping a per-account token version that every authenticated
+request is checked against.
+
+- `POST /api/v1/auth/logout-all` SHALL be reachable with a session cookie only.
+- The endpoint SHALL bump the account's token version and clear the caller's cookie.
+- Password reset, password change, and an OAuth seizure of an unverified account SHALL bump
+  the same counter.
+- A token-version bump SHALL NOT by itself revoke the account's API keys: a key is a durable
+  programmatic credential, not a session, and "sign out everywhere" is the account holder's own
+  action. The events that additionally destroy every API key are exactly the two where the
+  account changes hands — a password reset by mailed code and an OAuth seizure of an unverified
+  account — and they are specified with those flows, not here.
+
+#### Scenario: Sign out everywhere
+
+- **WHEN** a signed-in user POSTs to `/api/v1/auth/logout-all`
+- **THEN** the system bumps the account's token version, clears the caller's session cookie, and every other session for that account fails its next authenticated request with `401`
+
+#### Scenario: API keys survive a session revocation
+
+- **WHEN** the account's token version is bumped by `logout-all` or a password change
+- **THEN** the account's live API keys continue to authenticate, since they are revoked individually
+
+#### Scenario: Revocation requires a session
+
+- **WHEN** the request presents no session cookie, or authenticates with an API key
+- **THEN** the system responds `401` and bumps nothing

--- a/openspec/changes/revoke-api-keys-on-account-takeover/tasks.md
+++ b/openspec/changes/revoke-api-keys-on-account-takeover/tasks.md
@@ -1,0 +1,18 @@
+## 1. Keys die with the account's previous holder
+
+- [x] 1.1 Add failing integration tests in `internal/accounts/credential_revocation_integration_test.go`: a squatted account holding a never-expiring full-scope key keeps zero keys after `LinkOrCreateByEmail` seizes it; a `ResetPassword` leaves zero keys; a bystander account's key is untouched by someone else's seizure.
+- [x] 1.2 Add the `WITH revoked_keys AS (DELETE FROM api_keys WHERE user_id = $1)` CTE to `SeizeUnverifiedAccount` and `ResetUserPassword` in `internal/db/queries/users.sql`, documenting why the DELETE is welded to the statement rather than issued as a second call. Qualify the update's predicate as `WHERE users.id = $1` — the CTE puts `api_keys` columns in scope and sqlc rejects the bare `id` as ambiguous. Run `sqlc generate`.
+- [x] 1.3 Confirm the existing seizure/link tests stay green: a verified account keeps its password and session generation, an unverified passwordless one is only marked verified.
+
+## 2. An unproven address cannot mint a key
+
+- [x] 2.1 Add a failing integration test `TestCreateAPIKeyRequiresAVerifiedAddress` in `internal/handler/api_keys_integration_test.go`: an unverified account with a valid session cookie gets `403` from `POST /me/api-keys` and persists no row.
+- [x] 2.2 Turn `CreateAPIKey` into `INSERT ... SELECT $1, $2, … FROM users WHERE users.id = $1 AND users.email_verified`. Select the literal `$1` rather than `users.id` so sqlc names the parameter after the INSERT target column and `CreateAPIKeyParams.UserID` is unchanged.
+- [x] 2.3 Map `pgx.ErrNoRows` from `CreateAPIKey` to `403 "confirm your email address before creating an API key"` in `mintAPIKey`. The caller is authenticated, so this is an authorization refusal, not a missing row.
+- [x] 2.4 Update the fixtures that mint keys to seed verified accounts (`internal/handler` `seedAccount`, the agent-inbox and market-coverage seeds, `internal/db` `seedAPIKeyUser`, `TestAPIKeyScope`). Leave `internal/db`'s `seedAccount` unverified — the verification and seizure tests depend on it.
+
+## 3. Verification
+
+- [x] 3.1 `go build ./... && go vet ./... && gofmt -l internal/` clean.
+- [x] 3.2 `go test ./...` green.
+- [x] 3.3 `go test -tags=integration ./...` green.


### PR DESCRIPTION
## What

`SeizeUnverifiedAccount` — the account-pre-hijacking defence — clears the password and bumps `token_version`, but `AuthenticateAPIKey` matches `token_hash` + `expires_at` and never joins `users`. So the one credential the seizure did not revoke is the durable one.

Reachable end to end: registration issues a session before the address is proven, `POST /me/api-keys` had no verified-address gate, and the mint hard-codes `scope=full` with a NULL expiry. A squatter on `victim@corp.com` keeps a never-expiring, full-scope key across the seizure, over the 91 routes behind `RequireAuthOrKey` — including `/me/inbox` and `/me/emails/:id`. The same hole sat behind `ResetUserPassword`.

## Approach

Keys surviving a `token_version` bump is **specified** (`user-auth`: "API keys survive a session revocation") so a CLI credential outlives sign-out-everywhere. What the rule missed is the difference between a session revocation and a change of account holder. So only the two takeover statements delete keys; `logout-all` and a password change are untouched.

- `SeizeUnverifiedAccount` / `ResetUserPassword` carry `WITH revoked_keys AS (DELETE FROM api_keys WHERE user_id = $1)`. A data-modifying CTE runs exactly once and to completion regardless of the outer query, which welds the revocation to the takeover instead of leaving it to a call site to remember — precisely how it was missed.
- Second, independent layer: `CreateAPIKey` becomes `INSERT ... SELECT ... WHERE users.email_verified`; no row → `403`. An unproven address cannot mint a key at all, so the fix does not depend on a future revocation path remembering `api_keys`.

No migration. `CreateAPIKeyParams` is unchanged (the query selects the literal `$1`, not `users.id`, so sqlc keeps the name) — zero call-site churn.

## Behaviour change

`POST /api/v1/me/api-keys` answers `403 "confirm your email address before creating an API key"` for an unverified account. Migration `0041` grandfathered every pre-existing account as verified, so only new password registrations that have not confirmed are affected; the SPA already reads `email_verified` from `/auth/me`.

## Verification

- `go build ./... && go vet ./... && gofmt -l internal/` clean
- `go test ./...` green
- `go test -tags=integration ./...` green
- New tests fail against the old SQL for the stated reason (verified before the fix): the seizure and the reset each left 1 live key.

## Specs

`openspec/changes/revoke-api-keys-on-account-takeover` — `openspec validate --strict` passes. Modifies `user-auth`, `password-recovery`, `api-keys`.