### PR TITLE
The row→fingerprint mapping lives beside the hash it feeds

### DIFF
--- a/cmd/backfill-descriptions/main.go
+++ b/cmd/backfill-descriptions/main.go
@@ -152,7 +152,7 @@ func backfillAll(ctx context.Context, store jobStore, source string, pause time.
 			if desc == j.Description {
 				continue // clean row, or a marker that turned out to be real prose
 			}
-			hash := jobhash.Of(hashParams(j, desc))
+			hash := jobhash.OfRow(j, desc)
 			if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
 				ID:          j.ID,
 				Description: desc,
@@ -242,31 +242,4 @@ func pageJobs(ctx context.Context, store jobStore, source string, afterID int64)
 		AfterID:   afterID,
 		BatchSize: backfillBatchSize,
 	})
-}
-
-// hashParams builds the content_hash inputs for a row with a replaced description — the exact
-// indexed fields jobhash.Of fingerprints (see internal/jobhash), so the recomputed hash matches
-// what the ingest write path would produce for the same row.
-func hashParams(j db.Job, description string) db.UpsertJobParams {
-	return db.UpsertJobParams{
-		URL:                j.URL,
-		Title:              j.Title,
-		Company:            j.Company,
-		CompanySlug:        j.CompanySlug,
-		Location:           j.Location,
-		Remote:             j.Remote,
-		Description:        description,
-		PostedAt:           j.PostedAt,
-		PublicSlug:         j.PublicSlug,
-		Countries:          j.Countries,
-		Regions:            j.Regions,
-		WorkMode:           j.WorkMode,
-		Skills:             j.Skills,
-		Seniority:          j.Seniority,
-		Category:           j.Category,
-		PostingLanguage:    j.PostingLanguage,
-		EmploymentType:     j.EmploymentType,
-		EducationLevel:     j.EducationLevel,
-		ExperienceYearsMin: j.ExperienceYearsMin,
-	}
 }

--- a/cmd/backfill-descriptions/main_test.go
+++ b/cmd/backfill-descriptions/main_test.go
@@ -87,7 +87,7 @@ func TestBackfillDecodesOnlyEncodedDescriptions(t *testing.T) {
 	}
 	// content_hash must fingerprint the row with the decoded description, matching what a
 	// re-ingest of the fixed adapter would produce.
-	want1 := jobhash.Of(hashParams(store.jobs[0], u1.Description))
+	want1 := jobhash.OfRow(store.jobs[0], u1.Description)
 	if !u1.ContentHash.Valid || u1.ContentHash.String != want1 {
 		t.Errorf("job 1 ContentHash = %+v, want %q", u1.ContentHash, want1)
 	}
@@ -155,7 +155,7 @@ func TestBackfillDecodesEntityEncodedDescriptions(t *testing.T) {
 	if strings.Contains(u.Description, "&lt;") {
 		t.Errorf("job 1 still entity-encoded: %q", u.Description)
 	}
-	want := jobhash.Of(hashParams(store.jobs[0], u.Description))
+	want := jobhash.OfRow(store.jobs[0], u.Description)
 	if !u.ContentHash.Valid || u.ContentHash.String != want {
 		t.Errorf("job 1 ContentHash = %+v, want %q", u.ContentHash, want)
 	}
@@ -199,7 +199,7 @@ func TestBackfillStripsHimalayasSelfPromo(t *testing.T) {
 		t.Errorf("greenhouse Description = %q, want %q", got[2].Description, want)
 	}
 	// The row re-indexes only if content_hash moves with the text.
-	want := jobhash.Of(hashParams(store.jobs[0], got[1].Description))
+	want := jobhash.OfRow(store.jobs[0], got[1].Description)
 	if !got[1].ContentHash.Valid || got[1].ContentHash.String != want {
 		t.Errorf("ContentHash = %+v, want %q", got[1].ContentHash, want)
 	}

--- a/cmd/backfill-justjoin/main.go
+++ b/cmd/backfill-justjoin/main.go
@@ -93,7 +93,7 @@ func backfillAll(ctx context.Context, store jobStore, fetch descriptionFetcher) 
 			if desc == j.Description {
 				continue // already current — idempotent skip
 			}
-			hash := jobhash.Of(hashParams(j, desc))
+			hash := jobhash.OfRow(j, desc)
 			if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
 				ID:          j.ID,
 				Description: desc,
@@ -109,31 +109,4 @@ func backfillAll(ctx context.Context, store jobStore, fetch descriptionFetcher) 
 		}
 	}
 	return scanned, updated, failed, nil
