### PR TITLE
fix(sources): a hybrid role is not a remote one

### DIFF
--- a/internal/linksource/ashby_test.go
+++ b/internal/linksource/ashby_test.go
@@ -61,3 +61,27 @@ func TestAshbySkipsWhenJobNotOnBoard(t *testing.T) {
 		t.Error("ok=true, want skip for a job no longer on the board")
 	}
 }
+
+// Link resolution shares MapAshbyPosting with the ingest adapter, so a hybrid posting
+// resolves to the same facets on both paths.
+func TestAshbyResolvesHybridPostingAsNotRemote(t *testing.T) {
+	const board = `{"apiVersion":"1","jobs":[
+ {"id":"d675ca96-5678-4ed9-be94-01fa1e641f28","title":"Senior Web Designer","location":"Vilnius","jobUrl":"https://jobs.ashbyhq.com/surfshark/d675ca96-5678-4ed9-be94-01fa1e641f28","publishedAt":"2026-07-28T09:35:42.943+00:00","descriptionHtml":"<p>Design it.</p>","isRemote":true,"workplaceType":"Hybrid"}
+]}`
+	const link = "https://jobs.ashbyhq.com/surfshark/d675ca96-5678-4ed9-be94-01fa1e641f28"
+	c := (&fakeClient{}).route("api.ashbyhq.com/posting-api/job-board/surfshark", board, "")
+
+	job, ok, err := NewAshby(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	if job.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid from workplaceType", job.WorkMode)
+	}
+	if job.Remote {
+		t.Error("Remote = true, want false: a hybrid role is not remote")
+	}
+}

--- a/internal/sources/ashby.go
+++ b/internal/sources/ashby.go
@@ -49,25 +49,29 @@ type AshbyPosting struct {
 	PublishedAt     string `json:"publishedAt"`
 	DescriptionHTML string `json:"descriptionHtml"`
 	IsRemote        bool   `json:"isRemote"`
+	WorkplaceType   string `json:"workplaceType"`
 	EmploymentType  string `json:"employmentType"`
 }
 
 // MapAshbyPosting maps an Ashby API posting into a Job, so the board adapter and the
-// link-following adapter produce identical facets for the same posting. Remote unions the
-// explicit isRemote flag with the location heuristic (a false flag with a "Remote"
-// location is genuinely remote — the greenhouse convention), while WorkMode carries the
-// structured signal only. ExternalID and Company are left to the caller: the board
-// adapter sets the raw id (the pipeline namespaces it by board) and the configured
-// company; the link resolver namespaces the id itself and derives the company from the
-// board slug (the per-board API carries no company name).
+// link-following adapter produce identical facets for the same posting. workplaceType —
+// what the board renders as "Location Type" — decides the work mode; isRemote only says
+// "not strictly onsite" (a hybrid posting sets it too), so it is the fallback for boards
+// that omit workplaceType. Remote unions the resolved mode with the location heuristic,
+// keeping the greenhouse convention that a "Remote" location alone marks a job remote.
+// ExternalID and Company are left to the caller: the board adapter sets the raw id (the
+// pipeline namespaces it by board) and the configured company; the link resolver
+// namespaces the id itself and derives the company from the board slug (the per-board API
+// carries no company name).
 func MapAshbyPosting(j AshbyPosting) Job {
+	mode := firstNonEmpty(workplaceTypeMode(j.WorkplaceType), workModeFromRemote(j.IsRemote))
 	return Job{
 		URL:            j.JobURL,
 		Title:          j.Title,
 		Location:       j.Location,
 		Description:    sanitizeHTML(j.DescriptionHTML),
-		Remote:         j.IsRemote || isRemote(j.Location),
-		WorkMode:       workModeFromRemote(j.IsRemote),
+		Remote:         mode == "remote" || isRemote(j.Location),
+		WorkMode:       mode,
 		PostedAt:       parseRFC3339(j.PublishedAt),
 		EmploymentType: ashbyEmploymentType(j.EmploymentType),
 	}

--- a/internal/sources/ashby.go
+++ b/internal/sources/ashby.go
@@ -9,7 +9,7 @@ import (
 const ashbyBaseURL = "https://api.ashbyhq.com/posting-api/job-board"
 
 // ashby adapts the Ashby public job-board API. The list endpoint carries an HTML
-// description and an explicit remote flag, so no per-posting detail request is needed.
+// description and the posting's workplace type, so no per-posting detail request is needed.
 type ashby struct {
 	http JSONGetter
 }

--- a/internal/sources/ashby_test.go
+++ b/internal/sources/ashby_test.go
@@ -64,14 +64,13 @@ func TestAshbyFetch(t *testing.T) {
 	if strings.Contains(j.Description, "<script") {
 		t.Errorf("Description retained a script tag, got %q", j.Description)
 	}
-	// Remote unions Ashby's explicit isRemote flag with the location heuristic (see
-	// MapAshbyPosting); here the flag alone sets it.
+	// This posting carries no workplaceType, so isRemote is the fallback that resolves
+	// the mode — and Remote follows from that resolved mode (see MapAshbyPosting).
 	if !j.Remote {
-		t.Error("Remote = false, want true from the explicit isRemote field")
+		t.Error("Remote = false, want true from the isRemote fallback")
 	}
-	// The explicit isRemote flag also yields a structured work mode.
 	if j.WorkMode != "remote" {
-		t.Errorf("WorkMode = %q, want remote from the explicit isRemote field", j.WorkMode)
+		t.Errorf("WorkMode = %q, want remote from the isRemote fallback", j.WorkMode)
 	}
 	if j.PostedAt == nil {
 		t.Error("PostedAt = nil, want parsed publishedAt with milliseconds")

--- a/internal/sources/ashby_test.go
+++ b/internal/sources/ashby_test.go
@@ -77,3 +77,43 @@ func TestAshbyFetch(t *testing.T) {
 		t.Error("PostedAt = nil, want parsed publishedAt with milliseconds")
 	}
 }
+
+// Ashby sets isRemote on every posting that is not strictly onsite, so a hybrid role
+// carries isRemote=true alongside workplaceType="Hybrid". workplaceType is the field the
+// Ashby board itself renders as "Location Type", so it decides the work mode.
+func TestAshbyFetchWorkplaceTypeBeatsIsRemote(t *testing.T) {
+	fake := &fakeHTTP{body: `{
+		"jobs": [
+			{
+				"id": "hybrid-uuid",
+				"title": "Senior Web Designer",
+				"location": "Vilnius",
+				"jobUrl": "https://jobs.ashbyhq.com/surfshark/hybrid-uuid",
+				"publishedAt": "2026-07-28T09:35:42.943+00:00",
+				"descriptionHtml": "<p>Design it.</p>",
+				"isRemote": true,
+				"workplaceType": "Hybrid"
+			}
+		]
+	}`}
+
+	jobs, err := NewAshby(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Surfshark", Provider: "ashby", Board: "surfshark",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid from workplaceType", j.WorkMode)
+	}
+	// A hybrid role requires office presence, so it is not remote — and its location
+	// text carries no "remote" to trigger the heuristic either.
+	if j.Remote {
+		t.Error("Remote = true, want false: a hybrid role is not remote")
+	}
+}

--- a/internal/sources/bamboohr.go
+++ b/internal/sources/bamboohr.go
@@ -91,7 +91,7 @@ func (b bambooHR) detail(ctx context.Context, e CompanyEntry, p bambooHRPosting)
 		Company:     e.Company,
 		Location:    location,
 		Description: sanitizeHTML(jo.Description),
-		Remote:      mode == "remote" || isRemote(location),
+		Remote:      mode == "remote",
 		WorkMode:    mode,
 		PostedAt:    parseDate(jo.DatePosted),
 	}, true

--- a/internal/sources/bamboohr.go
+++ b/internal/sources/bamboohr.go
@@ -18,11 +18,28 @@ func NewBambooHR(c JSONGetter) Source { return bambooHR{http: c} }
 func (bambooHR) Provider() string { return "bamboohr" }
 
 // bambooHRPosting is one item from the careers list (no description here); the list
-// carries the remote flag, the detail carries the body.
+// carries the work-mode signal, the detail carries the body.
 type bambooHRPosting struct {
-	ID       string `json:"id"`
-	Name     string `json:"jobOpeningName"`
-	IsRemote bool   `json:"isRemote"`
+	ID           string `json:"id"`
+	Name         string `json:"jobOpeningName"`
+	IsRemote     bool   `json:"isRemote"`
+	LocationType string `json:"locationType"`
+}
+
+// bambooHRLocationType maps BambooHR's numeric locationType onto our work-mode
+// vocabulary. It is the only structured signal the public careers list carries: isRemote
+// is null on every posting there, so reading it alone leaves every job mode-less.
+func bambooHRLocationType(t string) string {
+	switch t {
+	case "0":
+		return "onsite"
+	case "1":
+		return "remote"
+	case "2":
+		return "hybrid"
+	default:
+		return ""
+	}
 }
 
 func (b bambooHR) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
@@ -65,15 +82,17 @@ func (b bambooHR) detail(ctx context.Context, e CompanyEntry, p bambooHRPosting)
 	}
 
 	jo := d.Result.JobOpening
