### PR TITLE
feat(web): a /features/ghost-jobs landing that a test keeps honest

### DIFF
--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -22,6 +22,7 @@
         { label: 'Inbox', href: resolve('/features/inbox') },
         { label: 'CV tailoring', href: resolve('/features/tailor') },
         { label: 'Referrals', href: resolve('/features/referrals') },
+        { label: 'Ghost jobs', href: resolve('/features/ghost-jobs') },
       ],
     },
     {

--- a/web/src/lib/components/GhostLandingView.svelte
+++ b/web/src/lib/components/GhostLandingView.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { Check, Minus } from '@lucide/svelte';
+  import { Button } from '$lib/ui';
+  import NumberedGrid from '$lib/components/NumberedGrid.svelte';
+  import SectionLabel from '$lib/components/SectionLabel.svelte';
+  import { GHOST_FAQ } from '$lib/ghostFaq';
+  import { CONVERGENCE, GHOST_SIGNALS, WITNESS_GATE } from '$lib/ghostSignals';
+
+  // The signals render from the same array the checklist reads, so this page cannot
+  // fall behind the product — ghostSignals.test.ts fails if a criterion joins the
+  // vocabulary without an explanation. See hire-features-landing-space.
+  const structural = $derived(GHOST_SIGNALS.filter((s) => s.tier === 'structural'));
+  const outcome = $derived(GHOST_SIGNALS.filter((s) => s.tier === 'outcome'));
+
+  // Previews are MARKUP, never screenshots: a screenshot is light-theme, carries a
+  // real employer's name, and freezes a UI that changes. These are the real
+  // components' shapes, built from illustrative data.
+  const demoChecklist = [
+    {
+      label: 'Posting behaves as evergreen',
+      detail: 'Open 240 days · reposted 13× · 7 copies open at once',
+      fired: true,
+    },
+    {
+      label: "Not on the company's own careers board",
+      detail: 'Checked 2 days ago',
+      fired: true,
+    },
+    { label: 'Applications here went unanswered', detail: 'No data', fired: false },
+    { label: 'People reported no response', detail: 'No data', fired: false },
+  ];
+
+  const levels = [
+    {
+      chip: 'Possibly inactive',
+      scale: '2/4',
+      tone: 'muted' as const,
+      when: `${CONVERGENCE} criteria fired, but nobody who applied has told us anything`,
+    },
+    {
+      chip: 'Likely inactive',
+      scale: '3/4',
+      tone: 'warn' as const,
+      when: `at least ${WITNESS_GATE} different people who applied went unanswered, and something else fired too`,
+    },
+  ];
+
+  const toneClass = {
+    warn: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    muted: 'border-border text-muted-foreground',
+  };
+</script>
+
+<article class="flex flex-col gap-14">
+  <!-- Hero. The number does the arguing; the promise is deliberately small. -->
+  <header class="flex flex-col gap-5">
+    <SectionLabel text="ghost jobs" />
+    <h1 class="max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl">
+      Some postings are not being filled. freehire tells you which, and why it thinks so.
+    </h1>
+    <p class="max-w-2xl text-base leading-relaxed text-muted-foreground">
+      Between 18% and 27% of listings on the big boards are jobs nobody is working to fill —
+      kept up to collect CVs, to look like growth, or because nobody took them down. You cannot
+      tell from the page. Every hour spent on one is unpaid work you will never hear about.
+    </p>
+    <p class="max-w-2xl text-base leading-relaxed">
+      freehire watches two things it can actually check: how a posting behaves over time, and
+      what happened to people who applied. When enough of them line up, the job carries a mark
+      —&nbsp;and the facts behind it.
+    </p>
+    <div class="flex flex-wrap gap-3">
+      <Button href={resolve('/jobs')} variant="primary" size="lg">Browse jobs</Button>
+      <Button href={resolve('/my/tracking')} variant="ghost" size="lg">Track your applications</Button>
+    </div>
+  </header>
+
+  <!-- What it will not say. Placed before the mechanics on purpose: the limit is the
+       feature's most important property, not a disclaimer at the bottom. -->
+  <section class="flex flex-col gap-4">
+    <SectionLabel text="the line we do not cross" />
+    <div class="grid gap-4 sm:grid-cols-2">
+      <div class="rounded-lg border border-border p-4">
+        <p class="mb-1.5 text-sm font-medium">What we can check</p>
+        <p class="text-sm leading-relaxed text-muted-foreground">
+          “Open 240 days, reposted 13 times, seven copies live at once, and absent from the
+          employer's own careers board.” Every part of that is verifiable, and every part is
+          shown to you.
+        </p>
+      </div>
+      <div class="rounded-lg border border-dashed border-border p-4">
+        <p class="mb-1.5 text-sm font-medium text-muted-foreground">What we never claim</p>
+        <p class="text-sm leading-relaxed text-muted-foreground">
+          “This company is not really hiring.” That is a claim about somebody's intent, which
+          no amount of data here can observe. So the wording stays hedged, and the word
+          <em>ghost</em> never appears on a job.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- The four signals, rendered from the product's own vocabulary. -->
+  <section class="flex flex-col gap-6">
+    <SectionLabel text="the four signals" />
+    <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      Two describe the <strong class="font-medium text-foreground">posting</strong>. Two describe
+      what happened to a <strong class="font-medium text-foreground">person who applied</strong>.
+      Only the second kind can witness that a job is not being worked, so no quantity of the
+      first will ever produce the stronger warning.
+    </p>
+
+    <div class="flex flex-col gap-6">
+      {#each [{ heading: 'The shape of the posting', items: structural }, { heading: 'What happened to applicants', items: outcome }] as group (group.heading)}
+        <div class="flex flex-col gap-3">
+          <h3 class="text-sm font-semibold tracking-tight">{group.heading}</h3>
+          <ul class="flex flex-col gap-3">
+            {#each group.items as s (s.code)}
+              <li class="rounded-lg border border-border p-4">
+                <p class="text-sm font-medium">{s.label}</p>
+                <p class="mt-1 font-mono text-xs text-muted-foreground">{s.fact}</p>
+                <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{s.why}</p>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- The UI, as markup. -->
+  <section class="flex flex-col gap-6">
+    <SectionLabel text="what you actually see" />
+
+    <div class="flex flex-col gap-3">
+      <p class="text-sm text-muted-foreground">
+        On a card — a hedged chip and how many criteria fired out of how many were checked:
+      </p>
+      <div class="flex flex-wrap items-center gap-3 rounded-lg border border-border p-4">
+        {#each levels as l (l.chip)}
+          <span
+            class="inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium {toneClass[
+              l.tone
+            ]}"
+          >
+            {l.chip}
+            <span class="tabular-nums opacity-70">{l.scale}</span>
+          </span>
+        {/each}
+      </div>
+      <ul class="flex flex-col gap-1.5 text-sm text-muted-foreground">
+        {#each levels as l (l.chip)}
+          <li><strong class="font-medium text-foreground">{l.chip}</strong> — {l.when}.</li>
+        {/each}
+      </ul>
+    </div>
+
+    <div class="flex flex-col gap-3">
+      <p class="text-sm text-muted-foreground">
+        On the job page — the full checklist, <strong class="font-medium text-foreground"
+          >including what we do not know</strong
+        >. The empty rows are the point: they tell you why the warning is not stronger.
+      </p>
+      <section class="rounded-lg border border-border p-4">
+        <div class="mb-3 flex items-baseline justify-between gap-4">
+          <h3 class="text-sm font-semibold tracking-tight">
+            Signs this posting may be inactive
+          </h3>
+          <span class="text-xs tabular-nums text-muted-foreground">2 / 4</span>
+        </div>
+        <ul class="flex flex-col gap-2">
+          {#each demoChecklist as row (row.label)}
+            <li class="flex items-start gap-2.5 text-sm">
+              {#if row.fired}
+                <Check class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              {:else}
+                <Minus class="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
+              {/if}
+              <span class="flex min-w-0 flex-col">
+                <span class={row.fired ? '' : 'text-muted-foreground'}>{row.label}</span>
+                <span class="text-xs text-muted-foreground">{row.detail}</span>
+              </span>
+            </li>
+          {/each}
+        </ul>
+        <p class="mt-3 text-xs text-muted-foreground">
+          These are observations about the posting, not a claim about the employer.
+        </p>
+      </section>
+    </div>
+  </section>
+
+  <!-- How a report becomes evidence. -->
+  <section class="flex flex-col gap-5">
+    <SectionLabel text="your part" />
+    <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      The strongest signal is the one only you can give: you applied, and nobody ever answered.
+      Reporting it takes one date.
+    </p>
+    <NumberedGrid
+      items={[
+        {
+          n: '01',
+          title: 'Report the silence',
+          body: 'On the job, choose Report → “No response”. It asks when you applied — that date is what separates a real silence from impatience.',
+        },
+        {
+          n: '02',
+          title: 'It waits before it counts',
+          body: 'Your report carries no weight until the same span has passed that a tracked application gets. Withdraw it if the employer eventually answers, and it stops counting.',
+        },
+        {
+          n: '03',
+          title: 'It stays anonymous',
+          body: `Only a count leaves your report, and only once ${WITNESS_GATE} different people have contributed — a count of one would point straight at you.`,
+        },
+      ]}
+    />
+    <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      Connect a mailbox and it happens without you: freehire sees the reply arrive, or sees that
+      it never did. Without a connected mailbox nothing is counted, because we could not tell
+      silence from a gap in our own data.
+    </p>
+    <div class="flex flex-wrap gap-3">
+      <Button href={resolve('/features/inbox')} variant="outline">How the inbox works</Button>
+    </div>
+  </section>
+
+  <!-- Honest limits. -->
+  <section class="flex flex-col gap-4">
+    <SectionLabel text="where it is blind" />
+    <ul class="flex max-w-3xl flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
+      <li>
+        <strong class="font-medium text-foreground">We only check boards we crawl.</strong> If a
+        company's own careers site is not one of them, its postings are not judged on that
+        criterion at all — absence of proof is not proof.
+      </li>
+      <li>
+        <strong class="font-medium text-foreground">Age counts from when we first saw it.</strong>
+        Sources that refresh a posting's date do not fool it, but a job that existed before we
+        started crawling looks younger than it is.
+      </li>
+      <li>
+        <strong class="font-medium text-foreground"
+          >Agencies and consultancies fire the board criterion honestly.</strong
+        > They advertise roles that belong to their clients, so those roles are genuinely absent
+        from their own board. This is why one criterion is never enough on its own.
+      </li>
+      <li>
+        <strong class="font-medium text-foreground">A quiet employer is not a fake job.</strong>
+        Recruiters go silent for ordinary reasons, which is why a silence needs a second person and
+        a second signal before it says anything.
+      </li>
+    </ul>
+  </section>
+
+  <!-- FAQ; shares GHOST_FAQ with the page's JSON-LD. -->
+  <section class="flex flex-col gap-5">
+    <SectionLabel text="questions" />
+    <dl class="flex flex-col gap-5">
+      {#each GHOST_FAQ as item (item.question)}
+        <div class="flex flex-col gap-1.5">
+          <dt class="text-sm font-medium">{item.question}</dt>
+          <dd class="max-w-3xl text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
+  </section>
+
+  <section class="flex flex-col items-start gap-4 rounded-lg border border-border p-6">
+    <h2 class="text-lg font-semibold tracking-tight">Stop applying into the void</h2>
+    <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      The catalogue is open and needs no account. Tracking your applications is what makes the
+      signal sharper — for you, and for whoever reads the posting after you.
+    </p>
+    <div class="flex flex-wrap gap-3">
+      <Button href={resolve('/jobs')} variant="primary">Browse jobs</Button>
+      <Button href={resolve('/my/tracking')} variant="ghost">Your tracking board</Button>
+    </div>
+  </section>
+</article>

--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -121,6 +121,12 @@
       body: 'Ask an employee inside the company to put your name forward — anonymously and for free — instead of applying cold.',
       cta: 'How referrals work',
     },
+    {
+      href: resolve('/features/ghost-jobs'),
+      title: 'Ghost jobs',
+      body: 'Some postings are not being filled at all. freehire marks the ones whose behaviour and applicant outcomes say so, and shows you every fact behind the warning.',
+      cta: 'How the signal works',
+    },
   ];
 
   const steps = [

--- a/web/src/lib/ghost.ts
+++ b/web/src/lib/ghost.ts
@@ -28,12 +28,16 @@ export interface GhostChecklistRow {
 
 /** The criteria in the order the classifier reports them: structural first, then
  *  outcome. Mirrors internal/ghost's constants — a code here with no counterpart
- *  there renders a row that can never fire. */
-const CRITERIA: { code: string; label: string }[] = [
-  { code: 'evergreen_posting', label: 'Posting behaves as evergreen' },
-  { code: 'ats_absent', label: "Not on the company's own careers board" },
-  { code: 'silent_applications', label: 'Applications here went unanswered' },
-  { code: 'user_reports', label: 'People reported no response' },
+ *  there renders a row that can never fire.
+ *
+ *  Exported because the /features/ghost-jobs landing explains them from this same
+ *  array, and a test fails if a criterion joins the vocabulary without being
+ *  explained there. A marketing page a test keeps honest. */
+export const CRITERIA: { code: string; label: string; tier: 'structural' | 'outcome' }[] = [
+  { code: 'evergreen_posting', label: 'Posting behaves as evergreen', tier: 'structural' },
+  { code: 'ats_absent', label: "Not on the company's own careers board", tier: 'structural' },
+  { code: 'silent_applications', label: 'Applications here went unanswered', tier: 'outcome' },
+  { code: 'user_reports', label: 'People reported no response', tier: 'outcome' },
 ];
 
 const LABELS: Record<string, { tone: 'warn' | 'muted'; label: string }> = {

--- a/web/src/lib/ghostFaq.ts
+++ b/web/src/lib/ghostFaq.ts
@@ -1,0 +1,50 @@
+// Ghost-jobs landing FAQ — the single source for both the visible section
+// (GhostLandingView.svelte) and the FAQPage JSON-LD (routes/features/ghost-jobs).
+// Google drops the rich result when the schema and the page disagree, so they share
+// this array. Answers are written from the code (internal/ghost, internal/jobreality,
+// internal/ghostreport), answer-first, and never claim more than the system observes.
+
+import type { FaqItem } from './seo';
+
+export const GHOST_FAQ: FaqItem[] = [
+  {
+    question: 'What is a ghost job?',
+    answer:
+      'A posting nobody is actually working to fill — kept up to collect CVs, to look like the company is growing, or simply because nobody took it down. Studies put it between 18% and 27% of listings; Greenhouse, which can see its own customers\' hiring pipelines, reported 18–22% per quarter with 70% of its employers having listed at least one.',
+  },
+  {
+    question: 'Does freehire say a company is lying?',
+    answer:
+      'No, and it is built so that it cannot. The system observes two things: how a posting behaves, and what happened to people who applied. It never observes intent, so the strongest thing it will say is that a posting may be inactive — always beside the specific facts that led there. "Open 240 days, found only on an aggregator" is checkable; "this employer is not really hiring" is a claim about someone\'s state of mind.',
+  },
+  {
+    question: 'How many signals does it take before I see anything?',
+    answer:
+      'Two. A single signal is weak on its own — a genuinely hard senior role stays open a long time, and a company can be missing from our board coverage for reasons of its own — so one criterion alone shows nothing at all. You always see how many fired out of how many were checked.',
+  },
+  {
+    question: 'Why does it sometimes say "no data" instead of a verdict?',
+    answer:
+      'Because that is the honest answer, and it tells you why the warning is not stronger. A posting flagged on two structural criteria with nothing known about applicants is a very different thing from one several people reported. Hiding the empty rows would leave you guessing which of the two you are looking at.',
+  },
+  {
+    question: 'Do you use my applications to flag jobs for other people?',
+    answer:
+      'Only as an anonymous count, and only above a threshold. Nothing you wrote, no dates, no identity — and no count at all until at least two different people have contributed, because a count of one would point straight at the single person who applied. Below that threshold the number is absent from the response, not hidden in it.',
+  },
+  {
+    question: 'An unanswered application means the job is fake, then?',
+    answer:
+      'No — that is why it takes two people and a second signal. Recruiters go quiet for ordinary reasons, and a silence only counts at all if your mailbox is connected, so a reply would have been seen. Where we cannot observe replies we count nothing, since a gap in our data is not an employer ignoring you.',
+  },
+  {
+    question: 'I applied and never heard back. How do I report it?',
+    answer:
+      'Open the job, choose Report, and pick "No response". It asks one thing: when you applied. That date is what separates a real silence from impatience, and it is what makes your report useful to the next person. You can withdraw it if the employer eventually answers.',
+  },
+  {
+    question: 'Does a flagged job get hidden or pushed down?',
+    answer:
+      'Neither. It keeps its place in search and in every list, and the mark disappears when the posting closes. The point is to tell you before you spend an hour on an application, not to make the decision for you.',
+  },
+];

--- a/web/src/lib/ghostSignals.test.ts
+++ b/web/src/lib/ghostSignals.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { CRITERIA } from './ghost';
+import { CONVERGENCE, GHOST_SIGNALS, WITNESS_GATE } from './ghostSignals';
+
+describe('GHOST_SIGNALS', () => {
+  // The point of this test: a criterion cannot join the product without being
+  // explained on the landing. A page that silently falls behind the thing it
+  // describes is worse than no page.
+  it('explains every criterion the classifier can report', () => {
+    expect(GHOST_SIGNALS.map((s) => s.code)).toEqual(CRITERIA.map((c) => c.code));
+    for (const s of GHOST_SIGNALS) {
+      expect(s.fact, `${s.code} has no example fact`).toBeTruthy();
+      expect(s.why, `${s.code} has no explanation`).toBeTruthy();
+    }
+  });
+
+  it('keeps both tiers represented', () => {
+    const tiers = new Set(GHOST_SIGNALS.map((s) => s.tier));
+    expect(tiers).toEqual(new Set(['structural', 'outcome']));
+  });
+
+  // The page states these numbers in prose. If the product changes them, the prose
+  // becomes a lie, so they are read from one place rather than typed twice.
+  it('pins the two gates the page describes', () => {
+    expect(CONVERGENCE).toBe(2);
+    expect(WITNESS_GATE).toBe(2);
+  });
+
+  // Nothing here may claim the system knows what an employer intends: it observes
+  // postings and outcomes, and that limit is the whole reason the wording hedges.
+  it('never claims to know an employer intent', () => {
+    for (const s of GHOST_SIGNALS) {
+      expect(`${s.label} ${s.fact} ${s.why}`.toLowerCase()).not.toMatch(
+        /\bfake\b|\bscam\b|not really hiring|no intention/,
+      );
+    }
+  });
+});

--- a/web/src/lib/ghostSignals.ts
+++ b/web/src/lib/ghostSignals.ts
@@ -1,0 +1,58 @@
+// The explanation of each ghost criterion, for the /features/ghost-jobs landing.
+//
+// Keyed by the SAME codes internal/ghost emits and $lib/ghost renders, so the page
+// cannot fall behind the product: ghostSignals.test.ts fails if a criterion joins the
+// vocabulary without an explanation here. A marketing page a test keeps honest — the
+// same trick the inbox landing uses for its status list.
+//
+// `fact` is what the interface actually shows beside a fired criterion; `why` is what
+// makes it evidence. Both are written from the code, not from the pitch: nothing here
+// claims the system knows an employer's intent, because it does not.
+
+import { CRITERIA } from './ghost';
+
+export interface SignalExplainer {
+  code: string;
+  /** Short human name — the checklist row's label. */
+  label: string;
+  /** structural = the shape of the posting; outcome = what happened to an applicant. */
+  tier: 'structural' | 'outcome';
+  /** An example of the facts shown beside it. */
+  fact: string;
+  /** Why this is evidence, and what it is not. */
+  why: string;
+}
+
+const EXPLAINERS: Record<string, { fact: string; why: string }> = {
+  evergreen_posting: {
+    fact: 'Open 240 days · reposted 13× · 7 copies open at once',
+    why: 'One role advertised over and over, often with several copies live at the same time. It never fires on age alone — a genuinely hard senior role stays open a long time. Age is measured from when freehire first saw the posting, not from the date the source prints, so refreshing that date does not reset it.',
+  },
+  ats_absent: {
+    fact: "Not on the company's own careers board · checked 2 days ago",
+    why: "The posting reached us through an aggregator, and the same role is not on the employer's own board. It only counts where we actually crawl that board — otherwise absence would report our blind spot as the employer's fault. The check is re-run continuously and expires if it stops, so a stale answer goes quiet instead of standing.",
+  },
+  silent_applications: {
+    fact: 'Applications through freehire went unanswered past their follow-up window',
+    why: 'People who applied here, whose mailbox is connected so a reply would have been seen, and who were not answered within the window their stage tolerates. Without a connected mailbox we could not tell silence from a gap in our data, so those applications are not counted at all.',
+  },
+  user_reports: {
+    fact: 'People reported applying with no response',
+    why: 'Someone states they applied on a given date and heard nothing. It carries no weight until the same span has passed that a tracked application gets, and it can be withdrawn — an employer who answers late costs the posting its evidence.',
+  },
+};
+
+/** The criteria with their explanations, in the order the classifier reports them.
+ *  A criterion with no explanation is dropped rather than rendered half-empty — and
+ *  ghostSignals.test.ts fails on the gap, so it cannot go unnoticed. */
+export const GHOST_SIGNALS: SignalExplainer[] = CRITERIA.flatMap((c) => {
+  const explainer = EXPLAINERS[c.code];
+  return explainer ? [{ code: c.code, label: c.label, tier: c.tier, ...explainer }] : [];
+});
+
+/** How many criteria must fire before anything is shown. Mirrors internal/ghost. */
+export const CONVERGENCE = 2;
+
+/** How many distinct people must have contributed outcome evidence for the stronger
+ *  claim — and the reason a count is never shown below it. */
+export const WITNESS_GATE = 2;

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -23,6 +23,7 @@ export const STATIC_PATHS = [
   '/features/inbox',
   '/features/referrals',
   '/features/tailor',
+  '/features/ghost-jobs',
 ];
 
 /** The curated collection landing pages (`/collections/:slug`), one per collection.

--- a/web/src/routes/features/ghost-jobs/+page.svelte
+++ b/web/src/routes/features/ghost-jobs/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import GhostLandingView from '$lib/components/GhostLandingView.svelte';
+  import { faqPageJsonLd, jsonLdScript } from '$lib/seo';
+  import { GHOST_FAQ } from '$lib/ghostFaq';
+
+  const canonical = $derived(`${page.url.origin}/features/ghost-jobs`);
+  // The FAQ block and this payload render from the same GHOST_FAQ array, so the
+  // structured data can never disagree with what the page shows.
+  const jsonLd = $derived(jsonLdScript([faqPageJsonLd(GHOST_FAQ)]));
+</script>
+
+<Seo
+  title="Ghost jobs — which postings are not being filled, and why we think so | freehire"
+  description="Between 18% and 27% of listings are jobs nobody is working to fill. freehire watches how a posting behaves and what happened to people who applied, then shows the facts behind every warning — never a claim about an employer's intent."
+  {canonical}
+/>
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <GhostLandingView />
+</div>


### PR DESCRIPTION
## What and why

A `/features/ghost-jobs` page explaining the signal from #1259: all four criteria, both tiers, the two gates, and the real UI.

Assembled to the existing recipe — route file carries only `<Seo>` + FAQ JSON-LD + the `max-w-6xl` wrapper, markup lives in `GhostLandingView.svelte`, and it runs on the two shared primitives (`SectionLabel`, `NumberedGrid`).

**The signals render from the same array the checklist reads.** `ghostSignals.test.ts` fails if a criterion joins the vocabulary without an explanation on the page, so this cannot fall behind the product — the trick the inbox landing already uses for its status list.

**Previews are markup, not screenshots**: a screenshot is light-theme, names a real employer, and freezes a UI that changes. The chip and checklist on the page are the real components' shapes with illustrative data.

### Two sections exist because of what the feature must not say

"The line we do not cross" sits *before* the mechanics rather than as a footnote. "Open 240 days, reposted 13×, seven copies live, absent from the employer's own board" is checkable; "this company is not really hiring" is a claim about intent nothing here can observe.

"Where it is blind" states the limits plainly — including that **agencies and consultancies fire the board criterion honestly**, because they advertise roles belonging to their clients. That is measured, not hypothetical: the production dry-run's head was staffing and IT outsourcing, which is exactly why one criterion is never enough alone.

A test also pins that no explainer may use *fake*, *scam*, *not really hiring* or *no intention*. The hedge is a property of the product, so a copy edit cannot quietly undo it.

### Discovery

The usual three edits: Footer's Features group, `HomeView`'s features section (renders on `/` and `/about`), and `STATIC_PATHS` in `sitemap.ts`.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` pass — no Go touched.
- [x] `go test ./...` passes — no Go touched.
- [x] No generated artifacts affected.
- [ ] For `design-system/` changes — not touched.
- [x] For `web/` changes: `pnpm run check` (0 errors) and `pnpm run build` pass; `pnpm test` 511 passing (49 files).
- [x] This stays within freehire's core/extension boundary.