### PR TITLE
classify-mail reports the run's outcome through the exit code

### DIFF
--- a/cmd/classify-mail/main.go
+++ b/cmd/classify-mail/main.go
@@ -52,10 +52,14 @@ func run() int {
 
 	runner := maillink.New(newDBStore(pool), mailclassify.NewClassifier(client), client.ModelID()).
 		WithLearner(newDomainLearner(pool))
-	if err := runner.Run(ctx); err != nil {
+	stats, err := runner.Run(ctx)
+	if err != nil {
 		log.Printf("classify-mail: %v", err)
 		return 1
 	}
-	log.Printf("classify-mail: done")
-	return 0
+	log.Printf("classify-mail: done failed=%d dead-lettered=%d", stats.Failed, stats.DeadLettered)
+	// Nothing else reads email_classification_outbox.failed_at, so a queue that dead-letters
+	// every entry was previously visible only in journalctl. The exit code is what the
+	// scheduler sees.
+	return worker.ExitCode(stats.Failed, stats.DeadLettered)
 }

--- a/cmd/classify-mail/store.go
+++ b/cmd/classify-mail/store.go
@@ -146,12 +146,18 @@ func (s *dbStore) Save(ctx context.Context, outboxID, userID int64, r maillink.R
 	return tx.Commit(ctx)
 }
 
-func (s *dbStore) Fail(ctx context.Context, outboxID int64, cause string, maxAttempts int) error {
-	return s.q.FailEmailClassification(ctx, db.FailEmailClassificationParams{
+// Fail records the attempt and reports whether the entry dead-lettered, which the statement
+// tells us by stamping failed_at — the same signal the enrichment and semantic queues return.
+func (s *dbStore) Fail(ctx context.Context, outboxID int64, cause string, maxAttempts int) (bool, error) {
+	row, err := s.q.FailEmailClassification(ctx, db.FailEmailClassificationParams{
 		LastError:   cause,
 		MaxAttempts: int32(maxAttempts),
 		ID:          outboxID,
 	})
+	if err != nil {
+		return false, err
+	}
+	return row.FailedAt.Valid, nil
 }
 
 func int8OrNull(v int64) pgtype.Int8 {

--- a/internal/db/mail_classification.sql.go
+++ b/internal/db/mail_classification.sql.go
@@ -199,12 +199,13 @@ func (q *Queries) EnqueuePendingEmailClassification(ctx context.Context) (int64,
 	return result.RowsAffected(), nil
 }
 
-const failEmailClassification = `-- name: FailEmailClassification :exec
+const failEmailClassification = `-- name: FailEmailClassification :one
 UPDATE email_classification_outbox
 SET attempts    = attempts + 1,
     last_error  = $1,
     failed_at   = CASE WHEN attempts + 1 >= $2::int THEN now() ELSE NULL END
 WHERE id = $3
+RETURNING attempts, failed_at
 `
 
 type FailEmailClassificationParams struct {
@@ -213,14 +214,23 @@ type FailEmailClassificationParams struct {
 	ID          int64  `json:"id"`
 }
 
+type FailEmailClassificationRow struct {
+	Attempts int32              `json:"attempts"`
+	FailedAt pgtype.Timestamptz `json:"failed_at"`
+}
+
 // Record a failed attempt: bump attempts, store the error, and dead-letter (set
 // failed_at) once attempts reach max_attempts. The lease (claimed_at) is
 // intentionally left in place — its expiry gates the retry to a later run and
 // doubles as the crash reaper, so a failed entry is never reprocessed within the
-// same run. Mirrors RecordEnrichmentFailure / RecordSemanticFailure.
-func (q *Queries) FailEmailClassification(ctx context.Context, arg FailEmailClassificationParams) error {
-	_, err := q.db.Exec(ctx, failEmailClassification, arg.LastError, arg.MaxAttempts, arg.ID)
-	return err
+// same run. Mirrors RecordEnrichmentFailure / RecordSemanticFailure, RETURNING included:
+// failed_at is how the caller learns an entry dead-lettered, which is what decides the
+// worker's exit code. Without it a mail queue can dead-letter every entry and still exit 0.
+func (q *Queries) FailEmailClassification(ctx context.Context, arg FailEmailClassificationParams) (FailEmailClassificationRow, error) {
+	row := q.db.QueryRow(ctx, failEmailClassification, arg.LastError, arg.MaxAttempts, arg.ID)
+	var i FailEmailClassificationRow
+	err := row.Scan(&i.Attempts, &i.FailedAt)
+	return i, err
 }
 
 const getUserJobStage = `-- name: GetUserJobStage :one

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -684,8 +684,10 @@ type Querier interface {
 	// failed_at) once attempts reach max_attempts. The lease (claimed_at) is
 	// intentionally left in place — its expiry gates the retry to a later run and
 	// doubles as the crash reaper, so a failed entry is never reprocessed within the
-	// same run. Mirrors RecordEnrichmentFailure / RecordSemanticFailure.
-	FailEmailClassification(ctx context.Context, arg FailEmailClassificationParams) error
+	// same run. Mirrors RecordEnrichmentFailure / RecordSemanticFailure, RETURNING included:
+	// failed_at is how the caller learns an entry dead-lettered, which is what decides the
+	// worker's exit code. Without it a mail queue can dead-letter every entry and still exit 0.
+	FailEmailClassification(ctx context.Context, arg FailEmailClassificationParams) (FailEmailClassificationRow, error)
 	// Import's write: fill only the fields the bank has nothing for, and never overwrite a value
 	// already there. A user who corrected their job title must not have that correction undone by
 	// re-uploading the CV it came from. is_current is not touched at all — a CV that still says

--- a/internal/db/queries/mail_classification.sql
+++ b/internal/db/queries/mail_classification.sql
@@ -100,17 +100,20 @@ WHERE emails.id = sqlc.arg(id) AND emails.user_id = sqlc.arg(user_id);
 -- name: DeleteEmailClassificationOutbox :exec
 DELETE FROM email_classification_outbox WHERE id = $1;
 
--- name: FailEmailClassification :exec
+-- name: FailEmailClassification :one
 -- Record a failed attempt: bump attempts, store the error, and dead-letter (set
 -- failed_at) once attempts reach max_attempts. The lease (claimed_at) is
 -- intentionally left in place — its expiry gates the retry to a later run and
 -- doubles as the crash reaper, so a failed entry is never reprocessed within the
--- same run. Mirrors RecordEnrichmentFailure / RecordSemanticFailure.
+-- same run. Mirrors RecordEnrichmentFailure / RecordSemanticFailure, RETURNING included:
+-- failed_at is how the caller learns an entry dead-lettered, which is what decides the
+-- worker's exit code. Without it a mail queue can dead-letter every entry and still exit 0.
 UPDATE email_classification_outbox
 SET attempts    = attempts + 1,
     last_error  = sqlc.arg(last_error),
     failed_at   = CASE WHEN attempts + 1 >= sqlc.arg(max_attempts)::int THEN now() ELSE NULL END
-WHERE id = sqlc.arg(id);
+WHERE id = sqlc.arg(id)
+RETURNING attempts, failed_at;
 
 -- name: ListUserApplicationsForMatch :many
 -- The caller's open applications offered to the matcher (applied, saved, or staged),

--- a/internal/maillink/runner.go
+++ b/internal/maillink/runner.go
@@ -67,7 +67,11 @@ type Store interface {
 	CurrentStage(ctx context.Context, userID, jobID int64) (string, error)
 	// Save persists the result and deletes the outbox row in one transaction.
 	Save(ctx context.Context, outboxID, userID int64, r Result, model string) error
-	Fail(ctx context.Context, outboxID int64, cause string, maxAttempts int) error
+	// Fail records a failed attempt and reports whether the entry dead-lettered — reached
+	// max_attempts and will not be retried. The bool is not decoration: it is what the
+	// worker's exit code is built from, and without it a queue can dead-letter every entry
+	// and still exit 0.
+	Fail(ctx context.Context, outboxID int64, cause string, maxAttempts int) (deadLettered bool, err error)
 }
 
 // Classifier is the LLM port.
@@ -117,9 +121,19 @@ func (r *Runner) WithLearner(l Learner) *Runner {
 
 // Run enqueues every unclassified email, then drains the outbox wave by wave
 // until it is empty.
-func (r *Runner) Run(ctx context.Context) error {
+// Stats is what a run reports upward. Failed counts entries whose processing errored this
+// run; DeadLettered counts the subset that reached max_attempts and will not be retried.
+// cmd/classify-mail turns them into its exit code, so a mail queue that quietly stops working
+// is visible to the scheduler rather than only in journalctl.
+type Stats struct {
+	Failed       int
+	DeadLettered int
+}
+
+func (r *Runner) Run(ctx context.Context) (Stats, error) {
+	var stats Stats
 	if _, err := r.store.EnqueuePending(ctx); err != nil {
-		return err
+		return stats, err
 	}
 	// A wave is mostly one user's mail, and their application list is the same for
 	// every message in it — see appCache for why the thread links are NOT cached
@@ -128,15 +142,24 @@ func (r *Runner) Run(ctx context.Context) error {
 	for {
 		batch, err := r.store.ClaimBatch(ctx, r.leaseSeconds, r.batchSize)
 		if err != nil {
-			return err
+			return stats, err
 		}
 		if len(batch) == 0 {
-			return nil
+			return stats, nil
 		}
 		for _, c := range batch {
 			if err := r.process(ctx, apps, c); err != nil {
-				if ferr := r.store.Fail(ctx, c.OutboxID, err.Error(), r.maxAttempts); ferr != nil {
+				stats.Failed++
+				// Tallied where the bookkeeping error is already logged: a Fail that itself
+				// fails leaves the entry to its lease expiry, so it counts as failed but its
+				// dead-letter state is unknown and is not guessed.
+				deadLettered, ferr := r.store.Fail(ctx, c.OutboxID, err.Error(), r.maxAttempts)
+				if ferr != nil {
 					log.Printf("maillink: fail outbox %d: %v", c.OutboxID, ferr)
+					continue
+				}
+				if deadLettered {
+					stats.DeadLettered++
 				}
 			}
 		}

--- a/internal/maillink/runner_test.go
+++ b/internal/maillink/runner_test.go
@@ -2,6 +2,7 @@ package maillink
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -18,6 +19,9 @@ type fakeStore struct {
 	claimedOnce bool
 	saved       []Result
 	savedOutbox []int64
+	failCalls   int
+	deadLetter  bool
+	failErr     error
 }
 
 func (s *fakeStore) EnqueuePending(context.Context) (int64, error) { return 0, nil }
@@ -42,7 +46,13 @@ func (s *fakeStore) Save(_ context.Context, outboxID, _ int64, r Result, _ strin
 	s.savedOutbox = append(s.savedOutbox, outboxID)
 	return nil
 }
-func (s *fakeStore) Fail(context.Context, int64, string, int) error { return nil }
+
+// failCalls records every Fail the run made, and deadLetter decides what each reports — the
+// signal the worker's exit code is built from.
+func (s *fakeStore) Fail(context.Context, int64, string, int) (bool, error) {
+	s.failCalls++
+	return s.deadLetter, s.failErr
+}
 
 type fakeClassifier struct {
 	out        mailclassify.Classification
@@ -68,7 +78,7 @@ func TestRunnerAutoLinksDeterministicMatchAndAdvancesStage(t *testing.T) {
 	cls := &fakeClassifier{out: mailclassify.Classification{Signal: mailclassify.SignalInterviewInvitation, Confidence: 0.95}}
 	r := New(store, cls, "test-model")
 
-	if err := r.Run(context.Background()); err != nil {
+	if _, err := r.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if len(store.saved) != 1 {
@@ -106,7 +116,7 @@ func TestRunnerFeedsHTMLOnlyBodyToClassifier(t *testing.T) {
 	cls := &fakeClassifier{out: mailclassify.Classification{Signal: mailclassify.SignalRejection, Confidence: 0.9}}
 	r := New(store, cls, "test-model")
 
-	if err := r.Run(context.Background()); err != nil {
+	if _, err := r.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if cls.gotBody == "" {
@@ -139,7 +149,7 @@ func TestRunnerLearnsSenderOfApplicationMail(t *testing.T) {
 	learner := &fakeLearner{}
 	r := New(store, cls, "test-model").WithLearner(learner)
 
-	if err := r.Run(context.Background()); err != nil {
+	if _, err := r.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if len(learner.learned) != 1 || learner.learned[0] != "no-reply@newats.example" {
@@ -156,7 +166,7 @@ func TestRunnerDoesNotLearnNonApplicationMail(t *testing.T) {
 	learner := &fakeLearner{}
 	r := New(store, cls, "test-model").WithLearner(learner)
 
-	if err := r.Run(context.Background()); err != nil {
+	if _, err := r.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if len(learner.learned) != 0 {
@@ -175,7 +185,7 @@ func TestRunnerAmbiguousMatchOffersLLMSuggestion(t *testing.T) {
 	cls := &fakeClassifier{out: mailclassify.Classification{Signal: mailclassify.SignalRejection, Confidence: 0.9, MatchedJobID: 6}}
 	r := New(store, cls, "test-model")
 
-	if err := r.Run(context.Background()); err != nil {
+	if _, err := r.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	got := store.saved[0]
@@ -210,7 +220,7 @@ func TestRunnerReadsApplicationsOncePerUserButThreadLinksEveryTime(t *testing.T)
 	}
 	r := New(store, &fakeClassifier{out: mailclassify.Classification{Signal: mailclassify.SignalAcknowledgement}}, "test-model")
 
-	if err := r.Run(context.Background()); err != nil {
+	if _, err := r.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -221,4 +231,75 @@ func TestRunnerReadsApplicationsOncePerUserButThreadLinksEveryTime(t *testing.T)
 		t.Errorf("ThreadLinks read %d times for 3 emails, want 3 — a link written mid-wave must be visible to the rest of it",
 			store.threadReads)
 	}
+}
+
+// A queue that fails everything must say so upward. Nothing else reads
+// email_classification_outbox.failed_at, so before this the worker logged "done" and returned 0
+// while every entry dead-lettered — the state worker.ExitCode exists to surface.
+func TestRunnerTalliesFailuresAndDeadLetters(t *testing.T) {
+	store := &fakeStore{
+		deadLetter: true,
+		claimed: []Claimed{
+			{OutboxID: 1, EmailID: 11, UserID: 1, Subject: "a"},
+			{OutboxID: 2, EmailID: 12, UserID: 1, Subject: "b"},
+		},
+	}
+	r := New(store, &explodingClassifier{}, "test-model")
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Failed != 2 || stats.DeadLettered != 2 {
+		t.Errorf("stats = %+v, want Failed=2 DeadLettered=2", stats)
+	}
+	if store.failCalls != 2 {
+		t.Errorf("Fail called %d times, want 2", store.failCalls)
+	}
+}
+
+// A failure that has NOT exhausted its attempts is a retry, not a dead letter. Counting it as
+// one would fail the run for a queue that is working exactly as designed.
+func TestRunnerCountsARetryableFailureSeparately(t *testing.T) {
+	store := &fakeStore{
+		deadLetter: false,
+		claimed:    []Claimed{{OutboxID: 1, EmailID: 11, UserID: 1, Subject: "a"}},
+	}
+	r := New(store, &explodingClassifier{}, "test-model")
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Failed != 1 || stats.DeadLettered != 0 {
+		t.Errorf("stats = %+v, want Failed=1 DeadLettered=0", stats)
+	}
+}
+
+// When the bookkeeping write itself fails the entry is left to its lease expiry, so its
+// dead-letter state is unknown — and unknown is not guessed. It still counts as failed.
+func TestRunnerDoesNotGuessDeadLetterWhenFailItselfFails(t *testing.T) {
+	store := &fakeStore{
+		deadLetter: true, // would have said yes, had the write landed
+		failErr:    errContrived,
+		claimed:    []Claimed{{OutboxID: 1, EmailID: 11, UserID: 1, Subject: "a"}},
+	}
+	r := New(store, &explodingClassifier{}, "test-model")
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Failed != 1 || stats.DeadLettered != 0 {
+		t.Errorf("stats = %+v, want Failed=1 DeadLettered=0 — the write never landed", stats)
+	}
+}
+
+var errContrived = errors.New("contrived bookkeeping failure")
+
+// explodingClassifier fails every message, which is how the tests above drive the failure path.
+type explodingClassifier struct{}
+
+func (explodingClassifier) Classify(context.Context, mailclassify.Input) (mailclassify.Classification, error) {
+	return mailclassify.Classification{}, errContrived
 }

--- a/openspec/changes/classify-mail-reports-its-outcome/.openspec.yaml
+++ b/openspec/changes/classify-mail-reports-its-outcome/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/classify-mail-reports-its-outcome/proposal.md
+++ b/openspec/changes/classify-mail-reports-its-outcome/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+`worker-lifecycle` already requires it: *"A worker process SHALL exit with a non-zero code when
+its run completes with one or more per-item failures or dead-lettered items."* Eight binaries
+obey it. `cmd/classify-mail` logged `"classify-mail: done"` and returned `0` unconditionally.
+
+It could not do otherwise. The information was dropped three layers down:
+`FailEmailClassification` was `:exec`, where its two siblings — `RecordEnrichmentFailure` and
+`RecordSemanticFailure`, which its own comment claims to mirror — are `:one ... RETURNING
+attempts, failed_at`. So `maillink.Store.Fail` returned only `error`, the `Run` loop kept no
+tallies, and `main` had nothing to report.
+
+Nothing else reads `email_classification_outbox.failed_at`. A mail queue that dead-letters every
+message was therefore visible in `journalctl` and nowhere else — which is exactly the state
+`worker.ExitCode` exists to surface.
+
+## What Changes
+
+- `FailEmailClassification` becomes `:one ... RETURNING attempts, failed_at`, matching the two
+  queries its comment already said it mirrored.
+- `maillink.Store.Fail` returns `(deadLettered bool, err error)`; `Runner.Run` returns
+  `Stats{Failed, DeadLettered}`, tallied where it already logged the bookkeeping error.
+- `cmd/classify-mail` ends on `worker.ExitCode(stats.Failed, stats.DeadLettered)` and logs the
+  two counts.
+- **A bookkeeping write that itself fails does not guess.** The entry is then left to its lease
+  expiry, so its dead-letter state is unknown: it counts as failed and not as dead-lettered.
+- Deliberately NOT extracted: a shared `worker.Outcome` for two callers of a dozen lines each.
+  `enrich` tallies under a mutex because a wave runs concurrently; `embed` deliberately fails on
+  `context.Background()`. They are not the same shape.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `worker-lifecycle`: "Bookkeeping failures are logged and counted" was scoped to *the enrichment
+  drain*. It binds every queue drain — leaving it enrichment-specific is how the next one drifts —
+  and it gains the rule that a drain must not guess a dead-letter it could not record.
+
+## Impact
+
+- `internal/db/queries/mail_classification.sql` (+ regenerated `internal/db`),
+  `internal/maillink/runner.go`, `cmd/classify-mail/{main,store}.go`.
+- No migration: the column already exists and the statement already wrote it. Only the read is new.
+- Operationally visible: a classify-mail run with any failure now exits non-zero, so cron alerts
+  where it previously did not.

--- a/openspec/changes/classify-mail-reports-its-outcome/specs/worker-lifecycle/spec.md
+++ b/openspec/changes/classify-mail-reports-its-outcome/specs/worker-lifecycle/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Bookkeeping failures are logged and counted
+
+A queue drain MUST count a failure of the bookkeeping call that records an item as failed
+toward the run's failure total (so the run reports a non-zero outcome), and SHALL log the error
+cause — so an operator can diagnose why the bookkeeping write failed instead of seeing only an
+opaque failure tally.
+
+This binds every queue drain, not only the enrichment one. A drain whose bookkeeping write fails
+does not know whether the item dead-lettered, and it MUST NOT guess: the item counts as failed
+and its dead-letter state is left unrecorded, because the entry is then governed by its lease
+expiry rather than by a stamp the run never wrote.
+
+#### Scenario: A failed bookkeeping write is counted and logged
+
+- **WHEN** the runner's call to mark a job as failed itself returns an error
+- **THEN** the failure is counted toward the run's failure total (the run's
+  outcome is non-zero) and the error cause is written to the log
+
+#### Scenario: A drain does not guess a dead-letter it could not record
+
+- **WHEN** a queue drain's call to record a failed attempt itself fails, and that call is what
+  would have reported whether the item dead-lettered
+- **THEN** the run counts the item as failed and does NOT count it as dead-lettered

--- a/openspec/changes/classify-mail-reports-its-outcome/tasks.md
+++ b/openspec/changes/classify-mail-reports-its-outcome/tasks.md
@@ -1,0 +1,28 @@
+## 1. Restore the signal at the source
+
+- [x] 1.1 `FailEmailClassification` → `:one ... RETURNING attempts, failed_at`, matching the two
+      siblings its comment already claimed to mirror. Regenerate with `make sqlc`.
+- [x] 1.2 `dbStore.Fail` reports `row.FailedAt.Valid` — the stamp IS the dead-letter signal.
+
+## 2. Carry it up
+
+- [x] 2.1 Widen `maillink.Store.Fail` to `(deadLettered bool, err error)`, with the doc saying
+      the bool is what the exit code is built from.
+- [x] 2.2 `Runner.Run` returns `Stats{Failed, DeadLettered}`, tallied where the bookkeeping error
+      is already logged.
+- [x] 2.3 A Fail that itself fails counts as failed and NOT as dead-lettered — the entry is left
+      to its lease expiry, so the state is unknown and must not be guessed.
+- [x] 2.4 `cmd/classify-mail` ends on `worker.ExitCode`, and logs both counts.
+
+## 3. Tests
+
+- [x] 3.1 Every message failing, all dead-lettering → `Failed=2, DeadLettered=2`.
+- [x] 3.2 A retryable failure counts as failed only — counting it as a dead letter would fail a
+      run for a queue working exactly as designed.
+- [x] 3.3 The unknown case: `deadLetter` would have been true, but the write failed.
+
+## 4. Verify and close
+
+- [x] 4.1 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 4.2 Confirm `cmd/classify-mail` now appears in the `worker.ExitCode` census.
+- [x] 4.3 Mark S20 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
S20 from the 2026-08-01 architecture review — the last of the ranked shortlist.

`worker-lifecycle` **already requires this**: *"A worker process SHALL exit with a non-zero code
when its run completes with one or more per-item failures or dead-lettered items."* Eight
binaries obey it. `cmd/classify-mail` logged `"classify-mail: done"` and returned `0`
unconditionally.

It could not do otherwise — the information was dropped three layers down:

| layer | classify-mail | its two siblings |
|---|---|---|
| query | `FailEmailClassification :exec` | `:one … RETURNING attempts, failed_at` |
| port | `Fail(…) error` | `Fail(…) (bool, error)` |
| run loop | no tallies | `Stats{Failed, DeadLettered}` |
| main | `return 0` | `worker.ExitCode(…)` |

…and the query's own comment claimed it *"Mirrors RecordEnrichmentFailure /
RecordSemanticFailure"*.

Nothing else reads `email_classification_outbox.failed_at`. So a mail queue that dead-lettered
**every** message was visible in `journalctl` and nowhere else — precisely the state
`worker.ExitCode` exists to surface.

## The unknown case, which is the interesting one

A bookkeeping write that itself fails does **not** guess. The entry is then governed by its lease
expiry rather than by a stamp the run never wrote, so its dead-letter state is unknown: it counts
as failed and **not** as dead-lettered. Tested explicitly — the fake would have reported `true`,
but the write errored.

## A spec that was right but scoped too narrowly

`worker-lifecycle`'s "Bookkeeping failures are logged and counted" said *"The **enrichment
drain** MUST count…"*. The rule is not enrichment-specific, and leaving it that way is how the
next queue drifts. It now binds every queue drain, and carries the don't-guess rule above.

That is the only spec delta here: the exit-code requirement itself needed no change, because
`classify-mail` was simply not obeying a rule already written down.

## Not done, deliberately

No shared `worker.Outcome` extracted for two callers of a dozen lines each. `enrich` tallies
under a mutex because a wave runs concurrently; `embed` deliberately fails on
`context.Background()`. They are not the same shape, and a premature common type would have to
paper over both.

No migration: the column exists and the statement already wrote it. Only the read is new.

**Operationally visible:** a classify-mail run with any failure now exits non-zero, so cron
alerts where it previously did not.

`go test ./...` **and** `go test -tags=integration ./...` green. `cmd/classify-mail` now appears
in the `worker.ExitCode` census alongside the other ten.
