### PR TITLE
feat(ghost): state the inactivity signal once, as a gauge you can read without reading

### DIFF
--- a/openspec/changes/compact-ghost-signal/.openspec.yaml
+++ b/openspec/changes/compact-ghost-signal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/compact-ghost-signal/design.md
+++ b/openspec/changes/compact-ghost-signal/design.md
@@ -1,0 +1,125 @@
+## Context
+
+`web/src/lib/ghost.ts` is the whole presentation layer for the signal: `ghostBadge` projects the
+served `Ghost` into a chip, `ghostChecklist` into four rows, `supersedesReality` decides whether the
+reality badge yields. Three components consume it — `GhostBadge.svelte` (the chip, used by `JobRow`
+and by `JobView`'s header), `GhostChecklist.svelte` (the bordered panel before the description), and
+`JobView.svelte`, which renders both.
+
+The served payload carries only the criteria that *fired* (`criteria: string[]`, `criteria_total`,
+plus `contributors?` and `ats_checked_at?`). Nothing in it separates "we checked this criterion and it
+was clear" from "we have no data on this criterion" — `detailFor` collapsed both into the string
+`No data`, which was false for `evergreen_posting` (derived from a reality class computed for every
+job) and for an `ats_absent` that did not fire because the role IS on the employer's board. That gap
+is the binding constraint on both the gauge's colour rules and the summary line's wording.
+
+`web/src/lib/ghost.test.ts` covers the projections as plain functions. The web workspace has no
+component-render harness (no `@testing-library/svelte`), so component behaviour is verified visually
+against a running dev server; logic that deserves a test has to live in `ghost.ts`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One statement of the signal on the job page, one line tall when collapsed.
+- The scale readable pre-attentively — two-of-four distinguishable from four-of-four without reading.
+- The full justification still reachable, one click away, with its hedging intact and the caveat one
+  further click away on the page that explains it.
+- The gauge's colour vocabulary honest about what the payload does and does not know.
+
+**Non-Goals:**
+
+- No backend, contract, or `Ghost` shape change. This is presentation only.
+- No change to list cards. `GhostBadge` and `JobRow` are untouched.
+- No change to `RealityBadge` or the supersede rule.
+- No new dependency, and no promotion of the gauge into `design-system` — one call site does not
+  justify a shared primitive yet.
+
+## Decisions
+
+**The gauge fills with risk, not health.** Segments colour as criteria fire; the tone escalates with
+the count. The alternative — a battery draining from full green — is the more familiar metaphor and
+was rejected twice over. First, green segments would assert that the remaining criteria were checked
+and found clear, which the payload cannot support. Second, the "healthy" end of that scale is
+unreachable: at level `none` the field is absent and nothing renders at all, so a full green battery
+would be a state the interface can never show.
+
+**The tone escalates on the fired count, not on `level`.** `level` has two values, and the gauge has
+four states worth distinguishing; keying tone to `level` would render one-of-four and two-of-four
+identically. The projection therefore derives tone from `criteria.length`, and `level` continues to
+drive only the wording. This is a deliberate second reading of the same data, and the wording stays
+authoritative: a three-of-four gauge in a strong tone still says "Possibly inactive" if that is the
+served level.
+
+**Uncoloured segments use a neutral grey.** Not green, not a lighter shade of the fired colour. The
+segment reads as "nothing observed here", which is exactly what the payload means. It is
+`muted-foreground/30` rather than the border tone: on the dark theme the border is nearly the
+background, and a gauge whose unfilled segments are invisible reads as "one of one" — losing the very
+denominator that caps the claim.
+
+**Disclosure is a `<button>` toggling local state, not `<details>`.** `<details>`/`<summary>` would
+work without JS, but the row's content — gauge, wording, scale, chevron — has to sit inside
+`<summary>`, whose default marker and flex behaviour need overriding in every browser, and the
+project's Svelte 5 components already reach for `$state` for this shape. The page is SSR'd but the
+signal is a secondary affordance; a collapsed row that needs hydration to expand is acceptable where
+a mis-styled marker in Safari is not. `aria-expanded` plus `aria-controls` carry the semantics.
+
+**The projection lands in `ghost.ts` as `ghostGauge`.** A third exported function beside the existing
+two, returning `{ segments, filled, tone }`. Keeping the arithmetic and the tone thresholds out of
+the component is what makes them testable at all, given the absent component harness — and it keeps
+`GhostChecklist.svelte` a template.
+
+**`GhostChecklist.svelte` is rewritten in place, not replaced by a new file.** It already owns the
+checklist markup and the caveat; the change adds a gauge row above and a toggle around it. A new
+`GhostSignal.svelte` alongside would leave the old component as dead code or force a second edit to
+delete it. The name stays slightly narrow for what it now renders, which is cheaper than the churn of
+renaming a component with one call site.
+
+**The expanded view names the missing criteria once, and links out for the caveat.** Four rows each
+reading "No data" said the same thing four times — and said it wrongly, so the line reads
+"Not observed: …" instead. That wording lives in `ghostUnobserved` rather than the template, which
+puts the doctrine under test: one line naming those criteria says it once and still tells the reader
+why the level is not higher — which is the whole reason unfired criteria are
+shown at all. A fired criterion's fact moves onto its own line as a lower-case continuation instead
+of a second line of type, and `detailFor` returns an empty string where firing IS the fact (the tick
+already said "yes"). The standing caveat becomes a link to `/features/ghost-jobs`, which states it
+and devotes a whole section to where each criterion is blind — more than the sentence it replaces,
+and it does not cost four lines on every job page.
+
+**The landing renders the components instead of copying their markup.** `GhostLandingView` hand-built
+a chip and the checklist panel from illustrative data, with a comment explaining that previews are
+markup rather than screenshots. The reasoning was right about screenshots and wrong about copies:
+this very change made that panel obsolete, so the page would have described an interface that no
+longer exists — to a reader who arrived because they did not understand what they saw. It now renders
+`GhostBadge` and `GhostChecklist` against fixture `Ghost` payloads, and the caveat sentence moves out
+of the copied panel and onto the page as the section's own line.
+
+**The row moves into `JobView`'s header slot.** It replaces `GhostBadge` there and the section before
+the description is deleted. The reader meets the hedge earlier than before — under the title rather
+than above the description — and `supersedesReality` keeps deciding between ghost and reality exactly
+as it does today.
+
+## Risks / Trade-offs
+
+- **A four-segment gauge is a small target on mobile** → the gauge is decorative (`aria-hidden`); the
+  wording and scale beside it carry the same information as text, and the whole row is the hit area
+  for the toggle.
+- **Tone keyed to count can outrun the wording** — a three-of-four `possible` job renders a
+  near-red gauge under hedged text → acceptable, and arguably the point: three fired criteria *is*
+  worse than one. The wording never escalates beyond what the classifier served.
+- **Collapsed by default means fewer readers see the unfired criteria**, which is what stops the
+  signal reading as an accusation → the collapsed row itself carries the hedged wording and the `2/4`
+  scale, so the ceiling on the claim is visible without expanding. The caveat sentence moves out of
+  the component entirely, to the page the expanded view links to.
+- **A gauge is a new visual idiom on the job page** → confined to one row on one page; if it earns
+  reuse (company pages, the tracking board), it graduates to `design-system` then, not now.
+
+## Migration Plan
+
+Not applicable — a client-side presentation change, shipped with the web bundle. Rollback is a
+revert. Note that the signal is gated off in production behind the calibration gate, so this lands
+unobserved by users until that gate opens.
+
+## Open Questions
+
+None.

--- a/openspec/changes/compact-ghost-signal/proposal.md
+++ b/openspec/changes/compact-ghost-signal/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+On the job page the ghost signal is stated twice — once as a chip under the title, then again as a
+bordered panel listing all four criteria, two of which usually read "No data". A reader deciding
+whether the posting is worth an hour of unpaid work meets a fourteen-line block where a single line
+would do, and half of it says nothing. The panel earns its space only for the reader who wants the
+justification; for everybody else it is the loudest thing on the page after the title.
+
+## What Changes
+
+- Replace the always-open panel with a single row: a four-segment gauge, the hedged level, the
+  `fired/total` scale, and a `Details` disclosure that expands the existing checklist in place.
+- The gauge fills with risk, not health: only fired criteria are coloured, and the tone escalates
+  with the count (one amber → four red). Unfilled segments stay neutral grey and mean *not
+  observed*, never *checked and clear* — a distinction the served payload cannot make, so the
+  interface must not imply it.
+- The row takes the chip's position under the title, and the separate bordered section before the
+  description is removed. One statement of the signal on the page instead of two.
+- List cards keep the existing text chip. In a row of `remote`/`salary` chips a gauge breaks the
+  rhythm, and a card reader is scanning, not adjudicating.
+- The hedged wording, the explicit "no data" rows, and the "observations about the posting, not the
+  employer" caveat all survive — they move behind the disclosure rather than disappearing.
+
+## Capabilities
+
+### New Capabilities
+
+None. This changes how an existing signal is presented, not what the system observes.
+
+### Modified Capabilities
+
+- `ghost-job-signal`: the interface requirement changes from "chip plus a full checklist on the job
+  page" to "a gauge row whose checklist is disclosed on demand", and adds the rule that an unfilled
+  segment carries no claim about the criterion behind it.
+
+## Impact
+
+- `web/src/lib/components/GhostChecklist.svelte` — becomes the gauge row plus disclosure.
+- `web/src/lib/components/GhostBadge.svelte` — unchanged; keeps serving list cards.
+- `web/src/lib/components/JobView.svelte` — the ghost row moves to the header slot where the chip
+  sits today, and the section before the description goes away.
+- `web/src/lib/ghost.ts` — gains the gauge projection (segment count, filled count, tone) beside the
+  existing `ghostBadge` / `ghostChecklist`; both keep their current contracts.
+- No backend, contract, or database change. `Ghost` is served exactly as it is today.

--- a/openspec/changes/compact-ghost-signal/specs/ghost-job-signal/spec.md
+++ b/openspec/changes/compact-ghost-signal/specs/ghost-job-signal/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: The explaining page previews the signal with the components that render it
+
+The `/features/ghost-jobs` landing SHALL illustrate the signal by rendering the same components the
+product renders, fed illustrative payloads, and MUST NOT reproduce their markup as a copy.
+
+A copy is stale the moment the component is redesigned, and the page then describes an interface
+that no longer exists — to a reader who has come to it precisely because they did not understand
+what they saw. Screenshots fail the same way, and additionally freeze one theme and one employer's
+name.
+
+#### Scenario: The preview follows a redesign
+
+- **WHEN** the job page's presentation of the signal changes shape
+- **THEN** the landing's preview changes with it, because it renders the same component rather than a copy of its markup
+
+#### Scenario: The preview carries the caveat
+
+- **WHEN** a reader reaches the landing's preview of the signal
+- **THEN** the observations-not-accusations caveat is stated on the page beside it
+
+## MODIFIED Requirements
+
+### Requirement: The interface states criteria, never an accusation
+
+The web SPA SHALL present the signal as a hedged statement — wording that the job may be inactive,
+never that it is a ghost or that the employer is not hiring — accompanied by the number of criteria
+that fired out of the total.
+
+In a list card the presentation SHALL be a text chip carrying that wording and scale. On the job page
+it SHALL instead be a single row: a segmented gauge, the hedged wording, the scale, and a disclosure
+control that expands the full checklist in place. The checklist SHALL NOT be expanded by default, and
+the job page SHALL carry the signal exactly once — the row replaces both the card-style chip and the
+separate always-open panel.
+
+The expanded checklist SHALL account for every criterion the classifier weighs. Each criterion that
+fired SHALL be listed, carrying the facts behind it where the payload supplies any — for a criterion
+whose firing IS the fact the interface SHALL add nothing further.
+
+The criteria that did not fire SHALL be named together in a single line, rather than one line each,
+and that line SHALL claim only that they were not OBSERVED. It MUST NOT state that there is no data
+on them: the payload reports which criteria fired and never distinguishes a criterion checked and
+found clear from one with nothing to check, so `evergreen_posting` — derived from a class computed
+for every job — is never a criterion the system lacks data on. This is the same constraint that
+governs the gauge's uncoloured segments, and prose beside the gauge must not concede what the colour
+withholds.
+
+The checklist SHALL carry a link to the page explaining the signal, which states the standing caveat
+that these are observations about the posting rather than a claim about the employer.
+
+The gauge SHALL have one segment per criterion the classifier weighs and SHALL colour exactly the
+number that fired, in a tone that escalates with that number. An uncoloured segment SHALL carry no
+claim about the criterion behind it: the served payload distinguishes a criterion that fired from one
+that did not, and never a criterion checked and found clear from one with no data at all, so the
+gauge MUST NOT render an uncoloured segment in a tone that reads as reassurance.
+
+The word *ghost* SHALL remain internal to the codebase — package name, API field, criterion codes —
+and MUST NOT appear in the interface. "Open 240 days, found only on an aggregator" is a claim about
+observable facts; "ghost job" is a claim about an employer's intent, which the system cannot
+observe.
+
+Where the ghost signal is present it SHALL supersede the reality badge, which would otherwise
+restate the `evergreen_posting` criterion as a second, louder badge for the same fact. Where the
+ghost level is `none`, the reality badge renders unchanged.
+
+#### Scenario: The chip is hedged and carries the scale
+
+- **WHEN** a job reaches level `possible` with two of four criteria
+- **THEN** the card shows a hedged chip and a two-of-four scale, and no accusatory wording
+
+#### Scenario: The job page states the signal once, as a gauge row
+
+- **WHEN** a user opens a job page at level `possible` with two of four criteria
+- **THEN** one row renders with two of four segments coloured, the hedged wording and the scale, and no separate panel repeating the same signal
+
+#### Scenario: The checklist is disclosed on demand
+
+- **WHEN** a user opens a job page carrying the signal
+- **THEN** the criteria are collapsed behind a disclosure control, and activating it accounts for every criterion and links to the explanation
+
+#### Scenario: The checklist explains what did not fire
+
+- **WHEN** a user expands the checklist on a job whose outcome criteria did not fire
+- **THEN** one line names those criteria as not observed, so the reader can see why the level is not higher
+
+#### Scenario: The summary does not claim an absence of data
+
+- **WHEN** the criteria that did not fire include one the system evaluates for every job
+- **THEN** the line says they were not observed, and does not say that there is no data on them
+
+#### Scenario: The caveat is reachable from the checklist
+
+- **WHEN** a user expands the checklist
+- **THEN** it links to the page explaining the signal, where the observations-not-accusations caveat and the limits of each criterion are stated
+
+#### Scenario: An uncoloured segment claims nothing
+
+- **WHEN** a job fires two of four criteria and the other two did not fire
+- **THEN** the two uncoloured segments render in a neutral tone that does not read as those criteria having been checked and cleared
+
+#### Scenario: The tone escalates with the count
+
+- **WHEN** one job fires one criterion and another fires four
+- **THEN** the four-of-four gauge renders in a stronger tone than the one-of-four gauge
+
+#### Scenario: The ghost chip replaces the reality chip
+
+- **WHEN** a job is both `likely-evergreen` and at ghost level `possible`
+- **THEN** only the ghost signal renders, and the evergreen fact appears inside its checklist
+
+#### Scenario: Reality is unaffected where ghost is silent
+
+- **WHEN** a job is `likely-evergreen` and its ghost level is `none`
+- **THEN** the reality badge renders exactly as before

--- a/openspec/changes/compact-ghost-signal/tasks.md
+++ b/openspec/changes/compact-ghost-signal/tasks.md
@@ -1,0 +1,39 @@
+## 1. The gauge projection
+
+- [x] 1.1 In `web/src/lib/ghost.test.ts`, write failing tests for a `ghostGauge` projection: it returns one segment per `criteria_total`, fills exactly `criteria.length` of them, escalates tone as the fired count rises, gives one-of-four and two-of-four distinct tones, and returns null for a signal `ghostBadge` refuses.
+- [x] 1.2 Implement `ghostGauge` in `web/src/lib/ghost.ts` returning `{ segments, filled, tone }`, with tone derived from the fired count and documented as the reason it is not derived from `level`.
+
+## 2. The gauge row
+
+- [x] 2.1 Rewrite `web/src/lib/components/GhostChecklist.svelte` as a collapsed row — gauge, hedged wording, `fired/total` scale, disclosure button — with the existing checklist and caveat rendered only when expanded.
+- [x] 2.2 Render the gauge segments from `ghostGauge`: filled segments in the escalating tone, unfilled in the neutral border tone, the whole gauge `aria-hidden` since the wording and scale carry the same information as text.
+- [x] 2.3 Wire the disclosure: a `$state` boolean toggled by a `<button>` carrying `aria-expanded` and `aria-controls` pointing at the checklist region.
+
+## 3. Job page placement
+
+- [x] 3.1 In `web/src/lib/components/JobView.svelte`, swap `GhostBadge` for the gauge row in the header slot (keeping `supersedesReality` as the ghost-vs-reality switch) and delete the section that rendered the panel before the description, updating both surrounding comments to match.
+- [x] 3.2 Confirm `GhostBadge.svelte` still has a caller (`JobRow`) and leave it untouched.
+
+## 4. Trim the expanded view
+
+- [x] 4.1 Test-drive `detailFor` returning an empty detail where firing IS the fact, and lower-case facts that read as a continuation of the criterion's own line.
+- [x] 4.2 Give each criterion a `short` name and collapse the unfired ones into one "No data on …" line, replacing four rows that each said it.
+- [x] 4.3 Drop the inner border in favour of a rule, and replace the caveat sentence with a link to `/features/ghost-jobs`.
+
+## 5. Keep the explaining page honest
+
+- [x] 5.1 Replace `GhostLandingView`'s hand-copied chip and checklist markup with `GhostBadge` and `GhostChecklist` fed fixture `Ghost` payloads.
+- [x] 5.2 Move the caveat sentence out of the copied panel and onto the page beside the preview.
+
+## 6. Verify
+
+- [x] 6.1 `cd web && pnpm test` green, `pnpm lint` and `pnpm build` clean.
+- [x] 6.2 Visually verify the job page and the landing — collapsed row one line tall, expanded checklist complete, both light and dark, at desktop and mobile widths — using headless Chrome over CDP.
+- [x] 6.3 Delete the throwaway `dev-ghost-gauge` route.
+
+## 7. Act on review
+
+- [x] 7.1 Keep the disclosed region mounted (`hidden`/`flex`, not `{#if}`) so `aria-controls` resolves in the collapsed state, and verify it over CDP.
+- [x] 7.2 Replace "No data on …" with `ghostUnobserved`'s "Not observed: …" — the payload cannot support the no-data reading — and pin the wording with a test.
+- [x] 7.3 Restore `<ul>/<li>` for the fired criteria, `aria-hidden` the tick, and separate the two lowest gauge tones.
+- [x] 7.4 Correct the comments and spec sentences the change had made false: `JobView`'s caveat claim, `ghostSignals`' `fact` docstring, design.md's caveat contradiction, and the delta spec's "facts behind every fired criterion".

--- a/web/src/lib/components/GhostChecklist.svelte
+++ b/web/src/lib/components/GhostChecklist.svelte
@@ -1,47 +1,145 @@
 <script lang="ts">
-  import { Check, Minus } from '@lucide/svelte';
-  import { ghostBadge, ghostChecklist } from '$lib/ghost';
+  import { resolve } from '$app/paths';
+  import { Check, ChevronDown } from '@lucide/svelte';
+  import { ghostBadge, ghostChecklist, ghostGauge, ghostUnobserved } from '$lib/ghost';
+  import type { GhostGaugeTone } from '$lib/ghost';
   import type { Ghost } from '$lib/generated/contracts';
+  import { cn } from '$lib/utils';
 
-  // The full justification behind the chip: every criterion the classifier weighs,
-  // the fired ones with their facts, the rest explicitly marked as having no data.
+  // One row for the whole signal: a gauge, the hedged wording, the fired/total scale,
+  // and the justification behind a disclosure.
   //
-  // Showing the unfired rows is the point, not clutter. They tell the reader WHY the
-  // verdict is not stronger — a posting flagged on two structural criteria with no
-  // outcome data is a very different thing from one several people reported — and
-  // that is the difference between informing somebody and accusing an employer at
-  // them.
+  // The justification is the point of the feature rather than decoration — a posting
+  // flagged on two structural criteria with no outcome data is a very different thing
+  // from one several people reported, and that difference is what separates informing
+  // somebody from accusing an employer at them. But it ran fourteen lines, half of them
+  // reading "no data", and it was the loudest thing on the page after the title.
+  // Collapsed, the ceiling on the claim still shows: the wording says the posting MAY
+  // be inactive, and the scale says how much of the evidence is missing.
   let { ghost }: { ghost?: Ghost | null } = $props();
 
   const badge = $derived(ghostBadge(ghost));
+  const gauge = $derived(ghostGauge(ghost));
   const rows = $derived(ghost && badge ? ghostChecklist(ghost) : []);
+  const fired = $derived(rows.filter((r) => r.fired));
+  const unobserved = $derived(ghost && badge ? ghostUnobserved(ghost) : '');
+
+  let open = $state(false);
+
+  // Per-instance, not a constant. One call site renders one row today, and a
+  // hardcoded id is a bug waiting for the second: two rows on a page would both claim
+  // it, and each button's aria-controls would resolve to the first one's criteria.
+  const criteriaId = $props.id();
+
+  // The escalation ladder. An unfilled segment is drawn in the neutral border tone and
+  // never a pale green: the payload says a criterion did not fire, never that it was
+  // checked and found clear, and a reassuring colour would claim that difference.
+  const filledTone: Record<GhostGaugeTone, string> = {
+    low: 'bg-yellow-400 dark:bg-yellow-300',
+    elevated: 'bg-amber-500 dark:bg-amber-400',
+    high: 'bg-orange-600 dark:bg-orange-500',
+    severe: 'bg-red-600 dark:bg-red-500',
+  };
+
+  const textTone: Record<'warn' | 'muted', string> = {
+    warn: 'text-amber-700 dark:text-amber-400',
+    muted: 'text-muted-foreground',
+  };
 </script>
 
 {#if badge && rows.length}
-  <section class="rounded-lg border border-border p-4">
-    <div class="mb-3 flex items-baseline justify-between gap-4">
-      <h3 class="text-sm font-semibold tracking-tight">Signs this posting may be inactive</h3>
-      <span class="text-xs tabular-nums text-muted-foreground">{badge.scale}</span>
+  <section class="flex flex-col gap-2">
+    <button
+      type="button"
+      onclick={() => (open = !open)}
+      aria-expanded={open}
+      aria-controls={criteriaId}
+      class="group flex w-full items-center gap-2.5 rounded-md text-left text-xs font-medium"
+    >
+      {#if gauge}
+        <!-- Decorative: the wording and the scale beside it carry the same information
+             as text, so a screen reader gains nothing from four unlabelled bars. -->
+        <span class="flex shrink-0 items-center gap-0.5" aria-hidden="true">
+          {#each { length: gauge.segments }, i (i)}
+            <span
+              class={cn(
+                'h-3 w-1.5 rounded-sm',
+                i < gauge.filled ? filledTone[gauge.tone] : 'bg-muted-foreground/30',
+              )}
+            ></span>
+          {/each}
+        </span>
+      {/if}
+
+      <span class={textTone[badge.tone]}>{badge.label}</span>
+      <span class="tabular-nums text-muted-foreground">{badge.scale}</span>
+
+      <!-- Beside the scale, not pushed to the far edge: the button spans the row so the
+           whole line is a hit area, but a control a thousand pixels from the thing it
+           expands stops reading as belonging to it. -->
+      <span
+        class="inline-flex shrink-0 items-center gap-1 text-muted-foreground group-hover:text-foreground"
+      >
+        Details
+        <ChevronDown
+          class={cn('size-3.5 transition-transform', open && 'rotate-180')}
+          aria-hidden="true"
+        />
+      </span>
+    </button>
+
+    <!-- Always mounted, toggled between `flex` and `hidden`: `aria-controls` above
+         names this element, and unmounting it would leave that IDREF pointing at
+         nothing in the collapsed state — which is every first paint. `hidden` takes it
+         out of the accessibility tree and the tab order just as `{#if}` did.
+         Tailwind's `hidden` utility rather than the attribute, because the `flex`
+         class would otherwise win over the attribute's `display: none`.
+
+         A rule rather than a box: the disclosure is already grouped by the row above
+         it, and a second border inside the page's own bordered column was the frame
+         that made this read as a warning panel. -->
+    <div
+      id={criteriaId}
+      class={cn(
+        'flex-col gap-1.5 border-l border-border pl-3 text-sm',
+        open ? 'flex' : 'hidden',
+      )}
+    >
+      <!-- A list, so a screen reader still announces how many criteria fired — a count
+           the gauge conveys visually and `aria-hidden` withholds. -->
+      <ul class="flex flex-col gap-1.5">
+        {#each fired as row (row.code)}
+          <li class="flex items-baseline gap-2">
+            <Check
+              class="size-3.5 shrink-0 translate-y-0.5 text-amber-600 dark:text-amber-400"
+              aria-hidden="true"
+            />
+            <!-- The separator is glued to the fact with a non-breaking space: Svelte
+                 trims leading whitespace inside an element, and a bare "·" would also
+                 be free to wrap onto a line of its own. -->
+            <span
+              >{row.label}{#if row.detail}<span class="text-muted-foreground"
+                  >&nbsp;· {row.detail}</span
+                >{/if}</span
+            >
+          </li>
+        {/each}
+      </ul>
+
+      <!-- The unfired criteria collapse into one line. Naming them is what tells the
+           reader why the level is not higher, but four rows each reading "No data" said
+           that four times over — and said it wrongly, which is why the wording and its
+           reasoning now live in ghostUnobserved. -->
+      {#if unobserved}
+        <p class="text-muted-foreground">{unobserved}</p>
+      {/if}
+
+      <a
+        class="mt-1 w-fit text-xs text-muted-foreground underline decoration-border hover:text-foreground"
+        href={resolve('/features/ghost-jobs')}
+      >
+        How this works
+      </a>
     </div>
-
-    <ul class="flex flex-col gap-2">
-      {#each rows as row (row.code)}
-        <li class="flex items-start gap-2.5 text-sm">
-          {#if row.fired}
-            <Check class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
-          {:else}
-            <Minus class="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
-          {/if}
-          <span class="flex min-w-0 flex-col">
-            <span class={row.fired ? '' : 'text-muted-foreground'}>{row.label}</span>
-            <span class="text-xs text-muted-foreground">{row.detail}</span>
-          </span>
-        </li>
-      {/each}
-    </ul>
-
-    <p class="mt-3 text-xs text-muted-foreground">
-      These are observations about the posting, not a claim about the employer.
-    </p>
   </section>
 {/if}

--- a/web/src/lib/components/GhostLandingView.svelte
+++ b/web/src/lib/components/GhostLandingView.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { Check, Minus } from '@lucide/svelte';
   import { Button } from '$lib/ui';
+  import GhostBadge from '$lib/components/GhostBadge.svelte';
+  import GhostChecklist from '$lib/components/GhostChecklist.svelte';
   import NumberedGrid from '$lib/components/NumberedGrid.svelte';
   import SectionLabel from '$lib/components/SectionLabel.svelte';
+  import type { Ghost } from '$lib/generated/contracts';
   import { GHOST_FAQ } from '$lib/ghostFaq';
+  import { ghostBadge } from '$lib/ghost';
   import { CONVERGENCE, GHOST_SIGNALS, WITNESS_GATE } from '$lib/ghostSignals';
 
   // The signals render from the same array the checklist reads, so this page cannot
@@ -13,43 +16,43 @@
   const structural = $derived(GHOST_SIGNALS.filter((s) => s.tier === 'structural'));
   const outcome = $derived(GHOST_SIGNALS.filter((s) => s.tier === 'outcome'));
 
-  // Previews are MARKUP, never screenshots: a screenshot is light-theme, carries a
-  // real employer's name, and freezes a UI that changes. These are the real
-  // components' shapes, built from illustrative data.
-  const demoChecklist = [
-    {
-      label: 'Posting behaves as evergreen',
-      detail: 'Open 240 days · reposted 13× · 7 copies open at once',
-      fired: true,
-    },
-    {
-      label: "Not on the company's own careers board",
-      detail: 'Checked 2 days ago',
-      fired: true,
-    },
-    { label: 'Applications here went unanswered', detail: 'No data', fired: false },
-    { label: 'People reported no response', detail: 'No data', fired: false },
-  ];
+  // Previews are the REAL components fed illustrative payloads, never screenshots and
+  // no longer hand-copied markup. A screenshot is light-theme, carries a real
+  // employer's name, and freezes a UI that changes; a copy of the markup goes stale
+  // the first time the component is redesigned, which is exactly what happened when
+  // the checklist panel became a gauge row. Rendering the components means this page
+  // cannot describe an interface that no longer exists.
+  const checkedAt = new Date(Date.now() - 2 * 86_400_000).toISOString();
 
+  const possible: Ghost = {
+    level: 'possible',
+    criteria: ['evergreen_posting', 'ats_absent'],
+    criteria_total: 4,
+    ats_checked_at: checkedAt,
+  };
+
+  const likely: Ghost = {
+    level: 'likely',
+    criteria: ['evergreen_posting', 'ats_absent', 'silent_applications'],
+    criteria_total: 4,
+    contributors: WITNESS_GATE,
+    ats_checked_at: checkedAt,
+  };
+
+  // The prose names each level by asking the projection, so the page cannot caption a
+  // chip with wording the product has since changed.
   const levels = [
     {
-      chip: 'Possibly inactive',
-      scale: '2/4',
-      tone: 'muted' as const,
+      chip: ghostBadge(possible)!.label,
       when: `${CONVERGENCE} criteria fired, but nobody who applied has told us anything`,
+      ghost: possible,
     },
     {
-      chip: 'Likely inactive',
-      scale: '3/4',
-      tone: 'warn' as const,
+      chip: ghostBadge(likely)!.label,
       when: `at least ${WITNESS_GATE} different people who applied went unanswered, and something else fired too`,
+      ghost: likely,
     },
   ];
-
-  const toneClass = {
-    warn: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400',
-    muted: 'border-border text-muted-foreground',
-  };
 </script>
 
 <article class="flex flex-col gap-14">
@@ -127,7 +130,7 @@
     </div>
   </section>
 
-  <!-- The UI, as markup. -->
+  <!-- The UI, rendered by the components that render it in the product. -->
   <section class="flex flex-col gap-6">
     <SectionLabel text="what you actually see" />
 
@@ -137,14 +140,7 @@
       </p>
       <div class="flex flex-wrap items-center gap-3 rounded-lg border border-border p-4">
         {#each levels as l (l.chip)}
-          <span
-            class="inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium {toneClass[
-              l.tone
-            ]}"
-          >
-            {l.chip}
-            <span class="tabular-nums opacity-70">{l.scale}</span>
-          </span>
+          <GhostBadge ghost={l.ghost} />
         {/each}
       </div>
       <ul class="flex flex-col gap-1.5 text-sm text-muted-foreground">
@@ -156,36 +152,16 @@
 
     <div class="flex flex-col gap-3">
       <p class="text-sm text-muted-foreground">
-        On the job page — the full checklist, <strong class="font-medium text-foreground"
-          >including what we do not know</strong
-        >. The empty rows are the point: they tell you why the warning is not stronger.
+        On the job page — a gauge you can read without reading, and the criteria one click
+        away, <strong class="font-medium text-foreground">including what we do not know</strong>.
+        What is missing is the point: it tells you why the warning is not stronger.
       </p>
-      <section class="rounded-lg border border-border p-4">
-        <div class="mb-3 flex items-baseline justify-between gap-4">
-          <h3 class="text-sm font-semibold tracking-tight">
-            Signs this posting may be inactive
-          </h3>
-          <span class="text-xs tabular-nums text-muted-foreground">2 / 4</span>
-        </div>
-        <ul class="flex flex-col gap-2">
-          {#each demoChecklist as row (row.label)}
-            <li class="flex items-start gap-2.5 text-sm">
-              {#if row.fired}
-                <Check class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
-              {:else}
-                <Minus class="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
-              {/if}
-              <span class="flex min-w-0 flex-col">
-                <span class={row.fired ? '' : 'text-muted-foreground'}>{row.label}</span>
-                <span class="text-xs text-muted-foreground">{row.detail}</span>
-              </span>
-            </li>
-          {/each}
-        </ul>
-        <p class="mt-3 text-xs text-muted-foreground">
-          These are observations about the posting, not a claim about the employer.
-        </p>
-      </section>
+      <div class="rounded-lg border border-border p-4">
+        <GhostChecklist ghost={possible} />
+      </div>
+      <p class="text-xs text-muted-foreground">
+        These are observations about the posting, not a claim about the employer.
+      </p>
     </div>
   </section>
 

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -16,7 +16,6 @@
   import JobDescription from './JobDescription.svelte';
   import JobMatch from './JobMatch.svelte';
   import { supersedesReality } from '$lib/ghost';
-  import GhostBadge from './GhostBadge.svelte';
   import GhostChecklist from './GhostChecklist.svelte';
   import RealityBadge from './RealityBadge.svelte';
   import ReferralBlock from './ReferralBlock.svelte';
@@ -253,11 +252,15 @@
       {@render applyCta('md', 'hidden shrink-0 lg:inline-flex')}
     </div>
 
-    <!-- The ghost chip supersedes the reality chip (see JobRow); the full
-         justification sits in the checklist further down the page, so the chip here
-         stays compact. -->
+    <!-- The ghost row supersedes the reality chip (see JobRow). It states the signal
+         once for the whole page: a gauge and the hedged wording here, the criteria and
+         a link to the full explanation behind its own disclosure. Placed above the
+         description, so somebody deciding whether this is worth an hour of unpaid work
+         meets the hedge before the pitch rather than after they have already invested
+         the reading. The caveat itself now lives on /features/ghost-jobs — the row
+         carries the ceiling on the claim ("possibly", two of four), not the essay. -->
     {#if supersedesReality(job.ghost)}
-      <GhostBadge ghost={job.ghost} />
+      <GhostChecklist ghost={job.ghost} />
     {:else}
       <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
     {/if}
@@ -441,11 +444,6 @@
         <p class="text-sm leading-relaxed text-muted-foreground">{e.summary}</p>
       </section>
     {/if}
-
-    <!-- Placed BEFORE the description, not after: somebody deciding whether this is
-         worth an hour of unpaid work should meet the caveat before reading the pitch,
-         not once they have already invested the reading. -->
-    <GhostChecklist ghost={job.ghost} />
 
     <JobDescription html={job.description} />
   </div>

--- a/web/src/lib/ghost.test.ts
+++ b/web/src/lib/ghost.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { ghostBadge, ghostChecklist, supersedesReality } from './ghost';
+import { ghostBadge, ghostChecklist, ghostGauge, ghostUnobserved, supersedesReality } from './ghost';
 import type { Ghost } from './generated/contracts';
+
+const CODES = ['evergreen_posting', 'ats_absent', 'silent_applications', 'user_reports'];
 
 const possible: Ghost = {
   level: 'possible',
@@ -60,12 +62,32 @@ describe('ghostChecklist', () => {
     ]);
   });
 
-  // "No data" is the point of showing an unfired row: it tells the reader WHY the
-  // level is not higher, instead of leaving them to guess how serious this is.
-  it('says a criterion has no data rather than hiding it', () => {
-    const silent = ghostChecklist(possible).find((r) => r.code === 'silent_applications')!;
-    expect(silent.fired).toBe(false);
-    expect(silent.detail.toLowerCase()).toContain('no data');
+  // The tick beside the row already says "yes". Repeating it on its own line was a
+  // second line of type carrying nothing.
+  it('adds no detail to a criterion whose firing is the whole fact', () => {
+    const evergreen = ghostChecklist(possible).find((r) => r.code === 'evergreen_posting')!;
+    expect(evergreen.fired).toBe(true);
+    expect(evergreen.detail).toBe('');
+  });
+
+  // Unfired criteria collapse into one summary line, which needs a name that reads
+  // in a list rather than the full sentence a row of its own can afford.
+  it('carries a short name for every criterion', () => {
+    for (const row of ghostChecklist(possible)) {
+      expect(row.short.length).toBeGreaterThan(0);
+      expect(row.short.length).toBeLessThan(row.label.length);
+    }
+  });
+
+  // A fired criterion's fact is appended to its own line rather than given a second
+  // line of its own, so it has to read as a continuation and not as a new sentence.
+  it('phrases a fired criterion fact to sit inline after its label', () => {
+    const rows = ghostChecklist({
+      ...possible,
+      ats_checked_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    });
+    const ats = rows.find((r) => r.code === 'ats_absent')!;
+    expect(ats.detail.startsWith('checked ')).toBe(true);
   });
 
   it('reports how many people contributed once the gate is met', () => {
@@ -95,6 +117,84 @@ describe('ghostChecklist', () => {
     });
     const ats = rows.find((r) => r.code === 'ats_absent')!;
     expect(ats.detail.toLowerCase()).toMatch(/checked/);
+  });
+});
+
+describe('ghostUnobserved', () => {
+  it('names every criterion that did not fire', () => {
+    const line = ghostUnobserved(possible);
+    for (const row of ghostChecklist(possible).filter((r) => !r.fired)) {
+      expect(line).toContain(row.short);
+    }
+  });
+
+  // The payload says a criterion did not fire. It never says whether that criterion
+  // was checked and found clear or had nothing to check — `evergreen_posting` is
+  // computed for every job, so "no data" about it is simply false. The summary must
+  // claim only the absence of an observation, which is true either way.
+  it('claims an absence of observation, never an absence of data', () => {
+    const line = ghostUnobserved(possible);
+    expect(line.toLowerCase()).not.toMatch(/no data|nothing known|unknown/);
+    expect(line.toLowerCase()).toContain('not observed');
+  });
+
+  it('says nothing when every criterion fired', () => {
+    expect(ghostUnobserved({ ...possible, criteria: CODES })).toBe('');
+  });
+});
+
+describe('ghostGauge', () => {
+  it('draws one segment per criterion the classifier weighs', () => {
+    expect(ghostGauge(possible)!.segments).toBe(4);
+  });
+
+  it('fills exactly the criteria that fired', () => {
+    expect(ghostGauge(possible)!.filled).toBe(2);
+  });
+
+  // The gauge is a second reading of the same evidence, and it has to be readable
+  // at four states where the wording has only two. Keying the tone to `level` would
+  // render one-of-four and two-of-four identically.
+  it('separates a count the wording cannot', () => {
+    const one = ghostGauge({ ...possible, criteria: ['evergreen_posting'] })!;
+    const two = ghostGauge(possible)!;
+    expect(one.tone).not.toBe(two.tone);
+  });
+
+  it('escalates the tone as more criteria fire', () => {
+    const tones = [1, 2, 3, 4].map(
+      (n) => ghostGauge({ ...possible, criteria: CODES.slice(0, n) })!.tone,
+    );
+    expect(new Set(tones).size).toBe(4);
+    expect(tones.at(-1)).toBe('severe');
+  });
+
+  // Thresholds keyed to an absolute count would mis-tone the day the classifier
+  // gains a fifth criterion: three of five is not three of four.
+  it('tones on the share that fired, not the raw count', () => {
+    const threeOfFour = ghostGauge({ ...possible, criteria: CODES.slice(0, 3) })!;
+    const threeOfSix = ghostGauge({ ...possible, criteria: CODES.slice(0, 3), criteria_total: 6 })!;
+    expect(threeOfSix.tone).not.toBe(threeOfFour.tone);
+  });
+
+  it('shows nothing wherever the chip shows nothing', () => {
+    expect(ghostGauge(null)).toBeNull();
+    expect(ghostGauge(undefined)).toBeNull();
+    expect(ghostGauge({ ...possible, level: 'invented' })).toBeNull();
+  });
+
+  // A gauge with nothing to draw is not a gauge. The row falls back to its wording
+  // rather than rendering an empty frame beside "Possibly inactive".
+  it('shows nothing when there is nothing to fill', () => {
+    expect(ghostGauge({ ...possible, criteria: [] })).toBeNull();
+    expect(ghostGauge({ ...possible, criteria_total: 0 })).toBeNull();
+  });
+
+  // The scale's denominator is served, so a payload claiming more fired criteria
+  // than the total must not paint segments that do not exist.
+  it('never fills past the segments it has', () => {
+    const gauge = ghostGauge({ ...possible, criteria: CODES, criteria_total: 2 })!;
+    expect(gauge.filled).toBeLessThanOrEqual(gauge.segments);
   });
 });
 

--- a/web/src/lib/ghost.ts
+++ b/web/src/lib/ghost.ts
@@ -17,11 +17,35 @@ export interface GhostBadge {
   tooltip: string;
 }
 
+/** A rendered gauge: how many segments to draw, how many to fill, and how loudly.
+ *
+ *  The gauge fills with risk rather than draining like a battery, and only fired
+ *  criteria are coloured. The served payload distinguishes a criterion that fired
+ *  from one that did not, and never a criterion checked and found clear from one with
+ *  no data at all — so an unfilled segment means "not observed" and must not be drawn
+ *  in a tone that reads as reassurance. */
+export interface GhostGauge {
+  segments: number;
+  filled: number;
+  tone: GhostGaugeTone;
+}
+
+/** The escalation ladder, low to severe. Four rungs where the wording has two levels:
+ *  the gauge is what tells one-of-four from three-of-four at a glance. */
+export type GhostGaugeTone = 'low' | 'elevated' | 'high' | 'severe';
+
 /** One row of the checklist: a criterion, whether it fired, and the facts behind it
- *  (or an explicit "no data" when it did not). */
+ *  where the payload carries any — `detail` is empty for a criterion whose firing IS
+ *  the fact, and for every criterion that did not fire.
+ *
+ *  `short` names the criterion for a list, where `label` states it as a sentence. A
+ *  fired criterion earns its own row and reads as the sentence; the unfired ones
+ *  collapse into one summary line, and four sentences do not survive being joined by
+ *  commas. */
 export interface GhostChecklistRow {
   code: string;
   label: string;
+  short: string;
   detail: string;
   fired: boolean;
 }
@@ -33,11 +57,36 @@ export interface GhostChecklistRow {
  *  Exported because the /features/ghost-jobs landing explains them from this same
  *  array, and a test fails if a criterion joins the vocabulary without being
  *  explained there. A marketing page a test keeps honest. */
-export const CRITERIA: { code: string; label: string; tier: 'structural' | 'outcome' }[] = [
-  { code: 'evergreen_posting', label: 'Posting behaves as evergreen', tier: 'structural' },
-  { code: 'ats_absent', label: "Not on the company's own careers board", tier: 'structural' },
-  { code: 'silent_applications', label: 'Applications here went unanswered', tier: 'outcome' },
-  { code: 'user_reports', label: 'People reported no response', tier: 'outcome' },
+export const CRITERIA: {
+  code: string;
+  label: string;
+  short: string;
+  tier: 'structural' | 'outcome';
+}[] = [
+  {
+    code: 'evergreen_posting',
+    label: 'Posting behaves as evergreen',
+    short: 'how the posting behaves',
+    tier: 'structural',
+  },
+  {
+    code: 'ats_absent',
+    label: "Not on the company's own careers board",
+    short: "the company's own board",
+    tier: 'structural',
+  },
+  {
+    code: 'silent_applications',
+    label: 'Applications here went unanswered',
+    short: 'applications here',
+    tier: 'outcome',
+  },
+  {
+    code: 'user_reports',
+    label: 'People reported no response',
+    short: 'reports from people',
+    tier: 'outcome',
+  },
 ];
 
 const LABELS: Record<string, { tone: 'warn' | 'muted'; label: string }> = {
@@ -66,6 +115,35 @@ export function ghostBadge(ghost?: Ghost | null): GhostBadge | null {
   };
 }
 
+/** ghostGauge projects the signal onto the segmented gauge the job page renders, or
+ *  null wherever the chip itself would show nothing.
+ *
+ *  The tone comes from the SHARE of criteria that fired, not from `level` and not from
+ *  the raw count. Not `level`, because it has two values where the gauge has four
+ *  states worth telling apart. Not the raw count, because the denominator is served:
+ *  the day the classifier gains a fifth criterion, thresholds pinned to absolute
+ *  counts would read three-of-five as loudly as three-of-four. `level` keeps driving
+ *  the wording, which stays the authoritative claim — a strongly toned gauge under
+ *  "Possibly inactive" is three criteria firing, not a stronger accusation. */
+export function ghostGauge(ghost?: Ghost | null): GhostGauge | null {
+  if (!ghost || !ghostBadge(ghost)) return null;
+
+  const segments = ghost.criteria_total;
+  // A payload claiming more fired criteria than the scale's denominator must not
+  // paint segments that do not exist.
+  const filled = Math.min(ghost.criteria.length, segments);
+  if (segments < 1 || filled < 1) return null;
+
+  return { segments, filled, tone: toneFor(filled / segments) };
+}
+
+function toneFor(share: number): GhostGaugeTone {
+  if (share >= 1) return 'severe';
+  if (share > 0.5) return 'high';
+  if (share > 0.25) return 'elevated';
+  return 'low';
+}
+
 /** supersedesReality reports whether the ghost badge replaces the reality badge.
  *
  *  `evergreen_posting` IS the reality verdict, so rendering both shows one fact
@@ -75,36 +153,58 @@ export function supersedesReality(ghost?: Ghost | null): boolean {
   return ghostBadge(ghost) !== null;
 }
 
-/** ghostChecklist renders every criterion the classifier considers — including the
- *  ones with nothing behind them.
+/** ghostChecklist projects every criterion the classifier considers — including the
+ *  ones that did not fire.
  *
- *  Showing the unfired rows is the point rather than clutter: "no data" beside the
- *  outcome criteria tells the reader WHY the level is not higher, instead of leaving
- *  them to guess how serious this is. */
+ *  Accounting for the unfired ones is the point rather than clutter: it tells the
+ *  reader WHY the level is not higher, instead of leaving them to guess how serious
+ *  this is. The interface renders the fired ones as rows and hands the rest to
+ *  ghostUnobserved, which names them in a single line. */
 export function ghostChecklist(ghost: Ghost): GhostChecklistRow[] {
   const fired = new Set(ghost.criteria);
-  return CRITERIA.map(({ code, label }) => ({
+  return CRITERIA.map(({ code, label, short }) => ({
     code,
     label,
+    short,
     fired: fired.has(code),
     detail: detailFor(code, ghost, fired.has(code)),
   }));
 }
 
+/** ghostUnobserved names the criteria that did not fire, in one line, or '' when they
+ *  all did.
+ *
+ *  It claims an absence of OBSERVATION and never an absence of data, because the
+ *  payload cannot tell those apart. `evergreen_posting` is derived from a reality class
+ *  computed for every job, and `ats_absent` not firing can mean the role IS on the
+ *  employer's board — both are criteria checked and found clear, and calling them "no
+ *  data" would be simply false. The gauge takes the same care with its unfilled
+ *  segments; a line of prose beside it must not give away what the colour withholds. */
+export function ghostUnobserved(ghost: Ghost): string {
+  const missing = ghostChecklist(ghost).filter((r) => !r.fired);
+  if (!missing.length) return '';
+  return `Not observed: ${missing.map((r) => r.short).join(', ')}.`;
+}
+
+// A fired criterion's fact rides on the criterion's own line, so it is phrased as a
+// continuation — lower case, no leading capital. A criterion whose firing IS the whole
+// fact gets none: the tick beside it already said "yes", and a second line reading
+// "Yes" was type carrying nothing. An unfired criterion gets none either — the row is
+// never rendered, and ghostUnobserved names it instead.
 function detailFor(code: string, ghost: Ghost, fired: boolean): string {
-  if (!fired) return 'No data';
+  if (!fired) return '';
   switch (code) {
     case 'ats_absent': {
       const ago = ghost.ats_checked_at ? timeAgo(ghost.ats_checked_at) : '';
-      return ago ? `Checked ${ago}` : 'Checked against the company board';
+      return ago ? `checked ${ago}` : 'checked against the company board';
     }
     case 'silent_applications':
     case 'user_reports':
       // The contributor count is served only above the anonymity gate, and the UI
       // must not invent one below it: a count of one identifies that applicant to
       // the employer. Absent means absent.
-      return ghost.contributors ? `From ${ghost.contributors} people` : 'Reported';
+      return ghost.contributors ? `from ${ghost.contributors} people` : 'reported';
     default:
-      return 'Yes';
+      return '';
   }
 }

--- a/web/src/lib/ghostSignals.ts
+++ b/web/src/lib/ghostSignals.ts
@@ -5,8 +5,10 @@
 // vocabulary without an explanation here. A marketing page a test keeps honest — the
 // same trick the inbox landing uses for its status list.
 //
-// `fact` is what the interface actually shows beside a fired criterion; `why` is what
-// makes it evidence. Both are written from the code, not from the pitch: nothing here
+// `fact` is an example of the observations that make a criterion fire; `why` is what
+// makes it evidence. `fact` is deliberately NOT a transcript of the interface — the job
+// page prints only what the payload carries, which for `evergreen_posting` is nothing
+// beyond the tick. Both are written from the code, not from the pitch: nothing here
 // claims the system knows an employer's intent, because it does not.
 
 import { CRITERIA } from './ghost';
@@ -17,7 +19,7 @@ export interface SignalExplainer {
   label: string;
   /** structural = the shape of the posting; outcome = what happened to an applicant. */
   tier: 'structural' | 'outcome';
-  /** An example of the facts shown beside it. */
+  /** An example of the observations behind it — illustrative, not a transcript of the UI. */
   fact: string;
   /** Why this is evidence, and what it is not. */
   why: string;


### PR DESCRIPTION
## Why

The job page said the ghost signal **twice** — a chip under the title, then a bordered panel listing four criteria, two of which usually read `No data`. Fourteen lines, half of them saying nothing, and the loudest thing on the page after the title.

Before / after, same job at 2 of 4:

| | |
|---|---|
| **was** | chip `Possibly inactive 2/4` + a bordered panel with 4 rows × 2 lines each + a caveat |
| **now** | `▰▰▱▱ Possibly inactive 2/4 Details ⌄` — one line, criteria on demand |

## What

- **One row**: a four-segment gauge, the hedged wording, the `fired/total` scale, and the criteria behind a `Details` disclosure. The separate panel before the description is gone.
- **The gauge fills with risk**, it does not drain like a battery. Only fired criteria are coloured; an uncoloured segment stays neutral grey. The payload distinguishes *fired* from *did not fire*, and never *checked and clear* from *no data* — so a reassuring colour would claim a difference we cannot see. (A drained-battery metaphor also has an unreachable happy end: at level `none` the field is absent and nothing renders at all.)
- **Tone comes from the share that fired, not the raw count.** Thresholds pinned to absolute numbers would read three-of-five as loudly as three-of-four the day a fifth criterion lands. `level` keeps driving the wording, which stays the authoritative claim.
- **The expanded view got the same trim.** A fired criterion carries its fact inline; `detailFor` returns nothing where firing *is* the fact (the tick already said "yes"); the unfired criteria are named together in one line.
- **That line says "Not observed: …", never "No data".** `evergreen_posting` comes from a reality class computed for every job, and `ats_absent` not firing can mean the role *is* on the employer's board — both are checked-and-clear, so "no data" is simply false. The gauge was already careful here; the prose beside it now is too, and `ghostUnobserved` puts that doctrine under test rather than in a comment.
- **The caveat becomes a link** to `/features/ghost-jobs`, which states it and devotes a section to where each criterion is blind — more than the sentence it replaces, and it does not cost four lines on every job page.
- **The landing stopped hand-copying the UI.** It reproduced the chip and the panel as markup, so this change would have left it describing an interface that no longer exists — to a reader who came *because* they did not understand what they saw. It now renders `GhostBadge` and `GhostChecklist` against fixture payloads, and a new spec requirement says it must.
- **List cards keep the text chip.** In a row of `remote`/`salary` chips a gauge breaks the rhythm, and a card reader is scanning, not adjudicating.

## Verification

- `pnpm test` — 528 pass (ghost.test.ts 18 → 32)
- `pnpm exec svelte-check --threshold error` — 0 errors
- `pnpm lint` — 0 errors (1 pre-existing warning in `AssistantChat.svelte`)
- `pnpm build` — clean
- Visual pass over CDP at 900px and 390px, light and dark, collapsed and expanded, all four gauge states.
- a11y probed over CDP: with the row collapsed, `aria-expanded="false"` and `aria-controls` **resolves** to an element at `display: none`. The disclosed region stays mounted for exactly this reason — unmounting it left the IDREF dangling on every first paint. Tailwind's `hidden` utility rather than the attribute, because the `flex` class wins over the attribute's `display: none`.

## Notes

The signal is still silent in production behind the calibration gate, so this lands unobserved by users until that gate opens. No backend, contract, or schema change — `Ghost` is served exactly as before.

OpenSpec: `openspec/changes/compact-ghost-signal/` (1 MODIFIED + 1 ADDED requirement on `ghost-job-signal`).