### PR TITLE
fix(jobs): a page whose posting is a duplicate is still a page we know

### DIFF
--- a/internal/db/find_job_by_url_integration_test.go
+++ b/internal/db/find_job_by_url_integration_test.go
@@ -102,7 +102,7 @@ func TestFindOpenJobByURL_ResolvesDespiteURLNoise(t *testing.T) {
 	}
 }
 
-func TestFindOpenJobByURL_SkipsClosedAndDuplicatePostings(t *testing.T) {
+func TestFindOpenJobByURL_SkipsClosedAndFollowsDuplicates(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
 	ctx := context.Background()
@@ -119,7 +119,32 @@ func TestFindOpenJobByURL_SkipsClosedAndDuplicatePostings(t *testing.T) {
 		}
 	})
 
-	t.Run("duplicate", func(t *testing.T) {
+	// A duplicate is not "nothing here". The candidate is standing on a page whose
+	// vacancy the catalogue holds; the dedup passes merely picked a twin to represent
+	// the group. Answer with that twin — one in five open postings is a duplicate, so
+	// the alternative is telling every fifth page it is unknown.
+	t.Run("duplicate resolves to what it duplicates", func(t *testing.T) {
+		truncate(t, pool)
+		mustUpsert(t, q, urlJob("himalayas:canonical", "https://himalayas.app/companies/mindera/jobs/other"))
+		mustUpsert(t, q, urlJob("himalayas:dup", himalayasPosting))
+		canonicalID, _ := dupOf(t, pool, "himalayas:canonical")
+		const canonicalSlug = "pslug-himalayas:canonical"
+		if _, err := pool.Exec(ctx,
+			"UPDATE jobs SET duplicate_of = $1 WHERE external_id = $2", canonicalID, "himalayas:dup"); err != nil {
+			t.Fatalf("suppress himalayasPosting: %v", err)
+		}
+		slug, err := findByURL(t, q, himalayasPosting)
+		if err != nil {
+			t.Fatalf("duplicate page: %v", err)
+		}
+		if slug != canonicalSlug {
+			t.Errorf("duplicate page resolved to %q, want the canonical %q", slug, canonicalSlug)
+		}
+	})
+
+	// Unless the representative is gone. Then the open row in hand is the best answer
+	// there is, and reporting nothing would hide a vacancy that is still live.
+	t.Run("duplicate of a closed canonical answers with itself", func(t *testing.T) {
 		truncate(t, pool)
 		mustUpsert(t, q, urlJob("himalayas:canonical", "https://himalayas.app/companies/mindera/jobs/other"))
 		mustUpsert(t, q, urlJob("himalayas:dup", himalayasPosting))
@@ -128,8 +153,15 @@ func TestFindOpenJobByURL_SkipsClosedAndDuplicatePostings(t *testing.T) {
 			"UPDATE jobs SET duplicate_of = $1 WHERE external_id = $2", canonicalID, "himalayas:dup"); err != nil {
 			t.Fatalf("suppress himalayasPosting: %v", err)
 		}
-		if slug, err := findByURL(t, q, himalayasPosting); !errors.Is(err, pgx.ErrNoRows) {
-			t.Errorf("suppressed posting resolved to %q (err %v), want no rows", slug, err)
+		if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = now() WHERE id = $1", canonicalID); err != nil {
+			t.Fatalf("close canonical: %v", err)
+		}
+		slug, err := findByURL(t, q, himalayasPosting)
+		if err != nil {
+			t.Fatalf("duplicate page: %v", err)
+		}
+		if slug == "" || slug == "pslug-himalayas:canonical" {
+			t.Errorf("resolved to %q, want the duplicate's own slug", slug)
 		}
 	})
 }
@@ -202,7 +234,10 @@ func TestFindOpenJobByURL_UsesTheExpressionIndex(t *testing.T) {
 		plan.WriteString(line)
 		plan.WriteString("\n")
 	}
-	if !strings.Contains(plan.String(), "jobs_normalized_url_idx") {
-		t.Errorf("plan does not use jobs_normalized_url_idx:\n%s", plan.String())
+	// The open-rows index (0051), not the canonical-only one (0042): this lookup now
+	// matches duplicates too. Without an index it is a sequential scan of every open
+	// posting, which is what this endpoint was rewritten to escape.
+	if !strings.Contains(plan.String(), "jobs_normalized_url_open_idx") {
+		t.Errorf("plan does not use jobs_normalized_url_open_idx:\n%s", plan.String())
 	}
 }

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -318,12 +318,12 @@ func (q *Queries) ExistingExternalIDsByBoard(ctx context.Context, arg ExistingEx
 }
 
 const findOpenJobByURL = `-- name: FindOpenJobByURL :one
-SELECT public_slug
-FROM jobs
-WHERE normalize_job_url(url) = normalize_job_url($1)
-  AND closed_at IS NULL
-  AND duplicate_of IS NULL
-ORDER BY last_seen_at DESC, id DESC
+SELECT COALESCE(canonical.public_slug, j.public_slug)
+FROM jobs j
+LEFT JOIN jobs canonical ON canonical.id = j.duplicate_of AND canonical.closed_at IS NULL
+WHERE normalize_job_url(j.url) = normalize_job_url($1)
+  AND j.closed_at IS NULL
+ORDER BY (j.duplicate_of IS NULL) DESC, j.last_seen_at DESC, j.id DESC
 LIMIT 1
 `
 
@@ -332,10 +332,21 @@ LIMIT 1
 // URL. Both sides go through normalize_job_url (migration 0042), so a link differing only
 // by scheme, www., tracking query, fragment, case or trailing slash still matches; the
 // same expression backs jobs_normalized_url_idx, so this is an index lookup.
-// Scoped to open canonical rows, matching that partial index: a closed or suppressed
-// posting is not one to show a match card for. Two open rows may share a URL (an
-// aggregator and an ATS row the dedup passes have not collapsed), so the most recently
-// confirmed one wins, with id as the deterministic tiebreak.
+// Scoped to open rows: a closed posting is not one to show a match card for.
+//
+// Duplicates ARE matched, and answer with the posting they duplicate. One in five open
+// postings is a duplicate of another, and the candidate standing on one is looking at a
+// vacancy the catalogue knows — answering "we do not have this" because the dedup passes
+// preferred a twin is wrong from where they are sitting. This is the opposite of what the
+// search index wants (one row per group), which is why the scoping lives here and not in
+// the dedup itself.
+//
+// A duplicate whose canonical row has since closed falls back to its own slug: the group's
+// chosen representative is gone, and this one is still open.
+//
+// Two open rows may share a URL (an aggregator and an ATS row the dedup passes have not
+// collapsed), so a canonical row wins over a duplicate, then the most recently confirmed,
+// with id as the deterministic tiebreak.
 func (q *Queries) FindOpenJobByURL(ctx context.Context, url string) (string, error) {
 	row := q.db.QueryRow(ctx, findOpenJobByURL, url)
 	var public_slug string

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -563,10 +563,21 @@ type Querier interface {
 	// URL. Both sides go through normalize_job_url (migration 0042), so a link differing only
 	// by scheme, www., tracking query, fragment, case or trailing slash still matches; the
 	// same expression backs jobs_normalized_url_idx, so this is an index lookup.
-	// Scoped to open canonical rows, matching that partial index: a closed or suppressed
-	// posting is not one to show a match card for. Two open rows may share a URL (an
-	// aggregator and an ATS row the dedup passes have not collapsed), so the most recently
-	// confirmed one wins, with id as the deterministic tiebreak.
+	// Scoped to open rows: a closed posting is not one to show a match card for.
+	//
+	// Duplicates ARE matched, and answer with the posting they duplicate. One in five open
+	// postings is a duplicate of another, and the candidate standing on one is looking at a
+	// vacancy the catalogue knows — answering "we do not have this" because the dedup passes
+	// preferred a twin is wrong from where they are sitting. This is the opposite of what the
+	// search index wants (one row per group), which is why the scoping lives here and not in
+	// the dedup itself.
+	//
+	// A duplicate whose canonical row has since closed falls back to its own slug: the group's
+	// chosen representative is gone, and this one is still open.
+	//
+	// Two open rows may share a URL (an aggregator and an ATS row the dedup passes have not
+	// collapsed), so a canonical row wins over a duplicate, then the most recently confirmed,
+	// with id as the deterministic tiebreak.
 	FindOpenJobByURL(ctx context.Context, url string) (string, error)
 	// One session owned by the caller. Owner-scoped: a foreign or missing id returns no row,
 	// which the handler maps to 404 — so a probe cannot tell the two apart.

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -121,16 +121,27 @@ WHERE source = $1 AND external_id = $2;
 -- URL. Both sides go through normalize_job_url (migration 0042), so a link differing only
 -- by scheme, www., tracking query, fragment, case or trailing slash still matches; the
 -- same expression backs jobs_normalized_url_idx, so this is an index lookup.
--- Scoped to open canonical rows, matching that partial index: a closed or suppressed
--- posting is not one to show a match card for. Two open rows may share a URL (an
--- aggregator and an ATS row the dedup passes have not collapsed), so the most recently
--- confirmed one wins, with id as the deterministic tiebreak.
-SELECT public_slug
-FROM jobs
-WHERE normalize_job_url(url) = normalize_job_url(@url)
-  AND closed_at IS NULL
-  AND duplicate_of IS NULL
-ORDER BY last_seen_at DESC, id DESC
+-- Scoped to open rows: a closed posting is not one to show a match card for.
+--
+-- Duplicates ARE matched, and answer with the posting they duplicate. One in five open
+-- postings is a duplicate of another, and the candidate standing on one is looking at a
+-- vacancy the catalogue knows — answering "we do not have this" because the dedup passes
+-- preferred a twin is wrong from where they are sitting. This is the opposite of what the
+-- search index wants (one row per group), which is why the scoping lives here and not in
+-- the dedup itself.
+--
+-- A duplicate whose canonical row has since closed falls back to its own slug: the group's
+-- chosen representative is gone, and this one is still open.
+--
+-- Two open rows may share a URL (an aggregator and an ATS row the dedup passes have not
+-- collapsed), so a canonical row wins over a duplicate, then the most recently confirmed,
+-- with id as the deterministic tiebreak.
+SELECT COALESCE(canonical.public_slug, j.public_slug)
+FROM jobs j
+LEFT JOIN jobs canonical ON canonical.id = j.duplicate_of AND canonical.closed_at IS NULL
+WHERE normalize_job_url(j.url) = normalize_job_url(@url)
+  AND j.closed_at IS NULL
+ORDER BY (j.duplicate_of IS NULL) DESC, j.last_seen_at DESC, j.id DESC
 LIMIT 1;
 
 -- name: GetJobIDBySlug :one

--- a/internal/handler/find_job_integration_test.go
+++ b/internal/handler/find_job_integration_test.go
@@ -94,6 +94,29 @@ func TestFindJobResolvesByIdentityAndByURL(t *testing.T) {
 		}
 	})
 
+	// One in five open postings is a duplicate of another. The candidate is standing
+	// on a page we know perfectly well; answering "freehire does not have this" because
+	// the dedup passes preferred a twin is wrong from where they are sitting.
+	t.Run("a duplicate page resolves to the posting it duplicates", func(t *testing.T) {
+		if _, err := pool.Exec(ctx,
+			`WITH canonical AS (
+			   INSERT INTO jobs (source, external_id, url, title, public_slug)
+			   VALUES ('ashby', 'truelogic:ef27e902', 'https://jobs.ashbyhq.com/truelogic/ef27e902', 'Senior Full Stack', 'senior-full-stack-canonical')
+			   RETURNING id
+			 )
+			 INSERT INTO jobs (source, external_id, url, title, public_slug, duplicate_of)
+			 SELECT 'ashby', 'truelogic:c6d2719d', 'https://jobs.ashbyhq.com/truelogic/c6d2719d',
+			        'Senior Full Stack', 'senior-full-stack-duplicate', id
+			 FROM canonical`); err != nil {
+			t.Fatalf("seed duplicate pair: %v", err)
+		}
+
+		const page = "https%3A%2F%2Fjobs.ashbyhq.com%2Ftruelogic%2Fc6d2719d"
+		if slug := findSlug(t, app, page); slug != "senior-full-stack-canonical" {
+			t.Errorf("slug = %q, want the canonical posting", slug)
+		}
+	})
+
 	t.Run("unknown page is unresolved", func(t *testing.T) {
 		if slug := findSlug(t, app, "https%3A%2F%2Fexample.test%2Fcareers%2Fsome-job"); slug != "" {
 			t.Errorf("slug = %q, want no match", slug)

--- a/migrations/0051_jobs_normalized_url_open_idx.sql
+++ b/migrations/0051_jobs_normalized_url_open_idx.sql
@@ -1,0 +1,24 @@
+-- Match a job page even when the posting on it is a duplicate.
+--
+-- 0042 indexed normalize_job_url(url) over OPEN CANONICAL rows, which is what a listing
+-- wants: one row per dedup group. The extension asks a different question — "what is the
+-- page in front of me?" — and there the answer is the vacancy, whichever row of the group
+-- carries the URL the candidate is standing on. One in five open postings is a duplicate,
+-- so the narrower index made every fifth page report that freehire does not have it.
+--
+-- This index drops `duplicate_of IS NULL` and keeps `closed_at IS NULL`; the query then
+-- follows duplicate_of to the canonical row. The 0042 index stays: it is narrower and
+-- still the right one for lookups that only want canonical rows.
+--
+-- Applied to a fresh volume by initdb after 0050. On the live database create it
+-- CONCURRENTLY instead, so the build takes no write lock on a 3.3M-row table:
+--
+--   CREATE INDEX CONCURRENTLY jobs_normalized_url_open_idx
+--       ON public.jobs (public.normalize_job_url(url)) WHERE closed_at IS NULL;
+--
+-- Run that from a session that survives a dropped connection (nohup/screen): a
+-- CONCURRENTLY build killed midway leaves an INVALID index behind, which has to be
+-- dropped before retrying.
+CREATE INDEX jobs_normalized_url_open_idx
+    ON public.jobs (public.normalize_job_url(url))
+    WHERE (closed_at IS NULL);


### PR DESCRIPTION
Reported from the side panel: *"freehire doesn't have this posting"* on an Ashby
vacancy — with a match card for that vacancy on the page behind.

It does have it. Truelogic published the role twice under different Ashby ids, the
dedup passes merged them, and the candidate was standing on the row that lost.

## Scale

| | open postings |
| --- | --- |
| canonical | 2,686,542 |
| **duplicates** | **669,951** |

One in five pages. Not an edge.

## Why it happened

`FindOpenJobByURL` was scoped to open **canonical** rows, matching the partial
index 0042 built (`WHERE closed_at IS NULL AND duplicate_of IS NULL`).

That scoping is right for a listing, which wants one row per dedup group. It is
wrong for *"what is the page in front of me?"* — there the answer is the vacancy,
whichever row of the group happens to carry the URL the candidate is standing on.

## The fix

The query matches duplicates and follows `duplicate_of` to the canonical row. A
duplicate whose canonical has since closed answers with itself: the group's chosen
representative is gone and this row is still open, so reporting nothing would hide
a live vacancy.

## Deploy

`migrations/0051_jobs_normalized_url_open_idx.sql` — the same expression as 0042
without `duplicate_of IS NULL`. Both indexes stay; 0042 is narrower and still
right for lookups that only want canonical rows.

**On prod, create it CONCURRENTLY, from a session that survives a dropped
connection** (3.36M rows):

```sql
CREATE INDEX CONCURRENTLY jobs_normalized_url_open_idx
    ON public.jobs (public.normalize_job_url(url)) WHERE closed_at IS NULL;
```

A CONCURRENTLY build killed midway leaves an INVALID index that must be dropped
before retrying. The migration file repeats this.

## Tests

Two db tests asserted the old contract and now assert the new one — including the
EXPLAIN test, which is what keeps this lookup off a sequential scan of 3.3M rows
and now names the new index. Plus the panel-level case in
`find_job_integration_test.go` reproducing the report.

`go build`, `go vet`, `gofmt`, `go test ./...` (109), `go test -tags=integration
./internal/db/ ./internal/handler/`.