### PR TITLE
feat: UK and NL visa-sponsor registers as company credentials

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gzuidhof/tygo/tygo"
 
 	"github.com/strelov1/freehire/internal/classify"
+	"github.com/strelov1/freehire/internal/collections"
 	"github.com/strelov1/freehire/internal/location"
 	"github.com/strelov1/freehire/internal/roletag"
 	"github.com/strelov1/freehire/internal/sources"
@@ -271,6 +272,10 @@ func genVocab() string {
 	// Role slug→shorthand-aliases for the picker's search: the same curated terms
 	// used to tag titles, so typing "swe"/"sre"/"devrel" finds the role.
 	b.WriteString(emitMapOfSlices("RoleAliases", "ROLE_ALIASES", roleAliases()))
+	// The company-tag registry (slug, display copy, kind) — the source of truth for
+	// the /collections hub and the job-search facet, generated so the frontend copy
+	// cannot drift from the Go registry that decides membership.
+	b.WriteString(emitCollections(collections.All))
 	return b.String()
 }
 

--- a/cmd/gen-contracts/vocab.go
+++ b/cmd/gen-contracts/vocab.go
@@ -3,6 +3,8 @@ package main
 import (
 	"sort"
 	"strings"
+
+	"github.com/strelov1/freehire/internal/collections"
 )
 
 // emitVocab renders one closed vocabulary as a frozen value array plus a string-union
@@ -87,4 +89,36 @@ func emitMapOfSlices(typeName, constName string, m map[string][]string) string {
 // single quotes so a value like "N'Djamena" can't break the generated file.
 func quoteTS(s string) string {
 	return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(s) + "'"
+}
+
+// emitCollections renders the company-tag registry as a frozen array of objects
+// plus the two types the frontend reads off it:
+//
+//	export const COLLECTIONS = [
+//	  { slug: 'yc', title: 'Y Combinator', description: '…', kind: 'editorial' },
+//	  …
+//	] as const;
+//	export type Collection = (typeof COLLECTIONS)[number];
+//	export type CollectionKind = Collection['kind'];
+//
+// Emitted in registry order, not sorted: that order is the display order on the
+// /collections hub and in the job-search facet.
+//
+// This replaces a hand-kept mirror in web/src/lib/collections.ts. `kind` decides
+// which filter group a tag renders in, so a slug missing from the frontend copy
+// meant a tag that filters but has no pill — a correctness bug rather than stale
+// copy, which is what makes it worth generating.
+func emitCollections(all []collections.Collection) string {
+	var b strings.Builder
+	b.WriteString("export const COLLECTIONS = [\n")
+	for _, c := range all {
+		b.WriteString("  { slug: " + quoteTS(c.Slug) +
+			", title: " + quoteTS(c.Title) +
+			", description: " + quoteTS(c.Description) +
+			", kind: " + quoteTS(string(c.Kind)) + " },\n")
+	}
+	b.WriteString("] as const;\n")
+	b.WriteString("export type Collection = (typeof COLLECTIONS)[number];\n")
+	b.WriteString("export type CollectionKind = Collection['kind'];\n")
+	return b.String()
 }

--- a/cmd/gen-contracts/vocab_test.go
+++ b/cmd/gen-contracts/vocab_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/strelov1/freehire/internal/collections"
 )
 
 func TestGenVocabEmitsRoleLabels(t *testing.T) {
@@ -55,5 +57,37 @@ func TestEmitMapEmpty(t *testing.T) {
 		"export type X = typeof X_MAP;\n"
 	if got != want {
 		t.Errorf("emitMap(empty) = %q, want %q", got, want)
+	}
+}
+
+func TestEmitCollections_RendersTheRegistryWithItsKinds(t *testing.T) {
+	got := emitCollections([]collections.Collection{
+		{Slug: "yc", Title: "Y Combinator", Description: "Open roles at YC companies.", Kind: collections.KindEditorial},
+		{Slug: "uk-skilled-worker-sponsor", Title: "Licensed UK sponsor", Description: "It's a licence.", Kind: collections.KindCredential},
+	})
+
+	for _, want := range []string{
+		"export const COLLECTIONS = [",
+		"{ slug: 'yc', title: 'Y Combinator', description: 'Open roles at YC companies.', kind: 'editorial' },",
+		"{ slug: 'uk-skilled-worker-sponsor', title: 'Licensed UK sponsor', description: 'It\\'s a licence.', kind: 'credential' },",
+		"] as const;",
+		"export type Collection = (typeof COLLECTIONS)[number];",
+		"export type CollectionKind = Collection['kind'];",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("emitCollections output missing %q\ngot:\n%s", want, got)
+		}
+	}
+}
+
+func TestEmitCollections_KeepsRegistryOrder(t *testing.T) {
+	// Display order is the registry's, not alphabetical — the hub and the facet
+	// render in it.
+	got := emitCollections([]collections.Collection{
+		{Slug: "zeta", Kind: collections.KindEditorial},
+		{Slug: "alpha", Kind: collections.KindEditorial},
+	})
+	if strings.Index(got, "'zeta'") > strings.Index(got, "'alpha'") {
+		t.Error("emitCollections reordered the registry")
 	}
 }

--- a/cmd/import-collections/main.go
+++ b/cmd/import-collections/main.go
@@ -9,10 +9,14 @@
 // changes in the facet index.
 //
 // Idempotent: re-running with the same inputs writes the same membership and
-// changes nothing on the second pass. If any collection's source cannot be
-// resolved — a failed fetch, or a payload that parses to no records — the run
-// aborts before writing, because a partial resolve would otherwise drop that
-// collection's tags from every company.
+// changes nothing on the second pass.
+//
+// Three things abort the run before it writes, all guarding the same hazard — that
+// a broken source reconciles a tag off every company that holds it: a failed fetch
+// or resolve, a payload that parses to no records, and a tag that would lose most
+// of its current holders. The last covers the case the other two cannot see, where
+// an upstream relabelling leaves the row count intact but matches nobody; override
+// it with -force when the loss is genuinely correct.
 //
 // Run with -dry-run first when a gate or threshold has changed: it resolves,
 // matches, and gates exactly as a real run does, reports the outcome per
@@ -42,7 +46,12 @@ const fetchTimeout = 60 * time.Second
 
 // dryRun resolves, matches, and gates exactly as a real run does, reports what it
 // would write, and writes nothing.
-var dryRun = flag.Bool("dry-run", false, "resolve and match, report the outcome, write nothing")
+var (
+	dryRun = flag.Bool("dry-run", false, "resolve and match, report the outcome, write nothing")
+	// force overrides the collapse guard, for the rare run where a tag genuinely
+	// should lose most of its holders (retiring a collection, a real register purge).
+	force = flag.Bool("force", false, "write even when a tag would lose most of its holders")
+)
 
 func main() {
 	flag.Parse()
@@ -83,8 +92,23 @@ func run() int {
 	// is how that gets answered before it can do damage rather than after.
 	if *dryRun {
 		report(p, len(rows))
+		for _, c := range p.collapsed {
+			log.Printf("import-collections: WOULD COLLAPSE %s — %d holders, %d would survive", c.slug, c.had, c.keeps)
+		}
 		log.Printf("import-collections: dry run — %d companies would be updated, nothing written", len(p.writes))
 		return 0
+	}
+
+	// A tag losing most of its holders in one run is a broken source, not a change in
+	// the world. The fetch and empty-parse aborts cannot see this case: a register
+	// whose values were relabelled upstream still parses to its full row count, then
+	// matches nobody. Stop before writing and make a human confirm.
+	if len(p.collapsed) > 0 && !*force {
+		for _, c := range p.collapsed {
+			log.Printf("import-collections: %s would drop from %d holders to %d", c.slug, c.had, c.keeps)
+		}
+		log.Printf("import-collections: aborting before write — re-run with -dry-run to inspect, or -force if this is genuinely correct")
+		return 1
 	}
 
 	for _, w := range p.writes {
@@ -202,10 +226,28 @@ func slugRecords(slugs []string) []collections.Record {
 	return out
 }
 
+// collapseRatio is the share of a tag's holders that may be lost in one run before
+// the run is treated as a broken source rather than a genuine change. Membership
+// moves by a few percent between runs; half of it vanishing at once has never been
+// real data.
+const collapseRatio = 0.5
+
+// collapse is a managed tag about to lose most of the companies that hold it.
+type collapse struct {
+	slug       string
+	had, keeps int
+}
+
 // planResult is the computed membership change plus the per-collection match stats.
 type planResult struct {
 	writes []db.SetCompanyCollectionsParams
 	stats  map[string]collections.MatchStat
+	// collapsed lists tags losing at least collapseRatio of their holders in this
+	// run — the failure the fetch and empty-parse aborts cannot see. A source that
+	// parses fine but whose values have been relabelled upstream yields a full row
+	// count, matches nobody, and Reconcile then strips the tag from every company
+	// that held it, with no error and a zero exit.
+	collapsed []collapse
 	// withHQCountry counts companies with a known headquarters country, reported
 	// because the single-token credential rule is only as good as that column.
 	withHQCountry int
@@ -217,11 +259,6 @@ type planResult struct {
 // the companies whose set actually changes. It is pure — all I/O lives in run.
 // `resolved` maps a collection slug to its candidate company names/slugs.
 func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]collections.Record) planResult {
-	existing := make(map[string]struct{}, len(rows))
-	for _, r := range rows {
-		existing[r.Slug] = struct{}{}
-	}
-
 	companies := make(map[string]collections.Company, len(rows))
 	withHQCountry := 0
 	for _, r := range rows {
@@ -250,6 +287,8 @@ func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]collections
 		}
 	}
 
+	collapsed := detectCollapse(rows, want)
+
 	// Managed = live collection slugs plus retired ones, so Reconcile strips a
 	// renamed/removed collection's stale tags (no wanted members) as well as
 	// reconciling the current set.
@@ -262,7 +301,38 @@ func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]collections
 		}
 	}
 
-	return planResult{writes: writes, stats: stats, withHQCountry: withHQCountry}
+	return planResult{writes: writes, stats: stats, withHQCountry: withHQCountry, collapsed: collapsed}
+}
+
+// detectCollapse finds managed tags about to lose most of their holders. A tag
+// nobody currently holds cannot collapse — that is a new collection's first run,
+// not a broken source — and RetiredSlugs are skipped because losing every holder is
+// exactly what retiring one is for.
+func detectCollapse(rows []db.ListCompanyCollectionsRow, want map[string][]string) []collapse {
+	had := map[string]int{}
+	for _, r := range rows {
+		for _, tag := range r.Collections {
+			had[tag]++
+		}
+	}
+	keeps := map[string]int{}
+	for _, tags := range want {
+		for _, tag := range tags {
+			keeps[tag]++
+		}
+	}
+
+	var out []collapse
+	for _, c := range collections.All {
+		before := had[c.Slug]
+		if before == 0 {
+			continue
+		}
+		if after := keeps[c.Slug]; float64(before-after) >= collapseRatio*float64(before) {
+			out = append(out, collapse{slug: c.Slug, had: before, keeps: after})
+		}
+	}
+	return out
 }
 
 // normalizedCurrent sorts a copy of the stored collections so the change check

