### PR TITLE
fix(search): an incremental push no longer narrows a collapsed role's geography

### DIFF
--- a/cmd/embed/indexer.go
+++ b/cmd/embed/indexer.go
@@ -50,6 +50,21 @@ func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) (map[int64
 			}
 			reality := jobview.ClassifyReality(job, time.Now(), int(repost), int(mass))
 			doc.Reality = &reality
+			// Widen the canon with its cluster's geography — the push is a field-level
+			// document update, so omitting this replaces the reindex's union with the
+			// canon's own narrow set. mass counts the cluster's open rows: at 1 there is
+			// nothing to widen with, which is also why this sits inside the !pgOnly branch
+			// alongside the count it reuses.
+			if mass > 1 {
+				if g, err := ix.q.RoleClusterGeo(ctx, db.RoleClusterGeoParams{
+					CompanySlug:     job.CompanySlug,
+					RoleFingerprint: job.RoleFingerprint,
+				}); err != nil {
+					log.Printf("embed: role-cluster geography for job %d: %v", job.ID, err)
+				} else {
+					doc.MergeClusterGeography(g.Countries, g.Regions, g.Cities)
+				}
+			}
 		}
 		docs = append(docs, doc)
 	}

--- a/cmd/embed/indexer.go
+++ b/cmd/embed/indexer.go
@@ -40,6 +40,10 @@ func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) (map[int64
 		// immediately; a cluster-count lookup failure degrades to a unique role (1,1).
 		if !ix.pgOnly {
 			repost, mass := int64(1), int64(1)
+			// askGeo defaults to true because a FAILED count must not also suppress the
+			// geography merge below: skipping it is destructive (the push replaces the
+			// stored union), not conservative. Only a known singleton can safely skip.
+			askGeo := true
 			if c, err := ix.q.RoleClusterCount(ctx, db.RoleClusterCountParams{
 				CompanySlug:     job.CompanySlug,
 				RoleFingerprint: job.RoleFingerprint,
@@ -47,15 +51,16 @@ func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) (map[int64
 				log.Printf("embed: role-cluster count for job %d: %v", job.ID, err)
 			} else {
 				repost, mass = c.RepostCount, c.MassCount
+				askGeo = mass > 1
 			}
 			reality := jobview.ClassifyReality(job, time.Now(), int(repost), int(mass))
 			doc.Reality = &reality
 			// Widen the canon with its cluster's geography — the push is a field-level
 			// document update, so omitting this replaces the reindex's union with the
-			// canon's own narrow set. mass counts the cluster's open rows: at 1 there is
-			// nothing to widen with, which is also why this sits inside the !pgOnly branch
-			// alongside the count it reuses.
-			if mass > 1 {
+			// canon's own narrow set. mass counts the cluster's open rows: at a known 1
+			// there is nothing to widen with. This sits inside the !pgOnly branch alongside
+			// the count it reuses — pg-only builds no Meili document at all.
+			if askGeo {
 				if g, err := ix.q.RoleClusterGeo(ctx, db.RoleClusterGeoParams{
 					CompanySlug:     job.CompanySlug,
 					RoleFingerprint: job.RoleFingerprint,

--- a/cmd/ingest/indexer_test.go
+++ b/cmd/ingest/indexer_test.go
@@ -39,6 +39,18 @@ func (f *fakePusher) total() int {
 	return n
 }
 
+// all flattens the recorded batches in push order, so a test can assert on the content
+// of a pushed document and not only on how many were pushed.
+func (f *fakePusher) all() []search.JobDocument {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []search.JobDocument
+	for _, b := range f.batches {
+		out = append(out, b...)
+	}
+	return out
+}
+
 func docs(n int) []search.JobDocument {
 	out := make([]search.JobDocument, n)
 	for i := range out {

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -166,6 +166,22 @@ func (s *dbStore) Save(ctx context.Context, j job.Job) error {
 		} else {
 			reality := jobview.ClassifyReality(saved.Job, time.Now(), int(repost), int(mass))
 			doc.Reality = &reality
+			// Widen the canon with its cluster's geography. The push is a field-level
+			// document update and the geography facets are always present in the payload,
+			// so skipping this would REPLACE the reindex's union with the canon's own
+			// narrow set and the role would stop being findable by the cities its reposts
+			// hold. mass counts the cluster's open rows: at 1 the canon is the only one, so
+			// the union is its own geography and there is nothing to ask for.
+			if mass > 1 {
+				if g, err := s.q.RoleClusterGeo(ctx, db.RoleClusterGeoParams{
+					CompanySlug:     saved.Job.CompanySlug,
+					RoleFingerprint: saved.Job.RoleFingerprint,
+				}); err != nil {
+					log.Printf("ingest: role-cluster geography for job %d: %v", saved.Job.ID, err)
+				} else {
+					doc.MergeClusterGeography(g.Countries, g.Regions, g.Cities)
+				}
+			}
 			s.indexer.Add(ctx, doc)
 		}
 	}

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -152,6 +152,12 @@ func (s *dbStore) Save(ctx context.Context, j job.Job) error {
 		// The job-reality signal needs this role's cluster counts; a lookup failure
 		// degrades to a unique role (counts 1) rather than failing the index push.
 		repost, mass := int64(1), int64(1)
+		// Whether to ask for the cluster's geography below. It defaults to true because a
+		// FAILED count must not also suppress the merge: skipping the merge is destructive
+		// (the push replaces the stored union), not conservative, so an unknown cluster
+		// size is a reason to ask rather than a reason to skip. A known singleton is the
+		// only case that can safely skip — its union is its own geography.
+		askGeo := true
 		if c, err := s.q.RoleClusterCount(ctx, db.RoleClusterCountParams{
 			CompanySlug:     saved.Job.CompanySlug,
 			RoleFingerprint: saved.Job.RoleFingerprint,
@@ -159,6 +165,7 @@ func (s *dbStore) Save(ctx context.Context, j job.Job) error {
 			log.Printf("ingest: role-cluster count for job %d: %v", saved.Job.ID, err)
 		} else {
 			repost, mass = c.RepostCount, c.MassCount
+			askGeo = mass > 1
 		}
 		doc, err := search.FromJob(saved.Job)
 		if err != nil {
@@ -170,9 +177,9 @@ func (s *dbStore) Save(ctx context.Context, j job.Job) error {
 			// document update and the geography facets are always present in the payload,
 			// so skipping this would REPLACE the reindex's union with the canon's own
 			// narrow set and the role would stop being findable by the cities its reposts
-			// hold. mass counts the cluster's open rows: at 1 the canon is the only one, so
-			// the union is its own geography and there is nothing to ask for.
-			if mass > 1 {
+			// hold. mass counts the cluster's open rows: at a known 1 the canon is the only
+			// one, so the union is its own geography and there is nothing to ask for.
+			if askGeo {
 				if g, err := s.q.RoleClusterGeo(ctx, db.RoleClusterGeoParams{
 					CompanySlug:     saved.Job.CompanySlug,
 					RoleFingerprint: saved.Job.RoleFingerprint,

--- a/cmd/ingest/store_cluster_geo_integration_test.go
+++ b/cmd/ingest/store_cluster_geo_integration_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+// Integration test for the incremental index push and a collapsed role's geography: the
+// push is a field-level document update and the geography facets are always present in the
+// payload, so a writer that does not widen the canon with its cluster's union actively
+// REPLACES the reindex's widened values with the canon's own narrow set — and the role
+// stops being findable by the cities its reposts hold until the next full rebuild.
+// Run with: go test -tags=integration ./cmd/ingest/
+package main
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/job"
+	"github.com/strelov1/freehire/internal/jobderive"
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+// editedCityPosting is cityPosting with a changed apply URL: a content change the index
+// push reacts to, chosen because it leaves the title and the description alone. Those two
+// are what RoleFingerprint hashes, so editing either would move the canon into a cluster of
+// its own — the role would become a singleton and there would be nothing to widen with,
+// which is the wrong reason for this test to pass or fail.
+func editedCityPosting(externalID, location string) job.Job {
+	j, err := job.New(job.Draft{
+		Input: jobderive.Input{
+			Source:      "zohorecruit",
+			ExternalID:  externalID,
+			Title:       "Senior Full Stack Engineer ID78855",
+			Company:     "AgileEngine",
+			Location:    location,
+			Description: "<div>We are looking for a Senior Full Stack Engineer with a backend orientation.</div>",
+		},
+		URL: "https://agileengine.zohorecruit.com/jobs/Careers/" + externalID + "?v=2",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return j
+}
+
+func TestSave_IncrementalPushKeepsTheClusterGeography(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+
+	pusher := &fakePusher{}
+	store := newDBStore(pool, 1, newBatchIndexer(pusher.push, 1), nil)
+
+	// The same role crawled once per city: the first is the canon, the second a repost
+	// that is kept as a row but never indexed.
+	const canonID, repostID = "248544000257794970", "248544000257794973"
+	if err := store.Save(ctx, cityPosting(canonID, "Querétaro, Mexico")); err != nil {
+		t.Fatalf("save the canon: %v", err)
+	}
+	if err := store.Save(ctx, cityPosting(repostID, "Bogota, Colombia")); err != nil {
+		t.Fatalf("save the repost: %v", err)
+	}
+
+	canon, err := q.GetJobBySourceExternalID(ctx, db.GetJobBySourceExternalIDParams{
+		Source: "zohorecruit", ExternalID: canonID,
+	})
+	if err != nil {
+		t.Fatalf("load the canon: %v", err)
+	}
+	repost, err := q.GetJobBySourceExternalID(ctx, db.GetJobBySourceExternalIDParams{
+		Source: "zohorecruit", ExternalID: repostID,
+	})
+	if err != nil {
+		t.Fatalf("load the repost: %v", err)
+	}
+	if len(canon.Cities) == 0 || len(repost.Cities) == 0 {
+		t.Fatalf("the fixture needs both rows to carry a city, got canon=%v repost=%v",
+			canon.Cities, repost.Cities)
+	}
+
+	// The next crawl reports a content change on the canon, so it is pushed again. That
+	// push must not narrow the document back to the canon's own city.
+	if err := store.Save(ctx, editedCityPosting(canonID, "Querétaro, Mexico")); err != nil {
+		t.Fatalf("re-save the canon: %v", err)
+	}
+
+	// The first save pushed the canon once; the re-save must push it again, or the
+	// assertion below would be reading the original push and pass for the wrong reason.
+	docs := pusher.all()
+	if len(docs) < 2 {
+		t.Fatalf("the content change pushed nothing new: %d document(s) pushed in total", len(docs))
+	}
+	last := docs[len(docs)-1]
+	if last.ID != canon.ID {
+		t.Fatalf("last pushed document is job %d, want the canon %d", last.ID, canon.ID)
+	}
+
+	want := slices.Concat(canon.Cities, repost.Cities)
+	slices.Sort(want)
+	want = slices.Compact(want)
+	if !slices.Equal(last.Cities, want) {
+		t.Errorf("the pushed canon carries cities %v, want the cluster union %v — an incremental "+
+			"push replaces the geography facets, so omitting the union un-widens the canon",
+			last.Cities, want)
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1810,6 +1810,59 @@ func (q *Queries) RoleClusterCountsFor(ctx context.Context, arg RoleClusterCount
 	return items, nil
 }
 
+const roleClusterGeo = `-- name: RoleClusterGeo :one
+SELECT
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'c' AND t.val <> '')::text[] AS countries,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'r' AND t.val <> '')::text[] AS regions,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'y' AND t.val <> '')::text[] AS cities
+FROM jobs o
+LEFT JOIN LATERAL (
+    SELECT 'c'::text AS kind, e AS val FROM unnest(o.countries) AS e
+    UNION ALL
+    SELECT 'r', e FROM unnest(o.regions) AS e
+    UNION ALL
+    SELECT 'y', e FROM unnest(o.cities) AS e
+) t ON true
+WHERE o.closed_at IS NULL
+  AND o.company_slug = $1
+  AND o.role_fingerprint = $2
+  AND o.role_fingerprint <> ''
+`
+
+type RoleClusterGeoParams struct {
+	CompanySlug     string      `json:"company_slug"`
+	RoleFingerprint pgtype.Text `json:"role_fingerprint"`
+}
+
+type RoleClusterGeoRow struct {
+	Countries []string `json:"countries"`
+	Regions   []string `json:"regions"`
+	Cities    []string `json:"cities"`
+}
+
+// The geography union across ONE role cluster's open rows — the per-row counterpart of
+// the whole-catalogue RoleClusterGeoAll, as RoleClusterCount is to RoleClusterCountsAll.
+// The incremental index writers (ingest, link import, embed) ask it so their push widens
+// a collapsed canon instead of narrowing it: the push is a field-level document update
+// and the three geography facets are always present in the payload, so a writer that
+// omits the union replaces the reindex's widened values with the canon's own.
+// Same shape as RoleClusterGeoAll: only OPEN rows count, a LATERAL tags each row's
+// countries/regions/cities into one unnested stream, and blanks are dropped by the FILTER.
+// Unlike the whole-catalogue query it carries no HAVING, so it ALWAYS answers with exactly
+// one row: aggregating over no matching rows yields empty arrays, which
+// MergeClusterGeography already treats as "leave this facet alone". That keeps the three
+// callers to one error branch instead of making them tell pgx.ErrNoRows (a singleton) apart
+// from a real failure. A singleton therefore returns its own geography — a self-union, and
+// a no-op — but callers skip the query entirely when the cluster has at most one open row,
+// which RoleClusterCount's mass_count already told them. A NULL/empty fingerprint never
+// clusters.
+func (q *Queries) RoleClusterGeo(ctx context.Context, arg RoleClusterGeoParams) (RoleClusterGeoRow, error) {
+	row := q.db.QueryRow(ctx, roleClusterGeo, arg.CompanySlug, arg.RoleFingerprint)
+	var i RoleClusterGeoRow
+	err := row.Scan(&i.Countries, &i.Regions, &i.Cities)
+	return i, err
+}
+
 const roleClusterGeoAll = `-- name: RoleClusterGeoAll :many
 SELECT
     o.company_slug,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1994,6 +1994,23 @@ type Querier interface {
 	// cannot type, and the surplus is bounded: a page holds few distinct companies, and a
 	// fingerprint belonging to another of them simply has no rows.
 	RoleClusterCountsFor(ctx context.Context, arg RoleClusterCountsForParams) ([]RoleClusterCountsForRow, error)
+	// The geography union across ONE role cluster's open rows — the per-row counterpart of
+	// the whole-catalogue RoleClusterGeoAll, as RoleClusterCount is to RoleClusterCountsAll.
+	// The incremental index writers (ingest, link import, embed) ask it so their push widens
+	// a collapsed canon instead of narrowing it: the push is a field-level document update
+	// and the three geography facets are always present in the payload, so a writer that
+	// omits the union replaces the reindex's widened values with the canon's own.
+	// Same shape as RoleClusterGeoAll: only OPEN rows count, a LATERAL tags each row's
+	// countries/regions/cities into one unnested stream, and blanks are dropped by the FILTER.
+	// Unlike the whole-catalogue query it carries no HAVING, so it ALWAYS answers with exactly
+	// one row: aggregating over no matching rows yields empty arrays, which
+	// MergeClusterGeography already treats as "leave this facet alone". That keeps the three
+	// callers to one error branch instead of making them tell pgx.ErrNoRows (a singleton) apart
+	// from a real failure. A singleton therefore returns its own geography — a self-union, and
+	// a no-op — but callers skip the query entirely when the cluster has at most one open row,
+	// which RoleClusterCount's mass_count already told them. A NULL/empty fingerprint never
+	// clusters.
+	RoleClusterGeo(ctx context.Context, arg RoleClusterGeoParams) (RoleClusterGeoRow, error)
 	// The whole-catalogue role-cluster geography union in one pass, so the reindex can widen
 	// each collapsed canon's countries/regions/cities with the union across its cluster's
 	// OPEN rows (a canon in one country must still be findable by the countries of the reposts

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -299,6 +299,40 @@ WHERE company_slug = sqlc.arg(company_slug)
   AND role_fingerprint = sqlc.arg(role_fingerprint)
   AND role_fingerprint <> '';
 
+-- name: RoleClusterGeo :one
+-- The geography union across ONE role cluster's open rows — the per-row counterpart of
+-- the whole-catalogue RoleClusterGeoAll, as RoleClusterCount is to RoleClusterCountsAll.
+-- The incremental index writers (ingest, link import, embed) ask it so their push widens
+-- a collapsed canon instead of narrowing it: the push is a field-level document update
+-- and the three geography facets are always present in the payload, so a writer that
+-- omits the union replaces the reindex's widened values with the canon's own.
+-- Same shape as RoleClusterGeoAll: only OPEN rows count, a LATERAL tags each row's
+-- countries/regions/cities into one unnested stream, and blanks are dropped by the FILTER.
+-- Unlike the whole-catalogue query it carries no HAVING, so it ALWAYS answers with exactly
+-- one row: aggregating over no matching rows yields empty arrays, which
+-- MergeClusterGeography already treats as "leave this facet alone". That keeps the three
+-- callers to one error branch instead of making them tell pgx.ErrNoRows (a singleton) apart
+-- from a real failure. A singleton therefore returns its own geography — a self-union, and
+-- a no-op — but callers skip the query entirely when the cluster has at most one open row,
+-- which RoleClusterCount's mass_count already told them. A NULL/empty fingerprint never
+-- clusters.
+SELECT
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'c' AND t.val <> '')::text[] AS countries,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'r' AND t.val <> '')::text[] AS regions,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'y' AND t.val <> '')::text[] AS cities
+FROM jobs o
+LEFT JOIN LATERAL (
+    SELECT 'c'::text AS kind, e AS val FROM unnest(o.countries) AS e
+    UNION ALL
+    SELECT 'r', e FROM unnest(o.regions) AS e
+    UNION ALL
+    SELECT 'y', e FROM unnest(o.cities) AS e
+) t ON true
+WHERE o.closed_at IS NULL
+  AND o.company_slug = sqlc.arg(company_slug)
+  AND o.role_fingerprint = sqlc.arg(role_fingerprint)
+  AND o.role_fingerprint <> '';
+
 -- name: CompanyHasOtherJobs :one
 -- Whether the catalog carries this company beyond the one posting named by (source,
 -- external_id) — asked right after an import, to answer "is this company new to us?".

--- a/internal/db/role_cluster_geo_integration_test.go
+++ b/internal/db/role_cluster_geo_integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+// Integration tests for RoleClusterGeo: the per-cluster counterpart of the
+// whole-catalogue RoleClusterGeoAll, asked by the incremental index writers so a push
+// widens a collapsed canon instead of replacing the reindex's union with the canon's own
+// narrow geography. The union, the open-rows-only scope and the empty-value filtering are
+// SQL behaviours verifiable only against a real Postgres.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// clusterRow is one posting of a shared role, in its own geography.
+func clusterRow(externalID, fingerprint string, countries, regions, cities []string) UpsertJobParams {
+	p := withFingerprint(externalID, "Senior Full Stack Engineer", fingerprint)
+	p.Countries = countries
+	p.Regions = regions
+	p.Cities = cities
+	return p
+}
+
+// fpText matches the generated param type, which mirrors the jobs.role_fingerprint column.
+func fpText(fp string) pgtype.Text {
+	return pgtype.Text{String: fp, Valid: true}
+}
+
+func TestRoleClusterGeo_UnionsTheOpenRowsOfOneCluster(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	const fp = "fp-fullstack"
+	rows := []UpsertJobParams{
+		clusterRow("c-1", fp, []string{"de"}, []string{"eu"}, []string{"Düsseldorf"}),
+		clusterRow("c-2", fp, []string{"pl"}, []string{"eu"}, []string{"Kraków"}),
+		clusterRow("c-3", fp, []string{"at"}, []string{"eu"}, []string{"Wien"}),
+		// A different role in the same company must not bleed into the union.
+		clusterRow("other-1", "fp-backend", []string{"us"}, []string{"north_america"}, []string{"Austin"}),
+	}
+	for _, p := range rows {
+		if _, err := q.UpsertJob(ctx, p); err != nil {
+			t.Fatalf("upsert %s: %v", p.ExternalID, err)
+		}
+	}
+
+	geo, err := q.RoleClusterGeo(ctx, RoleClusterGeoParams{CompanySlug: "acme", RoleFingerprint: fpText(fp)})
+	if err != nil {
+		t.Fatalf("RoleClusterGeo: %v", err)
+	}
+	if want := []string{"at", "de", "pl"}; !slices.Equal(geo.Countries, want) {
+		t.Errorf("countries = %v, want %v", geo.Countries, want)
+	}
+	if want := []string{"eu"}; !slices.Equal(geo.Regions, want) {
+		t.Errorf("regions = %v, want %v", geo.Regions, want)
+	}
+	if want := []string{"Düsseldorf", "Kraków", "Wien"}; !slices.Equal(geo.Cities, want) {
+		t.Errorf("cities = %v, want %v", geo.Cities, want)
+	}
+}
+
+func TestRoleClusterGeo_ExcludesClosedRows(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	const fp = "fp-closed"
+	open := clusterRow("open-1", fp, []string{"de"}, []string{"eu"}, []string{"Düsseldorf"})
+	closed := clusterRow("closed-1", fp, []string{"pl"}, []string{"eu"}, []string{"Kraków"})
+	for _, p := range []UpsertJobParams{open, closed} {
+		if _, err := q.UpsertJob(ctx, p); err != nil {
+			t.Fatalf("upsert %s: %v", p.ExternalID, err)
+		}
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE jobs SET closed_at = now() WHERE external_id = $1`, closed.ExternalID); err != nil {
+		t.Fatalf("close row: %v", err)
+	}
+
+	geo, err := q.RoleClusterGeo(ctx, RoleClusterGeoParams{CompanySlug: "acme", RoleFingerprint: fpText(fp)})
+	if err != nil {
+		t.Fatalf("RoleClusterGeo: %v", err)
+	}
+	// Only the open row contributes, so merging this back is a self-union no-op — the
+	// closed row's Kraków must not resurrect a city the role is no longer open in.
+	if want := []string{"de"}; !slices.Equal(geo.Countries, want) {
+		t.Errorf("countries = %v, want %v (the closed row must not contribute)", geo.Countries, want)
+	}
+	if want := []string{"Düsseldorf"}; !slices.Equal(geo.Cities, want) {
+		t.Errorf("cities = %v, want %v (the closed row must not contribute)", geo.Cities, want)
+	}
+}
+
+func TestRoleClusterGeo_SingletonReturnsItsOwnGeographyAndUnknownIsEmpty(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	if _, err := q.UpsertJob(ctx, clusterRow("solo-1", "fp-solo",
+		[]string{"de"}, []string{"eu"}, []string{"Düsseldorf"})); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// A singleton answers with its own geography — a self-union, so merging it changes
+	// nothing. Callers skip the query for a singleton anyway; what matters here is that the
+	// query always answers, so no caller has to tell "no cluster" apart from a failure.
+	t.Run("singleton returns its own geography", func(t *testing.T) {
+		geo, err := q.RoleClusterGeo(ctx, RoleClusterGeoParams{CompanySlug: "acme", RoleFingerprint: fpText("fp-solo")})
+		if err != nil {
+			t.Fatalf("RoleClusterGeo: %v", err)
+		}
+		if want := []string{"de"}; !slices.Equal(geo.Countries, want) {
+			t.Errorf("countries = %v, want %v", geo.Countries, want)
+		}
+	})
+
+	for _, tc := range []struct{ name, slug, fp string }{
+		{"unknown fingerprint", "acme", "fp-nothing-here"},
+		{"unknown company", "nobody", "fp-solo"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			geo, err := q.RoleClusterGeo(ctx, RoleClusterGeoParams{CompanySlug: tc.slug, RoleFingerprint: fpText(tc.fp)})
+			if err != nil {
+				t.Fatalf("RoleClusterGeo must answer even for an unknown cluster: %v", err)
+			}
+			if len(geo.Countries) != 0 || len(geo.Regions) != 0 || len(geo.Cities) != 0 {
+				t.Errorf("expected an empty union, got countries=%v regions=%v cities=%v",
+					geo.Countries, geo.Regions, geo.Cities)
+			}
+		})
+	}
+}
+
+// A fingerprint that never clusters must not be answered by accident.
+func TestRoleClusterGeo_EmptyFingerprintNeverClusters(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	for _, id := range []string{"blank-1", "blank-2"} {
+		p := clusterRow(id, "", []string{"de"}, []string{"eu"}, []string{"Düsseldorf"})
+		p.RoleFingerprint = pgtype.Text{}
+		if _, err := q.UpsertJob(ctx, p); err != nil {
+			t.Fatalf("upsert %s: %v", id, err)
+		}
+	}
+
+	geo, err := q.RoleClusterGeo(ctx, RoleClusterGeoParams{CompanySlug: "acme", RoleFingerprint: fpText("")})
+	if err != nil {
+		t.Fatalf("RoleClusterGeo: %v", err)
+	}
+	if len(geo.Countries) != 0 || len(geo.Cities) != 0 {
+		t.Errorf("unfingerprinted rows clustered: countries=%v cities=%v", geo.Countries, geo.Cities)
+	}
+}

--- a/internal/linkimport/linkimport.go
+++ b/internal/linkimport/linkimport.go
@@ -280,11 +280,16 @@ func (im *Importer) index(ctx context.Context, saved db.UpsertJobRow) {
 	// The job-reality signal needs this role's cluster counts; a lookup failure degrades
 	// to a unique role (counts 1) rather than skipping the push.
 	repost, mass := int64(1), int64(1)
+	// askGeo defaults to true because a FAILED count must not also suppress the geography
+	// merge below: skipping it is destructive (the push replaces the stored union), not
+	// conservative. Only a known singleton can safely skip — its union is its own geography.
+	askGeo := true
 	if c, err := im.q.RoleClusterCount(ctx, db.RoleClusterCountParams{
 		CompanySlug:     saved.Job.CompanySlug,
 		RoleFingerprint: saved.Job.RoleFingerprint,
 	}); err == nil {
 		repost, mass = c.RepostCount, c.MassCount
+		askGeo = mass > 1
 	}
 	doc, err := search.FromJob(saved.Job)
 	if err != nil {
@@ -295,8 +300,8 @@ func (im *Importer) index(ctx context.Context, saved db.UpsertJobRow) {
 	doc.Reality = &reality
 	// Widen the canon with its cluster's geography — the push is a field-level document
 	// update, so omitting this replaces the reindex's union with the canon's own narrow
-	// set. mass counts the cluster's open rows: at 1 there is nothing to widen with.
-	if mass > 1 {
+	// set. mass counts the cluster's open rows: at a known 1 there is nothing to widen with.
+	if askGeo {
 		if g, err := im.q.RoleClusterGeo(ctx, db.RoleClusterGeoParams{
 			CompanySlug:     saved.Job.CompanySlug,
 			RoleFingerprint: saved.Job.RoleFingerprint,

--- a/internal/linkimport/linkimport.go
+++ b/internal/linkimport/linkimport.go
@@ -293,6 +293,19 @@ func (im *Importer) index(ctx context.Context, saved db.UpsertJobRow) {
 	}
 	reality := jobview.ClassifyReality(saved.Job, time.Now(), int(repost), int(mass))
 	doc.Reality = &reality
+	// Widen the canon with its cluster's geography — the push is a field-level document
+	// update, so omitting this replaces the reindex's union with the canon's own narrow
+	// set. mass counts the cluster's open rows: at 1 there is nothing to widen with.
+	if mass > 1 {
+		if g, err := im.q.RoleClusterGeo(ctx, db.RoleClusterGeoParams{
+			CompanySlug:     saved.Job.CompanySlug,
+			RoleFingerprint: saved.Job.RoleFingerprint,
+		}); err != nil {
+			log.Printf("linkimport: role-cluster geography for job %d: %v", saved.Job.ID, err)
+		} else {
+			doc.MergeClusterGeography(g.Countries, g.Regions, g.Cities)
+		}
+	}
 	if err := im.idx.SubmitJobs(ctx, []search.JobDocument{doc}); err != nil {
 		log.Printf("linkimport: index job %d: %v", saved.Job.ID, err)
 	}

--- a/internal/search/document.go
+++ b/internal/search/document.go
@@ -79,8 +79,13 @@ func FromJob(j db.Job) (JobDocument, error) {
 // across its role cluster's open rows, so a collapsed multi-city/multi-country role
 // stays findable by every city and country it is open in — not only the canon's own.
 // Each facet becomes the sorted, deduped union of the document's own values and the
-// cluster's; an empty cluster slice leaves that facet unchanged. Called by the full
-// reindex (which alone has the whole cluster in view); the single-row FromJob cannot.
+// cluster's; an empty cluster slice leaves that facet unchanged.
+//
+// Every writer of a job document must call this, not only the full reindex. The push is a
+// field-level document update and these three facets are always present in the payload, so
+// a writer that skips the union does not merely fail to widen the canon — it replaces the
+// widened values with the canon's own. The reindex reads its cluster geography from the
+// whole-catalogue RoleClusterGeoAll; the per-row writers read theirs from RoleClusterGeo.
 func (d *JobDocument) MergeClusterGeography(countries, regions, cities []string) {
 	d.Countries = unionSorted(d.Countries, countries)
 	d.Regions = unionSorted(d.Regions, regions)

--- a/openspec/changes/cluster-geography-incremental-push/.openspec.yaml
+++ b/openspec/changes/cluster-geography-incremental-push/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/cluster-geography-incremental-push/design.md
+++ b/openspec/changes/cluster-geography-incremental-push/design.md
@@ -60,10 +60,12 @@ geography, exactly as today, and the next full reindex repairs it.
 ### `RoleClusterGeo` mirrors `RoleClusterGeoAll`'s semantics exactly
 
 Same LATERAL-unnest-then-aggregate shape, same `<> ''` filtering, same open-rows-only scope. It
-returns empty arrays for a singleton or unknown cluster, which `MergeClusterGeography` already
-treats as "leave this facet alone" (`unionSorted` returns `own` when `extra` is empty). With
-`emit_empty_slices: true` in `sqlc.yaml`, a no-row case surfaces as empty slices rather than
-nil, so no caller needs a nil check.
+differs in one way beyond scope: it carries no `HAVING`, so it always answers with exactly one
+row. An unknown cluster aggregates over no rows and yields SQL `NULL` arrays, which pgx scans
+into nil slices; `MergeClusterGeography` treats those as "leave this facet alone" because
+`unionSorted` gates on `len(extra) == 0`, which nil satisfies. A singleton is different and
+worth stating plainly: it answers with the canon's *own* geography, so merging it is a
+self-union and a no-op — the callers skip it anyway on `mass <= 1`.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/cluster-geography-incremental-push/design.md
+++ b/openspec/changes/cluster-geography-incremental-push/design.md
@@ -1,0 +1,89 @@
+## Context
+
+`MergeClusterGeography` (`internal/search/document.go:84`) already does the widening and is
+already tested. The gap is purely that three of its four potential callers have no way to ask
+for one cluster's geography: the schema carries only `RoleClusterGeoAll`, a whole-catalogue
+aggregate built for the reindex's one-pass lookup map.
+
+The counts have both shapes already — `RoleClusterCountsAll` for the reindex and
+`RoleClusterCount` for the per-row callers — so the missing query is the obvious sibling, not a
+new concept.
+
+Why the omission is destructive rather than merely incomplete: `SubmitJobs`
+(`internal/search/client.go:496`) uses `UpdateDocumentsWithContext`, which merges by *field*.
+`jobview.Job` declares `Countries`, `Regions` and `Cities` without `omitempty`, so those keys
+are always in the payload and always replace whatever the reindex wrote.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An incremental push widens the canon exactly as the reindex does.
+- No extra query for the common case (a role with one open posting).
+- The requirement stops blessing the narrow behaviour.
+
+**Non-Goals:**
+
+- **Collapsing the four assembly preambles into one constructor.** All four repeat
+  `repost, mass := 1, 1` → `RoleClusterCount` → `FromJob` → `ClassifyReality`, and after this
+  change three of them repeat the geography step too. It is a real duplication and a reasonable
+  follow-on, but it is a different change: `cmd/embed` deliberately skips reality in `pgOnly`
+  mode, and the reindex feeds from prebuilt whole-catalogue maps rather than per-row queries, so
+  the shared thing would need to take plain values rather than lookups. Doing it here would mix
+  a behaviour fix with a refactor across four packages.
+- Adding `omitempty` to the three facets. It would make an incremental push non-destructive by
+  accident, but it would also make "this role has no cities" unrepresentable, and the index
+  could never unset a facet.
+- Touching the full reindex.
+
+## Decisions
+
+### A separate `RoleClusterGeo`, not a widened `RoleClusterCount`
+
+The two questions are asked at the same place with the same key, so one round trip is tempting.
+Rejected: `RoleClusterCount` also serves the single-job detail read, which does not want the
+geography and should not pay for three `array_agg(DISTINCT …)` per request. Keeping them
+separate also mirrors the existing `…CountsAll` / `…GeoAll` pairing, so the four queries read as
+two pairs rather than three shapes.
+
+### The count already answers whether the geography query is needed
+
+`mass_count` is the number of **open** rows in the cluster. At `mass_count <= 1` the canon is
+the only open row, so the cluster union is precisely the canon's own geography and
+`MergeClusterGeography` would be a no-op. Skipping the lookup there is exact, not a heuristic,
+and it keeps the added cost off every singleton role — which is most of the catalogue.
+
+When the count lookup itself fails, the callers already degrade to `(1, 1)`. That now also means
+"skip the geography", which is the same conservative direction: the push carries the canon's own
+geography, exactly as today, and the next full reindex repairs it.
+
+### `RoleClusterGeo` mirrors `RoleClusterGeoAll`'s semantics exactly
+
+Same LATERAL-unnest-then-aggregate shape, same `<> ''` filtering, same open-rows-only scope. It
+returns empty arrays for a singleton or unknown cluster, which `MergeClusterGeography` already
+treats as "leave this facet alone" (`unionSorted` returns `own` when `extra` is empty). With
+`emit_empty_slices: true` in `sqlc.yaml`, a no-row case surfaces as empty slices rather than
+nil, so no caller needs a nil check.
+
+## Risks / Trade-offs
+
+- **One extra query per indexed row in a multi-row open cluster.** → Bounded by the same
+  condition that makes it necessary, and ingest already pays a per-row `RoleClusterCount`, so
+  the shape of the cost is established. Singletons pay nothing.
+- **The three sites now each carry five more lines of near-identical code.** → Accepted
+  deliberately; see Non-Goals. The follow-on is now concrete rather than speculative, which is
+  the better time to decide it.
+- **A cluster whose geography changes without any of its rows being re-pushed** still waits for
+  the reindex. → Unchanged by this work; the incremental path has always been per-row.
+- **PR #1385 is open against the same file** (`internal/linkimport/linkimport.go`), in the
+  upsert mapping rather than the index push. → Whichever lands second rebases; no semantic
+  conflict.
+
+## Migration Plan
+
+None. New read-only query, no schema change, no backfill. The next reindex would have repaired
+the narrowed documents anyway; this stops them being narrowed in the first place.
+
+## Open Questions
+
+None.

--- a/openspec/changes/cluster-geography-incremental-push/proposal.md
+++ b/openspec/changes/cluster-geography-incremental-push/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+A collapsed multi-city role loses the cities its reposts hold, every time anything touches it,
+until the next full rebuild.
+
+Four call sites turn a `db.Job` into the document Meilisearch holds, and they answer the
+geography question differently:
+
+| site | widens with the cluster's geography? |
+|---|---|
+| `cmd/reindex/main.go:530` (full rebuild) | yes — `doc.MergeClusterGeography` |
+| `cmd/ingest/store.go` (per crawled row) | no |
+| `internal/linkimport/linkimport.go` (per imported link) | no |
+| `cmd/embed/indexer.go` (per newly embedded row) | no |
+
+That would be harmless if the incremental pushes were additive. They are not.
+`search.Client.SubmitJobs` uses `UpdateDocumentsWithContext` — a field-level update — and
+`jobview.Job`'s `Countries`, `Regions` and `Cities` carry no `omitempty`, so those three keys
+are present in every pushed document. An incremental push therefore **replaces** the widened
+union with the canon's own narrow set. A role open in Kraków, Wien and Düsseldorf that collapses
+to the Düsseldorf canon is findable by all three after a reindex, and by Düsseldorf alone as
+soon as its next crawl reports any content change.
+
+The behaviour was specified, not merely unguarded. `ingest-content-dedup`'s requirement reads
+"When the search document for a canonical job is built **by a full reindex**, it SHALL carry the
+union…". Scoping the guarantee to the rebuild is what left the three incremental writers free to
+undo it, and `MergeClusterGeography`'s own doc comment records the reason: only the reindex had
+the whole cluster in view, because the only cluster-geography query in the schema
+(`RoleClusterGeoAll`) is a whole-catalogue aggregate.
+
+## What Changes
+
+- A new `RoleClusterGeo` query returns one cluster's geography union, keyed by
+  `(company_slug, role_fingerprint)` — the per-row counterpart of the whole-catalogue
+  `RoleClusterGeoAll`, exactly as `RoleClusterCount` is the per-row counterpart of
+  `RoleClusterCountsAll`.
+- The three incremental pushers call `doc.MergeClusterGeography` with it, so a push widens the
+  canon instead of narrowing it.
+- They ask only when there is something to widen with. Each already fetches `RoleClusterCount`
+  for the reality signal; `mass_count <= 1` means the canon is the cluster's only open row, so
+  the union is its own geography and the second query is skipped. This is exact, not an
+  approximation.
+- The requirement drops "by a full reindex": the guarantee is about the document, whichever
+  writer produces it.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `ingest-content-dedup`: "The canonical job unions its cluster's geography" stops being scoped
+  to the full reindex and gains the incremental-push case.
+
+## Impact
+
+- `internal/db/queries/jobs.sql` — one new query; `internal/db/` regenerated via `make sqlc`.
+  No migration: the query reads existing columns.
+- `cmd/ingest/store.go`, `internal/linkimport/linkimport.go`, `cmd/embed/indexer.go` — each
+  gains the conditional lookup and the merge.
+- One extra query per indexed row **only** for rows in a multi-row open cluster. Singletons —
+  the overwhelming majority — are unaffected.
+- No change to the full reindex, to `MergeClusterGeography` itself, or to any wire shape.
+- Note for sequencing: PR #1385 (`worktree-job-derived-columns`) is open against
+  `internal/linkimport/linkimport.go` too. Different region of the file (the upsert mapping, not
+  the index push), but whichever lands second may need a trivial rebase.

--- a/openspec/changes/cluster-geography-incremental-push/specs/ingest-content-dedup/spec.md
+++ b/openspec/changes/cluster-geography-incremental-push/specs/ingest-content-dedup/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: The canonical job unions its cluster's geography
+
+The search document for a canonical job SHALL carry the union of `countries`, `regions`,
+and `cities` across all open rows of its role cluster (not only the canon's own row), so a
+collapsed multi-city or multi-country role remains findable by every city and country it is
+open in. Non-canonical reposts remain excluded from the index.
+
+This binds every writer of the document, not only the full reindex. Because the incremental
+push is a field-level document update and the three geography facets are always present in
+the pushed payload, a writer that omits the union does not merely fail to widen the canon —
+it replaces the widened values with the canon's own, undoing the rebuild.
+
+A writer MAY skip the union when the cluster has at most one open row, since the union is
+then the canon's own geography and the merge is a no-op.
+
+#### Scenario: A collapsed multi-country role is found by any of its countries
+
+- **WHEN** a role cluster is open in several countries and collapses to one canon
+  in country A, and the search is filtered by country B (a non-canon row's
+  country)
+- **THEN** the canonical job is returned
+
+#### Scenario: The canon lists every city of its cluster
+
+- **WHEN** the canonical job of a multi-city cluster is indexed by a full reindex
+- **THEN** its `cities` facet contains every open city in the cluster
+
+#### Scenario: An incremental push does not narrow the canon
+
+- **WHEN** a canonical job in a multi-city cluster is pushed to the index by the ingest
+  write path, a link import, or an incremental embed — rather than by a full reindex
+- **THEN** the pushed document still carries the cluster's union, so the role stays findable
+  by the cities its reposts hold
+
+#### Scenario: A singleton cluster costs no extra query
+
+- **WHEN** a job's role cluster has at most one open row
+- **THEN** the writer skips the cluster-geography lookup, and the document carries the job's
+  own geography unchanged

--- a/openspec/changes/cluster-geography-incremental-push/tasks.md
+++ b/openspec/changes/cluster-geography-incremental-push/tasks.md
@@ -28,3 +28,17 @@
 - [x] 4.2 `go test -tags=integration ./internal/db/ ./cmd/ingest/` (Docker required).
 - [x] 4.3 Confirm the singleton path issues no second query: the merge sits behind `mass > 1`,
   which RoleClusterCount already answered, so a role with one open posting pays nothing.
+
+## 5. Close what review found
+
+- [x] 5.1 A failed `RoleClusterCount` degraded to `(1,1)`, which also skipped the geography
+  merge — reinstating the exact bug on that path. Skipping is destructive (the push replaces
+  the stored union), not conservative, so an unknown cluster size is now a reason to ask rather
+  than a reason to skip: only a KNOWN singleton skips.
+- [x] 5.2 `MergeClusterGeography`'s doc comment still said it is "called by the full reindex,
+  which alone has the whole cluster in view" — the premise this change overturns, and the one
+  comment a reader would trust. Rewritten to bind every writer.
+- [x] 5.3 Corrected two false statements in design.md: a singleton returns its own geography
+  (a self-union), not empty arrays; and `emit_empty_slices` governs what a `:many` query
+  returns, not how a column scans — an empty aggregate is SQL NULL and scans to a nil slice,
+  which `unionSorted` handles because it gates on `len(extra) == 0`.

--- a/openspec/changes/cluster-geography-incremental-push/tasks.md
+++ b/openspec/changes/cluster-geography-incremental-push/tasks.md
@@ -1,0 +1,30 @@
+## 1. The per-cluster geography query
+
+- [x] 1.1 Add a failing integration test in `internal/db` for `RoleClusterGeo`: a multi-city,
+  multi-country open cluster returns the sorted union of its open rows' countries/regions/
+  cities; a closed row does not contribute; a singleton and an unknown key return empty.
+- [x] 1.2 Write `RoleClusterGeo :one` in `internal/db/queries/jobs.sql` next to
+  `RoleClusterCount`, mirroring `RoleClusterGeoAll`'s LATERAL-unnest shape scoped to one
+  `(company_slug, role_fingerprint)`. Run `make sqlc`.
+
+## 2. Stop the ingest write path narrowing the canon
+
+- [x] 2.1 Add a failing integration test in `cmd/ingest`: after a multi-city role collapses to
+  one canon, re-saving the canon with changed content pushes a document that still carries the
+  cluster's cities — today it carries only the canon's own.
+- [x] 2.2 In `cmd/ingest/store.go`, when `mass > 1`, fetch `RoleClusterGeo` and call
+  `doc.MergeClusterGeography` before handing the document to the indexer. A lookup failure logs
+  and leaves the canon's own geography, matching how the count already degrades.
+
+## 3. The other two incremental writers
+
+- [x] 3.1 Same treatment in `internal/linkimport/linkimport.go`.
+- [x] 3.2 Same treatment in `cmd/embed/indexer.go`, inside the existing `!pgOnly` branch — the
+  pg-only mode builds no Meili document and must keep skipping both lookups.
+
+## 4. Verify
+
+- [x] 4.1 `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...`.
+- [x] 4.2 `go test -tags=integration ./internal/db/ ./cmd/ingest/` (Docker required).
+- [x] 4.3 Confirm the singleton path issues no second query: the merge sits behind `mass > 1`,
+  which RoleClusterCount already answered, so a role with one open posting pays nothing.


### PR DESCRIPTION
A collapsed multi-city role **loses the cities its reposts hold** every time anything touches it,
until the next full rebuild.

Four call sites turn a `db.Job` into the document Meilisearch holds. Only the full reindex
widened a canonical job with its role cluster's geography union:

| site | widens? |
|---|---|
| `cmd/reindex/main.go` (full rebuild) | yes |
| `cmd/ingest/store.go` (per crawled row) | no |
| `internal/linkimport/linkimport.go` (per imported link) | no |
| `cmd/embed/indexer.go` (per newly embedded row) | no |

That would be harmless if the incremental pushes were additive. **They are not.**
`search.Client.SubmitJobs` uses `UpdateDocumentsWithContext` — a *field-level* update — and
`jobview.Job`'s `Countries`/`Regions`/`Cities` carry no `omitempty`, so those keys are in every
payload. An incremental push therefore **replaces** the widened union with the canon's own narrow
set. A role open in Kraków, Wien and Düsseldorf that collapses to the Düsseldorf canon is
findable by all three after a reindex, and by Düsseldorf alone as soon as its next crawl reports
any content change.

## The behaviour was specified, not merely unguarded

`ingest-content-dedup` read *"When the search document for a canonical job is built **by a full
reindex**, it SHALL carry the union…"*. Scoping the guarantee to the rebuild is what left the
three incremental writers free to undo it. The requirement now binds every writer of the
document.

## What changed

- New `RoleClusterGeo` — the per-cluster counterpart of the whole-catalogue `RoleClusterGeoAll`,
  exactly as `RoleClusterCount` is to `RoleClusterCountsAll`. Unlike the whole-catalogue query it
  carries no `HAVING` and **always answers with one row**, so the three callers keep a single
  error branch instead of telling `pgx.ErrNoRows` (a singleton) apart from a real failure.
- The three writers call `doc.MergeClusterGeography`, asking only when the cluster has more than
  one open row — reusing `mass_count` from the `RoleClusterCount` each already fetches. That is
  exact, not a heuristic: at one open row the union *is* the canon's own geography. A singleton
  role — most of the catalogue — pays nothing.

## Found in review

A **destructive default**: when `RoleClusterCount` fails, all three degrade to `(1,1)`, which
also skipped the merge — so on the failure path the push still narrowed the canon, reinstating
the bug. Skipping is not the conservative direction; it is the destructive one. An unknown
cluster size is now a reason to *ask*. Only a **known** singleton skips.

Also corrected: `MergeClusterGeography`'s doc comment still claimed the full reindex "alone has
the whole cluster in view" — the premise this change overturns, in the one comment a reader would
trust.

## Verification

Integration tests against a real Postgres (testcontainers): the query's union, open-rows-only
scope, closed-row exclusion, singleton self-union and empty-fingerprint exclusion — plus the
defect itself, where after a multi-city role collapses, re-saving the canon pushes a document
that still carries Bogotá. **Both mutation-verified** (disable the merge → the test fails with
real data, not a tautology).

The fixture deliberately changes only the apply URL: `RoleFingerprint` hashes title+description,
so editing either would move the canon into a cluster of its own and the test would pass for the
wrong reason.

`go build ./...` · `go vet ./...` · `gofmt -l` · `go test ./...` ·
`go test -tags=integration ./internal/db/ ./cmd/ingest/` — all clean. `make sqlc` reproduces the
committed output with zero drift.

## Not done here, deliberately

Collapsing the four now-near-identical assembly preambles into one document constructor. Real
duplication, but `cmd/embed` skips reality in `pgOnly` mode and the reindex feeds from prebuilt
whole-catalogue maps, so the shared thing must take plain values — a refactor across four
packages that does not belong in a behaviour fix. It is now concrete rather than speculative.

> Touches `internal/linkimport/linkimport.go`, as does open PR #1385 — different region of the
> file (the upsert mapping, not the index push), so whichever lands second may need a trivial
> rebase.

OpenSpec: `cluster-geography-incremental-push` (modifies `ingest-content-dedup`).
Acts on **S2** of `docs/reviews/2026-08-01-architecture-review.md`.