### PR TITLE
A job description carries no links

### DIFF
--- a/cmd/backfill-descriptions/main.go
+++ b/cmd/backfill-descriptions/main.go
@@ -14,17 +14,27 @@
 // re-ingest; in-place repair is the only route.
 //
 // A third kind of damage is not an encoding at all: Himalayas brands the bodies it mirrors,
-// ending every posting with an "Originally posted on Himalayas" trailer and rewriting each
-// mention of the hiring company into a backlink to its own page. The adapter now strips both
-// (internal/sources.StripHimalayasSelfPromo); because the feed is a recency-ordered window the
+// ending every posting with an "Originally posted on Himalayas" trailer. The adapter now strips
+// it (internal/sources.StripHimalayasSelfPromo); because the feed is a recency-ordered window the
 // crawl only ever revisits its freshest slice, so the rows already in the catalogue can only be
 // repaired in place. Scope this one to its provider (`backfill-descriptions himalayas`).
 //
-// It pages by keyset and re-decodes every row whose description still carries an encoding marker
-// ("%3C" or "&lt;"), re-running the same sanitize+decode pipeline the fixed adapters use and
-// refreshing content_hash so the row re-indexes. The markers are source-agnostic: any encoded
-// description is repaired the same way, open or closed. Idempotent — a re-decoded row no longer
-// decodes to anything different, so a second run rewrites nothing.
+// The fourth repair is universal and by far the largest: descriptions no longer carry links at
+// all. sanitizeHTML unwraps every anchor to its text (and drops the ones whose text merely
+// repeated their own address), so a stored body that still contains "<a" predates that rule and
+// is re-sanitized here. Expect this to rewrite most of the catalogue on its first run — see the
+// pacing note below.
+//
+// It pages by keyset and rewrites every row whose description still carries a repair marker — an
+// encoding ("%3C" or "&lt;") or an anchor ("<a") — re-running the same sanitize+decode pipeline
+// the adapters use and refreshing content_hash so the row re-indexes. The markers are
+// source-agnostic: any such description is repaired the same way, open or closed. Idempotent — a
+// repaired row carries none of the markers, so a second run rewrites nothing.
+//
+// BACKFILL_PAUSE_MS (default 100) is how long the sweep waits after a page in which it actually
+// wrote rows. Postgres on the app host is untuned and a description lives in TOAST, so rewriting
+// millions of them back to back saturates disk I/O and takes the site down with it. Set it to 0
+// for a small, targeted repair; raise it if the host is already under load.
 //
 // With no argument it sweeps the whole catalogue (universal). Pass a source name as the first
 // argument (e.g. `backfill-descriptions taleo`) to scope the sweep to that provider — the
