### PR TITLE
feat(seo): structured data for the eleven public pages that had none

### DIFF
--- a/web/src/lib/cliLinks.ts
+++ b/web/src/lib/cliLinks.ts
@@ -1,0 +1,7 @@
+// Repository URLs for the CLI page — shared by the visible links (CliView.svelte)
+// and the SoftwareApplication JSON-LD (routes/cli), so `codeRepository` can never
+// name a repo the page does not link to. The install one-liner and skill link live
+// in the view; only these two are needed in both places.
+
+export const CLI_REPO = 'https://github.com/strelov1/freehire-cli';
+export const MCP_REPO = 'https://github.com/strelov1/freehire-mcp';

--- a/web/src/lib/components/CliView.svelte
+++ b/web/src/lib/components/CliView.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { CLI_REPO, MCP_REPO } from '$lib/cliLinks';
   import { Button } from '$lib/ui';
   import SectionLabel from '$lib/components/SectionLabel.svelte';
 
-  const CLI_REPO = 'https://github.com/strelov1/freehire-cli';
-  const MCP_REPO = 'https://github.com/strelov1/freehire-mcp';
   const SKILL_URL =
     'https://github.com/strelov1/freehire-cli/blob/main/skills/using-freehire/SKILL.md';
   const INSTALL = 'curl -fsSL https://freehire.me/install.sh | sh';
@@ -322,6 +321,7 @@ freehire jobs edit &lt;slug&gt; --title "Staff Go Developer"</pre>
   <section class="border-t border-border py-10">
     <p class="text-sm leading-relaxed text-muted-foreground">
       Free and open source — no tracking, no lock-in. Read every line of the
