### PR TITLE
feat(job): the write mapping owns content_hash and role_fingerprint

### DIFF
--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobdedup"
-	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/sources"
@@ -81,13 +80,9 @@ func (s *dbStore) Save(ctx context.Context, j job.Job) error {
 
 	// The aggregate's read projection carries every persistable field; the write path
 	// never touches enrichment (SetJobEnrichment owns those columns), so it is not mapped.
+	// The mapping also stamps content_hash — which the upsert reports back as
+	// inserted/changed, driving the incremental index push below — and role_fingerprint.
 	params := j.Fields().UpsertParams()
-	// Fingerprint the indexed fields so the upsert can report whether this write
-	// changed searchable content (drives incremental indexing below).
-	params.ContentHash = pgtype.Text{String: jobhash.Of(params), Valid: true}
-	// role_fingerprint is the repost IDENTITY (excludes posted_at/url/slug), so a
-	// reposted role clusters for the job-reality signal — distinct from content_hash.
-	params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
 
 	qtx := s.q.WithTx(tx)
 	saved, err := qtx.UpsertJob(ctx, params)

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobderive"
 	"github.com/strelov1/freehire/internal/jobhash"
+	"github.com/strelov1/freehire/internal/pgconv"
 	"github.com/strelov1/freehire/internal/telegram"
 	"github.com/strelov1/freehire/internal/vocab"
 )
@@ -38,14 +39,15 @@ func buildParams(source, externalID, url, title, company, loc string, remote boo
 		},
 		URL:    url,
 		Remote: remote,
+		// The Telegram post's timestamp is the posting's source posted time. It rides
+		// the draft rather than being written over the mapped params, so the derived
+		// columns fingerprint the posted_at that is actually stored.
+		PostedAt: pgconv.TimePtr(postedAt),
 	})
 	if err != nil {
 		return db.UpsertJobParams{}, err
 	}
 	params := j.Fields().UpsertParams()
-	// posted_at is supplied by the caller (the Telegram post's timestamp), not carried
-	// on the job draft, so it is set over the aggregate-derived (NULL) value here.
-	params.PostedAt = postedAt
 	params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
 	return params, nil
 }

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -14,7 +14,6 @@ import (
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobderive"
-	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/pgconv"
 	"github.com/strelov1/freehire/internal/telegram"
 	"github.com/strelov1/freehire/internal/vocab"
@@ -47,9 +46,7 @@ func buildParams(source, externalID, url, title, company, loc string, remote boo
 	if err != nil {
 		return db.UpsertJobParams{}, err
 	}
-	params := j.Fields().UpsertParams()
-	params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
-	return params, nil
+	return j.Fields().UpsertParams(), nil
 }
 
 // maxAttempts is the retry budget per post: the first failure leaves the post

--- a/cmd/tg-extract/store_test.go
+++ b/cmd/tg-extract/store_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// The Telegram post's timestamp is the posting's source posted time: it is supplied
+// by the caller rather than derived, and must reach the written params intact.
+func TestBuildParams_CarriesSuppliedPostedTime(t *testing.T) {
+	posted := pgtype.Timestamptz{Time: time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC), Valid: true}
+
+	params, err := buildParams(
+		"telegram", "chan/42", "https://t.me/chan/42",
+		"Senior Go Developer", "Acme", "Berlin", false,
+		"We use Golang and PostgreSQL.", "", posted,
+	)
+	if err != nil {
+		t.Fatalf("buildParams: %v", err)
+	}
+
+	if !params.PostedAt.Valid || !params.PostedAt.Time.Equal(posted.Time) {
+		t.Errorf("PostedAt = %v, want %v", params.PostedAt, posted.Time)
+	}
+}
+
+// An extraction with no post timestamp leaves posted_at unset rather than stamping
+// a zero instant, so the freshness signal can tell "unknown" from "the epoch".
+func TestBuildParams_UnsetPostedTimeStaysNull(t *testing.T) {
+	params, err := buildParams(
+		"telegram", "chan/43", "https://t.me/chan/43",
+		"Backend Engineer", "Acme", "Berlin", false,
+		"Go and Postgres.", "", pgtype.Timestamptz{},
+	)
+	if err != nil {
+		t.Fatalf("buildParams: %v", err)
+	}
+
+	if params.PostedAt.Valid {
+		t.Errorf("PostedAt = %v, want unset", params.PostedAt)
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -2619,6 +2619,7 @@ INSERT INTO jobs (
     public_slug, countries, regions, cities, work_mode, skills, seniority, category, is_tech,
     posting_language, employment_type, education_level, english_level, experience_years_min,
     salary_min_manual, salary_max_manual, salary_currency_manual, salary_period_manual, enrichment,
+    content_hash, role_fingerprint,
     created_by
 ) VALUES (
     $1, $2, $3, $4,
@@ -2642,7 +2643,8 @@ INSERT INTO jobs (
         ))
         ELSE '{}'::jsonb
     END,
-    $29::bigint
+    $29, $30,
+    $31::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -2670,6 +2672,11 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     salary_max_manual      = EXCLUDED.salary_max_manual,
     salary_currency_manual = EXCLUDED.salary_currency_manual,
     salary_period_manual   = EXCLUDED.salary_period_manual,
+    -- A re-create rewrites the content, so both derived columns move with it (see
+    -- UpsertJob): content_hash is what makes a later edit re-embed, role_fingerprint
+    -- what lets a hand-curated posting cluster with the crawled copy of its role.
+    content_hash     = EXCLUDED.content_hash,
+    role_fingerprint = EXCLUDED.role_fingerprint,
     -- Overlay the (possibly changed) manual salary onto the existing enrichment so a
     -- re-create reflects it immediately while preserving any prior LLM enrichment.
     enrichment = CASE
@@ -2682,7 +2689,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
         ))
         ELSE jobs.enrichment
     END,
-    updated_by   = $30::bigint,
+    updated_by   = $32::bigint,
     -- A moderator re-create reopens the job; reset the strike count too so the
     -- two-strike liveness grace survives a reopen (see UpsertJob).
     closed_at    = NULL,
@@ -2720,6 +2727,8 @@ type UpsertManualJobParams struct {
 	SalaryMaxManual      pgtype.Int4        `json:"salary_max_manual"`
 	SalaryCurrencyManual string             `json:"salary_currency_manual"`
 	SalaryPeriodManual   string             `json:"salary_period_manual"`
+	ContentHash          pgtype.Text        `json:"content_hash"`
+	RoleFingerprint      pgtype.Text        `json:"role_fingerprint"`
 	CreatedBy            int64              `json:"created_by"`
 	UpdatedBy            int64              `json:"updated_by"`
 }
@@ -2767,6 +2776,8 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		arg.SalaryMaxManual,
 		arg.SalaryCurrencyManual,
 		arg.SalaryPeriodManual,
+		arg.ContentHash,
+		arg.RoleFingerprint,
 		arg.CreatedBy,
 		arg.UpdatedBy,
 	)

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -2263,9 +2263,15 @@ SET title        = $1,
     education_level      = $18,
     english_level        = $19,
     experience_years_min = $20,
-    updated_by   = $21::bigint,
+    -- The edit re-derives the facets from the edited content, so both derived columns
+    -- move with it. content_hash is what makes the edit re-embed at all: the trigger is
+    -- ` + "`" + `semantic_embedded_hash IS DISTINCT FROM content_hash` + "`" + `, so leaving the stored hash
+    -- behind would freeze the vector on the pre-edit text.
+    content_hash     = $21,
+    role_fingerprint = $22,
+    updated_by   = $23::bigint,
     updated_at   = now()
-WHERE public_slug = $22 AND created_by IS NOT NULL
+WHERE public_slug = $24 AND created_by IS NOT NULL
 RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding, salary_min_manual, salary_max_manual, salary_currency_manual, salary_period_manual, upvote_count, downvote_count, ats_absent_at
 `
 
@@ -2290,6 +2296,8 @@ type UpdateManualJobParams struct {
 	EducationLevel     string             `json:"education_level"`
 	EnglishLevel       string             `json:"english_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
