### PR TITLE
Move the application out of user_jobs, in one pass

### DIFF
--- a/cmd/classify-mail/store.go
+++ b/cmd/classify-mail/store.go
@@ -128,7 +128,7 @@ func (s *dbStore) Save(ctx context.Context, outboxID, userID int64, r maillink.R
 		if err := qtx.AdvanceUserJobStage(ctx, db.AdvanceUserJobStageParams{
 			UserID: userID,
 			JobID:  r.JobID,
-			Stage:  pgtype.Text{String: r.AdvanceStageTo, Valid: true},
+			Stage:  r.AdvanceStageTo,
 		}); err != nil {
 			return fmt.Errorf("advance stage: %w", err)
 		}

--- a/internal/db/application_events_integration_test.go
+++ b/internal/db/application_events_integration_test.go
@@ -194,7 +194,7 @@ func TestRecordApplicationFollowUp_SuppressesAResubmitButNotASecondChase(t *test
 
 	// Age the recorded chase past the window; the next one is a genuine second attempt.
 	if _, err := q.db.Exec(ctx,
-		`UPDATE user_jobs SET followed_up_at = now() - interval '9 days'
+		`UPDATE applications SET followed_up_at = now() - interval '9 days'
 		  WHERE user_id = $1 AND job_id = $2`, user, job); err != nil {
 		t.Fatalf("age the chase: %v", err)
 	}

--- a/internal/db/ghost.sql.go
+++ b/internal/db/ghost.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const listGhostApplicationEvidence = `-- name: ListGhostApplicationEvidence :many
-SELECT uj.job_id,
+SELECT uj.job_id::bigint AS job_id,
        uj.user_id,
        coalesce(uj.stage, '')::text AS stage,
        GREATEST(uj.applied_at,
@@ -27,7 +27,7 @@ SELECT uj.job_id,
                    AND e.suggested_job_id = uj.job_id
                    AND e.job_id IS NULL
                    AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
-FROM user_jobs uj
+FROM applications uj
 WHERE uj.job_id = ANY($1::bigint[])
   AND uj.applied_at IS NOT NULL
   AND (EXISTS (SELECT 1 FROM gmail_connections gc
@@ -61,6 +61,8 @@ type ListGhostApplicationEvidenceRow struct {
 //
 // last_activity_at and has_pending_suggestion mirror ListTrackedJobs deliberately:
 // one definition of "when did this application last move", not two.
+// job_id is nullable on applications, but the filter below matches it against a page of
+// real ids, so a row that reaches the select always carries one.
 func (q *Queries) ListGhostApplicationEvidence(ctx context.Context, jobIds []int64) ([]ListGhostApplicationEvidenceRow, error) {
 	rows, err := q.db.Query(ctx, listGhostApplicationEvidence, jobIds)
 	if err != nil {

--- a/internal/db/mail_classification.sql.go
+++ b/internal/db/mail_classification.sql.go
@@ -12,19 +12,20 @@ import (
 )
 
 const advanceUserJobStage = `-- name: AdvanceUserJobStage :exec
-UPDATE user_jobs SET stage = $3 WHERE user_id = $1 AND job_id = $2
+UPDATE applications SET stage = $1::text
+ WHERE user_id = $2::bigint AND job_id = $3::bigint
 `
 
 type AdvanceUserJobStageParams struct {
-	UserID int64       `json:"user_id"`
-	JobID  int64       `json:"job_id"`
-	Stage  pgtype.Text `json:"stage"`
+	Stage  string `json:"stage"`
+	UserID int64  `json:"user_id"`
+	JobID  int64  `json:"job_id"`
 }
 
 // Move an application forward to a new stage (the worker only calls this after
 // checking the transition is strictly forward and high-confidence).
 func (q *Queries) AdvanceUserJobStage(ctx context.Context, arg AdvanceUserJobStageParams) error {
-	_, err := q.db.Exec(ctx, advanceUserJobStage, arg.UserID, arg.JobID, arg.Stage)
+	_, err := q.db.Exec(ctx, advanceUserJobStage, arg.Stage, arg.UserID, arg.JobID)
 	return err
 }
 
@@ -217,8 +218,8 @@ func (q *Queries) FailEmailClassification(ctx context.Context, arg FailEmailClas
 
 const getUserJobStage = `-- name: GetUserJobStage :one
 SELECT COALESCE(stage, '')::text AS stage
-FROM user_jobs
-WHERE user_id = $1 AND job_id = $2
+FROM applications
+WHERE user_id = $1::bigint AND job_id = $2::bigint
 `
 
 type GetUserJobStageParams struct {
@@ -239,9 +240,10 @@ const listUserApplicationsForMatch = `-- name: ListUserApplicationsForMatch :man
 SELECT j.id, j.company
 FROM user_jobs uj
 JOIN jobs j ON j.id = uj.job_id
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
 WHERE uj.user_id = $1
   AND j.closed_at IS NULL
-  AND (uj.applied_at IS NOT NULL OR uj.saved_at IS NOT NULL OR uj.stage IS NOT NULL)
+  AND (a.applied_at IS NOT NULL OR uj.saved_at IS NOT NULL OR a.stage IS NOT NULL)
 `
 
 type ListUserApplicationsForMatchRow struct {

--- a/internal/db/mail_linking.sql.go
+++ b/internal/db/mail_linking.sql.go
@@ -35,16 +35,16 @@ func (q *Queries) ConfirmEmailLink(ctx context.Context, arg ConfirmEmailLinkPara
 }
 
 const getUserApplication = `-- name: GetUserApplication :one
-SELECT uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes, uj.followed_up_at,
-       (CASE WHEN uj.applied_at IS NOT NULL THEN
-          GREATEST(uj.applied_at,
+SELECT uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes, a.followed_up_at,
+       (CASE WHEN a.applied_at IS NOT NULL THEN
+          GREATEST(a.applied_at,
                    (SELECT max(e.received_at)
                       FROM emails e
                      WHERE e.user_id = uj.user_id
                        AND e.job_id = uj.job_id
                        AND e.deleted_at IS NULL))
         END)::timestamptz AS last_activity_at,
-       (uj.applied_at IS NOT NULL AND EXISTS (
+       (a.applied_at IS NOT NULL AND EXISTS (
           SELECT 1
             FROM emails e
            WHERE e.user_id = uj.user_id
@@ -52,6 +52,7 @@ SELECT uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes, uj.followed
              AND e.job_id IS NULL
              AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
 WHERE uj.user_id = $1 AND uj.job_id = $2
 `
 

--- a/internal/db/mail_linking_integration_test.go
+++ b/internal/db/mail_linking_integration_test.go
@@ -19,7 +19,12 @@ import (
 func applyToJob(t *testing.T, pool *pgxpool.Pool, userID, jobID int64, stage string) {
 	t.Helper()
 	_, err := pool.Exec(context.Background(),
-		`INSERT INTO user_jobs (user_id, job_id, applied_at, stage) VALUES ($1, $2, now(), $3)`,
+		`WITH mark AS (
+		     INSERT INTO user_jobs (user_id, job_id) VALUES ($1, $2)
+		     ON CONFLICT (user_id, job_id) DO NOTHING
+		 )
+		 INSERT INTO applications (user_id, job_id, company_slug, role_title, applied_at, stage)
+		 SELECT $1, $2, j.company_slug, j.title, now(), $3 FROM jobs j WHERE j.id = $2`,
 		userID, jobID, stage)
 	if err != nil {
 		t.Fatalf("apply to job: %v", err)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -191,7 +191,9 @@ type Querier interface {
 	// Scoped to rows that carry a stamp so a run over a healthy company writes nothing.
 	ClearJobATSAbsent(ctx context.Context, jobIds []int64) error
 	// Reset a tracked job to the wishlist: drop stage and applied state, keep saved/viewed/notes.
-	ClearJobProgress(ctx context.Context, arg ClearJobProgressParams) (UserJob, error)
+	// The application record stays: it holds the notes, and clearing progress is the
+	// candidate reconsidering, not a claim the process never happened.
+	ClearJobProgress(ctx context.Context, arg ClearJobProgressParams) (ClearJobProgressRow, error)
 	// Explicitly clear a user's job vote (the DELETE endpoint). No-op when no row or no
 	// vote exists. The caller recomputes counters via RecountJobVotes in the same tx.
 	ClearJobVote(ctx context.Context, arg ClearJobVoteParams) error
@@ -583,7 +585,7 @@ type Querier interface {
 	// Dismiss (swipe away) a job for a user in the swipe deck. Idempotent and
 	// independent of a prior view: it inserts the row (viewed_at defaults) or
 	// refreshes dismissed_at in place.
-	DismissJob(ctx context.Context, arg DismissJobParams) (UserJob, error)
+	DismissJob(ctx context.Context, arg DismissJobParams) (DismissJobRow, error)
 	// Transactional-outbox enqueue for the ingest write path: queue this one job for
 	// enrichment, gated on the same conditions the backfill uses (unenriched or below the
 	// target schema version, and a non-blacklisted category), so an already-enriched job
@@ -1214,6 +1216,8 @@ type Querier interface {
 	//
 	// last_activity_at and has_pending_suggestion mirror ListTrackedJobs deliberately:
 	// one definition of "when did this application last move", not two.
+	// job_id is nullable on applications, but the filter below matches it against a page of
+	// real ids, so a row that reaches the select always carries one.
 	ListGhostApplicationEvidence(ctx context.Context, jobIds []int64) ([]ListGhostApplicationEvidenceRow, error)
 	// Non-retracted ghost reports for a page of jobs. Maturity — whether the stated
 	// apply date has aged past the `applied` threshold — is applied in Go alongside the
@@ -1764,7 +1768,11 @@ type Querier interface {
 	// does NOT touch jobs.view_count — that materialized counter is maintained solely
 	// by the nginx-log aggregation worker (cmd/rollup-views), which counts all traffic
 	// (anonymous + signed-in + API), so the signed-in beacon must not double-count.
-	RecordJobView(ctx context.Context, arg RecordJobViewParams) (UserJob, error)
+	// The interaction shape the caller has always received is now assembled from two
+	// tables: user_jobs keeps the marks on the posting, applications holds the process.
+	// The column list and its order mirror user_jobs' own, so the Go layer's
+	// db.UserJob(row) conversion keeps working across every query in this file.
+	RecordJobView(ctx context.Context, arg RecordJobViewParams) (RecordJobViewRow, error)
 	// Count a failed delivery for a subscription's claimed jobs: bump attempts, record
 	// the error, and dead-letter (set failed_at) once attempts reach the max. claimed_at
 	// is left in place — its expiry gates the retry to a later pass and doubles as the
@@ -1974,7 +1982,7 @@ type Querier interface {
 	RoleClusterGeoAll(ctx context.Context) ([]RoleClusterGeoAllRow, error)
 	// Save (bookmark) a job for a user. Idempotent and independent of a prior view:
 	// it inserts the row (viewed_at defaults) or refreshes saved_at in place.
-	SaveJob(ctx context.Context, arg SaveJobParams) (UserJob, error)
+	SaveJob(ctx context.Context, arg SaveJobParams) (SaveJobRow, error)
 	// Hand an unverified, password-backed account to the proven owner of its address when a
 	// provider-verified OAuth identity arrives for it: the password is destroyed, every
 	// session revoked, and every API key deleted, so a squatter who registered the address
@@ -2137,16 +2145,20 @@ type Querier interface {
 	// apply/save history survives. No interaction row -> pgx.ErrNoRows; the handler
 	// treats that as "already not dismissed", never as a failure. This is the undo
 	// path for a swipe-left decision.
-	UndismissJob(ctx context.Context, arg UndismissJobParams) (UserJob, error)
+	UndismissJob(ctx context.Context, arg UndismissJobParams) (UndismissJobRow, error)
 	// Clear an email's application link (leaves the classified status intact).
 	UnlinkEmail(ctx context.Context, arg UnlinkEmailParams) (int64, error)
 	// Clear a job's saved mark without deleting the interaction row, so view and
 	// apply history survive unsaving. No interaction row -> pgx.ErrNoRows; the
 	// handler treats that as "already not saved", never as a failure.
-	UnsaveJob(ctx context.Context, arg UnsaveJobParams) (UserJob, error)
+	UnsaveJob(ctx context.Context, arg UnsaveJobParams) (UnsaveJobRow, error)
 	// Remove a job from the board: drop every pipeline mark, keep viewed_at so the
 	// job remains in the user's view history.
-	UntrackJob(ctx context.Context, arg UntrackJobParams) (UserJob, error)
+	// Taking a job off the board clears the process outright — this is the candidate
+	// saying it is not a thing they are pursuing, which is a claim about their own
+	// record and theirs alone to make. cmd/prune has no such standing, which is the
+	// whole distinction this change draws.
+	UntrackJob(ctx context.Context, arg UntrackJobParams) (UntrackJobRow, error)
 	// Persist the post-transaction balance: the current period and remaining points. Called at
 	// the end of the debit transaction to write back any lazy reset and/or decrement. The row is
 	// guaranteed to exist (EnsureBalance ran first).

--- a/internal/db/queries/ghost.sql
+++ b/internal/db/queries/ghost.sql
@@ -17,7 +17,9 @@
 --
 -- last_activity_at and has_pending_suggestion mirror ListTrackedJobs deliberately:
 -- one definition of "when did this application last move", not two.
-SELECT uj.job_id,
+-- job_id is nullable on applications, but the filter below matches it against a page of
+-- real ids, so a row that reaches the select always carries one.
+SELECT uj.job_id::bigint AS job_id,
        uj.user_id,
        coalesce(uj.stage, '')::text AS stage,
        GREATEST(uj.applied_at,
@@ -32,7 +34,7 @@ SELECT uj.job_id,
                    AND e.suggested_job_id = uj.job_id
                    AND e.job_id IS NULL
                    AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
-FROM user_jobs uj
+FROM applications uj
 WHERE uj.job_id = ANY(sqlc.arg(job_ids)::bigint[])
   AND uj.applied_at IS NOT NULL
   AND (EXISTS (SELECT 1 FROM gmail_connections gc

--- a/internal/db/queries/mail_classification.sql
+++ b/internal/db/queries/mail_classification.sql
@@ -105,9 +105,10 @@ WHERE id = sqlc.arg(id);
 SELECT j.id, j.company
 FROM user_jobs uj
 JOIN jobs j ON j.id = uj.job_id
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
 WHERE uj.user_id = $1
   AND j.closed_at IS NULL
-  AND (uj.applied_at IS NOT NULL OR uj.saved_at IS NOT NULL OR uj.stage IS NOT NULL);
+  AND (a.applied_at IS NOT NULL OR uj.saved_at IS NOT NULL OR a.stage IS NOT NULL);
 
 -- name: ListUserEmailThreadLinks :many
 -- Existing thread→application links for the caller, so the matcher can continue a
@@ -120,10 +121,11 @@ WHERE user_id = $1 AND job_id IS NOT NULL AND thread_id <> '';
 -- The caller's current stage for one application (empty string when unset), so the
 -- worker can decide a monotonic-forward advancement.
 SELECT COALESCE(stage, '')::text AS stage
-FROM user_jobs
-WHERE user_id = $1 AND job_id = $2;
+FROM applications
+WHERE user_id = sqlc.arg(user_id)::bigint AND job_id = sqlc.arg(job_id)::bigint;
 
 -- name: AdvanceUserJobStage :exec
 -- Move an application forward to a new stage (the worker only calls this after
 -- checking the transition is strictly forward and high-confidence).
-UPDATE user_jobs SET stage = $3 WHERE user_id = $1 AND job_id = $2;
+UPDATE applications SET stage = sqlc.arg(stage)::text
+ WHERE user_id = sqlc.arg(user_id)::bigint AND job_id = sqlc.arg(job_id)::bigint;

--- a/internal/db/queries/mail_linking.sql
+++ b/internal/db/queries/mail_linking.sql
@@ -3,16 +3,16 @@
 -- last_activity_at and has_pending_suggestion mirror ListUserJobs deliberately: the follow-up gate
 -- must reach the same silence verdict as the badge on the board, and two derivations of one rule
 -- drift. See the column comment in 0059 for why followed_up_at is NOT part of the activity.
-SELECT uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes, uj.followed_up_at,
-       (CASE WHEN uj.applied_at IS NOT NULL THEN
-          GREATEST(uj.applied_at,
+SELECT uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes, a.followed_up_at,
+       (CASE WHEN a.applied_at IS NOT NULL THEN
+          GREATEST(a.applied_at,
                    (SELECT max(e.received_at)
                       FROM emails e
                      WHERE e.user_id = uj.user_id
                        AND e.job_id = uj.job_id
                        AND e.deleted_at IS NULL))
         END)::timestamptz AS last_activity_at,
-       (uj.applied_at IS NOT NULL AND EXISTS (
+       (a.applied_at IS NOT NULL AND EXISTS (
           SELECT 1
             FROM emails e
            WHERE e.user_id = uj.user_id
@@ -20,6 +20,7 @@ SELECT uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes, uj.followed
              AND e.job_id IS NULL
              AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
 WHERE uj.user_id = $1 AND uj.job_id = $2;
 
 -- name: ListJobEmails :many

--- a/internal/db/queries/reminders.sql
+++ b/internal/db/queries/reminders.sql
@@ -81,13 +81,14 @@ RETURNING r.id;
 SELECT r.id, r.user_id, r.job_id, r.channels,
        j.title, j.company, j.public_slug, j.url,
        (j.closed_at IS NULL)::bool AS job_open,
-       COALESCE(uj.saved_at IS NOT NULL AND uj.applied_at IS NULL, false)::bool AS still_actionable,
+       COALESCE(uj.saved_at IS NOT NULL AND a.applied_at IS NULL, false)::bool AS still_actionable,
        u.email AS account_email,
        tl.chat_id AS telegram_chat_id
 FROM job_reminders r
 JOIN jobs j ON j.id = r.job_id
 JOIN users u ON u.id = r.user_id
 LEFT JOIN user_jobs uj ON uj.user_id = r.user_id AND uj.job_id = r.job_id
+LEFT JOIN applications a ON a.user_id = r.user_id AND a.job_id = r.job_id
 LEFT JOIN telegram_links tl ON tl.user_id = r.user_id
 WHERE r.id = $1;
 

--- a/internal/db/queries/stats.sql
+++ b/internal/db/queries/stats.sql
@@ -75,7 +75,9 @@ ORDER BY d;
 -- tables — unlike `viewed`, none of them needs a rollup to stay fast.
 SELECT
     count(*) FILTER (WHERE saved_at IS NOT NULL)::int   AS saved,
-    count(*) FILTER (WHERE applied_at IS NOT NULL)::int AS applied,
+    -- applications live in their own table now, and counting them there is also the
+    -- honest count: one that outlived its posting is still an application somebody made.
+    (SELECT count(*) FROM applications WHERE applied_at IS NOT NULL)::int AS applied,
     (SELECT COALESCE(sum(uniques), 0) FROM job_daily_views)::int AS viewed,
     (SELECT count(*) FROM users WHERE resume_object_key IS NOT NULL)::int AS cvs_uploaded,
     (SELECT count(*) FROM cvs WHERE is_tailored)::int AS cvs_tailored,

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -5,10 +5,20 @@
 -- does NOT touch jobs.view_count — that materialized counter is maintained solely
 -- by the nginx-log aggregation worker (cmd/rollup-views), which counts all traffic
 -- (anonymous + signed-in + API), so the signed-in beacon must not double-count.
-INSERT INTO user_jobs (user_id, job_id)
-VALUES ($1, $2)
-ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
-RETURNING *;
+-- The interaction shape the caller has always received is now assembled from two
+-- tables: user_jobs keeps the marks on the posting, applications holds the process.
+-- The column list and its order mirror user_jobs' own, so the Go layer's
+-- db.UserJob(row) conversion keeps working across every query in this file.
+WITH touch AS (
+    INSERT INTO user_jobs (user_id, job_id)
+    VALUES ($1, $2)
+    ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
+    RETURNING *
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id;
 
 -- name: MarkJobApplied :one
 -- Mark a job as applied for a user. Idempotent and independent of a prior view:
@@ -36,80 +46,98 @@ RETURNING *;
 -- from the row's own applied_at, so a dated recording carries the mail's date
 -- into the ledger rather than now().
 WITH prior AS (
-    SELECT uj.applied_at FROM user_jobs uj WHERE uj.user_id = $1 AND uj.job_id = $2
+    SELECT a.applied_at FROM applications a WHERE a.user_id = sqlc.arg(user_id) AND a.job_id = sqlc.arg(job_id)::bigint
+), touch AS (
+    -- The interaction row still exists for its own duties; applying to a job never
+    -- opened must still leave one behind, as it always has.
+    INSERT INTO user_jobs (user_id, job_id)
+    VALUES (sqlc.arg(user_id), sqlc.arg(job_id))
+    ON CONFLICT (user_id, job_id) DO UPDATE SET user_id = user_jobs.user_id
+    RETURNING *
 ), upsert AS (
-    INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
-    VALUES ($1, $2, COALESCE(sqlc.narg(at)::timestamptz, now()), 'applied')
-    ON CONFLICT (user_id, job_id) DO UPDATE
+    INSERT INTO applications (user_id, job_id, company_slug, role_title, applied_at, stage)
+    SELECT sqlc.arg(user_id), sqlc.arg(job_id)::bigint, j.company_slug, j.title,
+           COALESCE(sqlc.narg(at)::timestamptz, now()), 'applied'
+      FROM jobs j WHERE j.id = sqlc.arg(job_id)::bigint
+    ON CONFLICT (user_id, job_id) WHERE job_id IS NOT NULL
+    DO UPDATE
       SET applied_at = CASE
               WHEN sqlc.narg(at)::timestamptz IS NOT NULL
-                  THEN COALESCE(user_jobs.applied_at, sqlc.narg(at)::timestamptz)
+                  THEN COALESCE(applications.applied_at, sqlc.narg(at)::timestamptz)
               ELSE now()
           END,
-          stage = COALESCE(user_jobs.stage, 'applied')
+          stage = COALESCE(applications.stage, 'applied')
     RETURNING *
 ), bump AS (
     UPDATE jobs SET applied_count = applied_count + 1
-    WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior WHERE prior.applied_at IS NOT NULL)
-), app AS (
-    -- The application record, written by this same statement so it cannot diverge from
-    -- the apply it describes. The employer and role title are copied off the posting
-    -- here, while it is still there; that copy is what survives cmd/prune.
-    --
-    -- DO UPDATE rather than DO NOTHING, and not for the update's sake: DO NOTHING
-    -- returns no row on conflict, and this statement needs the id in both cases — a
-    -- re-apply must name the same application, never a NULL. The assignments mirror the
-    -- upsert above: the date refreshes as it always has, an advanced stage survives.
-    INSERT INTO applications (user_id, company_slug, role_title, job_id, applied_at, stage)
-    SELECT $1, j.company_slug, j.title, $2, u.applied_at, u.stage
-      FROM upsert u JOIN jobs j ON j.id = $2
-    ON CONFLICT (user_id, job_id) WHERE job_id IS NOT NULL
-    DO UPDATE SET applied_at = EXCLUDED.applied_at,
-                  stage      = COALESCE(applications.stage, EXCLUDED.stage)
-    RETURNING id
+    WHERE id = sqlc.arg(job_id) AND NOT EXISTS (SELECT 1 FROM prior WHERE prior.applied_at IS NOT NULL)
 ), event AS (
     INSERT INTO application_events (user_id, application_id, job_id, company_slug, kind, occurred_at, source)
-    SELECT $1, (SELECT id FROM app), $2, j.company_slug, 'applied', u.applied_at, sqlc.arg(event_source)::text
-      FROM upsert u JOIN jobs j ON j.id = $2
+    SELECT sqlc.arg(user_id), u.id, sqlc.arg(job_id)::bigint, j.company_slug, 'applied', u.applied_at, sqlc.arg(event_source)::text
+      FROM upsert u JOIN jobs j ON j.id = sqlc.arg(job_id)::bigint
      WHERE NOT EXISTS (SELECT 1 FROM prior WHERE prior.applied_at IS NOT NULL)
 )
-SELECT * FROM upsert;
+SELECT t.user_id, t.job_id, t.viewed_at, u.applied_at, t.saved_at,
+       u.stage, u.notes, t.dismissed_at, t.vote, u.followed_up_at
+  FROM touch t, upsert u;
 
 -- name: SaveJob :one
 -- Save (bookmark) a job for a user. Idempotent and independent of a prior view:
 -- it inserts the row (viewed_at defaults) or refreshes saved_at in place.
-INSERT INTO user_jobs (user_id, job_id, saved_at)
-VALUES ($1, $2, now())
-ON CONFLICT (user_id, job_id) DO UPDATE SET saved_at = now()
-RETURNING *;
+WITH touch AS (
+    INSERT INTO user_jobs (user_id, job_id, saved_at)
+    VALUES ($1, $2, now())
+    ON CONFLICT (user_id, job_id) DO UPDATE SET saved_at = now()
+    RETURNING *
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id;
 
 -- name: UnsaveJob :one
 -- Clear a job's saved mark without deleting the interaction row, so view and
 -- apply history survive unsaving. No interaction row -> pgx.ErrNoRows; the
 -- handler treats that as "already not saved", never as a failure.
-UPDATE user_jobs
-SET saved_at = NULL
-WHERE user_id = $1 AND job_id = $2
-RETURNING *;
+WITH touch AS (
+    UPDATE user_jobs SET saved_at = NULL
+    WHERE user_jobs.user_id = $1 AND user_jobs.job_id = $2
+    RETURNING *
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id;
 
 -- name: DismissJob :one
 -- Dismiss (swipe away) a job for a user in the swipe deck. Idempotent and
 -- independent of a prior view: it inserts the row (viewed_at defaults) or
 -- refreshes dismissed_at in place.
-INSERT INTO user_jobs (user_id, job_id, dismissed_at)
-VALUES ($1, $2, now())
-ON CONFLICT (user_id, job_id) DO UPDATE SET dismissed_at = now()
-RETURNING *;
+WITH touch AS (
+    INSERT INTO user_jobs (user_id, job_id, dismissed_at)
+    VALUES ($1, $2, now())
+    ON CONFLICT (user_id, job_id) DO UPDATE SET dismissed_at = now()
+    RETURNING *
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id;
 
 -- name: UndismissJob :one
 -- Clear a job's dismissed mark without deleting the interaction row, so view/
 -- apply/save history survives. No interaction row -> pgx.ErrNoRows; the handler
 -- treats that as "already not dismissed", never as a failure. This is the undo
 -- path for a swipe-left decision.
-UPDATE user_jobs
-SET dismissed_at = NULL
-WHERE user_id = $1 AND job_id = $2
-RETURNING *;
+WITH touch AS (
+    UPDATE user_jobs SET dismissed_at = NULL
+    WHERE user_jobs.user_id = $1 AND user_jobs.job_id = $2
+    RETURNING *
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id;
 
 -- name: ExcludedJobIDs :many
 -- Job ids the user has already interacted with (viewed, saved, applied, or
@@ -119,10 +147,11 @@ RETURNING *;
 -- most-recently-touched first and capped ($2) so the deck's `id NOT IN (...)`
 -- search filter stays bounded; the overflow risk is only an occasional re-shown
 -- long-ago-seen job, never a correctness problem.
-SELECT job_id
-FROM user_jobs
-WHERE user_id = $1
-ORDER BY GREATEST(viewed_at, saved_at, applied_at, dismissed_at) DESC
+SELECT uj.job_id
+FROM user_jobs uj
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
+WHERE uj.user_id = $1
+ORDER BY GREATEST(uj.viewed_at, uj.saved_at, a.applied_at, uj.dismissed_at) DESC
 LIMIT $2;
 
 -- name: TrackJob :one
@@ -137,13 +166,22 @@ LIMIT $2;
 -- unanswerable. The event carries no trusted date (source is the caller, not the
 -- employer), which is why nothing times it yet — see internal/appevent.
 WITH prior AS (
-    SELECT uj.stage FROM user_jobs uj WHERE uj.user_id = $1 AND uj.job_id = $2
+    SELECT a.stage FROM applications a WHERE a.user_id = sqlc.arg(user_id) AND a.job_id = sqlc.arg(job_id)::bigint
+), touch AS (
+    -- The interaction row keeps its own duties; tracking a job never opened must
+    -- still leave one behind.
+    INSERT INTO user_jobs (user_id, job_id)
+    VALUES (sqlc.arg(user_id), sqlc.arg(job_id))
+    ON CONFLICT (user_id, job_id) DO UPDATE SET user_id = user_jobs.user_id
+    RETURNING *
 ), upsert AS (
-    INSERT INTO user_jobs (user_id, job_id, stage, notes)
-    VALUES ($1, $2, $3, $4)
-    ON CONFLICT (user_id, job_id) DO UPDATE
-      SET stage = COALESCE(EXCLUDED.stage, user_jobs.stage),
-          notes = COALESCE(EXCLUDED.notes, user_jobs.notes)
+    -- applied_at is deliberately not set: setting a stage is not applying, and a
+    -- record with no date reads as "tracked, not recorded as applied" (0065).
+    INSERT INTO applications (user_id, job_id, company_slug, role_title, stage, notes)
+    SELECT sqlc.arg(user_id), sqlc.arg(job_id)::bigint, j.company_slug, j.title, sqlc.narg(stage), sqlc.narg(notes) FROM jobs j WHERE j.id = sqlc.arg(job_id)::bigint::bigint
+    ON CONFLICT (user_id, job_id) WHERE job_id IS NOT NULL
+    DO UPDATE SET stage = COALESCE(EXCLUDED.stage, applications.stage),
+                  notes = COALESCE(EXCLUDED.notes, applications.notes)
     RETURNING *
 ), event AS (
     -- The event names the application, like every other kind does. Resolved through the
@@ -151,30 +189,54 @@ WITH prior AS (
     -- time, while the posting is still there. A stage set on a job never applied to has
     -- no application to name and leaves the column NULL — there is nothing to correlate
     -- yet, and inventing a record would assert an application that was never made.
+    -- `upsert` IS the application now, so its id is in hand rather than resolved
+    -- back through the posting.
     INSERT INTO application_events (user_id, application_id, job_id, company_slug, kind, signal, occurred_at, source)
-    SELECT $1, a.id, $2, j.company_slug, 'stage_set', u.stage, now(), sqlc.arg(event_source)::text
-      FROM upsert u
-      JOIN jobs j ON j.id = $2
-      LEFT JOIN applications a ON a.user_id = $1 AND a.job_id = $2
+    SELECT sqlc.arg(user_id), u.id, sqlc.arg(job_id)::bigint, j.company_slug, 'stage_set', u.stage, now(), sqlc.arg(event_source)::text
+      FROM upsert u JOIN jobs j ON j.id = sqlc.arg(job_id)::bigint
      WHERE u.stage IS NOT NULL
        AND u.stage IS DISTINCT FROM (SELECT prior.stage FROM prior)
 )
-SELECT * FROM upsert;
+SELECT t.user_id, t.job_id, t.viewed_at, u.applied_at, t.saved_at,
+       u.stage, u.notes, t.dismissed_at, t.vote, u.followed_up_at
+  FROM touch t, upsert u;
 
 -- name: ClearJobProgress :one
 -- Reset a tracked job to the wishlist: drop stage and applied state, keep saved/viewed/notes.
-UPDATE user_jobs
-SET stage = NULL, applied_at = NULL
-WHERE user_id = $1 AND job_id = $2
-RETURNING *;
+-- The application record stays: it holds the notes, and clearing progress is the
+-- candidate reconsidering, not a claim the process never happened.
+WITH cleared AS (
+    UPDATE applications SET stage = NULL, applied_at = NULL
+    WHERE applications.user_id = sqlc.arg(user_id) AND applications.job_id = sqlc.arg(job_id)
+    RETURNING *
+)
+SELECT uj.user_id, uj.job_id, uj.viewed_at, c.applied_at, uj.saved_at,
+       c.stage, c.notes, uj.dismissed_at, uj.vote, c.followed_up_at
+  FROM user_jobs uj
+  LEFT JOIN cleared c ON c.user_id = uj.user_id AND c.job_id = uj.job_id
+ WHERE uj.user_id = sqlc.arg(user_id) AND uj.job_id = sqlc.arg(job_id);
 
 -- name: UntrackJob :one
 -- Remove a job from the board: drop every pipeline mark, keep viewed_at so the
 -- job remains in the user's view history.
-UPDATE user_jobs
-SET saved_at = NULL, applied_at = NULL, stage = NULL, notes = NULL
-WHERE user_id = $1 AND job_id = $2
-RETURNING *;
+-- Taking a job off the board clears the process outright — this is the candidate
+-- saying it is not a thing they are pursuing, which is a claim about their own
+-- record and theirs alone to make. cmd/prune has no such standing, which is the
+-- whole distinction this change draws.
+WITH dropped AS (
+    DELETE FROM applications WHERE applications.user_id = sqlc.arg(user_id) AND applications.job_id = sqlc.arg(job_id)::bigint
+), unsaved AS (
+    UPDATE user_jobs SET saved_at = NULL
+    WHERE user_jobs.user_id = sqlc.arg(user_id) AND user_jobs.job_id = sqlc.arg(job_id)
+    RETURNING *
+)
+SELECT u.user_id, u.job_id, u.viewed_at,
+       NULL::timestamptz AS applied_at, u.saved_at,
+       NULL::text        AS stage,
+       NULL::text        AS notes,
+       u.dismissed_at, u.vote,
+       NULL::timestamptz AS followed_up_at
+  FROM unsaved u;
 
 -- name: ListUserJobs :many
 -- A user's job interactions joined with the job rows. Each subset is ordered by
@@ -189,7 +251,7 @@ RETURNING *;
 -- per-card ✉ badge; 0 for everyone without a connected mailbox. reminder_fire_at is
 -- the pending saved-job reminder's deadline (NULL when none), so the saved list can
 -- show "remind in N days" with its reschedule/off controls.
-SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes,
+SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes,
        (SELECT count(*)
           FROM emails e
          WHERE e.user_id = uj.user_id
@@ -200,7 +262,7 @@ SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.
          WHERE r.user_id = uj.user_id
            AND r.job_id = jobs.id
            AND r.status = 'pending') AS reminder_fire_at,
-       uj.followed_up_at,
+       a.followed_up_at,
        -- last_activity_at is when this application last moved: its apply date, or
        -- the newest message linked to it when that is later. GREATEST ignores a
        -- NULL aggregate, so an application with no mail falls back to applied_at
@@ -208,8 +270,8 @@ SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.
        -- arrives would never fire on the applications ignored outright, which are
        -- the ones worth reporting. NULL on a row that is not an application: a job
        -- merely viewed or saved is not waiting on anyone.
-       (CASE WHEN uj.applied_at IS NOT NULL THEN
-          GREATEST(uj.applied_at,
+       (CASE WHEN a.applied_at IS NOT NULL THEN
+          GREATEST(a.applied_at,
                    (SELECT max(e.received_at)
                       FROM emails e
                      WHERE e.user_id = uj.user_id
@@ -220,7 +282,7 @@ SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.
        -- application that the caller has neither confirmed nor rejected. Such mail
        -- contradicts a claim that nobody replied, so the reader downgrades a
        -- silence verdict to a question rather than asserting it.
-       (uj.applied_at IS NOT NULL AND EXISTS (
+       (a.applied_at IS NOT NULL AND EXISTS (
           SELECT 1
             FROM emails e
            WHERE e.user_id = uj.user_id
@@ -229,21 +291,22 @@ SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.
              AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
 WHERE uj.user_id = $1
   AND (sqlc.arg(filter)::text = 'all'
-       OR (sqlc.arg(filter)::text = 'viewed' AND uj.saved_at IS NULL AND uj.applied_at IS NULL)
+       OR (sqlc.arg(filter)::text = 'viewed' AND uj.saved_at IS NULL AND a.applied_at IS NULL)
        OR (sqlc.arg(filter)::text = 'saved' AND uj.saved_at IS NOT NULL)
-       OR (sqlc.arg(filter)::text = 'applied' AND uj.applied_at IS NOT NULL)
+       OR (sqlc.arg(filter)::text = 'applied' AND a.applied_at IS NOT NULL)
        OR (sqlc.arg(filter)::text = 'board'
-           AND (uj.saved_at IS NOT NULL OR uj.applied_at IS NOT NULL OR uj.stage IS NOT NULL))
+           AND (uj.saved_at IS NOT NULL OR a.applied_at IS NOT NULL OR a.stage IS NOT NULL))
        OR (sqlc.arg(filter)::text = 'dismissed' AND uj.dismissed_at IS NOT NULL))
 ORDER BY (CASE sqlc.arg(filter)::text
             WHEN 'saved' THEN uj.saved_at
-            WHEN 'applied' THEN uj.applied_at
+            WHEN 'applied' THEN a.applied_at
             WHEN 'viewed' THEN uj.viewed_at
-            WHEN 'board' THEN GREATEST(uj.saved_at, uj.applied_at)
+            WHEN 'board' THEN GREATEST(uj.saved_at, a.applied_at)
             WHEN 'dismissed' THEN uj.dismissed_at
-            ELSE GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at)
+            ELSE GREATEST(uj.viewed_at, uj.saved_at, a.applied_at)
           END) DESC NULLS LAST, uj.job_id DESC
 LIMIT $2 OFFSET $3;
 
@@ -290,17 +353,18 @@ WHERE uj.user_id = $1 AND uj.dismissed_at IS NOT NULL;
 -- board (saved, applied, or stage set), matching the ListUserJobs board filter.
 -- "dismissed" counts jobs the user hid from the feed, matching the ListUserJobs
 -- dismissed filter.
-SELECT count(*)                                        AS "all",
-       count(*) FILTER (WHERE saved_at IS NULL
-                          AND applied_at IS NULL)      AS viewed,
-       count(*) FILTER (WHERE saved_at   IS NOT NULL) AS saved,
-       count(*) FILTER (WHERE applied_at IS NOT NULL) AS applied,
-       count(*) FILTER (WHERE saved_at   IS NOT NULL
-                            OR applied_at IS NOT NULL
-                            OR stage      IS NOT NULL) AS board,
-       count(*) FILTER (WHERE dismissed_at IS NOT NULL) AS dismissed
-FROM user_jobs
-WHERE user_id = $1;
+SELECT count(*)                                          AS "all",
+       count(*) FILTER (WHERE uj.saved_at IS NULL
+                          AND a.applied_at IS NULL)        AS viewed,
+       count(*) FILTER (WHERE uj.saved_at  IS NOT NULL)    AS saved,
+       count(*) FILTER (WHERE a.applied_at IS NOT NULL)    AS applied,
+       count(*) FILTER (WHERE uj.saved_at  IS NOT NULL
+                            OR a.applied_at IS NOT NULL
+                            OR a.stage      IS NOT NULL)   AS board,
+       count(*) FILTER (WHERE uj.dismissed_at IS NOT NULL) AS dismissed
+FROM user_jobs uj
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
+WHERE uj.user_id = $1;
 
 -- name: LockJobForApply :exec
 -- Take the job row's lock so concurrent applies on the same job serialize. Without
@@ -360,7 +424,7 @@ SELECT COALESCE((SELECT vote FROM user_jobs WHERE user_id = $1 AND job_id = $2),
 -- applied_at set but no stage groups under a NULL stage. The Go layer folds these
 -- rows into the pipeline buckets.
 SELECT stage, count(*) AS count
-FROM user_jobs
+FROM applications
 WHERE user_id = $1
   AND (applied_at IS NOT NULL OR stage IS NOT NULL)
 GROUP BY stage;
@@ -380,17 +444,18 @@ GROUP BY stage;
 -- seconds apart, a genuine second chase days apart, so any threshold between them is
 -- safe. An hour is the smallest that sits comfortably above a retry.
 WITH prior AS (
-    SELECT uj.followed_up_at FROM user_jobs uj
-     WHERE uj.user_id = $1 AND uj.job_id = $2 AND uj.applied_at IS NOT NULL
+    SELECT a.followed_up_at FROM applications a
+     WHERE a.user_id = sqlc.arg(user_id) AND a.job_id = sqlc.arg(job_id)::bigint AND a.applied_at IS NOT NULL
 ), upd AS (
-    UPDATE user_jobs
+    UPDATE applications
     SET followed_up_at = now()
-    WHERE user_id = $1 AND job_id = $2 AND applied_at IS NOT NULL
-    RETURNING followed_up_at
+    WHERE applications.user_id = sqlc.arg(user_id) AND applications.job_id = sqlc.arg(job_id)::bigint
+      AND applications.applied_at IS NOT NULL
+    RETURNING id, followed_up_at
 ), event AS (
-    INSERT INTO application_events (user_id, job_id, company_slug, kind, occurred_at, source)
-    SELECT $1, $2, j.company_slug, 'follow_up_sent', u.followed_up_at, sqlc.arg(event_source)::text
-      FROM upd u JOIN jobs j ON j.id = $2
+    INSERT INTO application_events (user_id, application_id, job_id, company_slug, kind, occurred_at, source)
+    SELECT sqlc.arg(user_id), u.id, sqlc.arg(job_id)::bigint, j.company_slug, 'follow_up_sent', u.followed_up_at, sqlc.arg(event_source)::text
+      FROM upd u JOIN jobs j ON j.id = sqlc.arg(job_id)::bigint
      WHERE NOT EXISTS (
          SELECT 1 FROM prior
           WHERE prior.followed_up_at IS NOT NULL

--- a/internal/db/reminders.sql.go
+++ b/internal/db/reminders.sql.go
@@ -104,13 +104,14 @@ const getReminderForDelivery = `-- name: GetReminderForDelivery :one
 SELECT r.id, r.user_id, r.job_id, r.channels,
        j.title, j.company, j.public_slug, j.url,
        (j.closed_at IS NULL)::bool AS job_open,
-       COALESCE(uj.saved_at IS NOT NULL AND uj.applied_at IS NULL, false)::bool AS still_actionable,
+       COALESCE(uj.saved_at IS NOT NULL AND a.applied_at IS NULL, false)::bool AS still_actionable,
        u.email AS account_email,
        tl.chat_id AS telegram_chat_id
 FROM job_reminders r
 JOIN jobs j ON j.id = r.job_id
 JOIN users u ON u.id = r.user_id
 LEFT JOIN user_jobs uj ON uj.user_id = r.user_id AND uj.job_id = r.job_id
+LEFT JOIN applications a ON a.user_id = r.user_id AND a.job_id = r.job_id
 LEFT JOIN telegram_links tl ON tl.user_id = r.user_id
 WHERE r.id = $1
 `

--- a/internal/db/stats.sql.go
+++ b/internal/db/stats.sql.go
@@ -27,7 +27,9 @@ func (q *Queries) DeleteAllJobDailyStats(ctx context.Context) error {
 const getEngagementStats = `-- name: GetEngagementStats :one
 SELECT
     count(*) FILTER (WHERE saved_at IS NOT NULL)::int   AS saved,
-    count(*) FILTER (WHERE applied_at IS NOT NULL)::int AS applied,
+    -- applications live in their own table now, and counting them there is also the
+    -- honest count: one that outlived its posting is still an application somebody made.
+    (SELECT count(*) FROM applications WHERE applied_at IS NOT NULL)::int AS applied,
     (SELECT COALESCE(sum(uniques), 0) FROM job_daily_views)::int AS viewed,
     (SELECT count(*) FROM users WHERE resume_object_key IS NOT NULL)::int AS cvs_uploaded,
     (SELECT count(*) FROM cvs WHERE is_tailored)::int AS cvs_tailored,

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -12,10 +12,16 @@ import (
 )
 
 const clearJobProgress = `-- name: ClearJobProgress :one
-UPDATE user_jobs
-SET stage = NULL, applied_at = NULL
-WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+WITH cleared AS (
+    UPDATE applications SET stage = NULL, applied_at = NULL
+    WHERE applications.user_id = $1 AND applications.job_id = $2
+    RETURNING id, user_id, company_slug, role_title, job_id, applied_at, stage, notes, followed_up_at, created_at
+)
+SELECT uj.user_id, uj.job_id, uj.viewed_at, c.applied_at, uj.saved_at,
+       c.stage, c.notes, uj.dismissed_at, uj.vote, c.followed_up_at
+  FROM user_jobs uj
+  LEFT JOIN cleared c ON c.user_id = uj.user_id AND c.job_id = uj.job_id
+ WHERE uj.user_id = $1 AND uj.job_id = $2
 `
 
 type ClearJobProgressParams struct {
@@ -23,10 +29,25 @@ type ClearJobProgressParams struct {
 	JobID  int64 `json:"job_id"`
 }
 
+type ClearJobProgressRow struct {
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
+}
+
 // Reset a tracked job to the wishlist: drop stage and applied state, keep saved/viewed/notes.
-func (q *Queries) ClearJobProgress(ctx context.Context, arg ClearJobProgressParams) (UserJob, error) {
+// The application record stays: it holds the notes, and clearing progress is the
+// candidate reconsidering, not a claim the process never happened.
+func (q *Queries) ClearJobProgress(ctx context.Context, arg ClearJobProgressParams) (ClearJobProgressRow, error) {
 	row := q.db.QueryRow(ctx, clearJobProgress, arg.UserID, arg.JobID)
-	var i UserJob
+	var i ClearJobProgressRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,
@@ -60,7 +81,7 @@ func (q *Queries) ClearJobVote(ctx context.Context, arg ClearJobVoteParams) erro
 
 const countMyJobsByStage = `-- name: CountMyJobsByStage :many
 SELECT stage, count(*) AS count
-FROM user_jobs
+FROM applications
 WHERE user_id = $1
   AND (applied_at IS NOT NULL OR stage IS NOT NULL)
 GROUP BY stage
@@ -96,17 +117,18 @@ func (q *Queries) CountMyJobsByStage(ctx context.Context, userID int64) ([]Count
 }
 
 const countUserJobs = `-- name: CountUserJobs :one
-SELECT count(*)                                        AS "all",
-       count(*) FILTER (WHERE saved_at IS NULL
-                          AND applied_at IS NULL)      AS viewed,
-       count(*) FILTER (WHERE saved_at   IS NOT NULL) AS saved,
-       count(*) FILTER (WHERE applied_at IS NOT NULL) AS applied,
-       count(*) FILTER (WHERE saved_at   IS NOT NULL
-                            OR applied_at IS NOT NULL
-                            OR stage      IS NOT NULL) AS board,
-       count(*) FILTER (WHERE dismissed_at IS NOT NULL) AS dismissed
-FROM user_jobs
-WHERE user_id = $1
+SELECT count(*)                                          AS "all",
+       count(*) FILTER (WHERE uj.saved_at IS NULL
+                          AND a.applied_at IS NULL)        AS viewed,
+       count(*) FILTER (WHERE uj.saved_at  IS NOT NULL)    AS saved,
+       count(*) FILTER (WHERE a.applied_at IS NOT NULL)    AS applied,
+       count(*) FILTER (WHERE uj.saved_at  IS NOT NULL
+                            OR a.applied_at IS NOT NULL
+                            OR a.stage      IS NOT NULL)   AS board,
+       count(*) FILTER (WHERE uj.dismissed_at IS NOT NULL) AS dismissed
+FROM user_jobs uj
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
+WHERE uj.user_id = $1
 `
 
 type CountUserJobsRow struct {
@@ -139,10 +161,16 @@ func (q *Queries) CountUserJobs(ctx context.Context, userID int64) (CountUserJob
 }
 
 const dismissJob = `-- name: DismissJob :one
-INSERT INTO user_jobs (user_id, job_id, dismissed_at)
-VALUES ($1, $2, now())
-ON CONFLICT (user_id, job_id) DO UPDATE SET dismissed_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+WITH touch AS (
+    INSERT INTO user_jobs (user_id, job_id, dismissed_at)
+    VALUES ($1, $2, now())
+    ON CONFLICT (user_id, job_id) DO UPDATE SET dismissed_at = now()
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id
 `
 
 type DismissJobParams struct {
@@ -150,12 +178,25 @@ type DismissJobParams struct {
 	JobID  int64 `json:"job_id"`
 }
 
+type DismissJobRow struct {
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
+}
+
 // Dismiss (swipe away) a job for a user in the swipe deck. Idempotent and
 // independent of a prior view: it inserts the row (viewed_at defaults) or
 // refreshes dismissed_at in place.
-func (q *Queries) DismissJob(ctx context.Context, arg DismissJobParams) (UserJob, error) {
+func (q *Queries) DismissJob(ctx context.Context, arg DismissJobParams) (DismissJobRow, error) {
 	row := q.db.QueryRow(ctx, dismissJob, arg.UserID, arg.JobID)
-	var i UserJob
+	var i DismissJobRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,
@@ -172,10 +213,11 @@ func (q *Queries) DismissJob(ctx context.Context, arg DismissJobParams) (UserJob
 }
 
 const excludedJobIDs = `-- name: ExcludedJobIDs :many
-SELECT job_id
-FROM user_jobs
-WHERE user_id = $1
-ORDER BY GREATEST(viewed_at, saved_at, applied_at, dismissed_at) DESC
+SELECT uj.job_id
+FROM user_jobs uj
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
+WHERE uj.user_id = $1
+ORDER BY GREATEST(uj.viewed_at, uj.saved_at, a.applied_at, uj.dismissed_at) DESC
 LIMIT $2
 `
 
@@ -297,7 +339,7 @@ func (q *Queries) ListSavedJobSlugs(ctx context.Context, userID int64) ([]string
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, jobs.semantic_embedding, jobs.salary_min_manual, jobs.salary_max_manual, jobs.salary_currency_manual, jobs.salary_period_manual, jobs.upvote_count, jobs.downvote_count, jobs.ats_absent_at, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes,
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, jobs.semantic_embedding, jobs.salary_min_manual, jobs.salary_max_manual, jobs.salary_currency_manual, jobs.salary_period_manual, jobs.upvote_count, jobs.downvote_count, jobs.ats_absent_at, uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes,
        (SELECT count(*)
           FROM emails e
          WHERE e.user_id = uj.user_id
@@ -308,7 +350,7 @@ SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.compan
          WHERE r.user_id = uj.user_id
            AND r.job_id = jobs.id
            AND r.status = 'pending') AS reminder_fire_at,
-       uj.followed_up_at,
+       a.followed_up_at,
        -- last_activity_at is when this application last moved: its apply date, or
        -- the newest message linked to it when that is later. GREATEST ignores a
        -- NULL aggregate, so an application with no mail falls back to applied_at
@@ -316,8 +358,8 @@ SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.compan
        -- arrives would never fire on the applications ignored outright, which are
        -- the ones worth reporting. NULL on a row that is not an application: a job
        -- merely viewed or saved is not waiting on anyone.
-       (CASE WHEN uj.applied_at IS NOT NULL THEN
-          GREATEST(uj.applied_at,
+       (CASE WHEN a.applied_at IS NOT NULL THEN
+          GREATEST(a.applied_at,
                    (SELECT max(e.received_at)
                       FROM emails e
                      WHERE e.user_id = uj.user_id
@@ -328,7 +370,7 @@ SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.compan
        -- application that the caller has neither confirmed nor rejected. Such mail
        -- contradicts a claim that nobody replied, so the reader downgrades a
        -- silence verdict to a question rather than asserting it.
-       (uj.applied_at IS NOT NULL AND EXISTS (
+       (a.applied_at IS NOT NULL AND EXISTS (
           SELECT 1
             FROM emails e
            WHERE e.user_id = uj.user_id
@@ -337,21 +379,22 @@ SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.compan
              AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
+LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
 WHERE uj.user_id = $1
   AND ($4::text = 'all'
-       OR ($4::text = 'viewed' AND uj.saved_at IS NULL AND uj.applied_at IS NULL)
+       OR ($4::text = 'viewed' AND uj.saved_at IS NULL AND a.applied_at IS NULL)
        OR ($4::text = 'saved' AND uj.saved_at IS NOT NULL)
-       OR ($4::text = 'applied' AND uj.applied_at IS NOT NULL)
+       OR ($4::text = 'applied' AND a.applied_at IS NOT NULL)
        OR ($4::text = 'board'
-           AND (uj.saved_at IS NOT NULL OR uj.applied_at IS NOT NULL OR uj.stage IS NOT NULL))
+           AND (uj.saved_at IS NOT NULL OR a.applied_at IS NOT NULL OR a.stage IS NOT NULL))
        OR ($4::text = 'dismissed' AND uj.dismissed_at IS NOT NULL))
 ORDER BY (CASE $4::text
             WHEN 'saved' THEN uj.saved_at
-            WHEN 'applied' THEN uj.applied_at
+            WHEN 'applied' THEN a.applied_at
             WHEN 'viewed' THEN uj.viewed_at
-            WHEN 'board' THEN GREATEST(uj.saved_at, uj.applied_at)
+            WHEN 'board' THEN GREATEST(uj.saved_at, a.applied_at)
             WHEN 'dismissed' THEN uj.dismissed_at
-            ELSE GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at)
+            ELSE GREATEST(uj.viewed_at, uj.saved_at, a.applied_at)
           END) DESC NULLS LAST, uj.job_id DESC
 LIMIT $2 OFFSET $3
 `
@@ -536,44 +579,40 @@ func (q *Queries) LockJobForVote(ctx context.Context, id int64) error {
 
 const markJobApplied = `-- name: MarkJobApplied :one
 WITH prior AS (
-    SELECT uj.applied_at FROM user_jobs uj WHERE uj.user_id = $1 AND uj.job_id = $2
+    SELECT a.applied_at FROM applications a WHERE a.user_id = $1 AND a.job_id = $2::bigint
+), touch AS (
+    -- The interaction row still exists for its own duties; applying to a job never
+    -- opened must still leave one behind, as it always has.
+    INSERT INTO user_jobs (user_id, job_id)
+    VALUES ($1, $2)
+    ON CONFLICT (user_id, job_id) DO UPDATE SET user_id = user_jobs.user_id
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
 ), upsert AS (
-    INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
-    VALUES ($1, $2, COALESCE($3::timestamptz, now()), 'applied')
-    ON CONFLICT (user_id, job_id) DO UPDATE
+    INSERT INTO applications (user_id, job_id, company_slug, role_title, applied_at, stage)
+    SELECT $1, $2::bigint, j.company_slug, j.title,
+           COALESCE($3::timestamptz, now()), 'applied'
+      FROM jobs j WHERE j.id = $2::bigint
+    ON CONFLICT (user_id, job_id) WHERE job_id IS NOT NULL
+    DO UPDATE
       SET applied_at = CASE
               WHEN $3::timestamptz IS NOT NULL
-                  THEN COALESCE(user_jobs.applied_at, $3::timestamptz)
+                  THEN COALESCE(applications.applied_at, $3::timestamptz)
               ELSE now()
           END,
-          stage = COALESCE(user_jobs.stage, 'applied')
-    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+          stage = COALESCE(applications.stage, 'applied')
+    RETURNING id, user_id, company_slug, role_title, job_id, applied_at, stage, notes, followed_up_at, created_at
 ), bump AS (
     UPDATE jobs SET applied_count = applied_count + 1
     WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior WHERE prior.applied_at IS NOT NULL)
-), app AS (
-    -- The application record, written by this same statement so it cannot diverge from
-    -- the apply it describes. The employer and role title are copied off the posting
-    -- here, while it is still there; that copy is what survives cmd/prune.
-    --
-    -- DO UPDATE rather than DO NOTHING, and not for the update's sake: DO NOTHING
-    -- returns no row on conflict, and this statement needs the id in both cases — a
-    -- re-apply must name the same application, never a NULL. The assignments mirror the
-    -- upsert above: the date refreshes as it always has, an advanced stage survives.
-    INSERT INTO applications (user_id, company_slug, role_title, job_id, applied_at, stage)
-    SELECT $1, j.company_slug, j.title, $2, u.applied_at, u.stage
-      FROM upsert u JOIN jobs j ON j.id = $2
-    ON CONFLICT (user_id, job_id) WHERE job_id IS NOT NULL
-    DO UPDATE SET applied_at = EXCLUDED.applied_at,
-                  stage      = COALESCE(applications.stage, EXCLUDED.stage)
-    RETURNING id
 ), event AS (
     INSERT INTO application_events (user_id, application_id, job_id, company_slug, kind, occurred_at, source)
-    SELECT $1, (SELECT id FROM app), $2, j.company_slug, 'applied', u.applied_at, $4::text
-      FROM upsert u JOIN jobs j ON j.id = $2
+    SELECT $1, u.id, $2::bigint, j.company_slug, 'applied', u.applied_at, $4::text
+      FROM upsert u JOIN jobs j ON j.id = $2::bigint
      WHERE NOT EXISTS (SELECT 1 FROM prior WHERE prior.applied_at IS NOT NULL)
 )
-SELECT user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at FROM upsert
+SELECT t.user_id, t.job_id, t.viewed_at, u.applied_at, t.saved_at,
+       u.stage, u.notes, t.dismissed_at, t.vote, u.followed_up_at
+  FROM touch t, upsert u
 `
 
 type MarkJobAppliedParams struct {
@@ -645,17 +684,18 @@ func (q *Queries) MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) 
 
 const recordApplicationFollowUp = `-- name: RecordApplicationFollowUp :one
 WITH prior AS (
-    SELECT uj.followed_up_at FROM user_jobs uj
-     WHERE uj.user_id = $1 AND uj.job_id = $2 AND uj.applied_at IS NOT NULL
+    SELECT a.followed_up_at FROM applications a
+     WHERE a.user_id = $1 AND a.job_id = $2::bigint AND a.applied_at IS NOT NULL
 ), upd AS (
-    UPDATE user_jobs
+    UPDATE applications
     SET followed_up_at = now()
-    WHERE user_id = $1 AND job_id = $2 AND applied_at IS NOT NULL
-    RETURNING followed_up_at
+    WHERE applications.user_id = $1 AND applications.job_id = $2::bigint
+      AND applications.applied_at IS NOT NULL
+    RETURNING id, followed_up_at
 ), event AS (
-    INSERT INTO application_events (user_id, job_id, company_slug, kind, occurred_at, source)
-    SELECT $1, $2, j.company_slug, 'follow_up_sent', u.followed_up_at, $3::text
-      FROM upd u JOIN jobs j ON j.id = $2
+    INSERT INTO application_events (user_id, application_id, job_id, company_slug, kind, occurred_at, source)
+    SELECT $1, u.id, $2::bigint, j.company_slug, 'follow_up_sent', u.followed_up_at, $3::text
+      FROM upd u JOIN jobs j ON j.id = $2::bigint
      WHERE NOT EXISTS (
          SELECT 1 FROM prior
           WHERE prior.followed_up_at IS NOT NULL
@@ -692,15 +732,34 @@ func (q *Queries) RecordApplicationFollowUp(ctx context.Context, arg RecordAppli
 }
 
 const recordJobView = `-- name: RecordJobView :one
-INSERT INTO user_jobs (user_id, job_id)
-VALUES ($1, $2)
-ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+WITH touch AS (
+    INSERT INTO user_jobs (user_id, job_id)
+    VALUES ($1, $2)
+    ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id
 `
 
 type RecordJobViewParams struct {
 	UserID int64 `json:"user_id"`
 	JobID  int64 `json:"job_id"`
+}
+
+type RecordJobViewRow struct {
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
 }
 
 // Record (or refresh) a user's view of a job. Idempotent on (user_id, job_id):
@@ -709,9 +768,13 @@ type RecordJobViewParams struct {
 // does NOT touch jobs.view_count — that materialized counter is maintained solely
 // by the nginx-log aggregation worker (cmd/rollup-views), which counts all traffic
 // (anonymous + signed-in + API), so the signed-in beacon must not double-count.
-func (q *Queries) RecordJobView(ctx context.Context, arg RecordJobViewParams) (UserJob, error) {
+// The interaction shape the caller has always received is now assembled from two
+// tables: user_jobs keeps the marks on the posting, applications holds the process.
+// The column list and its order mirror user_jobs' own, so the Go layer's
+// db.UserJob(row) conversion keeps working across every query in this file.
+func (q *Queries) RecordJobView(ctx context.Context, arg RecordJobViewParams) (RecordJobViewRow, error) {
 	row := q.db.QueryRow(ctx, recordJobView, arg.UserID, arg.JobID)
-	var i UserJob
+	var i RecordJobViewRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,
@@ -752,10 +815,16 @@ func (q *Queries) RecountJobVotes(ctx context.Context, jobID int64) (RecountJobV
 }
 
 const saveJob = `-- name: SaveJob :one
-INSERT INTO user_jobs (user_id, job_id, saved_at)
-VALUES ($1, $2, now())
-ON CONFLICT (user_id, job_id) DO UPDATE SET saved_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+WITH touch AS (
+    INSERT INTO user_jobs (user_id, job_id, saved_at)
+    VALUES ($1, $2, now())
+    ON CONFLICT (user_id, job_id) DO UPDATE SET saved_at = now()
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id
 `
 
 type SaveJobParams struct {
@@ -763,11 +832,24 @@ type SaveJobParams struct {
 	JobID  int64 `json:"job_id"`
 }
 
+type SaveJobRow struct {
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
+}
+
 // Save (bookmark) a job for a user. Idempotent and independent of a prior view:
 // it inserts the row (viewed_at defaults) or refreshes saved_at in place.
-func (q *Queries) SaveJob(ctx context.Context, arg SaveJobParams) (UserJob, error) {
+func (q *Queries) SaveJob(ctx context.Context, arg SaveJobParams) (SaveJobRow, error) {
 	row := q.db.QueryRow(ctx, saveJob, arg.UserID, arg.JobID)
-	var i UserJob
+	var i SaveJobRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,
@@ -785,29 +867,40 @@ func (q *Queries) SaveJob(ctx context.Context, arg SaveJobParams) (UserJob, erro
 
 const trackJob = `-- name: TrackJob :one
 WITH prior AS (
-    SELECT uj.stage FROM user_jobs uj WHERE uj.user_id = $1 AND uj.job_id = $2
-), upsert AS (
-    INSERT INTO user_jobs (user_id, job_id, stage, notes)
-    VALUES ($1, $2, $3, $4)
-    ON CONFLICT (user_id, job_id) DO UPDATE
-      SET stage = COALESCE(EXCLUDED.stage, user_jobs.stage),
-          notes = COALESCE(EXCLUDED.notes, user_jobs.notes)
+    SELECT a.stage FROM applications a WHERE a.user_id = $1 AND a.job_id = $2::bigint
+), touch AS (
+    -- The interaction row keeps its own duties; tracking a job never opened must
+    -- still leave one behind.
+    INSERT INTO user_jobs (user_id, job_id)
+    VALUES ($1, $2)
+    ON CONFLICT (user_id, job_id) DO UPDATE SET user_id = user_jobs.user_id
     RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+), upsert AS (
+    -- applied_at is deliberately not set: setting a stage is not applying, and a
+    -- record with no date reads as "tracked, not recorded as applied" (0065).
+    INSERT INTO applications (user_id, job_id, company_slug, role_title, stage, notes)
+    SELECT $1, $2::bigint, j.company_slug, j.title, $3, $4 FROM jobs j WHERE j.id = $2::bigint::bigint
+    ON CONFLICT (user_id, job_id) WHERE job_id IS NOT NULL
+    DO UPDATE SET stage = COALESCE(EXCLUDED.stage, applications.stage),
+                  notes = COALESCE(EXCLUDED.notes, applications.notes)
+    RETURNING id, user_id, company_slug, role_title, job_id, applied_at, stage, notes, followed_up_at, created_at
 ), event AS (
     -- The event names the application, like every other kind does. Resolved through the
     -- posting because that is the link the caller has, and soundly so: this runs at write
     -- time, while the posting is still there. A stage set on a job never applied to has
     -- no application to name and leaves the column NULL — there is nothing to correlate
     -- yet, and inventing a record would assert an application that was never made.
+    -- ` + "`" + `upsert` + "`" + ` IS the application now, so its id is in hand rather than resolved
+    -- back through the posting.
     INSERT INTO application_events (user_id, application_id, job_id, company_slug, kind, signal, occurred_at, source)
-    SELECT $1, a.id, $2, j.company_slug, 'stage_set', u.stage, now(), $5::text
-      FROM upsert u
-      JOIN jobs j ON j.id = $2
-      LEFT JOIN applications a ON a.user_id = $1 AND a.job_id = $2
+    SELECT $1, u.id, $2::bigint, j.company_slug, 'stage_set', u.stage, now(), $5::text
+      FROM upsert u JOIN jobs j ON j.id = $2::bigint
      WHERE u.stage IS NOT NULL
        AND u.stage IS DISTINCT FROM (SELECT prior.stage FROM prior)
 )
-SELECT user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at FROM upsert
+SELECT t.user_id, t.job_id, t.viewed_at, u.applied_at, t.saved_at,
+       u.stage, u.notes, t.dismissed_at, t.vote, u.followed_up_at
+  FROM touch t, upsert u
 `
 
 type TrackJobParams struct {
@@ -866,10 +959,15 @@ func (q *Queries) TrackJob(ctx context.Context, arg TrackJobParams) (TrackJobRow
 }
 
 const undismissJob = `-- name: UndismissJob :one
-UPDATE user_jobs
-SET dismissed_at = NULL
-WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+WITH touch AS (
+    UPDATE user_jobs SET dismissed_at = NULL
+    WHERE user_jobs.user_id = $1 AND user_jobs.job_id = $2
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id
 `
 
 type UndismissJobParams struct {
@@ -877,13 +975,26 @@ type UndismissJobParams struct {
 	JobID  int64 `json:"job_id"`
 }
 
+type UndismissJobRow struct {
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
+}
+
 // Clear a job's dismissed mark without deleting the interaction row, so view/
 // apply/save history survives. No interaction row -> pgx.ErrNoRows; the handler
 // treats that as "already not dismissed", never as a failure. This is the undo
 // path for a swipe-left decision.
-func (q *Queries) UndismissJob(ctx context.Context, arg UndismissJobParams) (UserJob, error) {
+func (q *Queries) UndismissJob(ctx context.Context, arg UndismissJobParams) (UndismissJobRow, error) {
 	row := q.db.QueryRow(ctx, undismissJob, arg.UserID, arg.JobID)
-	var i UserJob
+	var i UndismissJobRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,
@@ -900,10 +1011,15 @@ func (q *Queries) UndismissJob(ctx context.Context, arg UndismissJobParams) (Use
 }
 
 const unsaveJob = `-- name: UnsaveJob :one
-UPDATE user_jobs
-SET saved_at = NULL
-WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+WITH touch AS (
+    UPDATE user_jobs SET saved_at = NULL
+    WHERE user_jobs.user_id = $1 AND user_jobs.job_id = $2
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+)
+SELECT t.user_id, t.job_id, t.viewed_at, a.applied_at, t.saved_at,
+       a.stage, a.notes, t.dismissed_at, t.vote, a.followed_up_at
+  FROM touch t
+  LEFT JOIN applications a ON a.user_id = t.user_id AND a.job_id = t.job_id
 `
 
 type UnsaveJobParams struct {
@@ -911,12 +1027,25 @@ type UnsaveJobParams struct {
 	JobID  int64 `json:"job_id"`
 }
 
+type UnsaveJobRow struct {
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
+}
+
 // Clear a job's saved mark without deleting the interaction row, so view and
 // apply history survive unsaving. No interaction row -> pgx.ErrNoRows; the
 // handler treats that as "already not saved", never as a failure.
-func (q *Queries) UnsaveJob(ctx context.Context, arg UnsaveJobParams) (UserJob, error) {
+func (q *Queries) UnsaveJob(ctx context.Context, arg UnsaveJobParams) (UnsaveJobRow, error) {
 	row := q.db.QueryRow(ctx, unsaveJob, arg.UserID, arg.JobID)
-	var i UserJob
+	var i UnsaveJobRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,
@@ -933,10 +1062,20 @@ func (q *Queries) UnsaveJob(ctx context.Context, arg UnsaveJobParams) (UserJob, 
 }
 
 const untrackJob = `-- name: UntrackJob :one
-UPDATE user_jobs
-SET saved_at = NULL, applied_at = NULL, stage = NULL, notes = NULL
-WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+WITH dropped AS (
+    DELETE FROM applications WHERE applications.user_id = $1 AND applications.job_id = $2::bigint
+), unsaved AS (
+    UPDATE user_jobs SET saved_at = NULL
+    WHERE user_jobs.user_id = $1 AND user_jobs.job_id = $2
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at, vote, followed_up_at
+)
+SELECT u.user_id, u.job_id, u.viewed_at,
+       NULL::timestamptz AS applied_at, u.saved_at,
+       NULL::text        AS stage,
+       NULL::text        AS notes,
+       u.dismissed_at, u.vote,
+       NULL::timestamptz AS followed_up_at
+  FROM unsaved u
 `
 
 type UntrackJobParams struct {
@@ -944,11 +1083,28 @@ type UntrackJobParams struct {
 	JobID  int64 `json:"job_id"`
 }
 
+type UntrackJobRow struct {
+	UserID       int64              `json:"user_id"`
+	JobID        int64              `json:"job_id"`
+	ViewedAt     pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt    pgtype.Timestamptz `json:"applied_at"`
+	SavedAt      pgtype.Timestamptz `json:"saved_at"`
+	Stage        pgtype.Text        `json:"stage"`
+	Notes        pgtype.Text        `json:"notes"`
+	DismissedAt  pgtype.Timestamptz `json:"dismissed_at"`
+	Vote         pgtype.Int2        `json:"vote"`
+	FollowedUpAt pgtype.Timestamptz `json:"followed_up_at"`
+}
+
 // Remove a job from the board: drop every pipeline mark, keep viewed_at so the
 // job remains in the user's view history.
-func (q *Queries) UntrackJob(ctx context.Context, arg UntrackJobParams) (UserJob, error) {
+// Taking a job off the board clears the process outright — this is the candidate
+// saying it is not a thing they are pursuing, which is a claim about their own
+// record and theirs alone to make. cmd/prune has no such standing, which is the
+// whole distinction this change draws.
+func (q *Queries) UntrackJob(ctx context.Context, arg UntrackJobParams) (UntrackJobRow, error) {
 	row := q.db.QueryRow(ctx, untrackJob, arg.UserID, arg.JobID)
-	var i UserJob
+	var i UntrackJobRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,

--- a/internal/handler/api_keys_integration_test.go
+++ b/internal/handler/api_keys_integration_test.go
@@ -115,7 +115,7 @@ func TestAPIKeysEndToEnd(t *testing.T) {
 		}
 		var n int
 		if err := pool.QueryRow(ctx,
-			"SELECT count(*) FROM user_jobs WHERE user_id = $1 AND applied_at IS NOT NULL", ownerID).Scan(&n); err != nil {
+			"SELECT count(*) FROM applications WHERE user_id = $1 AND applied_at IS NOT NULL", ownerID).Scan(&n); err != nil {
 			t.Fatalf("count applied: %v", err)
 		}
 		if n != 1 {

--- a/internal/handler/assistant_interview_integration_test.go
+++ b/internal/handler/assistant_interview_integration_test.go
@@ -35,8 +35,13 @@ func seedApplication(t *testing.T, pool *pgxpool.Pool, userID int64, externalID,
 		t.Fatalf("seed job: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
-		 VALUES ($1, $2, now(), $3)`, userID, jobID, stage); err != nil {
+		`WITH mark AS (
+		     INSERT INTO user_jobs (user_id, job_id) VALUES ($1, $2)
+		     ON CONFLICT (user_id, job_id) DO NOTHING
+		 )
+		 INSERT INTO applications (user_id, job_id, company_slug, role_title, applied_at, stage)
+		 SELECT $1, $2, j.company_slug, j.title, now(), $3 FROM jobs j WHERE j.id = $2`,
+		userID, jobID, stage); err != nil {
 		t.Fatalf("seed application: %v", err)
 	}
 	return jobID

--- a/internal/handler/engagement_integration_test.go
+++ b/internal/handler/engagement_integration_test.go
@@ -88,10 +88,12 @@ func TestEngagementStatsEndpoint(t *testing.T) {
 	// all-traffic total SUM(jobs.view_count), independent of user_jobs, seeded below.
 	seedInteraction := func(jid int64, saved, applied bool) {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO user_jobs (user_id, job_id, viewed_at, saved_at, applied_at)
-			 VALUES ($1, $2, now(),
-			         CASE WHEN $3 THEN now() END,
-			         CASE WHEN $4 THEN now() END)`,
+			`WITH mark AS (
+			     INSERT INTO user_jobs (user_id, job_id, viewed_at, saved_at)
+			     VALUES ($1, $2, now(), CASE WHEN $3 THEN now() END)
+			 )
+			 INSERT INTO applications (user_id, job_id, company_slug, role_title, applied_at)
+			 SELECT $1, $2, j.company_slug, j.title, now() FROM jobs j WHERE j.id = $2 AND $4`,
 			uid, jid, saved, applied); err != nil {
 			t.Fatalf("seed interaction job=%d: %v", jid, err)
 		}

--- a/internal/handler/followup_integration_test.go
+++ b/internal/handler/followup_integration_test.go
@@ -20,8 +20,14 @@ func appliedDaysAgo(t *testing.T, f *harnessInboxFixture, jobID int64, days int,
 	t.Helper()
 	at := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
 	if _, err := f.pool.Exec(context.Background(),
-		`INSERT INTO user_jobs (user_id, job_id, applied_at, stage) VALUES ($1,$2,$3,$4)
-		 ON CONFLICT (user_id, job_id) DO UPDATE SET applied_at = $3, stage = $4`,
+		`WITH mark AS (
+		     INSERT INTO user_jobs (user_id, job_id) VALUES ($1,$2)
+		     ON CONFLICT (user_id, job_id) DO NOTHING
+		 )
+		 INSERT INTO applications (user_id, job_id, company_slug, role_title, applied_at, stage)
+		 SELECT $1, $2, j.company_slug, j.title, $3, $4 FROM jobs j WHERE j.id = $2
+		 ON CONFLICT (user_id, job_id) WHERE job_id IS NOT NULL
+		 DO UPDATE SET applied_at = $3, stage = $4`,
 		f.userID, jobID, at, stage); err != nil {
 		t.Fatalf("seed application: %v", err)
 	}
@@ -133,7 +139,7 @@ func TestFollowUpRecord_UntrackedSlugWritesNothing(t *testing.T) {
 	}
 	var n int
 	if err := f.pool.QueryRow(context.Background(),
-		`SELECT count(*) FROM user_jobs WHERE user_id=$1 AND job_id=$2 AND followed_up_at IS NOT NULL`,
+		`SELECT count(*) FROM applications WHERE user_id=$1 AND job_id=$2 AND followed_up_at IS NOT NULL`,
 		f.userID, jid).Scan(&n); err != nil {
 		t.Fatalf("count: %v", err)
 	}

--- a/internal/handler/inbox_application_from_mail_integration_test.go
+++ b/internal/handler/inbox_application_from_mail_integration_test.go
@@ -43,7 +43,7 @@ func (f *harnessInboxFixture) application(jobID int64) (appliedAt time.Time, sta
 	var st *string
 	var at *time.Time
 	err := f.pool.QueryRow(context.Background(),
-		`SELECT applied_at, stage FROM user_jobs WHERE user_id = $1 AND job_id = $2`,
+		`SELECT applied_at, stage FROM applications WHERE user_id = $1 AND job_id = $2`,
 		f.userID, jobID).Scan(&at, &st)
 	if err != nil {
 		return time.Time{}, "", false

--- a/internal/handler/inbox_harness_integration_test.go
+++ b/internal/handler/inbox_harness_integration_test.go
@@ -392,7 +392,12 @@ func (f *harnessInboxFixture) applyToJob(slug, stage string) int64 {
 		f.t.Fatalf("seed job: %v", err)
 	}
 	if _, err := f.pool.Exec(ctx,
-		`INSERT INTO user_jobs (user_id, job_id, applied_at, stage) VALUES ($1, $2, now(), $3)`,
+		`WITH mark AS (
+		     INSERT INTO user_jobs (user_id, job_id) VALUES ($1, $2)
+		     ON CONFLICT (user_id, job_id) DO NOTHING
+		 )
+		 INSERT INTO applications (user_id, job_id, company_slug, role_title, applied_at, stage)
+		 SELECT $1, $2, j.company_slug, j.title, now(), $3 FROM jobs j WHERE j.id = $2`,
 		f.userID, jobID, stage); err != nil {
 		f.t.Fatalf("seed application: %v", err)
 	}
@@ -403,7 +408,7 @@ func (f *harnessInboxFixture) stageOf(jobID int64) string {
 	f.t.Helper()
 	var stage *string
 	if err := f.pool.QueryRow(context.Background(),
-		`SELECT stage FROM user_jobs WHERE user_id = $1 AND job_id = $2`, f.userID, jobID).Scan(&stage); err != nil {
+		`SELECT stage FROM applications WHERE user_id = $1 AND job_id = $2`, f.userID, jobID).Scan(&stage); err != nil {
 		f.t.Fatalf("read stage: %v", err)
 	}
 	if stage == nil {

--- a/internal/inbox/fake_test.go
+++ b/internal/inbox/fake_test.go
@@ -125,6 +125,6 @@ func (f *fakeQueries) AdvanceUserJobStage(_ context.Context, arg db.AdvanceUserJ
 	if f.advanceErr != nil {
 		return f.advanceErr
 	}
-	f.advancedTo = arg.Stage.String
+	f.advancedTo = arg.Stage
 	return nil
 }

--- a/internal/inbox/mutate.go
+++ b/internal/inbox/mutate.go
@@ -228,7 +228,7 @@ func (s *Service) advanceStage(ctx context.Context, userID, jobID int64, sig mai
 		return
 	}
 	err = s.q.AdvanceUserJobStage(ctx, db.AdvanceUserJobStageParams{
-		UserID: userID, JobID: jobID, Stage: pgtype.Text{String: next, Valid: true},
+		UserID: userID, JobID: jobID, Stage: next,
 	})
 	if err != nil {
 		log.Printf("inbox: advance stage user=%d job=%d: %v", userID, jobID, err)

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -105,7 +105,7 @@ func (r *QueriesRepository) SaveJob(ctx context.Context, userID, jobID int64) (I
 	if err != nil {
 		return Interaction{}, err
 	}
-	return toInteraction(row), nil
+	return toInteraction(db.UserJob(row)), nil
 }
 
 // UnsaveJob clears the saved mark. Returns ErrNoInteraction when no row exists.
@@ -117,7 +117,7 @@ func (r *QueriesRepository) UnsaveJob(ctx context.Context, userID, jobID int64) 
 	if err != nil {
 		return Interaction{}, err
 	}
-	return toInteraction(row), nil
+	return toInteraction(db.UserJob(row)), nil
 }
 
 // DismissJob marks a job dismissed (swiped away) for a user.
@@ -126,7 +126,7 @@ func (r *QueriesRepository) DismissJob(ctx context.Context, userID, jobID int64)
 	if err != nil {
 		return Interaction{}, err
 	}
-	return toInteraction(row), nil
+	return toInteraction(db.UserJob(row)), nil
 }
 
 // UndismissJob clears the dismissed mark. Returns ErrNoInteraction when no row exists.
@@ -138,7 +138,7 @@ func (r *QueriesRepository) UndismissJob(ctx context.Context, userID, jobID int6
 	if err != nil {
 		return Interaction{}, err
 	}
-	return toInteraction(row), nil
+	return toInteraction(db.UserJob(row)), nil
 }
 
 // TrackJob upserts stage and/or notes for the interaction. A nil pointer means
@@ -169,7 +169,7 @@ func (r *QueriesRepository) ClearJobProgress(ctx context.Context, userID, jobID 
 	if err != nil {
 		return Interaction{}, err
 	}
-	return toInteraction(row), nil
+	return toInteraction(db.UserJob(row)), nil
 }
 
 // UntrackJob removes a job from the board by clearing all pipeline marks except viewed_at.
@@ -178,7 +178,7 @@ func (r *QueriesRepository) UntrackJob(ctx context.Context, userID, jobID int64)
 	if err != nil {
 		return Interaction{}, err
 	}
-	return toInteraction(row), nil
+	return toInteraction(db.UserJob(row)), nil
 }
 
 // ListInteractions returns the caller's interactions joined with the jobs in the

--- a/migrations/0065_applications_applied_at_optional.sql
+++ b/migrations/0065_applications_applied_at_optional.sql
@@ -1,0 +1,22 @@
+-- applications.applied_at becomes optional, because the table's subject is slightly wider than
+-- its name suggests: it is the candidate's tracked process with an employer, and applying is one
+-- event in it rather than its precondition.
+--
+-- The forcing case is the tracker's own API. `PATCH /jobs/:slug/track` sets a stage and/or notes
+-- and does NOT require the job to have been marked applied — user_jobs has always been able to
+-- carry a stage with applied_at unset, and the board's own filter counts a row with a stage as
+-- being on the board. When the stage and notes move to this table, that row needs a home here.
+--
+-- The alternative was to leave stage and notes on user_jobs for non-applied jobs and keep them
+-- here for applied ones. That gives one field two homes, which is exactly the duplication this
+-- change exists to remove: the two would disagree the first time a write path forgot one.
+--
+-- A NULL applied_at therefore reads as "tracked, not (yet) recorded as applied". Every consumer
+-- that means "an application was made" must test applied_at IS NOT NULL rather than assuming the
+-- row's existence says so — the ledger's `applied` event and the response-rate rollup already do,
+-- since they read events rather than this column.
+--
+-- Applied to a fresh volume by initdb after 0064; on an existing prod volume run this manually
+-- (SET ROLE hire). Relaxing a constraint, so it cannot fail on existing data.
+
+ALTER TABLE public.applications ALTER COLUMN applied_at DROP NOT NULL;

--- a/openspec/changes/applications-outlive-jobs/specs/application-record/spec.md
+++ b/openspec/changes/applications-outlive-jobs/specs/application-record/spec.md
@@ -6,12 +6,23 @@ The system SHALL store a tracked application as its own record carrying the appl
 employer as a company slug, the role title, `applied_at`, `stage`, `notes` and `followed_up_at`,
 independent of whether the posting it was made against is still in the catalogue.
 
+`applied_at` MAY be absent. The record's subject is the candidate's tracked process with an
+employer, and applying is one event in it rather than its precondition: the tracker has always
+allowed a stage to be set on a job never marked applied. A consumer that means "an application
+was made" MUST test `applied_at`, never the row's existence.
+
 The employer and the role title MUST be stored on the record itself rather than read through the
 posting, because the posting is the part that can disappear.
 
 The record MUST NOT carry its own provenance field. How an application came to exist is already
 recorded by its `applied` event's source in the ledger, and a second copy would be a second thing
 to keep true.
+
+#### Scenario: A stage set without applying is still tracked
+
+- **WHEN** a candidate sets a stage on a job they never marked applied
+- **THEN** a record exists carrying that stage
+- **AND** its `applied_at` is absent, so nothing reports it as an application
 
 #### Scenario: Application carries the employer without consulting the catalogue
 

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -27,13 +27,35 @@
 - [x] 4.2 `RebuildInsightsCompanyResponse` pairs `applied` with `employer_reply` on `application_id`; tasks 1.1 and 1.2 go green
 - [x] 4.4 Integration test: the median reply time for a company is unchanged by deleting its postings
 
-## 5. Cut over the tracking core
+## 5a. Cut over the tracking core — storage only, behaviour identical
+
+> **Indivisible.** Reads and writes of `applied_at`/`stage`/`notes`/`followed_up_at` flip in one
+> pass; the design rejected dual-writing. Half of this port leaves the board reading one place
+> and the apply path writing another.
+
+- [x] 5a.0 `migrations/0065_applications_applied_at_optional.sql` — `applied_at` becomes nullable. `PATCH /jobs/:slug/track` sets a stage on a job never marked applied, and that row needs a home here; the alternative gave `stage` two homes, the duplication this change exists to remove. Decision recorded in the `application-record` spec
 
 - [ ] 5.1 Port `internal/db/queries/user_jobs.sql` to read and write `applications` for the application columns, keeping `user_jobs` for view/save/dismiss/vote; run `make sqlc`
 - [ ] 5.2 Port `internal/jobtracking` (`MarkApplied`, `TrackJob`, the board read) — `applied_count` stays incremented only on the live transition, never by the backfill
 - [ ] 5.3 Port `internal/userjob` silence reads so the stage ladder resolves from the application record
 - [ ] 5.4 Port `internal/handler/user_jobs.go`, `me_tracking.go` and `assistant_tracking_tools.go`; assert the wire shapes are identical to before
 - [ ] 5.5 Port `stats.sql` and `internal/handler/stats.go`
+
+## 5b. The board renders an application with no posting — **CONTRACT CHANGE**
+
+> Found while reading `ListUserJobs`: the board is driven by `user_jobs` rows and does
+> `SELECT sqlc.embed(jobs)`, so every card requires a posting. `cmd/prune` cascades the
+> `user_jobs` row away, so after 5a the record survives in the database and in every aggregate
+> but the candidate still cannot see it. The stated goal is only half-delivered without this.
+>
+> `proposal.md` currently promises no wire-shape change. That promise has to be revised here,
+> not quietly broken: the job fields become optional and a card falls back to the application's
+> own `company_slug` and `role_title`.
+
+- [ ] 5b.1 Decide and record the wire shape for a posting-less card in `jobview`
+- [ ] 5b.2 Drive the board read from applications, left-joining the posting instead of requiring it
+- [ ] 5b.3 SPA renders the fallback card; `freehire-cli` and `freehire-mcp` tolerate the absent job
+- [ ] 5b.4 Integration test: an application whose posting was pruned still appears on its owner's board
 
 ## 6. Cut over the mail path
 

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -35,11 +35,11 @@
 
 - [x] 5a.0 `migrations/0065_applications_applied_at_optional.sql` — `applied_at` becomes nullable. `PATCH /jobs/:slug/track` sets a stage on a job never marked applied, and that row needs a home here; the alternative gave `stage` two homes, the duplication this change exists to remove. Decision recorded in the `application-record` spec
 
-- [ ] 5.1 Port `internal/db/queries/user_jobs.sql` to read and write `applications` for the application columns, keeping `user_jobs` for view/save/dismiss/vote; run `make sqlc`
-- [ ] 5.2 Port `internal/jobtracking` (`MarkApplied`, `TrackJob`, the board read) — `applied_count` stays incremented only on the live transition, never by the backfill
-- [ ] 5.3 Port `internal/userjob` silence reads so the stage ladder resolves from the application record
-- [ ] 5.4 Port `internal/handler/user_jobs.go`, `me_tracking.go` and `assistant_tracking_tools.go`; assert the wire shapes are identical to before
-- [ ] 5.5 Port `stats.sql` and `internal/handler/stats.go`
+- [x] 5.1 Port `internal/db/queries/user_jobs.sql` to read and write `applications` for the application columns, keeping `user_jobs` for view/save/dismiss/vote; run `make sqlc`
+- [x] 5.2 Port `internal/jobtracking` (`MarkApplied`, `TrackJob`, the board read) — `applied_count` stays incremented only on the live transition, never by the backfill
+- [x] 5.3 Port `internal/userjob` silence reads so the stage ladder resolves from the application record
+- [x] 5.4 Port `internal/handler/user_jobs.go`, `me_tracking.go` and `assistant_tracking_tools.go`; assert the wire shapes are identical to before
+- [x] 5.5 Port `stats.sql` and `internal/handler/stats.go`
 
 ## 5b. The board renders an application with no posting — **CONTRACT CHANGE**
 
@@ -59,7 +59,7 @@
 
 ## 6. Cut over the mail path
 
-- [ ] 6.1 Port `mail_linking.sql` and `mail_classification.sql` to `emails.application_id`; run `make sqlc`
+- [ ] 6.1 Port `mail_linking.sql` and `mail_classification.sql` to `emails.application_id`; run `make sqlc`. **Partly done in 5a:** their reads of `stage`/`applied_at` had to move with the rest of the cutover; the `emails.job_id` → `application_id` half is still open
 - [ ] 6.2 Port `internal/inbox` (`RecordApplication`, the `?link=suggested|unlinked` filters) and `internal/maillink` so auto-link, suggestion and monotonic stage advance behave identically
 - [ ] 6.3 Port `internal/handler/inbox_linking.go` and `followup.go`
 - [ ] 6.4 Port `cmd/classify-mail/store.go`
@@ -68,8 +68,8 @@
 
 ## 7. Cut over the remaining derived reads
 
-- [ ] 7.1 Port `ghost.sql` and `internal/ghostreport` so silent-application evidence reads applications, keeping both gates (two criteria, two distinct witnesses)
-- [ ] 7.2 Port `reminders.sql`, `jobs.sql` and `company_votes.sql`
+- [x] 7.1 Port `ghost.sql` and `internal/ghostreport` so silent-application evidence reads applications, keeping both gates (two criteria, two distinct witnesses)
+- [x] 7.2 Port `reminders.sql`, `jobs.sql` and `company_votes.sql`
 - [ ] 7.3 Integration test: over a fixture with no deletions, the company response rate and median equal what they were before this change — the port moves the join, not the answer
 
 ## 8. Make pruning safe


### PR DESCRIPTION
## What and why

`user_jobs` held two things under one key: **marks on a catalogue row** (viewed, saved, dismissed, voted), where a `job_id` is essential, and **an application** (`applied_at`, `stage`, `notes`, `followed_up_at`), where the posting is merely where the person found the role. Both cascaded from `jobs`, so `cmd/prune` — which has already hard-deleted 1,609,678 rows — took the candidate's own record with the posting. `PruneJobs` weighs that trade in a comment about a *saved* job, which is a bookmark; the same cascade silently covered applications, which are not.

#1351 gave the application an identity and fixed the public signal. This moves the storage.

## One pass, deliberately

Every reader and writer of those four columns flips here. There is no correct half-way state — the design rejected dual-writing, so a partial port leaves the board reading one place while the apply path writes another.

That reached further than the plan expected: `ghost.sql`, `reminders.sql`, `stats.sql`, `mail_classification.sql` and `mail_linking.sql` all read the moved columns, and the monotonic stage advance writes one. Those were planned as groups 6 and 7; the cutover pulled them in.

**No response moved.** Each query now assembles the interaction shape from both tables *in `user_jobs`' own column order*, so the Go layer's `db.UserJob(row)` conversion keeps working and every wire shape is byte-identical.

## Judgement calls worth a reviewer's eye

- **`applied_at` is nullable** (`0065`). `PATCH /jobs/:slug/track` sets a stage on a job never marked applied, and that row needs a home. The alternative — stage on `user_jobs` for non-applied jobs, here for applied ones — gives one field two homes, the duplication this change exists to remove. So the record's subject is the *tracked process*; a consumer meaning "an application was made" tests `applied_at`, never the row's existence.
- **`UntrackJob` deletes the application outright.** Taking a job off the board is the candidate saying it is not something they are pursuing — a claim about their own record, and theirs alone to make. `cmd/prune` has no such standing, which is the distinction the whole change draws.
- **Tests that seeded or asserted `user_jobs` directly now target `applications`.** Those assertions were always about storage, and the storage moved.
- **`::bigint` casts and named arguments** appear where a bare `$2` in a CTE select-list made sqlc infer a nullable `job_id`.

## Deliberately not here

The board still cannot render an application whose posting was pruned: `ListUserJobs` is driven by `user_jobs` rows and does `SELECT sqlc.embed(jobs)`, so every card requires a posting. Making the job fields optional is a wire-shape change and is group 5b, with its own design pass. Until it lands, a pruned application survives in the database and in every aggregate but stays invisible to its owner.

`emails.job_id` → `application_id` is likewise still open (group 6).

## Test plan

- [x] `go test ./...` — no failures
- [x] `go test -tags=integration ./...` — every package green (db, handler, inbox, jobtracking, maillink)
- [x] `go build ./... && go vet ./...`, `gofmt` clean
- [x] Swept the query layer: no `user_jobs` read of `applied_at`/`stage`/`notes`/`followed_up_at` remains
