### PR TITLE
fix(tailor): a reload of the workspace keeps its CV and its conversation

### DIFF
--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -77,6 +77,7 @@ type Repository interface {
 	SnapshotForAutopilot(ctx context.Context, id uuid.UUID, userID int64) (int64, error)
 	SetAutopilotReport(ctx context.Context, id uuid.UUID, userID int64, report []byte) (int64, error)
 	RevertAutopilot(ctx context.Context, id uuid.UUID, userID int64) (db.RevertCVAutopilotRow, error)
+	GetTailoredForJob(ctx context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error)
 }
 
 // Seeder provides the user's extracted résumé, used to seed a base CV when they have none.
@@ -321,11 +322,32 @@ func (s *Store) Tailor(ctx context.Context, userID, jobID int64, tailoredTitle s
 		}
 		base = Record{Meta: meta, Document: doc}
 	}
+	// One tailored copy per vacancy. The workspace's address carries no CV reference, so a
+	// reload re-runs this exact request; minting a second copy leaves the candidate's
+	// conversation bound to the first one, which is what "my chat disappeared" looks like.
+	if existing, err := s.tailoredForJob(ctx, userID, jobID); err == nil {
+		return base.Meta, existing, nil
+	} else if !errors.Is(err, ErrNotFound) {
+		return Meta{}, Meta{}, err
+	}
+
 	tailored, err := s.CreateTailored(ctx, userID, jobID, tailoredTitle, base.TemplateID, base.Document)
 	if err != nil {
 		return Meta{}, Meta{}, err
 	}
 	return base.Meta, tailored, nil
+}
+
+// tailoredForJob returns the user's existing tailored copy for a vacancy, or ErrNotFound.
+func (s *Store) tailoredForJob(ctx context.Context, userID, jobID int64) (Meta, error) {
+	row, err := s.repo.GetTailoredForJob(ctx, userID, jobID)
+	if err != nil {
+		return Meta{}, mapNotFound(err)
+	}
+	return Meta{
+		ID: row.ID, Title: row.Title, TemplateID: row.TemplateID,
+		CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time,
+	}, nil
 }
 
 // defaultBaseTitle names a base CV seeded from the résumé (the user can rename it later).
