### PR TITLE
The stage vocabulary owns how an application may move

### DIFF
--- a/internal/mailclassify/classification.go
+++ b/internal/mailclassify/classification.go
@@ -5,6 +5,8 @@
 // value" guard (and the prompt-injection guard for untrusted email bodies).
 package mailclassify
 
+import "github.com/strelov1/freehire/internal/userjob"
+
 // StatusSignal is the controlled vocabulary an email is classified into.
 type StatusSignal string
 
@@ -80,21 +82,6 @@ func (c Classification) Sanitize() Classification {
 	return c
 }
 
-// stageOrder is the forward pipeline rank of the active application stages a
-// classified email can advance to. Terminal outcomes (rejected/withdrawn) and
-// accepted are intentionally absent — they are never applied automatically.
-var stageOrder = map[string]int{
-	"applied": 1, "screening": 2, "responded": 3, "interview": 4, "offer": 5,
-}
-
-// terminalStages are the settled outcomes an automatic advance must never move a
-// job OUT of. They rank below `applied` in stageOrder (rank 0), so without this
-// guard any forward signal would "advance" a rejected/accepted/withdrawn job back
-// into the active pipeline — resurrecting a dead application.
-var terminalStages = map[string]bool{
-	"rejected": true, "accepted": true, "withdrawn": true,
-}
-
 // signalStage maps a status signal to the application stage it implies and
 // whether that stage may be applied automatically. Negative/terminal outcomes
 // (rejection) and non-progress signals (info_request, other) are never auto.
@@ -106,21 +93,21 @@ var signalStage = map[StatusSignal]string{
 	SignalOffer:               "offer",
 }
 