+      <!-- eslint-disable svelte/no-navigation-without-resolve -- absolute GitHub URLs from $lib/cliLinks (shared with the JSON-LD's codeRepository), not SvelteKit routes -->
       <a
         href={CLI_REPO}
         target="_blank"
@@ -334,7 +334,7 @@ freehire jobs edit &lt;slug&gt; --title "Staff Go Developer"</pre>
         target="_blank"
         rel="noopener noreferrer"
         class="font-medium text-foreground underline-offset-4 hover:underline">MCP server ↗</a
-      > on GitHub.
+      ><!-- eslint-enable svelte/no-navigation-without-resolve --> on GitHub.
     </p>
   </section>
 </div>

--- a/web/src/lib/components/ForCompaniesView.svelte
+++ b/web/src/lib/components/ForCompaniesView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { FOR_COMPANIES_FAQ } from '$lib/forCompaniesFaq';
   import { Button } from '$lib/ui';
 
   const repoUrl = 'https://github.com/strelov1/freehire';
@@ -188,6 +189,19 @@ curl -X POST https://freehire.me/api/v1/submissions \
         <p class="text-sm leading-relaxed text-muted-foreground">{b.body}</p>
       </div>
     {/each}
+  </section>
+
+  <!-- FAQ. Visible answers and the FAQPage JSON-LD share FOR_COMPANIES_FAQ. -->
+  <section class="flex flex-col gap-6">
+    <h2 class="text-2xl font-semibold tracking-tight">Questions</h2>
+    <dl class="grid gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
+      {#each FOR_COMPANIES_FAQ as item (item.question)}
+        <div class="flex flex-col gap-2 bg-background p-5">
+          <dt class="text-base font-semibold tracking-tight">{item.question}</dt>
+          <dd class="text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
   </section>
 
   <!-- Closing CTA -->

--- a/web/src/lib/components/RecruitersView.svelte
+++ b/web/src/lib/components/RecruitersView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { RECRUITERS_FAQ } from '$lib/recruitersFaq';
   import { Button } from '$lib/ui';
 
   // Why a recruiter should submit. Kept honest — these are properties of the
@@ -66,6 +67,19 @@
         </li>
       {/each}
     </ol>
+  </section>
+
+  <!-- FAQ. Visible answers and the FAQPage JSON-LD share RECRUITERS_FAQ. -->
+  <section class="flex flex-col gap-6">
+    <h2 class="text-2xl font-semibold tracking-tight">Questions</h2>
+    <dl class="grid gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
+      {#each RECRUITERS_FAQ as item (item.question)}
+        <div class="flex flex-col gap-2 bg-background p-5">
+          <dt class="text-base font-semibold tracking-tight">{item.question}</dt>
+          <dd class="text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
   </section>
 
   <!-- Closing CTA -->

--- a/web/src/lib/components/ReferralsLandingView.svelte
+++ b/web/src/lib/components/ReferralsLandingView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { REFERRALS_FAQ } from '$lib/referralsFaq';
   import { Button } from '$lib/ui';
 
   // CTA destinations wired to the real feature (no invite-code program exists):
@@ -74,24 +75,6 @@
     'Reach out to the ones worth it',
   ];
 
-  const faqs = [
-    {
-      q: 'What does it cost?',
-      a: 'Nothing. freehire is a free, open-source aggregator — referrals included. No fees, no paywall.',
-    },
-    {
-      q: 'Will the referrer see my name?',
-      a: 'No. Referrers only see the CV, note and contact you attach. Your identity is never surfaced — they reach out only if they decide to take your request forward.',
-    },
-    {
-      q: 'How do I know a referrer actually works there?',
-      a: 'Anyone offering to refer uploads proof of employment, and a moderator reviews it before the company appears as referral-available.',
-    },
-    {
-      q: 'I work somewhere great — can I help people in?',
-      a: 'Yes. Offer to refer from your account, upload proof once, and approved requests for your company start reaching you. You stay anonymous throughout.',
-    },
-  ];
 </script>
 
 <div class="landing">
@@ -261,14 +244,14 @@
     </div>
   </section>
 
-  <!-- ── FAQ ──────────────────────────────────────────────────────────────── -->
+  <!-- FAQ. Visible answers and the FAQPage JSON-LD share REFERRALS_FAQ. -->
   <section class="border-t border-border py-16 sm:py-20">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// faq</p>
     <dl class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
-      {#each faqs as f (f.q)}
+      {#each REFERRALS_FAQ as item (item.question)}
         <div class="bg-background p-6 sm:p-7">
-          <dt class="text-lg font-semibold tracking-tight">{f.q}</dt>
-          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{f.a}</dd>
+          <dt class="text-lg font-semibold tracking-tight">{item.question}</dt>
+          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
         </div>
       {/each}
     </dl>

--- a/web/src/lib/forCompaniesFaq.ts
+++ b/web/src/lib/forCompaniesFaq.ts
@@ -1,0 +1,40 @@
+// /for-companies FAQ — the single source for both the visible section
+// (ForCompaniesView.svelte) and the FAQPage JSON-LD. Google requires the schema's
+// answers to match the on-page text, so they share this. Answers restate the ingest
+// mechanics the page already describes (scheduled crawl, normalize + dedup,
+// stale-sweep close) rather than adding new promises.
+
+import type { FaqItem } from './seo';
+
+export const FOR_COMPANIES_FAQ: FaqItem[] = [
+  {
+    question: 'What does it cost to list our board?',
+    answer:
+      'Nothing. freehire is a free, open-source, non-commercial aggregator — no listing fee, no paywall, no upsell, and no paid placement that would push your roles above or below anyone else.',
+  },
+  {
+    question: 'Which ATS platforms can we self-add?',
+    answer:
+      'The multi-tenant boards where a company maps to a single board entry: Greenhouse, Lever, Ashby, Workable, Recruitee, SmartRecruiters, Personio, BambooHR, Workday, Teamtailor and Rippling. On those, listing your company is one line in the source file.',
+  },
+  {
+    question: 'Our ATS is not on that list — can we still be indexed?',
+    answer:
+      'Yes. freehire is open source, so an adapter for another ATS can be contributed, and the crawler already covers far more providers than the self-serve subset. Open an issue or a pull request on the repository and the board can be onboarded.',
+  },
+  {
+    question: 'How quickly do new roles appear?',
+    answer:
+      'Your board is polled on a schedule — roughly once a day — and a newly published role reaches the catalogue and search within a few hours of that crawl.',
+  },
+  {
+    question: 'What happens when we take a role down?',
+    answer:
+      'It closes on its own. Once a vacancy stops appearing on your board, freehire marks it closed and it drops out of search — no action needed on your side. Your ATS stays the source of truth.',
+  },
+  {
+    question: 'Do we have to maintain a second copy of our jobs?',
+    answer:
+      'No. There is nothing to re-enter and nothing to keep in sync: freehire reads your existing ATS board, so what you publish there is exactly what gets listed, and what you remove gets closed.',
+  },
+];

--- a/web/src/lib/openFaq.ts
+++ b/web/src/lib/openFaq.ts
@@ -1,0 +1,34 @@
+// /open FAQ — the single source for both the visible section (routes/open) and the
+// FAQPage JSON-LD. Google requires the schema's answers to match the on-page text,
+// so they share this. Answers are written answer-first and describe the actual load
+// path in routes/open/+page.server.ts, not a promise about it.
+
+import type { FaqItem } from './seo';
+
+export const OPEN_FAQ: FaqItem[] = [
+  {
+    question: 'Where do these numbers come from?',
+    answer:
+      "Every figure is read at request time from freehire's own public API — the same endpoints anyone can call — plus the GitHub REST API for the repository stats. Each number on this page links to the endpoint it came from, so you can check it yourself rather than take it on trust.",
+  },
+  {
+    question: 'How fresh are they?',
+    answer:
+      'The catalogue scale, daily movement and member growth are read live and held for about a minute on the server, then five minutes in your browser. The repository stats refresh hourly, because unauthenticated GitHub calls are capped at 60 per hour. The distribution breakdowns — countries, skills, seniority, work mode — come from a daily rollup, so they lag the live counts by up to a day.',
+  },
+  {
+    question: 'Can I query the same data myself?',
+    answer:
+      'Yes, and without an account. Job search, company data and facets are public reads on the freehire HTTP API; only personal features such as saving and tracking need a key. The API reference documents every endpoint, and an OpenAPI schema is published for clients and AI agents.',
+  },
+  {
+    question: 'What counts as an open job?',
+    answer:
+      'A posting freehire has crawled and has not yet detected as closed. Roles are never silently deleted: when a vacancy stops appearing on the source board it is marked closed and drops out of the open count, which is what the "removed" bars on this page track.',
+  },
+  {
+    question: 'Why publish all of this?',
+    answer:
+      'freehire is free and open source, so the numbers behind its claims should be checkable rather than asserted. Any figure quoted elsewhere on the site — or by an AI assistant citing freehire — should reconcile with this page, which is the live source rather than a rounded snapshot.',
+  },
+];

--- a/web/src/lib/recruitersFaq.ts
+++ b/web/src/lib/recruitersFaq.ts
@@ -1,0 +1,35 @@
+// /recruiters FAQ — the single source for both the visible section
+// (RecruitersView.svelte) and the FAQPage JSON-LD. Google requires the schema's
+// answers to match the on-page text, so they share this. Answers restate the
+// submission flow the page already shows (sign in → submit URL → moderator review →
+// live) and deliberately promise no review turnaround, which is not guaranteed.
+
+import type { FaqItem } from './seo';
+
+export const RECRUITERS_FAQ: FaqItem[] = [
+  {
+    question: 'What does it cost to post a job?',
+    answer:
+      'Nothing. freehire is an open-source, non-commercial aggregator — no fees, no paywall, no upsell, and no paid placement. A submitted role sits in the same catalogue, ranked the same way, as one crawled from a company board.',
+  },
+  {
+    question: 'Do I need an account to submit?',
+    answer:
+      'Yes. Submitting is tied to an account so the posting has an owner and you can follow it afterwards — signing in takes a moment, and it is the only thing standing between you and the form.',
+  },
+  {
+    question: 'How does a submission go live?',
+    answer:
+      'A moderator reads every submission before it is published, so the catalogue stays free of spam and your posting sits among real roles. Once approved, the role joins the public catalogue and search, enriched and deduplicated like every other source.',
+  },
+  {
+    question: 'Can I check the status of a submission?',
+    answer:
+      'Yes. Every posting you send in appears under "My submissions" in your account with its current state, so you can see whether it is still awaiting review or already live.',
+  },
+  {
+    question: 'Our company already has an ATS board — should I still submit one by one?',
+    answer:
+      'No, list the whole board instead. If you hire through Greenhouse, Lever, Ashby, Workable or another supported ATS, freehire can crawl every role you publish and close them when you take them down, which is less work than submitting each vacancy by hand.',
+  },
+];

--- a/web/src/lib/referralsFaq.ts
+++ b/web/src/lib/referralsFaq.ts
@@ -1,0 +1,29 @@
+// Referrals landing FAQ — the single source for both the visible section
+// (ReferralsLandingView.svelte) and the FAQPage JSON-LD (routes/features/referrals).
+// Google requires the schema's answers to match the on-page text, so they share
+// this. Answers stay honest to what the product does (internal/referral).
+
+import type { FaqItem } from './seo';
+
+export const REFERRALS_FAQ: FaqItem[] = [
+  {
+    question: 'What does it cost?',
+    answer:
+      'Nothing. freehire is a free, open-source aggregator — referrals included. No fees, no paywall.',
+  },
+  {
+    question: 'Will the referrer see my name?',
+    answer:
+      'No. Referrers only see the CV, note and contact you attach. Your identity is never surfaced — they reach out only if they decide to take your request forward.',
+  },
+  {
+    question: 'How do I know a referrer actually works there?',
+    answer:
+      'Anyone offering to refer uploads proof of employment, and a moderator reviews it before the company appears as referral-available.',
+  },
+  {
+    question: 'I work somewhere great — can I help people in?',
+    answer:
+      'Yes. Offer to refer from your account, upload proof once, and approved requests for your company start reaching you. You stay anonymous throughout.',
+  },
+];

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { articleJsonLd, collectionPageJsonLd, jobPostingJsonLd, organizationJsonLd } from './seo';
+import {
+  articleJsonLd,
+  collectionPageJsonLd,
+  companyListItems,
+  datasetJsonLd,
+  jobListItems,
+  jobPostingJsonLd,
+  organizationJsonLd,
+} from './seo';
 import { companyLogoUrl } from './logo';
 import type { PostMeta } from './blog';
 import type { Company, Job } from './types';
@@ -197,8 +205,10 @@ describe('collectionPageJsonLd', () => {
       'React jobs',
       'Every open React role.',
       URL,
-      [job('Senior React Engineer', 'senior-react-engineer-abc'), job('React Native Dev', 'react-native-dev-xyz')],
-      ORIGIN
+      jobListItems(
+        [job('Senior React Engineer', 'senior-react-engineer-abc'), job('React Native Dev', 'react-native-dev-xyz')],
+        ORIGIN
+      )
     );
 
     expect(ld['@type']).toBe('CollectionPage');
@@ -225,9 +235,64 @@ describe('collectionPageJsonLd', () => {
   });
 
   it('emits an empty ItemList for a collection with no jobs', () => {
-    const ld = collectionPageJsonLd('Empty', 'Nothing yet.', URL, [], ORIGIN);
+    const ld = collectionPageJsonLd('Empty', 'Nothing yet.', URL, []);
 
     expect(ld.mainEntity).toEqual({ '@type': 'ItemList', itemListElement: [] });
+  });
+
+  // The directory reuses the same CollectionPage with company items, so a company's
+  // ListItem must point at /companies/<slug>, never the job path.
+  it('wraps companies in the same CollectionPage shape', () => {
+    const ld = collectionPageJsonLd(
+      'Companies hiring in tech',
+      'Browse companies hiring in tech.',
+      'https://freehire.me/companies',
+      companyListItems(
+        [
+          { name: 'Acme', slug: 'acme' },
+          { name: 'Globex', slug: 'globex' },
+        ],
+        ORIGIN
+      )
+    );
+
+    expect(ld['@type']).toBe('CollectionPage');
+    expect(ld.mainEntity).toEqual({
+      '@type': 'ItemList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Acme', url: 'https://freehire.me/companies/acme' },
+        { '@type': 'ListItem', position: 2, name: 'Globex', url: 'https://freehire.me/companies/globex' },
+      ],
+    });
+  });
+});
+
+describe('datasetJsonLd', () => {
+  const URL = 'https://freehire.me/insights/salary/engineering';
+
+  // The insights pages are aggregate-only: an empty `distribution` array would be a
+  // dead end for a crawler, so the key must be absent rather than empty.
+  it('omits distribution when the page advertises no endpoint', () => {
+    const ld = datasetJsonLd('Engineering salaries', 'Bands by seniority.', URL, ORIGIN);
+
+    expect(ld['@type']).toBe('Dataset');
+    expect(ld.isAccessibleForFree).toBe(true);
+    expect(ld).not.toHaveProperty('distribution');
+  });
+
+  it('advertises each endpoint as a JSON DataDownload', () => {
+    const ld = datasetJsonLd('Live figures', 'Catalogue scale.', `${ORIGIN}/open`, ORIGIN, [
+      { name: 'Jobs API', contentUrl: `${ORIGIN}/api/v1/jobs` },
+    ]);
+
+    expect(ld.distribution).toEqual([
+      {
+        '@type': 'DataDownload',
+        name: 'Jobs API',
+        encodingFormat: 'application/json',
+        contentUrl: 'https://freehire.me/api/v1/jobs',
+      },
+    ]);
   });
 });
 

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -258,17 +258,18 @@ export function breadcrumbJsonLd(items: { name: string; url: string }[]): Record
   };
 }
 
