### PR TITLE
feat(sources): onboard five contributed boards + fix the Huntflow board derivation

### DIFF
--- a/internal/atsboard/AGENTS.md
+++ b/internal/atsboard/AGENTS.md
@@ -17,10 +17,16 @@ nothing but the URL. No network, no database.
   contribution and paid for, and board coverage finds no adapter to read it with. Factorial was
   exactly this: `<tenant>.factorialhr.<tld>` mapped to a `factorialhr` source that does not
   exist, while one adapter serves both domains as `factorial`.
-- **Adding an ATS is one row plus one test case.** Five extraction modes say where the tenant
-  sits: `path` (first path segment), `pathlocale` (same, skipping a leading `xx-XX` locale),
-  `subdomain` (leftmost DNS label), `host` (the whole careers host IS the tenant), `hostpath`
-  (host + first path segment, for Workday).
+- **Adding an ATS is one row plus one test case.** Extraction modes say where the tenant sits:
+  `path` (first path segment), `pathlocale` (same, skipping a leading `xx-XX` locale),
+  `pathportal` (the segment before the posting, for SmartRecruiters' portal URLs), `subdomain`
+  (leftmost DNS label), `subdomainchain` (every label under the apex, for a tenant nested under a
+  regional instance like `<tenant>.global.huntflow.io`), `host` (the whole careers host IS the
+  tenant), `hostpath` (host + first path segment, for Workday).
+- **The mode must match how the ingest adapter addresses the board**, not how the URL reads. The
+  board string is copied verbatim into `sources/<provider>.yml` and into the `external_id`
+  namespace, so a truncated one is a board that 404s every crawl: Huntflow's adapter fetches
+  `<board>.huntflow.io`, which is why a regional tenant's board keeps its `.global` label.
 - **Fail-safe by construction.** A wrong or missing entry makes a link *unrecognised*, never a
   false board: a bad apex or mode yields an empty board, which is declined. So a best-guess
   host is safe to add.

--- a/internal/atsboard/board.go
+++ b/internal/atsboard/board.go
@@ -31,20 +31,26 @@ import (
 //     the same posting both bare (<company>/<posting>) and behind a portal segment
 //     (<portal>/<company>/<posting>). Taking the first segment reads the portal slug as a board.
 //   - subdomain: board = the leftmost DNS label under a fixed apex (<board>.recruitee.com).
+//   - subdomainchain: board = EVERY label under the apex, because the platform nests a tenant
+//     under a regional instance — Huntflow serves its international tenants at
+//     <tenant>.global.huntflow.io and its adapter fetches <board>.huntflow.io, so the board is
+//     "<tenant>.global"; taking the leftmost label alone yields a host that 404s.
 //   - host:      board = the whole careers host (the tenant identity IS the host, and the TLD
 //     varies by region, e.g. <tenant>.zohorecruit.eu / .com / .in).
 //   - hostpath:  board = "<host>/<first path segment>" (Workday: the tenant is the host, the
 //     site is the first path segment, e.g. acme.wd1.myworkdayjobs.com/Careers).
 //
-// For subdomain and host the board IS the host; for hostpath it is host + site. In all these the
-// canonical URL is stripped to that board, collapsing a vacancy URL and the board listing to one.
+// For subdomain, subdomainchain and host the board IS the host; for hostpath it is host + site.
+// In all these the canonical URL is stripped to that board, collapsing a vacancy URL and the
+// board listing to one.
 const (
-	modePath       = "path"
-	modePathLocale = "pathlocale"
-	modePathPortal = "pathportal"
-	modeSubdomain  = "subdomain"
-	modeHost       = "host"
-	modeHostPath   = "hostpath"
+	modePath           = "path"
+	modePathLocale     = "pathlocale"
+	modePathPortal     = "pathportal"
+	modeSubdomain      = "subdomain"
+	modeSubdomainChain = "subdomainchain"
+	modeHost           = "host"
+	modeHostPath       = "hostpath"
 )
 
 // atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
@@ -82,7 +88,6 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"bamboohr.com", "bamboohr", modeSubdomain},
 	{"breezy.hr", "breezy", modeSubdomain},
 	{"freshteam.com", "freshteam", modeSubdomain},
-	{"huntflow.io", "huntflow", modeSubdomain},
 	{"peopleforce.io", "peopleforce", modeSubdomain},
 	{"jobs.personio.com", "personio", modeSubdomain},
 	{"jobs.personio.de", "personio", modeSubdomain}, // Personio DE regional host; board = same tenant subdomain
@@ -106,6 +111,9 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"vagas.solides.com.br", "solides", modeSubdomain},
 	{"softgarden.io", "softgarden", modeSubdomain},
 	{"careers.hibob.com", "hibob", modeSubdomain}, // HiBob's careers module: <tenant>.careers.hibob.com
