### PR TITLE
feat(web): Product Hunt launch strip that retires itself

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -67,3 +67,12 @@
   -webkit-mask-image: radial-gradient(ellipse 90% 75% at 25% 0%, #000 18%, transparent 80%);
   mask-image: radial-gradient(ellipse 90% 75% at 25% 0%, #000 18%, transparent 80%);
 }
+
+/* Product Hunt strip: hidden before first paint for a visitor who already closed it.
+   The banner is server-rendered on purpose — it lives in the document flow, so
+   mounting it after hydration would shove the page down under someone mid-read. The
+   no-flash script in app.html sets this class from localStorage; the component then
+   catches up on mount and drops the node. See $lib/productHunt.ts. */
+.ph-dismissed [data-ph-banner] {
+  display: none;
+}

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -18,6 +18,15 @@
           if (dark) document.documentElement.classList.add('dark');
         } catch (e) {}
       })();
+      // Same trick for the Product Hunt strip: it renders on the server (so it never
+      // shoves the page down after hydration), and this hides it before first paint
+      // for a visitor who already closed it. Mirrors $lib/productHunt.ts.
+      (function () {
+        try {
+          if (localStorage.getItem('hire.ph-banner-dismissed') === '1')
+            document.documentElement.classList.add('ph-dismissed');
+        } catch (e) {}
+      })();
     </script>
     <!-- Google Analytics is no longer bootstrapped inline here: it now loads via
     $lib/analytics (initTrackers), gated on cookie consent alongside PostHog. -->

