### PR TITLE
docs(openspec): record the credential-register pre-deploy measurements

### DIFF
--- a/openspec/changes/company-credential-registries/tasks.md
+++ b/openspec/changes/company-credential-registries/tasks.md
@@ -48,5 +48,8 @@
 ## 8. Verify and ship
 
 - [x] 8.1 `go build ./... && go vet ./... && go test ./...` green, and the web build and lint at their baseline
-- [ ] 8.2 Run `-dry-run` against production; inspect `hq_country` coverage and the per-collection counts, and record the numbers in the change before any write
-- [ ] 8.3 Run the real import, then `make reindex` (never stacked with `reindex-companies`), and confirm the facet returns jobs for both credentials
+- [x] 8.2 Measure the gates against live data before any write. Run without database access, by exercising the real resolvers/parsers/gates against the live registers and the public catalogue API (`/api/v1/companies?countries=<c>` — note it paginates by `offset`; a `page` parameter is silently ignored and returns page one every time). Numbers recorded on 2026-07-31:
+  - **UK** — register resolved to the `2026-07-31` snapshot, 142,649 rows. Catalogue: 7,944 companies hiring in GB, `hq_country` populated for 2,106 (26.5%). Outcome: **matched 457**, gated 460, ambiguous 1,452. Top grants are the right legal entities (EPAM Systems, Ford, Rolls-Royce, BP, NatWest, Graphcore, several county councils); no false positive found in the top 40.
+  - **NL** — 12,887 register rows. Catalogue: 2,732 companies hiring in NL, `hq_country` populated for 535 (19.6%). Outcome: **matched 83**, gated 173, ambiguous 37. Top grants: Thermo Fisher, Arcadis, NXP, ING Bank, Adyen, Booking.com, Elsevier, IMC Trading.
+  - `hq_country` is **mixed-format**, which is why the country-alias comparison matters: 117 companies store `United Kingdom` rather than `gb`. Without the alias fix those 37 UK companies — Graphcore among them — and Adyen in NL would silently fail the single-token rule.
+- [ ] 8.3 Run the real import, then `make reindex` (never stacked with `reindex-companies`), and confirm the facet returns jobs for both credentials — BLOCKED: needs production database access (`DATABASE_URL` or a shell on the host). Until this runs the feature is live in code but empty in production: no badges render and the credential filter returns nothing.

