### PR TITLE
docs: Product Hunt badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@
 
 <br>
 
+<!-- Product Hunt: launching 26 August 2026. The badge is Product Hunt's own embed,
+     one SVG per theme, picked by prefers-color-scheme the same way the logo above is.
+     Its own utm_campaign so this traffic is separable from the site footer's badge. -->
+<a href="https://www.producthunt.com/products/freehire?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-readme">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196233&amp;theme=dark">
+    <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1196233&amp;theme=light" alt="freehire — every IT job, straight from the source | Product Hunt" width="250" height="54">
+  </picture>
+</a>
+
+<br>
+
 <img src="docs/assets/freehire.gif" alt="freehire — faceted search narrowing 3.4M+ live postings by region, work format, specialization and seniority, each linking straight to the company's own careers page" width="860">
 
 </div>


### PR DESCRIPTION
The site footer has carried the Product Hunt badge since #1418; the README — the first thing anyone landing from GitHub sees — did not.

Uses Product Hunt's own embed, one SVG per theme behind a `<picture>`, matching how the logo directly above it already switches. Both variants were fetched and compared: they genuinely differ, so the element is doing work rather than decorating.

`utm_campaign=badge-readme` keeps this traffic separable from the footer badge's.

Note: for a product that has not launched yet, the `featured.svg` endpoint returns a **FIND US ON Product Hunt** badge rather than an award. That is the correct state until 26 August, and it starts rendering the launch result on its own — no follow-up edit needed.