-/** schema.org CollectionPage wrapping an `ItemList` of the jobs rendered on a
- *  collection landing page. Each item is a summary `ListItem` (position + name +
- *  detail URL), not an embedded `JobPosting` — Google's recommended shape for a
- *  list page, and it keeps the payload small. An empty `jobs` yields an empty
- *  `itemListElement`, still valid JSON-LD. */
+/** schema.org CollectionPage wrapping an `ItemList` of whatever a list page
+ *  renders — jobs on a collection landing, companies on the directory. Each item is
+ *  a summary `ListItem` (position + name + detail URL), not an embedded entity —
+ *  Google's recommended shape for a list page, and it keeps the payload small.
+ *  Items arrive pre-resolved as `{name, url}` (the same shape `breadcrumbJsonLd`
+ *  takes) so this stays entity-agnostic; `jobListItems` builds them from jobs. An
+ *  empty `items` yields an empty `itemListElement`, still valid JSON-LD. */
 export function collectionPageJsonLd(
   title: string,
   description: string,
   url: string,
-  jobs: Job[],
-  origin: string
+  items: { name: string; url: string }[]
 ): Record<string, unknown> {
   return {
     '@context': 'https://schema.org',
@@ -278,27 +279,48 @@ export function collectionPageJsonLd(
     url,
     mainEntity: {
       '@type': 'ItemList',
-      itemListElement: jobs.map((job, i) => ({
+      itemListElement: items.map((item, i) => ({
         '@type': 'ListItem',
         position: i + 1,
-        name: job.title,
-        url: `${origin}/jobs/${job.public_slug}`,
+        name: item.name,
+        url: item.url,
       })),
     },
   };
 }
 
-/** schema.org Dataset descriptor for an insights page — tells search/AI engines
- *  the page presents an aggregate dataset (salary bands, demand rankings) free to
- *  access, published by freehire. Aggregate-only, so no distribution file is
- *  advertised. */
+/** `{name, url}` list items for jobs, for `collectionPageJsonLd`. */
+export function jobListItems(jobs: Job[], origin: string): { name: string; url: string }[] {
+  return jobs.map((job) => ({ name: job.title, url: `${origin}/jobs/${job.public_slug}` }));
+}
+
+/** `{name, url}` list items for companies, for `collectionPageJsonLd`. Takes the
+ *  name/slug pair structurally, so both `Company` and the lighter `CompanyListItem`
+ *  the directory lists fit without a cast. */
+export function companyListItems(
+  companies: { name: string; slug: string }[],
+  origin: string
+): { name: string; url: string }[] {
+  return companies.map((c) => ({ name: c.name, url: `${origin}/companies/${c.slug}` }));
+}
+
+/** schema.org Dataset descriptor for a page that presents aggregate figures
+ *  (insights salary bands and demand rankings; the live /open snapshot) — tells
+ *  search/AI engines the data is free to access and published by freehire.
+ *
+ *  `distributions` advertises the machine-readable endpoints the page's figures are
+ *  read from, and is omitted when there are none: the insights pages are
+ *  aggregate-only with no downloadable form, while /open cites the public JSON API
+ *  beside every number. An engine that can fetch the distribution can verify a
+ *  figure instead of merely quoting it. */
 export function datasetJsonLd(
   name: string,
   description: string,
   url: string,
-  origin: string
+  origin: string,
+  distributions: { name: string; contentUrl: string }[] = []
 ): Record<string, unknown> {
-  return {
+  const ld: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'Dataset',
     name,
@@ -307,6 +329,15 @@ export function datasetJsonLd(
     isAccessibleForFree: true,
     creator: { '@type': 'Organization', name: SITE, url: `${origin}/` },
   };
+  if (distributions.length > 0) {
+    ld.distribution = distributions.map((d) => ({
+      '@type': 'DataDownload',
+      name: d.name,
+      encodingFormat: 'application/json',
+      contentUrl: d.contentUrl,
+    }));
+  }
+  return ld;
 }
 
 /** schema.org FAQPage. The questions must also appear as visible text on the page
@@ -319,6 +350,73 @@ export function faqPageJsonLd(faqs: FaqItem[]): Record<string, unknown> {
       '@type': 'Question',
       name: f.question,
       acceptedAnswer: { '@type': 'Answer', text: f.answer },
+    })),
+  };
+}
+
+/** schema.org WebAPI for the API reference — names the endpoint set as one entity
+ *  and points at the OpenAPI document, so an assistant can fetch the machine-readable
+ *  spec instead of scraping the prose it is rendered beside. */
+export function webApiJsonLd(origin: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebAPI',
+    name: 'freehire API',
+    description:
+      'A read-first, open HTTP API over the freehire job catalogue: query jobs by seniority, skills, region and salary, read companies, and track applications with an API key.',
+    url: `${origin}/docs/api`,
+    documentation: `${origin}/docs/api`,
+    termsOfService: `${origin}/privacy`,
+    provider: { '@type': 'Organization', name: SITE, url: `${origin}/` },
+    // The OpenAPI document is the spec itself, not more prose about it.
+    potentialAction: {
+      '@type': 'ConsumeAction',
+      target: { '@type': 'EntryPoint', urlTemplate: `${origin}/openapi.yaml`, encodingType: 'application/yaml' },
+    },
+  };
+}
+
+/** schema.org SoftwareApplication for the CLI page. Free and open source, so the
+ *  zero-price `offers` is a fact rather than a marketing claim; `softwareHelp`
+ *  points back at the page that documents it. */
+export function cliApplicationJsonLd(
+  origin: string,
+  repositories: string[]
+): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'freehire CLI',
+    description:
+      'A small Go CLI and an MCP server over the freehire job API, so an AI agent or a script can search, open and track jobs without a browser. One API key drives both.',
+    url: `${origin}/cli`,
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'macOS, Linux',
+    isAccessibleForFree: true,
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    softwareHelp: { '@type': 'CreativeWork', url: `${origin}/cli` },
+    publisher: { '@type': 'Organization', name: SITE, url: `${origin}/` },
+    codeRepository: repositories,
+  };
+}
+
+/** schema.org Blog for the feed index, listing each post as a `BlogPosting`. A
+ *  `Blog` (rather than a bare CollectionPage) is what ties the index to the
+ *  `Article` on each post page, so engines read the feed as one publication.
+ *  Summary entries only — the post bodies live on their own pages. */
+export function blogJsonLd(posts: PostMeta[], origin: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    name: `${SITE} blog`,
+    url: `${origin}/blog`,
+    publisher: { '@type': 'Organization', name: SITE, url: `${origin}/` },
+    blogPost: posts.map((post) => ({
+      '@type': 'BlogPosting',
+      headline: post.title,
+      description: post.summary,
+      datePublished: post.date,
+      url: `${origin}/blog/${post.slug}`,
     })),
   };
 }

--- a/web/src/posts/2026-07-30-one-line-for-the-inactivity-warning.svx
+++ b/web/src/posts/2026-07-30-one-line-for-the-inactivity-warning.svx
@@ -1,0 +1,36 @@
+---
+title: One line for the inactivity warning
+date: 2026-07-30
+summary: The signs that a posting may not be getting filled now read as a small gauge under the title, with the criteria one click away instead of always open.
+type: changelog
+tags:
+  - ghost-jobs
+  - job-seekers
+---
+
+Some postings are not being worked on. freehire watches a few things it can actually
+check — how long a posting has behaved as evergreen, whether the employer's own careers
+board carries it, what happened to people who applied — and marks the ones where enough
+of that lines up.
+
+The mark used to state itself twice: a chip under the title, then a bordered panel
+listing all four criteria below it. Two of those four usually read "No data", so the
+loudest block on the page after the title was mostly saying nothing.
+
+Now it is one line: a small gauge, the wording, and how many criteria fired out of how
+many exist.
+
+Only the criteria that fired are coloured, and the tone climbs as more of them do — one
+is yellow, all four are red. The grey segments are deliberately grey rather than green:
+they mean we did not observe that criterion, never that we checked it and found the
+posting clean. That is also why the summary line now says **Not observed** instead of
+"No data" — for some criteria we do look every time, so claiming an absence of data
+would be untrue.
+
+Press **Details** and you get what the panel used to show, minus the repetition: the
+criteria that fired with the facts behind them, one line naming the rest, and a link to
+[how the whole thing works](/features/ghost-jobs) — including where it is blind, and why
+a staffing agency can trip a criterion honestly.
+
+The wording stays hedged everywhere. "Possibly inactive" is a claim about a posting; "not
+really hiring" would be a claim about somebody's intent, which nothing here can see.

--- a/web/src/routes/blog/+page.svelte
+++ b/web/src/routes/blog/+page.svelte
@@ -2,12 +2,28 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import Seo from '$lib/components/Seo.svelte';
+  import { blogJsonLd, breadcrumbJsonLd, jsonLdScript } from '$lib/seo';
   import type { PostType } from '$lib/blog';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
-  const canonical = $derived(`${page.url.origin}/blog`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/blog`);
+  const description =
+    'Product updates, changelog, and longer write-ups from the freehire team — new job sources, search improvements, and how the aggregator works.';
+  // Built from the full `data.posts`, not the filtered view: the type filter is a
+  // client-side affordance, so narrowing the schema to it would describe a
+  // transient UI state rather than the feed a crawler fetched.
+  const jsonLd = $derived(
+    jsonLdScript([
+      blogJsonLd(data.posts, origin),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Blog', url: canonical },
+      ]),
+    ]),
+  );
 
   // Client-side type filter over the already-loaded list — one feed, two tiers
   // (see design D6). No route/query round-trip; the default view shows everything.
@@ -28,11 +44,12 @@
   const formatDate = (iso: string) => dateFmt.format(new Date(iso));
 </script>
 
-<Seo
-  title="Blog · freehire"
-  description="Product updates, changelog, and longer write-ups from the freehire team — new job sources, search improvements, and how the aggregator works."
-  {canonical}
-/>
+<Seo title="Blog · freehire" {description} {canonical} />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-3xl px-4 py-6">
   <header class="mb-6">

--- a/web/src/routes/cli/+page.svelte
+++ b/web/src/routes/cli/+page.svelte
@@ -1,9 +1,21 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { CLI_REPO, MCP_REPO } from '$lib/cliLinks';
   import CliView from '$lib/components/CliView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { breadcrumbJsonLd, cliApplicationJsonLd, jsonLdScript } from '$lib/seo';
 
-  const canonical = $derived(`${page.url.origin}/cli`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/cli`);
+  const jsonLd = $derived(
+    jsonLdScript([
+      cliApplicationJsonLd(origin, [CLI_REPO, MCP_REPO]),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'CLI', url: canonical },
+      ]),
+    ])
+  );
 </script>
 
 <Seo
