### PR TITLE
feat(sources): add the emagine freelance-contract portal

### DIFF
--- a/internal/sources/emagine.go
+++ b/internal/sources/emagine.go
@@ -1,0 +1,289 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// emagine adapts portal.emagine.org, the consultant portal of emagine Consulting A/S — a
+// European freelance-contract marketplace (~1k live assignments across DE/PL/FR/PT/SE/UK and
+// India). Boardless: one public API, no per-tenant board. It is NOT an aggregator: the portal
+// never names the end client, so every posting is contracted through emagine itself and the
+// source facet would only duplicate the company filter.
+//
+// The listing is POST-only and omits the description, which lives behind a per-posting detail
+// call, so the adapter hydrates (HydratingSource) — a detail request is spent only on a posting
+// the catalogue does not already hold.
+type emagine struct {
+	list   JSONPoster // the search listing (three requests per crawl)
+	detail JSONGetter // per-posting detail, bounded in-flight (see limitedEmagineGetter)
+}
+
+const (
+	emagineSearchURL = "https://portal-api.emagine.org/api/JobAds/Search"
+	// emagineDetailURL carries the description the listing omits. The trailing language
+	// segment selects the UI language only — an ad is served in the language it was written
+	// in (a German posting stays German under /EN), so it is fixed rather than per-posting.
+	emagineDetailURL = "https://portal-api.emagine.org/api/JobAds/details/%d/EN"
+	// emagineJobURL is the public posting page. The slug segment is decorative — the portal
+	// routes on the id alone — but the canonical link carries it.
+	emagineJobURL = "https://portal.emagine.org/jobs/%d/%s"
+	// emagineCompany is the employer for every posting: emagine contracts the consultant and
+	// keeps the end client anonymous.
+	emagineCompany = "emagine"
+	// emaginePageSize is the listing page size. The API honours it verbatim up to at least
+	// 1000; 500 keeps a page's response comfortably inside the client's body cap.
+	emaginePageSize = 500
+	// emagineMaxPages bounds pagination as a backstop (totalCount is the primary stop).
+	emagineMaxPages = 40
+)
+
+// NewEmagine builds the emagine adapter: list pages the search endpoint, detail hydrates each
+// unseen posting's description under a bounded number of in-flight requests.
+func NewEmagine(list JSONPoster, detail JSONGetter) Source {
+	return emagine{list: list, detail: detail}
+}
+
+func (emagine) Provider() string { return "emagine" }
+
+func (emagine) boardless() {}
+
+// emagineSearchRequest is the listing request. Sorting is by ascending id: a stable order under
+// concurrent publishing, unlike the portal's own recency sort, where an ad created mid-crawl
+// shifts every later page down by one and pushes a posting across the page boundary unseen.
+type emagineSearchRequest struct {
+	SkipCount           int           `json:"skipCount"`
+	MaxResultCount      int           `json:"maxResultCount"`
+	Sorting             string        `json:"sorting"`
+	Filter              emagineFilter `json:"filter"`
+	SupportedLanguageID string        `json:"supportedLanguageId"`
+}
+
+// emagineFilter is the unfiltered filter block. Every collection on it is [Required] server-side,
+// so each must serialize as [] — a nil slice marshals to null and the request 400s. The whole
+// block and supportedLanguageId are mandatory too: omitting the language yields a 500.
+type emagineFilter struct {
+	TextFilters           []string `json:"textFilters"`
+	WorkLocationTypes     []string `json:"workLocationTypes"`
+	WorkLocations         []string `json:"workLocations"`
+	ProfessionalRolesIDs  []int    `json:"professionalRolesIds"`
+	ConsultantSeniorities []string `json:"consultantSeniorities"`
+	LanguageProficiencies []string `json:"languageProficiencies"`
+	IndustriesIDs         []int    `json:"industriesIds"`
+	RecordIDsToExclude    []int    `json:"recordIdsToExclude"`
+}
+
+// emagineSearchBody builds the request for one page.
+func emagineSearchBody(skip int) emagineSearchRequest {
+	return emagineSearchRequest{
+		SkipCount:      skip,
+		MaxResultCount: emaginePageSize,
+		Sorting:        "Id asc",
+		Filter: emagineFilter{
+			TextFilters:           []string{},
+			WorkLocationTypes:     []string{},
+			WorkLocations:         []string{},
+			ProfessionalRolesIDs:  []int{},
+			ConsultantSeniorities: []string{},
+			LanguageProficiencies: []string{},
+			IndustriesIDs:         []int{},
+			RecordIDsToExclude:    []int{},
+		},
+		SupportedLanguageID: "EN",
+	}
+}
+
+// emagineSearchResponse is one listing page.
+type emagineSearchResponse struct {
+	Items      []emagineAd `json:"items"`
+	TotalCount int         `json:"totalCount"`
+}
+
+// emagineAd is one listed assignment. The listing carries no description and no publication
+// date; startDate is when the consultant is expected on the project, not when the ad went up.
+type emagineAd struct {
+	ID         int    `json:"id"`
+	Title      string `json:"title"`
+	IsPartTime bool   `json:"isPartTime"`
+	Area       struct {
+		Name string `json:"name"`
+	} `json:"area"`
+	WorkLocation *emagineWorkLocation `json:"jobAdWorkLocation"`
+}
+
+// emagineWorkLocation is the assignment's place of work; city and region are often null.
+type emagineWorkLocation struct {
+	WorkLocationType string `json:"workLocationType"`
+	City             string `json:"city"`
+	Region           string `json:"region"`
+	Country          string `json:"country"`
+}
+
+// emagineDetail is the per-posting payload: the description, the grade, and the live status.
+type emagineDetail struct {
+	Status      string `json:"status"`
+	Description string `json:"description"`
+	Seniority   string `json:"seniority"`
+}
+
+// Fetch is the list-only crawl (no description) — the fallback for callers that do not drive
+// hydration. FetchNew is the hydrating path used by ingest.
+func (s emagine) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	ads, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var jobs []Job
+	for _, a := range ads {
+		if job, ok := a.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// FetchNew is the hydrating crawl: it pages the same listing but fetches a posting's detail only
+// when the catalogue does not already hold it. A seen posting yields a liveness-only refresh (no
+// detail request, content preserved); an unseen one is hydrated; a failed detail is isolated
+// (logged, ingested list-only) so a posting is never lost to it.
+func (s emagine) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	ads, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(ads, defaultDetailWorkers, func(a emagineAd) (Job, bool) {
+		base, ok := a.toJob()
+		if !ok {
+			return Job{}, false // unusable ad — dropped, as in Fetch
+		}
+		if seen(base.ExternalID) {
+			// Already ingested: refresh liveness only. Re-upserting content-less would
+			// wipe the description and the facets derived from it when this ad was new.
+			base.SeenRefresh = true
+			return base, true
+		}
+		d, err := s.fetchDetail(ctx, a.ID)
+		if err != nil {
+			log.Printf("emagine: detail %d failed; ingesting list-only: %v", a.ID, err)
+			return base, true
+		}
+		return d.apply(base)
+	}), nil
+}
+
+// crawl pages the listing by skipCount until totalCount is covered — the shared list walk behind
+// Fetch and FetchNew. An empty page ends the crawl regardless of the reported total, so a
+// shrinking or overstated count can never spin the pager.
+func (s emagine) crawl(ctx context.Context) ([]emagineAd, error) {
+	var ads []emagineAd
+	for page := 0; page < emagineMaxPages; page++ {
+		var resp emagineSearchResponse
+		if err := s.list.PostJSON(ctx, emagineSearchURL, emagineSearchBody(len(ads)), &resp); err != nil {
+			return nil, fmt.Errorf("emagine: search at %d: %w", len(ads), err)
+		}
+		if len(resp.Items) == 0 {
+			break
+		}
+		ads = append(ads, resp.Items...)
+		if len(ads) >= resp.TotalCount {
+			break
+		}
+	}
+	return ads, nil
+}
+
+// fetchDetail fetches a posting's detail. It returns the error rather than a bare miss so the
+// caller can name the cause when it falls back to the list-only job — a silently dropped
+// description is permanent, because the next crawl sees the posting as already ingested and never
+// re-fetches it.
+func (s emagine) fetchDetail(ctx context.Context, id int) (emagineDetail, error) {
+	var d emagineDetail
+	if err := s.detail.GetJSON(ctx, fmt.Sprintf(emagineDetailURL, id), &d); err != nil {
+		return emagineDetail{}, err
+	}
+	return d, nil
+}
+
+// apply enriches a list-derived job with its detail. It returns ok=false for an ad the detail
+// reports closed: the listing serves open ads only, but one can be taken down between the two
+// calls, and ingesting it would create a job that is already dead.
+func (d emagineDetail) apply(base Job) (Job, bool) {
+	if strings.EqualFold(strings.TrimSpace(d.Status), "closed") {
+		return Job{}, false
+	}
+	base.Description = sanitizeHTML(d.Description)
+	base.Seniority = emagineSeniority(d.Seniority)
+	return base, true
+}
+
+// toJob maps an ad to a Job, returning ok=false for an unusable one (no id to key on, or no
+// title to name it).
+func (a emagineAd) toJob() (Job, bool) {
+	if a.ID == 0 || strings.TrimSpace(a.Title) == "" {
+		return Job{}, false
+	}
+	job := Job{
+		ExternalID: strconv.Itoa(a.ID),
+		URL:        fmt.Sprintf(emagineJobURL, a.ID, normalize.Slug(a.Title)),
+		Title:      a.Title,
+		Company:    emagineCompany,
+		Category:   emagineCategory(a.Area.Name),
+		// The portal brokers freelance assignments, so a contract is what the source
+		// states rather than something inferred from the ad's wording.
+		EmploymentType: emagineEmploymentType(a.IsPartTime),
+	}
+	if l := a.WorkLocation; l != nil {
+		job.Location = distinctJoin([]string{l.City, l.Region, l.Country}, ", ", func(s string) string { return s })
+		job.WorkMode = workplaceTypeMode(l.WorkLocationType)
+	}
+	return job, true
+}
+
+// emagineEmploymentType maps the one employment fact the listing states. Part-time wins when set:
+// it is the narrower statement about the engagement, and every assignment here is a contract.
+func emagineEmploymentType(partTime bool) string {
+	if partTime {
+		return "part_time"
+	}
+	return "contract"
+}
+
+// emagineSeniority maps emagine's three grades onto freehire's vocabulary. The portal offers
+// nothing below entry and nothing above senior, so the tails (intern, lead and up) never appear,
+// and the grade is optional — most ads state none, which maps to "" and leaves it to the title
+// dictionary. Both spellings of a grade are accepted: the detail payload states the DISPLAY name
+// ("Mid level"), while the portal's own filter vocabulary keys the same grade by id ("Medium").
+func emagineSeniority(grade string) string {
+	switch strings.ToLower(strings.TrimSpace(grade)) {
+	case "entry", "entry level":
+		return "junior"
+	case "medium", "mid level":
+		return "middle"
+	case "senior":
+		return "senior"
+	default:
+		return ""
+	}
+}
+
+// emagineCategories maps the practice areas that pin exactly ONE freehire category. The rest are
+// deliberately absent: "Software Development" spans backend, frontend, mobile and fullstack, and
+// "Data & Analytics" spans data engineering, data science and analytics — mapping either would
+// state a category the source never claimed. An unmapped area leaves Category empty so the title
+// dictionary decides.
+var emagineCategories = map[string]string{
+	"test & qa":              "qa",
+	"ux, ui & visual design": "design",
+	"project delivery":       "project_management",
+}
+
+// emagineCategory resolves a practice area to a freehire category, or "" when it is broader than
+// one category.
+func emagineCategory(area string) string {
+	return emagineCategories[strings.ToLower(strings.TrimSpace(area))]
+}

