### PR TITLE
The board keeps an application whose posting was pruned

### DIFF
--- a/internal/db/applications.sql.go
+++ b/internal/db/applications.sql.go
@@ -7,6 +7,8 @@ package db
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const backfillApplicationEventLinks = `-- name: BackfillApplicationEventLinks :execrows
@@ -132,4 +134,83 @@ func (q *Queries) BackfillEmailApplicationLinks(ctx context.Context, batchSize i
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const listOrphanedApplications = `-- name: ListOrphanedApplications :many
+SELECT a.id, a.company_slug, a.role_title, a.applied_at, a.stage, a.notes, a.followed_up_at,
+       (SELECT count(*)
+          FROM emails e
+         WHERE e.application_id = a.id
+           AND e.deleted_at IS NULL) AS email_count,
+       -- Same last-activity rule as the posting-backed rows: the apply date, or the newest
+       -- linked message when that is later. Mail is reached through the application, never
+       -- through the posting, which no longer exists.
+       (CASE WHEN a.applied_at IS NOT NULL THEN
+          GREATEST(a.applied_at,
+                   (SELECT max(e.received_at)
+                      FROM emails e
+                     WHERE e.application_id = a.id
+                       AND e.deleted_at IS NULL))
+        END)::timestamptz AS last_activity_at
+  FROM applications a
+ WHERE a.user_id = $1
+   AND a.job_id IS NULL
+ ORDER BY a.applied_at DESC NULLS LAST, a.id DESC
+ LIMIT $2
+`
+
+type ListOrphanedApplicationsParams struct {
+	UserID int64 `json:"user_id"`
+	Limit  int32 `json:"limit"`
+}
+
+type ListOrphanedApplicationsRow struct {
+	ID             int64              `json:"id"`
+	CompanySlug    string             `json:"company_slug"`
+	RoleTitle      string             `json:"role_title"`
+	AppliedAt      pgtype.Timestamptz `json:"applied_at"`
+	Stage          pgtype.Text        `json:"stage"`
+	Notes          pgtype.Text        `json:"notes"`
+	FollowedUpAt   pgtype.Timestamptz `json:"followed_up_at"`
+	EmailCount     int64              `json:"email_count"`
+	LastActivityAt pgtype.Timestamptz `json:"last_activity_at"`
+}
+
+// The caller's applications whose posting the catalogue no longer holds.
+//
+// Deliberately joins nothing: cmd/prune cleared job_id, so there is no posting to reach
+// and sqlc.embed over a LEFT JOIN would generate a non-pointer Job that fails at scan
+// time on the NULL columns (measured). The employer and role title are on the record
+// itself, which is the whole reason they were copied there.
+//
+// The board reads these alongside the posting-backed rows and merges the two; they are
+// few by nature — one appears only when a posting a candidate applied to is pruned.
+func (q *Queries) ListOrphanedApplications(ctx context.Context, arg ListOrphanedApplicationsParams) ([]ListOrphanedApplicationsRow, error) {
+	rows, err := q.db.Query(ctx, listOrphanedApplications, arg.UserID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListOrphanedApplicationsRow{}
+	for rows.Next() {
+		var i ListOrphanedApplicationsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.CompanySlug,
+			&i.RoleTitle,
+			&i.AppliedAt,
+			&i.Stage,
+			&i.Notes,
+			&i.FollowedUpAt,
+			&i.EmailCount,
+			&i.LastActivityAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1339,6 +1339,16 @@ type Querier interface {
 	// First page of a subject's open threads, newest first. Served by the partial index
 	// threads_subject_open_created_idx.
 	ListOpenThreadsFirst(ctx context.Context, arg ListOpenThreadsFirstParams) ([]ListOpenThreadsFirstRow, error)
+	// The caller's applications whose posting the catalogue no longer holds.
+	//
+	// Deliberately joins nothing: cmd/prune cleared job_id, so there is no posting to reach
+	// and sqlc.embed over a LEFT JOIN would generate a non-pointer Job that fails at scan
+	// time on the NULL columns (measured). The employer and role title are on the record
+	// itself, which is the whole reason they were copied there.
+	//
+	// The board reads these alongside the posting-backed rows and merges the two; they are
+	// few by nature — one appears only when a posting a candidate applied to is pruned.
+	ListOrphanedApplications(ctx context.Context, arg ListOrphanedApplicationsParams) ([]ListOrphanedApplicationsRow, error)
 	// The moderator queue: offers awaiting a decision, oldest first, with display name.
 	// Capped at 500 as a runaway-growth guard — far above any plausible backlog; a
 	// queue that deep needs bulk triage, not a longer page.

--- a/internal/db/queries/applications.sql
+++ b/internal/db/queries/applications.sql
@@ -78,3 +78,34 @@ UPDATE emails e
    SET application_id = p.application_id
   FROM page p
  WHERE e.id = p.id;
+
+-- name: ListOrphanedApplications :many
+-- The caller's applications whose posting the catalogue no longer holds.
+--
+-- Deliberately joins nothing: cmd/prune cleared job_id, so there is no posting to reach
+-- and sqlc.embed over a LEFT JOIN would generate a non-pointer Job that fails at scan
+-- time on the NULL columns (measured). The employer and role title are on the record
+-- itself, which is the whole reason they were copied there.
+--
+-- The board reads these alongside the posting-backed rows and merges the two; they are
+-- few by nature — one appears only when a posting a candidate applied to is pruned.
+SELECT a.id, a.company_slug, a.role_title, a.applied_at, a.stage, a.notes, a.followed_up_at,
+       (SELECT count(*)
+          FROM emails e
+         WHERE e.application_id = a.id
+           AND e.deleted_at IS NULL) AS email_count,
+       -- Same last-activity rule as the posting-backed rows: the apply date, or the newest
+       -- linked message when that is later. Mail is reached through the application, never
+       -- through the posting, which no longer exists.
+       (CASE WHEN a.applied_at IS NOT NULL THEN
+          GREATEST(a.applied_at,
+                   (SELECT max(e.received_at)
+                      FROM emails e
+                     WHERE e.application_id = a.id
+                       AND e.deleted_at IS NULL))
+        END)::timestamptz AS last_activity_at
+  FROM applications a
+ WHERE a.user_id = $1
+   AND a.job_id IS NULL
+ ORDER BY a.applied_at DESC NULLS LAST, a.id DESC
+ LIMIT $2;

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -12,14 +12,23 @@ import (
 // jobview wire shape with the caller's interaction timestamps riding alongside
 // (not flattened in — the job shape stays identical to every other job surface).
 type myJobResponse struct {
-	Job            jobview.Job `json:"job"`
-	ViewedAt       *time.Time  `json:"viewed_at"`
-	SavedAt        *time.Time  `json:"saved_at"`
-	AppliedAt      *time.Time  `json:"applied_at"`
-	Stage          *string     `json:"stage"`
-	Notes          *string     `json:"notes"`
-	EmailCount     int         `json:"email_count"`
-	ReminderFireAt *time.Time  `json:"reminder_fire_at"`
+	// ID addresses the row. The board keys, routes and opens by it rather than by the
+	// posting's slug, which an application whose posting was pruned does not have.
+	ID string `json:"id"`
+	// Company and RoleTitle ride on every row, read from the application record, so a
+	// card renders whether or not a posting is still there.
+	Company   string `json:"company_slug"`
+	RoleTitle string `json:"role_title"`
+	// Job is null once the catalogue has removed the posting. The application is a fact
+	// about the candidate's life and outlives our inventory of it.
+	Job            *jobview.Job `json:"job"`
+	ViewedAt       *time.Time   `json:"viewed_at"`
+	SavedAt        *time.Time   `json:"saved_at"`
+	AppliedAt      *time.Time   `json:"applied_at"`
+	Stage          *string      `json:"stage"`
+	Notes          *string      `json:"notes"`
+	EmailCount     int          `json:"email_count"`
+	ReminderFireAt *time.Time   `json:"reminder_fire_at"`
 	// The silence fields are null together on any row that is not an application
 	// awaiting a reply — a job merely viewed or saved, or one in a settled stage.
 	// Null means "nothing is owed here", which the board must be able to tell
@@ -63,6 +72,9 @@ func (h *trackingHandlers) ListTrackedJobs(c *fiber.Ctx) error {
 	items := make([]myJobResponse, 0, len(listing.Items))
 	for _, it := range listing.Items {
 		item := myJobResponse{
+			ID:             it.ID,
+			Company:        it.CompanySlug,
+			RoleTitle:      it.RoleTitle,
 			Job:            it.Job,
 			ViewedAt:       it.ViewedAt,
 			SavedAt:        it.SavedAt,

--- a/internal/handler/me_tracking_integration_test.go
+++ b/internal/handler/me_tracking_integration_test.go
@@ -270,3 +270,79 @@ func TestListMyJobsBoardFilter(t *testing.T) {
 		t.Errorf("meta.counts.board = %d, want 3", body.Meta.Counts.Board)
 	}
 }
+
+// The point of the whole change, asserted where the candidate actually meets it:
+// cmd/prune removes the posting, and the application is still on their board.
+func TestTrackedBoardKeepsAnApplicationWhosePostingWasPruned(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('pruned-board@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	var jobID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, company_slug, public_slug)
+		 VALUES ('test', 'doomed', 'http://example.test', 'Go Dev', 'acme', 'job-doomed')
+		 RETURNING id`).Scan(&jobID); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	if _, err := queries.MarkJobApplied(ctx, db.MarkJobAppliedParams{
+		UserID: userID, JobID: jobID, EventSource: "user",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM jobs WHERE id = $1`, jobID); err != nil {
+		t.Fatalf("prune the posting: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(userID, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &trackingHandlers{tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries, pool))}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/tracking", auth.RequireAuth(iss, testVersions), h.ListTrackedJobs)
+
+	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/tracking?filter=board", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("board = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Data []struct {
+			ID        string          `json:"id"`
+			Company   string          `json:"company_slug"`
+			RoleTitle string          `json:"role_title"`
+			Job       json.RawMessage `json:"job"`
+			Stage     *string         `json:"stage"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 1 {
+		t.Fatalf("board returned %d rows, want 1 — the application must not vanish with its posting", len(body.Data))
+	}
+	row := body.Data[0]
+	if string(row.Job) != "null" {
+		t.Errorf("job = %s, want null once the posting is pruned", row.Job)
+	}
+	if row.ID == "" {
+		t.Error("the row carries no id, so the interface cannot open or route to it")
+	}
+	if row.Company != "acme" || row.RoleTitle != "Go Dev" {
+		t.Errorf("employer/role = %q/%q, want acme/Go Dev, read from the application itself", row.Company, row.RoleTitle)
+	}
+	if row.Stage == nil || *row.Stage != "applied" {
+		t.Errorf("stage = %v, want applied — the candidate's own record survives", row.Stage)
+	}
+}

--- a/internal/handler/me_tracking_silence_test.go
+++ b/internal/handler/me_tracking_silence_test.go
@@ -73,7 +73,7 @@ func listSilence(t *testing.T, items []jobtracking.TrackedJob) []trackingRow {
 
 func row(stage string, appliedAgo, activityAgo time.Duration, pending bool) jobtracking.TrackedJob {
 	j := jobtracking.TrackedJob{
-		Job:                  jobview.Job{PublicSlug: "a-job"},
+		Job:                  &jobview.Job{PublicSlug: "a-job"},
 		HasPendingSuggestion: pending,
 	}
 	if appliedAgo > 0 {

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -87,7 +87,16 @@ func (c Counts) Total(f Filter) int64 {
 // interaction marks. The job carries identity via its slug; the embedded
 // Interaction's JobID is the internal id, never serialized.
 type TrackedJob struct {
-	Job jobview.Job
+	// ID addresses the row. The board has always been a list of applications and only
+	// borrowed the posting's slug because one was always at hand; an application whose
+	// posting was pruned has none to borrow, so the row carries its own.
+	ID string
+	// CompanySlug and RoleTitle come from the application record and are present on
+	// every row, so a card can be rendered without reaching into Job.
+	CompanySlug string
+	RoleTitle   string
+	// Job is absent when the catalogue no longer holds the posting.
+	Job *jobview.Job
 	Interaction
 	// EmailCount is the caller's live inbox messages linked to this job — the
 	// board's per-card ✉ badge. 0 for users without a connected mailbox.

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -3,6 +3,7 @@ package jobtracking
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -205,7 +206,10 @@ func (r *QueriesRepository) ListInteractions(
 			return nil, err
 		}
 		items = append(items, TrackedJob{
-			Job: view,
+			ID:          view.PublicSlug,
+			CompanySlug: row.Job.CompanySlug,
+			RoleTitle:   row.Job.Title,
+			Job:         &view,
 			Interaction: Interaction{
 				JobID:     row.Job.ID,
 				ViewedAt:  pgconv.TimePtr(row.ViewedAt),
@@ -221,6 +225,34 @@ func (r *QueriesRepository) ListInteractions(
 			FollowedUpAt:         pgconv.TimePtr(row.FollowedUpAt),
 			CVOpenedAt:           pgconv.TimePtr(row.CvOpenedAt),
 		})
+	}
+
+	// Applications the catalogue no longer holds a posting for. They cannot come from
+	// the query above — it is driven by user_jobs rows, which cmd/prune cascades away —
+	// so they are read separately and merged here. Only the board and applied views owe
+	// them: a pruned application was never a view or a bookmark.
+	if filter == FilterBoard || filter == FilterApplied || filter == FilterAll {
+		orphans, err := r.q.ListOrphanedApplications(ctx, db.ListOrphanedApplicationsParams{
+			UserID: userID, Limit: limit,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, o := range orphans {
+			items = append(items, TrackedJob{
+				ID:          "a" + strconv.FormatInt(o.ID, 10),
+				CompanySlug: o.CompanySlug,
+				RoleTitle:   o.RoleTitle,
+				Interaction: Interaction{
+					AppliedAt: pgconv.TimePtr(o.AppliedAt),
+					Stage:     textPtr(o.Stage),
+					Notes:     textPtr(o.Notes),
+				},
+				EmailCount:     int(o.EmailCount),
+				LastActivityAt: pgconv.TimePtr(o.LastActivityAt),
+				FollowedUpAt:   pgconv.TimePtr(o.FollowedUpAt),
+			})
+		}
 	}
 	return items, nil
 }

--- a/openspec/changes/applications-outlive-jobs/proposal.md
+++ b/openspec/changes/applications-outlive-jobs/proposal.md
@@ -51,6 +51,14 @@ row the catalogue deletes on a schedule.
 - No user-visible behaviour changes, with one exception that is a bug fix: a company whose
   postings were pruned stops being reported as more silent than it was.
 
+**Correction, made after reading `ListUserJobs`:** the sentence above holds for the storage
+cutover and NOT for the goal. The board is driven by `user_jobs` rows and embeds a posting in
+every card, and `cmd/prune` cascades that row away — so an application whose posting was removed
+survives in the database and in every aggregate while staying invisible to its owner. Delivering
+the stated goal therefore requires a wire-shape change, and this proposal's promise not to make
+one was written before that was known. The change is scoped and specified rather than made
+quietly: see the posting-less card requirement in `application-record`.
+
 Out of scope, each its own change: reconstructing application history from a mailbox backfill,
 the retrospective surface, and the import channel.
 

--- a/openspec/changes/applications-outlive-jobs/specs/application-record/spec.md
+++ b/openspec/changes/applications-outlive-jobs/specs/application-record/spec.md
@@ -151,3 +151,31 @@ created for them, so no fact recorded before this change loses the application i
 
 - **WHEN** the carry-over runs a second time
 - **THEN** no duplicate applications are created
+
+### Requirement: The board shows an application whose posting is gone
+
+The tracking board SHALL list an application after the catalogue has removed the posting it was
+made against. The posting's fields MAY be absent from the row; the employer and the role title
+MUST be present regardless, read from the application itself.
+
+Each row SHALL carry an identifier of its own, independent of any posting. The board has always
+been a list of applications and only borrowed the posting's slug because one was always at hand;
+an application with no posting has no slug to borrow, and a card the interface cannot address is
+a card it cannot open, route to, or key a list by.
+
+#### Scenario: A pruned posting leaves the card standing
+
+- **WHEN** the catalogue removes a posting a user applied to
+- **AND** that user loads their tracking board
+- **THEN** the application is listed, showing the employer and role title it carries
+- **AND** the row reports no posting
+
+#### Scenario: The row is addressable without a posting
+
+- **WHEN** a row carries no posting
+- **THEN** it still carries an identifier the interface can open and route to
+
+#### Scenario: A row with a posting is unchanged
+
+- **WHEN** a row's posting is still in the catalogue
+- **THEN** the posting's fields are present exactly as before

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -53,19 +53,19 @@
 > own `company_slug` and `role_title`.
 
 - [x] 5b.1 Decide and record the wire shape. **Decided:** `job` becomes optional on a board row; `company_slug` and `role_title` ride at the top level, read from the application; and the row gains **an identifier of its own**. The last part is the finding — `JobBoard.svelte:54` keys every card, route and panel on `row.job.public_slug`, which a posting-less application does not have. Recorded as a requirement in `application-record`, and the proposal's "no wire-shape change" promise is corrected in place rather than quietly broken
-- [ ] 5b.2 Drive the board read from applications, left-joining the posting instead of requiring it.
+- [x] 5b.2 Drive the board read from applications. **Solved without touching `ListUserJobs`:** the orphans come from their own query (`ListOrphanedApplications`) that joins nothing, so the `sqlc.embed` constraint below never applies and the posting-backed path is untouched. Merged in the repository.
   **Hard constraint, measured with a throwaway probe:** `sqlc.embed(jobs)` over a LEFT JOIN generates a
   non-pointer `Job` field, and scanning a row whose posting is absent fails at runtime —
   `can't scan into dest[0] (col: id): cannot scan NULL into *int64`. So the board query cannot keep
   `sqlc.embed`; it must select explicit nullable posting columns, and `jobview.FromRow` needs a variant
   that builds from them. That is the bulk of this task, and it was not visible from the query text
-- [ ] 5b.2a Source the rows from a FULL OUTER JOIN of `user_jobs` and `applications`: the board must
+- [x] 5b.2a ~~FULL OUTER JOIN~~ — unnecessary once the orphans are a separate read. Source the rows from a FULL OUTER JOIN of `user_jobs` and `applications`: the board must
   still list a saved-but-never-applied job (only `user_jobs` has it) and an application whose posting
   is gone (only `applications` has it)
-- [ ] 5b.2b Emit one opaque row `id` the interface can key on — the posting's slug when there is one,
+- [x] 5b.2b Emit one opaque row `id` the interface can key on — the posting's slug when there is one,
   otherwise derived from the application. Fits the house style already set by the opaque-id swap
-- [ ] 5b.3 SPA renders the fallback card and keys it on the row's own id, not on `job.public_slug`; `freehire-cli` and `freehire-mcp` tolerate the absent job
-- [ ] 5b.4 Integration test: an application whose posting was pruned still appears on its owner's board
+- [x] 5b.3 SPA renders the fallback card and keys it on the row's own id, not on `job.public_slug`; `freehire-cli` and `freehire-mcp` tolerate the absent job
+- [x] 5b.4 Integration test: an application whose posting was pruned still appears on its owner's board
 
 ## 6. Cut over the mail path
 

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -53,7 +53,17 @@
 > own `company_slug` and `role_title`.
 
 - [x] 5b.1 Decide and record the wire shape. **Decided:** `job` becomes optional on a board row; `company_slug` and `role_title` ride at the top level, read from the application; and the row gains **an identifier of its own**. The last part is the finding — `JobBoard.svelte:54` keys every card, route and panel on `row.job.public_slug`, which a posting-less application does not have. Recorded as a requirement in `application-record`, and the proposal's "no wire-shape change" promise is corrected in place rather than quietly broken
-- [ ] 5b.2 Drive the board read from applications, left-joining the posting instead of requiring it
+- [ ] 5b.2 Drive the board read from applications, left-joining the posting instead of requiring it.
+  **Hard constraint, measured with a throwaway probe:** `sqlc.embed(jobs)` over a LEFT JOIN generates a
+  non-pointer `Job` field, and scanning a row whose posting is absent fails at runtime —
+  `can't scan into dest[0] (col: id): cannot scan NULL into *int64`. So the board query cannot keep
+  `sqlc.embed`; it must select explicit nullable posting columns, and `jobview.FromRow` needs a variant
+  that builds from them. That is the bulk of this task, and it was not visible from the query text
+- [ ] 5b.2a Source the rows from a FULL OUTER JOIN of `user_jobs` and `applications`: the board must
+  still list a saved-but-never-applied job (only `user_jobs` has it) and an application whose posting
+  is gone (only `applications` has it)
+- [ ] 5b.2b Emit one opaque row `id` the interface can key on — the posting's slug when there is one,
+  otherwise derived from the application. Fits the house style already set by the opaque-id swap
 - [ ] 5b.3 SPA renders the fallback card and keys it on the row's own id, not on `job.public_slug`; `freehire-cli` and `freehire-mcp` tolerate the absent job
 - [ ] 5b.4 Integration test: an application whose posting was pruned still appears on its owner's board
 

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -52,9 +52,9 @@
 > not quietly broken: the job fields become optional and a card falls back to the application's
 > own `company_slug` and `role_title`.
 
-- [ ] 5b.1 Decide and record the wire shape for a posting-less card in `jobview`
+- [x] 5b.1 Decide and record the wire shape. **Decided:** `job` becomes optional on a board row; `company_slug` and `role_title` ride at the top level, read from the application; and the row gains **an identifier of its own**. The last part is the finding — `JobBoard.svelte:54` keys every card, route and panel on `row.job.public_slug`, which a posting-less application does not have. Recorded as a requirement in `application-record`, and the proposal's "no wire-shape change" promise is corrected in place rather than quietly broken
 - [ ] 5b.2 Drive the board read from applications, left-joining the posting instead of requiring it
-- [ ] 5b.3 SPA renders the fallback card; `freehire-cli` and `freehire-mcp` tolerate the absent job
+- [ ] 5b.3 SPA renders the fallback card and keys it on the row's own id, not on `job.public_slug`; `freehire-cli` and `freehire-mcp` tolerate the absent job
 - [ ] 5b.4 Integration test: an application whose posting was pruned still appears on its owner's board
 
 ## 6. Cut over the mail path

--- a/web/src/lib/components/BoardCard.svelte
+++ b/web/src/lib/components/BoardCard.svelte
@@ -31,6 +31,11 @@
   // A further reading, and like the chase it sits beside the silence badge rather than instead
   // of it: they read the CV and still have not answered.
   const cvOpened = $derived(cvOpenedLabel(item));
+
+  // The posting is gone once cmd/prune removes it, and the card still has to render.
+  // The employer and role are carried by the application itself for exactly this.
+  const company = $derived(item.job?.company || item.company_slug);
+  const title = $derived(item.job?.title || item.role_title);
 </script>
 
 <!-- The card is a div, not a button: the follow-up action is a second control, and a
@@ -42,14 +47,14 @@
   <button
     type="button"
     onclick={() => onopen(item)}
-    aria-label="Open {item.job.title} at {item.job.company || 'unknown company'}"
+    aria-label="Open {title} at {company || 'unknown company'}"
     class="flex flex-col gap-1.5 text-left after:absolute after:inset-0 after:content-['']"
   >
     <span class="flex items-center gap-1.5 text-sm font-semibold">
-      <CompanyLogo name={item.job.company} />
-      <span class="min-w-0 truncate">{item.job.company || 'Unknown company'}</span>
+      <CompanyLogo name={company} />
+      <span class="min-w-0 truncate">{company || 'Unknown company'}</span>
     </span>
-    <span class="line-clamp-2 text-sm">{item.job.title}</span>
+    <span class="line-clamp-2 text-sm">{title}</span>
   </button>
   <!-- The badge row rides above the open action's overlay so its title tooltips still
        answer a hover. The cost is that this strip no longer opens the drawer; a lost

--- a/web/src/lib/components/Hidden.svelte
+++ b/web/src/lib/components/Hidden.svelte
@@ -29,7 +29,7 @@
     try {
       await api.undismissJob(slug);
       markUndismissed(slug);
-      page.items = page.items.filter((it) => it.job.public_slug !== slug);
+      page.items = page.items.filter((it) => it.job?.public_slug !== slug);
     } finally {
       unhiding = '';
     }
@@ -44,18 +44,19 @@
   <States state="empty" message="Nothing hidden. Jobs you hide from the feed show up here." />
 {:else}
   <ul class="flex flex-col gap-3">
-    {#each page.items as item (item.job.public_slug)}
+    <!-- Hidden jobs are always posting-backed: hiding is a mark on a posting. -->
+    {#each page.items.filter((i) => i.job) as item (item.id)}
       <li>
         <!-- Un-hide lives in the card's footer row (a divided sibling of the link),
              not an overlay, so it never sits on top of the title or blurb on a narrow
              screen. Mirrors the saved list's reminder chip. -->
-        <JobRow job={item.job} dimViewed={false}>
+        <JobRow job={item.job!} dimViewed={false}>
           {#snippet footer()}
             <div class="flex justify-end">
               <button
                 type="button"
-                onclick={() => unhide(item.job.public_slug)}
-                disabled={unhiding === item.job.public_slug}
+                onclick={() => unhide(item.job!.public_slug)}
+                disabled={unhiding === item.job!.public_slug}
                 title="Un-hide — show this job in the feed again"
                 class="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium text-muted-foreground transition hover:text-brand disabled:pointer-events-none disabled:opacity-50"
               >

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -310,11 +310,15 @@
     trackedLoading = true;
     try {
       const res = await api.listMyJobs('applied', 100, 0);
-      trackedApps = res.items.map((m) => ({
-        slug: m.job.public_slug,
-        company: m.job.company,
-        title: m.job.title,
-      }));
+      // Only postings-backed applications can be offered as a link target: linking
+      // mail names a job slug, and an application whose posting was pruned has none.
+      trackedApps = res.items
+        .filter((m) => m.job)
+        .map((m) => ({
+          slug: m.job!.public_slug,
+          company: m.job!.company,
+          title: m.job!.title,
+        }));
       trackedLoaded = true;
     } catch {
       // Leave the list empty; the picker shows its empty state.

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -51,7 +51,7 @@
     const next = emptyColumns();
     const cols: Record<string, BoardColumnId> = {};
     for (const row of rows) {
-      const item: BoardItem = { ...row, id: row.job.public_slug };
+      const item: BoardItem = { ...row, id: row.id };
       const col = columnOf(item);
       if (!col) continue; // saved-only rows live in Activity → Saved, not the board
       next[col].push(item);
@@ -231,6 +231,7 @@
     if (rehearsing) return;
     rehearsing = true;
     try {
+      if (!item.job) return;
       const session = await createRehearsal(item.job.public_slug);
       await goto(resolve('/my/assistant/[[id]]', { id: session.id }));
     } catch {
@@ -251,7 +252,8 @@
     openItem = item as BoardItem;
     pendingOutcome = false;
     // Give the open application its own shareable URL without a full navigation.
-    pushState(resolve('/my/tracking/[slug]', { slug: item.job.public_slug }), {});
+    // A card with no posting has no public URL to push; it opens in place.
+    if (item.job) pushState(resolve('/my/tracking/[slug]', { slug: item.job.public_slug }), {});
   }
 </script>
 
@@ -281,7 +283,7 @@
 {/if}
 
 {#if openItem}
-  {#key openItem.job.public_slug}
+  {#key openItem.id}
     <JobDrawer
       item={openItem}
       {pendingOutcome}
@@ -295,10 +297,10 @@
 {/if}
 
 {#if followUpItem}
-  {#key followUpItem.job.public_slug}
+  {#key followUpItem.id}
     <FollowUpDialog
-      slug={followUpItem.job.public_slug}
-      company={followUpItem.job.company}
+      slug={followUpItem.job?.public_slug ?? ''}
+      company={followUpItem.job?.company ?? followUpItem.company_slug}
       onclose={() => (followUpItem = null)}
       onrecorded={markChased}
     />

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -67,6 +67,7 @@
     emailsLoading = true;
     emailsError = null;
     try {
+      if (!item.job) return;
       const app = await api.getTrackedApplication(item.job.public_slug);
       emails = app.emails;
     } catch (e) {
@@ -102,7 +103,12 @@
 
   // Meta pills (work arrangement, region, employment type, seniority) — only the
   // stated ones, reusing the list-card logic.
-  let tags = $derived(cardTags(item.job));
+  // The posting is gone once cmd/prune removes it. The employer and role are on the
+  // application itself; everything else the drawer shows came from the posting and is
+  // simply absent — the honest rendering, since we no longer have it to show.
+  const company = $derived(item.job?.company || item.company_slug);
+  const title = $derived(item.job?.title || item.role_title);
+  let tags = $derived(item.job ? cardTags(item.job) : []);
   let stageLabel = $derived(item.stage ? humanizeStage(item.stage) : null);
 
   // Interaction timeline shown as a wizard-style stepper up top, in engagement-funnel
@@ -160,13 +166,14 @@
     <div class="mx-auto flex w-full max-w-2xl flex-col gap-4 px-5 pb-3 pt-5 sm:px-6">
       <div class="flex items-start gap-4">
         <div class="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl">
-          <CompanyLogo name={item.job.company} size="size-9" />
+          <CompanyLogo name={company} size="size-9" />
         </div>
         <div class="min-w-0 flex-1">
-          <h2 class="text-xl font-bold leading-tight tracking-tight">{item.job.title}</h2>
-          <p class="text-sm text-muted-foreground">{item.job.company || 'Unknown company'}</p>
+          <h2 class="text-xl font-bold leading-tight tracking-tight">{title}</h2>
+          <p class="text-sm text-muted-foreground">{company || 'Unknown company'}</p>
         </div>
         <div class="flex shrink-0 items-center gap-2">
+          {#if item.job}
           <Button
             variant="outline"
             size="sm"
@@ -178,6 +185,7 @@
             View job
             <ExternalLink class="size-3.5" />
           </Button>
+          {/if}
           <button
             type="button"
             onclick={close}
@@ -285,8 +293,10 @@
         </div>
       {:else if tab === 'fit'}
         <div class="flex flex-col gap-6">
-          <JobMatch job={item.job} />
-          <MatchAnalysisFull job={item.job} />
+          {#if item.job}
+            <JobMatch job={item.job} />
+            <MatchAnalysisFull job={item.job} />
+          {/if}
         </div>
       {:else if tab === 'emails'}
         <div class="flex flex-col gap-2">
@@ -349,7 +359,13 @@
         </div>
       {:else}
         <div class="flex flex-col gap-5">
-          {#if item.job.description}
+          {#if !item.job}
+            <!-- The posting was removed from the catalogue. What it said is genuinely
+                 gone; saying so is better than an empty tab that reads as a bug. -->
+            <p class="text-sm text-muted-foreground">
+              This posting is no longer listed. Your application, its stage and your notes are kept.
+            </p>
+          {:else if item.job.description}
             <!-- Description is server-sanitized HTML (see internal/sources), safe to render. -->
             <!-- eslint-disable-next-line svelte/no-at-html-tags -- server-sanitized; the rule flags every {@html} regardless -->
             <div class="job-description text-sm leading-relaxed">{@html item.job.description}</div>
@@ -357,7 +373,7 @@
             <p class="text-sm text-muted-foreground">No description available.</p>
           {/if}
 
-          {#if item.job.skills?.length}
+          {#if item.job?.skills?.length}
             <div class="flex flex-col gap-2 border-t border-border pt-5">
               <p class={sectionLabel}>Skills</p>
               <div class="flex flex-wrap gap-1.5">

--- a/web/src/lib/components/JobHistory.svelte
+++ b/web/src/lib/components/JobHistory.svelte
@@ -24,8 +24,11 @@
   <States state="empty" message="Nothing viewed yet. Jobs you open will show up here." />
 {:else}
   <ul class="flex flex-col gap-3">
-    {#each page.items as item (item.job.public_slug)}
-      <li><JobRow job={item.job} dimViewed={false} /></li>
+    <!-- Viewed history is always posting-backed: a row with no posting is an
+         application, and an application was never a view. The guard is the type's,
+         not a real case. -->
+    {#each page.items.filter((i) => i.job) as item (item.id)}
+      <li><JobRow job={item.job!} dimViewed={false} /></li>
     {/each}
   </ul>
   {#if page.hasMore}

--- a/web/src/lib/components/SavedJobs.svelte
+++ b/web/src/lib/components/SavedJobs.svelte
@@ -25,11 +25,13 @@
   <States state="empty" message="Nothing saved yet. Jobs you save will show up here." />
 {:else}
   <ul class="flex flex-col gap-3">
-    {#each page.items as item (item.job.public_slug)}
+    <!-- Saved jobs are always posting-backed: the bookmark lives on the posting and
+         goes with it. The guard satisfies the type rather than a real case. -->
+    {#each page.items.filter((i) => i.job) as item (item.id)}
       <li>
-        <JobRow job={item.job} dimViewed={false}>
+        <JobRow job={item.job!} dimViewed={false}>
           {#snippet footer()}
-            <ReminderChip slug={item.job.public_slug} fireAt={item.reminder_fire_at} />
+            <ReminderChip slug={item.job!.public_slug} fireAt={item.reminder_fire_at} />
           {/snippet}
         </JobRow>
       </li>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -401,7 +401,14 @@ export interface UserJob {
 /** One item of the my-jobs listing: the job in the shared wire shape with the
  *  caller's interaction timestamps riding alongside. */
 export interface MyJob {
-  job: Job;
+  /** Addresses the row. The board keys, routes and opens by this rather than by the
+   *  posting's slug: an application whose posting was pruned has no slug to borrow. */
+  id: string;
+  /** Read from the application record, so a card renders whether or not `job` is there. */
+  company_slug: string;
+  role_title: string;
+  /** Null once the catalogue has removed the posting. The application outlives it. */
+  job: Job | null;
   viewed_at: string;
   saved_at: string | null;
   applied_at: string | null;


### PR DESCRIPTION
## What and why

The half of the goal the storage cutover (#1356) could not deliver. `cmd/prune` cascades the `user_jobs` row away, and the board is driven by those rows and embeds a posting in every card — so an application whose posting was removed survived **in the database and in every aggregate** while staying invisible to the person who made it.

`pruned_jobs` already holds 1,609,678 rows, so this is the visible half of a live problem.

## `ListUserJobs` is untouched, deliberately

A throwaway probe (`14d5691d`) established that `sqlc.embed(jobs)` over a `LEFT JOIN` generates a **non-pointer** `Job` and fails at scan time:

```
can't scan into dest[0] (col: id): cannot scan NULL into *int64
```

Rewriting that query would have meant hand-rolling every posting column and a second `jobview` constructor. Instead the orphans come from **their own query that joins nothing** — the employer and role title are on the application, which is why they were copied there — and the repository merges the two lists. Only the `board`, `applied` and `all` filters ask for them: a pruned application was never a view or a bookmark.

## The wire shape changes, as specified rather than quietly

| field | |
|---|---|
| `job` | now `null` once the catalogue has removed the posting |
| `id` | **new** — addresses the row |
| `company_slug` | **new** — from the application |
| `role_title` | **new** — from the application |

`id` is the load-bearing part. The board keyed every card, route and drawer on `row.job.public_slug`, which an orphan does not have. The board has always been a list of applications and only borrowed the posting's slug because one was always at hand.

The proposal's "no wire-shape change" promise was corrected in place (`e95a71d0`) with the reason, and the requirement is specified in `application-record`.

## The interface degrades to what is actually known

- The card renders from the application; the drawer says the posting is no longer listed and keeps the stage and notes.
- Actions that need a posting — **View job**, interview rehearsal, fit analysis, the shareable URL, offering it as a mail link target — are **absent rather than broken**.
- Lists that are marks on a posting (viewed, saved, hidden) filter orphans out: hiding or bookmarking an application was never a thing that could happen.

Making `job` nullable in `types.ts` turned `pnpm check` into the exact list of consumers — including `Hidden.svelte` and `InboxView.svelte`, which I would not have thought to look at.

## Test plan

- [x] `go test ./...` — no failures
- [x] `go test -tags=integration ./...` — every package green
- [x] `TestTrackedBoardKeepsAnApplicationWhosePostingWasPruned` — applies, prunes the posting, asserts the row survives with `job: null`, an `id`, its employer, role and stage
- [x] `go build`, `go vet`, `gofmt` clean
- [x] `pnpm check` — no errors from this change (two pre-existing baseline errors remain in `ProfileForm`/`SubmitView`)
- [ ] **Not visually verified.** The fallback card and the drawer's "no longer listed" state have not been rendered in a browser; worth a look before merge.
