### PR TITLE
fix(cv): the evidence gate is a constructor argument, not optional wiring

### DIFF
--- a/internal/cvedit/editor.go
+++ b/internal/cvedit/editor.go
@@ -118,18 +118,16 @@ type Editor struct {
 	now    func() time.Time
 }
 
-// NewEditor builds the editor over its repository. The gate may be nil, which means no
-// evidence is required — the CLI and the editor commit as the candidate, who is asserting
-// things about themselves.
+// NewEditor builds the editor over its repository and the gate an agent's claims answer
+// to. The gate is supplied here and nowhere else, so an editor that admits an uncited
+// agent claim cannot be produced by assembling things in the wrong order.
+//
+// A nil gate means CANDIDATE-authored editing only: requireEvidence exempts the candidate,
+// who is the source the bank exists to record. It is what the candidate-only test editors
+// pass, and it is not a configuration an agent write path may be built on.
 func NewEditor(repo Repository, gate EvidenceGate) *Editor {
 	return &Editor{repo: repo, policy: DefaultPolicy(), gate: gate, now: time.Now}
 }
-
-// WithEvidenceGate attaches the bank the agent's claims are checked against. Assigned after
-// construction because the bank is wired later than the CV handlers — the same shape the
-// other late-bound dependencies here use. Without it the agent can write unevidenced claims,
-// so it is a wiring mistake rather than a configuration choice.
-func (e *Editor) WithEvidenceGate(gate EvidenceGate) { e.gate = gate }
 
 // Commit applies a batch and records it. The document and its revision are written in one
 // transaction against a locked row, so a reader never sees one without the other.

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -22,7 +22,6 @@ import (
 	"github.com/strelov1/freehire/internal/browsertools"
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/db"
-	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/llm"
 )
 
