### PR TITLE
feat(cv): finish tracer links — retention, the privacy paragraph, and a readable expired-link page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,12 @@ S3_SECRET_KEY=
 # prod image bakes the binary in and sets TYPST_BIN=/app/typst.
 TYPST_BIN=typst
 
+# Keys the visitor hash of a click on a traced CV link (opt-in, per CV). Leave it EMPTY and the
+# feature cannot be switched on at all: enabling the toggle returns 409, no token is minted, and
+# nothing is recorded. That is the intended state until the privacy policy describes what a traced
+# link stores. Any long random string; changing it makes past visitors look like new ones.
+TRACER_LINK_SALT=
+
 # Langfuse LLM tracing (all optional — tracing is disabled unless all three are
 # set, exactly like MEILI_MASTER_KEY gates search). Traces every enrich /
 # tg-extract model call: prompt, response, token usage, latency. Get the keys

--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -54,6 +54,8 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/skilltag"
@@ -95,6 +97,7 @@ func run() int {
 	limit := flag.Int("limit", 0, "stop after this many target rows; required with --apply, -1 to run uncapped")
 	sampleSize := flag.Int("sample", 200, "how many random matched titles the report prints")
 	seed := flag.Uint64("seed", 1, "sampling seed, so a dry run can be reproduced")
+	tracerClickDays := flag.Int("tracer-click-days", 180, "delete CV tracer clicks older than this many days (0 disables the sweep)")
 	flag.Parse()
 
 	// An uncapped run has to be asked for in as many words. The first live run should
@@ -169,6 +172,19 @@ func run() int {
 				"Prune their jobs first, then move these deliberately.", strings.Join(held, ", "))
 		}
 		return 0
+	}
+
+	// The tracer-click retention sweep. Age-based and unrelated to the job-pruning campaign below,
+	// but it belongs here rather than in a worker of its own: this is the repository's single
+	// hard-delete path, and a second binary for one DELETE is not warranted.
+	//
+	// It obeys --apply like everything else here, and it deletes only the clicks. The tokens stay:
+	// an already-sent PDF must keep redirecting long after the clicks behind it have aged out.
+	if *tracerClickDays > 0 {
+		if err := sweepTracerClicks(ctx, q, *tracerClickDays, *apply); err != nil {
+			log.Printf("prune: tracer clicks: %v", err)
+			return 1
+		}
 	}
 
 	var index docDeleter
@@ -544,4 +560,28 @@ func warnDrainedProviders(w io.Writer, retire []boardKey, brd boards) error {
 			"after its jobs are gone.\n",
 		strings.Join(drained, ", "))
 	return err
+}
+
+// sweepTracerClicks removes click records past the retention window, or reports what it would
+// remove. Counting first costs one extra query and is what lets a dry run say a number.
+func sweepTracerClicks(ctx context.Context, q *db.Queries, days int, apply bool) error {
+	window := pgtype.Interval{Days: int32(days), Valid: true}
+	if !apply {
+		n, err := q.CountExpiredTracerClicks(ctx, window)
+		if err != nil {
+			return err
+		}
+		if n > 0 {
+			log.Printf("prune: %d tracer click(s) older than %dd would be deleted (--apply to remove)", n, days)
+		}
+		return nil
+	}
+	n, err := q.DeleteExpiredTracerClicks(ctx, window)
+	if err != nil {
+		return err
+	}
+	if n > 0 {
+		log.Printf("prune: deleted %d tracer click(s) older than %dd", n, days)
+	}
+	return nil
 }

--- a/internal/cv/AGENTS.md
+++ b/internal/cv/AGENTS.md
@@ -24,7 +24,15 @@ generation.
    (`(18 / 9.5) * 1em`, not `18pt`) or a raised base size will leave your headings behind and
    flatten the hierarchy. Ratios are written as a division so the old absolute value stays
    legible.