-}
-
-// hashParams builds the content_hash inputs for a row with a replaced description — the exact
-// indexed fields jobhash.Of fingerprints (see internal/jobhash), so the recomputed hash matches
-// what the ingest write path would produce for the same row.
-func hashParams(j db.Job, description string) db.UpsertJobParams {
-	return db.UpsertJobParams{
-		URL:                j.URL,
-		Title:              j.Title,
-		Company:            j.Company,
-		CompanySlug:        j.CompanySlug,
-		Location:           j.Location,
-		Remote:             j.Remote,
-		Description:        description,
-		PostedAt:           j.PostedAt,
-		PublicSlug:         j.PublicSlug,
-		Countries:          j.Countries,
-		Regions:            j.Regions,
-		WorkMode:           j.WorkMode,
-		Skills:             j.Skills,
-		Seniority:          j.Seniority,
-		Category:           j.Category,
-		PostingLanguage:    j.PostingLanguage,
-		EmploymentType:     j.EmploymentType,
-		EducationLevel:     j.EducationLevel,
-		ExperienceYearsMin: j.ExperienceYearsMin,
-	}
 }

--- a/cmd/backfill-justjoin/main_test.go
+++ b/cmd/backfill-justjoin/main_test.go
@@ -61,7 +61,7 @@ func TestBackfillUpdatesOnlyChangedDescriptions(t *testing.T) {
 	}
 	// The content_hash must be the fingerprint of the row's indexed fields WITH the new
 	// description, so the row re-indexes (and is stable on a re-run).
-	want := jobhash.Of(hashParams(store.jobs[0], "New body A"))
+	want := jobhash.OfRow(store.jobs[0], "New body A")
 	if !u.ContentHash.Valid || u.ContentHash.String != want {
 		t.Errorf("ContentHash = %+v, want %q", u.ContentHash, want)
 	}

--- a/internal/jobhash/jobhash.go
+++ b/internal/jobhash/jobhash.go
@@ -52,6 +52,40 @@ func Of(p db.UpsertJobParams) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// OfRow fingerprints a STORED row rather than a write's params — what a backfill has, since
+// it is rewriting rows the ingest path already wrote. The description is separate because a
+// backfill's whole job is to replace it, and jobs.description is the column being changed.
+//
+// It lives here, beside Of, because the two are one decision split in half: Of names the fields
+// that make up the fingerprint, and this names where each comes from on a row. Kept apart, a
+// field added to Of leaves the mapping behind, and a backfill then rewrites rows carrying a hash
+// the ingest path will not reproduce — so the next crawl of each reports `changed` once for
+// nothing. That is not hypothetical: this mapping existed twice, byte-identical, in two backfill
+// commands. TestOfRow_CarriesEveryFieldTheHashReads is what now fails instead.
+func OfRow(j db.Job, description string) string {
+	return Of(db.UpsertJobParams{
+		URL:                j.URL,
+		Title:              j.Title,
+		Company:            j.Company,
+		CompanySlug:        j.CompanySlug,
+		Location:           j.Location,
+		Remote:             j.Remote,
+		Description:        description,
+		PostedAt:           j.PostedAt,
+		PublicSlug:         j.PublicSlug,
+		Countries:          j.Countries,
+		Regions:            j.Regions,
+		WorkMode:           j.WorkMode,
+		Skills:             j.Skills,
+		Seniority:          j.Seniority,
+		Category:           j.Category,
+		PostingLanguage:    j.PostingLanguage,
+		EmploymentType:     j.EmploymentType,
+		EducationLevel:     j.EducationLevel,
+		ExperienceYearsMin: j.ExperienceYearsMin,
+	})
+}
+
 // timestamp renders an optional timestamp deterministically; an unset value is the
 // empty string, distinct from any real instant.
 func timestamp(t pgtype.Timestamptz) string {

--- a/internal/jobhash/jobhash_test.go
+++ b/internal/jobhash/jobhash_test.go
@@ -114,3 +114,82 @@ func TestOf_FieldsAreDelimited(t *testing.T) {
 		t.Error("field boundary not delimited: content shifted across fields collides")
 	}
 }
