### PR TITLE
feat(sources): onboard 306 live ATS boards

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7626,3 +7626,93 @@
 # --- contributed boards ---
 - company: Passage Health
   board: passagehealth
+- company: Zafran
+  board: zafran-security
+- company: Plancraft
+  board: plancraft
+- company: Almetra
+  board: almetra
+- company: "EyeTell, Inc."
+  board: eyetell
+- company: Comand AI
+  board: comand-ai
+- company: Redpanda Data
+  board: redpanda-data
+- company: Pogo
+  board: joinpogo
+- company: Geordie
+  board: geordieai
+- company: Noïa Labs
+  board: noialabs
+- company: Apiphany AI
+  board: apiphany
+- company: Dream Three
+  board: dreamthree
+- company: Logiqal
+  board: logiqal
+- company: Extropic
+  board: extropic
+- company: Kairos
+  board: kairos-project
+- company: Ollama
+  board: ollama
+- company: Northflank
+  board: northflank.com
+- company: Trovy
+  board: trovy
+- company: Gigaton
+  board: gigaton
+- company: OKTOBER
+  board: oktoberagency
+- company: BeyondMath
+  board: beyondmath
+- company: HTTPie
+  board: httpie
+- company: Melius
+  board: melius
+- company: EducationSuperHighway
+  board: educationsuperhighway
+- company: Furo
+  board: furo
+- company: Mirai Robotics
+  board: mirai-robotics
+- company: Mycroft
+  board: mycroft
+- company: Simply Wall St.
+  board: simply-wall-st
+- company: Kunin
+  board: kunin
+- company: Bolna AI
+  board: bolna
+- company: Frontier Health
+  board: frontier-health
+- company: Infera
+  board: infera
+- company: Vigil Markets
+  board: vigil-markets
+- company: Porters
+  board: porters
+- company: IMU Biosciences
+  board: imubiosciences
+- company: Nucleus Health
+  board: nucleus
+- company: Pathwork
+  board: pathwork
+- company: Attention Engineering
+  board: attention
+- company: Fazeshift
+  board: fazeshift
+- company: Compresr
+  board: compresr
+- company: Opus1
+  board: Opus1
+- company: BEAVR
+  board: beavr
+- company: Climatiq
+  board: climatiq
+- company: Cosmic Robotics
+  board: cosmic-robotics
+- company: Lark Health
+  board: lark
+- company: Meliora Academy
+  board: meliora-academy

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -18699,3 +18699,7 @@
   board: koombea
 - company: X-Lab Systems
   board: xlabsystems1
+- company: Oddin.gg
+  board: oddingg
+- company: Intercept
+  board: intercept

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14223,3 +14223,19 @@
   board: zephyrhome
 - company: Venice AI
   board: veniceai
+- company: InstaLILY AI
+  board: instalilyai
+- company: Spektr
+  board: spektr
+- company: test IO
+  board: testio
+- company: Syntetica
+  board: syntetica
+- company: NcodiN
+  board: ncodin
+- company: Grey
+  board: grey
+- company: NaturalMotion
+  board: nmcareers
+- company: Chicory
+  board: chicory

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4395,3 +4395,23 @@
 # a16z Speedrun talent-network (harvested 2026-07)
 - company: Management Leadership for Tomorrow
   board: ml4t
+- company: Avive
+  board: AviveSolutions
+- company: Tiberius
+  board: tiberius
+- company: Quizizz
+  board: Wayground
+- company: zeroRISC
+  board: zerorisc
+- company: Mindy
+  board: mindy
+- company: Danti
+  board: danti.ai
+- company: Insight M
+  board: InsightM
+- company: Mast Reforestation
+  board: MastReforestation
+- company: Jupiter Intelligence
+  board: jupiterintel
+- company: Modern Intelligence
+  board: ModernIntelligence

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -8047,3 +8047,93 @@
   board: olando-gmbh
 - company: zdf-sparks
   board: zdf-sparks
