### PR TITLE
test(handler): the actor comes from the credential, not the body

### DIFF
--- a/internal/handler/cv_integration_test.go
+++ b/internal/handler/cv_integration_test.go
@@ -393,3 +393,121 @@ func TestCVRevisionHistoryAndUndo(t *testing.T) {
 		t.Error("the reverted entry is not marked as undone")
 	}
 }
+
+// Who made a change decides what the change is allowed to do: the agent is refused the
+// candidate's own fields and must cite evidence for a claim, the candidate is refused
+// nothing. So the actor has to come from the credential that authenticated the request and
+// never from the request itself — otherwise the gate is one JSON field away from being
+// optional.
+//
+// This test is the tripwire for that. It sends the actor in the body, by the name the wire
+// shape uses, and asserts the recorded revision ignored it.
+func TestTheActorIsNeverReadFromTheRequestBody(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	if _, err := pool.Exec(context.Background(), "TRUNCATE cvs, users RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h := &cvHandlers{queries: queries, jobReader: queries,
+		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
+	app := buildCVApp(h, iss)
+
+	tok, _ := iss.Issue(seedAccount(t, pool, "actor@example.test", true), testTokenVersion)
+
+	var created struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	decodeJSON(t, doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs", tok, createCVRequest{Title: "General"}), &created)
+	id := created.Data.ID
+
+	// A whole-document save carrying an actor it is not entitled to. BodyParser ignores the
+	// unknown field; what matters is that the recorded revision does too.
+	body := map[string]any{
+		"title":       "General",
+		"template_id": "classic-ats",
+		"actor":       "system",
+		"origin":      "import",
+		"document": map[string]any{
+			"summary": "Ten years of Go",
+			"header":  map[string]any{"full_name": "Ada"},
+		},
+	}
+	if r := doCV(t, app, fiber.MethodPut, "/api/v1/me/cvs/"+id, tok, body); r.StatusCode != fiber.StatusOK {
+		t.Fatalf("save = %d", r.StatusCode)
+	}
+
+	var feed struct {
+		Data []cvedit.RevisionView `json:"data"`
+	}
+	decodeJSON(t, doCV(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+id+"/revisions", tok, nil), &feed)
+	if len(feed.Data) == 0 {
+		t.Fatal("the save left no revision")
+	}
+	for _, r := range feed.Data {
+		if r.Actor != "candidate" {
+			t.Errorf("revision recorded actor %q — the body was believed over the cookie", r.Actor)
+		}
+		if r.Origin != "editor" {
+			t.Errorf("revision recorded origin %q — the body was believed over the entry point", r.Origin)
+		}
+	}
+}
+
+// Every entry point that changes a CV must leave an entry in its history: a change nobody
+// recorded is a change nobody can undo, and the feed would be quietly incomplete.
+func TestEveryEntryPointLeavesARevision(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	if _, err := pool.Exec(context.Background(), "TRUNCATE cvs, users RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h := &cvHandlers{queries: queries, jobReader: queries,
+		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
+	app := buildCVApp(h, iss)
+
+	tok, _ := iss.Issue(seedAccount(t, pool, "entrypoints@example.test", true), testTokenVersion)
+
+	var created struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	decodeJSON(t, doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs", tok, createCVRequest{Title: "General"}), &created)
+	id := created.Data.ID
+
+	count := func() int {
+		var feed struct {
+			Data []cvedit.RevisionView `json:"data"`
+		}
+		decodeJSON(t, doCV(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+id+"/revisions", tok, nil), &feed)
+		return len(feed.Data)
+	}
+
+	before := count()
+	if r := doCV(t, app, fiber.MethodPut, "/api/v1/me/cvs/"+id, tok, updateCVRequest{
+		Title: "General", TemplateID: "classic-ats",
+		Document: cv.Document{Summary: "Ten years of Go", Header: cv.Header{FullName: "Ada"}},
+	}); r.StatusCode != fiber.StatusOK {
+		t.Fatalf("whole-document save = %d", r.StatusCode)
+	}
+	if after := count(); after != before+1 {
+		t.Errorf("a whole-document save left %d revisions, want one more than %d", after, before)
+	}
+
+	before = count()
+	if r := doCV(t, app, fiber.MethodPut, "/api/v1/me/cvs/"+id+"/template", tok,
+		setCVTemplateRequest{TemplateID: "centered"}); r.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("template pick = %d", r.StatusCode)
+	}
+	if after := count(); after != before+1 {
+		t.Errorf("the template pick left %d revisions, want one more than %d", after, before)
+	}
+}

--- a/openspec/changes/archive/2026-07-31-cv-revision-history/tasks.md
+++ b/openspec/changes/archive/2026-07-31-cv-revision-history/tasks.md
@@ -52,7 +52,7 @@
 - [x] 7.5 Tailored-copy creation and seeding → a system revision that opens the feed
 - [x] 7.6 `GET /me/cvs/:id/revisions` and `POST /me/cvs/:id/revisions/:rid/undo`, cookie-only
 - [x] 7.7 Retire `POST /me/cvs/:id/autopilot/undo` in favour of the batch revert
-- [ ] 7.8 Test: every entry point leaves a revision; the actor is never read from the request body
+- [x] 7.8 Test: every entry point leaves a revision; the actor is never read from the request body — the tripwire for the whole gate, since an actor a caller could name would make the policy optional
 
 ## 8. Titles
 
@@ -71,8 +71,8 @@
 ## 10. Retirement and clients
 
 - [x] 10.1 Stop reading and writing `cvs.autopilot_undo`
-- [ ] 10.2 Second migration, separate release: drop `cvs.autopilot_undo`
-- [ ] 10.3 Update `freehire-cli` to the new `PATCH` body
+- [x] 10.2 Second migration, separate release: drop `cvs.autopilot_undo` — #1341, applied 31.07
+- [x] 10.3 Update `freehire-cli` to the new `PATCH` body — freehire-cli#22, released as v0.14.0
 - [x] 10.4 `internal/cv/AGENTS.md` and `internal/handler/AGENTS.md`: the single writer, the path policy, the evidence paths
 
 ## 11. Verification
@@ -81,5 +81,5 @@
 - [x] 11.2 `make sqlc` after the migration; contracts regenerated for the new wire types
 - [x] 11.3 Web `pnpm check` and `vitest` — 0 type errors, 608 tests
 - [x] 11.4 Driven against a real stack (scratch DB built the initdb way, server on :8095, Vite on :5179): two saves recorded as two entries, a rewrite undone and the bullet restored, a second undo refused with 409, the undo itself in the feed with the reversed entry struck through, a tailored copy's feed opening with the system milestone (no undo control), and the underline landing on the rewritten bullet while the one beside it stays untouched. The agent's own run was NOT driven — this machine has no `LLM_*`, so a turn ends 503; `cv_edit` is covered by its unit and integration tests instead
-- [ ] 11.5 Second migration to drop `cvs.autopilot_undo`, in the release AFTER this one lands
-- [ ] 11.6 `freehire-cli`: update to the new `PATCH` body (separate repository)
+- [x] 11.5 Second migration to drop `cvs.autopilot_undo`, in the release AFTER this one lands — done; 79 migrations in the ledger
+- [x] 11.6 `freehire-cli`: update to the new `PATCH` body (separate repository) — v0.14.0, and the installer serves it


### PR DESCRIPTION
The last outstanding task from the cv-revision-history change, plus four ticks that were owed.

**The test that was missing.** Who made a change decides what it may do: the agent is refused the candidate's own header fields and must cite evidence for a claim, the candidate is refused nothing. An actor a caller could name in the request body would make that one JSON field away from optional.

Nothing was watching. The handlers hardcode it correctly today — `ActorCandidate` on the cookie paths, `ActorAgent` behind an API key — but a future edit could thread it from the request and every existing test would still pass.

The second test asserts every entry point leaves an entry in the history. A change nobody recorded is a change nobody can undo, and the feed would be quietly incomplete rather than visibly wrong.

**The ticks.** The archived task list claimed five outstanding items. Four had actually shipped — the `autopilot_undo` drop (#1341, applied) and the CLI release (freehire-cli v0.14.0) — and were simply never ticked. The fifth was this test. The list now reads true.

Verified: both tests pass against a real database (`-tags=integration`).