### PR TITLE
feat(web): a missing skill can be claimed into the profile where it is noticed

### DIFF
--- a/openspec/changes/claim-skill-from-job-match/.openspec.yaml
+++ b/openspec/changes/claim-skill-from-job-match/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/claim-skill-from-job-match/design.md
+++ b/openspec/changes/claim-skill-from-job-match/design.md
@@ -1,0 +1,130 @@
+## Context
+
+The sidebar match block (`web/src/lib/components/JobMatch.svelte`) renders the result of
+`GET /api/v1/jobs/:slug/match`, which the backend computes as a pure set operation:
+`jobmatch.Compute(job.skills, profile.skills)` plus the curated adjacency dictionary. Both sides
+speak the same canonical `skilltag` slugs, and the chips display those slugs verbatim.
+
+Three existing facts decide most of this design:
+
+- **The chip's text is already a valid profile skill.** No dictionary lookup, no free-text entry, no
+  new validation — the token under the cursor is exactly what the profile stores.
+- **`PUT /api/v1/me/profile` replaces the whole row** (`specializations`, `skills`,
+  `excluded_skills`, `location_preferences`) and normalises what it is given: lowercase, trim,
+  deduplicate. So "add one skill" is really "save the profile again with one more element", which is
+  idempotent but not concurrency-safe from the client's side.
+- **The design system has no popover primitive** (`dialog`, `tooltip`, `chip`, and eleven others —
+  no floating layer). `ReminderChip.svelte` already solves the same shape by expanding an inline row
+  under the chip instead.
+
+No backend work is required. The next `Compute` call reclassifies the claimed skill on its own.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Claim a Missing or Close skill into the profile without leaving the job page.
+- Feedback is immediate: the chip moves and the percentage changes before the network settles.
+- The block never ends up disagreeing with the server about the match.
+- Two fast claims both survive.
+
+**Non-Goals:**
+
+- Writing to the CV, the structured résumé, or the experience bank. A profile skill is a filtering
+  and matching token, not a claim about employment history — the experience bank's provenance rule
+  exists precisely to keep those separate, and nothing here needs it.
+- Removing a held skill from the block (You have chips stay inert). Un-claiming lives on
+  `/my/profile`, and undo covers the misclick this feature introduces.
+- The same affordance on job cards (`JobRow`) or the drawer's teaser. Those chips are a seeded
+  teaser, not a match.
+- A reusable popover primitive in the design system. One inline disclosure does not establish the
+  need for one.
+
+## Decisions
+
+### An inline disclosure row, not a floating popover
+
+Pressing a Missing or Close chip expands a single row directly beneath that chip group:
+
+```
+● Missing
+[bash] [chatgpt] [confluence] [entra-id] …
+┌────────────────────────────────────────┐
+│ Do you have entra-id?  [Add to profile]│
+└────────────────────────────────────────┘
+```
+
+Only one row is open at a time and it names the skill in its own text, so the association with the
+pressed chip survives without anchoring; the pressed chip additionally carries a selected ring and
+`aria-expanded`.
+
+*Alternative considered:* a floating popover anchored to the chip. It would need a portal, collision
+handling against a ~285px sidebar column, outside-click and focus management — a new primitive built
+for one call site, against the "note the seam, don't build the infrastructure" rule. The inline row
+is what `ReminderChip` already does and what a narrow column can actually fit.
+
+### The optimistic view is a pure overlay in `jobMatch.ts`
+
+`claimSkill(match, skill)` returns a new `JobMatch` with the skill moved out of `missing`/`adjacent`
+into `matched`, with `exact_count`, `adjacent_count` and `coverage_percent` recomputed by the
+server's own formula — `round((exact + 0.5 × adjacent) / total × 100)`. It is pure and lives beside
+`matchBarSegments` and `computeClientMatch`, so it is unit-testable under vitest with no DOM, which
+is how the rest of this block's logic is already tested.
+
+The component holds `optimistic: JobMatch | null` and renders `optimistic ?? match`. Rolling back a
+failed write is dropping the overlay, not undoing an edit.
+
+*Alternative considered:* re-render only after the refetch. It costs two sequential round-trips
+(`PUT`, then `GET`) of dead time on the one interaction whose entire appeal is that it is instant.
+
+### Reconcile against the server after the write lands
+
+The overlay is a strict under-estimate: the client cannot know that claiming `aws` also promotes
+`azure` from Missing to Close, because the adjacency dictionary lives in `internal/skilladjacency`.
+Leaving it unreconciled means the block shows one match and a reload shows a different one. So on a
+successful write the block refetches `GET /jobs/:slug/match` and swaps the overlay for the response.
+
+A failed refetch keeps the overlay: the write succeeded, and reverting would misreport the profile.
+
+Note that the fetch `$effect` tracks only `job.public_slug` and the block state, and the block state
+stays `'ready'` across a claim — so the refetch has to be issued explicitly. That is the intent: a
+profile write should not be able to accidentally re-trigger the block's initial load.
+
+### The store owns serialisation
+
+`addSkill(skill)` and `removeSkill(skill)` land on `ProfileStore`, not in the component. The store is
+the single owner of the profile row, and it is the only place that can guarantee the second write is
+built from the first one's result — an internal promise chain (`#queue = #queue.then(...)`) means
+each `PUT` reads `#profile` at send time, after its predecessor has applied. Left in the component,
+two fast claims each read the pre-claim skills and the second silently drops the first.
+
+`addSkill` also drops the skill from `excluded_skills`: a profile that both claims and avoids the
+same token is incoherent, and the user resolved the contradiction by pressing the button. `removeSkill`
+subtracts only that one skill, so undoing an earlier claim leaves a later one alone; it does not
+restore the exclusion, which would re-create the contradiction the claim resolved.
+
+### Undo is a second write, not a snapshot
+
+Undo calls `removeSkill` and drops the block back to the pre-claim match. Restoring a whole
+pre-claim profile snapshot would be wrong the moment a second claim intervened — the snapshot would
+silently roll that one back too.
+
+## Risks / Trade-offs
+
+- **A claim is a bare assertion — nothing verifies it.** → It is the same assertion the profile
+  editor already accepts by typing, and it only affects the viewer's own matching and filtering. It
+  writes nothing that can reach a CV, which is where an unverified claim would actually cost the
+  candidate something.
+- **The optimistic percentage can be lower than the server's for a moment** (an unlocked adjacency).
+  → It resolves on the refetch a moment later, and it errs downward: the number never overstates the
+  match and then falls back.
+- **Widening the profile makes the viewer's whole feed less selective** — profile skills also feed
+  "Apply my profile" in the filter modal and the subscription digests. → It is the same effect as
+  editing the profile page, which is the honest outcome of the user saying they have the skill; the
+  confirmation names what was added and offers undo.
+- **A `PUT` that replaces the row can clobber a profile edited in another tab.** → Pre-existing to
+  this endpoint, not introduced here; the claim path reads the store's freshly-loaded copy and adds
+  one element to it.
+- **Every red chip is now a button, on a block that is mostly red chips.** → The claim row is one
+  press away and one press back; nothing is written without the explicit second press on "Add to
+  profile".

