### PR TITLE
feat(web): Product Hunt badge in the footer + launch announcement

### DIFF
--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -60,6 +60,19 @@
   ];
 
   const year = new Date().getFullYear();
+
+  // Product Hunt "featured" badge. Two embed URLs — one per theme — swapped by the
+  // `dark` class variant rather than by reading themeStore, so the right one is
+  // already in the SSR markup (the anti-FOUC script in app.html sets `.dark` before
+  // paint). Both URLs are Product Hunt's own, copied verbatim including the `t=`
+  // cache-buster it stamps per variant.
+  const productHunt = {
+    href: 'https://www.producthunt.com/products/freehire?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-freehire',
+    alt: 'freehire - The open-source job search that covers every board | Product Hunt',
+    light:
+      'https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196233&theme=light&t=1785605037608',
+    dark: 'https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196233&theme=dark&t=1785605357228',
+  };
 </script>
 
 <footer class="border-t border-border">
@@ -86,6 +99,28 @@
           </ul>
         </nav>
       {/each}
+    </div>
+
+    <div class="mt-8">
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Product Hunt page opened in a new tab; not an internal route -->
+      <a href={productHunt.href} target="_blank" rel="noopener noreferrer" class="inline-block">
+        <img
+          src={productHunt.light}
+          alt={productHunt.alt}
+          width="250"
+          height="54"
+          loading="lazy"
+          class="dark:hidden"
+        />
+        <img
+          src={productHunt.dark}
+          alt={productHunt.alt}
+          width="250"
+          height="54"
+          loading="lazy"
+          class="hidden dark:block"
+        />
+      </a>
     </div>
   </div>
 

--- a/web/src/posts/2026-08-01-launching-on-product-hunt-on-26-august.svx
+++ b/web/src/posts/2026-08-01-launching-on-product-hunt-on-26-august.svx
@@ -1,0 +1,27 @@
+---
+title: Launching on Product Hunt on 26 August
+date: 2026-08-01
+summary: freehire goes up on Product Hunt on 26 August 2026 — the badge is in the footer, and the page is live to follow before launch day.
+type: changelog
+tags:
+  - product
+  - transparency
+---
+
+freehire has been shipping quietly for months: a job catalogue aggregated from
+hundreds of company boards, deduplicated, and filterable down to the region, the
+seniority, and the stack. On **26 August 2026** it goes up on
+[Product Hunt](https://www.producthunt.com/products/freehire?utm_source=blog&utm_medium=post&utm_campaign=launch-announcement).
+
+There is nothing to do yet. The product page is live now, so you can follow it and
+get a notification when the launch opens — that is the only thing that helps before
+the day, since votes only count once it goes live. The badge now sits in the footer
+of every page and links straight there.
+
+Why announce it three weeks early: a Product Hunt launch is a single day, and a
+single day is a bad way to find out whether anything is broken. Between now and then
+we would rather hear what does not work than collect a good number. If a filter
+misses jobs you know exist, a company page looks wrong, or a source you rely on is
+missing, tell us — on [GitHub](https://github.com/strelov1/freehire),
+[Telegram](https://t.me/freehiredev), or [Discord](https://discord.gg/aAXS2rghW).
+Everything reported before the 26th has a chance of being fixed by it.

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -54,7 +54,14 @@ export default {
         // fetched under our own CSP, and job descriptions carry no images at all — the
         // ingest sanitizer strips them (internal/sources/sanitize.go). `data:` is here
         // for the handful of Tailwind utilities that inline an SVG.
-        'img-src': ['self', 'data:', 'https://logo.freehire.me'],
+        // api.producthunt.com serves the Product Hunt "featured" badge embedded in
+        // the footer (Footer.svelte) — a single static SVG per theme.
+        'img-src': [
+          'self',
+          'data:',
+          'https://logo.freehire.me',
+          'https://api.producthunt.com',
+        ],
         // Pinning img-src deliberately stopped there: connect-src was considered as
         // part of the same hardening and left out, because getting it wrong fails
         // silently — error reporting and analytics simply stop — and that deserves its


### PR DESCRIPTION
## What

- The Product Hunt "featured" badge now sits in the footer, above the bottom bar, on every page.
- A `/blog` changelog entry announcing the launch date: **26 August 2026**.

## Two things worth a look

**The badge is two `<img>` tags, not one.** Product Hunt serves a separate SVG per theme. They are swapped by the `dark:` class variant (`dark:hidden` / `hidden dark:block`) rather than by reading `themeStore`, because the theme class is set by the anti-FOUC script in `app.html` before paint — so the correct badge is already in the SSR markup and never swaps after hydration.

**`img-src` had to be widened.** `web/svelte.config.js` pins the CSP `img-src` allowlist deliberately — it is the layer under the assistant's markdown sanitizer, since the chat renders untrusted model output with `{@html}`. `https://api.producthunt.com` is added with a comment naming why it is there. Without it the badge fails closed: no image, no build error, only a console message.

## Verified

- `svelte-check`: no new errors in the touched files (the 46-error baseline is pre-existing and untouched).
- `pnpm build`: green; the blog post's frontmatter passes the loader in `web/src/lib/blog.ts`.
- Served the production build with `node build/index.js` and checked the real response: the CSP header carries `img-src 'self' data: https://logo.freehire.me https://api.producthunt.com`, and both badge URLs are present in the SSR HTML with the right classes.
- Headless screenshot in dark mode: exactly one badge renders, the dark variant.