### PR TITLE
feat(sources): onboard 55 Join.com boards

### DIFF
--- a/sources/join.yml
+++ b/sources/join.yml
@@ -8229,3 +8229,168 @@
   board: "11999"
 - company: Bonrepublic GmbH
   board: "66474"
+
+- company: Ayunis # locaboo
+  board: "106739"
+
+- company: Enzo # heyenzo
+  board: "30641"
+
+- company: hellomed # hellomed
+  board: "74777"
+
+- company: Introw # introw
+  board: "156883"
+
+- company: kalialab GmbH # kalialab
+  board: "100101"
+
+- company: KULT FARM # esenciafoods
+  board: "77196"
+
+- company: Küchenheld # kuechenheld
+  board: "5696"
+
+- company: MOTOR Ai # motor-ai
+  board: "5740"
+
+- company: PRIOjet GmbH # priojet
+  board: "22609"
+
+- company: SPiNE GmbH # spine
+  board: "145570"
+
+- company: stay awesome GmbH # stayawesome
+  board: "144813"
+
+- company: Tomorrow Biostasis GmbH # tomorrowbiostasis
+  board: "13344"
+
+- company: CoCrafter (YC W24) # cocrafter
+  board: "121551"
+
+- company: ecopals # ecopals
+  board: "31402"
+
+- company: "HydroNeo (Thailand) Co., Ltd." # hydroneo
+  board: "3202"
+
+- company: Inuru # inuru
+  board: "26880"
+
+- company: OBJECTS Manufacturing # objectsmanufacturing
+  board: "49167"
+
+- company: Ribbon Bio # ribbonbiolabs
+  board: "59658"
+
+- company: ai-omatic solutions GmbH # ai-omatic
+  board: "62435"
+
+- company: AnyTax # anytax
+  board: "154204"
+
+- company: Beautinda GmbH # beautinda
+  board: "49529"
+
+- company: eaze # eaze
+  board: "53139"
+
+- company: excav # excav
+  board: "122743"
+
+- company: Fainin GmbH # fainin
+  board: "79722"
+
+- company: Foodiary GmbH # foodiary
+  board: "59915"
+
+- company: GOFO # packaly
+  board: "121749"
+
+- company: Kurabu GmbH # kurabu
+  board: "62305"
+
+- company: Livin Farms AgriFood GmbH # livinfarms
+  board: "57492"
+
+- company: Logistica OS # logistica-oscom
+  board: "167442"
+
+- company: MARKTKOST # marktkost
+  board: "7044"
+
+- company: Napptilus Tech Labs # napptilus
+  board: "90613"
+
+- company: Proliance GmbH # datenschutzexperte
+  board: "16996"
+
+- company: Sherpany by Datasite # sherpany
+  board: "10874"
+
+- company: Stenon GmbH # stenon
+  board: "7137"
+
+- company: VAARHAFT # vaarhaft
+  board: "120862"
+
+- company: VAYS Ventures GmbH # vays-ventures
+  board: "127271"
+
+- company: Acodis AG # acodis
+  board: "288"
+
+- company: Airteam Aerial Intelligence GmbH # airteam
+  board: "8074"
+
+- company: bluu # bluuwash
+  board: "92208"
+
+- company: cureVision GmbH # curevision
+  board: "112271"
+
+- company: diffusion.agency # diffusion
+  board: "95541"
+
+- company: dnl # dnlab
+  board: "20443"
+
+- company: HonestDog # honestdog
+  board: "73990"
+
+- company: hyrise GmbH # hyrise
+  board: "33652"
+
+- company: i-flow GmbH # i-flow
+  board: "34477"
+
+- company: InsiderPie GmbH # insiderpie
+  board: "130000"
+
+- company: IRUBIS GmbH # irubis
+  board: "12792"
+
+- company: keleya Digital-Health Solutions GmbH # keleya
+  board: "1117"
+
+- company: Lumaly # lumaly
+  board: "18188"
+
+- company: myndpaar # myndwerk
+  board: "41219"
+
+- company: Planet A Ventures # planet-a
+  board: "27930"
+
+- company: Pragma Technologies # pragma
+  board: "41396"
+
+- company: Relocify # relocify
+  board: "46124"
+
+- company: UnitPlus # unitplus
+  board: "53839"
+
+- company: Wowflow GmbH # wowflow
+  board: "101037"


### PR DESCRIPTION
## What

55 new Join.com boards in `sources/join.yml` (4111 → 4166 entries).

## Why they were missing

Join's board key is the **numeric company id**, and it does not appear in the apply URL —
the link only carries the company slug. That is why apply-URL sweeps never picked these up
and why a `SLUG_PATTERNS` entry would not have helped, exactly like eRecruiter.

They came from a two-step resolve, the same lookup `sources/join.yml` already documents for
humans:

```
apply link → company slug
→ company.id from __NEXT_DATA__ on join.com/companies/<slug>
→ verify: join.com/api/public/companies/<id>/jobs?page=1&pageSize=5
```

(`pageSize` is capped at 5 — larger values return 422.)

74 companies were resolved this way: 17 were already tracked, 2 had no live posting, **55 are
new and live**.

## Names come from Join, not from where the slugs were found

**33 of 55 labels disagreed** with Join's own company name. Mostly a missing legal form
(`Wowflow` vs `Wowflow GmbH`), but twice a different company outright:

| label found alongside the slug | actual board owner |
|---|---|
| eCapital Entrepreneurial Partners | **MOTOR Ai** |
| Locaboo | **Ayunis** |

`internal/sources/join.go` stamps `Job.Company` straight from this file, so a wrong label
would file those postings under the wrong company. Every entry here uses Join's own name.

## Verification

Through the **real adapter**, not the validator: MOTOR Ai 11 jobs, Enzo 7, Ayunis 5, SPiNE 4,
hyrise 1 (the adapter paginates, so it sees more than the 5-capped probe did).

`sources/join.yml` parses, no duplicate board id, `go test ./internal/sources/` passes.
Data only — no Go changes.