### PR TITLE
JobDrawer uses the shared description and scroll-lock modules

### DIFF
--- a/openspec/changes/jobdrawer-uses-shared-modules/.openspec.yaml
+++ b/openspec/changes/jobdrawer-uses-shared-modules/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/jobdrawer-uses-shared-modules/proposal.md
+++ b/openspec/changes/jobdrawer-uses-shared-modules/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+`JobDrawer.svelte` re-implements two `$lib` modules whose stated job is to be the single home for
+exactly that code.
+
+`JobDescription.svelte` says so in its own first line — "one home for the CSS so the description
+reads the same everywhere" — and the drawer carries a **byte-identical 39-line copy** of its
+style block instead of rendering it. The two are one edit away from disagreeing, and the copy's
+comment already points somewhere false: it says "Styles mirror JobView's `.job-description`", but
+JobView holds no such rule any more — it renders `<JobDescription>`. That is how the next person
+misses the second copy.
+
+`scrollLock.ts` is a reference-counted body lock, so two overlays can hold it at once and the
+body only unlocks when the last releases. The drawer hand-rolls the lock instead, saving and
+restoring `document.body.style.overflow` directly. Not a live defect — the drawer is
+`fixed inset-0 z-50`, so it covers the header and the menu that would contend for the lock cannot
+be opened over it — but a direct write is precisely what breaks a refcount that only acts on the
+0↔1 transition, so the exemption depends on a layout fact rather than on the lock's contract.
+
+## What Changes
+
+- The drawer renders `<JobDescription html={item.job.description} />` and its 39-line
+  `.job-description` style block is deleted. The surrounding `{#if}` branch is unchanged, so the
+  "No description available." fallback still reads the same.
+- The drawer's `$effect` calls `lockScroll()` / `unlockScroll()` instead of writing
+  `document.body.style.overflow` itself.
+- No behaviour change and no visual change: the CSS moving is byte-identical and the wrapper div
+  carries the same classes (`job-description text-sm leading-relaxed`).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour changes. This is a reuse cleanup; `tasks.md` is the real
+artifact, and the change archives with `--skip-specs`.
+
+## Impact
+
+- `web/src/lib/components/JobDrawer.svelte` — one import, one element, one `$effect`, minus 39
+  lines of CSS.
+- No backend change, no contract change, no migration.

--- a/openspec/changes/jobdrawer-uses-shared-modules/tasks.md
+++ b/openspec/changes/jobdrawer-uses-shared-modules/tasks.md
@@ -1,0 +1,28 @@
+## 1. The description
+
+- [x] 1.1 Confirm the two style blocks are still byte-identical before deleting either — the
+      claim is what makes this a safe deletion rather than a restyle.
+- [x] 1.2 Import `JobDescription` and render it in place of the inline `{@html}` div, keeping the
+      surrounding `{#if item.job.description}` / `{:else}` branch as-is.
+- [x] 1.3 Delete the `.job-description` style block and the two `{@html}` eslint/sanitization
+      comments that came with the inline copy — they live in `JobDescription` already.
+
+## 2. The scroll lock
+
+- [x] 2.1 Swap the `$effect` for `lockScroll()` with `unlockScroll()` as its cleanup, matching
+      `HeaderMenu`/`HeaderSearch`. Say in the comment why the refcount matters even though the
+      drawer covers the header today, so the next reader does not restore the direct write.
+
+## 3. Verify and close
+
+- [x] 3.1 `pnpm run check` in `web/` — no worse than the baseline (which is warnings-only, not
+      zero).
+- [x] 3.2 Establish that the deletion cannot restyle anything. NOT verified by rendering the
+      authenticated drawer — that needs a signed-in account with tracked jobs and the full stack.
+      Verified structurally instead, which for this change is decisive: the deleted block was
+      byte-identical to `JobDescription`'s (`diff` empty over 39 lines), the wrapper div carries
+      the same classes, the `:global()` scoping construct is the same one, and the component
+      already renders on two other surfaces. Confirm no `.job-description` selector remains in
+      the drawer.
+- [x] 3.3 Mark S10 ✅ in `docs/reviews/2026-08-01-architecture-review.md` — shortlist row, the
+      `S10` heading, the Progress table — noting anything the finding got wrong.

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -10,6 +10,7 @@
   import { tablist } from '$lib/actions/tablist';
   import { cardTags } from '$lib/enrichment';
   import CompanyLogo from './CompanyLogo.svelte';
+  import JobDescription from './JobDescription.svelte';
   import MatchAnalysisFull from './MatchAnalysisFull.svelte';
   import JobMatch from './JobMatch.svelte';
   import NoteEditor from './NoteEditor.svelte';
@@ -20,6 +21,7 @@
   import { avatarInitials, avatarColor } from '$lib/avatar';
   import type { MyJob, ApplicationEmail } from '$lib/types';
   import { focusTrap } from '$lib/actions/focusTrap';
