### PR TITLE
Derive candidate geography from the CV, and ask where the user is

### DIFF
--- a/cmd/backfill-resume-geo/main.go
+++ b/cmd/backfill-resume-geo/main.go
@@ -1,0 +1,100 @@
+// Command backfill-resume-geo re-derives the candidate geography (resume_countries /
+// resume_regions / resume_cities) from the structured résumé already stored for each
+// user. It is the reconciler the derivation needs so that a change to the location
+// dictionary reaches existing candidates — the same role cmd/backfill-derive plays for
+// jobs, and the one thing the structured résumé itself still lacks.
+//
+// It needs ONLY DATABASE_URL. Unlike cmd/backfill-resume-structured — which reads the CV
+// out of object storage, de-identifies it, and spends an LLM call per user — this worker
+// re-reads a structure that is already persisted and runs it through a deterministic
+// dictionary. That is what makes it cheap enough to re-run after ANY dictionary edit.
+//
+// Idempotent by construction: it derives through resume.DeriveGeography, the same
+// projection the upload path uses, so a second run over unchanged data and an unchanged
+// dictionary writes identical values. It only visits users whose structured résumé still
+// describes their stored CV — deriving geography from a superseded structure would route
+// around the staleness rule that governs the structure itself — and every write carries
+// the same monotonic guard, so a CV replaced mid-run is left to the upload path.
+//
+//	go run ./cmd/backfill-resume-geo                # every eligible user
+//	go run ./cmd/backfill-resume-geo --user 291     # a single user
+//	go run ./cmd/backfill-resume-geo --dry-run      # report, don't persist
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/strelov1/freehire/internal/config"
+	"github.com/strelov1/freehire/internal/database"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/resume"
+)
+
+func main() {
+	var userID int64
+	var dryRun bool
+	flag.Int64Var(&userID, "user", 0, "backfill a single user id (0 = every eligible user)")
+	flag.BoolVar(&dryRun, "dry-run", false, "report what would be written without persisting")
+	flag.Parse()
+
+	cfg := config.Load()
+	ctx := context.Background()
+
+	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("database: %v", err)
+	}
+	defer pool.Close()
+	queries := db.New(pool)
+
+	rows, err := queries.ListUsersForResumeGeoBackfill(ctx, userID)
+	if err != nil {
+		log.Fatalf("list eligible users: %v", err)
+	}
+	log.Printf("backfill-resume-geo: %d user(s) with a current structured résumé%s", len(rows), dryRunSuffix(dryRun))
+
+	var resolved, unresolved, unstated, failed int
+	for _, row := range rows {
+		countries, regions, cities := resume.DeriveGeography(row.Location)
+
+		switch {
+		case countries == nil && regions == nil:
+			// The CV states no location: the answer is "not known", stored as NULL.
+			unstated++
+		case len(countries) == 0 && len(regions) == 0:
+			// The CV states a place the curated dictionary could not resolve. Logged
+			// individually because this set IS the dictionary's coverage gap, and the
+			// only way to see it is to look at the strings that landed here.
+			unresolved++
+			log.Printf("user %d: unresolved location %q", row.ID, row.Location)
+		default:
+			resolved++
+		}
+
+		if dryRun {
+			continue
+		}
+		if err := queries.SetUserResumeGeography(ctx, db.SetUserResumeGeographyParams{
+			ID:               row.ID,
+			ResumeCountries:  countries,
+			ResumeRegions:    regions,
+			ResumeCities:     cities,
+			ResumeUploadedAt: row.ResumeUploadedAt,
+		}); err != nil {
+			log.Printf("user %d: persist: %v", row.ID, err)
+			failed++
+		}
+	}
+
+	log.Printf("backfill-resume-geo: done — %d resolved, %d stated but unresolved, %d stating no location, %d failed",
+		resolved, unresolved, unstated, failed)
+}
+
+func dryRunSuffix(dry bool) string {
+	if dry {
+		return " (dry-run)"
+	}
+	return ""
+}

--- a/cmd/backfill-resume-geo/main.go
+++ b/cmd/backfill-resume-geo/main.go
@@ -4,10 +4,14 @@
 // dictionary reaches existing candidates — the same role cmd/backfill-derive plays for
 // jobs, and the one thing the structured résumé itself still lacks.
 //
-// It needs ONLY DATABASE_URL. Unlike cmd/backfill-resume-structured — which reads the CV
-// out of object storage, de-identifies it, and spends an LLM call per user — this worker
-// re-reads a structure that is already persisted and runs it through a deterministic
-// dictionary. That is what makes it cheap enough to re-run after ANY dictionary edit.
+// It needs ONLY DATABASE_URL (plus the optional SENTRY_* every worker shares). Unlike
+// cmd/backfill-resume-structured — which reads the CV out of object storage, de-identifies
+// it, and spends an LLM call per user — this worker re-reads a structure that is already
+// persisted and runs it through a deterministic dictionary. That is what makes it cheap
+// enough to re-run after ANY dictionary edit.
+//
+// It runs under worker.Main/worker.Bootstrap like every other cron worker, so it reports
+// panics to Sentry and unwinds on SIGTERM rather than being killed mid-write.
 //
 // Idempotent by construction: it derives through resume.DeriveGeography, the same
 // projection the upload path uses, so a second run over unchanged data and an unchanged
