### PR TITLE
feat(assistant): the agent is open to every signed-in user

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ Each is self-contained and can be read independently.
 - **Embeddings:** Queue-driven (`semantic_outbox`), incremental, reconciled by `reindex --semantic`
 - **Dictionaries:** All facet dictionaries are dict-only in production — never guess, emit nothing for unknowns
 - **Job deletion:** The lifecycle only soft-closes; `cmd/prune` is the sole hard-delete path
-- **In-app assistant:** a bounded tool-calling loop in-process (`internal/assistant`), streamed over SSE, gated to the restricted rollout. Tools act as the authenticated caller — no credential is minted for an agent
+- **In-app assistant:** a bounded tool-calling loop in-process (`internal/assistant`), streamed over SSE, open to every signed-in user. Tools act as the authenticated caller — no credential is minted for an agent. A turn is not metered against AI credits yet, so authentication is the only thing bounding the spend
 - **Experience provenance:** every banked achievement records whether the CANDIDATE asserted it (`cv_import`/`stated_in_chat`/`manual`) or the MODEL did (`agent_inferred`). Only the former may be written into a CV, and the check lives in the service path, not in a system prompt
 - **Sentry:** Opt-in, env-gated, errors-only — `sentry.Init` with `SendDefaultPII:false`
 - **Naming — "CV", not "résumé":** Default new surfaces to **CV**. Don't mass-rename the existing `resume`/`resumeextract` packages and columns — churn without value

--- a/internal/assistant/AGENTS.md
+++ b/internal/assistant/AGENTS.md
@@ -112,8 +112,10 @@ is never mistaken for the answer.
    the valid ones. That message is the model's only path to self-correction.
 
 ## Limitations
-- No metering. The assistant is free behind the restricted-rollout gate;
-  `internal/credits` is the seam for a per-turn debit.
+- **No metering.** A turn is free to the caller and billed to us. This was affordable
+  while the restricted-rollout gate held the audience to a handful of accounts; that
+  gate is gone and the assistant is open to every signed-in user, so nothing bounds
+  the spend now. `internal/credits` is the seam for a per-turn debit.
 - No summarisation: a long session loses its oldest messages to the window rather
   than compacting them.
 - One tool round runs its calls sequentially. Parallel execution would need

