### PR TITLE
fix(match): make fit-stream failures visible, and stop them hanging

### DIFF
--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -599,8 +599,18 @@ func mapAssistantError(err error) error {
 	return err
 }
 
+// writeComment writes an SSE comment line — ignored by EventSource — as a heartbeat that
+// keeps the connection producing bytes through long, silent stages. A write error (client
+// gone) is swallowed: the turn learns a connection is dead from writeEvent, not from here.
+func writeComment(w *bufio.Writer, text string) {
+	if _, err := fmt.Fprintf(w, ": %s\n\n", text); err != nil {
+		return
+	}
+	_ = w.Flush()
+}
+
 // writeEvent writes one named SSE event, reporting whether the write reached the
-// client. Unlike writeSSE it does not swallow the failure: a dead connection is
+// client. Unlike writeComment it does not swallow the failure: a dead connection is
 // how a streamed turn learns to stop.
 func writeEvent(w *bufio.Writer, event string, data any) bool {
 	blob, err := json.Marshal(data)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -55,7 +55,13 @@ const (
 	// matchAnalysisLLMTimeout is the per-stage LLM timeout for the fit analysis: its reasoning
 	// model spends tens of seconds thinking before answering, so a stage needs more than
 	// the shared client's default.
-	matchAnalysisLLMTimeout = 180 * time.Second
+	//
+	// It is a budget for ONE attempt, not for the stage: matchanalysis retries a timed-out
+	// stage once, so the worst case per stage is twice this. 90s sits well past the observed
+	// spread (healthy stages answer in 3–25s) while leaving room for that retry — a call
+	// still running at 90s is hung rather than slow, and in production the retry after such
+	// a call answered in under eight seconds.
+	matchAnalysisLLMTimeout = 90 * time.Second
 	// resumeExtractLLMTimeout bounds the single structured-résumé extraction call. It runs
 	// off the upload response path (background) so it can be generous, but still bounded so
 	// a stalled gateway cannot leak a goroutine indefinitely.

--- a/internal/handler/match_analysis_stream.go
+++ b/internal/handler/match_analysis_stream.go
@@ -6,9 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"sync"
 	"time"
 
+	"github.com/getsentry/sentry-go"
+	sentryfiber "github.com/getsentry/sentry-go/fiber"
 	"github.com/gofiber/fiber/v2"
 	"github.com/valyala/fasthttp"
 
@@ -76,18 +79,24 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	c.Set(fiber.HeaderConnection, "keep-alive")
 	c.Set("X-Accel-Buffering", "no") // stop nginx buffering so events reach the browser promptly
 
-	// The server's 10s WriteTimeout would kill this long-lived stream mid-analysis, so
-	// clear the connection's write deadline for the SSE response only (captured here while
-	// the ctx is valid; used inside the writer, which runs after this handler returns).
+	// The server's 10s WriteTimeout would kill this long-lived stream mid-analysis, so the
+	// SSE response sets its own, per-write deadline instead (see sseStream). Captured here
+	// while the ctx is valid; used inside the writer, which runs after this handler returns.
 	conn := c.Context().Conn()
 
+	// Same reason as conn: the sentryfiber hub is request-scoped and the ctx is released
+	// once this handler returns, so take a clone now. A clone rather than the hub itself
+	// because the writer outlives the request that owns its scope.
+	var hub *sentry.Hub
+	if reqHub := sentryfiber.GetHubFromContext(c); reqHub != nil {
+		hub = reqHub.Clone()
+	}
+
 	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
-		if conn != nil {
-			_ = conn.SetWriteDeadline(time.Time{})
-		}
+		stream := newSSEStream(w, conn, sseWriteTimeout)
 		start := time.Now()
 		log.Printf("matchanalysis: stream start user=%d job=%d has_cv=%v", userID, job.ID, hasCV)
-		writeSSE(w, "meta", map[string]bool{"has_cv": hasCV})
+		stream.event("meta", map[string]bool{"has_cv": hasCV})
 		if !hasCV {
 			return
 		}
@@ -107,9 +116,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 		// connection go quiet long enough for nginx's proxy_read_timeout to sever it
 		// mid-analysis — the client sees a bare "Connection lost". A periodic SSE comment
 		// keeps bytes flowing so the stream survives silent stages. The ticker goroutine
-		// and the stage callback both write to w, so a mutex serializes them (bufio.Writer
-		// is not safe for concurrent use).
-		var mu sync.Mutex
+		// and the stage callback both write, which sseStream serializes.
 		stopHeartbeat := make(chan struct{})
 		var heartbeat sync.WaitGroup
 		heartbeat.Add(1)
@@ -122,28 +129,25 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 				case <-stopHeartbeat:
 					return
 				case <-t.C:
-					mu.Lock()
-					writeComment(w, "keepalive")
-					mu.Unlock()
+					stream.comment("keepalive")
 				}
 			}
 		}()
 
 		analysis, err := h.matchAnalysis.AnalyzeStream(ctx, input, func(e matchanalysis.Event) {
 			events++
-			mu.Lock()
-			writeSSE(w, string(e.Kind), e)
-			mu.Unlock()
+			stream.event(string(e.Kind), e)
 		})
 		close(stopHeartbeat)
 		heartbeat.Wait()
 		if err != nil {
 			log.Printf("matchanalysis: stream FAILED user=%d job=%d dur=%s events=%d: %v", userID, job.ID, time.Since(start).Round(time.Millisecond), events, err)
-			writeSSE(w, "stream_error", map[string]string{"message": "analysis failed"})
+			reportStreamFault(hub, err)
+			stream.event("stream_error", map[string]string{"message": "analysis failed"})
 			return
 		}
 		if analysis == nil {
-			writeSSE(w, "stream_error", map[string]string{"message": "analysis unavailable"})
+			stream.event("stream_error", map[string]string{"message": "analysis unavailable"})
 			return
 		}
 		h.cacheAnalysis(ctx, userID, job, cvUploadedAt, analysis)
