### PR TITLE
fix(intake): a storefront link lands on the board it fronts

### DIFF
--- a/cmd/resolve-url/main.go
+++ b/cmd/resolve-url/main.go
@@ -61,7 +61,8 @@ func run() int {
 
 	var saved, skipped, failed int
 	for _, raw := range urls {
-		res, ok, err := im.Import(ctx, raw)
+		// No board hint: this worker takes bare URLs, with no intake to have resolved one.
+		res, ok, err := im.Import(ctx, raw, linkimport.Board{})
 		switch {
 		case err != nil:
 			failed++

--- a/docs/API.md
+++ b/docs/API.md
@@ -2290,7 +2290,7 @@ curl "https://freehire.me/api/v1/jobs/find?url=https%3A%2F%2Fboards.greenhouse.i
 
 Hand freehire a link: import the posting, and the board behind it.
 
-Four outcomes in one shape, distinguished by status: **200 found** — the catalogue already carries it, nothing fetched or written; **201 tracked** — we crawl that board already and the posting just had not landed, so it was imported now; **201 imported** — imported, and its board queued for onboarding; **202 queued** — nothing could read the page, so the link went to manual triage. Rate-limited, because it makes the server fetch a URL you chose. A URL that is not http(s) is a 422.
+Five outcomes in one shape, distinguished by status: **200 found** — the catalogue already carries it, nothing fetched or written; **201 tracked** — we crawl that board already and the posting just had not landed, so it was imported now; **201 imported** — imported, and its board queued for onboarding; **201 review** — imported, but its careers site names no board we can crawl, so the link went to manual triage; **202 queued** — nothing could read the page, so the link went to manual triage. `company_slug` is returned whenever the catalogue already carries the employer, through any source — independent of what became of the board. Rate-limited, because it makes the server fetch a URL you chose. A URL that is not http(s) is a 422.
 
 **Body**
 
@@ -2306,7 +2306,7 @@ curl -X POST "https://freehire.me/api/v1/jobs/resolve" \
 ```
 
 ```json
-{ "data": { "outcome": "tracked", "public_slug": "senior-backend-engineer-acme-1a2b", "company": "Acme" } }
+{ "data": { "status": "tracked", "public_slug": "senior-backend-engineer-acme-1a2b", "company_slug": "acme" } }
 ```
 
 ### `GET /me/contributions`

--- a/internal/contribution/AGENTS.md
+++ b/internal/contribution/AGENTS.md
@@ -61,9 +61,26 @@ door onto the same flow is a second behaviour waiting to drift. `GET /api/v1/me/
 still lists the caller's own, now carrying the `surface` each row came through
 (`web` | `telegram` | `extension` | `cli` | `unknown`).
 
-The intake answers with four outcomes: `found` (already carried), `tracked` (imported, and we
-already crawl this board), `imported` (imported, board queued for onboarding), `queued`
-(unreadable page, link filed for triage).
+The intake answers with five outcomes, all of them about the BOARD: `found` (already carried),
+`tracked` (imported, and we already crawl this board), `imported` (imported, board queued for
+onboarding), `review` (imported, but the URL names no board we can crawl — a careers site on the
+company's own domain — so the link went to triage), `queued` (unreadable page, link filed for
+triage).
+
+**Whether we know the COMPANY is a separate question, answered by `company_slug`**, which is set
+whenever the catalogue already carries that employer through ANY source. The board checks cannot
+answer it: `BoardTracked` is keyed by `(source, board)`, so a company we reach through a second
+ATS — or through an ATS the recogniser does not know — is board-new and company-old at once.
+Collapsing the two is what once told a contributor of a Dropbox posting on `dropbox.jobs` (a
+Phenom vanity domain, deliberately unrecognisable) that "this company is new to us — we'll start
+crawling its board", while we had been crawling Dropbox's Greenhouse board all along and no crawl
+followed.
+
+**The board `Inspect` resolves is handed to the import** (`linkimport.Board`). It overrides only
+the generic resolver, which files a page under `(weblink, <the URL>)` — correct when nothing
+better is known, a duplicate when the posting is one we crawl under `(greenhouse, <board>:<id>)`.
+The id-in-the-URL lookup is often the only thing that knows this, since a storefront's host
+names no board.
 
 Two orderings inside it are load-bearing, both pinned by tests:
 - the catalog lookup runs FIRST, or a posting we carry from an aggregator gets a second row

--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -15,9 +15,14 @@ import (
 var ghNumericID = regexp.MustCompile(`^[0-9]{7,12}$`)
 
 // greenhouseJobID extracts a Greenhouse job id from a link that carries one but no board token:
-// the gh_jid query param (Greenhouse's embed param, e.g. company.com/careers?gh_jid=123), or a
-// trailing all-numeric path segment (company.com/careers/…/<id>/). ok=false when neither is
-// present. A non-Greenhouse id won't be found downstream, so a false positive is harmless.
+// the gh_jid query param (Greenhouse's embed param, e.g. company.com/careers?gh_jid=123), or an
+// all-numeric path segment (company.com/careers/…/<id>/…). ok=false when neither is present.
+//
+// The path is read from the RIGHT, and not only at the tail: a storefront over Greenhouse often
+// appends a human-readable slug after the id (dropbox.jobs/en/jobs/<id>/<title>/), and matching
+// the last segment alone missed those. Scanning the whole path costs nothing in precision —
+// the id is only ever believed if the catalogue holds a Greenhouse posting under it, so a
+// numeric segment that is not a job id simply finds nothing.
 func greenhouseJobID(rawURL string) (string, bool) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -27,8 +32,10 @@ func greenhouseJobID(rawURL string) (string, bool) {
 		return id, true
 	}
 	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
-	if last := segs[len(segs)-1]; ghNumericID.MatchString(last) {
-		return last, true
+	for i := len(segs) - 1; i >= 0; i-- {
+		if ghNumericID.MatchString(segs[i]) {
+			return segs[i], true
+		}
 	}
 	return "", false
 }

--- a/internal/contribution/contribution_test.go
+++ b/internal/contribution/contribution_test.go
@@ -263,6 +263,10 @@ func TestSubmitResolvesGreenhouseJobIDForServerSideVanity(t *testing.T) {
 	cases := []string{
 		"https://www.sumup.com/careers/positions/x/8578073002/?city=Brazil",
 		"https://www.talkspace.com/careers/job?gh_jid=6118228004",
+		// The id need not be the LAST segment: a Phenom-style storefront over Greenhouse puts a
+		// human-readable slug after it (dropbox.jobs/en/jobs/<id>/<title>/), and reading only the
+		// tail missed a board we had been crawling all along.
+		"https://www.dropbox.jobs/en/jobs/7862086/frontend-product-software-engineer-design-systems/",
 	}
 	for _, raw := range cases {
 		got, err := submit(New(repo, nil), 7, raw)

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -188,6 +188,34 @@ func (q *Queries) CompaniesWithRoleClusters(ctx context.Context) ([]string, erro
 	return items, nil
 }
 
+const companyHasOtherJobs = `-- name: CompanyHasOtherJobs :one
+SELECT EXISTS (
+    SELECT 1
+    FROM jobs
+    WHERE company_slug = $1
+      AND NOT (source = $2 AND external_id = $3)
+) AS carried
+`
+
+type CompanyHasOtherJobsParams struct {
+	CompanySlug string `json:"company_slug"`
+	Source      string `json:"source"`
+	ExternalID  string `json:"external_id"`
+}
+
+// Whether the catalog carries this company beyond the one posting named by (source,
+// external_id) — asked right after an import, to answer "is this company new to us?".
+// The board-level check (BoardTracked) cannot answer it: a company reached through an
+// ATS we do not recognise, or through a second ATS, is still a company we already carry.
+// The posting itself is excluded by its dedup identity because it is written before this
+// runs. Callers skip the question for an empty company_slug, which names nobody.
+func (q *Queries) CompanyHasOtherJobs(ctx context.Context, arg CompanyHasOtherJobsParams) (bool, error) {
+	row := q.db.QueryRow(ctx, companyHasOtherJobs, arg.CompanySlug, arg.Source, arg.ExternalID)
+	var carried bool
+	err := row.Scan(&carried)
+	return carried, err
+}
+
 const enqueueJobEnrichment = `-- name: EnqueueJobEnrichment :execrows
 INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, $1::int

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -200,6 +200,13 @@ type Querier interface {
 	// Whether a company is referral-eligible — has at least one approved offer. Served by
 	// referral_offers_company_approved_idx.
 	CompanyHasApprovedReferrer(ctx context.Context, companySlug string) (bool, error)
+	// Whether the catalog carries this company beyond the one posting named by (source,
+	// external_id) — asked right after an import, to answer "is this company new to us?".
+	// The board-level check (BoardTracked) cannot answer it: a company reached through an
+	// ATS we do not recognise, or through a second ATS, is still a company we already carry.
+	// The posting itself is excluded by its dedup identity because it is written before this
+	// runs. Callers skip the question for an empty company_slug, which names nobody.
+	CompanyHasOtherJobs(ctx context.Context, arg CompanyHasOtherJobsParams) (bool, error)
 	// The denormalized open-job count for a slug (pgx.ErrNoRows if the company is
 	// absent). cmd/import-yc uses it to guard against homonym collisions: it skips
 	// enriching an existing company whose job_count dwarfs a matched YC entry's team.

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -299,6 +299,20 @@ WHERE company_slug = sqlc.arg(company_slug)
   AND role_fingerprint = sqlc.arg(role_fingerprint)
   AND role_fingerprint <> '';
 
+-- name: CompanyHasOtherJobs :one
+-- Whether the catalog carries this company beyond the one posting named by (source,
+-- external_id) — asked right after an import, to answer "is this company new to us?".
+-- The board-level check (BoardTracked) cannot answer it: a company reached through an
+-- ATS we do not recognise, or through a second ATS, is still a company we already carry.
+-- The posting itself is excluded by its dedup identity because it is written before this
+-- runs. Callers skip the question for an empty company_slug, which names nobody.
+SELECT EXISTS (
+    SELECT 1
+    FROM jobs
+    WHERE company_slug = sqlc.arg(company_slug)
+      AND NOT (source = sqlc.arg(source) AND external_id = sqlc.arg(external_id))
+) AS carried;
+
 -- name: ListRoleClusterCopies :many
 -- The open postings sharing a role cluster (company_slug + role_fingerprint) with the
 -- anchor job — the "N openings across cities" list for a collapsed role. Each copy keeps

--- a/internal/handler/intake.go
+++ b/internal/handler/intake.go
@@ -33,8 +33,12 @@ type intakeService struct {
 }
 
 // intakeOutcome is what happened to one link, in the vocabulary every surface renders from.
-// PublicSlug is empty unless a posting is in the catalog; CompanySlug is set only for
-// outcomeTracked, where naming the company we already cover is the point.
+// PublicSlug is empty unless a posting is in the catalog.
+//
+// Status and CompanySlug answer two different questions, and conflating them is what told a
+// contributor of a second Dropbox ATS that "this company is new to us": Status is the fate of
+// the BOARD (crawled already, queued for onboarding, or filed for review), CompanySlug names
+// the COMPANY when the catalog already carries it — through any source, not just this one.
 type intakeOutcome struct {
 	Status      string
 	PublicSlug  string
@@ -66,7 +70,13 @@ func (s *intakeService) Resolve(ctx context.Context, userID int64, pageURL, surf
 		return intakeOutcome{}, err
 	}
 
-	res, imported, err := s.imports.Import(ctx, pageURL)
+	// The board Inspect just resolved is handed to the import: it is often the only thing that
+	// knows a storefront link belongs to a board we already crawl, and without it the posting
+	// would be written a second time under its URL.
+	res, imported, err := s.imports.Import(ctx, pageURL, linkimport.Board{
+		Source: intake.Source,
+		Board:  intake.Board,
+	})
 	if err != nil {
 		// A transient fetch or parse failure, not a verdict on the page.
 		log.Printf("intake: import %s: %v", pageURL, err)
@@ -83,10 +93,43 @@ func (s *intakeService) Resolve(ctx context.Context, userID int64, pageURL, surf
 		out.Status = outcomeQueued
 	case intake.Tracked:
 		out.Status, out.PublicSlug = outcomeTracked, res.PublicSlug
-	default:
+	case intake.Recognized:
 		out.Status, out.PublicSlug = outcomeImported, res.PublicSlug
+	default:
+		// Imported, but no board could be named from the URL — a careers site on the company's
+		// own domain. Nothing was queued for onboarding, so promising a crawl here would be a
+		// promise nothing keeps; the link is in the manual triage queue instead.
+		out.Status, out.PublicSlug = outcomeReview, res.PublicSlug
+	}
+	if out.CompanySlug == "" {
+		out.CompanySlug = s.companyAlreadyCarried(ctx, res)
 	}
 	return out, nil
+}
+
+// companyAlreadyCarried names the employer of a just-imported posting when the catalog holds
+// more of it than this one row — the answer to "is this company new to us?", which the board
+// checks cannot give: a company reached through an ATS we do not recognise, or through a
+// second ATS, is one we already carry. Empty when the company is genuinely new, when nothing
+// was imported, or on a lookup failure — the posting is saved either way, so the question
+// degrades to "we won't claim we know them".
+func (s *intakeService) companyAlreadyCarried(ctx context.Context, res linkimport.Result) string {
+	if res.CompanySlug == "" {
+		return ""
+	}
+	carried, err := s.queries.CompanyHasOtherJobs(ctx, db.CompanyHasOtherJobsParams{
+		CompanySlug: res.CompanySlug,
+		Source:      res.Source,
+		ExternalID:  res.ExternalID,
+	})
+	if err != nil {
+		log.Printf("intake: company coverage for %s: %v", res.CompanySlug, err)
+		return ""
+	}
+	if !carried {
+		return ""
+	}
+	return res.CompanySlug
 }
 
 // record persists the inspected link and, for a board we already crawl, returns the company

--- a/internal/handler/resolve_job.go
+++ b/internal/handler/resolve_job.go
@@ -25,6 +25,10 @@ const (
 	outcomeTracked = "tracked"
 	// outcomeImported — imported, and the board behind it queued for onboarding.
 	outcomeImported = "imported"
+	// outcomeReview — imported, but the page names no board we can crawl (a careers site on
+	// the company's own domain), so the link went to manual triage rather than onboarding.
+	// Distinct from outcomeImported precisely because no crawl follows from it.
+	outcomeReview = "review"
 	// outcomeQueued — nothing could read the page; the link went to manual triage.
 	outcomeQueued = "queued"
 )
@@ -39,7 +43,12 @@ const (
 //	201 tracked  — we crawl this board already; the posting had not landed, so it was imported
 //	               now, and the company we cover is named
 //	201 imported — imported, and the board behind it queued for onboarding
+//	201 review   — imported, but no crawlable board could be named, so the link went to triage
 //	202 queued   — nothing could read the page, so the link went to manual triage
+//
+// company_slug rides along on every 201 whose employer the catalog already carries, whatever
+// became of the board — the two are independent, and a surface that reads "new company" off
+// the status alone gets it wrong for a company we reach through a different ATS.
 func (h *contributionHandlers) ResolveJob(c *fiber.Ctx) error {
 	var in resolveJobRequest
 	if err := c.BodyParser(&in); err != nil {
@@ -67,7 +76,7 @@ func (h *contributionHandlers) ResolveJob(c *fiber.Ctx) error {
 			JSON(fiber.Map{"data": fiber.Map{"public_slug": nil, "status": out.Status}})
 	}
 	body := fiber.Map{"public_slug": out.PublicSlug, "status": out.Status}
-	if out.Status == outcomeTracked {
+	if out.CompanySlug != "" {
 		body["company_slug"] = out.CompanySlug
 	}
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": body})

--- a/internal/handler/resolve_job_integration_test.go
+++ b/internal/handler/resolve_job_integration_test.go
@@ -37,6 +37,25 @@ const vacancyPage = `<html><head><script type="application/ld+json">
  "hiringOrganization":{"@type":"Organization","name":"Mindera"}}
 </script></head><body>Apply now</body></html>`
 
+// secondMinderaPage is another vacancy from a company the catalog already carries, on the same
+// unrecognisable careers host — the case that used to be answered "this company is new to us".
+const secondMinderaPage = `<html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+ "title":"Principal Java Architect","description":"Shape the platform.",
+ "datePosted":"2026-07-02","jobLocationType":"TELECOMMUTE",
+ "hiringOrganization":{"@type":"Organization","name":"Mindera"}}
+</script></head><body>Apply now</body></html>`
+
+// storefrontPage is a vanity careers storefront over an ATS board: it carries a perfectly good
+// JobPosting block, so the generic resolver reads it happily and would file it under the page's
+// own URL — the duplicate a known board has to override.
+const storefrontPage = `<html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+ "title":"Frontend Product Software Engineer, Design Systems","description":"Design systems work.",
+ "datePosted":"2026-07-20","jobLocationType":"TELECOMMUTE",
+ "hiringOrganization":{"@type":"Organization","name":"Globobox"}}
+</script></head><body>Apply now</body></html>`
+
 const aboutPage = `<html><head><title>About us</title></head><body>No vacancy here.</body></html>`
 
 // pagesClient is a test linksource.Client: it serves the body registered for the first
@@ -81,6 +100,25 @@ type resolveReply struct {
 	} `json:"data"`
 }
 
+// fakeGreenhouse serves one greenhouse board, so a storefront link resolved to that board can
+// be read from it. Its posting URL is the board's own, not the storefront's — which is exactly
+// why the posting has to be matched by id.
+type fakeGreenhouse struct{}
+
+func (fakeGreenhouse) Provider() string { return "greenhouse" }
+
+func (fakeGreenhouse) Fetch(_ context.Context, e sources.CompanyEntry) ([]sources.Job, error) {
+	if e.Board != "globobox" {
+		return nil, nil
+	}
+	return []sources.Job{{
+		ExternalID: "7862086",
+		URL:        "https://jobs.globobox.test/listing/7862086?gh_jid=7862086",
+		Title:      "Frontend Product Software Engineer, Design Systems",
+		Company:    "Globobox",
+	}}, nil
+}
+
 // fakeRecruitee is a stand-in ingest adapter for a platform with no single-page link adapter,
 // so the intake reaches it through board coverage — the path most pasted links now take.
 type fakeRecruitee struct{}
@@ -119,6 +157,8 @@ func TestResolveJobEndpoint(t *testing.T) {
 	queries := db.New(pool)
 	pages := pagesClient{
 		"/jobs/staff-java-backend-developer": vacancyPage,
+		"/jobs/principal-java-architect":     secondMinderaPage,
+		"/jobs/7862086":                      storefrontPage,
 		"/about-us":                          aboutPage,
 	}
 	contributionSvc := contribution.New(contribution.NewQueriesRepository(queries), nil)
@@ -128,7 +168,7 @@ func TestResolveJobEndpoint(t *testing.T) {
 			queries:      queries,
 			contribution: contributionSvc,
 			imports: linkimport.New(pool, queries, nil, pages,
-				map[string]sources.Source{"recruitee": fakeRecruitee{}}, nil),
+				map[string]sources.Source{"recruitee": fakeRecruitee{}, "greenhouse": fakeGreenhouse{}}, nil),
 		},
 	}
 
@@ -179,14 +219,20 @@ func TestResolveJobEndpoint(t *testing.T) {
 		}
 	})
 
-	t.Run("a parseable page is imported", func(t *testing.T) {
+	t.Run("a parseable page on an unrecognised host is imported and filed for review", func(t *testing.T) {
+		// No board can be derived from a company's own careers domain, so nothing is queued for
+		// onboarding — answering "imported" here would promise a crawl that never starts.
 		const page = "https://careers.mindera.test/jobs/staff-java-backend-developer"
 		resp, out := resolve(t, page, true)
 		if resp.StatusCode != http.StatusCreated {
 			t.Fatalf("status = %d, want 201", resp.StatusCode)
 		}
-		if out.Data == nil || out.Data.Status != "imported" || out.Data.PublicSlug == nil {
-			t.Fatalf("body = %+v, want status imported with a slug", out.Data)
+		if out.Data == nil || out.Data.Status != "review" || out.Data.PublicSlug == nil {
+			t.Fatalf("body = %+v, want status review with a slug", out.Data)
+		}
+		if out.Data.CompanySlug != "" {
+			t.Errorf("company_slug = %q, want empty — nothing else of Mindera's is in the catalog",
+				out.Data.CompanySlug)
 		}
 		var stored string
 		if err := pool.QueryRow(ctx,
@@ -208,6 +254,64 @@ func TestResolveJobEndpoint(t *testing.T) {
 		}
 		if rows != 1 {
 			t.Errorf("catalog holds %d imported postings, want 1", rows)
+		}
+	})
+
+	t.Run("a storefront link lands on the board it fronts, not as a second posting", func(t *testing.T) {
+		// The shape that started this: a vanity storefront over a Greenhouse board we already
+		// crawl (dropbox.jobs over greenhouse/dropbox). Its host names no board and its path puts
+		// the greenhouse job id BEFORE a readable slug, so every URL parse misses it — but the
+		// catalogue already holds that id, which is what resolves the board. The posting must
+		// update the row we crawl rather than appear a second time under (weblink, <the URL>).
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, public_slug, company, company_slug)
+			 VALUES ('greenhouse', 'globobox:7862086', 'https://jobs.globobox.test/listing/7862086',
+			         'Frontend Product Software Engineer, Design Systems', 'frontend-design-systems-globobox',
+			         'Globobox', 'globobox')`); err != nil {
+			t.Fatalf("seed the crawled greenhouse posting: %v", err)
+		}
+		const page = "https://www.globobox.jobs/en/jobs/7862086/frontend-product-software-engineer-design-systems/"
+		resp, out := resolve(t, page, true)
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("status = %d, want 201", resp.StatusCode)
+		}
+		if out.Data == nil || out.Data.Status != "tracked" {
+			t.Fatalf("body = %+v, want status tracked — we crawl the board behind that storefront", out.Data)
+		}
+		if out.Data.CompanySlug != "globobox" {
+			t.Errorf("company_slug = %q, want globobox", out.Data.CompanySlug)
+		}
+		var rows int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM jobs WHERE source = 'weblink' AND external_id = $1`, page).Scan(&rows); err != nil {
+			t.Fatalf("count weblink duplicates: %v", err)
+		}
+		if rows != 0 {
+			t.Errorf("the storefront link wrote %d weblink rows, want 0 — it duplicates the crawled posting", rows)
+		}
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM jobs WHERE company_slug = 'globobox'`).Scan(&rows); err != nil {
+			t.Fatalf("count globobox postings: %v", err)
+		}
+		if rows != 1 {
+			t.Errorf("catalog holds %d Globobox postings, want 1 — the import must land on the crawled row", rows)
+		}
+	})
+
+	t.Run("a company we already carry is not called new", func(t *testing.T) {
+		// Whether we can name the BOARD and whether we know the COMPANY are separate questions:
+		// the previous subtest put a Mindera posting in the catalog, so this second vacancy from
+		// the same company must come back naming it, however unrecognisable its host is.
+		resp, out := resolve(t, "https://careers.mindera.test/jobs/principal-java-architect", true)
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("status = %d, want 201", resp.StatusCode)
+		}
+		if out.Data == nil || out.Data.Status != "review" {
+			t.Fatalf("body = %+v, want status review", out.Data)
+		}
+		if out.Data.CompanySlug != "mindera" {
+			t.Errorf("company_slug = %q, want mindera — the catalog already carries this company",
+				out.Data.CompanySlug)
 		}
 	})
 

