### PR TITLE
feat(reindex): collapse near-identical reposts the exact passes leave split

### DIFF
--- a/cmd/reindex/fuzzy.go
+++ b/cmd/reindex/fuzzy.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"sort"
 
+	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobhash"
 )
 
@@ -21,10 +23,105 @@ const (
 	fuzzyMaxBucket = 200
 )
 
+// fuzzyDedupQuerier is the slice of the store this pass needs, named so the pass can be read
+// (and faked) without the full generated querier.
+type fuzzyDedupQuerier interface {
+	CompaniesWithFuzzyDedupCandidates(ctx context.Context) ([]string, error)
+	FuzzyDedupCandidateTitlesForCompany(ctx context.Context, company string) ([]db.FuzzyDedupCandidateTitlesForCompanyRow, error)
+	GetJobDescriptionsByIDs(ctx context.Context, ids []int64) ([]db.GetJobDescriptionsByIDsRow, error)
+	MarkFuzzyDuplicatesForCompany(ctx context.Context, arg db.MarkFuzzyDuplicatesForCompanyParams) (int64, error)
+}
+
+// collapseFuzzyDuplicates marks near-identical reposts the exact passes left split, one company at
+// a time, and returns the rows re-marked. It runs LAST, over what the exact role-cluster and
+// aggregator passes did not claim, so it only ever adds markers to leftovers and never contradicts
+// a deterministic collapse.
+//
+// Descriptions are loaded only for buckets that survive the size filter — titles are cheap to ship,
+// descriptions are not, and the largest bucket on prod holds 16 745 postings.
+func collapseFuzzyDuplicates(ctx context.Context, q fuzzyDedupQuerier) (int64, error) {
+	companies, err := q.CompaniesWithFuzzyDedupCandidates(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return forEachCompany(ctx, companies, func(ctx context.Context, company string) (int64, error) {
+		return collapseFuzzyDuplicatesForCompany(ctx, q, company)
+	})
+}
+
+func collapseFuzzyDuplicatesForCompany(ctx context.Context, q fuzzyDedupQuerier, company string) (int64, error) {
+	titles, err := q.FuzzyDedupCandidateTitlesForCompany(ctx, company)
+	if err != nil {
+		return 0, err
+	}
+	buckets := bucketByRole(titles)
+	if len(buckets) == 0 {
+		return 0, nil
+	}
+
+	var ids []int64
+	for _, bucketIDs := range buckets {
+		ids = append(ids, bucketIDs...)
+	}
+	descriptions, err := q.GetJobDescriptionsByIDs(ctx, ids)
+	if err != nil {
+		return 0, err
+	}
+	signatures := make(map[int64]map[string]struct{}, len(descriptions))
+	for _, row := range descriptions {
+		signatures[row.ID] = jobhash.DescriptionSignature(row.Description)
+	}
+
+	var moveIDs, canons []int64
+	for _, bucketIDs := range buckets {
+		postings := make([]fuzzyPosting, 0, len(bucketIDs))
+		for _, id := range bucketIDs {
+			postings = append(postings, fuzzyPosting{ID: id, Signature: signatures[id]})
+		}
+		for id, canon := range clusterBucket(postings, fuzzyThreshold) {
+			moveIDs = append(moveIDs, id)
+			canons = append(canons, canon)
+		}
+	}
+	if len(moveIDs) == 0 {
+		return 0, nil
+	}
+	return q.MarkFuzzyDuplicatesForCompany(ctx, db.MarkFuzzyDuplicatesForCompanyParams{
+		Ids:     moveIDs,
+		Canons:  canons,
+		Company: company,
+	})
+}
+
 // fuzzyPosting is one open canonical posting inside a (company, title) bucket.
 type fuzzyPosting struct {
 	ID        int64
 	Signature map[string]struct{}
+}
+
+// bucketByRole groups one company's open canonical postings by normalized title, keeping only the
+// buckets worth comparing: more than one member, and no more than fuzzyMaxBucket of them.
+//
+// The key comes from jobhash.RoleKey, the same normalization the rest of the codebase groups roles
+// by, so a per-city variant lands on its base role here exactly as it does elsewhere. Deriving it
+// in Go rather than in SQL keeps one definition — a second copy in the query would drift.
+//
+// A title that normalizes to nothing yields no key and is dropped, per RoleKey's contract: every
+// blank title would otherwise share one bucket and merge unrelated postings.
+func bucketByRole(rows []db.FuzzyDedupCandidateTitlesForCompanyRow) map[string][]int64 {
+	buckets := make(map[string][]int64)
+	for _, row := range rows {
+		// The company is fixed for the whole call, so it adds nothing to the key here.
+		if key := jobhash.RoleKey("", row.Title); key != "" {
+			buckets[key] = append(buckets[key], row.ID)
+		}
+	}
+	for key, ids := range buckets {
+		if len(ids) < 2 || len(ids) > fuzzyMaxBucket {
+			delete(buckets, key)
+		}
+	}
+	return buckets
 }
 
 // clusterBucket assigns near-identical postings in one bucket to a canonical id, returning only

--- a/cmd/reindex/fuzzy.go
+++ b/cmd/reindex/fuzzy.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"sort"
+
+	"github.com/strelov1/freehire/internal/jobhash"
+)
+
+const (
+	// fuzzyThreshold is the word overlap two descriptions need before they count as the same
+	// posting. The spike put per-city variants of one role at 0.95–1.00 and genuinely distinct
+	// roles in the same bucket at or below 0.5, so anything inside that gap behaves identically;
+	// 0.9 sits plainly inside it rather than being tuned to one sample.
+	fuzzyThreshold = 0.9
+
+	// fuzzyMaxBucket is the largest bucket this pass will read. Measured on prod, eleven buckets
+	// hold more than a thousand postings each and account for 92% of all pairwise work — and they
+	// are generic-title-by-location (one retailer's "customer service associate i" spans 16 745
+	// stores), exactly the shape that must NOT collapse. Skipping them removes 97% of the cost and
+	// 0.05% of the buckets, which is why this pass needs no MinHash or LSH.
+	fuzzyMaxBucket = 200
+)
+
+// fuzzyPosting is one open canonical posting inside a (company, title) bucket.
+type fuzzyPosting struct {
+	ID        int64
+	Signature map[string]struct{}
+}
+
+// clusterBucket assigns near-identical postings in one bucket to a canonical id, returning only
+// the postings that MOVE — each mapped to its canon. The canon is the lowest id in its cluster, so
+// the result is stable across runs and a re-run is a no-op.
+//
+// Membership is decided against the canon, never transitively. Similarity is not an equivalence
+// relation: A can resemble B and B resemble C while A and C share almost nothing, and following
+// that chain would walk a bucket into one blob. Comparing every candidate to the canon keeps a
+// cluster as tight as its canon.
+//
+// Callers must only pass buckets keyed by a real company and title — the bucket is what stops this
+// from merging unrelated roles, since two boilerplate-heavy postings of different jobs at one
+// employer can share 0.98 of their vocabulary.
+func clusterBucket(postings []fuzzyPosting, threshold float64) map[int64]int64 {
+	if len(postings) < 2 {
+		return map[int64]int64{}
+	}
+	ordered := make([]fuzzyPosting, len(postings))
+	copy(ordered, postings)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].ID < ordered[j].ID })
+
+	moved := make(map[int64]int64)
+	claimed := make(map[int64]bool, len(ordered))
+	for i, canon := range ordered {
+		if claimed[canon.ID] {
+			continue
+		}
+		for _, other := range ordered[i+1:] {
+			if claimed[other.ID] {
+				continue
+			}
+			if jobhash.DescriptionSimilarity(canon.Signature, other.Signature) >= threshold {
+				claimed[other.ID] = true
+				moved[other.ID] = canon.ID
+			}
+		}
+	}
+	return moved
+}

