### PR TITLE
SQLSTATE classification has one home, and a test says so

### DIFF
--- a/internal/embed/runner.go
+++ b/internal/embed/runner.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/strelov1/freehire/internal/db"
-	"github.com/strelov1/freehire/internal/worker"
+	"github.com/strelov1/freehire/internal/pgerr"
 )
 
 // Claimed is one outbox entry leased to this run. Closed marks whether the job is now
@@ -179,7 +179,7 @@ func (rn *run) processOpenOne(ctx context.Context, entry Claimed) {
 	if err != nil {
 		// A corrupted row (XX001) can never load — dead-letter it immediately rather
 		// than burning the attempt budget across cron runs (mirrors enrich).
-		if worker.IsCorruptedRow(err) {
+		if pgerr.IsDataCorrupted(err) {
 			rn.failN(entry, fmt.Errorf("load job: %w", err), 1)
 			return
 		}

--- a/internal/enrich/runner.go
+++ b/internal/enrich/runner.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/strelov1/freehire/internal/worker"
+	"github.com/strelov1/freehire/internal/pgerr"
 )
 
 // Claimed is one outbox entry leased to this run.
@@ -120,7 +120,7 @@ func (rn *run) process(ctx context.Context, entry Claimed) {
 		// A corrupted row (XX001) is permanently unreadable — retrying across cron
 		// runs would only burn the attempt budget on a job that can never load, so
 		// dead-letter it immediately (maxAttempts=1) instead.
-		if worker.IsCorruptedRow(err) {
+		if pgerr.IsDataCorrupted(err) {
 			rn.failN(ctx, entry, fmt.Errorf("load job: %w", err), 1)
 			log.Printf("enrich: job=%d dead-lettered (corrupted row) in %s: %v", entry.JobID, time.Since(start).Round(time.Millisecond), err)
 			return

--- a/internal/pgerr/pgerr.go
+++ b/internal/pgerr/pgerr.go
@@ -14,6 +14,10 @@ import (
 const (
 	codeUniqueViolation     = "23505"
 	codeForeignKeyViolation = "23503"
+	// codeDataCorrupted is XX001 (data_corrupted): a row cannot be read because its
+	// on-disk storage is damaged — most visibly a "missing chunk number N for toast
+	// value ..." on a broken TOAST pointer.
+	codeDataCorrupted = "XX001"
 )
 
 // IsUniqueViolation reports whether err is (or wraps) a unique-constraint violation
@@ -28,4 +32,14 @@ func IsUniqueViolation(err error) bool {
 func IsForeignKeyViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == codeForeignKeyViolation
+}
+
+// IsDataCorrupted reports whether err is (or wraps) a Postgres data-corruption error
+// (SQLSTATE XX001). It is deliberately narrow: recognizing the condition is this package's
+// job, but deciding what to do about it is the caller's — internal/worker's resilient scan
+// is what chooses to skip such a row, and only XX001 opts a read into that path, so every
+// other failure still surfaces unchanged.
+func IsDataCorrupted(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == codeDataCorrupted
 }

--- a/internal/pgerr/pgerr_test.go
+++ b/internal/pgerr/pgerr_test.go
@@ -1,0 +1,96 @@
+package pgerr
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestClassifiersRecogniseTheirOwnSQLSTATEAndNothingElse(t *testing.T) {
+	tests := []struct {
+		name              string
+		err               error
+		unique, fk, corpt bool
+	}{
+		{name: "nil"},
+		{name: "plain error", err: errors.New("boom")},
+		{name: "unique violation", err: &pgconn.PgError{Code: "23505"}, unique: true},
+		{name: "foreign key violation", err: &pgconn.PgError{Code: "23503"}, fk: true},
+		{name: "data corrupted", err: &pgconn.PgError{Code: "XX001"}, corpt: true},
+		// Wrapping is the case that matters in practice: a repository returns
+		// fmt.Errorf("read batch: %w", err) and the caller still has to classify it.
+		{name: "wrapped data corrupted", err: fmt.Errorf("read batch: %w", &pgconn.PgError{Code: "XX001"}), corpt: true},
+		{name: "wrapped unique violation", err: fmt.Errorf("insert: %w", &pgconn.PgError{Code: "23505"}), unique: true},
+		{name: "an unrelated pg error is none of them", err: &pgconn.PgError{Code: "42703"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUniqueViolation(tt.err); got != tt.unique {
+				t.Errorf("IsUniqueViolation = %v, want %v", got, tt.unique)
+			}
+			if got := IsForeignKeyViolation(tt.err); got != tt.fk {
+				t.Errorf("IsForeignKeyViolation = %v, want %v", got, tt.fk)
+			}
+			if got := IsDataCorrupted(tt.err); got != tt.corpt {
+				t.Errorf("IsDataCorrupted = %v, want %v", got, tt.corpt)
+			}
+		})
+	}
+}
+
+// This package's doc calls it "the single home for the SQLSTATE constants". That claim was
+// false: internal/worker declared XX001 and repeated the errors.As unwrap, and the predicted
+// consequence had already happened — internal/enrich and internal/embed pulled in the whole
+// bootstrap dependency tree (config, database, observability) to classify one SQLSTATE.
+//
+// So the claim is a test now. A package that unwraps *pgconn.PgError is classifying, whatever
+// it calls the function; that is this package's job, and a second copy is how the taxonomy
+// splits again.
+func TestOnlyThisPackageUnwrapsAPgError(t *testing.T) {
+	const marker = "pgconn.PgError"
+
+	var scanned, offenders int
+	err := filepath.WalkDir(filepath.Join("..", ".."), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Vendored and generated trees are nobody's taxonomy to keep.
+			if name := d.Name(); name == "node_modules" || name == ".git" || name == "archive" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		scanned++
+		if !strings.Contains(string(body), marker) {
+			return nil
+		}
+		if strings.Contains(filepath.ToSlash(path), "internal/pgerr/") {
+			return nil
+		}
+		offenders++
+		t.Errorf("%s unwraps *pgconn.PgError; SQLSTATE classification belongs in internal/pgerr, "+
+			"whose doc claims to be its single home. Add a predicate there and call it.", path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if scanned < 100 {
+		t.Fatalf("only %d Go files scanned — the walk is not seeing the repo, so a second "+
+			"classifier would pass unnoticed", scanned)
+	}
+	_ = offenders
+}

--- a/internal/worker/resilient.go
+++ b/internal/worker/resilient.go
@@ -7,24 +7,11 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/pgerr"
 )
-
-// corruptDataSQLState is Postgres SQLSTATE XX001 (data_corrupted), raised when a
-// row cannot be read because its on-disk storage is damaged — most visibly a
-// "missing chunk number N for toast value ..." on a broken TOAST pointer.
-const corruptDataSQLState = "XX001"
-
-// IsCorruptedRow reports whether err is (or wraps) a Postgres data-corruption
-// error. It is deliberately narrow: only XX001 opts a read into the skip path, so
-// every other failure still surfaces to the caller unchanged.
-func IsCorruptedRow(err error) bool {
-	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == corruptDataSQLState
-}
 
 // PageReader is the narrow slice of DB access ResilientPage needs: a wide keyset
 // batch (the fast path), an id-only projection of the same window (the degrade
@@ -113,7 +100,7 @@ func ResilientPage(ctx context.Context, r PageReader, afterID int64, batchSize i
 		}
 		return rows, rows[len(rows)-1].ID, nil, nil
 	}
-	if !IsCorruptedRow(err) {
+	if !pgerr.IsDataCorrupted(err) {
 		return nil, 0, nil, err
 	}
 
@@ -129,7 +116,7 @@ func ResilientPage(ctx context.Context, r PageReader, afterID int64, batchSize i
 	for _, id := range ids {
 		job, rowErr := r.Row(ctx, id)
 		if rowErr != nil {
-			if IsCorruptedRow(rowErr) {
+			if pgerr.IsDataCorrupted(rowErr) {
 				skipped = append(skipped, id)
 				log.Printf("resilient scan: skipping corrupted row id=%d: %v", id, rowErr)
 				continue

--- a/internal/worker/resilient_test.go
+++ b/internal/worker/resilient_test.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -43,7 +42,9 @@ func (f *fakeReader) Row(_ context.Context, id int64) (db.Job, error) {
 	return f.rowResults[id], nil
 }
 
-func corruptErr() error { return &pgconn.PgError{Code: corruptDataSQLState} }
+// corruptErr is the SQLSTATE the resilient scan degrades on. The classification itself is
+// pgerr's (and pgerr tests it); what these tests exercise is the POLICY built on it.
+func corruptErr() error { return &pgconn.PgError{Code: "XX001"} }
 
 func TestResilientPage_HealthyBatch(t *testing.T) {
 	r := &fakeReader{batchRows: []db.Job{{ID: 1}, {ID: 2}, {ID: 5}}}
@@ -140,26 +141,5 @@ func TestResilientPage_NonCorruptionRowErrorPropagates(t *testing.T) {
 	_, _, _, err := ResilientPage(context.Background(), r, 19, 2000)
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("expected sentinel propagated from per-row read, got %v", err)
-	}
-}
-
-func TestIsCorruptedRow(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"nil", nil, false},
-		{"plain error", errors.New("boom"), false},
-		{"data corruption XX001", &pgconn.PgError{Code: "XX001"}, true},
-		{"wrapped XX001", fmt.Errorf("read batch: %w", &pgconn.PgError{Code: "XX001"}), true},
-		{"other pg error", &pgconn.PgError{Code: "23505"}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsCorruptedRow(tt.err); got != tt.want {
-				t.Errorf("IsCorruptedRow(%v) = %v, want %v", tt.err, got, tt.want)
-			}
-		})
 	}
 }

--- a/openspec/changes/pgerr-owns-sqlstate-classification/.openspec.yaml
+++ b/openspec/changes/pgerr-owns-sqlstate-classification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/pgerr-owns-sqlstate-classification/proposal.md
+++ b/openspec/changes/pgerr-owns-sqlstate-classification/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+`internal/pgerr`'s package doc calls it "the single home for the SQLSTATE constants the
+repositories and the central error handler share". That was not true: `internal/worker` declared
+`XX001` itself and repeated the `errors.As(*pgconn.PgError)` unwrap, three lines below a doc that
+scopes `worker` to "shared bootstrap and run-outcome plumbing".
+
+The consequence the split predicts had already happened. `internal/enrich` and `internal/embed`
+imported `internal/worker` for **nothing but** `IsCorruptedRow` — so two domain packages
+transitively depended on config, database and observability in order to classify one SQLSTATE.
+
+## What Changes
+
+- `pgerr.IsDataCorrupted` joins `IsUniqueViolation` / `IsForeignKeyViolation`, with the `XX001`
+  constant. Recognizing the condition moves; **the policy stays in `worker`** — deciding that a
+  corrupted row is skipped rather than surfaced is the resilient scan's decision, not the
+  taxonomy's.
+- `worker.IsCorruptedRow` and `corruptDataSQLState` are deleted. `resilient.go` calls the shared
+  predicate at its two sites and stops importing `pgconn` entirely.
+- `internal/enrich` and `internal/embed` stop importing `internal/worker`.
+- **The doc's claim becomes a test.** `TestOnlyThisPackageUnwrapsAPgError` walks the repo and
+  fails on any non-test file outside `internal/pgerr` that mentions `pgconn.PgError` — a package
+  that unwraps one is classifying, whatever it names the function. It refuses to pass if the walk
+  scanned too few files, so a broken walk cannot read as a clean repo.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. The same errors are classified the same way;
+`tasks.md` is the real artifact and the change archives with `--skip-specs`.
+
+## Impact
+
+- `internal/pgerr` (+ a new test file), `internal/worker/resilient.go` and its test,
+  `internal/enrich/runner.go`, `internal/embed/runner.go`.
+- `internal/pipeline` keeps its `internal/worker` import — it uses `worker.Heartbeat`, shared
+  run-time plumbing rather than a leaked taxonomy, so the rule is about the classification and
+  not about the dependency in general.

--- a/openspec/changes/pgerr-owns-sqlstate-classification/tasks.md
+++ b/openspec/changes/pgerr-owns-sqlstate-classification/tasks.md
@@ -1,0 +1,23 @@
+## 1. Move the recognition, leave the policy
+
+- [x] 1.1 Add `pgerr.IsDataCorrupted` with the `XX001` constant, next to the other two, and say
+      in its doc that acting on the condition is the caller's decision.
+- [x] 1.2 Delete `worker.IsCorruptedRow` and `corruptDataSQLState`; call the shared predicate at
+      `resilient.go`'s two sites and drop the now-unneeded `pgconn` import.
+- [x] 1.3 Point `internal/enrich` and `internal/embed` at `pgerr` and confirm neither imports
+      `internal/worker` any more.
+
+## 2. Make the claim checkable
+
+- [x] 2.1 Move the classification test out of `worker` into `pgerr`, covering all three codes and
+      the wrapped case that matters in practice.
+- [x] 2.2 `TestOnlyThisPackageUnwrapsAPgError`: no non-test file outside `internal/pgerr` may
+      mention `pgconn.PgError`. Guard against a vacuous pass by requiring the walk to have
+      scanned a plausible number of files.
+- [x] 2.3 Prove the rule fires rather than assuming: add a throwaway unwrap to
+      `worker/resilient.go` and confirm the test names that file.
+
+## 3. Verify and close
+
+- [x] 3.1 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 3.2 Mark S15 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
S15 from the 2026-08-01 architecture review.

`internal/pgerr`'s package doc calls it *"the single home for the SQLSTATE constants the
repositories and the central error handler share"*. It was not. `internal/worker` declared `XX001`
itself and repeated the `errors.As(*pgconn.PgError)` unwrap — three lines below a doc scoping
`worker` to "shared bootstrap and run-outcome plumbing".

**The consequence the split predicts had already happened.** `internal/enrich` and
`internal/embed` imported `internal/worker` for *nothing but* `IsCorruptedRow`, so two domain
packages transitively depended on config, database and observability in order to classify one
SQLSTATE.

## Only the recognition moves

`pgerr.IsDataCorrupted` joins `IsUniqueViolation` / `IsForeignKeyViolation`. The **policy** stays
in `worker`: deciding that a corrupted row is skipped rather than surfaced is the resilient scan's
call, not the taxonomy's. `resilient.go` now imports no `pgconn` at all.

## The doc's claim is a test now

`TestOnlyThisPackageUnwrapsAPgError` walks the repo and fails on any non-test file outside
`internal/pgerr` that mentions `pgconn.PgError` — a package that unwraps one is classifying,
whatever it names the function. It refuses to pass if the walk scanned too few files, so a broken
walk cannot read as a clean repo.

Proved it fires rather than assuming — a throwaway unwrap added back to `resilient.go`:

```
--- FAIL: TestOnlyThisPackageUnwrapsAPgError
    ../../internal/worker/resilient.go unwraps *pgconn.PgError; SQLSTATE classification
    belongs in internal/pgerr, whose doc claims to be its single home.
```

## One thing the rule deliberately does not cover

`internal/pipeline` keeps its `internal/worker` import — it uses `worker.Heartbeat`, shared
run-time plumbing rather than a leaked taxonomy. The rule is about the classification, not about
the dependency in general, so it is written against `pgconn.PgError` and not against the import
graph.

No behaviour change: the same errors are classified the same way. `go test ./...` **and**
`go test -tags=integration ./...` green.
