### PR TITLE
feat(web): span the header edge to edge on the full-viewport surfaces

### DIFF
--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -9,6 +9,7 @@
   import HeaderMenu from './HeaderMenu.svelte';
   import BrandMark from './BrandMark.svelte';
   import { safeRedirect } from '$lib/safeRedirect';
+  import { isFullBleedRoute } from '$lib/shellLayout';
 
   // The header is three slots — logo | search | menu — identical on every
   // viewport. Nav links, the account items, the theme toggle, and the auth
@@ -30,6 +31,12 @@
           ? 'company'
           : null,
   );
+
+  // On the full-viewport surfaces (the agent, the tailor workspace) the page below runs
+  // edge to edge under its own icon rail, so the header drops the centered `max-w-6xl`
+  // and does the same: brand hard left, menu hard right. The search keeps a readable
+  // width and centers itself in the gap rather than stretching across the monitor.
+  const fullBleed = $derived(isFullBleedRoute(page.url.pathname));
 
   // The auth dialog lives at the layout level but its open state is a shared
   // singleton (see auth-dialog.svelte), so deep components — like a job's Save
@@ -71,24 +78,44 @@
      containing block for the mobile menu's `position: fixed` full-screen drawer,
      pinning it to the header instead of the viewport and breaking it. -->
 <header class="sticky top-0 z-40 border-b border-border bg-background">
-  <div class="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:gap-4">
-    <a
-      href={resolve('/')}
-      class="flex shrink-0 items-center gap-2 text-sm font-semibold tracking-tight"
-    >
-      <BrandMark />
-      <span class="hidden sm:inline">freehire</span>
-    </a>
+  <div
+    class={[
+      'mx-auto flex h-14 items-center gap-3 px-4 sm:gap-4',
+      fullBleed ? 'max-w-none' : 'max-w-6xl',
+    ]}
+  >
+    <!-- Full-bleed only: the two side slots grow from a zero basis, so the free space
+         splits evenly between them and the search sits on the container's axis — the
+         menu cluster is wider than the brand, so centering the middle slot on its own
+         leftover space would push it visibly off-centre. `basis-0` also keeps them from
+         shrinking (shrink scales the basis), so the narrow layout is untouched. -->
+    <div class={['flex shrink-0 items-center', fullBleed && 'flex-1 basis-0']}>
+      <a
+        href={resolve('/')}
+        class="flex items-center gap-2 text-sm font-semibold tracking-tight"
+      >
+        <BrandMark />
+        <span class="hidden sm:inline">freehire</span>
+      </a>
+    </div>
 
