### PR TITLE
feat(tailor): hand the agent the bank's answer instead of ten searches

### DIFF
--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -73,11 +73,14 @@ const tailorPrompt = `You are the freehire CV-tailoring assistant. You are worki
 
 Start by calling ` + "`cv_context`" + ` (the fit analysis for this vacancy) and ` + "`cv_get`" + ` (what the CV currently says).
 
-Then, for EVERY requirement you intend to address — ` + "`missing_have`" + ` and ` + "`missing_gap`" + ` alike — search before you ask:
+` + "`cv_context`" + ` already carries the bank's answer: every requirement it reports comes with the ` + "`evidence`" + ` found for it — the achievement's id, its claim, and whether it may be written into a CV. Read that first. Do NOT re-search a requirement whose evidence is already in front of you; ` + "`experience_search`" + ` is for going deeper on one point, not for finding out whether the bank holds anything.
 
-1. ` + "`experience_search`" + ` the requirement. The split between have and gap describes what the CV surfaces, not what the candidate has: the bank often holds evidence for a "gap" because they told us in an earlier session.
-2. Evidence found → reframe it into a bullet in the vacancy's language with ` + "`cv_edit`" + `, passing that achievement's id as ` + "`evidence_id`" + `. Stay inside what the evidence says.
-3. Nothing found → ASK them ("Do you know X? Where did you use it?"). If they confirm real experience, record it with ` + "`experience_add`" + ` FIRST — putting their own words in ` + "`said`" + ` — and then write the bullet citing the id it returns. If they say no, leave it out; a gap belongs in a cover letter, never keyword-stuffed into a CV.
+Then work the list ONE REQUIREMENT AT A TIME, editing as you go rather than researching everything first:
+
+1. Evidence present → reframe it into a bullet in the vacancy's language with ` + "`cv_edit`" + ` NOW, passing that achievement's id as ` + "`evidence_id`" + `. Stay inside what the evidence says. Do not queue edits for later; a turn that spends its rounds reading ends without having changed the CV.
+2. ` + "`evidence`" + ` empty → the bank holds nothing on that point. ASK them ("Do you know X? Where did you use it?"). If they confirm real experience, record it with ` + "`experience_add`" + ` FIRST — putting their own words in ` + "`said`" + ` — and then write the bullet citing the id it returns. If they say no, leave it out; a gap belongs in a cover letter, never keyword-stuffed into a CV.
+
+The split between ` + "`missing_have`" + ` and ` + "`missing_gap`" + ` describes what the CV surfaces, not what the candidate has: a "gap" often carries evidence, because they told us in an earlier session.
 
 Recording what they tell you is not bookkeeping. This CV is a copy made for one vacancy and will be thrown away; what they confirmed while making it is theirs for good, and the next vacancy will not have to ask again.
 
@@ -91,6 +94,7 @@ Mechanics:
 - Contact details cannot be edited here — do not try.
 - Keep the CV to one or two pages. Prefer sharpening existing bullets over adding new ones.
 - Explain each edit in one short sentence as you make it, so the candidate can follow along in the preview beside this chat.
+- Do NOT restate the fit analysis. The verdict, the score and the dimension comments are open in a panel beside this chat; repeating them spends the turn on something the candidate is already looking at. Open with what you are about to do, not with what you read.
 - If the conversation turns to other vacancies, show them ONLY by calling ` + "`present_jobs`" + ` — never write a vacancy's link into your text. Tailoring this CV stays the job; do not go looking for vacancies unasked.
 
 UNATTENDED RUNS

--- a/internal/assistant/prompt_test.go
+++ b/internal/assistant/prompt_test.go
@@ -120,3 +120,22 @@ func TestTailorPromptDescribesTheUnattendedRun(t *testing.T) {
 		t.Error("the prompt must ask for ONE closing question; a numbered list of gaps gets one answer")
 	}
 }
+
+// Two recorded sessions opened with a long restatement of the fit analysis the candidate had
+// open beside the chat, then spent every remaining round searching the bank one requirement at
+// a time — and edited nothing. The prompt now says where the evidence already is, and to spend
+// rounds on edits rather than on a summary.
+func TestTailorPromptSpendsRoundsOnEditsNotSummaries(t *testing.T) {
+	p := SystemPrompt(PresetTailor)
+
+	if !strings.Contains(p, "cv_context") || !strings.Contains(p, "evidence") {
+		t.Error("the prompt must point the agent at the evidence cv_context already carries")
+	}
+	lower := strings.ToLower(p)
+	if !strings.Contains(lower, "do not restate") && !strings.Contains(lower, "not repeat") {
+		t.Error("the prompt must forbid restating the fit analysis — the candidate has it open beside the chat")
+	}
+	if !strings.Contains(lower, "as you go") && !strings.Contains(lower, "one requirement at a time") {
+		t.Error("the prompt must ask for edits as each requirement is closed, not after all the research")
+	}
+}

--- a/internal/handler/assistant_cv_context_test.go
+++ b/internal/handler/assistant_cv_context_test.go
@@ -1,0 +1,226 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/experience"
+)
+
+// analysisCache serves one cached fit analysis, so cv_context can be exercised without a
+// database behind it.
+type analysisCache struct{ analysis string }
+
+func (c analysisCache) GetUserJobAnalysis(context.Context, db.GetUserJobAnalysisParams) (db.GetUserJobAnalysisRow, error) {
+	return db.GetUserJobAnalysisRow{Analysis: []byte(c.analysis)}, nil
+}
+func (c analysisCache) UpsertUserJobAnalysis(context.Context, db.UpsertUserJobAnalysisParams) error {
+	return nil
+}
+func (c analysisCache) ListUserJobAnalyses(context.Context, int64) ([]db.ListUserJobAnalysesRow, error) {
+	return nil, nil
+}
+
+// bankStub answers retrieval from a fixed atom list, recording the queries it was asked.
+type bankStub struct {
+	atoms   []experience.Atom
+	queries []experience.Query
+}
+
+func (b *bankStub) Retrieve(_ context.Context, _ int64, q experience.Query, limit int) ([]experience.Match, error) {
+	b.queries = append(b.queries, q)
+	var out []experience.Match
+	for _, a := range b.atoms {
+		// The stub stands in for scoring, not for it: an atom matches when the query text
+		// names one of its skills, which is enough to tell "found" from "not found" apart.
+		for _, s := range a.Skills {
+			if strings.Contains(strings.ToLower(q.Text), s) {
+				out = append(out, experience.Match{Atom: a, Score: 10})
+				break
+			}
+		}
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (b *bankStub) ListEmployments(context.Context, int64) ([]experience.Employment, error) {
+	return nil, nil
+}
+func (b *bankStub) ListAtoms(context.Context, int64) ([]experience.Atom, error) { return b.atoms, nil }
+func (b *bankStub) GetAtom(context.Context, uuid.UUID, int64) (experience.Atom, error) {
+	return experience.Atom{}, experience.ErrNotFound
+}
+func (b *bankStub) AddAtom(_ context.Context, _ int64, a experience.Atom) (experience.Atom, error) {
+	return a, nil
+}
+func (b *bankStub) UpdateAtom(_ context.Context, _ uuid.UUID, _ int64, a experience.Atom) (experience.Atom, error) {
+	return a, nil
+}
+
+const twoRequirementAnalysis = `{
+	"requirement_match": [
+		{"text":"Kafka in production","priority":"required","status":"missing-have"},
+		{"text":"Team leadership","priority":"preferred","status":"missing-gap"}
+	],
+	"verdict":"strong fit","overall_score":81
+}`
+
+// contextToolAPI wires cv_context over a stubbed analysis cache, bank and job row.
+func contextToolAPI(t *testing.T, description string, atoms []experience.Atom) (*assistantHandlers, *bankStub) {
+	t.Helper()
+	bank := &bankStub{atoms: atoms}
+	h := &assistantHandlers{
+		cv: &cvHandlers{
+			matchAnalysisCache: analysisCache{analysis: twoRequirementAnalysis},
+			jobReader:          jobStub{job: db.Job{Title: "Senior Backend Engineer", Company: "Acme", PublicSlug: "senior-backend-acme", Description: description}},
+		},
+		experience: bank,
+	}
+	return h, bank
+}
+
+// jobStub serves the one vacancy the tailoring context is about.
+type jobStub struct{ job db.Job }
+
+func (s jobStub) GetJob(context.Context, int64) (db.Job, error) { return s.job, nil }
+
+const htmlDescription = `<div><p>We need <strong>Kafka</strong> in production.</p><ul><li>Lead a team</li></ul></div>`
+
+// The posting is the largest and least trusted text in the turn. It reaches the model as
+// words, not markup — the same treatment get_job already gives it.
+func TestCVContextRendersTheDescriptionWithoutMarkup(t *testing.T) {
+	a, _ := contextToolAPI(t, htmlDescription, nil)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_context")
+	out, err := tool.Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("cv_context: %v", err)
+	}
+	payload, _ := json.Marshal(out)
+	if strings.Contains(string(payload), "<p>") || strings.Contains(string(payload), "<ul>") {
+		t.Errorf("description reached the model as markup:\n%s", payload)
+	}
+	if !strings.Contains(string(payload), "Kafka") {
+		t.Errorf("description lost its words:\n%s", payload)
+	}
+}
+
+func TestCVContextBoundsALongDescription(t *testing.T) {
+	long := "<p>" + strings.Repeat("word ", 20000) + "</p>"
+	a, _ := contextToolAPI(t, long, nil)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_context")
+	out, err := tool.Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("cv_context: %v", err)
+	}
+	payload, _ := json.Marshal(out)
+	if len(payload) > 2*tailorDescriptionLimit {
+		t.Errorf("context is %d bytes for a %d-byte bound; the opening round is the most expensive one in the turn", len(payload), tailorDescriptionLimit)
+	}
+}
+
+// The retrieval that answers "can I evidence this requirement?" is a local scan over the
+// candidate's own atoms. Making the agent ask for it one requirement at a time is what spent
+// ten tool rounds and left no room to edit.
+func TestCVContextCarriesTheBanksAnswerPerRequirement(t *testing.T) {
+	atomID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	a, bank := contextToolAPI(t, htmlDescription, []experience.Atom{{
+		ID:         atomID,
+		Claim:      "Ran the payments Kafka cluster through a 10x traffic year.",
+		Skills:     []string{"kafka"},
+		Provenance: experience.ProvenanceStatedInChat,
+	}})
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_context")
+	out, err := tool.Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("cv_context: %v", err)
+	}
+	payload, _ := json.Marshal(out)
+
+	// The evidenced requirement arrives with the id a cv_edit must cite.
+	if !strings.Contains(string(payload), atomID.String()) {
+		t.Errorf("the Kafka requirement carries no evidence id:\n%s", payload)
+	}
+	// "Looked and found nothing" must be distinguishable from "did not look".
+	var decoded struct {
+		MissingHave []struct {
+			Text     string            `json:"text"`
+			Evidence []json.RawMessage `json:"evidence"`
+		} `json:"missing_have"`
+		MissingGap []struct {
+			Text     string            `json:"text"`
+			Evidence []json.RawMessage `json:"evidence"`
+		} `json:"missing_gap"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("context is not decodable: %v\n%s", err, payload)
+	}
+	if len(decoded.MissingHave) != 1 || len(decoded.MissingHave[0].Evidence) != 1 {
+		t.Errorf("missing_have = %+v, want the Kafka requirement with one piece of evidence", decoded.MissingHave)
+	}
+	if len(decoded.MissingGap) != 1 || decoded.MissingGap[0].Evidence == nil {
+		t.Errorf("missing_gap = %+v, want an EMPTY evidence list rather than an absent one", decoded.MissingGap)
+	}
+	if len(bank.queries) != 2 {
+		t.Errorf("retrieval ran %d times, want once per reported requirement", len(bank.queries))
+	}
+}
+
+// A bank that cannot be read is not a reason to withhold the vacancy's requirements.
+func TestCVContextSurvivesAnUnavailableBank(t *testing.T) {
+	a, _ := contextToolAPI(t, htmlDescription, nil)
+	a.experience = nil
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_context")
+	out, err := tool.Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("cv_context with no bank: %v", err)
+	}
+	if !strings.Contains(string(mustJSON(t, out)), "Kafka in production") {
+		t.Error("the requirements went missing when the bank did")
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// The agent's context is narrower than the endpoint's on purpose: dimension comments,
+// strengths, gaps and the recommendation were 3 KB of a measured 11.4 KB result, and none of
+// them is something a CV edit can be made from. The candidate reads them in the panel.
+func TestCVContextLeavesTheNarrativeToThePanel(t *testing.T) {
+	a, _ := contextToolAPI(t, htmlDescription, nil)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_context")
+	out, err := tool.Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("cv_context: %v", err)
+	}
+	payload := string(mustJSON(t, out))
+	for _, unwanted := range []string{`"dimensions"`, `"strengths"`, `"gaps"`, `"recommendation"`} {
+		if strings.Contains(payload, unwanted) {
+			t.Errorf("the agent's context still carries %s — it cannot edit a CV from it and must not restate it:\n%s", unwanted, payload)
+		}
+	}
+	// What it does work from stays.
+	for _, wanted := range []string{`"missing_have"`, `"missing_gap"`, `"job"`, `"verdict"`} {
+		if !strings.Contains(payload, wanted) {
+			t.Errorf("the agent's context lost %s:\n%s", wanted, payload)
+		}
+	}
+}

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"strings"
 
 	"github.com/google/uuid"
