### PR TITLE
fix(profile): the tab strips scroll instead of clipping on a phone

### DIFF
--- a/web/src/lib/components/ExperienceBankView.svelte
+++ b/web/src/lib/components/ExperienceBankView.svelte
@@ -126,9 +126,13 @@
       </p>
       <!-- Capped, and right-aligned only once it shares the row: the example is two lines
            of hint, and letting it set the row's width pushed the whole action under the
-           paragraph. Narrow, it wraps to its own line and follows the text's edge. -->
+           paragraph. Narrow, it takes its own line and follows the text's edge.
+           `basis-full` below `sm` is what forces that own line — `flex-wrap` alone could not,
+           because the paragraph beside it is `flex-1` (so `flex-basis: 0`) and never claims
+           enough width to push anything down. With the action also refusing to shrink, it held
+           its full 16rem on a phone and crushed the paragraph to one word per line. -->
       <div
-        class="flex max-w-[16rem] shrink-0 flex-col items-start gap-1.5 text-left sm:items-end sm:text-right"
+        class="flex basis-full flex-col items-start gap-1.5 text-left sm:max-w-[16rem] sm:basis-auto sm:shrink-0 sm:items-end sm:text-right"
       >
         {@render interviewEntry('bank-example')}
       </div>

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -14,6 +14,7 @@
   import { Button, Input } from '$lib/ui';
   import RemoteSearchSelect from './facets/RemoteSearchSelect.svelte';
   import SearchSelect from './facets/SearchSelect.svelte';
+  import TabRow, { tabId } from './TabRow.svelte';
 
   // Mirror of the server's specialization cap (searchprofile.maxSpecializations).
   const MAX_SPECIALIZATIONS = 5;
@@ -51,7 +52,13 @@
   let formError = $state<string | null>(null);
   let busy = $state(false);
   // Which form section is shown — the profile is long, so split it into two tabs sharing
-  // one Save (both tabs feed the same PUT).
+  // one Save (both tabs feed the same PUT). The list drives TabRow, and typing it `as const`
+  // ties `formTab` to it: an id that is not a section stops being expressible.
+  const formTabs = [
+    { id: 'main', label: 'Skills & role' },
+    { id: 'location', label: 'Location & work' },
+  ] as const;
+  const formPanelId = 'profile-form-panel';
   let formTab = $state<'main' | 'location'>('main');
 
   // Location & work preferences — the optional "where & how I want to work" block. Seeded
@@ -281,26 +288,13 @@
 <form onsubmit={submit} class="flex flex-col gap-6 rounded-xl border border-border bg-card p-5 sm:p-6">
   <!-- Sub-tabs: the professional self vs. where/how you want to work. One Save below covers
        both (a single PUT). -->
-  <div class="flex gap-5 border-b border-border">
-    <button
-      type="button"
-      onclick={() => (formTab = 'main')}
-      class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {formTab === 'main'
-        ? 'border-brand text-foreground'
-        : 'border-transparent text-muted-foreground hover:text-foreground'}"
-    >
-      Skills &amp; role
-    </button>
-    <button
-      type="button"
-      onclick={() => (formTab = 'location')}
-      class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {formTab === 'location'
-        ? 'border-brand text-foreground'
-        : 'border-transparent text-muted-foreground hover:text-foreground'}"
-    >
-      Location &amp; work
-    </button>
-  </div>
+  <TabRow
+    tabs={formTabs}
+    active={formTab}
+    onSelect={(id) => (formTab = id)}
+    label="Profile form sections"
+    panelId={formPanelId}
+  />
 
   <!-- Region-pill group, reused by remote reach and relocation targets. Declared at the form
        top level so it is available inside either tab. -->
@@ -333,6 +327,15 @@
     />
   {/snippet}
 