--- a/openspec/changes/claim-skill-from-job-match/proposal.md
+++ b/openspec/changes/claim-skill-from-job-match/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The sidebar match block tells a signed-in viewer which of a job's skills they are missing, and
+stops there. The most common reason a skill reads as missing is not that the candidate lacks it —
+it is that the profile never learned it: the skill set was seeded from a CV parse or typed once at
+sign-up and has not been touched since. Today fixing that means leaving the job, opening
+`/my/profile`, finding the skill in a picker, saving, and navigating back — so nobody does it, and
+every subsequent match, card bar and filter stays wrong for the same missing token.
+
+The block already names the exact skill and the exact moment the candidate notices the gap. Letting
+them claim it in place turns a dead-end red chip into the cheapest profile-completion prompt the
+product has.
+
+## What Changes
+
+- A **Missing** or **Close** chip in the sidebar match block becomes an activatable control. Pressing
+  it expands an inline claim row directly under its group — "Do you have `<skill>`?" plus an **Add to
+  profile** action — following the existing `ReminderChip` disclosure pattern rather than introducing
+  a floating popover the design system does not have.
+- Confirming writes the skill into the caller's profile skill set (`PUT /api/v1/me/profile`) and
+  nothing else: no CV edit, no experience-bank atom.
+- The chip moves to **You have** immediately, with the percentage and the two-colour bar recomputed
+  client-side, before the request settles. Once the write lands, the block refetches the authoritative
+  match so a newly unlocked adjacency (a claim can turn a third skill from missing to close) is not
+  left showing a stale classification.
+- A confirmation line under the block offers **Undo**, which removes just that skill again.
+- A failed write rolls the chip back to where it was and states the failure.
+- **You have** chips stay inert — this change adds no "remove a skill" affordance.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `job-profile-match`: the real-match state gains a requirement for claiming a Missing or Close skill
+  into the profile from the block, covering the disclosure, the optimistic reclassification, the
+  reconciliation against the server, and undo.
+
+## Impact
+
+- `web/src/lib/components/JobMatch.svelte` — chips in the Missing/Close groups become buttons; new
+  inline claim row, confirmation line, and error state.
+- `web/src/lib/jobMatch.ts` — a pure overlay that reclassifies a claimed skill as exact and
+  recomputes counts and coverage, unit-tested in `jobMatch.test.ts`.
+- `web/src/lib/profile.svelte.ts` — the store gains `addSkill`/`removeSkill`, serialised so two quick
+  claims cannot each send a stale skill list (`PUT` replaces the whole profile row).
+- No backend, database, or contract change: `jobmatch.Compute` already reclassifies on the next call,
+  and the profile endpoint already lowercases, trims and deduplicates the skills it is handed.

