### PR TITLE
feat(match): a blurred, job-derived match teaser for viewers without one

### DIFF
--- a/openspec/changes/guest-match-teaser/.openspec.yaml
+++ b/openspec/changes/guest-match-teaser/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/guest-match-teaser/design.md
+++ b/openspec/changes/guest-match-teaser/design.md
@@ -1,0 +1,144 @@
+## Context
+
+Two surfaces render a profile match today, from the same state machine
+(`resolveMatchState` in `web/src/lib/jobMatch.ts`) but with different fallbacks for
+the locked states:
+
+- `JobMatchBar` (inside `JobRow`) renders `null` when the owning card passes
+  `match: null` — so a guest sees nothing.
+- `JobMatch` (job-detail sidebar, also used by `JobDrawer` and `SwipeDeck`) renders a
+  module-level constant `{percent: 76, have: ['React','Docker','SQL'], missing: ['Kafka']}`
+  under `blur-[1.5px]`.
+
+The job itself is server-rendered; only the viewer's profile hydrates client-side via
+`profileStore`. That asymmetry is what forces the teaser to be a pure function of the
+job: it has to produce the same output in the SSR pass, before any profile is known,
+as it does after hydration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One teaser derivation, shared by the card and the sidebar, so the same job cannot
+  show 73% in the feed and 68% on its own page.
+- Teaser figures that survive SSR → hydration and arbitrary re-renders unchanged.
+- Teaser chips that name the job's real skills.
+- No new network traffic: the locked states still never call `GET /jobs/:slug/match`.
+
+**Non-Goals:**
+
+- Computing a genuine match for a guest. There is no profile to match against; the
+  teaser is an invitation, not an estimate.
+- Touching the backend match endpoint, its formula, or the adjacency dictionary.
+- Changing what a viewer with a profile sees, on either surface.
+
+## Decisions
+
+### Deterministic hash over `Math.random()`
+
+The teaser is seeded from `job.public_slug` through FNV-1a (32-bit) and a `mulberry32`
+PRNG, both a handful of lines and dependency-free.
+
+`Math.random()` was the obvious alternative and is wrong here for three separate
+reasons, each of which is a visible defect rather than a theoretical concern:
+
+1. **SSR divergence.** The server renders one number, the client another; Svelte
+   replaces the text on hydration, so the percentage visibly flips on first paint.
+2. **Re-render churn.** The feed re-renders on filter changes and pagination. A
+   `$derived` over `Math.random()` re-rolls, so a card's score changes while the user
+   scrolls past it.
+3. **Cross-surface disagreement.** `JobDrawer` shows the sidebar block over the same
+   feed that shows the card. Two independent rolls put two different scores for one
+   job on screen at once.
+
+A slug-seeded hash costs about fifteen lines and removes all three.
+
+### `matchTeaser()` returns a `missing` set, not a chip list
+
+The helper's shape is deliberate:
+
+```ts
+export type MatchTeaser = {
+  percent: number;      // 60..90
+  matched: number;      // round(percent/100 × total)
+  total: number;        // the job's real skill count
+  missing: Set<string>; // which of the job's real skills read as "missing"
+};
+```
+
+`{percent, matched, total}` is structurally the existing `ClientMatch`, so
+`JobMatchBar` needs no new shape to render a teaser — only a `blurred` flag. Handing
+back a `Set` of names rather than a pre-sliced chip list keeps the decision of *how
+many* chips to show with each surface (the card shows five, the sidebar three) while
+the *tint* of any given skill stays one shared answer. A pre-built list would have
+forced the sidebar's cap onto the card.
+
+### Coherence beats pure randomness
+
+`matched` is derived from `percent`, not rolled independently, and the missing set is
+sized as `total - matched`. Rolling them apart produces cards that read as bugs — a
+73% bar over four green chips, or "8 of 11" beside 61%. The randomness is spent on
+*which* skills are marked missing (a `mulberry32` shuffle), not on the arithmetic, so
+red chips scatter through the row instead of always trailing it.
+
+Two clamps keep the visual honest at the edges: at least one held skill (never an
+all-red row under a 60–90% bar) and at least one missing (never an all-green row under
+anything short of 100%).
+
+### A one-skill job gets no teaser
+
+Rendering the teaser against live data showed the one case where a viewer can catch it
+out: a job with a single skill reads "1 of 1 skills" beside an 87% bar and a lone green
+chip. The fraction says everything matched, the bar says it didn't, and there is no
+have/missing contrast to show in the first place.
+
+The alternative — suppressing just the fraction for that case — trades one visible
+inconsistency for a special case in two components. Dropping the teaser below two
+skills instead *removes* a special case: the "at least one missing" clamp becomes
+unconditional and the percent ceiling loses its `total === 1` branch. On a sampled feed
+page, 57% of jobs carry no skills at all (already the not-enough-data state) and 11%
+carry exactly one, so the teaser covers the 32% where it has something to say.
+
+### A capped chip row borrows a missing skill
+
+The sidebar fits three chips at a legible width. Cutting the job's first three skills
+can miss the only missing one — a job at "5 of 6 skills" often renders a uniformly green
+row, which is precisely the contrast the teaser exists to show. `teaserChips` therefore
+trades the row's last chip for the first missing skill when the window would otherwise
+be all-held, preserving the job's own order among the rest.
+
+The card's five-chip window is left alone: its chip order is real information shared
+with the signed-in state, and a wider window rarely misses every missing skill.
+
+### Blur the chips container, not the row
+
+On the card, the skills and the salary share one flex row. The blur goes on the chips
+container so the salary — real information a guest should be able to read — stays
+crisp. The existing `Badge` variants `brand` and `missing` already carry the two
+tones (`design-system/src/Badge.svelte`), so no new styling is introduced.
+
+### `aria-hidden` plus an `sr-only` invitation
+
+The blurred strip gets `aria-hidden="true"`, and the card exposes a visually-hidden
+"Sign in to see your profile match" in its place. Today `JobMatchBar` builds an
+`aria-label` announcing the percentage; leaving that in place for a teaser would read
+a fabricated score to a screen-reader user as fact, which the blur does not
+communicate to them at all.
+
+## Risks / Trade-offs
+
+- **A guest reads the teaser as a real score.** → It is blurred and hidden from
+  assistive technology, which is offered the sign-in invitation in its place. In the
+  sidebar the copy names it as not-yet-computed ("Sign in to see your match"); on the
+  card the blur is the only signal a sighted viewer gets, since the card has no room
+  for copy and the spec asks for none. Accepted: the same trade the existing static
+  teaser already makes, now less contradictory because the skills on screen belong to
+  the job. If the blur alone proves too subtle in the feed, a lock glyph in the strip
+  is the cheap next step.
+- **The card's skill names become harder to read for guests.** → `blur-[1.5px]` is
+  light enough to leave short dictionary slugs legible, and the text stays in the DOM,
+  so crawlers and SEO are unaffected. This was an explicit product call in favour of
+  the stronger nudge.
+- **A slug-derived percent is stable enough to be mistaken for meaningful.** → It is
+  by construction never at either extreme (60–90) and never 100%, so it cannot be
+  read as a verdict.

