### PR TITLE
Keep the application link in step with the posting link

### DIFF
--- a/internal/db/applications_integration_test.go
+++ b/internal/db/applications_integration_test.go
@@ -234,3 +234,51 @@ func TestTrackJob_StageEventNamesTheApplication(t *testing.T) {
 		t.Errorf("stage_set event names application %v, want %v", eventApp, appID)
 	}
 }
+
+// Every path that links mail to a posting must keep application_id in step, or the
+// column quietly goes stale on each new link and the carry-over would have to be run
+// again to repair it.
+func TestLinkingMailKeepsTheApplicationInStep(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "link-step@example.test", true)
+	job := seedResponseJob(t, q, "link-step-1", "linkco")
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	var appID int64
+	if err := pool.QueryRow(ctx, `SELECT id FROM applications WHERE user_id = $1`, user).Scan(&appID); err != nil {
+		t.Fatalf("read application: %v", err)
+	}
+	var mailID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO emails (user_id, external_id, source, received_at)
+		 VALUES ($1, 'link-step-mail', 'gmail', now()) RETURNING id`, user).Scan(&mailID); err != nil {
+		t.Fatalf("seed mail: %v", err)
+	}
+
+	appOf := func() *int64 {
+		t.Helper()
+		var got *int64
+		if err := pool.QueryRow(ctx, `SELECT application_id FROM emails WHERE id = $1`, mailID).Scan(&got); err != nil {
+			t.Fatalf("read link: %v", err)
+		}
+		return got
+	}
+
+	if _, err := q.LinkEmailToJob(ctx, LinkEmailToJobParams{ID: mailID, UserID: user, JobID: pgtype.Int8{Int64: job, Valid: true}}); err != nil {
+		t.Fatalf("LinkEmailToJob: %v", err)
+	}
+	if got := appOf(); got == nil || *got != appID {
+		t.Errorf("after a manual link, application_id = %v, want %d", got, appID)
+	}
+
+	if _, err := q.UnlinkEmail(ctx, UnlinkEmailParams{ID: mailID, UserID: user}); err != nil {
+		t.Fatalf("UnlinkEmail: %v", err)
+	}
+	if got := appOf(); got != nil {
+		t.Errorf("after unlinking, application_id = %v, want NULL — the link cleared on both columns", *got)
+	}
+}

--- a/internal/db/mail_classification.sql.go
+++ b/internal/db/mail_classification.sql.go
@@ -309,13 +309,19 @@ func (q *Queries) ListUserEmailThreadLinks(ctx context.Context, userID int64) ([
 const setEmailClassification = `-- name: SetEmailClassification :exec
 UPDATE emails
 SET job_id               = $1,
+    -- Kept in step with job_id, and derived rather than passed: the caller names a
+    -- posting, and the application is what the ledger and the aggregates pair on. Left
+    -- NULL when the user has no application for that posting — an unlinked fact is
+    -- useful, a wrongly attached one is not.
+    application_id       = (SELECT a.id FROM applications a
+                             WHERE a.user_id = emails.user_id AND a.job_id = $1),
     suggested_job_id     = $2,
     link_source          = $3,
     match_confidence     = $4,
     status_signal        = $5,
     classification_model = $6,
     classified_at        = now()
-WHERE id = $7 AND user_id = $8
+WHERE emails.id = $7 AND emails.user_id = $8
 `
 
 type SetEmailClassificationParams struct {

--- a/internal/db/mail_linking.sql.go
+++ b/internal/db/mail_linking.sql.go
@@ -14,9 +14,11 @@ import (
 const confirmEmailLink = `-- name: ConfirmEmailLink :execrows
 UPDATE emails
 SET job_id           = suggested_job_id,
+    application_id   = (SELECT a.id FROM applications a
+                         WHERE a.user_id = emails.user_id AND a.job_id = emails.suggested_job_id),
     link_source      = 'manual',
     suggested_job_id = NULL
-WHERE id = $1 AND user_id = $2 AND suggested_job_id IS NOT NULL
+WHERE emails.id = $1 AND emails.user_id = $2 AND emails.suggested_job_id IS NOT NULL
 `
 
 type ConfirmEmailLinkParams struct {
@@ -95,9 +97,11 @@ func (q *Queries) GetUserApplication(ctx context.Context, arg GetUserApplication
 const linkEmailToJob = `-- name: LinkEmailToJob :execrows
 UPDATE emails
 SET job_id           = $3,
+    application_id   = (SELECT a.id FROM applications a
+                         WHERE a.user_id = emails.user_id AND a.job_id = $3),
     link_source      = 'manual',
     suggested_job_id = NULL
