### PR TITLE
fix(tailor): an empty conversation shows the way in, and the active pane is legible

### DIFF
--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -77,6 +77,7 @@ type Repository interface {
 	SnapshotForAutopilot(ctx context.Context, id uuid.UUID, userID int64) (int64, error)
 	SetAutopilotReport(ctx context.Context, id uuid.UUID, userID int64, report []byte) (int64, error)
 	RevertAutopilot(ctx context.Context, id uuid.UUID, userID int64) (db.RevertCVAutopilotRow, error)
+	GetTailoredForJob(ctx context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error)
 }
 
 // Seeder provides the user's extracted résumé, used to seed a base CV when they have none.
@@ -321,11 +322,32 @@ func (s *Store) Tailor(ctx context.Context, userID, jobID int64, tailoredTitle s
 		}
 		base = Record{Meta: meta, Document: doc}
 	}
+	// One tailored copy per vacancy. The workspace's address carries no CV reference, so a
+	// reload re-runs this exact request; minting a second copy leaves the candidate's
+	// conversation bound to the first one, which is what "my chat disappeared" looks like.
+	if existing, err := s.tailoredForJob(ctx, userID, jobID); err == nil {
+		return base.Meta, existing, nil
+	} else if !errors.Is(err, ErrNotFound) {
+		return Meta{}, Meta{}, err
+	}
+
 	tailored, err := s.CreateTailored(ctx, userID, jobID, tailoredTitle, base.TemplateID, base.Document)
 	if err != nil {
 		return Meta{}, Meta{}, err
 	}
 	return base.Meta, tailored, nil
+}
+
+// tailoredForJob returns the user's existing tailored copy for a vacancy, or ErrNotFound.
+func (s *Store) tailoredForJob(ctx context.Context, userID, jobID int64) (Meta, error) {
+	row, err := s.repo.GetTailoredForJob(ctx, userID, jobID)
+	if err != nil {
+		return Meta{}, mapNotFound(err)
+	}
+	return Meta{
+		ID: row.ID, Title: row.Title, TemplateID: row.TemplateID,
+		CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time,
+	}, nil
 }
 
 // defaultBaseTitle names a base CV seeded from the résumé (the user can rename it later).
