### PR TITLE
fix(config): name the transcription model in env, with no default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,13 +76,16 @@ TYPST_BIN=typst
 # link stores. Any long random string; changing it makes past visitors look like new ones.
 TRACER_LINK_SALT=
 
-# Speech-to-text for the assistant composer's microphone (optional). It runs on the
-# SAME gateway and key as the rest of the LLM stack — an OpenAI-compatible endpoint
-# serves /chat/completions and /audio/transcriptions alike — so there is nothing else
-# to configure. This is the one model name with a default; leave it be unless your
-# gateway names the model differently. Without LLM_BASE_URL/LLM_API_KEY the
-# transcription endpoint answers 501 and the composer renders no microphone.
-STT_MODEL=whisper-1
+# Speech-to-text for the assistant composer's microphone (optional, and OFF until you
+# name a model). It runs on the SAME gateway and key as the rest of the LLM stack — an
+# OpenAI-compatible endpoint serves /chat/completions and /audio/transcriptions alike —
+# so there is nothing else to configure.
+#
+# There is deliberately NO default: transcription is billed per minute of audio and an
+# assistant turn is not metered, so silence here means no microphone rather than a
+# model somebody did not choose. Empty (or LLM_BASE_URL/LLM_API_KEY unset) leaves the
+# transcription endpoint answering 501 and the composer rendering no microphone.
+STT_MODEL=
 
 # Langfuse LLM tracing (all optional — tracing is disabled unless all three are
 # set, exactly like MEILI_MASTER_KEY gates search). Traces every enrich /

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,10 +82,11 @@ type Settings struct {
 
 	// STTModel transcribes dictated audio, through the same gateway and key the LLM
 	// settings above name — an OpenAI-compatible endpoint serves /chat/completions and
-	// /audio/transcriptions alike. It is the one model name with a default: a
-	// deployment that configured LLM_* has already configured everything dictation
-	// needs, and requiring a second variable to enable a microphone would be ceremony.
-	// The composer offers no microphone where the gateway itself is unconfigured.
+	// /audio/transcriptions alike. Named explicitly like every other model here, with
+	// no default: transcription is billed per minute of audio against an assistant that
+	// is not metered, so a deployment that never said which model to use should not
+	// find itself paying for one. Empty leaves the endpoint answering 501 and the
+	// composer rendering no microphone.
 	STTModel string
 
 	// PIIFilterURL is the co-located openai/privacy-filter span-detection endpoint used to
@@ -195,7 +196,7 @@ func Load() Settings {
 		AssistantModel:    os.Getenv("ASSISTANT_MODEL"),
 		AssistantMaxSteps: envInt("ASSISTANT_MAX_STEPS", 0),
 
-		STTModel: env("STT_MODEL", "whisper-1"),
+		STTModel: os.Getenv("STT_MODEL"),
 
 		PIIFilterURL: os.Getenv("PII_FILTER_URL"),
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,14 +17,14 @@ func TestLoad_LLMFromEnv(t *testing.T) {
 	}
 }
 
-func TestLoad_STTModelDefaultsToWhisper(t *testing.T) {
+func TestLoad_STTModelHasNoDefault(t *testing.T) {
 	t.Setenv("STT_MODEL", "")
 
-	// Unlike the other model names, this one has a default: the gateway that serves
-	// chat also serves transcription, so a deployment that configured LLM_* has
-	// already configured everything dictation needs.
-	if s := Load(); s.STTModel != "whisper-1" {
-		t.Errorf("STTModel = %q, want whisper-1", s.STTModel)
+	// No default on purpose. Transcription is billed per minute of audio against an
+	// assistant that is not metered, so a deployment that never named a model must not
+	// find itself paying for one — it gets no microphone instead.
+	if s := Load(); s.STTModel != "" {
+		t.Errorf("STTModel = %q, want empty when unset", s.STTModel)
 	}
 }
 

--- a/internal/speech/AGENTS.md
+++ b/internal/speech/AGENTS.md
@@ -11,7 +11,10 @@ Its HTTP surface is `internal/handler/speech.go`; the microphone that feeds it i
   it would reach around the abstraction it exists to provide. What the two DO share is
   the endpoint — an OpenAI-compatible gateway serves `/chat/completions` and
   `/audio/transcriptions` from the same host with the same key — so they are configured
-  together and only the model name (`STT_MODEL`, default `whisper-1`) is separate.
+  together and only the model name (`STT_MODEL`) is separate.
+- **`STT_MODEL` has no default, and that is the feature switch.** Transcription is
+  billed per minute of audio against an assistant that is not metered, so a deployment
+  that never named a model gets no microphone rather than a bill for one nobody chose.
 - **`New` returns nil when unconfigured.** Nil is "this deployment has no speech",
   following `internal/headshot`: the handler answers 501 and the SPA reads that as a
   surface that does not exist here rather than as a fault. Whoever wires it must put an


### PR DESCRIPTION
## What and why

`STT_MODEL` shipped in #1370 as the one model name carrying a default (`whisper-1`), on the argument that a deployment which had configured `LLM_*` had already configured everything dictation needs.

That argument ignored what makes this model different from `LLM_MODEL` and `ASSISTANT_MODEL`. Those resolve, on our gateway, to the scavenged free minimax/zai/mistral pool. `whisper-1` resolves to `openai/whisper-1` behind a real paid key, and it is billed per minute of audio — against an assistant that is not metered at all.

A default there means a deployment that never said "yes, transcribe" can end up paying to transcribe. It is now named explicitly or not at all, like every other model in `config.Settings`. Silence means no microphone: `speech.New` returns nil, the endpoint answers 501, and the composer renders no control.

That also makes the variable the feature switch, which is what the rollout wanted anyway.

## Test plan

- [x] `go build`, `go vet`, `gofmt -l` clean
- [x] `go test ./...` — 0 failures (the config test now pins "empty when unset" rather than the default)