### PR TITLE
feat(ds): story the remaining five primitives, and the variants that drifted

### DIFF
--- a/design-system/.storybook/demos/DialogDemo.svelte
+++ b/design-system/.storybook/demos/DialogDemo.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  // A dialog only makes sense next to the thing that opens it: `open` is
+  // bindable, and a story that hard-codes it true cannot be reopened once
+  // closed. So the trigger lives here and the story drives the content.
+  import Button from '../../src/button.svelte';
+  import Dialog from '../../src/dialog.svelte';
+
+  let {
+    title = 'Withdraw application?',
+    description,
+  }: { title?: string; description?: string } = $props();
+
+  let open = $state(false);
+</script>
+
+<Button onclick={() => (open = true)}>Open dialog</Button>
+
+<Dialog bind:open {title} {description}>
+  <p class="text-sm text-muted-foreground">
+    Withdrawing moves the application to Closed. You can apply again while the job is open.
+  </p>
+  <div class="mt-6 flex justify-end gap-2">
+    <Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>
+    <Button variant="destructive" onclick={() => (open = false)}>Withdraw</Button>
+  </div>
+</Dialog>

--- a/design-system/.storybook/demos/FormFieldDemo.svelte
+++ b/design-system/.storybook/demos/FormFieldDemo.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  // The field hands its control four values through the children snippet, and
+  // the wiring is the whole point of the primitive — a story that faked the
+  // control with raw markup would show none of it.
+  import FormField from '../../src/form-field.svelte';
+  import Input from '../../src/input.svelte';
+
+  let {
+    label = 'Work email',
+    hint,
+    error,
+    required = false,
+  }: { label?: string; hint?: string; error?: string; required?: boolean } = $props();
+</script>
+
+<div class="max-w-sm">
+  <FormField {label} {hint} {error} {required}>
+    {#snippet children({ id, describedBy, required: isRequired, invalid })}
+      <Input
+        {id}
+        required={isRequired}
+        aria-describedby={describedBy}
+        aria-invalid={invalid || undefined}
+        type="email"
+        placeholder="you@company.com"
+        class="w-full"
+      />
+    {/snippet}
+  </FormField>
+</div>

--- a/design-system/.storybook/demos/IconButtonDemo.svelte
+++ b/design-system/.storybook/demos/IconButtonDemo.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  // `size: 'icon'` is the one Button size whose content is not text, and an icon
+  // button carries no accessible name unless the call site gives it one — worth
+  // showing together rather than as a square with a glyph in it.
+  import Button from '../../src/button.svelte';
+  import { X } from '@lucide/svelte';
+
+  let { variant = 'ghost' }: { variant?: 'primary' | 'secondary' | 'outline' | 'ghost' } = $props();
+</script>
+
+<Button {variant} size="icon" aria-label="Dismiss">
+  <X class="size-4" />
+</Button>

--- a/design-system/.storybook/demos/TableDemo.svelte
+++ b/design-system/.storybook/demos/TableDemo.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  // Table renders the table/thead/tbody and leaves rows and cells to the caller,
+  // handing out `tr`/`th`/`td` as classes. Only a real caller shows that shape.
+  import Table, { tableVariants } from '../../src/table.svelte';
+  import Badge from '../../src/badge.svelte';
+
+  type Row = { role: string; company: string; status: string };
+
+  let {
+    rows = [
+      { role: 'Senior Go Engineer', company: 'Granola', status: 'Applied' },
+      { role: 'Platform Engineer', company: 'Meilisearch', status: 'Screening' },
+      { role: 'Backend Engineer', company: 'Fly.io', status: 'Rejected' },
+    ],
+  }: { rows?: Row[] } = $props();
+
+  const slots = tableVariants();
+</script>
+
+<Table>
+  {#snippet header()}
+    <tr class={slots.tr()}>
+      <th class={slots.th()}>Role</th>
+      <th class={slots.th()}>Company</th>
+      <th class={slots.th()}>Status</th>
+    </tr>
+  {/snippet}
+  {#each rows as row (row.role)}
+    <tr class={slots.tr()}>
+      <td class={slots.td()}>{row.role}</td>
+      <td class={slots.td()}>{row.company}</td>
+      <td class={slots.td()}><Badge variant="secondary">{row.status}</Badge></td>
+    </tr>
+  {/each}
+</Table>

--- a/design-system/.storybook/demos/TooltipDemo.svelte
+++ b/design-system/.storybook/demos/TooltipDemo.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  // The tooltip wires aria-describedby onto the first focusable element inside
+  // its trigger snippet, so the trigger has to be a real control for the story
+  // to show the keyboard path (focus reveals it, Escape dismisses it).
+  import Button from '../../src/button.svelte';
+  import Tooltip from '../../src/tooltip.svelte';
+
+  let {
+    label = 'Posted 4 months ago and still open',
+    side = 'top',
+  }: { label?: string; side?: 'top' | 'right' | 'bottom' | 'left' } = $props();
+</script>
+
+<!-- Room on every side so the story reads the same whichever `side` is picked. -->
+<div class="flex justify-center p-16">
+  <Tooltip {side}>
+    {#snippet content()}
+      {label}
+    {/snippet}
+    <Button variant="outline">Hover or focus me</Button>
+  </Tooltip>
+</div>

--- a/design-system/.storybook/preview.css
+++ b/design-system/.storybook/preview.css
@@ -6,10 +6,12 @@
    unstyled markup while the build stays green. */
 @import "../src/theme.css";
 
-/* Stories carry classes of their own — Skeleton's dimensions, for one. They sit
-   outside the package's scan on purpose: the app must never ship a utility only
-   a story uses. Storybook does need them, so it asks for them here. */
+/* Stories and their demo components carry classes of their own — Skeleton's
+   dimensions, the demos' layout padding. Both sit outside the package's own scan
+   on purpose: the app must never ship a utility only a story uses, which is also
+   why the demos live here and not in src/. Storybook does need them. */
 @source "../src/**/*.stories.ts";
+@source "./demos/**/*.svelte";
 
 /* The canvas follows the tokens rather than a second, hand-copied set of hex
    values, so the theme toolbar cannot leave the backdrop and the components

--- a/design-system/AGENTS.md
+++ b/design-system/AGENTS.md
@@ -52,16 +52,28 @@ unfinished phase, not breakage.
 ## Storybook
 
 `pnpm storybook` (port 6006) / `pnpm build-storybook`. Stories are CSF in
-`src/*.stories.ts`; `src/story-text.ts` wraps a plain string in the snippet Svelte 5 needs
-for a component's `children`.
+`src/*.stories.ts`, one file per primitive, and all 15 are covered.
+
+**Two ways to give a story its `children`, and the choice is not taste.** For a primitive
+whose children are just text, `src/story-text.ts` wraps a string in the snippet Svelte 5
+requires. For one whose children compose *other primitives* or take snippet parameters —
+`Dialog` needs a trigger, `FormField` hands its control `{ id, describedBy, required,
+invalid }`, `Table` leaves rows to the caller, `Tooltip` wires `aria-describedby` onto the
+first focusable child — a raw HTML string would mean hand-copying the markup of `Input` or
+`Button`, and the story would drift from the component silently. Those get a real component
+in **`.storybook/demos/`**, named in the story's `component`.
+
+The demos live there and not in `src/` for two reasons: `src/*` is the package's public
+export surface (`"./*": "./src/*"`), and `theme.css`'s `@source "./**/*.svelte"` would mint
+their layout utilities into the *app's* bundle. `preview.css` scans them separately.
+(`@storybook/addon-svelte-csf` would be the tidier answer, but 5.1.2 peers `@storybook/svelte`
+at `^10.4.0-0` and we are on 10.5.4.)
 
 `docgen: false` in `.storybook/main.ts` — the svelte docgen plugin hands raw `.svelte` source
 to the bundler's JS parser and dies on the markup. The cost is the autodocs prop tables, so
 the Docs tab renders thin, and `argTypes` are hand-maintained: they drift from a component's
-actual variants with nothing to catch it.
+actual variants with nothing to catch it. `Button`'s list already did, losing `destructive`.
 
 ## Limitations
 
-- Five primitives have no stories — `Dialog`, `FormField`, `Table`, `Tabs`, `Tooltip` — and
-  neither do `Button`'s `destructive` variant and `icon` size, nor `Chip`'s `secondary`.
 - The DSDS docs site is not configured yet.

--- a/design-system/src/button-icon.stories.ts
+++ b/design-system/src/button-icon.stories.ts
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+// A separate entry rather than a story inside button.stories.ts: the icon size
+// needs a component for its child, which makes the meta a different type.
+import IconButtonDemo from '../.storybook/demos/IconButtonDemo.svelte';
+
+const meta = {
+  title: 'Primitives/Button (icon size)',
+  component: IconButtonDemo,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['primary', 'secondary', 'outline', 'ghost'] },
+  },
+} satisfies Meta<typeof IconButtonDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ghost: Story = { args: { variant: 'ghost' } };
+export const Outline: Story = { args: { variant: 'outline' } };

--- a/design-system/src/button.stories.ts
+++ b/design-system/src/button.stories.ts
@@ -7,7 +7,12 @@ const meta = {
   component: Button,
   tags: ['autodocs'],
   argTypes: {
-    variant: { control: 'select', options: ['primary', 'secondary', 'outline', 'ghost'] },
+    // Kept in step with buttonVariants by hand — docgen is off, so nothing
+    // derives this list from the component.
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'outline', 'ghost', 'destructive'],
+    },
     size: { control: 'select', options: ['sm', 'md', 'lg', 'icon'] },
   },
 } satisfies Meta<typeof Button>;