-    {#if listKind === 'jobs' || listKind === 'company'}
-      <HeaderListSearch placeholder="Search jobs…" />
-    {:else if listKind === 'companies'}
-      <HeaderListSearch placeholder="Search companies…" />
-    {:else}
-      <HeaderSearch />
-    {/if}
+    <!-- The slot, not the search component, owns the middle width: each search root is
+         `min-w-0 flex-1`, so it fills whatever this wrapper is given. Full-bleed gives it
+         a 48rem basis so it lands at that width instead of an even third of the row; the
+         cap then hands the rest back to the side slots, which keeps it on the axis. -->
+    <div class={['flex min-w-0 flex-1', fullBleed && 'max-w-3xl basis-3xl']}>
+      {#if listKind === 'jobs' || listKind === 'company'}
+        <HeaderListSearch placeholder="Search jobs…" />
+      {:else if listKind === 'companies'}
+        <HeaderListSearch placeholder="Search companies…" />
+      {:else}
+        <HeaderSearch />
+      {/if}
+    </div>
 
-    <HeaderMenu />
+    <div class={['flex shrink-0 items-center', fullBleed && 'flex-1 basis-0 justify-end']}>
+      <HeaderMenu />
+    </div>
   </div>
 </header>
 

--- a/web/src/lib/shellLayout.test.ts
+++ b/web/src/lib/shellLayout.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { isFullBleedRoute } from './shellLayout';
+
+describe('isFullBleedRoute', () => {
+  it('covers the agent, with and without a session id', () => {
+    expect(isFullBleedRoute('/my/assistant')).toBe(true);
+    expect(isFullBleedRoute('/my/assistant/0f0b1e3a-1c2d-4e5f-8a9b-0c1d2e3f4a5b')).toBe(true);
+  });
+
+  it('covers the tailor workspace', () => {
+    expect(isFullBleedRoute('/tailor/senior-go-engineer-acme')).toBe(true);
+  });
+
+  it('leaves the rest of the account shell centered', () => {
+    expect(isFullBleedRoute('/my')).toBe(false);
+    expect(isFullBleedRoute('/my/cvs')).toBe(false);
+  });
+
+  it('does not catch the tailor marketing page, which is a normal document', () => {
+    expect(isFullBleedRoute('/features/tailor')).toBe(false);
+  });
+
+  it('does not match on a prefix that only looks like the agent', () => {
+    expect(isFullBleedRoute('/my/assistants')).toBe(false);
+  });
+});

--- a/web/src/lib/shellLayout.ts
+++ b/web/src/lib/shellLayout.ts
@@ -1,0 +1,15 @@
+// Which routes render as a full-bleed, app-like shell rather than a centered document.
+// Kept as a pure predicate (not inline in TopBar) so the list of such routes is
+// unit-testable and lives in one place. These pages size themselves as
+// `h-[calc(100dvh-3.5rem)]` — the viewport minus the header — and carry their own
+// left-edge icon rail, so a header centered inside `max-w-6xl` would float above a page
+// that already reaches both screen edges.
+
+/** True on the agent chat and the CV tailoring workspace, the two full-viewport surfaces. */
+export function isFullBleedRoute(pathname: string): boolean {
+  return (
+    pathname === '/my/assistant' ||
+    pathname.startsWith('/my/assistant/') ||
+    pathname.startsWith('/tailor/')
+  );
+}


### PR DESCRIPTION
## What

On the two app-like surfaces — the agent (`/my/assistant`) and the CV tailoring workspace (`/tailor/:slug`) — the header now spans the full width: brand hard left, menu hard right. Every other route is untouched and keeps its centred `max-w-6xl` row.

Both pages size themselves as `h-[calc(100dvh-3.5rem)]` and carry their own left-edge icon rail, so the header was the one element still floating in a centred column above a page that already reached both screen edges.

## How

`isFullBleedRoute(pathname)` lands in `web/src/lib/shellLayout.ts` as a pure, unit-tested predicate rather than inline in `TopBar` — the route list stays in one place, and it reads `page.url.pathname` instead of a store the page would publish, since the header renders on SSR before the page does (a store would flash the narrow header on the first frame).

The three header slots turn symmetric on those routes:

| Slot | Full-bleed classes |
|---|---|
| Brand | `flex-1 basis-0` |
| Search | `flex-1 basis-3xl max-w-3xl` |
| Menu | `flex-1 basis-0 justify-end` |

Centring the search on its own leftover space (`mx-auto`) puts it 34px off — the menu cluster is wider than the brand. Growing both side slots from a zero basis splits the free space evenly instead. The search's 48rem basis keeps it at a readable width: without it, three equal `flex-1` slots collapsed the field to an even third of the row (482px at 1512).

`basis-0` on the side slots also means they never shrink (shrink scales the basis), so the narrow layout degrades exactly as before — the middle slot absorbs the whole deficit.

## Verification

`pnpm check` — 0 errors. `pnpm vitest run src/lib/shellLayout.test.ts` — 5 passed.

Screenshots of `/tailor/:slug`:

| Viewport | Search box | Field centre / viewport centre |
|---|---|---|
| 1512 | 372–1140 (768px) | 756 / 756 |
| 1920 | 576–1344 (768px) | 960 / 960 |
| 768 | shrinks to fit, no overflow | — |

The homepage at 1512 is pixel-identical to before (brand at 196, menu at 1298). Headless Chrome misrenders below ~500px, so the narrow layout was confirmed at 768 instead.