### PR TITLE
fix(match): bound how often one user may run the fit analysis

### DIFF
--- a/internal/handler/match_analysis.go
+++ b/internal/handler/match_analysis.go
@@ -66,15 +66,19 @@ func (h *matchHandlers) register(api fiber.Router, mw middleware) {
 	// Ad-hoc skill match for a job posting scraped off any page (title + text),
 	// no catalog job required — powers the browser extension's on-any-page card.
 	api.Post("/me/match-text", mw.key, h.MatchText)
-	// The on-demand LLM match analysis (GET cached / POST run / SSE stream).
+	// The on-demand LLM match analysis (GET cached / POST run / SSE stream). The two routes
+	// that actually drive the prompt chain share ONE limiter instance, so the budget is per
+	// user and not per route — a limiter per mount would hand the stream, the POST, and each
+	// deprecated alias a fresh allowance of the same user's quota.
+	runLimit := matchAnalysisLimiter()
 	api.Get("/jobs/:slug/match-analysis", mw.key, h.GetMatchAnalysis)
-	api.Post("/jobs/:slug/match-analysis", mw.key, h.PostMatchAnalysis)
-	api.Get("/jobs/:slug/match-analysis/stream", mw.key, h.StreamMatchAnalysis)
+	api.Post("/jobs/:slug/match-analysis", mw.key, runLimit, h.PostMatchAnalysis)
+	api.Get("/jobs/:slug/match-analysis/stream", mw.key, runLimit, h.StreamMatchAnalysis)
 	// Deprecated pre-rename aliases (was "fit") — kept so existing API-key clients and the
 	// CLI don't break; they hit the same handlers. Remove once callers have migrated.
 	api.Get("/jobs/:slug/fit", mw.key, h.GetMatchAnalysis)
-	api.Post("/jobs/:slug/fit", mw.key, h.PostMatchAnalysis)
-	api.Get("/jobs/:slug/fit/stream", mw.key, h.StreamMatchAnalysis)
+	api.Post("/jobs/:slug/fit", mw.key, runLimit, h.PostMatchAnalysis)
+	api.Get("/jobs/:slug/fit/stream", mw.key, runLimit, h.StreamMatchAnalysis)
 	// analyses lists the jobs the caller has run the AI fit analysis on.
 	api.Get("/me/tracking/analyses", mw.key, h.ListMyAnalyses)
 }

--- a/internal/handler/match_analysis_limit.go
+++ b/internal/handler/match_analysis_limit.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/limiter"
+
+	"github.com/strelov1/freehire/internal/auth"
+)
+
+// matchAnalysesPerHour bounds how many fit analyses one user may run per hour. Running one
+// drives a three-stage LLM prompt chain, so the endpoint spends real money per call — and
+// only a NEW (user, job) analysis costs an AI credit. Recomputing one already cached is free
+// by design, which leaves the credit budget bounding the first run of each job and nothing
+// bounding the re-runs.
+//
+// Thirty cannot be reached by legitimate use. The free tier grants 20 points a month and a
+// new analysis costs 1 (CREDITS_MONTHLY_GRANT / CREDITS_COST_MATCH), so the credit budget
+// already bounds first runs well below this in a whole month — including the SPA's automatic
+// run on a job page with no cached analysis. What is left is deliberate re-running of an
+// analysis already cached, which costs nothing and is the only way to get here.
+const matchAnalysesPerHour = 30
+
+// matchAnalysisLimiter throttles the two fit-analysis routes that run the chain (POST and the
+// SSE stream, plus their deprecated `fit` aliases) per authenticated user. The cached GET is
+// deliberately not throttled: it reads the stored analysis and recomputes only the
+// hard-constraint ceiling, so it costs a query, not a model call.
+//
+// Keying on the user rather than c.IP() is the point, exactly as in contributionLimiter: the
+// caller is already authenticated, and an IP key would be lifted by any rotating proxy pool.
+// It must be mounted AFTER the auth middleware so the user id is resolved; a request that
+// somehow arrives unauthenticated falls back to the address, which is stricter, not looser.
+func matchAnalysisLimiter() fiber.Handler {
+	return limiter.New(limiter.Config{
+		Max:        matchAnalysesPerHour,
+		Expiration: time.Hour,
+		KeyGenerator: func(c *fiber.Ctx) string {
+			if id, ok := auth.UserID(c); ok {
+				return "match:user:" + strconv.FormatInt(id, 10)
+			}
+			return "match:ip:" + c.IP()
+		},
+	})
+}

