### PR TITLE
feat(analytics): track the account-side funnel

### DIFF
--- a/openspec/changes/track-product-funnel-events/.openspec.yaml
+++ b/openspec/changes/track-product-funnel-events/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/track-product-funnel-events/design.md
+++ b/openspec/changes/track-product-funnel-events/design.md
@@ -1,0 +1,128 @@
+## Context
+
+`web/src/lib/analytics.ts` already provides everything needed: a guarded
+`track(event, props)` that no-ops until PostHog initializes, plus identity
+binding by user id. The five existing events sit inline in `JobsView.svelte` and
+`JobView.svelte`, so the established pattern is "call `track()` at the UI action
+site", not "wrap the API client".
+
+Three things about the current code shape the decisions below.
+
+**OAuth sign-up is invisible to the browser.** Password registration goes through
+`api.register()` (`lib/api.ts:584`), which the client obviously observes. OAuth
+is a full-page redirect through `/api/v1/auth/oauth/:provider/start`, so the app
+comes back with a session and no way to tell a first-ever sign-in from the
+hundredth. The server knows; the client does not.
+
+**A failure reason arrives as prose.** The CV upload rejection the rageclicks
+land on is `errResumeNoText` — a full sentence rendered to the user. Sending it
+as an event property would make the metric hostage to copy edits.
+
+**`job_track` already covers one path into `applications`, and only one.** It
+fires in `confirmApplied()` after `markJobApplied`. Production shows 79 of those
+events against 240 rows in `applications`, so most applications are created
+elsewhere — mail linking in the inbox, the tracking board, and possibly the
+extension.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the account-side funnel measurable: sign-up, CV upload (including
+  failure), application creation, the two credit-charged features, and assistant
+  usage.
+- Keep every new event PII-free and safe under the existing consent gate.
+- Keep failure reasons stable across copy changes.
+
+**Non-Goals:**
+
+- Any backend change, new endpoint, or schema change.
+- Charging for anything, or recording assistant token spend — that is
+  `meter-the-assistant-turn`, which writes to Postgres for billing. This change
+  records that a turn happened, for product analytics.
+- Identifying the specific OAuth provider (see Decisions).
+- Rewriting or retiring the five existing events.
+
+## Decisions
+
+**Events fire at the UI action site, not inside the API client.** Follows the
+existing convention and keeps `lib/api.ts` a pure transport. The alternative —
+instrumenting the client — would catch every caller automatically but would tie
+analytics to request plumbing and fire on retries and prefetches.
+
+**Sign-up is detected in exactly one place: identity binding.** When a user is
+identified and `User.created_at` falls inside a short window before now, the
+account is new. `User.created_at` is already on the wire (`lib/types.ts:199`), so
+no backend work is needed. Because a reload inside that window would fire the
+event twice, a `localStorage` marker keyed by user id makes it once-per-account.
+
+Tracking additionally at the `api.register()` call site was the first plan and is
+wrong: a password registration produces a fresh account with `has_password: true`,
+so it would satisfy the identify path as well and count twice. One detector,
+covering both registration routes, is both simpler and correct.
+
+The method property is therefore `'password' | 'oauth'`, derived from
+`has_password` — not the provider name. Recording which provider was used would
+require the server to say so on the callback, which is backend work this change
+excludes. Coarse method is enough for an activation funnel; provider breakdown can
+be added later from the server side.
+
+Alternative considered and rejected: firing `signup` on every first identify of a
+browser. That counts a returning user on a new device as a sign-up and inflates
+the top of the funnel permanently.
+
+**Failure reasons are a closed set produced by a pure function.** A mapper turns
+the server's message into one of a few bounded codes, with an explicit catch-all
+so an unrecognised failure still counts rather than vanishing. The function is
+plain TypeScript with no framework dependency, which is what the project's vitest
+setup can actually test — Svelte components have no test runner here.
+
+**`application_created` is dropped: the browser cannot see the paths that would
+justify it.** The plan was an event covering every route into `applications`, to
+close the 2,621-clicks against 240-rows gap. Tracing it settled the question
+differently. `markJobApplied` in `JobView.svelte` is the *only* client path;
+the other writers are server-side — `internal/handler/inbox_linking.go` and
+`internal/handler/gmail.go`, which create an application when an email is linked
+or Gmail syncs. A front-end event would therefore have duplicated the existing
+`job_track` exactly and still missed every row it was meant to explain.
+
+So the gap has an answer, and it is not an instrumentation gap in the browser:
+applications are created outside the browser, by mail. Measuring that belongs to
+server-side analytics and is deliberately not in this change.
+
+**Everything else is a single `track()` at the action.** `match_run` and
+`tailor_run` fire when the user starts the analysis or the tailoring session, not
+when it completes — a run that fails or times out still consumed intent and, in
+the tailor case, credits. `assistant_message` fires on submit, carrying no text.
+
+## Risks / Trade-offs
+
+**Inferred OAuth sign-up can miss or double-count.** → The `localStorage` marker
+bounds double-counting to one per browser per account; the window is generous
+enough to survive a slow first load. A user who clears storage and returns inside
+the window could re-fire once — acceptable for a funnel, and the exactness lives
+on the password path.
+
+**Two events on one path (`job_track` + `application_created`).** → Documented
+above and visible in the code; the alternative loses a running production series.
+
+**Component call sites are not unit-tested.** → The project has no Svelte test
+runner, so the testable surface is the pure reason-mapper and the sign-up freshness
+predicate. The rest is verified by observing the events arrive in PostHog after
+deploy, the same way the existing five were.
+
+**Event volume.** → Six new event types against a 1M/month free tier currently
+consuming roughly 70k events per 17 days. No practical risk.
+
+## Migration Plan
+
+Frontend-only, no migration. The events are additive; PostHog needs no schema.
+Rollback is reverting the commit. The three funnels are configured in the PostHog
+UI afterwards and depend only on event names, so they can be built once data
+starts arriving.
+
+## Open Questions
+
+Which client paths besides `confirmApplied()` create an application — the inbox
+link action and the tracking board are the known candidates, and the exact set
+gets pinned down in the task that implements `application_created`.

