### PR TITLE
fix(sources): make whatjobs postings corroborate their keyword

### DIFF
--- a/internal/sources/instaffo_test.go
+++ b/internal/sources/instaffo_test.go
@@ -120,11 +120,16 @@ func TestInstaffoFetchResolvesJobSitemapThenMaps(t *testing.T) {
 // Instaffo never retires a posting from its sitemap, so the unseen sweep can never close
 // one — age is the only staleness signal there is, and it is applied on the way in.
 func TestInstaffoDropsPostingsOlderThanMaxAge(t *testing.T) {
+	// The date is stamped in UTC because that is how the adapter reads a bare "2006-01-02"
+	// datePosted back. Formatting it in the local zone instead makes the test fail west of
+	// Greenwich whenever the local date still lags UTC's: the local calendar day is one earlier,
+	// the parsed midnight lands a day further back, and the "fresh" posting ages past the window.
+	// CI runs in UTC, so this only ever broke on developer machines.
 	postingAged := func(d time.Duration) string {
 		return `<html><head><script type="application/ld+json">
 {"@context":"https://schema.org","@type":"JobPosting","title":"Entwickler",
 "hiringOrganization":{"@type":"Organization","name":"Acme GmbH"},
-"datePosted":"` + time.Now().Add(-d).Format("2006-01-02") + `"}
+"datePosted":"` + time.Now().UTC().Add(-d).Format("2006-01-02") + `"}
 </script></head><body></body></html>`
 	}
 

--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -114,6 +114,19 @@ func limitedTrudvsemGetter(c JSONGetter) JSONGetter {
 	return concurrencyLimitedJSONGetter{inner: c, sem: make(chan struct{}, trudvsemMaxInFlight)}
 }
 
+// The WhatJobs feed serves sequential requests happily — a dozen back-to-back from one IP never
+// tripped anything — but the pipeline crawls board files in parallel, and on the provider's first
+// production run 8 of its 10 keyword boards failed with HTTP 429. So the trigger is simultaneity, not
+// rate. Two in flight is gentle enough to clear it, and cheap now that a keyword crawl ends when its
+// relevance collapses (typically 2 pages, not 40) rather than walking the page budget.
+const whatjobsMaxInFlight = 2
+
+// limitedWhatJobsGetter wraps a getter with a fresh semaphore shared across one registry build, so
+// every keyword board in a run competes for the same small number of in-flight requests.
+func limitedWhatJobsGetter(c JSONGetter) JSONGetter {
+	return concurrencyLimitedJSONGetter{inner: c, sem: make(chan struct{}, whatjobsMaxInFlight)}
+}
+
 // hh.ru egresses through the single proxy IP (its detail pages 403 the direct datacenter IP), and
 // its per-vacancy detail fan-out is large — thousands of ~1 MB pages across the seeded roles. Fired
 // unpaced at defaultDetailWorkers concurrency, that burst 429s the proxy IP and ~2/3 of details

--- a/internal/sources/pacer_test.go
+++ b/internal/sources/pacer_test.go
@@ -92,6 +92,22 @@ func TestConcurrencyLimitedJSONGetter_AcquiresThenDelegates(t *testing.T) {
 	}
 }
 
+// The WhatJobs feed rate-limited 8 of 10 boards on the first production run: sequential requests are
+// served fine, so the trigger is the pipeline crawling boards in parallel. One semaphore shared by
+// every board of the run is what bounds it.
+func TestLimitedWhatJobsGetter_SharesOneGentleCap(t *testing.T) {
+	g, ok := limitedWhatJobsGetter(&recordingJSONGetter{}).(concurrencyLimitedJSONGetter)
+	if !ok {
+		t.Fatal("limitedWhatJobsGetter should wrap the getter in a concurrency limiter")
+	}
+	if got := cap(g.sem); got != whatjobsMaxInFlight {
+		t.Errorf("cap = %d, want whatjobsMaxInFlight (%d)", got, whatjobsMaxInFlight)
+	}
+	if whatjobsMaxInFlight < 1 || whatjobsMaxInFlight > 4 {
+		t.Errorf("whatjobsMaxInFlight = %d, want a gentle few", whatjobsMaxInFlight)
+	}
+}
+
 func TestConcurrencyLimitedJSONGetter_CancelledContextShortCircuits(t *testing.T) {
 	inner := &recordingJSONGetter{}
 	sem := make(chan struct{}, 1)

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -276,8 +276,15 @@ func All(c HTTPClient) map[string]Source {
 	// than an API key — but it is registered the same way: only when configured, so an environment
 	// without it does not list a provider whose every board would 410. The id is per-country; this
 	// account serves US inventory.
+	// Its requests go through a shared in-flight cap: the feed rate-limits the pipeline's parallel
+	// board crawl (8 of 10 boards 429'd on the first prod run) though it serves sequential requests
+	// fine. On the transport-free listing path (c == nil) there is nothing to wrap.
 	if id := os.Getenv("WHATJOBS_PUBLISHER_ID"); id != "" {
-		registry["whatjobs"] = NewWhatJobs(c, id)
+		if c == nil {
+			registry["whatjobs"] = NewWhatJobs(nil, id)
+		} else {
+			registry["whatjobs"] = NewWhatJobs(limitedWhatJobsGetter(c), id)
+		}
 	}
 	// taleo needs a cookie-persisting client (its searchjobs POST requires the session cookie
 	// a careersection GET sets), so it cannot use the shared jar-less client. Build a dedicated

--- a/internal/sources/whatjobs.go
+++ b/internal/sources/whatjobs.go
@@ -39,6 +39,12 @@ const (
 	// and kept narrow in the board file instead. When the budget is what ended a crawl the adapter
 	// says so in the log: a bounded slice must never read as full coverage.
 	whatjobsMaxPages = 40
+	// whatjobsMinCorroboratedPct is the share of a page's postings that must name the keyword's terms
+	// for the crawl to continue. The feed's keyword RANKS rather than filters and pads a thin result
+	// set with unrelated inventory: measured on "rust developer", page 1 corroborated 47/47 and page 2
+	// only 4/26. Any threshold inside that gap behaves the same, so this sits plainly in the middle
+	// rather than being tuned to one sample.
+	whatjobsMinCorroboratedPct = 50
 	// whatjobsCrawlIP is the mandatory user_ip. A crawl is not a user viewing a page, so sending
 	// a real visitor address would fabricate an impression: the feed ignores tracking for an
 	// address it does not accept as a viewer but still serves the results, which is exactly the
@@ -105,8 +111,10 @@ func (w whatjobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	if keyword == "" {
 		return nil, fmt.Errorf("whatjobs: company %q has a blank keyword board", e.Company)
 	}
+	terms := whatjobsCorroborationTerms(keyword)
 	var jobs []Job
 	seen := make(map[string]bool)
+	stopped := ""
 	page := 1
 	for ; page <= whatjobsMaxPages; page++ {
 		var resp struct {
@@ -116,15 +124,20 @@ func (w whatjobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			return nil, fmt.Errorf("whatjobs: keyword %q page %d: %w", keyword, page, err)
 		}
 		if len(resp.Data) == 0 {
+			stopped = "feed ran dry"
 			break
 		}
-		var usable int
+		var usable, corroborated int
 		for _, p := range resp.Data {
 			job, ok := p.toJob()
 			if !ok {
 				continue
 			}
 			usable++
+			if !p.corroborates(terms) {
+				continue
+			}
+			corroborated++
 			if seen[job.ExternalID] {
 				continue
 			}
@@ -139,12 +152,58 @@ func (w whatjobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			return nil, fmt.Errorf("whatjobs: keyword %q page %d: %d postings, none carrying a %s id — tracked URL shape changed?",
 				keyword, page, len(resp.Data), whatjobsTrackedID)
 		}
+		// Relevance does not taper, it falls off a cliff — measured 100% on page 1 and 15% on page 2.
+		// A corroborated share under the minimum means the feed has started padding the result set, so
+		// every further page is mostly waste. Stopping here is what keeps the request volume (and the
+		// rate limiting it caused) down; the page's corroborated postings are real and are kept.
+		if len(terms) > 0 && corroborated*100 < usable*whatjobsMinCorroboratedPct {
+			stopped = fmt.Sprintf("relevance collapsed to %d/%d on page %d", corroborated, usable, page)
+			break
+		}
 	}
 	if page > whatjobsMaxPages {
-		log.Printf("whatjobs: keyword %q hit the %d-page budget with %d postings — slice is bounded, not exhausted",
-			keyword, whatjobsMaxPages, len(jobs))
+		stopped = fmt.Sprintf("hit the %d-page budget", whatjobsMaxPages)
 	}
+	log.Printf("whatjobs: keyword %q returned %d corroborated postings (%s)", keyword, len(jobs), stopped)
 	return jobs, nil
+}
+
+// whatjobsGenericRoleWords are the keyword words that corroborate nothing: they appear in nearly
+// every technical posting, so requiring them would wave through the unrelated inventory the feed pads
+// a thin keyword with, exactly as readily as a real match.
+var whatjobsGenericRoleWords = map[string]bool{
+	"developer": true, "engineer": true, "programmer": true,
+	"dev": true, "specialist": true, "architect": true,
+}
+
+// whatjobsCorroborationTerms reduces a keyword to the terms a posting must actually name to prove it
+// belongs to that keyword. Returns nil for a keyword that is entirely generic — there is nothing to
+// corroborate on, so such a board filters nothing rather than dropping everything.
+func whatjobsCorroborationTerms(keyword string) []string {
+	var out []string
+	for _, w := range strings.Fields(strings.ToLower(keyword)) {
+		if !whatjobsGenericRoleWords[w] {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// corroborates reports whether a posting names every one of the keyword's terms. The match is a
+// case-insensitive substring rather than a word-boundary match: the feed writes "iOS" and "Node.JS",
+// which tokenization would fail to line up with "ios" and "node.js". A substring can false-positive
+// ("rust" inside "trust"), which is the cheap direction — the alternative drops real matches.
+func (p whatjobsPosting) corroborates(terms []string) bool {
+	if len(terms) == 0 {
+		return true
+	}
+	hay := strings.ToLower(p.Title + " " + p.Snippet)
+	for _, t := range terms {
+		if !strings.Contains(hay, t) {
+			return false
+		}
+	}
+	return true
 }
 
 // whatjobsTrackedID matches the native posting id in a tracked click-through URL

--- a/internal/sources/whatjobs_test.go
+++ b/internal/sources/whatjobs_test.go
@@ -337,7 +337,9 @@ func TestWhatJobsUnrecognizedURLShapeIsAnError(t *testing.T) {
 func TestWhatJobsMixedPageIsNotAnError(t *testing.T) {
 	fake := (&recordingJSON{}).route("page=1", whatjobsPage).route("page=2", `{"data":[]}`)
 
-	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "golang"})
+	// The keyword must corroborate the fixture's posting, else the drop under test is ambiguous with
+	// a corroboration drop.
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "backend engineer"})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -384,6 +386,156 @@ func TestWhatJobsRejectedPublisherIsABoardFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "devops") {
 		t.Errorf("error should name the keyword that failed: %v", err)
+	}
+}
+
+// The feed's keyword RANKS rather than filters, so a posting has to prove it belongs to the keyword
+// it was found under. Generic role words are stripped first: they appear in nearly every technical
+// posting and would corroborate the radiology padding as readily as a real match.
+func TestWhatJobsCorroborationTerms(t *testing.T) {
+	cases := []struct {
+		keyword string
+		want    []string
+	}{
+		{"rust developer", []string{"rust"}},
+		{"kubernetes engineer", []string{"kubernetes"}},
+		{"golang", []string{"golang"}},
+		{"node.js developer", []string{"node.js"}},
+		{"machine learning engineer", []string{"machine", "learning"}},
+		// Wholly generic: nothing distinguishes it, so there is nothing to corroborate on.
+		{"developer", nil},
+		{"software engineer", []string{"software"}},
+	}
+	for _, tc := range cases {
+		got := whatjobsCorroborationTerms(tc.keyword)
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("whatjobsCorroborationTerms(%q) = %v, want %v", tc.keyword, got, tc.want)
+		}
+	}
+}
+
+// Padding is what the first production run poured into the catalogue: one hospital group's radiology
+// listings, returned under a developer keyword and waved through by the non-tech gate.
+func TestWhatJobsDropsPostingsThatDoNotCorroborate(t *testing.T) {
+	page := `{"data":[
+	 {"title":"Senior Rust Engineer","company":"Acme","location":"Austin","snippet":"<p>Systems work.</p>",
+	  "url":"https://www.whatjobs.com/pub_api__cpl__11__7065"},
+	 {"title":"Senior CT Technologist - PRN","company":"Mercy","location":"Ardmore","snippet":"<p>Imaging.</p>",
+	  "url":"https://www.whatjobs.com/pub_api__cpl__12__7065"},
+	 {"title":"Backend Engineer","company":"Acme","location":"Austin","snippet":"<p>We use Rust heavily.</p>",
+	  "url":"https://www.whatjobs.com/pub_api__cpl__13__7065"}
+	]}`
+	fake := (&recordingJSON{}).route("page=1", page).route("page=2", `{"data":[]}`)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "rust developer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	var got []string
+	for _, j := range jobs {
+		got = append(got, j.ExternalID)
+	}
+	// 11 names rust in the title, 13 in the description; 12 never does.
+	if !slices.Equal(got, []string{"11", "13"}) {
+		t.Errorf("kept %v, want [11 13] — the radiology posting must be dropped", got)
+	}
+}
+
+// A term has to survive the feed's casing and punctuation: iOS is written "iOS", not "ios".
+func TestWhatJobsCorroboratesCaseInsensitively(t *testing.T) {
+	page := `{"data":[
+	 {"title":"iOS Lead Developer","company":"Acme","location":"Plano","snippet":"<p>Swift.</p>",
+	  "url":"https://www.whatjobs.com/pub_api__cpl__21__7065"},
+	 {"title":"Node.JS Engineer","company":"Acme","location":"Plano","snippet":"<p>Server side.</p>",
+	  "url":"https://www.whatjobs.com/pub_api__cpl__22__7065"}
+	]}`
+	for _, tc := range []struct{ keyword, wantID string }{
+		{"ios developer", "21"},
+		{"node.js developer", "22"},
+	} {
+		fake := (&recordingJSON{}).route("page=1", page).route("page=2", `{"data":[]}`)
+		jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: tc.keyword})
+		if err != nil {
+			t.Fatalf("Fetch(%q): %v", tc.keyword, err)
+		}
+		var ids []string
+		for _, j := range jobs {
+			ids = append(ids, j.ExternalID)
+		}
+		if !slices.Contains(ids, tc.wantID) {
+			t.Errorf("keyword %q kept %v, want it to include %q", tc.keyword, ids, tc.wantID)
+		}
+	}
+}
+
+// A keyword with nothing distinguishing left cannot corroborate anything, so it must not filter
+// everything away.
+func TestWhatJobsGenericKeywordFiltersNothing(t *testing.T) {
+	fake := (&recordingJSON{}).route("page=1", whatjobsRows(1, 5)).route("page=2", `{"data":[]}`)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "developer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 5 {
+		t.Errorf("got %d jobs, want all 5 — a generic keyword has nothing to corroborate on", len(jobs))
+	}
+}
+
+// Relevance does not taper, it collapses: 100% on page 1, 15% on page 2. Below the minimum share the
+// feed has started padding, so every further page is mostly waste — and it was that wasted volume
+// that rate-limited the first production run.
+func TestWhatJobsStopsWhenAPageStopsCorroborating(t *testing.T) {
+	// Page 1: 4 of 4 name rust. Page 2: 1 of 4. Page 3 would be more padding.
+	page1 := `{"data":[
+	 {"title":"Rust Engineer A","company":"A","location":"X","snippet":"<p>rust</p>","url":"https://www.whatjobs.com/pub_api__cpl__1__7065"},
+	 {"title":"Rust Engineer B","company":"A","location":"X","snippet":"<p>rust</p>","url":"https://www.whatjobs.com/pub_api__cpl__2__7065"},
+	 {"title":"Rust Engineer C","company":"A","location":"X","snippet":"<p>rust</p>","url":"https://www.whatjobs.com/pub_api__cpl__3__7065"},
+	 {"title":"Rust Engineer D","company":"A","location":"X","snippet":"<p>rust</p>","url":"https://www.whatjobs.com/pub_api__cpl__4__7065"}
+	]}`
+	page2 := `{"data":[
+	 {"title":"Rust Engineer E","company":"A","location":"X","snippet":"<p>rust</p>","url":"https://www.whatjobs.com/pub_api__cpl__5__7065"},
+	 {"title":"CT Technologist","company":"M","location":"X","snippet":"<p>imaging</p>","url":"https://www.whatjobs.com/pub_api__cpl__6__7065"},
+	 {"title":"Mammography Technologist","company":"M","location":"X","snippet":"<p>imaging</p>","url":"https://www.whatjobs.com/pub_api__cpl__7__7065"},
+	 {"title":"Nuclear Medicine Technologist","company":"M","location":"X","snippet":"<p>imaging</p>","url":"https://www.whatjobs.com/pub_api__cpl__8__7065"}
+	]}`
+	fake := (&recordingJSON{}).route("page=1", page1).route("page=2", page2).route("page=3", whatjobsRows(90, 50))
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "rust developer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if len(fake.urls) != 2 {
+		t.Errorf("requested %d pages, want 2 — the collapsed page must end the crawl", len(fake.urls))
+	}
+	// The corroborated posting on the collapsed page is real and is kept.
+	if len(jobs) != 5 {
+		t.Errorf("got %d jobs, want 5 (4 from page 1 plus the one real posting on page 2)", len(jobs))
+	}
+}
+
+// A keyword the feed serves honestly must still be crawled to the end.
+func TestWhatJobsFullyCorroboratingKeywordCrawlsOn(t *testing.T) {
+	full := `{"data":[
+	 {"title":"Rust Engineer","company":"A","location":"X","snippet":"<p>rust</p>","url":"https://www.whatjobs.com/pub_api__cpl__%d__7065"}
+	]}`
+	fake := (&recordingJSON{}).
+		route("page=1", fmt.Sprintf(full, 1)).
+		route("page=2", fmt.Sprintf(full, 2)).
+		route("page=3", fmt.Sprintf(full, 3)).
+		route("page=4", `{"data":[]}`)
+
+	jobs, err := NewWhatJobs(fake, "7065").Fetch(context.Background(), CompanyEntry{Board: "rust developer"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(fake.urls) != 4 {
+		t.Errorf("requested %d pages, want 4 (three full, then the empty one)", len(fake.urls))
+	}
+	if len(jobs) != 3 {
+		t.Errorf("got %d jobs, want 3", len(jobs))
 	}
 }
 

--- a/openspec/changes/whatjobs-keyword-corroboration/.openspec.yaml
+++ b/openspec/changes/whatjobs-keyword-corroboration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/whatjobs-keyword-corroboration/design.md
+++ b/openspec/changes/whatjobs-keyword-corroboration/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`whatjobs` shipped in #1268 and failed its first production run. Rolled back by closing its 282 rows
+and deleting them from the Meilisearch index (they were searchable — incremental indexing pushes at
+ingest time, so closing rows in Postgres alone leaves them visible).
+
+The root cause is that the feed's `keyword` ranks rather than filters. Measured on `rust developer`:
+page 1 is 100% relevant, page 2 is 15%, page 5 is 0%. `total` reports 307 for that keyword; the real
+inventory is roughly 50. Every keyword volume in the board file was therefore chosen against a
+fictitious number.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep only postings that demonstrably belong to the keyword they were found under.
+- Stop paging a keyword once the feed starts padding, which also cuts the request volume that caused
+  HTTP 429.
+- Bound parallel request concurrency for this provider.
+
+**Non-Goals:**
+
+- Salvaging the padded postings by other means. They are unrelated inventory, not mislabelled roles.
+- Raising yield. Post-fix output is honestly small (~50–90 per keyword); that is the inventory.
+- A generic relevance-corroboration layer for other aggregators. One provider needs it; the seam is
+  noted, not built.
+
+## Decisions
+
+### Corroboration on the keyword's non-generic terms
+
+`developer`, `engineer`, `programmer`, `dev`, `specialist`, `architect` are dropped from the keyword
+before matching, because they appear in nearly every technical posting and would corroborate the
+radiology padding just as readily as a real match. What remains carries the meaning. Verified against
+live first pages — `backend engineer` 45/45, `ios developer` 49/49, `kubernetes engineer` 45/45,
+`rust developer` 47/47 kept — so the rule costs nothing where the feed is honest.
+
+Matching is a case-insensitive substring over title + description. Not word-boundary regex: `ios`
+must match `iOS`, and `node.js` must match `Node.JS`. A substring risks a false positive (`rust` in
+"trust"), which is the cheap direction of error — the term still has to appear, and the alternative
+(dropping a real match on tokenization) is worse.
+
+*Alternative considered:* an explicit `required_term` per board-file entry. Rejected as redundant —
+it would restate the keyword in almost every row, and a row where it genuinely differs is a sign the
+keyword itself is wrong.
+
+### Relevance collapse ends pagination
+
+A page whose corroborated share is below **50%** ends the keyword. The measured cliff is 100% → 15%,
+so any threshold in that gap behaves identically; 50% is chosen for being obviously mid-gap rather
+than tuned to one sample. Postings already corroborated on that page are kept — they are real, the
+page merely marks the end of the relevant run.
+
+This subsumes the rate-limit problem: `rust developer` goes from 40 pages to 2. The 40-page budget
+stays as a backstop for a keyword that never collapses.
+
+*Alternative considered:* keep paging and filter. Rejected — it spends 38 requests per keyword to
+discard almost everything, which is exactly what produced the 429s.
+
+### In-flight cap over request pacing
+
+`concurrencyLimitedJSONGetter` already exists for `trudvsem` ("its gov API degrades under the
+pipeline's board concurrency"). Reused with a cap of **2**. A rate pacer for JSON does not exist yet
+and is not built here: sequential requests were never rate-limited in testing, so the trigger is
+concurrency, and with the crawl now 2 pages deep per keyword the total volume is an order of
+magnitude smaller regardless.
+
+## Risks / Trade-offs
+
+- **A real posting that never names the term is dropped** — a Rust role advertised only as
+  "Systems Engineer (memory-safe languages)". → Accepted deliberately: the inverse error puts
+  radiology listings in a developer's search results, which is far more damaging to trust than a
+  missed posting the catalogue never had.
+- **The 50% threshold is calibrated on one keyword's cliff.** → The cliff is steep enough that the
+  exact value is not load-bearing; the log line reports why a crawl stopped, so a misfire is visible
+  in one run rather than silent.
+- **Yield may not justify the CPC integration at all.** → That is now a business call with honest
+  numbers behind it, which is the point of measuring: pre-fix estimates were built on `total`.
+
+## Migration Plan
+
+1. Merge, deploy, then run `sources/whatjobs.yml` by hand and read the corroborated counts.
+2. Re-annotate the board file's keyword volumes from that run.
+3. Only then consider a cron entry.
+
+`WHATJOBS_PUBLISHER_ID` is already set on prod and no cron references the provider, so nothing runs
+until triggered. Rollback is the recipe already exercised: close the rows, then delete them from the
+`jobs` index by filter.

--- a/openspec/changes/whatjobs-keyword-corroboration/design.md
+++ b/openspec/changes/whatjobs-keyword-corroboration/design.md
@@ -74,8 +74,15 @@ magnitude smaller regardless.
 - **The 50% threshold is calibrated on one keyword's cliff.** → The cliff is steep enough that the
   exact value is not load-bearing; the log line reports why a crawl stopped, so a misfire is visible
   in one run rather than silent.
-- **Yield may not justify the CPC integration at all.** → That is now a business call with honest
-  numbers behind it, which is the point of measuring: pre-fix estimates were built on `total`.
+- **Yield.** Measured after the fix: ~3200 corroborated postings across the ten keywords, none
+  failing corroboration and no rate limiting. That is well above the ~50–90 per keyword this design
+  first predicted — the collapse point varies from page 2 (`rust developer`) to page 32
+  (`backend engineer`), so a broad keyword stays honest much longer than the `rust developer` sample
+  suggested. The prediction was wrong in the safe direction, but it was still a prediction from one
+  sample: the corroborated counts now live in the board file, and they are the numbers to reason from.
+- **`backend engineer` collapses at page 32, close to the 40-page budget.** → If it grows past the
+  budget the crawl becomes bounded again and the log says so. Worth splitting into narrower keywords
+  at that point rather than raising the budget, since deeper pages are where padding lives.
 
 ## Migration Plan
 

--- a/openspec/changes/whatjobs-keyword-corroboration/proposal.md
+++ b/openspec/changes/whatjobs-keyword-corroboration/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+The first production run of the `whatjobs` source (added in #1268) failed and had to be rolled back.
+Two defects, both invisible to the unit tests and to the pre-flight measurements:
+
+**The feed's `keyword` is a relevance ranking, not a filter.** Board `rust developer` returned 193
+postings of which 49 mentioned rust; the rest were one hospital group's *CT Technologist* and
+*Nuclear Medicine Technologist* listings. Measured by page depth, relevance collapses immediately
+after the first page:
+
+| page | rows | mention `rust` | relevant |
+|---|---|---|---|
+| 1 | 47 | 47 | 100% |
+| 2 | 26 | 4 | 15% |
+| 3 | 30 | 4 | 13% |
+| 5 | 43 | 0 | 0% |
+
+So `total` (307 for that keyword) measures the padded result set, not the inventory — which means the
+board file's keywords were selected against a fictitious number. The non-tech gate does not catch the
+padding either: "Technologist" reads as technical, and it rejected only 16% of that board.
+
+**HTTP 429.** Twelve sequential requests from one IP are fine, but the pipeline crawls boards in
+parallel and 8 of 10 boards died on rate limiting.
+
+Both have the same cure. Stopping a keyword once its results stop corroborating cuts the crawl from
+40 pages to 2, which removes the junk and the request volume together.
+
+## What Changes
+
+- A posting is kept only when the keyword's **corroborating terms** appear in its title or
+  description. Generic role words (`developer`, `engineer`, …) are dropped from the keyword first —
+  they do not distinguish one posting from another — leaving the terms that carry the meaning:
+  `rust developer` → `rust`, `kubernetes engineer` → `kubernetes`.
+- **Pagination stops when a page stops corroborating.** Below a minimum share of corroborated
+  postings the keyword is treated as exhausted, so the 40-page budget becomes a backstop rather than
+  the usual stopping condition.
+- The adapter's requests run under a **shared in-flight cap**, following `limitedTrudvsemGetter`, so
+  parallel boards no longer trip the feed's rate limit.
+- `sources/whatjobs.yml` keywords are re-annotated with corroborated volume instead of the feed's
+  reported `total`, which overstates every slice.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `whatjobs-source`: postings must corroborate the keyword; pagination ends on collapsed relevance;
+  requests are bounded by an in-flight cap.
+
+## Impact
+
+- **Touched:** `internal/sources/whatjobs.go` (+ test), `internal/sources/pacer.go` (in-flight cap for
+  the provider), `internal/sources/registry.go` (wire the cap), `sources/whatjobs.yml` (comments).
+- **Behavioural:** the source yields far fewer postings than the pre-flight numbers suggested —
+  roughly 50–90 per keyword rather than the hundreds `total` implied. That is the real inventory.
+- **No schema, API, or web changes.**

--- a/openspec/changes/whatjobs-keyword-corroboration/proposal.md
+++ b/openspec/changes/whatjobs-keyword-corroboration/proposal.md
@@ -50,6 +50,11 @@ Both have the same cure. Stopping a keyword once its results stop corroborating 
 
 - **Touched:** `internal/sources/whatjobs.go` (+ test), `internal/sources/pacer.go` (in-flight cap for
   the provider), `internal/sources/registry.go` (wire the cap), `sources/whatjobs.yml` (comments).
-- **Behavioural:** the source yields far fewer postings than the pre-flight numbers suggested —
-  roughly 50–90 per keyword rather than the hundreds `total` implied. That is the real inventory.
+- **Behavioural:** measured live across all ten keywords after the fix — **~3200 corroborated
+  postings, none failing corroboration, and no rate limiting**. Per keyword the honest inventory
+  varies far more than expected: `backend engineer` 1270 (collapses at page 32), `python developer`
+  668 (page 17), `kubernetes engineer` 350, `ios developer` 212, `android developer` 171,
+  `frontend engineer` 139, `node.js developer` 136, `react developer` 124, `golang` 86 (the feed runs
+  dry with no padding at all), `rust developer` 51 (page 2). So the padding is not uniform: a broad
+  keyword stays honest for dozens of pages while a thin one collapses immediately.
 - **No schema, API, or web changes.**

--- a/openspec/changes/whatjobs-keyword-corroboration/specs/whatjobs-source/spec.md
+++ b/openspec/changes/whatjobs-keyword-corroboration/specs/whatjobs-source/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: A posting must corroborate the keyword it was found under
+
+The system SHALL keep a posting only when every corroborating term of its board's keyword appears in
+the posting's title or description, and SHALL drop it otherwise. Corroborating terms are the keyword's
+words with generic role words removed (`developer`, `engineer`, `programmer`, `dev`, `specialist`,
+`architect`), because those appear in almost every technical posting and so distinguish nothing:
+`rust developer` corroborates on `rust`, `kubernetes engineer` on `kubernetes`. A keyword made
+entirely of generic words has no corroborating term, and its postings SHALL pass unfiltered rather
+than all be dropped.
+
+The feed's `keyword` ranks by relevance instead of filtering, and pads a thin result set with
+unrelated inventory — one board returned 193 postings of which 144 were a hospital group's radiology
+listings. The non-technical dictionary does not catch that padding, since titles like
+"CT Technologist" read as technical.
+
+#### Scenario: A posting naming the keyword's term is kept
+
+- **WHEN** a posting found under keyword `rust developer` mentions `Rust` in its title
+- **THEN** the posting is returned
+
+#### Scenario: Padding that never names the term is dropped
+
+- **WHEN** a posting found under keyword `rust developer` is titled `Senior CT Technologist - PRN`
+  and its description never mentions rust
+- **THEN** the posting is not returned
+
+#### Scenario: The generic half of a keyword does not have to appear
+
+- **WHEN** a posting found under keyword `rust developer` is titled `Senior Rust Engineer` — naming
+  rust but never "developer"
+- **THEN** the posting is returned
+
+#### Scenario: A wholly generic keyword filters nothing
+
+- **WHEN** a board's keyword is `developer`, leaving no corroborating term
+- **THEN** its postings are returned without corroboration filtering
+
+### Requirement: Pagination ends when a page stops corroborating
+
+The system SHALL stop crawling a keyword when a page's share of corroborated postings falls below a
+minimum, treating the keyword as exhausted, and SHALL log that it stopped for this reason. Relevance
+does not taper — it collapses, from 100% on the first page to 15% on the second — so a corroborated
+share below the minimum means the feed has begun padding and every further page is mostly waste. This
+also bounds the request volume that trips the feed's rate limit.
+
+#### Scenario: A collapsed page ends the crawl
+
+- **WHEN** a keyword's first page corroborates fully and its second page corroborates 15%
+- **THEN** the crawl keeps the corroborated postings from both pages and requests no third page
+
+#### Scenario: A fully corroborating keyword crawls on
+
+- **WHEN** every page of a keyword corroborates above the minimum until the feed runs dry
+- **THEN** the crawl continues to the empty page as before
+
+### Requirement: Feed requests run under a shared in-flight cap
+
+The system SHALL bound how many WhatJobs requests are in flight at once across all of the provider's
+boards in a run. The pipeline crawls boards in parallel, and unbounded that parallelism rate-limits
+the feed — 8 of 10 boards failed with HTTP 429 on the first production run, while the same requests
+issued sequentially succeed.
+
+#### Scenario: Parallel boards share one cap
+
+- **WHEN** several whatjobs boards crawl concurrently in one run
+- **THEN** the number of simultaneous feed requests never exceeds the configured cap

--- a/openspec/changes/whatjobs-keyword-corroboration/tasks.md
+++ b/openspec/changes/whatjobs-keyword-corroboration/tasks.md
@@ -1,0 +1,24 @@
+## 1. Keyword corroboration
+
+- [ ] 1.1 Add `whatjobsCorroborationTerms(keyword)` returning the keyword's words minus the generic role words; test that `rust developer` → `[rust]`, `golang` → `[golang]`, and a wholly generic `developer` → empty
+- [ ] 1.2 Drop a posting whose title and description contain none of the corroborating terms; test that `Senior CT Technologist` under keyword `rust developer` is dropped while `Senior Rust Engineer` is kept
+- [ ] 1.3 Match case-insensitively as a substring so `iOS` corroborates `ios` and `Node.JS` corroborates `node.js`
+- [ ] 1.4 Pass postings unfiltered when the keyword has no corroborating term
+
+## 2. Relevance-collapse pagination
+
+- [ ] 2.1 Stop crawling a keyword when a page's corroborated share falls below 50%, keeping that page's corroborated postings; test a 100%-then-15% pair stops after page 2
+- [ ] 2.2 Keep crawling while pages corroborate above the threshold, still ending on the empty page
+- [ ] 2.3 Log which condition ended a crawl — collapse, empty page, or budget — so a bounded read is never mistaken for full coverage
+
+## 3. In-flight cap
+
+- [ ] 3.1 Add a whatjobs in-flight cap to `internal/sources/pacer.go` reusing `concurrencyLimitedJSONGetter`, documented with the 429 evidence
+- [ ] 3.2 Wire it in `sources.All` so all boards of a run share one semaphore
+
+## 4. Verification
+
+- [ ] 4.1 `go build ./... && go vet ./... && gofmt -l . && go test ./...` all clean
+- [ ] 4.2 Live-run two keywords against the real feed; confirm pages requested drops and every returned posting names its term
+- [ ] 4.3 Re-annotate `sources/whatjobs.yml` volumes from corroborated counts, replacing the feed's inflated `total`
+- [ ] 4.4 Deploy, run the board on prod, verify the rows are relevant before considering cron

--- a/openspec/changes/whatjobs-keyword-corroboration/tasks.md
+++ b/openspec/changes/whatjobs-keyword-corroboration/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Keyword corroboration
 
-- [ ] 1.1 Add `whatjobsCorroborationTerms(keyword)` returning the keyword's words minus the generic role words; test that `rust developer` → `[rust]`, `golang` → `[golang]`, and a wholly generic `developer` → empty
-- [ ] 1.2 Drop a posting whose title and description contain none of the corroborating terms; test that `Senior CT Technologist` under keyword `rust developer` is dropped while `Senior Rust Engineer` is kept
-- [ ] 1.3 Match case-insensitively as a substring so `iOS` corroborates `ios` and `Node.JS` corroborates `node.js`
-- [ ] 1.4 Pass postings unfiltered when the keyword has no corroborating term
+- [x] 1.1 Add `whatjobsCorroborationTerms(keyword)` returning the keyword's words minus the generic role words; test that `rust developer` → `[rust]`, `golang` → `[golang]`, and a wholly generic `developer` → empty
+- [x] 1.2 Drop a posting whose title and description contain none of the corroborating terms; test that `Senior CT Technologist` under keyword `rust developer` is dropped while `Senior Rust Engineer` is kept
+- [x] 1.3 Match case-insensitively as a substring so `iOS` corroborates `ios` and `Node.JS` corroborates `node.js`
+- [x] 1.4 Pass postings unfiltered when the keyword has no corroborating term
 
 ## 2. Relevance-collapse pagination
 
-- [ ] 2.1 Stop crawling a keyword when a page's corroborated share falls below 50%, keeping that page's corroborated postings; test a 100%-then-15% pair stops after page 2
-- [ ] 2.2 Keep crawling while pages corroborate above the threshold, still ending on the empty page
-- [ ] 2.3 Log which condition ended a crawl — collapse, empty page, or budget — so a bounded read is never mistaken for full coverage
+- [x] 2.1 Stop crawling a keyword when a page's corroborated share falls below 50%, keeping that page's corroborated postings; test a 100%-then-15% pair stops after page 2
+- [x] 2.2 Keep crawling while pages corroborate above the threshold, still ending on the empty page
+- [x] 2.3 Log which condition ended a crawl — collapse, empty page, or budget — so a bounded read is never mistaken for full coverage
 
 ## 3. In-flight cap
 
-- [ ] 3.1 Add a whatjobs in-flight cap to `internal/sources/pacer.go` reusing `concurrencyLimitedJSONGetter`, documented with the 429 evidence
-- [ ] 3.2 Wire it in `sources.All` so all boards of a run share one semaphore
+- [x] 3.1 Add a whatjobs in-flight cap to `internal/sources/pacer.go` reusing `concurrencyLimitedJSONGetter`, documented with the 429 evidence
+- [x] 3.2 Wire it in `sources.All` so all boards of a run share one semaphore
 
 ## 4. Verification
 
-- [ ] 4.1 `go build ./... && go vet ./... && gofmt -l . && go test ./...` all clean
-- [ ] 4.2 Live-run two keywords against the real feed; confirm pages requested drops and every returned posting names its term
-- [ ] 4.3 Re-annotate `sources/whatjobs.yml` volumes from corroborated counts, replacing the feed's inflated `total`
+- [x] 4.1 `go build ./... && go vet ./... && gofmt -l . && go test ./...` all clean
+- [x] 4.2 Live-run two keywords against the real feed; confirm pages requested drops and every returned posting names its term
+- [x] 4.3 Re-annotate `sources/whatjobs.yml` volumes from corroborated counts, replacing the feed's inflated `total`
 - [ ] 4.4 Deploy, run the board on prod, verify the rows are relevant before considering cron

--- a/sources/whatjobs.yml
+++ b/sources/whatjobs.yml
@@ -12,31 +12,28 @@
 # `country`, `locale` and `geo` query parameters are ignored, so another market needs its own
 # account and its own registration.
 #
-# Keywords are chosen NARROW on purpose. A crawl reads at most 40 pages (2000 postings) of a
-# keyword, so a keyword whose total exceeds that is only ever read as a bounded slice — its deeper
-# postings drift in and out of view between runs. Every keyword below was measured to sit inside the
-# budget, which keeps each crawl complete. Live totals at the time of writing are in the comments;
-# they grow, so re-measure before adding a broad term. Deliberately NOT listed (measured far beyond
-# the budget): data engineer 44k, machine learning engineer 34k, data scientist 33k,
-# software engineer 11.5k, devops engineer 10k, security engineer 8k, site reliability engineer 5k,
-# platform engineer 4.8k, qa automation engineer 3k, java developer 3k.
+# Keyword volumes below are CORROBORATED counts measured live on 2026-07-30 — the number of postings
+# that actually name the keyword's terms. Do NOT use the feed's own `total`: it ranks rather than
+# filters and pads a thin result set with unrelated inventory, so `total` describes the padding too
+# (it claimed 307 for "rust developer", of which ~51 are real). A crawl now ends when a page stops
+# corroborating; the page where that happened is noted, since it shows how far the honest run goes.
 - company: WhatJobs — Backend engineers
-  board: "backend engineer" # ~1.9k
+  board: "backend engineer" # ~1270 corroborated, collapses at page 32
 - company: WhatJobs — Frontend engineers
-  board: "frontend engineer" # ~1.2k
+  board: "frontend engineer" # ~139, collapses at page 4
 - company: WhatJobs — React developers
-  board: "react developer" # ~1.2k
+  board: "react developer" # ~124, collapses at page 4
 - company: WhatJobs — Python developers
-  board: "python developer" # ~1.0k
+  board: "python developer" # ~668, collapses at page 17
 - company: WhatJobs — Kubernetes engineers
-  board: "kubernetes engineer" # ~690
+  board: "kubernetes engineer" # ~350, collapses at page 10
 - company: WhatJobs — iOS developers
-  board: "ios developer" # ~510
+  board: "ios developer" # ~212, collapses at page 6
 - company: WhatJobs — Android developers
-  board: "android developer" # ~445
+  board: "android developer" # ~171, collapses at page 5
 - company: WhatJobs — Node.js developers
-  board: "node.js developer" # ~440
+  board: "node.js developer" # ~136, collapses at page 5
 - company: WhatJobs — Rust developers
-  board: "rust developer" # ~307
+  board: "rust developer" # ~51, collapses at page 2
 - company: WhatJobs — Go developers
-  board: "golang" # ~107
+  board: "golang" # ~86, feed runs dry (no padding at all)


### PR DESCRIPTION
## What and why

The `whatjobs` source added in #1268 failed its first production run and was rolled back. Two defects, neither visible to the unit tests nor to the pre-flight measurements.

### The feed's `keyword` ranks, it does not filter

Board `rust developer` returned 193 postings of which 144 were one hospital group's **CT Technologist** and **Nuclear Medicine Technologist** listings. The non-tech gate waved them through — "Technologist" reads as technical, and it rejected only 16% of that board. Those rows reached production and were visible in search.

Relevance does not taper, it falls off a cliff:

| page | rows | mention `rust` | relevant |
|---|---|---|---|
| 1 | 47 | 47 | 100% |
| 2 | 26 | 4 | 15% |
| 3 | 30 | 4 | 13% |
| 5 | 43 | 0 | 0% |

So **`total` describes the padded result set, not the inventory** — it claimed 307 for that keyword against ~51 real postings. Every keyword volume in the board file had been chosen against that fiction.

### HTTP 429

A dozen sequential requests from one IP never tripped anything, but the pipeline crawls boards in parallel and 8 of 10 boards died on rate limiting.

## The fix

Both problems share a cure: stop a keyword once its results stop corroborating.

- **Corroboration** — a posting is kept only if it names the keyword's meaningful terms. Generic role words (`developer`, `engineer`, `programmer`, `dev`, `specialist`, `architect`) are stripped first, because they corroborate the radiology padding exactly as readily as a real match. Matching is case-insensitive substring, not word-boundary: the feed writes `iOS` and `Node.JS`.
- **Relevance-collapse pagination** — a page corroborating below 50% ends the keyword. This cuts `rust developer` from 40 pages to 2, which is most of the answer to the 429s as well. The 40-page budget stays as a backstop.
- **Shared in-flight cap of 2**, reusing `concurrencyLimitedJSONGetter` (the `limitedTrudvsemGetter` precedent).

The rule was validated against live first pages *before* being written, so it costs nothing where the feed is honest: `backend engineer` 45/45, `ios developer` 49/49, `kubernetes engineer` 45/45, `rust developer` 47/47 kept.

## Measured after the fix, live across all ten keywords

```
backend engineer     1270  (collapses page 32)   android developer   171  (page 5)
python developer      668  (page 17)             frontend engineer   139  (page 4)
kubernetes engineer   350  (page 10)             node.js developer   136  (page 5)
ios developer         212  (page 6)              react developer     124  (page 4)
                                                 golang               86  (feed runs dry)
                                                 rust developer        51  (page 2)
────────────────────────────────────────────────────────────────────────────────────
~3200 postings · 0 failing corroboration · 0 rate-limited
```

Worth flagging: this design first predicted 50–90 per keyword, extrapolated from the one thin keyword that had failed. It understated the result by more than an order of magnitude — padding is not uniform, and a broad keyword stays honest for dozens of pages. The board file now carries measured corroborated counts instead of `total`.

## Also included

`test(sources): stamp the instaffo age fixture in UTC` — an unrelated pre-existing failure found while running the suite. The adapter reads a bare `2006-01-02` datePosted as UTC midnight, but the fixture stamped it in the local zone, so west of Greenwich (while the local date lags UTC's) the "fresh" posting ages out of its window. CI runs in UTC, which is why it only ever failed on a developer machine. Verified across UTC, +03, -03, -07.

OpenSpec: `openspec/changes/whatjobs-keyword-corroboration/`

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes.
- [x] I regenerated committed artifacts when their source changed — none changed.
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary — one adapter plus a reused pacer primitive.