+
+// fullRow is a db.Job with every hashed field set to something distinctive, so a mapping that
+// drops a field is visible as a hash that does not move when that field does.
+func fullRow() db.Job {
+	return db.Job{
+		URL:                "https://example.com/j/1",
+		Title:              "Backend Engineer",
+		Company:            "Acme",
+		CompanySlug:        "acme",
+		Location:           "Berlin",
+		Remote:             true,
+		Description:        "the stored description",
+		PostedAt:           pgtype.Timestamptz{Time: time.Unix(1700000000, 0).UTC(), Valid: true},
+		PublicSlug:         "backend-engineer-acme-abc123",
+		Countries:          []string{"de"},
+		Regions:            []string{"eu"},
+		WorkMode:           "remote",
+		Skills:             []string{"go"},
+		Seniority:          "senior",
+		Category:           "backend",
+		PostingLanguage:    "en",
+		EmploymentType:     "full_time",
+		EducationLevel:     "bachelor",
+		ExperienceYearsMin: pgtype.Int4{Int32: 5, Valid: true},
+	}
+}
+
+// TestOfRow_CarriesEveryFieldTheHashReads is the guard the duplication used to need a reviewer
+// for. Of names the fields the fingerprint covers; OfRow names where each comes from on a stored
+// row. They are one decision in two halves, so a field added to Of and forgotten in OfRow leaves
+// a backfill computing the OLD fingerprint — the rewritten rows then carry a hash the ingest path
+// will not reproduce, and the next crawl of each reports `changed` once for nothing.
+//
+// Each case mutates ONE field of a fully-populated row. If OfRow does not carry that field, the
+// hash cannot move, and the case fails naming the field.
+func TestOfRow_CarriesEveryFieldTheHashReads(t *testing.T) {
+	base := OfRow(fullRow(), "the stored description")
+
+	mutations := map[string]func(*db.Job){
+		"url":                  func(j *db.Job) { j.URL = "https://example.com/j/2" },
+		"title":                func(j *db.Job) { j.Title = "Frontend Engineer" },
+		"company":              func(j *db.Job) { j.Company = "Globex" },
+		"company_slug":         func(j *db.Job) { j.CompanySlug = "globex" },
+		"location":             func(j *db.Job) { j.Location = "Munich" },
+		"remote":               func(j *db.Job) { j.Remote = false },
+		"posted_at":            func(j *db.Job) { j.PostedAt = pgtype.Timestamptz{Time: time.Unix(1800000000, 0).UTC(), Valid: true} },
+		"public_slug":          func(j *db.Job) { j.PublicSlug = "backend-engineer-acme-zzz999" },
+		"countries":            func(j *db.Job) { j.Countries = []string{"fr"} },
+		"regions":              func(j *db.Job) { j.Regions = []string{"latam"} },
+		"work_mode":            func(j *db.Job) { j.WorkMode = "onsite" },
+		"skills":               func(j *db.Job) { j.Skills = []string{"rust"} },
+		"seniority":            func(j *db.Job) { j.Seniority = "junior" },
+		"category":             func(j *db.Job) { j.Category = "frontend" },
+		"posting_language":     func(j *db.Job) { j.PostingLanguage = "de" },
+		"employment_type":      func(j *db.Job) { j.EmploymentType = "contract" },
+		"education_level":      func(j *db.Job) { j.EducationLevel = "master" },
+		"experience_years_min": func(j *db.Job) { j.ExperienceYearsMin = pgtype.Int4{Int32: 9, Valid: true} },
+	}
+
+	for field, mutate := range mutations {
+		t.Run(field, func(t *testing.T) {
+			row := fullRow()
+			mutate(&row)
+			if OfRow(row, "the stored description") == base {
+				t.Errorf("changing %s left the fingerprint unchanged — OfRow does not carry it, "+
+					"so a backfill would rewrite rows with a hash ingest will not reproduce", field)
+			}
+		})
+	}
+
+	// The description is OfRow's separate argument, not read off the row, because replacing it
+	// is what a backfill is for.
+	if OfRow(fullRow(), "a different body") == base {
+		t.Error("changing the description left the fingerprint unchanged")
+	}
+	if OfRow(fullRow(), "the stored description") != base {
+		t.Error("OfRow is not deterministic for the same input")
+	}
+}