--- a/internal/sources/emagine_test.go
+++ b/internal/sources/emagine_test.go
@@ -1,0 +1,398 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// emagineFake serves the POST search listing keyed by the request's skipCount and the per-job
+// detail GET keyed by the id in the URL. It records the detail ids it served so a test can assert
+// that only unseen postings are hydrated; the adapter fans detail fetches out across a worker
+// pool, so that recorder is written concurrently and needs the lock.
+type emagineFake struct {
+	pages     map[int]string // skipCount -> search response JSON
+	details   map[int]string // job id -> detail response JSON
+	detailErr map[int]bool   // job id -> detail fetch fails
+
+	mu        sync.Mutex
+	detailIDs []int
+}
+
+func (f *emagineFake) PostJSON(_ context.Context, _ string, body, v any) error {
+	req, ok := body.(emagineSearchRequest)
+	if !ok {
+		return fmt.Errorf("search body is %T, want emagineSearchRequest", body)
+	}
+	page, ok := f.pages[req.SkipCount]
+	if !ok {
+		return fmt.Errorf("no page at skipCount %d", req.SkipCount)
+	}
+	return json.Unmarshal([]byte(page), v)
+}
+
+func (f *emagineFake) GetJSON(_ context.Context, url string, v any) error {
+	// .../api/JobAds/details/{id}/EN
+	parts := strings.Split(strings.TrimSuffix(url, "/EN"), "/")
+	id, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return fmt.Errorf("detail url %q carries no id", url)
+	}
+	f.mu.Lock()
+	f.detailIDs = append(f.detailIDs, id)
+	f.mu.Unlock()
+	if f.detailErr[id] {
+		return errors.New("detail boom")
+	}
+	body, ok := f.details[id]
+	if !ok {
+		return fmt.Errorf("no detail for id %d", id)
+	}
+	return json.Unmarshal([]byte(body), v)
+}
+
+// emagineListing is one page holding three postings: a remote one whose location is
+// country-only, a hybrid one with a city, and a part-time one whose location object is null.
+const emagineListing = `{"items":[
+{"id":178956,"title":"Senior AI Platform Engineer","isPartTime":false,
+ "jobAdWorkLocation":{"workLocationType":"Remote","city":null,"region":null,"country":"Portugal"},
+ "area":{"id":2140,"name":"Data & Analytics"}},
+{"id":178953,"title":"Junior Business Analyst","isPartTime":false,
+ "jobAdWorkLocation":{"workLocationType":"Hybrid","city":"Warsaw","region":"Mazovia","country":"Poland"},
+ "area":{"id":2133,"name":"Project Delivery"}},
+{"id":178950,"title":"Part-time Tester","isPartTime":true,
+ "jobAdWorkLocation":null,"area":{"id":2141,"name":"Test & QA"}}
+],"totalCount":3}`
+
+func emagineFetch(t *testing.T, f *emagineFake) map[string]Job {
+	t.Helper()
+	jobs, err := emagine{list: f, detail: f}.Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	return byID
+}
+
+func TestEmagineFetchMapsListing(t *testing.T) {
+	byID := emagineFetch(t, &emagineFake{pages: map[int]string{0: emagineListing}})
+
+	if len(byID) != 3 {
+		t.Fatalf("got %d jobs, want 3", len(byID))
+	}
+	got := byID["178953"]
+	if got.Title != "Junior Business Analyst" {
+		t.Errorf("Title = %q", got.Title)
+	}
+	if want := "https://portal.emagine.org/jobs/178953/junior-business-analyst"; got.URL != want {
+		t.Errorf("URL = %q, want %q", got.URL, want)
+	}
+	if got.Company != "emagine" {
+		t.Errorf("Company = %q, want emagine (the portal hides the end client)", got.Company)
+	}
+	if want := "Warsaw, Mazovia, Poland"; got.Location != want {
+		t.Errorf("Location = %q, want %q", got.Location, want)
+	}
+	if got.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid", got.WorkMode)
+	}
+}
+
+// The portal is a freelance-contract marketplace, so employment type is a source fact rather
+// than a guess: every posting is a contract unless it states part-time.
+func TestEmagineEmploymentTypeIsContractUnlessPartTime(t *testing.T) {
+	byID := emagineFetch(t, &emagineFake{pages: map[int]string{0: emagineListing}})
+
+	if got := byID["178956"].EmploymentType; got != "contract" {
+		t.Errorf("EmploymentType = %q, want contract", got)
+	}
+	if got := byID["178950"].EmploymentType; got != "part_time" {
+		t.Errorf("part-time posting EmploymentType = %q, want part_time", got)
+	}
+}
+
+// A country-only posting keeps just the country, and a null location object yields no location
+// rather than a stray separator.
+func TestEmagineLocationTolerates(t *testing.T) {
+	byID := emagineFetch(t, &emagineFake{pages: map[int]string{0: emagineListing}})
+
+	if got := byID["178956"].Location; got != "Portugal" {
+		t.Errorf("country-only Location = %q, want Portugal", got)
+	}
+	if got := byID["178950"]; got.Location != "" || got.WorkMode != "" {
+		t.Errorf("null location yielded Location=%q WorkMode=%q, want both empty", got.Location, got.WorkMode)
+	}
+}
+
+// The API states no publication date — startDate is when the consultant is expected on the
+// project, not when the ad went up — so PostedAt stays nil rather than carrying a wrong date.
+func TestEmagineLeavesPostedAtUnset(t *testing.T) {
+	for id, j := range emagineFetch(t, &emagineFake{pages: map[int]string{0: emagineListing}}) {
+		if j.PostedAt != nil {
+			t.Errorf("job %s PostedAt = %v, want nil", id, *j.PostedAt)
+		}
+	}
+}
+
+// The listing pages by skipCount until totalCount is reached. Sorting is by ascending id — a
+// stable order under concurrent publishing, unlike a recency sort where a posting created
+// mid-crawl shifts the window and pushes a posting past the page boundary unseen.
+func TestEmaginePagesUntilTotalCount(t *testing.T) {
+	first := `{"items":[{"id":1,"title":"One","jobAdWorkLocation":null}],"totalCount":2}`
+	second := `{"items":[{"id":2,"title":"Two","jobAdWorkLocation":null}],"totalCount":2}`
+	byID := emagineFetch(t, &emagineFake{pages: map[int]string{0: first, 1: second}})
+
+	if len(byID) != 2 {
+		t.Fatalf("got %d jobs, want both pages (2)", len(byID))
+	}
+}
+
+// A page that comes back empty ends the crawl even if totalCount claims more, so a shrinking or
+// lying total can never spin the pager forever.
+func TestEmagineStopsOnEmptyPage(t *testing.T) {
+	first := `{"items":[{"id":1,"title":"One","jobAdWorkLocation":null}],"totalCount":99}`
+	empty := `{"items":[],"totalCount":99}`
+	byID := emagineFetch(t, &emagineFake{pages: map[int]string{0: first, 1: empty}})
+
+	if len(byID) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(byID))
+	}
+}
+
+// The detail endpoint carries the description the listing omits plus emagine's own seniority,
+// which maps onto freehire's vocabulary. It states the grade's DISPLAY name ("Mid level"), not
+// the lookup id ("Medium") — verified against the live API.
+func TestEmagineDetailMapsDescriptionAndSeniority(t *testing.T) {
+	detail := `{"id":178950,"status":"Open","seniority":"Mid level",
+"description":"<p>Test things.</p><script>alert(1)</script>"}`
+	fake := &emagineFake{
+		pages:   map[int]string{0: emagineListing},
+		details: map[int]string{178950: detail},
+	}
+	jobs, err := emagine{list: fake, detail: fake}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	var got Job
+	for _, j := range jobs {
+		if j.ExternalID == "178950" {
+			got = j
+		}
+	}
+	if !strings.Contains(got.Description, "Test things.") || strings.Contains(got.Description, "<script>") {
+		t.Errorf("Description not sanitized/assembled: %q", got.Description)
+	}
+	if got.Seniority != "middle" {
+		t.Errorf("Seniority = %q, want middle (emagine grades it \"Mid level\")", got.Seniority)
+	}
+}
+
+// The grade arrives as the display name on the detail payload but as the lookup id in the
+// portal's own filter vocabulary, and the two spellings differ for the middle grade. Both are
+// accepted so a payload that switches to ids does not silently drop every seniority.
+func TestEmagineSeniorityAcceptsIDAndDisplayName(t *testing.T) {
+	for _, tc := range []struct{ grade, want string }{
+		{"Mid level", "middle"},
+		{"Medium", "middle"},
+		{"Entry level", "junior"},
+		{"Entry", "junior"},
+		{"Senior", "senior"},
+		{"", ""},
+		{"Freelance", ""},
+	} {
+		if got := emagineSeniority(tc.grade); got != tc.want {
+			t.Errorf("emagineSeniority(%q) = %q, want %q", tc.grade, got, tc.want)
+		}
+	}
+}
+
+// emagine's area is a broad practice, not a role: only the three that pin exactly one freehire
+// category are mapped, and a broad one (Data & Analytics spans data engineering, data science
+// and analytics) leaves the category empty so the title dictionary decides.
+func TestEmagineAreaMapsOnlyUnambiguousCategories(t *testing.T) {
+	for _, tc := range []struct{ area, want string }{
+		{"Test & QA", "qa"},
+		{"UX, UI & Visual Design", "design"},
+		{"Project Delivery", "project_management"},
+		{"Data & Analytics", ""},
+		{"Software Development", ""},
+		{"IT Infrastructure & Operations", ""},
+		{"", ""},
+	} {
+		if got := emagineCategory(tc.area); got != tc.want {
+			t.Errorf("emagineCategory(%q) = %q, want %q", tc.area, got, tc.want)
+		}
+	}
+}
+
+// A posting the catalogue already holds is refreshed for liveness only: no detail request, and
+// SeenRefresh set so the pipeline does not overwrite its stored description with an empty one.
+func TestEmagineFetchNewHydratesOnlyUnseen(t *testing.T) {
+	fake := &emagineFake{
+		pages: map[int]string{0: emagineListing},
+		details: map[int]string{
+			178956: `{"status":"Open","description":"<p>New one.</p>"}`,
+			178953: `{"status":"Open","description":"<p>Also new.</p>"}`,
+		},
+	}
+	seen := func(id string) bool { return id == "178950" }
+
+	jobs, err := emagine{list: fake, detail: fake}.FetchNew(context.Background(), CompanyEntry{}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3", len(jobs))
+	}
+	if slices.Contains(fake.detailIDs, 178950) {
+		t.Errorf("detail fetched for a seen posting: %v", fake.detailIDs)
+	}
+	for _, j := range jobs {
+		if j.ExternalID == "178950" && !j.SeenRefresh {
+			t.Error("seen posting should carry SeenRefresh so its stored content survives")
+		}
+	}
+}
+
+// A failed detail must not cost the posting: it is ingested list-only, and its description
+// arrives on a later crawl.
+func TestEmagineDetailFailureFallsBackToListOnly(t *testing.T) {
+	fake := &emagineFake{
+		pages:     map[int]string{0: emagineListing},
+		details:   map[int]string{178953: `{"status":"Open","description":"<p>Fine.</p>"}`, 178950: `{"status":"Open"}`},
+		detailErr: map[int]bool{178956: true},
+	}
+	jobs, err := emagine{list: fake, detail: fake}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want the failed-detail posting kept (3)", len(jobs))
+	}
+}
+
+// The listing only carries open ads, but a posting can be taken down between the listing and its
+// detail; the detail states the status, so a closed one is dropped rather than ingested dead.
+func TestEmagineDropsPostingClosedBeforeDetail(t *testing.T) {
+	fake := &emagineFake{
+		pages: map[int]string{0: emagineListing},
+		details: map[int]string{
+			178956: `{"status":"Closed","description":"<p>Gone.</p>"}`,
+			178953: `{"status":"Open","description":"<p>Live.</p>"}`,
+			178950: `{"status":"Open","description":"<p>Live.</p>"}`,
+		},
+	}
+	jobs, err := emagine{list: fake, detail: fake}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	for _, j := range jobs {
+		if j.ExternalID == "178956" {
+			t.Error("a posting closed before its detail was fetched should be dropped")
+		}
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+}
+
+// Every collection in the filter is [Required] server-side: a nil slice serializes as null and
+// the request 400s, so the filter must be built with empty slices.
+func TestEmagineSearchFilterSerializesEmptyArrays(t *testing.T) {
+	body, err := json.Marshal(emagineSearchBody(0))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "null") {
+		t.Errorf("search body carries a null the API rejects: %s", body)
+	}
+	for _, field := range []string{"textFilters", "workLocationTypes", "workLocations",
+		"professionalRolesIds", "consultantSeniorities", "languageProficiencies",
+		"industriesIds", "recordIdsToExclude", "supportedLanguageId"} {
+		if !strings.Contains(string(body), `"`+field+`"`) {
+			t.Errorf("search body omits required field %q: %s", field, body)
+		}
+	}
+}
+
+// The listing is three POSTs a crawl, but the detail fan-out is one GET per posting and the API
+// starts refusing connections under sustained concurrency, so detail rides its OWN transport —
+// the registry gives it an in-flight-bounded getter. A dropped description is permanent (the next
+// crawl sees the posting as ingested and never re-fetches it), so the two must stay separable.
+func TestEmagineFetchesDetailThroughItsOwnTransport(t *testing.T) {
+	list := &emagineFake{pages: map[int]string{0: emagineListing}}
+	detail := &emagineFake{details: map[int]string{
+		178956: `{"status":"Open","description":"<p>One.</p>"}`,
+		178953: `{"status":"Open","description":"<p>Two.</p>"}`,
+		178950: `{"status":"Open","description":"<p>Three.</p>"}`,
+	}}
+
+	jobs, err := emagine{list: list, detail: detail}.FetchNew(
+		context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(detail.detailIDs) != 3 {
+		t.Errorf("detail transport served %d requests, want 3", len(detail.detailIDs))
+	}
+	if len(list.detailIDs) != 0 {
+		t.Errorf("listing transport served %d detail requests, want 0", len(list.detailIDs))
+	}
+	for _, j := range jobs {
+		if j.Description == "" {
+			t.Errorf("job %s came back without a description", j.ExternalID)
+		}
+	}
+}
+
+func TestEmagineProvider(t *testing.T) {
+	if got := NewEmagine(nil, nil).Provider(); got != "emagine" {
+		t.Errorf("Provider() = %q, want emagine", got)
+	}
+}
+
+// Boardless (one public API, no per-tenant board) but not an aggregator: every posting is
+// contracted through emagine itself, so the source facet would duplicate the company filter.
+func TestEmagineIsBoardlessNotAggregator(t *testing.T) {
+	s := NewEmagine(nil, nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("emagine should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); ok {
+		t.Error("emagine should NOT be an aggregator (single company)")
+	}
+	if slices.Contains(FilterableProviders(), "emagine") {
+		t.Error("FilterableProviders() should exclude boardless single-company emagine")
+	}
+}
+
+func TestEmagineIsHydratingSource(t *testing.T) {
+	if _, ok := NewEmagine(nil, nil).(HydratingSource); !ok {
+		t.Error("emagine should implement the HydratingSource marker")
+	}
+}
+
+func TestEmagineRegistered(t *testing.T) {
+	if _, ok := All(nil)["emagine"]; !ok {
+		t.Error("All() should register provider emagine")
+	}
+}
+
+func TestEmagineBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/emagine.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/emagine.yml fails validation: %v", err)
+	}
+}