@@ -21,3 +26,9 @@ export const Outline: Story = { args: { variant: 'outline', size: 'md', children
 export const Ghost: Story = { args: { variant: 'ghost', size: 'md', children: text('Ghost') } };
 export const Small: Story = { args: { variant: 'secondary', size: 'sm', children: text('Small') } };
 export const Large: Story = { args: { variant: 'primary', size: 'lg', children: text('Large') } };
+// Filled, for the action that destroys something and cannot be undone. A soft
+// `ghost` plus destructive text is the right weight for the reversible ones —
+// the variant exists so that distinction stays visible.
+export const Destructive: Story = {
+  args: { variant: 'destructive', size: 'md', children: text('Delete account') },
+};

--- a/design-system/src/chip.stories.ts
+++ b/design-system/src/chip.stories.ts
@@ -16,5 +16,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = { args: { variant: 'default', children: text('Chip') } };
 export const Primary: Story = { args: { variant: 'primary', children: text('Active') } };
+export const Secondary: Story = { args: { variant: 'secondary', children: text('Remote') } };
 export const Brand: Story = { args: { variant: 'brand', children: text('Verified') } };
 export const Destructive: Story = { args: { variant: 'destructive', children: text('Rejected') } };

--- a/design-system/src/dialog.stories.ts
+++ b/design-system/src/dialog.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+// The component under test is Dialog; the demo supplies the trigger it needs to
+// be reopenable. Same for the other snippet-composing primitives — see
+// .storybook/demos/.
+import DialogDemo from '../.storybook/demos/DialogDemo.svelte';
+
+const meta = {
+  title: 'Primitives/Dialog',
+  component: DialogDemo,
+  tags: ['autodocs'],
+} satisfies Meta<typeof DialogDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Withdraw application?',
+    description: 'The employer keeps the messages you already sent.',
+  },
+};
+export const TitleOnly: Story = { args: { title: 'Withdraw application?' } };