--- a/internal/handler/match_analysis_limit_test.go
+++ b/internal/handler/match_analysis_limit_test.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// Running the fit analysis spends real LLM budget, and only a NEW (user, job) analysis costs
+// an AI credit — a recompute of one already cached is free by design. Free plus unbounded is
+// the problem: nothing else limits how often a signed-in caller may re-run the three-stage
+// chain. The bound must be keyed on the authenticated user, not the address, for the same
+// reason the contribution limiter is: a rotating proxy pool lifts an IP key.
+func TestMatchAnalysisLimiter_IsKeyedOnTheUser(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	// Stand in for the auth middleware: the user id comes from a header so one test can act
+	// as two users from the same address.
+	app.Post("/analysis", func(c *fiber.Ctx) error {
+		id := int64(1)
+		if c.Get("X-Test-User") == "2" {
+			id = 2
+		}
+		c.Locals("auth.userID", id)
+		return c.Next()
+	}, matchAnalysisLimiter(), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+
+	post := func(user string) int {
+		req := httptest.NewRequest(fiber.MethodPost, "/analysis", nil)
+		req.Header.Set("X-Test-User", user)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Test: %v", err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	var refused int
+	for i := 0; i < matchAnalysesPerHour+5; i++ {
+		if post("1") == fiber.StatusTooManyRequests {
+			refused++
+		}
+	}
+	if refused == 0 {
+		t.Fatalf("user 1 ran %d analyses without being throttled", matchAnalysesPerHour+5)
+	}
+
+	// A different user is unaffected by the first one's exhausted budget.
+	if got := post("2"); got == fiber.StatusTooManyRequests {
+		t.Error("a second user was throttled by the first user's budget — the key is not the user")
+	}
+}

--- a/internal/handler/match_analysis_stream.go
+++ b/internal/handler/match_analysis_stream.go
@@ -93,6 +93,13 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 		}
 		// A background context: the fiber request ctx is gone by now, and each LLM call
 		// is already bounded by the client's per-call timeout.
+		//
+		// A client that disconnects therefore does NOT abort the chain, and that is on
+		// purpose. The run is nearly always one an AI credit was just spent on, so finishing
+		// it puts the analysis in the cache for when the reader comes back, where aborting
+		// would charge them for nothing. What bounds the spend is the per-user rate limit on
+		// the routes that reach here (matchAnalysisLimiter), not the lifetime of a TCP
+		// connection — a limit a reload could reset would bound nothing at all.
 		ctx := context.Background()
 		events := 0
 


### PR DESCRIPTION
## What and why

Running the fit analysis drives a three-stage LLM prompt chain, so every call spends real
money — but only a **new** `(user, job)` analysis debits an AI credit. Recomputing one already
cached is free by design. That left the credit budget bounding the first run of each job and
**nothing at all** bounding the re-runs, on a route open to every signed-in caller.

A per-user hourly limit on the two routes that drive the chain (`POST` and the SSE stream,
plus their deprecated `fit` aliases), mirroring `contributionLimiter` — keyed on the
authenticated user, because an IP key is lifted by any rotating proxy pool.

Two details worth the review:

- **One limiter instance is shared across the mounts.** A `matchAnalysisLimiter()` call per
  route would give the stream, the POST, and each deprecated alias its own allowance of the
  same user's quota — four budgets instead of one.
- **The cached `GET` stays unthrottled.** It reads the stored analysis and recomputes only the
  hard-constraint ceiling, so it costs a query, not a model call. It is also what the SPA
  polls after a dropped stream.

## Why 30

Not a guess. The free tier grants **20 points a month** and a new analysis costs **1**
(`CREDITS_MONTHLY_GRANT` / `CREDITS_COST_MATCH`, neither overridden on prod), so credits
already bound first runs well below 30 in a whole *month* — including the SPA's automatic run
when a job page has no cached analysis (`MatchAnalysisFull.svelte`, `autoRun` on a cold
start). Everything left under the bound is deliberate re-running of a cached analysis, which
is exactly the free path this exists to limit.

## The stream's `context.Background()` is deliberate — left alone

The review also flagged that the SSE writer runs on `context.Background()`, so a client
disconnect does not abort the chain. I checked what depends on that before changing it, and
it should not change:

`MatchAnalysisFull.svelte` handles a dropped stream with `recoverFromDrop()`, which **polls
the cached GET precisely because it expects the server to finish on its own.** Aborting on
disconnect would break that recovery, and — since the run is nearly always one a credit was
just spent on — would charge a reader for nothing. What bounds the spend is a rate limit, not
the lifetime of a TCP connection; a limit a page reload could reset would bound nothing.

So the context stays, and the reasoning is now written into the comment where the next
reviewer will find it.

## Safe against the fail2ban jail

Worth stating explicitly, given this repo's history of banning 566 real users off a
`403`: I checked the live jails on prod before adding an endpoint that returns `429`.
`nginx-docker-auth` matches **`403` on any path** — still armed — while `nginx-docker-scan`
and `nginx-botsearch` only match scan/bot paths on `400|403|404`. Nothing matches `429`, so a
throttled caller is not banned.

(Separately: that any-path `403` jail is still a landmine for any future feature that legitimately
403s a real user. Not touched here.)

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `TZ=UTC go test ./...` green, run in a dedicated worktree.
- New test mirrors `TestContributionLimiter_IsKeyedOnTheUser`: one user is throttled past the
  bound, a second user from the same address is not.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes.
- [x] I regenerated committed artifacts when their source changed (none changed).
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a (read only, to check what the client expects).
- [x] This stays within freehire's core/extension boundary.
