### PR TITLE
feat(cv): tell the candidate what tailoring did to their ATS score

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -101,11 +101,12 @@ func genStructs() (string, error) {
 				TypeMappings: map[string]string{"skillbundle.Bundle": "Bundle"},
 			},
 			{
-				// The CV ATS-readiness report wire shape (Report + Check + Status).
-				// Self-contained — only primitives and []Check.
+				// The CV ATS-readiness report wire shape (Report + Check + Status) and the
+				// two-report comparison (Delta + CategoryChange). Self-contained — only
+				// primitives, []Check and []CategoryChange.
 				Path:         "github.com/strelov1/freehire/internal/atscheck",
 				OutputPath:   atscheckTS,
-				IncludeFiles: []string{"atscheck.go"},
+				IncludeFiles: []string{"atscheck.go", "delta.go"},
 			},
 			{
 				// The per-job profile-match wire shape (JobMatch + AdjacentSkill).

--- a/internal/atscheck/delta.go
+++ b/internal/atscheck/delta.go
@@ -1,0 +1,74 @@
+package atscheck
+
+// Delta is the change one CV's ATS readiness shows against another's: the overall
+// move plus one entry per category, and — only when the overall fell — the category
+// that fell furthest. It compares two Reports and computes nothing itself, so the
+// five categories, their labels and their weights stay the scorer's business.
+//
+// JSON is the wire contract shared with the frontend (see cmd/gen-contracts).
+type Delta struct {
+	Base     int `json:"base"`     // the baseline CV's overall score
+	Tailored int `json:"tailored"` // the compared CV's overall score
+	Change   int `json:"change"`   // Tailored − Base, signed
+	// Categories reports only the categories present in BOTH reports: a category on
+	// one side alone is not a difference, and reporting it against an implied zero
+	// would invent a change nobody made.
+	Categories []CategoryChange `json:"categories"`
+	// Regressed is true when the overall score fell. A category may fall while the
+	// overall holds; that is not a regression, and WorstCategory stays empty for it.
+	Regressed bool `json:"regressed"`
+	// WorstCategory is the id of the category with the most negative change, set only
+	// when Regressed. An equal drop resolves to the earlier of the two in the compared
+	// report's own order, so the answer never depends on map iteration.
+	WorstCategory string `json:"worst_category,omitempty"`
+}
+
+// CategoryChange is one scoring category's move between the two reports.
+type CategoryChange struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	Base     int    `json:"base"`
+	Tailored int    `json:"tailored"`
+	Change   int    `json:"change"` // Tailored − Base, signed
+}
+
+// Compare reports how `tailored` differs from `base`. Categories are joined by id and
+// emitted in the tailored report's order; the worst-drop search walks that same order,
+// so an equal drop resolves to the earlier category rather than to whichever the map
+// happened to yield.
+func Compare(base, tailored Report) Delta {
+	baseByID := make(map[string]ScoreCategory, len(base.Categories))
+	for _, c := range base.Categories {
+		baseByID[c.ID] = c
+	}
+
+	d := Delta{
+		Base:     base.Overall,
+		Tailored: tailored.Overall,
+		Change:   tailored.Overall - base.Overall,
+	}
+	d.Regressed = d.Change < 0
+
+	worst := 0
+	for _, c := range tailored.Categories {
+		b, ok := baseByID[c.ID]
+		if !ok {
+			continue
+		}
+		change := c.Score - b.Score
+		d.Categories = append(d.Categories, CategoryChange{
+			ID:       c.ID,
+			Label:    c.Label,
+			Base:     b.Score,
+			Tailored: c.Score,
+			Change:   change,
+		})
+		// Strictly less keeps the first of an equal drop, which is why this reads the
+		// tailored order rather than sorting.
+		if d.Regressed && change < worst {
+			worst = change
+			d.WorstCategory = c.ID
+		}
+	}
+	return d
+}

