### PR TITLE
fix(tailor): an empty conversation shows the way in, and the active pane is legible

### DIFF
--- a/openspec/changes/tailor-workspace-orientation/.openspec.yaml
+++ b/openspec/changes/tailor-workspace-orientation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/tailor-workspace-orientation/design.md
+++ b/openspec/changes/tailor-workspace-orientation/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Reported while using the workspace on production, with a screenshot: a CV opened by id showed
+"Ask the agent anything to get started" and no actions, and the active tab was indistinguishable
+from the inactive ones.
+
+The first is a defect in the change that introduced the actions: they were gated on `resuming`,
+a page-level flag meaning "opened with `?cv=`". The chat component already renders them only while
+`chat.messages.length === 0`, so the flag was a second gate on the same question — and the two
+disagree exactly when a bound conversation is empty, which is what a bootstrap leaves behind if
+nobody presses anything.
+
+## Goals / Non-Goals
+
+**Goals:**
+- An empty conversation always shows the way in, however it was reached.
+- The current pane is obvious at a glance.
+- The three sections people open mid-task are reachable without a detour.
+
+**Non-Goals:**
+- A general tab component. Two panels share a pattern; a third would be the time to extract one.
+- Renaming routes. `/my/cvs` stays — the label changes, the address does not.
+- Reordering the account navigation.
+
+## Decisions
+
+### One gate, in the component that renders
+
+`openingFor(resuming)` becomes `openingActions()`. The host says WHAT it offers; the chat decides
+WHEN, from the only state that matters (are there messages?). Two components answering the same
+question is what produced the bug.
+
+### The brand tint, not a darker grey
+
+The palette's brand colour is already the olive (`--brand: #5b6f00`, with `--brand-muted` as its
+soft tint and `--brand-strong` for readable text on it). Using it for the selected tab keeps the
+selection consistent with every other "this one is chosen" affordance in the product, and needs no
+new token.
+
+### The header menu duplicates three sections, not all of them
+
+Inbox was already there. Agent and Tailor join it because they are opened from a job page, a search,
+or nothing in particular — the rest of the account sections are destinations you go to deliberately.
+
+## Risks / Trade-offs
+
+- **A longer header menu** → Three more rows on a menu that already scrolls on mobile, against a
+  saved navigation each time; the sections chosen are the ones with the traffic.
+- **"Tailor" as a noun is a little odd in English** → It matches the workspace it opens
+  (`/tailor/<slug>`) and the verb the product uses everywhere else for this action.

