### PR TITLE
/companies serves a projection, not the sqlc row

### DIFF
--- a/internal/handler/companies.go
+++ b/internal/handler/companies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/pgconv"
 	"github.com/strelov1/freehire/internal/search"
 )
 
@@ -168,9 +169,9 @@ func (h *companiesHandlers) ListCompanies(c *fiber.Ctx) error {
 	// the Postgres substring path below, so /companies never depends on Meili being up.
 	if h.companySearch != nil && isCompanyFilter(search, collections, regions, countries,
 		domains, companyTypes, companySizes, remoteRegions, ycBatch, ycStatus, ycStage, ycFlags, maturity, subindustries) {
-		rows, total, err := h.companyHitsViaMeili(c.Context(), search, vals, limit, offset)
+		items, total, err := h.companyHitsViaMeili(c.Context(), search, vals, limit, offset)
 		if err == nil {
-			return listResponse(c, rows, total, limit, offset)
+			return listResponse(c, items, total, limit, offset)
 		}
 		log.Printf("companies: meili search fell back to postgres (q=%q): %v", search, err)
 	}
@@ -227,7 +228,11 @@ func (h *companiesHandlers) ListCompanies(c *fiber.Ctx) error {
 		return err
 	}
 
-	return listResponse(c, companies, total, limit, offset)
+	items := make([]companyListItem, len(companies))
+	for i, row := range companies {
+		items[i] = companyListItemFromRow(row)
+	}
+	return listResponse(c, items, total, limit, offset)
 }
 
 // isCompanyFilter reports whether a /companies request carries any name search or facet
@@ -329,11 +334,11 @@ func (h *companiesHandlers) GetCompany(c *fiber.Ctx) error {
 	}})
 }
 