--- a/internal/atscheck/delta_test.go
+++ b/internal/atscheck/delta_test.go
@@ -1,0 +1,144 @@
+package atscheck
+
+import "testing"
+
+// report builds a Report from (id, label, score) triples, with Overall as their sum —
+// the shape Score produces, without running the scorer.
+func report(cats ...ScoreCategory) Report {
+	overall := 0
+	for _, c := range cats {
+		overall += c.Score
+	}
+	return Report{Overall: overall, Categories: cats}
+}
+
+func cat(id, label string, score int) ScoreCategory {
+	return ScoreCategory{ID: id, Label: label, Score: score, Max: 30}
+}
+
+func changeByID(t *testing.T, d Delta, id string) CategoryChange {
+	t.Helper()
+	for _, c := range d.Categories {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("no category %q in %+v", id, d.Categories)
+	return CategoryChange{}
+}
+
+func TestCompareCategoryChangeIsTailoredMinusBase(t *testing.T) {
+	base := report(cat("keyword_strength", "Keyword Strength", 10), cat("format_compliance", "Format Compliance", 20))
+	tailored := report(cat("keyword_strength", "Keyword Strength", 18), cat("format_compliance", "Format Compliance", 15))
+
+	d := Compare(base, tailored)
+
+	kw := changeByID(t, d, "keyword_strength")
+	if kw.Base != 10 || kw.Tailored != 18 || kw.Change != 8 {
+		t.Errorf("keyword = {base %d tailored %d change %d}, want {10 18 8}", kw.Base, kw.Tailored, kw.Change)
+	}
+	format := changeByID(t, d, "format_compliance")
+	if format.Change != -5 {
+		t.Errorf("format change = %d, want -5", format.Change)
+	}
+	if d.Base != 30 || d.Tailored != 33 || d.Change != 3 {
+		t.Errorf("overall = {base %d tailored %d change %d}, want {30 33 3}", d.Base, d.Tailored, d.Change)
+	}
+}
+
+func TestCompareCarriesCategoryLabels(t *testing.T) {
+	base := report(cat("content_quality", "Content Quality", 5))
+	tailored := report(cat("content_quality", "Content Quality", 5))
+
+	if got := changeByID(t, Compare(base, tailored), "content_quality").Label; got != "Content Quality" {
+		t.Errorf("label = %q, want %q", got, "Content Quality")
+	}
+}
+
+func TestCompareIdenticalReportsAreZeroAndNotRegressed(t *testing.T) {
+	r := report(cat("keyword_strength", "Keyword Strength", 12), cat("length_density", "Length & Density", 8))
+
+	d := Compare(r, r)
+
+	if d.Change != 0 {
+		t.Errorf("overall change = %d, want 0", d.Change)
+	}
+	if len(d.Categories) != 2 {
+		t.Fatalf("categories = %d (%+v), want both reported even when nothing moved", len(d.Categories), d.Categories)
+	}
+	for _, c := range d.Categories {
+		if c.Change != 0 {
+			t.Errorf("category %s change = %d, want 0", c.ID, c.Change)
+		}
+	}
+	if d.Regressed {
+		t.Error("Regressed = true, want false for an unchanged CV")
+	}
+	if d.WorstCategory != "" {
+		t.Errorf("WorstCategory = %q, want empty when nothing regressed", d.WorstCategory)
+	}
+}
+
+func TestCompareLowerOverallIsRegressionNamingItsWorstCategory(t *testing.T) {
+	base := report(cat("keyword_strength", "Keyword Strength", 20), cat("format_compliance", "Format Compliance", 20))
+	tailored := report(cat("keyword_strength", "Keyword Strength", 18), cat("format_compliance", "Format Compliance", 5))
+
+	d := Compare(base, tailored)
+
+	if !d.Regressed {
+		t.Error("Regressed = false, want true when the tailored overall is lower")
+	}
+	if d.WorstCategory != "format_compliance" {
+		t.Errorf("WorstCategory = %q, want format_compliance (fell 15 vs 2)", d.WorstCategory)
+	}
+}
+
+func TestCompareEqualOverallIsNotRegression(t *testing.T) {
+	base := report(cat("keyword_strength", "Keyword Strength", 20), cat("format_compliance", "Format Compliance", 10))
+	tailored := report(cat("keyword_strength", "Keyword Strength", 25), cat("format_compliance", "Format Compliance", 5))
+
+	d := Compare(base, tailored)
+
+	if d.Regressed {
+		t.Error("Regressed = true, want false when the overall held despite a category falling")
+	}
+	if d.WorstCategory != "" {
+		t.Errorf("WorstCategory = %q, want empty when the overall did not fall", d.WorstCategory)
+	}
+}
+
+func TestCompareWorstCategoryTieTakesTheEarlierReportedCategory(t *testing.T) {
+	base := report(cat("keyword_strength", "Keyword Strength", 20), cat("format_compliance", "Format Compliance", 20))
+	tailored := report(cat("keyword_strength", "Keyword Strength", 17), cat("format_compliance", "Format Compliance", 17))
+
+	d := Compare(base, tailored)
+
+	if d.WorstCategory != "keyword_strength" {
+		t.Errorf("WorstCategory = %q, want keyword_strength — the earlier category wins an equal drop", d.WorstCategory)
+	}
+}
+
+func TestCompareReportsOnlyCategoriesPresentOnBothSides(t *testing.T) {
+	base := report(cat("keyword_strength", "Keyword Strength", 10))
+	tailored := report(cat("keyword_strength", "Keyword Strength", 12), cat("content_quality", "Content Quality", 9))
+
+	d := Compare(base, tailored)
+
+	if len(d.Categories) != 1 {
+		t.Fatalf("categories = %d (%+v), want 1 — a category on one side only is not a difference", len(d.Categories), d.Categories)
+	}
+	if d.Categories[0].ID != "keyword_strength" {
+		t.Errorf("category = %q, want keyword_strength", d.Categories[0].ID)
+	}
+}
+
+func TestCompareKeepsTheTailoredReportsCategoryOrder(t *testing.T) {
+	base := report(cat("length_density", "Length & Density", 5), cat("keyword_strength", "Keyword Strength", 5))
+	tailored := report(cat("keyword_strength", "Keyword Strength", 6), cat("length_density", "Length & Density", 6))
+
+	d := Compare(base, tailored)
+
+	if len(d.Categories) != 2 || d.Categories[0].ID != "keyword_strength" || d.Categories[1].ID != "length_density" {
+		t.Errorf("order = %+v, want the tailored report's order (keyword_strength, length_density)", d.Categories)
+	}
+}

--- a/internal/cv/AGENTS.md
+++ b/internal/cv/AGENTS.md
@@ -32,6 +32,36 @@ Fonts: the Typst binary embeds no proportional sans, so Liberation Sans (SIL OFL
 under `fonts/`, staged into the sandbox, and exposed via `--font-path`. A template that wants
 sans uses `#set text(font: "Liberation Sans")`.
 
+## ATS delta (tailored vs base)
+
+`GET /me/cvs/:id/ats-delta` reports what tailoring did to a CV's ATS readiness. The scoring
+input is the **rendered PDF's text layer**, not the stored document: the orchestration lives in
+`internal/handler/cv_ats_delta.go` (render → `resume.ExtractPDFText` → `skilltag.Parse` →
+`atscheck.Score`), and the two-report comparison is `atscheck.Compare`. A document field the
+active template never renders therefore earns nothing — `sidebar` has no certifications block,
+and the handler test pins exactly that.
+
+Four things the code decides and a reader would otherwise have to infer:
+
+- **The comparison holds everything but content constant.** The base CV is rendered with the
+  *tailored copy's* template and margins (an in-memory copy — the stored base is never touched),
+  and both sides are scored against one keyword baseline: the bound vacancy's canonical
+  `jobs.skills`. Not the role facet's top skills, and not the LLM's requirement match, whose
+  drift would move the delta while the CV stood still.
+- **The baseline is the base CV as it stands NOW.** There is one base CV per user
+  (`cv.Store.BaseCV`), not a snapshot taken when the copy was made, so editing the base moves
+  the delta. Deliberate — a snapshot would mean storing a second document per tailored CV —
+  and pinned by `TestATSDelta_ComparesAgainstTheCurrentBase`.
+- **The route is cookie-only, and that is the enforcement.** The tailoring agent authenticates
+  with a CLI credential, so the gate is what keeps the score away from the thing being measured.
+  Widening it to `mw.key` hands the agent a metric to optimise; `TestCVRegister_ATSDeltaIsCookieOnly`
+  is the tripwire.
+- **Unavailable is a 200, not a 501.** No renderer or a failed compile answers
+  `available: false` with a reason. `RenderCVPDF` 501s for the same condition because rendering
+  is what that caller asked for; the delta is an accessory read on a page that must keep working.
+
+Nothing is stored: it is recomputed per request, so a scoring-rule change needs no migration.
+
 ## Autopilot runs
 
 A tailored CV carries what the last unattended run left behind: `autopilot_report` (one entry

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -46,6 +46,9 @@ type cvHandlers struct {
 	// seeder answers what a new CV starts from: the banked work history plus the sections
 	// the stored structure still owns.
 	seeder cv.Seeder
+	// extractPDFText reads a rendered CV's text layer the way an ATS parser would. A field
+	// rather than a direct call so a test can state the text layer without a poppler binary.
+	extractPDFText func([]byte) (string, error)
 }
 
 // jobReader is the one vacancy read the tailoring context needs.
@@ -63,6 +66,7 @@ func newCVHandlers(queries *db.Queries, typstBin string, resumeStore *resume.Sto
 		credits:            creditsStore,
 		matchAnalysisCache: queries,
 		match:              match,
+		extractPDFText:     resume.ExtractPDFText,
 	}
 	// The renderer is enabled only when a typst binary was resolved (assign only a
 	// non-nil renderer so the interface stays nil when disabled — a typed-nil would

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -122,6 +122,10 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 	// Undo a whole autopilot run. Cookie-only: it rewrites the document, and the browser
 	// is where the candidate saw the run happen.
 	api.Post("/me/cvs/:id/autopilot/undo", mw.cookie, h.UndoAutopilotRun)
+	// What tailoring did to the CV's ATS readiness. Cookie-only, and deliberately so: the
+	// tailoring agent authenticates with a CLI credential, so this gate is what keeps the
+	// score out of the reach of the thing being measured.
+	api.Get("/me/cvs/:id/ats-delta", mw.cookie, h.GetCVATSDelta)
 }
 
 const maxCVTitleRunes = 200

--- a/internal/handler/cv_ats_delta.go
+++ b/internal/handler/cv_ats_delta.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/strelov1/freehire/internal/atscheck"
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// errNoRenderer is scoring's own missing-renderer error. The PDF endpoint answers 501 for
+// the same condition because rendering is what that caller asked for; the delta is an
+// accessory read, so it reports the score as unavailable instead (see the handler).
+var errNoRenderer = errors.New("cv renderer is not configured")
+
+// scoreRenderedCV renders a CV document and scores the text layer of the PDF it produced,
+// against `keywords` as the keyword baseline.
+//
+// The rendered text — not the document — is the scoring input, and that is the whole point:
+// a document field the active template never renders contributes nothing, a template that
+// buries the contact block scores its reading order as an ATS would read it, and a render
+// that yields no extractable text fails machine-readability instead of passing on the
+// strength of JSON nobody will parse. The CV's own skill set is parsed from that same text
+// for the same reason.
+func (h *cvHandlers) scoreRenderedCV(ctx context.Context, doc cv.Document, tmpl cv.Template, keywords []string) (atscheck.Report, error) {
+	if h.cvRenderer == nil {
+		return atscheck.Report{}, errNoRenderer
+	}
+	pdf, err := h.cvRenderer.Render(ctx, doc, tmpl)
+	if err != nil {
+		return atscheck.Report{}, fmt.Errorf("render cv for scoring: %w", err)
+	}
+	text, err := h.extractPDFText(pdf)
+	if err != nil {
+		return atscheck.Report{}, fmt.Errorf("extract rendered cv text: %w", err)
+	}
+	return atscheck.Score(text, skilltag.Parse(text, skilltag.WithResumeAcronyms()), keywords), nil
+}

--- a/internal/handler/cv_ats_delta.go
+++ b/internal/handler/cv_ats_delta.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+
+	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/atscheck"
 	"github.com/strelov1/freehire/internal/cv"
@@ -14,6 +17,95 @@ import (
 // the same condition because rendering is what that caller asked for; the delta is an
 // accessory read, so it reports the score as unavailable instead (see the handler).
 var errNoRenderer = errors.New("cv renderer is not configured")
+
+// atsDeltaResponse is the wire shape for the tailoring ATS delta. Available is false — with
+// a short reason and no Delta — when the comparison could not be made for an environmental
+// reason, so the workspace renders an absence instead of an error. BaseCVID names which base
+// CV the comparison was against: the baseline is the base CV as it stands NOW, not a snapshot
+// from when the copy was made, and a number whose baseline is anonymous invites misreading.
+type atsDeltaResponse struct {
+	Available bool            `json:"available"`
+	Reason    string          `json:"reason,omitempty"`
+	BaseCVID  string          `json:"base_cv_id,omitempty"`
+	Delta     *atscheck.Delta `json:"delta,omitempty"`
+}
+
+// GetCVATSDelta serves what tailoring did to a CV's ATS readiness: the tailored copy scored
+// against the base CV it came from, with the template, the page margins and the keyword
+// baseline held identical so the difference is the document's content and nothing else.
+//
+// Cookie-only and owner-scoped (a foreign id is the same 404 as a missing one). A CV that is
+// not a tailored copy has no defined baseline and is a 409 rather than a fabricated zero.
+// Recomputed per request and never stored, so it always reflects the current documents,
+// template and scoring rules.
+func (h *cvHandlers) GetCVATSDelta(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := cvPathID(c)
+	if err != nil {
+		return err
+	}
+	tailored, err := h.cvStore.Get(c.Context(), id, userID)
+	if err != nil {
+		return mapCVError(err)
+	}
+	if tailored.JobID == 0 {
+		return fiber.NewError(fiber.StatusConflict, "not a tailored CV: there is no base to compare against")
+	}
+	base, ok, err := h.cvStore.BaseCV(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fiber.NewError(fiber.StatusConflict, "no base CV to compare against")
+	}
+	tmpl, err := cv.ResolveTemplate(tailored.TemplateID)
+	if err != nil {
+		return mapCVError(err)
+	}
+	job, err := h.jobReader.GetJob(c.Context(), tailored.JobID)
+	if err != nil {
+		return err
+	}
+
+	// Hold everything but the content constant: the base is rendered with the tailored copy's
+	// template and margins (a copy of the document — the stored base is never touched), and
+	// both sides are scored against the vacancy's own canonical skills.
+	baseDoc := base.Document
+	baseDoc.Margins = tailored.Document.Margins
+
+	baseReport, err := h.scoreRenderedCV(c.Context(), baseDoc, tmpl, job.Skills)
+	if err != nil {
+		return h.atsDeltaUnavailable(c, err)
+	}
+	tailoredReport, err := h.scoreRenderedCV(c.Context(), tailored.Document, tmpl, job.Skills)
+	if err != nil {
+		return h.atsDeltaUnavailable(c, err)
+	}
+
+	delta := atscheck.Compare(baseReport, tailoredReport)
+	return c.JSON(fiber.Map{"data": atsDeltaResponse{
+		Available: true,
+		BaseCVID:  base.ID.String(),
+		Delta:     &delta,
+	}})
+}
+
+// atsDeltaUnavailable answers a scoring failure as an absent delta rather than an error: the
+// workspace this read serves must keep loading and editing when the renderer is missing or a
+// compile fails. The reason is a stable short string — the underlying error is logged, not
+// served, so a toolchain detail never reaches the client.
+func (h *cvHandlers) atsDeltaUnavailable(c *fiber.Ctx, err error) error {
+	reason := "could not read the rendered CV"
+	if errors.Is(err, errNoRenderer) {
+		reason = "CV rendering is not available"
+	} else {
+		log.Printf("cv ats-delta: %v", err)
+	}
+	return c.JSON(fiber.Map{"data": atsDeltaResponse{Available: false, Reason: reason}})
+}
 
 // scoreRenderedCV renders a CV document and scores the text layer of the PDF it produced,
 // against `keywords` as the keyword baseline.

--- a/internal/handler/cv_ats_delta.go
+++ b/internal/handler/cv_ats_delta.go
@@ -13,8 +13,9 @@ import (
 	"github.com/strelov1/freehire/internal/skilltag"
 )
 
-// errNoRenderer is scoring's own missing-renderer error. The PDF endpoint answers 501 for
-// the same condition because rendering is what that caller asked for; the delta is an
+// errNoRenderer is scoring's own missing-renderer error, covering both halves of the
+// toolchain: the Typst renderer and the PDF text extractor. The PDF endpoint answers 501 for
+// the renderer half because rendering is what that caller asked for; the delta is an
 // accessory read, so it reports the score as unavailable instead (see the handler).
 var errNoRenderer = errors.New("cv renderer is not configured")
 
@@ -117,7 +118,10 @@ func (h *cvHandlers) atsDeltaUnavailable(c *fiber.Ctx, err error) error {
 // strength of JSON nobody will parse. The CV's own skill set is parsed from that same text
 // for the same reason.
 func (h *cvHandlers) scoreRenderedCV(ctx context.Context, doc cv.Document, tmpl cv.Template, keywords []string) (atscheck.Report, error) {
-	if h.cvRenderer == nil {
+	// Both halves are checked, because a handler assembled with one and not the other exists:
+	// an unchecked extractor call turns a misassembled handler into a 500 rather than the
+	// unavailable delta every other missing-toolchain case yields.
+	if h.cvRenderer == nil || h.extractPDFText == nil {
 		return atscheck.Report{}, errNoRenderer
 	}
 	pdf, err := h.cvRenderer.Render(ctx, doc, tmpl)

--- a/internal/handler/cv_ats_delta_integration_test.go
+++ b/internal/handler/cv_ats_delta_integration_test.go
@@ -1,0 +1,276 @@
+//go:build integration
+
+// Integration tests for the tailoring ATS delta (tailor-ats-delta): the comparison holds the
+// template, margins and keyword baseline constant, owner isolation, the not-a-tailored-copy
+// conflict, and the degrade-not-fail path when no renderer is configured.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/atscheck"
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/resume"
+)
+
+// The base CV's rendered text: a clean CV that carries Go but not Kafka.
+const baseCVText = "Jane Roe\njane@example.com  +1 415 555 0134\n\nSummary\nBackend engineer.\n\nExperience\n2020-2024 Acme — Senior Engineer\n- Built Go services\n\nEducation\n2016-2020 BSc Computer Science\n\nSkills\nGolang"
+
+// The tailored CV's rendered text: the same CV with the vacancy's Kafka evidence added.
+const tailoredCVText = "Jane Roe\njane@example.com  +1 415 555 0134\n\nSummary\nBackend engineer. Core stack: Golang, Kafka.\n\nExperience\n2020-2024 Acme — Senior Engineer\n- Built Go services handling 2M requests/day\n- Ran Kafka pipelines for 4 teams\n\nEducation\n2016-2020 BSc Computer Science\n\nSkills\nGolang, Kafka"
+
+// seedJobWithSkills inserts a vacancy carrying canonical skills — the keyword baseline both
+// sides of the delta are scored against.
+func seedJobWithSkills(t *testing.T, pool *pgxpool.Pool, slug string, skills []string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, public_slug, skills)
+		 VALUES ('test', $1, 'https://e.test/'||$1, 'Backend Engineer', $1, $2) RETURNING id`,
+		slug, skills).Scan(&id); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	return id
+}
+
+// atsDeltaFixture stands up the CV surface with a base CV and one tailored copy bound to a
+// vacancy. The base deliberately differs from the copy in BOTH template and margins, so a
+// test can prove the comparison holds them constant.
+type atsDeltaFixture struct {
+	h        *cvHandlers
+	app      *fiber.App
+	token    string
+	renderer *fakeCVRenderer
+	base     cv.Meta
+	tailored cv.Meta
+	store    *cv.Store
+	userID   int64
+}
+
+func newATSDeltaFixture(t *testing.T, pool *pgxpool.Pool) atsDeltaFixture {
+	t.Helper()
+	queries := db.New(pool)
+	if _, err := pool.Exec(context.Background(), "TRUNCATE cvs, jobs, users RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	store := cv.NewStore(cv.NewQueriesRepository(queries))
+	renderer := &fakeCVRenderer{renderFn: func(doc cv.Document) []byte {
+		// The document's summary decides which side this is, so the assertion never depends
+		// on the order the handler renders them in.
+		if strings.Contains(doc.Summary, "tailored") {
+			return []byte(tailoredCVText)
+		}
+		return []byte(baseCVText)
+	}}
+	h := &cvHandlers{
+		queries: queries, jobReader: queries, cvStore: store,
+		resume:         resume.New(nil, resume.NewQueriesRepository(queries)),
+		cvRenderer:     renderer,
+		extractPDFText: textFromPDF,
+	}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	h.register(app.Group("/api/v1"), middleware{
+		cookie: auth.RequireAuth(iss, testVersions),
+		key:    auth.RequireAuth(iss, testVersions),
+	})
+
+	userID := seedAccount(t, pool, "delta@example.test", false)
+	token, _ := iss.Issue(userID, testTokenVersion)
+	jobID := seedJobWithSkills(t, pool, "backend-kafka", []string{"go", "kafka", "terraform"})
+
+	ctx := context.Background()
+	base, err := store.Create(ctx, userID, "Base", "centered", cv.Document{
+		Margins: cv.Margins{Top: 1.2, Right: 1.2, Bottom: 1.2, Left: 1.2},
+		Header:  cv.Header{FullName: "Jane Roe", Email: "jane@example.com"},
+		Summary: "base summary",
+	})
+	if err != nil {
+		t.Fatalf("create base cv: %v", err)
+	}
+	tailored, err := store.CreateTailored(ctx, userID, jobID, "Tailored", "classic-ats", cv.Document{
+		Margins: cv.Margins{Top: 0.4, Right: 0.4, Bottom: 0.4, Left: 0.4},
+		Header:  cv.Header{FullName: "Jane Roe", Email: "jane@example.com"},
+		Summary: "tailored summary",
+	})
+	if err != nil {
+		t.Fatalf("create tailored cv: %v", err)
+	}
+	return atsDeltaFixture{h: h, app: app, token: token, renderer: renderer,
+		base: base, tailored: tailored, store: store, userID: userID}
+}
+
+func (f atsDeltaFixture) get(t *testing.T, id string) (*fiber.Ctx, atsDeltaResponse, int) {
+	t.Helper()
+	resp := doCV(t, f.app, fiber.MethodGet, "/api/v1/me/cvs/"+id+"/ats-delta", f.token, nil)
+	defer resp.Body.Close()
+	var body struct {
+		Data atsDeltaResponse `json:"data"`
+	}
+	if resp.StatusCode == fiber.StatusOK {
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+	}
+	return nil, body.Data, resp.StatusCode
+}
+
+func TestATSDelta_ComparesTheTailoredCopyAgainstTheBase(t *testing.T) {
+	f := newATSDeltaFixture(t, startPostgres(t))
+
+	_, got, status := f.get(t, f.tailored.ID.String())
+
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !got.Available || got.Delta == nil {
+		t.Fatalf("available = %v delta = %v, want an available delta", got.Available, got.Delta)
+	}
+	if got.BaseCVID != f.base.ID.String() {
+		t.Errorf("base_cv_id = %q, want the base CV %q", got.BaseCVID, f.base.ID)
+	}
+	if got.Delta.Change <= 0 {
+		t.Errorf("change = %d, want positive: the tailored text adds the vacancy's Kafka evidence", got.Delta.Change)
+	}
+	if got.Delta.Regressed {
+		t.Error("regressed = true, want false when the tailored score rose")
+	}
+	if len(got.Delta.Categories) == 0 {
+		t.Error("categories = empty, want the scorer's categories")
+	}
+}
+
+func TestATSDelta_RendersBothSidesWithTheTailoredCopysTemplateAndMargins(t *testing.T) {
+	f := newATSDeltaFixture(t, startPostgres(t))
+
+	if _, _, status := f.get(t, f.tailored.ID.String()); status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	if f.renderer.calls != 2 {
+		t.Fatalf("render calls = %d, want 2 (base + tailored)", f.renderer.calls)
+	}
+	wantMargins := cv.Margins{Top: 0.4, Right: 0.4, Bottom: 0.4, Left: 0.4}
+	for i, doc := range f.renderer.docsSeen {
+		if doc.Margins != wantMargins {
+			t.Errorf("render %d margins = %+v, want the tailored copy's %+v", i, doc.Margins, wantMargins)
+		}
+	}
+	for i, tmpl := range f.renderer.tmplsSeen {
+		if tmpl.ID != "classic-ats" {
+			t.Errorf("render %d template = %q, want the tailored copy's classic-ats", i, tmpl.ID)
+		}
+	}
+}
+
+func TestATSDelta_LeavesTheBaseCVUntouched(t *testing.T) {
+	f := newATSDeltaFixture(t, startPostgres(t))
+	ctx := context.Background()
+	before, err := f.store.Get(ctx, f.base.ID, f.userID)
+	if err != nil {
+		t.Fatalf("read base before: %v", err)
+	}
+
+	if _, _, status := f.get(t, f.tailored.ID.String()); status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	after, err := f.store.Get(ctx, f.base.ID, f.userID)
+	if err != nil {
+		t.Fatalf("read base after: %v", err)
+	}
+	if after.TemplateID != before.TemplateID {
+		t.Errorf("base template = %q, want it unchanged at %q", after.TemplateID, before.TemplateID)
+	}
+	if after.Document.Margins != before.Document.Margins {
+		t.Errorf("base margins = %+v, want them unchanged at %+v", after.Document.Margins, before.Document.Margins)
+	}
+	if after.Document.Summary != before.Document.Summary {
+		t.Errorf("base summary = %q, want it unchanged at %q", after.Document.Summary, before.Document.Summary)
+	}
+}
+
+func TestATSDelta_ForeignCVIsNotFoundAndABaseCVIsAConflict(t *testing.T) {
+	pool := startPostgres(t)
+	f := newATSDeltaFixture(t, pool)
+
+	// A CV owned by somebody else is indistinguishable from one that does not exist.
+	otherID := seedAccount(t, pool, "other@example.test", false)
+	other, err := f.store.Create(context.Background(), otherID, "Theirs", "classic-ats", cv.Document{Summary: "theirs"})
+	if err != nil {
+		t.Fatalf("create foreign cv: %v", err)
+	}
+	if _, _, status := f.get(t, other.ID.String()); status != fiber.StatusNotFound {
+		t.Errorf("foreign cv = %d, want 404", status)
+	}
+
+	// A base CV has no baseline of its own.
+	if _, _, status := f.get(t, f.base.ID.String()); status != fiber.StatusConflict {
+		t.Errorf("base cv = %d, want 409", status)
+	}
+}
+
+func TestATSDelta_WithoutARendererDegradesInsteadOfFailing(t *testing.T) {
+	f := newATSDeltaFixture(t, startPostgres(t))
+	f.h.cvRenderer = nil
+
+	_, got, status := f.get(t, f.tailored.ID.String())
+
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 — an accessory read must not fail the workspace", status)
+	}
+	if got.Available {
+		t.Error("available = true, want false with no renderer configured")
+	}
+	if got.Reason == "" {
+		t.Error("reason = empty, want a stated reason")
+	}
+	if got.Delta != nil {
+		t.Errorf("delta = %+v, want nil when unavailable", got.Delta)
+	}
+}
+
+// TestATSDelta_ComparesAgainstTheCurrentBase pins the documented trade-off: the baseline is
+// the base CV as it stands NOW, not a snapshot from when the copy was made. Editing the base
+// moves the delta, and that is the behaviour to notice if it ever needs to change.
+func TestATSDelta_ComparesAgainstTheCurrentBase(t *testing.T) {
+	f := newATSDeltaFixture(t, startPostgres(t))
+	ctx := context.Background()
+
+	_, first, _ := f.get(t, f.tailored.ID.String())
+
+	// Rewrite the base so it now renders the same text as the tailored copy.
+	if _, err := f.store.Update(ctx, f.base.ID, f.userID, "Base", "centered", cv.Document{
+		Margins: cv.Margins{Top: 1.2, Right: 1.2, Bottom: 1.2, Left: 1.2},
+		Header:  cv.Header{FullName: "Jane Roe", Email: "jane@example.com"},
+		Summary: "tailored summary",
+	}); err != nil {
+		t.Fatalf("update base: %v", err)
+	}
+
+	_, second, _ := f.get(t, f.tailored.ID.String())
+
+	if first.Delta == nil || second.Delta == nil {
+		t.Fatalf("deltas = %v, %v, want both available", first.Delta, second.Delta)
+	}
+	if second.Delta.Change != 0 {
+		t.Errorf("change after the base caught up = %d, want 0", second.Delta.Change)
+	}
+	if first.Delta.Change == second.Delta.Change {
+		t.Errorf("change did not move (%d both times), want the baseline to track the current base CV",
+			first.Delta.Change)
+	}
+}
+
+// atscheck is imported for its Delta type in the response shape assertions above.
+var _ = atscheck.Delta{}

--- a/internal/handler/cv_ats_delta_integration_test.go
+++ b/internal/handler/cv_ats_delta_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/strelov1/freehire/internal/atscheck"
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/db"
@@ -110,7 +109,7 @@ func newATSDeltaFixture(t *testing.T, pool *pgxpool.Pool) atsDeltaFixture {
 		base: base, tailored: tailored, store: store, userID: userID}
 }
 
-func (f atsDeltaFixture) get(t *testing.T, id string) (*fiber.Ctx, atsDeltaResponse, int) {
+func (f atsDeltaFixture) get(t *testing.T, id string) (atsDeltaResponse, int) {
 	t.Helper()
 	resp := doCV(t, f.app, fiber.MethodGet, "/api/v1/me/cvs/"+id+"/ats-delta", f.token, nil)
 	defer resp.Body.Close()
@@ -122,13 +121,13 @@ func (f atsDeltaFixture) get(t *testing.T, id string) (*fiber.Ctx, atsDeltaRespo
 			t.Fatalf("decode: %v", err)
 		}
 	}
-	return nil, body.Data, resp.StatusCode
+	return body.Data, resp.StatusCode
 }
 
 func TestATSDelta_ComparesTheTailoredCopyAgainstTheBase(t *testing.T) {
 	f := newATSDeltaFixture(t, startPostgres(t))
 
-	_, got, status := f.get(t, f.tailored.ID.String())
+	got, status := f.get(t, f.tailored.ID.String())
 
 	if status != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -153,7 +152,7 @@ func TestATSDelta_ComparesTheTailoredCopyAgainstTheBase(t *testing.T) {
 func TestATSDelta_RendersBothSidesWithTheTailoredCopysTemplateAndMargins(t *testing.T) {
 	f := newATSDeltaFixture(t, startPostgres(t))
 
-	if _, _, status := f.get(t, f.tailored.ID.String()); status != fiber.StatusOK {
+	if _, status := f.get(t, f.tailored.ID.String()); status != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
 
@@ -181,7 +180,7 @@ func TestATSDelta_LeavesTheBaseCVUntouched(t *testing.T) {
 		t.Fatalf("read base before: %v", err)
 	}
 
-	if _, _, status := f.get(t, f.tailored.ID.String()); status != fiber.StatusOK {
+	if _, status := f.get(t, f.tailored.ID.String()); status != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
 
@@ -210,12 +209,12 @@ func TestATSDelta_ForeignCVIsNotFoundAndABaseCVIsAConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create foreign cv: %v", err)
 	}
-	if _, _, status := f.get(t, other.ID.String()); status != fiber.StatusNotFound {
+	if _, status := f.get(t, other.ID.String()); status != fiber.StatusNotFound {
 		t.Errorf("foreign cv = %d, want 404", status)
 	}
 
 	// A base CV has no baseline of its own.
-	if _, _, status := f.get(t, f.base.ID.String()); status != fiber.StatusConflict {
+	if _, status := f.get(t, f.base.ID.String()); status != fiber.StatusConflict {
 		t.Errorf("base cv = %d, want 409", status)
 	}
 }
@@ -224,7 +223,7 @@ func TestATSDelta_WithoutARendererDegradesInsteadOfFailing(t *testing.T) {
 	f := newATSDeltaFixture(t, startPostgres(t))
 	f.h.cvRenderer = nil
 
-	_, got, status := f.get(t, f.tailored.ID.String())
+	got, status := f.get(t, f.tailored.ID.String())
 
 	if status != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200 — an accessory read must not fail the workspace", status)
@@ -247,7 +246,7 @@ func TestATSDelta_ComparesAgainstTheCurrentBase(t *testing.T) {
 	f := newATSDeltaFixture(t, startPostgres(t))
 	ctx := context.Background()
 
-	_, first, _ := f.get(t, f.tailored.ID.String())
+	first, _ := f.get(t, f.tailored.ID.String())
 
 	// Rewrite the base so it now renders the same text as the tailored copy.
 	if _, err := f.store.Update(ctx, f.base.ID, f.userID, "Base", "centered", cv.Document{
@@ -258,7 +257,7 @@ func TestATSDelta_ComparesAgainstTheCurrentBase(t *testing.T) {
 		t.Fatalf("update base: %v", err)
 	}
 
-	_, second, _ := f.get(t, f.tailored.ID.String())
+	second, _ := f.get(t, f.tailored.ID.String())
 
 	if first.Delta == nil || second.Delta == nil {
 		t.Fatalf("deltas = %v, %v, want both available", first.Delta, second.Delta)
@@ -271,6 +270,3 @@ func TestATSDelta_ComparesAgainstTheCurrentBase(t *testing.T) {
 			first.Delta.Change)
 	}
 }
-
-// atscheck is imported for its Delta type in the response shape assertions above.
-var _ = atscheck.Delta{}

--- a/internal/handler/cv_ats_delta_test.go
+++ b/internal/handler/cv_ats_delta_test.go
@@ -1,0 +1,205 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/resume"
+)
+
+// fakeCVRenderer stands in for the Typst renderer: it records what it was asked to
+// render and returns canned bytes, so a scorer test needs no typst binary.
+type fakeCVRenderer struct {
+	pdf      []byte
+	err      error
+	gotDoc   cv.Document
+	gotTmpl  cv.Template
+	calls    int
+	perCall  [][]byte // when set, the bytes returned for call i
+	docsSeen []cv.Document
+}
+
+func (f *fakeCVRenderer) Render(_ context.Context, doc cv.Document, tmpl cv.Template) ([]byte, error) {
+	f.calls++
+	f.gotDoc, f.gotTmpl = doc, tmpl
+	f.docsSeen = append(f.docsSeen, doc)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if len(f.perCall) >= f.calls {
+		return f.perCall[f.calls-1], nil
+	}
+	return f.pdf, nil
+}
+
+// textFromPDF fakes the poppler text-layer extraction by treating the "PDF" bytes as
+// their own text, so a test states the text layer directly.
+func textFromPDF(b []byte) (string, error) { return string(b), nil }
+
+const scorableCV = "Jane Roe\njane@example.com  +1 415 555 0134\n\nSummary\nBackend engineer. Core stack: Golang, Kafka, Kubernetes.\n\nExperience\n2020-2024 Acme — Senior Engineer\n- Built Go services handling 2M requests/day\n- Led a team of 4 on Kubernetes migration\n\nEducation\n2016-2020 BSc Computer Science\n\nSkills\nGolang, Kafka, Kubernetes, PostgreSQL"
+
+func TestScoreRenderedCV_ScoresTheRenderedTextLayer(t *testing.T) {
+	r := &fakeCVRenderer{pdf: []byte(scorableCV)}
+	h := &cvHandlers{cvRenderer: r, extractPDFText: textFromPDF}
+	tmpl, err := cv.ResolveTemplate("classic-ats")
+	if err != nil {
+		t.Fatalf("ResolveTemplate: %v", err)
+	}
+
+	report, err := h.scoreRenderedCV(context.Background(), cv.Document{Summary: "ignored by the fake"}, tmpl, []string{"go", "kafka", "terraform"})
+	if err != nil {
+		t.Fatalf("scoreRenderedCV: %v", err)
+	}
+
+	if report.Overall <= 0 {
+		t.Errorf("overall = %d, want a positive score for a clean CV text", report.Overall)
+	}
+	if r.calls != 1 {
+		t.Errorf("render calls = %d, want 1", r.calls)
+	}
+	if r.gotTmpl.ID != "classic-ats" {
+		t.Errorf("rendered with template %q, want classic-ats", r.gotTmpl.ID)
+	}
+}
+
+func TestScoreRenderedCV_KeywordBaselineNamesTheMissingSkill(t *testing.T) {
+	h := &cvHandlers{cvRenderer: &fakeCVRenderer{pdf: []byte(scorableCV)}, extractPDFText: textFromPDF}
+	tmpl, _ := cv.ResolveTemplate("classic-ats")
+
+	report, err := h.scoreRenderedCV(context.Background(), cv.Document{}, tmpl, []string{"go", "kafka", "terraform"})
+	if err != nil {
+		t.Fatalf("scoreRenderedCV: %v", err)
+	}
+
+	if !strings.Contains(strings.Join(report.RecommendedKeywords, ","), "terraform") {
+		t.Errorf("recommended = %v, want terraform — it is in the baseline and absent from the CV", report.RecommendedKeywords)
+	}
+	if len(report.StrongKeywords) == 0 {
+		t.Errorf("strong = %v, want the baseline skills the CV text does carry", report.StrongKeywords)
+	}
+}
+
+func TestScoreRenderedCV_SkillsComeFromTheRenderedTextNotTheDocument(t *testing.T) {
+	// The document claims Rust; the rendered text layer does not mention it. The score
+	// describes the artifact, so Rust must not count as covered.
+	doc := cv.Document{Skills: []cv.SkillGroup{{Group: "Languages", Items: []string{"Rust"}}}}
+	h := &cvHandlers{cvRenderer: &fakeCVRenderer{pdf: []byte(scorableCV)}, extractPDFText: textFromPDF}
+	tmpl, _ := cv.ResolveTemplate("classic-ats")
+
+	report, err := h.scoreRenderedCV(context.Background(), doc, tmpl, []string{"rust"})
+	if err != nil {
+		t.Fatalf("scoreRenderedCV: %v", err)
+	}
+
+	if strings.Contains(strings.ToLower(strings.Join(report.StrongKeywords, ",")), "rust") {
+		t.Errorf("strong = %v, want rust absent — it is in the document but not in the rendered text", report.StrongKeywords)
+	}
+}
+
+func TestScoreRenderedCV_RenderFailureIsReported(t *testing.T) {
+	boom := errors.New("typst exploded")
+	h := &cvHandlers{cvRenderer: &fakeCVRenderer{err: boom}, extractPDFText: textFromPDF}
+	tmpl, _ := cv.ResolveTemplate("classic-ats")
+
+	_, err := h.scoreRenderedCV(context.Background(), cv.Document{}, tmpl, nil)
+
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want it to wrap the renderer's error", err)
+	}
+}
+
+func TestScoreRenderedCV_ExtractionFailureIsReported(t *testing.T) {
+	boom := errors.New("pdftotext missing")
+	h := &cvHandlers{
+		cvRenderer:     &fakeCVRenderer{pdf: []byte("whatever")},
+		extractPDFText: func([]byte) (string, error) { return "", boom },
+	}
+	tmpl, _ := cv.ResolveTemplate("classic-ats")
+
+	_, err := h.scoreRenderedCV(context.Background(), cv.Document{}, tmpl, nil)
+
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want it to wrap the extractor's error", err)
+	}
+}
+
+// TestScoreRenderedCV_AFieldTheTemplateDropsDoesNotScore is the claim the whole design
+// rests on, checked against the real toolchain: the score describes the rendered artifact,
+// so a document field the active template never renders cannot earn points. `sidebar` has
+// no certifications block while `classic-ats` does, so the same document — whose only
+// mention of Kubernetes is a certification — must score that keyword under one and miss it
+// under the other. Skips when typst or pdftotext is absent.
+func TestScoreRenderedCV_AFieldTheTemplateDropsDoesNotScore(t *testing.T) {
+	bin, err := exec.LookPath("typst")
+	if err != nil {
+		t.Skip("typst not installed; skipping rendered-artifact scoring")
+	}
+	if _, err := exec.LookPath("pdftotext"); err != nil {
+		t.Skip("pdftotext not installed; skipping rendered-artifact scoring")
+	}
+	h := &cvHandlers{cvRenderer: cv.NewTypstRenderer(bin), extractPDFText: resume.ExtractPDFText}
+
+	// Kubernetes appears in the certification and nowhere else in the document.
+	doc := cv.Document{
+		Margins: cv.DefaultMargins(),
+		Header:  cv.Header{FullName: "Ada Lovelace", Email: "ada@example.com", Phone: "+1 415 555 0134"},
+		Summary: "Backend engineer with a decade of systems work.",
+		Experience: []cv.ExperienceItem{
+			{Role: "Senior Engineer", Company: "Analytical Engines", Start: "2018", End: "Present",
+				Bullets: []string{"Cut p99 latency by 40% across 12 services."}},
+		},
+		Education: []cv.EducationItem{{Degree: "BSc Mathematics", Institution: "Cambridge", Start: "2010", End: "2014"}},
+		Skills:    []cv.SkillGroup{{Group: "Languages", Items: []string{"Go", "Python", "SQL"}}},
+		Certifications: []cv.Certification{
+			{Name: "Certified Kubernetes Administrator", Issuer: "CNCF", Year: "2023"},
+		},
+	}
+	classic, err := cv.ResolveTemplate("classic-ats")
+	if err != nil {
+		t.Fatalf("resolve classic-ats: %v", err)
+	}
+	sidebar, err := cv.ResolveTemplate("sidebar")
+	if err != nil {
+		t.Fatalf("resolve sidebar: %v", err)
+	}
+
+	withCerts, err := h.scoreRenderedCV(context.Background(), doc, classic, []string{"kubernetes"})
+	if err != nil {
+		t.Fatalf("score under classic-ats: %v", err)
+	}
+	withoutCerts, err := h.scoreRenderedCV(context.Background(), doc, sidebar, []string{"kubernetes"})
+	if err != nil {
+		t.Fatalf("score under sidebar: %v", err)
+	}
+
+	if !containsFold(withCerts.StrongKeywords, "kubernetes") {
+		t.Errorf("classic-ats strong = %v, want kubernetes — the template renders the certification that carries it",
+			withCerts.StrongKeywords)
+	}
+	if containsFold(withoutCerts.StrongKeywords, "kubernetes") {
+		t.Errorf("sidebar strong = %v, want kubernetes absent — the template drops the certification that carries it",
+			withoutCerts.StrongKeywords)
+	}
+}
+
+func containsFold(values []string, want string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScoreRenderedCV_NoRendererIsAnError(t *testing.T) {
+	h := &cvHandlers{extractPDFText: textFromPDF}
+	tmpl, _ := cv.ResolveTemplate("classic-ats")
+
+	if _, err := h.scoreRenderedCV(context.Background(), cv.Document{}, tmpl, nil); err == nil {
+		t.Error("err = nil, want an error when no renderer is configured")
+	}
+}

--- a/internal/handler/cv_ats_delta_test.go
+++ b/internal/handler/cv_ats_delta_test.go
@@ -306,3 +306,16 @@ func TestScoreRenderedCV_NoRendererIsAnError(t *testing.T) {
 		t.Error("err = nil, want an error when no renderer is configured")
 	}
 }
+
+// TestScoreRenderedCV_NoExtractorIsAnError guards the asymmetry that would otherwise be a
+// panic: a handler assembled with a renderer but no text extractor exists today
+// (cv_integration_test.go sets cvRenderer on a struct literal), so calling the extractor
+// unchecked turns a misassembled handler into a 500 instead of an unavailable delta.
+func TestScoreRenderedCV_NoExtractorIsAnError(t *testing.T) {
+	h := &cvHandlers{cvRenderer: &fakeCVRenderer{pdf: []byte(scorableCV)}}
+	tmpl, _ := cv.ResolveTemplate("classic-ats")
+
+	if _, err := h.scoreRenderedCV(context.Background(), cv.Document{}, tmpl, nil); err == nil {
+		t.Error("err = nil, want an error when no text extractor is configured")
+	}
+}

--- a/internal/handler/cv_ats_delta_test.go
+++ b/internal/handler/cv_ats_delta_test.go
@@ -3,10 +3,17 @@ package handler
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
 	"strings"
 	"testing"
 
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/atscheck"
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/resume"
 )
@@ -14,24 +21,27 @@ import (
 // fakeCVRenderer stands in for the Typst renderer: it records what it was asked to
 // render and returns canned bytes, so a scorer test needs no typst binary.
 type fakeCVRenderer struct {
-	pdf      []byte
-	err      error
-	gotDoc   cv.Document
-	gotTmpl  cv.Template
-	calls    int
-	perCall  [][]byte // when set, the bytes returned for call i
-	docsSeen []cv.Document
+	pdf []byte
+	err error
+	// renderFn, when set, derives the bytes from the document, so a test can tell the two
+	// sides of a comparison apart by content rather than by call order.
+	renderFn  func(cv.Document) []byte
+	gotTmpl   cv.Template
+	calls     int
+	docsSeen  []cv.Document
+	tmplsSeen []cv.Template
 }
 
 func (f *fakeCVRenderer) Render(_ context.Context, doc cv.Document, tmpl cv.Template) ([]byte, error) {
 	f.calls++
-	f.gotDoc, f.gotTmpl = doc, tmpl
+	f.gotTmpl = tmpl
 	f.docsSeen = append(f.docsSeen, doc)
+	f.tmplsSeen = append(f.tmplsSeen, tmpl)
 	if f.err != nil {
 		return nil, f.err
 	}
-	if len(f.perCall) >= f.calls {
-		return f.perCall[f.calls-1], nil
+	if f.renderFn != nil {
+		return f.renderFn(doc), nil
 	}
 	return f.pdf, nil
 }
@@ -183,6 +193,99 @@ func TestScoreRenderedCV_AFieldTheTemplateDropsDoesNotScore(t *testing.T) {
 	if containsFold(withoutCerts.StrongKeywords, "kubernetes") {
 		t.Errorf("sidebar strong = %v, want kubernetes absent — the template drops the certification that carries it",
 			withoutCerts.StrongKeywords)
+	}
+}
+
+// TestCVRegister_ATSDeltaIsCookieOnly pins the gate on the delta read against the real
+// register(). Cookie-only is the enforcement, not a preference: the tailoring agent
+// authenticates with a CLI credential, so a cookie-only route is what keeps the score away
+// from the thing being measured. Widening this to `key` or `cvKey` hands the agent a metric
+// to optimise, and this test is the tripwire.
+func TestCVRegister_ATSDeltaIsCookieOnly(t *testing.T) {
+	app := fiber.New()
+	api := app.Group("/api/v1")
+	(&cvHandlers{}).register(api, middleware{
+		key:    namedGate("key"),
+		cvKey:  namedGate("cvKey"),
+		cookie: namedGate("cookie"),
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/api/v1/me/cvs/"+uuid.New().String()+"/ats-delta", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if got := string(body); got != "cookie" {
+		t.Errorf("GET /me/cvs/:id/ats-delta is gated by %q, want %q", got, "cookie")
+	}
+}
+
+// TestScoreRenderedCV_RealToolchainDelta is the only test that exercises the whole scoring
+// path with the real binaries: two documents through typst and pdftotext into Compare. It
+// checks both directions the pipeline can be broken in — identical documents must yield a
+// zero delta (a nondeterministic render or a truncated extraction would not), and a document
+// that gains the vacancy's evidence must score above the one that lacks it (an extraction
+// that silently returned nothing would score both the same). Skips without the binaries.
+func TestScoreRenderedCV_RealToolchainDelta(t *testing.T) {
+	bin, err := exec.LookPath("typst")
+	if err != nil {
+		t.Skip("typst not installed; skipping real-toolchain delta")
+	}
+	if _, err := exec.LookPath("pdftotext"); err != nil {
+		t.Skip("pdftotext not installed; skipping real-toolchain delta")
+	}
+	h := &cvHandlers{cvRenderer: cv.NewTypstRenderer(bin), extractPDFText: resume.ExtractPDFText}
+	tmpl, err := cv.ResolveTemplate("classic-ats")
+	if err != nil {
+		t.Fatalf("resolve template: %v", err)
+	}
+	keywords := []string{"go", "kafka"}
+
+	base := cv.Document{
+		Margins: cv.DefaultMargins(),
+		Header:  cv.Header{FullName: "Ada Lovelace", Email: "ada@example.com", Phone: "+1 415 555 0134"},
+		Summary: "Backend engineer.",
+		Experience: []cv.ExperienceItem{
+			{Role: "Senior Engineer", Company: "Analytical Engines", Start: "2018", End: "Present",
+				Bullets: []string{"Built Go services."}},
+		},
+		Education: []cv.EducationItem{{Degree: "BSc Mathematics", Institution: "Cambridge", Start: "2010", End: "2014"}},
+		Skills:    []cv.SkillGroup{{Group: "Languages", Items: []string{"Go"}}},
+	}
+	tailored := base
+	tailored.Summary = "Backend engineer. Core stack: Go, Kafka."
+	tailored.Experience = []cv.ExperienceItem{
+		{Role: "Senior Engineer", Company: "Analytical Engines", Start: "2018", End: "Present",
+			Bullets: []string{"Built Go services handling 2M requests/day.", "Ran Kafka pipelines for 4 teams."}},
+	}
+	tailored.Skills = []cv.SkillGroup{{Group: "Languages", Items: []string{"Go", "Kafka"}}}
+
+	baseReport, err := h.scoreRenderedCV(context.Background(), base, tmpl, keywords)
+	if err != nil {
+		t.Fatalf("score base: %v", err)
+	}
+	tailoredReport, err := h.scoreRenderedCV(context.Background(), tailored, tmpl, keywords)
+	if err != nil {
+		t.Fatalf("score tailored: %v", err)
+	}
+
+	if d := atscheck.Compare(baseReport, baseReport); d.Change != 0 || len(d.Categories) == 0 {
+		t.Errorf("self-comparison = change %d over %d categories, want 0 over the scorer's categories",
+			d.Change, len(d.Categories))
+	}
+	d := atscheck.Compare(baseReport, tailoredReport)
+	if d.Change <= 0 {
+		t.Errorf("change = %d (base %d → tailored %d), want positive: the tailored document adds the vacancy's evidence",
+			d.Change, d.Base, d.Tailored)
+	}
+	if d.Regressed {
+		t.Errorf("regressed = true with change %d, want false", d.Change)
+	}
+	for _, c := range d.Categories {
+		if c.Change != c.Tailored-c.Base {
+			t.Errorf("category %s: change %d != tailored %d − base %d", c.ID, c.Change, c.Tailored, c.Base)
+		}
 	}
 }
 

--- a/openspec/changes/tailor-ats-delta/.openspec.yaml
+++ b/openspec/changes/tailor-ats-delta/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/tailor-ats-delta/design.md
+++ b/openspec/changes/tailor-ats-delta/design.md
@@ -119,6 +119,16 @@ contract that simply lacks the type.
   document per tailored CV, contradicting recompute-on-read for a case (editing the base mid-tailor)
   we have no evidence of. Accepted and documented; the response names which base CV it compared
   against so the number is never anonymous.
+- **A pruned vacancy can promote an orphan to "the base CV"** → Pre-existing, found while reviewing
+  this change, and NOT fixed here. `cvs_job_id_fkey` is `ON DELETE SET NULL`, so when `cmd/prune`
+  hard-deletes a job, its tailored copy keeps existing with `job_id` NULL — and
+  `GetBaseCVByUser` defines the base as the newest `job_id IS NULL` row. A recently-tailored
+  orphan therefore outranks the real base and becomes the baseline for every other tailored CV's
+  delta: wrong numbers, silently, with no crash. The orphan itself cannot be compared (its NULL
+  `job_id` is the 409 path), and it can never be its own baseline, so the damage is bounded to a
+  misleading comparison. The root cause is shared with `cv.Store.Tailor`, which seeds new copies
+  from that same query, so this predates the delta and fixing it properly means schema work (an
+  explicit `is_base` flag, or an FK that does not orphan) — its own change, not a rider on this one.
 - **A template switch is attributed to tailoring** → Prevented by design: the base is rendered with
   the tailored copy's template and margins, so a switch moves both sides together.
 - **Two renders on every workspace open** → Measured cheap (30–90 ms per compile). Watch the tailor

--- a/openspec/changes/tailor-ats-delta/design.md
+++ b/openspec/changes/tailor-ats-delta/design.md
@@ -1,0 +1,146 @@
+## Context
+
+`atscheck.Score` is pure and I/O-free and runs in exactly one place: `internal/handler/ats_report.go`
+scores the **uploaded** résumé's extracted text against the top-20 skills of a role facet. The CV
+builder is a different world — a structured `cv.Document` rendered to PDF by `cv.TypstRenderer` —
+and nothing there is ever scored. Tailoring therefore has no feedback loop: a run can thin the
+summary, overflow a page, or move the contact block behind a sidebar, and the candidate applies with
+a worse artifact than they started with.
+
+Everything needed already exists and is already shaped for this:
+
+- `atscheck.Score(cvText string, cvSkills, roleTopSkills []string) Report` — five categories summing
+  to 100, plus `Potential`.
+- `cv.Renderer` is an **interface** on `cvHandlers.cvRenderer`, left nil when no typst binary was
+  resolved (the existing 501 gate for `RenderCVPDF`). Fakeable in tests.
+- `resume.ExtractPDFText([]byte) (string, error)` is exported (`internal/resume/resume.go:271`) over
+  poppler's `pdftotext`.
+- `jobReader.GetJob(ctx, id) (db.Job, error)` is already a field on `cvHandlers`, and `db.Job` carries
+  canonical `Skills`.
+- `skilltag.Parse(text, skilltag.WithResumeAcronyms())` is how the existing report derives a CV's own
+  skills from its text.
+
+Measured before designing: a Typst compile of a representative CV takes **30–90 ms**
+(`go test ./internal/cv/ -run Render|Typst` — four templates compile in 0.15 s total), and
+`TestTypstRendererProducesExtractableATSText` already asserts a rendered CV's text layer carries the
+name and skills. So the honest path is also a cheap one.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Tell the candidate what tailoring did to their CV's machine-readability, measured on the artifact
+  an ATS will actually parse.
+- Isolate the tailoring's contribution: hold template, margins and keyword baseline constant across
+  both sides of the comparison.
+- Add no storage, no migration, and no new external dependency.
+
+**Non-Goals:**
+
+- The tailoring agent does not receive the score. Handing a metric to the thing being measured
+  invites keyword stuffing against the metric; that trade-off needs its own change and its own
+  evidence.
+- No LLM. The delta is deterministic; the existing optional LLM review stays where it is, on the
+  uploaded-résumé report.
+- No gating. Nothing about export, download or saving changes.
+- No new ATS category and no re-weighting. The five categories are the contract.
+
+## Decisions
+
+### Score the rendered PDF's text layer, not the stored document
+
+**Chosen:** render → `resume.ExtractPDFText` → `skilltag.Parse` → `atscheck.Score`.
+
+**Alternative rejected:** add a plain-text projection of `cv.Document` and score that. It is cheaper
+(no compile, no poppler) and it is exactly wrong: it would score what we intended to render. A
+sidebar template that buries contacts, a page that overflowed, a heading the active template drops —
+all invisible. The whole value of this change is reading the artifact back the way a parser reads it,
+which is the practice the upstream `ai-job-search` template converged on independently
+(`tools/verify_pdf.py` plus an ATS text-layer check after compiling).
+
+### Compute synchronously, cache nothing
+
+Two documents per request means two compiles and two `pdftotext` runs — under 400 ms with the
+measured numbers, on a read the client makes when a workspace opens and when a run ends.
+
+**Alternative rejected:** memoize the base CV's report by `(cv id, updated_at, template, margins,
+vacancy)`. It halves the work on repeat reads and buys a second source of truth for a score, plus a
+cache key with five components that must all be right. Not for savings we have not measured as a
+problem. If it ever becomes one, this is the escape hatch — and the key is written down here.
+
+### The comparison is a pure function in `internal/atscheck`
+
+`atscheck` owns `Report` and the five categories, so it owns what a difference between two reports
+means: a new `delta.go` with the wire type and a pure `Compare(base, tailored Report)`. Table-testable
+with no renderer, no HTTP, no DB.
+
+Orchestration — resolve both CVs, render both, extract, score, compare — lives in a new
+`internal/handler/cv_ats_delta.go` over the collaborators `cvHandlers` already holds.
+
+**Alternative rejected:** a new `internal/atsdelta` package. It would own one struct and one function
+and would have to import `atscheck` for both; the seam adds a name, not a boundary.
+
+### The keyword baseline is the bound vacancy's canonical skills
+
+Both sides are scored against `db.Job.Skills` for the vacancy the tailored CV is bound to, read
+through the existing `jobReader`.
+
+**Alternatives rejected:** the role's top-20 facet skills (what the uploaded-résumé report uses) —
+needs a search round-trip and is strictly less precise than the vacancy the CV is *for*; and
+`matchanalysis.RequirementMatch` — LLM-derived, so the baseline could shift between two reads and
+move the delta while the CV stood still. A deterministic delta needs a deterministic baseline.
+
+### The route is cookie-only, and that is the enforcement
+
+`GET /me/cvs/:id/ats-delta` registers with `mw.cookie`. The tailoring agent authenticates with a
+short-lived CLI credential, so a cookie-only route is closed to it by transport — the "the agent does
+not see the score" non-goal is enforced by the router, not asked for in a system prompt. This follows
+the project's existing line: rules that are ours to enforce live in the service path, not in prompt
+text.
+
+### Unavailability is a 200, not a 501
+
+The response carries `available: false` plus a reason when the renderer is absent or a render fails —
+the same shape as the existing report's `has_cv: false`. `RenderCVPDF` answers 501 when
+`cvRenderer` is nil because rendering *is* what the caller asked for; the delta is an accessory read
+on a page that must keep working, so it degrades instead.
+
+### The wire type must be added to the contracts generator
+
+`cmd/gen-contracts` lists `IncludeFiles: []string{"atscheck.go"}` for the atscheck package. A new
+`delta.go` is invisible to codegen unless it is added there, and the failure is silent — a TS
+contract that simply lacks the type.
+
+## Risks / Trade-offs
+
+- **The baseline is the base CV as it stands now, not as it stood when the copy was made** → If the
+  candidate edits their base CV after tailoring, the delta compares against something that was never
+  the copy's origin. Snapshotting the base at `Tailor` time would fix it and would mean a stored
+  document per tailored CV, contradicting recompute-on-read for a case (editing the base mid-tailor)
+  we have no evidence of. Accepted and documented; the response names which base CV it compared
+  against so the number is never anonymous.
+- **A template switch is attributed to tailoring** → Prevented by design: the base is rendered with
+  the tailored copy's template and margins, so a switch moves both sides together.
+- **Two renders on every workspace open** → Measured cheap (30–90 ms per compile). Watch the tailor
+  workspace's latency after ship; the memoization key above is the fix if it bites.
+- **Goodhart, if the score ever reaches the agent** → Blocked twice over: the non-goal, and a
+  cookie-only route the agent cannot call.
+- **A future scoring-rule change silently moves everyone's delta** → Acceptable, and preferable to
+  stored scores that would silently disagree with the current rules. Recompute-on-read means one
+  truth at a time.
+- **`pdftotext` missing on some deployment path** → Degrades to `available: false`, never a 500. The
+  production image already installs `poppler-utils` for résumé upload.
+
+## Migration Plan
+
+No schema change, no migration, nothing persisted — the change is code-only and additively
+deployable. Rollback is a revert: with no stored delta there is nothing to clean up and no way for
+old data to become inconsistent. The web surface reads a new endpoint, so an SPA deployed ahead of
+the API sees a 404 and must render the delta as absent, which is the same path as
+`available: false`.
+
+## Open Questions
+
+None blocking. Deferred deliberately: whether the tailoring agent should ever see the score. Revisit
+only with evidence that candidates ignore a displayed regression — and then as a change that
+confronts the keyword-stuffing incentive head-on, not as a quiet route change.

--- a/openspec/changes/tailor-ats-delta/proposal.md
+++ b/openspec/changes/tailor-ats-delta/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+We generate a tailored CV and never score the artifact we produced. `atscheck.Score` runs in
+exactly one place — the uploaded résumé's ATS report — so tailoring can lower a CV's
+machine-readability (synonym stuffing that thins the summary, an overflowed page, contacts pushed
+out of reading order by a template change) and the candidate never learns. They apply with a
+document we made worse and we told them nothing.
+
+The fix is cheap because every part already exists: `atscheck.Score` is pure, `cv.TypstRenderer`
+renders the document, and `resume.ExtractPDFText` reads a PDF's text layer. What is missing is the
+loop that closes them — compile the CV, read it back the way a parser reads it, and say what
+changed.
+
+## What Changes
+
+- **Score a tailored CV from its rendered PDF's text layer**, not from its stored JSON. The JSON is
+  what we meant; the text layer is what an ATS sees. This is the only way the score can catch a
+  layout regression, a non-ATS-safe template, or a contact block that stopped being first.
+- **Compare against the base CV the copy was made from**, rendered with the same template and
+  scored against the same vacancy, so the delta isolates the tailoring's contribution rather than
+  mixing in a template switch or a different keyword baseline.
+- **Serve an overall delta and a per-category delta** over the five existing `atscheck` categories.
+  A negative overall delta is reported as a warning that names the category that fell.
+- **Surface it in the tailoring workspace.** Informational only: nothing is blocked, no export is
+  gated, no confirmation is demanded. The candidate already has undo; this gives them the fact.
+- **Recompute on read.** Nothing new is stored, so the delta always reflects the current document,
+  the current template and the current scoring rules.
+
+Not in this change, and deliberately: the tailoring agent does not receive the score. Handing a
+metric to the thing being measured invites it to optimise the metric instead of the CV, and that
+tradeoff deserves its own change with its own evidence.
+
+## Capabilities
+
+### New Capabilities
+- `tailor-ats-delta`: scoring a tailored CV from its rendered artifact's text layer, comparing it
+  against the base CV under identical rendering and keyword conditions, and reporting the overall
+  and per-category change (including the warning when readability fell).
+
+### Modified Capabilities
+None. `cv-ats-score`'s requirements are about the profile's uploaded CV and stay true as written;
+this change adds a second, separately-specified subject rather than altering the first.
+`tailor-workspace`'s existing requirements (the three-column surface, the preview, the template
+picker) are unchanged — the delta's presentation contract is specified by the new capability that
+owns it, so there is one home for the feature instead of a requirement split across two specs.
+
+## Impact
+
+- **New**: an owner-scoped read endpoint under `/me/cvs/:id/` serving the delta; a small domain unit
+  that turns two `atscheck.Report`s into a comparison.
+- **Reused unchanged**: `internal/atscheck` (`Score`, the five categories), `internal/resume`
+  (`ExtractPDFText`), `internal/cv` (`TypstRenderer.Render`, `ResolveTemplate`).
+- **Web**: the tailoring workspace gains a delta indicator; `cmd/gen-contracts` picks up the new
+  wire shape.
+- **Cost**: a request scores two documents, so it pays two Typst compiles and two `pdftotext` runs.
+  Whether that is served synchronously per request, and what bounds it, is a design question — the
+  numbers, not the shape, are what design.md has to settle.
+- **Dependency**: scoring now needs poppler in the API image on a path that previously only needed
+  it for résumé upload. The production image already installs `poppler-utils`; a deployment without
+  it must degrade to "no delta available", never to a 500.

--- a/openspec/changes/tailor-ats-delta/specs/tailor-ats-delta/spec.md
+++ b/openspec/changes/tailor-ats-delta/specs/tailor-ats-delta/spec.md
@@ -1,0 +1,149 @@
+## ADDED Requirements
+
+### Requirement: A tailored CV is scored from its rendered artifact
+
+The system SHALL score a tailored CV by rendering it to PDF with its own template and page
+margins, extracting the PDF's text layer, and running the deterministic ATS score over that text.
+It MUST NOT score the stored CV document directly: the document is what we meant, the text layer is
+what a parser reads, and only the latter can expose a layout or reading-order regression.
+
+The CV's own skill set SHALL be parsed from the same extracted text (the existing résumé-acronym
+skill tagging), so the score describes the artifact and nothing outside it.
+
+#### Scenario: The score reads the rendered text layer
+- **WHEN** a tailored CV is scored
+- **THEN** the score is computed from text extracted from the rendered PDF, and a document whose
+  rendered text layer is empty (a template producing no extractable text) fails machine-readability
+  rather than scoring as if the JSON had been read
+
+#### Scenario: The stored document is not the scoring input
+- **WHEN** the stored document contains a field the active template does not render
+- **THEN** that field contributes nothing to the score
+
+### Requirement: The comparison holds everything but the tailoring constant
+
+The delta SHALL compare the tailored CV against the base CV it was copied from, with every scoring
+input other than the document content held identical: the base CV SHALL be rendered with the
+**tailored copy's** template and page margins, and both sides SHALL be scored against the **same**
+keyword baseline — the canonical skills of the vacancy the tailored CV is bound to.
+
+The base CV's own template and margins SHALL NOT be used, and the base CV SHALL NOT be modified in
+any way by scoring it.
+
+#### Scenario: A template difference does not leak into the delta
+- **WHEN** the base CV's stored template differs from the tailored copy's
+- **THEN** both sides are rendered with the tailored copy's template, so the delta reflects content
+  only
+
+#### Scenario: Both sides share one keyword baseline
+- **WHEN** the delta is computed for a CV bound to a vacancy
+- **THEN** the vacancy's canonical skills are the keyword baseline for both the base and the
+  tailored score
+
+#### Scenario: Scoring the base CV leaves it untouched
+- **WHEN** the delta is computed
+- **THEN** the base CV's stored document, template and margins are unchanged afterwards
+
+### Requirement: The delta reports the overall and per-category change
+
+The response SHALL carry, for the overall score and for each of the five ATS categories, the base
+value, the tailored value, and their signed difference. The category set and its labels SHALL be
+the ones the ATS score already defines — this change introduces no new category and no new
+weighting.
+
+#### Scenario: Every category carries before, after and difference
+- **WHEN** a delta is served
+- **THEN** the overall and each of the five categories report base, tailored, and a signed delta,
+  and each category's delta equals its tailored value minus its base value
+
+#### Scenario: An unchanged document reports a zero delta
+- **WHEN** the tailored CV's content is identical to the base CV's
+- **THEN** every reported delta is zero
+
+### Requirement: A drop in ATS readability is reported as a warning
+
+When the tailored CV's overall score is **lower** than the base CV's, the response SHALL mark the
+delta as a regression and name the category that fell furthest, so the candidate learns not only
+that the CV got worse but where. A score that rose or held SHALL NOT be marked as a regression.
+
+The warning is informational. The system MUST NOT block, gate, or require confirmation for any
+action because of it — rendering, downloading, or exporting the tailored CV SHALL behave exactly as
+it does without the delta.
+
+#### Scenario: A regression names its worst category
+- **WHEN** the tailored overall score is below the base overall score
+- **THEN** the response is marked as a regression and names the category with the most negative
+  delta
+
+#### Scenario: An improvement is not a regression
+- **WHEN** the tailored overall score is equal to or above the base overall score
+- **THEN** the response is not marked as a regression and names no category
+
+#### Scenario: A regression gates nothing
+- **WHEN** the delta is a regression
+- **THEN** the tailored CV's PDF still renders and downloads without confirmation
+
+### Requirement: The delta is computed on read and never stored
+
+The delta SHALL be computed per request from the current documents, the current template and the
+current scoring rules, and no part of it SHALL be persisted. A subsequent scoring-rule change or
+document edit SHALL therefore be reflected on the next read with no migration or invalidation step.
+
+#### Scenario: A repeated read of an unchanged CV is identical
+- **WHEN** the delta is read twice with no edit in between
+- **THEN** both responses are identical
+
+#### Scenario: An edit is reflected on the next read
+- **WHEN** the tailored CV is edited and the delta is read again
+- **THEN** the new response reflects the edit, and no stored delta had to be invalidated
+
+### Requirement: The delta is owner-scoped and only defined for a tailored CV
+
+The read SHALL be owner-scoped: a CV belonging to another account SHALL be indistinguishable from
+one that does not exist. A CV that is not a tailored copy — one with no base CV or no bound vacancy
+— has no defined comparison and SHALL be refused as a conflict, not answered with a fabricated
+baseline.
+
+#### Scenario: Another account's CV is not found
+- **WHEN** a caller reads the delta for a CV owned by a different account
+- **THEN** the response is the same not-found as for a CV id that does not exist
+
+#### Scenario: A base CV has no delta
+- **WHEN** a caller reads the delta for a CV that is not a tailored copy
+- **THEN** the response is a conflict naming the reason, and no score is computed
+
+### Requirement: An unavailable renderer degrades the delta, not the workspace
+
+When the delta cannot be computed for an environmental reason — the Typst renderer or the PDF text
+extractor is unavailable, or a render fails — the response SHALL report the delta as unavailable
+with a reason, with a success status. It MUST NOT return a server error and MUST NOT prevent the
+tailoring workspace from loading or the CV from being edited.
+
+#### Scenario: A missing renderer yields an unavailable delta
+- **WHEN** the CV renderer is not configured in the running environment
+- **THEN** the response reports the delta as unavailable with a reason and a success status
+
+#### Scenario: A failed render does not fail the workspace
+- **WHEN** rendering either side fails
+- **THEN** the delta is reported unavailable and the workspace continues to load and edit the CV
+
+### Requirement: The workspace surfaces the delta without being asked
+
+The tailoring workspace SHALL request the delta when it opens and again after an autopilot run
+completes — the two moments the document is most likely to have changed — and display the overall
+change, the per-category breakdown, and the regression warning when there is one. The candidate
+SHALL NOT have to trigger a check to be told their CV got worse.
+
+An unavailable delta SHALL render as an absence, not as an error state.
+
+#### Scenario: Opening the workspace shows the delta
+- **WHEN** the tailoring workspace opens for a tailored CV
+- **THEN** the delta is requested and its overall change and per-category breakdown are displayed
+
+#### Scenario: A completed run refreshes the delta
+- **WHEN** an autopilot run finishes
+- **THEN** the delta is requested again and the displayed values reflect the run's edits
+
+#### Scenario: An unavailable delta shows nothing rather than an error
+- **WHEN** the delta is reported unavailable
+- **THEN** the workspace displays no delta and no error state

--- a/openspec/changes/tailor-ats-delta/tasks.md
+++ b/openspec/changes/tailor-ats-delta/tasks.md
@@ -12,14 +12,14 @@
 
 ## 2. Scoring one CV from its rendered artifact
 
-- [ ] 2.1 Add `internal/handler/cv_ats_delta.go` with the single-side scorer: render a `cv.Document`
+- [x] 2.1 Add `internal/handler/cv_ats_delta.go` with the single-side scorer: render a `cv.Document`
       with a given template and margins through `cvHandlers.cvRenderer`, extract the text layer with
       `resume.ExtractPDFText`, parse the CV's own skills from that text with
       `skilltag.Parse(..., skilltag.WithResumeAcronyms())`, and score with `atscheck.Score` against a
       supplied keyword baseline. Tests use a fake `cv.Renderer` returning fixture PDF bytes and cover:
       the score is computed from the extracted text; a render error and an extraction error are both
       reported as unavailable-with-reason rather than as failures.
-- [ ] 2.2 Assert the anti-regression the design turns on: a document field the active template does
+- [x] 2.2 Assert the anti-regression the design turns on: a document field the active template does
       not render contributes nothing to the score (score the same document under two templates that
       differ in what they render).
 

--- a/openspec/changes/tailor-ats-delta/tasks.md
+++ b/openspec/changes/tailor-ats-delta/tasks.md
@@ -55,7 +55,7 @@
 
 ## 5. Close out
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...`; web lint and build.
-- [ ] 5.2 Document the delta in the CV/tailoring reference material that names the ATS report today,
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...`; web lint and build.
+- [x] 5.2 Document the delta in the CV/tailoring reference material that names the ATS report today,
       including the one trade-off a reader would otherwise trip on: the baseline is the base CV as it
       stands now, not a snapshot from when the copy was made.

--- a/openspec/changes/tailor-ats-delta/tasks.md
+++ b/openspec/changes/tailor-ats-delta/tasks.md
@@ -1,0 +1,61 @@
+## 1. The comparison (pure, no I/O)
+
+- [ ] 1.1 Add `internal/atscheck/delta.go`: the wire type (overall base/tailored/delta, one entry per
+      category with the same ids and labels the report uses, a regression flag, and the worst-drop
+      category id) plus `Compare(base, tailored Report) Delta`. Table tests cover: every category's
+      delta equals tailored minus base; identical reports yield all-zero deltas and no regression; a
+      lower tailored overall sets the regression flag and names the most negative category; equal
+      overalls are not a regression; a tie on the worst drop resolves deterministically.
+- [ ] 1.2 Add `delta.go` to the atscheck entry in `cmd/gen-contracts/main.go` `IncludeFiles` and
+      regenerate, so `web/src/lib/generated/contracts.ts` carries the new type. Verify the type is
+      present in the generated file — codegen omission here is silent.
+
+## 2. Scoring one CV from its rendered artifact
+
+- [ ] 2.1 Add `internal/handler/cv_ats_delta.go` with the single-side scorer: render a `cv.Document`
+      with a given template and margins through `cvHandlers.cvRenderer`, extract the text layer with
+      `resume.ExtractPDFText`, parse the CV's own skills from that text with
+      `skilltag.Parse(..., skilltag.WithResumeAcronyms())`, and score with `atscheck.Score` against a
+      supplied keyword baseline. Tests use a fake `cv.Renderer` returning fixture PDF bytes and cover:
+      the score is computed from the extracted text; a render error and an extraction error are both
+      reported as unavailable-with-reason rather than as failures.
+- [ ] 2.2 Assert the anti-regression the design turns on: a document field the active template does
+      not render contributes nothing to the score (score the same document under two templates that
+      differ in what they render).
+
+## 3. The delta endpoint
+
+- [ ] 3.1 Register `GET /me/cvs/:id/ats-delta` with `mw.cookie` in `internal/handler/cv.go`. Test that
+      a full-scope Bearer key is refused — the cookie-only route is what keeps the tailoring agent
+      from reading the score, so it needs a test that fails if someone widens it to `mw.key`.
+- [ ] 3.2 Implement the handler: resolve the tailored CV owner-scoped (another account's id is the
+      same not-found as a missing id), resolve its base CV and bound vacancy, refuse a CV that is not
+      a tailored copy with a conflict naming the reason, read the vacancy's canonical `Skills` through
+      `jobReader.GetJob`, score both sides with the **tailored copy's** template and margins, and
+      return `Compare`'s result. Tests cover the owner-scoping, the not-a-tailored-copy conflict, and
+      that both sides were rendered with the tailored copy's template even when the base CV's stored
+      template differs.
+- [ ] 3.3 Test the degrade path end to end: with `cvRenderer` nil the response is a success status
+      carrying `available: false` and a reason — not the 501 `RenderCVPDF` returns.
+- [ ] 3.4 Test that scoring leaves the base CV untouched: its stored document, template and margins
+      are identical after a delta read.
+- [ ] 3.5 Add a renderer-backed test that skips when typst or pdftotext is absent (the skip pattern in
+      `internal/cv/renderer_test.go`), asserting a real render of two documents produces a coherent
+      delta — this is the only test that proves the real toolchain path works.
+
+## 4. The workspace surface
+
+- [ ] 4.1 Add the client read for the new endpoint in the web app and render the delta in the tailoring
+      workspace: overall change, per-category breakdown, and the regression warning naming the
+      category that fell. An unavailable delta renders as an absence, with no error state.
+- [ ] 4.2 Request the delta when the workspace opens and again when an autopilot run completes, so a
+      regression reaches the candidate without them asking for a check.
+- [ ] 4.3 Verify visually at desktop and mobile widths (the workspace collapses to a tabbed view on
+      mobile — the delta must have a home there too, not overflow the column).
+
+## 5. Close out
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...`; web lint and build.
+- [ ] 5.2 Document the delta in the CV/tailoring reference material that names the ATS report today,
+      including the one trade-off a reader would otherwise trip on: the baseline is the base CV as it
+      stands now, not a snapshot from when the copy was made.

--- a/openspec/changes/tailor-ats-delta/tasks.md
+++ b/openspec/changes/tailor-ats-delta/tasks.md
@@ -1,12 +1,12 @@
 ## 1. The comparison (pure, no I/O)
 
-- [ ] 1.1 Add `internal/atscheck/delta.go`: the wire type (overall base/tailored/delta, one entry per
+- [x] 1.1 Add `internal/atscheck/delta.go`: the wire type (overall base/tailored/delta, one entry per
       category with the same ids and labels the report uses, a regression flag, and the worst-drop
       category id) plus `Compare(base, tailored Report) Delta`. Table tests cover: every category's
       delta equals tailored minus base; identical reports yield all-zero deltas and no regression; a
       lower tailored overall sets the regression flag and names the most negative category; equal
       overalls are not a regression; a tie on the worst drop resolves deterministically.
-- [ ] 1.2 Add `delta.go` to the atscheck entry in `cmd/gen-contracts/main.go` `IncludeFiles` and
+- [x] 1.2 Add `delta.go` to the atscheck entry in `cmd/gen-contracts/main.go` `IncludeFiles` and
       regenerate, so `web/src/lib/generated/contracts.ts` carries the new type. Verify the type is
       present in the generated file — codegen omission here is silent.
 

--- a/openspec/changes/tailor-ats-delta/tasks.md
+++ b/openspec/changes/tailor-ats-delta/tasks.md
@@ -50,7 +50,7 @@
       category that fell. An unavailable delta renders as an absence, with no error state.
 - [x] 4.2 Request the delta when the workspace opens and again when an autopilot run completes, so a
       regression reaches the candidate without them asking for a check.
-- [ ] 4.3 Verify visually at desktop and mobile widths (the workspace collapses to a tabbed view on
+- [x] 4.3 Verify visually at desktop and mobile widths (the workspace collapses to a tabbed view on
       mobile — the delta must have a home there too, not overflow the column).
 
 ## 5. Close out

--- a/openspec/changes/tailor-ats-delta/tasks.md
+++ b/openspec/changes/tailor-ats-delta/tasks.md
@@ -45,10 +45,10 @@
 
 ## 4. The workspace surface
 
-- [ ] 4.1 Add the client read for the new endpoint in the web app and render the delta in the tailoring
+- [x] 4.1 Add the client read for the new endpoint in the web app and render the delta in the tailoring
       workspace: overall change, per-category breakdown, and the regression warning naming the
       category that fell. An unavailable delta renders as an absence, with no error state.
-- [ ] 4.2 Request the delta when the workspace opens and again when an autopilot run completes, so a
+- [x] 4.2 Request the delta when the workspace opens and again when an autopilot run completes, so a
       regression reaches the candidate without them asking for a check.
 - [ ] 4.3 Verify visually at desktop and mobile widths (the workspace collapses to a tabbed view on
       mobile — the delta must have a home there too, not overflow the column).

--- a/openspec/changes/tailor-ats-delta/tasks.md
+++ b/openspec/changes/tailor-ats-delta/tasks.md
@@ -25,21 +25,21 @@
 
 ## 3. The delta endpoint
 
-- [ ] 3.1 Register `GET /me/cvs/:id/ats-delta` with `mw.cookie` in `internal/handler/cv.go`. Test that
+- [x] 3.1 Register `GET /me/cvs/:id/ats-delta` with `mw.cookie` in `internal/handler/cv.go`. Test that
       a full-scope Bearer key is refused — the cookie-only route is what keeps the tailoring agent
       from reading the score, so it needs a test that fails if someone widens it to `mw.key`.
-- [ ] 3.2 Implement the handler: resolve the tailored CV owner-scoped (another account's id is the
+- [x] 3.2 Implement the handler: resolve the tailored CV owner-scoped (another account's id is the
       same not-found as a missing id), resolve its base CV and bound vacancy, refuse a CV that is not
       a tailored copy with a conflict naming the reason, read the vacancy's canonical `Skills` through
       `jobReader.GetJob`, score both sides with the **tailored copy's** template and margins, and
       return `Compare`'s result. Tests cover the owner-scoping, the not-a-tailored-copy conflict, and
       that both sides were rendered with the tailored copy's template even when the base CV's stored
       template differs.
-- [ ] 3.3 Test the degrade path end to end: with `cvRenderer` nil the response is a success status
+- [x] 3.3 Test the degrade path end to end: with `cvRenderer` nil the response is a success status
       carrying `available: false` and a reason — not the 501 `RenderCVPDF` returns.
-- [ ] 3.4 Test that scoring leaves the base CV untouched: its stored document, template and margins
+- [x] 3.4 Test that scoring leaves the base CV untouched: its stored document, template and margins
       are identical after a delta read.
-- [ ] 3.5 Add a renderer-backed test that skips when typst or pdftotext is absent (the skip pattern in
+- [x] 3.5 Add a renderer-backed test that skips when typst or pdftotext is absent (the skip pattern in
       `internal/cv/renderer_test.go`), asserting a real render of two documents produces a coherent
       delta — this is the only test that proves the real toolchain path works.
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -11,6 +11,7 @@
 // requests from sharing (and racing on) a session.
 
 import type {
+  CvAtsDelta,
   CvMeta,
   CvRecord,
   CvTailoredItem,
@@ -1352,6 +1353,13 @@ export function createApi(
     return requestData<CvRecord>(`/api/v1/me/cvs/${id}`);
   }
 
+  /** What tailoring did to a tailored CV's ATS readiness, against the base CV it came from.
+   *  Cookie-only and recomputed per request. 409 for a CV that is not a tailored copy; the
+   *  response itself reports `available: false` when the comparison could not be made. */
+  async function getCvAtsDelta(id: string): Promise<CvAtsDelta> {
+    return requestData<CvAtsDelta>(`/api/v1/me/cvs/${id}/ats-delta`);
+  }
+
   /** Replace a CV's title, template, and document. */
   async function updateCv(id: string, input: UpdateCvInput): Promise<CvMeta> {
     return requestData<CvMeta>(`/api/v1/me/cvs/${id}`, jsonBody('PUT', input));
@@ -1587,6 +1595,7 @@ export function createApi(
     listCvTemplates,
     setCvTemplate,
     getCv,
+    getCvAtsDelta,
     updateCv,
     deleteCv,
     setCvSession,

--- a/web/src/lib/cv.ts
+++ b/web/src/lib/cv.ts
@@ -4,6 +4,7 @@
 // unit-testable.
 
 import type {
+  Delta as AtsDeltaWire,
   Document,
   Margins,
   ExperienceItem,
@@ -74,6 +75,21 @@ export const DEFAULT_TEMPLATE_ID = 'classic-ats';
 
 /** A CV template the user can pick in the gallery. `ats_safe` is false for richer layouts
  *  (e.g. the sidebar) that may not parse cleanly in some ATS. Mirrors cv.TemplateInfo. */
+// The two-report comparison behind the tailoring ATS delta.
+export type { Delta as AtsDelta, CategoryChange as AtsCategoryChange } from './generated/contracts';
+
+/** The tailoring ATS-delta response: what tailoring did to the CV's ATS readiness, measured on
+ *  the rendered artifact. `available` is false — with a `reason` and no `delta` — when the
+ *  comparison could not be made (no renderer, a failed compile), and the workspace then shows
+ *  nothing rather than an error. `base_cv_id` names the base CV compared against: the baseline is
+ *  that CV as it stands now, not a snapshot from when the copy was made. */
+export interface CvAtsDelta {
+  available: boolean;
+  reason?: string;
+  base_cv_id?: string;
+  delta?: AtsDeltaWire;
+}
+
 export interface CvTemplate {
   id: string;
   label: string;

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -363,6 +363,49 @@ export interface Report {
   suggestions?: string[];
 }
 
+//////////
+// source: delta.go
+
+/**
+ * Delta is the change one CV's ATS readiness shows against another's: the overall
+ * move plus one entry per category, and — only when the overall fell — the category
+ * that fell furthest. It compares two Reports and computes nothing itself, so the
+ * five categories, their labels and their weights stay the scorer's business.
+ * JSON is the wire contract shared with the frontend (see cmd/gen-contracts).
+ */
+export interface Delta {
+  base: number /* int */; // the baseline CV's overall score
+  tailored: number /* int */; // the compared CV's overall score
+  change: number /* int */; // Tailored − Base, signed
+  /**
+   * Categories reports only the categories present in BOTH reports: a category on
+   * one side alone is not a difference, and reporting it against an implied zero
+   * would invent a change nobody made.
+   */
+  categories: CategoryChange[];
+  /**
+   * Regressed is true when the overall score fell. A category may fall while the
+   * overall holds; that is not a regression, and WorstCategory stays empty for it.
+   */
+  regressed: boolean;
+  /**
+   * WorstCategory is the id of the category with the most negative change, set only
+   * when Regressed. An equal drop resolves to the earlier of the two in the compared
+   * report's own order, so the answer never depends on map iteration.
+   */
+  worst_category?: string;
+}
+/**
+ * CategoryChange is one scoring category's move between the two reports.
+ */
+export interface CategoryChange {
+  id: string;
+  label: string;
+  base: number /* int */;
+  tailored: number /* int */;
+  change: number /* int */; // Tailored − Base, signed
+}
+
 /**
  * AdjacentSkill is a job skill the profile does not hold exactly but for which it
  * holds a substitutable neighbour; Via names that held neighbour.

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -10,8 +10,9 @@
   import CompanyLogo from '$lib/components/CompanyLogo.svelte';
   import TemplateGallery from './TemplateGallery.svelte';
   import AutopilotReport from './AutopilotReport.svelte';
+  import AtsDelta from './AtsDelta.svelte';
   import type { Analysis, AutopilotEntry } from '$lib/generated/contracts';
-  import type { Job, MatchAnalysisResponse } from '$lib/types';
+  import type { CvAtsDelta, Job, MatchAnalysisResponse } from '$lib/types';
 
   type Tab = 'templates' | 'jd' | 'verdict';
 
@@ -28,6 +29,7 @@
     autopilotReport = undefined,
     autopilotRevertable = false,
     autopilotBusy = false,
+    atsDelta = null,
     onRerunAutopilot,
     onUndoAutopilot,
   }: {
@@ -42,6 +44,9 @@
     autopilotReport?: AutopilotEntry[];
     autopilotRevertable?: boolean;
     autopilotBusy?: boolean;
+    /** What tailoring did to the CV's ATS readiness. Null renders nothing — an unavailable
+     *  delta is an absence, not an error state. */
+    atsDelta?: CvAtsDelta | null;
     onRerunAutopilot: () => void;
     onUndoAutopilot: () => void;
   } = $props();
@@ -128,6 +133,9 @@
       </div>
     {:else}
       <div class="p-4">
+        <!-- The run's outcome before the run's log: what tailoring did to the CV an ATS will
+             parse, then how it got there, then the fit analysis underneath. -->
+        <AtsDelta data={atsDelta} />
         <AutopilotReport
           report={autopilotReport}
           revertable={autopilotRevertable}

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -12,7 +12,8 @@
   import AutopilotReport from './AutopilotReport.svelte';
   import AtsDelta from './AtsDelta.svelte';
   import type { Analysis, AutopilotEntry } from '$lib/generated/contracts';
-  import type { CvAtsDelta, Job, MatchAnalysisResponse } from '$lib/types';
+  import type { Job, MatchAnalysisResponse } from '$lib/types';
+  import type { CvAtsDelta } from '$lib/cv';
 
   type Tab = 'templates' | 'jd' | 'verdict';
 

--- a/web/src/lib/tailor/AtsDelta.svelte
+++ b/web/src/lib/tailor/AtsDelta.svelte
@@ -10,28 +10,29 @@
   // An unavailable delta renders nothing at all. A workspace that says "ATS score unavailable"
   // teaches the candidate to ignore the panel; an absence teaches nothing.
   import { TrendingDown, TrendingUp, Minus } from '@lucide/svelte';
-  import { viewAtsDelta } from './atsdelta';
+  import { viewAtsDelta, toneOf, type AtsDeltaTone } from './atsdelta';
   import type { CvAtsDelta } from '$lib/types';
 
   let { data }: { data: CvAtsDelta | null | undefined } = $props();
 
   const view = $derived(viewAtsDelta(data));
+
+  const toneClass: Record<AtsDeltaTone, string> = {
+    down: 'text-amber-600 dark:text-amber-400',
+    up: 'text-emerald-600 dark:text-emerald-400',
+    flat: 'text-muted-foreground',
+  };
+  const overallTone = $derived(view ? toneOf(view.overall.change, view.regressed) : 'flat');
 </script>
 
 {#if view}
   <section class="mb-4 rounded-xl border border-border bg-muted/30 p-3">
     <header class="mb-2 flex flex-wrap items-center justify-between gap-2">
       <h3 class="text-sm font-semibold text-foreground">ATS readability</h3>
-      <span
-        class="inline-flex items-center gap-1 text-sm font-semibold {view.regressed
-          ? 'text-amber-600 dark:text-amber-400'
-          : view.overall.change > 0
-            ? 'text-emerald-600 dark:text-emerald-400'
-            : 'text-muted-foreground'}"
-      >
-        {#if view.regressed}
+      <span class="inline-flex items-center gap-1 text-sm font-semibold {toneClass[overallTone]}">
+        {#if overallTone === 'down'}
           <TrendingDown class="size-4" aria-hidden="true" />
-        {:else if view.overall.change > 0}
+        {:else if overallTone === 'up'}
           <TrendingUp class="size-4" aria-hidden="true" />
         {:else}
           <Minus class="size-4" aria-hidden="true" />
@@ -54,13 +55,7 @@
       {#each view.rows as row (row.id)}
         <li class="flex items-center justify-between gap-2 text-xs">
           <span class="text-muted-foreground">{row.label}</span>
-          <span
-            class="tabular-nums {row.change < 0
-              ? 'text-amber-600 dark:text-amber-400'
-              : row.change > 0
-                ? 'text-emerald-600 dark:text-emerald-400'
-                : 'text-muted-foreground'}"
-          >
+          <span class="tabular-nums {toneClass[toneOf(row.change)]}">
             {row.base} → {row.tailored}
             <span class="text-muted-foreground">({row.text})</span>
           </span>

--- a/web/src/lib/tailor/AtsDelta.svelte
+++ b/web/src/lib/tailor/AtsDelta.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  // What tailoring did to the CV's ATS readiness, measured on the rendered PDF's text layer —
+  // the artifact a parser reads, not the document we meant to render. The tailored copy is
+  // compared against the base CV it came from, with the template, the margins and the keyword
+  // baseline held identical, so the number is the content's contribution and nothing else.
+  //
+  // Informational: it gates nothing. The candidate can still render, download and send a CV
+  // whose score fell — they simply get told that it did, and which category fell.
+  //
+  // An unavailable delta renders nothing at all. A workspace that says "ATS score unavailable"
+  // teaches the candidate to ignore the panel; an absence teaches nothing.
+  import { TrendingDown, TrendingUp, Minus } from '@lucide/svelte';
+  import { viewAtsDelta } from './atsdelta';
+  import type { CvAtsDelta } from '$lib/types';
+
+  let { data }: { data: CvAtsDelta | null | undefined } = $props();
+
+  const view = $derived(viewAtsDelta(data));
+</script>
+
+{#if view}
+  <section class="mb-4 rounded-xl border border-border bg-muted/30 p-3">
+    <header class="mb-2 flex flex-wrap items-center justify-between gap-2">
+      <h3 class="text-sm font-semibold text-foreground">ATS readability</h3>
+      <span
+        class="inline-flex items-center gap-1 text-sm font-semibold {view.regressed
+          ? 'text-amber-600 dark:text-amber-400'
+          : view.overall.change > 0
+            ? 'text-emerald-600 dark:text-emerald-400'
+            : 'text-muted-foreground'}"
+      >
+        {#if view.regressed}
+          <TrendingDown class="size-4" aria-hidden="true" />
+        {:else if view.overall.change > 0}
+          <TrendingUp class="size-4" aria-hidden="true" />
+        {:else}
+          <Minus class="size-4" aria-hidden="true" />
+        {/if}
+        {view.overall.base} → {view.overall.tailored}
+        <span class="font-normal">({view.overall.text})</span>
+      </span>
+    </header>
+
+    {#if view.warning}
+      <p
+        class="mb-2 rounded-lg bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300"
+        role="status"
+      >
+        {view.warning}
+      </p>
+    {/if}
+
+    <ul class="space-y-1">
+      {#each view.rows as row (row.id)}
+        <li class="flex items-center justify-between gap-2 text-xs">
+          <span class="text-muted-foreground">{row.label}</span>
+          <span
+            class="tabular-nums {row.change < 0
+              ? 'text-amber-600 dark:text-amber-400'
+              : row.change > 0
+                ? 'text-emerald-600 dark:text-emerald-400'
+                : 'text-muted-foreground'}"
+          >
+            {row.base} → {row.tailored}
+            <span class="text-muted-foreground">({row.text})</span>
+          </span>
+        </li>
+      {/each}
+    </ul>
+
+    <p class="mt-2 text-[11px] leading-snug text-muted-foreground">
+      Measured on the rendered PDF, against your base CV as it stands now.
+    </p>
+  </section>
+{/if}

--- a/web/src/lib/tailor/AtsDelta.svelte
+++ b/web/src/lib/tailor/AtsDelta.svelte
@@ -11,7 +11,7 @@
   // teaches the candidate to ignore the panel; an absence teaches nothing.
   import { TrendingDown, TrendingUp, Minus } from '@lucide/svelte';
   import { viewAtsDelta, toneOf, type AtsDeltaTone } from './atsdelta';
-  import type { CvAtsDelta } from '$lib/types';
+  import type { CvAtsDelta } from '$lib/cv';
 
   let { data }: { data: CvAtsDelta | null | undefined } = $props();
 

--- a/web/src/lib/tailor/atsdelta.test.ts
+++ b/web/src/lib/tailor/atsdelta.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { viewAtsDelta } from './atsdelta';
+import type { CvAtsDelta } from '$lib/types';
+
+function resp(over: Partial<CvAtsDelta> = {}): CvAtsDelta {
+  return {
+    available: true,
+    base_cv_id: 'base-1',
+    delta: {
+      base: 60,
+      tailored: 69,
+      change: 9,
+      regressed: false,
+      categories: [
+        { id: 'keyword_strength', label: 'Keyword Strength', base: 10, tailored: 18, change: 8 },
+        { id: 'format_compliance', label: 'Format Compliance', base: 20, tailored: 21, change: 1 },
+      ],
+    },
+    ...over,
+  };
+}
+
+describe('viewAtsDelta', () => {
+  it('is absent when there is nothing to show', () => {
+    expect(viewAtsDelta(null)).toBeNull();
+    expect(viewAtsDelta({ available: false, reason: 'CV rendering is not available' })).toBeNull();
+    expect(viewAtsDelta({ available: true })).toBeNull();
+  });
+
+  it('signs the overall change', () => {
+    expect(viewAtsDelta(resp())?.overall.text).toBe('+9');
+  });
+
+  it('renders a drop with a real minus sign, not a hyphen', () => {
+    const v = viewAtsDelta(
+      resp({
+        delta: {
+          base: 70,
+          tailored: 55,
+          change: -15,
+          regressed: true,
+          categories: [
+            { id: 'format_compliance', label: 'Format Compliance', base: 30, tailored: 15, change: -15 },
+          ],
+        },
+      }),
+    );
+    expect(v?.overall.text).toBe('−15');
+  });
+
+  it('says nothing changed rather than showing a bare zero', () => {
+    const v = viewAtsDelta(
+      resp({ delta: { base: 60, tailored: 60, change: 0, regressed: false, categories: [] } }),
+    );
+    expect(v?.overall.text).toBe('no change');
+  });
+
+  it('warns on a regression and names the category that fell furthest', () => {
+    const v = viewAtsDelta(
+      resp({
+        delta: {
+          base: 70,
+          tailored: 58,
+          change: -12,
+          regressed: true,
+          worst_category: 'format_compliance',
+          categories: [
+            { id: 'keyword_strength', label: 'Keyword Strength', base: 20, tailored: 22, change: 2 },
+            { id: 'format_compliance', label: 'Format Compliance', base: 30, tailored: 16, change: -14 },
+          ],
+        },
+      }),
+    );
+    expect(v?.regressed).toBe(true);
+    expect(v?.warning).toContain('Format Compliance');
+    expect(v?.warning).toContain('12');
+  });
+
+  it('warns without naming a category when the id is not among the rows', () => {
+    const v = viewAtsDelta(
+      resp({
+        delta: {
+          base: 70,
+          tailored: 65,
+          change: -5,
+          regressed: true,
+          worst_category: 'a_category_the_client_does_not_know',
+          categories: [
+            { id: 'keyword_strength', label: 'Keyword Strength', base: 20, tailored: 15, change: -5 },
+          ],
+        },
+      }),
+    );
+    expect(v?.regressed).toBe(true);
+    expect(v?.warning).toBeTruthy();
+    expect(v?.warning).not.toContain('undefined');
+  });
+
+  it('does not warn when the score held or rose', () => {
+    expect(viewAtsDelta(resp())?.warning).toBeUndefined();
+    expect(viewAtsDelta(resp())?.regressed).toBe(false);
+  });
+
+  it('carries every category through in the order served, each signed', () => {
+    const rows = viewAtsDelta(resp())?.rows ?? [];
+    expect(rows.map((r) => r.id)).toEqual(['keyword_strength', 'format_compliance']);
+    expect(rows.map((r) => r.text)).toEqual(['+8', '+1']);
+  });
+});

--- a/web/src/lib/tailor/atsdelta.test.ts
+++ b/web/src/lib/tailor/atsdelta.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { viewAtsDelta } from './atsdelta';
-import type { CvAtsDelta } from '$lib/types';
+import type { CvAtsDelta } from '$lib/cv';
 
 function resp(over: Partial<CvAtsDelta> = {}): CvAtsDelta {
   return {

--- a/web/src/lib/tailor/atsdelta.ts
+++ b/web/src/lib/tailor/atsdelta.ts
@@ -1,0 +1,72 @@
+// The tailoring ATS delta as the workspace shows it: signed numbers, and — when readability
+// fell — a warning that names the category responsible. Kept out of the component so the
+// wording and the sign handling are unit-tested rather than eyeballed in a browser.
+import type { CvAtsDelta } from '$lib/types';
+
+export interface AtsDeltaRow {
+  id: string;
+  label: string;
+  base: number;
+  tailored: number;
+  change: number;
+  /** The change as shown: '+8', '−15', or '0'. */
+  text: string;
+}
+
+export interface AtsDeltaView {
+  overall: { base: number; tailored: number; change: number; text: string };
+  regressed: boolean;
+  /** Set only on a regression: what fell, by how much, and where. */
+  warning?: string;
+  rows: AtsDeltaRow[];
+}
+
+/** signed renders a change with a real minus sign (U+2212), not a hyphen: these numbers sit
+ *  next to scores, and a hyphen there reads as a range. */
+function signed(change: number): string {
+  if (change > 0) return `+${change}`;
+  if (change < 0) return `−${Math.abs(change)}`;
+  return '0';
+}
+
+/**
+ * viewAtsDelta turns the endpoint's response into what the panel renders, or null when there
+ * is nothing to show — an unavailable delta is an absence, not an error state, so the caller
+ * has one falsy case to handle instead of two.
+ */
+export function viewAtsDelta(resp: CvAtsDelta | null | undefined): AtsDeltaView | null {
+  const delta = resp?.available ? resp.delta : undefined;
+  if (!delta) return null;
+
+  const rows: AtsDeltaRow[] = (delta.categories ?? []).map((c) => ({
+    id: c.id,
+    label: c.label,
+    base: c.base,
+    tailored: c.tailored,
+    change: c.change,
+    text: signed(c.change),
+  }));
+
+  const view: AtsDeltaView = {
+    overall: {
+      base: delta.base,
+      tailored: delta.tailored,
+      change: delta.change,
+      // A bare '0' beside a score reads as a score. Say it in words instead.
+      text: delta.change === 0 ? 'no change' : signed(delta.change),
+    },
+    regressed: delta.regressed,
+    rows,
+  };
+
+  if (delta.regressed) {
+    const worst = rows.find((r) => r.id === delta.worst_category);
+    const points = Math.abs(delta.change);
+    // The server names the worst category by id; an id this client does not know (an older
+    // SPA against a newer API) drops the clause rather than rendering 'undefined'.
+    view.warning = worst
+      ? `Tailoring lowered ATS readability by ${points} ${points === 1 ? 'point' : 'points'}, most of it in ${worst.label}.`
+      : `Tailoring lowered ATS readability by ${points} ${points === 1 ? 'point' : 'points'}.`;
+  }
+  return view;
+}

--- a/web/src/lib/tailor/atsdelta.ts
+++ b/web/src/lib/tailor/atsdelta.ts
@@ -1,7 +1,7 @@
 // The tailoring ATS delta as the workspace shows it: signed numbers, and — when readability
 // fell — a warning that names the category responsible. Kept out of the component so the
 // wording and the sign handling are unit-tested rather than eyeballed in a browser.
-import type { CvAtsDelta } from '$lib/types';
+import type { CvAtsDelta } from '$lib/cv';
 
 export interface AtsDeltaRow {
   id: string;

--- a/web/src/lib/tailor/atsdelta.ts
+++ b/web/src/lib/tailor/atsdelta.ts
@@ -60,13 +60,22 @@ export function viewAtsDelta(resp: CvAtsDelta | null | undefined): AtsDeltaView 
   };
 
   if (delta.regressed) {
-    const worst = rows.find((r) => r.id === delta.worst_category);
     const points = Math.abs(delta.change);
-    // The server names the worst category by id; an id this client does not know (an older
-    // SPA against a newer API) drops the clause rather than rendering 'undefined'.
-    view.warning = worst
-      ? `Tailoring lowered ATS readability by ${points} ${points === 1 ? 'point' : 'points'}, most of it in ${worst.label}.`
-      : `Tailoring lowered ATS readability by ${points} ${points === 1 ? 'point' : 'points'}.`;
+    // The server names the worst category by id; an id this client does not know (an older SPA
+    // against a newer API) drops the clause rather than rendering 'undefined'.
+    const worst = rows.find((r) => r.id === delta.worst_category);
+    const where = worst ? `, most of it in ${worst.label}` : '';
+    view.warning = `Tailoring lowered ATS readability by ${points} ${points === 1 ? 'point' : 'points'}${where}.`;
   }
   return view;
+}
+
+/** Which direction a change points, for the caller to map to its own styling. A regression is
+ *  its own tone rather than plain 'down': the overall score can fall while some category rose. */
+export type AtsDeltaTone = 'down' | 'up' | 'flat';
+
+export function toneOf(change: number, regressed = false): AtsDeltaTone {
+  if (regressed || change < 0) return 'down';
+  if (change > 0) return 'up';
+  return 'flat';
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -7,6 +7,7 @@ import type {
   Blocker,
   Professional,
   Report as ATSReportContract,
+  Delta as AtsDeltaContract,
   Analysis as MatchAnalysisContract,
 } from './generated/contracts';
 export type { Job, Enrichment, Verdict, Gap, SkillRow } from './generated/contracts';
@@ -30,6 +31,21 @@ export type {
 export interface ATSResponse {
   has_cv: boolean;
   report: ATSReportContract | null;
+}
+
+// The two-report comparison behind the tailoring ATS delta.
+export type { Delta as AtsDelta, CategoryChange as AtsCategoryChange } from './generated/contracts';
+
+/** The tailoring ATS-delta response: what tailoring did to the CV's ATS readiness, measured
+ *  on the rendered artifact. `available` is false — with a `reason` and no `delta` — when the
+ *  comparison could not be made (no renderer, a failed compile), and the workspace then shows
+ *  nothing rather than an error. `base_cv_id` names the base CV compared against: the baseline
+ *  is that CV as it stands now, not a snapshot from when the copy was made. */
+export interface CvAtsDelta {
+  available: boolean;
+  reason?: string;
+  base_cv_id?: string;
+  delta?: AtsDeltaContract;
 }
 
 // The on-demand LLM job-fit analysis wire shapes (five scored dimensions + the

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -7,7 +7,6 @@ import type {
   Blocker,
   Professional,
   Report as ATSReportContract,
-  Delta as AtsDeltaContract,
   Analysis as MatchAnalysisContract,
 } from './generated/contracts';
 export type { Job, Enrichment, Verdict, Gap, SkillRow } from './generated/contracts';
@@ -31,21 +30,6 @@ export type {
 export interface ATSResponse {
   has_cv: boolean;
   report: ATSReportContract | null;
-}
-
-// The two-report comparison behind the tailoring ATS delta.
-export type { Delta as AtsDelta, CategoryChange as AtsCategoryChange } from './generated/contracts';
-
-/** The tailoring ATS-delta response: what tailoring did to the CV's ATS readiness, measured
- *  on the rendered artifact. `available` is false — with a `reason` and no `delta` — when the
- *  comparison could not be made (no renderer, a failed compile), and the workspace then shows
- *  nothing rather than an error. `base_cv_id` names the base CV compared against: the baseline
- *  is that CV as it stands now, not a snapshot from when the copy was made. */
-export interface CvAtsDelta {
-  available: boolean;
-  reason?: string;
-  base_cv_id?: string;
-  delta?: AtsDeltaContract;
 }
 
 // The on-demand LLM job-fit analysis wire shapes (five scored dimensions + the

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -25,7 +25,7 @@
   import { undoRun, openingActions } from '$lib/tailor/autopilot';
   import { toEditable, emptyDocument, type CvRecord } from '$lib/cv';
   import type { Analysis, AutopilotEntry, Document } from '$lib/generated/contracts';
-  import type { Job } from '$lib/types';
+  import type { CvAtsDelta, Job } from '$lib/types';
 
   const slug = $derived(page.params.slug ?? '');
   const cvParam = $derived(page.url.searchParams.get('cv'));
@@ -56,6 +56,11 @@
   // side's work silently.
   let autopilotReport = $state<AutopilotEntry[] | undefined>(undefined);
   let autopilotRevertable = $state(false);
+  // What tailoring did to the CV's ATS readiness, refreshed at the two moments the document
+  // has just changed most: the workspace opening, and an agent turn finishing. Null until the
+  // first read, and after any failure — the panel renders it as an absence either way, so a
+  // score nobody can compute never becomes an error the candidate has to dismiss.
+  let atsDelta = $state<CvAtsDelta | null>(null);
   let runActive = $state(false);
   // Any turn, not just a run: "Run again" would silently do nothing while one is in flight.
   let turnActive = $state(false);
@@ -128,6 +133,17 @@
   }
   const loadCv = async () => hydrate(await api.getCv(cvId));
 
+  // Read the ATS delta for the current CV. Never throws: the workspace must load and edit
+  // whether or not the comparison is available, and a failed read is the same absence as an
+  // unavailable one.
+  async function refreshAtsDelta() {
+    try {
+      atsDelta = await api.getCvAtsDelta(cvId);
+    } catch {
+      atsDelta = null;
+    }
+  }
+
   onMount(async () => {
     try {
       if (cvParam) {
@@ -173,6 +189,9 @@
         });
       }
       status = 'ready';
+      // Not awaited: the workspace is usable before the comparison lands, and the comparison
+      // costs two renders.
+      void refreshAtsDelta();
     } catch (e) {
       if (e instanceof ApiError && e.status === 402) {
         // Out of AI credits: surface the message plus when the monthly grant renews.
@@ -235,6 +254,7 @@
     try {
       await loadCv();
       pdfVersion += 1;
+      void refreshAtsDelta();
     } catch {
       /* best-effort refresh; the next edit or reload will reconcile */
     }
@@ -263,6 +283,7 @@
         refetch: async () => {
           await loadCv();
           pdfVersion += 1;
+          void refreshAtsDelta();
         },
       });
     } catch (e) {
@@ -475,6 +496,7 @@
         {autopilotReport}
         autopilotRevertable={autopilotRevertable}
         autopilotBusy={turnActive || runActive || undoing}
+        {atsDelta}
         onRerunAutopilot={() => chatRef?.startRun()}
         onUndoAutopilot={undoAutopilot}
         {onTemplateSelected}

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -23,9 +23,9 @@
   import AccountNavRail from '$lib/components/AccountNavRail.svelte';
   import { clampWidth } from '$lib/tailor/geometry';
   import { undoRun, openingActions } from '$lib/tailor/autopilot';
-  import { toEditable, emptyDocument, type CvRecord } from '$lib/cv';
+  import { toEditable, emptyDocument, type CvRecord, type CvAtsDelta } from '$lib/cv';
   import type { Analysis, AutopilotEntry, Document } from '$lib/generated/contracts';
-  import type { CvAtsDelta, Job } from '$lib/types';
+  import type { Job } from '$lib/types';
 
   const slug = $derived(page.params.slug ?? '');
   const cvParam = $derived(page.url.searchParams.get('cv'));


### PR DESCRIPTION
## Why

We generate a tailored CV and never score the artifact we produced. `atscheck.Score` ran in exactly one place — the uploaded résumé's report — so tailoring could lower a CV's machine-readability and the candidate would never learn. They apply with a document we made worse and we told them nothing.

## What this does

`GET /me/cvs/:id/ats-delta` scores the tailored copy against the base CV it came from and reports the overall move, the per-category breakdown, and — when readability fell — a warning naming the category responsible. The tailoring workspace reads it when it opens and after every agent turn.

The scoring input is the **rendered PDF's text layer**, not the stored document: the JSON is what we meant, the text layer is what a parser reads. `sidebar` has no certifications block, so a keyword carried only there scores under `classic-ats` and not under `sidebar` — pinned by a real-toolchain test.

Four decisions worth reviewing:

- **The comparison holds everything but content constant.** The base is rendered with the *tailored copy's* template and margins (an in-memory copy — the stored base is never touched), and both sides are scored against one keyword baseline: the vacancy's canonical `jobs.skills`. Not the role facet's top skills, and not the LLM requirement match, whose drift would move the delta while the CV stood still.
- **Cookie-only, and that is the enforcement.** The tailoring agent authenticates with a CLI credential, so the route keeps the score away from the thing being measured. Keyword Strength is 40 of the 100 points and is exactly what an LLM can stuff, so this is load-bearing rather than tidy. `TestCVRegister_ATSDeltaIsCookieOnly` is the tripwire against widening it to `mw.key`.
- **Unavailable is a 200, not a 501.** No renderer or a failed compile answers `available: false` with a reason; the workspace renders an absence. `RenderCVPDF` 501s for the same condition because rendering is what *that* caller asked for.
- **Nothing is stored.** Recomputed per request, so a scoring-rule change needs no migration and no invalidation.

## Evidence

- **31 new tests**: 8 `atscheck` (pure comparison), 10 handler unit, 6 handler integration, 8 web view model. Two tests drive real `typst` + `pdftotext`.
- **The claim the design rests on was proven falsifiable**: neutralising the template difference makes the rendered-artifact test fail.
- **Four mutation checks** on the handler (margin alignment, the 409, degrade-not-fail, swapped comparison sides) — each breaks its own test.
- **Cost measured, not assumed**: a Typst compile is 30–90 ms, so two renders per read are served synchronously with no cache. The memoisation key is written down in `design.md` if it ever bites.
- Verified visually at 1280 px and 390 px (CDP device metrics, since `--window-size` does not honour widths below ~500 px).

## Found in review, deliberately not fixed here

`cvs_job_id_fkey` is `ON DELETE SET NULL`, and `GetBaseCVByUser` defines the base as the newest `job_id IS NULL` row. So when `cmd/prune` hard-deletes a job, its tailored copy is orphaned with a NULL `job_id` and can outrank the real base — becoming the baseline for other CVs' deltas. Pre-existing, shared with `cv.Store.Tailor` (which seeds copies from the same query), and a proper fix is schema work (an explicit `is_base` flag, or an FK that does not orphan). Recorded in `design.md`.

## Deploy

No migration, no new dependency, no config. `poppler-utils` is already in the production image for résumé upload; an environment without it degrades to `available: false` rather than erroring.

OpenSpec change: `openspec/changes/tailor-ats-delta/` (14/14 tasks).