### PR TITLE
fix(reports): say why an impossible apply date cannot be sent

### DIFF
--- a/web/src/lib/components/ReportDialog.svelte
+++ b/web/src/lib/components/ReportDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { ArrowLeft, Ban, BellOff, Check, ChevronRight, Clock, MoreHorizontal, ShieldAlert, X } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
-  import { isEvidenceReason, reportReasons } from '$lib/reports';
+  import { appliedOnError, isEvidenceReason, reportReasons } from '$lib/reports';
   import type { ReportReason } from '$lib/types';
   import { Button } from '$lib/ui';
   import { focusTrap } from '$lib/actions/focusTrap';
@@ -25,6 +25,10 @@
   let appliedOn = $state('');
   let submitting = $state(false);
   let error = $state<string | null>(null);
+
+  // The element itself, because a malformed entry never reaches `appliedOn`: the
+  // input clears its value and records the fact in `validity.badInput`.
+  let appliedInput = $state<HTMLInputElement | null>(null);
 
   // A claim needs a date we can measure silence from, and no date can be in the
   // future. The server re-checks both — this is the affordance, not the guard.
@@ -82,7 +86,15 @@
 
   async function submitApplied(e: SubmitEvent) {
     e.preventDefault();
-    if (!appliedOn) return;
+    const problem = appliedOnError({
+      value: appliedOn,
+      badInput: appliedInput?.validity.badInput ?? false,
+      today,
+    });
+    if (problem) {
+      error = problem;
+      return;
+    }
     await send(() => api.reportGhostJob(slug, { applied_on: appliedOn }));
   }
 </script>