--- a/openspec/changes/jobhash-owns-the-row-mapping/.openspec.yaml
+++ b/openspec/changes/jobhash-owns-the-row-mapping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/jobhash-owns-the-row-mapping/proposal.md
+++ b/openspec/changes/jobhash-owns-the-row-mapping/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Two backfill commands carried a byte-identical `hashParams(j db.Job, description string)
+db.UpsertJobParams` — 19 fields listed by hand, with the same doc comment ("the exact indexed
+fields `jobhash.Of` fingerprints").
+
+The cost is not the duplication itself but what it makes cheap. `Of` names the fields the
+fingerprint covers; the mapping names where each comes from on a stored row. They are **one
+decision in two halves**, and the halves lived in three files. Add a field to `Of` and the copies
+keep computing the old fingerprint — so a backfill rewrites rows carrying a hash the ingest path
+will not reproduce, and the next crawl of each reports `changed` once for nothing.
+
+## What Changes
+
+- `jobhash.OfRow(j db.Job, description string) string` — the mapping moves beside the hash it
+  feeds, which is the only place a reader can see both halves at once. `jobhash` already imports
+  `db`, so this adds no dependency.
+- Both `hashParams` copies are deleted; the two call sites and four test call sites go through
+  `OfRow`.
+- **A test replaces the reviewer.** `TestOfRow_CarriesEveryFieldTheHashReads` mutates one field
+  of a fully-populated row at a time and asserts the fingerprint moves. A field the mapping drops
+  cannot move it, so the case fails naming that field. Verified by removing `Seniority` from the
+  mapping: the test fails with `changing seniority left the fingerprint unchanged`.
+- Deliberately NOT routed through `job.FromRow → Fields → UpsertParams`: `FromRow` decodes the
+  enrichment JSONB and returns a per-row error, which is real work and a new failure path inside
+  two throwaway backfill loops.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. The fingerprint is byte-identical before and
+after; `tasks.md` is the real artifact and the change archives with `--skip-specs`.
+
+## Impact
+
+- `internal/jobhash/jobhash.go` (+ its test), `cmd/backfill-descriptions`, `cmd/backfill-justjoin`.
+- **Left alone, on purpose:** `Of` omits `Cities`, `EnglishLevel` and `IsTech`, which the search
+  document does carry. That is a real gap the finding surfaced as evidence, but closing it changes
+  every stored hash — every job would report `changed` once on its next crawl and force a full
+  re-push. That is an operational decision with a cost, not a cleanup to fold into a refactor.

--- a/openspec/changes/jobhash-owns-the-row-mapping/tasks.md
+++ b/openspec/changes/jobhash-owns-the-row-mapping/tasks.md
@@ -1,0 +1,23 @@
+## 1. Move the mapping to the hash
+
+- [x] 1.1 Confirm the two copies are still byte-identical before deleting either.
+- [x] 1.2 Add `jobhash.OfRow(j db.Job, description string) string`, with the doc comment saying
+      WHY it lives beside `Of` — the two are one decision split in half.
+- [x] 1.3 Delete both `hashParams` copies; point the two call sites and the four test call sites
+      at `OfRow`.
+
+## 2. Replace the reviewer with a test
+
+- [x] 2.1 `TestOfRow_CarriesEveryFieldTheHashReads`: mutate one hashed field at a time on a
+      fully-populated row and assert the fingerprint moves. A dropped field cannot move it.
+- [x] 2.2 Prove the guard fires rather than assuming: remove `Seniority` from the mapping and
+      confirm the test fails naming that field.
+
+## 3. Verify and close
+
+- [x] 3.1 `go test ./...` AND `go test -tags=integration ./...` — CI runs both, and the second is
+      the one that caught the last refactor's bug.
+- [x] 3.2 Confirm no `hashParams` remains anywhere.
+- [x] 3.3 Record what was deliberately left: `Of` under-covers the search document by three
+      fields, and closing that gap invalidates every stored hash.
+- [x] 3.4 Mark S14 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
S14 from the 2026-08-01 architecture review.

Two backfill commands carried a **byte-identical** `hashParams(j db.Job, description string)
db.UpsertJobParams` — 19 fields listed by hand, with the same doc comment.

The cost is not the duplication. `jobhash.Of` names the fields the fingerprint covers; the mapping
names where each comes from on a stored row. Those are **one decision in two halves**, and the
halves lived in three files. Add a field to `Of` and the copies keep computing the old
fingerprint — a backfill then rewrites rows carrying a hash the ingest path will not reproduce, so
the next crawl of each reports `changed` once for nothing.

## The fix

`jobhash.OfRow(j, description)` — the mapping beside the hash it feeds, which is the only place a
reader sees both halves at once. `jobhash` already imports `db`, so no new dependency. Both copies
deleted; two call sites and four test call sites go through it.

The description stays a separate argument rather than being read off the row, because replacing
it is what a backfill is *for*.

## A test replaces the reviewer

`TestOfRow_CarriesEveryFieldTheHashReads` mutates one hashed field at a time on a fully-populated
row and asserts the fingerprint moves. A field the mapping drops cannot move it, so the case fails
naming that field.

Proved it fires rather than assuming — removing `Seniority` from the mapping:

```
--- FAIL: TestOfRow_CarriesEveryFieldTheHashReads/seniority
    changing seniority left the fingerprint unchanged — OfRow does not carry it,
    so a backfill would rewrite rows with a hash ingest will not reproduce
```

## Two things deliberately not done

**Not routed through `job.FromRow → Fields → UpsertParams`.** `FromRow` decodes the enrichment
JSONB and returns a per-row error — real work and a new failure path inside two throwaway backfill
loops.

**`Of` still omits `Cities`, `EnglishLevel` and `IsTech`**, which the search document does carry.
The finding surfaced that as evidence of the drift, and it is real — but closing it invalidates
**every stored hash**: every job would report `changed` once on its next crawl and force a full
re-push. That is an operational decision with a cost, not a cleanup to fold into a refactor.
Recorded in the change so it is not lost.

The fingerprint is byte-identical before and after. `go test ./...` **and**
`go test -tags=integration ./...` green — CI runs both, and the second is the one that caught the
previous refactor's bug.