@@ -414,4 +436,10 @@ func (r queriesRepository) SetAutopilotReport(ctx context.Context, id uuid.UUID,
 
 func (r queriesRepository) RevertAutopilot(ctx context.Context, id uuid.UUID, userID int64) (db.RevertCVAutopilotRow, error) {
 	return r.q.RevertCVAutopilot(ctx, db.RevertCVAutopilotParams{ID: id, UserID: userID})
+}
+
+func (r queriesRepository) GetTailoredForJob(ctx context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {
+	return r.q.GetTailoredCVForJob(ctx, db.GetTailoredCVForJobParams{
+		UserID: userID, JobID: pgtype.Int8{Int64: jobID, Valid: true},
+	})
 }

--- a/internal/cv/store_tailor_test.go
+++ b/internal/cv/store_tailor_test.go
@@ -123,3 +123,41 @@ func TestStoreTailorUsesExistingBaseUntouched(t *testing.T) {
 		t.Errorf("tailored doc != base doc")
 	}
 }
+
+// Tailoring the SAME vacancy twice must reach the same tailored CV.
+//
+// The workspace opens at /tailor/<slug>, and without a `?cv` reference that address is a
+// bootstrap. So every reload used to mint another copy: three CVs for one vacancy in half an
+// hour on production, each with its own empty conversation, and the candidate's actual chat
+// stranded on the first of them. The bootstrap is the same request either way — it has to be
+// idempotent per (user, vacancy).
+func TestStoreTailorReturnsTheExistingCopyForTheSameVacancy(t *testing.T) {
+	repo := newFakeRepo()
+	s := NewStore(repo)
+	ctx := context.Background()
+
+	if _, err := s.Create(ctx, 7, "My CV", DefaultTemplateID, Document{Summary: "base"}); err != nil {
+		t.Fatalf("seed base: %v", err)
+	}
+
+	_, first, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	if err != nil {
+		t.Fatalf("first tailor: %v", err)
+	}
+	_, second, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	if err != nil {
+		t.Fatalf("second tailor: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Errorf("second bootstrap made a new CV (%s vs %s); the candidate's conversation is bound to the first", second.ID, first.ID)
+	}
+
+	// A DIFFERENT vacancy still gets its own copy.
+	_, other, err := s.Tailor(ctx, 7, 200, "Tailored", fakeSeeder{ok: false})
+	if err != nil {
+		t.Fatalf("other tailor: %v", err)
+	}
+	if other.ID == first.ID {
+		t.Error("a second vacancy reused the first vacancy's tailored CV")
+	}
+}

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -285,3 +285,26 @@ func (f *fakeRepo) RevertAutopilot(_ context.Context, id uuid.UUID, userID int64
 	f.rows[id] = r
 	return db.RevertCVAutopilotRow{ID: id, Title: r.title, TemplateID: r.templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
+
+func (f *fakeRepo) GetTailoredForJob(_ context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {
+	// Newest by insertion order, mirroring the query's `updated_at DESC, id DESC`.
+	var bestID uuid.UUID
+	var best *fakeRow
+	for id, r := range f.rows {
+		row := r
+		if row.userID != userID || row.jobID != jobID {
+			continue
+		}
+		if best == nil || row.seq > best.seq {
+			best, bestID = &row, id
+		}
+	}
+	if best == nil {
+		return db.GetTailoredCVForJobRow{}, pgx.ErrNoRows
+	}
+	return db.GetTailoredCVForJobRow{
+		ID: bestID, Title: best.title, TemplateID: best.templateID, Data: best.data,
+		AgentSessionID: pgtype.Text{String: best.sessionID, Valid: best.sessionID != ""},
+		CreatedAt:      stamp(), UpdatedAt: stamp(),
+	}, nil
+}

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -200,6 +200,48 @@ func (q *Queries) GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByID
 	return i, err
 }
 
+const getTailoredCVForJob = `-- name: GetTailoredCVForJob :one
+SELECT id, title, template_id, data, agent_session_id, created_at, updated_at
+FROM cvs
+WHERE user_id = $1 AND job_id = $2
+ORDER BY updated_at DESC, id DESC
+LIMIT 1
+`
+
+type GetTailoredCVForJobParams struct {
+	UserID int64       `json:"user_id"`
+	JobID  pgtype.Int8 `json:"job_id"`
+}
+
+type GetTailoredCVForJobRow struct {
+	ID             uuid.UUID          `json:"id"`
+	Title          string             `json:"title"`
+	TemplateID     string             `json:"template_id"`
+	Data           []byte             `json:"data"`
+	AgentSessionID pgtype.Text        `json:"agent_session_id"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+}
+
+// The user's existing tailored copy for one vacancy, newest first. The tailoring bootstrap is
+// reached by an address (/tailor/<slug>) that carries no CV reference, so a reload runs the
+// same request again: without this read every refresh minted another copy and stranded the
+// conversation bound to the previous one.
+func (q *Queries) GetTailoredCVForJob(ctx context.Context, arg GetTailoredCVForJobParams) (GetTailoredCVForJobRow, error) {
+	row := q.db.QueryRow(ctx, getTailoredCVForJob, arg.UserID, arg.JobID)
+	var i GetTailoredCVForJobRow
+	err := row.Scan(
+		&i.ID,
+		&i.Title,
+		&i.TemplateID,
+		&i.Data,
+		&i.AgentSessionID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listCVsByUser = `-- name: ListCVsByUser :many
 SELECT id, title, template_id, created_at, updated_at
 FROM cvs

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -43,7 +43,9 @@ type CanonicalJobForRoleRow struct {
 // agree rather than fight.
 // A canon must be open AND not itself a duplicate, or marking would build a chain (A -> B -> C)
 // that no reader expects. The row being written is excluded by its own dedup identity, because
-// a re-import of the same URL would otherwise find itself. Served by jobs_company_slug_idx.
+// a re-import of the same URL would otherwise find itself. Served by the partial
+// jobs_open_role_cluster_idx (migration 0013), with jobs_company_role_fingerprint_idx as the
+// non-partial fallback.
 func (q *Queries) CanonicalJobForRole(ctx context.Context, arg CanonicalJobForRoleParams) (CanonicalJobForRoleRow, error) {
 	row := q.db.QueryRow(ctx, canonicalJobForRole,
 		arg.CompanySlug,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -76,7 +76,9 @@ type Querier interface {
 	// agree rather than fight.
 	// A canon must be open AND not itself a duplicate, or marking would build a chain (A -> B -> C)
 	// that no reader expects. The row being written is excluded by its own dedup identity, because
-	// a re-import of the same URL would otherwise find itself. Served by jobs_company_slug_idx.
+	// a re-import of the same URL would otherwise find itself. Served by the partial
+	// jobs_open_role_cluster_idx (migration 0013), with jobs_company_role_fingerprint_idx as the
+	// non-partial fallback.
 	CanonicalJobForRole(ctx context.Context, arg CanonicalJobForRoleParams) (CanonicalJobForRoleRow, error)
 	// Lease a batch of due, pending reminders by stamping claimed_at, earliest deadline
 	// first. FOR UPDATE OF r + SKIP LOCKED lets overlapping worker passes take disjoint
@@ -727,6 +729,11 @@ type Querier interface {
 	// channel's live recipient), and the user's linked Telegram chat (NULL when
 	// unlinked → the worker soft-skips telegram delivery rather than failing it).
 	GetSubscriptionForDelivery(ctx context.Context, id int64) (GetSubscriptionForDeliveryRow, error)
+	// The user's existing tailored copy for one vacancy, newest first. The tailoring bootstrap is
+	// reached by an address (/tailor/<slug>) that carries no CV reference, so a reload runs the
+	// same request again: without this read every refresh minted another copy and stranded the
+	// conversation bound to the previous one.
+	GetTailoredCVForJob(ctx context.Context, arg GetTailoredCVForJobParams) (GetTailoredCVForJobRow, error)
 	// The caller's linked Telegram chat (link-status endpoint + delivery resolution).
 	GetTelegramLink(ctx context.Context, userID int64) (TelegramLink, error)
 	// The user's cached CV ATS qualitative review (content-quality + findings), or NULL

--- a/internal/db/queries/cvs.sql
+++ b/internal/db/queries/cvs.sql
@@ -107,3 +107,14 @@ UPDATE cvs
 SET data = autopilot_undo, autopilot_undo = NULL, autopilot_report = NULL, updated_at = now()
 WHERE id = $1 AND user_id = $2 AND autopilot_undo IS NOT NULL
 RETURNING id, title, template_id, created_at, updated_at;
+
+-- name: GetTailoredCVForJob :one
+-- The user's existing tailored copy for one vacancy, newest first. The tailoring bootstrap is
+-- reached by an address (/tailor/<slug>) that carries no CV reference, so a reload runs the
+-- same request again: without this read every refresh minted another copy and stranded the
+-- conversation bound to the previous one.
+SELECT id, title, template_id, data, agent_session_id, created_at, updated_at
+FROM cvs
+WHERE user_id = $1 AND job_id = $2
+ORDER BY updated_at DESC, id DESC
+LIMIT 1;

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -63,6 +63,13 @@ func (r *cvRepo) ListTailored(context.Context, int64) ([]db.ListTailoredCVsByUse
 	return nil, nil
 }
 
+func (r *cvRepo) GetTailoredForJob(_ context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {
+	if userID != r.userID || jobID != r.jobID {
+		return db.GetTailoredCVForJobRow{}, pgx.ErrNoRows
+	}
+	return db.GetTailoredCVForJobRow{ID: r.id, Title: "CV", TemplateID: "classic-ats", Data: r.data}, nil
+}
+
 func (r *cvRepo) SnapshotForAutopilot(_ context.Context, id uuid.UUID, userID int64) (int64, error) {
 	if id != r.id || userID != r.userID {
 		return 0, nil

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -74,9 +74,19 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	if err != nil {
 		return mapCVError(err)
 	}
-	sessionID, err := h.startTailoringSession(c.Context(), userID, tailored.ID, job.ID)
+	// A reload of /tailor/<slug> re-runs this request. The CV it reaches is the one that
+	// already exists (Tailor is idempotent per vacancy), so its conversation must be reached
+	// too — minting a second session here would rebind the CV and orphan everything the
+	// candidate had already said, which is exactly what "my chat disappeared" was.
+	sessionID, err := h.existingTailoringSession(c.Context(), userID, tailored.ID)
 	if err != nil {
 		return err
+	}
+	if sessionID == "" {
+		sessionID, err = h.startTailoringSession(c.Context(), userID, tailored.ID, job.ID)
+		if err != nil {
+			return err
+		}
 	}
 	// Charge the tailor cost only once the session is fully minted, so a mint failure never
 	// leaves the caller charged for an unusable session (a retry would mint a new CV id and
@@ -89,6 +99,30 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": tailorCVResponse{
 		TailorCVID: tailored.ID.String(), BaseCVID: base.ID.String(), Analysis: analysis, SessionID: sessionID,
 	}})
+}
+
+// existingTailoringSession reports the conversation already bound to a tailored CV, or "" when
+// it has none. A session id that no longer resolves to a live conversation counts as none: the
+// binding is text on the CV, and a deleted conversation must not strand the workspace.
+func (h *cvHandlers) existingTailoringSession(ctx context.Context, userID int64, cvID uuid.UUID) (string, error) {
+	rec, err := h.cvStore.Get(ctx, cvID, userID)
+	if err != nil {
+		return "", mapCVError(err)
+	}
+	if rec.AgentSessionID == "" {
+		return "", nil
+	}
+	if h.assistantSessions == nil {
+		return rec.AgentSessionID, nil
+	}
+	id, err := uuid.Parse(rec.AgentSessionID)
+	if err != nil {
+		return "", nil
+	}
+	if _, err := h.assistantSessions.Session(ctx, id, userID); err != nil {
+		return "", nil
+	}
+	return rec.AgentSessionID, nil
 }
 
 // tailorSessionResponse re-establishes a tailoring session for an EXISTING tailored CV (one

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -427,3 +427,71 @@ func cvScopedKey(t *testing.T, h *cvHandlers, userID int64) string {
 	}
 	return token
 }
+
+// Reloading /tailor/<slug> re-runs the bootstrap: the address carries no CV reference, so the
+// page asks for a tailored CV again. That must reach the SAME CV and the SAME conversation —
+// three CVs appeared on one vacancy in half an hour on production, each with an empty chat,
+// because every refresh minted another copy and rebound the session.
+func TestTailorCVBootstrapIsIdempotentPerVacancy(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+
+	user := seedAccount(t, pool, "tailor-reload@example.test", true)
+	tok, _ := iss.Issue(user, testTokenVersion)
+	jobID := seedJobSlug(t, pool, "backend-eng")
+	seedAnalysis(t, h, user, jobID)
+	seedFreshResume(t, pool, user)
+
+	bootstrap := func() tailorCVResponse {
+		t.Helper()
+		resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "backend-eng"})
+		if resp.StatusCode != fiber.StatusCreated {
+			t.Fatalf("bootstrap = %d, want 201", resp.StatusCode)
+		}
+		var got struct {
+			Data tailorCVResponse `json:"data"`
+		}
+		json.NewDecoder(resp.Body).Decode(&got)
+		resp.Body.Close()
+		return got.Data
+	}
+
+	first := bootstrap()
+	// Something was said in that conversation, so losing it would be losing real work.
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO assistant_messages (session_id, seq, role, content)
+		 VALUES ($1, 1, 'user', '{"text":"tailor it for me"}'::jsonb)`, first.SessionID); err != nil {
+		t.Fatalf("seed a message: %v", err)
+	}
+
+	second := bootstrap()
+
+	if second.TailorCVID != first.TailorCVID {
+		t.Errorf("reload made a new CV (%s vs %s)", second.TailorCVID, first.TailorCVID)
+	}
+	if second.SessionID != first.SessionID {
+		t.Errorf("reload rebound the conversation (%s vs %s) — the candidate's messages are on the old one", second.SessionID, first.SessionID)
+	}
+
+	var cvs, sessions int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT (SELECT count(*) FROM cvs WHERE user_id = $1 AND job_id = $2),
+		        (SELECT count(*) FROM assistant_sessions WHERE user_id = $1 AND job_id = $2)`,
+		user, jobID).Scan(&cvs, &sessions); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if cvs != 1 || sessions != 1 {
+		t.Errorf("after two bootstraps: %d CVs and %d sessions, want one of each", cvs, sessions)
+	}
+
+	// And the debit happened once, not twice.
+	var debits int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM credit_ledger WHERE user_id = $1 AND kind = 'debit' AND feature = 'tailor'`,
+		user).Scan(&debits); err != nil {
+		t.Fatalf("count debits: %v", err)
+	}
+	if debits != 1 {
+		t.Errorf("tailor debits = %d, want 1 — a reload is not a second purchase", debits)
+	}
+}

--- a/openspec/changes/tailor-bootstrap-idempotent/.openspec.yaml
+++ b/openspec/changes/tailor-bootstrap-idempotent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/tailor-bootstrap-idempotent/design.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/design.md
@@ -1,0 +1,65 @@
+## Context
+
+`POST /me/cvs/tailor` was written for the CTA on the match page: press it, get a tailored copy. The
+workspace it opens is addressed `/tailor/<slug>` — by vacancy — and treats a missing `?cv=` as "no
+copy yet", so every reload repeats the create. Production shows the result: three CVs on one
+vacancy in half an hour, each with its own conversation, none with any messages except the first.
+
+The autopilot change made this visible rather than causing it. Before, the bootstrap auto-sent a
+kickoff, so the new conversation was never empty and a reload read as a restart.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reloading the workspace keeps the CV and the conversation.
+- A reload is not a second debit.
+- Back behaves as it did.
+
+**Non-Goals:**
+- Cleaning up the duplicates already created. They are ordinary tailored CVs, they show in
+  `/my/cvs`, and deleting a candidate's CVs is not something a bug fix should do quietly.
+- Making the workspace addressable by CV only. The vacancy-addressed URL is what the match CTA and
+  every existing link use.
+- A per-vacancy uniqueness constraint in the schema. The read-then-create is enough for a
+  browser-driven flow, and a UNIQUE index would turn a benign race into a 500.
+
+## Decisions
+
+### Idempotence in the store, not in the handler
+
+`cv.Store.Tailor` already owns "what does a tailored copy start from" — seeding the base, copying
+the document. "There is already one" belongs in the same place: the handler would otherwise have to
+reproduce the ordering (newest first) and the not-found mapping to ask the question.
+
+### The conversation is reused, not re-minted
+
+The handler reads the CV's bound session and mints one only when there is none. It also verifies
+the id still resolves: the binding is text on a CV row, and a conversation deleted from
+`/my/assistant` would otherwise leave the workspace pointing at nothing.
+
+### The address is corrected client-side, not by a redirect
+
+The bootstrap answers with the CV id; the page rewrites its own URL with `replaceState`. A server
+redirect would have to happen before the page knows the id, and pushing a history entry would make
+Back step between two states of the same workspace.
+
+### Not a UNIQUE constraint
+
+Two bootstraps racing (double click) can still both create. A unique index would make the loser a
+500 on a page that could simply read the winner's row. The window is small, the outcome is the old
+behaviour rather than a new failure, and the read-then-create removes the case people actually hit —
+reloading.
+
+## Risks / Trade-offs
+
+- **A candidate who WANTED a second tailored CV for the same vacancy no longer gets one from the
+  CTA** → They can copy the CV from `/my/cvs`; nothing in the product asked for two copies of one
+  vacancy, and the reported behaviour is the opposite complaint.
+- **Two simultaneous bootstraps can still duplicate** → Same as today, and the fix removes the
+  repeat case (reload) rather than the race.
+- **A stale `?cv=` in a bookmark points at a CV that was deleted** → Already handled: the resume
+  path 404s the CV and reports it, as it did before this change.
+
+## Migration Plan
+
+No schema change. Ship with the release; the duplicates already on production stay as they are.

--- a/openspec/changes/tailor-bootstrap-idempotent/proposal.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Reported from production: opening `/tailor/senior-backend-engineer-appinio-slztl4lb` and then
+reloading loses the conversation. The data says why — three tailored CVs on that one vacancy
+inside half an hour, each with its own empty conversation:
+
+```
+8efbd881…  19:38  bound session, 0 messages
+59c41575…  19:57  bound session, 0 messages
+84738209…  20:05  bound session, 0 messages
+```
+
+The workspace's address is `/tailor/<slug>`. Without a `?cv=` reference the page bootstraps, and
+`POST /me/cvs/tailor` has always created a NEW copy — so a reload mints another CV, mints another
+conversation, rebinds the CV to it, and whatever the candidate had said stays on the previous one.
+
+This predates the autopilot. It was hidden by the automatic kickoff: a fresh conversation filled
+immediately with the agent's opening, so a reload looked like a chat that had restarted rather
+than one that had vanished. Removing the self-start made the existing bug visible.
+
+## What Changes
+
+- `POST /me/cvs/tailor` becomes idempotent per (user, vacancy): it returns the existing tailored
+  CV when there is one, and the conversation already bound to it, instead of minting a second of
+  each. A different vacancy still gets its own copy.
+- A session id pointing at a conversation that no longer exists counts as no session, so a deleted
+  conversation cannot strand the workspace.
+- The workspace puts the CV in the address as soon as it has one (`?cv=<id>`, replacing the history
+  entry rather than adding one), so a reload lands in the resume path.
+- **A reload is not a second purchase** — the tailor cost is charged once per tailored CV, and a
+  reload now reaches the same CV.
+
+## Capabilities
+
+### New Capabilities
+<!-- none: this fixes existing behaviour -->
+
+### Modified Capabilities
+- `cv-tailoring`: the bootstrap reaches one tailored copy per vacancy rather than creating one per
+  request.
+- `tailor-workspace`: the workspace names its CV in the address, so a reload resumes instead of
+  bootstrapping.
+
+## Impact
+
+- **Go:** `internal/db/queries/cvs.sql` (+ regenerated sqlc), `internal/cv/store.go` (`Tailor`),
+  `internal/handler/cv_tailor.go` (reuse the bound conversation).
+- **Web:** `web/src/routes/tailor/[slug]/+page.svelte` (replace the address after bootstrap).
+- **No schema change.** The duplicate CVs already on production are left alone — they are ordinary
+  tailored CVs and show up in `/my/cvs`.

--- a/openspec/changes/tailor-bootstrap-idempotent/specs/cv-tailoring/spec.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/specs/cv-tailoring/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Tailoring starts a job-bound copy of the base CV
+
+The system SHALL, on a tailoring bootstrap request for a vacancy, reach exactly ONE tailored CV per
+(user, vacancy): it returns the caller's existing copy for that vacancy when one exists, and
+otherwise creates a new CV row bound to it (`cvs.job_id` set) whose document is copied from the
+user's base CV (`job_id = NULL`). It SHALL return the tailored CV id, the base CV id, and the
+cached fit analysis. Both ids SHALL be the CVs' unguessable ids. The base CV MUST remain unchanged
+by the bootstrap, and the tailored CV MUST be owner-scoped to the requesting user.
+
+Repeating the request MUST also reach the SAME conversation: the workspace is addressed by vacancy,
+not by CV, so a reload re-runs this request, and minting a second conversation would rebind the CV
+and orphan everything already said in the first. A bound session id that no longer resolves to a
+conversation counts as none, and a fresh one is minted.
+
+#### Scenario: Bootstrap creates a tailored copy bound to the vacancy
+
+- **WHEN** a signed-in beta user requests tailoring for a vacancy and already has a base CV
+- **THEN** a new CV is created with `job_id` set to that vacancy, its document equals the base CV's document, and the response returns both ids plus the cached analysis
+
+#### Scenario: Repeating the bootstrap reaches the same CV and conversation
+
+- **WHEN** the bootstrap is requested a second time for the same vacancy
+- **THEN** it returns the CV and the conversation the first request produced, and no second CV, conversation or debit is created
+
+#### Scenario: Another vacancy gets its own copy
+
+- **WHEN** the bootstrap is requested for a different vacancy
+- **THEN** a separate tailored CV is created for it
+
+#### Scenario: The base CV is untouched by bootstrap
+
+- **WHEN** the tailoring bootstrap creates a tailored copy
+- **THEN** the base CV's document and `updated_at` are unchanged
+
+#### Scenario: The returned ids are not guessable
+
+- **WHEN** the bootstrap responds
+- **THEN** `tailor_cv_id` and `base_cv_id` are random ids, and neither can be derived from the other or from any previously issued id

--- a/openspec/changes/tailor-bootstrap-idempotent/specs/tailor-workspace/spec.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/specs/tailor-workspace/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: The workspace names its CV in the address
+
+The workspace SHALL put the tailored CV's id into the address as soon as it has one, replacing the
+current history entry rather than adding one. Until the address names the CV, a reload is a
+bootstrap request — the page is addressed by vacancy — and the candidate is one refresh away from a
+workspace that shows none of their conversation.
+
+Replacing rather than pushing keeps Back leaving the workspace, which is where it went before.
+
+#### Scenario: A reload resumes instead of bootstrapping
+
+- **WHEN** the workspace has bootstrapped and the candidate reloads the page
+- **THEN** the address carries the CV id, so the page re-attaches to that CV and its conversation
+
+#### Scenario: Back still leaves the workspace
+
+- **WHEN** the candidate presses Back after the address gained the CV id
+- **THEN** they leave the workspace rather than stepping between two states of it

--- a/openspec/changes/tailor-bootstrap-idempotent/tasks.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/tasks.md
@@ -1,0 +1,20 @@
+## 1. One tailored copy per vacancy
+
+- [x] 1.1 Add an owner-scoped read for the caller's existing tailored CV for a vacancy (newest first); `make sqlc`
+- [x] 1.2 Return it from `cv.Store.Tailor` instead of creating a second copy, leaving a different vacancy to create its own
+- [x] 1.3 Test at the store level: two bootstraps for one vacancy reach one CV, a second vacancy gets its own
+
+## 2. One conversation per tailored CV
+
+- [x] 2.1 Reuse the conversation already bound to the CV; mint one only when there is none, or when the bound id no longer resolves
+- [x] 2.2 Integration test over real Postgres: two bootstraps, one CV, one session, one debit, and a message written after the first bootstrap survives the second
+
+## 3. The address names the CV
+
+- [x] 3.1 Replace the workspace's address with `?cv=<id>` as soon as the bootstrap answers (replaceState, no scroll, keep focus)
+- [x] 3.2 Verified by the resume path's existing tests; the markup change itself is not unit-tested (no Svelte component renderer in the web suite)
+
+## 4. Verification
+
+- [x] 4.1 `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...`, integration suites, `svelte-check`, web tests
+- [ ] 4.2 Confirm on production: open the workspace, reload, and see the same conversation — and that `/my/cvs` stops gaining a row per refresh

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -10,6 +10,7 @@
   // typing re-renders the preview instantly, autosave persists in the background, and an agent turn
   // refetches and replaces the document.
   import { onMount, onDestroy } from 'svelte';
+  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { ZoomIn, ZoomOut, Download, Menu } from '@lucide/svelte';
@@ -154,13 +155,22 @@
           sessionId = s.session_id;
         }
       } else {
-        // Bootstrap: create the tailored CV + a seeded session, then bind the session to the CV.
+        // Bootstrap: reach the tailored CV for this vacancy (the backend returns the existing
+        // one when there is one) and the conversation bound to it.
         const [j, tailor] = await Promise.all([api.getJob(slug), api.tailorCv(slug)]);
         job = j;
         cvId = tailor.tailor_cv_id;
         analysis = tailor.analysis;
         sessionId = tailor.session_id;
-        await loadCv(); // bootstrap has no CV record in hand yet — fetch the fresh tailored copy
+        await loadCv(); // bootstrap has no CV record in hand yet — fetch the tailored copy
+        // Put the CV in the address, replacing this entry rather than adding one. A reload of
+        // the bare /tailor/<slug> is a bootstrap request, and until the address names the CV
+        // the candidate is one F5 away from an empty workspace. Back still leaves the page.
+        void goto(`${resolve('/tailor/[slug]', { slug })}?cv=${cvId}`, {
+          replaceState: true,
+          noScroll: true,
+          keepFocus: true,
+        });
       }
       status = 'ready';
     } catch (e) {

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -166,6 +166,7 @@
         // Put the CV in the address, replacing this entry rather than adding one. A reload of
         // the bare /tailor/<slug> is a bootstrap request, and until the address names the CV
         // the candidate is one F5 away from an empty workspace. Back still leaves the page.
+        // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() supplies the path; the rule can't see through the appended ?cv= query
         void goto(`${resolve('/tailor/[slug]', { slug })}?cv=${cvId}`, {
           replaceState: true,
           noScroll: true,


### PR DESCRIPTION
## What and why

Reported: opening `/tailor/senior-backend-engineer-appinio-slztl4lb` and reloading loses the conversation. Production data says why — three tailored CVs on that one vacancy inside half an hour, each with its own conversation:

```
8efbd881…  19:38  bound session, 0 messages
59c41575…  19:57  bound session, 0 messages
84738209…  20:05  bound session, 0 messages
```

The workspace is addressed by VACANCY (`/tailor/<slug>`). Without a `?cv=` reference the page bootstraps, and `POST /me/cvs/tailor` has always created a new copy — so a reload mints another CV, mints another conversation, rebinds the CV to it, and whatever was said stays on the previous one.

This predates the autopilot; the autopilot only made it visible. Before, the bootstrap auto-sent a kickoff, so the new conversation was never empty and a reload read as a restart rather than as a loss.

## The fix, in three parts

1. **`POST /me/cvs/tailor` is idempotent per (user, vacancy).** `cv.Store.Tailor` returns the existing tailored copy when there is one. A different vacancy still gets its own.
2. **The conversation is reused, not re-minted.** The handler reads the CV's bound session and mints only when there is none — or when the bound id no longer resolves to a live conversation, so a chat deleted from `/my/assistant` cannot strand the workspace.
3. **The address names the CV as soon as the bootstrap answers** (`?cv=<id>` via `replaceState`), so a reload lands in the resume path. Replacing rather than pushing keeps Back leaving the workspace.

A reload is also no longer a second debit: the tailor cost is charged per tailored CV, and a reload now reaches the same one.

## Deliberately not done

- **The duplicates already on production are left alone.** They are ordinary tailored CVs and appear in `/my/cvs`; deleting a candidate's CVs is not something a bug fix should do quietly.
- **No UNIQUE (user, job) index.** Two bootstraps racing on a double click can still both create — the outcome is today's behaviour, whereas a unique index would turn the loser into a 500 on a page that could just read the winner's row. The read-then-create removes the case people actually hit.

## Verification

`go build` / `go vet` / `gofmt` clean, `go test ./...` green, integration suites over real Postgres green, `svelte-check` 0 errors, 466 web tests.

The integration test is the reported scenario: bootstrap, write a message into the conversation, bootstrap again — one CV, one session, one debit, and the message still there.

One incidental diff: `internal/db/jobs.sql.go` picked up a comment that its source `.sql` already carried but the generated file did not — `make sqlc` brought them back into sync. No behaviour change.

OpenSpec: `openspec/changes/tailor-bootstrap-idempotent/`.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [x] I regenerated committed artifacts when their source changed (`make sqlc`).
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: `svelte-check` and the web tests pass.
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.
