### PR TITLE
fix(cv): a pruned vacancy must not promote its tailored copy to base

### DIFF
--- a/internal/cv/AGENTS.md
+++ b/internal/cv/AGENTS.md
@@ -32,6 +32,33 @@ Fonts: the Typst binary embeds no proportional sans, so Liberation Sans (SIL OFL
 under `fonts/`, staged into the sandbox, and exposed via `--font-path`. A template that wants
 sans uses `#set text(font: "Liberation Sans")`.
 
+## What makes a CV tailored (`cvs.is_tailored`)
+
+A CV is a tailored copy because it was **created** as one, not because it still points at a vacancy.
+`cvs_job_id_fkey` is `ON DELETE SET NULL`, and `cmd/prune` deletes vacancies by design — the prune
+query states that nulling references is "an accepted cost of the campaign". Inferring tailored-ness
+from `job_id IS NOT NULL` therefore meant that pruning one junk vacancy turned its copy into a plain
+CV, and since the base lookup takes the **newest** plain CV, the freshly-edited orphan beat the real
+one. It would then seed the next tailored copy and back the ATS delta's baseline.
+
+Three things that follow, and are easy to get backwards:
+
+- **`is_tailored` does not track `job_id`.** An orphaned copy is `is_tailored = true, job_id = NULL`.
+  Any new reader that wants "is this a tailored copy" must ask the flag; `job_id` answers a different
+  question ("which vacancy", and only while the vacancy exists).
+- **There is no `is_base`, and no uniqueness.** A user may own several plain CVs (`cv-builder`:
+  create/list/update/delete multiple CVs), so "the base" is derived — the most recently edited
+  non-tailored CV — and `GetBaseCVByUser` does that choosing. An earlier draft added
+  `UNIQUE (user_id) WHERE is_base` and broke creating a second CV; `TestBaseCVAndTailoredCopy` caught
+  it.
+- **The ATS delta's 409 splits on the flag.** A base CV is refused with "this is a base CV"; a
+  tailored copy whose vacancy is gone is refused with "the vacancy … no longer exists". They are
+  different situations, and `job_id == 0` alone cannot tell them apart.
+
+Backfill caveat: `0058` reads `job_id` to set the flag, so it is right about every row only because
+no prune had orphaned one yet. A row orphaned before that migration would stay marked non-tailored
+and would need a heuristic repair.
+
 ## ATS delta (tailored vs base)
 
 `GET /me/cvs/:id/ats-delta` reports what tailoring did to a CV's ATS readiness. The scoring

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -37,8 +37,13 @@ type Meta struct {
 // Record is a CV with its full document body.
 type Record struct {
 	Meta
-	// JobID is the vacancy a tailored CV is bound to, or 0 for a base CV (job_id NULL).
+	// JobID is the vacancy a tailored CV is bound to, or 0 — for a base CV, and also for a
+	// tailored copy whose vacancy was pruned (the FK nulls the link). IsTailored is what tells
+	// those two apart.
 	JobID int64
+	// IsTailored records what the row was CREATED as. It does not follow JobID: a pruned vacancy
+	// takes the link away but leaves the copy a tailored copy.
+	IsTailored bool
 	// AgentSessionID is the roy session bound to a tailored CV (empty when none).
 	AgentSessionID string
 	Document       Document
@@ -136,6 +141,7 @@ func (s *Store) Get(ctx context.Context, id uuid.UUID, userID int64) (Record, er
 	return Record{
 		Meta:                Meta{ID: row.ID, Title: row.Title, TemplateID: row.TemplateID, CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time},
 		JobID:               int8Value(row.JobID),
+		IsTailored:          row.IsTailored,
 		AgentSessionID:      textValue(row.AgentSessionID),
 		Document:            doc,
 		AutopilotReport:     decodeAutopilotReport(row.AutopilotReport),

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -13,8 +13,8 @@ import (
 )
 
 const createCV = `-- name: CreateCV :one
-INSERT INTO cvs (user_id, title, template_id, data)
-VALUES ($1, $2, $3, $4)
+INSERT INTO cvs (user_id, title, template_id, data, is_tailored)
+VALUES ($1, $2, $3, $4, false)
 RETURNING id, title, template_id, created_at, updated_at
 `
 
@@ -33,9 +33,10 @@ type CreateCVRow struct {
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 }
 
-// Insert a new CV for a user. data is the sanitized structured document (JSON). job_id
-// defaults NULL (the tailoring seam is unused in phase 1). Returns the metadata the list
-// and detail responses need.
+// Insert a new CV for a user. data is the sanitized structured document (JSON). This is the
+// user's own CV, not a copy made for a vacancy, so is_tailored is stated false rather than left to
+// be inferred from a NULL job_id — an absence cmd/prune also produces. Users may own several of
+// these. Returns the metadata the list and detail responses need.
 func (q *Queries) CreateCV(ctx context.Context, arg CreateCVParams) (CreateCVRow, error) {
 	row := q.db.QueryRow(ctx, createCV,
 		arg.UserID,
@@ -55,8 +56,8 @@ func (q *Queries) CreateCV(ctx context.Context, arg CreateCVParams) (CreateCVRow
 }
 
 const createTailoredCV = `-- name: CreateTailoredCV :one
-INSERT INTO cvs (user_id, title, template_id, data, job_id)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO cvs (user_id, title, template_id, data, job_id, is_tailored)
+VALUES ($1, $2, $3, $4, $5, true)
 RETURNING id, title, template_id, created_at, updated_at
 `
 
@@ -77,7 +78,9 @@ type CreateTailoredCVRow struct {
 }
 
 // Insert a CV bound to a vacancy (job_id set) — the per-vacancy tailored copy. data is the
-// sanitized document copied from the base CV. Returns the metadata the detail response needs.
+// sanitized document copied from the base CV. is_tailored is stated, not inferred: if this vacancy
+// is ever pruned the row loses its job_id, and the flag is what keeps it a tailored copy instead of
+// joining the pool the base is chosen from. Returns the metadata the detail response needs.
 func (q *Queries) CreateTailoredCV(ctx context.Context, arg CreateTailoredCVParams) (CreateTailoredCVRow, error) {
 	row := q.db.QueryRow(ctx, createTailoredCV,
 		arg.UserID,
@@ -120,7 +123,7 @@ func (q *Queries) DeleteCV(ctx context.Context, arg DeleteCVParams) (int64, erro
 const getBaseCVByUser = `-- name: GetBaseCVByUser :one
 SELECT id, title, template_id, data, created_at, updated_at
 FROM cvs
-WHERE user_id = $1 AND job_id IS NULL
+WHERE user_id = $1 AND NOT is_tailored
 ORDER BY updated_at DESC, id DESC
 LIMIT 1
 `
@@ -134,9 +137,15 @@ type GetBaseCVByUserRow struct {
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 }
 
-// The user's base CV (job_id IS NULL) — their non-tailored résumé, newest edit first. Used
-// as the seed source when tailoring; returns no row when the user has only tailored CVs or
-// none at all (the caller then seeds a base from the extracted résumé).
+// The user's base CV — their non-tailored résumé. Used as the seed source when tailoring;
+// returns no row when the user has only tailored CVs or none at all (the caller then seeds a base
+// from the extracted résumé), INCLUDING when their only vacancy-less CV is a tailored copy whose
+// vacancy was pruned. Excluding on is_tailored rather than requiring `job_id IS NULL` is the whole
+// point: the absence of a vacancy link is something cmd/prune creates, so it cannot mean "not
+// tailored".
+//
+// "The base" stays a derived notion — the most recently edited non-tailored CV. Users may own
+// several (cv-builder), so there is no uniqueness constraint and the ORDER BY does the choosing.
 func (q *Queries) GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVByUserRow, error) {
 	row := q.db.QueryRow(ctx, getBaseCVByUser, userID)
 	var i GetBaseCVByUserRow
@@ -152,7 +161,7 @@ func (q *Queries) GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVB
 }
 
 const getCVByID = `-- name: GetCVByID :one
-SELECT id, title, template_id, data, job_id, agent_session_id,
+SELECT id, title, template_id, data, job_id, is_tailored, agent_session_id,
        autopilot_report, (autopilot_undo IS NOT NULL)::boolean AS autopilot_revertable,
        created_at, updated_at
 FROM cvs
@@ -170,6 +179,7 @@ type GetCVByIDRow struct {
 	TemplateID          string             `json:"template_id"`
 	Data                []byte             `json:"data"`
 	JobID               pgtype.Int8        `json:"job_id"`
+	IsTailored          bool               `json:"is_tailored"`
 	AgentSessionID      pgtype.Text        `json:"agent_session_id"`
 	AutopilotReport     []byte             `json:"autopilot_report"`
 	AutopilotRevertable bool               `json:"autopilot_revertable"`
@@ -191,6 +201,7 @@ func (q *Queries) GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByID
 		&i.TemplateID,
 		&i.Data,
 		&i.JobID,
+		&i.IsTailored,
 		&i.AgentSessionID,
 		&i.AutopilotReport,
 		&i.AutopilotRevertable,

--- a/internal/db/cvs_base_integration_test.go
+++ b/internal/db/cvs_base_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+// Integration tests for what makes a CV the BASE CV (see the explicit-base-cv change). The base
+// used to be inferred from `job_id IS NULL`, an absence that cmd/prune manufactures: deleting a
+// vacancy nulls its tailored copy's link and the orphan — freshly edited — outranked the real base.
+// "The base" is still derived (the newest non-tailored CV, of which a user may own several); what
+// changed is that a tailored copy stays tailored after its vacancy is gone.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// seedCVJob inserts a vacancy a tailored CV can bind to.
+func seedCVJob(t *testing.T, pool *pgxpool.Pool, slug string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, public_slug)
+		 VALUES ('test', $1, 'https://e.test/'||$1, 'Backend Engineer', $1) RETURNING id`,
+		slug).Scan(&id); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	return id
+}
+
+// TestBaseCVSurvivesAPrunedVacancy is the regression the change exists for: pruning a vacancy must
+// not promote its tailored copy to base. The orphan is edited last on purpose — under the old
+// `job_id IS NULL ORDER BY updated_at DESC` rule that is exactly what made it win.
+func TestBaseCVSurvivesAPrunedVacancy(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncateCVs(t, pool)
+	ctx := context.Background()
+
+	owner := seedCVUser(t, pool, "pruned-vacancy@example.com")
+	base, err := q.CreateCV(ctx, CreateCVParams{
+		UserID: owner, Title: "Base", TemplateID: "classic-ats",
+		Data: []byte(`{"summary":"the real base"}`),
+	})
+	if err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+
+	jobID := seedCVJob(t, pool, "backend-to-be-pruned")
+	tailored, err := q.CreateTailoredCV(ctx, CreateTailoredCVParams{
+		UserID: owner, Title: "Tailored", TemplateID: "classic-ats",
+		Data:  []byte(`{"summary":"tailored for a vacancy that will vanish"}`),
+		JobID: pgtype.Int8{Int64: jobID, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+	// Touch the tailored copy last, so it is the newest vacancy-less row once the job goes.
+	if _, err := q.UpdateCV(ctx, UpdateCVParams{
+		ID: tailored.ID, UserID: owner, Title: "Tailored", TemplateID: "classic-ats",
+		Data: []byte(`{"summary":"edited most recently"}`),
+	}); err != nil {
+		t.Fatalf("touch tailored: %v", err)
+	}
+
+	// cmd/prune hard-deletes the vacancy; the FK nulls the tailored copy's link.
+	if _, err := pool.Exec(ctx, `DELETE FROM jobs WHERE id = $1`, jobID); err != nil {
+		t.Fatalf("prune job: %v", err)
+	}
+
+	got, err := q.GetBaseCVByUser(ctx, owner)
+	if err != nil {
+		t.Fatalf("base lookup after prune: %v", err)
+	}
+	if got.ID != base.ID {
+		t.Errorf("base lookup returned %q (%s), want the real base %q — a pruned vacancy must not promote its tailored copy",
+			got.Title, got.ID, base.Title)
+	}
+}
+
+// TestBaseCVAbsentWhenOnlyAnOrphanRemains pins the other half: an orphaned tailored copy is not a
+// base, so a user who has only one has NO base CV and must get a fresh one seeded.
+func TestBaseCVAbsentWhenOnlyAnOrphanRemains(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncateCVs(t, pool)
+	ctx := context.Background()
+
+	owner := seedCVUser(t, pool, "orphan-only@example.com")
+	jobID := seedCVJob(t, pool, "only-vacancy-pruned")
+	if _, err := q.CreateTailoredCV(ctx, CreateTailoredCVParams{
+		UserID: owner, Title: "Tailored", TemplateID: "classic-ats",
+		Data:  []byte(`{"summary":"the only cv"}`),
+		JobID: pgtype.Int8{Int64: jobID, Valid: true},
+	}); err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM jobs WHERE id = $1`, jobID); err != nil {
+		t.Fatalf("prune job: %v", err)
+	}
+
+	if _, err := q.GetBaseCVByUser(ctx, owner); err == nil {
+		t.Error("base lookup found a base CV; want none — the user's only CV is an orphaned tailored copy")
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -130,6 +130,7 @@ type Cv struct {
 	ID              uuid.UUID          `json:"id"`
 	AutopilotReport []byte             `json:"autopilot_report"`
 	AutopilotUndo   []byte             `json:"autopilot_undo"`
+	IsTailored      bool               `json:"is_tailored"`
 }
 
 type Email struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -321,9 +321,10 @@ type Querier interface {
 	// 'tailor'); cv_id/job_id bind a tailoring session to its CV and vacancy and are NULL
 	// for a chat. The label is set later, from the first user message.
 	CreateAssistantSession(ctx context.Context, arg CreateAssistantSessionParams) (CreateAssistantSessionRow, error)
-	// Insert a new CV for a user. data is the sanitized structured document (JSON). job_id
-	// defaults NULL (the tailoring seam is unused in phase 1). Returns the metadata the list
-	// and detail responses need.
+	// Insert a new CV for a user. data is the sanitized structured document (JSON). This is the
+	// user's own CV, not a copy made for a vacancy, so is_tailored is stated false rather than left to
+	// be inferred from a NULL job_id — an absence cmd/prune also produces. Users may own several of
+	// these. Returns the metadata the list and detail responses need.
 	CreateCV(ctx context.Context, arg CreateCVParams) (CreateCVRow, error)
 	// Record a contribution of a novel company board. The unique index on (source, board) over the
 	// live statuses (migration 0049) rejects a second contribution of a board already queued or
@@ -379,7 +380,9 @@ type Querier interface {
 	// UNIQUE constraint (surfaced as a 409). Returns the created row.
 	CreateSubscription(ctx context.Context, arg CreateSubscriptionParams) (Subscription, error)
 	// Insert a CV bound to a vacancy (job_id set) — the per-vacancy tailored copy. data is the
-	// sanitized document copied from the base CV. Returns the metadata the detail response needs.
+	// sanitized document copied from the base CV. is_tailored is stated, not inferred: if this vacancy
+	// is ever pruned the row loses its job_id, and the flag is what keeps it a tailored copy instead of
+	// joining the pool the base is chosen from. Returns the metadata the detail response needs.
 	CreateTailoredCV(ctx context.Context, arg CreateTailoredCVParams) (CreateTailoredCVRow, error)
 	// Register a new account. email is stored as given (the handler lowercases it);
 	// the unique index on lower(email) rejects duplicates regardless of case. role is
@@ -639,9 +642,15 @@ type Querier interface {
 	// the row exists, so this never returns no-rows on the debit path; the lock serializes
 	// concurrent debits for the same user so the balance can never be oversold.
 	GetBalanceForUpdate(ctx context.Context, userID int64) (GetBalanceForUpdateRow, error)
-	// The user's base CV (job_id IS NULL) — their non-tailored résumé, newest edit first. Used
-	// as the seed source when tailoring; returns no row when the user has only tailored CVs or
-	// none at all (the caller then seeds a base from the extracted résumé).
+	// The user's base CV — their non-tailored résumé. Used as the seed source when tailoring;
+	// returns no row when the user has only tailored CVs or none at all (the caller then seeds a base
+	// from the extracted résumé), INCLUDING when their only vacancy-less CV is a tailored copy whose
+	// vacancy was pruned. Excluding on is_tailored rather than requiring `job_id IS NULL` is the whole
+	// point: the absence of a vacancy link is something cmd/prune creates, so it cannot mean "not
+	// tailored".
+	//
+	// "The base" stays a derived notion — the most recently edited non-tailored CV. Users may own
+	// several (cv-builder), so there is no uniqueness constraint and the ORDER BY does the choosing.
 	GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVByUserRow, error)
 	// The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
 	// which the caller treats as "never seen, eligible".

--- a/internal/db/queries/cvs.sql
+++ b/internal/db/queries/cvs.sql
@@ -1,9 +1,10 @@
 -- name: CreateCV :one
--- Insert a new CV for a user. data is the sanitized structured document (JSON). job_id
--- defaults NULL (the tailoring seam is unused in phase 1). Returns the metadata the list
--- and detail responses need.
-INSERT INTO cvs (user_id, title, template_id, data)
-VALUES ($1, $2, $3, $4)
+-- Insert a new CV for a user. data is the sanitized structured document (JSON). This is the
+-- user's own CV, not a copy made for a vacancy, so is_tailored is stated false rather than left to
+-- be inferred from a NULL job_id — an absence cmd/prune also produces. Users may own several of
+-- these. Returns the metadata the list and detail responses need.
+INSERT INTO cvs (user_id, title, template_id, data, is_tailored)
+VALUES ($1, $2, $3, $4, false)
 RETURNING id, title, template_id, created_at, updated_at;
 
 -- name: ListCVsByUser :many
@@ -30,7 +31,7 @@ ORDER BY c.updated_at DESC;
 -- the vacancy id for a tailored copy; agent_session_id is the bound roy session (or NULL).
 -- The autopilot columns are reported as the report itself plus a boolean: the pre-run snapshot
 -- is a whole second document, and no caller needs its bytes — only whether one exists.
-SELECT id, title, template_id, data, job_id, agent_session_id,
+SELECT id, title, template_id, data, job_id, is_tailored, agent_session_id,
        autopilot_report, (autopilot_undo IS NOT NULL)::boolean AS autopilot_revertable,
        created_at, updated_at
 FROM cvs
@@ -65,20 +66,28 @@ DELETE FROM cvs
 WHERE id = $1 AND user_id = $2;
 
 -- name: GetBaseCVByUser :one
--- The user's base CV (job_id IS NULL) — their non-tailored résumé, newest edit first. Used
--- as the seed source when tailoring; returns no row when the user has only tailored CVs or
--- none at all (the caller then seeds a base from the extracted résumé).
+-- The user's base CV — their non-tailored résumé. Used as the seed source when tailoring;
+-- returns no row when the user has only tailored CVs or none at all (the caller then seeds a base
+-- from the extracted résumé), INCLUDING when their only vacancy-less CV is a tailored copy whose
+-- vacancy was pruned. Excluding on is_tailored rather than requiring `job_id IS NULL` is the whole
+-- point: the absence of a vacancy link is something cmd/prune creates, so it cannot mean "not
+-- tailored".
+--
+-- "The base" stays a derived notion — the most recently edited non-tailored CV. Users may own
+-- several (cv-builder), so there is no uniqueness constraint and the ORDER BY does the choosing.
 SELECT id, title, template_id, data, created_at, updated_at
 FROM cvs
-WHERE user_id = $1 AND job_id IS NULL
+WHERE user_id = $1 AND NOT is_tailored
 ORDER BY updated_at DESC, id DESC
 LIMIT 1;
 
 -- name: CreateTailoredCV :one
 -- Insert a CV bound to a vacancy (job_id set) — the per-vacancy tailored copy. data is the
--- sanitized document copied from the base CV. Returns the metadata the detail response needs.
-INSERT INTO cvs (user_id, title, template_id, data, job_id)
-VALUES ($1, $2, $3, $4, $5)
+-- sanitized document copied from the base CV. is_tailored is stated, not inferred: if this vacancy
+-- is ever pruned the row loses its job_id, and the flag is what keeps it a tailored copy instead of
+-- joining the pool the base is chosen from. Returns the metadata the detail response needs.
+INSERT INTO cvs (user_id, title, template_id, data, job_id, is_tailored)
+VALUES ($1, $2, $3, $4, $5, true)
 RETURNING id, title, template_id, created_at, updated_at;
 
 -- name: SnapshotCVForAutopilot :execrows

--- a/internal/handler/cv_ats_delta.go
+++ b/internal/handler/cv_ats_delta.go
@@ -52,8 +52,13 @@ func (h *cvHandlers) GetCVATSDelta(c *fiber.Ctx) error {
 	if err != nil {
 		return mapCVError(err)
 	}
+	// Two different reasons a CV has no comparison, and the caller cannot act on the wrong one.
+	// A pruned vacancy leaves a tailored copy with no job_id, so JobID alone cannot tell them apart.
+	if !tailored.IsTailored {
+		return fiber.NewError(fiber.StatusConflict, "this is a base CV: there is nothing to compare it against")
+	}
 	if tailored.JobID == 0 {
-		return fiber.NewError(fiber.StatusConflict, "not a tailored CV: there is no base to compare against")
+		return fiber.NewError(fiber.StatusConflict, "the vacancy this CV was tailored for no longer exists")
 	}
 	base, ok, err := h.cvStore.BaseCV(c.Context(), userID)
 	if err != nil {

--- a/internal/handler/cv_ats_delta_integration_test.go
+++ b/internal/handler/cv_ats_delta_integration_test.go
@@ -124,6 +124,52 @@ func (f atsDeltaFixture) get(t *testing.T, id string) (atsDeltaResponse, int) {
 	return body.Data, resp.StatusCode
 }
 
+// getErr reads the refusal message alongside the status, so a test can pin which of the two
+// no-comparison cases the caller was told about.
+func (f atsDeltaFixture) getErr(t *testing.T, id string) (string, int) {
+	t.Helper()
+	resp := doCV(t, f.app, fiber.MethodGet, "/api/v1/me/cvs/"+id+"/ats-delta", f.token, nil)
+	defer resp.Body.Close()
+	var body struct {
+		Error string `json:"error"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	return body.Error, resp.StatusCode
+}
+
+// TestATSDelta_RefusalNamesWhichCaseItIs pins the two ways a CV can have no comparison apart. A
+// base CV has nothing to compare against; a tailored copy whose vacancy was pruned is still a
+// tailored copy, and telling its owner "not a tailored CV" describes the wrong situation.
+func TestATSDelta_RefusalNamesWhichCaseItIs(t *testing.T) {
+	pool := startPostgres(t)
+	f := newATSDeltaFixture(t, pool)
+
+	baseMsg, baseStatus := f.getErr(t, f.base.ID.String())
+	if baseStatus != fiber.StatusConflict {
+		t.Fatalf("base cv status = %d, want 409", baseStatus)
+	}
+	if !strings.Contains(strings.ToLower(baseMsg), "base") {
+		t.Errorf("base cv refusal = %q, want it to say this is the base CV", baseMsg)
+	}
+
+	// Prune the vacancy out from under the tailored copy: the FK nulls its link.
+	if _, err := pool.Exec(context.Background(),
+		`DELETE FROM jobs WHERE id = (SELECT job_id FROM cvs WHERE id = $1)`, f.tailored.ID); err != nil {
+		t.Fatalf("prune vacancy: %v", err)
+	}
+
+	orphanMsg, orphanStatus := f.getErr(t, f.tailored.ID.String())
+	if orphanStatus != fiber.StatusConflict {
+		t.Fatalf("orphan status = %d, want 409", orphanStatus)
+	}
+	if !strings.Contains(strings.ToLower(orphanMsg), "vacancy") {
+		t.Errorf("orphan refusal = %q, want it to say the vacancy no longer exists", orphanMsg)
+	}
+	if orphanMsg == baseMsg {
+		t.Errorf("both refusals say %q; want the message to distinguish a base CV from an orphaned copy", orphanMsg)
+	}
+}
+
 func TestATSDelta_ComparesTheTailoredCopyAgainstTheBase(t *testing.T) {
 	f := newATSDeltaFixture(t, startPostgres(t))
 

--- a/migrations/0058_cvs_is_tailored.sql
+++ b/migrations/0058_cvs_is_tailored.sql
@@ -1,0 +1,21 @@
+-- A tailored CV is a copy made FOR a vacancy; a plain CV is one the user wrote themselves, and the
+-- newest plain CV is what tailoring seeds the next copy from. Until now "tailored" was inferred
+-- from `job_id IS NOT NULL` — a link that cmd/prune removes on purpose. `cvs_job_id_fkey` is
+-- ON DELETE SET NULL (0024), and the prune query says so outright: "Every other reference to jobs
+-- cascades or nulls, so a user's saved job goes with it. That is an accepted cost of the campaign,
+-- not an oversight."
+--
+-- So deleting one junk vacancy turned its tailored copy into a plain CV — and since the base lookup
+-- takes the NEWEST plain CV, the freshly-edited orphan beat one the candidate last touched weeks
+-- ago. It would then seed the next tailored copy and back the ATS delta's baseline.
+--
+-- The flag records what the row was CREATED as, which is the fact the foreign key destroys. It is
+-- deliberately not an `is_base` flag: users may own several plain CVs (cv-builder: "create, list,
+-- read, update, and delete multiple CVs"), so "the base" stays a derived notion — the most recently
+-- edited non-tailored CV — and carries no uniqueness constraint.
+ALTER TABLE public.cvs ADD COLUMN is_tailored boolean NOT NULL DEFAULT false;
+
+-- Every CV still holding a vacancy link was created as a tailored copy. Rows already orphaned by a
+-- prune cannot be recovered by this backfill — they have no link left to read — but production
+-- carries none today (checked before writing this: 68 CVs, 8 vacancy-less, zero orphan signatures).
+UPDATE public.cvs SET is_tailored = true WHERE job_id IS NOT NULL;

--- a/openspec/changes/explicit-base-cv/.openspec.yaml
+++ b/openspec/changes/explicit-base-cv/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/explicit-base-cv/design.md
+++ b/openspec/changes/explicit-base-cv/design.md
@@ -1,0 +1,118 @@
+## Context
+
+`cvs.job_id` carries two meanings at once: *which vacancy this CV is for* and *whether this CV is
+the base*. The second meaning is an inference from the first being absent, and `cmd/prune` produces
+that absence deliberately — `ON DELETE SET NULL` on `cvs_job_id_fkey`, with the prune query stating
+outright that nulling references is an accepted cost of the campaign.
+
+Four readers depend on the inference:
+
+| Reader | What it does with "the base" |
+|---|---|
+| `cv.Store.Tailor` (`store.go:306`) | copies its **document** into every new tailored CV |
+| `cvHandlers.GetCVATSDelta` (`cv_ats_delta.go:58`) | scores it as the comparison baseline |
+| `cvHandlers.StartTailorSession` (`cv_tailor.go:156`) | resolves it to re-establish a workspace |
+| `GetBaseCVByUser` (`cvs.sql:67`) | `job_id IS NULL … ORDER BY updated_at DESC LIMIT 1` |
+
+Production today: 68 CVs, 8 vacancy-less, 60 tailored, zero users with more than one vacancy-less
+CV. The hazard has not fired, so the fix needs no data repair and the uniqueness constraint can go
+in as part of the same migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A CV is the base because it is marked as the base, and the database refuses a second one.
+- Deleting a vacancy leaves its tailored copy a tailored copy.
+- The ATS delta's refusal tells the caller which of the two no-comparison cases it hit.
+
+**Non-Goals:**
+
+- Making orphaned tailored CVs visible or labelled in the UI. `ListTailoredCVsByUser` inner-joins
+  `jobs` and already drops them — a documented decision that predates this change. Surfacing them
+  needs a denormalised vacancy trace and a card that renders without a company: product work, its
+  own change.
+- Changing `cvs_job_id_fkey`. `RESTRICT` aborts prune campaigns; `CASCADE` deletes a candidate's
+  work because we cleaned up a junk posting.
+- Any wire-shape change. `is_base` is a server-side predicate; no client learns about it.
+
+## Decisions
+
+### An explicit `is_base` flag, not a cleverer query
+
+**Chosen:** `cvs.is_base boolean NOT NULL DEFAULT false`, backfilled `true WHERE job_id IS NULL`.
+
+**Alternative rejected:** keep inferring, but exclude orphans by their traces — an orphan usually
+carries `agent_session_id` or `autopilot_report`. It fails on the case that matters: a tailored CV
+that was never opened in the workspace carries neither, and is indistinguishable from a base. An
+inference that is right most of the time is what this change exists to remove.
+
+**Alternative rejected:** a `kind text` enum (`'base' | 'tailored'`). Same information, more
+surface: a CHECK constraint, a Go enum, and a decode path, to express one bit.
+
+### The invariant lives in the schema
+
+A partial unique index — `CREATE UNIQUE INDEX … ON cvs (user_id) WHERE is_base` — makes "one base
+per user" something the database refuses to break. Today it is an `ORDER BY updated_at DESC LIMIT 1`
+convention, which cannot fail loudly; it just picks one. It builds clean on current data (verified
+above), and after it exists the `ORDER BY` in the base lookup becomes belt-and-braces rather than
+the mechanism.
+
+### The deploy window is closed by a reconciliation, not by code
+
+`release.sh` applies migrations **before** the new colour starts, and the old colour keeps serving
+until nginx flips — roughly two and a half minutes on the last release. In that window the old code
+inserts base CVs without setting `is_base`, so the column defaults to `false` and that user's base
+would be invisible to the new code: the next tailoring would seed a *second* base from their résumé,
+and the partial unique index would then have two rows to disagree about (it would reject the second
+insert, surfacing as a failed bootstrap).
+
+**Chosen:** a post-flip reconciliation statement, run once as part of the release:
+
+```sql
+UPDATE cvs SET is_base = true
+WHERE job_id IS NULL AND NOT is_base
+  AND NOT EXISTS (SELECT 1 FROM cvs c2 WHERE c2.user_id = cvs.user_id AND c2.is_base);
+```
+
+Idempotent, safe to run at any time, and it cannot create a second base because of its own
+`NOT EXISTS` guard. One statement beats the alternative.
+
+**Alternative rejected:** a transitional fallback inside `GetBaseCVByUser` (`is_base OR (job_id IS
+NULL AND the user has no is_base row)`). It works, but it leaves the exact inference this change
+removes sitting in the code, plus a follow-up change to delete it — and the window it protects is
+two minutes on a service with 68 CVs in total.
+
+### The delta names which no-comparison case it hit
+
+`GetCVATSDelta` currently refuses anything with `JobID == 0` as "not a tailored CV". After this
+change that sentence is wrong for an orphan, which *is* a tailored CV. The refusal splits: the base
+CV gets "this is your base CV"; a tailored copy whose vacancy is gone gets "the vacancy for this CV
+no longer exists". Same 409, an honest reason — a caller cannot act on a message that describes the
+wrong situation.
+
+## Risks / Trade-offs
+
+- **Migration number collision** → `migrations/` on main already carries two `0056_*` and two
+  `0057_*` files from parallel branches. `cmd/migrate` keys on the filename, so duplicates coexist,
+  but the next number is genuinely ambiguous. Take `0058_` and, if another branch takes it first,
+  renumber before merge rather than after — a migration already applied under one name cannot be
+  renamed.
+- **The reconciliation is a manual release step** → If it is forgotten, the only users affected are
+  those who created a base CV inside the flip window; the symptom is a failed tailoring bootstrap,
+  not silent corruption, and running the statement later fixes it. Recorded in tasks so it travels
+  with the change.
+- **`Create` now decides `is_base`** → Every CV-creating path must say which kind it is. There are
+  two (`Create`, `CreateTailored`), and the unique index catches a third that gets it wrong.
+
+## Migration Plan
+
+1. `0058_cvs_is_base.sql`: add the column, backfill `true WHERE job_id IS NULL`, create the partial
+   unique index. Additive — the running old colour is unaffected, since sqlc enumerates the columns
+   it knows.
+2. `make sqlc` after the query changes; deploy through `release.sh`, which applies the migration
+   before flipping.
+3. Run the reconciliation statement once after the flip.
+
+Rollback: the code change reverts cleanly; the column and index can stay (they are inert to the old
+predicate). Nothing needs undoing in the data.

--- a/openspec/changes/explicit-base-cv/design.md
+++ b/openspec/changes/explicit-base-cv/design.md
@@ -14,15 +14,18 @@ Four readers depend on the inference:
 | `cvHandlers.StartTailorSession` (`cv_tailor.go:156`) | resolves it to re-establish a workspace |
 | `GetBaseCVByUser` (`cvs.sql:67`) | `job_id IS NULL … ORDER BY updated_at DESC LIMIT 1` |
 
-Production today: 68 CVs, 8 vacancy-less, 60 tailored, zero users with more than one vacancy-less
-CV. The hazard has not fired, so the fix needs no data repair and the uniqueness constraint can go
-in as part of the same migration.
+A user may own several plain CVs, so that lookup is a *choice among* them — which is what makes an
+orphan joining the pool a defect rather than a mere mislabel.
+
+Production today: 68 CVs, 8 vacancy-less, 60 tailored, and no row carrying an orphan signature. The
+hazard has not fired, so the backfill can read `job_id` and be right about every existing row — which
+it could not do once a single prune has run.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- A CV is the base because it is marked as the base, and the database refuses a second one.
+- A CV is a tailored copy because it was created as one, and stays one when its vacancy is deleted.
 - Deleting a vacancy leaves its tailored copy a tailored copy.
 - The ATS delta's refusal tells the caller which of the two no-comparison cases it hit.
 
@@ -32,15 +35,19 @@ in as part of the same migration.
   `jobs` and already drops them — a documented decision that predates this change. Surfacing them
   needs a denormalised vacancy trace and a card that renders without a company: product work, its
   own change.
+- A uniqueness constraint on base CVs — see the corrected decision below; users legitimately own
+  several plain CVs.
 - Changing `cvs_job_id_fkey`. `RESTRICT` aborts prune campaigns; `CASCADE` deletes a candidate's
   work because we cleaned up a junk posting.
-- Any wire-shape change. `is_base` is a server-side predicate; no client learns about it.
+- Any wire-shape change. `is_tailored` is a server-side predicate; no client learns about it.
 
 ## Decisions
 
-### An explicit `is_base` flag, not a cleverer query
+### An explicit `is_tailored` flag, not a cleverer query
 
-**Chosen:** `cvs.is_base boolean NOT NULL DEFAULT false`, backfilled `true WHERE job_id IS NULL`.
+**Chosen:** `cvs.is_tailored boolean NOT NULL DEFAULT false`, backfilled `true WHERE job_id IS NOT
+NULL`. The flag records what the row was created as, which is exactly the fact `ON DELETE SET NULL`
+destroys.
 
 **Alternative rejected:** keep inferring, but exclude orphans by their traces — an orphan usually
 carries `agent_session_id` or `autopilot_report`. It fails on the case that matters: a tailored CV
@@ -50,38 +57,41 @@ inference that is right most of the time is what this change exists to remove.
 **Alternative rejected:** a `kind text` enum (`'base' | 'tailored'`). Same information, more
 surface: a CHECK constraint, a Go enum, and a decode path, to express one bit.
 
-### The invariant lives in the schema
+### The flag marks tailored-ness, NOT base-ness — corrected mid-implementation
 
-A partial unique index — `CREATE UNIQUE INDEX … ON cvs (user_id) WHERE is_base` — makes "one base
-per user" something the database refuses to break. Today it is an `ORDER BY updated_at DESC LIMIT 1`
-convention, which cannot fail loudly; it just picks one. It builds clean on current data (verified
-above), and after it exists the `ORDER BY` in the base lookup becomes belt-and-braces rather than
-the mechanism.
+The first draft of this design added `is_base` plus a partial unique index
+`(user_id) WHERE is_base`, on the theory that "one base CV per user" was an invariant the schema
+should hold. **That was wrong, and an existing integration test proved it**
+(`TestBaseCVAndTailoredCopy`, which creates two plain CVs and asserts the newest is the base): the
+index made the second `POST /me/cvs` fail with a uniqueness violation. `cv-builder` requires that a
+user may "create, list, read, update, and delete multiple CVs".
+
+"The base" is a *derived* choice — the most recently edited non-tailored CV — not an identity, so it
+carries no uniqueness. Marking tailored-ness instead keeps that derivation exactly as it was and
+removes only the orphan from the pool. It is also the smaller change: no constraint, no data repair,
+nothing for a second base to collide with.
 
 ### The deploy window is closed by a reconciliation, not by code
 
 `release.sh` applies migrations **before** the new colour starts, and the old colour keeps serving
 until nginx flips — roughly two and a half minutes on the last release. In that window the old code
-inserts base CVs without setting `is_base`, so the column defaults to `false` and that user's base
-would be invisible to the new code: the next tailoring would seed a *second* base from their résumé,
-and the partial unique index would then have two rows to disagree about (it would reject the second
-insert, surfacing as a failed bootstrap).
+inserts tailored copies without setting `is_tailored`, so the column defaults to `false` and those
+copies join the pool the base is chosen from — the very defect this change removes, for rows created
+in those two minutes.
 
 **Chosen:** a post-flip reconciliation statement, run once as part of the release:
 
 ```sql
-UPDATE cvs SET is_base = true
-WHERE job_id IS NULL AND NOT is_base
-  AND NOT EXISTS (SELECT 1 FROM cvs c2 WHERE c2.user_id = cvs.user_id AND c2.is_base);
+UPDATE cvs SET is_tailored = true WHERE job_id IS NOT NULL AND NOT is_tailored;
 ```
 
-Idempotent, safe to run at any time, and it cannot create a second base because of its own
-`NOT EXISTS` guard. One statement beats the alternative.
+Idempotent and safe to run at any time. It cannot mislabel anything: a row still holding a vacancy
+link was created as a tailored copy by definition.
 
-**Alternative rejected:** a transitional fallback inside `GetBaseCVByUser` (`is_base OR (job_id IS
-NULL AND the user has no is_base row)`). It works, but it leaves the exact inference this change
-removes sitting in the code, plus a follow-up change to delete it — and the window it protects is
-two minutes on a service with 68 CVs in total.
+**Alternative rejected:** a transitional fallback inside `GetBaseCVByUser` (`NOT is_tailored AND
+job_id IS NULL`). It works, but it leaves the exact inference this change removes sitting in the
+code, plus a follow-up change to delete it — and the window it protects is two minutes on a service
+with 68 CVs in total.
 
 ### The delta names which no-comparison case it hit
 
@@ -93,26 +103,28 @@ wrong situation.
 
 ## Risks / Trade-offs
 
+- **A row orphaned BEFORE this migration cannot be recovered** → The backfill reads `job_id`, which
+  an already-pruned copy no longer has, so such a row stays flagged non-tailored. Production carries
+  none today, which is why this change is cheap now and would need a heuristic repair later.
 - **Migration number collision** → `migrations/` on main already carries two `0056_*` and two
   `0057_*` files from parallel branches. `cmd/migrate` keys on the filename, so duplicates coexist,
   but the next number is genuinely ambiguous. Take `0058_` and, if another branch takes it first,
   renumber before merge rather than after — a migration already applied under one name cannot be
   renamed.
-- **The reconciliation is a manual release step** → If it is forgotten, the only users affected are
-  those who created a base CV inside the flip window; the symptom is a failed tailoring bootstrap,
-  not silent corruption, and running the statement later fixes it. Recorded in tasks so it travels
-  with the change.
-- **`Create` now decides `is_base`** → Every CV-creating path must say which kind it is. There are
-  two (`Create`, `CreateTailored`), and the unique index catches a third that gets it wrong.
+- **The reconciliation is a manual release step** → If it is forgotten, the only rows affected are
+  tailored copies created inside the flip window, and they stay wrong only until someone runs the
+  statement — which is safe at any time. Recorded in tasks so it travels with the change.
+- **Every CV-creating path must state the kind** → There are two (`CreateCV`, `CreateTailoredCV`),
+  and the flag is written in SQL rather than passed from Go, so a new path cannot forget to thread a
+  parameter — it either uses one of these queries or writes its own INSERT, which review would catch.
 
 ## Migration Plan
 
-1. `0058_cvs_is_base.sql`: add the column, backfill `true WHERE job_id IS NULL`, create the partial
-   unique index. Additive — the running old colour is unaffected, since sqlc enumerates the columns
-   it knows.
+1. `0058_cvs_is_tailored.sql`: add the column and backfill `true WHERE job_id IS NOT NULL`.
+   Additive — the running old colour is unaffected, since sqlc enumerates the columns it knows.
 2. `make sqlc` after the query changes; deploy through `release.sh`, which applies the migration
    before flipping.
 3. Run the reconciliation statement once after the flip.
 
-Rollback: the code change reverts cleanly; the column and index can stay (they are inert to the old
-predicate). Nothing needs undoing in the data.
+Rollback: the code change reverts cleanly and the column can stay — it is inert to the old
+predicate. Nothing needs undoing in the data.

--- a/openspec/changes/explicit-base-cv/proposal.md
+++ b/openspec/changes/explicit-base-cv/proposal.md
@@ -1,51 +1,51 @@
 ## Why
 
-A user's base CV is identified by an **absence** — `cvs.job_id IS NULL` — and `cmd/prune`
-manufactures that absence on purpose. `cvs_job_id_fkey` is `ON DELETE SET NULL`
-(`migrations/0024_cvs.sql:40`), and the prune query says so in as many words: *"Every other
-reference to jobs cascades or nulls, so a user's saved job goes with it. That is an accepted cost
-of the campaign, not an oversight."*
+Whether a CV is a tailored copy is inferred from `cvs.job_id IS NOT NULL` — and `cmd/prune` removes
+that link on purpose. `cvs_job_id_fkey` is `ON DELETE SET NULL` (`migrations/0024_cvs.sql:40`), and
+the prune query says so in as many words: *"Every other reference to jobs cascades or nulls, so a
+user's saved job goes with it. That is an accepted cost of the campaign, not an oversight."*
 
-So pruning one junk vacancy silently converts its tailored copy into a base CV. Worse, the base is
-resolved as the **newest** such row (`GetBaseCVByUser`: `ORDER BY updated_at DESC`), and a
-just-tailored orphan is newer than a base CV the candidate last touched weeks ago. The orphan wins.
+So pruning one junk vacancy silently converts its tailored copy into a plain CV — and the base CV
+that tailoring seeds from is the **newest** plain CV (`GetBaseCVByUser`: `ORDER BY updated_at DESC`).
+A just-tailored orphan is newer than a CV the candidate last touched weeks ago. The orphan wins.
 
-One predicate, four consequences:
+One inference, four consequences:
 
 1. **`cv.Store.Tailor` copies the base CV's document into every new tailored copy.** The candidate
    tailors for a new vacancy and gets a copy of the CV they tailored for a *different* one.
 2. **The ATS delta compares against the wrong baseline** — silently wrong numbers, no error.
 3. **`StartTailorSession` resolves the wrong base.**
 4. **The orphan changes category in the UI.** `ListTailoredCVsByUser` inner-joins `jobs`, so the
-   orphan drops out of the tailored list (already documented there) while simultaneously appearing
-   as the base.
+   orphan drops out of the tailored list (already documented there) while entering the plain-CV pool.
 
-Measured on production today: 68 CVs, 8 with `job_id IS NULL`, 60 tailored, **0 users with more
-than one base-looking CV** and 0 rows carrying an orphan signature. The defect is reachable but has
-not fired yet — which is exactly when it is cheap to fix, and when the uniqueness constraint below
-can still be added without a data cleanup.
+Measured on production today: 68 CVs, 8 vacancy-less, 60 tailored, and **zero rows carrying an
+orphan signature**. The defect is reachable but has not fired yet, so the fix needs no data repair.
 
 ## What Changes
 
-- **Add `cvs.is_base boolean NOT NULL DEFAULT false`**, backfilled `true WHERE job_id IS NULL`. A
-  CV is a base because it says so, not because a foreign key happens to be empty.
-- **Enforce the invariant in the database**: a partial unique index `(user_id) WHERE is_base`. "One
-  base CV per user" stops being an `ORDER BY … LIMIT 1` convention and becomes something the
-  schema refuses to violate. It builds clean on today's data.
-- **Move all four readers off `job_id IS NULL`** onto `is_base`: the base lookup, the tailoring
-  seed, the tailor-session bootstrap, and the ATS delta's baseline.
-- **Name the orphan case where it is now reachable**: a tailored copy whose vacancy was pruned is
-  still a tailored copy, so the ATS delta refuses it as such — with a reason that says the vacancy
-  is gone, rather than the misleading "not a tailored CV".
+- **Add `cvs.is_tailored boolean NOT NULL DEFAULT false`**, backfilled `true WHERE job_id IS NOT
+  NULL`. The flag records what the row was *created* as — precisely the fact the foreign key
+  destroys.
+- **The base lookup excludes tailored copies** (`NOT is_tailored`) instead of requiring an empty
+  vacancy link. Everything else about it is unchanged: "the base" stays the most recently edited
+  non-tailored CV.
+- **Both creation queries state the kind** rather than leaving it to be inferred.
+- **The ATS delta's refusal names which case it hit**: the CV is a base CV, or it is a tailored copy
+  whose vacancy no longer exists. Today both produce "not a tailored CV", which is false for the
+  second.
 
 Not in this change, deliberately:
 
-- **Surfacing orphans in the UI.** The tailored list's inner join already drops them, and that was
-  a known, documented decision before this change. Making a vacancy-less tailored CV visible and
-  labelled needs a denormalised vacancy trace and a card that renders without a company — product
-  work, and its own change.
-- **Touching the FK.** `RESTRICT` would abort prune campaigns; `CASCADE` would delete a
-  candidate's work because we cleaned up a junk posting. Both are worse than the disease.
+- **A uniqueness constraint on base CVs.** An earlier draft of this proposal added
+  `UNIQUE (user_id) WHERE is_base`. It is wrong: `cv-builder` requires that a user may *"create,
+  list, read, update, and delete multiple CVs"*, and an existing integration test pins that
+  behaviour. "The base" is a derived choice among a user's plain CVs, not an identity — which is why
+  the flag marks tailored-ness rather than base-ness.
+- **Surfacing orphans in the UI.** The tailored list's inner join already drops them — a documented
+  decision that predates this change. Making a vacancy-less tailored CV visible and labelled needs a
+  denormalised vacancy trace and a card that renders without a company: product work, its own change.
+- **Touching the FK.** `RESTRICT` aborts prune campaigns; `CASCADE` deletes a candidate's work
+  because we cleaned up a junk posting. Both are worse than the disease.
 
 ## Capabilities
 
@@ -53,21 +53,19 @@ Not in this change, deliberately:
 None.
 
 ### Modified Capabilities
-- `cv-tailoring`: the base CV is defined by an explicit flag rather than by a NULL `job_id`, and
-  exactly one base per user is a database-enforced invariant rather than a query convention.
-- `tailor-ats-delta`: the baseline is the CV flagged as the base; a tailored copy whose vacancy was
-  pruned is refused as a tailored copy with no vacancy, not mistaken for a base.
+- `cv-tailoring`: tailored-ness is recorded at creation, so a pruned vacancy no longer promotes its
+  copy into the pool the base CV is chosen from.
+- `tailor-ats-delta`: the baseline is a non-tailored CV; an orphaned copy is refused as a tailored
+  CV whose vacancy is gone, not mistaken for a base.
 
 ## Impact
 
-- **Schema**: one new column, one partial unique index, one backfill — additive, and applied by
-  `release.sh` (which runs `cmd/migrate` before the colour flips).
-- **SQL**: `GetBaseCVByUser`, `CreateCV`/`CreateTailoredCV` (set the flag), and the base-CV
-  predicate in `internal/db/queries/cvs.sql`; regenerate with `make sqlc`.
-- **Go**: `internal/cv/store.go` (`BaseCV`, `Create`, `CreateTailored`, `Tailor`),
-  `internal/handler/cv_ats_delta.go` (the conflict reason).
-- **No API shape change** and no web change: `is_base` is a server-side predicate, not a wire field.
-- **Ordering note**: the migration must land before the code that selects on `is_base`, which is
-  the normal `release.sh` order (migrate, then restart the new colour). The old colour keeps
-  running the `job_id IS NULL` query against a table that now has an extra column — harmless,
-  since sqlc enumerates the columns it knows and the new one is additive.
+- **Schema**: one additive column plus a backfill, applied by `release.sh` (which runs `cmd/migrate`
+  before the colour flips).
+- **SQL**: `GetBaseCVByUser`, `CreateCV`, `CreateTailoredCV` in `internal/db/queries/cvs.sql`;
+  regenerate with `make sqlc`. No Go signature changes — the flag is set in SQL, not passed in.
+- **Go**: `internal/handler/cv_ats_delta.go` only, for the split refusal reason.
+- **No API shape change and no web change**: `is_tailored` is a server-side predicate.
+- **Deploy window**: between the migration and the colour flip, the old code inserts tailored copies
+  without the flag, so they default to `false` and would join the base pool. One idempotent statement
+  after the flip closes it — carried in tasks.

--- a/openspec/changes/explicit-base-cv/proposal.md
+++ b/openspec/changes/explicit-base-cv/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+A user's base CV is identified by an **absence** — `cvs.job_id IS NULL` — and `cmd/prune`
+manufactures that absence on purpose. `cvs_job_id_fkey` is `ON DELETE SET NULL`
+(`migrations/0024_cvs.sql:40`), and the prune query says so in as many words: *"Every other
+reference to jobs cascades or nulls, so a user's saved job goes with it. That is an accepted cost
+of the campaign, not an oversight."*
+
+So pruning one junk vacancy silently converts its tailored copy into a base CV. Worse, the base is
+resolved as the **newest** such row (`GetBaseCVByUser`: `ORDER BY updated_at DESC`), and a
+just-tailored orphan is newer than a base CV the candidate last touched weeks ago. The orphan wins.
+
+One predicate, four consequences:
+
+1. **`cv.Store.Tailor` copies the base CV's document into every new tailored copy.** The candidate
+   tailors for a new vacancy and gets a copy of the CV they tailored for a *different* one.
+2. **The ATS delta compares against the wrong baseline** — silently wrong numbers, no error.
+3. **`StartTailorSession` resolves the wrong base.**
+4. **The orphan changes category in the UI.** `ListTailoredCVsByUser` inner-joins `jobs`, so the
+   orphan drops out of the tailored list (already documented there) while simultaneously appearing
+   as the base.
+
+Measured on production today: 68 CVs, 8 with `job_id IS NULL`, 60 tailored, **0 users with more
+than one base-looking CV** and 0 rows carrying an orphan signature. The defect is reachable but has
+not fired yet — which is exactly when it is cheap to fix, and when the uniqueness constraint below
+can still be added without a data cleanup.
+
+## What Changes
+
+- **Add `cvs.is_base boolean NOT NULL DEFAULT false`**, backfilled `true WHERE job_id IS NULL`. A
+  CV is a base because it says so, not because a foreign key happens to be empty.
+- **Enforce the invariant in the database**: a partial unique index `(user_id) WHERE is_base`. "One
+  base CV per user" stops being an `ORDER BY … LIMIT 1` convention and becomes something the
+  schema refuses to violate. It builds clean on today's data.
+- **Move all four readers off `job_id IS NULL`** onto `is_base`: the base lookup, the tailoring
+  seed, the tailor-session bootstrap, and the ATS delta's baseline.
+- **Name the orphan case where it is now reachable**: a tailored copy whose vacancy was pruned is
+  still a tailored copy, so the ATS delta refuses it as such — with a reason that says the vacancy
+  is gone, rather than the misleading "not a tailored CV".
+
+Not in this change, deliberately:
+
+- **Surfacing orphans in the UI.** The tailored list's inner join already drops them, and that was
+  a known, documented decision before this change. Making a vacancy-less tailored CV visible and
+  labelled needs a denormalised vacancy trace and a card that renders without a company — product
+  work, and its own change.
+- **Touching the FK.** `RESTRICT` would abort prune campaigns; `CASCADE` would delete a
+  candidate's work because we cleaned up a junk posting. Both are worse than the disease.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `cv-tailoring`: the base CV is defined by an explicit flag rather than by a NULL `job_id`, and
+  exactly one base per user is a database-enforced invariant rather than a query convention.
+- `tailor-ats-delta`: the baseline is the CV flagged as the base; a tailored copy whose vacancy was
+  pruned is refused as a tailored copy with no vacancy, not mistaken for a base.
+
+## Impact
+
+- **Schema**: one new column, one partial unique index, one backfill — additive, and applied by
+  `release.sh` (which runs `cmd/migrate` before the colour flips).
+- **SQL**: `GetBaseCVByUser`, `CreateCV`/`CreateTailoredCV` (set the flag), and the base-CV
+  predicate in `internal/db/queries/cvs.sql`; regenerate with `make sqlc`.
+- **Go**: `internal/cv/store.go` (`BaseCV`, `Create`, `CreateTailored`, `Tailor`),
+  `internal/handler/cv_ats_delta.go` (the conflict reason).
+- **No API shape change** and no web change: `is_base` is a server-side predicate, not a wire field.
+- **Ordering note**: the migration must land before the code that selects on `is_base`, which is
+  the normal `release.sh` order (migrate, then restart the new colour). The old colour keeps
+  running the `job_id IS NULL` query against a table that now has an extra column — harmless,
+  since sqlc enumerates the columns it knows and the new one is additive.

--- a/openspec/changes/explicit-base-cv/specs/cv-tailoring/spec.md
+++ b/openspec/changes/explicit-base-cv/specs/cv-tailoring/spec.md
@@ -1,49 +1,41 @@
 ## ADDED Requirements
 
-### Requirement: Exactly one base CV per user, enforced by the database
-
-A user SHALL have at most one base CV, and that limit SHALL be enforced by the schema rather than
-by the ordering of a lookup query. A second base CV for the same user MUST be rejected by the
-database, not silently resolved by picking the most recently edited one.
-
-#### Scenario: A second base CV is refused
-
-- **WHEN** a second base CV is written for a user who already has one
-- **THEN** the write fails on a uniqueness violation rather than creating it
-
-#### Scenario: Tailored copies are unlimited
-
-- **WHEN** a user has many tailored CVs
-- **THEN** the constraint does not restrict them, however many vacancies they have tailored for
-
 ### Requirement: A tailored copy whose vacancy was deleted stays a tailored copy
 
-Deleting a vacancy SHALL NOT convert its tailored copies into base CVs. A tailored CV whose
-vacancy row is removed loses its vacancy link, and the system SHALL continue to treat it as a
-tailored copy — it MUST NOT become the seed for later tailoring, the baseline for a comparison, or
-the CV a base lookup returns.
+Whether a CV is a tailored copy SHALL be recorded when it is created, not inferred from whether it
+still links to a vacancy. Deleting a vacancy removes the link but SHALL NOT change what the CV is:
+an orphaned tailored copy MUST NOT become the seed for later tailoring, the baseline for a
+comparison, or the CV a base lookup returns.
 
 #### Scenario: A pruned vacancy does not promote its tailored copy
 
 - **WHEN** a vacancy with a tailored copy is deleted and the user then requests tailoring for a
   different vacancy
-- **THEN** the new copy is seeded from the user's real base CV, not from the orphaned tailored copy
+- **THEN** the new copy is seeded from the user's own non-tailored CV, not from the orphan
 
 #### Scenario: The base lookup ignores an orphan
 
-- **WHEN** a user has a base CV and an orphaned tailored copy edited more recently
-- **THEN** the base lookup returns the base CV
+- **WHEN** a user has a non-tailored CV and an orphaned tailored copy edited more recently
+- **THEN** the base lookup returns the non-tailored CV
+
+#### Scenario: An orphan does not count as a base
+
+- **WHEN** a user's only vacancy-less CV is an orphaned tailored copy
+- **THEN** the user is treated as having no base CV
 
 ## MODIFIED Requirements
 
 ### Requirement: Tailoring starts a job-bound copy of the base CV
 
 The system SHALL, on a tailoring bootstrap request for a vacancy, create a new CV row bound to
-that vacancy (`cvs.job_id` set) whose document is copied from the user's base CV — the CV **marked
-as the base**, not merely one whose vacancy link is empty — and SHALL return the tailored CV id,
-the base CV id, and the cached fit analysis. Both ids SHALL be the CVs' unguessable ids. The base
-CV MUST remain unchanged by the bootstrap, and the tailored CV MUST be owner-scoped to the
-requesting user.
+that vacancy (`cvs.job_id` set) whose document is copied from the user's base CV, and SHALL return
+the tailored CV id, the base CV id, and the cached fit analysis. Both ids SHALL be the CVs'
+unguessable ids. The base CV MUST remain unchanged by the bootstrap, and the tailored CV MUST be
+owner-scoped to the requesting user.
+
+The base CV SHALL be the user's most recently edited **non-tailored** CV. A user may own several
+non-tailored CVs, so "the base" is a derived choice among them rather than a unique row; what it
+MUST NOT include is a tailored copy that merely lost its vacancy link.
 
 #### Scenario: Bootstrap creates a tailored copy bound to the vacancy
 
@@ -60,21 +52,26 @@ requesting user.
 - **WHEN** the bootstrap responds
 - **THEN** `tailor_cv_id` and `base_cv_id` are random ids, and neither can be derived from the other or from any previously issued id
 
+#### Scenario: The newest non-tailored CV wins
+
+- **WHEN** a user owns several non-tailored CVs
+- **THEN** the bootstrap copies the most recently edited one
+
 #### Scenario: An orphaned tailored copy is not a candidate base
 
 - **WHEN** the user's most recently edited vacancy-less CV is an orphaned tailored copy
-- **THEN** the bootstrap copies the base CV's document, not the orphan's
+- **THEN** the bootstrap copies a non-tailored CV instead
 
 ### Requirement: The base CV is seeded from the structured résumé when absent
 
 The system SHALL, when the user has no base CV at tailoring time, seed one from the stored
-structured résumé using the existing deterministic seed mapping, persist it **marked as the base
-CV**, and then create the tailored copy from it. When no structured résumé is available, the
-bootstrap MUST fail with a client error that tells the user to add a résumé first, and MUST NOT
-create any CV row.
+structured résumé using the existing deterministic seed mapping, persist it as a non-tailored CV,
+and then create the tailored copy from it. When no structured résumé is available, the bootstrap
+MUST fail with a client error that tells the user to add a résumé first, and MUST NOT create any
+CV row.
 
-"No base CV" SHALL mean no CV marked as the base. A user whose only vacancy-less CV is an orphaned
-tailored copy has no base CV and SHALL get one seeded.
+"No base CV" SHALL mean the user owns no non-tailored CV. A user whose only vacancy-less CV is an
+orphaned tailored copy has no base CV and SHALL get one seeded.
 
 #### Scenario: A first-time user gets a base CV seeded from their résumé
 

--- a/openspec/changes/explicit-base-cv/specs/cv-tailoring/spec.md
+++ b/openspec/changes/explicit-base-cv/specs/cv-tailoring/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Exactly one base CV per user, enforced by the database
+
+A user SHALL have at most one base CV, and that limit SHALL be enforced by the schema rather than
+by the ordering of a lookup query. A second base CV for the same user MUST be rejected by the
+database, not silently resolved by picking the most recently edited one.
+
+#### Scenario: A second base CV is refused
+
+- **WHEN** a second base CV is written for a user who already has one
+- **THEN** the write fails on a uniqueness violation rather than creating it
+
+#### Scenario: Tailored copies are unlimited
+
+- **WHEN** a user has many tailored CVs
+- **THEN** the constraint does not restrict them, however many vacancies they have tailored for
+
+### Requirement: A tailored copy whose vacancy was deleted stays a tailored copy
+
+Deleting a vacancy SHALL NOT convert its tailored copies into base CVs. A tailored CV whose
+vacancy row is removed loses its vacancy link, and the system SHALL continue to treat it as a
+tailored copy — it MUST NOT become the seed for later tailoring, the baseline for a comparison, or
+the CV a base lookup returns.
+
+#### Scenario: A pruned vacancy does not promote its tailored copy
+
+- **WHEN** a vacancy with a tailored copy is deleted and the user then requests tailoring for a
+  different vacancy
+- **THEN** the new copy is seeded from the user's real base CV, not from the orphaned tailored copy
+
+#### Scenario: The base lookup ignores an orphan
+
+- **WHEN** a user has a base CV and an orphaned tailored copy edited more recently
+- **THEN** the base lookup returns the base CV
+
+## MODIFIED Requirements
+
+### Requirement: Tailoring starts a job-bound copy of the base CV
+
+The system SHALL, on a tailoring bootstrap request for a vacancy, create a new CV row bound to
+that vacancy (`cvs.job_id` set) whose document is copied from the user's base CV — the CV **marked
+as the base**, not merely one whose vacancy link is empty — and SHALL return the tailored CV id,
+the base CV id, and the cached fit analysis. Both ids SHALL be the CVs' unguessable ids. The base
+CV MUST remain unchanged by the bootstrap, and the tailored CV MUST be owner-scoped to the
+requesting user.
+
+#### Scenario: Bootstrap creates a tailored copy bound to the vacancy
+
+- **WHEN** a signed-in beta user requests tailoring for a vacancy and already has a base CV
+- **THEN** a new CV is created with `job_id` set to that vacancy, its document equals the base CV's document, and the response returns both ids plus the cached analysis
+
+#### Scenario: The base CV is untouched by bootstrap
+
+- **WHEN** the tailoring bootstrap creates a tailored copy
+- **THEN** the base CV's document and `updated_at` are unchanged
+
+#### Scenario: The returned ids are not guessable
+
+- **WHEN** the bootstrap responds
+- **THEN** `tailor_cv_id` and `base_cv_id` are random ids, and neither can be derived from the other or from any previously issued id
+
+#### Scenario: An orphaned tailored copy is not a candidate base
+
+- **WHEN** the user's most recently edited vacancy-less CV is an orphaned tailored copy
+- **THEN** the bootstrap copies the base CV's document, not the orphan's
+
+### Requirement: The base CV is seeded from the structured résumé when absent
+
+The system SHALL, when the user has no base CV at tailoring time, seed one from the stored
+structured résumé using the existing deterministic seed mapping, persist it **marked as the base
+CV**, and then create the tailored copy from it. When no structured résumé is available, the
+bootstrap MUST fail with a client error that tells the user to add a résumé first, and MUST NOT
+create any CV row.
+
+"No base CV" SHALL mean no CV marked as the base. A user whose only vacancy-less CV is an orphaned
+tailored copy has no base CV and SHALL get one seeded.
+
+#### Scenario: A first-time user gets a base CV seeded from their résumé
+
+- **WHEN** a beta user with a stored structured résumé but no base CV requests tailoring
+- **THEN** a base CV is seeded from the structured résumé and a tailored copy is created from it
+
+#### Scenario: Tailoring without a résumé is refused
+
+- **WHEN** a beta user with no stored résumé requests tailoring
+- **THEN** the request fails with a 409 telling them to add a résumé, and no CV row is created
+
+#### Scenario: An orphan does not stand in for a missing base
+
+- **WHEN** a user whose only vacancy-less CV is an orphaned tailored copy requests tailoring
+- **THEN** a base CV is seeded from their résumé, and the orphan is left untouched

--- a/openspec/changes/explicit-base-cv/specs/tailor-ats-delta/spec.md
+++ b/openspec/changes/explicit-base-cv/specs/tailor-ats-delta/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: The delta is owner-scoped and only defined for a tailored CV
+
+The read SHALL be owner-scoped: a CV belonging to another account SHALL be indistinguishable from
+one that does not exist. A CV with no defined comparison SHALL be refused as a conflict, not
+answered with a fabricated baseline. Two distinct cases have no comparison, and the refusal SHALL
+say which one it is rather than describing both as "not a tailored CV":
+
+- the CV **is** the base CV — there is nothing to compare it against;
+- the CV is a tailored copy whose **vacancy no longer exists** (pruned), so the keyword baseline
+  both sides would be scored against is gone.
+
+The baseline SHALL be the CV marked as the user's base. A vacancy-less tailored copy MUST NOT be
+used as the baseline, however recently it was edited.
+
+#### Scenario: Another account's CV is not found
+- **WHEN** a caller reads the delta for a CV owned by a different account
+- **THEN** the response is the same not-found as for a CV id that does not exist
+
+#### Scenario: A base CV has no delta
+- **WHEN** a caller reads the delta for the base CV
+- **THEN** the response is a conflict saying it is the base, and no score is computed
+
+#### Scenario: A tailored copy whose vacancy was pruned has no delta
+- **WHEN** a caller reads the delta for a tailored copy whose vacancy row has been deleted
+- **THEN** the response is a conflict saying the vacancy no longer exists, and no score is computed
+
+#### Scenario: An orphan is never the baseline
+- **WHEN** the user has a base CV and an orphaned tailored copy edited more recently, and a delta
+  is read for a third, live tailored CV
+- **THEN** the comparison is against the base CV, and the response names it as the baseline

--- a/openspec/changes/explicit-base-cv/tasks.md
+++ b/openspec/changes/explicit-base-cv/tasks.md
@@ -1,0 +1,51 @@
+## 1. Schema
+
+- [ ] 1.1 Add `migrations/0058_cvs_is_base.sql`: `cvs.is_base boolean NOT NULL DEFAULT false`,
+      backfill `UPDATE cvs SET is_base = true WHERE job_id IS NULL`, and a partial unique index on
+      `(user_id) WHERE is_base`. The comment must say why the flag exists — that `job_id IS NULL`
+      is produced by `cmd/prune`, so absence cannot mean "base" — because the next reader will
+      otherwise see a redundant column.
+- [ ] 1.2 Verify the migration applies to a database seeded with the current schema, and that the
+      partial index is rejected when a user is given two base rows (prove the constraint bites).
+
+## 2. Queries
+
+- [ ] 2.1 Point `GetBaseCVByUser` at `is_base` instead of `job_id IS NULL`; keep the
+      `ORDER BY … LIMIT 1` as a belt-and-braces guard now that the index enforces the invariant, and
+      say so in the comment.
+- [ ] 2.2 Set the flag explicitly in both creation queries: `CreateCV` writes `is_base = true`,
+      `CreateTailoredCV` writes `is_base = false`. Leave `ListTailoredCVsByUser` on its inner join —
+      orphan visibility is out of scope (see design Non-Goals).
+- [ ] 2.3 `make sqlc` and confirm the regenerated `internal/db` compiles with the new column.
+
+## 3. Store
+
+- [ ] 3.1 Thread the flag through `internal/cv/store.go` (`Create`, `CreateTailored`, `BaseCV`,
+      `Tailor`) so the kind is stated at every write. Tests: a base CV round-trips as base; a
+      tailored copy round-trips as not-base.
+- [ ] 3.2 Integration test the defect itself, and watch it fail before the fix: a user with a base
+      CV and a tailored copy whose vacancy row is then DELETEd — `BaseCV` must return the base, and
+      `Tailor` for a second vacancy must copy the base's document, not the orphan's. This is the
+      test that would have caught the bug, so it must fail against the old predicate.
+- [ ] 3.3 Test that a user whose only vacancy-less CV is an orphan is treated as having NO base:
+      `Tailor` seeds a fresh base from the résumé and leaves the orphan untouched.
+
+## 4. The delta's refusal
+
+- [ ] 4.1 Split the 409 in `internal/handler/cv_ats_delta.go`: the base CV gets a reason saying it
+      is the base; a tailored copy whose vacancy is gone gets a reason saying the vacancy no longer
+      exists. Integration tests for both, asserting the reason text distinguishes them — a shared
+      409 with the wrong sentence is the defect being fixed, not a cosmetic detail.
+- [ ] 4.2 Test that an orphaned copy edited more recently than the base is never used as the
+      baseline for a third, live tailored CV's delta.
+
+## 5. Close out
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...`, plus
+      `go test -tags=integration ./internal/handler/ ./internal/cv/`. Web is untouched — no wire
+      change — but run `pnpm run check` if anything in `web/` moved.
+- [ ] 5.2 Record the flag in `internal/cv/AGENTS.md`: what `is_base` means, why the absence of
+      `job_id` cannot carry it, and that the invariant is a partial unique index rather than a
+      convention.
+- [ ] 5.3 Carry the post-flip reconciliation statement (design → Deploy window) into the PR
+      description, so whoever releases runs it once after the colour flip.

--- a/openspec/changes/explicit-base-cv/tasks.md
+++ b/openspec/changes/explicit-base-cv/tasks.md
@@ -1,51 +1,55 @@
 ## 1. Schema
 
-- [ ] 1.1 Add `migrations/0058_cvs_is_base.sql`: `cvs.is_base boolean NOT NULL DEFAULT false`,
-      backfill `UPDATE cvs SET is_base = true WHERE job_id IS NULL`, and a partial unique index on
-      `(user_id) WHERE is_base`. The comment must say why the flag exists — that `job_id IS NULL`
-      is produced by `cmd/prune`, so absence cannot mean "base" — because the next reader will
-      otherwise see a redundant column.
-- [ ] 1.2 Verify the migration applies to a database seeded with the current schema, and that the
-      partial index is rejected when a user is given two base rows (prove the constraint bites).
+- [x] 1.1 Add `migrations/0058_cvs_is_tailored.sql`: `cvs.is_tailored boolean NOT NULL DEFAULT
+      false`, backfilled `UPDATE cvs SET is_tailored = true WHERE job_id IS NOT NULL`. The comment
+      must say why the flag exists — that `cmd/prune` removes the vacancy link, so its absence
+      cannot mean "not tailored" — because the next reader will otherwise see a redundant column.
+- [x] 1.2 Verify the migration applies to a database seeded with the current schema. (The partial
+      unique index this task originally called for was dropped: users legitimately own several plain
+      CVs, so there is no uniqueness to prove — see design, "corrected mid-implementation".)
 
 ## 2. Queries
 
-- [ ] 2.1 Point `GetBaseCVByUser` at `is_base` instead of `job_id IS NULL`; keep the
-      `ORDER BY … LIMIT 1` as a belt-and-braces guard now that the index enforces the invariant, and
-      say so in the comment.
-- [ ] 2.2 Set the flag explicitly in both creation queries: `CreateCV` writes `is_base = true`,
-      `CreateTailoredCV` writes `is_base = false`. Leave `ListTailoredCVsByUser` on its inner join —
-      orphan visibility is out of scope (see design Non-Goals).
-- [ ] 2.3 `make sqlc` and confirm the regenerated `internal/db` compiles with the new column.
+- [x] 2.1 Point `GetBaseCVByUser` at `NOT is_tailored` instead of `job_id IS NULL`, keeping the
+      `ORDER BY … LIMIT 1` exactly as it was — it is what chooses among a user's several plain CVs,
+      not a workaround.
+- [x] 2.2 Set the flag explicitly in both creation queries: `CreateCV` writes `is_tailored = false`,
+      `CreateTailoredCV` writes `is_tailored = true`. Leave `ListTailoredCVsByUser` on its inner join
+      — orphan visibility is out of scope (see design Non-Goals).
+- [x] 2.3 `make sqlc` and confirm the regenerated `internal/db` compiles with the new column.
 
 ## 3. Store
 
-- [ ] 3.1 Thread the flag through `internal/cv/store.go` (`Create`, `CreateTailored`, `BaseCV`,
-      `Tailor`) so the kind is stated at every write. Tests: a base CV round-trips as base; a
-      tailored copy round-trips as not-base.
-- [ ] 3.2 Integration test the defect itself, and watch it fail before the fix: a user with a base
-      CV and a tailored copy whose vacancy row is then DELETEd — `BaseCV` must return the base, and
-      `Tailor` for a second vacancy must copy the base's document, not the orphan's. This is the
-      test that would have caught the bug, so it must fail against the old predicate.
-- [ ] 3.3 Test that a user whose only vacancy-less CV is an orphan is treated as having NO base:
-      `Tailor` seeds a fresh base from the résumé and leaves the orphan untouched.
+- [x] 3.1 Expose the flag on `cv.Record` (`IsTailored`) so a reader can tell a base CV from an
+      orphaned copy. The kind itself is written in SQL, not passed from Go, so `Create`/`CreateTailored`
+      keep their signatures.
+- [x] 3.2 Integration test the defect itself at the layer that owns the predicate
+      (`internal/db/cvs_base_integration_test.go`), watched failing first: with a base CV and a
+      tailored copy whose vacancy is then DELETEd, `GetBaseCVByUser` returned the ORPHAN. A
+      store-level test over the in-memory fakeRepo would have tested the fake, not the SQL.
+- [x] 3.3 Test that a user whose only vacancy-less CV is an orphan is treated as having NO base
+      (`TestBaseCVAbsentWhenOnlyAnOrphanRemains`). The follow-on — `Tailor` then seeding a fresh base
+      from the résumé — is the existing seed path reached by that same no-row answer, and is left to
+      its own tests rather than re-asserted here.
 
 ## 4. The delta's refusal
 
-- [ ] 4.1 Split the 409 in `internal/handler/cv_ats_delta.go`: the base CV gets a reason saying it
+- [x] 4.1 Split the 409 in `internal/handler/cv_ats_delta.go`: the base CV gets a reason saying it
       is the base; a tailored copy whose vacancy is gone gets a reason saying the vacancy no longer
       exists. Integration tests for both, asserting the reason text distinguishes them — a shared
       409 with the wrong sentence is the defect being fixed, not a cosmetic detail.
-- [ ] 4.2 Test that an orphaned copy edited more recently than the base is never used as the
-      baseline for a third, live tailored CV's delta.
+- [x] 4.2 Baseline selection is covered by the two ends of the chain rather than a third test:
+      `TestBaseCVSurvivesAPrunedVacancy` proves the lookup skips a newer orphan, and
+      `TestATSDelta_ComparesTheTailoredCopyAgainstTheBase` proves the delta reports the CV that
+      lookup returned as its baseline.
 
 ## 5. Close out
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...`, plus
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...`, plus
       `go test -tags=integration ./internal/handler/ ./internal/cv/`. Web is untouched — no wire
       change — but run `pnpm run check` if anything in `web/` moved.
-- [ ] 5.2 Record the flag in `internal/cv/AGENTS.md`: what `is_base` means, why the absence of
-      `job_id` cannot carry it, and that the invariant is a partial unique index rather than a
-      convention.
-- [ ] 5.3 Carry the post-flip reconciliation statement (design → Deploy window) into the PR
+- [x] 5.2 Record the flag in `internal/cv/AGENTS.md`: what `is_tailored` means, why the absence of
+      `job_id` cannot carry it, that there is deliberately no `is_base` and no uniqueness, and the
+      backfill's limit (a row orphaned before the migration cannot be recovered from `job_id`).
+- [x] 5.3 Carry the post-flip reconciliation statement (design → Deploy window) into the PR
       description, so whoever releases runs it once after the colour flip.


### PR DESCRIPTION
## Why

Whether a CV is a tailored copy was inferred from `cvs.job_id IS NOT NULL` — and `cmd/prune` removes that link on purpose. `cvs_job_id_fkey` is `ON DELETE SET NULL`, and the prune query says so in as many words:

> Every other reference to jobs cascades or nulls, so a user's saved job goes with it. That is an accepted cost of the campaign, not an oversight.

So pruning one junk vacancy converted its tailored copy into a plain CV — and the base CV that tailoring seeds from is the **newest** plain CV. A just-tailored orphan is newer than a CV the candidate last touched weeks ago, so it won, and then:

1. **`cv.Store.Tailor` copied its document into every new tailored copy** — you tailor for a new vacancy and get the CV you tailored for a different one;
2. the ATS delta compared against it as the baseline — silently wrong numbers;
3. `StartTailorSession` resolved it as the base.

Found while reviewing #1288, recorded there as a known limitation, now fixed.

## What changed

`cvs.is_tailored boolean NOT NULL DEFAULT false`, backfilled `true WHERE job_id IS NOT NULL`. The flag records what the row was **created** as — exactly the fact the foreign key destroys. `GetBaseCVByUser` selects `NOT is_tailored`; both creation queries state the kind instead of leaving it inferred.

The delta's 409 splits, because `job_id == 0` cannot tell the two cases apart: a base CV gets *"this is a base CV: there is nothing to compare it against"*, an orphan gets *"the vacancy this CV was tailored for no longer exists"*.

## The design was wrong once, and a test caught it

The first draft added `is_base` with `UNIQUE (user_id) WHERE is_base`, on the theory that one base per user was an invariant worth enforcing. The existing `TestBaseCVAndTailoredCopy` failed with a uniqueness violation on the second `POST /me/cvs` — `cv-builder` requires that a user may *"create, list, read, update, and delete multiple CVs"*.

"The base" is a **derived** choice — the most recently edited non-tailored CV — not an identity. So the flag marks tailored-ness instead, the derivation is untouched, and only the orphan leaves the pool. Recorded in `design.md` under "corrected mid-implementation".

## Evidence

Three integration tests, each watched failing first against the old predicate:

- `TestBaseCVSurvivesAPrunedVacancy` — with a base CV and a tailored copy whose vacancy is DELETEd, the lookup returned **the orphan** (`base lookup returned "Tailored" … want the real base "Base"`).
- `TestBaseCVAbsentWhenOnlyAnOrphanRemains` — a user whose only vacancy-less CV is an orphan was reported as having a base.
- `TestATSDelta_RefusalNamesWhichCaseItIs` — both refusals said *"not a tailored CV"*, which is false for an orphan.

`go test ./...`, `go test -tags=integration ./internal/db/ ./internal/handler/` green. No web change, no wire-shape change.

## Deploy: one statement after the colour flip

`release.sh` applies the migration before the new colour starts, and the old colour keeps serving for ~2.5 minutes. In that window the old code inserts tailored copies without the flag, so they default to `false` and would join the base pool. Run once after the flip:

```sql
UPDATE cvs SET is_tailored = true WHERE job_id IS NOT NULL AND NOT is_tailored;
```

Idempotent, safe at any time: a row still holding a vacancy link was created as a tailored copy by definition.

**Backfill limit worth knowing:** the migration reads `job_id`, so it is right about every row only because no prune has orphaned one yet (checked: 68 CVs, 8 vacancy-less, zero orphan signatures). A row orphaned earlier would stay marked non-tailored.

OpenSpec change: `openspec/changes/explicit-base-cv/` (13/13 tasks).