### PR TITLE
One definition of which board a URL addresses

### DIFF
--- a/internal/atsboard/board.go
+++ b/internal/atsboard/board.go
@@ -52,6 +52,10 @@ const (
 	modeSubdomainChain = "subdomainchain"
 	modeHost           = "host"
 	modeHostPath       = "hostpath"
+	// pathnumeric: like path, but the segment must be an all-digit id. PageUp's board is a
+	// numeric institution id, so its localisation and section segments (/cw/en/search) are not
+	// boards — reading one as a board names an institution that does not exist.
+	modePathNumeric = "pathnumeric"
 )
 
 // atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
@@ -72,7 +76,7 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"jobs.jobvite.com", "jobvite", modePath},
 	{"jobs.quickin.io", "quickin", modePath},
 	{"jobs.talenthr.io", "talenthr", modePath},
-	{"careers.pageuppeople.com", "pageup", modePath},
+	{"careers.pageuppeople.com", "pageup", modePathNumeric},
 	{"oportunidades.mindsight.com.br", "mindsight", modePath},
 	{"careers.hireology.com", "hireology", modePath},
 	{"recruiting.ultipro.com", "ukg", modePath},
@@ -154,6 +158,14 @@ var apiBoards = []struct{ host, source, prefix string }{
 // SmartRecruiters got pathportal for. Greenhouse's embed URLs carry no board in the path at all
 // (the slug is in the `for=` query param, which atsdetect reads), so every one of their path
 // words is machinery.
+// noBoardFirstSegments lists, per matched host entry, leading path segments that mean the URL
+// carries NO board at all — unlike reservedSegments, which are skipped to reach the board behind
+// them. Workable's "/j/<id>" is a per-job shortlink: skipping "j" would take the JOB id as the
+// company slug, which is worse than declining.
+var noBoardFirstSegments = map[string][]string{
+	"apply.workable.com": {"j"},
+}
+
 var reservedSegments = map[string][]string{
 	"jobs.jobvite.com": {"careers"},
 	"greenhouse.io":    {"embed", "job_app", "job_board", "js"},
@@ -201,8 +213,12 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		// a 404 landing) has no derivable site and is left unrecognized rather than taken as a false
 		// "en-US" board. Canonical strips to scheme://host/site.
 		site := firstSegmentAfterLocale(u)
-		if site == "" {
-			return "", "", "", false // bare host or locale-only, no site
+		// A Workday per-job URL can reach us with no site at all (host/job/... or
+		// host/details/...), and those segments are the POSTING, never a career site. Taking one
+		// as the site yields "<host>/job" — a board that does not exist but looks new, so the
+		// contribution flow records and pays for it.
+		if site == "" || site == "job" || site == "details" {
+			return "", "", "", false // bare host, locale-only, or a per-job path with no site
 		}
 		u.RawQuery, u.Fragment = "", ""
 		u.Path = "/" + site
@@ -233,9 +249,16 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		return src, board, u.String(), true
 	}
 
-	// modePath: the board is the first path segment that isn't platform machinery.
+	// modePath / modePathNumeric: the board is the first path segment that isn't platform
+	// machinery — declined outright when the path leads with a segment that carries no board.
+	if leadsWithNoBoard(u, noBoardFirstSegments[apex]) {
+		return "", "", "", false
+	}
 	board = firstTenantSegment(u, reservedSegments[apex])
 	if board == "" {
+		return "", "", "", false
+	}
+	if mode == modePathNumeric && !allDigits(board) {
 		return "", "", "", false
 	}
 	u.RawQuery = ""
@@ -298,10 +321,16 @@ func subdomainChain(host, apex string) string {
 
 // subdomainLabel returns the leftmost DNS label of host under apex:
 // "acme.recruitee.com","recruitee.com" → "acme"; "recruitee.com",… → "" (no tenant).
+//
+// A remainder with more than one label yields NO board, deliberately. These adapters crawl
+// "<board>.<apex>", so a regional or nested host like "uk-ext.eu.csod.com" has no such form —
+// taking "uk-ext" names a host that does not exist. That is the expensive direction: the
+// contribution flow pays for a board it believes is new. Where a platform genuinely nests a
+// tenant under an instance, the entry uses subdomainchain and keeps every label.
 func subdomainLabel(host, apex string) string {
 	sub := subdomainChain(host, apex)
-	if i := strings.IndexByte(sub, '.'); i >= 0 {
-		return sub[:i]
+	if strings.Contains(sub, ".") {
+		return ""
 	}
 	return sub
 }
@@ -344,7 +373,11 @@ func segmentBeforePosting(u *url.URL, isPosting *regexp.Regexp) string {
 // localeSegment matches an xx-XX language-COUNTRY locale (e.g. en-GB) — the optional leading
 // path segment Rippling's public board site inserts before the tenant. Tenant slugs are
 // lowercase (satomic, 360-fire-flood), so the uppercase country code never collides.
-var localeSegment = regexp.MustCompile(`^[a-z]{2}-[A-Z]{2}$`)
+// The country half is matched case-insensitively: the canonical spelling is xx-XX, but the
+// lowercase form appears in real Workday links, and reading "en-us" as a career site produces
+// the board "<host>/en-us" — a board that does not exist, which the contribution flow would
+// record as new and pay for.
+var localeSegment = regexp.MustCompile(`^[a-z]{2}-[A-Za-z]{2}$`)
 
 // firstSegmentAfterLocale returns the first path segment that isn't a leading xx-XX locale — the
 // tenant board in ats.rippling.com/<locale?>/<board>/… (Rippling) or the site in a Workday
@@ -383,4 +416,31 @@ func firstTenantSegment(u *url.URL, reserved []string) string {
 		}
 	}
 	return ""
+}
+
+// leadsWithNoBoard reports whether u's first path segment marks a URL shape that carries no
+// board (see noBoardFirstSegments).
+func leadsWithNoBoard(u *url.URL, none []string) bool {
+	if len(none) == 0 {
+		return false
+	}
+	p := strings.Trim(u.Path, "/")
+	if p == "" {
+		return false
+	}
+	first, _, _ := strings.Cut(p, "/")
+	return slices.Contains(none, first)
+}
+
+// allDigits reports whether s is non-empty and only ASCII digits.
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/atsboard/board_test.go
+++ b/internal/atsboard/board_test.go
@@ -100,6 +100,26 @@ func TestRecognize(t *testing.T) {
 		{"workday bare host no site", "https://generalmotors.wd5.myworkdayjobs.com", "", "", "", false},
 		// a URL carrying only a locale has no derivable site — unrecognized, not a false "en-US" board
 		{"workday locale only no site", "https://salesforce.wd12.myworkdayjobs.com/en-US", "", "", "", false},
+		// Both halves of these were wrong before atsdetect.FromURL was folded into this table:
+		// the lowercase locale read as a career site, and a per-job path with no site read as
+		// the site "job". Each produced a board that does not exist — which the contribution
+		// flow records as new and pays for, the exact failure this package's doc warns about.
+		{"workday lowercase locale is still a locale", "https://trumpf.wd3.myworkdayjobs.com/en-us/trumpf_students/job/apodaca/ar_r1", "workday", "trumpf.wd3.myworkdayjobs.com/trumpf_students", "https://trumpf.wd3.myworkdayjobs.com/trumpf_students", true},
+		{"workday mixed-case locale is still a locale", "https://wmg.wd1.myworkdayjobs.com/de-De/wmgglobal/job/berlin/artist_jr1", "workday", "wmg.wd1.myworkdayjobs.com/wmgglobal", "https://wmg.wd1.myworkdayjobs.com/wmgglobal", true},
+		{"workday per-job path with no site", "https://acme.wd1.myworkdayjobs.com/job/Berlin/Engineer_R-1", "", "", "", false},
+		{"workday details path with no site", "https://acme.wd1.myworkdayjobs.com/details/Engineer_R-1", "", "", "", false},
+		{"workday locale then per-job with no site", "https://acme.wd1.myworkdayjobs.com/en-US/job/Berlin/Engineer_R-1", "", "", "", false},
+
+		// Three hosts this table matched but had no test for, each of which named a board that
+		// does not exist. atsdetect.FromURL already declined all three; folding it in surfaced
+		// them. A false board is the expensive direction — the contribution flow records it as
+		// new and pays for it.
+		{"workable per-job shortlink carries no board", "https://apply.workable.com/j/EF5014296F/apply", "", "", "", false},
+		{"workable company board still resolves", "https://apply.workable.com/acme/j/EF5014296F/", "workable", "acme", "https://apply.workable.com/acme/j/EF5014296F", true},
+		{"pageup non-numeric segment is not an institution", "https://careers.pageuppeople.com/cw/en/search", "", "", "", false},
+		{"pageup numeric institution id", "https://careers.pageuppeople.com/513/en/job/12345", "pageup", "513", "https://careers.pageuppeople.com/513/en/job/12345", true},
+		{"cornerstone regional host has no single-label tenant", "https://uk-ext.eu.csod.com/ux/ats/careersite/1/home", "", "", "", false},
+		{"cornerstone plain tenant still resolves", "https://acme.csod.com/ux/ats/careersite/4/home", "cornerstone", "acme", "https://acme.csod.com", true},
 		{"ashby bare host no board", "https://jobs.ashbyhq.com", "", "", "", false},
 		{"recruitee bare apex no tenant", "https://recruitee.com/", "", "", "", false},
 		{"personio bare apex no tenant", "https://jobs.personio.com", "", "", "", false},

--- a/internal/atsdetect/fromurl.go
+++ b/internal/atsdetect/fromurl.go
@@ -2,13 +2,10 @@ package atsdetect
 
 import (
 	"net/url"
-	"regexp"
 	"strings"
-)
 
-// localeSegment matches a Workday URL's optional locale path segment (e.g. "en-us",
-// "de-DE"), which sits before the career-site segment and is not part of the board id.
-var localeSegment = regexp.MustCompile(`^[a-z]{2}-[A-Za-z]{2}$`)
+	"github.com/strelov1/freehire/internal/atsboard"
+)
 
 // FromURL classifies a single outbound job-application URL into the (provider, board)
 // pair one of our source adapters can crawl, returning ok=false when the URL is not a
@@ -16,7 +13,25 @@ var localeSegment = regexp.MustCompile(`^[a-z]{2}-[A-Za-z]{2}$`)
 // (e.g. an ADP vanity path, a Join job link, or a Workable per-job shortlink). Unlike
 // Detect, which scans arbitrary HTML, this parses one known URL — the shape an
 // aggregator's apply link gives us directly.
+//
+// The shared table answers first. internal/atsboard is the ONE definition of "which board
+// does this URL address", read by the contribution flow, link resolution and boardresolve;
+// this package used to carry its own copy of eleven of those hosts, and the two had already
+// drifted in both directions — atsdetect read a SmartRecruiters portal segment as the board,
+// while atsboard read a lowercase Workday locale and a per-job "/job" path as career sites.
+// Delegating also means an ATS added to atsboard is immediately visible to the harvest tools,
+// which was the standing cost of the split.
+//
+// What stays here are the five shapes atsboard deliberately EXCLUDES. That exclusion is not an
+// oversight to correct: atsboard is the accept-set for internal/contribution, which PAYS for
+// onboarded boards, so widening it is a money-affecting decision that needs its own proposal.
+// These five are harvest-only, and the harvest path validates every candidate against the
+// platform's API before committing it.
 func FromURL(rawurl string) (provider, board string, ok bool) {
+	if src, brd, _, found := atsboard.Recognize(rawurl); found {
+		return src, brd, true
+	}
+
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return "", "", false
@@ -28,43 +43,6 @@ func FromURL(rawurl string) (provider, board string, ok bool) {
 	segs := pathSegments(u.Path)
 
 	switch {
-	case strings.HasSuffix(host, ".myworkdayjobs.com"):
-		if site := workdaySite(segs); site != "" {
-			return "workday", host + "/" + site, true
-		}
-	case host == "jobs.smartrecruiters.com":
-		if len(segs) >= 1 {
-			return "smartrecruiters", segs[0], true
-		}
-	case host == "job-boards.greenhouse.io", host == "boards.greenhouse.io",
-		host == "job-boards.eu.greenhouse.io", host == "boards.eu.greenhouse.io":
-		if len(segs) >= 1 && !reserved[segs[0]] {
-			return "greenhouse", segs[0], true
-		}
-	case host == "jobs.lever.co":
-		if len(segs) >= 1 {
-			return "lever", segs[0], true
-		}
-	case host == "jobs.ashbyhq.com":
-		if len(segs) >= 1 {
-			return "ashby", segs[0], true
-		}
-	case strings.HasSuffix(host, ".applytojob.com"):
-		if sub := subdomain(host, ".applytojob.com"); sub != "" {
-			return "jazzhr", sub, true
-		}
-	case strings.HasSuffix(host, ".recruitee.com"):
-		if sub := subdomain(host, ".recruitee.com"); sub != "" {
-			return "recruitee", sub, true
-		}
-	case strings.HasSuffix(host, ".pinpointhq.com"):
-		if sub := subdomain(host, ".pinpointhq.com"); sub != "" {
-			return "pinpoint", sub, true
-		}
-	case strings.HasSuffix(host, ".careerplug.com"):
-		if sub := subdomain(host, ".careerplug.com"); sub != "" {
-			return "careerplug", sub, true
-		}
 	case strings.HasSuffix(host, ".icims.com"):
 		// Our icims adapter builds the host "careers-<board>.icims.com", so only a
 		// careers-prefixed subdomain yields a crawlable board.
@@ -83,16 +61,6 @@ func FromURL(rawurl string) (provider, board string, ok bool) {
 		if section := segAfter(segs, "careersection"); section != "" {
 			return "taleo", host + "/" + section, true
 		}
-	case strings.HasSuffix(host, ".csod.com"):
-		// board is the tenant subdomain; a multi-label prefix is not a crawlable board.
-		if sub := subdomain(host, ".csod.com"); sub != "" {
-			return "cornerstone", sub, true
-		}
-	case host == "careers.pageuppeople.com":
-		// board is the numeric institution id, the first path segment on the canonical host.
-		if len(segs) >= 1 && isAllDigits(segs[0]) {
-			return "pageup", segs[0], true
-		}
 	case host == "www.governmentjobs.com", host == "www.schooljobs.com":
 		// board is "<domain>/<agency>"; the two domains are separate tenant spaces.
 		if agency := segAfter(segs, "careers"); agency != "" {
@@ -107,19 +75,6 @@ func FromURL(rawurl string) (provider, board string, ok bool) {
 	return "", "", false
 }
 
-// isAllDigits reports whether s is non-empty and only ASCII digits (a numeric board id).
-func isAllDigits(s string) bool {
-	if s == "" {
-		return false
-	}
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
-}
-
 // pathSegments splits a URL path into its non-empty segments.
 func pathSegments(p string) []string {
 	var out []string
@@ -129,27 +84,6 @@ func pathSegments(p string) []string {
 		}
 	}
 	return out
-}
-
-// workdaySite returns the career-site segment from a Workday URL's path, skipping the
-// optional leading locale segment. It returns "" when no site precedes the per-job
-// "/job" (or "/details") segment.
-func workdaySite(segs []string) string {
-	if len(segs) == 0 {
-		return ""
-	}
-	i := 0
-	if localeSegment.MatchString(segs[0]) {
-		i = 1
-	}
-	if i >= len(segs) {
-		return ""
-	}
-	site := segs[i]
-	if site == "job" || site == "details" {
-		return ""
-	}
-	return site
 }
 
 // subdomain returns the leftmost label of host once suffix is removed, or "" when the

--- a/internal/atsdetect/fromurl_test.go
+++ b/internal/atsdetect/fromurl_test.go
@@ -1,6 +1,10 @@
 package atsdetect
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/atsboard"
+)
 
 func TestFromURL(t *testing.T) {
 	cases := []struct {
@@ -187,6 +191,41 @@ func TestFromURL(t *testing.T) {
 			}
 			if ok && (p != tc.provider || b != tc.board) {
 				t.Errorf("got (%q, %q), want (%q, %q)", p, b, tc.provider, tc.board)
+			}
+		})
+	}
+}
+
+// TestLocalShapesStayOutsideTheSharedTable guards the split that remains.
+//
+// FromURL delegates to atsboard.Recognize and keeps only the five shapes atsboard deliberately
+// excludes. That exclusion is load-bearing, not an oversight: atsboard is the accept-set for
+// internal/contribution, which PAYS for onboarded boards, so moving one of these in is a
+// money-affecting decision that needs its own proposal — not a tidy-up.
+//
+// So the two sets must stay disjoint in both directions. If a shape here starts being recognised
+// by the shared table, this package's case for it is dead code silently shadowed by the
+// delegation above it; and the widening happened without anyone arguing for it.
+func TestLocalShapesStayOutsideTheSharedTable(t *testing.T) {
+	local := map[string]string{
+		"icims":  "https://careers-acme.icims.com/jobs/1234/engineer/job",
+		"oracle": "https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/1234",
+		"taleo":  "https://valero.taleo.net/careersection/2/jobsearch.ftl",
+		"neogov": "https://www.governmentjobs.com/careers/cityofboise/jobs/4567",
+		"paycom": "https://www.paycomonline.net/v4/ats/web.php/portal/0123456789abcdef0123456789abcdef/jobs",
+	}
+	for provider, rawurl := range local {
+		t.Run(provider, func(t *testing.T) {
+			if src, board, _, ok := atsboard.Recognize(rawurl); ok {
+				t.Errorf("atsboard now recognises the %s shape as (%q, %q). Either this package's "+
+					"case is dead code shadowed by the delegation, or the contribution accept-set "+
+					"widened without a proposal — decide which, do not just delete one.",
+					provider, src, board)
+			}
+			got, _, ok := FromURL(rawurl)
+			if !ok || got != provider {
+				t.Errorf("FromURL(%q) = (%q, ok=%v), want %q — this package still owns the shape",
+					rawurl, got, ok, provider)
 			}
 		})
 	}

--- a/openspec/changes/one-url-to-board-definition/.openspec.yaml
+++ b/openspec/changes/one-url-to-board-definition/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/one-url-to-board-definition/proposal.md
+++ b/openspec/changes/one-url-to-board-definition/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+`internal/atsboard` states a contract in its own package doc: *"One definition means a host added
+once is recognised by all three."* `internal/atsdetect.FromURL` was a second, independent table
+answering the same question — which board does this URL address — for ~16 providers, eleven of
+them already in `atsboard`.
+
+The finding framed `atsdetect` as the drifted copy. **The drift runs both ways, and the shared
+table is the one that costs money.** `atsboard` is the accept-set for `internal/contribution`,
+which pays for onboarded boards, and its own doc names the failure mode: a board recorded as new
+"is paid for". Comparing the two implementations on the same URLs found five divergences —
+**four of them `atsboard`'s**, none covered by a test:
+
+| URL shape | atsboard | atsdetect |
+|---|---|---|
+| `…/en-us/Careers/job/…` (lowercase locale) | board `…/en-us` ✗ | `…/Careers` ✓ |
+| `…/job/Berlin/Eng_R-1` (no career site) | board `…/job` ✗ | declined ✓ |
+| `…/details/Eng_R-1` | board `…/details` ✗ | declined ✓ |
+| `apply.workable.com/j/EF5014296F/apply` | board `j` ✗ | declined ✓ |
+| `careers.pageuppeople.com/cw/en/search` | board `cw` ✗ | declined ✓ |
+| `uk-ext.eu.csod.com/…` | board `uk-ext` ✗ | declined ✓ |
+| `jobs.smartrecruiters.com/Portal/Acme/…` | `Acme` ✓ | board `Portal` ✗ |
+
+Every ✗ on the `atsboard` side names a board that does not exist — precisely what the paying flow
+must not do.
+
+## What Changes
+
+- **`atsboard` gains the six narrowings `atsdetect` already knew**, each with the test it never
+  had: the locale match accepts a lowercase country; a Workday path leading with `job`/`details`
+  carries no site; a `noBoardFirstSegments` hook declines Workable's `/j/<id>` shortlink outright
+  (skipping `j` would take the JOB id as the board, which is worse); `modePathNumeric` requires
+  PageUp's numeric institution id; and `subdomainLabel` declines a multi-label remainder, because
+  those adapters crawl `<board>.<apex>` and `uk-ext.eu.csod.com` has no such form.
+- **`FromURL` delegates to `atsboard.Recognize`** and keeps only the five shapes `atsboard`
+  deliberately excludes (icims, oracle, taleo, neogov, paycom). Eleven overlapping cases and two
+  now-unused helpers are deleted.
+- **A test keeps the two sets disjoint.** If a local shape starts being recognised by the shared
+  table, either this package's case is dead code shadowed by the delegation, or the paying
+  accept-set widened without anyone arguing for it — and the failure says to decide which rather
+  than delete one.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) at the requirement level — no endpoint or contract changes. The behaviour that changes is
+six URL shapes that previously resolved to non-existent boards and now resolve to none.
+`tasks.md` is the real artifact; the change archives with `--skip-specs`.
+
+## Impact
+
+- `internal/atsboard` (+ tests), `internal/atsdetect` (+ tests).
+- Consumers of `atsboard.Recognize` — `internal/contribution`, link resolution, `boardresolve` —
+  stop being offered six shapes' worth of false boards. Nothing that previously resolved to a
+  REAL board changes.
+- `cmd/harvest-role`, the one production caller of `FromURL`, widens from ~16 providers to
+  `atsboard`'s ~46. That is the standing cost the split imposed, and it is safe: harvest writes
+  per-provider seed files that `cmd/harvest-boards` probes against each platform's API before
+  committing, and it is invoked per provider by hand.
+- **Deliberately NOT done:** moving the five local shapes into `atsboard`. Widening the accept-set
+  for a flow that pays is its own proposal.

--- a/openspec/changes/one-url-to-board-definition/tasks.md
+++ b/openspec/changes/one-url-to-board-definition/tasks.md
@@ -1,0 +1,34 @@
+## 1. Find out which side is actually right
+
+- [x] 1.1 Run both implementations over the same URLs rather than reading them, and record every
+      divergence with which side is correct.
+- [x] 1.2 Check whether any divergence is a deliberate, tested decision before treating it as a
+      gap — none of the six was covered by an `atsboard` test.
+
+## 2. Fix the shared table first
+
+- [x] 2.1 Locale match accepts a lowercase country half; a Workday path leading with
+      `job`/`details` carries no site.
+- [x] 2.2 `noBoardFirstSegments` declines Workable's `/j/<id>`. Not `reservedSegments`: skipping
+      `j` reaches the job id and takes it as the board, which is worse than declining.
+- [x] 2.3 `modePathNumeric` for PageUp's numeric institution id.
+- [x] 2.4 `subdomainLabel` declines a multi-label remainder; `subdomainchain` remains for the
+      platforms that genuinely nest a tenant under an instance.
+- [x] 2.5 A test for each — this table had none for workable, pageup or cornerstone at all.
+
+## 3. Then delegate
+
+- [x] 3.1 `FromURL` calls `atsboard.Recognize` first; delete the eleven overlapping cases and the
+      helpers only they used.
+- [x] 3.2 Keep the five shapes `atsboard` excludes, with the reason (the accept-set pays) written
+      in both packages.
+- [x] 3.3 The existing 30-URL `TestFromURL` corpus is the pin: it must pass unchanged, and it is
+      what caught all three remaining divergences.
+- [x] 3.4 A test that the two sets stay disjoint in both directions.
+
+## 4. Verify and close
+
+- [x] 4.1 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 4.2 Note that the finding's `boardresolve` evidence has gone stale — the inline
+      `matched && b != "embed"` is gone; that path already goes through `Recognize`.
+- [x] 4.3 Mark S17 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
S17 from the 2026-08-01 architecture review — the one L-effort finding, and the one where the
review's framing turned out to be backwards.

`internal/atsboard` states its contract: *"One definition means a host added once is recognised by
all three."* `atsdetect.FromURL` was a second, independent table answering the same question for
~16 providers, eleven of them already in `atsboard`.

## The drift runs both ways, and the shared table is the expensive side

The finding treats `atsdetect` as the drifted copy. I ran both over the same URLs instead of
reading them, and **four of the five divergences were `atsboard`'s** — none covered by a test:

| URL shape | atsboard | atsdetect |
|---|---|---|
| `…/en-us/Careers/job/…` lowercase locale | board `…/en-us` ✗ | `…/Careers` ✓ |
| `…/job/Berlin/Eng_R-1` (no career site) | board `…/job` ✗ | declined ✓ |
| `…/details/Eng_R-1` | board `…/details` ✗ | declined ✓ |
| `apply.workable.com/j/EF5014296F/apply` | board `j` ✗ | declined ✓ |
| `careers.pageuppeople.com/cw/en/search` | board `cw` ✗ | declined ✓ |
| `uk-ext.eu.csod.com/…` | board `uk-ext` ✗ | declined ✓ |
| `jobs.smartrecruiters.com/Portal/Acme/…` | `Acme` ✓ | board `Portal` ✗ |

Every ✗ on the `atsboard` side names **a board that does not exist**. That matters because
`atsboard` is the accept-set for `internal/contribution`, which **pays** for onboarded boards —
and its own package doc names exactly this failure: a board we already crawl under one name
"looks brand new under another, is recorded as a fresh contribution, and is paid for".

## So the shared table is fixed first

- the locale match accepts a lowercase country half;
- a Workday path leading with `job`/`details` carries no site;
- a new `noBoardFirstSegments` hook declines Workable's `/j/<id>` outright — **not** the existing
  `reservedSegments`, because skipping `j` reaches the JOB id and takes *that* as the board, which
  is worse than declining;
- `modePathNumeric` requires PageUp's numeric institution id;
- `subdomainLabel` declines a multi-label remainder — those adapters crawl `<board>.<apex>`, and
  `uk-ext.eu.csod.com` has no such form. `subdomainchain` remains for platforms that genuinely
  nest a tenant under an instance.

Each with the test it never had. `atsboard` had **no** test for workable, pageup or cornerstone.

## Then FromURL delegates

Eleven overlapping cases and two now-unused helpers deleted. The five shapes `atsboard`
deliberately excludes (icims, oracle, taleo, neogov, paycom) stay local, with the reason written
in both packages: widening the accept-set for a flow that pays is its own proposal, not a
tidy-up.

**A test keeps the two sets disjoint in both directions.** If a local shape starts being
recognised by the shared table, either this package's case is dead code silently shadowed by the
delegation, or the paying accept-set widened without anyone arguing for it — the failure says to
decide which rather than delete one.

The existing 30-URL `TestFromURL` corpus is the pin, unchanged. It is what caught three of the
divergences, including the lowercase-locale one, which its own fixture already used.

## Blast radius

`cmd/harvest-role` — the one production caller of `FromURL` — widens from ~16 providers to
`atsboard`'s ~46, which is the standing cost the split imposed. Safe: harvest writes per-provider
seed files that `cmd/harvest-boards` probes against each platform's API before committing, and it
is invoked per provider by hand.

Nothing that previously resolved to a REAL board changes.

`go test ./...` **and** `go test -tags=integration ./...` green.

*(Aside: the finding's `boardresolve` evidence has gone stale — the inline `matched && b != "embed"`
is gone; that path already goes through `Recognize`.)*
