### PR TITLE
fix(harvest-boards): tell a refused run from an exhausted one

### DIFF
--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -55,7 +55,7 @@ func run() int {
 	}
 
 	ctx := context.Background()
-	client := paced(sources.NewClient(), *pace)
+	client := newCountingClient(paced(sources.NewClient(), *pace))
 	if *pace > 0 {
 		log.Printf("harvest-boards: pacing probes at %.2f req/s with %d workers", *pace, *workers)
 	}
@@ -82,8 +82,18 @@ func run() int {
 		provider, len(raw), len(existing), len(candidates))
 
 	kept, failures, mismatches := probeAll(ctx, client, p, candidates, companyByBoard, *workers)
-	log.Printf("harvest-boards: live boards found=%d probe-failures=%d name-mismatches=%d",
-		len(kept), failures, mismatches)
+	log.Printf("harvest-boards: live boards found=%d probe-failures=%d name-mismatches=%d refused=%d answered=%d",
+		len(kept), failures, mismatches, client.refused(), client.answered())
+	// A run the platform mostly turned away found nothing because it was not allowed to look.
+	// The probers cannot say so — they report a refusal as an absent board — so this is the
+	// only guard that can tell a truncated harvest from an exhausted one. Committing the
+	// former is how a board file silently loses the boards nobody got to probe.
+	if refusalsDominated(client.refused(), client.answered()) {
+		log.Printf("harvest-boards: %d requests refused against %d answered — the platform is "+
+			"rate-limiting this run; nothing written. Retry later, or lower -pace",
+			client.refused(), client.answered())
+		return 1
+	}
 	// Every candidate erroring means the probe itself is broken (an API change, an
 	// auth wall, a network outage) — not "no new boards". Fail loudly so the empty
 	// result is not mistaken for an exhausted candidate list.

--- a/cmd/harvest-boards/refusals.go
+++ b/cmd/harvest-boards/refusals.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+
+	"golang.org/x/net/html"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// countingClient records what the probers deliberately throw away. A prober turns every
+// transport failure into ("", 0, nil) — "no such board" — which is right for a dead host and
+// wrong for a platform that refused to answer. Because the error never reaches probeAll, its
+// all-probes-failed guard can never fire for those probers: they do not fail, they report
+// absence. So the transport is the last place that still knows the difference, and it counts
+// it here.
+//
+// This matters more than it sounds. A harvest run against a rate-limiting platform otherwise
+// ends with a confident "found=N" that is short by an unknown amount, indistinguishable from
+// a run that genuinely found nothing new.
+type countingClient struct {
+	inner httpClient
+	mu    sync.Mutex
+	// refusedN counts responses that mean "not now" — the platform is there and declined.
+	refusedN int
+	// answeredN counts requests the platform answered at all, success or a plain absence.
+	answeredN int
+}
+
+func newCountingClient(inner httpClient) *countingClient {
+	return &countingClient{inner: inner}
+}
+
+// record classifies one transport outcome. A 429 (and the 503 a WAF serves under the same
+// conditions) is a refusal; a 404 is the platform answering "no such board", which is an
+// answer and exactly what a harvest is built to read; anything else — a timeout, a DNS
+// failure, a closed connection — is a dead host, which is neither.
+func (c *countingClient) record(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err == nil {
+		c.answeredN++
+		return
+	}
+	var se *sources.StatusError
+	if !errors.As(err, &se) {
+		return
+	}
+	switch se.Code {
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+		c.refusedN++
+	default:
+		c.answeredN++
+	}
+}
+
+func (c *countingClient) refused() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.refusedN
+}
+
+func (c *countingClient) answered() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.answeredN
+}
+
+// refusalsDominated reports whether a run was mostly turned away rather than answered. Such a
+// run is not a harvest that found little; it is a harvest that did not happen, and reporting
+// it as the former is how a truncated board file gets committed.
+func refusalsDominated(refused, answered int) bool {
+	return refused > 0 && refused > answered
+}
+
+func (c *countingClient) GetJSON(ctx context.Context, url string, v any) error {
+	err := c.inner.GetJSON(ctx, url, v)
+	c.record(err)
+	return err
+}
+
+func (c *countingClient) PostJSON(ctx context.Context, url string, body, v any) error {
+	err := c.inner.PostJSON(ctx, url, body, v)
+	c.record(err)
+	return err
+}
+
+func (c *countingClient) GetXML(ctx context.Context, url string, v any) error {
+	err := c.inner.GetXML(ctx, url, v)
+	c.record(err)
+	return err
+}
+
+func (c *countingClient) GetHTML(ctx context.Context, url string) (*html.Node, error) {
+	n, err := c.inner.GetHTML(ctx, url)
+	c.record(err)
+	return n, err
+}
+
+func (c *countingClient) GetText(ctx context.Context, url string) (string, error) {
+	s, err := c.inner.GetText(ctx, url)
+	c.record(err)
+	return s, err
+}
+
+func (c *countingClient) GetJSONWithHeaders(ctx context.Context, url string, headers map[string]string, v any) error {
+	err := c.inner.GetJSONWithHeaders(ctx, url, headers, v)
+	c.record(err)
+	return err
+}
+
+func (c *countingClient) PostJSONWithHeaders(ctx context.Context, url string, headers map[string]string, body, v any) error {
+	err := c.inner.PostJSONWithHeaders(ctx, url, headers, body, v)
+	c.record(err)
+	return err
+}