+  <!-- One panel around both sections: they are mutually exclusive, so a single element can
+       carry the tabpanel role and stay pointed at whichever tab is active. `gap-6` repeats the
+       form's own spacing, which the section's blocks used to inherit as direct form children. -->
+  <div
+    id={formPanelId}
+    role="tabpanel"
+    aria-labelledby={tabId(formPanelId, formTab)}
+    class="flex flex-col gap-6"
+  >
   {#if formTab === 'main'}
   <!-- Your CV: uploaded state or an empty drop-zone. Uploading extracts skills into the
        field below and stores the CV for the readiness tab. -->
@@ -564,6 +567,7 @@
     {/if}
   </div>
   {/if}
+  </div>
 
   {#if formError}
     <p class="text-sm text-destructive">{formError}</p>

--- a/web/src/lib/components/TabRow.svelte
+++ b/web/src/lib/components/TabRow.svelte
@@ -1,0 +1,156 @@
+<script module lang="ts">
+  /**
+   * id of the tab button for `tab` within the strip driving `panelId`. The panel lives at the
+   * call site, so it needs this to point `aria-labelledby` back at its own tab — exported so
+   * the convention lives in one place instead of being retyped as a magic string.
+   */
+  export function tabId(panelId: string, tab: string): string {
+    return `${panelId}-tab-${tab}`;
+  }
+</script>
+
+<script lang="ts" generics="T extends string">
+  import { cn } from '$lib/utils';
+
+  // A horizontal tab strip that survives a narrow viewport. Past its own width the row
+  // scrolls rather than wrapping: a flex row with nowhere to put the overflow first squeezes
+  // labels down to min-content (so a two-word label breaks mid-label) and then spills the
+  // remainder past the container's edge, which is how the profile's "CV readiness" came to
+  // render as "CV readine" on a phone.
+  //
+  // Owns the tablist semantics as well — arrow-key movement over a roving tabindex — because
+  // `role="tablist"` is a promise to assistive tech that the group is one widget stepped
+  // through with the arrows. Hand-rolled copies of this row could not each keep that promise;
+  // one component can.
+  let {
+    tabs,
+    active,
+    onSelect,
+    label,
+    panelId,
+    class: extra = '',
+  }: {
+    tabs: readonly { id: T; label: string }[];
+    active: T;
+    onSelect: (id: T) => void;
+    /** Names the strip for assistive tech, e.g. "Profile sections". */
+    label: string;
+    /** id of the `role="tabpanel"` element these tabs drive. */
+    panelId: string;
+    class?: string;
+  } = $props();
+
+  let strip = $state<HTMLElement | null>(null);
+  let buttons = $state<(HTMLElement | null)[]>([]);
+  const activeIndex = $derived(tabs.findIndex((t) => t.id === active));
+
+  // Whether either end is out of view. Measured rather than assumed: an unconditional fade
+  // would paint a phantom edge-shadow on the desktop row, which already fits.
+  let atStart = $state(true);
+  let atEnd = $state(true);
+
+  function measure() {
+    if (!strip) return;
+    atStart = strip.scrollLeft <= 1;
+    // 1px of slack — fractional layout widths leave scrollLeft just shy of its true maximum,
+    // so an exact comparison never reports the end as reached.
+    atEnd = strip.scrollLeft >= strip.scrollWidth - strip.clientWidth - 1;
+  }
+
+  // Re-measure on any resize of the strip or of a label inside it. The children matter on
+  // their own: a late web-font swap changes label widths, and so scrollWidth, without ever
+  // resizing the strip itself.
+  $effect(() => {
+    const el = strip;
+    if (!el) return;
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    for (const child of el.children) observer.observe(child);
+    return () => observer.disconnect();
+  });
+
+  // Fade whichever edge has content beyond it. A mask rather than a gradient overlay so the
+  // strip needs no knowledge of the surface it was dropped onto — it fades its own content to
+  // transparent, and reads correctly both on the page background and inside a card.
+  const maskStyle = $derived.by(() => {
+    if (atStart && atEnd) return undefined;
+    const from = atStart ? 'black 0' : 'transparent 0, black 1.5rem';
+    const to = atEnd ? 'black 100%' : 'black calc(100% - 1.5rem), transparent 100%';
+    return `mask-image: linear-gradient(to right, ${from}, ${to})`;
+  });
+
+  // Keep the active tab in view. Not cosmetic: the panels' empty states link back to a
+  // sibling tab, so the selection can change without the user having touched the strip, and
+  // the newly-active tab would otherwise stay parked off-screen.
+  $effect(() => {
+    const el = buttons[activeIndex];
+    if (!strip || !el) return;
+    // Scroll the strip itself instead of calling scrollIntoView, which would also drag the
+    // page vertically whenever the strip sits below the fold.
+    const tab = el.getBoundingClientRect();
+    const view = strip.getBoundingClientRect();
+    if (tab.right > view.right) strip.scrollLeft += tab.right - view.right;
+    else if (tab.left < view.left) strip.scrollLeft -= view.left - tab.left;
+  });
+
+  // Arrows move the selection and activate as they go — the automatic-activation pattern,
+  // which suits panels that are already rendered client-side and cost nothing to show.
+  // Home/End jump to the ends. Focus follows, since a roving tabindex leaves only the
+  // selected tab reachable by Tab.
+  function onKeydown(event: KeyboardEvent) {
+    let next: number;
+    switch (event.key) {
+      case 'ArrowRight':
+        next = (activeIndex + 1) % tabs.length;
+        break;
+      case 'ArrowLeft':
+        next = (activeIndex - 1 + tabs.length) % tabs.length;
+        break;
+      case 'Home':
+        next = 0;
+        break;
+      case 'End':
+        next = tabs.length - 1;
+        break;
+      default:
+        return;
+    }
+    const target = tabs[next];
+    if (!target) return; // only reachable with an empty `tabs`, where there is nothing to move to.
+    event.preventDefault();
+    onSelect(target.id);
+    buttons[next]?.focus();
+  }
+</script>
+
+<div class={cn('relative', extra)}>
+  <div
+    bind:this={strip}
+    onscroll={measure}
+    role="tablist"
+    aria-label={label}
+    style={maskStyle}
+    class="flex gap-4 overflow-x-auto border-b border-border sm:gap-5 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+  >
+    {#each tabs as t, i (t.id)}
+      <button
+        bind:this={buttons[i]}
+        type="button"
+        role="tab"
+        id={tabId(panelId, t.id)}
+        aria-selected={t.id === active}
+        aria-controls={panelId}
+        tabindex={t.id === active ? 0 : -1}
+        onclick={() => onSelect(t.id)}
+        onkeydown={onKeydown}
+        class="-mb-px shrink-0 whitespace-nowrap border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {t.id ===
+        active
+          ? 'border-brand text-foreground'
+          : 'border-transparent text-muted-foreground hover:text-foreground'}"
+      >
+        {t.label}
+      </button>
+    {/each}
+  </div>
+</div>

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -14,6 +14,7 @@
   import ProfileForm from '$lib/components/ProfileForm.svelte';
   import ResumeStructuredView from '$lib/components/ResumeStructuredView.svelte';
   import States from '$lib/components/States.svelte';
+  import TabRow, { tabId } from '$lib/components/TabRow.svelte';
   import VerdictView from '$lib/components/VerdictView.svelte';
   import { profileStore } from '$lib/profile.svelte';
   import type { ATSResponse, FacetCounts, ResumeStructured, Verdict } from '$lib/types';
@@ -35,6 +36,16 @@
   // independently of the filter-driven reload.
   let structured = $state<ResumeStructured | null>(null);
   let loadError = $state(false);
+  // The tab strip's sections. `as const` ties `tab` to this list, so a section can't be
+  // referenced by an id the strip doesn't offer.
+  const TABS = [
+    { id: 'settings', label: 'Settings' },
+    { id: 'structured', label: 'Profile' },
+    { id: 'experience', label: 'Experience' },
+    { id: 'coverage', label: 'Market coverage' },
+    { id: 'readiness', label: 'CV readiness' },
+  ] as const;
+  const PANEL_ID = 'profile-panel';
   let tab = $state<'settings' | 'structured' | 'experience' | 'coverage' | 'readiness'>('settings');
   let modalOpen = $state(false);
   let actionError = $state<string | null>(null);
@@ -240,55 +251,21 @@
     <div class="flex gap-6">
       <main class="flex min-w-0 flex-1 flex-col gap-6">
         <!-- Tabs -->
-        <div class="flex gap-5 border-b border-border">
-          <button
-            type="button"
-            onclick={() => (tab = 'settings')}
-            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'settings'
-              ? 'border-brand text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground'}"
-          >
-            Settings
-          </button>
-          <button
-            type="button"
-            onclick={() => (tab = 'structured')}
-            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'structured'
-              ? 'border-brand text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground'}"
-          >
-            Profile
-          </button>
-          <button
-            type="button"
-            onclick={() => (tab = 'experience')}
-            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'experience'
-              ? 'border-brand text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground'}"
-          >
-            Experience
-          </button>
-          <button
-            type="button"
-            onclick={() => (tab = 'coverage')}
-            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
-              ? 'border-brand text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground'}"
-          >
-            Market coverage
-          </button>
-          <button
-            type="button"
-            onclick={() => (tab = 'readiness')}
-            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'readiness'
-              ? 'border-brand text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground'}"
-          >
-            CV readiness
-          </button>
-        </div>
+        <TabRow
+          tabs={TABS}
+          active={tab}
+          onSelect={(id) => (tab = id)}
+          label="Profile sections"
+          panelId={PANEL_ID}
+        />
 
         <!-- Body -->