@@ -160,7 +172,7 @@
         </label>
 
         {#if error}
-          <p class="text-sm text-destructive">{error}</p>
+          <p role="alert" class="text-sm text-destructive">{error}</p>
         {/if}
 
         <Button type="submit" variant="primary" disabled={submitting}>
@@ -168,7 +180,10 @@
         </Button>
       </form>
     {:else if step === 'applied'}
-      <form class="flex flex-col gap-4" onsubmit={submitApplied}>
+      <!-- novalidate: the browser's own refusal for an impossible date is a tooltip
+           that never says which part is wrong, and it fires before submit, so the
+           dialog would never get to explain itself. -->
+      <form class="flex flex-col gap-4" novalidate onsubmit={submitApplied}>
         <button
           type="button"
           onclick={() => (step = 'reason')}
@@ -185,7 +200,9 @@
           </span>
           <input
             type="date"
+            bind:this={appliedInput}
             bind:value={appliedOn}
+            oninput={() => (error = null)}
             required
             max={today}
             class="mt-1 rounded-md border border-border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -193,10 +210,13 @@
         </label>
 
         {#if error}
-          <p class="text-sm text-destructive">{error}</p>
+          <p role="alert" class="text-sm text-destructive">{error}</p>
         {/if}
 
-        <Button type="submit" variant="primary" disabled={submitting || !appliedOn}>
+        <!-- Never disabled on an empty date: an impossible entry empties the value
+             while the field still reads as filled in, and a dead button is the one
+             thing that cannot say why. -->
+        <Button type="submit" variant="primary" disabled={submitting}>
           {submitting ? 'Sending…' : 'Send report'}
         </Button>
       </form>

--- a/web/src/lib/reports.test.ts
+++ b/web/src/lib/reports.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  appliedOnError,
   decisionLabel,
   decisionNotePlaceholder,
   decisionNotePrompt,
@@ -91,5 +92,30 @@ describe('isEvidenceReason', () => {
   it('classifies every reason in the vocabulary', () => {
     const evidence = reportReasons.filter((r) => isEvidenceReason(r.value));
     expect(evidence).toHaveLength(1);
+  });
+});
+
+describe('appliedOnError', () => {
+  const today = '2026-07-30';
+
+  it('accepts a past date and today itself', () => {
+    expect(appliedOnError({ value: '2026-06-01', badInput: false, today })).toBeNull();
+    expect(appliedOnError({ value: today, badInput: false, today })).toBeNull();
+  });
+
+  // A date input answers an impossible entry — 30 February, a half-typed year —
+  // by clearing its value, so the empty string alone cannot say whether the user
+  // typed nothing or typed something that does not exist. Only badInput can, and
+  // the two deserve different sentences.
+  it('separates an impossible date from an empty field', () => {
+    const impossible = appliedOnError({ value: '', badInput: true, today });
+    const empty = appliedOnError({ value: '', badInput: false, today });
+    expect(impossible).toMatch(/exist/i);
+    expect(empty).not.toBeNull();
+    expect(empty).not.toBe(impossible);
+  });
+
+  it('rejects a date in the future', () => {
+    expect(appliedOnError({ value: '2026-07-31', badInput: false, today })).toMatch(/future/i);
   });
 });

--- a/web/src/lib/reports.ts
+++ b/web/src/lib/reports.ts
@@ -99,3 +99,32 @@ export function decisionOutcome({
 export function isEvidenceReason(reason: ReportReason): boolean {
   return reason === 'no_response';
 }
+
+interface AppliedOnInput {
+  /** The input's value: an ISO `YYYY-MM-DD` day, or empty. */
+  value: string;
+  /** The input's `validity.badInput` — what the browser typed but could not read. */
+  badInput: boolean;
+  /** Today as an ISO day, in the reporter's own timezone. */
+  today: string;
+}
+
+/**
+ * Why the stated apply date cannot be filed, or null when it can.
+ *
+ * A date input reports an impossible entry (30 February, a year still being typed)
+ * by clearing its value, so an empty string means either "nothing entered" or
+ * "entered something that does not exist" — indistinguishable without `badInput`.
+ * Blocking the submit button on the empty value alone therefore reads, to someone
+ * looking at a filled-in field, as a button that simply does not work.
+ *
+ * The server checks the date again and answers 400. That answer says nothing the
+ * reporter can act on, which is what this exists to say instead.
+ */
+export function appliedOnError({ value, badInput, today }: AppliedOnInput): string | null {
+  if (badInput) return "That date doesn't exist — check the day and the month.";
+  if (!value) return 'Pick the date you applied.';
+  // Both sides are ISO days, so lexical order is calendar order.
+  if (value > today) return 'That date is in the future — pick the day you applied.';
+  return null;
+}


### PR DESCRIPTION
## The bug

Reported from the job page: the ghost-report dialog would not send. The date field read `30/02/2026` and **Send report** did nothing.

30 February does not exist, and a `<input type="date">` answers an entry it cannot read by **clearing its value** while leaving the typed text on screen. That empty value fed `disabled={submitting || !appliedOn}`, so the button was greyed out — a filled-in form with a dead button and no explanation.

Confirmed in Chrome:

```
{"value":"", "badInput":true, "valid":false,
 "msg":"Please enter a valid value. The field is incomplete or has an invalid date."}
```

## The fix

- `appliedOnError()` in `web/src/lib/reports.ts` — splits the empty value into its two meanings via `validity.badInput` (nothing typed vs. typed something impossible) and adds the future-date case, which the server rejects with a 400 the reporter cannot act on.
- The submit button now greys out only while sending.
- `novalidate` on the form: the browser's own refusal fires *before* submit, so the dialog never got to speak, and its tooltip never names which part of the date is wrong. `required` and `max` stay on the element as AT semantics and as the date-picker affordance.
- `role="alert"` on both error paragraphs — the message appears without a focus change, so a screen reader would otherwise miss it.

The server-side check in `internal/handler/ghost_reports.go` is unchanged; this is the affordance in front of it.

## Verification

```
vitest src/lib/reports.test.ts   18 passed (3 new)
svelte-check                     0 errors
oxlint + eslint (changed files)  clean
```

Both browser assumptions were checked live rather than assumed: that `30 February` yields `value=""` with `badInput=true`, and that with `novalidate` the submit handler still fires and can read `badInput`.

Not covered: no end-to-end run in the live app — that needs a local server plus a verified-email account.