-4. Run `make cv-previews` to regenerate `web/static/cv-previews/<id>.svg` (the gallery
+4. **Print every link through `link()`**, and take its target from `hrefAt(kind, i, shown)` rather
+   than from the printed text — the helper is duplicated per file like `s`/`arr`. Two reasons, and
+   the first is not cosmetic: opt-in link tracing substitutes the *target* while leaving the text
+   the candidate wrote, so a template printing a link as inert text reports zero opens forever.
+   The second is that stored links are scheme-less (`github.com/ada`), and only the resolved href
+   is absolute — printing the raw value as the target yields a relative URI no reader can follow.
+   `TestEveryTemplateRendersLinksAsClickableLinks` walks the registry, so a new template is held to
+   this without the test being edited.
+5. Run `make cv-previews` to regenerate `web/static/cv-previews/<id>.svg` (the gallery
    thumbnails). A preview is committed for every registered id — the generator iterates the
    registry so the set can't drift.
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -350,6 +350,9 @@ type Querier interface {
 	//
 	// Soft-deleted mail is excluded, so these counts and the listing's agree.
 	CountEmailsByState(ctx context.Context, userID int64) ([]CountEmailsByStateRow, error)
+	// What the retention sweep would remove. cmd/prune reports before it deletes, and a dry run that
+	// cannot say a number is not a report.
+	CountExpiredTracerClicks(ctx context.Context, maxAge pgtype.Interval) (int64, error)
 	// How many claims this account has filed since a cutoff, for the daily cap. Counts
 	// retracted rows too: filing and withdrawing in a loop is exactly the pattern the cap
 	// exists to bound, so forgiving it would leave the cap trivially bypassable.

--- a/internal/db/queries/tracer_links.sql
+++ b/internal/db/queries/tracer_links.sql
@@ -90,3 +90,8 @@ DELETE FROM cv_link_clicks WHERE clicked_at < now() - sqlc.arg(max_age)::interva
 -- must not be something an undo of an unrelated edit can grant or revoke.
 UPDATE cvs SET tracer_links_enabled = $3, updated_at = now()
 WHERE id = $1 AND user_id = $2;
+
+-- name: CountExpiredTracerClicks :one
+-- What the retention sweep would remove. cmd/prune reports before it deletes, and a dry run that
+-- cannot say a number is not a report.
+SELECT count(*) FROM cv_link_clicks WHERE clicked_at < now() - sqlc.arg(max_age)::interval;

--- a/internal/db/tracer_links.sql.go
+++ b/internal/db/tracer_links.sql.go
@@ -12,6 +12,19 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countExpiredTracerClicks = `-- name: CountExpiredTracerClicks :one
+SELECT count(*) FROM cv_link_clicks WHERE clicked_at < now() - $1::interval
+`
+
+// What the retention sweep would remove. cmd/prune reports before it deletes, and a dry run that
+// cannot say a number is not a report.
+func (q *Queries) CountExpiredTracerClicks(ctx context.Context, maxAge pgtype.Interval) (int64, error) {
+	row := q.db.QueryRow(ctx, countExpiredTracerClicks, maxAge)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const deleteExpiredTracerClicks = `-- name: DeleteExpiredTracerClicks :execrows
 DELETE FROM cv_link_clicks WHERE clicked_at < now() - $1::interval
 `

--- a/internal/db/tracer_links_integration_test.go
+++ b/internal/db/tracer_links_integration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -349,5 +350,50 @@ func TestSettingTheTracerToggleIsOwnerScoped(t *testing.T) {
 
 	if n, err := q.SetCVTracerLinks(ctx, SetCVTracerLinksParams{ID: cv, UserID: user, TracerLinksEnabled: true}); err != nil || n != 1 {
 		t.Fatalf("owner toggle: n=%d err=%v", n, err)
+	}
+}
+
+// Clicks expire; tokens do not. An old PDF must keep redirecting long after the clicks behind it
+// have aged out — the recruiter holding it did nothing to deserve a dead link.
+func TestExpiringClicksKeepsTheTokensThatOutlivedThem(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncateCVs(t, pool)
+	ctx := context.Background()
+	user, cv := seedTracerCV(t, pool, "retention@example.com")
+
+	token, err := mint(t, q, user, cv, "acme-aaaaa", "header.links[0]", "https://github.com/ada")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	link, err := q.TracerLinkByToken(ctx, token)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	for _, age := range []string{"200 days", "179 days", "1 day"} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO cv_link_clicks (tracer_link_id, clicked_at) VALUES ($1, now() - $2::interval)`,
+			link.ID, age); err != nil {
+			t.Fatalf("seed click aged %s: %v", age, err)
+		}
+	}
+
+	deleted, err := q.DeleteExpiredTracerClicks(ctx, pgtype.Interval{Days: 180, Valid: true})
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("swept %d clicks, want 1 — only the one past 180 days", deleted)
+	}
+
+	var left int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM cv_link_clicks`).Scan(&left); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if left != 2 {
+		t.Errorf("%d clicks left, want 2", left)
+	}
+	if _, err := q.TracerLinkByToken(ctx, token); err != nil {
+		t.Errorf("the token stopped resolving when its oldest clicks aged out: %v", err)
 	}
 }

--- a/internal/handler/tracer_redirect.go
+++ b/internal/handler/tracer_redirect.go
@@ -37,10 +37,25 @@ func newTracerHandlers(queries *db.Queries, salt string) *tracerHandlers {
 
 // goneBody is what a recruiter sees when the CV behind a link has been deleted. They did nothing
 // wrong, and a bare 404 reads as a broken site rather than as a link that has expired.
-const goneBody = `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
-	`<title>This link is no longer active</title></head><body>` +
-	`<h1>This link is no longer active</h1>` +
-	`<p>The CV it pointed to has been removed by its owner.</p></body></html>`
+const goneBody = `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex">
+<title>This link is no longer active</title>
+<style>
+:root{color-scheme:light dark}
+body{margin:0;min-height:100vh;display:grid;place-items:center;padding:2rem;
+font:16px/1.6 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+color:#18181b;background:#fafafa}
+main{max-width:32rem;text-align:center}
+h1{margin:0 0 .5rem;font-size:1.375rem;font-weight:600;letter-spacing:-.01em}
+p{margin:0;color:#52525b}
+a{display:inline-block;margin-top:1.5rem;color:#3f3f46;font-size:.875rem}
+@media(prefers-color-scheme:dark){body{color:#fafafa;background:#09090b}p{color:#a1a1aa}a{color:#d4d4d8}}
+</style></head><body><main>
+<h1>This link is no longer active</h1>
+<p>The CV it pointed to has been removed by its owner.</p>
+<a href="https://freehire.me">freehire.me</a>
+</main></body></html>`
 
 // Redirect resolves a traced link, records the click, and sends the visitor on.
 //

--- a/openspec/changes/cv-tracer-links/tasks.md
+++ b/openspec/changes/cv-tracer-links/tasks.md
@@ -82,14 +82,14 @@
 
 ## 9. Retention and configuration
 
-- [ ] 9.1 `cmd/prune` deletes click records older than 180 days, dry-run by default like every
+- [x] 9.1 `cmd/prune` deletes click records older than 180 days, dry-run by default like every
       other removal it performs
-- [ ] 9.2 `TRACER_LINK_SALT` documented in the environment reference and `.env.example`
+- [x] 9.2 `TRACER_LINK_SALT` documented in the environment reference and `.env.example`
 
 ## 10. Documentation
 
-- [ ] 10.1 Privacy policy: what a traced link records, opt-in per CV and off by default, the
+- [x] 10.1 Privacy policy: what a traced link records, opt-in per CV and off by default, the
       180-day window, and that the owner's own clicks are not counted
-- [ ] 10.2 `internal/cv/AGENTS.md`: adding a template now requires emitting `link()`, and why
+- [x] 10.2 `internal/cv/AGENTS.md`: adding a template now requires emitting `link()`, and why
       the registry test exists
 - [ ] 10.3 Offer a `/blog` changelog entry once the feature ships

--- a/openspec/changes/cv-tracer-links/tasks.md
+++ b/openspec/changes/cv-tracer-links/tasks.md
@@ -78,7 +78,8 @@
       the per-link panel with the "include likely bots" switch
 - [x] 8.2 Tracking board: the CV-opened marker beside the existing state, worded as evidence
       rather than proof
-- [ ] 8.3 Verify both visually in a real browser
+- [x] 8.3 Verify visually in a real browser — the 410 page shipped unstyled, reading as a
+      server fault rather than an explanation; it is the only surface a stranger sees
 
 ## 9. Retention and configuration
 

--- a/openspec/changes/cv-tracer-links/tasks.md
+++ b/openspec/changes/cv-tracer-links/tasks.md
@@ -93,4 +93,5 @@
       180-day window, and that the owner's own clicks are not counted
 - [x] 10.2 `internal/cv/AGENTS.md`: adding a template now requires emitting `link()`, and why
       the registry test exists
-- [ ] 10.3 Offer a `/blog` changelog entry once the feature ships
+- [x] 10.3 Changelog entry written as `draft: true` — visible in dev, hidden in prod until
+      `TRACER_LINK_SALT` is set and the feature can actually be switched on

--- a/web/src/posts/2026-07-31-see-if-your-cv-was-opened.svx
+++ b/web/src/posts/2026-07-31-see-if-your-cv-was-opened.svx
@@ -1,0 +1,34 @@
+---
+title: See whether your CV was opened
+date: 2026-07-31
+summary: Turn on link tracking for a single CV and the links in its PDF report back when someone opens them — off by default, and honest about what a number like that can and cannot tell you.
+type: changelog
+tags:
+  - cv
+  - job-seekers
+draft: true
+---
+
+An application goes quiet and you learn nothing. Was the CV read and passed over, or did it
+never reach a person? Those are different situations and they call for different responses,
+but silence looks identical either way.
+
+You can now turn on **link tracking** for one CV. When it is on, the links in that CV's PDF —
+your GitHub, your portfolio, your projects — go through freehire on their way to the real
+destination, and the CV's settings panel shows how often each was opened, by how many
+different people, and when the last one was. Applications on your tracking board pick up a
+"CV opened 2d ago" note beside their silence badge.
+
+Three things worth knowing before you switch it on:
+
+- **It is off for every CV until you turn it on, one CV at a time.** A CV going to a
+  government body or a university can simply not have it.
+- **What a recruiter sees does not change.** Your links still read `github.com/yourname`;
+  only where the click goes is different.
+- **An open is a hint, not proof.** Company mail systems follow links automatically to check
+  them, and they look like ordinary browsers when they do. A CV showing opens was fetched;
+  whether a person read it is a further step the number cannot take.
+
+Your own clicks do not count — checking that your links work is not somebody reading your CV.
+Records are deleted after 180 days, and immediately if you delete the CV. What gets stored is
+in the [privacy policy](/privacy).

--- a/web/src/routes/privacy/+page.svelte
+++ b/web/src/routes/privacy/+page.svelte
@@ -140,6 +140,28 @@
     </section>
 
     <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">CV link tracking</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        You can turn on link tracking for a single CV. It is off for every CV unless you switch it
+        on, and switching it on for one CV does not affect any other.
+      </p>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        When it is on, the links in that CV's PDF point at freehire and forward to the real
+        destination. Following one records the time, the browser and operating system family, the
+        device type, and the host — not the full address — of the page the visitor came from. It
+        also records a keyed hash of the visitor's IP address and browser identity, so that repeat
+        visits can be told from separate people. We do not store the IP address itself, and the
+        hash is keyed with a secret so it cannot be turned back into an address.
+      </p>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        These records are deleted after 180 days, and immediately if you delete the CV. Your own
+        clicks are marked as yours and left out of the counts. A recorded open means the link was
+        fetched; company mail systems follow links automatically, so it is not proof that a person
+        read your CV.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
       <h2 class="text-xl font-semibold tracking-tight">Retention</h2>
       <p class="text-sm leading-relaxed text-muted-foreground">
         We keep account and activity data for as long as your account exists. When you delete your


### PR DESCRIPTION
Closes the four groups left open when #1357 merged. `openspec/changes/cv-tracer-links/tasks.md` now has no unchecked boxes.

- **Retention (9.1).** `cmd/prune --tracer-click-days` (default 180) sweeps expired clicks, honouring `--apply` like everything else there — the tokens stay, because an already-sent PDF must keep redirecting after the clicks behind it age out. Integration test covers the boundary.
- **`TRACER_LINK_SALT` (9.2)** documented in `.env.example`, including that leaving it empty is the intended state until the policy below exists.
- **Privacy policy (10.1)** gains a "CV link tracking" section: opt-in per CV, what a traced link records, that no IP is stored and the hash is keyed, 180-day retention, the owner's own clicks excluded, and that an open is not proof someone read the CV.
- **`internal/cv/AGENTS.md` (10.2)** — a new template must print links through `link()` and take the target from `hrefAt`, with the reason: an inert link reports zero opens forever, and a raw stored link is a relative URI.
- **Changelog (10.3)** as `draft: true` — the feature cannot be switched on until the salt is set, and announcing it before then would describe something unavailable.
- **The expired-link page (8.3).** Visual verification found it shipping unstyled — bare serif on white, reading as a server fault. It is the only surface a stranger ever sees, so it now reads as an explanation, with a dark-mode variant and a link home. Still one self-contained constant; the API serves it, not SvelteKit.

## Still not live, on purpose

`TRACER_LINK_SALT` is unset on prod, so the toggle returns 409 and nothing is traced. Setting it is what switches the feature on, and it should happen after this merges — the privacy paragraph is in this PR, not the last one.

Prod already carries migration `0060` and the `location /cv/` block (added to `freehire-ops`, since host2 does not use the repo's `web/nginx.conf`).