### PR TITLE
fix(sources): the adapter test fakes are safe for the pool that calls them

### DIFF
--- a/internal/sources/apple_test.go
+++ b/internal/sources/apple_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -19,7 +20,14 @@ type appleFake struct {
 	details   map[string]string // positionId -> /api/v1/jobDetails response JSON
 	postFail  bool
 	postCalls int
-	getURLs   []string
+
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. Without it an append is
+	// simply lost and the "one detail per distinct position" count fails at random — it did
+	// in CI on 2026-07-29, on a frontend-only PR that touched no Go at all. The assertions
+	// read it after Fetch has joined the pool, which is already ordered.
+	mu      sync.Mutex
+	getURLs []string
 }
 
 var appleDetailRE = regexp.MustCompile(`jobDetails/([^?]+)`)
@@ -38,7 +46,9 @@ func (f *appleFake) PostJSON(_ context.Context, _ string, body, v any) error {
 }
 
 func (f *appleFake) GetJSON(_ context.Context, url string, v any) error {
+	f.mu.Lock()
 	f.getURLs = append(f.getURLs, url)
+	f.mu.Unlock()
 	id := ""
 	if m := appleDetailRE.FindStringSubmatch(url); m != nil {
 		id = m[1]

--- a/internal/sources/gem_test.go
+++ b/internal/sources/gem_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -19,11 +20,17 @@ type gqlHTTP struct {
 	list       string            // canned JobBoardList response
 	detail     map[string]string // extId -> canned ExternalJobPostingQuery response
 	failExtIDs map[string]bool   // extIds whose detail request errors
-	gotURL     string
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu     sync.Mutex
+	gotURL string
 }
 
 func (f *gqlHTTP) PostJSON(_ context.Context, url string, body, v any) error {
+	f.mu.Lock()
 	f.gotURL = url
+	f.mu.Unlock()
 	req, ok := body.(gemRequest)
 	if !ok {
 		return errors.New("gqlHTTP: body is not a gemRequest")

--- a/internal/sources/getro_test.go
+++ b/internal/sources/getro_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/net/html"
@@ -20,7 +21,11 @@ type getroFake struct {
 	labelErr   bool              // metadata lookup fails
 	detailHTML map[string]string // job slug -> detail page HTML
 	detailErr  map[string]bool   // job slug -> detail fetch fails
-	detailURLs []string          // detail URLs fetched, for asserting new-only hydration
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu         sync.Mutex
+	detailURLs []string // detail URLs fetched, for asserting new-only hydration
 }
 
 func (f *getroFake) PostJSON(_ context.Context, _ string, body, v any) error {
@@ -36,7 +41,9 @@ func (f *getroFake) GetJSON(_ context.Context, _ string, v any) error {
 }
 
 func (f *getroFake) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	f.mu.Lock()
 	f.detailURLs = append(f.detailURLs, url)
+	f.mu.Unlock()
 	slug := url[strings.LastIndex(url, "/")+1:]
 	if f.detailErr[slug] {
 		return nil, errors.New("detail boom")

--- a/internal/sources/hhru_test.go
+++ b/internal/sources/hhru_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/net/html"
@@ -20,7 +21,11 @@ type hhFake struct {
 	detailByID   map[string]string   // vacancy id -> ld+json description
 	detailErr    map[string]bool     // vacancy id -> GetHTML returns an error
 	searchPages  []int               // search pages requested, in order
-	detailHits   []string            // vacancy ids whose detail page was fetched, in order
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu         sync.Mutex
+	detailHits []string // vacancy ids whose detail page was fetched, in order
 }
 
 func (f *hhFake) GetHTML(_ context.Context, u string) (*html.Node, error) {
@@ -34,7 +39,9 @@ func (f *hhFake) GetHTML(_ context.Context, u string) (*html.Node, error) {
 		return html.Parse(strings.NewReader(hhSearchHTML(f.searchByPage[page])))
 	}
 	id := pu.Path[strings.LastIndex(pu.Path, "/")+1:]
+	f.mu.Lock()
 	f.detailHits = append(f.detailHits, id)
+	f.mu.Unlock()
 	if f.detailErr[id] {
 		return nil, errors.New("detail boom")
 	}

--- a/internal/sources/instaffo_test.go
+++ b/internal/sources/instaffo_test.go
@@ -132,8 +132,15 @@ func TestInstaffoDropsPostingsOlderThanMaxAge(t *testing.T) {
 	stale := "https://jobs.instaffo.com/de/job/stale-bbbbbbbbbbbb"
 	undated := "https://jobs.instaffo.com/de/job/undated-cccccccccccc"
 
+	// The fresh fixture sits a week inside the window, not an hour. `datePosted` is
+	// date-only, so formatting truncates it back to midnight and the posting reads as up to
+	// a day older than asked — and in a negative-offset timezone `Format` picks the local
+	// date while `Parse` reads it as UTC, adding the offset on top. At maxAge-24h that put
+	// it 16 minutes past a 365-day limit here (UTC-03:00, late evening) while still passing
+	// in CI's UTC by a few minutes. The test is about either side of the window, not its
+	// exact edge, so it takes a margin wider than any timezone.
 	fake := (&routedHTTP{}).
-		route("/de/job/fresh-aaaaaaaaaaaa", postingAged(instaffoMaxAge-24*time.Hour)).
+		route("/de/job/fresh-aaaaaaaaaaaa", postingAged(instaffoMaxAge-7*24*time.Hour)).
 		route("/de/job/stale-bbbbbbbbbbbb", postingAged(instaffoMaxAge+24*time.Hour)).
 		route("/de/job/undated-cccccccccccc", `<html><head><script type="application/ld+json">
 {"@context":"https://schema.org","@type":"JobPosting","title":"Entwickler",

--- a/internal/sources/jobdanmark_test.go
+++ b/internal/sources/jobdanmark_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/net/html"
@@ -22,6 +23,10 @@ type jobdanmarkHTTP struct {
 	failPage   map[int]bool      // a specific page's POST fails
 	failDetail map[string]bool   // a specific slug's detail GET fails
 	gotPages   []int
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu         sync.Mutex
 	gotDetails []string
 }
 
@@ -45,7 +50,9 @@ func (f *jobdanmarkHTTP) PostJSON(_ context.Context, url string, _ any, v any) e
 
 func (f *jobdanmarkHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) {
 	slug := url[strings.LastIndex(url, "/")+1:]
+	f.mu.Lock()
 	f.gotDetails = append(f.gotDetails, slug)
+	f.mu.Unlock()
 	if f.failDetail[slug] {
 		return nil, errors.New("jobdanmarkHTTP: detail boom")
 	}

--- a/internal/sources/mts_test.go
+++ b/internal/sources/mts_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/net/html"
@@ -21,7 +22,11 @@ type fakeMTS struct {
 	detail     map[string]string // id -> canned detail payload
 	failIDs    map[string]bool   // ids whose detail GET errors
 
-	listKey   string // x-api-key seen on the list POST
+	listKey string // x-api-key seen on the list POST
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu        sync.Mutex
 	detailKey string // x-api-key seen on a detail GET
 }
 
@@ -30,7 +35,9 @@ func (f *fakeMTS) GetHTML(_ context.Context, _ string) (*html.Node, error) {
 }
 
 func (f *fakeMTS) GetJSONWithHeaders(_ context.Context, url string, headers map[string]string, v any) error {
+	f.mu.Lock()
 	f.detailKey = headers["x-api-key"]
+	f.mu.Unlock()
 	id := url[strings.LastIndex(url, "/")+1:]
 	if f.failIDs[id] {
 		return errors.New("fakeMTS: detail boom for " + id)

--- a/internal/sources/neogov_test.go
+++ b/internal/sources/neogov_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/net/html"
@@ -122,9 +123,13 @@ func TestFirstByID(t *testing.T) {
 // detail URL returns its mapped body (or an error), and records whether the XHR header was
 // sent so the test can assert the detail fetch is a plain GET.
 type neogovFakeHTTP struct {
-	listing    string
-	details    map[string]string
-	detailErr  map[string]bool
+	listing   string
+	details   map[string]string
+	detailErr map[string]bool
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu         sync.Mutex
 	detailXHR  map[string]bool // id -> whether X-Requested-With was sent on its detail call
 	listingXHR bool
 }
@@ -142,10 +147,12 @@ func (f *neogovFakeHTTP) GetTextWithHeaders(_ context.Context, url string, heade
 	if m != nil {
 		id = m[1]
 	}
+	f.mu.Lock()
 	if f.detailXHR == nil {
 		f.detailXHR = map[string]bool{}
 	}
 	f.detailXHR[id] = xhr
+	f.mu.Unlock()
 	if f.detailErr[id] {
 		return "", errors.New("neogovFakeHTTP: detail boom")
 	}

--- a/internal/sources/nofluffjobs_test.go
+++ b/internal/sources/nofluffjobs_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -15,6 +16,10 @@ type nofluffjobsFake struct {
 	listing     string
 	detailByURL map[string]string
 	detailErr   map[string]bool
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu          sync.Mutex
 	detailSlugs []string
 }
 
@@ -24,7 +29,9 @@ func (f *nofluffjobsFake) GetStream(_ context.Context, _ string, _ string, fn fu
 
 func (f *nofluffjobsFake) GetJSON(_ context.Context, url string, v any) error {
 	slug := url[strings.LastIndex(url, "/")+1:]
+	f.mu.Lock()
 	f.detailSlugs = append(f.detailSlugs, slug)
+	f.mu.Unlock()
 	if f.detailErr[slug] {
 		return errors.New("detail boom")
 	}

--- a/internal/sources/paycom_test.go
+++ b/internal/sources/paycom_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -13,9 +14,13 @@ import (
 // and GetJSONWithHeaders (the authed company-name + job detail). It serves a canned body per
 // URL substring and records the Authorization header it last saw.
 type paycomFake struct {
-	pages  map[string]string // GetText: url-substr -> html
-	posts  map[string]string // PostJSON: url-substr -> json
-	gets   map[string]string // GetJSON: url-substr -> json
+	pages map[string]string // GetText: url-substr -> html
+	posts map[string]string // PostJSON: url-substr -> json
+	gets  map[string]string // GetJSON: url-substr -> json
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu     sync.Mutex
 	lastAu string
 }
 
@@ -43,7 +48,9 @@ func (f *paycomFake) match(m map[string]string, url string) (string, bool) {
 }
 
 func (f *paycomFake) GetJSONWithHeaders(_ context.Context, url string, h map[string]string, v any) error {
+	f.mu.Lock()
 	f.lastAu = h["Authorization"]
+	f.mu.Unlock()
 	body, ok := f.match(f.gets, url)
 	if !ok {
 		return fmt.Errorf("paycomFake: no GET for %s", url)
@@ -52,7 +59,9 @@ func (f *paycomFake) GetJSONWithHeaders(_ context.Context, url string, h map[str
 }
 
 func (f *paycomFake) PostJSONWithHeaders(_ context.Context, url string, h map[string]string, _, v any) error {
+	f.mu.Lock()
 	f.lastAu = h["Authorization"]
+	f.mu.Unlock()
 	body, ok := f.match(f.posts, url)
 	if !ok {
 		return fmt.Errorf("paycomFake: no POST for %s", url)

--- a/internal/sources/vagas_test.go
+++ b/internal/sources/vagas_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/net/html"
@@ -15,11 +16,17 @@ import (
 type vagasHTTP struct {
 	pages    map[string]string
 	failURLs map[string]bool
-	got      []string
+	// The adapter fans its detail fetches out across a worker pool, so this recorder is
+	// written from several goroutines at once and needs the lock. The assertions read it
+	// after Fetch has joined the pool, which is already ordered.
+	mu  sync.Mutex
+	got []string
 }
 
 func (f *vagasHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	f.mu.Lock()
 	f.got = append(f.got, url)
+	f.mu.Unlock()
 	if f.failURLs[url] {
 		return nil, errors.New("vagasHTTP: boom")
 	}


### PR DESCRIPTION
## What and why

`TestAppleFetchPaginatesDedupsAndMaps` failed CI on #1267 — a frontend-only PR that touched no Go at all — with `detail fetched 1 times, want 2`. The Apple adapter fans its detail fetches out across a worker pool, and the fake recorded each call with a bare `append`: two goroutines raced, one append was lost, the count assertion failed. A rerun of the same commit passed, which is exactly what a lost append looks like from the outside.

Apple was not alone. `go test -race ./internal/sources/` reports **13 data races across ten fakes** — apple, gem, getro, hh, jobdanmark, mts, neogov, nofluffjobs, paycom, vagas — each a recorder written from the pool without a lock, each a merge blocked at random on whichever PR happens to be unlucky. They all take the same fix: a mutex beside the recorder, held across the write. The assertions read after `Fetch` has joined the pool, so the reads need nothing.

`TestInstaffoDropsPostingsOlderThanMaxAge` is a different fragility in the same package, not a race. Its "fresh" fixture sat one hour inside a 365-day window, but `datePosted` is date-only: formatting truncates it to midnight, and in a negative-offset timezone `Format` picks the local date while `Parse` reads it as UTC, adding the offset on top. That put the posting 16 minutes past the limit locally (UTC-03:00, evening) while still passing in CI's UTC by minutes — so `go test ./...` fails for anyone west of UTC in the evening. The test is about either side of the window, not its exact edge, so the fixture now takes a margin wider than any timezone.

Test-only change: no adapter, no production code.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes — plus `go test -race -count=5 ./internal/sources/` clean, and the suite under both `TZ=UTC` and the local zone.
- [x] I regenerated committed artifacts when their source changed. — none touched
- [x] For `design-system/` changes: not touched
- [x] For `web/` changes: not touched
- [x] This stays within freehire's core/extension boundary — it does not bloat the core.