### PR TITLE
docs(assistant): plan the turn-usage record

### DIFF
--- a/openspec/changes/meter-the-assistant-turn/.openspec.yaml
+++ b/openspec/changes/meter-the-assistant-turn/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/meter-the-assistant-turn/design.md
+++ b/openspec/changes/meter-the-assistant-turn/design.md
@@ -1,0 +1,161 @@
+## Context
+
+`Runner.Run` is a bounded loop. Each pass calls `llm.Chat`, and `emitUsage` reads the
+provider's counts off the returned choice and emits a `usage` event. It is called from two
+places — inside the loop for a tool-calling round (`runner.go:170`) and after it for the
+answering call (`runner.go:193`) — so **one turn already emits N usage frames, one per model
+call.** Nothing sums them and nothing stores them.
+
+`internal/credits` is a working ledger: `credit_ledger` append-only with `kind`, `feature`,
+`delta`, `period` and a `ref`; `credit_balances` a materialized cache read on the hot debit
+path; `Debit` idempotent through `DebitExists(user, feature, ref)`. Two call sites use it
+(`cv_tailor.go:109`, `match_analysis.go:263`). The assistant is not one of them.
+
+The temptation is to jump straight to `Debit(userID, "assistant", turnRef)`. This change
+deliberately does not, for a reason that is not caution but arithmetic: nobody knows what a
+turn costs, so nobody can choose what it should cost. A turn ranges from one round of chat
+to a thirty-round autopilot pass. Pricing that spread without the distribution is guessing,
+and a guess that refuses people is expensive to be wrong about.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One durable row per turn, on every terminal path, with rounds and tokens.
+- Answer "what does a turn cost, by preset, by model, over a period" from one table.
+- Show a caller their own usage.
+- Add no failure mode to the turn.
+
+**Non-Goals:**
+
+- Debiting credits, refusing a turn, or pricing one. That is the next change, and this one
+  exists to inform it.
+- Per-round rows. The round is not the unit anyone would price or read.
+- Counting tokens ourselves when the provider reports none. A local tokenizer would
+  disagree with the invoice, and a number that looks authoritative and is not is worse than
+  a zero next to a truthful round count.
+- Dictation minutes. Transcription is billed by audio duration on a different endpoint;
+  it deserves its own row shape and is not squeezed in here.
+
+## Decisions
+
+### One row per turn, written once at the end
+
+The loop accumulates into a small value — rounds, input, output — and hands it to the store
+on its way out. Not a row per model call: the caller asked for one thing, a price would
+attach to one thing, and the per-round detail is loop mechanics that would triple the table
+for a question nobody asks.
+
+*Alternative considered:* writing a row per round and aggregating in SQL. Truer to what the
+provider bills, and it survives a crash mid-turn with partial data. Rejected because every
+read then needs a GROUP BY, and the crash case is exactly the case the terminal-path rule
+already covers — the loop emits a `result` on every path, so there is always a moment to write.
+
+### Written on every terminal path, including error and cancellation
+
+A turn that failed after twenty rounds is the most expensive kind. Recording only successes
+would make the table systematically understate the bill, and in the direction that matters.
+
+Cancellation is the subtle one. Aborting the fetch stops the loop before the next model
+call, but the calls already made were billed. The record is written from whatever the loop
+accumulated, so a cancelled turn tells the truth about what it spent rather than vanishing.
+
+### The turn's identity is its idempotency key
+
+`(session_id, seq)` of the assistant message the turn produced — a UNIQUE constraint, and
+the insert is `ON CONFLICT DO NOTHING`. This mirrors `credits.Debit`, which is idempotent
+through `DebitExists(user, feature, ref)` for the same reason: a retry must not double-count.
+
+It also means the ref is already in the right shape for the debit the next change will add,
+so that change does not have to invent one or backfill.
+
+### Failure to record is a log line
+
+The write happens after the terminal event, in the same goroutine, and its error is logged
+and dropped. A turn that answered correctly must not be reported as failed because a
+bookkeeping insert lost a connection. This is the same rule the follow-up endpoint follows
+and for the same reason.
+
+`Runner` takes the store as an optional dependency, nil meaning "do not record" — the
+pattern `internal/speech` and `internal/headshot` already use, so tests and any embedding
+that does not care are unaffected.
+
+### The table
+
+```sql
+CREATE TABLE assistant_turn_usage (
+    id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id       bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_id    uuid   NOT NULL REFERENCES assistant_sessions(id) ON DELETE CASCADE,
+    seq           integer NOT NULL,          -- of the assistant message this turn produced
+    preset        text   NOT NULL,
+    model         text   NOT NULL,
+    rounds        integer NOT NULL,
+    input_tokens  integer NOT NULL DEFAULT 0,
+    output_tokens integer NOT NULL DEFAULT 0,
+    stop_reason   text   NOT NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (session_id, seq)
+);
+CREATE INDEX ON assistant_turn_usage (user_id, created_at DESC);
+CREATE INDEX ON assistant_turn_usage (created_at);
+```
+
+`preset` and `model` are **denormalised on purpose.** The preset is on the session and the
+model is in configuration, but both can change under a row that is a historical fact:
+`ASSISTANT_MODEL` moved from `privateclaw/mid` to `privateclaw/flagship` at some point, and a
+join would silently reattribute every past turn to today's model. A cost record that changes
+when configuration changes is not a cost record.
+
+No CHECK on `preset`: `assistant_sessions.preset` already constrains the vocabulary at the
+source, and a second CHECK here means adding a preset becomes two migrations that can
+disagree.
+
+`ON DELETE CASCADE` on both keys, matching how the rest of the assistant's tables treat a
+deleted account and a deleted conversation. This does mean **deleting a conversation erases
+its cost history**, which is the right default for a per-user product and the wrong one for
+a finance report; if the numbers ever need to outlive the conversation, that is a deliberate
+change to make then, not a default to set now.
+
+### `/me/usage` reports the period, not the lifetime
+
+Scoped to the current period using the same `periodKey` shape `internal/credits` uses, so
+the two agree about what "this month" means and the next change does not have to reconcile
+two calendars.
+
+## Risks / Trade-offs
+
+- **A provider that never reports tokens makes the table look free** → rounds are counted by
+  us and are always right, so the fallback signal survives; and the spec pins the
+  zero-token-with-true-rounds case as a scenario rather than leaving it to chance.
+- **Denormalised `preset`/`model` drift from the session** → intended; documented above and
+  in the AGENTS.md addition, because the drift IS the historical record.
+- **Deleting a conversation erases its usage** → accepted for now, called out above.
+- **The write is on the turn's own path** → it is a single-row insert after the client has
+  its answer, and a failure is dropped; the turn cannot be slowed by more than one insert or
+  broken by any of it.
+- **This change measures and does not bound** → true, and stated. The bound is the next
+  change; the rate limits and the recording ceiling from the voice work stay in the meantime.
+
+## Migration Plan
+
+One migration (next free number — `0066` was the last on `origin/main` when this was
+written; re-check, migration numbers have collided in this repo before). Expand-only: a new
+table nothing reads until the endpoint ships, so it can be applied ahead of the deploy with
+no ordering hazard.
+
+`release.sh` on host-2 appeared to run `cmd/migrate` on the 2026-07-31 release
+(`migrate: 86 file(s) on disk, 0 baselined, 0 applied`), which contradicts the freehire-ops
+README. Confirm on a release that actually applies a file; if the README is right, apply by
+hand before the flip.
+
+Rollback is dropping the table. Nothing else reads it.
+
+## Open Questions
+
+- Does `/me/usage` belong on a page, or is it enough that the number exists for us? The
+  spec requires the endpoint; whether the SPA renders it is a product call. Building it
+  first as an API costs nothing either way.
+- Should a turn started by autopilot be distinguishable from one the caller typed? The
+  preset gives most of it (`tailor` covers both), but the unattended run is the expensive
+  shape and might deserve its own marker. Cheap to add now, awkward to backfill later.