--- a/openspec/changes/guest-match-teaser/proposal.md
+++ b/openspec/changes/guest-match-teaser/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+A signed-out visitor browsing the feed sees no hint that the product can tell them
+how well a job fits — the card-level coverage bar renders only for a signed-in
+viewer with a skills profile, so the single most persuasive reason to sign in is
+invisible exactly where the decision is made. The one place a guest does see a
+teaser (the job-detail Profile match block) shows hardcoded `React / Docker / SQL /
+Kafka` chips at a fixed `76%`, which contradicts the job on screen and reads as a
+mock rather than as a preview of a real feature.
+
+## What Changes
+
+- Job cards show a blurred profile-match teaser (tinted skill chips plus the
+  coverage strip) to the two locked viewer states — guest and signed-in-without-skills
+  — where today they show nothing. A viewer with a real match is unaffected.
+- The teaser's figures become **deterministic per job**, derived from the job's
+  public slug: a coverage percent in 60–90 and a have/missing split over the job's
+  **own** skills. Same job, same numbers on every render, on the server and in the
+  browser, on the card and in the sidebar.
+- The Profile match block's teaser drops its hardcoded skill names for the real
+  skills of the job being viewed, capped to a single non-wrapping row.
+- The blurred teaser is hidden from assistive technology and replaced there by the
+  sign-in affordance, so a screen reader is never told a fabricated score.
+
+## Capabilities
+
+### New Capabilities
+<!-- none: this extends an existing capability -->
+
+### Modified Capabilities
+- `job-profile-match`: the locked (guest / no-profile) states change from a static
+  sidebar-only teaser to a deterministic, job-derived teaser rendered in both the
+  sidebar block and the job card.
+
+## Impact
+
+- `web/src/lib/jobMatch.ts` — new pure `matchTeaser()` helper beside the existing
+  `resolveMatchState` / `computeClientMatch`; `web/src/lib/jobMatch.test.ts` grows.
+- `web/src/lib/components/JobMatchBar.svelte` — new `blurred` prop.
+- `web/src/lib/components/JobRow.svelte` — chip tint and the blurred wrapper for the
+  locked states.
+- `web/src/lib/components/JobMatch.svelte` — the static teaser constant is removed.
+- Frontend only: no API, no schema, no worker touched. The match endpoint is still
+  never called for a locked viewer, so no new request volume.

