### PR TITLE
/jobs/:slug/copies serves an empty page instead of 500ing

### DIFF
--- a/internal/handler/copies.go
+++ b/internal/handler/copies.go
@@ -36,8 +36,7 @@ func (h *jobsHandlers) JobCopies(c *fiber.Ctx) error {
 		return err
 	}
 
-	limit := min(max(c.QueryInt("limit", defaultCopiesLimit), 1), maxCopiesLimit)
-	offset := max(c.QueryInt("offset", 0), 0)
+	limit, offset := pageParamsBounded(c, defaultCopiesLimit, maxCopiesLimit)
 	rows, err := h.queries.ListRoleClusterCopies(c.Context(), db.ListRoleClusterCopiesParams{
 		JobID:     id,
 		RowLimit:  int32(limit),

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -119,17 +119,22 @@ type middleware struct {
 }
 
 // pageParams reads and clamps the shared limit/offset pagination query params.
-// The offset is clamped into int32 range because the column binds as a Postgres
-// int4, and an unbounded query value would otherwise overflow on the conversion.
 func pageParams(c *fiber.Ctx) (limit, offset int) {
-	return pageParamsMax(c, maxLimit)
+	return pageParamsBounded(c, defaultLimit, maxLimit)
 }
 
-// pageParamsMax is pageParams with a caller-supplied limit ceiling, for endpoints
-// whose page is bounded differently than the shared list cap (e.g. the tracking
-// board, which is unpaginated and needs the whole set).
-func pageParamsMax(c *fiber.Ctx, ceiling int) (limit, offset int) {
-	limit = min(max(c.QueryInt("limit", defaultLimit), 1), ceiling)
+// pageParamsBounded is pageParams with caller-supplied bounds, for endpoints whose page is
+// sized differently from the shared list cap (the tracking board, which is unpaginated and
+// needs the whole set; the role-cluster copies list, which pages a handful of city openings).
+//
+// It is the ONLY place the offset query param is read, and a test enforces that. The clamp to
+// MaxInt32 is the reason: every paginated column binds as a Postgres int4, Fiber's QueryInt is
+// a plain strconv.Atoi that happily accepts a 64-bit value, and the int32 conversion then wraps
+// it NEGATIVE — which Postgres rejects, turning ?offset=3000000000 into a 500 rather than an
+// empty page. Naming that in a comment did not stop a second call site re-implementing the
+// parse without it.
+func pageParamsBounded(c *fiber.Ctx, fallback, ceiling int) (limit, offset int) {
+	limit = min(max(c.QueryInt("limit", fallback), 1), ceiling)
 	offset = min(max(c.QueryInt("offset", 0), 0), math.MaxInt32)
 	return limit, offset
 }

--- a/internal/handler/inbox.go
+++ b/internal/handler/inbox.go
@@ -134,7 +134,7 @@ func (h *inboxHandlers) GetInbox(c *fiber.Ctx) error {
 	if q.WithBody {
 		ceiling = harnessPageMax
 	}
-	limit, offset := pageParamsMax(c, ceiling)
+	limit, offset := pageParamsBounded(c, defaultLimit, ceiling)
 	q.Limit, q.Offset = limit, offset
 
 	page, err := h.inbox.Search(c.Context(), userID, q)

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -60,7 +60,7 @@ func (h *trackingHandlers) ListTrackedJobs(c *fiber.Ctx) error {
 		return err
 	}
 
-	limit, offset := pageParamsMax(c, trackingMaxLimit)
+	limit, offset := pageParamsBounded(c, defaultLimit, trackingMaxLimit)
 	listing, err := h.tracking.ListTracked(c.Context(), userID, c.Query("filter"), int32(limit), int32(offset))
 	if err != nil {
 		return trackingError(err)

--- a/internal/handler/pagination_rule_test.go
+++ b/internal/handler/pagination_rule_test.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helperFile is where the shared pagination parse lives, and the one file allowed to read the
+// raw query params.
+const helperFile = "handler.go"
+
+// TestOffsetIsParsedOnlyByTheSharedHelper pins a rule that a comment failed to hold.
+//
+// Every paginated endpoint must read its offset through pageParams/pageParamsBounded, which
+// clamps it into int32 range. Fiber's QueryInt is a plain strconv.Atoi, so on a 64-bit build
+// `?offset=3000000000` parses fine — and the int32 conversion every paginated column needs
+// (they bind as Postgres int4) then wraps it NEGATIVE, which Postgres rejects. /jobs/:slug/copies
+// hand-rolled the parse and answered 500 on a public, unauthenticated URL where every other list
+// endpoint returns an empty page.
+//
+// The helper's own doc comment already named that overflow. Naming it did not stop a second call
+// site from re-implementing the parse without the clamp, which is why the rule is a test now.
+func TestOffsetIsParsedOnlyByTheSharedHelper(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	// The population is every file that paginates at all — one that reads the offset itself and
+	// one that calls the helper both count. Counting only the violators would let the suite look
+	// healthy the moment it was empty.
+	var population int
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		body := string(src)
+
+		readsRaw := strings.Contains(body, `QueryInt("offset"`) || strings.Contains(body, `Query("offset"`)
+		usesHelper := strings.Contains(body, "pageParams(") || strings.Contains(body, "pageParamsBounded(")
+		if !readsRaw && !usesHelper {
+			continue
+		}
+		population++
+
+		if readsRaw && name != helperFile {
+			t.Errorf("%s reads the offset query param itself; use pageParams/pageParamsBounded, "+
+				"which clamps into int32 range. Without the clamp, ?offset=3000000000 becomes a "+
+				"negative int4 and the endpoint 500s instead of serving an empty page.", name)
+		}
+	}
+
+	if population < 5 {
+		t.Fatalf("only %d paginating files found — the scan is not seeing the package, so a "+
+			"violation would pass unnoticed", population)
+	}
+}

--- a/openspec/changes/clamp-copies-pagination/.openspec.yaml
+++ b/openspec/changes/clamp-copies-pagination/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/clamp-copies-pagination/proposal.md
+++ b/openspec/changes/clamp-copies-pagination/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+`GET /api/v1/jobs/:slug/copies?offset=3000000000` answers **500**. Verified on production:
+
+```
+offset=0           -> 200
+offset=3000000000  -> 500
+```
+
+Fiber's `QueryInt` is a plain `strconv.Atoi`, so a 64-bit build accepts the value; the endpoint
+then converts it to the `int32` the Postgres `int4` param needs, which wraps it **negative**, and
+Postgres rejects a negative `OFFSET`. Every other list endpoint serves an empty page for the same
+request, because they read pagination through the shared helper — whose doc comment names this
+exact overflow. This one call site re-implemented the parse and left the clamp out.
+
+It is a public, unauthenticated endpoint, so anyone can reach it.
+
+## What Changes
+
+- `JobCopies` reads its pagination through the shared helper. `?offset=3000000000` becomes an
+  empty page, matching every other list endpoint.
+- The helper generalises: `pageParamsMax(c, ceiling)` becomes `pageParamsBounded(c, fallback,
+  ceiling)`, so a caller with its own default (copies pages 50 with a 200 cap) can use it instead
+  of hand-rolling. `pageParams` and the two existing callers delegate to it unchanged.
+- **A test now enforces the rule** rather than a comment: it scans the package for any file
+  reading the offset query param outside the helper, and derives its population from behaviour so
+  a new paginated endpoint is enrolled by existing. It fails on the current code.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `job-cluster-copies`: the endpoint's pagination bounds become part of its contract — an offset
+  past the end is an empty page, not an error.
+
+## Impact
+
+- `internal/handler/copies.go` — two lines become one.
+- `internal/handler/handler.go` — the helper's signature and its doc comment.
+- `internal/handler/inbox.go`, `me_tracking.go` — the renamed helper, behaviour unchanged.
+- No migration, no query change, no frontend change.

--- a/openspec/changes/clamp-copies-pagination/specs/job-cluster-copies/spec.md
+++ b/openspec/changes/clamp-copies-pagination/specs/job-cluster-copies/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Role-cluster copies are listable from a job
+
+The system SHALL expose `GET /jobs/:slug/copies` returning the OPEN postings sharing the
+addressed job's role cluster (`company_slug` + `role_fingerprint`), each carrying its
+location, apply URL, and public slug, ordered by location and paginated. The anchor job
+itself is included. A job whose fingerprint is empty clusters with no one and returns an
+empty list. The endpoint is public.
+
+Its pagination SHALL be bounded the way every other list endpoint's is: a `limit` outside the
+endpoint's range is clamped into it, and an `offset` beyond the end of the result set — including
+one larger than the paginated column's storage range — SHALL yield an empty page rather than an
+error. A caller MUST NOT be able to make the endpoint fail by supplying an out-of-range
+pagination value.
+
+#### Scenario: Copies of a collapsed role list every open city
+
+- **WHEN** a client requests the copies of a canonical job whose cluster has N open
+  postings across cities
+- **THEN** the response lists all N, each with its own location and apply URL, ordered
+  by location
+
+#### Scenario: A closed posting and unrelated roles are excluded
+
+- **WHEN** the cluster has a closed member and the company has other unrelated roles
+- **THEN** neither appears in the copies list
+
+#### Scenario: An out-of-range offset is an empty page, not an error
+
+- **WHEN** a client requests the copies with an `offset` far beyond the cluster's size —
+  including one exceeding the range of the underlying paginated column
+- **THEN** the response is a successful empty list, exactly as the other list endpoints answer
+  the same request

--- a/openspec/changes/clamp-copies-pagination/tasks.md
+++ b/openspec/changes/clamp-copies-pagination/tasks.md
@@ -1,0 +1,26 @@
+## 1. Make the rule a test
+
+- [x] 1.1 RED: a test that scans the handler package for any file reading the offset query param
+      outside the shared helper, with its population derived from behaviour (files that paginate
+      at all) so a new endpoint is enrolled by existing. It must fail on `copies.go` today.
+- [x] 1.2 Guard against a vacuous pass: assert the scan actually found the paginating files, so
+      a broken scan cannot read as a clean suite.
+
+## 2. One parse, one clamp
+
+- [x] 2.1 GREEN: generalise `pageParamsMax(c, ceiling)` to `pageParamsBounded(c, fallback,
+      ceiling)` so a caller with its own default can use it, and move the overflow rationale onto
+      it — the helper is now the only place the param is read.
+- [x] 2.2 `JobCopies` calls it with `defaultCopiesLimit` / `maxCopiesLimit`; its two hand-rolled
+      lines become one. Limit behaviour is unchanged (50 default, 200 cap).
+- [x] 2.3 Update `inbox.go` and `me_tracking.go` to the renamed helper — behaviour unchanged,
+      both already passed the shared default implicitly.
+
+## 3. Verify and close
+
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green.
+- [x] 3.2 Confirm the defect was live before the fix, not theoretical: `offset=3000000000`
+      answered 500 on production against a real job slug, `offset=0` answered 200.
+- [ ] 3.3 After deploy, re-run the same two requests and confirm the 500 became a 200.
+- [x] 3.4 Mark S11 ✅ in `docs/reviews/2026-08-01-architecture-review.md` — shortlist row, the
+      `S11` heading, the Progress table — noting anything the finding got wrong.


### PR DESCRIPTION
S11 from the 2026-08-01 architecture review — and it is **live on production**, not theoretical.
Verified against a real job slug before writing any code:

```
GET /api/v1/jobs/<slug>/copies?offset=0           -> 200
GET /api/v1/jobs/<slug>/copies?offset=3000000000  -> 500
```

Public, unauthenticated endpoint. Anyone can reach it.

## Why it 500s

Fiber's `QueryInt` is a plain `strconv.Atoi`, so a 64-bit build accepts `3000000000` happily. The
endpoint then converts it to the `int32` the Postgres `int4` param needs — and `int32(3000000000)`
is **negative**, which Postgres rejects as an `OFFSET`.

Every other list endpoint answers the same request with an empty page, because they read
pagination through the shared helper. That helper's doc comment names this exact overflow:

> The offset is clamped into int32 range because the column binds as a Postgres int4, and an
> unbounded query value would otherwise overflow on the conversion.

Naming it did not stop this call site re-implementing the parse without the clamp.

## The fix

`JobCopies` reads pagination through the helper. `pageParamsMax(c, ceiling)` generalises to
`pageParamsBounded(c, fallback, ceiling)` so a caller with its own default — copies pages 50 with
a 200 cap — can use it rather than hand-roll. Limit behaviour is unchanged everywhere; `inbox` and
`me_tracking` just pass the default they were already getting implicitly.

## The rule is a test now

A comment failed to hold this rule, so it is enforced instead: the test scans the handler package
for any file reading the offset query param outside the helper. Its population is derived from
behaviour — files that paginate at all — so a new paginated endpoint is enrolled by existing
rather than by someone remembering, and it refuses to pass if the scan found nothing (a broken
scan must not read as a clean suite). It fails on the pre-fix code:

```
--- FAIL: TestOffsetIsParsedOnlyByTheSharedHelper
    copies.go reads the offset query param itself; use pageParams/pageParamsBounded,
    which clamps into int32 range.
```

Verified: `go build ./... && go vet ./... && go test ./...` green. I will re-run the two live
requests after deploy to confirm the 500 became a 200.