--- a/openspec/changes/track-product-funnel-events/proposal.md
+++ b/openspec/changes/track-product-funnel-events/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+Analytics stops at the catalogue door. The five events we emit — `search`,
+`job_view`, `job_apply`, `job_save`, `job_track` — all fire in `JobsView.svelte`
+and `JobView.svelte`, so everything a signed-in user does is invisible: signing
+up, uploading a CV, running a match, tailoring, talking to the assistant. The
+single number that matters most for the product — 169 of 400 users uploaded a CV
+— can only be counted by querying Postgres by hand.
+
+Seventeen days of production data show what that blindness costs. There are 2,621
+`job_apply` clicks against 240 rows in `applications`, and nothing explains the
+gap. There are 354 rageclicks, three of them landing on the text of
+`errResumeNoText` (`internal/handler/resume.go:135`) — users hammering the error
+that says their PDF is a scan — and no event records how often that upload fails
+or why. Every question about activation currently ends in a hand-written SQL
+query, which means it is asked once and never tracked.
+
+## What Changes
+
+- The app emits `signup` when an account is created, carrying the method used
+  (OAuth provider or password) and no PII.
+- The app emits `cv_upload` on every CV upload attempt, carrying whether it
+  succeeded and, on failure, a coarse reason — so the scan-PDF dead end becomes a
+  number instead of a guess.
+- The app emits `match_run` and `tailor_run` when those credit-charged features
+  are invoked, so usage of the paid surfaces is known.
+- The app emits `assistant_message` when a user sends a turn to the assistant.
+- All five follow the existing rules: fired through the one analytics module,
+  safe no-ops when PostHog is inert or consent is not granted, and free of PII.
+
+Not in scope: charging for anything, changing any user-visible behaviour, and
+recording assistant token cost — that last one is `meter-the-assistant-turn`,
+which writes spend to Postgres for billing. This change records *that a turn
+happened* for product analytics; the two do not overlap.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `product-analytics`: the "Explicit funnel events" requirement currently names
+  five catalogue events as the core funnel. It changes to also require the five
+  account-side events above, so the funnel spans the whole product rather than
+  stopping at the job list.
+
+## Impact
+
+- `web/src/lib/analytics.ts` — no API change; `track()` already accepts an
+  arbitrary event name and props.
+- The call sites: the sign-up/OAuth completion path, the CV upload component,
+  the application-tracking action, the match and tailor entry points, and the
+  assistant composer.
+- No backend change, no new environment variable, no schema change.
+- PostHog dashboards gain two funnels: activation (visit → `signup` →
+  `cv_upload` → `match_run`) and SEO entry (landing on `/jobs/:slug` →
+  `job_view` → `signup`). Those are configured in PostHog, not in code. An
+  application funnel was intended as a third; tracing the write paths showed it
+  cannot be built from the browser — see the design note.