@@ -26,10 +30,9 @@ import (
 	"flag"
 	"log"
 
-	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/resume"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 func main() {
@@ -39,19 +42,22 @@ func main() {
 	flag.BoolVar(&dryRun, "dry-run", false, "report what would be written without persisting")
 	flag.Parse()
 
-	cfg := config.Load()
-	ctx := context.Background()
+	worker.Main(func() int { return run(userID, dryRun) })
+}
 
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+func run(userID int64, dryRun bool) int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 	queries := db.New(pool)
 
 	rows, err := queries.ListUsersForResumeGeoBackfill(ctx, userID)
 	if err != nil {
-		log.Fatalf("list eligible users: %v", err)
+		log.Printf("list eligible users: %v", err)
+		return 1
 	}
 	log.Printf("backfill-resume-geo: %d user(s) with a current structured résumé%s", len(rows), dryRunSuffix(dryRun))
 
@@ -90,6 +96,10 @@ func main() {
 
 	log.Printf("backfill-resume-geo: done — %d resolved, %d stated but unresolved, %d stating no location, %d failed",
 		resolved, unresolved, unstated, failed)
+	if failed > 0 {
+		return 1
+	}
+	return 0
 }
 
 func dryRunSuffix(dry bool) string {

--- a/internal/db/AGENTS.md
+++ b/internal/db/AGENTS.md
@@ -10,6 +10,17 @@ The `internal/db` package — generated sqlc code, hand-written SQL queries, and
 - `migrations/` is the single source of truth for schema — the same dir feeds both sqlc and Postgres initdb.
 - `jobs.UNIQUE (source, external_id)` is the dedup key; `UpsertJob` is `ON CONFLICT` on it.
 - Fresh volumes get the whole `migrations/` dir via Postgres initdb (mounted into `/docker-entrypoint-initdb.d`, applied once on first init, in filename order). Every existing database (prod included) is migrated by `cmd/migrate` (`go run ./cmd/migrate`), which applies only files not yet recorded in `schema_migrations` (version = filename) — one transaction per file, under a session advisory lock. Changing an already-applied migration does NOT re-apply it; add a new file instead.
+- **An EXPANSIVE migration is applied before the deploy that reads it, not with it.** Adding
+  a nullable column is safe to run ahead of time and unreadable by the previous binary, but
+  the next binary reads it on a hot path — an unapplied column is a `42703` on every request
+  that touches it, not a degraded feature. Migration `0068` (candidate geography on `users`)
+  is the current example; its own header states the ordering.
+- **A nullable column and a `NOT NULL DEFAULT '{}'` column answer different questions.**
+  `jobs.countries` is the latter because a job always has a location string and derives it
+  synchronously, so `'{}'` means "the dictionary was silent". `users.resume_countries` is
+  the former because a user has a third state — no CV, or no current structure — so `NULL`
+  means "not known" and `'{}'` means "stated, but unresolvable". Collapsing them would lose
+  the dictionary's live coverage metric. Copy the shape only when the states match.
 - A new column referencing `users` needs its **own index** — Postgres indexes only the referenced side, so an unindexed reference makes every account deletion scan that table (this is what timed out account deletion against the 19 GB `jobs` table). `TestEveryUserForeignKeyIsIndexed` enforces it.
 
 Response shapes and error rendering are the handler layer's concern — see

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -671,6 +671,9 @@ type User struct {
 	PhotoObjectKey             pgtype.Text        `json:"photo_object_key"`
 	PhotoUploadedAt            pgtype.Timestamptz `json:"photo_uploaded_at"`
 	LlmKey                     pgtype.Text        `json:"llm_key"`
+	ResumeCountries            []string           `json:"resume_countries"`
+	ResumeRegions              []string           `json:"resume_regions"`
+	ResumeCities               []string           `json:"resume_cities"`
 }
 
 type UserEmailCode struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -209,8 +209,11 @@ type Querier interface {
 	// Clear the user's headshot pointer, after deleting the object from storage.
 	ClearUserPhoto(ctx context.Context, id int64) error
 	// Clear the user's résumé pointer (after deleting the object from storage), any
-	// cached ATS review, the derived CV embedding (no CV → no recommendations), and the
-	// derived structured résumé (the structure must not outlive the CV it describes).
+	// cached ATS review, the derived CV embedding (no CV → no recommendations), the
+	// derived structured résumé (the structure must not outlive the CV it describes), and
+	// the geography derived from that structure (which must not outlive it either — a
+	// country left behind here would keep answering "where is this candidate" from a CV
+	// that no longer exists).
 	ClearUserResume(ctx context.Context, id int64) error
 	// Moderator close: the thread leaves the open listing and rejects new replies.
 	CloseCommunityThread(ctx context.Context, id int64) error
@@ -961,6 +964,13 @@ type Querier interface {
 	// NULLs when none is stored. The caller ignores a vector whose model no longer matches
 	// the current embedder (stale) — see the cv-recommendations change.
 	GetUserResumeEmbedding(ctx context.Context, id int64) (GetUserResumeEmbeddingRow, error)
+	// The geography derived from the user's structured résumé, alongside the two stamps the
+	// caller needs to judge freshness (the derivation's own stamp and the current résumé
+	// upload time) — the same stamp-and-compare the structure read uses, so a geography
+	// derived from a superseded CV reads as absent rather than being served.
+	// NULL arrays mean "not known"; an empty array means the CV named a place the dictionary
+	// could not resolve. The two are deliberately different answers.
+	GetUserResumeGeography(ctx context.Context, id int64) (GetUserResumeGeographyRow, error)
 	// The user's derived structured résumé plus its provenance stamps (the LLM model and
 	// the résumé upload time it was derived from), alongside the current résumé upload time
 	// so the caller can tell whether the structure still describes the stored CV (served
@@ -1472,6 +1482,15 @@ type Querier interface {
 	// the pending saved-job reminder's deadline (NULL when none), so the saved list can
 	// show "remind in N days" with its reschedule/off controls.
 	ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error)
+	// Users whose stored structured résumé currently describes their stored CV, for the
+	// geography reconciler (cmd/backfill-resume-geo). Superseded structures are excluded:
+	// deriving geography from one would route around the staleness rule that governs the
+	// structure itself. Returns the location line the derivation reads plus the stamp to
+	// write under, so the worker needs no second round-trip per user.
+	// The location line is coalesced to '' and cast so sqlc types it as a string rather than
+	// interface{}. An absent key and an empty string are the same case — the CV stated no
+	// location — and both must derive to an ABSENT geography, not to an empty resolved one.
+	ListUsersForResumeGeoBackfill(ctx context.Context, userID int64) ([]ListUsersForResumeGeoBackfillRow, error)
 	// Every public_slug the user has interacted with (viewed_at is always set, so
 	// any interaction row counts as viewed). Used by the SPA to dim already-seen
 	// cards in the browse list without authenticating the public job-read path.
@@ -2135,6 +2154,11 @@ type Querier interface {
 	// Persist the user's derived CV embedding vector plus the identity of the embedder
 	// that produced it (so a model change can mark the vector stale). Never the raw CV text.
 	SetUserResumeEmbedding(ctx context.Context, arg SetUserResumeEmbeddingParams) error
+	// Persist only the derived geography for a user, under the same monotonic guard the
+	// structure write uses. This is the reconciler's write path: it re-derives from an
+	// already-stored structure, so it must not touch the structure or its model stamp, and
+	// must still refuse to write against a CV that has been replaced since the row was read.
+	SetUserResumeGeography(ctx context.Context, arg SetUserResumeGeographyParams) error
 	// Persist the user's derived structured résumé, stamped with the producing LLM model
 	// and the résumé upload time it was derived from (passed in, not now(), so the stamp
 	// matches the CV the background extraction actually read). Never the raw CV text.
@@ -2142,6 +2166,12 @@ type Querier interface {
 	// extraction for a since-superseded CV (its stamp no longer equals the current upload
 	// time) matches no row and is dropped, so a late writer can't clobber a newer CV's
 	// structure with an already-stale stamp (which Store.Structured would then hide forever).
+	//
+	// The candidate's geography rides in this same statement rather than a second one, so it
+	// inherits that guard for free and can never end up describing a different CV than the
+	// structure it was derived from. It is deterministic and costs no I/O, so there is
+	// nothing to gain by deferring it — and a separate write would have to duplicate the
+	// guard, which is exactly how invariants drift apart.
 	SetUserResumeStructured(ctx context.Context, arg SetUserResumeStructuredParams) error
 	// Soft-delete one message (hidden from the listing, retained for restore),
 	// scoped to the caller and idempotent. Returns 0 rows only when it is not the

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -125,13 +125,17 @@ WHERE id = $1;
 
 -- name: ClearUserResume :exec
 -- Clear the user's résumé pointer (after deleting the object from storage), any
--- cached ATS review, the derived CV embedding (no CV → no recommendations), and the
--- derived structured résumé (the structure must not outlive the CV it describes).
+-- cached ATS review, the derived CV embedding (no CV → no recommendations), the
+-- derived structured résumé (the structure must not outlive the CV it describes), and
+-- the geography derived from that structure (which must not outlive it either — a
+-- country left behind here would keep answering "where is this candidate" from a CV
+-- that no longer exists).
 UPDATE users
 SET resume_object_key = NULL, resume_uploaded_at = NULL, resume_ats_analysis = NULL,
     resume_embedding = NULL, resume_embedding_model = NULL,
     resume_structured = NULL, resume_structured_model = NULL,
-    resume_structured_uploaded_at = NULL
+    resume_structured_uploaded_at = NULL,
+    resume_countries = NULL, resume_regions = NULL, resume_cities = NULL
 WHERE id = $1;
 
 -- name: GetUserPhoto :one
@@ -200,9 +204,54 @@ WHERE id = $1;
 -- extraction for a since-superseded CV (its stamp no longer equals the current upload
 -- time) matches no row and is dropped, so a late writer can't clobber a newer CV's
 -- structure with an already-stale stamp (which Store.Structured would then hide forever).
+--
+-- The candidate's geography rides in this same statement rather than a second one, so it
+-- inherits that guard for free and can never end up describing a different CV than the
+-- structure it was derived from. It is deterministic and costs no I/O, so there is
+-- nothing to gain by deferring it — and a separate write would have to duplicate the
+-- guard, which is exactly how invariants drift apart.
 UPDATE users
-SET resume_structured = $2, resume_structured_model = $3, resume_structured_uploaded_at = $4
+SET resume_structured = $2, resume_structured_model = $3, resume_structured_uploaded_at = $4,
+    resume_countries = $5, resume_regions = $6, resume_cities = $7
 WHERE id = $1 AND resume_uploaded_at = $4;
+
+-- name: GetUserResumeGeography :one
+-- The geography derived from the user's structured résumé, alongside the two stamps the
+-- caller needs to judge freshness (the derivation's own stamp and the current résumé
+-- upload time) — the same stamp-and-compare the structure read uses, so a geography
+-- derived from a superseded CV reads as absent rather than being served.
+-- NULL arrays mean "not known"; an empty array means the CV named a place the dictionary
+-- could not resolve. The two are deliberately different answers.
+SELECT resume_countries, resume_regions, resume_cities,
+       resume_structured_uploaded_at, resume_uploaded_at
+FROM users
+WHERE id = $1;
+
+-- name: ListUsersForResumeGeoBackfill :many
+-- Users whose stored structured résumé currently describes their stored CV, for the
+-- geography reconciler (cmd/backfill-resume-geo). Superseded structures are excluded:
+-- deriving geography from one would route around the staleness rule that governs the
+-- structure itself. Returns the location line the derivation reads plus the stamp to
+-- write under, so the worker needs no second round-trip per user.
+-- The location line is coalesced to '' and cast so sqlc types it as a string rather than
+-- interface{}. An absent key and an empty string are the same case — the CV stated no
+-- location — and both must derive to an ABSENT geography, not to an empty resolved one.
+SELECT id, coalesce(resume_structured ->> 'location', '')::text AS location, resume_uploaded_at
+FROM users
+WHERE resume_structured IS NOT NULL
+  AND resume_uploaded_at IS NOT NULL
+  AND resume_structured_uploaded_at IS NOT DISTINCT FROM resume_uploaded_at
+  AND (sqlc.arg(user_id)::bigint = 0 OR id = sqlc.arg(user_id)::bigint)
+ORDER BY id;
+
+-- name: SetUserResumeGeography :exec
+-- Persist only the derived geography for a user, under the same monotonic guard the
+-- structure write uses. This is the reconciler's write path: it re-derives from an
+-- already-stored structure, so it must not touch the structure or its model stamp, and
+-- must still refuse to write against a CV that has been replaced since the row was read.
+UPDATE users
+SET resume_countries = $2, resume_regions = $3, resume_cities = $4
+WHERE id = $1 AND resume_uploaded_at = $5;
 
 -- name: GetUserRole :one
 -- Slim role lookup for the RequireRole authorization middleware: it runs on every

--- a/internal/db/user_resume_geography_integration_test.go
+++ b/internal/db/user_resume_geography_integration_test.go
@@ -1,0 +1,234 @@
+//go:build integration
+
+// Integration tests for the candidate-geography SQL semantics. Three of the four
+// properties this change relies on are pure SQL and cannot be observed from a unit test:
+// the NULL-versus-'{}' distinction (Go's nil slice and empty slice both have to survive
+// the round trip as different values), the monotonic guard on both write paths, and the
+// staleness rule that keeps the reconciler off superseded structures. Run with:
+// go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func stamp(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: t, Valid: true}
+}
+
+// seedUserWithCV creates a user with a stored CV uploaded at uploadedAt, and optionally a
+// structured résumé stamped at structuredAt (zero = none stored).
+func seedUserWithCV(t *testing.T, q *Queries, email string, uploadedAt, structuredAt time.Time, structuredJSON string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	var id int64
+	if err := q.db.QueryRow(ctx,
+		`INSERT INTO users (email, email_verified, resume_object_key, resume_uploaded_at)
+		 VALUES ($1, true, 'resumes/x', $2) RETURNING id`, email, uploadedAt).Scan(&id); err != nil {
+		t.Fatalf("seed user %s: %v", email, err)
+	}
+	if !structuredAt.IsZero() {
+		if _, err := q.db.Exec(ctx,
+			`UPDATE users SET resume_structured = $2::jsonb, resume_structured_uploaded_at = $3 WHERE id = $1`,
+			id, structuredJSON, structuredAt); err != nil {
+			t.Fatalf("seed structure for %s: %v", email, err)
+		}
+	}
+	return id
+}
+
+// TestResumeGeographyDistinguishesUnknownFromUnresolved is the whole reason these columns
+// are nullable with no default. A candidate whose CV states nothing and a candidate whose
+// CV states a place the dictionary could not resolve are different facts, and the second
+// one is the dictionary's live coverage metric.
+func TestResumeGeographyDistinguishesUnknownFromUnresolved(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	at := time.Now().UTC().Truncate(time.Second)
+	unknown := seedUserWithCV(t, q, "geo-unknown@example.test", at, at, `{}`)
+	unresolved := seedUserWithCV(t, q, "geo-unresolved@example.test", at, at, `{"location":"Greater Philadelphia"}`)
+
+	// "not known" — nil arrays.
+	if err := q.SetUserResumeGeography(ctx, SetUserResumeGeographyParams{
+		ID: unknown, ResumeCountries: nil, ResumeRegions: nil, ResumeCities: nil,
+		ResumeUploadedAt: stamp(at),
+	}); err != nil {
+		t.Fatalf("SetUserResumeGeography(unknown): %v", err)
+	}
+	// "stated, but the dictionary was silent" — empty non-nil arrays.
+	if err := q.SetUserResumeGeography(ctx, SetUserResumeGeographyParams{
+		ID: unresolved, ResumeCountries: []string{}, ResumeRegions: []string{}, ResumeCities: []string{},
+		ResumeUploadedAt: stamp(at),
+	}); err != nil {
+		t.Fatalf("SetUserResumeGeography(unresolved): %v", err)
+	}
+
+	var isNull bool
+	if err := pool.QueryRow(ctx, `SELECT resume_countries IS NULL FROM users WHERE id = $1`, unknown).Scan(&isNull); err != nil {
+		t.Fatalf("read unknown: %v", err)
+	}
+	if !isNull {
+		t.Error("a candidate whose CV states no location stored a non-NULL country array")
+	}
+	if err := pool.QueryRow(ctx, `SELECT resume_countries IS NULL FROM users WHERE id = $1`, unresolved).Scan(&isNull); err != nil {
+		t.Fatalf("read unresolved: %v", err)
+	}
+	if isNull {
+		t.Error("a stated-but-unresolvable location stored NULL, collapsing it with 'not known'")
+	}
+
+	// The coverage metric the distinction exists to make possible.
+	var gap int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM users WHERE resume_countries = '{}'`).Scan(&gap); err != nil {
+		t.Fatalf("coverage query: %v", err)
+	}
+	if gap != 1 {
+		t.Errorf("count of stated-but-unresolved = %d, want 1", gap)
+	}
+}
+
+// TestListUsersForResumeGeoBackfillSkipsSupersededStructures pins the reconciler's
+// selection rule. Deriving geography from a structure that no longer describes the stored
+// CV would route around the staleness rule that governs the structure itself.
+func TestListUsersForResumeGeoBackfillSkipsSupersededStructures(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	at := time.Now().UTC().Truncate(time.Second)
+	fresh := seedUserWithCV(t, q, "geo-fresh@example.test", at, at, `{"location":"Kraków, Poland"}`)
+	// A newer CV landed; the structure still carries the older stamp.
+	seedUserWithCV(t, q, "geo-stale@example.test", at.Add(time.Hour), at, `{"location":"Kraków, Poland"}`)
+	// A CV whose extraction never landed at all — the 37-user case on production.
+	seedUserWithCV(t, q, "geo-nostruct@example.test", at, time.Time{}, "")
+
+	rows, err := q.ListUsersForResumeGeoBackfill(ctx, 0)
+	if err != nil {
+		t.Fatalf("ListUsersForResumeGeoBackfill: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != fresh {
+		ids := make([]int64, len(rows))
+		for i, r := range rows {
+			ids[i] = r.ID
+		}
+		t.Fatalf("selected %v, want only the user with a current structure (%d)", ids, fresh)
+	}
+	if rows[0].Location != "Kraków, Poland" {
+		t.Errorf("location = %q, want the structure's location line", rows[0].Location)
+	}
+
+	// --user narrows to one; a user outside the eligible set stays excluded.
+	one, err := q.ListUsersForResumeGeoBackfill(ctx, fresh)
+	if err != nil {
+		t.Fatalf("ListUsersForResumeGeoBackfill(--user): %v", err)
+	}
+	if len(one) != 1 || one[0].ID != fresh {
+		t.Errorf("--user selection = %+v, want exactly the requested eligible user", one)
+	}
+}
+
+// TestListUsersForResumeGeoBackfillReadsAnAbsentLocationAsEmpty guards the coalesce in
+// the query: a structure with no location key must not scan as NULL into a string.
+func TestListUsersForResumeGeoBackfillReadsAnAbsentLocationAsEmpty(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	at := time.Now().UTC().Truncate(time.Second)
+	seedUserWithCV(t, q, "geo-noloc@example.test", at, at, `{"full_name":"Jane"}`)
+
+	rows, err := q.ListUsersForResumeGeoBackfill(ctx, 0)
+	if err != nil {
+		t.Fatalf("ListUsersForResumeGeoBackfill: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("selected %d users, want 1", len(rows))
+	}
+	if rows[0].Location != "" {
+		t.Errorf("location = %q, want empty for a structure with no location key", rows[0].Location)
+	}
+}
+
+// TestSetUserResumeGeographyRefusesASupersededStamp: the reconciler reads a row, derives,
+// and writes back. If a fresh upload lands in between, the write must be dropped rather
+// than stamping the new CV with geography derived from the old one.
+func TestSetUserResumeGeographyRefusesASupersededStamp(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	at := time.Now().UTC().Truncate(time.Second)
+	id := seedUserWithCV(t, q, "geo-race@example.test", at, at, `{"location":"Kraków, Poland"}`)
+
+	// A new CV lands after the reconciler read the row.
+	if _, err := pool.Exec(ctx, `UPDATE users SET resume_uploaded_at = $2 WHERE id = $1`, id, at.Add(time.Hour)); err != nil {
+		t.Fatalf("simulate re-upload: %v", err)
+	}
+
+	if err := q.SetUserResumeGeography(ctx, SetUserResumeGeographyParams{
+		ID: id, ResumeCountries: []string{"pl"}, ResumeRegions: []string{"eu"}, ResumeCities: []string{"Kraków"},
+		ResumeUploadedAt: stamp(at), // the stamp read before the re-upload
+	}); err != nil {
+		t.Fatalf("SetUserResumeGeography: %v", err)
+	}
+
+	var isNull bool
+	if err := pool.QueryRow(ctx, `SELECT resume_countries IS NULL FROM users WHERE id = $1`, id).Scan(&isNull); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !isNull {
+		t.Error("geography derived from a superseded CV was written; the monotonic guard did not hold")
+	}
+}
+
+// TestSetUserResumeStructuredWritesGeographyInTheSameStatement is the invariant the whole
+// write-path decision rests on: structure and geography land together, or not at all.
+func TestSetUserResumeStructuredWritesGeographyInTheSameStatement(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	at := time.Now().UTC().Truncate(time.Second)
+	id := seedUserWithCV(t, q, "geo-together@example.test", at, time.Time{}, "")
+
+	if err := q.SetUserResumeStructured(ctx, SetUserResumeStructuredParams{
+		ID:                         id,
+		ResumeStructured:           []byte(`{"location":"Kraków, Poland"}`),
+		ResumeStructuredModel:      pgtype.Text{String: "model-x", Valid: true},
+		ResumeStructuredUploadedAt: stamp(at),
+		ResumeCountries:            []string{"pl"},
+		ResumeRegions:              []string{"eu"},
+		ResumeCities:               []string{"Kraków"},
+	}); err != nil {
+		t.Fatalf("SetUserResumeStructured: %v", err)
+	}
+
+	got, err := q.GetUserResumeGeography(ctx, id)
+	if err != nil {
+		t.Fatalf("GetUserResumeGeography: %v", err)
+	}
+	if len(got.ResumeCountries) != 1 || got.ResumeCountries[0] != "pl" {
+		t.Errorf("countries = %v, want [pl] from the structure write", got.ResumeCountries)
+	}
+	if !got.ResumeStructuredUploadedAt.Valid || !got.ResumeStructuredUploadedAt.Time.Equal(got.ResumeUploadedAt.Time) {
+		t.Error("the geography read does not report the structure as current")
+	}
+
+	// And clearing the résumé takes the geography with it.
+	if err := q.ClearUserResume(ctx, id); err != nil {
+		t.Fatalf("ClearUserResume: %v", err)
+	}
+	var isNull bool
+	if err := pool.QueryRow(ctx, `SELECT resume_countries IS NULL FROM users WHERE id = $1`, id).Scan(&isNull); err != nil {
+		t.Fatalf("read after clear: %v", err)
+	}
+	if !isNull {
+		t.Error("geography survived ClearUserResume — it must not outlive the CV it describes")
+	}
+}

--- a/internal/db/users.sql.go
+++ b/internal/db/users.sql.go
@@ -45,13 +45,17 @@ UPDATE users
 SET resume_object_key = NULL, resume_uploaded_at = NULL, resume_ats_analysis = NULL,
     resume_embedding = NULL, resume_embedding_model = NULL,
     resume_structured = NULL, resume_structured_model = NULL,
-    resume_structured_uploaded_at = NULL
+    resume_structured_uploaded_at = NULL,
+    resume_countries = NULL, resume_regions = NULL, resume_cities = NULL
 WHERE id = $1
 `
 
 // Clear the user's résumé pointer (after deleting the object from storage), any
-// cached ATS review, the derived CV embedding (no CV → no recommendations), and the
-// derived structured résumé (the structure must not outlive the CV it describes).
+// cached ATS review, the derived CV embedding (no CV → no recommendations), the
+// derived structured résumé (the structure must not outlive the CV it describes), and
+// the geography derived from that structure (which must not outlive it either — a
+// country left behind here would keep answering "where is this candidate" from a CV
+// that no longer exists).
 func (q *Queries) ClearUserResume(ctx context.Context, id int64) error {
 	_, err := q.db.Exec(ctx, clearUserResume, id)
 	return err
@@ -276,6 +280,40 @@ func (q *Queries) GetUserResumeEmbedding(ctx context.Context, id int64) (GetUser
 	return i, err
 }
 
+const getUserResumeGeography = `-- name: GetUserResumeGeography :one
+SELECT resume_countries, resume_regions, resume_cities,
+       resume_structured_uploaded_at, resume_uploaded_at
+FROM users
+WHERE id = $1
+`
+
+type GetUserResumeGeographyRow struct {
+	ResumeCountries            []string           `json:"resume_countries"`
+	ResumeRegions              []string           `json:"resume_regions"`
+	ResumeCities               []string           `json:"resume_cities"`
+	ResumeStructuredUploadedAt pgtype.Timestamptz `json:"resume_structured_uploaded_at"`
+	ResumeUploadedAt           pgtype.Timestamptz `json:"resume_uploaded_at"`
+}
+
+// The geography derived from the user's structured résumé, alongside the two stamps the
+// caller needs to judge freshness (the derivation's own stamp and the current résumé
+// upload time) — the same stamp-and-compare the structure read uses, so a geography
+// derived from a superseded CV reads as absent rather than being served.
+// NULL arrays mean "not known"; an empty array means the CV named a place the dictionary
+// could not resolve. The two are deliberately different answers.
+func (q *Queries) GetUserResumeGeography(ctx context.Context, id int64) (GetUserResumeGeographyRow, error) {
+	row := q.db.QueryRow(ctx, getUserResumeGeography, id)
+	var i GetUserResumeGeographyRow
+	err := row.Scan(
+		&i.ResumeCountries,
+		&i.ResumeRegions,
+		&i.ResumeCities,
+		&i.ResumeStructuredUploadedAt,
+		&i.ResumeUploadedAt,
+	)
+	return i, err
+}
+
 const getUserResumeStructured = `-- name: GetUserResumeStructured :one
 SELECT resume_structured, resume_structured_model, resume_structured_uploaded_at, resume_uploaded_at
 FROM users
@@ -370,6 +408,50 @@ func (q *Queries) ListUserBlobKeys(ctx context.Context, id int64) ([]pgtype.Text
 			return nil, err
 		}
 		items = append(items, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUsersForResumeGeoBackfill = `-- name: ListUsersForResumeGeoBackfill :many
+SELECT id, coalesce(resume_structured ->> 'location', '')::text AS location, resume_uploaded_at
+FROM users
+WHERE resume_structured IS NOT NULL
+  AND resume_uploaded_at IS NOT NULL
+  AND resume_structured_uploaded_at IS NOT DISTINCT FROM resume_uploaded_at
+  AND ($1::bigint = 0 OR id = $1::bigint)
+ORDER BY id
+`
+
+type ListUsersForResumeGeoBackfillRow struct {
+	ID               int64              `json:"id"`
+	Location         string             `json:"location"`
+	ResumeUploadedAt pgtype.Timestamptz `json:"resume_uploaded_at"`
+}
+
+// Users whose stored structured résumé currently describes their stored CV, for the
+// geography reconciler (cmd/backfill-resume-geo). Superseded structures are excluded:
+// deriving geography from one would route around the staleness rule that governs the
+// structure itself. Returns the location line the derivation reads plus the stamp to
+// write under, so the worker needs no second round-trip per user.
+// The location line is coalesced to ” and cast so sqlc types it as a string rather than
+// interface{}. An absent key and an empty string are the same case — the CV stated no
+// location — and both must derive to an ABSENT geography, not to an empty resolved one.
+func (q *Queries) ListUsersForResumeGeoBackfill(ctx context.Context, userID int64) ([]ListUsersForResumeGeoBackfillRow, error) {
+	rows, err := q.db.Query(ctx, listUsersForResumeGeoBackfill, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListUsersForResumeGeoBackfillRow{}
+	for rows.Next() {
+		var i ListUsersForResumeGeoBackfillRow
+		if err := rows.Scan(&i.ID, &i.Location, &i.ResumeUploadedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -545,9 +627,39 @@ func (q *Queries) SetUserResumeEmbedding(ctx context.Context, arg SetUserResumeE
 	return err
 }
 
+const setUserResumeGeography = `-- name: SetUserResumeGeography :exec
+UPDATE users
+SET resume_countries = $2, resume_regions = $3, resume_cities = $4
+WHERE id = $1 AND resume_uploaded_at = $5
+`
+
+type SetUserResumeGeographyParams struct {
+	ID               int64              `json:"id"`
+	ResumeCountries  []string           `json:"resume_countries"`
+	ResumeRegions    []string           `json:"resume_regions"`
+	ResumeCities     []string           `json:"resume_cities"`
+	ResumeUploadedAt pgtype.Timestamptz `json:"resume_uploaded_at"`
+}
+
+// Persist only the derived geography for a user, under the same monotonic guard the
+// structure write uses. This is the reconciler's write path: it re-derives from an
+// already-stored structure, so it must not touch the structure or its model stamp, and
+// must still refuse to write against a CV that has been replaced since the row was read.
+func (q *Queries) SetUserResumeGeography(ctx context.Context, arg SetUserResumeGeographyParams) error {
+	_, err := q.db.Exec(ctx, setUserResumeGeography,
+		arg.ID,
+		arg.ResumeCountries,
+		arg.ResumeRegions,
+		arg.ResumeCities,
+		arg.ResumeUploadedAt,
+	)
+	return err
+}
+
 const setUserResumeStructured = `-- name: SetUserResumeStructured :exec
 UPDATE users
-SET resume_structured = $2, resume_structured_model = $3, resume_structured_uploaded_at = $4
+SET resume_structured = $2, resume_structured_model = $3, resume_structured_uploaded_at = $4,
+    resume_countries = $5, resume_regions = $6, resume_cities = $7
 WHERE id = $1 AND resume_uploaded_at = $4
 `
 
@@ -556,6 +668,9 @@ type SetUserResumeStructuredParams struct {
 	ResumeStructured           []byte             `json:"resume_structured"`
 	ResumeStructuredModel      pgtype.Text        `json:"resume_structured_model"`
 	ResumeStructuredUploadedAt pgtype.Timestamptz `json:"resume_structured_uploaded_at"`
+	ResumeCountries            []string           `json:"resume_countries"`
+	ResumeRegions              []string           `json:"resume_regions"`
+	ResumeCities               []string           `json:"resume_cities"`
 }
 
 // Persist the user's derived structured résumé, stamped with the producing LLM model
@@ -565,12 +680,21 @@ type SetUserResumeStructuredParams struct {
 // extraction for a since-superseded CV (its stamp no longer equals the current upload
 // time) matches no row and is dropped, so a late writer can't clobber a newer CV's
 // structure with an already-stale stamp (which Store.Structured would then hide forever).
+//
+// The candidate's geography rides in this same statement rather than a second one, so it
+// inherits that guard for free and can never end up describing a different CV than the
+// structure it was derived from. It is deterministic and costs no I/O, so there is
+// nothing to gain by deferring it — and a separate write would have to duplicate the
+// guard, which is exactly how invariants drift apart.
 func (q *Queries) SetUserResumeStructured(ctx context.Context, arg SetUserResumeStructuredParams) error {
 	_, err := q.db.Exec(ctx, setUserResumeStructured,
 		arg.ID,
 		arg.ResumeStructured,
 		arg.ResumeStructuredModel,
 		arg.ResumeStructuredUploadedAt,
+		arg.ResumeCountries,
+		arg.ResumeRegions,
+		arg.ResumeCities,
 	)
 	return err
 }

--- a/internal/handler/hardconstraint_country_test.go
+++ b/internal/handler/hardconstraint_country_test.go
@@ -1,0 +1,70 @@
+package handler
+
+import "testing"
+
+// TestCandidateCountry pins the precedence between what the candidate ASSERTED about
+// where they are and what was DERIVED for them from their CV.
+//
+// The fallback exists because two hard constraints — "this job does not sponsor visas and
+// is pinned to a country you are not in" and "this on-site job is in another country" —
+// read this one field, and it was empty for the large majority of profiles, so both were
+// silently inert. Filling it from the CV revives them without ever overriding the user.
+func TestCandidateCountry(t *testing.T) {
+	tests := []struct {
+		name     string
+		asserted string
+		derived  []string
+		want     string
+	}{
+		{
+			name:     "an asserted base country always wins",
+			asserted: "de",
+			derived:  []string{"pl"},
+			want:     "de",
+		},
+		{
+			name:     "a single derived country fills an unstated base",
+			asserted: "",
+			derived:  []string{"pl"},
+			want:     "pl",
+		},
+		{
+			// The dictionary's never-guess rule reaches all the way here. An ambiguous
+			// derivation is not a fact about the candidate, and picking one of the two
+			// would be manufacturing evidence they never supplied.
+			name:     "more than one derived country yields nothing rather than a guess",
+			asserted: "",
+			derived:  []string{"pl", "de"},
+			want:     "",
+		},
+		{
+			name:     "neither source yields nothing, exactly as before",
+			asserted: "",
+			derived:  nil,
+			want:     "",
+		},
+		{
+			// A CV that stated a place the dictionary could not resolve arrives as an
+			// empty (non-nil) slice. It is still no answer.
+			name:     "a stated but unresolved location yields nothing",
+			asserted: "",
+			derived:  []string{},
+			want:     "",
+		},
+		{
+			// The user's own statement wins even when the derivation is ambiguous.
+			name:     "an asserted country wins over an ambiguous derivation",
+			asserted: "br",
+			derived:  []string{"pl", "de"},
+			want:     "br",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := candidateCountry(tt.asserted, tt.derived); got != tt.want {
+				t.Errorf("candidateCountry(%q, %v) = %q, want %q", tt.asserted, tt.derived, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/handler/hardconstraint_e2e_test.go
+++ b/internal/handler/hardconstraint_e2e_test.go
@@ -17,7 +17,7 @@ import (
 func TestServedAnalysisCappedByUnmetHardConstraint(t *testing.T) {
 	job := db.Job{Description: "Requires an active PMP certification."}
 	cv := resumeextract.Structured{Certifications: []string{"AWS Certified Solutions Architect"}} // lists certs, not PMP
-	jr, ev := buildHardConstraintInputs(job, cv, userprofile.LocationPreferences{})
+	jr, ev := buildHardConstraintInputs(job, cv, userprofile.LocationPreferences{}, nil)
 	blockers := hardconstraint.Evaluate(jr, ev)
 
 	analysis := &matchanalysis.Analysis{OverallScore: 88, Verdict: "Strong Fit"}

--- a/internal/handler/hardconstraint_inputs.go
+++ b/internal/handler/hardconstraint_inputs.go
@@ -63,7 +63,14 @@ func (h *matchHandlers) jobBlockers(ctx context.Context, userID int64, job db.Jo
 	if len(profile.LocationPreferences) > 0 {
 		_ = json.Unmarshal(profile.LocationPreferences, &loc) // best-effort; empty loc simply skips geo checks
 	}
-	jr, ev := buildHardConstraintInputs(job, cv, loc)
+	// Where the caller has asserted no base country, fall back to the one derived from
+	// their CV. Best-effort: a failing read simply leaves the country empty, which is the
+	// behaviour this path had for every caller before the fallback existed.
+	var derived []string
+	if geo, ok, err := h.resume.Geography(ctx, userID); err == nil && ok {
+		derived = geo.Countries
+	}
+	jr, ev := buildHardConstraintInputs(job, cv, loc, derived)
 	return hardconstraint.Evaluate(jr, ev)
 }
 
@@ -73,7 +80,9 @@ func (h *matchHandlers) jobBlockers(ctx context.Context, userID int64, job db.Jo
 // (required certifications and degree-optional); visa sponsorship comes from the
 // enrichment jsonb. The CV side reads the structured résumé and the profile's base
 // country / remote preference. Pure so it is unit-testable.
-func buildHardConstraintInputs(job db.Job, cv resumeextract.Structured, loc userprofile.LocationPreferences) (hardconstraint.JobRequirements, hardconstraint.CVEvidence) {
+// derivedCountries is the geography read off the caller's CV; it is consulted only when
+// the caller asserted no base country of their own (see candidateCountry).
+func buildHardConstraintInputs(job db.Job, cv resumeextract.Structured, loc userprofile.LocationPreferences, derivedCountries []string) (hardconstraint.JobRequirements, hardconstraint.CVEvidence) {
 	jr := hardconstraint.JobRequirements{
 		ExperienceYearsMin:     int4Ptr(job.ExperienceYearsMin),
 		EducationLevel:         job.EducationLevel,
@@ -89,7 +98,7 @@ func buildHardConstraintInputs(job db.Job, cv resumeextract.Structured, loc user
 		Degrees:        degreeNames(cv.Education),
 		Languages:      cv.Languages,
 		Certifications: cv.Certifications,
-		CountryCode:    loc.Base.Country,
+		CountryCode:    candidateCountry(loc.Base.Country, derivedCountries),
 		PrefersRemote:  prefersRemote(loc.WorkModes),
 	}
 	return jr, ev
@@ -141,4 +150,28 @@ func int4Ptr(v pgtype.Int4) *int {
 	}
 	n := int(v.Int32)
 	return &n
+}
+
+// candidateCountry decides which country the hard-constraint evaluator judges the caller
+// by: the one they ASSERTED on their profile (location_preferences.base.country), or —
+// only when they asserted none — the one DERIVED from their CV.
+//
+// This is the same shape as jobview.geoFacet, where the dictionary pins what it can and
+// the weaker source fills only the unpinned bucket. The candidate's own statement is the
+// authority; the derivation exists to stop the two country-dependent constraints from
+// being silently inert for everyone who never filled the field in.
+//
+// A derivation naming more than one country is treated as NO answer rather than resolved
+// by picking one. The whole dictionary discipline is never to guess, and an ambiguous
+// derivation is not a fact — manufacturing one here would produce a blocker the candidate
+// never supplied the evidence for, which is exactly what "never emit a false blocker"
+// forbids.
+func candidateCountry(asserted string, derived []string) string {
+	if asserted != "" {
+		return asserted
+	}
+	if len(derived) != 1 {
+		return ""
+	}
+	return derived[0]
 }

--- a/internal/handler/hardconstraint_inputs_test.go
+++ b/internal/handler/hardconstraint_inputs_test.go
@@ -27,7 +27,7 @@ func TestBuildHardConstraintInputs(t *testing.T) {
 	}
 	loc := userprofile.LocationPreferences{WorkModes: []string{"remote"}, Base: userprofile.BaseLocation{Country: "br"}}
 
-	jr, ev := buildHardConstraintInputs(job, cv, loc)
+	jr, ev := buildHardConstraintInputs(job, cv, loc, nil)
 
 	if jr.ExperienceYearsMin == nil || *jr.ExperienceYearsMin != 5 {
 		t.Errorf("ExperienceYearsMin = %v, want 5", jr.ExperienceYearsMin)

--- a/internal/handler/me_profile.go
+++ b/internal/handler/me_profile.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
 	"github.com/strelov1/freehire/internal/userprofile"
 )
@@ -18,6 +19,9 @@ import (
 // database. The bool reports whether a structure current with the stored CV exists.
 type structuredResumeReader interface {
 	Structured(ctx context.Context, userID int64) (resumeextract.Structured, bool, error)
+	// Geography is where the CV says the candidate IS, under the same freshness rule as
+	// Structured — a geography derived from a superseded CV reads as absent.
+	Geography(ctx context.Context, userID int64) (resume.Geography, bool, error)
 }
 
 // profileHandlers serves the single-per-user profile (a specialization + skills set).
@@ -65,20 +69,37 @@ type profileResponse struct {
 	Skills              []string                    `json:"skills"`
 	ExcludedSkills      []string                    `json:"excluded_skills"`
 	LocationPreferences json.RawMessage             `json:"location_preferences"`
+	DerivedLocation     *derivedLocation            `json:"derived_location"`
 	CV                  *resumeextract.Professional `json:"cv"`
 	CreatedAt           *time.Time                  `json:"created_at"`
 	UpdatedAt           *time.Time                  `json:"updated_at"`
 }
 
+// derivedLocation is where the caller's CV says they ARE, as resolved by the location
+// dictionary. It is deliberately a sibling of location_preferences rather than merged
+// into it: one is what the candidate asserted and the other is what was derived for them,
+// and a consumer needs to know which it is holding. Read-only — no profile write can set
+// it, because it is produced solely by the CV derivation.
+//
+// The client uses it to pre-fill "where you're based" for a user who has stated no base,
+// so confirming a fact already on the CV is cheaper than retyping it. null when the
+// caller has no current structured résumé.
+type derivedLocation struct {
+	Countries []string `json:"countries"`
+	Regions   []string `json:"regions"`
+	Cities    []string `json:"cities"`
+}
+
 // toProfileResponse maps a stored profile to its wire shape (no user id). The location
 // block is the raw JSONB (json.RawMessage), which marshals through unchanged — a NULL
 // column stays null.
-func toProfileResponse(p userprofile.Profile, cv *resumeextract.Professional) profileResponse {
+func toProfileResponse(p userprofile.Profile, cv *resumeextract.Professional, loc *derivedLocation) profileResponse {
 	return profileResponse{
 		Specializations:     p.Specializations,
 		Skills:              p.Skills,
 		ExcludedSkills:      p.ExcludedSkills,
 		LocationPreferences: p.LocationPreferences,
+		DerivedLocation:     loc,
 		CV:                  cv,
 		CreatedAt:           p.CreatedAt,
 		UpdatedAt:           p.UpdatedAt,
@@ -179,7 +200,7 @@ func (h *profileHandlers) GetProfile(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	return c.JSON(fiber.Map{"data": toProfileResponse(profile, h.structuredCV(c.Context(), userID))})
+	return c.JSON(fiber.Map{"data": toProfileResponse(profile, h.structuredCV(c.Context(), userID), h.derivedLocation(c.Context(), userID))})
 }
 
 // PutProfile creates-or-replaces the authenticated user's profile (specializations +
@@ -203,7 +224,7 @@ func (h *profileHandlers) PutProfile(c *fiber.Ctx) error {
 	}
 	// The same representation the read serves — one resource, one shape, so a client that
 	// saves and a client that fetches see the same profile.
-	return c.JSON(fiber.Map{"data": toProfileResponse(profile, h.structuredCV(c.Context(), userID))})
+	return c.JSON(fiber.Map{"data": toProfileResponse(profile, h.structuredCV(c.Context(), userID), h.derivedLocation(c.Context(), userID))})
 }
 
 // DeleteProfile clears the authenticated user's profile. Idempotent: deleting when none
@@ -218,4 +239,29 @@ func (h *profileHandlers) DeleteProfile(c *fiber.Ctx) error {
 		return err
 	}
 	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// derivedLocation reads the geography derived from the caller's CV, or nil when there is
+// none. Best-effort like the cv block: the derivation supplements the profile, so an
+// unconfigured résumé service or a failing lookup degrades to a null block rather than
+// denying the caller their own profile.
+//
+// A geography that resolved nothing reads as absent rather than as an empty block. The
+// database keeps "the CV stated nothing" and "the CV stated something unresolvable"
+// apart for the coverage metric, but a client asking "where is this candidate" gets the
+// same answer from both — nothing to pre-fill — and an empty block would invite it to
+// render an empty control as if it meant something.
+func (h *profileHandlers) derivedLocation(ctx context.Context, userID int64) *derivedLocation {
+	if h.resume == nil {
+		return nil
+	}
+	geo, ok, err := h.resume.Geography(ctx, userID)
+	if err != nil {
+		log.Printf("profile derived location: user %d: %v", userID, err)
+		return nil
+	}
+	if !ok || (len(geo.Countries) == 0 && len(geo.Regions) == 0 && len(geo.Cities) == 0) {
+		return nil
+	}
+	return &derivedLocation{Countries: geo.Countries, Regions: geo.Regions, Cities: geo.Cities}
 }

--- a/internal/handler/me_profile_cv_test.go
+++ b/internal/handler/me_profile_cv_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
 	"github.com/strelov1/freehire/internal/userprofile"
 )
@@ -21,10 +23,18 @@ type fakeStructuredResume struct {
 	ret resumeextract.Structured
 	ok  bool
 	err error
+	// geo is the derived candidate geography; geoOK mirrors the freshness bool. Zero
+	// values model a caller for whom nothing was derived.
+	geo   resume.Geography
+	geoOK bool
 }
 
 func (f fakeStructuredResume) Structured(context.Context, int64) (resumeextract.Structured, bool, error) {
 	return f.ret, f.ok, f.err
+}
+
+func (f fakeStructuredResume) Geography(context.Context, int64) (resume.Geography, bool, error) {
+	return f.geo, f.geoOK, nil
 }
 
 // profileAppWithResume mounts the profile read on a handler wired to the given résumé
@@ -125,4 +135,64 @@ func TestGetProfile_DegradesToNullCV(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The derived block is a SIBLING of location_preferences, not a merge into it: one is
+// what the candidate asserted, the other what was derived for them, and the client has to
+// know which it is holding before it pre-fills a control with it.
+func TestProfileRead_CarriesDerivedLocation(t *testing.T) {
+	repo := &fakeProfileRepo{}
+	cv := fakeStructuredResume{
+		ret: resumeextract.Structured{Headline: "Backend engineer"}, ok: true,
+		geo:   resume.Geography{Countries: []string{"pl"}, Regions: []string{"eu"}, Cities: []string{"Kraków"}},
+		geoOK: true,
+	}
+	app, token := profileAppWithResume(t, savedProfile(), cv)
+	_ = repo
+
+	body := profileDerived(t, app, token)
+	if body == nil {
+		t.Fatal("derived_location = null, want the geography derived from the CV")
+	}
+	if len(body.Countries) != 1 || body.Countries[0] != "pl" {
+		t.Errorf("derived countries = %v, want [pl]", body.Countries)
+	}
+}
+
+// Nothing derived reads as null rather than as an empty block — an empty block would
+// invite the client to render a pre-fill control as though it had something to offer.
+func TestProfileRead_DerivedLocationNullWhenNothingResolved(t *testing.T) {
+	repo := &fakeProfileRepo{}
+	cv := fakeStructuredResume{
+		ret: resumeextract.Structured{Headline: "Backend engineer"}, ok: true,
+		geo:   resume.Geography{Countries: []string{}, Regions: []string{}},
+		geoOK: true,
+	}
+	app, token := profileAppWithResume(t, savedProfile(), cv)
+	_ = repo
+
+	if got := profileDerived(t, app, token); got != nil {
+		t.Errorf("derived_location = %+v, want null when nothing resolved", got)
+	}
+}
+
+// profileDerived reads the response's derived_location block, nil when the key is null.
+func profileDerived(t *testing.T, app *fiber.App, token string) *derivedLocation {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/me/profile", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Data struct {
+			DerivedLocation *derivedLocation `json:"derived_location"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode profile response: %v", err)
+	}
+	return body.Data.DerivedLocation
 }

--- a/internal/handler/resume_storage_test.go
+++ b/internal/handler/resume_storage_test.go
@@ -62,6 +62,11 @@ type fakeResumeRepo struct {
 	structured  []byte
 	structModel string
 	structAt    pgtype.Timestamptz
+	// The candidate geography derived from the structure's location line, persisted in
+	// the same write. nil means "not known"; an empty slice means the CV stated a place
+	// the dictionary could not resolve.
+	structCountries []string
+	structRegions   []string
 }
 
 func (r *fakeResumeRepo) Get(_ context.Context, _ int64) (db.GetUserResumeRow, error) {
@@ -97,9 +102,10 @@ func (r *fakeResumeRepo) GetEmbedding(_ context.Context, _ int64) (db.GetUserRes
 	}, nil
 }
 
-func (r *fakeResumeRepo) SetStructured(_ context.Context, _ int64, blob []byte, model string, uploadedAt time.Time) error {
-	r.structured, r.structModel = blob, model
-	r.structAt = pgtype.Timestamptz{Time: uploadedAt, Valid: true}
+func (r *fakeResumeRepo) SetStructured(_ context.Context, w resume.StructuredWrite) error {
+	r.structured, r.structModel = w.Blob, w.Model
+	r.structAt = pgtype.Timestamptz{Time: w.UploadedAt, Valid: true}
+	r.structCountries, r.structRegions = w.Countries, w.Regions
 	return nil
 }
 
@@ -227,4 +233,16 @@ func TestResume_Unauthenticated(t *testing.T) {
 	if status, _ := resumeReq(t, app, fiber.MethodGet, "", ""); status != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", status)
 	}
+}
+
+func (r *fakeResumeRepo) GetGeography(_ context.Context, _ int64) (db.GetUserResumeGeographyRow, error) {
+	row := db.GetUserResumeGeographyRow{
+		ResumeCountries:            r.structCountries,
+		ResumeRegions:              r.structRegions,
+		ResumeStructuredUploadedAt: r.structAt,
+	}
+	if r.set {
+		row.ResumeUploadedAt = pgtype.Timestamptz{Time: resumeUploadedAt, Valid: true}
+	}
+	return row, nil
 }

--- a/internal/location/AGENTS.md
+++ b/internal/location/AGENTS.md
@@ -4,6 +4,27 @@
 Curated dictionary deriving ISO 3166-1 alpha-2 country codes, region codes, and a work-mode hint from a free-text ATS location string.
 
 ## Always true
+- **Two entry points, and the split is the point.** `Parse` answers "where is the WORK" (a
+  job's location line); `ParseResidence` answers "where is the PERSON" (a CV's). They are
+  distinct types, not a flag, because the same string means opposite things on the two
+  sides and a flag can be defaulted wrong at a call site. Candidate text goes through
+  `ParseResidence` and never through `Parse`.
+- **A person is never located globally.** `ParseResidence` is `Parse` minus the `global`
+  region and minus the work-mode hint. `global` reaches the result by TWO paths — the
+  bare-remote fallback in `Parse` and the dictionary's own `worldwide`/`anywhere` entries —
+  so the rule is phrased against the value, not against either mechanism. Work mode is a
+  preference and lives on the profile (`location_preferences.work_modes`), not in geography.
+- **Every code that carries a region must also have a NAME** (`TestEveryPlaceableCountryHasAName`).
+  The two maps had drifted apart for 25 codes, so "Honduras" and "Rwanda" resolved to
+  nothing. The failure is silent — an unresolvable country and an out-of-scope one both
+  emit nothing — which is why it is a test rather than a review item.
+- **Add country NAMES, never country CODES.** `resolveSubdivision` runs before the bare-code
+  branch, so a code would collide with the US/Canada subdivision table (`LA`→Louisiana,
+  `MN`→Minnesota, `MO`→Missouri). Names are full words and cannot.
+- **A country name that is also a US city/state is deliberately withheld.** `georgia` is
+  absent (the state); `palestine` is absent (Palestine, Texas) in favour of the unambiguous
+  long forms. `Tbilisi, Georgia` still resolves to `ge` — through the city, not the country
+  name. Precision over recall, the same rule the eligibility phrases follow.
 - It is a curated dictionary, not a geocoder — it resolves high-frequency names/shorthands and emits nothing for what it can't resolve (never guesses).
 - Region and work-mode values are drawn from the shared controlled vocabulary (`vocab.RegionValues`/`vocab.WorkModeValues`), so the parser, the enrichment payload, and the search facet all speak one set of values.
 - Geography is exposed as a Meilisearch facet (`regions`/`countries`/`work_mode` are filterable attributes), not a Postgres column filter.
@@ -15,4 +36,15 @@ Curated dictionary deriving ISO 3166-1 alpha-2 country codes, region codes, and 
 `internal/location` parses the free-text location string from an ATS posting (e.g. "Berlin, Germany" or "Remote - US") and derives structured geography from it. The dictionary is curated for high-frequency names and shorthands; anything it cannot resolve is left empty rather than guessed. Because geography lives as Meilisearch facets (not Postgres column filters), the dictionary output flows through the search index, not through SQL WHERE clauses. This means a dictionary update is a two-step propagation: re-derive the facet columns on existing jobs (`cmd/backfill-derive`), then rebuild the search index (`cmd/reindex`). The production facets follow a deliberate split: `work_mode` is purely dict-driven (the LLM's work-mode guess is never served), while `countries`/`regions` are a hybrid where the dictionary pins what it can and the LLM fills the gaps for remote/unspecified roles.
 
 ## Limitations
-None currently listed.
+- **The country dictionary is far from complete: 133 of 252 ISO countries carry a region.**
+  111 resolve to nothing (Afghanistan, Cuba, Haiti, Jamaica, Syria, Madagascar, DR Congo,
+  Namibia, plus a long tail of dependencies). Generating them is only half-possible:
+  GeoNames `countryInfo.txt` supplies names, but this project's regions are a business
+  taxonomy (`uk` split from `eu`, `cis` spanning the Caucasus and Central Asia, `mena`
+  cutting across Africa and Asia), so a continent→region mapping would misplace Turkey,
+  Egypt, Kazakhstan, the UK and Russia. The valuable half of that work is human.
+- **The next coverage gain is in tokenization, not in the country list.** Measured over 100
+  production CV locations: 38 distinct countries, all covered; the unresolved strings fail
+  on `·` not being a separator, on the LinkedIn `Greater X` prefix, and on non-US
+  subdivisions (`subdivisionToCountry` covers only the US and Canada, so Indian states do
+  not resolve).

--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -165,6 +165,26 @@ var nameToCountry = map[string]string{
 	"estonia": "ee", "luxembourg": "lu", "iceland": "is", "malta": "mt",
 	"monaco": "mc", "north macedonia": "mk", "bosnia and herzegovina": "ba",
 	"albania": "al", "montenegro": "me", "kosovo": "xk", "mauritius": "mu",
+	// Countries that regionCountries could already place but that no name resolved to,
+	// so they were reachable only via their bare ISO code and never from a location
+	// spelling them out. Names only — never the codes: a bare code here would be
+	// consulted before the US/Canada subdivision table's same-spelled entries and turn
+	// "Baton Rouge, LA" into Laos. TestEveryPlaceableCountryHasAName keeps the two maps
+	// from drifting apart again.
+	//
+	// "palestine" is deliberately absent: it is also a city in Texas, and the bare name
+	// would read "Palestine, TX" as the Palestinian territories. Only the unambiguous
+	// long forms are listed, the same precision-over-recall rule the eligibility phrases
+	// follow.
+	"andorra": "ad", "angola": "ao", "brunei": "bn", "brunei darussalam": "bn",
+	"ivory coast": "ci", "côte d'ivoire": "ci", "cote d'ivoire": "ci",
+	"cameroon": "cm", "honduras": "hn", "cambodia": "kh", "laos": "la",
+	"liechtenstein": "li", "libya": "ly", "myanmar": "mm", "burma": "mm",
+	"mongolia": "mn", "macao": "mo", "macau": "mo", "mozambique": "mz",
+	"nicaragua": "ni", "palestinian territories": "ps", "state of palestine": "ps",
+	"rwanda": "rw", "san marino": "sm", "senegal": "sn", "el salvador": "sv",
+	"tanzania": "tz", "uganda": "ug", "yemen": "ye", "zambia": "zm",
+	"zimbabwe": "zw",
 	// Spanish.
 	"españa": "es", "alemania": "de", "méxico": "mx", "méjico": "mx",
 	"grecia": "gr", "francia": "fr", "italia": "it", "países bajos": "nl",

--- a/internal/location/dictionaries_test.go
+++ b/internal/location/dictionaries_test.go
@@ -41,6 +41,28 @@ func TestDictionariesStayInVocabulary(t *testing.T) {
 	}
 }
 
+// TestEveryPlaceableCountryHasAName closes the other half of the invariant
+// TestDictionariesStayInVocabulary opens. That test walks nameToCountry and demands a
+// region for every name; this one walks countryToRegion and demands a name for every
+// code. A code with a region but no name is a country the parser can place once
+// something else has identified it, yet can never identify itself — so a posting or a
+// CV that spells the country out ("Honduras", "Rwanda") resolves to nothing.
+//
+// The drift is silent from the outside: an unresolvable country and a country the
+// dictionary was never meant to cover look identical (both emit nothing), which is why
+// it needs a test rather than review.
+func TestEveryPlaceableCountryHasAName(t *testing.T) {
+	named := make(map[string]struct{}, len(nameToCountry))
+	for _, code := range nameToCountry {
+		named[code] = struct{}{}
+	}
+	for code := range countryToRegion {
+		if _, ok := named[code]; !ok {
+			t.Errorf("countryToRegion has %q but no name in nameToCountry resolves to it", code)
+		}
+	}
+}
+
 func isAlpha2(s string) bool {
 	if len(s) != 2 {
 		return false

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -57,6 +57,46 @@ func TestParse(t *testing.T) {
 			location: "Łódź, Poland",
 			want:     Geo{Countries: []string{"pl"}, Regions: []string{"eu"}, Cities: []string{"Łódź"}},
 		},
+		// Countries that carried a region in countryToRegion but no name in nameToCountry:
+		// placeable once identified, yet unable to identify themselves. See
+		// TestEveryPlaceableCountryHasAName, which guards the two maps against drifting apart.
+		{
+			name:     "honduras named in full resolves to its code and region",
+			location: "San Pedro Sula, Honduras",
+			want:     Geo{Countries: []string{"hn"}, Regions: []string{"latam"}, Cities: []string{"San Pedro Sula"}},
+		},
+		{
+			name:     "rwanda named in full resolves to its code and region",
+			location: "Kigali, Rwanda",
+			want:     Geo{Countries: []string{"rw"}, Regions: []string{"africa"}, Cities: []string{"Kigali"}},
+		},
+		{
+			// Before the country name existed, "laos" fell through to the long-tail city
+			// branch and matched a Vietnamese city via its GeoNames alternate names. Naming
+			// the country makes the token resolve first, and the city-agreement check then
+			// rejects the unrelated city (la != vn) instead of emitting it.
+			name:     "naming laos stops it resolving to an unrelated vietnamese city",
+			location: "Laos",
+			want:     Geo{Countries: []string{"la"}, Regions: []string{"apac"}},
+		},
+		// Regression guards for the added names: every added entry is a full word, and the
+		// subdivision table is consulted BEFORE the bare two-letter country code, so the
+		// US-state readings of these tokens must be untouched by the new countries la/mn/mo.
+		{
+			name:     "LA stays louisiana rather than laos",
+			location: "Baton Rouge, LA",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, Cities: []string{"Baton Rouge"}},
+		},
+		{
+			name:     "MN stays minnesota rather than mongolia",
+			location: "Minneapolis, MN",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, Cities: []string{"Minneapolis"}},
+		},
+		{
+			name:     "MO stays missouri rather than macao",
+			location: "St. Louis, MO",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, Cities: []string{"St. Louis"}},
+		},
 		{
 			name:     "unambiguous UK city",
 			location: "Manchester",

--- a/internal/location/residence.go
+++ b/internal/location/residence.go
@@ -1,0 +1,52 @@
+package location
+
+// globalRegion is the region code meaning "open anywhere". It is a legitimate answer for
+// a job and never one for a person, which is the whole reason Residence exists.
+const globalRegion = "global"
+
+// Residence is where a PERSON is, derived from the free-text location line of a CV.
+//
+// It is deliberately a distinct type from Geo rather than a flag on Parse. The same
+// location string means opposite things on the two sides: for a job it answers "where is
+// the work", for a résumé "where is the person". A flag can be defaulted wrong at a call
+// site; two types cannot be confused at one. Residence carries no work mode at all —
+// how someone is willing to work is a preference that lives on their profile
+// (location_preferences.work_modes), not a fact about where they are.
+type Residence struct {
+	Countries []string
+	Regions   []string
+	Cities    []string
+}
+
+// ParseResidence maps a candidate's location line to where they are: the job geography
+// parser's output minus the work-mode hint and minus the global region.
+//
+// The global exclusion is stated as "a person is never located globally" rather than as
+// "do not inherit the bare-remote fallback", because global reaches the result by TWO
+// independent paths — the fallback in Parse (a remote marker that resolved no place) and
+// the dictionary's own "worldwide"/"anywhere"/"по всему миру" entries. A rule phrased
+// against the fallback alone would let the second one through.
+//
+// Everything else survives untouched, including a macro-region with no country ("EU /
+// Remote" -> eu), which is a true claim about where someone is. Like Parse, this never
+// guesses: a location the curated dictionary cannot resolve yields an empty Residence.
+func ParseResidence(location string) Residence {
+	geo := Parse(location)
+	return Residence{
+		Countries: geo.Countries,
+		Regions:   withoutGlobal(geo.Regions),
+		Cities:    geo.Cities,
+	}
+}
+
+// withoutGlobal drops the global region, returning nil when nothing else remains so an
+// all-global result is indistinguishable from no geography at all.
+func withoutGlobal(regions []string) []string {
+	var out []string
+	for _, r := range regions {
+		if r != globalRegion {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/location/residence_test.go
+++ b/internal/location/residence_test.go
@@ -1,0 +1,109 @@
+package location
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseResidence pins the candidate-side rule: a Residence is what Parse yields
+// MINUS the two things that are true of a job and false of a person — the work-mode
+// hint, and the "global" region.
+//
+// Residence has no WorkMode field at all, so that half of the rule is enforced by the
+// type rather than by a test; what is tested here is that a work-mode marker still
+// helps resolve the place it is attached to without leaking a mode or a global region.
+func TestParseResidence(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     Residence
+	}{
+		{
+			// Valencia is ambiguous (Spain and Venezuela), so the parser's city-agreement
+			// check suppresses the city facet while still pinning the country from the
+			// spelled-out country name. Residence inherits that never-guess behaviour
+			// unchanged — it subtracts from Parse, it does not soften it.
+			name:     "an ambiguous city still pins the country, without claiming the city",
+			location: "Valencia, Spain",
+			want:     Residence{Countries: []string{"es"}, Regions: []string{"eu"}},
+		},
+		{
+			name:     "an unambiguous city is carried through",
+			location: "Kraków, Poland",
+			want:     Residence{Countries: []string{"pl"}, Regions: []string{"eu"}, Cities: []string{"Kraków"}},
+		},
+		{
+			name:     "empty input yields nothing",
+			location: "",
+			want:     Residence{},
+		},
+		{
+			name:     "unresolvable location yields nothing rather than a guess",
+			location: "Nyarugenge District, Nyakabanda Sector",
+			want:     Residence{},
+		},
+		// The "global" region reaches a candidate by TWO independent paths, and the rule
+		// has to cut both. Phrasing it as "do not inherit the bare-remote fallback" would
+		// have missed the second one.
+		{
+			// Path 1: the bare-remote fallback in Parse — a remote marker that resolved no
+			// place is treated as open-anywhere. True of a job, false of a person.
+			name:     "bare remote marker does not make a candidate global",
+			location: "Remote (GMT+3)",
+			want:     Residence{},
+		},
+		{
+			// Path 2: the dictionary's own worldwide/anywhere -> global entries. This one
+			// never touches the fallback at all.
+			name:     "an explicit worldwide word does not make a candidate global",
+			location: "REMOTE · WORLDWIDE",
+			want:     Residence{},
+		},
+		{
+			name:     "a bare anywhere token does not make a candidate global",
+			location: "Anywhere",
+			want:     Residence{},
+		},
+		{
+			// A real macro-region IS a true claim about where a person is, and survives.
+			name:     "a real macro region without a country survives",
+			location: "EU / Remote",
+			want:     Residence{Regions: []string{"eu"}},
+		},
+		{
+			// The place is where the person is; the remoteness is not geography at all.
+			name:     "a place stated beside a remote marker survives",
+			location: "Berlin, Germany (Remote)",
+			want:     Residence{Countries: []string{"de"}, Regions: []string{"eu"}, Cities: []string{"Berlin"}},
+		},
+		{
+			name:     "a US state resolves the same way it does for a job",
+			location: "San Francisco, CA",
+			want:     Residence{Countries: []string{"us"}, Regions: []string{"north_america"}, Cities: []string{"San Francisco"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseResidence(tt.location)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseResidence(%q) = %+v, want %+v", tt.location, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseResidenceNeverEmitsGlobal is the exhaustive form of the rule above: whatever
+// the input, "global" must never appear. The table test pins the known paths; this one
+// guards the paths nobody has thought of yet, including any future dictionary entry that
+// maps a new phrase to the global region.
+func TestParseResidenceNeverEmitsGlobal(t *testing.T) {
+	for name, region := range nameToRegion {
+		if region != "global" {
+			continue
+		}
+		if got := ParseResidence(name); len(got.Regions) > 0 {
+			t.Errorf("ParseResidence(%q) = regions %v, want none — %q maps to the global region", name, got.Regions, name)
+		}
+	}
+}

--- a/internal/resume/geography_test.go
+++ b/internal/resume/geography_test.go
@@ -1,0 +1,194 @@
+package resume
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/resumeextract"
+)
+
+// stamped builds a store whose user 7 has a CV uploaded at t, so a SetStructured stamped
+// with the same t is a current (non-superseded) write.
+func stamped(t time.Time) (*fakeRepo, *Store) {
+	repo := newFakeRepo()
+	repo.uploadedAt[7] = pgtype.Timestamptz{Time: t, Valid: true}
+	return repo, New(&fakeBlobs{objs: map[string][]byte{}}, repo)
+}
+
+func TestStore_SetStructuredDerivesGeography(t *testing.T) {
+	t1 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	repo, s := stamped(t1)
+
+	st := resumeextract.Structured{FullName: "Jane", Location: "Kraków, Poland"}
+	if err := s.SetStructured(context.Background(), 7, st, "model-x", t1); err != nil {
+		t.Fatalf("SetStructured: %v", err)
+	}
+
+	assertGeo(t, repo, 7, []string{"pl"}, []string{"eu"}, []string{"Kraków"})
+}
+
+// A CV that states no location is NOT a candidate located nowhere — it is a candidate
+// whose location is unknown. That must reach the database as NULL, not as an empty array.
+func TestStore_SetStructuredWithNoLocationStoresUnknown(t *testing.T) {
+	t1 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	repo, s := stamped(t1)
+
+	st := resumeextract.Structured{FullName: "Jane"} // no Location at all
+	if err := s.SetStructured(context.Background(), 7, st, "model-x", t1); err != nil {
+		t.Fatalf("SetStructured: %v", err)
+	}
+
+	got := repo.geo[7]
+	if got.Countries != nil || got.Regions != nil || got.Cities != nil {
+		t.Errorf("geography = %+v, want all nil (unknown) for a CV stating no location", got)
+	}
+}
+
+// The other half of the same distinction: the CV DID state a place, and the curated
+// dictionary could not resolve it. That is a measurable coverage gap, not an unknown, so
+// it must be stored as an empty array rather than NULL.
+func TestStore_SetStructuredWithUnresolvableLocationStoresEmpty(t *testing.T) {
+	t1 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	repo, s := stamped(t1)
+
+	st := resumeextract.Structured{Location: "Greater Philadelphia"}
+	if err := s.SetStructured(context.Background(), 7, st, "model-x", t1); err != nil {
+		t.Fatalf("SetStructured: %v", err)
+	}
+
+	got := repo.geo[7]
+	if got.Countries == nil || len(got.Countries) != 0 {
+		t.Errorf("countries = %#v, want an empty non-nil slice (stated but unresolved)", got.Countries)
+	}
+	if got.Regions == nil || len(got.Regions) != 0 {
+		t.Errorf("regions = %#v, want an empty non-nil slice", got.Regions)
+	}
+}
+
+// A bare remote marker is a stated location that resolves to no PLACE. It must never
+// arrive as the global region — that is the job reading of the string, not the candidate
+// one — and it must not be mistaken for an unstated location either.
+func TestStore_SetStructuredNeverStoresGlobalForARemoteCandidate(t *testing.T) {
+	t1 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	repo, s := stamped(t1)
+
+	st := resumeextract.Structured{Location: "REMOTE · WORLDWIDE"}
+	if err := s.SetStructured(context.Background(), 7, st, "model-x", t1); err != nil {
+		t.Fatalf("SetStructured: %v", err)
+	}
+
+	got := repo.geo[7]
+	for _, r := range got.Regions {
+		if r == "global" {
+			t.Fatalf("regions = %v, want no global region for a candidate", got.Regions)
+		}
+	}
+	if got.Regions == nil {
+		t.Errorf("regions = nil, want an empty non-nil slice — the CV did state a location")
+	}
+}
+
+// The geography rides in the same statement as the structure, so it inherits that
+// statement's monotonic guard: a background derivation that completes for a CV which has
+// since been replaced must write NEITHER.
+func TestStore_SupersededStampWritesNeitherStructureNorGeography(t *testing.T) {
+	t1 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	repo, s := stamped(t1)
+
+	// A newer CV lands while the extraction for the older one is still running.
+	repo.uploadedAt[7] = pgtype.Timestamptz{Time: t1.Add(time.Hour), Valid: true}
+
+	st := resumeextract.Structured{FullName: "From the superseded CV", Location: "Kraków, Poland"}
+	if err := s.SetStructured(context.Background(), 7, st, "model-x", t1); err != nil {
+		t.Fatalf("SetStructured: %v", err)
+	}
+
+	if len(repo.structured[7]) != 0 {
+		t.Errorf("structure was written for a superseded CV: %s", repo.structured[7])
+	}
+	if got := repo.geo[7]; got.Countries != nil || got.Regions != nil || got.Cities != nil {
+		t.Errorf("geography = %+v, want nothing written for a superseded CV", got)
+	}
+}
+
+func TestStore_DeleteClearsGeography(t *testing.T) {
+	t1 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	repo := newFakeRepo()
+	repo.uploadedAt[7] = pgtype.Timestamptz{Time: t1, Valid: true}
+	s := New(&fakeBlobs{objs: map[string][]byte{"resumes/7": []byte("cv")}}, repo)
+
+	st := resumeextract.Structured{Location: "Kraków, Poland"}
+	if err := s.SetStructured(context.Background(), 7, st, "m", t1); err != nil {
+		t.Fatalf("SetStructured: %v", err)
+	}
+	if err := s.Delete(context.Background(), 7); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if got := repo.geo[7]; got.Countries != nil || got.Regions != nil || got.Cities != nil {
+		t.Errorf("geography after Delete = %+v, want cleared — it must not outlive the CV", got)
+	}
+}
+
+func assertGeo(t *testing.T, repo *fakeRepo, userID int64, countries, regions, cities []string) {
+	t.Helper()
+	got := repo.geo[userID]
+	if !equalStrings(got.Countries, countries) {
+		t.Errorf("countries = %v, want %v", got.Countries, countries)
+	}
+	if !equalStrings(got.Regions, regions) {
+		t.Errorf("regions = %v, want %v", got.Regions, regions)
+	}
+	if !equalStrings(got.Cities, cities) {
+		t.Errorf("cities = %v, want %v", got.Cities, cities)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Geography is served under the SAME staleness rule as the structure it was derived
+// from. A geography that outlived its CV would answer "where is this candidate" from a
+// document that has been replaced.
+func TestStore_GeographyServedOnlyWhileCurrent(t *testing.T) {
+	t1 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	repo, s := stamped(t1)
+
+	st := resumeextract.Structured{Location: "Kraków, Poland"}
+	if err := s.SetStructured(context.Background(), 7, st, "m", t1); err != nil {
+		t.Fatalf("SetStructured: %v", err)
+	}
+
+	got, ok, err := s.Geography(context.Background(), 7)
+	if err != nil || !ok {
+		t.Fatalf("Geography = (_, %v, %v), want (_, true, nil)", ok, err)
+	}
+	if len(got.Countries) != 1 || got.Countries[0] != "pl" {
+		t.Errorf("countries = %v, want [pl]", got.Countries)
+	}
+
+	// A newer CV lands; the derived geography still carries the older stamp.
+	repo.uploadedAt[7] = pgtype.Timestamptz{Time: t1.Add(time.Hour), Valid: true}
+	if _, ok, err := s.Geography(context.Background(), 7); ok || err != nil {
+		t.Fatalf("Geography after re-upload = (_, %v, %v), want (_, false, nil) — stale is absent", ok, err)
+	}
+}
+
+func TestStore_GeographyAbsentWhenNone(t *testing.T) {
+	s := New(&fakeBlobs{objs: map[string][]byte{}}, newFakeRepo())
+	if _, ok, err := s.Geography(context.Background(), 99); ok || err != nil {
+		t.Fatalf("Geography for user with none = (_, %v, %v), want (_, false, nil)", ok, err)
+	}
+}

--- a/internal/resume/resume.go
+++ b/internal/resume/resume.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/blobstore"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/location"
 	"github.com/strelov1/freehire/internal/resumeextract"
 )
 
@@ -69,12 +70,50 @@ type Repository interface {
 	// CV is never matched by the old vector). GetEmbedding reads them back.
 	SetEmbedding(ctx context.Context, userID int64, vec []float64, model string) error
 	GetEmbedding(ctx context.Context, userID int64) (db.GetUserResumeEmbeddingRow, error)
-	// SetStructured persists the derived structured résumé blob + the producing model and
-	// the résumé upload time it was derived from (the stamp). GetStructured reads the blob,
-	// its stamps, and the current résumé upload time so the Store can tell whether the
-	// structure still describes the stored CV.
-	SetStructured(ctx context.Context, userID int64, blob []byte, model string, uploadedAt time.Time) error
+	// SetStructured persists the derived structured résumé and the geography derived from
+	// it, as one write. GetStructured reads the blob, its stamps, and the current résumé
+	// upload time so the Store can tell whether the structure still describes the stored CV.
+	SetStructured(ctx context.Context, w StructuredWrite) error
 	GetStructured(ctx context.Context, userID int64) (db.GetUserResumeStructuredRow, error)
+	// GetGeography reads the derived candidate geography plus the two stamps needed to
+	// judge whether it still describes the stored CV.
+	GetGeography(ctx context.Context, userID int64) (db.GetUserResumeGeographyRow, error)
+}
+
+// Geography is where the candidate is, as derived from their CV and stored. Countries is
+// empty both when the CV named no place and when it named one the dictionary could not
+// resolve; the two are distinguished in the database (NULL vs '{}') for the coverage
+// metric, and deliberately NOT here — a consumer asking "where is this candidate" gets
+// the same answer either way, which is "nowhere I can tell you".
+type Geography struct {
+	Countries []string
+	Regions   []string
+	Cities    []string
+}
+
+// StructuredWrite is one persist of the derived structured résumé together with the
+// candidate geography derived from it — one row, one statement, one stamp. They travel
+// together so the monotonic guard (`WHERE resume_uploaded_at = UploadedAt`) covers both:
+// a slow extraction for a since-replaced CV writes neither, and a stored geography can
+// never describe a different CV than the structure beside it.
+//
+// Countries/Regions/Cities carry a three-way answer, and the nil/empty distinction is the
+// point rather than an accident:
+//
+//	nil          — not known: the CV states no location at all
+//	empty slice  — the CV stated a place the curated dictionary could not resolve
+//	non-empty    — what it resolved to
+//
+// Collapsing nil and empty would confuse "we don't know where this candidate is" with
+// "this candidate is nowhere", and would throw away the dictionary's live coverage metric.
+type StructuredWrite struct {
+	UserID     int64
+	Blob       []byte
+	Model      string
+	UploadedAt time.Time
+	Countries  []string
+	Regions    []string
+	Cities     []string
 }
 
 // Store owns the résumé's object storage plus its pointer. blobs is nil when storage is
@@ -139,7 +178,50 @@ func (s *Store) SetStructured(ctx context.Context, userID int64, st resumeextrac
 	if err != nil {
 		return fmt.Errorf("resume: marshal structured: %w", err)
 	}
-	return s.repo.SetStructured(ctx, userID, blob, model, uploadedAt)
+	countries, regions, cities := DeriveGeography(st.Location)
+	return s.repo.SetStructured(ctx, StructuredWrite{
+		UserID:     userID,
+		Blob:       blob,
+		Model:      model,
+		UploadedAt: uploadedAt,
+		Countries:  countries,
+		Regions:    regions,
+		Cities:     cities,
+	})
+}
+
+// DeriveGeography derives the candidate's geography from the location line their
+// structured résumé carries, and projects it onto the three stored columns.
+//
+// It is exported because it has TWO callers that must never disagree: the upload path
+// (Store.SetStructured, above) and the reconciler (cmd/backfill-resume-geo). If the two
+// derived differently, re-running the reconciler would rewrite rows the upload path had
+// just written, and "a second run changes nothing" would quietly stop being true.
+//
+// The derivation itself is location.ParseResidence — the candidate entry point, never
+// location.Parse: a job may be open anywhere and a person never is, so the global region
+// and the work-mode hint are not part of where someone lives. It is deterministic and
+// does no I/O, which is why it runs on the write path rather than as scheduled work.
+//
+// The nil-versus-empty decision lives here rather than in the parser, because it is a
+// question about the INPUT, not about the resolution: ParseResidence returns nothing both
+// for a CV that stated no location and for one whose location it could not resolve, and
+// only this layer still knows which of the two happened.
+func DeriveGeography(stated string) (countries, regions, cities []string) {
+	if strings.TrimSpace(stated) == "" {
+		return nil, nil, nil
+	}
+	res := location.ParseResidence(stated)
+	return orEmpty(res.Countries), orEmpty(res.Regions), orEmpty(res.Cities)
+}
+
+// orEmpty turns a nil slice into an empty one, so a stated-but-unresolved location is
+// stored as '{}' ("the dictionary was silent here") rather than NULL ("we don't know").
+func orEmpty(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }
 
 // Structured returns the user's derived structured résumé, but ONLY when it still
@@ -368,15 +450,42 @@ func (r *QueriesRepository) GetEmbedding(ctx context.Context, userID int64) (db.
 	return r.q.GetUserResumeEmbedding(ctx, userID)
 }
 
-func (r *QueriesRepository) SetStructured(ctx context.Context, userID int64, blob []byte, model string, uploadedAt time.Time) error {
+func (r *QueriesRepository) SetStructured(ctx context.Context, w StructuredWrite) error {
 	return r.q.SetUserResumeStructured(ctx, db.SetUserResumeStructuredParams{
-		ID:                         userID,
-		ResumeStructured:           blob,
-		ResumeStructuredModel:      pgtype.Text{String: model, Valid: model != ""},
-		ResumeStructuredUploadedAt: pgtype.Timestamptz{Time: uploadedAt, Valid: true},
+		ID:                         w.UserID,
+		ResumeStructured:           w.Blob,
+		ResumeStructuredModel:      pgtype.Text{String: w.Model, Valid: w.Model != ""},
+		ResumeStructuredUploadedAt: pgtype.Timestamptz{Time: w.UploadedAt, Valid: true},
+		ResumeCountries:            w.Countries,
+		ResumeRegions:              w.Regions,
+		ResumeCities:               w.Cities,
 	})
 }
 
 func (r *QueriesRepository) GetStructured(ctx context.Context, userID int64) (db.GetUserResumeStructuredRow, error) {
 	return r.q.GetUserResumeStructured(ctx, userID)
+}
+
+// Geography returns the candidate geography derived from the user's CV, under the SAME
+// freshness rule as Structured: it is served only while its stamp still equals the
+// résumé's upload time. ok is false (with no error) when none is stored or the stamp is
+// stale, so a geography derived from a superseded CV is treated as absent rather than
+// answering "where is this candidate" from a document that has been replaced.
+func (s *Store) Geography(ctx context.Context, userID int64) (Geography, bool, error) {
+	row, err := s.repo.GetGeography(ctx, userID)
+	if err != nil {
+		return Geography{}, false, err
+	}
+	if !stampsEqual(row.ResumeStructuredUploadedAt, row.ResumeUploadedAt) {
+		return Geography{}, false, nil
+	}
+	return Geography{
+		Countries: row.ResumeCountries,
+		Regions:   row.ResumeRegions,
+		Cities:    row.ResumeCities,
+	}, true, nil
+}
+
+func (r *QueriesRepository) GetGeography(ctx context.Context, userID int64) (db.GetUserResumeGeographyRow, error) {
+	return r.q.GetUserResumeGeography(ctx, userID)
 }

--- a/internal/resume/resume_test.go
+++ b/internal/resume/resume_test.go
@@ -51,6 +51,15 @@ type fakeRepo struct {
 	structured map[int64][]byte
 	structMod  map[int64]string
 	structAt   map[int64]pgtype.Timestamptz // simulates users.resume_structured_uploaded_at
+	geo        map[int64]storedGeo          // simulates users.resume_countries/regions/cities
+}
+
+// storedGeo mirrors the three derived geography columns. A nil slice stands for SQL NULL
+// ("not known"); a non-nil empty slice stands for '{}' ("stated, but unresolvable").
+type storedGeo struct {
+	Countries []string
+	Regions   []string
+	Cities    []string
 }
 
 func newFakeRepo() *fakeRepo {
@@ -62,13 +71,23 @@ func newFakeRepo() *fakeRepo {
 		structured: map[int64][]byte{},
 		structMod:  map[int64]string{},
 		structAt:   map[int64]pgtype.Timestamptz{},
+		geo:        map[int64]storedGeo{},
 	}
 }
 
-func (r *fakeRepo) SetStructured(_ context.Context, userID int64, blob []byte, model string, uploadedAt time.Time) error {
-	r.structured[userID] = blob
-	r.structMod[userID] = model
-	r.structAt[userID] = pgtype.Timestamptz{Time: uploadedAt, Valid: true}
+// SetStructured models the real statement, guard included: the SQL carries
+// `WHERE id = $1 AND resume_uploaded_at = $stamp`, so a write stamped with a
+// since-superseded upload time matches no row and is dropped whole — structure AND
+// geography. The fake used to write unconditionally, which meant no Store-level test
+// could ever observe that the two travel together.
+func (r *fakeRepo) SetStructured(_ context.Context, w StructuredWrite) error {
+	if cur, ok := r.uploadedAt[w.UserID]; !ok || !cur.Valid || !cur.Time.Equal(w.UploadedAt) {
+		return nil
+	}
+	r.structured[w.UserID] = w.Blob
+	r.structMod[w.UserID] = w.Model
+	r.structAt[w.UserID] = pgtype.Timestamptz{Time: w.UploadedAt, Valid: true}
+	r.geo[w.UserID] = storedGeo{Countries: w.Countries, Regions: w.Regions, Cities: w.Cities}
 	return nil
 }
 
@@ -110,11 +129,13 @@ func (r *fakeRepo) Set(_ context.Context, userID int64, key string) error {
 }
 
 func (r *fakeRepo) Clear(_ context.Context, userID int64) error {
-	// Mirrors ClearUserResume, which nulls the pointer AND the derived structured columns.
+	// Mirrors ClearUserResume, which nulls the pointer, the derived structured columns,
+	// and the geography derived from them.
 	delete(r.ptr, userID)
 	delete(r.structured, userID)
 	delete(r.structMod, userID)
 	delete(r.structAt, userID)
+	delete(r.geo, userID)
 	return nil
 }
 
@@ -271,3 +292,14 @@ func TestStore_DeleteClearsStructured(t *testing.T) {
 }
 
 var _ blobstore.Store = (*fakeBlobs)(nil)
+
+func (r *fakeRepo) GetGeography(_ context.Context, userID int64) (db.GetUserResumeGeographyRow, error) {
+	g := r.geo[userID]
+	return db.GetUserResumeGeographyRow{
+		ResumeCountries:            g.Countries,
+		ResumeRegions:              g.Regions,
+		ResumeCities:               g.Cities,
+		ResumeStructuredUploadedAt: r.structAt[userID],
+		ResumeUploadedAt:           r.uploadedAt[userID],
+	}, nil
+}

--- a/internal/resumeextract/AGENTS.md
+++ b/internal/resumeextract/AGENTS.md
@@ -15,7 +15,13 @@ Best-effort, read-only LLM parse of the stored user CV into a typed `Structured`
 - **The request carries a schema derived from `Structured`** (`schema.go`), minus the contact fields: those come from PII detection over text the model never sees, and a strict schema requires every property, so leaving them in would be an instruction to invent a name, an email and a phone for a CV that reaches the model with all three redacted.
 - **`total_years` is asked for as TEXT, though the contract field is an `int`.** Given an integer field a model turns "5.9 years" into 6 by rounding; `truncInt` turns it into 5. The difference is experience the candidate does not have, so the arithmetic stays on this side. Measured against the CV fixtures, the schema's one systematic effect was to stop the model filling the candidate's `location` with the last employer's office ("Singapore (Remote)", 3 runs of 3) for a CV that states no location for the person.
 - **An unconfigured/failing LLM leaves upload, embedding, and the deterministic extractors untouched.**
-- **Deletion clears the columns** (`ClearUserResume`).
+- **Persisting the structure also derives the candidate's GEOGRAPHY** from its `location`
+  line, in the same statement and under the same stamp (`resume.Store.SetStructured` →
+  `resume.DeriveGeography` → `location.ParseResidence`). Riding in one statement means the
+  monotonic guard covers both, so a stored geography can never describe a different CV than
+  the structure beside it. Unlike the structure, the geography HAS a reconciler
+  (`cmd/backfill-resume-geo`, database-only), so a dictionary change reaches existing users.
+- **Deletion clears the columns** (`ClearUserResume`), geography included.
 - **No new env** — reuses `LLM_*`.
 - **The fit analysis reads a COMPOSITION, not this shape alone:** `experience.ProfessionalFrom` takes the work history from the bank and everything else from here, and that is the only candidate text `matchanalysis` sends. An empty bank means no analysis; a stale structure now costs education and languages rather than the whole thing. There is still deliberately no raw-CV fallback, and there is deliberately no fallback to this package's own copy of the experience either — a silent one would hide a failed backfill for months.
 

--- a/migrations/0068_user_resume_geography.sql
+++ b/migrations/0068_user_resume_geography.sql
@@ -1,0 +1,41 @@
+-- Where the CANDIDATE is, derived deterministically from the location line of their
+-- structured résumé (see the candidate-resume-geography change). Jobs have carried
+-- derived countries/regions since 0001; candidates carried only the raw free-text line
+-- the LLM copied off the CV, so a candidate's country could not be filtered, faceted, or
+-- matched against a job's geography.
+--
+-- These mirror jobs.countries/regions as text[] so the same array idioms and aggregations
+-- work, but the resume_ prefix is load-bearing: on users it already means "derived from
+-- the stored CV" (resume_structured, resume_embedding, resume_ats_analysis), and it keeps
+-- this apart from user_profiles.location_preferences. The two answer different questions
+-- and must never be conflated — location_preferences.base is where the user SAYS they
+-- are, these columns are what their CV was read to say. Where both exist the user's own
+-- statement wins; these only fill a gap.
+--
+-- The values are the candidate projection of the location dictionary, NOT the job one:
+-- the `global` region is never stored here (a job may be open anywhere, a person is
+-- always somewhere) and no work mode is stored at all (how someone wants to work is a
+-- preference, and it already lives in location_preferences.work_modes).
+--
+-- NULLABLE WITH NO DEFAULT, deliberately diverging from jobs.countries (which is
+-- NOT NULL DEFAULT '{}'). A job always has a location string and derives it
+-- synchronously on ingest, so '{}' there unambiguously means "the dictionary was
+-- silent". A user has a third state a job does not — no CV, no structured résumé yet, or
+-- one superseded by a newer upload. So:
+--     NULL  -> unknown: no CV, no current structure, or a structure stating no location
+--     '{}'  -> the CV stated a place and the curated dictionary resolved nothing
+-- Collapsing the two would confuse "we don't know" with "nowhere", and would also throw
+-- away a permanent live-data coverage metric for the dictionary:
+--     SELECT count(*) FROM users WHERE resume_countries = '{}';
+-- Same reasoning as jobderive.Derived.IsTech being a *bool: never coerced, so the
+-- coverage gap stays measurable.
+--
+-- Three nullable columns: no table rewrite, no default to backfill, no lock of
+-- consequence. Additive and unread by the previous binary, but the NEXT binary reads
+-- them on every profile fetch, so on an existing prod volume this ALTER must be run
+-- BEFORE that deploy (an unapplied column is a 42703 on a hot path, not a degraded
+-- feature). A rollback leaves the columns harmlessly behind.
+ALTER TABLE public.users
+    ADD COLUMN resume_countries text[],
+    ADD COLUMN resume_regions text[],
+    ADD COLUMN resume_cities text[];

--- a/openspec/changes/candidate-resume-geography/.openspec.yaml
+++ b/openspec/changes/candidate-resume-geography/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/candidate-resume-geography/design.md
+++ b/openspec/changes/candidate-resume-geography/design.md
@@ -1,0 +1,302 @@
+## Context
+
+Jobs have carried derived `countries`/`regions` since migration `0001`; candidates carry
+nothing. The only record of where a candidate is sits in
+`users.resume_structured->>'location'`, a free-text line the LLM lifted off the CV.
+
+Measured on production, 2026-08-01:
+
+| | |
+|---|---|
+| users / with a stored CV | 400 / 169 |
+| structured résumé present / current | 132 / 129 |
+| non-empty `location` line | **100** |
+| → resolves to a country through the existing dictionary | **91 (91%)** |
+| → resolves to a region only (`EU / Remote`) | 1 |
+| → resolves to a city only | 2 |
+| → resolves to nothing | 6 |
+| profiles / with `location_preferences` | 145 / 70 |
+| profiles stating a `base.country` | **27 (19%)** |
+| users with a CV location and no stated base | **80** |
+
+Every one of the 91 resolves to exactly **one** country — multi-country derivations do
+not occur in the current data, but the code must still decide what to do with one.
+
+Three constraints shape the design.
+
+**The same string means opposite things on the two sides.** `location.Parse` was written
+for an ATS posting, where the location answers "where is the work". A CV's location line
+answers "where is the person". The divergence is not academic: a bare `Remote` is
+correctly globalized to the `global` region for a job, and that same expansion is a lie
+about a human being.
+
+**A fact and a wish already live in different places, and the boundary leaks.**
+`user_profiles.location_preferences` is what the user wants; `resume_structured.location`
+is where they are. The leak was found in three separate layers during design, all with
+the same shape — see the first decision below.
+
+**The structured résumé has no reconciler.** A failed background extraction leaves
+`resume_structured` NULL until the user re-uploads; 37 production users are in that state
+today. Anything derived from the structure inherits that hole unless it gets a reconciler
+of its own.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A deterministic, dictionary-only country/region/city derivation for candidates, with a
+  rule that cannot silently inherit job semantics.
+- Storage that distinguishes "not known" from "stated but unresolvable", so the
+  dictionary's coverage gap stays measurable on live data.
+- A reconciler for the derived geography, re-runnable after any dictionary change.
+- Ask every user where they are, not only those who accept office work — and pre-fill it
+  from their CV so confirming is cheaper than typing.
+- Revive the two hard constraints that already read a candidate country and currently
+  never fire.
+
+**Non-Goals:**
+
+- **No reconciler for the structured résumé itself.** The systemic hole is named and left
+  open; this change adds a manual run of the existing worker, not a scheduled one.
+- **No re-derive or reindex of jobs.** The dictionary change is additive; existing jobs
+  pick the new country names up on the next scheduled `cmd/backfill-derive`.
+- **No geocoding, no LLM, no new external dependency.** The dictionary stays curated and
+  silent on what it cannot resolve.
+- **No candidate-geography search facet or employer-facing candidate search.** The columns
+  are derived and queryable; exposing them as a product surface is separate work.
+- **No change to `location.Parse` behaviour for jobs.** Only additive dictionary entries.
+
+## Decisions
+
+### 1. A separate `ParseResidence` entry point, not a flag on `Parse`
+
+`internal/location` gains `ParseResidence(string) Residence{Countries, Regions, Cities}`.
+It is `Parse` minus the two things true of a job and false of a person: the `WorkMode`
+hint, and the `global` region.
+
+The `global` exclusion is deliberately stated as **"a person is never located globally"**
+rather than "do not inherit the bare-remote fallback". Measurement showed `global` reaches
+a candidate through **two** independent paths: the fallback at `location.go:140` (a remote
+marker that resolved no place) *and* the dictionary's own `"worldwide"/"anywhere"/"по
+всему миру" → global` entries at `dictionaries.go:348`. A rule phrased against the
+fallback alone would have let `REMOTE · WORLDWIDE` through. 4 of the 100 live rows hit
+this.
+
+*Alternatives considered.* A boolean flag on `Parse` — rejected: a flag can be defaulted
+wrong at a call site, and the whole failure mode being designed against is one meaning
+being used where the other was expected. A distinct return type makes that a compile
+error. Post-filtering `Parse`'s output at each call site — rejected: it puts the rule in
+every consumer instead of one place, which is exactly how the leak below happened.
+
+**Why this matters beyond the parser.** The same inversion was found in three layers, and
+they are one unproven seam rather than three bugs:
+
+| Layer | The leak |
+|---|---|
+| `location.go:140` + `dictionaries.go:348` | a person's location expands to "everywhere" |
+| `ProfileForm.svelte:263` | "where you are" is asked only of people who want office work |
+| `facetModel.ts:filtersFromProfile` | "where you live" is seeded as "where you want jobs" |
+
+### 2. Three nullable `text[]` columns on `users`, prefixed `resume_`
+
+```sql
+ALTER TABLE users
+    ADD COLUMN resume_countries text[],
+    ADD COLUMN resume_regions   text[],
+    ADD COLUMN resume_cities    text[];
+```
+
+**Naming.** The `resume_` prefix on `users` already means "derived from the stored CV"
+(`resume_structured`, `resume_structured_model`, `resume_embedding`,
+`resume_ats_analysis`). Reusing it separates the **fact** from the **wish**
+(`location_preferences`) with the project's existing vocabulary rather than a new one.
+Bare `countries`/`regions` — mirroring `jobs` exactly — were rejected: on `users` they
+would be ambiguous precisely where the fact/wish boundary must be sharpest.
+
+**`text[]`, not JSONB.** Mirrors `jobs.countries`/`regions`, and makes the acceptance
+criterion ("show the country distribution in one query") a plain `unnest` + `GROUP BY`.
+
+**Nullable, with no `DEFAULT '{}'` — a deliberate divergence from `jobs`.** A job always
+has a location string and its derivation is synchronous on ingest, so `'{}'` unambiguously
+means "the dictionary was silent". A user has a third state a job does not: no CV, no
+structure yet, or a stale structure. Therefore:
+
+- `NULL` — **unknown** (no CV, no current structure, or a structure stating no location);
+- `'{}'` — the CV **stated** a place and the dictionary resolved nothing.
+
+This is the trap the task called out ("do not confuse *we don't know* with *nowhere*"), and
+it buys a permanent live-data coverage metric: `count(*) WHERE resume_countries = '{}'`.
+It follows the same reasoning as `jobderive.Derived.IsTech *bool` — "never coerced, so the
+coverage gap stays measurable".
+
+**`resume_cities` is the one debatable column.** It earns its place through the profile
+pre-fill (`base.city` is free text and the derivation supplies a canonical name) and
+because a city is the only signal for locations the country dictionary cannot place.
+Without the profile work it would be premature, and it should be dropped if that work is
+ever cut.
+
+### 3. Derive synchronously inside `resume.Store.SetStructured`
+
+`SetStructured` is the **only** writer of the structured résumé, and both producers —
+the on-upload background extraction (`handler.extractStructuredResume`) and
+`cmd/backfill-resume-structured` — go through it. Deriving there means:
+
+- the geography lands in the **same** `UPDATE … WHERE id = $1 AND resume_uploaded_at = $4`,
+  so the existing monotonic guard covers it for free. A separate write would have to
+  duplicate the guard, and duplicated invariants drift;
+- the two producers cannot diverge, because there is one path;
+- there is no window in which a user has a structure but not the geography derived from it.
+
+Background derivation was rejected: `ParseResidence` is microseconds of map lookups with
+no I/O, so deferring it buys nothing and adds a state to reason about. Deriving in the
+handler was rejected: it would miss the backfill worker.
+
+`ClearUserResume` clears the three columns alongside the structure.
+
+### 4. `cmd/backfill-resume-geo` needs only `DATABASE_URL`
+
+The reconciler re-reads already-stored structures and re-runs the dictionary. It requires
+no LLM, no object storage, and no PII service — which is the point: it is cheap enough to
+re-run after **any** dictionary change, the same role `cmd/backfill-derive` plays for jobs.
+Contrast `cmd/backfill-resume-structured`, which needs all three and costs an LLM call per
+user.
+
+It processes only users whose structure currently describes their stored CV; deriving from
+a superseded structure would route around the staleness rule.
+
+### 5. Read-time precedence: asserted beats derived
+
+`buildHardConstraintInputs` takes `loc.Base.Country` when set, and falls back to the
+derived country only when it is empty. Exactly one derived country is used; **more than
+one yields none** rather than an arbitrary pick — an ambiguous derivation is not a fact,
+and the whole dictionary discipline is never to guess.
+
+This is a transplant of the existing `jobview.geoFacet` seam ("the dictionary wins when it
+pins a place, and the LLM fills only the unpinned bucket"), not a new pattern.
+
+The fallback is what actually revives the two dead constraints for the 80 users who have a
+CV location and no stated base; un-gating the form alone would only help users who come
+back and edit their profile.
+
+### 6. Front end: un-gate `base`, and pay the coupled cost
+
+`ProfileForm.svelte:263` currently computes
+`base: wantsPhysical ? {country, city} : {}` — for a remote-only user the base is
+**discarded at save time**, not merely hidden. It becomes an unconditional question,
+pre-filled from the derived geography when the user has stated nothing.
+
+That change forces a second one. `facetModel.ts:filtersFromProfile` folds `base.country`
+into the seeded `countries` facet and `base.city` into `cities`. This was survivable only
+because `base` was unreachable for remote-only users. Un-gate one without the other and a
+remote-only candidate in Colombia gets their job search silently filtered to Colombia.
+`base` therefore contributes to the seeded `countries`/`cities` only when the user accepts
+physical work — where "where I live" and "where I want the job" genuinely coincide.
+
+The gating predicate is extracted into a plain `.ts` module so it can be unit-tested;
+`web/src/lib/profileFilters.test.ts` is the existing seam.
+
+### 7. Dictionary: add 25 missing country **names** only
+
+25 ISO codes carry a region in `countryToRegion` but have no entry in `nameToCountry`:
+`ad ao bn ci cm hn kh la li ly mm mn mo mz ni ps rw sm sn sv tz ug ye zm zw`. The country
+is placeable once identified, but can never identify itself — so `Honduras` and `Rwanda`
+resolve to nothing.
+
+Only **names** are added, never codes. Names are full words (`"laos"`, `"mongolia"`,
+`"macao"`), so the known two-letter collisions are untouched: `resolveSubdivision` runs
+before the bare-code branch in `resolveGeoToken`, and `LA`→Louisiana, `MN`→Minnesota,
+`MO`→Missouri keep winning. This makes the change safe by construction rather than by
+inspection.
+
+The lasting part is the **guard test**: every code in `countryToRegion` must have a name.
+The drift was silent — an unresolvable country and an out-of-scope country look identical
+from the outside — so it needs a test, not review.
+
+**One name is deliberately withheld.** `palestine` is also a city in Texas, so the bare
+name would read `Palestine, TX` as the Palestinian territories; only the unambiguous long
+forms are listed. This turned out to match an existing unwritten policy: `georgia` is
+absent from `nameToCountry` for exactly the same reason (the US state), and
+`Tbilisi, Georgia` still resolves to `ge` — through the *city*, not the country name.
+The policy is now written down here and in `internal/location/AGENTS.md`.
+
+**Adding country names is safe; adding country codes is not.** Names are full words, and
+`resolveSubdivision` runs before the bare-code branch. A code would be consulted against
+the US/Canada subdivision table's same-spelled entries and turn `Baton Rouge, LA` into
+Laos.
+
+## Risks / Trade-offs
+
+- **Un-gating `base` regresses the profile→filters seed** → the coupled `facetModel.ts`
+  change ships in the same change with its own test; the spec delta records the rule so it
+  cannot be re-introduced later by someone reading only the old requirement.
+- **The hard-constraint fallback changes match scoring for real users** → the fallback
+  fires only where the field was previously empty, so it can turn a silently-skipped
+  category into an evaluated one but can never override a user's own statement. The
+  never-guess rule for multi-country keeps it from manufacturing evidence.
+- **A wrong LLM-extracted location now has consequences** it did not have while the string
+  sat unread → mitigated by the asserted-beats-derived precedence and by the profile
+  pre-fill being a confirmable default rather than a silent commit. `resumeextract`'s
+  schema work already removed the known systematic error here (the model filling the
+  candidate's location with the last employer's office).
+- **The dictionary change reaches jobs without a re-derive** → geography for existing jobs
+  stays as-is until the next scheduled `cmd/backfill-derive`; the change is additive, so no
+  job loses geography, some simply gain it later than CVs do. Accepted deliberately to
+  avoid a 2.5M-row re-derive plus reindex, which carries its own operational hazards.
+- **A reconciler for the derivative but not for its source** → geography can be rebuilt at
+  will, yet the structure it derives from still dies silently on extraction failure. The
+  asymmetry is recorded here and in the proposal; it is the strongest remaining argument
+  for scheduling `backfill-resume-structured`, which is deliberately out of scope.
+- **`resume_cities` may prove unused** if the profile pre-fill is cut → drop the column
+  with the pre-fill; nothing else reads it.
+
+## Migration Plan
+
+1. **Apply migration `0068` before deploying the code.** It is expansive (three nullable
+   columns, no rewrite, no default backfill), so it is safe to apply ahead of the deploy;
+   deploying first would produce `42703` on every profile read.
+2. Deploy. New uploads derive geography from that moment on.
+3. `cmd/backfill-resume-structured --dry-run`, review the list, then run it — 40 users
+   (37 with no structure, 3 stale). This needs `LLM_*`, `S3_*`, and `PII_FILTER_URL`.
+4. `cmd/backfill-resume-geo --dry-run`, then run it for every user with a current
+   structure. Needs only `DATABASE_URL`.
+5. Verify: country distribution in one query, and a second `backfill-resume-geo` run that
+   changes nothing.
+6. **Rollback:** revert the deploy. The columns are additive and read-only to everything
+   except the derivation, so they can be left in place; no data migration is undone. The
+   front-end changes revert with the deploy.
+
+**No Meilisearch reindex and no `cmd/backfill-derive` run** are part of this. Candidate
+geography is a Postgres column, not a search facet.
+
+## Open Questions
+
+- Should the derived geography eventually become an employer-facing candidate search
+  facet? Out of scope here; the columns are shaped to allow it (`text[]`, mirroring jobs)
+  without committing to it.
+- Should `backfill-resume-structured` gain a scheduled run so the 37-user hole cannot
+  recur? Named as the systemic cause, deliberately not fixed in this change.
+- **Should the country dictionary be generated rather than hand-maintained?** Measured
+  during this change: `countryToRegion` covers **133** countries; GeoNames knows 244 with
+  a city over 15k, and ISO 3166-1 has 252 — so **111 countries resolve to nothing**
+  (Afghanistan, Cuba, Haiti, Jamaica, Syria, Madagascar, DR Congo, Namibia, … plus a long
+  tail of dependencies). Deliberately deferred, for three reasons:
+  1. **Regions cannot be generated.** GeoNames supplies a *continent*; this project's
+     regions are a business taxonomy (`uk` split from `eu`, `cis` spanning the Caucasus
+     and Central Asia, `mena` cutting across Africa and Asia). A continent→region mapping
+     would misplace Turkey, Egypt, Kazakhstan, the UK, and Russia. The generator could
+     supply 111 names but not one region, and a name without a region fails
+     `TestDictionariesStayInVocabulary`. The valuable half of the work is human.
+  2. **Wholesale import would silently break the collision policy** recorded above:
+     `ga` is Gabon *and* the Georgia state code, `na` is Namibia, `ms` is Montserrat and
+     Mississippi.
+  3. **It would not have helped the measured data.** The 100 production CV locations named
+     38 distinct countries, all already covered; none of the 8 unresolved strings fail for
+     a missing country name. They fail on tokenization (`·` is not a separator, the
+     LinkedIn `Greater X` prefix) and on non-US subdivisions (`subdivisionToCountry` covers
+     only the US and Canada, so Indian states do not resolve). That is where the next
+     coverage gain actually is.
+
+  The shape if it is ever taken up: extend `cmd/gen-cities` into a `gen-geo` following the
+  same committed-output pattern, generate names from GeoNames `countryInfo.txt`, keep
+  regions curated, and let the existing guard test enumerate what a human still has to
+  classify. Add an explicit denylist for the subdivision collisions.

--- a/openspec/changes/candidate-resume-geography/proposal.md
+++ b/openspec/changes/candidate-resume-geography/proposal.md
@@ -1,0 +1,97 @@
+## Why
+
+A candidate's geography is unusable today. The only place it exists is
+`users.resume_structured->>'location'` — a raw free-text line the LLM copied off the
+CV ("Bogotá, Colombia", "San Francisco, CA", "Remote (GMT+3)"). Nothing normalizes it,
+so the candidate's country cannot be filtered, faceted, or matched against a job's
+geography, even though jobs have carried derived `countries`/`regions` since `0001`.
+
+The profile was supposed to be the other half of this, and it is quietly broken. The
+profile form gates the "where you're based" sub-form on the user accepting on-site or
+hybrid work, and **discards `base` at save time** for anyone who accepts only remote —
+as if a remote worker had no physical location. Measured on production (2026-08-01):
+of 145 profiles only **27 carry a `base.country`**, while 80 users have a location on
+their CV and no base at all. Two hard-constraint checks that already exist and already
+read `base.country` — "this job does not sponsor visas and is pinned to a country you
+are not in" and "this on-site job is in another country" — therefore never fire for
+**81% of profiles**. The logic is correct; the input was thrown away.
+
+## What Changes
+
+- Add `internal/location.ParseResidence` — the single entry point for candidate
+  location text, deriving where a **person** is rather than where **work** is.
+- Add three derived columns on `users` (`resume_countries`, `resume_regions`,
+  `resume_cities`), written in the same monotonic statement that persists the
+  structured résumé, so the derivation cannot drift from the structure it came from.
+- Add `cmd/backfill-resume-geo`, a run-once-and-exit worker that re-derives the
+  columns from already-stored structures. It needs only `DATABASE_URL` — no LLM, no
+  object storage, no network — so it is safely repeatable after any dictionary change.
+- Feed the derived country into hard-constraint evaluation **only where the user has
+  stated nothing**: an asserted `base.country` always wins.
+- Expose the derived geography read-only on `GET /api/v1/me/profile` so the profile
+  form can pre-fill "where you're based" for confirmation instead of asking the user
+  to type what their CV already says.
+- **Un-gate `base` in the profile form** so "where I am now" is asked of everyone,
+  independently of which work arrangements they accept.
+- **BREAKING (behavioural, filter seeding):** seeding job-search filters from a
+  profile currently folds `base.country` into the `countries` facet and `base.city`
+  into `cities`. That was tolerable only while `base` was reachable exclusively by
+  on-site/hybrid users. Once `base` is asked of everyone, a remote-only candidate in
+  Colombia would silently get their job search filtered to Colombia. The `base`
+  contribution to the seeded `countries`/`cities` facets is therefore restricted to
+  users who accept physical work.
+- Close a dictionary drift: 25 ISO country codes carry a region in `countryToRegion`
+  but have no name in `nameToCountry` (`hn`, `rw`, `kh`, `tz`, `ug`, …), so "Honduras"
+  and "Rwanda" resolve to nothing. Add the missing names and a guard test that keeps
+  the two maps in step.
+- Run the existing `cmd/backfill-resume-structured` against the 40 production users
+  whose structure is missing (37) or stale (3). No new code — it already exists.
+
+## Capabilities
+
+### New Capabilities
+- `candidate-geography`: deriving, storing, and backfilling where a candidate is
+  located, from the free-text location line of their CV — including the rule that
+  separates a person's whereabouts from a job's reach, and the precedence between
+  what the candidate asserted and what was derived for them.
+
+### Modified Capabilities
+- `resume-structured-profile`: persisting the structured résumé now also derives and
+  stores the candidate's geography in the same stamped, monotonic write; clearing the
+  résumé clears it too.
+- `hard-constraint-matching`: the location/work-authorization categories may take
+  their country evidence from the derived residence when the user has asserted no
+  base country, instead of skipping the category.
+- `search-profiles`: `base` is reframed as a fact about the user rather than a
+  preference, is asked of every user regardless of accepted work modes, and
+  `GET /api/v1/me/profile` gains a read-only derived-geography block.
+- `filter-modal`: the profile→filters seed no longer contributes `base.country` /
+  `base.city` for users who accept only remote work.
+- `job-geography`: every ISO country code the dictionary can place in a region SHALL
+  also be resolvable from its country name — the invariant that was silently violated
+  for 25 codes.
+
+## Impact
+
+**Schema.** Migration `0068` adds three nullable `text[]` columns to `users`. It is
+expansive and MUST be applied before the code that reads them is deployed.
+
+**Go.** `internal/location` (new entry point + dictionary names + guard test),
+`internal/resume` (write path), `internal/db/queries/users.sql` + regenerated
+`internal/db`, `internal/handler` (hard-constraint inputs, `/me/profile` response),
+new `cmd/backfill-resume-geo`.
+
+**Web.** `ProfileForm.svelte` (un-gate `base`, pre-fill from derived geography),
+`facetModel.ts` (`filtersFromProfile` seeding), `types.ts` contract.
+
+**Production operations.** Two worker runs, both dry-run first:
+`cmd/backfill-resume-structured` for the 40 users without a current structure, then
+`cmd/backfill-resume-geo` for everyone. No Meilisearch reindex and no job re-derive:
+the dictionary change is additive, so existing jobs pick the new names up on the next
+scheduled `cmd/backfill-derive`.
+
+**Known limitation, deliberately not fixed here.** The structured résumé still has no
+reconciler — a failed background extraction leaves `resume_structured` NULL until the
+user re-uploads, which is why 37 users need a manual backfill run. The derived
+geography *does* get a reconciler in this change, so the artifact now outlives the
+thing it is derived from. That asymmetry is recorded, not resolved.

--- a/openspec/changes/candidate-resume-geography/specs/candidate-geography/spec.md
+++ b/openspec/changes/candidate-resume-geography/specs/candidate-geography/spec.md
@@ -1,0 +1,192 @@
+## ADDED Requirements
+
+### Requirement: Candidate geography is derived through a candidate-specific entry point
+
+The system SHALL derive a candidate's geography from the free-text location line of
+their structured résumé through a dedicated entry point (`location.ParseResidence`)
+that returns countries, regions, and cities, and SHALL NOT consume the job-location
+parser's output (`location.Parse`) directly for candidate text. The derivation MUST be
+deterministic and dictionary-only: no LLM call, no network access, and no guessing —
+a location the curated dictionary cannot resolve yields nothing rather than an
+approximation, the same discipline every other production facet dictionary follows.
+
+The two parsers exist separately because the same string means different things. For a
+job, a location answers "where is the work"; for a résumé it answers "where is the
+person". A single parser with a flag would let one meaning be passed where the other is
+expected; two types cannot be confused at a call site.
+
+#### Scenario: A city and country on a CV resolve to a country and its region
+
+- **WHEN** a candidate's résumé states `Valencia, Spain`
+- **THEN** the derived geography is countries `[es]`, regions `[eu]`, and cities `[Valencia]`
+
+#### Scenario: An unresolvable location yields nothing rather than a guess
+
+- **WHEN** a candidate's résumé states a location the curated dictionary cannot place
+  (e.g. `Nyarugenge District, Nyakabanda Sector`)
+- **THEN** the derived countries, regions, and cities are all empty and no country is inferred
+
+#### Scenario: Deriving candidate geography performs no I/O
+
+- **WHEN** candidate geography is derived for any location string
+- **THEN** the derivation completes without an LLM call, an HTTP request, or a database read
+
+### Requirement: A candidate is never located globally
+
+The candidate geography derivation SHALL NOT emit the `global` region. A job may
+legitimately be open anywhere, but a person is always physically somewhere, so
+`global` is never a true statement about a candidate's whereabouts. The exclusion MUST
+hold regardless of which mechanism produced the region — both the bare-remote fallback
+(a location that resolves no place but carries a remote marker) and the dictionary's
+own `worldwide`/`anywhere`/`по всему миру` → `global` entries.
+
+A remote marker alongside a resolvable place MUST NOT suppress that place: the place is
+where the person is, and the remoteness is not geography at all.
+
+#### Scenario: A bare remote marker yields no geography for a candidate
+
+- **WHEN** a candidate's résumé states `Remote (GMT+3)`
+- **THEN** the derived countries and regions are empty — in particular the region is not `global`
+
+#### Scenario: An explicit worldwide word yields no geography for a candidate
+
+- **WHEN** a candidate's résumé states `REMOTE · WORLDWIDE`
+- **THEN** the derived regions are empty — the dictionary's `worldwide` → `global` mapping
+  does not reach the candidate result
+
+#### Scenario: A real macro-region without a country is kept
+
+- **WHEN** a candidate's résumé states `EU / Remote`
+- **THEN** the derived regions are `[eu]` and the countries are empty — a candidate stating
+  they are in the EU is a true claim about where they are
+
+#### Scenario: A place stated alongside a remote marker survives
+
+- **WHEN** a candidate's résumé states a resolvable place together with a remote marker
+- **THEN** the derived geography names that place and is not emptied or globalized
+
+### Requirement: Work mode is not part of a candidate's location
+
+The candidate geography derivation SHALL NOT emit a work-mode value. How a person is
+willing to work is a preference, not a fact about where they are, and it already has a
+home in the profile's `location_preferences.work_modes`. A work-mode marker in the CV
+location line MUST be used only to the extent that it helps resolve the place, and MUST
+NOT be persisted as part of the derived geography.
+
+#### Scenario: A hybrid marker does not become candidate geography
+
+- **WHEN** a candidate's résumé states a location carrying an explicit work-mode marker
+- **THEN** the derived geography carries countries, regions, and cities only, and no
+  work-mode value is stored on the user
+
+### Requirement: Derived geography is written with the structure it came from
+
+The derived geography SHALL be computed and persisted in the same write that persists
+the structured résumé, stamped with the same résumé upload time. It MUST therefore
+inherit that write's monotonic guard: a background derivation for a résumé that has
+since been replaced MUST leave both the structure and the geography untouched, so the
+two can never describe different CVs.
+
+Because the derivation is deterministic and costs no I/O, it MUST be computed
+synchronously on that write rather than scheduled as separate background work — a
+separate schedule would introduce a state in which a user has a structure but not yet
+the geography derived from it.
+
+#### Scenario: Persisting a structure persists its geography
+
+- **WHEN** a structured résumé stating a resolvable location is persisted for a user
+- **THEN** the user's derived countries, regions, and cities are stored in the same write
+
+#### Scenario: A superseded derivation writes neither structure nor geography
+
+- **WHEN** a background extraction completes for a résumé that has since been replaced by
+  a newer upload
+- **THEN** neither the structured résumé nor the derived geography is written, and the
+  newer CV's values are left intact
+
+#### Scenario: Deleting the résumé clears the derived geography
+
+- **WHEN** a signed-in user deletes their stored résumé
+- **THEN** the derived countries, regions, and cities are cleared along with the structure
+
+### Requirement: Unknown geography is distinguishable from unresolved geography
+
+The stored derived geography SHALL distinguish "we do not know where this candidate is"
+from "the candidate stated a place the dictionary could not resolve". Absent geography
+(no CV, no current structured résumé, or a structure stating no location) MUST be
+represented as absent; a stated-but-unresolved location MUST be represented as an empty
+resolved set. The two MUST NOT collapse into one value.
+
+This keeps the dictionary's coverage gap measurable on live data for as long as the
+column exists, rather than hiding it behind a value that also means "not derived yet".
+
+#### Scenario: A user with no current structured résumé has absent geography
+
+- **WHEN** a user has no structured résumé, or one that no longer matches their current CV
+- **THEN** their derived geography is absent — not an empty set of countries
+
+#### Scenario: A stated but unresolvable location is an empty resolved set
+
+- **WHEN** a user's structured résumé states a location the dictionary cannot resolve
+- **THEN** their derived countries are an empty set, distinguishable from absent
+
+### Requirement: Derived geography is reconcilable by a re-runnable worker
+
+The system SHALL provide a run-once-and-exit worker that re-derives the stored geography
+from already-persisted structured résumés. The worker MUST require only a database
+connection — no LLM, no object storage, and no other network dependency — so that it is
+cheap and safe to re-run after any change to the location dictionary, in the same way
+the job facets are re-derived.
+
+The worker MUST be idempotent: a second run over unchanged data and an unchanged
+dictionary MUST leave every stored value identical. It MUST process only users whose
+structured résumé currently describes their stored CV, since deriving geography from a
+superseded structure would circumvent the staleness rule.
+
+#### Scenario: Re-running the worker changes nothing
+
+- **WHEN** the worker is run twice in succession with no intervening change to the stored
+  structures or the dictionary
+- **THEN** the second run leaves every user's derived geography byte-identical to the first
+
+#### Scenario: A dictionary change is picked up by a re-run
+
+- **WHEN** the location dictionary gains the ability to resolve a country it previously
+  could not, and the worker is re-run
+- **THEN** users whose stated location names that country gain the resolved country
+
+#### Scenario: A user with a superseded structure is skipped
+
+- **WHEN** the worker runs over a user whose structured résumé no longer matches their
+  current CV
+- **THEN** that user is skipped and their derived geography is not written from the stale structure
+
+#### Scenario: The worker runs without LLM or object-storage configuration
+
+- **WHEN** the worker is started with only a database connection configured
+- **THEN** it runs to completion rather than failing on a missing LLM or storage setting
+
+### Requirement: An asserted location outranks a derived one
+
+Where a consumer needs the candidate's country and the candidate has asserted one in
+their profile, the asserted value SHALL be used. A derived country MAY fill the gap only
+when the candidate has asserted nothing. A derived geography naming more than one country
+MUST be treated as no answer rather than resolved by picking one, preserving the
+never-guess discipline: the point of the derivation is to supply a fact, and an ambiguous
+derivation is not one.
+
+#### Scenario: An asserted base country wins over a derived one
+
+- **WHEN** a candidate has stated a base country in their profile and their CV derives a
+  different country
+- **THEN** consumers use the stated country
+
+#### Scenario: A derived country fills an unstated base
+
+- **WHEN** a candidate has stated no base country and their CV derives exactly one country
+- **THEN** consumers use the derived country
+
+#### Scenario: An ambiguous derivation is not resolved by guessing
+
+- **WHEN** a candidate has stated no base country and their CV derives more than one country
+- **THEN** consumers receive no country rather than one of the derived candidates

--- a/openspec/changes/candidate-resume-geography/specs/filter-modal/spec.md
+++ b/openspec/changes/candidate-resume-geography/specs/filter-modal/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: The filter modal can apply the signed-in user's profile
+
+The jobs filter modal SHALL offer, in its header, an **Apply my profile** action for a
+signed-in user who has a saved profile. Activating it SHALL reset the staged filters and
+then seed them from the user's profile: each profile specialization SHALL be staged as a
+`category` value and each profile skill SHALL be staged as an included `skills` value.
+Each profile excluded skill SHALL be staged as an **excluded** `skills` value (into the
+`skills` facet's exclude set, so it commits as `?skills_exclude=…`). When the
+profile carries a `location_preferences` block, the action SHALL additionally seed the
+location facets by flattening the three blocks: `work_mode` from `work_modes`; `regions`
+from the union of `remote.regions` and `relocation.regions`; `countries` from the union of
+`remote.countries`, `base.country`, and `relocation.countries`; `cities` from the union of
+`base.city` and `relocation.cities`; and `relocation` staged as `supported` and `required`
+when `relocation.open` is true. Empty or absent parts contribute nothing.
+
+`base` SHALL contribute to the seeded `countries` and `cities` facets **only for a user
+who accepts on-site or hybrid work**. `base` states where the user lives, not where they
+want the work to be; for a user who accepts only remote work those are different places,
+and seeding their home country as a job-country filter would silently narrow their search
+to the one country they least need the work to be in. For a user who accepts physical
+work the two coincide — the job must be commutable — so the contribution is kept.
+
+The action SHALL only stage — it SHALL NOT change the live job list; the seeded selection
+is applied through the existing **Show results** commit, so the user previews (and MAY
+adjust) the profile-derived filters before applying.
+
+The action SHALL appear only on the full jobs filter modal (not on reuses that restrict
+the rail to a facet subset, such as the profile-comparison modal). When the signed-in
+user has no saved profile, the header SHALL instead present a link to create one at
+`/my/profile`. When no user is signed in, neither the action nor the link SHALL appear.
+
+#### Scenario: Applying the profile resets and seeds the staged filters
+- **WHEN** a signed-in user with a saved profile (specializations `A`, `B`; skills `x`,
+  `y`) has some unrelated staged filters and activates **Apply my profile**
+- **THEN** the previously staged filters are cleared, the `category` facet is staged with
+  `A` and `B`, the `skills` facet is staged with `x` and `y`, and the job list is
+  unchanged until **Show results** is activated
+
+#### Scenario: Applying a profile with excluded skills seeds the skills exclude set
+- **WHEN** a signed-in user whose profile has skills `[go]` and excluded skills `[php]`
+  activates **Apply my profile**
+- **THEN** the `skills` facet is staged with `go` included and `php` excluded, and on
+  **Show results** the committed filter carries `?skills=go` and `?skills_exclude=php`
+
+#### Scenario: Applying a profile with location preferences seeds the location facets
+- **WHEN** a signed-in user whose profile has `work_modes` `[remote, onsite]`,
+  `remote.regions` `[latam]`, `base` `{country: br, city: "Florianópolis"}`, and
+  `relocation` `{open: true, cities: ["Berlin"]}` activates **Apply my profile**
+- **THEN** the staged filters include `work_mode` `[remote, onsite]`, `regions` `[latam]`,
+  `countries` `[br]`, `cities` `["Florianópolis", "Berlin"]`, and `relocation`
+  `[supported, required]`, and the job list is unchanged until **Show results** is activated
+
+#### Scenario: A remote-only user's base does not narrow their search
+- **WHEN** a signed-in user whose `work_modes` are `[remote]` alone, with `base`
+  `{country: co, city: "Manizales"}` and `remote.regions` `[latam]`, activates
+  **Apply my profile**
+- **THEN** the staged `regions` are `[latam]` and the staged `countries` and `cities` are
+  empty — their home country is not staged as a job-country filter
+
+#### Scenario: Applying a profile without location preferences seeds no location facets
+- **WHEN** a signed-in user whose profile has no `location_preferences` block activates
+  **Apply my profile**
+- **THEN** only the `category` and `skills` facets are staged and the location facets
+  (`work_mode`, `regions`, `countries`, `cities`, `relocation`) remain empty
+
+#### Scenario: Show results commits the profile-derived filters
+- **WHEN** the user has applied their profile in the modal and then activates **Show
+  results**
+- **THEN** the staged selections become the live (URL-synced) filter state and the modal
+  closes

--- a/openspec/changes/candidate-resume-geography/specs/hard-constraint-matching/spec.md
+++ b/openspec/changes/candidate-resume-geography/specs/hard-constraint-matching/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Country evidence may fall back to the candidate's derived geography
+
+The assembly of the evaluator's CV evidence SHALL source the candidate's country from
+their asserted profile base country when they have stated one, and MAY fall back to the
+country derived from their CV when they have not. A derived geography naming more than
+one country MUST yield no country rather than one chosen arbitrarily, so the fallback
+can never manufacture evidence the candidate did not supply.
+
+This changes only which category can be evaluated, not the evaluator: the pure evaluator
+continues to skip a category whose evidence field is empty, and continues to emit no
+blocker where it has nothing to compare. The fallback exists because the two constraints
+that read this field — work-authorization and location-and-work-mode — were silently
+inert for the large majority of profiles, which state no base country at all.
+
+#### Scenario: A stated base country is used unchanged
+
+- **WHEN** evidence is assembled for a caller whose profile states a base country
+- **THEN** that country is the evidence country, regardless of what their CV derives
+
+#### Scenario: A derived country fills an unstated base country
+
+- **WHEN** evidence is assembled for a caller who states no base country and whose CV
+  derives exactly one country
+- **THEN** that derived country is the evidence country, and the work-authorization and
+  location categories become evaluable
+
+#### Scenario: An ambiguous derived geography supplies no country
+
+- **WHEN** evidence is assembled for a caller who states no base country and whose CV
+  derives more than one country
+- **THEN** the evidence country is empty and both country-dependent categories are skipped
+  silently, exactly as when no geography is known at all
+
+#### Scenario: A caller with neither source is unaffected
+
+- **WHEN** evidence is assembled for a caller who states no base country and has no
+  derived geography
+- **THEN** the evidence country is empty and no blocker is emitted for either category

--- a/openspec/changes/candidate-resume-geography/specs/job-geography/spec.md
+++ b/openspec/changes/candidate-resume-geography/specs/job-geography/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Every placeable country code is also resolvable by name
+
+Every ISO 3166-1 alpha-2 country code the dictionary can place in a region SHALL also be
+resolvable from at least one country name. The two tables MUST NOT drift apart: a code
+that carries a region but has no name is a country the parser can describe once something
+else has identified it, yet can never identify itself — so a posting or a CV that spells
+the country out in full resolves to nothing.
+
+This invariant SHALL be enforced by a test rather than by review, because the failure is
+silent: the affected locations simply return empty geography, which is
+indistinguishable from a location the dictionary was never meant to cover.
+
+#### Scenario: A country named in full resolves to its code and region
+
+- **WHEN** a location naming a country in full is parsed (e.g. `San Pedro Sula, Honduras`)
+- **THEN** the countries include that country's ISO code and the regions include the region
+  the dictionary already assigns to that code
+
+#### Scenario: The two dictionaries are verified to be in step
+
+- **WHEN** the location dictionaries are checked
+- **THEN** every country code carrying a region has at least one name resolving to it, and
+  a code without one fails the check
+
+#### Scenario: Adding country names does not disturb subdivision resolution
+
+- **WHEN** a location whose token is a two-letter subdivision code that collides with a
+  country code is parsed (e.g. `LA` for Louisiana, `MN` for Minnesota)
+- **THEN** the subdivision still wins and the country it belongs to is emitted, unchanged
+  by the presence of a same-coded country's name in the dictionary

--- a/openspec/changes/candidate-resume-geography/specs/resume-structured-profile/spec.md
+++ b/openspec/changes/candidate-resume-geography/specs/resume-structured-profile/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: The structured résumé is read-only and tied to the current résumé
+
+The stored structured résumé SHALL be read-only — this capability provides no per-field editing. It SHALL always describe the résumé currently stored for the user: a re-upload re-derives it, and it is served only when its stamp matches the current résumé's upload time. A structured résumé whose stamp does not match the current résumé (a newer CV whose extraction has not yet landed, or a persistent extraction outage) MUST be treated as absent rather than served. Deleting the résumé SHALL clear the stored structured résumé.
+
+Persisting the structure SHALL also derive and store the candidate's geography from the structure's location line, in the same statement and under the same stamp, so that a stored geography can never describe a different CV than the structure it was derived from. The derivation is deterministic and performs no I/O; the rules governing what it emits belong to the `candidate-geography` capability. Deleting the résumé SHALL clear the derived geography along with the structure.
+
+#### Scenario: Re-upload re-derives the structure
+
+- **WHEN** a user who already has a structured résumé uploads a new CV
+- **THEN** the structured résumé is re-derived from the new CV in the background and, once persisted, replaces the previous one
+
+#### Scenario: A structure from a superseded résumé is not served
+
+- **WHEN** a newer résumé has been uploaded but its structured extraction has not yet completed
+- **THEN** the read surface reports no structured résumé rather than the structure derived from the superseded CV
+
+#### Scenario: Deleting the résumé clears the structure
+
+- **WHEN** a signed-in user deletes their stored résumé
+- **THEN** the stored structured résumé is cleared along with the résumé pointer
+
+#### Scenario: Persisting the structure persists the derived geography
+
+- **WHEN** a structured résumé is persisted for a user
+- **THEN** the geography derived from its location line is stored in the same write, under the same résumé-upload stamp
+
+#### Scenario: A superseded extraction writes neither the structure nor the geography
+
+- **WHEN** a background extraction completes for a résumé that has since been replaced
+- **THEN** the write matches no row and neither the structure nor the derived geography is changed
+
+#### Scenario: Deleting the résumé clears the derived geography
+
+- **WHEN** a signed-in user deletes their stored résumé
+- **THEN** the derived geography is cleared along with the structure

--- a/openspec/changes/candidate-resume-geography/specs/search-profiles/spec.md
+++ b/openspec/changes/candidate-resume-geography/specs/search-profiles/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: Location & work-mode preferences
+
+A profile SHALL be able to carry an optional `location_preferences` block recording both where the user **is** and where and how they **want** to work. The block is composed of the parts below — freely combinable and stored whole (as one value); every part and every field within it is optional, and a profile with no location preferences SHALL be represented by the block being absent (`null`). The block SHALL be:
+
+- `work_modes`: a set of accepted work arrangements, each drawn from the controlled work-mode vocabulary (`enrich.WorkModeValues`: `remote`/`hybrid`/`onsite`), deduplicated.
+- `remote`: the remote reach — `{ regions, countries }` — where `regions` is drawn from the controlled region vocabulary (`enrich.RegionValues`) and `countries` is a set of ISO 3166-1 alpha-2 codes; an empty reach means "worldwide".
+- `base`: the user's current single location — `{ country, city }` — where `country` is an ISO 3166-1 alpha-2 code and `city` is free text. `base` is a **fact about the user**, not a preference: it states where they are, and is meaningful for every work arrangement. It MUST NOT be conditioned on which work modes the user accepts, and MUST NOT be dropped on save for a user who accepts only remote work — a remote worker's country still governs their right to work, their taxation, and their overlap with a team.
+- `relocation`: willingness to move — `{ open, regions, countries, cities }` — where `open` is a boolean and the target `regions`/`countries`/`cities` are the acceptable destinations; `open` with empty targets means "anywhere".
+
+On save the system SHALL validate and normalize the block: work modes and regions matched case-insensitively and rejected if outside their controlled vocabularies; countries lowercased and rejected if not a well-formed ISO 3166-1 alpha-2 shape (exactly two ASCII letters — shape, not assignment, so the full range of codes a user may pick is accepted); every code/token trimmed and deduplicated; cities trimmed, empty entries dropped, deduplicated, and capped. An invalid value SHALL reject the whole save (the profile is unchanged); nothing out-of-vocabulary is ever stored.
+
+#### Scenario: Save a profile with combined location preferences
+- **WHEN** an authenticated user saves a profile with `location_preferences` of `work_modes` `[remote, onsite]`, `remote.regions` `[latam]`, `base` `{country: br, city: "Florianópolis"}`, and `relocation` `{open: true, cities: ["Berlin"]}`
+- **THEN** the system stores the block whole and a subsequent fetch returns exactly those preferences
+
+#### Scenario: Location preferences are optional
+- **WHEN** an authenticated user saves a profile with valid `specializations` and `skills` and no `location_preferences`
+- **THEN** the system stores the profile with an absent (`null`) location block and the save succeeds
+
+#### Scenario: Out-of-vocabulary work mode or region is rejected
+- **WHEN** an authenticated user saves `location_preferences` whose `work_modes` or any `regions` entry is not in the controlled vocabulary
+- **THEN** the system responds `400`, stores nothing, and leaves any existing profile unchanged
+
+#### Scenario: Malformed country code is rejected
+- **WHEN** an authenticated user saves `location_preferences` with a `countries` or `base.country` value that is not a two-letter code (e.g. an alpha-3 code like `usa`)
+- **THEN** the system responds `400` and stores nothing
+
+#### Scenario: Countries and cities are normalized
+- **WHEN** an authenticated user saves `location_preferences` with country codes in mixed case and cities with surrounding whitespace or duplicates
+- **THEN** the system stores country codes lowercased and deduplicated, and cities trimmed, non-empty, and deduplicated
+
+#### Scenario: A remote-only user keeps their base location
+- **WHEN** an authenticated user whose `work_modes` are `[remote]` alone saves `location_preferences` with `base` `{country: co, city: "Manizales"}`
+- **THEN** the system stores that base and a subsequent fetch returns it — it is not dropped for want of an on-site or hybrid work mode
+
+## ADDED Requirements
+
+### Requirement: The profile asks where the user is, independently of how they work
+
+The profile edit UI SHALL present the "where you're based" control to every signed-in
+user, unconditionally — it MUST NOT be revealed or hidden by which work modes the user
+has accepted, and a base entered by a user who accepts only remote work MUST reach the
+save request rather than being discarded with the hidden sub-form.
+
+Where the system has derived a location from the user's CV and the user has not yet
+stated a base, the control SHALL be pre-filled with the derived value so the user
+confirms a fact already on their CV rather than retyping it. The pre-fill is a default
+for an unstated field only: it MUST NOT overwrite a base the user has already saved, and
+the saved value is whatever the user submits.
+
+#### Scenario: A remote-only user is asked where they are based
+
+- **WHEN** a signed-in user opens the profile editor and accepts only remote work
+- **THEN** the "where you're based" control is visible and editable, and saving stores the
+  country and city entered
+
+#### Scenario: The base control is pre-filled from the derived geography
+
+- **WHEN** a signed-in user with no saved base country, whose CV derives exactly one
+  country, opens the profile editor
+- **THEN** the base country control is pre-filled with the derived country, and saving
+  without further edits stores it as their stated base
+
+#### Scenario: A stated base is not overwritten by the derivation
+
+- **WHEN** a signed-in user who has already saved a base country opens the profile editor
+  and their CV derives a different country
+- **THEN** the control shows their saved country, not the derived one
+
+### Requirement: The profile read exposes the derived geography read-only
+
+`GET /api/v1/me/profile` SHALL include a read-only block carrying the geography derived
+from the caller's CV, alongside the stated `location_preferences`. The block MUST be
+distinguishable from the stated preferences rather than merged into them — one is what
+the candidate asserted and the other is what was derived for them, and a consumer needs
+to know which it is holding. The block SHALL be null when nothing is derived, and MUST
+never be writable through this or any other profile endpoint.
+
+#### Scenario: A caller with derived geography receives it
+
+- **WHEN** an authenticated user whose CV derives a country requests their profile
+- **THEN** the response carries the derived countries, regions, and cities in their own
+  block, separate from `location_preferences`
+
+#### Scenario: A caller with no derived geography receives null
+
+- **WHEN** an authenticated user with no current structured résumé requests their profile
+- **THEN** the derived-geography block is `null`
+
+#### Scenario: The derived block is not writable
+
+- **WHEN** an authenticated user sends a profile save containing a derived-geography block
+- **THEN** the stored derived geography is unchanged — it is produced only by the CV
+  derivation, never by a profile write

--- a/openspec/changes/candidate-resume-geography/tasks.md
+++ b/openspec/changes/candidate-resume-geography/tasks.md
@@ -1,0 +1,61 @@
+## 1. Location dictionary integrity
+
+- [x] 1.1 Add a guard test asserting every country code in `countryToRegion` resolves from at least one name in `nameToCountry` (currently fails for 25 codes)
+- [x] 1.2 Add the 25 missing country names to `nameToCountry` (`ad ao bn ci cm hn kh la li ly mm mn mo mz ni ps rw sm sn sv tz ug ye zm zw`) — names only, never codes
+- [x] 1.3 Add regression tests that the two-letter subdivision collisions still win (`LA`→Louisiana, `MN`→Minnesota, `MO`→Missouri) and that `San Pedro Sula, Honduras` now resolves to `hn`/`latam`
+
+## 2. Candidate geography rule
+
+- [x] 2.1 Write failing tests for `location.ParseResidence`: `Valencia, Spain` → `es`/`eu`/`Valencia`; empty input → empty
+- [x] 2.2 Write failing tests that `global` is excluded via BOTH paths — the bare-remote fallback (`Remote (GMT+3)`) and the dictionary entry (`REMOTE · WORLDWIDE`, `anywhere`)
+- [x] 2.3 Write failing tests that a real region without a country survives (`EU / Remote` → `eu`), that a place beside a remote marker survives, and that no work-mode value is returned
+- [x] 2.4 Implement `Residence` and `ParseResidence` in `internal/location`; document why it is a distinct type rather than a flag on `Parse`
+- [x] 2.5 Re-run the 100 production location strings through `ParseResidence` and record the country-coverage number before and after the dictionary fix
+
+## 3. Schema
+
+- [x] 3.1 Add migration `0068_user_resume_geography.sql` adding nullable `resume_countries`, `resume_regions`, `resume_cities` (`text[]`, no default) to `users`, with a comment stating the NULL-vs-`'{}'` distinction
+- [x] 3.2 Update `SetUserResumeStructured` and `ClearUserResume` in `internal/db/queries/users.sql` to write and clear the three columns; add a `GetUserResumeGeography`-style read for the profile surface
+- [x] 3.3 Run `make sqlc` and confirm `internal/db` regenerates cleanly
+
+## 4. Write path
+
+- [x] 4.1 Write failing tests in `internal/resume` that `SetStructured` persists the derived geography alongside the structure, under the same stamp
+- [x] 4.2 Write a failing test that a superseded stamp writes neither the structure nor the geography (the monotonic guard covers both)
+- [x] 4.3 Write a failing test that clearing the résumé clears the three columns
+- [x] 4.4 Implement the derivation inside `resume.Store.SetStructured`; confirm both producers (upload path and `cmd/backfill-resume-structured`) inherit it without changes
+
+## 5. Reconciler worker
+
+- [x] 5.1 Write failing tests for the worker's selection rule: users with a current structure are processed, users with a superseded structure are skipped
+- [x] 5.2 Write a failing idempotency test: a second run over unchanged data writes identical values
+- [x] 5.3 Implement `cmd/backfill-resume-geo` with `--user` / `--dry-run`, requiring only `DATABASE_URL` (no LLM, no S3, no PII detector)
+
+## 6. Read path
+
+- [x] 6.1 Write failing tests for country precedence in `buildHardConstraintInputs`: asserted base wins; derived fills an unstated base; two derived countries yield none; neither source yields none
+- [x] 6.2 Implement the precedence in `internal/handler/hardconstraint_inputs.go`
+- [x] 6.3 Write a failing test that `GET /api/v1/me/profile` returns the derived geography in its own block, `null` when absent, and that a profile write cannot set it
+- [x] 6.4 Implement the read-only derived-geography block on the profile response and regenerate the TS contract (`cmd/gen-contracts`)
+
+## 7. Profile form
+
+- [x] 7.1 Extract the profile→filters location seeding into a pure `.ts` module and write a failing test that a remote-only user's `base` does NOT seed the `countries`/`cities` facets
+- [x] 7.2 Implement the seeding rule in `facetModel.ts` (`base` contributes only when the user accepts on-site or hybrid); confirm the existing mixed-mode scenario still passes
+- [x] 7.3 Un-gate the "where you're based" control in `ProfileForm.svelte` — visible for every user, and reaching `buildLocation()` regardless of accepted work modes
+- [x] 7.4 Pre-fill the base control from the derived geography when the user has stated no base; verify a stated base is never overwritten
+- [ ] 7.5 Visually verify the profile form in a headless browser at a real viewport width (the work-format section no longer gates two sub-forms)
+
+## 8. Documentation
+
+- [x] 8.1 Update `internal/location/AGENTS.md` with the residence-vs-job-geography rule and the two-map guard
+- [x] 8.2 Update `internal/resumeextract/AGENTS.md` (or `internal/resume`'s notes) to record that the structure write now also carries geography
+- [x] 8.3 Note migration `0068` in the deploy-order documentation as apply-before-deploy
+
+## 9. Production rollout
+
+- [ ] 9.1 Apply migration `0068` on production before deploying
+- [ ] 9.2 Run `cmd/backfill-resume-structured --dry-run`, review the 40 users, then run it for real
+- [ ] 9.3 Run `cmd/backfill-resume-geo --dry-run`, then run it for real
+- [ ] 9.4 Verify: produce the country distribution in one query, and confirm a second `backfill-resume-geo` run changes nothing
+- [ ] 9.5 Record the final coverage number (resolved / consciously empty) across all users with a stored CV

--- a/openspec/changes/candidate-resume-geography/tasks.md
+++ b/openspec/changes/candidate-resume-geography/tasks.md
@@ -54,8 +54,8 @@
 
 ## 9. Production rollout
 
-- [ ] 9.1 Apply migration `0068` on production before deploying
-- [ ] 9.2 Run `cmd/backfill-resume-structured --dry-run`, review the 40 users, then run it for real
-- [ ] 9.3 Run `cmd/backfill-resume-geo --dry-run`, then run it for real
-- [ ] 9.4 Verify: produce the country distribution in one query, and confirm a second `backfill-resume-geo` run changes nothing
-- [ ] 9.5 Record the final coverage number (resolved / consciously empty) across all users with a stored CV
+- [x] 9.1 Apply migration `0068` on production before deploying
+- [x] 9.2 Run `cmd/backfill-resume-structured --dry-run`, review the 40 users, then run it for real
+- [x] 9.3 Run `cmd/backfill-resume-geo --dry-run`, then run it for real
+- [x] 9.4 Verify: produce the country distribution in one query, and confirm a second `backfill-resume-geo` run changes nothing
+- [x] 9.5 Record the final coverage number (resolved / consciously empty) across all users with a stored CV

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -10,6 +10,7 @@
   } from '$lib/facets';
   import { categoryLabel } from '$lib/labels';
   import { profileStore } from '$lib/profile.svelte';
+  import { buildLocationPreferences } from '$lib/profileLocation';
   import type { LocationPreferences, UserProfile } from '$lib/types';
   import { Button, Input } from '$lib/ui';
   import HeadshotField from './HeadshotField.svelte';
@@ -71,18 +72,33 @@
   let workModes = $state.raw<string[]>(loc0?.work_modes ?? []);
   let remoteRegions = $state.raw<string[]>(loc0?.remote.regions ?? []);
   let remoteCountries = $state.raw<string[]>(loc0?.remote.countries ?? []);
-  let baseCountry = $state<string>(loc0?.base.country ?? '');
-  let baseCity = $state<string>(loc0?.base.city ?? '');
+  // Where the user IS. Seeded from what they stated, falling back to what their CV was
+  // read to say — so someone who has uploaded a CV confirms a fact rather than retyping
+  // it. The derivation only ever fills an UNSTATED field: a saved base always wins, and
+  // an ambiguous derivation (more than one country) offers nothing rather than guessing.
+  // svelte-ignore state_referenced_locally
+  const derived0 = profile?.derived_location ?? null;
+  const derivedCountry = (derived0?.countries.length === 1 ? derived0.countries[0] : '') ?? '';
+  const derivedCity = (derived0?.cities.length === 1 ? derived0.cities[0] : '') ?? '';
+  let baseCountry = $state<string>(loc0?.base.country ?? derivedCountry);
+  let baseCity = $state<string>(loc0?.base.city ?? derivedCity);
   let relocOpen = $state<boolean>(loc0?.relocation.open ?? false);
   let relocRegions = $state.raw<string[]>(loc0?.relocation.regions ?? []);
   let relocCountries = $state.raw<string[]>(loc0?.relocation.countries ?? []);
   let relocCities = $state.raw<string[]>(loc0?.relocation.cities ?? []);
   let cityDraft = $state('');
 
-  // Work format gates the geo sub-forms (progressive disclosure): remote reach shows only
-  // when Remote is accepted; the physical base + relocation show only for On-site/Hybrid.
-  // Hidden fields linger in state (re-selecting the format restores the draft) but are not
-  // saved — buildLocation() reads the same gates.
+  // Work format gates the two "where would you take work" sub-forms: remote reach shows
+  // only when Remote is accepted, relocation only for On-site/Hybrid. Hidden fields linger
+  // in state (re-selecting the format restores the draft) but are not saved —
+  // buildLocation() reads the same gates.
+  //
+  // The physical BASE is deliberately not among them. Where someone lives is a fact about
+  // them, not a preference conditional on the arrangements they accept, and it matters
+  // most for a remote worker: it governs their right to work, their taxation and their
+  // overlap with a team. It used to be gated here and DISCARDED on save for anyone who
+  // accepted only remote work, which is why two hard-constraint checks that read it were
+  // silently inert for most profiles.
   const wantsRemote = $derived(workModes.includes('remote'));
   const wantsPhysical = $derived(workModes.includes('onsite') || workModes.includes('hybrid'));
 
@@ -249,24 +265,21 @@
     relocCities = [...relocCities, city];
   }
 
-  // Reassemble the flat fields into the location block, or null when the user picked nothing
-  // (the server also collapses an all-empty block, but sending null keeps intent explicit).
-  // Relocation targets are gated on `relocOpen`: withdrawing "Open to relocation" drops them
-  // from the saved block (they linger in local state so toggling back on restores the draft),
-  // matching how the filter seed ignores targets when the user is not open to relocating.
+  // Reassemble the flat fields into the saved location block. The rules — which sub-forms
+  // the work format gates, and why `base` is NOT among them — live in profileLocation.ts so
+  // they are unit-testable; this component only supplies the fields.
   function buildLocation(): LocationPreferences | null {
-    // Only persist fields the current work format reveals — a hidden sub-form's lingering
-    // draft is not saved (mirrors how the UI gates them).
-    const loc: LocationPreferences = {
-      work_modes: workModes,
-      remote: wantsRemote ? { regions: remoteRegions, countries: remoteCountries } : {},
-      base: wantsPhysical ? { country: baseCountry || undefined, city: baseCity.trim() || undefined } : {},
-      relocation:
-        wantsPhysical && relocOpen
-          ? { open: true, regions: relocRegions, countries: relocCountries, cities: relocCities }
-          : { open: false },
-    };
-    return workModes.length === 0 ? null : loc;
+    return buildLocationPreferences({
+      workModes,
+      remoteRegions,
+      remoteCountries,
+      baseCountry,
+      baseCity,
+      relocOpen,
+      relocRegions,
+      relocCountries,
+      relocCities,
+    });
   }
 
   async function submit(e: SubmitEvent) {
@@ -490,6 +503,27 @@
       </div>
     </div>
 
+    <!-- Where you are now. Asked of EVERY user, whatever work formats they accept: it is
+         a fact about the person, not a preference, and it is what the visa-sponsorship and
+         onsite-country checks compare a job against. Pre-filled from the CV when the user
+         has stated nothing, so they confirm rather than retype. -->
+    <div class="flex flex-col gap-1.5">
+      <span class="text-xs font-medium text-muted-foreground">Where you're based</span>
+      <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <select
+          bind:value={baseCountry}
+          aria-label="Base country"
+          class="h-9 rounded-lg border border-input bg-transparent px-3 text-sm transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-input/30"
+        >
+          <option value="">Country…</option>
+          {#each COUNTRY_OPTIONS as opt (opt.value)}
+            <option value={opt.value}>{opt.label}</option>
+          {/each}
+        </select>
+        <Input bind:value={baseCity} aria-label="Base city" placeholder="City" class="w-full" />
+      </div>
+    </div>
+
     {#if workModes.length === 0}
       <span class="text-xs text-muted-foreground">Pick a work format above to set where you can work.</span>
     {/if}
@@ -507,27 +541,8 @@
       </div>
     {/if}
 
-    <!-- Physical presence (base + relocation) — only for On-site / Hybrid. -->
+    <!-- Relocation — only meaningful for someone who would take physical work. -->
     {#if wantsPhysical}
-      <!-- Base location -->
-      <div class="flex flex-col gap-1.5">
-        <span class="text-xs font-medium text-muted-foreground">Where you're based</span>
-        <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <select
-            bind:value={baseCountry}
-            aria-label="Base country"
-            class="h-9 rounded-lg border border-input bg-transparent px-3 text-sm transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-input/30"
-          >
-            <option value="">Country…</option>
-            {#each COUNTRY_OPTIONS as opt (opt.value)}
-              <option value={opt.value}>{opt.label}</option>
-            {/each}
-          </select>
-          <Input bind:value={baseCity} aria-label="Base city" placeholder="City" class="w-full" />
-        </div>
-      </div>
-
-      <!-- Relocation -->
       <div class="flex flex-col gap-2">
         <label class="flex items-center gap-2 text-sm">
           <input type="checkbox" bind:checked={relocOpen} class="size-4 rounded border-input" />

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -221,15 +221,26 @@ export function filtersFromProfile(profile: UserProfile): JobFilters {
     // Relocation targets only count when the user is actually open to relocating — `open`
     // gates the whole relocation contribution (targets and the relocation facet alike).
     const reloc = loc.relocation.open ? loc.relocation : { regions: [], countries: [], cities: [] };
+    // `base` says where the user LIVES; the facets say where they want the WORK. Those
+    // coincide only for someone who accepts physical work — the job has to be commutable
+    // — so base is folded in for them and withheld from everyone else. Seeding a
+    // remote-only candidate's home country as a job-country filter would narrow their
+    // search to the one country they least need the job to be in.
+    //
+    // This gate used to be implicit: the profile form collected `base` from on-site and
+    // hybrid users only, and dropped it on save for everyone else. Now that the form asks
+    // every user where they are, the gate has to be stated here instead.
+    const wantsPhysical = (loc.work_modes ?? []).some((m) => m === 'onsite' || m === 'hybrid');
+    const base = wantsPhysical ? loc.base : {};
     f.facets.work_mode = seed(loc.work_modes ?? []);
     f.facets.regions = seed([...(loc.remote.regions ?? []), ...(reloc.regions ?? [])]);
     f.facets.countries = seed([
       ...(loc.remote.countries ?? []),
-      ...(loc.base.country ? [loc.base.country] : []),
+      ...(base.country ? [base.country] : []),
       ...(reloc.countries ?? []),
     ]);
     f.facets.cities = seed([
-      ...(loc.base.city ? [loc.base.city] : []),
+      ...(base.city ? [base.city] : []),
       ...(reloc.cities ?? []),
     ]);
     if (loc.relocation.open) f.facets.relocation = seed(['supported', 'required']);

--- a/web/src/lib/profileFilters.test.ts
+++ b/web/src/lib/profileFilters.test.ts
@@ -14,6 +14,7 @@ function mkProfile(
     skills,
     excluded_skills: excludedSkills,
     location_preferences: location,
+    derived_location: null,
     cv: null,
     created_at: null,
     updated_at: null,
@@ -102,6 +103,39 @@ describe('filtersFromProfile', () => {
     const p = filtersToParams(f);
     expect(p.getAll('skills')).toEqual(['go']);
     expect(p.getAll('skills_exclude')).toEqual(['php']);
+  });
+
+  // `base` is where the user LIVES, not where they want the work. For someone who
+  // accepts only remote work those are different places, and seeding their home country
+  // as a job-country filter would narrow their search to the one country they least need
+  // the job to be in. The gate used to be implicit — the profile form only ever collected
+  // `base` from on-site/hybrid users — so un-gating that form makes it load-bearing here.
+  it('does not seed countries or cities from base for a remote-only user', () => {
+    const location: LocationPreferences = {
+      work_modes: ['remote'],
+      remote: { regions: ['latam'] },
+      base: { country: 'co', city: 'Manizales' },
+      relocation: { open: false },
+    };
+    const p = filtersToParams(filtersFromProfile(mkProfile(['backend'], ['go'], location)));
+    expect(p.getAll('work_mode')).toEqual(['remote']);
+    expect(p.getAll('regions')).toEqual(['latam']);
+    expect(p.getAll('countries')).toEqual([]);
+    expect(p.getAll('cities')).toEqual([]);
+  });
+
+  // Someone who accepts physical work does need the job near where they are, so for them
+  // the two coincide and the contribution is kept.
+  it('still seeds countries and cities from base for a hybrid user', () => {
+    const location: LocationPreferences = {
+      work_modes: ['hybrid'],
+      remote: { regions: [] },
+      base: { country: 'co', city: 'Manizales' },
+      relocation: { open: false },
+    };
+    const p = filtersToParams(filtersFromProfile(mkProfile(['backend'], ['go'], location)));
+    expect(p.getAll('countries')).toEqual(['co']);
+    expect(p.getAll('cities')).toEqual(['Manizales']);
   });
 
   it('a profile with no location block seeds only category and skills', () => {

--- a/web/src/lib/profileLocation.test.ts
+++ b/web/src/lib/profileLocation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { buildLocationPreferences, type LocationFields } from './profileLocation';
+
+function fields(over: Partial<LocationFields> = {}): LocationFields {
+  return {
+    workModes: [],
+    remoteRegions: [],
+    remoteCountries: [],
+    baseCountry: '',
+    baseCity: '',
+    relocOpen: false,
+    relocRegions: [],
+    relocCountries: [],
+    relocCities: [],
+    ...over,
+  };
+}
+
+describe('buildLocationPreferences', () => {
+  // The regression this module exists for. `base` is asked of every user now, so it can be
+  // the ONLY thing they fill in — and the old emptiness proxy (no work modes → send null)
+  // would throw it away, reproducing the exact data loss this change removes.
+  it('keeps a base stated without any work format', () => {
+    const loc = buildLocationPreferences(fields({ baseCountry: 'co', baseCity: 'Manizales' }));
+    expect(loc).not.toBeNull();
+    expect(loc?.base).toEqual({ country: 'co', city: 'Manizales' });
+    expect(loc?.work_modes).toEqual([]);
+  });
+
+  it('keeps a base stated by a remote-only user', () => {
+    const loc = buildLocationPreferences(fields({ workModes: ['remote'], baseCountry: 'co' }));
+    expect(loc?.base.country).toBe('co');
+  });
+
+  it('still sends null when the user has stated nothing at all', () => {
+    expect(buildLocationPreferences(fields())).toBeNull();
+  });
+
+  it('treats a whitespace-only base as nothing stated', () => {
+    expect(buildLocationPreferences(fields({ baseCity: '   ' }))).toBeNull();
+  });
+
+  // The other gate is unchanged: a sub-form the current work format hides must not save
+  // its lingering draft.
+  it('drops a remote reach drafted before remote was deselected', () => {
+    const loc = buildLocationPreferences(
+      fields({ workModes: ['onsite'], remoteRegions: ['latam'], baseCountry: 'br' }),
+    );
+    expect(loc?.remote).toEqual({});
+  });
+
+  it('drops relocation targets when the user is not open to relocating', () => {
+    const loc = buildLocationPreferences(
+      fields({ workModes: ['onsite'], relocOpen: false, relocCities: ['Berlin'] }),
+    );
+    expect(loc?.relocation).toEqual({ open: false });
+  });
+
+  it('drops relocation targets for a user who takes no physical work', () => {
+    const loc = buildLocationPreferences(
+      fields({ workModes: ['remote'], relocOpen: true, relocCities: ['Berlin'] }),
+    );
+    expect(loc?.relocation).toEqual({ open: false });
+  });
+
+  it('carries the full block for a user who states everything', () => {
+    const loc = buildLocationPreferences(
+      fields({
+        workModes: ['remote', 'onsite'],
+        remoteRegions: ['latam'],
+        baseCountry: 'br',
+        baseCity: 'Florianópolis',
+        relocOpen: true,
+        relocCities: ['Berlin'],
+      }),
+    );
+    expect(loc?.remote).toEqual({ regions: ['latam'], countries: [] });
+    expect(loc?.base).toEqual({ country: 'br', city: 'Florianópolis' });
+    expect(loc?.relocation).toEqual({ open: true, regions: [], countries: [], cities: ['Berlin'] });
+  });
+});

--- a/web/src/lib/profileLocation.ts
+++ b/web/src/lib/profileLocation.ts
@@ -1,0 +1,52 @@
+import type { LocationPreferences } from './types';
+
+/** The flat form fields the profile editor holds while the user edits the location block. */
+export interface LocationFields {
+  workModes: string[];
+  remoteRegions: string[];
+  remoteCountries: string[];
+  baseCountry: string;
+  baseCity: string;
+  relocOpen: boolean;
+  relocRegions: string[];
+  relocCountries: string[];
+  relocCities: string[];
+}
+
+/**
+ * Reassemble the editor's flat fields into the saved location block, or null when the user
+ * has stated nothing at all.
+ *
+ * Two gates, and the difference between them is the whole point:
+ *
+ * - The "where would you take work" sub-forms (remote reach, relocation targets) ARE gated
+ *   on the accepted work formats. A hidden sub-form's lingering draft is not saved, so
+ *   toggling a format off and saving does not silently keep its targets.
+ * - `base` is NOT gated. Where someone lives is a fact about them, not a preference
+ *   conditional on the arrangements they accept, and it matters most for a remote worker:
+ *   it governs their right to work, their taxation, and their overlap with a team.
+ *
+ * The emptiness check has to respect that second point. It used to be `workModes.length
+ * === 0`, which was a correct proxy for "the user stated nothing" only while every
+ * geographic field was hidden behind a work format. With `base` asked unconditionally, that
+ * proxy silently discards the base of anyone who fills it in without picking a format —
+ * the same data loss this change exists to remove, just through a different door.
+ */
+export function buildLocationPreferences(f: LocationFields): LocationPreferences | null {
+  const wantsRemote = f.workModes.includes('remote');
+  const wantsPhysical = f.workModes.includes('onsite') || f.workModes.includes('hybrid');
+  const baseCountry = f.baseCountry.trim();
+  const baseCity = f.baseCity.trim();
+
+  if (f.workModes.length === 0 && !baseCountry && !baseCity) return null;
+
+  return {
+    work_modes: f.workModes,
+    remote: wantsRemote ? { regions: f.remoteRegions, countries: f.remoteCountries } : {},
+    base: { country: baseCountry || undefined, city: baseCity || undefined },
+    relocation:
+      wantsPhysical && f.relocOpen
+        ? { open: true, regions: f.relocRegions, countries: f.relocCountries, cities: f.relocCities }
+        : { open: false },
+  };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -700,12 +700,26 @@ export interface LocationPreferences {
   relocation: LocationRelocation;
 }
 
+/** Where the CV says the candidate IS, resolved by the location dictionary. Read-only:
+ *  it is produced by the CV derivation alone and no profile write can set it. Deliberately
+ *  a sibling of location_preferences rather than part of it — that block is what the user
+ *  ASSERTED, this is what was DERIVED for them, and only the former may be saved back. */
+export interface DerivedLocation {
+  countries: string[];
+  regions: string[];
+  cities: string[];
+}
+
 export interface UserProfile {
   specializations: string[];
   skills: string[];
   /** Canonical skill tokens the user wants to avoid; seeded into the jobs filter's skills exclude set by "Apply my profile". Empty when the user excludes nothing. */
   excluded_skills: string[];
   location_preferences: LocationPreferences | null;
+  /** Null when nothing was derived (no CV, no current structure, or a location the
+   *  dictionary could not resolve). Used to pre-fill "where you're based" for a user who
+   *  has stated no base, so they confirm a fact already on their CV instead of retyping it. */
+  derived_location: DerivedLocation | null;
   /** The caller's structured CV without its contact fields — served beside the profile so
    *  one read covers both what the user wants and what they have done. Null when no current
    *  structure exists. Contacts come from GET /me/resume instead (the profile page's contact


### PR DESCRIPTION
## Why

`users.resume_structured->>'location'` was a raw free-text line the LLM copied off the CV, so a candidate's country could not be filtered, faceted, or matched against a job's geography — while jobs have carried derived `countries`/`regions` since `0001`.

The profile was meant to be the other half and was quietly broken: `ProfileForm` gated "where you're based" on accepting on-site or hybrid work and **discarded it on save** for everyone else. Measured on production 2026-08-01: of 145 profiles only **27** carry a base country, and 80 users have a location on their CV and no base at all. The two hard constraints that read that field — no-visa-sponsorship in a country you are not in, and on-site abroad — were therefore inert for **81% of profiles**. The logic was right; the input was thrown away.

## The rule

`location.ParseResidence` is `Parse` minus the two things true of a **job** and false of a **person**:

- the **work-mode hint** — a preference, which already lives in `location_preferences.work_modes`;
- the **`global` region** — a job may be open anywhere, a person never is.

The `global` exclusion is stated against the *value*, not the mechanism, because it arrives by two independent paths: the bare-remote fallback in `Parse` **and** the dictionary's own `worldwide`/`anywhere` → `global` entries. A rule phrased against the fallback alone would let `REMOTE · WORLDWIDE` through — 4 of 100 live rows hit this.

It is a distinct type rather than a flag on `Parse`. The failure being designed against is one meaning used where the other was expected, and a flag can be defaulted wrong at a call site.

## Storage

Migration `0067` adds three **nullable** `text[]` columns to `users`. The divergence from `jobs.countries` (`NOT NULL DEFAULT '{}'`) is deliberate — a user has a third state a job does not:

- `NULL` — not known (no CV, no current structure, or a structure stating no location)
- `'{}'` — the CV stated a place the curated dictionary could not resolve

Collapsing them would confuse "we don't know" with "nowhere", and would throw away a permanent live coverage metric (`count(*) WHERE resume_countries = '{}'`).

Written in the **same statement** as the structure, so the existing monotonic guard covers both and a stored geography can never describe a different CV than the structure beside it.

## Coupled fixes

Un-gating `base` surfaced the same latent bug twice more, and both ship here:

- `filtersFromProfile` folded `base.country` into the seeded **job-country** facet — a remote-only candidate in Colombia would have had their search silently filtered to Colombia.
- `buildLocation` treated "no work modes" as "nothing stated" — throwing the base away again for anyone who filled in only that.

Block assembly moved to `profileLocation.ts` so both rules are unit-tested.

## Dictionary

25 ISO codes carried a region but no **name**, so `Honduras` and `Rwanda` resolved to nothing — and `Laos` resolved to an unrelated *Vietnamese* city via GeoNames alternate names. Names added, never codes (a code would collide with the US subdivision table: `Baton Rouge, LA`). `palestine` is withheld for the Texas city, which turned out to match an existing unwritten policy — `georgia` is absent for the same reason, and `Tbilisi, Georgia` resolves through the *city*.

`TestEveryPlaceableCountryHasAName` closes the invariant so the two maps cannot drift apart again.

## Verification

- Go: **120 packages ok**, `vet` and `gofmt` clean
- Integration (real Postgres, `-tags=integration`): 5 new tests — the NULL/`'{}'` round trip, the staleness selection, the monotonic guard on both write paths
- Web: **712 tests**, `svelte-check` 0 errors
- The SQL guards and the two regression rules were **mutation-checked** (weakened, watched the test fail, restored)

Coverage over the 100 production CV locations: **91% → 92%** resolving to a country. The remaining gap is tokenization (`·` not a separator, the LinkedIn `Greater X` prefix, non-US subdivisions), not the country list — recorded in `design.md` along with the measurement that 133 of 252 ISO countries carry a region.

## Deploy order

`0067` is expansive and **must be applied before this deploy** — the new binary reads the columns on every profile fetch, so an unapplied column is a `42703` on a hot path.

No Meilisearch reindex and no `cmd/backfill-derive` run: candidate geography is a Postgres column, not a search facet, and the dictionary change is additive (existing jobs pick the new names up on the next scheduled re-derive).

## Not in scope

The structured résumé still has **no reconciler** — a failed background extraction leaves it NULL until re-upload, which is why 37 production users need a manual `backfill-resume-structured` run. The derived geography *does* get one, so the artefact now outlives the thing it derives from. Recorded, not resolved.