### PR TITLE
One SSE stream writer instead of two

### DIFF
--- a/internal/handler/AGENTS.md
+++ b/internal/handler/AGENTS.md
@@ -88,9 +88,14 @@ client could forget to ask for is a run nobody can take back. Undoing it is
 `POST /me/cvs/:id/autopilot/undo` (also cookie-only), which restores the pre-run
 document and clears the run's report with it.
 
-The turn endpoint writes with `writeEvent`, which — unlike `writeSSE` — reports a
-failed write. That is how a streamed turn learns the client is gone: the failure
-cancels the loop's context, so it stops before spending another model call.
+Both SSE endpoints — the turn and the fit analysis — write through `sseStream`
+(`match_analysis_stream.go`), the one owner of the stream protocol: it serializes the
+heartbeat goroutine against the event callback and re-arms the write deadline before every
+write. `event` reports whether the frame reached the client, and a marshal failure reports
+**true** — an unencodable frame is our bug, not a dead reader. That is how a streamed turn
+learns the client is gone: the failure cancels the loop's context, so it stops before
+spending another model call. The fit analysis deliberately ignores the same signal — its run
+was paid for with an AI credit, so it finishes into the cache rather than aborting.
 
 `assistant_tools.go` / `assistant_tracking_tools.go` / `assistant_cv_tools.go` /
 `assistant_profile_tool.go` / `assistant_present_tool.go` / `assistant_page_tools.go`

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -3,13 +3,10 @@ package handler
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	sentryfiber "github.com/getsentry/sentry-go/fiber"
@@ -144,11 +141,6 @@ func (h *assistantHandlers) register(api fiber.Router, mw middleware) {
 // assistantMaxPrompt bounds one user message. The agent's context is finite and a
 // pasted job board is not a question; the limit is generous for prose.
 const assistantMaxPrompt = 8000
-
-// assistantKeepalive is how often a silent turn emits an SSE comment. A model
-// thinking for a minute would otherwise let nginx's read timeout sever the
-// stream, and the client would show a bare "connection lost" mid-answer.
-const assistantKeepalive = 15 * time.Second
 
 // sessionResponse is the wire shape of one conversation.
 type sessionResponse struct {
@@ -410,10 +402,7 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 
 	turnRunner := h.boundRunner(c.Context(), sess)
 
-	c.Set(fiber.HeaderContentType, "text/event-stream")
-	c.Set(fiber.HeaderCacheControl, "no-cache")
-	c.Set(fiber.HeaderConnection, "keep-alive")
-	c.Set("X-Accel-Buffering", "no") // stop nginx buffering so events reach the browser promptly
+	sseHeaders(c)
 
 	// The server's write timeout would kill this long-lived stream mid-turn, so the SSE
 	// response carries its own, bounded deadline instead (captured while the request ctx
@@ -429,61 +418,33 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 	}
 
 	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
-		// Set the write deadline before EVERY write, not once up front: fasthttp runs
-		// this stream writer on its own goroutine while the serving goroutine arms the
-		// server's WriteTimeout, so a single set races with it and loses about half the
-		// time — the turn then dies at exactly ten seconds, mid-answer, for no reason the
-		// user can see. It is a bounded deadline rather than a cleared one because a
-		// cleared deadline is forever: a reader that stopped reading would block the
-		// write, and with it this goroutine, for the life of the process.
-		write := func(event string, data any) bool {
-			if conn != nil {
-				_ = conn.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
-			}
-			return writeEvent(w, event, data)
-		}
+		// sseStream owns the write protocol both SSE endpoints need: it serializes the
+		// heartbeat goroutine against the event callback (bufio.Writer is not safe for
+		// concurrent use) and re-arms the write deadline before EVERY write. Per-write
+		// rather than once up front because fasthttp runs this stream writer on its own
+		// goroutine while the serving goroutine arms the server's WriteTimeout, so a single
+		// set races with it and loses about half the time — the turn then dies at exactly
+		// ten seconds, mid-answer, for no reason the user can see. Bounded rather than
+		// cleared because a cleared deadline is forever: a reader that stopped reading
+		// would block the write, and with it this goroutine, for the life of the process.
+		stream := newSSEStream(w, conn, sseWriteTimeout)
+
 		// The request context is gone once the handler returns, so the turn runs on
 		// its own cancellable context. Cancellation comes from the client going away,
 		// which shows up as a failed write below.
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		// The heartbeat goroutine and the event callback both write to w, which is not
-		// safe for concurrent use.
-		var mu sync.Mutex
-		stop := make(chan struct{})
-		var heartbeat sync.WaitGroup
-		heartbeat.Add(1)
-		go func() {
-			defer heartbeat.Done()
-			t := time.NewTicker(assistantKeepalive)
-			defer t.Stop()
-			for {
-				select {
-				case <-stop:
-					return
-				case <-t.C:
-					mu.Lock()
-					if conn != nil {
-						_ = conn.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
-					}
-					writeComment(w, "keepalive")
-					mu.Unlock()
-				}
-			}
-		}()
+		stopHeartbeat := stream.keepalive(sseKeepalive)
 
 		err := turnRunner.Run(ctx, sess, registry, system, prompt, turn, func(e assistant.Event) {
-			mu.Lock()
-			defer mu.Unlock()
-			if !write(string(e.Kind), e) {
+			if !stream.event(string(e.Kind), e) {
 				// The client is gone. Stop the loop at its next boundary rather than
 				// finishing a turn nobody is reading.
 				cancel()
 			}
 		})
-		close(stop)
-		heartbeat.Wait()
+		stopHeartbeat()
 		if err != nil {
 			// The loop has already emitted its terminal error event; this is for us —
 			// and for Sentry, which would otherwise never learn of it: this handler
@@ -669,28 +630,4 @@ func mapAssistantError(err error) error {
 		return fiber.NewError(fiber.StatusNotFound, "session not found")
 	}
 	return err
-}
-
-// writeComment writes an SSE comment line — ignored by EventSource — as a heartbeat that
-// keeps the connection producing bytes through long, silent stages. A write error (client
-// gone) is swallowed: the turn learns a connection is dead from writeEvent, not from here.
-func writeComment(w *bufio.Writer, text string) {
-	if _, err := fmt.Fprintf(w, ": %s\n\n", text); err != nil {
-		return
-	}
-	_ = w.Flush()
-}
-
-// writeEvent writes one named SSE event, reporting whether the write reached the
-// client. Unlike writeComment it does not swallow the failure: a dead connection is
-// how a streamed turn learns to stop.
-func writeEvent(w *bufio.Writer, event string, data any) bool {
-	blob, err := json.Marshal(data)
-	if err != nil {
-		return true // an unencodable frame is our bug, not a dead client
-	}
-	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, blob); err != nil {
-		return false
-	}
-	return w.Flush() == nil
 }

--- a/internal/handler/match_analysis_stream.go
+++ b/internal/handler/match_analysis_stream.go
@@ -78,10 +78,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 		Blockers:            blockers,
 	}
 