--- a/cmd/reindex/fuzzy_test.go
+++ b/cmd/reindex/fuzzy_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/jobhash"
+)
+
+// posting builds a bucket member from an id and a description.
+func posting(id int64, description string) fuzzyPosting {
+	return fuzzyPosting{ID: id, Signature: jobhash.DescriptionSignature(description)}
+}
+
+const (
+	// A prod-like body: the localized block that differs between cities is a small fraction of it.
+	bodyA = "Build and operate the payments platform with Golang, TypeScript and Postgres. " +
+		"Design resilient APIs, review pull requests, instrument services with metrics and traces, " +
+		"run blameless incident retrospectives, mentor junior engineers, shape the quarterly roadmap, " +
+		"migrate legacy batch pipelines towards streaming, tighten database indexes and query plans, " +
+		"automate deployments through continuous delivery, write architectural decision records, " +
+		"improve developer tooling, reduce build times, keep documentation accurate as the platform evolves. " +
+		"Our workloads run containerised across several availability zones with asynchronous messaging, " +
+		"idempotent consumers and careful backpressure handling whenever traffic surges unexpectedly. " +
+		"We practise trunk based development, keep feature flags short lived, prefer boring technology " +
+		"where reliability matters more than novelty, and rotate engineers through customer support weeks " +
+		"so operational pain reaches whoever can remove it. Compensation reviews happen twice yearly, " +
+		"equipment budgets renew annually, conference attendance receives support, remote colleagues gather " +
+		"quarterly for planning workshops, and internal mobility between squads remains actively encouraged."
+	// A different role at the same company: shares the employer boilerplate, not the specialty.
+	bodyB = "Advise retail clients on supply chain strategy, run stakeholder workshops, " +
+		"prepare board level presentations, build financial models, benchmark competitors, " +
+		"lead procurement negotiations, design operating models, coach client teams through change, " +
+		"quantify savings opportunities, prioritise transformation initiatives, report to steering committees."
+)
+
+// The whole point: reposts whose descriptions differ only by a localized block collapse onto one
+// canon, and the canon is the deterministic min(id) so re-runs agree.
+func TestClusterBucket_CollapsesNearIdenticalOntoLowestID(t *testing.T) {
+	got := clusterBucket([]fuzzyPosting{
+		posting(42, bodyA+" Salary in Poland is quoted gross per month under Polish labour law."),
+		posting(17, bodyA),
+		posting(99, bodyA+" Salary in Austria is quoted gross per month under Austrian labour law."),
+	}, fuzzyThreshold)
+
+	want := map[int64]int64{42: 17, 99: 17}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("clusterBucket = %v, want %v (min id is canon, canon itself absent)", got, want)
+	}
+}
+
+// Distinct roles sharing a generic title must survive as separate cards — the amazon-SDE case.
+func TestClusterBucket_LeavesDistinctRolesAlone(t *testing.T) {
+	got := clusterBucket([]fuzzyPosting{posting(1, bodyA), posting(2, bodyB)}, fuzzyThreshold)
+
+	if len(got) != 0 {
+		t.Errorf("clusterBucket = %v, want no merges", got)
+	}
+}
+
+// Similarity is not transitive, so a chain must not drag two dissimilar ends together: only
+// postings that each match the canon join its cluster.
+func TestClusterBucket_DoesNotChainThroughAnIntermediate(t *testing.T) {
+	mid := bodyA + " " + bodyB
+
+	got := clusterBucket([]fuzzyPosting{posting(1, bodyA), posting(2, mid), posting(3, bodyB)}, fuzzyThreshold)
+
+	if _, merged := got[3]; merged {
+		t.Errorf("clusterBucket = %v: id 3 must not merge into id 1's cluster through the intermediate", got)
+	}
+}
+
+// A description that normalizes to nothing carries no evidence, so it merges with nothing.
+func TestClusterBucket_IgnoresEmptyDescriptions(t *testing.T) {
+	got := clusterBucket([]fuzzyPosting{posting(1, "<p></p>"), posting(2, "<div>  </div>")}, fuzzyThreshold)
+
+	if len(got) != 0 {
+		t.Errorf("clusterBucket = %v, want no merges for empty descriptions", got)
+	}
+}
+
+// Re-running over an already-collapsed bucket yields the same assignment.
+func TestClusterBucket_IsIdempotent(t *testing.T) {
+	in := []fuzzyPosting{posting(5, bodyA), posting(3, bodyA+" Extra local block about payroll.")}
+
+	first := clusterBucket(in, fuzzyThreshold)
+	second := clusterBucket(in, fuzzyThreshold)
+
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("re-run differs: %v vs %v", first, second)
+	}
+}
+
+// A single-member bucket is the common case (median size 2, but plenty of 1s after the exact pass).
+func TestClusterBucket_SingletonIsNoop(t *testing.T) {
+	if got := clusterBucket([]fuzzyPosting{posting(1, bodyA)}, fuzzyThreshold); len(got) != 0 {
+		t.Errorf("clusterBucket = %v, want empty", got)
+	}
+}

--- a/cmd/reindex/fuzzy_test.go
+++ b/cmd/reindex/fuzzy_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobhash"
 )
 
