### PR TITLE
fix(atsboard): close the four board-recognition defects found in the rejected queue

### DIFF
--- a/internal/atsboard/board.go
+++ b/internal/atsboard/board.go
@@ -19,6 +19,7 @@ package atsboard
 import (
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -75,6 +76,10 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"oportunidades.mindsight.com.br", "mindsight", modePath},
 	{"careers.hireology.com", "hireology", modePath},
 	{"recruiting.ultipro.com", "ukg", modePath},
+	// Manatal's hosted career-page domain is PATH-based (careers-page.com/<tenant>/job/<id>),
+	// not a tenant subdomain, and its source is manatal: careerspage.yml is deliberately empty
+	// because every careers-page.com tenant is served by the Manatal adapter.
+	{"careers-page.com", "manatal", modePath},
 
 	// --- pathportal: board = the segment before the posting segment ---
 	{"jobs.smartrecruiters.com", "smartrecruiters", modePathPortal},
@@ -98,7 +103,6 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"applicantpro.com", "applicantpro", modeSubdomain},
 	{"isolvedhire.com", "isolvedhire", modeSubdomain},
 	{"careerplug.com", "careerplug", modeSubdomain},
-	{"careers-page.com", "careerspage", modeSubdomain},
 	{"catsone.com", "catsone", modeSubdomain},
 	{"csod.com", "cornerstone", modeSubdomain},
 	{"enlizt.me", "enlizt", modeSubdomain},
@@ -125,6 +129,36 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"myworkdayjobs.com", "workday", modeHostPath},
 }
 
+// apiBoards lists each ATS's OWN API host, where the board sits behind a fixed path prefix
+// rather than in the first segment. These are not links a person pastes; they are the XHR a
+// career site on the EMPLOYER's own domain makes to load its listing. That request often names
+// the board when nothing else on the page does — phantom.com/careers is a plain marketing page
+// whose only mention of the Ashby board "phantom" is the posting-api URL.
+//
+// Matched before atsBoards, which also settles a shadowing bug: boards-api.greenhouse.io is a
+// subdomain of greenhouse.io, so the path rule used to read the API version as the board and
+// hand back greenhouse/"v1" — a silently wrong board of exactly the kind this package's doc
+// comment warns about.
+var apiBoards = []struct{ host, source, prefix string }{
+	{"api.ashbyhq.com", "ashby", "posting-api/job-board"},
+	{"boards-api.greenhouse.io", "greenhouse", "v1/boards"},
+	{"api.lever.co", "lever", "v0/postings"},
+}
+
+// reservedSegments lists, per matched host entry, the leading path segments that are the
+// platform's own machinery and never a tenant. They are skipped in path mode; when nothing
+// but reserved segments remains the URL is declined rather than turned into a false board.
+//
+// Jobvite serves one board both bare (<board>/job/<id>) and behind a portal segment
+// (careers/<board>/jobs), so the first segment read "careers" as the employer — the same defect
+// SmartRecruiters got pathportal for. Greenhouse's embed URLs carry no board in the path at all
+// (the slug is in the `for=` query param, which atsdetect reads), so every one of their path
+// words is machinery.
+var reservedSegments = map[string][]string{
+	"jobs.jobvite.com": {"careers"},
+	"greenhouse.io":    {"embed", "job_app", "job_board", "js"},
+}
+
 // Recognize parses a pasted job link into the company board it belongs to: the source
 // (ATS provider), the board slug, and the canonical URL to store. ok=false when the host is
 // not a supported ATS or the URL carries no board segment/label.
@@ -134,6 +168,9 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		return "", "", "", false
 	}
 	host := hostname(u)
+	if src, board, canonical, ok := recognizeAPI(u, host); ok {
+		return src, board, canonical, true
+	}
 	src, mode, apex, known := matchHost(host)
 	if !known {
 		return "", "", "", false
@@ -196,8 +233,8 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		return src, board, u.String(), true
 	}
 