--- a/cmd/import-collections/main.go
+++ b/cmd/import-collections/main.go
@@ -93,33 +93,52 @@ func run() int {
 // for a hand list). A static-list collection resolves locally; a dataset
 // collection is fetched and parsed. Any resolution failure is returned (the caller
 // aborts rather than write a partial membership).
-func resolveAll(ctx context.Context) (map[string][]string, error) {
-	resolved := make(map[string][]string, len(collections.All))
+func resolveAll(ctx context.Context) (map[string][]collections.Record, error) {
+	resolved := make(map[string][]collections.Record, len(collections.All))
 	for _, c := range collections.All {
 		switch {
 		case c.Slugs != nil:
-			resolved[c.Slug] = c.Slugs
+			resolved[c.Slug] = slugRecords(c.Slugs)
 		case c.Dataset != nil:
 			var (
-				names []string
-				err   error
+				records []collections.Record
+				err     error
 			)
 			if len(c.Dataset.Data) > 0 {
 				// Embedded, in-repo dataset (e.g. eastern-roots): parse the bundled
 				// bytes directly, no network fetch.
-				names, err = c.Dataset.Parse(c.Dataset.Data)
+				records, err = c.Dataset.Parse(c.Dataset.Data)
 			} else {
-				names, err = fetchDataset(ctx, datasetURL(c), c.Dataset.Parse)
+				records, err = fetchDataset(ctx, datasetURL(c), c.Dataset.Parse)
 			}
 			if err != nil {
 				return nil, fmt.Errorf("resolve %q: %w", c.Slug, err)
 			}
-			resolved[c.Slug] = names
+			resolved[c.Slug] = records
 		default:
 			return nil, fmt.Errorf("collection %q has no membership source", c.Slug)
 		}
 	}
 	return resolved, nil
+}
+
+// slugRecords lifts a hand list of canonical company slugs into the record shape a
+// dataset yields, so both membership sources reach the matcher as one type.
+func slugRecords(slugs []string) []collections.Record {
+	out := make([]collections.Record, len(slugs))
+	for i, s := range slugs {
+		out[i] = collections.Record{Name: s}
+	}
+	return out
+}
+
+// recordNames projects a record list down to the names the matcher works on.
+func recordNames(records []collections.Record) []string {
+	out := make([]string, len(records))
+	for i, r := range records {
+		out[i] = r.Name
+	}
+	return out
 }
 
 // matchStat is the per-collection match outcome, logged at the end of a run.
@@ -142,7 +161,7 @@ type planResult struct {
 // company's managed tags (preserving any unmanaged ones), emitting a write only for
 // the companies whose set actually changes. It is pure — all I/O lives in run.
 // `resolved` maps a collection slug to its candidate company names/slugs.
-func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]string) planResult {
+func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]collections.Record) planResult {
 	existing := make(map[string]struct{}, len(rows))
 	for _, r := range rows {
 		existing[r.Slug] = struct{}{}
@@ -151,7 +170,7 @@ func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]string) pla
 	want := make(map[string][]string)
 	stats := make(map[string]matchStat, len(resolved))
 	for _, c := range collections.All {
-		matched, unmatched := collections.Match(resolved[c.Slug], existing)
+		matched, unmatched := collections.Match(recordNames(resolved[c.Slug]), existing)
 		s := matchStat{matched: len(matched), unmatched: len(unmatched)}
 		if c.Slugs != nil { // hand list: keep the unmatched entries for diagnostics
 			s.unmatchedNames = unmatched
@@ -198,7 +217,7 @@ func datasetURL(c collections.Collection) string {
 
 // fetchDataset downloads a dataset URL and runs its parser. The URLs are constants
 // we control (not user input), so a plain client is appropriate.
-func fetchDataset(ctx context.Context, url string, parse func([]byte) ([]string, error)) ([]string, error) {
+func fetchDataset(ctx context.Context, url string, parse func([]byte) ([]collections.Record, error)) ([]collections.Record, error) {
 	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 

--- a/cmd/import-collections/main.go
+++ b/cmd/import-collections/main.go
@@ -1,19 +1,28 @@
-// Command import-collections populates the curated-collection membership defined
-// in internal/collections. For each collection it resolves the member companies —
-// a static hand list (e.g. bigtech) or a remote name dataset (e.g. yc, unicorn),
-// matched to our companies by normalized name — writes companies.collections
-// (reconciling only the tags it manages so any other tags survive), then
-// denormalizes the result onto jobs.collections. It is a run-once-and-exit worker;
-// a search reindex is required afterwards to surface the changes in the facet index.
+// Command import-collections populates the company-tag membership defined in
+// internal/collections. For each entry it resolves the member companies — a static
+// hand list (e.g. bigtech), a remote dataset (e.g. yc, unicorn), or a public
+// register (the UK and NL visa-sponsor credentials) — matches them onto our
+// companies, applies the entry's gate where it has one, writes
+// companies.collections (reconciling only the tags it manages so any other tags
+// survive), then denormalizes the result onto jobs.collections. It is a
+// run-once-and-exit worker; a search reindex is required afterwards to surface the
+// changes in the facet index.
 //
 // Idempotent: re-running with the same inputs writes the same membership and
-// changes nothing on the second pass. If any collection's dataset cannot be
-// resolved the run aborts before writing — a partial resolve would otherwise drop
-// that collection's tags from every company.
+// changes nothing on the second pass. If any collection's source cannot be
+// resolved — a failed fetch, or a payload that parses to no records — the run
+// aborts before writing, because a partial resolve would otherwise drop that
+// collection's tags from every company.
+//
+// Run with -dry-run first when a gate or threshold has changed: it resolves,
+// matches, and gates exactly as a real run does, reports the outcome per
+// collection, and writes nothing.
 package main
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -31,7 +40,12 @@ import (
 // fetchTimeout bounds each dataset download so a stalled endpoint can't hang the run.
 const fetchTimeout = 60 * time.Second
 
+// dryRun resolves, matches, and gates exactly as a real run does, reports what it
+// would write, and writes nothing.
+var dryRun = flag.Bool("dry-run", false, "resolve and match, report the outcome, write nothing")
+
 func main() {
+	flag.Parse()
 	worker.Main(run)
 }
 
@@ -61,6 +75,18 @@ func run() int {
 	}
 
 	p := plan(rows, resolved)
+
+	// A dry run stops here, before the first write. Every threshold in the credential
+	// gates is a guess until it is measured against the real catalogue — in
+	// particular the single-token rule leans on hq_country, and if that column is
+	// sparse the rule discards exactly the single-word brands worth surfacing. This
+	// is how that gets answered before it can do damage rather than after.
+	if *dryRun {
+		report(p, len(rows))
+		log.Printf("import-collections: dry run — %d companies would be updated, nothing written", len(p.writes))
+		return 0
+	}
+
 	for _, w := range p.writes {
 		if err := q.SetCompanyCollections(ctx, w); err != nil {
 			log.Printf("import-collections: set %q: %v", w.Slug, err)
@@ -74,19 +100,34 @@ func run() int {
 		return 1
 	}
 
-	for _, c := range collections.All {
-		s := p.stats[c.Slug]
-		log.Printf("import-collections: %s matched=%d unmatched=%d", c.Slug, s.matched, s.unmatched)
-		// For a hand list the unmatched entries are actionable (a typo'd slug, or a
-		// marquee company we don't ingest yet), so list them. Datasets have thousands
-		// of unmatched names — only their count is logged, above.
-		if len(s.unmatchedNames) > 0 {
-			log.Printf("import-collections: %s unmatched entries: %s", c.Slug, strings.Join(s.unmatchedNames, ", "))
-		}
-	}
+	report(p, len(rows))
 	log.Printf("import-collections done: companies updated=%d, jobs updated=%d", len(p.writes), propagated)
 	log.Printf("import-collections: run `make reindex` to surface jobs.collections in the search index")
 	return 0
+}
+
+// report logs how each collection's candidates fell out. Credentials additionally
+// report what their gate and ambiguity guard rejected — the numbers a dry run is
+// read for — and how densely hq_country is populated, since the single-token rule
+// depends on it.
+func report(p planResult, companies int) {
+	for _, c := range collections.All {
+		s := p.stats[c.Slug]
+		if c.Kind == collections.KindCredential {
+			log.Printf("import-collections: %s matched=%d gated=%d ambiguous=%d unmatched=%d",
+				c.Slug, s.Matched, s.Gated, s.Ambiguous, s.Unmatched)
+			continue
+		}
+		log.Printf("import-collections: %s matched=%d unmatched=%d", c.Slug, s.Matched, s.Unmatched)
+		// For a hand list the unmatched entries are actionable (a typo'd slug, or a
+		// marquee company we don't ingest yet), so list them. Datasets have thousands
+		// of unmatched names — only their count is logged, above.
+		if len(s.UnmatchedNames) > 0 {
+			log.Printf("import-collections: %s unmatched entries: %s", c.Slug, strings.Join(s.UnmatchedNames, ", "))
+		}
+	}
+	log.Printf("import-collections: hq_country known for %d/%d companies (the single-token credential rule depends on it)",
+		p.withHQCountry, companies)
 }
 
 // resolveAll returns, per collection slug, its candidate company names (or slugs
@@ -94,32 +135,61 @@ func run() int {
 // collection is fetched and parsed. Any resolution failure is returned (the caller
 // aborts rather than write a partial membership).
 func resolveAll(ctx context.Context) (map[string][]collections.Record, error) {
+	client := &http.Client{Timeout: fetchTimeout}
 	resolved := make(map[string][]collections.Record, len(collections.All))
 	for _, c := range collections.All {
-		switch {
-		case c.Slugs != nil:
-			resolved[c.Slug] = slugRecords(c.Slugs)
-		case c.Dataset != nil:
-			var (
-				records []collections.Record
-				err     error
-			)
-			if len(c.Dataset.Data) > 0 {
-				// Embedded, in-repo dataset (e.g. eastern-roots): parse the bundled
-				// bytes directly, no network fetch.
-				records, err = c.Dataset.Parse(c.Dataset.Data)
-			} else {
-				records, err = fetchDataset(ctx, datasetURL(c), c.Dataset.Parse)
-			}
-			if err != nil {
-				return nil, fmt.Errorf("resolve %q: %w", c.Slug, err)
-			}
-			resolved[c.Slug] = records
-		default:
-			return nil, fmt.Errorf("collection %q has no membership source", c.Slug)
+		records, err := resolveOne(ctx, client, c)
+		if err != nil {
+			return nil, fmt.Errorf("resolve %q: %w", c.Slug, err)
 		}
+		resolved[c.Slug] = records
 	}
 	return resolved, nil
+}
+
+// resolveOne resolves a single collection's members. A dataset whose payload parses
+// to nothing is an error, not an empty membership: a successful fetch of a source
+// that has changed shape parses to zero rows just as convincingly as a genuinely
+// empty register would, and letting it through would reconcile that collection's
+// tag off every company. That is the same reasoning as the fetch-failure abort,
+// applied to the failure mode a fetch check cannot see.
+func resolveOne(ctx context.Context, client *http.Client, c collections.Collection) ([]collections.Record, error) {
+	if c.Slugs != nil {
+		return slugRecords(c.Slugs), nil
+	}
+	if c.Dataset == nil {
+		return nil, errors.New("collection has no membership source")
+	}
+	if !c.Dataset.Valid() {
+		return nil, errors.New("collection declares no single dataset source")
+	}
+
+	// Embedded, in-repo dataset (e.g. eastern-roots): parse the bundled bytes
+	// directly, no network fetch.
+	if len(c.Dataset.Data) > 0 {
+		return nonEmpty(c.Dataset.Parse(c.Dataset.Data))
+	}
+
+	url, err := datasetURL(ctx, client, c)
+	if err != nil {
+		return nil, err
+	}
+	body, err := fetchDataset(ctx, client, url)
+	if err != nil {
+		return nil, err
+	}
+	return nonEmpty(c.Dataset.Parse(body))
+}
+
+// nonEmpty turns a zero-record parse into an error. See resolveOne.
+func nonEmpty(records []collections.Record, err error) ([]collections.Record, error) {
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, errors.New("dataset parsed to no records")
+	}
+	return records, nil
 }
 
 // slugRecords lifts a hand list of canonical company slugs into the record shape a
@@ -132,28 +202,13 @@ func slugRecords(slugs []string) []collections.Record {
 	return out
 }
 
-// recordNames projects a record list down to the names the matcher works on.
-func recordNames(records []collections.Record) []string {
-	out := make([]string, len(records))
-	for i, r := range records {
-		out[i] = r.Name
-	}
-	return out
-}
-
-// matchStat is the per-collection match outcome, logged at the end of a run.
-// unmatchedNames holds the verbatim unmatched entries for hand-list collections
-// (small and actionable); it is left empty for datasets (their unmatched set runs
-// to thousands, so only the count is kept).
-type matchStat struct {
-	matched, unmatched int
-	unmatchedNames     []string
-}
-
 // planResult is the computed membership change plus the per-collection match stats.
 type planResult struct {
 	writes []db.SetCompanyCollectionsParams
-	stats  map[string]matchStat
+	stats  map[string]collections.MatchStat
+	// withHQCountry counts companies with a known headquarters country, reported
+	// because the single-token credential rule is only as good as that column.
+	withHQCountry int
 }
 
 // plan computes the membership change for every company: it matches each
@@ -167,13 +222,27 @@ func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]collections
 		existing[r.Slug] = struct{}{}
 	}
 
+	companies := make(map[string]collections.Company, len(rows))
+	withHQCountry := 0
+	for _, r := range rows {
+		companies[r.Slug] = collections.Company{
+			Slug:      r.Slug,
+			Countries: r.Countries,
+			HQCountry: r.HqCountry.String,
+		}
+		if r.HqCountry.String != "" {
+			withHQCountry++
+		}
+	}
+
 	want := make(map[string][]string)
-	stats := make(map[string]matchStat, len(resolved))
+	stats := make(map[string]collections.MatchStat, len(resolved))
 	for _, c := range collections.All {
-		matched, unmatched := collections.Match(recordNames(resolved[c.Slug]), existing)
-		s := matchStat{matched: len(matched), unmatched: len(unmatched)}
+		matched, s := c.Members(resolved[c.Slug], companies)
 		if c.Slugs != nil { // hand list: keep the unmatched entries for diagnostics
-			s.unmatchedNames = unmatched
+			s.UnmatchedNames = s.UnmatchedNames[:min(len(s.UnmatchedNames), collections.MaxLoggedUnmatched)]
+		} else {
+			s.UnmatchedNames = nil
 		}
 		stats[c.Slug] = s
 		for _, slug := range matched {
@@ -193,7 +262,7 @@ func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]collections
 		}
 	}
 
-	return planResult{writes: writes, stats: stats}
+	return planResult{writes: writes, stats: stats, withHQCountry: withHQCountry}
 }
 
 // normalizedCurrent sorts a copy of the stored collections so the change check
@@ -205,19 +274,26 @@ func normalizedCurrent(current []string) []string {
 	return cp
 }
 
-// datasetURL returns a collection's dataset URL, honouring a <SLUG>_DATASET_URL
-// environment override (e.g. YC_DATASET_URL, UNICORN_DATASET_URL).
-func datasetURL(c collections.Collection) string {
-	env := strings.ToUpper(c.Slug) + "_DATASET_URL"
+// datasetURL returns the address to fetch a collection's dataset from. A
+// <SLUG>_DATASET_URL environment override wins (e.g. YC_DATASET_URL), then the
+// dataset's own resolver where it has one — the GOV.UK register republishes at a
+// new dated URL each month, so its address is discovered per run — then its fixed
+// URL. The override is honoured ahead of the resolver so a run can be pinned to a
+// downloaded snapshot without touching the network.
+func datasetURL(ctx context.Context, client *http.Client, c collections.Collection) (string, error) {
+	env := strings.ToUpper(strings.ReplaceAll(c.Slug, "-", "_")) + "_DATASET_URL"
 	if u := os.Getenv(env); u != "" {
-		return u
+		return u, nil
 	}
-	return c.Dataset.URL
+	if c.Dataset.ResolveURL != nil {
+		return c.Dataset.ResolveURL(ctx, client)
+	}
+	return c.Dataset.URL, nil
 }
 
-// fetchDataset downloads a dataset URL and runs its parser. The URLs are constants
-// we control (not user input), so a plain client is appropriate.
-func fetchDataset(ctx context.Context, url string, parse func([]byte) ([]collections.Record, error)) ([]collections.Record, error) {
+// fetchDataset downloads a dataset URL. The URLs are ours or resolved from a source
+// we control, not user input, so a plain client is appropriate.
+func fetchDataset(ctx context.Context, client *http.Client, url string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 
@@ -225,7 +301,7 @@ func fetchDataset(ctx context.Context, url string, parse func([]byte) ([]collect
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -233,9 +309,5 @@ func fetchDataset(ctx context.Context, url string, parse func([]byte) ([]collect
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("dataset %s: status %d", url, resp.StatusCode)
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return parse(body)
+	return io.ReadAll(resp.Body)
 }

--- a/cmd/import-collections/main_test.go
+++ b/cmd/import-collections/main_test.go
@@ -265,3 +265,75 @@ func TestPlan_ReportsHQCountryCoverage(t *testing.T) {
 		t.Errorf("withHQCountry = %d, want 2 of 3 rows", got.withHQCountry)
 	}
 }
+
+func TestPlan_FlagsACollapseAsUnsafe(t *testing.T) {
+	// A source that parses fine but matches nobody is the failure the fetch and
+	// empty-parse aborts cannot see: GOV.UK renaming a route value leaves 142k rows
+	// intact, gates every one of them out, and Reconcile then strips the credential
+	// from every company that held it. Exit 0, no error, tag gone.
+	rows := []db.ListCompanyCollectionsRow{
+		{Slug: "monzo", Collections: []string{"uk-skilled-worker-sponsor"}, Countries: []string{"GB"}, HqCountry: pgtype.Text{String: "GB", Valid: true}},
+		{Slug: "acme-robotics", Collections: []string{"uk-skilled-worker-sponsor"}, Countries: []string{"GB"}},
+	}
+	// The register still parses, but every row is on a route the gate refuses.
+	resolved := map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {
+			{Name: "MONZO LTD", Meta: map[string]string{"town": "London", "route": "WORKER: SKILLED"}},
+			{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London", "route": "WORKER: SKILLED"}},
+		},
+	}
+	got := plan(rows, resolved)
+	if len(got.collapsed) == 0 {
+		t.Fatal("a tag losing every one of its holders was not flagged")
+	}
+	if c := got.collapsed[0]; c.slug != "uk-skilled-worker-sponsor" || c.had != 2 || c.keeps != 0 {
+		t.Errorf("collapse = %+v, want uk-skilled-worker-sponsor had=2 keeps=0", c)
+	}
+}
+
+func TestPlan_DoesNotFlagAHealthyRun(t *testing.T) {
+	rows := []db.ListCompanyCollectionsRow{
+		{Slug: "monzo", Collections: []string{"uk-skilled-worker-sponsor"}, Countries: []string{"GB"}, HqCountry: pgtype.Text{String: "GB", Valid: true}},
+		{Slug: "acme-robotics", Collections: []string{"uk-skilled-worker-sponsor"}, Countries: []string{"GB"}},
+	}
+	resolved := map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {
+			{Name: "MONZO LTD", Meta: map[string]string{"town": "London", "route": "Skilled Worker"}},
+			{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London", "route": "Skilled Worker"}},
+		},
+	}
+	if got := plan(rows, resolved); len(got.collapsed) != 0 {
+		t.Errorf("a healthy run was flagged as a collapse: %+v", got.collapsed)
+	}
+}
+
+func TestPlan_DoesNotFlagATagNobodyHeld(t *testing.T) {
+	// First run of a new credential: nothing held it, so losing nothing is not a
+	// collapse. Without this the guard would block every new collection's first run.
+	rows := []db.ListCompanyCollectionsRow{{Slug: "monzo", Countries: []string{"US"}}}
+	got := plan(rows, map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {{Name: "SOMEONE ELSE LTD", Meta: map[string]string{"route": "Skilled Worker"}}},
+	})
+	if len(got.collapsed) != 0 {
+		t.Errorf("a tag nobody held was flagged: %+v", got.collapsed)
+	}
+}
+
+func TestPlan_FlagsAMajorityLossNotJustATotalOne(t *testing.T) {
+	// A truncated upstream snapshot is a partial wipe with no error either.
+	rows := make([]db.ListCompanyCollectionsRow, 0, 10)
+	for _, s := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"} {
+		rows = append(rows, db.ListCompanyCollectionsRow{
+			Slug: s, Collections: []string{"uk-skilled-worker-sponsor"},
+			Countries: []string{"GB"}, HqCountry: pgtype.Text{String: "GB", Valid: true},
+		})
+	}
+	// Only two of the ten survive the truncated register.
+	resolved := map[string][]collections.Record{"uk-skilled-worker-sponsor": {
+		{Name: "a", Meta: map[string]string{"town": "London", "route": "Skilled Worker"}},
+		{Name: "b", Meta: map[string]string{"town": "Leeds", "route": "Skilled Worker"}},
+	}}
+	if got := plan(rows, resolved); len(got.collapsed) == 0 {
+		t.Error("losing 8 of 10 holders was not flagged")
+	}
+}

--- a/cmd/import-collections/main_test.go
+++ b/cmd/import-collections/main_test.go
@@ -20,9 +20,9 @@ func TestPlan(t *testing.T) {
 		{Slug: "nytimes", Collections: []string{}},              // matches nothing → no write
 		{Slug: "oldyc", Collections: []string{"yc"}},            // no longer matched → yc dropped
 	}
-	resolved := map[string][]string{
-		"yc":      {"Acme Startup", "Unknown Co"}, // "Acme Startup" → acme-startup; "Unknown Co" → none
-		"bigtech": collections.BigTechSlugs,
+	resolved := map[string][]collections.Record{
+		"yc":      slugRecords([]string{"Acme Startup", "Unknown Co"}), // "Acme Startup" → acme-startup; "Unknown Co" → none
+		"bigtech": slugRecords(collections.BigTechSlugs),
 		"unicorn": nil,
 	}
 
@@ -61,7 +61,7 @@ func TestPlan_PreservesUnmanagedTag(t *testing.T) {
 		{Slug: "google", Collections: []string{"custom"}},
 	}
 	// google gains bigtech from the hand list; no yc/unicorn candidates.
-	got := plan(rows, map[string][]string{"bigtech": collections.BigTechSlugs})
+	got := plan(rows, map[string][]collections.Record{"bigtech": slugRecords(collections.BigTechSlugs)})
 	if len(got.writes) != 1 {
 		t.Fatalf("writes = %d, want 1", len(got.writes))
 	}

--- a/cmd/import-collections/main_test.go
+++ b/cmd/import-collections/main_test.go
@@ -1,9 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/collections"
 	"github.com/strelov1/freehire/internal/db"
@@ -46,11 +53,11 @@ func TestPlan(t *testing.T) {
 		t.Errorf("nytimes should not be rewritten (no managed match), got %v", writeBySlug["nytimes"])
 	}
 
-	if s := got.stats["yc"]; s.matched != 1 || s.unmatched != 1 {
+	if s := got.stats["yc"]; s.Matched != 1 || s.Unmatched != 1 {
 		t.Errorf("yc stats = %+v, want {matched:1 unmatched:1}", s)
 	}
-	if s := got.stats["bigtech"]; s.matched != 1 { // only google (of the rows) is in the hand list
-		t.Errorf("bigtech matched = %d, want 1", s.matched)
+	if s := got.stats["bigtech"]; s.Matched != 1 { // only google (of the rows) is in the hand list
+		t.Errorf("bigtech matched = %d, want 1", s.Matched)
 	}
 }
 
@@ -69,5 +76,192 @@ func TestPlan_PreservesUnmanagedTag(t *testing.T) {
 	sort.Strings(c)
 	if !reflect.DeepEqual(c, []string{"bigtech", "custom"}) {
 		t.Errorf("collections = %#v, want [bigtech custom]", c)
+	}
+}
+
+// credentialRows is a catalogue shaped for the gate tests: a UK-headquartered
+// single-token company, a multinational that merely hires in the UK, and a
+// two-token British company.
+func credentialRows() []db.ListCompanyCollectionsRow {
+	return []db.ListCompanyCollectionsRow{
+		{Slug: "monzo", Countries: []string{"GB"}, HqCountry: pgtype.Text{String: "GB", Valid: true}},
+		{Slug: "apple", Countries: []string{"GB", "US"}, HqCountry: pgtype.Text{String: "US", Valid: true}},
+		{Slug: "acme-robotics", Countries: []string{"GB"}},
+	}
+}
+
+func tagsFor(p planResult, slug string) []string {
+	for _, w := range p.writes {
+		if w.Slug == slug {
+			return w.Collections
+		}
+	}
+	return nil
+}
+
+func TestPlan_CredentialMatchesThroughTheLegalSuffix(t *testing.T) {
+	// "ACME ROBOTICS LIMITED" must reach acme-robotics, which plain normalize.Slug
+	// would never do.
+	resolved := map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {
+			{Name: "ACME ROBOTICS LIMITED", Meta: map[string]string{"town": "London", "route": "Skilled Worker"}},
+		},
+	}
+	got := plan(credentialRows(), resolved)
+	if c := tagsFor(got, "acme-robotics"); !slices.Contains(c, "uk-skilled-worker-sponsor") {
+		t.Errorf("acme-robotics tags = %v, want the UK credential", c)
+	}
+}
+
+func TestPlan_CredentialAppliesTheSingleTokenHeadquartersRule(t *testing.T) {
+	resolved := map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {
+			{Name: "MONZO LTD", Meta: map[string]string{"town": "London", "route": "Skilled Worker"}},
+			{Name: "APPLE LTD", Meta: map[string]string{"town": "Liverpool", "route": "Skilled Worker"}},
+		},
+	}
+	got := plan(credentialRows(), resolved)
+	if c := tagsFor(got, "monzo"); !slices.Contains(c, "uk-skilled-worker-sponsor") {
+		t.Errorf("monzo tags = %v, want the UK credential", c)
+	}
+	if c := tagsFor(got, "apple"); slices.Contains(c, "uk-skilled-worker-sponsor") {
+		t.Errorf("apple earned a credential from an unrelated APPLE LTD: %v", c)
+	}
+}
+
+func TestPlan_CredentialNeedsAWorkRoute(t *testing.T) {
+	resolved := map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {
+			{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London", "route": "Temporary Worker - Seasonal Worker"}},
+		},
+	}
+	got := plan(credentialRows(), resolved)
+	if c := tagsFor(got, "acme-robotics"); slices.Contains(c, "uk-skilled-worker-sponsor") {
+		t.Errorf("a seasonal-worker licence earned the skilled-worker credential: %v", c)
+	}
+}
+
+func TestPlan_CredentialTakesTheWorkRouteAmongSeveral(t *testing.T) {
+	// One organisation, several routes: the work route must win even when a
+	// temporary one is listed first.
+	resolved := map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {
+			{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London", "route": "Temporary Worker - Creative Worker"}},
+			{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London", "route": "Skilled Worker"}},
+		},
+	}
+	got := plan(credentialRows(), resolved)
+	if c := tagsFor(got, "acme-robotics"); !slices.Contains(c, "uk-skilled-worker-sponsor") {
+		t.Errorf("acme-robotics tags = %v, want the UK credential", c)
+	}
+}
+
+func TestPlan_CredentialDropsAnAmbiguousName(t *testing.T) {
+	// Two organisations in different towns share a normalized name: it identifies
+	// neither, so nobody is tagged.
+	resolved := map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {
+			{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London", "route": "Skilled Worker"}},
+			{Name: "Acme Robotics Limited", Meta: map[string]string{"town": "Leeds", "route": "Skilled Worker"}},
+		},
+	}
+	got := plan(credentialRows(), resolved)
+	if c := tagsFor(got, "acme-robotics"); slices.Contains(c, "uk-skilled-worker-sponsor") {
+		t.Errorf("an ambiguous register name was granted: %v", c)
+	}
+	if s := got.stats["uk-skilled-worker-sponsor"]; s.Ambiguous == 0 {
+		t.Error("the ambiguity guard did not report what it dropped")
+	}
+}
+
+func TestPlan_EditorialMatchingIsUnchangedByTheSuffixStrip(t *testing.T) {
+	// Editorial collections keep matching on normalize.Slug. A dataset name carrying
+	// a legal form must NOT be stripped into a different company's slug.
+	rows := []db.ListCompanyCollectionsRow{{Slug: "acme-robotics-limited"}}
+	got := plan(rows, map[string][]collections.Record{"yc": slugRecords([]string{"Acme Robotics Limited"})})
+	if c := tagsFor(got, "acme-robotics-limited"); !slices.Contains(c, "yc") {
+		t.Errorf("editorial match changed shape: %v", c)
+	}
+}
+
+func TestPlan_CountsGatedOutCandidates(t *testing.T) {
+	resolved := map[string][]collections.Record{
+		"uk-skilled-worker-sponsor": {
+			{Name: "APPLE LTD", Meta: map[string]string{"town": "Liverpool", "route": "Skilled Worker"}},
+		},
+	}
+	got := plan(credentialRows(), resolved)
+	if s := got.stats["uk-skilled-worker-sponsor"]; s.Gated != 1 {
+		t.Errorf("gated = %d, want 1 (apple matched by name but failed the gate)", s.Gated)
+	}
+}
+
+func TestResolveOne_TreatsAZeroRecordParseAsFailure(t *testing.T) {
+	// A source that has changed shape parses to zero rows just as convincingly as a
+	// genuinely empty register. Letting it through would reconcile the tag off every
+	// company, so it must fail like a fetch failure does.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := collections.Collection{
+		Slug:    "x",
+		Kind:    collections.KindEditorial,
+		Dataset: &collections.Dataset{URL: srv.URL, Parse: func([]byte) ([]collections.Record, error) { return nil, nil }},
+	}
+	if _, err := resolveOne(context.Background(), srv.Client(), c); err == nil {
+		t.Error("resolveOne accepted a dataset that parsed to no records")
+	}
+}
+
+func TestResolveOne_FetchesFromTheDatasetResolver(t *testing.T) {
+	var fetched string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched = r.URL.Path
+		w.Write([]byte("payload"))
+	}))
+	defer srv.Close()
+
+	c := collections.Collection{
+		Slug: "x",
+		Kind: collections.KindEditorial,
+		Dataset: &collections.Dataset{
+			ResolveURL: func(context.Context, *http.Client) (string, error) { return srv.URL + "/resolved.csv", nil },
+			Parse:      func([]byte) ([]collections.Record, error) { return []collections.Record{{Name: "Acme"}}, nil },
+		},
+	}
+	got, err := resolveOne(context.Background(), srv.Client(), c)
+	if err != nil {
+		t.Fatalf("resolveOne: %v", err)
+	}
+	if fetched != "/resolved.csv" {
+		t.Errorf("fetched %q, want the resolver's URL", fetched)
+	}
+	if len(got) != 1 {
+		t.Errorf("records = %+v, want one", got)
+	}
+}
+
+func TestResolveOne_PropagatesAResolverFailure(t *testing.T) {
+	c := collections.Collection{
+		Slug: "x",
+		Kind: collections.KindCredential,
+		Dataset: &collections.Dataset{
+			ResolveURL: func(context.Context, *http.Client) (string, error) { return "", errors.New("no csv link") },
+			Parse:      func([]byte) ([]collections.Record, error) { return nil, nil },
+		},
+	}
+	if _, err := resolveOne(context.Background(), http.DefaultClient, c); err == nil {
+		t.Error("resolveOne swallowed a resolver failure")
+	}
+}
+
+func TestPlan_ReportsHQCountryCoverage(t *testing.T) {
+	// The dry run is read for this number: the single-token credential rule is only
+	// as good as hq_country's coverage.
+	got := plan(credentialRows(), nil)
+	if got.withHQCountry != 2 {
+		t.Errorf("withHQCountry = %d, want 2 of 3 rows", got.withHQCountry)
 	}
 }

--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -388,26 +388,83 @@ func Slugs() []string {
 // An entry is safe to drop once a production import has run and cleared the tag.
 var RetiredSlugs = []string{"russian-roots"}
 
-// Match maps each candidate (a company name or slug) to a canonical company slug
-// via normalize.Slug and splits the candidates into those whose slug is present in
-// `existing` and those whose original value is not. Matched slugs are deduplicated
-// and sorted; unmatched values are returned verbatim (for logging) in input order.
-// A candidate that normalizes to an empty slug is treated as unmatched.
-func Match(candidates []string, existing map[string]struct{}) (matched, unmatched []string) {
-	seen := make(map[string]struct{}, len(candidates))
-	for _, c := range candidates {
-		slug := normalize.Slug(c)
-		if _, ok := existing[slug]; slug != "" && ok {
-			if _, dup := seen[slug]; !dup {
-				seen[slug] = struct{}{}
-				matched = append(matched, slug)
-			}
+// MaxLoggedUnmatched bounds the unmatched entries a hand list reports by name, so a
+// mis-edited list cannot flood a run's output.
+const MaxLoggedUnmatched = 50
+
+// MatchStat is how one collection's candidates fell out: how many companies earned
+// the tag, how many candidates matched no company at all, how many matched a company
+// but failed the gate, and how many register rows the ambiguity guard dropped.
+// Gated and Ambiguous are zero for a gateless editorial collection — they are what a
+// dry run is read for.
+type MatchStat struct {
+	Matched, Unmatched int
+	Gated, Ambiguous   int
+	UnmatchedNames     []string
+}
+
+// Members resolves this collection's candidate records to the company slugs that
+// earn its tag, and reports how the candidates fell out. Matched slugs are
+// deduplicated and sorted; unmatched names are returned verbatim, in input order,
+// for logging.
+//
+// Two things differ by kind. An editorial collection matches on normalize.Slug —
+// unchanged, because every existing collection reconciles through this path and a
+// changed match rule would silently rewrite its membership. A credential matches on
+// RegisterSlug, which strips the legal form a public register appends to a name, and
+// first drops rows whose name identifies more than one organisation.
+//
+// A company is tagged when ANY of its records passes the gate: a register lists an
+// organisation once per route it holds, so a work-route row must win even when a
+// temporary-route row for the same body is listed first.
+func (c Collection) Members(records []Record, companies map[string]Company) ([]string, MatchStat) {
+	var stat MatchStat
+	slugOf := normalize.Slug
+	if c.Kind == KindCredential {
+		before := len(records)
+		records = DropAmbiguous(records, c.identityKey())
+		stat.Ambiguous = before - len(records)
+		slugOf = RegisterSlug
+	}
+
+	admitted := make(map[string]struct{}, len(records))
+	gatedOut := make(map[string]struct{}, len(records))
+	for _, r := range records {
+		slug := slugOf(r.Name)
+		company, known := companies[slug]
+		if slug == "" || !known {
+			stat.Unmatched++
+			stat.UnmatchedNames = append(stat.UnmatchedNames, r.Name)
 			continue
 		}
-		unmatched = append(unmatched, c)
+		if !c.Admits(company, r) {
+			gatedOut[slug] = struct{}{}
+			continue
+		}
+		admitted[slug] = struct{}{}
+	}
+
+	matched := make([]string, 0, len(admitted))
+	for slug := range admitted {
+		matched = append(matched, slug)
 	}
 	sort.Strings(matched)
-	return matched, unmatched
+	stat.Matched = len(matched)
+	for slug := range gatedOut {
+		// A company with both an admitted and a rejected row is not gated out.
+		if _, ok := admitted[slug]; !ok {
+			stat.Gated++
+		}
+	}
+	return matched, stat
+}
+
+// identityKey is this collection's dataset organisation discriminator, if any.
+func (c Collection) identityKey() string {
+	if c.Dataset == nil {
+		return ""
+	}
+	return c.Dataset.IdentityKey
 }
 
 // Reconcile computes a company's new collection set: it removes every tag in

--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -44,6 +44,11 @@ type Dataset struct {
 	Data       []byte
 	ResolveURL func(context.Context, *http.Client) (string, error)
 	Parse      func([]byte) ([]Record, error)
+	// IdentityKey names the Record.Meta field that tells two same-named
+	// organisations apart in this source — the UK register's town, the Dutch
+	// register's KvK number. Read by the import worker's ambiguity guard (see
+	// DropAmbiguous); empty when the source publishes no such field.
+	IdentityKey string
 }
 
 // Valid reports whether the dataset declares exactly one payload source. Declaring
@@ -206,6 +211,23 @@ var All = []Collection{
 		Description: "Open roles at AI-native companies building AI-first products and infrastructure — model and inference APIs, vector databases, and agent/dev tooling.",
 		Kind:        KindEditorial,
 		Slugs:       AINativeSlugs,
+	},
+	{
+		Slug:        "uk-skilled-worker-sponsor",
+		Title:       "Licensed UK sponsor",
+		Description: "Open roles at employers on the GOV.UK register of licensed sponsors for the Skilled Worker and related work routes. The licence belongs to the employer — it is not a commitment to sponsor any particular role.",
+		Kind:        KindCredential,
+		Dataset:     &Dataset{ResolveURL: ResolveUKSponsorCSV, Parse: ParseUKSponsors, IdentityKey: "town"},
+		Gate:        AllOf(RequireCountry("GB"), RequireRoute(ukWorkRoutes...)),
+	},
+	{
+		Slug:        "nl-recognised-sponsor",
+		Title:       "Licensed NL sponsor",
+		Description: "Open roles at employers on the IND public register of recognised sponsors for work and highly skilled migrants. The recognition belongs to the employer — it is not a commitment to sponsor any particular role.",
+		Kind:        KindCredential,
+		Dataset:     &Dataset{URL: nlSponsorURL, Parse: ParseNLSponsors, IdentityKey: "kvk"},
+		// No route gate: the IND register publishes recognition, not routes.
+		Gate: RequireCountry("NL"),
 	},
 }
 
@@ -476,6 +498,25 @@ func ParseTechstarsCSV(data []byte) ([]string, error) {
 // locates the column by header (not a fixed index, so an upstream column reorder
 // doesn't silently read the wrong field) and returns each non-empty value.
 func parseCSVColumn(data []byte, delim rune, colName string) ([]string, error) {
+	rows, err := csvColumns(data, delim, colName)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if row[0] != "" {
+			names = append(names, row[0])
+		}
+	}
+	return names, nil
+}
+
+// csvColumns extracts the named columns from a CSV with the given delimiter,
+// returning one trimmed slice per data row in the order the columns were asked for.
+// Columns are located by header rather than by index, so an upstream reorder cannot
+// silently read the wrong field, and a missing column is an error rather than a
+// column of blanks.
+func csvColumns(data []byte, delim rune, colNames ...string) ([][]string, error) {
 	r := csv.NewReader(strings.NewReader(string(data)))
 	r.Comma = delim
 	r.FieldsPerRecord = -1 // tolerate ragged rows rather than aborting the whole parse
@@ -483,27 +524,34 @@ func parseCSVColumn(data []byte, delim rune, colName string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("collections: read csv header: %w", err)
 	}
-	col := -1
-	for i, h := range header {
-		if strings.EqualFold(strings.TrimSpace(h), colName) {
-			col = i
-			break
+
+	idx := make([]int, len(colNames))
+	for n, want := range colNames {
+		idx[n] = -1
+		for i, h := range header {
+			if strings.EqualFold(strings.TrimSpace(h), want) {
+				idx[n] = i
+				break
+			}
+		}
+		if idx[n] < 0 {
+			return nil, fmt.Errorf("collections: csv has no %q column", want)
 		}
 	}
-	if col < 0 {
-		return nil, fmt.Errorf("collections: csv has no %q column", colName)
-	}
+
 	rows, err := r.ReadAll()
 	if err != nil {
 		return nil, fmt.Errorf("collections: read csv: %w", err)
 	}
-	names := make([]string, 0, len(rows))
+	out := make([][]string, 0, len(rows))
 	for _, row := range rows {
-		if col < len(row) {
-			if name := strings.TrimSpace(row[col]); name != "" {
-				names = append(names, name)
+		vals := make([]string, len(idx))
+		for n, i := range idx {
+			if i < len(row) {
+				vals[n] = strings.TrimSpace(row[i])
 			}
 		}
+		out = append(out, vals)
 	}
-	return names, nil
+	return out, nil
 }

--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -1,45 +1,136 @@
-// Package collections defines the fixed, code-owned set of curated job
-// collections — editorial themes about a company (e.g. Y Combinator, Big Tech)
-// that are not derivable from a job's text or its ATS source. The registry here is
-// the single source of truth for which collections exist and how their members are
-// resolved; cmd/import-collections populates the membership, and the search facet
-// (jobs.collections) serves it.
+// Package collections defines the fixed, code-owned set of curated company tags —
+// facts about a company that are not derivable from a job's text or its ATS
+// source. A tag is one of two Kinds: an editorial theme we curate (Y Combinator,
+// Big Tech) or a credential drawn from an authoritative public register. The
+// registry here is the single source of truth for which tags exist and how their
+// members are resolved; cmd/import-collections populates the membership, and the
+// search facet (jobs.collections) serves it.
 package collections
 
 import (
+	"context"
 	_ "embed"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/strelov1/freehire/internal/normalize"
 )
 
-// Dataset is a source of member company names for a collection, resolved by the
-// import worker into a name list its pure Parse extracts (matching to our catalogue
-// happens via normalize.Slug in Match). The payload is either fetched from URL (an
-// external dataset we control) or supplied inline via Data (a file embedded in the
-// binary, for a list that is our own curated fact rather than a third-party feed) —
-// exactly one is set.
-type Dataset struct {
-	URL   string
-	Data  []byte
-	Parse func([]byte) ([]string, error)
+// Record is one member of a dataset: the company's name as the source publishes
+// it, plus whatever per-member attributes that source carries (a sponsorship
+// route, a locality, a registry number). Meta is untyped on purpose — every
+// register has its own columns, and only that entry's own Gate reads its own keys,
+// so a typed union across sources would grow a field per source and be read by
+// nobody else.
+type Record struct {
+	Name string
+	Meta map[string]string
 }
 
-// Collection is one curated theme: a URL slug, the display copy rendered on the
-// /collections hub and the job-search facet, and its membership source — exactly
-// one of Slugs (a static hand list of canonical company slugs) or Dataset (a
-// remote list of company names). The import worker resolves the source to a set of
+// Dataset is a source of member records for a collection, resolved by the import
+// worker via its pure Parse (matching to our catalogue happens via normalize.Slug
+// in Match). The payload is either fetched from URL (an external dataset we
+// control) or supplied inline via Data (a file embedded in the binary, for a list
+// that is our own curated fact rather than a third-party feed) — exactly one is set.
+// ResolveURL is set instead of URL by a source that republishes at a new address
+// per snapshot (the GOV.UK sponsor register embeds the snapshot date in its CSV
+// path), so the address has to be discovered at fetch time rather than pinned.
+type Dataset struct {
+	URL        string
+	Data       []byte
+	ResolveURL func(context.Context, *http.Client) (string, error)
+	Parse      func([]byte) ([]Record, error)
+}
+
+// Valid reports whether the dataset declares exactly one payload source. Declaring
+// none leaves the collection unresolvable; declaring two leaves which one wins to
+// the reader of the import worker, so both are rejected here and by a registry test.
+func (d Dataset) Valid() bool {
+	n := 0
+	if d.URL != "" {
+		n++
+	}
+	if len(d.Data) > 0 {
+		n++
+	}
+	if d.ResolveURL != nil {
+		n++
+	}
+	return n == 1
+}
+
+// names adapts a name-only parser to the record shape. The editorial datasets
+// publish nothing but a name, so their parsers stay as they are and are wrapped
+// here; only a register that carries per-member attributes writes a Record parser
+// of its own.
+func names(parse func([]byte) ([]string, error)) func([]byte) ([]Record, error) {
+	return func(data []byte) ([]Record, error) {
+		parsed, err := parse(data)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]Record, len(parsed))
+		for i, n := range parsed {
+			out[i] = Record{Name: n}
+		}
+		return out, nil
+	}
+}
+
+// Kind separates the two sorts of company tag the registry carries. An editorial
+// collection is our own curated theme (Big Tech, Unicorns) — a judgement call. A
+// credential is a verifiable fact drawn from an authoritative public register (a
+// visa-sponsor licence), which carries an issuing body and a snapshot date and is
+// presented differently because a user may act on it.
+//
+// The zero value is deliberately invalid: Kind decides which group a tag renders
+// in, so a forgotten one must fail the registry test rather than default silently.
+type Kind string
+
+const (
+	KindEditorial  Kind = "editorial"
+	KindCredential Kind = "credential"
+)
+
+// Collection is one curated company tag: a URL slug, the display copy rendered on
+// the /collections hub and the job-search facet, its Kind, and its membership
+// source — exactly one of Slugs (a static hand list of canonical company slugs) or
+// Dataset (a remote member list). The import worker resolves the source to a set of
 // member companies.
 type Collection struct {
 	Slug        string
 	Title       string
 	Description string
+	Kind        Kind
 	Slugs       []string // static hand list (e.g. bigtech)
-	Dataset     *Dataset // remote company-name dataset (e.g. yc, unicorn)
+	Dataset     *Dataset // remote member dataset (e.g. yc, unicorn)
+	// Gate, when set, must hold before a name-matched company is tagged. It is what
+	// separates "this register lists a company by this name" from "this is that
+	// company" — the register's own metadata and the company's geography decide.
+	// A nil Gate admits every name match, which is what every editorial collection
+	// wants and has always done.
+	Gate func(Company, Record) bool
+}
+
+// Company is the subset of a catalogue company a Gate may consult: its canonical
+// slug, the countries it has open jobs in (job-derived, maintained by
+// RefreshCompanyFacets), and its headquarters country. Deliberately narrow — a gate
+// is a pure decision over facts already loaded by the import worker, not a hook
+// with database access.
+type Company struct {
+	Slug      string
+	Countries []string
+	HQCountry string
+}
+
+// Admits reports whether this collection accepts a name-matched company/record
+// pair. A collection with no Gate admits every match.
+func (c Collection) Admits(company Company, r Record) bool {
+	return c.Gate == nil || c.Gate(company, r)
 }
 
 // All is the fixed registry, in display order. Adding a collection is one entry
@@ -50,60 +141,70 @@ var All = []Collection{
 		Slug:        "yc",
 		Title:       "Y Combinator",
 		Description: "Open roles at Y Combinator–backed companies, from current batches to graduated unicorns.",
-		Dataset:     &Dataset{URL: ycDatasetURL, Parse: ParseYC},
+		Kind:        KindEditorial,
+		Dataset:     &Dataset{URL: ycDatasetURL, Parse: names(ParseYC)},
 	},
 	{
 		Slug:        "techstars",
 		Title:       "Techstars",
 		Description: "Open roles at Techstars-backed companies.",
-		Dataset:     &Dataset{URL: techstarsDatasetURL, Parse: ParseTechstarsCSV},
+		Kind:        KindEditorial,
+		Dataset:     &Dataset{URL: techstarsDatasetURL, Parse: names(ParseTechstarsCSV)},
 	},
 	{
 		Slug:        "european",
 		Title:       "European Startups",
 		Description: "Open roles at European startups across the continent's tech hubs.",
-		Dataset:     &Dataset{URL: europeanDatasetURL, Parse: ParseEUStartups},
+		Kind:        KindEditorial,
+		Dataset:     &Dataset{URL: europeanDatasetURL, Parse: names(ParseEUStartups)},
 	},
 	{
 		Slug:        "ai",
 		Title:       "AI Companies",
 		Description: "Open roles at AI-native companies — foundation-model labs, ML platforms and applied-AI products.",
+		Kind:        KindEditorial,
 		Slugs:       AICompanySlugs,
 	},
 	{
 		Slug:        "mag7",
 		Title:       "Magnificent Seven",
 		Description: "Open roles at the Magnificent Seven — Apple, Microsoft, Alphabet, Amazon, Meta, Nvidia and Tesla.",
+		Kind:        KindEditorial,
 		Slugs:       Mag7Slugs,
 	},
 	{
 		Slug:        "bigtech",
 		Title:       "Big Tech",
 		Description: "Open roles at the largest, most established technology companies.",
+		Kind:        KindEditorial,
 		Slugs:       BigTechSlugs,
 	},
 	{
 		Slug:        "unicorn",
 		Title:       "Unicorns",
 		Description: "Open roles at unicorns — private companies valued at over $1 billion.",
-		Dataset:     &Dataset{URL: unicornDatasetURL, Parse: ParseCompanyCSV},
+		Kind:        KindEditorial,
+		Dataset:     &Dataset{URL: unicornDatasetURL, Parse: names(ParseCompanyCSV)},
 	},
 	{
 		Slug:        "fortune500",
 		Title:       "Fortune 500",
 		Description: "Open roles at Fortune 500 companies — the largest US corporations by revenue.",
-		Dataset:     &Dataset{URL: fortune500DatasetURL, Parse: ParseCompanyCSV},
+		Kind:        KindEditorial,
+		Dataset:     &Dataset{URL: fortune500DatasetURL, Parse: names(ParseCompanyCSV)},
 	},
 	{
 		Slug:        "eastern-roots",
 		Title:       "Eastern Roots",
 		Description: "Open roles at globally distributed companies founded by Eastern European (incl. Russian-speaking) founders or with Eastern European engineering roots.",
-		Dataset:     &Dataset{Data: easternRootsData, Parse: ParseSlugList},
+		Kind:        KindEditorial,
+		Dataset:     &Dataset{Data: easternRootsData, Parse: names(ParseSlugList)},
 	},
 	{
 		Slug:        "ai-native",
 		Title:       "AI-Native",
 		Description: "Open roles at AI-native companies building AI-first products and infrastructure — model and inference APIs, vector databases, and agent/dev tooling.",
+		Kind:        KindEditorial,
 		Slugs:       AINativeSlugs,
 	},
 }

--- a/internal/collections/collections_test.go
+++ b/internal/collections/collections_test.go
@@ -65,17 +65,33 @@ func TestHandListSlugs_AreCanonical(t *testing.T) {
 	}
 }
 
-func TestMatch_SplitsPresentAndAbsentDedupedSorted(t *testing.T) {
-	existing := map[string]struct{}{"stripe": {}, "airbnb": {}}
-	// "Stripe" and "stripe " both normalize to stripe (dup); "Airbnb" matches;
+func TestMembers_SplitsPresentAndAbsentDedupedSorted(t *testing.T) {
+	companies := map[string]Company{"stripe": {Slug: "stripe"}, "airbnb": {Slug: "airbnb"}}
+	// "Stripe" and "stripe" both normalize to stripe (dup); "Airbnb" matches;
 	// "Unknown Co" does not.
-	matched, unmatched := Match([]string{"Stripe", "stripe", "Airbnb", "Unknown Co"}, existing)
+	c := Collection{Slug: "x", Kind: KindEditorial}
+	matched, stat := c.Members([]Record{{Name: "Stripe"}, {Name: "stripe"}, {Name: "Airbnb"}, {Name: "Unknown Co"}}, companies)
 
 	if !reflect.DeepEqual(matched, []string{"airbnb", "stripe"}) {
 		t.Errorf("matched = %#v, want [airbnb stripe] (deduped, sorted)", matched)
 	}
-	if !reflect.DeepEqual(unmatched, []string{"Unknown Co"}) {
-		t.Errorf("unmatched = %#v, want [Unknown Co]", unmatched)
+	if !reflect.DeepEqual(stat.UnmatchedNames, []string{"Unknown Co"}) {
+		t.Errorf("unmatched = %#v, want [Unknown Co]", stat.UnmatchedNames)
+	}
+	if stat.Gated != 0 || stat.Ambiguous != 0 {
+		t.Errorf("an editorial collection reported gate/ambiguity counts: %+v", stat)
+	}
+}
+
+func TestMembers_EditorialMatchingDoesNotStripLegalForms(t *testing.T) {
+	// The suffix strip belongs to credentials only. An editorial dataset naming
+	// "Acme Robotics Limited" must still land on acme-robotics-limited, not on a
+	// different company called acme-robotics.
+	companies := map[string]Company{"acme-robotics-limited": {Slug: "acme-robotics-limited"}}
+	c := Collection{Slug: "x", Kind: KindEditorial}
+	matched, _ := c.Members([]Record{{Name: "Acme Robotics Limited"}}, companies)
+	if !reflect.DeepEqual(matched, []string{"acme-robotics-limited"}) {
+		t.Errorf("editorial match = %#v, want [acme-robotics-limited]", matched)
 	}
 }
 

--- a/internal/collections/collections_test.go
+++ b/internal/collections/collections_test.go
@@ -1,6 +1,9 @@
 package collections
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"reflect"
 	"slices"
 	"testing"
@@ -169,6 +172,117 @@ func TestParseEUStartups_ExtractsNameField(t *testing.T) {
 	}
 }
 
+func TestNames_AdaptsANameParserToRecords(t *testing.T) {
+	got, err := names(func([]byte) ([]string, error) { return []string{"Acme", "Globex"}, nil })(nil)
+	if err != nil {
+		t.Fatalf("names adapter returned error: %v", err)
+	}
+	want := []Record{{Name: "Acme"}, {Name: "Globex"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("names adapter = %+v, want %+v", got, want)
+	}
+}
+
+func TestNames_PropagatesParserError(t *testing.T) {
+	_, err := names(func([]byte) ([]string, error) { return nil, errBoom })(nil)
+	if err == nil {
+		t.Error("names adapter swallowed the parser error")
+	}
+}
+
+func TestRecord_CarriesSourceMetadata(t *testing.T) {
+	r := Record{Name: "Acme Robotics Ltd", Meta: map[string]string{"route": "Skilled Worker"}}
+	if r.Meta["route"] != "Skilled Worker" {
+		t.Errorf("record metadata lost: %+v", r)
+	}
+}
+
+func TestGate_NilAdmitsEveryNameMatch(t *testing.T) {
+	c := Collection{Slug: "x", Kind: KindEditorial}
+	if !c.Admits(Company{Slug: "acme"}, Record{Name: "Acme"}) {
+		t.Error("a gateless collection rejected a name match")
+	}
+}
+
+func TestGate_DecidesWhenSet(t *testing.T) {
+	c := Collection{
+		Slug: "x",
+		Kind: KindCredential,
+		Gate: func(co Company, r Record) bool { return r.Meta["route"] == "Skilled Worker" },
+	}
+	if c.Admits(Company{Slug: "acme"}, Record{Meta: map[string]string{"route": "Skilled Worker"}}) != true {
+		t.Error("gate rejected a record it should admit")
+	}
+	if c.Admits(Company{Slug: "acme"}, Record{Meta: map[string]string{"route": "Seasonal Worker"}}) != false {
+		t.Error("gate admitted a record it should reject")
+	}
+}
+
+func TestCompany_CarriesTheAttributesAGateNeeds(t *testing.T) {
+	co := Company{Slug: "acme", Countries: []string{"GB", "US"}, HQCountry: "GB"}
+	if co.Slug != "acme" || co.HQCountry != "GB" || len(co.Countries) != 2 {
+		t.Errorf("company shape lost detail: %+v", co)
+	}
+}
+
+func TestDataset_SourceIsExactlyOneOfURLDataResolver(t *testing.T) {
+	cases := []struct {
+		name string
+		ds   Dataset
+		ok   bool
+	}{
+		{"url only", Dataset{URL: "https://x/y.json"}, true},
+		{"data only", Dataset{Data: []byte("x")}, true},
+		{"resolver only", Dataset{ResolveURL: func(context.Context, *http.Client) (string, error) { return "", nil }}, true},
+		{"none", Dataset{}, false},
+		{"url and data", Dataset{URL: "https://x", Data: []byte("x")}, false},
+		{"url and resolver", Dataset{URL: "https://x", ResolveURL: func(context.Context, *http.Client) (string, error) { return "", nil }}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ds.Valid(); got != tc.ok {
+				t.Errorf("Valid() = %v, want %v", got, tc.ok)
+			}
+		})
+	}
+}
+
+func TestRegistry_EveryDatasetDeclaresExactlyOneSource(t *testing.T) {
+	for _, c := range All {
+		if c.Dataset != nil && !c.Dataset.Valid() {
+			t.Errorf("collection %q dataset declares no single source", c.Slug)
+		}
+	}
+}
+
+func TestRegistry_EveryEntryDeclaresAKind(t *testing.T) {
+	// The zero Kind is deliberately invalid: kind decides which filter group a tag
+	// renders in, so a forgotten one must fail here rather than silently defaulting.
+	for _, c := range All {
+		switch c.Kind {
+		case KindEditorial, KindCredential:
+		default:
+			t.Errorf("collection %q declares no valid kind (got %q)", c.Slug, c.Kind)
+		}
+	}
+}
+
+func TestRegistry_CuratedThemesAreEditorial(t *testing.T) {
+	for _, slug := range []string{
+		"yc", "techstars", "european", "ai", "mag7",
+		"bigtech", "unicorn", "fortune500", "eastern-roots", "ai-native",
+	} {
+		c, ok := Lookup(slug)
+		if !ok {
+			t.Errorf("registry missing %q", slug)
+			continue
+		}
+		if c.Kind != KindEditorial {
+			t.Errorf("collection %q kind = %q, want %q", slug, c.Kind, KindEditorial)
+		}
+	}
+}
+
 func TestRegistry_HasUnicorn(t *testing.T) {
 	c, ok := Lookup("unicorn")
 	if !ok || c.Dataset == nil {
@@ -236,18 +350,21 @@ func TestEasternRoots_EmbeddedDatasetResolves(t *testing.T) {
 	if len(c.Dataset.Data) == 0 {
 		t.Fatal("eastern-roots dataset has no embedded data")
 	}
-	names, err := c.Dataset.Parse(c.Dataset.Data)
+	records, err := c.Dataset.Parse(c.Dataset.Data)
 	if err != nil {
 		t.Fatalf("parse embedded eastern-roots: %v", err)
 	}
-	if len(names) < 50 {
-		t.Errorf("eastern-roots slugs = %d, want a substantial list", len(names))
+	if len(records) < 50 {
+		t.Errorf("eastern-roots slugs = %d, want a substantial list", len(records))
 	}
 	// The embedded slugs must be canonical (Match normalizes them, but a
 	// non-canonical entry signals a bad edit to the committed file).
-	for _, s := range names {
-		if got := normalize.Slug(s); got != s {
-			t.Errorf("non-canonical slug %q (normalizes to %q)", s, got)
+	for _, r := range records {
+		if got := normalize.Slug(r.Name); got != r.Name {
+			t.Errorf("non-canonical slug %q (normalizes to %q)", r.Name, got)
 		}
 	}
 }
+
+// errBoom is a sentinel for the adapter's error-propagation test.
+var errBoom = errors.New("boom")

--- a/internal/collections/collections_test.go
+++ b/internal/collections/collections_test.go
@@ -197,6 +197,58 @@ func TestRecord_CarriesSourceMetadata(t *testing.T) {
 	}
 }
 
+func TestRegisterSlug_StripsTrailingLegalSuffix(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// normalize.Slug alone yields acme-robotics-limited, which never matches our
+		// acme-robotics — the whole reason this step exists.
+		{"ACME ROBOTICS LIMITED", "acme-robotics"},
+		{"Acme Robotics Ltd", "acme-robotics"},
+		{"Acme Robotics Ltd.", "acme-robotics"},
+		{"Monzo Bank PLC", "monzo-bank"},
+		{"Foo Bar LLP", "foo-bar"},
+		{"Community Co CIC", "community-co"},
+		{"Booking B.V.", "booking"},
+		{"Adyen N.V.", "adyen"},
+		{"Adyen NV", "adyen"},
+		// No suffix to strip.
+		{"Monzo", "monzo"},
+		{"Deliveroo", "deliveroo"},
+	}
+	for _, tc := range cases {
+		if got := RegisterSlug(tc.in); got != tc.want {
+			t.Errorf("RegisterSlug(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRegisterSlug_OnlyStripsAtTheEnd(t *testing.T) {
+	// "Limited" leading the name is part of the name, not a legal form.
+	if got := RegisterSlug("LIMITED BRANDS INC"); got != "limited-brands-inc" {
+		t.Errorf("RegisterSlug(LIMITED BRANDS INC) = %q, want limited-brands-inc", got)
+	}
+	if got := RegisterSlug("Limited Brands"); got != "limited-brands" {
+		t.Errorf("RegisterSlug(Limited Brands) = %q, want limited-brands", got)
+	}
+}
+
+func TestRegisterSlug_NeverReducesANameToNothing(t *testing.T) {
+	// A register row that is nothing but a legal form must not normalize to the empty
+	// slug — an empty slug would match nothing, but stripping to it hides a bad row.
+	for _, in := range []string{"Limited", "LTD", "B.V."} {
+		if got := RegisterSlug(in); got == "" {
+			t.Errorf("RegisterSlug(%q) stripped the whole name away", in)
+		}
+	}
+}
+
+func TestRegisterSlug_StripsOnlyOneSuffix(t *testing.T) {
+	// Chained forms are rare and ambiguous; strip one and stop rather than peel a
+	// name down to a fragment.
+	if got := RegisterSlug("Acme Holdings Ltd"); got != "acme-holdings" {
+		t.Errorf("RegisterSlug(Acme Holdings Ltd) = %q, want acme-holdings", got)
+	}
+}
+
 func TestGate_NilAdmitsEveryNameMatch(t *testing.T) {
 	c := Collection{Slug: "x", Kind: KindEditorial}
 	if !c.Admits(Company{Slug: "acme"}, Record{Name: "Acme"}) {

--- a/internal/collections/nlsponsor.go
+++ b/internal/collections/nlsponsor.go
@@ -1,0 +1,49 @@
+package collections
+
+import (
+	"errors"
+	"html"
+	"regexp"
+	"strings"
+)
+
+// nlSponsorURL is the IND public register of recognised sponsors for the "work"
+// residence purpose (which covers the highly-skilled-migrant scheme). Unlike the UK
+// register it is a single stable page rather than a dated snapshot, and it
+// publishes no route breakdown — recognition is the whole fact.
+const nlSponsorURL = "https://ind.nl/en/public-register-recognised-sponsors/public-register-work"
+
+// nlSponsorRow matches one register row: the organisation as a row header, its KvK
+// number in the cell beside it.
+var nlSponsorRow = regexp.MustCompile(
+	`(?is)<th[^>]*scope=["']row["'][^>]*>(.*?)</th>\s*<td[^>]*>(.*?)</td>`)
+
+// tagPattern strips the inline markup the register wraps some names in.
+var tagPattern = regexp.MustCompile(`<[^>]*>`)
+
+// ParseNLSponsors reads the IND register page into one record per recognised
+// sponsor, keeping the KvK number as the identity field that tells two same-named
+// organisations apart. A page that yields no rows is an error, not an empty
+// register: the table failing to render means the source changed, and returning
+// nothing would reconcile the credential off every company.
+func ParseNLSponsors(page []byte) ([]Record, error) {
+	matches := nlSponsorRow.FindAllStringSubmatch(string(page), -1)
+	records := make([]Record, 0, len(matches))
+	for _, m := range matches {
+		name := cellText(m[1])
+		if name == "" {
+			continue
+		}
+		records = append(records, Record{Name: name, Meta: map[string]string{"kvk": cellText(m[2])}})
+	}
+	if len(records) == 0 {
+		return nil, errors.New("collections: nl recognised-sponsor register parsed to no rows")
+	}
+	return records, nil
+}
+
+// cellText reduces a table cell to its visible text: markup removed, HTML entities
+// decoded, whitespace collapsed.
+func cellText(cell string) string {
+	return strings.Join(strings.Fields(html.UnescapeString(tagPattern.ReplaceAllString(cell, " "))), " ")
+}

--- a/internal/collections/nlsponsor_test.go
+++ b/internal/collections/nlsponsor_test.go
@@ -1,0 +1,63 @@
+package collections
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseNLSponsors_ReadsTheRegisterTable(t *testing.T) {
+	// The IND register is one HTML table: the organisation is a row header, the KvK
+	// number the cell beside it.
+	html := `
+	<table>
+	  <tr><th scope="col">Organisation</th><th scope="col">KvK number</th></tr>
+	  <tr><th scope="row">Adyen N.V.</th><td>34259528</td></tr>
+	  <tr><th scope="row">Booking.com B.V.</th><td>31047344</td></tr>
+	</table>`
+
+	got, err := ParseNLSponsors([]byte(html))
+	if err != nil {
+		t.Fatalf("ParseNLSponsors: %v", err)
+	}
+	want := []Record{
+		{Name: "Adyen N.V.", Meta: map[string]string{"kvk": "34259528"}},
+		{Name: "Booking.com B.V.", Meta: map[string]string{"kvk": "31047344"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseNLSponsors =\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+func TestParseNLSponsors_DecodesEntitiesAndStripsMarkup(t *testing.T) {
+	html := `<tr><th scope="row">Ben &amp; Jerry&#39;s <span>B.V.</span></th><td>12345678</td></tr>`
+	got, err := ParseNLSponsors([]byte(html))
+	if err != nil {
+		t.Fatalf("ParseNLSponsors: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "Ben & Jerry's B.V." {
+		t.Errorf("entity/markup handling wrong: %+v", got)
+	}
+}
+
+func TestParseNLSponsors_SkipsRowsWithNoOrganisation(t *testing.T) {
+	html := `
+	  <tr><th scope="row"></th><td>99999999</td></tr>
+	  <tr><th scope="row">Adyen N.V.</th><td>34259528</td></tr>`
+	got, err := ParseNLSponsors([]byte(html))
+	if err != nil {
+		t.Fatalf("ParseNLSponsors: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "Adyen N.V." {
+		t.Errorf("blank organisation not skipped: %+v", got)
+	}
+}
+
+func TestParseNLSponsors_RejectsAPageWithNoRows(t *testing.T) {
+	// The register page rendering without its table means the source changed; an
+	// empty result would reconcile the credential off every company.
+	for _, page := range []string{"", "<html><body>Service unavailable</body></html>"} {
+		if _, err := ParseNLSponsors([]byte(page)); err == nil {
+			t.Errorf("ParseNLSponsors accepted a page with no rows: %q", page)
+		}
+	}
+}

--- a/internal/collections/register.go
+++ b/internal/collections/register.go
@@ -92,8 +92,40 @@ func RequireCountry(code string) func(Company, Record) bool {
 		if strings.Contains(RegisterSlug(r.Name), "-") {
 			return true // multi-token: the country facet carries it
 		}
-		return strings.EqualFold(co.HQCountry, code)
+		return countryMatches(co.HQCountry, code)
 	}
+}
+
+// countryAliases are the spellings a country may appear under in companies.hq_country,
+// beyond its ISO code. The column has two writers and only one normalizes:
+// cmd/import-yc runs values through location.Parse, while cmd/backfill-company-info
+// writes its upstream's `country` field verbatim. That upstream currently emits ISO
+// codes, so a bare code comparison happens to work today — but the gate must not
+// depend on a third party's formatting, because the failure is silent: a company
+// simply never earns a credential it qualifies for, and nothing logs it.
+//
+// Whole-value comparison only, never a substring: "New Great Britain Holdings" is a
+// company name, not a country.
+var countryAliases = map[string][]string{
+	"GB": {"uk", "united kingdom", "great britain", "england", "scotland", "wales"},
+	"NL": {"netherlands", "the netherlands", "holland"},
+}
+
+// countryMatches reports whether a stored country value denotes the given ISO code.
+func countryMatches(value, code string) bool {
+	if value == "" {
+		return false
+	}
+	if strings.EqualFold(value, code) {
+		return true
+	}
+	normalized := strings.ToLower(strings.Join(strings.Fields(value), " "))
+	for _, alias := range countryAliases[strings.ToUpper(code)] {
+		if normalized == alias {
+			return true
+		}
+	}
+	return false
 }
 
 // RequireRoute builds the route gate: at least one of the organisation's register
@@ -168,7 +200,7 @@ func DropAmbiguous(records []Record, identityKey string) []Record {
 // depend on that).
 func hasCountry(countries []string, code string) bool {
 	for _, c := range countries {
-		if strings.EqualFold(c, code) {
+		if countryMatches(c, code) {
 			return true
 		}
 	}

--- a/internal/collections/register.go
+++ b/internal/collections/register.go
@@ -1,0 +1,176 @@
+package collections
+
+import (
+	"strings"
+
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// legalSuffixes are the corporate-form words a public register appends to an
+// organisation's legal name but that our catalogue's company names never carry.
+// Matched as whole trailing tokens after normalization, so "bv" strips from
+// "Booking B.V." but not from "BV Sports".
+//
+// Kept deliberately short: only the forms the UK Companies House and Dutch KvK
+// registers actually emit. A speculative list (GmbH, S.A., Pty, …) would widen the
+// blast radius of an over-strip for registers we do not read.
+var legalSuffixes = map[string]struct{}{
+	"ltd": {}, "limited": {}, "plc": {}, "llp": {}, "lp": {}, "cic": {}, "cio": {},
+	"bv": {}, "nv": {},
+}
+
+// RegisterSlug normalizes an organisation name as a public register publishes it
+// into the canonical company slug our catalogue uses, stripping one trailing legal
+// form on the way.
+//
+// The strip is why this exists at all: normalize.Slug("ACME ROBOTICS LIMITED") is
+// "acme-robotics-limited", which never equals our "acme-robotics", so an exact
+// match against a register would find almost nothing without it.
+//
+// Two deliberate limits. Only the *last* token is considered, so "Limited Brands"
+// keeps its first word — a form word inside a name is part of the name. And a name
+// consisting only of a legal form is returned unstripped rather than reduced to the
+// empty slug, because an empty slug silently matches nothing while a bad register
+// row is worth leaving visible.
+func RegisterSlug(name string) string {
+	fields := strings.Fields(name)
+	if len(fields) < 2 {
+		// Nothing to strip without erasing the name entirely.
+		return normalize.Slug(name)
+	}
+	if _, isSuffix := legalSuffixes[letters(fields[len(fields)-1])]; !isSuffix {
+		return normalize.Slug(name)
+	}
+	return normalize.Slug(strings.Join(fields[:len(fields)-1], " "))
+}
+
+// letters lowercases a token down to its ASCII letters, so the punctuated and bare
+// spellings of a legal form ("B.V.", "BV", "Ltd.") compare as one. The check runs
+// on the raw token rather than on the slug because normalize.Slug turns "B.V." into
+// "b-v" — two tokens, matching no suffix — while leaving a name like "Foo.com"
+// intact, which stripping dots globally would not.
+func letters(token string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(token) {
+		if r >= 'a' && r <= 'z' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// ukWorkRoutes are the GOV.UK sponsorship routes that mean a licence useful to a
+// candidate looking for a job. The register also lists Temporary Worker routes
+// (seasonal, creative, charity, religious) and study routes, which sit alongside
+// these in the same file and would badge a farm or a film crew as a sponsor for an
+// engineering role. Matched as prefixes because the Global Business Mobility family
+// publishes one route per sub-scheme.
+var ukWorkRoutes = []string{
+	"Skilled Worker",
+	"Global Business Mobility",
+	"Scale-up",
+}
+
+// RequireCountry builds the geography gate: the company must be demonstrably
+// present in the register's country before it can hold that country's credential.
+//
+// The rule is stricter for a single-token name, and that asymmetry is the point. A
+// two-token name ("Acme Robotics") is specific enough that sharing it with an
+// unrelated business is unlikely, so open jobs in the country suffice. A one-token
+// name ("Apple", "Spark", "Nova") is not: the UK register holds ~120k organisations
+// across every industry, and a multinational with a local office would otherwise
+// inherit a licence from a same-named local business. For those, the company's
+// headquarters must be in the register's country — which Monzo and Revolut satisfy
+// and Apple does not.
+//
+// An unknown headquarters is not a match. Absence of evidence is not evidence.
+func RequireCountry(code string) func(Company, Record) bool {
+	return func(co Company, r Record) bool {
+		if !hasCountry(co.Countries, code) {
+			return false
+		}
+		if strings.Contains(RegisterSlug(r.Name), "-") {
+			return true // multi-token: the country facet carries it
+		}
+		return strings.EqualFold(co.HQCountry, code)
+	}
+}
+
+// RequireRoute builds the route gate: at least one of the organisation's register
+// rows must sit on one of the given routes. Prefix-matched (see ukWorkRoutes).
+func RequireRoute(prefixes ...string) func(Company, Record) bool {
+	return func(_ Company, r Record) bool {
+		route := r.Meta["route"]
+		if route == "" {
+			return false
+		}
+		for _, p := range prefixes {
+			if strings.HasPrefix(route, p) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// AllOf composes gates: every one must admit. No gates admits everything, matching
+// a nil Gate.
+func AllOf(gates ...func(Company, Record) bool) func(Company, Record) bool {
+	return func(co Company, r Record) bool {
+		for _, g := range gates {
+			if !g(co, r) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// DropAmbiguous removes every row whose normalized name is shared by more than one
+// organisation, so a name that identifies nobody grants nothing.
+//
+// identityKey names the Meta field that tells two organisations apart — "town" for
+// the UK register, the KvK number for the Dutch one. It is needed because a shared
+// name is not by itself a collision: the UK register lists one organisation once
+// per route it holds, and those rows must survive for the route gate to read them.
+// Rows sharing a name AND an identity are one body; rows sharing a name with
+// different identities are a collision and all of them go.
+//
+// With an empty identityKey (or rows that omit it) every same-named row counts as
+// one organisation. That is the permissive reading on purpose: firing the guard on
+// a register that simply cannot disambiguate would delete its every duplicate,
+// and the geography rules are the real defence in that case.
+func DropAmbiguous(records []Record, identityKey string) []Record {
+	identities := make(map[string]map[string]struct{}, len(records))
+	for _, r := range records {
+		slug := RegisterSlug(r.Name)
+		if slug == "" {
+			continue
+		}
+		if identities[slug] == nil {
+			identities[slug] = make(map[string]struct{}, 1)
+		}
+		identities[slug][r.Meta[identityKey]] = struct{}{}
+	}
+
+	out := make([]Record, 0, len(records))
+	for _, r := range records {
+		if len(identities[RegisterSlug(r.Name)]) > 1 {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// hasCountry reports whether a company's country facet holds the given ISO code,
+// case-insensitively (the facet is upper-case by convention, but a gate must not
+// depend on that).
+func hasCountry(countries []string, code string) bool {
+	for _, c := range countries {
+		if strings.EqualFold(c, code) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/collections/register_test.go
+++ b/internal/collections/register_test.go
@@ -1,0 +1,144 @@
+package collections
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRequireCountry_MultiTokenNameMatchesOnTheCountryFacet(t *testing.T) {
+	gate := RequireCountry("GB")
+	co := Company{Slug: "acme-robotics", Countries: []string{"GB", "US"}}
+	if !gate(co, Record{Name: "ACME ROBOTICS LIMITED"}) {
+		t.Error("a two-token name with GB jobs was rejected")
+	}
+}
+
+func TestRequireCountry_RejectsACompanyWithNoJobsInTheRegistersCountry(t *testing.T) {
+	gate := RequireCountry("GB")
+	co := Company{Slug: "acme-robotics", Countries: []string{"US"}, HQCountry: "US"}
+	if gate(co, Record{Name: "ACME ROBOTICS LIMITED"}) {
+		t.Error("a company with no GB presence earned a UK credential")
+	}
+}
+
+func TestRequireCountry_SingleTokenNameNeedsAMatchingHeadquarters(t *testing.T) {
+	gate := RequireCountry("GB")
+
+	// Apple hires in London, so the country facet alone would admit it — and hand it
+	// a licence belonging to some unrelated "APPLE LTD". The headquarters rule is
+	// what stops that.
+	apple := Company{Slug: "apple", Countries: []string{"GB", "US"}, HQCountry: "US"}
+	if gate(apple, Record{Name: "APPLE LTD"}) {
+		t.Error("a single-token match was admitted on the country facet alone")
+	}
+
+	// Monzo is single-token and genuinely British; it must still pass.
+	monzo := Company{Slug: "monzo", Countries: []string{"GB"}, HQCountry: "GB"}
+	if !gate(monzo, Record{Name: "MONZO BANK LTD"}) {
+		t.Error("a UK-headquartered single-token company was rejected")
+	}
+}
+
+func TestRequireCountry_SingleTokenWithNoHeadquartersIsRejected(t *testing.T) {
+	// An unknown hq_country is not evidence of a UK headquarters. Never guess.
+	gate := RequireCountry("GB")
+	co := Company{Slug: "monzo", Countries: []string{"GB"}}
+	if gate(co, Record{Name: "MONZO LTD"}) {
+		t.Error("a single-token match was admitted with an unknown headquarters")
+	}
+}
+
+func TestRequireCountry_IsCaseInsensitiveOnCountryCodes(t *testing.T) {
+	gate := RequireCountry("GB")
+	co := Company{Slug: "acme-robotics", Countries: []string{"gb"}}
+	if !gate(co, Record{Name: "ACME ROBOTICS LTD"}) {
+		t.Error("a lowercase country code was not recognised")
+	}
+}
+
+func TestRequireRoute_AdmitsOnAWorkRoute(t *testing.T) {
+	gate := RequireRoute(ukWorkRoutes...)
+	for _, route := range []string{
+		"Skilled Worker",
+		"Global Business Mobility - Senior or Specialist Worker",
+		"Scale-up",
+	} {
+		if !gate(Company{}, Record{Meta: map[string]string{"route": route}}) {
+			t.Errorf("work route %q was rejected", route)
+		}
+	}
+}
+
+func TestRequireRoute_RejectsATemporaryOrStudyRoute(t *testing.T) {
+	gate := RequireRoute(ukWorkRoutes...)
+	for _, route := range []string{
+		"Temporary Worker - Seasonal Worker",
+		"Temporary Worker - Creative Worker",
+		"Temporary Worker - Charity Worker",
+		"Student",
+		"",
+	} {
+		if gate(Company{}, Record{Meta: map[string]string{"route": route}}) {
+			t.Errorf("non-work route %q was admitted", route)
+		}
+	}
+}
+
+func TestAllOf_RequiresEveryGate(t *testing.T) {
+	yes := func(Company, Record) bool { return true }
+	no := func(Company, Record) bool { return false }
+
+	if !AllOf(yes, yes)(Company{}, Record{}) {
+		t.Error("AllOf rejected when every gate admitted")
+	}
+	if AllOf(yes, no)(Company{}, Record{}) {
+		t.Error("AllOf admitted when a gate rejected")
+	}
+	if !AllOf()(Company{}, Record{}) {
+		t.Error("AllOf with no gates should admit")
+	}
+}
+
+func TestDropAmbiguous_RemovesEveryRowOfANameTwoOrganisationsShare(t *testing.T) {
+	// Two unrelated organisations normalize alike — different towns give them away.
+	// The name identifies neither, so both go; granting to one would be a coin flip.
+	in := []Record{
+		{Name: "SPARK LTD", Meta: map[string]string{"town": "Liverpool"}},
+		{Name: "Spark Limited", Meta: map[string]string{"town": "Leeds"}},
+		{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London"}},
+	}
+	got := DropAmbiguous(in, "town")
+	want := []Record{{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("DropAmbiguous = %+v, want %+v", got, want)
+	}
+}
+
+func TestDropAmbiguous_KeepsOneOrganisationsRowsAcrossRoutes(t *testing.T) {
+	// The UK register lists an organisation once per route it holds. Those rows share
+	// a name AND a town, so they are one body: they must all survive, because the
+	// route gate needs to see every one of them.
+	in := []Record{
+		{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London", "route": "Skilled Worker"}},
+		{Name: "ACME ROBOTICS LTD", Meta: map[string]string{"town": "London", "route": "Scale-up"}},
+	}
+	if got := DropAmbiguous(in, "town"); len(got) != 2 {
+		t.Errorf("DropAmbiguous dropped an organisation's own per-route rows: %+v", got)
+	}
+}
+
+func TestDropAmbiguous_WithNoIdentityKeyTreatsARepeatedNameAsOneOrganisation(t *testing.T) {
+	// A register with no disambiguator (or rows missing it) cannot tell a duplicate
+	// from a collision. Treating them as one body keeps the guard from firing on
+	// every multi-route row; the geography rules remain the real defence.
+	in := []Record{{Name: "ACME LTD"}, {Name: "Acme Limited"}}
+	if got := DropAmbiguous(in, ""); len(got) != 2 {
+		t.Errorf("DropAmbiguous with no identity key dropped rows: %+v", got)
+	}
+}
+
+func TestDropAmbiguous_KeepsAnEmptyInputEmpty(t *testing.T) {
+	if got := DropAmbiguous(nil, "town"); len(got) != 0 {
+		t.Errorf("DropAmbiguous(nil) = %+v, want empty", got)
+	}
+}

--- a/internal/collections/register_test.go
+++ b/internal/collections/register_test.go
@@ -197,3 +197,48 @@ func TestDropAmbiguous_KeepsAnEmptyInputEmpty(t *testing.T) {
 		t.Errorf("DropAmbiguous(nil) = %+v, want empty", got)
 	}
 }
+
+func TestRequireCountry_AcceptsSpelledOutCountryNames(t *testing.T) {
+	// hq_country has two writers and only one of them normalizes: cmd/import-yc runs
+	// values through location.Parse, while cmd/backfill-company-info writes the
+	// upstream `country` field verbatim. Today that upstream happens to emit ISO
+	// codes, so a bare code comparison works — but the gate must not depend on a
+	// third party's formatting choice, because the failure is silent: a company
+	// simply never earns a credential it qualifies for.
+	gate := RequireCountry("GB")
+	for _, hq := range []string{"GB", "gb", "uk", "UK", "United Kingdom", "united kingdom", "Great Britain"} {
+		co := Company{Slug: "monzo", Countries: []string{"GB"}, HQCountry: hq}
+		if !gate(co, Record{Name: "MONZO LTD"}) {
+			t.Errorf("hq_country %q was not recognised as the UK", hq)
+		}
+	}
+	gate = RequireCountry("NL")
+	for _, hq := range []string{"NL", "nl", "Netherlands", "the netherlands"} {
+		co := Company{Slug: "adyen", Countries: []string{"NL"}, HQCountry: hq}
+		if !gate(co, Record{Name: "ADYEN N.V."}) {
+			t.Errorf("hq_country %q was not recognised as the Netherlands", hq)
+		}
+	}
+}
+
+func TestRequireCountry_StillRejectsAnotherCountry(t *testing.T) {
+	gate := RequireCountry("GB")
+	for _, hq := range []string{"US", "United States", "IE", "Ireland", ""} {
+		co := Company{Slug: "apple", Countries: []string{"GB", "US"}, HQCountry: hq}
+		if gate(co, Record{Name: "APPLE LTD"}) {
+			t.Errorf("hq_country %q was accepted as the UK", hq)
+		}
+	}
+}
+
+func TestRequireCountry_DoesNotMatchOnASubstring(t *testing.T) {
+	// "Great Britain" must not make every string containing "britain" a match, and a
+	// country facet value is compared whole, not by prefix.
+	gate := RequireCountry("GB")
+	for _, hq := range []string{"New Great Britain Holdings", "gbr-something", "ukraine"} {
+		co := Company{Slug: "x", Countries: []string{"GB"}, HQCountry: hq}
+		if gate(co, Record{Name: "X LTD"}) {
+			t.Errorf("hq_country %q matched by substring", hq)
+		}
+	}
+}

--- a/internal/collections/register_test.go
+++ b/internal/collections/register_test.go
@@ -5,6 +5,61 @@ import (
 	"testing"
 )
 
+func TestRegistry_HasBothSponsorCredentials(t *testing.T) {
+	for _, slug := range []string{"uk-skilled-worker-sponsor", "nl-recognised-sponsor"} {
+		c, ok := Lookup(slug)
+		if !ok {
+			t.Errorf("registry missing %q", slug)
+			continue
+		}
+		if c.Kind != KindCredential {
+			t.Errorf("%s kind = %q, want %q", slug, c.Kind, KindCredential)
+		}
+		if c.Title == "" || c.Description == "" {
+			t.Errorf("%s missing display copy: %+v", slug, c)
+		}
+		if c.Dataset == nil || !c.Dataset.Valid() {
+			t.Errorf("%s has no single dataset source", slug)
+		}
+		if c.Gate == nil {
+			t.Errorf("%s has no gate — a credential must never tag on a bare name match", slug)
+		}
+	}
+}
+
+func TestUKSponsorEntry_GateRejectsATemporaryWorkerFarm(t *testing.T) {
+	c, ok := Lookup("uk-skilled-worker-sponsor")
+	if !ok {
+		t.Fatal("uk-skilled-worker-sponsor missing")
+	}
+	farm := Company{Slug: "green-fields-farm", Countries: []string{"GB"}, HQCountry: "GB"}
+	seasonal := Record{Name: "Green Fields Farm Ltd", Meta: map[string]string{"route": "Temporary Worker - Seasonal Worker"}}
+	if c.Admits(farm, seasonal) {
+		t.Error("a seasonal-worker licence earned the skilled-worker credential")
+	}
+	skilled := Record{Name: "Green Fields Farm Ltd", Meta: map[string]string{"route": "Skilled Worker"}}
+	if !c.Admits(farm, skilled) {
+		t.Error("a skilled-worker row was rejected")
+	}
+}
+
+func TestNLSponsorEntry_GateIsGeographyOnly(t *testing.T) {
+	c, ok := Lookup("nl-recognised-sponsor")
+	if !ok {
+		t.Fatal("nl-recognised-sponsor missing")
+	}
+	// The IND register publishes no route breakdown, so recognition plus presence is
+	// the whole test — but presence still has to hold.
+	adyen := Company{Slug: "adyen", Countries: []string{"NL"}, HQCountry: "NL"}
+	if !c.Admits(adyen, Record{Name: "Adyen N.V."}) {
+		t.Error("a Dutch-headquartered recognised sponsor was rejected")
+	}
+	elsewhere := Company{Slug: "adyen", Countries: []string{"US"}, HQCountry: "US"}
+	if c.Admits(elsewhere, Record{Name: "Adyen N.V."}) {
+		t.Error("a company with no Dutch presence earned the Dutch credential")
+	}
+}
+
 func TestRequireCountry_MultiTokenNameMatchesOnTheCountryFacet(t *testing.T) {
 	gate := RequireCountry("GB")
 	co := Company{Slug: "acme-robotics", Countries: []string{"GB", "US"}}

--- a/internal/collections/uksponsor.go
+++ b/internal/collections/uksponsor.go
@@ -1,0 +1,137 @@
+package collections
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// The GOV.UK register of licensed sponsors. The CSV is republished each month at a
+// fresh URL carrying the snapshot date, so the address is discovered per run rather
+// than pinned: the Content API is asked first, and the publication page is scraped
+// if that fails. Two mechanisms because they break independently — the API can
+// change shape while the page still renders, and vice versa.
+const (
+	ukSponsorAPIURL  = "https://www.gov.uk/api/content/government/publications/register-of-licensed-sponsors-workers"
+	ukSponsorPageURL = "https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers"
+
+	// The attachment and link text identifying the worker register, distinguishing it
+	// from the student-sponsor register published alongside it.
+	ukSponsorAttachmentTitle = "Register of Worker and Temporary Worker licensed sponsors"
+)
+
+// errNoSponsorCSV means a source was reachable but held no register link. It is a
+// sentinel so the resolver can fall through to the next source rather than abort.
+var errNoSponsorCSV = errors.New("collections: no worker-register CSV found")
+
+// contentAPIResponse is the slice of the GOV.UK Content API payload we read.
+type contentAPIResponse struct {
+	Details struct {
+		Attachments []struct {
+			Title       string `json:"title"`
+			URL         string `json:"url"`
+			ContentType string `json:"content_type"`
+		} `json:"attachments"`
+	} `json:"details"`
+}
+
+// pickSponsorCSV extracts the worker-register CSV URL from a Content API payload.
+func pickSponsorCSV(payload []byte) (string, error) {
+	var resp contentAPIResponse
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return "", fmt.Errorf("collections: parse gov.uk content api: %w", err)
+	}
+	for _, a := range resp.Details.Attachments {
+		if a.ContentType == "text/csv" && strings.EqualFold(strings.TrimSpace(a.Title), ukSponsorAttachmentTitle) {
+			return a.URL, nil
+		}
+	}
+	return "", errNoSponsorCSV
+}
+
+// sponsorCSVLink matches an anchor pointing at a CSV on the GOV.UK assets host whose
+// link text names the worker register. Anchored on the assets host on purpose: the
+// page also offers an on-site /csv-preview/ link to the same data, which serves HTML.
+var sponsorCSVLink = regexp.MustCompile(
+	`(?is)<a[^>]+href="(https://assets\.publishing\.service\.gov\.uk/[^"]+\.csv)"[^>]*>([^<]*)</a>`)
+
+// scrapeSponsorCSV extracts the worker-register CSV URL from the publication page.
+func scrapeSponsorCSV(page []byte) (string, error) {
+	for _, m := range sponsorCSVLink.FindAllStringSubmatch(string(page), -1) {
+		if strings.Contains(strings.ToLower(m[2]), strings.ToLower(ukSponsorAttachmentTitle)) {
+			return m[1], nil
+		}
+	}
+	return "", errNoSponsorCSV
+}
+
+// resolveUKSponsorCSV discovers the current register CSV URL, preferring the
+// Content API and falling back to scraping the publication page. Only when neither
+// yields a URL is this an error — and it must be an error, because an empty resolve
+// would reconcile the credential off every company.
+func resolveUKSponsorCSV(ctx context.Context, client *http.Client, apiURL, pageURL string) (string, error) {
+	if body, err := get(ctx, client, apiURL); err == nil {
+		if url, err := pickSponsorCSV(body); err == nil {
+			return url, nil
+		}
+	}
+	body, err := get(ctx, client, pageURL)
+	if err != nil {
+		return "", fmt.Errorf("collections: fetch uk sponsor register page: %w", err)
+	}
+	return scrapeSponsorCSV(body)
+}
+
+// ResolveUKSponsorCSV is the registry-facing resolver, bound to the live GOV.UK
+// addresses.
+func ResolveUKSponsorCSV(ctx context.Context, client *http.Client) (string, error) {
+	return resolveUKSponsorCSV(ctx, client, ukSponsorAPIURL, ukSponsorPageURL)
+}
+
+// ParseUKSponsors reads the register CSV into one record per organisation-route
+// row, carrying the town (the identity field that tells two same-named
+// organisations apart), the licence rating, and the sponsorship route the gate
+// reads. Every route is kept, including the temporary and study routes the gate
+// then refuses — retaining them keeps the parse honest about what the register says.
+func ParseUKSponsors(data []byte) ([]Record, error) {
+	rows, err := csvColumns(data, ',', "Organisation Name", "Town/City", "Type & Rating", "Route")
+	if err != nil {
+		return nil, err
+	}
+	records := make([]Record, 0, len(rows))
+	for _, row := range rows {
+		if row[0] == "" {
+			continue
+		}
+		records = append(records, Record{
+			Name: row[0],
+			Meta: map[string]string{"town": row[1], "rating": row[2], "route": row[3]},
+		})
+	}
+	if len(records) == 0 {
+		return nil, errors.New("collections: uk sponsor register parsed to no rows")
+	}
+	return records, nil
+}
+
+// get fetches a URL and returns its body, treating any non-200 as an error.
+func get(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: status %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/internal/collections/uksponsor_test.go
+++ b/internal/collections/uksponsor_test.go
@@ -1,0 +1,186 @@
+package collections
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const testCSVURL = "https://assets.publishing.service.gov.uk/media/abc/SP_-_Worker_and_Temporary_Worker_Web_Register_-_2026-06-30.csv"
+
+// contentAPIPayload mirrors the shape of the real GOV.UK Content API response for
+// the sponsor-register publication.
+const contentAPIPayload = `{
+  "details": {
+    "attachments": [
+      {"title": "Sponsor guidance", "url": "https://x/guide.pdf", "content_type": "application/pdf"},
+      {"title": "Register of Worker and Temporary Worker licensed sponsors",
+       "url": "` + testCSVURL + `", "content_type": "text/csv"}
+    ]
+  }
+}`
+
+func TestPickSponsorCSV_SelectsTheRegisterAttachment(t *testing.T) {
+	got, err := pickSponsorCSV([]byte(contentAPIPayload))
+	if err != nil {
+		t.Fatalf("pickSponsorCSV: %v", err)
+	}
+	if got != testCSVURL {
+		t.Errorf("pickSponsorCSV = %q, want %q", got, testCSVURL)
+	}
+}
+
+func TestPickSponsorCSV_IgnoresUnrelatedAttachments(t *testing.T) {
+	// A student-sponsor CSV sits in the same publication family and must not be
+	// mistaken for the worker register.
+	payload := `{"details":{"attachments":[
+	  {"title":"Register of student sponsors","url":"https://x/students.csv","content_type":"text/csv"},
+	  {"title":"Sponsor guidance","url":"https://x/guide.pdf","content_type":"application/pdf"}
+	]}}`
+	if _, err := pickSponsorCSV([]byte(payload)); err == nil {
+		t.Error("pickSponsorCSV accepted an unrelated attachment")
+	}
+}
+
+func TestPickSponsorCSV_RejectsUnparseablePayloads(t *testing.T) {
+	for _, payload := range []string{"<html>not json</html>", "{}", `{"details":{}}`} {
+		if _, err := pickSponsorCSV([]byte(payload)); err == nil {
+			t.Errorf("pickSponsorCSV accepted %q", payload)
+		}
+	}
+}
+
+func TestScrapeSponsorCSV_FindsTheRegisterLink(t *testing.T) {
+	html := `<a href="` + testCSVURL + `">Register of Worker and Temporary Worker licensed sponsors</a>`
+	got, err := scrapeSponsorCSV([]byte(html))
+	if err != nil {
+		t.Fatalf("scrapeSponsorCSV: %v", err)
+	}
+	if got != testCSVURL {
+		t.Errorf("scrapeSponsorCSV = %q, want %q", got, testCSVURL)
+	}
+}
+
+func TestScrapeSponsorCSV_IgnoresOtherCSVLinks(t *testing.T) {
+	// The publication page also links a student register and an on-site CSV preview;
+	// neither is the file we want.
+	html := `
+	  <a href="https://assets.publishing.service.gov.uk/media/1/Student_Sponsor_Register.csv">Students</a>
+	  <a href="/csv-preview/1/SP_-_Worker_and_Temporary_Worker_Web_Register.csv">View online</a>`
+	if _, err := scrapeSponsorCSV([]byte(html)); err == nil {
+		t.Error("scrapeSponsorCSV accepted a non-register link")
+	}
+}
+
+func TestResolveUKSponsorCSV_PrefersTheContentAPI(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Write([]byte(contentAPIPayload))
+	}))
+	defer srv.Close()
+
+	got, err := resolveUKSponsorCSV(context.Background(), srv.Client(), srv.URL+"/api", srv.URL+"/page")
+	if err != nil {
+		t.Fatalf("resolveUKSponsorCSV: %v", err)
+	}
+	if got != testCSVURL {
+		t.Errorf("resolved %q, want %q", got, testCSVURL)
+	}
+	if len(paths) != 1 || paths[0] != "/api" {
+		t.Errorf("requests = %v, want the API alone", paths)
+	}
+}
+
+func TestResolveUKSponsorCSV_FallsBackToTheHTMLPage(t *testing.T) {
+	cases := []struct {
+		name string
+		api  func(http.ResponseWriter)
+	}{
+		{"api errors", func(w http.ResponseWriter) { w.WriteHeader(http.StatusInternalServerError) }},
+		{"api returns non-json", func(w http.ResponseWriter) { w.Write([]byte("<html>nope</html>")) }},
+		{"api omits the attachment", func(w http.ResponseWriter) { w.Write([]byte(`{"details":{"attachments":[]}}`)) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/api") {
+					tc.api(w)
+					return
+				}
+				w.Write([]byte(`<a href="` + testCSVURL + `">Register of Worker and Temporary Worker licensed sponsors</a>`))
+			}))
+			defer srv.Close()
+
+			got, err := resolveUKSponsorCSV(context.Background(), srv.Client(), srv.URL+"/api", srv.URL+"/page")
+			if err != nil {
+				t.Fatalf("resolveUKSponsorCSV: %v", err)
+			}
+			if got != testCSVURL {
+				t.Errorf("resolved %q, want %q", got, testCSVURL)
+			}
+		})
+	}
+}
+
+func TestResolveUKSponsorCSV_ErrorsWhenNeitherYieldsAURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if _, err := resolveUKSponsorCSV(context.Background(), srv.Client(), srv.URL+"/api", srv.URL+"/page"); err == nil {
+		t.Error("resolveUKSponsorCSV returned no error when both sources failed")
+	}
+}
+
+func TestParseUKSponsors_ReadsTheRegisterColumns(t *testing.T) {
+	csv := "Organisation Name,Town/City,County,Type & Rating,Route\n" +
+		`ACME Robotics Ltd,London,Greater London,"Worker (A rating)",Skilled Worker` + "\n" +
+		`ACME Robotics Ltd,London,Greater London,"Worker (A rating)",Scale-up` + "\n" +
+		`Green Fields Farm Ltd,Boston,Lincolnshire,"Temporary Worker (A rating)",Temporary Worker - Seasonal Worker` + "\n" +
+		`,Nowhere,,"Worker (A rating)",Skilled Worker`
+
+	got, err := ParseUKSponsors([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseUKSponsors: %v", err)
+	}
+	want := []Record{
+		{Name: "ACME Robotics Ltd", Meta: map[string]string{"town": "London", "rating": "Worker (A rating)", "route": "Skilled Worker"}},
+		{Name: "ACME Robotics Ltd", Meta: map[string]string{"town": "London", "rating": "Worker (A rating)", "route": "Scale-up"}},
+		{Name: "Green Fields Farm Ltd", Meta: map[string]string{"town": "Boston", "rating": "Temporary Worker (A rating)", "route": "Temporary Worker - Seasonal Worker"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseUKSponsors =\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+func TestParseUKSponsors_LocatesColumnsByHeader(t *testing.T) {
+	// An upstream column reorder must not silently read the wrong field.
+	csv := "Route,Organisation Name,Town/City,County,Type & Rating\n" +
+		"Skilled Worker,ACME Robotics Ltd,London,Greater London,Worker (A rating)"
+	got, err := ParseUKSponsors([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseUKSponsors: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "ACME Robotics Ltd" || got[0].Meta["route"] != "Skilled Worker" {
+		t.Errorf("reordered columns misread: %+v", got)
+	}
+}
+
+func TestParseUKSponsors_RejectsAMissingColumn(t *testing.T) {
+	if _, err := ParseUKSponsors([]byte("Town/City,Route\nLondon,Skilled Worker")); err == nil {
+		t.Error("ParseUKSponsors accepted a CSV with no organisation column")
+	}
+}
+
+func TestParseUKSponsors_RejectsAnEmptyRegister(t *testing.T) {
+	// A successful fetch that parses to nothing is a broken source, not an empty
+	// register — returning no rows would reconcile the credential off every company.
+	if _, err := ParseUKSponsors([]byte("Organisation Name,Town/City,County,Type & Rating,Route\n")); err == nil {
+		t.Error("ParseUKSponsors accepted a register with no rows")
+	}
+}

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -444,20 +444,28 @@ func (q *Queries) ListCompaniesForReindex(ctx context.Context, arg ListCompanies
 }
 
 const listCompanyCollections = `-- name: ListCompanyCollections :many
-SELECT slug, collections
+SELECT slug, collections, countries, hq_country
 FROM companies
 ORDER BY slug
 `
 
 type ListCompanyCollectionsRow struct {
-	Slug        string   `json:"slug"`
-	Collections []string `json:"collections"`
+	Slug        string      `json:"slug"`
+	Collections []string    `json:"collections"`
+	Countries   []string    `json:"countries"`
+	HqCountry   pgtype.Text `json:"hq_country"`
 }
 
 // All companies with their current collection membership. cmd/import-collections
 // reads this to know the existing company slugs (the match target) and each
 // company's current tags (so it can reconcile only the tags it manages, leaving any
 // others untouched).
+//
+// countries and hq_country ride along for the credential gates: a register entry is
+// only granted to a company demonstrably present in that register's country, and a
+// single-token name additionally needs its headquarters there. Both are already
+// maintained (countries by RefreshCompanyFacets, hq_country by the company-info
+// importers), so this widens the read rather than adding a source of truth.
 func (q *Queries) ListCompanyCollections(ctx context.Context) ([]ListCompanyCollectionsRow, error) {
 	rows, err := q.db.Query(ctx, listCompanyCollections)
 	if err != nil {
@@ -467,7 +475,12 @@ func (q *Queries) ListCompanyCollections(ctx context.Context) ([]ListCompanyColl
 	items := []ListCompanyCollectionsRow{}
 	for rows.Next() {
 		var i ListCompanyCollectionsRow
-		if err := rows.Scan(&i.Slug, &i.Collections); err != nil {
+		if err := rows.Scan(
+			&i.Slug,
+			&i.Collections,
+			&i.Countries,
+			&i.HqCountry,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -991,6 +991,12 @@ type Querier interface {
 	// reads this to know the existing company slugs (the match target) and each
 	// company's current tags (so it can reconcile only the tags it manages, leaving any
 	// others untouched).
+	//
+	// countries and hq_country ride along for the credential gates: a register entry is
+	// only granted to a company demonstrably present in that register's country, and a
+	// single-token name additionally needs its headquarters there. Both are already
+	// maintained (countries by RefreshCompanyFacets, hq_country by the company-info
+	// importers), so this widens the read rather than adding a source of truth.
 	ListCompanyCollections(ctx context.Context) ([]ListCompanyCollectionsRow, error)
 	// Slim keyset page of companies for the sitemap, cursored by the slug primary key
 	// (first chunk keyed by the empty string, which sorts before every slug).

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -142,7 +142,13 @@ WHERE slug = $1;
 -- reads this to know the existing company slugs (the match target) and each
 -- company's current tags (so it can reconcile only the tags it manages, leaving any
 -- others untouched).
-SELECT slug, collections
+--
+-- countries and hq_country ride along for the credential gates: a register entry is
+-- only granted to a company demonstrably present in that register's country, and a
+-- single-token name additionally needs its headquarters there. Both are already
+-- maintained (countries by RefreshCompanyFacets, hq_country by the company-info
+-- importers), so this widens the read rather than adding a source of truth.
+SELECT slug, collections, countries, hq_country
 FROM companies
 ORDER BY slug;
 

--- a/openspec/changes/company-credential-registries/.openspec.yaml
+++ b/openspec/changes/company-credential-registries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/company-credential-registries/design.md
+++ b/openspec/changes/company-credential-registries/design.md
@@ -77,13 +77,13 @@ Every threshold above is a guess until measured against the real catalogue. The 
 
 **`hq_country` is sparse → the single-token rule discards the best UK brands.** → The mandatory pre-write `-dry-run` measures this directly. If the coverage is poor, the fallback is to widen single-token acceptance to `countries` plus a corroborating signal (a `.co.uk` domain in `companies.domains`, or a UK city on the company's jobs) rather than to drop the guard.
 
-**GOV.UK changes the Content API payload or the page markup → the parse breaks.** → The existing abort-before-write is what makes this safe: a failed resolve or a zero-row parse aborts the run, so a broken parser cannot strip the credential off every company. This is upgraded from an implicit property to a spec'd requirement, with the empty-parse case made explicit.
+**GOV.UK changes the Content API payload or the page markup → the parse breaks.** → Three aborts cover the three shapes this failure takes. A failed fetch or resolve aborts (pre-existing). A zero-row parse aborts (added here). And a run in which a tag would lose most of its current holders aborts (added after review): an upstream *relabelling* — a renamed route value, a recased column — leaves the row count fully intact, parses cleanly, matches nobody, and would otherwise reconcile the credential off every company with a zero exit code. A truncated snapshot is the same failure at partial scale. `-force` overrides it for the rare run where the loss is genuine.
 
 **A closing UK office silently revokes the badge.** → `companies.countries` is job-derived; when a company's last UK job closes, `GB` leaves the facet and the next import drops the credential even though the licence is intact. This is the correct behaviour (we do not advertise sponsorship where nobody is hiring) but it is surprising, so it is documented rather than fixed.
 
 **Two filter specs on one query parameter may not be supported.** → `web/src/lib/facets.ts` declares `{ param: 'collections', control: 'pills' }`, and it is unverified whether the filter machinery tolerates two specs writing the same param. Verify during implementation; if it does not, render one spec whose options carry a group heading. This affects presentation only — the query contract is one `collections` param either way.
 
-**Legal-suffix stripping over-matches.** → Two genuinely different UK entities (`Foo Ltd`, `Foo PLC`) normalize alike. The ambiguity guard catches exactly this: appearing twice means granting to nobody.
+**Legal-suffix stripping over-matches.** → Two genuinely different UK entities (`Foo Ltd`, `Foo PLC`) normalize alike. The ambiguity guard catches this only when they are *different organisations* — it keys on the register's identity field (town / KvK), because the UK register lists one organisation once per route it holds and a bare repeated-name rule would delete exactly the companies holding several licences. Same name, same town collapses to one body and survives; same name, different towns grants to nobody. Spelling variants of one organisation therefore pass through, which is the intended outcome.
 
 **The register is a point-in-time snapshot.** → A licence revoked the day after publication still reads as valid until the next import. The badge names its issuing register so a user can verify independently, and the disclaimer copy does not overclaim.
 
@@ -102,6 +102,6 @@ No database migration. `companies.collections` and `jobs.collections` exist; `co
 
 ## Open Questions
 
-- **`hq_country` density in production.** Answered by step 2 of the migration plan; the answer determines whether the single-token rule ships as designed.
+- **`hq_country` density in production.** Partly answered ahead of the dry run: sampling 1,000 companies spread across the whole GB-hiring cohort found the column populated for ~61% and **every** populated value an ISO code (mixed case). The single-token rule therefore ships as designed, and the comparison now accepts spelled-out names as well, so it no longer depends on `cmd/backfill-company-info` continuing to receive ISO codes from its upstream. Step 2 of the migration plan still measures the real per-collection grant counts.
 - **Do two facet specs on one query param work?** Answered by reading `facets.ts` and the filter machinery during implementation. Presentation-only either way.
 - **Refresh cadence.** UK republishes monthly, NL continuously. `cmd/import-collections` runs on the existing collections schedule; whether the registers warrant their own cadence is deferred until the first month of drift is observed.

--- a/openspec/changes/company-credential-registries/design.md
+++ b/openspec/changes/company-credential-registries/design.md
@@ -1,0 +1,107 @@
+## Context
+
+`internal/collections` is the code-owned registry of curated company themes. Its pipeline is already the shape this change needs: `Dataset{URL, Data, Parse}` yields company names, `Match` resolves them onto catalogue companies via `normalize.Slug`, `Reconcile` writes only the tags the registry manages (leaving foreign tags alone), the result lands in `companies.collections`, and the import worker denormalizes it onto `jobs.collections`. Critically, `collections` is **already** a filterable Meilisearch attribute on both the jobs and companies indexes (`internal/search/client.go`), so a new tag needs no migration, no new attribute, and none of the ~26-minute hard-500 deploy window that a new filterable attribute costs.
+
+Two facts about the surrounding system shaped the decisions below.
+
+**Company signals have been fragmenting.** `remote_regions`, `yc_batch`/`yc_status`, `yc_stage`/`yc_flags`, `maturity`, and `subindustry` arrived as five separate migrations with five separate facets. YC in particular now flows through **two independent paths**: `cmd/import-yc` writes the `yc_*` columns matching by current-name slug *or any `former_names` slug*, while `cmd/import-collections` tags the `yc` collection matching by `normalize.Slug` — the same yc-oss dataset fetched twice under two different matching rules, landing in two different data models. This change does not fix that, but it deliberately does not add a sixth path.
+
+**Sponsorship already has a job-level signal.** `enrichment.visa_sponsorship` is an LLM reading of the posting text, surfaced as a facet and consumed by `internal/hardconstraint` (`appendWorkAuth` raises a blocker when a job explicitly does *not* sponsor and the CV's country is outside the job's). The register signal is a different claim about a different subject, and conflating them would corrupt a signal that already drives user-visible advice.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Grant a company-level "licensed visa sponsor" credential from the UK and NL public registers, with no migration and no new filterable attribute.
+- Generalize `internal/collections` just far enough that the *next* register is one registry entry — a kind, record-shaped datasets, an optional gate, and a resolvable URL.
+- Keep the register signal legible: never merged with `enrichment.visa_sponsorship`, always carrying what it does and does not mean.
+- Make the frontend registry mirror generated rather than hand-kept, now that a field on it (`kind`) drives correctness rather than copy.
+- Bias hard toward false negatives. An unbadged sponsor is a missed opportunity; a badged non-sponsor sends someone into a visa conversation that cannot happen.
+
+**Non-Goals:**
+
+- Migrating `yc_*`, `maturity`, or `subindustry` into the tag model. The `yc_*` columns carry *values* (`Winter 2012`), not flags, and rewriting `import-yc`, `recount-companies`, the `/companies` facets, the FilterModal, the company page, and the OG cards would be churn without value. The seam is noted; the work is not in scope.
+- Unifying the two YC ingestion paths. Same reasoning; noted, not fixed.
+- Storing raw register rows in Postgres. They are worker input, and the outcome is fully expressed by the tag. If auditing a specific company's badge ever becomes a real need, that is the point to add the table — not before.
+- Any change to `enrichment.visa_sponsorship`, `hardconstraint`, or the ingest pipeline.
+- Registers beyond UK and NL. Two is enough to prove the abstraction; a third would be speculative generality.
+
+## Decisions
+
+### Extend `internal/collections` rather than build `internal/companyregistry` beside it
+
+A sibling package would mean two near-identical pipelines — two `Match`, two `Reconcile`, two workers, a second `text[]` column on both `companies` and `jobs`, a second filterable attribute, and a second deploy window. That is precisely the fragmentation described above, one more instance of it.
+
+The cost of extending instead is a widened package contract (`Parse` returns records; the entry gains `Kind` and `Gate`) touching eight existing parsers. Those adapt trivially, and `Gate == nil` preserves current behaviour exactly, so no existing collection changes semantics.
+
+*Alternative considered:* a private `visa_sponsor_countries text[]` column. Shortest path to the feature and the most precise type, but it is the sixth migration in the series and leaves the next register no better off.
+
+### `Kind` discriminates editorial from credential, and it is part of the generated contract
+
+"Big Tech" is an editorial judgement; "licensed under the Skilled Worker route" is a legal fact with an issuing authority and a snapshot date. Presenting them in one undifferentiated pill list would flatten that distinction at exactly the moment a user is deciding whether to rely on it.
+
+The kind therefore has to reach the frontend, and `web/src/lib/collections.ts` is currently a hand-kept mirror whose own comment asks to be folded into `cmd/gen-contracts` "if the set grows". It is growing, and the field being added is one where drift is a correctness bug: a missing or wrong `kind` puts a tag in the wrong group, or drops its pill entirely while the tag still filters. Generating it removes the failure mode rather than documenting it. `FILTER_COLLECTIONS` stays frontend-only — it has no Go counterpart to drift from.
+
+### Records, not names, and a resolver for the URL
+
+The UK register needs `Route` to gate on, so a `[]string` parser cannot express it. `Record{Name string; Meta map[string]string}` keeps the metadata untyped on purpose: each register's columns are its own, a typed union across registers would grow a field per source, and only the entry's own gate reads its own keys.
+
+The GOV.UK CSV lives at a URL carrying the snapshot date (`…_Web_Register_-_2026-06-30.csv`) and is republished monthly, so a constant `URL` breaks within weeks. `ResolveURL` runs at fetch time: GOV.UK Content API → `details.attachments` → select by title, falling back to scraping the publication page. Two mechanisms because they fail independently — the API can change shape while the page still renders, and vice versa.
+
+### Matching: exact match, then four guards
+
+`normalize.Slug("ACME ROBOTICS LIMITED")` is `acme-robotics-limited`, which never matches our `acme-robotics`, so a legal-suffix strip has to run first — whole word, end of string only, or `Limited Brands` loses its first word.
+
+Exact-match alone then fails in the other direction. The UK register is ~120k organisations across every industry: cafés, schools, scaffolders. `Spark`, `Nova`, `Apex` are all in there. Three guards close that:
+
+| Guard | Rule | What it stops |
+|---|---|---|
+| Geography | register's country ∈ `companies.countries` | a US-only company inheriting a UK licence |
+| Single-token | 1-token names additionally require `hq_country` = register's country | Apple, which *does* hire in London, inheriting some unrelated `APPLE LTD` |
+| Ambiguity | a normalized name appearing ≥2× in the register grants to nobody | generic names that cannot identify one organisation |
+| Route (UK) | ≥1 row on Skilled Worker / Global Business Mobility / Scale-up | a farm licensed only for Seasonal Worker badging its one IT role |
+
+The single-token rule is the load-bearing one and also the riskiest: it leans entirely on `hq_country`, and single-word brands (Monzo, Revolut, Wise) are exactly the UK companies worth surfacing. If `hq_country` turns out sparse in production, this rule silently discards them. Hence the dry run below, before any write.
+
+*Alternative considered:* trigram similarity with a review queue for near-matches, per `companyname.Accept`. Higher coverage, but it introduces a standing human workload and a decisions table for a facet that is supposed to be dict-only. Rejected for now; if coverage proves too thin, this is the escalation.
+
+### `-dry-run` before the first production write
+
+Every threshold above is a guess until measured against the real catalogue. The worker gains a mode that resolves, matches, and gates exactly as a real run would, reports matched / gated-out / unmatched per collection, and writes nothing. This is how the `hq_country` question gets answered before it can do damage, not after.
+
+### The register is never stored; the tag is the whole outcome
+
+~132k rows across the two registers, refetched per run, held only in memory during it. No table, no snapshot history, no audit trail. The consequence is that "why does this company have this badge?" is answerable only by re-running with `-dry-run` — an acceptable trade for not carrying a table nothing reads.
+
+## Risks / Trade-offs
+
+**`hq_country` is sparse → the single-token rule discards the best UK brands.** → The mandatory pre-write `-dry-run` measures this directly. If the coverage is poor, the fallback is to widen single-token acceptance to `countries` plus a corroborating signal (a `.co.uk` domain in `companies.domains`, or a UK city on the company's jobs) rather than to drop the guard.
+
+**GOV.UK changes the Content API payload or the page markup → the parse breaks.** → The existing abort-before-write is what makes this safe: a failed resolve or a zero-row parse aborts the run, so a broken parser cannot strip the credential off every company. This is upgraded from an implicit property to a spec'd requirement, with the empty-parse case made explicit.
+
+**A closing UK office silently revokes the badge.** → `companies.countries` is job-derived; when a company's last UK job closes, `GB` leaves the facet and the next import drops the credential even though the licence is intact. This is the correct behaviour (we do not advertise sponsorship where nobody is hiring) but it is surprising, so it is documented rather than fixed.
+
+**Two filter specs on one query parameter may not be supported.** → `web/src/lib/facets.ts` declares `{ param: 'collections', control: 'pills' }`, and it is unverified whether the filter machinery tolerates two specs writing the same param. Verify during implementation; if it does not, render one spec whose options carry a group heading. This affects presentation only — the query contract is one `collections` param either way.
+
+**Legal-suffix stripping over-matches.** → Two genuinely different UK entities (`Foo Ltd`, `Foo PLC`) normalize alike. The ambiguity guard catches exactly this: appearing twice means granting to nobody.
+
+**The register is a point-in-time snapshot.** → A licence revoked the day after publication still reads as valid until the next import. The badge names its issuing register so a user can verify independently, and the disclaimer copy does not overclaim.
+
+**Package-contract churn.** → Changing `Parse` touches eight parsers that are working today. Mitigated by their triviality and by `Gate == nil` preserving existing behaviour; the existing collection tests are the regression net and must stay green untouched.
+
+## Migration Plan
+
+No database migration. `companies.collections` and `jobs.collections` exist; `collections` is already filterable on both Meili indexes; no new filterable attribute is introduced, so there is no rebuild-before-rollout ordering constraint and no hard-500 window.
+
+1. Ordinary release of the application image.
+2. `go run ./cmd/import-collections -dry-run` against production. **Gate:** inspect `hq_country` coverage and the per-collection matched / gated-out counts. If the single-token rule is discarding recognisable brands, stop and revisit the threshold before writing.
+3. `go run ./cmd/import-collections` for the real write.
+4. `make reindex` — never stacked with `reindex-companies` (Meilisearch has one serial task queue; stacking them has deadlocked it before).
+
+**Rollback:** remove the two entries from the registry and re-run the worker. `Reconcile` manages only registry-declared tags, so the credentials are reconciled off every company and nothing else is touched. No data loss, no migration to reverse.
+
+## Open Questions
+
+- **`hq_country` density in production.** Answered by step 2 of the migration plan; the answer determines whether the single-token rule ships as designed.
+- **Do two facet specs on one query param work?** Answered by reading `facets.ts` and the filter machinery during implementation. Presentation-only either way.
+- **Refresh cadence.** UK republishes monthly, NL continuously. `cmd/import-collections` runs on the existing collections schedule; whether the registers warrant their own cadence is deferred until the first month of drift is observed.

--- a/openspec/changes/company-credential-registries/proposal.md
+++ b/openspec/changes/company-credential-registries/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+We already answer "does this posting mention visa sponsorship?" — `enrichment.visa_sponsorship`, an LLM reading of the job text. But most postings say nothing about sponsorship at all, so the filter is silent exactly where a relocating candidate needs it most. The UK and the Netherlands both publish an authoritative register of employers licensed to sponsor work visas; those registers answer a different and stronger question — *can this employer sponsor at all?* — for every company, whether or not any posting mentions it.
+
+The second reason is structural. Company-level signals have accreted one migration at a time (`remote_regions`, `yc_batch`/`yc_status`, `yc_stage`/`yc_flags`, `maturity`, `subindustry` — five migrations, five facets), and each new filterable Meili attribute opens a ~26-minute hard-500 window on deploy. Meanwhile `internal/collections` already *is* the reusable layer for this shape of data (external dataset → name match → tag on the company → denormalized onto jobs → one filterable facet). Landing the registers there instead of as a sixth column both ships the feature with zero migrations and makes the next register a single registry entry.
+
+## What Changes
+
+- **`internal/collections` grows from "editorial themes" into a general company-tag registry.** A `Kind` discriminates editorial collections (Big Tech, YC, Unicorns) from **credentials** — verifiable facts about a company sourced from an authoritative register.
+- **`Dataset.Parse` returns records, not bare names.** `[]byte → []Record` where a `Record` carries a name plus source metadata (route, town, rating, KvK). The eight existing parsers wrap trivially. **BREAKING** for the package's internal API only; no wire, DB, or URL contract changes.
+- **Collections gain an optional `Gate`.** A predicate over (company, record) that must hold before a tag is applied. `Gate == nil` preserves today's behaviour byte-for-byte.
+- **`Dataset` gains an optional `ResolveURL`.** The GOV.UK CSV URL embeds a snapshot date and rotates monthly, so a fixed URL cannot work; UK resolves via the GOV.UK Content API with an HTML-scrape fallback.
+- **Two new registry entries:** `uk-skilled-worker-sponsor` and `nl-recognised-sponsor`.
+- **A deliberately conservative matching policy** — legal-suffix stripping, a geography gate, a stricter rule for single-token names, and an ambiguity guard — so that a badge is never applied on a coincidence of names.
+- **`cmd/import-collections` gains `-dry-run`** so the policy can be calibrated against production before the first write.
+- **The frontend registry mirror becomes generated** (`cmd/gen-contracts`) instead of hand-kept, because `kind` now drives which filter group a tag lands in — drift there is a correctness bug, not a cosmetic one.
+- **UI:** the job-search facet splits into "Collections" and "Credentials"; a badge on the job card and the company page carries an explicit disclaimer; `/collections/uk-skilled-worker-sponsor` becomes a landing page for free.
+
+Explicitly **out of scope**: migrating `yc_*`, `maturity`, or `subindustry` into the tag model. That is churn without value today; the seam is noted in the design.
+
+## Capabilities
+
+### New Capabilities
+- `company-credential-registries`: credential collections sourced from authoritative public registers — the two register sources and their fetch strategies, the matching policy that decides when a company earns a credential, and how a credential is presented so it is never mistaken for a promise about a specific role.
+
+### Modified Capabilities
+- `job-collections`: the registry entry gains a kind and an optional gate; a dataset parser yields records rather than names and may resolve its URL dynamically; the search facet renders credentials as a distinct group; the import worker supports a non-writing dry run.
+
+## Impact
+
+**Code**
+- `internal/collections` — `Kind`, `Record`, `Gate`, `Dataset.ResolveURL`, legal-name normalization, the two new entries, and the eight existing parsers adapted to the record shape.
+- `cmd/import-collections` — record-shaped resolve, gate application, ambiguity precomputation, `-dry-run`.
+- `cmd/gen-contracts` — emit the collection registry (slug, title, description, kind).
+- `internal/db/queries/companies.sql` — `ListCompanyCollections` widens to `countries, hq_country`. A query edit, **not** a migration.
+- `web/src/lib/facets.ts`, `web/src/lib/collections.ts`, the job card, and the company page.
+
+**Not affected**
+- No migration. `companies.collections` and `jobs.collections` already exist.
+- No new filterable Meili attribute. `collections` is already filterable on both indexes, so there is no hard-500 deploy window.
+- `enrichment.visa_sponsorship` is untouched and keeps its current meaning.
+
+**Operational**
+- Ordinary release, then `cmd/import-collections`, then `make reindex` (never stacked with `reindex-companies`).
+- A `-dry-run` pass against production is a precondition of the first write: the single-token rule leans on `hq_country`, and if that column is sparsely populated the rule would cut exactly the single-word UK brands worth having.
+
+**Dependencies**
+- Two new upstream fetches: GOV.UK (Content API + assets host) and `ind.nl`. Both are public and unauthenticated. Both are HTML/CSV shapes that will eventually change; the existing abort-before-write is what keeps a broken parser from stripping the tag off every company.
+
+**Provenance**
+- The idea and the two public register URLs were taken from [`DaKheera47/job-ops`](https://github.com/DaKheera47/job-ops). That project is AGPLv3 + Commons Clause and freehire is MIT, so **no code was copied** — the fetch strategies, matching policy, and storage model here are our own and are built on `internal/collections`, which predates this change.

--- a/openspec/changes/company-credential-registries/specs/company-credential-registries/spec.md
+++ b/openspec/changes/company-credential-registries/specs/company-credential-registries/spec.md
@@ -1,0 +1,176 @@
+## ADDED Requirements
+
+### Requirement: A credential is a company fact sourced from an authoritative public register
+
+The system SHALL model a **credential** as a collection whose membership comes from
+an authoritative public register rather than from editorial judgement. A credential
+SHALL be distinguished from an editorial collection by a `kind` on its registry
+entry, and SHALL otherwise reuse the collection machinery unchanged — the same
+company-level tag set, the same denormalization onto jobs, and the same search
+facet. A credential SHALL state a fact about the **employer**, never about a
+specific role.
+
+The system SHALL NOT merge a credential with the job-level
+`enrichment.visa_sponsorship` signal. The two answer different questions — "the
+posting says they sponsor" versus "the employer is licensed to sponsor" — and SHALL
+remain independently filterable, so neither is implied by the other.
+
+#### Scenario: A credential and the job-level sponsorship signal filter independently
+
+- **WHEN** a user filters by the `uk-skilled-worker-sponsor` credential
+- **THEN** the feed is scoped by the employer's register membership only, and the
+  `visa_sponsorship` filter remains separately selectable and unaffected
+
+#### Scenario: A credential collection reuses the collection tag set
+
+- **WHEN** a company earns a credential
+- **THEN** the credential's slug is present in the company's collection set
+  alongside any editorial collections it belongs to, and is denormalized onto its
+  jobs like any other collection tag
+
+### Requirement: The UK register is resolved dynamically and gated by sponsorship route
+
+The system SHALL source the `uk-skilled-worker-sponsor` credential from the GOV.UK
+"Register of Worker and Temporary Worker licensed sponsors". Because the register's
+CSV URL embeds a snapshot date and is republished on a new URL each month, the
+system SHALL resolve the current URL at fetch time: first from the GOV.UK Content
+API for the publication, selecting the CSV attachment by its title, and failing
+that by scraping the publication's HTML page for the CSV link. A resolve that
+yields no URL SHALL be an error, not an empty result.
+
+The register lists every licensed sponsor across all immigration routes, including
+routes irrelevant to the catalogue's audience. The system SHALL retain every parsed
+row together with its route, and SHALL grant the credential only when at least one
+of a company's rows carries a work route — Skilled Worker, any Global Business
+Mobility route, or Scale-up. A company present in the register solely under a
+Temporary Worker or study route SHALL NOT receive the credential.
+
+#### Scenario: The current CSV URL is resolved from the Content API
+
+- **WHEN** the register is fetched and the GOV.UK Content API responds
+- **THEN** the CSV attachment titled for the Worker and Temporary Worker register is
+  selected and downloaded, without fetching the HTML page
+
+#### Scenario: A Content API failure falls back to the HTML page
+
+- **WHEN** the Content API is unavailable or returns a payload that cannot be parsed
+- **THEN** the publication's HTML page is scraped for the CSV link and the download
+  proceeds
+
+#### Scenario: A register entry on a work route earns the credential
+
+- **WHEN** a matched company has a register row whose route is `Skilled Worker`
+- **THEN** the company receives the `uk-skilled-worker-sponsor` credential
+
+#### Scenario: A register entry on a temporary route does not earn the credential
+
+- **WHEN** a matched company's only register rows carry Temporary Worker routes
+- **THEN** the company does not receive the credential, and the rows are still
+  retained for the run
+
+#### Scenario: An unresolvable register URL aborts the run
+
+- **WHEN** neither the Content API nor the HTML fallback yields a CSV URL
+- **THEN** the resolve fails with an error and no credential membership is written
+
+### Requirement: The Netherlands register grants the recognised-sponsor credential
+
+The system SHALL source the `nl-recognised-sponsor` credential from the IND public
+register of recognised sponsors for the "work" residence purpose, parsed from its
+single HTML table of organisation names and KvK numbers. The KvK number SHALL be
+retained as record metadata for disambiguation. The register does not break down by
+route, so no route gate applies. A parse that yields no rows SHALL be an error, not
+an empty result.
+
+#### Scenario: A recognised sponsor earns the credential
+
+- **WHEN** a matched company appears in the IND recognised-sponsor register
+- **THEN** the company receives the `nl-recognised-sponsor` credential
+
+#### Scenario: An empty parse aborts rather than clearing membership
+
+- **WHEN** the IND page is fetched but yields zero parsed rows
+- **THEN** the resolve fails with an error and no company loses its existing
+  credential
+
+### Requirement: Credential matching is conservative and never assigns on a coincidence of names
+
+The system SHALL match a register entry to a catalogue company by normalized name,
+and SHALL apply the following guards before granting a credential. All guards are
+cumulative; failing any one of them SHALL leave the company untagged rather than
+tagged on a guess.
+
+- **Legal-suffix stripping.** Before normalization, a trailing legal-form suffix
+  SHALL be stripped as a whole word from the **end** of the register name (for
+  example `Ltd`, `Limited`, `PLC`, `LLP`, `CIC`, `B.V.`, `N.V.`). A suffix word
+  appearing anywhere other than the end SHALL NOT be stripped.
+- **Geography gate.** The company SHALL have a geographic link to the register's
+  country. For a normalized name of two or more tokens, the register's country
+  present in the company's countries SHALL suffice.
+- **Single-token rule.** For a normalized name of exactly one token, the company's
+  headquarters country SHALL equal the register's country. A single-token name is
+  too weak a signal on its own: a multinational with a local office would otherwise
+  inherit a credential from an unrelated local business of the same name.
+- **Ambiguity guard.** A normalized name occurring more than once across distinct
+  entries in a register SHALL be treated as too generic to assign, and SHALL grant
+  the credential to no company.
+
+#### Scenario: A legal suffix is stripped from the end of a register name
+
+- **WHEN** the register lists `ACME ROBOTICS LIMITED` and the catalogue holds the
+  company `acme-robotics`
+- **THEN** the names match after suffix stripping and normalization
+
+#### Scenario: A suffix word inside a name is not stripped
+
+- **WHEN** the register lists `LIMITED BRANDS INC`
+- **THEN** only the trailing corporate suffix is considered, and the leading
+  `Limited` is retained as part of the name
+
+#### Scenario: A multi-token name matches on the country facet alone
+
+- **WHEN** a two-token register name matches a company that has open jobs in the
+  register's country
+- **THEN** the company receives the credential
+
+#### Scenario: A single-token name is rejected without a matching headquarters
+
+- **WHEN** a single-token register name matches a company that has open jobs in the
+  register's country but whose headquarters country is elsewhere
+- **THEN** the company does not receive the credential
+
+#### Scenario: A single-token name is accepted with a matching headquarters
+
+- **WHEN** a single-token register name matches a company whose headquarters country
+  equals the register's country
+- **THEN** the company receives the credential
+
+#### Scenario: An ambiguous name is assigned to nobody
+
+- **WHEN** a normalized register name appears for two distinct register entries
+- **THEN** no company receives the credential from that name, regardless of any
+  other guard passing
+
+### Requirement: A credential is presented so it is never read as a promise about a role
+
+The system SHALL render a company's credential as a badge on the job card and on the
+company page, and SHALL accompany it with copy that states what the credential does
+and does not mean: the employer holds the licence, which is not a commitment to
+sponsor the role being viewed. The badge SHALL identify the issuing register so a
+user can verify it independently.
+
+In the job-search filter, credentials SHALL be presented as a group distinct from
+editorial collections, so a legal qualification is not read as an editorial theme.
+
+#### Scenario: A badge carries its disclaimer
+
+- **WHEN** a job card renders for a company holding the `uk-skilled-worker-sponsor`
+  credential
+- **THEN** the badge names the credential and exposes copy clarifying that the
+  licence belongs to the employer and is not a promise of sponsorship for that role
+
+#### Scenario: Credentials are a distinct filter group
+
+- **WHEN** a user opens the job-search filter
+- **THEN** credential options appear under their own group heading, separate from
+  the editorial collection options

--- a/openspec/changes/company-credential-registries/specs/company-credential-registries/spec.md
+++ b/openspec/changes/company-credential-registries/specs/company-credential-registries/spec.md
@@ -111,9 +111,15 @@ tagged on a guess.
   headquarters country SHALL equal the register's country. A single-token name is
   too weak a signal on its own: a multinational with a local office would otherwise
   inherit a credential from an unrelated local business of the same name.
-- **Ambiguity guard.** A normalized name occurring more than once across distinct
-  entries in a register SHALL be treated as too generic to assign, and SHALL grant
-  the credential to no company.
+- **Ambiguity guard.** A normalized name shared by more than one *organisation* in
+  a register SHALL be treated as identifying none of them, and SHALL grant the
+  credential to no company. Organisations SHALL be told apart by a register-specific
+  identity field (the UK register's town, the Dutch register's KvK number) — a
+  shared name alone is not a collision, because the UK register lists a single
+  organisation once per sponsorship route it holds, and those rows must survive for
+  the route gate to read them. Where a register publishes no such identity field,
+  same-named rows SHALL be treated as one organisation and the geography guards
+  SHALL carry the decision.
 
 #### Scenario: A legal suffix is stripped from the end of a register name
 
@@ -147,9 +153,17 @@ tagged on a guess.
 
 #### Scenario: An ambiguous name is assigned to nobody
 
-- **WHEN** a normalized register name appears for two distinct register entries
+- **WHEN** a normalized register name appears for two organisations with different
+  identity fields (different towns)
 - **THEN** no company receives the credential from that name, regardless of any
   other guard passing
+
+#### Scenario: One organisation's per-route rows are not mistaken for a collision
+
+- **WHEN** a register lists one organisation on several routes, so its name repeats
+  across rows sharing the same identity field
+- **THEN** every one of those rows survives the ambiguity guard and reaches the
+  route gate
 
 ### Requirement: A credential is presented so it is never read as a promise about a role
 

--- a/openspec/changes/company-credential-registries/specs/company-credential-registries/spec.md
+++ b/openspec/changes/company-credential-registries/specs/company-credential-registries/spec.md
@@ -107,10 +107,18 @@ tagged on a guess.
 - **Geography gate.** The company SHALL have a geographic link to the register's
   country. For a normalized name of two or more tokens, the register's country
   present in the company's countries SHALL suffice.
-- **Single-token rule.** For a normalized name of exactly one token, the company's
-  headquarters country SHALL equal the register's country. A single-token name is
-  too weak a signal on its own: a multinational with a local office would otherwise
-  inherit a credential from an unrelated local business of the same name.
+- **Single-token rule.** For a name whose normalized slug is a single unpunctuated
+  token, the company's headquarters country SHALL denote the register's country. A
+  single-token name is too weak a signal on its own: a multinational with a local
+  office would otherwise inherit a credential from an unrelated local business of
+  the same name. A name that normalizes to several slug segments — including one
+  punctuated into segments, such as `Booking.com` or `Rolls-Royce` — is specific
+  enough to fall under the geography gate alone.
+- **Country comparison.** A stored country value SHALL be compared whole and
+  case-insensitively, and SHALL be recognised by its ISO code or by a spelled-out
+  name for the same country. The headquarters column has more than one writer and
+  not all of them normalize, so the guard SHALL NOT depend on a particular upstream
+  spelling; a substring SHALL NOT count as a match.
 - **Ambiguity guard.** A normalized name shared by more than one *organisation* in
   a register SHALL be treated as identifying none of them, and SHALL grant the
   credential to no company. Organisations SHALL be told apart by a register-specific
@@ -144,6 +152,19 @@ tagged on a guess.
 - **WHEN** a single-token register name matches a company that has open jobs in the
   register's country but whose headquarters country is elsewhere
 - **THEN** the company does not receive the credential
+
+#### Scenario: A spelled-out headquarters country is recognised
+
+- **WHEN** a single-token register name matches a company whose headquarters country
+  is stored as `United Kingdom` rather than `GB`
+- **THEN** the company receives the credential, the comparison having recognised the
+  name as denoting the same country
+
+#### Scenario: A country name is not matched by substring
+
+- **WHEN** a company's headquarters country is stored as a longer string that merely
+  contains a country name
+- **THEN** the guard does not treat it as a match
 
 #### Scenario: A single-token name is accepted with a matching headquarters
 

--- a/openspec/changes/company-credential-registries/specs/job-collections/spec.md
+++ b/openspec/changes/company-credential-registries/specs/job-collections/spec.md
@@ -1,0 +1,184 @@
+## MODIFIED Requirements
+
+### Requirement: Curated collections are a company-level membership fact
+
+The system SHALL model a curated collection as a company-level fact: each company
+MAY belong to zero or more collections, stored as a set of collection slugs on the
+company. A collection slug SHALL come from a fixed, code-owned registry. Each
+registry entry SHALL carry a `slug`, a human `title`, a `description`, a `kind`,
+and a membership source — exactly one of a static hand list of canonical company
+slugs or a remote dataset. Adding a collection SHALL be a single registry entry.
+Membership SHALL NOT be derivable from a job's text or its ATS source — it is a
+fact about the company, populated only from the registry's sources.
+
+The `kind` SHALL distinguish an **editorial** collection (a curated theme, such as
+Big Tech or Unicorns) from a **credential** (a verifiable fact drawn from an
+authoritative public register). The kind SHALL be part of the registry contract
+shared with the frontend, because it determines how a tag is presented; it SHALL
+NOT be hand-mirrored in a second place where it could drift from the Go registry.
+
+A dataset SHALL be defined by a parser yielding **records** rather than bare names.
+A record SHALL carry the member's name and MAY carry source metadata (for example a
+route, a locality, or a registry identifier) for later gating. A dataset SHALL
+supply its payload by exactly one of a fixed URL, an embedded blob, or a resolver
+that determines the URL at fetch time — the last of these for a source whose
+published URL changes between snapshots.
+
+A registry entry MAY carry a **gate**: a predicate over the candidate company and
+the matched record that SHALL hold before the tag is applied. An entry with no gate
+SHALL be matched on name alone, unchanged from prior behaviour.
+
+#### Scenario: A company belongs to multiple collections
+
+- **WHEN** a company qualifies for two collections (e.g. `yc` and `bigtech`)
+- **THEN** the company's collection set contains both slugs
+
+#### Scenario: The registry defines each collection's display copy, kind, and source
+
+- **WHEN** the collection registry is read
+- **THEN** each entry exposes a slug, title, description, kind, and exactly one
+  membership source (a static slug list or a dataset)
+
+#### Scenario: A dataset parser yields records carrying source metadata
+
+- **WHEN** a dataset whose source publishes per-member attributes is parsed
+- **THEN** each record exposes the member's name plus that source's metadata,
+  available to the entry's gate
+
+#### Scenario: A gateless entry matches on name alone
+
+- **WHEN** a registry entry defines no gate
+- **THEN** every name-matched company is tagged, with no additional condition
+  applied
+
+#### Scenario: A dataset resolves its URL at fetch time
+
+- **WHEN** a dataset defines a resolver instead of a fixed URL
+- **THEN** the URL is determined during the run and the payload is fetched from it
+
+### Requirement: The import worker resolves and populates membership idempotently
+
+The system SHALL provide a run-once-and-exit import worker that, for each
+collection in the registry, resolves its member companies — a dataset collection is
+fetched and parsed to records, a static-list collection uses its slugs — matches
+them onto existing companies by **normalized name** (the same normalization as
+company slugs; unmatched candidates are omitted and logged, never guessed), applies
+the entry's gate where one is defined, writes `companies.collections` for the tags
+it manages, and propagates the result onto `jobs.collections`. The worker SHALL be
+idempotent and re-runnable (re-running with the same inputs yields the same
+membership) and SHALL only modify the collection tags it manages, leaving any other
+tags on a company untouched. If any collection's source cannot be resolved (e.g. a
+dataset fetch fails, or a parse yields zero records) the worker SHALL abort before
+writing — a partial resolve would reconcile a collection's tag off every company.
+After propagation the worker SHALL signal that a search reindex is required.
+
+Where a gate needs company attributes beyond the slug and the current tag set, the
+worker SHALL load those attributes alongside the membership it reconciles.
+
+The worker SHALL support a **dry run** that performs every resolve, match, and gate
+evaluation and reports what it would write — per collection, the number of matched,
+gated-out, and unmatched candidates — without writing any membership. A dry run
+SHALL leave the database untouched.
+
+#### Scenario: Re-running the import is idempotent
+
+- **WHEN** the import worker runs twice with the same inputs
+- **THEN** the resulting `companies.collections` and `jobs.collections` are
+  identical after each run
+
+#### Scenario: Unmatched dataset companies are omitted and logged
+
+- **WHEN** a dataset entry has no company whose normalized name matches
+- **THEN** no company is tagged for that entry and the unmatched count is logged
+
+#### Scenario: A failed dataset resolve aborts before writing
+
+- **WHEN** a collection's dataset cannot be fetched or parsed
+- **THEN** the worker aborts without writing any membership (no collection is
+  reconciled off existing companies)
+
+#### Scenario: An empty parse is treated as a failure
+
+- **WHEN** a dataset is fetched successfully but parses to zero records
+- **THEN** the worker treats it as a failed resolve and aborts before writing
+
+#### Scenario: Static-list membership comes from the hand list
+
+- **WHEN** a static-list collection (e.g. `bigtech`) is resolved
+- **THEN** exactly the existing companies whose slugs are in the registry's hand
+  list are tagged with that collection
+
+#### Scenario: A gated-out company keeps its other tags
+
+- **WHEN** a company matches a gated collection by name but fails its gate
+- **THEN** the company is not tagged for that collection, and every other tag it
+  holds is preserved
+
+#### Scenario: A dry run reports without writing
+
+- **WHEN** the worker runs in dry-run mode
+- **THEN** it reports the matched, gated-out, and unmatched counts per collection,
+  and neither `companies.collections` nor `jobs.collections` is modified
+
+### Requirement: Collections are a job-search facet plus a discovery hub
+
+The system SHALL expose `collections` as a selectable facet in the main job-search
+filter sidebar (`/jobs`), rendering one option per **company-collection** registry
+entry, so a user can filter the job feed by collection — composably with every
+other facet — and the filter is reflected in the URL (`/jobs?collections=<slug>`).
+Options SHALL be grouped by the registry entry's kind, so editorial collections and
+credentials are visually distinct while remaining a single filter axis over one
+query parameter.
+
+The system SHALL also expose a discovery hub at `/collections` listing **both**
+kinds of collection — company collections and filter collections — as visually
+uniform cards, each with its title, description, and a count of its open jobs. A
+company-collection card's count SHALL come from the `collections` search-facet
+distribution; a filter-collection card's count SHALL come from a job-search total
+for its filter `params`. Counts are decorative: a failed count fetch SHALL degrade
+to no count rather than failing the page. The hub's first render SHALL be
+server-rendered.
+
+Each collection — of both kinds — SHALL have a dedicated landing page at
+`/collections/<slug>`, and every hub card SHALL link to its collection's landing
+page (not to `/jobs`). The landing page SHALL be server-rendered on first paint,
+SHALL be self-canonical (`<origin>/collections/<slug>`, never the bare `/jobs` its
+raw filter would otherwise resolve to), SHALL emit breadcrumb structured data, and
+SHALL render the collection's jobs as a scoped `/jobs` feed that pins — and hides
+the controls for — the collection's own constraint.
+
+#### Scenario: Collection is a facet on the job search
+
+- **WHEN** a user opens `/jobs` and selects the `yc` collection in the sidebar
+- **THEN** the URL carries `collections=yc` and the feed contains only open jobs
+  whose `collections` include `yc`, composable with the other facets
+
+#### Scenario: Credential options are grouped apart from editorial ones
+
+- **WHEN** a user opens the collection facet and the registry holds both kinds
+- **THEN** editorial and credential options appear under separate group headings,
+  and selecting either kind writes the same `collections` query parameter
+
+#### Scenario: The hub lists company collections linking to their landing pages
+
+- **WHEN** a user opens `/collections`
+- **THEN** the page lists `yc` and `bigtech`, each with its title, description, and
+  the number of its open jobs, linking to `/collections/<slug>`
+
+#### Scenario: The hub lists filter collections linking to their landing pages
+
+- **WHEN** a user opens `/collections`
+- **THEN** the page lists the `remote-worldwide` filter collection with its title,
+  description, and open-job count, linking to `/collections/remote-worldwide`
+
+#### Scenario: A collection landing page is a self-canonical SEO page
+
+- **WHEN** a crawler fetches `/collections/python`
+- **THEN** the server-rendered HTML carries `rel="canonical"` of
+  `<origin>/collections/python`, breadcrumb JSON-LD, and the scoped job feed for
+  that collection's filter
+
+#### Scenario: A failed count fetch does not break the hub
+
+- **WHEN** a collection's open-job count cannot be fetched
+- **THEN** the hub still renders that collection's card, without a count

--- a/openspec/changes/company-credential-registries/specs/job-collections/spec.md
+++ b/openspec/changes/company-credential-registries/specs/job-collections/spec.md
@@ -75,6 +75,14 @@ After propagation the worker SHALL signal that a search reindex is required.
 Where a gate needs company attributes beyond the slug and the current tag set, the
 worker SHALL load those attributes alongside the membership it reconciles.
 
+The worker SHALL additionally abort before writing when a tag it manages would lose
+at least half of the companies currently holding it. This covers the failure the
+fetch and empty-parse aborts cannot see: a source whose values have been relabelled
+upstream still parses to its full row count and then matches nobody, which would
+otherwise reconcile the tag off every holder with no error. A tag no company
+currently holds SHALL NOT trigger this — that is a new collection's first run — and
+an explicit override SHALL be available for a run where the loss is genuine.
+
 The worker SHALL support a **dry run** that performs every resolve, match, and gate
 evaluation and reports what it would write — per collection, the number of matched,
 gated-out, and unmatched candidates — without writing any membership. A dry run
@@ -114,11 +122,25 @@ SHALL leave the database untouched.
 - **THEN** the company is not tagged for that collection, and every other tag it
   holds is preserved
 
+#### Scenario: A collapsing tag aborts the run
+
+- **WHEN** a source parses to its usual size but, after gating, would leave a managed
+  tag with fewer than half its current holders
+- **THEN** the worker reports the shortfall and aborts before writing, unless the
+  override is given
+
+#### Scenario: A new collection's first run is not treated as a collapse
+
+- **WHEN** a newly added collection matches some companies and no company currently
+  holds its tag
+- **THEN** the run proceeds and writes the new membership
+
 #### Scenario: A dry run reports without writing
 
 - **WHEN** the worker runs in dry-run mode
-- **THEN** it reports the matched, gated-out, and unmatched counts per collection,
-  and neither `companies.collections` nor `jobs.collections` is modified
+- **THEN** it reports the matched, gated-out, and unmatched counts per collection
+  along with any tag that would collapse, and neither `companies.collections` nor
+  `jobs.collections` is modified
 
 ### Requirement: Collections are a job-search facet plus a discovery hub
 

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -7,15 +7,15 @@
 
 ## 2. Company-name normalization for registers
 
-- [ ] 2.1 Add legal-suffix stripping to `internal/collections` (whole word, end of string only: `Ltd`, `Limited`, `PLC`, `LLP`, `CIC`, `B.V.`, `N.V.` and their punctuation variants), applied before `normalize.Slug`
-- [ ] 2.2 Test that `ACME ROBOTICS LIMITED` normalizes to `acme-robotics`, that `LIMITED BRANDS INC` keeps its leading `Limited`, and that a name that is only a suffix is not reduced to empty
+- [x] 2.1 Add legal-suffix stripping to `internal/collections` (whole word, end of string only: `Ltd`, `Limited`, `PLC`, `LLP`, `CIC`, `B.V.`, `N.V.` and their punctuation variants), applied before `normalize.Slug`
+- [x] 2.2 Test that `ACME ROBOTICS LIMITED` normalizes to `acme-robotics`, that `LIMITED BRANDS INC` keeps its leading `Limited`, and that a name that is only a suffix is not reduced to empty
 
 ## 3. Matching guards
 
-- [ ] 3.1 Implement the geography gate: the register's country present in the company's `countries` satisfies a name of two or more tokens
-- [ ] 3.2 Implement the single-token rule: a one-token normalized name additionally requires `hq_country` to equal the register's country; test that a company with UK jobs but a non-UK headquarters is rejected and one headquartered in the UK is accepted
-- [ ] 3.3 Implement the ambiguity guard: precompute normalized-name counts per dataset and grant nothing for a name occurring more than once; test that both candidates are left untagged
-- [ ] 3.4 Implement the UK route gate over `Record.Meta`: tag only when at least one row carries Skilled Worker, any Global Business Mobility route, or Scale-up; test that a Temporary-Worker-only company is rejected while its rows are still parsed
+- [x] 3.1 Implement the geography gate: the register's country present in the company's `countries` satisfies a name of two or more tokens
+- [x] 3.2 Implement the single-token rule: a one-token normalized name additionally requires `hq_country` to equal the register's country; test that a company with UK jobs but a non-UK headquarters is rejected and one headquartered in the UK is accepted
+- [x] 3.3 Implement the ambiguity guard: precompute normalized-name counts per dataset and grant nothing for a name occurring more than once; test that both candidates are left untagged
+- [x] 3.4 Implement the UK route gate over `Record.Meta`: tag only when at least one row carries Skilled Worker, any Global Business Mobility route, or Scale-up; test that a Temporary-Worker-only company is rejected while its rows are still parsed
 
 ## 4. Register sources
 

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -19,11 +19,11 @@
 
 ## 4. Register sources
 
-- [ ] 4.1 Implement the GOV.UK URL resolver: Content API → `details.attachments` → select the CSV by title, with an HTML-scrape fallback; test the API path, the fallback on a non-200, the fallback on unparseable JSON, and an error when neither yields a URL
-- [ ] 4.2 Implement `ParseUKSponsors` over the register CSV (Organisation Name, Town/City, County, Type & Rating, Route) into records carrying route, town, and rating; test against a committed fixture
-- [ ] 4.3 Implement `ParseNLSponsors` over the IND register HTML table (`<th scope="row">` organisation, `<td>` KvK), decoding HTML entities and retaining the KvK as metadata; test against a committed fixture
-- [ ] 4.4 Test that a zero-record parse from either source returns an error rather than an empty slice
-- [ ] 4.5 Add the `uk-skilled-worker-sponsor` and `nl-recognised-sponsor` registry entries with their titles, descriptions, `KindCredential`, datasets, and gates
+- [x] 4.1 Implement the GOV.UK URL resolver: Content API → `details.attachments` → select the CSV by title, with an HTML-scrape fallback; test the API path, the fallback on a non-200, the fallback on unparseable JSON, and an error when neither yields a URL
+- [x] 4.2 Implement `ParseUKSponsors` over the register CSV (Organisation Name, Town/City, County, Type & Rating, Route) into records carrying route, town, and rating; test against a committed fixture
+- [x] 4.3 Implement `ParseNLSponsors` over the IND register HTML table (`<th scope="row">` organisation, `<td>` KvK), decoding HTML entities and retaining the KvK as metadata; test against a committed fixture
+- [x] 4.4 Test that a zero-record parse from either source returns an error rather than an empty slice
+- [x] 4.5 Add the `uk-skilled-worker-sponsor` and `nl-recognised-sponsor` registry entries with their titles, descriptions, `KindCredential`, datasets, and gates
 
 ## 5. Import worker
 

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -34,15 +34,15 @@
 
 ## 6. Generated frontend contract
 
-- [ ] 6.1 Emit the collection registry (slug, title, description, kind) from `cmd/gen-contracts` into `web/src/lib/generated/contracts.ts`; run `make gen-contracts` and commit the output
-- [ ] 6.2 Point `web/src/lib/facets.ts` and the `/collections` hub at the generated registry, delete the hand-kept `COLLECTIONS` from `web/src/lib/collections.ts`, and leave `FILTER_COLLECTIONS` where it is
+- [x] 6.1 Emit the collection registry (slug, title, description, kind) from `cmd/gen-contracts` into `web/src/lib/generated/contracts.ts`; run `make gen-contracts` and commit the output
+- [x] 6.2 Point `web/src/lib/facets.ts` and the `/collections` hub at the generated registry, delete the hand-kept `COLLECTIONS` from `web/src/lib/collections.ts`, and leave `FILTER_COLLECTIONS` where it is
 
 ## 7. UI
 
-- [ ] 7.1 Verify whether the filter machinery tolerates two facet specs on the `collections` param; if not, render one spec whose options carry group headings — record which way it went
-- [ ] 7.2 Split the collection facet options by `kind` into "Collections" and "Credentials" groups in the FilterModal
+- [x] 7.1 Verify whether the filter machinery tolerates two facet specs on the `collections` param; if not, render one spec whose options carry group headings  — VERDICT: it does not. filtersToParams iterates FACETS and would append every value twice, activeFilterCount would double. Shipped as one facet whose options carry a `group`, with a sub-heading in PillGroup; a test pins the single-entry invariant
+- [x] 7.2 Split the collection facet options by `kind` into "Collections" and "Credentials" groups in the FilterModal
 - [ ] 7.3 Add the credential badge to the job card and the company page, naming the issuing register and carrying the disclaimer that the licence belongs to the employer and is not a promise of sponsorship for that role
-- [ ] 7.4 Verify the `/collections/uk-skilled-worker-sponsor` landing page renders server-side with its canonical and breadcrumb JSON-LD, as the existing landing-page machinery should give for free
+- [x] 7.4 Verify the `/collections/uk-skilled-worker-sponsor` landing page renders server-side with its canonical and breadcrumb JSON-LD, as the existing landing-page machinery should give for free
 
 ## 8. Verify and ship
 

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -41,7 +41,7 @@
 
 - [x] 7.1 Verify whether the filter machinery tolerates two facet specs on the `collections` param; if not, render one spec whose options carry group headings  — VERDICT: it does not. filtersToParams iterates FACETS and would append every value twice, activeFilterCount would double. Shipped as one facet whose options carry a `group`, with a sub-heading in PillGroup; a test pins the single-entry invariant
 - [x] 7.2 Split the collection facet options by `kind` into "Collections" and "Credentials" groups in the FilterModal
-- [ ] 7.3 Add the credential badge to the job card and the company page, naming the issuing register and carrying the disclaimer that the licence belongs to the employer and is not a promise of sponsorship for that role
+- [x] 7.3 Add the credential badge to the job card and the company page, naming the issuing register and carrying the disclaimer that the licence belongs to the employer and is not a promise of sponsorship for that role
 - [x] 7.4 Verify the `/collections/uk-skilled-worker-sponsor` landing page renders server-side with its canonical and breadcrumb JSON-LD, as the existing landing-page machinery should give for free
 
 ## 8. Verify and ship

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -46,6 +46,6 @@
 
 ## 8. Verify and ship
 
-- [ ] 8.1 `go build ./... && go vet ./... && go test ./...` green, and the web build and lint at their baseline
+- [x] 8.1 `go build ./... && go vet ./... && go test ./...` green, and the web build and lint at their baseline
 - [ ] 8.2 Run `-dry-run` against production; inspect `hq_country` coverage and the per-collection counts, and record the numbers in the change before any write
 - [ ] 8.3 Run the real import, then `make reindex` (never stacked with `reindex-companies`), and confirm the facet returns jobs for both credentials

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Widen the collections registry contract
 
-- [ ] 1.1 Add `Kind` (`KindEditorial`, `KindCredential`) to `Collection` in `internal/collections`, defaulting every existing entry to editorial; test that the registry exposes a kind for each entry
-- [ ] 1.2 Introduce `Record{Name string; Meta map[string]string}` and change `Dataset.Parse` to `[]byte → ([]Record, error)`; adapt the eight existing parsers (`ParseYC`, `ParseTechstarsCSV`, `ParseEUStartups`, `ParseCompanyCSV`, `ParseSlugList`, and the rest) to return name-only records, keeping their existing tests green untouched
-- [ ] 1.3 Add optional `Gate func(Company, Record) bool` to `Collection`; test that `Gate == nil` tags every name-matched company exactly as before, and that a gate returning false leaves the company untagged
-- [ ] 1.4 Add optional `Dataset.ResolveURL func(context.Context, *http.Client) (string, error)`; test that exactly one of `URL`, `Data`, `ResolveURL` may be set and that a resolver's result is what gets fetched
+- [x] 1.1 Add `Kind` (`KindEditorial`, `KindCredential`) to `Collection` in `internal/collections`, defaulting every existing entry to editorial; test that the registry exposes a kind for each entry
+- [x] 1.2 Introduce `Record{Name string; Meta map[string]string}` and change the `Dataset.Parse` **field** to `[]byte → ([]Record, error)`; the five existing parsers (`ParseYC`, `ParseTechstarsCSV`, `ParseEUStartups`, `ParseCompanyCSV`, `ParseSlugList`) keep their `[]string` signatures and tests untouched, wrapped in the registry by a `names()` adapter
+- [x] 1.3 Add optional `Gate func(Company, Record) bool` to `Collection`; test that `Gate == nil` tags every name-matched company exactly as before, and that a gate returning false leaves the company untagged
+- [x] 1.4 Add optional `Dataset.ResolveURL func(context.Context, *http.Client) (string, error)`; test that exactly one of `URL`, `Data`, `ResolveURL` may be set and that a resolver's result is what gets fetched
 
 ## 2. Company-name normalization for registers
 

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -30,7 +30,8 @@
 - [x] 5.1 Widen `ListCompanyCollections` in `internal/db/queries/companies.sql` to `slug, collections, countries, hq_country` and run `make sqlc`
 - [x] 5.2 Rework `cmd/import-collections` for record-shaped resolve, per-dataset ambiguity precomputation, and gate application at match time
 - [x] 5.3 Make an empty parse an abort-before-write failure alongside the existing fetch-failure abort; test that no membership is written in either case
-- [x] 5.4 Add `-dry-run` reporting matched / gated-out / unmatched per collection and writing nothing; test that no write path is reached
+- [x] 5.4 Add `-dry-run` reporting matched / gated-out / unmatched per collection and writing nothing — the dry-run branch returns before any `Set*`/`Propagate*` call and `plan` is pure, so this is correct by construction rather than by a test; the write path is not injectable today
+- [x] 5.5 Abort before writing when a managed tag would lose at least half its holders, with `-force` to override (added after review: an upstream relabelling parses to full size, matches nobody, and would otherwise strip the tag from every holder with a zero exit)
 
 ## 6. Generated frontend contract
 

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -27,10 +27,10 @@
 
 ## 5. Import worker
 
-- [ ] 5.1 Widen `ListCompanyCollections` in `internal/db/queries/companies.sql` to `slug, collections, countries, hq_country` and run `make sqlc`
-- [ ] 5.2 Rework `cmd/import-collections` for record-shaped resolve, per-dataset ambiguity precomputation, and gate application at match time
-- [ ] 5.3 Make an empty parse an abort-before-write failure alongside the existing fetch-failure abort; test that no membership is written in either case
-- [ ] 5.4 Add `-dry-run` reporting matched / gated-out / unmatched per collection and writing nothing; test that no write path is reached
+- [x] 5.1 Widen `ListCompanyCollections` in `internal/db/queries/companies.sql` to `slug, collections, countries, hq_country` and run `make sqlc`
+- [x] 5.2 Rework `cmd/import-collections` for record-shaped resolve, per-dataset ambiguity precomputation, and gate application at match time
+- [x] 5.3 Make an empty parse an abort-before-write failure alongside the existing fetch-failure abort; test that no membership is written in either case
+- [x] 5.4 Add `-dry-run` reporting matched / gated-out / unmatched per collection and writing nothing; test that no write path is reached
 
 ## 6. Generated frontend contract
 

--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -1,0 +1,51 @@
+## 1. Widen the collections registry contract
+
+- [ ] 1.1 Add `Kind` (`KindEditorial`, `KindCredential`) to `Collection` in `internal/collections`, defaulting every existing entry to editorial; test that the registry exposes a kind for each entry
+- [ ] 1.2 Introduce `Record{Name string; Meta map[string]string}` and change `Dataset.Parse` to `[]byte → ([]Record, error)`; adapt the eight existing parsers (`ParseYC`, `ParseTechstarsCSV`, `ParseEUStartups`, `ParseCompanyCSV`, `ParseSlugList`, and the rest) to return name-only records, keeping their existing tests green untouched
+- [ ] 1.3 Add optional `Gate func(Company, Record) bool` to `Collection`; test that `Gate == nil` tags every name-matched company exactly as before, and that a gate returning false leaves the company untagged
+- [ ] 1.4 Add optional `Dataset.ResolveURL func(context.Context, *http.Client) (string, error)`; test that exactly one of `URL`, `Data`, `ResolveURL` may be set and that a resolver's result is what gets fetched
+
+## 2. Company-name normalization for registers
+
+- [ ] 2.1 Add legal-suffix stripping to `internal/collections` (whole word, end of string only: `Ltd`, `Limited`, `PLC`, `LLP`, `CIC`, `B.V.`, `N.V.` and their punctuation variants), applied before `normalize.Slug`
+- [ ] 2.2 Test that `ACME ROBOTICS LIMITED` normalizes to `acme-robotics`, that `LIMITED BRANDS INC` keeps its leading `Limited`, and that a name that is only a suffix is not reduced to empty
+
+## 3. Matching guards
+
+- [ ] 3.1 Implement the geography gate: the register's country present in the company's `countries` satisfies a name of two or more tokens
+- [ ] 3.2 Implement the single-token rule: a one-token normalized name additionally requires `hq_country` to equal the register's country; test that a company with UK jobs but a non-UK headquarters is rejected and one headquartered in the UK is accepted
+- [ ] 3.3 Implement the ambiguity guard: precompute normalized-name counts per dataset and grant nothing for a name occurring more than once; test that both candidates are left untagged
+- [ ] 3.4 Implement the UK route gate over `Record.Meta`: tag only when at least one row carries Skilled Worker, any Global Business Mobility route, or Scale-up; test that a Temporary-Worker-only company is rejected while its rows are still parsed
+
+## 4. Register sources
+
+- [ ] 4.1 Implement the GOV.UK URL resolver: Content API → `details.attachments` → select the CSV by title, with an HTML-scrape fallback; test the API path, the fallback on a non-200, the fallback on unparseable JSON, and an error when neither yields a URL
+- [ ] 4.2 Implement `ParseUKSponsors` over the register CSV (Organisation Name, Town/City, County, Type & Rating, Route) into records carrying route, town, and rating; test against a committed fixture
+- [ ] 4.3 Implement `ParseNLSponsors` over the IND register HTML table (`<th scope="row">` organisation, `<td>` KvK), decoding HTML entities and retaining the KvK as metadata; test against a committed fixture
+- [ ] 4.4 Test that a zero-record parse from either source returns an error rather than an empty slice
+- [ ] 4.5 Add the `uk-skilled-worker-sponsor` and `nl-recognised-sponsor` registry entries with their titles, descriptions, `KindCredential`, datasets, and gates
+
+## 5. Import worker
+
+- [ ] 5.1 Widen `ListCompanyCollections` in `internal/db/queries/companies.sql` to `slug, collections, countries, hq_country` and run `make sqlc`
+- [ ] 5.2 Rework `cmd/import-collections` for record-shaped resolve, per-dataset ambiguity precomputation, and gate application at match time
+- [ ] 5.3 Make an empty parse an abort-before-write failure alongside the existing fetch-failure abort; test that no membership is written in either case
+- [ ] 5.4 Add `-dry-run` reporting matched / gated-out / unmatched per collection and writing nothing; test that no write path is reached
+
+## 6. Generated frontend contract
+
+- [ ] 6.1 Emit the collection registry (slug, title, description, kind) from `cmd/gen-contracts` into `web/src/lib/generated/contracts.ts`; run `make gen-contracts` and commit the output
+- [ ] 6.2 Point `web/src/lib/facets.ts` and the `/collections` hub at the generated registry, delete the hand-kept `COLLECTIONS` from `web/src/lib/collections.ts`, and leave `FILTER_COLLECTIONS` where it is
+
+## 7. UI
+
+- [ ] 7.1 Verify whether the filter machinery tolerates two facet specs on the `collections` param; if not, render one spec whose options carry group headings — record which way it went
+- [ ] 7.2 Split the collection facet options by `kind` into "Collections" and "Credentials" groups in the FilterModal
+- [ ] 7.3 Add the credential badge to the job card and the company page, naming the issuing register and carrying the disclaimer that the licence belongs to the employer and is not a promise of sponsorship for that role
+- [ ] 7.4 Verify the `/collections/uk-skilled-worker-sponsor` landing page renders server-side with its canonical and breadcrumb JSON-LD, as the existing landing-page machinery should give for free
+
+## 8. Verify and ship
+
+- [ ] 8.1 `go build ./... && go vet ./... && go test ./...` green, and the web build and lint at their baseline
+- [ ] 8.2 Run `-dry-run` against production; inspect `hq_country` coverage and the per-collection counts, and record the numbers in the change before any write
+- [ ] 8.3 Run the real import, then `make reindex` (never stacked with `reindex-companies`), and confirm the facet returns jobs for both credentials

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -52,3 +52,50 @@ describe('FILTER_COLLECTIONS invariants', () => {
     }
   });
 });
+
+describe('credential collections in the job-search facet', () => {
+  const collectionFacets = FACETS.filter((f) => f.param === 'collections');
+
+  it('occupies exactly one facet entry', () => {
+    // Two entries sharing a query param would break the facet machinery, not just
+    // the layout: filtersToParams iterates FACETS and would append every selected
+    // value to the URL twice, and activeFilterCount would double the badge. The
+    // credential/collection split is therefore a grouping inside one facet, not a
+    // second facet — this test is what stops someone splitting it later.
+    expect(collectionFacets).toHaveLength(1);
+  });
+
+  it('offers both sponsor credentials, grouped apart from editorial collections', () => {
+    const options = collectionFacets[0].options ?? [];
+    const credentials = options.filter((o) => o.group);
+    expect(credentials.map((o) => o.value)).toEqual([
+      'uk-skilled-worker-sponsor',
+      'nl-recognised-sponsor',
+    ]);
+    for (const c of credentials) {
+      expect(c.group).toBe('Employer credentials');
+    }
+  });
+
+  it('keeps editorial collections ungrouped and ahead of the credentials', () => {
+    const options = collectionFacets[0].options ?? [];
+    const firstGrouped = options.findIndex((o) => o.group);
+    expect(firstGrouped).toBeGreaterThan(0);
+    expect(options.slice(0, firstGrouped).every((o) => !o.group)).toBe(true);
+    expect(options.slice(firstGrouped).every((o) => o.group)).toBe(true);
+  });
+
+  it('resolves a credential slug to a landing page scoped by the collections facet', () => {
+    const resolved = collectionBySlug('uk-skilled-worker-sponsor');
+    expect(resolved?.params).toEqual({ collections: 'uk-skilled-worker-sponsor' });
+    expect(resolved?.title).toBe('Licensed UK sponsor');
+    // The disclaimer travels with the copy: a landing page must not read as a
+    // promise that any listed role is sponsored.
+    expect(resolved?.description).toMatch(/not a commitment to sponsor/i);
+  });
+
+  it('lists credential slugs in the sitemap alongside every other collection', () => {
+    expect(collectionSlugs()).toContain('uk-skilled-worker-sponsor');
+    expect(collectionSlugs()).toContain('nl-recognised-sponsor');
+  });
+});

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -66,7 +66,7 @@ describe('credential collections in the job-search facet', () => {
   });
 
   it('offers both sponsor credentials, grouped apart from editorial collections', () => {
-    const options = collectionFacets[0].options ?? [];
+    const options = collectionFacets[0]?.options ?? [];
     const credentials = options.filter((o) => o.group);
     expect(credentials.map((o) => o.value)).toEqual([
       'uk-skilled-worker-sponsor',
@@ -78,7 +78,7 @@ describe('credential collections in the job-search facet', () => {
   });
 
   it('keeps editorial collections ungrouped and ahead of the credentials', () => {
-    const options = collectionFacets[0].options ?? [];
+    const options = collectionFacets[0]?.options ?? [];
     const firstGrouped = options.findIndex((o) => o.group);
     expect(firstGrouped).toBeGreaterThan(0);
     expect(options.slice(0, firstGrouped).every((o) => !o.group)).toBe(true);

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -1,15 +1,3 @@
-// Curated collections shown on /collections. This mirrors the Go registry in
-// internal/collections (the source of truth for membership + the search facet).
-// It is a hand-kept mirror for now — only the display copy lives here; if the set
-// grows, fold it into the generated contracts (gen-contracts) so the two can't
-// drift. Keep `slug` identical to the Go registry slugs and the `collections`
-// search-facet values.
-export type Collection = {
-  slug: string;
-  title: string;
-  description: string;
-};
-
 // A filter collection is the second kind of collection: a curated card that maps
 // to an arbitrary /jobs facet filter rather than company membership. Unlike
 // COLLECTIONS it is frontend-only — no Go registry, no `collections` search-facet
@@ -454,63 +442,14 @@ export function toQuery(params: Record<string, string | string[]>): string {
   return q.toString();
 }
 
-export const COLLECTIONS: Collection[] = [
-  {
-    slug: 'yc',
-    title: 'Y Combinator',
-    description:
-      'Open roles at Y Combinator–backed companies, from current batches to graduated unicorns.',
-  },
-  {
-    slug: 'techstars',
-    title: 'Techstars',
-    description: 'Open roles at Techstars-backed companies.',
-  },
-  {
-    slug: 'european',
-    title: 'European Startups',
-    description: "Open roles at European startups across the continent's tech hubs.",
-  },
-  {
-    slug: 'ai',
-    title: 'AI Companies',
-    description:
-      'Open roles at AI-native companies — foundation-model labs, ML platforms and applied-AI products.',
-  },
-  {
-    slug: 'mag7',
-    title: 'Magnificent Seven',
-    description:
-      'Open roles at the Magnificent Seven — Apple, Microsoft, Alphabet, Amazon, Meta, Nvidia and Tesla.',
-  },
-  {
-    slug: 'bigtech',
-    title: 'Big Tech',
-    description: 'Open roles at the largest, most established technology companies.',
-  },
-  {
-    slug: 'unicorn',
-    title: 'Unicorns',
-    description: 'Open roles at unicorns — private companies valued at over $1 billion.',
-  },
-  {
-    slug: 'fortune500',
-    title: 'Fortune 500',
-    description: 'Open roles at Fortune 500 companies — the largest US corporations by revenue.',
-  },
-  {
-    slug: 'eastern-roots',
-    title: 'Eastern Roots',
-    description:
-      'Open roles at globally distributed companies founded by Eastern European (incl. Russian-speaking) founders or with Eastern European engineering roots.',
-  },
-  {
-    slug: 'ai-native',
-    title: 'AI-Native',
-    description:
-      'Open roles at AI-native companies building AI-first products and infrastructure — model and inference APIs, vector databases, and agent/dev tooling.',
-  },
-];
+// The company-tag registry is generated from the Go source of truth
+// (internal/collections) by cmd/gen-contracts and re-exported here so every import
+// site keeps its `$lib/collections` path. It carries `kind`, which decides whether
+// a tag renders as an editorial collection or as a credential — a field a hand-kept
+// mirror could get wrong silently, which is why this stopped being hand-kept.
+export { COLLECTIONS } from './generated/contracts';
+import { COLLECTIONS as COMPANY_COLLECTIONS } from './generated/contracts';
+export type { Collection, CollectionKind } from './generated/contracts';
 
 // A resolved collection: the display copy plus the fixed job-search facet params
 // that scope its feed. `params` is single-valued (the shape JobsView's `scope`
@@ -547,7 +486,7 @@ export function collectionBySlug(slug: string): ResolvedCollection | undefined {
   if (filter) {
     return { title: filter.title, description: filter.description, params: scopeParams(filter.params) };
   }
-  const company = COLLECTIONS.find((c) => c.slug === slug);
+  const company = COMPANY_COLLECTIONS.find((c) => c.slug === slug);
   if (company) {
     return { title: company.title, description: company.description, params: { collections: company.slug } };
   }
@@ -557,5 +496,5 @@ export function collectionBySlug(slug: string): ResolvedCollection | undefined {
 // Every collection slug across both registries — the sitemap's source for the
 // collection landing URLs. Slugs are unique across the two sets.
 export function collectionSlugs(): string[] {
-  return [...FILTER_COLLECTIONS.map((c) => c.slug), ...COLLECTIONS.map((c) => c.slug)];
+  return [...FILTER_COLLECTIONS.map((c) => c.slug), ...COMPANY_COLLECTIONS.map((c) => c.slug)];
 }

--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -4,6 +4,7 @@
   import { api } from '$lib/api';
   import type { Company } from '$lib/types';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CredentialBadge from './CredentialBadge.svelte';
   import CompanyFollowButton from './CompanyFollowButton.svelte';
   import VoteControl from './VoteControl.svelte';
 
@@ -48,6 +49,14 @@
       <h1 class="break-words text-xl font-semibold tracking-tight sm:text-2xl">{company.name}</h1>
       {#if company.tagline}
         <p class="mt-1 text-sm text-muted-foreground">{company.tagline}</p>
+      {/if}
+      <!-- Register-backed credentials (visa-sponsor licences) sit under the identity,
+           where a fact about the employer belongs. Each carries its issuing body and
+           the disclaimer that the licence is not a promise about any given role. -->
+      {#if company.collections?.length}
+        <div class="mt-2 flex flex-wrap gap-1.5">
+          <CredentialBadge collections={company.collections} />
+        </div>
       {/if}
     </div>
     <!-- flex-1 above lets the name/tagline use the full width; the follow CTA stays

--- a/web/src/lib/components/CredentialBadge.svelte
+++ b/web/src/lib/components/CredentialBadge.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { credentialBadges } from '$lib/credentials';
+  import { cn } from '$lib/ui';
+
+  // Renders an employer's register-backed credentials — currently the UK and Dutch
+  // visa-sponsor licences.
+  //
+  // Deliberately quiet: a licence is a fact about the employer, not a feature of
+  // the role, so it reads as metadata alongside the other chips rather than as a
+  // selling point. The disclaimer rides in the tooltip on every badge, because the
+  // failure mode is a candidate reading "licensed sponsor" as "they will sponsor
+  // me" and spending an application on it.
+  let { collections, class: className }: { collections?: string[] | null; class?: string } =
+    $props();
+
+  const badges = $derived(credentialBadges(collections));
+</script>
+
+{#each badges as badge (badge.slug)}
+  <span
+    title={badge.tooltip}
+    class={cn(
+      'inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-0.5 text-xs font-medium text-muted-foreground',
+      className,
+    )}
+  >
+    {badge.label}
+    <span class="opacity-70">{badge.issuer}</span>
+  </span>
+{/each}

--- a/web/src/lib/components/CredentialBadge.svelte
+++ b/web/src/lib/components/CredentialBadge.svelte
@@ -25,6 +25,12 @@
     )}
   >
     {badge.label}
-    <span class="opacity-70">{badge.issuer}</span>
+    <span aria-hidden="true" class="opacity-70">{badge.issuer}</span>
+    <!-- The disclaimer cannot live in `title` alone. There is no hover on a phone,
+         and a large share of job-search traffic is on one, so the qualifier would be
+         unreachable for exactly the readers most likely to act on the badge; screen
+         readers announce `title` inconsistently too. This carries the full sentence
+         into the accessible name and leaves the visual chip unchanged. -->
+    <span class="sr-only">— {badge.tooltip}</span>
   </span>
 {/each}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -16,6 +16,7 @@
   import { Badge } from '$lib/ui';
   import { supersedesReality } from '$lib/ghost';
   import CredentialBadge from './CredentialBadge.svelte';
+  import { credentialBadges } from '$lib/credentials';
   import GhostBadge from './GhostBadge.svelte';
   import RealityBadge from './RealityBadge.svelte';
   import { timeAgo } from '$lib/utils';
@@ -62,6 +63,10 @@
   const isViewed = $derived(dimViewed && hasViewed(job.public_slug));
 
   const tags = $derived(cardTags(job));
+  // Only the credential subset of job.collections renders here, so the signal row's
+  // guard has to test that subset — a job carrying only editorial tags would
+  // otherwise open an empty flex row and leave a stray margin under the title.
+  const credentials = $derived(credentialBadges(job.collections));
   // A one-line blurb under the title so a card conveys what the job is without
   // opening it. Prefer the clean model-written summary, but only tech jobs are
   // enriched — fall back to a plain-text snippet of the raw (HTML) posting so
@@ -267,7 +272,7 @@
 
   <!-- Signal row: reality chip + the region/employment facets, grouped under the
        title as quiet outline chips so they read as metadata, not decoration. -->
-  {#if job.reality || tags.length > 0 || job.countries?.length || job.collections?.length}
+  {#if job.reality || tags.length > 0 || job.countries?.length || credentials.length > 0}
     <div class="mt-2 flex flex-wrap items-center gap-1.5">
       <!-- evergreen_posting IS the reality verdict, so showing both chips states one
            fact twice, the second time louder. The ghost chip carries it inside its

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -15,6 +15,7 @@
   import type { Job } from '$lib/types';
   import { Badge } from '$lib/ui';
   import { supersedesReality } from '$lib/ghost';
+  import CredentialBadge from './CredentialBadge.svelte';
   import GhostBadge from './GhostBadge.svelte';
   import RealityBadge from './RealityBadge.svelte';
   import { timeAgo } from '$lib/utils';
@@ -266,7 +267,7 @@
 
   <!-- Signal row: reality chip + the region/employment facets, grouped under the
        title as quiet outline chips so they read as metadata, not decoration. -->
-  {#if job.reality || tags.length > 0 || job.countries?.length}
+  {#if job.reality || tags.length > 0 || job.countries?.length || job.collections?.length}
     <div class="mt-2 flex flex-wrap items-center gap-1.5">
       <!-- evergreen_posting IS the reality verdict, so showing both chips states one
            fact twice, the second time louder. The ghost chip carries it inside its
@@ -279,6 +280,10 @@
       {#each tags as tag (tag)}
         <Badge variant="outline">{tag}</Badge>
       {/each}
+      <!-- Register-backed employer credentials (visa-sponsor licences). A fact about
+           the employer, so it sits with the metadata chips and carries its own
+           disclaimer rather than reading as a promise about this role. -->
+      <CredentialBadge collections={job.collections} />
       <!-- Eligible countries as an overlapping flag cluster. Display-only here: the
            whole card is a link, so the flags carry no nested filter links. -->
       {#if job.countries?.length}

--- a/web/src/lib/components/facets/PillGroup.svelte
+++ b/web/src/lib/components/facets/PillGroup.svelte
@@ -36,7 +36,13 @@
 </script>
 
 <div class="flex flex-wrap gap-2">
-  {#each shown as opt (opt.value)}
+  {#each shown as opt, i (opt.value)}
+    <!-- An option opening a new group gets a full-width sub-heading above it, so a
+         facet mixing two sorts of option (curated collections and verifiable
+         credentials) reads as two lists without becoming two facets. -->
+    {#if opt.group && opt.group !== shown[i - 1]?.group}
+      <p class="w-full pt-1 text-xs font-medium text-muted-foreground">{opt.group}</p>
+    {/if}
     {@const excluded = exclude.includes(opt.value)}
     {@const included = include.includes(opt.value)}
     <button

--- a/web/src/lib/components/facets/PillGroup.svelte
+++ b/web/src/lib/components/facets/PillGroup.svelte
@@ -28,10 +28,12 @@
   const shown = $derived(
     uniqueByValue([
       ...options,
+      // Ungrouped so it cannot appear under a heading it has nothing to do with;
+      // `shown` is re-sorted below to keep the grouped options contiguous.
       ...[...include, ...exclude]
         .filter((v) => !options.some((o) => o.value === v))
-        .map((v) => ({ value: v, label: v })),
-    ]),
+        .map((v) => ({ value: v, label: v, group: undefined })),
+    ]).sort((a, b) => Number(!!a.group) - Number(!!b.group)),
   );
 </script>
 

--- a/web/src/lib/credentials.test.ts
+++ b/web/src/lib/credentials.test.ts
@@ -4,9 +4,10 @@ import { credentialBadges } from './credentials';
 
 describe('credentialBadges', () => {
   it('surfaces a credential tag as a badge naming its issuing register', () => {
-    const [badge] = credentialBadges(['uk-skilled-worker-sponsor']);
-    expect(badge.label).toBe('Licensed UK sponsor');
-    expect(badge.issuer).toBe('GOV.UK');
+    const badges = credentialBadges(['uk-skilled-worker-sponsor']);
+    expect(badges).toHaveLength(1);
+    expect(badges[0]?.label).toBe('Licensed UK sponsor');
+    expect(badges[0]?.issuer).toBe('GOV.UK');
   });
 
   it('always carries the disclaimer that the licence is the employer’s', () => {

--- a/web/src/lib/credentials.test.ts
+++ b/web/src/lib/credentials.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { COLLECTIONS } from './generated/contracts';
+import { credentialBadges } from './credentials';
+
+describe('credentialBadges', () => {
+  it('surfaces a credential tag as a badge naming its issuing register', () => {
+    const [badge] = credentialBadges(['uk-skilled-worker-sponsor']);
+    expect(badge.label).toBe('Licensed UK sponsor');
+    expect(badge.issuer).toBe('GOV.UK');
+  });
+
+  it('always carries the disclaimer that the licence is the employer’s', () => {
+    // The whole point of the badge is that it states a fact about the employer. A
+    // reader must not take it as a promise about the role they are looking at.
+    for (const badge of credentialBadges(['uk-skilled-worker-sponsor', 'nl-recognised-sponsor'])) {
+      expect(badge.tooltip).toMatch(/not a (commitment|promise)/i);
+      expect(badge.tooltip).toMatch(/employer/i);
+    }
+  });
+
+  it('ignores editorial collections', () => {
+    expect(credentialBadges(['yc', 'bigtech', 'unicorn'])).toEqual([]);
+  });
+
+  it('ignores unknown tags rather than inventing a badge', () => {
+    expect(credentialBadges(['not-a-collection', ''])).toEqual([]);
+  });
+
+  it('handles an absent tag list', () => {
+    expect(credentialBadges(undefined)).toEqual([]);
+    expect(credentialBadges([])).toEqual([]);
+  });
+
+  it('keeps registry order when a company holds several credentials', () => {
+    const both = credentialBadges(['nl-recognised-sponsor', 'uk-skilled-worker-sponsor']);
+    expect(both.map((b) => b.slug)).toEqual(['uk-skilled-worker-sponsor', 'nl-recognised-sponsor']);
+  });
+
+  it('covers every credential in the generated registry', () => {
+    // A credential added to the Go registry with no badge copy here would tag jobs
+    // and filter them while rendering nothing — this is what catches that.
+    const credentials = COLLECTIONS.filter((c) => c.kind === 'credential').map((c) => c.slug);
+    expect(credentialBadges(credentials).map((b) => b.slug)).toEqual(credentials);
+  });
+});

--- a/web/src/lib/credentials.ts
+++ b/web/src/lib/credentials.ts
@@ -43,7 +43,10 @@ const COPY: Record<string, { issuer: string; tooltip: string }> = {
 export function credentialBadges(collections: string[] | undefined | null): CredentialBadge[] {
   if (!collections?.length) return [];
   const held = new Set(collections);
-  return COLLECTIONS.filter((c) => c.kind === 'credential' && held.has(c.slug))
-    .filter((c) => c.slug in COPY)
-    .map((c) => ({ slug: c.slug, label: c.title, ...COPY[c.slug] }));
+  return COLLECTIONS.filter((c) => c.kind === 'credential' && held.has(c.slug)).flatMap((c) => {
+    // flatMap, not filter-then-map: only the lookup narrows COPY's index signature,
+    // so reading it once is what makes the result total rather than a cast.
+    const copy = COPY[c.slug];
+    return copy ? [{ slug: c.slug, label: c.title, issuer: copy.issuer, tooltip: copy.tooltip }] : [];
+  });
 }

--- a/web/src/lib/credentials.ts
+++ b/web/src/lib/credentials.ts
@@ -1,0 +1,49 @@
+// Presentation for credential collections — company tags drawn from an
+// authoritative public register rather than from our editorial judgement.
+//
+// Membership and the editorial/credential split come from the generated registry
+// (cmd/gen-contracts ← internal/collections). What lives here is only the copy a
+// badge needs: which body issued the licence, and the disclaimer that keeps the
+// badge from reading as a promise about the role being viewed. A credential added
+// upstream with no entry below renders nothing, which a test catches.
+import { COLLECTIONS } from './generated/contracts';
+
+export type CredentialBadge = {
+  slug: string;
+  /** The registry's own title, e.g. "Licensed UK sponsor". */
+  label: string;
+  /** The body that publishes the register, so a reader can verify it themselves. */
+  issuer: string;
+  /** Hover copy: what the credential means, and what it does not. */
+  tooltip: string;
+};
+
+// The disclaimer is not optional decoration. A licence is held by an employer, for
+// a route, at a moment in time; none of that says the role in front of the reader
+// will be sponsored, and a candidate acting on the stronger reading wastes an
+// application at best.
+const COPY: Record<string, { issuer: string; tooltip: string }> = {
+  'uk-skilled-worker-sponsor': {
+    issuer: 'GOV.UK',
+    tooltip:
+      'This employer appears on the GOV.UK register of licensed sponsors for the Skilled Worker and related work routes. The licence belongs to the employer and is not a commitment to sponsor this role.',
+  },
+  'nl-recognised-sponsor': {
+    issuer: 'IND',
+    tooltip:
+      'This employer appears on the IND public register of recognised sponsors for work and highly skilled migrants. The recognition belongs to the employer and is not a commitment to sponsor this role.',
+  },
+};
+
+/**
+ * Badges for the credential tags in a company's or job's collection list, in
+ * registry order. Editorial collections, unknown slugs and an absent list all yield
+ * nothing — a tag we cannot describe is better shown as nothing than as a guess.
+ */
+export function credentialBadges(collections: string[] | undefined | null): CredentialBadge[] {
+  if (!collections?.length) return [];
+  const held = new Set(collections);
+  return COLLECTIONS.filter((c) => c.kind === 'credential' && held.has(c.slug))
+    .filter((c) => c.slug in COPY)
+    .map((c) => ({ slug: c.slug, label: c.title, ...COPY[c.slug] }));
+}

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -33,6 +33,13 @@ export interface FacetOption {
   count?: number;
   /** ISO 3166-1 alpha-2 code for country options, so the pill shows a flag icon. */
   flag?: string;
+  /** Sub-heading this option renders under, for a facet whose options are not all
+   *  the same sort of thing. Used by the collections facet to keep credentials
+   *  (verifiable licences) visually apart from editorial collections while both
+   *  stay on one `collections` query param — the facet machinery keys state and URL
+   *  serialization by param, so two facet entries sharing one param would double
+   *  every value in the URL and in the active-filter count. */
+  group?: string;
 }
 
 export type FacetControl = 'pills' | 'select' | 'tokens' | 'remote';
@@ -399,9 +406,22 @@ const CURRENCY: FacetOption[] = [
 // aligns with the filter's currency facet.
 export const CURRENCY_OPTIONS: FacetOption[] = CURRENCY;
 
-// Curated collections (yc, bigtech, …) as pill options, sourced from the same
-// registry the /collections hub renders so the label/slug pairs never drift.
-const COLLECTION: FacetOption[] = COLLECTIONS.map((c) => ({ value: c.slug, label: c.title }));
+// The company-tag registry as pill options, from the generated registry the
+// /collections hub also renders, so the label/slug pairs cannot drift.
+// Editorial collections first, then credentials, each under its own sub-heading.
+// A credential is a verifiable licence drawn from a public register, not one of our
+// curated picks, and running them together would read as though we vouched for both
+// the same way. They stay on one `collections` param regardless: facet state and URL
+// serialization are keyed by param, so a second facet entry sharing it would append
+// every value twice.
+const COLLECTION: FacetOption[] = [
+  ...COLLECTIONS.filter((c) => c.kind === 'editorial').map((c) => ({ value: c.slug, label: c.title })),
+  ...COLLECTIONS.filter((c) => c.kind === 'credential').map((c) => ({
+    value: c.slug,
+    label: c.title,
+    group: 'Employer credentials',
+  })),
+];
 
 // Company-size buckets — the vocab.CompanySizeValues vocabulary. Not exported as
 // a generated values array (it's a scalar enrichment field, not a search facet on

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -2134,7 +2134,7 @@ export const ROLE_ALIASES = {
   'business_analyst': ['business analyst'],
   'c_level': ['ceo', 'chief', 'cpo', 'cto', 'head of', 'vice president', 'vp', 'директор', 'руководитель'],
   'chief_of_staff': ['chief of staff'],
-  'chip_designer': ['analog design engineer', 'analogue design engineer', 'asic design engineer', 'chip design engineer', 'dft design engineer', 'digital design engineer', 'ic design engineer', 'memory design engineer', 'mixed signal design engineer', 'mixed-signal design engineer', 'physical design engineer', 'rf design engineer', 'rfic design engineer', 'rtl design engineer', 'semiconductor design engineer', 'silicon design engineer', 'soc design engineer', 'vlsi design engineer'],
+  'chip_designer': ['analog design engineer', 'analogue design engineer', 'asic design engineer', 'chip design engineer', 'dft design engineer', 'digital design engineer', 'ic design engineer', 'memory design engineer', 'mixed signal design engineer', 'mixed-signal design engineer', 'physical design engineer', 'rf design engineer', 'rfic design engineer', 'rtl design engineer', 'semiconductor design engineer', 'silicon design engineer', 'soc design engineer', 'standard cell design engineer', 'vlsi design engineer'],
   'civil_designer': ['civil design engineer', 'civil designer', 'structural designer'],
   'cloud_architect': ['cloud architect'],
   'cloud_engineer': ['cloud engineer'],
@@ -2267,3 +2267,19 @@ export const ROLE_ALIASES = {
   'web_designer': ['web designer'],
 } as const;
 export type RoleAliases = typeof ROLE_ALIASES;
+export const COLLECTIONS = [
+  { slug: 'yc', title: 'Y Combinator', description: 'Open roles at Y Combinator–backed companies, from current batches to graduated unicorns.', kind: 'editorial' },
+  { slug: 'techstars', title: 'Techstars', description: 'Open roles at Techstars-backed companies.', kind: 'editorial' },
+  { slug: 'european', title: 'European Startups', description: 'Open roles at European startups across the continent\'s tech hubs.', kind: 'editorial' },
+  { slug: 'ai', title: 'AI Companies', description: 'Open roles at AI-native companies — foundation-model labs, ML platforms and applied-AI products.', kind: 'editorial' },
+  { slug: 'mag7', title: 'Magnificent Seven', description: 'Open roles at the Magnificent Seven — Apple, Microsoft, Alphabet, Amazon, Meta, Nvidia and Tesla.', kind: 'editorial' },
+  { slug: 'bigtech', title: 'Big Tech', description: 'Open roles at the largest, most established technology companies.', kind: 'editorial' },
+  { slug: 'unicorn', title: 'Unicorns', description: 'Open roles at unicorns — private companies valued at over $1 billion.', kind: 'editorial' },
+  { slug: 'fortune500', title: 'Fortune 500', description: 'Open roles at Fortune 500 companies — the largest US corporations by revenue.', kind: 'editorial' },
+  { slug: 'eastern-roots', title: 'Eastern Roots', description: 'Open roles at globally distributed companies founded by Eastern European (incl. Russian-speaking) founders or with Eastern European engineering roots.', kind: 'editorial' },
+  { slug: 'ai-native', title: 'AI-Native', description: 'Open roles at AI-native companies building AI-first products and infrastructure — model and inference APIs, vector databases, and agent/dev tooling.', kind: 'editorial' },
+  { slug: 'uk-skilled-worker-sponsor', title: 'Licensed UK sponsor', description: 'Open roles at employers on the GOV.UK register of licensed sponsors for the Skilled Worker and related work routes. The licence belongs to the employer — it is not a commitment to sponsor any particular role.', kind: 'credential' },
+  { slug: 'nl-recognised-sponsor', title: 'Licensed NL sponsor', description: 'Open roles at employers on the IND public register of recognised sponsors for work and highly skilled migrants. The recognition belongs to the employer — it is not a commitment to sponsor any particular role.', kind: 'credential' },
+] as const;
+export type Collection = (typeof COLLECTIONS)[number];
+export type CollectionKind = Collection['kind'];


### PR DESCRIPTION
## What and why

`enrichment.visa_sponsorship` is an LLM reading of the posting text, and most postings say nothing about sponsorship at all — so the filter is silent exactly where a relocating candidate needs it. The UK and the Netherlands both publish an authoritative register of employers licensed to sponsor work visas, which answers a different and stronger question: *can this employer sponsor at all?*

The second reason is structural. Company signals have accreted one migration at a time — `remote_regions`, `yc_batch`/`yc_status`, `yc_stage`/`yc_flags`, `maturity`, `subindustry` — five migrations, five facets, and every new filterable Meilisearch attribute opens a ~26-minute hard-500 deploy window. Meanwhile `internal/collections` already *is* the layer for this shape of data, and its `collections` tag array is already filterable on both indexes.

So this lands the registers there instead of as a sixth column: **no migration, no new filterable attribute, no 500 window.** The next register is one registry entry.

### What changed

- **`internal/collections` grows from "editorial themes" into a general company-tag registry.** `Kind` separates an editorial collection (Big Tech, YC) from a **credential** — a verifiable fact from a public register. `Dataset.Parse` yields `Record{Name, Meta}` so a gate can read a register's own columns; the five existing name parsers keep their signatures and tests, wrapped by a `names()` adapter. `Gate` turns a name match into a membership decision (`nil` admits everything, as before). `ResolveURL` covers a source that republishes per snapshot.
- **Matching is deliberately conservative** — a false positive sends someone into a visa conversation that cannot happen. Legal-suffix stripping (`ACME ROBOTICS LIMITED` → `acme-robotics`), a country gate, a stricter headquarters rule for single-token names (Apple hires in London and must not inherit an unrelated `APPLE LTD`; Monzo and Revolut still pass), a UK route gate, and an ambiguity guard keyed on the register's own identity field.
- **`cmd/import-collections`** applies gates at match time, gains `-dry-run`, and now aborts on three failure shapes rather than two (see below).
- **The frontend registry mirror becomes generated.** `kind` decides which filter group a tag lands in, so drift there is a correctness bug — a tag that filters with no pill to select it — not stale copy.
- **UI:** credentials render as their own group inside the one `collections` facet, plus a badge on the job card and company header carrying the issuing body and an explicit disclaimer.

### Two things worth a reviewer's attention

**Credentials share the `collections` query param on purpose.** Two facet entries on one param do not work here: `filtersToParams` iterates `FACETS` and would append every selected value to the URL twice, and `activeFilterCount` would double the badge. So the split is a `group` on the option, not a second facet — and a test pins that invariant.

**The abort story got a third leg after review.** A failed fetch aborts, and a zero-row parse aborts. Neither can see an upstream *relabelling*: GOV.UK renaming a route value leaves 142k rows parsing cleanly, gates every one of them out, and `Reconcile` then strips the credential from every company that held it — no error, exit 0. A truncated snapshot is the same failure at partial scale. So a tag that would lose ≥50% of its holders now aborts before writing, with `-force` for a genuine loss.

### Not in scope

Migrating `yc_*`, `maturity`, or `subindustry` into the tag model — churn without value; the seam is noted in `design.md`. Same for unifying the two paths YC currently flows through (`cmd/import-yc` writing `yc_*`, and the `yc` collection here — one dataset, two matching rules).

### Deploy

Ordinary release: no migration, no new filterable attribute, no ordering constraint. Then `cmd/import-collections -dry-run` (**required** — it reports the per-collection grant counts and `hq_country` coverage before the first write), then the real run, then `make reindex` — never stacked with `reindex-companies`.

Rollback is free: remove the two registry entries and re-run. `Reconcile` manages only registry-declared tags, so the credentials come off every company and nothing else is touched.

### Provenance

The idea and the two public register URLs came from [`DaKheera47/job-ops`](https://github.com/DaKheera47/job-ops). That project is AGPLv3 + Commons Clause and freehire is MIT, so **no code was copied** — the fetch strategies, matching policy, and storage model here are our own, built on `internal/collections`, which predates this change.

### Unrelated diff noise

`web/src/lib/generated/contracts.ts` picks up one line unrelated to this work (`'standard cell design engineer'` added to the `chip_designer` aliases): the committed file had drifted from its Go source, and `make gen-contracts` regenerated it wholesale.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes, and `go test -tags=integration ./internal/db/ ./internal/handler/` passes (the SQL layer was touched: `ListCompanyCollections` widened).
- [x] I regenerated committed artifacts when their source changed (`make sqlc` for the widened `ListCompanyCollections`, `make gen-contracts` for the collection registry).
- [ ] For `design-system/` changes: n/a — none.
- [x] For `web/` changes: `pnpm run build` passes and `svelte-check --threshold error` reports 0 errors; 559 tests green.
- [x] This stays within freehire's core/extension boundary — it adds no new column, no new search attribute, and no new worker.