### PR TITLE
fix(sources): let a response body outgrow 32 MiB, and name the cap when it does

### DIFF
--- a/internal/sources/fingerprinthttp.go
+++ b/internal/sources/fingerprinthttp.go
@@ -92,7 +92,7 @@ func (c *fingerprintHTTP) get(ctx context.Context, url string) ([]byte, error) {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("sources: GET %s: status %d", url, resp.StatusCode)
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	body, err := io.ReadAll(newCappedReader(resp.Body, url, maxResponseBody))
 	if err != nil {
 		return nil, fmt.Errorf("sources: read %s: %w", url, err)
 	}

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -106,16 +106,66 @@ type HTTPClient interface {
 	HeaderJSONPoster
 }
 
-// maxResponseBody caps how many bytes a decoder reads from any response. ATS list
-// feeds run to a few MB at most; this generous ceiling bounds a hostile or buggy
-// endpoint returning a multi-GB body (or a gzip bomb the transport transparently
-// inflates) so it cannot exhaust the worker's memory.
-const maxResponseBody = 32 << 20 // 32 MiB
+// maxResponseBody caps how many bytes a decoder reads from any response. It bounds a
+// hostile or buggy endpoint returning a multi-GB body (or a gzip bomb the transport
+// transparently inflates) so it cannot exhaust the worker's memory. The ceiling sits
+// well past the largest real feed: measured 2026-07-30, the biggest list bodies were
+// Lever jobgether 36.8 MiB, Greenhouse pulse 35.5 MiB and Anduril 34.6 MiB — a list
+// endpoint that inlines every description (`?content=true`) reaches tens of MiB at a
+// few thousand postings. The previous 32 MiB ceiling sat just under that, silently
+// truncating five of the largest boards; those now fetch, and a board that ever does
+// outgrow this one says so through BodyTooLargeError instead of looking transient.
+const maxResponseBody = 64 << 20 // 64 MiB
 
-// limitedBody caps how many bytes a decoder reads from a response while preserving
-// the original Closer, so the connection is still released after the bounded read.
-type limitedBody struct {
-	io.Reader
+// BodyTooLargeError is a response whose body ran past the size cap and was therefore
+// truncated mid-stream. It is NOT transient — the same board returns the same oversized
+// body on every run — so callers must not treat it as a fetch that might recover. A bare
+// io.LimitReader used to cap the read, which handed the decoder a truncated stream that
+// was indistinguishable from a dropped connection; Anduril's Greenhouse board then spent
+// six weeks reporting "unexpected EOF" and cooling down as if the network were at fault.
+type BodyTooLargeError struct {
+	URL   string
+	Limit int64
+}
+
+func (e *BodyTooLargeError) Error() string {
+	return fmt.Sprintf("sources: GET %s: body exceeds %d bytes", e.URL, e.Limit)
+}
+
+// cappedReader bounds how many bytes are read from a response body and names the cap when
+// it trips. The read window is limit+1 bytes: a body of exactly limit bytes is complete,
+// and only the sentinel byte past it proves truncation.
+type cappedReader struct {
+	r     io.Reader
+	url   string
+	limit int64
+	read  int64
+}
+
+func newCappedReader(r io.Reader, url string, limit int64) *cappedReader {
+	return &cappedReader{r: r, url: url, limit: limit}
+}
+
+func (b *cappedReader) Read(p []byte) (int, error) {
+	room := b.limit + 1 - b.read
+	if room <= 0 {
+		return 0, &BodyTooLargeError{URL: b.url, Limit: b.limit}
+	}
+	if int64(len(p)) > room {
+		p = p[:room]
+	}
+	n, err := b.r.Read(p)
+	b.read += int64(n)
+	if b.read > b.limit {
+		return n, &BodyTooLargeError{URL: b.url, Limit: b.limit}
+	}
+	return n, err
+}
+
+// cappedBody is a cappedReader that still closes the response body it wraps, so the
+// connection is released after the bounded read.
+type cappedBody struct {
+	*cappedReader
 	io.Closer
 }
 
@@ -131,6 +181,17 @@ type Client struct {
 	userAgent    string
 	maxRetries   int
 	retryDelay   time.Duration
+	// maxBody overrides maxResponseBody; zero means the default. Only tests set it, so a
+	// cap-trip case need not stream tens of MiB through the loopback.
+	maxBody int64
+}
+
+// bodyLimit is the response-size cap in effect for this client.
+func (c *Client) bodyLimit() int64 {
+	if c.maxBody > 0 {
+		return c.maxBody
+	}
+	return maxResponseBody
 }
 
 // NewClient builds the default ingest HTTP client.
@@ -427,7 +488,10 @@ func (c *Client) do(ctx context.Context, r request) error {
 		case resp.StatusCode >= 200 && resp.StatusCode < 300:
 			// Bound the read so a pathological body cannot OOM the worker; Close still
 			// runs on the underlying body to release the connection.
-			resp.Body = limitedBody{Reader: io.LimitReader(resp.Body, maxResponseBody), Closer: resp.Body}
+			resp.Body = cappedBody{
+				cappedReader: newCappedReader(resp.Body, r.url, c.bodyLimit()),
+				Closer:       resp.Body,
+			}
 			err := r.decode(resp)
 			resp.Body.Close()
 			if err != nil {

--- a/internal/sources/http_test.go
+++ b/internal/sources/http_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -252,5 +253,58 @@ func TestClientDoesNotRetryWAFChallenge(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Errorf("attempts = %d, want 1 (a challenge is not a transient failure)", attempts)
+	}
+}
+
+// A body past the size cap must name itself. Capping with a bare io.LimitReader hands the
+// decoder a truncated stream, which is indistinguishable from a dropped connection — that
+// is how a permanently oversized Greenhouse board (Anduril, 34.6 MiB against the old
+// 32 MiB cap) spent weeks reporting "unexpected EOF" and cooling down as if transient.
+func TestClientGetJSONSurfacesOversizedBodyAsTypedError(t *testing.T) {
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"content":%q}`, strings.Repeat("x", 4096))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxRetries: 2, maxBody: 512}
+
+	var out struct {
+		Content string `json:"content"`
+	}
+	err := c.GetJSON(context.Background(), srv.URL, &out)
+	var tooLarge *BodyTooLargeError
+	if !errors.As(err, &tooLarge) {
+		t.Fatalf("GetJSON error = %v, want a *BodyTooLargeError", err)
+	}
+	if tooLarge.Limit != 512 {
+		t.Errorf("reported limit = %d, want 512", tooLarge.Limit)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (an oversized body will not shrink on a retry)", attempts)
+	}
+}
+
+// The cap is inclusive: a body of exactly maxBody bytes is complete, not truncated.
+func TestClientGetJSONAcceptsBodyExactlyAtCap(t *testing.T) {
+	body := `{"content":"acme"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxBody: int64(len(body))}
+
+	var out struct {
+		Content string `json:"content"`
+	}
+	if err := c.GetJSON(context.Background(), srv.URL, &out); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if out.Content != "acme" {
+		t.Errorf("decoded content = %q, want %q", out.Content, "acme")
 	}
 }


### PR DESCRIPTION
## The bug

`internal/sources/http.go` capped every decoded body at **32 MiB using a bare
`io.LimitReader`**. A larger feed was truncated mid-stream, so the JSON decoder returned
`unexpected EOF` — indistinguishable from a dropped connection. `board_health` then treated a
fully deterministic failure as transient: cooldown → retry → truncate → cooldown.

`andurilindustries` has been in that loop since **17 June**: 1936 rows closed in `jobs` while
its live board carries **2128 postings**.

## Why now

The constant's comment claimed "ATS list feeds run to a few MB at most". That premise expired —
a list endpoint that inlines every description (`?content=true`) reaches tens of MiB at a few
thousand postings. Measured 2026-07-30:

| board | body | over old cap |
|---|---|---|
| lever `jobgether` | 36.8 MiB | yes |
| greenhouse `pulse` | 35.5 MiB | yes |
| greenhouse `andurilindustries` | 34.6 MiB | yes |
| greenhouse `eosfitness` | 34.4 MiB | yes |
| greenhouse `svetness` | 32.1 MiB | yes, barely |
| greenhouse `knowbe4` | 0.9 MiB | no — a real transient drop |

## The change

- ceiling **32 → 64 MiB** (1.7× the largest body seen), comment now cites the measurements
- `cappedReader` replaces `io.LimitReader`: exceeding the cap returns a typed
  **`BodyTooLargeError`**, so the failure names itself instead of impersonating the network.
  The cap still bounds a hostile multi-GB body or an inflated gzip bomb.
- same reader in `fingerprinthttp.go`, which capped identically and would hide the same way
- read window is `limit+1`, so a body of exactly the cap still decodes
- `Client.maxBody` test hook, so the cap-trip test doesn't stream tens of MiB through loopback

## Verification

Against the real board, same code path as ingest:

```
cap 32 MiB → greenhouse: fetch board andurilindustries: ... body exceeds 33554432 bytes
cap 64 MiB → fetched 2128 postings
```

Plus two unit tests: an oversized body surfaces `*BodyTooLargeError` **and is not retried**;
a body of exactly the cap decodes normally. `go build ./...`, `go vet`, `go test ./...` pass.

Worst-case memory is unchanged in shape: 8 concurrent boards (`pipeline.defaultConcurrency`)
× 64 MiB.