### PR TITLE
docs(blog): publish the CV link tracking changelog

### DIFF
--- a/web/src/posts/2026-07-31-see-if-your-cv-was-opened.svx
+++ b/web/src/posts/2026-07-31-see-if-your-cv-was-opened.svx
@@ -6,7 +6,6 @@ type: changelog
 tags:
   - cv
   - job-seekers
-draft: true
 ---
 
 An application goes quiet and you learn nothing. Was the CV read and passed over, or did it


### PR DESCRIPTION
The salt is set on prod, so the toggle can actually be switched on. Drops `draft: true` from the entry written alongside the feature.