### PR TITLE
feat(sources): onboard 348 own-ATS boards found for aggregator-only companies

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14231,3 +14231,35 @@
   board: nmcareers
 - company: Chicory
   board: chicory
+- company: Accompany Health
+  board: accompanyhealth
+- company: Akero Therapeutics
+  board: akerotherapeutics
+- company: Alnylam Pharmaceuticals
+  board: alnylampharmaceuticals
+- company: Ampliform LLC
+  board: ampliform
+- company: ApexIT
+  board: apexit
+- company: Cabin
+  board: cabin
+- company: Candidly
+  board: candidly
+- company: CoreView
+  board: coreview
+- company: Coterie Insurance
+  board: coterieinsurance
+- company: Cro Metrics
+  board: crometrics
+- company: 'ESO '
+  board: eso
+- company: evermore
+  board: evermore
+- company: Firesprite
+  board: firesprite
+- company: FronteraCare
+  board: fronteracare
+- company: GigFinesse
+  board: gigfinesse
+- company: GoodAI
+  board: goodai

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -5657,3 +5657,657 @@
   board: RockYou
 - company: StratApps
   board: StratApps
+- company: Aadmi Consulting
+  board: aadmiconsulting
+- company: AccessPay
+  board: accesspay
+- company: Acrobyte Technologies
+  board: acrobytetechnologies
+- company: Advantine Technologies
+  board: advantinetechnologies
+- company: Agile IT
+  board: agileit
+- company: Airswift
+  board: airswift
+- company: AJNA INFOTECH
+  board: ajnainfotech
+- company: A.K.A New Media
+  board: akanewmedia
+- company: Alaska Communications
+  board: alaskacommunications
+- company: AlediumHR
+  board: alediumhr
+- company: Alquicoche
+  board: alquicoche
+- company: American IT Staff
+  board: americanitstaff
+- company: American Montessori Society
+  board: americanmontessorisociety
+- company: American Veterinary Group
+  board: americanveterinarygroup
+- company: AngioDynamics
+  board: angiodynamics
+- company: Anteelo
+  board: anteelo
+- company: ApplePie Capital
+  board: applepiecapital
+- company: AppXite
+  board: appxite
+- company: Aprende Institute
+  board: aprendeinstitute
+- company: Arch Capital Group Ltd.
+  board: archcapitalgroup
+- company: ASL Consulting
+  board: aslconsulting
+- company: ASPER BROTHERS
+  board: asperbrothers
+- company: Athlete Studio
+  board: athletestudio
+- company: Automa.Net
+  board: automanet
+- company: AVÉQ
+  board: aveq
+- company: Avila Dental
+  board: aviladental
+- company: B2B Industrial Packaging
+  board: b2bindustrialpackaging
+- company: B2G Consulting
+  board: b2gconsulting
+- company: Baltic Assist
+  board: balticassist
+- company: Base Camp Data Solutions
+  board: basecampdatasolutions
+- company: BeBetter Shop
+  board: bebettershop
+- company: BeiGene
+  board: beigene
+- company: Benivo Limited
+  board: benivo
+- company: Bertoni Solutions
+  board: bertonisolutions
+- company: BHC Press
+  board: bhcpress
+- company: BigBinary
+  board: bigbinary
+- company: Bits In Glass
+  board: bitsinglass
+- company: Blackbird Collective
+  board: blackbirdcollective
+- company: BlueAlly
+  board: blueally
+- company: Blue Coding
+  board: bluecoding
+- company: B Riley Financial
+  board: brileyfinancial
+- company: Bringle Excellence
+  board: bringleexcellence
+- company: Bucketlist Xperiences
+  board: bucketlistxperiences
+- company: Business Wire
+  board: businesswire
+- company: CallMiner
+  board: callminer
+- company: Cami.AI
+  board: camiai
+- company: Canyon GBS
+  board: canyongbs
+- company: Capital Development Services
+  board: capitaldevelopmentservices
+- company: CareBand
+  board: careband
+- company: CareerBricks Learning Solutions
+  board: careerbrickslearningsolutions
+- company: Career Consulting Partners
+  board: careerconsultingpartners
+- company: CareerTEAM, LLC
+  board: careerteam
+- company: Carilion Clinic
+  board: carilionclinic
+- company: Castro & Company
+  board: castrocompany
+- company: Catasys Health
+  board: catasyshealth
+- company: CDK Global
+  board: cdkglobal
+- company: Chabez Tech
+  board: chabeztech
+- company: Change State
+  board: changestate
+- company: Chariot Solutions
+  board: chariotsolutions
+- company: Chewi Creative
+  board: chewicreative
+- company: 'Citrus: A Global Healthcare Communications Group'
+  board: citrusaglobalhealthcarecommunicationsgroup
+- company: Clark Outsourcing
+  board: clarkoutsourcing
+- company: ClearSource
+  board: clearsource
+- company: Clinch
+  board: clinch
+- company: CloudFactory
+  board: cloudfactory
+- company: Coherus BioSciences
+  board: coherusbiosciences
+- company: Concurrences
+  board: concurrences
+- company: CONFISA INTERNATIONAL GROUP
+  board: confisainternationalgroup
+- company: Cornerstone Building Brands, Inc.
+  board: cornerstonebuildingbrands
+- company: Creatively Smart Marketing
+  board: creativelysmartmarketing
+- company: Culina Group
+  board: culinagroup
+- company: CYB Human Resources
+  board: cybhumanresources
+- company: Dalstrong
+  board: dalstrong
+- company: DBC
+  board: dbc
+- company: Delaphone
+  board: delaphone
+- company: DemandMatrix
+  board: demandmatrix
+- company: Devoted Health
+  board: devotedhealth
+- company: Devsinc
+  board: devsinc
+- company: DHD Consulting
+  board: dhdconsulting
+- company: Digital Forge Cyber Assurance Group
+  board: digitalforgecyberassurancegroup
+- company: DIGITALPOiNTUSA
+  board: digitalpointusa
+- company: Divertinc
+  board: divertinc
+- company: Doc Clik
+  board: docclik
+- company: Domino's
+  board: dominos
+- company: Dresden Partners
+  board: dresdenpartners
+- company: DRT Strategies
+  board: drtstrategies
+- company: Dwellworks
+  board: dwellworks
+- company: Education Development Center
+  board: educationdevelopmentcenter
+- company: Ekipa
+  board: ekipa
+- company: ELIXIR MULTINATIONAL
+  board: elixirmultinational
+- company: Engio
+  board: engio
+- company: Ensabill
+  board: ensabill
+- company: Ensiti
+  board: ensiti
+- company: Ethereum Address Service (EAS)
+  board: ethereumaddressserviceeas
+- company: Ethereum Community Fund
+  board: ethereumcommunityfund
+- company: eTrepid
+  board: etrepid
+- company: Executiva Outsourcing
+  board: executivaoutsourcing
+- company: Fabventure Travel
+  board: fabventuretravel
+- company: FANtium
+  board: fantium
+- company: Finance active
+  board: financeactive
+- company: First Resources Management Group
+  board: firstresourcesmanagementgroup
+- company: Fiscal Team
+  board: fiscalteam
+- company: Focus Finance International
+  board: focusfinanceinternational
+- company: Forest Stewards Guild
+  board: foreststewardsguild
+- company: Franco Pinto
+  board: francopinto
+- company: Free2move
+  board: free2move
+- company: FreedUp
+  board: freedup
+- company: Free the Slaves
+  board: freetheslaves
+- company: Fulcrum Digital
+  board: fulcrumdigital
+- company: Fusion Medical Staffing
+  board: fusionmedicalstaffing
+- company: Genetec
+  board: genetec
+- company: Ginas Tech Jobs
+  board: ginastechjobs
+- company: Goldbelt
+  board: goldbelt
+- company: Goldstone Partners, Inc.
+  board: goldstonepartners
+- company: Green Thumb Industries
+  board: greenthumbindustries
+- company: Growth Leads
+  board: growthleads
+- company: Harver
+  board: harver
+- company: HealCommunity
+  board: healcommunity
+- company: Helium SEO
+  board: heliumseo
+- company: Hello English
+  board: helloenglish
+- company: Hello World Technologies
+  board: helloworldtechnologies
+- company: HireTech Group
+  board: hiretechgroup
+- company: HIRINGMAN
+  board: hiringman
+- company: Hitachi Solutions
+  board: hitachisolutions
+- company: Hivemapper
+  board: hivemapper
+- company: HiWave
+  board: hiwave
+- company: Hollis Cobb Associates
+  board: holliscobbassociates
+- company: Hooli Software
+  board: hoolisoftware
+- company: https://shiperp.com/
+  board: httpsshiperpcom
+- company: Hummingbot.io
+  board: hummingbotio
+- company: iFLIP4
+  board: iflip4
+- company: ihire global
+  board: ihireglobal
+- company: Inchcape Shipping Services
+  board: inchcapeshippingservices
+- company: IndSAfri
+  board: indsafri
+- company: Infoway Group
+  board: infowaygroup
+- company: Infoya
+  board: infoya
+- company: inSegment
+  board: insegment
+- company: insightsoftware
+  board: insightsoftware
+- company: Inspectorio
+  board: inspectorio
+- company: IntegriChain
+  board: integrichain
+- company: Integrity Web Consulting
+  board: integritywebconsulting
+- company: International Film Festival Rotterdam
+  board: internationalfilmfestivalrotterdam
+- company: Intersog
+  board: intersog
+- company: Invisible Technologies
+  board: invisibletechnologies
+- company: IPS Technology Services
+  board: ipstechnologyservices
+- company: ISC2
+  board: isc2
+- company: iScale Solutions
+  board: iscalesolutions
+- company: iSchool
+  board: ischool
+- company: itechstack
+  board: itechstack
+- company: IvyPanda
+  board: ivypanda
+- company: JACOBS DOUWE EGBERTS
+  board: jacobsdouweegberts
+- company: jetfuel.agency
+  board: jetfuelagency
+- company: JFL Media
+  board: jfl-media
+- company: JSat Automation
+  board: jsatautomation
+- company: Justworks, Inc.
+  board: justworks
+- company: Kazidomi
+  board: kazidomi
+- company: KeyCommerce
+  board: keycommerce
+- company: Keyrus
+  board: keyrus
+- company: Kitman Labs
+  board: kitmanlabs
+- company: Kitu Systems
+  board: kitusystems
+- company: Knimbus
+  board: knimbus
+- company: KoiReader Technologies
+  board: koireadertechnologies
+- company: Kore.ai
+  board: koreai
+- company: Land O'Lakes, Inc.
+  board: landolakes
+- company: Language Services Associates
+  board: languageservicesassociates
+- company: Lanshore
+  board: lanshore
+- company: Leadway Pensure
+  board: leadwaypensure
+- company: LegalAndGeneral
+  board: legalandgeneral
+- company: Lifted (an Upwork Company)
+  board: liftedanupworkcompany
+- company: Lingaro
+  board: lingaro
+- company: LingoHub
+  board: lingohub
+- company: Lostar
+  board: lostar
+- company: Ludwig
+  board: ludwig
+- company: Lynx Solutions
+  board: lynxsolutions
+- company: M3 USA
+  board: m3usa
+- company: Magellan Health
+  board: magellanhealth
+- company: Magic Ears
+  board: magicears
+- company: Mainspring Energy
+  board: mainspringenergy
+- company: Mama Money
+  board: mamamoney
+- company: Mapjects.com
+  board: mapjectscom
+- company: Markel
+  board: markel
+- company: MATCHMOVE PAY
+  board: matchmovepay
+- company: Maxcademy B.V.
+  board: maxcademybv
+- company: MBJ Network
+  board: mbjnetwork
+- company: Mediatree
+  board: mediatree
+- company: MedShr
+  board: medshr
+- company: MENA Alliances
+  board: menaalliances
+- company: Mohan Management Consultants
+  board: mohanmanagementconsultants
+- company: Mondosol
+  board: mondosol
+- company: MonetizeNow
+  board: monetizenow
+- company: Montu
+  board: montu
+- company: M&S Consulting
+  board: msconsulting
+- company: NECSWS
+  board: necsws
+- company: Neilson Financial Services
+  board: neilsonfinancialservices
+- company: New Amsterdam Technology and Business Ventures
+  board: newamsterdamtechnologyandbusinessventures
+- company: Nextstep Recruitment
+  board: nextsteprecruitment
+- company: Next Step Systems
+  board: nextstepsystems
+- company: Nile Bits
+  board: nilebits
+- company: NOCD
+  board: nocd
+- company: Node.Digital
+  board: nodedigital
+- company: Nvelup Consulting
+  board: nvelupconsulting
+- company: Oak Hall Group
+  board: oakhallgroup
+- company: Oak Ridge National Laboratory
+  board: oakridgenationallaboratory
+- company: OneTouch Direct
+  board: onetouchdirect
+- company: Outreach.io
+  board: outreachio
+- company: Paidiem
+  board: paidiem
+- company: Palm Realty
+  board: palmrealty
+- company: Parlay Games
+  board: parlaygames
+- company: Partly
+  board: partly
+- company: PCS Global Tech
+  board: pcsglobaltech
+- company: Penbrothers
+  board: penbrothers
+- company: Pereira O'Dell
+  board: pereiraodell
+- company: Pintaria.com
+  board: pintariacom
+- company: Playaway Products
+  board: playawayproducts
+- company: POLY Consulting
+  board: polyconsulting
+- company: Privafy
+  board: privafy
+- company: Privia Health
+  board: priviahealth
+- company: Pro Coffee Gear
+  board: procoffeegear
+- company: Public Outdoor Creations
+  board: publicoutdoorcreations
+- company: Pulse Healthcare Services
+  board: pulsehealthcareservices
+- company: PureLogics
+  board: purelogics
+- company: Purple Rain
+  board: purplerain
+- company: Qraved
+  board: qraved
+- company: Quant AIs
+  board: quantais
+- company: Quest Global Technologies
+  board: questglobaltechnologies
+- company: RBL Labs
+  board: rbllabs
+- company: R&D Partners
+  board: rdpartners
+- company: Recruit Aid Agency
+  board: recruitaidagency
+- company: Rede Consulting Services
+  board: redeconsultingservices
+- company: REDICA Systems
+  board: redicasystems
+- company: Red Stamp Media
+  board: redstampmedia
+- company: Relief International
+  board: reliefinternational
+- company: Remotual
+  board: remotual
+- company: RES Consultant Group
+  board: resconsultantgroup
+- company: ResourceQ Services
+  board: resourceqservices
+- company: Resto Dapur Griya Seafood
+  board: restodapurgriyaseafood
+- company: ReversingLabs
+  board: reversinglabs
+- company: Rolo Studios
+  board: rolostudios
+- company: Rotork
+  board: rotork
+- company: R.S.Consultants
+  board: rsconsultants
+- company: RumbleUp
+  board: rumbleup
+- company: Saba Trust
+  board: sabatrust
+- company: Safely Connected, The Eating Disorder Centre
+  board: safelyconnectedtheeatingdisordercentre
+- company: Saxon Global
+  board: saxonglobal
+- company: ScaleOps
+  board: scaleops
+- company: SCL Health
+  board: sclhealth
+- company: SDF Systems
+  board: sdfsystems
+- company: Search Engine Journal
+  board: searchenginejournal
+- company: Seasoned Recruitment
+  board: seasonedrecruitment
+- company: SemiDot Infotech
+  board: semidotinfotech
+- company: Sevaa Group
+  board: sevaagroup
+- company: Seven Bits Technologies
+  board: sevenbitstechnologies
+- company: Shape 404
+  board: shape404
+- company: Sierre Technologies
+  board: sierretechnologies
+- company: SimpleTense Education
+  board: simpletenseeducation
+- company: Skyhook Interactive
+  board: skyhookinteractive
+- company: Slasify
+  board: slasify
+- company: SmartCookie.App
+  board: smartcookieapp
+- company: Smart IMS
+  board: smartims
+- company: Smartylink
+  board: smartylink
+- company: Snarkify
+  board: snarkify
+- company: SNIPEBRIDGE
+  board: snipebridge
+- company: Social Lighthouse
+  board: sociallighthouse
+- company: Sociokix
+  board: sociokix
+- company: Softensity Inc.,
+  board: softensity
+- company: SoluDyne
+  board: soludyne
+- company: Solwin Infotech
+  board: solwininfotech
+- company: Sparrow Connected
+  board: sparrowconnected
+- company: Spectrio
+  board: spectrio
+- company: Spijker Recruitment
+  board: spijkerrecruitment
+- company: Spotted Zebra
+  board: spottedzebra
+- company: Sseko Designs
+  board: ssekodesigns
+- company: STIC soft solutions
+  board: sticsoftsolutions
+- company: Sumundi
+  board: sumundi
+- company: super{set}
+  board: superset
+- company: Sutter Health
+  board: sutterhealth
+- company: SwissTank Media
+  board: swisstankmedia
+- company: Syke Legal Engineering
+  board: sykelegalengineering
+- company: Syncreon Consulting
+  board: syncreonconsulting
+- company: Talent2Africa
+  board: talent2africa
+- company: Talent Navigation Experts
+  board: talentnavigationexperts
+- company: TASTE Productions
+  board: tasteproductions
+- company: Taxera Technologies
+  board: taxeratechnologies
+- company: Technology Navigators
+  board: technologynavigators
+- company: TechScribe
+  board: techscribe
+- company: Teladoc Health
+  board: teladochealth
+- company: Tenengroup Ltd.
+  board: tenengroup
+- company: Ten Mile Square Technologies
+  board: tenmilesquaretechnologies
+- company: Tester Work
+  board: testerwork
+- company: TexAu
+  board: texau
+- company: Textile Exchange
+  board: textileexchange
+- company: The Climate Reality Project Canada
+  board: theclimaterealityprojectcanada
+- company: The HR Hub Nigeria
+  board: thehrhubnigeria
+- company: The Impact Project
+  board: theimpactproject
+- company: The Nielsen Company
+  board: thenielsencompany
+- company: The Opportunity Group
+  board: theopportunitygroup
+- company: The Restory
+  board: therestory
+- company: The Spark Group
+  board: thesparkgroup
+- company: Tidepool
+  board: tidepool
+- company: TLVTech
+  board: tlvtech
+- company: Tracklings
+  board: tracklings
+- company: Travelstride
+  board: travelstride
+- company: Tripexpert
+  board: tripexpert
+- company: 'TTEC '
+  board: ttec
+- company: Turner & Townsend
+  board: turnertownsend
+- company: U-Haul
+  board: u-haul
+- company: Unowhy
+  board: unowhy
+- company: Uplevel
+  board: uplevel
+- company: Uptech
+  board: uptech
+- company: Urbanic
+  board: urbanic
+- company: Valuable Recruitment
+  board: valuablerecruitment
+- company: Value1
+  board: value1
+- company: Veles Productions Sp. z o.o.
+  board: velesproductionsspzoo
+- company: Vida Health
+  board: vidahealth
+- company: Videodesign.com
+  board: videodesigncom
+- company: Virtual Worker Now
+  board: virtualworkernow
+- company: Visuary
+  board: visuary
+- company: Vital Research
+  board: vitalresearch
+- company: VoxelCloud
+  board: voxelcloud
+- company: VT Enterprise
+  board: vtenterprise
+- company: We Are Rosie
+  board: wearerosie
+- company: Wecom
+  board: wecom
+- company: Wider Circle
+  board: widercircle
+- company: Work Better Now
+  board: workbetternow
+- company: XceedSearch.com
+  board: xceedsearchcom
+- company: Xinnovit
+  board: xinnovit
+- company: Ziffity Solutions
+  board: ziffitysolutions

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1530,3 +1530,13 @@
   board: deepmirror
 - company: FLO EV Charging
   board: flo-addenergie