--- a/openspec/changes/meter-the-assistant-turn/proposal.md
+++ b/openspec/changes/meter-the-assistant-turn/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+Nobody knows what the assistant costs.
+
+`internal/assistant/runner.go` already reads token counts off every model call and
+emits them as a `usage` SSE frame. The browser receives them and throws them away.
+Nothing is written down, so there is no answer to "what did last week cost", "which
+preset is expensive", or "is one account responsible for most of it".
+
+`internal/credits` — a per-user points ledger with grants, debits, periods and an
+idempotency key — has existed since the résumé match and CV tailoring shipped. The
+assistant was never wired to it. Its own AGENTS.md says so outright: *"A turn is free
+to the caller and billed to us... nothing bounds the spend now. `internal/credits` is
+the seam for a per-turn debit."*
+
+Two things since then made that gap wider rather than narrower. Dictation added a path
+billed per minute of audio against a real paid key. Follow-ups added a model call per
+settled turn. Both are bounded only by rate limits, which bound *frequency*, not *cost* —
+a rate limit cannot tell a one-round question from a thirty-round autopilot pass.
+
+This change does the half that blocks nothing: **write down what a turn cost.** It
+changes no behaviour, refuses nobody, and produces the numbers any pricing decision needs
+first. Charging for turns is deliberately a separate change, because a credit price
+chosen before seeing the distribution is a guess.
+
+## What Changes
+
+- Every completed turn records what it spent: the session, the preset, the model, the
+  rounds it took, and the input/output tokens summed across those rounds.
+- The record is written whether the turn ended with an answer, at the step ceiling, or in
+  error. A turn that failed after twenty rounds is the most expensive kind and the one
+  worst served by recording nothing.
+- Cancelled turns record what was spent before the caller walked away, because the
+  provider billed for it.
+- `GET /api/v1/me/usage` reports the caller's own totals for the current period.
+- A `meta` block on the assistant's own admin/insights read (or a small worker query —
+  see design) can answer the per-preset question without a per-user scan.
+- **No refusal, no gate, no credit debit.** The endpoint that runs a turn behaves exactly
+  as it does today.
+
+## Capabilities
+
+### New Capabilities
+
+- `assistant-turn-accounting`: recording what one turn spent, and reporting it back to the
+  caller.
+
+### Modified Capabilities
+
+None. `assistant-agent-runtime` describes the turn loop's contract with its client — the
+events, the bounds, the terminal `result`. Recording a row after the loop finishes adds no
+requirement to it and removes none. If the follow-up change adds a *refusal*, that is when
+that spec changes.
+
+## Impact
+
+**New code.** `internal/assistant/usage.go` (the aggregate and its store), a migration
+adding `assistant_turn_usage`, `internal/db/queries/assistant_usage.sql` plus `make sqlc`,
+and a handler for `/me/usage`.
+
+**Modified code.** `internal/assistant/runner.go` — the loop must accumulate per-round
+usage and hand the total to the store on every terminal path. `internal/handler/assistant.go`
+wires the store.
+
+**Schema.** One new table. Expand-only, no backfill, nothing reads it until the endpoint
+ships. Note for the deploy: `release.sh` on host-2 **does** run `cmd/migrate` (observed
+2026-07-31: `migrate: 86 file(s) on disk, 0 baselined, 0 applied`), which contradicts the
+freehire-ops README claiming bare metal has no migration runner. Confirm on a run that
+actually applies something before relying on it.
+
+**Not in scope, deliberately:** debiting `credit_ledger`, refusing a turn on an empty
+balance, a price per turn, and the `feature IN ('match','tailor')` CHECK that would have to
+grow a third value. All of that belongs to the change this one makes possible.