--- a/openspec/changes/claim-skill-from-job-match/specs/job-profile-match/spec.md
+++ b/openspec/changes/claim-skill-from-job-match/specs/job-profile-match/spec.md
@@ -1,0 +1,131 @@
+## ADDED Requirements
+
+### Requirement: Claiming a missing skill from the match block
+
+In the real-match state, every chip in the **Missing** and **Close** groups SHALL be an activatable
+control that discloses a claim row naming that skill and offering to add it to the caller's profile.
+Confirming SHALL write the skill into the caller's profile skill set and MUST NOT write to the stored
+CV, the structured résumé, or the experience bank. Chips in the **You have** group SHALL remain inert:
+this affordance adds skills and never removes them. The claim affordance SHALL be absent from the
+guest, no-profile, no-skills and loading states, whose chips are a fabricated teaser rather than a
+match.
+
+#### Scenario: Missing chip discloses the claim row
+
+- **WHEN** a signed-in viewer with a profile presses the `entra-id` chip in the Missing group
+- **THEN** a claim row naming `entra-id` SHALL appear with an action to add it to the profile, and the
+  pressed chip SHALL report itself as expanded to assistive technology
+
+#### Scenario: Close chip discloses the same claim row
+
+- **WHEN** the viewer presses a Close chip — a skill they hold only through a neighbour, such as
+  `azure · you have aws`
+- **THEN** the claim row SHALL offer to add `azure` itself, not the neighbour it was matched through
+
+#### Scenario: Only one claim row is open at a time
+
+- **WHEN** a claim row is open for one skill and the viewer presses a different Missing or Close chip
+- **THEN** the row SHALL move to the newly pressed skill, and pressing the same chip again SHALL close it
+
+#### Scenario: Held chips offer nothing
+
+- **WHEN** the viewer presses a chip in the You have group
+- **THEN** no claim row SHALL open and the profile SHALL NOT change
+
+#### Scenario: A locked viewer cannot claim
+
+- **WHEN** an unauthenticated viewer, or a signed-in viewer with no profile skills, sees the blurred
+  teaser
+- **THEN** its chips SHALL NOT be activatable and no claim row SHALL be reachable
+
+### Requirement: The claimed skill is reclassified before the write settles
+
+Confirming a claim SHALL move the skill into the **You have** group and recompute the coverage
+percentage and the two-colour bar client-side, without waiting for the profile write. The client-side
+recomputation SHALL use the same weighting as the server — an exact match weighs 1, an adjacent match
+one half — so the optimistic figure agrees with the server's for the skills it can classify. Once the
+write succeeds the block SHALL refetch the match and render the server's classification in place of the
+optimistic one, because a claim can also turn a third skill from missing to close through the adjacency
+dictionary, which the client does not hold.
+
+#### Scenario: Chip moves and the percentage rises immediately
+
+- **WHEN** the viewer confirms a claim for a Missing skill of a job carrying 4 skills, 1 of which was
+  already exact
+- **THEN** the skill SHALL appear in You have, the reported counts SHALL read 2 of 4, and the coverage
+  SHALL read 50% before the profile request settles
+
+#### Scenario: A claimed Close skill stops being half-weighted
+
+- **WHEN** the viewer claims a skill that was classified adjacent
+- **THEN** it SHALL leave the Close group, the adjacent count SHALL fall by one, the exact count SHALL
+  rise by one, and the coverage SHALL rise by the half weight the adjacency was contributing
+
+#### Scenario: The server's classification replaces the optimistic one
+
+- **WHEN** the profile write succeeds
+- **THEN** the block SHALL refetch the match and render the returned classification, so a skill the
+  claim newly made adjacent is shown as Close rather than left in Missing
+
+#### Scenario: A failed refetch keeps the optimistic view
+
+- **WHEN** the profile write succeeds but the follow-up match request fails
+- **THEN** the block SHALL keep showing the optimistic classification and MUST NOT revert the claim,
+  which the server has already accepted
+
+### Requirement: A claim is confirmed and reversible
+
+After a successful claim the block SHALL show a confirmation naming the skill and offering to undo it.
+The confirmation SHALL name the most recent claim; a further claim replaces it. Undo SHALL subtract
+only that skill from the profile skill set — never restore a whole earlier profile, which would roll
+back any claim made after it — and SHALL restore the block to the classification it had before that
+claim. A claimed skill SHALL also be dropped from the profile's excluded-skills set, so the profile
+cannot simultaneously claim and avoid the same skill; undo SHALL NOT restore that exclusion.
+
+#### Scenario: Confirmation offers undo
+
+- **WHEN** a claim for `entra-id` is written successfully
+- **THEN** the block SHALL show that `entra-id` was added to the profile, with an undo action
+
+#### Scenario: A second claim takes over the confirmation
+
+- **WHEN** the viewer claims `entra-id` and then claims `powershell`
+- **THEN** the confirmation SHALL name `powershell`, and undoing it SHALL leave `entra-id` in the
+  profile
+
+#### Scenario: Undo returns the skill to the group it came from
+
+- **WHEN** the viewer undoes a claim for `entra-id`
+- **THEN** `entra-id` SHALL return to the Missing group and the coverage SHALL read what it did
+  before the claim
+
+#### Scenario: Claiming an excluded skill resolves the contradiction
+
+- **WHEN** the viewer claims a skill their profile currently lists among its excluded skills
+- **THEN** the saved profile SHALL carry that skill among its skills and no longer among its excluded
+  skills
+
+### Requirement: Concurrent claims cannot drop each other
+
+Because the profile endpoint replaces the whole profile row, claims SHALL be serialised so that each
+write is built from the result of the previous one. Two claims confirmed in quick succession SHALL both
+survive.
+
+#### Scenario: Two rapid claims both persist
+
+- **WHEN** the viewer confirms a claim for `bash` and, before that request settles, confirms one for
+  `powershell`
+- **THEN** the profile SHALL end up holding both skills, and neither write SHALL be sent with a skill
+  list that predates the other
+
+### Requirement: A failed claim is rolled back and reported
+
+When the profile write fails, the block SHALL return the skill to the group it came from, restore the
+previous counts and coverage, and state that the skill could not be added. It MUST NOT show the
+confirmation or the undo action for a claim that did not land.
+
+#### Scenario: Write failure restores the chip
+
+- **WHEN** the profile write for a claimed skill fails
+- **THEN** the skill SHALL reappear in the group it was claimed from, the coverage SHALL return to its
+  previous value, and an error naming the failure SHALL be shown

