### PR TITLE
refactor(web): give the inbox's settings pane its own component

### DIFF
--- a/web/src/lib/components/InboxSettings.svelte
+++ b/web/src/lib/components/InboxSettings.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  // The inbox's Settings pane: the two ways to get mail in. It owns its own
+  // mutations (claim, release, disconnect) and the flags that go with them, and
+  // reports the outcome upward — the mail list, its filters and its pager live in
+  // InboxView and stay there.
+  //
+  // `sync` is deliberately NOT owned here even though its button is. Syncing polls
+  // the listing repeatedly while Gmail catches up, and that loop belongs beside the
+  // pager it polls; this component only renders the button and its pending state.
+  import { api } from '$lib/api';
+  import type { GmailStatus, MailboxStatus, InboxSource } from '$lib/api';
+  import { Badge, Button } from '$lib/ui';
+  import { Mail, AtSign, Copy } from '@lucide/svelte';
+  import { errorMessage } from '$lib/utils';
+
+  interface Props {
+    gmail: GmailStatus | null;
+    mailbox: MailboxStatus | null;
+    /** True while the parent's sync poll is running. */
+    syncing: boolean;
+    /** Run the Gmail sync + the listing poll that follows it. */
+    onSync: () => void;
+    /** Open the first-time connect explainer. */
+    onConnect: () => void;
+    /** Send the browser to Google's consent screen (re-consent path). */
+    onReconnect: () => void;
+    /**
+     * A source was added or removed. `removed` names the account that went away, so
+     * the parent can drop a filter pointing at it before reloading.
+     */
+    onSourceChanged: (removed: InboxSource | null) => void;
+    onError: (message: string) => void;
+  }
+
+  let {
+    gmail = $bindable(),
+    mailbox = $bindable(),
+    syncing,
+    onSync,
+    onConnect,
+    onReconnect,
+    onSourceChanged,
+    onError,
+  }: Props = $props();
+
+  let claiming = $state(false);
+
+  const hasGmail = $derived(!!gmail?.connected);
+  const hasMailbox = $derived(!!mailbox?.address);
+
+  async function disconnectGmail() {
+    if (!confirm('Disconnect Gmail and remove its synced mail?')) return;
+    try {
+      await api.disconnectGmail();
+      gmail = { connected: false, available: gmail?.available };
+      onSourceChanged('gmail');
+    } catch (e) {
+      onError(errorMessage(e, 'Failed to disconnect.'));
+    }
+  }
+
+  async function claimMailbox() {
+    if (claiming) return;
+    claiming = true;
+    try {
+      mailbox = await api.claimMailbox();
+      onSourceChanged(null);
+    } catch (e) {
+      onError(errorMessage(e, 'Failed to create a mailbox.'));
+    } finally {
+      claiming = false;
+    }
+  }
+
+  async function releaseMailbox() {
+    if (!confirm('Release your freehire mailbox and delete its received mail?')) return;
+    try {
+      mailbox = await api.releaseMailbox();
+      onSourceChanged('hosted');
+    } catch (e) {
+      onError(errorMessage(e, 'Failed to release the mailbox.'));
+    }
+  }
+
+  function copyAddress() {
+    if (mailbox?.address) navigator.clipboard?.writeText(mailbox.address);
+  }
+</script>
+
+<!-- Sources: the two ways to get mail in — connect Gmail and/or claim a mailbox. -->
+<div class="grid gap-3 sm:grid-cols-2">
+  <!-- Gmail -->
+  <div class="rounded-xl border border-border bg-card p-4">
+    <div class="flex items-center gap-2 text-sm font-medium">
+      <Mail class="h-4 w-4 text-muted-foreground" /> Gmail
+    </div>
+    {#if hasGmail}
+      <p class="mt-1 truncate text-xs text-muted-foreground">{gmail?.email}</p>
+      {#if gmail?.status === 'needs_reconsent'}
+        <Badge variant="outline" class="mt-2 border-destructive/40 text-destructive">Reconnect needed</Badge>
+      {/if}
+      <div class="mt-3 flex flex-wrap gap-2">
+        {#if gmail?.status === 'needs_reconsent'}
+          <Button variant="secondary" size="sm" onclick={onReconnect}>Reconnect</Button>
+        {/if}
+        <Button variant="secondary" size="sm" disabled={syncing} onclick={onSync}>
+          {syncing ? 'Syncing…' : 'Sync'}
+        </Button>
+        <Button variant="outline" size="sm" onclick={disconnectGmail}>Disconnect</Button>
+      </div>
+    {:else if gmail?.available}
+      <p class="mt-1 text-xs text-muted-foreground">Pull replies from your own Gmail (needs Google sign-in).</p>
+      <Button variant="primary" size="sm" class="mt-3" onclick={onConnect}>
+        Connect Gmail <Mail class="h-4 w-4" />
+      </Button>
+    {:else}
+      <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
+    {/if}
+  </div>
+
+  <!-- Hosted mailbox -->
+  <div class="rounded-xl border border-border bg-card p-4">
+    <div class="flex items-center gap-2 text-sm font-medium">
+      <AtSign class="h-4 w-4 text-muted-foreground" /> freehire mailbox
+    </div>
+    {#if hasMailbox}
+      <div class="mt-1 flex items-center gap-1">
+        <code class="truncate rounded bg-muted px-1.5 py-0.5 text-xs">{mailbox?.address}</code>
+        <button type="button" onclick={copyAddress} title="Copy address" class="shrink-0 text-muted-foreground hover:text-foreground">
+          <Copy class="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <p class="mt-2 text-xs text-muted-foreground">Use this address when you apply — replies land here.</p>
+      <Button variant="outline" size="sm" class="mt-3" onclick={releaseMailbox}>Release</Button>
+    {:else if mailbox?.available}
+      <p class="mt-1 text-xs text-muted-foreground">Get an address on our domain — no Google needed.</p>
+      <Button variant="primary" size="sm" class="mt-3" disabled={claiming} onclick={claimMailbox}>
+        {claiming ? 'Creating…' : 'Get a freehire mailbox'} <AtSign class="h-4 w-4" />
+      </Button>
+    {:else}
+      <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
+    {/if}
+  </div>
+</div>

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -17,9 +17,10 @@
   import { Paginator } from '$lib/paginated.svelte';
   import { Badge, Button } from '$lib/ui';
   import GmailConnectDialog from './GmailConnectDialog.svelte';
+  import InboxSettings from './InboxSettings.svelte';
   import ApplicationLinkPicker from './ApplicationLinkPicker.svelte';
   import InfiniteScroll from './InfiniteScroll.svelte';
-  import { Mail, AtSign, Copy, Search, RefreshCw, ChevronLeft, CheckCheck, Trash2 } from '@lucide/svelte';
+  import { Mail, Search, RefreshCw, ChevronLeft, CheckCheck, Trash2 } from '@lucide/svelte';
   import { timeAgo, errorMessage } from '$lib/utils';
   import { avatarInitials, avatarColor } from '$lib/avatar';
 
@@ -53,7 +54,6 @@
   );
 
   let syncing = $state(false);
-  let claiming = $state(false);
   let refreshing = $state(false);
   let markingAll = $state(false);
 
@@ -421,17 +421,6 @@
     }
   }
 
-  async function disconnectGmail() {
-    if (!confirm('Disconnect Gmail and remove its synced mail?')) return;
-    try {
-      await api.disconnectGmail();
-      gmail = { connected: false, available: gmail?.available };
-      if (source === 'gmail') source = '';
-      await refresh();
-    } catch (e) {
-      error = errorMessage(e, 'Failed to disconnect.');
-    }
-  }
 
   // Deep link to a Gmail message in Gmail's web UI (the Gmail API id is the URL id).
   const gmailUrl = (externalId: string) =>
@@ -439,33 +428,15 @@
 
   // --- Hosted mailbox source ---
 
-  async function claimMailbox() {
-    if (claiming) return;
-    claiming = true;
-    error = null;
-    try {
-      mailbox = await api.claimMailbox();
-      await refresh();
-    } catch (e) {
-      error = errorMessage(e, 'Failed to create a mailbox.');
-    } finally {
-      claiming = false;
-    }
-  }
 
-  async function releaseMailbox() {
-    if (!confirm('Release your freehire mailbox and delete its received mail?')) return;
-    try {
-      mailbox = await api.releaseMailbox();
-      if (source === 'hosted') source = '';
-      await refresh();
-    } catch (e) {
-      error = errorMessage(e, 'Failed to release the mailbox.');
-    }
-  }
 
-  function copyAddress() {
-    if (mailbox?.address) navigator.clipboard?.writeText(mailbox.address);
+
+  // A source was added or removed in the Settings pane. A filter pointing at an
+  // account that no longer exists would render an empty list that looks like "no
+  // mail" rather than "no such account", so clear it before reloading.
+  async function onSourceChanged(removed: InboxSource | null) {
+    if (removed && source === removed) source = '';
+    await refresh();
   }
 
   // Refresh the listing after a source is added/removed; empties it when none left.
@@ -511,61 +482,16 @@
     </div>
 
     {#if tab === 'settings'}
-      <!-- Sources: the two ways to get mail in — connect Gmail and/or claim a mailbox. -->
-      <div class="grid gap-3 sm:grid-cols-2">
-        <!-- Gmail -->
-        <div class="rounded-xl border border-border bg-card p-4">
-          <div class="flex items-center gap-2 text-sm font-medium">
-            <Mail class="h-4 w-4 text-muted-foreground" /> Gmail
-          </div>
-          {#if hasGmail}
-            <p class="mt-1 truncate text-xs text-muted-foreground">{gmail?.email}</p>
-            {#if gmail?.status === 'needs_reconsent'}
-              <Badge variant="outline" class="mt-2 border-destructive/40 text-destructive">Reconnect needed</Badge>
-            {/if}
-            <div class="mt-3 flex flex-wrap gap-2">
-              {#if gmail?.status === 'needs_reconsent'}
-                <Button variant="secondary" size="sm" onclick={connectGmail}>Reconnect</Button>
-              {/if}
-              <Button variant="secondary" size="sm" disabled={syncing} onclick={sync}>
-                {syncing ? 'Syncing…' : 'Sync'}
-              </Button>
-              <Button variant="outline" size="sm" onclick={disconnectGmail}>Disconnect</Button>
-            </div>
-          {:else if gmail?.available}
-            <p class="mt-1 text-xs text-muted-foreground">Pull replies from your own Gmail (needs Google sign-in).</p>
-            <Button variant="primary" size="sm" class="mt-3" onclick={() => (showConnectDialog = true)}>
-              Connect Gmail <Mail class="h-4 w-4" />
-            </Button>
-          {:else}
-            <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
-          {/if}
-        </div>
-
-        <!-- Hosted mailbox -->
-        <div class="rounded-xl border border-border bg-card p-4">
-          <div class="flex items-center gap-2 text-sm font-medium">
-            <AtSign class="h-4 w-4 text-muted-foreground" /> freehire mailbox
-          </div>
-          {#if hasMailbox}
-            <div class="mt-1 flex items-center gap-1">
-              <code class="truncate rounded bg-muted px-1.5 py-0.5 text-xs">{mailbox?.address}</code>
-              <button type="button" onclick={copyAddress} title="Copy address" class="shrink-0 text-muted-foreground hover:text-foreground">
-                <Copy class="h-3.5 w-3.5" />
-              </button>
-            </div>
-            <p class="mt-2 text-xs text-muted-foreground">Use this address when you apply — replies land here.</p>
-            <Button variant="outline" size="sm" class="mt-3" onclick={releaseMailbox}>Release</Button>
-          {:else if mailbox?.available}
-            <p class="mt-1 text-xs text-muted-foreground">Get an address on our domain — no Google needed.</p>
-            <Button variant="primary" size="sm" class="mt-3" disabled={claiming} onclick={claimMailbox}>
-              {claiming ? 'Creating…' : 'Get a freehire mailbox'} <AtSign class="h-4 w-4" />
-            </Button>
-          {:else}
-            <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
-          {/if}
-        </div>
-      </div>
+      <InboxSettings
+        bind:gmail
+        bind:mailbox
+        {syncing}
+        onSync={sync}
+        onConnect={() => (showConnectDialog = true)}
+        onReconnect={connectGmail}
+        onSourceChanged={onSourceChanged}
+        onError={(m) => (error = m)}
+      />
     {:else if !hasAnySource}
       <p class="py-8 text-center text-sm text-muted-foreground">
         No mail source yet —

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -15,7 +15,7 @@
   import { statusLabel, statusClass, STATUS_LABELS } from '$lib/emailStatus';
   import { inboxLinkState, type LastUnlinked } from '$lib/inboxLink';
   import { Paginator } from '$lib/paginated.svelte';
-  import { Badge, Button } from '$lib/ui';
+  import { Badge } from '$lib/ui';
   import GmailConnectDialog from './GmailConnectDialog.svelte';
   import InboxSettings from './InboxSettings.svelte';
   import ApplicationLinkPicker from './ApplicationLinkPicker.svelte';


### PR DESCRIPTION
The last item from the mail-feature review. `InboxView.svelte` held three features in 879
lines — the account-setup tab, the message list, and the reading pane with its linking — and
25 async functions between them.

`InboxSettings.svelte` now owns the Settings pane: the two source cards, its own mutations
(claim, release, disconnect) and the flags that go with them. It reports outcomes upward
through `onSourceChanged(removed)` so the parent can drop a filter pointing at an account
that no longer exists before reloading. `InboxView` is 93 lines lighter.

**`sync` deliberately did NOT move**, even though its button did. Syncing polls the listing
repeatedly while Gmail catches up, and that loop belongs beside the pager it polls; the
component renders the button and its pending state, nothing else.

## Why this was held back, and what closed it

Moving reactive state across a component boundary fails *silently* when it fails — a
`$bindable` mistake leaves a pane that simply stops updating, and neither `pnpm check` nor
any test in this repo would catch it (components have no test runner here). So it wanted a
real browser.

Verified against a local stack (scratch DB, API, dev server) driven over CDP:

- Settings renders both cards, the mailbox address, Release and the copy button.
- **Release updates the pane** — the address disappears and the claim button returns. That is
  the two-way binding, exercised end to end.
- **Re-claim restores it** — the address and Release come back.
- Back on the Inbox tab the three seeded messages still render, and the account switcher has
  recomputed to `All / Mailbox / Pushed`, so `onSourceChanged` reached the pager.
- 0 page errors across the whole sequence.

The **Gmail-connected** branch is the one state a local stack cannot reach (no OAuth
credentials), so it is covered differently: its markup is byte-identical to what was removed,
modulo the two handlers that became props — asserted by diffing the extracted block against
`origin/main`.

## Verification

`pnpm check` (0 errors), `pnpm test` (562), `pnpm build`, plus the CDP run above.