### PR TITLE
fix: bound five untrusted inputs that reach a shared resource

### DIFF
--- a/internal/accounts/codes.go
+++ b/internal/accounts/codes.go
@@ -24,7 +24,8 @@ const (
 
 	// maxCodeAttempts is how many wrong guesses a code survives. Six digits is a million
 	// possibilities; five tries makes online guessing hopeless without frustrating a human
-	// who mistyped.
+	// who mistyped. It bounds the guessing rate only together with resendCooldown, which is
+	// why a burnt code keeps its row (see consumeCode).
 	maxCodeAttempts = 5
 
 	// resendCooldown keeps the endpoint from being used to flood an address with mail.
@@ -130,10 +131,17 @@ func (s *Service) issueCode(ctx context.Context, userID int64, purpose string) (
 }
 
 // consumeCode checks a presented code against the outstanding one and, on success, deletes
-// it so it cannot be replayed. A wrong guess counts toward the ceiling; reaching the
-// ceiling burns the code, so even the right value stops working until a new one is issued.
+// it so it cannot be replayed. A wrong guess counts toward the ceiling; a code that has spent
+// its budget is dead, so even the right value stops working until a new one is issued.
 // Absent, burnt, and wrong all surface as ErrInvalidCode — the caller learns only that this
 // code does not work.
+//
+// A burnt code keeps its row rather than being deleted. That row is what issueCode reads the
+// resend cooldown off, and deleting it made burning the code the cheapest way to get a fresh
+// one: the ceiling then cost a guesser one round-trip instead of a minute, so five guesses
+// per code was not a rate limit at all. Keeping the row makes the two bounds compose — a
+// guesser gets maxCodeAttempts tries per resendCooldown against a six-digit secret — and
+// costs nothing, since UpsertEmailCode resets attempts when the next code is issued.
 func (s *Service) consumeCode(ctx context.Context, userID int64, purpose, presented string) error {
 	stored, err := s.codes.Code(ctx, userID, purpose)
 	if errors.Is(err, ErrNoCode) {
@@ -142,18 +150,15 @@ func (s *Service) consumeCode(ctx context.Context, userID int64, purpose, presen
 	if err != nil {
 		return err
 	}
+	if stored.Attempts >= maxCodeAttempts {
+		return ErrInvalidCode
+	}
 	if s.now().After(stored.ExpiresAt) {
 		return ErrCodeExpired
 	}
 	if s.hasher.Check(stored.Hash, presented) != nil {
-		attempts, err := s.codes.BumpAttempts(ctx, userID, purpose)
-		if err != nil {
+		if _, err := s.codes.BumpAttempts(ctx, userID, purpose); err != nil {
 			return err
-		}
-		if attempts >= maxCodeAttempts {
-			if err := s.codes.DeleteCode(ctx, userID, purpose); err != nil {
-				return err
-			}
 		}
 		return ErrInvalidCode
 	}

--- a/internal/accounts/verification_test.go
+++ b/internal/accounts/verification_test.go
@@ -186,12 +186,75 @@ func TestConfirmVerificationBurnsTheCodeAfterTooManyAttempts(t *testing.T) {
 	if err := s.ConfirmVerification(context.Background(), 5, "999999"); !errors.Is(err, ErrInvalidCode) {
 		t.Fatalf("err = %v, want ErrInvalidCode", err)
 	}
-	if _, err := codes.Code(context.Background(), 5, PurposeVerifyEmail); !errors.Is(err, ErrNoCode) {
-		t.Error("the code must be burnt once the attempt ceiling is reached")
-	}
 	// Even the right code no longer works: the guesser must request a new one.
 	if err := s.ConfirmVerification(context.Background(), 5, "123456"); !errors.Is(err, ErrInvalidCode) {
 		t.Errorf("err = %v, want ErrInvalidCode after the code was burnt", err)
+	}
+	// The row survives on purpose — it carries the resend cooldown, so burning the code is
+	// not a way to skip it. Only a successful consume deletes.
+	c, err := codes.Code(context.Background(), 5, PurposeVerifyEmail)
+	if err != nil {
+		t.Fatalf("a burnt code must keep its row: %v", err)
+	}
+	if c.Attempts < maxCodeAttempts {
+		t.Errorf("attempts = %d, want the ceiling recorded on the row", c.Attempts)
+	}
+	if len(codes.deleted) != 0 {
+		t.Errorf("deleted %v, want nothing deleted by a burn", codes.deleted)
+	}
+}
+
+// The attempt ceiling is only a real bound if it cannot be reset on demand. Burning a code
+// must therefore leave the cooldown standing: otherwise the ceiling costs a guesser one
+// round-trip instead of a minute, and five guesses per code becomes an unbounded rate
+// against a six-digit secret.
+func TestBurningACodeDoesNotLiftTheResendCooldown(t *testing.T) {
+	codes := newFakeCodes()
+	now := time.Now()
+	codes.put(5, PurposeVerifyEmail, StoredCode{
+		Hash: "hashed:123456", ExpiresAt: now.Add(codeTTL), IssuedAt: now, Attempts: maxCodeAttempts - 1,
+	})
+	mailer := &fakeMailer{}
+	s := verifyService(&fakeRepo{}, codes, mailer, now)
+
+	// Spend the last attempt; the code is dead from here on.
+	if err := s.ConfirmVerification(context.Background(), 5, "999999"); !errors.Is(err, ErrInvalidCode) {
+		t.Fatalf("err = %v, want ErrInvalidCode", err)
+	}
+	if err := s.IssueVerificationCode(context.Background(), 5, "new@example.test"); !errors.Is(err, ErrResendTooSoon) {
+		t.Errorf("err = %v, want ErrResendTooSoon — burning a code must not reset the cooldown", err)
+	}
+	if len(mailer.verification) != 0 {
+		t.Errorf("mailed %d codes inside the cooldown, want 0", len(mailer.verification))
+	}
+}
+
+// Once the cooldown has passed, a fresh code is issued normally and starts with a clean
+// attempt budget — the burnt row must not outlive its own cooldown.
+func TestABurntCodeIsReplacedAfterTheCooldown(t *testing.T) {
+	codes := newFakeCodes()
+	now := time.Now()
+	codes.put(5, PurposeVerifyEmail, StoredCode{
+		Hash:      "hashed:123456",
+		ExpiresAt: now.Add(codeTTL),
+		IssuedAt:  now.Add(-2 * resendCooldown),
+		Attempts:  maxCodeAttempts,
+	})
+	mailer := &fakeMailer{}
+	s := verifyService(&fakeRepo{}, codes, mailer, now)
+
+	if err := s.IssueVerificationCode(context.Background(), 5, "new@example.test"); err != nil {
+		t.Fatalf("IssueVerificationCode: %v", err)
+	}
+	if len(mailer.verification) != 1 {
+		t.Fatalf("mailed %d codes, want 1", len(mailer.verification))
+	}
+	c, err := codes.Code(context.Background(), 5, PurposeVerifyEmail)
+	if err != nil {
+		t.Fatalf("Code: %v", err)
+	}
+	if c.Attempts != 0 {
+		t.Errorf("attempts = %d, want 0 — a re-issued code starts with a fresh budget", c.Attempts)
 	}
 }
 

--- a/internal/handler/me_profile.go
+++ b/internal/handler/me_profile.go
@@ -135,6 +135,8 @@ func profileError(err error) error {
 		return fiber.NewError(fiber.StatusBadRequest, "too many specializations (max 5)")
 	case errors.Is(err, userprofile.ErrEmptySkills):
 		return fiber.NewError(fiber.StatusBadRequest, "at least one skill is required")
+	case errors.Is(err, userprofile.ErrTooManySkills):
+		return fiber.NewError(fiber.StatusBadRequest, "too many skills (max 100)")
 	case errors.Is(err, userprofile.ErrInvalidWorkMode):
 		return fiber.NewError(fiber.StatusBadRequest, "work mode is not a known value")
 	case errors.Is(err, userprofile.ErrInvalidRegion):

--- a/internal/mailbox/allocate.go
+++ b/internal/mailbox/allocate.go
@@ -37,6 +37,12 @@ func GetOrCreate(ctx context.Context, s Store, userID int64, email, domain strin
 
 	base := Handle(email)
 	for n := 1; n <= maxAllocAttempts; n++ {
+		// A reserved handle is skipped rather than claimed, so a user whose own local-part
+		// is an operational name gets the next suffix instead. Only the bare form is ever
+		// reserved, so this costs at most one attempt.
+		if isReserved(Candidate(base, n)) {
+			continue
+		}
 		addr := Address(base, n, domain)
 		err := s.Insert(ctx, userID, addr)
 		if err == nil {

--- a/internal/mailbox/allocate_test.go
+++ b/internal/mailbox/allocate_test.go
@@ -55,6 +55,39 @@ func TestGetOrCreate_Collision(t *testing.T) {
 	}
 }
 
+// A user whose own local-part happens to be an operational name must not be handed the
+// bare form of it on the receiving domain: those addresses are where abuse reports land and
+// what a CA will mail to prove control of the domain.
+func TestGetOrCreate_SkipsReservedHandles(t *testing.T) {
+	for _, email := range []string{"postmaster@somewhere.io", "abuse@somewhere.io", "admin@somewhere.io"} {
+		s := newFakeStore()
+		addr, err := GetOrCreate(context.Background(), s, 1, email, "inbox.freehire.me")
+		if err != nil {
+			t.Fatalf("GetOrCreate(%q): %v", email, err)
+		}
+		base := Handle(email)
+		if addr == base+"@inbox.freehire.me" {
+			t.Errorf("GetOrCreate(%q) allocated the reserved address %q", email, addr)
+		}
+		if want := base + "-2@inbox.freehire.me"; addr != want {
+			t.Errorf("GetOrCreate(%q) = %q, want the first non-reserved candidate %q", email, addr, want)
+		}
+	}
+}
+
+// A suffixed form of a reserved name is not itself an operational address, so nothing
+// stops a user from holding it.
+func TestGetOrCreate_ReservationIsExactLocalPartOnly(t *testing.T) {
+	s := newFakeStore()
+	addr, err := GetOrCreate(context.Background(), s, 1, "administrator.uk@somewhere.io", "inbox.freehire.me")
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	if addr != "administrator.uk@inbox.freehire.me" {
+		t.Errorf("addr = %q, want the bare handle (not a reserved name)", addr)
+	}
+}
+
 func TestGetOrCreate_Idempotent(t *testing.T) {
 	s := newFakeStore()
 	first, _ := GetOrCreate(context.Background(), s, 1, "ivan@gmail.com", "inbox.freehire.me")

--- a/internal/mailbox/mailbox.go
+++ b/internal/mailbox/mailbox.go
@@ -33,6 +33,37 @@ func Handle(email string) string {
 	return b.String()
 }
 
+// reservedHandles are local-parts no user may hold on the receiving domain, because
+// something other than a person is expected to answer them.
+//
+// Two reasons, both real. The RFC 2142 role names (and the operational ones around them)
+// are where mail *about* the service arrives — an abuse report delivered into a stranger's
+// job inbox is a report nobody reads. And the CA/Browser Forum's domain validation lets a
+// certificate be issued to whoever answers a "constructed email address" (admin,
+// administrator, webmaster, hostmaster, postmaster) at the domain, so handing one out
+// hands out the ability to obtain a certificate for the receiving domain.
+//
+// Matching is on the exact local-part: a suffixed form like "postmaster-2" is not an
+// operational address and nothing stops a user from holding it.
+var reservedHandles = map[string]struct{}{
+	// CA/Browser Forum constructed email addresses — certificate issuance.
+	"admin": {}, "administrator": {}, "webmaster": {}, "hostmaster": {}, "postmaster": {},
+	// RFC 2142 role addresses.
+	"abuse": {}, "noc": {}, "security": {}, "usenet": {}, "news": {}, "www": {},
+	"uucp": {}, "ftp": {}, "marketing": {}, "sales": {}, "support": {}, "info": {},
+	// Bounce and automated-sender names: mail addressed to these is machine traffic, and
+	// a human inbox answering them invites loops.
+	"mailer-daemon": {}, "noreply": {}, "no-reply": {}, "bounce": {}, "bounces": {},
+	// Domain-control and mail-authentication reporting.
+	"dmarc": {}, "dkim": {}, "spf": {}, "root": {}, "ssl-admin": {}, "ssladmin": {},
+}
+
+// isReserved reports whether a candidate handle is one nobody may be allocated.
+func isReserved(handle string) bool {
+	_, ok := reservedHandles[handle]
+	return ok
+}
+
 // Candidate returns the nth handle for a base: the base itself for n<=1, then
 // "base-2", "base-3", … so a collision gets the smallest free suffix.
 func Candidate(base string, n int) string {

--- a/internal/resume/pdftext_test.go
+++ b/internal/resume/pdftext_test.go
@@ -3,8 +3,11 @@ package resume
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // requirePDFTool skips a test when pdftotext is not on PATH, mirroring the typst-gated
@@ -14,6 +17,55 @@ func requirePDFTool(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("pdftotext"); err != nil {
 		t.Skip("pdftotext not on PATH; skipping PDF extraction test")
+	}
+}
+
+// stubPDFTool points pdftotextBin at a script emitting n bytes of the given UTF-8 filler on
+// stdout, so the output-size guard is exercised without hunting for a pathological PDF.
+// Restored by t.Cleanup.
+func stubPDFTool(t *testing.T, filler string, n int) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "spew.sh")
+	script := "#!/bin/sh\nyes '" + filler + "' | head -c " + strconv.Itoa(n) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	prev := pdftotextBin
+	pdftotextBin = path
+	t.Cleanup(func() { pdftotextBin = prev })
+}
+
+// A PDF's text layer can be far larger than the file itself, so the extractor's output is
+// not bounded by the upload limit: a 472KB file has been observed yielding 12.6MB of text,
+// and the whole string then travels to the PII filter and the embedder. Bound what is
+// retained instead.
+func TestExtractPDFText_BoundsOutputSize(t *testing.T) {
+	stubPDFTool(t, "freehire", maxPDFTextBytes+512*1024)
+
+	text, err := ExtractPDFText([]byte("%PDF-1.4 stub"))
+	if err != nil {
+		t.Fatalf("ExtractPDFText: %v", err)
+	}
+	if len(text) > maxPDFTextBytes {
+		t.Errorf("extracted %d bytes, want at most the %d-byte cap", len(text), maxPDFTextBytes)
+	}
+	if len(text) == 0 {
+		t.Error("extracted nothing; the cap must truncate, not discard")
+	}
+}
+
+// Truncation lands wherever the cap falls, which for multi-byte text is mid-rune. The text
+// goes on to a JSON request body and an embedder, so it must stay valid UTF-8.
+func TestExtractPDFText_TruncatesOnARuneBoundary(t *testing.T) {
+	// U+2014 is three bytes, so the cap cannot fall on a rune boundary.
+	stubPDFTool(t, "———————————————", maxPDFTextBytes+512*1024)
+
+	text, err := ExtractPDFText([]byte("%PDF-1.4 stub"))
+	if err != nil {
+		t.Fatalf("ExtractPDFText: %v", err)
+	}
+	if !utf8.ValidString(text) {
+		t.Error("truncated text is not valid UTF-8")
 	}
 }
 

--- a/internal/resume/resume.go
+++ b/internal/resume/resume.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -251,14 +252,22 @@ func extractText(data []byte) (string, error) {
 // request; extracting a normal résumé is well under a second.
 const pdfExtractTimeout = 15 * time.Second
 
+// maxPDFTextBytes bounds the text one extraction retains. A PDF's text layer is not bounded
+// by the file: a 472KB upload has been observed yielding 12.6MB of text, and the whole string
+// then travels onward to the PII filter and the embedder, so the upload limit is not the
+// ceiling it looks like. Two megabytes is an order of magnitude past the densest real résumé
+// (a hundred pages of prose is a few hundred KB), so only a pathological document is ever
+// truncated — and for one of those, truncating beats propagating.
+const maxPDFTextBytes = 2 << 20
+
 // ExtractPDFText extracts plain text from PDF bytes, shared by the résumé store and the
 // upload handler (which wraps a returned error into a 400). It shells out to poppler's
 // pdftotext, which — unlike a pure-Go parser — decodes CID/Identity-H fonts through their
 // ToUnicode CMap (as produced by Canva and similar builders), where the previous library
 // silently returned empty text. The bytes go to a temp file (never onto argv) and the text
-// is read from stdout. A non-zero exit (corrupt/undecodable PDF) is an error; a clean run
-// yielding no text (an image-only PDF with no text layer) returns ("", nil), which the
-// handler renders as the "scan or image" rejection.
+// is read from stdout, retaining at most maxPDFTextBytes. A non-zero exit (corrupt/undecodable
+// PDF) is an error; a clean run yielding no text (an image-only PDF with no text layer)
+// returns ("", nil), which the handler renders as the "scan or image" rejection.
 func ExtractPDFText(data []byte) (string, error) {
 	dir, err := os.MkdirTemp("", "resume-pdf-*")
 	if err != nil {
@@ -277,13 +286,52 @@ func ExtractPDFText(data []byte) (string, error) {
 	// Only fixed flags and a temp path reach argv: -q silences warnings on slightly
 	// malformed but readable PDFs; "-" writes the extracted text to stdout.
 	cmd := exec.CommandContext(ctx, pdftotextBin, "-q", "-nopgbrk", inPath, "-")
-	var out, errBuf bytes.Buffer
+	out := cappedBuffer{max: maxPDFTextBytes}
+	// stderr only ever becomes part of an error message, so a few kilobytes is plenty; it is
+	// bounded for the same reason stdout is.
+	errBuf := cappedBuffer{max: 8 << 10}
 	cmd.Stdout = &out
 	cmd.Stderr = &errBuf
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("resume: invalid PDF: %w: %s", err, strings.TrimSpace(errBuf.String()))
 	}
-	return out.String(), nil
+	return trimPartialRune(out.String()), nil
+}
+
+// cappedBuffer accumulates at most max bytes and discards the rest, so a subprocess writing
+// an unbounded amount of output cannot grow this process's heap with it.
+//
+// It reports the discarded bytes as written on purpose. Returning an error (or short count)
+// would break the child's stdout pipe mid-run and surface as a failed command, turning a
+// merely enormous document into an extraction error; the existing timeout is what bounds how
+// long the child may keep producing output nobody keeps.
+type cappedBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	if room := c.max - c.buf.Len(); room > 0 {
+		c.buf.Write(p[:min(room, len(p))])
+	}
+	return len(p), nil
+}
+
+func (c *cappedBuffer) String() string { return c.buf.String() }
+
+// trimPartialRune drops a trailing incomplete UTF-8 sequence, which truncating at a byte cap
+// leaves behind whenever the cap falls inside a multi-byte rune. The text goes on into a JSON
+// request body, an LLM prompt and an embedder, so it must not end mid-rune. A genuine U+FFFD
+// in the document decodes with size 3 and is left alone.
+func trimPartialRune(s string) string {
+	for s != "" {
+		if r, size := utf8.DecodeLastRuneInString(s); r == utf8.RuneError && size <= 1 {
+			s = s[:len(s)-1]
+			continue
+		}
+		break
+	}
+	return s
 }
 
 // QueriesRepository adapts *db.Queries to Repository, mapping the pointer to the nullable

--- a/internal/sources/alignerr.go
+++ b/internal/sources/alignerr.go
@@ -111,7 +111,9 @@ func (a alignerr) detail(ctx context.Context, e CompanyEntry, it alignerrListIte
 
 	description := sanitizeHTML(j.HTMLLongDescription)
 	if description == "" {
-		description = strings.TrimSpace(j.ShortDescription)
+		// The short field is feed-controlled too, and nothing guarantees it is free of
+		// markup — it goes through the same sanitizer as the long one.
+		description = strings.TrimSpace(sanitizeHTML(j.ShortDescription))
 	}
 	// The listing presents every posting's location as "Remote"; the detail's own location is
 	// the fallback when the listing item is absent.

--- a/internal/sources/alignerr_test.go
+++ b/internal/sources/alignerr_test.go
@@ -101,6 +101,35 @@ func TestAlignerrDropsInactiveAndMissingDetail(t *testing.T) {
 	}
 }
 
+// shortDescription is feed-controlled like htmlLongDescription, so the fallback must go
+// through the same sanitizer — the description is rendered with {@html}, where an <img> is
+// a tracking pixel fired against every viewer and an <iframe> is third-party content.
+func TestAlignerrSanitizesShortDescriptionFallback(t *testing.T) {
+	detail := `<script id="__NEXT_DATA__" type="application/json">` +
+		`{"props":{"pageProps":{"job":{"id":"aaa","name":"Task Author",` +
+		`"htmlLongDescription":"",` +
+		`"shortDescription":"Write tasks. <img src=\"https://tracker.example/p.gif\"><iframe src=\"https://evil.example\"></iframe>",` +
+		`"isActive":true,"jobType":"CONTRACT","location":"United States"}}}}` +
+		`</script>`
+	fake := (&routedHTTP{}).
+		route("/jobs/aaa", detail).
+		route("alignerr.com/jobs", alignerrListingJSON("aaa"))
+
+	jobs, err := NewAlignerr(fake).Fetch(context.Background(), CompanyEntry{Company: "Alignerr"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if got := jobs[0].Description; strings.Contains(got, "<img") || strings.Contains(got, "<iframe") {
+		t.Errorf("shortDescription fallback not sanitized: %q", got)
+	}
+	if !strings.Contains(jobs[0].Description, "Write tasks.") {
+		t.Errorf("Description lost real content: %q", jobs[0].Description)
+	}
+}
+
 func TestAlignerrEmploymentType(t *testing.T) {
 	cases := map[string]string{
 		"CONTRACT": "contract", "FULL_TIME": "full_time",

--- a/internal/sources/talentadore.go
+++ b/internal/sources/talentadore.go
@@ -71,7 +71,9 @@ func (s talentadore) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		location := joinNonEmpty(j.City, j.County, j.Country)
 		description := sanitizeHTML(j.DescriptionHTML)
 		if description == "" {
-			description = strings.TrimSpace(j.DescriptionText)
+			// The text field is feed-controlled too, and nothing guarantees it is free of
+			// markup — it goes through the same sanitizer as the HTML one.
+			description = strings.TrimSpace(sanitizeHTML(j.DescriptionText))
 		}
 		jobs = append(jobs, Job{
 			ExternalID:  token,

--- a/internal/sources/talentadore_test.go
+++ b/internal/sources/talentadore_test.go
@@ -107,6 +107,33 @@ func TestTalentAdoreFetch(t *testing.T) {
 	}
 }
 
+// The description_text fallback is feed-controlled like description_html, so it must go
+// through the same sanitizer: it reaches the SPA through {@html}, where an <img> is a
+// tracking pixel fired against every viewer and an <iframe> is third-party content.
+func TestTalentAdoreSanitizesTextFallback(t *testing.T) {
+	fake := &fakeHTTP{body: `{"jobs":[{
+		"job_token": "t1",
+		"name": "Designer",
+		"link": "https://ats.talentadore.com/apply/designer/t1",
+		"description_html": "",
+		"description_text": "Design things. <img src=\"https://tracker.example/p.gif\"><iframe src=\"https://evil.example\"></iframe>"
+	}]}`}
+
+	jobs, err := NewTalentAdore(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "b"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if got := jobs[0].Description; strings.Contains(got, "<img") || strings.Contains(got, "<iframe") {
+		t.Errorf("description_text fallback not sanitized: %q", got)
+	}
+	if !strings.Contains(jobs[0].Description, "Design things.") {
+		t.Errorf("Description lost real content: %q", jobs[0].Description)
+	}
+}
+
 func TestTalentAdoreSkipsMissingToken(t *testing.T) {
 	fake := &fakeHTTP{body: `{"jobs":[
 		{"job_token":"","name":"No Token","link":"x"},

--- a/internal/userprofile/userprofile.go
+++ b/internal/userprofile/userprofile.go
@@ -2,7 +2,7 @@
 // their professional self — a non-empty set of specializations (job categories) and a
 // non-empty set of skills — and can fetch, save (create-or-replace), and clear that one
 // profile. It owns validation (the specialization vocabulary and cap, skill
-// normalization); the Repository owns persistence and maps the no-row condition onto
+// normalization and cap); the Repository owns persistence and maps the no-row condition onto
 // ErrNotFound. There is at most one profile per user (keyed by user_id), so there is no
 // name, no id, and no cap. How a profile is consumed (match scoring, ranked feeds,
 // notifications) lives outside this package.
@@ -31,6 +31,8 @@ var (
 	ErrTooManySpecializations = errors.New("userprofile: too many specializations")
 	// ErrEmptySkills is a profile whose skills are empty after normalization (mapped to 400).
 	ErrEmptySkills = errors.New("userprofile: at least one skill is required")
+	// ErrTooManySkills is a wanted or avoided skill set past maxSkills (mapped to 400).
+	ErrTooManySkills = errors.New("userprofile: too many skills")
 	// ErrNotFound is the caller having no profile yet (mapped to a null payload on GET,
 	// 404 on the verdict/ATS sub-resources).
 	ErrNotFound = errors.New("userprofile: not found")
@@ -39,6 +41,19 @@ var (
 // maxSpecializations caps how many specializations one profile may combine; the
 // migration's cardinality CHECK is the backstop.
 const maxSpecializations = 5
+
+// maxSkills caps how many skills one profile may list, wanted or avoided. The wanted set is
+// not just stored: the coverage verdict turns it into one `skills != "<skill>"` AND group per
+// element (see search.AndNotSkills), so an unbounded list would balloon that Meilisearch
+// filter on every later read of the profile — against the same index that serves public
+// search. It is the ceiling the stateless coverage endpoint already applies to a supplied
+// list; the migration's cardinality CHECK is the backstop.
+const maxSkills = 100
+
+// maxSkillLen bounds one skill's length. The longest canonical form the skill dictionary can
+// emit is 30 characters, so this leaves generous room for a free-text entry while keeping a
+// single value from reaching the search filter as a multi-kilobyte literal.
+const maxSkillLen = 64
 
 // Profile is the user's saved professional profile: their specializations (job
 // categories) and skills, plus optional location preferences kept as raw JSON
@@ -96,7 +111,11 @@ func (s *Service) Save(ctx context.Context, userID int64, specializations, skill
 	if err != nil {
 		return Profile{}, err
 	}
-	excluded := subtractSkills(normalizeExcludedSkills(excludedSkills), normalized)
+	avoided, err := normalizeSkillList(excludedSkills)
+	if err != nil {
+		return Profile{}, err
+	}
+	excluded := subtractSkills(avoided, normalized)
 	locJSON, err := normalizeLocationPreferences(loc)
 	if err != nil {
 		return Profile{}, err
@@ -141,27 +160,32 @@ func normalizeSpecializations(specializations []string) ([]string, error) {
 	return out, nil
 }
 
-// normalizeSkills lowercases, trims, and deduplicates the skills (preserving first-seen
-// order), dropping blanks. It returns ErrEmptySkills if nothing remains — a profile without
-// skills has no meaning.
+// normalizeSkills normalizes the wanted skills and additionally requires the set to be
+// non-empty — a profile without skills has no meaning.
 func normalizeSkills(skills []string) ([]string, error) {
-	out := normalizeExcludedSkills(skills)
+	out, err := normalizeSkillList(skills)
+	if err != nil {
+		return nil, err
+	}
 	if len(out) == 0 {
 		return nil, ErrEmptySkills
 	}
 	return out, nil
 }
 
-// normalizeExcludedSkills lowercases, trims, and deduplicates a skill list (preserving
-// first-seen order), dropping blanks. Unlike normalizeSkills it never errors: an empty set
-// is valid (the user need not avoid anything). It always returns a non-nil slice so the
-// value persists as an empty array, not NULL.
-func normalizeExcludedSkills(skills []string) []string {
+// normalizeSkillList lowercases, trims, and deduplicates a skill list (preserving first-seen
+// order), and caps it at maxSkills. A per-value problem drops that value: blanks, and anything
+// past maxSkillLen — a string that long is not a skill, and losing one junk entry beats
+// failing an otherwise valid save. A whole-list problem errors: a set past the cardinality cap
+// returns ErrTooManySkills, mirroring normalizeSpecializations. An empty result is valid here
+// (the user need not avoid anything), and the slice is always non-nil so the value persists as
+// an empty array, not NULL.
+func normalizeSkillList(skills []string) ([]string, error) {
 	out := make([]string, 0, len(skills))
 	seen := make(map[string]struct{}, len(skills))
 	for _, raw := range skills {
 		skill := strings.ToLower(strings.TrimSpace(raw))
-		if skill == "" {
+		if skill == "" || len(skill) > maxSkillLen {
 			continue
 		}
 		if _, dup := seen[skill]; dup {
@@ -170,7 +194,10 @@ func normalizeExcludedSkills(skills []string) []string {
 		seen[skill] = struct{}{}
 		out = append(out, skill)
 	}
-	return out
+	if len(out) > maxSkills {
+		return nil, ErrTooManySkills
+	}
+	return out, nil
 }
 
 // subtractSkills returns the values in a that are not in remove, preserving a's order. It

--- a/internal/userprofile/userprofile_test.go
+++ b/internal/userprofile/userprofile_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -144,6 +145,69 @@ func TestSave_RejectsEmptySkills(t *testing.T) {
 				t.Error("repo.Upsert should not be called on empty skills")
 			}
 		})
+	}
+}
+
+// manySkills builds n distinct skills, enough to cross a cardinality cap.
+func manySkills(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = "skill" + strconv.Itoa(i)
+	}
+	return out
+}
+
+// The saved skill list becomes one `skills != "…"` AND group per element in the coverage
+// verdict's Meilisearch filter, so an unbounded list is a stored amplification of every
+// later read against the index that also serves public search.
+func TestSave_RejectsTooManySkills(t *testing.T) {
+	repo := &fakeRepo{}
+	_, err := userprofile.New(repo).Save(context.Background(), 7,
+		[]string{"backend"}, manySkills(101), nil, nil)
+	if !errors.Is(err, userprofile.ErrTooManySkills) {
+		t.Errorf("err = %v, want ErrTooManySkills", err)
+	}
+	if repo.upsertCalled {
+		t.Error("repo.Upsert should not be called past the skill cap")
+	}
+}
+
+func TestSave_AcceptsSkillsAtTheCap(t *testing.T) {
+	repo := &fakeRepo{upsertRet: userprofile.Profile{UserID: 7}}
+	_, err := userprofile.New(repo).Save(context.Background(), 7,
+		[]string{"backend"}, manySkills(100), nil, nil)
+	if err != nil {
+		t.Fatalf("Save at the cap: %v", err)
+	}
+	if len(repo.upserted.Skills) != 100 {
+		t.Errorf("persisted %d skills, want all 100 at the cap", len(repo.upserted.Skills))
+	}
+}
+
+func TestSave_RejectsTooManyExcludedSkills(t *testing.T) {
+	repo := &fakeRepo{}
+	_, err := userprofile.New(repo).Save(context.Background(), 7,
+		[]string{"backend"}, []string{"go"}, manySkills(101), nil)
+	if !errors.Is(err, userprofile.ErrTooManySkills) {
+		t.Errorf("err = %v, want ErrTooManySkills", err)
+	}
+	if repo.upsertCalled {
+		t.Error("repo.Upsert should not be called past the excluded-skill cap")
+	}
+}
+
+// A value far longer than any canonical skill is junk, not a skill, and is dropped the way
+// blanks and duplicates already are — a per-value problem does not fail the whole save.
+func TestSave_DropsOverlongSkills(t *testing.T) {
+	repo := &fakeRepo{upsertRet: userprofile.Profile{UserID: 7}}
+	_, err := userprofile.New(repo).Save(context.Background(), 7,
+		[]string{"backend"}, []string{"go", strings.Repeat("x", 200)}, nil, nil)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	want := []string{"go"}
+	if strings.Join(repo.upserted.Skills, ",") != strings.Join(want, ",") {
+		t.Errorf("Skills = %v, want the overlong value dropped %v", repo.upserted.Skills, want)
 	}
 }
 

--- a/migrations/0056_user_profile_skills_cap.sql
+++ b/migrations/0056_user_profile_skills_cap.sql
@@ -1,0 +1,29 @@
+-- Bound the cardinality of the user profile's skill sets, the backstop for the cap
+-- internal/userprofile now enforces (maxSkills = 100).
+--
+-- Why it matters beyond storage: the coverage verdict turns the wanted set into one
+-- `skills != "<skill>"` AND group per element (search.AndNotSkills), so the list is a
+-- multiplier on every later read of the profile — against the same Meilisearch index that
+-- serves public /jobs/search. specializations has carried a cardinality CHECK since 0001 and
+-- the stateless coverage endpoint has capped a supplied list at 100 all along; the profile —
+-- the one path that PERSISTS the list, and so lets one write amplify unboundedly many cheap
+-- reads — was the entry point without a cap.
+--
+-- NOT VALID is deliberate. It enforces the bound on every INSERT and UPDATE from here on
+-- (which is all the backstop is for) while skipping the validation scan of existing rows, so
+-- the statement takes no lengthy lock and cannot fail the migration on a legacy row written
+-- before the application cap existed. Such a row can only shrink: the service normalizes
+-- every write to at most 100 skills before SQL sees it. To promote it later, once prod is
+-- known clean: ALTER TABLE public.user_profiles VALIDATE CONSTRAINT <name>.
+--
+-- Applied to a fresh volume by initdb after 0055; on an existing prod volume run manually
+-- (SET ROLE hire). Safe in either order relative to the image — the new binary writes lists
+-- that already satisfy the bound, and the old binary is unaffected by a constraint it never
+-- crosses.
+ALTER TABLE public.user_profiles
+    ADD CONSTRAINT user_profiles_skills_card_chk
+    CHECK (cardinality(skills) <= 100) NOT VALID;
+
+ALTER TABLE public.user_profiles
+    ADD CONSTRAINT user_profiles_excluded_skills_card_chk
+    CHECK (cardinality(excluded_skills) <= 100) NOT VALID;


### PR DESCRIPTION
## What and why

Five independent bounds/guards found in review, each one an input that reaches a shared
resource without a ceiling. No behaviour changes for a legitimate caller except a new 400
past the skill cap.

### `fix(sources)`: the plain-text description fallback was not sanitized

`talentadore` and `alignerr` sanitized their HTML description field but assigned the feed's
*text* field raw when the HTML one was empty. Both reach the SPA through `{@html}`
(`JobDescription.svelte`, `SwipeDeck.svelte`, both commented "server-sanitized"), and
`descriptionPolicy` exists precisely to strip what a posting must not render there — an
`<img>` tracking pixel fired against every viewer, an `<iframe>`, a `<form>`. Nothing
guarantees a feed's "text" field is free of markup. These were the only two adapters with
this shape; `earcu`'s fallback sanitizes internally, `wantapply`'s already wraps.

### `fix(userprofile)`: the profile's skill sets had no cardinality bound

Only a non-empty check in the service and `cardinality(skills) > 0` in SQL, while the
neighbouring `specializations` carried a cap of 5 in both places. It is not inert storage:
the coverage verdict expands the wanted set into one `skills != "<skill>"` AND group per
element (`search.AndNotSkills`), so one `PUT /me/profile` of ~10^5 skills turns every later
cheap `GET /me/resume/verdict` into a vast Meilisearch filter — against the same index that
serves public `/jobs/search`, on a route with no throttle. The 8MB body limit admits that
many distinct values with room to spare.

`/market/coverage` and the assistant tool both cap a supplied list at 100 with that
reasoning written out in a comment. The profile — the one entry point that *persists* the
list, so a single write amplifies unboundedly many reads — did not. Both sets are now capped
at the same 100; values past 64 characters (the longest canonical skill the dictionary emits
is 30) are dropped the way blanks and duplicates already are.

Migration `0056` adds the SQL backstop `NOT VALID`: it guards every future INSERT/UPDATE
(verified by hand) without a validation scan, so it takes no lengthy lock and cannot fail the
migration on a row written before the application cap existed. Such a row can only shrink —
the service normalizes every write before SQL sees it. Safe to apply in either order relative
to the image.

### `fix(mailbox)`: reserved local-parts were allocatable

The handle derives from the user's email local-part and `Candidate` returns the bare base for
`n<=1`, so registering with an address whose local-part is `postmaster` was enough to be
handed `postmaster@` on the receiving domain. Two things live at those names: mail *about* the
service (an abuse report delivered into a stranger's job inbox is a report nobody reads) and
the CA/Browser Forum's constructed-email domain validation, which issues a certificate to
whoever answers admin/administrator/webmaster/hostmaster/postmaster at the domain.

The allocator now skips a reserved candidate rather than claiming it, so such a user gets the
next suffix. Matching is on the exact local-part — `postmaster-2` is not an operational
address and stays claimable.

**Prospective only.** It does not reclaim an address already handed out; worth checking prod
for an existing holder.

### `fix(accounts)`: burning a code lifted the resend cooldown

Reaching the attempt ceiling deleted the code's row, and `issueCode` reads the resend
cooldown off that row — so burning a code was the cheapest way to get a fresh one, with no
wait at all. The ceiling then bounded nothing: five guesses plus one round-trip, repeated, is
an unbounded guessing rate against a six-digit secret, with only the 10/min per-IP credential
limiter in the way.

A burnt code now keeps its row and `consumeCode` rejects it on the recorded attempt count
before checking the hash. The two bounds compose as designed — `maxCodeAttempts` guesses per
`resendCooldown` — and nothing lingers: `UpsertEmailCode` already resets `attempts` and
re-stamps `created_at` when the next code is issued.

The burn test asserted the deletion, which was the defect itself. It now asserts what the
design promises: the code is dead, the row survives, and only a successful consume deletes.

### `fix(resume)`: `pdftotext` output was unbounded

It wrote into an unbounded `bytes.Buffer`, and a PDF's text layer is not bounded by the file:
a 472KB upload has been observed yielding 12.6MB of text in 1.5s, so the 8MB body limit is
not the ceiling it looks like. The whole string then travels to the PII filter and the
embedder. Concurrent uploads of a pathological document are an OOM, not a slow request.

Retain at most 2MB — an order of magnitude past the densest real CV, so only a pathological
document is truncated — and bound stderr too, since it only becomes part of an error message.
The capped writer reports discarded bytes as written rather than erroring: breaking the
child's pipe would turn a merely enormous document into a *failed* extraction, and
`pdfExtractTimeout` already bounds how long it may keep producing output nobody keeps.
Truncation trims a trailing partial rune, since the cap lands mid-rune in multi-byte text and
the result goes on into a JSON body, a prompt and an embedder.

## Spec note

`openspec/specs/search-profiles/spec.md` states the skill-normalization rules ("A profile's
`skills` set SHALL be non-empty after normalization") and the specialization cap, so it now
under-describes the behaviour by one rule. Not filed as an OpenSpec change here — happy to
add the delta if you'd rather the spec lead.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean.
- `go test ./...` green; `-race` green on all five touched packages.
- `go test -tags=integration ./internal/db/` green (29.7s) — the harness applies every
  migration, including `0056`.
- `make sqlc` regenerated with no diff (the migration adds no columns).
- Migration applied to a scratch Postgres 16 by hand: all 56 files apply, both constraints
  land as `NOT VALID` (`convalidated = f`), 100 skills accepted, 101 rejected.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [x] I regenerated committed artifacts when their source changed (`make sqlc` — no diff).
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary — five guards on existing paths.