-	// modePath: the board is the first path segment.
-	board = firstPathSegment(u)
+	// modePath: the board is the first path segment that isn't platform machinery.
+	board = firstTenantSegment(u, reservedSegments[apex])
 	if board == "" {
 		return "", "", "", false
 	}
@@ -205,6 +242,28 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 	u.Fragment = ""
 	u.Path = strings.TrimSuffix(strings.TrimSuffix(u.Path, "/"), "/apply")
 	return src, board, u.String(), true
+}
+
+// recognizeAPI resolves a URL on an ATS's own API host, where the board is the segment right
+// after the entry's fixed path prefix. The canonical collapses to that prefix + board, so every
+// query-parametered variant of the same API call maps to one board.
+func recognizeAPI(u *url.URL, host string) (source, board, canonical string, ok bool) {
+	for _, a := range apiBoards {
+		if host != a.host {
+			continue
+		}
+		rest, found := strings.CutPrefix(strings.Trim(u.Path, "/"), a.prefix+"/")
+		if !found {
+			return "", "", "", false
+		}
+		if board, _, _ = strings.Cut(rest, "/"); board == "" {
+			return "", "", "", false
+		}
+		u.RawQuery, u.Fragment = "", ""
+		u.Path = "/" + a.prefix + "/" + board
+		return a.source, board, u.String(), true
+	}
+	return "", "", "", false
 }
 
 // matchHost returns the ATS entry for a host. path/subdomain entries match the host exactly or
@@ -310,15 +369,18 @@ func hostname(u *url.URL) string {
 	return strings.TrimPrefix(strings.ToLower(u.Hostname()), "www.")
 }
 