+- company: Felmo
+  board: felmo
+- company: Startup-Insider
+  board: startup-insider
+- company: Building Radar
+  board: building-radar
+- company: ENVIRIA
+  board: enviria
+- company: Cylib
+  board: cylib-gmbh
+- company: Curity
+  board: curity
+- company: Contentbird
+  board: contentbird
+- company: REEV
+  board: reev
+- company: Humanoo
+  board: humanoo
+- company: Demodesk
+  board: demodesk-gmbh
+- company: Elona Health
+  board: elona-health
+- company: Nebenan
+  board: good-hood-gmbh
+- company: Modelwise
+  board: modelwise
+- company: United Manufacturing Hub
+  board: umh-systems-gmbh
+- company: Arweave
+  board: arweave
+- company: Climedo Health
+  board: climedo
+- company: Jobs bei
+  board: aquaty
+- company: Tidely
+  board: tidely
+- company: Unframe AI
+  board: unframe-ai
+- company: ArtNight
+  board: artnight-gmbh
+- company: Candis
+  board: candis
+- company: Celus
+  board: celus
+- company: Credium
+  board: credium
+- company: deeploi
+  board: deeploi
+- company: everstox
+  board: everstox
+- company: Fides Technology GmbH
+  board: fides-technology-gmbh
+- company: Filics
+  board: filics
+- company: L1R1 Technologies
+  board: l1r1technologies-gmbh
+- company: Threedy
+  board: threedy-gmbh
+- company: CNC24
+  board: cncteile24-gmbh
+- company: Her One
+  board: her1
+- company: KEYOU
+  board: keyou-gmbh
+- company: Tibo Energy
+  board: tibo-energy
+- company: Uniify
+  board: uniify
+- company: Cyclize
+  board: cyclize
+- company: Output Sports
+  board: output-sports
+- company: Polyteia
+  board: polyteia
+- company: AVES Reality GmbH
+  board: aves-reality
+- company: Fulfin
+  board: fulfin
+- company: Invesdor
+  board: invesdor
+- company: Klarx
+  board: klarx
+- company: Lunar X
+  board: lunar-x
+- company: Metalshub
+  board: metalshub
+- company: SimplyCook
+  board: simplycook
+- company: Workpath
+  board: workpath

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3727,3 +3727,23 @@
   board: wgalegacypropertymanagement
 - company: zelh
   board: zelh
+- company: LeydenJar Technologies
+  board: leydenjar
+- company: Cascador/moveUP
+  board: moveup
+- company: Doxter
+  board: doctenasa
+- company: Companisto Investor Network
+  board: companisto
+- company: Crow
+  board: crow
+- company: Instruqt
+  board: instruqt
+- company: Pietercil Group
+  board: pietercil
+- company: Amilia
+  board: amilia
+- company: Serra
+  board: serra
+- company: Ecochain Technologies
+  board: ecochain

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -5823,3 +5823,257 @@
   board: nilebits
 - company: syncreonconsulting
   board: syncreonconsulting