--- a/openspec/changes/guest-match-teaser/specs/job-profile-match/spec.md
+++ b/openspec/changes/guest-match-teaser/specs/job-profile-match/spec.md
@@ -1,0 +1,109 @@
+## MODIFIED Requirements
+
+### Requirement: Sidebar match block states
+
+The job-detail sidebar SHALL render a match block at its top with exactly four mutually exclusive states, choosing the state without redundant network calls. The guest and no-profile states SHALL show a lightly-blurred teaser built from the open job's own skills with a single footer call-to-action, and MUST NOT call the match endpoint.
+
+#### Scenario: Not-enough-data state
+
+- **WHEN** the open job has no recognised skills
+- **THEN** the block SHALL show a "not enough data" card and SHALL NOT call the match endpoint
+
+#### Scenario: Guest state
+
+- **WHEN** the viewer is not authenticated and the job has two or more skills
+- **THEN** the block SHALL show a lightly-blurred teaser carrying the job's own skills, its deterministic percentage, and a footer "Sign in" button, and SHALL NOT call the match endpoint
+
+#### Scenario: No-profile state
+
+- **WHEN** the viewer is authenticated but has no profile or an empty profile skill list
+- **THEN** the block SHALL show the same lightly-blurred teaser with a footer "Upload CV" button, and SHALL NOT call the match endpoint
+
+#### Scenario: Single-skill job shows the call-to-action alone
+
+- **WHEN** a locked viewer opens a job carrying exactly one skill
+- **THEN** the block SHALL show its call-to-action without a teaser and without the rule that would divide them
+
+#### Scenario: Teaser chips stay on one row
+
+- **WHEN** the open job carries more skills than fit the sidebar's width
+- **THEN** the teaser SHALL cap the chips it renders at a count that leaves each name legible and clip the row at the panel's edge, so it never wraps to a second line
+
+#### Scenario: A short chip row still shows both tones
+
+- **WHEN** the capped chip row would otherwise consist entirely of skills the teaser marks as held
+- **THEN** the row SHALL trade its last chip for the job's first missing skill, so the have/missing contrast survives the cap
+
+#### Scenario: Real match state
+
+- **WHEN** the viewer is authenticated with a non-empty profile skill list and the job has skills
+- **THEN** the block SHALL call the match endpoint and render the percentage, a two-colour progress bar (exact segment plus a half-weight adjacent segment), and three chip groups — You have (exact), Close (adjacent, each hinting its `via` skill), and Missing
+
+## ADDED Requirements
+
+### Requirement: Deterministic locked-state teaser figures
+
+The teaser figures SHALL be derived deterministically from the job's public slug, so the same job yields the same teaser on every render, during server-side rendering and after hydration, and in every surface that shows it. The teaser MUST be built from the job's own skills — never from a hardcoded skill list — and MUST NOT be presented as a computed match. It SHALL report a coverage percent between 60 and 90 inclusive, a matched count consistent with that percent over the job's real skill count, and a have/missing split marking at least one skill as held and at least one as missing. A job carrying fewer than two skills SHALL yield no teaser: there is no contrast to draw, and a "1 of 1 skills" label beside a partly-filled bar is a figure a viewer could catch out.
+
+#### Scenario: Same job renders the same teaser
+
+- **WHEN** the teaser is derived twice for one job slug
+- **THEN** both derivations SHALL yield an identical percent and an identical have/missing split
+
+#### Scenario: Percent stays inside the teaser band
+
+- **WHEN** the teaser is derived for any job slug
+- **THEN** the percent SHALL be at least 60 and at most 90
+
+#### Scenario: Matched count agrees with the percent
+
+- **WHEN** the teaser reports a percent for a job with a known skill count
+- **THEN** the matched count SHALL be that percent of the skill count, rounded, so the "N of M skills" label cannot contradict the percentage shown beside it
+
+#### Scenario: Both tones are present
+
+- **WHEN** the teaser is derived for any job it applies to
+- **THEN** at least one skill SHALL read as held and at least one SHALL read as missing
+
+#### Scenario: A skill-less job has no teaser
+
+- **WHEN** the teaser is derived for a job with an empty skill list
+- **THEN** it SHALL yield nothing, leaving the not-enough-data state to render
+
+#### Scenario: A single-skill job has no teaser
+
+- **WHEN** the teaser is derived for a job carrying exactly one skill
+- **THEN** it SHALL yield nothing, and the surfaces SHALL fall back to what they show for a viewer with no teaser
+
+### Requirement: Card-level teaser for locked viewers
+
+A job card SHALL show the blurred profile-match teaser to a viewer in either locked state — not authenticated, or authenticated without profile skills — where a viewer with profile skills sees the real client-computed coverage bar. The card's skill chips SHALL take their held/missing tint from the same teaser that feeds its bar, so the chips and the percentage cannot disagree. Blurring SHALL cover the chips and the coverage strip only, leaving the rest of the card — salary included — legible.
+
+#### Scenario: Guest sees the blurred teaser
+
+- **WHEN** an unauthenticated viewer sees a card for a job with two or more skills
+- **THEN** the card SHALL render the tinted skill chips and the coverage strip under a light blur, and SHALL NOT issue a per-card match request
+
+#### Scenario: Signed-in viewer without skills sees the blurred teaser
+
+- **WHEN** an authenticated viewer whose profile has no skills sees a card for a job with two or more skills
+- **THEN** the card SHALL render the same blurred teaser as a guest
+
+#### Scenario: A viewer with a profile sees the real bar
+
+- **WHEN** an authenticated viewer with profile skills sees a card for a job with two or more skills
+- **THEN** the card SHALL render the client-computed coverage bar unblurred, with chips tinted by the viewer's actual skills
+
+#### Scenario: Salary stays legible under the teaser
+
+- **WHEN** a card showing the blurred teaser also carries a salary
+- **THEN** the salary SHALL render unblurred
+
+### Requirement: The blurred teaser is not announced as a score
+
+The blurred teaser SHALL be hidden from assistive technology, and a screen reader MUST NOT be given its fabricated percentage as if it were the viewer's match. A card showing the teaser SHALL expose, in place of the hidden figures, a text alternative pointing at the sign-in affordance.
+
+#### Scenario: Screen reader is offered the invitation, not the number
+
+- **WHEN** a card renders the blurred teaser
+- **THEN** the teaser strip SHALL be marked hidden from assistive technology, and a visually-hidden invitation to sign in for a real match SHALL be exposed instead

--- a/openspec/changes/guest-match-teaser/tasks.md
+++ b/openspec/changes/guest-match-teaser/tasks.md
@@ -1,0 +1,22 @@
+## 1. The teaser derivation
+
+- [x] 1.1 Add `matchTeaser(seed, jobSkills)` to `web/src/lib/jobMatch.ts`, test-first in `web/src/lib/jobMatch.test.ts`: determinism for one seed, percent within 60–90 across many seeds, `matched === round(percent/100 × total)`, at least one held skill and at least one missing, `null` for a job with fewer than two skills, and a spread of percents across distinct slugs
+- [x] 1.2 Confirm the returned `{percent, matched, total}` is assignable to the existing `ClientMatch` shape consumed by `JobMatchBar`, so the bar needs no second match type
+
+## 2. The card teaser
+
+- [x] 2.1 Add a `blurred` prop to `web/src/lib/components/JobMatchBar.svelte`: light blur, non-interactive, `aria-hidden` on the strip, and a visually-hidden sign-in invitation in place of the announced percentage
+- [x] 2.2 In `web/src/lib/components/JobRow.svelte`, derive the teaser for the `guest` and `no-profile` states and pass it to `JobMatchBar` with `blurred`; a `ready` viewer keeps the real client-computed match unblurred
+- [x] 2.3 Tint the card's skill chips from the teaser's missing set in the locked states, and blur the chips container only — the salary in the same row stays legible
+
+## 3. The sidebar teaser
+
+- [x] 3.1 Replace the hardcoded teaser constant in `web/src/lib/components/JobMatch.svelte` with `matchTeaser(job.public_slug, job.skills)`, wiring the percent, the bar width, and the "N of M skills" label to it
+- [x] 3.2 Render the teaser chips from the job's own skills, capped at three at natural width (clipped, not ellipsised) so the row cannot wrap
+- [x] 3.3 Add `teaserChips` so a capped row still carries a missing skill, and drop the teaser entirely for a single-skill job (no have/missing contrast to draw)
+
+## 4. Verification
+
+- [x] 4.1 `pnpm test` and `pnpm lint` green in `web/`; `pnpm build` succeeds
+- [x] 4.2 Visually verify the guest state against the production API: the feed's blurred chips and strip with the salary still crisp, the sidebar teaser on a six-skill job, and the bare call-to-action on a single-skill job
+- [ ] 4.3 Verify the two signed-in states (no profile skills, and a real match) in a browser — needs a session, so not covered by the guest pass above; the `ready` markup is unchanged and `no-profile` shares the guest branch apart from its call-to-action