-// firstPathSegment returns u's first non-empty path segment ("/acme/jobs/1" → "acme",
-// "/acme" → "acme", "/" → "").
-func firstPathSegment(u *url.URL) string {
+// firstTenantSegment returns u's first path segment that is not one of reserved — the platform
+// path words that are never a tenant on this host. "/acme/jobs/1" → "acme"; "/careers/ness/jobs"
+// with reserved{"careers"} → "ness"; "/" or a path of nothing but reserved words → "".
+func firstTenantSegment(u *url.URL, reserved []string) string {
 	p := strings.Trim(u.Path, "/")
 	if p == "" {
 		return ""
 	}
-	if i := strings.IndexByte(p, '/'); i >= 0 {
-		return p[:i]
+	for _, seg := range strings.Split(p, "/") {
+		if !slices.Contains(reserved, seg) {
+			return seg
+		}
 	}
-	return p
+	return ""
 }

--- a/internal/atsboard/board_test.go
+++ b/internal/atsboard/board_test.go
@@ -25,6 +25,27 @@ func TestRecognize(t *testing.T) {
 		{"deel path", "https://jobs.deel.com/acme/jobs/123", "deel", "acme", "https://jobs.deel.com/acme/jobs/123", true},
 		{"jobvite path", "https://jobs.jobvite.com/acme/job/oABC", "jobvite", "acme", "https://jobs.jobvite.com/acme/job/oABC", true},
 
+		// Reserved segments — a platform path word is never a tenant. Jobvite serves the same
+		// board bare and behind a "careers" portal segment, so the first segment read the portal
+		// word as the board and onboarded nothing; Greenhouse's embed machinery has no board in
+		// the path at all (the slug is in the `for=` param, which atsdetect reads).
+		{"jobvite portal segment skipped", "https://jobs.jobvite.com/careers/ness/jobs", "jobvite", "ness", "https://jobs.jobvite.com/careers/ness/jobs", true},
+		{"greenhouse embed app has no board", "https://job-boards.greenhouse.io/embed/job_app?token=1", "", "", "", false},
+		{"greenhouse embed script has no board", "https://boards.greenhouse.io/embed/job_board/js?for=acme", "", "", "", false},
+
+		// Manatal's hosted career-page domain is path-based, not subdomain-based, and its boards
+		// live in manatal.yml — careerspage.yml is deliberately empty.
+		{"manatal careers-page posting", "https://www.careers-page.com/nearshore-business-solutions/job/5W939XW3", "manatal", "nearshore-business-solutions", "https://www.careers-page.com/nearshore-business-solutions/job/5W939XW3", true},
+		{"manatal careers-page listing", "https://www.careers-page.com/hiretidal", "manatal", "hiretidal", "https://www.careers-page.com/hiretidal", true},
+
+		// pathprefix — the ATS's OWN API host. A careers page on the employer's domain loads its
+		// listing over XHR, so the board is named in that API URL and nowhere else in the page.
+		{"ashby posting API", "https://api.ashbyhq.com/posting-api/job-board/phantom?includeCompensation=false", "ashby", "phantom", "https://api.ashbyhq.com/posting-api/job-board/phantom", true},
+		{"greenhouse boards API", "https://boards-api.greenhouse.io/v1/boards/anthropic/jobs", "greenhouse", "anthropic", "https://boards-api.greenhouse.io/v1/boards/anthropic", true},
+		{"lever postings API", "https://api.lever.co/v0/postings/matchgroup?mode=json", "lever", "matchgroup", "https://api.lever.co/v0/postings/matchgroup", true},
+		{"api host without a board", "https://api.ashbyhq.com/posting-api/job-board", "", "", "", false},
+		{"api host off-prefix path", "https://api.lever.co/v1/something/else", "", "", "", false},
+
 		// SmartRecruiters serves a posting either bare (<company>/<posting>) or behind a portal
 		// segment (<portal>/<company>/<posting>). The employer is the segment before the
 		// posting, never the first one — reading the first turned a portal slug into a board.

--- a/internal/atsdetect/atsdetect.go
+++ b/internal/atsdetect/atsdetect.go
@@ -4,7 +4,10 @@
 // board feeds the existing harvest-boards validator. It performs no I/O.
 package atsdetect
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // matchers are tried in order, so the first provider listed wins when a page links
 // several ATSes. Each regex captures the board slug. Greenhouse has two shapes —
@@ -24,6 +27,58 @@ var matchers = []struct {
 // reserved are path words a direct-URL matcher can capture that are not real board
 // slugs (e.g. `boards.greenhouse.io/embed/...` with no `for=` param).
 var reserved = map[string]bool{"embed": true}
+
+// selfHosted fingerprints the ATS platforms whose tenants serve from the EMPLOYER's own domain,
+// where the board IS that host (jobs.intuit.com, careers.arrive.com) exactly as the ingest
+// adapters and their board files store it. Nothing in such a URL names the platform, and the
+// page need not link to any ATS host either — so neither atsboard.Recognize nor a scan of the
+// page's links can resolve one. The vendor's own bundle in the markup is the only tell.
+//
+// Each marker is the vendor's product name as it appears in asset paths and inline config, and
+// they do not overlap: sampled across the boards already in radancy.yml / phenom.yml / jibe.yml
+// / teamtailor.yml, every page carried its own marker and none carried another's. Greenhouse,
+// Lever, Ashby, Workable and plain non-ATS careers pages carry none.
+var selfHosted = []struct {
+	provider string
+	marker   *regexp.Regexp
+}{
+	{"radancy", regexp.MustCompile(`(?i)talentbrew`)},
+	{"phenom", regexp.MustCompile(`(?i)phenompeople`)},
+	{"jibe", regexp.MustCompile(`(?i)jibeapply`)},
+	{"teamtailor", regexp.MustCompile(`(?i)teamtailor`)},
+}
+
+// vendorDomains are the ATS vendors' own domains. Their marketing sites naturally carry their
+// own marker, and a tenant hosted on the vendor's domain is URL-derivable without fetching
+// anything — either way the fetched host is not an employer board.
+var vendorDomains = []string{
+	"radancy.com", "talentbrew.com",
+	"phenom.com", "phenompeople.com",
+	"jibe.com", "jibeapply.com",
+	"teamtailor.com",
+}
+
+// DetectSelfHosted reports the board for a career site served from the employer's own domain:
+// the provider comes from the platform's fingerprint in html, the board is host itself. It is
+// the last resort, after both the URL rules and the page's links have come up empty, and it
+// performs no I/O.
+func DetectSelfHosted(html, host string) (provider, board string, ok bool) {
+	host = strings.TrimPrefix(strings.ToLower(host), "www.")
+	if host == "" {
+		return "", "", false
+	}
+	for _, d := range vendorDomains {
+		if host == d || strings.HasSuffix(host, "."+d) {
+			return "", "", false
+		}
+	}
+	for _, s := range selfHosted {
+		if s.marker.MatchString(html) {
+			return s.provider, host, true
+		}
+	}
+	return "", "", false
+}
 
 // absURLRe extracts absolute http(s) URLs from arbitrary markup (href/src attributes
 // or bare URLs in inline scripts), stopping at the first quote, angle bracket, or

--- a/internal/atsdetect/atsdetect_test.go
+++ b/internal/atsdetect/atsdetect_test.go
@@ -89,3 +89,64 @@ func TestDetect(t *testing.T) {
 		})
 	}
 }
+
+// TestDetectSelfHosted covers the career sites served from the employer's own domain, where the
+// board is the host and only the vendor's bundle in the markup says which platform it is. The
+// markers are the ones sampled live off the boards already in radancy.yml / phenom.yml /
+// jibe.yml / teamtailor.yml.
+func TestDetectSelfHosted(t *testing.T) {
+	cases := []struct {
+		name     string
+		html     string
+		host     string
+		provider string
+		board    string
+		ok       bool
+	}{
+		{
+			name: "radancy talentbrew bundle", host: "jobs.intuit.com",
+			html:     `<script src="https://cdn.example.com/talentbrew/main.js"></script>`,
+			provider: "radancy", board: "jobs.intuit.com", ok: true,
+		},
+		{
+			name: "phenom widget config", host: "jobs.kuehne-nagel.com",
+			html:     `<script>var phApp={"ddoKey":"refineSearch"};</script><link href="//assets.phenompeople.com/x.css">`,
+			provider: "phenom", board: "jobs.kuehne-nagel.com", ok: true,
+		},
+		{
+			name: "jibe apply bundle", host: "careers.amd.com",
+			html:     `<div data-jibeapply="1"></div>`,
+			provider: "jibe", board: "careers.amd.com", ok: true,
+		},
+		{
+			name: "teamtailor on a custom domain", host: "careers.investengine.com",
+			html:     `<meta name="generator" content="Teamtailor">`,
+			provider: "teamtailor", board: "careers.investengine.com", ok: true,
+		},
+		// www is not part of the board: the adapters and board files store the bare careers host.
+		{
+			name: "www stripped from the board", host: "www.github.careers",
+			html:     `<script src="/jibeapply.js"></script>`,
+			provider: "jibe", board: "github.careers", ok: true,
+		},
+		// The vendor's own site carries its own marker; it is never an employer board. Nor is a
+		// tenant hosted on the vendor's domain — atsboard resolves that one from the URL alone.
+		{name: "vendor marketing site", host: "www.phenom.com", html: `phenompeople`, ok: false},
+		{name: "tenant on the vendor domain", host: "bryter.teamtailor.com", html: `Teamtailor`, ok: false},
+		// Another ATS's page must not be claimed.
+		{name: "greenhouse embed page", host: "acme.com", html: `<script src="https://boards.greenhouse.io/embed/job_board/js?for=acme"></script>`, ok: false},
+		{name: "plain careers page", host: "acme.com", html: `<h1>Join us</h1>`, ok: false},
+		{name: "no host", host: "", html: `talentbrew`, ok: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, b, ok := DetectSelfHosted(tc.html, tc.host)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v (got provider=%q board=%q)", ok, tc.ok, p, b)
+			}
+			if ok && (p != tc.provider || b != tc.board) {
+				t.Errorf("got (%q, %q), want (%q, %q)", p, b, tc.provider, tc.board)
+			}
+		})
+	}
+}