-// companyHitsViaMeili runs the ranked company search and projects each hit back onto
-// the db.ListCompaniesRow wire shape, so the Meili path is byte-for-byte compatible
-// with the Postgres path. meta.total is Meilisearch's estimated filtered total, which
-// backs list pagination exactly as CountCompanies does on the Postgres path.
-func (h *companiesHandlers) companyHitsViaMeili(ctx context.Context, query string, vals url.Values, limit, offset int) ([]db.ListCompaniesRow, int64, error) {
+// companyHitsViaMeili runs the ranked company search and projects each hit onto the list wire
+// shape — the same type the Postgres path serves, so the two cannot disagree. meta.total is
+// Meilisearch's estimated filtered total, which backs list pagination exactly as CountCompanies
+// does on the Postgres path.
+func (h *companiesHandlers) companyHitsViaMeili(ctx context.Context, query string, vals url.Values, limit, offset int) ([]companyListItem, int64, error) {
 	res, err := h.companySearch.SearchCompanies(ctx, search.CompanySearchParams{
 		Query:  query,
 		Filter: search.CompanyFilterFromValues(vals),
@@ -343,42 +348,76 @@ func (h *companiesHandlers) companyHitsViaMeili(ctx context.Context, query strin
 	if err != nil {
 		return nil, 0, err
 	}
-	rows := make([]db.ListCompaniesRow, len(res.Hits))
+	items := make([]companyListItem, len(res.Hits))
 	for i, h := range res.Hits {
-		rows[i] = companyRowFromDoc(h)
+		items[i] = companyListItemFromDoc(h)
 	}
-	return rows, res.Total, nil
+	return items, res.Total, nil
 }
 
-// companyRowFromDoc projects a company search document onto the list wire shape,
-// re-wrapping the unwrapped scalar strings into pgtype.Text (empty → NULL) so the
-// response matches the Postgres path exactly. An absent array (industries,
-// collections) normalizes to an empty slice so it serializes as [] like the Postgres
-// '{}', not null — the two paths serve the same endpoint, and a field that differs
-// between them makes the catalogue card change shape the moment a user searches.
-func companyRowFromDoc(d search.CompanyDocument) db.ListCompaniesRow {
-	industries := d.Industries
-	if industries == nil {
-		industries = []string{}
+// companyListItem is the public projection of a company for the list endpoint. It exists so the
+// response shape is owned here rather than by sqlc: served straight, a generated row makes
+// `make sqlc` an API-changing operation — a renamed column or a changed SELECT alias would
+// rewrite the public JSON with nothing to compile against. Both backends project onto this one
+// type, so a field added for one cannot be silently missing from the other.
+//
+// The nullable columns are *string rather than pgtype.Text: identical on the wire in all three
+// states ("x", "", null — pinned by the golden bodies in companies_test.go), without putting a
+// persistence vocabulary on a public contract. A plain string would collapse null into "" and
+// change the response for every company with no tagline.
+type companyListItem struct {
+	Slug        string   `json:"slug"`
+	Name        string   `json:"name"`
+	JobCount    int32    `json:"job_count"`
+	Tagline     *string  `json:"tagline"`
+	Industries  []string `json:"industries"`
+	HqCountry   *string  `json:"hq_country"`
+	Collections []string `json:"collections"`
+}
+
+// companyListItemFromRow projects the Postgres read onto the wire shape. The row already carries
+// null-ness, so the two nullable columns pass through as-is.
+func companyListItemFromRow(r db.ListCompaniesRow) companyListItem {
+	return companyListItem{
+		Slug:        r.Slug,
+		Name:        r.Name,
+		JobCount:    r.JobCount,
+		Tagline:     pgconv.TextPtr(r.Tagline),
+		Industries:  r.Industries,
+		HqCountry:   pgconv.TextPtr(r.HqCountry),
+		Collections: r.Collections,
 	}
-	collections := d.Collections
-	if collections == nil {
-		collections = []string{}
-	}
-	return db.ListCompaniesRow{
+}
+
+// companyListItemFromDoc projects a company search document onto the same shape, carrying the
+// two rules the search path has always needed. A document stores an absent scalar as the empty
+// string, which must serialize as null like the Postgres NULL; and an absent array arrives nil,
+// which must serialize as [] like the Postgres '{}'. Collections drive the backer marks, so an
+// array that came back null instead would make those marks disappear the moment a user searched.
+func companyListItemFromDoc(d search.CompanyDocument) companyListItem {
+	return companyListItem{
 		Slug:        d.Slug,
 		Name:        d.Name,
 		JobCount:    d.JobCount,
-		Tagline:     pgText(d.Tagline),
-		Industries:  industries,
-		HqCountry:   pgText(d.HqCountry),
-		Collections: collections,
+		Tagline:     presentOrNil(d.Tagline),
+		Industries:  orEmpty(d.Industries),
+		HqCountry:   presentOrNil(d.HqCountry),
+		Collections: orEmpty(d.Collections),
 	}
 }
 
-// pgText wraps a plain string as a pgtype.Text, treating the empty string as NULL —
-// the inverse of the FromCompany unwrap, so a round-tripped NULL scalar renders as
-// JSON null exactly as the Postgres row would.
-func pgText(s string) pgtype.Text {
-	return pgtype.Text{String: s, Valid: s != ""}
+// presentOrNil treats the empty string as absent — the search document's way of spelling NULL.
+func presentOrNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// orEmpty normalizes a nil array so it serializes as [] rather than null.
+func orEmpty(v []string) []string {
+	if v == nil {
+		return []string{}
+	}
+	return v
 }

--- a/internal/handler/companies_test.go
+++ b/internal/handler/companies_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/search"
@@ -50,22 +52,76 @@ func TestCompanyDetailHidesJobID(t *testing.T) {
 // differently depending on whether a search term was typed. Collections drive the
 // backer marks, so the omission would be visible: the marks would disappear the
 // moment a user searched.
-func TestCompanyRowFromDocCarriesCollections(t *testing.T) {
-	row := companyRowFromDoc(search.CompanyDocument{
+func TestCompanyListItemFromDocCarriesCollections(t *testing.T) {
+	item := companyListItemFromDoc(search.CompanyDocument{
 		Slug:        "euro-lab",
 		Name:        "Euro Lab",
 		Collections: []string{"yc", "a16z-portfolio"},
 	})
-	if !reflect.DeepEqual(row.Collections, []string{"yc", "a16z-portfolio"}) {
-		t.Errorf("collections = %+v, want [yc a16z-portfolio]", row.Collections)
+	if !reflect.DeepEqual(item.Collections, []string{"yc", "a16z-portfolio"}) {
+		t.Errorf("collections = %+v, want [yc a16z-portfolio]", item.Collections)
 	}
 }
 
 // An absent array must serialize as [] like the Postgres '{}', not as null — the
 // same normalization industries already gets.
-func TestCompanyRowFromDocNormalizesAbsentCollections(t *testing.T) {
-	row := companyRowFromDoc(search.CompanyDocument{Slug: "x", Name: "X"})
-	if row.Collections == nil {
+func TestCompanyListItemFromDocNormalizesAbsentCollections(t *testing.T) {
+	item := companyListItemFromDoc(search.CompanyDocument{Slug: "x", Name: "X"})
+	if item.Collections == nil {
 		t.Error("absent collections stayed nil — it will serialize as null, unlike the Postgres path")
+	}
+}
+
+// The two golden bodies below ARE the /companies contract. They are asserted as bytes rather
+// than as Go values because the distinction that would break a client — a null tagline versus an
+// empty one — is invisible to a struct comparison, and because the field ORDER is part of what a
+// caller receives. Any change here is an API change and must be argued for, not merged as a
+// refactor.
+const (
+	goldenCompanyFull  = `{"slug":"euro-lab","name":"Euro Lab","job_count":12,"tagline":"We ship fridges","industries":["fintech"],"hq_country":"de","collections":["yc"]}`
+	goldenCompanyEmpty = `{"slug":"x","name":"X","job_count":0,"tagline":null,"industries":[],"hq_country":null,"collections":[]}`
+)
+
+// The endpoint has two backends and one response, so the assertion that matters is that they
+// agree byte for byte — a field one branch sets and the other forgets would make the catalogue
+// card change shape the moment a user typed a search term.
+func TestCompanyListItemJSONIsStableAcrossBothBackends(t *testing.T) {
+	fromPostgres := companyListItemFromRow(db.ListCompaniesRow{
+		Slug: "euro-lab", Name: "Euro Lab", JobCount: 12,
+		Tagline:     pgtype.Text{String: "We ship fridges", Valid: true},
+		Industries:  []string{"fintech"},
+		HqCountry:   pgtype.Text{String: "de", Valid: true},
+		Collections: []string{"yc"},
+	})
+	fromSearch := companyListItemFromDoc(search.CompanyDocument{
+		Slug: "euro-lab", Name: "Euro Lab", JobCount: 12,
+		Tagline:     "We ship fridges",
+		Industries:  []string{"fintech"},
+		HqCountry:   "de",
+		Collections: []string{"yc"},
+	})
+
+	assertJSON(t, "postgres", fromPostgres, goldenCompanyFull)
+	assertJSON(t, "search", fromSearch, goldenCompanyFull)
+}
+
+// Absence is the half a struct comparison cannot see: a missing tagline must serialize as null
+// and a missing facet array as [], from either backend.
+func TestCompanyListItemJSONKeepsAbsenceShapes(t *testing.T) {
+	fromPostgres := companyListItemFromRow(db.ListCompaniesRow{Slug: "x", Name: "X", Industries: []string{}, Collections: []string{}})
+	fromSearch := companyListItemFromDoc(search.CompanyDocument{Slug: "x", Name: "X"})
+
+	assertJSON(t, "postgres", fromPostgres, goldenCompanyEmpty)
+	assertJSON(t, "search", fromSearch, goldenCompanyEmpty)
+}
+
+func assertJSON(t *testing.T, label string, v any, want string) {
+	t.Helper()
+	got, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("%s: marshal: %v", label, err)
+	}
+	if string(got) != want {
+		t.Errorf("%s body changed — this is an API change, not a refactor\n got: %s\nwant: %s", label, got, want)
 	}
 }

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -70,8 +70,20 @@ func Text(s string) pgtype.Text {
 	return pgtype.Text{String: s, Valid: true}
 }
 
+// TextPtr maps a nullable DB text to a *string, preserving NULL as nil. Use this where the
+// distinction survives to the caller — a JSON response, where NULL must render as null and an
+// empty value as "" — and TextString where the domain has no use for it. Same shape as TimePtr
+// and IntPtr.
+func TextPtr(t pgtype.Text) *string {
+	if !t.Valid {
+		return nil
+	}
+	return &t.String
+}
+
 // TextString maps a nullable DB text to a plain string: NULL becomes "", a valid value
-// its content. The read-side inverse of Text.
+// its content. The read-side inverse of Text, and lossy by design: a caller that needs to
+// tell NULL from "" wants TextPtr.
 func TextString(t pgtype.Text) string {
 	if !t.Valid {
 		return ""

--- a/openspec/changes/companies-list-wire-type/.openspec.yaml
+++ b/openspec/changes/companies-list-wire-type/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/companies-list-wire-type/design.md
+++ b/openspec/changes/companies-list-wire-type/design.md
@@ -1,0 +1,96 @@
+## Context
+
+`GET /api/v1/companies` has two backends and one response. The Postgres branch returns
+`[]db.ListCompaniesRow` from sqlc; the Meilisearch branch converts each hit into the *same
+generated struct* so the two agree:
+
+```go
+rows[i] = companyRowFromDoc(h)          // search.CompanyDocument → db.ListCompaniesRow
+Tagline: pgText(d.Tagline),             // string → pgtype.Text, "" meaning NULL
+```
+
+The comment on `companyRowFromDoc` states the goal plainly — "so the Meili path is byte-for-byte
+compatible with the Postgres path" — and the mechanism it chose is to imitate the persistence
+type. That makes `db.ListCompaniesRow`'s json tags the public contract of the endpoint, which is
+the whole thing `internal/jobview` exists to prevent one endpoint over:
+
+> One type, projected from the job.Job aggregate, so the API surfaces cannot drift apart.
+
+Two consequences, neither firing today:
+
+- `make sqlc` is an API-changing operation here. Rename a column or change a `SELECT` alias and
+  the response changes with nothing to compile against.
+- A new column in the query lands in the Postgres branch only. `companyRowFromDoc` sets fields
+  one by one, so the Meili branch would omit it — and the two branches serve the same URL, so the
+  body would depend on whether the caller typed a search term.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The endpoint's response shape is a type the transport owns, declared next to the handler that
+  serves it, and both backends project onto it.
+- Byte-identical output. This change must be provable as a no-op on the wire, or it is a silent
+  API break dressed as a refactor.
+- The Meili branch stops constructing a persistence value.
+
+**Non-Goals:**
+
+- `internal/companyview`. `jobview` earns its package by being shared across the list, the detail
+  read, the search index and the wrapper responses; `companies` has one six-field list row and
+  one detail projection, both in one file. A package here would be structure without a second
+  consumer.
+- `companyView` (the detail endpoint) keeps its `pgtype` fields. It is the same family of
+  problem, but it is a different endpoint, it is already a hand-written projection rather than a
+  generated row, and S12 covers the `pgconv` question directly.
+- Any change to the query, the index, or the fallback rule.
+
+## Decisions
+
+**`*string` for the nullable columns, not `pgtype.Text` and not a bare `string`.** The wire
+behaviour must not move, so the candidate had to be checked rather than assumed. Marshalled
+directly:
+
+| value | JSON |
+|---|---|
+| `pgtype.Text{String: "x", Valid: true}` | `"x"` |
+| `pgtype.Text{String: "", Valid: true}` | `""` |
+| `pgtype.Text{Valid: false}` | `null` |
+| `*string` → `"x"` | `"x"` |
+| `*string` → `""` | `""` |
+| `*string` → `nil` | `null` |
+
+Identical in all three states. A bare `string` would collapse `null` into `""` and change the
+response for every company with no tagline.
+
+*Alternative considered — keep `pgtype.Text` in a hand-written struct.* It removes the sqlc
+coupling but keeps a persistence vocabulary on the wire, which is the half of the finding that
+makes the Meili branch need `pgText` at all.
+
+**Two named projections, `fromListRow` and `fromDocument`, rather than one generic converter.**
+The two backends genuinely differ: the row already carries null-ness, the document carries `""`
+for absent scalars and `nil` for absent arrays. Each conversion states its own rule, and the
+empty-string-means-absent decision that `pgText` used to hide moves into `fromDocument` where a
+reader looking at the search path will find it.
+
+**The array normalisation stays exactly where it is.** `companyRowFromDoc` normalises a nil
+`Industries`/`Collections` to `[]string{}` so it serializes as `[]` rather than `null`, matching
+Postgres's `'{}'`. That rule is load-bearing for the same reason the null-ness is — it moves to
+`fromDocument` unchanged, with its comment.
+
+## Risks / Trade-offs
+
+- **A silent response change would be invisible to the existing tests if they assert on the Go
+  struct rather than the JSON.** → The change is pinned by a test that marshals both branches'
+  output and compares the bytes, not the values. That is the only assertion that can actually
+  catch a null-ness regression.
+- **The struct and the query can still drift** — adding a column to `ListCompanies` will not
+  automatically surface it. → That is the intended trade: the drift becomes a deliberate edit in
+  the handler instead of an automatic rewrite of the public API. Nothing is lost, because a
+  column nobody projected was never reaching the Meili branch either.
+- **One more type to read.** → It replaces two helpers (`companyRowFromDoc`, `pgText`) whose only
+  job was to make a persistence type do a transport type's work, so the file gets shorter.
+
+## Migration Plan
+
+None. No schema, no query, no response change. Rollback is the revert.

--- a/openspec/changes/companies-list-wire-type/proposal.md
+++ b/openspec/changes/companies-list-wire-type/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+`GET /api/v1/companies` returns `[]db.ListCompaniesRow` — the struct `sqlc` generates from a
+`SELECT` — straight to the client. Its json tags *are* the public API, so `make sqlc` after a
+column rename or a changed `SELECT` alias rewrites the endpoint's response with no compile error
+anywhere. Every other list endpoint in the package (`agent_search.go`, `jobs.go`, `search.go`,
+`swipe.go`, `recommendations.go`, `inbox.go`) serves a projection; this is the sole exception,
+and it abandons the rule `internal/jobview` exists to enforce one endpoint over.
+
+The cost is already visible in the code. The endpoint has two backends, and the Meilisearch one
+has to fabricate a persistence row it has nothing to do with — `companyRowFromDoc` builds a
+`db.ListCompaniesRow` field by field and `pgText` re-wraps plain strings into `pgtype.Text`
+purely so JSON null-ness matches the Postgres path. Add a column to the query and the Postgres
+branch grows a field the Meili branch silently omits, so the same request returns different
+bodies depending on which backend served it.
+
+Nothing is broken today. The exposure is the next `make sqlc`.
+
+## What Changes
+
+- A `companyListItem` struct in `internal/handler/companies.go` with plain Go types — `*string`
+  for the two nullable columns — becomes the endpoint's wire shape. Verified byte-identical:
+  `pgtype.Text` and `*string` marshal the same in all three states (`"x"`, `""`, `null`).
+- `fromListRow(db.ListCompaniesRow)` and `fromDocument(search.CompanyDocument)` project the two
+  backends onto it, and both branches return `[]companyListItem`.
+- **`companyRowFromDoc` and `pgText` are deleted.** The Meili path stops imitating a database
+  row; it projects onto the wire type directly, like every other search-backed surface.
+- **`pgconv.TextPtr`** — found while implementing. The deleted `pgText` was a duplicate of
+  `pgconv.Text`, and `pgconv` had no null-preserving read even though `TimePtr` and `IntPtr` are
+  exactly that shape. Adding it there rather than a fourth local unwrapper also makes
+  `internal/handler` import `pgconv` for the first time, which is what S12 asks of the package.
+- No response change. The endpoint's JSON is identical before and after, which is the point: the
+  contract stops being a side effect of code generation and becomes something a diff can show.
+  Pinned by golden bodies captured from the OLD type before the refactor, so the proof is that
+  they still pass.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `companies`: gains the rule that the list endpoint's item is a projection owned by the
+  transport, not a generated persistence row — and that both backends serve the same type, so
+  they cannot drift field by field.
+
+## Impact
+
+- `internal/handler/companies.go` — the new struct, two projections, two deleted helpers, and the
+  two `listResponse` call sites. `internal/pgconv/pgconv.go` — one added converter.
+- No migration, no query change, no new dependency, no frontend change.
+- Deliberately NOT in scope: an `internal/companyview` package mirroring `jobview`. `jobview`
+  earns a package by being shared across list, detail, search and the index; companies have one
+  six-field list row and one detail view in the same file. Also out of scope: retyping
+  `companyView`'s `pgtype` fields through `internal/pgconv` — that is S12's cheap follow-up and
+  touches a different endpoint.

--- a/openspec/changes/companies-list-wire-type/specs/companies/spec.md
+++ b/openspec/changes/companies-list-wire-type/specs/companies/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: The company list item is a transport projection, not a persistence row
+
+The system SHALL serve `GET /api/v1/companies` as a list of a projection type owned by the
+transport layer, and MUST NOT serve a generated persistence row as the endpoint's response shape.
+Regenerating the database access layer SHALL NOT be capable of changing the endpoint's public
+JSON: a change to a column name or a query alias must either fail to compile or leave the wire
+shape untouched.
+
+Both backends of the endpoint — the Postgres read and the Meilisearch read — SHALL project onto
+that one type. Neither SHALL construct the other's representation to stay compatible, so a field
+added for one backend cannot be silently absent from the other, and the same request cannot
+return different bodies depending on which backend served it.
+
+The projection SHALL preserve the endpoint's existing null-ness: a nullable text column with no
+value serializes as JSON `null`, and a facet array with no values serializes as `[]` rather than
+`null`, whichever backend produced it.
+
+#### Scenario: Regenerating the data-access layer cannot change the response
+
+- **WHEN** a column in the company list query is renamed or given a different alias, and the
+  database access layer is regenerated
+- **THEN** the endpoint's response fields are unchanged, and any mismatch surfaces as a
+  compilation failure rather than as a silently altered public contract
+
+#### Scenario: Both backends serve the same shape
+
+- **WHEN** the same company is returned once by the Postgres path and once by the Meilisearch
+  path
+- **THEN** the two response bodies are byte-identical, including which fields are `null` and
+  which empty arrays are `[]`
+
+#### Scenario: An absent tagline stays null, an absent facet stays an empty array
+
+- **WHEN** a company has no tagline and no industries, served from either backend
+- **THEN** `tagline` is `null` and `industries` is `[]`

--- a/openspec/changes/companies-list-wire-type/tasks.md
+++ b/openspec/changes/companies-list-wire-type/tasks.md
@@ -1,0 +1,35 @@
+## 1. Pin the wire shape before touching it
+
+- [x] 1.1 RED-by-construction: add a test that marshals the SAME company through both backends'
+      projections and asserts the two JSON bodies are byte-identical, including `null` tagline
+      and `[]` industries. Write it against the shape as it will be, so it compiles only after
+      the type exists.
+- [x] 1.2 Capture today's exact JSON for a fully-populated company and for an all-empty one, and
+      assert the new type reproduces both byte for byte. This is the only assertion that can
+      catch a null-ness regression; comparing Go values cannot.
+
+## 2. The projection
+
+- [x] 2.1 Add `companyListItem` to `internal/handler/companies.go` with `*string` for `tagline`
+      and `hq_country` — verified to marshal identically to `pgtype.Text` in all three states —
+      and the same json tags the generated row carries.
+- [x] 2.2 `fromListRow(db.ListCompaniesRow) companyListItem`.
+- [x] 2.3 `fromDocument(search.CompanyDocument) companyListItem`, carrying the two rules `pgText`
+      and `companyRowFromDoc` used to hold: empty string means absent, and a nil array
+      normalizes to `[]` so it does not serialize as `null`.
+- [x] 2.4 Both branches return `[]companyListItem`; delete `companyRowFromDoc` and `pgText`.
+- [x] 2.5 Found while implementing: the deleted `pgText` was a duplicate of `pgconv.Text`, and
+      `pgconv` has no null-preserving read (`TextString` collapses NULL to `""`) though its
+      `TimePtr`/`IntPtr` siblings are exactly that shape. Add `pgconv.TextPtr` there rather than
+      a fourth local unwrapper, and have the handler import `pgconv` — which is what S12 asks
+      the package to start doing.
+
+## 3. Verify and close
+
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green.
+- [x] 3.2 Confirm nothing else in the package still serves a `db.*Row`: grep every
+      `listResponse` call site.
+- [x] 3.3 Check the SPA's companies types against the response — no change expected, so any
+      diff means the projection moved something.
+- [x] 3.4 Mark S9 ✅ in `docs/reviews/2026-08-01-architecture-review.md` — shortlist row, the
+      `S9` heading, the Progress table — noting anything the finding got wrong.


### PR DESCRIPTION
S9 from the 2026-08-01 architecture review.

## The defect

`GET /api/v1/companies` returned `[]db.ListCompaniesRow` — the struct `sqlc` generates from a
`SELECT` — straight to the client, so **its json tags were the public API**. `make sqlc` after a
column rename or a changed alias would have rewritten the endpoint's response with no compile
error anywhere. Every other list endpoint in the package (`jobs`, `search`, `swipe`,
`recommendations`, `agent_search`, `inbox`) serves a projection; this was the sole exception —
one endpoint over from the rule `internal/jobview` exists to enforce.

The cost was already visible in the code. The endpoint has two backends, and the Meilisearch one
had to fabricate a persistence row it has nothing to do with: `companyRowFromDoc` built a
`db.ListCompaniesRow` field by field, and `pgText` re-wrapped plain strings into `pgtype.Text`
purely so JSON null-ness matched. Add a column to the query and the Postgres branch grows a field
the Meili branch silently omits — same URL, different body depending on whether the caller typed
a search term.

## The fix

`companyListItem` is the wire shape now, with `*string` for the two nullable columns. Checked
rather than assumed — `pgtype.Text` and `*string` marshal identically in all three states:

| value | JSON |
|---|---|
| `pgtype.Text{String: "x", Valid: true}` / `*string` → `"x"` | `"x"` |
| `pgtype.Text{String: "", Valid: true}` / `*string` → `""` | `""` |
| `pgtype.Text{Valid: false}` / `nil` | `null` |

Both backends project onto it; `companyRowFromDoc` and `pgText` are deleted.

## Found while implementing

`pgText` was a **duplicate of `pgconv.Text`**, and `pgconv` had no null-preserving read —
`TextString` collapses NULL to `""` — even though its `TimePtr` and `IntPtr` siblings are exactly
the shape needed. So `pgconv.TextPtr` goes there rather than a fourth local unwrapper, and
`internal/handler` imports `pgconv` for the first time, which is what the review's S12 asks of
the package.

## No response change, and here is why you can believe it

The golden bodies pinning the contract were captured from the **old** type, and the test was
green before the refactor. The proof is that the same bytes still pass afterwards:

```
{"slug":"euro-lab","name":"Euro Lab","job_count":12,"tagline":"We ship fridges","industries":["fintech"],"hq_country":"de","collections":["yc"]}
{"slug":"x","name":"X","job_count":0,"tagline":null,"industries":[],"hq_country":null,"collections":[]}
```

Asserted as bytes, not as Go values: a struct comparison cannot tell a null tagline from an empty
one, and field order is part of what a caller receives. The SPA's `CompanyListItem` interface
already matches field for field — no frontend change.

Deliberately not in scope: an `internal/companyview` package (jobview earns one by being shared
across four surfaces; companies have one six-field list row), and retyping the detail endpoint's
`companyView` — that is S12, a different endpoint.

Verified: `go build ./... && go vet ./... && go test ./...` green.