### PR TITLE
build(web): link the design system instead of copying it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,16 @@ jobs:
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
 
+      # The design system is a `link:` dependency — a bare symlink, so pnpm does not
+      # install its dependencies with web's. The package resolves tailwind-variants,
+      # clsx, tailwind-merge and @lucide/svelte out of its OWN node_modules, which has
+      # to exist before anything imports a primitive. Missing, the web build fails with
+      # MODULE_NOT_FOUND, which is loud — the point of `link:` over `file:` is that its
+      # failure mode is loud.
+      - name: Install design-system dependencies
+        working-directory: design-system
+        run: pnpm install --frozen-lockfile
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,9 @@ Non-obvious:
 
 - `migrations/` — the source for **both** sqlc codegen and Postgres initdb. Never edit an applied migration; add a new file.
 - `sources/` — YAML board files, not Go. One file per ATS provider, plus `custom.yml` and `telegram.yml`.
-- `design-system/` — a separate pnpm package, sibling to `web/`, linked via `file:../design-system`.
+- `design-system/` — a separate pnpm package, sibling to `web/`, linked via `link:../design-system`
+  (a symlink, not a copy). **Install it before building `web/`** — pnpm does not install a
+  linked package's own dependencies.
 - `internal/db/` — **generated**; edit `internal/db/queries/*.sql` and run `make sqlc`.
 - `services/pii-filter` — a standalone service, not a Go package.
 

--- a/design-system/AGENTS.md
+++ b/design-system/AGENTS.md
@@ -1,7 +1,7 @@
 # Design system
 
 `freehire-design-system` — tokens and Svelte primitives, a **pnpm** package sibling to
-`web/`, linked in as `file:../design-system`. `web/src/lib/ui/index.ts` is a thin re-export
+`web/`, linked in as `link:../design-system`. `web/src/lib/ui/index.ts` is a thin re-export
 surface, so app code imports from `$lib/ui` and never reaches into the package directly.
 It re-exports with `export *`, not a list: an enumerated list is a second copy of `src/index.ts`
 that nothing reconciles, and it drifted once already — eleven of the fifteen primitives were
@@ -18,6 +18,16 @@ rather than here — their census of `web/` was already off by a third.
 - **pnpm, not npm.** `pnpm install && pnpm build` here, then `pnpm install` in `web/`.
   Corepack activates the pinned version. There is no `package-lock.json` anywhere — adding
   one breaks the CI `design-system` → `web` job chain.
+- **`link:`, not `file:` — and the order matters.** `link:` is a bare symlink, so there is no
+  copy of this package to go stale; editing a token here is visible to `web` on its next build
+  with no install at all. It was `file:` until 2026-07-31, which copies into web's virtual
+  store keyed by name+version — and this package's version is a permanent `0.0.0`, so
+  `--frozen-lockfile` happily reused a copy from days earlier. That shipped an app referencing
+  `bg-warning` against a design system defining no such token: green release, colourless
+  badges. The price of the symlink is that **pnpm does not install a linked package's own
+  dependencies** — `tailwind-variants`, `clsx`, `tailwind-merge` and `@lucide/svelte` resolve
+  from `design-system/node_modules`, so **install here before building `web/`** or the build
+  dies with `MODULE_NOT_FOUND`. Loud, which is the trade.
 - **`src/theme.css` is the package's CSS contract, and every consumer imports it.** It holds
   the token imports, the `@source` scan, and the `@theme inline` bridge. `web/src/app.css`
   and `.storybook/preview.css` each `@import` it and add only what is theirs (the typography

--- a/web/package.json
+++ b/web/package.json
@@ -58,6 +58,6 @@
     "satori-html": "^0.3.2",
     "shiki": "^4.3.1",
     "svelte-dnd-action": "^0.9.70",
-    "freehire-design-system": "file:../design-system"
+    "freehire-design-system": "link:../design-system"
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^7.5.0
         version: 7.5.0
       freehire-design-system:
-        specifier: file:../design-system
-        version: file:../design-system(svelte@5.56.7(@typescript-eslint/types@8.65.0))(tailwindcss@4.3.3)
+        specifier: link:../design-system
+        version: link:../design-system
       isomorphic-dompurify:
         specifier: ^3.18.0
         version: 3.19.0
@@ -1741,12 +1741,6 @@ packages:
 
   flatted@3.4.3:
     resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
-
-  freehire-design-system@file:../design-system:
-    resolution: {directory: ../design-system, type: directory}
-    peerDependencies:
-      svelte: ^5
-      tailwindcss: ^4
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4254,15 +4248,6 @@ snapshots:
 
   flatted@3.4.3: {}
 
-  freehire-design-system@file:../design-system(svelte@5.56.7(@typescript-eslint/types@8.65.0))(tailwindcss@4.3.3):
-    dependencies:
-      '@lucide/svelte': 1.25.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))
-      clsx: 2.1.1
-      svelte: 5.56.7(@typescript-eslint/types@8.65.0)
-      tailwind-merge: 3.6.0
-      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
-      tailwindcss: 4.3.3
-
   fsevents@2.3.3:
     optional: true
 
@@ -4980,7 +4965,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwind-merge@3.6.0: {}
+  tailwind-merge@3.6.0:
+    optional: true
 
   tailwind-variants@3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3):
     dependencies:


### PR DESCRIPTION
Root-causes the incident that shipped colourless caution badges to production this morning.

## The defect

`file:` makes pnpm **copy** the package into web's virtual store and key the copy by name+version — and this package's version is a permanent `0.0.0`. So `pnpm install --frozen-lockfile` reuses a copy from days earlier however much the package changed. Neither `--force` nor deleting the store entry moves it; only `rm -rf web/node_modules` does.

Two incidents in two days:

- **2026-07-30, loud** — #1300 failed to build against a `theme.css` the copy did not have.
- **2026-07-31, silent** — prod shipped markup referencing `bg-warning` against a design system defining no such token. The class was in the HTML, no rule was in the CSS, and every caution badge rendered with no colour. Green release, 200 from `/health`, 2477 assets. The only external tell was a CSS asset hash that did not change while `version.json` did.

## The fix

`link:` is a bare symlink. **There is no copy, so there is nothing to go stale.** Verified by adding a token to the package and rebuilding web with no install at all — it reaches the bundle. It also makes local design-system work visible to `web` immediately, which until now needed `rm -rf web/node_modules`.

## The price, and why it is worth paying

pnpm does not install a linked package's own dependencies. `tailwind-variants`, `clsx`, `tailwind-merge` and `@lucide/svelte` resolve from `design-system/node_modules`, so it must be installed before web builds — the new CI step, and the matching one in freehire-ops#18.

Verified both ways:

| | |
|---|---|
| without the install | web build **exits 1**, `MODULE_NOT_FOUND` |
| with it | 605 web tests, 91 package tests, 0 svelte-check errors, lint clean, every token present in the bundle |

**A loud failure in place of a silent one is the whole trade.**

## Deploy order

freehire-ops#18 must reach `/opt/freehire/bin/release.sh` **before** this merges, or the first release after it dies at the web build. I will sequence it.