### PR TITLE
feat(harvest-boards): pace the probe rate, not just its burst

### DIFF
--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -5,10 +5,12 @@
 // redistributed dataset. Run-once host tool; review the diff before ingesting.
 //
 //	go run ./cmd/harvest-boards <provider> <seed.json>
+//	go run ./cmd/harvest-boards -pace 2 -workers 4 workable seed.json   # rate-limited platform
 package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -19,22 +21,31 @@ import (
 	"github.com/strelov1/freehire/internal/sources"
 )
 
-// probeWorkers bounds the concurrent probe fan-out. The shared client handles 429 backoff,
-// so this stays polite under load without a per-request delay.
-const probeWorkers = 16
+// defaultProbeWorkers bounds the concurrent probe fan-out. It bounds the BURST only; a
+// platform whose budget is per-window needs -pace as well (see pacer.go).
+const defaultProbeWorkers = 16
 
 func main() { os.Exit(run()) }
 
 func run() int {
-	// 3 args = seed path; 2 args = discovery (the prober must support it).
-	if len(os.Args) != 2 && len(os.Args) != 3 {
-		log.Printf("usage: harvest-boards <provider> [seed.json]")
+	// Flags precede the positional arguments, which stay as they were: 1 = discovery (the
+	// prober must support it), 2 = provider plus seed path.
+	pace := flag.Float64("pace", 0, "cap the probe rate at this many requests per second (0 = unpaced)")
+	workers := flag.Int("workers", defaultProbeWorkers, "concurrent probes in flight")
+	flag.Parse()
+	args := flag.Args()
+	if len(args) != 1 && len(args) != 2 {
+		log.Printf("usage: harvest-boards [-pace N] [-workers N] <provider> [seed.json]")
 		return 2
 	}
-	provider := os.Args[1]
+	provider := args[0]
 	seedPath := ""
-	if len(os.Args) == 3 {
-		seedPath = os.Args[2]
+	if len(args) == 2 {
+		seedPath = args[1]
+	}
+	if *workers < 1 {
+		log.Printf("harvest-boards: -workers must be at least 1")
+		return 2
 	}
 
 	p, ok := probers[provider]
@@ -44,7 +55,10 @@ func run() int {
 	}
 
 	ctx := context.Background()
-	client := sources.NewClient()
+	client := paced(sources.NewClient(), *pace)
+	if *pace > 0 {
+		log.Printf("harvest-boards: pacing probes at %.2f req/s with %d workers", *pace, *workers)
+	}
 
 	raw, companyByBoard, err := resolveCandidates(ctx, p, client, seedPath)
 	if err != nil {
@@ -67,7 +81,7 @@ func run() int {
 	log.Printf("harvest-boards: %s candidates=%d existing=%d new-candidates=%d",
 		provider, len(raw), len(existing), len(candidates))
 
-	kept, failures, mismatches := probeAll(ctx, client, p, candidates, companyByBoard)
+	kept, failures, mismatches := probeAll(ctx, client, p, candidates, companyByBoard, *workers)
 	log.Printf("harvest-boards: live boards found=%d probe-failures=%d name-mismatches=%d",
 		len(kept), failures, mismatches)
 	// Every candidate erroring means the probe itself is broken (an API change, an
@@ -159,8 +173,8 @@ func resolveCandidates(ctx context.Context, p prober, c httpClient, seedPath str
 // Mismatches are counted apart from failures because they mean something else entirely — a
 // dead board is noise, while a wave of mismatches means the candidates or the prober's name
 // extraction are wrong, and burying them in the failure count would hide that.
-func probeAll(ctx context.Context, client httpClient, p prober, candidates []string, companyByBoard map[string]string) ([]entry, int, int) {
-	sem := make(chan struct{}, probeWorkers)
+func probeAll(ctx context.Context, client httpClient, p prober, candidates []string, companyByBoard map[string]string, workers int) ([]entry, int, int) {
+	sem := make(chan struct{}, workers)
 	var (
 		mu         sync.Mutex
 		kept       []entry

--- a/cmd/harvest-boards/pacer.go
+++ b/cmd/harvest-boards/pacer.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+
+	"golang.org/x/net/html"
+	"golang.org/x/time/rate"
+)
+
+// waiter gates a request until the limiter admits it. *rate.Limiter satisfies it; tests
+// inject a fake so the gate can be asserted without timing flake. Mirrors the ingest-side
+// pacer in internal/sources.
+type waiter interface {
+	Wait(ctx context.Context) error
+}
+
+// pacedClient wraps the probe transport with a shared limiter so a run's AGGREGATE request
+// rate to one platform stays under its per-IP window budget, independent of worker count.
+//
+// The worker pool bounds how many requests are in flight; it does not bound how many go out
+// per minute. A harvest is a far denser traffic shape than the ingest crawl the platforms are
+// used to — the first orphan harvest put ~15k probes at Workable in minutes, and partway
+// through it began answering with an HTML challenge instead of JSON. The prober reads a
+// non-JSON body as a dead board, so the candidates arriving during the penalty window were
+// not judged absent, they were never judged at all: a silently truncated harvest that looks
+// like a complete one.
+//
+// Every verb is gated, not just the JSON ones, so a provider whose prober scrapes HTML or
+// posts a query shares the same bucket.
+type pacedClient struct {
+	inner   httpClient
+	limiter waiter
+}
+
+func (c pacedClient) GetJSON(ctx context.Context, url string, v any) error {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return c.inner.GetJSON(ctx, url, v)
+}
+
+func (c pacedClient) PostJSON(ctx context.Context, url string, body, v any) error {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return c.inner.PostJSON(ctx, url, body, v)
+}
+
+func (c pacedClient) GetXML(ctx context.Context, url string, v any) error {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return c.inner.GetXML(ctx, url, v)
+}
+
+func (c pacedClient) GetHTML(ctx context.Context, url string) (*html.Node, error) {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+	return c.inner.GetHTML(ctx, url)
+}
+
+func (c pacedClient) GetText(ctx context.Context, url string) (string, error) {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return "", err
+	}
+	return c.inner.GetText(ctx, url)
+}
+
+func (c pacedClient) GetJSONWithHeaders(ctx context.Context, url string, headers map[string]string, v any) error {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return c.inner.GetJSONWithHeaders(ctx, url, headers, v)
+}
+
+func (c pacedClient) PostJSONWithHeaders(ctx context.Context, url string, headers map[string]string, body, v any) error {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return c.inner.PostJSONWithHeaders(ctx, url, headers, body, v)
+}
+
+// paced wraps a client to admit at most ratePerSec requests per second, or returns it
+// unchanged when ratePerSec is zero — an unpaced run stays the default, since most platforms
+// answer a whole harvest without complaint and pacing only lengthens it.
+func paced(c httpClient, ratePerSec float64) httpClient {
+	if ratePerSec <= 0 {
+		return c
+	}
+	// Burst 1: the point is the total per window, and a burst bucket would let a fresh run
+	// fire its whole allowance at once — which is the shape that drew the challenge.
+	return pacedClient{inner: c, limiter: rate.NewLimiter(rate.Limit(ratePerSec), 1)}
+}

--- a/cmd/harvest-boards/pacer_test.go
+++ b/cmd/harvest-boards/pacer_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// countingWaiter stands in for the rate limiter so the gate can be asserted without timing
+// flake: it records every admission and can refuse, the way a cancelled context does.
+type countingWaiter struct {
+	admitted int
+	err      error
+}
+
+func (w *countingWaiter) Wait(context.Context) error {
+	w.admitted++
+	return w.err
+}
+
+// recordingClient counts the calls that actually reached the transport.
+type recordingClient struct{ calls int }
+
+func (c *recordingClient) GetJSON(context.Context, string, any) error { c.calls++; return nil }
+func (c *recordingClient) PostJSON(context.Context, string, any, any) error {
+	c.calls++
+	return nil
+}
+func (c *recordingClient) GetXML(context.Context, string, any) error { c.calls++; return nil }
+func (c *recordingClient) GetHTML(context.Context, string) (*html.Node, error) {
+	c.calls++
+	return nil, nil
+}
+func (c *recordingClient) GetText(context.Context, string) (string, error) {
+	c.calls++
+	return "", nil
+}
+func (c *recordingClient) GetJSONWithHeaders(context.Context, string, map[string]string, any) error {
+	c.calls++
+	return nil
+}
+func (c *recordingClient) PostJSONWithHeaders(context.Context, string, map[string]string, any, any) error {
+	c.calls++
+	return nil
+}
+
+// Every verb a prober can reach the platform through has to pass the same bucket. A verb that
+// skipped it would let a provider whose prober uses it run unpaced — the whole point is an
+// aggregate rate, not a per-method one.
+func TestPacedClientGatesEveryVerb(t *testing.T) {
+	w := &countingWaiter{}
+	inner := &recordingClient{}
+	c := pacedClient{inner: inner, limiter: w}
+	ctx := context.Background()
+
+	_ = c.GetJSON(ctx, "u", nil)
+	_ = c.PostJSON(ctx, "u", nil, nil)
+	_ = c.GetXML(ctx, "u", nil)
+	_, _ = c.GetHTML(ctx, "u")
+	_, _ = c.GetText(ctx, "u")
+	_ = c.GetJSONWithHeaders(ctx, "u", nil, nil)
+	_ = c.PostJSONWithHeaders(ctx, "u", nil, nil, nil)
+
+	if w.admitted != 7 {
+		t.Errorf("admitted %d requests, want 7 — a verb is bypassing the pacer", w.admitted)
+	}
+	if inner.calls != 7 {
+		t.Errorf("inner calls = %d, want 7", inner.calls)
+	}
+}
+
+// A refused admission (a cancelled run) must not reach the platform: the pacer exists to keep
+// requests off the wire, so delegating anyway would defeat it at exactly the wrong moment.
+func TestPacedClientDoesNotFetchWhenRefused(t *testing.T) {
+	w := &countingWaiter{err: errors.New("cancelled")}
+	inner := &recordingClient{}
+	c := pacedClient{inner: inner, limiter: w}
+
+	if err := c.GetJSON(context.Background(), "u", nil); err == nil {
+		t.Error("a refused admission must surface as an error")
+	}
+	if inner.calls != 0 {
+		t.Errorf("inner calls = %d, want 0 — the fetch went out despite the refusal", inner.calls)
+	}
+}

--- a/cmd/harvest-boards/probe_test.go
+++ b/cmd/harvest-boards/probe_test.go
@@ -55,7 +55,7 @@ func TestProbeAllNameGate(t *testing.T) {
 		"acme.wd1.myworkdayjobs.com/careers",
 	}
 
-	kept, failures, mismatches := probeAll(context.Background(), nil, prober, candidates, seed)
+	kept, failures, mismatches := probeAll(context.Background(), nil, prober, candidates, seed, defaultProbeWorkers)
 
 	got := make(map[string]string, len(kept))
 	for _, e := range kept {


### PR DESCRIPTION
## Why

The worker pool bounds how many probes are **in flight**; nothing bounded how many go out **per minute**. The first orphan harvest (#1419) put ~15k probes at Workable in minutes and it began answering with an HTML challenge instead of JSON. The prober reads a non-JSON body as a dead board, so every candidate arriving inside the penalty window was not judged absent — it was **never judged at all**. A silently truncated harvest that looks like a complete one.

Worse, inside that window Workable answered some requests with **a different account's data**: seven probes for other employers' slugs came back named `Workable`. The name gate from #1413 rejected all seven.

Queried later, in the quiet, an unknown slug returns a plain-text `Not Found` that the prober correctly reads as dead:

```
zzqqnonexistent1234        NON-JSON 9 bytes: Not Found
derq                       JSON name= 'Derq' jobs= 7
```

So this is **response substitution under load**, not a catch-all account — which is the wider risk: a throttled harvest can attribute one account's jobs to another board id. (This corrects the "catch-all on any slug" reading in #1419's description.)

## What

- `-pace N` caps the run at N requests/second through one shared bucket. **Every verb is gated**, not just the JSON ones, so a prober that scrapes HTML or posts a query shares the same budget. Burst is 1 — a burst bucket would let a fresh run fire its whole allowance at once, which is the shape that drew the challenge.
- `-workers N` makes the pool size a flag (was a `const 16`).
- Unpaced stays the default: most platforms answer a whole harvest without complaint, and pacing only lengthens the run.

Mirrors the ingest-side `pacedHTMLGetter` idiom (careerspage, vagas, clinch), whose own comment puts it best: concurrency limits the burst, pacing limits the total-per-window.

## Not proxy egress

`SOURCES_PROXY_URL` and the `proxiedProviders` allowlist exist for platforms that **blocklist the prod datacenter IP** — eightfold 403s every prod-IP request, djinni serves a block page, 2gis tarpits. This is a burst we create ourselves, and rotating IPs to evade a rate limit we cause is the wrong answer.

## Verification

- `gofmt`/`go build`/`go vet` clean, package tests pass.
- Two unit tests: every verb passes the bucket (a bypassing verb would run unpaced), and a refused admission never reaches the transport.
- Smoke-tested against the live Workable API: `-pace 1 -workers 2` over 3 new candidates took 3.2s wall — the pacing held.
