### PR TITLE
feat(sources): onboard the last two boards from the coverage sweep

### DIFF
--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1528,3 +1528,5 @@
   board: satellitevu
 - company: DeepMirror
   board: deepmirror
+- company: FLO EV Charging
+  board: flo-addenergie

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -2214,3 +2214,5 @@
   board: specialist.zohorecruit.com
 - company: Tobias Solutions
   board: solutionstobias.zohorecruit.com
+- company: LINDERA GmbH
+  board: lindera.zohorecruit.eu


### PR DESCRIPTION
## What

Two boards, the last reachable ones in the coverage sweep:

| provider | board | jobs | company |
|---|---|---|---|
| workable | `flo-addenergie` | 34 | FLO EV Charging |
| zohorecruit | `lindera.zohorecruit.eu` | 2 | LINDERA GmbH |

## Why they were missed

These companies' pages carry no ATS marker in their outbound links, so an apply-URL sweep
sees nothing. Fetching each careers page directly and scanning the markup found the boards.

Two other candidates turned out to be **already tracked**, worth recording so nobody re-chases
them: **Slice** hides its board inside a Greenhouse embed script
(`boards.greenhouse.io/embed/job_board/js?for=slice` → board `slice`, 50 jobs) and **Gigs**
exposes only `gh_jid=` links (board `gigs`, 38 jobs). The remaining companies in the residue
have no ATS at all — each would need its own adapter.

## Names

Taken from each ATS, not from the directory that pointed at them: the Workable board's own
name is **FLO EV Charging** where the listing said "AddEnergie". Same reasoning as #1292 —
`Job.Company` is stamped straight from this file.

## Verification

Through the real adapters (`NewWorkable`, `NewZoho`): 34 and 2 jobs. Both files parse, no
duplicate board. Data only — no Go changes.