+- company: Blueberry Labs Private Limited
+  board: BlueberryLabsPrivateLimited
+- company: ACT-ON
+  board: ACT-ON
+- company: Blueberry Digital Labs
+  board: BlueberryDigitalLabs
+- company: DOZR
+  board: DOZR
+- company: Zen3
+  board: Zen31
+- company: BEX
+  board: BexTechnologiesGmbH
+- company: iHealth Labs
+  board: IHealthLabs
+- company: CyberVadis
+  board: CyberVadis
+- company: Atomic32
+  board: Atomic32
+- company: Manara
+  board: Manara
+- company: balanGO
+  board: BalanGO
+- company: DESIGNATION Labs
+  board: DESIGNATIONLabs
+- company: Bristol Labs
+  board: BristolLabs
+- company: Byron
+  board: Byron1
+- company: Jindal Biotech Private Limited
+  board: JindalBiotechPrivateLimited
+- company: Jobiak
+  board: Jobiak
+- company: KCS
+  board: KCS2
+- company: Rise Up
+  board: RiseUp
+- company: TrafficCast
+  board: TrafficCast
+- company: Yoyo
+  board: Yoyo
+- company: Boomtrain
+  board: Boomtrain
+- company: Epro 360
+  board: Epro360
+- company: First Genesis
+  board: FirstGenesis
+- company: iBlack
+  board: iBlack
+- company: NEOGEN25
+  board: NEOGEN25
+- company: Baron
+  board: Baron
+- company: Apptopia
+  board: Apptopia1
+- company: Agency Cybersecurity
+  board: Agency
+- company: AnalyzeData
+  board: AnalyzeData
+- company: Countx
+  board: CountXGmbH
+- company: UserIQ
+  board: UserIQ
+- company: VirtualWorks
+  board: VirtualWorks
+- company: Appcoach
+  board: Appcoach
+- company: Aviso AI
+  board: AvisoAI
+- company: Flextock
+  board: Flextock
+- company: CTM360
+  board: CTM360
+- company: AdGate Media
+  board: AdGateMedia
+- company: Alitheon
+  board: Alitheon
+- company: Lalaland.ai
+  board: Lalaland
+- company: LucidChart
+  board: Lucidchart
+- company: Pattern AI
+  board: PatternAI
+- company: Retain.ai
+  board: Retainai
+- company: Vernacular.ai
+  board: Vernacularai
+- company: 合同会社AXIA
+  board: HeTongHuiSheAXIA
+- company: BukuWarung
+  board: BukuWarung
+- company: Zenefits
+  board: Zenefits
+- company: salesbox ai
+  board: SalesboxAi
+- company: WiNGS
+  board: WiNGS1
+- company: Actimo
+  board: Actimo
+- company: Alipes
+  board: Alipes
+- company: Alquds
+  board: Alquds
+- company: Atlas IAC
+  board: AtlasIAC
+- company: Bridj
+  board: Bridj
+- company: Clik.ai
+  board: Clikai
+- company: Kula
+  board: Kula
+- company: Line2
+  board: Line2
+- company: New Job 40
+  board: NewJob40
+- company: PanaceaLogics
+  board: PanaceaLogics
+- company: Parcel22
+  board: Parcel22
+- company: PeopleFlow
+  board: PeopleFlow
+- company: Yellow Messenger
+  board: YellowMessenger1
+- company: ElectroNeek
+  board: ElectroNeek
+- company: 株式会社M’ｓ
+  board: ZhuShiHuiSheMs
+- company: bStream
+  board: BStream
+- company: QACube
+  board: QACube
+- company: Quant Systems Inc
+  board: QuantSystemsInc
+- company: QuoteCenter
+  board: QuoteCenter
+- company: Yellow Class
+  board: YellowClass
+- company: Accordo
+  board: Accordo
+- company: Antimatter
+  board: Antimatter
+- company: APPx Crypto Technologies
+  board: APPxCryptoTechnologies
+- company: ARTIS
+  board: ARTIS1
+- company: AUDIENCEX
+  board: AUDIENCEX
+- company: Bigtincan
+  board: Bigtincan
+- company: Bitex
+  board: Bitex
+- company: Boost.ai
+  board: Boostai
+- company: "Borough, Inc"
+  board: BoroughInc
+- company: BridgeU
+  board: BridgeU1
+- company: Crypto Quantique
+  board: CryptoQuantique
+- company: emotif.ai
+  board: Emotifai
+- company: Envise
+  board: Envise
+- company: Forloop.ai
+  board: Forloopai
+- company: Going Merry
+  board: GoingMerry
+- company: GOOD BANK
+  board: GOODBANK
+- company: Jammy
+  board: Jammy
+- company: Kiya.ai
+  board: Kiyaai
+- company: MaestroQA
+  board: MaestroQA
+- company: Qgiv
+  board: Qgiv
+- company: SmartBarrel
+  board: SmartBarrel
+- company: Studio 29
+  board: Studio29
+- company: User.com
+  board: Usercom1
+- company: Virtuagym
+  board: Virtuagym
+- company: Vitalvibe
+  board: Vitalvibe
+- company: whiz.ai
+  board: Whizai1
+- company: ZingHR
+  board: ZingHR
+- company: Zooz
+  board: Zooz
+- company: Actiondesk
+  board: ActionDesk
+- company: Alpha Solutions
+  board: AlphaSolutions1
+- company: Bellabeat
+  board: Bellabeat
+- company: bluesheets
+  board: Bluesheets
+- company: CLARA analytics
+  board: CLARAAnalytics
+- company: dMetrics
+  board: DMetrics
+- company: Excepgen
+  board: ExcepGen
+- company: Innov8
+  board: Innov8
+- company: Kamcord
+  board: Kamcord
+- company: Loop Health
+  board: LoopHealth
+- company: Lucky415
+  board: Lucky415
+- company: Physikit
+  board: Physikit
+- company: SPRUIT AI
+  board: SPRUITAI
+- company: Statiq.
+  board: Statiq
+- company: Syrona Health
+  board: SyronaHealth
+- company: VOIQ
+  board: VOIQ
+- company: Zyper
+  board: Zyper
+- company: ACEA
+  board: ACEA1
+- company: AI Palette
+  board: AIPalette
+- company: AJCO
+  board: AJCO2
+- company: ALIVE
+  board: ALIVE5
+- company: Athos
+  board: Athos
+- company: Code11
+  board: Code113
+- company: ENLYZE
+  board: ENLYZE
+- company: J7
+  board: J7
+- company: Jyve
+  board: Jyve
+- company: KeyAGENT
+  board: KeyAGENT
+- company: Koru
+  board: Koru1
+- company: Leucine
+  board: Leucine
+- company: RockYou
+  board: RockYou
+- company: StratApps
+  board: StratApps

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3090,3 +3090,7 @@
   board: careers.phorest.com
 - company: INEXTO
   board: careers.inexto.com