--- a/openspec/specs/company-credential-registries/spec.md
+++ b/openspec/specs/company-credential-registries/spec.md
@@ -1,0 +1,221 @@
+# company-credential-registries Specification
+
+## Purpose
+Company tags drawn from authoritative public registers rather than editorial
+judgement — currently the UK Skilled Worker and Dutch recognised-sponsor visa
+licences. Covers each register's source and fetch strategy, the conservative
+matching policy that decides when a company earns a credential, and how a
+credential is presented so it is never mistaken for a promise about a specific
+role. Distinct from the job-level `enrichment.visa_sponsorship` signal, which
+reports what a posting says rather than what the employer is licensed to do.
+
+## Requirements
+### Requirement: A credential is a company fact sourced from an authoritative public register
+
+The system SHALL model a **credential** as a collection whose membership comes from
+an authoritative public register rather than from editorial judgement. A credential
+SHALL be distinguished from an editorial collection by a `kind` on its registry
+entry, and SHALL otherwise reuse the collection machinery unchanged — the same
+company-level tag set, the same denormalization onto jobs, and the same search
+facet. A credential SHALL state a fact about the **employer**, never about a
+specific role.
+
+The system SHALL NOT merge a credential with the job-level
+`enrichment.visa_sponsorship` signal. The two answer different questions — "the
+posting says they sponsor" versus "the employer is licensed to sponsor" — and SHALL
+remain independently filterable, so neither is implied by the other.
+
+#### Scenario: A credential and the job-level sponsorship signal filter independently
+
+- **WHEN** a user filters by the `uk-skilled-worker-sponsor` credential
+- **THEN** the feed is scoped by the employer's register membership only, and the
+  `visa_sponsorship` filter remains separately selectable and unaffected
+
+#### Scenario: A credential collection reuses the collection tag set
+
+- **WHEN** a company earns a credential
+- **THEN** the credential's slug is present in the company's collection set
+  alongside any editorial collections it belongs to, and is denormalized onto its
+  jobs like any other collection tag
+
+### Requirement: The UK register is resolved dynamically and gated by sponsorship route
+
+The system SHALL source the `uk-skilled-worker-sponsor` credential from the GOV.UK
+"Register of Worker and Temporary Worker licensed sponsors". Because the register's
+CSV URL embeds a snapshot date and is republished on a new URL each month, the
+system SHALL resolve the current URL at fetch time: first from the GOV.UK Content
+API for the publication, selecting the CSV attachment by its title, and failing
+that by scraping the publication's HTML page for the CSV link. A resolve that
+yields no URL SHALL be an error, not an empty result.
+
+The register lists every licensed sponsor across all immigration routes, including
+routes irrelevant to the catalogue's audience. The system SHALL retain every parsed
+row together with its route, and SHALL grant the credential only when at least one
+of a company's rows carries a work route — Skilled Worker, any Global Business
+Mobility route, or Scale-up. A company present in the register solely under a
+Temporary Worker or study route SHALL NOT receive the credential.
+
+#### Scenario: The current CSV URL is resolved from the Content API
+
+- **WHEN** the register is fetched and the GOV.UK Content API responds
+- **THEN** the CSV attachment titled for the Worker and Temporary Worker register is
+  selected and downloaded, without fetching the HTML page
+
+#### Scenario: A Content API failure falls back to the HTML page
+
+- **WHEN** the Content API is unavailable or returns a payload that cannot be parsed
+- **THEN** the publication's HTML page is scraped for the CSV link and the download
+  proceeds
+
+#### Scenario: A register entry on a work route earns the credential
+
+- **WHEN** a matched company has a register row whose route is `Skilled Worker`
+- **THEN** the company receives the `uk-skilled-worker-sponsor` credential
+
+#### Scenario: A register entry on a temporary route does not earn the credential
+
+- **WHEN** a matched company's only register rows carry Temporary Worker routes
+- **THEN** the company does not receive the credential, and the rows are still
+  retained for the run
+
+#### Scenario: An unresolvable register URL aborts the run
+
+- **WHEN** neither the Content API nor the HTML fallback yields a CSV URL
+- **THEN** the resolve fails with an error and no credential membership is written
+
+### Requirement: The Netherlands register grants the recognised-sponsor credential
+
+The system SHALL source the `nl-recognised-sponsor` credential from the IND public
+register of recognised sponsors for the "work" residence purpose, parsed from its
+single HTML table of organisation names and KvK numbers. The KvK number SHALL be
+retained as record metadata for disambiguation. The register does not break down by
+route, so no route gate applies. A parse that yields no rows SHALL be an error, not
+an empty result.
+
+#### Scenario: A recognised sponsor earns the credential
+
+- **WHEN** a matched company appears in the IND recognised-sponsor register
+- **THEN** the company receives the `nl-recognised-sponsor` credential
+
+#### Scenario: An empty parse aborts rather than clearing membership
+
+- **WHEN** the IND page is fetched but yields zero parsed rows
+- **THEN** the resolve fails with an error and no company loses its existing
+  credential
+
+### Requirement: Credential matching is conservative and never assigns on a coincidence of names
+
+The system SHALL match a register entry to a catalogue company by normalized name,
+and SHALL apply the following guards before granting a credential. All guards are
+cumulative; failing any one of them SHALL leave the company untagged rather than
+tagged on a guess.
+
+- **Legal-suffix stripping.** Before normalization, a trailing legal-form suffix
+  SHALL be stripped as a whole word from the **end** of the register name (for
+  example `Ltd`, `Limited`, `PLC`, `LLP`, `CIC`, `B.V.`, `N.V.`). A suffix word
+  appearing anywhere other than the end SHALL NOT be stripped.
+- **Geography gate.** The company SHALL have a geographic link to the register's
+  country. For a normalized name of two or more tokens, the register's country
+  present in the company's countries SHALL suffice.
+- **Single-token rule.** For a name whose normalized slug is a single unpunctuated
+  token, the company's headquarters country SHALL denote the register's country. A
+  single-token name is too weak a signal on its own: a multinational with a local
+  office would otherwise inherit a credential from an unrelated local business of
+  the same name. A name that normalizes to several slug segments — including one
+  punctuated into segments, such as `Booking.com` or `Rolls-Royce` — is specific
+  enough to fall under the geography gate alone.
+- **Country comparison.** A stored country value SHALL be compared whole and
+  case-insensitively, and SHALL be recognised by its ISO code or by a spelled-out
+  name for the same country. The headquarters column has more than one writer and
+  not all of them normalize, so the guard SHALL NOT depend on a particular upstream
+  spelling; a substring SHALL NOT count as a match.
+- **Ambiguity guard.** A normalized name shared by more than one *organisation* in
+  a register SHALL be treated as identifying none of them, and SHALL grant the
+  credential to no company. Organisations SHALL be told apart by a register-specific
+  identity field (the UK register's town, the Dutch register's KvK number) — a
+  shared name alone is not a collision, because the UK register lists a single
+  organisation once per sponsorship route it holds, and those rows must survive for
+  the route gate to read them. Where a register publishes no such identity field,
+  same-named rows SHALL be treated as one organisation and the geography guards
+  SHALL carry the decision.
+
+#### Scenario: A legal suffix is stripped from the end of a register name
+
+- **WHEN** the register lists `ACME ROBOTICS LIMITED` and the catalogue holds the
+  company `acme-robotics`
+- **THEN** the names match after suffix stripping and normalization
+
+#### Scenario: A suffix word inside a name is not stripped
+
+- **WHEN** the register lists `LIMITED BRANDS INC`
+- **THEN** only the trailing corporate suffix is considered, and the leading
+  `Limited` is retained as part of the name
+
+#### Scenario: A multi-token name matches on the country facet alone
+
+- **WHEN** a two-token register name matches a company that has open jobs in the
+  register's country
+- **THEN** the company receives the credential
+
+#### Scenario: A single-token name is rejected without a matching headquarters
+
+- **WHEN** a single-token register name matches a company that has open jobs in the
+  register's country but whose headquarters country is elsewhere
+- **THEN** the company does not receive the credential
+
+#### Scenario: A spelled-out headquarters country is recognised
+
+- **WHEN** a single-token register name matches a company whose headquarters country
+  is stored as `United Kingdom` rather than `GB`
+- **THEN** the company receives the credential, the comparison having recognised the
+  name as denoting the same country
+
+#### Scenario: A country name is not matched by substring
+
+- **WHEN** a company's headquarters country is stored as a longer string that merely
+  contains a country name
+- **THEN** the guard does not treat it as a match
+
+#### Scenario: A single-token name is accepted with a matching headquarters
+
+- **WHEN** a single-token register name matches a company whose headquarters country
+  equals the register's country
+- **THEN** the company receives the credential
+
+#### Scenario: An ambiguous name is assigned to nobody
+
+- **WHEN** a normalized register name appears for two organisations with different
+  identity fields (different towns)
+- **THEN** no company receives the credential from that name, regardless of any
+  other guard passing
+
+#### Scenario: One organisation's per-route rows are not mistaken for a collision
+
+- **WHEN** a register lists one organisation on several routes, so its name repeats
+  across rows sharing the same identity field
+- **THEN** every one of those rows survives the ambiguity guard and reaches the
+  route gate
+
+### Requirement: A credential is presented so it is never read as a promise about a role
+
+The system SHALL render a company's credential as a badge on the job card and on the
+company page, and SHALL accompany it with copy that states what the credential does
+and does not mean: the employer holds the licence, which is not a commitment to
+sponsor the role being viewed. The badge SHALL identify the issuing register so a
+user can verify it independently.
+
+In the job-search filter, credentials SHALL be presented as a group distinct from
+editorial collections, so a legal qualification is not read as an editorial theme.
+
+#### Scenario: A badge carries its disclaimer
+
+- **WHEN** a job card renders for a company holding the `uk-skilled-worker-sponsor`
+  credential
+- **THEN** the badge names the credential and exposes copy clarifying that the
+  licence belongs to the employer and is not a promise of sponsorship for that role
+
+#### Scenario: Credentials are a distinct filter group
+
+- **WHEN** a user opens the job-search filter
+- **THEN** credential options appear under their own group heading, separate from
+  the editorial collection options