@@ -11,6 +23,11 @@
   description="A small Go CLI and an MCP server over the freehire job API, built so an AI agent or a script can search, open and track jobs — no browser. One API key drives both CLI and MCP."
   {canonical}
 />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <CliView />

--- a/web/src/routes/collections/[slug]/+page.svelte
+++ b/web/src/routes/collections/[slug]/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/state';
   import JobsView from '$lib/components/JobsView.svelte';
   import Seo from '$lib/components/Seo.svelte';
-  import { breadcrumbJsonLd, collectionPageJsonLd, jsonLdScript } from '$lib/seo';
+  import { breadcrumbJsonLd, collectionPageJsonLd, jobListItems, jsonLdScript } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -30,8 +30,7 @@
         heading,
         data.collection.description,
         canonical,
-        data.initial.items,
-        origin
+        jobListItems(data.initial.items, origin)
       ),
       breadcrumbJsonLd([
         { name: 'freehire', url: `${origin}/` },

--- a/web/src/routes/companies/+page.svelte
+++ b/web/src/routes/companies/+page.svelte
@@ -2,18 +2,46 @@
   import { page } from '$app/state';
   import CompaniesView from '$lib/components/CompaniesView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import {
+    breadcrumbJsonLd,
+    collectionPageJsonLd,
+    companyListItems,
+    jsonLdScript,
+  } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
-  const canonical = $derived(`${page.url.origin}/companies`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/companies`);
+  const description =
+    'Browse companies hiring in tech, with their current open roles — aggregated by freehire.';
+  // Structured data for the directory: a CollectionPage wrapping the server-rendered
+  // first page of companies as an ItemList, plus a breadcrumb (freehire → Companies),
+  // mirroring the collection landings. The list follows the active filters, so a
+  // deep-linked filtered URL describes what it actually shows.
+  const jsonLd = $derived(
+    jsonLdScript([
+      collectionPageJsonLd(
+        'Companies hiring in tech',
+        description,
+        canonical,
+        companyListItems(data.initial.items, origin)
+      ),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Companies', url: canonical },
+      ]),
+    ])
+  );
 </script>
 
-<Seo
-  title="Companies · freehire"
-  description="Browse companies hiring in tech, with their current open roles — aggregated by freehire."
-  {canonical}
-/>
+<Seo title="Companies · freehire" {description} {canonical} />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <!-- Primary heading kept for search engines and assistive tech, but visually

--- a/web/src/routes/docs/api/+page.svelte
+++ b/web/src/routes/docs/api/+page.svelte
@@ -7,10 +7,21 @@
   import { FILTER_FACETS, FILTER_EXTRAS, FILTER_MODIFIERS, RECIPES } from '$lib/docs/filters';
   import { NAV, slugify } from '$lib/docs/nav';
   import { METHOD_TEXT, inlineCode } from '$lib/docs/format';
+  import { breadcrumbJsonLd, jsonLdScript, webApiJsonLd } from '$lib/seo';
 
   let { data } = $props();
 
-  const canonical = $derived(`${page.url.origin}/docs/api`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/docs/api`);
+  const jsonLd = $derived(
+    jsonLdScript([
+      webApiJsonLd(origin),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'API reference', url: canonical },
+      ]),
+    ])
+  );
 </script>
 
 <Seo