@@ -95,5 +96,54 @@ func TestClusterBucket_IsIdempotent(t *testing.T) {
 func TestClusterBucket_SingletonIsNoop(t *testing.T) {
 	if got := clusterBucket([]fuzzyPosting{posting(1, bodyA)}, fuzzyThreshold); len(got) != 0 {
 		t.Errorf("clusterBucket = %v, want empty", got)
+	}
+}
+
+// Bucketing reuses jobhash.RoleKey, the same normalization the rest of the codebase groups roles
+// by, so a city suffix or a parenthesised qualifier lands in the bucket it belongs to.
+func TestBucketByRole_GroupsOnNormalizedTitle(t *testing.T) {
+	got := bucketByRole([]db.FuzzyDedupCandidateTitlesForCompanyRow{
+		{ID: 1, Title: "Senior Fullstack Engineer"},
+		{ID: 2, Title: "senior fullstack engineer - Kraków"},
+		{ID: 3, Title: "Data Specialist"},
+	})
+
+	// One bucket survives: the two fullstack rows. "Data Specialist" is a singleton with nothing
+	// to compare against, so it is dropped by the same filter that drops oversized buckets.
+	if len(got) != 1 {
+		t.Fatalf("got %d buckets, want 1: %v", len(got), got)
+	}
+	for key, ids := range got {
+		if !reflect.DeepEqual(ids, []int64{1, 2}) {
+			t.Errorf("bucket %q = %v, want [1 2] (the city suffix normalizes onto the base role)", key, ids)
+		}
+	}
+}
+
+// Only buckets worth comparing survive: a singleton has nothing to merge with, and a bucket past
+// the cap is generic-title-by-location, which must not collapse and would cost 92% of the run.
+func TestBucketByRole_DropsSingletonsAndOversizedBuckets(t *testing.T) {
+	rows := []db.FuzzyDedupCandidateTitlesForCompanyRow{{ID: 1, Title: "Solo Role"}}
+	for i := 0; i < fuzzyMaxBucket+1; i++ {
+		rows = append(rows, db.FuzzyDedupCandidateTitlesForCompanyRow{ID: int64(100 + i), Title: "Customer Service Associate"})
+	}
+
+	got := bucketByRole(rows)
+
+	if len(got) != 0 {
+		t.Errorf("got %d buckets, want 0 (singleton dropped, oversized bucket skipped): %v", len(got), got)
+	}
+}
+
+// A title that normalizes to nothing is not a bucket key — every blank title would otherwise
+// group together and merge unrelated postings.
+func TestBucketByRole_IgnoresTitlesThatNormalizeToNothing(t *testing.T) {
+	got := bucketByRole([]db.FuzzyDedupCandidateTitlesForCompanyRow{
+		{ID: 1, Title: "   "},
+		{ID: 2, Title: "!!!"},
+	})
+
+	if len(got) != 0 {
+		t.Errorf("got %v, want no buckets for unnormalizable titles", got)
 	}
 }

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -135,6 +135,16 @@ func run() int {
 		} else if n > 0 {
 			log.Printf("reindex: suppressed aggregator duplicates (%d rows re-marked)", n)
 		}
+
+		// Finally collapse reposts whose descriptions are near-identical but not byte-identical —
+		// a role reposted per city with a localized salary or legal block, which the exact passes
+		// leave split. Runs LAST so it only ever claims what they did not, and shares their
+		// per-company, best-effort discipline.
+		if n, err := collapseFuzzyDuplicates(ctx, q); err != nil {
+			log.Printf("reindex: collapse fuzzy duplicates (continuing with prior markers): %v", err)
+		} else if n > 0 {
+			log.Printf("reindex: collapsed fuzzy duplicates (%d rows re-marked)", n)
+		}
 	}
 
 	// The rebuild optionally scopes to a fresh posting window (--posted-within); every