--- a/openspec/specs/job-collections/spec.md
+++ b/openspec/specs/job-collections/spec.md
@@ -8,23 +8,56 @@ TBD - created by archiving change add-collections-pages. Update Purpose after ar
 The system SHALL model a curated collection as a company-level fact: each company
 MAY belong to zero or more collections, stored as a set of collection slugs on the
 company. A collection slug SHALL come from a fixed, code-owned registry. Each
-registry entry SHALL carry a `slug`, a human `title`, a `description`, and a
-membership source — exactly one of a static hand list of canonical company slugs
-or a remote dataset (a URL plus a parser that yields company names). Adding a
-collection SHALL be a single registry entry. Membership SHALL NOT be derivable
-from a job's text or its ATS source — it is an editorial fact about the company,
-populated only from the registry's sources.
+registry entry SHALL carry a `slug`, a human `title`, a `description`, a `kind`,
+and a membership source — exactly one of a static hand list of canonical company
+slugs or a remote dataset. Adding a collection SHALL be a single registry entry.
+Membership SHALL NOT be derivable from a job's text or its ATS source — it is a
+fact about the company, populated only from the registry's sources.
+
+The `kind` SHALL distinguish an **editorial** collection (a curated theme, such as
+Big Tech or Unicorns) from a **credential** (a verifiable fact drawn from an
+authoritative public register). The kind SHALL be part of the registry contract
+shared with the frontend, because it determines how a tag is presented; it SHALL
+NOT be hand-mirrored in a second place where it could drift from the Go registry.
+
+A dataset SHALL be defined by a parser yielding **records** rather than bare names.
+A record SHALL carry the member's name and MAY carry source metadata (for example a
+route, a locality, or a registry identifier) for later gating. A dataset SHALL
+supply its payload by exactly one of a fixed URL, an embedded blob, or a resolver
+that determines the URL at fetch time — the last of these for a source whose
+published URL changes between snapshots.
+
+A registry entry MAY carry a **gate**: a predicate over the candidate company and
+the matched record that SHALL hold before the tag is applied. An entry with no gate
+SHALL be matched on name alone, unchanged from prior behaviour.
 
 #### Scenario: A company belongs to multiple collections
 
 - **WHEN** a company qualifies for two collections (e.g. `yc` and `bigtech`)
 - **THEN** the company's collection set contains both slugs
 