--- a/openspec/changes/track-product-funnel-events/specs/product-analytics/spec.md
+++ b/openspec/changes/track-product-funnel-events/specs/product-analytics/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Explicit funnel events
+
+The app SHALL emit explicit events for the core funnel — `search`, `job_view`,
+`job_apply`, `job_save`, `job_track`, `signup`, `cv_upload`, `match_run`,
+`tailor_run`, `assistant_message` — through a single analytics module, fired on
+the UI action regardless of authentication state. A no-op SHALL be safe when PostHog is uninitialized. Event properties
+SHALL carry no personal data: no email, no name, no file name, no résumé or
+message text. A failure reason SHALL be reported as a bounded code drawn from a
+closed set, never as a raw error message, so that a reworded error does not
+silently split a metric into two.
+
+#### Scenario: Anonymous user applies
+
+- **WHEN** an unauthenticated user clicks Apply on a job
+- **THEN** a `job_apply` event is captured with the job slug and source
+
+#### Scenario: PostHog uninitialized
+
+- **WHEN** a tracked action fires while PostHog is not initialized
+- **THEN** the analytics call is a safe no-op and does not throw
+
+#### Scenario: Account created
+
+- **WHEN** a visitor completes registration, by OAuth provider or by password
+- **THEN** a `signup` event is captured carrying the method used and no PII
+
+#### Scenario: CV uploaded successfully
+
+- **WHEN** a user uploads a CV and the server accepts it
+- **THEN** a `cv_upload` event is captured marked as successful, with no file
+  name and no résumé text
+
+#### Scenario: CV upload rejected
+
+- **WHEN** a CV upload is rejected by the server, for example because the PDF
+  carries no extractable text
+- **THEN** a `cv_upload` event is captured marked as failed, carrying a bounded
+  reason code rather than the server's message text
+
+#### Scenario: Unrecognized failure
+
+- **WHEN** an upload fails with a message the reason mapping does not recognise
+- **THEN** the event is still captured with a catch-all reason code, so a failure
+  is never silently dropped from the count
+
+#### Scenario: Credit-charged feature invoked
+
+- **WHEN** a user starts a job-match analysis or a CV tailoring session
+- **THEN** a `match_run` or `tailor_run` event is captured respectively
+
+#### Scenario: Assistant turn sent
+
+- **WHEN** a user sends a message to the in-app assistant
+- **THEN** an `assistant_message` event is captured carrying no message text

