### PR TITLE
fix(referral): erase the proof CV when an offer is withdrawn

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -327,7 +327,7 @@ func Register(app *fiber.App, cfg Config) {
 	}
 	referralPinger := referral.NewChannelPinger(referralEmail, cfg.NotifyEmailFrom, referralTelegram)
 	referralCabinetURL := strings.TrimRight(cfg.FrontendOrigin, "/") + "/my/referrals?tab=incoming"
-	referralSvc := referral.New(referral.NewQueriesRepository(queries), referralPinger,
+	referralSvc := referral.New(referral.NewQueriesRepository(queries), referralPinger, cfg.Blob,
 		referral.Config{CabinetURL: referralCabinetURL})
 	referralsH := newReferralHandlers(referralSvc, cfg.Blob, cvH.cvRenderer, cvH.cvStore)
 

--- a/internal/handler/referrals.go
+++ b/internal/handler/referrals.go
@@ -154,6 +154,9 @@ func referralError(err error) error {
 		return fiber.NewError(fiber.StatusConflict, "this offer is not pending")
 	case errors.Is(err, referral.ErrOfferNotFound):
 		return fiber.NewError(fiber.StatusNotFound, "offer not found")
+	case errors.Is(err, referral.ErrProofStorageUnavailable):
+		// Nothing was deleted — the offer stands and the same request can be retried.
+		return fiber.NewError(fiber.StatusServiceUnavailable, "could not erase the proof CV; the offer was kept, please try again")
 	case errors.Is(err, referral.ErrAlreadyRequested):
 		return fiber.NewError(fiber.StatusConflict, "you already have an active request for this company")
 	case errors.Is(err, referral.ErrRequestNotOpen):

--- a/internal/handler/referrals_integration_test.go
+++ b/internal/handler/referrals_integration_test.go
@@ -56,8 +56,10 @@ func TestReferralEndpoints(t *testing.T) {
 	}
 
 	h := &referralHandlers{
+		// A nil blob store stands in for a deployment without object storage: withdrawing
+		// then has no proof object to erase, which is the same path these cases exercise.
 		referral: referral.New(referral.NewQueriesRepository(queries),
-			referral.NewChannelPinger(nil, "", nil), referral.Config{}),
+			referral.NewChannelPinger(nil, "", nil), nil, referral.Config{}),
 	}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	requireMod := auth.RequireRole(queries, "moderator")

--- a/internal/referral/referral.go
+++ b/internal/referral/referral.go
@@ -10,11 +10,15 @@ package referral
 import (
 	"context"
 	"errors"
-	"github.com/google/uuid"
+	"fmt"
 	"log"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/blobstore"
 )
 
 // Offer status vocabulary: an offer waits pending until a moderator approves or rejects
@@ -62,6 +66,11 @@ var (
 	// ErrOfferNotFound is returned when withdrawing an offer that does not exist or is
 	// not owned by the caller — the two are indistinguishable on purpose (no IDOR probe).
 	ErrOfferNotFound = errors.New("referral: offer not found")
+	// ErrProofStorageUnavailable reports that a withdrawal's proof CV could not be erased,
+	// so the offer was left standing and the member can simply retry (503). It mirrors
+	// accountdelete.ErrStorageUnavailable, and for the same reason: the alternative is
+	// deleting the row that names the object and losing the object forever.
+	ErrProofStorageUnavailable = errors.New("referral: proof storage unavailable")
 	// ErrNoContact is a request with neither a Telegram handle nor an email (422).
 	ErrNoContact = errors.New("referral: at least one contact required")
 	// ErrInvalidCVChoice is a CV choice that violates the kind/id invariant: an original
@@ -208,16 +217,19 @@ type Config struct {
 
 // Service implements the referral use cases over a Repository and a Pinger.
 type Service struct {
-	repo       Repository
-	pinger     Pinger
+	repo   Repository
+	pinger Pinger
+	// blobs erases a withdrawn offer's proof CV. Nil where object storage is unconfigured,
+	// in which case there is no object to erase — which must not stop a withdrawal.
+	blobs      blobstore.Store
 	dailyCap   int
 	cabinetURL string
 	now        func() time.Time
 }
 
 // New builds a Service. A zero DailyRequestCap falls back to DefaultDailyRequestCap and a
-// nil Now to time.Now.
-func New(repo Repository, pinger Pinger, cfg Config) *Service {
+// nil Now to time.Now; a nil blobs is a deployment without object storage.
+func New(repo Repository, pinger Pinger, blobs blobstore.Store, cfg Config) *Service {
 	cap := cfg.DailyRequestCap
 	if cap <= 0 {
 		cap = DefaultDailyRequestCap
@@ -226,7 +238,7 @@ func New(repo Repository, pinger Pinger, cfg Config) *Service {
 	if now == nil {
 		now = time.Now
 	}
-	return &Service{repo: repo, pinger: pinger, dailyCap: cap, cabinetURL: cfg.CabinetURL, now: now}
+	return &Service{repo: repo, pinger: pinger, blobs: blobs, dailyCap: cap, cabinetURL: cfg.CabinetURL, now: now}
 }
 
 // SubmitOffer records a member's offer to refer into a company, awaiting moderation. It
@@ -260,7 +272,30 @@ func (s *Service) GetOffer(ctx context.Context, offerID uuid.UUID) (Offer, bool,
 // WithdrawOffer lets a member stop being a referrer: it hard-deletes their own offer,
 // owner-scoped by userID. A missing offer or one owned by someone else returns
 // ErrOfferNotFound. Deleting frees the (user, company) slot so they can offer again later.
+//
+// The offer's proof CV is erased with it, and that is not housekeeping. The offer row is the
+// only thing that names the object: accountdelete finds a member's stored objects by reading
+// these rows (see its BlobKeys), so a row deleted on its own leaves a CV in the bucket that
+// nothing can reach again — not a later withdrawal, not the member's own account deletion.
+//
+// The object goes BEFORE the row, the order accountdelete uses and for its reason: if the
+// object cannot be erased the offer stands, so the member simply retries, whereas deleting
+// the row first would strand the object with no key left to find it by. The read that learns
+// the key is also what enforces ownership, so a non-owner never reaches another member's
+// proof. Object deletes are idempotent, so a retry after a partial run is safe.
 func (s *Service) WithdrawOffer(ctx context.Context, offerID uuid.UUID, userID int64) error {
+	offer, ok, err := s.repo.GetOffer(ctx, offerID)
+	if err != nil {
+		return err
+	}
+	if !ok || offer.UserID != userID {
+		return ErrOfferNotFound
+	}
+	if s.blobs != nil && offer.ProofKey != "" {
+		if err := s.blobs.Delete(ctx, offer.ProofKey); err != nil {
+			return fmt.Errorf("%w: delete %q: %v", ErrProofStorageUnavailable, offer.ProofKey, err)
+		}
+	}
 	return s.repo.DeleteOffer(ctx, offerID, userID)
 }
 

--- a/internal/referral/referral_test.go
+++ b/internal/referral/referral_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"github.com/google/uuid"
+	"io"
 	"testing"
 	"time"
+
+	"github.com/strelov1/freehire/internal/blobstore"
 )
 
 // --- fakes ---------------------------------------------------------------
@@ -24,6 +27,9 @@ type fakeRepo struct {
 	createErr    error
 	resolveErr   error
 	deleteErr    error
+	getOffer     Offer
+	getOfferOK   bool
+	getOfferErr  error
 
 	createdReq *RequestInput
 	createdOff *OfferInput
@@ -93,7 +99,7 @@ func (f *fakeRepo) UserHasResume(context.Context, int64) (bool, error) {
 	return f.hasResume, nil
 }
 func (f *fakeRepo) GetOffer(context.Context, uuid.UUID) (Offer, bool, error) {
-	return Offer{}, false, nil
+	return f.getOffer, f.getOfferOK, f.getOfferErr
 }
 func (f *fakeRepo) DeleteOffer(_ context.Context, offerID uuid.UUID, userID int64) error {
 	f.deleted = &deletedOffer{offerID, userID}
@@ -138,8 +144,34 @@ func (p *fakePinger) PingReferrer(_ context.Context, r Recipient, _ string) erro
 	return p.err
 }
 
+// fakeBlobs is an in-memory blobstore.Store recording the keys it was asked to delete. Only
+// Delete is exercised here — the service never reads or writes an object.
+type fakeBlobs struct {
+	deleted []string
+	err     error
+}
+
+func (f *fakeBlobs) Put(context.Context, string, string, io.Reader, int64) error { return nil }
+func (f *fakeBlobs) Get(context.Context, string) (io.ReadCloser, error)          { return nil, nil }
+func (f *fakeBlobs) Delete(_ context.Context, key string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.deleted = append(f.deleted, key)
+	return nil
+}
+
 func newService(repo *fakeRepo, pinger *fakePinger) *Service {
-	return New(repo, pinger, Config{DailyRequestCap: 3, CabinetURL: "https://freehire.me/my/referrals"})
+	return newServiceWithBlobs(repo, pinger, nil)
+}
+
+func newServiceWithBlobs(repo *fakeRepo, pinger *fakePinger, blobs blobstore.Store) *Service {
+	return New(repo, pinger, blobs, Config{DailyRequestCap: 3, CabinetURL: "https://freehire.me/my/referrals"})
+}
+
+// ownedOffer is a stored offer belonging to userID, carrying a proof object.
+func ownedOffer(userID int64, proofKey string) Offer {
+	return Offer{ID: testOfferID, UserID: userID, CompanySlug: "acme", ProofKey: proofKey, Status: OfferApproved}
 }
 
 func cvID(n uuid.UUID) *uuid.UUID { return &n }
@@ -217,7 +249,7 @@ func TestDecideOfferMapsApproveReject(t *testing.T) {
 }
 
 func TestWithdrawOfferIsOwnerScoped(t *testing.T) {
-	repo := &fakeRepo{}
+	repo := &fakeRepo{getOffer: ownedOffer(42, ""), getOfferOK: true}
 	s := newService(repo, &fakePinger{})
 	if err := s.WithdrawOffer(context.Background(), testOfferID, 42); err != nil {
 		t.Fatalf("withdraw: %v", err)
@@ -228,10 +260,63 @@ func TestWithdrawOfferIsOwnerScoped(t *testing.T) {
 }
 
 func TestWithdrawOfferPropagatesNotFound(t *testing.T) {
-	repo := &fakeRepo{deleteErr: ErrOfferNotFound}
+	repo := &fakeRepo{getOffer: ownedOffer(42, ""), getOfferOK: true, deleteErr: ErrOfferNotFound}
 	s := newService(repo, &fakePinger{})
 	if err := s.WithdrawOffer(context.Background(), testOfferID, 42); !errors.Is(err, ErrOfferNotFound) {
 		t.Errorf("err = %v, want ErrOfferNotFound", err)
+	}
+}
+
+// Withdrawing hard-deletes the offer row, and that row is the ONLY thing that names the
+// proof object: accountdelete finds a member's objects by reading these very rows
+// (ListUserBlobKeys), so a row deleted without its object leaves a CV in the bucket that
+// nothing can ever reach again — including the member's own account deletion.
+func TestWithdrawOfferDeletesTheProofObject(t *testing.T) {
+	repo := &fakeRepo{getOffer: ownedOffer(42, "referral-proofs/42/proof.pdf"), getOfferOK: true}
+	blobs := &fakeBlobs{}
+	s := newServiceWithBlobs(repo, &fakePinger{}, blobs)
+
+	if err := s.WithdrawOffer(context.Background(), testOfferID, 42); err != nil {
+		t.Fatalf("withdraw: %v", err)
+	}
+	if len(blobs.deleted) != 1 || blobs.deleted[0] != "referral-proofs/42/proof.pdf" {
+		t.Errorf("deleted objects = %v, want the offer's proof key", blobs.deleted)
+	}
+	if repo.deleted == nil {
+		t.Error("the offer row was not deleted")
+	}
+}
+
+// Objects go before rows, the same order accountdelete uses and for the same reason: if the
+// object cannot be erased, leaving the row means the member can simply retry, whereas
+// deleting it first would strand the object with no key left to find it by.
+func TestWithdrawOfferKeepsTheOfferWhenTheProofCannotBeDeleted(t *testing.T) {
+	repo := &fakeRepo{getOffer: ownedOffer(42, "referral-proofs/42/proof.pdf"), getOfferOK: true}
+	blobs := &fakeBlobs{err: errors.New("s3 down")}
+	s := newServiceWithBlobs(repo, &fakePinger{}, blobs)
+
+	err := s.WithdrawOffer(context.Background(), testOfferID, 42)
+	if !errors.Is(err, ErrProofStorageUnavailable) {
+		t.Fatalf("err = %v, want ErrProofStorageUnavailable", err)
+	}
+	if repo.deleted != nil {
+		t.Error("the offer row must survive a storage failure so the withdrawal can be retried")
+	}
+}
+
+func TestWithdrawOfferRefusesAnotherMembersOffer(t *testing.T) {
+	repo := &fakeRepo{getOffer: ownedOffer(7, "referral-proofs/7/proof.pdf"), getOfferOK: true}
+	blobs := &fakeBlobs{}
+	s := newServiceWithBlobs(repo, &fakePinger{}, blobs)
+
+	if err := s.WithdrawOffer(context.Background(), testOfferID, 42); !errors.Is(err, ErrOfferNotFound) {
+		t.Errorf("err = %v, want ErrOfferNotFound", err)
+	}
+	if len(blobs.deleted) != 0 {
+		t.Errorf("deleted %v — a non-owner must not reach another member's proof", blobs.deleted)
+	}
+	if repo.deleted != nil {
+		t.Error("a non-owner must not delete the row")
 	}
 }
 


### PR DESCRIPTION
## What and why

`WithdrawOffer` hard-deleted the offer row and nothing else. That row is the only thing that
names the proof CV in object storage: `accountdelete` finds a member's stored objects by
reading these very rows, and its `BlobKeys` comment says so outright — *"Only meaningful
before DeleteUser: the mail and referral-proof keys live in the rows themselves."*

So withdrawing an offer left a CV in the bucket that nothing could ever reach again. Not a
later withdrawal, and not the member's own account deletion — the one path that promises to
erase everything they stored. That makes it a quiet violation of the account-deletion
guarantee, not just wasted bytes.

## Ordering

The object is erased **before** the row, the order `accountdelete` uses and for the reason it
writes down: if the object cannot be erased the offer stands, so the member simply retries,
whereas deleting the row first strands the object with no key left to find it by. A storage
failure surfaces as `503` with the offer intact, mirroring
`accountdelete.ErrStorageUnavailable`.

The residual failure mode — object erased, row delete then fails — is self-healing: a retry
re-reads the key, the idempotent object delete is a no-op, and the row goes. That is the
same trade `accountdelete` already accepted.

## No SQL change

The finding suggested `DELETE ... RETURNING proof_object_key`, but none of that is needed:
`GetOffer` already returns `ProofKey`. Reading the offer first also enforces ownership in the
same step, so a non-owner never reaches another member's proof — and there is no sqlc regen,
no new query, and no change to the delete statement.

`referral.New` gains a `blobstore.Store` (nil where object storage is unconfigured, like
`accountdelete`); `cfg.Blob` was already in scope at the construction site.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `TZ=UTC go test ./...` green, run in a **clean detached worktree** at this commit (the shared
  primary checkout had an unrelated session's uncommitted work in it).
- New tests: the proof object is deleted with the row; a storage failure keeps the offer and
  returns `ErrProofStorageUnavailable`; a non-owner gets `ErrOfferNotFound` and touches neither
  the row nor the object.
- Watched the two new tests fail against the old behaviour before implementing (object-delete
  block disabled → `deleted objects = []` and `err = <nil>`).

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes.
- [x] I regenerated committed artifacts when their source changed (none changed — no SQL touched).
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary.
