### PR TITLE
fix(cvedit): a degree nobody earned needed no evidence

### DIFF
--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -65,11 +65,13 @@ type TailoredItem struct {
 
 // Repository persists CVs. Every read/update/delete is owner-scoped by (id, userID); a
 // foreign or missing id yields pgx.ErrNoRows (Get/Update) or a zero delete count.
+// Repository deliberately has NO method that writes a CV's document. internal/cvedit owns
+// that, and one declared here — even unused — is an invitation to write a document with no
+// revision, no policy and no evidence gate behind it.
 type Repository interface {
 	Create(ctx context.Context, userID int64, title, templateID string, data []byte) (db.CreateCVRow, error)
 	List(ctx context.Context, userID int64) ([]db.ListCVsByUserRow, error)
 	Get(ctx context.Context, id uuid.UUID, userID int64) (db.GetCVByIDRow, error)
-	Update(ctx context.Context, id uuid.UUID, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error)
 	Delete(ctx context.Context, id uuid.UUID, userID int64) (int64, error)
 	GetBase(ctx context.Context, userID int64) (db.GetBaseCVByUserRow, error)
 	CreateTailored(ctx context.Context, userID, jobID int64, title, templateID string, data []byte) (db.CreateTailoredCVRow, error)
@@ -349,10 +351,6 @@ func (r queriesRepository) List(ctx context.Context, userID int64) ([]db.ListCVs
 
 func (r queriesRepository) Get(ctx context.Context, id uuid.UUID, userID int64) (db.GetCVByIDRow, error) {
 	return r.q.GetCVByID(ctx, db.GetCVByIDParams{ID: id, UserID: userID})
-}
-
-func (r queriesRepository) Update(ctx context.Context, id uuid.UUID, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
-	return r.q.UpdateCV(ctx, db.UpdateCVParams{ID: id, UserID: userID, Title: title, TemplateID: templateID, Data: data})
 }
 
 func (r queriesRepository) Delete(ctx context.Context, id uuid.UUID, userID int64) (int64, error) {

--- a/internal/cvedit/AGENTS.md
+++ b/internal/cvedit/AGENTS.md
@@ -25,11 +25,19 @@ outside it: nobody edited them, and they would read as nonsense in a feed of edi
 is still in hand. `Apply` is all-or-nothing: a refused batch leaves the state untouched, so a
 rejected edit is never a partial one.
 
-What a revision STORES, though, is `Diff(sanitized-after, before)` — derived from what will
-actually be written, not from what `Apply` produced. The sanitizer runs afterwards and drops
-entries with nothing in them and bullets that were only whitespace; every index after such a
-drop shifts, and an inverse computed a moment earlier then removes the wrong element. That cost
-a real experience entry in the test that found it.
+Which inverse a revision STORES depends on whether the sanitizer moved anything:
+
+- **It did not** (the overwhelming majority) — `Apply`'s inverse is stored. It reverses each
+  operation in kind, so undoing a reorder is one `move` back.
+- **It did** — `Diff(sanitized-after, before)` is stored instead. The sanitizer drops empty
+  entries and whitespace-only bullets, every index after such a drop shifts, and an inverse
+  computed a moment earlier removes the wrong element. That cost a real experience entry in the
+  test that found it.
+
+Storing the diff unconditionally was the first attempt, and it broke reorders: the differ has no
+`move` in its vocabulary, so a reorder's inverse came back as field-by-field rewrites of every
+entry the move touched — and applying those overwrote whatever had been edited since, which is
+exactly the promise undo makes and must not break.
 
 An absent list and an empty one are the same stored state (the json tags omit both). Both
 `Apply` and `Diff` treat them as one; keeping them distinct had the differ reporting operations

--- a/internal/cvedit/editor.go
+++ b/internal/cvedit/editor.go
@@ -171,20 +171,32 @@ func (e *Editor) commit(ctx context.Context, tx Tx, cvID uuid.UUID, userID int64
 	if err != nil {
 		return cv.Meta{}, Revision{}, err
 	}
-	after, _, err := Apply(before, ch.Ops)
+	applied, applyInverse, err := Apply(before, ch.Ops)
 	if err != nil {
 		return cv.Meta{}, Revision{}, err
 	}
 
 	// Sanitize after applying and before storing, exactly as the whole-document path always
 	// has: a change states what was asked for, and the sanitizer decides what is kept.
+	after := applied
 	after.Document.Sanitize()
 
-	// The inverse is derived from what will actually be STORED, not from what Apply produced.
-	// The sanitizer drops entries with nothing in them and bullets that were only whitespace,
-	// and every index after such a drop shifts — so an inverse computed a moment earlier
-	// removes the wrong element. It cost a real experience entry in the test that found this.
-	inverse := Diff(after, before)
+	// Which inverse to store depends on whether the sanitizer moved anything.
+	//
+	// Apply's inverse is the precise one: it reverses each operation in kind, so undoing a
+	// reorder is one `move` back rather than a rewrite of every entry it touched. But it was
+	// computed against the pre-sanitized result, and the sanitizer drops empty entries and
+	// whitespace-only bullets — every index after such a drop shifts, and the inverse then
+	// removes the wrong element.
+	//
+	// So: keep Apply's inverse when the sanitizer changed nothing (the overwhelming majority,
+	// and the only case where a `move` survives at all — the differ has no move in its
+	// vocabulary). Fall back to the diff when it did, where precision is already lost but
+	// correctness is not.
+	inverse := applyInverse
+	if !Equal(applied, after) {
+		inverse = Diff(after, before)
+	}
 
 	// An operation that changes nothing files nothing. Picking the template already in use
 	// is a click the gallery allows, and "switched to the Sidebar template" under a CV that

--- a/internal/cvedit/policy.go
+++ b/internal/cvedit/policy.go
@@ -93,18 +93,38 @@ type EvidenceGate interface {
 	Publishable(ctx context.Context, userID int64, evidenceID string) error
 }
 
-// claimShapes are the places where writing means asserting something about the candidate.
-// The gate is keyed on these rather than on operation names, which is what closes a hole the
-// old vocabulary had: only two of its eight operations required evidence, so a technology
-// written into a stack line or a skill group arrived uncited while the same claim as a bullet
-// was refused. Same assertion, different syntax.
-var claimShapes = map[string]bool{
-	"summary":                true,
-	"experience[].summary":   true,
-	"experience[].bullets[]": true,
-	"experience[].stack[]":   true,
-	"projects[].bullets[]":   true,
-	"skills[].items[]":       true,
+// presentationShapes are the places that assert NOTHING about the candidate: how the CV
+// looks, and what it is called. Everything else in the document is a claim.
+//
+// The list is inverted on purpose, and the earlier version — a list of the places that DO
+// carry a claim — is why. It named summary, bullets, stack and skills, so a degree nobody
+// earned, a certification nobody holds and a job title nobody had all landed uncited. They
+// are the larger lie: a recruiter checks a diploma, not a bullet's phrasing.
+//
+// Listing what is exempt makes the default safe. A field added to the document is a claim
+// until someone says otherwise, which is the direction this has to fail in.
+var presentationShapes = map[string]bool{
+	"title":             true,
+	"template_id":       true,
+	"style":             true,
+	"style.font_family": true,
+	"style.font_size":   true,
+	"style.line_height": true,
+	"margins":           true,
+	"margins.top":       true,
+	"margins.right":     true,
+	"margins.bottom":    true,
+	"margins.left":      true,
+	// The header is the candidate's identity rather than a claim about their career, and the
+	// agent is denied most of it by policy anyway. What it may still write — the location —
+	// is the candidate's own to state and is not evidenced in the bank.
+	"header":           true,
+	"header.full_name": true,
+	"header.email":     true,
+	"header.phone":     true,
+	"header.location":  true,
+	"header.links":     true,
+	"header.links[]":   true,
 }
 
 var pathIndex = regexp.MustCompile(`\[\d+\]`)
@@ -113,27 +133,17 @@ var pathIndex = regexp.MustCompile(`\[\d+\]`)
 // are recognised as the same kind of place.
 func shapeOf(p Path) string { return pathIndex.ReplaceAllString(string(p), "[]") }
 
-// assertsAClaim reports whether an operation puts a new claim about the candidate on the
-// page. Removing and moving assert nothing: they rearrange or delete what was already said.
+// assertsAClaim reports whether an operation puts a claim about the candidate on the page.
+// Removing and moving assert nothing: they rearrange or delete what was already said.
 //
-// A container counts. Writing `experience[0]` writes the bullets inside it, and `skills[0]`
-// writes the items — so an operation is gated when its shape IS a claim shape or when a claim
-// shape sits inside it. Checking only for an exact match reopened, one level up, exactly the
-// hole this gate was moved onto paths to close.
+// Anything that is not presentation is a claim, INCLUDING a container: writing `experience[0]`
+// writes the bullets inside it, and writing `education` replaces the whole section. A write to
+// a container of presentation — `style` — is exempt only because everything inside it is.
 func assertsAClaim(op Op) bool {
 	if op.Kind != OpSet && op.Kind != OpInsert {
 		return false
 	}
-	shape := shapeOf(op.Path)
-	if claimShapes[shape] {
-		return true
-	}
-	for claim := range claimShapes {
-		if nests(claim, shape) {
-			return true
-		}
-	}
-	return false
+	return !presentationShapes[shapeOf(op.Path)]
 }
 
 // requireEvidence holds the rule the whole tailoring capability exists to keep: a sentence

--- a/internal/cvedit/policy_test.go
+++ b/internal/cvedit/policy_test.go
@@ -261,3 +261,62 @@ func TestWritingAContainerOfClaimsNeedsEvidence(t *testing.T) {
 		})
 	}
 }
+
+// A degree nobody earned is a bigger lie than a bullet nobody wrote, and it was landing
+// uncited: the gate listed the places that carry a claim, and education, certifications and
+// languages were simply not on the list. Nor were an entry's own identity fields — the role,
+// the employer, the dates.
+func TestFabricatedCredentialsNeedEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		op    Op
+		value any
+	}{
+		{"a degree", Op{Kind: OpInsert, Path: "education[0]"},
+			map[string]any{"institution": "Stanford", "degree": "PhD"}},
+		{"the whole education section", Op{Kind: OpSet, Path: "education"},
+			[]map[string]any{{"institution": "MIT", "degree": "MSc"}}},
+		{"a certification", Op{Kind: OpInsert, Path: "certifications[0]"},
+			map[string]any{"name": "AWS Solutions Architect Professional"}},
+		{"a language", Op{Kind: OpInsert, Path: "languages[0]"},
+			map[string]any{"name": "Japanese", "level": "native"}},
+		{"an inflated job title", Op{Kind: OpSet, Path: "experience[0].role"}, "VP of Engineering"},
+		{"an employer never worked for", Op{Kind: OpSet, Path: "experience[0].company"}, "Google"},
+		{"a papered-over gap", Op{Kind: OpSet, Path: "experience[0].start"}, "2015"},
+		{"a skill group's name", Op{Kind: OpSet, Path: "skills[0].group"}, "Distributed Systems"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newFakeRepo()
+			e, _ := newEditor(repo, &bank{})
+
+			op := tc.op
+			op.Value = tc.value
+			if err := agentEdit(t, e, op); !errors.Is(err, ErrEvidenceRequired) {
+				t.Fatalf("uncited write to %s returned %v, want ErrEvidenceRequired", op.Path, err)
+			}
+			if repo.saves != 0 {
+				t.Fatal("an uncited claim was written")
+			}
+		})
+	}
+}
+
+// Presentation is not a claim: the candidate's own layout choices assert nothing about their
+// career, and gating them would leave the agent unable to fit a CV onto one page.
+func TestPresentationNeedsNoEvidence(t *testing.T) {
+	repo := newFakeRepo()
+	b := &bank{}
+	e, _ := newEditor(repo, b)
+
+	for _, op := range []Op{
+		{Kind: OpSet, Path: "style.font_size", Value: 11.0},
+		{Kind: OpSet, Path: "margins.left", Value: 0.75},
+	} {
+		if err := agentEdit(t, e, op); err != nil {
+			t.Fatalf("%s was gated: %v", op.Path, err)
+		}
+	}
+	if b.calls != 0 {
+		t.Fatalf("the bank was asked %d times about presentation", b.calls)
+	}
+}