--- a/web/src/lib/components/ProductHuntBanner.svelte
+++ b/web/src/lib/components/ProductHuntBanner.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { launchPhase, PH_URL, readDismissed, writeDismissed } from '$lib/productHunt';
+
+  // A strip under the header pointing at the Product Hunt page, dismissible and
+  // remembered. Self-gating like EmailVerificationBanner, so the layout mounts it
+  // unconditionally: it renders nothing once the launch day has passed.
+  //
+  // Its wording follows the clock (`launchPhase`) rather than a flag, so it turns
+  // itself from "launching on the 26th" into "live today" and then retires — nobody
+  // has to ship a web build on launch day.
+  //
+  // Why it renders on the server and hides via a class rather than waiting for mount:
+  // this strip sits in the document flow, so mounting it after hydration would shove
+  // the page down under someone already reading it. The no-flash script in app.html
+  // sets `.ph-dismissed` before first paint for a visitor who closed it, exactly as it
+  // does for the theme; `dismissed` then catches up on mount and removes the node.
+
+  const phase = launchPhase(Date.now());
+
+  // Starts false so the hydrated markup matches the server's; the real value arrives
+  // on mount, by which point CSS has already hidden the strip for anyone who closed it.
+  let dismissed = $state(false);
+
+  onMount(() => {
+    dismissed = readDismissed();
+  });
+
+  function dismiss() {
+    dismissed = true;
+    writeDismissed();
+  }
+</script>
+
+{#if phase !== 'over' && !dismissed}
+  <div data-ph-banner class="border-b border-border bg-brand/5">
+    <div class="mx-auto flex w-full max-w-6xl items-center gap-3 px-4 py-2.5 text-sm">
+      <p class="min-w-0 flex-1 text-muted-foreground">
+        {#if phase === 'live'}
+          <span class="font-medium text-foreground">freehire is live on Product Hunt today.</span>
+          <span class="hidden sm:inline">One day decides whether anyone sees it.</span>
+        {:else}
+          <span class="font-medium text-foreground"
+            >freehire launches on Product Hunt on 26 August.</span
+          >
+          <span class="hidden sm:inline">Follow the page and you'll hear the moment it opens.</span>
+        {/if}
+      </p>
+
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Product Hunt page opened in a new tab; not an internal route -->
+      <a
+        href={PH_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="shrink-0 whitespace-nowrap font-medium text-brand underline-offset-4 hover:underline"
+      >
+        {phase === 'live' ? 'Support the launch' : 'Follow'} →
+      </a>
+
+      <button
+        type="button"
+        onclick={dismiss}
+        aria-label="Dismiss"
+        class="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+      >
+        ✕
+      </button>
+    </div>
+  </div>
+{/if}

--- a/web/src/lib/components/ProductHuntBanner.svelte
+++ b/web/src/lib/components/ProductHuntBanner.svelte
@@ -47,7 +47,9 @@
         {/if}
       </p>
 
-      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Product Hunt page opened in a new tab; not an internal route -->
+      <!-- Block form, not disable-next-line: the tag spans several lines, so the
+           href the rule fires on is not the line after the comment. -->
+      <!-- eslint-disable svelte/no-navigation-without-resolve -- external Product Hunt page opened in a new tab; not an internal route -->
       <a
         href={PH_URL}
         target="_blank"
@@ -56,6 +58,7 @@
       >
         {phase === 'live' ? 'Support the launch' : 'Follow'} →
       </a>
+      <!-- eslint-enable svelte/no-navigation-without-resolve -->
 
       <button
         type="button"

--- a/web/src/lib/productHunt.test.ts
+++ b/web/src/lib/productHunt.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { LAUNCH_OPENS_AT, launchPhase } from './productHunt';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe('launchPhase', () => {
+  it('announces the launch until the Product Hunt day opens', () => {
+    expect(launchPhase(Date.UTC(2026, 7, 1))).toBe('before');
+    expect(launchPhase(LAUNCH_OPENS_AT - 1)).toBe('before');
+  });
+
+  it('opens on Pacific midnight, not UTC midnight', () => {
+    // 26 August 00:00 UTC is still the 25th in California — the day has not opened.
+    expect(launchPhase(Date.UTC(2026, 7, 26, 0, 0))).toBe('before');
+    expect(launchPhase(LAUNCH_OPENS_AT)).toBe('live');
+  });
+
+  it('stays live for the whole 24-hour day', () => {
+    expect(launchPhase(LAUNCH_OPENS_AT + 12 * HOUR)).toBe('live');
+    expect(launchPhase(LAUNCH_OPENS_AT + DAY - 1)).toBe('live');
+  });
+
+  it('retires itself once the day is over, with no deploy', () => {
+    expect(launchPhase(LAUNCH_OPENS_AT + DAY)).toBe('over');
+    expect(launchPhase(Date.UTC(2026, 8, 15))).toBe('over');
+  });
+});

--- a/web/src/lib/productHunt.ts
+++ b/web/src/lib/productHunt.ts
@@ -1,0 +1,55 @@
+// Product Hunt launch banner: pure phase logic and dismissal persistence, kept free
+// of Svelte runes and SvelteKit imports so it unit-tests in the plain-node vitest
+// environment. The markup lives in components/ProductHuntBanner.svelte.
+//
+// The phase is derived from the clock rather than from a flag someone flips, so the
+// banner switches itself from "we launch on the 26th" to "we are live today" and then
+// disappears — with no deploy on launch day, which is exactly the day not to be
+// shipping a web build.
+
+/** When the Product Hunt day opens: 00:00 PDT on 26 August 2026 (07:00 UTC).
+ *  Product Hunt runs its day on Pacific time, so UTC midnight is seven hours early. */
+export const LAUNCH_OPENS_AT = Date.UTC(2026, 7, 26, 7, 0, 0);
+
+/** A Product Hunt day is 24 hours from the moment it opens. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** localStorage key holding the visitor's dismissal of the banner. */
+export const PH_DISMISSED_KEY = 'hire.ph-banner-dismissed';
+
+/** Where the banner points. Carries its own campaign so the launch-day traffic is
+ *  separable from the footer badge's. */
+export const PH_URL =
+  'https://www.producthunt.com/products/freehire?utm_source=freehire&utm_medium=banner&utm_campaign=launch';
+
+/** Which message the banner should carry, or `over` once the launch day has passed
+ *  and it should not render at all. */
+export type LaunchPhase = 'before' | 'live' | 'over';
+
+/** Classify a moment against the launch window. */
+export function launchPhase(now: number): LaunchPhase {
+  if (now < LAUNCH_OPENS_AT) return 'before';
+  if (now < LAUNCH_OPENS_AT + DAY_MS) return 'live';
+  return 'over';
+}
+
+/** Whether the visitor has closed the banner. Absent or unreadable storage (Safari
+ *  private mode, a blocked origin) reads as "not dismissed" — showing a banner to
+ *  someone who closed it is a smaller harm than a thrown error in the layout. */
+export function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(PH_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** Record that the visitor closed the banner. Silently a no-op when storage is
+ *  unavailable — the banner then simply returns on the next page load. */
+export function writeDismissed(): void {
+  try {
+    localStorage.setItem(PH_DISMISSED_KEY, '1');
+  } catch {
+    /* storage unavailable; the dismissal lasts for this page only */
+  }
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
     trackSignupIfNew,
   } from '$lib/analytics';
   import TopBar from '$lib/components/TopBar.svelte';
+  import ProductHuntBanner from '$lib/components/ProductHuntBanner.svelte';
   import EmailVerificationBanner from '$lib/components/EmailVerificationBanner.svelte';
   import Footer from '$lib/components/Footer.svelte';
   import CookieConsent from '$lib/components/CookieConsent.svelte';
@@ -98,6 +99,11 @@
 
   <!-- Self-gating: renders only for a signed-in, unverified account. -->
   <EmailVerificationBanner />
+
+  <!-- Self-gating: renders until the Product Hunt launch day is over, unless
+       dismissed. Below the verification prompt on purpose — a promo strip must not
+       push a security notice further from the header. -->
+  <ProductHuntBanner />
 
   <main class="flex-1">
     {@render children()}

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -21,17 +21,25 @@ export default {
     // (<script type="application/ld+json">) is non-executable and unaffected.
     // style-src is left unset (no default-src), so styles and fonts are unrestricted.
     //
-    // The anti-FOUC theme script in app.html is author-written, so SvelteKit does NOT
+    // The anti-FOUC script in app.html is author-written, so SvelteKit does NOT
     // nonce it — it is allowed by the SHA-256 of its exact contents below. WARNING:
-    // editing that <script> in app.html changes its hash and will silently break the
-    // no-flash theme load; recompute and update this hash when you touch it.
+    // editing that <script> in app.html changes its hash and will silently break
+    // BOTH no-flash passes it carries (the theme and the Product Hunt strip): the
+    // browser blocks the whole block, nothing errors, and the only symptom is a
+    // flash of the wrong theme. Recompute whenever you touch it —
+    //
+    //   python3 -c "import re,hashlib,base64;b=re.findall(r'<script>(.*?)</script>',
+    //     open('src/app.html').read(),re.S)[0];
+    //     print('sha256-'+base64.b64encode(hashlib.sha256(b.encode()).digest()).decode())"
+    //
+    // — and verify in a real browser: a CSP block shows up only in the console.
     csp: {
       mode: 'auto',
       directives: {
         'script-src': [
           'self',
-          // Anti-FOUC theme script in app.html (see WARNING above).
-          'sha256-qvzE1AlG+fDQlxleonlMQaOrsjjgE6qfHfnkE0pD/bo=',
+          // Anti-FOUC script in app.html — theme + Product Hunt strip (see WARNING above).
+          'sha256-MW6zpEdH1zWlGWKLAC6RP63TxcORvBoLwbJTeRL+HD0=',
           // Google Analytics: the gtag.js host. GA now loads from the same-origin
           // bundle ($lib/analytics, consent-gated), so no inline-script hash is
           // needed — only the external host it injects.


### PR DESCRIPTION
Follows #1418 (the footer badge). Adds the strip under the header.

## What

- `ProductHuntBanner.svelte` — a dismissible strip linking to the Product Hunt page, self-gating like `EmailVerificationBanner`, so the layout mounts it unconditionally.
- `$lib/productHunt.ts` — the phase logic and dismissal storage, kept free of runes and SvelteKit imports so it unit-tests in plain node (4 tests).

## Three decisions worth reviewing

**The wording follows the clock, not a flag.** `launchPhase(now)` turns "launches on 26 August" into "live today" at 00:00 PDT on the 26th (Product Hunt runs its day on Pacific time), then reports `over` and the component renders nothing. Nobody has to ship a web build on launch day.

**It renders on the server, and hides via a class.** The strip is in the document flow, so mounting it after hydration would push the page down under someone mid-read. The anti-FOUC script in `app.html` sets `.ph-dismissed` before first paint for a visitor who already closed it; the component catches up on mount and drops the node.

**The CSP hash had to be recomputed.** That inline script's SHA-256 is pinned in `script-src`. Editing it fails silently — the browser drops the whole block, nothing errors, and the only symptom is a flash of the wrong theme. The hash is updated, and the recompute one-liner now lives in the comment above it.

## Verified

- `vitest src/lib/productHunt.test.ts`: 4 passed.
- `svelte-check`: no errors in the touched files.
- `pnpm build`: green.
- Served the production build and hashed the script as actually delivered: `sha256-MW6zpEdH1zWlGWKLAC6RP63TxcORvBoLwbJTeRL+HD0=`, byte-identical to the `script-src` entry in the response header.
- Headless screenshot: the strip renders under the header with the pre-launch wording — and the page comes up in dark mode, which is the proof that the inline script ran rather than being blocked.