--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -114,6 +114,22 @@ func limitedTrudvsemGetter(c JSONGetter) JSONGetter {
 	return concurrencyLimitedJSONGetter{inner: c, sem: make(chan struct{}, trudvsemMaxInFlight)}
 }
 
+// portal-api.emagine.org serves a single detail request in ~0.9s and tolerates a burst (80
+// back-to-back at 8-way all returned 200), but a whole-catalogue hydration — 1025 details in one
+// run — starts refusing CONNECTIONS near the end: `dial tcp: i/o timeout`, already past the
+// client's own three attempts, on ~1% of postings clustered in the run's tail. So the trigger is
+// sustained concurrency over a long run, not rate, and the loss is permanent: a posting ingested
+// list-only is seen on the next crawl and never re-fetches its detail. Four in flight halves the
+// pressure while keeping a full first crawl inside the ingest window; later crawls hydrate only
+// new postings, so the cap costs nothing in steady state. Tune from the observed loss rate.
+const emagineMaxInFlight = 4
+
+// limitedEmagineGetter wraps a getter with a fresh semaphore shared across one registry build, so
+// the whole detail fan-out of a run competes for the same few in-flight slots.
+func limitedEmagineGetter(c JSONGetter) JSONGetter {
+	return concurrencyLimitedJSONGetter{inner: c, sem: make(chan struct{}, emagineMaxInFlight)}
+}
+
 // The WhatJobs feed serves sequential requests happily — a dozen back-to-back from one IP never
 // tripped anything — but the pipeline crawls board files in parallel, and on the provider's first
 // production run 8 of its 10 keyword boards failed with HTTP 429. So the trigger is simultaneity, not

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -226,6 +226,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJobtech(c),
 		NewJobnet(c),
 		NewJobdanmark(c),