@@ -70,9 +69,10 @@ type assistantHandlers struct {
 // unavailable, rather than the whole surface disappearing.
 func newAssistantHandlers(queries *db.Queries, model *llm.Client, maxSteps int,
 	search *searchHandlers, resumeH *resumeHandlers, tracking *trackingHandlers, cvH *cvHandlers,
-	profileH *profileHandlers, browserTools *browsertools.Hub, mail *inboxHandlers) *assistantHandlers {
+	profileH *profileHandlers, browserTools *browsertools.Hub, mail *inboxHandlers,
+	bank experienceBankTools) *assistantHandlers {
 	h := &assistantHandlers{
-		experience:   experience.NewStore(experience.NewQueriesRepository(queries)),
+		experience:   bank,
 		store:        assistant.NewStore(queries),
 		queries:      queries,
 		search:       search,
@@ -89,11 +89,6 @@ func newAssistantHandlers(queries *db.Queries, model *llm.Client, maxSteps int,
 	// would put a second reader outside that rule.
 	if mail != nil {
 		h.invitation = mail.inbox
-	}
-	// The editor refuses an agent's unevidenced claim, and the bank is what answers that
-	// question — it is wired here because this is where the bank comes into existence.
-	if cvH != nil && cvH.editor != nil {
-		cvH.editor.WithEvidenceGate(bankGate{bank: h.experience})
 	}
 	if model != nil {
 		h.runner = assistant.NewRunner(model, h.store, assistant.RunnerConfig{MaxSteps: maxSteps})

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -354,9 +354,6 @@ func cvToolError(err error) error {
 type bankGate struct{ bank experienceBankTools }
 
 func (g bankGate) Publishable(ctx context.Context, userID int64, evidenceID string) error {
-	if g.bank == nil {
-		return nil
-	}
 	id, err := uuid.Parse(evidenceID)
 	if err != nil {
 		return errors.New("evidence_id must be an achievement id from experience_search")

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -95,6 +95,19 @@ func cvToolsAPI(t *testing.T, doc string) (*assistantHandlers, *cvRepo) {
 	return &assistantHandlers{cv: &cvHandlers{cvStore: cv.NewStore(repo), editor: editor}}, repo
 }
 
+// cvToolsAPIWithBank is cvToolsAPI for the cases that exercise the evidence gate. The
+// editor is CONSTRUCTED with the gate, the way the production assembly builds it — the
+// gate is not something a caller can attach to an editor after the fact.
+func cvToolsAPIWithBank(t *testing.T, doc string, bank experienceBankTools) (*assistantHandlers, *cvRepo) {
+	t.Helper()
+	repo := &cvRepo{id: testCVID, userID: 3, jobID: 9, data: []byte(doc)}
+	editor := cvedit.NewEditor(&memRevisions{cv: repo}, bankGate{bank: bank})
+	return &assistantHandlers{
+		experience: bank,
+		cv:         &cvHandlers{cvStore: cv.NewStore(repo), editor: editor},
+	}, repo
+}
+
 // memRevisions is an in-memory cvedit.Repository over the same cvRepo the CV store uses, so
 // a tool test exercises the real editor — policy, evidence gate, apply, coalescing — without
 // a database. Writes land in cvRepo.written, which is what the cases assert on.
@@ -363,10 +376,8 @@ func TestCVEditToolSchemaNamesTheAddressableShapes(t *testing.T) {
 }
 
 func TestCVEditWithoutAnyEvidenceIdNamesWhereItGoes(t *testing.T) {
-	a, _ := cvToolsAPI(t, oneExperienceCV)
 	bank := newStubBank()
-	a.experience = bank
-	a.cv.editor.WithEvidenceGate(bankGate{bank: bank})
+	a, _ := cvToolsAPIWithBank(t, oneExperienceCV, bank)
 
 	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
 	_, err := tool.Run(context.Background(), 3, json.RawMessage(
@@ -380,14 +391,12 @@ func TestCVEditWithoutAnyEvidenceIdNamesWhereItGoes(t *testing.T) {
 }
 
 func TestCVEditWritesACitedBullet(t *testing.T) {
-	a, repo := cvToolsAPI(t, oneExperienceCV)
 	bank := newStubBank()
 	atom := bank.add(3, experience.Atom{
 		Claim:      "Ran the payments Kafka cluster.",
 		Provenance: experience.ProvenanceStatedInChat,
 	})
-	a.experience = bank
-	a.cv.editor.WithEvidenceGate(bankGate{bank: bank})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
 
 	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
 	_, err := tool.Run(context.Background(), 3, json.RawMessage(

--- a/internal/handler/assistant_integration_test.go
+++ b/internal/handler/assistant_integration_test.go
@@ -57,27 +57,28 @@ func (m *turnModel) Chat(_ context.Context, _ []llms.MessageContent, _ []llms.To
 // server runs in production; existing callers pass none and are unaffected.
 func newAssistantApp(pool *pgxpool.Pool, iss *auth.Issuer, model assistant.Model, mws ...fiber.Handler) (*fiber.App, *assistantHandlers) {
 	queries := db.New(pool)
+	bank := experience.NewStore(experience.NewQueriesRepository(queries))
 	h := &assistantHandlers{
 		store: assistant.NewStore(queries), queries: queries,
 		// A rehearsal resolves its application through the same store the production
 		// wiring gives it; without this the ownership check reports the assistant
 		// unavailable and the 404 under test would never be reached.
 		stages: queries,
-		// The evidence gate answers from the bank, and the production wiring attaches it in
-		// newAssistantHandlers. Without it here the run could write an unevidenced claim and
-		// the test that says it cannot would pass for the wrong reason.
-		experience: experience.NewStore(experience.NewQueriesRepository(queries)),
+		// The evidence gate answers from the bank. Without it the run could write an
+		// unevidenced claim and the test that says it cannot would pass for the wrong
+		// reason — which is why the editor below is CONSTRUCTED with it, exactly as the
+		// production assembly does, rather than having it attached afterwards.
+		experience: bank,
 		// The tailoring tools and the autopilot run reach the CV store, so the assistant
 		// under test carries the same CV service the HTTP surface uses.
 		cv: &cvHandlers{
 			cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
-			editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil), queries: queries, jobReader: queries,
+			editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}), queries: queries, jobReader: queries,
 			// The run reads the cached fit analysis to lay down its plan, so the CV handlers
 			// under test carry the same cache the production wiring gives them.
 			matchAnalysisCache: queries,
 		},
 	}
-	h.cv.editor.WithEvidenceGate(bankGate{bank: h.experience})
 	if model != nil {
 		h.runner = assistant.NewRunner(model, h.store, assistant.RunnerConfig{MaxSteps: 3})
 	}

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -75,7 +75,7 @@ type jobReader interface {
 	GetJob(ctx context.Context, id int64) (db.Job, error)
 }
 
-func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, typstBin, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers) *cvHandlers {
+func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, typstBin, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate) *cvHandlers {
 	h := &cvHandlers{
 		cvStore:    cv.NewStore(cv.NewQueriesRepository(queries)),
 		tracerSalt: tracerSalt,
@@ -87,9 +87,12 @@ func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, typstBin, tracerSalt
 				})
 			}), servedHosts),
 		tracerBaseURL: baseURL,
-		// The editor is the only thing that writes a stored CV. The evidence gate is
-		// attached later (withExperienceBank) because the bank is wired after this.
-		editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		// The editor is the only thing that writes a stored CV, and the gate is what
+		// refuses an agent's uncited claim. It is a constructor argument rather than
+		// something attached afterwards: PATCH /me/cvs/:id edits as the agent for any
+		// API-key caller, so the wall cannot depend on which other features the assembly
+		// built.
+		editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), gate),
 		jobReader:          queries,
 		resume:             resumeStore,
 		photos:             photoStore,

--- a/internal/handler/cv_evidence_gate_integration_test.go
+++ b/internal/handler/cv_evidence_gate_integration_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+// The evidence gate must be a property of the editor the CV surface is built with, not
+// of whether some other feature's constructor happened to run. These tests assemble the
+// CV handlers through the production constructor and NOTHING else — no assistant — and
+// then edit as the agent.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/credits"
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/experience"
+	"github.com/strelov1/freehire/internal/headshot"
+	"github.com/strelov1/freehire/internal/resume"
+)
+
+// newCVAPIWithoutAssistant builds the CV handlers the way handler.Register does — through
+// newCVHandlers — and mounts only the CV routes. The assistant is deliberately absent:
+// PATCH /me/cvs/:id edits as the agent for any API-key caller and has nothing to do with
+// the assistant, so it must not depend on the assistant having been built.
+func newCVAPIWithoutAssistant(t *testing.T) (*cvHandlers, *auth.Issuer, *fiber.App, int64) {
+	t.Helper()
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	if _, err := pool.Exec(context.Background(),
+		"TRUNCATE cvs, users, jobs, user_job_analysis, api_keys, assistant_sessions, experience_atoms RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	creditsStore := credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3})
+	bank := experience.NewStore(experience.NewQueriesRepository(queries))
+
+	h := newCVHandlers(pool, queries, "", "test-salt", "https://freehire.test",
+		[]string{"freehire.test"},
+		resume.New(nil, resume.NewQueriesRepository(queries)),
+		headshot.New(nil, headshot.NewQueriesRepository(queries)),
+		creditsStore,
+		&matchHandlers{credits: creditsStore},
+		bankGate{bank: bank},
+	)
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	keyAuth := auth.RequireAuthOrScopedKey(iss, testVersions, apiKeys{h.queries}, auth.ScopeCV)
+	app.Patch("/api/v1/me/cvs/:id", keyAuth, h.PatchCV)
+
+	owner := seedAccount(t, pool, "owner@example.test", true)
+	return h, iss, app, owner
+}
+
+// The honest wall: an API-key caller edits as ActorAgent, so a bullet — a claim about what
+// the candidate did — cannot reach the page without citing banked evidence. Before this
+// was a constructor argument, the same request succeeded whenever the assembly did not
+// also build the assistant, because the editor was created with a nil gate and the gate
+// treated its own absence as permission.
+func TestPatchCVAsAgentIsGatedWithoutTheAssistant(t *testing.T) {
+	h, _, app, owner := newCVAPIWithoutAssistant(t)
+	ctx := context.Background()
+
+	base, err := h.cvStore.Create(ctx, owner, "General", cv.DefaultTemplateID, cv.Document{
+		Header:     cv.Header{FullName: "Ada Lovelace", Email: "ada@x.com"},
+		Experience: []cv.ExperienceItem{{Role: "Eng", Bullets: []string{"Shipped API"}}},
+	})
+	if err != nil {
+		t.Fatalf("create cv: %v", err)
+	}
+	path := "/api/v1/me/cvs/" + base.ID.String()
+	key := cvScopedKey(t, h, owner)
+
+	resp := doBearer(t, app, fiber.MethodPatch, path, key, map[string]any{
+		"ops": []map[string]any{
+			{"kind": "insert", "path": "experience[0].bullets[1]", "value": "Cut latency by 40%"},
+		},
+	})
+	if resp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("uncited agent patch = %d, want 403 — the editor admitted a claim with no evidence", resp.StatusCode)
+	}
+
+	// And it really was refused, not merely reported as refused.
+	rec, err := h.cvStore.Get(ctx, base.ID, owner)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if got := rec.Document.Experience[0].Bullets; len(got) != 1 {
+		t.Errorf("bullets = %v, want the original one only", got)
+	}
+}
+
+// The rule exempts the candidate: they are the source the bank exists to record, so their
+// own edit needs no citation. The same editor serves both actors, which is why the gate
+// being present cannot be allowed to break candidate editing.
+func TestPatchCVAsCandidateNeedsNoEvidence(t *testing.T) {
+	h, iss, app, owner := newCVAPIWithoutAssistant(t)
+	ctx := context.Background()
+
+	base, err := h.cvStore.Create(ctx, owner, "General", cv.DefaultTemplateID, cv.Document{
+		Experience: []cv.ExperienceItem{{Role: "Eng", Bullets: []string{"Shipped API"}}},
+	})
+	if err != nil {
+		t.Fatalf("create cv: %v", err)
+	}
+	token, _ := iss.Issue(owner, testTokenVersion)
+	body, _ := json.Marshal(map[string]any{
+		"ops": []map[string]any{
+			{"kind": "insert", "path": "experience[0].bullets[1]", "value": "Cut latency by 40%"},
+		},
+	})
+	req := httptest.NewRequest(fiber.MethodPatch, "/api/v1/me/cvs/"+base.ID.String(), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("candidate patch = %d, want 200", resp.StatusCode)
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -263,7 +263,11 @@ func Register(app *fiber.App, cfg Config) {
 	// The profile read serves the structured résumé beside the profile, so it needs the
 	// résumé store — hence constructed after it.
 	profileH := newProfileHandlers(profileSvc, resumeStore, newCandidateProfiler(queries))
-	experienceH := newExperienceHandlers(experience.NewStore(experience.NewQueriesRepository(queries)))
+	// One bank for the whole surface. It is stateless over the shared queries, but the
+	// single value is what keeps the evidence gate from being anyone's to attach later:
+	// the CV editor is constructed with it below, not handed it by the assistant.
+	bank := experience.NewStore(experience.NewQueriesRepository(queries))
+	experienceH := newExperienceHandlers(bank)
 	// Nil-safe: NewAnalyzer(nil) is a no-op analyzer, so the ATS report works whether
 	// or not the LLM is configured.
 	atsAnalyzer := atscheck.NewAnalyzer(cfg.LLM)
@@ -286,7 +290,7 @@ func Register(app *fiber.App, cfg Config) {
 	contributionsH := newContributionHandlers(contributionSvc, creditsStore, queries, importer)
 	creditsH := newCreditsHandlers(creditsStore, queries)
 	matchH := newMatchHandlers(queries, profileSvc, resumeStore, matchAnalyzer, creditsStore)
-	cvH := newCVHandlers(cfg.Pool, queries, cfg.TypstBin, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH)
+	cvH := newCVHandlers(cfg.Pool, queries, cfg.TypstBin, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank})
 	telegramH := newTelegramHandlers(queries, cfg.JWTSecret, cfg.TelegramBotToken, cfg.TelegramBotUsername, cfg.TelegramWebhookSecret, cfg.FrontendOrigin, contributionsH.intake)
 	inboxH := newInboxHandlers(queries, cfg.Pool, cfg.GmailConnector, cfg.GmailCipher, cfg.FrontendOrigin, cfg.CookieSecure, cfg.MailboxDomain)
 	// Account deletion reaches past the FK cascade: cfg.Blob is nil when storage is
@@ -321,7 +325,7 @@ func Register(app *fiber.App, cfg Config) {
 	// disagree. The tailoring bootstrap mints its conversations through the same
 	// store, which is why the CV handlers get it back. It also takes the browser-tool
 	// hub, which a browsing session reads the caller's open page through.
-	assistantH := newAssistantHandlers(queries, cfg.AssistantLLM, cfg.AssistantMaxSteps, searchH, resumeH, trackingH, cvH, profileH, a.browserTools, inboxH)
+	assistantH := newAssistantHandlers(queries, cfg.AssistantLLM, cfg.AssistantMaxSteps, searchH, resumeH, trackingH, cvH, profileH, a.browserTools, inboxH, bank)
 	cvH.withAssistantSessions(assistantH.store)
 	// Suggestions run on LLM (cheap, one-shot) rather than on AssistantLLM: the whole
 	// argument for generating them outside the turn is that they cost almost nothing.

--- a/openspec/changes/evidence-gate-by-construction/.openspec.yaml
+++ b/openspec/changes/evidence-gate-by-construction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/evidence-gate-by-construction/design.md
+++ b/openspec/changes/evidence-gate-by-construction/design.md
@@ -1,0 +1,121 @@
+## Context
+
+`internal/cvedit` is the only writer of a stored CV, and its `requireEvidence` is the
+service-path enforcement of the tailoring capability's central rule. The enforcement is
+correct. The *wiring* of the collaborator it needs is not:
+
+```
+internal/handler/cv.go:92        cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil)
+internal/handler/assistant.go:96 if cvH != nil && cvH.editor != nil { cvH.editor.WithEvidenceGate(bankGate{...}) }
+internal/handler/cv_tailor.go:241 actor = cvedit.ActorAgent   // for any API-key caller
+```
+
+The gate is created nil, attached later, by a different feature's constructor, behind two
+nil guards. `internal/cvedit/editor.go` justifies the mutator with "the bank is wired
+later than the CV handlers" — but `handler.go:266` already builds an equivalent
+`experience.Store` twenty-three lines before `newCVHandlers` at `:289`, and the store is
+stateless. The justification is simply stale.
+
+There are two independent fail-opens on the same rule:
+
+| Site | Guard | Reachable in production? |
+|---|---|---|
+| `internal/cvedit/policy.go:157` | `if e.gate == nil { return nil }` | No — production attaches a gate |
+| `internal/handler/assistant_cv_tools.go:356` | `if g.bank == nil { return nil }` | No — `g.bank` is always `experience.NewStore` |
+
+Neither fires today. Both exist so that a wiring mistake reads as a permission.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the gate a value the editor is constructed with, so an editor that admits an
+  agent's uncited claim cannot be assembled.
+- Remove the fail-open that has no legitimate use (`bankGate` with no bank).
+- Delete the post-construction mutator, so `newAssistantHandlers` stops reaching into a
+  struct it was handed.
+
+**Non-Goals:**
+
+- Making `NewEditor` reject a nil gate, or introducing a `cvedit.NoGate{}` type.
+  `requireEvidence` returns early for `ActorCandidate`, so a nil gate is legitimate for
+  candidate-only editors; eleven test editors construct one, and stubbing all of them buys
+  no invariant.
+- Changing *what* the rule is, which paths it gates, or its messages. This change moves
+  where the dependency is supplied, nothing else.
+- Reconciling the three test fixtures that exercise the agent write path with a nil gate
+  (see the proposal). They bypass `newCVHandlers` with a struct literal, so this change
+  neither fixes nor breaks them; the reconciliation is a product question of its own.
+
+## Decisions
+
+### D1: `newCVHandlers` takes a `cvedit.EvidenceGate`, not the bank
+
+The narrower type states exactly what the CV handlers need — an answer to "may this be
+published?" — rather than handing them a whole experience bank they would only use to
+build one. The assembly in `handler.go` constructs `bankGate{bank: bank}`, which is where
+a composition decision belongs.
+
+*Alternative considered:* pass `experienceBankTools` and let `newCVHandlers` wrap it.
+Rejected — it widens the CV handlers' dependency to six bank methods to use one, and
+`bankGate` is already the adapter for exactly this.
+
+### D2: The bank is hoisted once and threaded to its three consumers
+
+`experience.NewStore(experience.NewQueriesRepository(queries))` is currently built twice
+(`handler.go:266` for the experience handlers, `assistant.go:75` for the assistant) and
+would be built a third time for the gate. The store is stateless, so the duplication is
+harmless in behaviour — but "the assistant owns the bank" is precisely the belief that put
+the gate's wiring inside `newAssistantHandlers`. Hoisting it to the assembly removes the
+belief along with the mutator.
+
+### D3: `requireEvidence`'s nil-gate short-circuit stays; `bankGate`'s does not
+
+They look like the same guard and are not. A nil *gate* means "this editor was built for
+candidate-authored editing", which is a real configuration with eleven users in the test
+suite. A `bankGate` with a nil *bank* means "an adapter was built around nothing" — there
+is no configuration that wants it, and the field is never nil in production.
+
+Deleting the first one would also be actively worse than it looks: with `if e.gate == nil`
+removed, the very next statement to run for an agent write is `e.gate.Publishable(...)`,
+so a candidate-only editor handed an agent change would panic rather than refuse. Fixing
+that properly means fail-closed, which means the three agent-path fixtures must first be
+given real gates — out of scope here by decision.
+
+### D4: The mutator is deleted, not deprecated
+
+`WithEvidenceGate` has exactly two callers: the production wiring being replaced, and one
+test harness that re-does that wiring by hand. Both move to the constructor in the same
+diff, so there is nothing to deprecate for.
+
+## Risks / Trade-offs
+
+**`newCVHandlers` gains an eleventh parameter.** → It gains the one dependency that is
+security-relevant, and loses a mutator that made the dependency invisible. The alternative
+— a config struct for the CV handlers — is a larger refactor than this finding warrants
+and would obscure the very argument being made explicit.
+
+**A future assembly could still pass a nil gate to `newCVHandlers`.** → True, and
+deliberately not defended against: `NewEditor` keeps accepting nil for candidate-only
+editors, so nil remains expressible. What changes is that the value must now be supplied
+at the one call site that builds the production editor, where its absence is visible in
+the same expression, rather than depending on a later mutator in another feature's
+constructor.
+
+**Collapsing three `experience.NewStore` constructions could couple otherwise independent
+handlers.** → The store is stateless and holds only a repository over the shared
+`*db.Queries`; sharing one value is equivalent to sharing three identical ones.
+
+## Migration Plan
+
+None. No schema, no API, no wire shape, no behaviour change in production — the gate is
+attached today and stays attached, from a different line. Rollback is a plain revert.
+
+## Open Questions
+
+Must an API-key caller editing `PATCH /me/cvs/:id` as `ActorAgent` cite banked evidence?
+Production says yes (the gate is attached). `cv_tailor_integration_test.go:276` records a
+comment saying the CLI is "not a place to enforce provenance it cannot query", and its
+fixture wires no gate. The two disagree. This change does not resolve it — it makes
+production's answer unambiguous and leaves the fixture untouched — and the disagreement is
+recorded as its own finding in the architecture review.

--- a/openspec/changes/evidence-gate-by-construction/proposal.md
+++ b/openspec/changes/evidence-gate-by-construction/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+The evidence gate is the rule the whole tailoring capability exists to keep: a sentence
+about what the candidate did cannot reach the page unless it traces to something *they*
+asserted. `internal/cvedit` deliberately enforces it in the service path rather than in a
+system prompt, "because a rule that lives only in a prompt is one a long conversation
+eventually loses."
+
+The rule is enforced in the right place and wired correctly today. What is wrong is that
+the type system models the dependency as *optional*:
+
+- `internal/handler/cv.go:92` builds the editor every CV write goes through with an
+  explicitly nil gate: `cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil)`.
+- The only production attachment is a post-construction mutator, and it lives inside a
+  different feature's constructor — `internal/handler/assistant.go:96`:
+  `if cvH != nil && cvH.editor != nil { cvH.editor.WithEvidenceGate(...) }`.
+- `PATCH /me/cvs/:id` sets `ActorAgent` for any API-key caller
+  (`internal/handler/cv_tailor.go:241`). That write path has nothing to do with the
+  assistant, yet it depends on the assistant's constructor having run.
+
+So reordering handler assembly — or building the CV handlers in any context that does not
+also build the assistant — silently disables the wall, with no compile error and no test
+failure. The stated reason for the late binding is also false: `internal/cvedit/editor.go`
+says "the bank is wired later than the CV handlers", but an equivalent, stateless
+`experience.Store` is already constructed at `internal/handler/handler.go:266`,
+twenty-three lines before `newCVHandlers` at `:289`.
+
+Nothing is broken in production today. This is a latent fail-open, and the fix is to make
+the dependency non-optional at the one place it is created.
+
+## What Changes
+
+- The experience bank is hoisted to a single variable in `handler.go` before the CV
+  handlers are built, and passed into `newCVHandlers`; the editor is constructed with its
+  real gate at `cv.go:92`. The bank is stateless, so the two existing constructions
+  (`handler.go:266` for the experience handlers, `assistant.go:75` for the assistant)
+  collapse onto the hoisted one.
+- `Editor.WithEvidenceGate` is deleted. The gate becomes what it already was in
+  substance — a constructor argument — and `assistant.go` stops mutating a struct it was
+  merely handed.
+- `bankGate.Publishable`'s `if g.bank == nil { return nil }` is deleted: a second,
+  independent fail-open on the same rule, on a field that is never nil in production.
+- **Not changed:** `requireEvidence`'s `if e.gate == nil` short-circuit stays, and
+  `NewEditor` continues to accept a nil gate. `requireEvidence` already returns early for
+  `ActorCandidate`, so a nil gate is legitimate for the candidate-only editors that
+  tests construct; forcing a stub on all of them buys no invariant.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cv-tailoring`: adds a requirement that the evidence gate is a construction-time
+  dependency of the editor rather than optional wiring, so no assembly order or feature
+  combination can produce an editor that admits an agent's uncited claim.
+
+## Impact
+
+- `internal/cvedit/editor.go` — `WithEvidenceGate` removed; `NewEditor`'s doc corrected.
+- `internal/handler/handler.go` — the bank hoisted and threaded into `newCVHandlers`.
+- `internal/handler/cv.go` — `newCVHandlers` takes the bank; the editor is built with the
+  real gate.
+- `internal/handler/assistant.go` — stops constructing a second bank and stops mutating
+  the CV handlers' editor.
+- `internal/handler/assistant_cv_tools.go` — `bankGate`'s nil-bank branch removed.
+- `internal/handler/assistant_integration_test.go` — its harness re-did the production
+  wiring by hand (`h.cv.editor.WithEvidenceGate(...)`); it now passes the gate at
+  construction like production does.
+
+No API, schema or wire-shape change. No migration.
+
+### Found while implementing, deliberately out of scope
+
+Three test fixtures build a `cvHandlers` literal directly — bypassing `newCVHandlers` —
+with a nil gate, and then exercise the **agent** write path through it:
+`cv_tailor_integration_test.go:47` (PATCH via `Bearer`, i.e. `ActorAgent`),
+`assistant_cv_tools_test.go:94` (whose comment claims it "exercises the real editor —
+policy, evidence gate, apply"), and the tool cases reached through them. Because they
+bypass the constructor, this change does not break them — but they assert the behaviour of
+a configuration production will no longer have, and `cv_tailor_integration_test.go:276`
+records the divergence as intentional in a comment that contradicts how production is
+wired. Recorded as a separate finding in the architecture review rather than folded in
+here: reconciling it is a product question (must an API-key CV edit cite evidence?), not a
+wiring one.

--- a/openspec/changes/evidence-gate-by-construction/specs/cv-tailoring/spec.md
+++ b/openspec/changes/evidence-gate-by-construction/specs/cv-tailoring/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: The evidence gate is a construction-time dependency of the editor
+
+The component that answers "may this claim be published?" SHALL be supplied when the CV
+editor is created, and SHALL NOT be attachable afterwards. No assembly order, and no
+combination of features built or not built, may produce an editor that admits an agent's
+uncited claim.
+
+The system SHALL NOT carry more than one place that answers the evidence question by
+returning "permitted" for a missing dependency. Where the gate's own collaborator is
+absent, that is a construction error, not a silent permission.
+
+An editor built with no gate remains legitimate for candidate-authored editing only —
+the candidate writing about their own career is the source the bank exists to record, and
+the rule already exempts them — but it SHALL NOT be reachable from any agent write path.
+
+#### Scenario: The agent write path cannot be built without a gate
+
+- **WHEN** the HTTP surface is assembled
+- **THEN** the editor serving `PATCH /me/cvs/:id` carries the evidence gate as a value it
+  was constructed with, so an API-key caller editing as the agent is checked regardless of
+  which other features the assembly built
+
+#### Scenario: The gate does not depend on another feature's constructor
+
+- **WHEN** the CV handlers are built in an assembly that does not build the assistant
+- **THEN** the editor still refuses an agent's uncited claim, because the gate was never
+  the assistant's to attach
+
+#### Scenario: A missing bank is not a permission
+
+- **WHEN** the gate is asked whether a claim is publishable and its backing bank is absent
+- **THEN** the answer is not "permitted" — the absence is a wiring error the assembly
+  cannot express, rather than a silent pass

--- a/openspec/changes/evidence-gate-by-construction/tasks.md
+++ b/openspec/changes/evidence-gate-by-construction/tasks.md
@@ -1,39 +1,39 @@
 ## 1. The gate becomes a constructor argument
 
-- [ ] 1.1 `internal/handler/cv.go`: `newCVHandlers` takes a `cvedit.EvidenceGate` and
+- [x] 1.1 `internal/handler/cv.go`: `newCVHandlers` takes a `cvedit.EvidenceGate` and
   builds the editor with it (`cvedit.NewEditor(cvedit.NewRepository(pool, queries), gate)`);
   delete the "attached later (withExperienceBank) because the bank is wired after this"
   comment, which is the stale justification.
-- [ ] 1.2 `internal/handler/handler.go`: hoist
+- [x] 1.2 `internal/handler/handler.go`: hoist
   `experience.NewStore(experience.NewQueriesRepository(queries))` to one variable before
   `newExperienceHandlers`, pass it there, and pass `bankGate{bank: bank}` into
   `newCVHandlers`.
 
 ## 2. The mutator and the assistant's ownership of the bank go away
 
-- [ ] 2.1 `internal/handler/assistant.go`: `newAssistantHandlers` takes the hoisted bank
+- [x] 2.1 `internal/handler/assistant.go`: `newAssistantHandlers` takes the hoisted bank
   instead of constructing its own, and drops the
   `cvH.editor.WithEvidenceGate(bankGate{...})` block.
-- [ ] 2.2 `internal/cvedit/editor.go`: delete `Editor.WithEvidenceGate`, and correct
+- [x] 2.2 `internal/cvedit/editor.go`: delete `Editor.WithEvidenceGate`, and correct
   `NewEditor`'s doc — a nil gate means candidate-only editing, and there is no CLI caller
   that builds one.
-- [ ] 2.3 `internal/handler/assistant_integration_test.go`: the harness re-does the
+- [x] 2.3 `internal/handler/assistant_integration_test.go`: the harness re-does the
   production wiring by hand; construct its editor with the gate instead.
 
 ## 3. The duplicate fail-open
 
-- [ ] 3.1 `internal/handler/assistant_cv_tools.go`: delete `bankGate.Publishable`'s
+- [x] 3.1 `internal/handler/assistant_cv_tools.go`: delete `bankGate.Publishable`'s
   `if g.bank == nil { return nil }` — a second, independent fail-open on the same rule,
   on a field that is never nil.
 
 ## 4. Record what was found but not fixed
 
-- [ ] 4.1 Add the fixture-divergence finding (three harnesses exercise the agent write
+- [x] 4.1 Add the fixture-divergence finding (three harnesses exercise the agent write
   path with a nil gate, and `cv_tailor_integration_test.go:276` documents the divergence
   as intentional) to `docs/reviews/2026-08-01-architecture-review.md`.
 
 ## 5. Verification
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green; the assistant and CV
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` green; the assistant and CV
   integration suites green under `-tags=integration`; `openspec validate
   evidence-gate-by-construction --strict` passes.

--- a/openspec/changes/evidence-gate-by-construction/tasks.md
+++ b/openspec/changes/evidence-gate-by-construction/tasks.md
@@ -1,0 +1,39 @@
+## 1. The gate becomes a constructor argument
+
+- [ ] 1.1 `internal/handler/cv.go`: `newCVHandlers` takes a `cvedit.EvidenceGate` and
+  builds the editor with it (`cvedit.NewEditor(cvedit.NewRepository(pool, queries), gate)`);
+  delete the "attached later (withExperienceBank) because the bank is wired after this"
+  comment, which is the stale justification.
+- [ ] 1.2 `internal/handler/handler.go`: hoist
+  `experience.NewStore(experience.NewQueriesRepository(queries))` to one variable before
+  `newExperienceHandlers`, pass it there, and pass `bankGate{bank: bank}` into
+  `newCVHandlers`.
+
+## 2. The mutator and the assistant's ownership of the bank go away
+
+- [ ] 2.1 `internal/handler/assistant.go`: `newAssistantHandlers` takes the hoisted bank
+  instead of constructing its own, and drops the
+  `cvH.editor.WithEvidenceGate(bankGate{...})` block.
+- [ ] 2.2 `internal/cvedit/editor.go`: delete `Editor.WithEvidenceGate`, and correct
+  `NewEditor`'s doc — a nil gate means candidate-only editing, and there is no CLI caller
+  that builds one.
+- [ ] 2.3 `internal/handler/assistant_integration_test.go`: the harness re-does the
+  production wiring by hand; construct its editor with the gate instead.
+
+## 3. The duplicate fail-open
+
+- [ ] 3.1 `internal/handler/assistant_cv_tools.go`: delete `bankGate.Publishable`'s
+  `if g.bank == nil { return nil }` — a second, independent fail-open on the same rule,
+  on a field that is never nil.
+
+## 4. Record what was found but not fixed
+
+- [ ] 4.1 Add the fixture-divergence finding (three harnesses exercise the agent write
+  path with a nil gate, and `cv_tailor_integration_test.go:276` documents the divergence
+  as intentional) to `docs/reviews/2026-08-01-architecture-review.md`.
+
+## 5. Verification
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green; the assistant and CV
+  integration suites green under `-tags=integration`; `openspec validate
+  evidence-gate-by-construction --strict` passes.


### PR DESCRIPTION
Architecture review 2026-08-01, finding **S5** (catalogue entry 21, verdict `confirmed`).
OpenSpec change: `evidence-gate-by-construction` (8/8 tasks).

## The problem

`internal/cvedit` keeps the rule the whole tailoring capability exists for — a sentence
about what the candidate did cannot reach the page unless it traces to something *they*
asserted — and keeps it in the service path rather than a system prompt, "because a rule
that lives only in a prompt is one a long conversation eventually loses."

The rule is in the right place. The dependency it needs was modelled as optional:

- `internal/handler/cv.go:92` built the editor every CV write goes through with an
  explicitly **nil** gate.
- The only production attachment was a post-construction mutator, inside a **different
  feature's** constructor — `assistant.go:96`:
  `if cvH != nil && cvH.editor != nil { cvH.editor.WithEvidenceGate(...) }`.
- `PATCH /me/cvs/:id` sets `ActorAgent` for any API-key caller (`cv_tailor.go:241`).
  That path has nothing to do with the assistant, yet depended on the assistant's
  constructor having run.
- Two independent fail-opens sat on the same rule: `policy.go:157` (`e.gate == nil`) and
  `assistant_cv_tools.go:356` (`g.bank == nil`).

The stated reason for the late binding was stale: `editor.go` said "the bank is wired later
than the CV handlers", but an equivalent, stateless `experience.Store` was already built at
`handler.go:266` — twenty-three lines before `newCVHandlers` at `:289`.

### It was reachable, not merely latent

The review called this "a latent fail-open, not a live bug", because production is wired
correctly. The new integration test assembles the CV surface through `newCVHandlers` with
**no assistant** and shows the shape of the hole directly — before this change, an API-key
`PATCH` inserting an uncited bullet returned **200** and the claim landed in the CV:

```
cv_evidence_gate_integration_test.go:85: uncited agent patch = 200, want 403 —
    the editor admitted a claim with no evidence
```

It now returns 403, and a candidate's own cookie-authenticated edit still returns 200.

## The change

- `newCVHandlers` takes a `cvedit.EvidenceGate` and constructs the editor with it. The
  narrow type states exactly what the CV handlers need, rather than handing them a bank.
- `handler.go` hoists one `experience.Store` and threads it to the experience handlers,
  the gate, and the assistant — which stops constructing its own and stops mutating a
  struct it was handed.
- `Editor.WithEvidenceGate` deleted. `bankGate.Publishable`'s nil-bank branch deleted.
- Two test harnesses that re-did the production wiring by hand now construct with the gate.

## Deliberately unchanged

`requireEvidence`'s `if e.gate == nil` short-circuit stays, and `NewEditor` still accepts
nil. `requireEvidence` exempts `ActorCandidate`, so a nil gate is legitimate for the
candidate-only editors tests build; forcing a stub on all of them buys no invariant.
Deleting it would also be worse than it looks — the next statement for an agent write is
`e.gate.Publishable(...)`, so a candidate-only editor handed an agent change would panic
rather than refuse.

## Found while implementing, not fixed here

Three fixtures build a `cvHandlers` **struct literal** — bypassing `newCVHandlers` — with a
nil gate and then exercise the agent write path, and `cv_tailor_integration_test.go:276`
records that divergence as intentional in a comment that contradicts how production is
wired. Because they bypass the constructor, this change neither fixes nor breaks them.
Reconciling it is a product question (must an API-key CV edit cite evidence?), so it is
recorded as finding **I1** in the architecture review rather than folded in here.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` green.
- `go test -tags=integration ./internal/handler/ ./internal/db/` green — the full handler
  suite includes the assistant, CV, tailor and ATS-delta integration tests.
- The new test was observed failing (200) before the fix and passing (403) after.

No API, schema or wire-shape change. No migration.