### PR TITLE
fix(sources): drop the workable 'careers' phantom board

### DIFF
--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1316,8 +1316,6 @@
   board: trl11-inc
 - company: karbon-business
   board: karbon-business
-- company: careers
-  board: careers
 - company: weekday-1
   board: weekday-1
 - company: questronix-corporation-2


### PR DESCRIPTION
## What the audit found

Closing the question #1419 raised: were any of the 766 pre-gate boards in `workable.yml` phantoms?

Every board was probed against `apply.workable.com/api/v1/widget/accounts/<board>` and the employer name it reports was compared with the name in the file, using the same `normalize.SameCompany` fold the harvest gate uses. Paced at ~2.5 req/s.

| | |
|---|---:|
| names agree | 612 |
| differ in spelling / reflect an acquisition | 150 |
| dead board | 4 |
| **phantom** | **1** |

## The one phantom

Board `careers` is answered by an account named **`Workable`**, serving Workable's own `Implementation Manager` posting. Prod carries 2 open jobs under a company literally named `careers`.

`careers` is a dictionary word — short and generic enough to belong to the platform rather than to any employer. That is the whole failure mode in one entry, and it is exactly what the gate added in #1413 now prevents for new boards.

Removing the board lets the unseen sweep close its jobs.

## The 150 that differ are not defects

Two thirds are one name containing the other (`Antarctica Global` / `Antarctica`, `Team17` / `Team17 Digital`, `Jagex` / `Jagex: The RuneScape Company`). Of the rest, most are acquisitions where the platform now reports the acquirer (`Coconut Lizard` → `Keywords Studios`, `houseful` → `Alto`) or entries whose `company` is still the slug (`toloka-ai`, `imachines`) and where the platform's name is the better one — `cmd/backfill-company-names` territory, not this PR's.

Not fixed here deliberately: they are labels, and relabelling 150 boards in the same change that removes a phantom would bury the one thing that actually matters.