+	location := joinNonEmpty(jo.Location.City, jo.Location.State, jo.Location.AddressCountry)
+	mode := firstNonEmpty(bambooHRLocationType(p.LocationType), workModeFromRemote(p.IsRemote))
 	return Job{
 		ExternalID:  p.ID,
 		URL:         jo.ShareURL,
 		Title:       p.Name,
 		Company:     e.Company,
-		Location:    joinNonEmpty(jo.Location.City, jo.Location.State, jo.Location.AddressCountry),
+		Location:    location,
 		Description: sanitizeHTML(jo.Description),
-		Remote:      p.IsRemote,
-		WorkMode:    workModeFromRemote(p.IsRemote),
+		Remote:      mode == "remote" || isRemote(location),
+		WorkMode:    mode,
 		PostedAt:    parseDate(jo.DatePosted),
 	}, true
 }

--- a/internal/sources/bamboohr_test.go
+++ b/internal/sources/bamboohr_test.go
@@ -91,3 +91,40 @@ func TestBambooHRFetchSkipsFailedDetail(t *testing.T) {
 		t.Fatalf("want only 52 to survive, got %d jobs", len(jobs))
 	}
 }
+
+// BambooHR leaves isRemote null on the public careers list and carries the real signal in
+// locationType: "0" onsite, "1" remote, "2" hybrid.
+func TestBambooHRFetchReadsLocationType(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/careers/60/detail", bambooDetail("60", "Office Manager")).
+		route("/careers/61/detail", bambooDetail("61", "Account Manager")).
+		route("/careers/62/detail", bambooDetail("62", "Security Engineer")).
+		route("/careers/list", `{"result": [
+			{"id": "60", "jobOpeningName": "Office Manager", "isRemote": null, "locationType": "0"},
+			{"id": "61", "jobOpeningName": "Account Manager", "isRemote": null, "locationType": "1"},
+			{"id": "62", "jobOpeningName": "Security Engineer", "isRemote": null, "locationType": "2"}
+		]}`)
+
+	jobs, err := NewBambooHR(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "bamboohr", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	for id, want := range map[string]string{"60": "onsite", "61": "remote", "62": "hybrid"} {
+		if got := byID[id].WorkMode; got != want {
+			t.Errorf("job %s WorkMode = %q, want %q", id, got, want)
+		}
+	}
+	if !byID["61"].Remote {
+		t.Error("locationType 1 should set Remote = true")
+	}
+	if byID["62"].Remote {
+		t.Error("locationType 2 (hybrid) should leave Remote = false")
+	}
+}

--- a/internal/sources/bamboohr_test.go
+++ b/internal/sources/bamboohr_test.go
@@ -128,3 +128,26 @@ func TestBambooHRFetchReadsLocationType(t *testing.T) {
 		t.Error("locationType 2 (hybrid) should leave Remote = false")
 	}
 }