--- a/design-system/src/form-field.stories.ts
+++ b/design-system/src/form-field.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import FormFieldDemo from '../.storybook/demos/FormFieldDemo.svelte';
+
+const meta = {
+  title: 'Primitives/FormField',
+  component: FormFieldDemo,
+  tags: ['autodocs'],
+} satisfies Meta<typeof FormFieldDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { label: 'Work email' } };
+export const WithHint: Story = {
+  args: { label: 'Work email', hint: 'Only used to verify the employer domain.' },
+};
+export const Required: Story = { args: { label: 'Work email', required: true } };
+// `error` wins over `hint`: one message element, and the field points
+// aria-describedby at whichever is showing.
+export const WithError: Story = {
+  args: {
+    label: 'Work email',
+    hint: 'Only used to verify the employer domain.',
+    error: 'That address is already on another account.',
+    required: true,
+  },
+};

--- a/design-system/src/table.stories.ts
+++ b/design-system/src/table.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import TableDemo from '../.storybook/demos/TableDemo.svelte';
+
+const meta = {
+  title: 'Primitives/Table',
+  component: TableDemo,
+  tags: ['autodocs'],
+} satisfies Meta<typeof TableDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+// tbody's `[&_tr:last-child]:border-0` is only visible with more than one row,
+// and the hover tint is what a single row cannot show at all.
+export const SingleRow: Story = {
+  args: { rows: [{ role: 'Senior Go Engineer', company: 'Granola', status: 'Applied' }] },
+};

--- a/design-system/src/tabs.stories.ts
+++ b/design-system/src/tabs.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import { text } from './story-text.js';
+import Tabs from './tabs.svelte';
+
+const meta = {
+  title: 'Primitives/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const tabs = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'skills', label: 'Skills' },
+  { value: 'company', label: 'Company' },
+];
+
+export const Default: Story = {
+  args: { tabs, value: 'overview', children: text('Panel content for the selected tab.') },
+};
+// No `value`: a tablist always has exactly one selected tab, so the first one
+// reads as selected — which is also what keeps the roving tabindex reachable.
+export const Unselected: Story = {
+  args: { tabs, children: text('Panel content for the selected tab.') },
+};
+export const TwoTabs: Story = {
+  args: {
+    tabs: [
+      { value: 'open', label: 'Open' },
+      { value: 'closed', label: 'Closed' },
+    ],
+    value: 'open',
+    children: text('Panel content for the selected tab.'),
+  },
+};