--- a/openspec/changes/claim-skill-from-job-match/tasks.md
+++ b/openspec/changes/claim-skill-from-job-match/tasks.md
@@ -1,0 +1,47 @@
+## 1. Optimistic reclassification (pure)
+
+- [x] 1.1 In `web/src/lib/jobMatch.test.ts`, add failing tests for a new `claimSkill(match, skill)`:
+      a Missing skill moves to `matched` (exact count +1, coverage recomputed by
+      `round((exact + 0.5 × adjacent) / total × 100)`); an adjacent skill also leaves `adjacent`
+      (adjacent count −1); a skill the match does not carry returns the match unchanged; the input
+      match object is not mutated.
+- [x] 1.2 Implement `claimSkill` in `web/src/lib/jobMatch.ts` beside `matchBarSegments`, reusing the
+      server's weighting so the optimistic figure cannot drift from `jobmatch.Compute`.
+
+## 2. Profile writes
+
+- [x] 2.1 Add failing tests in `web/src/lib/profileSkills.test.ts` for the pure merge rules:
+      `withSkill(profile, skill)` appends the skill (no duplicate when already held, case-insensitively)
+      and drops it from `excluded_skills`; `withoutSkill(profile, skill)` removes only that skill and
+      leaves the rest — including a skill claimed afterwards — untouched.
+- [x] 2.2 Implement `web/src/lib/profileSkills.ts` with those two pure functions.
+- [x] 2.3 Add `addSkill`/`removeSkill` to `ProfileStore` (`web/src/lib/profile.svelte.ts`): each builds
+      its payload from `#profile` at send time and goes through `save()`, chained on an internal
+      promise so a second claim issued before the first settles is built from the first one's result.
+      The runner cannot host the store itself (`web/vitest.config.ts` runs plain Node with no
+      Svelte plugin, so runes never compile), so the ordering guarantee is tested one level down:
+      `serialQueue` in `web/src/lib/serialQueue.ts`, with the store holding only the wiring.
+
+## 3. The claim affordance in the match block
+
+- [x] 3.1 Turn Missing and Close chips into `<button>`s in
+      `web/src/lib/components/JobMatch.svelte`, carrying `aria-expanded` and a selected ring, with a
+      single `claiming: string | null` selection so pressing another chip moves the row and pressing
+      the same chip closes it. You-have chips stay plain `<span>`s; the locked teaser is untouched.
+- [x] 3.2 Render the inline claim row under the group that owns the selected chip — "Do you have
+      `<skill>`?" plus an **Add to profile** button — following `ReminderChip.svelte`'s inline
+      disclosure, not a floating layer.
+- [x] 3.3 Wire confirmation: apply `claimSkill` to an `optimistic` copy rendered in place of `match`,
+      close the row, call `profileStore.addSkill`, then refetch `GET /jobs/:slug/match` and swap the
+      overlay for the response. A failed refetch keeps the overlay; a failed write drops it and shows
+      the error.
+- [x] 3.4 Show the confirmation line with **Undo** after a successful claim; undo calls
+      `profileStore.removeSkill`, restores the pre-claim match, and clears the line. Guard the whole
+      surface against a stale response after navigating to another job (the existing `slug` re-check).
+
+## 4. Verification
+
+- [x] 4.1 `pnpm --dir web test` and `pnpm --dir web run check` (and lint) pass.
+- [x] 4.2 Visually verify the block in a browser at the sidebar's real width: claim a Missing skill and
+      a Close skill, confirm the chip moves, the bar and percentage change, undo restores, and the
+      row is reachable and dismissable by keyboard.

--- a/web/src/lib/components/JobMatch.svelte
+++ b/web/src/lib/components/JobMatch.svelte
@@ -10,6 +10,7 @@
     matchTeaser,
     teaserChips,
     partitionBlockers,
+    claimSkill,
   } from '$lib/jobMatch';
   import { profileStore } from '$lib/profile.svelte';
   import type { BlockerSeverity, Job, JobMatchResult } from '$lib/types';
@@ -41,10 +42,23 @@
     }),
   );
 
