### PR TITLE
fix(migrate): bound how long a migration waits for a lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,28 +7,34 @@ hire
 # #1212) blocks `git pull` on every deploy host that already has its own build sitting
 # there. Named individually rather than by a glob: these are real, expected artifacts,
 # and a blanket rule would also swallow a source file someone adds with the same name.
-backfill-company-info
-backfill-company-names
-backfill-derive
-backfill-descriptions
-backfill-experience
-backfill-resume-structured
-backfill-semantic-vectors
-classify-mail
-embed
-enrich
-gmail-sync
-hire-api
-ingest
-liveness
-mail-ingest
-migrate
-mine-titles
-notify
-prune
-recount-companies
-reindex
-remind
+#
+# Each pattern is ANCHORED with a leading slash. Unanchored, a bare name matches that name
+# at ANY depth — including the package directory of the same name, so `migrate` silently
+# ignored every new file under internal/migrate/, and `enrich`/`embed`/`ingest` did the same
+# to theirs. 26 package directories were shadowed this way; a new source file in one of them
+# would simply never be committed.
+/backfill-company-info
+/backfill-company-names
+/backfill-derive
+/backfill-descriptions
+/backfill-experience
+/backfill-resume-structured
+/backfill-semantic-vectors
+/classify-mail
+/embed
+/enrich
+/gmail-sync
+/hire-api
+/ingest
+/liveness
+/mail-ingest
+/migrate
+/mine-titles
+/notify
+/prune
+/recount-companies
+/reindex
+/remind
 # Root-level build output of `go build ./cmd/<name>/` — never commit these artifacts.
 /backfill-company-info
 /backfill-derive

--- a/internal/migrate/lock_timeout_integration_test.go
+++ b/internal/migrate/lock_timeout_integration_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+// Integration test for the migration runner's lock timeout. Needs Docker (testcontainers);
+// run with: go test -tags=integration ./internal/migrate/
+package migrate_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/migrate"
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+// A migration that needs ACCESS EXCLUSIVE must fail rather than queue for it.
+//
+// This reproduces a real incident (2026-07-30). The nightly pg_dump holds ACCESS SHARE on
+// every table for the length of the dump. An `ALTER TABLE` issued in that window cannot get
+// ACCESS EXCLUSIVE, and while it waits it sits at the head of the table's lock queue — so
+// every ordinary reader that arrives behind it also waits. One bounded schema change became
+// minutes of hanging profile reads for signed-in users. Failing fast keeps the release
+// honest: release.sh aborts with the live colour untouched, and nobody's read is blocked.
+func TestRun_FailsFastWhenAnotherTransactionHoldsTheTableLock(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, `CREATE TABLE lock_probe (id bigint)`); err != nil {
+		t.Fatalf("create probe table: %v", err)
+	}
+	// A recorded version makes the runner treat this database as already bootstrapped, so the
+	// migration below is APPLIED rather than baselined (the legacy-schema path records without
+	// executing, which would not exercise the lock at all).
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS public.schema_migrations (
+		version text PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now())`); err != nil {
+		t.Fatalf("ensure schema_migrations: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO public.schema_migrations (version) VALUES ('0000_bootstrap.sql')
+		ON CONFLICT DO NOTHING`); err != nil {
+		t.Fatalf("seed schema_migrations: %v", err)
+	}
+
+	// Hold ACCESS SHARE on the probe table, exactly as a running pg_dump would.
+	holder, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire holder: %v", err)
+	}
+	defer holder.Release()
+	tx, err := holder.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `SELECT count(*) FROM lock_probe`); err != nil {
+		t.Fatalf("holder read: %v", err)
+	}
+
+	migs := []migrate.Migration{{
+		Version: "9999_needs_access_exclusive.sql",
+		SQL:     `ALTER TABLE lock_probe ADD COLUMN note text`,
+	}}
+
+	start := time.Now()
+	_, applied, err := migrate.NewRunner(pool).Run(ctx, migs, false)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("Run succeeded while the table lock was held; applied=%v", applied)
+	}
+	if !strings.Contains(err.Error(), "lock timeout") {
+		t.Errorf("err = %v, want a lock-timeout failure", err)
+	}
+	// The point is that it gives up quickly instead of queueing for the holder. Generous
+	// enough not to flake on a slow CI container, far below "waits for the dump".
+	if elapsed > 60*time.Second {
+		t.Errorf("waited %s for the lock — the runner must fail fast, not queue", elapsed.Round(time.Second))
+	}
+	if len(applied) != 0 {
+		t.Errorf("applied = %v, want nothing recorded when the migration could not run", applied)
+	}
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -40,6 +40,21 @@ const noTxMarker = "migrate: no-transaction"
 // other advisory-lock users, and the project has none.
 const advisoryLockKey int64 = 728391
 