--- a/design-system/src/tooltip.stories.ts
+++ b/design-system/src/tooltip.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import TooltipDemo from '../.storybook/demos/TooltipDemo.svelte';
+
+const meta = {
+  title: 'Primitives/Tooltip',
+  component: TooltipDemo,
+  tags: ['autodocs'],
+  argTypes: {
+    side: { control: 'select', options: ['top', 'right', 'bottom', 'left'] },
+  },
+} satisfies Meta<typeof TooltipDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Top: Story = { args: { side: 'top' } };
+export const Right: Story = { args: { side: 'right' } };
+export const Bottom: Story = { args: { side: 'bottom' } };
+export const Left: Story = { args: { side: 'left' } };
+// max-w-xs wraps rather than stretching the trigger's row.
+export const LongContent: Story = {
+  args: {
+    side: 'top',
+    label:
+      'Reposted three times in six months with no change to the description — the pattern the ghost-job signal looks for.',
+  },
+};

--- a/design-system/tsconfig.json
+++ b/design-system/tsconfig.json
@@ -28,6 +28,7 @@
     // framework's own types; leaving it out of the check is how a preview that
     // never loaded Tailwind still built green.
     ".storybook/**/*.ts",
+    ".storybook/**/*.svelte",
     "vitest.config.ts",
     "vitest.setup.ts"
   ]


### PR DESCRIPTION
Closes the story-coverage gap left by #1099 and tracked in `design-system/AGENTS.md`. All 15 primitives now have stories — 53 in total, up from 33.

## What was missing, and why it was the wrong half

`Dialog`, `FormField`, `Table`, `Tabs`, `Tooltip` — the interactive ones. Exactly where a rendered surface tells you something a unit test doesn't, and exactly where the existing story-authoring trick runs out.

Four of the five cannot take their `children` from a string:

- **Dialog** — `open` is bindable, and a story that hard-codes it `true` cannot be reopened once closed. It needs a trigger.
- **FormField** — hands its control `{ id, describedBy, required, invalid }` through a parameterised snippet. That wiring *is* the primitive.
- **Table** — renders `table`/`thead`/`tbody` and leaves rows and cells to the caller, exporting `tr`/`th`/`td` as classes.
- **Tooltip** — attaches `aria-describedby` to the first focusable element inside the trigger snippet, so the trigger has to be a real control for the keyboard path to exist.

Forcing these through `createRawSnippet` would mean hand-copying `Input`'s or `Button`'s markup into an HTML string. The story would then drift from the component silently — the same failure mode this package keeps hitting. So they get real components in **`.storybook/demos/`**, named as the story's `component`.

`Tabs` needed none: its `tabs` prop is a plain array and the panel is plain text.

## Why the demos are not in `src/`

Two reasons, both load-bearing:

1. `src/*` is the package's public export surface (`"./*": "./src/*"`), so a demo there would be importable as `freehire-design-system/DialogDemo.svelte`.
2. `theme.css`'s `@source "./**/*.svelte"` would mint the demos' layout utilities (`p-16`, `max-w-sm`, `justify-end`) into the **app's** bundle.

`preview.css` scans `./demos/**/*.svelte` separately — the same boundary the story files already sit on.

`@storybook/addon-svelte-csf` is the tidier answer and was the first thing tried: 5.1.2 peers `@storybook/svelte` at `^10.4.0-0` and we are on `10.5.4`. Not worth an unmet peer; revisit when the range moves.

## Drift the review turned up

- `Button`'s `argTypes` never listed **`destructive`**, though `buttonVariants` has had it all along — with `docgen: false` nothing derives that list, so it silently fell behind. Added, with a story and a note about when the filled variant is the right weight.
- `size: 'icon'` had no story. It gets its own sidebar entry rather than a story inside `button.stories.ts`, because an icon child makes the meta a different type — and it's worth showing that an icon button carries no accessible name without an `aria-label`.
- `Chip`'s **`secondary`** was in `argTypes` with no story.

## Verified

`pnpm check` 0 errors (`.storybook/**/*.svelte` added to `tsconfig` include so the demos are typechecked), `pnpm test` 35 passed, `pnpm build-storybook` ✓ and the CI utility assert from #1296 still passes.

`index.json` lists 53 stories across all 15 primitives. The new `@source` line is confirmed working — `p-16`, `max-w-sm` and `justify-end` reach the CSS only from the demos.

Screenshotted through headless Chrome: `Table/Default` (header, hover borders, badge cells), `FormField/WithError` (required asterisk, red message under the real `Input`), `Tabs/Default` (active pill, panel), `Button (icon size)/Ghost`.

`Tooltip` and `Dialog` reveal on interaction, so a static screenshot proves little there; their CSS is present (`z-popover`, `bg-popover`, `backdrop:bg-black/50`, `max-w-lg`) and their behaviour stays covered by `tooltip.test.ts` (7 cases) and `dialog.test.ts` (6).