--- a/openspec/changes/track-product-funnel-events/tasks.md
+++ b/openspec/changes/track-product-funnel-events/tasks.md
@@ -1,0 +1,55 @@
+## 1. Pure helpers (test-first)
+
+- [x] 1.1 Add a CV-upload failure-reason mapper in `web/src/lib/analytics.ts` (or
+  a sibling pure module): server message → bounded reason code, with a catch-all
+  for unrecognised messages. Cover the `errResumeNoText` scan-PDF message, at
+  least one other rejection, and the unknown case in `analytics.test.ts`.
+- [x] 1.2 Add a sign-up freshness predicate: given `User.created_at`, a clock and
+  a window, decide whether the account was just created. Test the boundaries
+  (inside, outside, null `created_at`).
+
+## 2. Sign-up
+
+- [x] 2.1 Add a once-per-account guard: a `localStorage` marker keyed by user id
+  that claims the sign-up exactly once, tested for the repeat call and for storage
+  being unavailable.
+- [x] 2.2 Track `signup` on identity binding when the freshness predicate says the
+  account is new, with `method` derived from `has_password`. One detector covers
+  both registration routes — see the design note on why the `api.register()` call
+  site must NOT also track.
+
+## 3. CV upload
+
+- [x] 3.1 Track `cv_upload` on success at the upload call site, carrying no file
+  name and no résumé text.
+- [x] 3.2 Track `cv_upload` on rejection, passing the server message through the
+  reason mapper from 1.1.
+
+## 4. Applications
+
+- [x] 4.1 Find every client path that creates an application (start from
+  `confirmApplied()` in `JobView.svelte`; check the inbox link action and the
+  tracking board) and list them in the change before wiring.
+  **Result: `markJobApplied` in `JobView.svelte` is the only one.** The other
+  writers are server-side (`internal/handler/inbox_linking.go`,
+  `internal/handler/gmail.go`), reached by mail linking and Gmail sync.
+- [x] 4.2 ~~Track `application_created`~~ — **dropped, see design.** With one
+  client path already carrying `job_track`, the event would have been a pure
+  duplicate and would still have missed every server-created row it was meant to
+  explain. The 2,621-vs-240 gap is answered instead: applications are created
+  outside the browser.
+
+## 5. Credit-charged features and assistant
+
+- [x] 5.1 Track `match_run` when a job-match analysis is started.
+- [x] 5.2 Track `tailor_run` when a tailoring session is started.
+- [x] 5.3 Track `assistant_message` on composer submit in
+  `lib/assistant/AssistantChat.svelte`, carrying no message text.
+
+## 6. Verify
+
+- [x] 6.1 Run the web checks (`pnpm test`, `svelte-check`) and confirm the pure
+  helpers are covered.
+- [ ] 6.2 After deploy, confirm each new event arrives in PostHog and carries no
+  PII, then build the two funnels (activation, SEO entry) in the PostHog UI. The
+  application funnel is not buildable from the browser — see 4.2.

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { initTrackers, isPrivateRoute, track, isFeatureEnabled } from './analytics';
+import {
+  claimSignupOnce,
+  cvUploadReason,
+  initTrackers,
+  isFreshAccount,
+  isPrivateRoute,
+  track,
+  isFeatureEnabled,
+} from './analytics';
 
 // These tests exercise the pure/guarded surface — no PostHog init happens (the
 // config below carries no key), so the module is in its uninitialized state