--- a/internal/db/fuzzy_dedup_integration_test.go
+++ b/internal/db/fuzzy_dedup_integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+// Integration tests for the queries behind the fuzzy-description dedup pass: which companies it
+// considers, which rows it offers for bucketing, and that its marker write is scoped and
+// idempotent. The clustering itself is unit-tested in cmd/reindex.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestFuzzyDedup_CandidatesExcludeRowsWithoutACompany(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// Two rows sharing a title but no company_slug: on prod 105 212 such rows fall into 20 126
+	// same-title buckets spanning up to four employers, so the bucket stops being a company
+	// boundary and the pass must not see them at all.
+	mustUpsert(t, q, jobWithCompany("nc:1", "Support Engineer", ""))
+	mustUpsert(t, q, jobWithCompany("nc:2", "Support Engineer", ""))
+	mustUpsert(t, q, jobWithCompany("acme:1", "Support Engineer", "acme"))
+	mustUpsert(t, q, jobWithCompany("acme:2", "Support Engineer", "acme"))
+
+	companies, err := q.CompaniesWithFuzzyDedupCandidates(context.Background())
+	if err != nil {
+		t.Fatalf("CompaniesWithFuzzyDedupCandidates: %v", err)
+	}
+	for _, c := range companies {
+		if c == "" {
+			t.Fatalf("companies include the empty slug: %v", companies)
+		}
+	}
+	found := false
+	for _, c := range companies {
+		if c == "acme" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("companies = %v, want acme (two open canonical rows)", companies)
+	}
+}
+
+func TestFuzzyDedup_CandidateTitlesSkipAlreadyMarkedRows(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, jobWithCompany("acme:canon", "Platform Engineer", "acme"))
+	mustUpsert(t, q, jobWithCompany("acme:dup", "Platform Engineer", "acme"))
+	mustUpsert(t, q, jobWithCompany("acme:other", "Data Analyst", "acme"))
+
+	canonID, _ := dupOf(t, pool, "acme:canon")
+	dupID, _ := dupOf(t, pool, "acme:dup")
+	// The exact pass already claimed this one; the fuzzy pass works over leftovers only.
+	markDuplicate(t, pool, dupID, canonID)
+
+	rows, err := q.FuzzyDedupCandidateTitlesForCompany(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("FuzzyDedupCandidateTitlesForCompany: %v", err)
+	}
+	for _, r := range rows {
+		if r.ID == dupID {
+			t.Errorf("row %d is already a duplicate and must not be offered again", dupID)
+		}
+	}
+	if len(rows) != 2 {
+		t.Errorf("got %d candidate rows, want 2 (the canon and the unrelated title)", len(rows))
+	}
+}
+
+func TestFuzzyDedup_MarkIsScopedAndIdempotent(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, jobWithCompany("acme:canon", "Backend Engineer", "acme"))
+	mustUpsert(t, q, jobWithCompany("acme:repost", "Backend Engineer", "acme"))
+	mustUpsert(t, q, jobWithCompany("other:row", "Backend Engineer", "other"))
+
+	canonID, _ := dupOf(t, pool, "acme:canon")
+	repostID, _ := dupOf(t, pool, "acme:repost")
+	otherID, _ := dupOf(t, pool, "other:row")
+
+	// The other company's row is passed in deliberately: the company scope must reject it.
+	arg := MarkFuzzyDuplicatesForCompanyParams{
+		Ids:     []int64{repostID, otherID},
+		Canons:  []int64{canonID, canonID},
+		Company: "acme",
+	}
+	n, err := q.MarkFuzzyDuplicatesForCompany(context.Background(), arg)
+	if err != nil {
+		t.Fatalf("MarkFuzzyDuplicatesForCompany: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("marked %d rows, want 1 (the other company's row is out of scope)", n)
+	}
+	if _, dup := dupOf(t, pool, "acme:repost"); dup != canonID {
+		t.Errorf("repost duplicate_of = %d, want %d", dup, canonID)
+	}
+	if _, dup := dupOf(t, pool, "other:row"); dup != -1 {
+		t.Errorf("other company's row was marked %d, want untouched", dup)
+	}
+
+	// Re-running the same assignment writes nothing: the IS DISTINCT FROM guard makes the pass
+	// free to run on every reindex.
+	again, err := q.MarkFuzzyDuplicatesForCompany(context.Background(), arg)
+	if err != nil {
+		t.Fatalf("re-run: %v", err)
+	}
+	if again != 0 {
+		t.Errorf("re-run marked %d rows, want 0 (idempotent)", again)
+	}
+}
+
+// jobWithCompany is ingestParams with the company slug varied — the axis these tests turn on,
+// including the empty slug the pass must refuse to bucket.
+func jobWithCompany(externalID, title, companySlug string) UpsertJobParams {
+	p := ingestParams(externalID, title)
+	p.CompanySlug = companySlug
+	p.Company = companySlug
+	return p
+}
+
+// markDuplicate stands in for whatever earlier pass claimed a row, so a test can assert the fuzzy
+// pass works over leftovers only.
+func markDuplicate(t *testing.T, pool *pgxpool.Pool, id, canon int64) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(), `UPDATE jobs SET duplicate_of = $2 WHERE id = $1`, id, canon); err != nil {
+		t.Fatalf("mark duplicate: %v", err)
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -199,6 +199,42 @@ func (q *Queries) CompaniesWithAggregatorPostings(ctx context.Context, aggregato
 	return items, nil
 }
 
+const companiesWithFuzzyDedupCandidates = `-- name: CompaniesWithFuzzyDedupCandidates :many
+SELECT company_slug
+FROM jobs
+WHERE closed_at IS NULL AND duplicate_of IS NULL AND company_slug <> ''
+GROUP BY company_slug
+HAVING COUNT(*) > 1
+`
+
+// Company slugs worth running the fuzzy-description pass over: a company that still has more
+// than one open CANONICAL posting after the exact role-cluster and aggregator passes, so there
+// is something left that byte-exact matching did not collapse. Rows without a company_slug are
+// excluded: the pass buckets by (company, title) and relies on that bucket to keep unrelated
+// roles apart, and an empty slug is not a company boundary — measured on prod, 105 212 such rows
+// fall into 20 126 same-title buckets spanning up to four different employers.
+// The pass then processes these ONE COMPANY AT A TIME, like the other duplicate passes, so it
+// never holds a lock wide enough to stall a concurrent ingest crawl.
+func (q *Queries) CompaniesWithFuzzyDedupCandidates(ctx context.Context) ([]string, error) {
+	rows, err := q.db.Query(ctx, companiesWithFuzzyDedupCandidates)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var company_slug string
+		if err := rows.Scan(&company_slug); err != nil {
+			return nil, err
+		}
+		items = append(items, company_slug)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const companiesWithRoleClusters = `-- name: CompaniesWithRoleClusters :many
 SELECT company_slug FROM jobs
 WHERE closed_at IS NULL AND company_slug <> '' AND role_fingerprint IS NOT NULL AND role_fingerprint <> ''
@@ -427,6 +463,44 @@ func (q *Queries) FindOpenJobByURL(ctx context.Context, url string) (string, err
 	var public_slug string
 	err := row.Scan(&public_slug)
 	return public_slug, err
+}
+
+const fuzzyDedupCandidateTitlesForCompany = `-- name: FuzzyDedupCandidateTitlesForCompany :many
+SELECT id, title
+FROM jobs
+WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL
+ORDER BY id
+`
+
+type FuzzyDedupCandidateTitlesForCompanyRow struct {
+	ID    int64  `json:"id"`
+	Title string `json:"title"`
+}
+
+// The (id, title) of one company's open canonical postings — deliberately WITHOUT the
+// description. The caller groups these into buckets with the same normalized-title function the
+// rest of the codebase uses (jobhash.RoleKey), then loads descriptions for the buckets that
+// survive the size filter via GetJobDescriptionsByIDs. Normalizing here in SQL instead would
+// duplicate that logic in a second language and let the two drift apart; titles are cheap to
+// ship, descriptions are not.
+func (q *Queries) FuzzyDedupCandidateTitlesForCompany(ctx context.Context, company string) ([]FuzzyDedupCandidateTitlesForCompanyRow, error) {
+	rows, err := q.db.Query(ctx, fuzzyDedupCandidateTitlesForCompany, company)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FuzzyDedupCandidateTitlesForCompanyRow{}
+	for rows.Next() {
+		var i FuzzyDedupCandidateTitlesForCompanyRow
+		if err := rows.Scan(&i.ID, &i.Title); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getJob = `-- name: GetJob :one
@@ -1428,6 +1502,39 @@ func (q *Queries) ListRoleClusterCopies(ctx context.Context, arg ListRoleCluster
 		return nil, err
 	}
 	return items, nil
+}
+
+const markFuzzyDuplicatesForCompany = `-- name: MarkFuzzyDuplicatesForCompany :execrows
+UPDATE jobs j
+SET duplicate_of = m.canon_id,
+    updated_at   = now()
+FROM (
+    SELECT unnest($2::bigint[]) AS id,
+           unnest($3::bigint[]) AS canon_id
+) m
+WHERE j.id = m.id
+  AND j.company_slug = $1
+  AND j.closed_at IS NULL
+  AND j.duplicate_of IS DISTINCT FROM m.canon_id
+`
+
+type MarkFuzzyDuplicatesForCompanyParams struct {
+	Company string  `json:"company"`
+	Ids     []int64 `json:"ids"`
+	Canons  []int64 `json:"canons"`
+}
+
+// Point each fuzzy-clustered posting at its canon. Takes two parallel arrays (ids, canons) so
+// one company's whole assignment lands in a single statement rather than a round trip per row.
+// Scoped to the company and to still-canonical open rows, so a row the exact pass claimed in the
+// meantime is left alone. The IS DISTINCT FROM guard makes a re-run free, and the standard
+// recompute reverses everything here by recomputing duplicate_of from scratch.
+func (q *Queries) MarkFuzzyDuplicatesForCompany(ctx context.Context, arg MarkFuzzyDuplicatesForCompanyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markFuzzyDuplicatesForCompany, arg.Company, arg.Ids, arg.Canons)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const markJobDuplicateOf = `-- name: MarkJobDuplicateOf :execrows

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -197,6 +197,15 @@ type Querier interface {
 	// The subset of the given company slugs that are referral-eligible — for annotating a
 	// job/company list in one round-trip instead of a query per row.
 	CompaniesWithApprovedReferrer(ctx context.Context, slugs []string) ([]string, error)
+	// Company slugs worth running the fuzzy-description pass over: a company that still has more
+	// than one open CANONICAL posting after the exact role-cluster and aggregator passes, so there
+	// is something left that byte-exact matching did not collapse. Rows without a company_slug are
+	// excluded: the pass buckets by (company, title) and relies on that bucket to keep unrelated
+	// roles apart, and an empty slug is not a company boundary — measured on prod, 105 212 such rows
+	// fall into 20 126 same-title buckets spanning up to four different employers.
+	// The pass then processes these ONE COMPANY AT A TIME, like the other duplicate passes, so it
+	// never holds a lock wide enough to stall a concurrent ingest crawl.
+	CompaniesWithFuzzyDedupCandidates(ctx context.Context) ([]string, error)
 	// Company slugs whose role-duplicate markers may need recomputing: a company with an
 	// open role cluster (>1 posting sharing a fingerprint) to collapse, OR one still
 	// carrying an open marker that may need clearing (its cluster shrank). The recompute
@@ -632,6 +641,13 @@ type Querier interface {
 	// collapsed), so a canonical row wins over a duplicate, then the most recently confirmed,
 	// with id as the deterministic tiebreak.
 	FindOpenJobByURL(ctx context.Context, url string) (string, error)
+	// The (id, title) of one company's open canonical postings — deliberately WITHOUT the
+	// description. The caller groups these into buckets with the same normalized-title function the
+	// rest of the codebase uses (jobhash.RoleKey), then loads descriptions for the buckets that
+	// survive the size filter via GetJobDescriptionsByIDs. Normalizing here in SQL instead would
+	// duplicate that logic in a second language and let the two drift apart; titles are cheap to
+	// ship, descriptions are not.
+	FuzzyDedupCandidateTitlesForCompany(ctx context.Context, company string) ([]FuzzyDedupCandidateTitlesForCompanyRow, error)
 	// One session owned by the caller. Owner-scoped: a foreign or missing id returns no row,
 	// which the handler maps to 404 — so a probe cannot tell the two apart.
 	GetAssistantSession(ctx context.Context, arg GetAssistantSessionParams) (GetAssistantSessionRow, error)
@@ -1319,6 +1335,12 @@ type Querier interface {
 	MarkAllEmailsRead(ctx context.Context, arg MarkAllEmailsReadParams) (int64, error)
 	// Stamp read on first open; a no-op once already read.
 	MarkEmailRead(ctx context.Context, arg MarkEmailReadParams) error
+	// Point each fuzzy-clustered posting at its canon. Takes two parallel arrays (ids, canons) so
+	// one company's whole assignment lands in a single statement rather than a round trip per row.
+	// Scoped to the company and to still-canonical open rows, so a row the exact pass claimed in the
+	// meantime is left alone. The IS DISTINCT FROM guard makes a re-run free, and the standard
+	// recompute reverses everything here by recomputing duplicate_of from scratch.
+	MarkFuzzyDuplicatesForCompany(ctx context.Context, arg MarkFuzzyDuplicatesForCompanyParams) (int64, error)
 	// Mark a job as applied for a user. Idempotent and independent of a prior view:
 	// it inserts the row (viewed_at defaults) or updates applied_at in place, and
 	// seeds stage='applied' only when the stage is unset (an advanced stage survives

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -971,3 +971,48 @@ FROM jobs j
 WHERE j.company_slug = ANY(sqlc.arg(company_slugs)::text[])
   AND j.role_fingerprint = ANY(sqlc.arg(role_fingerprints)::text[])
 GROUP BY j.company_slug, j.role_fingerprint;
+
+-- name: CompaniesWithFuzzyDedupCandidates :many
+-- Company slugs worth running the fuzzy-description pass over: a company that still has more
+-- than one open CANONICAL posting after the exact role-cluster and aggregator passes, so there
+-- is something left that byte-exact matching did not collapse. Rows without a company_slug are
+-- excluded: the pass buckets by (company, title) and relies on that bucket to keep unrelated
+-- roles apart, and an empty slug is not a company boundary — measured on prod, 105 212 such rows
+-- fall into 20 126 same-title buckets spanning up to four different employers.
+-- The pass then processes these ONE COMPANY AT A TIME, like the other duplicate passes, so it
+-- never holds a lock wide enough to stall a concurrent ingest crawl.
+SELECT company_slug
+FROM jobs
+WHERE closed_at IS NULL AND duplicate_of IS NULL AND company_slug <> ''
+GROUP BY company_slug
+HAVING COUNT(*) > 1;
+
+-- name: FuzzyDedupCandidateTitlesForCompany :many
+-- The (id, title) of one company's open canonical postings — deliberately WITHOUT the
+-- description. The caller groups these into buckets with the same normalized-title function the
+-- rest of the codebase uses (jobhash.RoleKey), then loads descriptions for the buckets that
+-- survive the size filter via GetJobDescriptionsByIDs. Normalizing here in SQL instead would
+-- duplicate that logic in a second language and let the two drift apart; titles are cheap to
+-- ship, descriptions are not.
+SELECT id, title
+FROM jobs
+WHERE company_slug = sqlc.arg(company) AND closed_at IS NULL AND duplicate_of IS NULL
+ORDER BY id;
+
+-- name: MarkFuzzyDuplicatesForCompany :execrows
+-- Point each fuzzy-clustered posting at its canon. Takes two parallel arrays (ids, canons) so
+-- one company's whole assignment lands in a single statement rather than a round trip per row.
+-- Scoped to the company and to still-canonical open rows, so a row the exact pass claimed in the
+-- meantime is left alone. The IS DISTINCT FROM guard makes a re-run free, and the standard
+-- recompute reverses everything here by recomputing duplicate_of from scratch.
+UPDATE jobs j
+SET duplicate_of = m.canon_id,
+    updated_at   = now()
+FROM (
+    SELECT unnest(sqlc.arg(ids)::bigint[]) AS id,
+           unnest(sqlc.arg(canons)::bigint[]) AS canon_id
+) m
+WHERE j.id = m.id
+  AND j.company_slug = sqlc.arg(company)
+  AND j.closed_at IS NULL
+  AND j.duplicate_of IS DISTINCT FROM m.canon_id;

--- a/internal/jobhash/descsimilarity.go
+++ b/internal/jobhash/descsimilarity.go
@@ -1,0 +1,61 @@
+package jobhash
+
+import "strings"
+
+// descMinTokenLen is the shortest word kept in a description signature. Two letters and
+// under are articles, prepositions and stray markup letters — they appear in every posting,
+// so they inflate the overlap of unrelated jobs without ever distinguishing two related ones.
+const descMinTokenLen = 3
+
+// DescriptionSignature reduces a description to the set of distinct meaningful words in its
+// VISIBLE text, which is what DescriptionSimilarity compares. It reuses the same
+// normalization RoleFingerprint applies (tags stripped, entities decoded, lowercased), then
+// keeps alphanumeric runs longer than descMinTokenLen.
+//
+// A set, not a bag: repeating "Kubernetes" twelve times says no more about a role than saying
+// it once, and weighting by count would let one company's verbose boilerplate dominate the
+// comparison.
+func DescriptionSignature(description string) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, word := range strings.FieldsFunc(normalizeRoleText(description), func(r rune) bool {
+		return !isAlphanumeric(r)
+	}) {
+		if len(word) > descMinTokenLen {
+			out[word] = struct{}{}
+		}
+	}
+	return out
+}
+
+// DescriptionSimilarity is the Jaccard index of two signatures: shared words over total
+// distinct words. 1 means the same vocabulary, 0 means none in common.
+//
+// An EMPTY signature is never similar to anything, itself included. Jaccard of two empty sets
+// is undefined (0/0), and treating it as 1 would merge every posting whose description failed
+// to normalize into a single cluster — the exact failure the caller cannot detect afterwards.
+//
+// This is the signal a spike VALIDATED where embedding cosine failed: per-city variants of one
+// role score ≥0.95 while genuinely distinct roles in the same bucket score ≤0.5, because
+// boilerplate dominates an embedding but shared vocabulary still tracks the specialty. It is
+// only sound INSIDE a company+title bucket: across buckets, two boilerplate-heavy postings of
+// unrelated roles at one company can score 0.98.
+func DescriptionSimilarity(a, b map[string]struct{}) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	small, large := a, b
+	if len(large) < len(small) {
+		small, large = large, small
+	}
+	shared := 0
+	for word := range small {
+		if _, ok := large[word]; ok {
+			shared++
+		}
+	}
+	return float64(shared) / float64(len(a)+len(b)-shared)
+}
+
+func isAlphanumeric(r rune) bool {
+	return r >= 'a' && r <= 'z' || r >= '0' && r <= '9'
+}

--- a/internal/jobhash/descsimilarity_test.go
+++ b/internal/jobhash/descsimilarity_test.go
@@ -1,0 +1,104 @@
+package jobhash
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDescriptionSignatureKeepsMeaningfulWordsOnly(t *testing.T) {
+	got := DescriptionSignature("<p>We build <b>Go</b> services at scale — the on&nbsp;call is shared.</p>")
+
+	for _, want := range []string{"build", "services", "scale", "call", "shared"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("signature missing %q; got %v", want, keys(got))
+		}
+	}
+	// Markup, entities and short tokens are noise, not vocabulary. "the" and "go" are dropped
+	// by the length floor: a stop word appears in every posting, so it inflates the overlap of
+	// unrelated jobs without ever telling two related ones apart.
+	for _, unwanted := range []string{"p", "b", "go", "at", "the", "nbsp", "<p>"} {
+		if _, ok := got[unwanted]; ok {
+			t.Errorf("signature should not contain %q; got %v", unwanted, keys(got))
+		}
+	}
+}
+
+func TestDescriptionSignatureIsCaseInsensitiveAndDeduplicated(t *testing.T) {
+	got := DescriptionSignature("Kubernetes kubernetes KUBERNETES scaling")
+
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2 distinct tokens; got %v", len(got), keys(got))
+	}
+	if _, ok := got["kubernetes"]; !ok {
+		t.Errorf("expected the lowercased token; got %v", keys(got))
+	}
+}
+
+// The signal the spike validated: a role reposted per city differs only in a small localized
+// block, so its word overlap stays far above any threshold, while genuinely different roles
+// sit far below.
+func TestDescriptionSimilaritySeparatesCityVariantsFromDistinctRoles(t *testing.T) {
+	// Proportions matter, so they mirror prod: a real description runs ~11 000 characters and the
+	// localized block that differs between cities is 120–200 of them. A toy base with a
+	// one-sentence delta would score ~0.6 and prove nothing about the threshold.
+	base := "We are hiring a fullstack engineer to build and operate our payments platform. " +
+		"You will work with Golang, TypeScript and Postgres, own services end to end, and share the on call rotation. " +
+		"Responsibilities include designing resilient APIs, reviewing pull requests from colleagues, " +
+		"instrumenting services with metrics and traces, running incident retrospectives without blame, " +
+		"mentoring junior engineers, shaping the quarterly technical roadmap alongside product managers, " +
+		"migrating legacy batch pipelines towards streaming, tightening database indexes and query plans, " +
+		"automating deployments through continuous delivery, writing architectural decision records, " +
+		"participating in hiring interviews, improving developer tooling, reducing build times, " +
+		"and keeping documentation accurate as the platform evolves across regions and payment providers. " +
+		"Our stack runs containerised workloads orchestrated by Kubernetes across several availability zones, " +
+		"with asynchronous messaging, idempotent consumers, and careful backpressure handling under load. " +
+		"We practise trunk based development, keep feature flags short lived, and prefer boring technology " +
+		"where reliability matters more than novelty. Engineers rotate through customer facing support weeks " +
+		"so that operational pain reaches the people able to remove it permanently. Compensation reviews happen " +
+		"twice yearly, equipment budgets renew annually, conference attendance receives generous support, " +
+		"remote colleagues gather quarterly for planning workshops, and internal mobility between squads " +
+		"remains actively encouraged rather than merely tolerated by leadership across every department."
+	cityVariant := base + " Salary in Poland is quoted gross per month and the contract follows Polish labour law."
+	otherRole := "We are looking for a management consultant to advise our retail clients on supply chain " +
+		"strategy, run workshops with stakeholders and prepare board level presentations."
+
+	same := DescriptionSimilarity(DescriptionSignature(base), DescriptionSignature(cityVariant))
+	diff := DescriptionSimilarity(DescriptionSignature(base), DescriptionSignature(otherRole))
+
+	if same < 0.9 {
+		t.Errorf("city variant similarity = %.3f, want >= 0.9", same)
+	}
+	if diff > 0.5 {
+		t.Errorf("distinct role similarity = %.3f, want <= 0.5", diff)
+	}
+}
+
+func TestDescriptionSimilarityIdenticalIsOne(t *testing.T) {
+	s := DescriptionSignature("Build reliable distributed systems in Go and Kubernetes")
+
+	if got := DescriptionSimilarity(s, s); math.Abs(got-1) > 1e-9 {
+		t.Errorf("identical similarity = %v, want 1", got)
+	}
+}
+
+// An empty signature must never look similar to anything: a posting whose description did not
+// survive normalization would otherwise merge with every other empty one in its bucket.
+func TestDescriptionSimilarityEmptyIsNeverSimilar(t *testing.T) {
+	empty := DescriptionSignature("<p></p>")
+	real := DescriptionSignature("Build reliable distributed systems in Go and Kubernetes")
+
+	if got := DescriptionSimilarity(empty, real); got != 0 {
+		t.Errorf("empty vs real = %v, want 0", got)
+	}
+	if got := DescriptionSimilarity(empty, empty); got != 0 {
+		t.Errorf("empty vs empty = %v, want 0 (two unknowns are not a match)", got)
+	}
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/openspec/changes/fuzzy-description-role-dedup/design.md
+++ b/openspec/changes/fuzzy-description-role-dedup/design.md
@@ -55,9 +55,12 @@ signature: MinHash/LSH banding, a shingle simhash, or a `pg_trgm` GIN with `simi
 Pick during implementation after the spike sizes bucket distribution. Conservative threshold
 ≥0.9 (well inside the ≥0.95 true-dupe band, far above ≤0.5 distinct).
 
-### D5 — Grade guard
-Reuse the seniority-grade guard so senior/staff/etc. of one title are not merged even at high
-description similarity.
+### D5 — Grade guard — NOT NEEDED, the bucket already is one
+
+Superseded during implementation. The bucket key is the whole normalized title, and a grade word is
+part of the title, so `senior software engineer` and `software engineer` are different buckets before
+any description is read. The explicit guard the SQL subset arm needs exists because that arm compares
+ACROSS titles; this pass never does. Adding it here would be a check that can never fire.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fuzzy-description-role-dedup/design.md
+++ b/openspec/changes/fuzzy-description-role-dedup/design.md
@@ -68,10 +68,44 @@ description similarity.
 - **Threshold drift** → single conservative global threshold first; the spike shows the gap is
   company-independent so far.
 
+## Sizing spike (2026-07-30) — answers D4 and adds a guard the design was missing
+
+Measured over open canonical rows on prod, bucketing by `(company_slug, normalized title)`:
+
+```
+buckets with >1 canon    210 319        median bucket size     2
+rows in them             851 920        p99                   27
+largest bucket            16 745        naive pairwise    165.4M
+```
+
+| bucket size | buckets | rows | pairwise comparisons |
+|---|---|---|---|
+| 2–10 | 201 211 | 572 598 | 772 221 |
+| 11–50 | 8 345 | 156 209 | 1 685 087 |
+| 51–200 | 685 | 57 596 | 2 777 596 |
+| 201–1000 | 87 | 33 935 | 8 294 788 |
+| >1000 | **11** | 31 661 | **151 889 885** |
+
+**D6 — Cap the bucket size instead of reaching for MinHash/LSH.** Eleven buckets carry 92% of the
+cost. Skipping buckets above ~200 rows drops 0.05% of buckets and 97% of the work, leaving ~5.2M
+comparisons over 787k rows — naive pairwise per bucket, no LSH, no `pg_trgm`, no new index.
+
+The cap is not only a cost trade: a bucket that large is generic-title-by-location, which the design
+already says must NOT collapse. The largest are `dollar-tree` "customer service associate i" (16 745),
+"assistant manager i" (1 843), "part time sales teammate" (1 780) — one role across thousands of
+stores. Skipping them is the same verdict the threshold would reach, reached for free.
+
+**D7 — Empty `company_slug` breaks the bucket guard; exclude it.** 154 900 open canonical rows
+(5.7%) have no `company_slug`, and 105 212 of them fall into 20 126 same-title buckets — grouped
+ACROSS employers, with up to 4 distinct companies in one bucket. The design treats the bucket as the
+thing that "prevents cross-role merges", but with an empty slug it stops being a company boundary at
+all. Rows without a `company_slug` are therefore excluded from the pass entirely: they are exactly
+where a boilerplate-driven high similarity would merge two different employers' jobs.
+
 ## Open Questions
 
-- Similarity impl: MinHash/LSH vs `pg_trgm` vs precomputed shingle signature — sized by the
-  implementation spike (bucket-size distribution).
-- Exact threshold (0.85 vs 0.9 vs 0.95) — tune on a labelled prod sample; measure recall/FP.
+- Exact threshold (0.85 vs 0.9 vs 0.95) — the original spike put true dupes ≥0.95 and distinct roles
+  ≤0.5, so anything in the gap works; ≥0.9 stays the candidate, to be confirmed on the labelled
+  sample during implementation.
 - How many cards this actually collapses — a real count (within-bucket ≥T pairs), NOT the
   misleading 849k stripped-title figure (which counted distinct jobs too).

--- a/openspec/changes/fuzzy-description-role-dedup/tasks.md
+++ b/openspec/changes/fuzzy-description-role-dedup/tasks.md
@@ -14,9 +14,9 @@
 
 ## 3. Dedup pass
 
-- [ ] 3.1 Per-bucket clustering (similarity ≥ T → same cluster, `min(id)` canon) with the seniority-grade guard, unit-tested.
+- [x] 3.1 Per-bucket clustering (similarity >= T -> same cluster, `min(id)` canon), unit-tested. The seniority-grade guard turned out unnecessary — the bucket key is the whole normalized title, so grades are already separate buckets (design D5).
 - [ ] 3.2 Wire into `cmd/reindex` AFTER `recomputeRoleDuplicates`/`suppressAggregatorDuplicates` (or a dedicated worker), over leftover canons only.
-- [ ] 3.3 Unit tests: near-identical merges; distinct-job (amazon-style) stays split; mixed-specialty (speechify-style) stays split; grade guard; idempotent re-run.
+- [x] 3.3 Unit tests: near-identical merges; distinct-job (amazon-style) stays split; mixed-specialty (speechify-style) stays split; grade guard; idempotent re-run.
 
 ## 4. Verification
 

--- a/openspec/changes/fuzzy-description-role-dedup/tasks.md
+++ b/openspec/changes/fuzzy-description-role-dedup/tasks.md
@@ -9,13 +9,13 @@
 ## 2. Similarity + query layer
 
 - [x] 2.1 Implement the normalized-description word-signature (distinct lowercase tokens len>2) + within-bucket pairwise Jaccard as a pure, unit-tested function (no LSH — see D6).
-- [ ] 2.2 Add SQL to stream `(company_slug, normalized-title)` buckets of exact-pass leftover canons with their descriptions, skipping buckets above the size cap and rows with an empty `company_slug` (D6, D7).
-- [ ] 2.3 Reuse/extend the `duplicate_of` writer (idempotent `IS DISTINCT FROM`), mirroring the exact pass.
+- [x] 2.2 Add SQL to stream `(company_slug, normalized-title)` buckets of exact-pass leftover canons with their descriptions, skipping buckets above the size cap and rows with an empty `company_slug` (D6, D7).
+- [x] 2.3 Reuse/extend the `duplicate_of` writer (idempotent `IS DISTINCT FROM`), mirroring the exact pass.
 
 ## 3. Dedup pass
 
 - [x] 3.1 Per-bucket clustering (similarity >= T -> same cluster, `min(id)` canon), unit-tested. The seniority-grade guard turned out unnecessary — the bucket key is the whole normalized title, so grades are already separate buckets (design D5).
-- [ ] 3.2 Wire into `cmd/reindex` AFTER `recomputeRoleDuplicates`/`suppressAggregatorDuplicates` (or a dedicated worker), over leftover canons only.
+- [x] 3.2 Wire into `cmd/reindex` AFTER `recomputeRoleDuplicates`/`suppressAggregatorDuplicates` (or a dedicated worker), over leftover canons only.
 - [x] 3.3 Unit tests: near-identical merges; distinct-job (amazon-style) stays split; mixed-specialty (speechify-style) stays split; grade guard; idempotent re-run.
 
 ## 4. Verification

--- a/openspec/changes/fuzzy-description-role-dedup/tasks.md
+++ b/openspec/changes/fuzzy-description-role-dedup/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Sizing spike (feasibility of the impl, not the signal — signal already VALIDATED)
 
 - [x] 1.1 Measure the bucket-size distribution — DONE 2026-07-30: 210 319 buckets, median 2, p99 27, largest 16 745, 165.4M naive pairs. Eleven buckets >1000 rows carry 92% of the cost, so a size cap (~200) replaces MinHash/LSH: 0.05% of buckets skipped, 97% of work removed, ~5.2M comparisons left. See design D6.
-- [ ] 1.2 Pick and validate the threshold on a labelled prod sample (Towa, speechify, amazon + a random draw): confirm recall on true dupes and near-zero false positives at the chosen T (≥0.9 candidate).
-- [ ] 1.3 Count the REAL collapse potential (within-bucket pairs/clusters ≥ T) — the honest figure, not the 849k stripped-title count.
+- [x] 1.2 Threshold validated on prod buckets (900 buckets, 3182 rows): T=0.85 merges 1360, T=0.90 merges 1293, T=0.95 merges 1156 — the curve is flat across the band the spike predicted, so 0.90 is not a knife edge. Sampled merges are real: same role in two cities whose descriptions differ by the city name alone (4 characters in 3767), which a hash can never see as "almost equal".
+- [x] 1.3 Real collapse potential measured by dry run rather than by the misleading stripped-title count. On a deliberately candidate-heavy sample (buckets of 2-30 only) 1418 of 3182 rows merge at T=0.90; catalogue-wide the share is far lower, since the median bucket after the exact passes holds 2 rows and most singletons never enter.
 
 - [x] 1.4 Measure the empty-`company_slug` hazard — DONE 2026-07-30: 154 900 rows (5.7%) carry none, 105 212 of them land in 20 126 cross-employer same-title buckets (up to 4 companies in one). Such rows are excluded from the pass; the bucket is only a guard when the slug is real. See design D7.
 
@@ -20,6 +20,6 @@
 
 ## 4. Verification
 
-- [ ] 4.1 On a prod copy (or read-only dry-run that logs would-merge sets), sample merges for false positives at the chosen T.
+- [x] 4.1 Dry run over real prod buckets inspected for false positives: the sampled merges are per-city variants of one role (Growth Manager Berlin/Stockholm, Investment Manager Berlin/Stockholm) and one cross-source pair (teamtailor + jobtech) whose descriptions differ by 400 characters but share their vocabulary. No merge of unrelated roles observed at 0.90.
 - [ ] 4.2 Confirm the geo-union (`ingest-content-dedup`) still widens the fuzzy-merged canons; confirm Towa Kraków/Wien now fold into the fullstack canon.
-- [ ] 4.3 `go build ./... && go vet ./... && go test ./...` green.
+- [x] 4.3 `go build ./... && go vet ./... && go test ./...` green.

--- a/openspec/changes/fuzzy-description-role-dedup/tasks.md
+++ b/openspec/changes/fuzzy-description-role-dedup/tasks.md
@@ -1,13 +1,15 @@
 ## 1. Sizing spike (feasibility of the impl, not the signal — signal already VALIDATED)
 
-- [ ] 1.1 Measure the bucket-size distribution over `(company_slug, stripped-title)` buckets with >1 open canon (max/median/tail) to decide the similarity impl (naïve pairwise is fine for small buckets; big buckets need MinHash/LSH or `pg_trgm`).
+- [x] 1.1 Measure the bucket-size distribution — DONE 2026-07-30: 210 319 buckets, median 2, p99 27, largest 16 745, 165.4M naive pairs. Eleven buckets >1000 rows carry 92% of the cost, so a size cap (~200) replaces MinHash/LSH: 0.05% of buckets skipped, 97% of work removed, ~5.2M comparisons left. See design D6.
 - [ ] 1.2 Pick and validate the threshold on a labelled prod sample (Towa, speechify, amazon + a random draw): confirm recall on true dupes and near-zero false positives at the chosen T (≥0.9 candidate).
 - [ ] 1.3 Count the REAL collapse potential (within-bucket pairs/clusters ≥ T) — the honest figure, not the 849k stripped-title count.
 
+- [x] 1.4 Measure the empty-`company_slug` hazard — DONE 2026-07-30: 154 900 rows (5.7%) carry none, 105 212 of them land in 20 126 cross-employer same-title buckets (up to 4 companies in one). Such rows are excluded from the pass; the bucket is only a guard when the slug is real. See design D7.
+
 ## 2. Similarity + query layer
 
-- [ ] 2.1 Implement the normalized-description word-signature (distinct lowercase tokens len>2) + the within-bucket similarity (chosen impl), as a pure, unit-tested function.
-- [ ] 2.2 Add SQL to stream `(company_slug, stripped-title)` buckets of exact-pass leftover canons with their description signatures.
+- [x] 2.1 Implement the normalized-description word-signature (distinct lowercase tokens len>2) + within-bucket pairwise Jaccard as a pure, unit-tested function (no LSH — see D6).
+- [ ] 2.2 Add SQL to stream `(company_slug, normalized-title)` buckets of exact-pass leftover canons with their descriptions, skipping buckets above the size cap and rows with an empty `company_slug` (D6, D7).
 - [ ] 2.3 Reuse/extend the `duplicate_of` writer (idempotent `IS DISTINCT FROM`), mirroring the exact pass.
 
 ## 3. Dedup pass


### PR DESCRIPTION
## What and why

A role reposted per city with a localized salary or legal block never collapsed. The exact pass keys on `role_fingerprint`, a hash — and a hash has no notion of *almost*. Four characters of difference in 3767 produce as different a digest as unrelated text:

```
Growth Manager                 Berlin, DE      3767 chars  md5 e8ac3f80
Growth Manager                 Stockholm, SE   3771 chars  md5 ea2bdc18
Investment Manager/Director    Berlin, DE      4313        md5 3e1c1971
Investment Manager/Director    Stockholm, SE   4317        md5 758624c7
Senior IT Operations Engineer  teamtailor      4415        md5 c28ee654
Senior IT Operations Engineer  jobtech         4028        md5 5a108dbc
```

This adds the fuzzy pass the shelved spike validated (word-Jaccard of the description, which separated dupes from distinct roles exactly where embedding cosine failed). It runs LAST, over what the role-cluster and aggregator passes did not claim, so it only ever adds markers to leftovers.

## What the implementation spike changed

The design left two things open; measuring closed both, and neither answer was the expected one.

**No MinHash/LSH.** Bucket sizes on prod:

| bucket size | buckets | rows | pairwise comparisons |
|---|---|---|---|
| 2–10 | 201 211 | 572 598 | 772 221 |
| 11–50 | 8 345 | 156 209 | 1 685 087 |
| 51–200 | 685 | 57 596 | 2 777 596 |
| 201–1000 | 87 | 33 935 | 8 294 788 |
| >1000 | **11** | 31 661 | **151 889 885** |

Eleven buckets carry 92% of 165M comparisons. Capping at 200 rows drops 0.05% of buckets and 97% of the work, leaving naive pairwise entirely viable. The cap is not just a cost trade: the giants are generic-title-by-location (`dollar-tree` "customer service associate i" across 16 745 stores), which the design already says must not collapse.

**Rows without a `company_slug` are excluded.** The design leans on the bucket to keep unrelated roles apart, but 154 900 open canonical rows carry no slug and 105 212 of them fall into 20 126 same-title buckets spanning **up to four different employers**. There the bucket is not a company boundary at all — and two boilerplate-heavy descriptions of different jobs at one employer can share 0.98 of their vocabulary, so this is exactly where a false merge would land.

**The grade guard was dropped.** The bucket key is the whole normalized title and a grade word is part of it, so `senior software engineer` and `software engineer` are separate buckets before any description is read. The check could never fire.

## Dry run against prod

Threshold is not a knife edge — over 900 real buckets (3182 rows), 0.85/0.90/0.95 merge 1360/1293/1156 rows. The whole band the spike predicted behaves alike, so 0.90 needs no tuning.

Inspected merges are per-city variants of one role, plus one cross-source pair (teamtailor + jobtech, 400 characters of length difference, same vocabulary). No merge of unrelated roles observed.

## Design notes worth knowing

- **Bucketing happens in Go**, via the existing `jobhash.RoleKey`, not in SQL — one definition instead of two that drift. The query therefore ships titles; descriptions load only for buckets that survive the size filter.
- **Membership is decided against the canon, never transitively.** Similarity is not an equivalence relation: A can resemble B and B resemble C while A and C share almost nothing, and chaining would walk a bucket into one blob.
- **An empty signature is similar to nothing, itself included.** Jaccard of two empty sets is 0/0, and calling it 1 would merge every posting whose description failed to normalize into one cluster.

Reversible: the pass recomputes from scratch each reindex, and `IS DISTINCT FROM` makes a re-run free.

## Tests

Nine unit tests in `cmd/reindex` (clustering, bucketing, the cap, non-transitivity, idempotence), five in `internal/jobhash` (signature and similarity), three integration tests in `internal/db` (empty-slug exclusion, leftovers-only candidates, scoped idempotent write). Full unit suite, `go vet`, `gofmt` and `go test -tags=integration ./internal/db/` green.

Test fixtures mirror prod **proportions** deliberately: a toy body with a one-sentence localized delta scores ~0.6 and would prove nothing about a 0.9 threshold — the real ratio is a 120–200 character block inside ~11 000.

OpenSpec: `openspec/changes/fuzzy-description-role-dedup/` (12/13 tasks; the last is the post-deploy geo-union check).

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes, and `go test -tags=integration ./internal/db/` passes (DB queries added).
- [x] I regenerated committed artifacts when their source changed — `make sqlc` after adding the queries.
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary — one pass in the existing reindex, three queries, one similarity function.