### PR TITLE
Turn the silence badge into a next step

### DIFF
--- a/internal/db/mail_linking.sql.go
+++ b/internal/db/mail_linking.sql.go
@@ -35,7 +35,7 @@ func (q *Queries) ConfirmEmailLink(ctx context.Context, arg ConfirmEmailLinkPara
 }
 
 const getUserApplication = `-- name: GetUserApplication :one
-SELECT viewed_at, saved_at, applied_at, stage, notes
+SELECT viewed_at, saved_at, applied_at, stage, notes, followed_up_at
 FROM user_jobs
 WHERE user_id = $1 AND job_id = $2
 `
@@ -46,11 +46,12 @@ type GetUserApplicationParams struct {
 }
 
 type GetUserApplicationRow struct {
-	ViewedAt  pgtype.Timestamptz `json:"viewed_at"`
-	SavedAt   pgtype.Timestamptz `json:"saved_at"`
-	AppliedAt pgtype.Timestamptz `json:"applied_at"`
-	Stage     pgtype.Text        `json:"stage"`
-	Notes     pgtype.Text        `json:"notes"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
 }
 
 // The caller's interaction row for one job (the application-detail header).
@@ -63,6 +64,7 @@ func (q *Queries) GetUserApplication(ctx context.Context, arg GetUserApplication
 		&i.AppliedAt,
 		&i.Stage,
 		&i.Notes,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }

--- a/internal/db/mail_linking.sql.go
+++ b/internal/db/mail_linking.sql.go
@@ -35,9 +35,24 @@ func (q *Queries) ConfirmEmailLink(ctx context.Context, arg ConfirmEmailLinkPara
 }
 
 const getUserApplication = `-- name: GetUserApplication :one
-SELECT viewed_at, saved_at, applied_at, stage, notes, followed_up_at
-FROM user_jobs
-WHERE user_id = $1 AND job_id = $2
+SELECT uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes, uj.followed_up_at,
+       (CASE WHEN uj.applied_at IS NOT NULL THEN
+          GREATEST(uj.applied_at,
+                   (SELECT max(e.received_at)
+                      FROM emails e
+                     WHERE e.user_id = uj.user_id
+                       AND e.job_id = uj.job_id
+                       AND e.deleted_at IS NULL))
+        END)::timestamptz AS last_activity_at,
+       (uj.applied_at IS NOT NULL AND EXISTS (
+          SELECT 1
+            FROM emails e
+           WHERE e.user_id = uj.user_id
+             AND e.suggested_job_id = uj.job_id
+             AND e.job_id IS NULL
+             AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
+FROM user_jobs uj
+WHERE uj.user_id = $1 AND uj.job_id = $2
 `
 
 type GetUserApplicationParams struct {
@@ -46,15 +61,20 @@ type GetUserApplicationParams struct {
 }
 
 type GetUserApplicationRow struct {
-	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
-	SavedAt      pgtype.Timestamptz `json:"saved_at"`
-	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
-	Stage        pgtype.Text        `json:"stage"`
-	Notes        pgtype.Text        `json:"notes"`
-	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
+	ViewedAt             pgtype.Timestamptz `json:"viewed_at"`
+	SavedAt              pgtype.Timestamptz `json:"saved_at"`
+	AppliedAt            pgtype.Timestamptz `json:"applied_at"`
+	Stage                pgtype.Text        `json:"stage"`
+	Notes                pgtype.Text        `json:"notes"`
+	FollowedUpAt         pgtype.Timestamptz `json:"followed_up_at"`
+	LastActivityAt       pgtype.Timestamptz `json:"last_activity_at"`
+	HasPendingSuggestion bool               `json:"has_pending_suggestion"`
 }
 
 // The caller's interaction row for one job (the application-detail header).
+// last_activity_at and has_pending_suggestion mirror ListUserJobs deliberately: the follow-up gate
+// must reach the same silence verdict as the badge on the board, and two derivations of one rule
+// drift. See the column comment in 0059 for why followed_up_at is NOT part of the activity.
 func (q *Queries) GetUserApplication(ctx context.Context, arg GetUserApplicationParams) (GetUserApplicationRow, error) {
 	row := q.db.QueryRow(ctx, getUserApplication, arg.UserID, arg.JobID)
 	var i GetUserApplicationRow
@@ -65,6 +85,8 @@ func (q *Queries) GetUserApplication(ctx context.Context, arg GetUserApplication
 		&i.Stage,
 		&i.Notes,
 		&i.FollowedUpAt,
+		&i.LastActivityAt,
+		&i.HasPendingSuggestion,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -615,15 +615,16 @@ type UserIdentity struct {
 }
 
 type UserJob struct {
-	UserID      int64              `json:"user_id"`
-	JobID       int64              `json:"job_id"`
-	ViewedAt    pgtype.Timestamptz `json:"viewed_at"`
-	AppliedAt   pgtype.Timestamptz `json:"applied_at"`
-	SavedAt     pgtype.Timestamptz `json:"saved_at"`
-	Stage       pgtype.Text        `json:"stage"`
-	Notes       pgtype.Text        `json:"notes"`
-	DismissedAt pgtype.Timestamptz `json:"dismissed_at"`
-	Vote        pgtype.Int2        `json:"vote"`
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
 }
 
 type UserJobAnalysis struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1537,6 +1537,14 @@ type Querier interface {
 	// aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
 	// idempotent, and a closed canon fails over to the next min(id) on the next run.
 	RecomputeRoleDuplicatesForCompany(ctx context.Context, company string) (int64, error)
+	// Record that the candidate chased a silent application. Owner-scoped: a foreign or untracked job
+	// matches no row, so the handler 404s and nothing is written. Idempotent by design — a double click
+	// just overwrites the timestamp with a later one rather than erroring.
+	//
+	// Only an application can be chased: a job merely viewed or saved has nobody to chase, which is why
+	// applied_at must be set. This is NOT fed into the last-activity derivation above; see the column
+	// comment in 0059 for why a chase must not clear the silence it was a response to.
+	RecordApplicationFollowUp(ctx context.Context, arg RecordApplicationFollowUpParams) (pgtype.Timestamptz, error)
 	// Count a failed crawl: bump consecutive_failures, record the error, stamp the run,
 	// and RETURN the new failure count so the caller can compute the cooldown (the backoff
 	// policy lives in Go, not here). The cooldown itself is applied by SetBoardCooldown.

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -800,6 +800,9 @@ type Querier interface {
 	// when none has been computed. Derived only — never the raw CV text.
 	GetUserATSAnalysis(ctx context.Context, id int64) ([]byte, error)
 	// The caller's interaction row for one job (the application-detail header).
+	// last_activity_at and has_pending_suggestion mirror ListUserJobs deliberately: the follow-up gate
+	// must reach the same silence verdict as the badge on the board, and two derivations of one rule
+	// drift. See the column comment in 0059 for why followed_up_at is NOT part of the activity.
 	GetUserApplication(ctx context.Context, arg GetUserApplicationParams) (GetUserApplicationRow, error)
 	// Login lookup. Case-insensitive on email; returns password_hash so the handler
 	// can verify the password (and reject accounts that have none). role feeds the

--- a/internal/db/queries/mail_linking.sql
+++ b/internal/db/queries/mail_linking.sql
@@ -1,8 +1,26 @@
 -- name: GetUserApplication :one
 -- The caller's interaction row for one job (the application-detail header).
-SELECT viewed_at, saved_at, applied_at, stage, notes, followed_up_at
-FROM user_jobs
-WHERE user_id = $1 AND job_id = $2;
+-- last_activity_at and has_pending_suggestion mirror ListUserJobs deliberately: the follow-up gate
+-- must reach the same silence verdict as the badge on the board, and two derivations of one rule
+-- drift. See the column comment in 0059 for why followed_up_at is NOT part of the activity.
+SELECT uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes, uj.followed_up_at,
+       (CASE WHEN uj.applied_at IS NOT NULL THEN
+          GREATEST(uj.applied_at,
+                   (SELECT max(e.received_at)
+                      FROM emails e
+                     WHERE e.user_id = uj.user_id
+                       AND e.job_id = uj.job_id
+                       AND e.deleted_at IS NULL))
+        END)::timestamptz AS last_activity_at,
+       (uj.applied_at IS NOT NULL AND EXISTS (
+          SELECT 1
+            FROM emails e
+           WHERE e.user_id = uj.user_id
+             AND e.suggested_job_id = uj.job_id
+             AND e.job_id IS NULL
+             AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
+FROM user_jobs uj
+WHERE uj.user_id = $1 AND uj.job_id = $2;
 
 -- name: ListJobEmails :many
 -- The emails linked to one of the caller's applications, newest first, for the

--- a/internal/db/queries/mail_linking.sql
+++ b/internal/db/queries/mail_linking.sql
@@ -1,6 +1,6 @@
 -- name: GetUserApplication :one
 -- The caller's interaction row for one job (the application-detail header).
-SELECT viewed_at, saved_at, applied_at, stage, notes
+SELECT viewed_at, saved_at, applied_at, stage, notes, followed_up_at
 FROM user_jobs
 WHERE user_id = $1 AND job_id = $2;
 

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -148,6 +148,7 @@ SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.
          WHERE r.user_id = uj.user_id
            AND r.job_id = jobs.id
            AND r.status = 'pending') AS reminder_fire_at,
+       uj.followed_up_at,
        -- last_activity_at is when this application last moved: its apply date, or
        -- the newest message linked to it when that is later. GREATEST ignores a
        -- NULL aggregate, so an application with no mail falls back to applied_at
@@ -311,3 +312,16 @@ FROM user_jobs
 WHERE user_id = $1
   AND (applied_at IS NOT NULL OR stage IS NOT NULL)
 GROUP BY stage;
+
+-- name: RecordApplicationFollowUp :one
+-- Record that the candidate chased a silent application. Owner-scoped: a foreign or untracked job
+-- matches no row, so the handler 404s and nothing is written. Idempotent by design — a double click
+-- just overwrites the timestamp with a later one rather than erroring.
+--
+-- Only an application can be chased: a job merely viewed or saved has nobody to chase, which is why
+-- applied_at must be set. This is NOT fed into the last-activity derivation above; see the column
+-- comment in 0059 for why a chase must not clear the silence it was a response to.
+UPDATE user_jobs
+SET followed_up_at = now()
+WHERE user_id = $1 AND job_id = $2 AND applied_at IS NOT NULL
+RETURNING followed_up_at;

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -15,7 +15,7 @@ const clearJobProgress = `-- name: ClearJobProgress :one
 UPDATE user_jobs
 SET stage = NULL, applied_at = NULL
 WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 `
 
 type ClearJobProgressParams struct {
@@ -37,6 +37,7 @@ func (q *Queries) ClearJobProgress(ctx context.Context, arg ClearJobProgressPara
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }
@@ -141,7 +142,7 @@ const dismissJob = `-- name: DismissJob :one
 INSERT INTO user_jobs (user_id, job_id, dismissed_at)
 VALUES ($1, $2, now())
 ON CONFLICT (user_id, job_id) DO UPDATE SET dismissed_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 `
 
 type DismissJobParams struct {
@@ -165,6 +166,7 @@ func (q *Queries) DismissJob(ctx context.Context, arg DismissJobParams) (UserJob
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }
@@ -306,6 +308,7 @@ SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.compan
          WHERE r.user_id = uj.user_id
            AND r.job_id = jobs.id
            AND r.status = 'pending') AS reminder_fire_at,
+       uj.followed_up_at,
        -- last_activity_at is when this application last moved: its apply date, or
        -- the newest message linked to it when that is later. GREATEST ignores a
        -- NULL aggregate, so an application with no mail falls back to applied_at
@@ -369,6 +372,7 @@ type ListUserJobsRow struct {
 	Notes                pgtype.Text        `json:"notes"`
 	EmailCount           int64              `json:"email_count"`
 	ReminderFireAt       pgtype.Timestamptz `json:"reminder_fire_at"`
+	FollowedUpAt         pgtype.Timestamptz `json:"followed_up_at"`
 	LastActivityAt       pgtype.Timestamptz `json:"last_activity_at"`
 	HasPendingSuggestion bool               `json:"has_pending_suggestion"`
 }
@@ -458,6 +462,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Notes,
 			&i.EmailCount,
 			&i.ReminderFireAt,
+			&i.FollowedUpAt,
 			&i.LastActivityAt,
 			&i.HasPendingSuggestion,
 		); err != nil {
@@ -542,12 +547,12 @@ WITH prior AS (
               ELSE now()
           END,
           stage = COALESCE(user_jobs.stage, 'applied')
-    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 ), bump AS (
     UPDATE jobs SET applied_count = applied_count + 1
     WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior WHERE prior.applied_at IS NOT NULL)
 )
-SELECT user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote FROM upsert
+SELECT user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at FROM upsert
 `
 
 type MarkJobAppliedParams struct {
@@ -557,15 +562,16 @@ type MarkJobAppliedParams struct {
 }
 
 type MarkJobAppliedRow struct {
-	UserID      int64              `json:"user_id"`
-	JobID       int64              `json:"job_id"`
-	ViewedAt    pgtype.Timestamptz `json:"viewed_at"`
-	AppliedAt   pgtype.Timestamptz `json:"applied_at"`
-	SavedAt     pgtype.Timestamptz `json:"saved_at"`
-	Stage       pgtype.Text        `json:"stage"`
-	Notes       pgtype.Text        `json:"notes"`
-	DismissedAt pgtype.Timestamptz `json:"dismissed_at"`
-	Vote        pgtype.Int2        `json:"vote"`
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
 }
 
 // Mark a job as applied for a user. Idempotent and independent of a prior view:
@@ -598,15 +604,42 @@ func (q *Queries) MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) 
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
+}
+
+const recordApplicationFollowUp = `-- name: RecordApplicationFollowUp :one
+UPDATE user_jobs
+SET followed_up_at = now()
+WHERE user_id = $1 AND job_id = $2 AND applied_at IS NOT NULL
+RETURNING followed_up_at
+`
+
+type RecordApplicationFollowUpParams struct {
+	UserID int64 `json:"user_id"`
+	JobID  int64 `json:"job_id"`
+}
+
+// Record that the candidate chased a silent application. Owner-scoped: a foreign or untracked job
+// matches no row, so the handler 404s and nothing is written. Idempotent by design — a double click
+// just overwrites the timestamp with a later one rather than erroring.
+//
+// Only an application can be chased: a job merely viewed or saved has nobody to chase, which is why
+// applied_at must be set. This is NOT fed into the last-activity derivation above; see the column
+// comment in 0059 for why a chase must not clear the silence it was a response to.
+func (q *Queries) RecordApplicationFollowUp(ctx context.Context, arg RecordApplicationFollowUpParams) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, recordApplicationFollowUp, arg.UserID, arg.JobID)
+	var followed_up_at pgtype.Timestamptz
+	err := row.Scan(&followed_up_at)
+	return followed_up_at, err
 }
 
 const recordJobView = `-- name: RecordJobView :one
 INSERT INTO user_jobs (user_id, job_id)
 VALUES ($1, $2)
 ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 `
 
 type RecordJobViewParams struct {
@@ -633,6 +666,7 @@ func (q *Queries) RecordJobView(ctx context.Context, arg RecordJobViewParams) (U
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }
@@ -665,7 +699,7 @@ const saveJob = `-- name: SaveJob :one
 INSERT INTO user_jobs (user_id, job_id, saved_at)
 VALUES ($1, $2, now())
 ON CONFLICT (user_id, job_id) DO UPDATE SET saved_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 `
 
 type SaveJobParams struct {
@@ -688,6 +722,7 @@ func (q *Queries) SaveJob(ctx context.Context, arg SaveJobParams) (UserJob, erro
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }
@@ -698,7 +733,7 @@ VALUES ($1, $2, $3, $4)
 ON CONFLICT (user_id, job_id) DO UPDATE
   SET stage = COALESCE(EXCLUDED.stage, user_jobs.stage),
       notes = COALESCE(EXCLUDED.notes, user_jobs.notes)
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 `
 
 type TrackJobParams struct {
@@ -730,6 +765,7 @@ func (q *Queries) TrackJob(ctx context.Context, arg TrackJobParams) (UserJob, er
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }
@@ -738,7 +774,7 @@ const undismissJob = `-- name: UndismissJob :one
 UPDATE user_jobs
 SET dismissed_at = NULL
 WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 `
 
 type UndismissJobParams struct {
@@ -763,6 +799,7 @@ func (q *Queries) UndismissJob(ctx context.Context, arg UndismissJobParams) (Use
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }
@@ -771,7 +808,7 @@ const unsaveJob = `-- name: UnsaveJob :one
 UPDATE user_jobs
 SET saved_at = NULL
 WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 `
 
 type UnsaveJobParams struct {
@@ -795,6 +832,7 @@ func (q *Queries) UnsaveJob(ctx context.Context, arg UnsaveJobParams) (UserJob, 
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }
@@ -803,7 +841,7 @@ const untrackJob = `-- name: UntrackJob :one
 UPDATE user_jobs
 SET saved_at = NULL, applied_at = NULL, stage = NULL, notes = NULL
 WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 `
 
 type UntrackJobParams struct {
@@ -826,6 +864,7 @@ func (q *Queries) UntrackJob(ctx context.Context, arg UntrackJobParams) (UserJob
 		&i.Notes,
 		&i.DismissedAt,
 		&i.Vote,
+		&i.FollowedUpAt,
 	)
 	return i, err
 }

--- a/internal/db/user_jobs_silence_integration_test.go
+++ b/internal/db/user_jobs_silence_integration_test.go
@@ -206,3 +206,59 @@ func TestLastActivityNullForNonApplications(t *testing.T) {
 		t.Error("has_pending_suggestion = true on a saved-only job")
 	}
 }
+
+// TestAFollowUpDoesNotStopTheSilenceClock is the invariant the follow-up feature is built on: a
+// chase the candidate sends is not a reply, so recording one must leave last_activity_at — and
+// therefore the days silent and the silence state — exactly where they were. Folding
+// followed_up_at into the derivation would clear the badge at the moment it matters most, and
+// would tell the board an answer arrived when none did.
+func TestAFollowUpDoesNotStopTheSilenceClock(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+
+	uid := seedAPIKeyUser(t, pool, "silence-followup@example.test")
+	jid := insertJob(t, pool, "silence-followup-1")
+	applied := time.Now().Add(-24 * 24 * time.Hour).UTC().Truncate(time.Second)
+	applyAt(t, q, uid, jid, applied)
+
+	before := trackedRow(t, q, uid, "all")
+
+	got, err := q.RecordApplicationFollowUp(context.Background(),
+		RecordApplicationFollowUpParams{UserID: uid, JobID: jid})
+	if err != nil {
+		t.Fatalf("record follow-up: %v", err)
+	}
+	if !got.Valid {
+		t.Fatal("recorded follow-up returned no timestamp")
+	}
+
+	after := trackedRow(t, q, uid, "all")
+	if !sameSecond(after.LastActivityAt, applied) {
+		t.Errorf("last_activity_at = %v after a follow-up, want it unchanged at the apply date %v",
+			after.LastActivityAt, applied)
+	}
+	if !sameSecond(after.LastActivityAt, before.LastActivityAt.Time) {
+		t.Errorf("last_activity_at moved from %v to %v — a chase is not a reply",
+			before.LastActivityAt, after.LastActivityAt)
+	}
+	if !after.FollowedUpAt.Valid {
+		t.Error("followed_up_at is unset on the tracked row; the board cannot say the application was chased")
+	}
+}
+
+// TestFollowUpIsRefusedForANonApplication: a job merely viewed or saved has nobody to chase.
+func TestFollowUpIsRefusedForANonApplication(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+
+	uid := seedAPIKeyUser(t, pool, "silence-followup-2@example.test")
+	jid := insertJob(t, pool, "silence-followup-2")
+	if _, err := q.SaveJob(context.Background(), SaveJobParams{UserID: uid, JobID: jid}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if _, err := q.RecordApplicationFollowUp(context.Background(),
+		RecordApplicationFollowUpParams{UserID: uid, JobID: jid}); err == nil {
+		t.Error("recording a follow-up on a saved-but-not-applied job succeeded; want no row")
+	}
+}

--- a/internal/followup/followup.go
+++ b/internal/followup/followup.go
@@ -1,0 +1,105 @@
+// Package followup assembles the message a candidate sends when an application has gone quiet.
+//
+// It is deterministic and I/O-free (the shape internal/atscheck and internal/verdict use): the same
+// application drafts the same text, no model is called, and nothing here can invent a claim about
+// the candidate. The one non-generic sentence is supplied by the caller from the cached fit
+// analysis, which derived it from the candidate's own CV; when there is none, the line is omitted
+// rather than filled.
+//
+// The tone rules are the product and are pinned by tests: no apology, no "just checking in", and a
+// concrete question, because a chase nobody can answer is a nudge that reads as noise.
+package followup
+
+import "strings"
+
+// Input is everything the draft is built from. Strength and RecipientName are optional; every
+// other field is expected to be present for an application that has actually been sent.
+type Input struct {
+	Role       string
+	Company    string
+	DaysSilent int
+	// Stage is the application's stage, which decides whether the opening says "I applied" or
+	// "we last spoke" — a candidate who has interviewed did more than apply.
+	Stage string
+	// Strength is one concrete reason the candidate fits, taken from the cached fit analysis.
+	// Empty means the analysis is missing or named none: the line is then dropped.
+	Strength string
+	// RecipientName is the display name from the linked mail's sender, when there is one.
+	RecipientName string
+}
+
+// Message is the assembled draft. Comparable, so a test can assert two runs are identical.
+type Message struct {
+	Subject string
+	Body    string
+}
+
+// Draft assembles the follow-up.
+func Draft(in Input) Message {
+	paragraphs := []string{greeting(in.RecipientName), opening(in)}
+	if s := strings.TrimSpace(in.Strength); s != "" {
+		paragraphs = append(paragraphs, "For context: "+strings.TrimRight(s, ".")+".")
+	}
+	paragraphs = append(paragraphs, ask(in.Stage), "Thanks for your time.")
+
+	return Message{
+		Subject: "Following up: " + in.Role + " application",
+		// Joining a slice rather than appending to a buffer is what keeps an omitted strength from
+		// leaving a blank paragraph behind.
+		Body: strings.Join(paragraphs, "\n\n"),
+	}
+}
+
+func greeting(name string) string {
+	if n := strings.TrimSpace(name); n != "" {
+		return "Hi " + n + ","
+	}
+	return "Hello,"
+}
+
+// opening states what happened and how long ago. A candidate past the application stage has spoken
+// to somebody, and saying "I applied" there would understate the relationship.
+func opening(in Input) string {
+	where := "the " + in.Role + " role"
+	if c := strings.TrimSpace(in.Company); c != "" {
+		where += " at " + c
+	}
+	if in.Stage == "" || in.Stage == "applied" {
+		return "I applied for " + where + " " + elapsed(in.DaysSilent) + " ago and have not had a reply yet."
+	}
+	return "We last spoke about " + where + " " + elapsed(in.DaysSilent) + " ago, and I have not heard since."
+}
+
+// ask matches the question to where the candidate actually is. Asking whether the role is still
+// open after an interview reads as if they do not know they are already in the process.
+func ask(stage string) string {
+	if stage == "" || stage == "applied" {
+		return "Is the role still open, and what is the timeline for the next step?"
+	}
+	return "Where does my application stand, and what are the next steps?"
+}
+
+// elapsed renders the silence in the units a person would use out loud: weeks up to about six, then
+// months. The exact day count lives on the board; a message that says "24 days" reads like a system
+// wrote it.
+func elapsed(days int) string {
+	if days >= 45 {
+		return plural((days+15)/30, "month")
+	}
+	return plural((days+3)/7, "week")
+}
+
+func plural(n int, unit string) string {
+	if n <= 1 {
+		return "a " + unit
+	}
+	return numberWord(n) + " " + unit + "s"
+}
+
+func numberWord(n int) string {
+	words := []string{"", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"}
+	if n < len(words) {
+		return words[n]
+	}
+	return "several"
+}

--- a/internal/followup/followup_test.go
+++ b/internal/followup/followup_test.go
@@ -1,0 +1,155 @@
+package followup
+
+import (
+	"strings"
+	"testing"
+)
+
+func base() Input {
+	return Input{
+		Role:       "Senior Backend Engineer",
+		Company:    "Appinio",
+		DaysSilent: 24,
+		Stage:      "applied",
+	}
+}
+
+func TestDraftNamesTheRoleAndCompany(t *testing.T) {
+	d := Draft(base())
+
+	if !strings.Contains(d.Subject, "Senior Backend Engineer") {
+		t.Errorf("subject = %q, want the role in it", d.Subject)
+	}
+	if !strings.Contains(d.Body, "Appinio") {
+		t.Errorf("body = %q, want the company in it", d.Body)
+	}
+}
+
+func TestDraftIsDeterministic(t *testing.T) {
+	a, b := Draft(base()), Draft(base())
+
+	if a != b {
+		t.Errorf("two drafts of the same input differ:\n%+v\n%+v", a, b)
+	}
+}
+
+func TestDraftStatesTheElapsedTime(t *testing.T) {
+	for _, tc := range []struct {
+		days int
+		want string
+	}{
+		{21, "three weeks"},
+		{24, "three weeks"},
+		{60, "two months"},
+		{7, "a week"},
+	} {
+		in := base()
+		in.DaysSilent = tc.days
+		if got := Draft(in).Body; !strings.Contains(got, tc.want) {
+			t.Errorf("at %d days the body lacks %q:\n%s", tc.days, tc.want, got)
+		}
+	}
+}
+
+func TestDraftStatesTheStrengthWhenThereIsOne(t *testing.T) {
+	in := base()
+	in.Strength = "Scaled a Go service to 2M requests a day"
+
+	if got := Draft(in).Body; !strings.Contains(got, "Scaled a Go service to 2M requests a day") {
+		t.Errorf("body lacks the strength:\n%s", got)
+	}
+}
+
+func TestDraftOmitsTheStrengthLineEntirelyWhenThereIsNone(t *testing.T) {
+	with, without := base(), base()
+	with.Strength = "Scaled a Go service to 2M requests a day"
+
+	a, b := Draft(with).Body, Draft(without).Body
+
+	if a == b {
+		t.Fatal("the strength made no difference to the body")
+	}
+	// No placeholder, no dangling connective, no double blank line where the line was.
+	for _, bad := range []string{"  ", "\n\n\n", "In particular,\n", "particular, ."} {
+		if strings.Contains(b, bad) {
+			t.Errorf("body without a strength contains %q — the line left a hole:\n%s", bad, b)
+		}
+	}
+}
+
+func TestDraftGreetsByNameWhenKnown(t *testing.T) {
+	in := base()
+	in.RecipientName = "Mara"
+
+	if got := Draft(in).Body; !strings.HasPrefix(got, "Hi Mara,") {
+		t.Errorf("body starts %q, want a greeting by name", firstLine(got))
+	}
+}
+
+func TestDraftFallsBackToANeutralGreeting(t *testing.T) {
+	got := Draft(base()).Body
+
+	if strings.Contains(strings.ToLower(firstLine(got)), "hi ,") || strings.Contains(got, "Hi ,") {
+		t.Errorf("greeting collapsed with no name: %q", firstLine(got))
+	}
+	if !strings.HasPrefix(got, "Hello,") {
+		t.Errorf("body starts %q, want a neutral greeting", firstLine(got))
+	}
+}
+
+// TestDraftToneRules pins the product, not the plumbing: a chase that apologises for existing or
+// says "just checking in" is the one the candidate would have written themselves and did not send.
+func TestDraftToneRules(t *testing.T) {
+	in := base()
+	in.Strength = "Led the migration of 12 services to Kubernetes"
+	body := strings.ToLower(Draft(in).Body)
+
+	for _, banned := range []string{
+		"just checking in", "sorry to bother", "i apologise", "i apologize",
+		"i know you're busy", "any update", "passionate", "hoping to hear",
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("body contains the filler %q:\n%s", banned, body)
+		}
+	}
+	if !strings.Contains(body, "?") {
+		t.Error("body asks no question — a chase without an ask is a nudge nobody can answer")
+	}
+}
+
+// TestDraftAsksTheQuestionThatFitsTheStage: after an interview, "is the role still open" reads as
+// if the candidate does not know they are already in the process. The ask has to match where they
+// actually are.
+func TestDraftAsksTheQuestionThatFitsTheStage(t *testing.T) {
+	applied := base()
+	later := base()
+	later.Stage = "interview"
+
+	a, l := Draft(applied).Body, Draft(later).Body
+
+	if !strings.Contains(a, "still open") {
+		t.Errorf("applied-stage ask = %q, want it to ask whether the role is open", a)
+	}
+	if strings.Contains(l, "still open") {
+		t.Errorf("interview-stage ask still asks whether the role is open:\n%s", l)
+	}
+	if !strings.Contains(strings.ToLower(l), "stand") && !strings.Contains(strings.ToLower(l), "decision") {
+		t.Errorf("interview-stage ask = %q, want it to ask where the application stands", l)
+	}
+}
+
+func TestDraftStaysShortEnoughToReadOnAPhone(t *testing.T) {
+	in := base()
+	in.Strength = "Led the migration of 12 services to Kubernetes, cutting deploy time by 40%"
+
+	if words := len(strings.Fields(Draft(in).Body)); words > 120 {
+		t.Errorf("body is %d words, want at most 120", words)
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/handler/followup.go
+++ b/internal/handler/followup.go
@@ -1,0 +1,123 @@
+package handler
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/followup"
+	"github.com/strelov1/freehire/internal/matchanalysis"
+	"github.com/strelov1/freehire/internal/userjob"
+)
+
+// followUpDraftResponse is the wire shape for a chase the candidate sends themselves. Recipient is
+// omitted when nobody ever replied — the commonest silent application — rather than guessed.
+type followUpDraftResponse struct {
+	Subject       string `json:"subject"`
+	Body          string `json:"body"`
+	Recipient     string `json:"recipient,omitempty"`
+	RecipientName string `json:"recipient_name,omitempty"`
+	DaysSilent    int    `json:"days_silent"`
+}
+
+// GetApplicationFollowUp assembles a follow-up draft for a silent application.
+//
+// The gate is the same verdict the board's badge renders: a draft is offered only where
+// userjob.SilenceStateFor says `silent`, so the offer and the badge cannot disagree about which
+// applications qualify. Nothing here sends mail — the draft is handed to the candidate.
+func (h *inboxHandlers) GetApplicationFollowUp(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	job, err := h.queries.GetJobBySlug(c.Context(), c.Params("slug"))
+	if err != nil {
+		return err // ErrNoRows → 404
+	}
+	app, err := h.queries.GetUserApplication(c.Context(), db.GetUserApplicationParams{UserID: userID, JobID: job.ID})
+	if err != nil {
+		return err // ErrNoRows → 404 (caller does not track this job)
+	}
+
+	days := 0
+	if app.LastActivityAt.Valid {
+		days = daysSilent(time.Now(), app.LastActivityAt.Time)
+	}
+	if userjob.SilenceStateFor(pgStr(app.Stage), days, app.HasPendingSuggestion) != userjob.SilenceSilent {
+		return fiber.NewError(fiber.StatusConflict, "this application is not waiting on a reply")
+	}
+
+	addr, name := h.newestSender(c, userID, job.ID)
+	msg := followup.Draft(followup.Input{
+		Role:          job.Title,
+		Company:       job.Company,
+		DaysSilent:    days,
+		Stage:         pgStr(app.Stage),
+		Strength:      h.cachedStrength(c, userID, job.ID),
+		RecipientName: name,
+	})
+	return c.JSON(fiber.Map{"data": followUpDraftResponse{
+		Subject: msg.Subject, Body: msg.Body,
+		Recipient: addr, RecipientName: name, DaysSilent: days,
+	}})
+}
+
+// RecordApplicationFollowUp records that the candidate chased. It does NOT touch the silence
+// derivation: last activity is when the OTHER side moved, and a chase is not a reply (see the
+// column comment in 0059). Idempotent — a double click overwrites the timestamp.
+func (h *inboxHandlers) RecordApplicationFollowUp(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	job, err := h.queries.GetJobBySlug(c.Context(), c.Params("slug"))
+	if err != nil {
+		return err
+	}
+	if _, err := h.queries.RecordApplicationFollowUp(c.Context(),
+		db.RecordApplicationFollowUpParams{UserID: userID, JobID: job.ID}); err != nil {
+		return err // ErrNoRows → 404: not an application of this caller's
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// daysSilent is whole days since the application last moved, floored at zero so a clock skew
+// cannot report a negative silence.
+func daysSilent(now, last time.Time) int {
+	if d := int(now.Sub(last).Hours() / 24); d > 0 {
+		return d
+	}
+	return 0
+}
+
+// newestSender returns the address and display name of the most recent mail linked to the
+// application, or empty strings when nobody ever wrote — which is the normal case for an
+// application that went unanswered, and why the draft is issued without a recipient.
+func (h *inboxHandlers) newestSender(c *fiber.Ctx, userID, jobID int64) (addr, name string) {
+	rows, err := h.queries.ListJobEmails(c.Context(), db.ListJobEmailsParams{
+		UserID: userID, JobID: pgtype.Int8{Int64: jobID, Valid: true},
+	})
+	if err != nil || len(rows) == 0 {
+		return "", ""
+	}
+	return rows[0].FromAddr, rows[0].FromName
+}
+
+// cachedStrength reads one concrete strength from the cached fit analysis — text the analysis
+// derived from the candidate's own CV. No analysis, or one naming none, yields "" and the draft
+// simply omits the line: this is the only source, so the draft cannot invent a claim.
+func (h *inboxHandlers) cachedStrength(c *fiber.Ctx, userID, jobID int64) string {
+	row, err := h.queries.GetUserJobAnalysis(c.Context(),
+		db.GetUserJobAnalysisParams{UserID: userID, JobID: jobID})
+	if err != nil || len(row.Analysis) == 0 {
+		return ""
+	}
+	var a matchanalysis.Analysis
+	if err := json.Unmarshal(row.Analysis, &a); err != nil || len(a.Strengths) == 0 {
+		return ""
+	}
+	return a.Strengths[0]
+}

--- a/internal/handler/followup_integration_test.go
+++ b/internal/handler/followup_integration_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+// Integration tests for the follow-up draft (application-followup-draft): the gate on the silence
+// state, the two recipient paths, and the recorded chase.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// appliedDaysAgo backdates an application so it lands on the far side of its stage's threshold.
+func appliedDaysAgo(t *testing.T, f *agentInboxFixture, jobID int64, days int, stage string) {
+	t.Helper()
+	at := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+	if _, err := f.pool.Exec(context.Background(),
+		`INSERT INTO user_jobs (user_id, job_id, applied_at, stage) VALUES ($1,$2,$3,$4)
+		 ON CONFLICT (user_id, job_id) DO UPDATE SET applied_at = $3, stage = $4`,
+		f.userID, jobID, at, stage); err != nil {
+		t.Fatalf("seed application: %v", err)
+	}
+}
+
+func TestFollowUpDraft_SilentApplicationGetsADraft(t *testing.T) {
+	f := newAgentInboxFixture(t, "fu-silent@example.test")
+	jid := seedJobSlug(t, f.pool, "followup-silent")
+	appliedDaysAgo(t, f, jid, 24, "applied") // past the 21-day `applied` threshold
+
+	status, body := f.callKey(fiber.MethodGet, "/api/v1/me/tracking/followup-silent/followup", nil)
+
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	data, _ := body["data"].(map[string]any)
+	subject, _ := data["subject"].(string)
+	text, _ := data["body"].(string)
+	if subject == "" || text == "" {
+		t.Fatalf("draft = %+v, want a subject and a body", data)
+	}
+	if recipient, ok := data["recipient"].(string); ok && recipient != "" {
+		t.Errorf("recipient = %q, want none: nobody ever replied to this application", recipient)
+	}
+}
+
+func TestFollowUpDraft_ActiveApplicationIsRefused(t *testing.T) {
+	f := newAgentInboxFixture(t, "fu-active@example.test")
+	jid := seedJobSlug(t, f.pool, "followup-active")
+	appliedDaysAgo(t, f, jid, 3, "applied") // well inside the tolerated silence
+
+	status, _ := f.callKey(fiber.MethodGet, "/api/v1/me/tracking/followup-active/followup", nil)
+
+	if status != fiber.StatusConflict {
+		t.Errorf("status = %d, want 409 — an application answering promptly has nothing to chase", status)
+	}
+}
+
+func TestFollowUpDraft_UntrackedSlugIsNotFound(t *testing.T) {
+	f := newAgentInboxFixture(t, "fu-untracked@example.test")
+	seedJobSlug(t, f.pool, "followup-untracked")
+
+	if status, _ := f.callKey(fiber.MethodGet, "/api/v1/me/tracking/followup-untracked/followup", nil); status != fiber.StatusNotFound {
+		t.Errorf("status = %d, want 404 for a job the caller does not track", status)
+	}
+}
+
+// TestFollowUpDraft_PrefillsTheRecipientFromLinkedMail covers the other half of the constraint that
+// shaped this feature: an address exists only when somebody wrote back and then went quiet.
+func TestFollowUpDraft_PrefillsTheRecipientFromLinkedMail(t *testing.T) {
+	f := newAgentInboxFixture(t, "fu-replied@example.test")
+	jid := seedJobSlug(t, f.pool, "followup-replied")
+	appliedDaysAgo(t, f, jid, 40, "screening")
+	if _, err := f.pool.Exec(context.Background(),
+		`INSERT INTO emails (user_id, external_id, thread_id, from_addr, from_name, subject, body_text, received_at, source, job_id)
+		 VALUES ($1,'fu-1','t-1','mara@acme.test','Mara Lin','Re: your application','...',$2,'test',$3)`,
+		f.userID, time.Now().Add(-30*24*time.Hour), jid); err != nil {
+		t.Fatalf("seed mail: %v", err)
+	}
+
+	status, body := f.callKey(fiber.MethodGet, "/api/v1/me/tracking/followup-replied/followup", nil)
+
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	data, _ := body["data"].(map[string]any)
+	if got, _ := data["recipient"].(string); got != "mara@acme.test" {
+		t.Errorf("recipient = %q, want the sender of the linked mail", got)
+	}
+	if text, _ := data["body"].(string); text == "" {
+		t.Fatal("no body")
+	}
+}
+
+func TestFollowUpRecord_WritesTheChaseAndIsOwnerScoped(t *testing.T) {
+	f := newAgentInboxFixture(t, "fu-record@example.test")
+	jid := seedJobSlug(t, f.pool, "followup-record")
+	appliedDaysAgo(t, f, jid, 24, "applied")
+
+	if status, _ := f.callKey(fiber.MethodPost, "/api/v1/me/tracking/followup-record/followup", nil); status != fiber.StatusNoContent {
+		t.Fatalf("record status = %d, want 204", status)
+	}
+
+	row, err := f.q.GetUserApplication(context.Background(),
+		db.GetUserApplicationParams{UserID: f.userID, JobID: jid})
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !row.FollowedUpAt.Valid {
+		t.Error("followed_up_at is unset after recording a follow-up")
+	}
+	// The silence it was a response to must survive it.
+	if !row.LastActivityAt.Valid || row.LastActivityAt.Time.After(time.Now().Add(-20*24*time.Hour)) {
+		t.Errorf("last_activity_at = %v after the chase, want it still ~24 days back", row.LastActivityAt)
+	}
+
+	// A second press is not an error.
+	if status, _ := f.callKey(fiber.MethodPost, "/api/v1/me/tracking/followup-record/followup", nil); status != fiber.StatusNoContent {
+		t.Errorf("second record status = %d, want 204 — a double click must not error", status)
+	}
+}
+
+func TestFollowUpRecord_UntrackedSlugWritesNothing(t *testing.T) {
+	f := newAgentInboxFixture(t, "fu-record-untracked@example.test")
+	jid := seedJobSlug(t, f.pool, "followup-record-untracked")
+
+	if status, _ := f.callKey(fiber.MethodPost, "/api/v1/me/tracking/followup-record-untracked/followup", nil); status != fiber.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+	var n int
+	if err := f.pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM user_jobs WHERE user_id=$1 AND job_id=$2 AND followed_up_at IS NOT NULL`,
+		f.userID, jid).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("wrote %d follow-up rows for an untracked job, want 0", n)
+	}
+}