@@ -155,25 +159,83 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	return nil
 }
 
-// writeSSE writes one named SSE event with a JSON data payload and flushes it. A write
-// error (client disconnected) is swallowed — the stream is best-effort.
-func writeSSE(w *bufio.Writer, event string, data any) {
+// reportStreamFault sends a fault that surfaced AFTER the response body began streaming
+// to Sentry. It exists because RenderError — the single reporting point for the whole API
+// — only ever sees errors a handler RETURNS, and this handler returns nil before the body
+// writer runs. Without this seam every failed analysis is invisible: the reader gets a
+// `stream_error` event, the access log records the 200 the stream opened with, and the
+// error inbox stays empty.
+//
+// hub is a clone captured while the request context was still alive; it is nil when Sentry
+// is unconfigured, which must report nothing rather than panic on the SSE goroutine.
+//
+// What counts as a fault is classify's decision, not a second policy invented here: the
+// streaming path must not disagree with the returned-error path about whether a reader
+// who walked away is an error. Only classify's status mapping is dropped — the response
+// status was fixed when the stream opened, long before this failure existed.
+func reportStreamFault(hub *sentry.Hub, err error) {
+	if hub == nil {
+		return
+	}
+	if _, _, report := classify(err); !report {
+		return
+	}
+	hub.CaptureException(err)
+}
+
+// sseWriteTimeout bounds a single SSE write. It is generous — a live reader never comes
+// close, and the deadline is refreshed per write, so a slow-but-alive client is never cut
+// off mid-analysis. Its job is only to put a ceiling on a write that would otherwise never
+// return, which is what strands the analysis goroutine.
+const sseWriteTimeout = 30 * time.Second
+
+// sseStream owns one SSE response body: it serializes the writes (the heartbeat goroutine
+// and the analysis callback both write, and bufio.Writer is not safe for concurrent use)
+// and bounds each of them.
+//
+// The bounding is the point. The handler clears the connection's write deadline so the
+// server's 10s WriteTimeout cannot kill a long analysis — but a cleared deadline is
+// forever, so a reader that stopped reading blocks Flush indefinitely while holding the
+// lock, stranding the analysis goroutine for the life of the process. A per-write
+// deadline, refreshed on every write, keeps the long stream alive without ever letting a
+// single write block without limit.
+type sseStream struct {
+	mu      sync.Mutex
+	w       *bufio.Writer
+	conn    net.Conn
+	timeout time.Duration
+}
+
+func newSSEStream(w *bufio.Writer, conn net.Conn, timeout time.Duration) *sseStream {
+	return &sseStream{w: w, conn: conn, timeout: timeout}
+}
+
+// event writes one named SSE event with a JSON data payload and flushes it.
+func (s *sseStream) event(name string, data any) {
 	blob, err := json.Marshal(data)
 	if err != nil {
 		return
 	}
-	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, blob); err != nil {
-		return
-	}
-	_ = w.Flush()
+	s.write(fmt.Sprintf("event: %s\ndata: %s\n\n", name, blob))
 }
 
