### PR TITLE
A message is linked to an application, not to a posting

### DIFF
--- a/internal/db/application_events_integration_test.go
+++ b/internal/db/application_events_integration_test.go
@@ -265,7 +265,10 @@ func TestSyncEmailApplicationEvent_DeletionKeepsTheFactRelinkMovesIt(t *testing.
 	}
 
 	// Re-linking to the right employer must move it.
-	if _, err := q.db.Exec(ctx, `UPDATE emails SET job_id = $2 WHERE id = $1`, emailID, jobB); err != nil {
+	if _, err := q.db.Exec(ctx, `UPDATE emails SET job_id = $2,
+		    application_id = (SELECT a.id FROM applications a
+		                       WHERE a.user_id = emails.user_id AND a.job_id = $2)
+		 WHERE emails.id = $1`, emailID, jobB); err != nil {
 		t.Fatalf("relink: %v", err)
 	}
 	sync()

--- a/internal/db/company_response_integration_test.go
+++ b/internal/db/company_response_integration_test.go
@@ -307,7 +307,10 @@ func TestRebuildInsightsCompanyResponse_DeletionAndRelink(t *testing.T) {
 	}
 
 	// Correcting a mislink must move the credit, or the wrong company stays poisoned.
-	if _, err := pool.Exec(ctx, `UPDATE emails SET job_id = $2 WHERE id = $1`, reply, jobB); err != nil {
+	if _, err := pool.Exec(ctx, `UPDATE emails SET job_id = $2,
+		    application_id = (SELECT a.id FROM applications a
+		                       WHERE a.user_id = emails.user_id AND a.job_id = $2)
+		 WHERE emails.id = $1`, reply, jobB); err != nil {
 		t.Fatalf("relink: %v", err)
 	}
 	reconcile()

--- a/internal/db/gmail.sql.go
+++ b/internal/db/gmail.sql.go
@@ -22,9 +22,9 @@ WHERE user_id = $1
   AND ($5::bool = false OR classified_at IS NULL)
   AND (
     $6::text = ''
-    OR ($6 = 'linked'    AND job_id IS NOT NULL)
-    OR ($6 = 'suggested' AND job_id IS NULL AND suggested_job_id IS NOT NULL)
-    OR ($6 = 'unlinked'  AND job_id IS NULL AND suggested_job_id IS NULL)
+    OR ($6 = 'linked'    AND application_id IS NOT NULL)
+    OR ($6 = 'suggested' AND application_id IS NULL AND suggested_job_id IS NOT NULL)
+    OR ($6 = 'unlinked'  AND application_id IS NULL AND suggested_job_id IS NULL)
   )
   AND (
     $7::text = ''
@@ -67,8 +67,8 @@ SELECT coalesce(status_signal, '')::text AS label,
     count(*)::bigint AS n,
     count(*) FILTER (WHERE read_at IS NULL)::bigint AS unread,
     count(*) FILTER (WHERE classified_at IS NULL)::bigint AS unclassified,
-    count(*) FILTER (WHERE job_id IS NOT NULL)::bigint AS linked,
-    count(*) FILTER (WHERE job_id IS NULL AND suggested_job_id IS NOT NULL)::bigint AS suggested
+    count(*) FILTER (WHERE application_id IS NOT NULL)::bigint AS linked,
+    count(*) FILTER (WHERE application_id IS NULL AND suggested_job_id IS NOT NULL)::bigint AS suggested
 FROM emails
 WHERE user_id = $1 AND deleted_at IS NULL
 GROUP BY 1
@@ -147,10 +147,15 @@ const getEmail = `-- name: GetEmail :one
 SELECT emails.id, emails.source, emails.external_id, emails.s3_key, emails.from_addr, emails.from_name, emails.subject,
     emails.body_text, emails.body_html, emails.received_at, (emails.read_at IS NOT NULL)::boolean AS read,
     emails.job_id, emails.suggested_job_id, emails.status_signal, emails.link_source,
-    lj.public_slug AS linked_slug, lj.company AS linked_company,
+    -- The link is to the APPLICATION; the posting is how it is displayed while the
+    -- catalogue still holds one. cmd/prune clears la.job_id, so linked_slug goes NULL
+    -- while the row stays linked — the employer is on the application for exactly that.
+    lj.public_slug AS linked_slug,
+    COALESCE(lj.company, la.company_slug, '')::text AS linked_company,
     sj.public_slug AS suggested_slug, sj.company AS suggested_company
 FROM emails
-LEFT JOIN jobs lj ON lj.id = emails.job_id
+LEFT JOIN applications la ON la.id = emails.application_id
+LEFT JOIN jobs lj ON lj.id = la.job_id
 LEFT JOIN jobs sj ON sj.id = emails.suggested_job_id
 WHERE emails.id = $1 AND emails.user_id = $2 AND emails.deleted_at IS NULL
 `
@@ -177,7 +182,7 @@ type GetEmailRow struct {
 	StatusSignal     pgtype.Text        `json:"status_signal"`
 	LinkSource       pgtype.Text        `json:"link_source"`
 	LinkedSlug       pgtype.Text        `json:"linked_slug"`
-	LinkedCompany    pgtype.Text        `json:"linked_company"`
+	LinkedCompany    string             `json:"linked_company"`
 	SuggestedSlug    pgtype.Text        `json:"suggested_slug"`
 	SuggestedCompany pgtype.Text        `json:"suggested_company"`
 }
@@ -364,10 +369,15 @@ SELECT emails.id, emails.source, emails.external_id, emails.from_addr, emails.fr
     (CASE WHEN $2::bool THEN emails.body_html ELSE '' END)::text AS body_html,
     emails.received_at, (emails.read_at IS NOT NULL)::boolean AS read,
     emails.job_id, emails.suggested_job_id, emails.status_signal, emails.link_source,
-    lj.public_slug AS linked_slug, lj.company AS linked_company,
+    -- The link is to the APPLICATION; the posting is how it is displayed while the
+    -- catalogue still holds one. cmd/prune clears la.job_id, so linked_slug goes NULL
+    -- while the row stays linked — the employer is on the application for exactly that.
+    lj.public_slug AS linked_slug,
+    COALESCE(lj.company, la.company_slug, '')::text AS linked_company,
     sj.public_slug AS suggested_slug, sj.company AS suggested_company
 FROM emails
-LEFT JOIN jobs lj ON lj.id = emails.job_id
+LEFT JOIN applications la ON la.id = emails.application_id
+LEFT JOIN jobs lj ON lj.id = la.job_id
 LEFT JOIN jobs sj ON sj.id = emails.suggested_job_id
 WHERE emails.user_id = $1
   AND emails.deleted_at IS NULL
@@ -377,9 +387,9 @@ WHERE emails.user_id = $1
   AND ($6::bool = false OR emails.classified_at IS NULL)
   AND (
     $7::text = ''
-    OR ($7 = 'linked'    AND emails.job_id IS NOT NULL)
-    OR ($7 = 'suggested' AND emails.job_id IS NULL AND emails.suggested_job_id IS NOT NULL)
-    OR ($7 = 'unlinked'  AND emails.job_id IS NULL AND emails.suggested_job_id IS NULL)
+    OR ($7 = 'linked'    AND emails.application_id IS NOT NULL)
+    OR ($7 = 'suggested' AND emails.application_id IS NULL AND emails.suggested_job_id IS NOT NULL)
+    OR ($7 = 'unlinked'  AND emails.application_id IS NULL AND emails.suggested_job_id IS NULL)
   )
   AND (
     $8::text = ''
@@ -422,7 +432,7 @@ type ListEmailsRow struct {
 	StatusSignal     pgtype.Text        `json:"status_signal"`
 	LinkSource       pgtype.Text        `json:"link_source"`
 	LinkedSlug       pgtype.Text        `json:"linked_slug"`
-	LinkedCompany    pgtype.Text        `json:"linked_company"`
+	LinkedCompany    string             `json:"linked_company"`
 	SuggestedSlug    pgtype.Text        `json:"suggested_slug"`
 	SuggestedCompany pgtype.Text        `json:"suggested_company"`
 }
@@ -509,9 +519,9 @@ WHERE user_id = $1
   AND ($3::text = '' OR status_signal = $3)
   AND (
     $4::text = ''
-    OR ($4 = 'linked'    AND job_id IS NOT NULL)
-    OR ($4 = 'suggested' AND job_id IS NULL AND suggested_job_id IS NOT NULL)
-    OR ($4 = 'unlinked'  AND job_id IS NULL AND suggested_job_id IS NULL)
+    OR ($4 = 'linked'    AND application_id IS NOT NULL)
+    OR ($4 = 'suggested' AND application_id IS NULL AND suggested_job_id IS NOT NULL)
+    OR ($4 = 'unlinked'  AND application_id IS NULL AND suggested_job_id IS NULL)
   )
   AND (
     $5::text = ''

--- a/internal/db/mail_classification.sql.go
+++ b/internal/db/mail_classification.sql.go
@@ -33,6 +33,13 @@ const agentTriageEmail = `-- name: AgentTriageEmail :execrows
 UPDATE emails
 SET status_signal        = $1,
     job_id               = COALESCE($2, job_id),
+    -- Follows job_id, derived rather than passed, exactly as the other link paths do:
+    -- an untouched link keeps the application it already names.
+    application_id       = CASE WHEN $2 IS NOT NULL
+                                THEN (SELECT a.id FROM applications a
+                                       WHERE a.user_id = emails.user_id
+                                         AND a.job_id = $2)
+                                ELSE application_id END,
     link_source          = CASE WHEN $2 IS NOT NULL THEN 'agent' ELSE link_source END,
     -- The cast is load-bearing: this is the parameter's FIRST appearance, and it is
     -- inside an IS NOT NULL, which tells Postgres nothing about its type. Without
@@ -46,7 +53,7 @@ SET status_signal        = $1,
     suggested_job_id     = NULL,
     classification_model = 'agent',
     classified_at        = now()
-WHERE id = $4 AND user_id = $5
+WHERE emails.id = $4 AND emails.user_id = $5
 `
 
 type AgentTriageEmailParams struct {

--- a/internal/db/mail_external_integration_test.go
+++ b/internal/db/mail_external_integration_test.go
@@ -338,7 +338,10 @@ func TestAgentTriageWithoutJobKeepsTheLink(t *testing.T) {
 	job := insertJob(t, pool, "kept-role")
 	id, _ := pushExternal(t, q, user, "msg-4", "Update", "some news")
 	if _, err := pool.Exec(ctx,
-		`UPDATE emails SET job_id = $2, link_source = 'manual' WHERE id = $1`, id, job); err != nil {
+		`UPDATE emails SET job_id = $2, link_source = 'manual',
+		    application_id = (SELECT a.id FROM applications a
+		                       WHERE a.user_id = emails.user_id AND a.job_id = $2)
+		 WHERE emails.id = $1`, id, job); err != nil {
 		t.Fatalf("seed link: %v", err)
 	}
 

--- a/internal/db/queries/gmail.sql
+++ b/internal/db/queries/gmail.sql
@@ -102,10 +102,15 @@ SELECT emails.id, emails.source, emails.external_id, emails.from_addr, emails.fr
     (CASE WHEN sqlc.arg(with_body)::bool THEN emails.body_html ELSE '' END)::text AS body_html,
     emails.received_at, (emails.read_at IS NOT NULL)::boolean AS read,
     emails.job_id, emails.suggested_job_id, emails.status_signal, emails.link_source,
-    lj.public_slug AS linked_slug, lj.company AS linked_company,
+    -- The link is to the APPLICATION; the posting is how it is displayed while the
+    -- catalogue still holds one. cmd/prune clears la.job_id, so linked_slug goes NULL
+    -- while the row stays linked — the employer is on the application for exactly that.
+    lj.public_slug AS linked_slug,
+    COALESCE(lj.company, la.company_slug, '')::text AS linked_company,
     sj.public_slug AS suggested_slug, sj.company AS suggested_company
 FROM emails
-LEFT JOIN jobs lj ON lj.id = emails.job_id
+LEFT JOIN applications la ON la.id = emails.application_id
+LEFT JOIN jobs lj ON lj.id = la.job_id
 LEFT JOIN jobs sj ON sj.id = emails.suggested_job_id
 WHERE emails.user_id = $1
   AND emails.deleted_at IS NULL
@@ -115,9 +120,9 @@ WHERE emails.user_id = $1
   AND (sqlc.arg(unclassified)::bool = false OR emails.classified_at IS NULL)
   AND (
     sqlc.arg(link)::text = ''
-    OR (sqlc.arg(link) = 'linked'    AND emails.job_id IS NOT NULL)
-    OR (sqlc.arg(link) = 'suggested' AND emails.job_id IS NULL AND emails.suggested_job_id IS NOT NULL)
-    OR (sqlc.arg(link) = 'unlinked'  AND emails.job_id IS NULL AND emails.suggested_job_id IS NULL)
+    OR (sqlc.arg(link) = 'linked'    AND emails.application_id IS NOT NULL)
+    OR (sqlc.arg(link) = 'suggested' AND emails.application_id IS NULL AND emails.suggested_job_id IS NOT NULL)
+    OR (sqlc.arg(link) = 'unlinked'  AND emails.application_id IS NULL AND emails.suggested_job_id IS NULL)
   )
   AND (
     sqlc.arg(q)::text = ''
@@ -142,9 +147,9 @@ WHERE user_id = $1
   AND (sqlc.arg(unclassified)::bool = false OR classified_at IS NULL)
   AND (
     sqlc.arg(link)::text = ''
-    OR (sqlc.arg(link) = 'linked'    AND job_id IS NOT NULL)
-    OR (sqlc.arg(link) = 'suggested' AND job_id IS NULL AND suggested_job_id IS NOT NULL)
-    OR (sqlc.arg(link) = 'unlinked'  AND job_id IS NULL AND suggested_job_id IS NULL)
+    OR (sqlc.arg(link) = 'linked'    AND application_id IS NOT NULL)
+    OR (sqlc.arg(link) = 'suggested' AND application_id IS NULL AND suggested_job_id IS NOT NULL)
+    OR (sqlc.arg(link) = 'unlinked'  AND application_id IS NULL AND suggested_job_id IS NULL)
   )
   AND (
     sqlc.arg(q)::text = ''
@@ -192,10 +197,15 @@ LIMIT 1;
 SELECT emails.id, emails.source, emails.external_id, emails.s3_key, emails.from_addr, emails.from_name, emails.subject,
     emails.body_text, emails.body_html, emails.received_at, (emails.read_at IS NOT NULL)::boolean AS read,
     emails.job_id, emails.suggested_job_id, emails.status_signal, emails.link_source,
-    lj.public_slug AS linked_slug, lj.company AS linked_company,
+    -- The link is to the APPLICATION; the posting is how it is displayed while the
+    -- catalogue still holds one. cmd/prune clears la.job_id, so linked_slug goes NULL
+    -- while the row stays linked — the employer is on the application for exactly that.
+    lj.public_slug AS linked_slug,
+    COALESCE(lj.company, la.company_slug, '')::text AS linked_company,
     sj.public_slug AS suggested_slug, sj.company AS suggested_company
 FROM emails
-LEFT JOIN jobs lj ON lj.id = emails.job_id
+LEFT JOIN applications la ON la.id = emails.application_id
+LEFT JOIN jobs lj ON lj.id = la.job_id
 LEFT JOIN jobs sj ON sj.id = emails.suggested_job_id
 WHERE emails.id = $1 AND emails.user_id = $2 AND emails.deleted_at IS NULL;
 
@@ -216,9 +226,9 @@ WHERE user_id = $1
   AND (sqlc.arg(status)::text = '' OR status_signal = sqlc.arg(status))
   AND (
     sqlc.arg(link)::text = ''
-    OR (sqlc.arg(link) = 'linked'    AND job_id IS NOT NULL)
-    OR (sqlc.arg(link) = 'suggested' AND job_id IS NULL AND suggested_job_id IS NOT NULL)
-    OR (sqlc.arg(link) = 'unlinked'  AND job_id IS NULL AND suggested_job_id IS NULL)
+    OR (sqlc.arg(link) = 'linked'    AND application_id IS NOT NULL)
+    OR (sqlc.arg(link) = 'suggested' AND application_id IS NULL AND suggested_job_id IS NOT NULL)
+    OR (sqlc.arg(link) = 'unlinked'  AND application_id IS NULL AND suggested_job_id IS NULL)
   )
   AND (
     sqlc.arg(q)::text = ''
@@ -254,8 +264,8 @@ SELECT coalesce(status_signal, '')::text AS label,
     count(*)::bigint AS n,
     count(*) FILTER (WHERE read_at IS NULL)::bigint AS unread,
     count(*) FILTER (WHERE classified_at IS NULL)::bigint AS unclassified,
-    count(*) FILTER (WHERE job_id IS NOT NULL)::bigint AS linked,
-    count(*) FILTER (WHERE job_id IS NULL AND suggested_job_id IS NOT NULL)::bigint AS suggested
+    count(*) FILTER (WHERE application_id IS NOT NULL)::bigint AS linked,
+    count(*) FILTER (WHERE application_id IS NULL AND suggested_job_id IS NOT NULL)::bigint AS suggested
 FROM emails
 WHERE user_id = $1 AND deleted_at IS NULL
 GROUP BY 1;

--- a/internal/db/queries/mail_classification.sql
+++ b/internal/db/queries/mail_classification.sql
@@ -75,6 +75,13 @@ WHERE emails.id = sqlc.arg(id) AND emails.user_id = sqlc.arg(user_id);
 UPDATE emails
 SET status_signal        = sqlc.narg(status_signal),
     job_id               = COALESCE(sqlc.narg(job_id), job_id),
+    -- Follows job_id, derived rather than passed, exactly as the other link paths do:
+    -- an untouched link keeps the application it already names.
+    application_id       = CASE WHEN sqlc.narg(job_id) IS NOT NULL
+                                THEN (SELECT a.id FROM applications a
+                                       WHERE a.user_id = emails.user_id
+                                         AND a.job_id = sqlc.narg(job_id))
+                                ELSE application_id END,
     link_source          = CASE WHEN sqlc.narg(job_id) IS NOT NULL THEN 'agent' ELSE link_source END,
     -- The cast is load-bearing: this is the parameter's FIRST appearance, and it is
     -- inside an IS NOT NULL, which tells Postgres nothing about its type. Without
@@ -88,7 +95,7 @@ SET status_signal        = sqlc.narg(status_signal),
     suggested_job_id     = NULL,
     classification_model = 'agent',
     classified_at        = now()
-WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
+WHERE emails.id = sqlc.arg(id) AND emails.user_id = sqlc.arg(user_id);
 
 -- name: DeleteEmailClassificationOutbox :exec
 DELETE FROM email_classification_outbox WHERE id = $1;

--- a/internal/handler/inbox_linkstate_integration_test.go
+++ b/internal/handler/inbox_linkstate_integration_test.go
@@ -17,12 +17,22 @@ import (
 // pending suggestion instead of a link.
 func (f *harnessInboxFixture) linkEmail(emailID, jobID int64, suggested bool) {
 	f.t.Helper()
-	col := "job_id"
 	if suggested {
-		col = "suggested_job_id"
+		if _, err := f.pool.Exec(context.Background(),
+			`UPDATE emails SET suggested_job_id = $1 WHERE id = $2`, jobID, emailID); err != nil {
+			f.t.Fatalf("suggest email %d: %v", emailID, err)
+		}
+		return
 	}
+	// A link is to the application; the posting is where it was found. Setting job_id
+	// alone is what the link paths stopped doing, so a fixture that did it would test a
+	// state the product can no longer produce.
 	if _, err := f.pool.Exec(context.Background(),
-		`UPDATE emails SET `+col+` = $1 WHERE id = $2`, jobID, emailID); err != nil {
+		`UPDATE emails
+		    SET job_id         = $1,
+		        application_id = (SELECT a.id FROM applications a
+		                           WHERE a.user_id = emails.user_id AND a.job_id = $1)
+		  WHERE emails.id = $2`, jobID, emailID); err != nil {
 		f.t.Fatalf("link email %d: %v", emailID, err)
 	}
 }

--- a/internal/inbox/inbox.go
+++ b/internal/inbox/inbox.go
@@ -235,7 +235,7 @@ func (s *Service) Search(ctx context.Context, userID int64, q Query) (Page, erro
 			LinkSource:       pgStr(r.LinkSource),
 			LinkState:        linkState(r.JobID, r.SuggestedJobID),
 			LinkedSlug:       pgStr(r.LinkedSlug),
-			LinkedCompany:    pgStr(r.LinkedCompany),
+			LinkedCompany:    r.LinkedCompany,
 			SuggestedSlug:    pgStr(r.SuggestedSlug),
 			SuggestedCompany: pgStr(r.SuggestedCompany),
 		}
@@ -267,7 +267,7 @@ func (s *Service) Get(ctx context.Context, userID, id int64) (Message, error) {
 		LinkSource:       pgStr(row.LinkSource),
 		LinkState:        linkState(row.JobID, row.SuggestedJobID),
 		LinkedSlug:       pgStr(row.LinkedSlug),
-		LinkedCompany:    pgStr(row.LinkedCompany),
+		LinkedCompany:    row.LinkedCompany,
 		SuggestedSlug:    pgStr(row.SuggestedSlug),
 		SuggestedCompany: pgStr(row.SuggestedCompany),
 	}, nil

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -70,10 +70,10 @@
 ## 6. Cut over the mail path
 
 - [x] 6.0 Keep `emails.application_id` in step on every link path — `SetEmailClassification`, `ConfirmEmailLink`, `LinkEmailToJob`, `UnlinkEmail`. Purely additive: no reader changes, so nothing can break, and the column stops going stale on each new link (it did, and only the carry-over could repair it). Derived from the posting inside the statement rather than passed in, so a caller cannot pass a mismatched pair
-- [ ] 6.1 Port `mail_linking.sql` and `mail_classification.sql` to READ `emails.application_id`. **Sized:** `gmail.sql` alone joins `jobs` twice to render the inbox's linked/suggested labels, so this carries a wire-shape consequence of its own — an inbox row whose linked application has no posting, the same problem 5b solved for the board; run `make sqlc`. **Partly done in 5a:** their reads of `stage`/`applied_at` had to move with the rest of the cutover; the `emails.job_id` → `application_id` half is still open
-- [ ] 6.2 Port `internal/inbox` (`RecordApplication`, the `?link=suggested|unlinked` filters) and `internal/maillink` so auto-link, suggestion and monotonic stage advance behave identically
-- [ ] 6.3 Port `internal/handler/inbox_linking.go` and `followup.go`
-- [ ] 6.4 Port `cmd/classify-mail/store.go`
+- [x] 6.1 Port `mail_linking.sql` and `mail_classification.sql` to READ `emails.application_id`. **Sized:** `gmail.sql` alone joins `jobs` twice to render the inbox's linked/suggested labels, so this carries a wire-shape consequence of its own — an inbox row whose linked application has no posting, the same problem 5b solved for the board; run `make sqlc`. **Partly done in 5a:** their reads of `stage`/`applied_at` had to move with the rest of the cutover; the `emails.job_id` → `application_id` half is still open
+- [x] 6.2 Port `internal/inbox` (`RecordApplication`, the `?link=suggested|unlinked` filters) and `internal/maillink` so auto-link, suggestion and monotonic stage advance behave identically
+- [x] 6.3 Port `internal/handler/inbox_linking.go` and `followup.go`
+- [x] 6.4 Port `cmd/classify-mail/store.go`
 - [ ] 6.5 Integration test: mail linked to an application whose posting is then deleted stays linked, and a forward-mapping signal still advances the stage
 - [ ] 6.6 Port the link-correction path (the ordered two-statement retract-then-insert) to compare applications rather than postings, keeping the unique index's `retracted_at` term so a correction can still be recorded. **Moved out of group 4:** the retraction condition can only ask "did this mail move to another application" once the link paths maintain `emails.application_id`, which is 6.1–6.2
 


### PR DESCRIPTION
## What and why

The inbox read the link off `emails.job_id` and joined `jobs` to label it — the same mistake the board carried until #1359. A posting is inventory and `cmd/prune` deletes it on a schedule, so a linked row would have gone to **unlinked** without anybody touching it, and the employer it named would have vanished from the label.

The link state, the counts and the label now read `emails.application_id`. The posting still renders the slug while the catalogue holds one; when it does not, `linked_slug` is null and the employer comes from the application, which carries it for exactly this reason.

## Also

- `AgentTriageEmail` joins the other link paths in keeping `application_id` in step — derived inside the statement rather than passed by the caller, and an untouched link keeps the application it already names, matching how it already treats `match_confidence`.
- Fixtures that set `job_id` alone were producing a state the product can no longer reach. They set both now, like every write path.

## Test plan

- [x] `go test ./...` and `go test -tags=integration ./...` — every package green
- [x] `go build`, `go vet`, `gofmt` clean