--- a/internal/handler/AGENTS.md
+++ b/internal/handler/AGENTS.md
@@ -61,10 +61,12 @@ Pipeline and cross-package invariants live in [docs/agents/mail-stack.md](../../
 ## Assistant (`assistant.go`, `assistant_*_tools.go`)
 
 Routes (all on `mw.key` — the session cookie, the session JWT the extension's
-connect flow minted, or a full-scope API key — then `requireRollout`, because
-inference is billed to us and the assistant is not open to everyone while it is
-free). The gate is `key` rather than `cookie` because the extension's side panel
-holds conversations too and cannot send an httpOnly cookie across origins:
+connect flow minted, or a full-scope API key — and nothing else). Authentication
+is the whole gate: every signed-in user reaches the assistant. The gate is `key`
+rather than `cookie` because the extension's side panel holds conversations too
+and cannot send an httpOnly cookie across origins. **Nothing meters a turn** —
+the beta-tester gate that used to bound this spend is gone, and credit metering
+has not replaced it yet:
 
 | Route | Does |
 |---|---|

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -75,37 +75,20 @@ func newAssistantHandlers(queries *db.Queries, model *llm.Client, maxSteps int,
 // the extension's side panel holds conversations too, and it cannot send hire's
 // httpOnly cookie across origins — so the gate is `key`, which resolves the cookie,
 // the session JWT the connect flow minted, or a full-scope API key to one user.
-// Every route stays behind the restricted rollout: inference is billed to us, so it
-// is not open to everyone while it is free.
+// Authentication is the whole gate: every signed-in user reaches the assistant. The
+// beta-tester restriction that used to sit here was written when the agent ran on the
+// candidate's own machine, and did not survive the move in-process. Note what left
+// with it — nothing meters a turn, so until credit metering lands, being signed in is
+// all that bounds our inference spend.
 func (h *assistantHandlers) register(api fiber.Router, mw middleware) {
-	gate := h.requireRollout
-	api.Post("/assistant/sessions", mw.key, gate, h.CreateAssistantSession)
-	api.Get("/assistant/sessions", mw.key, gate, h.ListAssistantSessions)
-	api.Get("/assistant/sessions/:id", mw.key, gate, h.GetAssistantSession)
-	api.Delete("/assistant/sessions/:id", mw.key, gate, h.DeleteAssistantSession)
-	api.Post("/assistant/sessions/:id/messages", mw.key, gate, h.PostAssistantMessage)
+	api.Post("/assistant/sessions", mw.key, h.CreateAssistantSession)
+	api.Get("/assistant/sessions", mw.key, h.ListAssistantSessions)
+	api.Get("/assistant/sessions/:id", mw.key, h.GetAssistantSession)
+	api.Delete("/assistant/sessions/:id", mw.key, h.DeleteAssistantSession)
+	api.Post("/assistant/sessions/:id/messages", mw.key, h.PostAssistantMessage)
 	// Cookie-only: an unattended run rewrites a CV, and the browser is the only place
 	// the candidate can watch it happen and undo it.
-	api.Post("/assistant/sessions/:id/autopilot", mw.cookie, gate, h.PostAssistantAutopilot)
-}
-
-// requireRollout admits moderators and beta testers. Membership is read fresh per
-// request rather than from the token, so revoking it takes effect immediately, and
-// a read failure fails closed — the assistant spends our money, so an unresolvable
-// caller is refused rather than let through.
-func (h *assistantHandlers) requireRollout(c *fiber.Ctx) error {
-	userID, err := requireUserID(c)
-	if err != nil {
-		return err
-	}
-	u, err := h.queries.GetUserByID(c.Context(), userID)
-	if err != nil {
-		return fiber.NewError(fiber.StatusUnauthorized, "not authenticated")
-	}
-	if u.Role != "moderator" && !u.BetaTester {
-		return fiber.NewError(fiber.StatusForbidden, "forbidden")
-	}
-	return c.Next()
+	api.Post("/assistant/sessions/:id/autopilot", mw.cookie, h.PostAssistantAutopilot)
 }
 
 // assistantMaxPrompt bounds one user message. The agent's context is finite and a

--- a/internal/handler/assistant_integration_test.go
+++ b/internal/handler/assistant_integration_test.go
@@ -2,8 +2,9 @@
 
 // Integration tests for the in-app assistant's HTTP surface against a real
 // Postgres: the session lifecycle (create, list, read, delete), the owner checks
-// on every one of them, the beta gate, and a full streamed turn driven by a
-// scripted model — its events, its persisted transcript, and its resumption.
+// on every one of them, the boundary at authentication (any signed-in user is
+// served, a caller with no credential is not), and a full streamed turn driven by
+// a scripted model — its events, its persisted transcript, and its resumption.
 // Run with: go test -tags=integration ./internal/handler/
 package handler
 
@@ -218,14 +219,18 @@ func TestAssistantSessionsAreOwnerScoped(t *testing.T) {
 	}
 }
 
