### PR TITLE
chore(db): drop cvs.autopilot_undo, and announce the history

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -129,7 +129,6 @@ type Cv struct {
 	AgentSessionID  pgtype.Text        `json:"agent_session_id"`
 	ID              uuid.UUID          `json:"id"`
 	AutopilotReport []byte             `json:"autopilot_report"`
-	AutopilotUndo   []byte             `json:"autopilot_undo"`
 	IsTailored      bool               `json:"is_tailored"`
 }
 

--- a/migrations/0061_drop_cvs_autopilot_undo.sql
+++ b/migrations/0061_drop_cvs_autopilot_undo.sql
@@ -1,0 +1,21 @@
+-- Retire cvs.autopilot_undo, the pre-run document snapshot an autopilot run used to take.
+--
+-- Undoing a run is undoing the revisions it made: every edit carries the batch of the turn it
+-- belongs to (see 0060), so the run is reconstructible from the log and nothing has to be
+-- copied up front. That also removed the edge the snapshot created — two runs started at once
+-- each took one, the second captured a half-edited document, and undoing returned to the
+-- middle of the first.
+--
+-- SEPARATE RELEASE, deliberately. The code stopped reading and writing this column in the
+-- release that shipped cv_revisions. Dropping it in that same release would have been a 42703
+-- on every CV read served by a binary that had not yet been replaced — sqlc generates reads
+-- that name every column of the table, so one missing column fails any query against `cvs`,
+-- not just the feature that owned it.
+--
+-- By the time this runs, both blue and green carry code that never mentions the column, so a
+-- rollback to the other colour is safe too.
+--
+-- Applied to a fresh volume by initdb after 0060; on an existing prod volume release.sh
+-- applies it (schema_migrations tracks it) before restarting the new colour.
+
+ALTER TABLE public.cvs DROP COLUMN autopilot_undo;

--- a/web/src/posts/2026-07-31-every-cv-edit-is-undoable-on-its-own.svx
+++ b/web/src/posts/2026-07-31-every-cv-edit-is-undoable-on-its-own.svx
@@ -1,0 +1,28 @@
+---
+title: Every CV edit is undoable on its own
+date: 2026-07-31
+summary: The tailoring workspace now keeps a history of what changed your CV — yours and the assistant's — with an undo button on each entry and the edit underlined in the preview.
+type: changelog
+tags:
+  - cv
+  - tailor
+draft: false
+---
+
+Two hands edit a tailored CV: yours and the assistant's. Until now you could see the result and
+nothing else. If the assistant rewrote eleven bullets and you disliked one of them, the only way
+back was to undo the whole run — losing the ten you were happy with.
+
+The [tailoring workspace](/features/tailor) has a **History** tab. Every change to the CV is an
+entry: who made it, when, what it changed, and a button that reverses that one edit and leaves the
+rest alone. Hovering an entry underlines what it touched in the live preview, so "what did it
+actually change" is answered by looking at the page rather than by reading a description of it.
+
+- An assistant run folds into one entry you can undo whole — or open, to undo any single edit
+  inside it.
+- Undoing is itself recorded, so you can undo an undo, and the history keeps describing what
+  really happened to the document.
+- Your own edits are in there too. The history is of the CV, not of the assistant.
+
+When the assistant explains why it made a change, that note sits under the entry in its own
+words — separate from the description of what changed, which is ours.


### PR DESCRIPTION
Two things that belong to the release AFTER #1337, now that it is on prod.

**The column.** `cvs.autopilot_undo` held the pre-run snapshot. Undoing a run is undoing the revisions it made — each carries its turn's batch — so nothing is copied up front, and the edge where two concurrent runs snapshotted over each other went with it.

Separate release deliberately: the code stopped reading the column in #1337, and dropping it there would have been a 42703 on every CV read served by a binary not yet replaced (sqlc names every column of a table in its reads). By the time this runs, both colours carry code that never mentions it.

**The changelog.** The feature has been live since #1337 deployed and had no announcement. The entry describes what a job seeker gets: every edit to a CV has its own undo, and hovering an entry underlines what it changed in the preview.

Verified: `go test` and the `internal/db` integration suite (which builds the schema from `migrations/` and checks it) green; `pnpm build` green, so the post satisfies the blog loader.