### PR TITLE
docs(blog): changelog — reporting a job got shorter

### DIFF
--- a/web/src/posts/2026-07-29-reporting-a-job-got-shorter.svx
+++ b/web/src/posts/2026-07-29-reporting-a-job-got-shorter.svx
@@ -1,0 +1,23 @@
+---
+title: Reporting a job got shorter
+date: 2026-07-29
+summary: The explanation is now optional, and "no response" asks when you applied instead of asking you to write an essay.
+type: changelog
+tags:
+  - reports
+  - job-seekers
+---
+
+Reporting a problem with a vacancy used to demand a written explanation before it
+would send. The reason you picked already says what is wrong, so that field is now
+optional — pick a reason and send, or add a line if there is something we would not
+guess. The Telegram contact field is gone.
+
+"No response — applied but never heard back" now works differently from the rest.
+Instead of a text box, it asks one thing: **when did you apply?** That date is what
+makes the report useful to anyone other than us. Without it, "nobody answered me"
+cannot be told apart from "I applied on Tuesday", and there was nothing we could do
+with it beyond reading it.
+
+The other four reasons — no longer relevant, spam, fraud, other — still go to a human
+who can take the posting down.


### PR DESCRIPTION
## What and why

Changelog entry for the report-dialog changes that landed in #1259: the explanation field is now optional, the Telegram contact field is gone, and "no response" asks for the apply date instead of free text.

It deliberately does **not** announce the ghost-job signal from that same PR. That signal is merged but silent in production until `cmd/ghost-crosscheck` is run with `--apply` and the calibration gate is opened — until then no posting can pass the convergence threshold, so an announcement would describe something a reader could not find. It gets its own entry once it is actually visible.

`pnpm run check` 0 errors, `pnpm test` 487 passing, `pnpm run build` green (which is what validates the post's frontmatter).

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` pass — no Go touched.
- [x] `go test ./...` passes — no Go touched.
- [x] No generated artifacts affected.
- [ ] For `design-system/` changes — not touched.
- [x] For `web/` changes: `pnpm run check` and `pnpm run build` pass.
- [x] This stays within freehire's core/extension boundary.