@@ -18,6 +29,11 @@
   description="The freehire HTTP API: a read-first, open endpoint set over the job catalogue. Search and filter jobs by seniority, skills, region, salary and more, read companies, and track applications with an API key."
   {canonical}
 />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <!-- Header. -->
 <header class="mb-14 border-b border-border pb-10">

--- a/web/src/routes/features/referrals/+page.svelte
+++ b/web/src/routes/features/referrals/+page.svelte
@@ -2,8 +2,13 @@
   import { page } from '$app/state';
   import ReferralsLandingView from '$lib/components/ReferralsLandingView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { REFERRALS_FAQ } from '$lib/referralsFaq';
+  import { faqPageJsonLd, jsonLdScript } from '$lib/seo';
 
   const canonical = $derived(`${page.url.origin}/features/referrals`);
+  // The FAQ block and this payload render from the same REFERRALS_FAQ array, so the
+  // structured data can never disagree with what the page shows.
+  const jsonLd = $derived(jsonLdScript([faqPageJsonLd(REFERRALS_FAQ)]));
 </script>
 
 <Seo
@@ -11,6 +16,11 @@
   description="Ask an employee inside the company to put your name forward — anonymously, for free. freehire's referral marketplace connects job seekers with verified insiders who can refer them, and lets employees offer to refer good people in."
   {canonical}
 />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <ReferralsLandingView />

