### PR TITLE
The ledger reconcile has one home, and a test holds the order

### DIFF
--- a/cmd/classify-mail/store.go
+++ b/cmd/classify-mail/store.go
@@ -9,9 +9,9 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/strelov1/freehire/internal/appevent"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/gmailsync"
+	"github.com/strelov1/freehire/internal/inbox"
 	"github.com/strelov1/freehire/internal/maillink"
 )
 
@@ -135,21 +135,10 @@ func (s *dbStore) Save(ctx context.Context, outboxID, userID int64, r maillink.R
 	}
 	// Reconcile the ledger inside the same transaction that persisted the link, so an
 	// employer_reply event cannot exist for a classification that rolled back — nor be
-	// missing for one that committed. The reconcile is the same statement the inbox's
-	// manual paths call; the rule has one home.
-	eventSource, err := appevent.SourceForMail(r.MailSource)
-	if err != nil {
-		return fmt.Errorf("ledger source: %w", err)
-	}
-	if _, err := qtx.RetractSupersededEmailEvent(ctx, db.RetractSupersededEmailEventParams{
-		ID: r.EmailID, UserID: userID,
-	}); err != nil {
-		return fmt.Errorf("retract superseded event: %w", err)
-	}
-	if err := qtx.RecordEmailApplicationEvent(ctx, db.RecordEmailApplicationEventParams{
-		ID: r.EmailID, UserID: userID, EventSource: eventSource,
-	}); err != nil {
-		return fmt.Errorf("record reply event: %w", err)
+	// missing for one that committed. This is now literally the function the inbox's manual
+	// paths call, rather than a second copy of it asserting the rule has one home.
+	if err := inbox.ReconcileMailEvent(ctx, qtx, userID, r.EmailID, r.MailSource); err != nil {
+		return err
 	}
 	if err := qtx.DeleteEmailClassificationOutbox(ctx, outboxID); err != nil {
 		return fmt.Errorf("delete outbox entry: %w", err)

--- a/docs/agents/mail-stack.md
+++ b/docs/agents/mail-stack.md
@@ -108,9 +108,13 @@ the point: it is the tier that costs us nothing. See the `external` bullets belo
   A linked message records an `employer_reply` in `application_events`, and that ledger —
   not this table — is what the per-company response rate reads. Five paths change the
   pairing (`SetEmailClassification`, `AgentTriageEmail`, `ConfirmEmailLink`,
-  `LinkEmailToJob`, `UnlinkEmail`), so the rule is one reconcile with five callers: the
-  inbox's four funnel through `mutate`, `Triage` calls it directly because it writes
-  status, link and provenance in a single update. **Deleting a message changes nothing** —
+  `LinkEmailToJob`, `UnlinkEmail`), and the classification worker is a sixth. The rule is
+  one reconcile — `inbox.ReconcileMailEvent` — and it now really is one: the worker used to
+  carry its own copy of the same three steps, inside a `cmd/` main where no domain test
+  could reach it, under a comment asserting the rule had one home. The callers differ only
+  in what they do with the error: the inbox's paths are best-effort (the mutation the user
+  asked for already succeeded, and the reconcile is idempotent), while the worker propagates
+  it to roll back the transaction that persisted the link. **Deleting a message changes nothing** —
   it hides content, it does not un-happen the reply — while **re-linking retracts and
   re-records**, because a wrong link left standing poisons a named company's public rate
   permanently (the Workable case above). The reconcile is deliberately **two statements in

--- a/internal/appevent/appevent.go
+++ b/internal/appevent/appevent.go
@@ -1,6 +1,7 @@
 // Package appevent holds the application-event vocabulary shared by the paths that
-// record into the ledger — internal/maillink, internal/inbox, internal/jobtracking —
-// and by the aggregates that read it.
+// record into the ledger — internal/inbox (which owns the mail reconcile both the
+// interactive paths and cmd/classify-mail call) and internal/jobtracking — and by the
+// aggregates that read it.
 //
 // It is vocabulary and rules only, in the shape internal/userjob uses for stages: no
 // database access, so every caller can validate before it writes and the rules are