@@ -414,4 +436,10 @@ func (r queriesRepository) SetAutopilotReport(ctx context.Context, id uuid.UUID,
 
 func (r queriesRepository) RevertAutopilot(ctx context.Context, id uuid.UUID, userID int64) (db.RevertCVAutopilotRow, error) {
 	return r.q.RevertCVAutopilot(ctx, db.RevertCVAutopilotParams{ID: id, UserID: userID})
+}
+
+func (r queriesRepository) GetTailoredForJob(ctx context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {
+	return r.q.GetTailoredCVForJob(ctx, db.GetTailoredCVForJobParams{
+		UserID: userID, JobID: pgtype.Int8{Int64: jobID, Valid: true},
+	})
 }

--- a/internal/cv/store_tailor_test.go
+++ b/internal/cv/store_tailor_test.go
@@ -123,3 +123,41 @@ func TestStoreTailorUsesExistingBaseUntouched(t *testing.T) {
 		t.Errorf("tailored doc != base doc")
 	}
 }
+
+// Tailoring the SAME vacancy twice must reach the same tailored CV.
+//
+// The workspace opens at /tailor/<slug>, and without a `?cv` reference that address is a
+// bootstrap. So every reload used to mint another copy: three CVs for one vacancy in half an
+// hour on production, each with its own empty conversation, and the candidate's actual chat
+// stranded on the first of them. The bootstrap is the same request either way — it has to be
+// idempotent per (user, vacancy).
+func TestStoreTailorReturnsTheExistingCopyForTheSameVacancy(t *testing.T) {
+	repo := newFakeRepo()
+	s := NewStore(repo)
+	ctx := context.Background()
+
+	if _, err := s.Create(ctx, 7, "My CV", DefaultTemplateID, Document{Summary: "base"}); err != nil {
+		t.Fatalf("seed base: %v", err)
+	}
+
+	_, first, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	if err != nil {
+		t.Fatalf("first tailor: %v", err)
+	}
+	_, second, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	if err != nil {
+		t.Fatalf("second tailor: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Errorf("second bootstrap made a new CV (%s vs %s); the candidate's conversation is bound to the first", second.ID, first.ID)
+	}
+
+	// A DIFFERENT vacancy still gets its own copy.
+	_, other, err := s.Tailor(ctx, 7, 200, "Tailored", fakeSeeder{ok: false})
+	if err != nil {
+		t.Fatalf("other tailor: %v", err)
+	}
+	if other.ID == first.ID {
+		t.Error("a second vacancy reused the first vacancy's tailored CV")
+	}
+}

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -285,3 +285,26 @@ func (f *fakeRepo) RevertAutopilot(_ context.Context, id uuid.UUID, userID int64
 	f.rows[id] = r
 	return db.RevertCVAutopilotRow{ID: id, Title: r.title, TemplateID: r.templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
+
+func (f *fakeRepo) GetTailoredForJob(_ context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {
+	// Newest by insertion order, mirroring the query's `updated_at DESC, id DESC`.
+	var bestID uuid.UUID
+	var best *fakeRow
+	for id, r := range f.rows {
+		row := r
+		if row.userID != userID || row.jobID != jobID {
+			continue
+		}
+		if best == nil || row.seq > best.seq {
+			best, bestID = &row, id
+		}
+	}
+	if best == nil {
+		return db.GetTailoredCVForJobRow{}, pgx.ErrNoRows
+	}
+	return db.GetTailoredCVForJobRow{
+		ID: bestID, Title: best.title, TemplateID: best.templateID, Data: best.data,
+		AgentSessionID: pgtype.Text{String: best.sessionID, Valid: best.sessionID != ""},
+		CreatedAt:      stamp(), UpdatedAt: stamp(),
+	}, nil
+}

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -200,6 +200,48 @@ func (q *Queries) GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByID
 	return i, err
 }
 
+const getTailoredCVForJob = `-- name: GetTailoredCVForJob :one
+SELECT id, title, template_id, data, agent_session_id, created_at, updated_at
+FROM cvs
+WHERE user_id = $1 AND job_id = $2
+ORDER BY updated_at DESC, id DESC
+LIMIT 1
+`
+
+type GetTailoredCVForJobParams struct {
+	UserID int64       `json:"user_id"`
+	JobID  pgtype.Int8 `json:"job_id"`
+}
+
+type GetTailoredCVForJobRow struct {
+	ID             uuid.UUID          `json:"id"`
+	Title          string             `json:"title"`
+	TemplateID     string             `json:"template_id"`
+	Data           []byte             `json:"data"`
+	AgentSessionID pgtype.Text        `json:"agent_session_id"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+}
+
+// The user's existing tailored copy for one vacancy, newest first. The tailoring bootstrap is
+// reached by an address (/tailor/<slug>) that carries no CV reference, so a reload runs the
+// same request again: without this read every refresh minted another copy and stranded the
+// conversation bound to the previous one.
+func (q *Queries) GetTailoredCVForJob(ctx context.Context, arg GetTailoredCVForJobParams) (GetTailoredCVForJobRow, error) {
+	row := q.db.QueryRow(ctx, getTailoredCVForJob, arg.UserID, arg.JobID)
+	var i GetTailoredCVForJobRow
+	err := row.Scan(
+		&i.ID,
+		&i.Title,
+		&i.TemplateID,
+		&i.Data,
+		&i.AgentSessionID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listCVsByUser = `-- name: ListCVsByUser :many
 SELECT id, title, template_id, created_at, updated_at
 FROM cvs

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -43,7 +43,9 @@ type CanonicalJobForRoleRow struct {
 // agree rather than fight.
 // A canon must be open AND not itself a duplicate, or marking would build a chain (A -> B -> C)
 // that no reader expects. The row being written is excluded by its own dedup identity, because
-// a re-import of the same URL would otherwise find itself. Served by jobs_company_slug_idx.
+// a re-import of the same URL would otherwise find itself. Served by the partial
+// jobs_open_role_cluster_idx (migration 0013), with jobs_company_role_fingerprint_idx as the
+// non-partial fallback.
 func (q *Queries) CanonicalJobForRole(ctx context.Context, arg CanonicalJobForRoleParams) (CanonicalJobForRoleRow, error) {
 	row := q.db.QueryRow(ctx, canonicalJobForRole,
 		arg.CompanySlug,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -76,7 +76,9 @@ type Querier interface {
 	// agree rather than fight.
 	// A canon must be open AND not itself a duplicate, or marking would build a chain (A -> B -> C)
 	// that no reader expects. The row being written is excluded by its own dedup identity, because
-	// a re-import of the same URL would otherwise find itself. Served by jobs_company_slug_idx.
+	// a re-import of the same URL would otherwise find itself. Served by the partial
+	// jobs_open_role_cluster_idx (migration 0013), with jobs_company_role_fingerprint_idx as the
+	// non-partial fallback.
 	CanonicalJobForRole(ctx context.Context, arg CanonicalJobForRoleParams) (CanonicalJobForRoleRow, error)
 	// Lease a batch of due, pending reminders by stamping claimed_at, earliest deadline
 	// first. FOR UPDATE OF r + SKIP LOCKED lets overlapping worker passes take disjoint
@@ -727,6 +729,11 @@ type Querier interface {
 	// channel's live recipient), and the user's linked Telegram chat (NULL when
 	// unlinked → the worker soft-skips telegram delivery rather than failing it).
 	GetSubscriptionForDelivery(ctx context.Context, id int64) (GetSubscriptionForDeliveryRow, error)
+	// The user's existing tailored copy for one vacancy, newest first. The tailoring bootstrap is
+	// reached by an address (/tailor/<slug>) that carries no CV reference, so a reload runs the
+	// same request again: without this read every refresh minted another copy and stranded the
+	// conversation bound to the previous one.
+	GetTailoredCVForJob(ctx context.Context, arg GetTailoredCVForJobParams) (GetTailoredCVForJobRow, error)
 	// The caller's linked Telegram chat (link-status endpoint + delivery resolution).
 	GetTelegramLink(ctx context.Context, userID int64) (TelegramLink, error)
 	// The user's cached CV ATS qualitative review (content-quality + findings), or NULL

--- a/internal/db/queries/cvs.sql
+++ b/internal/db/queries/cvs.sql
@@ -107,3 +107,14 @@ UPDATE cvs
 SET data = autopilot_undo, autopilot_undo = NULL, autopilot_report = NULL, updated_at = now()
 WHERE id = $1 AND user_id = $2 AND autopilot_undo IS NOT NULL
 RETURNING id, title, template_id, created_at, updated_at;
+
+-- name: GetTailoredCVForJob :one
+-- The user's existing tailored copy for one vacancy, newest first. The tailoring bootstrap is
+-- reached by an address (/tailor/<slug>) that carries no CV reference, so a reload runs the
+-- same request again: without this read every refresh minted another copy and stranded the
+-- conversation bound to the previous one.
+SELECT id, title, template_id, data, agent_session_id, created_at, updated_at
+FROM cvs
+WHERE user_id = $1 AND job_id = $2
+ORDER BY updated_at DESC, id DESC
+LIMIT 1;

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -63,6 +63,13 @@ func (r *cvRepo) ListTailored(context.Context, int64) ([]db.ListTailoredCVsByUse
 	return nil, nil
 }
 
+func (r *cvRepo) GetTailoredForJob(_ context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {
+	if userID != r.userID || jobID != r.jobID {
+		return db.GetTailoredCVForJobRow{}, pgx.ErrNoRows
+	}
+	return db.GetTailoredCVForJobRow{ID: r.id, Title: "CV", TemplateID: "classic-ats", Data: r.data}, nil
+}
+
 func (r *cvRepo) SnapshotForAutopilot(_ context.Context, id uuid.UUID, userID int64) (int64, error) {
 	if id != r.id || userID != r.userID {
 		return 0, nil

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -74,9 +74,19 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	if err != nil {
 		return mapCVError(err)
 	}
-	sessionID, err := h.startTailoringSession(c.Context(), userID, tailored.ID, job.ID)
+	// A reload of /tailor/<slug> re-runs this request. The CV it reaches is the one that
+	// already exists (Tailor is idempotent per vacancy), so its conversation must be reached
+	// too — minting a second session here would rebind the CV and orphan everything the
+	// candidate had already said, which is exactly what "my chat disappeared" was.
+	sessionID, err := h.existingTailoringSession(c.Context(), userID, tailored.ID)
 	if err != nil {
 		return err
+	}
+	if sessionID == "" {
+		sessionID, err = h.startTailoringSession(c.Context(), userID, tailored.ID, job.ID)
+		if err != nil {
+			return err
+		}
 	}
 	// Charge the tailor cost only once the session is fully minted, so a mint failure never
 	// leaves the caller charged for an unusable session (a retry would mint a new CV id and
@@ -89,6 +99,30 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": tailorCVResponse{
 		TailorCVID: tailored.ID.String(), BaseCVID: base.ID.String(), Analysis: analysis, SessionID: sessionID,
 	}})
+}
+
+// existingTailoringSession reports the conversation already bound to a tailored CV, or "" when
+// it has none. A session id that no longer resolves to a live conversation counts as none: the
+// binding is text on the CV, and a deleted conversation must not strand the workspace.
+func (h *cvHandlers) existingTailoringSession(ctx context.Context, userID int64, cvID uuid.UUID) (string, error) {
+	rec, err := h.cvStore.Get(ctx, cvID, userID)
+	if err != nil {
+		return "", mapCVError(err)
+	}
+	if rec.AgentSessionID == "" {
+		return "", nil
+	}
+	if h.assistantSessions == nil {
+		return rec.AgentSessionID, nil
+	}
+	id, err := uuid.Parse(rec.AgentSessionID)
+	if err != nil {
+		return "", nil
+	}
+	if _, err := h.assistantSessions.Session(ctx, id, userID); err != nil {
+		return "", nil
+	}
+	return rec.AgentSessionID, nil
 }
 
 // tailorSessionResponse re-establishes a tailoring session for an EXISTING tailored CV (one

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -427,3 +427,71 @@ func cvScopedKey(t *testing.T, h *cvHandlers, userID int64) string {
 	}
 	return token
 }
+
+// Reloading /tailor/<slug> re-runs the bootstrap: the address carries no CV reference, so the
+// page asks for a tailored CV again. That must reach the SAME CV and the SAME conversation —
+// three CVs appeared on one vacancy in half an hour on production, each with an empty chat,
+// because every refresh minted another copy and rebound the session.
+func TestTailorCVBootstrapIsIdempotentPerVacancy(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+
+	user := seedAccount(t, pool, "tailor-reload@example.test", true)
+	tok, _ := iss.Issue(user, testTokenVersion)
+	jobID := seedJobSlug(t, pool, "backend-eng")
+	seedAnalysis(t, h, user, jobID)
+	seedFreshResume(t, pool, user)
+
+	bootstrap := func() tailorCVResponse {
+		t.Helper()
+		resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "backend-eng"})
+		if resp.StatusCode != fiber.StatusCreated {
+			t.Fatalf("bootstrap = %d, want 201", resp.StatusCode)
+		}
+		var got struct {
+			Data tailorCVResponse `json:"data"`
+		}
+		json.NewDecoder(resp.Body).Decode(&got)
+		resp.Body.Close()
+		return got.Data
+	}
+
+	first := bootstrap()
+	// Something was said in that conversation, so losing it would be losing real work.
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO assistant_messages (session_id, seq, role, content)
+		 VALUES ($1, 1, 'user', '{"text":"tailor it for me"}'::jsonb)`, first.SessionID); err != nil {
+		t.Fatalf("seed a message: %v", err)
+	}
+
+	second := bootstrap()
+
+	if second.TailorCVID != first.TailorCVID {
+		t.Errorf("reload made a new CV (%s vs %s)", second.TailorCVID, first.TailorCVID)
+	}
+	if second.SessionID != first.SessionID {
+		t.Errorf("reload rebound the conversation (%s vs %s) — the candidate's messages are on the old one", second.SessionID, first.SessionID)
+	}
+
+	var cvs, sessions int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT (SELECT count(*) FROM cvs WHERE user_id = $1 AND job_id = $2),
+		        (SELECT count(*) FROM assistant_sessions WHERE user_id = $1 AND job_id = $2)`,
+		user, jobID).Scan(&cvs, &sessions); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if cvs != 1 || sessions != 1 {
+		t.Errorf("after two bootstraps: %d CVs and %d sessions, want one of each", cvs, sessions)
+	}
+
+	// And the debit happened once, not twice.
+	var debits int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM credit_ledger WHERE user_id = $1 AND kind = 'debit' AND feature = 'tailor'`,
+		user).Scan(&debits); err != nil {
+		t.Fatalf("count debits: %v", err)
+	}
+	if debits != 1 {
+		t.Errorf("tailor debits = %d, want 1 — a reload is not a second purchase", debits)
+	}
+}

--- a/openspec/changes/tailor-bootstrap-idempotent/.openspec.yaml
+++ b/openspec/changes/tailor-bootstrap-idempotent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/tailor-bootstrap-idempotent/design.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/design.md
@@ -1,0 +1,65 @@
+## Context
+
+`POST /me/cvs/tailor` was written for the CTA on the match page: press it, get a tailored copy. The
+workspace it opens is addressed `/tailor/<slug>` — by vacancy — and treats a missing `?cv=` as "no
+copy yet", so every reload repeats the create. Production shows the result: three CVs on one
+vacancy in half an hour, each with its own conversation, none with any messages except the first.
+
+The autopilot change made this visible rather than causing it. Before, the bootstrap auto-sent a
+kickoff, so the new conversation was never empty and a reload read as a restart.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reloading the workspace keeps the CV and the conversation.
+- A reload is not a second debit.
+- Back behaves as it did.
+
+**Non-Goals:**
+- Cleaning up the duplicates already created. They are ordinary tailored CVs, they show in
+  `/my/cvs`, and deleting a candidate's CVs is not something a bug fix should do quietly.
+- Making the workspace addressable by CV only. The vacancy-addressed URL is what the match CTA and
+  every existing link use.
+- A per-vacancy uniqueness constraint in the schema. The read-then-create is enough for a
+  browser-driven flow, and a UNIQUE index would turn a benign race into a 500.
+
+## Decisions
+
+### Idempotence in the store, not in the handler
+
+`cv.Store.Tailor` already owns "what does a tailored copy start from" — seeding the base, copying
+the document. "There is already one" belongs in the same place: the handler would otherwise have to
+reproduce the ordering (newest first) and the not-found mapping to ask the question.
+
+### The conversation is reused, not re-minted
+
+The handler reads the CV's bound session and mints one only when there is none. It also verifies
+the id still resolves: the binding is text on a CV row, and a conversation deleted from
+`/my/assistant` would otherwise leave the workspace pointing at nothing.
+
+### The address is corrected client-side, not by a redirect
+
+The bootstrap answers with the CV id; the page rewrites its own URL with `replaceState`. A server
+redirect would have to happen before the page knows the id, and pushing a history entry would make
+Back step between two states of the same workspace.
+
+### Not a UNIQUE constraint
+
+Two bootstraps racing (double click) can still both create. A unique index would make the loser a
+500 on a page that could simply read the winner's row. The window is small, the outcome is the old
+behaviour rather than a new failure, and the read-then-create removes the case people actually hit —
+reloading.
+
+## Risks / Trade-offs
+
+- **A candidate who WANTED a second tailored CV for the same vacancy no longer gets one from the
+  CTA** → They can copy the CV from `/my/cvs`; nothing in the product asked for two copies of one
+  vacancy, and the reported behaviour is the opposite complaint.
+- **Two simultaneous bootstraps can still duplicate** → Same as today, and the fix removes the
+  repeat case (reload) rather than the race.
+- **A stale `?cv=` in a bookmark points at a CV that was deleted** → Already handled: the resume
+  path 404s the CV and reports it, as it did before this change.
+
+## Migration Plan
+
+No schema change. Ship with the release; the duplicates already on production stay as they are.

--- a/openspec/changes/tailor-bootstrap-idempotent/proposal.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Reported from production: opening `/tailor/senior-backend-engineer-appinio-slztl4lb` and then
+reloading loses the conversation. The data says why — three tailored CVs on that one vacancy
+inside half an hour, each with its own empty conversation:
+
+```
+8efbd881…  19:38  bound session, 0 messages
+59c41575…  19:57  bound session, 0 messages
+84738209…  20:05  bound session, 0 messages
+```
+
+The workspace's address is `/tailor/<slug>`. Without a `?cv=` reference the page bootstraps, and
+`POST /me/cvs/tailor` has always created a NEW copy — so a reload mints another CV, mints another
+conversation, rebinds the CV to it, and whatever the candidate had said stays on the previous one.
+
+This predates the autopilot. It was hidden by the automatic kickoff: a fresh conversation filled
+immediately with the agent's opening, so a reload looked like a chat that had restarted rather
+than one that had vanished. Removing the self-start made the existing bug visible.
+
+## What Changes
+
+- `POST /me/cvs/tailor` becomes idempotent per (user, vacancy): it returns the existing tailored
+  CV when there is one, and the conversation already bound to it, instead of minting a second of
+  each. A different vacancy still gets its own copy.
+- A session id pointing at a conversation that no longer exists counts as no session, so a deleted
+  conversation cannot strand the workspace.
+- The workspace puts the CV in the address as soon as it has one (`?cv=<id>`, replacing the history
+  entry rather than adding one), so a reload lands in the resume path.
+- **A reload is not a second purchase** — the tailor cost is charged once per tailored CV, and a
+  reload now reaches the same CV.
+
+## Capabilities
+
+### New Capabilities
+<!-- none: this fixes existing behaviour -->
+
+### Modified Capabilities
+- `cv-tailoring`: the bootstrap reaches one tailored copy per vacancy rather than creating one per
+  request.
+- `tailor-workspace`: the workspace names its CV in the address, so a reload resumes instead of
+  bootstrapping.
+
+## Impact
+
+- **Go:** `internal/db/queries/cvs.sql` (+ regenerated sqlc), `internal/cv/store.go` (`Tailor`),
+  `internal/handler/cv_tailor.go` (reuse the bound conversation).
+- **Web:** `web/src/routes/tailor/[slug]/+page.svelte` (replace the address after bootstrap).
+- **No schema change.** The duplicate CVs already on production are left alone — they are ordinary
+  tailored CVs and show up in `/my/cvs`.

--- a/openspec/changes/tailor-bootstrap-idempotent/specs/cv-tailoring/spec.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/specs/cv-tailoring/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Tailoring starts a job-bound copy of the base CV
+
+The system SHALL, on a tailoring bootstrap request for a vacancy, reach exactly ONE tailored CV per
+(user, vacancy): it returns the caller's existing copy for that vacancy when one exists, and
+otherwise creates a new CV row bound to it (`cvs.job_id` set) whose document is copied from the
+user's base CV (`job_id = NULL`). It SHALL return the tailored CV id, the base CV id, and the
+cached fit analysis. Both ids SHALL be the CVs' unguessable ids. The base CV MUST remain unchanged
+by the bootstrap, and the tailored CV MUST be owner-scoped to the requesting user.
+
+Repeating the request MUST also reach the SAME conversation: the workspace is addressed by vacancy,
+not by CV, so a reload re-runs this request, and minting a second conversation would rebind the CV
+and orphan everything already said in the first. A bound session id that no longer resolves to a
+conversation counts as none, and a fresh one is minted.
+
+#### Scenario: Bootstrap creates a tailored copy bound to the vacancy
+
+- **WHEN** a signed-in beta user requests tailoring for a vacancy and already has a base CV
+- **THEN** a new CV is created with `job_id` set to that vacancy, its document equals the base CV's document, and the response returns both ids plus the cached analysis
+
+#### Scenario: Repeating the bootstrap reaches the same CV and conversation
+
+- **WHEN** the bootstrap is requested a second time for the same vacancy
+- **THEN** it returns the CV and the conversation the first request produced, and no second CV, conversation or debit is created
+
+#### Scenario: Another vacancy gets its own copy
+
+- **WHEN** the bootstrap is requested for a different vacancy
+- **THEN** a separate tailored CV is created for it
+
+#### Scenario: The base CV is untouched by bootstrap
+
+- **WHEN** the tailoring bootstrap creates a tailored copy
+- **THEN** the base CV's document and `updated_at` are unchanged
+
+#### Scenario: The returned ids are not guessable
+
+- **WHEN** the bootstrap responds
+- **THEN** `tailor_cv_id` and `base_cv_id` are random ids, and neither can be derived from the other or from any previously issued id

--- a/openspec/changes/tailor-bootstrap-idempotent/specs/tailor-workspace/spec.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/specs/tailor-workspace/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: The workspace names its CV in the address
+
+The workspace SHALL put the tailored CV's id into the address as soon as it has one, replacing the
+current history entry rather than adding one. Until the address names the CV, a reload is a
+bootstrap request — the page is addressed by vacancy — and the candidate is one refresh away from a
+workspace that shows none of their conversation.
+
+Replacing rather than pushing keeps Back leaving the workspace, which is where it went before.
+
+#### Scenario: A reload resumes instead of bootstrapping
+
+- **WHEN** the workspace has bootstrapped and the candidate reloads the page
+- **THEN** the address carries the CV id, so the page re-attaches to that CV and its conversation
+
+#### Scenario: Back still leaves the workspace
+
+- **WHEN** the candidate presses Back after the address gained the CV id
+- **THEN** they leave the workspace rather than stepping between two states of it

--- a/openspec/changes/tailor-bootstrap-idempotent/tasks.md
+++ b/openspec/changes/tailor-bootstrap-idempotent/tasks.md
@@ -1,0 +1,20 @@
+## 1. One tailored copy per vacancy
+
+- [x] 1.1 Add an owner-scoped read for the caller's existing tailored CV for a vacancy (newest first); `make sqlc`
+- [x] 1.2 Return it from `cv.Store.Tailor` instead of creating a second copy, leaving a different vacancy to create its own
+- [x] 1.3 Test at the store level: two bootstraps for one vacancy reach one CV, a second vacancy gets its own
+
+## 2. One conversation per tailored CV
+
+- [x] 2.1 Reuse the conversation already bound to the CV; mint one only when there is none, or when the bound id no longer resolves
+- [x] 2.2 Integration test over real Postgres: two bootstraps, one CV, one session, one debit, and a message written after the first bootstrap survives the second
+
+## 3. The address names the CV
+
+- [x] 3.1 Replace the workspace's address with `?cv=<id>` as soon as the bootstrap answers (replaceState, no scroll, keep focus)
+- [x] 3.2 Verified by the resume path's existing tests; the markup change itself is not unit-tested (no Svelte component renderer in the web suite)
+
+## 4. Verification
+
+- [x] 4.1 `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...`, integration suites, `svelte-check`, web tests
+- [ ] 4.2 Confirm on production: open the workspace, reload, and see the same conversation — and that `/my/cvs` stops gaining a row per refresh

--- a/openspec/changes/tailor-workspace-orientation/.openspec.yaml
+++ b/openspec/changes/tailor-workspace-orientation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/tailor-workspace-orientation/design.md
+++ b/openspec/changes/tailor-workspace-orientation/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Reported while using the workspace on production, with a screenshot: a CV opened by id showed
+"Ask the agent anything to get started" and no actions, and the active tab was indistinguishable
+from the inactive ones.
+
+The first is a defect in the change that introduced the actions: they were gated on `resuming`,
+a page-level flag meaning "opened with `?cv=`". The chat component already renders them only while
+`chat.messages.length === 0`, so the flag was a second gate on the same question — and the two
+disagree exactly when a bound conversation is empty, which is what a bootstrap leaves behind if
+nobody presses anything.
+
+## Goals / Non-Goals
+
+**Goals:**
+- An empty conversation always shows the way in, however it was reached.
+- The current pane is obvious at a glance.
+- The three sections people open mid-task are reachable without a detour.
+
+**Non-Goals:**
+- A general tab component. Two panels share a pattern; a third would be the time to extract one.
+- Renaming routes. `/my/cvs` stays — the label changes, the address does not.
+- Reordering the account navigation.
+
+## Decisions
+
+### One gate, in the component that renders
+
+`openingFor(resuming)` becomes `openingActions()`. The host says WHAT it offers; the chat decides
+WHEN, from the only state that matters (are there messages?). Two components answering the same
+question is what produced the bug.
+
+### The brand tint, not a darker grey
+
+The palette's brand colour is already the olive (`--brand: #5b6f00`, with `--brand-muted` as its
+soft tint and `--brand-strong` for readable text on it). Using it for the selected tab keeps the
+selection consistent with every other "this one is chosen" affordance in the product, and needs no
+new token.
+
+### The header menu duplicates three sections, not all of them
+
+Inbox was already there. Agent and Tailor join it because they are opened from a job page, a search,
+or nothing in particular — the rest of the account sections are destinations you go to deliberately.
+
+## Risks / Trade-offs
+
+- **A longer header menu** → Three more rows on a menu that already scrolls on mobile, against a
+  saved navigation each time; the sections chosen are the ones with the traffic.
+- **"Tailor" as a noun is a little odd in English** → It matches the workspace it opens
+  (`/tailor/<slug>`) and the verb the product uses everywhere else for this action.

--- a/openspec/changes/tailor-workspace-orientation/proposal.md
+++ b/openspec/changes/tailor-workspace-orientation/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Three things reported from using the tailoring workspace on production:
+
+1. **A CV opened by id showed an empty chat with no way in.** The two opening actions were keyed
+   on "this is a fresh workspace", but a CV re-opened by `?cv=` can carry a conversation bound at
+   bootstrap that nobody ever spoke to. That case rendered "Ask the agent anything to get started"
+   and nothing else — indistinguishable from a chat whose history had been lost.
+2. **The active tab was not readable as active.** Editor / Settings / Chat marked the current one
+   with `bg-muted`, which against the panel's own background is nearly invisible: you cannot tell
+   which pane you are looking at.
+3. **The account section was still called "CV builder"**, and the agent and the tailoring list were
+   reachable only from inside the account shell, while the inbox was duplicated in the header menu.
+
+## What Changes
+
+- The workspace offers its two actions whenever the conversation is EMPTY, not only when it was
+  just bootstrapped. The chat already renders them only while there are no messages, so the
+  "resuming" condition was a second, wrong gate on the same thing.
+- The active tab in both the left panel and the artifact panel is marked with the brand tint
+  (the palette's olive) and a heavier weight, rather than a barely-visible grey.
+- The account section is renamed **Tailor** — every CV in it is aimed at one vacancy, and
+  "CV builder" named the tool it grew out of.
+- The header menu duplicates **Agent** and **Tailor** beside the inbox it already carried, so the
+  three things opened from anywhere are reachable from anywhere.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `tailor-workspace`: the opening actions follow an empty conversation rather than a fresh
+  workspace, and the active tab is legible.
+- `account-navigation`: the tailoring section's name, and which sections the header menu repeats.
+
+## Impact
+
+- **Web only:** `web/src/lib/tailor/autopilot.ts` (`openingFor` → `openingActions`),
+  `web/src/routes/tailor/[slug]/+page.svelte`, `web/src/lib/tailor/ArtifactPanel.svelte`,
+  `web/src/lib/accountNav.ts`, `web/src/lib/components/HeaderMenu.svelte`.
+- No API, schema or backend change.

--- a/openspec/changes/tailor-workspace-orientation/specs/account-navigation/spec.md
+++ b/openspec/changes/tailor-workspace-orientation/specs/account-navigation/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: The header menu repeats what is opened from anywhere
+
+The header menu SHALL carry the account sections a user reaches from outside the account shell —
+the mail inbox, the agent, and the tailoring list — alongside its own links. These three are opened
+in the middle of other work, so requiring a trip through the account shell to reach them costs a
+navigation for no reason. The remaining sections stay in the account navigation only.
+
+#### Scenario: The agent and the tailoring list are one click from anywhere
+
+- **WHEN** a signed-in user opens the header menu from any page
+- **THEN** it lists the inbox, the agent and the tailoring section among its account links
+
+### Requirement: The tailoring section is named for its purpose
+
+The account navigation SHALL name the section holding vacancy-bound CVs **Tailor**. Every CV it
+lists is aimed at one posting; the earlier name described the CV-building tool the section grew out
+of rather than what a user comes here to do.
+
+#### Scenario: The section reads as Tailor
+
+- **WHEN** the account navigation is rendered
+- **THEN** the `/my/cvs` section is labelled "Tailor"

--- a/openspec/changes/tailor-workspace-orientation/specs/tailor-workspace/spec.md
+++ b/openspec/changes/tailor-workspace-orientation/specs/tailor-workspace/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: The tailoring workspace resumes an existing session
+
+The system SHALL, when `/tailor/[slug]` is opened for an existing tailored CV (`?cv=<id>`),
+re-attach to that CV's stored agent session WITHOUT bootstrapping a new CV or sending a kickoff
+prompt. Opening `/tailor/[slug]` without a CV reference SHALL reach the tailored CV for that
+vacancy and the conversation bound to it. A session MUST NOT start talking on its own: while its
+conversation holds NO messages, the chat SHALL offer two actions — running the tailoring
+unattended, or walking the gaps in conversation — and the turn begins when one is chosen.
+
+The offer follows the conversation being empty, not the workspace being new. A CV re-opened by id
+can carry a conversation nobody has spoken to, and leaving that case without actions makes it
+indistinguishable from a conversation whose history was lost.
+
+#### Scenario: Re-opening a CV continues its conversation
+
+- **WHEN** a user opens the workspace for an existing tailored CV
+- **THEN** the existing agent session is attached (its prior messages replay) and no new session or kickoff is created
+
+#### Scenario: Opening without a CV reaches the vacancy's CV
+
+- **WHEN** a user opens the workspace from the match CTA (no CV reference)
+- **THEN** the tailored CV for that vacancy and its bound conversation are attached, and the empty chat offers the two actions without sending anything
+
+#### Scenario: An empty resumed conversation still offers the way in
+
+- **WHEN** a user opens a tailored CV by id whose conversation holds no messages
+- **THEN** the chat offers the same two actions rather than an empty pane
+
+#### Scenario: Choosing an action starts the turn
+
+- **WHEN** the user picks one of the two actions in the empty chat
+- **THEN** the corresponding turn runs — the unattended run, or the conversational walkthrough
+
+## ADDED Requirements
+
+### Requirement: The active pane is legible
+
+The workspace SHALL mark the selected tab of each tabbed panel so it is unmistakable at a glance,
+using the brand tint and a heavier weight rather than a fill that reads as background. A
+three-column surface where the current pane is ambiguous costs the user the orientation the tabs
+exist to give.
+
+#### Scenario: The selected tab stands out
+
+- **WHEN** a panel's tab is selected
+- **THEN** it is rendered with the brand tint and heavier weight, and the unselected tabs are not

--- a/openspec/changes/tailor-workspace-orientation/tasks.md
+++ b/openspec/changes/tailor-workspace-orientation/tasks.md
@@ -1,0 +1,18 @@
+## 1. An empty conversation always offers the way in
+
+- [x] 1.1 Replace `openingFor(resuming)` with `openingActions()` and have the workspace pass it unconditionally
+- [x] 1.2 Update the unit tests to the new contract: the actions are offered regardless of how the workspace was opened, and still send nothing by themselves
+
+## 2. The active pane is legible
+
+- [x] 2.1 Mark the selected tab with the brand tint and heavier weight in the left panel and the artifact panel
+
+## 3. Navigation
+
+- [x] 3.1 Rename the `/my/cvs` section to "Tailor" in the account navigation model, with a test
+- [x] 3.2 Duplicate Agent and Tailor beside Inbox in the header menu, reusing the rail's icons
+
+## 4. Verification
+
+- [x] 4.1 `svelte-check` clean, `pnpm run lint` clean, `pnpm test` green, `pnpm run build` green, Go untouched and still green
+- [ ] 4.2 Confirm on production: an empty conversation shows both actions, the active tab is obvious, and the header menu carries the three sections

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -29,16 +29,16 @@ describe('accountNav config', () => {
 });
 
 describe('visibleAccountNav', () => {
-  it('shows the Assistant, Inbox and CV builder to a plain user', () => {
+  it('shows the Agent, Inbox and Tailor sections to a plain user', () => {
     const hrefs = visibleAccountNav(false, false).map((i) => i.href);
     // The Assistant left its beta rollout: it runs on the user's own machine
     // with their own Claude, so there is nothing left to ration.
     expect(hrefs).toContain('/my/assistant');
     expect(hrefs).toContain('/my/inbox');
-    expect(hrefs).toContain('/my/cvs'); // CV builder is public now (credits meter the AI spend)
+    expect(hrefs).toContain('/my/cvs'); // the tailoring list is public now (credits meter the AI spend)
   });
 
-  it('shows the CV builder to every signed-in user, gate-free', () => {
+  it('shows the tailoring section to every signed-in user, gate-free', () => {
     for (const [mod, beta] of [
       [false, false],
       [true, false],
@@ -85,5 +85,14 @@ describe('isSectionActive', () => {
     // '/my/api-keys-extra' shares the '/my/api-keys' prefix but is a different
     // route — a segment boundary ('/') is required, not a bare string prefix.
     expect(isSectionActive('/my/api-keys-extra', '/my/api-keys')).toBe(false);
+  });
+});
+
+describe('the burger menu duplicates what is opened from anywhere', () => {
+  it('names the tailoring section after what it is for', () => {
+    // "CV builder" described the tool this grew out of; every CV in here is aimed at one
+    // vacancy, which is what the section is actually for.
+    const tailor = accountNav.find((i) => i.href === '/my/cvs');
+    expect(tailor?.label).toBe('Tailor');
   });
 });

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -18,8 +18,10 @@ export const accountNav = [
   // The agent: open to every signed-in user. It runs in our backend, and unlike the CV
   // builder below, nothing meters its spend yet.
   { href: '/my/assistant', label: 'Agent' },
-  // CV builder + AI tailoring: open to every signed-in user (credits meter the AI spend).
-  { href: '/my/cvs', label: 'CV builder' },
+  // The tailoring workspace's re-open list: CVs already tailored to a vacancy. Open to every
+  // signed-in user (credits meter the AI spend). Named after what the section is FOR — a CV
+  // here is always aimed at one posting, and "CV builder" described the tool it grew out of.
+  { href: '/my/cvs', label: 'Tailor' },
   // Employee referrals: request a referral, offer to refer (moderated), and — for
   // referrers — manage incoming requests. Open to every signed-in user.
   { href: '/my/referrals', label: 'Referrals' },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1308,7 +1308,7 @@ export function createApi(
     return requestData<EmailBody>(`/api/v1/me/emails/${id}/unlink`, { method: 'POST' });
   }
 
-  // --- CV builder (beta-gated on the server) ---
+  // --- CVs and tailoring (open to every signed-in user; credits meter the AI spend) ---
 
   /** List the available CV templates (id, label, style, ats_safe) for the gallery. */
   async function listCvTemplates(): Promise<CvTemplate[]> {

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -15,6 +15,8 @@
     BellRing,
     KeyRound,
     Inbox,
+    Bot,
+    ScrollText,
     FileText,
     SquarePlus,
     ShieldCheck,
@@ -87,6 +89,10 @@
     { href: '/my/activity', label: 'Activity', icon: Activity },
     { href: '/my/tracking', label: 'Tracking', icon: ListChecks },
     { href: '/my/inbox', label: 'Inbox', icon: Inbox },
+    // The agent and the tailoring list are reached from anywhere, not only from the account
+    // shell, so they are duplicated here beside the inbox rather than left one level deeper.
+    { href: '/my/assistant', label: 'Agent', icon: Bot },
+    { href: '/my/cvs', label: 'Tailor', icon: ScrollText },
     { href: '/my/searches', label: 'Search notifications', icon: BellRing },
     { href: '/my/api-keys', label: 'API keys', icon: KeyRound },
     { href: '/my/submissions', label: 'My submissions', icon: FileText },

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -97,7 +97,7 @@
         onclick={() => (tab = id)}
         class={[
           'rounded px-2 py-1 transition-colors',
-          tab === id ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground',
+          tab === id ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground',
         ]}
       >
         {label}

--- a/web/src/lib/tailor/autopilot.test.ts
+++ b/web/src/lib/tailor/autopilot.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { summarizeRun, statusMeta, undoRun, openingFor } from './autopilot';
+import { summarizeRun, statusMeta, undoRun, openingActions } from './autopilot';
 import type { AutopilotEntry } from '$lib/generated/contracts';
 
 const report: AutopilotEntry[] = [
@@ -75,25 +75,27 @@ describe('undoRun', () => {
   });
 });
 
-describe('openingFor', () => {
-  it('offers both rhythms to a workspace that has not started', () => {
-    const actions = openingFor(false);
+describe('openingActions', () => {
+  it('offers both rhythms of the same method', () => {
+    const actions = openingActions();
     expect(actions).toHaveLength(2);
-    expect(actions?.map((a) => a.kind)).toContain('autopilot');
+    expect(actions.map((a) => a.kind)).toContain('autopilot');
     // The conversational action carries the text it will send; the run carries none, because
     // its brief belongs to the server.
-    const walk = actions?.find((a) => a.kind === 'message');
+    const walk = actions.find((a) => a.kind === 'message');
     expect(walk && 'text' in walk && walk.text.length).toBeTruthy();
   });
 
-  it('offers nothing to a resumed conversation', () => {
-    expect(openingFor(true)).toBeUndefined();
+  it('offers them regardless of how the workspace was opened', () => {
+    // Keyed on an EMPTY conversation, not on a fresh one: a CV re-opened by id can carry a
+    // conversation nobody has spoken to, and that case read as lost history. The chat renders
+    // these only while there are no messages, so the decision lives there.
+    expect(openingActions()).toHaveLength(2);
   });
 
   it('never opens a turn by itself', () => {
     // The actions are data, not effects: nothing here sends anything until one is picked.
-    const actions = openingFor(false) ?? [];
-    for (const action of actions) {
+    for (const action of openingActions()) {
       expect(typeof action.label).toBe('string');
     }
   });

--- a/web/src/lib/tailor/autopilot.ts
+++ b/web/src/lib/tailor/autopilot.ts
@@ -6,15 +6,17 @@ import type { AutopilotEntry, AutopilotStatus } from '$lib/generated/contracts';
 import type { OpeningAction } from '$lib/assistant/presets';
 
 /**
- * What a tailoring workspace offers before its first turn.
+ * What a tailoring workspace offers while its conversation is EMPTY.
  *
- * A resumed conversation offers nothing: it already has messages, and the way back in is the
- * composer. A fresh one offers both rhythms of the same method and sends NOTHING on its own —
- * the agent talking first is what left people staring at a three-column workspace they had
- * not asked anything of.
+ * Not "while it is fresh": a CV re-opened by id can have a conversation with nothing in it —
+ * bound at bootstrap, never spoken to — and keying the offer on "resuming" left exactly that
+ * case looking like a chat whose history had vanished. The chat itself only renders these while
+ * there are no messages, so handing them over always is both simpler and correct.
+ *
+ * Nothing is sent on its own either way: the agent talking first is what left people staring at
+ * a three-column workspace they had not asked anything of.
  */
-export function openingFor(resuming: boolean): OpeningAction[] | undefined {
-  if (resuming) return undefined;
+export function openingActions(): OpeningAction[] {
   return [
     {
       label: 'Tailor it for me',

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -10,6 +10,7 @@
   // typing re-renders the preview instantly, autosave persists in the background, and an agent turn
   // refetches and replaces the document.
   import { onMount, onDestroy } from 'svelte';
+  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { ZoomIn, ZoomOut, Download, Menu } from '@lucide/svelte';
@@ -154,13 +155,22 @@
           sessionId = s.session_id;
         }
       } else {
-        // Bootstrap: create the tailored CV + a seeded session, then bind the session to the CV.
+        // Bootstrap: reach the tailored CV for this vacancy (the backend returns the existing
+        // one when there is one) and the conversation bound to it.
         const [j, tailor] = await Promise.all([api.getJob(slug), api.tailorCv(slug)]);
         job = j;
         cvId = tailor.tailor_cv_id;
         analysis = tailor.analysis;
         sessionId = tailor.session_id;
-        await loadCv(); // bootstrap has no CV record in hand yet — fetch the fresh tailored copy
+        await loadCv(); // bootstrap has no CV record in hand yet — fetch the tailored copy
+        // Put the CV in the address, replacing this entry rather than adding one. A reload of
+        // the bare /tailor/<slug> is a bootstrap request, and until the address names the CV
+        // the candidate is one F5 away from an empty workspace. Back still leaves the page.
+        void goto(`${resolve('/tailor/[slug]', { slug })}?cv=${cvId}`, {
+          replaceState: true,
+          noScroll: true,
+          keepFocus: true,
+        });
       }
       status = 'ready';
     } catch (e) {

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -166,6 +166,7 @@
         // Put the CV in the address, replacing this entry rather than adding one. A reload of
         // the bare /tailor/<slug> is a bootstrap request, and until the address names the CV
         // the candidate is one F5 away from an empty workspace. Back still leaves the page.
+        // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() supplies the path; the rule can't see through the appended ?cv= query
         void goto(`${resolve('/tailor/[slug]', { slug })}?cv=${cvId}`, {
           replaceState: true,
           noScroll: true,

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -22,7 +22,7 @@
   import MarginSettings from '$lib/components/cv/MarginSettings.svelte';
   import AccountNavRail from '$lib/components/AccountNavRail.svelte';
   import { clampWidth } from '$lib/tailor/geometry';
-  import { undoRun, openingFor } from '$lib/tailor/autopilot';
+  import { undoRun, openingActions } from '$lib/tailor/autopilot';
   import { toEditable, emptyDocument, type CvRecord } from '$lib/cv';
   import type { Analysis, AutopilotEntry, Document } from '$lib/generated/contracts';
   import type { Job } from '$lib/types';
@@ -110,10 +110,9 @@
   const zoomIn = () => (zoom = clampZoom(zoom + 0.1));
   const pdfUrl = $derived(`${api.cvPdfUrl(cvId)}?v=${pdfVersion}`);
 
-  // A fresh workspace opens on a choice rather than on the agent talking to itself; a resumed
-  // one opens on its own transcript. Both actions run the SAME method and differ only in
-  // rhythm — see openingFor, which is unit-tested.
-  const opening = $derived(openingFor(resuming));
+  // Offered whenever the conversation is empty — the chat renders them only then. A CV opened
+  // by id can carry a conversation nobody has spoken to, and that case looked like lost history.
+  const opening = openingActions();
   const sessionLabel = $derived(job ? `${job.title} · ${job.company}` : undefined);
 
   // Hydrate the page-owned CV state from a CV record (marking the snapshot as the persisted
@@ -358,21 +357,21 @@
             <button
               type="button"
               onclick={() => (leftTab = 'editor')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'editor' ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
+              class={['rounded px-2 py-1 transition-colors', leftTab === 'editor' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
             >
               Editor
             </button>
             <button
               type="button"
               onclick={() => (leftTab = 'settings')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'settings' ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
+              class={['rounded px-2 py-1 transition-colors', leftTab === 'settings' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
             >
               Settings
             </button>
             <button
               type="button"
               onclick={() => (leftTab = 'chat')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'chat' ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
+              class={['rounded px-2 py-1 transition-colors', leftTab === 'chat' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
             >
               Chat
             </button>


### PR DESCRIPTION
## What and why

Three things from using the workspace on production.

**1. A CV opened by id showed an empty chat with no way in.** I gated the two opening actions on \`resuming\` — "opened with \`?cv=\`" — but a CV re-opened by id can carry a conversation that was bound at bootstrap and never spoken to. That case rendered "Ask the agent anything to get started" and nothing else, which is indistinguishable from a chat whose history was lost. Reported as exactly that.

The chat component already renders the actions only while \`chat.messages.length === 0\`, so my flag was a second gate on the same question — and the two disagree in precisely the case that was reported. \`openingFor(resuming)\` is now \`openingActions()\`: the host says what it offers, the chat decides when.

**2. The active tab was not readable as active.** Editor / Settings / Chat marked the current one with \`bg-muted\`, which against the panel's own background is nearly invisible. Now the brand tint — the palette's olive (\`--brand: #5b6f00\`, \`--brand-muted\` as its soft fill, \`--brand-strong\` for text on it) — plus a heavier weight. Same treatment in the artifact panel, so both tab strips read alike. No new token.

**3. Navigation.** The account section is renamed **Tailor**: every CV it lists is aimed at one vacancy, and "CV builder" named the tool it grew out of. The header menu now repeats **Agent** and **Tailor** beside the **Inbox** it already carried — those three get opened in the middle of other work, so a trip through the account shell to reach them is a navigation for nothing. Icons come from the existing \`accountNavIcons\` map, so the menu and the rail cannot drift.

Route addresses are unchanged; only the label moved.

## Verification

\`svelte-check\` 0 errors, \`pnpm run lint\` clean, 467 web tests green, \`pnpm run build\` green. Go untouched and still green.

The unit tests follow the new contract: the actions are offered regardless of how the workspace was opened, they still send nothing by themselves, and the section's label is asserted so a rename cannot happen silently.

Not verified: the visual result on production — that is the next thing to look at, and 4.2 in the change's tasks is left open for it.

OpenSpec: \`openspec/changes/tailor-workspace-orientation/\`.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] \`go build ./...\`, \`go vet ./...\`, and \`gofmt -l .\` (prints nothing) pass.
- [x] \`go test ./...\` passes (and \`go test -tags=integration ./...\` if I touched DB/handlers).
- [x] I regenerated committed artifacts when their source changed — none changed.
- [x] For \`design-system/\` changes: n/a.
- [x] For \`web/\` changes: lint, \`svelte-check\` and \`pnpm run build\` pass.
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.