-WHERE id = $1 AND user_id = $2
+WHERE emails.id = $1 AND emails.user_id = $2
 `
 
 type LinkEmailToJobParams struct {
@@ -195,7 +199,8 @@ func (q *Queries) RejectEmailLink(ctx context.Context, arg RejectEmailLinkParams
 
 const unlinkEmail = `-- name: UnlinkEmail :execrows
 UPDATE emails
-SET job_id      = NULL,
+SET job_id         = NULL,
+    application_id = NULL,
     link_source = NULL
 WHERE id = $1 AND user_id = $2
 `

--- a/internal/db/pruning.sql.go
+++ b/internal/db/pruning.sql.go
@@ -197,8 +197,15 @@ type PruneJobsParams struct {
 // a row named outright keeps its own rule rather than an arbitrary one — the archive's
 // purpose is auditing a rule in isolation, which a nondeterministic rule defeats.
 //
-// Every other reference to jobs cascades or nulls, so a user's saved job goes with it.
-// That is an accepted cost of the campaign, not an oversight.
+// A user's marks on the posting — the view, the bookmark, the dismissal, the vote — cascade
+// away with it. That is an accepted cost of the campaign: what is lost is a bookmark.
+//
+// Their APPLICATION does not, and the distinction is deliberate. It lives in its own table
+// (0064), holds a date, a stage, free-text notes and a mail history, and references the
+// posting with ON DELETE SET NULL: the link clears, the record stands. An application is a
+// record of something a person did, and no catalogue-hygiene campaign has the standing to
+// delete it. The sentence this replaces weighed a bookmark and, through one shared cascade,
+// silently applied the same verdict to applications.
 //
 // Returns the ids actually deleted, which the caller mirrors into the search index.
 // The two parameter arrays are positionally paired. They are unnested separately and

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1642,8 +1642,15 @@ type Querier interface {
 	// a row named outright keeps its own rule rather than an arbitrary one — the archive's
 	// purpose is auditing a rule in isolation, which a nondeterministic rule defeats.
 	//
-	// Every other reference to jobs cascades or nulls, so a user's saved job goes with it.
-	// That is an accepted cost of the campaign, not an oversight.
+	// A user's marks on the posting — the view, the bookmark, the dismissal, the vote — cascade
+	// away with it. That is an accepted cost of the campaign: what is lost is a bookmark.
+	//
+	// Their APPLICATION does not, and the distinction is deliberate. It lives in its own table
+	// (0064), holds a date, a stage, free-text notes and a mail history, and references the
+	// posting with ON DELETE SET NULL: the link clears, the record stands. An application is a
+	// record of something a person did, and no catalogue-hygiene campaign has the standing to
+	// delete it. The sentence this replaces weighed a bookmark and, through one shared cascade,
+	// silently applied the same verdict to applications.
 	//
 	// Returns the ids actually deleted, which the caller mirrors into the search index.
 	// The two parameter arrays are positionally paired. They are unnested separately and

--- a/internal/db/queries/mail_classification.sql
+++ b/internal/db/queries/mail_classification.sql
@@ -41,13 +41,19 @@ RETURNING o.id, o.email_id, e.user_id, e.source, e.thread_id, e.from_addr, e.fro
 -- unlinked or suggestion-only email leaves job_id NULL.
 UPDATE emails
 SET job_id               = sqlc.narg(job_id),
+    -- Kept in step with job_id, and derived rather than passed: the caller names a
+    -- posting, and the application is what the ledger and the aggregates pair on. Left
+    -- NULL when the user has no application for that posting — an unlinked fact is
+    -- useful, a wrongly attached one is not.
+    application_id       = (SELECT a.id FROM applications a
+                             WHERE a.user_id = emails.user_id AND a.job_id = sqlc.narg(job_id)),
     suggested_job_id     = sqlc.narg(suggested_job_id),
     link_source          = sqlc.narg(link_source),
     match_confidence     = sqlc.narg(match_confidence),
     status_signal        = sqlc.narg(status_signal),
     classification_model = sqlc.arg(model),
     classified_at        = now()
-WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
+WHERE emails.id = sqlc.arg(id) AND emails.user_id = sqlc.arg(user_id);
 
 -- name: AgentTriageEmail :execrows
 -- Persist an agent-produced verdict for one message, scoped to the caller (0 rows

--- a/internal/db/queries/mail_linking.sql
+++ b/internal/db/queries/mail_linking.sql
@@ -37,9 +37,11 @@ ORDER BY received_at DESC, id DESC;
 -- link_source 'manual'. No-op (0 rows) when there is no pending suggestion.
 UPDATE emails
 SET job_id           = suggested_job_id,
+    application_id   = (SELECT a.id FROM applications a
+                         WHERE a.user_id = emails.user_id AND a.job_id = emails.suggested_job_id),
     link_source      = 'manual',
     suggested_job_id = NULL
-WHERE id = $1 AND user_id = $2 AND suggested_job_id IS NOT NULL;
+WHERE emails.id = $1 AND emails.user_id = $2 AND emails.suggested_job_id IS NOT NULL;
 
 -- name: RejectEmailLink :execrows
 -- Dismiss a suggestion without linking.
@@ -52,13 +54,16 @@ WHERE id = $1 AND user_id = $2 AND suggested_job_id IS NOT NULL;
 -- auto-link or suggestion.
 UPDATE emails
 SET job_id           = $3,
+    application_id   = (SELECT a.id FROM applications a
+                         WHERE a.user_id = emails.user_id AND a.job_id = $3),
     link_source      = 'manual',
     suggested_job_id = NULL
-WHERE id = $1 AND user_id = $2;
+WHERE emails.id = $1 AND emails.user_id = $2;
 
 -- name: UnlinkEmail :execrows
 -- Clear an email's application link (leaves the classified status intact).
 UPDATE emails
-SET job_id      = NULL,
+SET job_id         = NULL,
+    application_id = NULL,
     link_source = NULL
 WHERE id = $1 AND user_id = $2;

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -69,7 +69,8 @@
 
 ## 6. Cut over the mail path
 
-- [ ] 6.1 Port `mail_linking.sql` and `mail_classification.sql` to `emails.application_id`; run `make sqlc`. **Partly done in 5a:** their reads of `stage`/`applied_at` had to move with the rest of the cutover; the `emails.job_id` → `application_id` half is still open
+- [x] 6.0 Keep `emails.application_id` in step on every link path — `SetEmailClassification`, `ConfirmEmailLink`, `LinkEmailToJob`, `UnlinkEmail`. Purely additive: no reader changes, so nothing can break, and the column stops going stale on each new link (it did, and only the carry-over could repair it). Derived from the posting inside the statement rather than passed in, so a caller cannot pass a mismatched pair
+- [ ] 6.1 Port `mail_linking.sql` and `mail_classification.sql` to READ `emails.application_id`. **Sized:** `gmail.sql` alone joins `jobs` twice to render the inbox's linked/suggested labels, so this carries a wire-shape consequence of its own — an inbox row whose linked application has no posting, the same problem 5b solved for the board; run `make sqlc`. **Partly done in 5a:** their reads of `stage`/`applied_at` had to move with the rest of the cutover; the `emails.job_id` → `application_id` half is still open
 - [ ] 6.2 Port `internal/inbox` (`RecordApplication`, the `?link=suggested|unlinked` filters) and `internal/maillink` so auto-link, suggestion and monotonic stage advance behave identically
 - [ ] 6.3 Port `internal/handler/inbox_linking.go` and `followup.go`
 - [ ] 6.4 Port `cmd/classify-mail/store.go`


### PR DESCRIPTION
## What and why

`emails.application_id` was written by the carry-over (#1351) and by nothing since. Every link made afterwards — the classifier's auto-link, a confirmed suggestion, a manual link — set `job_id` and left `application_id` NULL.

Nothing reads it yet, so nothing was visibly wrong. It was quietly drifting out of date, and only re-running `cmd/backfill-applications` would have repaired it.

Four paths now keep it in step: `SetEmailClassification`, `ConfirmEmailLink`, `LinkEmailToJob`, `UnlinkEmail`.

## Additive on purpose

No reader changes here, so no behaviour can move — and the column is correct for whenever the readers do move. That is the opposite of the dual-writing the design rejected: `job_id` stays the single source of truth until the cutover, and `application_id` is kept true alongside it rather than competing with it.

## The application is derived, not passed

A caller that supplied both the posting and the application could supply a mismatched pair, and there is no reason to let it: the posting is what the caller names, the application is a fact about the user that follows from it. It stays NULL when the user has no application for that posting — an unlinked fact is useful, a wrongly attached one is not.

## Sizing the rest of group 6, while I was in there

`gmail.sql` joins `jobs` twice to render the inbox's linked/suggested labels, so moving the *readers* carries a wire-shape consequence of its own: an inbox row whose linked application has no posting — the same problem #1359 solved for the board. Recorded in `tasks.md`.

## Test plan

- [x] `TestLinkingMailKeepsTheApplicationInStep` — manual link sets it, unlink clears it
- [x] `go test ./...` and `go test -tags=integration ./...` — every package green
- [x] `go build`, `go vet` clean
