### PR TITLE
handler uses the shared pgconv converters instead of local twins

### DIFF
--- a/internal/handler/api_keys.go
+++ b/internal/handler/api_keys.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/pgconv"
 )
 
 // apiKeyResponse is the public, secret-free shape of an API key: the display prefix
@@ -95,12 +96,7 @@ func (h *authHandlers) CreateAPIKey(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "name is required")
 	}
 
-	var expiresAt pgtype.Timestamptz
-	if in.ExpiresAt != nil {
-		expiresAt = pgtype.Timestamptz{Time: *in.ExpiresAt, Valid: true}
-	}
-
-	token, row, err := h.mintAPIKey(c.Context(), userID, name, expiresAt)
+	token, row, err := h.mintAPIKey(c.Context(), userID, name, pgconv.Timestamptz(in.ExpiresAt))
 	if err != nil {
 		return err
 	}

--- a/internal/handler/hardconstraint_inputs.go
+++ b/internal/handler/hardconstraint_inputs.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/jackc/pgx/v5/pgtype"
-
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/hardconstraint"
 	"github.com/strelov1/freehire/internal/jobfacts"
 	"github.com/strelov1/freehire/internal/matchanalysis"
+	"github.com/strelov1/freehire/internal/pgconv"
 	"github.com/strelov1/freehire/internal/resumeextract"
 	"github.com/strelov1/freehire/internal/userprofile"
 )