@@ -32,6 +40,98 @@ describe('isFeatureEnabled (uninitialized)', () => {
   it('returns the caller-supplied fallback when PostHog is inert', () => {
     expect(isFeatureEnabled('some-flag', true)).toBe(true);
     expect(isFeatureEnabled('other-flag', false)).toBe(false);
+  });
+});
+
+describe('cvUploadReason', () => {
+  // The server's rejection is prose shown to the user, so the mapper exists to keep
+  // the metric stable when that copy is reworded — the codes are what PostHog sees.
+  it('recognizes the scan-PDF rejection', () => {
+    expect(
+      cvUploadReason(
+        "couldn't read any text from this PDF — it looks like a scan or image. Upload a text-based PDF, or paste your résumé text instead.",
+      ),
+    ).toBe('no_text');
+  });
+
+  it('recognizes the other upload rejections', () => {
+    expect(cvUploadReason('missing resume file')).toBe('missing_file');
+    expect(cvUploadReason('cannot read resume file')).toBe('unreadable');
+    expect(cvUploadReason('invalid request body')).toBe('bad_request');
+  });
+
+  it('matches regardless of case and surrounding whitespace', () => {
+    expect(cvUploadReason('  Missing Resume File  ')).toBe('missing_file');
+  });
+
+  it('falls back to a catch-all so a failure is never dropped from the count', () => {
+    expect(cvUploadReason('request entity too large')).toBe('other');
+    expect(cvUploadReason('')).toBe('other');
+  });
+});
+
+describe('isFreshAccount', () => {
+  // OAuth sign-up is a full-page redirect, so the browser cannot tell a first-ever
+  // sign-in from the hundredth; a just-created account is the only signal it has.
+  const now = Date.parse('2026-08-01T12:00:00Z');
+  const windowMs = 2 * 60 * 1000;
+
+  it('treats an account created inside the window as fresh', () => {
+    expect(isFreshAccount('2026-08-01T11:59:00Z', now, windowMs)).toBe(true);
+  });
+
+  it('treats an older account as not fresh', () => {
+    expect(isFreshAccount('2026-08-01T11:50:00Z', now, windowMs)).toBe(false);
+  });
+
+  it('is exclusive at the window edge', () => {
+    expect(isFreshAccount('2026-08-01T11:58:00Z', now, windowMs)).toBe(false);
+  });
+
+  it('tolerates a clock skew that puts creation slightly in the future', () => {
+    expect(isFreshAccount('2026-08-01T12:00:30Z', now, windowMs)).toBe(true);
+  });
+
+  it('treats a missing or unparseable timestamp as not fresh', () => {
+    expect(isFreshAccount(null, now, windowMs)).toBe(false);
+    expect(isFreshAccount('not a date', now, windowMs)).toBe(false);
+  });
+});
+
+describe('claimSignupOnce', () => {
+  // A reload inside the freshness window would re-fire `signup` for the same
+  // account, so the claim has to be idempotent per user.
+  function memoryStorage() {
+    const data = new Map<string, string>();
+    return {
+      getItem: (k: string) => data.get(k) ?? null,
+      setItem: (k: string, v: string) => void data.set(k, v),
+    };
+  }
+
+  it('claims once and refuses every repeat for the same account', () => {
+    const store = memoryStorage();
+    expect(claimSignupOnce(42, store)).toBe(true);
+    expect(claimSignupOnce(42, store)).toBe(false);
+    expect(claimSignupOnce(42, store)).toBe(false);
+  });
+
+  it('claims separately per account', () => {
+    const store = memoryStorage();
+    expect(claimSignupOnce(1, store)).toBe(true);
+    expect(claimSignupOnce(2, store)).toBe(true);
+  });
+
+  it('refuses when storage is unavailable, rather than risking a double count', () => {
+    const broken = {
+      getItem: () => {
+        throw new Error('denied');
+      },
+      setItem: () => {
+        throw new Error('denied');
+      },
+    };
+    expect(claimSignupOnce(7, broken)).toBe(false);
   });
 });
 

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -112,6 +112,85 @@ export function isPrivateRoute(path: string): boolean {
   return path === '/my' || path.startsWith('/my/');
 }
 
