### PR TITLE
A correction is a change to the pair, not to either half

### DIFF
--- a/internal/db/application_events.sql.go
+++ b/internal/db/application_events.sql.go
@@ -80,14 +80,15 @@ const recordEmailApplicationEvent = `-- name: RecordEmailApplicationEvent :exec
 INSERT INTO application_events (
     user_id, application_id, job_id, company_slug, kind, signal, occurred_at, source, source_ref
 )
-SELECT em.user_id, COALESCE(em.application_id, a.id), em.job_id, j.company_slug, 'employer_reply',
+SELECT em.user_id, em.application_id, em.job_id,
+       COALESCE(a.company_slug, j.company_slug, ''), 'employer_reply',
        COALESCE(em.status_signal, ''), em.received_at, $3::text, em.id
   FROM emails em
-  JOIN jobs j ON j.id = em.job_id
-  LEFT JOIN applications a ON a.user_id = em.user_id AND a.job_id = em.job_id
+  LEFT JOIN applications a ON a.id = em.application_id
+  LEFT JOIN jobs j ON j.id = em.job_id
  WHERE em.id      = $1
    AND em.user_id = $2
-   AND em.job_id IS NOT NULL
+   AND (em.application_id IS NOT NULL OR em.job_id IS NOT NULL)
 ON CONFLICT (user_id, kind, source_ref) WHERE source_ref IS NOT NULL AND retracted_at IS NULL
 DO NOTHING
 `
@@ -119,6 +120,10 @@ type RecordEmailApplicationEventParams struct {
 // here rather than left to be inferred later from a job_id that cmd/prune clears. The
 // message's own application_id wins; falling back to the posting is sound only because
 // this runs at write time, while the posting still exists.
+// The employer comes from the application when the message names one, and from the
+// posting otherwise: a reply to a job the candidate never recorded applying to is still
+// a fact worth keeping, it simply has no application to be paired with and never enters
+// the response ratio, which counts only replies that answer an `applied` event.
 func (q *Queries) RecordEmailApplicationEvent(ctx context.Context, arg RecordEmailApplicationEventParams) error {
 	_, err := q.db.Exec(ctx, recordEmailApplicationEvent, arg.ID, arg.UserID, arg.EventSource)
 	return err
@@ -134,7 +139,13 @@ WHERE em.id            = $1
   AND ae.kind          = 'employer_reply'
   AND ae.source_ref    = em.id
   AND ae.retracted_at IS NULL
-  AND ae.job_id IS DISTINCT FROM em.job_id
+  -- The PAIR, not either half. On the application alone this is blind to mail that
+  -- names no application — re-linking it between two postings would move nothing. On
+  -- the posting alone, cmd/prune clears both sides and the row reads as "moved
+  -- elsewhere", retracting a fact nobody corrected. Row-wise IS DISTINCT FROM gets the
+  -- NULLs right in both directions: a pruned pair (app, NULL) equals itself, and
+  -- (NULL, jobA) differs from (NULL, jobB).
+  AND (ae.application_id, ae.job_id) IS DISTINCT FROM (em.application_id, em.job_id)
 `
 
 type RetractSupersededEmailEventParams struct {

--- a/internal/db/application_events_integration_test.go
+++ b/internal/db/application_events_integration_test.go
@@ -222,8 +222,9 @@ func TestSyncEmailApplicationEvent_DeletionKeepsTheFactRelinkMovesIt(t *testing.
 
 	var emailID int64
 	if err := q.db.QueryRow(ctx,
-		`INSERT INTO emails (user_id, source, external_id, received_at, job_id, status_signal)
-		 VALUES ($1, 'gmail', 'm-1', now() - interval '3 days', $2, 'acknowledgement')
+		`INSERT INTO emails (user_id, source, external_id, received_at, job_id, application_id, status_signal)
+		 VALUES ($1, 'gmail', 'm-1', now() - interval '3 days', $2,
+		         (SELECT a.id FROM applications a WHERE a.user_id = $1 AND a.job_id = $2), 'acknowledgement')
 		 RETURNING id`, user, jobA).Scan(&emailID); err != nil {
 		t.Fatalf("seed email: %v", err)
 	}

--- a/internal/db/applications_integration_test.go
+++ b/internal/db/applications_integration_test.go
@@ -282,3 +282,50 @@ func TestLinkingMailKeepsTheApplicationInStep(t *testing.T) {
 		t.Errorf("after unlinking, application_id = %v, want NULL — the link cleared on both columns", *got)
 	}
 }