+
+	// --- subdomainchain: board = every label under the apex (tenant nested under a region) ---
+	{"huntflow.io", "huntflow", modeSubdomainChain},
 
 	// --- host: board = the whole careers host (regional TLD varies) ---
 	{"zohorecruit", "zohorecruit", modeHost},
@@ -132,9 +140,11 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 	}
 
 	switch mode {
-	case modeSubdomain, modeHost:
+	case modeSubdomain, modeSubdomainChain, modeHost:
 		if mode == modeSubdomain {
 			board = subdomainLabel(host, apex)
+		} else if mode == modeSubdomainChain {
+			board = subdomainChain(host, apex)
 		} else if !platformHost(host) {
 			board = host // the whole careers host is the tenant identity
 		}
@@ -217,13 +227,20 @@ func matchHost(host string) (source, mode, apex string, ok bool) {
 	return "", "", "", false
 }
 
+// subdomainChain returns every DNS label of host under apex:
+// "thefjx.global.huntflow.io","huntflow.io" → "thefjx.global"; "huntflow.io",… → "" (no tenant).
+func subdomainChain(host, apex string) string {
+	sub := strings.TrimSuffix(host, "."+apex)
+	if sub == host {
+		return ""
+	}
+	return sub
+}
+
 // subdomainLabel returns the leftmost DNS label of host under apex:
 // "acme.recruitee.com","recruitee.com" → "acme"; "recruitee.com",… → "" (no tenant).
 func subdomainLabel(host, apex string) string {
-	sub := strings.TrimSuffix(host, "."+apex)
-	if sub == host || sub == "" {
-		return ""
-	}
+	sub := subdomainChain(host, apex)
 	if i := strings.IndexByte(sub, '.'); i >= 0 {
 		return sub[:i]
 	}

--- a/internal/atsboard/board_test.go
+++ b/internal/atsboard/board_test.go
@@ -50,6 +50,13 @@ func TestRecognize(t *testing.T) {
 		{"hibob careers subdomain", "https://qogita.careers.hibob.com/jobs/ceb6c947-c906-44d1-a56b-bb33ae5599fa", "hibob", "qogita", "https://qogita.careers.hibob.com", true},
 		{"hibob apply tail collapses to the same board", "https://unique.careers.hibob.com/jobs/f8d9a0bc/apply", "hibob", "unique", "https://unique.careers.hibob.com", true},
 
+		// subdomainchain — Huntflow nests its international tenants under a "global" label, and
+		// the adapter fetches <board>.huntflow.io, so the board must carry that label too;
+		// the leftmost label alone ("thefjx") is a host that 404s.
+		{"huntflow regional tenant keeps the region label", "https://thefjx.global.huntflow.io/vacancy/rust-developer-2", "huntflow", "thefjx.global", "https://thefjx.global.huntflow.io", true},
+		{"huntflow plain tenant", "https://flowwow.huntflow.io/vacancy/123", "huntflow", "flowwow", "https://flowwow.huntflow.io", true},
+		{"huntflow bare apex no tenant", "https://huntflow.io/", "", "", "", false},
+
 		// host mode — board is the whole careers host, regional TLD varies
 		{"zoho eu vacancy strips encoded path + query", "https://be-exec.zohorecruit.eu/jobs/Careers/73534000009044079/%D0%9F%D1%80%D0%BE?source=CareerSite", "zohorecruit", "be-exec.zohorecruit.eu", "https://be-exec.zohorecruit.eu", true},
 		{"zoho com host", "https://kaptiva.zohorecruit.com/jobs/Careers/568", "zohorecruit", "kaptiva.zohorecruit.com", "https://kaptiva.zohorecruit.com", true},

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7622,3 +7622,7 @@
   board: walrus
 - company: XMTP Labs
   board: XMTP Labs
+
+# --- contributed boards ---
+- company: Passage Health
+  board: passagehealth

--- a/sources/gupy.yml
+++ b/sources/gupy.yml
@@ -2913,3 +2913,5 @@
 # --- contributed boards ---
 - company: Realco Soluções em Gestão de Pessoas
   board: "21289"
+- company: Phiz Chat
+  board: "91018"

--- a/sources/huntflow.yml
+++ b/sources/huntflow.yml
@@ -13,6 +13,10 @@
   board: coffeemaniahr
 - company: Flowwow
   board: flowwow
+# FJX Group hosts its board on Huntflow's international instance, so the board carries the
+# ".global" label too (thefjx.global.huntflow.io); the bare subdomain 404s.
+- company: FJX Group
+  board: thefjx.global
 - company: Huntflow Opportunities
   board: opportunities
 - company: itoolabs

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -43,3 +43,7 @@
   board: zarego
 - company: Alcor
   board: alcor
+
+# --- contributed boards ---
+- company: Tidal
+  board: hiretidal

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1410,3 +1410,7 @@
   board: futureplc
 - company: Base.
   board: base-com
+
+# --- contributed boards ---
+- company: Pion
+  board: wearepion


### PR DESCRIPTION
Drains the `link_contributions` queue on prod: 3 `pending` rows and 2 `review` rows that
resolved to platforms we already crawl. Every board was validated live before adding.

## Boards

| source | board | company | live check |
|---|---|---|---|
| huntflow | `thefjx.global` | FJX Group | 6 open vacancies via `_payload.json` |
| ashby | `passagehealth` | Passage Health | 7 postings via the posting API |
| workable | `wearepion` | Pion | 13 postings via the widget API |
| gupy | `91018` | Phiz Chat | postings via `employability-portal` |
| manatal | `hiretidal` | Tidal | `count: 187` via the career-page API |

`hiretidal.com` fronts `careers-page.com/hiretidal`, which is Manatal — the vanity domain is
why the recognizer declined it. Gupy boards are numeric `companyId`s, not derivable from a URL
at all, so that link landed in review by design.

## Recognizer fix

`thefjx.global.huntflow.io` was recorded as board `thefjx`. Subdomain mode takes the leftmost
DNS label, but Huntflow's adapter fetches `<board>.huntflow.io` — the bare `thefjx` host 404s.
Copied verbatim into `sources/huntflow.yml` (which the onboarding rule mandates, so the
already-tracked dedup matches) it would have burnt a crawl slot every cycle. The already-tracked
`tteam.global` entry shows the shape the adapter expects.

Adds a `subdomainchain` mode (board = every label under the apex) and moves the huntflow row
onto it. Single-label tenants resolve exactly as before; `subdomainLabel` is now that function
plus a truncation.

## Verification

- `go build ./...`, `go vet ./internal/atsboard/`, `gofmt` clean
- `go test ./internal/atsboard/ ./internal/sources/ ./internal/contribution/` — pass (the
  `sources` suite validates every edited board file through `LoadConfig`)
- 3 new test cases: regional tenant keeps `.global`, plain tenant unchanged, bare apex declined

Prod `link_contributions` statuses get flipped after this merges (sources sync from
`origin/main` on deploy). Crawling starts on the next ingest cycle.