--- a/web/src/lib/components/JobMatch.svelte
+++ b/web/src/lib/components/JobMatch.svelte
@@ -4,7 +4,13 @@
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
-  import { resolveMatchState, matchBarSegments, partitionBlockers } from '$lib/jobMatch';
+  import {
+    resolveMatchState,
+    matchBarSegments,
+    matchTeaser,
+    teaserChips,
+    partitionBlockers,
+  } from '$lib/jobMatch';
   import { profileStore } from '$lib/profile.svelte';
   import type { BlockerSeverity, Job, JobMatchResult } from '$lib/types';
   import { Button } from '$lib/ui';
@@ -23,9 +29,12 @@
     if (isAuthenticated()) profileStore.ensureLoaded();
   });
 
+  // Top-level `skills` is the served dictionary facet; absent on a non-tech posting.
+  const jobSkills = $derived(job.skills ?? []);
+
   const blockState = $derived(
     resolveMatchState({
-      jobSkills: job.skills ?? [],
+      jobSkills,
       authenticated: isAuthenticated(),
       profileLoaded: profileStore.loaded,
       profileSkills: profileStore.profile?.skills,
@@ -55,8 +64,24 @@
     return 'text-muted-foreground';
   }
 
-  // Static teaser for the locked states — deliberately not a real score.
-  const teaser = { percent: 76, have: ['React', 'Docker', 'SQL'], missing: ['Kafka'] };
+  // The locked states' teaser — deliberately not a real score, but built from this job's
+  // own skills and seeded from its slug, so it agrees with the same job's card in the
+  // feed instead of naming skills the posting never mentioned.
+  // Gated on the block state, not just on the template branch it renders in, so "can the
+  // teaser reach a viewer with a real match?" is answered here rather than by reading the
+  // markup — and so the derivation doesn't run for the states that discard it.
+  const teaser = $derived(
+    blockState === 'guest' || blockState === 'no-profile'
+      ? matchTeaser(job.public_slug, jobSkills)
+      : null,
+  );
+  // Three is what a ~285px sidebar column fits at natural chip width; a fourth forced
+  // every name down to an unreadable stub ("anal…", "c…"). teaserChips makes sure the
+  // short row still carries a missing skill.
+  const TEASER_CHIPS = 3;
+  const teaserSkills = $derived(
+    teaser ? teaserChips(jobSkills, teaser.missing, TEASER_CHIPS) : [],
+  );
 
   const chip = 'rounded-full border px-2 py-0.5 text-xs font-medium';
   const haveChip = `${chip} border-brand/30 bg-brand-muted text-brand-strong`;
@@ -75,21 +100,40 @@
   {#if blockState === 'no-skills'}
     <p class="text-sm text-muted-foreground">Not enough data to compare this job to your profile.</p>
   {:else if blockState === 'guest' || blockState === 'no-profile'}
-    <!-- Locked teaser: lightly-blurred static content (not a real score) + a footer CTA. -->
-    <div class="pointer-events-none select-none space-y-3 opacity-90 blur-[1.5px]" aria-hidden="true">
-      <div class="flex items-baseline justify-between gap-2">
-        <span class="text-2xl font-bold tabular-nums leading-none">{teaser.percent}%</span>
-        <span class="text-xs text-muted-foreground">4 of 5 skills</span>
+    <!-- Locked teaser: lightly-blurred figures (not a real score) over the job's own
+         skills + a footer CTA. A single-skill job has no teaser (nothing to contrast),
+         and then the call-to-action stands alone under the heading. -->
+    {#if teaser}
+      <div class="pointer-events-none select-none space-y-3 opacity-90 blur-[1.5px]" aria-hidden="true">
+        <div class="flex items-baseline justify-between gap-2">
+          <span class="text-2xl font-bold tabular-nums leading-none">{teaser.percent}%</span>
+          <span class="shrink-0 text-xs text-muted-foreground">
+            {teaser.matched} of {teaser.total} skills
+          </span>
+        </div>
+        <div class="flex h-2 overflow-hidden rounded bg-secondary">
+          <div class="h-full bg-brand" style="width: {teaser.percent}%"></div>
+        </div>
+        <!-- Chips keep their natural width and the row clips at the panel edge, rather
+             than every name being ellipsised to fit — a clipped last chip still reads,
+             an "anal…" does not. -->
+        <div class="flex flex-nowrap gap-1.5 overflow-hidden">
+          {#each teaserSkills as skill (skill)}
+            <span class={`${teaser.missing.has(skill) ? missChip : haveChip} whitespace-nowrap`}>
+              {skill}
+            </span>
+          {/each}
+        </div>
       </div>
-      <div class="flex h-2 overflow-hidden rounded bg-secondary">
-        <div class="h-full bg-brand" style="width: {teaser.percent}%"></div>
-      </div>
-      <div class="flex flex-wrap gap-1.5">
-        {#each teaser.have as skill (skill)}<span class={haveChip}>{skill}</span>{/each}
-        {#each teaser.missing as skill (skill)}<span class={missChip}>{skill}</span>{/each}
-      </div>
-    </div>
-    <div class="flex items-center justify-between gap-2 border-t border-dashed border-border pt-3">
+    {/if}
+    <!-- The dashed rule divides the teaser from the call-to-action; with no teaser above
+         it there is nothing to divide, so it goes. -->
+    <div
+      class={[
+        'flex items-center justify-between gap-2',
+        teaser && 'border-t border-dashed border-border pt-3',
+      ]}
+    >
       {#if blockState === 'guest'}
         <span class="flex items-center gap-1.5 text-xs text-muted-foreground">
           <Lock class="size-3.5 shrink-0" />Sign in to see your match

--- a/web/src/lib/components/JobMatchBar.svelte
+++ b/web/src/lib/components/JobMatchBar.svelte
@@ -5,15 +5,34 @@
   // Purely presentational — the owning JobRow computes the client-side match (exact
   // overlap of the job's skills and the signed-in viewer's profile skills) and passes it
   // in, so the chips it colours and this bar can't disagree on the score. `match` is null
-  // for guests / no-profile viewers, in which case nothing renders. `gutterRight` reserves
+  // when there is nothing to show, in which case nothing renders. `gutterRight` reserves
   // the feed's bottom-right hide control so the percent never slides under that icon.
-  let { match, gutterRight = false }: { match: ClientMatch | null; gutterRight?: boolean } = $props();
+  //
+  // `blurred` renders the same strip as a teaser for a viewer who has no match yet — a
+  // guest, or a signed-in viewer with no profile skills. The figures are then the job's
+  // deterministic teaser rather than a computed score, so they are lightly blurred and
+  // hidden from assistive technology: a fabricated percentage must not be read out as
+  // this viewer's match. Offering the text alternative is the caller's job — only it
+  // knows which invitation applies, and where it can sit without joining the accessible
+  // name of a card-wide link.
+  let {
+    match,
+    gutterRight = false,
+    blurred = false,
+  }: { match: ClientMatch | null; gutterRight?: boolean; blurred?: boolean } = $props();
 </script>
 
 {#if match}
   <div
-    class={['mt-3 flex items-center gap-2 border-t border-dashed border-border pt-2.5', gutterRight && 'pr-9']}
-    aria-label="Profile match: {match.percent}%, {match.matched} of {match.total} skills"
+    class={[
+      'mt-3 flex items-center gap-2 border-t border-dashed border-border pt-2.5',
+      gutterRight && 'pr-9',
+      blurred && 'pointer-events-none select-none opacity-90 blur-[1.5px]',
+    ]}
+    aria-label={blurred
+      ? undefined
+      : `Profile match: ${match.percent}%, ${match.matched} of ${match.total} skills`}
+    aria-hidden={blurred ? 'true' : undefined}
   >
     <!-- The unfilled remainder is a soft red (the skills you're missing); the fill is the
          brand tone (the skills you have) — a two-tone have/missing bar in one track. -->

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -9,7 +9,7 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { cardTags, formatSalary } from '$lib/enrichment';
-  import { computeClientMatch, resolveMatchState } from '$lib/jobMatch';
+  import { computeClientMatch, matchTeaser, resolveMatchState } from '$lib/jobMatch';
   import { profileStore } from '$lib/profile.svelte';
   import { metaDescription } from '$lib/seo';
   import type { Job } from '$lib/types';
@@ -95,12 +95,31 @@
     }),
   );
   // The viewer's skills as a lowercase set, only when there's a real match to show —
-  // used to tint each skill chip (a skill you have vs one you're missing). Null for
-  // guests / no-profile viewers, who see the plain brand chips.
+  // used to tint each skill chip (a skill you have vs one you're missing). Null in the
+  // locked states, where the teaser below decides the tint instead.
   const haveSet = $derived(
     matchState === 'ready' ? new Set(profileSkills.map((s) => s.toLowerCase())) : null,
   );
   const match = $derived(matchState === 'ready' ? computeClientMatch(skills, profileSkills) : null);
+
+  // A viewer with no match to show — signed out, or signed in with no skills — gets the
+  // job's deterministic teaser instead of an empty card corner: the same chips and strip,
+  // blurred, as an invitation to sign in. Seeded from the slug, so the figures survive
+  // hydration and agree with the sidebar block on the job's own page.
+  const teaser = $derived(
+    matchState === 'guest' || matchState === 'no-profile'
+      ? matchTeaser(job.public_slug, skills)
+      : null,
+  );
+
+  // A chip is red when the viewer's own profile lacks the skill, or — under the teaser —
+  // when the teaser marked it missing. Both tints come from the same source as the strip
+  // below, so the chips and the percentage can never tell different stories.
+  function chipVariant(skill: string): 'brand' | 'missing' {
+    if (haveSet) return haveSet.has(skill.toLowerCase()) ? 'brand' : 'missing';
+    if (teaser) return teaser.missing.has(skill) ? 'missing' : 'brand';
+    return 'brand';
+  }
 
   // Whether the signed-in user has saved this job, read from the shared saved set
   // (loaded once on the browse view). The bookmark reflects this and updates the
@@ -290,16 +309,23 @@
          doesn't need. With basis:auto the row's width is derived from its max-content
          width, so shorter chips would ironically shrink the row and cause *more*
          wrapping. -->
-    <div class="flex w-full min-w-0 flex-wrap items-center gap-1.5 sm:w-auto sm:flex-1">
+    <!-- Under the teaser the chips are blurred with the strip below, because their
+         green/red tint is part of the same not-yet-computed signal. The blur stops at
+         this container so the salary beside it — real information — stays crisp. The
+         skill names themselves are left announced to assistive technology: they're the
+         job's own facet, and colour was never conveyed there in the first place. -->
+    <div
+      class={[
+        'flex w-full min-w-0 flex-wrap items-center gap-1.5 sm:w-auto sm:flex-1',
+        teaser && 'pointer-events-none select-none opacity-90 blur-[1.5px]',
+      ]}
+    >
       <!-- A long dictionary slug ("event-driven-architecture") would wrap inside its
            own chip and stretch the row to two lines, breaking the card's rhythm on a
            phone. Each chip stays one line and ellipsises past max-w; the full skill is
            in `title` for anyone who needs it. -->
       {#each shownSkills as skill (skill)}
-        <Badge
-          variant={haveSet && !haveSet.has(skill.toLowerCase()) ? 'missing' : 'brand'}
-          class="max-w-[9rem]"
-        >
+        <Badge variant={chipVariant(skill)} class="max-w-[9rem]">
           <span class="truncate" title={skill}>{skill}</span>
         </Badge>
       {/each}
@@ -312,11 +338,26 @@
     {/if}
   </div>
 
-  <!-- Card-level profile match: a thin coverage bar shown only to a signed-in viewer with
-       a skills profile (`match` is null otherwise). `gutterRight` keeps the percent clear
-       of the feed's bottom-right hide control. -->
-  <JobMatchBar {match} gutterRight={!!onHide} />
+  <!-- Card-level profile match: the real client-computed coverage bar for a signed-in
+       viewer with a skills profile, the blurred teaser for one without. `blurred` is
+       gated on there being no real match too, so the two props cannot contradict each
+       other and render a genuine score under a blur. `gutterRight` keeps the percent
+       clear of the feed's bottom-right hide control. -->
+  <JobMatchBar match={match ?? teaser} blurred={!match && !!teaser} gutterRight={!!onHide} />
 </a>
+
+{#if teaser}
+  <!-- The blurred strip is hidden from assistive technology, so this is what stands in
+       for it — the invitation that would actually get this viewer a real match. It sits
+       outside the card link deliberately: `sr-only` is clip-based, not display:none, so
+       inside the <a> it would join the link's accessible name and every card in the feed
+       would announce a sign-in instruction that the link doesn't carry out. -->
+  <span class="sr-only">
+    {matchState === 'guest'
+      ? 'Sign in to see how this job matches your profile'
+      : 'Add your skills to see how this job matches your profile'}
+  </span>
+{/if}
 
 {#if footer}
   <!-- Optional in-card actions row (e.g. the saved list's reminder chip, the

--- a/web/src/lib/jobMatch.test.ts
+++ b/web/src/lib/jobMatch.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { resolveMatchState, matchBarSegments, computeClientMatch, partitionBlockers } from './jobMatch';
+import {
+  resolveMatchState,
+  matchBarSegments,
+  computeClientMatch,
+  matchTeaser,
+  teaserChips,
+  partitionBlockers,
+} from './jobMatch';
 
 describe('resolveMatchState', () => {
   const base = { jobSkills: ['go'], authenticated: true, profileLoaded: true, profileSkills: ['go'] };
@@ -73,6 +80,148 @@ describe('computeClientMatch', () => {
 
   it('does not let duplicate profile skills inflate the count', () => {
     expect(computeClientMatch(['go', 'kafka'], ['go', 'go'])).toEqual({ total: 2, matched: 1, percent: 50 });
+  });
+});
+
+describe('matchTeaser', () => {
+  const SKILLS = ['go', 'kafka', 'aws', 'postgres', 'docker'];
+  // Enough distinct slugs to exercise the hash rather than one lucky seed.
+  const MANY = Array.from(
+    { length: 200 },
+    (_, i) => matchTeaser(`senior-go-engineer-at-acme-${i}`, SKILLS)!,
+  );
+  // The percent ceiling has three regimes — a fractional bound below five skills, an
+  // exact-integer one at five (where 90% would round 4.5 up to a full house), and the
+  // flat 90 cap above six. Sampling only one skill count would leave two untested.
+  const ACROSS_COUNTS = [2, 3, 4, 5, 6, 10, 36, 100].flatMap((total) => {
+    const skills = Array.from({ length: total }, (_, i) => `skill-${i}`);
+    return Array.from({ length: 40 }, (_, i) => matchTeaser(`job-${total}-${i}`, skills)!);
+  });
+
+  it('is nothing at all for a job with no skills, leaving the no-skills state to render', () => {
+    expect(matchTeaser('some-slug', [])).toBeNull();
+  });
+
+  it('is nothing for a one-skill job, which has no have/missing story to tell', () => {
+    // "1 of 1 skills" beside an 87% bar is the one figure a viewer can catch out, and a
+    // lone chip carries no contrast either way — so such a job shows no teaser at all.
+    expect(matchTeaser('one-skill-job', ['go'])).toBeNull();
+  });
+
+  it('gives one slug the same figures every time it is derived', () => {
+    // The teaser is rendered during SSR and again after hydration, on the card and in
+    // the sidebar. Two derivations that disagree put two scores for one job on screen.
+    const first = matchTeaser('senior-go-engineer-at-acme', SKILLS);
+    const second = matchTeaser('senior-go-engineer-at-acme', SKILLS);
+    expect(second).toEqual(first);
+    expect([...second!.missing]).toEqual([...first!.missing]);
+  });
+
+  it('keeps the percent inside the 60-90 teaser band for every slug', () => {
+    for (const t of MANY) {
+      expect(t.percent).toBeGreaterThanOrEqual(60);
+      expect(t.percent).toBeLessThanOrEqual(90);
+    }
+  });
+
+  it('takes the total from the real skill count of the job', () => {
+    expect(matchTeaser('a-slug', SKILLS)!.total).toBe(5);
+    expect(matchTeaser('a-slug', ['go', 'kafka'])!.total).toBe(2);
+  });
+
+  it('derives matched from the percent, so the label cannot contradict the bar', () => {
+    for (const t of MANY) {
+      expect(t.matched).toBe(Math.round((t.percent / 100) * t.total));
+    }
+  });
+
+  it('marks exactly the skills the matched count leaves over as missing', () => {
+    for (const t of MANY) {
+      expect(t.missing.size).toBe(t.total - t.matched);
+    }
+  });
+
+  it('only ever marks skills the job actually carries', () => {
+    for (const t of MANY) {
+      for (const name of t.missing) expect(SKILLS).toContain(name);
+    }
+  });
+
+  it('always shows both tones — every teased job has a held and a missing skill', () => {
+    // An all-green row under a 73% bar, or an all-red one, reads as a rendering bug.
+    for (const t of MANY) {
+      expect(t.missing.size).toBeGreaterThanOrEqual(1);
+      expect(t.missing.size).toBeLessThanOrEqual(SKILLS.length - 1);
+    }
+    expect(matchTeaser('two-skill-job', ['go', 'kafka'])!.missing.size).toBe(1);
+  });
+
+  it('holds the percent band and both tones at every skill count', () => {
+    // The ceiling arithmetic is the subtlest line in the teaser; a regression in it (a
+    // dropped `- 1`, a changed cap) would still pass a suite that only samples five
+    // skills, because five is the one count where the bound happens to be exact.
+    for (const t of ACROSS_COUNTS) {
+      expect(t.percent).toBeGreaterThanOrEqual(60);
+      expect(t.percent).toBeLessThanOrEqual(90);
+      expect(t.matched).toBe(Math.round((t.percent / 100) * t.total));
+      expect(t.matched).toBeGreaterThanOrEqual(1);
+      expect(t.matched).toBeLessThan(t.total);
+      expect(t.missing.size).toBe(t.total - t.matched);
+    }
+  });
+
+  it('can mark any position missing, not just the tail of the row', () => {
+    // Which skills read as missing is the one thing the seed actually randomises; a
+    // shuffle that degenerated to "always the last ones" would still satisfy every
+    // other test here, so pin it to every position being reachable.
+    const positions = new Set(MANY.flatMap((t) => [...t.missing].map((s) => SKILLS.indexOf(s))));
+    expect(positions.size).toBe(SKILLS.length);
+  });
+
+  it('reaches every percent in the band rather than parking on a few', () => {
+    // Deterministic, so this is an exact count: 60..89 for a five-skill job (the ceiling
+    // keeps 90 out, since it would round to a full house).
+    expect(new Set(MANY.map((t) => t.percent)).size).toBe(30);
+  });
+});
+
+describe('teaserChips', () => {
+  const SKILLS = ['go', 'kafka', 'aws', 'postgres', 'docker', 'terraform'];
+
+  it('shows the job’s leading skills untouched when one of them already reads missing', () => {
+    expect(teaserChips(SKILLS, new Set(['kafka']), 3)).toEqual(['go', 'kafka', 'aws']);
+  });
+
+  it('trades the last chip for a missing skill when the whole window reads held', () => {
+    // A three-chip row cut from a six-skill job can miss the only red one entirely; the
+    // teaser is meant to show both tones, so the row borrows one from further down.
+    expect(teaserChips(SKILLS, new Set(['terraform']), 3)).toEqual(['go', 'kafka', 'terraform']);
+  });
+
+  it('borrows the first missing skill, keeping the job’s own order', () => {
+    expect(teaserChips(SKILLS, new Set(['docker', 'terraform']), 3)).toEqual([
+      'go',
+      'kafka',
+      'docker',
+    ]);
+  });
+
+  it('does not borrow into a one-chip row, which would leave it all-missing', () => {
+    // Trading the only chip for a missing skill inverts the contrast instead of showing
+    // it — a lone red chip is no better than a lone green one.
+    expect(teaserChips(SKILLS, new Set(['terraform']), 1)).toEqual(['go']);
+  });
+
+  it('shows every skill of a job shorter than the row', () => {
+    expect(teaserChips(['go', 'kafka'], new Set(['kafka']), 3)).toEqual(['go', 'kafka']);
+  });
+
+  it('leaves an all-held row alone when the job has no missing skill to borrow', () => {
+    expect(teaserChips(['go'], new Set(), 3)).toEqual(['go']);
+  });
+
+  it('has nothing to show for a job with no skills', () => {
+    expect(teaserChips([], new Set(), 3)).toEqual([]);
   });
 });
 

--- a/web/src/lib/jobMatch.ts
+++ b/web/src/lib/jobMatch.ts
@@ -54,6 +54,92 @@ export function computeClientMatch(jobSkills: string[], profileSkills: string[])
   return { total, matched, percent };
 }
 
+/** The locked-state teaser: plausible figures for a match nobody has computed yet,
+ *  shown blurred to a guest (or a signed-in viewer with no skills) as an invitation
+ *  rather than an estimate. `{total, matched, percent}` is the `ClientMatch` shape, so
+ *  the same bar renders it; `missing` names which of the job's own skills read as
+ *  not-held, leaving each surface free to show as many chips as it has room for. */
+export type MatchTeaser = ClientMatch & { missing: Set<string> };
+
+/** FNV-1a (32-bit). Seeds the teaser from a job's slug so the same job yields the same
+ *  figures in the SSR pass and after hydration — `Math.random()` would re-roll on both,
+ *  flipping the score on first paint and again on every re-render of the feed. */
+function hashSeed(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** mulberry32 — a small seeded PRNG, enough to shuffle a handful of skill names. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), a | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const TEASER_MIN = 60;
+const TEASER_MAX = 90;
+
+/** Derive the teaser for one job. Null when the job has fewer than two skills: there is
+ *  no have/missing story to tell about a single one, and "1 of 1 skills" beside an 87%
+ *  bar is the one figure a viewer could catch out. Those jobs keep the plain card corner
+ *  and the sidebar's bare call-to-action.
+ *
+ *  `matched` follows from `percent` rather than being rolled beside it, so the "N of M
+ *  skills" label can never contradict the bar. What the seed actually randomises is
+ *  *which* skills read as missing, so the red chips scatter through the row.
+ *
+ *  The band's top is capped per skill count: at five skills, 90% would round to 5 of 5
+ *  and leave an all-green row under a bar that isn't full. Keeping the percent below
+ *  `100 − 50/total` guarantees one missing skill, so both tones always show. */
+export function matchTeaser(seed: string, jobSkills: string[]): MatchTeaser | null {
+  const total = jobSkills.length;
+  if (total < 2) return null;
+
+  const h = hashSeed(seed);
+  // The largest whole percent that still rounds below `total` — Math.ceil(x) - 1 is the
+  // greatest integer strictly less than x, for a fractional x and an exact one alike.
+  const ceiling = Math.min(TEASER_MAX, Math.ceil(100 - 50 / total) - 1);
+  const percent = TEASER_MIN + (h % (ceiling - TEASER_MIN + 1));
+  const matched = Math.round((percent / 100) * total);
+
+  // Give every skill a seeded sort key and take the lowest `total - matched` of them as
+  // the missing ones — a shuffle without the index juggling, so which skills read as
+  // missing scatters through the row instead of always being its tail.
+  const rand = mulberry32(h);
+  const missing = new Set(
+    jobSkills
+      .map((name) => ({ name, key: rand() }))
+      .toSorted((a, b) => a.key - b.key)
+      .slice(0, total - matched)
+      .map((s) => s.name),
+  );
+
+  return { total, matched, percent, missing };
+}
+
+/** Which skills a narrow teaser row should show. Takes the job's leading skills, but if
+ *  that window happens to be all-held it trades its last chip for the first missing skill
+ *  further down — a three-chip row cut from a job with one missing skill would otherwise
+ *  come out uniformly green, losing the have/missing contrast that is the teaser's whole
+ *  point. The job's own order is preserved among the chips that stay. */
+export function teaserChips(jobSkills: string[], missing: Set<string>, limit: number): string[] {
+  const shown = jobSkills.slice(0, limit);
+  // A one-chip row has nothing to spare: trading its only chip would leave it all-missing,
+  // which inverts the contrast rather than showing it.
+  if (shown.length > 1 && shown.length < jobSkills.length && !shown.some((s) => missing.has(s))) {
+    const borrowed = jobSkills.find((s) => missing.has(s));
+    if (borrowed) return [...shown.slice(0, -1), borrowed];
+  }
+  return shown;
+}
+
 /** The two progress-bar segment widths (in percent of the track): a full-weight
  *  green segment for exact matches and a half-weight amber segment for adjacent
  *  ones. Their sum is the (unrounded) coverage percent. */


### PR DESCRIPTION
## What and why

A signed-out visitor saw **nothing** in the card corner where the coverage bar lives — the clearest reason to sign in was invisible exactly where the decision gets made. The one teaser that did exist, the job-detail Profile match block, named `React / Docker / SQL / Kafka` at a fixed `76%`, contradicting whatever job was on screen.

Both locked states — signed out, and signed in with no profile skills — now get the same teaser, built from the job's **own** skills and seeded from its public slug:

- percent in 60–90, with `matched` derived from it so the "N of M skills" label can't contradict the bar;
- a have/missing split over the real skill names, tinting the card's chips and the sidebar's;
- blurred, with the blur scoped to the chips and the strip — the salary next to them stays crisp.

Seeding from the slug rather than `Math.random()` is what makes it hold still: the same figures survive SSR, hydration, every re-render of the feed, and agree between a job's card and its own sidebar page.

### Accessibility

The blurred strip is `aria-hidden` — a fabricated percentage must not be read out as this viewer's match. In its place the card exposes a state-appropriate invitation ("Sign in…" / "Add your skills…"), rendered **outside** the card link: `sr-only` is clip-based, so inside the `<a>` it would have joined the accessible name of every link in the feed with an instruction the link doesn't carry out.

### Three things the live data and review taught us, not the tests

- Three chips is what the sidebar fits at legible width; four collapsed every name to a stub (`anal…`, `c…`).
- A capped row cut from a job's leading skills can miss the only missing one — a job at "5 of 6 skills" rendered a uniformly green row — so `teaserChips` borrows one.
- A one-skill job now shows **no** teaser: "1 of 1 skills" beside an 87% bar was the one figure a viewer could catch out, and dropping it *removed* a special case (the "at least one missing" clamp became unconditional).

OpenSpec change: `openspec/changes/guest-match-teaser/` — a delta on the `job-profile-match` capability.

Frontend only: no API, no schema, no worker. The locked states still never call `GET /jobs/:slug/match`, so no new request volume.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass. — no Go touched by this change
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers). — no Go touched
- [x] I regenerated committed artifacts when their source changed. — no SQL, migrations, or contracts touched
- [x] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass. — design-system not touched
- [x] For `web/` changes: `pnpm run check` and `pnpm run build` pass. — `check` 0 errors, `lint` 0 errors, `build` clean, `test` 507 pass
- [x] This stays within freehire's core/extension boundary — it does not bloat the core.

### Verification detail

- `pnpm test` — 507 pass. 26 new cases over `matchTeaser` / `teaserChips`; the invariants are exercised across skill counts 2, 3, 4, 5, 6, 10, 36 and 100, because the percent ceiling has three regimes and sampling only five skills tests one of them.
- Guest state verified in a browser against the production API: feed cards, the sidebar on a six-skill job, and the bare call-to-action on a single-skill job.
- **Not yet verified in a browser:** the two signed-in states (`tasks.md` 4.3). The `ready` markup is byte-identical to before, and `no-profile` shares the guest branch apart from its call-to-action text — but that text is exactly what changed, so it deserves a signed-in look.