--- a/web/src/routes/for-companies/+page.svelte
+++ b/web/src/routes/for-companies/+page.svelte
@@ -2,8 +2,22 @@
   import { page } from '$app/state';
   import ForCompaniesView from '$lib/components/ForCompaniesView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { FOR_COMPANIES_FAQ } from '$lib/forCompaniesFaq';
+  import { breadcrumbJsonLd, faqPageJsonLd, jsonLdScript } from '$lib/seo';
 
-  const canonical = $derived(`${page.url.origin}/for-companies`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/for-companies`);
+  // The FAQ block and this payload render from the same FOR_COMPANIES_FAQ array, so
+  // the structured data can never disagree with what the page shows.
+  const jsonLd = $derived(
+    jsonLdScript([
+      faqPageJsonLd(FOR_COMPANIES_FAQ),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'For companies', url: canonical },
+      ]),
+    ])
+  );
 </script>
 
 <Seo
@@ -11,6 +25,11 @@
   description="Get your company's whole ATS board indexed by freehire, the free, open-source IT job aggregator. Add a supported board with one line, or contribute an adapter — we crawl it regularly and close roles you take down."
   {canonical}
 />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <ForCompaniesView />

--- a/web/src/routes/insights/+page.svelte
+++ b/web/src/routes/insights/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import Seo from '$lib/components/Seo.svelte';
-  import { breadcrumbJsonLd, jsonLdScript } from '$lib/seo';
+  import { breadcrumbJsonLd, collectionPageJsonLd, jsonLdScript } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -11,8 +11,25 @@
   const canonical = $derived(`${origin}/insights`);
   const description =
     'Aggregate job-market data from freehire: salaries, in-demand skills, and hiring demand for every tech category.';
+  // This hub exists so crawlers reach every category page from one indexable page
+  // (see +page.server.ts), so the ItemList names all three pages per covered
+  // category — the same links the cards render, in the same order.
+  const sections = [
+    { path: 'salary', label: 'salaries' },
+    { path: 'skills', label: 'skills' },
+    { path: 'roles', label: 'roles' },
+  ];
+  const items = $derived(
+    data.covered.flatMap((c) =>
+      sections.map((s) => ({
+        name: `${c.label} ${s.label}`,
+        url: `${origin}/insights/${s.path}/${c.category}`,
+      })),
+    ),
+  );
   const jsonLd = $derived(
     jsonLdScript([
+      collectionPageJsonLd('Job Market Insights', description, canonical, items),
       breadcrumbJsonLd([
         { name: 'freehire', url: `${origin}/` },
         { name: 'Insights', url: canonical },

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -3,7 +3,8 @@
   import Seo from '$lib/components/Seo.svelte';
   import ActivityBars from '$lib/components/ActivityBars.svelte';
   import GrowthArea from '$lib/components/GrowthArea.svelte';
-  import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import { OPEN_FAQ } from '$lib/openFaq';
+  import { breadcrumbJsonLd, datasetJsonLd, faqPageJsonLd, jsonLdScript } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -22,6 +23,7 @@
         { name: 'Jobs API', contentUrl: `${origin}/api/v1/jobs` },
         { name: 'Companies API', contentUrl: `${origin}/api/v1/companies` },
       ]),
+      faqPageJsonLd(OPEN_FAQ),
       breadcrumbJsonLd([
         { name: 'freehire', url: `${origin}/` },
         { name: 'Open', url: canonical },
@@ -299,5 +301,20 @@
         >.
       </p>
     </div>
+  </section>
+
+  <!-- E. FAQ. Visible answers and the FAQPage JSON-LD share OPEN_FAQ; the schema is
+       only honest while this section renders. Kept last so the numbers stay the
+       page's opening subject. -->
+  <section class="mt-14">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// about these numbers</p>
+    <dl class="mt-6 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each OPEN_FAQ as item (item.question)}
+        <div class="bg-background p-5 sm:p-6">
+          <dt class="text-base font-semibold tracking-tight">{item.question}</dt>
+          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
   </section>
 </div>

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -3,11 +3,31 @@
   import Seo from '$lib/components/Seo.svelte';
   import ActivityBars from '$lib/components/ActivityBars.svelte';
   import GrowthArea from '$lib/components/GrowthArea.svelte';
+  import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
-  const canonical = $derived(`${page.url.origin}/open`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/open`);
+  const description =
+    "The open startup page for freehire: live catalogue scale, daily job movement, what's inside, member growth, and open-source stats. Every figure comes straight from the public API.";
+  // llms.txt points AI engines here for the live figures ("cite that page rather
+  // than these floors"), so the page has to be readable as data, not just prose: a
+  // Dataset naming the public JSON endpoints each number is read from, plus a
+  // breadcrumb. The distributions mirror the per-stat source links below.
+  const jsonLd = $derived(
+    jsonLdScript([
+      datasetJsonLd("freehire's live catalogue and platform figures", description, canonical, origin, [
+        { name: 'Jobs API', contentUrl: `${origin}/api/v1/jobs` },
+        { name: 'Companies API', contentUrl: `${origin}/api/v1/companies` },
+      ]),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Open', url: canonical },
+      ]),
+    ])
+  );
 
   // Repo constants — the crawler covers this many ATS platforms and Telegram
   // channels. Not DB rows; they change only when adapters/channels are added (i.e.