-	c.Set(fiber.HeaderContentType, "text/event-stream")
-	c.Set(fiber.HeaderCacheControl, "no-cache")
-	c.Set(fiber.HeaderConnection, "keep-alive")
-	c.Set("X-Accel-Buffering", "no") // stop nginx buffering so events reach the browser promptly
+	sseHeaders(c)
 
 	// The server's 10s WriteTimeout would kill this long-lived stream mid-analysis, so the
 	// SSE response sets its own, per-write deadline instead (see sseStream). Captured here
@@ -121,29 +118,13 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 		// mid-analysis — the client sees a bare "Connection lost". A periodic SSE comment
 		// keeps bytes flowing so the stream survives silent stages. The ticker goroutine
 		// and the stage callback both write, which sseStream serializes.
-		stopHeartbeat := make(chan struct{})
-		var heartbeat sync.WaitGroup
-		heartbeat.Add(1)
-		go func() {
-			defer heartbeat.Done()
-			t := time.NewTicker(15 * time.Second)
-			defer t.Stop()
-			for {
-				select {
-				case <-stopHeartbeat:
-					return
-				case <-t.C:
-					stream.comment("keepalive")
-				}
-			}
-		}()
+		stopHeartbeat := stream.keepalive(sseKeepalive)
 
 		analysis, err := analyzer.AnalyzeStream(ctx, input, func(e matchanalysis.Event) {
 			events++
 			stream.event(string(e.Kind), e)
 		})