-#### Scenario: The registry defines each collection's display copy and source
+#### Scenario: The registry defines each collection's display copy, kind, and source
 
 - **WHEN** the collection registry is read
-- **THEN** each entry exposes a slug, title, description, and exactly one
+- **THEN** each entry exposes a slug, title, description, kind, and exactly one
   membership source (a static slug list or a dataset)
+
+#### Scenario: A dataset parser yields records carrying source metadata
+
+- **WHEN** a dataset whose source publishes per-member attributes is parsed
+- **THEN** each record exposes the member's name plus that source's metadata,
+  available to the entry's gate
+
+#### Scenario: A gateless entry matches on name alone
+
+- **WHEN** a registry entry defines no gate
+- **THEN** every name-matched company is tagged, with no additional condition
+  applied
+
+#### Scenario: A dataset resolves its URL at fetch time
+
+- **WHEN** a dataset defines a resolver instead of a fixed URL
+- **THEN** the URL is determined during the run and the payload is fetched from it
 
 ### Requirement: Collection membership is propagated onto jobs for the search facet
 
@@ -49,18 +82,34 @@ empty `collections` set. Propagation is a deterministic copy, distinct from
 ### Requirement: The import worker resolves and populates membership idempotently
 
 The system SHALL provide a run-once-and-exit import worker that, for each