@@ -117,11 +137,12 @@
   </a>
 {/snippet}
 
-<Seo
-  title="Open — freehire's numbers, live"
-  description="The open startup page for freehire: live catalogue scale, daily job movement, what's inside, member growth, and open-source stats. Every figure comes straight from the public API."
-  {canonical}
-/>
+<Seo title="Open — freehire's numbers, live" {description} {canonical} />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-4xl px-4 py-10 sm:py-14">
   <!-- Intro -->

--- a/web/src/routes/recruiters/+page.svelte
+++ b/web/src/routes/recruiters/+page.svelte
@@ -2,8 +2,22 @@
   import { page } from '$app/state';
   import RecruitersView from '$lib/components/RecruitersView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { RECRUITERS_FAQ } from '$lib/recruitersFaq';
+  import { breadcrumbJsonLd, faqPageJsonLd, jsonLdScript } from '$lib/seo';
 
-  const canonical = $derived(`${page.url.origin}/recruiters`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/recruiters`);
+  // The FAQ block and this payload render from the same RECRUITERS_FAQ array, so the
+  // structured data can never disagree with what the page shows.
+  const jsonLd = $derived(
+    jsonLdScript([
+      faqPageJsonLd(RECRUITERS_FAQ),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'For recruiters', url: canonical },
+      ]),
+    ])
+  );
 </script>
 
 <Seo
@@ -11,6 +25,11 @@
   description="Submit a tech job to freehire, the free, open-source IT job aggregator. Moderator-reviewed postings join one clean, searchable feed of developer roles."
   {canonical}
 />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <RecruitersView />

--- a/web/src/routes/robots.txt/+server.ts
+++ b/web/src/routes/robots.txt/+server.ts
@@ -2,12 +2,18 @@ import type { RequestHandler } from './$types';
 
 // A real robots file (not the SPA shell): allow crawling the public pages, keep
 // personal pages out, and point at the sitemap.
+//
+// The wildcard already admits every AI crawler (GPTBot, ClaudeBot, PerplexityBot,
+// …), so no per-bot Allow block is listed — a redundant one would only invite
+// drift from this rule. llms.txt has no robots directive of its own, so it is
+// advertised as a comment, the convention crawlers look for.
 export const GET: RequestHandler = ({ url }) => {
   const body = `User-agent: *
 Allow: /
 Disallow: /my/
 
 Sitemap: ${url.origin}/sitemap.xml
+# llms.txt: ${url.origin}/llms.txt
 `;
   return new Response(body, {
     headers: {

--- a/web/src/routes/trends/+page.svelte
+++ b/web/src/routes/trends/+page.svelte
@@ -4,12 +4,29 @@
   import Seo from '$lib/components/Seo.svelte';
   import ActivityBars from '$lib/components/ActivityBars.svelte';
   import { api } from '$lib/api';
+  import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
   import type { ActivityGranularity, ActivityPoint } from '$lib/types';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
-  const canonical = $derived(`${page.url.origin}/trends`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/trends`);
+  const description =
+    'How the freehire catalogue moves over time — new vacancies added versus postings removed, by day, week, or month.';
+  // A time series, not a page of prose: the Dataset names the endpoint the chart
+  // reads so an engine can fetch the series rather than infer it from the bars.
+  const jsonLd = $derived(
+    jsonLdScript([
+      datasetJsonLd('freehire job-posting activity over time', description, canonical, origin, [
+        { name: 'Jobs activity API', contentUrl: `${origin}/api/v1/stats/jobs-activity` },
+      ]),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Trends', url: canonical },
+      ]),
+    ]),
+  );
 
   const options: { value: ActivityGranularity; label: string }[] = [
     { value: 'day', label: 'Day' },
@@ -55,11 +72,12 @@
   }
 </script>
 