-// writeComment writes an SSE comment line — ignored by EventSource — as a heartbeat that
-// keeps the connection producing bytes through long, silent stages. A write error (client
-// gone) is swallowed, exactly like writeSSE.
-func writeComment(w *bufio.Writer, text string) {
-	if _, err := fmt.Fprintf(w, ": %s\n\n", text); err != nil {
+// comment writes an SSE comment line — ignored by EventSource — as a heartbeat that keeps
+// the connection producing bytes through long, silent stages.
+func (s *sseStream) comment(text string) {
+	s.write(fmt.Sprintf(": %s\n\n", text))
+}
+
+// write emits one frame under the lock, with a fresh deadline. A write error (the reader
+// is gone) is swallowed — the stream is best-effort — but the deadline is what guarantees
+// the call RETURNS, so a reader that stopped reading cannot pin this goroutine.
+func (s *sseStream) write(frame string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.conn != nil {
+		_ = s.conn.SetWriteDeadline(time.Now().Add(s.timeout))
+	}
+	if _, err := s.w.WriteString(frame); err != nil {
 		return
 	}
-	_ = w.Flush()
+	_ = s.w.Flush()
 }

--- a/internal/handler/match_analysis_stream_integration_test.go
+++ b/internal/handler/match_analysis_stream_integration_test.go
@@ -8,13 +8,17 @@ package handler
 import (
 	"bufio"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/getsentry/sentry-go"
+	sentryfiber "github.com/getsentry/sentry-go/fiber"
 	"github.com/gofiber/fiber/v2"
+	"github.com/tmc/langchaingo/llms"
 
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/credits"
@@ -25,6 +29,17 @@ import (
 	"github.com/strelov1/freehire/internal/resumeextract"
 	"github.com/strelov1/freehire/internal/userprofile"
 )
+
+// failingFitModel stands in for an upstream that is down or times out mid-stage — the
+// shape of the production failure this test is about.
+type failingFitModel struct{}
+
+func (*failingFitModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	return nil, errors.New("upstream llm exploded")
+}
+func (*failingFitModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
 
 // sseEvents reads an SSE body and returns the ordered list of event names.
 func sseEvents(t *testing.T, body string) []string {
@@ -72,7 +87,9 @@ func TestMatchAnalysisStreamEndpoint(t *testing.T) {
 		return s
 	}
 
-	appFor := func(store *resume.Store, an *matchanalysis.Analyzer) *fiber.App {
+	// mws are mounted before the route so a test can install the sentryfiber middleware
+	// the server runs in production; the existing subtests pass none and are unaffected.
+	appFor := func(store *resume.Store, an *matchanalysis.Analyzer, mws ...fiber.Handler) *fiber.App {
 		h := &matchHandlers{
 			queries:     queries,
 			userProfile: userprofile.New(ownedProfile()),
@@ -80,6 +97,9 @@ func TestMatchAnalysisStreamEndpoint(t *testing.T) {
 			credits: credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3}),
 		}
 		app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+		for _, mw := range mws {
+			app.Use(mw)
+		}
 		app.Get("/api/v1/jobs/:slug/fit/stream", auth.RequireAuth(iss, testVersions), h.StreamMatchAnalysis)
 		return app
 	}
@@ -135,6 +155,35 @@ func TestMatchAnalysisStreamEndpoint(t *testing.T) {
 		_ = pool.QueryRow(ctx, `SELECT count(*) FROM user_job_analysis WHERE user_id=$1 AND job_id=$2`, userID, jobID).Scan(&n)
 		if n != 1 {
 			t.Errorf("cache rows = %d, want 1 after stream", n)
+		}
+	})
+
+	// The regression this whole change exists for. The handler returns nil long before the
+	// chain runs, so a chain failure never reaches RenderError — the only place the API
+	// reports to Sentry. The reader sees `stream_error` and the access log records the 200
+	// the stream opened with, which is why the outage looked like an empty error inbox.
+	t.Run("a failed chain reaches Sentry", func(t *testing.T) {
+		tr := &recordingTransport{}
+		if err := sentry.Init(sentry.ClientOptions{
+			Dsn:       "https://public@o0.ingest.sentry.io/0",
+			Transport: tr,
+		}); err != nil {
+			t.Fatalf("sentry.Init: %v", err)
+		}
+		app := appFor(
+			storeWithCV(),
+			matchanalysis.NewAnalyzer(llm.NewWithModel(&failingFitModel{})),
+			sentryfiber.New(sentryfiber.Options{Repanic: true, WaitForDelivery: true}),
+		)
+		status, body := get(t, app, token)
+		if status != fiber.StatusOK {
+			t.Fatalf("status = %d, want 200 (the stream opens before it fails)", status)
+		}
+		if names := sseEvents(t, body); len(names) == 0 || names[len(names)-1] != "stream_error" {
+			t.Fatalf("last event = %v, want stream_error", names)
+		}
+		if got := tr.count(); got != 1 {
+			t.Errorf("sentry events = %d, want exactly 1 for a failed chain", got)
 		}
 	})
 

--- a/internal/handler/match_analysis_stream_test.go
+++ b/internal/handler/match_analysis_stream_test.go
@@ -1,0 +1,143 @@
+package handler
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// stalledConn models the socket of a reader that stopped reading: writes block until the
+// write deadline the caller set, then fail the way a real one does. With no deadline set
+// it blocks for far longer than any test would wait — which is precisely the production
+// hazard, since SetWriteDeadline(time.Time{}) clears the deadline for good.
+type stalledConn struct {
+	net.Conn
+	mu        sync.Mutex
+	deadline  time.Time
+	deadlines int
+}
+
+func (c *stalledConn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deadline = t
+	c.deadlines++
+	return nil
+}
+
+func (c *stalledConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	d := c.deadline
+	c.mu.Unlock()
+	if d.IsZero() {
+		time.Sleep(time.Minute) // unbounded in production; the test must never reach this
+		return len(p), nil
+	}
+	if wait := time.Until(d); wait > 0 {
+		time.Sleep(wait)
+	}
+	return 0, os.ErrDeadlineExceeded
+}
+
+func (c *stalledConn) deadlinesSet() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.deadlines
+}
+
+// The stream clears the connection's write deadline so the server's 10s WriteTimeout can't
+// kill a long analysis — but an unbounded write lets a reader that went away block Flush
+// forever, stranding the analysis goroutine holding the lock. Every write must therefore
+// carry its own deadline, refreshed per write so a slow-but-alive reader is never cut off.
+func TestSSEStream_BoundsEveryWriteSoADeadReaderCannotStrandTheStream(t *testing.T) {
+	conn := &stalledConn{}
+	s := newSSEStream(bufio.NewWriter(conn), conn, 50*time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.event("meta", map[string]bool{"has_cv": true})
+		s.event("stage_start", map[string]int{"stage": 1})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("writes did not return; a dead reader can still strand the stream")
+	}
+	if got := conn.deadlinesSet(); got < 2 {
+		t.Errorf("write deadlines set = %d, want one per write (>=2) so a slow reader is not cut off", got)
+	}
+}
+
+// Without a connection (the handler captures a nil conn) the stream must still write —
+// the deadline is simply not settable, exactly as before.
+func TestSSEStream_NilConnStillWrites(t *testing.T) {
+	var buf bytes.Buffer
+	s := newSSEStream(bufio.NewWriter(&buf), nil, time.Second)
+
+	s.event("meta", map[string]bool{"has_cv": false})
+	s.comment("keepalive")
+
+	if !strings.Contains(buf.String(), "event: meta") {
+		t.Errorf("body = %q, want the meta event written", buf.String())
+	}
+}
+
+// streamFaultHub builds an isolated hub over a recording transport. It deliberately
+// avoids the global sentry.Init that sentryApp uses: these tests assert what one hub
+// delivered, and a package-global client would couple them to test execution order.
+func streamFaultHub(t *testing.T) (*sentry.Hub, *recordingTransport) {
+	t.Helper()
+	tr := &recordingTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://public@o0.ingest.sentry.io/0",
+		Transport: tr,
+	})
+	if err != nil {
+		t.Fatalf("sentry.NewClient: %v", err)
+	}
+	return sentry.NewHub(client, sentry.NewScope()), tr
+}
+
+// The whole point of the seam: a fault raised after the body began streaming is never
+// returned to Fiber, so RenderError never sees it. Without this call such a failure is
+// invisible in Sentry — which is exactly how the fit-stream outage went unreported.
+func TestReportStreamFault_ReportsUnexpectedFault(t *testing.T) {
+	hub, tr := streamFaultHub(t)
+
+	reportStreamFault(hub, errString("llm chain exploded"))
+
+	if got := tr.count(); got != 1 {
+		t.Errorf("sentry events = %d, want exactly 1", got)
+	}
+}
+
+// A reader that walked away is not an application fault. classify() already encodes
+// that rule for the returned-error path; the streaming path must not disagree with it,
+// or every closed tab becomes an error-inbox entry.
+func TestReportStreamFault_IgnoresClientDisconnect(t *testing.T) {
+	hub, tr := streamFaultHub(t)
+
+	reportStreamFault(hub, fmt.Errorf("stage 1: %w", context.Canceled))
+
+	if got := tr.count(); got != 0 {
+		t.Errorf("sentry events = %d, want 0 for a client disconnect", got)
+	}
+}
+
+// Sentry is opt-in and env-gated: with no DSN the middleware installs no hub, so the
+// writer holds a nil one. Reporting must degrade to nothing rather than panic inside
+// the SSE goroutine, where a panic would take the whole stream down.
+func TestReportStreamFault_NilHubIsNoop(t *testing.T) {
+	reportStreamFault(nil, errString("llm chain exploded"))
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -277,6 +277,14 @@ func (c *Client) GenerateJSONStream(
 	})
 
 	resp, err := model.GenerateContent(ctx, messages, llms.WithJSONMode(), stream)
+	// A gateway that stops emitting when our own deadline fires can hand back whatever it
+	// accumulated and call it success — production logged exactly that as `dur=3m0.018s
+	// err=<nil>`, and the truncated JSON then failed downstream as "unexpected end of JSON
+	// input", naming neither the deadline nor the stage. Our context is the authority on
+	// whether the call had time to finish, so it overrules the provider's claim.
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
 	// The fit model is slow (tens of seconds per call); log the duration so per-stage
 	// cost stays observable without a tracer.
 	log.Printf("llm: stream model=%s dur=%s err=%v", c.modelID, time.Since(start).Round(time.Millisecond), err)

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -77,6 +77,40 @@ func TestGenerateJSONStream_AccumulatesContentAndStreamsThinking(t *testing.T) {
 	}
 }
 