+		NewEmagine(c, limitedEmagineGetter(c)),
 		NewTyomarkkinatori(c),
 		NewLikeit(c),
 		NewArbeitsagentur(c),

--- a/sources/emagine.yml
+++ b/sources/emagine.yml
@@ -1,0 +1,6 @@
+# emagine Consulting A/S — the European freelance-contract portal (portal.emagine.org).
+# Boardless: one public API (portal-api.emagine.org/api/JobAds/Search), so the entry carries no
+# board. The portal never names the end client, so emagine is the employer on every posting, not
+# a placeholder.
+- company: emagine
+  provider: emagine

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -2579,7 +2579,7 @@
   board: elpasocenterforchildren
 - company: Elucid
   board: elucid
-- company: emagine
+- company: emagineHealth
   board: emagine
 - company: Embark Veterinary
   board: embarkvet


### PR DESCRIPTION
emagine Consulting A/S ([portal.emagine.org](https://portal.emagine.org/jobs/all)) brokers freelance IT assignments across Europe. Its Angular portal is backed by a public JSON API — a POST search listing plus a per-posting detail call carrying the description the listing omits — so the adapter is **boardless** and **hydrating**.

Catalogue at the time of writing: **1025 live contracts**, Germany 208 / Poland 184 / France 107 / Portugal 99 / Sweden 75 / UK 62 / Belgium 54 / India 51 / Denmark 35. Hybrid 581, onsite 268, remote 151.

## Not an aggregator, and the name collision

The portal never names the end client, so emagine is the employer on every posting — a single-company boardless source, excluded from the source facet because it would only duplicate the company filter. `make gen-contracts` produces no diff, which confirms it.

Two unrelated tenants already sat under that name. `sources/jazzhr.yml` carried the US marketing agency "emagine / emagineHealth", which would have merged into one `company_slug` with these 1025 contracts; it is renamed to `emagineHealth`. (`careerplug.yml` has "Emagine Entertainment", which slugs differently and is left alone.)

## Detail rides its own bounded transport

A whole-catalogue hydration at the default 8-way concurrency makes the API refuse connections near the end of a run — `dial tcp 20.105.216.33:443: i/o timeout`, already past the client's own three retries — on ~1% of postings, clustered in the run's tail. Single requests and an 80-request burst at 8-way all return 200, so the trigger is sustained concurrency over a long run, not rate.

That loss is permanent: `ExistingExternalIDs` does not distinguish "already stored" from "stored with a description", so a posting ingested list-only is seen on the next crawl and never re-fetches its detail — the same hole `cmd/backfill-justjoin` exists to patch, and the one the hh.ru note in `pacer.go` describes.

Fix is the existing `concurrencyLimitedJSONGetter` (as for trudvsem and whatjobs), capped at 4 in flight, with the listing kept on the direct client. Measured against the live API: **6–10 lost descriptions → 0**, at 180s → 230s.

## Mapping

Dict-only throughout — only the three practice areas that pin exactly one freehire category are mapped (`Test & QA` → qa, `UX, UI & Visual Design` → design, `Project Delivery` → project_management); the broad ones like `Software Development` and `Data & Analytics` leave the category to the title dictionary. Employment type is the source's own freelance framing (`contract`, or `part_time` when stated). `PostedAt` is left unset: the API states no publication date, and `startDate` is when the consultant is due on the project.

Two traps worth naming, both found against the live API rather than in the docs:

- The listing sorts by `Id asc`, not the portal's own recency sort. Under `CreationTime desc` an ad published mid-crawl shifts the window and pushes a posting across the page boundary unseen.
- Seniority arrives as the DISPLAY name on the detail payload (`"Mid level"`) but as the lookup id in the portal's filter vocabulary (`"Medium"`). Both spellings are accepted; the id-only mapping silently dropped every grade.

Every filter collection is `[Required]` server-side, so a nil Go slice marshals to `null` and the request 400s — a test asserts the body carries no nulls.

## Verification

19 unit tests, plus a full end-to-end run of `cmd/ingest` against a throwaway database:

```
ingest done: providers=1 ingested=1020 failed=0 skipped=0 rejected=5
  rejected: non-technical — Project engineer HVAC; Mechanical Engineer
```

Descriptions and locations on 100% of rows (avg 2669 chars), seniority on 98%, `is_tech` on 614. A second run costs 10s instead of 4min and leaves the stored descriptions intact, confirming `SeenRefresh` does not overwrite hydrated content.

**Deploy note:** a board file does nothing until ops adds its timer — this needs `freehire-ingest@emagine.timer`.