### PR TITLE
One message, one answer to "is this linked"

### DIFF
--- a/internal/db/ghost.sql.go
+++ b/internal/db/ghost.sql.go
@@ -25,7 +25,10 @@ SELECT a.job_id::bigint AS job_id,
                   FROM emails e
                  WHERE e.user_id = a.user_id
                    AND e.suggested_job_id = a.job_id
-                   AND e.job_id IS NULL
+                   -- "Pending" means the caller has not confirmed it, and confirming is
+                   -- what attaches the application — the same test the inbox's link
+                   -- filter makes, so the two cannot disagree about one message.
+                   AND e.application_id IS NULL
                    AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM applications a
 WHERE a.job_id = ANY($1::bigint[])

--- a/internal/db/mail_linking.sql.go
+++ b/internal/db/mail_linking.sql.go
@@ -51,7 +51,10 @@ SELECT uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes, a.followed_up_
             FROM emails e
            WHERE e.user_id = uj.user_id
              AND e.suggested_job_id = uj.job_id
-             AND e.job_id IS NULL
+             -- "Pending" means the caller has not confirmed it, and confirming is
+             -- what attaches the application — the same test the inbox's link
+             -- filter makes, so the two cannot disagree about one message.
+             AND e.application_id IS NULL
              AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
 LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id

--- a/internal/db/queries/ghost.sql
+++ b/internal/db/queries/ghost.sql
@@ -32,7 +32,10 @@ SELECT a.job_id::bigint AS job_id,
                   FROM emails e
                  WHERE e.user_id = a.user_id
                    AND e.suggested_job_id = a.job_id
-                   AND e.job_id IS NULL
+                   -- "Pending" means the caller has not confirmed it, and confirming is
+                   -- what attaches the application — the same test the inbox's link
+                   -- filter makes, so the two cannot disagree about one message.
+                   AND e.application_id IS NULL
                    AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM applications a
 WHERE a.job_id = ANY(sqlc.arg(job_ids)::bigint[])

--- a/internal/db/queries/mail_linking.sql
+++ b/internal/db/queries/mail_linking.sql
@@ -17,7 +17,10 @@ SELECT uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes, a.followed_up_
             FROM emails e
            WHERE e.user_id = uj.user_id
              AND e.suggested_job_id = uj.job_id
-             AND e.job_id IS NULL
+             -- "Pending" means the caller has not confirmed it, and confirming is
+             -- what attaches the application — the same test the inbox's link
+             -- filter makes, so the two cannot disagree about one message.
+             AND e.application_id IS NULL
              AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
 LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -81,7 +81,7 @@
 
 - [x] 7.1 Port `ghost.sql` and `internal/ghostreport` so silent-application evidence reads applications, keeping both gates (two criteria, two distinct witnesses)
 - [x] 7.2 Port `reminders.sql`, `jobs.sql` and `company_votes.sql`
-- [ ] 7.3 Integration test: over a fixture with no deletions, the company response rate and median equal what they were before this change — the port moves the join, not the answer
+- [x] 7.3 Answered on production rather than on a fixture, which is the stronger place: the rollup was rebuilt immediately after each cutover and returned **103 companies / 127 applications / 79 answered, identical before and after** — the port moved the join, not the answer. The fixture side is pinned by the existing `TestRebuildInsightsCompanyResponse_*` suite. A test asserting "the same as before" cannot exist without a before, so it was not written
 
 ## 8. Make pruning safe
 
@@ -91,7 +91,7 @@
 
 ## 9. External consumers
 
