### PR TITLE
Delete the profile composer nothing called

### DIFF
--- a/internal/experience/professional.go
+++ b/internal/experience/professional.go
@@ -14,7 +14,22 @@ import (
 // about résumés.
 
 // Professional composes the owner's de-identified candidate profile: work history from the
-// bank, everything else from the structured résumé.
+// bank, everything else from the structured résumé. It is what the fit chain scores and what
+// an API-key caller reads.
+//
+// The division is the point. Work history comes from the bank, which accumulates — so evidence
+// a candidate confirmed in a chat, and that appears in no uploaded file, is scored by the fit
+// chain and seeded into their next CV. Education, languages, the summary and the years estimate
+// keep coming from the structure, which owns them and has no accumulation problem.
+//
+// The structure's OWN experience is ignored rather than used as a fallback. A bank that failed
+// to seed produces no work history, and the fit chain treats that as "no analysis" — the correct
+// degradation: scoring a candidate against a work history nothing owns is worse than not scoring
+// them.
+//
+// Contacts never cross over. The projection's field set stays the whitelist
+// resumeextract.Professional already defines, so a field added there is withheld until it is
+// added deliberately.
 func (s *Store) Professional(ctx context.Context, userID int64, st resumeextract.Structured) (resumeextract.Professional, error) {
 	history, err := s.WorkHistory(ctx, userID)
 	if err != nil {
@@ -37,28 +52,6 @@ func (s *Store) WorkHistory(ctx context.Context, userID int64) ([]resumeextract.
 		return nil, err
 	}
 	return experienceFromBank(employments, atoms), nil
-}
-
-// ProfessionalFrom builds the candidate profile from a bank and a structured résumé.
-//
-// The division is the point of the whole change. Work history comes from the bank, which
-// accumulates — so evidence a candidate confirmed in a chat, and that appears in no
-// uploaded file, is scored by the fit chain and seeded into their next CV. Education,
-// languages, the summary and the years estimate keep coming from the structure, which owns
-// them and has no accumulation problem.
-//
-// The structure's OWN experience is ignored rather than used as a fallback. A bank that
-// failed to seed produces no work history, and the fit chain treats that as "no analysis"
-// — which is the correct degradation: scoring a candidate against a work history nothing
-// owns is worse than not scoring them.
-//
-// Contacts never cross over. The projection's field set stays the whitelist
-// resumeextract.Professional already defines, so a field added there is withheld until it
-// is added deliberately.
-func ProfessionalFrom(st resumeextract.Structured, employments []Employment, atoms []Atom) resumeextract.Professional {
-	out := st.Professional()
-	out.Experience = experienceFromBank(employments, atoms)
-	return out
 }
 
 // experienceFromBank renders the bank as work-history entries, in the order the store

--- a/internal/experience/professional_test.go
+++ b/internal/experience/professional_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/strelov1/freehire/internal/resumeextract"
 )
 
@@ -26,17 +28,55 @@ func structuredWithoutExperience() resumeextract.Structured {
 	}
 }
 
