### PR TITLE
Stop writing ANSI colour codes into the request log

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -101,7 +101,12 @@ func main() {
 		EnableStackTrace:  true,
 		StackTraceHandler: func(c *fiber.Ctx, _ any) { c.Locals(handler.LocalPanicReported, true) },
 	}))
-	app.Use(logger.New())
+	// The request log goes to journald and on into /var/log/syslog, never to a terminal, so
+	// Fiber's default colours are ANSI escapes written into a file nobody reads in a terminal.
+	// They were ~28% of syslog's lines on prod, where the API's per-request log is ~71% of a
+	// file that reaches 3.9 GB a week — on a host whose facet reindex refuses to run below a
+	// 70 GiB free-space floor it clears by about 1 GiB. They also make the log ungreppable.
+	app.Use(logger.New(logger.Config{DisableColors: true}))
 
 	// Sentry request middleware, wired only when error reporting is configured. It
 	// sits AFTER recover.New so its deferred capture runs first on a panic (reporting


### PR DESCRIPTION
Found while investigating why the facet reindex refused to run on prod.

`app.Use(logger.New())` takes Fiber's default config, which colourizes. The request log goes to
journald and on into `/var/log/syslog` — never to a terminal — so those colours are ANSI escapes
written into a file nobody reads in a terminal:

```
2026-08-01T16:04:29+00:00 openclaw-host-2 hire-api[1183846]: 16:04:29 | 401 | 167.725µs | | GET | /api/v1/auth/me | not authenticated
```

## Measured, not guessed

Of a 400k-line sample of `/var/log/syslog` on host-2:

| | lines |
|---|---|
| `hire-api` per-request log | ~71% of the sample |
| of those, carrying an ANSI escape as field 5 | ~112k |

`/var/log/syslog` reaches **3.9 GB a week**. nginx logs **726 MB** for the same traffic.

## Why that number matters here

The facet reindex refuses to rebuild below a 70 GiB free-space floor
(`REINDEX_MIN_FREE_GB`), and the host currently clears it by about **1 GiB** (71 free of 301 GB,
with postgres at 111 GB and the Meili index at 50 GB). That floor is not decoration: a
swap-rebuild needs a full second copy of the 44 GB jobs index. When it was last missed, the facet
index silently froze for four days with `/health` still answering 200.

This one line is not the whole answer to that — logrotate's `weekly` with no `maxsize` is the
other half, and that is a host config change, not a code change. But it removes ~28% of the
volume for free.

The escapes also make the log ungreppable, which is the cost that shows up in minutes rather
than gigabytes.

`go build ./... && go vet ./... && go test ./...` green. No behaviour change beyond the log format.