@@ -11,6 +12,7 @@ import (
 	"github.com/strelov1/freehire/internal/assistant"
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/experience"
+	"github.com/strelov1/freehire/internal/matchanalysis"
 )
 
 // assistantCVTools are the tools a CV-tailoring session gets on top of the shared
@@ -106,17 +108,94 @@ func (h *assistantHandlers) cvContextTool(jobID int64) assistant.Tool {
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
-			analysis, err := h.cv.cachedAnalysisCtx(ctx, userID, jobID)
+			base, err := h.cv.tailoringContext(ctx, userID, jobID)
 			if err != nil {
 				return nil, err
 			}
-			job, err := h.queries.GetJob(ctx, jobID)
-			if err != nil {
-				return nil, err
-			}
-			return tailorContext(analysis, job), nil
+			return h.withBankEvidence(ctx, userID, base), nil
 		},
 	}
+}
+
+// evidencedRequirement is a requirement plus what the candidate's own bank already holds for
+// it. The evidence is named, not inlined whole: the agent needs enough to decide "I can write
+// this" and the id to cite, and a tool result is replayed into its context on every later turn.
+type evidencedRequirement struct {
+	matchanalysis.Requirement
+	Evidence []requirementEvidence `json:"evidence"`
+}
+
+type requirementEvidence struct {
+	ID         string `json:"id"`
+	Claim      string `json:"claim"`
+	CanWriteCV bool   `json:"can_write_cv"`
+}
+
+// agentTailorContext is the tailoring context as the AGENT reads it — deliberately narrower
+// than what the endpoint serves the page.
+//
+// Measured on a recorded session, the served context was 11.4 KB: 4.2 KB of posting, 2.5 KB of
+// requirements, and 3 KB of dimension comments, strengths, gaps and recommendation. That last
+// 3 KB is the part the agent must NOT act on — it cannot edit a CV from a dimension comment,
+// and restating the verdict is exactly what it is told not to do. It is on the candidate's
+// screen already, in the panel beside the chat.
+//
+// So the agent gets what it works from: the vacancy, the score in one line for tone, and the
+// requirements with the bank's answer attached.
+type agentTailorContext struct {
+	Job          tailorJob              `json:"job"`
+	Verdict      string                 `json:"verdict"`
+	OverallScore int                    `json:"overall_score"`
+	MissingHave  []evidencedRequirement `json:"missing_have"`
+	MissingGap   []evidencedRequirement `json:"missing_gap"`
+}
+
+// evidencePerRequirement bounds what one requirement may carry. Three is enough to write a
+// bullet from and to see that the bank is not empty; the rest is one experience_search away.
+const evidencePerRequirement = 3
+
+// withBankEvidence answers, for every requirement, the question the agent would otherwise
+// spend a tool round on: does the bank hold anything for this?
+//
+// Retrieval is a linear scan over the caller's own atoms with no model call in it, so asking it
+// once per requirement here costs less than the single round it replaces. A recorded session
+// made TEN searches and never reached an edit; this is what those searches were asking for.
+//
+// A bank that cannot be read degrades to no evidence rather than to an error: the requirements
+// are worth reading either way, and an empty list already means "nothing found".
+func (h *assistantHandlers) withBankEvidence(ctx context.Context, userID int64, base tailorContextResponse) agentTailorContext {
+	return agentTailorContext{
+		Job:          base.Job,
+		Verdict:      base.Verdict,
+		OverallScore: base.OverallScore,
+		MissingHave:  h.evidenceFor(ctx, userID, base.MissingHave),
+		MissingGap:   h.evidenceFor(ctx, userID, base.MissingGap),
+	}
+}
+
+func (h *assistantHandlers) evidenceFor(ctx context.Context, userID int64, reqs []matchanalysis.Requirement) []evidencedRequirement {
+	out := make([]evidencedRequirement, 0, len(reqs))
+	for _, r := range reqs {
+		// Always a list, never nil: "looked and found nothing" is the answer that decides
+		// whether to ask the candidate, and an absent field reads as "did not look".
+		found := []requirementEvidence{}
+		if h.experience != nil {
+			matches, err := h.experience.Retrieve(ctx, userID,
+				experience.Query{Text: r.Text}, evidencePerRequirement)
+			if err != nil {
+				log.Printf("assistant: bank retrieval for %q: %v", r.Text, err)
+			}
+			for _, m := range matches {
+				found = append(found, requirementEvidence{
+					ID:         m.Atom.ID.String(),
+					Claim:      m.Atom.Claim,
+					CanWriteCV: m.Atom.Provenance.Publishable(),
+				})
+			}
+		}
+		out = append(out, evidencedRequirement{Requirement: r, Evidence: found})
+	}
+	return out
 }
 
 // cvGetTool reads the tailored CV document the session is editing, minus the contact