+
+// A board that omits locationType falls back to the list's isRemote flag.
+func TestBambooHRFetchFallsBackToIsRemote(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/careers/70/detail", bambooDetail("70", "Support Lead")).
+		route("/careers/list", `{"result": [
+			{"id": "70", "jobOpeningName": "Support Lead", "isRemote": true}
+		]}`)
+
+	jobs, err := NewBambooHR(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "bamboohr", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if jobs[0].WorkMode != "remote" || !jobs[0].Remote {
+		t.Errorf("WorkMode = %q, Remote = %v; want remote/true from the isRemote fallback",
+			jobs[0].WorkMode, jobs[0].Remote)
+	}
+}

--- a/internal/sources/helpers.go
+++ b/internal/sources/helpers.go
@@ -84,6 +84,22 @@ func workModeFromRemote(remote bool) string {
 	return ""
 }
 
+// workModeFromRemoteHybrid maps the PAIR of booleans an ATS exposes when it tracks remote
+// and hybrid separately (Recruitee, SmartRecruiters) to a work mode. The two flags are
+// mutually exclusive there, so reading the remote one alone silently drops every hybrid
+// posting. Both false stays "" rather than "onsite": an ATS cannot distinguish "marked as
+// office" from "not marked at all", and the dictionary contract forbids the guess.
+func workModeFromRemoteHybrid(remote, hybrid bool) string {
+	switch {
+	case remote:
+		return "remote"
+	case hybrid:
+		return "hybrid"
+	default:
+		return ""
+	}
+}
+
 // workplaceTypeMode maps an ATS workplace-type enum (as Lever and JustJoin expose) to our
 // work mode vocabulary; an unspecified/unknown value yields "".
 func workplaceTypeMode(t string) string {

--- a/internal/sources/helpers.go
+++ b/internal/sources/helpers.go
@@ -75,8 +75,11 @@ func isRemote(location string) bool {
 
 // workModeFromRemote maps an adapter's STRUCTURED remote flag to a work mode:
 // "remote" when set, else "" (a false flag does not imply onsite vs hybrid, so it
-// is left unknown for the parser/LLM to resolve). Adapters whose API exposes an
-// explicit remote boolean (Ashby, Recruitee, SmartRecruiters, Workable) use this.
+// is left unknown for the parser/LLM to resolve). Adapters whose API exposes a remote
+// boolean and nothing better (Workable, Breezy) use this. Reach for it only after
+// checking that the API carries no richer field: an ATS that also reports hybrid needs
+// workModeFromRemoteHybrid, and one with a workplace-type enum needs workplaceTypeMode —
+// a lone boolean often means "not onsite", which is not the same as "remote".
 func workModeFromRemote(remote bool) string {
 	if remote {
 		return "remote"
@@ -85,10 +88,13 @@ func workModeFromRemote(remote bool) string {
 }
 
 // workModeFromRemoteHybrid maps the PAIR of booleans an ATS exposes when it tracks remote
-// and hybrid separately (Recruitee, SmartRecruiters) to a work mode. The two flags are
-// mutually exclusive there, so reading the remote one alone silently drops every hybrid
-// posting. Both false stays "" rather than "onsite": an ATS cannot distinguish "marked as
-// office" from "not marked at all", and the dictionary contract forbids the guess.
+// and hybrid separately (Recruitee, SmartRecruiters) to a work mode. Reading the remote one
+// alone silently drops every hybrid posting, which is most of them on some boards.
+//
+// Remote wins when a posting sets both — around 2% of Recruitee offers do, and Recruitee
+// itself renders each of them as "Remote job", so the broader arrangement is what the
+// employer means. Both false stays "" rather than "onsite": an ATS cannot distinguish
+// "marked as office" from "not marked at all", and the dictionary contract forbids the guess.
 func workModeFromRemoteHybrid(remote, hybrid bool) string {
 	switch {
 	case remote:

--- a/internal/sources/recruitee.go
+++ b/internal/sources/recruitee.go
@@ -33,6 +33,7 @@ func (r recruitee) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Location     string `json:"location"`
 			CreatedAt    string `json:"created_at"`
 			Remote       bool   `json:"remote"`
+			Hybrid       bool   `json:"hybrid"`
 			Description  string `json:"description"`
 			Requirements string `json:"requirements"`
 		} `json:"offers"`
@@ -52,7 +53,7 @@ func (r recruitee) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Location:    o.Location,
 			Description: sanitizeHTML(o.Description + o.Requirements),
 			Remote:      o.Remote,
-			WorkMode:    workModeFromRemote(o.Remote),
+			WorkMode:    workModeFromRemoteHybrid(o.Remote, o.Hybrid),
 			PostedAt:    parseSpaceTime(o.CreatedAt),
 		})
 	}

--- a/internal/sources/recruitee_test.go
+++ b/internal/sources/recruitee_test.go
@@ -79,3 +79,33 @@ func TestRecruiteeFetch(t *testing.T) {
 		t.Errorf("second job description = %q", jobs[1].Description)
 	}
 }
+
+// Recruitee exposes remote and hybrid as separate booleans, and they are mutually
+// exclusive: a hybrid offer carries remote=false, so reading the remote flag alone drops
+// the hybrid signal entirely.
+func TestRecruiteeFetchHybridOffer(t *testing.T) {
+	fake := &fakeHTTP{body: `{
+		"offers": [
+			{"id": 1, "title": "Designer", "careers_url": "https://acme.recruitee.com/o/designer",
+			 "location": "Warszawa", "created_at": "2024-03-01 10:00:00 UTC",
+			 "remote": false, "hybrid": true, "description": "<p>Design.</p>", "requirements": ""}
+		]
+	}`}
+
+	jobs, err := NewRecruitee(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "recruitee", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+
+	if jobs[0].WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid from the hybrid flag", jobs[0].WorkMode)
+	}
+	if jobs[0].Remote {
+		t.Error("Remote = true, want false: a hybrid offer is not remote")
+	}
+}

--- a/internal/sources/smartrecruiters.go
+++ b/internal/sources/smartrecruiters.go
@@ -61,6 +61,7 @@ type smartRecruitersPosting struct {
 		Region  string `json:"region"`
 		Country string `json:"country"`
 		Remote  bool   `json:"remote"`
+		Hybrid  bool   `json:"hybrid"`
 	} `json:"location"`
 }
 
@@ -139,7 +140,7 @@ func (s smartRecruiters) detail(ctx context.Context, e CompanyEntry, p smartRecr
 		Location:    joinNonEmpty(p.Location.City, p.Location.Region, p.Location.Country),
 		Description: sanitizeHTML(body),
 		Remote:      p.Location.Remote,
-		WorkMode:    workModeFromRemote(p.Location.Remote),
+		WorkMode:    workModeFromRemoteHybrid(p.Location.Remote, p.Location.Hybrid),
 		PostedAt:    parseRFC3339(p.ReleasedDate),
 		// experienceLevel is the employer's own structured seniority; the pipeline gives it
 		// precedence over the title dictionary, so it fills the grade for title-silent roles.

--- a/internal/sources/smartrecruiters_test.go
+++ b/internal/sources/smartrecruiters_test.go
@@ -241,3 +241,32 @@ func TestSmartRecruitersFetchSkipsFailedDetail(t *testing.T) {
 		t.Fatalf("want only P1 to survive, got %d jobs", len(jobs))
 	}
 }
+
+// SmartRecruiters carries remote and hybrid as separate booleans on the posting's
+// location, and a hybrid posting sets remote=false — so reading location.remote alone
+// leaves every hybrid role without a work mode.
+func TestSmartRecruitersFetchHybridPosting(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("offset=0", `{"totalFound": 1, "content": [
+			{"id": "H1", "name": "Product Owner", "releasedDate": "2024-06-11T15:19:46.134Z",
+			 "location": {"city": "Sunshine Coast", "region": "Queensland", "country": "au", "remote": false, "hybrid": true}}
+		]}`).
+		route("/postings/H1", detailBody("H1", "H1"))
+
+	jobs, err := NewSmartRecruiters(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "smartrecruiters", Board: "Acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+
+	if jobs[0].WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid from location.hybrid", jobs[0].WorkMode)
+	}
+	if jobs[0].Remote {
+		t.Error("Remote = true, want false: a hybrid posting is not remote")
+	}
+}

--- a/internal/sources/workmode_test.go
+++ b/internal/sources/workmode_test.go
@@ -29,3 +29,24 @@ func TestWorkplaceTypeMode(t *testing.T) {
 		}
 	}
 }