-<Seo
-  title="Trends · freehire"
-  description="How the freehire catalogue moves over time — new vacancies added versus postings removed, by day, week, or month."
-  {canonical}
-/>
+<Seo title="Trends · freehire" {description} {canonical} />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <div class="mb-4 flex flex-wrap items-end justify-between gap-3">


### PR DESCRIPTION
An SEO/GEO audit of the live site found eleven public pages emitting no JSON-LD, while their siblings carried it. In every case the capability already existed — `web/src/lib/seo.ts` held the factories — so these were missed call sites, not missing infrastructure.

## The costly one

`llms.txt` tells AI engines to cite `/open` for the live figures ("cite that page rather than these floors"). The page answered with prose only. It now carries a `Dataset` naming the JSON endpoints each number is read from, so an engine can *verify* a figure instead of quoting it. `/trends` gets the same for its time series.

## Coverage

| Page | Added |
|---|---|
| `/open` | `Dataset` + `DataDownload` ×2, `FAQPage`, breadcrumb |
| `/companies` | `CollectionPage` + `ItemList`, breadcrumb |
| `/features/referrals` | `FAQPage` |
| `/trends` | `Dataset` + `DataDownload`, breadcrumb |
| `/insights` | `CollectionPage` + `ItemList` (3 links × N categories) |
| `/docs/api` | `WebAPI` → `openapi.yaml`, breadcrumb |
| `/cli` | `SoftwareApplication` + `Offer`, breadcrumb |
| `/blog` | `Blog` + `BlogPosting`, breadcrumb |
| `/recruiters`, `/for-companies` | `FAQPage` + breadcrumb |
| `robots.txt` | `llms.txt` pointer |

## Notable

**`/features/referrals` had a visible FAQ all along** — declared inline as `{q, a}` instead of the shared `FaqItem`, which is why the schema was never wired. Extracted to `$lib/referralsFaq` so the rendered block and the `FAQPage` read one array, the invariant the other feature pages hold.

**`collectionPageJsonLd` took `Job[]`** and built job URLs, so the companies directory could not reuse it. Generalized to `{name, url}[]` — the shape `breadcrumbJsonLd` already takes — with `jobListItems`/`companyListItems` adapters. One caller updated.

**`/open`, `/recruiters` and `/for-companies` had no FAQ to wire.** `FAQPage` requires the questions to be visible text, so each got a rendered section first and the schema second. Answers are drawn from the code, not from copy — `/open` cites its own load path (60s server memo, `max-age=300`, hourly GitHub refresh against the 60/hr cap, daily-rollup facets that lag the live counts), and `/recruiters` deliberately promises no review turnaround, which nothing guarantees.

**Shared constants where two places would otherwise drift:** the CLI repo URLs moved to `$lib/cliLinks` so `codeRepository` can never name a repo the page does not link.

## Verification

Served a production build against the prod API:

- All eleven pages render their schema in the SSR HTML.
- `/collections/*` still emits job URLs after the `collectionPageJsonLd` refactor.
- All 16 FAQ questions were checked programmatically to appear as visible `<dt>` text — the requirement that makes `FAQPage` legitimate rather than a penalty.
- Screenshots confirm the new sections adopt each page's existing styling.

`pnpm check` 0 errors; `pnpm lint` byte-identical to baseline (0 errors, 49 warnings — compared against a stashed tree, not assumed); 539 tests pass (+3 new).

## Not included

Schema validation in Google's Rich Results Test. Worth running on the existing `JobPosting`, whose required-field rules are strict — but that is pre-existing markup this PR does not touch.