### PR TITLE
fix(ghost): make the cross-check usable at catalogue scale

### DIFF
--- a/cmd/ghost-crosscheck/main.go
+++ b/cmd/ghost-crosscheck/main.go
@@ -25,6 +25,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"sort"
 
@@ -117,26 +118,49 @@ func boardProviders(reg map[string]sources.Source) []string {
 	return out
 }
 
-// crosscheckAll pages through candidate postings by keyset, batching each company's
-// postings together so its board is read once rather than once per posting.
+// croscheckAll walks each aggregator source separately, paging by keyset within it, and
+// batches each company's postings so its board is read once rather than once per posting.
+//
+// Per SOURCE rather than across all of them: a single `source = ANY(...) ORDER BY id LIMIT n`
+// defeats its own keyset — the planner answers it with a bitmap scan over every aggregator's
+// postings plus a sort, so every page re-scans the whole set (measured: 28s per page on
+// prod). One source at a time walks jobs_source_id_open_idx in id order and stops at LIMIT.
+//
+// Progress is logged per source. A run over a large catalogue takes long enough that a
+// worker which printed nothing until the end could not be told from one that had hung.
 func crosscheckAll(ctx context.Context, q *db.Queries, aggregators, boards []string, rep *report) error {
+	for i, source := range aggregators {
+		seen, err := crosscheckSource(ctx, q, source, boards, rep)
+		if err != nil {
+			return fmt.Errorf("source %s: %w", source, err)
+		}
+		log.Printf("ghost-crosscheck: [%d/%d] %s — %d postings considered (running totals: %d stamped, %d cleared, %d skipped)",
+			i+1, len(aggregators), source, seen, rep.stamped, rep.cleared, rep.skipped)
+	}
+	return nil
+}
+
+// crosscheckSource pages through one source's open postings and returns how many it read.
+func crosscheckSource(ctx context.Context, q *db.Queries, source string, boards []string, rep *report) (int, error) {
 	var afterID int64
+	var seen int
 	pending := map[string][]ghost.Posting{}
 
 	for {
-		rows, err := q.ListAggregatorJobsForCrosscheck(ctx, db.ListAggregatorJobsForCrosscheckParams{
-			AggregatorSources: aggregators,
-			AfterID:           afterID,
-			PageSize:          pageSize,
+		rows, err := q.ListAggregatorJobsForCrosscheckBySource(ctx, db.ListAggregatorJobsForCrosscheckBySourceParams{
+			Source:   source,
+			AfterID:  afterID,
+			PageSize: pageSize,
 		})
 		if err != nil {
-			return err
+			return seen, err
 		}
 		if len(rows) == 0 {
 			break
 		}
 		for _, r := range rows {
 			afterID = r.ID
+			seen++
 			pending[r.CompanySlug] = append(pending[r.CompanySlug], ghost.Posting{
 				ID:          r.ID,
 				CompanySlug: r.CompanySlug,
@@ -144,15 +168,15 @@ func crosscheckAll(ctx context.Context, q *db.Queries, aggregators, boards []str
 				Stamped:     r.AtsAbsentAt.Valid,
 			})
 		}
-		// Postings arrive by id, so one company's can straddle pages. Flushing only
-		// at the end would hold the whole catalogue in memory; flushing per page
-		// would read a straddling company's board twice. Keeping the last company
-		// back until the next page is the cheap middle.
+		// Postings arrive by id, so one company's can straddle pages. Flushing only at
+		// the end would hold a whole source in memory; flushing per page would read a
+		// straddling company's board twice. Keeping the last company back until the
+		// next page is the cheap middle.
 		if err := flush(ctx, q, boards, pending, rep, len(rows) == pageSize); err != nil {
-			return err
+			return seen, err
 		}
 	}
-	return flush(ctx, q, boards, pending, rep, false)
+	return seen, flush(ctx, q, boards, pending, rep, false)
 }
 
 // flush cross-checks the companies buffered so far. When more pages follow, the

--- a/internal/db/ghost_crosscheck.sql.go
+++ b/internal/db/ghost_crosscheck.sql.go
@@ -23,46 +23,48 @@ func (q *Queries) ClearJobATSAbsent(ctx context.Context, jobIds []int64) error {
 	return err
 }
 
-const listAggregatorJobsForCrosscheck = `-- name: ListAggregatorJobsForCrosscheck :many
+const listAggregatorJobsForCrosscheckBySource = `-- name: ListAggregatorJobsForCrosscheckBySource :many
 SELECT j.id, j.company_slug, j.title, j.ats_absent_at
 FROM jobs j
 WHERE j.closed_at IS NULL
-  AND j.source = ANY($1::text[])
+  AND j.source = $1
   AND j.id > $2
 ORDER BY j.id
 LIMIT $3
 `
 
-type ListAggregatorJobsForCrosscheckParams struct {
-	AggregatorSources []string `json:"aggregator_sources"`
-	AfterID           int64    `json:"after_id"`
-	PageSize          int32    `json:"page_size"`
+type ListAggregatorJobsForCrosscheckBySourceParams struct {
+	Source   string `json:"source"`
+	AfterID  int64  `json:"after_id"`
+	PageSize int32  `json:"page_size"`
 }
 
-type ListAggregatorJobsForCrosscheckRow struct {
+type ListAggregatorJobsForCrosscheckBySourceRow struct {
 	ID          int64              `json:"id"`
 	CompanySlug string             `json:"company_slug"`
 	Title       string             `json:"title"`
 	AtsAbsentAt pgtype.Timestamptz `json:"ats_absent_at"`
 }
 
-// Keyset page of open aggregator postings to cross-check, ordered by id so the scan
-// resumes exactly where it stopped. The worker buffers a page and groups it by company
-// itself, so a company's board is read once rather than once per posting; ordering by
-// company instead would make the keyset cursor non-unique and risk skipping rows.
+// Keyset page of one AGGREGATOR SOURCE's open postings.
 //
-// The caller passes the aggregator provider names (sources.AggregatorProviders): the
-// provider taxonomy lives in Go adapter markers, not in the database, and copying it
-// into SQL would leave two lists to keep in step.
-func (q *Queries) ListAggregatorJobsForCrosscheck(ctx context.Context, arg ListAggregatorJobsForCrosscheckParams) ([]ListAggregatorJobsForCrosscheckRow, error) {
-	rows, err := q.db.Query(ctx, listAggregatorJobsForCrosscheck, arg.AggregatorSources, arg.AfterID, arg.PageSize)
+// Scoped to a single source on purpose. The earlier `source = ANY(...)` form defeated its
+// own keyset: measured on prod, the planner answered it with a Bitmap Heap Scan over every
+// posting of all 42 aggregators followed by a Sort — so each 2000-row page re-scanned and
+// re-sorted the whole set, at 28 seconds a page. One source at a time lets the index walk
+// in id order and stop at LIMIT, which is what keyset pagination is for.
+//
+// Requires jobs_source_id_open_idx (migration 0056); without it this is the same scan
+// restricted to one source.
+func (q *Queries) ListAggregatorJobsForCrosscheckBySource(ctx context.Context, arg ListAggregatorJobsForCrosscheckBySourceParams) ([]ListAggregatorJobsForCrosscheckBySourceRow, error) {
+	rows, err := q.db.Query(ctx, listAggregatorJobsForCrosscheckBySource, arg.Source, arg.AfterID, arg.PageSize)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListAggregatorJobsForCrosscheckRow{}
+	items := []ListAggregatorJobsForCrosscheckBySourceRow{}
 	for rows.Next() {
-		var i ListAggregatorJobsForCrosscheckRow
+		var i ListAggregatorJobsForCrosscheckBySourceRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.CompanySlug,

--- a/internal/db/ghost_crosscheck_integration_test.go
+++ b/internal/db/ghost_crosscheck_integration_test.go
@@ -36,13 +36,13 @@ func TestGhostCrosscheck_CandidatesAreOpenAggregatorPostings(t *testing.T) {
 		t.Fatalf("close job: %v", err)
 	}
 
-	rows, err := q.ListAggregatorJobsForCrosscheck(ctx, ListAggregatorJobsForCrosscheckParams{
-		AggregatorSources: []string{"jobstash"},
-		AfterID:           0,
-		PageSize:          100,
+	rows, err := q.ListAggregatorJobsForCrosscheckBySource(ctx, ListAggregatorJobsForCrosscheckBySourceParams{
+		Source:   "jobstash",
+		AfterID:  0,
+		PageSize: 100,
 	})
 	if err != nil {
-		t.Fatalf("ListAggregatorJobsForCrosscheck: %v", err)
+		t.Fatalf("ListAggregatorJobsForCrosscheckBySource: %v", err)
 	}
 	if len(rows) != 1 || rows[0].ID != wanted {
 		t.Fatalf("rows = %+v, want only the open jobstash posting %d", rows, wanted)
@@ -110,8 +110,8 @@ func TestGhostCrosscheck_StampAndClearRoundTrip(t *testing.T) {
 	if err := q.StampJobATSAbsent(ctx, []int64{id}); err != nil {
 		t.Fatalf("StampJobATSAbsent: %v", err)
 	}
-	rows, err := q.ListAggregatorJobsForCrosscheck(ctx, ListAggregatorJobsForCrosscheckParams{
-		AggregatorSources: []string{"jobstash"}, AfterID: 0, PageSize: 100,
+	rows, err := q.ListAggregatorJobsForCrosscheckBySource(ctx, ListAggregatorJobsForCrosscheckBySourceParams{
+		Source: "jobstash", AfterID: 0, PageSize: 100,
 	})
 	if err != nil {
 		t.Fatalf("read back: %v", err)
@@ -123,8 +123,8 @@ func TestGhostCrosscheck_StampAndClearRoundTrip(t *testing.T) {
 	if err := q.ClearJobATSAbsent(ctx, []int64{id}); err != nil {
 		t.Fatalf("ClearJobATSAbsent: %v", err)
 	}
-	rows, err = q.ListAggregatorJobsForCrosscheck(ctx, ListAggregatorJobsForCrosscheckParams{
-		AggregatorSources: []string{"jobstash"}, AfterID: 0, PageSize: 100,
+	rows, err = q.ListAggregatorJobsForCrosscheckBySource(ctx, ListAggregatorJobsForCrosscheckBySourceParams{
+		Source: "jobstash", AfterID: 0, PageSize: 100,
 	})
 	if err != nil {
 		t.Fatalf("read back after clear: %v", err)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -889,15 +889,17 @@ type Querier interface {
 	// worker groups these by canonical(query) so each distinct filter hits the search
 	// index once regardless of how many subscriptions share it.
 	ListActiveSubscriptions(ctx context.Context) ([]ListActiveSubscriptionsRow, error)
-	// Keyset page of open aggregator postings to cross-check, ordered by id so the scan
-	// resumes exactly where it stopped. The worker buffers a page and groups it by company
-	// itself, so a company's board is read once rather than once per posting; ordering by
-	// company instead would make the keyset cursor non-unique and risk skipping rows.
+	// Keyset page of one AGGREGATOR SOURCE's open postings.
 	//
-	// The caller passes the aggregator provider names (sources.AggregatorProviders): the
-	// provider taxonomy lives in Go adapter markers, not in the database, and copying it
-	// into SQL would leave two lists to keep in step.
-	ListAggregatorJobsForCrosscheck(ctx context.Context, arg ListAggregatorJobsForCrosscheckParams) ([]ListAggregatorJobsForCrosscheckRow, error)
+	// Scoped to a single source on purpose. The earlier `source = ANY(...)` form defeated its
+	// own keyset: measured on prod, the planner answered it with a Bitmap Heap Scan over every
+	// posting of all 42 aggregators followed by a Sort — so each 2000-row page re-scanned and
+	// re-sorted the whole set, at 28 seconds a page. One source at a time lets the index walk
+	// in id order and stop at LIMIT, which is what keyset pagination is for.
+	//
+	// Requires jobs_source_id_open_idx (migration 0056); without it this is the same scan
+	// restricted to one source.
+	ListAggregatorJobsForCrosscheckBySource(ctx context.Context, arg ListAggregatorJobsForCrosscheckBySourceParams) ([]ListAggregatorJobsForCrosscheckBySourceRow, error)
 	// The notify fan-out targets: every approved referrer of a company with their email and
 	// linked Telegram chat (NULL when unlinked). Email is always present; chat_id drives the
 	// optional Telegram ping.

--- a/internal/db/queries/ghost_crosscheck.sql
+++ b/internal/db/queries/ghost_crosscheck.sql
@@ -1,16 +1,18 @@
--- name: ListAggregatorJobsForCrosscheck :many
--- Keyset page of open aggregator postings to cross-check, ordered by id so the scan
--- resumes exactly where it stopped. The worker buffers a page and groups it by company
--- itself, so a company's board is read once rather than once per posting; ordering by
--- company instead would make the keyset cursor non-unique and risk skipping rows.
+-- name: ListAggregatorJobsForCrosscheckBySource :many
+-- Keyset page of one AGGREGATOR SOURCE's open postings.
 --
--- The caller passes the aggregator provider names (sources.AggregatorProviders): the
--- provider taxonomy lives in Go adapter markers, not in the database, and copying it
--- into SQL would leave two lists to keep in step.
+-- Scoped to a single source on purpose. The earlier `source = ANY(...)` form defeated its
+-- own keyset: measured on prod, the planner answered it with a Bitmap Heap Scan over every
+-- posting of all 42 aggregators followed by a Sort — so each 2000-row page re-scanned and
+-- re-sorted the whole set, at 28 seconds a page. One source at a time lets the index walk
+-- in id order and stop at LIMIT, which is what keyset pagination is for.
+--
+-- Requires jobs_source_id_open_idx (migration 0056); without it this is the same scan
+-- restricted to one source.
 SELECT j.id, j.company_slug, j.title, j.ats_absent_at
 FROM jobs j
 WHERE j.closed_at IS NULL
-  AND j.source = ANY(sqlc.arg(aggregator_sources)::text[])
+  AND j.source = sqlc.arg(source)
   AND j.id > sqlc.arg(after_id)
 ORDER BY j.id
 LIMIT sqlc.arg(page_size);

--- a/internal/jobhash/rolekey.go
+++ b/internal/jobhash/rolekey.go
@@ -1,5 +1,7 @@
 package jobhash
 
+import "regexp"
+
 // RoleKey returns a CROSS-SOURCE role identity: the company slug and the
 // normalized, trailing-clause-stripped title, joined. Two postings of one role
 // share a key however differently their descriptions read.
@@ -16,13 +18,29 @@ package jobhash
 // reuses the same normalization RoleFingerprint applies to a title, so a per-city
 // variant collapses onto its base role here exactly as it does there.
 //
+// Parentheses are UNWRAPPED rather than kept, because an aggregator that adds or drops
+// them is describing the same role: measured on prod, "Data Engineer (Semi Senior)" and
+// "Data Engineer Semi Senior" counted as two roles and inflated the cross-check's absent
+// count by 13%. Unwrapping keeps the words — dropping the contents would collapse
+// "Go Developer (Remote)" onto "Rust Developer (Remote)".
+//
 // A title that normalizes to nothing yields the empty string, and a caller MUST
 // treat that as "no key" rather than as a key — every blank title would otherwise
 // match every other one.
 func RoleKey(companySlug, title string) string {
-	normalized := normalizeRoleText(stripTrailingClause(title))
+	normalized := normalizeRoleText(stripTrailingClause(unwrapParens(title)))
 	if normalized == "" {
 		return ""
 	}
 	return companySlug + "\x1e" + normalized
+}
+
+// parens matches one parenthesised group.
+var parens = regexp.MustCompile(`[()]`)
+
+// unwrapParens removes the brackets while keeping what they enclose, so a role reads
+// the same whether or not the source wrapped its qualifier. normalizeRoleText collapses
+// the whitespace this leaves behind.
+func unwrapParens(title string) string {
+	return parens.ReplaceAllString(title, " ")
 }

--- a/internal/jobhash/rolekey_test.go
+++ b/internal/jobhash/rolekey_test.go
@@ -64,3 +64,32 @@ func TestRoleKey_IsEmptyForAnEmptyTitle(t *testing.T) {
 		t.Error("a blank title produced a key; it would match every other blank one")
 	}
 }
+
+// Measured on prod (2026-07-29): parenthetical variants of one role were counted as
+// separate roles, inflating the cross-check's absent count by 13% — 15,706 candidates
+// fell to 13,641 once parentheses were stripped. "Data Engineer (Semi Senior)" and
+// "Data Engineer Semi Senior" are one role advertised twice, and an aggregator that
+// drops or adds the parentheses must not manufacture an absence.
+func TestRoleKey_CollapsesParentheticalVariants(t *testing.T) {
+	base := RoleKey("acme", "Data Engineer Semi Senior")
+	for _, variant := range []string{
+		"Data Engineer (Semi Senior)",
+		"Data Engineer  (Semi   Senior)",
+		"Data Engineer (Semi Senior) ",
+	} {
+		if got := RoleKey("acme", variant); got != base {
+			t.Errorf("RoleKey(%q) = %q, want it to match %q", variant, got, base)
+		}
+	}
+}
+
+// A parenthetical that carries the WHOLE distinction must not erase the role either:
+// stripping must leave something, and what is left must still be two words.
+func TestRoleKey_ParenthesisStripNeverEmptiesATitle(t *testing.T) {
+	if RoleKey("acme", "(Senior)") == "" {
+		t.Error("a title that is only a parenthetical lost its key entirely")
+	}
+	if RoleKey("acme", "Go Developer (Remote)") == RoleKey("acme", "Rust Developer (Remote)") {
+		t.Error("stripping parentheses collapsed two different roles")
+	}
+}

--- a/migrations/0056_ghost_crosscheck_scan_idx.sql
+++ b/migrations/0056_ghost_crosscheck_scan_idx.sql
@@ -1,0 +1,17 @@
+-- The index the ghost cross-check's keyset scan needs.
+--
+-- Without it, paging through one aggregator's open postings in id order costs a scan of
+-- that source's whole set plus a sort. Measured on prod before this index: the earlier
+-- multi-source form of the query took 28 SECONDS per 2000-row page, because the planner
+-- answered `source = ANY(...) ORDER BY id LIMIT n` with a Bitmap Heap Scan and a Sort
+-- rather than an ordered index walk. Narrowing the query to one source is half the fix;
+-- this index is the other half.
+--
+-- Partial on `closed_at IS NULL` because the worker only ever considers open postings,
+-- which keeps the index proportional to the live catalogue rather than to its history.
+--
+-- Applied to a fresh volume by initdb after 0055. On an existing prod volume build it
+-- CONCURRENTLY by hand, under nohup or screen: a CONCURRENTLY build dies with its ssh
+-- session and leaves an INVALID index behind.
+CREATE INDEX IF NOT EXISTS jobs_source_id_open_idx
+    ON public.jobs (source, id) WHERE closed_at IS NULL;


### PR DESCRIPTION
## What and why

Three defects in the ghost cross-check from #1259, all found by running its dry-run against **production** rather than by reading the code. None had reached users — the worker is dry-run by default and its cron was never enabled.

### The keyset scan defeated itself

`ListAggregatorJobsForCrosscheck` filtered `source = ANY(<42 aggregators>)` and ordered by `id`. Postgres answered that with a **Bitmap Heap Scan + Sort** over every aggregator posting, so each 2000-row page re-scanned and re-sorted the entire set:

```
Sort  (Sort Key: id)
  ->  Bitmap Heap Scan on jobs j
        Recheck Cond: (source = ANY (...))
        Filter: ((closed_at IS NULL) AND (id > 0))
        ->  Bitmap Index Scan on jobs_source_idx
```

**28 seconds per page**, which makes a full run unusable — I killed the first attempt. The worker now walks **one source at a time**, so the index can be read in id order and stop at `LIMIT`, and migration `0056` adds the partial `(source, id) WHERE closed_at IS NULL` index that walk needs.

### RoleKey counted parenthetical variants as different roles

Measured on prod: `Data Engineer (Semi Senior)` and `Data Engineer Semi Senior` were two roles, so a company collected several "absent" postings for one advertised role. Stripping parentheses cut the candidate set by 13% — **15,706 → 13,641**.

Parentheses are **unwrapped, not dropped**: dropping the contents would collapse `Go Developer (Remote)` onto `Rust Developer (Remote)`.

### The worker was silent until the end

The report only printed on completion, so a long run could not be told from a hung one. It now logs per source with running totals.

## What the production dry-run also established (no code change here)

Worth recording, since it corrects an earlier reading of my own:

- The **coverage gate** limits the signal to **6,804 of 84,884** companies seen on aggregators (8%) — for the rest we do not crawl their own board, so absence proves nothing and they are judged not at all.
- `ats_absent` **in isolation** is confounded with company type: its head is IT outsourcing and staffing (scalo, epam-systems, dcg, addepto, andersen, antal, accenture, luxoft…), and restricting to `is_tech` made the concentration worse, not better (29.5% → 39.7% in the top 10). That is the same confound that invalidated the 2026-07-21 spike, reproduced in a new coordinate.
- **But convergence rescues it.** `ats_absent` alone marks nothing — a badge needs two criteria. Only **227 postings across 4 companies** reach that bar (142 tech, across 2), and they converge via *reposts and concurrent copies*, not age: e.g. one EPAM role posted 14 times with **7 copies open at once**, absent from EPAM's own board. That is the pattern the feature exists to surface, and it is information a job seeker can act on regardless of how we classify the employer.

So the criterion stays, and the calibration gate stays too — the numbers above are what it exists to produce.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` pass.
- [x] `go test ./...` passes, and `go test -tags=integration ./internal/db/ ./internal/handler/` passes.
- [x] I regenerated committed artifacts when their source changed (`make sqlc`).
- [ ] For `design-system/` changes — not touched.
- [ ] For `web/` changes — not touched.
- [x] This stays within freehire's core/extension boundary.