--- a/internal/handler/gmail.go
+++ b/internal/handler/gmail.go
@@ -81,6 +81,11 @@ func (h *inboxHandlers) register(api fiber.Router, mw middleware) {
 	// Email → application linking. :slug is registered after the static
 	// /me/tracking/* routes (see Register) so it does not shadow them.
 	api.Get("/me/tracking/:slug", mw.key, h.GetTrackedApplication)
+	// The chase for an application that went quiet: assemble the draft, and record that the
+	// candidate sent it. A key is admitted for the same reason the apply write admits one — the
+	// CLI records applications, and a follow-up is the same kind of act.
+	api.Get("/me/tracking/:slug/followup", mw.key, h.GetApplicationFollowUp)
+	api.Post("/me/tracking/:slug/followup", mw.key, h.RecordApplicationFollowUp)
 	api.Post("/me/emails/:id/link", mw.key, h.LinkEmail)
 	api.Post("/me/emails/:id/unlink", mw.key, h.UnlinkEmail)
 	api.Post("/me/emails/:id/confirm", mw.key, h.ConfirmEmailLink)

--- a/internal/handler/inbox_linking.go
+++ b/internal/handler/inbox_linking.go
@@ -32,7 +32,10 @@ type applicationDetail struct {
 	AppliedAt *time.Time         `json:"applied_at"`
 	Stage     string             `json:"stage,omitempty"`
 	Notes     string             `json:"notes,omitempty"`
-	Emails    []applicationEmail `json:"emails"`
+	// FollowedUpAt is when the caller last recorded chasing this application, or null
+	// for never. It says nothing about whether anybody replied.
+	FollowedUpAt *time.Time         `json:"followed_up_at"`
+	Emails       []applicationEmail `json:"emails"`
 }
 
 // GetTrackedApplication returns the caller's application for a job slug together
@@ -70,13 +73,14 @@ func (h *inboxHandlers) GetTrackedApplication(c *fiber.Ctx) error {
 		})
 	}
 	return c.JSON(fiber.Map{"data": applicationDetail{
-		Job:       jv,
-		ViewedAt:  tsPtr(app.ViewedAt),
-		SavedAt:   tsPtr(app.SavedAt),
-		AppliedAt: tsPtr(app.AppliedAt),
-		Stage:     pgStr(app.Stage),
-		Notes:     pgStr(app.Notes),
-		Emails:    emails,
+		Job:          jv,
+		ViewedAt:     tsPtr(app.ViewedAt),
+		SavedAt:      tsPtr(app.SavedAt),
+		AppliedAt:    tsPtr(app.AppliedAt),
+		Stage:        pgStr(app.Stage),
+		Notes:        pgStr(app.Notes),
+		FollowedUpAt: tsPtr(app.FollowedUpAt),
+		Emails:       emails,
 	}})
 }
 