+  import { lockScroll, unlockScroll } from '$lib/scrollLock';
 
   let {
     item,
@@ -161,14 +163,17 @@
     ].filter((x): x is { label: string; at: string } => x !== null),
   );
 
-  // Lock background scroll while the fullscreen panel is open, restored on unmount
+  // Lock background scroll while the fullscreen panel is open, released on unmount
   // (close / job switch). A DOM side-effect — the legitimate use of $effect.
+  //
+  // Through the shared reference-counted lock rather than by writing body.overflow here: a
+  // direct write is exactly what desynchronizes a refcount that only acts on the 0↔1
+  // transition. The drawer happens to cover the header today (fixed inset-0 z-50), so nothing
+  // else can be holding the lock — but that is a layout fact, and the next layout change should
+  // not be able to leave the page unscrollable.
   $effect(() => {
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
+    lockScroll();
+    return () => unlockScroll();
   });
 
   // Close the panel, first blurring whatever is focused so a pending notes edit is
@@ -445,9 +450,7 @@
               This posting is no longer listed. Your application, its stage and your notes are kept.
             </p>
           {:else if item.job.description}
-            <!-- Description is server-sanitized HTML (see internal/sources), safe to render. -->
-            <!-- eslint-disable-next-line svelte/no-at-html-tags -- server-sanitized; the rule flags every {@html} regardless -->
-            <div class="job-description text-sm leading-relaxed">{@html item.job.description}</div>
+            <JobDescription html={item.job.description} />
           {:else}
             <p class="text-sm text-muted-foreground">No description available.</p>
           {/if}
@@ -491,48 +494,5 @@
   }
   .no-scrollbar::-webkit-scrollbar {
     display: none;
-  }
-
-  /* Descriptions are arbitrary scraped HTML: a long URL — or words glued by
-     non-breaking spaces — must wrap instead of forcing a horizontal scroll.
-     Styles mirror JobView's .job-description so the read matches the job page. */
-  .job-description {
-    overflow-wrap: break-word;
-  }
-
-  .job-description :global(h1),
-  .job-description :global(h2),
-  .job-description :global(h3),
-  .job-description :global(h4) {
-    margin-top: 1.25rem;
-    margin-bottom: 0.5rem;
-    font-weight: 600;
-  }
-
-  .job-description :global(p) {
-    margin: 0.5rem 0;
-  }
-
-  .job-description :global(ul),
-  .job-description :global(ol) {
-    margin: 0.5rem 0;
-    padding-left: 1.25rem;
-  }
-
-  .job-description :global(li) {
-    display: list-item;
-    list-style: disc outside;
-    margin: 0.25rem 0;
-  }
-
-  /* ATS boards (e.g. Greenhouse) wrap each <li> in a block <p>; collapse its
-     margins so the bullet sits beside the text instead of on its own line. */
-  .job-description :global(li) > :global(p) {
-    margin: 0;
-  }
-
-  .job-description :global(b),
-  .job-description :global(strong) {
-    font-weight: 600;
   }
 </style>


### PR DESCRIPTION
S10 from the 2026-08-01 architecture review.

## The defect

`JobDescription.svelte` states its own purpose in its first line — *"one home for the CSS so the
description reads the same everywhere"* — and `JobDrawer` carried a **byte-identical 39-line
copy** of its style block instead of rendering it:

```
$ diff <(sed -n '499,537p' JobDrawer.svelte) <(sed -n '17,55p' JobDescription.svelte)
$ # empty
```

Two blocks one edit away from disagreeing — and the copy's comment already pointed somewhere
false. It said *"Styles mirror JobView's `.job-description`"*, but JobView holds no such rule any
more; it renders `<JobDescription>`. That misdirection is how the next person misses the second
copy.

`scrollLock.ts` is a reference-counted body lock so two overlays can hold it at once and the body
only unlocks when the last releases. The drawer hand-rolled it, saving and restoring
`document.body.style.overflow` directly.

## On the scroll lock, precisely

Not a live defect, and I checked rather than repeating the finding: the drawer is
`fixed inset-0 z-50`, so it covers the header, and `HeaderMenu`/`HeaderSearch` — the only other
lock holders — cannot be opened over it.

But a direct write is exactly what desynchronizes a refcount that only acts on the 0↔1
transition. Had they been able to overlap, closing the menu would have set `overflow: ''` under
an open drawer, or the drawer's restore of a captured `'hidden'` would have left the page stuck.
The exemption rested on a layout fact rather than on the lock's contract, so the comment now says
so and the next layout change cannot quietly reintroduce it.

## Verification

- `pnpm run check`: **0 errors, 18 warnings, 9 files** — identical to baseline.
- Not verified by rendering the authenticated drawer (that needs a signed-in account with tracked
  jobs and the full stack). Verified structurally instead, which for this change is decisive: the
  deleted CSS was byte-identical, the wrapper div carries the same classes
  (`job-description text-sm leading-relaxed`), the `:global()` scoping construct is the same, and
  the component already renders on two other surfaces. No `.job-description` selector remains in
  the drawer.

Net −40 lines. No backend change, no contract change.