-collection in the registry, resolves its member companies — a dataset collection
-is fetched and parsed to company names, a static-list collection uses its slugs —
-matches them onto existing companies by **normalized name** (the same
-normalization as company slugs; unmatched candidates are omitted and logged, never
-guessed), writes `companies.collections` for the tags it manages, and propagates
-the result onto `jobs.collections`. The worker SHALL be idempotent and re-runnable
-(re-running with the same inputs yields the same membership) and SHALL only modify
-the collection tags it manages, leaving any other tags on a company untouched. If
-any collection's source cannot be resolved (e.g. a dataset fetch fails) the worker
-SHALL abort before writing — a partial resolve would reconcile a collection's tag
-off every company. After propagation the worker SHALL signal that a search reindex
-is required.
+collection in the registry, resolves its member companies — a dataset collection is
+fetched and parsed to records, a static-list collection uses its slugs — matches
+them onto existing companies by **normalized name** (the same normalization as
+company slugs; unmatched candidates are omitted and logged, never guessed), applies
+the entry's gate where one is defined, writes `companies.collections` for the tags
+it manages, and propagates the result onto `jobs.collections`. The worker SHALL be
+idempotent and re-runnable (re-running with the same inputs yields the same
+membership) and SHALL only modify the collection tags it manages, leaving any other
+tags on a company untouched. If any collection's source cannot be resolved (e.g. a
+dataset fetch fails, or a parse yields zero records) the worker SHALL abort before
+writing — a partial resolve would reconcile a collection's tag off every company.
+After propagation the worker SHALL signal that a search reindex is required.
+
+Where a gate needs company attributes beyond the slug and the current tag set, the
+worker SHALL load those attributes alongside the membership it reconciles.
+
+The worker SHALL additionally abort before writing when a tag it manages would lose
+at least half of the companies currently holding it. This covers the failure the
+fetch and empty-parse aborts cannot see: a source whose values have been relabelled
+upstream still parses to its full row count and then matches nobody, which would
+otherwise reconcile the tag off every holder with no error. A tag no company
+currently holds SHALL NOT trigger this — that is a new collection's first run — and
+an explicit override SHALL be available for a run where the loss is genuine.
+
+The worker SHALL support a **dry run** that performs every resolve, match, and gate
+evaluation and reports what it would write — per collection, the number of matched,
+gated-out, and unmatched candidates — without writing any membership. A dry run
+SHALL leave the database untouched.
 
 #### Scenario: Re-running the import is idempotent
 
@@ -79,11 +128,42 @@ is required.
 - **THEN** the worker aborts without writing any membership (no collection is
   reconciled off existing companies)
 
+#### Scenario: An empty parse is treated as a failure
+
+- **WHEN** a dataset is fetched successfully but parses to zero records
+- **THEN** the worker treats it as a failed resolve and aborts before writing
+
 #### Scenario: Static-list membership comes from the hand list
 
 - **WHEN** a static-list collection (e.g. `bigtech`) is resolved
 - **THEN** exactly the existing companies whose slugs are in the registry's hand
   list are tagged with that collection