--- a/openspec/changes/meter-the-assistant-turn/specs/assistant-turn-accounting/spec.md
+++ b/openspec/changes/meter-the-assistant-turn/specs/assistant-turn-accounting/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Every completed turn records what it spent
+
+A turn SHALL write exactly one usage record when it ends, on every terminal path: an
+answer, the step ceiling, cancellation, and failure. The record MUST carry the session it
+belonged to, the preset it ran under, the model that ran it, how many model calls it took,
+and the input and output tokens summed across those calls.
+
+One record per turn, not one per model call. A turn is what a caller asks for and what a
+price would attach to; the rounds inside it are an implementation detail of the loop.
+
+#### Scenario: An answered turn is recorded
+
+- **WHEN** a turn ends with `end_turn` after three model calls
+- **THEN** one record exists for it, carrying three rounds and the summed token counts
+
+#### Scenario: A failed turn is recorded too
+
+- **WHEN** a turn ends in error after several rounds
+- **THEN** its record exists and reports the error stop reason
+
+#### Scenario: A cancelled turn records what was already spent
+
+- **WHEN** the caller aborts the request mid-turn
+- **THEN** a record exists carrying the rounds completed before the abort
+
+#### Scenario: A turn stopped at the ceiling is recorded
+
+- **WHEN** a turn reaches `MaxSteps` and answers under the forced final call
+- **THEN** its record counts that final call among its rounds
+
+### Requirement: A provider that reports no tokens still yields a record
+
+Where the provider surfaces no token counts, the turn SHALL still be recorded, with zero
+tokens and its true round count. Rounds are counted by this process and are never missing;
+tokens come from the provider and sometimes are. A turn absent from the table would
+otherwise be indistinguishable from a turn that never ran, and the round count is the
+fallback signal for what a turn cost.
+
+#### Scenario: No usage in the provider's response
+
+- **WHEN** a turn completes and no model call reported token counts
+- **THEN** a record exists with zero input and output tokens and the true number of rounds
+
+### Requirement: Recording never affects the turn
+
+A failure to record SHALL NOT fail the turn, alter any event the client receives, or delay
+the terminal `result`. The caller has their answer; losing the bookkeeping for it is our
+problem and belongs in a log.
+
+#### Scenario: The store is unavailable
+
+- **WHEN** writing the usage record fails
+- **THEN** the turn's events are unchanged, the client sees no error, and the failure is logged
+
+#### Scenario: No store configured
+
+- **WHEN** the runner has no usage store
+- **THEN** turns run exactly as they do today
+
+### Requirement: A turn is recorded once
+
+Recording SHALL be idempotent per turn: a retry of the write, or a second terminal path
+reached by the same turn, MUST NOT produce a second row. The turn's own identity — its
+session and the sequence of the assistant message it produced — is what makes it unique,
+not the moment it was written.
+
+#### Scenario: A repeated write is absorbed
+
+- **WHEN** the same turn is recorded twice
+- **THEN** the table holds one row for it
+
+### Requirement: The caller can see their own usage
+
+`GET /api/v1/me/usage` SHALL report the authenticated caller's assistant usage for the
+current period: turns, rounds, and tokens. It MUST report only the caller's own, and MUST
+answer a caller with no usage as zeroes rather than as an error or a 404.
+
+#### Scenario: A caller with usage
+
+- **WHEN** a caller who has run turns this period reads the endpoint
+- **THEN** the response carries their turn count, round count and token totals
+
+#### Scenario: A caller with none
+
+- **WHEN** a caller who has never run a turn reads the endpoint
+- **THEN** the response is `200` with zeroes
+
+#### Scenario: Usage is owner-scoped
+
+- **WHEN** two accounts have both run turns
+- **THEN** each sees only its own totals
+
+#### Scenario: The endpoint requires authentication
+
+- **WHEN** the request carries no accepted credential
+- **THEN** the response is `401`
+
+### Requirement: The record supports asking which preset costs what
+
+The stored shape SHALL allow totals to be grouped by preset and by model over a period
+without reading the transcript. The question that prompted this change — which of chat,
+tailoring, the rehearsal and the browsing panel is expensive — must be answerable from
+this table alone.
+
+#### Scenario: Grouping by preset
+
+- **WHEN** turns have run under more than one preset
+- **THEN** their totals can be summed per preset for a period

