### PR TITLE
fix(workers): the derive backfill survives a corrupted row

### DIFF
--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -81,7 +81,10 @@ const progressEvery = 100_000
 // DeleteOrphanCompanies) is deliberately not here — it runs once, single-threaded,
 // after the pass.
 type deriveStore interface {
-	ListJobsByIDAfter(ctx context.Context, arg db.ListJobsByIDAfterParams) ([]db.Job, error)
+	// The three reads worker.NewFullScanReader needs: the wide keyset batch, the id-only
+	// projection it falls back to, and the single-row fetch that isolates a damaged row
+	// from its readable neighbours.
+	worker.FullScanQueries
 	UpdateJobDerived(ctx context.Context, arg db.UpdateJobDerivedParams) error
 }
 
@@ -235,25 +238,35 @@ func backfillProgress(ctx context.Context, store deriveStore, concurrency int, e
 	jobsCh := make(chan db.Job, backfillBatchSize)
 
 	// Reader (producer): pages the table by keyset and feeds the channel.
+	//
+	// It reads through worker.ResilientPage because this pass has no resume point: a row
+	// whose TOAST is damaged fails the whole wide SELECT, and an aborting scan would
+	// re-fail at the same id on every later run, leaving every derived column past it
+	// stale for good. The helper degrades to reading the faulting window row by row and
+	// skips only what is genuinely unreadable.
+	reader := worker.NewFullScanReader(store)
 	var readerWG sync.WaitGroup
 	readerWG.Add(1)
 	go func() {
 		defer readerWG.Done()
 		defer close(jobsCh)
+		// Owned by this goroutine alone, so a plain counter is enough. Reported once at
+		// the end rather than per page: an operator needs the total, and each skipped id
+		// is already logged where it was met.
+		var skipped int
+		defer func() {
+			if skipped > 0 {
+				log.Printf("backfill-derive: skipped %d corrupted row(s); their derived columns are unchanged", skipped)
+			}
+		}()
 		var afterID int64
 		for {
-			jobs, e := store.ListJobsByIDAfter(ctx, db.ListJobsByIDAfterParams{
-				AfterID:   afterID,
-				BatchSize: backfillBatchSize,
-			})
+			jobs, lastID, corrupted, e := worker.ResilientPage(ctx, reader, afterID, backfillBatchSize)
 			if e != nil {
 				fail(e)
 				return
 			}
-			if len(jobs) == 0 {
-				return
-			}
-			afterID = jobs[len(jobs)-1].ID
+			skipped += len(corrupted)
 			for i := range jobs {
 				select {
 				case jobsCh <- jobs[i]:
@@ -261,9 +274,13 @@ func backfillProgress(ctx context.Context, store deriveStore, concurrency int, e
 					return
 				}
 			}
-			if len(jobs) < backfillBatchSize {
+			// Keyset progress is the exhaustion signal. A "< batchSize" test would end
+			// the scan at the first corrupted row, because the degrade path returns a
+			// legitimately short page whenever it skips one.
+			if lastID == afterID {
 				return
 			}
+			afterID = lastID
 		}
 	}()
 

--- a/cmd/backfill-derive/main_test.go
+++ b/cmd/backfill-derive/main_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -18,16 +20,64 @@ import (
 // empty) and records every UpdateJobDerived call. UpdateJobDerived is guarded so the
 // concurrent worker pool can call it in parallel without a data race.
 type fakeStore struct {
-	jobs    []db.Job
+	jobs []db.Job
+	// corrupt marks ids whose row cannot be read: the wide batch over any window
+	// containing one fails with XX001, and so does fetching it singly.
+	corrupt map[int64]bool
 	mu      sync.Mutex
 	updates []db.UpdateJobDerivedParams
 }
 
-func (f *fakeStore) ListJobsByIDAfter(_ context.Context, arg db.ListJobsByIDAfterParams) ([]db.Job, error) {
-	if arg.AfterID != 0 {
-		return nil, nil
+// page is the keyset window the three read methods share, so the degrade path sees
+// exactly the rows the wide batch would have returned.
+func (f *fakeStore) page(afterID int64, batchSize int32) []db.Job {
+	var out []db.Job
+	for _, j := range f.jobs {
+		if j.ID <= afterID {
+			continue
+		}
+		out = append(out, j)
+		if len(out) == int(batchSize) {
+			break
+		}
 	}
-	return f.jobs, nil
+	return out
+}
+
+// corruptedRow is the SQLSTATE a damaged TOAST pointer raises. A wide SELECT over a
+// window containing one such row fails entirely; the id-only projection does not
+// detoast, so it still answers.
+func corruptedRow() error { return &pgconn.PgError{Code: "XX001", Message: "missing chunk number 0"} }
+
+func (f *fakeStore) ListJobsByIDAfter(_ context.Context, arg db.ListJobsByIDAfterParams) ([]db.Job, error) {
+	rows := f.page(arg.AfterID, arg.BatchSize)
+	for _, j := range rows {
+		if f.corrupt[j.ID] {
+			return nil, corruptedRow()
+		}
+	}
+	return rows, nil
+}
+
+func (f *fakeStore) ListJobIDsAfter(_ context.Context, arg db.ListJobIDsAfterParams) ([]int64, error) {
+	rows := f.page(arg.AfterID, arg.BatchSize)
+	ids := make([]int64, len(rows))
+	for i, j := range rows {
+		ids[i] = j.ID
+	}
+	return ids, nil
+}
+
+func (f *fakeStore) GetJob(_ context.Context, id int64) (db.Job, error) {
+	if f.corrupt[id] {
+		return db.Job{}, corruptedRow()
+	}
+	for _, j := range f.jobs {
+		if j.ID == id {
+			return j, nil
+		}
+	}
+	return db.Job{}, pgx.ErrNoRows
 }
 
 func (f *fakeStore) UpdateJobDerived(_ context.Context, arg db.UpdateJobDerivedParams) error {
@@ -270,5 +320,79 @@ func TestBackfill_ProgressDoesNotChangeTheResult(t *testing.T) {
 	}
 	if scanned != 1 || updated != 1 || slugsMoved != 1 {
 		t.Errorf("scanned=%d updated=%d slugsMoved=%d, want 1/1/1", scanned, updated, slugsMoved)
+	}
+}
+
+// The backfill records no resume point, so an aborting scan is not one failed run: every
+// later run restarts at id 0 and dies at the same row, leaving every deterministic column
+// past it stale forever. Skipping the unreadable row is what makes the pass finishable.
+func TestBackfill_SkipsACorruptedRowAndFinishesTheScan(t *testing.T) {
+	jobs := make([]db.Job, 0, 3)
+	for i := 1; i <= 3; i++ {
+		jobs = append(jobs, db.Job{
+			ID: int64(i), Title: "Senior Go Developer", Company: "Acme",
+			Source: "manual", ExternalID: "x", Location: "Berlin, Germany",
+			Description: backfillJobDescription,
+		})
+	}
+	store := &fakeStore{jobs: jobs, corrupt: map[int64]bool{2: true}}
+
+	scanned, updated, _, err := backfillAll(context.Background(), store, 1)
+	if err != nil {
+		t.Fatalf("backfillAll: %v — a corrupted row must not end the run", err)
+	}
+	if scanned != 2 || updated != 2 {
+		t.Errorf("scanned=%d updated=%d, want 2/2 (the readable rows either side of the damaged one)", scanned, updated)
+	}
+	for _, u := range store.updates {
+		if u.ID == 2 {
+			t.Error("the corrupted row was written")
+		}
+	}
+	// The row AFTER the damaged one is the point: an abort would have left it stale.
+	var sawThird bool
+	for _, u := range store.updates {
+		if u.ID == 3 {
+			sawThird = true
+		}
+	}
+	if !sawThird {
+		t.Error("the scan stopped at the corrupted row instead of continuing past it")
+	}
+}
+
+// The exhaustion signal is the keyset cursor, not the page size. A page that skipped a
+// corrupted row is legitimately SHORT, so a "fewer rows than the batch → end of table"
+// test would stop here and report a complete pass — silently leaving every row after the
+// first damaged one stale. That is worse than the abort this change replaces, because
+// nothing in the run says so.
+func TestBackfill_ShortDegradedPageDoesNotEndTheScan(t *testing.T) {
+	const n = backfillBatchSize + 1
+	jobs := make([]db.Job, 0, n)
+	for i := 1; i <= n; i++ {
+		jobs = append(jobs, db.Job{
+			ID: int64(i), Title: "Go Developer", Company: "Acme",
+			Source: "manual", ExternalID: "x", Location: "Berlin, Germany",
+		})
+	}
+	// Inside the FIRST page, so that page comes back one row short of the batch size.
+	store := &fakeStore{jobs: jobs, corrupt: map[int64]bool{250: true}}
+
+	scanned, _, _, err := backfillAll(context.Background(), store, 4)
+	if err != nil {
+		t.Fatalf("backfillAll: %v", err)
+	}
+	if scanned != n-1 {
+		t.Fatalf("scanned=%d, want %d — the scan ended at the short page instead of following the cursor", scanned, n-1)
+	}
+	// The row past the first page is the proof: it is only reachable on a second page.
+	var sawLast bool
+	for _, u := range store.updates {
+		if u.ID == int64(n) {
+			sawLast = true
+		}
+	}
+	if !sawLast {
+		t.Errorf("row %d (page 2) was never scanned", n)
 	}
 }

--- a/internal/worker/resilient.go
+++ b/internal/worker/resilient.go
@@ -37,21 +37,28 @@ type PageReader interface {
 	Row(ctx context.Context, id int64) (db.Job, error)
 }
 
-// jobQueries is the subset of *db.Queries the readers call — narrowed to keep the
-// readers testable and their dependency explicit.
-type jobQueries interface {
+// FullScanQueries is the subset of *db.Queries a whole-table reader calls. It is
+// declared separately from PostedSinceQueries so each constructor asks for exactly what
+// it uses: a worker with its own narrow store (cmd/backfill-derive) can satisfy one
+// without declaring methods the reader would never invoke.
+type FullScanQueries interface {
 	ListJobsByIDAfter(context.Context, db.ListJobsByIDAfterParams) ([]db.Job, error)
 	ListJobIDsAfter(context.Context, db.ListJobIDsAfterParams) ([]int64, error)
+	GetJob(context.Context, int64) (db.Job, error)
+}
+
+// PostedSinceQueries is the same for the freshness-windowed reader.
+type PostedSinceQueries interface {
 	ListOpenJobsPostedAfter(context.Context, db.ListOpenJobsPostedAfterParams) ([]db.Job, error)
 	ListOpenJobIDsPostedAfter(context.Context, db.ListOpenJobIDsPostedAfterParams) ([]int64, error)
 	GetJob(context.Context, int64) (db.Job, error)
 }
 
-type fullScanReader struct{ q jobQueries }
+type fullScanReader struct{ q FullScanQueries }
 
-// NewFullScanReader adapts *db.Queries to a PageReader over the whole jobs table
+// NewFullScanReader adapts a job store to a PageReader over the whole jobs table
 // (keyset by id).
-func NewFullScanReader(q jobQueries) PageReader { return fullScanReader{q} }
+func NewFullScanReader(q FullScanQueries) PageReader { return fullScanReader{q} }
 
 func (r fullScanReader) Batch(ctx context.Context, afterID int64, bs int32) ([]db.Job, error) {
 	return r.q.ListJobsByIDAfter(ctx, db.ListJobsByIDAfterParams{AfterID: afterID, BatchSize: bs})
@@ -64,16 +71,16 @@ func (r fullScanReader) Row(ctx context.Context, id int64) (db.Job, error) {
 }
 
 type postedSinceReader struct {
-	q     jobQueries
+	q     PostedSinceQueries
 	since pgtype.Timestamptz
 }
 
-// NewPostedSinceReader adapts *db.Queries to a PageReader over OPEN jobs whose
+// NewPostedSinceReader adapts a job store to a PageReader over OPEN jobs whose
 // effective posting date (COALESCE(posted_at, created_at)) is at or after since —
 // the freshness window `reindex --semantic --posted-within` embeds. Keyset by id.
 // Unlike the incremental reader it returns open jobs only, since the semantic swap
 // rebuild it feeds never holds closed jobs (nothing to delete).
-func NewPostedSinceReader(q jobQueries, since time.Time) PageReader {
+func NewPostedSinceReader(q PostedSinceQueries, since time.Time) PageReader {
 	return postedSinceReader{q: q, since: pgtype.Timestamptz{Time: since, Valid: true}}
 }
 

--- a/openspec/changes/resilient-derive-backfill/.openspec.yaml
+++ b/openspec/changes/resilient-derive-backfill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/resilient-derive-backfill/design.md
+++ b/openspec/changes/resilient-derive-backfill/design.md
@@ -1,0 +1,103 @@
+## Context
+
+`internal/worker/resilient.go` is the shared answer to an observed production condition:
+a damaged TOAST pointer makes a whole `SELECT *` page fail with SQLSTATE `XX001`, so a
+full-table scan dies on one bad row. `ResilientPage` degrades — re-lists the window as
+bare ids (a projection that never detoasts), fetches rows singly, skips the ones that
+still fault, and advances the cursor past them.
+
+Three workers scan the whole `jobs` table. One uses it:
+
+| Worker | Scan | Resilient? | On `XX001` |
+|---|---|---|---|
+| `cmd/reindex` | `NewFullScanReader` + `ResilientPage` | yes | skips, logs, completes the swap |
+| `cmd/backfill-derive` | raw `ListJobsByIDAfter` in the producer goroutine | no | `fail(e)` cancels the run |
+| `cmd/backfill-descriptions` | raw `ListJobsByIDAfter` via `pageJobs` | no | aborts `backfillAll` |
+
+`cmd/backfill-derive` has no resume flag, so its failure mode is not "this run failed" but
+"this worker can never finish again": each run restarts from id 0 and dies at the same row.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the whole-catalogue derive pass finishable in the presence of a corrupted row.
+- Reuse the existing helper rather than growing a second degrade path.
+
+**Non-Goals:**
+
+- `cmd/backfill-descriptions`. Its scoped branch pages by source, which no existing
+  `PageReader` constructor serves, and it is a one-off historical encoding repair. A third
+  constructor built for it would be infrastructure ahead of need.
+- A resume flag for `cmd/backfill-derive`. Worth considering separately; skipping the
+  unreadable row removes the reason it is currently needed.
+- Changing what the backfill derives, its concurrency, or its progress reporting.
+
+## Decisions
+
+### D1: `NewFullScanReader` narrows from `jobQueries` to the three methods it calls
+
+`jobQueries` declares five methods because it serves *both* reader constructors —
+`fullScanReader` uses `ListJobsByIDAfter` / `ListJobIDsAfter` / `GetJob`, and
+`postedSinceReader` uses the two `ListOpenJobs*PostedAfter`. `NewFullScanReader` therefore
+demands two methods it never invokes.
+
+That is harmless while the only caller passes `*db.Queries`, which has everything. It stops
+being harmless the moment a worker wants to pass a narrower store: `cmd/backfill-derive`'s
+`deriveStore`, and the fake in its tests, would each have to declare two dead
+`ListOpenJobs*PostedAfter` methods to satisfy a constructor that ignores them.
+
+So each constructor takes its own narrow interface. `*db.Queries` satisfies both, and
+`cmd/reindex` is untouched.
+
+*Alternative considered:* have `cmd/backfill-derive` implement `worker.PageReader` itself
+over its own store. Rejected — it re-implements the adapter `NewFullScanReader` already is,
+which is the duplication this change exists to remove.
+
+*Alternative considered:* widen `deriveStore` to all five methods. Rejected — it puts two
+permanently-unused methods on the production store interface and on every test fake, to
+work around a declared dependency that was too wide to begin with.
+
+### D2: The exhaustion test moves to the keyset cursor
+
+The current loop ends on two conditions: an empty page, and a page shorter than
+`backfillBatchSize`. The second is an optimisation that is *wrong* under the degrade path —
+a page that skipped a corrupted row is legitimately short, and treating it as the end of
+the table would stop the scan at the first corrupted row while reporting success. That is
+strictly worse than today's hard failure: a silent partial pass over a catalogue-wide
+re-derive leaves stale columns with nothing to indicate it.
+
+`ResilientPage` returns `lastID == afterID` — no cursor movement — precisely as its
+exhaustion signal, and `cmd/reindex/main.go:355-358` already carries this reasoning in a
+comment. The backfill adopts the same test.
+
+### D3: Skipped ids are counted and logged, not aggregated into the run's error
+
+A skipped row is a fact about the database, not a failure of the pass. `ResilientPage`
+already logs each id; the producer accumulates the count so the run's summary can report
+it, matching how `cmd/reindex` reports `skipped`.
+
+## Risks / Trade-offs
+
+**A corrupted row now leaves its derived columns stale silently, where before the run
+failed loudly.** → It did not fail *usefully*: with no resume flag, the loud failure meant
+the entire catalogue past that id stayed stale, not just the one row. The skipped ids are
+logged and counted in the summary, so the signal is preserved and the blast radius shrinks
+from "everything after the bad row" to "the bad row".
+
+**Narrowing an exported constructor's parameter type is an API change to
+`internal/worker`.** → Internal package, one non-test caller, and it narrows rather than
+widens: every existing argument still satisfies it, so nothing outside can break.
+
+**The degrade path issues one query per row for the faulting window.** → Bounded by one
+batch, only on a batch that actually faulted, and only for that window. The alternative is
+not scanning at all.
+
+## Migration Plan
+
+None. No schema, no API, no wire shape. The worker is run-once-and-exit and cron-driven, so
+the change takes effect on its next run. Rollback is a plain revert.
+
+## Open Questions
+
+None.

--- a/openspec/changes/resilient-derive-backfill/proposal.md
+++ b/openspec/changes/resilient-derive-backfill/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+`worker.ResilientPage` exists because of an observed production condition: one damaged
+TOAST pointer fails an entire `SELECT *` page, and commit `1153d215` ("survive corrupted
+(XX001) rows in full-scan workers") records that this already crashed a full facet reindex
+on this database. The shared answer was written, tested, given two reader constructors —
+and then wired into exactly one of the three workers that scan the whole `jobs` table.
+
+`cmd/backfill-derive` is the one that needs it most. CLAUDE.md describes it as the worker
+that "re-derives every deterministic column (facets, `role_fingerprint`, slugs) in one
+keyset pass" — a whole-catalogue pass is its entire purpose. Its producer goroutine issues
+a raw `ListJobsByIDAfter`, and any error calls `fail(e)`, which cancels the run. It has no
+resume flag. So a single corrupted row makes the whole-catalogue re-derive **permanently
+unable to finish past that id**: every run re-fails at the same place, and every column
+after it stays stale forever.
+
+## What Changes
+
+- `cmd/backfill-derive`'s producer reads through `worker.ResilientPage` over a
+  `worker.NewFullScanReader`, so a corrupted row is skipped and logged instead of ending
+  the run.
+- Its exhaustion test changes from "the page was shorter than the batch" to "the keyset
+  cursor did not advance". This is a correctness requirement of the move, not a tidy-up:
+  the degrade path legitimately returns a short page after skipping a damaged row, so the
+  old test would stop the scan at the first corrupted row — converting a hard failure into
+  a silent partial pass, which is worse.
+- `deriveStore` widens from two methods to four: the three the full-scan reader calls plus
+  the update it already had.
+- `worker.NewFullScanReader`'s parameter narrows from the five-method `jobQueries` to the
+  three methods it actually calls. Without this the backfill's store — and its test fake —
+  would have to declare two `ListOpenJobs*PostedAfter` methods that the full-scan reader
+  never invokes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `corruption-resilience`: adds a requirement that the whole-catalogue derive backfill
+  completes despite corrupted rows, alongside the existing one for `reindex`.
+
+## Impact
+
+- `cmd/backfill-derive/main.go` — the producer loop and the store interface.
+- `cmd/backfill-derive/main_test.go` — the fake gains the two reader methods, and gains a
+  case for the corrupted-row path.
+- `internal/worker/resilient.go` — `NewFullScanReader`'s parameter type narrows.
+  `*db.Queries` satisfies both, so `cmd/reindex` is unaffected.
+
+No schema, API or wire-shape change. No migration.
+
+### Deliberately out of scope
+
+`cmd/backfill-descriptions` has the same raw scan. Its scoped branch pages by source, which
+`NewFullScanReader` does not serve, and inventing a third `PageReader` constructor for a
+one-off historical encoding repair is infrastructure ahead of need. Its unscoped branch
+could adopt the existing constructor later if that repair is ever re-run.

--- a/openspec/changes/resilient-derive-backfill/specs/corruption-resilience/spec.md
+++ b/openspec/changes/resilient-derive-backfill/specs/corruption-resilience/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: The derive backfill completes despite corrupted rows
+
+The whole-catalogue derive backfill SHALL read jobs through the resilient full-scan
+helper, so a row that cannot be read due to data corruption is skipped and logged rather
+than ending the run. Every readable row after the corrupted one SHALL still be re-derived
+in the same pass.
+
+Because the backfill records no resume point, an aborting scan is not merely a failed run:
+it re-fails at the same id on every subsequent run, so every deterministic column past that
+row stays stale indefinitely. Skipping is what makes the pass finishable at all.
+
+The scan SHALL treat a keyset cursor that did not advance as its exhaustion signal, and
+SHALL NOT treat a page shorter than the batch size as the end of the table. The degrade
+path returns a short page whenever it skips a damaged row, so the shorter-than-batch test
+would end the scan at the first corrupted row and report a complete pass.
+
+#### Scenario: A corrupted row does not end the backfill
+
+- **WHEN** the derive backfill's scan meets a row that fails to read with a data-corruption
+  error
+- **THEN** that row is skipped and logged, and the rows after it are still scanned and
+  re-derived in the same run
+
+#### Scenario: A short page from the degrade path does not end the scan
+
+- **WHEN** a page returns fewer rows than the batch size because a corrupted row was
+  skipped
+- **THEN** the scan continues from the advanced cursor rather than treating the short page
+  as the end of the table
+
+#### Scenario: A non-corruption read failure still ends the run
+
+- **WHEN** the scan's read fails with an error that is not data corruption
+- **THEN** the run fails with that error, exactly as before — the resilience is narrow to
+  corruption and hides nothing else

--- a/openspec/changes/resilient-derive-backfill/tasks.md
+++ b/openspec/changes/resilient-derive-backfill/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Let a narrow store reach the shared reader
 
-- [ ] 1.1 `internal/worker/resilient.go`: give each reader constructor its own narrow
+- [x] 1.1 `internal/worker/resilient.go`: give each reader constructor its own narrow
   interface — `NewFullScanReader` takes the three methods `fullScanReader` calls,
   `NewPostedSinceReader` the three `postedSinceReader` calls — instead of both taking the
   five-method `jobQueries`. `*db.Queries` satisfies both, so `cmd/reindex` is unchanged.
 
 ## 2. The derive backfill scans resiliently
 
-- [ ] 2.1 `cmd/backfill-derive/main.go`: widen `deriveStore` to carry
+- [x] 2.1 `cmd/backfill-derive/main.go`: widen `deriveStore` to carry
   `ListJobsByIDAfter` / `ListJobIDsAfter` / `GetJob` plus `UpdateJobDerived`.
-- [ ] 2.2 `cmd/backfill-derive/main.go`: read the producer's pages through
+- [x] 2.2 `cmd/backfill-derive/main.go`: read the producer's pages through
   `worker.ResilientPage` over `worker.NewFullScanReader(store)`, replacing the raw
   `ListJobsByIDAfter`; drop the `len(jobs) < backfillBatchSize` early return and end the
   scan on `lastID == afterID`.
-- [ ] 2.3 `cmd/backfill-derive/main.go`: count skipped ids and report them in the run's
+- [x] 2.3 `cmd/backfill-derive/main.go`: count skipped ids and report them in the run's
   log summary, as `cmd/reindex` does.
 
 ## 3. Verification
 
-- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green;
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green;
   `go test -tags=integration ./internal/db/` green; `openspec validate
   resilient-derive-backfill --strict` passes.

--- a/openspec/changes/resilient-derive-backfill/tasks.md
+++ b/openspec/changes/resilient-derive-backfill/tasks.md
@@ -1,0 +1,23 @@
+## 1. Let a narrow store reach the shared reader
+
+- [ ] 1.1 `internal/worker/resilient.go`: give each reader constructor its own narrow
+  interface — `NewFullScanReader` takes the three methods `fullScanReader` calls,
+  `NewPostedSinceReader` the three `postedSinceReader` calls — instead of both taking the
+  five-method `jobQueries`. `*db.Queries` satisfies both, so `cmd/reindex` is unchanged.
+
+## 2. The derive backfill scans resiliently
+
+- [ ] 2.1 `cmd/backfill-derive/main.go`: widen `deriveStore` to carry
+  `ListJobsByIDAfter` / `ListJobIDsAfter` / `GetJob` plus `UpdateJobDerived`.
+- [ ] 2.2 `cmd/backfill-derive/main.go`: read the producer's pages through
+  `worker.ResilientPage` over `worker.NewFullScanReader(store)`, replacing the raw
+  `ListJobsByIDAfter`; drop the `len(jobs) < backfillBatchSize` early return and end the
+  scan on `lastID == afterID`.
+- [ ] 2.3 `cmd/backfill-derive/main.go`: count skipped ids and report them in the run's
+  log summary, as `cmd/reindex` does.
+
+## 3. Verification
+
+- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green;
+  `go test -tags=integration ./internal/db/` green; `openspec validate
+  resilient-derive-backfill --strict` passes.


### PR DESCRIPTION
Architecture review 2026-08-01, finding **S6** (catalogue entry 31, verdict `confirmed`).
OpenSpec change: `resilient-derive-backfill` (5/5 tasks).

## The problem

`worker.ResilientPage` exists because of an observed production condition, not a
hypothetical one: commit `1153d215` ("survive corrupted (XX001) rows in full-scan
workers") records that a broken TOAST pointer had already crashed a full facet reindex on
this database. One damaged row fails an entire `SELECT *` page.

The shared answer was written, tested, given two reader constructors — and then wired into
one of the three workers that scan the whole `jobs` table.

| Worker | Scan | On `XX001` |
|---|---|---|
| `cmd/reindex` | `NewFullScanReader` + `ResilientPage` | skips, logs, completes the swap |
| `cmd/backfill-derive` | raw `ListJobsByIDAfter` in the producer goroutine | `fail(e)` cancels the run |
| `cmd/backfill-descriptions` | raw `ListJobsByIDAfter` via `pageJobs` | aborts `backfillAll` |

`cmd/backfill-derive` is the one that needs it most. It is described in CLAUDE.md as the
worker that re-derives every deterministic column "in one keyset pass" — a whole-catalogue
pass is its entire purpose — and it has **no resume flag**. So one corrupted row is not a
failed run: every later run restarts at id 0 and dies at the same id, and every derived
column past that row stays stale indefinitely.

## The change

The producer reads through `worker.ResilientPage` over `worker.NewFullScanReader`.

**The exhaustion test moves with it, and that is a correctness requirement, not a
tidy-up.** The degrade path returns a legitimately short page whenever it skips a damaged
row, so the old `len(jobs) < backfillBatchSize` check would have ended the scan there and
reported a complete pass — silently losing the whole tail of the table, which is *worse*
than the abort it replaces because nothing in the run says so. `cmd/reindex/main.go:355`
already carries this reasoning in a comment; the backfill now uses the same
`lastID == afterID` signal.

A test pins it. With the old check restored, a 501-row table scans 499:

```
main_test.go:386: scanned=499, want 500 — the scan ended at the short page
    instead of following the cursor
```

`NewFullScanReader`'s parameter narrows from the five-method `jobQueries` to the three it
actually calls. Without that, `deriveStore` and its test fake would each have to declare
two `ListOpenJobs*PostedAfter` methods the full-scan reader never invokes. `*db.Queries`
satisfies both new interfaces, so `cmd/reindex` is untouched.

Skipped ids are counted and reported once at the end of the scan; `ResilientPage` already
logs each one where it was met.

## Deliberately out of scope

`cmd/backfill-descriptions` has the same raw scan, but its scoped branch pages by source,
which no existing `PageReader` constructor serves. Inventing a third constructor for a
one-off historical encoding repair is infrastructure ahead of need — its unscoped branch
can adopt `NewFullScanReader` later if that repair is ever re-run.

A resume flag for `cmd/backfill-derive` is worth considering separately; skipping the
unreadable row removes the reason it is currently needed.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` green.
- `go test -tags=integration ./internal/db/` green.
- Both new tests were observed failing before their fix: the corrupted-row case aborted
  with `SQLSTATE XX001`, and the short-page case scanned 499 of 500.

No schema, API or wire-shape change. No migration. The worker is run-once-and-exit, so the
change takes effect on its next cron run.