+
+#### Scenario: A gated-out company keeps its other tags
+
+- **WHEN** a company matches a gated collection by name but fails its gate
+- **THEN** the company is not tagged for that collection, and every other tag it
+  holds is preserved
+
+#### Scenario: A collapsing tag aborts the run
+
+- **WHEN** a source parses to its usual size but, after gating, would leave a managed
+  tag with fewer than half its current holders
+- **THEN** the worker reports the shortfall and aborts before writing, unless the
+  override is given
+
+#### Scenario: A new collection's first run is not treated as a collapse
+
+- **WHEN** a newly added collection matches some companies and no company currently
+  holds its tag
+- **THEN** the run proceeds and writes the new membership
+
+#### Scenario: A dry run reports without writing
+
+- **WHEN** the worker runs in dry-run mode
+- **THEN** it reports the matched, gated-out, and unmatched counts per collection
+  along with any tag that would collapse, and neither `companies.collections` nor
+  `jobs.collections` is modified
 
 ### Requirement: Collections are a job-search facet plus a discovery hub
 
@@ -91,6 +171,10 @@ The system SHALL expose `collections` as a selectable facet in the main job-sear
 filter sidebar (`/jobs`), rendering one option per **company-collection** registry
 entry, so a user can filter the job feed by collection — composably with every
 other facet — and the filter is reflected in the URL (`/jobs?collections=<slug>`).
+Options SHALL be grouped by the registry entry's kind, so editorial collections and
+credentials are visually distinct while remaining a single filter axis over one
+query parameter.
+
 The system SHALL also expose a discovery hub at `/collections` listing **both**
 kinds of collection — company collections and filter collections — as visually
 uniform cards, each with its title, description, and a count of its open jobs. A
@@ -113,6 +197,12 @@ the controls for — the collection's own constraint.
 - **WHEN** a user opens `/jobs` and selects the `yc` collection in the sidebar
 - **THEN** the URL carries `collections=yc` and the feed contains only open jobs
   whose `collections` include `yc`, composable with the other facets
+
+#### Scenario: Credential options are grouped apart from editorial ones
+
+- **WHEN** a user opens the collection facet and the registry holds both kinds
+- **THEN** editorial and credential options appear under separate group headings,
+  and selecting either kind writes the same `collections` query parameter
 
 #### Scenario: The hub lists company collections linking to their landing pages
 


### PR DESCRIPTION
Follow-up to #1327 / #1330. Records the task 8.2 measurements and closes it.

The gates need only a company's slug, countries and `hq_country`, so they could be measured without database access — by running the real resolvers, parsers and gates against the live registers and the public catalogue API.

**UK** — resolved to the `2026-07-31` snapshot, 142,649 rows. 7,944 companies hiring in GB. **457 granted**, 460 gated out, 1,452 rows dropped as ambiguous. Top grants are the correct legal entities: EPAM Systems, Ford, Rolls-Royce, BP, NatWest, Graphcore, several county councils. No false positive in the top 40.

**NL** — 12,887 rows, 2,732 companies hiring in NL. **83 granted**, 173 gated, 37 ambiguous. Thermo Fisher, Arcadis, NXP, ING Bank, Adyen, Booking.com, Elsevier.

**The open question about `hq_country` is settled, and not the way I expected.** It is mixed-format: 117 companies store `United Kingdom` rather than `gb`. The country-alias comparison added after code review is therefore load-bearing rather than defensive — without it Graphcore and 36 other UK companies, and Adyen in NL, fail the single-token rule with no error and no log line.

Also recorded: `/api/v1/companies` paginates by `offset` and ignores a `page` parameter outright, returning page one however many times it is asked. That cost me a wrong conclusion earlier — worth having written down.

Task 8.3 (the real import + reindex) stays open; it needs production database access.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` pass.
- [x] `go test ./...` passes.
- [x] I regenerated committed artifacts when their source changed — n/a, documentation only.
- [ ] For `design-system/` changes: n/a.
- [ ] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary — documentation only.