-func TestAssistantIsGatedToTheRestrictedRollout(t *testing.T) {
+// The assistant applies no membership test beyond authentication: a signed-in user in
+// no group at all is served. Authentication itself did not loosen with the gate — a
+// caller presenting no credential is still refused, and this test guards both halves,
+// because "open to everyone" is one edit away from "open to anyone".
+func TestAssistantServesAUserInNoGroup(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	app, _ := newAssistantApp(pool, iss, nil)
 	_, plain := assistantUser(t, pool, iss, "plain@example.test", false)
 
-	if resp := assistantRequest(t, app, fiber.MethodPost, "/api/v1/assistant/sessions", plain, map[string]any{}); resp.StatusCode != fiber.StatusForbidden {
-		t.Errorf("non-beta create: status %d, want 403", resp.StatusCode)
+	if resp := assistantRequest(t, app, fiber.MethodPost, "/api/v1/assistant/sessions", plain, map[string]any{}); resp.StatusCode != fiber.StatusCreated {
+		t.Errorf("create as a user who is neither moderator nor beta tester: status %d, want 201", resp.StatusCode)
 	}
 	if resp := assistantRequest(t, app, fiber.MethodGet, "/api/v1/assistant/sessions", "", nil); resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("unauthenticated list: status %d, want 401", resp.StatusCode)
@@ -338,17 +343,18 @@ func TestSessionListSpansBrowsingConversations(t *testing.T) {
 	}
 }
 
-// Widening the carrier must not widen the rollout: the gate reads group membership
-// per request, whichever credential resolved the caller.
-func TestAssistantRefusesABearerCallerOutsideTheRollout(t *testing.T) {
+// The carrier decides nothing about standing: a user in no group is served over Bearer
+// exactly as the cookie serves them. Paired with the unauthenticated case above, this
+// pins the boundary at authentication and nowhere else.
+func TestAssistantServesABearerCallerInNoGroup(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	app, _ := newAssistantApp(pool, iss, nil)
 	_, token := assistantUser(t, pool, iss, "plain-extension@example.test", false)
 
 	resp := assistantBearerRequest(t, app, fiber.MethodPost, "/api/v1/assistant/sessions", token, map[string]any{})
-	if resp.StatusCode != fiber.StatusForbidden {
-		t.Errorf("non-beta create over Bearer: status %d, want 403", resp.StatusCode)
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Errorf("create over Bearer as a user in no group: status %d, want 201", resp.StatusCode)
 	}
 }
 

--- a/openspec/changes/open-assistant-to-all-users/.openspec.yaml
+++ b/openspec/changes/open-assistant-to-all-users/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/open-assistant-to-all-users/design.md
+++ b/openspec/changes/open-assistant-to-all-users/design.md
@@ -1,0 +1,104 @@
+## Context
+
+`requireRollout` sits in front of all five `/api/v1/assistant/*` routes and refuses any
+signed-in caller who is neither a moderator nor a beta tester. On production that is 358 of
+360 accounts. The gate is the last piece of a policy the rest of the product has already
+abandoned: `accountNav.ts` links "Agent" unconditionally, `/tailor` mounts the same chat
+with `requireBeta={false}`, and `AssistantChat.svelte`'s `requireBeta` prop defaults to
+`false` — so no host ever turned the UI mirror on.
+
+The visible symptom is a triple `403` on one page load. `boot()` catches the refused session
+list, keeps going with an empty array, and the emptiness is then read as "this user has no
+chats" — which the next branch answers by `POST`ing a new session, earning a second refusal.
+A gate the client cannot distinguish from an absence produces exactly this.
+
+The gate's original justification is in the code and has expired: it was affordable to open
+the assistant to nobody because inference was ours to pay for. `accountNav.ts` still carries
+the counter-claim that the agent "runs on the user's own machine with their own Claude
+subscription" — true before #1165 moved the agent in-process, false since.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Any signed-in user reaches the assistant, through `/my/assistant` and through the chat
+  embedded in `/tailor`, with no membership test beyond authentication.
+- The spec stops asserting a gate the code no longer has — `assistant-sessions` is the only
+  spec that normatively requires it.
+- The client stops carrying a mirror of a gate that does not exist, rather than being taught
+  to mirror it correctly.
+
+**Non-Goals:**
+
+- **AI-credit metering for assistant turns.** Owed follow-up, deliberately not bundled: it is
+  a design problem of its own (what a turn costs, whether tool calls count, what a `402`
+  mid-stream looks like over SSE) and holding this change for it keeps 358 users at a wall.
+- **Hardening `boot()`'s failure handling.** Its conflation of "the list was refused" with
+  "the list was empty" is the bug that turned one `403` into three, but with the refusal
+  gone the conflation has no trigger left in this code path. Fixing it here would be
+  speculative work against a hypothetical future gate; leaving it costs nothing today.
+  Noted as a seam, not built.
+- **The `beta_tester` flag.** It stays on the model and on `/auth/me`. This change retires
+  one consumer, not the mechanism.
+- **The `cv-builder` spec's own rollout requirement.** It asserts a restriction that
+  `/api/v1/me/cvs` does not implement — a pre-existing drift, out of this change's scope.
+
+## Decisions
+
+**Delete the gate rather than make it configurable.** An env-var or feature flag would
+preserve the ability to re-close the assistant cheaply. Rejected: a flag is an undecided
+policy stored in two places, and the failure mode we just lived through was precisely a
+policy half-applied across layers. Re-closing it later is a revert of a small diff.
+
+**Delete the UI mirror rather than repair it.** The alternative was to keep `requireBeta`,
+default it to `true`, and align its condition with the backend's (`moderator || beta_tester`
+— the current mirror checks only `beta_tester`, so it would have blocked a plain moderator
+the API admits). Rejected because it solves the wrong problem: with the gate gone there is
+nothing to mirror, and a prop that must be remembered by every host is the defect that
+produced this incident. Removing it also removes the `{:else if !allowed}` notice, which has
+no reachable state left.
+
+**Keep `mw.key` untouched.** The routes stay authenticated by cookie, session JWT, or
+full-scope API key. The spec's carrier requirement is edited only to stop deferring to a
+rollout gate that no longer exists; its unauthenticated-caller scenario is unchanged, and
+the scenario asserting a Bearer caller outside the rollout is refused is removed with the
+requirement it referenced.
+
+**Rewrite the rollout tests in place rather than delete them.** The case asserting a
+non-member is refused inverts to assert they are served — that is the change's contract, and
+it deserves a test that fails if the gate returns. The Bearer-carrier tests keep asserting
+that widening the carrier does not widen authentication.
+
+## Risks / Trade-offs
+
+**Unmetered spend on 358 accounts.** → The real risk of this change, accepted knowingly. The
+assistant is a bounded tool-calling loop, so a single turn is bounded, but the number of
+turns is not. Mitigation is the follow-up metering task; until it lands, spend is watched
+rather than capped, and re-closing the gate is a one-line revert.
+
+**Load on the LLM proxy.** The in-process agent shares the litellm proxy with `enrich`,
+whose 502s have historically traced to that proxy restarting or filling its disk. A jump in
+assistant traffic lands on the same dependency. → Watch proxy error rate after deploy; the
+revert path is the same one-liner.
+
+**The spec's account-nav requirement mentions "beta/moderator gating".** It describes the
+rail as listing the same items with the same gating as the sidebar — a statement about
+sharing one visibility model, not about the assistant specifically. Left alone deliberately:
+it stays true whether or not any item is gated.
+
+## Migration Plan
+
+Ordinary deploy, no migration, no data change. Backend and frontend land together; if they
+land apart, either order is safe — an open API with a mirroring client just gates the UI for
+non-members (today's behaviour), and an open client against a gated API is today's behaviour
+exactly.
+
+Rollback: revert the commit. The gate returns, and the only state created meanwhile is
+assistant sessions belonging to newly-admitted users, which remain theirs and reappear
+whenever the gate opens again.
+
+## Open Questions
+
+- Does opening the assistant change what the follow-up metering should charge for — a turn,
+  a tool call, or tokens? Not blocking, but the answer is cheaper to find while usage from a
+  wider audience is being observed.

--- a/openspec/changes/open-assistant-to-all-users/proposal.md
+++ b/openspec/changes/open-assistant-to-all-users/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+The assistant refuses 358 of the 360 accounts on production, but the product no longer
+behaves as if it were restricted: the account nav links "Agent" for everyone, and the
+tailoring workspace mounts the same chat with its UI gate explicitly switched off. What a
+non-member actually meets is not a closed door but a wall of `403`s — opening
+`/my/assistant` fires three refused requests in one page load, because the client reads the
+refusal of the session list as "you have no chats yet" and answers it by trying to create
+one.
+
+The gate's stated reason has also expired. `requireRollout` was written when inference was
+billed to us and the assistant was free; the nav comment beside it still claims the agent
+"runs on the user's own machine with their own Claude subscription", which stopped being
+true when #1165 moved the agent in-process. The gate now protects a decision nobody has
+re-made, and half the product already routes around it.
+
+## What Changes
+
+- **BREAKING** (for the spec, not for any caller): every `/api/v1/assistant/*` route drops
+  `requireRollout`. Authentication is unchanged — `mw.key` still resolves a cookie, a
+  session JWT, or a full-scope API key, and an unauthenticated caller is still refused.
+  What disappears is the second check that turned a signed-in non-member into a `403`.
+- The UI stops mirroring a gate that no longer exists: the `requireBeta` prop and the
+  `allowed` derivation come out of `AssistantChat.svelte`, along with the restricted-rollout
+  notice they guarded, and `/tailor` stops passing `requireBeta={false}` to switch off a
+  gate that is gone.
+- The stale justification in `accountNav.ts` is replaced with what is actually true: the
+  agent runs in our backend, and the spend it incurs is ours.
+- The rollout tests in `assistant_integration_test.go` are rewritten: the case that asserted
+  a non-member is refused now asserts they are served, and the Bearer-carrier case keeps
+  asserting that widening the carrier does not widen *authentication*.
+
+Deliberately unchanged: the `beta_tester` flag itself. It stays on the user model and on
+`/auth/me` — this change retires one consumer of it, not the mechanism.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `assistant-sessions`: the requirement "The assistant is gated to the beta-tester group" is
+  removed, and the session-carrier requirement stops deferring to a rollout gate — its
+  scenario asserting that a Bearer caller outside the rollout is refused goes with it.
+
+## Impact
+
+- `internal/handler/assistant.go` — `requireRollout` and its wiring in `register`.
+- `internal/handler/assistant_integration_test.go` — the rollout cases.
+- `internal/handler/AGENTS.md`, root `AGENTS.md` — both describe the assistant as gated.
+- `web/src/lib/assistant/AssistantChat.svelte`, `web/src/routes/tailor/[slug]/+page.svelte`,
+  `web/src/lib/accountNav.ts`.
+- No migration, no API-shape change, no client contract change. A caller that used to get
+  `403` now gets the same body every member already got.
+
+**Out of scope, and load-bearing:** the assistant charges no AI credits. Metering lives in
+`cv_tailor.go`, `cv.go`, `match_analysis_stream.go`, `contributions.go` and `intake.go`, but
+`internal/assistant/` has no notion of credits at all — the rollout gate was the only thing
+bounding that spend. Opening the assistant hands an unmetered tool-calling loop to every
+signed-in user; metering it is a required follow-up, tracked separately, and this proposal
+is written on the explicit understanding that the follow-up is owed.

--- a/openspec/changes/open-assistant-to-all-users/specs/assistant-sessions/spec.md
+++ b/openspec/changes/open-assistant-to-all-users/specs/assistant-sessions/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: The assistant is open to every signed-in user
+
+Every assistant route SHALL serve any caller it can authenticate, and SHALL apply no
+membership test beyond authentication. A signed-in user SHALL reach the assistant whatever
+their `role` and whatever the state of their `beta_tester` flag; an unauthenticated caller
+SHALL still be refused, and owner scoping SHALL still confine each caller to their own
+conversations. The `/my/assistant` page and its account-nav entry SHALL be shown to every
+signed-in user.
+
+The `beta_tester` flag SHALL remain on the user account and SHALL remain exposed on the
+authenticated user's profile (`/auth/me`), independent of `role`. The assistant simply
+stops reading it — the flag outlives this consumer.
+
+#### Scenario: A user with no special standing opens the assistant
+
+- **WHEN** a signed-in user who is neither a moderator nor a beta tester requests the session list, creates a session, reads a transcript, or sends a turn
+- **THEN** the request is served exactly as it would be for a beta tester
+
+#### Scenario: The nav entry is shown to everyone signed in
+
+- **WHEN** any signed-in user loads the account area
+- **THEN** the "Agent" nav entry is present and `/my/assistant` renders the chat rather than a restricted-rollout notice
+
+#### Scenario: Authentication is still required
+
+- **WHEN** an assistant route is called with neither a cookie nor a Bearer credential
+- **THEN** the request is refused and no session is created, read or advanced
+
+## MODIFIED Requirements
+
+### Requirement: The session API accepts a Bearer credential as well as the cookie
+
+Every assistant session operation SHALL authenticate either the browser's session
+cookie or an `Authorization: Bearer` credential — a session JWT or a full-scope
+API key — resolving both to the same freehire user. A browser extension cannot
+send hire's httpOnly cookie across origins, and holding a conversation from the
+extension's side panel is why this widens.
+
+Widening the carrier SHALL change nothing else: the owner scoping and the "a session you do
+not own is missing, not forbidden" rule apply identically however the caller authenticated.
+
+#### Scenario: A Bearer session JWT holds a conversation
+
+- **WHEN** the session list, a transcript read, or a turn is requested with a valid session JWT as `Authorization: Bearer` and no cookie
+- **THEN** the request is served as that user, subject to the same owner scoping as a cookie request
+
+#### Scenario: An unauthenticated request is still refused
+
+- **WHEN** an assistant route is called with neither a cookie nor a Bearer credential
+- **THEN** the request is rejected and no session is created, read or advanced
+
+## REMOVED Requirements
+
+### Requirement: The assistant is gated to the beta-tester group
+
+**Reason**: The gate was written when the assistant was free to us and cost the user their
+own Claude subscription; #1165 moved the agent in-process, and the justification did not
+survive the move. Meanwhile the product had already routed around it — the account nav
+linked "Agent" for everyone and the tailoring workspace mounted the chat with its UI gate
+switched off — so the only thing the gate still produced was a wall of `403`s for 358 of
+360 accounts. The decision it encoded is hereby re-made rather than left to erode.
+
+**Migration**: None for any caller. A signed-in user who previously received `403` now
+receives the same response a beta tester received; no request that used to succeed changes
+shape, and no stored session is affected. The `beta_tester` flag is not dropped — it stays
+on the user model and on `/auth/me`, and granting or revoking it simply no longer affects
+assistant access.
+
+**Note**: this removes the gate, not the reason it was affordable. The assistant charges no
+AI credits, so the spend it incurs was bounded by this gate alone. Metering assistant turns
+is an owed follow-up, tracked outside this change.

--- a/openspec/changes/open-assistant-to-all-users/tasks.md
+++ b/openspec/changes/open-assistant-to-all-users/tasks.md
@@ -1,0 +1,25 @@
+## 1. Backend — open the routes
+
+- [x] 1.1 Invert the rollout cases in `internal/handler/assistant_integration_test.go`: the test asserting a signed-in non-member gets `403` now asserts the request is served, and the Bearer case asserting a caller outside the rollout is refused becomes a case asserting they are served over Bearer too. Run them and watch them fail (RED).
+- [x] 1.2 Drop `requireRollout` and its `gate` wiring from `register` in `internal/handler/assistant.go`, leaving `mw.key` on every route. Tests from 1.1 go green.
+- [x] 1.3 Confirm the unauthenticated-caller test still passes unchanged — authentication must not have loosened with the gate.
+- [x] 1.4 Rewrite the route comment in `assistant.go` that explains the restricted rollout, and check no other Go file references `requireRollout`.
+
+## 2. Frontend — remove the dead mirror
+
+- [x] 2.1 Remove the `requireBeta` prop, its type entry, the `allowed` derivation and the `{:else if !allowed}` restricted-rollout branch from `web/src/lib/assistant/AssistantChat.svelte`; drop the now-unused `currentUser` import if nothing else uses it, and unguard the `onMount` boot.
+- [x] 2.2 Remove `requireBeta={false}` from `web/src/routes/tailor/[slug]/+page.svelte`.
+- [x] 2.3 Replace the stale justification comment above the `/my/assistant` entry in `web/src/lib/accountNav.ts` — the agent runs in our backend, not on the user's machine.
+- [x] 2.4 Run the web unit tests and `eslint`; both must be green (the repo gates CI on eslint).
+
+## 3. Documentation
+
+- [x] 3.1 Update the assistant line in the root `AGENTS.md` conventions list — it describes the assistant as gated to the restricted rollout.
+- [x] 3.2 Update `internal/handler/AGENTS.md`, which documents `requireRollout` as part of the assistant's middleware chain.
+
+## 4. Verify and finish
+
+- [x] 4.1 `go build ./... && go vet ./... && go test ./...` green; run the assistant integration tests under their build tag.
+- [x] 4.2 Invoke the `simplify` skill over the whole diff; tests stay green after it.
+- [x] 4.3 Request code review on the full diff, act on Critical and Important findings.
+- [ ] 4.4 Open the follow-up for AI-credit metering of assistant turns, so the debt this change takes on is recorded somewhere other than the design doc.

--- a/openspec/changes/open-assistant-to-all-users/tasks.md
+++ b/openspec/changes/open-assistant-to-all-users/tasks.md
@@ -22,4 +22,4 @@
 - [x] 4.1 `go build ./... && go vet ./... && go test ./...` green; run the assistant integration tests under their build tag.
 - [x] 4.2 Invoke the `simplify` skill over the whole diff; tests stay green after it.
 - [x] 4.3 Request code review on the full diff, act on Critical and Important findings.
-- [ ] 4.4 Open the follow-up for AI-credit metering of assistant turns, so the debt this change takes on is recorded somewhere other than the design doc.
+- [x] 4.4 Open the follow-up for AI-credit metering of assistant turns, so the debt this change takes on is recorded somewhere other than the design doc.

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -15,8 +15,8 @@ export const accountNav = [
   // Mail inbox: connect Gmail and/or claim a freehire mailbox to track application
   // replies. Open to every signed-in user.
   { href: '/my/inbox', label: 'Inbox' },
-  // Out of restricted rollout: the assistant now runs on the user's own machine
-  // with their own Claude subscription, so it costs us nothing to open up.
+  // The agent: open to every signed-in user. It runs in our backend, and unlike the CV
+  // builder below, nothing meters its spend yet.
   { href: '/my/assistant', label: 'Agent' },
   // CV builder + AI tailoring: open to every signed-in user (credits meter the AI spend).
   { href: '/my/cvs', label: 'CV builder' },

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -2,7 +2,6 @@
   import { onMount, tick, untrack } from 'svelte';
   import { AlertTriangle, PanelLeft, Plus, Trash2 } from '@lucide/svelte';
   import { resolve } from '$app/paths';
-  import { currentUser } from '$lib/auth.svelte';
   import {
     createSession,
     listSessions,
@@ -47,7 +46,6 @@
   //    into a navigation so each chat has its own URL and Back works; the tailor host,
   //    whose chat is bound to one CV, passes nothing.
   //  - showSessionRail: whether to render the session sidebar (off on the focused /tailor surface).
-  //  - requireBeta: kept so an embedder can gate the chat in the UI as well as at the API.
   let {
     session = undefined,
     kickoff = undefined,
@@ -58,7 +56,6 @@
     beforeTurn = undefined,
     onSessionChange = undefined,
     showSessionRail = true,
-    requireBeta = false,
     preset = 'chat',
     openingActions = undefined,
   }: {
@@ -79,7 +76,6 @@
     beforeTurn?: () => Promise<void>;
     onSessionChange?: (id: string) => void;
     showSessionRail?: boolean;
-    requireBeta?: boolean;
     /** What an empty conversation offers instead of a blank prompt. Shown only while the
      *  session has no messages: once it has any, the composer is the way in. A host that
      *  passes these should NOT also pass a kickoff — the whole point is that the first turn
@@ -89,10 +85,6 @@
      *  whatever preset it was created with. */
     preset?: ChatPreset;
   } = $props();
-
-  // The API gates the assistant to the restricted rollout; this mirrors it in the
-  // UI so a non-member sees an explanation instead of a wall of 403s.
-  const allowed = $derived(!requireBeta || (currentUser()?.beta_tester ?? false));
 
   let phase = $state<Phase>('loading');
   let error = $state<string | null>(null);
@@ -531,7 +523,6 @@
   }
 
   onMount(() => {
-    if (!allowed) return;
     void boot();
     return cancelTurn;
   });
@@ -561,10 +552,6 @@
     >
       Open your chats
     </a>
-  </div>
-{:else if !allowed}
-  <div class="m-3 rounded-xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
-    The agent is a limited beta and isn't available for your account yet.
   </div>
 {:else}
   <div class="flex min-h-0 flex-1">

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -32,9 +32,10 @@
     if (browser) localStorage.setItem('hire.myNavCollapsed', collapsed ? '1' : '0');
   }
 
-  // Moderator-only sections (Inbox) and beta-only sections (Agent) are hidden
-  // from the nav for everyone else; the relevant server surfaces enforce the
-  // real gate, this just declutters the UI.
+  // Sections marked moderator- or beta-only are hidden from the nav for everyone
+  // else; the relevant server surfaces enforce the real gate, this just declutters
+  // the UI. No section carries such a mark today — the Agent lost its beta gate and
+  // is open to every signed-in user.
   const navItems = $derived(
     visibleAccountNav(currentUser()?.role === 'moderator', currentUser()?.beta_tester ?? false),
   );

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -405,7 +405,6 @@
               openingActions={opening}
               {sessionLabel}
               showSessionRail={false}
-              requireBeta={false}
               {onTurnComplete}
               onRunStateChange={(running) => (runActive = running)}
               onTurnStateChange={(active) => (turnActive = active)}


### PR DESCRIPTION
## Why

`requireRollout` refused anyone who was neither a moderator nor a beta tester — on production that is **358 of 360 accounts**. But the product had already stopped acting restricted:

- `accountNav.ts` links "Agent" for everyone
- `/tailor` mounted the same chat with `requireBeta={false}`
- `AssistantChat.svelte`'s `requireBeta` prop defaulted to `false`, so no host ever turned the UI mirror on

What a non-member actually met was a **wall of 403s**. Opening `/my/assistant` fires three refused requests in one page load: `boot()` catches the refused session list, carries on with an empty array, and the emptiness is then read as "this user has no chats" — which the next branch answers by `POST`ing a new session, earning a second refusal.

The gate's stated reason had expired. It was written when inference was the user's to pay for; the comment beside it still claimed the agent "runs on the user's own machine with their own Claude subscription", which stopped being true when #1165 moved the agent in-process.

## What changed

- `requireRollout` is gone. Every `/api/v1/assistant/*` route keeps `mw.key` — cookie, session JWT, or full-scope API key — and nothing else.
- The dead UI mirror comes out: the `requireBeta` prop, the `allowed` derivation, the restricted-rollout notice, and `/tailor`'s `requireBeta={false}`.
- Stale comments corrected in `accountNav.ts` and `my/+layout.svelte` (the latter claimed the Agent entry was hidden from non-beta users; it never was).
- Docs updated: root `AGENTS.md`, `internal/handler/AGENTS.md`, `internal/assistant/AGENTS.md`.
- OpenSpec change `open-assistant-to-all-users` with the delta against `assistant-sessions`.

`beta_tester` stays on the user model and on `/auth/me` — this retires one consumer, not the mechanism.

## Tests

The two rollout tests are inverted rather than deleted — the contract deserves a test that fails if the gate comes back:

- `TestAssistantServesAUserInNoGroup` — a user in no group is served (201), **and** a caller with no credential is still refused (401). Both halves, because "open to everyone" is one edit away from "open to anyone".
- `TestAssistantServesABearerCallerInNoGroup` — same over Bearer.

Watched both fail (403, want 201) before removing the gate.

Green: `go build`, `go vet`, `go test ./...`, `gofmt`, `go test -tags=integration ./internal/handler/`, web `vitest` 447/447, `eslint` (0 errors), `pnpm build`.

## ⚠️ The debt this takes on

**Nothing meters an assistant turn.** Credits are charged in `cv_tailor.go`, `cv.go`, `match_analysis_stream.go`, `contributions.go` and `intake.go` — `internal/assistant` has no notion of them. The rollout gate was the only thing bounding that spend, and it is now gone.

Credit metering is an owed follow-up, filed separately. Until it lands, spend is watched rather than capped; re-closing the gate is a revert of this commit.

## Noted, not fixed

- `visibleAccountNav()` filters on `betaOnly` / `moderatorOnly` / `moderatorOrBeta`, but **no nav item carries any of those flags** — the whole mechanism is dead. Pre-existing, left alone.
- `boot()` still conflates "the list was refused" with "the list was empty". That conflation is what turned one 403 into three; with the refusal gone it has no trigger left in this path, so it is noted as a seam rather than built against a hypothetical future gate.