### PR TITLE
fix(web): stop the apply button from passing link authority

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -186,14 +186,18 @@
 
 <!-- The apply CTA renders twice: inline in the header on desktop, and in the
      mobile sticky bar at the end of the article. Sole difference is size + layout
-     classes, so both share this snippet. -->
+     classes, so both share this snippet.
+     nofollow: the destination is the posting's own site, which the catalogue never
+     vetted — the same stance the description sanitizer takes on in-body links
+     (internal/sources/sanitize.go). Without it a submitted vacancy buys a followed
+     link from every job page, which is what the SEO submissions are actually after. -->
 {#snippet applyCta(size: 'md' | 'lg', className: string)}
   <Button
     variant="primary"
     {size}
     href={job.url}
     target="_blank"
-    rel="noopener noreferrer"
+    rel="nofollow noopener noreferrer"
     onclick={onApplyClick}
     class={className}
   >


### PR DESCRIPTION
## Why

The `/moderation` queue turned out to be a backlink target, not a vacancy feed. Every submission that arrived between 2026-07-27 and 2026-07-30 (#2–#5) was MSP marketing copy dressed as a job:

- the URL points at the company's homepage or a services page, never a job page;
- the exact-match keyword phrase is repeated and pushed into the job title ("Managed IT Services Charlotte – IT Support Specialist");
- one submission shipped its brief verbatim: `Keyword: Managed IT Services Denver`;
- two are not even framed as hiring — they pitch services, or ask for an MSP *vendor*.

One was approved by mistake and went live. It has since been closed and dropped from the search index; the other three are rejected.

## What

`internal/sources/sanitize.go` already sets `RequireNoFollowOnLinks(true)`, so links inside a description were defanged. The apply CTA — the single outbound link on every job page — was not, and that is the link being farmed. This adds `nofollow` to it.

Blanket, not gated on `manually_added`: the destination is the posting's own site, which the catalogue never vetted, so an ATS link has no stronger claim to an endorsement than a submitted one — and a blanket rule needs no per-source branch to maintain.

Both renders of the CTA (desktop header, mobile sticky bar) share one `{#snippet}`, so this is the only place. The remaining outbound job links (`/contribute`, `/my/submissions`, `/moderation`) are behind auth and unreachable by a crawler.

## Verification

`pnpm run check` — 0 errors, 17 pre-existing warnings, none in this file.

## Not in this PR

The submission path itself is unchanged: any day-old account can still put a row in front of a moderator. At four a week that is fine. If the volume grows, the cheapest next filter is a "does this URL look like a job page" check — all four spammers submitted a bare domain root.