--- a/cmd/harvest-boards/refusals_test.go
+++ b/cmd/harvest-boards/refusals_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"golang.org/x/net/html"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// erroringClient answers every verb with a canned error, standing in for a platform that
+// refuses or a host that never answers.
+type erroringClient struct{ err error }
+
+func (c erroringClient) GetJSON(context.Context, string, any) error       { return c.err }
+func (c erroringClient) PostJSON(context.Context, string, any, any) error { return c.err }
+func (c erroringClient) GetXML(context.Context, string, any) error        { return c.err }
+func (c erroringClient) GetHTML(context.Context, string) (*html.Node, error) {
+	return nil, c.err
+}
+func (c erroringClient) GetText(context.Context, string) (string, error) { return "", c.err }
+func (c erroringClient) GetJSONWithHeaders(context.Context, string, map[string]string, any) error {
+	return c.err
+}
+func (c erroringClient) PostJSONWithHeaders(context.Context, string, map[string]string, any, any) error {
+	return c.err
+}
+
+// A prober turns every transport failure into "no such board" — right for a dead host,
+// wrong for a refusal. The counting client is the only place that still sees the
+// difference, so it has to separate them.
+func TestCountingClientSeparatesRefusalsFromOtherFailures(t *testing.T) {
+	refused := newCountingClient(erroringClient{
+		err: &sources.StatusError{Method: http.MethodGet, Code: http.StatusTooManyRequests, URL: "u"},
+	})
+	_ = refused.GetJSON(context.Background(), "u", nil)
+	if got := refused.refused(); got != 1 {
+		t.Errorf("refused = %d, want 1", got)
+	}
+	if got := refused.answered(); got != 0 {
+		t.Errorf("answered = %d, want 0", got)
+	}
+
+	dead := newCountingClient(erroringClient{err: errors.New("dial tcp: i/o timeout")})
+	_ = dead.GetJSON(context.Background(), "u", nil)
+	if got := dead.refused(); got != 0 {
+		t.Errorf("a timeout is not a refusal, refused = %d, want 0", got)
+	}
+}
+
+// A 404 is the platform answering "no such board" — the outcome a harvest is built to read,
+// and not a sign anything is wrong with the run.
+func TestCountingClientDoesNotCountAbsenceAsRefusal(t *testing.T) {
+	c := newCountingClient(erroringClient{
+		err: &sources.StatusError{Method: http.MethodGet, Code: http.StatusNotFound, URL: "u"},
+	})
+	_ = c.GetJSON(context.Background(), "u", nil)
+	if got := c.refused(); got != 0 {
+		t.Errorf("a 404 is an answer, refused = %d, want 0", got)
+	}
+}
+
+func TestCountingClientCountsSuccessfulAnswers(t *testing.T) {
+	c := newCountingClient(erroringClient{err: nil})
+	_ = c.GetJSON(context.Background(), "u", nil)
+	_ = c.GetXML(context.Background(), "u", nil)
+	if got := c.answered(); got != 2 {
+		t.Errorf("answered = %d, want 2", got)
+	}
+}
+
+// The whole point: a run the platform mostly refused is not a harvest that found nothing,
+// and it must not be reported as one.
+func TestRefusalsDominated(t *testing.T) {
+	if !refusalsDominated(10, 3) {
+		t.Error("more refusals than answers must be reported as a refused run")
+	}
+	if refusalsDominated(3, 10) {
+		t.Error("a few refusals among many answers is normal")
+	}
+	if refusalsDominated(0, 0) {
+		t.Error("a run that made no requests is not a refused run")
+	}
+}


### PR DESCRIPTION
## The bug

A prober turns every transport failure into `("", 0, nil)` — "no such board". That is right for a dead host and wrong for a platform that declined to answer.

The consequence is worse than it sounds: because the error never reaches `probeAll`, its **all-probes-failed guard can never fire** for those probers. They do not fail; they report absence. So a harvest against a rate-limiting platform ends with a confident `found=N` that is short by an unknown amount, indistinguishable from a run that genuinely found nothing new.

This is what the first Workable harvest (#1419) did. The paced re-run (#1423) did it again, more slowly — 3h14m to produce the same wrong answer. **Pacing treated a symptom, because the diagnosis was wrong.** We were not bursting too hard; we were being refused and could not tell. Workable returns 429 to this egress even at 3 req/s, on every slug, in 60ms.

## The fix

The transport is the last place that still knows, so it counts there:

| outcome | meaning |
|---|---|
| 429, 503 | **refusal** — the platform is there and declined |
| 404 | an answer: "no such board", exactly what a harvest reads |
| timeout, DNS failure, closed connection | a dead host |

When refusals outnumber answers, the run exits non-zero and writes nothing.

## Verification

Against the live Workable API, which is still rate-limiting this egress:

```
found=0 probe-failures=0 name-mismatches=0 refused=2 answered=0
2 requests refused against 0 answered — the platform is rate-limiting this run;
nothing written. Retry later, or lower -pace
exit status 1
```

Before this change the identical run logged `found=0 probe-failures=0` and exited **0**.

`gofmt`/`go build`/`go vet` clean, full `go test ./...` passes. Four unit tests cover the classification (429 refusal, 404 not a refusal, timeout not a refusal, success counted) and the dominance rule.