-func TestProfessionalFromTakesExperienceFromTheBank(t *testing.T) {
-	employments := []Employment{{
+// seedBank fills a fresh store with the owner's employments and atoms and returns the store,
+// so these tests exercise the live composition — Store.Professional — rather than a
+// parameter-taking twin of it. Each atom's EmploymentID is an INDEX into employments, or -1 for
+// evidence with no place, because the ids are the store's to mint.
+func seedBank(t *testing.T, employments []Employment, atoms []Atom, placeOf []int) *Store {
+	t.Helper()
+	s, _ := newStore()
+	ctx := context.Background()
+
+	ids := make([]uuid.UUID, len(employments))
+	for i, e := range employments {
+		created, err := s.CreateEmployment(ctx, owner, e)
+		if err != nil {
+			t.Fatalf("CreateEmployment: %v", err)
+		}
+		ids[i] = created.ID
+	}
+	for i, a := range atoms {
+		if place := placeOf[i]; place >= 0 {
+			a.EmploymentID = &ids[place]
+		}
+		if _, err := s.AddAtom(ctx, owner, a); err != nil {
+			t.Fatalf("AddAtom: %v", err)
+		}
+	}
+	return s
+}
+
+// professionalOf is the assertion subject of every test below: the live path the fit chain and
+// the profile read both take.
+func professionalOf(t *testing.T, s *Store) resumeextract.Professional {
+	t.Helper()
+	got, err := s.Professional(context.Background(), owner, structuredWithoutExperience())
+	if err != nil {
+		t.Fatalf("Professional: %v", err)
+	}
+	return got
+}
+
+func TestProfessionalTakesExperienceFromTheBank(t *testing.T) {
+	s := seedBank(t, []Employment{{
 		Kind: KindJob, Company: "RingCentral", Role: "Senior Software Engineer",
 		Location: "USA, Remote", Start: "2023-09", End: "Present", Current: true,
 		Summary: "Global SaaS leader", Stack: []string{"go", "mongodb"},
-	}}
-	atoms := []Atom{{
-		EmploymentID: &employments[0].ID, Claim: "Cut latency 20s to 1s", Provenance: ProvenanceCVImport,
-	}}
+	}}, []Atom{
+		{Claim: "Cut latency 20s to 1s", Provenance: ProvenanceCVImport},
+	}, []int{0})
 
-	got := ProfessionalFrom(structuredWithoutExperience(), employments, atoms)
+	got := professionalOf(t, s)
 
 	if len(got.Experience) != 1 {
 		t.Fatalf("experience = %+v, want the bank's single role", got.Experience)
@@ -54,8 +94,8 @@ func TestProfessionalFromTakesExperienceFromTheBank(t *testing.T) {
 }
 
 // The non-experience sections have no home in the bank and keep coming from the structure.
-func TestProfessionalFromKeepsTheStructuresOtherSections(t *testing.T) {
-	got := ProfessionalFrom(structuredWithoutExperience(), nil, nil)
+func TestProfessionalKeepsTheStructuresOtherSections(t *testing.T) {
+	got := professionalOf(t, seedBank(t, nil, nil, nil))
 
 	if got.Headline != "Senior Backend Engineer" || got.Summary == "" || got.TotalYears != 14 {
 		t.Errorf("headline/summary/years lost: %+v", got)
@@ -67,8 +107,8 @@ func TestProfessionalFromKeepsTheStructuresOtherSections(t *testing.T) {
 
 // The whole point of the contact-free projection: identity never crosses over, and the
 // composition must not reopen the hole the whitelist closed.
-func TestProfessionalFromCarriesNoContacts(t *testing.T) {
-	got := ProfessionalFrom(structuredWithoutExperience(), nil, nil)
+func TestProfessionalCarriesNoContacts(t *testing.T) {
+	got := professionalOf(t, seedBank(t, nil, nil, nil))
 
 	rendered := got.Headline + got.Summary + strings.Join(got.Languages, " ")
 	for _, contact := range []string{"Ilya Strelov", "someone@example.test", "+00 000", "https://example.test"} {
@@ -80,14 +120,13 @@ func TestProfessionalFromCarriesNoContacts(t *testing.T) {
 
 // An agent's own inference is not evidence the candidate stands behind, so it must not
 // reach the model that scores their fit — nor any CV composed from this projection.
-func TestProfessionalFromWithholdsUnpublishableAtoms(t *testing.T) {
-	employments := []Employment{{Kind: KindJob, Company: "RingCentral", Role: "SWE"}}
-	atoms := []Atom{
-		{EmploymentID: &employments[0].ID, Claim: "Confirmed achievement", Provenance: ProvenanceStatedInChat},
-		{EmploymentID: &employments[0].ID, Claim: "The agent's guess", Provenance: ProvenanceAgentInferred},
-	}
+func TestProfessionalWithholdsUnpublishableAtoms(t *testing.T) {
+	s := seedBank(t, []Employment{{Kind: KindJob, Company: "RingCentral", Role: "SWE"}}, []Atom{
+		{Claim: "Confirmed achievement", Provenance: ProvenanceStatedInChat},
+		{Claim: "The agent's guess", Provenance: ProvenanceAgentInferred},
+	}, []int{0, 0})
 
-	got := ProfessionalFrom(structuredWithoutExperience(), employments, atoms)
+	got := professionalOf(t, s)
 
 	highlights := got.Experience[0].Highlights
 	if len(highlights) != 1 || highlights[0] != "Confirmed achievement" {
@@ -98,10 +137,12 @@ func TestProfessionalFromWithholdsUnpublishableAtoms(t *testing.T) {
 // Evidence with no place is still evidence. Dropping it would defeat the change's whole
 // claim — that the fit analysis begins to see what a candidate confirmed in chat — so it
 // is carried in an entry that names no place rather than a fabricated one.
-func TestProfessionalFromCarriesPlacelessEvidence(t *testing.T) {
-	atoms := []Atom{{Claim: "AWS Certified Solutions Architect", Provenance: ProvenanceStatedInChat}}
+func TestProfessionalCarriesPlacelessEvidence(t *testing.T) {
+	s := seedBank(t, nil, []Atom{
+		{Claim: "AWS Certified Solutions Architect", Provenance: ProvenanceStatedInChat},
+	}, []int{-1})
 
-	got := ProfessionalFrom(structuredWithoutExperience(), nil, atoms)
+	got := professionalOf(t, s)
 
 	if len(got.Experience) != 1 {
 		t.Fatalf("experience = %+v, want the placeless evidence carried", got.Experience)
@@ -117,10 +158,10 @@ func TestProfessionalFromCarriesPlacelessEvidence(t *testing.T) {
 
 // A role the bank holds with no evidence under it is still career history the fit chain
 // should see — a person's job titles matter even before their bullets do.
-func TestProfessionalFromKeepsARoleWithNoAtoms(t *testing.T) {
-	employments := []Employment{{Kind: KindJob, Company: "Sber", Role: "Team Lead"}}
+func TestProfessionalKeepsARoleWithNoAtoms(t *testing.T) {
+	s := seedBank(t, []Employment{{Kind: KindJob, Company: "Sber", Role: "Team Lead"}}, nil, nil)
 
-	got := ProfessionalFrom(structuredWithoutExperience(), employments, nil)
+	got := professionalOf(t, s)
 
 	if len(got.Experience) != 1 || got.Experience[0].Company != "Sber" {
 		t.Errorf("experience = %+v, want the role kept even with no highlights", got.Experience)
@@ -130,8 +171,8 @@ func TestProfessionalFromKeepsARoleWithNoAtoms(t *testing.T) {
 // An empty bank yields no experience at all rather than falling back to the structure's
 // copy. The fit chain treats that as "no analysis", which is the correct degradation:
 // scoring a candidate on a work history nothing owns is worse than not scoring them.
-func TestProfessionalFromDoesNotFallBackToTheStructure(t *testing.T) {
-	got := ProfessionalFrom(structuredWithoutExperience(), nil, nil)
+func TestProfessionalDoesNotFallBackToTheStructure(t *testing.T) {
+	got := professionalOf(t, seedBank(t, nil, nil, nil))
 
 	if len(got.Experience) != 0 {
 		t.Errorf("experience = %+v, want none — the structure's copy is not a fallback", got.Experience)

--- a/internal/resumeextract/AGENTS.md
+++ b/internal/resumeextract/AGENTS.md
@@ -23,7 +23,7 @@ Best-effort, read-only LLM parse of the stored user CV into a typed `Structured`
   (`cmd/backfill-resume-geo`, database-only), so a dictionary change reaches existing users.
 - **Deletion clears the columns** (`ClearUserResume`), geography included.
 - **No new env** — reuses `LLM_*`.
-- **The fit analysis reads a COMPOSITION, not this shape alone:** `experience.ProfessionalFrom` takes the work history from the bank and everything else from here, and that is the only candidate text `matchanalysis` sends. An empty bank means no analysis; a stale structure now costs education and languages rather than the whole thing. There is still deliberately no raw-CV fallback, and there is deliberately no fallback to this package's own copy of the experience either — a silent one would hide a failed backfill for months.
+- **The fit analysis reads a COMPOSITION, not this shape alone:** `experience.Store.Professional` takes the work history from the bank and everything else from here, and that is the only candidate text `matchanalysis` sends. (It named `ProfessionalFrom` until 2026-08-01 — a second implementation of the same composition that no production path called.) An empty bank means no analysis; a stale structure now costs education and languages rather than the whole thing. There is still deliberately no raw-CV fallback, and there is deliberately no fallback to this package's own copy of the experience either — a silent one would hide a failed backfill for months.
 
 ## How it works
 

--- a/openspec/changes/drop-the-dead-profile-composer/.openspec.yaml
+++ b/openspec/changes/drop-the-dead-profile-composer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/drop-the-dead-profile-composer/proposal.md
+++ b/openspec/changes/drop-the-dead-profile-composer/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`experience.ProfessionalFrom` is an exported function with a sixteen-line doc comment defending
+its design and seven dedicated tests — and **no production caller**. Verified by repo-wide grep:
+the only references were its own declaration and its own tests.
+
+It duplicates `Store.Professional`'s composition, so a change to how the candidate profile is
+assembled had two places to land, and one of them was exercised only by tests that would keep
+passing either way. `internal/resumeextract/AGENTS.md` — the file a reader consults first to
+answer "what does the fit chain send?" — pointed at the dead one.
+
+## What Changes
+
+- `ProfessionalFrom` is deleted.
+- **Its rationale is not.** The sixteen lines explaining why work history comes from the bank,
+  why the structure's own experience is ignored rather than used as a fallback, and why contacts
+  never cross over move onto `Store.Professional`, which is the path that actually runs them.
+- Its seven tests move to `Store.Professional` rather than to `experienceFromBank`. That is
+  strictly more coverage than they had: the assertions now run through the store reads the live
+  path makes, not around them. Two small helpers keep them readable — atoms name their employment
+  by index, because the ids are the store's to mint.
+- `internal/resumeextract/AGENTS.md` names `experience.Store.Professional`, and records that it
+  said otherwise until today, so the next reader knows the old name was not simply renamed.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. Nothing called the deleted function;
+`tasks.md` is the real artifact and the change archives with `--skip-specs`.
+
+## Impact
+
+- `internal/experience/professional.go` (−22 lines of function, +14 of relocated rationale),
+  `internal/experience/professional_test.go`, `internal/resumeextract/AGENTS.md`.

--- a/openspec/changes/drop-the-dead-profile-composer/tasks.md
+++ b/openspec/changes/drop-the-dead-profile-composer/tasks.md
@@ -1,0 +1,28 @@
+## 1. Confirm it is really dead
+
+- [x] 1.1 Repo-wide grep for every reference, including docs — declaration plus seven test call
+      sites, no `cmd/` or `internal/` non-test caller.
+
+## 2. Delete the function, keep what it knew
+
+- [x] 2.1 Move the rationale onto `Store.Professional`: the bank/structure division, the
+      deliberate absence of a fallback, and the contact whitelist. Deleting the function must not
+      delete the reasoning — that is the part a future reader needs.
+- [x] 2.2 Delete `ProfessionalFrom`.
+
+## 3. Re-point the tests at the live path
+
+- [x] 3.1 To `Store.Professional`, not `experienceFromBank`: the seven rules are worth asserting
+      through the store reads the fit chain actually makes.
+- [x] 3.2 A `seedBank` helper where atoms name their employment by INDEX, since the store mints
+      the ids — and a `professionalOf` helper so each test reads as one assertion.
+
+## 4. Fix the doc that pointed at the dead one
+
+- [x] 4.1 `internal/resumeextract/AGENTS.md` names `Store.Professional`, and says what the old
+      name was, so this does not read as a rename.
+
+## 5. Verify and close
+
+- [x] 5.1 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 5.2 Mark S19 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
S19 from the 2026-08-01 architecture review.

`experience.ProfessionalFrom` was an exported function with a **sixteen-line doc comment
defending its design** and **seven dedicated tests** — and no production caller. Verified by
repo-wide grep: its own declaration and its own tests, nothing else.

It duplicated `Store.Professional`'s composition, so a change to how the candidate profile is
assembled had two places to land and one of them was exercised only by tests that would keep
passing either way. `internal/resumeextract/AGENTS.md` — the file a reader consults first to
answer *"what does the fit chain send?"* — pointed at the dead one.

## The function goes; what it knew does not

The sixteen lines are the valuable part: why work history comes from the bank (it accumulates, so
evidence confirmed in a chat and present in no file still reaches the fit chain), why the
structure's own experience is ignored **rather than used as a fallback** (scoring a candidate
against a work history nothing owns is worse than not scoring them), and why contacts never cross
over. They move onto `Store.Professional`, which is the path that actually runs them.

Deleting a function should not delete its reasoning.

## The tests move to the live path, not to the helper

The remedy offered `experienceFromBank` as the easier target. `Store.Professional` is the better
one: the seven rules are worth asserting **through the store reads the fit chain actually makes**
rather than around them, and a `newStore()` helper over a fake repo already existed.

Two small helpers keep them readable — `seedBank` takes atoms that name their employment by
INDEX, because the ids are the store's to mint, and `professionalOf` makes each test one
assertion.

Net: seven tests that exercised a dead twin now exercise the live composition.

## Doc

`internal/resumeextract/AGENTS.md` names `experience.Store.Professional`, and records that it said
otherwise until today — so the next reader knows this was a deletion, not a rename.

No behaviour change: nothing called the deleted function. `go test ./...` **and**
`go test -tags=integration ./...` green.