--- a/openspec/changes/tailor-workspace-orientation/proposal.md
+++ b/openspec/changes/tailor-workspace-orientation/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Three things reported from using the tailoring workspace on production:
+
+1. **A CV opened by id showed an empty chat with no way in.** The two opening actions were keyed
+   on "this is a fresh workspace", but a CV re-opened by `?cv=` can carry a conversation bound at
+   bootstrap that nobody ever spoke to. That case rendered "Ask the agent anything to get started"
+   and nothing else — indistinguishable from a chat whose history had been lost.
+2. **The active tab was not readable as active.** Editor / Settings / Chat marked the current one
+   with `bg-muted`, which against the panel's own background is nearly invisible: you cannot tell
+   which pane you are looking at.
+3. **The account section was still called "CV builder"**, and the agent and the tailoring list were
+   reachable only from inside the account shell, while the inbox was duplicated in the header menu.
+
+## What Changes
+
+- The workspace offers its two actions whenever the conversation is EMPTY, not only when it was
+  just bootstrapped. The chat already renders them only while there are no messages, so the
+  "resuming" condition was a second, wrong gate on the same thing.
+- The active tab in both the left panel and the artifact panel is marked with the brand tint
+  (the palette's olive) and a heavier weight, rather than a barely-visible grey.
+- The account section is renamed **Tailor** — every CV in it is aimed at one vacancy, and
+  "CV builder" named the tool it grew out of.
+- The header menu duplicates **Agent** and **Tailor** beside the inbox it already carried, so the
+  three things opened from anywhere are reachable from anywhere.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `tailor-workspace`: the opening actions follow an empty conversation rather than a fresh
+  workspace, and the active tab is legible.
+- `account-navigation`: the tailoring section's name, and which sections the header menu repeats.
+
+## Impact
+
+- **Web only:** `web/src/lib/tailor/autopilot.ts` (`openingFor` → `openingActions`),
+  `web/src/routes/tailor/[slug]/+page.svelte`, `web/src/lib/tailor/ArtifactPanel.svelte`,
+  `web/src/lib/accountNav.ts`, `web/src/lib/components/HeaderMenu.svelte`.
+- No API, schema or backend change.

--- a/openspec/changes/tailor-workspace-orientation/specs/account-navigation/spec.md
+++ b/openspec/changes/tailor-workspace-orientation/specs/account-navigation/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: The header menu repeats what is opened from anywhere
+
+The header menu SHALL carry the account sections a user reaches from outside the account shell —
+the mail inbox, the agent, and the tailoring list — alongside its own links. These three are opened
+in the middle of other work, so requiring a trip through the account shell to reach them costs a
+navigation for no reason. The remaining sections stay in the account navigation only.
+
+#### Scenario: The agent and the tailoring list are one click from anywhere
+
+- **WHEN** a signed-in user opens the header menu from any page
+- **THEN** it lists the inbox, the agent and the tailoring section among its account links
+
+### Requirement: The tailoring section is named for its purpose
+
+The account navigation SHALL name the section holding vacancy-bound CVs **Tailor**. Every CV it
+lists is aimed at one posting; the earlier name described the CV-building tool the section grew out
+of rather than what a user comes here to do.
+
+#### Scenario: The section reads as Tailor
+
+- **WHEN** the account navigation is rendered
+- **THEN** the `/my/cvs` section is labelled "Tailor"

--- a/openspec/changes/tailor-workspace-orientation/specs/tailor-workspace/spec.md
+++ b/openspec/changes/tailor-workspace-orientation/specs/tailor-workspace/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: The tailoring workspace resumes an existing session
+
+The system SHALL, when `/tailor/[slug]` is opened for an existing tailored CV (`?cv=<id>`),
+re-attach to that CV's stored agent session WITHOUT bootstrapping a new CV or sending a kickoff
+prompt. Opening `/tailor/[slug]` without a CV reference SHALL reach the tailored CV for that
+vacancy and the conversation bound to it. A session MUST NOT start talking on its own: while its
+conversation holds NO messages, the chat SHALL offer two actions — running the tailoring
+unattended, or walking the gaps in conversation — and the turn begins when one is chosen.
+
+The offer follows the conversation being empty, not the workspace being new. A CV re-opened by id
+can carry a conversation nobody has spoken to, and leaving that case without actions makes it
+indistinguishable from a conversation whose history was lost.
+
+#### Scenario: Re-opening a CV continues its conversation
+
+- **WHEN** a user opens the workspace for an existing tailored CV
+- **THEN** the existing agent session is attached (its prior messages replay) and no new session or kickoff is created
+
+#### Scenario: Opening without a CV reaches the vacancy's CV
+
+- **WHEN** a user opens the workspace from the match CTA (no CV reference)
+- **THEN** the tailored CV for that vacancy and its bound conversation are attached, and the empty chat offers the two actions without sending anything
+
+#### Scenario: An empty resumed conversation still offers the way in
+
+- **WHEN** a user opens a tailored CV by id whose conversation holds no messages
+- **THEN** the chat offers the same two actions rather than an empty pane
+
+#### Scenario: Choosing an action starts the turn
+
+- **WHEN** the user picks one of the two actions in the empty chat
+- **THEN** the corresponding turn runs — the unattended run, or the conversational walkthrough
+
+## ADDED Requirements
+
+### Requirement: The active pane is legible
+
+The workspace SHALL mark the selected tab of each tabbed panel so it is unmistakable at a glance,
+using the brand tint and a heavier weight rather than a fill that reads as background. A
+three-column surface where the current pane is ambiguous costs the user the orientation the tabs
+exist to give.
+
+#### Scenario: The selected tab stands out
+
+- **WHEN** a panel's tab is selected
+- **THEN** it is rendered with the brand tint and heavier weight, and the unselected tabs are not

--- a/openspec/changes/tailor-workspace-orientation/tasks.md
+++ b/openspec/changes/tailor-workspace-orientation/tasks.md
@@ -1,0 +1,18 @@
+## 1. An empty conversation always offers the way in
+
+- [x] 1.1 Replace `openingFor(resuming)` with `openingActions()` and have the workspace pass it unconditionally
+- [x] 1.2 Update the unit tests to the new contract: the actions are offered regardless of how the workspace was opened, and still send nothing by themselves
+
+## 2. The active pane is legible
+
+- [x] 2.1 Mark the selected tab with the brand tint and heavier weight in the left panel and the artifact panel
+
+## 3. Navigation
+
+- [x] 3.1 Rename the `/my/cvs` section to "Tailor" in the account navigation model, with a test
+- [x] 3.2 Duplicate Agent and Tailor beside Inbox in the header menu, reusing the rail's icons
+
+## 4. Verification
+
+- [x] 4.1 `svelte-check` clean, `pnpm run lint` clean, `pnpm test` green, `pnpm run build` green, Go untouched and still green
+- [ ] 4.2 Confirm on production: an empty conversation shows both actions, the active tab is obvious, and the header menu carries the three sections

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -29,16 +29,16 @@ describe('accountNav config', () => {
 });
 
 describe('visibleAccountNav', () => {
-  it('shows the Assistant, Inbox and CV builder to a plain user', () => {
+  it('shows the Agent, Inbox and Tailor sections to a plain user', () => {
     const hrefs = visibleAccountNav(false, false).map((i) => i.href);
     // The Assistant left its beta rollout: it runs on the user's own machine
     // with their own Claude, so there is nothing left to ration.
     expect(hrefs).toContain('/my/assistant');
     expect(hrefs).toContain('/my/inbox');
-    expect(hrefs).toContain('/my/cvs'); // CV builder is public now (credits meter the AI spend)
+    expect(hrefs).toContain('/my/cvs'); // the tailoring list is public now (credits meter the AI spend)
   });
 
-  it('shows the CV builder to every signed-in user, gate-free', () => {
+  it('shows the tailoring section to every signed-in user, gate-free', () => {
     for (const [mod, beta] of [
       [false, false],
       [true, false],
@@ -85,5 +85,14 @@ describe('isSectionActive', () => {
     // '/my/api-keys-extra' shares the '/my/api-keys' prefix but is a different
     // route — a segment boundary ('/') is required, not a bare string prefix.
     expect(isSectionActive('/my/api-keys-extra', '/my/api-keys')).toBe(false);
+  });
+});
+
+describe('the burger menu duplicates what is opened from anywhere', () => {
+  it('names the tailoring section after what it is for', () => {
+    // "CV builder" described the tool this grew out of; every CV in here is aimed at one
+    // vacancy, which is what the section is actually for.
+    const tailor = accountNav.find((i) => i.href === '/my/cvs');
+    expect(tailor?.label).toBe('Tailor');
   });
 });

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -18,8 +18,10 @@ export const accountNav = [
   // The agent: open to every signed-in user. It runs in our backend, and unlike the CV
   // builder below, nothing meters its spend yet.
   { href: '/my/assistant', label: 'Agent' },
-  // CV builder + AI tailoring: open to every signed-in user (credits meter the AI spend).
-  { href: '/my/cvs', label: 'CV builder' },
+  // The tailoring workspace's re-open list: CVs already tailored to a vacancy. Open to every
+  // signed-in user (credits meter the AI spend). Named after what the section is FOR — a CV
+  // here is always aimed at one posting, and "CV builder" described the tool it grew out of.
+  { href: '/my/cvs', label: 'Tailor' },
   // Employee referrals: request a referral, offer to refer (moderated), and — for
   // referrers — manage incoming requests. Open to every signed-in user.
   { href: '/my/referrals', label: 'Referrals' },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1308,7 +1308,7 @@ export function createApi(
     return requestData<EmailBody>(`/api/v1/me/emails/${id}/unlink`, { method: 'POST' });
   }
 
-  // --- CV builder (beta-gated on the server) ---
+  // --- CVs and tailoring (open to every signed-in user; credits meter the AI spend) ---
 
   /** List the available CV templates (id, label, style, ats_safe) for the gallery. */
   async function listCvTemplates(): Promise<CvTemplate[]> {

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -15,6 +15,8 @@
     BellRing,
     KeyRound,
     Inbox,
+    Bot,
+    ScrollText,
     FileText,
     SquarePlus,
     ShieldCheck,
@@ -87,6 +89,10 @@
     { href: '/my/activity', label: 'Activity', icon: Activity },
     { href: '/my/tracking', label: 'Tracking', icon: ListChecks },
     { href: '/my/inbox', label: 'Inbox', icon: Inbox },
+    // The agent and the tailoring list are reached from anywhere, not only from the account
+    // shell, so they are duplicated here beside the inbox rather than left one level deeper.
+    { href: '/my/assistant', label: 'Agent', icon: Bot },
+    { href: '/my/cvs', label: 'Tailor', icon: ScrollText },
     { href: '/my/searches', label: 'Search notifications', icon: BellRing },
     { href: '/my/api-keys', label: 'API keys', icon: KeyRound },
     { href: '/my/submissions', label: 'My submissions', icon: FileText },

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -97,7 +97,7 @@
         onclick={() => (tab = id)}
         class={[
           'rounded px-2 py-1 transition-colors',
-          tab === id ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground',
+          tab === id ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground',
         ]}
       >
         {label}

--- a/web/src/lib/tailor/autopilot.test.ts
+++ b/web/src/lib/tailor/autopilot.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { summarizeRun, statusMeta, undoRun, openingFor } from './autopilot';
+import { summarizeRun, statusMeta, undoRun, openingActions } from './autopilot';
 import type { AutopilotEntry } from '$lib/generated/contracts';
 
 const report: AutopilotEntry[] = [
@@ -75,25 +75,27 @@ describe('undoRun', () => {
   });
 });
 
-describe('openingFor', () => {
-  it('offers both rhythms to a workspace that has not started', () => {
-    const actions = openingFor(false);
+describe('openingActions', () => {
+  it('offers both rhythms of the same method', () => {
+    const actions = openingActions();
     expect(actions).toHaveLength(2);
-    expect(actions?.map((a) => a.kind)).toContain('autopilot');
+    expect(actions.map((a) => a.kind)).toContain('autopilot');
     // The conversational action carries the text it will send; the run carries none, because
     // its brief belongs to the server.
-    const walk = actions?.find((a) => a.kind === 'message');
+    const walk = actions.find((a) => a.kind === 'message');
     expect(walk && 'text' in walk && walk.text.length).toBeTruthy();
   });
 
-  it('offers nothing to a resumed conversation', () => {
-    expect(openingFor(true)).toBeUndefined();
+  it('offers them regardless of how the workspace was opened', () => {
+    // Keyed on an EMPTY conversation, not on a fresh one: a CV re-opened by id can carry a
+    // conversation nobody has spoken to, and that case read as lost history. The chat renders
+    // these only while there are no messages, so the decision lives there.
+    expect(openingActions()).toHaveLength(2);
   });
 
   it('never opens a turn by itself', () => {
     // The actions are data, not effects: nothing here sends anything until one is picked.
-    const actions = openingFor(false) ?? [];
-    for (const action of actions) {
+    for (const action of openingActions()) {
       expect(typeof action.label).toBe('string');
     }
   });

--- a/web/src/lib/tailor/autopilot.ts
+++ b/web/src/lib/tailor/autopilot.ts
@@ -6,15 +6,17 @@ import type { AutopilotEntry, AutopilotStatus } from '$lib/generated/contracts';
 import type { OpeningAction } from '$lib/assistant/presets';
 
 /**
- * What a tailoring workspace offers before its first turn.
+ * What a tailoring workspace offers while its conversation is EMPTY.
  *
- * A resumed conversation offers nothing: it already has messages, and the way back in is the
- * composer. A fresh one offers both rhythms of the same method and sends NOTHING on its own —
- * the agent talking first is what left people staring at a three-column workspace they had
- * not asked anything of.
+ * Not "while it is fresh": a CV re-opened by id can have a conversation with nothing in it —
+ * bound at bootstrap, never spoken to — and keying the offer on "resuming" left exactly that
+ * case looking like a chat whose history had vanished. The chat itself only renders these while
+ * there are no messages, so handing them over always is both simpler and correct.
+ *
+ * Nothing is sent on its own either way: the agent talking first is what left people staring at
+ * a three-column workspace they had not asked anything of.
  */
-export function openingFor(resuming: boolean): OpeningAction[] | undefined {
-  if (resuming) return undefined;
+export function openingActions(): OpeningAction[] {
   return [
     {
       label: 'Tailor it for me',

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -22,7 +22,7 @@
   import MarginSettings from '$lib/components/cv/MarginSettings.svelte';
   import AccountNavRail from '$lib/components/AccountNavRail.svelte';
   import { clampWidth } from '$lib/tailor/geometry';
-  import { undoRun, openingFor } from '$lib/tailor/autopilot';
+  import { undoRun, openingActions } from '$lib/tailor/autopilot';
   import { toEditable, emptyDocument, type CvRecord } from '$lib/cv';
   import type { Analysis, AutopilotEntry, Document } from '$lib/generated/contracts';
   import type { Job } from '$lib/types';
@@ -110,10 +110,9 @@
   const zoomIn = () => (zoom = clampZoom(zoom + 0.1));
   const pdfUrl = $derived(`${api.cvPdfUrl(cvId)}?v=${pdfVersion}`);
 
-  // A fresh workspace opens on a choice rather than on the agent talking to itself; a resumed
-  // one opens on its own transcript. Both actions run the SAME method and differ only in
-  // rhythm — see openingFor, which is unit-tested.
-  const opening = $derived(openingFor(resuming));
+  // Offered whenever the conversation is empty — the chat renders them only then. A CV opened
+  // by id can carry a conversation nobody has spoken to, and that case looked like lost history.
+  const opening = openingActions();
   const sessionLabel = $derived(job ? `${job.title} · ${job.company}` : undefined);
 
   // Hydrate the page-owned CV state from a CV record (marking the snapshot as the persisted
@@ -358,21 +357,21 @@
             <button
               type="button"
               onclick={() => (leftTab = 'editor')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'editor' ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
+              class={['rounded px-2 py-1 transition-colors', leftTab === 'editor' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
             >
               Editor
             </button>
             <button
               type="button"
               onclick={() => (leftTab = 'settings')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'settings' ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
+              class={['rounded px-2 py-1 transition-colors', leftTab === 'settings' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
             >
               Settings
             </button>
             <button
               type="button"
               onclick={() => (leftTab = 'chat')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'chat' ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground']}
+              class={['rounded px-2 py-1 transition-colors', leftTab === 'chat' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
             >
               Chat
             </button>


### PR DESCRIPTION
## What and why

Three things from using the workspace on production.

**1. A CV opened by id showed an empty chat with no way in.** I gated the two opening actions on `resuming` — "opened with `?cv=`" — but a CV re-opened by id can carry a conversation that was bound at bootstrap and never spoken to. That case rendered "Ask the agent anything to get started" and nothing else, which is indistinguishable from a chat whose history was lost. It was reported as exactly that.

The chat component already renders the actions only while `chat.messages.length === 0`, so my flag was a second gate on the same question — and the two disagree in precisely the case that was reported. `openingFor(resuming)` is now `openingActions()`: the host says what it offers, the chat decides when.

**2. The active tab was not readable as active.** Editor / Settings / Chat marked the current one with `bg-muted`, which against the panel's own background is nearly invisible. Now the brand tint — the palette's olive (`--brand: #5b6f00`, `--brand-muted` as its soft fill, `--brand-strong` for text on it) — plus a heavier weight. Same treatment in the artifact panel, so both tab strips read alike. No new token.

**3. Navigation.** The account section is renamed **Tailor**: every CV it lists is aimed at one vacancy, and "CV builder" named the tool it grew out of. The header menu now repeats **Agent** and **Tailor** beside the **Inbox** it already carried — those three get opened in the middle of other work, so a trip through the account shell to reach them is a navigation for nothing. Icons come from the existing `accountNavIcons` map, so the menu and the rail cannot drift.

Route addresses are unchanged; only the label moved.

## Verification

`svelte-check` 0 errors, `pnpm run lint` clean, 467 web tests green, `pnpm run build` green. Go untouched and still green.

The unit tests follow the new contract: the actions are offered regardless of how the workspace was opened, they still send nothing by themselves, and the section's label is asserted so a rename cannot happen silently.

Not verified: the visual result on production — that is the next thing to look at, and 4.2 in the change's tasks is left open for it.

OpenSpec: `openspec/changes/tailor-workspace-orientation/`.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [x] I regenerated committed artifacts when their source changed — none changed.
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: lint, `svelte-check` and `pnpm run build` pass.
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.