--- a/internal/cvedit/undo.go
+++ b/internal/cvedit/undo.go
@@ -89,19 +89,22 @@ func (e *Editor) undo(ctx context.Context, tx Tx, cvID uuid.UUID, inverse []Op,
 		return cv.Meta{}, Revision{}, err
 	}
 
-	after, _, err := Apply(before, inverse)
+	applied, applyRedo, err := Apply(before, inverse)
 	if err != nil {
 		// The place the inverse would restore is gone. This is a fact about the document as
 		// it stands, not a malformed request — and it cannot be known without trying, which
 		// is why the control is offered and the failure explained.
 		return cv.Meta{}, Revision{}, fmt.Errorf("%w: %s", ErrCannotUndo, err)
 	}
+	after := applied
 	after.Document.Sanitize()
 
-	// Derived from the sanitized result, exactly as a commit's inverse is: undoing an undo has
-	// to return to what was stored, not to what Apply produced a moment before the sanitizer
-	// looked at it.
-	redo := Diff(after, before)
+	// Same rule as a commit: the precise inverse unless the sanitizer moved something, in
+	// which case the diff against what was stored is the only one that applies cleanly.
+	redo := applyRedo
+	if !Equal(applied, after) {
+		redo = Diff(after, before)
+	}
 
 	meta, err := tx.Save(ctx, after)
 	if err != nil {

--- a/internal/cvedit/undo_test.go
+++ b/internal/cvedit/undo_test.go
@@ -217,3 +217,39 @@ func TestUndoingARevisionOfAnotherCVIsRefused(t *testing.T) {
 		t.Fatalf("the wrong document was rewritten: %q", repo.state.Summary)
 	}
 }