+// truncatingModel models what the production gateway actually does when our own per-call
+// deadline fires mid-stream: it stops emitting and hands back whatever accumulated so far,
+// reporting success. Prod logged exactly this shape — `dur=3m0.018s err=<nil>` — and the
+// truncated JSON then surfaced downstream as "unexpected end of JSON input", which names
+// neither the deadline nor the stage that blew it.
+type truncatingModel struct{}
+
+func (truncatingModel) GenerateContent(ctx context.Context, _ []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	<-ctx.Done()
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: `{"score"`}}}, nil
+}
+func (truncatingModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+// A stream cut short by our own deadline is a failure, whatever the provider claims.
+// Trusting the nil error hands a truncated document to the caller, turning a timeout we
+// control into a parse error that looks like a bad model response.
+func TestGenerateJSONStream_DeadlineIsAFailureEvenWhenProviderReportsSuccess(t *testing.T) {
+	c := &Client{model: truncatingModel{}, timeout: 20 * time.Millisecond}
+
+	got, err := c.GenerateJSONStream(context.Background(), "s", "u", nil)
+
+	if err == nil {
+		t.Fatalf("GenerateJSONStream returned %q with a nil error, want a deadline failure", got)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %v, want one wrapping context.DeadlineExceeded", err)
+	}
+	if got != "" {
+		t.Errorf("content = %q, want empty when the call failed", got)
+	}
+}
+
 func TestGenerateJSONStream_NoReasoningIsFine(t *testing.T) {
 	m := &streamModel{content: []string{`{"ok":`, `true}`}} // no reasoning deltas
 	c := &Client{model: m, timeout: time.Second}

--- a/internal/matchanalysis/analyzer.go
+++ b/internal/matchanalysis/analyzer.go
@@ -3,6 +3,7 @@ package matchanalysis
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -179,16 +180,17 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 	return &analysis, nil
 }
 
-// stageAttempts is how many times a stage's LLM call is tried on a PARSE failure. The
-// gateway occasionally returns a transient HTML error page (a 502/504) that fails JSON
-// parsing; a single re-try recovers it, mirroring the enrichment worker. A transport
-// error (timeout, connection) is NOT retried — the model is slow, so a retry with the
-// same timeout would only double the wait — it is returned immediately.
+// stageAttempts is how many times a stage's LLM call is tried. Two failures earn a retry:
+// a PARSE failure (the gateway occasionally returns a transient HTML error page that fails
+// JSON parsing — a single re-try recovers it, mirroring the enrichment worker), and a
+// TIMEOUT (a stage that burns its whole budget is hung, not slow; prod showed the retry
+// answering in seconds). A connection error, or a caller who has gone away, is returned
+// immediately. Two attempts of matchAnalysisLLMTimeout bound the worst case per stage.
 const stageAttempts = 2
 
 // streamStage runs one streaming JSON call, forwarding reasoning deltas as thinking
-// events for the given stage, and unmarshals the accumulated JSON into out. A transport
-// failure returns at once; a parse failure (non-JSON gateway error page) is retried once.
+// events for the given stage, and unmarshals the accumulated JSON into out. A parse
+// failure and a timed-out stage are each retried once; anything else returns at once.
 func (a *Analyzer) streamStage(ctx context.Context, stage int, system, user string, emit func(Event), out any) error {
 	var parseErr error
 	for attempt := 1; attempt <= stageAttempts; attempt++ {
@@ -196,7 +198,16 @@ func (a *Analyzer) streamStage(ctx context.Context, stage int, system, user stri
 			emit(Event{Kind: EventThinking, Stage: stage, Thinking: t})
 		})
 		if err != nil {
-			return err // transport/timeout — retrying wouldn't help, fail fast
+			// A stage that burned its own per-call deadline is retried like a parse failure.
+			// Production showed such a call hung rather than slow — it ate the full budget
+			// while the very next attempt answered in seconds — so failing here throws away
+			// an analysis that was one retry away. A caller who went away is final: nobody
+			// is left to read a second answer, and it would only spend tokens.
+			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil && attempt < stageAttempts {
+				log.Printf("matchanalysis: stage %d timed out, retrying: %v", stage, err)
+				continue
+			}
+			return err // transport error, or a caller who is gone — retrying wouldn't help
 		}
 		if parseErr = json.Unmarshal([]byte(strings.TrimSpace(raw)), out); parseErr == nil {
 			return nil

--- a/internal/matchanalysis/analyzer_test.go
+++ b/internal/matchanalysis/analyzer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 
@@ -29,6 +30,66 @@ func (m *queuedModel) GenerateContent(context.Context, []llms.MessageContent, ..
 	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: r}}}, nil
 }
 func (*queuedModel) Call(context.Context, string, ...llms.CallOption) (string, error) { return "", nil }
