### PR TITLE
fix(tailor): accept the evidence id wherever the model puts it

### DIFF
--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -88,6 +88,7 @@ Never invent, inflate or imply experience the candidate has not confirmed. That 
 
 Mechanics:
 - ` + "`cv_edit`" + ` applies ONE patch per call; its schema lists the ops and the fields each one reads. Make several calls for several edits.
+- ` + "`evidence_id`" + ` sits BESIDE ` + "`patch`" + `, not inside it — the call is one object holding both, and a nested id is a patch field that does not exist.
 - Writing a bullet needs ` + "`evidence_id`" + `. Rearranging what is already on the page — reordering, removing, the technology line, the skill groups — does not.
 - Address an experience entry and a bullet by their 0-based index in what ` + "`cv_get`" + ` returned — ` + "`bullet`" + ` is that index, never the bullet's text; the new text always goes in ` + "`value`" + `.
 - The server validates every patch; if one is rejected, read the reason and correct the address rather than retrying the same shape.

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -230,7 +231,8 @@ func (h *assistantHandlers) cvGetTool(cvID uuid.UUID) assistant.Tool {
 var cvPatchSchema = map[string]any{
 	"type": "object",
 	"description": "One patch: an `op` plus the address and payload that op reads. Indices are 0-based, " +
-		"counted over what cv_get returned. Send only the fields the op needs.",
+		"counted over what cv_get returned. Send only the fields the op needs. `evidence_id` is NOT a " +
+		"patch field — it sits beside `patch`, one level up.",
 	"properties": map[string]any{
 		"op": map[string]any{
 			"type":        "string",
@@ -327,10 +329,16 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID) assistant.Tool {
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
+			// The id may arrive INSIDE the patch instead of beside it. Both readings are
+			// reasonable — the evidence belongs to the bullet the patch writes — and a real
+			// run lost three edits in a row to the strict decoder refusing the nested one,
+			// then repeating the same shape because the error never said where it belonged.
+			// Accept either position; the provenance check below is untouched.
+			patch, evidenceID := liftEvidenceID(in.Patch, in.EvidenceID)
 			// Decode strictly, exactly as the HTTP endpoint does: a stray field or a
 			// numeric where a string belongs must fail with a reason rather than
 			// silently editing the wrong part of the document.
-			p, err := cv.DecodePatch(in.Patch)
+			p, err := cv.DecodePatch(patch)
 			if err != nil {
 				return nil, err // already reads "cv: invalid patch: <reason>"
 			}
@@ -339,7 +347,7 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID) assistant.Tool {
 			if p.Op == cv.PatchSetHeaderField && isContactHeaderField(p.Field) {
 				return nil, errors.New("contact fields are not editable in a tailoring session")
 			}
-			if err := h.requireEvidence(ctx, userID, p.Op, in.EvidenceID); err != nil {
+			if err := h.requireEvidence(ctx, userID, p.Op, evidenceID); err != nil {
 				return nil, err
 			}
 			meta, err := h.cv.cvStore.Patch(ctx, cvID, userID, p)
@@ -349,6 +357,36 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID) assistant.Tool {
 			return map[string]any{"updated_at": meta.UpdatedAt, "title": meta.Title}, nil
 		},
 	}
+}
+
+// liftEvidenceID moves a nested `evidence_id` out of the patch object, so the strict patch
+// decoder sees only patch fields. A top-level id wins if both are present, and a patch that
+// carries none is returned untouched — the cheapest path stays allocation-free.
+func liftEvidenceID(patch json.RawMessage, topLevel string) (json.RawMessage, string) {
+	if !bytes.Contains(patch, []byte(`"evidence_id"`)) {
+		return patch, topLevel
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(patch, &fields); err != nil {
+		return patch, topLevel // let DecodePatch report the real problem
+	}
+	raw, ok := fields["evidence_id"]
+	if !ok {
+		return patch, topLevel
+	}
+	delete(fields, "evidence_id")
+	cleaned, err := json.Marshal(fields)
+	if err != nil {
+		return patch, topLevel
+	}
+	if topLevel != "" {
+		return cleaned, topLevel
+	}
+	var nested string
+	if err := json.Unmarshal(raw, &nested); err != nil {
+		return cleaned, topLevel // a non-string id fails the provenance check with its own message
+	}
+	return cleaned, nested
 }
 
 // cvToolError renders a CV failure for the model, keeping owner isolation intact:

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/experience"
 )
 
 // cvRepo is a one-document stand-in for cv.Repository: it serves a single owned
@@ -357,5 +358,69 @@ func TestTailorReportReplacesRatherThanAppends(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0]["status"] != "closed_candidate" {
 		t.Errorf("stored report = %s, want one entry carrying the newer status", repo.report)
+	}
+}
+
+// A real run failed three edits in a row with `unknown field "evidence_id"`: the model put the
+// id INSIDE the patch object instead of beside it. Both readings are reasonable — the id
+// belongs to the bullet the patch writes — and the strict patch decoder refuses the nested one.
+//
+// Refusing it costs a tool round and, when it repeats, the whole run: the same misplacement
+// comes back because nothing in the error says where the field belongs. So the tool accepts
+// either position. The provenance check is unchanged; only the reading is forgiving.
+func TestCVEditAcceptsEvidenceIdInsideThePatch(t *testing.T) {
+	a, repo := cvToolsAPI(t, oneExperienceCV)
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{
+		Claim:      "Ran the payments Kafka cluster.",
+		Provenance: experience.ProvenanceStatedInChat,
+	})
+	a.experience = bank
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"patch":{"op":"add_bullet","experience":0,"value":"Ran the payments Kafka cluster.","evidence_id":"`+atom.ID.String()+`"}}`))
+	if err != nil {
+		t.Fatalf("a nested evidence_id was refused: %v", err)
+	}
+	if !strings.Contains(string(repo.written), "Kafka") {
+		t.Errorf("the bullet was not written: %s", repo.written)
+	}
+}
+
+// The wall still holds when the id is nested: a nested id that is not the candidate's own
+// evidence must be refused exactly as a top-level one is.
+func TestCVEditStillRequiresRealEvidenceWhenNested(t *testing.T) {
+	a, repo := cvToolsAPI(t, oneExperienceCV)
+	bank := newStubBank()
+	inferred := bank.add(3, experience.Atom{
+		Claim:      "Probably led the migration.",
+		Provenance: experience.ProvenanceAgentInferred,
+	})
+	a.experience = bank
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_edit")
+	if _, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"patch":{"op":"add_bullet","experience":0,"value":"Led the migration.","evidence_id":"`+inferred.ID.String()+`"}}`)); err == nil {
+		t.Fatal("a nested id pointing at the agent's own inference was accepted")
+	}
+	if repo.written != nil {
+		t.Errorf("a refused edit still wrote: %s", repo.written)
+	}
+}
+
+// A bullet with the id in NEITHER place is still refused, and the message says where it goes.
+func TestCVEditWithoutAnyEvidenceIdNamesWhereItGoes(t *testing.T) {
+	a, _ := cvToolsAPI(t, oneExperienceCV)
+	a.experience = newStubBank()
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"patch":{"op":"add_bullet","experience":0,"value":"Led the migration."}}`))
+	if err == nil {
+		t.Fatal("a bullet with no evidence was accepted")
+	}
+	if !strings.Contains(err.Error(), "experience_search") {
+		t.Errorf("error %q does not tell the model how to get an id", err)
 	}
 }


### PR DESCRIPTION
## What and why

From a real run on production, three edits in a row:

```
Updating your CV: add_bullet
— cv: invalid patch: json: unknown field "evidence_id"
Updating your CV: add_bullet
— cv: invalid patch: json: unknown field "evidence_id"
Updating your CV: add_bullet
— cv: invalid patch: json: unknown field "evidence_id"
```

The tool's shape is `{"patch": {...}, "evidence_id": "..."}`. The model sent the id **inside** the patch — and kept sending it that way, because the refusal named the field but never said where it belonged. The transcript shows both readings from the same session:

```jsonc
{"evidence_id": "ea5ee2ee…", "patch": {"op":"add_bullet", …}}          // beside — accepted
{"patch": {"op":"add_bullet", …, "evidence_id": "4763…"}}              // inside — refused
```

Both readings are reasonable: the evidence belongs to the bullet the patch writes. The strict decoder (`DisallowUnknownFields`, which exists so a mis-addressed patch fails loudly rather than editing the wrong bullet) had no reason to know about a field that isn't a patch field at all.

## The fix

- `cv_edit` lifts a nested `evidence_id` out of the patch before decoding, so either position works. A top-level id wins if both are present; a patch without the field is passed through untouched.
- **The provenance wall is unchanged.** A nested id still resolves through `requireEvidence`: an id that isn't the candidate's own assertion is refused exactly as before, and the refused edit writes nothing. There are tests for both.
- The schema and the prompt now say where the field goes, in the two places the model reads while composing the call.

This follows the project's existing line on LLM JSON — be forgiving about shape at the boundary, strict about meaning inside it.

## Verification

`go build` / `go vet` / `gofmt` clean, `go test ./...` green, integration suite over real Postgres green.

Three new tests: a nested id writes the bullet, a nested id pointing at the agent's own inference is refused and writes nothing, and a bullet with the id in neither place is refused with a message that names `experience_search`.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [x] I regenerated committed artifacts when their source changed — none changed.
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.