+
+// Undoing a reorder must reverse the reorder and nothing else. Deriving the inverse from a
+// diff cannot express that: the differ has no `move` in its vocabulary, so a reorder's inverse
+// came back as field-by-field rewrites of every entry the move touched — and applying those
+// overwrote whatever had been edited since.
+func TestUndoingAMoveLeavesLaterEditsAlone(t *testing.T) {
+	repo := newFakeRepo()
+	e, c := newEditor(repo, nil)
+	to := 1
+
+	_, reorder, err := e.Commit(context.Background(), repo.cvID, 1, Change{
+		Actor: ActorCandidate, Origin: OriginEditor,
+		Ops: []Op{{Kind: OpMove, Path: mustParse(t, "experience[0]"), To: &to}},
+	})
+	if err != nil {
+		t.Fatalf("Commit(move): %v", err)
+	}
+	if repo.state.Experience[0].Company != "Initech" {
+		t.Fatalf("the move did not happen: %+v", repo.state.Experience)
+	}
+
+	// A later edit to the entry that moved.
+	c.at = c.at.Add(2 * time.Minute)
+	commitSet(t, e, repo, ActorCandidate, OriginEditor, "experience[1].role", "Staff Engineer")
+
+	if _, _, err := e.Revert(context.Background(), repo.cvID, 1, reorder.ID); err != nil {
+		t.Fatalf("Revert: %v", err)
+	}
+
+	if repo.state.Experience[0].Company != "Acme" {
+		t.Fatalf("the reorder was not undone: %+v", repo.state.Experience)
+	}
+	if got := repo.state.Experience[0].Role; got != "Staff Engineer" {
+		t.Fatalf("role = %q, want the later edit to have survived the undo", got)
+	}
+}


