### PR TITLE
fix(assistant): the rehearsal's loose ends from review

### DIFF
--- a/internal/handler/assistant_interview_tools.go
+++ b/internal/handler/assistant_interview_tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -108,6 +109,13 @@ func (h *assistantHandlers) interviewContextTool(jobID int64) assistant.Tool {
 // a vacancy the caller never applied to has no stage, no invitation and no reason to
 // exist, and the missing row is also how we learn the session is not theirs.
 func (h *assistantHandlers) rehearsalContext(ctx context.Context, userID, jobID int64) (interviewContext, error) {
+	// A tool error is a sentence the model can act on; a nil dereference here is a panic
+	// inside the SSE writer's goroutine, where Registry.Call's error path cannot reach it
+	// and Fiber's recover is not listening. Production always wires both, so this guards
+	// the next partially-wired harness rather than a live caller.
+	if h.stages == nil || h.cv == nil {
+		return interviewContext{}, errors.New("the rehearsal context is unavailable in this deployment")
+	}
 	stage, err := h.stages.GetUserJobStage(ctx, db.GetUserJobStageParams{UserID: userID, JobID: jobID})
 	if err != nil {
 		return interviewContext{}, err
@@ -141,12 +149,17 @@ func (h *assistantHandlers) rehearsalContext(ctx context.Context, userID, jobID 
 		out.Requirements = h.evidenceFor(ctx, userID, capRequirements(analysis.RequirementMatch))
 	}
 
+	if h.invitation == nil {
+		return out, nil
+	}
 	if msg, err := h.invitation.InterviewInvitation(ctx, userID, jobID); err == nil {
 		out.Invitation = &interviewInvitation{
 			Untrusted: untrustedNotice,
-			From:      msg.FromName,
-			Subject:   msg.Subject,
-			Body:      clipRunes(msg.BodyText, interviewInvitationLimit),
+			// The display name, or the address when the sender left none — an ATS often
+			// does, which is the same reason the body falls back from text to HTML.
+			From:    invitationSender(msg),
+			Subject: msg.Subject,
+			Body:    clipRunes(msg.BodyText, interviewInvitationLimit),
 		}
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		// A mailbox that cannot be read costs the rehearsal its opening line about the
@@ -155,6 +168,16 @@ func (h *assistantHandlers) rehearsalContext(ctx context.Context, userID, jobID 
 	}
 
 	return out, nil
+}
+
+// invitationSender names who wrote the invitation: the display name when there is one,
+// otherwise the address. "From: " with nothing after it tells the model less than an
+// address does, and an ATS relay frequently sends exactly that.
+func invitationSender(msg inbox.Message) string {
+	if name := strings.TrimSpace(msg.FromName); name != "" {
+		return name
+	}
+	return strings.TrimSpace(msg.FromAddr)
 }
 
 // capRequirements keeps the requirements the interview is most likely to press on.

--- a/internal/handler/assistant_interview_tools_test.go
+++ b/internal/handler/assistant_interview_tools_test.go
@@ -238,6 +238,40 @@ func TestInterviewContextOmitsAMissingInvitation(t *testing.T) {
 	}
 }
 
+// An ATS relay often mails with no display name at all. "From: " with nothing after it
+// tells the model less than an address does — the same reason the body falls back from
+// text/plain to rendered HTML.
+func TestInterviewContextNamesTheSenderWhenTheresNoDisplayName(t *testing.T) {
+	invite := invitationStub{msg: inbox.Message{
+		Subject: "Interview invitation", FromAddr: "no-reply@ashbyhq.test", FromName: "",
+		BodyText: "Tuesday at 10.",
+	}}
+	a := rehearsalAPI(t, twoRequirementAnalysis, nil, stageStub{stage: "interview"}, invite)
+
+	out, err := toolByName(t, a.assistantInterviewTools(9), "interview_context").
+		Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("interview_context: %v", err)
+	}
+	got := out.(interviewContext)
+	if got.Invitation == nil || got.Invitation.From != "no-reply@ashbyhq.test" {
+		t.Errorf("invitation from = %q, want the address when the sender left no name", got.Invitation.From)
+	}
+}
+
+// A tool that reaches a collaborator nobody wired must report it, not panic: the call
+// runs inside the SSE writer's goroutine, where Registry.Call's error path cannot reach
+// a panic and Fiber's recover is not listening.
+func TestInterviewContextReportsAnUnwiredDeployment(t *testing.T) {
+	bare := &assistantHandlers{}
+
+	_, err := toolByName(t, bare.assistantInterviewTools(9), "interview_context").
+		Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("interview_context answered from a handler wired to nothing")
+	}
+}
+
 // A rehearsal for an application the caller does not have is not a rehearsal. The stage
 // read is the ownership check: user_jobs holds one row per (user, vacancy).
 func TestInterviewContextRefusesAVacancyTheCallerHasNotApplied(t *testing.T) {

--- a/web/src/lib/components/BoardCard.svelte
+++ b/web/src/lib/components/BoardCard.svelte
@@ -24,8 +24,9 @@
   // is still quiet, the label says we already prodded them. Neither replaces the other.
   const offersFollowUp = $derived(canFollowUp(item));
   const chased = $derived(chasedLabel(item));
-  // The two actions never appear together: a follow-up is offered on silence, a
-  // rehearsal once an employer has engaged, and an application is not both.
+  // Both can show at once: `screening` tolerates 18 days of silence, so an application
+  // waiting on a scheduled call that has gone quiet offers a chase AND a rehearsal. The
+  // row wraps, and the rehearsal is listed first because it is the one with a date on it.
   const offersRehearsal = $derived(canRehearse(item));
 </script>
 
@@ -117,7 +118,8 @@
       <button
         type="button"
         onclick={() => onfollowup(item)}
-        class="relative z-10 ml-auto flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-warning-strong transition-colors hover:bg-warning-muted text-warning-strong dark:hover:bg-warning-muted/50"
+        class:ml-auto={!offersRehearsal}
+        class="relative z-10 flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-warning-strong transition-colors hover:bg-warning-muted text-warning-strong dark:hover:bg-warning-muted/50"
       >
         <Send class="size-3 shrink-0" aria-hidden="true" />
         {chased ? 'Chase again' : 'Follow up'}


### PR DESCRIPTION
Closes tasks 7.3, 7.4 and 7.5 recorded in `openspec/changes/archive/2026-07-31-interview-rehearsal-preset/tasks.md`.

- **7.4** `rehearsalContext` dereferenced `h.stages`, `h.cv` and `h.invitation` unguarded. Not reachable through production wiring, but the call runs inside the SSE writer's goroutine — a panic there escapes both `Registry.Call`'s error path and Fiber's recover. Now it reports itself unavailable, with a test.
- **7.5** `interviewInvitation.From` fell back to nothing when the sender left no display name, which ATS relays routinely do — the same reason the body already falls back from `body_text` to rendered HTML. Now falls back to the address, with a test.
- **7.3** The card's comment asserted the two actions are mutually exclusive; they are not (an application in `screening` silent past 18 days shows both). Comment corrected, and the `ml-auto` collision fixed so the two buttons stay together on the right.

Still open from that list: 7.1 (the opening brief renders as the candidate's own message) and 7.2 (the web auto-open fires only from `boot()`), both of which need the turn's origin to survive into the transcript.