### PR TITLE
feat(sources): ingest the WhatJobs CPC feed as a keyword-sliced aggregator

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -32,9 +32,10 @@ import (
 	"github.com/strelov1/freehire/internal/worker"
 )
 
-// staleAfter is the grace window before an unseen job is closed: many crawl cycles
+// staleAfter is the DEFAULT grace window before an unseen job is closed: many crawl cycles
 // at the hourly per-provider cadence, so a board failing several runs in a row keeps
-// its jobs open.
+// its jobs open. An adapter that crawls only a slice of its catalogue widens it for its own
+// provider — see sweepWindowFor.
 const staleAfter = 48 * time.Hour
 
 func main() {
@@ -178,7 +179,11 @@ func run() int {
 	// registered providers), so this is accepted to avoid the far worse over-close: closing
 	// live jobs of boards a partial/timed-out run never reached.
 	queries := db.New(pool)
-	cutoff := pgtype.Timestamptz{Time: time.Now().Add(-staleAfter), Valid: true}
+	now := time.Now()
+	// A slice-crawled source (e.g. whatjobs) declares a window wider than staleAfter: its crawl
+	// reaches only a keyword's first pages, so a posting that drifted deeper reads as unseen and
+	// the default window would close it and reopen it on the next run.
+	grace := sources.SweepGraceWindows(registry)
 	// A self-closing source (e.g. jobtech) manages its own closes from its stream, so the
 	// unseen sweep must skip it: it re-reports only changed ads, and the cutoff would wrongly
 	// close every still-open ad it did not touch this run.
@@ -198,6 +203,8 @@ func run() int {
 		if selfClosing[provider] {
 			continue
 		}
+		window := sweepWindowFor(grace, provider)
+		cutoff := pgtype.Timestamptz{Time: now.Add(-window), Valid: true}
 		var closed int64
 		var err error
 		if sweepBySource(runStats[provider], fullCatalog[provider]) {
@@ -219,7 +226,7 @@ func run() int {
 			log.Printf("close stale jobs (%s): %v", provider, err)
 			continue
 		}
-		log.Printf("closed %d stale %s jobs (unseen for %s)", closed, provider, staleAfter)
+		log.Printf("closed %d stale %s jobs (unseen for %s)", closed, provider, window)
 	}
 	return worker.ExitCode(failed, 0)
 }
@@ -252,4 +259,15 @@ func shouldSweep(stats pipeline.Stats) bool {
 // falls back to the safe company-scoped CloseUnseenJobs. Callers gate on shouldSweep first.
 func sweepBySource(stats pipeline.Stats, fullCatalog bool) bool {
 	return fullCatalog && stats.Failed == 0
+}
+
+// sweepWindowFor reports how long a provider's unseen jobs are spared before the sweep closes
+// them: the window its adapter declared (sources.SweepGraceWindows) when it crawls only a slice
+// of a catalogue too deep to walk, else staleAfter. Widening is per-provider so one feed's drift
+// tolerance never slows the sweep for the ATS boards, whose crawls are complete.
+func sweepWindowFor(grace map[string]time.Duration, provider string) time.Duration {
+	if w, ok := grace[provider]; ok {
+		return w
+	}
+	return staleAfter
 }

--- a/cmd/ingest/main_test.go
+++ b/cmd/ingest/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/strelov1/freehire/internal/pipeline"
 	"github.com/strelov1/freehire/internal/sources"
@@ -55,6 +56,27 @@ func TestShouldSweep(t *testing.T) {
 	for _, tc := range cases {
 		if got := shouldSweep(tc.stats); got != tc.want {
 			t.Errorf("%s: shouldSweep = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// A slice-crawled source declares a window wider than the default so a posting that merely
+// drifted past the crawl's page depth is not closed and then reopened; every other provider
+// keeps the default untouched.
+func TestSweepWindowFor(t *testing.T) {
+	grace := map[string]time.Duration{"whatjobs": 14 * 24 * time.Hour}
+
+	cases := []struct {
+		name     string
+		provider string
+		want     time.Duration
+	}{
+		{"declaring provider gets its wider window", "whatjobs", 14 * 24 * time.Hour},
+		{"ordinary provider keeps the default", "greenhouse", staleAfter},
+	}
+	for _, tc := range cases {
+		if got := sweepWindowFor(grace, tc.provider); got != tc.want {
+			t.Errorf("%s: sweepWindowFor(%q) = %v, want %v", tc.name, tc.provider, got, tc.want)
 		}
 	}
 }

--- a/internal/sources/AGENTS.md
+++ b/internal/sources/AGENTS.md
@@ -9,7 +9,9 @@ Source ingest: board list, provider registry, board-file parsing/validation, per
 - **`cmd/ingest` processes one board file per run** (path as first argument or `SOURCES_FILE`). It validates every entry against the registry and **fails fast** — a misconfigured board never starts a run.
 - **Run-once-and-exit worker** meant for cron (one schedule per file, so providers crawl independently). No long-lived process.
 - **Adapters are read-only over public ATS JSON APIs.** Per-board crawl is independent: one failing board is counted (`stats.Failed`) but does not abort the rest.
-- **Sources are keyless by default; `usajobs` is the lone exception.** USAJobs Search API requires `Authorization-Key` header — `sources.All` registers it only when `USAJOBS_API_KEY` is set in the environment. The key lives in the env, never in a board file.
+- **Sources are keyless by default.** The exceptions are `usajobs` (`USAJOBS_API_KEY`), `reed` (`REED_API_KEY`) and `whatjobs` (`WHATJOBS_PUBLISHER_ID`) — `sources.All` registers each only when its variable is set. The credential lives in the env, never in a board file; an unconfigured environment leaves the provider absent rather than listing one that cannot crawl.
+- **A board is not always a tenant.** For `hh` it is a `professional_role`, for `trudvsem` an OKATO region code, for `whatjobs` a SEARCH KEYWORD. Such a provider is an `aggregator` (many employers, company read per posting) but NOT `boardless` — the board is what selects the slice to crawl.
+- **`sweepGrace` widens the unseen sweep for a slice-crawled provider.** `whatjobs` reads at most 40 pages of a keyword from a feed thousands of pages deep, so a posting that drifts past that depth reads as unseen; on the 48-hour default it would be closed and reopened repeatedly, each cycle writing a phantom removal into `job_daily_stats`. The adapter declares 14 days instead (`sources.SweepGraceWindows` → `cmd/ingest`'s `sweepWindowFor`). Sound only where liveness cannot be probed — anything verifiable should close on evidence.
 - **Dedup key is `jobs.UNIQUE (source, external_id)`.** `UpsertJob` is `ON CONFLICT` on it.
 - **`sources.SelfClosingProviders`** lists providers whose adapters implement the `selfClosing` marker — they emit `Job{Removed: true}` for taken-down postings and are excluded from the unseen-job sweep.
 - **Board health table holds ONLY runtime state** — the board catalog stays in YAML (git); a stale row for a removed board is inert.
@@ -34,6 +36,17 @@ Source ingest: board list, provider registry, board-file parsing/validation, per
 3. **Liveness probe** (`cmd/liveness`): URL-probes orphan jobs from non-board sources. Closes after two consecutive `expired` reads (the `liveness_strikes` counter).
 
 **Telegram ingest** is a two-stage queue (crawl then LLM-extract): `cmd/tg-ingest` crawls `sources/telegram.yml` channels into `telegram_posts`; `cmd/tg-extract` drains via the LLM. Both are run-once-and-exit cron workers.
+
+**WhatJobs FeedAPI traps** (its documentation is wrong in several places; all of the below was verified against the live API):
+
+- A `/` in the `user_agent` query value makes the edge redirect with the value corrupted (`Mozilla/5.0` → `Mozilla%215.0`), which is why every code sample in the vendor's docs fails. The adapter sends no `user_agent` at all.
+- `limit` above 50 is silently clamped, and `limit=1` **with** a keyword returns an empty `data` with `per_page: 0`. Worse, the feed post-filters duplicates *after* selecting a page, so a request for 50 routinely returns 44 while more pages remain — **a short page is not the last page**, and the same posting can appear on several pages of one keyword.
+- Pagination dies past roughly 2000 pages regardless of the `total` reported (594k), so no keyword is ever exhaustible; keep board keywords narrow enough to fit the page budget.
+- `snippet` is the FULL description HTML, not the highlighted excerpt the docs describe. The documented `onmousedown` field does not exist.
+- `salary` is always `"0.000000 - 0.000000"`, `job_type` always `""`, `logo` always `null` — all three are dropped rather than stored.
+- `age`/`age_days` measure the record's age in the reseller's index, not the posting date (postings from unrelated companies share one value), so `PostedAt` is left nil.
+- An invalid publisher answers **410** (docs claim 422); `unique_id` does not deduplicate despite the docs.
+- No country field, and its cities collide with foreign ones (London is Ohio, Vienna is Virginia) — the account's country is stated by the adapter, since the publisher id is per-country.
 
 ## Limitations
 - No versioned migration runner for `board_health` migration (`0006_board_health.sql`) — apply to prod manually before deploying.

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"os"
 	"slices"
+	"time"
 )
 
 // SelfClosingProviders returns the provider names in reg that manage their own closes and
@@ -25,6 +26,20 @@ func FullCatalogProviders(reg map[string]Source) []string {
 	for name, src := range reg {
 		if _, ok := src.(fullCatalog); ok {
 			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// SweepGraceWindows returns the post-run sweep window each adapter in reg declares that is wider
+// than the default (see sweepGrace). cmd/ingest consults this when computing a provider's cutoff;
+// a provider absent from the map is swept on the default window, which is every provider but the
+// slice-crawled few.
+func SweepGraceWindows(reg map[string]Source) map[string]time.Duration {
+	out := make(map[string]time.Duration)
+	for name, src := range reg {
+		if s, ok := src.(sweepGrace); ok {
+			out[name] = s.sweepGrace()
 		}
 	}
 	return out

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -272,6 +272,13 @@ func All(c HTTPClient) map[string]Source {
 	if key := os.Getenv("REED_API_KEY"); key != "" {
 		registry["reed"] = NewReed(c, key)
 	}
+	// whatjobs is a CPC network freehire publishes for, so its credential is the publisher id rather
+	// than an API key — but it is registered the same way: only when configured, so an environment
+	// without it does not list a provider whose every board would 410. The id is per-country; this
+	// account serves US inventory.
+	if id := os.Getenv("WHATJOBS_PUBLISHER_ID"); id != "" {
+		registry["whatjobs"] = NewWhatJobs(c, id)
+	}
 	// taleo needs a cookie-persisting client (its searchjobs POST requires the session cookie
 	// a careersection GET sets), so it cannot use the shared jar-less client. Build a dedicated
 	// one for a real crawl; on the transport-free listing path (c == nil) register a bare adapter

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -133,3 +133,14 @@ type selfClosing interface{ selfClosing() }
 // never reached. cmd/ingest gates the source-scoped close on a zero-Failed run for exactly
 // this reason. See FullCatalogProviders.
 type fullCatalog interface{ fullCatalog() }
+
+// sweepGrace marks an adapter that needs the post-run unseen sweep to wait longer than the
+// default before closing its jobs, and reports how long. It is the opposite case to fullCatalog:
+// the crawl deliberately reaches only a SLICE of the source's catalogue (a keyword's first N
+// pages of a feed far deeper than any crawl can walk), so a posting that merely drifted past
+// that depth reads as unseen. On the default window it would be closed and then reopened when it
+// drifts back — churn that also lands in job_daily_stats as a phantom removal. A window wider
+// than the drift absorbs it, at the cost of a genuinely withdrawn posting lingering that long.
+// The marker is only sound for a source whose postings CANNOT be probed for liveness; anything
+// verifiable should be closed on evidence instead. See SweepGraceWindows.
+type sweepGrace interface{ sweepGrace() time.Duration }

--- a/internal/sources/source_test.go
+++ b/internal/sources/source_test.go
@@ -2,8 +2,10 @@ package sources
 
 import (
 	"context"
+	"maps"
 	"slices"
 	"testing"
+	"time"
 )
 
 type fakeSource struct{ provider string }
@@ -34,6 +36,22 @@ func (f fakeAggregatorSource) Fetch(context.Context, CompanyEntry) ([]Job, error
 
 func (f fakeAggregatorSource) boardless()  {}
 func (f fakeAggregatorSource) aggregator() {}
+
+// fakeGraceSource declares a sweep window wider than the default: its crawl reaches only a
+// slice of its catalogue, so the default window would close a posting that merely drifted
+// past the crawl's page depth.
+type fakeGraceSource struct {
+	provider string
+	grace    time.Duration
+}
+
+func (f fakeGraceSource) Provider() string { return f.provider }
+
+func (f fakeGraceSource) Fetch(context.Context, CompanyEntry) ([]Job, error) { return nil, nil }
+
+func (f fakeGraceSource) aggregator() {}
+
+func (f fakeGraceSource) sweepGrace() time.Duration { return f.grace }
 
 func TestRegIndexesByProvider(t *testing.T) {
 	r := reg(fakeSource{"greenhouse"}, fakeSource{"lever"})
@@ -90,6 +108,19 @@ func TestAggregatorProvidersListsOnlyAggregators(t *testing.T) {
 	want := []string{"himalayas", "jobstash"}
 	if !slices.Equal(got, want) {
 		t.Errorf("AggregatorProviders() = %v, want %v", got, want)
+	}
+}
+
+func TestSweepGraceWindowsListsOnlyDeclaringProviders(t *testing.T) {
+	got := SweepGraceWindows(reg(
+		fakeSource{"greenhouse"},                         // board-based, no window → absent (default applies)
+		fakeAggregatorSource{"jobstash"},                 // aggregator without a window → absent
+		fakeGraceSource{"whatjobs", 14 * 24 * time.Hour}, // declares a window → listed
+	))
+
+	want := map[string]time.Duration{"whatjobs": 14 * 24 * time.Hour}
+	if !maps.Equal(got, want) {
+		t.Errorf("SweepGraceWindows() = %v, want %v", got, want)
 	}
 }
 

--- a/internal/sources/whatjobs.go
+++ b/internal/sources/whatjobs.go
@@ -1,0 +1,199 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// whatjobs adapts the WhatJobs FeedAPI, a CPC network where freehire is a publisher. Unlike the
+// ATS adapters it has no per-tenant board: the account exposes one searchable pool, so the board
+// carries a SEARCH KEYWORD and each entry crawls that slice — the same shape as hh, whose board is
+// a professional_role. Every posting names its own employer, so the entry's company is a display
+// label only.
+//
+// The feed cannot be crawled exhaustively (it stops serving results past roughly two thousand
+// pages while reporting a far larger total), and its postings cannot be verified: url points at
+// the network's billing landing page rather than the employer's posting, so cmd/liveness can never
+// probe one. Both facts are why the adapter declares a wide sweepGrace instead of relying on the
+// default unseen window.
+type whatjobs struct {
+	http        JSONGetter
+	publisherID string
+}
+
+const (
+	whatjobsFeedURL = "https://api.whatjobs.com/api/v1/jobs.json"
+	// whatjobsPageSize is the feed's maximum. A larger value is silently clamped to it, and
+	// limit=1 combined with a keyword returns an empty page reporting per_page 0 — a bug in the
+	// feed's paginator — so the size is pinned here rather than made configurable.
+	whatjobsPageSize = 50
+	// whatjobsMaxPages bounds one keyword's crawl. The feed stops serving results past roughly two
+	// thousand pages regardless of the total it reports, and a broad keyword ("software engineer",
+	// 12k postings) would take hundreds of requests to walk, so a keyword is read as a bounded slice
+	// and kept narrow in the board file instead. When the budget is what ended a crawl the adapter
+	// says so in the log: a bounded slice must never read as full coverage.
+	whatjobsMaxPages = 40
+	// whatjobsCrawlIP is the mandatory user_ip. A crawl is not a user viewing a page, so sending
+	// a real visitor address would fabricate an impression: the feed ignores tracking for an
+	// address it does not accept as a viewer but still serves the results, which is exactly the
+	// behaviour wanted here. An empty value is rejected outright (HTTP 400).
+	whatjobsCrawlIP = "0.0.0.0"
+	// whatjobsSweepGrace is how long the unseen sweep spares a whatjobs posting. A crawl reads
+	// only the first whatjobsMaxPages of a keyword, so a posting that drifts deeper reads as
+	// unseen; on the 48-hour default it would be closed and reopened as it drifts back. Two weeks
+	// outlasts that drift, at the cost of a withdrawn posting lingering that long — unavoidable,
+	// since nothing about these postings can be probed.
+	whatjobsSweepGrace = 14 * 24 * time.Hour
+	// whatjobsCountry is the country this publisher account serves. The vendor issues a separate
+	// publisher id per country, so it is a property of the credential rather than of any posting;
+	// an account for another market needs its own adapter registration, not a parsed field.
+	whatjobsCountry = "United States"
+)
+
+// NewWhatJobs builds the WhatJobs adapter over the given HTTP client. The publisher id is the
+// account credential; it is read from the environment by All and never from a board file.
+func NewWhatJobs(c JSONGetter, publisherID string) Source {
+	return whatjobs{http: c, publisherID: publisherID}
+}
+
+func (whatjobs) Provider() string { return "whatjobs" }
+
+// whatjobs lists many employers under one account, so it stays in the source facet and takes each
+// posting's company from the feed. It is deliberately NOT boardless: the keyword board is what
+// selects the slice to crawl, and an entry without one has nothing to fetch.
+func (whatjobs) aggregator() {}
+
+// whatjobs crawls a keyword slice, never the whole catalogue, so its unseen jobs need a window
+// wider than the sweep default. See whatjobsSweepGrace.
+func (whatjobs) sweepGrace() time.Duration { return whatjobsSweepGrace }
+
+// whatjobsPosting is one posting from the feed. snippet is the FULL description HTML despite the
+// name and despite the vendor's documentation, which describes it as a highlighted excerpt. The
+// documented onmousedown field does not exist. salary, jobType and logo are declared here to
+// document that they were read and found worthless — every row carries the same placeholder — so a
+// later reader does not go looking for them again.
+type whatjobsPosting struct {
+	Title    string `json:"title"`
+	Company  string `json:"company"`
+	Location string `json:"location"`
+	Postcode string `json:"postcode"`
+	Snippet  string `json:"snippet"`
+	URL      string `json:"url"`
+	AgeDays  int    `json:"age_days"`
+	Salary   string `json:"salary"`
+	JobType  string `json:"job_type"`
+	Logo     string `json:"logo"`
+}
+
+// Fetch reads one keyword slice. Pagination stops on an EMPTY page — never on a short one: the feed
+// post-filters duplicates after selecting the page, so a request for 50 routinely returns 44 while
+// more pages remain, and treating that as the end would truncate every keyword. The same
+// post-filtering lets a posting appear on more than one page, so repeats are collapsed here rather
+// than left for the pipeline to upsert over and over.
+func (w whatjobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	seen := make(map[string]bool)
+	page := 1
+	for ; page <= whatjobsMaxPages; page++ {
+		var resp struct {
+			Data []whatjobsPosting `json:"data"`
+		}
+		if err := w.http.GetJSON(ctx, w.pageURL(e.Board, page), &resp); err != nil {
+			return nil, fmt.Errorf("whatjobs: keyword %q page %d: %w", e.Board, page, err)
+		}
+		if len(resp.Data) == 0 {
+			break
+		}
+		for _, p := range resp.Data {
+			job, ok := p.toJob()
+			if !ok || seen[job.ExternalID] {
+				continue
+			}
+			seen[job.ExternalID] = true
+			jobs = append(jobs, job)
+		}
+	}
+	if page > whatjobsMaxPages {
+		log.Printf("whatjobs: keyword %q hit the %d-page budget with %d postings — slice is bounded, not exhausted",
+			e.Board, whatjobsMaxPages, len(jobs))
+	}
+	return jobs, nil
+}
+
+// whatjobsTrackedID matches the native posting id in a tracked click-through URL
+// (…/pub_api__cpl__<postingID>__<publisherID>). The id is the only stable identity the feed
+// exposes — there is no id field on the posting itself.
+var whatjobsTrackedID = regexp.MustCompile(`pub_api__cpl__(\d+)__\d+`)
+
+// whatjobsExternalID reads the native posting id out of a tracked URL. It reports ok=false for any
+// other URL shape: a posting without this id cannot be deduplicated, so it must be dropped rather
+// than stored under something guessed.
+func whatjobsExternalID(trackedURL string) (string, bool) {
+	m := whatjobsTrackedID.FindStringSubmatch(trackedURL)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
+// whatjobsResellerMark matches the tracking signature a reseller appends to the body, which 96% of
+// the feed's descriptions carry. It identifies the network the posting was resold through, not the
+// role, so it is cut before the description reaches the catalogue.
+var whatjobsResellerMark = regexp.MustCompile(`\s*#J-\d+-Ljbffr\s*$`)
+
+// toJob maps a posting, returning ok=false when the tracked URL carries no native id. The tracked
+// URL is stored verbatim — it is not IP-bound, so the stored copy serves any later visitor and the
+// publisher attribution rides along in its path.
+//
+// Three of the feed's fields are deliberately dropped rather than mapped. salary is the literal
+// "0.000000 - 0.000000" on every row, jobType is always empty and logo always null, so storing them
+// would assert facts the feed never carried. age/age_days are dropped too: they measure how long
+// the record has been in the reseller's index (postings from unrelated companies share one value),
+// so PostedAt stays nil and freshness falls back to when freehire first saw the row.
+func (p whatjobsPosting) toJob() (Job, bool) {
+	id, ok := whatjobsExternalID(p.URL)
+	if !ok {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:  id,
+		URL:         p.URL,
+		Title:       p.Title,
+		Company:     p.Company,
+		Location:    whatjobsLocation(p.Location),
+		Description: sanitizeHTML(whatjobsResellerMark.ReplaceAllString(p.Snippet, "")),
+	}, true
+}
+
+// whatjobsLocation states the account's country alongside the posting's city. The feed names no
+// country, and its cities collide with better-known foreign ones (London is Ohio here, Vienna is
+// Virginia), so without this a third of the postings resolve to no country and a few resolve to the
+// wrong one. The country is a fact about the configured publisher account — the id is per-country by
+// the vendor's design — not a guess about an individual posting.
+func whatjobsLocation(city string) string {
+	if city = strings.TrimSpace(city); city == "" {
+		return whatjobsCountry
+	}
+	return city + ", " + whatjobsCountry
+}
+
+// pageURL builds one feed request. user_agent is deliberately absent: it is optional, it only
+// sharpens click attribution on shared IPs, and a slash in its value makes the edge redirect with
+// the value corrupted — the reason the vendor's own documented examples fail. unique_id is absent
+// too: it promises to suppress previously returned postings and does not.
+func (w whatjobs) pageURL(keyword string, page int) string {
+	q := url.Values{
+		"publisher": {w.publisherID},
+		"user_ip":   {whatjobsCrawlIP},
+		"keyword":   {keyword},
+		"limit":     {strconv.Itoa(whatjobsPageSize)},
+		"page":      {strconv.Itoa(page)},
+	}
+	return whatjobsFeedURL + "?" + q.Encode()
+}

--- a/internal/sources/whatjobs.go
+++ b/internal/sources/whatjobs.go
@@ -73,22 +73,22 @@ func (whatjobs) aggregator() {}
 // wider than the sweep default. See whatjobsSweepGrace.
 func (whatjobs) sweepGrace() time.Duration { return whatjobsSweepGrace }
 
-// whatjobsPosting is one posting from the feed. snippet is the FULL description HTML despite the
-// name and despite the vendor's documentation, which describes it as a highlighted excerpt. The
-// documented onmousedown field does not exist. salary, jobType and logo are declared here to
-// document that they were read and found worthless — every row carries the same placeholder — so a
-// later reader does not go looking for them again.
+// whatjobsPosting is the part of a feed posting worth reading. snippet is the FULL description HTML
+// despite its name and despite the vendor's documentation, which calls it a highlighted excerpt.
+//
+// The feed sends five more fields, all deliberately unread, so that a later reader does not go
+// looking for them: salary is the literal "0.000000 - 0.000000" on every row, job_type is always
+// empty, logo always null, and age/age_days measure the record's age in the reseller's index rather
+// than the posting date. postcode carries a real US ZIP, but the geography dictionary cannot use it
+// — it reads a state token ("Austin, TX"), not a ZIP, and a ZIP would not settle the homonym cities
+// anyway: "London, OH" resolves to gb+us exactly as "London" alone does. The documented onmousedown
+// field does not exist at all.
 type whatjobsPosting struct {
 	Title    string `json:"title"`
 	Company  string `json:"company"`
 	Location string `json:"location"`
-	Postcode string `json:"postcode"`
 	Snippet  string `json:"snippet"`
 	URL      string `json:"url"`
-	AgeDays  int    `json:"age_days"`
-	Salary   string `json:"salary"`
-	JobType  string `json:"job_type"`
-	Logo     string `json:"logo"`
 }
 
 // Fetch reads one keyword slice. Pagination stops on an EMPTY page — never on a short one: the feed
@@ -149,13 +149,9 @@ var whatjobsResellerMark = regexp.MustCompile(`\s*#J-\d+-Ljbffr\s*$`)
 
 // toJob maps a posting, returning ok=false when the tracked URL carries no native id. The tracked
 // URL is stored verbatim — it is not IP-bound, so the stored copy serves any later visitor and the
-// publisher attribution rides along in its path.
-//
-// Three of the feed's fields are deliberately dropped rather than mapped. salary is the literal
-// "0.000000 - 0.000000" on every row, jobType is always empty and logo always null, so storing them
-// would assert facts the feed never carried. age/age_days are dropped too: they measure how long
-// the record has been in the reseller's index (postings from unrelated companies share one value),
-// so PostedAt stays nil and freshness falls back to when freehire first saw the row.
+// publisher attribution rides along in its path. PostedAt is left nil on purpose (see
+// whatjobsPosting): freshness then falls back to when freehire first saw the row, which is true,
+// where the feed's own age is not.
 func (p whatjobsPosting) toJob() (Job, bool) {
 	id, ok := whatjobsExternalID(p.URL)
 	if !ok {

--- a/internal/sources/whatjobs.go
+++ b/internal/sources/whatjobs.go
@@ -97,6 +97,14 @@ type whatjobsPosting struct {
 // post-filtering lets a posting appear on more than one page, so repeats are collapsed here rather
 // than left for the pipeline to upsert over and over.
 func (w whatjobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	// A blank keyword is refused rather than crawled. Config validation only rejects an EMPTY board,
+	// so an entry padded with whitespace reaches here — and the feed answers a blank keyword with its
+	// whole unfiltered inventory (tens of thousands of postings, most of them not even technical),
+	// which one stray board entry would pour into the catalogue.
+	keyword := strings.TrimSpace(e.Board)
+	if keyword == "" {
+		return nil, fmt.Errorf("whatjobs: company %q has a blank keyword board", e.Company)
+	}
 	var jobs []Job
 	seen := make(map[string]bool)
 	page := 1
@@ -104,24 +112,37 @@ func (w whatjobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		var resp struct {
 			Data []whatjobsPosting `json:"data"`
 		}
-		if err := w.http.GetJSON(ctx, w.pageURL(e.Board, page), &resp); err != nil {
-			return nil, fmt.Errorf("whatjobs: keyword %q page %d: %w", e.Board, page, err)
+		if err := w.http.GetJSON(ctx, w.pageURL(keyword, page), &resp); err != nil {
+			return nil, fmt.Errorf("whatjobs: keyword %q page %d: %w", keyword, page, err)
 		}
 		if len(resp.Data) == 0 {
 			break
 		}
+		var usable int
 		for _, p := range resp.Data {
 			job, ok := p.toJob()
-			if !ok || seen[job.ExternalID] {
+			if !ok {
+				continue
+			}
+			usable++
+			if seen[job.ExternalID] {
 				continue
 			}
 			seen[job.ExternalID] = true
 			jobs = append(jobs, job)
 		}
+		// A page full of postings none of which carried a native id means the tracked-URL shape
+		// changed. Returning an empty result would hide that: a provider credited with zero ingested
+		// jobs is skipped by the unseen sweep, so every existing row would stay open indefinitely
+		// while nothing refreshed it. Failing the board surfaces it in board_health within a cycle.
+		if usable == 0 {
+			return nil, fmt.Errorf("whatjobs: keyword %q page %d: %d postings, none carrying a %s id — tracked URL shape changed?",
+				keyword, page, len(resp.Data), whatjobsTrackedID)
+		}
 	}
 	if page > whatjobsMaxPages {
 		log.Printf("whatjobs: keyword %q hit the %d-page budget with %d postings — slice is bounded, not exhausted",
-			e.Board, whatjobsMaxPages, len(jobs))
+			keyword, whatjobsMaxPages, len(jobs))
 	}
 	return jobs, nil
 }

--- a/internal/sources/whatjobs_test.go
+++ b/internal/sources/whatjobs_test.go
@@ -1,0 +1,431 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// recordingJSON is a JSONGetter that records every URL it is asked for and replies with the first
+// canned body whose match substring the URL contains, so a test can assert on the query string the
+// adapter builds — the feed's traps are all in the query, not the body.
+type recordingJSON struct {
+	routes []struct{ match, body string }
+	urls   []string
+	err    error
+}
+
+func (r *recordingJSON) route(match, body string) *recordingJSON {
+	r.routes = append(r.routes, struct{ match, body string }{match, body})
+	return r
+}
+
+func (r *recordingJSON) GetJSON(_ context.Context, u string, v any) error {
+	r.urls = append(r.urls, u)
+	if r.err != nil {
+		return r.err
+	}
+	for _, rt := range r.routes {
+		if strings.Contains(u, rt.match) {
+			return json.Unmarshal([]byte(rt.body), v)
+		}
+	}
+	return json.Unmarshal([]byte(`{"data":[]}`), v)
+}
+
+// query returns the parsed query of the n-th recorded request.
+func (r *recordingJSON) query(t *testing.T, n int) url.Values {
+	t.Helper()
+	if n >= len(r.urls) {
+		t.Fatalf("only %d request(s) recorded, wanted #%d", len(r.urls), n)
+	}
+	u, err := url.Parse(r.urls[n])
+	if err != nil {
+		t.Fatalf("parse recorded url: %v", err)
+	}
+	return u.Query()
+}
+
+func TestWhatJobsProvider(t *testing.T) {
+	if got := NewWhatJobs(nil, "7065").Provider(); got != "whatjobs" {
+		t.Errorf("Provider() = %q, want whatjobs", got)
+	}
+}
+
+// The feed aggregates many employers under one account, so it is an aggregator (its copy may
+// lose to a first-party ATS posting of the same role). It is NOT boardless — the board carries
+// the search keyword and an entry without one cannot be crawled — and NOT fullCatalog, because
+// one crawl reads a keyword's first pages, never the whole catalogue.
+func TestWhatJobsIsKeywordBoardedAggregator(t *testing.T) {
+	s := NewWhatJobs(nil, "7065")
+
+	if _, ok := s.(aggregator); !ok {
+		t.Error("whatjobs should implement the aggregator marker")
+	}
+	if _, ok := s.(boardless); ok {
+		t.Error("whatjobs must NOT be boardless: the keyword board is mandatory")
+	}
+	if _, ok := s.(fullCatalog); ok {
+		t.Error("whatjobs must NOT be fullCatalog: a crawl sees only a keyword slice")
+	}
+}
+
+// The board's keyword drives the search, and the account credential rides the query. limit is
+// pinned to the feed's maximum: anything larger is silently clamped, and limit=1 combined with a
+// keyword returns an empty page with per_page 0 — a pagination bug in the feed.
+func TestWhatJobsRequestCarriesPublisherAndKeyword(t *testing.T) {
+	fake := (&recordingJSON{}).route("jobs.json", `{"data":[]}`)
+
+	if _, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{
+		Company: "WhatJobs — Backend",
+		Board:   "backend engineer",
+	}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	q := fake.query(t, 0)
+	for _, want := range []struct{ key, val string }{
+		{"publisher", "7065"},
+		{"keyword", "backend engineer"},
+		{"limit", "50"},
+		{"page", "1"},
+	} {
+		if got := q.Get(want.key); got != want.val {
+			t.Errorf("query %s = %q, want %q", want.key, got, want.val)
+		}
+	}
+	if q.Get("user_ip") == "" {
+		t.Error("user_ip is mandatory and must be sent")
+	}
+}
+
+// A slash anywhere in the user_agent value makes the edge redirect the request with the value
+// corrupted (Mozilla/5.0 arrives as Mozilla%215.0), which is why every code sample in the vendor's
+// own documentation fails. The parameter is optional, so the adapter simply never sends it.
+func TestWhatJobsRequestSendsNoUserAgent(t *testing.T) {
+	fake := (&recordingJSON{}).route("jobs.json", `{"data":[]}`)
+
+	if _, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "devops"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if got, ok := fake.query(t, 0)["user_agent"]; ok {
+		t.Errorf("user_agent must not be sent, got %q", got)
+	}
+	for _, u := range fake.urls {
+		if strings.Contains(u, "user_agent") {
+			t.Errorf("url mentions user_agent: %s", u)
+		}
+	}
+}
+
+// whatjobsPage is the feed's real envelope, trimmed. snippet carries the FULL description despite
+// its name, and the tracked url is what the native id is read from.
+const whatjobsPage = `{"data":[
+{"title":"Lead Backend Engineer","company":"Duolingo","location":"New York","postcode":"10001",
+ "snippet":"<p>Own the scoring platform.</p>\n#J-18808-Ljbffr","age":"July 28th, 2026","age_days":1,
+ "salary":"0.000000 - 0.000000","job_type":"","logo":null,
+ "url":"https://www.whatjobs.com/pub_api__cpl__2737655843__7065?utm_campaign=publisher&utm_medium=api&utm_source=7065&geoID=25088"},
+{"title":"No tracked id","company":"Nowhere","location":"Austin","postcode":"73301",
+ "snippet":"<p>Should be skipped.</p>","age_days":3,"url":"https://www.whatjobs.com/some-other-page"}
+],"total":350,"per_page":"50","current_page":1,"last_page":7}`
+
+// The native id is the tracked URL's pub_api__cpl__<id>__<publisher> segment; a posting whose URL
+// lacks it is dropped rather than stored under a guessed id, which would collide on the dedup key.
+// The tracked URL is stored verbatim: it is not IP-bound, so a stored copy stays valid for any
+// later visitor and the publisher attribution survives.
+func TestWhatJobsFetchMapsPostingsAndSkipsUntrackedOnes(t *testing.T) {
+	fake := (&recordingJSON{}).route("page=1", whatjobsPage)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{
+		Company: "WhatJobs — Backend",
+		Board:   "backend engineer",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (the untracked posting dropped)", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "2737655843" {
+		t.Errorf("ExternalID = %q, want the cpl id 2737655843", j.ExternalID)
+	}
+	// The employer comes from the posting, never from the entry's display label.
+	if j.Company != "Duolingo" {
+		t.Errorf("Company = %q, want Duolingo (not the board entry's label)", j.Company)
+	}
+	if j.Title != "Lead Backend Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if !strings.Contains(j.URL, "pub_api__cpl__2737655843__7065") {
+		t.Errorf("URL lost the tracked path: %q", j.URL)
+	}
+	if !strings.Contains(j.URL, "utm_source=7065") {
+		t.Errorf("URL lost its attribution query: %q", j.URL)
+	}
+	if !strings.Contains(j.Description, "Own the scoring platform") {
+		t.Errorf("Description lost the body: %q", j.Description)
+	}
+}
+
+// 96% of the feed's descriptions end with a reseller's tracking signature. It is not content —
+// it identifies the network the posting was resold through — so it must not reach the catalogue.
+func TestWhatJobsStripsResellerSignature(t *testing.T) {
+	fake := (&recordingJSON{}).route("page=1", whatjobsPage)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "backend engineer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) == 0 {
+		t.Fatal("no jobs")
+	}
+
+	got := jobs[0].Description
+	for _, marker := range []string{"#J-18808-Ljbffr", "Ljbffr"} {
+		if strings.Contains(got, marker) {
+			t.Errorf("Description still carries the reseller marker %q: %q", marker, got)
+		}
+	}
+	if !strings.Contains(got, "Own the scoring platform") {
+		t.Errorf("stripping ate the real body: %q", got)
+	}
+}
+
+// The feed names a city but no country, and its cities collide with better-known foreign ones
+// (London is Ohio here, Vienna is Virginia). The publisher id is per-country by the vendor's
+// design and this account serves US inventory, so the country is stated rather than left to be
+// guessed from a city name — without it a third of the postings resolve to no country at all.
+func TestWhatJobsStatesTheAccountCountry(t *testing.T) {
+	fake := (&recordingJSON{}).route("page=1", whatjobsPage)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "backend engineer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) == 0 {
+		t.Fatal("no jobs")
+	}
+
+	got := jobs[0].Location
+	if !strings.Contains(got, "New York") {
+		t.Errorf("Location lost the city: %q", got)
+	}
+	if !strings.Contains(got, "United States") {
+		t.Errorf("Location = %q, want the account's country stated", got)
+	}
+}
+
+// A posting with no city still belongs to the account's country, and must not arrive with a
+// dangling separator the geography tokenizer would read as an empty token.
+func TestWhatJobsCountryOnlyWhenCityMissing(t *testing.T) {
+	page := `{"data":[{"title":"Remote SRE","company":"Acme","location":"","postcode":"",
+	 "snippet":"<p>Body.</p>","url":"https://www.whatjobs.com/pub_api__cpl__99__7065"}]}`
+	fake := (&recordingJSON{}).route("page=1", page)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "sre"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if got := jobs[0].Location; got != "United States" {
+		t.Errorf("Location = %q, want a bare %q", got, "United States")
+	}
+}
+
+// age/age_days report how long the record has sat in the reseller's index, not when the employer
+// published the role — postings from unrelated companies routinely share one value — so they must
+// never become a posting date. Leaving it unset lets freshness fall back to first-seen, which is
+// true if less precise.
+func TestWhatJobsNeverDatesAPostingFromAge(t *testing.T) {
+	fake := (&recordingJSON{}).route("page=1", whatjobsPage)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "backend engineer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) == 0 {
+		t.Fatal("no jobs")
+	}
+	if jobs[0].PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil: age_days is the reseller's index age", *jobs[0].PostedAt)
+	}
+}
+
+// The publisher id is the account credential, so it lives in the environment and the provider is
+// absent without it — an unconfigured environment must leave a provider that cannot crawl
+// unregistered rather than register one that fails every board.
+func TestWhatJobsRegisteredOnlyWhenPublisherSet(t *testing.T) {
+	t.Setenv("WHATJOBS_PUBLISHER_ID", "")
+	if _, ok := All(nil)["whatjobs"]; ok {
+		t.Error("All() should NOT register whatjobs without WHATJOBS_PUBLISHER_ID")
+	}
+
+	t.Setenv("WHATJOBS_PUBLISHER_ID", "7065")
+	if _, ok := All(nil)["whatjobs"]; !ok {
+		t.Error("All() should register whatjobs when WHATJOBS_PUBLISHER_ID is set")
+	}
+	if !slices.Contains(FilterableProviders(), "whatjobs") {
+		t.Error("FilterableProviders() should include whatjobs when configured")
+	}
+}
+
+// The board file must load and validate against the real registry, so a malformed entry fails the
+// build rather than a cron run. Validation needs the provider registered, hence the env.
+func TestWhatJobsBoardFileValidates(t *testing.T) {
+	t.Setenv("WHATJOBS_PUBLISHER_ID", "7065")
+
+	cfg, err := LoadConfig("../../sources/whatjobs.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/whatjobs.yml fails validation: %v", err)
+	}
+	if len(cfg.Sources) == 0 {
+		t.Fatal("sources/whatjobs.yml lists no keyword slices")
+	}
+	// Every entry's board is the search keyword — the adapter has nothing to crawl without one.
+	for _, e := range cfg.Sources {
+		if strings.TrimSpace(e.Board) == "" {
+			t.Errorf("entry %q has no keyword board", e.Company)
+		}
+	}
+}
+
+// The feed answers a rejected publisher id with 410 and an "Invalid Publisher" body. That is a
+// board-level failure: the run must count it and close nothing, rather than read an empty result as
+// a keyword that ran dry.
+func TestWhatJobsRejectedPublisherIsABoardFailure(t *testing.T) {
+	fake := &recordingJSON{err: &StatusError{Method: "GET", Code: 410, URL: whatjobsFeedURL}}
+
+	jobs, err := NewWhatJobs(fake, "bad-id").Fetch(context.Background(), CompanyEntry{Board: "devops"})
+	if err == nil {
+		t.Fatal("Fetch should fail when the feed rejects the publisher id")
+	}
+	if jobs != nil {
+		t.Errorf("Fetch returned %d jobs alongside the error, want none", len(jobs))
+	}
+	if !strings.Contains(err.Error(), "devops") {
+		t.Errorf("error should name the keyword that failed: %v", err)
+	}
+}
+
+// whatjobsRows builds a page of n postings with distinct tracked ids offset by base.
+func whatjobsRows(base, n int) string {
+	rows := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		rows = append(rows, fmt.Sprintf(
+			`{"title":"Engineer %[1]d","company":"Acme","location":"Austin","snippet":"<p>Body.</p>",`+
+				`"url":"https://www.whatjobs.com/pub_api__cpl__%[1]d__7065"}`, base+i))
+	}
+	return `{"data":[` + strings.Join(rows, ",") + `]}`
+}
+
+// The feed post-filters duplicates AFTER selecting the page, so a page requested with limit=50
+// routinely comes back with 44 rows while more pages remain. Treating a short page as the last one
+// would silently truncate every keyword — the most costly mistake available here.
+func TestWhatJobsShortPageDoesNotEndPagination(t *testing.T) {
+	fake := (&recordingJSON{}).
+		route("page=1", whatjobsRows(100, 44)). // short, yet not the last page
+		route("page=2", whatjobsRows(200, 50)).
+		route("page=3", `{"data":[]}`)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "engineer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if len(jobs) != 94 {
+		t.Errorf("got %d jobs, want 94 (44 + 50): a short page must not stop the crawl", len(jobs))
+	}
+	if len(fake.urls) != 3 {
+		t.Errorf("requested %d pages, want 3 (stop on the EMPTY page, not the short one)", len(fake.urls))
+	}
+}
+
+// An empty page is the real end-of-results signal.
+func TestWhatJobsEmptyPageEndsPagination(t *testing.T) {
+	fake := (&recordingJSON{}).
+		route("page=1", whatjobsRows(1, 50)).
+		route("page=2", `{"data":[]}`)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "engineer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 50 {
+		t.Errorf("got %d jobs, want 50", len(jobs))
+	}
+	if len(fake.urls) != 2 {
+		t.Errorf("requested %d pages, want 2", len(fake.urls))
+	}
+}
+
+// The feed serves nothing past roughly two thousand pages while reporting a far larger total, so a
+// crawl must be bounded rather than trusting the reported page count. A keyword that never runs dry
+// stops at the budget.
+func TestWhatJobsPageBudgetBoundsAKeyword(t *testing.T) {
+	// Every page is full, so only the budget can stop this crawl.
+	fake := (&recordingJSON{}).route("jobs.json", whatjobsRows(1, 50))
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "engineer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(fake.urls) != whatjobsMaxPages {
+		t.Errorf("requested %d pages, want the budget %d", len(fake.urls), whatjobsMaxPages)
+	}
+	if len(jobs) == 0 {
+		t.Error("the bounded crawl should still return the pages it read")
+	}
+}
+
+// The feed post-filters duplicates per page, which means the same posting can surface on more than
+// one page of the same keyword. Returning it repeatedly would have the pipeline upsert one row
+// hundreds of times over a deep crawl, so the adapter collapses a keyword's repeats itself.
+func TestWhatJobsCollapsesRepeatsWithinAKeyword(t *testing.T) {
+	// Both pages carry the SAME ids, then the feed runs dry.
+	fake := (&recordingJSON{}).
+		route("page=1", whatjobsRows(1, 10)).
+		route("page=2", whatjobsRows(1, 10)).
+		route("page=3", `{"data":[]}`)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "engineer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if len(jobs) != 10 {
+		t.Errorf("got %d jobs, want 10 distinct ids (the repeated page collapsed)", len(jobs))
+	}
+	seen := map[string]bool{}
+	for _, j := range jobs {
+		if seen[j.ExternalID] {
+			t.Errorf("external id %q returned twice", j.ExternalID)
+		}
+		seen[j.ExternalID] = true
+	}
+}
+
+// The postings cannot be liveness-probed (the url is a billing landing page, not the employer's
+// posting) and a crawl reads only the first pages of each keyword, so the sweep must wait out
+// page drift instead of closing on the 48-hour default.
+func TestWhatJobsDeclaresWideSweepGrace(t *testing.T) {
+	s, ok := NewWhatJobs(nil, "7065").(sweepGrace)
+	if !ok {
+		t.Fatal("whatjobs should declare a sweepGrace window")
+	}
+	if got := s.sweepGrace(); got != 14*24*time.Hour {
+		t.Errorf("sweepGrace() = %v, want 14 days", got)
+	}
+}

--- a/internal/sources/whatjobs_test.go
+++ b/internal/sources/whatjobs_test.go
@@ -279,6 +279,73 @@ func TestWhatJobsRegisteredOnlyWhenPublisherSet(t *testing.T) {
 	}
 }
 
+// A keyword that is blank after trimming must never be sent. Config validation only rejects an
+// EMPTY board, so an entry holding spaces slips through — and the feed answers a blank keyword with
+// its entire unfiltered inventory (32k postings for "   ", 560k for ""), which a single stray board
+// entry would pour into the catalogue. The adapter refuses instead of crawling.
+func TestWhatJobsRefusesABlankKeyword(t *testing.T) {
+	for _, board := range []string{"", "   ", "\t\n"} {
+		fake := (&recordingJSON{}).route("jobs.json", whatjobsPage)
+
+		_, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{
+			Company: "WhatJobs — oops",
+			Board:   board,
+		})
+		if err == nil {
+			t.Errorf("Fetch with board %q should fail, not crawl the whole feed", board)
+		}
+		if len(fake.urls) != 0 {
+			t.Errorf("board %q: adapter issued %d request(s), want none", board, len(fake.urls))
+		}
+	}
+}
+
+// A keyword padded with whitespace is still a real keyword; only a blank one is refused.
+func TestWhatJobsTrimsThePaddedKeyword(t *testing.T) {
+	fake := (&recordingJSON{}).route("jobs.json", `{"data":[]}`)
+
+	if _, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "  golang  "}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fake.query(t, 0).Get("keyword"); got != "golang" {
+		t.Errorf("keyword = %q, want the trimmed %q", got, "golang")
+	}
+}
+
+// If the feed ever changes its tracked-URL shape, every posting loses its native id and the crawl
+// returns nothing. That failure is invisible on its own: a provider that ingested zero jobs is
+// skipped by the sweep, so the existing rows would sit open forever while nothing refreshed them.
+// A page that carried postings yet yielded no usable id is therefore an error, not an empty result.
+func TestWhatJobsUnrecognizedURLShapeIsAnError(t *testing.T) {
+	// A full page whose urls carry no pub_api__cpl__ segment at all.
+	fake := (&recordingJSON{}).route("page=1", `{"data":[
+	 {"title":"A","company":"Acme","location":"Austin","snippet":"<p>x</p>","url":"https://www.whatjobs.com/jobs/a-1"},
+	 {"title":"B","company":"Acme","location":"Austin","snippet":"<p>y</p>","url":"https://www.whatjobs.com/jobs/b-2"}
+	]}`)
+
+	_, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "golang"})
+	if err == nil {
+		t.Fatal("a page of postings with no recognizable ids must fail the board, not read as empty")
+	}
+	if !strings.Contains(err.Error(), "golang") {
+		t.Errorf("error should name the keyword: %v", err)
+	}
+}
+
+// A page that merely MIXES usable and unusable postings is normal — only a page with nothing usable
+// signals the format changed.
+func TestWhatJobsMixedPageIsNotAnError(t *testing.T) {
+	fake := (&recordingJSON{}).route("page=1", whatjobsPage).route("page=2", `{"data":[]}`)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "golang"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Errorf("got %d jobs, want 1", len(jobs))
+	}
+}
+
 // The board file must load and validate against the real registry, so a malformed entry fails the
 // build rather than a cron run. Validation needs the provider registered, hence the env.
 func TestWhatJobsBoardFileValidates(t *testing.T) {

--- a/openspec/changes/whatjobs-cpc-ingest/.openspec.yaml
+++ b/openspec/changes/whatjobs-cpc-ingest/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/whatjobs-cpc-ingest/design.md
+++ b/openspec/changes/whatjobs-cpc-ingest/design.md
@@ -146,6 +146,11 @@ findable under Ireland's. Narrowing that last 1.7% needs the dictionary to treat
 country as authoritative over a city-name match, which is a change to `internal/location` and out
 of scope here.
 
+The `postcode` field is deliberately unused. The dictionary reads a *state* token ("Austin, TX"),
+not a ZIP, and supplying the state would not help either: `"London, OH"` resolves to `gb`+`us`
+exactly as bare `"London"` does. So there is no formatting of city/state/ZIP that fixes the
+homonyms — only the dictionary change above would.
+
 ### Request hygiene
 
 `user_agent` is omitted entirely — it is optional, it only improves click attribution on shared

--- a/openspec/changes/whatjobs-cpc-ingest/design.md
+++ b/openspec/changes/whatjobs-cpc-ingest/design.md
@@ -129,6 +129,23 @@ leaving it to infer "Vienna" or "London" — both of which appear in this feed a
 (London, Ohio 43140). This is a fact about the configured account, not a guess about a posting, so
 it does not breach the dict-only rule.
 
+Measured against `location.Parse` over the 738-posting sample (102 of which carry no location at
+all):
+
+| | bare city | city + `", United States"` |
+|---|---|---|
+| no country resolved | 218 | 0 |
+| a foreign country resolved | 11 | 11 |
+| US resolved | 407 | 636 |
+
+So the suffix rescues 229 postings and regresses none. It does not *fix* the 11 homonyms — the
+dictionary unions the tokens rather than letting the country arbitrate, so "Dublin, United States"
+resolves to `ie` **and** `us`. That is still strictly better than the bare city, which resolves to
+`ie` alone: the posting becomes findable under the US filter it belongs to, while remaining wrongly
+findable under Ireland's. Narrowing that last 1.7% needs the dictionary to treat an explicit
+country as authoritative over a city-name match, which is a change to `internal/location` and out
+of scope here.
+
 ### Request hygiene
 
 `user_agent` is omitted entirely — it is optional, it only improves click attribution on shared

--- a/openspec/changes/whatjobs-cpc-ingest/design.md
+++ b/openspec/changes/whatjobs-cpc-ingest/design.md
@@ -1,0 +1,180 @@
+## Context
+
+WhatJobs is a CPC network where freehire is an approved publisher (`publisher=7065`). Its FeedAPI
+answers `GET https://api.whatjobs.com/api/v1/jobs.json` with a keyword-searchable slice of US
+inventory — 594k postings by its own count, of which the tech slices are modest (`software
+engineer` 12.5k, `devops engineer` 1.3k, `golang` 108).
+
+Two properties of the feed shape the whole design.
+
+**The tracked URL is stable.** `url` is `whatjobs.com/pub_api__cpl__<jobID>__<publisherID>`, and
+three different `user_ip` values return a byte-identical URL. This is the opposite of CareerJet,
+whose `jobviewtrack.com/v2/<token>` is IP-bound and therefore forced a live per-click resolver.
+Here the URL can simply be stored, so `whatjobs` rides the ordinary crawl path with no new
+click-time machinery.
+
+**Nothing about a posting can be verified.** The URL is a billing landing page, not the employer's
+posting, so `cmd/liveness` can never confirm a role still exists — and it will not try, because it
+only probes jobs whose source is *not* a registered board provider. Meanwhile the inventory is old:
+56% of a 738-posting sample is over 90 days, the oldest 413 days. The only defence left is the
+unseen sweep, which makes the sweep's correctness the central design problem.
+
+The vendor documentation is unreliable and was corrected against the live API: `snippet` is the
+full description rather than a highlighted excerpt, the documented `onmousedown` field does not
+exist, `unique_id` does not deduplicate, an invalid publisher answers `410` rather than `422`, and
+every code sample in the docs is broken because a `/` in the `user_agent` parameter makes the edge
+redirect with the value corrupted to `Mozilla%215.0`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ingest the feed's tech slices through the existing pipeline, gaining dedup, enrichment outbox,
+  board health and incremental search indexing for free.
+- Keep the publisher id out of the repository, in the environment only.
+- Never let an unverifiable posting masquerade as a fresh, salaried, or employer-hosted one.
+- Do not let partial keyword coverage cause false closes.
+
+**Non-Goals:**
+
+- Filtering staffing intermediaries (~35% of the feed's companies). Explicitly declined — the
+  postings are real.
+- A click-proxy endpoint hiding the publisher id from the public API. Declined; the source name
+  and tracked URL are published openly.
+- Non-US inventory. The publisher id is per-country and this one serves US only; `country`,
+  `locale` and `geo` parameters are ignored by the API.
+- Recovering the employer's own posting URL. Not obtainable from the feed.
+
+## Decisions
+
+### Board is a search keyword, modelled on `hh`
+
+`hh` already establishes this shape: a multi-company aggregator enumerated by a slice id
+(`professional_role`), whose `company` in the board file is a display label while the real
+employer comes from each posting. `whatjobs` reuses it with the keyword as board, so it is
+`aggregator()` but neither `boardless()` (the keyword is required) nor `fullCatalog()` (a crawl
+sees one slice).
+
+*Alternative considered:* a boardless adapter with keywords hardcoded in Go. Rejected — it would
+lose per-keyword `board_health`, independent cooldown, and the ability to tune the keyword list
+without a deploy.
+
+### Provider-declared sweep grace window, not a new closing mechanism
+
+The 48-hour sweep is unsafe here: a posting that drifts past the crawl's page budget looks unseen,
+gets closed, and reopens on a later run when it drifts back — churn that also pollutes
+`job_daily_stats`. But `CloseUnseenJobs` already takes its cutoff from the caller ("The caller
+passes the crawled slugs and owns the grace window"), so no new SQL and no new closing path is
+needed. An adapter declares a wider window; `cmd/ingest` uses it when computing the cutoff.
+
+The marker follows the existing family (`selfClosing`, `fullCatalog`, `aggregator`) but carries a
+value, so it needs an accessor for `cmd/ingest` outside the package — mirroring
+`SelfClosingProviders`:
+
+```go
+type sweepGrace interface{ sweepGrace() time.Duration }
+
+// SweepGraceWindows returns the widened sweep windows the registry's adapters declare.
+func SweepGraceWindows(reg map[string]Source) map[string]time.Duration
+```
+
+`whatjobs` declares **14 days**: long enough that page drift and a skipped cron cannot close a live
+posting, short enough that a role withdrawn from the feed leaves the catalogue within a fortnight.
+
+*Alternatives considered:* (a) a `ttlBound` marker closing on `created_at + N` regardless of the
+feed — rejected, it would close postings the feed still lists, contradicting the reappearance rule;
+(b) crawling every keyword to full depth so coverage is complete — rejected, `software engineer`
+alone is 250 pages and the feed's ceiling (~2000 pages) makes completeness unattainable anyway;
+(c) marking it `selfClosing` to skip the sweep entirely — rejected, that marker means the adapter
+emits authoritative removal events, which this feed does not.
+
+### Duplicates across keywords are accepted, not engineered away
+
+`external_id` is namespaced `"<board>:<native-id>"` by the pipeline unconditionally, so a posting
+matching two keywords becomes two rows. Measured overlap is small — 742 rows across 8 keywords
+collapsed to 738 unique postings, 0.5% — and the existing cluster dedup
+(`aggregator-ats-dedup`, `job-cluster-copies`) is what collapses copies for display. Keywords are
+chosen to minimise overlap rather than changing a namespacing rule the rest of the catalogue
+depends on.
+
+### Page budget is bounded and logged when hit
+
+Pagination stops on an empty page, at the feed's ceiling, or at a per-board page budget
+(**40 pages**, ≈2000 postings). A page returning fewer rows than requested is *not* an
+end-of-results signal: the feed post-filters duplicates, so `limit=50` routinely yields 44. When
+the budget is what stopped a crawl, the run logs it — a bounded crawl must not read as complete
+coverage.
+
+`limit` is sent as **50** and never as `1`: values above 50 are silently clamped, and `limit=1`
+combined with a keyword returns an empty `data` with `per_page: 0`, a pagination bug in the feed.
+
+### Identity from the URL, junk fields dropped
+
+The native id is the `pub_api__cpl__(\d+)__` capture; a posting whose URL lacks it is skipped
+rather than stored under a guessed id. `salary` (always `0.000000 - 0.000000`), `job_type` (always
+empty) and `logo` (always null) are ignored. The trailing `#J-<digits>-Ljbffr` reseller signature —
+on 96% of descriptions — is stripped.
+
+`age_days` is dropped rather than mapped to `posted_at`: 15 postings from unrelated companies
+shared `age_days: 109`, which shows it measures the record's age in the reseller's index, not the
+role's publication date. Leaving `posted_at` unset lets `EffectivePostedAt` fall back to
+`created_at`, so these postings sort by when freehire first saw them — true, if less precise.
+
+### Country is asserted from the publisher id, not guessed from the city
+
+`location` carries a bare city and `postcode` a US ZIP; no country field exists. The publisher id
+is per-country by the vendor's own design and this one serves US inventory (625 of 626 postcodes
+are US ZIPs). The adapter therefore states the country for the geography dictionary rather than
+leaving it to infer "Vienna" or "London" — both of which appear in this feed as US cities
+(London, Ohio 43140). This is a fact about the configured account, not a guess about a posting, so
+it does not breach the dict-only rule.
+
+### Request hygiene
+
+`user_agent` is omitted entirely — it is optional, it only improves click attribution on shared
+IPs, and any slash in it breaks the request. `user_ip` is mandatory, but a crawl is not a user
+viewing a page, so it carries a fixed placeholder; the vendor ignores tracking on values it
+dislikes and still serves results. `unique_id` is not used.
+
+## Risks / Trade-offs
+
+- **Prod datacenter IP may be challenged by the edge.** Verification ran from a residential IP; a
+  prod crawl could meet the Cloudflare validation page the click-through already redirects to.
+  → `sources.ApplyProxyEgress` exists for exactly this; if the board fails on prod, add `whatjobs`
+  to `proxiedProviders`. Board health surfaces it within one cycle rather than silently.
+- **Ghost jobs persist for up to 14 days after withdrawal.** The widened window is the price of not
+  false-closing, and no probe can shorten it.
+  → Accepted deliberately. The 14 days bound the damage; without the window the churn would be
+  worse and would corrupt daily stats.
+- **City-multiplied postings survive dedup.** One remote role appears under several cities with
+  words reordered in the title (CAI ×3), so `role_fingerprint`, which hashes visible text, will not
+  collapse them.
+  → Out of scope here; it is the same class of problem `fuzzy-description-role-dedup` addresses.
+  Logged as a known limitation rather than patched inside this adapter.
+- **A silently truncated crawl looks like a small keyword.** The feed answers `200` with fewer rows
+  rather than erroring.
+  → The provider is not `fullCatalog`, so the source-scoped close that punishes truncation is never
+  reached; the company-scoped sweep plus the 14-day window absorbs it.
+- **Terms of use permit caching only presumptively.** The publisher terms link in the vendor's
+  documentation is an unfilled placeholder, so the right to store descriptions is unconfirmed.
+  → Ask the network directly before the board list grows; storing a reseller's full descriptions is
+  the plausible cause of an account being closed.
+
+## Migration Plan
+
+1. Merge with `WHATJOBS_PUBLISHER_ID` unset everywhere — the provider stays unregistered and
+   nothing changes for any existing crawl.
+2. Set the variable in the prod ingest worker's env file, then run one board file on prod
+   (`sources/whatjobs.yml`) and inspect counts before adding it to cron.
+3. Rollback is unsetting the variable: the provider disappears from the registry, and its jobs
+   close on the ordinary sweep once nothing re-lists them.
+
+No migration is needed — the change adds no column and alters no stored shape.
+
+## Open Questions
+
+- Confirm with WhatJobs whether caching descriptions and tracked URLs is permitted, since their
+  documented terms link is empty.
+- The keyword list in `sources/whatjobs.yml` is seeded from the slices measured during
+  verification; its shape should be revisited once real click-through data shows which slices
+  convert.

--- a/openspec/changes/whatjobs-cpc-ingest/proposal.md
+++ b/openspec/changes/whatjobs-cpc-ingest/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+WhatJobs is an approved CPC publisher account (`publisher=7065`) whose FeedAPI carries
+US tech postings the catalogue does not have — a spot check of 14 fresh tech postings
+found only 3 already present. It is the first monetization-network feed whose tracked
+click-through URL is **not IP-bound**, so unlike CareerJet it can be ingested and stored
+on the ordinary crawl path instead of needing a live per-click resolver.
+
+The feed also has two properties that make a naive adapter actively harmful: its postings
+are old (56% older than 90 days, up to 413) and its `url` points at a billing landing page
+rather than the employer's posting, so neither the liveness probe nor the origin can ever
+verify them. The adapter has to compensate for both, or it pours unverifiable ghost jobs
+into the catalogue.
+
+## What Changes
+
+- New `whatjobs` source adapter reading the WhatJobs FeedAPI as a multi-company aggregator,
+  enumerated by search keyword — the same shape as `hh`, whose board is a `professional_role`.
+- `sources/whatjobs.yml` lists one entry per keyword slice; `company` is a display label only,
+  the real employer comes from each posting.
+- The publisher id lives **only** in the environment (`WHATJOBS_PUBLISHER_ID`), never in the
+  board file. `sources.All` registers the adapter only when it is set, matching `usajobs`/`reed`.
+- Normalization compensates for the feed's defects: the reseller signature `#J-…-Ljbffr` is
+  stripped from descriptions, and the always-garbage `salary` (`"0.000000 - 0.000000"`),
+  always-empty `job_type` and always-null `logo` are ignored rather than stored as facts.
+- `age_days` is **not** trusted as a posting date. It reports the age of the record in the
+  reseller's index (15 postings from different companies share `age_days: 109`), so it never
+  feeds `posted_at`.
+- The post-run unseen sweep gets a **provider-declared grace window**. The sweep's caller
+  already owns the cutoff; a provider whose crawl reaches only a slice of its catalogue
+  declares a window wider than the 48-hour default, so a posting that merely drifted past
+  the crawl's page depth is not falsely closed and then reopened.
+
+## Capabilities
+
+### New Capabilities
+
+- `whatjobs-source`: the WhatJobs FeedAPI adapter — request shape and its documented-but-broken
+  parameters, keyword-sliced pagination and its ceiling, posting identity derived from the
+  tracked URL, and the normalization that discards the feed's junk fields.
+
+### Modified Capabilities
+
+- `job-lifecycle`: the unseen-job sweep's grace window becomes provider-declared rather than a
+  fixed 48 hours, so a provider with deliberately partial catalogue coverage closes on a wider
+  window. The default is unchanged for every existing provider.
+
+## Impact
+
+- **New code**: `internal/sources/whatjobs.go` (+ test), `sources/whatjobs.yml`.
+- **Touched**: `internal/sources/registry.go` (conditional registration), `internal/sources/source.go`
+  (grace-window marker), `cmd/ingest/main.go` (honour the declared window when computing the cutoff).
+- **Environment**: `WHATJOBS_PUBLISHER_ID` — a new secret for the ingest worker; unset leaves the
+  provider unregistered, so tests, CI and local dev are unaffected.
+- **Not touched**: the liveness probe needs no change — it only probes jobs whose source is *not*
+  a registered board provider, and `whatjobs` is one, so its jobs are excluded by the existing rule.
+- **Deliberately out of scope**: filtering staffing intermediaries out of the feed (~35% of its
+  companies), a click-proxy endpoint that would hide the publisher id from the public API, and any
+  non-US inventory — the publisher id is per-country and this one is US-only.

--- a/openspec/changes/whatjobs-cpc-ingest/specs/job-lifecycle/spec.md
+++ b/openspec/changes/whatjobs-cpc-ingest/specs/job-lifecycle/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Jobs unseen beyond a grace window are closed after a run
+
+After an ingest run, the system SHALL run the unseen-job sweep **per provider, scoped to the companies that run wrote**: for each provider that ingested at least one job during the run, it SHALL stamp `closed_at` on every open job of that provider whose `last_seen_at` is older than that provider's grace window **and whose `company_slug` the run wrote a job for**. The grace window SHALL default to 48 hours and MAY be widened by the provider's adapter, which declares a longer window when its crawl deliberately reaches only a slice of its catalogue — a posting that merely drifted past the crawl's page depth must not be closed and then reopened on a later run. A provider that ingested nothing SHALL NOT have its jobs swept, and a company the run did not write (its board was not in this run, returned no postings, or was removed from the board file) SHALL NOT be swept — so a partial or targeted run, or a full crawl of a large provider that times out before completing, cannot mass-close the boards it never reached. The sweep of one provider never touches another provider's jobs. The trade-off is deliberate: a board that empties out or is removed leaks its open jobs (they reopen or close on a later crawl) rather than risk over-closing live jobs the run simply did not reach.
+
+#### Scenario: Stale job is closed
+
+- **WHEN** a sweep runs after a provider ingested at least one job and an open job of that
+  provider — belonging to a company the run wrote — was last seen 49 hours ago
+- **THEN** that job's `closed_at` is set and the job stops appearing in list surfaces
+
+#### Scenario: A company the run did not crawl is not swept
+
+- **WHEN** a run ingests jobs for company A of a provider but does not write any job for
+  company B of the same provider (B's board was not in this run, or returned no postings)
+  and B has an open job last seen 49 hours ago
+- **THEN** the sweep closes A's stale jobs but leaves B's stale job open
+
+#### Scenario: Recently seen job survives the sweep
+
+- **WHEN** a sweep runs and an open job was last seen 6 hours ago
+- **THEN** the job remains open
+
+#### Scenario: A provider that ingested nothing closes nothing
+
+- **WHEN** a run ingested jobs for provider A but zero for provider B (B's crawl failed)
+- **THEN** the sweep runs for A but not for B, so no B job is closed
+
+#### Scenario: One provider's sweep leaves another provider's jobs alone
+
+- **WHEN** a multi-provider run sweeps provider A's stale jobs
+- **THEN** provider B's jobs are never closed by A's sweep
+
+#### Scenario: A partial-coverage provider closes on its own wider window
+
+- **WHEN** a sweep runs for a provider whose adapter declares a 14-day grace window and an open
+  job of that provider was last seen 49 hours ago
+- **THEN** that job remains open, because 49 hours is inside the declared window
+
+#### Scenario: A provider declaring no window keeps the default
+
+- **WHEN** a sweep runs for a provider whose adapter declares no grace window
+- **THEN** its jobs are closed on the 48-hour default, unchanged

--- a/openspec/changes/whatjobs-cpc-ingest/specs/whatjobs-source/spec.md
+++ b/openspec/changes/whatjobs-cpc-ingest/specs/whatjobs-source/spec.md
@@ -64,6 +64,32 @@ carry that segment SHALL be skipped rather than stored under a guessed id.
 - **WHEN** a posting's url does not contain a `pub_api__cpl__<digits>__<digits>` segment
 - **THEN** that posting is not returned as a job
 
+#### Scenario: A page where nothing carries an id fails the board
+
+- **WHEN** a page returns postings and not one of them carries a recognizable native id
+- **THEN** the board's crawl fails with an error naming the keyword, rather than reporting an empty
+  result — a provider credited with zero ingested jobs is skipped by the unseen sweep, so a silent
+  empty would leave every existing row open indefinitely with nothing refreshing it
+
+### Requirement: A blank keyword is refused rather than crawled
+
+The system MUST NOT request the feed when the board's keyword is empty or whitespace-only, and SHALL
+fail that board with an error naming the company. The feed answers a blank keyword with its entire
+unfiltered inventory — tens of thousands of postings, most not technical — so one padded board entry
+would otherwise pour that into the catalogue. Config validation rejects only a strictly empty board,
+which is why the adapter checks after trimming. A keyword padded with surrounding whitespace is a
+real keyword and SHALL be sent trimmed.
+
+#### Scenario: A whitespace-only keyword issues no request
+
+- **WHEN** a board entry's keyword is `"   "`
+- **THEN** the crawl fails for that entry and no feed request is made
+
+#### Scenario: A padded keyword is trimmed and used
+
+- **WHEN** a board entry's keyword is `"  golang  "`
+- **THEN** the feed is queried for `golang`
+
 ### Requirement: The feed's junk fields are discarded rather than stored
 
 The system SHALL ignore the feed's `salary`, `job_type` and `logo` fields, which carry no

--- a/openspec/changes/whatjobs-cpc-ingest/specs/whatjobs-source/spec.md
+++ b/openspec/changes/whatjobs-cpc-ingest/specs/whatjobs-source/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+### Requirement: The WhatJobs feed is crawled as a keyword-sliced aggregator
+
+The system SHALL crawl the WhatJobs FeedAPI as a multi-company aggregator whose board is a
+search keyword, registered under the provider key `whatjobs`. Each board entry's `company` is
+a display label only — the employer of record comes from each posting's own `company` field.
+The adapter SHALL be marked an aggregator so the cross-source dedup pass may suppress its copy
+in favour of a first-party ATS posting of the same role. It SHALL NOT be marked boardless (the
+keyword is mandatory) and SHALL NOT be marked full-catalogue (a crawl reaches only a slice).
+
+#### Scenario: Keyword board is crawled
+
+- **WHEN** a board entry for provider `whatjobs` carries the keyword `backend engineer`
+- **THEN** the adapter requests that keyword's postings and returns them as jobs whose company
+  is each posting's own employer, not the entry's display label
+
+#### Scenario: Aggregator copy loses to a first-party posting
+
+- **WHEN** the feed returns a posting for a role the catalogue already holds from that company's
+  own ATS board
+- **THEN** the cross-source dedup pass treats the `whatjobs` row as the aggregator copy and the
+  ATS posting wins
+
+#### Scenario: A board entry without a keyword fails validation
+
+- **WHEN** a `sources/whatjobs.yml` entry omits `board`
+- **THEN** config validation fails fast and the run does not start
+
+### Requirement: The publisher id is read from the environment only
+
+The system SHALL read the WhatJobs publisher id from the `WHATJOBS_PUBLISHER_ID` environment
+variable and MUST NOT accept it from a board file. The provider SHALL be registered in the
+adapter registry only when that variable is set to a non-empty value, so an environment without
+the credential leaves `whatjobs` absent from the registry rather than registering a provider
+that cannot crawl.
+
+#### Scenario: Configured environment registers the provider
+
+- **WHEN** `WHATJOBS_PUBLISHER_ID` is set and the registry is assembled
+- **THEN** the registry contains a `whatjobs` adapter carrying that publisher id
+
+#### Scenario: Unconfigured environment omits the provider
+
+- **WHEN** `WHATJOBS_PUBLISHER_ID` is unset or empty and the registry is assembled
+- **THEN** the registry has no `whatjobs` entry, and a board file naming that provider fails
+  validation fast
+
+### Requirement: Posting identity is derived from the tracked click-through URL
+
+The system SHALL derive each posting's native id from the tracked URL's
+`pub_api__cpl__<id>__<publisher>` path segment, and SHALL store the tracked URL as the job's
+posting URL. The tracked URL is not bound to the requesting IP, so a stored copy stays valid
+for any later visitor and the publisher attribution survives. A posting whose URL does not
+carry that segment SHALL be skipped rather than stored under a guessed id.
+
+#### Scenario: Native id is extracted
+
+- **WHEN** a posting's url is `https://www.whatjobs.com/pub_api__cpl__2737655843__7065?utm_source=7065`
+- **THEN** the job's native id is `2737655843` and its URL is the tracked url as returned
+
+#### Scenario: Unrecognized URL shape is skipped
+
+- **WHEN** a posting's url does not contain a `pub_api__cpl__<digits>__<digits>` segment
+- **THEN** that posting is not returned as a job
+
+### Requirement: The feed's junk fields are discarded rather than stored
+
+The system SHALL ignore the feed's `salary`, `job_type` and `logo` fields, which carry no
+information: `salary` is always the literal `0.000000 - 0.000000`, `job_type` is always empty
+and `logo` is always null. The system SHALL strip the reseller signature (a trailing
+`#J-<digits>-Ljbffr` marker, present on 96% of descriptions) from the description text before
+the job is persisted.
+
+#### Scenario: Placeholder salary is not stored as a salary
+
+- **WHEN** a posting reports `salary` as `0.000000 - 0.000000`
+- **THEN** the job carries no salary
+
+#### Scenario: Reseller signature is stripped
+
+- **WHEN** a posting's description ends with `#J-18808-Ljbffr`
+- **THEN** the persisted description does not contain that marker
+
+### Requirement: The feed's age field never becomes a posting date
+
+The system MUST NOT map the feed's `age` or `age_days` onto the job's posted date. Those fields
+report how long the record has been in the reseller's index rather than when the employer
+published the role — postings from unrelated companies routinely share one `age_days` value —
+so treating them as a posting date would misorder every freshness-sorted surface.
+
+#### Scenario: Age is not persisted as a posted date
+
+- **WHEN** a posting reports `age_days` as 109
+- **THEN** the job's posted date is left unset rather than computed from that value
+
+### Requirement: Pagination stops at the feed's ceiling and its short pages
+
+The system SHALL page through a keyword's results until a page returns no postings, the
+configured page budget is exhausted, or the feed's depth ceiling is reached, and SHALL treat a
+page returning fewer postings than requested as normal rather than as the last page. The feed
+clamps any requested page size above 50, returns fewer rows than asked for once a keyword is
+given (it post-filters duplicates), and serves nothing beyond roughly two thousand pages even
+when it reports a far larger total.
+
+#### Scenario: A short page does not end pagination
+
+- **WHEN** a page requested with a size of 50 returns 44 postings and the next page returns more
+- **THEN** the crawl continues to the next page
+
+#### Scenario: An empty page ends pagination
+
+- **WHEN** a page returns zero postings
+- **THEN** the crawl of that keyword stops and the postings gathered so far are returned
+
+#### Scenario: The page budget bounds a huge keyword
+
+- **WHEN** a keyword reports a total far beyond the crawl's page budget
+- **THEN** the crawl stops at the budget and the run succeeds with the slice it read
+
+### Requirement: The request avoids the feed's documented-but-broken parameters
+
+The system MUST NOT send a `user_agent` query parameter containing a forward slash, and MUST NOT
+rely on the `unique_id` parameter for deduplication. A slash in `user_agent` causes the edge to
+redirect the request with the value corrupted, which is why the vendor's own documented examples
+fail; `unique_id` does not suppress previously returned postings despite the documentation
+claiming it does.
+
+#### Scenario: User agent carries no slash
+
+- **WHEN** the adapter builds a feed request
+- **THEN** any `user_agent` value it sends contains no `/` character
+
+#### Scenario: An invalid publisher id surfaces as a board failure
+
+- **WHEN** the feed rejects the configured publisher id (it answers `410` with an
+  `Invalid Publisher` body)
+- **THEN** the board's crawl fails with an error, is counted as a failure, and does not close
+  any existing job

--- a/openspec/changes/whatjobs-cpc-ingest/specs/whatjobs-source/spec.md
+++ b/openspec/changes/whatjobs-cpc-ingest/specs/whatjobs-source/spec.md
@@ -118,6 +118,24 @@ when it reports a far larger total.
 - **WHEN** a keyword reports a total far beyond the crawl's page budget
 - **THEN** the crawl stops at the budget and the run succeeds with the slice it read
 
+#### Scenario: The bounded crawl says so
+
+- **WHEN** the page budget rather than an empty page is what ended a keyword's crawl
+- **THEN** the run logs that the slice is bounded, so a partial read is never mistaken for full
+  coverage of that keyword
+
+### Requirement: A keyword's repeated postings are collapsed before they are returned
+
+The system SHALL return each posting at most once per keyword crawl, keyed on the native posting id.
+The feed post-filters duplicates only within a page, so the same posting can surface on several
+pages of one keyword; returning it each time would have the pipeline upsert one row repeatedly
+across a deep crawl for no gain.
+
+#### Scenario: The same posting on two pages is returned once
+
+- **WHEN** two pages of one keyword both carry a posting with the same native id
+- **THEN** the crawl returns that posting once
+
 ### Requirement: The request avoids the feed's documented-but-broken parameters
 
 The system MUST NOT send a `user_agent` query parameter containing a forward slash, and MUST NOT

--- a/openspec/changes/whatjobs-cpc-ingest/tasks.md
+++ b/openspec/changes/whatjobs-cpc-ingest/tasks.md
@@ -37,3 +37,9 @@
 - [x] 6.1 Run `go build ./... && go vet ./... && go test ./...` green
 - [x] 6.2 Run one live board end to end against the real feed with the publisher id set, and confirm the stored rows: description free of the reseller signature, no salary, unset posted date, URL intact, country present
 - [x] 6.3 Document the provider in `internal/sources/AGENTS.md` — the keyword-as-board shape, the env-only publisher id, and the two feed traps (slash in `user_agent`, `limit=1` with a keyword)
+
+## 7. Review findings
+
+- [x] 7.1 Refuse a blank (whitespace-only) keyword before any request — config validation only rejects a strictly empty board, and the feed answers a blank keyword with its whole unfiltered inventory (32k postings for `"   "`, 560k for `""`)
+- [x] 7.2 Send the keyword trimmed, so a padded board entry still crawls the intended slice
+- [x] 7.3 Fail the board when a page returns postings but none carries a recognizable native id — a silent empty result would be invisible, since a provider with zero ingested jobs is skipped by the sweep and its rows would stay open forever

--- a/openspec/changes/whatjobs-cpc-ingest/tasks.md
+++ b/openspec/changes/whatjobs-cpc-ingest/tasks.md
@@ -1,0 +1,39 @@
+## 1. Sweep grace window
+
+- [ ] 1.1 Add the `sweepGrace` marker interface to `internal/sources/source.go`, documented in the style of `selfClosing`/`fullCatalog`: an adapter declares a window wider than the sweep default when its crawl deliberately covers only a slice of its catalogue
+- [ ] 1.2 Add `sources.SweepGraceWindows(reg map[string]Source) map[string]time.Duration` to `internal/sources/registry.go`, mirroring `SelfClosingProviders`, with a test proving a declaring adapter appears and a non-declaring one does not
+- [ ] 1.3 Make `cmd/ingest` compute the sweep cutoff from the provider's declared window, falling back to the existing 48-hour default; test that a declaring provider's recently-drifted job survives and a default provider's behaviour is unchanged
+
+## 2. Feed client
+
+- [ ] 2.1 Create `internal/sources/whatjobs.go` with `NewWhatJobs(c HTTPClient, publisherID string)` and `Provider() string` returning `whatjobs`; assert the `aggregator()` marker and the absence of `boardless()`/`fullCatalog()`
+- [ ] 2.2 Build the feed request from a board entry: `publisher`, `user_ip` placeholder, `keyword` from the board, `limit=50`, `page`; assert no `user_agent` parameter is sent and no value contains a slash
+- [ ] 2.3 Decode the response envelope (`data`, `total`, `current_page`, `last_page`) from a recorded fixture, including the `snippet`-as-full-description shape
+- [ ] 2.4 Surface a rejected publisher id (HTTP `410`, `Invalid Publisher` body) as a board-level error so the run counts it failed and closes nothing
+
+## 3. Posting identity and normalization
+
+- [ ] 3.1 Extract the native id from the tracked URL's `pub_api__cpl__(\d+)__` segment; skip a posting whose URL lacks it rather than storing a guessed id
+- [ ] 3.2 Store the tracked URL unchanged as the job's posting URL, with a test pinning that the query string is preserved so publisher attribution survives
+- [ ] 3.3 Strip the trailing `#J-<digits>-Ljbffr` reseller signature from the description; test a signed and an unsigned description
+- [ ] 3.4 Discard `salary`, `job_type` and `logo`; test that the placeholder salary `0.000000 - 0.000000` yields no salary
+- [ ] 3.5 Leave the posted date unset — assert `age`/`age_days` never reach it, so freshness falls back to `created_at`
+- [ ] 3.6 Compose the location from the posting's city plus the account's country, and carry the US ZIP through; test that a bare city like `London` is not left to be read as the UK one
+
+## 4. Pagination
+
+- [ ] 4.1 Page a keyword until an empty page, the feed's depth ceiling, or the 40-page budget; test that a short page (44 rows for a requested 50) does NOT end pagination
+- [ ] 4.2 Log once when the page budget is what stopped a crawl, so a bounded slice never reads as full coverage
+- [ ] 4.3 Declare the 14-day `sweepGrace` window on the adapter and cover it with a test
+
+## 5. Wiring
+
+- [ ] 5.1 Register `whatjobs` in `sources.All` only when `WHATJOBS_PUBLISHER_ID` is non-empty, following the `usajobs`/`reed` pattern; test both the configured and unconfigured registry
+- [ ] 5.2 Create `sources/whatjobs.yml` with the seed keyword slices, each entry carrying a display-label `company` and the keyword as `board`, headed by a comment explaining the keyword-as-board shape and the US-only account
+- [ ] 5.3 Verify the board file against the registry the way `cmd/ingest` does, so a malformed entry fails fast
+
+## 6. Verification
+
+- [ ] 6.1 Run `go build ./... && go vet ./... && go test ./...` green
+- [ ] 6.2 Run one live board end to end against the real feed with the publisher id set, and confirm the stored rows: description free of the reseller signature, no salary, unset posted date, URL intact, country present
+- [ ] 6.3 Document the provider in `internal/sources/AGENTS.md` — the keyword-as-board shape, the env-only publisher id, and the two feed traps (slash in `user_agent`, `limit=1` with a keyword)

--- a/openspec/changes/whatjobs-cpc-ingest/tasks.md
+++ b/openspec/changes/whatjobs-cpc-ingest/tasks.md
@@ -6,34 +6,34 @@
 
 ## 2. Feed client
 
-- [ ] 2.1 Create `internal/sources/whatjobs.go` with `NewWhatJobs(c HTTPClient, publisherID string)` and `Provider() string` returning `whatjobs`; assert the `aggregator()` marker and the absence of `boardless()`/`fullCatalog()`
-- [ ] 2.2 Build the feed request from a board entry: `publisher`, `user_ip` placeholder, `keyword` from the board, `limit=50`, `page`; assert no `user_agent` parameter is sent and no value contains a slash
-- [ ] 2.3 Decode the response envelope (`data`, `total`, `current_page`, `last_page`) from a recorded fixture, including the `snippet`-as-full-description shape
-- [ ] 2.4 Surface a rejected publisher id (HTTP `410`, `Invalid Publisher` body) as a board-level error so the run counts it failed and closes nothing
+- [x] 2.1 Create `internal/sources/whatjobs.go` with `NewWhatJobs(c HTTPClient, publisherID string)` and `Provider() string` returning `whatjobs`; assert the `aggregator()` marker and the absence of `boardless()`/`fullCatalog()`
+- [x] 2.2 Build the feed request from a board entry: `publisher`, `user_ip` placeholder, `keyword` from the board, `limit=50`, `page`; assert no `user_agent` parameter is sent and no value contains a slash
+- [x] 2.3 Decode the response envelope (`data`, `total`, `current_page`, `last_page`) from a recorded fixture, including the `snippet`-as-full-description shape
+- [x] 2.4 Surface a rejected publisher id (HTTP `410`, `Invalid Publisher` body) as a board-level error so the run counts it failed and closes nothing
 
 ## 3. Posting identity and normalization
 
-- [ ] 3.1 Extract the native id from the tracked URL's `pub_api__cpl__(\d+)__` segment; skip a posting whose URL lacks it rather than storing a guessed id
-- [ ] 3.2 Store the tracked URL unchanged as the job's posting URL, with a test pinning that the query string is preserved so publisher attribution survives
-- [ ] 3.3 Strip the trailing `#J-<digits>-Ljbffr` reseller signature from the description; test a signed and an unsigned description
-- [ ] 3.4 Discard `salary`, `job_type` and `logo`; test that the placeholder salary `0.000000 - 0.000000` yields no salary
-- [ ] 3.5 Leave the posted date unset — assert `age`/`age_days` never reach it, so freshness falls back to `created_at`
-- [ ] 3.6 Compose the location from the posting's city plus the account's country, and carry the US ZIP through; test that a bare city like `London` is not left to be read as the UK one
+- [x] 3.1 Extract the native id from the tracked URL's `pub_api__cpl__(\d+)__` segment; skip a posting whose URL lacks it rather than storing a guessed id
+- [x] 3.2 Store the tracked URL unchanged as the job's posting URL, with a test pinning that the query string is preserved so publisher attribution survives
+- [x] 3.3 Strip the trailing `#J-<digits>-Ljbffr` reseller signature from the description; test a signed and an unsigned description
+- [x] 3.4 Discard `salary`, `job_type` and `logo`; test that the placeholder salary `0.000000 - 0.000000` yields no salary
+- [x] 3.5 Leave the posted date unset — assert `age`/`age_days` never reach it, so freshness falls back to `created_at`
+- [x] 3.6 Compose the location from the posting's city plus the account's country, and carry the US ZIP through; test that a bare city like `London` is not left to be read as the UK one
 
 ## 4. Pagination
 
-- [ ] 4.1 Page a keyword until an empty page, the feed's depth ceiling, or the 40-page budget; test that a short page (44 rows for a requested 50) does NOT end pagination
-- [ ] 4.2 Log once when the page budget is what stopped a crawl, so a bounded slice never reads as full coverage
-- [ ] 4.3 Declare the 14-day `sweepGrace` window on the adapter and cover it with a test
+- [x] 4.1 Page a keyword until an empty page, the feed's depth ceiling, or the 40-page budget; test that a short page (44 rows for a requested 50) does NOT end pagination
+- [x] 4.2 Log once when the page budget is what stopped a crawl, so a bounded slice never reads as full coverage
+- [x] 4.3 Declare the 14-day `sweepGrace` window on the adapter and cover it with a test
 
 ## 5. Wiring
 
-- [ ] 5.1 Register `whatjobs` in `sources.All` only when `WHATJOBS_PUBLISHER_ID` is non-empty, following the `usajobs`/`reed` pattern; test both the configured and unconfigured registry
-- [ ] 5.2 Create `sources/whatjobs.yml` with the seed keyword slices, each entry carrying a display-label `company` and the keyword as `board`, headed by a comment explaining the keyword-as-board shape and the US-only account
-- [ ] 5.3 Verify the board file against the registry the way `cmd/ingest` does, so a malformed entry fails fast
+- [x] 5.1 Register `whatjobs` in `sources.All` only when `WHATJOBS_PUBLISHER_ID` is non-empty, following the `usajobs`/`reed` pattern; test both the configured and unconfigured registry
+- [x] 5.2 Create `sources/whatjobs.yml` with the seed keyword slices, each entry carrying a display-label `company` and the keyword as `board`, headed by a comment explaining the keyword-as-board shape and the US-only account
+- [x] 5.3 Verify the board file against the registry the way `cmd/ingest` does, so a malformed entry fails fast
 
 ## 6. Verification
 
-- [ ] 6.1 Run `go build ./... && go vet ./... && go test ./...` green
+- [x] 6.1 Run `go build ./... && go vet ./... && go test ./...` green
 - [ ] 6.2 Run one live board end to end against the real feed with the publisher id set, and confirm the stored rows: description free of the reseller signature, no salary, unset posted date, URL intact, country present
-- [ ] 6.3 Document the provider in `internal/sources/AGENTS.md` — the keyword-as-board shape, the env-only publisher id, and the two feed traps (slash in `user_agent`, `limit=1` with a keyword)
+- [x] 6.3 Document the provider in `internal/sources/AGENTS.md` — the keyword-as-board shape, the env-only publisher id, and the two feed traps (slash in `user_agent`, `limit=1` with a keyword)

--- a/openspec/changes/whatjobs-cpc-ingest/tasks.md
+++ b/openspec/changes/whatjobs-cpc-ingest/tasks.md
@@ -35,5 +35,5 @@
 ## 6. Verification
 
 - [x] 6.1 Run `go build ./... && go vet ./... && go test ./...` green
-- [ ] 6.2 Run one live board end to end against the real feed with the publisher id set, and confirm the stored rows: description free of the reseller signature, no salary, unset posted date, URL intact, country present
+- [x] 6.2 Run one live board end to end against the real feed with the publisher id set, and confirm the stored rows: description free of the reseller signature, no salary, unset posted date, URL intact, country present
 - [x] 6.3 Document the provider in `internal/sources/AGENTS.md` — the keyword-as-board shape, the env-only publisher id, and the two feed traps (slash in `user_agent`, `limit=1` with a keyword)

--- a/openspec/changes/whatjobs-cpc-ingest/tasks.md
+++ b/openspec/changes/whatjobs-cpc-ingest/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Sweep grace window
 
-- [ ] 1.1 Add the `sweepGrace` marker interface to `internal/sources/source.go`, documented in the style of `selfClosing`/`fullCatalog`: an adapter declares a window wider than the sweep default when its crawl deliberately covers only a slice of its catalogue
-- [ ] 1.2 Add `sources.SweepGraceWindows(reg map[string]Source) map[string]time.Duration` to `internal/sources/registry.go`, mirroring `SelfClosingProviders`, with a test proving a declaring adapter appears and a non-declaring one does not
-- [ ] 1.3 Make `cmd/ingest` compute the sweep cutoff from the provider's declared window, falling back to the existing 48-hour default; test that a declaring provider's recently-drifted job survives and a default provider's behaviour is unchanged
+- [x] 1.1 Add the `sweepGrace` marker interface to `internal/sources/source.go`, documented in the style of `selfClosing`/`fullCatalog`: an adapter declares a window wider than the sweep default when its crawl deliberately covers only a slice of its catalogue
+- [x] 1.2 Add `sources.SweepGraceWindows(reg map[string]Source) map[string]time.Duration` to `internal/sources/registry.go`, mirroring `SelfClosingProviders`, with a test proving a declaring adapter appears and a non-declaring one does not
+- [x] 1.3 Make `cmd/ingest` compute the sweep cutoff from the provider's declared window, falling back to the existing 48-hour default; test that a declaring provider's recently-drifted job survives and a default provider's behaviour is unchanged
 
 ## 2. Feed client
 

--- a/sources/whatjobs.yml
+++ b/sources/whatjobs.yml
@@ -1,0 +1,42 @@
+# WhatJobs — a CPC network freehire publishes for, crawled as a multi-company aggregator.
+#
+# Each entry's board is a SEARCH KEYWORD, not a tenant id: the account exposes one searchable pool
+# rather than per-employer boards, so a keyword is how a slice is selected. The shape matches
+# sources/hh.yml, whose board is a professional_role. company is a display label only — the real
+# employer comes from each posting.
+#
+# The publisher id is NOT here: it is the account credential and lives in WHATJOBS_PUBLISHER_ID.
+# Without it the provider is not registered and this file fails validation, by design.
+#
+# US inventory only. The vendor issues one publisher id per country and this account is the US one;
+# `country`, `locale` and `geo` query parameters are ignored, so another market needs its own
+# account and its own registration.
+#
+# Keywords are chosen NARROW on purpose. A crawl reads at most 40 pages (2000 postings) of a
+# keyword, so a keyword whose total exceeds that is only ever read as a bounded slice — its deeper
+# postings drift in and out of view between runs. Every keyword below was measured to sit inside the
+# budget, which keeps each crawl complete. Live totals at the time of writing are in the comments;
+# they grow, so re-measure before adding a broad term. Deliberately NOT listed (measured far beyond
+# the budget): data engineer 44k, machine learning engineer 34k, data scientist 33k,
+# software engineer 11.5k, devops engineer 10k, security engineer 8k, site reliability engineer 5k,
+# platform engineer 4.8k, qa automation engineer 3k, java developer 3k.
+- company: WhatJobs — Backend engineers
+  board: "backend engineer" # ~1.9k
+- company: WhatJobs — Frontend engineers
+  board: "frontend engineer" # ~1.2k
+- company: WhatJobs — React developers
+  board: "react developer" # ~1.2k
+- company: WhatJobs — Python developers
+  board: "python developer" # ~1.0k
+- company: WhatJobs — Kubernetes engineers
+  board: "kubernetes engineer" # ~690
+- company: WhatJobs — iOS developers
+  board: "ios developer" # ~510
+- company: WhatJobs — Android developers
+  board: "android developer" # ~445
+- company: WhatJobs — Node.js developers
+  board: "node.js developer" # ~440
+- company: WhatJobs — Rust developers
+  board: "rust developer" # ~307
+- company: WhatJobs — Go developers
+  board: "golang" # ~107


### PR DESCRIPTION
## What and why

freehire is an approved WhatJobs publisher (`publisher=7065`). This reads that CPC feed as a source. It is the first monetization-network feed that fits the ordinary crawl path: its tracked click-through URL is **not IP-bound** (three different `user_ip` values return a byte-identical URL), so unlike CareerJet — whose `jobviewtrack.com` token changes with the requester's IP and would force a live per-click resolver — the URL can simply be stored and served to anyone.

A spot check of 14 fresh tech postings found only 3 already in the catalogue, so the feed carries incremental US inventory.

**Two feed defects drive most of the design.** The postings are old (56% older than 90 days, oldest 413) and `url` points at the network's billing landing page rather than the employer's posting — so `cmd/liveness` can never verify one. That makes the unseen sweep the only defence, and its correctness the central problem.

### The sweep gets a provider-declared grace window

A crawl reads at most 40 pages of a keyword from a feed thousands of pages deep, so a posting that drifts past that depth reads as unseen. On the 48-hour default it would be closed and reopened as it drifts back, writing a phantom removal into `job_daily_stats` each cycle. `CloseUnseenJobs` already took its cutoff from the caller, so this is a window the adapter declares (14 days) rather than a second closing path. **Every existing provider is untouched** — absent from the map means the default.

### The vendor's documentation is wrong in ~8 places

All verified against the live API; written up in `internal/sources/AGENTS.md` so the next reader does not rediscover them:

- A `/` in the `user_agent` query value makes the edge redirect with the value corrupted (`Mozilla/5.0` → `Mozilla%215.0`) — which is why **every code sample in the vendor's own docs fails**. The adapter never sends it.
- **A short page is not the last page.** The feed post-filters duplicates *after* selecting a page, so `limit=50` routinely returns 44 while more pages remain; treating that as the end would truncate every keyword. The same post-filtering lets one posting appear on several pages, so repeats are collapsed per keyword.
- `limit` above 50 is silently clamped; `limit=1` **with** a keyword returns empty `data` with `per_page: 0`.
- Pagination dies past ~2000 pages regardless of the reported `total` (594k), so no keyword is exhaustible.
- `snippet` is the FULL description HTML, not the highlighted excerpt described. The documented `onmousedown` field does not exist.
- `salary` is always `"0.000000 - 0.000000"`, `job_type` always `""`, `logo` always `null` — dropped rather than stored as facts.
- `age`/`age_days` measure the record's age in the **reseller's** index, not the posting date (15 postings from unrelated companies shared `age_days: 109`), so `PostedAt` stays nil and freshness falls back to first-seen.
- An invalid publisher answers **410**, not the documented 422; `unique_id` does not deduplicate.

### Two silent failure modes caught in review

- **A whitespace-only keyword.** Config validation rejects only a strictly *empty* board, so a padded entry reached the adapter — and the feed answers a blank keyword with its entire unfiltered inventory (32k postings for `"   "`, 560k for `""`, the first a radiology technologist). Now trimmed, and blank fails the board without a request.
- **A changed URL shape**, worse for being invisible: every posting would lose its native id, the crawl would return nothing, and a provider with zero ingested jobs is skipped by the sweep — so existing rows would sit open forever with no error anywhere. A page carrying postings of which none yields an id now fails the board.

### Deliberate scope limits

- **Keywords are narrow by measurement.** Each of the 10 listed slices fits the 40-page budget, so its crawl stays complete. The ten broad terms that do not (`data engineer` 44k, `software engineer` 11.5k, `devops engineer` 10k, …) are named in the board file with their totals.
- **US only.** The publisher id is per-country by the vendor's design; `country`/`locale`/`geo` are ignored.
- The account's country is stated for the geography dictionary. Measured over 738 postings: the suffix rescues 229 (218 resolved no country at all) and regresses none. It does not fix 11 homonym cities (Dublin, Glasgow, Vienna…) which resolve to their foreign country *and* `us` — still better than the bare city, which resolves to the foreign one alone. Narrowing that 1.7% needs `internal/location` to let an explicit country arbitrate; out of scope.
- Not done: filtering staffing intermediaries (~35% of companies — the postings are real), and a click-proxy hiding the publisher id.

**Deploy:** merge with `WHATJOBS_PUBLISHER_ID` unset and nothing changes — the provider stays unregistered. Set it in the prod ingest env, run `sources/whatjobs.yml` once, inspect, then add to cron. Rollback is unsetting the variable.

**Open question for the account owner:** the publisher terms-of-use link in WhatJobs' documentation is an unfilled placeholder, so the right to cache descriptions is unconfirmed. Worth asking before the keyword list grows.

OpenSpec: `openspec/changes/whatjobs-cpc-ingest/`

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes. 21 new adapter tests + 2 for the sweep window; no DB/handler code touched.
- [x] I regenerated committed artifacts when their source changed — none changed (no SQL, migrations, or contracts).
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary — one adapter over the existing registry, plus an opt-in marker no other provider uses.

Also verified live against the real feed: `golang` → 87 postings, `rust developer` → 233, all carrying a native id and the account country, none carrying the reseller signature, `PostedAt` nil throughout.