### PR DESCRIPTION
Three defects a verification pass found in what shipped with #1337 and #1341. All three are live on prod.

## The gate missed the larger lie

It listed the places that carry a claim — summary, bullets, stack, skills — so education, certifications, languages, and an entry's own role, employer and dates were on nobody's list. The tailoring agent could write any of them without citing anything:

```
insert education[0] {Stanford, PhD, Computer Science}   → landed, bank never asked
insert certifications[0] {AWS Solutions Architect Pro}  → landed
set experience[0].company = Google                      → landed
```

A recruiter checks a diploma; nobody audits a bullet's phrasing. This is the class of fabrication the gate exists to stop.

The list is inverted: `presentationShapes` names what is NOT a claim — typography, margins, title, template, header — and everything else in the document is one. A field added later is a claim until someone says otherwise. The enumerate-the-claims form has now leaked twice, one level at a time.

## Undoing a reorder clobbered later edits

Storing `Diff(after, before)` as the inverse unconditionally (the fix for the sanitizer defect) broke `move`: the differ has no move in its vocabulary, so a reorder's inverse came back as field-by-field rewrites of every entry it touched. Undoing the reorder then overwrote whatever had been edited since — the one promise undo makes.

Apply's inverse is stored when the sanitizer changed nothing; the diff only when it did, where precision was already lost but correctness is not.

## A write past the editor

`cv.Repository` declared and implemented a document write nothing called. Removed, with a note on the interface saying why it has none.

Verified: `go test ./...`, the handler and db integration suites, and new tests that fail without each fix.