--- a/internal/handler/telegram.go
+++ b/internal/handler/telegram.go
@@ -269,13 +269,22 @@ func (h *telegramHandlers) intakeReply(out intakeOutcome) string {
 	case outcomeFound:
 		return "👍 We already have this one:\n" + h.jobURL(out.PublicSlug)
 	case outcomeTracked:
-		reply := "✅ Added — and we already track this company, so the rest of its roles will follow on the next crawl.\n" + h.jobURL(out.PublicSlug)
-		if out.CompanySlug != "" && h.frontendOrigin != "" {
-			reply += "\n" + h.frontendOrigin + "/companies/" + out.CompanySlug
-		}
-		return reply
+		return "✅ Added — and we already track this company, so the rest of its roles will follow on the next crawl.\n" +
+			h.jobURL(out.PublicSlug) + h.companyURL(out.CompanySlug)
 	case outcomeImported:
+		if out.CompanySlug != "" {
+			return "✅ Added — we already carry this company, and now we'll crawl this board of theirs too.\n" +
+				h.jobURL(out.PublicSlug) + h.companyURL(out.CompanySlug)
+		}
 		return "🎉 Added, and this company is new to us — we'll start crawling its board.\n" + h.jobURL(out.PublicSlug)
+	case outcomeReview:
+		// Imported, but the page named no board we know how to crawl, so no crawl is promised.
+		if out.CompanySlug != "" {
+			return "✅ Added — we already carry this company. Its careers site isn't one we can crawl yet, so we'll look at it by hand.\n" +
+				h.jobURL(out.PublicSlug) + h.companyURL(out.CompanySlug)
+		}
+		return "✅ Added. Its careers site isn't one we can crawl yet — we'll check by hand whether we can pull the rest of its jobs.\n" +
+			h.jobURL(out.PublicSlug)
 	}
 	// outcomeQueued. Failing to read the page says nothing about whether we recognised the
 	// board behind it, and answering only "couldn't read" would hide a contribution we just