+
+// hangsThenSucceedsModel burns the first call's entire deadline and then returns the
+// partial text a gateway hands back when it stops emitting — with a nil error, exactly as
+// production logged it. The second call answers normally. This is the 19:25 shape: a stage
+// that ate its whole budget while the retry finished in under eight seconds.
+type hangsThenSucceedsModel struct{ calls int }
+
+func (m *hangsThenSucceedsModel) GenerateContent(ctx context.Context, _ []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.calls++
+	if m.calls == 1 {
+		<-ctx.Done()
+		return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: `{"requi`}}}, nil
+	}
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: `{"ok":true}`}}}, nil
+}
+func (*hangsThenSucceedsModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+// A hung stage is not a slow one: prod showed a call burn its full deadline while the very
+// next attempt answered in seconds. Failing the whole analysis there throws away an answer
+// that was one retry away, so a timed-out stage is retried like a parse failure.
+func TestStreamStage_RetriesATimedOutStage(t *testing.T) {
+	m := &hangsThenSucceedsModel{}
+	a := &Analyzer{client: llm.NewWithModel(m).WithTimeout(20 * time.Millisecond)}
+
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	err := a.streamStage(context.Background(), 1, "sys", "usr", func(Event) {}, &out)
+
+	if err != nil {
+		t.Fatalf("streamStage: %v, want the retry to succeed", err)
+	}
+	if m.calls != 2 {
+		t.Errorf("model calls = %d, want 2 (the timed-out stage retried once)", m.calls)
+	}
+	if !out.OK {
+		t.Error("out was not populated from the retry's response")
+	}
+}
+
+// A retry is only worth spending when there is still someone to answer. When the caller's
+// own context is already dead, a second call would burn tokens on a reply nobody reads.
+func TestStreamStage_DoesNotRetryWhenTheCallerIsGone(t *testing.T) {
+	m := &hangsThenSucceedsModel{}
+	a := &Analyzer{client: llm.NewWithModel(m).WithTimeout(time.Second)}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var out struct{}
+	err := a.streamStage(ctx, 1, "sys", "usr", func(Event) {}, &out)
+
+	if err == nil {
+		t.Fatal("streamStage returned nil, want the cancellation")
+	}
+	if m.calls != 1 {
+		t.Errorf("model calls = %d, want 1 (no retry once the caller is gone)", m.calls)
+	}
+}
 
 func sampleInput() Input {
 	return Input{

--- a/internal/observability/AGENTS.md
+++ b/internal/observability/AGENTS.md
@@ -8,6 +8,7 @@ Opt-in Sentry across all three surfaces, env-gated.
 - Empty DSN = **no-op** (app runs unchanged). Malformed DSN = **fatal** (fail-fast).
 - `sentryfiber` middleware registered **after** `recover.New` so deferred capture reports panic *with a stack* before `recover.New` renders standard 500 (`Repanic:true`).
 - `handler.RenderError` reports **only** fall-through unexpected 500 to request hub — routine 4xx / `pgx.ErrNoRows`→404 / FK-violation→404 are never reported. Recovered panic is **not** double-reported (recover middleware marks it via `handler.LocalPanicReported`).
+- **Streamed responses need their own reporting.** `RenderError` only ever sees errors a handler *returns*, and an SSE handler returns `nil` before its body writer runs — so a failure inside the stream reports nothing, while the access log records the `200` the stream opened with. `handler.reportStreamFault` closes that gap for the fit stream: it takes a **clone** of the request hub captured before the ctx is released, and defers to the same `classify` policy so a reader who walked away is not filed as a fault. Any new streaming endpoint has this blind spot until it does the same.
 
 ## Workers
 


### PR DESCRIPTION
Users reported the match analysis was unavailable. Sentry was empty — **by construction**, on every surface:

- `StreamMatchAnalysis` returns `nil` before its body writer runs, so `RenderError` (the API's only `CaptureException`) never sees a chain failure.
- SSE fixes its status when the stream opens, so all 69 streams in a week were logged `200` regardless of outcome.
- 402 and 429 on `match-analysis` were **zero** over 7 days — neither credits nor the rate limiter were involved.

The only trace was `journalctl`, which retains ~12 hours.

## What the journal showed

```
19:25:41  llm: stream model=privateclaw/mid dur=3m0.018s err=<nil>
19:25:41  matchanalysis: stage 1 parse failed, retrying: parse: unexpected end of JSON input
19:25:59  matchanalysis: stream DONE dur=3m17.962s events=4328 overall=85
```

`180.018s` is our own `matchAnalysisLLMTimeout`, reported as success with a truncated body. Healthy runs are `events=9` in 14–25s.

Separately, `user=185` opened four streams in 28 seconds with no `DONE`, no `FAILED`, and no subsequent `llm: stream` line for 23+ minutes — on a process that was demonstrably alive (same PID served another user at 19:16).

## Changes

1. **`reportStreamFault`** — captures post-response faults on a clone of the request hub, taken before the ctx is released. `classify` decides what qualifies, so the streaming and returned-error paths cannot disagree.
2. **`GenerateJSONStream`** — our context overrules the provider's nil error. A deadline that fired is a failure, not a short answer.
3. **A timed-out stage is retried** like a parse failure, and `matchAnalysisLLMTimeout` drops 180s → 90s. It is a budget for *one attempt*, so the worst case per stage is unchanged (~3 min) while the 19:25 case would now finish in ~1.5 min, successfully. Note `analyzer.go` already claimed `transport/timeout — retrying wouldn't help`; the timeout never actually reached that branch, because it arrived as a nil error.
4. **`sseStream`** — a per-write deadline replaces `SetWriteDeadline(time.Time{})`, which cleared the deadline for good and let an unbounded `Flush` pin the analysis goroutine. It also owns the mutex that previously sat apart from the writer. `writeSSE` is now orphaned and removed; `writeComment` moves to `assistant.go`, its only remaining caller.

## Verification

`gofmt`, `go build`, `go vet`, `go test ./...`, `go test -race` on the new type, and `go test -tags=integration ./internal/handler/` all pass.

Seven new tests, each watched failing first. `truncatingModel` reproduces the production line literally (`err=<nil>` plus truncated `{"score"`); `stalledConn` blocks for a minute without a deadline, so the test would hang exactly as production does.

## Not covered

- `internal/handler/assistant.go:395` has the **same Sentry blind spot** and is untouched.
- The hang's root cause is **not proven**: the process holding those goroutines has restarted and `pprof` is not wired on prod. The cleared write deadline is an objective defect (an unbounded write *can* block forever), but its link to that specific incident remains probable, not established.