### PR TITLE
docs(blog): changelog — 3,300 US engineering jobs from WhatJobs

### DIFF
--- a/web/src/posts/2026-07-30-us-engineering-jobs-from-whatjobs.svx
+++ b/web/src/posts/2026-07-30-us-engineering-jobs-from-whatjobs.svx
@@ -1,0 +1,32 @@
+---
+title: 3,300 US engineering jobs from WhatJobs
+date: 2026-07-30
+summary: WhatJobs is now one of the sources feeding the catalogue, adding around 3,300 US engineering vacancies — with one difference worth knowing about before you click apply.
+type: changelog
+tags:
+  - sources
+  - united-states
+draft: false
+---
+
+[WhatJobs](/?source=whatjobs) now feeds the catalogue. That is roughly **3,300 more US
+engineering vacancies** — backend, frontend, mobile, Python, Go, Rust, Kubernetes — from
+employers including Roblox, Revolut, ByteDance, Coupang and LangChain, alongside a long tail
+of smaller companies.
+
+**One difference from every other source, and it matters.** For a vacancy from an employer's
+own careers site, **Apply** takes you to that employer. For a WhatJobs vacancy it takes you
+to WhatJobs, which then forwards you to wherever the role actually lives. One extra hop, and
+a page that is not the company's. Nothing else about the listing changes — title, employer,
+location and the full description are all here on the vacancy page, so you can read the
+whole thing and decide before that hop.
+
+Two smaller things, in the interest of not surprising you:
+
+- **No posting date.** This feed reports when *it* first saw a role, not when the employer
+  published it, and those are not the same number — so we do not show a date rather than
+  show a wrong one. Sorting by freshness puts these where we first saw them.
+- **US only.** Every one of these vacancies is in the United States.
+
+You can see them on their own with the [WhatJobs source filter](/?source=whatjobs), or leave
+your filters alone and they will simply appear in the results they belong in.


### PR DESCRIPTION
## What and why

Announces the WhatJobs source (#1268, #1272), now live on prod with 3337 rows across ten keyword boards.

The post leads with the awkward part rather than burying it: **Apply on these vacancies goes to WhatJobs, not the employer** — one hop further than every other source in the catalogue. A reader who clicks and lands on a network page instead of a careers site should have been told first.

It also flags the two things that would otherwise read as bugs:

- **No posting date.** The feed reports when *it* first saw a role, not when the employer published it — so the catalogue shows no date rather than a wrong one.
- **US only.** The publisher account is per-country and this one is the US account.

Employer names in the post are real rows from the live run (Roblox, Revolut, ByteDance, Coupang, LangChain), and the linked filter `/?source=whatjobs` returns 3332 results.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass — no Go changes.
- [x] `go test ./...` passes.
- [x] I regenerated committed artifacts when their source changed — none changed.
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: `pnpm run check` (0 errors) and `pnpm run build` pass; `pnpm run lint` clean apart from one pre-existing warning in `AssistantChat.svelte`.
- [x] This stays within freehire's core/extension boundary — one blog post.