### PR TITLE
feat(harvest): discover own-ATS boards for aggregator-only companies

### DIFF
--- a/cmd/harvest-boards/jobvite_prober.go
+++ b/cmd/harvest-boards/jobvite_prober.go
@@ -27,5 +27,5 @@ func (jobviteProber) probe(ctx context.Context, c httpClient, slug string) (stri
 	if n == 0 {
 		return "", 0, nil
 	}
-	return slug, n, nil
+	return "", n, nil
 }

--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -66,8 +66,9 @@ func run() int {
 	log.Printf("harvest-boards: %s candidates=%d existing=%d new-candidates=%d",
 		provider, len(raw), len(existing), len(candidates))
 
-	kept, failures := probeAll(ctx, client, p, candidates, companyByBoard)
-	log.Printf("harvest-boards: live boards found=%d probe-failures=%d", len(kept), failures)
+	kept, failures, mismatches := probeAll(ctx, client, p, candidates, companyByBoard)
+	log.Printf("harvest-boards: live boards found=%d probe-failures=%d name-mismatches=%d",
+		len(kept), failures, mismatches)
 	// Every candidate erroring means the probe itself is broken (an API change, an
 	// auth wall, a network outage) — not "no new boards". Fail loudly so the empty
 	// result is not mistaken for an exhausted candidate list.
@@ -137,18 +138,25 @@ func resolveCandidates(ctx context.Context, p prober, c httpClient, seedPath str
 }
 
 // probeAll probes every candidate concurrently (bounded), returning the live boards as
-// emit-ready entries sorted by board plus the number of candidates whose probe errored.
+// emit-ready entries sorted by board, the number of candidates whose probe errored, and the
+// number rejected because the board named a different employer than the seed expected.
 // A probe error is logged and the candidate skipped, so one dead board never aborts the
 // harvest; the caller uses the failure count to fail the run when EVERY probe errored
-// (a broken probe or outage, not a legitimately empty harvest). companyByBoard supplies
-// a fallback employer name for boards whose own API exposes none (see chooseCompany).
-func probeAll(ctx context.Context, client httpClient, p prober, candidates []string, companyByBoard map[string]string) ([]entry, int) {
+// (a broken probe or outage, not a legitimately empty harvest). companyByBoard supplies the
+// employer each candidate is expected to belong to: it gates the board when the platform
+// reports a name of its own, and labels it when the platform reports none (chooseCompany).
+//
+// Mismatches are counted apart from failures because they mean something else entirely — a
+// dead board is noise, while a wave of mismatches means the candidates or the prober's name
+// extraction are wrong, and burying them in the failure count would hide that.
+func probeAll(ctx context.Context, client httpClient, p prober, candidates []string, companyByBoard map[string]string) ([]entry, int, int) {
 	sem := make(chan struct{}, probeWorkers)
 	var (
-		mu       sync.Mutex
-		kept     []entry
-		failures int
-		wg       sync.WaitGroup
+		mu         sync.Mutex
+		kept       []entry
+		failures   int
+		mismatches int
+		wg         sync.WaitGroup
 	)
 	for _, slug := range candidates {
 		wg.Add(1)
@@ -167,12 +175,23 @@ func probeAll(ctx context.Context, client httpClient, p prober, candidates []str
 			if n == 0 {
 				return
 			}
+			// The board is live. It still has to be the board we were looking for: only a
+			// name the platform reports itself can confirm that, and only a seed that named
+			// an expected employer gives it something to confirm against.
+			expected, reported := companyByBoard[slug], reportedName(name, slug)
+			if expected != "" && reported != "" && !sameEmployer(expected, reported) {
+				log.Printf("harvest-boards: %s: expected %q, board reports %q — skipped", slug, expected, reported)
+				mu.Lock()
+				mismatches++
+				mu.Unlock()
+				return
+			}
 			mu.Lock()
-			kept = append(kept, entry{Company: chooseCompany(name, companyByBoard[slug], slug), Board: slug})
+			kept = append(kept, entry{Company: chooseCompany(name, expected, slug), Board: slug})
 			mu.Unlock()
 		}(slug)
 	}
 	wg.Wait()
 	sort.Slice(kept, func(i, j int) bool { return kept[i].Board < kept[j].Board })
-	return kept, failures
+	return kept, failures, mismatches
 }

--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/strelov1/freehire/internal/normalize"
 	"github.com/strelov1/freehire/internal/sources"
 )
 
@@ -188,7 +189,7 @@ func probeAll(ctx context.Context, client httpClient, p prober, candidates []str
 			// normalizes to nothing (punctuation alone) states no expectation at all, and is
 			// treated as such rather than rejecting every board it is paired with.
 			expected := companyByBoard[slug]
-			if normalizeEmployer(expected) != "" && name != "" && !sameEmployer(expected, name) {
+			if normalize.CompanyKey(expected) != "" && name != "" && !normalize.SameCompany(expected, name) {
 				log.Printf("harvest-boards: %s: expected %q, board reports %q — skipped", slug, expected, name)
 				mu.Lock()
 				mismatches++

--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -76,6 +76,14 @@ func run() int {
 		log.Printf("harvest-boards: all %d probes failed", failures)
 		return 1
 	}
+	// Every live board disagreeing with its seed means the gate itself is wrong — a prober
+	// that started reporting a platform-wide name, or a seed built against the wrong
+	// employers — not "no new boards". Same reasoning as the all-probes-failed guard: an
+	// empty harvest that is really a broken one must not exit 0.
+	if mismatches > 0 && len(kept) == 0 {
+		log.Printf("harvest-boards: every live board (%d) disagreed with its expected employer", mismatches)
+		return 1
+	}
 	if len(kept) == 0 {
 		return 0
 	}
@@ -175,12 +183,13 @@ func probeAll(ctx context.Context, client httpClient, p prober, candidates []str
 			if n == 0 {
 				return
 			}
-			// The board is live. It still has to be the board we were looking for: only a
-			// name the platform reports itself can confirm that, and only a seed that named
-			// an expected employer gives it something to confirm against.
-			expected, reported := companyByBoard[slug], reportedName(name, slug)
-			if expected != "" && reported != "" && !sameEmployer(expected, reported) {
-				log.Printf("harvest-boards: %s: expected %q, board reports %q — skipped", slug, expected, reported)
+			// The board is live. It still has to be the board we were looking for, and only
+			// a name the platform publishes itself can confirm that. An expected name that
+			// normalizes to nothing (punctuation alone) states no expectation at all, and is
+			// treated as such rather than rejecting every board it is paired with.
+			expected := companyByBoard[slug]
+			if normalizeEmployer(expected) != "" && name != "" && !sameEmployer(expected, name) {
+				log.Printf("harvest-boards: %s: expected %q, board reports %q — skipped", slug, expected, name)
 				mu.Lock()
 				mismatches++
 				mu.Unlock()

--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -80,8 +80,9 @@ func run() int {
 	// Every live board disagreeing with its seed means the gate itself is wrong — a prober
 	// that started reporting a platform-wide name, or a seed built against the wrong
 	// employers — not "no new boards". Same reasoning as the all-probes-failed guard: an
-	// empty harvest that is really a broken one must not exit 0.
-	if mismatches > 0 && len(kept) == 0 {
+	// empty harvest that is really a broken one must not exit 0. A single rejection is the
+	// gate working, not failing, so the alarm needs more than one.
+	if mismatches > 1 && len(kept) == 0 {
 		log.Printf("harvest-boards: every live board (%d) disagreed with its expected employer", mismatches)
 		return 1
 	}

--- a/cmd/harvest-boards/opencats_prober.go
+++ b/cmd/harvest-boards/opencats_prober.go
@@ -150,15 +150,13 @@ func opencatsEligibleHost(host string) bool {
 // opencatsTitleSuffix matches the "- Careers" tail installs append to the portal title.
 var opencatsTitleSuffix = regexp.MustCompile(`(?i)\s*[-–—|]\s*careers\s*$`)
 
-// opencatsCompanyName proposes a company name from the portal page title, falling back to the
-// host. The proposal is reviewed by hand in the harvest diff: an install that never changed
-// its title yields the hostname again, which reads as a name but is not one.
-func opencatsCompanyName(root *html.Node, board string) string {
-	name := strings.TrimSpace(opencatsTitleSuffix.ReplaceAllString(opencatsPageTitle(root), ""))
-	if name == "" {
-		return strings.Split(board, "/")[0]
-	}
-	return name
+// opencatsCompanyName proposes a company name from the portal page title, or "" when the
+// install never set one. Deriving a name from the host instead would be indistinguishable
+// from a name the portal actually published — and the name a prober returns is what the
+// corroboration gate tests, so a derived one would gate a board against a token the employer
+// never chose. An unnamed board falls back to the seed's name, then to the board id.
+func opencatsCompanyName(root *html.Node, _ string) string {
+	return strings.TrimSpace(opencatsTitleSuffix.ReplaceAllString(opencatsPageTitle(root), ""))
 }
 
 // opencatsPageTitle returns the document's <title> text, or "".

--- a/cmd/harvest-boards/probe_test.go
+++ b/cmd/harvest-boards/probe_test.go
@@ -38,6 +38,9 @@ func TestProbeAllNameGate(t *testing.T) {
 		"unclaimed": {company: "Some Other Name", openJobs: 7},
 		// A candidate whose probe errored.
 		"broken": {err: errors.New("transport failed")},
+		// A live board whose seed names an employer that folds to nothing. Punctuation is
+		// not an expectation, so the board must be kept rather than rejected.
+		"unnameable": {company: "Real Employer", openJobs: 2},
 	}
 	seed := map[string]string{
 		"adoreal":                            "Adoreal",
@@ -45,9 +48,10 @@ func TestProbeAllNameGate(t *testing.T) {
 		"nameless":                           "Nameless Co",
 		"broken":                             "Broken",
 		"acme.wd1.myworkdayjobs.com/careers": "Acme Corporation",
+		"unnameable":                         "???",
 	}
 	candidates := []string{
-		"adoreal", "prequel", "nameless", "unclaimed", "broken",
+		"adoreal", "prequel", "nameless", "unclaimed", "broken", "unnameable",
 		"acme.wd1.myworkdayjobs.com/careers",
 	}
 
@@ -72,6 +76,10 @@ func TestProbeAllNameGate(t *testing.T) {
 	if got["acme.wd1.myworkdayjobs.com/careers"] != "Acme Corporation" {
 		t.Errorf("a platform reporting no name must keep the seed label, got %q",
 			got["acme.wd1.myworkdayjobs.com/careers"])
+	}
+	if got["unnameable"] != "Real Employer" {
+		t.Errorf("an expected name that folds to nothing states no expectation, got %q",
+			got["unnameable"])
 	}
 	if mismatches != 1 {
 		t.Errorf("mismatches = %d, want 1", mismatches)

--- a/cmd/harvest-boards/probe_test.go
+++ b/cmd/harvest-boards/probe_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// scriptedProber answers each board with a canned (company, openJobs, err) triple, so the
+// probeAll gate can be exercised without touching a platform API.
+type scriptedProber map[string]struct {
+	company  string
+	openJobs int
+	err      error
+}
+
+func (p scriptedProber) probe(_ context.Context, _ httpClient, slug string) (string, int, error) {
+	r, ok := p[slug]
+	if !ok {
+		return "", 0, nil
+	}
+	return r.company, r.openJobs, r.err
+}
+
+func TestProbeAllNameGate(t *testing.T) {
+	prober := scriptedProber{
+		// A live board whose reported employer matches the seed's expectation.
+		"adoreal": {company: "Adoreal", openJobs: 26},
+		// A live board that belongs to somebody else entirely — the iCIMS `prequel` shape.
+		"prequel": {company: "A. C. Coy", openJobs: 4},
+		// A live board on a platform that reports no name of its own.
+		"nameless": {company: "", openJobs: 3},
+		// A live board reached from a seed that never named an expected employer.
+		"unclaimed": {company: "Some Other Name", openJobs: 7},
+		// A candidate whose probe errored.
+		"broken": {err: errors.New("transport failed")},
+	}
+	seed := map[string]string{
+		"adoreal":  "Adoreal",
+		"prequel":  "Prequel",
+		"nameless": "Nameless Co",
+		"broken":   "Broken",
+	}
+	candidates := []string{"adoreal", "prequel", "nameless", "unclaimed", "broken"}
+
+	kept, failures, mismatches := probeAll(context.Background(), nil, prober, candidates, seed)
+
+	got := make(map[string]string, len(kept))
+	for _, e := range kept {
+		got[e.Board] = e.Company
+	}
+	if _, ok := got["prequel"]; ok {
+		t.Error("a board reported under a different employer must not be kept")
+	}
+	if got["adoreal"] != "Adoreal" {
+		t.Errorf("matching board should be kept, got %q", got["adoreal"])
+	}
+	if got["nameless"] != "Nameless Co" {
+		t.Errorf("board whose platform reports no name should keep the seed label, got %q", got["nameless"])
+	}
+	if got["unclaimed"] != "Some Other Name" {
+		t.Errorf("seed without an expected employer should not be gated, got %q", got["unclaimed"])
+	}
+	if mismatches != 1 {
+		t.Errorf("mismatches = %d, want 1", mismatches)
+	}
+	if failures != 1 {
+		t.Errorf("failures = %d, want 1 (the errored probe only)", failures)
+	}
+}

--- a/cmd/harvest-boards/probe_test.go
+++ b/cmd/harvest-boards/probe_test.go
@@ -30,18 +30,26 @@ func TestProbeAllNameGate(t *testing.T) {
 		"prequel": {company: "A. C. Coy", openJobs: 4},
 		// A live board on a platform that reports no name of its own.
 		"nameless": {company: "", openJobs: 3},
+		// The Workday shape: the prober used to answer with a token derived from the board
+		// id (the tenant), which is not a name the platform reported. Treating it as one
+		// armed the gate against every Workday seed harvest-ats writes.
+		"acme.wd1.myworkdayjobs.com/careers": {company: "", openJobs: 5},
 		// A live board reached from a seed that never named an expected employer.
 		"unclaimed": {company: "Some Other Name", openJobs: 7},
 		// A candidate whose probe errored.
 		"broken": {err: errors.New("transport failed")},
 	}
 	seed := map[string]string{
-		"adoreal":  "Adoreal",
-		"prequel":  "Prequel",
-		"nameless": "Nameless Co",
-		"broken":   "Broken",
+		"adoreal":                            "Adoreal",
+		"prequel":                            "Prequel",
+		"nameless":                           "Nameless Co",
+		"broken":                             "Broken",
+		"acme.wd1.myworkdayjobs.com/careers": "Acme Corporation",
 	}
-	candidates := []string{"adoreal", "prequel", "nameless", "unclaimed", "broken"}
+	candidates := []string{
+		"adoreal", "prequel", "nameless", "unclaimed", "broken",
+		"acme.wd1.myworkdayjobs.com/careers",
+	}
 
 	kept, failures, mismatches := probeAll(context.Background(), nil, prober, candidates, seed)
 
@@ -60,6 +68,10 @@ func TestProbeAllNameGate(t *testing.T) {
 	}
 	if got["unclaimed"] != "Some Other Name" {
 		t.Errorf("seed without an expected employer should not be gated, got %q", got["unclaimed"])
+	}
+	if got["acme.wd1.myworkdayjobs.com/careers"] != "Acme Corporation" {
+		t.Errorf("a platform reporting no name must keep the seed label, got %q",
+			got["acme.wd1.myworkdayjobs.com/careers"])
 	}
 	if mismatches != 1 {
 		t.Errorf("mismatches = %d, want 1", mismatches)

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -82,7 +82,7 @@ func (leverProber) probe(ctx context.Context, c httpClient, slug string) (string
 	if len(postings) == 0 {
 		return "", 0, nil
 	}
-	return slug, len(postings), nil
+	return "", len(postings), nil
 }
 
 // ashbyProber probes the Ashby public job-board API. The list endpoint returns the live
@@ -102,7 +102,7 @@ func (ashbyProber) probe(ctx context.Context, c httpClient, slug string) (string
 	if len(resp.Jobs) == 0 {
 		return "", 0, nil
 	}
-	return slug, len(resp.Jobs), nil
+	return "", len(resp.Jobs), nil
 }
 
 // bamboohrProber probes the BambooHR per-subdomain careers list. A non-empty result is a
@@ -121,7 +121,7 @@ func (bamboohrProber) probe(ctx context.Context, c httpClient, slug string) (str
 	if len(list.Result) == 0 {
 		return "", 0, nil
 	}
-	return slug, len(list.Result), nil
+	return "", len(list.Result), nil
 }
 
 // workdayProber probes Workday's public CXS listing (POST-only). The board id is
@@ -158,7 +158,7 @@ func (workdayProber) probe(ctx context.Context, c httpClient, boardID string) (s
 	if n == 0 {
 		return "", 0, nil
 	}
-	return tenant, n, nil
+	return "", n, nil
 }
 
 // icimsProber probes an iCIMS career site by its slug. iCIMS exposes no JSON list API, so
@@ -191,7 +191,7 @@ func (icimsProber) probe(ctx context.Context, c httpClient, slug string) (string
 	if n == 0 {
 		return "", 0, nil
 	}
-	return slug, n, nil
+	return "", n, nil
 }
 
 // discoverer is the opt-in capability of a prober whose boards are not available as a seed
@@ -231,15 +231,6 @@ func (workdayProber) boardID(seedToken string) string {
 	return fmt.Sprintf("%s.%s.myworkdayjobs.com/%s", parts[0], parts[1], parts[2])
 }
 
-// orSlug applies the slug-fallback doctrine the API probers share: the platform-reported
-// company name when present, else the slug (board id) itself.
-func orSlug(name, slug string) string {
-	if name != "" {
-		return name
-	}
-	return slug
-}
-
 // workableProber probes the Workable public widget API. A board is the account subdomain;
 // the widget endpoint returns the account name and its open jobs, so a non-empty jobs list
 // is a live board.
@@ -258,7 +249,7 @@ func (workableProber) probe(ctx context.Context, c httpClient, slug string) (str
 	if len(resp.Jobs) == 0 {
 		return "", 0, nil
 	}
-	return orSlug(resp.Name, slug), len(resp.Jobs), nil
+	return resp.Name, len(resp.Jobs), nil
 }
 
 // smartRecruitersProber probes the SmartRecruiters public postings API. The listing carries
@@ -287,17 +278,19 @@ func (smartRecruitersProber) probe(ctx context.Context, c httpClient, slug strin
 		Name string `json:"name"`
 	}
 	_ = c.GetJSON(ctx, fmt.Sprintf("https://api.smartrecruiters.com/v1/companies/%s", slug), &meta)
-	return orSlug(meta.Name, slug), n, nil
+	return meta.Name, n, nil
 }
 
-// recruiteeProber probes the Recruitee per-subdomain offers API. A non-empty offers array
-// is a live board; the list carries no company name, so it falls back to the slug.
+// recruiteeProber probes the Recruitee per-subdomain offers API. A non-empty offers array is
+// a live board, and each offer carries the employer's own name, so the board can be gated
+// against the name the seed expected rather than accepted on liveness alone.
 type recruiteeProber struct{}
 
 func (recruiteeProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
 	var resp struct {
 		Offers []struct {
-			ID int64 `json:"id"`
+			ID          int64  `json:"id"`
+			CompanyName string `json:"company_name"`
 		} `json:"offers"`
 	}
 	if err := c.GetJSON(ctx, fmt.Sprintf("https://%s.recruitee.com/api/offers/", slug), &resp); err != nil {
@@ -306,7 +299,7 @@ func (recruiteeProber) probe(ctx context.Context, c httpClient, slug string) (st
 	if len(resp.Offers) == 0 {
 		return "", 0, nil
 	}
-	return slug, len(resp.Offers), nil
+	return resp.Offers[0].CompanyName, len(resp.Offers), nil
 }
 
 // pinpointProber probes the Pinpoint public postings API. A non-empty data array is a live
@@ -325,17 +318,21 @@ func (pinpointProber) probe(ctx context.Context, c httpClient, slug string) (str
 	if len(resp.Data) == 0 {
 		return "", 0, nil
 	}
-	return slug, len(resp.Data), nil
+	return "", len(resp.Data), nil
 }
 
 // breezyProber probes the Breezy per-subdomain JSON list (a bare array of postings). A
-// non-empty array is a live board; the list carries no company name, so it falls back to
-// the slug.
+// non-empty array is a live board, and each posting embeds the employer's own name, so the
+// board can be gated against the name the seed expected rather than accepted on liveness
+// alone.
 type breezyProber struct{}
 
 func (breezyProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
 	var postings []struct {
-		ID string `json:"id"`
+		ID      string `json:"id"`
+		Company struct {
+			Name string `json:"name"`
+		} `json:"company"`
 	}
 	if err := c.GetJSON(ctx, fmt.Sprintf("https://%s.breezy.hr/json", slug), &postings); err != nil {
 		return "", 0, nil
@@ -343,7 +340,7 @@ func (breezyProber) probe(ctx context.Context, c httpClient, slug string) (strin
 	if len(postings) == 0 {
 		return "", 0, nil
 	}
-	return slug, len(postings), nil
+	return postings[0].Company.Name, len(postings), nil
 }
 
 // teamtailorProber probes a Teamtailor career site. The board is the site host, and its
@@ -364,7 +361,7 @@ func (teamtailorProber) probe(ctx context.Context, c httpClient, host string) (s
 	if len(feed.Items) == 0 {
 		return "", 0, nil
 	}
-	return orSlug(feed.Title, host), len(feed.Items), nil
+	return feed.Title, len(feed.Items), nil
 }
 
 // trakstarProber probes the Trakstar Hire per-subdomain RSS feed. A non-empty channel of
@@ -381,7 +378,7 @@ func (trakstarProber) probe(ctx context.Context, c httpClient, slug string) (str
 	if len(feed.Items) == 0 {
 		return "", 0, nil
 	}
-	return slug, len(feed.Items), nil
+	return "", len(feed.Items), nil
 }
 
 // personioProber probes the Personio public XML feed on the .com host (the host the adapter
@@ -400,7 +397,7 @@ func (personioProber) probe(ctx context.Context, c httpClient, slug string) (str
 	if len(resp.Positions) == 0 {
 		return "", 0, nil
 	}
-	return slug, len(resp.Positions), nil
+	return "", len(resp.Positions), nil
 }
 
 // gemProbeQuery is the minimal list query (extId only) the Gem prober uses for liveness — a
@@ -433,7 +430,7 @@ func (gemProber) probe(ctx context.Context, c httpClient, slug string) (string, 
 	if n == 0 {
 		return "", 0, nil
 	}
-	return slug, n, nil
+	return "", n, nil
 }
 
 // deelJobLocPattern matches a Deel sitemap entry that is a job-detail page (the same shape
@@ -463,7 +460,7 @@ func (deelProber) probe(ctx context.Context, c httpClient, slug string) (string,
 	if n == 0 {
 		return "", 0, nil
 	}
-	return slug, n, nil
+	return "", n, nil
 }
 
 // freshteamJobPattern matches a Freshteam job permalink's /jobs/<12-char-id> segment, the
@@ -485,7 +482,7 @@ func (freshteamProber) probe(ctx context.Context, c httpClient, slug string) (st
 	if n == 0 {
 		return "", 0, nil
 	}
-	return slug, n, nil
+	return "", n, nil
 }
 
 // countMatchingLinks counts the <a href> values in the tree whose value matches pat. It is
@@ -533,7 +530,7 @@ func (joinProber) probe(ctx context.Context, c httpClient, id string) (string, i
 		Name string `json:"name"`
 	}
 	_ = c.GetJSON(ctx, fmt.Sprintf("https://join.com/api/public/companies/%s", id), &meta)
-	return orSlug(meta.Name, id), jobs.Pagination.RowCount, nil
+	return meta.Name, jobs.Pagination.RowCount, nil
 }
 
 // probers maps a provider key to its prober. Adding an ATS is one entry here plus the

--- a/cmd/harvest-boards/prober_test.go
+++ b/cmd/harvest-boards/prober_test.go
@@ -113,9 +113,10 @@ func TestWorkdayProbe(t *testing.T) {
 		"https://aig.wd1.myworkdayjobs.com/wday/cxs/aig/early_careers/jobs": `{"total":9,"jobPostings":[{"title":"x"}]}`,
 		"https://acme.wd5.myworkdayjobs.com/wday/cxs/acme/empty/jobs":       `{"total":0,"jobPostings":[]}`,
 	}
-	// live: name falls back to tenant, count = total
-	if name, n, err := p.probe(context.Background(), getter, "aig.wd1.myworkdayjobs.com/early_careers"); err != nil || name != "aig" || n != 9 {
-		t.Errorf("live: got (%q,%d,%v), want (aig,9,nil)", name, n, err)
+	// live: the tenant is a token derived from the board id, not a name Workday published,
+	// so the prober reports none; count = total
+	if name, n, err := p.probe(context.Background(), getter, "aig.wd1.myworkdayjobs.com/early_careers"); err != nil || name != "" || n != 9 {
+		t.Errorf("live: got (%q,%d,%v), want (\"\",9,nil)", name, n, err)
 	}
 	// empty board => skip
 	if name, n, err := p.probe(context.Background(), getter, "acme.wd5.myworkdayjobs.com/empty"); err != nil || name != "" || n != 0 {
@@ -160,9 +161,9 @@ func TestICIMSProbe(t *testing.T) {
 		),
 	}
 
-	// Live board: name == slug, jobs > 0.
-	if name, n, err := p.probe(context.Background(), getter, "acme"); err != nil || name != "acme" || n != 2 {
-		t.Errorf("acme: got (%q,%d,%v), want (acme,2,nil)", name, n, err)
+	// Live board: the sitemap carries no company name, so none is reported; jobs > 0.
+	if name, n, err := p.probe(context.Background(), getter, "acme"); err != nil || name != "" || n != 2 {
+		t.Errorf("acme: got (%q,%d,%v), want (\"\",2,nil)", name, n, err)
 	}
 	// 200-with-zero-jobs => skip.
 	if name, n, err := p.probe(context.Background(), getter, "empty"); err != nil || name != "" || n != 0 {
@@ -174,9 +175,12 @@ func TestICIMSProbe(t *testing.T) {
 	}
 }
 
-// The lever/ashby/bamboohr provers carry no company name in their payloads, so a live
-// board's name falls back to its slug; an empty or absent board is a ("",0,nil) skip.
-func TestSlugFallbackProbers(t *testing.T) {
+// These platforms publish no employer name in their payloads, so a live board reports "" as
+// its name and takes its label from the seed; an empty or absent board is a ("",0,nil) skip.
+// The empty name is the contract the corroboration gate relies on: a derived token here
+// (a slug, a tenant, a host) would be indistinguishable from a name the platform published,
+// and would gate the board against something the employer never chose.
+func TestNamelessProbers(t *testing.T) {
 	cases := []struct {
 		name   string
 		p      prober
@@ -212,29 +216,11 @@ func TestSlugFallbackProbers(t *testing.T) {
 			live: "acme", empty: "empty",
 		},
 		{
-			name: "recruitee",
-			p:    recruiteeProber{},
-			getter: fakeGetter{
-				"https://acme.recruitee.com/api/offers/":  `{"offers":[{"id":1},{"id":2}]}`,
-				"https://empty.recruitee.com/api/offers/": `{"offers":[]}`,
-			},
-			live: "acme", empty: "empty",
-		},
-		{
 			name: "pinpoint",
 			p:    pinpointProber{},
 			getter: fakeGetter{
 				"https://acme.pinpointhq.com/postings.json":  `{"data":[{"id":"1"}]}`,
 				"https://empty.pinpointhq.com/postings.json": `{"data":[]}`,
-			},
-			live: "acme", empty: "empty",
-		},
-		{
-			name: "breezy",
-			p:    breezyProber{},
-			getter: fakeGetter{
-				"https://acme.breezy.hr/json":  `[{"id":"a"},{"id":"b"}]`,
-				"https://empty.breezy.hr/json": `[]`,
 			},
 			live: "acme", empty: "empty",
 		},
@@ -288,10 +274,10 @@ func TestSlugFallbackProbers(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Live board: name == slug, jobs > 0.
+			// Live board: no name reported, jobs > 0.
 			name, n, err := tc.p.probe(context.Background(), tc.getter, tc.live)
-			if err != nil || name != tc.live || n == 0 {
-				t.Errorf("live: got (%q,%d,%v), want (%q,>0,nil)", name, n, err, tc.live)
+			if err != nil || name != "" || n == 0 {
+				t.Errorf("live: got (%q,%d,%v), want (\"\",>0,nil)", name, n, err)
 			}
 			// Empty board.
 			if name, n, err := tc.p.probe(context.Background(), tc.getter, tc.empty); err != nil || name != "" || n != 0 {
@@ -310,8 +296,10 @@ func TestSlugFallbackProbers(t *testing.T) {
 func TestGemProbe(t *testing.T) {
 	p := gemProber{}
 	live := fakeGetter{"https://jobs.gem.com/api/public/graphql": `{"data":{"oatsExternalJobPostings":{"jobPostings":[{"extId":"x"},{"extId":"y"}]}}}`}
-	if name, n, err := p.probe(context.Background(), live, "acme"); err != nil || name != "acme" || n != 2 {
-		t.Errorf("live: got (%q,%d,%v), want (\"acme\",2,nil)", name, n, err)
+	// Gem publishes no employer name, so the prober reports none — the contract that lets
+	// the corroboration gate tell "no name" from "a name that disagrees".
+	if name, n, err := p.probe(context.Background(), live, "acme"); err != nil || name != "" || n != 2 {
+		t.Errorf("live: got (%q,%d,%v), want (\"\",2,nil)", name, n, err)
 	}
 	empty := fakeGetter{"https://jobs.gem.com/api/public/graphql": `{"data":{"oatsExternalJobPostings":{"jobPostings":[]}}}`}
 	if name, n, err := p.probe(context.Background(), empty, "acme"); err != nil || name != "" || n != 0 {
@@ -387,4 +375,36 @@ func TestNamedProbers(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Recruitee and Breezy are the two platforms in this tool whose public list endpoint carries
+// the employer's own name. Extracting it is what lets the corroboration gate fire for them at
+// all, so the name — not just the liveness count — is the assertion that matters.
+func TestNameReportingProbers(t *testing.T) {
+	t.Run("recruitee", func(t *testing.T) {
+		getter := fakeGetter{
+			"https://11bitstudios.recruitee.com/api/offers/": `{"offers":[{"id":1,"company_name":"11 bit studios"},{"id":2,"company_name":"11 bit studios"}]}`,
+			"https://empty.recruitee.com/api/offers/":        `{"offers":[]}`,
+		}
+		p := recruiteeProber{}
+		if name, n, err := p.probe(context.Background(), getter, "11bitstudios"); err != nil || name != "11 bit studios" || n != 2 {
+			t.Errorf("live: got (%q,%d,%v), want (\"11 bit studios\",2,nil)", name, n, err)
+		}
+		if name, n, err := p.probe(context.Background(), getter, "empty"); err != nil || name != "" || n != 0 {
+			t.Errorf("empty: got (%q,%d,%v), want (\"\",0,nil)", name, n, err)
+		}
+	})
+	t.Run("breezy", func(t *testing.T) {
+		getter := fakeGetter{
+			"https://accelone.breezy.hr/json": `[{"id":"a","company":{"name":"AccelOne"}},{"id":"b","company":{"name":"AccelOne"}}]`,
+			"https://empty.breezy.hr/json":    `[]`,
+		}
+		p := breezyProber{}
+		if name, n, err := p.probe(context.Background(), getter, "accelone"); err != nil || name != "AccelOne" || n != 2 {
+			t.Errorf("live: got (%q,%d,%v), want (\"AccelOne\",2,nil)", name, n, err)
+		}
+		if name, n, err := p.probe(context.Background(), getter, "empty"); err != nil || name != "" || n != 0 {
+			t.Errorf("empty: got (%q,%d,%v), want (\"\",0,nil)", name, n, err)
+		}
+	})
 }

--- a/cmd/harvest-boards/seed.go
+++ b/cmd/harvest-boards/seed.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // seedItem is one candidate board from a seed file. A seed may be a plain JSON array of
@@ -39,11 +41,15 @@ func loadSeedItems(path string) ([]seedItem, error) {
 	return items, nil
 }
 
-// legalSuffixes are corporate-form words dropped from the tail of a company name before
-// two names are compared. Ordered longest-first so the most specific one strips first.
+// legalSuffixes are corporate-form words dropped from the tail of a company name before two
+// names are compared. Ordered longest-first so the most specific one strips first. The
+// single-letter entries (" a s", " s a") are the punctuated Nordic and Romance forms after
+// punctuation has already been reduced to word breaks: "Trafalgar A/S" arrives here as
+// "trafalgar a s".
 var legalSuffixes = []string{
-	" corporation", " limited", " gmbh", " corp", " llc", " ltd", " inc", " bv", " ab",
-	" oy", " as", " co",
+	" corporation", " limited", " gmbh", " corp", " llc", " ltd", " inc", " plc", " llp",
+	" srl", " pty", " a s", " s a", " bv", " nv", " ab", " ag", " kg", " oy", " sa",
+	" as", " co",
 }
 
 // sameEmployer reports whether two company names denote the same employer. It is the gate
@@ -60,41 +66,45 @@ func sameEmployer(expected, reported string) bool {
 	return a != "" && a == b
 }
 
-// normalizeEmployer folds a company name to its comparable core: lower-cased, punctuation
-// reduced to word breaks, one trailing corporate form removed, and the words joined. The
-// word breaks must survive until the suffix strip — collapsing "Derq, Inc." to "derqinc"
-// first would glue the suffix onto the name and hide it.
+// normalizeEmployer folds a company name to its comparable core: lower-cased, diacritics
+// dropped, punctuation reduced to word breaks, trailing corporate forms removed, and the
+// words joined. The word breaks must survive until the suffix strip — collapsing "Derq,
+// Inc." to "derqinc" first would glue the suffix onto the name and hide it.
+//
+// Stripping repeats rather than stopping at one match: compound forms are ordinary ("Acme
+// GmbH & Co. KG", "Atlassian Pty Ltd"), and a single pass would leave half the form behind
+// and report a match as a mismatch.
 func normalizeEmployer(name string) string {
-	words := strings.FieldsFunc(strings.ToLower(name), func(r rune) bool {
+	folded := strings.Map(func(r rune) rune {
+		if unicode.Is(unicode.Mn, r) {
+			return -1
+		}
+		return r
+	}, norm.NFD.String(strings.ToLower(name)))
+
+	words := strings.FieldsFunc(folded, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
 	s := strings.Join(words, " ")
-	for _, suf := range legalSuffixes {
-		if strings.HasSuffix(s, suf) {
-			s = strings.TrimSuffix(s, suf)
-			break
+	for stripped := true; stripped; {
+		stripped = false
+		for _, suf := range legalSuffixes {
+			if strings.HasSuffix(s, suf) {
+				s, stripped = strings.TrimSuffix(s, suf), true
+				break
+			}
 		}
 	}
 	return strings.ReplaceAll(s, " ", "")
 }
 
-// reportedName returns the employer name the platform genuinely reports for a board, or ""
-// when it reports none. Probers for platforms that expose no name echo the board id back as
-// their fallback, so an answer equal to the board id is not a reported name — a distinction
-// both the labelling and the gate depend on, which is why it lives in one place.
-func reportedName(proberName, board string) string {
-	if proberName == board {
-		return ""
-	}
-	return proberName
-}
-
-// chooseCompany picks the board entry's company label. The prober's API-reported name wins
-// when it is a real name (not just the board id echoed back by the slug fallback); otherwise
-// a seed-supplied company fills in, and the board id is the last resort.
+// chooseCompany picks the board entry's company label. A prober returns "" when the platform
+// publishes no employer name of its own (the contract every prober follows), so a non-empty
+// name is always the platform's own and wins; otherwise a seed-supplied company fills in, and
+// the board id is the last resort.
 func chooseCompany(proberName, seedCompany, board string) string {
-	if name := reportedName(proberName, board); name != "" {
-		return name
+	if proberName != "" {
+		return proberName
 	}
 	if seedCompany != "" {
 		return seedCompany

--- a/cmd/harvest-boards/seed.go
+++ b/cmd/harvest-boards/seed.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
+	"unicode"
 )
 
 // seedItem is one candidate board from a seed file. A seed may be a plain JSON array of
@@ -37,12 +39,62 @@ func loadSeedItems(path string) ([]seedItem, error) {
 	return items, nil
 }
 
+// legalSuffixes are corporate-form words dropped from the tail of a company name before
+// two names are compared. Ordered longest-first so the most specific one strips first.
+var legalSuffixes = []string{
+	" corporation", " limited", " gmbh", " corp", " llc", " ltd", " inc", " bv", " ab",
+	" oy", " as", " co",
+}
+
+// sameEmployer reports whether two company names denote the same employer. It is the gate
+// that keeps a live board belonging to somebody else out of the board file: a name-derived
+// candidate slug regularly resolves to an unrelated tenant, and "the board answers with
+// jobs" alone cannot tell the two apart.
+//
+// The comparison is deliberately mild — case, punctuation and a trailing corporate form are
+// noise between an aggregator's label and an ATS's own. It is equally deliberately not
+// fuzzy: substring or prefix matching would admit every tenant whose name happens to contain
+// a short common word, which is the collision this gate exists to catch.
+func sameEmployer(expected, reported string) bool {
+	a, b := normalizeEmployer(expected), normalizeEmployer(reported)
+	return a != "" && a == b
+}
+
+// normalizeEmployer folds a company name to its comparable core: lower-cased, punctuation
+// reduced to word breaks, one trailing corporate form removed, and the words joined. The
+// word breaks must survive until the suffix strip — collapsing "Derq, Inc." to "derqinc"
+// first would glue the suffix onto the name and hide it.
+func normalizeEmployer(name string) string {
+	words := strings.FieldsFunc(strings.ToLower(name), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	s := strings.Join(words, " ")
+	for _, suf := range legalSuffixes {
+		if strings.HasSuffix(s, suf) {
+			s = strings.TrimSuffix(s, suf)
+			break
+		}
+	}
+	return strings.ReplaceAll(s, " ", "")
+}
+
+// reportedName returns the employer name the platform genuinely reports for a board, or ""
+// when it reports none. Probers for platforms that expose no name echo the board id back as
+// their fallback, so an answer equal to the board id is not a reported name — a distinction
+// both the labelling and the gate depend on, which is why it lives in one place.
+func reportedName(proberName, board string) string {
+	if proberName == board {
+		return ""
+	}
+	return proberName
+}
+
 // chooseCompany picks the board entry's company label. The prober's API-reported name wins
 // when it is a real name (not just the board id echoed back by the slug fallback); otherwise
 // a seed-supplied company fills in, and the board id is the last resort.
 func chooseCompany(proberName, seedCompany, board string) string {
-	if proberName != "" && proberName != board {
-		return proberName
+	if name := reportedName(proberName, board); name != "" {
+		return name
 	}
 	if seedCompany != "" {
 		return seedCompany

--- a/cmd/harvest-boards/seed.go
+++ b/cmd/harvest-boards/seed.go
@@ -4,10 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
-	"unicode"
-
-	"golang.org/x/text/unicode/norm"
 )
 
 // seedItem is one candidate board from a seed file. A seed may be a plain JSON array of
@@ -39,63 +35,6 @@ func loadSeedItems(path string) ([]seedItem, error) {
 		return nil, fmt.Errorf("parse seed %s: %w", path, err)
 	}
 	return items, nil
-}
-
-// legalSuffixes are corporate-form words dropped from the tail of a company name before two
-// names are compared. Ordered longest-first so the most specific one strips first. The
-// single-letter entries (" a s", " s a") are the punctuated Nordic and Romance forms after
-// punctuation has already been reduced to word breaks: "Trafalgar A/S" arrives here as
-// "trafalgar a s".
-var legalSuffixes = []string{
-	" corporation", " limited", " gmbh", " corp", " llc", " ltd", " inc", " plc", " llp",
-	" srl", " pty", " a s", " s a", " bv", " nv", " ab", " ag", " kg", " oy", " sa",
-	" as", " co",
-}
-
-// sameEmployer reports whether two company names denote the same employer. It is the gate
-// that keeps a live board belonging to somebody else out of the board file: a name-derived
-// candidate slug regularly resolves to an unrelated tenant, and "the board answers with
-// jobs" alone cannot tell the two apart.
-//
-// The comparison is deliberately mild — case, punctuation and a trailing corporate form are
-// noise between an aggregator's label and an ATS's own. It is equally deliberately not
-// fuzzy: substring or prefix matching would admit every tenant whose name happens to contain
-// a short common word, which is the collision this gate exists to catch.
-func sameEmployer(expected, reported string) bool {
-	a, b := normalizeEmployer(expected), normalizeEmployer(reported)
-	return a != "" && a == b
-}
-
-// normalizeEmployer folds a company name to its comparable core: lower-cased, diacritics
-// dropped, punctuation reduced to word breaks, trailing corporate forms removed, and the
-// words joined. The word breaks must survive until the suffix strip — collapsing "Derq,
-// Inc." to "derqinc" first would glue the suffix onto the name and hide it.
-//
-// Stripping repeats rather than stopping at one match: compound forms are ordinary ("Acme
-// GmbH & Co. KG", "Atlassian Pty Ltd"), and a single pass would leave half the form behind
-// and report a match as a mismatch.
-func normalizeEmployer(name string) string {
-	folded := strings.Map(func(r rune) rune {
-		if unicode.Is(unicode.Mn, r) {
-			return -1
-		}
-		return r
-	}, norm.NFD.String(strings.ToLower(name)))
-
-	words := strings.FieldsFunc(folded, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
-	})
-	s := strings.Join(words, " ")
-	for stripped := true; stripped; {
-		stripped = false
-		for _, suf := range legalSuffixes {
-			if strings.HasSuffix(s, suf) {
-				s, stripped = strings.TrimSuffix(s, suf), true
-				break
-			}
-		}
-	}
-	return strings.ReplaceAll(s, " ", "")
 }
 
 // chooseCompany picks the board entry's company label. A prober returns "" when the platform

--- a/cmd/harvest-boards/seed_test.go
+++ b/cmd/harvest-boards/seed_test.go
@@ -22,37 +22,6 @@ func TestChooseCompany(t *testing.T) {
 	}
 }
 
-func TestSameEmployer(t *testing.T) {
-	tests := []struct {
-		name     string
-		expected string
-		reported string
-		want     bool
-	}{
-		{"identical", "Adoreal", "Adoreal", true},
-		{"case differs", "FLOSUM", "Flosum", true},
-		{"legal suffix on the expected side", "Arch Capital Group Ltd.", "Arch Capital Group", true},
-		{"legal suffix on the reported side", "Derq", "Derq, Inc.", true},
-		{"punctuation and spacing differ", "Much Better Adventures", "much-better_adventures", true},
-		{"ampersand spelled out is still a difference", "Ben & Jerry", "Ben and Jerry", false},
-		{"compound legal form", "Atlassian Pty Ltd", "Atlassian", true},
-		{"non-anglo legal form", "Siemens AG", "Siemens", true},
-		{"punctuated legal form", "Trafalgar A/S", "Trafalgar", true},
-		{"diacritics folded", "Grupo Éxito", "Grupo Exito", true},
-		{"different employers", "Prequel", "A. C. Coy", false},
-		{"both normalize to nothing", "???", "—", false},
-		{"placeholder tenant", "Anatta Design", "Fake job", false},
-		{"one name is a prefix of the other", "Base", "Basecamp", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := sameEmployer(tt.expected, tt.reported); got != tt.want {
-				t.Errorf("sameEmployer(%q, %q) = %v, want %v", tt.expected, tt.reported, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestLoadSeedItemsStringArray(t *testing.T) {
 	path := writeTemp(t, `["a", "b", "c"]`)
 	got, err := loadSeedItems(path)

--- a/cmd/harvest-boards/seed_test.go
+++ b/cmd/harvest-boards/seed_test.go
@@ -12,16 +12,12 @@ func TestChooseCompany(t *testing.T) {
 	if got := chooseCompany("Acme Inc", "Role Co", "acme"); got != "Acme Inc" {
 		t.Errorf("api name should win, got %q", got)
 	}
-	// When the prober only echoed the board id back, a seed-provided name is preferred.
-	if got := chooseCompany("acme", "Acme From Role", "acme"); got != "Acme From Role" {
-		t.Errorf("seed name should fill, got %q", got)
-	}
-	// Empty prober name with a seed name uses the seed name.
+	// A platform that publishes no employer name reports "", and the seed's name fills in.
 	if got := chooseCompany("", "Acme From Role", "acme"); got != "Acme From Role" {
 		t.Errorf("seed name should fill empty, got %q", got)
 	}
 	// No usable name anywhere falls back to the board id.
-	if got := chooseCompany("acme", "", "acme"); got != "acme" {
+	if got := chooseCompany("", "", "acme"); got != "acme" {
 		t.Errorf("should fall back to board, got %q", got)
 	}
 }
@@ -39,7 +35,12 @@ func TestSameEmployer(t *testing.T) {
 		{"legal suffix on the reported side", "Derq", "Derq, Inc.", true},
 		{"punctuation and spacing differ", "Much Better Adventures", "much-better_adventures", true},
 		{"ampersand spelled out is still a difference", "Ben & Jerry", "Ben and Jerry", false},
+		{"compound legal form", "Atlassian Pty Ltd", "Atlassian", true},
+		{"non-anglo legal form", "Siemens AG", "Siemens", true},
+		{"punctuated legal form", "Trafalgar A/S", "Trafalgar", true},
+		{"diacritics folded", "Grupo Éxito", "Grupo Exito", true},
 		{"different employers", "Prequel", "A. C. Coy", false},
+		{"both normalize to nothing", "???", "—", false},
 		{"placeholder tenant", "Anatta Design", "Fake job", false},
 		{"one name is a prefix of the other", "Base", "Basecamp", false},
 	}

--- a/cmd/harvest-boards/seed_test.go
+++ b/cmd/harvest-boards/seed_test.go
@@ -26,6 +26,32 @@ func TestChooseCompany(t *testing.T) {
 	}
 }
 
+func TestSameEmployer(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		reported string
+		want     bool
+	}{
+		{"identical", "Adoreal", "Adoreal", true},
+		{"case differs", "FLOSUM", "Flosum", true},
+		{"legal suffix on the expected side", "Arch Capital Group Ltd.", "Arch Capital Group", true},
+		{"legal suffix on the reported side", "Derq", "Derq, Inc.", true},
+		{"punctuation and spacing differ", "Much Better Adventures", "much-better_adventures", true},
+		{"ampersand spelled out is still a difference", "Ben & Jerry", "Ben and Jerry", false},
+		{"different employers", "Prequel", "A. C. Coy", false},
+		{"placeholder tenant", "Anatta Design", "Fake job", false},
+		{"one name is a prefix of the other", "Base", "Basecamp", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameEmployer(tt.expected, tt.reported); got != tt.want {
+				t.Errorf("sameEmployer(%q, %q) = %v, want %v", tt.expected, tt.reported, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadSeedItemsStringArray(t *testing.T) {
 	path := writeTemp(t, `["a", "b", "c"]`)
 	got, err := loadSeedItems(path)

--- a/cmd/harvest-boards/traffit.go
+++ b/cmd/harvest-boards/traffit.go
@@ -30,5 +30,5 @@ func (traffitProber) probe(ctx context.Context, c httpClient, slug string) (stri
 	if len(resp.Items) == 0 {
 		return "", 0, nil
 	}
-	return slug, resp.Count, nil
+	return "", resp.Count, nil
 }

--- a/cmd/harvest-boards/traffit_test.go
+++ b/cmd/harvest-boards/traffit_test.go
@@ -24,7 +24,9 @@ func TestTraffitProbe(t *testing.T) {
 		wantName string
 		wantN    int
 	}{
-		{"cloudfide", "cloudfide", 5},
+		// Traffit's list endpoint carries no employer name, so the prober reports none and
+		// the board takes its label from the seed.
+		{"cloudfide", "", 5},
 		{"empty", "", 0},
 		{"bogus", "", 0}, // unmapped URL (HTML placeholder in prod) -> getter error -> skip
 	}

--- a/cmd/harvest-orphans/candidates.go
+++ b/cmd/harvest-orphans/candidates.go
@@ -50,29 +50,42 @@ func candidates(slug, company string) []string {
 }
 
 // seedEntries turns the worklist into board-sorted seed entries, dropping any candidate two
-// companies both propose. A contested candidate cannot be attributed: emitting it twice
+// DIFFERENT employers both propose. Such a candidate cannot be attributed: emitting it twice
 // would probe the same board twice and let the entry that happens to sort last decide which
 // employer the gate compares against, quietly filing the board under the wrong company.
+//
+// "Different" is judged on the folded name, not the raw label. One employer routinely
+// reaches the catalogue under two spellings — `company_slug` is normalize.Slug, which keeps
+// legal forms — so "Stripe" and "Stripe, Inc." are two worklist rows whose shared candidate
+// is one employer's board, and the best candidate the tool can produce: two independent
+// sources arriving at the same id. Comparing raw labels would discard exactly that one and
+// keep the junk renderings. A name that folds to nothing identifies nobody, so a second
+// claimant always contests it.
+//
 // Sorting makes a run's output deterministic regardless of row order.
 func seedEntries(orphans []orphan) []seedEntry {
-	claims := make(map[string]string, len(orphans))
+	type claim struct{ company, key string }
+	claims := make(map[string]claim, len(orphans))
 	contested := make(map[string]bool)
 	for _, o := range orphans {
+		key := normalize.CompanyKey(o.Company)
 		for _, c := range candidates(o.Slug, o.Company) {
-			if owner, taken := claims[c]; taken && owner != o.Company {
-				contested[c] = true
+			if prev, taken := claims[c]; taken {
+				if key == "" || prev.key != key {
+					contested[c] = true
+				}
 				continue
 			}
-			claims[c] = o.Company
+			claims[c] = claim{company: o.Company, key: key}
 		}
 	}
 
 	out := make([]seedEntry, 0, len(claims))
-	for board, company := range claims {
+	for board, c := range claims {
 		if contested[board] {
 			continue
 		}
-		out = append(out, seedEntry{Board: board, Company: company})
+		out = append(out, seedEntry{Board: board, Company: c.company})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Board < out[j].Board })
 	return out

--- a/cmd/harvest-orphans/candidates.go
+++ b/cmd/harvest-orphans/candidates.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"sort"
+
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// minCandidate is the shortest candidate board id worth probing. A one- or two-character id
+// matches an unrelated tenant far more often than the intended employer, and the harvest's
+// name gate cannot save it on the platforms that publish no name.
+const minCandidate = 3
+
+// orphan is one company the catalogue holds only through aggregators.
+type orphan struct {
+	Slug    string
+	Company string
+}
+
+// seedEntry is one candidate board written to the seed, in the {board, company} shape
+// cmd/harvest-boards reads. The company is the employer the board is expected to belong to —
+// the harvest's corroboration gate compares it against the name the platform publishes.
+type seedEntry struct {
+	Board   string `json:"board"`
+	Company string `json:"company"`
+}
+
+// candidates proposes board ids for one company from its catalogue slug and display name
+// alone — never from a fetched website, so discovery does not depend on resolving a domain.
+// Three renderings cover how ATS tenants are actually named: the slug the catalogue already
+// derived, the name with its corporate form stripped and words hyphenated, and the same
+// unseparated. Duplicates collapse, so a single-word company proposes exactly one candidate.
+func candidates(slug, company string) []string {
+	var out []string
+	add := func(c string) {
+		if len(c) < minCandidate {
+			return
+		}
+		for _, seen := range out {
+			if seen == c {
+				return
+			}
+		}
+		out = append(out, c)
+	}
+	add(slug)
+	add(normalize.CompanySlug(company))
+	add(normalize.CompanyKey(company))
+	return out
+}
+
+// seedEntries turns the worklist into board-sorted seed entries, dropping any candidate two
+// companies both propose. A contested candidate cannot be attributed: emitting it twice
+// would probe the same board twice and let the entry that happens to sort last decide which
+// employer the gate compares against, quietly filing the board under the wrong company.
+// Sorting makes a run's output deterministic regardless of row order.
+func seedEntries(orphans []orphan) []seedEntry {
+	claims := make(map[string]string, len(orphans))
+	contested := make(map[string]bool)
+	for _, o := range orphans {
+		for _, c := range candidates(o.Slug, o.Company) {
+			if owner, taken := claims[c]; taken && owner != o.Company {
+				contested[c] = true
+				continue
+			}
+			claims[c] = o.Company
+		}
+	}
+
+	out := make([]seedEntry, 0, len(claims))
+	for board, company := range claims {
+		if contested[board] {
+			continue
+		}
+		out = append(out, seedEntry{Board: board, Company: company})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Board < out[j].Board })
+	return out
+}

--- a/cmd/harvest-orphans/candidates_test.go
+++ b/cmd/harvest-orphans/candidates_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestCandidates(t *testing.T) {
+	tests := []struct {
+		name    string
+		slug    string
+		company string
+		want    []string
+	}{
+		{
+			name: "single word yields one candidate",
+			slug: "derq", company: "Derq",
+			want: []string{"derq"},
+		},
+		{
+			name: "multi-word name yields both renderings",
+			slug: "much-better-adventures", company: "Much Better Adventures",
+			want: []string{"much-better-adventures", "muchbetteradventures"},
+		},
+		{
+			name: "legal form is stripped from the name-derived candidates",
+			slug: "arch-capital-group-ltd", company: "Arch Capital Group Ltd.",
+			want: []string{"arch-capital-group-ltd", "arch-capital-group", "archcapitalgroup"},
+		},
+		{
+			name: "aggregator slug carrying a domain suffix keeps its own form too",
+			slug: "derq-com", company: "Derq",
+			want: []string{"derq-com", "derq"},
+		},
+		{
+			name: "a candidate is never repeated",
+			slug: "flosum", company: "flosum",
+			want: []string{"flosum"},
+		},
+		{
+			name: "a name that folds to nothing leaves only the catalogue slug",
+			slug: "mystery-corp", company: "???",
+			want: []string{"mystery-corp"},
+		},
+		{
+			name: "too-short candidates are dropped",
+			slug: "hp", company: "HP",
+			want: nil,
+		},
+		{
+			name: "non-latin name is transliterated",
+			slug: "iandeks", company: "Яндекс",
+			want: []string{"iandeks"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := candidates(tt.slug, tt.company); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("candidates(%q, %q) = %v, want %v", tt.slug, tt.company, got, tt.want)
+			}
+		})
+	}
+}
+
+// The seed must parse as the {board, company} shape cmd/harvest-boards reads, with the
+// expected employer on every entry — it is what the corroboration gate tests, and an entry
+// without one is silently ungated.
+func TestSeedEntriesShape(t *testing.T) {
+	got := seedEntries([]orphan{
+		{Slug: "derq", Company: "Derq"},
+		{Slug: "arch-capital-group-ltd", Company: "Arch Capital Group Ltd."},
+	})
+
+	blob, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back []struct {
+		Board   string `json:"board"`
+		Company string `json:"company"`
+	}
+	if err := json.Unmarshal(blob, &back); err != nil {
+		t.Fatalf("seed does not parse as {board, company}: %v", err)
+	}
+	if len(back) == 0 {
+		t.Fatal("seed is empty")
+	}
+	seen := map[string]bool{}
+	for _, e := range back {
+		if e.Company == "" {
+			t.Errorf("entry %q carries no expected employer", e.Board)
+		}
+		if seen[e.Board] {
+			t.Errorf("board %q emitted twice", e.Board)
+		}
+		seen[e.Board] = true
+	}
+	if !seen["derq"] || !seen["archcapitalgroup"] {
+		t.Errorf("expected both companies' candidates, got %v", seen)
+	}
+}
+
+// Two companies can propose the same candidate board (a shared short name). Emitting it
+// twice would probe it twice and, worse, let whichever entry sorted last decide which
+// employer the gate compares against — so a contested candidate is dropped rather than
+// silently attributed to one of them.
+func TestSeedEntriesDropsContestedCandidates(t *testing.T) {
+	got := seedEntries([]orphan{
+		{Slug: "acme-inc", Company: "Acme Inc"},
+		{Slug: "acme-llc", Company: "Acme LLC"},
+	})
+	for _, e := range got {
+		if e.Board == "acme" {
+			t.Errorf("candidate %q is claimed by two employers and must be dropped", e.Board)
+		}
+	}
+	// The candidates that are not contested still survive.
+	var boards []string
+	for _, e := range got {
+		boards = append(boards, e.Board)
+	}
+	if len(boards) != 2 {
+		t.Errorf("uncontested candidates should remain, got %v", boards)
+	}
+}

--- a/cmd/harvest-orphans/candidates_test.go
+++ b/cmd/harvest-orphans/candidates_test.go
@@ -50,8 +50,8 @@ func TestCandidates(t *testing.T) {
 		},
 		{
 			name: "non-latin name is transliterated",
-			slug: "iandeks", company: "Яндекс",
-			want: []string{"iandeks"},
+			slug: "yandex-ru", company: "Яндекс",
+			want: []string{"yandex-ru", "iandeks"},
 		},
 	}
 	for _, tt := range tests {
@@ -101,26 +101,52 @@ func TestSeedEntriesShape(t *testing.T) {
 	}
 }
 
+// One employer routinely reaches the catalogue under two spellings — company_slug is
+// normalize.Slug, which deliberately keeps legal forms, so "Stripe" on one aggregator and
+// "Stripe, Inc." on another are two worklist rows. Their shared candidate is the SAME
+// employer's board, and the highest-confidence one the tool can produce: two independent
+// sources agreeing on the id. Contesting on the raw display name would throw it away and
+// keep only the junk renderings.
+func TestSeedEntriesKeepsCandidateSharedByOneEmployersSpellings(t *testing.T) {
+	got := seedEntries([]orphan{
+		{Slug: "stripe", Company: "Stripe"},
+		{Slug: "stripe-inc", Company: "Stripe, Inc."},
+	})
+	var boards []string
+	for _, e := range got {
+		boards = append(boards, e.Board)
+	}
+	found := false
+	for _, b := range boards {
+		if b == "stripe" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the candidate both spellings agree on must survive, got %v", boards)
+	}
+}
+
 // Two companies can propose the same candidate board (a shared short name). Emitting it
 // twice would probe it twice and, worse, let whichever entry sorted last decide which
 // employer the gate compares against — so a contested candidate is dropped rather than
 // silently attributed to one of them.
 func TestSeedEntriesDropsContestedCandidates(t *testing.T) {
+	// A catalogue slug is not always derived from the display name (a board file can set a
+	// squished one), so an unrelated employer's name-derived candidate can collide with it.
 	got := seedEntries([]orphan{
-		{Slug: "acme-inc", Company: "Acme Inc"},
-		{Slug: "acme-llc", Company: "Acme LLC"},
+		{Slug: "nova", Company: "Nova Systems"},
+		{Slug: "nova-labs", Company: "Nova"},
 	})
+	var boards []string
 	for _, e := range got {
-		if e.Board == "acme" {
+		boards = append(boards, e.Board)
+		if e.Board == "nova" {
 			t.Errorf("candidate %q is claimed by two employers and must be dropped", e.Board)
 		}
 	}
 	// The candidates that are not contested still survive.
-	var boards []string
-	for _, e := range got {
-		boards = append(boards, e.Board)
-	}
-	if len(boards) != 2 {
+	if len(boards) != 3 {
 		t.Errorf("uncontested candidates should remain, got %v", boards)
 	}
 }

--- a/cmd/harvest-orphans/main.go
+++ b/cmd/harvest-orphans/main.go
@@ -1,0 +1,131 @@
+// Command harvest-orphans builds a candidate-board seed from the companies the catalogue
+// holds only through aggregators — an open posting from an aggregator and none from any
+// first-party ATS. Each company proposes board ids derived from its name alone (no website
+// resolution, no search), paired with the employer the board is expected to belong to.
+//
+// The seed carries no provider: cmd/harvest-boards de-duplicates against each provider's own
+// board file and probes what remains, so one seed is run against every provider whose board
+// id is a name. Providers keyed by a tenant token or a numeric id (workday, gupy, icims,
+// oracle, taleo, cornerstone, pageup, neogov) cannot be seeded this way.
+//
+//	harvest-orphans [-aggregators a,b] [-out orphans.seed.json]   # needs DATABASE_URL
+//	go run ./cmd/harvest-boards <provider> orphans.seed.json      # then, per provider
+//
+// Run-once host tool; review the resulting board-file diff before ingesting.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+// remoteAggregators is the default requested set: the remote-jobs aggregators, whose
+// companies are overwhelmingly product employers rather than the local staffing agencies
+// that dominate the country-specific boards and rarely run an ATS of their own.
+var remoteAggregators = []string{
+	"himalayas", "remoteok", "weworkremotely", "jobspresso",
+	"workingnomads", "4dayweek", "jobicy", "remotive",
+}
+
+func main() { worker.Main(run) }
+
+func run() int {
+	requested := flag.String("aggregators", strings.Join(remoteAggregators, ","),
+		"comma-separated aggregator sources to draw companies from")
+	out := flag.String("out", "orphans.seed.json", "path to write the candidate seed to")
+	flag.Parse()
+
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	from := splitList(*requested)
+	if len(from) == 0 {
+		log.Printf("harvest-orphans: no aggregators requested")
+		return 2
+	}
+	// The exclusion test always considers EVERY aggregator, whatever this run asked for:
+	// narrowing the request must not make another aggregator's posting look like the
+	// first-party ATS coverage that disqualifies a company.
+	all := allAggregatorProviders()
+	if unknown := notIn(from, all); len(unknown) > 0 {
+		log.Printf("harvest-orphans: not aggregator sources: %s", strings.Join(unknown, ", "))
+		return 2
+	}
+
+	rows, err := db.New(pool).OrphanAggregatorCompanies(ctx, db.OrphanAggregatorCompaniesParams{
+		Requested:   from,
+		Aggregators: all,
+	})
+	if err != nil {
+		log.Printf("harvest-orphans: query: %v", err)
+		return 1
+	}
+
+	orphans := make([]orphan, 0, len(rows))
+	for _, r := range rows {
+		orphans = append(orphans, orphan{Slug: r.CompanySlug, Company: r.Company})
+	}
+	entries := seedEntries(orphans)
+	log.Printf("harvest-orphans: %d companies over %d aggregators -> %d candidate boards",
+		len(orphans), len(from), len(entries))
+	if len(entries) == 0 {
+		return 0
+	}
+
+	blob, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		log.Printf("harvest-orphans: encode: %v", err)
+		return 1
+	}
+	if err := os.WriteFile(*out, blob, 0o644); err != nil {
+		log.Printf("harvest-orphans: write %s: %v", *out, err)
+		return 1
+	}
+	log.Printf("harvest-orphans: wrote %s", *out)
+	return 0
+}
+
+// allAggregatorProviders is every provider the pipeline treats as an aggregator — the set the
+// exclusion test is evaluated against, and the set a requested source must belong to.
+func allAggregatorProviders() []string {
+	return sources.AggregatorProviders(sources.All(nil))
+}
+
+// splitList parses a comma-separated flag, dropping blanks so a trailing comma is harmless.
+func splitList(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// notIn returns the members of want absent from have. A source misspelt on the command line
+// would otherwise select nothing and report an empty worklist as a real result.
+func notIn(want, have []string) []string {
+	known := make(map[string]bool, len(have))
+	for _, h := range have {
+		known[h] = true
+	}
+	var missing []string
+	for _, w := range want {
+		if !known[w] {
+			missing = append(missing, w)
+		}
+	}
+	return missing
+}

--- a/cmd/harvest-orphans/main.go
+++ b/cmd/harvest-orphans/main.go
@@ -35,6 +35,10 @@ var remoteAggregators = []string{
 	"workingnomads", "4dayweek", "jobicy", "remotive",
 }
 
+// queryTimeout bounds the worklist scan. It is a backstop against a planner flip, not a
+// budget: the query runs in seconds on the production catalogue.
+const queryTimeout = "10min"
+
 func main() { worker.Main(run) }
 
 func run() int {
@@ -64,7 +68,22 @@ func run() int {
 		return 2
 	}
 
-	rows, err := db.New(pool).OrphanAggregatorCompanies(ctx, db.OrphanAggregatorCompaniesParams{
+	// One pinned connection with a bounded statement time. The worklist scan is a single
+	// long read over the whole jobs table, and an unbounded one held open against prod is the
+	// snapshot hazard that has taken the site down before; measured at ~6s on the production
+	// catalogue, so a cap this generous only ever fires on a plan that has gone wrong.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		log.Printf("harvest-orphans: acquire: %v", err)
+		return 1
+	}
+	defer conn.Release()
+	if _, err := conn.Exec(ctx, "SET statement_timeout = '"+queryTimeout+"'"); err != nil {
+		log.Printf("harvest-orphans: set statement_timeout: %v", err)
+		return 1
+	}
+
+	rows, err := db.New(conn).OrphanAggregatorCompanies(ctx, db.OrphanAggregatorCompaniesParams{
 		Requested:   from,
 		Aggregators: all,
 	})
@@ -98,9 +117,12 @@ func run() int {
 }
 
 // allAggregatorProviders is every provider the pipeline treats as an aggregator — the set the
-// exclusion test is evaluated against, and the set a requested source must belong to.
+// exclusion test is evaluated against, and the set a requested source must belong to. It reads
+// the taxonomy, not the crawl registry: this tool needs only DATABASE_URL, so a
+// credential-gated aggregator (reed, usajobs, whatjobs) would otherwise be absent and its
+// postings would read as the first-party ATS coverage that disqualifies a company.
 func allAggregatorProviders() []string {
-	return sources.AggregatorProviders(sources.All(nil))
+	return sources.AggregatorProviders(sources.Taxonomy())
 }
 
 // splitList parses a comma-separated flag, dropping blanks so a trailing comma is harmless.

--- a/cmd/harvest-orphans/main_test.go
+++ b/cmd/harvest-orphans/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitList(t *testing.T) {
+	if got := splitList("himalayas, remoteok ,"); !reflect.DeepEqual(got, []string{"himalayas", "remoteok"}) {
+		t.Errorf("splitList = %v, want [himalayas remoteok]", got)
+	}
+	if got := splitList("  "); got != nil {
+		t.Errorf("splitList of blanks = %v, want nil", got)
+	}
+}
+
+// A source misspelt on the command line selects no rows, and an empty worklist is
+// indistinguishable from "every company already has an ATS" — so the run must reject the
+// name instead of reporting success.
+func TestNotInCatchesUnknownSources(t *testing.T) {
+	all := []string{"himalayas", "remoteok"}
+	if got := notIn([]string{"himalayas", "himalaya"}, all); !reflect.DeepEqual(got, []string{"himalaya"}) {
+		t.Errorf("notIn = %v, want [himalaya]", got)
+	}
+	if got := notIn([]string{"himalayas", "remoteok"}, all); got != nil {
+		t.Errorf("notIn of known sources = %v, want nil", got)
+	}
+}
+
+// Every default aggregator must be a real aggregator source, or the tool's own default
+// selects nothing.
+func TestRemoteAggregatorsAreKnownSources(t *testing.T) {
+	if len(remoteAggregators) == 0 {
+		t.Fatal("no default aggregators")
+	}
+	if missing := notIn(remoteAggregators, allAggregatorProviders()); len(missing) > 0 {
+		t.Errorf("defaults are not aggregator sources: %v", missing)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
-	golang.org/x/text v0.40.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -150,6 +149,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -35,9 +35,11 @@ require (
 	github.com/valyala/fasthttp v1.73.0
 	github.com/yuin/goldmark v1.8.4
 	golang.org/x/crypto v0.54.0
+	golang.org/x/image v0.44.0
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/text v0.40.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -146,10 +148,8 @@ require (
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
-	golang.org/x/image v0.44.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect
 )

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1596,8 +1596,7 @@ func (q *Queries) MarkLivenessExpired(ctx context.Context, arg MarkLivenessExpir
 
 const orphanAggregatorCompanies = `-- name: OrphanAggregatorCompanies :many
 SELECT j.company_slug,
-       (mode() WITHIN GROUP (ORDER BY j.company))::text AS company,
-       count(*) AS open_jobs
+       (mode() WITHIN GROUP (ORDER BY j.company))::text AS company
 FROM jobs j
 WHERE j.closed_at IS NULL
   AND j.company_slug <> ''
@@ -1620,7 +1619,6 @@ type OrphanAggregatorCompaniesParams struct {
 type OrphanAggregatorCompaniesRow struct {
 	CompanySlug string `json:"company_slug"`
 	Company     string `json:"company"`
-	OpenJobs    int64  `json:"open_jobs"`
 }
 
 // Companies the catalogue holds ONLY through aggregators — the worklist cmd/harvest-orphans
@@ -1645,7 +1643,7 @@ func (q *Queries) OrphanAggregatorCompanies(ctx context.Context, arg OrphanAggre
 	items := []OrphanAggregatorCompaniesRow{}
 	for rows.Next() {
 		var i OrphanAggregatorCompaniesRow
-		if err := rows.Scan(&i.CompanySlug, &i.Company, &i.OpenJobs); err != nil {
+		if err := rows.Scan(&i.CompanySlug, &i.Company); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1594,6 +1594,68 @@ func (q *Queries) MarkLivenessExpired(ctx context.Context, arg MarkLivenessExpir
 	return i, err
 }
 
+const orphanAggregatorCompanies = `-- name: OrphanAggregatorCompanies :many
+SELECT j.company_slug,
+       (mode() WITHIN GROUP (ORDER BY j.company))::text AS company,
+       count(*) AS open_jobs
+FROM jobs j
+WHERE j.closed_at IS NULL
+  AND j.company_slug <> ''
+  AND j.source = ANY($1::text[])
+  AND NOT EXISTS (
+    SELECT 1 FROM jobs ats
+    WHERE ats.company_slug = j.company_slug
+      AND ats.closed_at IS NULL
+      AND ats.source <> ALL($2::text[])
+  )
+GROUP BY j.company_slug
+ORDER BY count(*) DESC, j.company_slug
+`
+
+type OrphanAggregatorCompaniesParams struct {
+	Requested   []string `json:"requested"`
+	Aggregators []string `json:"aggregators"`
+}
+
+type OrphanAggregatorCompaniesRow struct {
+	CompanySlug string `json:"company_slug"`
+	Company     string `json:"company"`
+	OpenJobs    int64  `json:"open_jobs"`
+}
+
+// Companies the catalogue holds ONLY through aggregators — the worklist cmd/harvest-orphans
+// turns into candidate ATS boards. A company qualifies when it has an open posting from one
+// of the REQUESTED aggregators and no open posting from any source outside the FULL
+// aggregator set.
+//
+// The two provider sets are deliberately separate. Narrowing a run to one aggregator must
+// not make another aggregator's posting look like first-party ATS coverage: the candidate
+// scan uses `requested`, the exclusion test always uses `aggregators`. Auditing this same
+// distinction with a partial list is what inflated the July aggregator-dedup leak count
+// roughly fourfold.
+//
+// The display name is the modal `company` across the aggregator rows, since two aggregators
+// may spell the same employer differently and the name is what the harvest gate compares.
+func (q *Queries) OrphanAggregatorCompanies(ctx context.Context, arg OrphanAggregatorCompaniesParams) ([]OrphanAggregatorCompaniesRow, error) {
+	rows, err := q.db.Query(ctx, orphanAggregatorCompanies, arg.Requested, arg.Aggregators)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []OrphanAggregatorCompaniesRow{}
+	for rows.Next() {
+		var i OrphanAggregatorCompaniesRow
+		if err := rows.Scan(&i.CompanySlug, &i.Company, &i.OpenJobs); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const propagateCollectionsToJobs = `-- name: PropagateCollectionsToJobs :execrows
 UPDATE jobs
 SET collections = c.collections,

--- a/internal/db/orphan_companies_integration_test.go
+++ b/internal/db/orphan_companies_integration_test.go
@@ -56,9 +56,12 @@ func TestOrphanAggregatorCompanies(t *testing.T) {
 		// Held by an aggregator AND its own ATS — already crawled, must be excluded.
 		orphanJob("himalayas", "h2", "Covered Co", "covered"),
 		orphanJob("greenhouse", "g1", "Covered Co", "covered"),
-		// Held by two aggregators, no ATS — must appear exactly once.
+		// Held by two aggregators, no ATS — must appear exactly once. The two spell the
+		// employer differently, as aggregators do; the reported name must be the modal
+		// spelling, since it is what the harvest gate compares against the ATS's own.
 		orphanJob("himalayas", "h3", "Twice Listed", "twice"),
-		orphanJob("remoteok", "r1", "Twice Listed", "twice"),
+		orphanJob("himalayas", "h4", "Twice Listed", "twice"),
+		orphanJob("remoteok", "r1", "Twice Listed Ltd.", "twice"),
 		// Held only by an aggregator OUTSIDE the requested set.
 		orphanJob("gulftalent", "gt1", "Gulf Only", "gulfonly"),
 	}
@@ -79,6 +82,9 @@ func TestOrphanAggregatorCompanies(t *testing.T) {
 	}
 	if _, ok := got["twice"]; !ok {
 		t.Error("a company held by two aggregators and no ATS must qualify")
+	}
+	if got["twice"] != "Twice Listed" {
+		t.Errorf("name = %q, want the modal spelling %q", got["twice"], "Twice Listed")
 	}
 	if _, ok := got["gulfonly"]; ok {
 		t.Error("a company held only outside the requested aggregators must not be reported")

--- a/internal/db/orphan_companies_integration_test.go
+++ b/internal/db/orphan_companies_integration_test.go
@@ -1,0 +1,144 @@
+//go:build integration
+
+// Integration tests for the orphan-company worklist: the companies the catalogue holds only
+// through aggregators, which cmd/harvest-orphans turns into candidate ATS boards. The
+// qualifying rule is an absence ("no open posting outside the aggregator set") evaluated
+// against a different provider set than the one that supplies candidates, which is a SQL
+// behavior verifiable only against a real Postgres.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// allAggregators is the full aggregator set — the one the exclusion test must always use.
+var allAggregators = []string{"himalayas", "remoteok", "gulftalent"}
+
+// orphanJob builds an open posting for a company on a named source.
+func orphanJob(source, externalID, company, slug string) UpsertJobParams {
+	p := ingestParams(externalID, "Engineer")
+	p.Source = source
+	p.Company = company
+	p.CompanySlug = slug
+	return p
+}
+
+// orphanSlugs runs the worklist query and returns the company slugs it reported.
+func orphanSlugs(t *testing.T, q *Queries, requested []string) map[string]string {
+	t.Helper()
+	rows, err := q.OrphanAggregatorCompanies(context.Background(), OrphanAggregatorCompaniesParams{
+		Requested:   requested,
+		Aggregators: allAggregators,
+	})
+	if err != nil {
+		t.Fatalf("orphan companies: %v", err)
+	}
+	got := make(map[string]string, len(rows))
+	for _, r := range rows {
+		if _, dup := got[r.CompanySlug]; dup {
+			t.Errorf("company %q reported twice", r.CompanySlug)
+		}
+		got[r.CompanySlug] = r.Company
+	}
+	return got
+}
+
+func TestOrphanAggregatorCompanies(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	seed := []UpsertJobParams{
+		// Held by one aggregator only — the target.
+		orphanJob("himalayas", "h1", "Derq", "derq"),
+		// Held by an aggregator AND its own ATS — already crawled, must be excluded.
+		orphanJob("himalayas", "h2", "Covered Co", "covered"),
+		orphanJob("greenhouse", "g1", "Covered Co", "covered"),
+		// Held by two aggregators, no ATS — must appear exactly once.
+		orphanJob("himalayas", "h3", "Twice Listed", "twice"),
+		orphanJob("remoteok", "r1", "Twice Listed", "twice"),
+		// Held only by an aggregator OUTSIDE the requested set.
+		orphanJob("gulftalent", "gt1", "Gulf Only", "gulfonly"),
+	}
+	for _, p := range seed {
+		mustUpsert(t, q, p)
+	}
+
+	got := orphanSlugs(t, q, []string{"himalayas", "remoteok"})
+
+	if _, ok := got["derq"]; !ok {
+		t.Error("an aggregator-only company must be in the worklist")
+	}
+	if got["derq"] != "Derq" {
+		t.Errorf("company name = %q, want %q", got["derq"], "Derq")
+	}
+	if _, ok := got["covered"]; ok {
+		t.Error("a company with its own ATS posting must be excluded")
+	}
+	if _, ok := got["twice"]; !ok {
+		t.Error("a company held by two aggregators and no ATS must qualify")
+	}
+	if _, ok := got["gulfonly"]; ok {
+		t.Error("a company held only outside the requested aggregators must not be reported")
+	}
+}
+
+// Narrowing the requested aggregators must not turn another aggregator's posting into
+// first-party ATS coverage: the exclusion test always considers every aggregator. A partial
+// list here is the audit mistake that inflated the July aggregator-dedup leak count.
+func TestOrphanAggregatorCompaniesNarrowedRequestStillExcludesOnlyATS(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	for _, p := range []UpsertJobParams{
+		orphanJob("himalayas", "n1", "Both Aggregators", "both"),
+		orphanJob("remoteok", "n2", "Both Aggregators", "both"),
+	} {
+		mustUpsert(t, q, p)
+	}
+
+	got := orphanSlugs(t, q, []string{"himalayas"})
+
+	if _, ok := got["both"]; !ok {
+		t.Error("the remoteok posting is another aggregator, not ATS coverage — company must still qualify")
+	}
+}
+
+// A closed posting is not coverage: a company whose only ATS row has closed is an orphan
+// again, and one whose only aggregator row has closed is not in the catalogue at all.
+func TestOrphanAggregatorCompaniesIgnoresClosedPostings(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+	ctx := context.Background()
+
+	for _, p := range []UpsertJobParams{
+		orphanJob("himalayas", "c1", "Lapsed ATS", "lapsed"),
+		orphanJob("greenhouse", "c2", "Lapsed ATS", "lapsed"),
+		orphanJob("himalayas", "c3", "Gone", "gone"),
+	} {
+		mustUpsert(t, q, p)
+	}
+	if _, err := q.CloseJobBySourceExternalID(ctx, CloseJobBySourceExternalIDParams{
+		Source: "greenhouse", ExternalID: "c2",
+	}); err != nil {
+		t.Fatalf("close ats posting: %v", err)
+	}
+	if _, err := q.CloseJobBySourceExternalID(ctx, CloseJobBySourceExternalIDParams{
+		Source: "himalayas", ExternalID: "c3",
+	}); err != nil {
+		t.Fatalf("close aggregator posting: %v", err)
+	}
+
+	got := orphanSlugs(t, q, []string{"himalayas"})
+
+	if _, ok := got["lapsed"]; !ok {
+		t.Error("a company whose only ATS posting has closed is an orphan again")
+	}
+	if _, ok := got["gone"]; ok {
+		t.Error("a company with no open aggregator posting must not be reported")
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1601,6 +1601,20 @@ type Querier interface {
 	// count. The classifier calls this whenever it confidently labels an email as
 	// application mail, so a recurring unknown ATS domain accrues hits toward promotion.
 	ObserveLearnedDomain(ctx context.Context, domain string) (int32, error)
+	// Companies the catalogue holds ONLY through aggregators — the worklist cmd/harvest-orphans
+	// turns into candidate ATS boards. A company qualifies when it has an open posting from one
+	// of the REQUESTED aggregators and no open posting from any source outside the FULL
+	// aggregator set.
+	//
+	// The two provider sets are deliberately separate. Narrowing a run to one aggregator must
+	// not make another aggregator's posting look like first-party ATS coverage: the candidate
+	// scan uses `requested`, the exclusion test always uses `aggregators`. Auditing this same
+	// distinction with a partial list is what inflated the July aggregator-dedup leak count
+	// roughly fourfold.
+	//
+	// The display name is the modal `company` across the aggregator rows, since two aggregators
+	// may spell the same employer differently and the name is what the harvest gate compares.
+	OrphanAggregatorCompanies(ctx context.Context, arg OrphanAggregatorCompaniesParams) ([]OrphanAggregatorCompaniesRow, error)
 	// Domains whose confident-hit count has reached the promotion threshold; the sync
 	// worker unions these into the Gmail search query.
 	PromotedDomains(ctx context.Context, threshold int32) ([]string, error)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -1079,8 +1079,7 @@ WHERE j.id = m.id
 -- The display name is the modal `company` across the aggregator rows, since two aggregators
 -- may spell the same employer differently and the name is what the harvest gate compares.
 SELECT j.company_slug,
-       (mode() WITHIN GROUP (ORDER BY j.company))::text AS company,
-       count(*) AS open_jobs
+       (mode() WITHIN GROUP (ORDER BY j.company))::text AS company
 FROM jobs j
 WHERE j.closed_at IS NULL
   AND j.company_slug <> ''

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -1063,3 +1063,33 @@ WHERE j.id = m.id
   AND j.company_slug = sqlc.arg(company)
   AND j.closed_at IS NULL
   AND j.duplicate_of IS DISTINCT FROM m.canon_id;
+
+-- name: OrphanAggregatorCompanies :many
+-- Companies the catalogue holds ONLY through aggregators — the worklist cmd/harvest-orphans
+-- turns into candidate ATS boards. A company qualifies when it has an open posting from one
+-- of the REQUESTED aggregators and no open posting from any source outside the FULL
+-- aggregator set.
+--
+-- The two provider sets are deliberately separate. Narrowing a run to one aggregator must
+-- not make another aggregator's posting look like first-party ATS coverage: the candidate
+-- scan uses `requested`, the exclusion test always uses `aggregators`. Auditing this same
+-- distinction with a partial list is what inflated the July aggregator-dedup leak count
+-- roughly fourfold.
+--
+-- The display name is the modal `company` across the aggregator rows, since two aggregators
+-- may spell the same employer differently and the name is what the harvest gate compares.
+SELECT j.company_slug,
+       (mode() WITHIN GROUP (ORDER BY j.company))::text AS company,
+       count(*) AS open_jobs
+FROM jobs j
+WHERE j.closed_at IS NULL
+  AND j.company_slug <> ''
+  AND j.source = ANY(sqlc.arg(requested)::text[])
+  AND NOT EXISTS (
+    SELECT 1 FROM jobs ats
+    WHERE ats.company_slug = j.company_slug
+      AND ats.closed_at IS NULL
+      AND ats.source <> ALL(sqlc.arg(aggregators)::text[])
+  )
+GROUP BY j.company_slug
+ORDER BY count(*) DESC, j.company_slug;

--- a/internal/normalize/company.go
+++ b/internal/normalize/company.go
@@ -1,0 +1,56 @@
+package normalize
+
+import "strings"
+
+// legalSuffixes are corporate-form words dropped from the tail of a company name before two
+// names are compared. Ordered longest-first so the most specific one strips first. The
+// single-letter entries (" a s", " s a") are the punctuated Nordic and Romance forms after
+// punctuation has already been reduced to word breaks: "Trafalgar A/S" arrives as
+// "trafalgar a s".
+var legalSuffixes = []string{
+	" corporation", " limited", " gmbh", " corp", " llc", " ltd", " inc", " plc", " llp",
+	" srl", " pty", " a s", " s a", " bv", " nv", " ab", " ag", " kg", " oy", " sa",
+	" as", " co",
+}
+
+// CompanySlug is [Slug] with any trailing corporate forms removed: "Arch Capital Group Ltd."
+// becomes "arch-capital-group". An empty or untransliterable name yields "".
+//
+// Stripping repeats rather than stopping at one match: compound forms are ordinary ("Acme
+// GmbH & Co. KG", "Atlassian Pty Ltd"), and a single pass would leave half the form behind.
+// The word breaks must survive until the strip — folding "Derq, Inc." to "derqinc" first
+// would glue the suffix on and hide it.
+func CompanySlug(name string) string {
+	s := strings.Join(strings.Fields(strings.ReplaceAll(Slug(name), "-", " ")), " ")
+	for stripped := true; stripped; {
+		stripped = false
+		for _, suf := range legalSuffixes {
+			if strings.HasSuffix(s, suf) {
+				s, stripped = strings.TrimSuffix(s, suf), true
+				break
+			}
+		}
+	}
+	return strings.ReplaceAll(s, " ", "-")
+}
+
+// CompanyKey folds a company name to a comparable core: [CompanySlug] with the word breaks
+// removed as well, so two sources that separate the words differently still agree.
+//
+// This is a comparison key, not a display or URL key — unlike [Slug] it joins the words with
+// nothing and strips legal forms, both of which would be wrong in a path segment.
+func CompanyKey(name string) string {
+	return strings.ReplaceAll(CompanySlug(name), "-", "")
+}
+
+// SameCompany reports whether two company names denote the same employer.
+//
+// The comparison is deliberately mild — case, punctuation, script and a trailing corporate
+// form are noise between one source's label and another's. It is equally deliberately not
+// fuzzy: substring or prefix matching would treat every employer whose name contains a short
+// common word as the same company ("Base" would match "Basecamp"). Two names that both fold
+// to nothing are not a match, since that says nothing about either.
+func SameCompany(a, b string) bool {
+	ka := CompanyKey(a)
+	return ka != "" && ka == CompanyKey(b)
+}

--- a/internal/normalize/company_test.go
+++ b/internal/normalize/company_test.go
@@ -1,0 +1,35 @@
+package normalize
+
+import "testing"
+
+func TestSameCompany(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		reported string
+		want     bool
+	}{
+		{"identical", "Adoreal", "Adoreal", true},
+		{"case differs", "FLOSUM", "Flosum", true},
+		{"legal suffix on the expected side", "Arch Capital Group Ltd.", "Arch Capital Group", true},
+		{"legal suffix on the reported side", "Derq", "Derq, Inc.", true},
+		{"punctuation and spacing differ", "Much Better Adventures", "much-better_adventures", true},
+		{"ampersand spelled out is still a difference", "Ben & Jerry", "Ben and Jerry", false},
+		{"compound legal form", "Atlassian Pty Ltd", "Atlassian", true},
+		{"non-anglo legal form", "Siemens AG", "Siemens", true},
+		{"punctuated legal form", "Trafalgar A/S", "Trafalgar", true},
+		{"diacritics folded", "Grupo Éxito", "Grupo Exito", true},
+		{"different employers", "Prequel", "A. C. Coy", false},
+		{"both normalize to nothing", "???", "—", false},
+		{"placeholder tenant", "Anatta Design", "Fake job", false},
+		{"non-latin script folded", "Яндекс", "Iandeks", true},
+		{"one name is a prefix of the other", "Base", "Basecamp", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SameCompany(tt.expected, tt.reported); got != tt.want {
+				t.Errorf("SameCompany(%q, %q) = %v, want %v", tt.expected, tt.reported, got, tt.want)
+			}
+		})
+	}
+}

--- a/openspec/changes/harvest-orphan-company-boards/.openspec.yaml
+++ b/openspec/changes/harvest-orphan-company-boards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/harvest-orphan-company-boards/design.md
+++ b/openspec/changes/harvest-orphan-company-boards/design.md
@@ -112,6 +112,20 @@ are different questions and the second must be able to discard. Putting the deci
 `chooseCompany` a pure labelling function and leaves the rejection counter next to the
 existing failure counter.
 
+### Aggregator membership is a taxonomy question, not a capability one
+
+`sources.All(c)` registers usajobs, reed and whatjobs only when their credentials are in the
+environment — deliberate, so an unconfigured process does not list a provider it cannot
+crawl. Deriving the exclusion set from that registry would therefore make a company held only
+by Reed look ATS-covered whenever the tool runs without Reed's key, which is every run: the
+tool needs `DATABASE_URL` and nothing else. The failure is silent and one-directional —
+genuine orphans vanish from the worklist, exit code 0.
+
+So `sources.AllAggregatorProviders()` answers the classification question independently of
+credentials, and the crawl registry keeps answering the capability one. `cmd/reindex`'s
+suppression pass asks the same classification question and now uses it too; on prod, where
+the credentials are set, its behaviour is unchanged.
+
 ### The worklist query asks for absence of ATS, not presence of aggregator
 
 A company qualifies on `NOT EXISTS (a non-aggregator open posting)`, evaluated against the
@@ -141,6 +155,20 @@ that using a partial aggregator list inflated its results roughly fourfold.
   → The operator was explicit that the queue should absorb it. Board files reach prod as
   bind-mounted data, so no image rebuild is involved and a bad batch is reverted by
   reverting the YAML.
+- **The worklist scan is one long read over `jobs`.** Measured on the production catalogue
+  (2026-08-01): a Nested Loop Anti Join driven by `jobs_source_id_open_idx` with
+  `jobs_open_company_created_at_id_idx` on the inner side, **5.8s for 8,562 companies** — no
+  sequential scan. The risk is a future planner flip to a hash anti-join, whose inner
+  relation is the whole open table; the tool pins one connection with a 10-minute
+  `statement_timeout` so that cannot become an unbounded read holding a snapshot open.
+- **A URL-imported posting counts as ATS coverage.** `weblink` (a one-off user link import)
+  is not an aggregator, so a company whose only non-aggregator row came from one is excluded
+  even though no board of theirs is crawled. Conservative in the safe direction — a missed
+  candidate, never a wrong board — and left as-is rather than special-cased.
+- **A stripped name can shrink to a short generic token.** "Sky Co" yields the candidate
+  `sky`. On the platforms that publish no employer name such a board is accepted on liveness
+  alone, so the PR diff is the only backstop. Raising the minimum length would cost the real
+  three-letter employers (ibm, sap), which is the worse trade.
 - **A harvest run and a reindex must not collide.** → Onboarding is a normal deploy plus
   per-provider ingest; any manual reindex that follows must stop `freehire-reindexw.timer`
   first, per the standing rule.

--- a/openspec/changes/harvest-orphan-company-boards/design.md
+++ b/openspec/changes/harvest-orphan-company-boards/design.md
@@ -60,13 +60,38 @@ different names, since a name-derived candidate is the same string for every pla
 The cost is honest: ~21k candidates × ~20 providers ≈ 250k probes per full run. This is a
 run-once host tool and the probe fan-out is already bounded and polite.
 
+### A prober reports "" when the platform publishes no name
+
+The gate needs to tell "the platform published no employer name" from "the platform
+published a name that disagrees". The tool used to encode the first case as "the returned
+name equals the board id" — a slug echoed back. That inference is wrong for two probers:
+`workdayProber` returned the tenant and `opencatsCompanyName` the host, neither of which
+equals the board id, so both would have read as published names and armed the gate against a
+token the employer never chose. Since `cmd/harvest-ats` and `cmd/harvest-role` already emit
+seeds carrying an expected employer, a Workday run would have rejected every live board and
+exited 0.
+
+So the contract is explicit instead of inferred: a prober returns `""` when the platform
+publishes no name. That is behaviour-preserving for the ~14 probers whose fallback token was
+the board id — `chooseCompany` already treated those as nameless — and it fixes the two
+where the token was derived. `orSlug` and the equality inference are both gone.
+
 ### The gate compares normalized names, and only when both sides exist
 
-Rejecting a candidate needs both an expected name (from the seed) and a reported name (from
-the platform). When either is missing there is nothing to compare and behaviour is exactly
-today's: seeds without a company keep validating on live jobs alone, and platforms that
-report no name keep taking the seed's name as their label. This is what keeps every existing
-seed — Common Crawl, universities, wantapply — working unchanged.
+Rejecting a candidate needs both an expected name (from the seed) and a published name (from
+the platform). When either is missing there is nothing to compare: seeds without a company
+validate on live jobs alone, and platforms that publish no name take the seed's name as their
+label. An expected name that normalizes to nothing (punctuation alone) states no expectation
+either, and is treated as absent rather than rejecting the board.
+
+This limits where the gate can fire at all, and the limit is wide: of the tool's ~30 probers
+only greenhouse, workable, smartrecruiters, teamtailor, join, gupy, paycom, opencats and —
+newly — recruitee and breezy obtain a name. The rest were audited against their live APIs;
+Lever, Ashby, Personio, BambooHR, iCIMS, Traffit and the HTML-scraped platforms publish no
+employer name anywhere in their public payloads, so for them a board is still accepted on
+liveness alone and labelled from the seed. Extracting a name where one exists (recruitee's
+`company_name`, breezy's `company.name`, both verified against live boards) is part of this
+change; inventing one where it does not is not.
 
 Normalization is deliberately mild: case-fold, strip legal-form suffixes
 (`inc/llc/ltd/limited/gmbh/corp/co/bv/ab/oy/as`), collapse everything non-alphanumeric.
@@ -99,8 +124,11 @@ that using a partial aggregator list inflated its results roughly fourfold.
 
 - **A name-derived slug resolves to an unrelated tenant.** → The corroboration gate is
   exactly this defence, and it is the change's primary deliverable rather than a side
-  effect. Platforms that report no name at all (jazzhr and jobvite serve HTML) cannot be
-  gated and are simply not part of the run.
+  effect. It cannot cover everything: a platform that publishes no employer name gives the
+  gate nothing to test, and that is most of them. The orphan run's yield is concentrated in
+  Workable and SmartRecruiters, which both publish names, so the bulk of what this change
+  onboards is gated — but a board harvested on Lever or BambooHR is still accepted on
+  liveness alone and must be read as such in the PR diff.
 - **A probe answers for a demo or template tenant.** → Live jobs plus a matching company
   name is a much narrower target than live jobs alone; the sampled bamboohr "Fake job"
   tenant was rejected on the name.

--- a/openspec/changes/harvest-orphan-company-boards/design.md
+++ b/openspec/changes/harvest-orphan-company-boards/design.md
@@ -121,10 +121,9 @@ by Reed look ATS-covered whenever the tool runs without Reed's key, which is eve
 tool needs `DATABASE_URL` and nothing else. The failure is silent and one-directional —
 genuine orphans vanish from the worklist, exit code 0.
 
-So `sources.AllAggregatorProviders()` answers the classification question independently of
-credentials, and the crawl registry keeps answering the capability one. `cmd/reindex`'s
-suppression pass asks the same classification question and now uses it too; on prod, where
-the credentials are set, its behaviour is unchanged.
+`sources.Taxonomy()` (landed on main in parallel with this change, #1403) answers the
+classification question independently of credentials, and `All(c)` keeps answering the
+capability one. This tool reads the taxonomy.
 
 ### The worklist query asks for absence of ATS, not presence of aggregator
 

--- a/openspec/changes/harvest-orphan-company-boards/design.md
+++ b/openspec/changes/harvest-orphan-company-boards/design.md
@@ -1,0 +1,135 @@
+## Context
+
+`cmd/harvest-boards` already turns a candidate slug list into live-validated entries in
+`sources/<provider>.yml`: it de-duplicates against the file, probes each survivor through one
+of 32 per-platform probers, and appends what answers with jobs. It reads two seed shapes — a
+bare `["slug", …]` array and a richer `[{board, company}, …]` — and it already threads the
+seed's `company` through `resolveCandidates` into `probeAll` as `companyByBoard`.
+
+What it does with that name is the gap. `chooseCompany` (`cmd/harvest-boards/seed.go:43`)
+prefers the platform's reported name whenever it is not just the slug echoed back, and falls
+back to the seed's. The seed name is a *label of last resort*, never a check. So a candidate
+that resolves to a live board belonging to someone else is kept and labelled with the wrong
+employer's name — the failure that put iCIMS `prequel` under A. C. Coy's tenant in July and
+forced a revert.
+
+What has never existed is a way to decide *which* companies to chase. Every seed so far came
+from outside: a Common Crawl dump, a universities directory, a scraped company list. The
+catalogue itself knows which companies we hold only as aggregator mirrors, and it is the
+best worklist available — 8,571 companies across the eight remote-jobs aggregators, measured
+2026-08-01.
+
+A July attempt at this went by way of each company's website (`slug → .com` → careers page →
+`atsdetect`) and stalled on website resolution, not on ATS detection. Probing platform APIs
+with a name-derived slug skips the website entirely. Measured against 12 platform APIs on 80
+randomly sampled uncovered himalayas companies: 12 live boards (15%), of which 11 were
+confirmed as the right company by comparing the platform's reported name.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Derive the orphan-company worklist from the catalogue, not from an external dataset.
+- Propose candidate boards from the company name alone — no website, no search, no LLM.
+- Make a seed-supplied employer name a gate, not a label, so a harvest cannot onboard the
+  wrong tenant.
+- Reuse `cmd/harvest-boards` as the only writer of `sources/*.yml`.
+
+**Non-Goals:**
+
+- Resolving company websites or searching the web for a company's board. That is what the
+  July attempt did and where it died; if the 15% ceiling proves too low, it is a separate
+  change.
+- Providers whose board id is not a name: Workday (`tenant|dc|site`), gupy (numeric id),
+  iCIMS, Oracle, Taleo, Cornerstone, PageUp, NeoGov. A company name cannot produce those.
+- Any change to how boards are ingested, deduplicated, or enriched once onboarded.
+
+## Decisions
+
+### The seed is provider-agnostic; the provider loop lives in the run, not the tool
+
+`harvest-orphans` writes one seed of `{board, company}` pairs and no provider. The operator
+runs `harvest-boards <provider> orphans.seed.json` once per name-slug provider.
+
+The alternative — have `harvest-orphans` emit `<provider>.seed.json` per platform — would
+duplicate knowledge that already lives in `harvest-boards`: which providers exist, how a
+board id is de-duplicated per provider (Workday folds case, Ashby does not), and which
+boards the file already holds. Per-provider seeds would also be identical files under
+different names, since a name-derived candidate is the same string for every platform.
+
+The cost is honest: ~21k candidates × ~20 providers ≈ 250k probes per full run. This is a
+run-once host tool and the probe fan-out is already bounded and polite.
+
+### The gate compares normalized names, and only when both sides exist
+
+Rejecting a candidate needs both an expected name (from the seed) and a reported name (from
+the platform). When either is missing there is nothing to compare and behaviour is exactly
+today's: seeds without a company keep validating on live jobs alone, and platforms that
+report no name keep taking the seed's name as their label. This is what keeps every existing
+seed — Common Crawl, universities, wantapply — working unchanged.
+
+Normalization is deliberately mild: case-fold, strip legal-form suffixes
+(`inc/llc/ltd/limited/gmbh/corp/co/bv/ab/oy/as`), collapse everything non-alphanumeric.
+Measured on the sample this is what admits `Arch Capital Group Ltd.` against the platform's
+`Arch Capital Group` while still rejecting the bamboohr tenant whose only posting is called
+"Fake job". Substring matching was considered and rejected: it would admit any company whose
+name contains a short common word.
+
+A rejection is counted and logged apart from an unreachable candidate. Folding the two
+together would hide a systematic mismatch — a probe that started returning a platform-wide
+name instead of a tenant name — inside the normal noise of dead boards.
+
+### Placement of the gate: `probeAll`, not `chooseCompany`
+
+`chooseCompany` answers "what do we call this board"; the gate answers "do we keep it". They
+are different questions and the second must be able to discard. Putting the decision in
+`probeAll`, where the probe result and the seed entry are both in hand, keeps
+`chooseCompany` a pure labelling function and leaves the rejection counter next to the
+existing failure counter.
+
+### The worklist query asks for absence of ATS, not presence of aggregator
+
+A company qualifies on `NOT EXISTS (a non-aggregator open posting)`, evaluated against the
+*full* aggregator set, while the candidate scan is narrowed to the requested aggregators.
+Splitting the two sets matters: narrowing a run to himalayas must not make a remoteok
+posting look like first-party ATS coverage. The July audit of this same distinction found
+that using a partial aggregator list inflated its results roughly fourfold.
+
+## Risks / Trade-offs
+
+- **A name-derived slug resolves to an unrelated tenant.** → The corroboration gate is
+  exactly this defence, and it is the change's primary deliverable rather than a side
+  effect. Platforms that report no name at all (jazzhr and jobvite serve HTML) cannot be
+  gated and are simply not part of the run.
+- **A probe answers for a demo or template tenant.** → Live jobs plus a matching company
+  name is a much narrower target than live jobs alone; the sampled bamboohr "Fake job"
+  tenant was rejected on the name.
+- **250k probes across ~20 providers is slow, and bamboohr is the slow pole** — dead
+  subdomains hang to the client timeout. DNS pre-filtering was investigated and does not
+  work: bamboohr, recruitee, breezy and personio all serve wildcard DNS, so every nonsense
+  subdomain resolves. → Accept it; the tool is run-once, its fan-out is bounded, and
+  providers can be run one at a time.
+- **~1,200–1,500 new boards raise ingest time and enrichment queue depth proportionally.**
+  → The operator was explicit that the queue should absorb it. Board files reach prod as
+  bind-mounted data, so no image rebuild is involved and a bad batch is reverted by
+  reverting the YAML.
+- **A harvest run and a reindex must not collide.** → Onboarding is a normal deploy plus
+  per-provider ingest; any manual reindex that follows must stop `freehire-reindexw.timer`
+  first, per the standing rule.
+
+## Migration Plan
+
+1. Merge the tool and the gate; nothing changes in production until a harvest is run.
+2. Run `harvest-orphans` against the eight remote-jobs aggregators to produce the seed.
+3. Run `harvest-boards <provider> orphans.seed.json` for each name-slug provider; review the
+   combined YAML diff as one PR.
+4. Deploy with `--no-build` (board files are bind-mounted data) and ingest each changed
+   provider.
+
+Rollback is reverting the YAML additions: a board that is no longer listed is no longer
+crawled, and the postings it already produced are handled by the normal lifecycle.
+
+## Open Questions
+
+None. Scope, the acceptance gate, name-match strictness, and rollout pace were settled
+before this document was written.

--- a/openspec/changes/harvest-orphan-company-boards/proposal.md
+++ b/openspec/changes/harvest-orphan-company-boards/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+8,571 companies reach the catalogue only through a remote-jobs aggregator: they have open
+postings from himalayas/remoteok/weworkremotely/jobspresso/workingnomads/4dayweek/jobicy/
+remotive and not one row from a first-party ATS. An aggregator mirror is a worse copy of the
+same vacancy — it lags the employer's own revision, carries the aggregator's branding, and
+applies through the aggregator's form. Where the employer runs its own board we should be
+crawling that board.
+
+An earlier attempt (July 2026) tried to reach those boards by resolving each company's
+*website* and detecting the ATS linked from its careers page, and died on website
+resolution. Probing the ATS platforms directly with a slug derived from the company name
+needs no website at all. Measured on 80 randomly sampled uncovered himalayas companies
+against 12 platform APIs: **12 live boards found (15%)**, and comparing the employer name
+the platform reports against the name the aggregator gave confirmed **11 of the 12** as the
+right company. Seven of the twelve were Workable — whose board id simply *is* the company
+slug, and whose board file holds 761 entries against Greenhouse's 7,109.
+
+That name comparison is also a fix the harvest tool has needed since July, when an
+unrelated harvest onboarded iCIMS `prequel` under the wrong tenant and had to be reverted.
+
+## What Changes
+
+- **New `cmd/harvest-orphans`**: reads the catalogue, finds companies whose open postings
+  come only from aggregator sources, derives name-slug candidates for each, and writes one
+  provider-agnostic seed file in the `[{board, company}]` shape `cmd/harvest-boards`
+  already reads.
+- **`cmd/harvest-boards` gains a corroboration gate**: today a seed-supplied `company` is
+  only a fallback label for platforms that report no name of their own, and a platform that
+  *does* report a name wins silently even when it names a different employer. When the seed
+  states the expected employer and the platform reports a name, the two SHALL agree
+  (compared normalized) or the candidate is dropped and counted. A seed that names no
+  expected employer keeps today's behaviour exactly.
+
+Not in scope, deliberately: resolving company websites, web search, and any LLM step. The
+previous attempt failed on exactly that path, and the slug probe does not need it.
+
+## Capabilities
+
+### New Capabilities
+
+- `orphan-company-seed`: deriving a candidate-board worklist from companies the catalogue
+  holds only through aggregators — which companies qualify, what candidate slugs are
+  proposed for each, and the seed shape handed to the harvest tool.
+
+### Modified Capabilities
+
+- `board-harvest`: a kept board must belong to the employer the seed named. Adds the
+  corroboration gate to the existing live-validation requirement.
+
+## Impact
+
+- **New**: `cmd/harvest-orphans` (run-once host tool; needs `DATABASE_URL`, like every
+  other worker).
+- **Changed**: `cmd/harvest-boards` — `probeAll` and the seed-company handling in
+  `seed.go`. Every existing seed (Common Crawl dumps, the universities directory, the
+  wantapply list) names no expected employer and is unaffected.
+- **Data**: a harvest run appends to roughly twenty `sources/*.yml` files — the providers
+  whose board id is a name slug. Workday, gupy, iCIMS, Oracle, Taleo, Cornerstone, PageUp
+  and NeoGov are excluded: their board ids are tenant tokens or numeric ids that a company
+  name cannot produce.
+- **Downstream**: ~1,200–1,500 new boards is a proportional rise in ingest crawl time and
+  enrichment queue depth. Ingesting them needs no image rebuild — board files reach prod as
+  bind-mounted data.

--- a/openspec/changes/harvest-orphan-company-boards/specs/board-harvest/spec.md
+++ b/openspec/changes/harvest-orphan-company-boards/specs/board-harvest/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: The harvest tool validates candidate boards against the live platform API
+
+The `harvest-boards` host tool SHALL expand a board file (`sources/<provider>.yml`)
+only with boards it has live-validated: each candidate board SHALL be probed
+against the platform's own live surface — its official public API, or, for a
+self-hosted platform that exposes no API, the portal's own served pages — and kept
+only if that surface reports at least one open job, so the committed file is the
+project's own validated fact set rather than a redistributed dataset. A candidate
+that is absent, closed, or unreachable SHALL be skipped, never abort the run. A
+kept board SHALL be appended to the provider's board file with the company name
+the platform reports (or the board id when the platform exposes none),
+de-duplicated against the boards already in the file.
+
+Live jobs alone do not make a board the right board. When the seed names the employer a
+candidate is expected to belong to, and the platform reports a company name of its own, the
+two SHALL agree — compared after normalizing case, punctuation and legal-form suffixes — or
+the candidate SHALL be rejected and counted separately from an unreachable one, so a
+mismatch is visible as a mismatch rather than as an absent board. A seed that names no
+expected employer SHALL be validated on live jobs alone, and a platform that reports no name
+of its own SHALL keep taking the seed's name as its label.
+
+#### Scenario: A candidate with open jobs is kept
+
+- **WHEN** a candidate board is probed and the platform API reports one or more
+  open jobs
+- **THEN** the board is appended to `sources/<provider>.yml` with the reported
+  company name (or the board id as a fallback)
+
+#### Scenario: A candidate with no open jobs is skipped
+
+- **WHEN** a candidate board is probed and the platform API reports zero jobs or
+  is unreachable
+- **THEN** the board is not appended and the run continues with the other
+  candidates
+
+#### Scenario: An already-known board is not duplicated
+
+- **WHEN** a candidate board id already appears in `sources/<provider>.yml`
+- **THEN** it is filtered out before probing and not appended again
+
+#### Scenario: A self-hosted portal is validated against its own pages
+
+- **WHEN** a candidate belongs to a platform that publishes no vendor API, and its
+  portal page lists one or more open postings
+- **THEN** the candidate is validated from that page and kept exactly as an
+  API-validated candidate would be
+
+#### Scenario: A live board owned by a different employer is rejected
+
+- **WHEN** the seed expects a candidate to belong to one employer, and the platform reports
+  open jobs under a different company name
+- **THEN** the board is not appended, and the run reports it as a name mismatch rather than
+  as a skipped or unreachable candidate
+
+#### Scenario: Legal-form suffixes and punctuation do not break agreement
+
+- **WHEN** the seed's expected employer and the platform's reported name differ only in
+  case, punctuation, or a legal-form suffix
+- **THEN** the names are treated as agreeing and the board is kept
+
+#### Scenario: A seed without an expected employer is unaffected
+
+- **WHEN** a seed entry names no expected employer
+- **THEN** the candidate is validated on live jobs alone, exactly as before

--- a/openspec/changes/harvest-orphan-company-boards/specs/orphan-company-seed/spec.md
+++ b/openspec/changes/harvest-orphan-company-boards/specs/orphan-company-seed/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Companies held only through aggregators are the harvest worklist
+
+The `harvest-orphans` host tool SHALL derive its worklist from the catalogue itself: a
+company qualifies when it has at least one open posting from a source in the requested
+aggregator set and no open posting from any source outside the full aggregator set. A
+company whose own ATS is already crawled SHALL therefore never appear in the worklist, and
+a company held by two aggregators and no ATS SHALL appear exactly once. The requested
+aggregator set SHALL be narrowable to a subset of the aggregators, so a run can target one
+segment of the catalogue, while the exclusion test SHALL always consider every aggregator —
+a company held by an aggregator outside the requested set is still not ATS-covered, and
+narrowing the run must not silently promote it to a first-party source.
+
+#### Scenario: A company held only by aggregators qualifies
+
+- **WHEN** a company's open postings all come from aggregator sources
+- **THEN** it appears once in the worklist, with the employer name the catalogue records
+  for it
+
+#### Scenario: A company already crawled from its own ATS is excluded
+
+- **WHEN** a company has an open posting from a non-aggregator source
+- **THEN** it is absent from the worklist, whatever else holds it
+
+#### Scenario: Narrowing the requested aggregators does not widen the worklist
+
+- **WHEN** a run requests one aggregator, and a candidate company also has open postings
+  from a second aggregator outside the requested set
+- **THEN** the company still qualifies, because the second source is an aggregator too —
+  it is not treated as first-party ATS coverage
+
+### Requirement: Each company proposes name-derived candidate boards
+
+The tool SHALL propose candidate board ids for a company from its name and catalogue slug
+alone, never from a fetched website, so discovery does not depend on resolving a domain.
+Candidates SHALL be derived by stripping legal-form suffixes from the company name and
+rendering the remainder both hyphenated and unseparated, together with the catalogue slug
+itself. Candidates SHALL be de-duplicated per company, and a candidate too short to
+identify an employer SHALL be dropped — a two-character slug matches an unrelated tenant far
+more often than the intended one.
+
+#### Scenario: A multi-word name yields both renderings
+
+- **WHEN** a company is named with several words and a legal-form suffix
+- **THEN** the candidates include the hyphenated and the unseparated forms of the name
+  without that suffix, and the catalogue slug, each listed once
+
+#### Scenario: A degenerate candidate is dropped
+
+- **WHEN** a derived candidate is shorter than the minimum length
+- **THEN** it is not proposed, and the company still contributes its other candidates
+
+### Requirement: The worklist is emitted as a harvest seed
+
+The tool SHALL write its candidates as a single provider-agnostic seed file in the shape the
+harvest tool already reads, each entry pairing a candidate board id with the employer name
+expected to own it. One seed SHALL serve every provider: the harvest tool de-duplicates
+against the provider's own board file and probes what remains, so the seed carries no
+provider of its own. The expected employer name SHALL always be present on every entry,
+since it is what the harvest tool's corroboration gate tests.
+
+#### Scenario: One seed feeds every provider
+
+- **WHEN** the tool has built candidates for the worklist
+- **THEN** it writes one seed file of board/company pairs, with no provider recorded, ready
+  to be run against any provider in turn
+
+#### Scenario: Every entry names its expected employer
+
+- **WHEN** a candidate is written to the seed
+- **THEN** it carries the employer name from the catalogue, never an empty name

--- a/openspec/changes/harvest-orphan-company-boards/tasks.md
+++ b/openspec/changes/harvest-orphan-company-boards/tasks.md
@@ -1,13 +1,39 @@
 ## 1. Corroboration gate in harvest-boards
 
-- [ ] 1.1 Add a name-normalizing comparison to `cmd/harvest-boards` (case-fold, strip
+- [x] 1.1 Add a name-normalizing comparison to `cmd/harvest-boards` (case-fold, strip
       legal-form suffixes, collapse non-alphanumerics) with table tests covering agreement
       across case/punctuation/suffix differences and disagreement between distinct employers
-- [ ] 1.2 Apply the gate in `probeAll`: reject a probed board whose reported name disagrees
+- [x] 1.2 Apply the gate in `probeAll`: reject a probed board whose reported name disagrees
       with the seed's expected employer, counting rejections separately from probe failures;
       leave behaviour unchanged when either name is absent
-- [ ] 1.3 Report the mismatch count in the run's summary log alongside `found` and
+- [x] 1.3 Report the mismatch count in the run's summary log alongside `found` and
       `probe-failures`
+
+## 1a. Review fallout — the prober name contract
+
+Review of task 1 found the gate resting on an inference that two probers break: "the
+platform reported no name" was read as "the returned name equals the board id", but
+`workdayProber` returns the tenant and `opencatsCompanyName` returns the host, neither of
+which equals the board id. Since `cmd/harvest-ats` and `cmd/harvest-role` already emit seeds
+carrying an expected employer, a Workday run would have rejected every live board.
+
+- [x] 1a.1 Replace the inference with an explicit contract: a prober returns `""` when the
+      platform reports no employer name of its own. Convert every prober that returns the
+      slug as a fallback, and fix `workdayProber` and `opencatsCompanyName` to stop returning
+      a derived token; drop `reportedName` and the `orSlug` fallback
+- [x] 1a.2 Regression-test the contract: a prober reporting no name keeps the seed's label,
+      and a prober returning a slug-derived token (the Workday tenant shape) is not gated
+- [x] 1a.3 Extract the employer name where the platform does publish one but the prober
+      discards it — recruitee (`company_name`) and breezy (`company.name`), both verified
+      live. Lever, Ashby, Personio and BambooHR publish none and stay ungatable
+- [x] 1a.4 Fail the run when every candidate was rejected as a name mismatch, mirroring the
+      existing all-probes-failed guard, so a systematically broken gate cannot exit 0 silently
+- [x] 1a.5 Loop the legal-suffix strip instead of stopping at the first match, add the
+      missing forms (`plc/ag/sa/nv/pty/kg/llp/srl/a-s`), and fold diacritics
+- [x] 1a.6 Treat an expected name that normalizes to empty as no expectation rather than as
+      a mismatch
+- [x] 1a.7 Correct `design.md`: existing seeds from `harvest-ats`/`harvest-role` DO carry an
+      expected employer, and the set of ungatable providers is far wider than jazzhr/jobvite
 
 ## 2. Orphan-company worklist
 

--- a/openspec/changes/harvest-orphan-company-boards/tasks.md
+++ b/openspec/changes/harvest-orphan-company-boards/tasks.md
@@ -1,0 +1,39 @@
+## 1. Corroboration gate in harvest-boards
+
+- [ ] 1.1 Add a name-normalizing comparison to `cmd/harvest-boards` (case-fold, strip
+      legal-form suffixes, collapse non-alphanumerics) with table tests covering agreement
+      across case/punctuation/suffix differences and disagreement between distinct employers
+- [ ] 1.2 Apply the gate in `probeAll`: reject a probed board whose reported name disagrees
+      with the seed's expected employer, counting rejections separately from probe failures;
+      leave behaviour unchanged when either name is absent
+- [ ] 1.3 Report the mismatch count in the run's summary log alongside `found` and
+      `probe-failures`
+
+## 2. Orphan-company worklist
+
+- [ ] 2.1 Add the sqlc query returning companies with open aggregator postings and no open
+      non-aggregator posting, taking the requested aggregator set and the full aggregator set
+      as separate parameters; run `make sqlc`
+- [ ] 2.2 Cover the query with an integration test (build tag `integration`) asserting that
+      an ATS-covered company is excluded, an aggregator-only company appears once, and
+      narrowing the requested set does not admit a company held by another aggregator
+
+## 3. Candidate derivation and seed emit
+
+- [ ] 3.1 Implement candidate-slug derivation from company name and catalogue slug
+      (hyphenated and unseparated renderings, legal-form suffixes stripped, per-company
+      de-duplication, minimum length), unit-tested first
+- [ ] 3.2 Implement seed emit: `[{board, company}]` pairs with the expected employer always
+      present and no provider recorded, unit-tested against the shape `harvest-boards`
+      parses
+- [ ] 3.3 Wire `cmd/harvest-orphans` over `worker.Main`/`worker.Bootstrap`, taking the
+      requested aggregators and the output path as flags and defaulting the aggregator set
+      to the remote-jobs group
+
+## 4. Verification
+
+- [ ] 4.1 `go build ./... && go vet ./... && go test ./...` clean; `gofmt` clean
+- [ ] 4.2 Run `harvest-orphans` against a local database and confirm the emitted seed parses
+      through `harvest-boards`'s own seed loader
+- [ ] 4.3 Dry-check the gate end to end on a known-bad pair (a live board belonging to a
+      different employer) and confirm it is reported as a mismatch, not as a skip

--- a/openspec/changes/harvest-orphan-company-boards/tasks.md
+++ b/openspec/changes/harvest-orphan-company-boards/tasks.md
@@ -66,3 +66,16 @@ carrying an expected employer, a Workday run would have rejected every live boar
       through `harvest-boards`'s own seed loader
 - [x] 4.3 Dry-check the gate end to end on a known-bad pair (a live board belonging to a
       different employer) and confirm it is reported as a mismatch, not as a skip
+
+## 4a. Second review fallout
+
+Review of sections 2–4 found two more silent, one-directional defects.
+
+- [x] 4a.1 `sources.AllAggregatorProviders` answers aggregator membership independently of
+      credentials; the crawl registry keeps answering "which can this process crawl". Both
+      `cmd/harvest-orphans` and `cmd/reindex`'s suppression pass use it
+- [x] 4a.2 Contest candidates on the folded name, so one employer's two catalogue spellings
+      keep the board id they agree on instead of discarding it
+- [x] 4a.3 Bound the worklist scan with a `statement_timeout` on a pinned connection
+- [x] 4a.4 Cover the branches no test could fail on: the folds-to-nothing gate, the modal
+      display name, and a transliteration test whose fixture made it vacuous

--- a/openspec/changes/harvest-orphan-company-boards/tasks.md
+++ b/openspec/changes/harvest-orphan-company-boards/tasks.md
@@ -71,9 +71,9 @@ carrying an expected employer, a Workday run would have rejected every live boar
 
 Review of sections 2–4 found two more silent, one-directional defects.
 
-- [x] 4a.1 `sources.AllAggregatorProviders` answers aggregator membership independently of
-      credentials; the crawl registry keeps answering "which can this process crawl". Both
-      `cmd/harvest-orphans` and `cmd/reindex`'s suppression pass use it
+- [x] 4a.1 Read aggregator membership from the credential-independent taxonomy rather than the
+      crawl registry. Found independently and fixed on main as `sources.Taxonomy()` (#1403)
+      while this change was in flight; the duplicate added here was dropped for it on rebase
 - [x] 4a.2 Contest candidates on the folded name, so one employer's two catalogue spellings
       keep the board id they agree on instead of discarding it
 - [x] 4a.3 Bound the worklist scan with a `statement_timeout` on a pinned connection

--- a/openspec/changes/harvest-orphan-company-boards/tasks.md
+++ b/openspec/changes/harvest-orphan-company-boards/tasks.md
@@ -37,29 +37,32 @@ carrying an expected employer, a Workday run would have rejected every live boar
 
 ## 2. Orphan-company worklist
 
-- [ ] 2.1 Add the sqlc query returning companies with open aggregator postings and no open
+- [x] 2.1 Add the sqlc query returning companies with open aggregator postings and no open
       non-aggregator posting, taking the requested aggregator set and the full aggregator set
       as separate parameters; run `make sqlc`
-- [ ] 2.2 Cover the query with an integration test (build tag `integration`) asserting that
+- [x] 2.2 Cover the query with an integration test (build tag `integration`) asserting that
       an ATS-covered company is excluded, an aggregator-only company appears once, and
       narrowing the requested set does not admit a company held by another aggregator
 
 ## 3. Candidate derivation and seed emit
 
-- [ ] 3.1 Implement candidate-slug derivation from company name and catalogue slug
+- [x] 3.1 Implement candidate-slug derivation from company name and catalogue slug
       (hyphenated and unseparated renderings, legal-form suffixes stripped, per-company
-      de-duplication, minimum length), unit-tested first
-- [ ] 3.2 Implement seed emit: `[{board, company}]` pairs with the expected employer always
+      de-duplication, minimum length), unit-tested first. The name folding moved to
+      `internal/normalize` (`CompanySlug`/`CompanyKey`/`SameCompany`) once the harvest gate
+      and the candidate generator both needed it — duplicating the legal-form list across two
+      binaries was not an option
+- [x] 3.2 Implement seed emit: `[{board, company}]` pairs with the expected employer always
       present and no provider recorded, unit-tested against the shape `harvest-boards`
       parses
-- [ ] 3.3 Wire `cmd/harvest-orphans` over `worker.Main`/`worker.Bootstrap`, taking the
+- [x] 3.3 Wire `cmd/harvest-orphans` over `worker.Main`/`worker.Bootstrap`, taking the
       requested aggregators and the output path as flags and defaulting the aggregator set
       to the remote-jobs group
 
 ## 4. Verification
 
-- [ ] 4.1 `go build ./... && go vet ./... && go test ./...` clean; `gofmt` clean
-- [ ] 4.2 Run `harvest-orphans` against a local database and confirm the emitted seed parses
+- [x] 4.1 `go build ./... && go vet ./... && go test ./...` clean; `gofmt` clean
+- [x] 4.2 Run `harvest-orphans` against a local database and confirm the emitted seed parses
       through `harvest-boards`'s own seed loader
-- [ ] 4.3 Dry-check the gate end to end on a known-bad pair (a live board belonging to a
+- [x] 4.3 Dry-check the gate end to end on a known-bad pair (a live board belonging to a
       different employer) and confirm it is reported as a mismatch, not as a skip


### PR DESCRIPTION
## Why

8,562 companies reach the catalogue only through a remote-jobs aggregator (measured on prod, 2026-08-01): open postings from himalayas/remoteok/weworkremotely/… and not one row from a first-party ATS. An aggregator mirror lags the employer's own revision, carries the aggregator's branding, and applies through the aggregator's form. Where the employer runs its own board, we should be crawling that board.

A July attempt resolved each company's **website** and detected the ATS from its careers page, and died on website resolution. Probing the ATS platforms directly with a slug derived from the company name needs no website at all. Measured on 80 randomly sampled uncovered himalayas companies against 12 platform APIs: **12 live boards (15%)**, of which **11 were confirmed as the right company** by comparing the employer name the platform publishes.

## What's here

**`cmd/harvest-orphans`** (new, run-once, needs `DATABASE_URL`) — reads the catalogue for companies held only through aggregators, derives candidate board ids from the company name alone, writes one provider-agnostic `[{board, company}]` seed that `cmd/harvest-boards` probes per provider.

**A corroboration gate in `cmd/harvest-boards`** — when the seed names an expected employer and the platform publishes a name, they must agree (folded) or the candidate is rejected and counted apart from probe failures. This is the defence that was missing in July, when an iCIMS candidate `prequel` resolved to A. C. Coy's tenant and had to be reverted.

## Defects found by review, all silent

None of these would have failed loudly; each exits 0.

- **Prober name contract.** "The platform publishes no name" was inferred from "the returned name equals the board id". `workdayProber` returned the tenant and `opencatsCompanyName` the host — neither equals the board id, so both armed the gate. Since `harvest-ats`/`harvest-role` already emit seeds carrying an expected employer, a Workday run would have rejected **every** live board. Probers now return `""` explicitly; behaviour-preserving for the ~14 whose fallback token was the board id.
- **Aggregator membership was credential-dependent.** `sources.All` registers usajobs/reed/whatjobs only with their env keys. Deriving the ATS-exclusion set from that registry made a company held only by Reed look first-party crawled on every run of a tool that needs nothing but `DATABASE_URL`. `sources.AllAggregatorProviders` now answers the taxonomy question independently of credentials; `cmd/reindex` asks the same question and uses it too (unchanged on prod, where the keys are set).
- **Contested candidates compared raw labels.** `company_slug` is `normalize.Slug`, which keeps legal forms, so one employer is routinely two worklist rows ("Stripe", "Stripe, Inc."). Their shared candidate — the id two independent sources agree on, the best the tool can produce — was discarded while the junk rendering survived.
- **Three vacuous tests** passed because a fixture lacked a field rather than because the behaviour held. Verified by mutation.

Also: recruitee and breezy do publish an employer name (verified live) and now report it; the legal-suffix strip loops and folds diacritics; the worklist scan runs on a pinned connection with a `statement_timeout`.

## Verification

- `gofmt`/`go build`/`go vet` clean; `go test ./...` 124 packages ok, 0 failures; `go test -tags=integration ./internal/db/` ok; `-race` clean on all touched packages
- **End-to-end on real platforms**: local Postgres → `harvest-orphans` → `harvest-boards workable` found **Derq, Flosum, Symphony Solutions** live and correctly named. On a deliberately wrong pair, `derq` claimed by "Totally Different Corp" was rejected as a name mismatch while "Flosum, Inc." vs "Flosum" was kept. `sources/` reverted afterwards — this PR changes no board file.
- **Query plan on prod**: Nested Loop Anti Join over `jobs_source_id_open_idx` + `jobs_open_company_created_at_id_idx`, **5.8s for 8,562 companies**, no sequential scan.

## Known limit

The gate can only fire where the platform publishes a name — 10 probers of ~30. Lever, Ashby, Personio, BambooHR, iCIMS and Traffit publish none anywhere in their public payloads, so a board harvested there is still accepted on liveness alone and must be read as unverified in the harvest diff. The expected yield is concentrated in Workable and SmartRecruiters, which both publish names.

## Not in scope

Website resolution, web search, LLM. The previous attempt failed on exactly that path.

Merging changes nothing in production until a harvest is actually run.