### PR TITLE
The empty CV list says Analyze match, like the button does

### DIFF
--- a/web/src/lib/components/cv/CvList.svelte
+++ b/web/src/lib/components/cv/CvList.svelte
@@ -59,7 +59,7 @@
         <FileText class="mx-auto h-8 w-8 text-muted-foreground" />
         <p class="mt-3 text-center font-medium">No tailored CVs yet</p>
         <p class="mt-1 text-center text-sm text-muted-foreground">
-          A tailored CV starts from a vacancy’s fit analysis. Here’s how:
+          A tailored CV starts from a vacancy’s match analysis. Here’s how:
         </p>
         <ol class="mx-auto mt-5 flex max-w-sm flex-col gap-3 text-left text-sm">
           <li class="flex items-start gap-3">
@@ -68,7 +68,7 @@
           </li>
           <li class="flex items-start gap-3">
             <span class="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">2</span>
-            <span>Run the fit check — press <strong class="font-medium text-foreground">Analyze match</strong> on the job page.</span>
+            <span>Press <strong class="font-medium text-foreground">Analyze match</strong> on the job page.</span>
           </li>
           <li class="flex items-start gap-3">
             <span class="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">3</span>


### PR DESCRIPTION
Follow-up to #1329, which renamed the `/open` counter from "fit checks" to "matches analyzed".

The tailoring how-to in the empty CV list still told you to "run the fit check" and then, in the same sentence, to press **Analyze match**. Step 2 now just names the button, which also matches step 3's shape ("On the result, choose **Tailor my CV**").

```diff
- A tailored CV starts from a vacancy's fit analysis. Here's how:
+ A tailored CV starts from a vacancy's match analysis. Here's how:

- Run the fit check — press <strong>Analyze match</strong> on the job page.
+ Press <strong>Analyze match</strong> on the job page.
```

## Scope

This surface only. "Fit analysis" survives in ~10 other visible strings — `TailorLandingView`, `CliView`, the `/match` page title, `/features/tailor`'s SEO description, and three lines of the privacy policy — plus the `matchanalysis` package's own description in AGENTS.md. Retiring the term everywhere is a naming decision, not a typo fix, so it stays out of here.

Published posts under `web/src/posts/` keep their wording either way: they are dated records.