+- company: Padoa
+  board: padoa.teamtailor.com
+- company: TISSIUM
+  board: tissium.teamtailor.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1414,3 +1414,117 @@
 # --- contributed boards ---
 - company: Pion
   board: wearepion
+- company: Esevel
+  board: lovebonito
+- company: Exponent Energy
+  board: exponent-energy
+- company: Rapyuta Robotics
+  board: rapyuta-robotics
+- company: Modash
+  board: modash
+- company: First Circle
+  board: first-circle
+- company: Hourly
+  board: hourly
+- company: Cowboy
+  board: cowboy
+- company: Povio
+  board: povio
+- company: Halo Industries
+  board: halo-industries
+- company: Ikerian
+  board: retinai
+- company: GroundTruth
+  board: groundtruth
+- company: Manna
+  board: manna-1
+- company: Extreme Reach
+  board: extremereach
+- company: Tutored by Teachers
+  board: tutoredbyteachers
+- company: Andromeda Robotics Operations
+  board: andromeda-robotics
+- company: TIN Capital
+  board: breachlock
+- company: Fundcraft
+  board: fundcraft
+- company: Yapily
+  board: yapily
+- company: Syntiant
+  board: syntiant
+- company: Flyability
+  board: flyability
+- company: Basetwo AI
+  board: basetwo
+- company: Fenergo
+  board: fenergocareers
+- company: Capital Factory
+  board: capital-factory
+- company: Cresilon
+  board: cresilon
+- company: Skimlinks
+  board: connexity
+- company: Eden GeoPower
+  board: eden-geopower
+- company: Palm Venture Studio
+  board: palm-venture-studios
+- company: Rise Robotics
+  board: rise-robotics
+- company: Nile
+  board: nile-fresh-pty-ltd
+- company: Owlet Baby Care
+  board: owlet-baby-care-1
+- company: SPOTIO
+  board: spotio
+- company: Connected Kerb
+  board: connected-kerb
+- company: Contrarian Ventures
+  board: zoomo
+- company: C4T (Customs4Trade)
+  board: customs4trade
+- company: Up Learn
+  board: uplearn
+- company: Cledara
+  board: cledara
+- company: Simple Mills
+  board: simple-mills-9
+- company: Screencastify
+  board: screencastify
+- company: Sapi
+  board: sapigroup
+- company: Lithos Carbon
+  board: lithos
+- company: Ofload
+  board: ofload
+- company: PastureMap
+  board: grassrootscarbon
+- company: Blackbird.AI
+  board: blackbirdai
+- company: Flowerbx
+  board: flowerbx
+- company: Bloomlife
+  board: bloomlife
+- company: Campus Ink
+  board: campusink
+- company: Workbox
+  board: workbox-company
+- company: Circonomit
+  board: circonomit
+- company: Genus AI
+  board: genus-ai
+- company: Little Journey
+  board: little-journey
+- company: CancerIQ
+  board: canceriq
+- company: Progressive Robotics
+  board: progressive-robotics
+- company: Station A
+  board: stationa
+- company: Convergent Energy + Power
+  board: convergent-careers
+- company: Lantum
+  board: lantum
+- company: Satellite Vu
+  board: satellitevu
+- company: DeepMirror
+  board: deepmirror


### PR DESCRIPTION
## What

Adds 306 ATS boards to `sources/*.yml`:

| provider | boards | | provider | boards |
|---|---|---|---|---|
| smartrecruiters | 127 | | recruitee | 10 |
| workable | 57 | | greenhouse | 8 |
| ashby | 45 | | bamboohr | 2 |
| personio | 45 | | teamtailor | 2 |
| lever | 10 | | | |

## How they were found

Followed the outbound apply-URLs on an aggregator's per-company pages — the same
mechanism as `scripts/mine_aggregators.py` — then ran the candidates through
`scripts/ats_boards.py`: dedup against `sources/*.yml`, then live validation against
the very endpoints the adapters call.

390 candidates were probed; **84 returned no live posting and were dropped** (e.g.
`lever/quantinuum`, whose posting API 404s), so every entry here had jobs at validation
time.

## Verification

- Spot-checked through the **real adapters**, not the validator: ashby `zafran-security`
  29 jobs, smartrecruiters `ACT-ON` 34, personio `felmo` 65, workable `rapyuta-robotics`
  33, greenhouse `instalilyai` 17, teamtailor `padoa` 16, recruitee `aikidosecurity` 63.
- Every touched file parses as YAML, and **no new duplicate board** is introduced
  (the pre-existing case-variant duplicates in ashby/smartrecruiters are untouched).
- `go build ./...` and `go test ./internal/sources/` pass.

Data only — no Go changes.