-// AdvanceStage returns the stage a signal should move `current` to and whether
-// an automatic change should occur. It advances only strictly forward in the
-// pipeline; a backward, terminal, or non-progress signal returns ("", false).
-// An empty `current` ranks below every stage, so a first classified email can
-// seed the stage.
+// AdvanceStage returns the stage a signal should move `current` to and whether an automatic
+// change should occur.
+//
+// The two halves belong to different packages and this is the seam. Which stage a SIGNAL implies
+// is mail's own question — it is about what an employer's email means. Whether an application may
+// MOVE from one stage to another is a tracking rule, and internal/userjob owns it along with the
+// vocabulary itself, so a stage added there cannot leave this package computing an order that no
+// longer matches.
 func AdvanceStage(current string, sig StatusSignal) (string, bool) {
-	if terminalStages[current] {
-		return "", false // a settled application is never resurrected automatically
-	}
 	target, ok := signalStage[sig]
 	if !ok {
 		return "", false
 	}
-	if stageOrder[target] > stageOrder[current] {
-		return target, true
+	if !userjob.Forward(current, target) {
+		return "", false
 	}
-	return "", false
+	return target, true
 }

--- a/internal/mailclassify/classification_test.go
+++ b/internal/mailclassify/classification_test.go
@@ -6,18 +6,21 @@ import (
 	"github.com/strelov1/freehire/internal/userjob"
 )
 
-// TestStageTargetsAreValidStages guards the coupling: every stage this package
-// maps a signal to must be a real user_jobs stage, so the vocabulary can't drift
-// out from under the tracking pipeline.
+// TestStageTargetsAreValidStages guards what remains of the coupling: every stage this package
+// maps a signal to must be a real user_jobs stage, so the mail vocabulary cannot drift out from
+// under the tracking pipeline.
+//
+// The other direction — every tracking stage is ranked or terminal — now lives in internal/userjob
+// with the rule itself, which is the point of the move. It used to be missing entirely, and that
+// gap is what let a stage inserted into Stages rank below `applied`.
 func TestStageTargetsAreValidStages(t *testing.T) {
 	for sig, stage := range signalStage {
 		if !userjob.ValidStage(stage) {
 			t.Errorf("signal %q maps to invalid stage %q", sig, stage)
 		}
-	}
-	for stage := range stageOrder {
-		if !userjob.ValidStage(stage) {
-			t.Errorf("stageOrder has invalid stage %q", stage)
+		if userjob.IsTerminal(stage) {
+			t.Errorf("signal %q maps to the terminal stage %q; deciding an application is settled "+
+				"is never an inference from mail", sig, stage)
 		}
 	}
 }

--- a/internal/userjob/pipeline.go
+++ b/internal/userjob/pipeline.go
@@ -1,0 +1,52 @@
+package userjob
+
+// activeRank is the forward position of each ACTIVE stage — how far along the pipeline an
+// application has got. It is deliberately NOT the index in Stages: accepted, rejected and
+// withdrawn sit after offer in the vocabulary but are outcomes, not positions. An application
+// does not pass THROUGH them, so they have no rank.
+//
+// This lives here rather than in the package that reads mail because "how an application may
+// move through its stages" is a tracking rule. It was in internal/mailclassify, which welded
+// the mail vocabulary to the application state machine and let a real drift through: a stage
+// inserted into Stages got rank 0, ranking BELOW applied and absent from the terminal set, so
+// any forward signal advanced the application backward out of it. TestEveryStageIsRankedOrTerminal
+// is what now fails instead.
+//
+// The keys are the same five that silenceThresholds keys on, which is not a coincidence: both
+// answer "is this application still in flight", and a test binds them.
+var activeRank = map[string]int{
+	"applied":   1,
+	"screening": 2,
+	"responded": 3,
+	"interview": 4,
+	"offer":     5,
+}
+
+// terminalStages are the settled outcomes. An automatic advance must never move an application
+// out of one — that would resurrect a dead application — and never into one either: deciding an
+// application is rejected, accepted or withdrawn is the candidate's call or an explicit action,
+// never an inference from a piece of mail.
+var terminalStages = map[string]bool{
+	"accepted":  true,
+	"rejected":  true,
+	"withdrawn": true,
+}
+
+// IsTerminal reports whether stage is a settled outcome.
+func IsTerminal(stage string) bool { return terminalStages[stage] }
+
+// Forward reports whether an application at `current` may be advanced to `target` automatically.
+//
+// Strictly forward, and only between active stages. An empty or unranked `current` ranks below
+// every stage, so a first classified email can seed the stage. A target that is not an active
+// stage — a terminal outcome, or anything unknown — is never an automatic advance.
+func Forward(current, target string) bool {
+	if IsTerminal(current) {
+		return false
+	}
+	next, ok := activeRank[target]
+	if !ok {
+		return false
+	}
+	return next > activeRank[current]
+}

--- a/internal/userjob/pipeline_test.go
+++ b/internal/userjob/pipeline_test.go
@@ -1,0 +1,99 @@
+package userjob
+
+import "testing"
+
+// TestEveryStageIsRankedOrTerminal is the direction the old cross-package test lacked. It checked
+// that every stage mailclassify named was a real stage; nothing checked the reverse, so a stage
+// added to Stages was silently unranked — rank 0, below `applied`, absent from the terminal set.
+// Any forward signal would then advance an application BACKWARD out of it.
+//
+// Exactly one of the two, never both and never neither: a stage is either a position an
+// application passes through or an outcome it ends at.
+func TestEveryStageIsRankedOrTerminal(t *testing.T) {
+	for _, stage := range Stages {
+		_, ranked := activeRank[stage]
+		isTerminal := terminalStages[stage]
+		switch {
+		case ranked && isTerminal:
+			t.Errorf("stage %q is both ranked and terminal — an application cannot both pass "+
+				"through it and end at it", stage)
+		case !ranked && !isTerminal:
+			t.Errorf("stage %q is neither ranked nor terminal. Add it to activeRank (a position "+
+				"the pipeline passes through) or to terminalStages (a settled outcome). Left out "+
+				"of both it ranks 0, below `applied`, so any forward signal advances an "+
+				"application backward out of it.", stage)
+		}
+	}
+
+	// And nothing ranked or terminal may be missing from the vocabulary itself.
+	for stage := range activeRank {
+		if !ValidStage(stage) {
+			t.Errorf("activeRank has %q, which is not in Stages", stage)
+		}
+	}
+	for stage := range terminalStages {
+		if !ValidStage(stage) {
+			t.Errorf("terminalStages has %q, which is not in Stages", stage)
+		}
+	}
+}
+
+// The silence thresholds answer the same question the ranks do — is this application still in
+// flight — so a stage that accrues silence is exactly a stage with a rank. Adding an active
+// stage without a threshold makes it tolerate silence forever; adding a threshold without a rank
+// makes it unreachable.
+func TestSilenceThresholdsCoverExactlyTheActiveStages(t *testing.T) {
+	for stage := range activeRank {
+		if _, ok := silenceThresholds[stage]; !ok {
+			t.Errorf("active stage %q has no silence threshold, so it never reports as silent", stage)
+		}
+	}
+	for stage := range silenceThresholds {
+		if _, ok := activeRank[stage]; !ok {
+			t.Errorf("silenceThresholds has %q, which is not an active stage", stage)
+		}
+	}
+}
+
+// Aggregate's stage→bucket mapping is a switch, so nothing can introspect it — but its shape is
+// still checkable. Exactly ONE stage is meant to fall to the default (`applied` → no_answer), so
+// a stage added to Stages and forgotten in the switch shows up as a second one landing there.
+func TestExactlyOneStageFallsToTheDefaultBucket(t *testing.T) {
+	var defaulted []string
+	for _, stage := range Stages {
+		p := Aggregate([]StageCount{{Stage: stage, Count: 1}})
+		if p.Buckets.NoAnswer == 1 {
+			defaulted = append(defaulted, stage)
+		}
+	}
+	if len(defaulted) != 1 || defaulted[0] != "applied" {
+		t.Errorf("stages landing in no_answer = %v, want exactly [applied]. A stage added to "+
+			"Stages without a case in Aggregate falls through the default and is counted as "+
+			"unanswered.", defaulted)
+	}
+}
+
+func TestForward(t *testing.T) {
+	tests := []struct {
+		name            string
+		current, target string
+		want            bool
+	}{
+		{"seeds from empty", "", "applied", true},
+		{"advances one step", "applied", "screening", true},
+		{"advances several steps", "applied", "offer", true},
+		{"refuses backward", "interview", "screening", false},
+		{"refuses sideways", "interview", "interview", false},
+		{"never resurrects a rejection", "rejected", "interview", false},
+		{"never resurrects an acceptance", "accepted", "offer", false},
+		{"never advances INTO a terminal outcome", "interview", "rejected", false},
+		{"refuses an unknown target", "applied", "definitely-not-a-stage", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Forward(tt.current, tt.target); got != tt.want {
+				t.Errorf("Forward(%q, %q) = %v, want %v", tt.current, tt.target, got, tt.want)
+			}
+		})
+	}
+}

--- a/openspec/changes/userjob-owns-the-pipeline-rule/.openspec.yaml
+++ b/openspec/changes/userjob-owns-the-pipeline-rule/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/userjob-owns-the-pipeline-rule/proposal.md
+++ b/openspec/changes/userjob-owns-the-pipeline-rule/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+"How an application may move through its stages" is a tracking-domain rule, and it was decided by
+the mail-classification package. `internal/mailclassify` held `stageOrder` — a second, independent
+encoding of the pipeline rank — and `terminalStages`, the settled-outcome set. So the mail
+vocabulary and the application state machine were welded together, and `internal/userjob`, which
+documents `Stages` as "the single source of truth", did not own the rule that gives those stages
+meaning.
+
+The one binding test between the packages ran in one direction only: every stage mailclassify
+names must be a real stage. Nothing checked the reverse, and that gap admits a real drift —
+insert `take_home` between `screening` and `interview` in `userjob.Stages` and it gets rank 0,
+which ranks **below `applied`** and is not terminal, so any forward signal advances the
+application **backward out of it**. `silence.go` and `buckets.go` go stale the same way; both
+hand-list the same five active stages.
+
+## What Changes
+
+- `userjob.IsTerminal` and `userjob.Forward(current, target)` own rank and terminality, beside
+  `Stages` and `silenceThresholds` which key on the same five active stages.
+- `mailclassify.AdvanceStage` becomes signal→stage plus `userjob.Forward`. `signalStage` stays —
+  what an employer's email *means* is genuinely mail's question. `stageOrder` and mailclassify's
+  `terminalStages` are deleted.
+- Rank stays an explicit table rather than the index in `Stages`: `accepted`/`rejected`/
+  `withdrawn` sit after `offer` in the vocabulary but are outcomes, not positions.
+- **Three guards, each verified to fire** by inserting the exact stage the finding names:
+  - every stage in `Stages` is ranked **or** terminal, never both and never neither;
+  - `silenceThresholds` covers exactly the active stages;
+  - exactly one stage falls to `Aggregate`'s default bucket (`applied` → `no_answer`), so a stage
+    added without a case shows up as a second one landing there.
+- The cross-package test keeps its direction and gains one assertion: no signal may map to a
+  terminal stage — deciding an application is settled is never an inference from mail.
+
+No behaviour change. Every branch was compared: the old code tested terminality before looking up
+the signal and the new one after, and both return `("", false)` either way.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. `tasks.md` is the real artifact; the change
+archives with `--skip-specs`.
+
+## Impact
+
+- `internal/userjob` — a new `pipeline.go` and its tests.
+- `internal/mailclassify/classification.go` and its test.
+- `internal/inbox` and `internal/maillink` are unaffected: both call `AdvanceStage`, whose
+  signature and answers are unchanged.

--- a/openspec/changes/userjob-owns-the-pipeline-rule/tasks.md
+++ b/openspec/changes/userjob-owns-the-pipeline-rule/tasks.md
@@ -1,0 +1,24 @@
+## 1. Move the rule to the vocabulary that owns it
+
+- [x] 1.1 `userjob.activeRank` + `terminalStages`, with the doc saying why rank is not the index
+      in `Stages` and why the keys match `silenceThresholds`.
+- [x] 1.2 `userjob.IsTerminal` and `userjob.Forward(current, target)`. `Forward` refuses a target
+      that is not an active stage, so advancing INTO a terminal outcome is impossible by
+      construction rather than by the accident of terminals ranking 0.
+- [x] 1.3 `mailclassify.AdvanceStage` becomes signal→stage plus `userjob.Forward`; delete
+      `stageOrder` and mailclassify's `terminalStages`. Compare every branch for behaviour.
+
+## 2. Close the direction the test never checked
+
+- [x] 2.1 Every stage in `Stages` is ranked or terminal — exactly one of the two.
+- [x] 2.2 `silenceThresholds` covers exactly the active stages, in both directions.
+- [x] 2.3 Exactly one stage falls to `Aggregate`'s default bucket — the switch cannot be
+      introspected, but its shape can.
+- [x] 2.4 Prove all three fire rather than assuming: insert `take_home` into `Stages` — the stage
+      the finding names — and confirm the failures name it.
+- [x] 2.5 The cross-package test gains: no signal maps to a terminal stage.
+
+## 3. Verify and close
+
+- [x] 3.1 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 3.2 Mark S16 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
S16 from the 2026-08-01 architecture review.

"How an application may move through its stages" is a tracking rule, and `internal/mailclassify`
was deciding it. It held `stageOrder` — a second, independent encoding of the pipeline rank — and
`terminalStages`, the settled-outcome set. So the mail vocabulary and the application state
machine were welded together, while `internal/userjob`, which documents `Stages` as *"the single
source of truth"*, did not own the rule that gives those stages meaning.

## The drift the one-directional test allowed

The only binding between the packages checked that every stage **mailclassify** names is a real
stage. Nothing checked the reverse. Insert `take_home` between `screening` and `interview` in
`userjob.Stages` and it gets rank 0 — **below `applied`**, and not terminal — so any forward
signal advances the application *backward out of it*. `silence.go` and `buckets.go` go stale the
same way; both hand-list the same five active stages.

## What moved, and what deliberately did not

`userjob.IsTerminal` and `userjob.Forward(current, target)` own rank and terminality now, beside
`Stages` and `silenceThresholds` — which key on the same five active stages, and a test now says
so.

`signalStage` **stays** in `mailclassify`: what an employer's email *means* is genuinely mail's
question. `AdvanceStage` is signal→stage plus `userjob.Forward`.

Rank stays an explicit table rather than the index in `Stages`, because `accepted`/`rejected`/
`withdrawn` sit after `offer` in the vocabulary but are outcomes, not positions — an application
does not pass *through* them. And `Forward` refuses a target that is not an active stage, so
advancing INTO a terminal outcome is impossible by construction rather than by the accident of
terminals ranking 0.

## Three guards, each proved to fire

Verified by actually inserting `take_home` — the stage the finding names — rather than assuming:

```
--- FAIL: TestEveryStageIsRankedOrTerminal
    stage "take_home" is neither ranked nor terminal. Add it to activeRank (a position the
    pipeline passes through) or to terminalStages (a settled outcome). Left out of both it
    ranks 0, below `applied`, so any forward signal advances an application backward out of it.

--- FAIL: TestExactlyOneStageFallsToTheDefaultBucket
    stages landing in no_answer = [applied take_home], want exactly [applied].
```

`Aggregate`'s stage→bucket mapping is a `switch`, so nothing can introspect it — but its *shape*
is still checkable: exactly one stage is meant to fall through to the default.

The cross-package test keeps its direction and gains one assertion: no signal may map to a
terminal stage, because deciding an application is settled is never an inference from mail.

## Behaviour

None. Every branch was compared: the old code tested terminality *before* looking up the signal
and the new one *after*, and both return `("", false)` either way. `internal/inbox` and
`internal/maillink` are untouched — `AdvanceStage`'s signature and answers are unchanged.

`go test ./...` **and** `go test -tags=integration ./...` green.