+	ContentHash        pgtype.Text        `json:"content_hash"`
+	RoleFingerprint    pgtype.Text        `json:"role_fingerprint"`
 	UpdatedBy          int64              `json:"updated_by"`
 	PublicSlug         string             `json:"public_slug"`
 }
@@ -2328,6 +2336,8 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		arg.EducationLevel,
 		arg.EnglishLevel,
 		arg.ExperienceYearsMin,
+		arg.ContentHash,
+		arg.RoleFingerprint,
 		arg.UpdatedBy,
 		arg.PublicSlug,
 	)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -731,6 +731,12 @@ SET title        = sqlc.arg(title),
     education_level      = sqlc.arg(education_level),
     english_level        = sqlc.arg(english_level),
     experience_years_min = sqlc.arg(experience_years_min),
+    -- The edit re-derives the facets from the edited content, so both derived columns
+    -- move with it. content_hash is what makes the edit re-embed at all: the trigger is
+    -- `semantic_embedded_hash IS DISTINCT FROM content_hash`, so leaving the stored hash
+    -- behind would freeze the vector on the pre-edit text.
+    content_hash     = sqlc.arg(content_hash),
+    role_fingerprint = sqlc.arg(role_fingerprint),
     updated_by   = sqlc.arg(updated_by)::bigint,
     updated_at   = now()
 WHERE public_slug = sqlc.arg(public_slug) AND created_by IS NOT NULL

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -611,6 +611,7 @@ INSERT INTO jobs (
     public_slug, countries, regions, cities, work_mode, skills, seniority, category, is_tech,
     posting_language, employment_type, education_level, english_level, experience_years_min,
     salary_min_manual, salary_max_manual, salary_currency_manual, salary_period_manual, enrichment,
+    content_hash, role_fingerprint,
     created_by
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
@@ -634,6 +635,7 @@ INSERT INTO jobs (
         ))
         ELSE '{}'::jsonb
     END,
+    sqlc.arg(content_hash), sqlc.arg(role_fingerprint),
     sqlc.arg(created_by)::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
@@ -662,6 +664,11 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     salary_max_manual      = EXCLUDED.salary_max_manual,
     salary_currency_manual = EXCLUDED.salary_currency_manual,
     salary_period_manual   = EXCLUDED.salary_period_manual,
+    -- A re-create rewrites the content, so both derived columns move with it (see
+    -- UpsertJob): content_hash is what makes a later edit re-embed, role_fingerprint
+    -- what lets a hand-curated posting cluster with the crawled copy of its role.
+    content_hash     = EXCLUDED.content_hash,
+    role_fingerprint = EXCLUDED.role_fingerprint,
     -- Overlay the (possibly changed) manual salary onto the existing enrichment so a
     -- re-create reflects it immediately while preserving any prior LLM enrichment.
     enrichment = CASE