+
+func TestWorkModeFromRemoteHybrid(t *testing.T) {
+	cases := []struct {
+		remote, hybrid bool
+		want           string
+	}{
+		{remote: true, hybrid: false, want: "remote"},
+		{remote: false, hybrid: true, want: "hybrid"},
+		// Both false is "not marked", which an ATS cannot distinguish from "office" —
+		// so it stays unknown rather than becoming a guessed onsite.
+		{remote: false, hybrid: false, want: ""},
+		// The flags are mutually exclusive in practice; if a board sets both, the
+		// broader arrangement wins.
+		{remote: true, hybrid: true, want: "remote"},
+	}
+	for _, c := range cases {
+		if got := workModeFromRemoteHybrid(c.remote, c.hybrid); got != c.want {
+			t.Errorf("workModeFromRemoteHybrid(%v, %v) = %q, want %q", c.remote, c.hybrid, got, c.want)
+		}
+	}
+}

--- a/internal/sources/workmode_test.go
+++ b/internal/sources/workmode_test.go
@@ -40,8 +40,8 @@ func TestWorkModeFromRemoteHybrid(t *testing.T) {
 		// Both false is "not marked", which an ATS cannot distinguish from "office" —
 		// so it stays unknown rather than becoming a guessed onsite.
 		{remote: false, hybrid: false, want: ""},
-		// The flags are mutually exclusive in practice; if a board sets both, the
-		// broader arrangement wins.
+		// Around 2% of Recruitee offers set both, and Recruitee renders them as
+		// "Remote job" — the broader arrangement wins.
 		{remote: true, hybrid: true, want: "remote"},
 	}
 	for _, c := range cases {

--- a/openspec/changes/fix-ats-work-mode-signal/.openspec.yaml
+++ b/openspec/changes/fix-ats-work-mode-signal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/fix-ats-work-mode-signal/design.md
+++ b/openspec/changes/fix-ats-work-mode-signal/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`workModeFromRemote(bool)` is a narrowing helper: it accepts one bit where an ATS reports
+three states. Its own doc comment warns that a false flag implies nothing, but its
+signature invites any boolean, and 22 adapters pass one. For four providers that boolean
+is not the best signal the API offers.
+
+Evidence gathered by probing the live APIs before writing code:
+
+| Provider | sampled | finding |
+|---|---|---|
+| ashby | 1097 postings / 7 boards | `(Hybrid, isRemote=true)` 701, `(Remote, true)` 80, `(OnSite, false)` 33, `(absent, absent)` 283 — `isRemote` is "not onsite" |
+| recruitee | 138 offers / 11 boards | `(remote,hybrid)` = (F,F) 110, (F,T) 15, (T,F) 13 — mutually exclusive |
+| smartrecruiters | 122 postings | `location` carries both `remote` and `hybrid` |
+| bamboohr | 902 postings / 120 boards | `isRemote` null everywhere; `locationType` `0` 619, `1` 115, `2` 168 |
+
+## Goals / Non-Goals
+
+**Goals:** read each ATS's authoritative work-mode field; stop emitting `remote` for hybrid
+Ashby postings; keep the ingest and link-resolution paths identical.
+
+**Non-Goals:** auditing the other 18 `workModeFromRemote` callers (workable and breezy were
+checked and carry no richer field); backfilling historic rows by any path other than
+re-ingest; changing the `Job.WorkMode` contract itself, which already says structured
+signal only.
+
+## Decisions
+
+**Ashby: `workplaceType` first, `isRemote` as fallback.** `firstNonEmpty(workplaceTypeMode(…),
+workModeFromRemote(…))` rather than replacing the flag outright. The 283 postings with
+neither field keep today's behaviour, and a board that someday sets only `isRemote` still
+resolves. Alternative — dropping `isRemote` entirely — was rejected as it removes a working
+signal for no gain.
+
+**`Remote` is derived from the resolved mode, not from the raw flag.** `mode == "remote" ||
+isRemote(location)`. This keeps the two fields from contradicting each other and preserves
+the greenhouse convention where a "Remote" location text alone marks a job remote.
+
+**Recruitee/SmartRecruiters: a new `workModeFromRemoteHybrid(remote, hybrid)` helper.** Two
+callers justify it, and the shared helper is where the "(false, false) is not onsite" rule
+is documented once. Alternative — inlining a switch in each adapter — would duplicate that
+reasoning in two places and invite a third adapter to guess `onsite`.
+
+**BambooHR: `locationType` `0`=onsite, `1`=remote, `2`=hybrid.** BambooHR publishes no enum
+documentation, so the mapping was established by two independent signals: postings with
+`locationType=1` never carry a physical address (46/46), and work-mode words in job titles
+match the enum (title~remote → `1` in 10/11, title~onsite → `0` in 15/16, title~hybrid →
+`2` in 1/1). Alternative — parsing the public posting page — was rejected: those pages are
+client-rendered and expose nothing in HTML.
+
+## Risks / Trade-offs
+
+- **BambooHR enum is inferred, not documented** → two independent signals agree, and a wrong
+  guess degrades to a wrong facet on one provider, not a crash. If BambooHR renumbers, the
+  `default: ""` arm keeps unknown values silent.
+- **Ashby hybrid jobs leave the remote filter** → intended, and it is the bug being fixed;
+  the volume is large (most Ashby postings), so the change is visible in remote counts and
+  in company `remote_regions` rollups.
+- **Stale search results until reindex** → Meilisearch keeps the old `work_mode` until the
+  index is rebuilt; the migration plan sequences it.
+
+## Migration Plan
+
+1. Merge; no schema change, no migration file.
+2. Re-ingest the four providers — `UpsertJob` refreshes `work_mode` from the adapter, so
+   crawled boards self-correct: `go run ./cmd/ingest sources/{ashby,recruitee,smartrecruiters,bamboohr}.yml`.
+3. `make reindex` afterwards so search stops serving the stale facet. Never stack it with
+   `reindex-companies` — Meilisearch deadlocks.
+4. Rollback: revert the commit and re-ingest; the adapters are stateless.
+
+## Open Questions
+
+- Do the remaining 18 `workModeFromRemote` callers hide the same defect? Workable and breezy
+  were cleared; the rest are unaudited and out of scope here.

--- a/openspec/changes/fix-ats-work-mode-signal/design.md
+++ b/openspec/changes/fix-ats-work-mode-signal/design.md
@@ -10,9 +10,9 @@ Evidence gathered by probing the live APIs before writing code:
 | Provider | sampled | finding |
 |---|---|---|
 | ashby | 1097 postings / 7 boards | `(Hybrid, isRemote=true)` 701, `(Remote, true)` 80, `(OnSite, false)` 33, `(absent, absent)` 283 — `isRemote` is "not onsite" |
-| recruitee | 138 offers / 11 boards | `(remote,hybrid)` = (F,F) 110, (F,T) 15, (T,F) 13 — mutually exclusive |
-| smartrecruiters | 122 postings | `location` carries both `remote` and `hybrid` |
-| bamboohr | 902 postings / 120 boards | `isRemote` null everywhere; `locationType` `0` 619, `1` 115, `2` 168 |
+| recruitee | 1984 offers / 120 boards | `(remote,hybrid)` = (F,F) 904, (F,T) 602, (T,F) 442, (T,T) 36 |
+| smartrecruiters | 2485 postings / 120 boards | `location` carries both flags: (T,F) 273, (F,T) 615, (F,F) 1597 |
+| bamboohr | 999 postings / 150 boards | `isRemote` null on all 999; `locationType` `0` 438, `1` 268, `2` 293 |
 
 ## Goals / Non-Goals
 
@@ -32,14 +32,20 @@ neither field keep today's behaviour, and a board that someday sets only `isRemo
 resolves. Alternative — dropping `isRemote` entirely — was rejected as it removes a working
 signal for no gain.
 
-**`Remote` is derived from the resolved mode, not from the raw flag.** `mode == "remote" ||
-isRemote(location)`. This keeps the two fields from contradicting each other and preserves
-the greenhouse convention where a "Remote" location text alone marks a job remote.
+**`Remote` is derived from the resolved mode, not from the raw flag.** For Ashby that is
+`mode == "remote" || isRemote(location)`: the mode decides, and the location heuristic is
+preserved because it is pre-existing behaviour (the greenhouse convention, where a "Remote"
+location text alone marks a job remote — it can still leave `WorkMode=onsite` with
+`Remote=true` on the four sampled postings whose location reads "San Francisco or Remote").
+BambooHR takes `mode == "remote"` alone: it never had the heuristic, and adding it would
+widen this change for no evidenced gain.
 
 **Recruitee/SmartRecruiters: a new `workModeFromRemoteHybrid(remote, hybrid)` helper.** Two
 callers justify it, and the shared helper is where the "(false, false) is not onsite" rule
 is documented once. Alternative — inlining a switch in each adapter — would duplicate that
-reasoning in two places and invite a third adapter to guess `onsite`.
+reasoning in two places and invite a third adapter to guess `onsite`. Both flags true is a
+live case, not a hypothetical (36 of 1984 Recruitee offers); remote wins there because
+Recruitee renders every one of those offers as "Remote job".
 
 **BambooHR: `locationType` `0`=onsite, `1`=remote, `2`=hybrid.** BambooHR publishes no enum
 documentation, so the mapping was established by two independent signals: postings with
@@ -72,3 +78,7 @@ client-rendered and expose nothing in HTML.
 
 - Do the remaining 18 `workModeFromRemote` callers hide the same defect? Workable and breezy
   were cleared; the rest are unaudited and out of scope here.
+- BambooHR returns an all-null `location` for `locationType=1` and puts the real office in
+  `atsLocation`, which the adapter does not read. Those postings (~27%) therefore land with
+  an empty location and no geography — newly visible now that they carry `remote`. Worth a
+  follow-up change, not this one.

--- a/openspec/changes/fix-ats-work-mode-signal/proposal.md
+++ b/openspec/changes/fix-ats-work-mode-signal/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Four ATS adapters read the wrong field for a posting's work mode. Ashby is the damaging
+case: its `isRemote` flag means "not strictly onsite" and is set on hybrid postings too,
+so every hybrid Ashby job entered the catalogue as `work_mode=remote` — 701 of 1097
+postings sampled across seven boards, and `sources/ashby.yml` carries 3808 boards. The
+board's own "Location Type" comes from `workplaceType`, which the adapter never decoded.
+Recruitee, SmartRecruiters, and BambooHR do not lie but stay silent: each carries a
+richer signal (`hybrid` flag, `hybrid` flag, `locationType`) that the adapter ignores, so
+hybrid and onsite roles arrive with no work mode at all.
+
+## What Changes
+
+- Ashby maps `workplaceType` (`Remote`/`Hybrid`/`OnSite`) to the structured work mode;
+  `isRemote` drops to a fallback for boards that leave `workplaceType` unset. A hybrid
+  posting is no longer flagged `Remote`.
+- Recruitee and SmartRecruiters read the `hybrid` boolean alongside `remote`, via a shared
+  `workModeFromRemoteHybrid` helper. Both flags false stays unknown rather than a guessed
+  `onsite`, per the dict-only contract.
+- BambooHR reads `locationType` (`0` onsite, `1` remote, `2` hybrid). Its public careers
+  list leaves `isRemote` null on every posting, so today the adapter emits no work mode at
+  all; `isRemote` remains as a fallback.
+- **BREAKING** for stored data, not for the API shape: re-ingesting these providers moves
+  hybrid Ashby jobs out of the remote filter. A reindex is required for search to follow.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `source-ingest`: the "Ingest persists job geography and work mode" requirement currently
+  treats "an explicit remote flag from the ATS API" as a structured work mode. It is
+  narrowed: when an ATS exposes both a work-mode field and a boolean flag, the field wins,
+  and a flag that only distinguishes onsite from everything else SHALL NOT be read as
+  `remote`.
+
+## Impact
+
+- `internal/sources/ashby.go` — `AshbyPosting.WorkplaceType`, `MapAshbyPosting`; shared
+  with `internal/linksource/ashby.go`, so link-resolved postings gain the same fix.
+- `internal/sources/recruitee.go`, `internal/sources/smartrecruiters.go`,
+  `internal/sources/bamboohr.go`, `internal/sources/helpers.go`.
+- No schema, API, or config change. Post-merge operations: re-ingest the four providers
+  (`UpsertJob` refreshes `work_mode`), then `make reindex` so Meilisearch stops serving
+  the stale values.

--- a/openspec/changes/fix-ats-work-mode-signal/specs/source-ingest/spec.md
+++ b/openspec/changes/fix-ats-work-mode-signal/specs/source-ingest/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: Ingest persists job geography and work mode
+
+The ingest write path SHALL parse each posting's `location` string into
+`countries`/`regions`/`work_mode` (via the job-geography parser) and persist them
+on the job row. These columns SHALL be written on insert and refreshed on
+re-ingest, like the other raw source fields and unlike the enrichment payload
+(which ingest never writes). A posting whose location yields no geography SHALL
+store empty arrays.
+
+For `work_mode`, when the adapter exposes a STRUCTURED work mode (a workplace-type
+enum or an explicit remote flag from the ATS API) it SHALL take precedence over
+the parser's free-text heuristic; the parser fills `work_mode` only when the
+adapter has no structured signal.
+
+When an ATS exposes BOTH a work-mode field and a boolean flag for the same posting, the
+adapter SHALL read the field and MAY keep the flag only as a fallback for postings that
+omit the field. An adapter SHALL NOT map a boolean flag to `remote` when that flag merely
+separates onsite from every other arrangement, because such a flag is set on hybrid
+postings too. Where an ATS splits the signal across separate `remote` and `hybrid`
+booleans, both false SHALL yield no work mode rather than a guessed `onsite`, since the
+API cannot distinguish "marked as office" from "not marked at all".
+
+#### Scenario: A new posting stores its parsed geography
+
+- **WHEN** a posting with location `Remote - Germany` is ingested
+- **THEN** the stored job has `countries=[de]` and `regions` including `eu`
+
+#### Scenario: Re-ingest refreshes geography from the updated location
+
+- **WHEN** an already-ingested posting is re-ingested with its location changed
+  from `Remote - UK` to `Remote - USA`
+- **THEN** the job's `countries` updates to `[us]` and its `regions` update
+  accordingly
+
+#### Scenario: A location with no geography stores empty arrays
+
+- **WHEN** a posting with location `Remote` is ingested
+- **THEN** the stored job has empty `countries` and empty `regions`
+
+#### Scenario: A structured adapter work mode is persisted over the parsed one
+
+- **WHEN** an adapter reports a structured `work_mode` (e.g. Lever's
+  `workplaceType=hybrid`) for a posting whose location parses as `remote`
+- **THEN** the stored `jobs.work_mode` is the structured value `hybrid`
+
+#### Scenario: An Ashby hybrid posting is not remote
+
+- **WHEN** an Ashby posting carries `workplaceType=Hybrid` together with `isRemote=true`
+- **THEN** the yielded job's `work_mode` is `hybrid` and the job is not marked remote
+
+#### Scenario: An Ashby posting without a workplace type falls back to the flag
+
+- **WHEN** an Ashby posting omits `workplaceType` and carries `isRemote=true`
+- **THEN** the yielded job's `work_mode` is `remote`
+
+#### Scenario: A Recruitee hybrid offer keeps its work mode
+
+- **WHEN** a Recruitee offer carries `remote=false` and `hybrid=true`
+- **THEN** the yielded job's `work_mode` is `hybrid` and the job is not marked remote
+
+#### Scenario: A SmartRecruiters hybrid posting keeps its work mode
+
+- **WHEN** a SmartRecruiters posting's location carries `remote=false` and `hybrid=true`
+- **THEN** the yielded job's `work_mode` is `hybrid` and the job is not marked remote
+
+#### Scenario: Neither remote nor hybrid leaves the work mode unknown
+
+- **WHEN** an offer carries `remote=false` and `hybrid=false`
+- **THEN** the yielded job carries no structured `work_mode`, leaving the decision to the
+  pipeline's location parser
+
+#### Scenario: A BambooHR posting takes its work mode from locationType
+
+- **WHEN** a BambooHR careers-list posting carries `locationType` `0`, `1`, or `2` with a
+  null `isRemote`
+- **THEN** the yielded job's `work_mode` is `onsite`, `remote`, or `hybrid` respectively,
+  and only the `remote` one is marked remote

--- a/openspec/changes/fix-ats-work-mode-signal/specs/source-ingest/spec.md
+++ b/openspec/changes/fix-ats-work-mode-signal/specs/source-ingest/spec.md
@@ -15,12 +15,13 @@ the parser's free-text heuristic; the parser fills `work_mode` only when the
 adapter has no structured signal.
 
 When an ATS exposes BOTH a work-mode field and a boolean flag for the same posting, the
-adapter SHALL read the field and MAY keep the flag only as a fallback for postings that
-omit the field. An adapter SHALL NOT map a boolean flag to `remote` when that flag merely
-separates onsite from every other arrangement, because such a flag is set on hybrid
-postings too. Where an ATS splits the signal across separate `remote` and `hybrid`
-booleans, both false SHALL yield no work mode rather than a guessed `onsite`, since the
-API cannot distinguish "marked as office" from "not marked at all".
+adapter SHALL resolve the mode from the field, and MAY fall back to the flag only for
+postings that omit the field — for a posting that carries the field, a flag that merely
+separates onsite from every other arrangement SHALL NOT be mapped to `remote`, because
+such a flag is set on hybrid postings too. Where an ATS splits the signal across separate
+`remote` and `hybrid` booleans, both false SHALL yield no work mode rather than a guessed
+`onsite`, since the API cannot distinguish "marked as office" from "not marked at all";
+both true SHALL yield `remote`, the broader arrangement.
 
 #### Scenario: A new posting stores its parsed geography
 
@@ -70,6 +71,11 @@ API cannot distinguish "marked as office" from "not marked at all".
 - **WHEN** an offer carries `remote=false` and `hybrid=false`
 - **THEN** the yielded job carries no structured `work_mode`, leaving the decision to the
   pipeline's location parser
+
+#### Scenario: An offer flagged both remote and hybrid resolves to remote
+
+- **WHEN** an offer carries `remote=true` and `hybrid=true`
+- **THEN** the yielded job's `work_mode` is `remote`
 
 #### Scenario: A BambooHR posting takes its work mode from locationType
 

--- a/openspec/changes/fix-ats-work-mode-signal/tasks.md
+++ b/openspec/changes/fix-ats-work-mode-signal/tasks.md
@@ -1,0 +1,40 @@
+## 1. Ashby: workplaceType decides the work mode
+
+- [x] 1.1 Failing test: a posting with `workplaceType=Hybrid` and `isRemote=true` yields
+      `work_mode=hybrid` and is not remote (`ashby_test.go`)
+- [x] 1.2 Decode `workplaceType` on `AshbyPosting`; resolve the mode via
+      `firstNonEmpty(workplaceTypeMode, workModeFromRemote)` and derive `Remote` from it
+- [x] 1.3 Confirm `internal/linksource` inherits the fix through the shared
+      `MapAshbyPosting`
+
+## 2. Recruitee and SmartRecruiters: read the hybrid flag
+
+- [x] 2.1 Failing test: a Recruitee offer with `remote=false, hybrid=true` yields
+      `work_mode=hybrid` (`recruitee_test.go`)
+- [x] 2.2 Add the `workModeFromRemoteHybrid` helper; both-false yields `""`
+- [x] 2.3 Failing test: a SmartRecruiters posting with `location.hybrid=true` yields
+      `work_mode=hybrid` (`smartrecruiters_test.go`)
+- [x] 2.4 Decode `hybrid` on both adapters and route them through the helper
+- [x] 2.5 Unit-test the helper's four input combinations (`workmode_test.go`)
+
+## 3. BambooHR: read locationType
+
+- [x] 3.1 Failing test: careers-list postings with `locationType` `0`/`1`/`2` and null
+      `isRemote` yield `onsite`/`remote`/`hybrid` (`bamboohr_test.go`)
+- [x] 3.2 Decode `locationType`, add the `bambooHRLocationType` mapper, keep `isRemote`
+      as the fallback
+
+## 4. Quality pass and verification
+
+- [x] 4.1 Run the `simplify` skill over the diff; tests stay green
+- [x] 4.2 `gofmt -l`, `go vet ./...`, `go build ./...`, `go test ./...` all clean
+- [x] 4.3 Verify the four adapters against their live APIs — the Surfshark posting that
+      triggered the report resolves to `hybrid`
+- [ ] 4.4 Code review on the full diff; fix Critical and Important findings
+
+## 5. Finish
+
+- [ ] 5.1 Commit, open the PR, merge the branch
+- [ ] 5.2 Archive and sync the OpenSpec change
+- [ ] 5.3 Post-merge ops: re-ingest the four providers, then `make reindex`
+- [ ] 5.4 Offer a changelog entry (user-visible: hybrid jobs leave the remote filter)

--- a/openspec/changes/fix-ats-work-mode-signal/tasks.md
+++ b/openspec/changes/fix-ats-work-mode-signal/tasks.md
@@ -34,7 +34,7 @@
 
 ## 5. Finish
 
-- [ ] 5.1 Commit, open the PR, merge the branch
+- [x] 5.1 Commit and open the PR (#1243); merge pending review
 - [ ] 5.2 Archive and sync the OpenSpec change
 - [ ] 5.3 Post-merge ops: re-ingest the four providers, then `make reindex`
 - [ ] 5.4 Offer a changelog entry (user-visible: hybrid jobs leave the remote filter)

--- a/openspec/changes/fix-ats-work-mode-signal/tasks.md
+++ b/openspec/changes/fix-ats-work-mode-signal/tasks.md
@@ -30,7 +30,7 @@
 - [x] 4.2 `gofmt -l`, `go vet ./...`, `go build ./...`, `go test ./...` all clean
 - [x] 4.3 Verify the four adapters against their live APIs — the Surfshark posting that
       triggered the report resolves to `hybrid`
-- [ ] 4.4 Code review on the full diff; fix Critical and Important findings
+- [x] 4.4 Code review on the full diff; fix Critical and Important findings
 
 ## 5. Finish
 


### PR DESCRIPTION
## Why

[This Surfshark posting](https://freehire.me/jobs/senior-web-designer-incogni-surfshark-vxkcxskn) showed **Work format: Remote** while [its Ashby board](https://jobs.ashbyhq.com/surfshark/d675ca96-5678-4ed9-be94-01fa1e641f28) says **Location Type: Hybrid**.

Ashby sets `isRemote` on every posting that is not strictly onsite, so a hybrid role carries `isRemote=true`. The adapter read that flag as the work mode and never decoded `workplaceType` — the field the board itself renders as "Location Type".

```json
"isRemote": true,
"workplaceType": "Hybrid",
```

Probing the live API across 150 boards (4392 postings): `(Hybrid, isRemote=true)` 909, `(Remote, true)` 1288, `(OnSite, false)` 1632, both absent 563. Every one of those 909 hybrid postings entered the catalogue as `work_mode=remote`, and `sources/ashby.yml` carries 3808 boards.

Checking the neighbours turned up three more adapters reading an incomplete signal — they do not lie, they stay silent:

| provider | reads | ignores | effect |
|---|---|---|---|
| ashby | `isRemote` | `workplaceType` | **hybrid → remote** |
| recruitee | `remote` | `hybrid` | 602 of 1984 offers mode-less |
| smartrecruiters | `location.remote` | `location.hybrid` | 615 of 2485 mode-less |
| bamboohr | `isRemote` (null on all 999 sampled) | `locationType` | every posting mode-less |

`workable` and `breezy` were checked and carry no richer field.

## What changed

- **ashby** — `workplaceType` decides the mode; `isRemote` kept as the fallback for boards that omit it. `Remote` now derives from the resolved mode. `internal/linksource` inherits the fix through the shared `MapAshbyPosting`.
- **recruitee / smartrecruiters** — read the `hybrid` boolean via a new `workModeFromRemoteHybrid` helper. Both false stays `""` rather than a guessed `onsite`: an ATS cannot tell "marked as office" from "not marked at all", and the dict-only contract forbids the guess. Both true (36 of 1984 Recruitee offers) resolves to `remote` — Recruitee renders exactly those as "Remote job".
- **bamboohr** — reads `locationType` (`0` onsite, `1` remote, `2` hybrid). BambooHR documents no enum, so it was established from two independent signals: `locationType=1` never carries a physical address (268/268), and work-mode words in titles match the enum (remote→`1` 32/41, onsite→`0` 15/16).

## Verification

Adapters run against their real APIs, before/after:

| board | before | after |
|---|---|---|
| ashby/surfshark | 26 remote | 26 hybrid, 1 onsite, remote=0 |
| ashby/ramp | 112 remote | 97 hybrid, 9 onsite, 15 remote |
| recruitee/11bitstudios | 4 mode-less | 4 hybrid |
| smartrecruiters/judobank | 13 mode-less | 12 hybrid |
| bamboohr/mirrorweb | 3 mode-less | 2 hybrid, 1 remote |

The reported job now resolves to `work_mode="hybrid" remote=false location="Vilnius"`. Ramp's counts match the raw API exactly (97/9/15).

Test-first throughout; `go build`, `go vet`, `go test ./...` clean.

## After merge

`work_mode` is refreshed by `UpsertJob`, so crawled boards self-correct on the next ingest of `sources/{ashby,recruitee,smartrecruiters,bamboohr}.yml`. Then `make reindex` — Meilisearch keeps serving the stale facet until the index is rebuilt. Do not stack it with `reindex-companies`.

Known follow-up (not this PR): BambooHR returns an all-null `location` for `locationType=1` and puts the real office in `atsLocation`, which the adapter does not read — so ~27% of its postings land with no geography. Newly visible now that they carry `remote`.

OpenSpec change: `openspec/changes/fix-ats-work-mode-signal/`