### PR TITLE
feat: a calendar of what happened to your applications

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -2,7 +2,7 @@
   "Alert": 0,
   "Avatar": 0,
   "Badge": 12,
-  "Button": 49,
+  "Button": 50,
   "Card": 0,
   "Chip": 0,
   "Dialog": 4,

--- a/docs/API.md
+++ b/docs/API.md
@@ -1298,7 +1298,7 @@ The application-event ledger as a dated series, oldest first: applications sent,
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `from` | string (RFC3339) | yes | Lower bound, inclusive. (e.g. `2026-08-01T00:00:00Z`) |
+| `from` | string (RFC3339) | yes | Lower bound, inclusive. Use `Z`, or percent-encode a numeric offset — a bare `+` decodes as a space in a query string and will be rejected. (e.g. `2026-08-01T00:00:00Z`) |
 | `to` | string (RFC3339) | yes | Upper bound, inclusive. (e.g. `2026-08-31T23:59:59Z`) |
 
 ```bash

--- a/docs/API.md
+++ b/docs/API.md
@@ -92,7 +92,7 @@ Every facet below supports repeat-OR, `_mode=and`, and `_exclude` as described a
 
 | Param | Filter | Values |
 | --- | --- | --- |
-| `collections` | Collection | yc, techstars, european, ai, mag7, bigtech, unicorn, fortune500, eastern-roots, ai-native |
+| `collections` | Collection | yc, techstars, a16z-portfolio, a16z-speedrun, european, ai, mag7, bigtech, unicorn, fortune500, eastern-roots, ai-native, uk-skilled-worker-sponsor, nl-recognised-sponsor |
 | `regions` | Region | global, north_america, latam, eu, uk, mena, africa, apac, cis, none |
 | `work_mode` | Work format | remote, hybrid, onsite |
 | `is_tech` | Tech / Non-tech | tech, non_tech |
@@ -1283,6 +1283,57 @@ curl "https://freehire.me/api/v1/me/tracking/swipe" -H "Authorization: Bearer $F
 {
   "data": [ { "public_slug": "...", "title": "Senior Go Engineer", "...": "..." } ],
   "meta": { "total": 137, "limit": 20, "offset": 0 }
+}
+```
+
+### `GET /me/timeline`
+
+**Auth:** Session or API key
+
+What happened to your applications over a date range.
+
+The application-event ledger as a dated series, oldest first: applications sent, employer replies, follow-ups and stage changes. `occurred_at` is an instant, not a day — which day it falls on depends on your timezone, so group it client-side. `observed` says whether the date came from a source other than you: mail-derived events carry a date the employer set, while a stage you set yourself is dated from when you recorded it. `email_id` and `email_subject` are present only while the message exists; deleting it hides the content and leaves the event standing. Both bounds are required and may span at most 366 days.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `from` | string (RFC3339) | yes | Lower bound, inclusive. (e.g. `2026-08-01T00:00:00Z`) |
+| `to` | string (RFC3339) | yes | Upper bound, inclusive. (e.g. `2026-08-31T23:59:59Z`) |
+
+```bash
+curl "https://freehire.me/api/v1/me/timeline?from=2026-08-01T00:00:00Z&to=2026-08-31T23:59:59Z" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{
+  "data": [
+    {
+      "id": 7,
+      "kind": "employer_reply",
+      "signal": "interview_invitation",
+      "source": "mail_gmail",
+      "observed": true,
+      "occurred_at": "2026-08-13T09:41:00Z",
+      "company_slug": "derq",
+      "role_title": "Senior Go Engineer",
+      "application_id": 31,
+      "job_slug": "senior-go-engineer-derq-1a2b",
+      "email_id": 42,
+      "email_subject": "Invitation to interview"
+    },
+    {
+      "id": 8,
+      "kind": "stage_set",
+      "signal": "screening",
+      "source": "user",
+      "observed": false,
+      "occurred_at": "2026-08-13T21:15:00Z",
+      "company_slug": "linear",
+      "application_id": 33
+    }
+  ],
+  "meta": { "from": "2026-08-01T00:00:00Z", "to": "2026-08-31T23:59:59Z", "count": 2 }
 }
 ```
 
@@ -2806,14 +2857,14 @@ curl "https://freehire.me/api/v1/stats/user-growth"
 
 **Auth:** Public
 
-Jobs saved, applied to and viewed across all users.
+Jobs saved, applied to and viewed across all users, plus CV and inbox usage.
 
 ```bash
 curl "https://freehire.me/api/v1/stats/engagement"
 ```
 
 ```json
-{ "data": { "saved": 41200, "applied": 18730, "viewed": 903400 } }
+{ "data": { "saved": 41200, "applied": 18730, "viewed": 903400, "cvs_uploaded": 2140, "cvs_tailored": 860, "match_analyses": 5310, "inboxes_connected": 410, "saved_searches": 1290 } }
 ```
 
 ### `GET /status`
@@ -3147,19 +3198,7 @@ curl -X PUT "https://freehire.me/api/v1/me/cvs/0f2c…" -b cookies.txt \
 
 Apply a batch of edits, addressed by path.
 
-An edit is a `kind` (`set`, `insert`, `remove`, `move`) and a `path` into the CV — `summary`,
-`experience[2].bullets[1]`, `skills[0].items[3]`, `education[1].degree`, `style.font_size`.
-Indices are 0-based. The four kinds reach every field of the document, and the whole batch is
-applied or none of it is: an unknown path or an index past the end refuses the request without
-touching the CV.
-
-An API key edits as the tailoring agent, which means two things. The candidate's own fields —
-`header.full_name`, `header.email`, `header.phone`, `header.links`, `title`, `template_id` — are
-refused with a 403. And an edit that states something about the candidate (a summary, a bullet,
-a technology, a skill) must carry `evidence_id` from the experience bank.
-
-Every request is recorded in the CV's history and can be undone on its own; see
-`GET /me/cvs/{id}/revisions`.
+An edit is a `kind` (`set`, `insert`, `remove`, `move`) and a `path` into the CV — `summary`, `experience[2].bullets[1]`, `skills[0].items[3]`, `style.font_size`. Indices are 0-based. The whole batch applies or none of it does: an unknown path or an index past the end refuses the request without touching the CV. An API key edits as the tailoring agent, so the candidate's own fields are refused and a claim about them needs `evidence_id` from the experience bank. Every request lands in the CV's history and can be undone on its own.
 
 **Path parameters**
 
@@ -3172,11 +3211,11 @@ Every request is recorded in the CV's history and can be undone on its own; see
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `ops` | object[] | yes | The edits, applied in order. |
-| `ops[].kind` | string | yes | `set`, `insert`, `remove` or `move`. |
-| `ops[].path` | string | yes | Where to edit (e.g. `experience[0].bullets[1]`). |
+| `ops[].kind` | string | yes | `set`, `insert`, `remove` or `move`. (e.g. `set`) |
+| `ops[].path` | string | yes | Where to edit. (e.g. `experience[0].bullets[1]`) |
 | `ops[].value` | any | no | The new content, for `set` and `insert`. |
 | `ops[].to` | integer | no | The element's new position, for `move`. |
-| `ops[].evidence_id` | string | no | The banked achievement this rests on. Required for a claim about the candidate when editing with an API key. |
+| `ops[].evidence_id` | string | no | The banked achievement this rests on. |
 | `note` | string | no | One line on why, shown beside the entry in the history. |
 
 ```bash

--- a/internal/apptimeline/apptimeline.go
+++ b/internal/apptimeline/apptimeline.go
@@ -98,6 +98,11 @@ func (s *Service) Range(ctx context.Context, userID int64, from, to time.Time) (
 		UserID: userID,
 		FromAt: pgtype.Timestamptz{Time: from, Valid: true},
 		ToAt:   pgtype.Timestamptz{Time: to, Valid: true},
+		// Which sources carry an emails.id in source_ref. Passed rather than written into
+		// the statement so the vocabulary stays here, beside the trust rule that reads it.
+		SrcGmail:    appevent.SourceMailGmail,
+		SrcHosted:   appevent.SourceMailHosted,
+		SrcExternal: appevent.SourceMailExternal,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/apptimeline/apptimeline.go
+++ b/internal/apptimeline/apptimeline.go
@@ -1,0 +1,124 @@
+// Package apptimeline reads the application-event ledger as a dated series: one caller's
+// events over a range, oldest first.
+//
+// It is the ledger's first dated reader. Until now the table was written by every path
+// that moves an application and read only by the per-company aggregate in insights.sql,
+// which groups by employer and never asks when.
+//
+// It is not a method on internal/jobtracking. That package is organised around mutations
+// of one (user, job) pair; this is a range read across every application a caller has,
+// joining two tables jobtracking never touches, with no mutation behind it.
+//
+// The rules live here rather than in the Fiber handler for the reason internal/inbox
+// states: the in-app assistant calls services directly with the session owner's id and
+// issues no HTTP request, so a rule enforced in a handler is a rule that reader never
+// meets. "What happened last month" is an obvious tool for it.
+package apptimeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/appevent"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// Queries is the slice of the store this package reaches.
+//
+// One statement, and deliberately no way to read a message. The subject arrives joined
+// onto the event; anything more would mean GET /me/emails/:id, which marks mail read —
+// and read_at means "a human saw this", not "a calendar was scrolled past this".
+type Queries interface {
+	ListApplicationEventsInRange(ctx context.Context, arg db.ListApplicationEventsInRangeParams) ([]db.ListApplicationEventsInRangeRow, error)
+}
+
+// MaxRangeDays caps one request at a year and a day — enough for any calendar span a
+// reader paints at once, including a leap year.
+//
+// The index (user_id, occurred_at) makes the scan cheap and per-user volumes are small,
+// so this is hygiene rather than a fix: an unbounded range over an append-only table is
+// the kind of thing that costs nothing now and something later.
+const MaxRangeDays = 366
+
+// ErrInvalidRange is a from/to pair the reader cannot answer for. Callers wrap it with
+// what was wrong; both readers need only to recognise it — the handler renders a 400,
+// the in-process caller a sentence.
+var ErrInvalidRange = errors.New("invalid range")
+
+// Event is one thing that happened to one application.
+//
+// Kind and Signal are values from the appevent and mailclassify vocabularies, carried as
+// they are rather than mapped onto a closed set here. application_events splits the two
+// precisely so a growing vocabulary is not a change to a table that must not change, and
+// a reader that enumerated today's kinds would put that cost back.
+//
+// The optional fields are zero when absent: an application whose posting cmd/prune has
+// removed has no JobSlug, an event the candidate recorded has no message, and a message
+// the candidate deleted lends neither EmailID nor EmailSubject while the event stands.
+type Event struct {
+	ID     int64
+	Kind   string
+	Signal string
+	Source string
+	// Observed is appevent's verdict on Source, resolved here so no reader has to hold a
+	// second copy of the trust rule.
+	Observed      bool
+	OccurredAt    time.Time
+	CompanySlug   string
+	RoleTitle     string
+	ApplicationID int64
+	JobSlug       string
+	EmailID       int64
+	EmailSubject  string
+}
+
+// Service is the ledger's dated read.
+type Service struct{ q Queries }
+
+// New builds the service.
+func New(q Queries) *Service { return &Service{q: q} }
+
+// Range returns the caller's live events between from and to inclusive, oldest first.
+func (s *Service) Range(ctx context.Context, userID int64, from, to time.Time) ([]Event, error) {
+	if from.IsZero() || to.IsZero() {
+		return nil, fmt.Errorf("%w: both bounds are required", ErrInvalidRange)
+	}
+	if to.Before(from) {
+		return nil, fmt.Errorf("%w: the upper bound precedes the lower one", ErrInvalidRange)
+	}
+	if to.Sub(from) > MaxRangeDays*24*time.Hour {
+		return nil, fmt.Errorf("%w: a range may span at most %d days", ErrInvalidRange, MaxRangeDays)
+	}
+
+	rows, err := s.q.ListApplicationEventsInRange(ctx, db.ListApplicationEventsInRangeParams{
+		UserID: userID,
+		FromAt: pgtype.Timestamptz{Time: from, Valid: true},
+		ToAt:   pgtype.Timestamptz{Time: to, Valid: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]Event, 0, len(rows))
+	for _, r := range rows {
+		events = append(events, Event{
+			ID:            r.ID,
+			Kind:          r.Kind,
+			Signal:        r.Signal,
+			Source:        r.Source,
+			Observed:      appevent.TrustedForDayMath(r.Source),
+			OccurredAt:    r.OccurredAt.Time,
+			CompanySlug:   r.CompanySlug,
+			RoleTitle:     r.RoleTitle.String,
+			ApplicationID: r.ApplicationID.Int64,
+			JobSlug:       r.JobSlug.String,
+			EmailID:       r.EmailID.Int64,
+			EmailSubject:  r.EmailSubject.String,
+		})
+	}
+	return events, nil
+}

--- a/internal/apptimeline/apptimeline_test.go
+++ b/internal/apptimeline/apptimeline_test.go
@@ -1,0 +1,112 @@
+package apptimeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/appevent"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// stubStore answers with a fixed set of rows, so the service's own rules — validation and
+// the observed verdict — are tested without a pool.
+type stubStore struct {
+	rows []db.ListApplicationEventsInRangeRow
+}
+
+func (s stubStore) ListApplicationEventsInRange(context.Context, db.ListApplicationEventsInRangeParams) ([]db.ListApplicationEventsInRangeRow, error) {
+	return s.rows, nil
+}
+
+func row(source string) db.ListApplicationEventsInRangeRow {
+	return db.ListApplicationEventsInRangeRow{
+		ID:         1,
+		Kind:       appevent.KindEmployerReply,
+		Source:     source,
+		OccurredAt: pgtype.Timestamptz{Time: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC), Valid: true},
+	}
+}
+
+// Every case here passes a nil store. Validation that reaches the database first is
+// validation the in-process caller pays for on every mistyped bound, and a panic here is
+// the proof that it did.
+func TestRangeRefusesBoundsItCannotAnswerFor(t *testing.T) {
+	day := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name     string
+		from, to time.Time
+	}{
+		{"no bounds at all", time.Time{}, time.Time{}},
+		{"no lower bound", time.Time{}, day},
+		{"no upper bound", day, time.Time{}},
+		{"inverted", day.AddDate(0, 0, 1), day},
+		{"longer than the cap", day, day.AddDate(0, 0, MaxRangeDays+1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := New(nil).Range(context.Background(), 1, tc.from, tc.to)
+			if !errors.Is(err, ErrInvalidRange) {
+				t.Errorf("Range(%v, %v) error = %v, want one wrapping ErrInvalidRange", tc.from, tc.to, err)
+			}
+		})
+	}
+}
+
+// The cap bounds one request, not the calendar: a month with a day of margin either side,
+// and a full year, both have to fit through it.
+func TestRangeAcceptsTheSpansTheCalendarAsksFor(t *testing.T) {
+	day := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	cases := map[string]time.Time{
+		"a single instant": day,
+		"a padded month":   day.AddDate(0, 1, 2),
+		"the cap exactly":  day.AddDate(0, 0, MaxRangeDays),
+	}
+	for name, to := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := New(stubStore{}).Range(context.Background(), 1, day, to); err != nil {
+				t.Errorf("Range over %s returned %v, want no error", name, err)
+			}
+		})
+	}
+}
+
+// The verdict must be appevent's, not a copy of it. A second list of trusted sources would
+// still call a newly added one observed after appevent had already refused it — and the
+// calendar draws that difference as the difference between a date somebody set and a date
+// the candidate typed. Iterating the whole vocabulary is what makes a hardcoded copy fail.
+func TestObservedIsAppeventsVerdictAndNotACopy(t *testing.T) {
+	for _, src := range appevent.Sources {
+		t.Run(src, func(t *testing.T) {
+			events, err := New(stubStore{rows: []db.ListApplicationEventsInRangeRow{row(src)}}).
+				Range(context.Background(), 1, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC))
+			if err != nil {
+				t.Fatalf("Range: %v", err)
+			}
+			if len(events) != 1 {
+				t.Fatalf("got %d events, want 1", len(events))
+			}
+			if got, want := events[0].Observed, appevent.TrustedForDayMath(src); got != want {
+				t.Errorf("Observed for source %q = %v, want %v", src, got, want)
+			}
+		})
+	}
+}
+
+// An unknown source is untrusted for the same reason appevent gives: unknown provenance
+// must never read as an observation. The calendar would otherwise draw it filled.
+func TestAnUnknownSourceIsNotObserved(t *testing.T) {
+	events, err := New(stubStore{rows: []db.ListApplicationEventsInRangeRow{row("mail_carrier_pigeon")}}).
+		Range(context.Background(), 1, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Range: %v", err)
+	}
+	if events[0].Observed {
+		t.Error("an event from an unrecognised source reported as observed")
+	}
+}

--- a/internal/db/application_events.sql.go
+++ b/internal/db/application_events.sql.go
@@ -80,30 +80,35 @@ func (q *Queries) BackfillEmployerReplyEvents(ctx context.Context, arg BackfillE
 
 const listApplicationEventsInRange = `-- name: ListApplicationEventsInRange :many
 SELECT ae.id, ae.kind, ae.signal, ae.source, ae.occurred_at, ae.company_slug,
-       ae.application_id, ae.job_id,
+       ae.application_id,
        a.role_title,
        j.public_slug AS job_slug,
        em.id         AS email_id,
        em.subject    AS email_subject
   FROM application_events ae
   LEFT JOIN applications a ON a.id = ae.application_id
+                          AND a.user_id = ae.user_id
   LEFT JOIN jobs j         ON j.id = ae.job_id
   LEFT JOIN emails em      ON em.id = ae.source_ref
                           AND em.user_id = ae.user_id
                           AND em.deleted_at IS NULL
+                          AND ae.source IN ($2, $3, $4)
  WHERE ae.user_id      = $1
    AND ae.retracted_at IS NULL
