### PR TITLE
fix(web): one display label per facet code across every surface

### DIFF
--- a/openspec/changes/unify-facet-display-labels/.openspec.yaml
+++ b/openspec/changes/unify-facet-display-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/unify-facet-display-labels/design.md
+++ b/openspec/changes/unify-facet-display-labels/design.md
@@ -1,0 +1,139 @@
+## Context
+
+Three SPA modules render closed-vocabulary facet codes:
+
+| module | surface | category label source | fallback for a code not in the map |
+|---|---|---|---|
+| `facets.ts` | filter panel, profile pickers | `labels.CATEGORY_LABELS` | local `humanize` — **Title Case Every Word** |
+| `enrichment.ts` | job-detail facet rows | `labels.CATEGORY_LABELS` | local `humanize` — **Sentence case** |
+| `insights.ts` | indexed `/insights` pages | **its own 35-entry map** | local title-case regex |
+
+`labels.ts` states its rule in its opening comment: "only the codes whose label differs from
+the title-cased fallback are listed here". That rule is coherent for exactly one fallback.
+With two, every multi-word code the map omits is rendered two ways by construction — which is
+also why `insights.ts` grew its own map rather than trusting the shared one.
+
+So the shared map is not really the single source it claims to be: it is a partial override
+table over two different defaults. The fix is to remove the ambiguity at its root rather than
+to reconcile the two forks against each other.
+
+Note that the seniority vocabulary does **not** have this problem: its codes are single words
+(`intern`, `junior`, …) plus `c_level`, and single words title-case and sentence-case
+identically. `insights.ts`'s `SENIORITY_LABELS` is therefore byte-equivalent to what the
+shared map plus either fallback already produces, with one exception — the empty-string
+"category-wide" band, which is an `/insights` concept and not a vocabulary value at all.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One code, one string, on all three surfaces.
+- The rule that keeps them aligned is checked by the test suite, not asserted in a comment —
+  the review theme this change is drawn from is "invariants held by prose".
+- Settle the three wordings that currently differ, in one place.
+- Leave the `/insights` publication logic, intro sentences and page set untouched.
+
+**Non-Goals:**
+
+- **Unifying the two fallback functions.** `enrichment.ts` deliberately sentence-cases; its
+  doc comment says so, and other facets on the job page (domains, company types, English
+  levels) still route through it. Changing that is a visual decision about facets this change
+  does not touch, and it would be invisible in review if smuggled in here.
+- **Making every label map exhaustive.** Only the category vocabulary suffers the two-fallback
+  divergence, because only it has multi-word codes rendered on all three surfaces. Domains,
+  regions, work modes and English levels stay override-only.
+- **Touching the wire.** Filter values are the codes; nothing sent to the API changes.
+- Restructuring `insights.ts` beyond removing the duplicated maps.
+
+## Decisions
+
+### Exhaustive category map, not a reconciled fallback
+
+**Chosen:** make `CATEGORY_LABELS` cover all of `CATEGORY_VALUES`, so the fallback never fires
+for a category and the two fallback styles become irrelevant to it.
+
+**Alternative considered — make both surfaces call one `categoryLabel()` helper and leave the
+map partial.** This also produces one string per code, and is a smaller diff. Rejected because
+it leaves the trap armed: the map would still be a partial override table, so the *next*
+vocabulary rendered on two surfaces repeats the bug, and nothing tells a maintainer which
+codes are safe to omit. Exhaustiveness makes the map's contract stateable — and therefore
+testable.
+
+**Cost accepted:** `labels.ts` grows by ~25 entries that equal their title-cased fallback, in
+apparent violation of its own "only the differing codes" rule. The rule is amended in the
+comment for this one map, with the reason recorded in place.
+
+### The vocabulary-coverage test is the enforcement
+
+`CATEGORY_VALUES` is generated from the Go vocabulary by `cmd/gen-contracts`. A unit test
+asserting that every generated value is a key of `CATEGORY_LABELS` converts "keep this map in
+sync" from a comment into a build failure the moment contract regeneration adds a code.
+
+**Alternative considered — declare the map as `Record<Category, string>`** and let the
+compiler demand totality. Stronger in principle, and rejected in practice: `CATEGORY_LABELS`
+is consumed by `label(map, value)` helpers typed `Record<string, string>`, so narrowing the
+declaration ripples into those signatures for no gain, and a type error at the regeneration
+site is a worse diagnostic than a test that names the unlabelled code.
+
+### One title-case helper, owned by `labels.ts`
+
+`facets.ts`'s `humanize` moves to `labels.ts` as the exported `titleCase` and is imported
+back. Putting the fallback in the module that owns the maps keeps "how a label is produced"
+in one place; leaving it in `facets.ts` would mean `labels.ts` importing from the filter panel
+to define its own lookup.
+
+`enrichment.ts`'s `humanize` is renamed `sentenceCase` in place. It is not moved and not
+merged. The rename is in scope because the current name plus its doc comment ("Title-case an
+unknown snake_case code (e.g. `data_engineering` → `Data engineering`)") is self-contradictory
+and is a plausible reason the divergence went unnoticed.
+
+### `categoryLabel` lives with the maps; `seniorityLabel` does not move
+
+`categoryLabel` moves from `facets.ts` to `labels.ts`; its two importers
+(`filterSections.ts`, `ProfileForm.svelte`) and the three `/insights` loaders point at the new
+home. No re-export shim — a re-export chain would leave two importable paths for one function,
+which is the shape of problem this change exists to remove.
+
+`insights.ts` keeps exporting its own `seniorityLabel`, because it alone must answer for the
+empty-string category-wide band. It delegates for every real code:
+
+```
+seniority === '' ? 'All levels' : (SENIORITY_LABELS[seniority] ?? titleCase(seniority))
+```
+
+Adding the `''` sentinel to the shared map instead was rejected: `''` is not a member of the
+seniority vocabulary, and a shared map containing a non-vocabulary key would make the
+coverage-test idea incoherent for seniority later.
+
+### Relocation gets a named map
+
+The filter panel's inline `{ not_supported: 'None', … }` and `enrichment.ts`'s module-level
+`RELOCATION` become one `RELOCATION_LABELS` in `labels.ts`. Three entries; it is only worth
+naming because two surfaces already spelled it differently.
+
+## Risks / Trade-offs
+
+- **A visible copy change ships on indexed pages** (~15 job-detail category rows gain a
+  capital; two categories and one relocation value change wording). → Every change is a
+  *convergence* onto a string the product already displays on another surface, and the
+  `/insights` H1s and titles — the actual indexed text — keep their current strings except
+  where the owner deliberately settled the wording. Nothing gains a spelling that appears
+  nowhere today.
+- **The exhaustive map will drift from the vocabulary.** → That is exactly what the coverage
+  test prevents; it is the change's load-bearing artifact, not a nicety.
+- **`labels.ts` grows and reads more repetitively.** → Accepted. A list that is boring to read
+  and impossible to get silently wrong beats a clever partial map that renders two ways.
+- **Someone re-adds a private map later.** → The spec requirement states the rule, and
+  `labels.ts`'s comment records why the category map is exhaustive when its siblings are not.
+- **`other` gets a label ("Other") although `/insights` never publishes it.** → Harmless: the
+  filter panel and the job page can both receive `other` from the API today, and both already
+  render it through their fallbacks.
+
+## Migration Plan
+
+None required. Display-only change in the SPA; no schema, no API, no index, no data
+backfill. Rollback is a revert of the commit.
+
+## Open Questions
+
+None. The three wordings were settled by the product owner before implementation began.

--- a/openspec/changes/unify-facet-display-labels/design.md
+++ b/openspec/changes/unify-facet-display-labels/design.md
@@ -8,6 +8,13 @@ Three SPA modules render closed-vocabulary facet codes:
 | `enrichment.ts` | job-detail facet rows | `labels.CATEGORY_LABELS` | local `humanize` — **Sentence case** |
 | `insights.ts` | indexed `/insights` pages | **its own 35-entry map** | local title-case regex |
 
+A fourth surface was missed in the first pass and found in review: `routes/open/+page.svelte`
+labels its seniority and work-mode distributions with a private fallback and consults no
+shared map at all, so the sitemap'd `/open` page prints "C level" and "Onsite" where the rest
+of the app prints "C-level" and "On-site". Different vocabularies from the ones this change
+set out to fix, same defect — so it is fixed here rather than left as a known divergence that
+would falsify the first requirement on the day it is archived.
+
 `labels.ts` states its rule in its opening comment: "only the codes whose label differs from
 the title-cased fallback are listed here". That rule is coherent for exactly one fallback.
 With two, every multi-word code the map omits is rendered two ways by construction — which is
@@ -63,17 +70,34 @@ testable.
 apparent violation of its own "only the differing codes" rule. The rule is amended in the
 comment for this one map, with the reason recorded in place.
 
-### The vocabulary-coverage test is the enforcement
+### `satisfies Record<Category, string>` is the enforcement
 
-`CATEGORY_VALUES` is generated from the Go vocabulary by `cmd/gen-contracts`. A unit test
-asserting that every generated value is a key of `CATEGORY_LABELS` converts "keep this map in
-sync" from a comment into a build failure the moment contract regeneration adds a code.
+`CATEGORY_VALUES` is generated from the Go vocabulary by `cmd/gen-contracts`, and
+`contracts.ts` exports the matching `Category` union. Writing
 
-**Alternative considered — declare the map as `Record<Category, string>`** and let the
-compiler demand totality. Stronger in principle, and rejected in practice: `CATEGORY_LABELS`
-is consumed by `label(map, value)` helpers typed `Record<string, string>`, so narrowing the
-declaration ripples into those signatures for no gain, and a type error at the regeneration
-site is a worse diagnostic than a test that names the unlabelled code.
+```ts
+export const CATEGORY_LABELS: Record<string, string> = { … } satisfies Record<Category, string>;
+```
+
+converts "keep this map in sync" from a comment into a compile error, in **both**
+directions — verified against this repo's own tsc: a missing code fails with `TS1360`
+naming the property, an extra one with `TS2353`. The declared type stays
+`Record<string, string>`, so the `label(map, value)` helpers and the `options()` call sites
+are untouched; `satisfies` constrains the literal without widening or narrowing the binding.
+
+It runs in the required gate: `main`'s branch protection requires the `web` job, which runs
+`pnpm run check` (`svelte-check`).
+
+**Alternative considered — a unit test asserting `CATEGORY_VALUES ⊆ keys(CATEGORY_LABELS)`.**
+That was the first implementation and it worked, but it is strictly weaker: it is
+one-directional (a label left behind after a category is removed goes undetected), and it is
+a bespoke assertion where the type system already expresses totality. Dropped in favour of
+the one-line constraint.
+
+**Alternative considered — declaring the map as `Record<Category, string>` outright.** Also
+total, but it changes the exported binding's type, which would ripple into the helper
+signatures and force a cast at the direct-index site. `satisfies` gets the check without the
+ripple, which is exactly what it exists for.
 
 ### One title-case helper, owned by `labels.ts`
 

--- a/openspec/changes/unify-facet-display-labels/proposal.md
+++ b/openspec/changes/unify-facet-display-labels/proposal.md
@@ -28,8 +28,9 @@ fork exists precisely because neither fallback was trustworthy enough to rely on
 
 - `CATEGORY_LABELS` becomes **exhaustive** over the generated `CATEGORY_VALUES`, so the
   fallback cannot fire for that closed vocabulary and the two fallback styles stop mattering
-  for categories. A unit test binds the map to the generated vocabulary, so a new backend
-  category fails the suite instead of silently rendering two ways.
+  for categories. `satisfies Record<Category, string>` binds the map to the generated
+  vocabulary in both directions, so an unlabelled new category and a stale leftover label
+  each fail `pnpm run check` — which `main`'s required `web` CI job runs.
 - The `/insights` pages lose their private `CATEGORY_LABELS` and `SENIORITY_LABELS`; they read
   the shared maps. Their category-page titles, H1s and auto-intro sentences keep rendering the
   same strings they render today.
@@ -48,8 +49,15 @@ somewhere:
 
 - The filter panel and the job page start saying "AI Engineering" and "Full-Stack".
 - The filter panel's relocation pill starts saying "Not supported" instead of "None".
-- ~15 multi-word categories on the job page gain their missing capital
-  ("Network engineering" → "Network Engineering"), matching the panel and the indexed pages.
+- Seven multi-word categories on the job page gain their missing capital
+  (`network_engineering`, `engineering_design`, `business_analysis`,
+  `solutions_engineering`, `developer_relations`, `technical_writing`,
+  `customer_success`), matching the panel and the indexed pages.
+- `/open` starts saying "C-level" and "On-site" in its seniority and work-mode
+  distributions, matching every other surface.
+
+`/insights` page titles, H1s and intro sentences are byte-identical apart from the two
+settled category wordings.
 
 No **BREAKING** API change: these are display strings in the SPA. The filter *values* sent to
 the API are the underlying codes and are untouched.
@@ -76,8 +84,11 @@ governs how the codes themselves are derived, and neither is affected.
 - `web/src/lib/facets.ts` — loses its local `humanize` and `categoryLabel`, and its inline
   relocation overrides.
 - `web/src/lib/enrichment.ts` — loses its inline `RELOCATION`; `humanize` renamed.
+- `web/src/routes/open/+page.svelte` — its seniority and work-mode buckets read the shared
+  maps instead of a private fallback; skills keep the local one, being an open vocabulary.
 - Import sites: `web/src/lib/filterSections.ts`, `web/src/lib/components/ProfileForm.svelte`,
   and the three `web/src/routes/insights/*/[category]/+page.server.ts` loaders.
-- Tests: `web/src/lib/insights.test.ts` (the `categoryLabel` cases move), plus a new
-  `web/src/lib/labels.test.ts` holding the vocabulary-coverage guard.
+- Tests: `web/src/lib/insights.test.ts` (the `categoryLabel` cases move, a
+  `seniorityLabel` case is added), plus a new `web/src/lib/labels.test.ts` pinning the
+  settled wordings and the fallback.
 - No backend, database, API or Meilisearch change. No migration.

--- a/openspec/changes/unify-facet-display-labels/proposal.md
+++ b/openspec/changes/unify-facet-display-labels/proposal.md
@@ -1,0 +1,83 @@
+## Why
+
+`web/src/lib/labels.ts` opens by declaring itself the single source of facet display
+labels — "Keeping ONE map prevents the drift that previously left stale region codes and
+inconsistent casing in two places." Three surfaces render those labels, and only one reads
+that map exclusively. The `/insights` SEO pages carry a second, 35-entry `CATEGORY_LABELS`
+of their own, and the job-detail page reaches the shared map through a *different* fallback
+function than the filter panel does. Both forks have already produced visible disagreement
+on pages Google indexes.
+
+The drift is not a tidiness complaint — the same facet code renders under different names
+depending on which page the reader is on:
+
+| code | filter panel | job detail page | /insights (indexed) |
+|---|---|---|---|
+| `ai_engineering` | AI Engineer | AI Engineer | AI Engineering |
+| `fullstack` | Fullstack | Fullstack | Full-Stack |
+| `network_engineering` | Network Engineering | Network engineering | Network Engineering |
+| `not_supported` (relocation) | None | Not supported | — |
+
+The root cause is structural rather than clerical. `CATEGORY_LABELS` deliberately lists only
+the codes whose label differs from a title-cased fallback, but two surfaces supply *different*
+fallbacks: `facets.ts` title-cases every word, `enrichment.ts` capitalises only the first. So
+every multi-word category the map omits renders two ways by construction, and the `/insights`
+fork exists precisely because neither fallback was trustworthy enough to rely on.
+
+## What Changes
+
+- `CATEGORY_LABELS` becomes **exhaustive** over the generated `CATEGORY_VALUES`, so the
+  fallback cannot fire for that closed vocabulary and the two fallback styles stop mattering
+  for categories. A unit test binds the map to the generated vocabulary, so a new backend
+  category fails the suite instead of silently rendering two ways.
+- The `/insights` pages lose their private `CATEGORY_LABELS` and `SENIORITY_LABELS`; they read
+  the shared maps. Their category-page titles, H1s and auto-intro sentences keep rendering the
+  same strings they render today.
+- `RELOCATION_LABELS` moves into `labels.ts` and is read by both the filter panel and the
+  job-detail facet row, replacing two divergent inline maps.
+- One title-cased fallback (`titleCase`) is owned by `labels.ts` and imported by `facets.ts`,
+  instead of being declared in both. `enrichment.ts`'s sentence-cased fallback stays and is
+  renamed `sentenceCase` — its current name and doc comment claim title case and demonstrate
+  sentence case, which is how the divergence stayed invisible.
+- Wording decisions settled by the product owner and applied once, in one place:
+  `ai_engineering` → **AI Engineering**, `fullstack` → **Full-Stack**,
+  relocation `not_supported` → **Not supported**.
+
+Visible consequences, all of them convergences onto a string the product already shows
+somewhere:
+
+- The filter panel and the job page start saying "AI Engineering" and "Full-Stack".
+- The filter panel's relocation pill starts saying "Not supported" instead of "None".
+- ~15 multi-word categories on the job page gain their missing capital
+  ("Network engineering" → "Network Engineering"), matching the panel and the indexed pages.
+
+No **BREAKING** API change: these are display strings in the SPA. The filter *values* sent to
+the API are the underlying codes and are untouched.
+
+## Capabilities
+
+### New Capabilities
+
+- `facet-display-labels`: how the SPA turns a closed-vocabulary facet code into the text a
+  reader sees, and the rule that one code renders as one string on every surface — the filter
+  panel, the job-detail facet rows, and the indexed `/insights` pages.
+
+### Modified Capabilities
+
+None. No existing spec states a requirement about how a facet code is spelled on screen;
+`market-insights` governs which `/insights` pages get published and `deterministic-facets`
+governs how the codes themselves are derived, and neither is affected.
+
+## Impact
+
+- `web/src/lib/labels.ts` — gains the exhaustive category map, `RELOCATION_LABELS`,
+  `titleCase`, `categoryLabel`.
+- `web/src/lib/insights.ts` — loses two maps and its local `categoryLabel` body.
+- `web/src/lib/facets.ts` — loses its local `humanize` and `categoryLabel`, and its inline
+  relocation overrides.
+- `web/src/lib/enrichment.ts` — loses its inline `RELOCATION`; `humanize` renamed.
+- Import sites: `web/src/lib/filterSections.ts`, `web/src/lib/components/ProfileForm.svelte`,
+  and the three `web/src/routes/insights/*/[category]/+page.server.ts` loaders.
+- Tests: `web/src/lib/insights.test.ts` (the `categoryLabel` cases move), plus a new
+  `web/src/lib/labels.test.ts` holding the vocabulary-coverage guard.
+- No backend, database, API or Meilisearch change. No migration.

--- a/openspec/changes/unify-facet-display-labels/specs/facet-display-labels/spec.md
+++ b/openspec/changes/unify-facet-display-labels/specs/facet-display-labels/spec.md
@@ -2,11 +2,17 @@
 
 ### Requirement: A facet code renders as one string on every surface
 
-The SPA SHALL resolve a closed-vocabulary facet code to its display text through a single
-shared label map, so the filter panel, the job-detail facet rows, and the indexed
-`/insights` pages cannot render the same code under different names. A surface MUST NOT
-declare its own map for a vocabulary the shared module already owns, and MUST NOT reach a
-shared map through a fallback of its own.
+The SPA SHALL resolve a closed-vocabulary facet code to its display text through the
+shared label maps in `labels.ts`, so no two surfaces render the same code under different
+names. A surface MUST NOT declare a competing map for a vocabulary the shared module
+already owns, and MUST NOT label a code from such a vocabulary without consulting that
+map.
+
+A surface MAY keep its own fallback for codes *outside* the map — the job-detail rows
+sentence-case where the filter panel title-cases, because those rows read as prose. That
+freedom is only safe where it cannot reach a real code, which is why the category
+vocabulary is labelled exhaustively (next requirement). Open vocabularies with no shared
+map at all, such as skill tags, are outside this requirement.
 
 #### Scenario: The same category on three surfaces
 
@@ -20,24 +26,29 @@ shared map through a fallback of its own.
   Relocation row of a job's detail page
 - **THEN** both read "Not supported"
 
+#### Scenario: The open-startup page's facet buckets
+
+- **WHEN** the `/open` page renders its seniority and work-mode distributions, whose codes
+  come from the same closed vocabularies
+- **THEN** it reads "C-level" and "On-site", not "C level" and "Onsite"
+
 ### Requirement: The category vocabulary is labelled exhaustively
 
 The shared category label map SHALL carry an entry for every value in the generated
 `CATEGORY_VALUES` vocabulary, so no category is ever rendered through a fallback. The
-binding between map and vocabulary SHALL be enforced by an automated check rather than by
-convention, so adding a category to the backend vocabulary fails the suite until the SPA is
-given its display text.
-
-#### Scenario: Every generated category has a label
-
-- **WHEN** the label suite runs
-- **THEN** it asserts that each value of `CATEGORY_VALUES` is a key of the shared category map
+binding between map and vocabulary SHALL be enforced mechanically rather than by
+convention, in both directions, and the enforcement MUST run in the required CI gate.
 
 #### Scenario: A new backend category arrives without a label
 
 - **WHEN** a category is added to the backend vocabulary and the generated contracts are
   regenerated, but no display text is added
-- **THEN** the label suite fails, naming the unlabelled code
+- **THEN** the type check fails, naming the unlabelled code
+
+#### Scenario: A category leaves the vocabulary
+
+- **WHEN** a category is removed from the backend vocabulary but its label is left behind
+- **THEN** the type check fails, naming the stale label
 
 ### Requirement: An unrecognised code still renders as readable text
 

--- a/openspec/changes/unify-facet-display-labels/specs/facet-display-labels/spec.md
+++ b/openspec/changes/unify-facet-display-labels/specs/facet-display-labels/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: A facet code renders as one string on every surface
+
+The SPA SHALL resolve a closed-vocabulary facet code to its display text through a single
+shared label map, so the filter panel, the job-detail facet rows, and the indexed
+`/insights` pages cannot render the same code under different names. A surface MUST NOT
+declare its own map for a vocabulary the shared module already owns, and MUST NOT reach a
+shared map through a fallback of its own.
+
+#### Scenario: The same category on three surfaces
+
+- **WHEN** a reader sees the category `network_engineering` in the filter panel, in the
+  Category row of a job's detail page, and in the H1 of `/insights/roles/network_engineering`
+- **THEN** all three read "Network Engineering"
+
+#### Scenario: The same relocation value in a filter and on a job
+
+- **WHEN** a reader sees the relocation value `not_supported` as a filter option and as the
+  Relocation row of a job's detail page
+- **THEN** both read "Not supported"
+
+### Requirement: The category vocabulary is labelled exhaustively
+
+The shared category label map SHALL carry an entry for every value in the generated
+`CATEGORY_VALUES` vocabulary, so no category is ever rendered through a fallback. The
+binding between map and vocabulary SHALL be enforced by an automated check rather than by
+convention, so adding a category to the backend vocabulary fails the suite until the SPA is
+given its display text.
+
+#### Scenario: Every generated category has a label
+
+- **WHEN** the label suite runs
+- **THEN** it asserts that each value of `CATEGORY_VALUES` is a key of the shared category map
+
+#### Scenario: A new backend category arrives without a label
+
+- **WHEN** a category is added to the backend vocabulary and the generated contracts are
+  regenerated, but no display text is added
+- **THEN** the label suite fails, naming the unlabelled code
+
+### Requirement: An unrecognised code still renders as readable text
+
+The label lookup SHALL fall back to a title-cased rendering of the code for any value outside
+the map, so a vocabulary the SPA has not yet been taught renders as readable text rather than
+as a blank, a raw snake_case token, or an error. This fallback is a safety net for
+unrecognised input, not the mechanism by which known codes are labelled.
+
+#### Scenario: A code the SPA has never seen
+
+- **WHEN** the SPA is asked to render the category code `quantum_widgets`, which is in no map
+- **THEN** it renders "Quantum Widgets"
+
+### Requirement: The settled wordings
+
+The shared maps SHALL carry these display strings, which resolve wordings that previously
+differed between surfaces:
+
+- `ai_engineering` renders "AI Engineering" — the vocabulary names disciplines
+  (Data Engineering, Network Engineering, Project Management), not job titles.
+- `fullstack` renders "Full-Stack" — already the text on the indexed `/insights` page, and
+  consistent with the hyphenated compounds elsewhere in the vocabulary (Full-time, On-site,
+  C-level, In-house).
+- relocation `not_supported` renders "Not supported" — grammatically parallel to its sibling
+  values Supported and Required, where the former filter-panel wording "None" was ambiguous
+  with "not stated".
+
+#### Scenario: AI engineering is a discipline
+
+- **WHEN** the code `ai_engineering` is rendered on any surface
+- **THEN** it reads "AI Engineering", not "AI Engineer"
+
+#### Scenario: Full-stack keeps its indexed spelling
+
+- **WHEN** the code `fullstack` is rendered on any surface
+- **THEN** it reads "Full-Stack", the spelling already published at `/insights/roles/fullstack`
+
+### Requirement: The `/insights` pages keep their published category set and copy
+
+The `/insights` capability SHALL keep deciding which categories are published and how its
+intro sentences read; only the source of the category's display text changes. The
+category-wide seniority band, which is not a value of the seniority vocabulary, SHALL keep
+its own label on those pages.
+
+#### Scenario: The all-levels band
+
+- **WHEN** an `/insights` salary table renders the category-wide band, whose seniority value
+  is the empty string
+- **THEN** it reads "All levels", and the shared seniority map is not consulted for it
+
+#### Scenario: The published set is unchanged
+
+- **WHEN** the change is applied
+- **THEN** the set of categories that clear the publication floor, and the auto-intro
+  sentences generated for them, are exactly what they were before

--- a/openspec/changes/unify-facet-display-labels/tasks.md
+++ b/openspec/changes/unify-facet-display-labels/tasks.md
@@ -1,0 +1,50 @@
+## 1. Bind the category map to the generated vocabulary
+
+- [ ] 1.1 Add `web/src/lib/labels.test.ts` with a failing coverage test: every value of
+  `CATEGORY_VALUES` (from `$lib/generated/contracts`) is a key of `CATEGORY_LABELS`, and the
+  failure message names the missing codes. Also assert the three settled wordings
+  (`ai_engineering` → "AI Engineering", `fullstack` → "Full-Stack") and that
+  `RELOCATION_LABELS.not_supported` is "Not supported".
+- [ ] 1.2 Make it pass: extend `CATEGORY_LABELS` in `web/src/lib/labels.ts` to cover every
+  `CATEGORY_VALUES` entry including `other`, applying the settled wordings; add
+  `RELOCATION_LABELS`. Amend the file's opening comment to record why this one map is
+  exhaustive while its siblings stay override-only.
+
+## 2. Give the label lookup one home
+
+- [ ] 2.1 Move `facets.ts`'s `humanize` into `labels.ts` as the exported `titleCase`, and
+  `facets.ts`'s `categoryLabel` into `labels.ts` alongside it. Import `titleCase` back into
+  `facets.ts` for `options()` and `sourceLabel`. Cover the fallback
+  (`categoryLabel('quantum_widgets')` → "Quantum Widgets") in `labels.test.ts`.
+- [ ] 2.2 Point `web/src/lib/filterSections.ts` and `web/src/lib/components/ProfileForm.svelte`
+  at `$lib/labels` for `categoryLabel`. No re-export shim in `facets.ts`.
+- [ ] 2.3 Replace `facets.ts`'s inline relocation overrides with `RELOCATION_LABELS`.
+
+## 3. Retire the `/insights` fork
+
+- [ ] 3.1 Delete `CATEGORY_LABELS`, `SENIORITY_LABELS` and the body of `categoryLabel` from
+  `web/src/lib/insights.ts`; reduce `seniorityLabel` to the empty-string band plus a delegation
+  to the shared map and `titleCase`.
+- [ ] 3.2 Point the three `/insights` loaders
+  (`routes/insights/{roles,salary,skills}/[category]/+page.server.ts`) at `$lib/labels` for
+  `categoryLabel`.
+- [ ] 3.3 Move the `categoryLabel` cases out of `web/src/lib/insights.test.ts` (they now live in
+  `labels.test.ts`) and add a case pinning `seniorityLabel('')` to "All levels". Confirm the
+  intro-sentence and `coveredCategories` tests still pass unchanged.
+
+## 4. Align the job-detail facet rows
+
+- [ ] 4.1 Replace `enrichment.ts`'s module-level `RELOCATION` with `RELOCATION_LABELS` from
+  `labels.ts`.
+- [ ] 4.2 Rename `enrichment.ts`'s `humanize` to `sentenceCase` and correct its doc comment,
+  which currently claims title case and demonstrates sentence case. Do not merge it with
+  `titleCase` — the other facets on that page depend on it.
+
+## 5. Verify and finish
+
+- [ ] 5.1 Run the web checks: `pnpm -C web test`, `pnpm -C web check`, `pnpm -C web build`.
+- [ ] 5.2 Grep the tree for any surviving second declaration of a category or relocation label
+  map, and for any remaining importer of `categoryLabel` from `$lib/facets` or `$lib/insights`.
+- [ ] 5.3 Visually confirm the three converged surfaces render the settled strings: a category
+  in the filter panel, the Category and Relocation rows of a job detail page, and an
+  `/insights/roles/<category>` H1.

--- a/openspec/changes/unify-facet-display-labels/tasks.md
+++ b/openspec/changes/unify-facet-display-labels/tasks.md
@@ -1,50 +1,63 @@
 ## 1. Bind the category map to the generated vocabulary
 
-- [ ] 1.1 Add `web/src/lib/labels.test.ts` with a failing coverage test: every value of
-  `CATEGORY_VALUES` (from `$lib/generated/contracts`) is a key of `CATEGORY_LABELS`, and the
-  failure message names the missing codes. Also assert the three settled wordings
-  (`ai_engineering` → "AI Engineering", `fullstack` → "Full-Stack") and that
-  `RELOCATION_LABELS.not_supported` is "Not supported".
-- [ ] 1.2 Make it pass: extend `CATEGORY_LABELS` in `web/src/lib/labels.ts` to cover every
-  `CATEGORY_VALUES` entry including `other`, applying the settled wordings; add
-  `RELOCATION_LABELS`. Amend the file's opening comment to record why this one map is
-  exhaustive while its siblings stay override-only.
+- [x] 1.1 Add `web/src/lib/labels.test.ts` pinning the settled wordings
+  (`ai_engineering` → "AI Engineering", `fullstack` → "Full-Stack",
+  `RELOCATION_LABELS.not_supported` → "Not supported") and the title-cased fallback.
+- [x] 1.2 Extend `CATEGORY_LABELS` in `web/src/lib/labels.ts` to cover every `CATEGORY_VALUES`
+  entry including `other`, applying the settled wordings; add `RELOCATION_LABELS`. Amend the
+  file's opening comment to record why this one map is exhaustive while its siblings stay
+  override-only.
+- [x] 1.3 Constrain the map with `satisfies Record<Category, string>` so exhaustiveness is a
+  compile error in both directions, and delete the runtime coverage assertion it replaces.
+  (Adopted after review — verified: `TS1360` names an unlabelled code, `TS2353` names a stale
+  one, and `pnpm run check` runs in the required `web` CI job.)
 
 ## 2. Give the label lookup one home
 
-- [ ] 2.1 Move `facets.ts`'s `humanize` into `labels.ts` as the exported `titleCase`, and
+- [x] 2.1 Move `facets.ts`'s `humanize` into `labels.ts` as the exported `titleCase`, and
   `facets.ts`'s `categoryLabel` into `labels.ts` alongside it. Import `titleCase` back into
-  `facets.ts` for `options()` and `sourceLabel`. Cover the fallback
-  (`categoryLabel('quantum_widgets')` → "Quantum Widgets") in `labels.test.ts`.
-- [ ] 2.2 Point `web/src/lib/filterSections.ts` and `web/src/lib/components/ProfileForm.svelte`
+  `facets.ts` for `options()`, `companyLabel`, `roleLabel` and `sourceLabel`.
+- [x] 2.2 Point `web/src/lib/filterSections.ts` and `web/src/lib/components/ProfileForm.svelte`
   at `$lib/labels` for `categoryLabel`. No re-export shim in `facets.ts`.
-- [ ] 2.3 Replace `facets.ts`'s inline relocation overrides with `RELOCATION_LABELS`.
+- [x] 2.3 Replace `facets.ts`'s inline relocation overrides with `RELOCATION_LABELS`.
 
 ## 3. Retire the `/insights` fork
 
-- [ ] 3.1 Delete `CATEGORY_LABELS`, `SENIORITY_LABELS` and the body of `categoryLabel` from
+- [x] 3.1 Delete `CATEGORY_LABELS`, `SENIORITY_LABELS` and the body of `categoryLabel` from
   `web/src/lib/insights.ts`; reduce `seniorityLabel` to the empty-string band plus a delegation
   to the shared map and `titleCase`.
-- [ ] 3.2 Point the three `/insights` loaders
+- [x] 3.2 Point the three `/insights` loaders
   (`routes/insights/{roles,salary,skills}/[category]/+page.server.ts`) at `$lib/labels` for
   `categoryLabel`.
-- [ ] 3.3 Move the `categoryLabel` cases out of `web/src/lib/insights.test.ts` (they now live in
-  `labels.test.ts`) and add a case pinning `seniorityLabel('')` to "All levels". Confirm the
-  intro-sentence and `coveredCategories` tests still pass unchanged.
+- [x] 3.3 Move the `categoryLabel` cases out of `web/src/lib/insights.test.ts` (they now live in
+  `labels.test.ts`) and add cases pinning `seniorityLabel('')` to "All levels" and a real token
+  to its shared-vocabulary label. Confirm the intro-sentence and `coveredCategories` tests still
+  pass unchanged.
 
 ## 4. Align the job-detail facet rows
 
-- [ ] 4.1 Replace `enrichment.ts`'s module-level `RELOCATION` with `RELOCATION_LABELS` from
+- [x] 4.1 Replace `enrichment.ts`'s module-level `RELOCATION` with `RELOCATION_LABELS` from
   `labels.ts`.
-- [ ] 4.2 Rename `enrichment.ts`'s `humanize` to `sentenceCase` and correct its doc comment,
-  which currently claims title case and demonstrates sentence case. Do not merge it with
-  `titleCase` — the other facets on that page depend on it.
+- [x] 4.2 Rename `enrichment.ts`'s `humanize` to `sentenceCase` and correct its doc comment,
+  which claimed title case and demonstrated sentence case. Do not merge it with `titleCase` —
+  the other facets on that page depend on it.
 
-## 5. Verify and finish
+## 5. Close the fourth surface (found in review)
 
-- [ ] 5.1 Run the web checks: `pnpm -C web test`, `pnpm -C web check`, `pnpm -C web build`.
-- [ ] 5.2 Grep the tree for any surviving second declaration of a category or relocation label
+- [x] 5.1 `routes/open/+page.svelte` labels its seniority and work-mode distributions with a
+  private fallback, so the sitemap'd `/open` page reads "C level" and "Onsite". Point those two
+  buckets at `SENIORITY_LABELS` / `WORK_MODE_LABELS`; leave skills on the local fallback, being
+  an open vocabulary with no shared map.
+- [x] 5.2 Narrow the first spec requirement: a surface must not declare a competing map or
+  label a code without consulting the shared one, but may keep its own fallback for codes
+  outside it — which is what `enrichment.ts` does by design, and what the requirement as first
+  written wrongly forbade.
+
+## 6. Verify and finish
+
+- [x] 6.1 Run the web gate: `pnpm test`, `pnpm check`, `pnpm lint`, `pnpm build`.
+- [x] 6.2 Grep the tree for any surviving second declaration of a category or relocation label
   map, and for any remaining importer of `categoryLabel` from `$lib/facets` or `$lib/insights`.
-- [ ] 5.3 Visually confirm the three converged surfaces render the settled strings: a category
-  in the filter panel, the Category and Relocation rows of a job detail page, and an
-  `/insights/roles/<category>` H1.
+- [ ] 6.3 Visually confirm the converged surfaces render the settled strings: a category in the
+  filter panel, the Category and Relocation rows of a job detail page, an
+  `/insights/roles/<category>` H1, and the `/open` seniority bucket.

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -3,12 +3,12 @@
   import { api, ApiError, RESUME_MAX_MB } from '$lib/api';
   import {
     CATEGORY_OPTIONS,
-    categoryLabel,
     COUNTRY_OPTIONS,
     REGION_OPTIONS,
     WORK_MODE_OPTIONS,
     type FacetOption,
   } from '$lib/facets';
+  import { categoryLabel } from '$lib/labels';
   import { profileStore } from '$lib/profile.svelte';
   import type { LocationPreferences, UserProfile } from '$lib/types';
   import { Button, Input } from '$lib/ui';

--- a/web/src/lib/enrichment.ts
+++ b/web/src/lib/enrichment.ts
@@ -1,6 +1,7 @@
 // Presentation helpers for a job's AI enrichment. Pure functions that turn the
-// controlled-vocabulary codes (validated server-side) into display labels.
-// Unknown codes fall back to a humanized form so a future vocabulary addition
+// controlled-vocabulary codes (validated server-side) into display labels, all of
+// them read from labels.ts so this page cannot disagree with the filter panel.
+// Unknown codes fall back to a sentence-cased form so a future vocabulary addition
 // never renders blank — the SPA never re-validates, it only formats.
 
 import type { Enrichment, Job } from './types';
@@ -8,6 +9,7 @@ import { countryLabel } from './facets';
 import {
   REGION_LABELS, SENIORITY_LABELS, EMPLOYMENT_LABELS, WORK_MODE_LABELS,
   CATEGORY_LABELS, DOMAIN_LABELS, COMPANY_TYPE_LABELS, ENGLISH_LEVEL_LABELS,
+  RELOCATION_LABELS,
 } from './labels';
 
 /** One value within a facet row: its display text and, when the facet maps to a
@@ -28,12 +30,6 @@ export interface Facet {
   values: FacetValue[];
 }
 
-const RELOCATION: Record<string, string> = {
-  not_supported: 'Not supported',
-  supported: 'Supported',
-  required: 'Required',
-};
-
 const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', EUR: '€', GBP: '£' };
 
 const PERIOD_SUFFIX: Record<string, string> = {
@@ -43,15 +39,18 @@ const PERIOD_SUFFIX: Record<string, string> = {
   // `year` is the implicit default and reads cleaner without a suffix.
 };
 
-/** Title-case an unknown snake_case code (e.g. "data_engineering" → "Data engineering"). */
-function humanize(value: string): string {
+/** Sentence-case an unknown snake_case code (e.g. "data_engineering" → "Data
+ *  engineering"). Deliberately different from labels.ts's titleCase: the facet rows on
+ *  this page read as prose. Only reached by codes outside their map — the category
+ *  vocabulary is labelled exhaustively, so it never lands here. */
+function sentenceCase(value: string): string {
   const spaced = value.replace(/_/g, ' ');
   return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }
 
-/** Look a code up in its label map, humanizing anything outside the map. */
+/** Look a code up in its label map, sentence-casing anything outside the map. */
 function label(map: Record<string, string>, value: string): string {
-  return map[value] ?? humanize(value);
+  return map[value] ?? sentenceCase(value);
 }
 
 /** The job-feed URL that filters by a single facet value. The feed lives at the
@@ -188,7 +187,7 @@ export function summaryFacets(job: Job): Facet[] {
   link('English', 'english_level', english, ENGLISH_LEVEL_LABELS);
   link('Category', 'category', e.category, CATEGORY_LABELS);
   links('Country', 'countries', job.countries, countryLabel, true);
-  link('Relocation', 'relocation', e.relocation, RELOCATION);
+  link('Relocation', 'relocation', e.relocation, RELOCATION_LABELS);
   if (e.visa_sponsorship === true) {
     facets.push({ label: 'Visa', values: [{ text: 'Sponsored', href: filterHref('visa_sponsorship', 'true') }] });
   }

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -5,10 +5,11 @@
 //
 // SOURCE_VALUES and the other generated value arrays (WORK_MODE_VALUES, etc.)
 // in ./generated/contracts are the single source of truth for closed-vocabulary
-// option values. A new backend value appears automatically here (humanized);
-// only the label-override map below needs updating when the label differs from
-// the title-cased fallback. REGION and CURRENCY are curated subsets not driven
-// by generated arrays — leave those alone. Job language is a dynamic facet: its
+// option values, and labels.ts is the single source of their display text. A new
+// backend value appears automatically here, title-cased, unless labels.ts overrides
+// it — except for categories, whose map is exhaustive and fails its test until the
+// new value is named. REGION and CURRENCY are curated subsets not driven by
+// generated arrays — leave those alone. Job language is a dynamic facet: its
 // options come from the live distribution (any detected language), labelled via
 // languageLabel.
 
@@ -21,6 +22,7 @@ import { fuzzyMatch } from './fuzzy';
 import {
   REGION_LABELS, SENIORITY_LABELS, EMPLOYMENT_LABELS, WORK_MODE_LABELS,
   CATEGORY_LABELS, DOMAIN_LABELS, COMPANY_TYPE_LABELS, ENGLISH_LEVEL_LABELS,
+  RELOCATION_LABELS, titleCase,
 } from './labels';
 import { COLLECTIONS } from './collections';
 import { ROLE_RELATED } from './roleRelated';
@@ -157,11 +159,11 @@ export function languageLabel(code: string): string {
 }
 
 // Company facet values are slugs (group-ib, epam); the live distribution carries
-// no display name, so humanize the slug for a readable label. Imperfect for
+// no display name, so title-case the slug for a readable label. Imperfect for
 // acronyms (group-ib → "Group Ib") but consistent with the other facets — a real
 // slug→name lookup would need a per-company fetch, which this facet forgoes.
 export function companyLabel(slug: string): string {
-  return humanize(slug.replace(/-/g, '_'));
+  return titleCase(slug.replace(/-/g, '_'));
 }
 
 // Option source for the Company facet's 'remote' control: the count-ordered
@@ -203,7 +205,7 @@ async function subindustrySearch(query: string): Promise<FacetOption[]> {
 // ROLE_LABELS catalog (the roletag dictionary is the source of truth), falling
 // back to a humanized slug for a value the catalog somehow lacks.
 export function roleLabel(slug: string): string {
-  return (ROLE_LABELS as Record<string, string>)[slug] ?? humanize(slug);
+  return (ROLE_LABELS as Record<string, string>)[slug] ?? titleCase(slug);
 }
 
 /** Display label for a dynamic facet value: country code → name, company slug →
@@ -301,17 +303,9 @@ export function optionMatches(
   return !!aliases && aliases.some((a) => fuzzyMatch(a, query));
 }
 
-/** A title-cased fallback label for a value with no explicit label. */
-function humanize(value: string): string {
-  return value
-    .split('_')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
-}
-
 /** Build facet options from generated values, overriding labels where given. */
 function options(values: readonly string[], labels: Record<string, string> = {}): FacetOption[] {
-  return values.map((value) => ({ value, label: labels[value] ?? humanize(value) }));
+  return values.map((value) => ({ value, label: labels[value] ?? titleCase(value) }));
 }
 
 // Label overrides for the source facet, where the display name differs from the
@@ -329,7 +323,7 @@ const SOURCE_LABELS: Record<string, string> = {
 /** Display label for a source slug (e.g. smartrecruiters → "SmartRecruiters"),
  *  used by the dynamic source select; falls back to the humanized slug. */
 export function sourceLabel(value: string): string {
-  return SOURCE_LABELS[value] ?? humanize(value);
+  return SOURCE_LABELS[value] ?? titleCase(value);
 }
 
 // The backend's `regions` reach vocabulary (vocab.RegionValues): one consistent
@@ -355,9 +349,7 @@ const WORK_MODE: FacetOption[] = options(WORK_MODE_VALUES, WORK_MODE_LABELS);
 const SENIORITY: FacetOption[] = options(SENIORITY_VALUES, SENIORITY_LABELS);
 const COMPANY_TYPE: FacetOption[] = options(COMPANY_TYPE_VALUES, COMPANY_TYPE_LABELS);
 const EMPLOYMENT: FacetOption[] = options(EMPLOYMENT_TYPE_VALUES, EMPLOYMENT_LABELS);
-const RELOCATION: FacetOption[] = options(RELOCATION_VALUES, {
-  not_supported: 'None', supported: 'Supported', required: 'Required',
-});
+const RELOCATION: FacetOption[] = options(RELOCATION_VALUES, RELOCATION_LABELS);
 const ENGLISH: FacetOption[] = options(ENGLISH_LEVEL_VALUES, ENGLISH_LEVEL_LABELS);
 const CATEGORY: FacetOption[] = options(CATEGORY_VALUES, CATEGORY_LABELS);
 
@@ -370,11 +362,6 @@ export const CATEGORY_OPTIONS: FacetOption[] = CATEGORY;
 export const WORK_MODE_OPTIONS: FacetOption[] = WORK_MODE;
 export const REGION_OPTIONS: FacetOption[] = REGION;
 
-/** Display label for a category code (e.g. ml_ai → "ML / AI"), shared by the profile
- *  view; falls back to the humanized code. */
-export function categoryLabel(value: string): string {
-  return CATEGORY_LABELS[value] ?? humanize(value);
-}
 const DOMAINS: FacetOption[] = options(DOMAIN_VALUES, DOMAIN_LABELS);
 
 // The job-reality classes (internal/jobreality) — a small closed set, spelled out

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -203,13 +203,13 @@ async function subindustrySearch(query: string): Promise<FacetOption[]> {
 // Role facet values are canonical slugs (senior_backend, founding_engineer); the
 // live distribution carries no display name, so map them through the generated
 // ROLE_LABELS catalog (the roletag dictionary is the source of truth), falling
-// back to a humanized slug for a value the catalog somehow lacks.
+// back to a title-cased slug for a value the catalog somehow lacks.
 export function roleLabel(slug: string): string {
   return (ROLE_LABELS as Record<string, string>)[slug] ?? titleCase(slug);
 }
 
 /** Display label for a dynamic facet value: country code → name, company slug →
- *  humanized name, else the value. */
+ *  title-cased name, else the value. */
 export function dynamicLabel(param: string, value: string): string {
   if (param === 'countries') return countryLabel(value);
   if (param === 'posting_language') return languageLabel(value);
@@ -321,7 +321,7 @@ const SOURCE_LABELS: Record<string, string> = {
 };
 
 /** Display label for a source slug (e.g. smartrecruiters → "SmartRecruiters"),
- *  used by the dynamic source select; falls back to the humanized slug. */
+ *  used by the dynamic source select; falls back to the title-cased slug. */
 export function sourceLabel(value: string): string {
   return SOURCE_LABELS[value] ?? titleCase(value);
 }

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -9,7 +9,7 @@
 // silently fall out of the modal.
 
 import { CATEGORY_VALUES, type Category } from './generated/contracts';
-import { categoryLabel } from './facets';
+import { categoryLabel } from './labels';
 
 // `SAVED` heads the job modal's "My filters" tab; `FILTERS` heads the (single-section)
 // company modal rail. Both ride the same shell as the job sections below.

--- a/web/src/lib/insights.test.ts
+++ b/web/src/lib/insights.test.ts
@@ -9,7 +9,7 @@ import {
   skillsIntro,
   rolesIntro,
   MIN_CATEGORY_OPEN,
-  categoryLabel,
+  seniorityLabel,
 } from './insights';
 
 const role = (category: string, seniority: string, open_count: number): InsightRole => ({
@@ -110,9 +110,16 @@ describe('auto-intros', () => {
   });
 });
 
-describe('categoryLabel', () => {
-  it('maps known tokens and title-cases unknowns', () => {
-    expect(categoryLabel('ml_ai')).toBe('ML / AI');
-    expect(categoryLabel('quantum_widgets')).toBe('Quantum Widgets');
+describe('seniorityLabel', () => {
+  // The category-wide band is an /insights concept, not a value of the seniority
+  // vocabulary — it must keep its label here even though every real token is now
+  // resolved through the shared map.
+  it('names the category-wide band', () => {
+    expect(seniorityLabel('')).toBe('All levels');
+  });
+
+  it('resolves a real seniority token through the shared vocabulary', () => {
+    expect(seniorityLabel('c_level')).toBe('C-level');
+    expect(seniorityLabel('senior')).toBe('Senior');
   });
 });

--- a/web/src/lib/insights.ts
+++ b/web/src/lib/insights.ts
@@ -1,57 +1,21 @@
 // Pure helpers behind the /insights SEO pages: the data-quality gate that decides
-// which categories get published pages, human labels for the enrichment category /
-// seniority tokens, and the deterministic auto-intro sentences. Kept free of fetch
-// and Svelte so it is unit-testable in isolation; the routes fetch via the API and
-// feed these functions.
+// which categories get published pages, the seniority rank order, and the
+// deterministic auto-intro sentences. Kept free of fetch and Svelte so it is
+// unit-testable in isolation; the routes fetch via the API and feed these functions.
+//
+// Display text is NOT owned here — these pages read the same labels.ts maps the
+// filter panel and the job page read, so a category cannot be spelled one way on an
+// indexed page and another way in the app. The one exception is the category-wide
+// seniority band, which is an /insights concept rather than a vocabulary value.
 
 import type { InsightRole, InsightSalaryBand, InsightSkill } from './api';
+import { SENIORITY_LABELS, categoryLabel, titleCase } from './labels';
 
 /** A category is published only when its open-job demand clears this floor, so no
  *  thin page ships. Tunable; deliberately conservative. */
 export const MIN_CATEGORY_OPEN = 25;
 
-/** Human labels for the lowercase enrichment category tokens. Unlisted tokens fall
- *  back to a title-cased form. `other` is intentionally never published. */
-export const CATEGORY_LABELS: Record<string, string> = {
-  backend: 'Backend',
-  frontend: 'Frontend',
-  fullstack: 'Full-Stack',
-  mobile: 'Mobile',
-  devops: 'DevOps',
-  sre: 'SRE',
-  network_engineering: 'Network Engineering',
-  data_engineering: 'Data Engineering',
-  data_science: 'Data Science',
-  data_analytics: 'Data Analytics',
-  ml_ai: 'ML / AI',
-  ai_engineering: 'AI Engineering',
-  qa: 'QA',
-  security: 'Security',
-  hardware: 'Hardware',
-  embedded: 'Embedded',
-  blockchain: 'Blockchain',
-  architecture: 'Architecture',
-  design: 'Design',
-  engineering_design: 'Engineering Design',
-  product: 'Product',
-  project_management: 'Project Management',
-  management: 'Management',
-  marketing: 'Marketing',
-  sales: 'Sales',
-  support: 'Support',
-  business_analysis: 'Business Analysis',
-  solutions_engineering: 'Solutions Engineering',
-  developer_relations: 'Developer Relations',
-  technical_writing: 'Technical Writing',
-  recruiting: 'Recruiting',
-  hr: 'HR',
-  finance: 'Finance',
-  legal: 'Legal',
-  operations: 'Operations',
-  customer_success: 'Customer Success',
-};
-
-/** Seniority tokens in rank order, with labels. '' is the category-wide band. */
+/** Seniority tokens in rank order. '' is the category-wide band. */
 export const SENIORITY_ORDER = [
   'intern',
   'junior',
@@ -63,24 +27,12 @@ export const SENIORITY_ORDER = [
   'c_level',
 ] as const;
 
-export const SENIORITY_LABELS: Record<string, string> = {
-  '': 'All levels',
-  intern: 'Intern',
-  junior: 'Junior',
-  middle: 'Middle',
-  senior: 'Senior',
-  lead: 'Lead',
-  staff: 'Staff',
-  principal: 'Principal',
-  c_level: 'C-level',
-};
-
-export function categoryLabel(category: string): string {
-  return CATEGORY_LABELS[category] ?? category.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
+/** The seniority label for an /insights table row. Every real token resolves through
+ *  the shared vocabulary; the empty string is this capability's own category-wide
+ *  band, which is not a seniority value and so is not in the shared map. */
 export function seniorityLabel(seniority: string): string {
-  return SENIORITY_LABELS[seniority] ?? seniority;
+  if (seniority === '') return 'All levels';
+  return SENIORITY_LABELS[seniority] ?? titleCase(seniority);
 }
 
 export interface CoveredCategory {

--- a/web/src/lib/labels.test.ts
+++ b/web/src/lib/labels.test.ts
@@ -1,18 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { CATEGORY_VALUES } from './generated/contracts';
 import { CATEGORY_LABELS, RELOCATION_LABELS, categoryLabel, titleCase } from './labels';
 
+// Exhaustiveness over the generated vocabulary is enforced by the type checker rather
+// than here: CATEGORY_LABELS carries `satisfies Record<Category, string>`, so
+// `pnpm run check` fails in BOTH directions — a category added to the backend and left
+// unlabelled (TS1360) and a label left behind after a category is removed (TS2353).
+// These cases pin the wordings that were product decisions rather than mechanical ones.
 describe('CATEGORY_LABELS', () => {
-  // The category map is the one label map that must be exhaustive: three surfaces
-  // render it through two different fallbacks (facets.ts title-cases every word,
-  // enrichment.ts capitalizes only the first), so any code the map omits renders two
-  // ways by construction. This test is what keeps the map bound to the backend
-  // vocabulary — a new category fails here instead of quietly rendering twice.
-  it('labels every category in the generated vocabulary', () => {
-    const unlabelled = CATEGORY_VALUES.filter((value) => !(value in CATEGORY_LABELS));
-    expect(unlabelled).toEqual([]);
-  });
-
   it('names AI engineering as a discipline, not a job title', () => {
     expect(CATEGORY_LABELS.ai_engineering).toBe('AI Engineering');
   });

--- a/web/src/lib/labels.test.ts
+++ b/web/src/lib/labels.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { CATEGORY_VALUES } from './generated/contracts';
+import { CATEGORY_LABELS, RELOCATION_LABELS, categoryLabel, titleCase } from './labels';
+
+describe('CATEGORY_LABELS', () => {
+  // The category map is the one label map that must be exhaustive: three surfaces
+  // render it through two different fallbacks (facets.ts title-cases every word,
+  // enrichment.ts capitalizes only the first), so any code the map omits renders two
+  // ways by construction. This test is what keeps the map bound to the backend
+  // vocabulary — a new category fails here instead of quietly rendering twice.
+  it('labels every category in the generated vocabulary', () => {
+    const unlabelled = CATEGORY_VALUES.filter((value) => !(value in CATEGORY_LABELS));
+    expect(unlabelled).toEqual([]);
+  });
+
+  it('names AI engineering as a discipline, not a job title', () => {
+    expect(CATEGORY_LABELS.ai_engineering).toBe('AI Engineering');
+  });
+
+  it('spells fullstack the way the indexed insights page already does', () => {
+    expect(CATEGORY_LABELS.fullstack).toBe('Full-Stack');
+  });
+});
+
+describe('categoryLabel', () => {
+  it('reads the shared map', () => {
+    expect(categoryLabel('ml_ai')).toBe('ML / AI');
+  });
+
+  // The safety net for a vocabulary the SPA has not been taught yet — not the
+  // mechanism by which known categories are labelled, which is the map above.
+  it('title-cases a code it has never seen', () => {
+    expect(categoryLabel('quantum_widgets')).toBe('Quantum Widgets');
+  });
+});
+
+describe('titleCase', () => {
+  it('capitalizes every word of a snake_case code', () => {
+    expect(titleCase('network_engineering')).toBe('Network Engineering');
+  });
+});
+
+describe('RELOCATION_LABELS', () => {
+  // The filter panel said "None" and the job page said "Not supported" for the same
+  // code. "None" reads as "not stated"; the other two values of this facet are
+  // participles, so the negative one is too.
+  it('reads as a participle, parallel to its sibling values', () => {
+    expect(RELOCATION_LABELS.not_supported).toBe('Not supported');
+    expect(RELOCATION_LABELS.supported).toBe('Supported');
+    expect(RELOCATION_LABELS.required).toBe('Required');
+  });
+});

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -9,6 +9,8 @@
 // fallback. CATEGORY_LABELS is the deliberate exception and is exhaustive; the reason
 // is recorded above it.
 
+import type { Category } from './generated/contracts';
+
 /** A title-cased fallback label for a code with no explicit label
  *  (e.g. "network_engineering" → "Network Engineering"). Lives here, with the maps,
  *  so "how a label is produced" has one home; enrichment.ts keeps a separate
@@ -79,8 +81,13 @@ export const RELOCATION_LABELS: Record<string, string> = {
 // word, enrichment.ts capitalizes only the first). Any code left to the fallback
 // therefore renders two ways by construction, which is what previously forked an
 // entire second map into insights.ts. Listing every code removes the fallback from the
-// path instead of asking three call sites to agree. labels.test.ts binds this map to
-// CATEGORY_VALUES, so a new backend category fails the suite until it is named here.
+// path instead of asking three call sites to agree.
+//
+// `satisfies Record<Category, string>` is what keeps it exhaustive: adding a category
+// to the backend vocabulary and regenerating contracts fails `pnpm run check` (TS1360,
+// naming the code) until it is labelled here, and removing one fails the same check
+// (TS2353) rather than leaving a stale entry. The declared type stays
+// Record<string, string> because the `label(map, value)` helpers take that shape.
 export const CATEGORY_LABELS: Record<string, string> = {
   backend: 'Backend',
   frontend: 'Frontend',
@@ -119,7 +126,7 @@ export const CATEGORY_LABELS: Record<string, string> = {
   operations: 'Operations',
   customer_success: 'Customer Success',
   other: 'Other',
-};
+} satisfies Record<Category, string>;
 
 /** Display label for a category code (e.g. ml_ai → "ML / AI"), shared by the filter
  *  panel, the profile view and the /insights pages. The map above is exhaustive over

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -1,10 +1,24 @@
-// Single source of display labels for the closed-vocabulary facet codes, shared
-// by the detail-page facet rows (enrichment.ts) and the filter panel (facets.ts).
-// Values come from the generated contracts; only the codes whose label differs
-// from the title-cased fallback are listed here. Keeping ONE map prevents the
-// drift that previously left stale region codes and inconsistent casing in two
-// places. REGIONS is the curated macro-region set (vocab.RegionValues) — keep it
-// in sync with the backend vocabulary.
+// Single source of display labels for the closed-vocabulary facet codes, shared by
+// the detail-page facet rows (enrichment.ts), the filter panel (facets.ts) and the
+// /insights pages (insights.ts). Values come from the generated contracts. Keeping
+// ONE map prevents the drift that previously left stale region codes and inconsistent
+// casing in two places. REGIONS is the curated macro-region set (vocab.RegionValues) —
+// keep it in sync with the backend vocabulary.
+//
+// Most maps here list only the codes whose label differs from the title-cased
+// fallback. CATEGORY_LABELS is the deliberate exception and is exhaustive; the reason
+// is recorded above it.
+
+/** A title-cased fallback label for a code with no explicit label
+ *  (e.g. "network_engineering" → "Network Engineering"). Lives here, with the maps,
+ *  so "how a label is produced" has one home; enrichment.ts keeps a separate
+ *  sentence-cased fallback for the facets it renders. */
+export function titleCase(value: string): string {
+  return value
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
 
 // Region code → display names, one row per vocab.RegionValues entry. `short`
 // is the compact UI label (filter pills, facet rows); `long` is the full place
@@ -47,18 +61,72 @@ export const EMPLOYMENT_LABELS: Record<string, string> = {
 
 export const WORK_MODE_LABELS: Record<string, string> = { onsite: 'On-site' };
 
+// All three relocation values, not just the overrides: the filter panel and the
+// detail-page row previously spelled the negative one differently ("None" vs "Not
+// supported"), and "None" was ambiguous with "not stated". Spelling the whole facet
+// out here keeps the three values reading as one set.
+export const RELOCATION_LABELS: Record<string, string> = {
+  not_supported: 'Not supported',
+  supported: 'Supported',
+  required: 'Required',
+};
+
+// The one map that is EXHAUSTIVE rather than override-only, listed in the order of
+// the generated CATEGORY_VALUES so a diff against the vocabulary reads straight down.
+// Categories are the only vocabulary rendered on all three surfaces — the filter
+// panel, the job-detail facet row, and the indexed /insights pages — and those
+// surfaces reach a label through two different fallbacks (facets.ts title-cases every
+// word, enrichment.ts capitalizes only the first). Any code left to the fallback
+// therefore renders two ways by construction, which is what previously forked an
+// entire second map into insights.ts. Listing every code removes the fallback from the
+// path instead of asking three call sites to agree. labels.test.ts binds this map to
+// CATEGORY_VALUES, so a new backend category fails the suite until it is named here.
 export const CATEGORY_LABELS: Record<string, string> = {
-  ml_ai: 'ML / AI',
-  ai_engineering: 'AI Engineer',
+  backend: 'Backend',
+  frontend: 'Frontend',
+  fullstack: 'Full-Stack',
+  mobile: 'Mobile',
+  devops: 'DevOps',
+  sre: 'SRE',
+  network_engineering: 'Network Engineering',
   data_engineering: 'Data Engineering',
   data_science: 'Data Science',
   data_analytics: 'Data Analytics',
+  ml_ai: 'ML / AI',
+  ai_engineering: 'AI Engineering',
   qa: 'QA',
-  devops: 'DevOps',
-  sre: 'SRE',
+  security: 'Security',
+  hardware: 'Hardware',
+  embedded: 'Embedded',
+  blockchain: 'Blockchain',
+  architecture: 'Architecture',
+  design: 'Design',
+  engineering_design: 'Engineering Design',
+  product: 'Product',
   project_management: 'Project Management',
+  management: 'Management',
+  marketing: 'Marketing',
+  sales: 'Sales',
+  support: 'Support',
+  business_analysis: 'Business Analysis',
+  solutions_engineering: 'Solutions Engineering',
+  developer_relations: 'Developer Relations',
+  technical_writing: 'Technical Writing',
+  recruiting: 'Recruiting',
   hr: 'HR',
+  finance: 'Finance',
+  legal: 'Legal',
+  operations: 'Operations',
+  customer_success: 'Customer Success',
+  other: 'Other',
 };
+
+/** Display label for a category code (e.g. ml_ai → "ML / AI"), shared by the filter
+ *  panel, the profile view and the /insights pages. The map above is exhaustive over
+ *  the vocabulary, so the fallback only fires for a code the SPA has not been taught. */
+export function categoryLabel(value: string): string {
+  return CATEGORY_LABELS[value] ?? titleCase(value);
+}
 
 export const DOMAIN_LABELS: Record<string, string> = {
   fintech: 'FinTech',

--- a/web/src/routes/insights/roles/[category]/+page.server.ts
+++ b/web/src/routes/insights/roles/[category]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
-import { coveredCategories, isCovered, categoryLabel, rolesIntro } from '$lib/insights';
+import { coveredCategories, isCovered, rolesIntro } from '$lib/insights';
+import { categoryLabel } from '$lib/labels';
 import type { PageServerLoad } from './$types';
 
 // Per-category roles landing page: the category's seniorities ranked by open-job

--- a/web/src/routes/insights/salary/[category]/+page.server.ts
+++ b/web/src/routes/insights/salary/[category]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
-import { coveredCategories, isCovered, categoryLabel, sortBandsBySeniority, salaryIntro } from '$lib/insights';
+import { coveredCategories, isCovered, sortBandsBySeniority, salaryIntro } from '$lib/insights';
+import { categoryLabel } from '$lib/labels';
 import type { PageServerLoad } from './$types';
 
 // Per-category salary landing page. The gate (global roles ranking) decides whether

--- a/web/src/routes/insights/skills/[category]/+page.server.ts
+++ b/web/src/routes/insights/skills/[category]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
-import { coveredCategories, isCovered, categoryLabel, skillsIntro } from '$lib/insights';
+import { coveredCategories, isCovered, skillsIntro } from '$lib/insights';
+import { categoryLabel } from '$lib/labels';
 import type { PageServerLoad } from './$types';
 
 // Per-category skill-demand landing page. Gated like the salary page: an uncovered

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -5,6 +5,7 @@
   import GrowthArea from '$lib/components/GrowthArea.svelte';
   import { OPEN_FAQ } from '$lib/openFaq';
   import { breadcrumbJsonLd, datasetJsonLd, faqPageJsonLd, jsonLdScript } from '$lib/seo';
+  import { SENIORITY_LABELS, WORK_MODE_LABELS } from '$lib/labels';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -51,7 +52,13 @@
       return code.toUpperCase();
     }
   }
-  const titleCase = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ');
+  // Skills are an open vocabulary with no shared map, so they keep the local
+  // sentence-cased fallback. Seniority and work mode are closed vocabularies that
+  // labels.ts already names — reading it here is what stops this page printing
+  // "C level" and "Onsite" while the rest of the app prints "C-level" and "On-site".
+  const sentenceCase = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ');
+  const labelled = (map: Record<string, string>) => (code: string) =>
+    map[code] ?? sentenceCase(code);
 
   type Bar = { label: string; count: number };
   function top(facet: Record<string, number> | undefined, n: number, label: (k: string) => string): Bar[] {
@@ -64,9 +71,9 @@
 
   const facets = $derived(data.facets);
   const countries = $derived(top(facets?.countries, 8, countryName));
-  const skills = $derived(top(facets?.skills, 8, titleCase));
-  const seniority = $derived(top(facets?.seniority, 6, titleCase));
-  const workMode = $derived(top(facets?.work_mode, 3, titleCase));
+  const skills = $derived(top(facets?.skills, 8, sentenceCase));
+  const seniority = $derived(top(facets?.seniority, 6, labelled(SENIORITY_LABELS)));
+  const workMode = $derived(top(facets?.work_mode, 3, labelled(WORK_MODE_LABELS)));
 
   // The snapshot endpoint always returns the four facet keys (empty maps before the
   // daily rollup's first run), so `facets` is truthy even when there's nothing to


### PR DESCRIPTION
`web/src/lib/labels.ts` opens by calling itself the single source of facet display labels —
*"Keeping ONE map prevents the drift that previously left stale region codes and inconsistent
casing in two places."* It was not. The `/insights` SEO pages carried a second 35-entry
`CATEGORY_LABELS`, and the job-detail page reached the shared map through a **different
fallback** than the filter panel. Both forks had already drifted, on pages Google indexes.

| code | filter panel | job page | /insights (indexed) |
|---|---|---|---|
| `ai_engineering` | AI Engineer | AI Engineer | AI Engineering |
| `fullstack` | Fullstack | Fullstack | Full-Stack |
| `network_engineering` | Network Engineering | Network **e**ngineering | Network Engineering |
| `not_supported` (relocation) | None | Not supported | — |

## Why it drifted

The map lists only codes whose label differs from a title-cased fallback — coherent for *one*
fallback. There were two: `facets.ts` title-cases every word, `enrichment.ts` capitalises only
the first. So every multi-word code the map omitted rendered two ways **by construction**, which
is also why `insights.ts` grew its own map rather than trusting the shared one.

## What changed

- `CATEGORY_LABELS` is now **exhaustive** over the generated `CATEGORY_VALUES`, so the fallback
  cannot fire for that vocabulary and the two fallback styles stop mattering for categories.
- Exhaustiveness is enforced by `satisfies Record<Category, string>`, which fails
  `pnpm run check` in **both** directions: an unlabelled new category (`TS1360`) and a label left
  behind after a category is removed (`TS2353`). Verified by removing a label and watching it
  fail by name.
- The `/insights` fork is deleted; `titleCase` and `categoryLabel` move to `labels.ts`;
  relocation gets one `RELOCATION_LABELS` read by both surfaces.
- `enrichment.ts`'s `humanize` is renamed `sentenceCase` — its name and doc comment claimed title
  case and demonstrated sentence case, which is how the divergence stayed invisible.

## Found in review

A **fourth** surface: `routes/open/+page.svelte` labelled its seniority and work-mode
distributions with a private fallback and consulted no shared map, so the sitemap'd `/open` page
printed "C level" and "Onsite". Fixed here. Skills keep the local fallback — an open vocabulary
with no shared map.

The spec requirement as first written also forbade *any* surface having its own fallback, which
contradicts the design's own non-goal (`enrichment.ts` keeps sentence case deliberately).
Narrowed to what it means: do not declare a competing map, and do not label a code without
consulting the shared one.

## Visible changes

All are convergences onto a string the product already shows somewhere. Seven multi-word
categories on the job page gain a capital; the panel and job page say "AI Engineering" and
"Full-Stack"; the relocation pill says "Not supported"; `/open` says "C-level" and "On-site".
`/insights` titles and H1s are byte-identical apart from the two settled wordings.

## Verification

`pnpm test` 63 files / 697 tests · `pnpm check` **0 errors** (18 warnings, all pre-existing and
unrelated — confirmed identical at the base commit) · `pnpm lint` unchanged from baseline ·
`pnpm build` ✓

OpenSpec: `unify-facet-display-labels` (new capability `facet-display-labels`).
Acts on **S1** of `docs/reviews/2026-08-01-architecture-review.md`.