--- a/internal/handler/assistant_experience_tools.go
+++ b/internal/handler/assistant_experience_tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
@@ -166,7 +167,7 @@ func (h *assistantHandlers) experienceAddTool(sessionID uuid.UUID) assistant.Too
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
-			employmentID, err := optionalUUID(in.EmploymentID)
+			employmentID, err := h.resolveEmployment(ctx, userID, in.EmploymentID)
 			if err != nil {
 				return nil, err
 			}
@@ -300,6 +301,41 @@ func optionalUUID(raw string) (*uuid.UUID, error) {
 		return nil, errors.New("employment_id must be an id from experience_employments")
 	}
 	return &id, nil
+}
+
+// resolveEmployment parses the role an achievement attaches to, and — when the value is not
+// an id — refuses with the ids that WOULD have worked.
+//
+// The list is the whole point. A model that guesses ("the ringcentral one") used to be told
+// only that it was wrong, spend a round on experience_employments, and retry: one of the eight
+// rounds a turn has, burned on a lookup the refusal could have carried. The candidate's roles
+// are a handful of rows, already owner-scoped, and they are what the retry needs.
+func (h *assistantHandlers) resolveEmployment(ctx context.Context, userID int64, raw string) (*uuid.UUID, error) {
+	id, err := optionalUUID(raw)
+	if err == nil {
+		return id, nil
+	}
+	if h.experience == nil {
+		return nil, err
+	}
+	employments, listErr := h.experience.ListEmployments(ctx, userID)
+	if listErr != nil {
+		return nil, err // the original message; a failed lookup is not the model's problem to fix
+	}
+	if len(employments) == 0 {
+		return nil, errors.New("this candidate has no roles on file yet, so employment_id must be left out — " +
+			"record the achievement without one")
+	}
+	var b strings.Builder
+	b.WriteString("employment_id must be one of this candidate's roles: ")
+	for i, e := range employments {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		fmt.Fprintf(&b, "%s = %s", e.ID, strings.TrimSpace(e.Company+" "+e.Role))
+	}
+	b.WriteString(". Leave it out if none of them is where this happened.")
+	return nil, errors.New(b.String())
 }
 
 // searchResult shapes matches for the model: the claim it can reframe, the place it