+        <div
+          id={PANEL_ID}
+          role="tabpanel"
+          aria-labelledby={tabId(PANEL_ID, tab)}
+          class="flex flex-col gap-6"
+        >
         {#if tab === 'experience'}
           <!-- What the product has recorded about what this person has done, and the only
                place they can correct or remove it. -->
@@ -353,6 +330,7 @@
             {/if}
           </div>
         {/if}
+        </div>
       </main>
 
       <!-- Filters refine the Market coverage comparison only, so the summary sidebar


### PR DESCRIPTION
## What was wrong

Two separate mobile defects on `/my/profile`, both visible at 390px.

**1 — the tab strips clipped.** Both tab rows were flex rows with nowhere to put their overflow. Flexbox first squeezed two-word labels to min-content (so `Market coverage` broke mid-label into two lines) and then spilled the remainder past the container edge, where it was clipped — `CV readiness` rendered as `CV readine`. Measured: the strip wants **472px** and had **358px**.

**2 — the Experience header collapsed to one word per line.** The paragraph beside the action is `flex-1`, so `flex-basis: 0`, and never claims enough width to push anything down; the action was `shrink-0` and held its full `16rem` regardless. `flex-wrap` could not help, because wrapping is driven by the basis and the basis was zero.

## What changed

The class recipe for a tab was duplicated across both profile rows *and* the account nav in `my/+layout.svelte` — where it was already solved correctly (`overflow-x-auto` + `shrink-0 whitespace-nowrap` below `lg`). Rather than paste it a third time, it moves into a new `TabRow` component used by both profile rows. The account nav is left alone: those are route links, not tabs.

`TabRow` adds what a single implementation can afford but three copies could not:

- **Scrolls past its width** instead of squeezing then clipping.
- **`role="tablist"`, arrow-key movement, roving tabindex, `Home`/`End`.** The role is a promise to assistive tech that the group is one widget stepped through with the arrows; now something keeps it.
- **An edge fade marking content past either end.** Implemented as a `mask-image`, not a gradient overlay, so the component needs no knowledge of the surface it sits on — the page tabs are on the background, the form's sub-tabs inside a `bg-card` card. A colour overlay would have needed the surface passed in as a prop.
- **Keeps the active tab in view.** Not cosmetic: the panels' empty states contain links back to a sibling tab, so the selection can change without the user having touched the strip, and the newly-active tab would otherwise stay off-screen. It sets `scrollLeft` itself rather than calling `scrollIntoView`, which would also drag the page vertically whenever the strip sits below the fold.

The fade is **measured, not assumed** (`ResizeObserver` on the strip and its labels, plus the scroll event). An unconditional fade would paint a phantom edge-shadow on the desktop row, which already fits.

`ExperienceBankView`'s header gets `basis-full` below `sm`, which is what actually forces the action onto its own line, and keeps the previous side-by-side layout from `sm` up.

## Verification

`pnpm check` 0 errors · `pnpm lint` 0 errors · `pnpm build` ✓ · `pnpm test` 488 passed.

Visual and behavioural verification was driven over CDP at a genuine 390px viewport:

| Path | Result |
|---|---|
| Overflow is real | `scrollWidth 472` vs `clientWidth 358` — 114px that used to be clipped |
| Fade at the right edge | present at 390px, absent at 1100px (no phantom shadow) |
| Fade after scrolling to the end | mask flips to `transparent 0px, black 1.5rem, black 100%` — left on, right off |
| Programmatic tab activation | `scrollLeft` → 114, last tab fully visible, `pageScrollY` stayed `0` |
| `ArrowRight` | selection and focus both move; tabindex row `-1,0,-1,-1,-1,0,-1` — one `0` per strip |

Worth recording for the next person: **Chrome clamps `--window-size` to a 500px minimum**, so a plain `--headless --screenshot` at 390px lays out at 500px and captures only 390 of it. That shows a false clip on *every* page, including untouched ones — the control shot of `/about` looked just as broken. A real phone width needs `Emulation.setDeviceMetricsOverride` over CDP.