+/** Why a CV upload was rejected, as a bounded code. `other` is deliberate: an
+ *  unrecognized failure still has to reach the funnel, and dropping it would make
+ *  the success rate read better than it is. */
+export type CvUploadReason = 'no_text' | 'missing_file' | 'unreadable' | 'bad_request' | 'other';
+
+// The server rejects with prose meant for the user, so matching on it directly would
+// tie the metric to copy — a reworded sentence would silently split one failure into
+// two. Substring matching (not equality) keeps the mapping working when a message
+// gains a suffix; the fragments are the stable part of each rejection.
+const CV_UPLOAD_REASONS: ReadonlyArray<readonly [string, CvUploadReason]> = [
+  ["couldn't read any text from this pdf", 'no_text'],
+  ['missing resume file', 'missing_file'],
+  ['cannot read resume file', 'unreadable'],
+  ['invalid request body', 'bad_request'],
+];
+
+/** Map a server rejection message to a bounded reason code for `cv_upload`. */
+export function cvUploadReason(message: string): CvUploadReason {
+  const text = message.trim().toLowerCase();
+  for (const [fragment, reason] of CV_UPLOAD_REASONS) {
+    if (text.includes(fragment)) return reason;
+  }
+  return 'other';
+}
+
+/** Whether an account was created just now, within `windowMs` of `now`.
+ *
+ *  OAuth sign-up is a full-page redirect, so the app comes back holding a session
+ *  with no way to tell a first-ever sign-in from the hundredth — a freshly stamped
+ *  `created_at` is the only signal the browser has. Creation slightly in the future
+ *  counts as fresh: that is clock skew between server and browser, not an old
+ *  account. An absent or unparseable stamp is treated as not fresh, so a missing
+ *  value can never manufacture a sign-up. */
+export function isFreshAccount(createdAt: string | null, now: number, windowMs: number): boolean {
+  if (!createdAt) return false;
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) return false;
+  return created > now - windowMs;
+}
+
+/** The slice of Storage the sign-up claim needs, so a test can hand it a map. */
+type SignupStore = Pick<Storage, 'getItem' | 'setItem'>;
+
+// How recently an account must have been created to read as a sign-up rather than a
+// returning sign-in. Wide enough to survive a slow first load and a redirect back
+// from an OAuth provider; far short of a session.
+const SIGNUP_WINDOW_MS = 2 * 60 * 1000;
+
+/** Claim the single `signup` event for an account: true exactly once, false on
+ *  every repeat. A storage failure also returns false — a browser that refuses
+ *  storage cannot be deduplicated, and inflating sign-ups is worse than missing
+ *  a few. */
+export function claimSignupOnce(userId: number, store: SignupStore): boolean {
+  const key = `fh:signup:${userId}`;
+  try {
+    if (store.getItem(key) !== null) return false;
+    store.setItem(key, '1');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Capture `signup` when identity binds to an account that was just created.
+ *
+ *  This is the ONLY sign-up detector, and it deliberately covers both routes into
+ *  an account. Tracking at the password-registration call site as well would count
+ *  that account twice: it arrives here fresh too, just with `has_password` set. */
+export function trackSignupIfNew(user: {
+  id: number;
+  created_at: string | null;
+  has_password: boolean;
+}): void {
+  if (!isFreshAccount(user.created_at, Date.now(), SIGNUP_WINDOW_MS)) return;
+  if (typeof localStorage === 'undefined') return;
+  if (!claimSignupOnce(user.id, localStorage)) return;
+  track('signup', { method: user.has_password ? 'password' : 'oauth' });
+}
+
 /** Capture an explicit funnel event. No-op until the SDK has loaded. */
 export function track(event: string, props?: Record<string, unknown>): void {
   ph?.capture(event, props);

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -10,6 +10,7 @@
     suggestFollowUps,
     SessionNotFound,
   } from '$lib/assistant/api';
+  import { track } from '$lib/analytics';
   import { forDisplay, shouldRequest } from '$lib/assistant/followups';
   import { openRehearsal, sendTurn, startAutopilot, type Turn } from '$lib/assistant/client';
   import { initChat, reduceTurnEvent, type ChatState } from '$lib/assistant/chat';
@@ -544,6 +545,9 @@
   function submitText(raw: string) {
     const text = raw.trim();
     if (!text || phase !== 'ready' || switching || !activeId) return;
+    // Counted once per message the user sends, queued or dispatched — never the text
+    // itself. This measures usage only; what a turn costs is recorded server-side.
+    track('assistant_message');
     draft = '';
     if (turnActive || queue.length > 0) {
       enqueue(text);

--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
   import { RefreshCw, FileText, Check, Loader, TriangleAlert } from '@lucide/svelte';
   import { api } from '$lib/api';
+  import { track } from '$lib/analytics';
   import { isAuthenticated } from '$lib/auth.svelte';
   import {
     verdictTone,
@@ -113,6 +114,10 @@
 
   function start() {
     stop();
+    // Tracked at the start, not on `final`: the run costs a credit the moment it
+    // begins, and an analysis that stalls or times out is exactly the one worth
+    // seeing in the funnel.
+    track('match_run', { slug: job.public_slug });
     stream = initMatchStream();
     streaming = true;
     showThinking = true;

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ArrowUp, Check, X } from '@lucide/svelte';
   import { api, ApiError, RESUME_MAX_MB } from '$lib/api';
+  import { cvUploadReason, track } from '$lib/analytics';
   import {
     CATEGORY_OPTIONS,
     COUNTRY_OPTIONS,
@@ -142,6 +143,7 @@
     resumeNote = null;
     try {
       const cv = await api.extractResumeProfile(file);
+      track('cv_upload', { ok: true, origin: 'profile' });
       onCvUploaded?.();
 
       const beforeSkills = skills.length;
@@ -172,6 +174,13 @@
       else resumeNote = 'Everything from your CV was already listed.';
     } catch (err) {
       resumeError = err instanceof ApiError ? err.message : 'Could not read the CV. Please try again.';
+      // The reason goes out as a bounded code, never the message itself: the copy is
+      // written for the user and rewording it must not split the metric in two.
+      track('cv_upload', {
+        ok: false,
+        origin: 'profile',
+        reason: err instanceof ApiError ? cvUploadReason(err.message) : 'other',
+      });
     } finally {
       resumeBusy = false;
     }

--- a/web/src/lib/components/onboarding/OnboardingWizard.svelte
+++ b/web/src/lib/components/onboarding/OnboardingWizard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ArrowLeft, ArrowRight, FileUp, LoaderCircle, X } from '@lucide/svelte';
   import { api, ApiError, RESUME_MAX_MB } from '$lib/api';
+  import { cvUploadReason, track } from '$lib/analytics';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import {
@@ -84,6 +85,7 @@
     cvNote = null;
     try {
       const cv = await api.extractResumeProfile(file);
+      track('cv_upload', { ok: true, origin: 'onboarding' });
       if (gen !== cvGen) return; // superseded by another pick or a wizard reset
       const resolved = cv.categories.length > 0 || !!cv.seniority || cv.skills.length > 0;
       // Pre-fill the fields the dictionaries resolved and stay on step 1, so the user
@@ -101,6 +103,14 @@
       cvState = 'idle';
       cvNote = resolved ? 'Filled in what we found — review below.' : 'Couldn’t read details from that CV — pick below.';
     } catch (err) {
+      // Tracked before the supersede guard: the upload did fail, and dropping it
+      // because the user has since picked another file would understate the failure
+      // rate exactly where it is worst.
+      track('cv_upload', {
+        ok: false,
+        origin: 'onboarding',
+        reason: err instanceof ApiError ? cvUploadReason(err.message) : 'other',
+      });
       if (gen !== cvGen) return;
       cvState = 'error';
       cvError = err instanceof ApiError ? err.message : 'Could not read the CV. Please try again.';

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
     syncReplayForRoute,
     identifyUser,
     resetIdentity,
+    trackSignupIfNew,
   } from '$lib/analytics';
   import TopBar from '$lib/components/TopBar.svelte';
   import EmailVerificationBanner from '$lib/components/EmailVerificationBanner.svelte';
@@ -64,8 +65,14 @@
     const id = page.data.user?.id ?? null;
     if (id === lastIdentified) return;
     lastIdentified = id;
-    if (page.data.user) identifyUser(page.data.user);
-    else resetIdentity();
+    if (page.data.user) {
+      identifyUser(page.data.user);
+      // Identity binding is the only place a sign-up is visible: OAuth returns
+      // through a full-page redirect, so the app cannot tell a first-ever sign-in
+      // from any other. A just-created account is the signal; the call itself is
+      // idempotent per account.
+      trackSignupIfNew(page.data.user);
+    } else resetIdentity();
   });
 </script>
 

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -15,6 +15,7 @@
   import { page } from '$app/state';
   import { ZoomIn, ZoomOut, Download, Menu, PanelLeftClose, PanelLeftOpen } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
+  import { track } from '$lib/analytics';
   import AssistantChat from '$lib/assistant/AssistantChat.svelte';
   import ArtifactPanel from '$lib/tailor/ArtifactPanel.svelte';
   import CvHtmlPreview from '$lib/tailor/CvHtmlPreview.svelte';
@@ -224,6 +225,10 @@
       } else {
         // Bootstrap: reach the tailored CV for this vacancy (the backend returns the existing
         // one when there is one) and the conversation bound to it.
+        // Only the bootstrap is tracked as a run: it is the path that mints a tailored
+        // CV and spends credits. Re-opening an existing one (startTailorSession above)
+        // costs nothing and would inflate the count on every revisit.
+        track('tailor_run', { slug });
         const [j, tailor] = await Promise.all([api.getJob(slug), api.tailorCv(slug)]);
         job = j;
         cvId = tailor.tailor_cv_id;


### PR DESCRIPTION
## Why

Analytics stopped at the catalogue door. The five events we had — `search`, `job_view`, `job_apply`, `job_save`, `job_track` — all fire in `JobsView.svelte` and `JobView.svelte`, so everything a signed-in user does was invisible: signing up, uploading a CV, running a match, tailoring, talking to the assistant. The number that matters most for the product (how many registered users get as far as a CV) could only be counted by querying Postgres by hand.

Seventeen days of production data made the cost concrete: 354 rageclicks, three of them landing on the text of `errResumeNoText` — users hammering the error that says their PDF is a scan — with no event recording how often that upload fails or why.

## What this adds

| Event | Where | Properties |
|---|---|---|
| `signup` | identity binding, `+layout.svelte` | `method: password\|oauth` |
| `cv_upload` | `ProfileForm`, `OnboardingWizard` | `ok`, `origin`, bounded `reason` |
| `match_run` | stream start, `MatchAnalysisFull` | `slug` |
| `tailor_run` | bootstrap, `/tailor/[slug]` | `slug` |
| `assistant_message` | composer submit, `AssistantChat` | none — no message text |

All go through the existing guarded `track()`, carry no PII, and stay inert when PostHog is (no key, or consent not granted).

## Two decisions that changed while wiring

**Sign-up is detected in one place, not two.** The plan was to track at the `api.register()` call site *and* on identify. That double-counts: a password registration arrives at identify freshly created too. One detector covers both routes; OAuth returns through a full-page redirect and a just-created `created_at` is the only signal the browser has, deduplicated per account in `localStorage`. The method stays coarse because the provider is not on the wire.

**`application_created` was dropped.** It was meant to explain the gap between 2,621 apply clicks and 240 rows in `applications`. Tracing the write paths settled it differently: `markJobApplied` is the *only* client path and it already carries `job_track` — the other writers are server-side (`internal/handler/inbox_linking.go`, `internal/handler/gmail.go`). The event would have duplicated `job_track` exactly and still missed every row it was for. The gap has an answer instead: applications are created outside the browser, by mail. Measuring that belongs to server-side analytics.

## Notes

- CV upload failures report a bounded code (`no_text`, `missing_file`, `unreadable`, `bad_request`, `other`) rather than the server's prose, so rewording an error cannot split the metric — with a catch-all so an unrecognised failure is never dropped from the count.
- Frontend only. No backend change, no new env var, no schema change.
- OpenSpec: `track-product-funnel-events`, modifying the `product-analytics` capability.

## Verification

- `pnpm test` — 721 passed (was 709; +12 covering the reason mapper, the freshness predicate and the once-per-account claim)
- `svelte-check` — 0 errors
- `eslint` on changed files — clean (the one warning in `AssistantChat.svelte` pre-exists on `main`)
- Still open: after deploy, confirm each event arrives without PII and build the activation and SEO-entry funnels in PostHog.