### PR TITLE
feat(sources): recover four boards the recognizer had thrown away

### DIFF
--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -130,3 +130,5 @@
   board: nychdc
 - company: ARRISE
   board: pragmaticplay
+- company: Ness Digital Engineering
+  board: ness

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -47,3 +47,5 @@
 # --- contributed boards ---
 - company: Tidal
   board: hiretidal
+- company: Nearshore Business Solutions
+  board: nearshore-business-solutions

--- a/sources/phenom.yml
+++ b/sources/phenom.yml
@@ -101,3 +101,7 @@
 # Phenom tenant from jobcrawls harvest (2026-07, refineSearch-validated 482 postings)
 - company: Exyte
   board: careers.exyte.net
+
+# Phenom tenant recovered from the contribution queue (2026-08, refineSearch 1135 postings)
+- company: Kuehne+Nagel
+  board: jobs.kuehne-nagel.com

--- a/sources/radancy.yml
+++ b/sources/radancy.yml
@@ -5,3 +5,5 @@
   board: careers.astrazeneca.com
 - company: ING
   board: careers.ing.com
+- company: Intuit
+  board: jobs.intuit.com


### PR DESCRIPTION
A second pass over the `rejected` rows in `link_contributions`, prompted by the question "were
there good candidates among the ones that did not make it?" There were. Each board below was
turned down because the **URL recognizer produced the wrong board or none at all** — not because
the employer was unreachable.

| source | board | company | live check | catalogue had |
|---|---|---|---|---|
| `jobvite` | `ness` | Ness Digital Engineering | listing page, ~139 postings | nothing |
| `manatal` | `nearshore-business-solutions` | Nearshore Business Solutions | open API, 66 postings | 14 via himalayas |
| `radancy` | `jobs.intuit.com` | Intuit | adapter's `sitemap.xml`, 388 job URLs | 6 via whatjobs |
| `phenom` | `jobs.kuehne-nagel.com` | Kuehne+Nagel | `refineSearch` → `totalHits: 1135` | 14 justjoin, 7 infojobs |

~1600 postings that were sitting one recognizer bug away.

## The two defect classes these expose

**1. A platform path segment read as a tenant.** `jobs.jobvite.com/careers/<board>/jobs` — jobvite
is registered `modePath`, so the first segment gave the portal word `careers`. This is exactly the
shape `#1206` fixed for SmartRecruiters with `modePathPortal`. And `careers-page.com` is registered
`modeSubdomain` while its URLs are path-based (`www.careers-page.com/<tenant>/job/<id>`), so the
board came out `www`; its source should also map to `manatal`, since `careerspage.yml` is
deliberately empty and every careers-page.com tenant lives in `manatal.yml`.

**2. The host IS the board, and only the page can say so.** Radancy, Phenom, Teamtailor and Jibe
tenants serve from the employer's own domain. `boardresolve` fetches the page but only scans it for
*links* to a recognized ATS — it never considers the fetched URL's own host as the board. So a
TalentBrew or Phenom career site can never resolve, however obvious its fingerprint
(`talentbrew` in the markup; a `ddoKey`/`/widgets` call). Both boards above were found by hand
this way.

No code changes here — this PR only adds the boards. The recognizer work is tracked separately.

## Verification

- `go build ./...`
- `go test ./internal/sources/...` — ok
- Every board probed against the exact endpoint its own adapter fetches, per each board file's
  "validated live before adding" header.