-		close(stopHeartbeat)
-		heartbeat.Wait()
+		stopHeartbeat()
 		if err != nil {
 			log.Printf("matchanalysis: stream FAILED user=%d job=%d dur=%s events=%d: %v", userID, job.ID, time.Since(start).Round(time.Millisecond), events, err)
 			reportStreamFault(hub, err)
@@ -214,32 +195,81 @@ func newSSEStream(w *bufio.Writer, conn net.Conn, timeout time.Duration) *sseStr
 	return &sseStream{w: w, conn: conn, timeout: timeout}
 }
 
-// event writes one named SSE event with a JSON data payload and flushes it.
-func (s *sseStream) event(name string, data any) {
+// event writes one named SSE event with a JSON data payload and flushes it, reporting
+// whether it reached the client. A marshal failure reports TRUE: an unencodable frame is
+// our bug, not a dead reader, and a caller that stops the work on false must not stop it
+// over our own encoding mistake.
+func (s *sseStream) event(name string, data any) bool {
 	blob, err := json.Marshal(data)
 	if err != nil {
-		return
+		return true
 	}
-	s.write(fmt.Sprintf("event: %s\ndata: %s\n\n", name, blob))
+	return s.write(fmt.Sprintf("event: %s\ndata: %s\n\n", name, blob))
 }
 
 // comment writes an SSE comment line — ignored by EventSource — as a heartbeat that keeps
-// the connection producing bytes through long, silent stages.
+// the connection producing bytes through long, silent stages. A failure is nothing to act
+// on: the next event will report it.
 func (s *sseStream) comment(text string) {
-	s.write(fmt.Sprintf(": %s\n\n", text))
+	_ = s.write(fmt.Sprintf(": %s\n\n", text))
 }
 
-// write emits one frame under the lock, with a fresh deadline. A write error (the reader
-// is gone) is swallowed — the stream is best-effort — but the deadline is what guarantees
-// the call RETURNS, so a reader that stopped reading cannot pin this goroutine.
-func (s *sseStream) write(frame string) {
+// sseKeepalive is how often a silent stream emits a comment. Both SSE endpoints go quiet
+// for the same reason — a model thinking — and would be severed by the same thing: nginx's
+// proxy_read_timeout, which shows the client a bare "connection lost" mid-answer. One
+// number because it answers one constraint.
+const sseKeepalive = 15 * time.Second
+
+// keepalive starts the heartbeat and returns the function that stops it. Stopping BLOCKS
+// until the goroutine has finished, so no comment can be written after the caller believes
+// the stream is done — both endpoints hand-rolled this ticker plus a WaitGroup, and getting
+// the ordering wrong writes into a closed body.
+//
+// The interval is an argument rather than the constant so that property can be tested at a
+// millisecond instead of the fifteen seconds production waits.
+func (s *sseStream) keepalive(every time.Duration) (stop func()) {
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		t := time.NewTicker(every)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+				s.comment("keepalive")
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		wg.Wait()
+	}
+}
+
+// write emits one frame under the lock, with a fresh deadline, and reports whether it
+// reached the client. The deadline is what guarantees the call RETURNS, so a reader that
+// stopped reading cannot pin this goroutine.
+func (s *sseStream) write(frame string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.conn != nil {
 		_ = s.conn.SetWriteDeadline(time.Now().Add(s.timeout))
 	}
 	if _, err := s.w.WriteString(frame); err != nil {
-		return
+		return false
 	}
-	_ = s.w.Flush()
+	return s.w.Flush() == nil
+}
+
+// sseHeaders sets the response headers every SSE endpoint needs, so a new one cannot ship
+// with three of the four.
+func sseHeaders(c *fiber.Ctx) {
+	c.Set(fiber.HeaderContentType, "text/event-stream")
+	c.Set(fiber.HeaderCacheControl, "no-cache")
+	c.Set(fiber.HeaderConnection, "keep-alive")
+	c.Set("X-Accel-Buffering", "no") // stop nginx buffering so events reach the browser promptly
 }

--- a/internal/handler/match_analysis_stream_test.go
+++ b/internal/handler/match_analysis_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -140,4 +141,90 @@ func TestReportStreamFault_IgnoresClientDisconnect(t *testing.T) {
 // the SSE goroutine, where a panic would take the whole stream down.
 func TestReportStreamFault_NilHubIsNoop(t *testing.T) {
 	reportStreamFault(nil, errString("llm chain exploded"))
+}
+
+// failingWriter fails every write, standing in for a reader that went away.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("connection reset") }
+
+// countingWriter records what was written and how many times, safely enough to be read
+// from the test goroutine while the heartbeat writes from its own.
+type countingWriter struct {
+	mu     sync.Mutex
+	writes int
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writes++
+	return len(p), nil
+}
+
+func (c *countingWriter) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writes
+}
+
+// A caller cancels its work when event reports false, so the two failure modes must not be
+// spelled the same. A dead reader is a reason to stop; an unencodable frame is our own bug
+// and stopping the turn over it would abort a live client's work for our mistake.
+func TestSSEStream_EventDistinguishesADeadReaderFromOurOwnBug(t *testing.T) {
+	var sb strings.Builder
+	live := newSSEStream(bufio.NewWriter(&sb), nil, time.Second)
+
+	if !live.event("token", map[string]string{"text": "hi"}) {
+		t.Error("event over a live writer reported the client gone")
+	}
+	if got := sb.String(); !strings.Contains(got, "event: token") || !strings.Contains(got, `"text":"hi"`) {
+		t.Errorf("frame = %q, want an SSE event carrying the payload", got)
+	}
+
+	// A channel cannot be marshalled. The frame never goes out, and the caller must not
+	// read that as a disconnect.
+	if !live.event("token", make(chan int)) {
+		t.Error("an unencodable payload reported the client gone; the caller would cancel a live turn")
+	}
+
+	dead := newSSEStream(bufio.NewWriter(failingWriter{}), nil, time.Second)
+	if dead.event("token", map[string]string{"text": "hi"}) {
+		t.Error("event over a failing writer reported success; the turn would run on for nobody")
+	}
+}
+
+// The stop returned by keepalive must not return until the goroutine has finished, or a
+// comment can land in a body the caller believes is closed. Both endpoints hand-rolled this
+// ticker-plus-WaitGroup pairing before it moved onto the type.
+func TestSSEStream_KeepaliveStopsSynchronously(t *testing.T) {
+	var w countingWriter
+	stream := newSSEStream(bufio.NewWriter(&w), nil, time.Second)
+
+	stop := stream.keepalive(time.Millisecond)
+	// Let it beat a few times so the goroutine is genuinely in flight, not merely started.
+	deadline := time.Now().Add(2 * time.Second)
+	for w.count() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if w.count() == 0 {
+		t.Fatal("the heartbeat never wrote")
+	}
+	stop()
+
+	settled := w.count()
+	time.Sleep(20 * time.Millisecond) // ~20 ticks' worth, had it survived stop
+	if got := w.count(); got != settled {
+		t.Errorf("the heartbeat wrote %d more times after stop returned", got-settled)
+	}
+}
+
+// comment swallows its failure: the heartbeat has nobody to report to, and the next event
+// is what tells the caller the reader is gone.
+func TestSSEStream_CommentIsBestEffort(t *testing.T) {
+	stream := newSSEStream(bufio.NewWriter(failingWriter{}), nil, time.Second)
+	stream.comment("keepalive") // must not panic
+	if stream.event("token", "x") {
+		t.Error("event over the same failing writer reported success")
+	}
 }

--- a/openspec/changes/one-sse-stream-writer/.openspec.yaml
+++ b/openspec/changes/one-sse-stream-writer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/one-sse-stream-writer/proposal.md
+++ b/openspec/changes/one-sse-stream-writer/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Both long-lived SSE endpoints — the assistant turn and the fit analysis — had to solve the same
+four problems, and solved them twice:
+
+- fasthttp's `WriteTimeout` racing the stream writer, so a deadline set once up front loses about
+  half the time and kills the stream at exactly ten seconds, mid-answer;
+- a *cleared* deadline being forever, so a reader that stopped reading pins the goroutine for the
+  life of the process;
+- `bufio.Writer` not being safe against the keepalive ticker;
+- the request-scoped Sentry hub dying before the writer runs.
+
+One of them solved it with a small type (`sseStream`). The other copied the reasoning into an
+inline closure, a bare `var mu sync.Mutex`, a hand-rolled ticker goroutine, and two package-level
+free functions. This is one subtle concurrency/deadline protocol, not two vendor-shaped
+implementations — the next fix to the deadline race has to be made twice, and nothing says so.
+
+The split had already started to drift: the assistant reaches into the other file's
+`sseWriteTimeout` while re-implementing the type that owns it; one endpoint names its keepalive
+interval and the other writes a bare `15 * time.Second`; and `handler/AGENTS.md` still contrasts
+`writeEvent` with `writeSSE`, a function that no longer exists.
+
+## What Changes
+
+- `sseStream.event` gains a bool result — did the frame reach the client — with a marshal failure
+  reporting **true**, because an unencodable frame is our bug and must not cancel a live turn.
+- The keepalive goroutine both endpoints hand-rolled moves onto the type as
+  `keepalive(every) (stop func())`, where `stop` blocks until the goroutine has finished. Getting
+  that ordering wrong writes into a closed body.
+- `streamTurn` is rewritten over `newSSEStream`. `writeEvent`, `writeComment`, the inline write
+  closure, the bare mutex and the ticker goroutine are deleted.
+- `sseHeaders(c)` holds the four headers both endpoints set identically, so a new SSE endpoint
+  cannot ship with three of the four.
+- `assistantKeepalive` and the bare `15 * time.Second` become one `sseKeepalive`.
+- The Sentry hub clone stays inline in both, where its comment lives.
+
+No behaviour change: same frames, same deadlines, same cancellation.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. `tasks.md` is the real artifact; the change
+archives with `--skip-specs`.
+
+## Impact
+
+- `internal/handler/match_analysis_stream.go` — the type grows `keepalive`, `sseHeaders` and the
+  bool result.
+- `internal/handler/assistant.go` — ~50 lines of stream machinery become ~20; three imports go.
+- `internal/handler/AGENTS.md` — the passage naming a function that no longer exists.

--- a/openspec/changes/one-sse-stream-writer/tasks.md
+++ b/openspec/changes/one-sse-stream-writer/tasks.md
@@ -1,0 +1,28 @@
+## 1. Let the type answer the question the callers ask
+
+- [x] 1.1 `event`/`write` return whether the frame reached the client; a marshal failure reports
+      true, so a caller that cancels on false cannot be made to cancel by our own bug.
+- [x] 1.2 Move the keepalive onto the type. `stop` must block until the goroutine has finished —
+      the property worth pinning, since both endpoints hand-rolled the ticker/WaitGroup pairing.
+- [x] 1.3 Take the interval as an argument rather than reading the constant: not for symmetry,
+      but because the synchronous-stop property is otherwise untestable at 15 seconds.
+
+## 2. Collapse the second implementation
+
+- [x] 2.1 Rewrite `streamTurn` over `newSSEStream`; delete `writeEvent`, `writeComment`, the
+      inline write closure, the bare mutex and the ticker goroutine.
+- [x] 2.2 `sseHeaders(c)` for the four identical header lines.
+- [x] 2.3 Fold `assistantKeepalive` and the bare `15 * time.Second` into one `sseKeepalive`.
+- [x] 2.4 Leave the Sentry hub clone inline in both — its comment explains a request-scoped
+      lifetime that is per-endpoint, not shared machinery.
+
+## 3. Verify and close
+
+- [x] 3.1 Tests for the two properties a reader cannot check by eye: `event` telling a dead
+      reader apart from an unencodable frame, and `stop` returning only after the last beat.
+      Placed beside the existing `TestSSEStream_*` rather than in a second file.
+- [x] 3.2 `go build ./... && go vet ./... && go test ./...` green, plus `-race` over the SSE and
+      assistant tests — the change moves a mutex, so the race detector is the relevant check.
+- [x] 3.3 Fix `handler/AGENTS.md`, which contrasted `writeEvent` with a `writeSSE` that no longer
+      exists, and state which endpoint ignores the disconnect signal and why.
+- [x] 3.4 Mark S13 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
S13 from the 2026-08-01 architecture review.

Both long-lived SSE endpoints — the assistant turn and the fit analysis — had to solve the same
four problems:

- fasthttp's `WriteTimeout` racing the stream writer, so a deadline set once up front loses about
  half the time and kills the stream at exactly ten seconds, mid-answer;
- a *cleared* deadline being forever, so a reader that stopped reading pins the goroutine for the
  life of the process;
- `bufio.Writer` not being safe against the keepalive ticker;
- the request-scoped Sentry hub dying before the writer runs.

One solved it with a small type (`sseStream`). The other copied the reasoning into an inline
closure, a bare `var mu sync.Mutex`, a hand-rolled ticker goroutine, and two package-level free
functions. That is **one** subtle concurrency/deadline protocol, not two implementations — the
next fix to the deadline race had to be made twice, and nothing said so.

It had already begun to drift: the assistant reached into the other file's `sseWriteTimeout`
while re-implementing the type that owns it, and one endpoint named its keepalive interval where
the other wrote a bare `15 * time.Second`.

## What moved onto the type

**`event` now answers the question its callers ask** — did the frame reach the client — and a
marshal failure answers **true**. An unencodable frame is our bug, not a dead reader, and the
assistant cancels the turn on false: it must not be made to abandon a live client's work over our
own encoding mistake.

**The keepalive**, whose `stop` blocks until the goroutine has finished. Both endpoints
hand-rolled the ticker plus a `WaitGroup`, and getting that ordering wrong writes into a closed
body. The interval is an argument rather than the shared constant for one reason: otherwise that
property can only be tested by waiting the fifteen seconds production waits.

**`sseHeaders(c)`** for the four headers both set identically, so a new SSE endpoint cannot ship
with three of the four.

`streamTurn` is rewritten over `newSSEStream`; `writeEvent`, `writeComment`, the write closure,
the bare mutex and the ticker goroutine are deleted — ~50 lines become ~20. The Sentry hub clone
stays inline in both, where its comment explains a request-scoped lifetime that is per-endpoint
rather than shared machinery.

## Tests

Two properties a reader cannot check by eye, placed beside the existing `TestSSEStream_*` rather
than in a second file:

- `event` tells a dead reader apart from an unencodable frame;
- `stop` returns only after the last beat — asserted by counting writes after it returns.

`-race` over the SSE and assistant tests, three runs: the change moves a mutex, so that is the
relevant check.

## Docs

`handler/AGENTS.md` contrasted `writeEvent` with a `writeSSE` that no longer exists. It now
describes the shared type and records which endpoint ignores the disconnect signal and why — the
fit run was paid for with an AI credit, so it finishes into the cache rather than aborting.

No behaviour change: same frames, same deadlines, same cancellation.
`go build ./... && go vet ./... && go test ./...` green.