--- a/openspec/changes/meter-the-assistant-turn/tasks.md
+++ b/openspec/changes/meter-the-assistant-turn/tasks.md
@@ -1,0 +1,30 @@
+## 1. The record
+
+- [ ] 1.1 Add the migration creating `assistant_turn_usage` (schema in design.md). Take the next free number after re-checking `origin/main` — numbers have collided here before — and mirror it into the sqlc source of truth.
+- [ ] 1.2 Add `internal/db/queries/assistant_usage.sql`: the `ON CONFLICT (session_id, seq) DO NOTHING` insert, the per-caller period rollup, and the per-preset rollup. Run `make sqlc` and commit the generated diff.
+- [ ] 1.3 Add `internal/assistant/usage.go` with the accumulator (`rounds`, `input`, `output`, `add(llm.Usage)`) and the store's `Record` method; unit-test the accumulator over several rounds, over rounds that reported nothing, and over zero rounds.
+
+## 2. Wiring the loop
+
+- [ ] 2.1 Make `Runner` take an optional usage store (nil = do not record), following the `internal/speech` nil-means-absent pattern.
+- [ ] 2.2 Accumulate usage where `emitUsage` already reads it — both call sites, `runner.go:170` and `:193` — without changing what is emitted.
+- [ ] 2.3 Record on every terminal path: answer, step ceiling, cancellation, failure. Prove it with a test per path against a scripted model, asserting one row each and the right round count.
+- [ ] 2.4 Test that a failing store leaves the turn's events untouched and the terminal `result` unchanged, and that a nil store changes nothing at all.
+- [ ] 2.5 Test that recording the same turn twice leaves one row.
+
+## 3. The endpoint
+
+- [ ] 3.1 Add `GET /api/v1/me/usage` returning the caller's turns, rounds and tokens for the current period, using the same `periodKey` shape `internal/credits` uses.
+- [ ] 3.2 Handler tests: a caller with usage, a caller with none (200 and zeroes, not 404), owner scoping across two accounts, and 401 without a credential.
+- [ ] 3.3 Integration test against a real turn: run one through the scripted model, then read the endpoint and see it.
+
+## 4. Close out
+
+- [ ] 4.1 Update `internal/assistant/AGENTS.md`: replace the "No metering" limitation with what is now true — the turn is recorded, still not bounded — and write down why `preset` and `model` are denormalised, because that reads as a mistake until someone explains that the drift is the point.
+- [ ] 4.2 `go build ./... && go vet ./... && gofmt -l .`, `go test ./...`, `go test -tags=integration ./internal/handler/`.
+- [ ] 4.3 Verify against the spec's scenarios, deploy, then let it run a week before touching pricing — the whole point of this change is the distribution it produces.
+
+## 5. Deliberately not here
+
+The debit, the refusal, the price, and growing `credit_ledger`'s `feature IN ('match','tailor')`
+CHECK to admit a third value. Open that change once this table has a week of data in it.