--- a/internal/handler/inbox_linking.go
+++ b/internal/handler/inbox_linking.go
@@ -26,12 +26,12 @@ type applicationEmail struct {
 // applicationDetail is the wire shape for GET /me/tracking/:slug — the job in the
 // shared jobview shape, the caller's interaction, and the emails linked to it.
 type applicationDetail struct {
-	Job       jobview.Job        `json:"job"`
-	ViewedAt  *time.Time         `json:"viewed_at"`
-	SavedAt   *time.Time         `json:"saved_at"`
-	AppliedAt *time.Time         `json:"applied_at"`
-	Stage     string             `json:"stage,omitempty"`
-	Notes     string             `json:"notes,omitempty"`
+	Job       jobview.Job `json:"job"`
+	ViewedAt  *time.Time  `json:"viewed_at"`
+	SavedAt   *time.Time  `json:"saved_at"`
+	AppliedAt *time.Time  `json:"applied_at"`
+	Stage     string      `json:"stage,omitempty"`
+	Notes     string      `json:"notes,omitempty"`
 	// FollowedUpAt is when the caller last recorded chasing this application, or null
 	// for never. It says nothing about whether anybody replied.
 	FollowedUpAt *time.Time         `json:"followed_up_at"`

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -27,6 +27,10 @@ type myJobResponse struct {
 	LastActivityAt *time.Time `json:"last_activity_at"`
 	DaysSilent     *int       `json:"days_silent"`
 	SilenceState   *string    `json:"silence_state"`
+	// FollowedUpAt is when the caller last recorded chasing, or null for never. It is
+	// independent of the silence fields above — a chased application stays silent —
+	// so the board can show both readings at once.
+	FollowedUpAt *time.Time `json:"followed_up_at"`
 }
 
 // ListTrackedJobs returns the authenticated user's job interactions joined with the
@@ -63,6 +67,7 @@ func (h *trackingHandlers) ListTrackedJobs(c *fiber.Ctx) error {
 			Notes:          it.Notes,
 			EmailCount:     it.EmailCount,
 			ReminderFireAt: it.ReminderFireAt,
+			FollowedUpAt:   it.FollowedUpAt,
 		}
 		if s := it.Silence(now); s != nil {
 			item.LastActivityAt = &s.LastActivityAt

--- a/internal/handler/me_tracking_silence_test.go
+++ b/internal/handler/me_tracking_silence_test.go
@@ -39,6 +39,7 @@ type trackingRow struct {
 	LastActivityAt *time.Time `json:"last_activity_at"`
 	DaysSilent     *int       `json:"days_silent"`
 	SilenceState   *string    `json:"silence_state"`
+	FollowedUpAt   *time.Time `json:"followed_up_at"`
 }
 
 func listSilence(t *testing.T, items []jobtracking.TrackedJob) []trackingRow {
@@ -153,5 +154,35 @@ func TestTrackingSilenceUnconfirmed(t *testing.T) {
 	}
 	if *rows[0].SilenceState != userjob.SilenceUnconfirmed {
 		t.Errorf("silence_state = %q, want %q", *rows[0].SilenceState, userjob.SilenceUnconfirmed)
+	}
+}
+
+// TestTrackingCarriesTheChaseBesideTheSilence asserts a chased application reports both readings
+// at once: it is still silent for the full elapsed time, and it additionally says when it was
+// chased. The board renders a third state from that pair, so dropping either half — omitting
+// followed_up_at from the wire, or letting the chase move the clock — collapses it back to two.
+func TestTrackingCarriesTheChaseBesideTheSilence(t *testing.T) {
+	chased := row("applied", 40*oneDay, 30*oneDay, false)
+	at := time.Now().Add(-2 * oneDay)
+	chased.FollowedUpAt = &at
+
+	rows := listSilence(t, []jobtracking.TrackedJob{chased, row("applied", 40*oneDay, 30*oneDay, false)})
+	if len(rows) != 2 {
+		t.Fatalf("listing returned %d rows, want 2", len(rows))
+	}
+	if rows[0].FollowedUpAt == nil {
+		t.Fatal("a chased application reports no followed_up_at; the board cannot say it was chased")
+	}
+	if !rows[0].FollowedUpAt.Equal(at) {
+		t.Errorf("followed_up_at = %v, want %v", rows[0].FollowedUpAt, at)
+	}
+	if rows[0].SilenceState == nil || *rows[0].SilenceState != userjob.SilenceSilent {
+		t.Errorf("a chased application is no longer silent: %+v", rows[0])
+	}
+	if rows[0].DaysSilent == nil || *rows[0].DaysSilent != 30 {
+		t.Errorf("chasing moved the clock: days_silent = %v, want 30", rows[0].DaysSilent)
+	}
+	if rows[1].FollowedUpAt != nil {
+		t.Errorf("an unchased application reports followed_up_at = %v, want null", rows[1].FollowedUpAt)
 	}
 }

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -101,6 +101,11 @@ type TrackedJob struct {
 	// separate so the adapter carries facts and the domain does the judging.
 	LastActivityAt       *time.Time
 	HasPendingSuggestion bool
+	// FollowedUpAt is when the candidate last recorded chasing this application, or
+	// nil for one never chased. It rides beside the silence rather than inside it:
+	// Silence must not read it, because a chase is not a reply (see 0059's column
+	// comment). The board renders the pair — still silent, and chased N days ago.
+	FollowedUpAt *time.Time
 }
 
 // Listing is the result of ListTracked: a page of tracked jobs for the active

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -209,6 +209,7 @@ func (r *QueriesRepository) ListInteractions(
 			ReminderFireAt:       pgconv.TimePtr(row.ReminderFireAt),
 			LastActivityAt:       pgconv.TimePtr(row.LastActivityAt),
 			HasPendingSuggestion: row.HasPendingSuggestion,
+			FollowedUpAt:         pgconv.TimePtr(row.FollowedUpAt),
 		})
 	}
 	return items, nil

--- a/internal/userjob/AGENTS.md
+++ b/internal/userjob/AGENTS.md
@@ -20,6 +20,10 @@ The per-user job-tracking use cases — **`RecordView`** (touches `viewed_at`), 
 
 Two invariants worth knowing before touching it: a threshold is the **last tolerated day**, not the first offending one, and a settled application reports **no state at all** rather than `active` — the board must be able to tell "nothing owed" from "owed and answered promptly". `TestSilenceThresholdsGrowStricter` guards the ladder's direction, which no individual scenario would catch if it inverted.
 
+**`user_jobs.followed_up_at` records the candidate chasing, and is deliberately outside the clock.** `last_activity_at` is `GREATEST(applied_at, newest linked inbound mail)` — it measures how long the *other side* has been quiet, and a follow-up the candidate sends is not a reply. Adding the column to that `GREATEST(...)` would clear the badge at the moment it matters most, so it is carried *beside* the silence verdict (`jobtracking.TrackedJob`, the listing response, and `GET /me/tracking/:slug`) and never inside its inputs — `SilenceStateFor` is not given it and so cannot read it. `TestAFollowUpDoesNotStopTheSilenceClock` fails if a future reader wires it in; the column comment in migration 0059 says why.
+
+A chased application therefore has **two readings at once**, and the board card shows both: the amber "24d" badge (they still have not answered) plus "chased 2d ago" (we already prodded). The follow-up offer itself stays available — a second chase is the candidate's call. `GET /me/tracking/:slug/followup` assembles the draft via `internal/followup` (deterministic, no LLM, no credits) and refuses anything whose state is not `silent`, reusing `SilenceStateFor` so the offer and the badge can never disagree; `POST` on the same path records the chase. Nothing in this path sends mail — `inboxHandlers` holds no mail client at all.
+
 The `/me/tracking` read joins the caller's interactions with the jobs they touch. View history = all rows; applications = `applied_at IS NOT NULL`.
 
 ## Limitations

--- a/migrations/0059_user_jobs_followed_up_at.sql
+++ b/migrations/0059_user_jobs_followed_up_at.sql
@@ -1,0 +1,9 @@
+-- When the candidate chased a silent application. Set by the record action after they send the
+-- follow-up draft; NULL means they never did, which is true of every existing row.
+--
+-- It is deliberately NOT part of the last-activity derivation in ListUserJobs. That derivation is
+-- GREATEST(applied_at, newest linked inbound mail): it measures when the OTHER SIDE last moved, and
+-- a chase the candidate sends is not a reply. Folding this column in would make the board report an
+-- answer that never came, and would clear the silence badge precisely when the candidate most needs
+-- to see it. The card reads both: still silent, and already chased.
+ALTER TABLE public.user_jobs ADD COLUMN followed_up_at timestamptz;

--- a/openspec/changes/application-followup-draft/.openspec.yaml
+++ b/openspec/changes/application-followup-draft/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/application-followup-draft/design.md
+++ b/openspec/changes/application-followup-draft/design.md
@@ -1,0 +1,106 @@
+## Context
+
+The silence signal is finished work: `internal/userjob/silence.go` holds a stage-aware threshold
+ladder whose numbers carry their own provenance, `ListTrackedJobs` derives
+`last_activity_at = GREATEST(applied_at, newest linked inbound mail)`, and `BoardCard.svelte` already
+paints "No reply for N days". `internal/ghost/evidence.go` consumes the same verdict.
+
+What is absent is anything to do about it. This change adds the action and touches none of the
+measurement.
+
+Two facts shape the design more than any preference:
+
+- **`last_activity_at` measures the other side.** It is the later of the apply date and the newest
+  *inbound* message. A follow-up the candidate sends is not inbound, so feeding it into that
+  derivation would make the board report a reply that never came.
+- **The commonest silent application has no recipient.** An address exists only via
+  `emails.from_addr` on linked mail. The `applied` stage — 21 days, 16% of the observed sample — is
+  precisely the case where nobody ever wrote back, so there is nothing to prefill.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Turn a silence badge into a next step, at the place the badge already is.
+- Assemble the draft deterministically: no credits, no metering, no fabricated claims.
+- Record that a chase happened without corrupting what silence means.
+
+**Non-Goals:**
+
+- Sending. `emailnotify.Client.Send` exists and the hosted mailbox would give a plausible From, but
+  putting our infrastructure between a candidate and a recruiter is an identity and deliverability
+  decision with its own failure modes — and it could only serve the minority of silent applications
+  where an address is known.
+- An LLM draft. A template plus one line of the candidate's own evidence cannot invent a claim and
+  costs nothing. If real use shows the drafts read as boilerplate, an LLM pass has a baseline to beat.
+- A digest across applications. Same data, different surface; this change stays next to the badge.
+
+## Decisions
+
+### The assembler is pure, and lives in its own package
+
+A new `internal/followup` with a single entry point taking a small input struct (role, company, days
+silent, stage, optional strength, optional recipient) and returning subject + body. Pure and I/O-free,
+in the shape `internal/atscheck` and `internal/verdict` already use, so the wording is table-tested
+rather than eyeballed.
+
+**Alternative rejected:** assembling inside the handler. The text is the part worth testing hardest —
+tone, the elapsed-time phrasing, what happens when a field is missing — and a handler drags a DB and
+an HTTP context into every one of those cases.
+
+### The one non-generic line comes from the cached fit analysis
+
+`matchanalysis.Analysis.Strengths` already names why this candidate fits this vacancy, derived from
+their own CV and sanitized on the way in. The draft restates the first one.
+
+**Alternative rejected:** deriving it from `RequirementMatch` by picking the strongest
+`evidence_strength`. More precise in theory, but a requirement is the *vacancy's* phrasing ("5+ years
+Go"), while a strength is already written as a claim about the candidate — which is what a chase
+needs. **Alternative rejected:** letting the candidate type it. That turns a one-click action into a
+writing task, which is the thing they were already avoiding.
+
+**Absence is honoured, not filled.** No cached analysis, or none with strengths, means the line is
+omitted. The provenance rule this project runs on — a claim about the candidate must come from the
+candidate — is enforced here by having no other source available.
+
+### `followed_up_at` is recorded, and deliberately not wired into the clock
+
+A new `user_jobs.followed_up_at`. It is written by an explicit record action and read by the board;
+it is NOT added to the `GREATEST(...)` that derives `last_activity_at`, and the ghost signal that
+consumes silence therefore sees no change.
+
+The card gains a third reading — silent *and chased* — instead of flipping back to green. Resetting
+would have been the cheaper code and the wrong meaning: the employer still has not replied, and a
+candidate deciding whether to write off an application needs to know they already tried once.
+
+### Both endpoints sit on the tracking surface and admit an API key
+
+`GET /me/tracking/:slug/followup` assembles the draft; `POST` records the chase. The neighbouring
+tracking reads and the apply-tracking write already admit a key (the CLI records applies), so a key
+here is consistent — a follow-up is the same kind of act as marking an application sent.
+
+The draft endpoint refuses anything that is not `silent`, reusing `userjob.SilenceStateFor` rather
+than re-deriving the rule, so the offer and the badge can never disagree about which applications
+qualify.
+
+## Risks / Trade-offs
+
+- **A template reads as boilerplate** → Mitigated by the strength line and a concrete ask, and
+  bounded by being free: if adoption shows it is ignored, the LLM upgrade starts from a measurable
+  baseline rather than a guess.
+- **The candidate sends the draft and we never learn** → We record only what they tell us via the
+  record action. A follow-up sent without pressing it leaves the card saying "not chased". Accepted:
+  the alternative is sending on their behalf, which is the non-goal above.
+- **`followed_up_at` invites a future reader to add it to the silence clock** → The requirement
+  states it must not, the derivation query carries a comment, and a test asserts the days-silent is
+  unchanged by a recorded follow-up.
+- **A stage that never accrues silence could still be chased** → The draft endpoint gates on the
+  silence state, so a terminal or active application is refused rather than drafting something the
+  board would not have suggested.
+
+## Migration Plan
+
+`0059_user_jobs_followed_up_at.sql` adds one nullable timestamptz. No backfill: a null means "never
+chased", which is true of every existing row. `make sqlc` after the query changes; `release.sh`
+applies the migration before the colour flips. Rollback is a revert — the column is inert to code
+that does not read it.

--- a/openspec/changes/application-followup-draft/proposal.md
+++ b/openspec/changes/application-followup-draft/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+We measure application silence carefully and then do nothing with it.
+
+`internal/userjob/silence.go` carries a threshold ladder with per-value provenance — `applied` 21
+days (measured over 92 observed applications, marks 16% of them), `interview` 12 (measured over 6,
+raised from 7 because a badge on nearly every card is one nobody reads) — three states that
+distinguish *silent* from *waiting and fine* from *unconfirmed*, and it already feeds the ghost
+signal. `/me/tracking` serves `days_silent` and `silence_state` per row, and `BoardCard.svelte`
+already renders "No reply for N days".
+
+So the candidate is told, accurately and at the right moment, that an application has gone quiet —
+and is offered nothing to do about it. `grep -rn "follow.?up" internal/` returns comments only;
+`internal/reminder` nudges *saved jobs*, not applications. The signal stops one step short of being
+useful.
+
+## What Changes
+
+- **A follow-up draft for a silent application.** The candidate opens it from the card that already
+  carries the badge, gets a short message they can send from their own mail client, and the drafting
+  costs nothing: it is assembled deterministically, not generated.
+- **The one non-generic line comes from the cached fit analysis.** A chase that only says "checking
+  in" is ignorable; the draft names one concrete strength. That text already exists — the fit
+  analysis records the candidate's strongest evidence for this vacancy, drawn from their own CV — so
+  the draft restates something true rather than inventing a reason.
+- **The recipient is prefilled when we know it.** `emails.from_addr` gives a real address on
+  applications where somebody replied and then went quiet. On the commonest silent case — applied,
+  never answered — there is no address to prefill, and the draft is issued without one.
+- **A sent follow-up is recorded, and does not stop the clock.** `user_jobs.followed_up_at` records
+  that the candidate chased. `last_activity_at` is `GREATEST(applied_at, newest inbound mail)` — it
+  measures when the *other side* last moved, and a chase is not a reply. So silence keeps accruing
+  and the board can say "chased 4 days ago, still nothing" instead of resetting to a reassuring
+  green.
+
+Not in this change, deliberately:
+
+- **Sending on the candidate's behalf.** `emailnotify.Client.Send` could do it and the hosted mailbox
+  gives a plausible From, but a chase sent from our infrastructure to a recruiter is a
+  deliverability and identity decision that deserves its own change — and it would only ever work for
+  the minority of silent applications where we hold an address.
+- **An LLM draft.** A template plus one line of the candidate's own evidence needs no credits, no
+  metering, and cannot fabricate a claim. If the drafts prove too generic in use, an LLM pass is a
+  later upgrade with a baseline to beat.
+- **A batch digest** ("three applications went quiet"). That is a notification feature over the same
+  data; this change puts the action next to the badge that already exists.
+
+## Capabilities
+
+### New Capabilities
+- `application-followup-draft`: assembling a follow-up message for a silent application, prefilling
+  the recipient when one is known, and recording that the candidate chased.
+
+### Modified Capabilities
+- `application-silence-signal`: a recorded follow-up is now part of what the board reports about a
+  silent application, and — the requirement worth pinning — it does NOT reset the silence clock.
+
+## Impact
+
+- **Schema**: `user_jobs.followed_up_at timestamptz` (additive) and its backfill-free migration.
+- **SQL**: `ListTrackedJobs` and the tracking detail read carry the new column; a small write to set
+  it. Regenerate with `make sqlc`.
+- **Go**: a new deterministic assembler (pure, testable without a DB or an LLM), a read endpoint for
+  the draft, and a write endpoint recording the chase.
+- **Web**: an action on the board card behind the existing silence badge, and the card's copy when a
+  follow-up has been recorded.
+- **No LLM, no credits, no new external dependency.**

--- a/openspec/changes/application-followup-draft/specs/application-followup-draft/spec.md
+++ b/openspec/changes/application-followup-draft/specs/application-followup-draft/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: A follow-up draft is offered for a silent application
+
+The system SHALL assemble a follow-up message for an application the candidate owns, containing at
+minimum the role, the company, and how long it has been since the application last moved. The draft
+SHALL be assembled deterministically — the same application and the same underlying data produce the
+same text — and MUST NOT call a language model or consume AI credits.
+
+The draft SHALL be offered only for an application that is actually waiting on somebody: one whose
+silence state is `silent`. An application in a terminal stage, one still inside its stage's tolerated
+silence, or one with mail awaiting confirmation has nothing to chase and SHALL NOT be offered a
+draft.
+
+#### Scenario: A silent application yields a draft
+- **WHEN** the candidate requests a follow-up draft for an application whose silence state is `silent`
+- **THEN** the response carries a subject and a body naming the role, the company, and the elapsed time
+
+#### Scenario: The same application drafts identically twice
+- **WHEN** a draft is requested twice with no change to the application
+- **THEN** both responses are identical
+
+#### Scenario: An application that is not silent is refused
+- **WHEN** the candidate requests a draft for an application whose silence state is `active`,
+  `unconfirmed`, or absent (a terminal stage, or a job merely viewed or saved)
+- **THEN** the request is refused and no draft is assembled
+
+### Requirement: The draft states one true strength, taken from the fit analysis
+
+The draft SHALL include one concrete reason the candidate fits the role, taken from the cached fit
+analysis for that (candidate, vacancy) pair — which derives it from the candidate's own CV. The
+system MUST NOT compose a new claim about the candidate: if no cached analysis exists, or it names
+no strength, the draft SHALL omit the line rather than invent one.
+
+#### Scenario: A cached analysis supplies the line
+- **WHEN** a fit analysis is cached for the application's vacancy and names at least one strength
+- **THEN** the draft states that strength
+
+#### Scenario: No analysis means no claim
+- **WHEN** no fit analysis is cached, or the cached one names no strengths
+- **THEN** the draft is still assembled and simply carries no strength line
+
+### Requirement: The recipient is prefilled only when it is known
+
+When mail linked to the application carries a sender address, the draft SHALL prefill that address
+and display name as the recipient. When no linked mail exists — the commonest silent case, an
+application nobody ever answered — the draft SHALL be issued with no recipient rather than withheld
+or guessed.
+
+#### Scenario: A replied-then-quiet application prefills its recipient
+- **WHEN** the application has linked mail carrying a sender address
+- **THEN** the draft's recipient is that address
+
+#### Scenario: An unanswered application drafts without a recipient
+- **WHEN** the application has no linked mail
+- **THEN** the draft is still returned, with no recipient set
+
+### Requirement: The system does not send the follow-up
+
+The system SHALL NOT transmit the follow-up. The draft is handed to the candidate to send from their
+own mail client, and no endpoint in this capability delivers mail to a third party.
+
+#### Scenario: Requesting a draft sends nothing
+- **WHEN** a draft is requested
+- **THEN** no message is transmitted to any address
+
+### Requirement: A recorded follow-up does not stop the silence clock
+
+The candidate SHALL be able to record that they followed up, and the system SHALL store when. That
+record MUST NOT feed the last-activity derivation: silence measures how long the *other side* has
+been quiet, and the candidate chasing is not a reply. An application that was silent for 24 days and
+has since been chased SHALL still report its silence, alongside the fact that it was chased.
+
+#### Scenario: Chasing does not reset the silence
+- **WHEN** the candidate records a follow-up on an application silent for 24 days
+- **THEN** the application still reports silence, and its days-silent keeps counting from the last
+  inbound activity
+
+#### Scenario: A reply does reset it
+- **WHEN** mail linked to the application arrives after the recorded follow-up
+- **THEN** the last activity moves to that mail, as it would have without any follow-up
+
+#### Scenario: The record is owner-scoped
+- **WHEN** a caller records a follow-up on an application belonging to a different account
+- **THEN** the request is refused as not found, and nothing is written

--- a/openspec/changes/application-followup-draft/specs/application-silence-signal/spec.md
+++ b/openspec/changes/application-followup-draft/specs/application-silence-signal/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Tracking board marks a silent application
+
+The web SPA's tracking board SHALL mark each application card with its silence
+state, showing the days silent for an application that is `silent` and an
+invitation to confirm the pending mail for one that is `unconfirmed`. A card in
+the `active` state and a card for a terminal application SHALL carry no silence
+marker, so the marker means something when it appears.
+
+A `silent` card SHALL additionally offer the candidate a follow-up draft, and — once a follow-up has
+been recorded — SHALL say that the application was chased and when, without dropping or softening the
+silence marker. "Chased, still nothing" and "nobody has done anything about it" are different
+situations, and the card MUST NOT render them the same way.
+
+#### Scenario: Silent card
+
+- **WHEN** a signed-in user opens the tracking board with an application whose
+  silence state is `silent` at 24 days
+- **THEN** that card shows a silence marker reading 24 days
+
+#### Scenario: Unconfirmed card
+
+- **WHEN** a card's application has the silence state `unconfirmed`
+- **THEN** the card invites the user to confirm the pending mail rather than
+  reporting a silence
+
+#### Scenario: Active and terminal cards are unmarked
+
+- **WHEN** a card's application is `active` or in a terminal stage
+- **THEN** the card shows no silence marker
+
+#### Scenario: A silent card offers a draft
+
+- **WHEN** a card's application is `silent`
+- **THEN** the card offers a follow-up draft
+
+#### Scenario: A chased card keeps its silence marker
+
+- **WHEN** a card's application is `silent` and a follow-up has been recorded
+- **THEN** the card still shows the silence marker, and additionally reports that it was chased

--- a/openspec/changes/application-followup-draft/tasks.md
+++ b/openspec/changes/application-followup-draft/tasks.md
@@ -11,11 +11,11 @@
 
 ## 2. Schema and reads
 
-- [ ] 2.1 Add `migrations/0059_user_jobs_followed_up_at.sql`: one nullable timestamptz, no backfill.
+- [x] 2.1 Add `migrations/0059_user_jobs_followed_up_at.sql`: one nullable timestamptz, no backfill.
       The comment must say why it is NOT part of the last-activity derivation.
-- [ ] 2.2 Carry `followed_up_at` on the tracking reads (`ListTrackedJobs` and the per-slug detail),
+- [x] 2.2 Carry `followed_up_at` on the tracking reads (`ListTrackedJobs` and the per-slug detail),
       and add the write that sets it. `make sqlc`.
-- [ ] 2.3 Integration test the invariant that pays for this change: an application silent for 24 days
+- [x] 2.3 Integration test the invariant that pays for this change: an application silent for 24 days
       that has been chased still reports 24 days silent and the same silence state. Watch it fail
       first by wiring `followed_up_at` into the `GREATEST(...)` — if the test passes with the column
       in the derivation, it is not testing anything.

--- a/openspec/changes/application-followup-draft/tasks.md
+++ b/openspec/changes/application-followup-draft/tasks.md
@@ -22,21 +22,22 @@
 
 ## 3. Endpoints
 
-- [ ] 3.1 `GET /me/tracking/:slug/followup` assembles the draft: resolve the application owner-scoped
+- [x] 3.1 `GET /me/tracking/:slug/followup` assembles the draft: resolve the application owner-scoped
       (a foreign slug is the same not-found as a missing one), refuse anything whose silence state is
       not `silent` via `userjob.SilenceStateFor`, read the cached analysis for the strength, and
       prefill the recipient from the newest linked email's `from_addr` when there is one. Tests:
       draft for a silent application; refusal for active / unconfirmed / terminal; a foreign slug is
       404.
-- [ ] 3.2 Test both recipient paths against a real DB: an application with linked mail prefills the
+- [x] 3.2 Test both recipient paths against a real DB: an application with linked mail prefills the
       sender; one without returns a draft with no recipient — the commonest case, and the one a
       naive implementation would drop.
-- [ ] 3.3 `POST /me/tracking/:slug/followup` records the chase, owner-scoped, idempotent enough that
+- [x] 3.3 `POST /me/tracking/:slug/followup` records the chase, owner-scoped, idempotent enough that
       a double click does not error. Test that it writes the timestamp and that a foreign slug writes
       nothing.
-- [ ] 3.4 Assert no mail is transmitted by either endpoint — the handler must not reach
-      `emailnotify`. A test that constructs the handler with a nil mailer and expects no panic pins
-      the non-goal in code.
+- [x] 3.4 The non-goal is enforced by construction rather than by a test: `inboxHandlers` holds no
+      mail client at all (queries, pool, the gmail connector/cipher, origin, cookie flag, mail
+      domain, tracking service), so neither endpoint has anything to send with. A test constructing
+      a nil mailer would have asserted against a field that does not exist.
 
 ## 4. The board
 

--- a/openspec/changes/application-followup-draft/tasks.md
+++ b/openspec/changes/application-followup-draft/tasks.md
@@ -1,0 +1,57 @@
+## 1. The draft assembler (pure, no I/O)
+
+- [ ] 1.1 Add `internal/followup` with an input struct (role, company, days silent, stage, optional
+      strength, optional recipient name) and a function returning subject + body. Table tests cover:
+      the same input drafts identically; a missing strength omits the line rather than leaving a gap
+      or a placeholder; a missing recipient name falls back to a neutral greeting; the elapsed time
+      reads naturally at 21, 24 and 60 days.
+- [ ] 1.2 Pin the tone rules as tests, since they are the product here: no apology, no "just
+      checking in", the ask is a concrete question (is the role still open / what is the timeline),
+      and the body stays under a stated length so it is readable on a phone.
+
+## 2. Schema and reads
+
+- [ ] 2.1 Add `migrations/0059_user_jobs_followed_up_at.sql`: one nullable timestamptz, no backfill.
+      The comment must say why it is NOT part of the last-activity derivation.
+- [ ] 2.2 Carry `followed_up_at` on the tracking reads (`ListTrackedJobs` and the per-slug detail),
+      and add the write that sets it. `make sqlc`.
+- [ ] 2.3 Integration test the invariant that pays for this change: an application silent for 24 days
+      that has been chased still reports 24 days silent and the same silence state. Watch it fail
+      first by wiring `followed_up_at` into the `GREATEST(...)` — if the test passes with the column
+      in the derivation, it is not testing anything.
+
+## 3. Endpoints
+
+- [ ] 3.1 `GET /me/tracking/:slug/followup` assembles the draft: resolve the application owner-scoped
+      (a foreign slug is the same not-found as a missing one), refuse anything whose silence state is
+      not `silent` via `userjob.SilenceStateFor`, read the cached analysis for the strength, and
+      prefill the recipient from the newest linked email's `from_addr` when there is one. Tests:
+      draft for a silent application; refusal for active / unconfirmed / terminal; a foreign slug is
+      404.
+- [ ] 3.2 Test both recipient paths against a real DB: an application with linked mail prefills the
+      sender; one without returns a draft with no recipient — the commonest case, and the one a
+      naive implementation would drop.
+- [ ] 3.3 `POST /me/tracking/:slug/followup` records the chase, owner-scoped, idempotent enough that
+      a double click does not error. Test that it writes the timestamp and that a foreign slug writes
+      nothing.
+- [ ] 3.4 Assert no mail is transmitted by either endpoint — the handler must not reach
+      `emailnotify`. A test that constructs the handler with a nil mailer and expects no panic pins
+      the non-goal in code.
+
+## 4. The board
+
+- [ ] 4.1 Offer the draft from the silent card in `BoardCard.svelte`, next to the existing badge, and
+      show the assembled subject/body with a copy action.
+- [ ] 4.2 A chased card keeps its silence marker and additionally reports when it was chased. Unit
+      test the view logic (the repo's convention: logic in `.ts`, thin components).
+- [ ] 4.3 Verify visually at desktop and mobile widths — the board card is dense, and a second line
+      of state is exactly where it will overflow.
+
+## 5. Close out
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...`; `go test -tags=integration ./internal/db/
+      ./internal/handler/`; in `web/`: `pnpm run lint`, `pnpm run check`, `pnpm test`, `pnpm run build`
+      (all four — `svelte-check` catches what the others miss).
+- [ ] 5.2 Record in `docs/agents/notifications.md` (or the tracking reference) that `followed_up_at`
+      exists, that it is deliberately outside the silence derivation, and what the card shows when
+      both are set.

--- a/openspec/changes/application-followup-draft/tasks.md
+++ b/openspec/changes/application-followup-draft/tasks.md
@@ -1,11 +1,11 @@
 ## 1. The draft assembler (pure, no I/O)
 
-- [ ] 1.1 Add `internal/followup` with an input struct (role, company, days silent, stage, optional
+- [x] 1.1 Add `internal/followup` with an input struct (role, company, days silent, stage, optional
       strength, optional recipient name) and a function returning subject + body. Table tests cover:
       the same input drafts identically; a missing strength omits the line rather than leaving a gap
       or a placeholder; a missing recipient name falls back to a neutral greeting; the elapsed time
       reads naturally at 21, 24 and 60 days.
-- [ ] 1.2 Pin the tone rules as tests, since they are the product here: no apology, no "just
+- [x] 1.2 Pin the tone rules as tests, since they are the product here: no apology, no "just
       checking in", the ask is a concrete question (is the role still open / what is the timeline),
       and the body stays under a stated length so it is readable on a phone.
 

--- a/openspec/changes/application-followup-draft/tasks.md
+++ b/openspec/changes/application-followup-draft/tasks.md
@@ -41,18 +41,31 @@
 
 ## 4. The board
 
-- [ ] 4.1 Offer the draft from the silent card in `BoardCard.svelte`, next to the existing badge, and
-      show the assembled subject/body with a copy action.
-- [ ] 4.2 A chased card keeps its silence marker and additionally reports when it was chased. Unit
-      test the view logic (the repo's convention: logic in `.ts`, thin components).
-- [ ] 4.3 Verify visually at desktop and mobile widths — the board card is dense, and a second line
-      of state is exactly where it will overflow.
+- [x] 4.1 Offer the draft from the silent card in `BoardCard.svelte`, next to the existing badge, and
+      show the assembled subject/body with a copy action. The card stopped being one `<button>` — a
+      second control cannot nest inside the first — so the open action stretches over the card via an
+      `::after` overlay and the follow-up button sits above it on `z-10`. The dialog also offers a
+      Gmail and a `mailto:` compose link: both hand the draft to the candidate's own client, which is
+      the same handoff the clipboard makes, one click shorter. Copy stays because a `mailto:` on a
+      machine with no registered handler fails silently.
+- [x] 4.2 A chased card keeps its silence marker and additionally reports when it was chased. Unit
+      test the view logic (the repo's convention: logic in `.ts`, thin components) — `$lib/followup.ts`,
+      15 tests. This needed the wire shape first: `followed_up_at` reached the sqlc rows but neither
+      `jobtracking.TrackedJob` nor the two responses carried it, so the board could not have shown it.
+- [x] 4.3 Verify visually at desktop and mobile widths — the board card is dense, and a second line
+      of state is exactly where it will overflow. Shot at 1100 and at a real 390 (CDP device
+      emulation; `--window-size` clamps the layout viewport at 500). No card or dialog overflows; the
+      badge row and the dialog footer wrap rather than clip. Hit-tested the overlay by dispatched
+      pointer events: a click on Follow up does NOT open the drawer, and a click anywhere else still
+      does — the one failure mode a screenshot cannot show.
 
 ## 5. Close out
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...`; `go test -tags=integration ./internal/db/
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...`; `go test -tags=integration ./internal/db/
       ./internal/handler/`; in `web/`: `pnpm run lint`, `pnpm run check`, `pnpm test`, `pnpm run build`
-      (all four — `svelte-check` catches what the others miss).
-- [ ] 5.2 Record in `docs/agents/notifications.md` (or the tracking reference) that `followed_up_at`
+      (all four — `svelte-check` catches what the others miss). Run after rebasing onto origin/main,
+      which had moved four commits (including design-system changes).
+- [x] 5.2 Record in `docs/agents/notifications.md` (or the tracking reference) that `followed_up_at`
       exists, that it is deliberately outside the silence derivation, and what the card shows when
-      both are set.
+      both are set. Written into `internal/userjob/AGENTS.md`, beside the silence ladder it must not
+      join.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   Job,
   EmailLinking,
   TrackedApplication,
+  FollowUpDraft,
   Company,
   CompanyListItem,
   FacetCounts,
@@ -1305,6 +1306,19 @@ export function createApi(
     return requestData<TrackedApplication>(`/api/v1/me/tracking/${encodeURIComponent(slug)}`);
   }
 
+  /** The assembled follow-up draft for a silent application. 409 when the
+   *  application is not waiting on a reply — the same verdict the board's badge
+   *  renders, so a card that offers the draft never gets one. */
+  async function getFollowUpDraft(slug: string): Promise<FollowUpDraft> {
+    return requestData<FollowUpDraft>(`/api/v1/me/tracking/${encodeURIComponent(slug)}/followup`);
+  }
+
+  /** Record that the caller chased this application. Sends nothing — it stamps
+   *  followed_up_at, which stays outside the silence derivation. 204, no body. */
+  async function recordFollowUp(slug: string): Promise<void> {
+    await call(`/api/v1/me/tracking/${encodeURIComponent(slug)}/followup`, { method: 'POST' });
+  }
+
   /** Promote an email's pending suggestion to a confirmed link. */
   async function confirmEmailLink(id: number): Promise<EmailBody> {
     return requestData<EmailBody>(`/api/v1/me/emails/${id}/confirm`, { method: 'POST' });
@@ -1587,6 +1601,8 @@ export function createApi(
     deleteEmail,
     restoreEmail,
     getTrackedApplication,
+    getFollowUpDraft,
+    recordFollowUp,
     confirmEmailLink,
     rejectEmailLink,
     linkEmail,

--- a/web/src/lib/components/BoardCard.svelte
+++ b/web/src/lib/components/BoardCard.svelte
@@ -37,7 +37,11 @@
     </span>
     <span class="line-clamp-2 text-sm">{item.job.title}</span>
   </button>
-  <span class="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+  <!-- The badge row rides above the open action's overlay so its title tooltips still
+       answer a hover. The cost is that this strip no longer opens the drawer; a lost
+       tooltip is the worse trade, since the badges are the card's only explanation of
+       what "24d" means. -->
+  <span class="relative z-10 flex flex-wrap items-center gap-x-1.5 gap-y-1">
     {#if item.stage}
       <Badge variant="secondary">{humanizeStage(item.stage)}</Badge>
     {/if}

--- a/web/src/lib/components/BoardCard.svelte
+++ b/web/src/lib/components/BoardCard.svelte
@@ -1,26 +1,43 @@
 <script lang="ts">
-  import { Clock, Mail, MessageSquare } from '@lucide/svelte';
+  import { Clock, Mail, MessageSquare, Send } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import { Badge } from '$lib/ui';
   import { humanizeStage } from '$lib/stages';
+  import { canFollowUp, chasedLabel } from '$lib/followup';
   import type { MyJob } from '$lib/types';
 
-  let { item, onopen }: { item: MyJob; onopen: (item: MyJob) => void } = $props();
+  let {
+    item,
+    onopen,
+    onfollowup,
+  }: { item: MyJob; onopen: (item: MyJob) => void; onfollowup: (item: MyJob) => void } = $props();
 
   const hasNotes = $derived(!!item.notes && item.notes.trim().length > 0);
+  // Both readings of a chased application, side by side: the badge says the employer
+  // is still quiet, the label says we already prodded them. Neither replaces the other.
+  const offersFollowUp = $derived(canFollowUp(item));
+  const chased = $derived(chasedLabel(item));
 </script>
 
-<button
-  type="button"
-  onclick={() => onopen(item)}
-  class="flex w-full flex-col gap-1.5 rounded-lg border border-border bg-card p-3 text-left shadow-sm transition-colors hover:bg-accent"
+<!-- The card is a div, not a button: the follow-up action is a second control, and a
+     button inside a button is invalid. The open action keeps the whole card clickable
+     via a stretched ::after overlay; the follow-up button sits above it on z-10. -->
+<div
+  class="relative flex w-full flex-col gap-1.5 rounded-lg border border-border bg-card p-3 text-left shadow-sm transition-colors hover:bg-accent"
 >
-  <span class="flex items-center gap-1.5 text-sm font-semibold">
-    <CompanyLogo name={item.job.company} />
-    <span class="min-w-0 truncate">{item.job.company || 'Unknown company'}</span>
-  </span>
-  <span class="line-clamp-2 text-sm">{item.job.title}</span>
-  <span class="flex items-center gap-1.5">
+  <button
+    type="button"
+    onclick={() => onopen(item)}
+    aria-label="Open {item.job.title} at {item.job.company || 'unknown company'}"
+    class="flex flex-col gap-1.5 text-left after:absolute after:inset-0 after:content-['']"
+  >
+    <span class="flex items-center gap-1.5 text-sm font-semibold">
+      <CompanyLogo name={item.job.company} />
+      <span class="min-w-0 truncate">{item.job.company || 'Unknown company'}</span>
+    </span>
+    <span class="line-clamp-2 text-sm">{item.job.title}</span>
+  </button>
+  <span class="flex flex-wrap items-center gap-x-1.5 gap-y-1">
     {#if item.stage}
       <Badge variant="secondary">{humanizeStage(item.stage)}</Badge>
     {/if}
@@ -42,6 +59,9 @@
         <MessageSquare class="size-3 shrink-0" aria-hidden="true" />
         ?
       </span>
+    {/if}
+    {#if chased}
+      <span class="text-xs text-muted-foreground">{chased}</span>
     {/if}
     {#if item.email_count > 0}
       <span
@@ -69,5 +89,15 @@
         <path d="M8 7h8M8 12h8M8 17h5" />
       </svg>
     {/if}
+    {#if offersFollowUp}
+      <button
+        type="button"
+        onclick={() => onfollowup(item)}
+        class="relative z-10 ml-auto flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-100 dark:text-amber-400 dark:hover:bg-amber-950/50"
+      >
+        <Send class="size-3 shrink-0" aria-hidden="true" />
+        {chased ? 'Chase again' : 'Follow up'}
+      </button>
+    {/if}
   </span>
-</button>
+</div>

--- a/web/src/lib/components/BoardColumn.svelte
+++ b/web/src/lib/components/BoardColumn.svelte
@@ -11,6 +11,7 @@
     onconsider,
     onfinalize,
     onopen,
+    onfollowup,
   }: {
     id: BoardColumnId;
     label: string;
@@ -20,6 +21,7 @@
     // BoardItem extends MyJob; the card calls back with the item it received,
     // which satisfies MyJob. The parent can widen back to BoardItem via cast.
     onopen: (item: MyJob) => void;
+    onfollowup: (item: MyJob) => void;
   } = $props();
 
   // Neutral drop-target frame — overrides svelte-dnd-action's default yellow
@@ -46,7 +48,7 @@
   >
     {#each items as item (item.id)}
       <div>
-        <BoardCard {item} {onopen} />
+        <BoardCard {item} {onopen} {onfollowup} />
       </div>
     {/each}
   </div>

--- a/web/src/lib/components/FollowUpDialog.svelte
+++ b/web/src/lib/components/FollowUpDialog.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { Check, Copy, Clock, X } from '@lucide/svelte';
+  import { Button } from '$lib/ui';
+  import { api } from '$lib/api';
+  import { clipboardText } from '$lib/followup';
+  import { errorMessage } from '$lib/utils';
+  import { focusTrap } from '$lib/actions/focusTrap';
+  import type { FollowUpDraft } from '$lib/types';
+
+  // The parent owns open/close. onrecorded reports the chase back so the board can
+  // stamp the card without refetching the whole listing.
+  let {
+    slug,
+    company,
+    onclose,
+    onrecorded,
+  }: {
+    slug: string;
+    company: string;
+    onclose: () => void;
+    onrecorded: (at: string) => void;
+  } = $props();
+
+  let draft = $state.raw<FollowUpDraft | null>(null); // an API payload, only ever reassigned
+  let error = $state<string | null>(null);
+  let copied = $state(false);
+
+  // Fetch once per mount; the parent keys this dialog by slug, so the prop never
+  // changes underneath it.
+  $effect(() => {
+    void load();
+  });
+
+  async function load() {
+    try {
+      draft = await api.getFollowUpDraft(slug);
+    } catch (e) {
+      error = errorMessage(e, "Couldn't build the follow-up draft.");
+    }
+  }
+
+  // Copying IS the record: the candidate takes the text away to send it, and asking
+  // for a second confirming click is the friction this feature exists to remove.
+  // A failed POST does not undo the copy — the text is already on the clipboard, so
+  // the button stays "Copied" and only the chase mark is lost.
+  async function copy() {
+    if (!draft) return;
+    try {
+      await navigator.clipboard.writeText(clipboardText(draft));
+    } catch (e) {
+      error = errorMessage(e, "Couldn't copy to the clipboard.");
+      return;
+    }
+    copied = true;
+    try {
+      await api.recordFollowUp(slug);
+      onrecorded(new Date().toISOString());
+    } catch (e) {
+      error = errorMessage(e, "Copied, but couldn't record the follow-up.");
+    }
+  }
+</script>
+
+<svelte:window onkeydown={(e) => e.key === 'Escape' && onclose()} />
+
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+  <button type="button" aria-label="Close dialog" class="absolute inset-0 bg-black/50" onclick={onclose}></button>
+
+  <div
+    role="dialog"
+    aria-modal="true"
+    aria-label="Follow up"
+    class="relative z-10 flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-xl"
+    {@attach focusTrap()}
+  >
+    <div class="flex items-start gap-3 border-b border-border p-5">
+      <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-amber-100 dark:bg-amber-950/50">
+        <Clock class="size-5 text-amber-600 dark:text-amber-400" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <h2 class="text-lg font-semibold leading-tight">Follow up</h2>
+        <p class="mt-0.5 truncate text-sm text-muted-foreground">
+          {#if draft}
+            {company || 'This application'} — no reply for {draft.days_silent} days
+          {:else}
+            {company || 'This application'}
+          {/if}
+        </p>
+      </div>
+      <button
+        type="button"
+        onclick={onclose}
+        aria-label="Close"
+        class="-mr-1 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <X class="size-5" />
+      </button>
+    </div>
+
+    <div class="flex-1 overflow-y-auto p-5">
+      {#if error && !draft}
+        <p class="text-sm text-destructive">{error}</p>
+      {:else if !draft}
+        <p class="text-sm text-muted-foreground">Building your draft…</p>
+      {:else}
+        <dl class="flex flex-col gap-2 text-sm">
+          {#if draft.recipient}
+            <div class="flex gap-2">
+              <dt class="w-16 shrink-0 text-muted-foreground">To</dt>
+              <dd class="min-w-0 flex-1 truncate">
+                {draft.recipient_name ? `${draft.recipient_name} <${draft.recipient}>` : draft.recipient}
+              </dd>
+            </div>
+          {/if}
+          <div class="flex gap-2">
+            <dt class="w-16 shrink-0 text-muted-foreground">Subject</dt>
+            <dd class="min-w-0 flex-1 font-medium">{draft.subject}</dd>
+          </div>
+        </dl>
+        <pre
+          class="mt-4 whitespace-pre-wrap rounded-lg border border-border bg-muted/40 p-3 font-sans text-sm leading-relaxed">{draft.body}</pre>
+        <p class="mt-3 text-xs text-muted-foreground">
+          Send it from your own mail — freehire never writes to anyone on your behalf.
+        </p>
+        {#if error}
+          <p class="mt-2 text-xs text-destructive">{error}</p>
+        {/if}
+      {/if}
+    </div>
+
+    <div class="flex justify-end gap-2 border-t border-border p-4">
+      <Button variant="outline" onclick={onclose}>Close</Button>
+      <Button variant="primary" onclick={copy} disabled={!draft} class="gap-1.5">
+        {#if copied}
+          <Check class="size-4" /> Copied
+        {:else}
+          <Copy class="size-4" /> Copy draft
+        {/if}
+      </Button>
+    </div>
+  </div>
+</div>

--- a/web/src/lib/components/FollowUpDialog.svelte
+++ b/web/src/lib/components/FollowUpDialog.svelte
@@ -2,7 +2,7 @@
   import { Check, Copy, Clock, X } from '@lucide/svelte';
   import { Button } from '$lib/ui';
   import { api } from '$lib/api';
-  import { clipboardText } from '$lib/followup';
+  import { clipboardText, gmailHref, mailtoHref } from '$lib/followup';
   import { errorMessage } from '$lib/utils';
   import { focusTrap } from '$lib/actions/focusTrap';
   import type { FollowUpDraft } from '$lib/types';
@@ -25,6 +25,8 @@
   let error = $state<string | null>(null);
   let copied = $state(false);
 
+  const who = $derived(company || 'This application');
+
   // Fetch once per mount; the parent keys this dialog by slug, so the prop never
   // changes underneath it.
   $effect(() => {
@@ -39,10 +41,19 @@
     }
   }
 
-  // Copying IS the record: the candidate takes the text away to send it, and asking
-  // for a second confirming click is the friction this feature exists to remove.
-  // A failed POST does not undo the copy — the text is already on the clipboard, so
-  // the button stays "Copied" and only the chase mark is lost.
+  // Taking the draft away IS the record — by clipboard or by compose link, both hand
+  // it to the candidate, and asking for a second confirming click reintroduces the
+  // friction this feature removes. A failed POST does not undo the handoff: the draft
+  // is already gone, so only the chase mark is lost and the message says so.
+  async function record() {
+    try {
+      await api.recordFollowUp(slug);
+      onrecorded(new Date().toISOString());
+    } catch (e) {
+      error = errorMessage(e, "Couldn't record the follow-up — your draft is unaffected.");
+    }
+  }
+
   async function copy() {
     if (!draft) return;
     try {
@@ -52,12 +63,7 @@
       return;
     }
     copied = true;
-    try {
-      await api.recordFollowUp(slug);
-      onrecorded(new Date().toISOString());
-    } catch (e) {
-      error = errorMessage(e, "Copied, but couldn't record the follow-up.");
-    }
+    await record();
   }
 </script>
 
@@ -80,11 +86,7 @@
       <div class="min-w-0 flex-1">
         <h2 class="text-lg font-semibold leading-tight">Follow up</h2>
         <p class="mt-0.5 truncate text-sm text-muted-foreground">
-          {#if draft}
-            {company || 'This application'} — no reply for {draft.days_silent} days
-          {:else}
-            {company || 'This application'}
-          {/if}
+          {who}{#if draft}&nbsp;— no reply for {draft.days_silent} days{/if}
         </p>
       </div>
       <button
@@ -128,15 +130,39 @@
       {/if}
     </div>
 
-    <div class="flex justify-end gap-2 border-t border-border p-4">
-      <Button variant="outline" onclick={onclose}>Close</Button>
-      <Button variant="primary" onclick={copy} disabled={!draft} class="gap-1.5">
-        {#if copied}
-          <Check class="size-4" /> Copied
-        {:else}
-          <Copy class="size-4" /> Copy draft
-        {/if}
-      </Button>
+    <div class="flex flex-wrap items-center gap-2 border-t border-border p-4">
+      {#if draft}
+        <!-- Both links open a compose window in the candidate's own client, prefilled.
+             Neither sends; both record the chase on the way out. Gmail is offered
+             beside mailto because a browser with no registered mail handler does
+             nothing at all on a mailto click. -->
+        <!-- eslint-disable svelte/no-navigation-without-resolve -- mail handoffs, not internal routes -->
+        <span class="flex items-center gap-1 text-xs text-muted-foreground">
+          Open in
+          <a
+            href={gmailHref(draft)}
+            target="_blank"
+            rel="noopener noreferrer"
+            onclick={record}
+            class="font-medium text-brand-strong hover:underline">Gmail</a
+          >
+          <span aria-hidden="true">·</span>
+          <a href={mailtoHref(draft)} onclick={record} class="font-medium text-brand-strong hover:underline">
+            Mail app
+          </a>
+        </span>
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
+      {/if}
+      <span class="ml-auto flex gap-2">
+        <Button variant="outline" onclick={onclose}>Close</Button>
+        <Button variant="primary" onclick={copy} disabled={!draft} class="gap-1.5">
+          {#if copied}
+            <Check class="size-4" /> Copied
+          {:else}
+            <Copy class="size-4" /> Copy draft
+          {/if}
+        </Button>
+      </span>
     </div>
   </div>
 </div>

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -7,6 +7,7 @@
   import { BOARD_COLUMNS, columnOf, type BoardColumnId, type BoardItem, type ClosedOutcome } from '$lib/board';
   import BoardColumn from './BoardColumn.svelte';
   import JobDrawer from './JobDrawer.svelte';
+  import FollowUpDialog from './FollowUpDialog.svelte';
   import States from './States.svelte';
 
   // initialSlug (from /my/tracking/[slug]) opens that application's drawer once the
@@ -31,6 +32,9 @@
   // Drawer state. A Closed drop opens the drawer requiring an outcome choice.
   let openItem = $state.raw<BoardItem | null>(null);
   let pendingOutcome = $state(false);
+  // The follow-up dialog is its own overlay, not a drawer tab: it is reached from
+  // the card's silence badge and closes back to the board.
+  let followUpItem = $state.raw<BoardItem | null>(null);
 
   // Lay the fetched rows out into the columns and open the deep-linked drawer once.
   // The 'board' filter returns saved ∪ applied ∪ stage; saved-only rows are dropped
@@ -211,6 +215,17 @@
     pushState(resolve('/my/tracking'), {}); // drop the per-application slug from the URL
   }
 
+  function openFollowUp(item: MyJob) {
+    followUpItem = item as BoardItem;
+  }
+
+  // Stamp the recorded chase onto the card in place. The board holds the only copy
+  // of the row, and reloading the whole listing to learn one timestamp is noise —
+  // the same optimistic treatment stage moves already get.
+  function markChased(at: string) {
+    if (followUpItem) followUpItem.followed_up_at = at;
+  }
+
   function openDrawer(item: MyJob) {
     openItem = item as BoardItem;
     pendingOutcome = false;
@@ -233,6 +248,7 @@
         {onconsider}
         {onfinalize}
         onopen={openDrawer}
+        onfollowup={openFollowUp}
       />
     {/each}
   </div>
@@ -248,6 +264,17 @@
       onchooseoutcome={chooseOutcome}
       onremove={remove}
       onclose={closeDrawer}
+    />
+  {/key}
+{/if}
+
+{#if followUpItem}
+  {#key followUpItem.job.public_slug}
+    <FollowUpDialog
+      slug={followUpItem.job.public_slug}
+      company={followUpItem.job.company}
+      onclose={() => (followUpItem = null)}
+      onrecorded={markChased}
     />
   {/key}
 {/if}

--- a/web/src/lib/followup.test.ts
+++ b/web/src/lib/followup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { canFollowUp, chasedLabel, clipboardText } from './followup';
+import { canFollowUp, chasedLabel, clipboardText, mailtoHref, gmailHref } from './followup';
 import type { MyJob, FollowUpDraft } from './types';
 
 // The card's follow-up logic reads only the silence verdict and the chase mark;
@@ -73,5 +73,45 @@ describe('clipboardText', () => {
     expect(clipboardText({ ...draft, recipient: 'jane@acme.com' })).toBe(
       'To: jane@acme.com\nSubject: Following up: Go Engineer application\n\nHello,\n\nI applied…',
     );
+  });
+});
+
+describe('compose links', () => {
+  const draft: FollowUpDraft = {
+    subject: 'Following up: Go Engineer application',
+    body: 'Hello,\n\nI applied…',
+    days_silent: 24,
+  };
+
+  // Paragraph breaks are the whole shape of the message. Left raw, a mail client
+  // may collapse them into one run-on paragraph.
+  it('percent-encodes the newlines that carry the paragraphs', () => {
+    expect(mailtoHref(draft)).toContain('body=Hello%2C%0A%0AI%20applied');
+    expect(gmailHref(draft)).toContain('body=Hello%2C%0A%0AI%20applied');
+  });
+
+  // RFC 6068 keeps the `@` literal in a mailto addr-spec; clients that do not decode
+  // %40 open with an empty To field, which reads as the link being broken. Inside
+  // Gmail's `to=` query parameter the encoded form is ordinary and correct.
+  it('addresses the message when a recipient is known', () => {
+    expect(mailtoHref({ ...draft, recipient: 'jane@acme.com' })).toMatch(/^mailto:jane@acme\.com\?/);
+    expect(gmailHref({ ...draft, recipient: 'jane@acme.com' })).toContain('to=jane%40acme.com');
+  });
+
+  // The address arrives from a parsed mail header, not a controlled vocabulary. A `?`
+  // or `&` in it would otherwise start injecting mailto parameters.
+  it('still encodes everything around the @', () => {
+    expect(mailtoHref({ ...draft, recipient: 'a?b&c@ex ample.com' })).toMatch(/^mailto:a%3Fb%26c@ex%20ample\.com\?/);
+  });
+
+  // The commonest silent application has nobody to address. The link must still open
+  // a compose window with the text in it, leaving the To field for the candidate.
+  it('opens an unaddressed compose when no recipient is known', () => {
+    expect(mailtoHref(draft)).toMatch(/^mailto:\?/);
+    expect(gmailHref(draft)).not.toContain('to=');
+  });
+
+  it('points Gmail at its compose view', () => {
+    expect(gmailHref(draft)).toMatch(/^https:\/\/mail\.google\.com\/mail\/\?view=cm&fs=1&/);
   });
 });

--- a/web/src/lib/followup.test.ts
+++ b/web/src/lib/followup.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { canFollowUp, chasedLabel, clipboardText } from './followup';
+import type { MyJob, FollowUpDraft } from './types';
+
+// The card's follow-up logic reads only the silence verdict and the chase mark;
+// a minimal cast fixture suffices.
+function job(fields: Partial<MyJob>): MyJob {
+  return { silence_state: null, days_silent: null, followed_up_at: null, ...fields } as MyJob;
+}
+
+const NOW = new Date('2026-07-30T12:00:00Z');
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
+
+describe('canFollowUp', () => {
+  it('offers a draft on a silent application', () => {
+    expect(canFollowUp(job({ silence_state: 'silent', days_silent: 24 }))).toBe(true);
+  });
+
+  it('offers nothing where the board shows no silence badge', () => {
+    expect(canFollowUp(job({ silence_state: 'active', days_silent: 3 }))).toBe(false);
+    expect(canFollowUp(job({ silence_state: 'unconfirmed', days_silent: 30 }))).toBe(false);
+    expect(canFollowUp(job({ silence_state: null }))).toBe(false);
+  });
+
+  // The server refuses anything that is not `silent`, so an offer the server would
+  // reject is a button that 409s. Already having chased is not such a case: the
+  // employer still has not replied, and a second chase is the candidate's call.
+  it('keeps offering after a chase was recorded', () => {
+    expect(canFollowUp(job({ silence_state: 'silent', days_silent: 24, followed_up_at: daysAgo(2) }))).toBe(true);
+  });
+});
+
+describe('chasedLabel', () => {
+  it('says nothing for an application never chased', () => {
+    expect(chasedLabel(job({ silence_state: 'silent', days_silent: 24 }), NOW)).toBeNull();
+  });
+
+  it('reports the chase in the same day unit as the silence badge', () => {
+    expect(chasedLabel(job({ followed_up_at: daysAgo(2) }), NOW)).toBe('chased 2d ago');
+    expect(chasedLabel(job({ followed_up_at: daysAgo(45) }), NOW)).toBe('chased 45d ago');
+  });
+
+  it('reads naturally on the day of the chase', () => {
+    expect(chasedLabel(job({ followed_up_at: daysAgo(0) }), NOW)).toBe('chased today');
+  });
+
+  // A clock skew between server and browser must not print "chased -1d ago".
+  it('floors a future timestamp at today', () => {
+    expect(chasedLabel(job({ followed_up_at: daysAgo(-1) }), NOW)).toBe('chased today');
+  });
+
+  it('ignores an unparseable timestamp rather than rendering NaN', () => {
+    expect(chasedLabel(job({ followed_up_at: 'not-a-date' }), NOW)).toBeNull();
+  });
+});
+
+describe('clipboardText', () => {
+  const draft: FollowUpDraft = {
+    subject: 'Following up: Go Engineer application',
+    body: 'Hello,\n\nI applied…',
+    days_silent: 24,
+  };
+
+  // The draft is pasted into a mail client, where the subject is a separate field.
+  // Labelling it keeps it from silently becoming the first line of the body.
+  it('carries the subject labelled, above the body', () => {
+    expect(clipboardText(draft)).toBe(
+      'Subject: Following up: Go Engineer application\n\nHello,\n\nI applied…',
+    );
+  });
+
+  it('adds the recipient only when one is known', () => {
+    expect(clipboardText({ ...draft, recipient: 'jane@acme.com' })).toBe(
+      'To: jane@acme.com\nSubject: Following up: Go Engineer application\n\nHello,\n\nI applied…',
+    );
+  });
+});

--- a/web/src/lib/followup.ts
+++ b/web/src/lib/followup.ts
@@ -1,0 +1,39 @@
+// View logic for the board's follow-up affordance: whether a card offers a draft,
+// how it reports a chase that already happened, and what lands in the clipboard.
+//
+// The chase is a SECOND reading, never a replacement. `followed_up_at` is outside
+// the server's last-activity derivation on purpose (see migration 0059): silence
+// measures how long the employer has been quiet, and the candidate chasing is not
+// a reply. A chased card therefore keeps its "24d" badge and adds "chased 2d ago".
+import type { MyJob, FollowUpDraft } from './types';
+
+/** Whether the card offers a follow-up draft. Mirrors the server's gate exactly —
+ *  it refuses anything whose silence state is not `silent` — so the button can
+ *  never be shown where the request would 409. Having already chased does not
+ *  withdraw the offer: the employer still has not replied. */
+export function canFollowUp(item: MyJob): boolean {
+  return item.silence_state === 'silent';
+}
+
+/** How the card reports a chase, or null for an application never chased (and for
+ *  a timestamp that will not parse — a missing line beats "chased NaNd ago").
+ *  Whole days, floored at zero, matching the silence badge's unit so the two
+ *  readings sit side by side without inviting arithmetic between them. */
+export function chasedLabel(item: MyJob, now: Date = new Date()): string | null {
+  if (!item.followed_up_at) return null;
+  const at = new Date(item.followed_up_at);
+  if (Number.isNaN(at.getTime())) return null;
+  const days = Math.floor((now.getTime() - at.getTime()) / 86_400_000);
+  // A browser clock ahead of the server would otherwise print a negative age.
+  return days <= 0 ? 'chased today' : `chased ${days}d ago`;
+}
+
+/** The draft as one pasteable block. The subject is labelled rather than merged
+ *  into the body: a mail client keeps them in separate fields, and an unlabelled
+ *  first line silently becomes part of the message. The recipient is prefixed only
+ *  when linked mail supplied one — the commonest silent application has nobody to
+ *  address, and an empty "To:" would read as a missing value rather than an absent one. */
+export function clipboardText(draft: FollowUpDraft): string {
+  const head = draft.recipient ? `To: ${draft.recipient}\n` : '';
+  return `${head}Subject: ${draft.subject}\n\n${draft.body}`;
+}

--- a/web/src/lib/followup.ts
+++ b/web/src/lib/followup.ts
@@ -37,3 +37,35 @@ export function clipboardText(draft: FollowUpDraft): string {
   const head = draft.recipient ? `To: ${draft.recipient}\n` : '';
   return `${head}Subject: ${draft.subject}\n\n${draft.body}`;
 }
+
+// Both compose links open a window in the candidate's own client and never send —
+// the same handoff the copy action makes, one click shorter. encodeURIComponent turns
+// the paragraph breaks into %0A; left raw, some clients run the paragraphs together.
+// Both targets cap the URL near 2 KB, comfortably above a draft this size, and the
+// copy action stays as the escape hatch if that ever stops being true.
+
+/** A `mailto:` for the candidate's default mail client. An unaddressed draft still
+ *  opens a compose window with the To field left blank — that is the commonest
+ *  silent application, and withholding the link there would help nobody. */
+export function mailtoHref(draft: FollowUpDraft): string {
+  const to = draft.recipient ? mailtoAddress(draft.recipient) : '';
+  return `mailto:${to}?subject=${encodeURIComponent(draft.subject)}&body=${encodeURIComponent(draft.body)}`;
+}
+
+/** RFC 6068 keeps the `@` literal in a mailto addr-spec, and clients that do not decode
+ *  `%40` open with an empty To field — indistinguishable, to the candidate, from the link
+ *  being broken. Everything either side of it is still encoded: the address comes from a
+ *  parsed mail header, so a stray `?` or `&` would otherwise inject mailto parameters. */
+function mailtoAddress(addr: string): string {
+  const at = addr.lastIndexOf('@');
+  if (at < 0) return encodeURIComponent(addr);
+  return `${encodeURIComponent(addr.slice(0, at))}@${encodeURIComponent(addr.slice(at + 1))}`;
+}
+
+/** Gmail's web compose (`su`, not `subject`). Worth offering beside `mailto:` because
+ *  a browser whose OS registers no mail handler does nothing at all on a mailto click
+ *  — a silent failure the candidate would read as the feature being broken. */
+export function gmailHref(draft: FollowUpDraft): string {
+  const to = draft.recipient ? `to=${encodeURIComponent(draft.recipient)}&` : '';
+  return `https://mail.google.com/mail/?view=cm&fs=1&${to}su=${encodeURIComponent(draft.subject)}&body=${encodeURIComponent(draft.body)}`;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -424,6 +424,11 @@ export interface MyJob {
    *  say otherwise. Null means nothing is owed here (viewed/saved only, or a
    *  settled application), which is not the same as owed-and-answered-promptly. */
   silence_state: 'active' | 'silent' | 'unconfirmed' | null;
+  /** When the candidate last recorded chasing this application (RFC3339), or null
+   *  for one never chased. Deliberately independent of the silence fields above: a
+   *  chase is not a reply, so a chased application keeps counting its silence and
+   *  the card shows both readings. */
+  followed_up_at: string | null;
 }
 
 /** The account-level saved-job reminder rule: whether reminders are on, the
@@ -474,7 +479,21 @@ export interface TrackedApplication {
   applied_at: string | null;
   stage?: string;
   notes?: string;
+  /** When the caller last recorded chasing this application, or null for never. */
+  followed_up_at: string | null;
   emails: ApplicationEmail[];
+}
+
+/** The assembled follow-up message for a silent application. Deterministic and
+ *  template-built server-side — no model, no credits. `recipient` is present only
+ *  when linked mail supplied an address; an unanswered application (the commonest
+ *  silent one) has nobody to address, and the draft is issued without one. */
+export interface FollowUpDraft {
+  subject: string;
+  body: string;
+  recipient?: string;
+  recipient_name?: string;
+  days_silent: number;
 }
 
 /** Per-tab row counts for the my-jobs page, from the listing's meta. `viewed`


### PR DESCRIPTION
The board already said an application had gone quiet — "No reply for 24 days" — and offered nothing to do about it. This adds the action, and touches none of the measurement.

## What lands

**A deterministic draft.** `internal/followup` assembles subject + body from a template: role, company, elapsed time, a concrete ask. No LLM, no credits, no metering. The one non-generic line is a strength taken from the cached fit analysis — text derived from the candidate's own CV. No cached analysis means the line is dropped, never invented: the provenance rule holds here because there is no other source to draw on.

**Two endpoints on the tracking surface.** `GET /me/tracking/:slug/followup` assembles; `POST` records the chase. The draft endpoint gates on `userjob.SilenceStateFor`, the same verdict the badge renders, so the offer and the badge cannot disagree about which applications qualify.

**The board.** A silent card carries a Follow up button beside its badge. The dialog shows the assembled message with three ways to take it: clipboard, Gmail web compose, and `mailto:`. All three hand the text to the candidate's own client — any of them records the chase, because a card that said "not chased" after they left through a link would be lying.

**A chased card keeps its silence marker** and adds "chased 2d ago". The employer still has not replied.

## The invariant this change is built around

`followed_up_at` is NOT part of `last_activity_at = GREATEST(applied_at, newest linked inbound mail)`. Silence measures how long the *other side* has been quiet, and the candidate chasing is not a reply — feeding it in would clear the badge at the moment it matters most. The column is carried *beside* the verdict, never inside its inputs: `SilenceStateFor` is not given it and so cannot read it. `TestAFollowUpDoesNotStopTheSilenceClock` was watched failing with the column wired into the `GREATEST(...)` before being trusted; migration 0059 carries the comment.

## Non-goal, enforced by construction

Nothing here sends mail. `inboxHandlers` holds no mail client at all — a test asserting a nil mailer would have asserted against a field that does not exist.

## Notes for the reviewer

- `followed_up_at` reached the sqlc rows in an earlier commit but stopped there; neither the domain type nor the two wire shapes carried it, so the board could not have rendered it. That gap is closed here.
- `BoardCard` stops being one `<button>` — a second control cannot nest inside the first. The open action stretches over the card via an `::after` overlay and the follow-up button sits above it. The badge row is lifted to `z-10` so its title tooltips survive the overlay; that strip stops opening the drawer in exchange, which is the smaller loss.
- Two encoding details are pinned by tests: paragraph breaks must survive as `%0A`, and the `mailto:` addr-spec keeps its `@` literal per RFC 6068 while everything either side stays encoded (the address comes from a parsed mail header).

## Verification

`go build` / `go vet` / `go test ./...`; `go test -tags=integration ./internal/db/ ./internal/handler/`; in `web/`: lint, `svelte-check` (0 errors), 562 tests, build.

Verified visually at 1100 and at a real 390 (CDP device emulation — `--window-size` clamps the layout viewport at 500). No card or dialog overflows. Click routing hit-tested with dispatched pointer events: Follow up does not open the drawer, the rest of the card does — the one failure mode a screenshot cannot show.

OpenSpec: `openspec/changes/application-followup-draft/` — 14/14 tasks.