### PR TITLE
feat(tailor): open the workspace at a layout that needs no dragging

### DIFF
--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, tick, untrack } from 'svelte';
-  import { AlertTriangle, PanelLeft, Plus, Trash2 } from '@lucide/svelte';
+  import { AlertTriangle, MessagesSquare, PanelLeft, Plus, Trash2, WandSparkles } from '@lucide/svelte';
   import { resolve } from '$app/paths';
   import {
     createSession,
@@ -664,13 +664,19 @@
           {:else if chat.messages.length === 0 && openingActions?.length}
             <div class="rounded-xl border border-border bg-muted/30 p-4">
               <div class="flex flex-wrap gap-2">
+                <!-- The icon comes from the action's kind, not from the action itself: the
+                     surfaces that offer these are plain modules, and a Svelte component cannot
+                     travel through one. The two kinds are the two rhythms — the unattended run
+                     and the conversation — so the mapping is complete by construction. -->
                 {#each openingActions as action (action.label)}
+                  {@const Icon = action.kind === 'autopilot' ? WandSparkles : MessagesSquare}
                   <button
                     type="button"
-                    class="rounded-lg bg-brand px-3 py-2 text-sm font-medium text-brand-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+                    class="inline-flex items-center gap-1.5 rounded-lg bg-brand px-3 py-2 text-sm font-medium text-brand-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
                     disabled={turnActive || switching}
                     onclick={() => runOpening(action)}
                   >
+                    <Icon class="size-4" />
                     {action.label}
                   </button>
                 {/each}

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -82,7 +82,9 @@
     ['jd', 'Job'],
     ['templates', 'Templates'],
   ];
-  let width = $state(340);
+  // 400 rather than the 340 floor: at the floor the tab strip wraps "Job Match" onto two lines
+  // and the vacancy title truncates after a couple of words, so the panel opened looking cramped.
+  let width = $state(400);
   let resizing = false;
   // Collapsed to a rail so the centre CV preview can take the width. Desktop-only: below lg
   // the columns already show one at a time, and collapsing there would hide a view with no

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -88,7 +88,7 @@
   // Left panel: which tab is shown, and its resizable width. The chat stays mounted across tab
   // switches (hidden, not unmounted) so its live session is never dropped.
   let leftTab = $state<'chat' | 'editor' | 'settings'>('chat');
-  let leftWidth = $state(380);
+  let leftWidth = $state(350);
   // Folded to a rail so the centre CV preview can take the width. Desktop-only: below lg the
   // columns already show one at a time, and collapsing there would hide a view with no way back.
   let leftCollapsed = $state(false);
@@ -127,9 +127,9 @@
     else if (v !== 'preview') artifactTab = v;
   }
 
-  // Centre preview zoom, clamped to 50–150% in 10% steps. Starts at 90% so the full A4 page
-  // fits the centre column on load.
-  let zoom = $state(0.9);
+  // Centre preview zoom, clamped to 50–150% in 10% steps. Starts at 80%: the A4 page then fits
+  // the centre column with both side panels open, so nothing has to be dragged before reading.
+  let zoom = $state(0.8);
   const zoomPct = $derived(Math.round(zoom * 100));
   const clampZoom = (z: number) => Math.min(1.5, Math.max(0.5, Math.round(z * 10) / 10));
   const zoomOut = () => (zoom = clampZoom(zoom - 0.1));


### PR DESCRIPTION
The three-column CV workspace opened at 90% zoom with a 340px artifact panel, and the two did not fit together: the A4 sheet overflowed the centre column, while the panel wrapped "Job Match" onto two lines and truncated the vacancy title after a couple of words. Both were a splitter drag away from readable.

**Defaults now:** 80% zoom, 400px artifact panel, 350px editor panel. All inside the existing `clampWidth(…, 340, 720)` / 50–150% clamps, so resizing behaves exactly as before — only the layout you land on changes.

**Opening actions get an icon**, picked from the action's `kind`: a wand for the unattended run ("Tailor it for me"), a conversation for the walkthrough. The mapping lives in the chat rather than in the action data — `OpeningAction` is minted by plain `.ts` modules, and `web/vitest.config.ts` runs those in bare Node with no Svelte plugin, so a component cannot travel through one.

## Verification

- `pnpm exec svelte-check --threshold error` — 0 errors (run against this branch's tree)
- `pnpm exec vitest run src/lib/tailor` — 63 passed
- Not screenshotted in a live workspace (needs a signed-in CV bound to a vacancy); the changes are three numeric defaults and one icon slot.