@@ -87,7 +86,7 @@ func (h *matchHandlers) jobBlockers(ctx context.Context, userID int64, job db.Jo
 // the caller asserted no base country of their own (see candidateCountry).
 func buildHardConstraintInputs(job db.Job, cv resumeextract.Professional, loc userprofile.LocationPreferences, derivedCountries []string) (hardconstraint.JobRequirements, hardconstraint.CVEvidence) {
 	jr := hardconstraint.JobRequirements{
-		ExperienceYearsMin:     int4Ptr(job.ExperienceYearsMin),
+		ExperienceYearsMin:     pgconv.IntPtr(job.ExperienceYearsMin),
 		EducationLevel:         job.EducationLevel,
 		DegreeOptional:         jobfacts.DegreeOptional(job.Description),
 		EnglishLevel:           job.EnglishLevel,
@@ -144,15 +143,6 @@ func jobVisaSponsorship(raw json.RawMessage) *bool {
 		return nil
 	}
 	return e.VisaSponsorship
-}
-
-// int4Ptr converts a pgtype.Int4 to an optional int, mapping SQL NULL to nil.
-func int4Ptr(v pgtype.Int4) *int {
-	if !v.Valid {
-		return nil
-	}
-	n := int(v.Int32)
-	return &n
 }
 
 // candidateCountry decides which country the hard-constraint evaluator judges the caller

--- a/internal/handler/match_analysis.go
+++ b/internal/handler/match_analysis.go
@@ -17,6 +17,7 @@ import (
 	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/jobmatch"
 	"github.com/strelov1/freehire/internal/matchanalysis"
+	"github.com/strelov1/freehire/internal/pgconv"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
 	"github.com/strelov1/freehire/internal/userprofile"
@@ -283,7 +284,7 @@ func (h *matchHandlers) cacheAnalysis(ctx context.Context, userID int64, job db.
 		JobID:          job.ID,
 		Analysis:       blob,
 		Model:          h.matchAnalysis.ModelID(),
-		CvUploadedAt:   tsFromPtr(cvUploadedAt),
+		CvUploadedAt:   pgconv.Timestamptz(cvUploadedAt),
 		JobContentHash: job.ContentHash,
 	}); err != nil {
 		log.Printf("matchanalysis: cache analysis for user %d job %d: %v", userID, job.ID, err)
@@ -419,11 +420,4 @@ func decodeAnalysis(blob []byte) *matchanalysis.Analysis {
 		return nil
 	}
 	return &a
-}
-
-func tsFromPtr(t *time.Time) pgtype.Timestamptz {
-	if t == nil {
-		return pgtype.Timestamptz{}
-	}
-	return pgtype.Timestamptz{Time: *t, Valid: true}
 }

--- a/openspec/changes/handler-uses-shared-pgconv/.openspec.yaml
+++ b/openspec/changes/handler-uses-shared-pgconv/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/handler-uses-shared-pgconv/proposal.md
+++ b/openspec/changes/handler-uses-shared-pgconv/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+`internal/pgconv` states its own purpose: these conversions live in one place "instead of being
+re-declared in every package that touches the database". Sixteen packages import it.
+`internal/handler` — the largest in the repo — carried private twins under different names, so a
+reader grepping for the conversion found several spellings and could not tell whether they agree.
+
+Body-identical, verified:
+
+| handler | pgconv |
+|---|---|
+| `tsFromPtr(*time.Time) pgtype.Timestamptz` | `Timestamptz` |
+| `int4Ptr(pgtype.Int4) *int` | `IntPtr` |
+
+And a **third the finding does not name**: `api_keys.go` wrote `pgconv.Timestamptz` out inline as
+a `var` plus an `if`, four lines doing one function's job.
+
+Small in isolation. It is the same habit that produced `pgText` in `companies.go` (deleted in
+#1409, where it turned out to duplicate `pgconv.Text`), and it is what keeps the `pgtype`
+vocabulary alive inside the transport layer.
+
+## What Changes
+
+- `tsFromPtr` and `int4Ptr` are deleted; their two call sites use `pgconv.Timestamptz` and
+  `pgconv.IntPtr`.
+- `api_keys.go`'s inline twin collapses to one call.
+- `hardconstraint_inputs.go` stops importing `pgtype` altogether.
+- No behaviour change: the deleted bodies are character-for-character the shared ones.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. `tasks.md` is the real artifact; the change
+archives with `--skip-specs`.
+
+## Impact
+
+- `internal/handler/match_analysis.go`, `hardconstraint_inputs.go`, `api_keys.go`.
+- Deliberately left: six `pgtype` literals the handler still builds. Four are `pgtype.Timestamp`
+  (pgconv has `Timestamptz`, a different type), one is `pgtype.UUID`, and one takes a non-pointer
+  so there is no nil↔NULL question to answer. They are plain literals, not converters; inventing
+  `pgconv` functions for them would be infrastructure ahead of need.

--- a/openspec/changes/handler-uses-shared-pgconv/tasks.md
+++ b/openspec/changes/handler-uses-shared-pgconv/tasks.md
@@ -1,0 +1,17 @@
+## 1. Delete the twins
+
+- [x] 1.1 Confirm each local helper is body-identical to its pgconv counterpart before deleting
+      it — that identity is what makes this a deletion rather than a behaviour change.
+- [x] 1.2 Delete `tsFromPtr`; call `pgconv.Timestamptz` at its one call site.
+- [x] 1.3 Delete `int4Ptr`; call `pgconv.IntPtr` at its one call site, and drop the now-unused
+      `pgtype` import from that file.
+- [x] 1.4 Found while implementing: `api_keys.go` inlines the same conversion as a `var` plus an
+      `if`. Collapse it to one `pgconv.Timestamptz` call.
+
+## 2. Verify and close
+
+- [x] 2.1 `go build ./... && go vet ./... && go test ./...` green.
+- [x] 2.2 Survey every remaining `pgtype` literal in the package and record which are genuinely
+      outside pgconv's scope, so the next reader does not mistake them for missed twins.
+- [x] 2.3 Mark S12 ✅ in `docs/reviews/2026-08-01-architecture-review.md`, noting that its
+      "handler never imports pgconv" evidence went stale when #1409 added the first import.


### PR DESCRIPTION
S12 from the 2026-08-01 architecture review.

`internal/pgconv` states its purpose in its own first lines: these conversions live in one place
*"instead of being re-declared in every package that touches the database"*. Sixteen packages
import it. `internal/handler` — the largest in the repo — carried private twins under different
names, so a reader grepping for the conversion found several spellings and could not tell whether
they agree.

Body-identical, verified before deleting:

| handler | pgconv |
|---|---|
| `tsFromPtr(*time.Time) pgtype.Timestamptz` | `Timestamptz` |
| `int4Ptr(pgtype.Int4) *int` | `IntPtr` |

## A third the finding does not name

`api_keys.go` wrote the same conversion out inline — a `var` plus an `if`, four lines doing one
function's job:

```go
var expiresAt pgtype.Timestamptz
if in.ExpiresAt != nil {
    expiresAt = pgtype.Timestamptz{Time: *in.ExpiresAt, Valid: true}
}
```

That is `pgconv.Timestamptz(in.ExpiresAt)`.

## What stays, and why it is not a missed twin

Six `pgtype` literals remain in the package. Four are `pgtype.Timestamp` — pgconv has
`Timestamptz`, a *different* type. One is `pgtype.UUID`, which pgconv does not cover. One takes a
non-pointer, so there is no nil↔NULL question to answer at all. These are plain literals, not
converters; inventing `pgconv` functions for them would be infrastructure ahead of need.

`hardconstraint_inputs.go` stops importing `pgtype` entirely.

## One correction to the finding

Its evidence line *"`grep -n pgconv internal/handler/*.go` returns nothing — the largest package
in the repo never imports it"* went stale in #1409, which added the first import when `pgText`
turned out to duplicate `pgconv.Text`. Same habit, two findings apart.

No behaviour change: the deleted bodies are character-for-character the shared ones.
`go build ./... && go vet ./... && go test ./...` green.