@@ -298,4 +307,13 @@ func (h *telegramHandlers) jobURL(slug string) string {
 		return ""
 	}
 	return h.frontendOrigin + "/jobs/" + slug
+}
+
+// companyURL renders a company link on its own line, so a reply can append it unconditionally.
+// Empty under the same rule as jobURL.
+func (h *telegramHandlers) companyURL(slug string) string {
+	if slug == "" || h.frontendOrigin == "" {
+		return ""
+	}
+	return "\n" + h.frontendOrigin + "/companies/" + slug
 }

--- a/internal/linkimport/import_integration_test.go
+++ b/internal/linkimport/import_integration_test.go
@@ -62,7 +62,7 @@ func TestImport_WritesTheParsedVacancy(t *testing.T) {
 
 	im := New(pool, q, nil, pageClient{body: jobPostingPage}, nil, nil)
 
-	res, ok, err := im.Import(ctx, pageURL)
+	res, ok, err := im.Import(ctx, pageURL, Board{})
 	if err != nil {
 		t.Fatalf("import: %v", err)
 	}
@@ -108,11 +108,11 @@ func TestImport_IsIdempotentForTheSameURL(t *testing.T) {
 
 	im := New(pool, q, nil, pageClient{body: jobPostingPage}, nil, nil)
 
-	first, _, err := im.Import(ctx, pageURL)
+	first, _, err := im.Import(ctx, pageURL, Board{})
 	if err != nil {
 		t.Fatalf("first import: %v", err)
 	}
-	second, ok, err := im.Import(ctx, pageURL)
+	second, ok, err := im.Import(ctx, pageURL, Board{})
 	if err != nil {
 		t.Fatalf("second import: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestImport_ReportsAPageThatIsNotAVacancy(t *testing.T) {
 
 	im := New(pool, q, nil, pageClient{body: plainPage}, nil, nil)
 
-	res, ok, err := im.Import(ctx, "https://careers.mindera.test/about-us")
+	res, ok, err := im.Import(ctx, "https://careers.mindera.test/about-us", Board{})
 	if err != nil {
 		t.Fatalf("import: %v", err)
 	}

--- a/internal/linkimport/linkimport.go
+++ b/internal/linkimport/linkimport.go
@@ -36,6 +36,10 @@ type Result struct {
 	Source     string
 	ExternalID string
 	PublicSlug string
+	// CompanySlug is the employer the posting was filed under, empty when the page named no
+	// company. The intake asks the catalog about it to tell a genuinely new employer from one
+	// we already carry under another ATS.
+	CompanySlug string
 }
 
 // BoardResolver detects the ATS board embedded in a page whose host says nothing — a company
@@ -74,14 +78,37 @@ func New(pool *pgxpool.Pool, q *db.Queries, idx *search.Client, c linksource.Cli
 	}
 }
 
+// Board is an ATS board a caller has already resolved for the link it is importing. The intake
+// resolves one on every link before importing it, and it can name a board no URL parse would
+// reach — a storefront on the company's own domain whose posting id gives away the greenhouse
+// board behind it. A zero Board simply means "unknown".
+type Board struct {
+	Source string
+	Board  string
+}
+
+func (b Board) known() bool { return b.Source != "" && b.Board != "" }
+
 // Import resolves raw through the registry and writes the vacancy it parses. ok=false
 // means the page is not a single vacancy we can read (no adapter matched, or the page
 // carries no posting) — the caller decides what to do with it, and nothing is written. A
 // non-nil error is a transient fetch/parse failure or a write failure.
-func (im *Importer) Import(ctx context.Context, raw string) (Result, bool, error) {
+//
+// known is the board the caller already resolved, and it only ever overrides the generic
+// resolver — the host-scoped adapters and board coverage already write a board's own identity,
+// and cost less. Generic reads any page with a JobPosting block, and files it under (weblink,
+// <the URL>): correct when nothing better is known, but a second row for a posting we crawl
+// under (greenhouse, <board>:<id>) when a board IS known. Preferring the board there is what
+// keeps a storefront link from duplicating the posting it points at.
+func (im *Importer) Import(ctx context.Context, raw string, known Board) (Result, bool, error) {
 	resolved, err := linksource.ResolveLinks(ctx, im.reg, []string{raw})
 	if err != nil {
 		return Result{}, false, err
+	}
+	if len(resolved) == 0 || resolved[0].Source == linksource.GenericSource {
+		if r, ok := im.resolveOnKnownBoard(ctx, raw, known); ok {
+			return im.write(ctx, r)
+		}
 	}
 	if len(resolved) == 0 {
 		if r, ok := im.resolveVanityDomain(ctx, raw); ok {
@@ -90,6 +117,24 @@ func (im *Importer) Import(ctx context.Context, raw string) (Result, bool, error
 		return Result{}, false, nil
 	}
 	return im.write(ctx, resolved[0])
+}
+
+// resolveOnKnownBoard reads the posting from the board the caller named, so it is stored under
+// the identity a crawl of that board would give it. A board we cannot crawl (no ingest adapter)
+// or a posting absent from it leaves the caller's own resolution in place.
+func (im *Importer) resolveOnKnownBoard(ctx context.Context, raw string, known Board) (linksource.Resolved, bool) {
+	if !known.known() || im.ingest == nil {
+		return linksource.Resolved{}, false
+	}
+	job, ok, err := linksource.ResolveOnBoard(ctx, im.ingest, known.Source, known.Board, raw)
+	if err != nil {
+		log.Printf("linkimport: known board %s/%s for %s: %v", known.Source, known.Board, raw, err)
+		return linksource.Resolved{}, false
+	}
+	if !ok {
+		return linksource.Resolved{}, false
+	}
+	return linksource.Resolved{Source: known.Source, Job: job}, true
 }
 
 // resolveVanityDomain is the last thing tried before a link is given up on: a company careers
@@ -168,9 +213,10 @@ func (im *Importer) write(ctx context.Context, r linksource.Resolved) (Result, b
 	im.index(ctx, res)
 
 	return Result{
-		Source:     res.Job.Source,
-		ExternalID: res.Job.ExternalID,
-		PublicSlug: res.Job.PublicSlug,
+		Source:      res.Job.Source,
+		ExternalID:  res.Job.ExternalID,
+		PublicSlug:  res.Job.PublicSlug,
+		CompanySlug: res.Job.CompanySlug,
 	}, true, nil
 }
 

--- a/internal/linksource/AGENTS.md
+++ b/internal/linksource/AGENTS.md
@@ -22,6 +22,15 @@ Resolving a single outbound job-detail URL into a fully parsed vacancy under the
   and `Find` commits to a single adapter.
 - **A fetched-but-absent posting is `ok=false`; an unfetchable board is an error.** Conflating
   them makes the caller file a reachable vacancy as unimportable.
+- **`generic` winning is not the same as nothing matching.** Its `Match` is always true, so a
+  page it can read never reaches anything downstream — `linkimport` therefore checks for
+  `GenericSource` explicitly, not just for an empty result, before preferring a board the
+  caller already resolved. A `len(resolved) == 0` guard alone leaves that branch dead for every
+  page carrying a `JobPosting` block, which is most storefronts.
+- **A posting id is matched anywhere in the path, last segment first** (`pickPosting`). A
+  storefront appends a readable slug after the id (`…/jobs/<id>/<title>/`), so tail-only
+  matching reports a posting as absent from its own board. Precision is safe here because the
+  comparison is against one board's own ids.
 
 ## How it works
 A Telegram post often just links to a real vacancy elsewhere. Rather than treating the Telegram post itself as the job, `internal/linksource` follows the outbound URL and resolves the actual detail page at the destination ATS. This reuses the same adapter pattern as `internal/sources` but at the granularity of a single page: a `LinkSource` matches the link's host and parses that one detail page into a normalized job. The job is then stored under the destination source's identity (e.g. greenhouse, lever), not under telegram, so the dedup key `(source, external_id)` naturally prevents duplication if another source also carries the same posting.

--- a/internal/linksource/boardcoverage.go
+++ b/internal/linksource/boardcoverage.go
@@ -3,6 +3,7 @@ package linksource
 import (
 	"context"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/strelov1/freehire/internal/atsboard"
@@ -123,9 +124,9 @@ func pickPosting(jobs []sources.Job, raw string) (sources.Job, bool) {
 			return j, true
 		}
 	}
-	if id := lastPathSegment(raw); id != "" {
+	for _, seg := range pathSegmentsFromEnd(raw) {
 		for _, j := range jobs {
-			if j.ExternalID != "" && j.ExternalID == id {
+			if j.ExternalID != "" && j.ExternalID == seg {
 				return j, true
 			}
 		}
@@ -145,19 +146,21 @@ func normalizeURL(raw string) string {
 	return host + strings.TrimSuffix(u.Path, "/")
 }
 
-// lastPathSegment returns a URL's final path segment ("" when there is none) — where an ATS
-// puts the posting id in most of its URL shapes.
-func lastPathSegment(raw string) string {
+// pathSegmentsFromEnd returns a URL's path segments last-first — the order to look for a
+// posting id in. Most ATS URL shapes end in the id, but a storefront over the board appends a
+// readable slug after it (…/jobs/<id>/<title>/), so the tail alone is not enough. Matching is
+// against one board's own posting ids, a set small enough that scanning inward costs no
+// precision.
+func pathSegmentsFromEnd(raw string) []string {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return ""
+		return nil
 	}
 	p := strings.Trim(u.Path, "/")
 	if p == "" {
-		return ""
+		return nil
 	}
-	if i := strings.LastIndexByte(p, '/'); i >= 0 {
-		return p[i+1:]
-	}
-	return p
+	segs := strings.Split(p, "/")
+	slices.Reverse(segs)
+	return segs
 }

--- a/internal/linksource/boardcoverage_test.go
+++ b/internal/linksource/boardcoverage_test.go
@@ -147,6 +147,29 @@ func TestBoardCoverageMatchesAVacancyByItsIDInThePath(t *testing.T) {
 	}
 }
 
+func TestBoardCoverageMatchesAVacancyByAnIDBeforeTheSlug(t *testing.T) {
+	// A storefront over the board puts a human-readable slug AFTER the id
+	// (…/jobs/<id>/<title>/), so reading only the last path segment finds a title where an id
+	// was expected and the posting looks absent from its own board.
+	board := &fakeBoard{
+		provider: "recruitee",
+		jobs: []sources.Job{
+			{ExternalID: "7862086", URL: "https://acme.recruitee.com/o/senior-go", Title: "Senior Go"},
+		},
+	}
+	// Reached through ResolveOnBoard, since the board came from elsewhere (the intake resolved
+	// it) rather than from this unrecognisable host.
+	reg := map[string]sources.Source{"recruitee": board}
+	job, ok, err := ResolveOnBoard(context.Background(), reg, "recruitee", "acme",
+		"https://careers.acme.test/en/jobs/7862086/senior-go/")
+	if err != nil || !ok {
+		t.Fatalf("ResolveOnBoard = (ok %v, err %v), want the vacancy matched by the id before the slug", ok, err)
+	}
+	if job.Title != "Senior Go" {
+		t.Errorf("resolved %q, want Senior Go", job.Title)
+	}
+}
+
 // TestImportRegistryOrder pins the resolver order the import path depends on. Getting it
 // wrong is silent and expensive: board coverage ahead of the host-scoped adapters would fetch
 // a whole board where a per-job API call would do, and anything after generic would never be

--- a/internal/linksource/generic.go
+++ b/internal/linksource/generic.go
@@ -27,10 +27,15 @@ type generic struct {
 // NewGeneric builds the last-resort JobPosting-ld+json link resolver.
 func NewGeneric(c Client) Source { return generic{http: c} }
 
+// GenericSource is the provenance tag of a page read by the last-resort resolver, exported
+// because a caller has to be able to tell "read off the page itself, keyed by its URL" from a
+// real board identity — the import path prefers a known board over it.
+const GenericSource = "weblink"
+
 // Source is a fixed provenance tag for hand-imported links. It is not in sources.All, so
 // these jobs are treated as orphans by the liveness worker (URL-probed and closed when
 // dead) — the right lifecycle for a one-off posting that has no board to re-crawl it.
-func (generic) Source() string { return "weblink" }
+func (generic) Source() string { return GenericSource }
 
 // Match accepts any absolute http(s) URL. The real gate is Resolve finding a JobPosting
 // block, so a non-vacancy page returns ok=false rather than a bogus job.

--- a/web/src/lib/components/ContributeView.svelte
+++ b/web/src/lib/components/ContributeView.svelte
@@ -84,9 +84,15 @@
         {:else if resolved.status === 'tracked'}
           Added — and we already track this company, so the rest of its roles will follow on the
           next crawl.
+        {:else if resolved.status === 'imported' && resolved.company_slug}
+          Added — we already carry this company, and now we'll crawl this board of theirs too.
+          <span class="font-medium">+1 AI credit.</span>
         {:else if resolved.status === 'imported'}
           Added, and this company is new to us — we'll start crawling its board.
           <span class="font-medium">+1 AI credit.</span>
+        {:else if resolved.status === 'review'}
+          Added. Its careers site isn't one we can crawl yet, so we'll check by hand whether we
+          can pull the rest of its jobs. <span class="font-medium">Not credited yet.</span>
         {:else}
           We couldn't read that page. We'll check by hand whether we can pull its jobs — if we
           can, we'll award you a credit. <span class="font-medium">Not credited yet.</span>

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -1640,13 +1640,16 @@ ${BASE_URL}/auth/oauth/google/start`,
         auth: 'cookie-or-key',
         summary: 'Hand freehire a link: import the posting, and the board behind it.',
         description:
-          'Four outcomes in one shape, distinguished by status: **200 found** — the ' +
+          'Five outcomes in one shape, distinguished by status: **200 found** — the ' +
           'catalogue already carries it, nothing fetched or written; **201 tracked** ' +
           '— we crawl that board already and the posting just had not landed, so it ' +
           'was imported now; **201 imported** — imported, and its board queued for ' +
-          'onboarding; **202 queued** — nothing could read the page, so the link went ' +
-          'to manual triage. Rate-limited, because it makes the server fetch a URL ' +
-          'you chose. A URL that is not http(s) is a 422.',
+          'onboarding; **201 review** — imported, but its careers site names no board ' +
+          'we can crawl, so the link went to manual triage; **202 queued** — nothing ' +
+          'could read the page, so the link went to manual triage. `company_slug` is ' +
+          'returned whenever the catalogue already carries the employer, through any ' +
+          'source — independent of what became of the board. Rate-limited, because it ' +
+          'makes the server fetch a URL you chose. A URL that is not http(s) is a 422.',
         body: [
           { name: 'url', type: 'string', required: true, description: 'The job page to resolve.' },
           { name: 'surface', type: 'string', description: 'Where the link came from (website, extension, cli, bot) — recorded, not validated against a whitelist.' },
@@ -1654,7 +1657,7 @@ ${BASE_URL}/auth/oauth/google/start`,
         curl: `curl -X POST "${BASE_URL}/jobs/resolve" \\
   -H "Authorization: Bearer fhk_…" -H 'Content-Type: application/json' \\
   -d '{"url":"https://boards.greenhouse.io/acme/jobs/123","surface":"cli"}'`,
-        responseExample: `{ "data": { "outcome": "tracked", "public_slug": "senior-backend-engineer-acme-1a2b", "company": "Acme" } }`,
+        responseExample: `{ "data": { "status": "tracked", "public_slug": "senior-backend-engineer-acme-1a2b", "company_slug": "acme" } }`,
       },
       {
         method: 'GET',

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -218,17 +218,20 @@ export interface Contribution {
   created_at: string | null;
 }
 
-/** What became of a link handed to the intake.
+/** What became of the BOARD behind a link handed to the intake.
  *  - `found`    the catalog already carried the posting
  *  - `tracked`  imported, and we already crawl this company's board
  *  - `imported` imported, and the board behind it is now queued for onboarding
+ *  - `review`   imported, but its careers site names no board we can crawl, so it went to triage
  *  - `queued`   nothing could read the page, so the link went to manual triage */
-export type IntakeStatus = 'found' | 'tracked' | 'imported' | 'queued';
+export type IntakeStatus = 'found' | 'tracked' | 'imported' | 'review' | 'queued';
 
 export interface ResolvedLink {
   public_slug: string | null;
   status: IntakeStatus;
-  /** Set only for `tracked`: the company we already cover, so the UI can link to it. */
+  /** The employer, when the catalog already carries it — through any source, not just the one
+   *  this link came from. Whether we know the COMPANY is a separate question from what became
+   *  of its BOARD, so this rides along with every outcome, not just `tracked`. */
   company_slug?: string;
 }
 


### PR DESCRIPTION
## What happened

A Dropbox posting pasted from `dropbox.jobs` — a Phenom storefront over the Greenhouse board we have been crawling all along — was answered:

> 🎉 Added, and this company is new to us — we'll start crawling its board.

Both halves were wrong. We crawl `greenhouse/dropbox` (26 live postings), and no crawl followed: the link went to manual triage. It also imported the vacancy a second time — prod now holds both `greenhouse / dropbox:7862086` and a `weblink` row keyed by the storefront URL, for one job.

## Four defects, one link

| # | Where | What |
|---|---|---|
| 1 | `handler/intake.go` | An **unrecognised** board fell through the outcome switch to `imported`, whose contract is "board queued for onboarding". Now its own outcome, `review`. |
| 2 | `handler/intake.go` | "Is this company new?" was read off the board check, which is keyed by `(source, board)`. A company reached through a second ATS is board-new and company-old at once. `company_slug` now accompanies every outcome whose employer the catalogue already carries. |
| 3 | `contribution/board.go` | `greenhouseJobID` read only the **last** path segment. A storefront appends a readable slug after the id (`…/jobs/<id>/<title>/`), hiding a board the catalogue could name. |
| 4 | `linksource/boardcoverage.go` | `pickPosting` had the same tail-only assumption, so a posting matched by id looked absent from its own board. |

Plus the structural one: `linkimport` reached its vanity-domain fallback only at `len(resolved) == 0`, but the generic resolver's `Match` is always true and it reads any page with a `JobPosting` block. That branch was dead for the exact case it exists for.

## The fix

The board `Inspect` resolves is handed to the import (`linkimport.Board`), overriding **only** the generic resolver — host-scoped adapters and board coverage already write a board's own identity and cost less. That is what keeps a storefront link from duplicating the posting it points at.

## API

`POST /jobs/resolve` gains a fifth status, `review` (201): imported, but no crawlable board could be named. `company_slug` is no longer restricted to `tracked`. Docs and `docs/API.md` regenerated.

## Verification

Every fix is pinned by a test that was confirmed **red without it** — the implementation was reverted temporarily to check:

- without the board hint the regression test writes two rows for one vacancy (`catalog holds 2 Globobox postings, want 1`);
- without right-to-left path reading the board is not named and the posting is absent from its own board.

`go build`, `go vet`, `gofmt`, full `go test ./...`, integration (`handler`, `linkimport`, `contribution`), web `lint` (0 errors) and `build` all pass.

## Not in this PR

The existing `weblink` duplicate in prod. The role-cluster pass already groups the pair (`repost_count: 2`), so a reindex collapses it in the listings, but the row stays. Cleanup and a survey of how many such pairs exist are a separate change.