### PR TITLE
feat(sources): onboard two contributed boards

### DIFF
--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -173,3 +173,5 @@
   board: urban-sky
 - company: Abby Health
   board: abby-health
+- company: RE Partners Consulting
+  board: jobboard

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3094,3 +3094,5 @@
   board: padoa.teamtailor.com
 - company: TISSIUM
   board: tissium.teamtailor.com
+- company: InvestEngine
+  board: careers.investengine.com


### PR DESCRIPTION
Drains the recognized `pending` rows in `link_contributions` — the manual run of the deferred
ingest worker the contribution flow was designed around (`internal/contribution`: "this flow only
ever writes 'pending'").

## Boards added

| source | board | company | live check |
|---|---|---|---|
| `rippling` | `jobboard` | RE Partners Consulting | `api.rippling.com/platform/api/ats/v1/board/jobboard/jobs` → 20 postings |
| `teamtailor` | `careers.investengine.com` | InvestEngine | `careers.investengine.com/jobs` → 8 postings, JobPosting ld+json |

`jobboard` reads like a generic platform path, which is exactly why it is worth a note: it is a
real Rippling tenant that happens to have claimed that slug. The adapter's own listing endpoint
answers with 20 live postings (Java / frontend / DBA roles across PL, UK, US, AR), so the
recognizer was right and the board is ingestable.

InvestEngine arrived through the **review** queue, not as a recognized board: its Teamtailor career
site sits on the company's own domain, so the URL named no board `atsboard` knows. Teamtailor's
`modeHost` takes the whole careers host, which is the board the adapter wants.

## Pending rows that needed no edit

`ashby/Kojo` and `ashby/Kustomer` are **case variants** of the already-tracked `kojo` and
`kustomer`. `atsboard.Recognize` copies the URL segment verbatim, so a link with a capitalized
path segment opens a fresh row for a board we already crawl. The Ashby posting API is
case-insensitive — both forms return the same 3 and 6 jobs — and Ashby namespaces `external_id`
by the bare job UUID with no board prefix, so the lowercase entries already cover them and a
CamelCase twin would buy nothing. Their rows are flipped to `onboarded` without a source change.

## Verification

- `go build ./...`
- `go test ./internal/sources/...` — ok
- Every board above probed live against the endpoint its own adapter fetches, per the
  "validated live before adding" header in both board files.

Statuses on prod flip to `onboarded`/`rejected` after this merges, so the table reflects what is
actually in `sources/`.