### PR TITLE
fix(sitemap): bound what one sitemap request reads, and put the site schema back on the homepage

### DIFF
--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -43,17 +43,25 @@ func (q *Queries) CompanyJobCountBySlug(ctx context.Context, slug string) (int32
 const companySitemapBoundaries = `-- name: CompanySitemapBoundaries :many
 SELECT slug FROM (
   SELECT slug,
-         row_number() OVER (ORDER BY slug) AS rn,
-         count(*) OVER () AS total
+         row_number() OVER (ORDER BY slug) AS rn
   FROM companies
+  WHERE job_count > 0
 ) t
-WHERE rn % $1::bigint = 0 AND rn < total
+WHERE rn % $1::bigint = 0
+  AND slug < (SELECT max(slug) FROM companies WHERE job_count > 0)
 ORDER BY slug
 `
 
-// The slug ending every full chunk of `chunk_size` companies (ordered by slug),
-// excluding the final row, so the sitemap index can list each company sub-sitemap's
-// keyset cursor.
+// The slug ending every full chunk of `chunk_size` hiring companies (ordered by
+// slug), excluding the final row, so the sitemap index can list each company
+// sub-sitemap's keyset cursor. Same `job_count > 0` scope as ListCompanySitemap, or
+// the cursors would not line up with the chunks they open.
+//
+// The last-row guard is a max(slug) probe, not the `count(*) OVER ()` this query
+// used to compare `rn` against: that count is exact only by materializing every row
+// of the walk in a tuplestore, while max(slug) over the same partial index is one
+// backward index probe. Both exclude exactly the row whose rn = total — the maximum
+// slug — whose cursor would open an empty trailing chunk.
 func (q *Queries) CompanySitemapBoundaries(ctx context.Context, chunkSize int64) ([]string, error) {
 	rows, err := q.db.Query(ctx, companySitemapBoundaries, chunkSize)
 	if err != nil {
@@ -473,7 +481,7 @@ func (q *Queries) ListCompanyCollections(ctx context.Context) ([]ListCompanyColl
 const listCompanySitemap = `-- name: ListCompanySitemap :many
 SELECT slug, updated_at
 FROM companies
-WHERE slug > $1
+WHERE slug > $1 AND job_count > 0
 ORDER BY slug
 LIMIT $2
 `
@@ -490,6 +498,13 @@ type ListCompanySitemapRow struct {
 
 // Slim keyset page of companies for the sitemap, cursored by the slug primary key
 // (first chunk keyed by the empty string, which sorts before every slug).
+//
+// Scoped to hiring companies (job_count > 0), the same scope the /companies catalog
+// lists: a company with no open role has nothing on its page for a crawler to rank,
+// and ~90k of the ~299k rows are job-less reference imports (YC, company-info), so
+// listing them spends crawl budget on thin pages. Rides companies_sitemap_hiring_idx
+// (0057), which covers the predicate, the order and updated_at — without it the
+// predicate alone sends every candidate row to the heap.
 func (q *Queries) ListCompanySitemap(ctx context.Context, arg ListCompanySitemapParams) ([]ListCompanySitemapRow, error) {
 	rows, err := q.db.Query(ctx, listCompanySitemap, arg.AfterSlug, arg.BatchSize)
 	if err != nil {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -226,9 +226,16 @@ type Querier interface {
 	// absent). cmd/import-yc uses it to guard against homonym collisions: it skips
 	// enriching an existing company whose job_count dwarfs a matched YC entry's team.
 	CompanyJobCountBySlug(ctx context.Context, slug string) (int32, error)
-	// The slug ending every full chunk of `chunk_size` companies (ordered by slug),
-	// excluding the final row, so the sitemap index can list each company sub-sitemap's
-	// keyset cursor.
+	// The slug ending every full chunk of `chunk_size` hiring companies (ordered by
+	// slug), excluding the final row, so the sitemap index can list each company
+	// sub-sitemap's keyset cursor. Same `job_count > 0` scope as ListCompanySitemap, or
+	// the cursors would not line up with the chunks they open.
+	//
+	// The last-row guard is a max(slug) probe, not the `count(*) OVER ()` this query
+	// used to compare `rn` against: that count is exact only by materializing every row
+	// of the walk in a tuplestore, while max(slug) over the same partial index is one
+	// backward index probe. Both exclude exactly the row whose rn = total — the maximum
+	// slug — whose cursor would open an empty trailing chunk.
 	CompanySitemapBoundaries(ctx context.Context, chunkSize int64) ([]string, error)
 	// Whether a company with this slug exists — the cheap existence check the vote
 	// path uses to return 404 before touching company_votes (whose FK would otherwise
@@ -962,6 +969,13 @@ type Querier interface {
 	ListCompanyCollections(ctx context.Context) ([]ListCompanyCollectionsRow, error)
 	// Slim keyset page of companies for the sitemap, cursored by the slug primary key
 	// (first chunk keyed by the empty string, which sorts before every slug).
+	//
+	// Scoped to hiring companies (job_count > 0), the same scope the /companies catalog
+	// lists: a company with no open role has nothing on its page for a crawler to rank,
+	// and ~90k of the ~299k rows are job-less reference imports (YC, company-info), so
+	// listing them spends crawl budget on thin pages. Rides companies_sitemap_hiring_idx
+	// (0057), which covers the predicate, the order and updated_at — without it the
+	// predicate alone sends every candidate row to the heap.
 	ListCompanySitemap(ctx context.Context, arg ListCompanySitemapParams) ([]ListCompanySitemapRow, error)
 	// Drives the sync worker: every connection still authorized.
 	ListConnectedGmailUsers(ctx context.Context) ([]ListConnectedGmailUsersRow, error)

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -82,9 +82,16 @@ ORDER BY count(*) DESC, subindustry;
 -- name: ListCompanySitemap :many
 -- Slim keyset page of companies for the sitemap, cursored by the slug primary key
 -- (first chunk keyed by the empty string, which sorts before every slug).
+--
+-- Scoped to hiring companies (job_count > 0), the same scope the /companies catalog
+-- lists: a company with no open role has nothing on its page for a crawler to rank,
+-- and ~90k of the ~299k rows are job-less reference imports (YC, company-info), so
+-- listing them spends crawl budget on thin pages. Rides companies_sitemap_hiring_idx
+-- (0057), which covers the predicate, the order and updated_at — without it the
+-- predicate alone sends every candidate row to the heap.
 SELECT slug, updated_at
 FROM companies
-WHERE slug > sqlc.arg(after_slug)
+WHERE slug > sqlc.arg(after_slug) AND job_count > 0
 ORDER BY slug
 LIMIT sqlc.arg(batch_size);
 
@@ -102,16 +109,24 @@ ORDER BY slug
 LIMIT sqlc.arg(batch_size);
 
 -- name: CompanySitemapBoundaries :many
--- The slug ending every full chunk of `chunk_size` companies (ordered by slug),
--- excluding the final row, so the sitemap index can list each company sub-sitemap's
--- keyset cursor.
+-- The slug ending every full chunk of `chunk_size` hiring companies (ordered by
+-- slug), excluding the final row, so the sitemap index can list each company
+-- sub-sitemap's keyset cursor. Same `job_count > 0` scope as ListCompanySitemap, or
+-- the cursors would not line up with the chunks they open.
+--
+-- The last-row guard is a max(slug) probe, not the `count(*) OVER ()` this query
+-- used to compare `rn` against: that count is exact only by materializing every row
+-- of the walk in a tuplestore, while max(slug) over the same partial index is one
+-- backward index probe. Both exclude exactly the row whose rn = total — the maximum
+-- slug — whose cursor would open an empty trailing chunk.
 SELECT slug FROM (
   SELECT slug,
-         row_number() OVER (ORDER BY slug) AS rn,
-         count(*) OVER () AS total
+         row_number() OVER (ORDER BY slug) AS rn
   FROM companies
+  WHERE job_count > 0
 ) t
-WHERE rn % sqlc.arg(chunk_size)::bigint = 0 AND rn < total
+WHERE rn % sqlc.arg(chunk_size)::bigint = 0
+  AND slug < (SELECT max(slug) FROM companies WHERE job_count > 0)
 ORDER BY slug;
 
 -- name: GetCompany :one

--- a/internal/db/sitemap_integration_test.go
+++ b/internal/db/sitemap_integration_test.go
@@ -79,6 +79,18 @@ func TestCompanySitemapKeyset(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		seedOpenJob(ctx, t, q, i) // also upserts company co-0i
 	}
+	// co-06 keeps a job, but a closed one — so it is a company with nothing open,
+	// the ~90k-row shape (job-less reference imports) the sitemap must not list.
+	jobless := seedOpenJob(ctx, t, q, 6)
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, jobless.ID); err != nil {
+		t.Fatalf("close job: %v", err)
+	}
+	// companies.job_count is denormalized, recomputed by cmd/recount-companies rather
+	// than on the write path, and the sitemap filters on it — so the seed is only in
+	// its final state once the recount has run.
+	if _, err := q.RefreshCompanyFacets(ctx); err != nil {
+		t.Fatalf("RefreshCompanyFacets: %v", err)
+	}
 
 	t.Run("slice pages by slug cursor", func(t *testing.T) {
 		first, err := q.ListCompanySitemap(ctx, ListCompanySitemapParams{AfterSlug: "", BatchSize: 2})
@@ -105,6 +117,29 @@ func TestCompanySitemapKeyset(t *testing.T) {
 		want := []string{"co-02", "co-04"}
 		if fmt.Sprint(got) != fmt.Sprint(want) {
 			t.Fatalf("boundaries = %v, want %v", got, want)
+		}
+	})
+
+	// The chunk size divides the hiring count exactly, so the final row IS a boundary
+	// — the case the max(slug) guard replaced `rn < total` to keep excluding. Its
+	// cursor would open a sub-sitemap with no URLs in it.
+	t.Run("boundaries exclude a final row that lands on a chunk edge", func(t *testing.T) {
+		got, err := q.CompanySitemapBoundaries(ctx, 5)
+		if err != nil {
+			t.Fatalf("CompanySitemapBoundaries: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("boundaries = %v, want none (co-05 is both the 5th and the last)", got)
+		}
+	})
+
+	t.Run("a company with no open job is listed nowhere", func(t *testing.T) {
+		page, err := q.ListCompanySitemap(ctx, ListCompanySitemapParams{AfterSlug: "co-04", BatchSize: 50})
+		if err != nil {
+			t.Fatalf("ListCompanySitemap: %v", err)
+		}
+		if fmt.Sprint(companySlugs(page)) != fmt.Sprint([]string{"co-05"}) {
+			t.Fatalf("tail page = %v, want [co-05] — co-06 has nothing open", companySlugs(page))
 		}
 	})
 }

--- a/internal/handler/sitemap.go
+++ b/internal/handler/sitemap.go
@@ -26,20 +26,32 @@ func (h *sitemapHandlers) register(api fiber.Router) {
 	api.Get("/companies/sitemap/boundaries", h.CompanySitemapBoundaries)
 }
 
-// sitemapMaxURLs is the sitemap-protocol per-file cap. It bounds the company slice
-// and the chunk size the company index uses for keyset boundaries, so a served
-// chunk can never exceed the protocol limit.
+// sitemapMaxURLs is the sitemap-protocol per-file cap — the hard ceiling an
+// untrusted ?limit= / ?chunk= is clamped to, so a served chunk can never exceed the
+// protocol limit however it is asked for.
 const sitemapMaxURLs = 50000
+
+// companySitemapChunk is how many companies one sub-sitemap holds: the default for
+// both ?limit= and ?chunk=, and the value web/src/lib/sitemap.ts SITEMAP_CHUNK must
+// equal so each boundary cursor opens exactly one file's worth.
+//
+// Deliberately far below the protocol cap. These reads compete with the ingest for
+// the buffer cache and their latency swings with it by more than an order of
+// magnitude: on prod (2026-07-29) the same 50k-row chunk measured 0.9s warm and past
+// 60s — an nginx 504 — while an ingest run was evicting the cache. A tenth of the
+// rows keeps the slow end inside the proxy timeout; the cost is ~21 files instead of
+// ~5, which a sitemap index carries for free (its own cap is 50k entries).
+const companySitemapChunk = 10000
 
 // jobSitemapFreshest is how many of the newest open jobs the sitemap ships. The
 // jobs table is far too large (millions of rows) to enumerate per request without
 // a heap-bound scan that also evicts the buffer cache, so the sitemap covers the
 // freshest slice (ordered by id DESC, a cache-warm scan); fuller coverage would
-// need a precomputed narrow table. Held below the 50k protocol cap so that even
-// during the periodic reindex's I/O contention the one file builds well under the
-// 60s proxy timeout (50k measured ~30-40s under load; 25k halves that), while still
-// fitting a single sub-sitemap with no chunking.
-const jobSitemapFreshest = 25000
+// need a precomputed narrow table. Held below the 50k protocol cap so the one file
+// builds under the 60s proxy timeout even against I/O contention — 50k measured
+// ~30-40s under load, and 25k still measured 29s and 57s on two prod probes minutes
+// apart, so this is the margin that band needs, not the row count we'd prefer.
+const jobSitemapFreshest = 15000
 
 // sitemapEntry is the slim wire shape a sitemap URL needs — the public slug and a
 // lastmod. Nothing wider (no full job row, no search engine) crosses the wire.
@@ -49,14 +61,14 @@ type sitemapEntry struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// sitemapLimit clamps ?limit= to [1, sitemapMaxURLs], defaulting to the protocol cap.
+// sitemapLimit clamps ?limit= to [1, sitemapMaxURLs], defaulting to the chunk size.
 func sitemapLimit(c *fiber.Ctx) int32 {
-	return int32(min(max(c.QueryInt("limit", sitemapMaxURLs), 1), sitemapMaxURLs))
+	return int32(min(max(c.QueryInt("limit", companySitemapChunk), 1), sitemapMaxURLs))
 }
 
-// sitemapChunk clamps ?chunk= to [1, sitemapMaxURLs], defaulting to the protocol cap.
+// sitemapChunk clamps ?chunk= to [1, sitemapMaxURLs], defaulting to the chunk size.
 func sitemapChunk(c *fiber.Ctx) int64 {
-	return int64(min(max(c.QueryInt("chunk", sitemapMaxURLs), 1), sitemapMaxURLs))
+	return int64(min(max(c.QueryInt("chunk", companySitemapChunk), 1), sitemapMaxURLs))
 }
 
 // JobSitemap serves the freshest open-job sitemap entries (newest id first).
@@ -72,7 +84,8 @@ func (h *sitemapHandlers) JobSitemap(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"data": entries})
 }
 
-// CompanySitemap serves one keyset page of company sitemap entries after ?after=<slug>.
+// CompanySitemap serves one keyset page of company sitemap entries after ?after=<slug>,
+// covering the hiring companies the /companies catalog lists (see ListCompanySitemap).
 func (h *sitemapHandlers) CompanySitemap(c *fiber.Ctx) error {
 	rows, err := h.queries.ListCompanySitemap(c.Context(), db.ListCompanySitemapParams{
 		AfterSlug: c.Query("after"),
@@ -89,7 +102,8 @@ func (h *sitemapHandlers) CompanySitemap(c *fiber.Ctx) error {
 }
 
 // CompanySitemapBoundaries returns the keyset cursor (slug) ending each ?chunk=<n> of
-// companies, for building the sitemap index.
+// hiring companies, for building the sitemap index. Same scope as CompanySitemap, so a
+// cursor always opens a chunk that has URLs in it.
 func (h *sitemapHandlers) CompanySitemapBoundaries(c *fiber.Ctx) error {
 	cursors, err := h.queries.CompanySitemapBoundaries(c.Context(), sitemapChunk(c))
 	if err != nil {

--- a/internal/handler/sitemap_integration_test.go
+++ b/internal/handler/sitemap_integration_test.go
@@ -44,6 +44,12 @@ func TestSitemapEndpoints(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		seedSitemapJob(t, q, i) // also upserts company co-0i
 	}
+	// The company sitemap lists only companies with an open job, and that count lives
+	// in the denormalized companies.job_count recomputed by cmd/recount-companies — so
+	// the seeded companies are not hiring until the recount runs.
+	if _, err := q.RefreshCompanyFacets(context.Background()); err != nil {
+		t.Fatalf("RefreshCompanyFacets: %v", err)
+	}
 
 	h := &sitemapHandlers{queries: q}
 	jh := &jobsHandlers{queries: q}

--- a/migrations/0057_companies_sitemap_idx.sql
+++ b/migrations/0057_companies_sitemap_idx.sql
@@ -1,0 +1,28 @@
+-- The covering index the company sitemap pages by: slug order, the lastmod it
+-- emits, and the hiring predicate it filters on — so both sitemap reads are
+-- index-only and never touch the companies heap.
+--
+-- The sitemap's two queries (ListCompanySitemap, CompanySitemapBoundaries) run on
+-- every crawler fetch of /sitemap.xml and each company chunk. Measured on prod
+-- (2026-07-29, 320k companies, 7.7 GB heap): the boundary walk takes 2.8 s and an
+-- unfiltered 50k-row chunk 0.9 s warm — but both swing past nginx's 60 s ceiling
+-- while an ingest run evicts the buffer cache, and three of three probes 504'd
+-- inside one ten-minute window. Chunk size alone doesn't fix that: adding the
+-- `job_count > 0` scope the sitemap wants made a *smaller* 20k chunk slower (8.4 s),
+-- because companies_pkey carries neither the predicate nor updated_at, so every
+-- candidate row went to the heap twice over.
+--
+-- With this index a chunk is a bounded index-only range scan, and the boundary walk
+-- reads ~209k narrow index tuples instead of heap-checking 306k rows. Partial on the
+-- same `job_count > 0` scope as the /companies catalog (see 0023), which is also
+-- what the sitemap now lists — so it stays proportional to the hiring set.
+--
+-- release.sh applies migrations before restarting the new color, so this builds on
+-- deploy: a plain CREATE INDEX holds a SHARE lock on companies (blocking upserts,
+-- not reads) for the few seconds a 209k-row partial index takes. If a deploy ever
+-- can't afford even that, build it CONCURRENTLY beforehand — psql -f from a file
+-- under systemd-run, never `psql -c` over ssh — and IF NOT EXISTS makes the
+-- migration a no-op.
+CREATE INDEX IF NOT EXISTS companies_sitemap_hiring_idx
+    ON public.companies (slug) INCLUDE (updated_at)
+    WHERE job_count > 0;

--- a/web/src/lib/firstVisit.test.ts
+++ b/web/src/lib/firstVisit.test.ts
@@ -17,6 +17,20 @@ describe('isCrawler', () => {
     }
   });
 
+  // The UAs an AI assistant sends when it opens a link on a person's behalf. None
+  // carries "bot", and their fetch is the one that ends up quoted in an answer, so
+  // they must read the canonical homepage rather than the default filter slice.
+  it('flags the AI assistant fetchers that carry no "bot" in their UA', () => {
+    for (const ua of [
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36; compatible; Perplexity-User/1.0; +https://perplexity.ai/perplexity-user',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Claude-User/1.0; +Claude-User@anthropic.com',
+      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0',
+      'meta-externalagent/1.1',
+    ]) {
+      expect(isCrawler(ua)).toBe(true);
+    }
+  });
+
   it('treats a real browser UA as not a crawler', () => {
     expect(
       isCrawler(

--- a/web/src/lib/firstVisit.ts
+++ b/web/src/lib/firstVisit.ts
@@ -13,7 +13,15 @@ import { DEFAULT_JOB_FILTERS } from './filterStorage';
 // the UA string; the cost of a miss is only that a bot gets the default slice, and
 // the cost of a false positive is only that a rare human keeps the full feed — so a
 // broad, maintenance-light pattern beats an exhaustive list.
-const CRAWLER_UA = /bot|crawl|spider|slurp|mediapartners|facebookexternalhit|embedly|quora|bitlybot|whatsapp|telegram|discord|preview|scanner|archiver/i;
+//
+// `bot` alone covers the indexers (Googlebot, GPTBot, PerplexityBot, ClaudeBot,
+// OAI-SearchBot). It does NOT cover the fetchers an AI assistant uses when it opens a
+// link *for a person* — Perplexity-User, Claude-User, ChatGPT-User, meta-externalagent
+// — and those are the requests whose content gets quoted in an answer. A miss there
+// costs more than a slice: the page the assistant reads, and cites, becomes the
+// filtered variant rather than the homepage.
+const CRAWLER_UA =
+  /bot|crawl|spider|slurp|mediapartners|facebookexternalhit|embedly|quora|bitlybot|whatsapp|telegram|discord|preview|scanner|archiver|perplexity|claude|chatgpt|externalagent/i;
 
 /** True when the User-Agent looks like a crawler/link-preview bot rather than a
  *  human browser. A missing UA reads as human — the bots we care about all send one,

--- a/web/src/lib/homeFaq.ts
+++ b/web/src/lib/homeFaq.ts
@@ -1,7 +1,9 @@
-// Homepage FAQ content — the single source for both the visible section
-// (HomeView.svelte) and the FAQPage JSON-LD (routes/+page.svelte). Google
-// requires the schema's answers to match the on-page text, so they share this.
-// Answers are written answer-first and stay honest to what the product does.
+// The site's FAQ content — the single source for both the visible section
+// (HomeView.svelte) and the FAQPage JSON-LD. Google requires the schema's answers to
+// match the on-page text, so they share this. Both now render on /about, which is
+// where HomeView moved when the homepage became the job feed; the schema has to
+// follow the visible copy, so it must not be emitted from a page that no longer
+// shows it. Answers are written answer-first and stay honest to what the product does.
 
 import type { FaqItem } from './seo';
 

--- a/web/src/lib/sitemap.test.ts
+++ b/web/src/lib/sitemap.test.ts
@@ -1,10 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { STATIC_PATHS, collectionPaths, blogPaths } from './sitemap';
+import { SITEMAP_CHUNK, STATIC_PATHS, collectionPaths, blogPaths } from './sitemap';
 
 describe('sitemap static paths', () => {
   it('includes the collections hub and the for-companies page', () => {
     expect(STATIC_PATHS).toContain('/collections');
     expect(STATIC_PATHS).toContain('/for-companies');
+  });
+
+  // Indexable pages that the job feed does not link to, so nothing but the sitemap
+  // would lead a crawler to them.
+  it('includes the data and API surfaces', () => {
+    for (const path of ['/open', '/trends', '/docs/api', '/contribute', '/status', '/privacy']) {
+      expect(STATIC_PATHS).toContain(path);
+    }
+  });
+
+  it('lists each path once', () => {
+    expect(new Set(STATIC_PATHS).size).toBe(STATIC_PATHS.length);
   });
 
   it('includes the feature landings', () => {
@@ -37,5 +49,16 @@ describe('blogPaths', () => {
 
   it('is just the index when there are no posts', () => {
     expect(blogPaths([])).toEqual(['/blog']);
+  });
+});
+
+describe('SITEMAP_CHUNK', () => {
+  // The chunk is a latency budget, not a protocol allowance: one chunk is one
+  // Postgres read that has to finish inside the 60s proxy timeout even while an
+  // ingest run is evicting the buffer cache. Keep it an order of magnitude under the
+  // 50,000-URL protocol cap, and in step with internal/handler's companySitemapChunk.
+  it('stays well under the sitemap protocol cap', () => {
+    expect(SITEMAP_CHUNK).toBe(10000);
+    expect(SITEMAP_CHUNK).toBeLessThanOrEqual(50000 / 4);
   });
 });

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -5,10 +5,12 @@
 
 import { collectionSlugs } from './collections';
 
-// Must equal the backend's sitemapMaxURLs — the chunk size the boundary cursors
-// are computed with — so each sub-sitemap holds exactly one keyset chunk and
-// never exceeds the protocol limit.
-export const SITEMAP_CHUNK = 50000;
+// Must equal the backend's companySitemapChunk — the chunk size the boundary
+// cursors are computed with — so each sub-sitemap holds exactly one keyset chunk.
+// Well under the protocol's 50,000-URL cap on purpose: these reads compete with the
+// ingest for Postgres' buffer cache, and a 50k chunk measured both 0.9s warm and
+// past the 60s proxy timeout during an ingest run (see internal/handler/sitemap.go).
+export const SITEMAP_CHUNK = 10000;
 
 /** The site's static, always-present pages (relative paths). */
 export const STATIC_PATHS = [
@@ -17,13 +19,23 @@ export const STATIC_PATHS = [
   '/companies',
   '/collections',
   '/for-companies',
-  '/cli',
-  '/chatgpt',
   '/recruiters',
   '/features/inbox',
   '/features/referrals',
   '/features/tailor',
   '/features/ghost-jobs',
+  // The data and API surfaces. Indexable pages that carry the site's most citable
+  // material — live catalogue figures (/open), market rollups (/trends), the API
+  // reference — so they belong in the sitemap even though nothing links to some of
+  // them from the feed.
+  '/open',
+  '/trends',
+  '/docs/api',
+  '/cli',
+  '/chatgpt',
+  '/contribute',
+  '/status',
+  '/privacy',
 ];
 
 /** The curated collection landing pages (`/collections/:slug`), one per collection.

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -2,11 +2,19 @@
   import { page } from '$app/state';
   import JobsView from '$lib/components/JobsView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { jsonLdScript, siteOrganizationJsonLd, websiteJsonLd } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
-  const canonical = $derived(`${page.url.origin}/`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/`);
+  // What the site is (WebSite + the search action that names our own query
+  // parameter) and who publishes it (Organization). These describe the site as a
+  // whole, so they belong on the URL search engines treat as the site — the
+  // homepage. /about carries the same pair plus its FAQPage, because the visible FAQ
+  // lives there; a repeated site-level entity is expected, an absent one is not.
+  const jsonLd = $derived(jsonLdScript([websiteJsonLd(origin), siteOrganizationJsonLd(origin)]));
 </script>
 
 <Seo
@@ -14,6 +22,11 @@
   description="Search 3M+ tech jobs indexed straight from company career boards — deduplicated and tagged by stack, seniority and location. Free, open source, no walls."
   {canonical}
 />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <!-- Primary heading kept for search engines and assistive tech, but visually

--- a/web/static/llms.txt
+++ b/web/static/llms.txt
@@ -10,6 +10,11 @@ and need no authentication. Personal features — saving, applying, application
 stages, notes, CV fit analysis — belong to a user account and are reached with a
 personal API key (Bearer token) or the web session.
 
+Scale, as of July 2026: more than 3.3 million open postings from over 200,000
+companies that currently have a role open. The live figures are published on
+[/open](https://freehire.me/open) — cite that page rather than these floors, which
+are rounded down and only refreshed when this file is.
+
 ## API
 
 - [OpenAPI schema](https://freehire.me/openapi.yaml): full machine-readable API spec (import this into a ChatGPT Action or any client).
@@ -29,6 +34,14 @@ personal API key (Bearer token) or the web session.
 - [Companies](https://freehire.me/companies): companies with open roles and their profiles.
 - [Collections](https://freehire.me/collections): curated slices (YC, Techstars, big tech, unicorns, and more).
 - [Trends](https://freehire.me/trends): job-market activity over time.
+- [Market insights](https://freehire.me/insights): salary bands, in-demand skills and role rankings per category, computed from the catalogue and dated on each page.
+- [Open numbers](https://freehire.me/open): the live catalogue, coverage and repository figures behind every claim on this site.
+
+## Features
+
+- [Inbox](https://freehire.me/features/inbox): a hosted mailbox that reads ATS replies and advances each application's stage.
+- [CV tailoring](https://freehire.me/features/tailor): rewrites a CV for one posting from banked, candidate-asserted experience — it does not invent employment.
+- [Referrals](https://freehire.me/features/referrals): employee referrals for indexed roles.
 
 ## About
 


### PR DESCRIPTION
## Why

Probing the live site for an SEO audit turned up that the sitemap layer is **intermittently absent**, not slow. Inside one ten-minute window on 2026-07-29, `/sitemap.xml`, `/api/v1/companies/sitemap/boundaries` and a company chunk all returned **504** at nginx's 60s ceiling; twenty minutes later the same URLs answered in 0.95s / 3.8s / 0.9s. `/sitemap-jobs.xml` measured **57s** and **29s** on two probes minutes apart.

A 5xx on the index costs every sub-sitemap, because the index is the only URL `robots.txt` advertises — the healthy static-pages (133 URLs) and insights (100 URLs) files become undiscoverable with it.

Measured per layer before changing anything, so the fix targets the real cause:

| layer | result |
|---|---|
| boundary walk in psql | 2.8s |
| 50k company chunk in psql | 0.9s warm |
| same chunk **with** the hiring filter, no covering index | **8.4s** |
| API on `127.0.0.1:8082` (bypassing nginx) | 4.8s / 200 |
| through nginx locally | 5.4s / 200 |

So the SQL is not the bottleneck — buffer-cache contention with the ingest is, and the band is ~20×. The queries need to be *small enough that the slow end still fits*, which is what this PR does.

## Sitemap

- **Company chunk 50k → 10k.** The chunk is a latency budget, not a protocol allowance.
- **Hiring companies only** (`job_count > 0`), the same scope `/companies` lists. ~90k of ~299k rows are job-less reference imports (YC, company-info) whose pages have nothing to rank — they were spending crawl budget to say nothing.
- **`count(*) OVER ()` → a `max(slug)` probe.** The old query bought an exact last-row guard by materializing every row of the walk; `max(slug)` excludes exactly the same row in one index probe.
- **Migration 0057** — `companies_sitemap_hiring_idx (slug) INCLUDE (updated_at) WHERE job_count > 0`. Required, not an optimization: without it the hiring filter made a *smaller* 20k chunk **slower** (8.4s vs 0.9s), because `companies_pkey` carries neither the predicate nor `updated_at` and sent every candidate row to the 7.7 GB heap.
- **`jobSitemapFreshest` 25k → 15k** for the same margin. The freshest-jobs file keeps its deliberate partial coverage.
- **Six indexable pages added** to the static file, which nothing else linked a crawler to: `/open`, `/trends`, `/docs/api`, `/contribute`, `/status`, `/privacy`.

## SEO / GEO

- **The homepage emitted no JSON-LD at all.** `WebSite` + its `SearchAction` and the publisher `Organization` moved to `/about` when `HomeView` did, and `homeFaq.ts` still described them as living in `routes/+page.svelte` — a regression from that move, not a decision. They are back on `/`; `/about` keeps its copy plus the `FAQPage`, which has to stay where the visible FAQ is.
- **AI assistants' link fetchers were being redirected.** `Perplexity-User`, `Claude-User`, `ChatGPT-User` and `meta-externalagent` carry no `bot` in their UA, so `CRAWLER_UA` missed them and the first-visit redirect sent them to `?work_mode=remote&regions=global`. Those are exactly the fetches that get quoted in an answer, so the page an assistant cited was the filtered slice rather than the homepage.
- **`llms.txt`** gains `/open`, `/insights` and the feature landings, plus the catalogue's order of magnitude — rounded down and pointing at `/open` for live figures, since a static file shouldn't claim a precise number.

## Verification

- `go test -tags=integration ./internal/db/ ./internal/handler/` — the sitemap suites pass, incl. two new cases: a chunk-edge final row is still excluded, and a company with nothing open is listed nowhere.
- `go build ./...`, `go test ./...`, `gofmt`, `go vet` clean. Web: 511 unit tests, eslint on the touched files, `pnpm build`.
- The built SSR server run against the **live prod API** emits `WebSite`/`SearchAction`/`EntryPoint`/`Organization` in the homepage's initial HTML, and serves a 139-URL static file containing all six new paths.

## Deploy notes

- `companies_sitemap_hiring_idx` was pre-built on prod **CONCURRENTLY** ahead of this merge, so the migration's `IF NOT EXISTS` is a no-op and the release takes no lock on the constantly-upserted `companies` table.
- Follow-up, not in this PR: nginx has no `proxy_cache` for freehire. Copying the logo proxy's own `proxy_cache_use_stale error timeout updating http_50x` + `background_update` pattern onto `/sitemap*.xml` would make a slow window serve the previous sitemap instead of a 504. Bounded queries narrow the band; the cache is what removes the failure mode.
- Also observed, out of scope: `companies` carries a **7.7 GB main heap for 320k rows** — impossible under the 8 KB page limit, so 3-10× bloat (its PK index is 44 MB). `pg_repack` would speed up every companies read, not just these.