### PR TITLE
fix(workers): put the two LLM-spending backfills on the shared bootstrap

### DIFF
--- a/cmd/backfill-experience/main.go
+++ b/cmd/backfill-experience/main.go
@@ -102,7 +102,17 @@ func run() int {
 	}
 
 	var seeded, skipped, failed int
-	for _, t := range targets {
+	var cancelled bool
+	for i, t := range targets {
+		// The root context is signal-bound, so a redeploy's SIGTERM cancels it mid-run.
+		// Without this the loop would run to the end of the list turning every remaining
+		// user into a logged failure, reporting one cancellation as a fleet of them.
+		if ctx.Err() != nil {
+			log.Printf("backfill-experience: cancelled — %d target(s) left unprocessed; the import is "+
+				"idempotent, so re-running finishes them", len(targets)-i)
+			cancelled = true
+			break
+		}
 		st, err := resolveStructured(ctx, t, extractor, resumeStore)
 		if err != nil {
 			log.Printf("user %d: %v", t.id, err)
@@ -137,6 +147,9 @@ func run() int {
 	}
 
 	log.Printf("backfill-experience: done — %d seeded, %d skipped, %d failed", seeded, skipped, failed)
+	if cancelled {
+		return 1
+	}
 	return worker.ExitCode(failed, 0)
 }
 

--- a/cmd/backfill-experience/main.go
+++ b/cmd/backfill-experience/main.go
@@ -25,18 +25,17 @@ import (
 	"encoding/json"
 	"flag"
 	"log"
-	"os"
 	"time"
 
 	"github.com/strelov1/freehire/internal/blobstore"
 	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/pii"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 // extractTimeout bounds a single structured-extraction LLM call, matching the on-upload
@@ -53,20 +52,25 @@ type target struct {
 }
 
 func main() {
+	worker.Main(run)
+}
+
+// run holds the whole worker so every exit is a return value: the Langfuse trace flush
+// and the pool close are deferred here, and os.Exit — which log.Fatalf calls — would
+// skip both on exactly the failed run whose traces explain the failure.
+func run() int {
 	var userID int64
 	var dryRun bool
 	flag.Int64Var(&userID, "user", 0, "seed a single user id (0 = every user with a stored CV)")
 	flag.BoolVar(&dryRun, "dry-run", false, "report what would be imported without writing")
 	flag.Parse()
 
-	cfg := config.Load()
-	ctx := context.Background()
-
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	ctx, cfg, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 	queries := db.New(pool)
 
 	bank := experience.NewStore(experience.NewQueriesRepository(queries))
@@ -78,7 +82,8 @@ func main() {
 
 	targets, err := eligible(ctx, queries, userID)
 	if err != nil {
-		log.Fatalf("query eligible users: %v", err)
+		log.Printf("query eligible users: %v", err)
+		return 1
 	}
 
 	var reusable, needExtract int
@@ -132,9 +137,7 @@ func main() {
 	}
 
 	log.Printf("backfill-experience: done — %d seeded, %d skipped, %d failed", seeded, skipped, failed)
-	if failed > 0 {
-		os.Exit(1)
-	}
+	return worker.ExitCode(failed, 0)
 }
 
 // resolveStructured returns the structured résumé to import for this target: the stored

--- a/cmd/backfill-resume-structured/main.go
+++ b/cmd/backfill-resume-structured/main.go
@@ -141,7 +141,17 @@ func run() int {
 	log.Printf("backfill-resume-structured: %d eligible user(s)%s", len(targets), dryRunSuffix(dryRun))
 
 	var ok, failed int
-	for _, t := range targets {
+	var cancelled bool
+	for i, t := range targets {
+		// The root context is signal-bound, so a redeploy's SIGTERM cancels it mid-run.
+		// Without this the loop would run to the end of the list turning every remaining
+		// user into a logged failure, reporting one cancellation as a fleet of them.
+		if ctx.Err() != nil {
+			log.Printf("backfill-resume-structured: cancelled — %d user(s) left unprocessed; the worker "+
+				"is idempotent, so re-running finishes them", len(targets)-i)
+			cancelled = true
+			break
+		}
 		text, err := store.Text(ctx, t.id)
 		if err != nil {
 			log.Printf("user %d: read CV text: %v", t.id, err)
@@ -171,6 +181,9 @@ func run() int {
 		ok++
 	}
 	log.Printf("backfill-resume-structured: done — %d succeeded, %d failed", ok, failed)
+	if cancelled {
+		return 1
+	}
 	return worker.ExitCode(failed, 0)
 }
 

--- a/cmd/backfill-resume-structured/main.go
+++ b/cmd/backfill-resume-structured/main.go
@@ -24,13 +24,12 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/blobstore"
-	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/pii"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 // extractTimeout bounds a single structured-extraction LLM call, matching the on-upload
@@ -38,20 +37,25 @@ import (
 const extractTimeout = 120 * time.Second
 
 func main() {
+	worker.Main(run)
+}
+
+// run holds the whole worker so every exit is a return value rather than a log.Fatal:
+// os.Exit runs no deferred function, so a fatal after the Langfuse flush is registered
+// would drop the traces for the run that failed.
+func run() int {
 	var userID int64
 	var dryRun bool
 	flag.Int64Var(&userID, "user", 0, "backfill a single user id (0 = every eligible user)")
 	flag.BoolVar(&dryRun, "dry-run", false, "list eligible users without extracting or persisting")
 	flag.Parse()
 
-	cfg := config.Load()
-	ctx := context.Background()
-
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	ctx, cfg, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 	queries := db.New(pool)
 
 	blobStore, err := blobstore.New(blobstore.Config{
@@ -61,10 +65,12 @@ func main() {
 		SecretKey: cfg.S3SecretKey,
 	})
 	if err != nil {
-		log.Fatalf("blobstore: %v", err)
+		log.Printf("blobstore: %v", err)
+		return 1
 	}
 	if blobStore == nil {
-		log.Fatal("backfill-resume-structured: résumé storage (S3_*) is not configured")
+		log.Print("backfill-resume-structured: résumé storage (S3_*) is not configured")
+		return 1
 	}
 
 	llmClient, llmFlush, err := llm.NewClient(llm.Settings{
@@ -76,17 +82,20 @@ func main() {
 		LangfuseSecretKey: cfg.LangfuseSecretKey,
 	}, "resume-structured")
 	if err != nil {
-		log.Fatalf("llm: %v", err)
+		log.Printf("llm: %v", err)
+		return 1
 	}
 	defer llmFlush()
 	if llmClient == nil {
-		log.Fatal("backfill-resume-structured: LLM (LLM_*) is not configured")
+		log.Print("backfill-resume-structured: LLM (LLM_*) is not configured")
+		return 1
 	}
 
 	// The extractor de-identifies each CV before it reaches the LLM; without the detector it
 	// would be fail-closed (a no-op), so a backfill run without it is pointless — require it.
 	if cfg.PIIFilterURL == "" {
-		log.Fatal("backfill-resume-structured: PII_FILTER_URL is not configured")
+		log.Print("backfill-resume-structured: PII_FILTER_URL is not configured")
+		return 1
 	}
 	piiDetector := pii.NewHTTPDetector(cfg.PIIFilterURL, nil)
 
@@ -105,7 +114,8 @@ func main() {
 		       OR resume_structured_uploaded_at IS DISTINCT FROM resume_uploaded_at)
 		ORDER BY id`, userID)
 	if err != nil {
-		log.Fatalf("query eligible users: %v", err)
+		log.Printf("query eligible users: %v", err)
+		return 1
 	}
 	type target struct {
 		id         int64
@@ -117,13 +127,15 @@ func main() {
 		var uploadedAt pgtype.Timestamptz
 		if err := rows.Scan(&id, &uploadedAt); err != nil {
 			rows.Close()
-			log.Fatalf("scan: %v", err)
+			log.Printf("scan: %v", err)
+			return 1
 		}
 		targets = append(targets, target{id: id, uploadedAt: uploadedAt.Time})
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
-		log.Fatalf("iterate: %v", err)
+		log.Printf("iterate: %v", err)
+		return 1
 	}
 
 	log.Printf("backfill-resume-structured: %d eligible user(s)%s", len(targets), dryRunSuffix(dryRun))
@@ -159,6 +171,7 @@ func main() {
 		ok++
 	}
 	log.Printf("backfill-resume-structured: done — %d succeeded, %d failed", ok, failed)
+	return worker.ExitCode(failed, 0)
 }
 
 func dryRunSuffix(dry bool) string {

--- a/internal/worker/cmdbootstrap_test.go
+++ b/internal/worker/cmdbootstrap_test.go
@@ -1,6 +1,9 @@
 package worker_test
 
 import (
+	"go/parser"
+	"go/printer"
+	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,6 +59,17 @@ func TestPoolOpeningCommandsUseSharedBootstrap(t *testing.T) {
 			t.Errorf("cmd/%s opens a database pool without worker.Bootstrap: it gets no Sentry init, "+
 				"no SIGTERM-cancellable context, and its deferred cleanup is at the mercy of os.Exit. "+
 				"Convert it to worker.Main(run) + worker.Bootstrap, or add it to exemptFromBootstrap with a reason.", name)
+			continue
+		}
+
+		// Bootstrap alone is not enough: it registers the pool close and the worker's own
+		// telemetry flush as deferred calls, and os.Exit — which log.Fatal calls — runs no
+		// deferred function. A worker that bootstraps and then log.Fatals still drops both,
+		// on exactly the failed run whose traces would explain it.
+		if strings.Contains(src, "log.Fatal") || strings.Contains(src, "os.Exit") {
+			t.Errorf("cmd/%s uses worker.Bootstrap but still calls log.Fatal or os.Exit: neither runs a "+
+				"deferred function, so the pool close and any buffered telemetry flush are skipped. "+
+				"Return a non-zero code from run() and let worker.Main exit.", name)
 		}
 	}
 
@@ -66,23 +80,32 @@ func TestPoolOpeningCommandsUseSharedBootstrap(t *testing.T) {
 	}
 }
 
-// packageSource concatenates the non-test Go sources of one package directory.
+// packageSource concatenates the non-test Go sources of one package directory with the
+// comments stripped, by re-printing each parsed file. Matching raw text would let a
+// `// TODO: move this to worker.Bootstrap` satisfy the check — which is precisely the
+// comment someone deferring the migration would leave behind.
 func packageSource(dir string) (string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return "", err
 	}
+	fset := token.NewFileSet()
 	var b strings.Builder
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(dir, name))
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.SkipObjectResolution)
 		if err != nil {
 			return "", err
 		}
-		b.Write(data)
+		// printer.Fprint on the *ast.File alone omits comments — they live in File.Comments
+		// and are only emitted for a printer.CommentedNode.
+		if err := printer.Fprint(&b, fset, file); err != nil {
+			return "", err
+		}
+		b.WriteByte('\n')
 	}
 	return b.String(), nil
 }

--- a/internal/worker/cmdbootstrap_test.go
+++ b/internal/worker/cmdbootstrap_test.go
@@ -1,0 +1,88 @@
+package worker_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// exemptFromBootstrap lists the cmd/ binaries that open a database pool without going
+// through worker.Bootstrap, with the reason. Every other pool-opening binary must use
+// the shared bootstrap: it is what initializes Sentry, derives the SIGTERM-cancellable
+// context, and returns the cleanup that closes the pool. Two backfills drifted out of
+// that rule without anything failing, which is why the rule is a test and not a comment.
+var exemptFromBootstrap = map[string]string{
+	"server": "long-lived daemon, not a run-once worker: owns its own startup and shutdown",
+}
+
+// TestPoolOpeningCommandsUseSharedBootstrap derives its population from behaviour rather
+// than from a hand-maintained list of worker names, so a new worker is enrolled by
+// existing rather than by someone remembering to add it here.
+func TestPoolOpeningCommandsUseSharedBootstrap(t *testing.T) {
+	entries, err := os.ReadDir(filepath.Join("..", "..", "cmd"))
+	if err != nil {
+		t.Fatalf("read cmd/: %v", err)
+	}
+
+	// The population is every binary that reaches the database at all: the compliant ones
+	// name worker.Bootstrap and never mention the pool constructor themselves (Bootstrap
+	// opens it for them), so looking only for database.Connect/pgxpool would find the
+	// violators and nothing else — and the suite would look healthy the moment it was empty.
+	var population int
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		src, err := packageSource(filepath.Join("..", "..", "cmd", name))
+		if err != nil {
+			t.Fatalf("read cmd/%s: %v", name, err)
+		}
+		usesBootstrap := strings.Contains(src, "worker.Bootstrap")
+		opensPoolDirectly := strings.Contains(src, "database.Connect") || strings.Contains(src, "pgxpool")
+		if !usesBootstrap && !opensPoolDirectly {
+			continue // touches no database — a code generator or a file-writing harvest tool
+		}
+		population++
+
+		if reason, ok := exemptFromBootstrap[name]; ok {
+			if usesBootstrap {
+				t.Errorf("cmd/%s is listed as exempt (%s) but now uses worker.Bootstrap — drop the exemption", name, reason)
+			}
+			continue
+		}
+		if !usesBootstrap {
+			t.Errorf("cmd/%s opens a database pool without worker.Bootstrap: it gets no Sentry init, "+
+				"no SIGTERM-cancellable context, and its deferred cleanup is at the mercy of os.Exit. "+
+				"Convert it to worker.Main(run) + worker.Bootstrap, or add it to exemptFromBootstrap with a reason.", name)
+		}
+	}
+
+	// Guards against the population silently emptying — a rename of the bootstrap helper or
+	// the pool constructor would otherwise turn this into a test that passes by finding nothing.
+	if population < 25 {
+		t.Errorf("only %d database-touching commands found; the detection is probably broken", population)
+	}
+}
+
+// packageSource concatenates the non-test Go sources of one package directory.
+func packageSource(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return "", err
+		}
+		b.Write(data)
+	}
+	return b.String(), nil
+}

--- a/openspec/changes/backfill-workers-shared-bootstrap/.openspec.yaml
+++ b/openspec/changes/backfill-workers-shared-bootstrap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/backfill-workers-shared-bootstrap/design.md
+++ b/openspec/changes/backfill-workers-shared-bootstrap/design.md
@@ -1,0 +1,113 @@
+## Context
+
+`worker.Main(run func() int)` defers a panic-capture-and-flush and then `os.Exit(run())`.
+`worker.Bootstrap(parent)` returns `(ctx, cfg, pool, cleanup, error)` having already called
+`observability.Init` and derived a `SIGINT`/`SIGTERM`-cancellable context. `cmd/recount-companies`
+is the canonical 39-line consumer.
+
+The two backfills predate none of this — they simply were not converted. Their current shape is:
+
+```
+cfg := config.Load()
+ctx := context.Background()
+pool, err := database.Connect(ctx, cfg.DatabaseURL)
+if err != nil { log.Fatalf(...) }
+defer pool.Close()
+```
+
+which is exactly what `Bootstrap` returns, minus Sentry and minus signal handling.
+
+Measured, not assumed: of the 11 binaries under `cmd/` that do not call `worker.Bootstrap`,
+only three open a database pool — these two and `cmd/server`. The other eight are code
+generators and file-writing harvest tools. That is what makes the guard test cheap: the
+exemption list is one entry, not ten.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bring both workers under the shared bootstrap, so Sentry sees their failures and `SIGTERM`
+  cancels their in-flight LLM calls.
+- Make the deferred Langfuse flush actually run on the failed run.
+- Give `backfill-resume-structured` an exit code that reflects its failure tally.
+- Convert "every worker uses the bootstrap" from prose into a test.
+
+**Non-Goals:**
+
+- Merging the two workers' extractor construction. They encode opposite policies (optional vs
+  fatal), both documented in place; a shared constructor would have to smuggle a flag to
+  reproduce them, which is how one of the two ends up wrong.
+- Touching per-user logic, flags, log lines, or idempotence.
+- Replacing `backfill-resume-structured`'s hand-written eligibility SQL with sqlc. Real, and a
+  separate concern from process lifecycle — mixing it in would hide this diff's point.
+- Rewriting the other nine non-bootstrap binaries. They open no pool; the requirement does not
+  bind them.
+
+## Decisions
+
+### `log.Fatalf` → `return 1`, not a wrapper
+
+Every `log.Fatalf` becomes a `log.Printf` plus `return 1` from `run`. `log.Fatalf` calls
+`os.Exit(1)` internally, which is precisely the defect: it runs no deferred function, so the
+pool close and the Langfuse flush are skipped. The mechanical rule is that inside a
+`worker.Main` worker, the only exit is a return value.
+
+This matters most in `backfill-experience`, where the flush is registered at
+`main.go:76` and the `os.Exit(1)` at `:136` is reached only when `failed > 0` — so the traces
+are dropped on exactly the run that needed them.
+
+In `backfill-resume-structured` the picture is subtler and worth stating: four of its nine
+`log.Fatalf` calls fire *before* `defer llmFlush()` is registered, so those drop nothing today.
+The remaining five do. Converting all nine is still right — it removes the need for anyone to
+work out which is which.
+
+### The guard test scans `cmd/`, and its exemption list is the documentation
+
+A test in `internal/worker` walks `../../cmd/*/`, finds packages that reference
+`database.Connect` or `pgxpool`, and asserts each also references `worker.Bootstrap`. `server`
+is the declared exemption, with the reason in the literal.
+
+**Alternative considered — assert on an explicit list of expected worker names.** Rejected:
+that list would need editing whenever a worker is added, which is the failure mode of the thing
+it replaces. Deriving the population from "opens a pool" means a new worker is enrolled by
+existing.
+
+**Alternative considered — no test, just fix the two.** Rejected because it is what happened
+last time. The whole reason this change exists is that three written requirements did not stop
+two workers drifting out of compliance.
+
+The test reads source text rather than building an import graph. Coarser, but it depends on no
+build tooling, runs in milliseconds, and cannot be defeated by anything short of deliberately
+aliasing the import — for which the honest answer is that the test states an intent, not a
+security boundary.
+
+### `worker.ExitCode`, not a hand-written comparison
+
+`backfill-resume-structured` ends on `worker.ExitCode(failed, 0)`. `backfill-experience`
+already has the equivalent `if failed > 0` and switches to the same helper, so both read the
+same and neither restates the convention.
+
+## Risks / Trade-offs
+
+- **`SIGTERM` now cancels in-flight work where it previously did not.** → That is the intended
+  behaviour and matches every other worker. Both workers are idempotent by construction, so a
+  cancelled run is safe to re-run; a partially-completed run needs no reconciliation.
+- **`backfill-resume-structured` starts exiting non-zero on partial failure**, so a cron entry
+  that previously looked green may start alerting. → That is the requirement, and a silent
+  partial failure on a worker that spends money is the worse outcome.
+- **The guard test could go stale** if a future worker reaches the database through some path
+  that mentions neither `database.Connect` nor `pgxpool`. → It would then be out of the test's
+  population and silently pass. Accepted: the test is a ratchet against the common case, not a
+  proof.
+- **Sentry now receives errors from two workers that were silent.** → Intended; it is the
+  headline of the change.
+
+## Migration Plan
+
+None. No schema, no data, no deploy ordering. Both binaries keep their flags
+(`--user`, `--dry-run`) and their idempotence, so any in-flight operational runbook is
+unaffected apart from the new exit code.
+
+## Open Questions
+
+None.

--- a/openspec/changes/backfill-workers-shared-bootstrap/design.md
+++ b/openspec/changes/backfill-workers-shared-bootstrap/design.md
@@ -77,9 +77,18 @@ last time. The whole reason this change exists is that three written requirement
 two workers drifting out of compliance.
 
 The test reads source text rather than building an import graph. Coarser, but it depends on no
-build tooling, runs in milliseconds, and cannot be defeated by anything short of deliberately
-aliasing the import — for which the honest answer is that the test states an intent, not a
-security boundary.
+build tooling and runs in milliseconds. It parses each file and re-prints it without comments
+before matching, because matching raw text would let a `// TODO: move this to worker.Bootstrap`
+satisfy the check — exactly the comment someone deferring the migration would leave. What it
+still cannot see is a pool obtained through a helper package that mentions neither
+`database.Connect` nor `pgxpool`; the honest answer there is that the test is a ratchet against
+the common case, not a proof.
+
+The same walk also asserts the second half of the rule: a package that uses `worker.Bootstrap`
+must contain no `log.Fatal` or `os.Exit`. Bootstrapping is not enough on its own — a worker
+that bootstraps and then fatals still skips its deferred pool close and telemetry flush, which
+is half the defect being fixed here. That assertion is green across the fleet today, so it
+costs nothing and holds the line.
 
 ### `worker.ExitCode`, not a hand-written comparison
 
@@ -91,7 +100,11 @@ same and neither restates the convention.
 
 - **`SIGTERM` now cancels in-flight work where it previously did not.** → That is the intended
   behaviour and matches every other worker. Both workers are idempotent by construction, so a
-  cancelled run is safe to re-run; a partially-completed run needs no reconciliation.
+  cancelled run is safe to re-run; a partially-completed run needs no reconciliation. Each
+  per-user loop checks `ctx.Err()` at the top and stops, following
+  `cmd/backfill-applications/main.go:84` — without that the loop would run to the end of the
+  list turning every remaining user into a logged failure, reporting one cancellation as a
+  fleet of them. A cancelled run exits non-zero and says how many targets it left.
 - **`backfill-resume-structured` starts exiting non-zero on partial failure**, so a cron entry
   that previously looked green may start alerting. → That is the requirement, and a silent
   partial failure on a worker that spends money is the worse outcome.

--- a/openspec/changes/backfill-workers-shared-bootstrap/proposal.md
+++ b/openspec/changes/backfill-workers-shared-bootstrap/proposal.md
@@ -10,9 +10,11 @@ stored user CVs**:
 - `cmd/backfill-experience`
 - `cmd/backfill-resume-structured`
 
-Neither calls `observability.Init`, so a panic or a run-ending error in either is invisible to
-Sentry — the exact gap `worker.Bootstrap` exists to close, and one that `error-tracking`'s
-"Worker error capture with guaranteed delivery" already requires them to close.
+Neither calls `observability.Init`, so a panic in either is invisible to Sentry — the exact gap
+`worker.Bootstrap` exists to close, and one that `error-tracking`'s "Worker error capture with
+guaranteed delivery" already requires them to close. (Run-ending *errors* are still only logged
+here as everywhere else: no worker in the fleet calls `sentry.CaptureException`. This change
+brings these two to parity with the other 34, it does not raise the fleet's bar.)
 
 The consequences are not theoretical:
 

--- a/openspec/changes/backfill-workers-shared-bootstrap/proposal.md
+++ b/openspec/changes/backfill-workers-shared-bootstrap/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+`internal/worker` is one of this repo's genuinely successful shared seams: 33 of the 34
+production cron binaries call `worker.Main` + `worker.Bootstrap`, and per-main boilerplate is
+about eight lines. The exceptions are not the harmless ones. Of every binary under `cmd/` that
+opens a database pool, exactly three sit outside the shared bootstrap — `cmd/server`, which is
+a long-lived daemon with its own lifecycle, and the two backfills that **spend LLM money on
+stored user CVs**:
+
+- `cmd/backfill-experience`
+- `cmd/backfill-resume-structured`
+
+Neither calls `observability.Init`, so a panic or a run-ending error in either is invisible to
+Sentry — the exact gap `worker.Bootstrap` exists to close, and one that `error-tracking`'s
+"Worker error capture with guaranteed delivery" already requires them to close.
+
+The consequences are not theoretical:
+
+- `cmd/backfill-experience/main.go:136` calls `os.Exit(1)` with `defer pool.Close()` and the
+  Langfuse `defer flush()` still pending. `os.Exit` runs no deferred function, so the trace
+  flush is skipped **precisely on the partially-failed run** — the only run whose traces would
+  explain what happened.
+- `cmd/backfill-resume-structured/main.go:161` logs its failure tally and returns normally, so
+  the process exits `0` even when every user failed. `worker-lifecycle`'s "Run outcome reported
+  through exit code" says it must not.
+- Both derive their root context from `context.Background()`, so a redeploy's or cron timeout's
+  `SIGTERM` hard-kills an in-flight LLM call instead of cancelling it.
+
+Three existing requirements across two specs already forbid all of this. They were held by
+prose, and prose did not hold: the two workers drifted out of compliance without anything
+failing. So this change also makes the rule checkable.
+
+## What Changes
+
+- Both mains become `worker.Main(run)` + `run() int` built on `worker.Bootstrap`, replacing the
+  hand-rolled `config.Load` / `context.Background` / `database.Connect` / `defer pool.Close()`.
+- Every `os.Exit(1)` and `log.Fatalf` in the two workers becomes `return 1` from `run`, so the
+  deferred pool close and the Langfuse flush actually run — including on the failed run.
+- `cmd/backfill-resume-structured` reports its outcome through `worker.ExitCode(failed, 0)`
+  instead of always exiting `0`.
+- A guard test makes the bootstrap rule mechanical: every binary under `cmd/` that opens a
+  database pool must reach it through `worker.Bootstrap`, with `cmd/server` the single declared
+  exception. The list of exceptions becomes readable data instead of an unwritten assumption.
+
+Explicitly NOT changed: the two workers' résumé-extractor construction chains, which look
+duplicated and are not. `backfill-experience` treats every piece as optional (missing S3 or LLM
+degrades to the free pass over users with a current structure); `backfill-resume-structured`
+treats every piece as fatal (a run without the PII detector would be a no-op, so it refuses to
+start). Those are opposite policies, both documented in place, and merging them would break one.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `worker-lifecycle`: the "Shared worker bootstrap" requirement gains an explicit scope (which
+  binaries it binds and which are exempt) and the requirement that compliance is enforced
+  mechanically rather than by convention.
+
+`error-tracking`'s "Worker error capture with guaranteed delivery" and `worker-lifecycle`'s
+"Run outcome reported through exit code" need no text change — the two workers simply start
+complying with what they already say.
+
+## Impact
+
+- `cmd/backfill-experience/main.go`, `cmd/backfill-resume-structured/main.go` — rewired; their
+  per-user logic, flags, idempotence and log lines are untouched.
+- `internal/worker/` — gains the guard test. No production code change in the package.
+- No schema, API, index or wire change. No migration. Both workers stay idempotent, so a
+  partially-completed pre-change run needs no reconciliation.

--- a/openspec/changes/backfill-workers-shared-bootstrap/specs/worker-lifecycle/spec.md
+++ b/openspec/changes/backfill-workers-shared-bootstrap/specs/worker-lifecycle/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Shared worker bootstrap
+
+Every standalone run-once-and-exit worker SHALL obtain its runtime dependencies
+(loaded config, an open database pool, and a root context) from one shared
+bootstrap helper rather than re-implementing the setup inline. The helper SHALL
+open the pgx pool and return a cleanup function that closes it.
+
+The rule binds by behaviour, not by naming: any binary under `cmd/` that opens a
+database pool is a worker for this purpose. `cmd/server` is the single exemption —
+it is a long-lived daemon rather than a run-once process and owns its own startup
+and shutdown. Binaries that never open a pool (code generators, harvest tools that
+write files) are out of scope.
+
+Compliance SHALL be enforced mechanically rather than by convention, and the set of
+exempt binaries SHALL be declared in that enforcement, so a new worker that
+hand-rolls its setup fails the suite instead of drifting silently.
+
+#### Scenario: Bootstrap provides pool and cleanup
+
+- **WHEN** a worker calls the shared bootstrap helper with a valid database URL
+- **THEN** it receives a usable database pool, a root context, and a cleanup
+  function that closes the pool when invoked
+
+#### Scenario: Bootstrap fails fast on an unreachable database
+
+- **WHEN** the bootstrap helper cannot connect to the database
+- **THEN** it returns an error (no usable pool), and the worker terminates with a
+  non-zero exit code rather than proceeding
+
+#### Scenario: A database-touching binary bypasses the bootstrap
+
+- **WHEN** a binary under `cmd/` opens a database pool without going through the
+  shared bootstrap, and is not in the declared exemption list
+- **THEN** the test suite fails, naming that binary
+
+#### Scenario: A worker exits without running its deferred cleanup
+
+- **WHEN** a worker's run ends in failure
+- **THEN** it returns a non-zero code from its run function rather than calling
+  `os.Exit` or `log.Fatal` directly, so the deferred pool close and any buffered
+  telemetry flush still run

--- a/openspec/changes/backfill-workers-shared-bootstrap/tasks.md
+++ b/openspec/changes/backfill-workers-shared-bootstrap/tasks.md
@@ -1,33 +1,52 @@
 ## 1. Make the bootstrap rule mechanical
 
-- [ ] 1.1 Add a failing guard test in `internal/worker` that walks `../../cmd/*/`, selects the
-  packages referencing `database.Connect` or `pgxpool`, and asserts each also references
-  `worker.Bootstrap`, with `cmd/server` as the one declared exemption and its reason in the
-  literal. It must fail now, naming `backfill-experience` and `backfill-resume-structured`.
+- [x] 1.1 Add a failing guard test in `internal/worker` that walks `../../cmd/*/`, selects the
+  packages referencing `worker.Bootstrap`, `database.Connect` or `pgxpool`, and asserts each
+  non-exempt one reaches the database through `worker.Bootstrap`, with `cmd/server` the one
+  declared exemption and its reason in the literal. It must fail now, naming both backfills.
+- [x] 1.2 Guard the population floor: a rename of the bootstrap helper or the pool constructor
+  must fail the test rather than silently empty its population.
 
 ## 2. Convert cmd/backfill-experience
 
-- [ ] 2.1 Replace `main`'s body with `worker.Main(run)` and move the work into `run() int`
-  built on `worker.Bootstrap(context.Background())`, dropping the hand-rolled `config.Load` /
-  `context.Background` / `database.Connect` / `defer pool.Close()`.
-- [ ] 2.2 Convert the two `log.Fatalf` sites and the trailing `os.Exit(1)` to `return 1`, so the
+- [x] 2.1 Replace `main`'s body with `worker.Main(run)` and move the work into `run() int`
+  built on `worker.Bootstrap(context.Background())`.
+- [x] 2.2 Convert the two `log.Fatalf` sites and the trailing `os.Exit(1)` to `return 1`, so the
   deferred Langfuse flush runs on the failed run; end on `worker.ExitCode(failed, 0)`.
-- [ ] 2.3 Leave `newExtractor`, `resolveStructured`, `eligible` and `decodeStructured`
+- [x] 2.3 Leave `newExtractor`, `resolveStructured`, `eligible` and `decodeStructured`
   unchanged — including the every-piece-optional policy.
 
 ## 3. Convert cmd/backfill-resume-structured
 
-- [ ] 3.1 Same conversion: `worker.Main(run)` + `worker.Bootstrap`, and all nine `log.Fatalf`
+- [x] 3.1 Same conversion: `worker.Main(run)` + `worker.Bootstrap`, and all nine `log.Fatalf`
   sites become `log.Printf` + `return 1`.
-- [ ] 3.2 End on `worker.ExitCode(failed, 0)` instead of returning normally, so a run where
-  users failed no longer exits `0`.
-- [ ] 3.3 Leave the every-piece-fatal policy, the eligibility SQL and the per-user loop as they
+- [x] 3.2 End on `worker.ExitCode(failed, 0)` instead of returning normally.
+- [x] 3.3 Leave the every-piece-fatal policy, the eligibility SQL and the per-user loop as they
   are.
 
-## 4. Verify
+## 4. Close what review found
 
-- [ ] 4.1 The guard test now passes; confirm it still fails if `worker.Bootstrap` is removed
-  from one of the two converted workers.
-- [ ] 4.2 `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...`.
-- [ ] 4.3 Confirm both binaries still parse their flags and print their usage — `go run
-  ./cmd/<name> --help` — without a database.
+- [x] 4.1 Both per-user loops now check `ctx.Err()` at the top and stop. The root context became
+  signal-bound in this change, so without the guard a SIGTERM would run the loop to the end of
+  the list and turn every remaining user into a logged failure — reporting one cancellation as a
+  fleet of them. Follows `cmd/backfill-applications/main.go:84`. A cancelled run says how many
+  targets it left and exits non-zero.
+- [x] 4.2 Harden the guard test: parse and re-print each file without comments before matching,
+  so a `// TODO: migrate this to worker.Bootstrap` no longer satisfies it. Verified — the
+  comment-only mutant now fails by name.
+- [x] 4.3 Assert the other half of the rule the delta spec added: a package using
+  `worker.Bootstrap` must contain no `log.Fatal` or `os.Exit`, since bootstrapping does not stop
+  a fatal from skipping the deferred flush. Green fleet-wide today; verified it fails when a
+  `log.Fatalf` is reintroduced.
+- [x] 4.4 Correct two artifact claims review falsified: the design said the test "cannot be
+  defeated by anything short of aliasing the import" (a comment defeated it), and the proposal
+  implied run-ending errors reach Sentry (no worker in the fleet calls `CaptureException` —
+  this change reaches parity, it does not raise the bar).
+
+## 5. Verify
+
+- [x] 5.1 The guard test passes; verified by mutation that it fails when `worker.Bootstrap` is
+  removed from a converted worker, when only a comment mentions it, and when a `log.Fatal` is
+  reintroduced.
+- [x] 5.2 `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...` — all clean.
+- [x] 5.3 Both binaries still parse their flags and print usage without a database.

--- a/openspec/changes/backfill-workers-shared-bootstrap/tasks.md
+++ b/openspec/changes/backfill-workers-shared-bootstrap/tasks.md
@@ -1,0 +1,33 @@
+## 1. Make the bootstrap rule mechanical
+
+- [ ] 1.1 Add a failing guard test in `internal/worker` that walks `../../cmd/*/`, selects the
+  packages referencing `database.Connect` or `pgxpool`, and asserts each also references
+  `worker.Bootstrap`, with `cmd/server` as the one declared exemption and its reason in the
+  literal. It must fail now, naming `backfill-experience` and `backfill-resume-structured`.
+
+## 2. Convert cmd/backfill-experience
+
+- [ ] 2.1 Replace `main`'s body with `worker.Main(run)` and move the work into `run() int`
+  built on `worker.Bootstrap(context.Background())`, dropping the hand-rolled `config.Load` /
+  `context.Background` / `database.Connect` / `defer pool.Close()`.
+- [ ] 2.2 Convert the two `log.Fatalf` sites and the trailing `os.Exit(1)` to `return 1`, so the
+  deferred Langfuse flush runs on the failed run; end on `worker.ExitCode(failed, 0)`.
+- [ ] 2.3 Leave `newExtractor`, `resolveStructured`, `eligible` and `decodeStructured`
+  unchanged — including the every-piece-optional policy.
+
+## 3. Convert cmd/backfill-resume-structured
+
+- [ ] 3.1 Same conversion: `worker.Main(run)` + `worker.Bootstrap`, and all nine `log.Fatalf`
+  sites become `log.Printf` + `return 1`.
+- [ ] 3.2 End on `worker.ExitCode(failed, 0)` instead of returning normally, so a run where
+  users failed no longer exits `0`.
+- [ ] 3.3 Leave the every-piece-fatal policy, the eligibility SQL and the per-user loop as they
+  are.
+
+## 4. Verify
+
+- [ ] 4.1 The guard test now passes; confirm it still fails if `worker.Bootstrap` is removed
+  from one of the two converted workers.
+- [ ] 4.2 `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...`.
+- [ ] 4.3 Confirm both binaries still parse their flags and print their usage — `go run
+  ./cmd/<name> --help` — without a database.


### PR DESCRIPTION
`internal/worker` is one of this repo's successful shared seams: 33 of 34 production cron
binaries call `worker.Main` + `worker.Bootstrap`. The exceptions were not the harmless ones.

Of every binary under `cmd/` that opens a database pool, exactly **three** sat outside the shared
bootstrap: `cmd/server` (a daemon with its own lifecycle), and the two backfills that **spend LLM
money on stored user CVs**.

## What was broken

- Neither called `observability.Init`, so a panic in either was invisible to Sentry — the gap
  `worker.Bootstrap` exists to close, and one `error-tracking`'s *"Worker error capture with
  guaranteed delivery"* already required them to close.
- `cmd/backfill-experience` ended on `os.Exit(1)` with the Langfuse flush and the pool close
  still deferred. **`os.Exit` runs no deferred function**, so the traces were dropped on exactly
  the partially-failed run whose traces would explain it.
- `cmd/backfill-resume-structured` logged its failure tally and returned normally, so it exited
  `0` even when every user failed — against `worker-lifecycle`'s *"Run outcome reported through
  exit code"*.
- Both derived their root context from `context.Background()`, so a redeploy's `SIGTERM`
  hard-killed an in-flight LLM call instead of cancelling it.

Three written requirements across two specs already forbade all of this. Prose did not hold.

## What changed

Both are now `worker.Main(run)` + `worker.Bootstrap`, every `log.Fatalf`/`os.Exit` is a return
value, and both end on `worker.ExitCode`.

The rule is now a **test**. `internal/worker/cmdbootstrap_test.go` asserts that every `cmd/`
package reaching the database goes through `worker.Bootstrap`, deriving its population from
*behaviour* rather than a hand-kept list of names, so a new worker is enrolled by existing.
`cmd/server` is the one declared exemption, with its reason in the literal.

## Found in review

- **A regression the fix itself introduced.** Making the context signal-bound was the point — but
  neither per-user loop checked `ctx.Err()`, so on `SIGTERM` both would run to the end of the
  target list turning every remaining user into a logged `context canceled` failure. One
  cancellation reported as a fleet of them, on the exact operational event this change is
  selling. Both loops now stop, say how many targets they left, and exit non-zero — following
  `cmd/backfill-applications/main.go:84`.
- **The guard matched raw source**, so a `// TODO: migrate this to worker.Bootstrap` satisfied
  it — precisely the comment someone deferring the migration would leave. It now parses and
  re-prints each file without comments.
- **It enforced only half the rule** the delta spec added: a worker can bootstrap and still
  `log.Fatal`, skipping the same deferred flush. Now asserted too; green fleet-wide today.

All three assertions are mutation-verified: removing `Bootstrap`, mentioning it only in a
comment, and reintroducing a `log.Fatalf` each fail the test **by name**.

## Deliberately unchanged

The two workers' extractor construction chains. They encode opposite policies — every piece
optional vs every piece fatal — both documented in place; a shared constructor would need a flag
to reproduce them. Also left alone: `backfill-resume-structured`'s hand-written eligibility SQL
(a real wart, but a data-layer concern, not lifecycle).

## Verification

`go build ./...` · `go vet ./...` · `gofmt -l` · `go test ./...` — all clean. Both binaries still
parse flags and print usage without a database.

OpenSpec: `backfill-workers-shared-bootstrap` (modifies `worker-lifecycle`).
Acts on **S3** of `docs/reviews/2026-08-01-architecture-review.md`.