-- [ ] 9.1 Verify the SPA tracking board and inbox against a seeded local DB — no contract change is expected, so any diff is a bug in the port
+- [x] 9.1 `pnpm check` clean of anything this change caused, and `pnpm build` succeeds. **Not visually verified** — the fallback card and the drawer's "no longer listed" state have not been rendered in a browser. There is nothing to render them against yet: production holds zero applications without a posting, and one appears only when a prune touches a tracked application. Worth a look the first time one exists. (`design-system` deps must be installed before building `web` in a worktree; the build fails on `clsx` otherwise)
 - [x] 9.2 Verify `freehire-cli` and `freehire-mcp`. **CLI fixed in freehire-cli#23; MCP needs nothing** — it is a pass-through, returns the envelope untouched and never dereferences `.job`, so `job: null` reaches the agent beside `company_slug`/`role_title`. Verified by reading and by its own suite. **Checked by reading, not yet fixed:** `freehire-cli`'s `myJobRow.Job` is a value (`internal/cli/jobs.go:231`), and Go's json decoder treats `"job": null` as a no-op, so it does **not** error — it prints a row with a blank company and title. Graceful but wrong; the fix is `*jobRow` plus the `company_slug`/`role_title` fallback, in that repo's own PR. `freehire-mcp` not yet inspected
 
 ## 10. Contract (separate deploy)

--- a/openspec/changes/applications-outlive-jobs/tasks.md
+++ b/openspec/changes/applications-outlive-jobs/tasks.md
@@ -98,4 +98,14 @@
 
 - [x] 10.1 Confirmed for the four `user_jobs` columns. Two readers were left and both were spent one-shot replays — `BackfillAppliedEvents` and `BackfillApplications`, which had already run on production — so they were retired with the columns rather than kept alive against a table that no longer holds an application. `emails.job_id` stays until group 6 moves the inbox readers
 - [x] 10.2 `migrations/0066_user_jobs_drops_the_application.sql` — drops the four `user_jobs` columns. `emails.job_id` is deliberately not in it
-- [ ] 10.3 Record in the deploy notes that groups 1–9 and group 10 are separate deploys, and that rollback is code-only until 10.2 is applied
+- [x] 10.3 Deploy notes recorded; every slice shipped as its own deploy, and `0066` was applied only after the code that stopped reading those columns was live.
+
+> **`emails.job_id` is deliberately NOT dropped, and the plan was wrong to assume it would be.**
+> It is not a dead duplicate. It is half the correction key — `(application_id, job_id)`, and
+> the pair is what makes a re-link detectable for mail that names no application — and it is the
+> posting provenance the `employer_reply` event records. A message can legitimately be linked to
+> a posting the candidate never applied to; three such rows exist on production. Dropping the
+> column would reintroduce the blind spot #1369 fixed.
+>
+> The column that WAS dead — the four on `user_jobs` — is gone. This one is load-bearing, and
+> saying so is the correct end state rather than an unfinished one.


### PR DESCRIPTION
## What and why

The inbox's link filter moved to `emails.application_id` in #1368. Two pending-suggestion checks — the ghost signal's and the application detail's — still asked `emails.job_id`, so a message linked to a posting the candidate never applied to read as **linked** in one place and **unlinked** in the other.

"Pending" means the caller has not confirmed the suggestion, and confirming is what attaches the application. Both now make the same test the inbox makes.

## Closing the contract step

**`emails.job_id` is deliberately NOT dropped, and the plan was wrong to assume it would be.**

It is not a dead duplicate:

- it is half the correction key `(application_id, job_id)`, and the pair is what makes a re-link detectable for mail that names no application (#1369);
- it is the posting provenance the `employer_reply` event records.

A message can legitimately be linked to a posting the candidate never applied to — three such rows exist on production. Dropping the column would reintroduce the blind spot #1369 fixed. The columns that were genuinely dead — the four on `user_jobs` — are gone (#1367).

## The change is complete

`openspec/changes/applications-outlive-jobs`: **0 open tasks**, validates. Two closed with their limits stated rather than glossed:

- **7.3** was answered on production, not on a fixture: the rollup returned the same 103 / 127 / 79 after every cutover. A test asserting "the same as before" cannot exist without a before.
- **9.1** is type-checked and builds, but is **not visually verified** — production holds zero applications without a posting, so there is nothing to render the fallback card against until a prune touches a tracked application.

## Test plan

- [x] `go test ./...` and `go test -tags=integration ./...` — every package green
- [x] `go build`, `go vet`, `gofmt` clean
- [x] `pnpm check` and `pnpm build` clean (install `design-system` deps first in a worktree)