+// lockTimeout bounds how long a migration may WAIT for a lock. It does not bound how long a
+// statement may hold one, so a long index build is unaffected — only the wait is.
+//
+// Without it a schema change does not merely stall itself, it stalls the table. Postgres
+// queues lock requests, so an `ALTER TABLE` waiting for ACCESS EXCLUSIVE sits ahead of every
+// reader that arrives after it, and those readers wait too. That is how one bounded migration
+// took out signed-in profile reads on 2026-07-30: a release landed inside the nightly
+// pg_dump window, the dump holds ACCESS SHARE on every table for the length of the dump, and
+// the ALTER queued behind it with live reads piling up behind the ALTER.
+//
+// Five seconds is far longer than an uncontended DDL lock takes and far shorter than anything
+// worth stalling a table for. Failing is the right outcome: release.sh aborts the release with
+// the live colour untouched, and the operator retries outside the window.
+const lockTimeout = "5s"
+
 // Migration is one migrations/*.sql file. Version is the filename — unique by
 // construction, so the historical duplicate number prefixes (0009_job_daily_stats
 // vs 0009_user_job_analysis) need no renumbering.
@@ -154,6 +169,13 @@ func (r *Runner) Run(ctx context.Context, migs []Migration, forceBaseline bool) 
 			log.Printf("migrate: advisory unlock: %v", err)
 		}
 	}()
+
+	// Set after the advisory lock deliberately: a second concurrent run should still WAIT its
+	// turn for that (it is not a table lock and blocks nobody), while every table lock taken
+	// below is bounded. Session-level, so it covers the no-transaction files too.
+	if _, err := conn.Exec(ctx, "SET lock_timeout = '"+lockTimeout+"'"); err != nil {
+		return nil, nil, fmt.Errorf("set lock_timeout: %w", err)
+	}
 
 	if _, err := conn.Exec(ctx, `CREATE TABLE IF NOT EXISTS public.schema_migrations (
     version text PRIMARY KEY,


### PR DESCRIPTION
## What and why — a prod incident, reproduced in a test

A schema change that waits for a lock does not merely stall itself, **it stalls the table**.
Postgres queues lock requests, so an `ALTER TABLE` waiting for `ACCESS EXCLUSIVE` sits ahead
of every reader that arrives after it, and those readers wait too.

That happened on prod today, deploying #1277. The release landed inside the **nightly pg_dump
window** (`freehire-pg-backup`, 03:00 UTC). A dump holds `ACCESS SHARE` on every table for its
whole duration, so `0057_user_profile_skills_cap_200`'s `ALTER TABLE user_profiles` queued
behind it — and seven `GetUserProfile` reads from signed-in users piled up **behind the
ALTER**, hanging for up to twelve minutes:

```
   pid   | blocked_by |       dur       | q
 2459692 | {}         | 00:25:29        | COPY public.jobs (...)          <- the dump
 2471695 | {2459692}  | 00:15:00        | -- Raise the user profile's ... <- the migration
 2466684 | {2471695}  | 00:12:16        | -- name: GetUserProfile :one    <- a real user
 2468036 | {2471695}  | 00:09:19        | -- name: GetUserProfile :one
 ... 5 more
```

`pg_cancel_backend` on the migration drained the queue instantly. Nothing in the pipeline
noticed, because the migration was doing exactly what it was told: wait. `release.sh` had
already aborted, so no bad code was ever served — the damage was purely the lock queue.

## The fix

The runner sets a **5s session `lock_timeout`**. This bounds only the *wait*, never how long a
statement may *hold* a lock, so:

- a long index build is unaffected — `lock_timeout` is not `statement_timeout`;
- `CREATE INDEX [CONCURRENTLY]` is unaffected in a dump window anyway, because
  `ShareUpdateExclusive`/`Share` do not conflict with the dump's `ACCESS SHARE`;
- what it catches is precisely the dangerous shape — `ALTER`/`DROP` against a table someone
  else has open.

Failing is the right outcome: `release.sh` already aborts with the live colour untouched, and
the operator retries outside the window.

It is set **after** the advisory lock on purpose. A second concurrent run should still wait
its turn for that — an advisory lock is not a table lock and blocks nobody.

## `.gitignore` is part of the same change

The test file could not otherwise be committed. `.gitignore` listed the worker-binary names
**unanchored**, and a bare name matches at *any depth* — so `migrate` silently ignored every
new file under `internal/migrate/`, and `enrich`, `embed`, `ingest` and 23 more did the same to
their package directories. A new source file in any of them would simply never be committed.

Only the worker block is anchored. `.env`, `.DS_Store` and `*.pyc` must keep matching at depth
— anchoring `.env` would have started tracking nested env files, which is how secrets get
committed. Verified after the change that `services/pii-filter/.env` is still ignored and that
a root-level `./migrate` binary still is too.

## Verification

- The integration test **reproduces the incident**: before the fix it hangs until the 600s Go
  test timeout; after it, `go test -tags=integration ./internal/migrate/` passes in **12s**.
- `go build ./...`, `go vet -tags=integration ./...`, `gofmt -l .` — clean.
- `TZ=UTC go test ./...` green.

## Follow-up, not in this PR

`0057` is still unapplied on prod (the nightly dump was still running at the time of writing).
It will apply on the next release, which is now safe by construction: either it takes the lock
immediately or the release aborts without touching a reader.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `-tags=integration ./internal/migrate/`).
- [x] I regenerated committed artifacts when their source changed (none changed).
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary.