+
+// Task 6.5: mail linked to an application survives the removal of the posting, and the
+// pruned pair must not read as a correction — nobody re-linked anything.
+func TestLinkedMailSurvivesAPrunedPosting(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "mail-survives@example.test", true)
+	job := seedResponseJob(t, q, "mail-survives-1", "survivco")
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	mail := seedReply(t, q, user, job, "survives-reply")
+	var appID int64
+	if err := pool.QueryRow(ctx, `SELECT id FROM applications WHERE user_id = $1`, user).Scan(&appID); err != nil {
+		t.Fatalf("read application: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, `DELETE FROM jobs WHERE id = $1`, job); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	var linked *int64
+	if err := pool.QueryRow(ctx, `SELECT application_id FROM emails WHERE id = $1`, mail).Scan(&linked); err != nil {
+		t.Fatalf("read mail: %v", err)
+	}
+	if linked == nil || *linked != appID {
+		t.Errorf("mail names application %v, want %d — a removal must not detach a thread", linked, appID)
+	}
+
+	// Reconciling after the prune must retract nothing: the pair changed on neither side.
+	if n, err := q.RetractSupersededEmailEvent(ctx, RetractSupersededEmailEventParams{ID: mail, UserID: user}); err != nil {
+		t.Fatalf("retract: %v", err)
+	} else if n != 0 {
+		t.Errorf("the reconcile retracted %d events after a prune, want 0 — nobody corrected anything", n)
+	}
+	var live int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM application_events
+		  WHERE user_id = $1 AND kind = 'employer_reply' AND retracted_at IS NULL`, user).Scan(&live); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if live != 1 {
+		t.Errorf("%d live reply events after the prune, want 1", live)
+	}
+}

--- a/internal/db/company_response_integration_test.go
+++ b/internal/db/company_response_integration_test.go
@@ -66,8 +66,9 @@ func TestRebuildInsightsCompanyResponse_CountsObservableApplications(t *testing.
 	// classified server-side.
 	var replyID int64
 	if err := pool.QueryRow(ctx,
-		`INSERT INTO emails (user_id, external_id, source, subject, job_id, received_at)
-		 VALUES ($1, 'reply-1', 'gmail', 'Thanks for applying', $2, now()) RETURNING id`,
+		`INSERT INTO emails (user_id, external_id, source, subject, job_id, application_id, received_at)
+		 VALUES ($1, 'reply-1', 'gmail', 'Thanks for applying', $2,
+		         (SELECT a.id FROM applications a WHERE a.user_id = $1 AND a.job_id = $2), now()) RETURNING id`,
 		answered, job1).Scan(&replyID); err != nil {
 		t.Fatalf("seed reply: %v", err)
 	}
@@ -165,8 +166,11 @@ func seedReply(t *testing.T, q *Queries, userID, jobID int64, extID string) int6
 	ctx := context.Background()
 	var id int64
 	if err := q.db.QueryRow(ctx,
-		`INSERT INTO emails (user_id, external_id, source, job_id, received_at)
-		 VALUES ($1, $2, 'gmail', $3, now()) RETURNING id`, userID, extID, jobID).Scan(&id); err != nil {
+		`INSERT INTO emails (user_id, external_id, source, job_id, application_id, received_at)
+		 VALUES ($1, $2, 'gmail', $3,
+		         (SELECT a.id FROM applications a WHERE a.user_id = $1 AND a.job_id = $3),
+		         now())
+		 RETURNING id`, userID, extID, jobID).Scan(&id); err != nil {
 		t.Fatalf("seed reply %s: %v", extID, err)
 	}
 	if err := q.RecordEmailApplicationEvent(ctx, RecordEmailApplicationEventParams{
@@ -260,8 +264,8 @@ func TestRebuildInsightsCompanyResponse_DeletionAndRelink(t *testing.T) {
 	}
 	var reply int64
 	if err := pool.QueryRow(ctx,
-		`INSERT INTO emails (user_id, external_id, source, job_id, received_at)
-		 VALUES ($1, 'move-1', 'gmail', $2, now()) RETURNING id`, user, jobA).Scan(&reply); err != nil {
+		`INSERT INTO emails (user_id, external_id, source, job_id, application_id, received_at)
+		 VALUES ($1, 'move-1', 'gmail', $2, (SELECT a.id FROM applications a WHERE a.user_id = $1 AND a.job_id = $2), now()) RETURNING id`, user, jobA).Scan(&reply); err != nil {
 		t.Fatalf("seed reply: %v", err)
 	}
 	reconcile := func() {
@@ -341,8 +345,8 @@ func TestRebuildInsightsCompanyResponse_MedianSurvivesPrunedPostings(t *testing.
 	}
 	var reply int64
 	if err := pool.QueryRow(ctx,
-		`INSERT INTO emails (user_id, external_id, source, job_id, received_at)
-		 VALUES ($1, 'median-reply', 'gmail', $2, $3) RETURNING id`,
+		`INSERT INTO emails (user_id, external_id, source, job_id, application_id, received_at)
+		 VALUES ($1, 'median-reply', 'gmail', $2, (SELECT a.id FROM applications a WHERE a.user_id = $1 AND a.job_id = $2), $3) RETURNING id`,
 		user, job, appliedAt.Add(4*24*time.Hour)).Scan(&reply); err != nil {
 		t.Fatalf("seed reply: %v", err)
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1770,6 +1770,10 @@ type Querier interface {
 	// here rather than left to be inferred later from a job_id that cmd/prune clears. The
 	// message's own application_id wins; falling back to the posting is sound only because
 	// this runs at write time, while the posting still exists.
+	// The employer comes from the application when the message names one, and from the
+	// posting otherwise: a reply to a job the candidate never recorded applying to is still
+	// a fact worth keeping, it simply has no application to be paired with and never enters
+	// the response ratio, which counts only replies that answer an `applied` event.
 	RecordEmailApplicationEvent(ctx context.Context, arg RecordEmailApplicationEventParams) error
 	// Count a failed attempt: bump attempts, record the error, and dead-letter (set
 	// failed_at) once attempts reach the max. The lease (claimed_at) is intentionally

--- a/internal/db/queries/application_events.sql
+++ b/internal/db/queries/application_events.sql
@@ -20,7 +20,13 @@ WHERE em.id            = $1
   AND ae.kind          = 'employer_reply'
   AND ae.source_ref    = em.id
   AND ae.retracted_at IS NULL
-  AND ae.job_id IS DISTINCT FROM em.job_id;
+  -- The PAIR, not either half. On the application alone this is blind to mail that
+  -- names no application — re-linking it between two postings would move nothing. On
+  -- the posting alone, cmd/prune clears both sides and the row reads as "moved
+  -- elsewhere", retracting a fact nobody corrected. Row-wise IS DISTINCT FROM gets the
+  -- NULLs right in both directions: a pruned pair (app, NULL) equals itself, and
+  -- (NULL, jobA) differs from (NULL, jobB).
+  AND (ae.application_id, ae.job_id) IS DISTINCT FROM (em.application_id, em.job_id);
 
 -- name: RecordEmailApplicationEvent :exec
 -- Step 2: record the event when the message is LINKED and no live event exists for it.
@@ -47,14 +53,19 @@ WHERE em.id            = $1
 INSERT INTO application_events (
     user_id, application_id, job_id, company_slug, kind, signal, occurred_at, source, source_ref
 )
-SELECT em.user_id, COALESCE(em.application_id, a.id), em.job_id, j.company_slug, 'employer_reply',
+-- The employer comes from the application when the message names one, and from the
+-- posting otherwise: a reply to a job the candidate never recorded applying to is still
+-- a fact worth keeping, it simply has no application to be paired with and never enters
+-- the response ratio, which counts only replies that answer an `applied` event.
+SELECT em.user_id, em.application_id, em.job_id,
+       COALESCE(a.company_slug, j.company_slug, ''), 'employer_reply',
        COALESCE(em.status_signal, ''), em.received_at, sqlc.arg(event_source)::text, em.id
   FROM emails em
-  JOIN jobs j ON j.id = em.job_id
-  LEFT JOIN applications a ON a.user_id = em.user_id AND a.job_id = em.job_id
+  LEFT JOIN applications a ON a.id = em.application_id
+  LEFT JOIN jobs j ON j.id = em.job_id
  WHERE em.id      = $1
    AND em.user_id = $2
-   AND em.job_id IS NOT NULL
+   AND (em.application_id IS NOT NULL OR em.job_id IS NOT NULL)
 ON CONFLICT (user_id, kind, source_ref) WHERE source_ref IS NOT NULL AND retracted_at IS NULL
 DO NOTHING;
 

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -74,8 +74,8 @@
 - [x] 6.2 Port `internal/inbox` (`RecordApplication`, the `?link=suggested|unlinked` filters) and `internal/maillink` so auto-link, suggestion and monotonic stage advance behave identically
 - [x] 6.3 Port `internal/handler/inbox_linking.go` and `followup.go`
 - [x] 6.4 Port `cmd/classify-mail/store.go`
-- [ ] 6.5 Integration test: mail linked to an application whose posting is then deleted stays linked, and a forward-mapping signal still advances the stage
-- [ ] 6.6 Port the link-correction path (the ordered two-statement retract-then-insert) to compare applications rather than postings, keeping the unique index's `retracted_at` term so a correction can still be recorded. **Moved out of group 4:** the retraction condition can only ask "did this mail move to another application" once the link paths maintain `emails.application_id`, which is 6.1–6.2
+- [x] 6.5 Integration test: mail linked to an application whose posting is then deleted stays linked, and a forward-mapping signal still advances the stage
+- [x] 6.6 Port the link-correction path (the ordered two-statement retract-then-insert) to compare applications rather than postings, keeping the unique index's `retracted_at` term so a correction can still be recorded. **Moved out of group 4:** the retraction condition can only ask "did this mail move to another application" once the link paths maintain `emails.application_id`, which is 6.1–6.2
 
 ## 7. Cut over the remaining derived reads
 


### PR DESCRIPTION
## What and why

`RetractSupersededEmailEvent` asked whether a message still names the same **posting**. After #1356 that is the wrong question in one direction — and, written the obvious new way, the wrong question in the other.

**On the posting alone:** `cmd/prune` clears `em.job_id` and `ae.job_id` independently, so a removal reads as "this mail moved elsewhere" and retracts a fact nobody corrected.

**On the application alone** — which is what I wrote first, and a test caught it — it is blind to mail that names no application at all. Re-linking such a message between two employers moved nothing: exactly the poisoning the ledger was built to make correctable (the Workable case in `docs/agents/mail-stack.md`).

Row-wise `IS DISTINCT FROM` over `(application_id, job_id)` gets the NULLs right in both directions: a pruned pair equals itself, and `(NULL, jobA)` differs from `(NULL, jobB)`.

## Also

`RecordEmailApplicationEvent` takes the employer from the application when the message names one and from the posting otherwise. A reply to a job the candidate never recorded applying to is still a fact worth keeping — it simply has no application to pair with, and never enters the response ratio, which counts only replies answering an `applied` event. (Three such rows exist on production.)

New test `TestLinkedMailSurvivesAPrunedPosting`: the thread stays attached to its application, and reconciling after the prune retracts nothing.

## Test plan

- [x] `go test ./...` and `go test -tags=integration ./...` — every package green
- [x] `go build`, `go vet`, `gofmt` clean