--- a/internal/handler/jobs_moderation_integration_test.go
+++ b/internal/handler/jobs_moderation_integration_test.go
@@ -76,7 +76,7 @@ func TestModeratorJobsEndToEnd(t *testing.T) {
 
 	const validBody = `{"url":"https://acme.example/jobs/1","title":"Senior Go Developer","company":"Acme","location":"Germany","remote":true,"description":"We use Golang."}`
 
-	var createdSlug string
+	var createdSlug, createdHash string
 
 	t.Run("moderator creates a manual job (201)", func(t *testing.T) {
 		resp, err := app.Test(req(fiber.MethodPost, "/api/v1/jobs", modCookie, validBody))
@@ -119,6 +119,24 @@ func TestModeratorJobsEndToEnd(t *testing.T) {
 		body, _ := json.Marshal(out)
 		if bytes.Contains(body, []byte("created_by")) {
 			t.Error("wire response leaked created_by")
+		}
+
+		// The derived columns are written by the same mapping every other write path
+		// uses. A NULL role_fingerprint would keep the vacancy out of role clustering
+		// (RoleClusterCount filters role_fingerprint <> ''), and a NULL content_hash
+		// would make the re-embed comparison NULL IS DISTINCT FROM NULL — false —
+		// freezing its semantic vector on the text of the first embed.
+		var fingerprint string
+		if err := pool.QueryRow(ctx,
+			"SELECT coalesce(content_hash, ''), coalesce(role_fingerprint, '') FROM jobs WHERE public_slug = $1",
+			createdSlug).Scan(&createdHash, &fingerprint); err != nil {
+			t.Fatalf("read derived columns: %v", err)
+		}
+		if createdHash == "" {
+			t.Error("content_hash is NULL; a later edit could never re-embed")
+		}
+		if fingerprint == "" {
+			t.Error("role_fingerprint is NULL; the vacancy can never cluster with the crawled copy of its role")
 		}
 	})
 
@@ -190,6 +208,23 @@ func TestModeratorJobsEndToEnd(t *testing.T) {
 		}
 		if updatedBy != modID {
 			t.Errorf("updated_by = %d, want %d", updatedBy, modID)
+		}
+
+		// The edit re-derives the facets from the edited content, so the content
+		// fingerprint must move with them — it is what makes the semantic vector
+		// re-embed instead of describing the pre-edit text forever. The role
+		// fingerprint moves too here, because the edited field is the title.
+		var editedHash, editedFingerprint string
+		if err := pool.QueryRow(ctx,
+			"SELECT coalesce(content_hash, ''), coalesce(role_fingerprint, '') FROM jobs WHERE public_slug = $1",
+			createdSlug).Scan(&editedHash, &editedFingerprint); err != nil {
+			t.Fatalf("read derived columns: %v", err)
+		}
+		if editedHash == "" || editedHash == createdHash {
+			t.Errorf("content_hash = %q after the edit, want a new fingerprint (was %q)", editedHash, createdHash)
+		}
+		if editedFingerprint == "" {
+			t.Error("role_fingerprint is NULL after the edit")
 		}
 	})
 

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -221,6 +221,11 @@ func withDerived(p db.UpsertJobParams) db.UpsertJobParams {
 // path shares the one column mapping instead of re-listing them. It additionally
 // seeds the salary_*_manual columns from the authoritative ManualSalary (nil when
 // none) and stamps the moderator's id as created_by/updated_by.
+//
+// The derived columns are taken from UpsertParams rather than recomputed, so a
+// hand-curated posting and a crawled one carry identical fingerprints for identical
+// content — which is what lets the two cluster as one role instead of the manual copy
+// sitting outside clustering.
 func (f Fields) UpsertManualParams(actorID int64) db.UpsertManualJobParams {
 	var salMin, salMax *int
 	var salCurrency, salPeriod string
@@ -228,6 +233,7 @@ func (f Fields) UpsertManualParams(actorID int64) db.UpsertManualJobParams {
 		salMin, salMax = f.ManualSalary.Min, f.ManualSalary.Max
 		salCurrency, salPeriod = f.ManualSalary.Currency, f.ManualSalary.Period
 	}
+	derived := f.UpsertParams()
 	return db.UpsertManualJobParams{
 		Source:      f.Source,
 		ExternalID:  f.ExternalID,
@@ -259,6 +265,9 @@ func (f Fields) UpsertManualParams(actorID int64) db.UpsertManualJobParams {
 		SalaryMaxManual:      pgconv.Int4(salMax),
 		SalaryCurrencyManual: salCurrency,
 		SalaryPeriodManual:   salPeriod,
+
+		ContentHash:     derived.ContentHash,
+		RoleFingerprint: derived.RoleFingerprint,
 
 		CreatedBy: actorID,
 		UpdatedBy: actorID,

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -274,5 +274,47 @@ func (f Fields) UpsertManualParams(actorID int64) db.UpsertManualJobParams {
 	}
 }
 
+// UpdateManualParams is the moderator-EDIT analogue of UpsertManualParams: it maps the
+// same Fields columns to the generated UpdateManualJob params, addressing the row by its
+// public slug and stamping the acting moderator. It deliberately carries no salary or
+// created_by — the edit query touches neither the manual salary nor the authorship of
+// the original create.
+//
+// Like the other two mappings it owns the derived columns, and the edit is the write
+// that most needs them: re-deriving facets from edited content is exactly when the
+// fingerprints move.
+func (f Fields) UpdateManualParams(slug string, actorID int64) db.UpdateManualJobParams {
+	derived := f.UpsertParams()
+	return db.UpdateManualJobParams{
+		Title:       f.Title,
+		Company:     f.Company,
+		CompanySlug: f.CompanySlug,
+		Location:    f.Location,
+		Remote:      f.Remote,
+		Description: f.Description,
+		PostedAt:    pgconv.Timestamptz(f.PostedAt),
+		Countries:   f.Countries,
+		Regions:     f.Regions,
+		Cities:      f.Cities,
+		WorkMode:    f.WorkMode,
+		Skills:      f.Skills,
+		Seniority:   f.Seniority,
+		Category:    f.Category,
+		IsTech:      pgconv.Bool(f.IsTech),
+
+		PostingLanguage:    f.PostingLanguage,
+		EmploymentType:     f.EmploymentType,
+		EducationLevel:     f.EducationLevel,
+		EnglishLevel:       f.EnglishLevel,
+		ExperienceYearsMin: pgconv.Int4(f.ExperienceYearsMin),
+
+		ContentHash:     derived.ContentHash,
+		RoleFingerprint: derived.RoleFingerprint,
+
+		UpdatedBy:  actorID,
+		PublicSlug: slug,
+	}
+}
+
 // IsOpen reports whether the job is live (not soft-closed).
 func (j Job) IsOpen() bool { return j.f.ClosedAt == nil }

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -10,9 +10,12 @@ import (
 	"errors"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/jobderive"
+	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/normalize"
 	"github.com/strelov1/freehire/internal/pgconv"
 )
@@ -162,14 +165,17 @@ func New(d Draft) (Job, error) {
 // fields alias the aggregate's; callers treat the result as read-only.
 func (j Job) Fields() Fields { return j.f }
 
-// UpsertParams maps the Fields-derived columns of a job to the generated UpsertJob
-// params, so every write path (ingest, telegram extraction) shares one mapping
-// instead of re-listing the columns. It covers only the fields carried on Fields;
-// columns a caller derives separately (ContentHash, RoleFingerprint, or a PostedAt
-// supplied outside the aggregate) are set on the returned struct after this call.
+// UpsertParams maps a job to the generated UpsertJob params, so every write path
+// (ingest, telegram extraction, link import) shares one mapping instead of re-listing
+// the columns. It owns the DERIVED columns too — content_hash and role_fingerprint are
+// computed here rather than bolted on by each caller afterwards, so a write path cannot
+// persist a posting missing either one by forgetting a step. A posted time supplied
+// outside the deterministic derivation therefore belongs on the Draft, before this
+// mapping runs: content_hash fingerprints posted_at, so setting it on the returned
+// struct would fingerprint a value other than the one written.
 // Enrichment columns are deliberately excluded — SetJobEnrichment owns those.
 func (f Fields) UpsertParams() db.UpsertJobParams {
-	return db.UpsertJobParams{
+	p := db.UpsertJobParams{
 		Source:      f.Source,
 		ExternalID:  f.ExternalID,
 		URL:         f.URL,
@@ -196,6 +202,18 @@ func (f Fields) UpsertParams() db.UpsertJobParams {
 		EnglishLevel:       f.EnglishLevel,
 		ExperienceYearsMin: pgconv.Int4(f.ExperienceYearsMin),
 	}
+	return withDerived(p)
+}
+
+// withDerived stamps the two fingerprints a persisted posting carries onto a mapped
+// params struct. content_hash covers the indexed content (posted_at included), so the
+// upsert can report whether a re-ingest changed anything searchable; role_fingerprint
+// is the repost IDENTITY and deliberately excludes posted_at/url/slug, so a reposted
+// role clusters with its original for the reality signal.
+func withDerived(p db.UpsertJobParams) db.UpsertJobParams {
+	p.ContentHash = pgtype.Text{String: jobhash.Of(p), Valid: true}
+	p.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(p), Valid: true}
+	return p
 }
 
 // UpsertManualParams is the moderator-write analogue of UpsertParams: it maps the

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -242,3 +242,32 @@ func TestUpsertParams_PostedAtMovesContentHashButNotRoleFingerprint(t *testing.T
 		t.Errorf("RoleFingerprint = %q and %q; the role identity must not move with posted_at", a.RoleFingerprint.String, b.RoleFingerprint.String)
 	}
 }
+
+// A posting carries the same two fingerprints for the same content whatever wrote it:
+// the moderator mapping and the automated one share one computation, so a hand-curated
+// vacancy is comparable with the crawled copy of the same role rather than sitting
+// outside clustering with NULL columns.
+func TestUpsertManualParams_DerivedColumnsMatchTheAutomatedMapping(t *testing.T) {
+	j, err := job.New(job.Draft{Input: jobderive.Input{
+		Source:      "workatastartup",
+		ExternalID:  "https://acme.example/jobs/1",
+		Title:       "Senior Go Developer",
+		Company:     "Acme",
+		Location:    "Berlin",
+		Description: "We use Golang.",
+	}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	f := j.Fields()
+
+	automated := f.UpsertParams()
+	moderator := f.UpsertManualParams(7)
+
+	if moderator.ContentHash != automated.ContentHash {
+		t.Errorf("ContentHash = %v, want %v", moderator.ContentHash, automated.ContentHash)
+	}
+	if moderator.RoleFingerprint != automated.RoleFingerprint {
+		t.Errorf("RoleFingerprint = %v, want %v", moderator.RoleFingerprint, automated.RoleFingerprint)
+	}
+}

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -3,6 +3,7 @@ package job_test
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobderive"
@@ -175,5 +176,69 @@ func TestNew_NoManualSalaryByDefault(t *testing.T) {
 	}
 	if j.Fields().ManualSalary != nil {
 		t.Errorf("ManualSalary = %v, want nil (none supplied)", j.Fields().ManualSalary)
+	}
+}
+
+// The write mapping owns every derived column a persisted posting carries. A write
+// path cannot omit the content fingerprint or the role fingerprint by forgetting a
+// step, because there is no step to forget.
+func TestUpsertParams_FillsDerivedColumns(t *testing.T) {
+	j, err := job.New(job.Draft{Input: jobderive.Input{
+		Source:      "manual",
+		ExternalID:  "https://acme.example/jobs/1",
+		Title:       "Senior Go Developer",
+		Company:     "Acme",
+		Description: "We use Golang.",
+	}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	params := j.Fields().UpsertParams()
+
+	if !params.ContentHash.Valid || params.ContentHash.String == "" {
+		t.Errorf("ContentHash = %v, want a fingerprint", params.ContentHash)
+	}
+	if !params.RoleFingerprint.Valid || params.RoleFingerprint.String == "" {
+		t.Errorf("RoleFingerprint = %v, want a fingerprint", params.RoleFingerprint)
+	}
+}
+
+// The two derived columns answer different questions, and posted_at is what separates
+// them: content_hash fingerprints the indexed content (posted_at included, so a
+// re-ingest with a bumped date counts as changed), while role_fingerprint is the role
+// IDENTITY and deliberately excludes it, so a repost still clusters with its original.
+func TestUpsertParams_PostedAtMovesContentHashButNotRoleFingerprint(t *testing.T) {
+	draft := func(postedAt *time.Time) job.Draft {
+		return job.Draft{
+			Input: jobderive.Input{
+				Source:      "manual",
+				ExternalID:  "https://acme.example/jobs/1",
+				Title:       "Senior Go Developer",
+				Company:     "Acme",
+				Description: "We use Golang.",
+			},
+			PostedAt: postedAt,
+		}
+	}
+	earlier := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	later := time.Date(2026, 4, 5, 6, 7, 8, 0, time.UTC)
+
+	first, err := job.New(draft(&earlier))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	second, err := job.New(draft(&later))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	a, b := first.Fields().UpsertParams(), second.Fields().UpsertParams()
+
+	if a.ContentHash.String == b.ContentHash.String {
+		t.Errorf("ContentHash unchanged across posted_at = %q; the hash does not cover the posted time actually written", a.ContentHash.String)
+	}
+	if a.RoleFingerprint.String != b.RoleFingerprint.String {
+		t.Errorf("RoleFingerprint = %q and %q; the role identity must not move with posted_at", a.RoleFingerprint.String, b.RoleFingerprint.String)
 	}
 }

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -271,3 +271,62 @@ func TestUpsertManualParams_DerivedColumnsMatchTheAutomatedMapping(t *testing.T)
 		t.Errorf("RoleFingerprint = %v, want %v", moderator.RoleFingerprint, automated.RoleFingerprint)
 	}
 }
+
+// The moderator edit is the write that MUST move the fingerprints: re-deriving facets
+// from edited content is exactly when they change. A stale content_hash would leave
+// `semantic_embedded_hash IS DISTINCT FROM content_hash` false, freezing the vector on
+// the pre-edit text.
+func TestUpdateManualParams_EditedContentMovesTheContentHash(t *testing.T) {
+	fields := func(description string) job.Fields {
+		j, err := job.New(job.Draft{Input: jobderive.Input{
+			Source:      "manual",
+			ExternalID:  "https://acme.example/jobs/1",
+			Title:       "Senior Go Developer",
+			Company:     "Acme",
+			Description: description,
+		}})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		return j.Fields()
+	}
+
+	before := fields("We use Golang.").UpdateManualParams("acme-senior-go-developer", 7)
+	after := fields("We use Golang and PostgreSQL.").UpdateManualParams("acme-senior-go-developer", 7)
+
+	if before.ContentHash == after.ContentHash {
+		t.Errorf("ContentHash unchanged across an edited description = %q", before.ContentHash.String)
+	}
+}
+
+// The edit mapping addresses the row by public slug and stamps the acting moderator,
+// and its derived columns agree with every other write path's for the same content.
+func TestUpdateManualParams_CarriesSlugActorAndDerivedColumns(t *testing.T) {
+	j, err := job.New(job.Draft{Input: jobderive.Input{
+		Source:      "manual",
+		ExternalID:  "https://acme.example/jobs/1",
+		Title:       "Senior Go Developer",
+		Company:     "Acme",
+		Description: "We use Golang.",
+	}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	f := j.Fields()
+
+	params := f.UpdateManualParams("acme-senior-go-developer", 7)
+	automated := f.UpsertParams()
+
+	if params.PublicSlug != "acme-senior-go-developer" {
+		t.Errorf("PublicSlug = %q", params.PublicSlug)
+	}
+	if params.UpdatedBy != 7 {
+		t.Errorf("UpdatedBy = %d, want 7", params.UpdatedBy)
+	}
+	if params.Title != f.Title || params.Description != f.Description {
+		t.Errorf("content = %q/%q", params.Title, params.Description)
+	}
+	if params.ContentHash != automated.ContentHash || params.RoleFingerprint != automated.RoleFingerprint {
+		t.Errorf("derived = %v/%v, want %v/%v", params.ContentHash, params.RoleFingerprint, automated.ContentHash, automated.RoleFingerprint)
+	}
+}

--- a/internal/linkimport/draft_test.go
+++ b/internal/linkimport/draft_test.go
@@ -1,0 +1,79 @@
+package linkimport
+
+import (
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/linksource"
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// A destination adapter that states the posting's own date supplies it as the source
+// posted time. It reaches the aggregate through the draft, so the write maps — and
+// fingerprints — the posted_at that is actually stored.
+func TestDraftFrom_CarriesResolvedPostedTime(t *testing.T) {
+	posted := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	d := draftFrom(linksource.Resolved{
+		Source: "greenhouse",
+		Job: sources.Job{
+			ExternalID: "acme/1",
+			URL:        "https://boards.greenhouse.io/acme/jobs/1",
+			Title:      "Senior Go Developer",
+			Company:    "Acme",
+			PostedAt:   &posted,
+		},
+	})
+
+	if d.PostedAt == nil || !d.PostedAt.Equal(posted) {
+		t.Errorf("PostedAt = %v, want %v", d.PostedAt, posted)
+	}
+}
+
+// Most destination pages state no date. The draft then leaves posted_at unset rather
+// than stamping the import time, so freshness can tell "unknown" from "posted now".
+func TestDraftFrom_UnstatedPostedTimeStaysNil(t *testing.T) {
+	d := draftFrom(linksource.Resolved{
+		Source: "greenhouse",
+		Job: sources.Job{
+			ExternalID: "acme/2",
+			URL:        "https://boards.greenhouse.io/acme/jobs/2",
+			Title:      "Backend Engineer",
+			Company:    "Acme",
+		},
+	})
+
+	if d.PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil", d.PostedAt)
+	}
+}
+
+// The draft carries the resolved identity and content verbatim; derivation happens
+// inside job.New, never here.
+func TestDraftFrom_CarriesIdentityAndContent(t *testing.T) {
+	d := draftFrom(linksource.Resolved{
+		Source: "greenhouse",
+		Job: sources.Job{
+			ExternalID:  "acme/3",
+			URL:         "https://boards.greenhouse.io/acme/jobs/3",
+			Title:       "Platform Engineer",
+			Company:     "Acme",
+			Location:    "Berlin",
+			Description: "We use Go.",
+			Remote:      true,
+			WorkMode:    "remote",
+		},
+	})
+
+	if d.Source != "greenhouse" || d.ExternalID != "acme/3" {
+		t.Errorf("identity = %q/%q", d.Source, d.ExternalID)
+	}
+	if d.Title != "Platform Engineer" || d.Company != "Acme" || d.Location != "Berlin" {
+		t.Errorf("content = %q/%q/%q", d.Title, d.Company, d.Location)
+	}
+	if d.Description != "We use Go." || d.WorkMode != "remote" {
+		t.Errorf("description/workMode = %q/%q", d.Description, d.WorkMode)
+	}
+	if d.URL != "https://boards.greenhouse.io/acme/jobs/3" || !d.Remote {
+		t.Errorf("url/remote = %q/%v", d.URL, d.Remote)
+	}
+}

--- a/internal/linkimport/linkimport.go
+++ b/internal/linkimport/linkimport.go
@@ -171,11 +171,11 @@ func (im *Importer) resolveVanityDomain(ctx context.Context, raw string) (linkso
 	return linksource.Resolved{Source: source, Job: job}, true
 }
 
-// write persists one resolved job through the Job aggregate factory and the canonical
-// UpsertJob, enqueuing it for enrichment in the same transaction — the same write path as
-// ingest and tg-extract, so facets, slugs and the enrichment outbox stay consistent.
-func (im *Importer) write(ctx context.Context, r linksource.Resolved) (Result, bool, error) {
-	j, err := job.New(job.Draft{
+// draftFrom maps a resolved vacancy onto the aggregate's draft. The destination
+// adapter's posted date rides the draft rather than being written over the mapped
+// params, so the derived columns fingerprint the posted_at that is actually stored.
+func draftFrom(r linksource.Resolved) job.Draft {
+	return job.Draft{
 		Input: jobderive.Input{
 			Source:      r.Source,
 			ExternalID:  r.Job.ExternalID,
@@ -185,16 +185,21 @@ func (im *Importer) write(ctx context.Context, r linksource.Resolved) (Result, b
 			Description: r.Job.Description,
 			WorkMode:    r.Job.WorkMode,
 		},
-		URL:    r.Job.URL,
-		Remote: r.Job.Remote,
-	})
+		URL:      r.Job.URL,
+		Remote:   r.Job.Remote,
+		PostedAt: r.Job.PostedAt,
+	}
+}
+
+// write persists one resolved job through the Job aggregate factory and the canonical
+// UpsertJob, enqueuing it for enrichment in the same transaction — the same write path as
+// ingest and tg-extract, so facets, slugs and the enrichment outbox stay consistent.
+func (im *Importer) write(ctx context.Context, r linksource.Resolved) (Result, bool, error) {
+	j, err := job.New(draftFrom(r))
 	if err != nil {
 		return Result{}, false, err
 	}
 	params := j.Fields().UpsertParams()
-	if r.Job.PostedAt != nil {
-		params.PostedAt = pgtype.Timestamptz{Time: *r.Job.PostedAt, Valid: true}
-	}
 	params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
 
 	tx, err := im.pool.Begin(ctx)

--- a/internal/linkimport/linkimport.go
+++ b/internal/linkimport/linkimport.go
@@ -23,7 +23,6 @@ import (
 	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobdedup"
 	"github.com/strelov1/freehire/internal/jobderive"
-	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/linksource"
 	"github.com/strelov1/freehire/internal/search"
@@ -200,7 +199,6 @@ func (im *Importer) write(ctx context.Context, r linksource.Resolved) (Result, b
 		return Result{}, false, err
 	}
 	params := j.Fields().UpsertParams()
-	params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
 
 	tx, err := im.pool.Begin(ctx)
 	if err != nil {

--- a/internal/moderation/repository.go
+++ b/internal/moderation/repository.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/job"
-	"github.com/strelov1/freehire/internal/pgconv"
 	"github.com/strelov1/freehire/internal/vocab"
 )
 
@@ -82,34 +81,11 @@ func (r *QueriesRepository) BySlug(ctx context.Context, slug string) (job.Job, j
 
 // Update writes the full resulting row for a moderator-authored job. The query's
 // created_by scope means a missing or non-moderator-created slug affects no row
-// (ErrNoRows → ErrJobNotFound).
+// (ErrNoRows → ErrJobNotFound). The Fields→params mapping lives on the aggregate
+// (job.Fields.UpdateManualParams), shared with every other write path, so the derived
+// columns move with the edited content instead of being left behind here.
 func (r *QueriesRepository) Update(ctx context.Context, slug string, f job.Fields, actorID int64) (job.Job, job.Extras, error) {
-	row, err := r.q.UpdateManualJob(ctx, db.UpdateManualJobParams{
-		PublicSlug:  slug,
-		Title:       f.Title,
-		Company:     f.Company,
-		CompanySlug: f.CompanySlug,
-		Location:    f.Location,
-		Remote:      f.Remote,
-		Description: f.Description,
-		PostedAt:    pgconv.Timestamptz(f.PostedAt),
-		Countries:   f.Countries,
-		Regions:     f.Regions,
-		Cities:      f.Cities,
-		WorkMode:    f.WorkMode,
-		Skills:      f.Skills,
-		Seniority:   f.Seniority,
-		Category:    f.Category,
-		IsTech:      pgconv.Bool(f.IsTech),
-
-		PostingLanguage:    f.PostingLanguage,
-		EmploymentType:     f.EmploymentType,
-		EducationLevel:     f.EducationLevel,
-		EnglishLevel:       f.EnglishLevel,
-		ExperienceYearsMin: pgconv.Int4(f.ExperienceYearsMin),
-
-		UpdatedBy: actorID,
-	})
+	row, err := r.q.UpdateManualJob(ctx, f.UpdateManualParams(slug, actorID))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return job.Job{}, job.Extras{}, ErrJobNotFound
 	}

--- a/openspec/changes/job-aggregate-derived-columns/.openspec.yaml
+++ b/openspec/changes/job-aggregate-derived-columns/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/job-aggregate-derived-columns/design.md
+++ b/openspec/changes/job-aggregate-derived-columns/design.md
@@ -1,0 +1,171 @@
+## Context
+
+`internal/job` is the aggregate with a single guarded construction door: a `Job` can
+only be built through `job.New` or loaded through a repository, which makes "a Job
+carries facets consistent with its source fields" a type-enforced invariant. The write
+mapping `Fields.UpsertParams` extends that idea to persistence — one column list, shared
+by every write path.
+
+Two columns were left outside it. `UpsertParams`' doc states the contract in prose:
+*"columns a caller derives separately (ContentHash, RoleFingerprint, or a PostedAt
+supplied outside the aggregate) are set on the returned struct after this call."* The
+result is what a prose contract usually produces:
+
+| Write path | `content_hash` | `role_fingerprint` |
+|---|---|---|
+| `cmd/ingest/store.go` | set | set |
+| `cmd/tg-extract/store.go` | **missing** | set |
+| `internal/linkimport` | **missing** | set |
+| moderator create (`UpsertManualJob`) | **not even a column** | **not even a column** |
+| moderator edit (`UpdateManualJob`) | **not even a column** | **not even a column** |
+
+The moderator create/edit queries are a fourth and fifth hand-maintained column list;
+`internal/moderation/repository.go` builds `db.UpdateManualJobParams` as a literal
+rather than going through the aggregate the way its sibling `Create` does.
+
+Constraint that shapes the whole change: `jobhash.Of` hashes `posted_at`, and both
+`cmd/tg-extract` and `internal/linkimport` assign `params.PostedAt` *after*
+`UpsertParams()` returns. Computing the hash inside the mapping without touching those
+two callers first would fingerprint a `NULL` posted time while writing a real one — a
+hash that no re-ingest of the same posting could ever reproduce.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make "a persisted posting carries both derived columns" true by construction, not by
+  each caller remembering a second step.
+- Make the derived columns identical across write paths for identical content, so a
+  moderator-authored copy of a role is comparable with the crawled one.
+- Fix the posted-time ordering so the fingerprint covers the value actually written.
+- Fold the fifth column list (`UpdateManualJobParams`) into the aggregate, since the
+  change has to edit it anyway.
+
+**Non-Goals:**
+
+- Backfilling `content_hash` on manual rows already in production. Handled
+  operationally (see Migration Plan), not by a domain change.
+- The duplicated `hashParams` remap in `cmd/backfill-descriptions` and
+  `cmd/backfill-justjoin` — a separate review finding with its own trade-offs.
+- `jobhash.Of`'s known omission of `cities`, `english_level` and `is_tech` from the
+  fingerprint. Real, documented, and orthogonal: changing the hash input would
+  invalidate every stored `content_hash` at once.
+- Marking manual jobs as duplicates at write time. `jobdedup.CanonicalForRole` is
+  called by ingest and link-import only; the moderator path continues to leave that to
+  the batch reconciler.
+
+## Decisions
+
+### D1: The derived columns are computed inside the mapping, not returned beside it
+
+`Fields.UpsertParams()` returns params with `ContentHash` and `RoleFingerprint` already
+populated.
+
+*Alternative considered:* a `Fields.Derived() (contentHash, roleFingerprint string)`
+helper that callers apply. Rejected — it is the same "remember the second step" contract
+with a shorter spelling, and the failure mode this change exists to remove is precisely
+a forgotten second step. A helper would still let a write path compile while omitting a
+column.
+
+*Alternative considered:* enforcing the columns in the SQL (a generated column or a
+trigger). Rejected — `role_fingerprint` normalizes titles through `internal/jobhash`'s
+Go dictionary logic, which has no SQL equivalent, and the project keeps derivation in Go
+so it is testable and dictionary-driven.
+
+### D2: The manual mapping hashes the shared params, not a second hash function
+
+`jobhash.Of` and `jobhash.RoleFingerprint` take `db.UpsertJobParams`, while the manual
+path produces `db.UpsertManualJobParams`. `UpsertManualParams` therefore calls
+`f.UpsertParams()` internally and fingerprints that.
+
+*Alternative considered:* a `jobhash.OfManual(db.UpsertManualJobParams)` overload.
+Rejected outright — two hash functions over two structs that must agree field-for-field
+forever is a stronger version of the exact drift this change removes. Routing both
+through one params shape makes cross-path equality structural rather than a convention,
+which is what the spec's "identical content fingerprints identically" scenario asserts.
+
+### D3: A caller-supplied posted time goes through `job.Draft`, which already has the field
+
+`job.Draft` already declares `PostedAt *time.Time`, documented as "the source posted
+time"; `cmd/tg-extract` and `internal/linkimport` simply do not use it and patch the
+mapped params instead. Both move to the draft field.
+
+This is why the ordering fix is cheap: it is not a new mechanism, it is starting to use
+an existing one. `jobderive.Derive` reads only the embedded `jobderive.Input`, and
+`PostedAt` sits outside it, so routing the value through the draft cannot disturb facet
+derivation.
+
+`cmd/tg-extract` holds its value as a `pgtype.Timestamptz` (the Telegram post's
+timestamp); it converts to `*time.Time` at the draft boundary rather than the aggregate
+learning a persistence type.
+
+### D4: `internal/job` takes a dependency on `internal/jobhash`
+
+`internal/jobhash` imports `internal/db` only, so there is no cycle. The direction is
+right: the aggregate owns what a persisted posting carries, and fingerprinting is part
+of that; `jobhash` stays a leaf that knows nothing about the aggregate.
+
+### D5: The moderator edit path moves onto the aggregate
+
+`Fields.UpdateManualParams(slug, actorID)` joins `UpsertParams` and
+`UpsertManualParams`, and `internal/moderation/repository.go`'s `Update` stops building
+the literal. Without this, the change would add the two columns to a hand-rolled list
+and leave the sixth-caller-forgets problem in place one line below the fix.
+
+`content_hash` and `role_fingerprint` are added to `UpdateManualJob`'s SET list — the
+edit path is the one that *must* rewrite them, since re-deriving facets from edited
+content is exactly when the fingerprints move.
+
+## Risks / Trade-offs
+
+**A manual job that starts carrying `role_fingerprint` becomes visible to role
+clustering, and a non-canonical repost is hidden from catalogue and search — a curated
+vacancy could disappear behind a crawled canon.** → Verified as pre-existing, not
+introduced here: `cmd/backfill-derive` pages the whole `jobs` table with no source or
+`created_by` filter and writes `role_fingerprint` for every row, so manual rows already
+acquire fingerprints on each run. This change makes new manual rows consistent with what
+the backfill already produces. Duplicate *marking* still happens only in the batch
+reconciler for this path, unchanged.
+
+**A previously-`NULL` `content_hash` becoming non-NULL enqueues manual jobs for
+re-embedding.** → Intended, and the desired outcome of the finding: the vector currently
+freezes on the pre-edit text forever. The volume is bounded — manual and submission jobs
+are a small slice of the catalogue — and the semantic outbox is leased and rate-bounded,
+so the enqueue drains rather than spikes.
+
+**Computing two SHA-256 hashes inside the mapping makes `UpsertParams` non-trivial, and
+it is called once per ingested row.** → Both hashes were already computed once per row
+on the ingest path; this relocates the work rather than adding it. The two paths that
+previously computed only one hash now compute two, which is a per-row cost measured in
+microseconds against a query round-trip.
+
+**`make sqlc` regenerates `internal/db` from the edited queries; a stale checkout could
+produce a params struct without the new fields.** → The generated code is committed, and
+`go build ./...` fails loudly on a missing field, so the failure is compile-time and
+local, not a silent production divergence.
+
+## Migration Plan
+
+No schema migration: `content_hash` and `role_fingerprint` already exist on `jobs`.
+
+Deploy order is unconstrained — the change only starts writing two columns that readers
+already tolerate as NULL.
+
+Existing rows, after deploy:
+
+1. `role_fingerprint` on legacy manual rows — already handled by the next scheduled
+   `cmd/backfill-derive` run; no new step.
+2. `content_hash` on legacy manual rows stays NULL until that row is edited or
+   re-created, since nothing re-crawls a manual posting. This is the pre-existing gap,
+   now bounded to rows written before the deploy rather than growing. Closing it is a
+   one-line addition to `cmd/backfill-derive`'s update set and is left as a follow-up so
+   this change stays a domain change with no worker behavior in it.
+
+Rollback is a plain revert: the columns become unwritten again, and no reader breaks on
+values already present.
+
+## Open Questions
+
+None blocking. The follow-up question — whether `cmd/backfill-derive` should also
+re-derive `content_hash`, closing the legacy manual-row gap — is deliberately deferred
+rather than unresolved.

--- a/openspec/changes/job-aggregate-derived-columns/design.md
+++ b/openspec/changes/job-aggregate-derived-columns/design.md
@@ -151,6 +151,12 @@ No schema migration: `content_hash` and `role_fingerprint` already exist on `job
 Deploy order is unconstrained — the change only starts writing two columns that readers
 already tolerate as NULL.
 
+One-time effect on the first crawl after deploy: Telegram-extracted and link-imported
+rows written before this change carry `content_hash` NULL, and `NULL IS DISTINCT FROM
+<value>` is true, so their next re-ingest reports `changed` and pushes them to the live
+search index once. That is a bounded, self-limiting backlog over two small sources — and
+it is the change signal starting to work for paths where it never had, not a regression.
+
 Existing rows, after deploy:
 
 1. `role_fingerprint` on legacy manual rows — already handled by the next scheduled

--- a/openspec/changes/job-aggregate-derived-columns/proposal.md
+++ b/openspec/changes/job-aggregate-derived-columns/proposal.md
@@ -1,0 +1,80 @@
+## Why
+
+"What columns a persisted job must carry" is split between the aggregate and two
+derived columns — `content_hash` and `role_fingerprint` — that every write path is
+told, in a doc comment, to bolt on after the mapping returns. Three of the four write
+paths forget at least one, and the moderator path forgets both: `UpsertManualJob` and
+`UpdateManualJob` do not even list the columns.
+
+The consequences are live, not hypothetical:
+
+- A moderator- or submission-authored vacancy lands with `role_fingerprint` NULL.
+  `RoleClusterCount` filters `role_fingerprint <> ''`, so that vacancy can never be
+  deduped or clustered against the ATS copy of the same role — which is exactly the
+  case a crowdsourced submission creates.
+- It also lands with `content_hash` NULL. The re-embed trigger is
+  `semantic_embedded_hash IS DISTINCT FROM content_hash`, and `NULL IS DISTINCT FROM
+  NULL` is false, so after the first embed a moderator's description edit never
+  refreshes the vector: the semantic index permanently describes the pre-edit text.
+  The rule that justifies stamping NULL ("a non-board job with no content_hash is
+  never re-crawled, so its text is stable") is falsified by `UpdateManualJob`, which
+  exists to edit exactly those jobs.
+
+A prose contract that three of four callers get wrong is not a contract. Moving the
+two columns inside the mapping the aggregate already owns makes "a persisted job
+carries a content hash and a role fingerprint" true by construction.
+
+## What Changes
+
+- `Fields.UpsertParams` computes `ContentHash` and `RoleFingerprint` itself instead of
+  documenting that the caller must. The three automated write paths
+  (`cmd/ingest/store.go`, `cmd/tg-extract/store.go`, `internal/linkimport`) drop their
+  post-mapping assignments.
+- **Ordering prerequisite:** `jobhash.Of` hashes `posted_at`, and `cmd/tg-extract` and
+  `internal/linkimport` overwrite `params.PostedAt` *after* the mapping returns. Both
+  move to the `job.Draft.PostedAt` field that already exists for this purpose, so the
+  hash covers the posted time that is actually written.
+- `Fields.UpsertManualParams` computes both columns too, and `content_hash` /
+  `role_fingerprint` are added to the `UpsertManualJob` column list.
+- The moderator edit path gets the same treatment: `content_hash` and
+  `role_fingerprint` are added to `UpdateManualJob`'s SET list, and the hand-rolled
+  `db.UpdateManualJobParams` literal in `internal/moderation/repository.go` — a fourth
+  copy of the same column list — moves onto the aggregate as
+  `Fields.UpdateManualParams`, mirroring `UpsertManualParams`.
+- Existing rows are not backfilled by this change. `cmd/backfill-derive` already
+  re-derives `role_fingerprint` for the whole catalogue; the remaining manual-job
+  `content_hash` gap is called out in the design as a follow-up operational step
+  rather than smuggled into a domain change.
+
+No behavior visible on the public wire shape changes. No migration: both columns
+already exist on `jobs`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `job-aggregate`: adds a requirement that the aggregate's write mapping — not the
+  caller — owns every derived column a persisted job carries, so the derived columns
+  cannot be omitted by a write path, and that the mapping hashes the posted time that
+  is actually written.
+
+## Impact
+
+- `internal/job/job.go` — `UpsertParams`, `UpsertManualParams`, new `UpdateManualParams`;
+  the package gains a dependency on `internal/jobhash`.
+- `internal/db/queries/jobs.sql` — `UpsertManualJob` and `UpdateManualJob` column lists;
+  `make sqlc` regenerates `internal/db`.
+- `internal/moderation/repository.go` — `Update` stops hand-building params.
+- `cmd/ingest/store.go`, `cmd/tg-extract/store.go`, `internal/linkimport/linkimport.go` —
+  post-mapping assignments removed; the latter two pass `PostedAt` through the draft.
+- Downstream, already-specified behavior that starts working for manual jobs:
+  role clustering / repost dedup (`ingest-content-dedup`, `job-reality-signal`) and
+  semantic re-embedding after a moderator edit (`semantic-embedding`). Those specs
+  already require this behavior generally; none of their requirements change.
+- Out of scope: the duplicated `hashParams` remap in `cmd/backfill-descriptions` and
+  `cmd/backfill-justjoin` (a separate review finding), and `jobhash.Of`'s known
+  omission of `cities` / `english_level` / `is_tech`.

--- a/openspec/changes/job-aggregate-derived-columns/specs/job-aggregate/spec.md
+++ b/openspec/changes/job-aggregate-derived-columns/specs/job-aggregate/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: The aggregate's write mapping owns every derived column
+
+The mapping from a `Job`'s readable projection to its persistence parameters SHALL
+compute every derived column a stored posting carries — the content fingerprint
+(`content_hash`) and the role-identity fingerprint (`role_fingerprint`) — rather than
+documenting that each caller must set them after the mapping returns. A write path
+SHALL NOT be able to persist a posting missing either column by omitting a step.
+
+This SHALL hold for every write path without exception: automated ingest, Telegram
+extraction, URL import, moderator authoring, and moderator editing. The mapping SHALL
+be the only producer of these two columns on the write path, so the same posting
+content yields the same fingerprints regardless of which path wrote it.
+
+Because the content fingerprint covers the source posted time, a caller that supplies
+a posted time outside the deterministic derivation SHALL supply it through the
+aggregate's draft, before the mapping runs — not by overwriting the mapped parameters
+afterwards, which would fingerprint a posted time other than the one written.
+
+#### Scenario: A moderator-authored vacancy carries both derived columns
+
+- **WHEN** a moderator creates a hand-curated vacancy
+- **THEN** the stored row carries a non-empty `role_fingerprint` and a non-empty
+  `content_hash`, so the vacancy clusters against the automated copy of the same role
+  and is eligible for the content-change re-embed
+
+#### Scenario: A moderator edit refreshes the content fingerprint
+
+- **WHEN** a moderator edits the description of a hand-curated vacancy that has
+  already been embedded
+- **THEN** the stored `content_hash` changes to match the edited content, so the
+  semantic index re-embeds the vacancy instead of permanently describing the pre-edit
+  text
+
+#### Scenario: A caller-supplied posted time is inside the fingerprint
+
+- **WHEN** a write path that takes the posted time from its source (Telegram
+  extraction, URL import) persists a posting
+- **THEN** the stored `content_hash` is the fingerprint of the posted time that was
+  written, and re-ingesting the same posting unchanged reports no content change
+
+#### Scenario: Identical content fingerprints identically across write paths
+
+- **WHEN** two write paths persist postings with identical mapped content
+- **THEN** both rows carry the same `content_hash` and the same `role_fingerprint`,
+  because a single mapping computed them

--- a/openspec/changes/job-aggregate-derived-columns/tasks.md
+++ b/openspec/changes/job-aggregate-derived-columns/tasks.md
@@ -1,0 +1,42 @@
+## 1. Route the caller-supplied posted time through the draft
+
+Must land before the mapping computes the content hash, or the two callers below
+would fingerprint a NULL posted time while writing a real one.
+
+- [ ] 1.1 `cmd/tg-extract/store.go`: pass the Telegram post's timestamp through
+  `job.Draft.PostedAt` (converting `pgtype.Timestamptz` → `*time.Time` at the draft
+  boundary) instead of overwriting `params.PostedAt` after `UpsertParams()` returns.
+- [ ] 1.2 `internal/linkimport/linkimport.go`: pass `r.Job.PostedAt` through
+  `job.Draft.PostedAt` instead of overwriting the mapped params.
+
+## 2. The write mapping owns the derived columns
+
+- [ ] 2.1 `internal/job/job.go`: `Fields.UpsertParams` computes `ContentHash`
+  (`jobhash.Of`) and `RoleFingerprint` (`jobhash.RoleFingerprint`) on the params it
+  returns; rewrite the doc comment so it states the mapping owns every derived
+  column instead of instructing callers to set them afterwards.
+- [ ] 2.2 Delete the now-redundant post-mapping assignments in `cmd/ingest/store.go`,
+  `cmd/tg-extract/store.go` and `internal/linkimport/linkimport.go`.
+
+## 3. The moderator create path
+
+- [ ] 3.1 `internal/db/queries/jobs.sql`: add `content_hash` and `role_fingerprint` to
+  `UpsertManualJob`'s insert column list and its `ON CONFLICT DO UPDATE` set; run
+  `make sqlc`.
+- [ ] 3.2 `internal/job/job.go`: `Fields.UpsertManualParams` fills both derived columns
+  by fingerprinting `f.UpsertParams()`, so a manual write and an automated write of the
+  same content produce the same two values.
+
+## 4. The moderator edit path
+
+- [ ] 4.1 `internal/db/queries/jobs.sql`: add `content_hash` and `role_fingerprint` to
+  `UpdateManualJob`'s SET list — the edit is exactly when re-derived content moves the
+  fingerprints; run `make sqlc`.
+- [ ] 4.2 `internal/job/job.go`: add `Fields.UpdateManualParams(slug, actorID)` mirroring
+  `UpsertManualParams`, and have `internal/moderation/repository.go`'s `Update` call it
+  instead of hand-building the `db.UpdateManualJobParams` literal.
+
+## 5. Verification
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green; `openspec validate
+  job-aggregate-derived-columns --strict` passes.

--- a/openspec/changes/job-aggregate-derived-columns/tasks.md
+++ b/openspec/changes/job-aggregate-derived-columns/tasks.md
@@ -11,11 +11,11 @@ would fingerprint a NULL posted time while writing a real one.
 
 ## 2. The write mapping owns the derived columns
 
-- [ ] 2.1 `internal/job/job.go`: `Fields.UpsertParams` computes `ContentHash`
+- [x] 2.1 `internal/job/job.go`: `Fields.UpsertParams` computes `ContentHash`
   (`jobhash.Of`) and `RoleFingerprint` (`jobhash.RoleFingerprint`) on the params it
   returns; rewrite the doc comment so it states the mapping owns every derived
   column instead of instructing callers to set them afterwards.
-- [ ] 2.2 Delete the now-redundant post-mapping assignments in `cmd/ingest/store.go`,
+- [x] 2.2 Delete the now-redundant post-mapping assignments in `cmd/ingest/store.go`,
   `cmd/tg-extract/store.go` and `internal/linkimport/linkimport.go`.
 
 ## 3. The moderator create path

--- a/openspec/changes/job-aggregate-derived-columns/tasks.md
+++ b/openspec/changes/job-aggregate-derived-columns/tasks.md
@@ -3,10 +3,10 @@
 Must land before the mapping computes the content hash, or the two callers below
 would fingerprint a NULL posted time while writing a real one.
 
-- [ ] 1.1 `cmd/tg-extract/store.go`: pass the Telegram post's timestamp through
+- [x] 1.1 `cmd/tg-extract/store.go`: pass the Telegram post's timestamp through
   `job.Draft.PostedAt` (converting `pgtype.Timestamptz` → `*time.Time` at the draft
   boundary) instead of overwriting `params.PostedAt` after `UpsertParams()` returns.
-- [ ] 1.2 `internal/linkimport/linkimport.go`: pass `r.Job.PostedAt` through
+- [x] 1.2 `internal/linkimport/linkimport.go`: pass `r.Job.PostedAt` through
   `job.Draft.PostedAt` instead of overwriting the mapped params.
 
 ## 2. The write mapping owns the derived columns

--- a/openspec/changes/job-aggregate-derived-columns/tasks.md
+++ b/openspec/changes/job-aggregate-derived-columns/tasks.md
@@ -20,10 +20,10 @@ would fingerprint a NULL posted time while writing a real one.
 
 ## 3. The moderator create path
 
-- [ ] 3.1 `internal/db/queries/jobs.sql`: add `content_hash` and `role_fingerprint` to
+- [x] 3.1 `internal/db/queries/jobs.sql`: add `content_hash` and `role_fingerprint` to
   `UpsertManualJob`'s insert column list and its `ON CONFLICT DO UPDATE` set; run
   `make sqlc`.
-- [ ] 3.2 `internal/job/job.go`: `Fields.UpsertManualParams` fills both derived columns
+- [x] 3.2 `internal/job/job.go`: `Fields.UpsertManualParams` fills both derived columns
   by fingerprinting `f.UpsertParams()`, so a manual write and an automated write of the
   same content produce the same two values.
 

--- a/openspec/changes/job-aggregate-derived-columns/tasks.md
+++ b/openspec/changes/job-aggregate-derived-columns/tasks.md
@@ -29,10 +29,10 @@ would fingerprint a NULL posted time while writing a real one.
 
 ## 4. The moderator edit path
 
-- [ ] 4.1 `internal/db/queries/jobs.sql`: add `content_hash` and `role_fingerprint` to
+- [x] 4.1 `internal/db/queries/jobs.sql`: add `content_hash` and `role_fingerprint` to
   `UpdateManualJob`'s SET list — the edit is exactly when re-derived content moves the
   fingerprints; run `make sqlc`.
-- [ ] 4.2 `internal/job/job.go`: add `Fields.UpdateManualParams(slug, actorID)` mirroring
+- [x] 4.2 `internal/job/job.go`: add `Fields.UpdateManualParams(slug, actorID)` mirroring
   `UpsertManualParams`, and have `internal/moderation/repository.go`'s `Update` call it
   instead of hand-building the `db.UpdateManualJobParams` literal.
 

--- a/openspec/changes/job-aggregate-derived-columns/tasks.md
+++ b/openspec/changes/job-aggregate-derived-columns/tasks.md
@@ -38,5 +38,5 @@ would fingerprint a NULL posted time while writing a real one.
 
 ## 5. Verification
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green; `openspec validate
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` green; `openspec validate
   job-aggregate-derived-columns --strict` passes.


### PR DESCRIPTION
Architecture review 2026-08-01, finding **S4** (`docs/reviews/2026-08-01-architecture-review.md`).
OpenSpec change: `job-aggregate-derived-columns` (8/8 tasks).

## The problem

"What columns a persisted job must carry" was split between the aggregate and two
derived columns every caller was told, in a doc comment, to bolt on afterwards:

> columns a caller derives separately (ContentHash, RoleFingerprint, …) are set on the
> returned struct after this call — `internal/job/job.go:168`

Four of the five write paths got it wrong.

| Write path | `content_hash` | `role_fingerprint` |
|---|---|---|
| `cmd/ingest` | set | set |
| `cmd/tg-extract` | **NULL** | set |
| `internal/linkimport` | **NULL** | set |
| moderator create (`UpsertManualJob`) | **not a column** | **not a column** |
| moderator edit (`UpdateManualJob`) | **not a column** | **not a column** |

Consequences, all live:

- A moderator- or submission-authored vacancy landed with `role_fingerprint` NULL.
  `RoleClusterCount` filters `role_fingerprint <> ''`, so it could never dedup against
  the ATS copy of the same role — exactly what a crowdsourced submission creates.
- It also landed with `content_hash` NULL, and the re-embed trigger is
  `semantic_embedded_hash IS DISTINCT FROM content_hash`. `NULL IS DISTINCT FROM NULL`
  is false, so after the first embed a moderator's description edit never refreshed the
  vector. The rule justifying the NULL stamp (`match_analysis.go:381-387`: "a non-board
  job with no content_hash is never re-crawled, so its text is stable") is falsified by
  `UpdateManualJob`, which exists to edit exactly those jobs.
- Wider than the finding stated: `cmd/tg-extract` and `internal/linkimport` were also
  writing `content_hash` NULL, so the upsert's `changed` signal — what drives incremental
  search indexing — was dead for both sources.

## The change

- `Fields.UpsertParams` computes both columns; the three automated paths drop their
  post-mapping assignments. `internal/jobhash` is no longer imported by any write path.
- Ordering prerequisite: `jobhash.Of` hashes `posted_at`, and `cmd/tg-extract` /
  `internal/linkimport` overwrote `params.PostedAt` *after* the mapping. Both now pass it
  through the `job.Draft.PostedAt` field that already existed for the purpose, so the hash
  covers the posted time actually written.
- `content_hash` + `role_fingerprint` added to `UpsertManualJob` and `UpdateManualJob`.
- `Fields.UpdateManualParams` joins the other two mappings; `internal/moderation` stops
  hand-building a fifth copy of the column list. The aggregate is now the only place
  either manual params struct is built.

`UpsertManualParams`/`UpdateManualParams` take the fingerprints from `UpsertParams` rather
than recomputing, so a hand-curated posting and a crawled one fingerprint identically for
identical content — which is what lets the two cluster as one role.

## Not in scope

The duplicated `hashParams` remap in `cmd/backfill-descriptions` / `cmd/backfill-justjoin`
(review finding S14), and `jobhash.Of`'s known omission of `cities`/`english_level`/`is_tech`
— changing the hash input would invalidate every stored `content_hash` at once.

## Deploy

No migration: both columns already exist on `jobs`. Deploy order unconstrained.

One-time effect on the first crawl after deploy: Telegram and link-imported rows written
before this change carry `content_hash` NULL, and `NULL IS DISTINCT FROM <value>` is true,
so their next re-ingest reports `changed` and pushes them to the live index once. Bounded,
self-limiting, and it is the change signal starting to work where it never had.

Legacy manual rows keep `content_hash` NULL until edited or re-created; `role_fingerprint`
is already covered by the next `cmd/backfill-derive` run, which pages the table unfiltered.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` green.
- `go test -tags=integration` green for `internal/db`, `internal/linkimport`, `cmd/ingest`,
  and `internal/handler`'s moderator end-to-end suite.
- The new end-to-end assertions were proved to fail: nulling the mapping makes both
  subtests fail with the NULL-column messages.