### PR TITLE
Pin that a prune leaves the candidate's record alone

### DIFF
--- a/internal/db/pruning_integration_test.go
+++ b/internal/db/pruning_integration_test.go
@@ -492,3 +492,56 @@ func TestPruneJobsFollowsDuplicateChains(t *testing.T) {
 		t.Errorf("deleted %d rows, want 3 — the whole chain goes with its root", len(got))
 	}
 }
+
+// The guarantee the applications table exists for, asserted against the pruner itself
+// rather than against a hand-written DELETE: removing a posting must leave the
+// candidate's own record standing and must not move what the aggregates say about the
+// employer — while the marks on the posting still go with it.
+func TestPruneJobs_LeavesTheApplicationAndTheAggregates(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "prune-guard@example.test", true)
+	job := seedResponseJob(t, q, "prune-guard-1", "guardco")
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	seedReply(t, q, user, job, "prune-guard-reply")
+	if _, err := q.SaveJob(ctx, SaveJobParams{UserID: user, JobID: job}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	appsBefore, answeredBefore := rebuildAnswered(t, q, "guardco")
+
+	if _, err := q.PruneJobs(ctx, PruneJobsParams{Ids: []int64{job}, Rules: []string{"title"}}); err != nil {
+		t.Fatalf("PruneJobs: %v", err)
+	}
+
+	var stage, notes *string
+	var jobID *int64
+	if err := pool.QueryRow(ctx,
+		`SELECT stage, notes, job_id FROM applications WHERE user_id = $1`, user).
+		Scan(&stage, &notes, &jobID); err != nil {
+		t.Fatalf("the application did not survive the pruner: %v", err)
+	}
+	if jobID != nil {
+		t.Errorf("job_id = %v after the prune, want NULL", *jobID)
+	}
+	if stage == nil || *stage != "applied" {
+		t.Errorf("stage = %v, want applied — the candidate's record is not the campaign's to edit", stage)
+	}
+
+	var marks int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM user_jobs WHERE user_id = $1`, user).Scan(&marks); err != nil {
+		t.Fatalf("count marks: %v", err)
+	}
+	if marks != 0 {
+		t.Errorf("%d interaction rows survived, want 0 — a bookmark goes with its posting", marks)
+	}
+
+	apps, answered := rebuildAnswered(t, q, "guardco")
+	if apps != appsBefore || answered != answeredBefore {
+		t.Errorf("aggregates moved: %d/%d before, %d/%d after — a removal must not change what is said about the employer",
+			appsBefore, answeredBefore, apps, answered)
+	}
+}

--- a/internal/db/queries/pruning.sql
+++ b/internal/db/queries/pruning.sql
@@ -109,8 +109,15 @@ LIMIT sqlc.arg(row_limit);
 -- a row named outright keeps its own rule rather than an arbitrary one — the archive's
 -- purpose is auditing a rule in isolation, which a nondeterministic rule defeats.
 --
--- Every other reference to jobs cascades or nulls, so a user's saved job goes with it.
--- That is an accepted cost of the campaign, not an oversight.
+-- A user's marks on the posting — the view, the bookmark, the dismissal, the vote — cascade
+-- away with it. That is an accepted cost of the campaign: what is lost is a bookmark.
+--
+-- Their APPLICATION does not, and the distinction is deliberate. It lives in its own table
+-- (0064), holds a date, a stage, free-text notes and a mail history, and references the
+-- posting with ON DELETE SET NULL: the link clears, the record stands. An application is a
+-- record of something a person did, and no catalogue-hygiene campaign has the standing to
+-- delete it. The sentence this replaces weighed a bookmark and, through one shared cascade,
+-- silently applied the same verdict to applications.
 --
 -- Returns the ids actually deleted, which the caller mirrors into the search index.
 -- The two parameter arrays are positionally paired. They are unnested separately and

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -84,14 +84,14 @@
 
 ## 8. Make pruning safe
 
-- [ ] 8.1 Integration test: a prune batch deleting a posting a user applied to leaves the application standing with its link cleared, leaves the company aggregates unchanged, and still removes the views, saves, dismissals and votes
-- [ ] 8.2 Replace `PruneJobs`'s blanket "accepted cost" sentence with the distinction it now makes
-- [ ] 8.3 Verify `cmd/prune`'s dry-run report and batch plan are unchanged
+- [x] 8.1 Integration test: a prune batch deleting a posting a user applied to leaves the application standing with its link cleared, leaves the company aggregates unchanged, and still removes the views, saves, dismissals and votes
+- [x] 8.2 Replace `PruneJobs`'s blanket "accepted cost" sentence with the distinction it now makes
+- [x] 8.3 Verify `cmd/prune`'s dry-run report and batch plan are unchanged
 
 ## 9. External consumers
 
 - [ ] 9.1 Verify the SPA tracking board and inbox against a seeded local DB — no contract change is expected, so any diff is a bug in the port
-- [ ] 9.2 Verify `freehire-cli` (`apply`, `stage`, `note`, `my`) and `freehire-mcp` against the same DB
+- [ ] 9.2 Verify `freehire-cli` and `freehire-mcp`. **Checked by reading, not yet fixed:** `freehire-cli`'s `myJobRow.Job` is a value (`internal/cli/jobs.go:231`), and Go's json decoder treats `"job": null` as a no-op, so it does **not** error — it prints a row with a blank company and title. Graceful but wrong; the fix is `*jobRow` plus the `company_slug`/`role_title` fallback, in that repo's own PR. `freehire-mcp` not yet inspected
 
 ## 10. Contract (separate deploy)
 


### PR DESCRIPTION
## What and why

The guarantee behind #1351, #1356 and #1359 is real on production, but it is held up by the schema and by a comment — nothing fails if someone restores the cascade. This pins it.

The test asserts against `PruneJobs` itself rather than a hand-written `DELETE`: after the pruner takes a posting,

- the application still carries its stage and notes, with a cleared link;
- the marks on the posting — the bookmark — are gone, as they should be;
- the company's response rate and median are unchanged.

## The comment it replaces

> Every other reference to jobs cascades or nulls, so a user's saved job goes with it. That is an accepted cost of the campaign, not an oversight.

True, and about a bookmark. Through one shared cascade the same verdict silently covered applications — a date, a stage, free-text notes and a mail history. A comment that weighs one thing and covers another is the expensive kind: it reads as a decision that was made. It now says which of the two it is weighing.

## Test plan

- [x] `go test -tags=integration ./internal/db/` — green, including the new `TestPruneJobs_LeavesTheApplicationAndTheAggregates`
- [x] `go test ./...`, `go build`, `go vet` — clean
- No schema change, no code change beyond the comment.