+  // A claim in progress or already made. `overlay` is the match as it reads once a skill
+  // is claimed, rendered in place of the fetched one until the server's own answer lands;
+  // `claimed` keeps the pre-claim match so undo can put it back.
+  let claiming = $state<string | null>(null);
+  let overlay = $state.raw<JobMatchResult | null>(null);
+  let claimed = $state.raw<{ skill: string; before: JobMatchResult } | null>(null);
+  let failed = $state<string | null>(null);
+  let pending = $state(false);
+
   // Fetch the real match only when ready; re-fetch on navigation to another job.
   $effect(() => {
     const slug = job.public_slug; // track the current job
     match = null;
+    overlay = null;
+    claiming = null;
+    claimed = null;
+    failed = null;
     if (blockState !== 'ready') return;
     api.getJobMatch(slug)
       .then((m) => {
@@ -53,8 +67,78 @@
       .catch(() => {});
   });
 
-  const segments = $derived(match ? matchBarSegments(match) : { exact: 0, adjacent: 0 });
-  const blockers = $derived(partitionBlockers(match?.blockers));
+  // What the block renders: the optimistic reading while a claim is unreconciled, the
+  // fetched match otherwise.
+  const view = $derived(overlay ?? match);
+
+  /** Put the block back to a reading it showed before — dropping the overlay when that
+   *  reading is the fetched match itself, so an abandoned claim leaves no overlay behind. */
+  function restore(reading: JobMatchResult | null) {
+    overlay = reading === match ? null : reading;
+  }
+
+  /** Replace the optimistic reading with the server's own, which also accounts for any
+   *  skill the claim newly made adjacent. A failed refetch keeps the overlay: the write
+   *  landed, so reverting would misreport the profile. */
+  async function reconcile(slug: string) {
+    try {
+      const fresh = await api.getJobMatch(slug);
+      if (job.public_slug !== slug) return;
+      match = fresh;
+      overlay = null;
+    } catch {
+      // Keep showing the optimistic reading.
+    }
+  }
+
+  async function claim(skill: string) {
+    const before = view;
+    if (!before || pending) return;
+    const slug = job.public_slug;
+    pending = true;
+    failed = null;
+    claiming = null;
+    overlay = claimSkill(before, skill);
+    try {
+      await profileStore.addSkill(skill);
+      // Navigated on mid-write: the claim stands, but its confirmation belongs to the job
+      // that was open, and the next job's block has already reset itself.
+      if (job.public_slug !== slug) return;
+      claimed = { skill, before };
+      await reconcile(slug);
+    } catch {
+      if (job.public_slug !== slug) return;
+      restore(before);
+      failed = skill;
+    } finally {
+      pending = false;
+    }
+  }
+
+  async function undoClaim() {
+    if (!claimed || pending) return;
+    const { skill, before } = claimed;
+    const shown = view;
+    const slug = job.public_slug;
+    pending = true;
+    failed = null;
+    overlay = before;
+    claimed = null;
+    try {
+      await profileStore.removeSkill(skill);
+      await reconcile(slug);
+    } catch {
+      if (job.public_slug !== slug) return;
+      restore(shown);
+      claimed = { skill, before };
+      failed = skill;
+    } finally {
+      pending = false;
+    }
+  }
+
+  const segments = $derived(view ? matchBarSegments(view) : { exact: 0, adjacent: 0 });
+  const blockers = $derived(partitionBlockers(view?.blockers));
 
   // Warning tone by severity: hard constraints (work auth, certs) read as blocking,
   // fit constraints (location, language) as softer cautions.
@@ -87,9 +171,42 @@
   const haveChip = `${chip} border-brand/30 bg-brand-muted text-brand-strong`;
   const adjChip = `${chip} border-warning/30 bg-warning/10 text-warning-strong`;
   const missChip = `${chip} border-destructive/30 bg-destructive/10 text-destructive`;
+  // A not-held chip is a control: pressing it asks whether the viewer holds the skill
+  // after all. The ring marks which one the open claim row belongs to.
+  const claimable = (base: string, open: boolean) =>
+    `${base} transition-shadow hover:brightness-95 disabled:opacity-60 ${open ? 'ring-2 ring-foreground/30' : ''}`;
 
   const profileHref = resolve('/my/profile');
+
+  /** Open the claim row for a skill, or close it if it is already the open one. Only one
+   *  is open at a time — the row names its skill, which is what keeps it tied to the chip
+   *  without anchoring a floating layer inside a narrow column. */
+  function toggleClaimRow(skill: string) {
+    claiming = claiming === skill ? null : skill;
+  }
 </script>
+
+{#snippet claimRow(skill: string)}
+  <!-- The claim row expands under the group rather than floating over it: the sidebar
+       column is too narrow for an anchored popover, and naming the skill in the row's own
+       text keeps it tied to the chip that opened it. Same shape as ReminderChip. -->
+  <div
+    class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed border-border px-2.5 py-2"
+  >
+    <span class="text-xs text-muted-foreground">
+      Do you have <span class="font-medium text-foreground">{skill}</span>?
+    </span>
+    <Button variant="primary" size="sm" disabled={pending} onclick={() => claim(skill)}>
+      Add to profile
+    </Button>
+  </div>
+{/snippet}
+
+<svelte:window
+  onkeydown={(e) => {
+    if (e.key === 'Escape' && claiming) claiming = null;
+  }}
+/>
 
 <section
   class="flex flex-col gap-3 border-t border-border pt-4 first:border-t-0 first:pt-0"
@@ -155,13 +272,13 @@
            be repeated. -->
       <MatchSummary slug={job.public_slug} />
     {/if}
-  {:else if blockState === 'ready' && match}
+  {:else if blockState === 'ready' && view}
     <!-- Real match: percent + two-colour bar + three skill groups. -->
     <div class="flex items-baseline justify-between gap-2">
-      <span class="text-2xl font-bold tabular-nums leading-none">{match.coverage_percent}%</span>
+      <span class="text-2xl font-bold tabular-nums leading-none">{view.coverage_percent}%</span>
       <span class="text-xs text-muted-foreground">
-        {match.exact_count} of {match.total} skills{#if match.adjacent_count}
-          · {match.adjacent_count} close{/if}
+        {view.exact_count} of {view.total} skills{#if view.adjacent_count}
+          · {view.adjacent_count} close{/if}
       </span>
     </div>
     <div class="flex h-2 overflow-hidden rounded bg-secondary">
@@ -169,39 +286,80 @@
       <div class="h-full bg-warning transition-all" style="width: {segments.adjacent}%"></div>
     </div>
 
-    {#if match.matched.length}
+    {#if view.matched.length}
       <div class="flex flex-col gap-1.5">
         <span class="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
           <span class="size-1.5 rounded-full bg-brand"></span>You have
         </span>
         <div class="flex flex-wrap gap-1.5">
-          {#each match.matched as skill (skill)}<span class={haveChip}>{skill}</span>{/each}
+          {#each view.matched as skill (skill)}<span class={haveChip}>{skill}</span>{/each}
         </div>
       </div>
     {/if}
 
-    {#if match.adjacent.length}
+    {#if view.adjacent.length}
       <div class="flex flex-col gap-1.5">
         <span class="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
           <span class="size-1.5 rounded-full bg-warning"></span>Close — you have a related skill
         </span>
         <div class="flex flex-wrap gap-1.5">
-          {#each match.adjacent as a (a.name)}
-            <span class={adjChip}>{a.name} <span class="opacity-70">· you have {a.via}</span></span>
+          {#each view.adjacent as a (a.name)}
+            <button
+              type="button"
+              class={claimable(adjChip, claiming === a.name)}
+              aria-expanded={claiming === a.name}
+              disabled={pending}
+              onclick={() => toggleClaimRow(a.name)}
+            >
+              {a.name} <span class="opacity-70">· you have {a.via}</span>
+            </button>
           {/each}
         </div>
+        {#if claiming && view.adjacent.some((a) => a.name === claiming)}
+          {@render claimRow(claiming)}
+        {/if}
       </div>
     {/if}
 
-    {#if match.missing.length}
+    {#if view.missing.length}
       <div class="flex flex-col gap-1.5">
         <span class="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
           <span class="size-1.5 rounded-full bg-destructive"></span>Missing
         </span>
         <div class="flex flex-wrap gap-1.5">
-          {#each match.missing as skill (skill)}<span class={missChip}>{skill}</span>{/each}
+          {#each view.missing as skill (skill)}
+            <button
+              type="button"
+              class={claimable(missChip, claiming === skill)}
+              aria-expanded={claiming === skill}
+              disabled={pending}
+              onclick={() => toggleClaimRow(skill)}
+            >
+              {skill}
+            </button>
+          {/each}
         </div>
+        {#if claiming && view.missing.includes(claiming)}
+          {@render claimRow(claiming)}
+        {/if}
       </div>
+    {/if}
+
+    {#if claimed}
+      <p class="flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground">
+        <Check class="size-3.5 shrink-0 text-brand" />
+        <span><span class="font-medium text-foreground">{claimed.skill}</span> added to your profile.</span>
+        <button
+          type="button"
+          class="font-medium underline underline-offset-2 hover:text-foreground disabled:opacity-60"
+          disabled={pending}
+          onclick={undoClaim}>Undo</button
+        >
+      </p>
+    {/if}
+
+    {#if failed}
+      <p class="text-xs text-destructive">Could not update {failed} in your profile. Try again.</p>
     {/if}
 
     {#if blockers.unmet.length || blockers.met.length}

--- a/web/src/lib/jobMatch.test.ts
+++ b/web/src/lib/jobMatch.test.ts
@@ -6,6 +6,7 @@ import {
   matchTeaser,
   teaserChips,
   partitionBlockers,
+  claimSkill,
 } from './jobMatch';
 
 describe('resolveMatchState', () => {
@@ -222,6 +223,52 @@ describe('teaserChips', () => {
 
   it('has nothing to show for a job with no skills', () => {
     expect(teaserChips([], new Set(), 3)).toEqual([]);
+  });
+});
+
+describe('claimSkill', () => {
+  // A job of four skills the viewer holds one of exactly, one through a neighbour.
+  const match = {
+    total: 4,
+    exact_count: 1,
+    adjacent_count: 1,
+    coverage_percent: 38,
+    matched: ['docker'],
+    adjacent: [{ name: 'azure', via: 'aws' }],
+    missing: ['bash', 'powershell'],
+  };
+
+  it('moves a missing skill into the held group and recomputes the coverage', () => {
+    const after = claimSkill(match, 'bash');
+    expect(after.matched).toEqual(['docker', 'bash']);
+    expect(after.missing).toEqual(['powershell']);
+    expect(after.exact_count).toBe(2);
+    // round((2 + 0.5 × 1) / 4 × 100)
+    expect(after.coverage_percent).toBe(63);
+  });
+
+  it('stops half-weighting a claimed adjacent skill', () => {
+    const after = claimSkill(match, 'azure');
+    expect(after.matched).toEqual(['docker', 'azure']);
+    expect(after.adjacent).toEqual([]);
+    expect(after.adjacent_count).toBe(0);
+    expect(after.exact_count).toBe(2);
+    expect(after.coverage_percent).toBe(50);
+  });
+
+  it('leaves a match this job never carried alone', () => {
+    expect(claimSkill(match, 'kafka')).toEqual(match);
+  });
+
+  it('leaves an already-held skill alone', () => {
+    expect(claimSkill(match, 'docker')).toEqual(match);
+  });
+
+  it('does not mutate the match it was given', () => {
+    claimSkill(match, 'bash');
+    expect(match.matched).toEqual(['docker']);
+    expect(match.missing).toEqual(['bash', 'powershell']);
+    expect(match.coverage_percent).toBe(38);
   });
 });
 

--- a/web/src/lib/jobMatch.ts
+++ b/web/src/lib/jobMatch.ts
@@ -2,7 +2,7 @@
 // component so it is unit-testable (vitest) without a DOM: which of the four block
 // states to render, and how to size the two-colour progress bar.
 
-import type { Blocker } from './types';
+import type { Blocker, JobMatch } from './types';
 
 /** Split the hard-constraint blockers for display: the unmet ones (shown as warnings,
  *  hardest first — a lower score_cap is a harder blocker) and the met ones (shown as
@@ -138,6 +138,33 @@ export function teaserChips(jobSkills: string[], missing: Set<string>, limit: nu
     if (borrowed) return [...shown.slice(0, -1), borrowed];
   }
   return shown;
+}
+
+/** The match as it reads once the viewer claims a skill they were missing, before the
+ *  profile write settles. The skill joins the held group and leaves whichever group it
+ *  came from; the counts and the coverage are recomputed by the server's own weighting
+ *  (an exact match weighs 1, an adjacent one half), so the optimistic figure cannot drift
+ *  from what `jobmatch.Compute` will answer next.
+ *
+ *  It is a strict under-estimate: the adjacency dictionary lives on the backend, so a
+ *  claim that promotes some *other* missing skill to adjacent is invisible here. The block
+ *  refetches once the write lands and that is where such a promotion shows up.
+ *
+ *  A skill this job does not carry, or one already held, yields the match untouched. */
+export function claimSkill<M extends JobMatch>(match: M, skill: string): M {
+  if (!match.missing.includes(skill) && !match.adjacent.some((a) => a.name === skill)) return match;
+
+  const exact_count = match.exact_count + 1;
+  const adjacent = match.adjacent.filter((a) => a.name !== skill);
+  return {
+    ...match,
+    exact_count,
+    adjacent_count: adjacent.length,
+    coverage_percent: Math.round(((exact_count + 0.5 * adjacent.length) / match.total) * 100),
+    matched: [...match.matched, skill],
+    adjacent,
+    missing: match.missing.filter((s) => s !== skill),
+  };
 }
 
 /** The two progress-bar segment widths (in percent of the track): a full-weight

--- a/web/src/lib/profile.svelte.ts
+++ b/web/src/lib/profile.svelte.ts
@@ -7,6 +7,8 @@
 // caller (a bad specialization or empty skills is a 400) so the UI can show them.
 
 import { api } from '$lib/api';
+import { withSkill, withoutSkill, type ProfileSkillSets } from '$lib/profileSkills';
+import { serialQueue } from '$lib/serialQueue';
 import { UserResource } from '$lib/userResource.svelte';
 import type { LocationPreferences, UserProfile } from '$lib/types';
 
@@ -16,6 +18,11 @@ class ProfileStore extends UserResource<UserProfile | null> {
   // reactive too, so the filter modal can wait for the load to settle before showing
   // its "Apply my profile" action.
   #profile = $state.raw<UserProfile | null>(null);
+
+  // Single-skill edits go one at a time: the endpoint replaces the whole row, so two
+  // claims made a moment apart would otherwise both be assembled from the same
+  // pre-claim skill list and the second would drop the first.
+  #queue = serialQueue();
 
   get profile(): UserProfile | null {
     return this.#profile;
@@ -47,6 +54,35 @@ class ProfileStore extends UserResource<UserProfile | null> {
     this.#profile = row;
     this.markLoaded();
     return row;
+  }
+
+  /** Add one skill to the profile — what the job-match block writes when the viewer says
+   *  they have a skill it listed as missing. Also stops excluding that skill. Rejects when
+   *  there is no profile to add to (the block only offers this to a profiled viewer) or
+   *  when the write is refused, leaving the stored copy untouched either way. */
+  addSkill(skill: string): Promise<UserProfile> {
+    return this.#queue(() => this.#writeSkills((sets) => withSkill(sets, skill)));
+  }
+
+  /** Take one skill back out — undoing a claim. Subtracts only that skill, so a claim made
+   *  after it survives. */
+  removeSkill(skill: string): Promise<UserProfile> {
+    return this.#queue(() => this.#writeSkills((sets) => withoutSkill(sets, skill)));
+  }
+
+  /** Re-save the profile with edited skill sets. Reads `#profile` at call time — inside the
+   *  queue — so it sees whatever the preceding write applied rather than a copy that
+   *  predates it. */
+  #writeSkills(edit: (sets: ProfileSkillSets) => ProfileSkillSets): Promise<UserProfile> {
+    const current = this.#profile;
+    if (!current) return Promise.reject(new Error('No profile to edit.'));
+    const next = edit(current);
+    return this.save(
+      current.specializations,
+      next.skills,
+      next.excluded_skills,
+      current.location_preferences,
+    );
   }
 
   /** Clear the profile. */

--- a/web/src/lib/profileSkills.test.ts
+++ b/web/src/lib/profileSkills.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { withSkill, withoutSkill } from './profileSkills';
+
+describe('withSkill', () => {
+  it('appends the claimed skill', () => {
+    expect(withSkill({ skills: ['docker'], excluded_skills: [] }, 'bash')).toEqual({
+      skills: ['docker', 'bash'],
+      excluded_skills: [],
+    });
+  });
+
+  it('adds nothing when the skill is already held, whatever its case', () => {
+    expect(withSkill({ skills: ['Docker'], excluded_skills: [] }, 'docker')).toEqual({
+      skills: ['Docker'],
+      excluded_skills: [],
+    });
+  });
+
+  it('stops excluding a skill the viewer just claimed', () => {
+    expect(withSkill({ skills: ['docker'], excluded_skills: ['PHP', 'perl'] }, 'php')).toEqual({
+      skills: ['docker', 'php'],
+      excluded_skills: ['perl'],
+    });
+  });
+
+  it('does not mutate what it was given', () => {
+    const before = { skills: ['docker'], excluded_skills: ['bash'] };
+    withSkill(before, 'bash');
+    expect(before).toEqual({ skills: ['docker'], excluded_skills: ['bash'] });
+  });
+});
+
+describe('withoutSkill', () => {
+  it('removes only the named skill, keeping one claimed after it', () => {
+    expect(
+      withoutSkill({ skills: ['docker', 'bash', 'powershell'], excluded_skills: [] }, 'bash'),
+    ).toEqual({ skills: ['docker', 'powershell'], excluded_skills: [] });
+  });
+
+  it('matches the held skill whatever its case', () => {
+    expect(withoutSkill({ skills: ['Bash'], excluded_skills: [] }, 'bash')).toEqual({
+      skills: [],
+      excluded_skills: [],
+    });
+  });
+
+  it('leaves the excluded set alone — undoing a claim does not re-exclude the skill', () => {
+    expect(withoutSkill({ skills: ['php'], excluded_skills: ['perl'] }, 'php')).toEqual({
+      skills: [],
+      excluded_skills: ['perl'],
+    });
+  });
+
+  it('does not mutate what it was given', () => {
+    const before = { skills: ['docker', 'bash'], excluded_skills: [] };
+    withoutSkill(before, 'bash');
+    expect(before).toEqual({ skills: ['docker', 'bash'], excluded_skills: [] });
+  });
+});

--- a/web/src/lib/profileSkills.ts
+++ b/web/src/lib/profileSkills.ts
@@ -1,0 +1,37 @@
+// The two skill-set edits behind claiming a skill from the job-match block, kept pure and
+// apart from the store that performs them: `PUT /me/profile` replaces the whole profile
+// row, so every write starts by rebuilding these two lists from the copy currently held.
+//
+// Case-insensitive throughout. The endpoint lowercases what it is given, so a profile
+// seeded before that (or typed by hand) can hold "Docker" where a job's canonical facet
+// says "docker" — comparing verbatim would let the same skill be claimed twice.
+
+/** The two lists a claim touches. `UserProfile` satisfies this structurally, so callers
+ *  hand it over directly. */
+export interface ProfileSkillSets {
+  skills: string[];
+  excluded_skills: string[];
+}
+
+const same = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+
+/** The skill sets once the viewer claims `skill`: held, and no longer avoided. A profile
+ *  that both claims and excludes one skill is incoherent — the viewer resolved that by
+ *  pressing the button, so the exclusion goes. */
+export function withSkill(sets: ProfileSkillSets, skill: string): ProfileSkillSets {
+  return {
+    skills: sets.skills.some((s) => same(s, skill)) ? sets.skills : [...sets.skills, skill],
+    excluded_skills: sets.excluded_skills.filter((s) => !same(s, skill)),
+  };
+}
+
+/** The skill sets once the viewer undoes a claim. It subtracts that one skill rather than
+ *  restoring a snapshot, so undoing an earlier claim leaves a later one standing. The
+ *  exclusion `withSkill` dropped is not restored — that would re-create the contradiction
+ *  the claim resolved. */
+export function withoutSkill(sets: ProfileSkillSets, skill: string): ProfileSkillSets {
+  return {
+    skills: sets.skills.filter((s) => !same(s, skill)),
+    excluded_skills: sets.excluded_skills,
+  };
+}

--- a/web/src/lib/serialQueue.test.ts
+++ b/web/src/lib/serialQueue.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { serialQueue } from './serialQueue';
+
+/** A promise the test settles by hand, so a second job can be queued while the first
+ *  is still running. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let every already-resolved promise deliver. The queue starts a job in a microtask
+ *  rather than synchronously, so nothing has run right after queueing. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('serialQueue', () => {
+  it('does not start a job while its predecessor is still running', async () => {
+    const queue = serialQueue();
+    const first = deferred<string>();
+    const started: string[] = [];
+
+    const a = queue(() => {
+      started.push('a');
+      return first.promise;
+    });
+    const b = queue(() => {
+      started.push('b');
+      return Promise.resolve('b');
+    });
+
+    await flush();
+    expect(started).toEqual(['a']);
+    first.resolve('a');
+    await a;
+    await b;
+    expect(started).toEqual(['a', 'b']);
+  });
+
+  it('lets a job read state its predecessor wrote', async () => {
+    const queue = serialQueue();
+    const first = deferred<void>();
+    let state = 'initial';
+
+    const a = queue(async () => {
+      await first.promise;
+      state = 'written by a';
+    });
+    const b = queue(async () => `b saw: ${state}`);
+
+    first.resolve();
+    await a;
+    expect(await b).toBe('b saw: written by a');
+  });
+
+  it('returns each job its own result', async () => {
+    const queue = serialQueue();
+    expect(await Promise.all([queue(async () => 1), queue(async () => 2)])).toEqual([1, 2]);
+  });
+
+  it('rejects the failing job without wedging the ones behind it', async () => {
+    const queue = serialQueue();
+    const failing = queue(async () => {
+      throw new Error('write failed');
+    });
+    const next = queue(async () => 'ran anyway');
+
+    await expect(failing).rejects.toThrow('write failed');
+    expect(await next).toBe('ran anyway');
+  });
+});

--- a/web/src/lib/serialQueue.ts
+++ b/web/src/lib/serialQueue.ts
@@ -1,0 +1,20 @@
+// A one-at-a-time queue for writes that must each be built from the previous one's
+// result. `PUT /me/profile` replaces the whole profile row, so two claims issued a
+// moment apart would both assemble their payload from the same pre-claim skill list and
+// the second would silently drop the first. Queueing makes each write read the store
+// after its predecessor has applied.
+
+/** Create a queue. Each call runs its job only once every job queued before it has
+ *  settled, and resolves (or rejects) with that job's own outcome. A failing job rejects
+ *  its own caller and does not wedge the ones behind it — a refused profile write must
+ *  not disable the next claim. */
+export function serialQueue(): <T>(job: () => Promise<T>) => Promise<T> {
+  let tail: Promise<unknown> = Promise.resolve();
+  return <T>(job: () => Promise<T>): Promise<T> => {
+    // The chain swallows the rejection so the *queue* keeps moving; the promise handed
+    // back is the un-swallowed one, so the caller still sees the failure.
+    const run = tail.then(job, job);
+    tail = run.catch(() => {});
+    return run;
+  };
+}


### PR DESCRIPTION
## Why

The sidebar match block names the skills a viewer lacks and stops there. The usual reason a skill reads as missing is that the profile never learned it — the skill set was seeded from a CV parse or typed once at sign-up. Fixing that meant leaving the job for `/my/profile`, so nobody did, and every later match, card bar and filter stayed wrong for the same token.

## What

Pressing a **Missing** or **Close** chip expands a claim row under its group — "Do you have `bash`?" plus **Add to profile** — following `ReminderChip`'s inline disclosure rather than a floating popover the design system does not have (and that a ~285px column cannot hold). Confirming writes the skill into `user_profiles.skills` and nothing else: no CV, no experience bank.

The chip moves to **You have** and the coverage recomputes client-side before the write settles. Once it lands the block refetches the match, because a claim can also promote a third skill from missing to close through the adjacency dictionary, which lives on the backend. A confirmation line offers **Undo**; a failed write rolls the chip back.

**No backend change** — `jobmatch.Compute` reclassifies on the next call, and the profile endpoint already lowercases, trims and deduplicates what it is handed.

## Notes

- Claims are serialised in `ProfileStore`. `PUT /me/profile` replaces the whole row, so two claims a moment apart would each be assembled from the same pre-claim skill list and the second would silently drop the first.
- `web/vitest.config.ts` runs plain Node with no Svelte plugin, so a runes module cannot be hosted in the runner. The ordering guarantee is therefore tested one level down, in `serialQueue.ts`, with the store holding only the wiring.
- Verified in a browser against a stubbed API: claim → optimistic 38% → reconciled 42% with `powershell` promoted to Close via the new `bash`, then Undo back to 29%. Keyboard: Enter opens the row, Escape closes it.

OpenSpec change: `claim-skill-from-job-match`.