### PR TITLE
Ghost-jobs landing: draw the signal instead of describing it

### DIFF
--- a/openspec/changes/ghost-jobs-landing-redesign/.openspec.yaml
+++ b/openspec/changes/ghost-jobs-landing-redesign/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/ghost-jobs-landing-redesign/design.md
+++ b/openspec/changes/ghost-jobs-landing-redesign/design.md
@@ -1,0 +1,180 @@
+## Context
+
+`GhostLandingView.svelte` is 256 lines rendering eight stacked sections. It is built on a
+good idea that this change keeps: the page renders from the product's own vocabulary rather
+than from copy. `GHOST_SIGNALS` is derived from `CRITERIA` in `$lib/ghost`, and
+`ghostSignals.test.ts` fails when a criterion joins the vocabulary without an explanation;
+`GHOST_FAQ` feeds both the visible FAQ and `faqPageJsonLd`, so schema and page cannot
+disagree. The two live previews already render the real `GhostBadge` and `GhostChecklist`
+rather than screenshots or copied markup.
+
+What it lacks is any graphic. Four criteria, two tiers, two gates and a prevalence range are
+all stated in prose at a uniform `text-sm text-muted-foreground`, and the reader arriving
+from the job page's "How this works" link has to mine ~2,500 words for the two facts they
+came for.
+
+Three existing constraints shape everything below:
+
+- **`ghostBadge()` does not compute the level.** It reads `ghost.level` from the served
+  payload. The gate rule lives in `internal/ghost` and has no frontend counterpart at all.
+- **The escalation palette is partly migrated to semantic tokens.** `GhostChecklist` now
+  uses `bg-warning` and `text-warning-strong` alongside raw ladder tones, and carries an
+  explicit rule that an unfired criterion is never drawn in a reassuring colour.
+- **`web/`'s vitest suite tests pure `.ts` modules.** There is one `.svelte.test.ts`, for
+  runes, not component rendering.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Answer the arriving reader's two questions — which criteria fired, and why the level is
+  not higher — above the fold and in pictures.
+- Cut visible copy to roughly a fifth without deleting a single honesty caveat.
+- Make the level rule checkable by a test instead of asserted in prose.
+- Keep the page's existing anti-drift property: nothing on it may describe an interface or a
+  vocabulary the product no longer has.
+
+**Non-Goals:**
+
+- No change to `internal/ghost`, any worker, the API, or the database.
+- No new visual identity. The page stays in the `/features` language — `SectionLabel`,
+  design-system tokens, hairline grids — and does not become a showcase.
+- No chart library. These are mechanic diagrams, not plots.
+- No refactor of `GhostChecklist` onto the new disclosure primitive.
+- No strengthening of any claim the page makes about employers.
+
+## Decisions
+
+### `ghostLevel()` in `$lib/ghost.ts`, not a lookup table and not an endpoint
+
+The sandbox needs a level for an arbitrary selection of criteria, and nothing in the
+frontend can produce one. Three options were considered.
+
+A **precomputed fixture table** mapping selections to payload literals introduces no
+"logic", but the mapping *is* the logic, hidden where no test would think to check it. A
+**preview endpoint** returning the real classifier's verdict eliminates drift entirely, at
+the cost of a public route existing for a marketing page and a network round-trip behind a
+checkbox — overengineering by this repo's own standard.
+
+The chosen option is a three-line pure function beside `CRITERIA`, with the two gate
+constants moved there from `ghostSignals.ts` and re-exported. The reasoning that settles it:
+the frontend **already** mirrors `CONVERGENCE` and `WITNESS_GATE`, and the landing already
+asserts the gate rule — in English, where no test can reach it. This does not add a mirror;
+it moves an existing one out of prose into a tested function and consolidates it from two
+modules into the one that declares itself the mirror of `internal/ghost`.
+
+### Pure geometry modules for two diagrams, not six
+
+`activityChart.ts` sets the precedent, with its rationale in the file: geometry lives in
+`.ts` so the bug-prone scaling math is unit-testable, and `ActivityBars.svelte` is a dumb
+renderer.
+
+That applies to the prevalence waffle, whose 100 cell states derive from the published
+range, and to the gate matrix, whose four cells derive from `ghostLevel`. Both genuinely
+compute, and both would fail silently if wrong.
+
+It does not apply to the four criterion diagrams. Those are drawings with literal
+coordinates; routing them through a model would be ceremony for symmetry's sake, which the
+project's working principles call out directly.
+
+### The diagram registry is exhaustive by type, not by test
+
+The original plan asserted "every criterion has a diagram" from a unit test. Probed before
+any diagram was drawn, that turns out to be unreachable here: vitest in this project fails
+on a `.svelte` import twice over — the `$lib` alias does not resolve, and with a relative
+path the component reaches `vite:import-analysis` untransformed, because the svelte plugin
+does not apply in the test environment. Making it work means adding jsdom, a Svelte testing
+library and plugin configuration — a test-infrastructure change well outside a landing-page
+redesign. The documented fallback (export the registry's keys for the test) fails for the
+same reason: importing the registry pulls its `.svelte` imports along.
+
+The replacement is stronger than what it replaces. `CRITERIA` gains
+`as const satisfies readonly {...}[]`, which checks the shape without widening the inferred
+type, and a `GhostCriterionCode` union is derived from it. The dispatcher's registry is
+typed `Record<GhostCriterionCode, Component>`, so a criterion with no diagram is a
+compile error — `TS2741`, caught by `pnpm run check` in CI, visible in the editor, and
+impossible to leave unwritten. `.map` and `.flatMap` on the now-readonly array are
+unaffected, so `ghostChecklist` and `ghostSignals` need no change.
+
+`as const` alone would give the literal codes but lose the shape check, letting a
+mistyped `tier` through silently. The existing explicit annotation checks the shape but
+widens `code` to `string`, leaving nothing to build a union from. `satisfies` is what
+does both.
+
+### Native `<details>` for twelve disclosures
+
+The page will hold eight FAQ disclosures and four criterion disclosures.
+`GhostChecklist`'s hand-rolled pattern — button, `aria-expanded`, `aria-controls`, an
+always-mounted panel toggled between `flex` and `hidden` — is justified there by a trigger
+row containing a gauge, a chip and a chevron, and by two non-obvious traps its comments
+record: the `aria-controls` IDREF must resolve in the collapsed state, and Tailwind's
+`hidden` utility is required because the `flex` class beats the HTML attribute's
+`display: none`.
+
+None of that applies to a plain disclosure. `<details>/<summary>` gives the expanded state
+and the trigger-content association from the platform, operates without client JS under
+SSR, and keeps collapsed text in the DOM for `faqPageJsonLd`. A thin `Disclosure.svelte`
+wraps it for styling only.
+
+`GhostChecklist` is deliberately not migrated: it is a product component imported by the job
+card, and rewriting it is not a side effect of editing a landing page. The seam is noted, not
+taken.
+
+### Diagrams are `aria-hidden`, following the gauge
+
+Each criterion's name, example observations and summary sit beside its diagram as text
+carrying the same information. The gauge in `GhostChecklist` is `aria-hidden` for exactly
+this reason, with the reasoning written down: a screen reader gains nothing from unlabelled
+shapes. The diagrams inherit the treatment and the justification.
+
+### The evergreen diagram drops the time axis
+
+The criterion's example text opens with "Open 240 days", which invites a timeline. Measured
+on the live catalogue, none of the 16,461 open postings carrying a fresh stamp are older
+than the 90-day threshold: the marked ones converge through repost and concurrent-copy
+thresholds instead. A timeline would be the most legible element on the page and would name
+the wrong cause to a reader who came to find out why their posting is marked. The diagram
+shows the stack of concurrent copies and a repost count, and no axis.
+
+### `gist` beside `why`, rather than a shortened `why`
+
+`why` carries the caveats the feature's ethics rest on — that the board criterion counts
+only where the board is crawled, that silence counts only behind a connected mailbox. Those
+cannot be cut to fit a card. `SignalExplainer` gains a short `gist` for the always-visible
+line, `why` moves under the disclosure unchanged, and `ghostSignals.test.ts` grows to
+require both.
+
+## Risks / Trade-offs
+
+**A frontend mirror of the gate rule can drift from `internal/ghost`.** → The constants were
+already mirrored, so this adds no new class of drift; it converts an unverifiable prose
+claim into a tested function and puts it in the single module that announces itself as the
+mirror. A threshold change in Go now has one frontend place to look instead of three.
+
+**The "every criterion has a diagram" assertion cannot be a unit test here.** → Probed and
+settled before any diagram was drawn: vitest cannot import a `.svelte` component in this
+project without new test infrastructure. The invariant moved to the type system instead, as
+a `Record<GhostCriterionCode, Component>` the compiler must see satisfied. A duplicated list
+of criterion codes was rejected outright — a list that can drift from the registry defeats
+the assertion it exists to make.
+
+**Diagrams built from semantic tokens can collapse into one tone in dark mode**, taking
+hatching and hollow outlines with them. → Both themes are verified visually before the change
+is called done; the states that carry meaning by texture rather than hue are the ones to
+check.
+
+**Cutting ~2,000 visible words costs organic search on a page that currently ranks on
+long-form text.** → Accepted deliberately: the primary audience is the in-product reader
+arriving from the checklist link. The mitigation is that almost nothing is deleted — the text
+moves behind disclosures and stays in the served HTML, and `GHOST_FAQ` and its structured
+data are untouched.
+
+**`GhostLandingView` could simply grow to 600 lines.** → The six diagrams, the sandbox and
+the disclosure wrapper move into `components/ghost/`, following the existing subdirectory
+convention. `GhostBadge` and `GhostChecklist` stay put; they belong to the product, not the
+landing.
+
+## Open Questions
+
+None. The one unknown — whether vitest resolves a registry importing `.svelte` — was
+probed first and answered no; see the registry decision above for what replaced it.

--- a/openspec/changes/ghost-jobs-landing-redesign/proposal.md
+++ b/openspec/changes/ghost-jobs-landing-redesign/proposal.md
@@ -1,0 +1,83 @@
+## Why
+
+`/features/ghost-jobs` is the page a reader reaches from the "How this works" link in the
+job page's ghost row — they arrive mid-question, having just seen a mark they did not
+understand. What they find is eight stacked sections and roughly 2,500 words of uniform
+small grey text, with no illustration of any kind: every mechanic the signal runs on is
+prose. The two things that actually answer their question — which criteria fired, and why
+the warning is not stronger — are the hardest things on the page to extract.
+
+The feature is inherently quantitative and structural: four criteria, two tiers, two
+independent gates, a published prevalence range. All of it is drawable, and none of it is
+drawn.
+
+## What Changes
+
+- **Eight sections become five**, plus a collapsed FAQ and a shortened closing CTA. The
+  "what you actually see" section and the tier-explaining paragraph are absorbed by the
+  new gate section; the "line we do not cross" section is compressed from a full section
+  into a two-line contrast in the hero, keeping its deliberate placement above the
+  mechanics.
+- **Six diagrams are added.** A 100-cell prevalence waffle showing the 18–27% range as a
+  band rather than a fake-precise number; one diagram per criterion; and a 2×2 gate matrix
+  that makes "structural evidence can never reach `likely`" geometric instead of a clause
+  in a sentence.
+- **The static preview becomes an interactive sandbox.** Four criterion toggles and a
+  three-position contributor control drive the *real* `GhostBadge` and `GhostChecklist`,
+  fed a `Ghost` assembled on the fly. The reader discovers the ceiling by failing to reach
+  `likely` with structural criteria alone.
+- **`ghostLevel()` joins `$lib/ghost.ts`**, and `CONVERGENCE` / `WITNESS_GATE` move there
+  from `ghostSignals.ts` with a re-export left behind. The gate rule exists nowhere in the
+  frontend today — the landing asserts it in English prose that no test can check. This
+  trades an unverifiable claim for a unit-tested function and consolidates a mirror
+  currently smeared across two modules.
+- **`SignalExplainer` gains a `gist` field.** ~25 words visible per criterion; the existing
+  `why`, which carries the load-bearing honesty caveats, moves under a disclosure rather
+  than being cut. Visible copy drops from ~2,500 words to ~515, with ~1,000 more preserved
+  in the DOM behind disclosures.
+- **Twelve disclosures use native `<details>`** behind a thin styling wrapper, so the
+  collapsed FAQ text stays in the DOM for `faqPageJsonLd` and works without client JS under
+  SSR. `GhostChecklist` is deliberately not refactored onto it.
+- No API, worker, or database change. No copy claim is strengthened: every caveat the page
+  makes today it still makes, either visibly or one disclosure away.
+
+## Capabilities
+
+### New Capabilities
+
+- `ghost-jobs-feature-landing`: the composition of the `/features/ghost-jobs` page — its
+  section order, the six diagrams and what each is allowed to depict, the copy budget and
+  disclosure discipline, the colour rule the diagrams inherit, and the page's accessibility
+  treatment of decorative graphics.
+
+### Modified Capabilities
+
+- `ghost-job-signal`: the requirement *"The explaining page previews the signal with the
+  components that render it"* grows. The preview becomes interactive, and the frontend gains
+  a tested mirror of the gate rule so the page can demonstrate the level ladder rather than
+  assert it. The existing constraint — render the real components, never a copy or a
+  screenshot — is retained unchanged and now also binds the sandbox.
+
+## Impact
+
+**Frontend, `web/` only.**
+
+- `web/src/lib/ghost.ts` — gains `ghostLevel()`, `CONVERGENCE`, `WITNESS_GATE`.
+- `web/src/lib/ghostSignals.ts` — gains `gist` on `SignalExplainer`; its two constants
+  become re-exports from `$lib/ghost`.
+- `web/src/lib/components/GhostLandingView.svelte` — restructured; drops from 256 lines as
+  markup moves into the new subdirectory.
+- `web/src/lib/components/ghost/` — new: the six diagrams, the sandbox, the pure-geometry
+  module for the waffle and matrix, and a `Disclosure.svelte` styling wrapper.
+- Tests: `ghost.test.ts` and `ghostSignals.test.ts` extended; `ghostDiagrams.test.ts` and
+  `ghostFaq.test.ts` added. The ghost FAQ has no test today despite feeding JSON-LD.
+
+**Deliberately untouched:** `internal/ghost` and every worker; `GhostBadge.svelte` and
+`GhostChecklist.svelte`, which are product components imported by the job card; the
+`GHOST_FAQ` array itself, which stays intact so the visible block and the JSON-LD payload
+cannot disagree; and the route file's `<Seo>` and structured-data payload.
+
+**Risk to resolve first:** the "every criterion has a diagram" assertion must import a
+registry that pulls in `.svelte` files, and this vitest setup tests pure `.ts`. If that
+import does not resolve, the registry stays the single source and exposes its keys for the
+test rather than a duplicated code list being introduced.

--- a/openspec/changes/ghost-jobs-landing-redesign/specs/ghost-job-signal/spec.md
+++ b/openspec/changes/ghost-jobs-landing-redesign/specs/ghost-job-signal/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: The explaining page previews the signal with the components that render it
+
+The `/features/ghost-jobs` landing SHALL illustrate the signal by rendering the same components the
+product renders, fed illustrative payloads, and MUST NOT reproduce their markup as a copy.
+
+A copy is stale the moment the component is redesigned, and the page then describes an interface
+that no longer exists — to a reader who has come to it precisely because they did not understand
+what they saw. Screenshots fail the same way, and additionally freeze one theme and one employer's
+name.
+
+The preview SHALL be operable rather than fixed: the reader SHALL be able to select which criteria
+have fired and how many distinct people have contributed outcome evidence, and the components SHALL
+re-render from a payload assembled from that selection. The contributor control SHALL offer only the
+values that mean something relative to the gate — none, one, and enough — because a free count
+communicates nothing the gate does not already decide.
+
+To drive that preview the frontend SHALL hold the level rule as a tested function rather than as
+prose, deriving the level from the criteria that fired and the number of contributors, and that
+function SHALL live in the same module that already declares itself the mirror of the classifier's
+constants. The page today asserts the rule — that structural evidence alone cannot reach the higher
+level — in a sentence no test can check, so the claim can silently outlive the thresholds it
+describes. A mirrored rule can drift from the classifier, but the constants it depends on were
+already mirrored in the frontend; expressing the rule as a function makes the drift detectable
+instead of invisible, and gathers a mirror that was spread across two modules into one.
+
+#### Scenario: The preview follows a redesign
+
+- **WHEN** the job page's presentation of the signal changes shape
+- **THEN** the landing's preview changes with it, because it renders the same component rather than a copy of its markup
+
+#### Scenario: The preview carries the caveat
+
+- **WHEN** a reader reaches the landing's preview of the signal
+- **THEN** the observations-not-accusations caveat is stated on the page beside it
+
+#### Scenario: The reader drives the preview
+
+- **WHEN** a reader selects a different set of fired criteria in the preview
+- **THEN** the same chip, gauge and checklist the product renders update to the level and scale that
+  selection produces
+
+#### Scenario: The ceiling is discovered, not asserted
+
+- **WHEN** a reader selects both structural criteria and no contributors
+- **THEN** the preview holds at the lower level, and no control offered by the preview raises it to
+  the higher one
+
+#### Scenario: A single contributor yields no count
+
+- **WHEN** a reader sets the preview to one contributor
+- **THEN** the rendered row carries no contributor count, matching the payload the product serves
+  below the anonymity gate
+
+#### Scenario: The level rule is pinned by test
+
+- **WHEN** the frontend's level rule is exercised across the combinations of convergence and
+  contributor gates
+- **THEN** each combination yields the level the classifier defines, and no set of structural-only
+  criteria yields the higher level

--- a/openspec/changes/ghost-jobs-landing-redesign/specs/ghost-jobs-feature-landing/spec.md
+++ b/openspec/changes/ghost-jobs-landing-redesign/specs/ghost-jobs-feature-landing/spec.md
@@ -1,0 +1,165 @@
+## ADDED Requirements
+
+### Requirement: Public ghost-jobs feature landing page
+
+The frontend SHALL serve a public, unauthenticated page at `/features/ghost-jobs` that
+explains the ghost signal to a reader who is not signed in, and SHALL render its copy
+server-side so the initial HTML carries the explanatory text without client JavaScript.
+
+The page SHALL be composed of, in order: a hero, a criteria section, a section explaining
+how the level is decided, a section on how a reader contributes evidence, a section stating
+the limits of the system's coverage, a FAQ, and a closing call to action.
+
+The hero SHALL carry the contrast between what the system can check and what it never
+claims. That contrast SHALL appear above any explanation of the mechanics: the limit on the
+claim is the feature's most important property rather than a disclaimer, and a reader who
+stops after the hero must have read it.
+
+#### Scenario: Page is public and server-rendered
+
+- **WHEN** an anonymous visitor requests `GET /features/ghost-jobs`
+- **THEN** the response is 200 and its HTML body already contains the page headline and
+  section copy, with no sign-in redirect
+
+#### Scenario: The limit is stated before the mechanics
+
+- **WHEN** the page renders
+- **THEN** the statement of what the system never claims appears in the hero, above the
+  section explaining which criteria fire
+
+### Requirement: Every criterion the classifier weighs carries its own diagram
+
+The page SHALL render one diagram per criterion in the classifier's vocabulary, drawn from
+the same array the product's checklist reads, so a criterion cannot join the vocabulary and
+appear on the page as an empty cell.
+
+Each criterion SHALL be presented as its diagram, the criterion's name, an example of the
+observations behind it, and a short summary, with the full explanation available through a
+disclosure rather than deleted.
+
+#### Scenario: A criterion without a diagram fails the build
+
+- **WHEN** a criterion is present in the classifier vocabulary with no diagram registered
+- **THEN** the type check fails, rather than the page rendering a criterion with no
+  illustration
+
+#### Scenario: The criteria are grouped by tier
+
+- **WHEN** the criteria section renders
+- **THEN** the structural criteria and the outcome criteria are presented as two labelled
+  groups, so the reader can see which kind of evidence they are looking at
+
+### Requirement: The evergreen diagram depicts convergence, not age
+
+The diagram for the evergreen criterion SHALL depict reposting and concurrent duplicate
+postings as what makes the criterion fire, and MUST NOT depict elapsed time as the trigger.
+
+A criterion whose example text opens with a posting's age invites a time axis, but age
+alone does not fire it, and in the live catalogue effectively never does — the marked
+postings converge through repost and duplicate-copy thresholds instead. A diagram
+foregrounding a timeline would tell the reader the wrong reason their posting is marked,
+which is the one question that brought them to the page.
+
+#### Scenario: The diagram foregrounds duplicate copies
+
+- **WHEN** the evergreen criterion's diagram renders
+- **THEN** it depicts multiple concurrent copies of one posting and a repost count, and
+  presents no time axis as the criterion's cause
+
+### Requirement: The prevalence figure is shown as a range
+
+The page SHALL present the share of listings that are not being worked as the published
+range rather than a single number, and the graphic depicting it SHALL distinguish the
+lower bound from the uncertain band above it.
+
+A single averaged figure would claim a precision the underlying studies do not have, on a
+page whose entire argument is that it states only what it can check.
+
+#### Scenario: The band is visible as a band
+
+- **WHEN** the prevalence graphic renders
+- **THEN** the cells representing the lower bound are distinguishable from those
+  representing the remainder of the range
+
+### Requirement: Diagrams inherit the signal's no-reassurance colour rule
+
+A diagram element standing for a criterion that did not fire, for evidence that was not
+counted, or for a check that was not performed SHALL be rendered in a neutral tone, and
+MUST NOT be rendered in a tone that reads as reassurance.
+
+This is the constraint that already governs the gauge's uncoloured segments, and it binds
+the page's diagrams for the same reason: the system distinguishes a criterion that fired
+from one that did not, and never a criterion checked and found clear from one with nothing
+to check. A reassuring colour would assert a difference the data does not carry.
+
+#### Scenario: An uncounted lane claims nothing
+
+- **WHEN** a diagram depicts evidence that was not counted, such as an application whose
+  owner has no connected mailbox
+- **THEN** that element renders in a neutral tone rather than one reading as cleared or safe
+
+#### Scenario: An unjudged criterion is shown as unjudged
+
+- **WHEN** the diagram for the company-board criterion renders
+- **THEN** it distinguishes three states — the role found, the role absent from a board the
+  system crawls, and a company whose board the system does not crawl and therefore does not
+  judge at all
+
+### Requirement: Counts below the anonymity gate are drawn as absent
+
+A diagram depicting outcome evidence below the contributor gate SHALL render the count as
+absent rather than as a zero or a suppressed value.
+
+The served payload omits the field entirely below the gate, because a count of one
+identifies the single person who applied to the employer. A diagram showing "0" or a
+redacted placeholder would depict a system that holds the number and withholds it, which is
+not the system that exists.
+
+#### Scenario: One contributor renders no count
+
+- **WHEN** a diagram or the sandbox depicts outcome evidence from a single contributor
+- **THEN** no count is rendered, and the space where a count would sit is shown as carrying
+  no value
+
+### Requirement: Diagrams are decorative to assistive technology
+
+Each diagram SHALL be hidden from assistive technology, and the criterion's name, example
+observations and summary SHALL sit beside it as text carrying the same information.
+
+A screen reader gains nothing from an unlabelled arrangement of shapes, and the page already
+states every fact the diagrams depict in prose. This follows the treatment the product's own
+gauge receives for the same reason.
+
+#### Scenario: The diagram is skipped and nothing is lost
+
+- **WHEN** a screen reader traverses the criteria section
+- **THEN** the diagrams are not announced, and the criterion's name, example and summary are
+
+### Requirement: Long-form copy is disclosed rather than deleted
+
+The page SHALL keep the full explanation of each criterion and the full FAQ in the served
+HTML, presenting them behind disclosure controls that are collapsed on first paint.
+
+Disclosures SHALL work without client JavaScript, so a server-rendered first paint is
+operable and the collapsed text is present for the page's structured data.
+
+The FAQ SHALL continue to render from the same array that builds the page's FAQ structured
+data, so the two cannot disagree.
+
+#### Scenario: Collapsed text is still served
+
+- **WHEN** an anonymous visitor requests the page and does not expand anything
+- **THEN** the HTML body contains the full text of every FAQ answer and every criterion
+  explanation
+
+#### Scenario: A disclosure opens without client JavaScript
+
+- **WHEN** a reader activates a disclosure control on a page whose client JavaScript has not
+  run
+- **THEN** the content expands
+
+#### Scenario: The FAQ and its structured data share one source
+
+- **WHEN** a FAQ entry is added, edited or removed
+- **THEN** both the visible FAQ and the page's FAQ structured data change together, because
+  they render from the same array

--- a/openspec/changes/ghost-jobs-landing-redesign/tasks.md
+++ b/openspec/changes/ghost-jobs-landing-redesign/tasks.md
@@ -1,0 +1,70 @@
+## 1. Resolve the test-harness unknown first
+
+- [x] 1.1 Prove whether vitest resolves a module that imports `.svelte` components — ANSWERED NO: the `$lib` alias does not resolve under vitest, and a relative import reaches `vite:import-analysis` untransformed because the svelte plugin does not apply in the test environment. Recorded in `design.md` under Decisions
+- [x] 1.2 The documented fallback also fails — importing the registry for its keys pulls its `.svelte` imports along. Replaced by a compile-time invariant: `CRITERIA` gains `as const satisfies`, a `GhostCriterionCode` union is derived from it, and the dispatcher's registry is typed `Record<GhostCriterionCode, Component>` so a missing diagram is `TS2741`. No second list of criterion codes is introduced
+- [x] 1.3 Apply that change to `web/src/lib/ghost.ts`: `as const satisfies readonly {...}[]` on `CRITERIA`, plus an exported `GhostCriterionCode`; confirm `ghostChecklist` and `ghostSignals` still compile against the now-readonly array
+
+## 2. The level rule, test-first
+
+- [x] 2.1 RED: extend `web/src/lib/ghost.test.ts` with `ghostLevel(criteria, contributors)` covering all four gate combinations — neither gate, convergence only, witnesses only, both
+- [x] 2.2 RED: add the property test that no structural-only criteria set yields `likely`, exercising every subset of the structural codes
+- [x] 2.3 GREEN: implement `ghostLevel` in `web/src/lib/ghost.ts` beside `CRITERIA`, with a comment naming `internal/ghost` as the authority it mirrors
+- [x] 2.4 Move `CONVERGENCE` and `WITNESS_GATE` from `ghostSignals.ts` into `ghost.ts`; run the full web suite. The re-export planned here was added and then removed in task 8.7: once the gate matrix interpolated the constants instead of the page quoting them in prose, every consumer imported from `ghost.ts` directly and the re-export was left feeding only its own test
+
+## 3. Copy vocabulary
+
+- [x] 3.1 RED: extend `web/src/lib/ghostSignals.test.ts` to require a non-empty `gist` on every criterion as well as a `why`. The diagram-per-criterion invariant is NOT tested here — task 1 settled it as a compile-time check
+- [x] 3.2 GREEN: add `gist` to `SignalExplainer` and write one ~25-word summary per criterion, leaving every existing `why` unchanged
+- [x] 3.3 Add `web/src/lib/ghostFaq.test.ts` modelled on `tailorFaq.test.ts` — non-empty questions and answers, no duplicate questions, and the FAQPage payload matching the visible list. The intent-word blacklist that guards GHOST_SIGNALS is deliberately absent: a FAQ voices the reader's suspicion in order to refuse it, so the check flags good copy and can only be satisfied by blunting it. Reasoning recorded in the file
+
+## 4. Pure geometry
+
+- [x] 4.1 RED: add `web/src/lib/ghostDiagrams.test.ts` asserting the waffle model yields exactly 100 cells, that the solid count matches the range's lower bound and the hatched count the width of the band
+- [x] 4.2 RED: extend that test so the gate matrix model's four cells are produced by `ghostLevel` rather than literal strings, and so each cell's axis labels are checked against the example it carries — a mislabelled axis leaves every level correct and the diagram still wrong
+- [x] 4.3 GREEN: implement the waffle and matrix models in `web/src/lib/ghostDiagrams.ts`, following the `activityChart.ts` precedent — geometry in `.ts`, no rendering
+
+## 5. Diagram components
+
+- [x] 5.1 Add `web/src/lib/components/ghost/Prevalence.svelte` and `GateMatrix.svelte` as dumb renderers of the task-4 models
+- [x] 5.2 Add `diagrams/Evergreen.svelte` — a stack of concurrent copy silhouettes and a repost count, with NO time axis
+- [x] 5.3 Add `diagrams/AtsAbsent.svelte` — three states: role found, role absent from a crawled board with a check-age stamp, and a set-apart muted panel for a board not crawled and therefore not judged
+- [x] 5.4 Add `diagrams/Silent.svelte` — three lanes: window elapsed with no reply (counts), reply arrived (does not count), no connected mailbox drawn hollow (not counted at all)
+- [x] 5.5 Add `diagrams/Reports.svelte` — one contributor versus two, where the count field below the gate is drawn as carrying no value rather than as a zero
+- [x] 5.6 Wire the registry so `SignalDiagram.svelte` dispatches on criterion code, typed `Record<GhostCriterionCode, Component>`; verify by temporarily deleting one entry that `pnpm run check` reports `TS2741`, then restore it
+- [x] 5.7 Verify every diagram against the colour rule: nothing not-fired, not-counted or not-judged may render in a reassuring tone, and no green appears anywhere
+
+## 6. Disclosure primitive
+
+- [x] 6.1 Add `web/src/lib/components/ghost/Disclosure.svelte` wrapping native `<details>/<summary>` for styling only
+- [x] 6.2 Confirm it operates with client JavaScript disabled and that collapsed content is present in the server-rendered HTML
+- [x] 6.3 Leave `GhostChecklist.svelte` on its hand-rolled disclosure; add no migration
+
+## 7. The sandbox
+
+- [x] 7.1 Add `web/src/lib/components/ghost/GhostSandbox.svelte` — four criterion toggles plus a three-position contributor control (none / one / enough)
+- [x] 7.2 Assemble a `Ghost` from that state via `ghostLevel` and render the real `GhostBadge` and `GhostChecklist`, importing them rather than reproducing their markup
+- [x] 7.3 Confirm by hand: both structural criteria with no contributors holds at the lower level with no control able to raise it, and one contributor renders no count
+
+## 8. Page restructure
+
+- [x] 8.1 Rewrite `GhostLandingView.svelte` to the five-section order — hero, criteria, how the level is decided, your part, where it is blind — plus FAQ and closing CTA
+- [x] 8.2 Compress "the line we do not cross" into a two-line contrast inside the hero, keeping it above the mechanics; place the prevalence waffle beneath it
+- [x] 8.3 Build the criteria section as two tier-labelled groups, each cell carrying diagram, name, `fact`, `gist` and a disclosure holding `why`
+- [x] 8.4 Replace the "what you actually see" section and the tier-explaining paragraph with the gate matrix and the sandbox
+- [x] 8.5 Reduce "your part" to two numbered items — report manually, connect a mailbox — keeping the "without a connected mailbox nothing is counted" wording verbatim
+- [x] 8.6 Move the FAQ onto `Disclosure`, collapsed, still rendering from `GHOST_FAQ`; leave the route file's `<Seo>` and JSON-LD untouched
+- [x] 8.7 Delete the markup orphaned by the restructure and confirm no unused import or dead helper is left behind
+
+## 9. Verification
+
+- [x] 9.1 Run the full web test suite; run `pnpm run check` and the linter, comparing against the pre-change baseline rather than expecting zero
+- [x] 9.2 Visually verify light and dark themes, checking that hatching, hollow lanes and the empty count slot stay distinguishable in dark
+- [x] 9.3 Verify at a real narrow viewport rather than trusting a `--window-size` flag below ~500px
+- [ ] 9.4 Walk the primary entry path end to end: from a marked job's checklist, follow "How this works" and confirm the page answers which criteria fired and why the level is not higher. PARTIAL — the destination is verified (the link target returns 200 and the page is server-rendered), but the walk from an actually-marked job needs a running API and a job carrying a live stamp, neither of which exists in this worktree. Do it against a deployed build before merging
+- [x] 9.5 Confirm the served HTML still contains every FAQ answer and every criterion `why` with nothing expanded, and that the FAQ structured data still matches the visible list
+
+## 10. Close out
+
+- [ ] 10.1 Request code review on the whole diff and act on Critical and Important findings
+- [ ] 10.2 Finish the branch, then archive and sync the change
+- [ ] 10.3 Offer a changelog entry — the page is user-facing, and the ghost signal's own entry was deferred until the signal actually fired

--- a/openspec/changes/ghost-jobs-landing-redesign/tasks.md
+++ b/openspec/changes/ghost-jobs-landing-redesign/tasks.md
@@ -65,6 +65,6 @@
 
 ## 10. Close out
 
-- [ ] 10.1 Request code review on the whole diff and act on Critical and Important findings
+- [x] 10.1 Request code review on the whole diff and act on Critical and Important findings. Fixed: the lint ERROR that broke CI (my verification grepped for "warning" and so never saw it — check the exit code, not a summary of the output); a new sentence claiming nothing shows below two criteria, which the gate matrix three lines below it visibly refutes; the sandbox guard running only one way; the waffle band separated from the remainder by hue alone in dark; four disclosures sharing one accessible name; the matrix rendered as divs rather than a table. Declined: typing EXPLAINERS by the criterion union, because dropping an unexplained criterion rather than failing to compile is documented behaviour and changing it is not this change's business
 - [ ] 10.2 Finish the branch, then archive and sync the change
 - [ ] 10.3 Offer a changelog entry — the page is user-facing, and the ghost signal's own entry was deferred until the signal actually fired

--- a/web/src/lib/components/GhostLandingView.svelte
+++ b/web/src/lib/components/GhostLandingView.svelte
@@ -99,7 +99,10 @@
                 <p class="text-sm font-medium">{s.label}</p>
                 <p class="font-mono text-xs text-muted-foreground">{s.fact}</p>
                 <p class="text-sm leading-relaxed text-muted-foreground">{s.gist}</p>
-                <Disclosure summary="The full account" class="mt-1">
+                <!-- Named per criterion: four controls all reading "The full account" are
+                     indistinguishable in a list of controls, and the card titles beside
+                     them are paragraphs rather than headings. -->
+                <Disclosure summary="The full account — {s.label}" class="mt-1">
                   <p
                     class="mt-2 border-l border-border pl-3 text-sm leading-relaxed text-muted-foreground"
                   >
@@ -119,8 +122,9 @@
   <section class="flex flex-col gap-6">
     <SectionLabel text="why the level is what it is" />
     <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
-      Two separate gates, and the wording depends on how many pass. Nothing shows at all
-      until at least two criteria fire — one on its own is ordinary.
+      Two separate gates, and the wording depends on how many pass. Pass neither and
+      nothing is shown at all — a lone criterion with nobody behind it is too ordinary to
+      mean anything.
     </p>
 
     <GateMatrix />

--- a/web/src/lib/components/GhostLandingView.svelte
+++ b/web/src/lib/components/GhostLandingView.svelte
@@ -1,213 +1,179 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { Button } from '$lib/ui';
-  import GhostBadge from '$lib/components/GhostBadge.svelte';
-  import GhostChecklist from '$lib/components/GhostChecklist.svelte';
+  import Disclosure from '$lib/components/ghost/Disclosure.svelte';
+  import GateMatrix from '$lib/components/ghost/GateMatrix.svelte';
+  import GhostSandbox from '$lib/components/ghost/GhostSandbox.svelte';
+  import Prevalence from '$lib/components/ghost/Prevalence.svelte';
+  import SignalDiagram from '$lib/components/ghost/SignalDiagram.svelte';
   import NumberedGrid from '$lib/components/NumberedGrid.svelte';
   import SectionLabel from '$lib/components/SectionLabel.svelte';
-  import type { Ghost } from '$lib/generated/contracts';
   import { GHOST_FAQ } from '$lib/ghostFaq';
-  import { ghostBadge } from '$lib/ghost';
-  import { CONVERGENCE, GHOST_SIGNALS, WITNESS_GATE } from '$lib/ghostSignals';
+  import { GHOST_SIGNALS } from '$lib/ghostSignals';
 
-  // The signals render from the same array the checklist reads, so this page cannot
-  // fall behind the product — ghostSignals.test.ts fails if a criterion joins the
-  // vocabulary without an explanation. See hire-features-landing-space.
-  const structural = $derived(GHOST_SIGNALS.filter((s) => s.tier === 'structural'));
-  const outcome = $derived(GHOST_SIGNALS.filter((s) => s.tier === 'outcome'));
-
-  // Previews are the REAL components fed illustrative payloads, never screenshots and
-  // no longer hand-copied markup. A screenshot is light-theme, carries a real
-  // employer's name, and freezes a UI that changes; a copy of the markup goes stale
-  // the first time the component is redesigned, which is exactly what happened when
-  // the checklist panel became a gauge row. Rendering the components means this page
-  // cannot describe an interface that no longer exists.
-  const checkedAt = new Date(Date.now() - 2 * 86_400_000).toISOString();
-
-  const possible: Ghost = {
-    level: 'possible',
-    criteria: ['evergreen_posting', 'ats_absent'],
-    criteria_total: 4,
-    ats_checked_at: checkedAt,
-  };
-
-  const likely: Ghost = {
-    level: 'likely',
-    criteria: ['evergreen_posting', 'ats_absent', 'silent_applications'],
-    criteria_total: 4,
-    contributors: WITNESS_GATE,
-    ats_checked_at: checkedAt,
-  };
-
-  // The prose names each level by asking the projection, so the page cannot caption a
-  // chip with wording the product has since changed.
-  const levels = [
+  // The page a reader reaches from the "How this works" link on a marked job. They arrive
+  // mid-question, having just seen a badge they did not understand, and the two things
+  // they want are which criteria fired and why the warning is not stronger. Both are now
+  // drawn rather than described: the criteria carry a diagram each, and the level rule is
+  // a matrix plus a preview the reader can drive.
+  //
+  // The signals still render from the same array the product's checklist reads, so this
+  // page cannot fall behind the vocabulary — ghostSignals.test.ts fails if a criterion
+  // joins without an explanation, and the diagram registry fails to COMPILE if it joins
+  // without an illustration. See hire-features-landing-space.
+  const groups = $derived([
     {
-      chip: ghostBadge(possible)!.label,
-      when: `${CONVERGENCE} criteria fired, but nobody who applied has told us anything`,
-      ghost: possible,
+      heading: 'The shape of the posting',
+      items: GHOST_SIGNALS.filter((s) => s.tier === 'structural'),
     },
     {
-      chip: ghostBadge(likely)!.label,
-      when: `at least ${WITNESS_GATE} different people who applied went unanswered, and something else fired too`,
-      ghost: likely,
+      heading: 'What happened to applicants',
+      items: GHOST_SIGNALS.filter((s) => s.tier === 'outcome'),
     },
-  ];
+  ]);
 </script>
 
-<article class="flex flex-col gap-14">
-  <!-- Hero. The number does the arguing; the promise is deliberately small. -->
-  <header class="flex flex-col gap-5">
+<article class="flex flex-col gap-16">
+  <!-- Hero. The limit on the claim sits here rather than in a section of its own: it is
+       the feature's most important property, not a disclaimer, and a reader who stops
+       after the first screen must still have read it. -->
+  <header class="flex flex-col gap-6">
     <SectionLabel text="ghost jobs" />
     <h1 class="max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl">
       Some postings are not being filled. freehire tells you which, and why it thinks so.
     </h1>
     <p class="max-w-2xl text-base leading-relaxed text-muted-foreground">
-      Between 18% and 27% of listings on the big boards are jobs nobody is working to fill —
-      kept up to collect CVs, to look like growth, or because nobody took them down. You cannot
-      tell from the page. Every hour spent on one is unpaid work you will never hear about.
+      You cannot tell from the page, and every hour spent on one is unpaid work you will
+      never hear about. So freehire watches two things it can actually check: how a posting
+      behaves over time, and what happened to people who applied.
     </p>
-    <p class="max-w-2xl text-base leading-relaxed">
-      freehire watches two things it can actually check: how a posting behaves over time, and
-      what happened to people who applied. When enough of them line up, the job carries a mark
-      —&nbsp;and the facts behind it.
-    </p>
+
+    <dl
+      class="flex max-w-3xl flex-col gap-2 border-l-2 border-border pl-4 text-sm leading-relaxed"
+    >
+      <div>
+        <dt class="inline font-medium">What we can check —</dt>
+        <dd class="inline text-muted-foreground">
+          “open 240 days, reposted 13 times, seven copies live at once, and absent from the
+          employer's own careers board.” Every part is verifiable, and every part is shown
+          to you.
+        </dd>
+      </div>
+      <div>
+        <dt class="inline font-medium text-muted-foreground">What we never claim —</dt>
+        <dd class="inline text-muted-foreground">
+          “this company is not really hiring.” That is a claim about somebody's intent,
+          which no amount of data here can observe.
+        </dd>
+      </div>
+    </dl>
+
+    <Prevalence />
+
     <div class="flex flex-wrap gap-3">
       <Button href={resolve('/jobs')} variant="primary" size="lg">Browse jobs</Button>
-      <Button href={resolve('/my/tracking')} variant="ghost" size="lg">Track your applications</Button>
+      <Button href={resolve('/my/tracking')} variant="ghost" size="lg">
+        Track your applications
+      </Button>
     </div>
   </header>
 
-  <!-- What it will not say. Placed before the mechanics on purpose: the limit is the
-       feature's most important property, not a disclaimer at the bottom. -->
-  <section class="flex flex-col gap-4">
-    <SectionLabel text="the line we do not cross" />
-    <div class="grid gap-4 sm:grid-cols-2">
-      <div class="rounded-lg border border-border p-4">
-        <p class="mb-1.5 text-sm font-medium">What we can check</p>
-        <p class="text-sm leading-relaxed text-muted-foreground">
-          “Open 240 days, reposted 13 times, seven copies live at once, and absent from the
-          employer's own careers board.” Every part of that is verifiable, and every part is
-          shown to you.
-        </p>
-      </div>
-      <div class="rounded-lg border border-dashed border-border p-4">
-        <p class="mb-1.5 text-sm font-medium text-muted-foreground">What we never claim</p>
-        <p class="text-sm leading-relaxed text-muted-foreground">
-          “This company is not really hiring.” That is a claim about somebody's intent, which
-          no amount of data here can observe. So the wording stays hedged, and the word
-          <em>ghost</em> never appears on a job.
-        </p>
-      </div>
-    </div>
-  </section>
-
-  <!-- The four signals, rendered from the product's own vocabulary. -->
+  <!-- The four criteria, each with its own picture. -->
   <section class="flex flex-col gap-6">
-    <SectionLabel text="the four signals" />
+    <SectionLabel text="what lights the mark" />
     <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
-      Two describe the <strong class="font-medium text-foreground">posting</strong>. Two describe
-      what happened to a <strong class="font-medium text-foreground">person who applied</strong>.
-      Only the second kind can witness that a job is not being worked, so no quantity of the
-      first will ever produce the stronger warning.
+      Two describe the <strong class="font-medium text-foreground">posting</strong>. Two
+      describe what happened to a
+      <strong class="font-medium text-foreground">person who applied</strong>. Only the
+      second kind can witness that a job is not being worked.
     </p>
 
-    <div class="flex flex-col gap-6">
-      {#each [{ heading: 'The shape of the posting', items: structural }, { heading: 'What happened to applicants', items: outcome }] as group (group.heading)}
-        <div class="flex flex-col gap-3">
+    <div class="grid gap-x-6 gap-y-8 sm:grid-cols-2">
+      {#each groups as group (group.heading)}
+        <div class="flex flex-col gap-4">
           <h3 class="text-sm font-semibold tracking-tight">{group.heading}</h3>
-          <ul class="flex flex-col gap-3">
-            {#each group.items as s (s.code)}
-              <li class="rounded-lg border border-border p-4">
+          {#each group.items as s (s.code)}
+            <div class="flex flex-col gap-3 rounded-lg border border-border p-4">
+              <SignalDiagram code={s.code} />
+              <div class="flex flex-col gap-1.5">
                 <p class="text-sm font-medium">{s.label}</p>
-                <p class="mt-1 font-mono text-xs text-muted-foreground">{s.fact}</p>
-                <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{s.why}</p>
-              </li>
-            {/each}
-          </ul>
+                <p class="font-mono text-xs text-muted-foreground">{s.fact}</p>
+                <p class="text-sm leading-relaxed text-muted-foreground">{s.gist}</p>
+                <Disclosure summary="The full account" class="mt-1">
+                  <p
+                    class="mt-2 border-l border-border pl-3 text-sm leading-relaxed text-muted-foreground"
+                  >
+                    {s.why}
+                  </p>
+                </Disclosure>
+              </div>
+            </div>
+          {/each}
         </div>
       {/each}
     </div>
   </section>
 
-  <!-- The UI, rendered by the components that render it in the product. -->
+  <!-- How the level is decided. The matrix states the rule; the sandbox lets the reader
+       try to break it and find they cannot. -->
   <section class="flex flex-col gap-6">
-    <SectionLabel text="what you actually see" />
+    <SectionLabel text="why the level is what it is" />
+    <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      Two separate gates, and the wording depends on how many pass. Nothing shows at all
+      until at least two criteria fire — one on its own is ordinary.
+    </p>
 
-    <div class="flex flex-col gap-3">
-      <p class="text-sm text-muted-foreground">
-        On a card — a hedged chip and how many criteria fired out of how many were checked:
-      </p>
-      <div class="flex flex-wrap items-center gap-3 rounded-lg border border-border p-4">
-        {#each levels as l (l.chip)}
-          <GhostBadge ghost={l.ghost} />
-        {/each}
-      </div>
-      <ul class="flex flex-col gap-1.5 text-sm text-muted-foreground">
-        {#each levels as l (l.chip)}
-          <li><strong class="font-medium text-foreground">{l.chip}</strong> — {l.when}.</li>
-        {/each}
-      </ul>
-    </div>
+    <GateMatrix />
 
-    <div class="flex flex-col gap-3">
-      <p class="text-sm text-muted-foreground">
-        On the job page — a gauge you can read without reading, and the criteria one click
-        away, <strong class="font-medium text-foreground">including what we do not know</strong>.
-        What is missing is the point: it tells you why the warning is not stronger.
+    <div class="mt-2 flex flex-col gap-3">
+      <h3 class="text-sm font-semibold tracking-tight">Try it</h3>
+      <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+        Below is the interface the job page renders, driven by what you switch on. See how
+        far posting shape alone can take it.
       </p>
-      <div class="rounded-lg border border-border p-4">
-        <GhostChecklist ghost={possible} />
-      </div>
+      <GhostSandbox />
       <p class="text-xs text-muted-foreground">
         These are observations about the posting, not a claim about the employer.
       </p>
     </div>
   </section>
 
-  <!-- How a report becomes evidence. -->
+  <!-- How a person's experience becomes evidence. The waiting period and the anonymity
+       gate are not restated here — the reports diagram above draws both, and saying it
+       twice says it the second time more weakly. -->
   <section class="flex flex-col gap-5">
     <SectionLabel text="your part" />
     <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
-      The strongest signal is the one only you can give: you applied, and nobody ever answered.
-      Reporting it takes one date.
+      The strongest signal is the one only you can give: you applied, and nobody ever
+      answered. There are two ways it reaches us.
     </p>
     <NumberedGrid
       items={[
         {
           n: '01',
-          title: 'Report the silence',
-          body: 'On the job, choose Report → “No response”. It asks when you applied — that date is what separates a real silence from impatience.',
+          title: 'Report it yourself',
+          body: 'On the job, choose Report → “No response”. It asks one thing: when you applied. That date is what separates a real silence from impatience, and you can withdraw the report if the employer eventually answers.',
         },
         {
           n: '02',
-          title: 'It waits before it counts',
-          body: 'Your report carries no weight until the same span has passed that a tracked application gets. Withdraw it if the employer eventually answers, and it stops counting.',
-        },
-        {
-          n: '03',
-          title: 'It stays anonymous',
-          body: `Only a count leaves your report, and only once ${WITNESS_GATE} different people have contributed — a count of one would point straight at you.`,
+          title: 'Or connect a mailbox',
+          body: 'Then it happens without you: freehire sees the reply arrive, or sees that it never did. Without a connected mailbox nothing is counted, because we could not tell silence from a gap in our own data.',
         },
       ]}
     />
-    <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
-      Connect a mailbox and it happens without you: freehire sees the reply arrive, or sees that
-      it never did. Without a connected mailbox nothing is counted, because we could not tell
-      silence from a gap in our own data.
-    </p>
     <div class="flex flex-wrap gap-3">
       <Button href={resolve('/features/inbox')} variant="outline">How the inbox works</Button>
     </div>
   </section>
 
-  <!-- Honest limits. -->
+  <!-- Honest limits of coverage — a different thing from the limit on the claim, which is
+       in the hero where a reader cannot miss it. -->
   <section class="flex flex-col gap-4">
     <SectionLabel text="where it is blind" />
     <ul class="flex max-w-3xl flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
       <li>
-        <strong class="font-medium text-foreground">We only check boards we crawl.</strong> If a
-        company's own careers site is not one of them, its postings are not judged on that
+        <strong class="font-medium text-foreground">We only check boards we crawl.</strong>
+        If a company's own careers site is not one of them, its postings are not judged on that
         criterion at all — absence of proof is not proof.
       </li>
       <li>
@@ -217,36 +183,38 @@
       </li>
       <li>
         <strong class="font-medium text-foreground"
-          >Agencies and consultancies fire the board criterion honestly.</strong
+          >Agencies fire the board criterion honestly.</strong
         > They advertise roles that belong to their clients, so those roles are genuinely absent
         from their own board. This is why one criterion is never enough on its own.
       </li>
       <li>
         <strong class="font-medium text-foreground">A quiet employer is not a fake job.</strong>
-        Recruiters go silent for ordinary reasons, which is why a silence needs a second person and
-        a second signal before it says anything.
+        Recruiters go silent for ordinary reasons, which is why a silence needs a second person
+        and a second signal before it says anything.
       </li>
     </ul>
   </section>
 
-  <!-- FAQ; shares GHOST_FAQ with the page's JSON-LD. -->
-  <section class="flex flex-col gap-5">
+  <!-- FAQ; shares GHOST_FAQ with the page's JSON-LD. Collapsed with <details>, so every
+       answer is still in the served HTML and the structured data cannot disagree with it. -->
+  <section class="flex flex-col gap-4">
     <SectionLabel text="questions" />
-    <dl class="flex flex-col gap-5">
+    <div class="flex flex-col divide-y divide-border border-y border-border">
       {#each GHOST_FAQ as item (item.question)}
-        <div class="flex flex-col gap-1.5">
-          <dt class="text-sm font-medium">{item.question}</dt>
-          <dd class="max-w-3xl text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
-        </div>
+        <Disclosure summary={item.question} class="py-3">
+          <p class="mt-2 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+            {item.answer}
+          </p>
+        </Disclosure>
       {/each}
-    </dl>
+    </div>
   </section>
 
   <section class="flex flex-col items-start gap-4 rounded-lg border border-border p-6">
     <h2 class="text-lg font-semibold tracking-tight">Stop applying into the void</h2>
     <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
-      The catalogue is open and needs no account. Tracking your applications is what makes the
-      signal sharper — for you, and for whoever reads the posting after you.
+      The catalogue is open and needs no account. Tracking your applications is what makes
+      the signal sharper — for you, and for whoever reads the posting after you.
     </p>
     <div class="flex flex-wrap gap-3">
       <Button href={resolve('/jobs')} variant="primary">Browse jobs</Button>

--- a/web/src/lib/components/ghost/Disclosure.svelte
+++ b/web/src/lib/components/ghost/Disclosure.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { ChevronDown } from '@lucide/svelte';
+
+  // A styling wrapper over native `<details>`, and nothing more.
+  //
+  // The platform supplies the expanded state, the trigger-to-content association and
+  // keyboard operation, and it all works before client JavaScript runs — which matters
+  // on a server-rendered page whose collapsed text must also be present for the FAQ
+  // structured data. GhostChecklist hand-rolls its disclosure because its trigger row
+  // carries a gauge, a chip and a scale with custom layout; a plain one has no such
+  // excuse, and re-implementing `aria-expanded` here would be a shim over the API that
+  // already does it.
+  let {
+    summary,
+    children,
+    class: className = '',
+  }: { summary: string; children: Snippet; class?: string } = $props();
+</script>
+
+<details class="group {className}">
+  <summary
+    class="flex cursor-pointer list-none items-center gap-1.5 text-sm text-muted-foreground marker:hidden hover:text-foreground [&::-webkit-details-marker]:hidden"
+  >
+    {summary}
+    <ChevronDown
+      class="size-3.5 shrink-0 transition-transform group-open:rotate-180"
+      aria-hidden="true"
+    />
+  </summary>
+  {@render children()}
+</details>

--- a/web/src/lib/components/ghost/GateMatrix.svelte
+++ b/web/src/lib/components/ghost/GateMatrix.svelte
@@ -20,33 +20,63 @@
 </script>
 
 <div class="w-full max-w-2xl">
-  <div class="grid grid-cols-[auto_1fr_1fr] gap-px overflow-hidden rounded-lg border border-border bg-border text-sm">
-    <div class="bg-background p-3"></div>
-    <div class="bg-background p-3 text-xs text-muted-foreground">
-      under {CONVERGENCE} criteria
-    </div>
-    <div class="bg-background p-3 text-xs text-muted-foreground">
-      {CONVERGENCE}+ criteria fired
-    </div>
-
-    {#each [false, true] as witnessed (witnessed)}
-      <div class="flex items-center bg-background p-3 text-xs text-muted-foreground">
-        {witnessed ? `${WITNESS_GATE}+ people` : `under ${WITNESS_GATE} people`}
-      </div>
-      {#each [false, true] as converged (converged)}
-        {@const cell = cells.find((c) => c.converged === converged && c.witnessed === witnessed)!}
-        <div
-          class={cn(
-            'bg-background p-3',
-            cell.level === 'likely' && 'text-warning-strong',
-            cell.level === 'none' && 'text-muted-foreground',
-          )}
+  <!-- A real table, not a grid of divs: this is two axes crossed, and a screen reader
+       given nine unrelated cells in source order gets none of that. `scope` is what ties
+       "nothing shown" back to "under 2 criteria" and "under 2 people". -->
+  <table
+    class="w-full border-separate border-spacing-0 overflow-hidden rounded-lg border border-border text-sm"
+  >
+    <caption class="sr-only">
+      The ghost level for each combination of the convergence and witness gates
+    </caption>
+    <thead>
+      <tr>
+        <td class="border-b border-border p-3"></td>
+        <th
+          scope="col"
+          class="border-b border-l border-border p-3 text-left text-xs font-normal text-muted-foreground"
         >
-          {WORDING[cell.level]}
-        </div>
+          under {CONVERGENCE} criteria
+        </th>
+        <th
+          scope="col"
+          class="border-b border-l border-border p-3 text-left text-xs font-normal text-muted-foreground"
+        >
+          {CONVERGENCE}+ criteria fired
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each [false, true] as witnessed (witnessed)}
+        <tr>
+          <th
+            scope="row"
+            class={cn(
+              'p-3 text-left text-xs font-normal text-muted-foreground',
+              !witnessed && 'border-b border-border',
+            )}
+          >
+            {witnessed ? `${WITNESS_GATE}+ people` : `under ${WITNESS_GATE} people`}
+          </th>
+          {#each [false, true] as converged (converged)}
+            {@const cell = cells.find(
+              (c) => c.converged === converged && c.witnessed === witnessed,
+            )!}
+            <td
+              class={cn(
+                'border-l border-border p-3',
+                !witnessed && 'border-b',
+                cell.level === 'likely' && 'text-warning-strong',
+                cell.level === 'none' && 'text-muted-foreground',
+              )}
+            >
+              {WORDING[cell.level]}
+            </td>
+          {/each}
+        </tr>
       {/each}
-    {/each}
-  </div>
+    </tbody>
+  </table>
 
   <p class="mt-3 max-w-xl text-sm leading-relaxed text-muted-foreground">
     Posting shape can fill the right-hand column, and nothing more. The bottom row needs

--- a/web/src/lib/components/ghost/GateMatrix.svelte
+++ b/web/src/lib/components/ghost/GateMatrix.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { CONVERGENCE, WITNESS_GATE } from '$lib/ghost';
+  import { gateMatrix } from '$lib/ghostDiagrams';
+  import { cn } from '$lib/ui';
+
+  // Two gates, four outcomes. The cell wording is asked of the rule rather than typed
+  // here, so the diagram cannot caption a level the classifier stopped producing.
+  //
+  // What the picture is for: the cell where posting shape converges and nobody has
+  // witnessed anything sits one square away from the strongest claim and cannot reach it,
+  // whatever else the employer does to the posting. That is the feature's central limit,
+  // and it survives as geometry where it did not survive as a clause in a sentence.
+  const cells = gateMatrix();
+
+  const WORDING: Record<string, string> = {
+    none: 'nothing shown',
+    possible: 'Possibly inactive',
+    likely: 'Likely inactive',
+  };
+</script>
+
+<div class="w-full max-w-2xl">
+  <div class="grid grid-cols-[auto_1fr_1fr] gap-px overflow-hidden rounded-lg border border-border bg-border text-sm">
+    <div class="bg-background p-3"></div>
+    <div class="bg-background p-3 text-xs text-muted-foreground">
+      under {CONVERGENCE} criteria
+    </div>
+    <div class="bg-background p-3 text-xs text-muted-foreground">
+      {CONVERGENCE}+ criteria fired
+    </div>
+
+    {#each [false, true] as witnessed (witnessed)}
+      <div class="flex items-center bg-background p-3 text-xs text-muted-foreground">
+        {witnessed ? `${WITNESS_GATE}+ people` : `under ${WITNESS_GATE} people`}
+      </div>
+      {#each [false, true] as converged (converged)}
+        {@const cell = cells.find((c) => c.converged === converged && c.witnessed === witnessed)!}
+        <div
+          class={cn(
+            'bg-background p-3',
+            cell.level === 'likely' && 'text-warning-strong',
+            cell.level === 'none' && 'text-muted-foreground',
+          )}
+        >
+          {WORDING[cell.level]}
+        </div>
+      {/each}
+    {/each}
+  </div>
+
+  <p class="mt-3 max-w-xl text-sm leading-relaxed text-muted-foreground">
+    Posting shape can fill the right-hand column, and nothing more. The bottom row needs
+    something only people who applied can supply, which is why no quantity of the first
+    kind ever produces the strongest wording.
+  </p>
+</div>

--- a/web/src/lib/components/ghost/GhostSandbox.svelte
+++ b/web/src/lib/components/ghost/GhostSandbox.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { SvelteSet } from 'svelte/reactivity';
   import GhostBadge from '$lib/components/GhostBadge.svelte';
   import GhostChecklist from '$lib/components/GhostChecklist.svelte';
   import { CRITERIA, WITNESS_GATE, ghostLevel } from '$lib/ghost';
@@ -13,7 +14,10 @@
   // Its job is to let the reader FAIL to reach the strongest wording with posting shape
   // alone. Asserting that in a sentence is what the page did before, and a sentence is
   // exactly what a reader who has just been surprised by a badge does not believe.
-  let fired = $state<Set<GhostCriterionCode>>(new Set(['evergreen_posting', 'ats_absent']));
+  // SvelteSet rather than a plain Set reassigned on every change: it is the reactive
+  // collection the framework ships, so `toggle` mutates in place and the deriveds below
+  // still fire.
+  const fired = new SvelteSet<GhostCriterionCode>(['evergreen_posting', 'ats_absent']);
   let contributors = $state(0);
 
   const outcomeSelected = $derived(
@@ -38,16 +42,19 @@
     };
   });
 
+  // Contributors and outcome criteria imply each other in the real system: every row that
+  // fires an outcome criterion records the person behind it, so neither can exist alone.
+  // The guard runs BOTH ways — switching the last outcome criterion off drops the count,
+  // and switching the first one on raises it to one — because a panel reading "applications
+  // went unanswered" beside "nobody reported" describes a payload that cannot exist, on a
+  // preview whose whole claim is that it cannot lie.
   function toggle(code: GhostCriterionCode) {
-    const next = new Set(fired);
-    if (next.has(code)) next.delete(code);
-    else next.add(code);
-    fired = next;
+    if (fired.has(code)) fired.delete(code);
+    else fired.add(code);
 
-    // Contributors come from outcome evidence. Leaving a count standing after its last
-    // outcome criterion is switched off would let the reader build a state the payload
-    // cannot hold.
-    if (!CRITERIA.some((c) => c.tier === 'outcome' && next.has(c.code))) contributors = 0;
+    const anyOutcome = CRITERIA.some((c) => c.tier === 'outcome' && fired.has(c.code));
+    if (!anyOutcome) contributors = 0;
+    else if (contributors === 0) contributors = 1;
   }
 
   const STEPS = [
@@ -127,8 +134,8 @@
       </div>
     {:else}
       <p class="text-sm text-muted-foreground">
-        Nothing is shown on the job. One criterion on its own is weak enough to be
-        ordinary, so below two the interface says nothing at all.
+        Nothing is shown on the job. Neither gate has passed — a lone criterion with
+        nobody behind it is too ordinary to mean anything.
       </p>
     {/if}
   </div>

--- a/web/src/lib/components/ghost/GhostSandbox.svelte
+++ b/web/src/lib/components/ghost/GhostSandbox.svelte
@@ -120,13 +120,13 @@
            does not have. -->
       <div class="flex flex-col gap-4">
         <div class="flex flex-col gap-1.5">
-          <span class="text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span class="text-xs uppercase tracking-wider text-muted-foreground">
             In a list, on the card
           </span>
           <div><GhostBadge {ghost} /></div>
         </div>
         <div class="flex flex-col gap-1.5 border-t border-border pt-3">
-          <span class="text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span class="text-xs uppercase tracking-wider text-muted-foreground">
             On the job page
           </span>
           <GhostChecklist {ghost} />

--- a/web/src/lib/components/ghost/GhostSandbox.svelte
+++ b/web/src/lib/components/ghost/GhostSandbox.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import GhostBadge from '$lib/components/GhostBadge.svelte';
+  import GhostChecklist from '$lib/components/GhostChecklist.svelte';
+  import { CRITERIA, WITNESS_GATE, ghostLevel } from '$lib/ghost';
+  import type { GhostCriterionCode } from '$lib/ghost';
+  import type { Ghost } from '$lib/generated/contracts';
+
+  // The preview the reader drives. Below it stand the SAME components the job page
+  // renders — not a copy of their markup, which would go stale the first time they are
+  // redesigned, and not a screenshot, which additionally freezes one theme and one
+  // employer's name.
+  //
+  // Its job is to let the reader FAIL to reach the strongest wording with posting shape
+  // alone. Asserting that in a sentence is what the page did before, and a sentence is
+  // exactly what a reader who has just been surprised by a badge does not believe.
+  let fired = $state<Set<GhostCriterionCode>>(new Set(['evergreen_posting', 'ats_absent']));
+  let contributors = $state(0);
+
+  const outcomeSelected = $derived(
+    CRITERIA.some((c) => c.tier === 'outcome' && fired.has(c.code)),
+  );
+
+  // Below the gate the contributor count is ABSENT from the payload rather than zeroed:
+  // a count of one identifies that applicant to the employer. The assembled payload has
+  // to reproduce that, or the preview would show a system that holds the number back
+  // instead of never having one to serve.
+  const ghost = $derived.by((): Ghost | null => {
+    const criteria = CRITERIA.map((c) => c.code).filter((code) => fired.has(code));
+    const level = ghostLevel(criteria, contributors);
+    if (level === 'none') return null;
+
+    return {
+      level,
+      criteria,
+      criteria_total: CRITERIA.length,
+      ...(contributors >= WITNESS_GATE ? { contributors } : {}),
+      ats_checked_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    };
+  });
+
+  function toggle(code: GhostCriterionCode) {
+    const next = new Set(fired);
+    if (next.has(code)) next.delete(code);
+    else next.add(code);
+    fired = next;
+
+    // Contributors come from outcome evidence. Leaving a count standing after its last
+    // outcome criterion is switched off would let the reader build a state the payload
+    // cannot hold.
+    if (!CRITERIA.some((c) => c.tier === 'outcome' && next.has(c.code))) contributors = 0;
+  }
+
+  const STEPS = [
+    { value: 0, label: 'nobody' },
+    { value: 1, label: '1 person' },
+    { value: WITNESS_GATE, label: `${WITNESS_GATE} people` },
+  ];
+</script>
+
+<div class="flex flex-col gap-5 rounded-xl border border-border p-5">
+  <div class="grid gap-5 sm:grid-cols-2">
+    {#each [{ tier: 'structural', heading: 'The shape of the posting' }, { tier: 'outcome', heading: 'What happened to applicants' }] as group (group.tier)}
+      <fieldset class="flex flex-col gap-2">
+        <legend class="mb-2 text-xs font-medium tracking-tight">{group.heading}</legend>
+        {#each CRITERIA.filter((c) => c.tier === group.tier) as c (c.code)}
+          <label class="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+            <input
+              type="checkbox"
+              class="accent-warning"
+              checked={fired.has(c.code)}
+              onchange={() => toggle(c.code)}
+            />
+            {c.label}
+          </label>
+        {/each}
+      </fieldset>
+    {/each}
+  </div>
+
+  <fieldset class="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-4">
+    <legend class="sr-only">How many distinct people contributed outcome evidence</legend>
+    <span class="text-xs font-medium">Different people who reported</span>
+    {#each STEPS as step (step.value)}
+      <label
+        class="flex items-center gap-1.5 text-sm {outcomeSelected
+          ? 'cursor-pointer text-muted-foreground'
+          : 'cursor-not-allowed text-muted-foreground/50'}"
+      >
+        <input
+          type="radio"
+          class="accent-warning"
+          name="contributors"
+          value={step.value}
+          checked={contributors === step.value}
+          disabled={!outcomeSelected}
+          onchange={() => (contributors = step.value)}
+        />
+        {step.label}
+      </label>
+    {/each}
+    {#if !outcomeSelected}
+      <span class="basis-full text-xs text-muted-foreground">
+        People arrive with outcome evidence — switch one on to move this.
+      </span>
+    {/if}
+  </fieldset>
+
+  <div class="rounded-lg border border-border bg-secondary/20 p-4">
+    {#if ghost}
+      <!-- Two surfaces, labelled as two surfaces. Stacked unlabelled they read as one
+           screen saying the same thing twice — which is the arrangement the job page
+           deliberately dropped, so showing it here would advertise a layout the product
+           does not have. -->
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-1.5">
+          <span class="text-[10px] uppercase tracking-wider text-muted-foreground">
+            In a list, on the card
+          </span>
+          <div><GhostBadge {ghost} /></div>
+        </div>
+        <div class="flex flex-col gap-1.5 border-t border-border pt-3">
+          <span class="text-[10px] uppercase tracking-wider text-muted-foreground">
+            On the job page
+          </span>
+          <GhostChecklist {ghost} />
+        </div>
+      </div>
+    {:else}
+      <p class="text-sm text-muted-foreground">
+        Nothing is shown on the job. One criterion on its own is weak enough to be
+        ordinary, so below two the interface says nothing at all.
+      </p>
+    {/if}
+  </div>
+</div>

--- a/web/src/lib/components/ghost/Prevalence.svelte
+++ b/web/src/lib/components/ghost/Prevalence.svelte
@@ -23,7 +23,7 @@
 <figure class="flex flex-wrap items-center gap-5 sm:flex-nowrap">
   <div class="grid w-fit shrink-0 grid-cols-10 gap-1" aria-hidden="true">
     {#each cells as cell, i (i)}
-      <span class="size-3.5 rounded-[3px] {TONE[cell]}"></span>
+      <span class="size-3.5 rounded-sm {TONE[cell]}"></span>
     {/each}
   </div>
 

--- a/web/src/lib/components/ghost/Prevalence.svelte
+++ b/web/src/lib/components/ghost/Prevalence.svelte
@@ -9,9 +9,13 @@
   // on a page whose whole argument is that it states only what it can check.
   const cells = prevalenceWaffle(PREVALENCE);
 
+  // The band carries a ring as well as a tint. In dark the muted warning token lands at
+  // almost exactly the lightness of the neutral remainder, so hue alone separates them —
+  // and hue alone is the one distinction a colour-blind reader does not get. The outline
+  // makes the band a different SHAPE, which survives both themes and any vision.
   const TONE: Record<string, string> = {
     solid: 'bg-warning',
-    banded: 'bg-warning-muted',
+    banded: 'bg-warning-muted ring-1 ring-inset ring-warning/50',
     empty: 'bg-muted-foreground/15',
   };
 </script>
@@ -27,8 +31,8 @@
     <span class="block text-2xl font-semibold tracking-tight text-foreground tabular-nums">
       {PREVALENCE.low}–{PREVALENCE.high}%
     </span>
-    of listings are jobs nobody is working to fill — kept up to collect CVs, to look like
-    growth, or because nobody took them down. The solid cells are the floor every study
-    agrees on; the paler ones are how much they disagree.
+    of listings on the big boards are jobs nobody is working to fill — kept up to collect
+    CVs, to look like growth, or because nobody took them down. The solid cells are the
+    floor every study agrees on; the tinted ones are how much they disagree.
   </figcaption>
 </figure>

--- a/web/src/lib/components/ghost/Prevalence.svelte
+++ b/web/src/lib/components/ghost/Prevalence.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { PREVALENCE, prevalenceWaffle } from '$lib/ghostDiagrams';
+
+  // A hundred postings, and the share of them nobody is working to fill.
+  //
+  // The band is drawn differently from the floor because the sources differ: everyone
+  // agrees on the lower bound, and the cells above it are the width of the disagreement.
+  // One averaged figure would be easier to draw and would claim a precision nobody has —
+  // on a page whose whole argument is that it states only what it can check.
+  const cells = prevalenceWaffle(PREVALENCE);
+
+  const TONE: Record<string, string> = {
+    solid: 'bg-warning',
+    banded: 'bg-warning-muted',
+    empty: 'bg-muted-foreground/15',
+  };
+</script>
+
+<figure class="flex flex-wrap items-center gap-5 sm:flex-nowrap">
+  <div class="grid w-fit shrink-0 grid-cols-10 gap-1" aria-hidden="true">
+    {#each cells as cell, i (i)}
+      <span class="size-3.5 rounded-[3px] {TONE[cell]}"></span>
+    {/each}
+  </div>
+
+  <figcaption class="text-sm leading-relaxed text-muted-foreground">
+    <span class="block text-2xl font-semibold tracking-tight text-foreground tabular-nums">
+      {PREVALENCE.low}–{PREVALENCE.high}%
+    </span>
+    of listings are jobs nobody is working to fill — kept up to collect CVs, to look like
+    growth, or because nobody took them down. The solid cells are the floor every study
+    agrees on; the paler ones are how much they disagree.
+  </figcaption>
+</figure>

--- a/web/src/lib/components/ghost/SignalDiagram.svelte
+++ b/web/src/lib/components/ghost/SignalDiagram.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { Component } from 'svelte';
+  import type { GhostCriterionCode } from '$lib/ghost';
+  import AtsAbsent from './diagrams/AtsAbsent.svelte';
+  import Evergreen from './diagrams/Evergreen.svelte';
+  import Reports from './diagrams/Reports.svelte';
+  import Silent from './diagrams/Silent.svelte';
+
+  // The registry is keyed by the criterion union rather than by `string`, so a criterion
+  // that joins the classifier's vocabulary without an illustration is a COMPILE error
+  // (TS2741) instead of an empty cell on the page.
+  //
+  // This is what stands in for the test that cannot be written: vitest here cannot import
+  // a `.svelte` component — the `$lib` alias does not resolve under it, and a relative
+  // path reaches vite's import analysis untransformed — so asserting the registry's
+  // coverage at runtime would mean adding test infrastructure this project does not
+  // carry. The type checker already runs in CI and catches it earlier anyway.
+  const DIAGRAMS: Record<GhostCriterionCode, Component> = {
+    evergreen_posting: Evergreen,
+    ats_absent: AtsAbsent,
+    silent_applications: Silent,
+    user_reports: Reports,
+  };
+
+  let { code }: { code: GhostCriterionCode } = $props();
+
+  const Diagram = $derived(DIAGRAMS[code]);
+</script>
+
+<Diagram />

--- a/web/src/lib/components/ghost/diagrams/AtsAbsent.svelte
+++ b/web/src/lib/components/ghost/diagrams/AtsAbsent.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  // Where the role is, and where it is not — plus the state that is neither.
+  //
+  // The third panel is the one that earns its place. A reader whose posting is NOT
+  // marked asks why, and the answer is usually that we do not crawl that employer's
+  // board at all, so the criterion is never put to it. Drawing only "found" and
+  // "absent" would report our blind spot as the employer's fault, which is exactly what
+  // the coverage gate exists to prevent.
+</script>
+
+<div class="flex h-24 items-stretch gap-3 text-[10px]" aria-hidden="true">
+  <div class="flex flex-1 flex-col rounded-md border border-border p-2">
+    <span class="mb-1.5 text-muted-foreground">aggregator</span>
+    <span class="mb-1 h-1.5 w-full rounded-full bg-muted-foreground/30"></span>
+    <span class="mb-1 h-1.5 w-2/3 rounded-full bg-warning"></span>
+    <span class="h-1.5 w-4/5 rounded-full bg-muted-foreground/30"></span>
+  </div>
+
+  <div class="flex flex-1 flex-col rounded-md border border-dashed border-warning/60 p-2">
+    <span class="mb-1.5 text-muted-foreground">their own board</span>
+    <span class="flex flex-1 items-center justify-center text-warning-strong">not there</span>
+    <!-- The check expires. A stale answer goes quiet rather than standing. -->
+    <span class="text-muted-foreground">checked 2d ago</span>
+  </div>
+
+  <div class="flex flex-1 flex-col rounded-md bg-muted p-2">
+    <span class="mb-1.5 text-muted-foreground">board we don't crawl</span>
+    <span class="flex flex-1 items-center justify-center text-muted-foreground">
+      not judged
+    </span>
+  </div>
+</div>

--- a/web/src/lib/components/ghost/diagrams/AtsAbsent.svelte
+++ b/web/src/lib/components/ghost/diagrams/AtsAbsent.svelte
@@ -8,7 +8,7 @@
   // the coverage gate exists to prevent.
 </script>
 
-<div class="flex h-24 items-stretch gap-3 text-[10px]" aria-hidden="true">
+<div class="flex h-24 items-stretch gap-3 text-xs" aria-hidden="true">
   <div class="flex flex-1 flex-col rounded-md border border-border p-2">
     <span class="mb-1.5 text-muted-foreground">aggregator</span>
     <span class="mb-1 h-1.5 w-full rounded-full bg-muted-foreground/30"></span>

--- a/web/src/lib/components/ghost/diagrams/Evergreen.svelte
+++ b/web/src/lib/components/ghost/diagrams/Evergreen.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  // One role, advertised over and over, with several copies live at the same time.
+  //
+  // There is deliberately NO time axis. The criterion's example copy opens with a
+  // posting's age, which invites one — but age alone does not fire it, and in the live
+  // catalogue effectively never does: the marked postings converge through the repost
+  // and duplicate-copy thresholds instead. A timeline would be the most legible thing
+  // here and would name the wrong cause to a reader who came to find out why their
+  // posting is marked.
+  //
+  // The numbers mirror the criterion's illustrative `fact` line, which renders beside
+  // this. They are an example, not a threshold.
+  const COPIES = 7;
+  const REPOSTS = 13;
+</script>
+
+<div class="flex h-24 items-center gap-4" aria-hidden="true">
+  <!-- A fanned deck: the same posting, several times over. Overlap is the point, so the
+       cards are translucent and the stacked region darkens on its own. -->
+  <div class="relative h-20 flex-1">
+    {#each { length: COPIES }, i (i)}
+      <div
+        class="absolute h-8 w-24 rounded-sm border border-warning/50 bg-warning/20"
+        style="left: {i * 12}px; top: {i * 6}px;"
+      ></div>
+    {/each}
+  </div>
+
+  <div class="shrink-0 font-mono text-xs text-muted-foreground">
+    <div class="text-warning-strong">×{COPIES}</div>
+    <div>live at once</div>
+    <div class="mt-1.5 text-warning-strong">↻ {REPOSTS}</div>
+    <div>reposts</div>
+  </div>
+</div>

--- a/web/src/lib/components/ghost/diagrams/Reports.svelte
+++ b/web/src/lib/components/ghost/diagrams/Reports.svelte
@@ -10,7 +10,7 @@
   // knows and declines to say, which is not the system that exists.
 </script>
 
-<div class="flex h-24 items-center gap-3 text-[10px]" aria-hidden="true">
+<div class="flex h-24 items-center gap-3 text-xs" aria-hidden="true">
   <div class="flex flex-1 flex-col gap-2 rounded-md border border-border p-2">
     <span class="text-muted-foreground">1 report</span>
     <span class="flex gap-1">

--- a/web/src/lib/components/ghost/diagrams/Reports.svelte
+++ b/web/src/lib/components/ghost/diagrams/Reports.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { WITNESS_GATE } from '$lib/ghost';
+
+  // Below the gate and above it.
+  //
+  // The count on the left is drawn as an empty slot rather than a zero or a redaction.
+  // That is what the payload does: below the gate the field is ABSENT, not suppressed —
+  // a count of one identifies the single person who applied to the employer, so there is
+  // no number held back, there is no number. A "0" or a "•••" would depict a system that
+  // knows and declines to say, which is not the system that exists.
+</script>
+
+<div class="flex h-24 items-center gap-3 text-[10px]" aria-hidden="true">
+  <div class="flex flex-1 flex-col gap-2 rounded-md border border-border p-2">
+    <span class="text-muted-foreground">1 report</span>
+    <span class="flex gap-1">
+      <span class="size-2.5 rounded-full bg-muted-foreground/40"></span>
+    </span>
+    <span class="flex items-center gap-1 text-muted-foreground">
+      count:
+      <span class="h-3 w-8 rounded-sm border border-dashed border-muted-foreground/50"></span>
+    </span>
+  </div>
+
+  <div class="flex flex-1 flex-col gap-2 rounded-md border border-warning/60 p-2">
+    <span class="text-muted-foreground">{WITNESS_GATE} reports</span>
+    <span class="flex gap-1">
+      {#each { length: WITNESS_GATE }, i (i)}
+        <span class="size-2.5 rounded-full bg-warning"></span>
+      {/each}
+    </span>
+    <span class="text-warning-strong">count: {WITNESS_GATE}</span>
+  </div>
+
+  <div class="shrink-0 space-y-1 text-muted-foreground">
+    <div>⏱ waits</div>
+    <div>↩ withdrawable</div>
+  </div>
+</div>

--- a/web/src/lib/components/ghost/diagrams/Silent.svelte
+++ b/web/src/lib/components/ghost/diagrams/Silent.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  // Three applications, three outcomes — only one of which is evidence.
+  //
+  // The hollow third lane is the correctness core rather than an edge case. Without a
+  // connected mailbox a reply could never have been seen, so silence is indistinguishable
+  // from a gap in our own data and counts for nothing. Drawing it in a reassuring tone
+  // would claim it had been checked and cleared; drawing it like the first would claim
+  // evidence we do not have. It is hollow because it is unobserved.
+  const LANES = [
+    { label: 'no reply — counts', state: 'counts' },
+    { label: 'reply arrived', state: 'answered' },
+    { label: 'no mailbox', state: 'unobserved' },
+  ] as const;
+</script>
+
+<div class="flex h-24 flex-col justify-center gap-2.5 text-[10px]" aria-hidden="true">
+  {#each LANES as lane (lane.label)}
+    <div class="flex items-center gap-2">
+      <!-- The apply date. Hollow where the application can never be evidence. -->
+      <span
+        class="size-2 shrink-0 rounded-full {lane.state === 'unobserved'
+          ? 'border border-dashed border-muted-foreground/60'
+          : 'bg-muted-foreground'}"
+      ></span>
+
+      <!-- The window the stage tolerates. -->
+      <span
+        class="h-1.5 flex-1 rounded-full {lane.state === 'unobserved'
+          ? 'border border-dashed border-muted-foreground/40'
+          : 'bg-muted-foreground/25'}"
+      ></span>
+
+      <span
+        class="w-24 shrink-0 whitespace-nowrap {lane.state === 'counts'
+          ? 'text-warning-strong'
+          : 'text-muted-foreground'}"
+      >
+        {lane.state === 'counts' ? '⌀ ' : lane.state === 'answered' ? '↩ ' : ''}{lane.label}
+      </span>
+    </div>
+  {/each}
+</div>

--- a/web/src/lib/components/ghost/diagrams/Silent.svelte
+++ b/web/src/lib/components/ghost/diagrams/Silent.svelte
@@ -13,7 +13,7 @@
   ] as const;
 </script>
 
-<div class="flex h-24 flex-col justify-center gap-2.5 text-[10px]" aria-hidden="true">
+<div class="flex h-24 flex-col justify-center gap-2.5 text-xs" aria-hidden="true">
   {#each LANES as lane (lane.label)}
     <div class="flex items-center gap-2">
       <!-- The apply date. Hollow where the application can never be evidence. -->

--- a/web/src/lib/ghost.test.ts
+++ b/web/src/lib/ghost.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { ghostBadge, ghostChecklist, ghostGauge, ghostUnobserved, supersedesReality } from './ghost';
+import {
+  CONVERGENCE,
+  CRITERIA,
+  WITNESS_GATE,
+  ghostBadge,
+  ghostChecklist,
+  ghostGauge,
+  ghostLevel,
+  ghostUnobserved,
+  supersedesReality,
+} from './ghost';
 import type { Ghost } from './generated/contracts';
 
 const CODES = ['evergreen_posting', 'ats_absent', 'silent_applications', 'user_reports'];
@@ -212,5 +222,67 @@ describe('supersedesReality', () => {
 
   it('leaves the reality badge alone for a level it does not know', () => {
     expect(supersedesReality({ ...possible, level: 'invented' })).toBe(false);
+  });
+});
+
+// The level rule, mirrored from internal/ghost so the /features/ghost-jobs landing can
+// demonstrate the ladder instead of asserting it in a sentence no test can reach.
+describe('ghostLevel', () => {
+  const STRUCTURAL = ['evergreen_posting', 'ats_absent'];
+  const OUTCOME = ['silent_applications', 'user_reports'];
+
+  it('shows nothing when neither gate passes', () => {
+    expect(ghostLevel([], 0)).toBe('none');
+    expect(ghostLevel(['evergreen_posting'], 0)).toBe('none');
+    // One outcome criterion from one person passes neither gate either.
+    expect(ghostLevel(['user_reports'], 1)).toBe('none');
+  });
+
+  it('reaches possible on convergence alone', () => {
+    expect(ghostLevel(STRUCTURAL, 0)).toBe('possible');
+  });
+
+  // Two strangers independently reporting silence is a stronger fact than any two
+  // artifacts of posting shape, so the witness gate stands on its own.
+  it('reaches possible on the witness gate alone', () => {
+    expect(ghostLevel(['user_reports'], WITNESS_GATE)).toBe('possible');
+  });
+
+  it('reaches likely only when both gates pass', () => {
+    expect(ghostLevel(['ats_absent', 'user_reports'], WITNESS_GATE)).toBe('likely');
+  });
+
+  // The gate counts people, not criteria: one person with both a silent application and
+  // a filed report converges two criteria but remains a single witness.
+  it('counts people rather than criteria', () => {
+    expect(ghostLevel(OUTCOME, 1)).toBe('possible');
+    expect(ghostLevel(OUTCOME, WITNESS_GATE)).toBe('likely');
+  });
+
+  // The guarantee the landing is built to demonstrate. It lives here rather than in the
+  // caller because the landing's sandbox lets a reader move the criteria and the
+  // contributor count independently: a rule that trusted its caller would happily render
+  // `likely` from posting shape alone, which is the one claim the feature must never make.
+  it('never reaches likely on structural evidence, whatever the contributor count', () => {
+    const subsets = [[], ['evergreen_posting'], ['ats_absent'], STRUCTURAL];
+    for (const criteria of subsets) {
+      for (const contributors of [0, 1, 2, 7]) {
+        expect(ghostLevel(criteria, contributors)).not.toBe('likely');
+      }
+    }
+  });
+
+  it('mirrors the gates it depends on', () => {
+    expect(CONVERGENCE).toBe(2);
+    expect(WITNESS_GATE).toBe(2);
+  });
+
+  // The tiers above are written out rather than derived, so a flipped tier in CRITERIA
+  // fails a test instead of being followed by both the rule and its test. Pinning them
+  // here is what stops the opposite failure: a fifth criterion joining the vocabulary
+  // would otherwise leave the structural property above quietly untested on it.
+  it('covers the whole vocabulary', () => {
+    expect(CRITERIA.filter((c) => c.tier === 'structural').map((c) => c.code)).toEqual(STRUCTURAL);
+    expect(CRITERIA.filter((c) => c.tier === 'outcome').map((c) => c.code)).toEqual(OUTCOME);
   });
 });

--- a/web/src/lib/ghost.ts
+++ b/web/src/lib/ghost.ts
@@ -57,12 +57,7 @@ export interface GhostChecklistRow {
  *  Exported because the /features/ghost-jobs landing explains them from this same
  *  array, and a test fails if a criterion joins the vocabulary without being
  *  explained there. A marketing page a test keeps honest. */
-export const CRITERIA: {
-  code: string;
-  label: string;
-  short: string;
-  tier: 'structural' | 'outcome';
-}[] = [
+export const CRITERIA = [
   {
     code: 'evergreen_posting',
     label: 'Posting behaves as evergreen',
@@ -87,7 +82,65 @@ export const CRITERIA: {
     short: 'reports from people',
     tier: 'outcome',
   },
-];
+] as const satisfies readonly {
+  code: string;
+  label: string;
+  short: string;
+  tier: 'structural' | 'outcome';
+}[];
+
+/** The criterion codes, as a union rather than `string`.
+ *
+ *  `satisfies` rather than an annotation: an annotation checks the shape but widens `code`
+ *  to `string`, leaving nothing to build this union from, while a bare `as const` gives the
+ *  literals but would let a mistyped `tier` through. Both are wanted.
+ *
+ *  What it buys: the landing's diagram registry is keyed by this union, so a criterion that
+ *  joins the vocabulary without an illustration is a compile error rather than an empty cell
+ *  on the page. The same guarantee could not be had from a test — vitest here cannot import a
+ *  `.svelte` component without test infrastructure this project does not carry. */
+export type GhostCriterionCode = (typeof CRITERIA)[number]['code'];
+
+/** How many criteria must fire, of any tier, before the signal says anything. */
+export const CONVERGENCE = 2;
+
+/** How many DISTINCT people must contribute outcome evidence for the stronger claim —
+ *  and the reason a contributor count is never served below it. */
+export const WITNESS_GATE = 2;
+
+/** The levels the classifier reports. `none` is most of the catalogue. */
+export type GhostLevel = 'none' | 'possible' | 'likely';
+
+const OUTCOME_CODES: ReadonlySet<string> = new Set(
+  CRITERIA.filter((c) => c.tier === 'outcome').map((c) => c.code),
+);
+
+/** ghostLevel derives the level from the criteria that fired and the number of distinct
+ *  people behind the outcome evidence. Mirrors internal/ghost, which remains the
+ *  authority — the served payload's `level` is what a job actually carries, and this is
+ *  here so the /features/ghost-jobs landing can demonstrate the ladder rather than
+ *  assert it in prose no test can check.
+ *
+ *  Two independent gates: convergence, and witnesses. Both pass → `likely`, exactly one
+ *  → `possible`, neither → `none`. The witness gate stands on its own because two
+ *  strangers independently reporting silence is a stronger fact than any two artifacts of
+ *  posting shape, and requiring structural corroboration would leave the only tier that
+ *  observes reality unable to mark anything by itself.
+ *
+ *  The witness gate additionally requires that an outcome criterion actually fired. That
+ *  looks redundant — contributors come from outcome evidence, so a real payload cannot
+ *  carry one without the other — but the landing's sandbox moves the criteria and the
+ *  contributor count independently, and a rule that trusted its caller would render
+ *  `likely` from posting shape alone. That is the one claim the feature must never make,
+ *  so the guarantee lives here rather than in the caller's discipline. */
+export function ghostLevel(criteria: readonly string[], contributors: number): GhostLevel {
+  const converged = criteria.length >= CONVERGENCE;
+  const witnessed = contributors >= WITNESS_GATE && criteria.some((c) => OUTCOME_CODES.has(c));
+
+  if (converged && witnessed) return 'likely';
+  if (converged || witnessed) return 'possible';
+  return 'none';
+}
 
 const LABELS: Record<string, { tone: 'warn' | 'muted'; label: string }> = {
   possible: { tone: 'muted', label: 'Possibly inactive' },

--- a/web/src/lib/ghostDiagrams.test.ts
+++ b/web/src/lib/ghostDiagrams.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { CONVERGENCE, CRITERIA, WITNESS_GATE, ghostLevel } from './ghost';
+import { PREVALENCE, WAFFLE_CELLS, gateMatrix, prevalenceWaffle } from './ghostDiagrams';
+
+describe('prevalenceWaffle', () => {
+  it('always fills the whole grid', () => {
+    expect(prevalenceWaffle(PREVALENCE)).toHaveLength(WAFFLE_CELLS);
+  });
+
+  // The lower bound is what every study agrees on; the cells above it are the width of
+  // the disagreement. Drawing them alike would claim a precision the sources do not have,
+  // on a page whose whole argument is that it states only what it can check.
+  it('separates the agreed floor from the uncertain band', () => {
+    const cells = prevalenceWaffle(PREVALENCE);
+    const count = (kind: string) => cells.filter((c) => c === kind).length;
+
+    expect(count('solid')).toBe(PREVALENCE.low);
+    expect(count('banded')).toBe(PREVALENCE.high - PREVALENCE.low);
+    expect(count('empty')).toBe(WAFFLE_CELLS - PREVALENCE.high);
+  });
+
+  it('orders the grid so the band sits on top of the floor', () => {
+    const cells = prevalenceWaffle(PREVALENCE);
+    expect(cells.slice(0, PREVALENCE.low).every((c) => c === 'solid')).toBe(true);
+    expect(cells.slice(PREVALENCE.high).every((c) => c === 'empty')).toBe(true);
+  });
+
+  // A published figure is copy, and copy gets edited. The grid must degrade rather than
+  // spill: a range someone widens past the grid still yields a drawable hundred cells.
+  it('never spills past the grid', () => {
+    expect(prevalenceWaffle({ low: 40, high: 130 })).toHaveLength(WAFFLE_CELLS);
+    expect(prevalenceWaffle({ low: 0, high: 0 })).toHaveLength(WAFFLE_CELLS);
+  });
+});
+
+describe('gateMatrix', () => {
+  it('covers every combination of the two gates once', () => {
+    const cells = gateMatrix();
+    expect(cells).toHaveLength(4);
+    expect(new Set(cells.map((c) => `${c.converged}:${c.witnessed}`)).size).toBe(4);
+  });
+
+  // The cells are asked, not captioned. A hand-written label is a second statement of the
+  // rule, free to drift from the one the product runs on — which is the drift this whole
+  // page exists to prevent.
+  it('takes every level from the rule itself', () => {
+    for (const cell of gateMatrix()) {
+      expect(ghostLevel(cell.criteria, cell.contributors)).toBe(cell.level);
+    }
+  });
+
+  // The axes are labels, and a label can be put on the wrong cell. Checking the level
+  // came from the rule does not catch that: a mislabelled axis leaves every level
+  // correct and the diagram still wrong.
+  it('labels each axis by what its example actually does', () => {
+    const outcome = new Set<string>(
+      CRITERIA.filter((c) => c.tier === 'outcome').map((c) => c.code),
+    );
+    for (const cell of gateMatrix()) {
+      expect(cell.criteria.length >= CONVERGENCE, `converged on ${cell.criteria}`).toBe(
+        cell.converged,
+      );
+      const witnesses =
+        cell.contributors >= WITNESS_GATE && cell.criteria.some((c) => outcome.has(c));
+      expect(witnesses, `witnessed on ${cell.criteria}`).toBe(cell.witnessed);
+    }
+  });
+
+  it('shows the ceiling on structural evidence', () => {
+    const structural = new Set<string>(
+      CRITERIA.filter((c) => c.tier === 'structural').map((c) => c.code),
+    );
+    for (const cell of gateMatrix()) {
+      if (cell.criteria.every((code) => structural.has(code))) {
+        expect(cell.level, 'structural-only cells must never read likely').not.toBe('likely');
+      }
+    }
+  });
+
+  it('reaches likely in exactly one cell', () => {
+    expect(gateMatrix().filter((c) => c.level === 'likely')).toHaveLength(1);
+    expect(gateMatrix().filter((c) => c.level === 'none')).toHaveLength(1);
+    expect(gateMatrix().filter((c) => c.level === 'possible')).toHaveLength(2);
+  });
+});

--- a/web/src/lib/ghostDiagrams.ts
+++ b/web/src/lib/ghostDiagrams.ts
@@ -1,0 +1,98 @@
+// Pure models for the two computed diagrams on the /features/ghost-jobs landing: the
+// prevalence waffle and the gate matrix. Kept out of the Svelte components so the parts
+// that can be wrong quietly — cell accounting, and which level a gate combination
+// produces — are unit-testable without rendering. Same split as activityChart.ts, and for
+// the same reason.
+//
+// The other four diagrams have no model here on purpose. They are drawings with literal
+// coordinates: nothing about them can be computed, so a model would be ceremony.
+
+import { CRITERIA, WITNESS_GATE, ghostLevel } from './ghost';
+import type { GhostLevel } from './ghost';
+
+/** The share of listings nobody is working to fill, as published rather than averaged.
+ *  Studies put it between these bounds; Greenhouse, which can see its own customers'
+ *  pipelines, reported 18–22% per quarter. A single figure would claim a precision the
+ *  sources do not have. */
+export const PREVALENCE = { low: 18, high: 27 } as const;
+
+/** One cell per percentage point, so the grid reads as "this many in a hundred" with no
+ *  scale to interpret. */
+export const WAFFLE_CELLS = 100;
+
+/** `solid` — the floor every study agrees on. `banded` — the width of the disagreement.
+ *  `empty` — the rest of the catalogue.
+ *
+ *  Three states rather than two because the band is the honest part: drawn like the floor
+ *  it would overstate what is known, and drawn like the remainder it would hide it. */
+export type WaffleCell = 'solid' | 'banded' | 'empty';
+
+/** prevalenceWaffle lays the range out over a fixed hundred cells, floor first.
+ *
+ *  The bounds are clamped rather than trusted. They are published copy, and copy gets
+ *  edited — a range widened past the grid should still yield something drawable instead
+ *  of a row that runs off the component. */
+export function prevalenceWaffle(range: { low: number; high: number }): WaffleCell[] {
+  const low = clamp(range.low);
+  const high = clamp(Math.max(range.high, low));
+
+  return Array.from({ length: WAFFLE_CELLS }, (_, i) => {
+    if (i < low) return 'solid';
+    return i < high ? 'banded' : 'empty';
+  });
+}
+
+function clamp(n: number): number {
+  return Math.min(Math.max(Math.round(n), 0), WAFFLE_CELLS);
+}
+
+/** One cell of the gate matrix: which gates its example passes, the example that gets it
+ *  there, and the level the rule returns for that example.
+ *
+ *  The example travels with the cell so the diagram can be checked against `ghostLevel`
+ *  rather than against a caption. */
+export interface GateCell {
+  converged: boolean;
+  witnessed: boolean;
+  criteria: string[];
+  contributors: number;
+  level: GhostLevel;
+}
+
+const byTier = (tier: string): string[] =>
+  CRITERIA.filter((c) => c.tier === tier).map((c) => c.code);
+
+/** The gates a cell passes are declared, not recomputed — recomputing them here would be
+ *  a second copy of `ghostLevel`'s predicates, free to disagree with it. The example
+ *  beside them is what makes the declaration checkable. */
+const cell = (
+  converged: boolean,
+  witnessed: boolean,
+  criteria: string[],
+  contributors: number,
+): GateCell => ({
+  converged,
+  witnessed,
+  criteria,
+  contributors,
+  level: ghostLevel(criteria, contributors),
+});
+
+/** gateMatrix builds the four combinations of the two gates, asking the rule for each
+ *  level rather than stating it.
+ *
+ *  Row-major from the corner that shows nothing: neither gate, convergence only, witnesses
+ *  only, both. The top-right cell — structural convergence with nobody to witness it — is
+ *  the one the page is really about, because no amount of posting shape moves it down to
+ *  the last one. */
+export function gateMatrix(): GateCell[] {
+  const structural = byTier('structural');
+  const outcome = byTier('outcome');
+
+  return [
+    cell(false, false, [], 0),
+    cell(true, false, structural, 0),
+    cell(false, true, outcome.slice(0, 1), WITNESS_GATE),
+    cell(true, true, [...structural.slice(0, 1), ...outcome.slice(0, 1)], WITNESS_GATE),
+  ];
+}

--- a/web/src/lib/ghostFaq.test.ts
+++ b/web/src/lib/ghostFaq.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { GHOST_FAQ } from './ghostFaq';
+import { faqPageJsonLd } from './seo';
+
+describe('GHOST_FAQ', () => {
+  it('carries entries', () => {
+    expect(GHOST_FAQ.length).toBeGreaterThan(0);
+  });
+
+  it('asks each question once', () => {
+    const questions = GHOST_FAQ.map((f) => f.question);
+    expect(new Set(questions).size).toBe(questions.length);
+  });
+
+  it('answers every question', () => {
+    for (const { question, answer } of GHOST_FAQ) {
+      expect(question.trim(), `question: ${question}`).not.toBe('');
+      expect(answer.trim(), `answer to: ${question}`).not.toBe('');
+    }
+  });
+
+  // The page renders this same array into its FAQPage payload, so the structured
+  // data cannot drift from the visible text. Google drops the rich result when the
+  // two disagree, and collapsing the visible FAQ behind disclosures does not change
+  // that — the answers stay in the served HTML precisely so they still match.
+  it('feeds the FAQPage payload', () => {
+    const jsonLd = faqPageJsonLd(GHOST_FAQ) as { mainEntity: { name: string }[] };
+    expect(jsonLd.mainEntity.map((e) => e.name)).toEqual(GHOST_FAQ.map((f) => f.question));
+  });
+
+  // Deliberately NOT here: the word-blacklist check that guards GHOST_SIGNALS. That
+  // test works on the criteria vocabulary because `label`, `fact` and `why` are
+  // assertions — they never argue with anybody. A FAQ is a dialogue, and its work is to
+  // voice the reader's suspicion and refuse it: "An unanswered application means the job
+  // is fake, then?" is answered "No — that is why it takes two people and a second
+  // signal." A blacklist flags that as an accusation, and the only way to satisfy it is
+  // to blunt a question that is doing its job. A test that makes the copy worse is worse
+  // than no test.
+  //
+  // For the same reason "What is a ghost job?" belongs here. The word is barred from
+  // interface attached to a posting, where it would accuse a named employer; on the page
+  // that explains the signal it is the term the reader searched for.
+});

--- a/web/src/lib/ghostSignals.test.ts
+++ b/web/src/lib/ghostSignals.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CRITERIA } from './ghost';
-import { CONVERGENCE, GHOST_SIGNALS, WITNESS_GATE } from './ghostSignals';
+import { GHOST_SIGNALS } from './ghostSignals';
 
 describe('GHOST_SIGNALS', () => {
   // The point of this test: a criterion cannot join the product without being
@@ -10,7 +10,20 @@ describe('GHOST_SIGNALS', () => {
     expect(GHOST_SIGNALS.map((s) => s.code)).toEqual(CRITERIA.map((c) => c.code));
     for (const s of GHOST_SIGNALS) {
       expect(s.fact, `${s.code} has no example fact`).toBeTruthy();
+      expect(s.gist, `${s.code} has no short summary`).toBeTruthy();
       expect(s.why, `${s.code} has no explanation`).toBeTruthy();
+    }
+  });
+
+  // `gist` is what the reader sees without expanding anything; `why` is the full
+  // account, one disclosure away. The ceiling is not a style rule — it is the failure
+  // mode: a gist that grows into a second `why` rebuilds the wall of grey the page was
+  // restructured to remove, and does it without anything going red.
+  it('keeps the visible summary short', () => {
+    for (const s of GHOST_SIGNALS) {
+      const words = s.gist.trim().split(/\s+/).length;
+      expect(words, `${s.code} gist runs ${words} words`).toBeLessThanOrEqual(40);
+      expect(words, `${s.code} gist is shorter than the fact it summarises`).toBeGreaterThan(5);
     }
   });
 
@@ -19,18 +32,15 @@ describe('GHOST_SIGNALS', () => {
     expect(tiers).toEqual(new Set(['structural', 'outcome']));
   });
 
-  // The page states these numbers in prose. If the product changes them, the prose
-  // becomes a lie, so they are read from one place rather than typed twice.
-  it('pins the two gates the page describes', () => {
-    expect(CONVERGENCE).toBe(2);
-    expect(WITNESS_GATE).toBe(2);
-  });
+  // The gates were pinned here when the page stated them in prose. They are pinned in
+  // ghost.test.ts now, beside the rule that reads them — the matrix interpolates the
+  // constants instead of quoting them, so there is no second copy left to keep honest.
 
   // Nothing here may claim the system knows what an employer intends: it observes
   // postings and outcomes, and that limit is the whole reason the wording hedges.
   it('never claims to know an employer intent', () => {
     for (const s of GHOST_SIGNALS) {
-      expect(`${s.label} ${s.fact} ${s.why}`.toLowerCase()).not.toMatch(
+      expect(`${s.label} ${s.fact} ${s.gist} ${s.why}`.toLowerCase()).not.toMatch(
         /\bfake\b|\bscam\b|not really hiring|no intention/,
       );
     }

--- a/web/src/lib/ghostSignals.ts
+++ b/web/src/lib/ghostSignals.ts
@@ -12,34 +12,45 @@
 // claims the system knows an employer's intent, because it does not.
 
 import { CRITERIA } from './ghost';
+import type { GhostCriterionCode } from './ghost';
 
 export interface SignalExplainer {
-  code: string;
+  /** The union rather than `string`: the landing hands this straight to the diagram
+   *  registry, which is keyed by it. */
+  code: GhostCriterionCode;
   /** Short human name — the checklist row's label. */
   label: string;
   /** structural = the shape of the posting; outcome = what happened to an applicant. */
   tier: 'structural' | 'outcome';
   /** An example of the observations behind it — illustrative, not a transcript of the UI. */
   fact: string;
-  /** Why this is evidence, and what it is not. */
+  /** The one-line version, always visible beside the criterion's diagram. Carries the
+   *  single limit that matters most for this criterion, because a summary that drops
+   *  every caveat is how a hedged page turns into an accusing one. */
+  gist: string;
+  /** Why this is evidence, and what it is not — the full account, one disclosure away. */
   why: string;
 }
 
-const EXPLAINERS: Record<string, { fact: string; why: string }> = {
+const EXPLAINERS: Record<string, { fact: string; gist: string; why: string }> = {
   evergreen_posting: {
     fact: 'Open 240 days · reposted 13× · 7 copies open at once',
+    gist: 'One role advertised over and over, often with several copies live at the same time. Age alone never fires it — a genuinely hard senior role stays open a long while.',
     why: 'One role advertised over and over, often with several copies live at the same time. It never fires on age alone — a genuinely hard senior role stays open a long time. Age is measured from when freehire first saw the posting, not from the date the source prints, so refreshing that date does not reset it.',
   },
   ats_absent: {
     fact: "Not on the company's own careers board · checked 2 days ago",
+    gist: "The posting reached us through an aggregator, and the same role is not on the employer's own board. It counts only where we crawl that board, never where we cannot look.",
     why: "The posting reached us through an aggregator, and the same role is not on the employer's own board. It only counts where we actually crawl that board — otherwise absence would report our blind spot as the employer's fault. The check is re-run continuously and expires if it stops, so a stale answer goes quiet instead of standing.",
   },
   silent_applications: {
     fact: 'Applications through freehire went unanswered past their follow-up window',
+    gist: 'People who applied here and were not answered within the window their stage tolerates. Counted only where a mailbox is connected, so a reply would have been seen.',
     why: 'People who applied here, whose mailbox is connected so a reply would have been seen, and who were not answered within the window their stage tolerates. Without a connected mailbox we could not tell silence from a gap in our data, so those applications are not counted at all.',
   },
   user_reports: {
     fact: 'People reported applying with no response',
+    gist: 'Someone states they applied on a given date and heard nothing. It carries no weight until the wait a tracked application gets has passed, and it can be withdrawn.',
     why: 'Someone states they applied on a given date and heard nothing. It carries no weight until the same span has passed that a tracked application gets, and it can be withdrawn — an employer who answers late costs the posting its evidence.',
   },
 };
@@ -52,9 +63,8 @@ export const GHOST_SIGNALS: SignalExplainer[] = CRITERIA.flatMap((c) => {
   return explainer ? [{ code: c.code, label: c.label, tier: c.tier, ...explainer }] : [];
 });
 
-/** How many criteria must fire before anything is shown. Mirrors internal/ghost. */
-export const CONVERGENCE = 2;
-
-/** How many distinct people must have contributed outcome evidence for the stronger
- *  claim — and the reason a count is never shown below it. */
-export const WITNESS_GATE = 2;
+// The gates used to live here and now live in `./ghost`, beside the rule that reads them
+// and in the one module that declares itself the mirror of internal/ghost's constants.
+// No re-export is left behind: the page no longer quotes the numbers in prose — the gate
+// matrix interpolates them from the constants — so every consumer imports them from the
+// authority directly.


### PR DESCRIPTION
## What and why

`/features/ghost-jobs` is reached from the **How this works** link inside `GhostChecklist` on a marked job, so its reader arrives mid-question: *which criteria fired, and why is the warning not stronger.* What they found was eight stacked sections and ~2,500 words of uniform small grey text, with those two answers the hardest things to extract. The feature is four criteria, two tiers, two gates and a published range — all of it drawable, none of it drawn.

Eight sections become five plus a collapsed FAQ. Visible copy drops to ~1,000 words and **nothing is deleted**: the long `why` for each criterion and every FAQ answer move behind native `<details>` and stay in the served HTML, so `faqPageJsonLd` still matches what the page shows.

### Six diagrams

| | |
|---|---|
| Prevalence waffle | 18–27% as a band, not an averaged figure — the floor every study agrees on, ringed cells for the width of the disagreement |
| `evergreen_posting` | a stack of concurrent copies and a repost count, **with no time axis** |
| `ats_absent` | found / absent from a crawled board / *board we don't crawl → not judged at all* |
| `silent_applications` | three lanes: counts, reply arrived, no mailbox (drawn hollow) |
| `user_reports` | one contributor vs two, count below the gate drawn as **absent**, not zeroed |
| Gate matrix | 2×2 making "structural evidence can never reach `likely`" geometric |

The static preview becomes a sandbox driving the **real** `GhostBadge` and `GhostChecklist`, where the reader discovers the ceiling by failing to pass it.

### Two invariants replacing things that were only asserted

- **`ghostLevel()`** joins `$lib/ghost`, with `CONVERGENCE` and `WITNESS_GATE` moved beside it. The gate rule existed nowhere in the frontend — the page stated it in English no test could reach. Its witness gate additionally requires an outcome criterion to have fired: a no-op on any real payload (`internal/ghost/evidence.go` only ever increments `Contributors` alongside an outcome row), but a genuine guard for a sandbox that moves both controls independently.
- **`CRITERIA as const satisfies`** derives a `GhostCriterionCode` union keying the diagram registry, so a criterion joining the vocabulary without an illustration is `TS2741`. This replaces a planned unit test: vitest here cannot import a `.svelte` component without test infrastructure this project does not carry. Verified by deleting an entry and watching it fail.

### Why the evergreen diagram has no time axis

Its example copy opens with a posting's age, which invites one. But age alone does not fire the criterion, and in the live catalogue effectively never does — of the open postings carrying a fresh stamp, none are past the 90-day threshold; they converge through repost and concurrent-copy thresholds. A timeline would be the most legible element on the page and would name the wrong cause to the one reader who came to find out the right one.

### Review found two things worth naming

- A new sentence claimed *"nothing shows at all until at least two criteria fire"* — which the classifier does not do, and which the gate matrix three lines below it visibly refutes. Reworded to speak of gates.
- `pnpm lint` was exiting 1 while my verification reported "at baseline": I had been counting lines matching `warning`, and an error line contains no such word.

Also fixed from review: the sandbox guard ran one way only; the waffle band was separated from the remainder by hue alone in dark; the matrix rendered as divs rather than a `<table>` with scoped headers; four disclosures shared one accessible name.

OpenSpec change: `openspec/changes/ghost-jobs-landing-redesign/` — new capability `ghost-jobs-feature-landing`, plus a delta on `ghost-job-signal` growing its "the explaining page previews the signal" requirement to cover an operable preview and a tested level rule.

### Not done

The walk from an **actually marked** job through the *How this works* link needs a running API and a live stamp; only the destination is verified here. Worth doing on the deploy preview.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` — no Go touched by this change.
- [x] `go test ./...` — no Go touched by this change.
- [x] I regenerated committed artifacts when their source changed — none changed.
- [x] For `design-system/` changes: none.
- [x] For `web/` changes: `pnpm run check` (0 errors), `pnpm run build` and `pnpm lint` all exit 0; 626 unit tests pass.
- [x] This stays within freehire's core/extension boundary — a landing page and one exported rule, no new dependency.