--- a/internal/handler/assistant_experience_tools_test.go
+++ b/internal/handler/assistant_experience_tools_test.go
@@ -45,10 +45,12 @@ func TestExperienceToolsReportFailuresToTheModel(t *testing.T) {
 			want: "claim",
 		},
 		{
+			// The bank in this stand has no roles, so the refusal says that rather than
+			// pointing at a lookup that would come back empty.
 			name: "an employment id that is not an id",
 			tool: "experience_add",
 			args: `{"claim":"Did a thing","employment_id":"the sber one"}`,
-			want: "experience_employments",
+			want: "no roles on file",
 		},
 		{
 			name: "an unknown argument",
@@ -186,5 +188,40 @@ func TestExperienceSearchResultCarriesWhatTheAgentMustCite(t *testing.T) {
 	// The agent's own hypothesis is returned so it can ask about it — flagged, not hidden.
 	if decoded.Evidence[1].CanWriteCV {
 		t.Error("an agent_inferred entry was reported as usable on a CV")
+	}
+}
+
+// A wrong employment id used to cost a whole tool round: the model guessed, was told only
+// that it was wrong, spent a round on experience_employments, and retried. The refusal now
+// carries the ids it could have used, so the correction happens inside the same round.
+func TestARejectedEmploymentIdNamesTheValidOnes(t *testing.T) {
+	bank := newStubBank()
+	bank.employments = []experience.Employment{
+		{ID: uuid.MustParse("22222222-2222-4222-8222-222222222222"), Company: "RingCentral", Role: "Tech Lead"},
+		{ID: uuid.MustParse("33333333-3333-4333-8333-333333333333"), Company: "Acme", Role: "Engineer"},
+	}
+	reg, _ := experienceToolsFor(t, bank)
+
+	out := reg.Call(context.Background(), 1, "experience_add",
+		json.RawMessage(`{"claim":"Ran the Java containers","employment_id":"the ringcentral one"}`))
+	payload, _ := json.Marshal(out)
+
+	for _, want := range []string{"22222222-2222-4222-8222-222222222222", "RingCentral", "Acme"} {
+		if !strings.Contains(string(payload), want) {
+			t.Errorf("the refusal does not mention %q — the model has to spend a round finding it:\n%s", want, payload)
+		}
+	}
+}
+
+// A candidate with no roles on file gets a refusal that says so, rather than an empty list
+// that reads as "the ids exist, you just guessed wrong".
+func TestARejectedEmploymentIdWithNoRolesSaysSo(t *testing.T) {
+	reg, _ := experienceToolsFor(t, newStubBank())
+
+	out := reg.Call(context.Background(), 1, "experience_add",
+		json.RawMessage(`{"claim":"Did a thing","employment_id":"nope"}`))
+	payload, _ := json.Marshal(out)
+	if !strings.Contains(strings.ToLower(string(payload)), "no roles") {
+		t.Errorf("the refusal should say the bank holds no roles yet:\n%s", payload)
 	}
 }

--- a/internal/handler/assistant_integration_test.go
+++ b/internal/handler/assistant_integration_test.go
@@ -55,7 +55,7 @@ func newAssistantApp(pool *pgxpool.Pool, iss *auth.Issuer, model assistant.Model
 		// The tailoring tools and the autopilot run reach the CV store, so the assistant
 		// under test carries the same CV service the HTTP surface uses.
 		cv: &cvHandlers{
-			cvStore: cv.NewStore(cv.NewQueriesRepository(queries)), queries: queries,
+			cvStore: cv.NewStore(cv.NewQueriesRepository(queries)), queries: queries, jobReader: queries,
 			// The run reads the cached fit analysis to lay down its plan, so the CV handlers
 			// under test carry the same cache the production wiring gives them.
 			matchAnalysisCache: queries,

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"time"
@@ -35,7 +36,10 @@ type cvHandlers struct {
 	queries            *db.Queries
 	credits            *credits.Store
 	matchAnalysisCache matchAnalysisStore
-	match              *matchHandlers
+	// jobReader serves the vacancy a tailoring context is about. Narrow on purpose: the
+	// tailoring path reads one row by id and nothing else.
+	jobReader jobReader
+	match     *matchHandlers
 	// assistantSessions mints the conversation a tailoring workspace runs in.
 	// Assigned after construction (see withAssistantSessions).
 	assistantSessions *assistant.Store
@@ -44,9 +48,15 @@ type cvHandlers struct {
 	seeder cv.Seeder
 }
 
+// jobReader is the one vacancy read the tailoring context needs.
+type jobReader interface {
+	GetJob(ctx context.Context, id int64) (db.Job, error)
+}
+
 func newCVHandlers(queries *db.Queries, typstBin string, resumeStore *resume.Store, creditsStore *credits.Store, match *matchHandlers) *cvHandlers {
 	h := &cvHandlers{
 		cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
+		jobReader:          queries,
 		resume:             resumeStore,
 		seeder:             bankedSeeder{resume: resumeStore, bank: newWorkHistoryReader(queries)},
 		queries:            queries,

--- a/internal/handler/cv_integration_test.go
+++ b/internal/handler/cv_integration_test.go
@@ -86,7 +86,7 @@ func TestCVTemplatesEndpoint_OpenToAuthed(t *testing.T) {
 		t.Fatalf("truncate: %v", err)
 	}
 	iss := auth.NewIssuer("test-secret", time.Hour)
-	h := &cvHandlers{queries: queries,
+	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
 	app := buildCVApp(h, iss)
@@ -121,7 +121,7 @@ func TestSetCVTemplateEndpoint(t *testing.T) {
 		t.Fatalf("truncate: %v", err)
 	}
 	iss := auth.NewIssuer("test-secret", time.Hour)
-	h := &cvHandlers{queries: queries,
+	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
 	app := buildCVApp(h, iss)
@@ -180,7 +180,7 @@ func TestCVEndpoints_CRUDAndIsolation(t *testing.T) {
 		t.Fatalf("truncate: %v", err)
 	}
 	iss := auth.NewIssuer("test-secret", time.Hour)
-	h := &cvHandlers{queries: queries,
+	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))} // storage disabled → seed no-ops
 	app := buildCVApp(h, iss)
@@ -271,7 +271,7 @@ func TestCVCreate_SeedsFromStructuredResume(t *testing.T) {
 	// S3 storage is DISABLED (nil blobs): seeding reads the structured résumé from
 	// Postgres, so it must work independently of object storage.
 	store := resume.New(nil, resume.NewQueriesRepository(queries))
-	h := &cvHandlers{queries: queries,
+	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)), resume: store}
 	app := buildCVApp(h, iss)
 

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -206,6 +206,20 @@ type tailorJob struct {
 	Description string `json:"description"`
 }
 
+// tailorDescriptionLimit bounds the posting inside a tailoring context. A recorded session
+// spent 11.4 KB of its opening round on one description in raw HTML — more than a third of the
+// whole conversation, before the agent had done anything.
+const tailorDescriptionLimit = 6000
+
+// clipRunes bounds a string on a rune boundary, so a multi-byte character is never cut in half.
+func clipRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return strings.TrimSpace(string(r[:max])) + "…"
+}
+
 // tailorContextResponse is the reasoning context the agent reads (freehire cv context): the
 // vacancy, the verdict and recommendation, per-dimension comments, and the requirement split
 // the honest wall turns on — missing_have (reframe existing evidence) vs missing_gap (ask first).
@@ -240,15 +254,11 @@ func (h *cvHandlers) TailorContext(c *fiber.Ctx) error {
 	if rec.JobID == 0 {
 		return fiber.NewError(fiber.StatusConflict, "not a tailored CV")
 	}
-	analysis, err := h.cachedAnalysis(c, userID, rec.JobID)
+	ctx, err := h.tailoringContext(c.Context(), userID, rec.JobID)
 	if err != nil {
 		return err
 	}
-	job, err := h.queries.GetJob(c.Context(), rec.JobID)
-	if err != nil {
-		return err
-	}
-	return c.JSON(fiber.Map{"data": tailorContext(analysis, job)})
+	return c.JSON(fiber.Map{"data": ctx})
 }
 
 // cachedAnalysis loads the cached fit analysis for (user, job), or a 409 telling the caller to
@@ -290,10 +300,13 @@ func tailorContext(a *matchanalysis.Analysis, job db.Job) tailorContextResponse 
 	}
 	return tailorContextResponse{
 		Job: tailorJob{
-			Title:       job.Title,
-			Company:     job.Company,
-			Slug:        job.PublicSlug,
-			Description: job.Description,
+			Title:   job.Title,
+			Company: job.Company,
+			Slug:    job.PublicSlug,
+			// The posting is the largest thing in the turn and the least trusted: it reaches
+			// the model as words, bounded, the same way get_job already serves it. Sending
+			// markup spends the context window on tags and widens what there is to misread.
+			Description: clipRunes(formatDescription(job.Description, "markdown"), tailorDescriptionLimit),
 		},
 		Verdict:        a.Verdict,
 		OverallScore:   a.OverallScore,
@@ -304,6 +317,21 @@ func tailorContext(a *matchanalysis.Analysis, job db.Job) tailorContextResponse 
 		Strengths:      a.Strengths,
 		Gaps:           a.Gaps,
 	}
+}
+
+// tailoringContext assembles what a tailoring reader needs: the cached analysis, projected
+// over the vacancy it is about. Both the HTTP endpoint and the agent's tool go through here,
+// so neither can drift into reading a different analysis or a different vacancy.
+func (h *cvHandlers) tailoringContext(ctx context.Context, userID, jobID int64) (tailorContextResponse, error) {
+	analysis, err := h.cachedAnalysisCtx(ctx, userID, jobID)
+	if err != nil {
+		return tailorContextResponse{}, err
+	}
+	job, err := h.jobReader.GetJob(ctx, jobID)
+	if err != nil {
+		return tailorContextResponse{}, err
+	}
+	return tailorContext(analysis, job), nil
 }
 
 // tailoredCVTitle names a tailored copy from the vacancy title (bounded/defaulted like any CV

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -41,7 +41,7 @@ func newTailorAPI(t *testing.T) (*cvHandlers, *auth.Issuer, *pgxpool.Pool) {
 	}
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	creditsStore := credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3})
-	h := &cvHandlers{queries: queries,
+	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
 		resume:             resume.New(nil, resume.NewQueriesRepository(queries)),
 		matchAnalysisCache: queries,

--- a/openspec/changes/tailor-context-retrieval/.openspec.yaml
+++ b/openspec/changes/tailor-context-retrieval/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/tailor-context-retrieval/design.md
+++ b/openspec/changes/tailor-context-retrieval/design.md
@@ -1,0 +1,92 @@
+## Context
+
+Read from two production transcripts (29 July 2026):
+
+- **litit** — 16 messages, 30.7 KB. Opening round alone: `cv_context` 11.4 KB, `cv_get` 6.5 KB.
+  Then ten `experience_search` calls, four of which returned the same atoms as one another.
+  Zero CV edits; the turn ran out of rounds (`ASSISTANT_MAX_STEPS` unset on prod → 8).
+- **getambush** — 23 messages, five searches, zero CV edits, plus a round lost to
+  `experience_add` guessing an `employment_id`.
+
+The retrieval those ten calls were asking for is `experience.Store.Retrieve` — a linear scan over
+the caller's atoms with skill, stack and word-overlap scoring. No model, no network. The agent was
+spending tool rounds on something the server could have handed it in the first result.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The agent arrives at its first edit knowing what it can evidence, without paying rounds to find out.
+- The opening round stops being the most expensive thing in the conversation.
+- A wrong id costs a correction, not a round.
+
+**Non-Goals:**
+- A batch search tool. If the context already carries retrieval for every requirement, the ten
+  calls do not happen — building a batching mechanism for them would be machinery for a problem
+  this change removes.
+- Changing the retrieval algorithm itself. Its scoring is not what failed here.
+- Touching the public `GET /me/cvs/:id/tailor-context` shape. The additions belong to the agent's
+  view of that context; a client that reads the endpoint is unaffected.
+- Semantic/embedding retrieval. The word-overlap floor is enough to decide "ask or reframe", and
+  an embedding pipeline is a different change with its own cost.
+
+## Decisions
+
+### Enrichment lives in the tool, not in `tailorContext`
+
+`tailorContext(analysis, job)` is shared by the HTTP endpoint and the agent's tool. The evidence
+attachment goes in the TOOL — `cvContextTool` — because it is the agent that needs it and the
+agent that has an experience store to hand. The endpoint keeps serving what it serves.
+
+Alternative rejected: enriching `tailorContext` itself. It would push a bank dependency into a
+handler that has no business holding one, and would put per-requirement evidence into a response
+the SPA renders, where nothing reads it.
+
+### The evidence is named, not inlined
+
+Each requirement carries the atoms' ids and claims, bounded — not their full context, metrics and
+role blocks. The agent needs enough to decide "I can write this" and the id to cite; the rest it
+can fetch with `experience_search` for the one requirement where it matters. A tool result is
+replayed into the model's context on every later turn, so what goes in it is paid for repeatedly.
+
+### An empty list, not an absent field
+
+A requirement with nothing in the bank reports `evidence: []`. Omitting the field would read as
+"not looked at", and the difference between "looked and found nothing" and "did not look" is
+exactly the difference between asking the candidate and staying silent.
+
+### Measured, not assumed: where the 11.4 KB actually went
+
+Breaking the recorded `cv_context` result down by field: `job` 4235 B (the posting, as HTML),
+`missing_gap` 2297, `dimensions` 1756, then `gaps` 472, `recommendation` 402, `strengths` 399,
+`missing_have` 199.
+
+Rendering the description to markdown saves ~700 B on that posting — real, but a tenth of what
+the first guess said. The larger and easier saving is the ~3 KB of dimension comments, strengths,
+gaps and recommendation: the agent cannot edit a CV from any of them, and the prompt now forbids
+restating them, so carrying them through every subsequent turn buys nothing. The agent's context
+drops them; the HTTP endpoint keeps serving them to the page that renders them.
+
+### The description is rendered, not stripped by the model
+
+`get_job` already renders the stored HTML to text before it reaches a model, with a test that says
+so. The tailoring context did not — an inconsistency in how the same field reaches the same model
+through two tools. Same helper, same treatment.
+
+## Risks / Trade-offs
+
+- **The context result grows a little** → It shrinks overall: ~700 B off the description and ~3 KB
+  of narrative sections dropped, against a few hundred bytes of evidence per requirement. Both the
+  description and the evidence lists are bounded.
+- **Retrieval runs even when the agent would not have searched** → It is a linear pass over tens
+  of atoms with no I/O beyond two owner-scoped reads. Cheaper than the round it replaces.
+- **A model may now cite an id it never searched for** → Unchanged where it matters: `cv_edit`
+  still resolves the id and refuses anything not publishable. The context reports `can_write_cv`
+  per atom exactly as search does.
+- **The prompt asks for edits earlier, which could mean shallower edits** → The instruction is to
+  edit per requirement as it is closed, not to edit faster; the evidence wall is what bounds
+  quality, and it is untouched.
+
+## Migration Plan
+
+No schema, no endpoint, no client change. Ship with the code; nothing to backfill and nothing to
+roll back beyond the release itself.

--- a/openspec/changes/tailor-context-retrieval/proposal.md
+++ b/openspec/changes/tailor-context-retrieval/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Two real tailoring sessions on production, read from their transcripts:
+
+| Session | Messages | `experience_search` calls | CV edits |
+|---|---|---|---|
+| litit, 13:01 | 16 (30.7 KB) | 10 | **0** |
+| getambush, 11:33 | 23 | 5 | **0** |
+
+Neither changed the CV. The first spent 18 KB of its 30 KB on the opening round alone —
+`cv_context` returned **11.4 KB**, `cv_get` 6.5 KB — then made ten searches, four of which
+returned the same atoms as each other, and ran out of tool-call rounds before editing anything.
+
+Two things cause that. `cv_context` hands the model the vacancy description as **raw HTML**,
+while the neighbouring `get_job` renders the same field to markdown. And it reports the
+requirements without saying anything about the bank, so the agent has to ask about each one
+separately — even though the retrieval that answers those questions is a local scan over the
+candidate's own atoms, with no model call in it.
+
+## What Changes
+
+- `cv_context` renders the vacancy description to markdown and bounds it, the way `get_job`
+  already does. The HTTP endpoint of the same name is unaffected — this is the agent's view.
+- `cv_context` attaches the bank's own answer to every requirement it reports: the ids and
+  claims that retrieval already scores against it. The agent arrives knowing what it can
+  evidence and what it must ask about, instead of discovering it one call at a time.
+- `experience_add`'s employment error names the valid roles and their ids, so a model that
+  guessed can correct itself in the same round rather than spending one on
+  `experience_employments`.
+- The tailoring prompt tells the agent to edit as it goes and to stop restating the verdict —
+  both sessions opened with a long summary of an analysis the candidate has open beside the chat.
+
+## Capabilities
+
+### New Capabilities
+<!-- none: this sharpens an existing capability rather than adding one -->
+
+### Modified Capabilities
+- `cv-tailoring`: the tailoring context an agent reads now carries retrieved evidence per
+  requirement and a markdown description, rather than a raw posting and no bank information.
+- `assistant-agent-runtime`: a rejected tool call reports what a valid argument would have been,
+  not only that the one sent was wrong — a correction that costs a round is a correction the
+  step cap pays for.
+
+## Impact
+
+- **Go:** `internal/handler/cv_tailor.go` (the context shape), `internal/handler/assistant_cv_tools.go`
+  (the tool's own enrichment), `internal/handler/assistant_experience_tools.go` (the error),
+  `internal/assistant/prompt.go` (the tailoring prompt).
+- **No schema change, no new endpoint, no client change.** The wire shape of
+  `GET /me/cvs/:id/tailor-context` keeps its current fields; the additions are the agent's.
+- **Not affected:** the fit analysis itself, the autopilot run's mechanics, the experience bank's
+  provenance rule.

--- a/openspec/changes/tailor-context-retrieval/specs/assistant-agent-runtime/spec.md
+++ b/openspec/changes/tailor-context-retrieval/specs/assistant-agent-runtime/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Malformed tool calls are reported to the model, not crashed on
+
+Tool arguments SHALL be decoded strictly: unknown fields, missing required
+fields, and type mismatches SHALL be rejected. A rejected call and a failing
+tool SHALL both be returned to the model as a tool result describing the error,
+so it can correct itself within the same turn. Such a failure SHALL count
+against the turn's step cap and MUST NOT abort the turn or surface as a request
+error.
+
+Where the valid values are a short, caller-owned set — the ids of the roles an achievement may
+attach to, the values an enum admits — the error SHALL carry them. A message that only says the
+argument was wrong costs a round to discover what would be right, and that round comes out of the
+step cap the same turn is trying to spend on work.
+
+#### Scenario: A mis-shaped argument object is corrected in-turn
+
+- **WHEN** the model calls a tool with an argument object that fails strict decoding
+- **THEN** the turn continues with a tool result naming the decoding problem, and the model may retry the call
+
+#### Scenario: A failing dependency does not kill the turn
+
+- **WHEN** a tool fails because a backing service is unavailable
+- **THEN** the error is returned to the model as that tool's result and the turn continues within its step cap
+
+#### Scenario: A rejected id names the ids that would have been accepted
+
+- **WHEN** an achievement is recorded against an employment id that is not one of the caller's
+- **THEN** the error lists the caller's employments with their ids, so the retry needs no separate lookup

--- a/openspec/changes/tailor-context-retrieval/specs/cv-tailoring/spec.md
+++ b/openspec/changes/tailor-context-retrieval/specs/cv-tailoring/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: The agent's tailoring context carries the bank's answer per requirement
+
+The tailoring agent's context tool SHALL attach, to every requirement it reports, the evidence the
+candidate's experience bank already holds for it — each piece named by the id a CV edit must cite,
+so the agent knows before it acts which requirements it can evidence and which it must ask about.
+Retrieval MUST be the same scoring the search tool uses, and MUST NOT call a model: it is a scan
+over the caller's own atoms, so attaching it costs a round nobody has to spend.
+
+A requirement the bank has nothing for MUST say so explicitly rather than omit the field, because
+"no evidence" is the answer that decides whether to ask the candidate, and an absent field reads
+as "not looked at".
+
+#### Scenario: A requirement the bank can evidence arrives with its evidence
+
+- **WHEN** the agent reads the tailoring context for a vacancy whose requirement the bank holds evidence for
+- **THEN** that requirement carries the evidence's id and claim, ready to be cited in an edit
+
+#### Scenario: A requirement the bank cannot evidence says so
+
+- **WHEN** a reported requirement has nothing scoring against it in the bank
+- **THEN** it is reported with an empty evidence list rather than with the field left out
+
+#### Scenario: Reading the context calls no model
+
+- **WHEN** the agent reads the tailoring context
+- **THEN** the evidence attached to each requirement comes from local scoring, with no LLM call
+
+### Requirement: The agent's context carries what it can act on, not the narrative
+
+The tailoring context served to the AGENT SHALL carry the vacancy, the verdict and score, and the
+requirements with their evidence — and SHALL NOT carry the per-dimension comments, strengths, gaps
+or recommendation the endpoint serves the page. None of them is something a CV edit can be made
+from, all of them are on the candidate's screen already, and on a measured session they were 3 KB
+of an 11.4 KB result the agent had to carry for the rest of the turn.
+
+#### Scenario: The narrative sections stay with the page
+
+- **WHEN** the agent reads the tailoring context
+- **THEN** the result carries the vacancy, verdict, score and the evidenced requirements, and none of the dimension comments, strengths, gaps or recommendation
+
+#### Scenario: The endpoint is unchanged
+
+- **WHEN** a client reads the tailoring context over HTTP
+- **THEN** it receives the full projection it received before, narrative sections included
+
+### Requirement: The agent reads the posting as text, not as markup
+
+The tailoring context served to the agent SHALL render the vacancy description from stored HTML to
+plain text, and SHALL bound its length, exactly as the vacancy-reading tool already does. The
+posting is the least trusted text in the conversation and the largest; sending it as markup spends
+the turn's context on tags and widens what the model is asked to interpret.
+
+#### Scenario: The description reaches the model without markup
+
+- **WHEN** the agent reads the tailoring context for a vacancy whose stored description is HTML
+- **THEN** the description it receives carries the posting's words and none of its tags
+
+#### Scenario: A very long posting is bounded
+
+- **WHEN** the stored description is longer than the context allows
+- **THEN** it is truncated to the bound rather than sent whole

--- a/openspec/changes/tailor-context-retrieval/tasks.md
+++ b/openspec/changes/tailor-context-retrieval/tasks.md
@@ -1,0 +1,28 @@
+## 1. The posting reaches the agent as text
+
+- [x] 1.1 Render the vacancy description to plain text and bound it in the agent's tailoring context, reusing the same helper `get_job` uses
+- [x] 1.2 Test: a stored HTML description reaches the tool's result without tags, and an over-long one is truncated to the bound
+
+## 2. The context carries the bank's answer and drops what the agent cannot act on
+
+- [x] 2.1 Attach retrieved evidence (id, claim, `can_write_cv`) to every requirement the tool reports, bounded per requirement, using the same `experience.Store.Retrieve` scoring the search tool uses
+- [x] 2.2 Report an empty list for a requirement the bank has nothing for, rather than omitting the field
+- [x] 2.3 Degrade to no evidence (never an error) when the bank is unavailable — a tailoring context without retrieval is still worth reading
+- [x] 2.5 Keep the dimension comments, strengths, gaps and recommendation out of the agent's context (the endpoint keeps serving them), with a test that says so
+- [x] 2.4 Test: a requirement the bank evidences carries the id a later `cv_edit` can cite; a requirement it does not carries an empty list; no model is called
+
+## 3. A rejected id names the valid ones
+
+- [x] 3.1 When `experience_add` rejects an unknown `employment_id`, list the caller's employments with their ids in the error
+- [x] 3.2 Test: the refusal names an existing role's id, and a retry using it succeeds within the same turn
+
+## 4. The prompt spends rounds on edits
+
+- [x] 4.1 Tell the tailoring agent to edit as each requirement is closed rather than researching everything first, and to read `cv_context`'s evidence instead of re-searching what it already carries
+- [x] 4.2 Tell it not to restate the fit analysis — the candidate has it open beside the chat — and to keep its opening to what it is about to do
+- [x] 4.3 Test the prompt states both, so a future edit cannot quietly drop them
+
+## 5. Verification
+
+- [x] 5.1 `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...`, and the integration suites green
+- [x] 5.2 Measured against the recorded baseline by field: `job` 4235 B, `missing_gap` 2297, `dimensions` 1756, `gaps`/`recommendation`/`strengths` 1273, `missing_have` 199. Rendering the posting saves ~700 B (not the ~7 KB first assumed — the description was 4.2 KB, not 11 KB); dropping the narrative sections from the agent's view saves ~3 KB more. A run against a live model is still unverified — no LLM credentials on this machine

--- a/web/src/posts/2026-07-29-one-button-tailors-your-cv.svx
+++ b/web/src/posts/2026-07-29-one-button-tailors-your-cv.svx
@@ -1,0 +1,27 @@
+---
+title: One button tailors your CV to the job
+date: 2026-07-29
+summary: The CV workspace no longer opens on a conversation you have to drive — press "Tailor it for me" and the agent works through every requirement of the posting on its own, then comes back with the ones it could not answer for you.
+type: changelog
+tags:
+  - cv
+  - ai
+draft: false
+---
+
+Opening the [tailoring workspace](/features/tailor) used to mean starting a conversation and
+steering it: the agent offered to walk the gaps, and you worked through them one message at a
+time. Everything it needed was already there — the posting's requirements, your experience bank,
+the method — but you had to ask for each step.
+
+Now the empty chat offers two ways in. **"Walk me through it"** is the old rhythm. **"Tailor it
+for me"** is new: the agent goes through every requirement of the posting by itself, searches
+your experience bank for each one, and rewrites the relevant bullets in the vacancy's language.
+It asks you nothing while it works.
+
+When it finishes, the panel beside your CV lists every requirement and what became of it —
+closed from your bank, still open, or not reached. Then it asks about the first thing it could
+not close. Anything you confirm there is banked, so the next vacancy will not ask you again.
+
+If you do not like what it did, **Undo the run** puts the CV back exactly as it was before,
+in one move.


### PR DESCRIPTION
## What and why

Read from two real tailoring transcripts on production (29 July):

| Session | Messages | `experience_search` | CV edits |
|---|---|---|---|
| litit, 13:01 | 16 (30.7 KB) | **10** | **0** |
| getambush, 11:33 | 23 | 5 | **0** |

Neither changed the CV. The first spent its opening round on an 11.4 KB `cv_context` and a 6.5 KB `cv_get`, then made ten searches — four of which returned the same atoms as one another — and ran out of tool-call rounds before editing anything. The second lost a round to `experience_add` guessing an `employment_id`, was told only that the guess was wrong, and spent another round looking the ids up.

What those ten searches were asking for is `experience.Store.Retrieve`: a linear scan over the candidate's own atoms, no model, no network. The server could have handed it over in the first result.

## What changes

- **`cv_context` carries the bank's answer.** Every requirement it reports arrives with the evidence found for it — the achievement id a `cv_edit` must cite, its claim, and whether it may be written into a CV. A requirement with nothing gets `evidence: []`, never an absent field: "looked and found nothing" is what decides whether to ask the candidate, and an absent field reads as "did not look".
- **`cv_context` stops carrying what the agent cannot act on.** Dimension comments, strengths, gaps and the recommendation stay with the HTTP endpoint that feeds the page. The agent cannot edit a CV from a dimension comment, and the prompt now forbids restating them — carrying them through every later turn buys nothing.
- **The posting reaches the model as text.** `get_job` already renders the stored HTML; the tailoring context did not. Same helper, now bounded too.
- **A rejected `employment_id` names the ids that would have worked** (and says plainly when the bank holds no roles yet), so the correction happens inside the round instead of costing one.
- **The prompt spends rounds on edits**: read the evidence `cv_context` already carries instead of re-searching it, edit as each requirement is closed rather than researching everything first, and do not restate an analysis the candidate has open beside the chat.

## Measured, not assumed

My first reading blamed the raw HTML for the 11.4 KB. Breaking the recorded result down by field says otherwise:

| Field | Bytes |
|---|---|
| `job` (the posting, HTML) | 4235 |
| `missing_gap` | 2297 |
| `dimensions` | 1756 |
| `gaps` + `recommendation` + `strengths` | 1273 |
| `missing_have` | 199 |

Rendering the posting saves ~700 B — real, but a tenth of the first guess. The bigger and easier saving is the ~3 KB of narrative the agent was carrying and could not use. Both are in this change; the estimate that was wrong is written down in the design doc rather than quietly dropped.

## Not in scope

A batch search tool — if the context already answers every requirement, the ten calls do not happen, and batching them would be machinery for a problem this removes. Also unchanged: the retrieval scoring itself, the public `tailor-context` endpoint's shape, and the provenance wall.

## Verification

`go build` / `go vet` / `gofmt` clean, `go test ./...` green, integration suites over real Postgres green (`internal/handler`, `internal/db`). Unit tests cover: the posting arriving without markup and bounded, evidence attached per requirement with the citable id, the empty-list-not-absent-field rule, retrieval degrading to no evidence when the bank is unavailable, the narrative sections staying out, the rejected id naming the valid ones, and the prompt stating both new rules.

**Not verified:** behaviour against a live model — no LLM credentials on this machine. What the transcripts will show is the point of the change, so the next real session is the test that matters.

OpenSpec: `openspec/changes/tailor-context-retrieval/`.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [x] I regenerated committed artifacts when their source changed — none changed.
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.
