### PR TITLE
fix(ds): a held dialog has to put itself back, not just refuse

### DIFF
--- a/design-system/AGENTS.md
+++ b/design-system/AGENTS.md
@@ -124,8 +124,15 @@ defect, listed here so it is not mistaken for a migration target.
 
 **`dismissible={false}` holds a dialog open** while an irreversible request is in flight, so
 Escape cannot hide whether it succeeded. Escape, the backdrop and the close button go away
-together — leaving one is a dialog that claims to be held and is not. Escape is refused by
-preventing the platform's own `cancel` event, not by a keydown listener racing it.
+together — leaving one is a dialog that claims to be held and is not.
+
+**Preventing `cancel` is necessary and not sufficient**, and jsdom cannot show you why. The
+platform's close watcher spends a user-activation budget on each `preventDefault`, and once it
+runs out it fires `cancel` unprevented and closes anyway — measured in Chrome: two Escapes
+refused, the third gets through. That valve exists so a page cannot trap someone. So a held
+dialog also **reasserts itself in `onclose`**. Keep the window short and always leave the
+caller a way out once the request resolves; a unit test that only asserts `defaultPrevented`
+will pass either way.
 
 ## Storybook
 

--- a/design-system/src/dialog.svelte
+++ b/design-system/src/dialog.svelte
@@ -79,13 +79,27 @@
   function oncancel(e: Event) {
     if (!dismissible) e.preventDefault();
   }
+
+  // Preventing `cancel` is necessary and not sufficient. The close watcher
+  // spends a user-activation budget on each preventDefault, and when it runs
+  // out it fires `cancel` unprevented and closes regardless — in Chrome, two
+  // Escapes are refused and the third gets through. That valve exists so a page
+  // cannot trap someone, which is right in general and wrong for the seconds an
+  // irreversible request is in flight, so a held dialog puts itself back.
+  function onclose() {
+    if (!dismissible) {
+      el?.showModal();
+      return;
+    }
+    open = false;
+  }
 </script>
 
 <dialog
   bind:this={el}
   aria-labelledby={title ? titleId : undefined}
   aria-describedby={description ? descriptionId : undefined}
-  onclose={() => (open = false)}
+  {onclose}
   {oncancel}
   {onclick}
   class={cn(

--- a/design-system/src/dialog.test.ts
+++ b/design-system/src/dialog.test.ts
@@ -106,6 +106,21 @@ describe('Dialog', () => {
       expect(el.open).toBe(true);
     });
 
+    // Preventing `cancel` is not enough on its own. The platform's close watcher
+    // spends a user-activation budget on each preventDefault, and once that runs
+    // out it fires `cancel` unprevented and closes anyway — measured in Chrome:
+    // two Escapes refused, the third closes. It is a deliberate anti-trap valve,
+    // so the only way to honour the contract is to reassert the dialog.
+    it('reopens itself if the platform closes it anyway', async () => {
+      const { getByRole } = render(Dialog, undismissable());
+      const el = getByRole('dialog', { hidden: true }) as HTMLDialogElement;
+
+      el.close();
+      await Promise.resolve();
+
+      expect(el.open).toBe(true);
+    });
+
     it('offers no close button', () => {
       const { queryByLabelText } = render(Dialog, undismissable());
 


### PR DESCRIPTION
Found by doing the thing #1325 left undone — click-testing the dialogs instead of ticking the task on a green compiler.

`dismissible={false}` prevented the platform's `cancel` event, and the unit test asserted `defaultPrevented` and passed. In Chrome the dialog closes on the **third** Escape:

```
cancel prevented=true
cancel prevented=true
cancel prevented=false
CLOSE
```

The close watcher spends a user-activation budget on each `preventDefault` and stops honouring it once that runs out. The valve is deliberate — a page must not be able to trap someone — and it is right in general. It is wrong for the seconds an irreversible request is in flight and the dialog is the only place its outcome will appear, which is the entire reason the prop exists.

So `onclose` reasserts the dialog when it is not dismissible.

**Verified in Chrome against the built Storybook**, both directions:

| | |
|---|---|
| `NotDismissible` | held after five Escapes |
| `Default` | closes on the first, focus returns to the trigger |

**jsdom could not have caught this.** It has no close watcher and no user activation, so `preventDefault was called` is the whole of what it can observe — which is exactly what the passing test observed. The new unit test asserts the reassertion instead, which jsdom *can* see, and `AGENTS.md` now carries the browser reality next to the prop.

91 tests.