### PR TITLE
docs: document the product half of freehire

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **3.3M+ live postings pulled directly from company career pages — no recruiters, no reposts, no dead links. Fully open source.**
 
-[**Try it live →**](https://freehire.me) · [Sources](#sources) · [API](#api) · [Add a source](#adding-a-source) · [Contributing](CONTRIBUTING.md)
+[**Try it live →**](https://freehire.me) · [Features](docs/features.md) · [Sources](#sources) · [API](#api) · [Add a source](#adding-a-source) · [Contributing](CONTRIBUTING.md)
 
 [![Live](https://img.shields.io/badge/live-freehire.me-0a0a0a)](https://freehire.me)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -38,8 +38,9 @@
   seniority, skills and salary — derived from curated dictionaries, never guessed.
 - **Actually open.** MIT-licensed and self-hostable, pipeline and data both in the
   open. Adding a company is one line of YAML.
-- **Yours to build on.** A clean HTTP API, a CLI, Telegram digests, and per-user
-  application tracking — use the hosted site, run your own, or build on top.
+- **Yours to build on.** A clean HTTP API, a CLI, Telegram digests, and a whole
+  workspace on top of the catalogue — see [Beyond the catalogue](#beyond-the-catalogue).
+  Use the hosted site, run your own, or build on top.
 
 Aggregating **3.3M+ live postings** from **205,000+ companies** across **80+ ATS
 platforms** and a long tail of aggregators and direct feeds — see
@@ -47,6 +48,23 @@ platforms** and a long tail of aggregators and direct feeds — see
 
 > If freehire saves you time — or you just like the idea of jobs straight from the
 > source — a ⭐ helps other people find it.
+
+## Beyond the catalogue
+
+Finding the posting is half the problem. The other half — writing the CV,
+sending it, and knowing what happened to it — is built on the same data, in the
+same repository, under the same licence.
+
+| | |
+| --- | --- |
+| **Find** | Faceted search, curated collections, saved searches with email/Telegram digests, shared boards, market analytics, the ghost-job signal |
+| **Apply** | CV builder with ATS-safe PDF templates, deterministic CV↔vacancy scoring, AI fit analysis, CV tailoring that invents nothing, tracer links, referrals |
+| **Track** | An application board with stages, a mail inbox that links recruiter replies to the application they answer, an append-only event ledger, reminders |
+| **Ask** | An in-process agent with five presets — chat, browse, profile, CV tailoring, interview rehearsal — with no shell and no minted credential |
+| **Build on** | A keyless public API, a CLI, a form-filling browser extension, ChatGPT Actions |
+
+**[Full feature reference → `docs/features.md`](docs/features.md)** — what each one
+does, where it lives in the tree, and which need an LLM endpoint configured.
 
 ## Stack
 
@@ -134,6 +152,11 @@ internal/
   location/          geography parsed from free-text ATS location strings
   jobview/           the single public wire shape of a job
   normalize/         slug normalization
+  cv/ cvedit/        structured CVs + PDF rendering; cvedit is their only writer
+  experience/        durable employments + evidence atoms behind every CV claim
+  userjob/           per-user job tracking (view / apply / save / stages)
+  inbox/             recruiter mail → classify → link to an application
+  assistant/         the in-process agent: turn loop, tools, transcripts
 migrations/          SQL schema (source for both sqlc and initdb)
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ same repository, under the same licence.
 | **Build on** | A keyless public API, a CLI, a form-filling browser extension, ChatGPT Actions |
 
 **[Full feature reference → `docs/features.md`](docs/features.md)** — what each one
-does, where it lives in the tree, and which need an LLM endpoint configured.
+does, where it lives in the tree, which need an LLM endpoint configured, and
+which draw on AI credits.
 
 ## Stack
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,198 @@
+# Features
+
+The [README](../README.md) covers how postings get *in* — the crawlers, the
+dedup, the normalization. This covers what is built on top of the catalogue:
+finding a role, applying to it, and tracking what happens next.
+
+Two markers appear below. **needs `LLM_*`** means the feature calls an
+OpenAI-compatible endpoint and stays disabled in a self-host that has not
+configured one, the same way OAuth sign-in stays disabled without provider
+credentials. **costs AI credits** means it draws on a per-user points balance —
+granted monthly, use-it-or-lose-it, debited per action, and earned back by
+contributing a board; an exhausted balance is refused with HTTP 402 rather than
+degrading into a worse answer. Everything listed is reachable in production
+today; nothing is behind a rollout flag.
+
+## Find
+
+### Faceted search
+
+Full-text search over the catalogue, narrowed by region, work mode, seniority,
+specialization, skills and salary. Every facet comes from a curated dictionary
+rather than from a model guess: an unrecognised value produces no tag at all
+instead of a plausible wrong one. The trade is deliberate — what a filter returns
+is right, at the cost of a posting phrasing something unusually falling outside
+it — and it is why the dictionaries are worth contributing to.
+
+**Live:** /jobs · **Code:** `internal/search`, `internal/skilltag`, `internal/classify`, `internal/location` · **Deep dive:** [internal/search/AGENTS.md](../internal/search/AGENTS.md)
+
+### Collections and role landings
+
+Curated entry points into the catalogue — a stack, a role family, a hiring
+profile — each a real filtered view rather than a static page, so a collection
+never goes stale against the index behind it.
+
+**Live:** /collections · **Code:** `web/src/lib/collections.ts` (the definitions), `internal/roletag`, `internal/search` (the scoped feed)
+
+### Saved searches, shared boards and digests
+
+A search can be saved, subscribed to, and shared. A subscription mails or
+Telegrams a digest of what is new since the last one; a shared board is a
+link-addressed, unindexed view of a saved search that you can hand to someone
+else.
+
+**Live:** /my/searches, /b/<slug> · **Code:** `internal/savedsearch`, `internal/subscription`, `internal/notify`, `internal/telegramnotify` · **Deep dive:** [docs/agents/notifications.md](agents/notifications.md)
+
+### Market analytics
+
+Aggregates over the whole catalogue rather than over one search: which skills
+are gaining postings, what a role pays by region, which companies are actually
+hiring. Built from periodic rollups, so the pages stay fast at catalogue scale.
+
+**Live:** /insights, /trends · **Code:** `internal/facetsnapshot`, `cmd/rollup-facets`, `cmd/rollup-stats`
+
+### The ghost-job signal
+
+Some postings stay open without being filled. freehire flags the behaviour it
+can observe — repost patterns, age, how a posting moves — and carries the
+evidence alongside the flag. When there is nothing to say it says nothing: this
+is a signal with its workings shown, never a verdict about an employer.
+
+**Live:** /features/ghost-jobs · **Code:** `internal/ghost`, `internal/jobreality`, `internal/ghostreport`
+
+## Apply
+
+### CV builder
+
+Structured CVs rendered to PDF through Typst templates, each marked for whether
+it survives an ATS parser and whether it prints a headshot. Editing is
+revisioned and undoable. Contact details can be masked on a per-CV basis.
+
+**Live:** /my/cvs · **Code:** `internal/cv`, `internal/cvsection`, `internal/headshot`, `internal/pii` · **Deep dive:** [internal/cv/AGENTS.md](../internal/cv/AGENTS.md)
+
+### Match score and fit analysis
+
+Two layers against one vacancy. The deterministic score compares your CV to the
+posting's requirements and refuses to credit anything it cannot verify from the
+CV. On top of it, an optional LLM pass argues the fit in three stages and
+streams its verdict as it goes.
+
+The score itself is free; the analysis on top of it is metered.
+
+**Live:** /match/<slug> · **Code:** `internal/cvmatch`, `internal/jobmatch`, `internal/matchanalysis`, `internal/hardconstraint` · **Deep dive:** [internal/cvmatch/AGENTS.md](../internal/cvmatch/AGENTS.md) — the analysis needs `LLM_*` and costs AI credits
+
+### CV tailoring
+
+Rewrites one CV against one vacancy, requirement by requirement, and invents
+nothing: every edit must be backed by an atom in the experience bank, and that
+check lives in the service path rather than in a prompt. Autopilot walks the
+whole vacancy in a single pass and snapshots the CV first, so the run is
+undoable.
+
+**Live:** /tailor/<slug> · **Code:** `internal/cvedit`, `internal/assistant`, `internal/credits` · **Deep dive:** [internal/cvedit/AGENTS.md](../internal/cvedit/AGENTS.md) — needs `LLM_*` and costs AI credits
+
+### The experience bank
+
+Durable employments plus the evidence atoms under them, each recording who
+asserted it — you, or the model. Only what you asserted may be written into a
+CV, which is what makes tailoring safe to run unattended.
+
+**Live:** /my/profile · **Code:** `internal/experience`, `internal/resumeextract` · **Deep dive:** [internal/experience/AGENTS.md](../internal/experience/AGENTS.md)
+
+### Tracer links
+
+Opt-in link tracing swaps the *target* of the links your CV prints while leaving
+the text you wrote intact, so you learn that a PDF was opened and which link was
+followed. Consent is per-CV and off until you say otherwise. A deployment with no
+visitor salt configured refuses to turn it *on* — recording less while accepting
+the consent would answer a question you did not ask — but withdrawing consent is
+never refused.
+
+**Live:** /my/cvs/<id>, server:/cv/:token · **Code:** `internal/tracerlink`
+
+### Referrals
+
+A warm intro beats a cold apply. Members already inside a company can offer
+referrals, and an opening can be matched to someone able to make one.
+
+**Live:** /referrals · **Code:** `internal/referral`
+
+## Track
+
+### The application board
+
+Every job you view, save, apply to or track lands on a board with stages you
+move it through. An application is a durable record of its own: when a posting is
+hard-deleted, `cmd/prune` clears the reference and leaves the application
+standing, so applying to a role that later vanishes still leaves you a history.
+(Plain views and saves are tied to the posting and go with it.)
+
+**Live:** /my/tracking · **Code:** `internal/jobtracking`, `internal/userjob` · **Deep dive:** [internal/userjob/AGENTS.md](../internal/userjob/AGENTS.md)
+
+### The mail inbox
+
+Connect Gmail or use a hosted address, and recruiter replies are classified,
+linked to the application they answer, and advance its stage on their own.
+Mislinked mail can be relinked by hand, and that undone.
+
+**Live:** /my/inbox · **Code:** `internal/inbox`, `internal/mailingest`, `internal/mailclassify`, `internal/maillink`, `internal/gmailsync`, `internal/mailbox` · **Deep dive:** [docs/agents/mail-stack.md](agents/mail-stack.md)
+
+### The event ledger and reminders
+
+One append-only history of what happened to each application — sent, answered,
+advanced, gone quiet — and reminders when a saved job is about to age out or an
+application has been silent too long. Notifications go to email or Telegram.
+
+**Live:** /my/activity · **Code:** `internal/appevent`, `internal/reminder`, `internal/emailnotify` · **Deep dive:** [docs/agents/notifications.md](agents/notifications.md)
+
+## Ask
+
+### The in-app assistant
+
+A tool-calling agent that runs inside the API process, streamed over SSE, open to
+every signed-in user. There is no shell and no minted credential: a tool receives
+the session owner's id and calls a Go service directly, so anything the agent
+must not reach is simply a tool that does not exist. Five presets shape one loop
+— general chat, browsing the catalogue, filling out your profile, tailoring a
+CV, and interview rehearsal. The composer takes dictation as well as typing.
+
+**Live:** /my/assistant/<id> · **Code:** `internal/assistant`, `internal/speech` · **Deep dive:** [internal/assistant/AGENTS.md](../internal/assistant/AGENTS.md) — needs `LLM_*`
+
+### Interview rehearsal
+
+The `interview` preset runs a mock interview against one specific vacancy,
+drawing its questions from the gap between that posting's requirements and what
+your experience bank already holds — and from the employer's own invitation when
+it is sitting in your inbox. A rehearsal binds to a vacancy you have actually
+applied to, and the server verifies that binding rather than taking the client's
+word for it.
+
+**Live:** /my/assistant/<id> · **Code:** `internal/assistant`, `internal/experience` — needs `LLM_*`
+
+## Build on it
+
+### The public API
+
+The catalogue is served over a keyless HTTP API — no credential, no quota
+handshake. Per-user surfaces authenticate with a session cookie or an API key,
+and the split is deliberate: the CV builder, the inbox and subscriptions are
+cookie-only, so a leaked key cannot act on them.
+
+**Live:** /docs/api · **Code:** `internal/handler`, `internal/auth` · **Deep dive:** [internal/handler/AGENTS.md](../internal/handler/AGENTS.md)
+
+### CLI, browser extension and ChatGPT Actions
+
+The same API drives a CLI, a browser extension that autofills application forms
+from your canonical profile, and a ChatGPT Actions manifest. The extension can
+also hand its browser to an agent over a relay that routes strictly within one
+user's channel.
+
+**Live:** /cli, /chatgpt · **Code:** `internal/browsertools`, `internal/autofillagent` · **Deep dive:** [internal/browsertools/AGENTS.md](../internal/browsertools/AGENTS.md)
+
+### Contributing a board or a posting
+
+Paste a careers URL and freehire works out which ATS it runs on and whether that
+board is already covered; a single posting can be submitted directly. Both feed
+the same review queue that onboards new sources.
+
+**Live:** /contribute, /submit · **Code:** `internal/contribution`, `internal/submission`, `internal/boardresolve` · **Deep dive:** [internal/contribution/AGENTS.md](../internal/contribution/AGENTS.md)

--- a/docs/superpowers/specs/2026-08-01-readme-product-features-design.md
+++ b/docs/superpowers/specs/2026-08-01-readme-product-features-design.md
@@ -1,0 +1,116 @@
+# README: document the product half
+
+**Date:** 2026-08-01
+**Status:** approved, ready for planning
+
+## Problem
+
+`README.md` describes freehire as a catalogue and an ingest pipeline: Why → Stack
+→ Quick start → Workers → Layout → Sources → Adding a source. Every section
+below "Why freehire?" is about getting postings *in*.
+
+Roughly a third of `internal/` serves what happens *after* a posting is found —
+`cv`, `cvedit`, `cvmatch`, `matchanalysis`, `experience`, `tracerlink`,
+`jobtracking`, `appevent`, `inbox`, `mailingest`, `maillink`, `assistant`,
+`referral`, `ghost`, `subscription`, `savedsearch`. None of it appears in the
+README. A reader learns the project aggregates jobs and nothing about the
+workspace built on top: the application tracker, the mail inbox, CV tailoring,
+tracer-link analytics, the in-app agent, or interview rehearsal.
+
+This costs twice: a visitor underestimates the project, and a contributor sees
+only one seam to contribute to (add a source).
+
+## Decision
+
+Two artefacts, deliberately split by depth.
+
+1. **A short block in `README.md`** — a five-row table keyed by the job-seeker
+   funnel, each row linking into the new document. README stays ~405 lines.
+2. **`docs/features.md`** — a hybrid reference, ~150 lines: what each feature
+   does for a person, plus where it lives in the tree.
+
+Rejected: rewriting the README's positioning (more churn than the gap warrants),
+and a product-only page (would duplicate the `/features/*` landings on the site).
+
+## `README.md` changes
+
+Four edits, all additive:
+
+1. **New section `## Beyond the catalogue`**, placed directly after
+   "Why freehire?" and before "Stack". A table of five rows — Find, Apply,
+   Track, Ask, Build on — one line of features each, with a lead-in sentence and
+   a link to `docs/features.md`.
+2. **Nav line (line 14)** — add `[Features](docs/features.md)` between `Sources`
+   and `API`.
+3. **`## Layout`** — the tree lists only pipeline packages. Add the load-bearing
+   product ones: `cv/`, `cvedit/`, `assistant/`, `inbox/`, `userjob/`,
+   `experience/`.
+4. **"Why freehire?" last bullet** — it already says "per-user application
+   tracking"; widen it to name the workspace and point at the new section.
+
+Untouched: the header, the tagline, the counts, and every source table.
+
+## `docs/features.md` structure
+
+Five sections following the funnel. Per feature: a heading, 2–3 sentences of
+what it does and why it is built that way, then one pointer line.
+
+```
+### CV tailoring
+
+Rewrites one CV against one vacancy, requirement by requirement, and invents
+nothing: every edit must be backed by an atom in the experience bank, and the
+check lives in the service path rather than in a prompt. Autopilot walks the
+whole vacancy in a single pass and snapshots the CV first, so the run is
+undoable.
+
+Live: /tailor/<job> · Code: `internal/cvedit`, `internal/assistant` · Deep dive: [internal/cvedit/AGENTS.md](../internal/cvedit/AGENTS.md)
+```
+
+**Find** — faceted search over the catalogue; collections and role landings;
+saved searches with subscription digests (email + Telegram); market analytics
+(`/insights`, `/trends`); the ghost-job signal.
+
+**Apply** — the CV builder (Typst templates, PDF, previews, headshot); the
+deterministic CV↔vacancy score and the Job Match tab; the LLM fit analysis;
+CV tailoring plus autopilot; the experience bank and its provenance rule;
+tracer links; PII masking; referrals.
+
+**Track** — the application board and its stages; the hosted mail inbox with
+automatic linking of replies to applications; the application event ledger;
+reminders and notification channels.
+
+**Ask** — the in-process assistant: five presets (`chat`, `browse`, `profile`,
+`tailor`, `interview`), the tool contract, dictation, and the fact that tools
+act as the authenticated caller rather than under a minted credential.
+
+**Build on it** — the keyless public API, the CLI, the browser extension,
+ChatGPT Actions, and crowdsourced board contributions.
+
+## Accuracy rules
+
+These bind the implementation:
+
+- **Every link is verified before commit.** Each `internal/*/AGENTS.md` target
+  must exist on disk; each `Live:` path must exist under `web/src/routes`.
+  A README that links into nothing is worse than a README that omits the
+  feature.
+- **LLM-gated features are marked as such.** Tailoring, fit analysis, Telegram
+  extraction and the assistant need `LLM_*` configured and stay disabled in a
+  self-host without it — the README already sets this precedent for OAuth.
+- **The ghost-job signal is described as a signal**, not a verdict.
+- **No feature is listed that is not reachable in production.** Anything found
+  to be behind a flag or unshipped is dropped rather than hedged.
+
+## Out of scope
+
+Screenshots and GIFs per feature; changes to the `/features/*` landing pages on
+the site; any code change; the source tables and their counts.
+
+## Verification
+
+- `docs/features.md` exists, is under ~160 lines, and every one of its links
+  resolves (checked by listing the targets, not by eye).
+- `README.md` renders with the new section and nav link, and stays under 420
+  lines.
+- No file outside `README.md` and `docs/features.md` is modified.

--- a/openspec/changes/document-product-features/.openspec.yaml
+++ b/openspec/changes/document-product-features/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/document-product-features/proposal.md
+++ b/openspec/changes/document-product-features/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+`README.md` describes freehire as a catalogue and an ingest pipeline — every
+section below "Why freehire?" is about getting postings *in*. Roughly a third of
+`internal/` serves what happens *after* a posting is found (`cv`, `cvedit`,
+`cvmatch`, `matchanalysis`, `experience`, `tracerlink`, `jobtracking`,
+`appevent`, `inbox`, `mailingest`, `maillink`, `assistant`, `referral`, `ghost`,
+`subscription`, `savedsearch`), and none of it is mentioned. A visitor
+underestimates the project; a contributor sees only one seam to contribute to.
+
+## What Changes
+
+- **New `docs/features.md`** (~150 lines): a hybrid reference covering every
+  production feature in five funnel sections — Find, Apply, Track, Ask, Build on
+  it. Per feature: 2–3 sentences of what it does and why it is built that way,
+  then one pointer line (`Live:` route · `Code:` packages · `Deep dive:`
+  AGENTS.md).
+- **`README.md`, four additive edits**: a new `## Beyond the catalogue` section
+  after "Why freehire?" (five-row table keyed by the funnel, linking into
+  `docs/features.md`); a `Features` entry in the nav line; the load-bearing
+  product packages added to `## Layout`; the last "Why freehire?" bullet widened
+  to name the workspace.
+- **Accuracy rules bind the write-up**: every `AGENTS.md` target and every
+  `Live:` route is verified against disk before commit; LLM-gated features are
+  marked as needing `LLM_*`; the ghost-job signal is described as a signal, not
+  a verdict; anything not reachable in production is dropped rather than hedged.
+
+No code changes. The header, tagline, catalogue counts and source tables are
+untouched.
+
+## Capabilities
+
+### New Capabilities
+
+(none) — documentation-only change; no new requirement-level behavior.
+
+### Modified Capabilities
+
+(none) — no existing capability's requirements change. Per the repo's convention
+for doc-only and refactor changes, this change carries no spec deltas and is
+archived with `openspec archive <name> --skip-specs -y`.
+
+## Impact
+
+- `README.md` — four additive edits, grows from 390 to roughly 405 lines.
+- `docs/features.md` — new file.
+- No Go, SQL, or web source is touched; no migration, no worker, no endpoint.
+- Risk is broken links: a README pointing at a non-existent `AGENTS.md` or route
+  is worse than one omitting the feature. Verification is a real link check, not
+  a read-through.

--- a/openspec/changes/document-product-features/tasks.md
+++ b/openspec/changes/document-product-features/tasks.md
@@ -1,0 +1,53 @@
+The approved design lives in
+`docs/superpowers/specs/2026-08-01-readme-product-features-design.md`. It is not
+duplicated into `design.md` — one document, one source of truth.
+
+## 1. Inventory and verification harness
+
+- [ ] 1.1 Enumerate every production feature from `web/src/routes`, the handler
+  route registration, and `internal/` — producing, per feature, its live route,
+  its owning packages, and its `AGENTS.md` (if any). Drop anything not reachable
+  in production rather than hedging it.
+- [ ] 1.2 Write the link check as a runnable command: every `Deep dive:` target
+  must exist on disk and every `Live:` route must resolve to a directory under
+  `web/src/routes`. It must fail loudly on a bad path — this is the change's
+  substitute for a test suite.
+
+## 2. docs/features.md
+
+- [ ] 2.1 Write the Find section — faceted search, collections and role
+  landings, saved searches with subscription digests, market analytics, the
+  ghost-job signal (as a signal, not a verdict).
+- [ ] 2.2 Write the Apply section — CV builder and templates, the deterministic
+  CV↔vacancy score and Job Match tab, LLM fit analysis, CV tailoring and
+  autopilot, the experience bank and its provenance rule, tracer links, PII
+  masking, referrals.
+- [ ] 2.3 Write the Track section — the application board and its stages, the
+  hosted mail inbox and automatic reply linking, the application event ledger,
+  reminders and notification channels.
+- [ ] 2.4 Write the Ask section — the in-process assistant, its five presets
+  (`chat`, `browse`, `profile`, `tailor`, `interview`), dictation, and the fact
+  that tools act as the authenticated caller rather than under a minted
+  credential.
+- [ ] 2.5 Write the Build on it section — the keyless public API, the CLI, the
+  browser extension, ChatGPT Actions, crowdsourced board contributions.
+- [ ] 2.6 Mark every LLM-gated feature as requiring `LLM_*`, matching how the
+  README already frames optional OAuth credentials.
+
+## 3. README.md
+
+- [ ] 3.1 Add the `## Beyond the catalogue` section after "Why freehire?" — a
+  five-row table (Find / Apply / Track / Ask / Build on) linking into
+  `docs/features.md`.
+- [ ] 3.2 Add `Features` to the nav line.
+- [ ] 3.3 Add the load-bearing product packages to the `## Layout` tree.
+- [ ] 3.4 Widen the last "Why freehire?" bullet to name the workspace.
+
+## 4. Verify
+
+- [ ] 4.1 Run the link check from 1.2 — zero failures.
+- [ ] 4.2 Confirm the size budget: `docs/features.md` under ~160 lines,
+  `README.md` under 420.
+- [ ] 4.3 Confirm `git diff --stat` touches only `README.md`,
+  `docs/features.md`, and this change's own artifacts.
+- [ ] 4.4 Request code review on the diff; fix Critical and Important findings.

--- a/openspec/changes/document-product-features/tasks.md
+++ b/openspec/changes/document-product-features/tasks.md
@@ -4,50 +4,93 @@ duplicated into `design.md` — one document, one source of truth.
 
 ## 1. Inventory and verification harness
 
-- [ ] 1.1 Enumerate every production feature from `web/src/routes`, the handler
+- [x] 1.1 Enumerate every production feature from `web/src/routes`, the handler
   route registration, and `internal/` — producing, per feature, its live route,
   its owning packages, and its `AGENTS.md` (if any). Drop anything not reachable
   in production rather than hedging it.
-- [ ] 1.2 Write the link check as a runnable command: every `Deep dive:` target
+- [x] 1.2 Write the link check as a runnable command: every `Deep dive:` target
   must exist on disk and every `Live:` route must resolve to a directory under
   `web/src/routes`. It must fail loudly on a bad path — this is the change's
   substitute for a test suite.
 
+  Written as `docs/check-feature-links.sh`, proven against injected faults (a
+  dangling `AGENTS.md` target, a non-existent web route, a non-existent server
+  route — all three caught), then **deleted rather than committed**. No CI
+  workflow runs markdown link checks, so a committed-but-unwired script would
+  rot into false assurance. The seam: if `docs/features.md` starts drifting,
+  wire a link check into `.github/workflows/ci.yml` as its own change.
+
 ## 2. docs/features.md
 
-- [ ] 2.1 Write the Find section — faceted search, collections and role
+- [x] 2.1 Write the Find section — faceted search, collections and role
   landings, saved searches with subscription digests, market analytics, the
   ghost-job signal (as a signal, not a verdict).
-- [ ] 2.2 Write the Apply section — CV builder and templates, the deterministic
+- [x] 2.2 Write the Apply section — CV builder and templates, the deterministic
   CV↔vacancy score and Job Match tab, LLM fit analysis, CV tailoring and
   autopilot, the experience bank and its provenance rule, tracer links, PII
   masking, referrals.
-- [ ] 2.3 Write the Track section — the application board and its stages, the
+- [x] 2.3 Write the Track section — the application board and its stages, the
   hosted mail inbox and automatic reply linking, the application event ledger,
   reminders and notification channels.
-- [ ] 2.4 Write the Ask section — the in-process assistant, its five presets
+- [x] 2.4 Write the Ask section — the in-process assistant, its five presets
   (`chat`, `browse`, `profile`, `tailor`, `interview`), dictation, and the fact
   that tools act as the authenticated caller rather than under a minted
   credential.
-- [ ] 2.5 Write the Build on it section — the keyless public API, the CLI, the
+- [x] 2.5 Write the Build on it section — the keyless public API, the CLI, the
   browser extension, ChatGPT Actions, crowdsourced board contributions.
-- [ ] 2.6 Mark every LLM-gated feature as requiring `LLM_*`, matching how the
+- [x] 2.6 Mark every LLM-gated feature as requiring `LLM_*`, matching how the
   README already frames optional OAuth credentials.
 
 ## 3. README.md
 
-- [ ] 3.1 Add the `## Beyond the catalogue` section after "Why freehire?" — a
+- [x] 3.1 Add the `## Beyond the catalogue` section after "Why freehire?" — a
   five-row table (Find / Apply / Track / Ask / Build on) linking into
   `docs/features.md`.
-- [ ] 3.2 Add `Features` to the nav line.
-- [ ] 3.3 Add the load-bearing product packages to the `## Layout` tree.
-- [ ] 3.4 Widen the last "Why freehire?" bullet to name the workspace.
+- [x] 3.2 Add `Features` to the nav line.
+- [x] 3.3 Add the load-bearing product packages to the `## Layout` tree.
+- [x] 3.4 Widen the last "Why freehire?" bullet to name the workspace.
 
 ## 4. Verify
 
-- [ ] 4.1 Run the link check from 1.2 — zero failures.
-- [ ] 4.2 Confirm the size budget: `docs/features.md` under ~160 lines,
-  `README.md` under 420.
-- [ ] 4.3 Confirm `git diff --stat` touches only `README.md`,
+- [x] 4.1 Run the link check from 1.2 — zero failures.
+- [x] 4.2 Confirm the size budget: `README.md` is 413 lines (under 420, as
+  planned). `docs/features.md` came in at **198 lines against an estimated
+  ~150–160** — 19 features at roughly 10 lines each; 181 before the review, plus
+  17 lines of corrections the review forced (see 4.4). The estimate was a guess
+  made before the inventory ran; the overrun is feature entries and accuracy, not
+  padding, and cutting to hit a number chosen before the content was known would
+  mean deleting true statements. Recorded rather than met.
+- [x] 4.3 Confirm `git diff --stat` touches only `README.md`,
   `docs/features.md`, and this change's own artifacts.
-- [ ] 4.4 Request code review on the diff; fix Critical and Important findings.
+- [x] 4.4 Request code review on the diff; fix Critical and Important findings.
+
+  Reviewed inline rather than by dispatching a reviewer subagent: this session
+  carries a standing instruction not to spawn agents unless asked. The review
+  was a claim-by-claim check of the prose against the code, which is where the
+  risk of a docs change lives. Six findings, all fixed:
+
+  1. **Critical — false claim.** The intro asserted "nothing here is behind a
+     paywall". `credits.FeatureMatch` and `credits.FeatureTailor` are metered,
+     and `cv_tailor.go:71` blocks tailoring on an insufficient balance. Rewritten
+     to describe the monthly points grant and the 402, and both features marked.
+  2. **Important — inverted guarantee.** Faceted search was said to make a
+     filtered list "complete". Dict-only facets buy precision, not recall: an
+     unrecognised term yields no tag, so the posting drops out of the filter. The
+     trade is now stated in the direction it actually runs.
+  3. **Important — overclaim.** "A job being pruned does not erase your
+     application" was true of `applications` (whose `job_id` `cmd/prune` clears)
+     but false of `user_jobs` (`ON DELETE CASCADE`, migrations/0001_init.sql:992).
+     Scoped to applications, with views and saves called out as not surviving.
+  4. **Important — unverified behaviour.** Tracer links were said to invalidate
+     tokens when switched off. The handler shows something different and better:
+     enabling is refused without a visitor salt, disabling never is.
+  5. **Important — unverified behaviour.** Interview rehearsal was said to bank
+     what you say; the preset's only tool reads. Replaced with the verified fact
+     that a rehearsal binds to an application the server checks for itself.
+  6. **Minor — misleading pointers.** Market analytics pointed at
+     `internal/viewlog` (nginx logs → per-job views, not insights) and collections
+     at `internal/collections` (visa-sponsor registry parsing, not the landings).
+     Both repointed at what actually serves the page.
+
+  Re-verified after the fixes: every pointer resolves, and every `internal/`,
+  `cmd/` and `web/` path named in the document exists on disk.


### PR DESCRIPTION
## Why

The README described freehire as a catalogue and an ingest pipeline — every section below "Why freehire?" is about getting postings *in*. Roughly a third of `internal/` serves what happens *after* a posting is found, and none of it was mentioned: the application board, the mail inbox, CV building and tailoring, scoring, tracer links, the in-app agent, interview rehearsal.

## What

- **New `docs/features.md`** (198 lines) — 19 features in five funnel sections (Find / Apply / Track / Ask / Build on it). Each gets 2–3 sentences on what it does and why it is built that way, plus a pointer line: `**Live:** <route> · **Code:** <packages> · **Deep dive:** <AGENTS.md>`.
- **README, four additive edits** — a `## Beyond the catalogue` section after "Why freehire?", `Features` in the nav line, the product packages added to `## Layout`, and the last "Why freehire?" bullet widened. Header, tagline, counts and source tables untouched.

No code changes.

## Accuracy

Every pointer was verified against disk with a fault-injected checker (a dangling `AGENTS.md` target, a bad web route and a bad server route were all caught before the real run). Every `internal/`, `cmd/` and `web/` path named in the document exists.

A claim-by-claim review against the code found six errors in the first draft, all fixed:

1. **Critical** — "nothing here is behind a paywall" was false: `credits.FeatureMatch` and `credits.FeatureTailor` are metered and `cv_tailor.go:71` refuses on an insufficient balance. Now describes the monthly grant and the 402.
2. Dict-only facets were credited with making a filtered list *complete*. They buy precision, not recall — an unrecognised term yields no tag at all. Stated in the direction it runs.
3. "Pruning does not erase your application" held for `applications` but not `user_jobs` (`ON DELETE CASCADE`). Scoped.
4. Tracer links do not invalidate tokens when switched off; enabling is refused without a visitor salt, disabling never is.
5. Interview rehearsal reads the experience bank, it does not write to it.
6. Two code pointers (`internal/viewlog` for market analytics, `internal/collections` for the landings) pointed at packages that serve something else.

## OpenSpec

`openspec/changes/document-product-features` — proposal + tasks, no spec deltas (doc-only, per the repo's convention). Archive with `openspec archive document-product-features --skip-specs -y`.