--- a/internal/inbox/ledger.go
+++ b/internal/inbox/ledger.go
@@ -1,0 +1,51 @@
+package inbox
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/strelov1/freehire/internal/appevent"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// EventRecorder is the pair of statements the ledger reconcile needs, and nothing else. Both
+// *db.Queries and a WithTx copy of it satisfy this, which is what lets the interactive paths and
+// the classification worker — one best-effort, one inside a transaction — share the rule.
+type EventRecorder interface {
+	RetractSupersededEmailEvent(ctx context.Context, arg db.RetractSupersededEmailEventParams) (int64, error)
+	RecordEmailApplicationEvent(ctx context.Context, arg db.RecordEmailApplicationEventParams) error
+}
+
+// ReconcileMailEvent brings the employer-reply ledger in line with one message's current link.
+//
+// ORDER IS THE RULE: the retraction must land before the insert. Both statements are
+// data-modifying CTEs, so they read the same pre-statement snapshot — run the other way round,
+// the insert's conflict check still sees the superseded row as live and the message ends up with
+// two live events, or none.
+//
+// It lives here rather than at each call site because it had two implementations: this one and a
+// copy inside cmd/classify-mail, the highest-volume writer of employer_reply events and the one
+// furthest from the rule's documentation — where no domain package's tests could reach it. Three
+// separate comments asserted the rule had "one home" while it had two.
+//
+// The error is returned rather than handled: the callers genuinely differ. The interactive paths
+// are best-effort — the mutation the user asked for has already succeeded, and the reconcile is
+// idempotent, so the next mutation or the backfill carries it out — while the worker propagates
+// it to roll back the transaction that persisted the link.
+func ReconcileMailEvent(ctx context.Context, q EventRecorder, userID, emailID int64, mailSource string) error {
+	source, err := appevent.SourceForMail(mailSource)
+	if err != nil {
+		return fmt.Errorf("ledger source: %w", err)
+	}
+	if _, err := q.RetractSupersededEmailEvent(ctx, db.RetractSupersededEmailEventParams{
+		ID: emailID, UserID: userID,
+	}); err != nil {
+		return fmt.Errorf("retract superseded event: %w", err)
+	}
+	if err := q.RecordEmailApplicationEvent(ctx, db.RecordEmailApplicationEventParams{
+		ID: emailID, UserID: userID, EventSource: source,
+	}); err != nil {
+		return fmt.Errorf("record reply event: %w", err)
+	}
+	return nil
+}

--- a/internal/inbox/ledger_test.go
+++ b/internal/inbox/ledger_test.go
@@ -1,0 +1,86 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// recordingLedger notes the order the two statements ran in, which is the whole invariant.
+type recordingLedger struct {
+	calls       []string
+	retractErr  error
+	recordErr   error
+	gotUserID   int64
+	gotEmailID  int64
+	gotSource   string
+	retractSeen db.RetractSupersededEmailEventParams
+}
+
+func (r *recordingLedger) RetractSupersededEmailEvent(_ context.Context, arg db.RetractSupersededEmailEventParams) (int64, error) {
+	r.calls = append(r.calls, "retract")
+	r.retractSeen = arg
+	return 0, r.retractErr
+}
+
+func (r *recordingLedger) RecordEmailApplicationEvent(_ context.Context, arg db.RecordEmailApplicationEventParams) error {
+	r.calls = append(r.calls, "record")
+	r.gotUserID, r.gotEmailID, r.gotSource = arg.UserID, arg.ID, arg.EventSource
+	return r.recordErr
+}
+
+// The ordering IS the rule. Both statements are data-modifying CTEs reading the same
+// pre-statement snapshot, so an insert that runs first still sees the superseded row as live —
+// leaving the message with two live events or none. The rule was documented in three places and
+// implemented in two, and neither copy was covered by a test: the worker's lived in a cmd/ main,
+// outside every domain package's test surface.
+func TestReconcileMailEventRetractsBeforeItRecords(t *testing.T) {
+	var q recordingLedger
+
+	if err := ReconcileMailEvent(context.Background(), &q, 7, 42, "gmail"); err != nil {
+		t.Fatalf("ReconcileMailEvent: %v", err)
+	}
+
+	if got := strings.Join(q.calls, ","); got != "retract,record" {
+		t.Errorf("statement order = %q, want \"retract,record\" — an insert that runs first sees "+
+			"the superseded row as live", got)
+	}
+	if q.retractSeen.ID != 42 || q.retractSeen.UserID != 7 {
+		t.Errorf("retract addressed (id=%d,user=%d), want (42,7)", q.retractSeen.ID, q.retractSeen.UserID)
+	}
+	if q.gotEmailID != 42 || q.gotUserID != 7 || q.gotSource == "" {
+		t.Errorf("record addressed (id=%d,user=%d,source=%q), want (42,7,non-empty)",
+			q.gotEmailID, q.gotUserID, q.gotSource)
+	}
+}
+
+// A failed retraction must stop the reconcile. Recording anyway would insert alongside a
+// superseded row nobody retracted — the two-live-events state the ordering exists to prevent.
+func TestReconcileMailEventStopsWhenTheRetractionFails(t *testing.T) {
+	q := recordingLedger{retractErr: errors.New("deadlock detected")}
+
+	err := ReconcileMailEvent(context.Background(), &q, 7, 42, "gmail")
+	if err == nil {
+		t.Fatal("a failed retraction was not reported")
+	}
+	if got := strings.Join(q.calls, ","); got != "retract" {
+		t.Errorf("calls = %q, want only \"retract\" — recording after a failed retraction leaves "+
+			"two live events", got)
+	}
+}
+
+// An unknown mail source is rejected before either statement runs, so a bad source cannot
+// half-apply the reconcile.
+func TestReconcileMailEventRejectsAnUnknownSourceBeforeWriting(t *testing.T) {
+	var q recordingLedger
+
+	if err := ReconcileMailEvent(context.Background(), &q, 7, 42, "carrier-pigeon"); err == nil {
+		t.Fatal("an unknown mail source was accepted")
+	}
+	if len(q.calls) != 0 {
+		t.Errorf("calls = %v, want none before the source is validated", q.calls)
+	}
+}

