### PR TITLE
fix(userprofile): set the skill cap by what real profiles hold

### DIFF
--- a/internal/handler/me_profile.go
+++ b/internal/handler/me_profile.go
@@ -136,7 +136,7 @@ func profileError(err error) error {
 	case errors.Is(err, userprofile.ErrEmptySkills):
 		return fiber.NewError(fiber.StatusBadRequest, "at least one skill is required")
 	case errors.Is(err, userprofile.ErrTooManySkills):
-		return fiber.NewError(fiber.StatusBadRequest, "too many skills (max 100)")
+		return fiber.NewError(fiber.StatusBadRequest, "too many skills (max 200)")
 	case errors.Is(err, userprofile.ErrInvalidWorkMode):
 		return fiber.NewError(fiber.StatusBadRequest, "work mode is not a known value")
 	case errors.Is(err, userprofile.ErrInvalidRegion):

--- a/internal/userprofile/userprofile.go
+++ b/internal/userprofile/userprofile.go
@@ -46,9 +46,15 @@ const maxSpecializations = 5
 // not just stored: the coverage verdict turns it into one `skills != "<skill>"` AND group per
 // element (see search.AndNotSkills), so an unbounded list would balloon that Meilisearch
 // filter on every later read of the profile — against the same index that serves public
-// search. It is the ceiling the stateless coverage endpoint already applies to a supplied
-// list; the migration's cardinality CHECK is the backstop.
-const maxSkills = 100
+// search. The migration's cardinality CHECK is the backstop.
+//
+// The number is set by what real profiles hold, not by symmetry with the stateless coverage
+// endpoint's 100. Measured on prod: of 131 profiles, 89% list 50 skills or fewer, but the
+// largest lists 90 — so a ceiling of 100 left a live user 10 of headroom, and the CV-autofill
+// path unions extracted skills into whatever is already in the form. 200 keeps that user
+// clear of the bound while still bounding the filter: 90 groups already run against prod's
+// index today, and the guard is against a list of 10^5, not against a long CV.
+const maxSkills = 200
 
 // maxSkillLen bounds one skill's length. The longest canonical form the skill dictionary can
 // emit is 30 characters, so this leaves generous room for a free-text entry while keeping a

--- a/internal/userprofile/userprofile_test.go
+++ b/internal/userprofile/userprofile_test.go
@@ -163,7 +163,7 @@ func manySkills(n int) []string {
 func TestSave_RejectsTooManySkills(t *testing.T) {
 	repo := &fakeRepo{}
 	_, err := userprofile.New(repo).Save(context.Background(), 7,
-		[]string{"backend"}, manySkills(101), nil, nil)
+		[]string{"backend"}, manySkills(201), nil, nil)
 	if !errors.Is(err, userprofile.ErrTooManySkills) {
 		t.Errorf("err = %v, want ErrTooManySkills", err)
 	}
@@ -175,19 +175,19 @@ func TestSave_RejectsTooManySkills(t *testing.T) {
 func TestSave_AcceptsSkillsAtTheCap(t *testing.T) {
 	repo := &fakeRepo{upsertRet: userprofile.Profile{UserID: 7}}
 	_, err := userprofile.New(repo).Save(context.Background(), 7,
-		[]string{"backend"}, manySkills(100), nil, nil)
+		[]string{"backend"}, manySkills(200), nil, nil)
 	if err != nil {
 		t.Fatalf("Save at the cap: %v", err)
 	}
-	if len(repo.upserted.Skills) != 100 {
-		t.Errorf("persisted %d skills, want all 100 at the cap", len(repo.upserted.Skills))
+	if len(repo.upserted.Skills) != 200 {
+		t.Errorf("persisted %d skills, want all 200 at the cap", len(repo.upserted.Skills))
 	}
 }
 
 func TestSave_RejectsTooManyExcludedSkills(t *testing.T) {
 	repo := &fakeRepo{}
 	_, err := userprofile.New(repo).Save(context.Background(), 7,
-		[]string{"backend"}, []string{"go"}, manySkills(101), nil)
+		[]string{"backend"}, []string{"go"}, manySkills(201), nil)
 	if !errors.Is(err, userprofile.ErrTooManySkills) {
 		t.Errorf("err = %v, want ErrTooManySkills", err)
 	}

--- a/migrations/0057_user_profile_skills_cap_200.sql
+++ b/migrations/0057_user_profile_skills_cap_200.sql
@@ -1,0 +1,29 @@
+-- Raise the user profile's skill-set cardinality bound from 100 to 200, matching
+-- internal/userprofile's maxSkills.
+--
+-- 0056_user_profile_skills_cap picked 100 for symmetry with the stateless coverage endpoint,
+-- on the assumption that a real profile lists well under it. Prod says otherwise: of 131
+-- profiles, 89% list 50 skills or fewer, but the largest lists 90 — ten short of the bound.
+-- The CV-autofill path unions extracted skills into whatever the form already holds, so that
+-- user could cross it and be refused a save. The purpose of the bound is to stop a list of
+-- 10^5 from expanding into a Meilisearch filter of 10^5 AND groups on every read; 200 serves
+-- that just as well as 100, and 90 groups already run against prod's index today.
+--
+-- Dropped and re-added rather than altered, because Postgres has no ALTER CONSTRAINT for a
+-- CHECK expression. Kept NOT VALID for the reason 0056 gives: the bound is enforced on every
+-- INSERT and UPDATE from here on, which is all a backstop is for, without a validation scan.
+-- Widening a bound can never reject a row the narrower one admitted, so this cannot fail on
+-- existing data. The table is small (131 rows) and the lock is momentary.
+ALTER TABLE public.user_profiles
+    DROP CONSTRAINT IF EXISTS user_profiles_skills_card_chk;
+
+ALTER TABLE public.user_profiles
+    ADD CONSTRAINT user_profiles_skills_card_chk
+    CHECK (cardinality(skills) <= 200) NOT VALID;
+
+ALTER TABLE public.user_profiles
+    DROP CONSTRAINT IF EXISTS user_profiles_excluded_skills_card_chk;
+
+ALTER TABLE public.user_profiles
+    ADD CONSTRAINT user_profiles_excluded_skills_card_chk
+    CHECK (cardinality(excluded_skills) <= 200) NOT VALID;

--- a/openspec/changes/cap-profile-skills/.openspec.yaml
+++ b/openspec/changes/cap-profile-skills/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/cap-profile-skills/proposal.md
+++ b/openspec/changes/cap-profile-skills/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+A profile's `skills` set had no cardinality bound: the service only required it to be
+non-empty and SQL only carried `cardinality(skills) > 0`, while the neighbouring
+`specializations` was capped at 5 in both places. That asymmetry mattered because the set is
+not inert storage. The coverage verdict expands it into one `skills != "<skill>"` AND group
+per element (`search.AndNotSkills`), so a single `PUT /me/profile` of ~10^5 skills turned
+every later, cheap `GET /me/resume/verdict` into a vast Meilisearch filter — against the same
+index that serves public `/jobs/search`, on a route with no throttle. The 8MB body limit
+admits that many distinct values with room to spare.
+
+Two sibling entry points for the same list — the stateless `/market/coverage` and the
+assistant's coverage tool — already cap a supplied list at 100, each with the reasoning
+written out in a comment. The profile, the one entry point that *persists* the list and so
+lets one write amplify unboundedly many reads, was the one without a cap.
+
+The bound shipped at 100 and is being raised to 200 in the same change, because prod data
+contradicted the assumption behind 100: of 131 profiles, 89% list 50 skills or fewer, but the
+largest lists **90** — ten short of the bound — and the CV-autofill path unions extracted
+skills into whatever the form already holds, so that user could cross it and be refused a
+save. 200 bounds the filter just as effectively; the guard is against a list of 10^5, not
+against a long CV.
+
+## What Changes
+
+- Both the wanted `skills` and the avoided `excluded_skills` sets are capped at 200 entries;
+  a set past the cap is rejected with `400`, mirroring how `specializations` past its cap of 5
+  is rejected.
+- A single value longer than 64 characters is **dropped**, not rejected — the same treatment
+  blanks and duplicates already get in that normalizer. A per-value problem does not fail an
+  otherwise valid save, and the longest canonical form the skill dictionary emits is 30
+  characters, so no real skill is affected.
+- A SQL backstop (`cardinality(...) <= 200` on both columns) is added `NOT VALID`: it guards
+  every future INSERT and UPDATE without a validation scan, so it takes no lengthy lock and
+  cannot fail the migration on a row written before the application cap existed. Such a row
+  can only shrink — the service normalizes every write before SQL sees it.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `search-profiles`: the skills-validation requirement gains a cardinality bound on both skill
+  sets and states what happens to an over-long value. The non-empty rule is unchanged.
+
+## Impact
+
+- **Code:** `internal/userprofile/userprofile.go` (`maxSkills`, `maxSkillLen`,
+  `normalizeSkillList`, `ErrTooManySkills`) and the error mapping in
+  `internal/handler/me_profile.go`. `normalizeExcludedSkills` was renamed to
+  `normalizeSkillList` — it is the shared core of both sets and now returns an error, so the
+  old name no longer described it.
+- **Data:** none. No existing row exceeds the bound (prod max is 90), so the constraints
+  admit the whole table as it stands.
+- **Migrations:** `0056_user_profile_skills_cap.sql` (adds the constraints at 100) and
+  `0057_user_profile_skills_cap_200.sql` (drops and re-adds them at 200 — Postgres has no
+  ALTER CONSTRAINT for a CHECK expression). Widening can never reject a row the narrower bound
+  admitted, so 0057 cannot fail on existing data.
+- **Risk:** a caller who legitimately holds more than 200 skills would be refused a save. The
+  largest profile on prod holds 90, so the margin is a factor of two over the observed
+  maximum.

--- a/openspec/changes/cap-profile-skills/specs/search-profiles/spec.md
+++ b/openspec/changes/cap-profile-skills/specs/search-profiles/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Skills validation
+
+A profile's `skills` set SHALL be non-empty after normalization, and neither `skills` nor
+`excluded_skills` SHALL exceed 200 entries after normalization.
+
+The bound exists because the set is expanded per element into the coverage verdict's search
+filter (one `skills != "<skill>"` AND group each), so a stored list is a multiplier on every
+later read of the profile against the index that also serves public search. A set past the
+bound SHALL be rejected with `400` and nothing stored, exactly as a specialization set past
+its own cap is.
+
+A single skill longer than 64 characters SHALL be dropped from the set rather than rejecting
+the save, the same treatment blanks and duplicates receive: a per-value problem does not fail
+an otherwise valid save, and no canonical skill the dictionary emits approaches that length.
+
+#### Scenario: Empty skills rejected
+- **WHEN** an authenticated user saves a profile whose `skills` are absent, empty, or reduce to empty after trimming
+- **THEN** the system responds `400` and stores nothing
+
+#### Scenario: Too many skills rejected
+- **WHEN** an authenticated user saves a profile with more than 200 distinct skills, in either the wanted or the avoided set
+- **THEN** the system responds `400` and stores nothing
+
+#### Scenario: A skill set at the bound is stored whole
+- **WHEN** an authenticated user saves a profile with exactly 200 distinct skills
+- **THEN** the profile is stored with all 200
+
+#### Scenario: An over-long value is dropped, not rejected
+- **WHEN** an authenticated user saves a profile whose skills include a value longer than 64 characters alongside valid ones
+- **THEN** the profile is stored with the over-long value omitted and the valid skills kept

--- a/openspec/changes/cap-profile-skills/tasks.md
+++ b/openspec/changes/cap-profile-skills/tasks.md
@@ -1,0 +1,20 @@
+## 1. Cap the skill sets
+
+- [x] 1.1 Add failing tests to `internal/userprofile/userprofile_test.go`: a set past the cap returns `ErrTooManySkills` and does not reach the repository (for both the wanted and the avoided set); a set exactly at the cap is persisted whole; an over-long value is dropped while its valid siblings survive.
+- [x] 1.2 Add `maxSkills`, `maxSkillLen` and `ErrTooManySkills`; rename `normalizeExcludedSkills` to `normalizeSkillList` (it is the shared core of both sets and now returns an error, so the old name no longer described it) and apply both bounds there.
+- [x] 1.3 Map `ErrTooManySkills` to `400` in `profileError` (`internal/handler/me_profile.go`).
+- [x] 1.4 Add `migrations/0056_user_profile_skills_cap.sql` — both constraints `NOT VALID`, so the bound guards every future write without a validation scan or a lengthy lock.
+- [x] 1.5 Run `go test ./internal/userprofile/ ./internal/handler/`, `go build ./...`, `go vet ./...`, `gofmt -l`.
+
+## 2. Raise the bound to what real profiles hold
+
+- [x] 2.1 Measure prod: 131 profiles, 89% at 50 skills or fewer, maximum 90. A ceiling of 100 leaves a live user 10 of headroom while CV autofill unions more skills into the form.
+- [x] 2.2 Change the failing tests to the new bound: 200 accepted whole, 201 rejected.
+- [x] 2.3 Raise `maxSkills` to 200 and rewrite its comment to justify the number by the measurement rather than by symmetry with the coverage endpoint's 100. Update the `400` message.
+- [x] 2.4 Add `migrations/0057_user_profile_skills_cap_200.sql` — drop and re-add both constraints (no ALTER CONSTRAINT exists for a CHECK expression), still `NOT VALID`.
+- [x] 2.5 Verify the migration sequence on a scratch Postgres: every file applies in order, both constraints end at `<= 200` and `convalidated = f`, 200 skills accepted, 201 rejected.
+
+## 3. Rollout
+
+- [x] 3.1 `0056` applied to prod by `release.sh` during the release of the change that introduced it (`migrate: 72 file(s) on disk, 0 baselined, 1 applied`).
+- [ ] 3.2 `0057` applies on the next release — `release.sh` runs the migration runner before starting the new colour, and widening a bound cannot fail on existing data.


### PR DESCRIPTION
## What and why

Follow-up to #1274, driven by prod data rather than by symmetry.

`0056` capped a profile's skill sets at 100 for consistency with the stateless
`/market/coverage` endpoint, on the stated assumption that a real profile lists well under
it. Prod contradicts that: of **131 profiles, 89% list 50 skills or fewer, but the largest
lists 90** — ten short of the bound. The CV-autofill path unions extracted skills into
whatever the form already holds, so that user could cross 100 and be refused a save.

Distribution measured on prod:

| skills | profiles |
|---|---|
| ≤10 | 14 |
| ≤20 | 26 |
| ≤30 | 36 |
| ≤40 | 21 |
| ≤50 | 20 |
| ≤60 | 6 |
| ≤70 | 4 |
| <90 | 3 |
| 90 | 1 |

Raise the bound to **200**. It bounds the search filter just as effectively — the guard is
against a list of 10^5 expanding into 10^5 `skills != "…"` AND groups on every read, not
against a long CV, and 90 groups already run against prod's index today. Nobody is locked out
either way (90 < 100), so this is headroom, not a fix for a live break.

The migration drops and re-adds both constraints, because Postgres has no `ALTER CONSTRAINT`
for a CHECK expression. Still `NOT VALID`, for the reason `0056` gives; widening a bound can
never reject a row the narrower one admitted, so it cannot fail on existing data.

## Spec

Also files the OpenSpec change the shipped cap owed. `openspec/specs/search-profiles/spec.md`
stated the skills-validation rule with no cardinality bound, so the spec described one rule
less than the code. The delta modifies `Skills validation` to carry the bound, the `400`, and
what happens to an over-long value; `openspec validate cap-profile-skills` passes.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `TZ=UTC go test ./...` green.
- `openspec validate cap-profile-skills` → valid; delta parses with all four scenarios.
- Migration sequence replayed on a scratch Postgres 16: all 73 files apply, both constraints
  end at `<= 200` with `convalidated = f`, 200 skills accepted, 201 rejected.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes.
- [x] I regenerated committed artifacts when their source changed (no sqlc-visible change — the migration only alters a CHECK).
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary.