### PR DESCRIPTION
## What and why

Planning only — no code. Opens the OpenSpec change `meter-the-assistant-turn` so the implementation session starts from `/opsx:apply`.

The runner already reads token counts off every model call (`emitUsage`, called at `runner.go:170` and `:193`) and emits them as a `usage` frame. The browser throws them away. Meanwhile `internal/credits` has been the documented seam for a per-turn debit since the assistant shipped — `internal/assistant/AGENTS.md` says so in as many words — and nothing sits in it.

Two things since then widened the gap rather than closing it: dictation added a path billed per minute of audio against a real paid key, and follow-ups added a model call per settled turn. Both are bounded by rate limits, which bound frequency and not cost — a rate limit cannot tell one round of chat from a thirty-round autopilot pass.

## The shape of the plan

It does the half that blocks nothing: **record what a turn spent**, on every terminal path including error and cancellation, since a turn that failed after twenty rounds is the most expensive kind and the one worst served by recording nothing. Plus `GET /me/usage` for the caller's own totals.

**Pricing is deliberately a separate change.** Nobody knows what a turn costs, so nobody can choose what it should cost; a credit price picked before seeing the distribution is a guess that refuses people when it is wrong. `tasks.md` §5 names exactly what was left out and when to open it.

Three decisions worth arguing with before implementation starts, all in `design.md`:

- **One row per turn, not per model call.** The round is loop mechanics; the turn is what a caller asks for and what a price would attach to.
- **`preset` and `model` are denormalised on purpose.** Both can change under a row that is a historical fact — `ASSISTANT_MODEL` has already moved once — and a join would silently reattribute past turns to today's configuration.
- **`(session_id, seq)` is the idempotency key**, mirroring how `credits.Debit` uses `DebitExists`. It is also already the right shape for the debit the next change adds, so that change needs no backfill.

Two open questions are left open rather than answered: whether `/me/usage` gets a page, and whether an autopilot turn should be distinguishable from a typed one (cheap now, awkward to backfill).

## Test plan

- [x] `openspec validate meter-the-assistant-turn` — valid, 4/4 artifacts