-   AND ae.occurred_at >= $2
-   AND ae.occurred_at <= $3
+   AND ae.occurred_at >= $5
+   AND ae.occurred_at <= $6
  -- id breaks the tie so a day's events keep a stable order between requests; two events
  -- sharing a timestamp is routine when a mailbox import lands a batch.
  ORDER BY ae.occurred_at, ae.id
 `
 
 type ListApplicationEventsInRangeParams struct {
-	UserID int64              `json:"user_id"`
-	FromAt pgtype.Timestamptz `json:"from_at"`
-	ToAt   pgtype.Timestamptz `json:"to_at"`
+	UserID      int64              `json:"user_id"`
+	SrcGmail    string             `json:"src_gmail"`
+	SrcHosted   string             `json:"src_hosted"`
+	SrcExternal string             `json:"src_external"`
+	FromAt      pgtype.Timestamptz `json:"from_at"`
+	ToAt        pgtype.Timestamptz `json:"to_at"`
 }
 
 type ListApplicationEventsInRangeRow struct {
@@ -114,7 +119,6 @@ type ListApplicationEventsInRangeRow struct {
 	OccurredAt    pgtype.Timestamptz `json:"occurred_at"`
 	CompanySlug   string             `json:"company_slug"`
 	ApplicationID pgtype.Int8        `json:"application_id"`
-	JobID         pgtype.Int8        `json:"job_id"`
 	RoleTitle     pgtype.Text        `json:"role_title"`
 	JobSlug       pgtype.Text        `json:"job_slug"`
 	EmailID       pgtype.Int8        `json:"email_id"`
@@ -138,8 +142,23 @@ type ListApplicationEventsInRangeRow struct {
 // the join rather than a filter on the result, so a deleted message yields NULL on both
 // columns while the event itself stands: deletion hides content, it does not un-happen
 // the reply. Reading a body instead would mean GET /me/emails/:id, which marks mail read.
+//
+// The join is restricted to mail-derived sources because source_ref names an emails.id
+// only for those — the column's comment in 0062 says so, and the idempotency index keys on
+// (user_id, kind, source_ref) precisely because the referent is namespaced per kind. On the
+// bare column, the next kind to carry a source_ref into some other table would be served
+// whichever of the caller's messages happened to share that id, and the calendar would
+// caption an interview with an unrelated rejection. The three names arrive as parameters
+// rather than being written here, so the vocabulary stays in Go where a pin test guards it.
 func (q *Queries) ListApplicationEventsInRange(ctx context.Context, arg ListApplicationEventsInRangeParams) ([]ListApplicationEventsInRangeRow, error) {
-	rows, err := q.db.Query(ctx, listApplicationEventsInRange, arg.UserID, arg.FromAt, arg.ToAt)
+	rows, err := q.db.Query(ctx, listApplicationEventsInRange,
+		arg.UserID,
+		arg.SrcGmail,
+		arg.SrcHosted,
+		arg.SrcExternal,
+		arg.FromAt,
+		arg.ToAt,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +174,6 @@ func (q *Queries) ListApplicationEventsInRange(ctx context.Context, arg ListAppl
 			&i.OccurredAt,
 			&i.CompanySlug,
 			&i.ApplicationID,
-			&i.JobID,
 			&i.RoleTitle,
 			&i.JobSlug,
 			&i.EmailID,

--- a/internal/db/application_events.sql.go
+++ b/internal/db/application_events.sql.go
@@ -7,6 +7,8 @@ package db
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const backfillEmployerReplyEvents = `-- name: BackfillEmployerReplyEvents :one
@@ -74,6 +76,99 @@ func (q *Queries) BackfillEmployerReplyEvents(ctx context.Context, arg BackfillE
 	var i BackfillEmployerReplyEventsRow
 	err := row.Scan(&i.LastID, &i.Scanned, &i.Inserted)
 	return i, err
+}
+
+const listApplicationEventsInRange = `-- name: ListApplicationEventsInRange :many
+SELECT ae.id, ae.kind, ae.signal, ae.source, ae.occurred_at, ae.company_slug,
+       ae.application_id, ae.job_id,
+       a.role_title,
+       j.public_slug AS job_slug,
+       em.id         AS email_id,
+       em.subject    AS email_subject
+  FROM application_events ae
+  LEFT JOIN applications a ON a.id = ae.application_id
+  LEFT JOIN jobs j         ON j.id = ae.job_id
+  LEFT JOIN emails em      ON em.id = ae.source_ref
+                          AND em.user_id = ae.user_id
+                          AND em.deleted_at IS NULL
+ WHERE ae.user_id      = $1
+   AND ae.retracted_at IS NULL
+   AND ae.occurred_at >= $2
+   AND ae.occurred_at <= $3
+ -- id breaks the tie so a day's events keep a stable order between requests; two events
+ -- sharing a timestamp is routine when a mailbox import lands a batch.
+ ORDER BY ae.occurred_at, ae.id
+`
+
+type ListApplicationEventsInRangeParams struct {
+	UserID int64              `json:"user_id"`
+	FromAt pgtype.Timestamptz `json:"from_at"`
+	ToAt   pgtype.Timestamptz `json:"to_at"`
+}
+
+type ListApplicationEventsInRangeRow struct {
+	ID            int64              `json:"id"`
+	Kind          string             `json:"kind"`
+	Signal        string             `json:"signal"`
+	Source        string             `json:"source"`
+	OccurredAt    pgtype.Timestamptz `json:"occurred_at"`
+	CompanySlug   string             `json:"company_slug"`
+	ApplicationID pgtype.Int8        `json:"application_id"`
+	JobID         pgtype.Int8        `json:"job_id"`
+	RoleTitle     pgtype.Text        `json:"role_title"`
+	JobSlug       pgtype.Text        `json:"job_slug"`
+	EmailID       pgtype.Int8        `json:"email_id"`
+	EmailSubject  pgtype.Text        `json:"email_subject"`
+}
+
+// One caller's live events over a date range, oldest first — the ledger's first dated
+// read, behind internal/apptimeline and the tracking calendar.
+//
+// Retracted rows are excluded here as they are in every other reader: a correction the
+// calendar still showed under the wrong employer would be a correction its author cannot
+// see they made.
+//
+// The employer is taken from the event's own denormalized slug, never through the posting.
+// cmd/prune clears job_id, and an event that had to join jobs for its company would drop
+// out of the range retroactively — the instability the ledger exists to remove. The
+// posting is joined only for the slug the SPA links with, and legitimately comes back
+// absent.
+//
+// The message is joined for its subject and nothing else. Its deletion is a condition OF
+// the join rather than a filter on the result, so a deleted message yields NULL on both
+// columns while the event itself stands: deletion hides content, it does not un-happen
+// the reply. Reading a body instead would mean GET /me/emails/:id, which marks mail read.
+func (q *Queries) ListApplicationEventsInRange(ctx context.Context, arg ListApplicationEventsInRangeParams) ([]ListApplicationEventsInRangeRow, error) {
+	rows, err := q.db.Query(ctx, listApplicationEventsInRange, arg.UserID, arg.FromAt, arg.ToAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListApplicationEventsInRangeRow{}
+	for rows.Next() {
+		var i ListApplicationEventsInRangeRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Kind,
+			&i.Signal,
+			&i.Source,
+			&i.OccurredAt,
+			&i.CompanySlug,
+			&i.ApplicationID,
+			&i.JobID,
+			&i.RoleTitle,
+			&i.JobSlug,
+			&i.EmailID,
+			&i.EmailSubject,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const recordEmailApplicationEvent = `-- name: RecordEmailApplicationEvent :exec

--- a/internal/db/application_timeline_integration_test.go
+++ b/internal/db/application_timeline_integration_test.go
@@ -41,9 +41,12 @@ func linkedReply(t *testing.T, q *Queries, userID, jobID int64, subject string, 
 func wideRange(t *testing.T, q *Queries, userID int64) []ListApplicationEventsInRangeRow {
 	t.Helper()
 	rows, err := q.ListApplicationEventsInRange(context.Background(), ListApplicationEventsInRangeParams{
-		UserID: userID,
-		FromAt: ts(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)),
-		ToAt:   ts(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)),
+		UserID:      userID,
+		FromAt:      ts(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)),
+		ToAt:        ts(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)),
+		SrcGmail:    "mail_gmail",
+		SrcHosted:   "mail_hosted",
+		SrcExternal: "mail_external",
 	})
 	if err != nil {
 		t.Fatalf("list events: %v", err)
@@ -102,6 +105,73 @@ func TestListApplicationEventsInRange_DeletionHidesTheSubjectNotTheEvent(t *test
 	}
 }
 
+// source_ref names an emails.id only for a mail-derived event — the table's own comment
+// says so, and the idempotency index keys on (user_id, kind, source_ref) precisely because
+// the referent is namespaced per kind. A read that joined emails on the bare column would
+// hand the next kind's event whatever message happens to share its id.
+func TestListApplicationEventsInRange_OnlyMailEventsBorrowAMessage(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "timeline-ref@example.test", true)
+	job := seedResponseJob(t, q, "timeline-ref-1", "acme")
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	emailID := linkedReply(t, q, user, job, "Unfortunately we are moving forward with others",
+		time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC))
+
+	// The shape a later kind takes: an event of the caller's own, carrying a source_ref
+	// into some other table that happens to collide with one of their message ids.
+	if _, err := q.db.Exec(ctx,
+		`INSERT INTO application_events (user_id, job_id, company_slug, kind, signal, occurred_at, source, source_ref)
+		 VALUES ($1, $2, 'acme', 'interview_scheduled', '', $3, 'user', $4)`,
+		user, job, time.Date(2026, 7, 21, 15, 0, 0, 0, time.UTC), emailID); err != nil {
+		t.Fatalf("seed the next kind's event: %v", err)
+	}
+
+	for _, r := range wideRange(t, q, user) {
+		if r.Kind != "interview_scheduled" {
+			continue
+		}
+		if r.EmailSubject.Valid || r.EmailID.Valid {
+			t.Errorf("a non-mail event borrowed message %d (%q) — source_ref is only an emails.id for mail-derived events",
+				r.EmailID.Int64, r.EmailSubject.String)
+		}
+		return
+	}
+	t.Fatal("the seeded event is missing from the range — an unrecognised kind must still be served")
+}
+
+// Nothing in the range read may mark mail read. read_at means "a human saw this", and a
+// reader that browsed a month through the message endpoint would zero its owner's unread
+// count without anyone opening anything.
+func TestListApplicationEventsInRange_DoesNotMarkMailRead(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "timeline-unread@example.test", true)
+	job := seedResponseJob(t, q, "timeline-unread-1", "acme")
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	emailID := linkedReply(t, q, user, job, "Thanks for applying", time.Date(2026, 7, 9, 7, 0, 0, 0, time.UTC))
+
+	if len(wideRange(t, q, user)) == 0 {
+		t.Fatal("the range served nothing to read")
+	}
+
+	var readAt *time.Time
+	if err := q.db.QueryRow(ctx, `SELECT read_at FROM emails WHERE id = $1`, emailID).Scan(&readAt); err != nil {
+		t.Fatalf("read read_at: %v", err)
+	}
+	if readAt != nil {
+		t.Errorf("reading the range marked the message read at %v — nobody opened it", *readAt)
+	}
+}
+
 // A retracted event is excluded from every aggregate that reads the ledger, and the dated
 // read is one of them: a correction that still showed the wrong employer on the calendar
 // would be a correction the reader cannot see they made.
@@ -136,14 +206,20 @@ func TestListApplicationEventsInRange_RetractedEventsAreNotServed(t *testing.T) 
 		t.Fatalf("re-record: %v", err)
 	}
 
-	var replies []string
+	var replies []ListApplicationEventsInRangeRow
 	for _, r := range wideRange(t, q, user) {
 		if r.Kind == "employer_reply" {
-			replies = append(replies, r.CompanySlug)
+			replies = append(replies, r)
 		}
 	}
-	if len(replies) != 1 || replies[0] != "derq" {
-		t.Errorf("the range served replies for %v, want exactly one for derq — the retracted row must not appear", replies)
+	if len(replies) != 1 || replies[0].CompanySlug != "derq" {
+		t.Fatalf("the range served %d replies (first for %q), want exactly one for derq — the retracted row must not appear",
+			len(replies), replies[0].CompanySlug)
+	}
+	// The correction moves who the reply belongs to, never when it arrived: the message's
+	// own received_at is the date, and re-linking is not a new event in time.
+	if want := time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC); !replies[0].OccurredAt.Time.Equal(want) {
+		t.Errorf("the replacement is dated %v, want the message's own %v", replies[0].OccurredAt.Time, want)
 	}
 }
 
@@ -189,6 +265,7 @@ func TestListApplicationEventsInRange_BoundsAreInclusiveAndExcludeTheRest(t *tes
 
 	rows, err := q.ListApplicationEventsInRange(ctx, ListApplicationEventsInRangeParams{
 		UserID: user, FromAt: ts(at(1)), ToAt: ts(at(15)),
+		SrcGmail: "mail_gmail", SrcHosted: "mail_hosted", SrcExternal: "mail_external",
 	})
 	if err != nil {
 		t.Fatalf("list: %v", err)

--- a/internal/db/application_timeline_integration_test.go
+++ b/internal/db/application_timeline_integration_test.go
@@ -1,0 +1,202 @@
+//go:build integration
+
+// Integration tests for the ledger's dated read — the statement behind
+// internal/apptimeline and the calendar view.
+//
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// linkedReply seeds a message against the caller's application to jobID and reconciles it
+// into the ledger the way every link path does, returning the message's id.
+func linkedReply(t *testing.T, q *Queries, userID, jobID int64, subject string, at time.Time) int64 {
+	t.Helper()
+	ctx := context.Background()
+	var id int64
+	if err := q.db.QueryRow(ctx,
+		`INSERT INTO emails (user_id, source, external_id, subject, received_at, job_id, application_id, status_signal)
+		 VALUES ($1, 'gmail', $2, $3, $4, $5,
+		         (SELECT a.id FROM applications a WHERE a.user_id = $1 AND a.job_id = $5), 'acknowledgement')
+		 RETURNING id`, userID, subject, subject, at, jobID).Scan(&id); err != nil {
+		t.Fatalf("seed email %q: %v", subject, err)
+	}
+	if _, err := q.RetractSupersededEmailEvent(ctx, RetractSupersededEmailEventParams{ID: id, UserID: userID}); err != nil {
+		t.Fatalf("retract: %v", err)
+	}
+	if err := q.RecordEmailApplicationEvent(ctx, RecordEmailApplicationEventParams{
+		ID: id, UserID: userID, EventSource: "mail_gmail",
+	}); err != nil {
+		t.Fatalf("record reply event: %v", err)
+	}
+	return id
+}
+
+// wideRange lists every event the caller has, by asking for a span no test date escapes.
+func wideRange(t *testing.T, q *Queries, userID int64) []ListApplicationEventsInRangeRow {
+	t.Helper()
+	rows, err := q.ListApplicationEventsInRange(context.Background(), ListApplicationEventsInRangeParams{
+		UserID: userID,
+		FromAt: ts(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)),
+		ToAt:   ts(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	return rows
+}
+
+// The asymmetry the ledger is built on, seen from the read side. Deleting a message hides
+// its content and does not un-happen the reply, so the event must still be served — with
+// the subject withheld, because the reader asked to be rid of it.
+func TestListApplicationEventsInRange_DeletionHidesTheSubjectNotTheEvent(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "timeline-delete@example.test", true)
+	job := seedResponseJob(t, q, "timeline-del-1", "derq")
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	emailID := linkedReply(t, q, user, job, "Invitation to interview", time.Date(2026, 7, 14, 9, 30, 0, 0, time.UTC))
+
+	reply := func() ListApplicationEventsInRangeRow {
+		t.Helper()
+		for _, r := range wideRange(t, q, user) {
+			if r.Kind == "employer_reply" {
+				return r
+			}
+		}
+		t.Fatal("the employer_reply event is missing from the range")
+		return ListApplicationEventsInRangeRow{}
+	}
+
+	before := reply()
+	if before.EmailSubject.String != "Invitation to interview" || !before.EmailSubject.Valid {
+		t.Errorf("a live message lent subject %q (valid=%v), want its own", before.EmailSubject.String, before.EmailSubject.Valid)
+	}
+	if before.EmailID.Int64 != emailID {
+		t.Errorf("event points at email %d, want %d", before.EmailID.Int64, emailID)
+	}
+
+	if _, err := q.db.Exec(ctx, `UPDATE emails SET deleted_at = now() WHERE id = $1`, emailID); err != nil {
+		t.Fatalf("delete the message: %v", err)
+	}
+
+	after := reply()
+	if after.EmailSubject.Valid {
+		t.Errorf("a deleted message still lent subject %q — deletion hides content", after.EmailSubject.String)
+	}
+	if after.EmailID.Valid {
+		t.Errorf("a deleted message is still addressable as %d — the reader has no message to open", after.EmailID.Int64)
+	}
+	if !after.OccurredAt.Time.Equal(before.OccurredAt.Time) || after.CompanySlug != before.CompanySlug {
+		t.Errorf("the event moved when its message was deleted: %v/%q, was %v/%q",
+			after.OccurredAt.Time, after.CompanySlug, before.OccurredAt.Time, before.CompanySlug)
+	}
+}
+
+// A retracted event is excluded from every aggregate that reads the ledger, and the dated
+// read is one of them: a correction that still showed the wrong employer on the calendar
+// would be a correction the reader cannot see they made.
+func TestListApplicationEventsInRange_RetractedEventsAreNotServed(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "timeline-retract@example.test", true)
+	wrong := seedResponseJob(t, q, "timeline-ret-a", "workable")
+	right := seedResponseJob(t, q, "timeline-ret-b", "derq")
+	for _, j := range []int64{wrong, right} {
+		if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: j, EventSource: "user"}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+	}
+	emailID := linkedReply(t, q, user, wrong, "Thanks for applying", time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC))
+
+	// The correction: the message belonged to the other employer all along.
+	if _, err := q.db.Exec(ctx, `UPDATE emails SET job_id = $2,
+		    application_id = (SELECT a.id FROM applications a
+		                       WHERE a.user_id = emails.user_id AND a.job_id = $2)
+		 WHERE emails.id = $1`, emailID, right); err != nil {
+		t.Fatalf("relink: %v", err)
+	}
+	if _, err := q.RetractSupersededEmailEvent(ctx, RetractSupersededEmailEventParams{ID: emailID, UserID: user}); err != nil {
+		t.Fatalf("retract: %v", err)
+	}
+	if err := q.RecordEmailApplicationEvent(ctx, RecordEmailApplicationEventParams{
+		ID: emailID, UserID: user, EventSource: "mail_gmail",
+	}); err != nil {
+		t.Fatalf("re-record: %v", err)
+	}
+
+	var replies []string
+	for _, r := range wideRange(t, q, user) {
+		if r.Kind == "employer_reply" {
+			replies = append(replies, r.CompanySlug)
+		}
+	}
+	if len(replies) != 1 || replies[0] != "derq" {
+		t.Errorf("the range served replies for %v, want exactly one for derq — the retracted row must not appear", replies)
+	}
+}
+
+// Someone else's events are not the caller's history. The ledger's per-user index is the
+// only thing standing between the two, so the read must lead with it.
+func TestListApplicationEventsInRange_ServesOnlyTheCallersOwnEvents(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	mine := seedResponseUser(t, q, "timeline-mine@example.test", true)
+	theirs := seedResponseUser(t, q, "timeline-theirs@example.test", true)
+	job := seedResponseJob(t, q, "timeline-shared", "acme")
+	for _, u := range []int64{mine, theirs} {
+		if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: u, JobID: job, EventSource: "user"}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+	}
+
+	rows := wideRange(t, q, mine)
+	if len(rows) != 1 {
+		t.Fatalf("the caller's range holds %d events, want 1 — both users applied to the same posting", len(rows))
+	}
+}
+
+// The bounds are the request. An event outside them is not a near miss to be rounded in:
+// the caller is painting one month and the margin either side of it is deliberate.
+func TestListApplicationEventsInRange_BoundsAreInclusiveAndExcludeTheRest(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "timeline-bounds@example.test", true)
+	at := func(day int) time.Time { return time.Date(2026, 7, day, 12, 0, 0, 0, time.UTC) }
+	for _, day := range []int{1, 15, 31} {
+		job := seedResponseJob(t, q, fmt.Sprintf("timeline-bound-%d", day), "acme")
+		if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{
+			UserID: user, JobID: job, At: ts(at(day)), EventSource: "mail_hosted",
+		}); err != nil {
+			t.Fatalf("apply on day %d: %v", day, err)
+		}
+	}
+
+	rows, err := q.ListApplicationEventsInRange(ctx, ListApplicationEventsInRangeParams{
+		UserID: user, FromAt: ts(at(1)), ToAt: ts(at(15)),
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("a range covering two of three events served %d, want 2 — both bounds are inclusive", len(rows))
+	}
+	if !rows[0].OccurredAt.Time.Before(rows[1].OccurredAt.Time) {
+		t.Errorf("events came back as %v then %v, want oldest first", rows[0].OccurredAt.Time, rows[1].OccurredAt.Time)
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1070,6 +1070,24 @@ type Querier interface {
 	// Requires jobs_source_id_open_idx (migration 0056); without it this is the same scan
 	// restricted to one source.
 	ListAggregatorJobsForCrosscheckBySource(ctx context.Context, arg ListAggregatorJobsForCrosscheckBySourceParams) ([]ListAggregatorJobsForCrosscheckBySourceRow, error)
+	// One caller's live events over a date range, oldest first — the ledger's first dated
+	// read, behind internal/apptimeline and the tracking calendar.
+	//
+	// Retracted rows are excluded here as they are in every other reader: a correction the
+	// calendar still showed under the wrong employer would be a correction its author cannot
+	// see they made.
+	//
+	// The employer is taken from the event's own denormalized slug, never through the posting.
+	// cmd/prune clears job_id, and an event that had to join jobs for its company would drop
+	// out of the range retroactively — the instability the ledger exists to remove. The
+	// posting is joined only for the slug the SPA links with, and legitimately comes back
+	// absent.
+	//
+	// The message is joined for its subject and nothing else. Its deletion is a condition OF
+	// the join rather than a filter on the result, so a deleted message yields NULL on both
+	// columns while the event itself stands: deletion hides content, it does not un-happen
+	// the reply. Reading a body instead would mean GET /me/emails/:id, which marks mail read.
+	ListApplicationEventsInRange(ctx context.Context, arg ListApplicationEventsInRangeParams) ([]ListApplicationEventsInRangeRow, error)
 	// The notify fan-out targets: every approved referrer of a company with their email and
 	// linked Telegram chat (NULL when unlinked). Email is always present; chat_id drives the
 	// optional Telegram ping.

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1087,6 +1087,14 @@ type Querier interface {
 	// the join rather than a filter on the result, so a deleted message yields NULL on both
 	// columns while the event itself stands: deletion hides content, it does not un-happen
 	// the reply. Reading a body instead would mean GET /me/emails/:id, which marks mail read.
+	//
+	// The join is restricted to mail-derived sources because source_ref names an emails.id
+	// only for those — the column's comment in 0062 says so, and the idempotency index keys on
+	// (user_id, kind, source_ref) precisely because the referent is namespaced per kind. On the
+	// bare column, the next kind to carry a source_ref into some other table would be served
+	// whichever of the caller's messages happened to share that id, and the calendar would
+	// caption an interview with an unrelated rejection. The three names arrive as parameters
+	// rather than being written here, so the vocabulary stays in Go where a pin test guards it.
 	ListApplicationEventsInRange(ctx context.Context, arg ListApplicationEventsInRangeParams) ([]ListApplicationEventsInRangeRow, error)
 	// The notify fan-out targets: every approved referrer of a company with their email and
 	// linked Telegram chat (NULL when unlinked). Email is always present; chat_id drives the

--- a/internal/db/queries/application_events.sql
+++ b/internal/db/queries/application_events.sql
@@ -1,3 +1,41 @@
+-- name: ListApplicationEventsInRange :many
+-- One caller's live events over a date range, oldest first — the ledger's first dated
+-- read, behind internal/apptimeline and the tracking calendar.
+--
+-- Retracted rows are excluded here as they are in every other reader: a correction the
+-- calendar still showed under the wrong employer would be a correction its author cannot
+-- see they made.
+--
+-- The employer is taken from the event's own denormalized slug, never through the posting.
+-- cmd/prune clears job_id, and an event that had to join jobs for its company would drop
+-- out of the range retroactively — the instability the ledger exists to remove. The
+-- posting is joined only for the slug the SPA links with, and legitimately comes back
+-- absent.
+--
+-- The message is joined for its subject and nothing else. Its deletion is a condition OF
+-- the join rather than a filter on the result, so a deleted message yields NULL on both
+-- columns while the event itself stands: deletion hides content, it does not un-happen
+-- the reply. Reading a body instead would mean GET /me/emails/:id, which marks mail read.
+SELECT ae.id, ae.kind, ae.signal, ae.source, ae.occurred_at, ae.company_slug,
+       ae.application_id, ae.job_id,
+       a.role_title,
+       j.public_slug AS job_slug,
+       em.id         AS email_id,
+       em.subject    AS email_subject
+  FROM application_events ae
+  LEFT JOIN applications a ON a.id = ae.application_id
+  LEFT JOIN jobs j         ON j.id = ae.job_id
+  LEFT JOIN emails em      ON em.id = ae.source_ref
+                          AND em.user_id = ae.user_id
+                          AND em.deleted_at IS NULL
+ WHERE ae.user_id      = $1
+   AND ae.retracted_at IS NULL
+   AND ae.occurred_at >= sqlc.arg(from_at)
+   AND ae.occurred_at <= sqlc.arg(to_at)
+ -- id breaks the tie so a day's events keep a stable order between requests; two events
+ -- sharing a timestamp is routine when a mailbox import lands a batch.
+ ORDER BY ae.occurred_at, ae.id;
+
 -- name: RetractSupersededEmailEvent :execrows
 -- Step 1 of reconciling one email with the ledger: retract the live event when the
 -- message is no longer linked, or is now linked to a different application.

--- a/internal/db/queries/application_events.sql
+++ b/internal/db/queries/application_events.sql
@@ -16,18 +16,28 @@
 -- the join rather than a filter on the result, so a deleted message yields NULL on both
 -- columns while the event itself stands: deletion hides content, it does not un-happen
 -- the reply. Reading a body instead would mean GET /me/emails/:id, which marks mail read.
+--
+-- The join is restricted to mail-derived sources because source_ref names an emails.id
+-- only for those — the column's comment in 0062 says so, and the idempotency index keys on
+-- (user_id, kind, source_ref) precisely because the referent is namespaced per kind. On the
+-- bare column, the next kind to carry a source_ref into some other table would be served
+-- whichever of the caller's messages happened to share that id, and the calendar would
+-- caption an interview with an unrelated rejection. The three names arrive as parameters
+-- rather than being written here, so the vocabulary stays in Go where a pin test guards it.
 SELECT ae.id, ae.kind, ae.signal, ae.source, ae.occurred_at, ae.company_slug,
-       ae.application_id, ae.job_id,
+       ae.application_id,
        a.role_title,
        j.public_slug AS job_slug,
        em.id         AS email_id,
        em.subject    AS email_subject
   FROM application_events ae
   LEFT JOIN applications a ON a.id = ae.application_id
+                          AND a.user_id = ae.user_id
   LEFT JOIN jobs j         ON j.id = ae.job_id
   LEFT JOIN emails em      ON em.id = ae.source_ref
                           AND em.user_id = ae.user_id
                           AND em.deleted_at IS NULL
+                          AND ae.source IN (sqlc.arg(src_gmail), sqlc.arg(src_hosted), sqlc.arg(src_external))
  WHERE ae.user_id      = $1
    AND ae.retracted_at IS NULL
    AND ae.occurred_at >= sqlc.arg(from_at)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -324,6 +324,7 @@ func Register(app *fiber.App, cfg Config) {
 	searchH := newSearchHandlers(jobSearch, facets, queries)
 	companiesH := newCompaniesHandlers(queries, companySearch)
 	trackingH := newTrackingHandlers(queries, cfg.Pool, jobSearch)
+	timelineH := newTimelineHandlers(queries)
 	resumeH := newResumeHandlers(resumeStore, structuredExtractor, jobSearch, facets, profileSvc, atsAnalyzer, queries)
 	photoH := newPhotoHandlers(photoStore)
 	// Same reason as jobSearch above: a nil *speech.Client wrapped in the transcriber
@@ -465,6 +466,9 @@ func Register(app *fiber.App, cfg Config) {
 	// (see trackingHandlers). The interaction writes precede the vote routes,
 	// mirroring the previous registration order.
 	trackingH.register(api, mw)
+	// The ledger's dated read, behind the tracking calendar. Its own namespace, not a
+	// segment under /me/tracking — see the comment on its register.
+	timelineH.register(api, mw)
 	votesH.register(api, mw)
 	// Per-job skill match + the on-demand LLM fit analysis (see matchHandlers).
 	matchH.register(api, mw)

--- a/internal/handler/me_timeline.go
+++ b/internal/handler/me_timeline.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"errors"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/apptimeline"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// timelineHandlers serves the ledger's dated read — the caller's application events over
+// a range, which the tracking calendar paints and an agent can ask for directly.
+type timelineHandlers struct {
+	timeline *apptimeline.Service
+}
+
+func newTimelineHandlers(queries *db.Queries) *timelineHandlers {
+	return &timelineHandlers{timeline: apptimeline.New(queries)}
+}
+
+func (h *timelineHandlers) register(api fiber.Router, mw middleware) {
+	// Its own namespace rather than /me/tracking/calendar, for the reason recorded above
+	// /me/applications/:id: GET /me/tracking/:slug is already mounted — from gmail.go,
+	// while its static siblings are registered in two other files — so a static segment
+	// under that prefix resolves only on the order the Register* calls happen to run in.
+	// Nothing enforces that order and the failure is quiet: the parameterised route would
+	// answer for a job slug that does not exist.
+	//
+	// mw.key like the rest of /me: a cookie or a full-scope key, so a caller's own harness
+	// can read its history.
+	api.Get("/me/timeline", mw.key, h.Timeline)
+}
+
+// timelineEvent is one ledger event on the wire — a projection of apptimeline.Event, and
+// separate from it so that a field added to the service type has to be published
+// deliberately rather than by inheritance.
+//
+// The optional members are omitted rather than zeroed; apptimeline.Event says when each
+// is legitimately absent.
+type timelineEvent struct {
+	ID     int64  `json:"id"`
+	Kind   string `json:"kind"`
+	Signal string `json:"signal,omitempty"`
+	Source string `json:"source"`
+	// Observed is the server's verdict, not the reader's: appevent owns the rule that
+	// says which sources carry a date somebody other than the candidate set.
+	Observed bool `json:"observed"`
+	// OccurredAt is an instant, not a day. Which day it falls on depends on the reader's
+	// clock, so the grouping belongs in the browser that knows it.
+	OccurredAt    time.Time `json:"occurred_at"`
+	CompanySlug   string    `json:"company_slug"`
+	RoleTitle     string    `json:"role_title,omitempty"`
+	ApplicationID int64     `json:"application_id,omitempty"`
+	JobSlug       string    `json:"job_slug,omitempty"`
+	EmailID       int64     `json:"email_id,omitempty"`
+	EmailSubject  string    `json:"email_subject,omitempty"`
+}
+
+// Timeline serves the caller's events between from and to inclusive, oldest first.
+func (h *timelineHandlers) Timeline(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	from, err := timelineBound(c, "from")
+	if err != nil {
+		return err
+	}
+	to, err := timelineBound(c, "to")
+	if err != nil {
+		return err
+	}
+
+	events, err := h.timeline.Range(c.Context(), userID, from, to)
+	if err != nil {
+		if errors.Is(err, apptimeline.ErrInvalidRange) {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		return err
+	}
+
+	out := make([]timelineEvent, 0, len(events))
+	for _, e := range events {
+		out = append(out, timelineEvent{
+			ID:            e.ID,
+			Kind:          e.Kind,
+			Signal:        e.Signal,
+			Source:        e.Source,
+			Observed:      e.Observed,
+			OccurredAt:    e.OccurredAt,
+			CompanySlug:   e.CompanySlug,
+			RoleTitle:     e.RoleTitle,
+			ApplicationID: e.ApplicationID,
+			JobSlug:       e.JobSlug,
+			EmailID:       e.EmailID,
+			EmailSubject:  e.EmailSubject,
+		})
+	}
+	return c.JSON(fiber.Map{
+		"data": out,
+		"meta": fiber.Map{"from": from, "to": to, "count": len(out)},
+	})
+}
+
+// timelineBound parses one RFC3339 bound. Both are required and neither is defaulted: a
+// missing bound silently widened to "the last month" would answer a question the caller
+// did not ask, and the reader's month is not the server's to guess.
+func timelineBound(c *fiber.Ctx, name string) (time.Time, error) {
+	raw := c.Query(name)
+	if raw == "" {
+		return time.Time{}, fiber.NewError(fiber.StatusBadRequest, "both from and to are required, as RFC3339 instants")
+	}
+	at, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, fiber.NewError(fiber.StatusBadRequest, name+" is not an RFC3339 instant")
+	}
+	return at, nil
+}

--- a/internal/handler/me_timeline.go
+++ b/internal/handler/me_timeline.go
@@ -21,12 +21,13 @@ func newTimelineHandlers(queries *db.Queries) *timelineHandlers {
 }
 
 func (h *timelineHandlers) register(api fiber.Router, mw middleware) {
-	// Its own namespace rather than /me/tracking/calendar, for the reason recorded above
-	// /me/applications/:id: GET /me/tracking/:slug is already mounted — from gmail.go,
-	// while its static siblings are registered in two other files — so a static segment
-	// under that prefix resolves only on the order the Register* calls happen to run in.
-	// Nothing enforces that order and the failure is quiet: the parameterised route would
-	// answer for a job slug that does not exist.
+	// Its own namespace rather than a segment under /me/tracking. GET /me/tracking/:slug
+	// is mounted from gmail.go and only avoids shadowing its static siblings because the
+	// registration order is deliberate — both sides say so (see the comment there and the
+	// one above inboxH.register). That arrangement is maintained by hand and by nothing
+	// else, and its failure is quiet: the parameterised route would answer for a job slug
+	// that does not exist. Every static segment added under that prefix is another thing
+	// the arrangement has to keep carrying, so this one is not added to it.
 	//
 	// mw.key like the rest of /me: a cookie or a full-scope key, so a caller's own harness
 	// can read its history.

--- a/internal/handler/me_timeline_test.go
+++ b/internal/handler/me_timeline_test.go
@@ -143,6 +143,40 @@ func TestTimeline_RendersTheDocumentedEnvelope(t *testing.T) {
 	}
 }
 
+// A quiet month is an answer, not a fault: the series comes back empty, reporting the
+// range it answered for, so a reader can tell "nothing happened" from "I asked wrongly".
+// data must serialize as [] and not null — a reader iterating it should not have to guard.
+func TestTimeline_AQuietRangeAnswersEmptyAndNamesItsBounds(t *testing.T) {
+	app, token := meTimelineApp(t, timelineStore{})
+
+	status, body := getTimeline(t, app, "/me/timeline?from=2026-08-01T00:00:00Z&to=2026-08-31T00:00:00Z", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", status, body)
+	}
+	var got struct {
+		Data []timelineEvent `json:"data"`
+		Meta struct {
+			From  time.Time `json:"from"`
+			To    time.Time `json:"to"`
+			Count int       `json:"count"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+	if got.Data == nil {
+		t.Errorf("data came back as null in %s, want an empty array", body)
+	}
+	if got.Meta.Count != 0 {
+		t.Errorf("meta count = %d, want 0", got.Meta.Count)
+	}
+	wantFrom := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	wantTo := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
+	if !got.Meta.From.Equal(wantFrom) || !got.Meta.To.Equal(wantTo) {
+		t.Errorf("meta reports %v..%v, want the requested %v..%v", got.Meta.From, got.Meta.To, wantFrom, wantTo)
+	}
+}
+
 // A hand-recorded stage change carries no message, and the wire must say so by omission
 // rather than by inventing an id nobody can open.
 func TestTimeline_AHandRecordedEventCarriesNoMessage(t *testing.T) {

--- a/internal/handler/me_timeline_test.go
+++ b/internal/handler/me_timeline_test.go
@@ -1,0 +1,176 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/apptimeline"
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// timelineStore answers with fixed rows so the envelope is asserted without a pool.
+type timelineStore struct {
+	rows []db.ListApplicationEventsInRangeRow
+}
+
+func (s timelineStore) ListApplicationEventsInRange(context.Context, db.ListApplicationEventsInRangeParams) ([]db.ListApplicationEventsInRangeRow, error) {
+	return s.rows, nil
+}
+
+// meTimelineApp mounts the range read behind RequireAuth. The store is nil unless a case
+// supplies one: the auth and range cases must refuse before the service reaches it, and a
+// nil dereference here is how a regression that queried first would announce itself.
+func meTimelineApp(t *testing.T, store apptimeline.Queries) (*fiber.App, string) {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(1, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &timelineHandlers{timeline: apptimeline.New(store)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/me/timeline", auth.RequireAuth(iss, testVersions), h.Timeline)
+	return app, token
+}
+
+func getTimeline(t *testing.T, app *fiber.App, path, token string) (int, []byte) {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodGet, path, nil)
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+func TestTimeline_RequiresAuth(t *testing.T) {
+	app, _ := meTimelineApp(t, nil)
+	if got, _ := getTimeline(t, app, "/me/timeline?from=2026-08-01T00:00:00Z&to=2026-08-31T00:00:00Z", ""); got != fiber.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", got)
+	}
+}
+
+// Each of these is refused before the store is consulted — the nil store proves it.
+func TestTimeline_RefusesABadRangeBeforeReachingTheStore(t *testing.T) {
+	cases := map[string]string{
+		"no bounds":       "/me/timeline",
+		"only a lower":    "/me/timeline?from=2026-08-01T00:00:00Z",
+		"unparseable":     "/me/timeline?from=August&to=2026-08-31T00:00:00Z",
+		"inverted":        "/me/timeline?from=2026-08-31T00:00:00Z&to=2026-08-01T00:00:00Z",
+		"beyond the span": "/me/timeline?from=2020-01-01T00:00:00Z&to=2026-08-01T00:00:00Z",
+	}
+	for name, path := range cases {
+		t.Run(name, func(t *testing.T) {
+			app, token := meTimelineApp(t, nil)
+			if got, _ := getTimeline(t, app, path, token); got != fiber.StatusBadRequest {
+				t.Errorf("status = %d, want 400", got)
+			}
+		})
+	}
+}
+
+func TestTimeline_RendersTheDocumentedEnvelope(t *testing.T) {
+	at := time.Date(2026, 8, 13, 9, 41, 0, 0, time.UTC)
+	app, token := meTimelineApp(t, timelineStore{rows: []db.ListApplicationEventsInRangeRow{{
+		ID:           7,
+		Kind:         "employer_reply",
+		Signal:       "interview_invitation",
+		Source:       "mail_gmail",
+		OccurredAt:   pgtype.Timestamptz{Time: at, Valid: true},
+		CompanySlug:  "derq",
+		RoleTitle:    pgtype.Text{String: "Senior Go Engineer", Valid: true},
+		EmailID:      pgtype.Int8{Int64: 42, Valid: true},
+		EmailSubject: pgtype.Text{String: "Invitation to interview", Valid: true},
+	}}})
+
+	status, body := getTimeline(t, app, "/me/timeline?from=2026-08-01T00:00:00Z&to=2026-08-31T00:00:00Z", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", status, body)
+	}
+
+	var got struct {
+		Data []struct {
+			ID           int64     `json:"id"`
+			Kind         string    `json:"kind"`
+			Signal       string    `json:"signal"`
+			Source       string    `json:"source"`
+			Observed     bool      `json:"observed"`
+			OccurredAt   time.Time `json:"occurred_at"`
+			CompanySlug  string    `json:"company_slug"`
+			RoleTitle    string    `json:"role_title"`
+			EmailID      int64     `json:"email_id"`
+			EmailSubject string    `json:"email_subject"`
+		} `json:"data"`
+		Meta struct {
+			Count int `json:"count"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+	if len(got.Data) != 1 || got.Meta.Count != 1 {
+		t.Fatalf("served %d events with meta count %d, want 1 and 1", len(got.Data), got.Meta.Count)
+	}
+	e := got.Data[0]
+	if !e.Observed {
+		t.Error("a gmail-sourced reply rendered as unobserved")
+	}
+	if !e.OccurredAt.Equal(at) {
+		t.Errorf("occurred_at = %v, want the instant %v — the reader groups days, not the server", e.OccurredAt, at)
+	}
+	if e.Kind != "employer_reply" || e.Signal != "interview_invitation" || e.CompanySlug != "derq" {
+		t.Errorf("event rendered as %+v, want the seeded reply", e)
+	}
+	if e.EmailID != 42 || e.EmailSubject != "Invitation to interview" {
+		t.Errorf("message rendered as %d/%q, want 42 and its subject", e.EmailID, e.EmailSubject)
+	}
+}
+
+// A hand-recorded stage change carries no message, and the wire must say so by omission
+// rather than by inventing an id nobody can open.
+func TestTimeline_AHandRecordedEventCarriesNoMessage(t *testing.T) {
+	app, token := meTimelineApp(t, timelineStore{rows: []db.ListApplicationEventsInRangeRow{{
+		ID:          8,
+		Kind:        "stage_set",
+		Signal:      "screening",
+		Source:      "user",
+		OccurredAt:  pgtype.Timestamptz{Time: time.Date(2026, 8, 13, 21, 15, 0, 0, time.UTC), Valid: true},
+		CompanySlug: "linear",
+	}}})
+
+	status, body := getTimeline(t, app, "/me/timeline?from=2026-08-01T00:00:00Z&to=2026-08-31T00:00:00Z", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", status, body)
+	}
+	var got struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+	if observed := got.Data[0]["observed"]; observed != false {
+		t.Errorf("a hand-recorded stage change rendered observed=%v, want false", observed)
+	}
+	for _, absent := range []string{"email_id", "email_subject", "role_title"} {
+		if _, present := got.Data[0][absent]; present {
+			t.Errorf("%q was rendered for an event that has none: %v", absent, got.Data[0])
+		}
+	}
+}

--- a/openspec/changes/tracking-calendar-view/.openspec.yaml
+++ b/openspec/changes/tracking-calendar-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/tracking-calendar-view/design.md
+++ b/openspec/changes/tracking-calendar-view/design.md
@@ -1,0 +1,153 @@
+## Context
+
+`application_events` (migration 0062) has been written by every path that moves an application
+since it landed: `internal/maillink`, `internal/inbox`, `jobtracking.MarkApplied`,
+`jobtracking.TrackJob`, and the follow-up record action. It is read in exactly one place —
+the per-company response aggregate in `internal/db/queries/insights.sql` — and read there by
+company, not by date. Nothing reads one caller's events as a series.
+
+Three constraints come from the surrounding code rather than from this feature:
+
+- **`appevent.TrustedForDayMath` already splits observed from recorded.** Mail sources carry a
+  date somebody else set; `user` and `assistant` carry the date the candidate updated their
+  board. `TestOnlyMailSourcesAreTrustedForDayMath` fails if a future edit promotes a manual
+  source, and pins the whole vocabulary so a new source needs an explicit verdict.
+- **The ledger is content-free by construction.** Subjects, bodies and addresses live in
+  `emails`, and reaching a body through `GET /me/emails/:id` marks the message read.
+- **`GET /me/tracking/:slug` is registered in `internal/handler/gmail.go`** while its static
+  siblings (`/viewed`, `/saved`, `/pipeline`, `/swipe`, `/analyses`) are registered in two other
+  files. They resolve because Fiber matches in registration order and their `Register*` happens
+  to run first.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One caller's ledger events, over a date range, in one request.
+- A month view that tells the truth about which dates were observed and which were typed.
+- A reader that a later event kind can flow through without a redesign.
+
+**Non-Goals:**
+
+- Interview times and any forward-looking view. The ledger has no interview time and neither
+  does the mail: `interview_invitation` says an invitation arrived, not when the meeting is.
+  That date will come from reading the candidate's own calendar, in its own change.
+- Writing anything. This change adds no mutation, no migration and no worker.
+- An ICS feed, reminders, or export.
+
+## Decisions
+
+### A new package, `internal/apptimeline`, rather than a method on `jobtracking`
+
+`jobtracking` is organised around mutations of one `(user, job)` pair — apply, save, track,
+each an idempotent upsert. This read is addressed by a date range across every application a
+user has, joins two tables `jobtracking` never touches, and returns a shape with no mutation
+behind it. Folding it in would make one package answer two unrelated questions.
+
+The read lives in a service and not in the handler for the reason the mail stack states and the
+ledger spec repeats: the in-app assistant calls services directly with the session owner's id
+and issues no HTTP request. "Show me what happened last month" is an obvious assistant tool, and
+a rule enforced in a Fiber handler is one that reader never meets.
+
+*Alternative considered:* extend `internal/jobtracking`. Fewer files, but the package starts
+doing two things, and the next reader has to find out which half applies to them.
+
+### `GET /me/timeline`, not `/me/tracking/calendar`
+
+Adding a fourth static segment under `/me/tracking/` would be a fourth bet on `Register*` call
+order against the `:slug` route in `gmail.go`. Nothing enforces that order, and the failure is
+quiet: the parameterised route would swallow `calendar` and answer with a 404 for a job slug
+that does not exist. A separate path removes the question rather than answering it.
+
+The name is also honest about scope — the series is not the calendar's private data, and the
+same endpoint serves an application's own history and an assistant tool later.
+
+*Alternative considered:* register the static route explicitly before the parameterised one.
+That works, and it leaves the next person to discover the constraint by breaking it.
+
+### The server serves moments; the browser decides days
+
+`occurred_at` is `timestamptz` — an absolute instant. Which cell it belongs to depends on the
+reader's clock, and only the browser knows that. So the response carries instants, the grid is
+built client-side, and the range is fetched with one day of margin on each side. Without the
+margin the first and last cells of a month are systematically short.
+
+This makes the server render data-only: `+page.server.ts` fetches, the component arranges. The
+initial fetch uses the current month in UTC plus the same margin, which covers the reader's
+month whatever their offset; navigating months fetches again.
+
+*Alternative considered:* a `tz` query parameter and server-side grouping. It moves timezone
+handling to where there are no tests for it, and puts an IANA zone name in a URL that then has
+to be validated and kept in sync with the browser's own idea of the zone.
+
+### `observed` is computed on the server
+
+The response carries a boolean per event, taken from `appevent.TrustedForDayMath(source)`.
+Deriving it in the browser would fork the trust rule: the source vocabulary has grown before,
+and a browser-side list would keep calling a newly added source observed after the Go side had
+already refused it. A pin test asserts the served verdict against `TrustedForDayMath` over the
+whole `appevent.Sources` collection, so a source added without a verdict fails the build — the
+same device `TestOnlyMailSourcesAreTrustedForDayMath` already uses one layer down.
+
+### The subject is joined, never fetched
+
+`LEFT JOIN emails ON application_events.source_ref` supplies the subject and the message id, and
+supplies neither when `emails.deleted_at IS NOT NULL`. The event still comes back: the ledger's
+position is that deleting a message hides content and does not un-happen the reply, and a series
+that dropped the event would reintroduce exactly the distortion the ledger removed.
+
+Fetching per message is the alternative and it is the trap: `GET /me/emails/:id` marks mail
+read, so a reader assembled from it would zero its owner's unread count by browsing.
+
+### One range fetch feeds both the grid and the day panel
+
+Selecting a day filters data already in hand. This is a guard, not an optimisation: a panel that
+cannot issue a request cannot reach the message endpoint by a later edit. It also removes a
+loading state from every click.
+
+The cost is a larger first payload. For the volumes involved — a heavy month is tens of events,
+and a heavy user has under a hundred applications in total — this is not a trade worth making
+the other way.
+
+### `kind` crosses the wire as a value, not as an enumerated set
+
+`application_events` splits `kind` from `signal` so that a growing classifier vocabulary is not
+a change to a table that must not change. The reader honours the same split: it renders an
+unknown kind generically rather than failing, so the interview kind this change deliberately
+does not add can arrive without touching the response format or the grid.
+
+### The range is bounded
+
+`from` and `to` are required, `from <= to`, and a span longer than 366 days is a 400. The index
+`application_events (user_id, occurred_at)` makes the scan cheap and per-user volumes are small,
+so this is hygiene rather than a performance fix — but an unbounded range on an
+append-only table is the kind of thing that is cheap now and expensive later.
+
+## Risks / Trade-offs
+
+- **A bulk-apply day overflows its cell.** Twenty applications in one evening is normal
+  behaviour. → The cell shows what it can and reports the remainder; the day panel lists all of
+  them.
+- **A user with no connected mailbox sees a thin calendar.** Their `applied` and `stage_set`
+  events are there, and most of the latter are hand-recorded, so the month reads as mostly
+  unobserved. → That is accurate, and the empty state points at the board. Connecting a mailbox
+  is what fills it in, which the view can say.
+- **A larger first payload than a per-day fetch.** → Bounded by the range cap and by real
+  volumes; measured against the read-marking hazard it removes, this is the cheaper side.
+- **Not a risk, though it looks like one:** connecting a mailbox imports a year of ATS mail in
+  one pass. The calendar does not show a wall of events on that day, because `occurred_at` is
+  the message's own date — this is precisely what `recorded_at` was separated from it to
+  prevent.
+
+## Migration Plan
+
+None. No schema change, no backfill, no worker. The change is additive to the API and the SPA
+and can be deployed in the normal order; the route is under `mw.key` like the rest of the
+`/me` surface. Rolling back is removing the tab and the route — no data written, so nothing to
+undo.
+
+## Open Questions
+
+None blocking. The interview-date source is decided (reading the candidate's own calendar) and
+scoped to a later change, where the Google verification limit — the OAuth app is unverified and
+restricted-scope, so test users only — is the first thing to confront.

--- a/openspec/changes/tracking-calendar-view/proposal.md
+++ b/openspec/changes/tracking-calendar-view/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+`application_events` has recorded every movement of every application since migration 0062 —
+applied, employer replies, follow-ups, stage changes — each with the date it happened and the
+provenance that says whether anyone observed it. Nothing reads it as a series. The writes are
+there, `insights.sql` aggregates it per company, and the migration's own comment concedes that
+`stage_set` is "written from day one and read by no timing yet".
+
+The candidate therefore cannot see their own search laid out in time. The board answers "where
+is this application now" and the list answers "what am I waiting on", but neither answers "what
+happened in July" — how many applications went out, when the answers came back, how long the
+gaps ran. That question is what a calendar is for, and the data for it is already on disk.
+
+## What Changes
+
+- A new **Calendar** tab under `/my/tracking`, beside Board · List · Pipeline: a month grid of
+  the caller's application events with arrows to move month to month.
+- Selecting a day opens a panel beneath the grid listing that day's events — employer, role,
+  what happened, and the email subject when the event came from mail. Each event offers two
+  exits: the application, and the message in `/my/inbox` when there is one.
+- A new read of the ledger, `GET /me/timeline?from=&to=`, and the service behind it. This is
+  the ledger's first reader for a dated series; today it is only written and aggregated.
+- Events carry their provenance to the surface. An event a mail source dated is drawn as
+  observed; one the candidate recorded by hand is drawn differently and says so. The verdict is
+  the server's, taken from `appevent.TrustedForDayMath`, so the rule has one home.
+- No new tables, no migration, no backfill. Every row this reads is already being written.
+
+Not in this change, and deliberately: interview dates and any forward-looking view. The ledger
+holds no interview time and neither does the mail — `interview_invitation` means an invitation
+arrived, not when the meeting is. That date will come from reading the candidate's own calendar
+in a change of its own.
+
+## Capabilities
+
+### New Capabilities
+- `application-timeline`: reading the application-event ledger as a dated series for one
+  caller — the range read, what each event carries to the wire, how provenance is reported,
+  and what happens to an event whose message was deleted.
+- `tracking-calendar-view`: the calendar surface itself — the tab, the month grid, the day
+  panel and its two exits, the day boundary under the reader's own clock, and the narrow
+  layout.
+
+### Modified Capabilities
+
+None. The ledger's existing requirements govern how events are written, retracted and
+backfilled; a reader adds to them without changing any of them.
+
+## Impact
+
+- **New**: `internal/apptimeline` (the ledger reader), a query in `internal/db/queries/`
+  (`make sqlc`), a handler for `GET /me/timeline`, `web/src/routes/my/tracking/calendar/`,
+  and the grouping helper it is tested through.
+- **Modified**: `web/src/routes/my/tracking/+layout.svelte` gains a fourth tab; the web API
+  client gains the timeline call.
+- **Read, not changed**: `application_events`, `applications`, `emails` (subject only).
+- **Route hazard**: the new path is `/me/timeline`, not `/me/tracking/calendar`.
+  `GET /me/tracking/:slug` is registered in `internal/handler/gmail.go`, and its static
+  siblings live in other files — they resolve only because their `Register*` runs first.
+  A fourth static segment under that prefix would be a fourth bet on call order.

--- a/openspec/changes/tracking-calendar-view/specs/application-timeline/spec.md
+++ b/openspec/changes/tracking-calendar-view/specs/application-timeline/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: The ledger is readable as a dated range
+
+The application-event ledger SHALL be readable as a series of one caller's events over a date
+range, through `GET /me/timeline?from=&to=` and the service behind it. The read SHALL return
+only the caller's own events and SHALL exclude retracted ones, matching every aggregate that
+already reads the ledger.
+
+The read SHALL live in a service package rather than in the Fiber handler. The mail stack
+already pins this rule and the ledger spec repeats it: the in-app assistant calls services
+directly with the session owner's id and issues no HTTP request, so a rule enforced in a
+handler is a rule the in-process reader never meets.
+
+The range SHALL be bounded by the caller's `from` and `to`, and the response SHALL report the
+range it answered for, so a reader can tell a quiet month from a request it mis-addressed.
+
+#### Scenario: The range is the caller's own
+
+- **WHEN** two users each have events on the same day and one requests that day's range
+- **THEN** only the requesting user's events are returned
+
+#### Scenario: A retracted event is not served
+
+- **WHEN** an email is re-linked from company A to company B and the range covers its date
+- **THEN** A's retracted event is absent from the series and B's replacement is present at the
+  same `occurred_at`
+
+#### Scenario: An empty range answers with an empty series
+
+- **WHEN** the caller requests a range in which nothing happened
+- **THEN** the response is an empty series reporting the range requested, not an error
+
+### Requirement: The server reports whether an event was observed
+
+Each event SHALL carry a verdict saying whether its date was observed or recorded by hand, and
+that verdict SHALL be computed on the server from `appevent.TrustedForDayMath`. A reader SHALL
+NOT derive it from the source name itself.
+
+Only the mail sources carry a date somebody other than the candidate set. A stage the candidate
+switched records when they got around to updating their board, not when the employer moved
+them. Surfacing both without the distinction would draw the same confidence under each. Placing
+the rule in the reader would fork it: the vocabulary has grown before, and a second copy would
+still call a newly added source observed while the first had already refused it.
+
+#### Scenario: A mail-derived event reports as observed
+
+- **WHEN** an `employer_reply` recorded from Gmail, hosted or external mail is served
+- **THEN** it reports as observed
+
+#### Scenario: A hand-recorded event reports as unobserved
+
+- **WHEN** a `stage_set` the candidate made from the board is served
+- **THEN** it reports as not observed, whichever stage it moved to
+
+#### Scenario: A new source cannot slip through as observed
+
+- **WHEN** a source is added to the `appevent` vocabulary
+- **THEN** the served verdict for it still equals `appevent.TrustedForDayMath` for that source,
+  and the test asserting this over the whole vocabulary fails until the source has a verdict
+
+### Requirement: An event outlives its message, its subject does not
+
+An event SHALL be served whether or not the message that produced it still exists to the
+reader. Where the message is present and not deleted, the event MAY carry that message's
+subject and its identifier. Where the message was deleted, the event SHALL be served without
+them.
+
+The ledger already holds this position for aggregates: deleting a message hides content, it
+does not un-happen the reply. A series that dropped the event would repeat the distortion the
+ledger was written to remove; one that showed the subject anyway would serve content the reader
+asked to be rid of.
+
+No content beyond the subject SHALL be served. Reading a message body through
+`GET /me/emails/:id` marks it read, and `read_at` means a human saw it; a series assembled from
+that endpoint would silently zero its owner's unread count.
+
+#### Scenario: A deleted message leaves the event standing
+
+- **WHEN** the range covers an `employer_reply` whose email was deleted
+- **THEN** the event is served with its date, employer and signal, carrying neither subject nor
+  message identifier
+
+#### Scenario: A live message lends its subject
+
+- **WHEN** the range covers an `employer_reply` whose email is present
+- **THEN** the event carries that email's subject and identifier, and the email is not marked
+  read
+
+### Requirement: The wire shape does not enumerate the kind vocabulary
+
+An event's `kind` and `signal` SHALL be served as values from the `appevent` and
+`mailclassify` vocabularies rather than as a fixed set the response format enumerates. A reader
+SHALL render a kind it does not recognise rather than failing on it.
+
+`application_events` separates `kind` from `signal` precisely so that a growing vocabulary is
+not a change to a table that must not change. A response format, or a reader, that hard-codes
+today's four kinds would put that cost back — one addition would then be a change to the
+schema, the reader and their tests at once.
+
+#### Scenario: An unrecognised kind still renders
+
+- **WHEN** the series carries an event whose kind the reader does not know
+- **THEN** the event is shown with its date, employer and role rather than dropped or errored

--- a/openspec/changes/tracking-calendar-view/specs/tracking-calendar-view/spec.md
+++ b/openspec/changes/tracking-calendar-view/specs/tracking-calendar-view/spec.md
@@ -108,15 +108,21 @@ candidate updated their board as for the day somebody answered.
 On a viewport too narrow for seven columns the view SHALL present the month as a list of the
 days that hold events rather than a grid.
 
-Where the caller has no events at all, the view SHALL say so and point at the board rather than
-render an empty month, which reads as a fault in the calendar rather than as an empty history.
+Where the month on screen holds nothing, the view SHALL name that month, say that nothing was
+recorded in it, and offer the tracking board — rather than render a bare empty grid, which
+reads as a fault in the calendar rather than as a quiet month.
+
+The message SHALL be about the month and not about the account. The view fetches one month at
+a time and cannot tell an empty history from a quiet August without a second read of the whole
+ledger; a message claiming the stronger thing would be a guess.
 
 #### Scenario: A narrow viewport lists days
 
 - **WHEN** the calendar renders on a viewport too narrow for a seven-column grid
 - **THEN** the month is presented as a list of days holding events
 
-#### Scenario: A caller with no history is pointed at the board
+#### Scenario: An empty month explains itself
 
-- **WHEN** a signed-in user with no application events opens the calendar
-- **THEN** the view explains that there is nothing recorded yet and offers the tracking board
+- **WHEN** the caller opens a month in which nothing was recorded
+- **THEN** the view names that month, says nothing was recorded in it, and offers the tracking
+  board, while the month controls stay usable so another month can be looked at

--- a/openspec/changes/tracking-calendar-view/specs/tracking-calendar-view/spec.md
+++ b/openspec/changes/tracking-calendar-view/specs/tracking-calendar-view/spec.md
@@ -1,0 +1,122 @@
+## ADDED Requirements
+
+### Requirement: The search is readable as a calendar
+
+The tracking section SHALL offer a calendar view of the caller's application events at
+`/my/tracking/calendar`, presented as a tab beside Board, List and Pipeline. The view SHALL be
+its own URL so it is linkable, bookmarkable and survives a reload.
+
+The view SHALL show one month at a time, defaulting to the current month, with controls to move
+to the previous and next month. A day SHALL show what happened on it: the events of that day,
+distinguished by kind, with a count where there are more than the cell can hold.
+
+The calendar SHALL show application events — what happened to applications — and SHALL NOT show
+catalogue marks such as a viewed or saved job, which are not events in the ledger and live in
+Activity.
+
+#### Scenario: The calendar is its own URL
+
+- **WHEN** a signed-in user opens `/my/tracking/calendar`
+- **THEN** the calendar renders with the Calendar tab selected, and a reload returns to the same
+  view
+
+#### Scenario: Moving between months
+
+- **WHEN** the user moves to the previous month
+- **THEN** that month's grid is shown with its own events
+
+#### Scenario: A crowded day reports its count
+
+- **WHEN** a day holds more events than its cell shows
+- **THEN** the cell shows the events it can and reports how many remain
+
+#### Scenario: A saved job is not an event
+
+- **WHEN** the caller saved a job without applying
+- **THEN** no mark for it appears on any day
+
+### Requirement: A day is decided by the reader's own clock
+
+The day an event falls on SHALL be decided in the reader's local timezone, not the server's.
+The server SHALL serve the moment an event occurred and SHALL NOT group events into days.
+
+`occurred_at` is an absolute moment. A reply that arrived at 23:40 UTC belongs to the next day
+for a reader in Warsaw and to the same day for one in London, and only the reader's browser
+knows which. The rendered range SHALL therefore be requested with a margin of one day on each
+side, or the first and last cells of a month would be short of events that belong in them.
+
+Because the server render cannot know the reader's timezone, the grid SHALL be arranged in the
+browser; the server load SHALL fetch data only.
+
+#### Scenario: A late-evening event lands on the reader's day
+
+- **WHEN** an event occurred at 23:40 UTC and the reader's clock is an hour ahead
+- **THEN** it appears on the following day's cell
+
+#### Scenario: The edges of the month are complete
+
+- **WHEN** the caller opens a month whose first day holds an event that occurred late on the
+  previous day in UTC
+- **THEN** that event appears in the first day's cell
+
+### Requirement: A day opens without a further request
+
+Selecting a day SHALL open a panel beneath the grid listing that day's events, and that panel
+SHALL be assembled from the data already fetched for the range. Selecting a day SHALL NOT issue
+a request.
+
+The rule is a guard as much as a performance choice. The panel names each event's employer,
+role and — for a mail-derived event — the subject of the message; fetching that per selection
+would reach for the message endpoint, which marks mail read. A panel that cannot request cannot
+make that mistake, and browsing a month cannot silently empty the caller's unread count.
+
+Each event in the panel SHALL offer the application it belongs to, and, where the event came
+from a message that still exists, that message in the inbox.
+
+#### Scenario: Selecting a day issues no request
+
+- **WHEN** the user selects a day in the rendered month
+- **THEN** the panel lists that day's events with no network request made
+
+#### Scenario: A mail-derived event reaches its message
+
+- **WHEN** the panel lists an event whose message still exists
+- **THEN** it offers both the application and that message in the inbox
+
+#### Scenario: An event whose message was deleted still reaches its application
+
+- **WHEN** the panel lists an event whose message was deleted
+- **THEN** it offers the application, shows no subject, and offers no message
+
+### Requirement: An event says whether it was observed or recorded
+
+The calendar SHALL distinguish an event whose date was observed from one the candidate recorded
+by hand, in the grid and in the day panel, using the verdict the server serves rather than one
+derived in the browser.
+
+A calendar makes the distinction physical: a mark sits on a particular cell, and a hand-recorded
+stage change drawn identically to an employer's reply claims the same authority for the day the
+candidate updated their board as for the day somebody answered.
+
+#### Scenario: A hand-recorded stage change is marked as such
+
+- **WHEN** the day panel lists a stage change the candidate made from the board
+- **THEN** it is presented as recorded by the candidate rather than as an observed moment
+
+### Requirement: The calendar is legible on a narrow screen and honest when empty
+
+On a viewport too narrow for seven columns the view SHALL present the month as a list of the
+days that hold events rather than a grid.
+
+Where the caller has no events at all, the view SHALL say so and point at the board rather than
+render an empty month, which reads as a fault in the calendar rather than as an empty history.
+
+#### Scenario: A narrow viewport lists days
+
+- **WHEN** the calendar renders on a viewport too narrow for a seven-column grid
+- **THEN** the month is presented as a list of days holding events
+
+#### Scenario: A caller with no history is pointed at the board
+
+- **WHEN** a signed-in user with no application events opens the calendar
+- **THEN** the view explains that there is nothing recorded yet and offers the tracking board

--- a/openspec/changes/tracking-calendar-view/tasks.md
+++ b/openspec/changes/tracking-calendar-view/tasks.md
@@ -48,45 +48,45 @@
 
 ## 4. The month model
 
-- [ ] 4.1 Add `web/src/lib/calendarModel.ts`: pure functions turning a flat event series into a
+- [x] 4.1 Add `web/src/lib/calendarModel.ts`: pure functions turning a flat event series into a
       month grid — the weeks and days of a given month, each day's events, and the fetch range
       for a month with one day of margin on each side. Follow `activityChart.ts`: the
       bug-prone arithmetic lives here so it is testable without rendering.
-- [ ] 4.2 Group by the reader's local day, not by UTC. The model takes instants and derives the
+- [x] 4.2 Group by the reader's local day, not by UTC. The model takes instants and derives the
       day from them locally; nothing in it formats a date server-side.
-- [ ] 4.3 Vitest for `calendarModel.ts`: an event at 23:40 UTC lands on the next local day for
+- [x] 4.3 Vitest for `calendarModel.ts`: an event at 23:40 UTC lands on the next local day for
       a reader ahead of UTC; the first and last cells of a month receive events that fall in
       them only under the local offset; an empty month yields a full grid of empty days; a day
       with more events than the cell holds reports the remainder.
 
 ## 5. The calendar view
 
-- [ ] 5.1 Add the Calendar tab to `web/src/routes/my/tracking/+layout.svelte`, following the
+- [x] 5.1 Add the Calendar tab to `web/src/routes/my/tracking/+layout.svelte`, following the
       existing `tablist` pattern and its `aria-selected` / `activeTabId` handling.
-- [ ] 5.2 Add `web/src/routes/my/tracking/calendar/+page.server.ts` fetching the current UTC
+- [x] 5.2 Add `web/src/routes/my/tracking/calendar/+page.server.ts` fetching the current UTC
       month plus margin through a `loadTimeline` helper in `web/src/lib/server/tracking.ts`,
       returning `undefined` on a transient failure the way `loadBoard` does.
-- [ ] 5.3 Add the timeline call to `web/src/lib/api.ts` and the event type to the web types,
+- [x] 5.3 Add the timeline call to `web/src/lib/api.ts` and the event type to the web types,
       matching how the contract types are generated or declared for the other `/me` reads.
-- [ ] 5.4 Add `web/src/routes/my/tracking/calendar/+page.svelte` and a `TrackingCalendar`
+- [x] 5.4 Add `web/src/routes/my/tracking/calendar/+page.svelte` and a `TrackingCalendar`
       component rendering the model: month grid, previous/next month, per-kind marks with
       observed drawn filled and hand-recorded drawn outlined, and an overflow count.
-- [ ] 5.5 Day panel beneath the grid, filtered from data already loaded — no fetch on select.
+- [x] 5.5 Day panel beneath the grid, filtered from data already loaded — no fetch on select.
       Each entry shows employer, role, what happened, the subject when there is one, and links
       to the application and, when the message still exists, to it in `/my/inbox`.
-- [ ] 5.6 Render an unrecognised kind generically (date, employer, role) rather than dropping
+- [x] 5.6 Render an unrecognised kind generically (date, employer, role) rather than dropping
       it or throwing, so the interview kind can arrive without a change here.
-- [ ] 5.7 Narrow viewport: present the month as a list of days holding events instead of a
+- [x] 5.7 Narrow viewport: present the month as a list of days holding events instead of a
       seven-column grid.
-- [ ] 5.8 Empty state: a caller with no events at all is told so and pointed at the board,
+- [x] 5.8 Empty state: a caller with no events at all is told so and pointed at the board,
       rather than shown an empty month.
 
 ## 6. Verify
 
-- [ ] 6.1 `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -tags=integration
+- [x] 6.1 `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -tags=integration
       ./internal/db/` — both runs, since the untagged run does not compile the integration
       tests.
-- [ ] 6.2 `web/`: install the linked design system first, then `svelte-check`, `eslint` and
+- [x] 6.2 `web/`: install the linked design system first, then `svelte-check`, `eslint` and
       `vitest`; all green against the repository's existing baseline.
 - [ ] 6.3 Visual check against a running authed stack: the tab is selected and reload-safe at
       `/my/tracking/calendar`; a month with events renders marks; selecting a day opens the

--- a/openspec/changes/tracking-calendar-view/tasks.md
+++ b/openspec/changes/tracking-calendar-view/tasks.md
@@ -1,0 +1,94 @@
+## 1. The ledger read
+
+- [ ] 1.1 Add `ListApplicationEventsInRange` to `internal/db/queries/application_events.sql`:
+      the caller's events between two timestamps, `retracted_at IS NULL`, ordered by
+      `occurred_at`. `LEFT JOIN applications` for `role_title` and `LEFT JOIN emails ON
+      ae.source_ref = e.id` for `subject` and `id`, with both email columns NULL when
+      `e.deleted_at IS NOT NULL`. Select `kind`, `signal`, `source`, `occurred_at`,
+      `company_slug`, `application_id`, `job_id`. Run `make sqlc`.
+- [ ] 1.2 Add `internal/apptimeline` with a package doc stating what it is (the ledger's first
+      dated reader) and why it is not in `jobtracking` (that package is per-`(user, job)`
+      mutations; this is a range read, and the in-app assistant will call it without HTTP).
+      Define the `Event` type and a `Range(ctx, userID, from, to)` method over a narrow
+      `Queries` interface, following the shape `internal/inbox` uses.
+- [ ] 1.3 Set `Observed` on each event from `appevent.TrustedForDayMath(source)` inside
+      `apptimeline`, never at the handler or in the SPA. Comment says why: the source
+      vocabulary has grown before, and a second copy of the rule would call a newly added
+      source observed after the first had refused it.
+- [ ] 1.4 Validate the range in the service: `from` and `to` required, `from <= to`, span
+      capped at 366 days, returning `apptimeline`'s invalid-input error so both the handler
+      and a future in-process caller meet the same rule.
+
+## 2. Tests for the read
+
+- [ ] 2.1 Integration test (build tag `integration`, `internal/db`): an event whose email was
+      deleted comes back with its date, employer and signal, and with neither subject nor
+      email id.
+- [ ] 2.2 Integration test: a retracted event is absent and its replacement is present at the
+      same `occurred_at`; and a second user's events on the same day are not returned.
+- [ ] 2.3 Unit test in `apptimeline`: `Observed` equals `appevent.TrustedForDayMath` for every
+      entry in `appevent.Sources`, asserting the collection length first so a source added
+      without a verdict fails the test rather than being skipped — the device
+      `TestOnlyMailSourcesAreTrustedForDayMath` uses.
+- [ ] 2.4 Unit test in `apptimeline`: the range validation — missing bounds, inverted bounds
+      and an over-long span are refused; a single-day range is accepted.
+
+## 3. The endpoint
+
+- [ ] 3.1 Add `GET /me/timeline` under `mw.key` in `internal/handler`, parsing `from`/`to` as
+      RFC3339 and rendering `{"data": [...], "meta": {"from", "to", "count"}}`. Comment the
+      path choice: not `/me/tracking/calendar`, because `GET /me/tracking/:slug` is registered
+      in `gmail.go` and its static siblings resolve only on `Register*` call order — the same
+      reasoning already recorded above `/me/applications/:id` in `user_jobs.go`.
+- [ ] 3.2 Serve `kind` and `signal` as plain strings from their vocabularies; do not enumerate
+      today's four kinds in the response type or in any switch that would fail on a fifth.
+- [ ] 3.3 Handler tests: unauthenticated is 401, a bad or inverted range is 400 before any DB
+      touch, and a valid range renders the documented envelope.
+- [ ] 3.4 Add the route to the API documentation surface alongside the other `/me` reads.
+
+## 4. The month model
+
+- [ ] 4.1 Add `web/src/lib/calendarModel.ts`: pure functions turning a flat event series into a
+      month grid — the weeks and days of a given month, each day's events, and the fetch range
+      for a month with one day of margin on each side. Follow `activityChart.ts`: the
+      bug-prone arithmetic lives here so it is testable without rendering.
+- [ ] 4.2 Group by the reader's local day, not by UTC. The model takes instants and derives the
+      day from them locally; nothing in it formats a date server-side.
+- [ ] 4.3 Vitest for `calendarModel.ts`: an event at 23:40 UTC lands on the next local day for
+      a reader ahead of UTC; the first and last cells of a month receive events that fall in
+      them only under the local offset; an empty month yields a full grid of empty days; a day
+      with more events than the cell holds reports the remainder.
+
+## 5. The calendar view
+
+- [ ] 5.1 Add the Calendar tab to `web/src/routes/my/tracking/+layout.svelte`, following the
+      existing `tablist` pattern and its `aria-selected` / `activeTabId` handling.
+- [ ] 5.2 Add `web/src/routes/my/tracking/calendar/+page.server.ts` fetching the current UTC
+      month plus margin through a `loadTimeline` helper in `web/src/lib/server/tracking.ts`,
+      returning `undefined` on a transient failure the way `loadBoard` does.
+- [ ] 5.3 Add the timeline call to `web/src/lib/api.ts` and the event type to the web types,
+      matching how the contract types are generated or declared for the other `/me` reads.
+- [ ] 5.4 Add `web/src/routes/my/tracking/calendar/+page.svelte` and a `TrackingCalendar`
+      component rendering the model: month grid, previous/next month, per-kind marks with
+      observed drawn filled and hand-recorded drawn outlined, and an overflow count.
+- [ ] 5.5 Day panel beneath the grid, filtered from data already loaded — no fetch on select.
+      Each entry shows employer, role, what happened, the subject when there is one, and links
+      to the application and, when the message still exists, to it in `/my/inbox`.
+- [ ] 5.6 Render an unrecognised kind generically (date, employer, role) rather than dropping
+      it or throwing, so the interview kind can arrive without a change here.
+- [ ] 5.7 Narrow viewport: present the month as a list of days holding events instead of a
+      seven-column grid.
+- [ ] 5.8 Empty state: a caller with no events at all is told so and pointed at the board,
+      rather than shown an empty month.
+
+## 6. Verify
+
+- [ ] 6.1 `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -tags=integration
+      ./internal/db/` — both runs, since the untagged run does not compile the integration
+      tests.
+- [ ] 6.2 `web/`: install the linked design system first, then `svelte-check`, `eslint` and
+      `vitest`; all green against the repository's existing baseline.
+- [ ] 6.3 Visual check against a running authed stack: the tab is selected and reload-safe at
+      `/my/tracking/calendar`; a month with events renders marks; selecting a day opens the
+      panel with no network request in the devtools panel; a mail event links to the message
+      and a deleted-message event does not; the narrow layout lists days.

--- a/openspec/changes/tracking-calendar-view/tasks.md
+++ b/openspec/changes/tracking-calendar-view/tasks.md
@@ -1,50 +1,50 @@
 ## 1. The ledger read
 
-- [ ] 1.1 Add `ListApplicationEventsInRange` to `internal/db/queries/application_events.sql`:
+- [x] 1.1 Add `ListApplicationEventsInRange` to `internal/db/queries/application_events.sql`:
       the caller's events between two timestamps, `retracted_at IS NULL`, ordered by
       `occurred_at`. `LEFT JOIN applications` for `role_title` and `LEFT JOIN emails ON
       ae.source_ref = e.id` for `subject` and `id`, with both email columns NULL when
       `e.deleted_at IS NOT NULL`. Select `kind`, `signal`, `source`, `occurred_at`,
       `company_slug`, `application_id`, `job_id`. Run `make sqlc`.
-- [ ] 1.2 Add `internal/apptimeline` with a package doc stating what it is (the ledger's first
+- [x] 1.2 Add `internal/apptimeline` with a package doc stating what it is (the ledger's first
       dated reader) and why it is not in `jobtracking` (that package is per-`(user, job)`
       mutations; this is a range read, and the in-app assistant will call it without HTTP).
       Define the `Event` type and a `Range(ctx, userID, from, to)` method over a narrow
       `Queries` interface, following the shape `internal/inbox` uses.
-- [ ] 1.3 Set `Observed` on each event from `appevent.TrustedForDayMath(source)` inside
+- [x] 1.3 Set `Observed` on each event from `appevent.TrustedForDayMath(source)` inside
       `apptimeline`, never at the handler or in the SPA. Comment says why: the source
       vocabulary has grown before, and a second copy of the rule would call a newly added
       source observed after the first had refused it.
-- [ ] 1.4 Validate the range in the service: `from` and `to` required, `from <= to`, span
+- [x] 1.4 Validate the range in the service: `from` and `to` required, `from <= to`, span
       capped at 366 days, returning `apptimeline`'s invalid-input error so both the handler
       and a future in-process caller meet the same rule.
 
 ## 2. Tests for the read
 
-- [ ] 2.1 Integration test (build tag `integration`, `internal/db`): an event whose email was
+- [x] 2.1 Integration test (build tag `integration`, `internal/db`): an event whose email was
       deleted comes back with its date, employer and signal, and with neither subject nor
       email id.
-- [ ] 2.2 Integration test: a retracted event is absent and its replacement is present at the
+- [x] 2.2 Integration test: a retracted event is absent and its replacement is present at the
       same `occurred_at`; and a second user's events on the same day are not returned.
-- [ ] 2.3 Unit test in `apptimeline`: `Observed` equals `appevent.TrustedForDayMath` for every
+- [x] 2.3 Unit test in `apptimeline`: `Observed` equals `appevent.TrustedForDayMath` for every
       entry in `appevent.Sources`, asserting the collection length first so a source added
       without a verdict fails the test rather than being skipped — the device
       `TestOnlyMailSourcesAreTrustedForDayMath` uses.
-- [ ] 2.4 Unit test in `apptimeline`: the range validation — missing bounds, inverted bounds
+- [x] 2.4 Unit test in `apptimeline`: the range validation — missing bounds, inverted bounds
       and an over-long span are refused; a single-day range is accepted.
 
 ## 3. The endpoint
 
-- [ ] 3.1 Add `GET /me/timeline` under `mw.key` in `internal/handler`, parsing `from`/`to` as
+- [x] 3.1 Add `GET /me/timeline` under `mw.key` in `internal/handler`, parsing `from`/`to` as
       RFC3339 and rendering `{"data": [...], "meta": {"from", "to", "count"}}`. Comment the
       path choice: not `/me/tracking/calendar`, because `GET /me/tracking/:slug` is registered
       in `gmail.go` and its static siblings resolve only on `Register*` call order — the same
       reasoning already recorded above `/me/applications/:id` in `user_jobs.go`.
-- [ ] 3.2 Serve `kind` and `signal` as plain strings from their vocabularies; do not enumerate
+- [x] 3.2 Serve `kind` and `signal` as plain strings from their vocabularies; do not enumerate
       today's four kinds in the response type or in any switch that would fail on a fifth.
-- [ ] 3.3 Handler tests: unauthenticated is 401, a bad or inverted range is 400 before any DB
+- [x] 3.3 Handler tests: unauthenticated is 401, a bad or inverted range is 400 before any DB
       touch, and a valid range renders the documented envelope.
-- [ ] 3.4 Add the route to the API documentation surface alongside the other `/me` reads.
+- [x] 3.4 Add the route to the API documentation surface alongside the other `/me` reads.
 
 ## 4. The month model
 

--- a/openspec/changes/tracking-calendar-view/tasks.md
+++ b/openspec/changes/tracking-calendar-view/tasks.md
@@ -88,7 +88,7 @@
       tests.
 - [x] 6.2 `web/`: install the linked design system first, then `svelte-check`, `eslint` and
       `vitest`; all green against the repository's existing baseline.
-- [ ] 6.3 Visual check against a running authed stack: the tab is selected and reload-safe at
+- [x] 6.3 Visual check against a running authed stack: the tab is selected and reload-safe at
       `/my/tracking/calendar`; a month with events renders marks; selecting a day opens the
       panel with no network request in the devtools panel; a mail event links to the message
       and a deleted-message event does not; the narrow layout lists days.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
   MyJob,
   MyJobCounts,
   PipelineStats,
+  TimelineEvent,
   User,
   UserJob,
   VoteResult,
@@ -774,6 +775,18 @@ export function createApi(
    *  counts aggregated server-side, for the Pipeline tab's Sankey and rate cards. */
   async function getMyPipeline(): Promise<PipelineStats> {
     return requestData<PipelineStats>('/api/v1/me/tracking/pipeline');
+  }
+
+  /** What happened to the caller's applications between two instants, oldest first —
+   *  the application-event ledger behind the Tracking → Calendar view.
+   *
+   *  Both bounds are RFC3339 instants and the server does not group them into days: which
+   *  day an event falls on depends on the reader's clock, so calendarModel does that here.
+   *  Bounds are percent-encoded because a bare `+` in an offset decodes as a space. */
+  async function myTimeline(from: string, to: string): Promise<TimelineEvent[]> {
+    return requestData<TimelineEvent[]>(
+      `/api/v1/me/timeline?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+    );
   }
 
   /** The jobs the current user has run the AI fit analysis on (newest first), plus their
@@ -1643,6 +1656,7 @@ export function createApi(
     untrackApplication,
     listMyJobs,
     getMyPipeline,
+    myTimeline,
     myAnalyses,
     myCredits,
     myCreditsHistory,

--- a/web/src/lib/board.test.ts
+++ b/web/src/lib/board.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { BOARD_COLUMNS, columnOf, matchesQuery } from './board';
+import { BOARD_COLUMNS, boardRefFor, columnOf, matchesQuery } from './board';
 import type { MyJob } from './types';
 
 // columnOf reads only `stage` and `applied_at`; a minimal cast fixture suffices.
@@ -98,5 +98,22 @@ describe('matchesQuery', () => {
   // predicate resolves this, it must not depend on the user guessing the punctuation.
   it('does not make the user type the slug punctuation', () => {
     expect(matchesQuery(pruned('acme-corp', 'Backend Engineer'), 'acme corp')).toBe(true);
+  });
+});
+
+describe('boardRefFor', () => {
+  it('addresses a posting-backed application by its posting slug', () => {
+    expect(boardRefFor({ job_slug: 'senior-go-engineer-derq-1a2b', application_id: 42 })).toBe(
+      'senior-go-engineer-derq-1a2b',
+    );
+  });
+
+  // The bare id matches no row the listing mints, so the drawer would never open.
+  it('prefixes an application whose posting was pruned, never serving the bare id', () => {
+    expect(boardRefFor({ application_id: 42 })).toBe('a42');
+  });
+
+  it('addresses nothing when the event names no application', () => {
+    expect(boardRefFor({})).toBeNull();
   });
 });

--- a/web/src/lib/board.ts
+++ b/web/src/lib/board.ts
@@ -67,3 +67,21 @@ export function matchesQuery(item: MyJob, query: string): boolean {
 function normalize(s: string): string {
   return s.toLowerCase().replace(/[-_/.]+/g, ' ');
 }
+
+/** How the board addresses one application's row, given what a timeline event knows
+ *  about it — or null when the event names no application at all.
+ *
+ *  The listing mints two forms and neither is the bare application id: a row backed by a
+ *  posting is named by that posting's public slug, and only an application whose posting
+ *  cmd/prune removed is named `a<id>` (see ListInteractions in
+ *  internal/jobtracking/repository.go and the applicationRef contract in internal/handler).
+ *  `/my/tracking/[id]` opens its drawer by matching this id against the loaded rows, so a
+ *  link built from the bare integer matches nothing and fails silently — the drawer simply
+ *  does not open, with no error to notice. */
+export function boardRefFor(e: {
+  job_slug?: string;
+  application_id?: number;
+}): string | null {
+  if (e.job_slug) return e.job_slug;
+  return e.application_id ? `a${e.application_id}` : null;
+}

--- a/web/src/lib/calendarModel.test.ts
+++ b/web/src/lib/calendarModel.test.ts
@@ -1,0 +1,126 @@
+// The reader's timezone is the whole point of this module, so the suite runs in one that
+// is not UTC. Set before anything touches Date: Node reads TZ lazily, but only the first
+// use of a given date-time formatting path is guaranteed to see a later change.
+process.env.TZ = 'Europe/Warsaw'; // UTC+2 in summer
+
+import { describe, it, expect } from 'vitest';
+import { buildCalendarMonth, rangeForMonth, splitDayEvents } from './calendarModel';
+import type { TimelineEvent } from './types';
+
+const event = (occurredAt: string, over: Partial<TimelineEvent> = {}): TimelineEvent => ({
+  id: 1,
+  kind: 'employer_reply',
+  source: 'mail_gmail',
+  observed: true,
+  occurred_at: occurredAt,
+  company_slug: 'derq',
+  ...over,
+});
+
+// requireDay asserts a day exists at a key and returns it narrowed, so the tests read
+// straight-line under noUncheckedIndexedAccess.
+function dayAt(month: ReturnType<typeof buildCalendarMonth>, key: string) {
+  const day = month.days.find((d) => d.key === key);
+  if (!day) throw new Error(`expected a day ${key} in the grid, got ${month.days.map((d) => d.key).join(', ')}`);
+  return day;
+}
+
+describe('buildCalendarMonth', () => {
+  it('places an instant on the reader’s day, not on UTC’s', () => {
+    // 23:40 UTC on 12 August is 01:40 on 13 August in Warsaw. A grid built from the UTC
+    // date would file it a day early, and the reader would look for it on the wrong row.
+    const month = buildCalendarMonth(2026, 7, [event('2026-08-12T23:40:00Z')]);
+
+    expect(dayAt(month, '2026-08-13').events).toHaveLength(1);
+    expect(dayAt(month, '2026-08-12').events).toHaveLength(0);
+  });
+
+  it('gives every cell of the grid, empty ones included', () => {
+    const month = buildCalendarMonth(2026, 7, []);
+
+    expect(month.days.length % 7).toBe(0);
+    expect(month.weeks.every((w) => w.length === 7)).toBe(true);
+    expect(month.days.every((d) => d.events.length === 0)).toBe(true);
+    // August 2026 starts on a Saturday, so a Monday-first grid leads with July's tail.
+    expect(month.days[0]?.inMonth).toBe(false);
+    expect(dayAt(month, '2026-08-01').inMonth).toBe(true);
+  });
+
+  it('fills the leading and trailing cells that belong to neighbouring months', () => {
+    const month = buildCalendarMonth(2026, 7, [
+      event('2026-07-31T09:00:00Z', { id: 2 }),
+      event('2026-09-01T09:00:00Z', { id: 3 }),
+    ]);
+
+    expect(dayAt(month, '2026-07-31').events).toHaveLength(1);
+    expect(dayAt(month, '2026-07-31').inMonth).toBe(false);
+    expect(dayAt(month, '2026-09-01').events).toHaveLength(1);
+  });
+
+  it('orders a day’s events oldest first', () => {
+    const month = buildCalendarMonth(2026, 7, [
+      event('2026-08-13T18:00:00Z', { id: 20 }),
+      event('2026-08-13T07:00:00Z', { id: 10 }),
+    ]);
+
+    expect(dayAt(month, '2026-08-13').events.map((e) => e.id)).toEqual([10, 20]);
+  });
+
+  it('keeps an event whose kind it does not recognise', () => {
+    const month = buildCalendarMonth(2026, 7, [
+      event('2026-08-13T09:00:00Z', { kind: 'interview_scheduled' }),
+    ]);
+
+    expect(dayAt(month, '2026-08-13').events).toHaveLength(1);
+  });
+
+  it('lists only the days that hold events, for the narrow layout', () => {
+    const month = buildCalendarMonth(2026, 7, [
+      event('2026-08-03T09:00:00Z', { id: 1 }),
+      event('2026-08-20T09:00:00Z', { id: 2 }),
+    ]);
+
+    expect(month.daysWithEvents.map((d) => d.key)).toEqual(['2026-08-03', '2026-08-20']);
+  });
+});
+
+describe('rangeForMonth', () => {
+  it('covers the whole grid and a day either side of it', () => {
+    const month = buildCalendarMonth(2026, 7, []);
+    const { from, to } = rangeForMonth(2026, 7);
+
+    const firstCell = new Date(`${month.days[0]?.key}T00:00:00`).getTime();
+    const lastCell = new Date(`${month.days[month.days.length - 1]?.key}T00:00:00`).getTime();
+    const day = 24 * 60 * 60 * 1000;
+
+    // A grid cell's own events must be inside the requested span, with margin to spare:
+    // without it the first and last rows are systematically short.
+    expect(new Date(from).getTime()).toBeLessThanOrEqual(firstCell - day);
+    expect(new Date(to).getTime()).toBeGreaterThanOrEqual(lastCell + day);
+  });
+
+  it('asks for a span the API will accept', () => {
+    const { from, to } = rangeForMonth(2026, 7);
+    const days = (new Date(to).getTime() - new Date(from).getTime()) / (24 * 60 * 60 * 1000);
+
+    expect(days).toBeGreaterThan(0);
+    expect(days).toBeLessThanOrEqual(366); // apptimeline.MaxRangeDays
+  });
+});
+
+describe('splitDayEvents', () => {
+  it('reports what a full cell could not show', () => {
+    const many = Array.from({ length: 7 }, (_, i) => event('2026-08-13T09:00:00Z', { id: i }));
+    const { shown, remaining } = splitDayEvents(many, 4);
+
+    expect(shown).toHaveLength(4);
+    expect(remaining).toBe(3);
+  });
+
+  it('reports nothing remaining when the cell fits', () => {
+    const { shown, remaining } = splitDayEvents([event('2026-08-13T09:00:00Z')], 4);
+
+    expect(shown).toHaveLength(1);
+    expect(remaining).toBe(0);
+  });
+});

--- a/web/src/lib/calendarModel.ts
+++ b/web/src/lib/calendarModel.ts
@@ -35,7 +35,9 @@ export interface CalendarMonth {
   days: CalendarDay[];
   /** Only the cells holding something, for the narrow layout that lists days. */
   daysWithEvents: CalendarDay[];
-  /** How many events the grid holds in total — an empty month is not an empty account. */
+  /** How many events this month's OWN days hold. Deliberately not the whole grid: a
+   *  September whose only mark sits in its 31 August pad cell holds nothing of its own,
+   *  and counting the pad would suppress the message saying so. */
   total: number;
 }
 
@@ -89,8 +91,11 @@ export function buildCalendarMonth(
     if (bucket) bucket.push(e);
     else byDay.set(key, [e]);
   }
+  // Compared as instants, not as strings. Postgres keeps microseconds and Go trims
+  // trailing zeros, so one second can hold both "09:00:00Z" and "09:00:00.482913Z" — and
+  // lexically '.' sorts before 'Z', which would put the later event first.
   for (const bucket of byDay.values()) {
-    bucket.sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
+    bucket.sort((a, b) => Date.parse(a.occurred_at) - Date.parse(b.occurred_at));
   }
 
   const { first, last } = gridBounds(year, month);
@@ -120,7 +125,7 @@ export function buildCalendarMonth(
     weeks,
     days,
     daysWithEvents: days.filter((d) => d.events.length > 0),
-    total: days.reduce((n, d) => n + d.events.length, 0),
+    total: days.reduce((n, d) => n + (d.inMonth ? d.events.length : 0), 0),
   };
 }
 

--- a/web/src/lib/calendarModel.ts
+++ b/web/src/lib/calendarModel.ts
@@ -1,0 +1,153 @@
+// Pure month arithmetic for the tracking calendar: turn a flat series of application
+// events into the grid a month is drawn on, and work out the range to fetch for it.
+//
+// Kept out of the Svelte component for the reason activityChart.ts gives — the bug-prone
+// part is the arithmetic, and here that part is the timezone. `occurred_at` is an instant;
+// which cell it belongs to depends on the reader's clock, and only the browser knows that.
+// Everything below therefore reads a Date through its LOCAL accessors and never through
+// the UTC ones, and is testable without rendering.
+
+import type { TimelineEvent } from './types';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** One cell of the grid. */
+export interface CalendarDay {
+  /** The reader's own calendar date, YYYY-MM-DD — the grouping key, and stable to compare. */
+  key: string;
+  date: Date;
+  dayOfMonth: number;
+  /** False for the neighbouring month's days that pad the first and last rows. */
+  inMonth: boolean;
+  isToday: boolean;
+  /** That day's events, oldest first. */
+  events: TimelineEvent[];
+}
+
+/** A drawable month. */
+export interface CalendarMonth {
+  year: number;
+  /** 0-based, as Date uses. */
+  month: number;
+  /** Whole weeks, Monday first — every row is seven cells. */
+  weeks: CalendarDay[][];
+  /** The same cells, flat and in order. */
+  days: CalendarDay[];
+  /** Only the cells holding something, for the narrow layout that lists days. */
+  daysWithEvents: CalendarDay[];
+  /** How many events the grid holds in total — an empty month is not an empty account. */
+  total: number;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** The reader's own calendar date for an instant. Local accessors, deliberately: the
+ *  UTC ones would file a late-evening event on the previous day for anyone east of
+ *  Greenwich, and on the next one for anyone west of it. */
+export function dayKey(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Monday-first weekday index, 0–6. */
+function mondayIndex(d: Date): number {
+  return (d.getDay() + 6) % 7;
+}
+
+/** The first and last cells of a month's grid, in the reader's zone. The grid runs whole
+ *  weeks, so it reaches into the neighbouring months — and those cells show events too. */
+function gridBounds(year: number, month: number): { first: Date; last: Date } {
+  const firstOfMonth = new Date(year, month, 1);
+  const lastOfMonth = new Date(year, month + 1, 0);
+  return {
+    first: new Date(year, month, 1 - mondayIndex(firstOfMonth)),
+    last: new Date(year, month + 1, 0 + (6 - mondayIndex(lastOfMonth))),
+  };
+}
+
+/** Adds whole days by calendar arithmetic rather than by milliseconds, so a DST boundary
+ *  inside the month does not shift every later cell by an hour. */
+function addDays(d: Date, days: number): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + days);
+}
+
+/** buildCalendarMonth groups a series into the cells of one month's grid.
+ *
+ *  `events` may cover more than the month — the fetch deliberately asks for margin — and
+ *  anything outside the grid is simply not placed. */
+export function buildCalendarMonth(
+  year: number,
+  month: number,
+  events: TimelineEvent[],
+  today: Date = new Date(),
+): CalendarMonth {
+  const byDay = new Map<string, TimelineEvent[]>();
+  for (const e of events) {
+    const key = dayKey(new Date(e.occurred_at));
+    const bucket = byDay.get(key);
+    if (bucket) bucket.push(e);
+    else byDay.set(key, [e]);
+  }
+  for (const bucket of byDay.values()) {
+    bucket.sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
+  }
+
+  const { first, last } = gridBounds(year, month);
+  const cells = Math.round((last.getTime() - first.getTime()) / MS_PER_DAY) + 1;
+  const todayKey = dayKey(today);
+
+  const days: CalendarDay[] = [];
+  for (let i = 0; i < cells; i++) {
+    const date = addDays(first, i);
+    const key = dayKey(date);
+    days.push({
+      key,
+      date,
+      dayOfMonth: date.getDate(),
+      inMonth: date.getMonth() === month && date.getFullYear() === year,
+      isToday: key === todayKey,
+      events: byDay.get(key) ?? [],
+    });
+  }
+
+  const weeks: CalendarDay[][] = [];
+  for (let i = 0; i < days.length; i += 7) weeks.push(days.slice(i, i + 7));
+
+  return {
+    year,
+    month,
+    weeks,
+    days,
+    daysWithEvents: days.filter((d) => d.events.length > 0),
+    total: days.reduce((n, d) => n + d.events.length, 0),
+  };
+}
+
+/** rangeForMonth is the span to fetch so every cell of the month's grid is complete.
+ *
+ *  It covers the grid — which reaches into the neighbouring months — plus a day either
+ *  side. The margin is what makes the edges honest: an event that occurred late on the
+ *  day before the first cell in UTC belongs to the first cell for a reader ahead of it,
+ *  and a range cut to the grid would leave it out. */
+export function rangeForMonth(year: number, month: number): { from: string; to: string } {
+  const { first, last } = gridBounds(year, month);
+  const from = addDays(first, -1);
+  const to = addDays(last, 2); // start of the day after the margin day…
+  return { from: from.toISOString(), to: new Date(to.getTime() - 1).toISOString() }; // …less an instant
+}
+
+/** splitDayEvents divides a cell's events into the ones it shows and a count of the rest.
+ *  A bulk-apply evening is ordinary behaviour, and a cell that silently dropped the tail
+ *  would under-report the day. */
+export function splitDayEvents(
+  events: TimelineEvent[],
+  cap: number,
+): { shown: TimelineEvent[]; remaining: number } {
+  return { shown: events.slice(0, cap), remaining: Math.max(0, events.length - cap) };
+}
+
+/** The month's own name, in the reader's locale. */
+export function monthLabel(year: number, month: number): string {
+  return new Date(year, month, 1).toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+}

--- a/web/src/lib/calendarModel.west.test.ts
+++ b/web/src/lib/calendarModel.west.test.ts
@@ -1,0 +1,48 @@
+// The mirror of calendarModel.test.ts, run west of UTC.
+//
+// It is a separate file because TZ is a per-process setting and vitest gives each file its
+// own worker. One zone is not a test of timezone handling: a grid built from UTC accessors
+// passes every eastern assertion that a correct one does for the opposite instant, and the
+// failure only shows up on the other side of Greenwich.
+process.env.TZ = 'America/Los_Angeles'; // UTC-7 in summer
+
+import { describe, it, expect } from 'vitest';
+import { buildCalendarMonth, rangeForMonth } from './calendarModel';
+import type { TimelineEvent } from './types';
+
+const event = (occurredAt: string, id = 1): TimelineEvent => ({
+  id,
+  kind: 'employer_reply',
+  source: 'mail_gmail',
+  observed: true,
+  occurred_at: occurredAt,
+  company_slug: 'derq',
+});
+
+describe('buildCalendarMonth west of UTC', () => {
+  it('places an early-morning UTC instant on the previous local day', () => {
+    // 01:00 UTC on 13 August is 18:00 on 12 August in Los Angeles. Reading the UTC date
+    // would file it a day late — the mirror of the eastern case, and invisible without it.
+    const month = buildCalendarMonth(2026, 7, [event('2026-08-13T01:00:00Z')]);
+
+    expect(month.days.find((d) => d.key === '2026-08-12')?.events).toHaveLength(1);
+    expect(month.days.find((d) => d.key === '2026-08-13')?.events).toHaveLength(0);
+  });
+
+  it('reaches back far enough for the first cell’s own evening', () => {
+    // The first cell of the August grid is 27 July locally; an event at 03:00 UTC on
+    // 28 July belongs to its evening. A range cut to the grid in UTC would miss it.
+    const { from } = rangeForMonth(2026, 7);
+
+    expect(new Date(from).getTime()).toBeLessThan(new Date('2026-07-27T00:00:00-07:00').getTime());
+  });
+
+  it('counts only the month’s own days, not the neighbouring pad cells', () => {
+    // September 2026 starts on a Tuesday, so its grid leads with 31 August. An event there
+    // is not September's, and counting it would suppress the message saying so.
+    const month = buildCalendarMonth(2026, 8, [event('2026-08-31T18:00:00Z')]);
+
+    expect(month.days.find((d) => d.key === '2026-08-31')?.events).toHaveLength(1);
+    expect(month.total).toBe(0);
+  });
+});

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -125,8 +125,23 @@
   }
 
   let destroyed = false;
+  // A message addressed from outside the inbox — the tracking calendar links each
+  // mail-derived event to the message behind it. Opening it here marks it read, which is
+  // correct: read_at means a human saw the message, and this arrival is a person clicking
+  // through to it. What must never mark mail read is a view that merely lists events, and
+  // that is why the calendar reaches the subject through a join and links here instead of
+  // fetching bodies itself.
+  function openAddressedMessage() {
+    const id = Number(page.url.searchParams.get('message'));
+    if (!Number.isInteger(id) || id <= 0) return;
+    void openMessage(id);
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- shallow same-page URL clean-up to the current pathname; nothing to resolve
+    replaceState(page.url.pathname, {});
+  }
+
   onMount(() => {
     readConnectVerdict();
+    openAddressedMessage();
     void load();
   });
   onDestroy(() => {

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -141,8 +141,10 @@
 
   onMount(() => {
     readConnectVerdict();
-    openAddressedMessage();
-    void load();
+    // After load(), not before: fetchFirstPage replaces pager.items wholesale, and
+    // openMessage patches the opened row to read INSIDE that list. Racing the two leaves
+    // the message the reader just opened still showing as unread.
+    void load().then(openAddressedMessage);
   });
   onDestroy(() => {
     destroyed = true;

--- a/web/src/lib/components/TrackingCalendar.svelte
+++ b/web/src/lib/components/TrackingCalendar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronLeft, ChevronRight } from '@lucide/svelte';
   import { onMount } from 'svelte';
   import { resolve } from '$app/paths';
   import { api } from '$lib/api';
@@ -9,13 +10,16 @@
     splitDayEvents,
     type CalendarDay,
   } from '$lib/calendarModel';
+  import { boardRefFor } from '$lib/board';
   import type { TimelineEvent } from '$lib/types';
+  import { Button } from '$lib/ui';
   import States from './States.svelte';
 
-  // The server load hands over the current month; everything after that is fetched here,
-  // because only the browser knows the reader's timezone and therefore which month they
-  // are actually looking at. See calendarModel.
-  let { events }: { events: TimelineEvent[] | undefined } = $props();
+  // The server load hands over one month, fetched in ITS timezone; everything after that
+  // is fetched here, because only the browser knows the reader's. See calendarModel.
+  let {
+    prefetched,
+  }: { prefetched: { events: TimelineEvent[]; year: number; month: number } | undefined } = $props();
 
   const now = new Date();
   let year = $state(now.getFullYear());
@@ -25,12 +29,23 @@
   // its first value, and the two would then disagree after a navigation. Once the client
   // has fetched a month of its own, that is what the grid reads.
   let fetched = $state<TimelineEvent[] | null>(null);
-  const series = $derived(fetched ?? events ?? []);
-  // 'initial' means nothing has been asked for yet: the view is ready if the server load
-  // succeeded, and waiting on the mount fetch if it did not. Reading `events` here rather
-  // than in an initialiser is what keeps the prop live instead of frozen at its first value.
+  const series = $derived(fetched ?? prefetched?.events ?? []);
+  // 'initial' means nothing has been asked for yet: usable if the server load succeeded
+  // for the month on screen, waiting on the mount fetch otherwise. Reading the prop here
+  // rather than in an initialiser is what keeps it live instead of frozen at first value.
   let phase = $state<'initial' | 'loading' | 'ready' | 'error'>('initial');
-  const status = $derived.by(() => (phase === 'initial' ? (events ? 'ready' : 'loading') : phase));
+  const status = $derived.by(() => (phase === 'initial' ? (serverMonthIsOurs ? 'ready' : 'loading') : phase));
+
+  // The server's month is not necessarily the reader's — a render at 18:00 in Los Angeles
+  // on 31 July happens on 1 August in a UTC process. The margin rangeForMonth adds is
+  // sized for a day boundary and cannot absorb a month boundary, so when the two disagree
+  // the payload is for a month we are not drawing and has to be replaced.
+  const serverMonthIsOurs = $derived(prefetched?.year === year && prefetched?.month === month);
+
+  // Only the newest request may write. Stepping twice quickly leaves two in flight, and
+  // without this the slower one lands last and paints one month's events under another's
+  // grid — with phase 'ready' and nothing to say the data is not this month's.
+  let inFlight = 0;
 
   // Deliberately not an $effect: this function writes year and month, and an effect that
   // read them would re-run on its own writes. Navigation is the only thing that moves the
@@ -40,19 +55,23 @@
     month = m;
     selectedKey = null;
     phase = 'loading';
+    const generation = ++inFlight;
     const { from, to } = rangeForMonth(y, m);
     try {
-      fetched = await api.myTimeline(from, to);
+      const events = await api.myTimeline(from, to);
+      if (generation !== inFlight) return;
+      fetched = events;
       phase = 'ready';
     } catch {
+      if (generation !== inFlight) return;
       phase = 'error';
     }
   }
 
-  // The server render may have failed transiently, and its month is the server's UTC one
-  // rather than the reader's. One fetch on mount settles both — once, not reactively.
+  // One fetch on mount when the server load failed, or when it answered for a month other
+  // than the reader's. Once, not reactively.
   onMount(() => {
-    if (!events) void show(year, month);
+    if (!serverMonthIsOurs) void show(year, month);
   });
 
   const grid = $derived(buildCalendarMonth(year, month, series));
@@ -95,28 +114,26 @@
 
   const dayHeading = (d: CalendarDay) =>
     d.date.toLocaleDateString(undefined, { weekday: 'long', day: 'numeric', month: 'long' });
+
+  /** What a cell announces. An empty day says nothing about a count: "0 events" on the
+   *  thirty-odd empty cells is noise a screen reader has to walk through. */
+  function cellLabel(d: CalendarDay): string {
+    if (d.events.length === 0) return dayHeading(d);
+    const n = d.events.length;
+    return `${dayHeading(d)} — ${n} ${n === 1 ? 'event' : 'events'}`;
+  }
 </script>
 
 <div class="flex flex-col gap-3">
   <div class="flex items-center justify-between gap-3">
     <h2 class="text-lg font-medium">{monthLabel(year, month)}</h2>
     <div class="flex items-center gap-1">
-      <button
-        type="button"
-        onclick={() => step(-1)}
-        class="rounded-md border px-2.5 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
-        aria-label="Previous month"
-      >
-        ←
-      </button>
-      <button
-        type="button"
-        onclick={() => step(1)}
-        class="rounded-md border px-2.5 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
-        aria-label="Next month"
-      >
-        →
-      </button>
+      <Button variant="outline" size="icon" onclick={() => step(-1)} aria-label="Previous month">
+        <ChevronLeft class="size-4" />
+      </Button>
+      <Button variant="outline" size="icon" onclick={() => step(1)} aria-label="Next month">
+        <ChevronRight class="size-4" />
+      </Button>
     </div>
   </div>
 
@@ -139,8 +156,9 @@
           <button
             type="button"
             onclick={() => (selectedKey = selectedKey === day.key ? null : day.key)}
-            aria-pressed={selectedKey === day.key}
-            aria-label="{dayHeading(day)} — {day.events.length} events"
+            aria-expanded={selectedKey === day.key}
+            aria-controls={selectedKey === day.key ? 'calendar-day-panel' : undefined}
+            aria-label={cellLabel(day)}
             class="flex min-h-16 flex-col items-start gap-1 rounded-md border p-1.5 text-left transition-colors
                    {day.inMonth ? '' : 'opacity-45'}
                    {selectedKey === day.key ? 'border-primary bg-accent' : 'hover:bg-accent'}"
@@ -171,11 +189,6 @@
     </div>
 
     <div class="flex flex-col gap-2 sm:hidden">
-      {#if grid.daysWithEvents.length === 0}
-        <p class="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
-          Nothing recorded in {monthLabel(year, month)}.
-        </p>
-      {/if}
       {#each grid.daysWithEvents as day (day.key)}
         <button
           type="button"
@@ -194,7 +207,7 @@
       <!-- Assembled from the events already fetched for the range. Selecting a day issues
            no request, which is also what keeps this panel from ever reaching the message
            endpoint — that one marks mail read. -->
-      <div class="rounded-lg border bg-card p-4">
+      <div id="calendar-day-panel" role="region" aria-live="polite" class="rounded-lg border bg-card p-4">
         <h3 class="mb-3 text-sm font-medium">
           {dayHeading(selected)}
           <span class="font-normal text-muted-foreground">· {selected.events.length} events</span>
@@ -225,10 +238,11 @@
                     {:else}
                       recorded by you
                     {/if}
-                    {#if e.application_id}
-                      · <a class="underline hover:no-underline" href={resolve(`/my/tracking/${e.application_id}`)}
-                        >application</a
-                      >
+                    {#if boardRefFor(e)}
+                      · <a
+                          class="underline hover:no-underline"
+                          href={resolve('/my/tracking/[id]', { id: boardRefFor(e) ?? '' })}>application</a
+                        >
                     {/if}
                     {#if e.email_id}
                       ·

--- a/web/src/lib/components/TrackingCalendar.svelte
+++ b/web/src/lib/components/TrackingCalendar.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { resolve } from '$app/paths';
+  import { api } from '$lib/api';
+  import {
+    buildCalendarMonth,
+    monthLabel,
+    rangeForMonth,
+    splitDayEvents,
+    type CalendarDay,
+  } from '$lib/calendarModel';
+  import type { TimelineEvent } from '$lib/types';
+  import States from './States.svelte';
+
+  // The server load hands over the current month; everything after that is fetched here,
+  // because only the browser knows the reader's timezone and therefore which month they
+  // are actually looking at. See calendarModel.
+  let { events }: { events: TimelineEvent[] | undefined } = $props();
+
+  const now = new Date();
+  let year = $state(now.getFullYear());
+  let month = $state(now.getMonth());
+  let selectedKey = $state<string | null>(null);
+  // The server payload is a fallback, not a seed: copying a prop into state freezes it at
+  // its first value, and the two would then disagree after a navigation. Once the client
+  // has fetched a month of its own, that is what the grid reads.
+  let fetched = $state<TimelineEvent[] | null>(null);
+  const series = $derived(fetched ?? events ?? []);
+  // 'initial' means nothing has been asked for yet: the view is ready if the server load
+  // succeeded, and waiting on the mount fetch if it did not. Reading `events` here rather
+  // than in an initialiser is what keeps the prop live instead of frozen at its first value.
+  let phase = $state<'initial' | 'loading' | 'ready' | 'error'>('initial');
+  const status = $derived.by(() => (phase === 'initial' ? (events ? 'ready' : 'loading') : phase));
+
+  // Deliberately not an $effect: this function writes year and month, and an effect that
+  // read them would re-run on its own writes. Navigation is the only thing that moves the
+  // cursor, so navigation fetches.
+  async function show(y: number, m: number) {
+    year = y;
+    month = m;
+    selectedKey = null;
+    phase = 'loading';
+    const { from, to } = rangeForMonth(y, m);
+    try {
+      fetched = await api.myTimeline(from, to);
+      phase = 'ready';
+    } catch {
+      phase = 'error';
+    }
+  }
+
+  // The server render may have failed transiently, and its month is the server's UTC one
+  // rather than the reader's. One fetch on mount settles both — once, not reactively.
+  onMount(() => {
+    if (!events) void show(year, month);
+  });
+
+  const grid = $derived(buildCalendarMonth(year, month, series));
+  const selected = $derived(grid.days.find((d) => d.key === selectedKey) ?? null);
+  const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const CELL_MARKS = 4;
+
+  function step(by: number) {
+    const d = new Date(year, month + by, 1);
+    void show(d.getFullYear(), d.getMonth());
+  }
+
+  // The mark colours carry the kind; filled versus hollow carries whether anybody but the
+  // candidate set the date. An unrecognised kind gets the neutral mark rather than none —
+  // a fifth kind is coming and must be visible before this file knows its name.
+  const KIND_TONE: Record<string, string> = {
+    applied: 'text-sky-600 dark:text-sky-400',
+    employer_reply: 'text-emerald-600 dark:text-emerald-400',
+    follow_up_sent: 'text-amber-600 dark:text-amber-400',
+    stage_set: 'text-violet-600 dark:text-violet-400',
+  };
+  const tone = (kind: string) => KIND_TONE[kind] ?? 'text-muted-foreground';
+
+  /** Sentence-case an unknown kind so a new one reads as words, not as a column name. */
+  function humanKind(kind: string): string {
+    const words = kind.replace(/_/g, ' ');
+    return words.charAt(0).toUpperCase() + words.slice(1);
+  }
+
+  const KIND_LABEL: Record<string, (e: TimelineEvent) => string> = {
+    applied: () => 'Applied',
+    employer_reply: (e) => (e.signal ? `Employer replied — ${e.signal.replace(/_/g, ' ')}` : 'Employer replied'),
+    follow_up_sent: () => 'Followed up',
+    stage_set: (e) => (e.signal ? `Moved to ${e.signal}` : 'Stage changed'),
+  };
+  const label = (e: TimelineEvent) => (KIND_LABEL[e.kind] ?? (() => humanKind(e.kind)))(e);
+
+  const timeOf = (e: TimelineEvent) =>
+    new Date(e.occurred_at).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+
+  const dayHeading = (d: CalendarDay) =>
+    d.date.toLocaleDateString(undefined, { weekday: 'long', day: 'numeric', month: 'long' });
+</script>
+
+<div class="flex flex-col gap-3">
+  <div class="flex items-center justify-between gap-3">
+    <h2 class="text-lg font-medium">{monthLabel(year, month)}</h2>
+    <div class="flex items-center gap-1">
+      <button
+        type="button"
+        onclick={() => step(-1)}
+        class="rounded-md border px-2.5 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
+        aria-label="Previous month"
+      >
+        ←
+      </button>
+      <button
+        type="button"
+        onclick={() => step(1)}
+        class="rounded-md border px-2.5 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
+        aria-label="Next month"
+      >
+        →
+      </button>
+    </div>
+  </div>
+
+  {#if status === 'error'}
+    <States state="error" message="Couldn't load what happened this month." />
+  {:else if status === 'loading'}
+    <States state="loading" rows={3} />
+  {:else}
+    <!-- The grid below seven columns is unreadable on a phone, so the same month is
+         presented there as the list of days that hold something. -->
+    <div class="hidden rounded-lg border bg-card p-3 sm:block">
+      <div class="mb-1 grid grid-cols-7 gap-1">
+        {#each weekdays as w (w)}
+          <div class="px-1 py-0.5 text-xs font-medium text-muted-foreground">{w}</div>
+        {/each}
+      </div>
+      <div class="grid grid-cols-7 gap-1">
+        {#each grid.days as day (day.key)}
+          {@const marks = splitDayEvents(day.events, CELL_MARKS)}
+          <button
+            type="button"
+            onclick={() => (selectedKey = selectedKey === day.key ? null : day.key)}
+            aria-pressed={selectedKey === day.key}
+            aria-label="{dayHeading(day)} — {day.events.length} events"
+            class="flex min-h-16 flex-col items-start gap-1 rounded-md border p-1.5 text-left transition-colors
+                   {day.inMonth ? '' : 'opacity-45'}
+                   {selectedKey === day.key ? 'border-primary bg-accent' : 'hover:bg-accent'}"
+          >
+            <span
+              class="text-xs {day.isToday
+                ? 'flex h-5 w-5 items-center justify-center rounded-full bg-primary font-medium text-primary-foreground'
+                : 'text-muted-foreground'}">{day.dayOfMonth}</span
+            >
+            <span class="flex flex-wrap items-center gap-0.5">
+              {#each marks.shown as e (e.id)}
+                <!-- Filled = a date somebody other than the candidate set. Hollow = one
+                     they recorded themselves. -->
+                <span
+                  class="inline-block h-2 w-2 rounded-full border {tone(e.kind)}"
+                  class:bg-current={e.observed}
+                  style="border-color: currentColor"
+                  title={label(e)}
+                ></span>
+              {/each}
+              {#if marks.remaining > 0}
+                <span class="text-[10px] leading-none text-muted-foreground">+{marks.remaining}</span>
+              {/if}
+            </span>
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2 sm:hidden">
+      {#if grid.daysWithEvents.length === 0}
+        <p class="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+          Nothing recorded in {monthLabel(year, month)}.
+        </p>
+      {/if}
+      {#each grid.daysWithEvents as day (day.key)}
+        <button
+          type="button"
+          onclick={() => (selectedKey = selectedKey === day.key ? null : day.key)}
+          aria-pressed={selectedKey === day.key}
+          class="flex items-center justify-between gap-3 rounded-lg border bg-card p-3 text-left text-sm
+                 {selectedKey === day.key ? 'border-primary' : ''}"
+        >
+          <span>{dayHeading(day)}</span>
+          <span class="text-muted-foreground">{day.events.length}</span>
+        </button>
+      {/each}
+    </div>
+
+    {#if selected}
+      <!-- Assembled from the events already fetched for the range. Selecting a day issues
+           no request, which is also what keeps this panel from ever reaching the message
+           endpoint — that one marks mail read. -->
+      <div class="rounded-lg border bg-card p-4">
+        <h3 class="mb-3 text-sm font-medium">
+          {dayHeading(selected)}
+          <span class="font-normal text-muted-foreground">· {selected.events.length} events</span>
+        </h3>
+        {#if selected.events.length === 0}
+          <p class="text-sm text-muted-foreground">Nothing happened on this day.</p>
+        {:else}
+          <ul class="flex flex-col gap-3">
+            {#each selected.events as e (e.id)}
+              <li class="flex gap-3">
+                <span
+                  class="mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full border {tone(e.kind)}"
+                  class:bg-current={e.observed}
+                  style="border-color: currentColor"
+                ></span>
+                <div class="min-w-0 flex-1">
+                  <p class="text-sm">
+                    <span class="font-medium">{e.company_slug}</span>
+                    {#if e.role_title}<span class="text-muted-foreground"> · {e.role_title}</span>{/if}
+                  </p>
+                  <p class="text-sm text-muted-foreground">{label(e)}</p>
+                  {#if e.email_subject}
+                    <p class="truncate text-sm italic text-muted-foreground">“{e.email_subject}”</p>
+                  {/if}
+                  <p class="mt-0.5 text-xs text-muted-foreground">
+                    {#if e.observed}
+                      {timeOf(e)}
+                    {:else}
+                      recorded by you
+                    {/if}
+                    {#if e.application_id}
+                      · <a class="underline hover:no-underline" href={resolve(`/my/tracking/${e.application_id}`)}
+                        >application</a
+                      >
+                    {/if}
+                    {#if e.email_id}
+                      ·
+                      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve()d base plus a query string; there is no dynamic route segment to resolve -->
+                      <a class="underline hover:no-underline" href={`${resolve('/my/inbox')}?message=${e.email_id}`}
+                        >message</a
+                      >
+                    {/if}
+                  </p>
+                </div>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    {/if}
+
+    {#if grid.total === 0}
+      <p class="text-sm text-muted-foreground">
+        Nothing recorded in {monthLabel(year, month)}. Applications you track, and the replies they
+        get, appear here — start from the
+        <a class="underline hover:no-underline" href={resolve('/my/tracking')}>board</a>.
+      </p>
+    {/if}
+  {/if}
+</div>

--- a/web/src/lib/components/TrackingCalendar.svelte
+++ b/web/src/lib/components/TrackingCalendar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ChevronLeft, ChevronRight } from '@lucide/svelte';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import {
@@ -79,6 +79,19 @@
   const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
   const CELL_MARKS = 4;
 
+  // A month of mostly-empty cells is tall, so on a laptop the panel opens below the fold
+  // and the click reads as having done nothing. Only scrolls when it actually is out of
+  // view, and only as far as it must — an unconditional jump is worse than the problem.
+  async function selectDay(key: string) {
+    selectedKey = selectedKey === key ? null : key;
+    if (!selectedKey) return;
+    await tick();
+    const panel = document.getElementById('calendar-day-panel');
+    if (panel && panel.getBoundingClientRect().bottom > window.innerHeight) {
+      panel.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }
+
   function step(by: number) {
     const d = new Date(year, month + by, 1);
     void show(d.getFullYear(), d.getMonth());
@@ -155,7 +168,7 @@
           {@const marks = splitDayEvents(day.events, CELL_MARKS)}
           <button
             type="button"
-            onclick={() => (selectedKey = selectedKey === day.key ? null : day.key)}
+            onclick={() => selectDay(day.key)}
             aria-expanded={selectedKey === day.key}
             aria-controls={selectedKey === day.key ? 'calendar-day-panel' : undefined}
             aria-label={cellLabel(day)}
@@ -192,7 +205,7 @@
       {#each grid.daysWithEvents as day (day.key)}
         <button
           type="button"
-          onclick={() => (selectedKey = selectedKey === day.key ? null : day.key)}
+          onclick={() => selectDay(day.key)}
           aria-pressed={selectedKey === day.key}
           class="flex items-center justify-between gap-3 rounded-lg border bg-card p-3 text-left text-sm
                  {selectedKey === day.key ? 'border-primary' : ''}"

--- a/web/src/lib/components/TrackingCalendar.svelte
+++ b/web/src/lib/components/TrackingCalendar.svelte
@@ -100,11 +100,19 @@
   // The mark colours carry the kind; filled versus hollow carries whether anybody but the
   // candidate set the date. An unrecognised kind gets the neutral mark rather than none —
   // a fifth kind is coming and must be visible before this file knows its name.
+  //
+  // Tokens, not raw palette hues. Four arbitrary colours would read as a fifth vocabulary
+  // nobody owns, and `pnpm check:tokens` counts them per file; the neighbouring status maps
+  // predate the check and carry a recorded baseline, which is not a reason to add to it.
+  //
+  // Only four token colours are actually distinct: primary and secondary-foreground hold
+  // the SAME value in both themes (oklch(0.13 0 0) light, oklch(0.985 0 0) dark), so
+  // reaching for the second to separate two kinds silently collapses them into one mark.
   const KIND_TONE: Record<string, string> = {
-    applied: 'text-sky-600 dark:text-sky-400',
-    employer_reply: 'text-emerald-600 dark:text-emerald-400',
-    follow_up_sent: 'text-amber-600 dark:text-amber-400',
-    stage_set: 'text-violet-600 dark:text-violet-400',
+    applied: 'text-primary',
+    employer_reply: 'text-brand-strong',
+    follow_up_sent: 'text-warning-strong',
+    stage_set: 'text-muted-foreground',
   };
   const tone = (kind: string) => KIND_TONE[kind] ?? 'text-muted-foreground';
 
@@ -193,7 +201,7 @@
                 ></span>
               {/each}
               {#if marks.remaining > 0}
-                <span class="text-[10px] leading-none text-muted-foreground">+{marks.remaining}</span>
+                <span class="text-xs leading-none text-muted-foreground">+{marks.remaining}</span>
               {/if}
             </span>
           </button>

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -989,7 +989,7 @@ ${BASE_URL}/auth/oauth/google/start`,
           'the content and leaves the event standing. Both bounds are required and may ' +
           'span at most 366 days.',
         query: [
-          { name: 'from', type: 'string (RFC3339)', required: true, description: 'Lower bound, inclusive.', example: '2026-08-01T00:00:00Z' },
+          { name: 'from', type: 'string (RFC3339)', required: true, description: 'Lower bound, inclusive. Use `Z`, or percent-encode a numeric offset — a bare `+` decodes as a space in a query string and will be rejected.', example: '2026-08-01T00:00:00Z' },
           { name: 'to', type: 'string (RFC3339)', required: true, description: 'Upper bound, inclusive.', example: '2026-08-31T23:59:59Z' },
         ],
         curl: `curl "${BASE_URL}/me/timeline?from=2026-08-01T00:00:00Z&to=2026-08-31T23:59:59Z" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -973,6 +973,56 @@ ${BASE_URL}/auth/oauth/google/start`,
   "meta": { "total": 137, "limit": 20, "offset": 0 }
 }`,
       },
+      {
+        method: 'GET',
+        path: '/me/timeline',
+        auth: 'cookie-or-key',
+        summary: 'What happened to your applications over a date range.',
+        description:
+          'The application-event ledger as a dated series, oldest first: applications ' +
+          'sent, employer replies, follow-ups and stage changes. `occurred_at` is an ' +
+          'instant, not a day — which day it falls on depends on your timezone, so ' +
+          'group it client-side. `observed` says whether the date came from a source ' +
+          'other than you: mail-derived events carry a date the employer set, while a ' +
+          'stage you set yourself is dated from when you recorded it. `email_id` and ' +
+          '`email_subject` are present only while the message exists; deleting it hides ' +
+          'the content and leaves the event standing. Both bounds are required and may ' +
+          'span at most 366 days.',
+        query: [
+          { name: 'from', type: 'string (RFC3339)', required: true, description: 'Lower bound, inclusive.', example: '2026-08-01T00:00:00Z' },
+          { name: 'to', type: 'string (RFC3339)', required: true, description: 'Upper bound, inclusive.', example: '2026-08-31T23:59:59Z' },
+        ],
+        curl: `curl "${BASE_URL}/me/timeline?from=2026-08-01T00:00:00Z&to=2026-08-31T23:59:59Z" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{
+  "data": [
+    {
+      "id": 7,
+      "kind": "employer_reply",
+      "signal": "interview_invitation",
+      "source": "mail_gmail",
+      "observed": true,
+      "occurred_at": "2026-08-13T09:41:00Z",
+      "company_slug": "derq",
+      "role_title": "Senior Go Engineer",
+      "application_id": 31,
+      "job_slug": "senior-go-engineer-derq-1a2b",
+      "email_id": 42,
+      "email_subject": "Invitation to interview"
+    },
+    {
+      "id": 8,
+      "kind": "stage_set",
+      "signal": "screening",
+      "source": "user",
+      "observed": false,
+      "occurred_at": "2026-08-13T21:15:00Z",
+      "company_slug": "linear",
+      "application_id": 33
+    }
+  ],
+  "meta": { "from": "2026-08-01T00:00:00Z", "to": "2026-08-31T23:59:59Z", "count": 2 }
+}`,
+      },
     ],
   },
   {

--- a/web/src/lib/server/tracking.ts
+++ b/web/src/lib/server/tracking.ts
@@ -17,18 +17,22 @@ export async function loadBoard(fetchImpl: typeof fetch, cookie: string | null) 
 /** Fetch the caller's application events for a month's grid, so the calendar paints with
  *  the page instead of after a client fetch on mount.
  *
- *  The month is the SERVER's, in UTC — this render cannot know the reader's zone. The
- *  margin rangeForMonth adds is what makes that safe: whatever the reader's offset, their
- *  own current month falls inside the span asked for here, and moving between months
- *  refetches from the browser where the zone is known.
+ *  The month is the one this PROCESS is in, which is not necessarily the reader's: a
+ *  render at 18:00 in Los Angeles on 31 July happens on 1 August here. The margin
+ *  rangeForMonth adds is sized for a day boundary and cannot absorb a month boundary, so
+ *  the month fetched is reported back rather than assumed — the component compares it
+ *  with the reader's own and refetches when they differ. Guessing instead would serve a
+ *  July grid populated only in its last week, with nothing to say so.
  *
  *  A transient failure returns undefined, letting the view fall back to its own client
  *  fetch and a friendly error rather than 500ing the page — same contract as loadBoard. */
 export async function loadTimeline(fetchImpl: typeof fetch, cookie: string | null) {
   const now = new Date();
-  const { from, to } = rangeForMonth(now.getUTCFullYear(), now.getUTCMonth());
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const { from, to } = rangeForMonth(year, month);
   try {
-    return await serverApi(fetchImpl, cookie).myTimeline(from, to);
+    return { events: await serverApi(fetchImpl, cookie).myTimeline(from, to), year, month };
   } catch {
     return undefined;
   }

--- a/web/src/lib/server/tracking.ts
+++ b/web/src/lib/server/tracking.ts
@@ -1,4 +1,5 @@
 import { serverApi } from './api';
+import { rangeForMonth } from '$lib/calendarModel';
 
 /** Fetch the caller's Kanban board rows for the tracking routes' server load, so
  *  the board renders with the page instead of after a client fetch on mount. A
@@ -8,6 +9,26 @@ export async function loadBoard(fetchImpl: typeof fetch, cookie: string | null) 
   try {
     const board = await serverApi(fetchImpl, cookie).listMyJobs('board', 500, 0);
     return board.items;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Fetch the caller's application events for a month's grid, so the calendar paints with
+ *  the page instead of after a client fetch on mount.
+ *
+ *  The month is the SERVER's, in UTC — this render cannot know the reader's zone. The
+ *  margin rangeForMonth adds is what makes that safe: whatever the reader's offset, their
+ *  own current month falls inside the span asked for here, and moving between months
+ *  refetches from the browser where the zone is known.
+ *
+ *  A transient failure returns undefined, letting the view fall back to its own client
+ *  fetch and a friendly error rather than 500ing the page — same contract as loadBoard. */
+export async function loadTimeline(fetchImpl: typeof fetch, cookie: string | null) {
+  const now = new Date();
+  const { from, to } = rangeForMonth(now.getUTCFullYear(), now.getUTCMonth());
+  try {
+    return await serverApi(fetchImpl, cookie).myTimeline(from, to);
   } catch {
     return undefined;
   }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -852,3 +852,34 @@ export type ExperienceBank = {
   employments: ExperienceEmploymentWithAtoms[];
   unplaced: ExperienceAtom[];
 };
+
+/** One thing that happened to one application, as GET /me/timeline serves it.
+ *
+ *  `kind` and `signal` are values from the server's vocabularies rather than a closed
+ *  union: `application_events` splits the two precisely so a growing vocabulary is not a
+ *  change to a table that must not change, and a union here would make every addition a
+ *  change to the SPA as well. Render an unrecognised kind, do not drop it.
+ *
+ *  `occurred_at` is an instant, not a day. Which day it falls on depends on the reader's
+ *  clock — see calendarModel.
+ *
+ *  `observed` is the server's verdict on the source: mail-derived events carry a date
+ *  somebody other than the candidate set, a stage they moved themselves carries the date
+ *  they got around to recording it. Never re-derive this from `source` here; the rule
+ *  lives in Go and a second copy would drift from it. */
+export interface TimelineEvent {
+  id: number;
+  kind: string;
+  signal?: string;
+  source: string;
+  observed: boolean;
+  occurred_at: string;
+  company_slug: string;
+  role_title?: string;
+  application_id?: number;
+  job_slug?: string;
+  /** Absent for an event with no message, and for one whose message was deleted — the
+   *  deletion hides the content and leaves the event standing. */
+  email_id?: number;
+  email_subject?: string;
+}

--- a/web/src/routes/my/tracking/+layout.svelte
+++ b/web/src/routes/my/tracking/+layout.svelte
@@ -16,9 +16,16 @@
   const boardActive = $derived(path === '/my/tracking');
   const listActive = $derived(path.startsWith('/my/tracking/list'));
   const pipelineActive = $derived(path.startsWith('/my/tracking/pipeline'));
+  const calendarActive = $derived(path.startsWith('/my/tracking/calendar'));
   // The id of the active tab, so the routed panel can point back at it (aria-labelledby).
   const activeTabId = $derived(
-    pipelineActive ? 'tracking-tab-pipeline' : listActive ? 'tracking-tab-list' : 'tracking-tab-board',
+    calendarActive
+      ? 'tracking-tab-calendar'
+      : pipelineActive
+        ? 'tracking-tab-pipeline'
+        : listActive
+          ? 'tracking-tab-list'
+          : 'tracking-tab-board',
   );
 
   const tabClass = (active: boolean) =>
@@ -68,6 +75,16 @@
       class={tabClass(pipelineActive)}
     >
       Pipeline
+    </a>
+    <a
+      role="tab"
+      id="tracking-tab-calendar"
+      aria-selected={calendarActive}
+      aria-controls="tracking-tabpanel"
+      href={resolve('/my/tracking/calendar')}
+      class={tabClass(calendarActive)}
+    >
+      Calendar
     </a>
   </div>
 

--- a/web/src/routes/my/tracking/calendar/+page.server.ts
+++ b/web/src/routes/my/tracking/calendar/+page.server.ts
@@ -1,0 +1,18 @@
+import { redirect } from '@sveltejs/kit';
+import { loadTimeline } from '$lib/server/tracking';
+import type { PageServerLoad } from './$types';
+
+// /my/tracking/calendar is the application-event ledger laid out in time. Same guard as
+// the other tracking views; the fetch is its own, because the board's rows answer "where
+// is this application now" and this view answers "what happened, and when".
+//
+// The load fetches only. The grid is arranged in the browser, which is the only place the
+// reader's timezone is known — see calendarModel.
+export const load: PageServerLoad = async ({ parent, url, fetch, request }) => {
+  const { user } = await parent();
+  if (!user) {
+    const target = url.pathname + url.search;
+    redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
+  }
+  return { events: await loadTimeline(fetch, request.headers.get('cookie')) };
+};

--- a/web/src/routes/my/tracking/calendar/+page.server.ts
+++ b/web/src/routes/my/tracking/calendar/+page.server.ts
@@ -14,5 +14,5 @@ export const load: PageServerLoad = async ({ parent, url, fetch, request }) => {
     const target = url.pathname + url.search;
     redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
   }
-  return { events: await loadTimeline(fetch, request.headers.get('cookie')) };
+  return { prefetched: await loadTimeline(fetch, request.headers.get('cookie')) };
 };

--- a/web/src/routes/my/tracking/calendar/+page.svelte
+++ b/web/src/routes/my/tracking/calendar/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import TrackingCalendar from '$lib/components/TrackingCalendar.svelte';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+  <title>Calendar — Tracking — freehire</title>
+</svelte:head>
+
+<TrackingCalendar events={data.events} />

--- a/web/src/routes/my/tracking/calendar/+page.svelte
+++ b/web/src/routes/my/tracking/calendar/+page.svelte
@@ -9,4 +9,4 @@
   <title>Calendar — Tracking — freehire</title>
 </svelte:head>
 
-<TrackingCalendar events={data.events} />
+<TrackingCalendar prefetched={data.prefetched} />


### PR DESCRIPTION
## What and why

`application_events` (migration 0062) has recorded every movement of every application
since it landed — applied, employer replies, follow-ups, stage changes — each with the
date it happened and the provenance that says whether anybody but the candidate observed
it. Nothing read it as a series. The writes are there, `insights.sql` aggregates it per
company, and the migration's own comment concedes that `stage_set` is *"written from day
one and read by no timing yet"*.

So the candidate could not see their own search laid out in time. Board answers "where is
this application now", List answers "what am I waiting on", and neither answers "what
happened in July". This adds the reader and the view.

- **`GET /me/timeline?from=&to=`** (`internal/apptimeline`) — the ledger's first dated read.
- **Tracking → Calendar** — a month grid with a day panel, each event linking to its
  application and, when the message still exists, to it in the inbox.

No new table, no migration, no backfill. Every row this reads is already being written.

### Three rules worth naming

- **`observed` is the server's verdict**, taken from `appevent.TrustedForDayMath`. Only mail
  sources carry a date somebody else set; a stage the candidate moved records when they got
  around to updating their board. A second copy of that rule in the browser would keep
  calling a newly added source observed after the Go side had refused it. Filled marks are
  observed, hollow ones are recorded.
- **Deleting a message withholds its subject and leaves the event standing.** It is a
  condition of the `LEFT JOIN`, not a filter on the result — as a `WHERE` clause it would
  have dropped the event, which is the exact distortion the ledger exists to remove.
- **`occurred_at` crosses the wire as an instant.** Which day it falls on depends on the
  reader's clock, so the server never groups by day and the browser does. The fetch asks
  for a day of margin either side of the grid, or its first and last rows are short.
  `calendarModel.west.test.ts` runs the suite west of UTC, where a UTC-based grid fails the
  opposite way and the eastern file cannot see it.

### Deliberately out of scope

Interview times and any forward-looking view. The ledger holds no interview time and
neither does the mail — `interview_invitation` says an invitation arrived, not when the
meeting is. That date will come from reading the candidate's own calendar, in its own
change. `kind` therefore crosses the wire as a value rather than a closed set, and an
unrecognised kind renders instead of disappearing.

### Notable fixes found in review

- The `emails` join used the bare `source_ref`, which 0062 defines as an `emails.id` **only
  for mail-derived events**. The deferred interview kind would have captioned an interview
  with an unrelated rejection.
- The server fetched its own month while the browser drew the reader's; they differ for
  hours at every month boundary, and only a failed load triggered a refetch.
- The day panel's application link used the bare application id. The board addresses rows
  by the posting's public slug, or `a<id>` only when `cmd/prune` removed the posting — so
  the drawer silently did not open, for every event.

### Verification

Beyond the gates below, the whole path was exercised against a running stack seeded through
the real apply path: browsing the calendar marked **no** mail read, while clicking through
to a message marked exactly that one — the asymmetry the day panel's no-fetch rule exists
to protect.

OpenSpec: `openspec/changes/tracking-calendar-view` (26/26 tasks, `openspec validate` clean).

No tracking issue — requested directly by the maintainer.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` — 129 packages ok).
- [x] I regenerated committed artifacts when their source changed (`make sqlc`; `make gen-contracts` leaves the tree clean; `docs/API.md` regenerated from `api-spec.ts`).
- [x] For `design-system/` changes: n/a — none.
- [x] For `web/` changes: `pnpm run check` (0 errors) and `pnpm run build` pass.
- [x] This stays within freehire's core/extension boundary — it reads a table the core already writes and adds no new storage.