--- a/internal/inbox/mutate.go
+++ b/internal/inbox/mutate.go
@@ -192,23 +192,8 @@ func (s *Service) mutate(ctx context.Context, userID, id int64, do func() (int64
 // primary result. A failure here is logged, never surfaced — the reconcile is idempotent
 // and the next mutation, or the backfill, will carry it out.
 func (s *Service) syncLedger(ctx context.Context, userID, id int64, mailSource string) {
-	source, err := appevent.SourceForMail(mailSource)
-	if err != nil {
+	if err := ReconcileMailEvent(ctx, s.q, userID, id, mailSource); err != nil {
 		log.Printf("inbox: ledger sync user=%d email=%d: %v", userID, id, err)
-		return
-	}
-	// Order matters: the retraction must land before the insert, or the insert's
-	// conflict check still sees the superseded row as live. See the query comments.
-	if _, err := s.q.RetractSupersededEmailEvent(ctx, db.RetractSupersededEmailEventParams{
-		ID: id, UserID: userID,
-	}); err != nil {
-		log.Printf("inbox: ledger retract user=%d email=%d: %v", userID, id, err)
-		return
-	}
-	if err := s.q.RecordEmailApplicationEvent(ctx, db.RecordEmailApplicationEventParams{
-		ID: id, UserID: userID, EventSource: source,
-	}); err != nil {
-		log.Printf("inbox: ledger record user=%d email=%d: %v", userID, id, err)
 	}
 }
 

--- a/openspec/changes/one-ledger-reconcile/.openspec.yaml
+++ b/openspec/changes/one-ledger-reconcile/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/one-ledger-reconcile/proposal.md
+++ b/openspec/changes/one-ledger-reconcile/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The employer-reply ledger reconcile is a two-statement **ordering** rule: the retraction must
+land before the insert. Both statements are data-modifying CTEs, so they read the same
+pre-statement snapshot — run the other way round, the insert's conflict check still sees the
+superseded row as live and the message ends with two live events or none.
+
+That rule was documented in three places as having one home, and implemented in two. The second
+copy sat in `cmd/classify-mail` — the highest-volume writer of `employer_reply` events, the one
+furthest from the rule's documentation, and the one **outside every domain package's test
+surface**. Neither copy had a test for the ordering at all.
+
+Unlike S17, the two implementations really were identical: same three steps, same order, same
+parameters. Verified by comparison before extracting, because the previous finding of this shape
+turned out to have it backwards.
+
+## What Changes
+
+- `inbox.ReconcileMailEvent(ctx, q EventRecorder, userID, emailID int64, mailSource string) error`
+  holds the rule. `EventRecorder` is the two-method pair `*db.Queries` and a `WithTx` copy both
+  satisfy, which is what lets a best-effort caller and a transactional one share it.
+- `inbox.syncLedger` collapses to a call plus a log line; `cmd/classify-mail` calls the same
+  function inside its transaction. The error is returned rather than handled, because the callers
+  genuinely differ — one is best-effort and idempotent, the other must roll back.
+- **Three tests, none of which existed:** the statements run retract-then-record; a failed
+  retraction stops the reconcile rather than recording alongside a row nobody retracted; an
+  unknown mail source is rejected before either statement runs. The ordering test was verified to
+  fire by swapping the two statements.
+- Two docs that asserted the opposite are corrected: `docs/agents/mail-stack.md` said "one
+  reconcile with five callers" (there were two implementations and six callers), and
+  `internal/appevent`'s package doc named `internal/maillink` as a recording path — it does not
+  reference `appevent` at all.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. The same two statements run in the same order
+with the same parameters; `tasks.md` is the real artifact and the change archives with
+`--skip-specs`.
+
+## Impact
+
+- `internal/inbox` (a new `ledger.go` + tests), `internal/inbox/mutate.go`,
+  `cmd/classify-mail/store.go`, `internal/appevent/appevent.go`, `docs/agents/mail-stack.md`.
+- `cmd/classify-mail` gains an `internal/inbox` import. That is the right direction: a `cmd/`
+  binary depending on a domain package is how every other worker is built, and it is what moved
+  the rule inside a test surface.

--- a/openspec/changes/one-ledger-reconcile/tasks.md
+++ b/openspec/changes/one-ledger-reconcile/tasks.md
@@ -1,0 +1,33 @@
+## 1. Confirm they really are the same
+
+- [x] 1.1 Compare the two implementations step by step before extracting — the previous finding
+      of this shape (S17) had the drift backwards, and deleting the "copy" would have kept live
+      defects.
+- [x] 1.2 Record the one genuine difference: error semantics, which the extraction must preserve
+      rather than unify.
+
+## 2. One home, with the interface that already existed
+
+- [x] 2.1 `inbox.ReconcileMailEvent` over an `EventRecorder` pair that `*db.Queries` and a
+      `WithTx` copy both satisfy. Return the error; let each caller decide.
+- [x] 2.2 `syncLedger` becomes a call plus a log; the worker calls it inside its transaction and
+      drops its now-unused `appevent` import.
+
+## 3. Test the rule, not the plumbing
+
+- [x] 3.1 The statements run retract-then-record. Verify the test fires by swapping them.
+- [x] 3.2 A failed retraction stops the reconcile — recording anyway is the two-live-events state
+      the ordering exists to prevent.
+- [x] 3.3 An unknown mail source is rejected before either statement runs.
+
+## 4. Correct the docs that asserted the opposite
+
+- [x] 4.1 `docs/agents/mail-stack.md` — "one reconcile with five callers" was neither: two
+      implementations, six callers.
+- [x] 4.2 `internal/appevent` named `internal/maillink` as a recording path; it does not
+      reference the package.
+
+## 5. Verify and close
+
+- [x] 5.1 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 5.2 Mark S18 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
S18 from the 2026-08-01 architecture review.

The employer-reply ledger reconcile is a two-statement **ordering** rule: the retraction must land
before the insert. Both are data-modifying CTEs reading the same pre-statement snapshot, so run
the other way round the insert's conflict check still sees the superseded row as live — leaving
the message with two live events, or none.

That rule was documented in three places as having *one home*, and implemented in **two**. The
second copy sat in `cmd/classify-mail`: the highest-volume writer of `employer_reply` events, the
one furthest from the rule's documentation, and **outside every domain package's test surface**.
Neither copy had a test for the ordering.

## Checked before extracting, not after

S17 — the previous finding of this exact shape — turned out to have its drift backwards, and
deleting the "copy" on the review's reading would have kept four live defects in a paying path.
So I compared these two step by step first.

They really are identical: same three steps, same order, same parameters. The only genuine
difference is error semantics, and the extraction preserves it rather than unifying it.

## The fix

`inbox.ReconcileMailEvent(ctx, q EventRecorder, userID, emailID int64, mailSource string) error`,
over the two-method pair that `*db.Queries` and a `WithTx` copy both satisfy — which is precisely
what lets a best-effort caller and a transactional one share the rule. The error is **returned**,
not handled: the inbox's paths are best-effort (the mutation the user asked for already succeeded,
and the reconcile is idempotent), while the worker propagates it to roll back the transaction that
persisted the link.

## Three tests, none of which existed

- the statements run retract-then-record — **verified to fire** by swapping them:
  ```
  statement order = "record,retract", want "retract,record" —
  an insert that runs first sees the superseded row as live
  ```
- a failed retraction stops the reconcile, rather than recording alongside a row nobody
  retracted — the two-live-events state the ordering exists to prevent;
- an unknown mail source is rejected before either statement runs.

## Two docs that asserted the opposite

`docs/agents/mail-stack.md` said "the rule is one reconcile with five callers". It was neither:
two implementations, six callers. `internal/appevent`'s package doc named `internal/maillink` as
a recording path — `maillink` does not reference `appevent` at all.

No behaviour change: the same two statements run in the same order with the same parameters.
`go test ./...` **and** `go test -tags=integration ./...` green.