@@ -40,7 +50,9 @@ import (
 	"context"
 	"log"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -53,14 +65,20 @@ import (
 // backfillBatchSize bounds how many rows are read per keyset page.
 const backfillBatchSize = 500
 
-// A description stored still encoded carries its "<" encoded one of two ways, each the
+// defaultPause is how long the sweep rests after a page in which it wrote rows, when
+// BACKFILL_PAUSE_MS says nothing. It is deliberately non-zero: the universal link strip
+// rewrites most of the catalogue, and each rewrite is a TOAST write.
+const defaultPause = 100 * time.Millisecond
+
+// A row needing repair announces it in its stored text. Two markers are encodings, each the
 // signature of a different upstream habit: percent-encoded ("%3C", the strict-PathUnescape
 // fallback the Taleo adapter used to hit) or HTML entity-encoded ("&lt;", which arbeitnow
-// serves for part of its feed). Either marker selects candidate rows cheaply, without a
-// content-scanning SQL predicate.
+// serves for part of its feed). The third is an anchor, which no description may carry any
+// more. Any of them selects candidate rows cheaply, without a content-scanning SQL predicate.
 const (
 	percentEncodedMarker = "%3C"
 	entityEncodedMarker  = "&lt;"
+	anchorMarker         = "<a"
 )
 
 // himalayasSource is the one provider whose stored bodies carry the aggregator's own branding
@@ -94,7 +112,7 @@ func run() int {
 		source = os.Args[1]
 	}
 
-	scanned, updated, err := backfillAll(ctx, db.New(pool), source)
+	scanned, updated, err := backfillAll(ctx, db.New(pool), source, backfillPause())
 	if err != nil {
 		log.Printf("backfill-descriptions: %v", err)
 		return 1
@@ -108,11 +126,14 @@ func run() int {
 }
 
 // backfillAll pages jobs by keyset (id > last seen, so concurrent writes cannot skip or repeat
-// rows) and re-decodes the ones whose stored description still carries the encoded marker. An
-// empty source sweeps the whole table; a non-empty source scopes the sweep to that provider. The
-// decode reproduces the fixed adapter's pipeline exactly (LenientPercentUnescape then
-// SanitizeHTML), so the recomputed content_hash matches what a re-ingest would produce.
-func backfillAll(ctx context.Context, store jobStore, source string) (scanned, updated int, err error) {
+// rows) and repairs the ones whose stored description still carries a marker. An empty source
+// sweeps the whole table; a non-empty source scopes the sweep to that provider. The repair
+// reproduces the adapter pipeline exactly (decode then SanitizeHTML), so the recomputed
+// content_hash matches what a re-ingest would produce.
+//
+// pause rests between pages that wrote rows, keeping a catalogue-wide sweep from monopolising
+// the database's disk. A page that changed nothing costs nothing, so it does not wait.
+func backfillAll(ctx context.Context, store jobStore, source string, pause time.Duration) (scanned, updated int, err error) {
 	var afterID int64
 	for {
 		jobs, err := pageJobs(ctx, store, source, afterID)
@@ -124,11 +145,12 @@ func backfillAll(ctx context.Context, store jobStore, source string) (scanned, u
 		}
 		afterID = jobs[len(jobs)-1].ID
 
+		wrote := false
 		for _, j := range jobs {
 			scanned++
 			desc := repairDescription(j.Source, j.Description)
 			if desc == j.Description {
-				continue // clean row, or an encoding marker that turned out to be real prose
+				continue // clean row, or a marker that turned out to be real prose
 			}
 			hash := jobhash.Of(hashParams(j, desc))
 			if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
@@ -139,20 +161,36 @@ func backfillAll(ctx context.Context, store jobStore, source string) (scanned, u
 				return scanned, updated, err
 			}
 			updated++
+			wrote = true
 		}
 
 		if len(jobs) < backfillBatchSize {
 			break
 		}
+		if wrote {
+			select {
+			case <-ctx.Done():
+				return scanned, updated, ctx.Err()
+			case <-time.After(pause):
+			}
+		}
 	}
 	return scanned, updated, nil
 }
 
-// repairDescription reproduces the fixed adapters' pipeline for a stored description: decode
-// whichever encoding the row was stored with, then re-sanitize, then drop the branding the
-// serving aggregator added. It returns stored unchanged when there was nothing to repair, so a
-// clean row is never rewritten (and never re-sanitized, keeping the pass free of any dependence
-// on sanitizeHTML being byte-for-byte idempotent).
+// backfillPause reads the between-pages rest from BACKFILL_PAUSE_MS, falling back to
+// defaultPause for an unset or unparseable value. An explicit 0 disables the wait.
+func backfillPause() time.Duration {
+	if ms, err := strconv.Atoi(os.Getenv("BACKFILL_PAUSE_MS")); err == nil && ms >= 0 {
+		return time.Duration(ms) * time.Millisecond
+	}
+	return defaultPause
+}
+
+// repairDescription reproduces the adapters' pipeline for a stored description: decode whichever
+// encoding the row was stored with, then re-sanitize, then drop the branding the serving
+// aggregator added. It returns stored unchanged when there was nothing to repair, so a row with
+// no marker is never rewritten.
 //
 // Each decoder runs only when its own marker is present, so a row mangled by one encoding is
 // never put through the other's decoder — percent-decoding an entity-encoded body would rewrite
@@ -160,10 +198,17 @@ func backfillAll(ctx context.Context, store jobStore, source string) (scanned, u
 // outweighing live markup (see sources.UnescapeEncodedHTML), which is what leaves a posting that
 // merely writes "&lt;" as a less-than sign alone.
 //
-// The de-branding is keyed on source, not on a marker: the markers are the aggregator's own
-// links, and a posting from any other provider that links to them wrote that link itself. It
-// also runs on a body nothing decoded, which is the normal case — branding rides on well-formed
-// HTML — so it sits outside the decode gate.
+// A stored anchor also sends the body through the sanitizer, whatever its source: descriptions
+// carry no links any more (see internal/sources.sanitizeHTML), and the rows stored before that
+// rule can only be brought in line by re-running it. Unlike the decodes this path does lean on
+// the sanitizer being idempotent, which its own test pins. The marker is a plain prefix, so it
+// also matches "<abbr" and friends — those elements are not on the allowlist either, so the
+// sanitizer has work to do on such a row regardless.
+//
+// The de-branding is keyed on source, not on a marker: an "Originally posted on Himalayas"
+// trailer under any other provider is that employer's own text. It also runs on a body nothing
+// else touched, which is the normal case — branding rides on well-formed HTML — so it sits
+// outside the repair gate.
 func repairDescription(source, stored string) string {
 	decoded := stored
 	if strings.Contains(decoded, percentEncodedMarker) {
@@ -173,7 +218,7 @@ func repairDescription(source, stored string) string {
 		decoded = sources.UnescapeEncodedHTML(decoded)
 	}
 	repaired := stored
-	if decoded != stored {
+	if decoded != stored || strings.Contains(decoded, anchorMarker) {
 		repaired = sources.SanitizeHTML(decoded)
 	}
 	if source == himalayasSource {

--- a/cmd/backfill-descriptions/main_test.go
+++ b/cmd/backfill-descriptions/main_test.go
@@ -57,7 +57,7 @@ func TestBackfillDecodesOnlyEncodedDescriptions(t *testing.T) {
 		{ID: 3, Source: "icims", Title: "C", Description: `%3Cp%3EHello%3C%2Fp%3E`},
 	}}
 
-	scanned, updated, err := backfillAll(context.Background(), store, "")
+	scanned, updated, err := backfillAll(context.Background(), store, "", 0)
 	if err != nil {
 		t.Fatalf("backfillAll: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestBackfillScopedToSource(t *testing.T) {
 		{ID: 2, Source: "icims", Title: "B", Description: `%3Cp%3Ehi%3C%2Fp%3E`},
 	}}
 
-	scanned, updated, err := backfillAll(context.Background(), store, "taleo")
+	scanned, updated, err := backfillAll(context.Background(), store, "taleo", 0)
 	if err != nil {
 		t.Fatalf("backfillAll: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestBackfillDecodesEntityEncodedDescriptions(t *testing.T) {
 		{ID: 3, Source: "arbeitnow", Title: "C", Description: "<p>Clean HTML.</p>"},
 	}}
 
-	scanned, updated, err := backfillAll(context.Background(), store, "arbeitnow")
+	scanned, updated, err := backfillAll(context.Background(), store, "arbeitnow", 0)
 	if err != nil {
 		t.Fatalf("backfillAll: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestBackfillDecodesEntityEncodedDescriptions(t *testing.T) {
 	}
 
 	u := store.updates[0]
-	for _, want := range []string{"<h2>Role</h2>", "<li>Go</li>", `href="https://x.test/jobs"`} {
+	for _, want := range []string{"<h2>Role</h2>", "<li>Go</li>", "<p>Find more jobs</p>"} {
 		if !strings.Contains(u.Description, want) {
 			t.Errorf("job 1 missing decoded markup %q: %q", want, u.Description)
 		}
@@ -162,39 +162,103 @@ func TestBackfillDecodesEntityEncodedDescriptions(t *testing.T) {
 }
 
 // TestBackfillStripsHimalayasSelfPromo covers the third way a stored body carries text the
-// employer never wrote: Himalayas brands what it mirrors. Unlike the encoding repairs this one
-// is provider-scoped — the markers are Himalayas' own links, and only its rows may be rewritten
-// on sight of them. It is also the only repair that must fire on an otherwise well-formed body,
-// so it cannot ride on the "did anything decode?" gate the encoding repairs share.
+// employer never wrote: Himalayas brands what it mirrors with an "Originally posted on
+// Himalayas" trailer. Unlike the other repairs this one is provider-scoped — the same trailer
+// under another provider would be that employer's own words — and it must fire on an otherwise
+// well-formed body, so it cannot ride on the "did anything decode?" gate.
 func TestBackfillStripsHimalayasSelfPromo(t *testing.T) {
 	promo := `<p>Join <a href="https://himalayas.app/companies/x" rel="nofollow">X</a>.</p>` +
 		`<p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`
 	store := &fakeStore{jobs: []db.Job{
 		{ID: 1, Source: "himalayas", Title: "A", Description: promo},
-		// Same body under another provider: not ours to rewrite. A greenhouse posting that
-		// genuinely links to himalayas.app is the employer's own text.
+		// Same body under another provider: its links go, like every other source's, but the
+		// trailer is left standing — under greenhouse those are the employer's own words.
 		{ID: 2, Source: "greenhouse", Title: "B", Description: promo},
 		// A himalayas row already cleaned by an earlier run must not be rewritten again.
 		{ID: 3, Source: "himalayas", Title: "C", Description: `<p>Join X.</p>`},
 	}}
 
-	scanned, updated, err := backfillAll(context.Background(), store, "")
+	scanned, updated, err := backfillAll(context.Background(), store, "", 0)
 	if err != nil {
 		t.Fatalf("backfillAll: %v", err)
 	}
-	if scanned != 3 || updated != 1 {
-		t.Fatalf("scanned=%d updated=%d, want 3/1 (only the himalayas promo row)", scanned, updated)
+	if scanned != 3 || updated != 2 {
+		t.Fatalf("scanned=%d updated=%d, want 3/2 (both linked rows, not the clean one)", scanned, updated)
 	}
-	if len(store.updates) != 1 || store.updates[0].ID != 1 {
-		t.Fatalf("updates = %+v, want only himalayas job 1", store.updates)
+	got := map[int64]db.UpdateJobDescriptionParams{}
+	for _, u := range store.updates {
+		got[u.ID] = u
 	}
-	if want := `<p>Join X.</p>`; store.updates[0].Description != want {
-		t.Errorf("Description = %q, want %q", store.updates[0].Description, want)
+	if _, rewritten := got[3]; rewritten {
+		t.Error("the already-clean himalayas row must not be rewritten")
+	}
+	if want := `<p>Join X.</p>`; got[1].Description != want {
+		t.Errorf("himalayas Description = %q, want %q", got[1].Description, want)
+	}
+	if want := `<p>Join X.</p><p>Originally posted on Himalayas</p>`; got[2].Description != want {
+		t.Errorf("greenhouse Description = %q, want %q", got[2].Description, want)
 	}
 	// The row re-indexes only if content_hash moves with the text.
-	want := jobhash.Of(hashParams(store.jobs[0], store.updates[0].Description))
-	if !store.updates[0].ContentHash.Valid || store.updates[0].ContentHash.String != want {
-		t.Errorf("ContentHash = %+v, want %q", store.updates[0].ContentHash, want)
+	want := jobhash.Of(hashParams(store.jobs[0], got[1].Description))
+	if !got[1].ContentHash.Valid || got[1].ContentHash.String != want {
+		t.Errorf("ContentHash = %+v, want %q", got[1].ContentHash, want)
+	}
+}
+
+// TestBackfillStripsLinksAcrossSources pins the universal repair: any stored description that
+// still carries an anchor is re-sanitized, whatever its provider, and a body that never had one
+// is left byte-for-byte alone.
+func TestBackfillStripsLinksAcrossSources(t *testing.T) {
+	store := &fakeStore{jobs: []db.Job{
+		{ID: 1, Source: "greenhouse", Title: "A",
+			Description: `<p>We use <a href="https://k8s.io" rel="nofollow">Kubernetes</a>.</p>`},
+		{ID: 2, Source: "lever", Title: "B",
+			Description: `<p>Apply: <a href="https://x.co/1" rel="nofollow">https://x.co/1</a></p>`},
+		{ID: 3, Source: "workday", Title: "C", Description: `<p>No links here.</p>`},
+	}}
+
+	scanned, updated, err := backfillAll(context.Background(), store, "", 0)
+	if err != nil {
+		t.Fatalf("backfillAll: %v", err)
+	}
+	if scanned != 3 || updated != 2 {
+		t.Fatalf("scanned=%d updated=%d, want 3/2 (the two linked rows)", scanned, updated)
+	}
+	got := map[int64]db.UpdateJobDescriptionParams{}
+	for _, u := range store.updates {
+		got[u.ID] = u
+	}
+	if want := `<p>We use Kubernetes.</p>`; got[1].Description != want {
+		t.Errorf("job 1 Description = %q, want %q", got[1].Description, want)
+	}
+	// The self-labelled anchor goes with its text, and the block it emptied goes too.
+	if want := `<p>Apply: </p>`; got[2].Description != want {
+		t.Errorf("job 2 Description = %q, want %q", got[2].Description, want)
+	}
+	if _, rewritten := got[3]; rewritten {
+		t.Error("the link-free row must not be rewritten")
+	}
+}
+
+// TestBackfillIsIdempotent asserts a second sweep over rows the first one repaired writes
+// nothing — the property that makes it safe to re-run an interrupted catalogue-wide pass.
+func TestBackfillIsIdempotent(t *testing.T) {
+	store := &fakeStore{jobs: []db.Job{
+		{ID: 1, Source: "himalayas", Title: "A",
+			Description: `<p>Join <a href="https://himalayas.app/companies/x">X</a>.</p><p>Originally posted on <a href="https://himalayas.app">Himalayas</a></p>`},
+		{ID: 2, Source: "taleo", Title: "B", Description: `%3Cp%3EApply at %3Ca href=%22https://x.co%22%3Ehttps://x.co%3C/a%3E%3C/p%3E`},
+	}}
+
+	if _, updated, err := backfillAll(context.Background(), store, "", 0); err != nil || updated != 2 {
+		t.Fatalf("first pass: updated=%d err=%v, want 2/nil", updated, err)
+	}
+	for i, u := range store.updates {
+		store.jobs[i].Description = u.Description
+	}
+	store.updates = nil
+
+	if _, updated, err := backfillAll(context.Background(), store, "", 0); err != nil || updated != 0 {
+		t.Fatalf("second pass: updated=%d err=%v, want 0/nil\nrewrote: %+v", updated, err, store.updates)
 	}
 }
 
@@ -205,7 +269,7 @@ func TestBackfillRepairsEncodedHimalayasBody(t *testing.T) {
 	store := &fakeStore{jobs: []db.Job{{ID: 1, Source: "himalayas", Title: "A",
 		Description: `&lt;p&gt;Join us.&lt;/p&gt;&lt;p&gt;Originally posted on &lt;a href="https://himalayas.app"&gt;Himalayas&lt;/a&gt;&lt;/p&gt;`}}}
 
-	if _, updated, err := backfillAll(context.Background(), store, "himalayas"); err != nil || updated != 1 {
+	if _, updated, err := backfillAll(context.Background(), store, "himalayas", 0); err != nil || updated != 1 {
 		t.Fatalf("backfillAll: updated=%d err=%v, want 1/nil", updated, err)
 	}
 	got := store.updates[0].Description

--- a/internal/sources/arbeitnow_test.go
+++ b/internal/sources/arbeitnow_test.go
@@ -107,8 +107,12 @@ func TestArbeitnowDecodesEntityEncodedDescription(t *testing.T) {
 	if strings.Contains(got, "text-align") {
 		t.Errorf("Description kept a disallowed style attribute\ngot: %s", got)
 	}
-	// The board's live-HTML footer passes through untouched.
-	if !strings.Contains(got, `href="https://www.arbeitnow.co.uk/english-speaking-jobs"`) {
-		t.Errorf("Description lost the live footer link\ngot: %s", got)
+	// The board's live-HTML footer keeps its words but loses its link, like every other
+	// anchor in the catalogue.
+	if want := `<p>Find more jobs on Arbeitnow</p>`; !strings.Contains(got, want) {
+		t.Errorf("Description missing the unwrapped footer %q\ngot: %s", want, got)
+	}
+	if strings.Contains(got, "href=") {
+		t.Errorf("Description kept a link\ngot: %s", got)
 	}
 }

--- a/internal/sources/himalayas.go
+++ b/internal/sources/himalayas.go
@@ -109,33 +109,22 @@ func (p himalayasPosting) toJob() (Job, bool) {
 	}, true
 }
 
-// Himalayas brands the bodies it serves: every posting ends with a promo trailer, and each
-// mention of the hiring company is rewritten into a backlink to the company's himalayas.app
-// page. Neither is the employer's text. Both are removed, for two reasons: rendering them
-// would point a reader at a competing aggregator instead of the employer, and the extra
-// visible text is what stops a mirrored posting from fingerprinting to the same role as the
-// copy we already hold from the company's own ATS (see internal/jobhash.RoleFingerprint,
-// which hashes visible text).
+// Himalayas brands the bodies it serves: every posting ends with an "Originally posted on
+// Himalayas" trailer. That paragraph is not the employer's text, and the extra visible text
+// is what stops a mirrored posting from fingerprinting to the same role as the copy we
+// already hold from the company's own ATS (see internal/jobhash.RoleFingerprint, which
+// hashes visible text). The board's other habit — rewriting each mention of the hiring
+// company into a backlink to its himalayas.app page — needs no handling here: sanitizeHTML
+// unwraps every anchor in every source, leaving the company's name as the plain text it was.
 //
-// himalayasPromoTrailer matches only the bare-host link, so a company backlink can never be
-// mistaken for the trailer. himalayasSelfLink then unwraps the backlinks to their visible
-// text — the anchor carries nothing the body does not already say.
-var (
-	himalayasPromoTrailer = regexp.MustCompile(`(?is)\s*<p>\s*Originally posted on\s*<a\b[^>]*href="https?://himalayas\.app/?"[^>]*>\s*Himalayas\s*</a>\s*</p>\s*$`)
-	himalayasSelfLink     = regexp.MustCompile(`(?is)<a\b[^>]*href="https?://himalayas\.app[^"]*"[^>]*>(.*?)</a>`)
-)
+// The anchor is optional in the pattern because the trailer reaches this function both ways:
+// unwrapped when it arrives through sanitizeHTML, and still linked in the catalogue rows
+// stored before descriptions dropped their links.
+var himalayasPromoTrailer = regexp.MustCompile(`(?is)\s*<p>\s*Originally posted on\s*(?:<a\b[^>]*href="https?://himalayas\.app/?"[^>]*>\s*)?Himalayas\s*(?:</a>\s*)?</p>\s*$`)
 
-// StripHimalayasSelfPromo removes Himalayas' own branding from a posting body: the trailing
-// "Originally posted on Himalayas" paragraph and the self-backlinks wrapping company mentions.
-// It expects sanitized HTML (the shape both the adapter and the stored catalogue carry) but
-// also matches the raw feed's un-defanged anchors, so either input cleans the same way.
-//
-// The trailer is stripped BEFORE the backlinks: it is recognised by the anchor it contains,
-// which unwrapping would have already dissolved. Unwrapping deletes the tags rather than
-// replacing them with a space, so `<a>Acme</a>.` keeps its punctuation glued exactly as the
-// employer wrote it. A body carrying neither is returned unchanged, and a cleaned body is
+// StripHimalayasSelfPromo removes the trailing "Originally posted on Himalayas" paragraph
+// from a posting body. A body without one is returned unchanged, and a cleaned body is
 // unchanged by a second pass, so the backfill can re-run over rows it already fixed.
 func StripHimalayasSelfPromo(s string) string {
-	s = himalayasPromoTrailer.ReplaceAllString(s, "")
-	return himalayasSelfLink.ReplaceAllString(s, "$1")
+	return himalayasPromoTrailer.ReplaceAllString(s, "")
 }

--- a/internal/sources/himalayas_test.go
+++ b/internal/sources/himalayas_test.go
@@ -113,15 +113,21 @@ func TestHimalayasErrorsWhenFirstPageFails(t *testing.T) {
 }
 
 func TestStripHimalayasSelfPromo(t *testing.T) {
-	// Bodies are stored post-sanitize, so the anchors carry the rel="nofollow" bluemonday
-	// adds; the raw feed serves them without it. Both shapes must strip.
+	// The trailer reaches this function in three shapes: unwrapped (what sanitizeHTML now
+	// hands the adapter), and still linked with or without the rel="nofollow" the sanitizer
+	// used to add — which is how the catalogue rows stored before the link strip look.
 	cases := []struct {
 		name string
 		in   string
 		want string
 	}{
 		{
-			name: "trailer as stored (sanitized, rel=nofollow)",
+			name: "trailer as sanitized today (link already unwrapped)",
+			in:   `<p>Apply today.</p><p>Originally posted on Himalayas</p>`,
+			want: `<p>Apply today.</p>`,
+		},
+		{
+			name: "trailer as stored before the link strip (rel=nofollow)",
 			in:   `<p>Apply today.</p><p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`,
 			want: `<p>Apply today.</p>`,
 		},
@@ -129,26 +135,6 @@ func TestStripHimalayasSelfPromo(t *testing.T) {
 			name: "trailer as served (raw feed, no rel)",
 			in:   `<p>Apply today.</p><p>Originally posted on <a href="https://himalayas.app">Himalayas</a></p>`,
 			want: `<p>Apply today.</p>`,
-		},
-		{
-			name: "company mention rewritten into a self-backlink is unwrapped to its text",
-			in:   `<p>At <a href="https://himalayas.app/companies/ptc" rel="nofollow">PTC</a>, we build things.</p>`,
-			want: `<p>At PTC, we build things.</p>`,
-		},
-		{
-			name: "unwrapping keeps the punctuation glued, which is what defeats fingerprinting",
-			in:   `<p>a signed agreement with <a href="https://himalayas.app/companies/oasis" rel="nofollow">Oasis</a>.</p>`,
-			want: `<p>a signed agreement with Oasis.</p>`,
-		},
-		{
-			name: "markup nested inside the self-backlink survives the unwrap",
-			in:   `<p><a href="https://himalayas.app/companies/x" rel="nofollow"><strong>Acme</strong></a> hires.</p>`,
-			want: `<p><strong>Acme</strong> hires.</p>`,
-		},
-		{
-			name: "the posting's own outbound links are left alone",
-			in:   `<p>Read our <a href="https://ptc.com/privacy" rel="nofollow">Privacy Policy</a>.</p>`,
-			want: `<p>Read our <a href="https://ptc.com/privacy" rel="nofollow">Privacy Policy</a>.</p>`,
 		},
 		{
 			name: "a body that merely names the mountains is not a promo trailer",
@@ -159,11 +145,6 @@ func TestStripHimalayasSelfPromo(t *testing.T) {
 			name: "a clean body is returned byte-for-byte",
 			in:   `<p>Build web.</p>`,
 			want: `<p>Build web.</p>`,
-		},
-		{
-			name: "trailer and self-backlinks in the same body both go",
-			in:   `<p>Join <a href="https://himalayas.app/companies/x" rel="nofollow">X</a>.</p><p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`,
-			want: `<p>Join X.</p>`,
 		},
 	}
 	for _, tc := range cases {
@@ -178,7 +159,7 @@ func TestStripHimalayasSelfPromo(t *testing.T) {
 func TestStripHimalayasSelfPromoIsIdempotent(t *testing.T) {
 	// The backfill re-runs over rows a previous run already cleaned, so a second pass must
 	// rewrite nothing.
-	in := `<p>At <a href="https://himalayas.app/companies/ptc" rel="nofollow">PTC</a>, we build.</p><p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`
+	in := `<p>At PTC, we build.</p><p>Originally posted on <a href="https://himalayas.app" rel="nofollow">Himalayas</a></p>`
 	once := StripHimalayasSelfPromo(in)
 	if twice := StripHimalayasSelfPromo(once); twice != once {
 		t.Errorf("second pass changed the body:\n got %q\nwant %q", twice, once)

--- a/internal/sources/sanitize.go
+++ b/internal/sources/sanitize.go
@@ -24,11 +24,16 @@ var noBreakSpaces = strings.NewReplacer(
 //
 // It is an explicit prose allowlist rather than bluemonday's UGCPolicy: descriptions
 // come from third-party ATS boards, so we keep only the structural formatting we
-// render (headings, paragraphs, lists, tables, emphasis, links) and drop everything
-// that triggers requests or execution — scripts, styles, forms, and crucially media
+// render (headings, paragraphs, lists, tables, emphasis) and drop everything that
+// triggers requests or execution — scripts, styles, forms, and crucially media
 // (`<img>`), which would otherwise let a posting fetch a tracking pixel against every
-// viewer when rendered with `{@html}`. Links are kept but marked nofollow so untrusted
-// postings cannot pass link authority.
+// viewer when rendered with `{@html}`.
+//
+// `a` is deliberately absent: a description is prose, not a set of exits. bluemonday
+// unwraps an element it does not allow rather than deleting its content, so an anchor
+// leaves its text — and any emphasis inside it — behind. That is what we want, because
+// aggregators weave backlinks through ordinary sentences and deleting the text with the
+// tag would punch holes in the prose.
 var descriptionPolicy = newDescriptionPolicy()
 
 func newDescriptionPolicy() *bluemonday.Policy {
@@ -40,17 +45,114 @@ func newDescriptionPolicy() *bluemonday.Policy {
 		"table", "thead", "tbody", "tr", "th", "td",
 		"strong", "em", "b", "i", "u",
 	)
-	p.AllowAttrs("href").OnElements("a")
-	p.AllowStandardURLs()          // http/https/mailto schemes only
-	p.RequireNoFollowOnLinks(true) // defang untrusted outbound links
 	return p
 }
 
-// sanitizeHTML returns s with active content and media removed, leaving HTML that is
-// safe to render directly in a browser. Adapters call it on their assembled description
+// sanitizeHTML returns s with active content, media, and links removed, leaving HTML that
+// is safe to render directly in a browser. Adapters call it on their assembled description
 // HTML before yielding a job, so the catalogue stores only sanitized markup.
+//
+// Self-labelled anchors are dropped BEFORE the policy runs, because that is the only point
+// at which an anchor's text can still be compared against its own destination — the policy
+// unwraps the tag and the two become indistinguishable from prose.
 func sanitizeHTML(s string) string {
-	return noBreakSpaces.Replace(descriptionPolicy.Sanitize(s))
+	stripped, dropped := dropSelfLabelledAnchors(s)
+	out := noBreakSpaces.Replace(descriptionPolicy.Sanitize(stripped))
+	if dropped {
+		// Only a drop can empty a block, so a body with nothing stripped is never rewritten.
+		out = dropEmptyBlocks(out)
+	}
+	return out
+}
+
+var (
+	// anchorTag matches one anchor: its attribute run and its inner HTML. Anchors cannot
+	// nest in HTML, so the non-greedy body cannot swallow a following link.
+	anchorTag = regexp.MustCompile(`(?is)<a\b([^>]*)>(.*?)</a>`)
+	// anchorHref reads the href value out of an attribute run, quoted either way or bare.
+	anchorHref = regexp.MustCompile(`(?is)\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))`)
+	// innerTag strips the markup nested inside an anchor, leaving its visible text.
+	innerTag = regexp.MustCompile(`<[^>]*>`)
+	// addressLikeText matches visible text that reads as a web address rather than prose:
+	// a scheme, a "www." host, or a dotted host with an optional path. It is only half the
+	// test — "Node.js" matches this too — and is paired with the destination comparison.
+	addressLikeText = regexp.MustCompile(`(?i)^(?:https?://|www\.)\S+$|^[\w-]+(?:\.[\w-]+)+(?:/\S*)?$`)
+	// emptyBlock matches a block element left with nothing in it. The pairs are spelled out
+	// because RE2 has no backreference; a heading may close on a different level, which is
+	// malformed input either way and empty in both readings.
+	emptyBlock = regexp.MustCompile(`(?is)<p>\s*</p>|<li>\s*</li>|<div>\s*</div>|<blockquote>\s*</blockquote>|<td>\s*</td>|<h[1-6]>\s*</h[1-6]>`)
+)
+
+// dropSelfLabelledAnchors removes anchors whose visible text merely repeats their own
+// destination ("<a href=x.co/1>https://x.co/1</a>"). Unwrapped, such an anchor leaves a
+// dead address sitting in the prose — it carries no information the link itself did not,
+// and unlike a worded link there is no sentence to keep whole. Every other anchor is left
+// for the policy to unwrap, text intact.
+//
+// The test is deliberately two-sided: the text must LOOK like an address and must MATCH
+// the href. Either half alone misfires — "Node.js" reads as a host, and a one-word label
+// can be a prefix of its own URL by chance.
+//
+// It reports whether anything was dropped, which is what gates the empty-block sweep.
+func dropSelfLabelledAnchors(s string) (string, bool) {
+	if !strings.Contains(s, "<a") && !strings.Contains(s, "<A") {
+		return s, false
+	}
+	dropped := false
+	out := anchorTag.ReplaceAllStringFunc(s, func(tag string) string {
+		m := anchorTag.FindStringSubmatch(tag)
+		if m == nil || !isSelfLabelled(m[1], m[2]) {
+			return tag
+		}
+		dropped = true
+		return ""
+	})
+	return out, dropped
+}
+
+// isSelfLabelled reports whether an anchor's text says nothing beyond its own address.
+// Only http(s) destinations qualify: a mailto's text is a contact address the reader
+// needs, and it survives the unwrap as prose.
+func isSelfLabelled(attrs, inner string) bool {
+	text := strings.TrimSpace(html.UnescapeString(innerTag.ReplaceAllString(inner, "")))
+	if !addressLikeText.MatchString(text) {
+		return false
+	}
+	m := anchorHref.FindStringSubmatch(attrs)
+	if m == nil {
+		return false
+	}
+	href := strings.ToLower(strings.TrimSpace(m[1] + m[2] + m[3]))
+	if !strings.HasPrefix(href, "http://") && !strings.HasPrefix(href, "https://") {
+		return false
+	}
+	label, target := normalizeAddress(text), normalizeAddress(href)
+	return strings.HasPrefix(label, target) || strings.HasPrefix(target, label)
+}
+
+// normalizeAddress reduces a web address to the part that carries its identity, so a label
+// and its href compare equal across the cosmetic differences between how a board writes the
+// two (scheme present or not, "www." present or not, trailing slash or not).
+func normalizeAddress(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimPrefix(s, "www.")
+	return strings.TrimSuffix(s, "/")
+}
+
+// dropEmptyBlocks removes block elements a dropped anchor left empty, which would otherwise
+// render as a stray gap in the description. It repeats until the body stops changing, so a
+// block whose only child was itself emptied ("<div><p></p></div>") goes too; each pass only
+// shortens the string, so the loop terminates.
+func dropEmptyBlocks(s string) string {
+	for {
+		next := emptyBlock.ReplaceAllString(s, "")
+		if next == s {
+			return s
+		}
+		s = next
+	}
 }
 
 // SanitizeHTML is the exported description sanitizer, for sibling packages that build

--- a/internal/sources/sanitize_test.go
+++ b/internal/sources/sanitize_test.go
@@ -15,7 +15,7 @@ func TestSanitizeHTML(t *testing.T) {
 	got := sanitizeHTML(in)
 
 	// Structural formatting is preserved.
-	for _, want := range []string{"<h2>Role</h2>", "<strong>backend</strong>", "<li>Ship features</li>", `href="https://example.com"`} {
+	for _, want := range []string{"<h2>Role</h2>", "<strong>backend</strong>", "<li>Ship features</li>", "apply"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("sanitizeHTML dropped expected markup %q\ngot: %s", want, got)
 		}
@@ -28,9 +28,89 @@ func TestSanitizeHTML(t *testing.T) {
 		}
 	}
 
-	// Links are defanged so untrusted postings cannot pass link authority.
-	if !strings.Contains(got, `rel="nofollow"`) {
-		t.Errorf("sanitizeHTML should mark links nofollow\ngot: %s", got)
+	// Links carry no destination at all: the anchor is unwrapped to its text.
+	for _, bad := range []string{"<a ", "href=", "example.com", "nofollow"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("sanitizeHTML kept link markup %q\ngot: %s", bad, got)
+		}
+	}
+}
+
+// Descriptions are prose, not a link farm: every anchor is unwrapped to its text, so a
+// posting can neither route a reader off the catalogue nor pass link authority. What the
+// anchor SAID still matters, though — aggregators weave backlinks through ordinary
+// sentences ("we use <a>Kubernetes</a>"), and dropping the text with the tag would punch
+// holes in the prose. The one exception is an anchor whose text is itself a bare URL:
+// stripped of its href that is not prose at all, just an unclickable address, so it goes
+// with the tag.
+func TestSanitizeHTMLStripsLinks(t *testing.T) {
+	cases := map[string]struct{ in, want string }{
+		"anchor unwrapped to its text": {
+			`<p>We use <a href="https://k8s.io">Kubernetes</a> in prod.</p>`,
+			`<p>We use Kubernetes in prod.</p>`,
+		},
+		"nested markup survives the unwrap": {
+			`<p>See <a href="https://x.co"><strong>the docs</strong></a>.</p>`,
+			`<p>See <strong>the docs</strong>.</p>`,
+		},
+		// The unwrap deletes the tags rather than replacing them with a space, so a linked
+		// word keeps its punctuation glued exactly as the employer wrote it. Any drift here
+		// would change visible text and so change role_fingerprint (see internal/jobhash).
+		"unwrap keeps punctuation glued": {
+			`<p>an agreement with <a href="https://x.co">Oasis</a>.</p>`,
+			`<p>an agreement with Oasis.</p>`,
+		},
+		"bare URL text goes with the tag": {
+			`<p>Apply here: <a href="https://boards.x.co/1">https://boards.x.co/1</a></p>`,
+			`<p>Apply here: </p>`,
+		},
+		"schemeless www text goes too": {
+			`<p>More: <a href="https://www.x.co">www.x.co/jobs</a></p>`,
+			`<p>More: </p>`,
+		},
+		"bare domain text goes too": {
+			`<p>Visit <a href="https://arbeitnow.com">arbeitnow.com</a></p>`,
+			`<p>Visit </p>`,
+		},
+		// A contact address is prose the reader needs, even though it looks address-like.
+		"mailto text is kept": {
+			`<p>Send your CV to <a href="mailto:hr@x.co">hr@x.co</a></p>`,
+			`<p>Send your CV to hr@x.co</p>`,
+		},
+		// The aggregator footer the catalogue is full of: the words stay, the link does not.
+		"promo trailer keeps its words": {
+			`<p><a href="https://www.arbeitnow.com/">Find Jobs in Germany on Arbeitnow</a></p>`,
+			`<p>Find Jobs in Germany on Arbeitnow</p>`,
+		},
+		// A block left empty by a dropped bare-URL anchor would render as a stray gap.
+		"block emptied by the drop is removed": {
+			`<p>Role</p><p><a href="https://x.co/1">https://x.co/1</a></p>`,
+			`<p>Role</p>`,
+		},
+		"list item emptied by the drop is removed": {
+			`<ul><li>Go</li><li><a href="https://x.co/1">https://x.co/1</a></li></ul>`,
+			`<ul><li>Go</li></ul>`,
+		},
+		// Nothing to strip: a body without anchors must survive byte for byte.
+		"link-free body is untouched": {
+			`<p>Build <strong>things</strong>.</p>`,
+			`<p>Build <strong>things</strong>.</p>`,
+		},
+	}
+	for name, c := range cases {
+		if got := sanitizeHTML(c.in); got != c.want {
+			t.Errorf("%s: sanitizeHTML(%q) = %q, want %q", name, c.in, got, c.want)
+		}
+	}
+}
+
+// The backfill re-runs this pipeline over rows the ingest path already sanitized, so a
+// second pass must be a no-op — otherwise every run would rewrite the whole catalogue.
+func TestSanitizeHTMLLinkStripIsIdempotent(t *testing.T) {
+	in := `<p>Apply: <a href="https://x.co/1">https://x.co/1</a> or ask <a href="mailto:hr@x.co">hr@x.co</a></p>`
+	once := sanitizeHTML(in)
+	if twice := sanitizeHTML(once); twice != once {
+		t.Errorf("sanitizeHTML is not idempotent:\nonce:  %q\ntwice: %q", once, twice)
 	}
 }
 

--- a/openspec/specs/source-ingest/spec.md
+++ b/openspec/specs/source-ingest/spec.md
@@ -182,7 +182,9 @@ The system SHALL provide a standalone `cmd/ingest` binary that loads configurati
 
 ### Requirement: Adapter descriptions are sanitized HTML
 
-Each adapter SHALL yield the job `description` as sanitized HTML assembled from the platform's authoritative HTML field(s), so the stored value is safe to render directly in a browser without further escaping. An adapter SHALL NOT yield raw or entity-encoded source markup, and SHALL NOT rely on a platform plain-text field that the platform may leave empty or partial. Sanitization SHALL run server-side before the description is persisted, stripping scripts, event handlers, and other active content while preserving structural formatting (headings, paragraphs, lists, emphasis, links).
+Each adapter SHALL yield the job `description` as sanitized HTML assembled from the platform's authoritative HTML field(s), so the stored value is safe to render directly in a browser without further escaping. An adapter SHALL NOT yield raw or entity-encoded source markup, and SHALL NOT rely on a platform plain-text field that the platform may leave empty or partial. Sanitization SHALL run server-side before the description is persisted, stripping scripts, event handlers, and other active content while preserving structural formatting (headings, paragraphs, lists, emphasis).
+
+A persisted description SHALL carry no links. Sanitization SHALL unwrap every anchor to its visible text, so a posting can neither route a reader off the catalogue nor pass link authority, while the sentence the link sat in stays whole. It SHALL discard an anchor whose visible text merely restates its own destination, together with any block element that leaves empty — stripped of its href such text is a dead address rather than prose.
 
 #### Scenario: Greenhouse entity-encoded HTML is decoded and sanitized
 
@@ -203,6 +205,16 @@ Each adapter SHALL yield the job `description` as sanitized HTML assembled from 
 
 - **WHEN** a source posting's HTML contains a `<script>` tag or an inline event handler (e.g. `onclick`)
 - **THEN** the persisted description contains neither the script nor the event handler, while its safe structural markup is retained
+
+#### Scenario: A worded link keeps its words and loses its destination
+
+- **WHEN** a source posting's HTML links a word inside a sentence (e.g. `We use <a href="https://k8s.io">Kubernetes</a> in prod.`)
+- **THEN** the persisted description reads `We use Kubernetes in prod.` with no anchor, href, or `rel` attribute
+
+#### Scenario: A link labelled with its own address is discarded
+
+- **WHEN** a source posting's HTML contains an anchor whose visible text restates its destination (e.g. `<p><a href="https://x.co/1">https://x.co/1</a></p>`)
+- **THEN** the persisted description contains neither the address nor the paragraph it stood alone in
 
 ### Requirement: Workable, Recruitee, and SmartRecruiters are registered providers
 

--- a/web/src/lib/components/JobDescription.svelte
+++ b/web/src/lib/components/JobDescription.svelte
@@ -49,10 +49,6 @@
     margin: 0;
   }
 
-  .job-description :global(a) {
-    text-decoration: underline;
-  }
-
   .job-description :global(b),
   .job-description :global(strong) {
     font-weight: 600;

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -531,10 +531,6 @@
     margin: 0;
   }
 
-  .job-description :global(a) {
-    text-decoration: underline;
-  }
-
   .job-description :global(b),
   .job-description :global(strong) {
     font-weight: 600;


### PR DESCRIPTION
## What

Descriptions no longer carry links anywhere in the catalogue. Every anchor is unwrapped to its text; an anchor whose text merely restates its own address is dropped outright, along with any block it leaves empty.

```
before:  Apply here: <a href="https://boards.x.co/1">https://boards.x.co/1</a>
         We use <a href="https://k8s.io">Kubernetes</a> in prod.
         <a href="https://arbeitnow.com/">Find Jobs in Germany on Arbeitnow</a>

after:   Apply here:
         We use Kubernetes in prod.
         Find Jobs in Germany on Arbeitnow
```

## Why this shape

- **Unwrap, not delete.** Aggregators weave backlinks through ordinary sentences ("we use `<a>`Kubernetes`</a>`"); deleting the text with the tag would punch holes in the prose and, because `role_fingerprint` hashes visible text, would move fingerprints for no reason.
- **Self-labelled anchors are the exception.** Stripped of its href, `https://boards.x.co/1` is a dead address rather than prose. The test is two-sided — the text must *look* like an address **and** *match* the href — because either half alone misfires (`Node.js` reads as a host; a one-word label can be a prefix of its own URL by chance).
- **Order matters.** Self-labelled anchors are dropped *before* bluemonday runs. That is the only point at which an anchor's text can still be compared against its own destination.

## Blast radius

One seam: `internal/sources/sanitize.go`. Every write path already goes through it — the ATS adapters, `internal/linksource`, `internal/moderation`.

`StripHimalayasSelfPromo` shrinks to the promo trailer alone: its company backlinks are now unwrapped like everyone else's. The trailer pattern accepts both the linked and unlinked shape, since stored rows still carry the linked one.

## Ops — this is the expensive half

`cmd/backfill-descriptions` gains the matching universal repair (marker: a stored body still containing `<a`) and a new `BACKFILL_PAUSE_MS` (default 100ms) rest between pages that wrote rows. It will rewrite **most of the catalogue**; each rewrite is a TOAST write and Postgres on the app host is untuned.

```
go run ./cmd/backfill-descriptions      # BACKFILL_PAUSE_MS to pace it
go run ./cmd/backfill-derive            # visible text moved -> role_fingerprint moves
systemctl stop freehire-reindexw.timer  # never stack a manual reindex with the timer
make reindex
systemctl start freehire-reindexw.timer
```

Idempotent: a repaired row carries no marker, so an interrupted sweep is safe to re-run — pinned by a test.

## Spec

`openspec/specs/source-ingest/spec.md` required sanitization to preserve "links". Updated in place with two scenarios, since this PR is the behaviour change rather than an OpenSpec cycle.

## Verification

`go build ./... && go vet ./... && go test ./...` clean; `openspec validate --specs` 180/180.