### PR TITLE
fix(dedup): treat a trailing colon clause in a title as decoration

### DIFF
--- a/internal/db/aggregator_title_decoration_integration_test.go
+++ b/internal/db/aggregator_title_decoration_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+// Integration tests for which title decorations the aggregator suppression pass treats as
+// noise. A trailing colon clause is decoration an aggregator appends to an otherwise identical
+// title; a parenthetical and a clause after a comma are NOT — they name the team or the
+// specialty, and stripping them would merge separate roles at one company. Measured on prod
+// before being written down: stripping parentheticals produced 39 wrong pairs out of 55.
+// Reuses the helpers from aggregator_dedup_integration_test.go.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"testing"
+)
+
+// The shape whatjobs produces constantly: the ATS states the role, the aggregator appends the
+// stack after a colon.
+func TestSuppressAggregator_TrailingColonClauseIsDecoration(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, atsJob("acme:ats", "Senior Software Engineer", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Senior Software Engineer: Full-Stack with TypeScript", []string{"US"}))
+
+	suppressAggregators(t, q)
+
+	atsID, atsDup := dupOf(t, pool, "acme:ats")
+	if atsDup != -1 {
+		t.Errorf("ATS row duplicate_of = %d, want NULL (canonical)", atsDup)
+	}
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != atsID {
+		t.Errorf("aggregator duplicate_of = %d, want ATS %d (trailing colon clause is decoration)", aggDup, atsID)
+	}
+}
+
+// A colon clause in front of a dash clause must not stop the strip half-way.
+func TestSuppressAggregator_ColonAndDashClausesBothStripped(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, atsJob("acme:ats", "Backend Engineer", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Backend Engineer: Go, Kubernetes - Remote", []string{"US"}))
+
+	suppressAggregators(t, q)
+
+	atsID, _ := dupOf(t, pool, "acme:ats")
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != atsID {
+		t.Errorf("aggregator duplicate_of = %d, want ATS %d (both clauses stripped)", aggDup, atsID)
+	}
+}
+
+// A parenthetical names the team. One company runs Backend (Traffic), (Payments), (Identity) and
+// (Infrastructure) as separate roles — stripping the parenthetical would collapse them into one.
+func TestSuppressAggregator_ParentheticalIsNotDecoration(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, atsJob("acme:ats", "Senior Software Engineer, Backend (Payments)", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Senior Software Engineer, Backend (Traffic)", []string{"US"}))
+
+	suppressAggregators(t, q)
+
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != -1 {
+		t.Errorf("aggregator duplicate_of = %d, want NULL: (Traffic) and (Payments) are different teams", aggDup)
+	}
+}
+
+// A clause after a comma names the specialty.
+func TestSuppressAggregator_CommaClauseIsNotDecoration(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, atsJob("acme:ats", "Senior Software Engineer, Fullstack", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Senior Software Engineer, Backend", []string{"US"}))
+
+	suppressAggregators(t, q)
+
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != -1 {
+		t.Errorf("aggregator duplicate_of = %d, want NULL: Backend and Fullstack are different roles", aggDup)
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1862,7 +1862,9 @@ WITH ats AS (
            btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
-               regexp_replace(jobs.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+               regexp_replace(
+                 regexp_replace(jobs.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+                 '^(.*?):.+$', '\1'),
                '^(.*)\s[-|—]\s.+$', '\1')
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            jobs.countries
@@ -1876,7 +1878,9 @@ agg AS (
            btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
-               regexp_replace(a.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+               regexp_replace(
+                 regexp_replace(a.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+                 '^(.*?):.+$', '\1'),
                '^(.*)\s[-|—]\s.+$', '\1')
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            a.countries
@@ -1895,8 +1899,13 @@ agg AS (
 ),
 matches AS (
     -- Two match paths: the exact key (ntitle) and the entity-decoded, suffix-stripped key
-    -- (ntitle2), which catches an ATS title that only appends " - <suffix>" or carries an
-    -- undecoded HTML entity. Each path is a SEPARATE single-equality hash join (O(agg + ats))
+    -- (ntitle2), which catches a title that only appends a trailing " - <suffix>" or
+    -- ": <suffix>" clause, or carries an undecoded HTML entity. The colon clause is stripped
+    -- INSIDE the dash strip so a title carrying both ("Engineer: Go, K8s - Remote") reduces all
+    -- the way. Only those two clauses are decoration: measured on prod, also stripping a
+    -- parenthetical produced 39 wrong pairs out of 55 — one company's "…, Backend (Traffic)"
+    -- matching its "(Payments)", "(Identity)" and "(Infrastructure)" roles — and a comma clause
+    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE single-equality hash join (O(agg + ats))
     -- and the two are UNION ALL-ed — an OR of the two equalities in one ON would defeat the
     -- hash join and go quadratic on a big company (the hotel-chain case). UNION ALL, not
     -- UNION: a row matched by both paths appears twice, but the downstream MIN(ats_id)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -476,7 +476,9 @@ WITH ats AS (
            btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
-               regexp_replace(jobs.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+               regexp_replace(
+                 regexp_replace(jobs.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+                 '^(.*?):.+$', '\1'),
                '^(.*)\s[-|—]\s.+$', '\1')
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            jobs.countries
@@ -490,7 +492,9 @@ agg AS (
            btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
-               regexp_replace(a.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+               regexp_replace(
+                 regexp_replace(a.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+                 '^(.*?):.+$', '\1'),
                '^(.*)\s[-|—]\s.+$', '\1')
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            a.countries
@@ -509,8 +513,13 @@ agg AS (
 ),
 matches AS (
     -- Two match paths: the exact key (ntitle) and the entity-decoded, suffix-stripped key
-    -- (ntitle2), which catches an ATS title that only appends " - <suffix>" or carries an
-    -- undecoded HTML entity. Each path is a SEPARATE single-equality hash join (O(agg + ats))
+    -- (ntitle2), which catches a title that only appends a trailing " - <suffix>" or
+    -- ": <suffix>" clause, or carries an undecoded HTML entity. The colon clause is stripped
+    -- INSIDE the dash strip so a title carrying both ("Engineer: Go, K8s - Remote") reduces all
+    -- the way. Only those two clauses are decoration: measured on prod, also stripping a
+    -- parenthetical produced 39 wrong pairs out of 55 — one company's "…, Backend (Traffic)"
+    -- matching its "(Payments)", "(Identity)" and "(Infrastructure)" roles — and a comma clause
+    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE single-equality hash join (O(agg + ats))
     -- and the two are UNION ALL-ed — an OR of the two equalities in one ON would defeat the
     -- hash join and go quadratic on a big company (the hotel-chain case). UNION ALL, not
     -- UNION: a row matched by both paths appears twice, but the downstream MIN(ats_id)

--- a/openspec/changes/aggregator-title-normalization/.openspec.yaml
+++ b/openspec/changes/aggregator-title-normalization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/aggregator-title-normalization/design.md
+++ b/openspec/changes/aggregator-title-normalization/design.md
@@ -1,0 +1,73 @@
+## Context
+
+`SuppressAggregatorDuplicatesForCompany` matches an aggregator posting to its ATS twin on two
+title keys, UNION ALL-ed as two separate single-equality hash joins. The query carries an explicit
+warning: an `OR` of both equalities in one `ON` defeats the hash join and goes quadratic on a large
+company. Any change must preserve that shape.
+
+The decorated key (`ntitle2`) already decodes HTML entities and strips a trailing ` - `/` — `/` | `
+clause. It does not strip a trailing `: …` clause.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Treat a trailing colon clause as decoration, so an aggregator that appends technologies to an
+  otherwise identical title finds its ATS twin.
+- Keep the two-hash-join shape; no new join, no new scan.
+
+**Non-Goals:**
+- Stripping parentheticals or comma clauses — measured, and both merge distinct roles.
+- Any similarity/fuzzy matching. A normalization rule cannot bridge titles that differ by more than
+  a trailing clause.
+
+## Decisions
+
+### D1 — Extend `ntitle2` in place rather than adding a third key
+
+The colon clause is the same *kind* of thing the expression already strips: a trailing decorative
+clause. Folding it into the existing `regexp_replace` chain keeps the query at two match paths.
+A third key would mean a third hash join and a third UNION ALL branch for a 3% gain.
+
+Order matters inside the chain: strip the colon clause **before** the dash clause, so
+`Engineer: Go, K8s - Remote` reduces to `Engineer` rather than stopping at `Engineer: Go, K8s`.
+
+### D2 — Reject the parenthetical and the comma, and record why in the spec
+
+Measured on prod: adding the parenthetical raises matches from 536 to 575, and the 39 extra pairs
+are wrong — one company's `Senior Software Engineer, Backend (Traffic)` matching its `(Payments)`,
+`(Identity)`, `(Infrastructure)`, `(ML Feature)` and `(Lake Analytics)` roles. The comma fails the
+same way (`, Backend` vs `, Fullstack`). Both are recorded as prohibitions in the spec so a later
+reader does not re-derive the idea and re-introduce the bug.
+
+### D3 — Do NOT reverse the subset arm
+
+The query already has a third match path: `a.ntitle <@ t.ntitle`, i.e. the aggregator *dropped*
+words the ATS keeps, guarded so the added words include a non-seniority one. Our case is the
+mirror image — the aggregator *adds* words — so the obvious idea is to add the reverse containment
+`t.ntitle <@ a.ntitle`.
+
+Rejected, for the same reason as the parenthetical. Reversed, `Senior Software Engineer, Backend
+(Traffic)` contains `Senior Software Engineer`, so an aggregator posting for one team would be
+suppressed by an unrelated ATS posting with a shorter title — and with several such teams the
+`MIN(ats_id)` would pick an arbitrary one. The existing direction is safe precisely because dropping
+words loses information while adding words asserts it; only the latter can be checked against the
+words themselves.
+
+### D4 — Verify by counting, not by reasoning
+
+The gain (+16) and the rejection (39 bad pairs) both came from running the candidate expressions
+against prod and reading the pairs. Any future decoration rule should be justified the same way:
+the corpus decides which punctuation is decorative, not intuition.
+
+## Risks / Trade-offs
+
+- **A colon clause that carries meaning** — e.g. `Engineer: Level II` — would merge with a plain
+  `Engineer`. Not observed in the sampled pairs, and the seniority-grade guard on the role pass does
+  not apply here. Accepted: the pass is reversible per reindex, and a wrong merge shows up as a
+  missing card rather than a wrong one (the ATS twin stays canonical and correct).
+- **Small gain.** +16 rows of 6371. Worth it only because the change is one expression and carries
+  the measured prohibitions into the spec, which is the durable part.
+
+## Open Questions
+
+None. The rule, its gain and its two rejected variants were all measured before implementation.

--- a/openspec/changes/aggregator-title-normalization/proposal.md
+++ b/openspec/changes/aggregator-title-normalization/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Cross-source aggregator suppression pairs an aggregator posting with its first-party ATS twin by
+company + normalized title + compatible country. The normalization already drops a trailing
+`— …` / `| …` clause. It does not drop a trailing `: …` clause, so an aggregator that decorates a
+title that way never finds its twin and both cards stay in the catalogue — a shape `whatjobs`
+produces constantly:
+
+```
+whatjobs «Senior Software Engineer: Full-Stack with TypeScript»  ↔  greenhouse «Senior Software Engineer»
+whatjobs «Senior Lead Software Engineer: Golang, Kubernetes…»    ↔  workday «Senior Lead Software Engineer»
+```
+
+Measured on prod across the 784 companies present in both `whatjobs` and a real ATS (2406 whatjobs
+rows):
+
+| normalization | rows finding an ATS twin |
+|---|---|
+| trailing `—`/`\|` clause (today) | 520 |
+| + trailing `: …` clause | **536** (+16) |
+| + parenthetical group | 575 (+55) — **rejected, see below** |
+
+## What Changes
+
+- The aggregator-suppression title key additionally ignores a **trailing `: …` clause**.
+
+That is the whole change. Two other decorations were measured and **deliberately rejected**, because
+each one merges genuinely different roles:
+
+- **Parenthetical.** Dropping it accounts for 39 of the 55 extra matches, and they are wrong:
+  `«Senior Software Engineer, Backend (Traffic)»` would merge with `(Payments)`, `(Identity)`,
+  `(Infrastructure)`, `(ML Feature)`, `(Lake Analytics)` — separate teams at one company, not
+  reposts of one job.
+- **Comma.** `«Senior Software Engineer, Backend»` would merge with `«…, Fullstack»`.
+
+Both carry meaning; only the colon clause is reliably decorative in this corpus.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `aggregator-ats-dedup`: the decorated-title match key additionally ignores a trailing colon clause,
+  and the spec records that parenthetical and comma clauses are meaning-bearing and must not be
+  stripped.
+
+## Impact
+
+- **Code:** the `ntitle2` expression in `SuppressAggregatorDuplicatesForCompany`
+  (`internal/db/queries/jobs.sql`) — extended in place, so the query keeps its two hash-join match
+  paths and does not go quadratic (the existing comment warns about exactly that).
+- **Data:** ~16 more rows gain `duplicate_of` per reindex on today's catalogue. Reversible: the pass
+  re-evaluates from scratch each run and a row with no twin resolves back to NULL.
+- **Honest scope:** this is a 3% improvement on the aggregator pass, not a fix for aggregator
+  duplicates in general. Titles that differ by more than a trailing clause — the `whatjobs`
+  "Senior Golang Engineer for Distributed Cloud & CI/CD" class — need a similarity signal, which is
+  what `fuzzy-description-role-dedup` addresses next.

--- a/openspec/changes/aggregator-title-normalization/specs/aggregator-ats-dedup/spec.md
+++ b/openspec/changes/aggregator-title-normalization/specs/aggregator-ats-dedup/spec.md
@@ -1,0 +1,68 @@
+## MODIFIED Requirements
+
+### Requirement: An aggregator posting is suppressed when a first-party ATS twin exists
+
+The system SHALL, when the reindex recomputes duplicate markers, mark an open posting
+from an aggregator source as `duplicate_of` an open posting from a non-aggregator (ATS)
+source when both share the
+same `company_slug`, the same normalized title, and a compatible country. Two postings
+have a compatible country when their `countries` arrays overlap, or when either array is
+empty. The ATS posting SHALL remain canonical (its `duplicate_of` stays NULL); the
+aggregator posting SHALL become the duplicate. A source is an aggregator when its
+provider is in `sources.AggregatorProviders()`.
+
+Titles match on either of two keys. The **plain key** is lowercase with runs of
+non-alphanumeric characters collapsed to a single space. The **decorated key** additionally
+decodes HTML entities and drops a trailing clause introduced by ` - `, ` — `, ` | ` or `:` —
+the ways an aggregator appends technologies or a team to an otherwise identical title. A
+posting matches when either key is equal and non-empty.
+
+The decorated key MUST NOT strip a parenthetical group or a clause after a comma. Both carry
+meaning rather than decoration: at one company `Senior Software Engineer, Backend (Traffic)`,
+`(Payments)`, `(Identity)` and `(Infrastructure)` are separate roles, as are
+`Senior Software Engineer, Backend` and `Senior Software Engineer, Fullstack`. Stripping
+either would merge distinct jobs.
+
+#### Scenario: Aggregator copy of an ATS job is suppressed
+
+- **WHEN** a company has an open ATS posting and an open aggregator posting with the same
+  normalized title and overlapping (or empty) countries
+- **THEN** the aggregator posting's `duplicate_of` points to the ATS posting, and the ATS
+  posting stays canonical
+
+#### Scenario: A trailing colon clause is decoration
+
+- **WHEN** an aggregator posting is titled `Senior Software Engineer: Full-Stack with TypeScript`
+  and the company has an ATS posting titled `Senior Software Engineer`
+- **THEN** the aggregator posting is suppressed as a duplicate of it
+
+#### Scenario: A parenthetical distinguishes roles and is kept
+
+- **WHEN** an aggregator posting titled `Senior Software Engineer, Backend (Traffic)` and an ATS
+  posting titled `Senior Software Engineer, Backend (Payments)` exist at one company
+- **THEN** neither is suppressed by this pass
+
+#### Scenario: A clause after a comma distinguishes roles and is kept
+
+- **WHEN** an aggregator posting titled `Senior Software Engineer, Backend` and an ATS posting
+  titled `Senior Software Engineer, Fullstack` exist at one company
+- **THEN** neither is suppressed by this pass
+
+#### Scenario: Same title in a different country is not suppressed
+
+- **WHEN** an aggregator posting and an ATS posting of the same company share a title but
+  their non-empty `countries` arrays do not overlap
+- **THEN** neither posting is suppressed by this pass
+
+#### Scenario: An ATS posting is never demoted by an aggregator twin
+
+- **WHEN** an aggregator posting and an ATS posting match on company, title, and country
+- **THEN** only the aggregator posting may be marked `duplicate_of`; the ATS posting is
+  never marked a duplicate of the aggregator posting
+
+#### Scenario: Two aggregator postings are not merged by this pass
+
+- **WHEN** two postings of the same company and title both come from aggregator sources
+  and no ATS twin exists
+- **THEN** this pass suppresses neither (cross-aggregator collapse stays the role-cluster
+  pass's responsibility)

--- a/openspec/changes/aggregator-title-normalization/tasks.md
+++ b/openspec/changes/aggregator-title-normalization/tasks.md
@@ -1,0 +1,16 @@
+## 1. Normalization
+
+- [x] 1.1 Extend the decorated-title key in `SuppressAggregatorDuplicatesForCompany` to strip a trailing `: …` clause, ordered before the dash/pipe strip so both reduce; keep the two-hash-join UNION ALL shape
+- [x] 1.2 Regenerate `internal/db` with `make sqlc`
+
+## 2. Tests
+
+- [x] 2.1 Integration test: an aggregator posting titled `Senior Software Engineer: Full-Stack with TypeScript` is suppressed by an ATS `Senior Software Engineer` at the same company
+- [x] 2.2 Integration test: `Senior Software Engineer, Backend (Traffic)` is NOT suppressed by `Senior Software Engineer, Backend (Payments)` — the parenthetical is meaning-bearing
+- [x] 2.3 Integration test: `Senior Software Engineer, Backend` is NOT suppressed by `Senior Software Engineer, Fullstack` — the comma clause is meaning-bearing
+
+## 3. Verification
+
+- [x] 3.1 `go build ./... && go vet ./... && gofmt -l . && go test ./...` clean
+- [x] 3.2 `go test -tags=integration ./internal/db/` clean
+- [ ] 3.3 Re-run the prod count after deploy and confirm the suppressed total rose by roughly the measured +16


### PR DESCRIPTION
## What and why

Cross-source aggregator suppression pairs an aggregator posting with its ATS twin on a normalized title. The decorated key already drops a trailing ` - ` / ` — ` / ` | ` clause, but not a trailing `: …` clause — a shape `whatjobs` produces constantly, so both cards stayed in the catalogue:

```
whatjobs «Senior Software Engineer: Full-Stack with TypeScript»  ↔  greenhouse «Senior Software Engineer»
whatjobs «Senior Lead Software Engineer: Golang, Kubernetes…»    ↔  workday «Senior Lead Software Engineer»
```

The colon is now stripped **inside** the dash strip, so a title carrying both (`Engineer: Go, K8s - Remote`) reduces all the way. The query keeps its two hash-join match paths — the existing comment warns that an `OR` of both equalities in one `ON` goes quadratic on a large company.

## What was measured and rejected

Two neighbouring ideas look obvious and are wrong. Both were run against prod before being ruled out, and both are now spec'd as prohibitions with tests, so they do not get re-derived:

| normalization | rows finding an ATS twin |
|---|---|
| trailing `—`/`\|` clause (before) | 520 |
| + trailing `: …` clause (this PR) | **536** (+16) |
| + parenthetical | 575 (+55) — **rejected** |

- **Parenthetical.** 39 of those 55 extra pairs are wrong: one company's `Senior Software Engineer, Backend (Traffic)` would merge with its `(Payments)`, `(Identity)`, `(Infrastructure)`, `(ML Feature)` and `(Lake Analytics)` roles — separate teams, not reposts.
- **Comma clause.** Same failure: `…, Backend` against `…, Fullstack`.
- **Reversing the word-subset arm.** The pass already matches `aggregator words ⊂ ATS words` (the aggregator *dropped* words). Mirroring it for *added* words fails identically — `…, Backend (Traffic)` contains `Senior Software Engineer`, so an unrelated shorter ATS title would suppress it, with `MIN(ats_id)` picking arbitrarily. The existing direction is safe precisely because dropping words loses information while adding words asserts it.

## Honest scope

+16 rows of 6371 — a 3% improvement to this pass, not a general fix for aggregator duplicates. Titles differing by more than a trailing clause (the `whatjobs` "Senior Golang Engineer for Distributed Cloud & CI/CD" class) need a similarity signal; that is `fuzzy-description-role-dedup`, next.

The durable part of this change is the two recorded prohibitions, not the 16 rows.

## Tests

Four new integration tests: the colon clause is stripped, a colon+dash title reduces fully, and the parenthetical and comma cases are asserted NOT to merge. Full `go test -tags=integration ./internal/db/` green (26s), unit suite and `go vet`/`gofmt` clean.

OpenSpec: `openspec/changes/aggregator-title-normalization/`

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes, and `go test -tags=integration ./internal/db/` passes (DB query touched).
- [x] I regenerated committed artifacts when their source changed — `make sqlc` after the query edit.
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary — one SQL expression plus tests.