+- company: 6 Figure Creative
+  board: 6figurecreative
+- company: OysterHR
+  board: oysterhr
+- company: RYNO Strategic Solutions
+  board: ryno-strategic-solutions
+- company: WaveStrong, Inc.
+  board: wavestrong
+- company: Yodeck
+  board: yodeck


### PR DESCRIPTION
First harvest through `cmd/harvest-orphans` (#1413).

## What ran

`harvest-orphans` on prod: **8,727 companies** held only through a remote-jobs aggregator → **15,617 name-derived candidate boards**, each probed against the platform's own public API by `harvest-boards`.

This PR carries only the providers that **publish an employer name**, so the corroboration gate could confirm every board belongs to the company the seed expected:

| Provider | Boards | Rejected on the name |
|---|---:|---:|
| smartrecruiters | 327 | 0 |
| greenhouse | 16 | 1 |
| workable | 5 | 7 |

348 boards. `go test ./internal/sources/` passes; no duplicate board ids introduced.

## The gate earned its keep on the first run

Workable's widget API answers an **unknown** slug with a live-looking JSON body under a catch-all account named `Workable`. The prober's liveness test — "the board returns jobs" — is therefore true for *every* candidate, valid or not. Only the name comparison rejects them.

Without the gate this harvest would have written **thousands of phantom boards** into `workable.yml`, all pointing at one Workable-owned account. Every rejection logged the same reported name:

```
7 board reports "Workable"
```

For the existing 761 workable boards: if any came from an earlier slug-guessing harvest, they deserve the same check.

## Workable's number is not its yield

Partway through the run Workable began serving an HTML challenge instead of JSON in response to our request volume. The prober reads a non-JSON response as a dead board, so an unknown share of its candidates was **silently never tested** rather than found absent. Workable was the highest-yield provider in the original sample (7 of 12 hits), so it needs a paced re-run — pacing, not proxy egress: this is a burst we created, not an IP blocklist, and `pacedHTMLGetter` is the existing tool for it.

## Not in this batch

- **breezy, recruitee** — probing per-subdomain, where dead hosts hang to the client timeout; both were still running after an hour and were stopped so they can be re-run with pacing alongside Workable. They publish names, so they belong in a later batch.
- **lever, ashby, bamboohr, personio, freshteam, jazzhr, jobvite, traffit, trakstar, deel, gem, pinpoint, hireology, isolvedhire, applicantpro, careerplug** — their public APIs publish no employer name anywhere, so the gate cannot fire and a board would be accepted on liveness alone. Held back deliberately after what Workable showed.
- **apploi, paylocity, join, teamtailor** — board ids are numeric ids, GUIDs or hosts, so a name-derived candidate is meaningless.

## After merge

`sources/*.yml` are bind-mounted data — no image rebuild. Ingest each changed provider, then a reindex (stopping `freehire-reindexw.timer` first).