--- a/internal/boardresolve/boardresolve.go
+++ b/internal/boardresolve/boardresolve.go
@@ -53,7 +53,9 @@ var absURLRe = regexp.MustCompile(`https?://[^\s"'<>)\\]+`)
 //     can't parse, since the board is in the query param and the path holds only machinery;
 //  2. any supported ATS apply/board URL embedded in the page, run through the full
 //     atsboard.Recognize (all ~40 ATS, all modes) — this catches a company careers page
-//     that links to its recruitee/peopleforce/zoho/workday board.
+//     that links to its recruitee/peopleforce/zoho/workday board;
+//  3. the platforms whose board IS the careers host (Radancy/Phenom/Jibe/Teamtailor), via
+//     atsdetect.DetectSelfHosted — a site that links to no ATS host because it is the ATS.
 //
 // ok=false when the fetch fails or no board is found.
 func (r *Resolver) Resolve(ctx context.Context, rawURL string) (source, board, canonical string, ok bool) {
@@ -71,6 +73,17 @@ func (r *Resolver) Resolve(ctx context.Context, rawURL string) (source, board, c
 	for _, u := range absURLRe.FindAllString(html, -1) {
 		if s, b, _, matched := atsboard.Recognize(u); matched {
 			return s, b, stripTails(rawURL), true
+		}
+	}
+
+	// 3. The host IS the board. Radancy, Phenom, Jibe and Teamtailor tenants serve from the
+	//    employer's own domain and need link out to no ATS host at all, so both steps above come
+	//    up empty however plainly the page is a career site. The platform's fingerprint in the
+	//    markup names the provider, and the fetched host is the board — which is exactly what
+	//    these adapters namespace jobs.external_id by, so it dedups against the catalogue.
+	if u, err := url.Parse(rawURL); err == nil {
+		if provider, board, ok := atsdetect.DetectSelfHosted(html, u.Hostname()); ok {
+			return provider, board, stripTails(rawURL), true
 		}
 	}
 	return "", "", "", false

--- a/internal/boardresolve/boardresolve.go
+++ b/internal/boardresolve/boardresolve.go
@@ -50,7 +50,7 @@ var absURLRe = regexp.MustCompile(`https?://[^\s"'<>)\\]+`)
 // Resolve fetches rawURL and finds the ATS board it belongs to, returning the catalogue
 // (source, board) and a canonical URL to store. It looks two ways:
 //  1. the Greenhouse embed shape (script for=<board>) via atsdetect — which the URL recognizer
-//     can't parse (it would read the path word "embed" as the board);
+//     can't parse, since the board is in the query param and the path holds only machinery;
 //  2. any supported ATS apply/board URL embedded in the page, run through the full
 //     atsboard.Recognize (all ~40 ATS, all modes) — this catches a company careers page
 //     that links to its recruitee/peopleforce/zoho/workday board.
@@ -67,10 +67,9 @@ func (r *Resolver) Resolve(ctx context.Context, rawURL string) (source, board, c
 		return provider, slug, stripTails(rawURL), true
 	}
 
-	// 2. Any supported ATS URL in the page, via the full recognizer. First recognized wins;
-	//    a Greenhouse embed URL misparses to board "embed" (step 1 owns Greenhouse), so skip it.
+	// 2. Any supported ATS URL in the page, via the full recognizer. First recognized wins.
 	for _, u := range absURLRe.FindAllString(html, -1) {
-		if s, b, _, matched := atsboard.Recognize(u); matched && b != "embed" {
+		if s, b, _, matched := atsboard.Recognize(u); matched {
 			return s, b, stripTails(rawURL), true
 		}
 	}

--- a/internal/boardresolve/boardresolve_test.go
+++ b/internal/boardresolve/boardresolve_test.go
@@ -79,3 +79,37 @@ func TestResolveNoAtsAndFetchError(t *testing.T) {
 		t.Error("ok=true on fetch error, want false")
 	}
 }
+
+func TestResolveDetectsSelfHostedCareerSite(t *testing.T) {
+	// A Radancy (TalentBrew) site on the employer's own domain: no ATS host in the URL and no
+	// ATS link in the page, so steps 1 and 2 find nothing. The board is the careers host, which
+	// is how radancy.yml and jobs.external_id name it.
+	html := `<html><head><script src="/assets/talentbrew/app.js"></script></head></html>`
+	src, board, canon, ok := resolver(html, nil).Resolve(context.Background(),
+		"https://jobs.intuit.com/job/mountain-view/staff-product-manager/27595/97850406528?src=x")
+	if !ok {
+		t.Fatal("ok=false, want the self-hosted radancy board detected")
+	}
+	if src != "radancy" || board != "jobs.intuit.com" {
+		t.Errorf("(source, board) = (%q, %q), want (radancy, jobs.intuit.com)", src, board)
+	}
+	if canon != "https://jobs.intuit.com/job/mountain-view/staff-product-manager/27595/97850406528" {
+		t.Errorf("canonical = %q, want the URL without query/fragment", canon)
+	}
+}
+
+func TestResolvePrefersAnEmbeddedBoardOverTheHost(t *testing.T) {
+	// Step 2 still wins when the page names a real board: a careers site that embeds another
+	// ATS must resolve to that board, not to its own host.
+	html := `<html><body>
+	  <a href="https://acme.recruitee.com/o/senior-go"></a>
+	  <script src="/talentbrew/app.js"></script>
+	</body></html>`
+	src, board, _, ok := resolver(html, nil).Resolve(context.Background(), "https://careers.acme.com/jobs/1")
+	if !ok {
+		t.Fatal("ok=false, want the embedded recruitee board")
+	}
+	if src != "recruitee" || board != "acme" {
+		t.Errorf("(source, board) = (%q, %q), want (recruitee, acme)", src, board)
+	}
+}

--- a/internal/contribution/AGENTS.md
+++ b/internal/contribution/AGENTS.md
@@ -25,7 +25,14 @@ contributions are URL-only, auto-validated, unmoderated.
   (`<host>/<site>` — Workday). For subdomain/host/hostpath the canonical URL collapses to the
   board itself. Whatever a mode yields, the platform's **own** product hosts (`app.`,
   `dashboard.`, …) are never a tenant — a career site links to them, and `boardresolve` takes
-  the first recognized ATS URL it finds in a page. This is
+  the first recognized ATS URL it finds in a page. The same is true along the path:
+  `reservedSegments` lists, per host, the platform words that are never a tenant, skipped in
+  path mode (Jobvite's `careers/<board>/jobs` portal segment) and declining the URL when nothing
+  else remains (Greenhouse's `embed/job_app`, whose board lives in the `for=` param). A separate
+  `apiBoards` table covers each ATS's **own API host**, where the board sits behind a fixed
+  prefix (`api.ashbyhq.com/posting-api/job-board/<board>`) — that XHR is often the only place a
+  vanity careers page names its board, and matching it first also stops
+  `boards-api.greenhouse.io` from being read as the tenant `v1`. This is
   deliberately a small local table, NOT a per-adapter method on `linksource` — adding an ATS is
   one row + a test. Covers ~37 multi-tenant ATS (greenhouse, lever, ashby, workable, recruitee,
   smartrecruiters, bamboohr, personio, peopleforce, gupy, freshteam, jazzhr, huntflow, deel,


### PR DESCRIPTION
Re-triaging the `rejected` rows in `link_contributions` (#1379) turned up ~1600 postings that had
been thrown away because the **recognizer** was wrong, not the link. This closes the four defects
behind them. Two commits, reviewable separately.

## 1 — `fix(atsboard)`: three URL shapes that named the wrong board

| shape | was | now |
|---|---|---|
| `jobs.jobvite.com/careers/<board>/jobs` | board `careers` | board `<board>` |
| `careers-page.com/<tenant>/job/<id>` | subdomain mode → board `www` | `manatal` / `<tenant>` |
| `boards-api.greenhouse.io/v1/boards/<board>/jobs` | **`greenhouse` / `v1`** | `greenhouse` / `<board>` |
| `job-boards.greenhouse.io/embed/job_app` | board `embed` | declined |

The greenhouse one is worth calling out: `boards-api.greenhouse.io` is a subdomain of
`greenhouse.io`, so the path rule silently handed back the API version as a tenant — the exact
failure this package's doc comment warns about ("fails silently and expensively").

Two new tables carry it, keeping the package's "adding a platform is one row plus one test"
promise:

- **`reservedSegments`** — per host, the path words that are never a tenant. Skipped in path
  mode; when only reserved words remain the URL is declined instead of becoming a false board.
  This subsumes the hand-rolled `b != "embed"` guard in `boardresolve`, now removed.
- **`apiBoards`** — each ATS's own API host, where the board sits behind a fixed prefix
  (`api.ashbyhq.com/posting-api/job-board/<board>`). Matched first, which is also what fixes the
  greenhouse shadowing. These are not links a person pastes; they are the XHR a vanity careers
  page makes to load its listing, and often the only place the board is named at all.

## 2 — `feat(boardresolve)`: the host IS the board

Radancy, Phenom, Jibe and Teamtailor tenants serve from the **employer's own domain**. Nothing in
such a URL names the platform, and the page need not link to any ATS host — it *is* the ATS — so
both existing resolution steps come up empty however plainly the page is a career site.

`atsdetect.DetectSelfHosted(html, host)` reads the provider from the vendor's bundle in the
markup and returns the fetched host as the board. That host is exactly what these adapters
namespace `jobs.external_id` by (`radancy` → `careers.arm.com:60321257296`, `teamtailor` →
`123pousse.teamtailor.com:5275525`), so a resolved board dedups against the catalogue instead of
opening a twin.

Marker selection was measured, not guessed: sampled across the boards already in `radancy.yml`,
`phenom.yml`, `jibe.yml` and `teamtailor.yml`, every page carried its own marker and none carried
another's; Greenhouse, Lever, Ashby, Workable and plain careers pages carried none. Tenants on the
vendor's own domain are excluded — the vendor's marketing site trips its own marker, and a real
tenant there is URL-derivable without a fetch. It runs **last**, so a page that names a real board
still resolves to that board rather than to its own host.

## Verification

`go build ./...`, `go vet ./...`, `gofmt`, `go test ./...` — all clean.

End-to-end against the live pages that motivated the change:

```
jobs.jobvite.com/careers/ness/jobs                 URL   -> jobvite / ness
careers-page.com/nearshore-business-solutions/...  URL   -> manatal / nearshore-business-solutions
job-boards.greenhouse.io/embed/job_app?token=1     (unresolved)      <- was board "embed"
phantom.com/careers                                FETCH -> ashby / phantom
careers.investengine.com/jobs/8150398-...          FETCH -> teamtailor / careers.investengine.com
jobs.intuit.com/job/...                            FETCH -> radancy / jobs.intuit.com
jobs.kuehne-nagel.com/global/en/job/...            FETCH -> phenom / jobs.kuehne-nagel.com
careers.celonis.com/join-us/...                    (unresolved)      <- correctly, no marker/link
macpaw.com/careers/...                             (unresolved)      <- correctly, no marker/link
```

The last two stay unresolved on purpose: both are JS-rendered pages with neither a marker nor an
ATS link, and both employers are already crawled through their real source. A miss is fail-safe;
a false board is not.