### PR TITLE
One shape for the six LLM env values, two policies over it

### DIFF
--- a/cmd/backfill-experience/main.go
+++ b/cmd/backfill-experience/main.go
@@ -218,14 +218,7 @@ func newExtractor(cfg config.Settings, queries *db.Queries) (*resumeextract.Extr
 	if cfg.PIIFilterURL == "" {
 		return nil, nil, nil
 	}
-	llmClient, flush, err := llm.NewClient(llm.Settings{
-		BaseURL:           cfg.LLMBaseURL,
-		APIKey:            cfg.LLMAPIKey,
-		Model:             cfg.LLMModel,
-		LangfuseBaseURL:   cfg.LangfuseBaseURL,
-		LangfusePublicKey: cfg.LangfusePublicKey,
-		LangfuseSecretKey: cfg.LangfuseSecretKey,
-	}, "backfill-experience")
+	llmClient, flush, err := llm.NewClient(cfg.LLM.Settings(cfg.LLM.Model), "backfill-experience")
 	if err != nil || llmClient == nil {
 		return nil, nil, nil
 	}

--- a/cmd/backfill-resume-structured/main.go
+++ b/cmd/backfill-resume-structured/main.go
@@ -73,14 +73,7 @@ func run() int {
 		return 1
 	}
 
-	llmClient, llmFlush, err := llm.NewClient(llm.Settings{
-		BaseURL:           cfg.LLMBaseURL,
-		APIKey:            cfg.LLMAPIKey,
-		Model:             cfg.LLMModel,
-		LangfuseBaseURL:   cfg.LangfuseBaseURL,
-		LangfusePublicKey: cfg.LangfusePublicKey,
-		LangfuseSecretKey: cfg.LangfuseSecretKey,
-	}, "resume-structured")
+	llmClient, llmFlush, err := llm.NewClient(cfg.LLM.Settings(cfg.LLM.Model), "resume-structured")
 	if err != nil {
 		log.Printf("llm: %v", err)
 		return 1

--- a/cmd/classify-mail/main.go
+++ b/cmd/classify-mail/main.go
@@ -22,21 +22,17 @@ func main() {
 }
 
 func run() int {
-	// LLM config first, so a misconfigured worker fails before it opens the pool.
-	ecfg, err := config.LoadEnrich()
-	if err != nil {
+	// LLM config first, so a misconfigured worker fails before it opens the pool. Its OWN
+	// config: this used to be config.LoadEnrich(), read purely to reach the six LLM values
+	// — which meant a classifier inherited the enrichment worker's ENRICH_* validation and would
+	// have broken if that changed.
+	lcfg := config.LoadLLM()
+	if err := lcfg.Require(); err != nil {
 		log.Printf("config: %v", err)
 		return 1
 	}
 
-	client, flush, err := llm.NewClient(llm.Settings{
-		BaseURL:           ecfg.LLMBaseURL,
-		APIKey:            ecfg.LLMAPIKey,
-		Model:             ecfg.LLMModel,
-		LangfuseBaseURL:   ecfg.LangfuseBaseURL,
-		LangfusePublicKey: ecfg.LangfusePublicKey,
-		LangfuseSecretKey: ecfg.LangfuseSecretKey,
-	}, "classify-mail")
+	client, flush, err := llm.NewClient(lcfg.Settings(lcfg.Model), "classify-mail")
 	if err != nil {
 		log.Printf("llm: %v", err)
 		return 1

--- a/cmd/enrich/main.go
+++ b/cmd/enrich/main.go
@@ -31,14 +31,7 @@ func run() int {
 	// One construction path: llm.NewClient builds the client and, when LANGFUSE_* are
 	// set, wires tracing (source "enrich"). flush drains buffered traces at run end
 	// (no-op when tracing is off). LoadEnrich already required the LLM settings.
-	client, flush, err := llm.NewClient(llm.Settings{
-		BaseURL:           ecfg.LLMBaseURL,
-		APIKey:            ecfg.LLMAPIKey,
-		Model:             ecfg.LLMModel,
-		LangfuseBaseURL:   ecfg.LangfuseBaseURL,
-		LangfusePublicKey: ecfg.LangfusePublicKey,
-		LangfuseSecretKey: ecfg.LangfuseSecretKey,
-	}, "enrich")
+	client, flush, err := llm.NewClient(ecfg.LLM.Settings(ecfg.LLM.Model), "enrich")
 	if err != nil {
 		log.Printf("llm: %v", err)
 		return 1

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -146,14 +146,7 @@ func main() {
 	// shutdown. Nil client when unconfigured — the ATS score stays deterministic. A
 	// build error on a configured endpoint is fatal (a misconfigured gateway must not
 	// boot silently).
-	llmClient, llmFlush, err := llm.NewClient(llm.Settings{
-		BaseURL:           cfg.LLMBaseURL,
-		APIKey:            cfg.LLMAPIKey,
-		Model:             cfg.LLMModel,
-		LangfuseBaseURL:   cfg.LangfuseBaseURL,
-		LangfusePublicKey: cfg.LangfusePublicKey,
-		LangfuseSecretKey: cfg.LangfuseSecretKey,
-	}, "cv-ats")
+	llmClient, llmFlush, err := llm.NewClient(cfg.LLM.Settings(cfg.LLM.Model), "cv-ats")
 	if err != nil {
 		log.Fatalf("llm: %v", err)
 	}
@@ -163,14 +156,7 @@ func main() {
 	// reliable tool calling and a large context, where LLM_MODEL is chosen for cheap
 	// one-shot JSON extraction. Unset falls back to LLM_MODEL, so a single-model
 	// deployment still works. Traced under its own source label.
-	assistantLLM, assistantFlush, err := llm.NewClient(llm.Settings{
-		BaseURL:           cfg.LLMBaseURL,
-		APIKey:            cfg.LLMAPIKey,
-		Model:             cmp.Or(cfg.AssistantModel, cfg.LLMModel),
-		LangfuseBaseURL:   cfg.LangfuseBaseURL,
-		LangfusePublicKey: cfg.LangfusePublicKey,
-		LangfuseSecretKey: cfg.LangfuseSecretKey,
-	}, "assistant")
+	assistantLLM, assistantFlush, err := llm.NewClient(cfg.LLM.Settings(cmp.Or(cfg.AssistantModel, cfg.LLM.Model)), "assistant")
 	if err != nil {
 		log.Fatalf("llm (assistant): %v", err)
 	}
@@ -180,7 +166,7 @@ func main() {
 	// an OpenAI-compatible endpoint serves /chat/completions and /audio/transcriptions
 	// alike — so there is nothing extra to configure and nothing extra to fail. Nil
 	// when the gateway is unset, which the composer reads as "no microphone here".
-	speechClient := speech.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.STTModel)
+	speechClient := speech.New(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.STTModel)
 
 	// The gateway's administrative API, which mints the per-user credential each
 	// account's model calls are spent under. Nil when unconfigured, and that is an

--- a/cmd/tg-extract/main.go
+++ b/cmd/tg-extract/main.go
@@ -25,9 +25,11 @@ func main() {
 
 func run() int {
 	// LLM and channel config are loaded first so a misconfigured worker fails before
-	// it opens the pool.
-	ecfg, err := config.LoadEnrich()
-	if err != nil {
+	// it opens the pool. Its OWN LLM config: this used to be config.LoadEnrich(), read
+	// purely to reach the six LLM values — which meant a Telegram extractor inherited the
+	// enrichment worker's ENRICH_* validation and would have broken if that changed.
+	lcfg := config.LoadLLM()
+	if err := lcfg.Require(); err != nil {
 		log.Printf("config: %v", err)
 		return 1
 	}
@@ -43,14 +45,7 @@ func run() int {
 	// One construction path: llm.NewClient builds the client and, when LANGFUSE_* are
 	// set, wires tracing (source "telegram"). flush drains buffered traces at run end
 	// (no-op when tracing is off). LoadEnrich already required the LLM settings.
-	client, flush, err := llm.NewClient(llm.Settings{
-		BaseURL:           ecfg.LLMBaseURL,
-		APIKey:            ecfg.LLMAPIKey,
-		Model:             ecfg.LLMModel,
-		LangfuseBaseURL:   ecfg.LangfuseBaseURL,
-		LangfusePublicKey: ecfg.LangfusePublicKey,
-		LangfuseSecretKey: ecfg.LangfuseSecretKey,
-	}, "telegram")
+	client, flush, err := llm.NewClient(lcfg.Settings(lcfg.Model), "telegram")
 	if err != nil {
 		log.Printf("llm: %v", err)
 		return 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,14 +62,12 @@ type Settings struct {
 	MeiliURL string
 	MeiliKey string
 
-	// LLM backs the optional CV ATS qualitative review on the HTTP server (the enrich
-	// worker reads its own LLM settings via config.Enrich). Optional and provider-
-	// agnostic: any empty field disables the AI layer — the server builds no LLM client
-	// and the ATS score stays deterministic (enforced at the cmd/server call site, not
-	// here). Langfuse tracing is optional observability, wired only when all three set.
-	LLMBaseURL string
-	LLMAPIKey  string
-	LLMModel   string
+	// LLM backs the optional CV ATS qualitative review and the in-app assistant. Optional
+	// and provider-agnostic: any empty field disables the AI layer — the server builds no
+	// LLM client and the ATS score stays deterministic (enforced at the cmd/server call
+	// site, not here, which is why Require is deliberately NOT called on it). The workers
+	// share the same six values and the same loader; what differs is that policy.
+	LLM
 
 	// LLMAdminURL and LLMAdminKey reach the gateway's administrative API, which mints
 	// the per-user credential each account's calls are spent under. They are named
@@ -114,10 +112,6 @@ type Settings struct {
 	// them entirely (no CV is sent to the LLM) rather than leaking PII — enforced at the
 	// call site, not here.
 	PIIFilterURL string
-
-	LangfuseBaseURL   string
-	LangfusePublicKey string
-	LangfuseSecretKey string
 
 	// S3 backs résumé storage (internal/blobstore). Optional and provider-agnostic:
 	// any S3-compatible endpoint works, and no bucket/host/provider is baked into code —
@@ -195,6 +189,7 @@ var oauthProviders = []string{"google", "github", "linkedin"}
 // Load reads configuration from the environment, falling back to sensible defaults.
 func Load() Settings {
 	return Settings{
+		LLM:            LoadLLM(),
 		Port:           env("PORT", "8080"),
 		DatabaseURL:    env("DATABASE_URL", "postgres://hire:hire@localhost:5432/hire?sslmode=disable"),
 		FrontendOrigin: env("FRONTEND_ORIGIN", "http://localhost:5173"),
@@ -208,10 +203,6 @@ func Load() Settings {
 		MeiliURL:       env("MEILI_URL", "http://localhost:7700"),
 		MeiliKey:       os.Getenv("MEILI_MASTER_KEY"),
 
-		LLMBaseURL: os.Getenv("LLM_BASE_URL"),
-		LLMAPIKey:  os.Getenv("LLM_API_KEY"),
-		LLMModel:   os.Getenv("LLM_MODEL"),
-
 		LLMAdminURL:         os.Getenv("LLM_ADMIN_URL"),
 		LLMAdminKey:         os.Getenv("LLM_ADMIN_KEY"),
 		LLMUserMaxBudget:    envFloat("LLM_USER_MAX_BUDGET", 0),
@@ -224,10 +215,6 @@ func Load() Settings {
 		STTModel: os.Getenv("STT_MODEL"),
 
 		PIIFilterURL: os.Getenv("PII_FILTER_URL"),
-
-		LangfuseBaseURL:   os.Getenv("LANGFUSE_BASE_URL"),
-		LangfusePublicKey: os.Getenv("LANGFUSE_PUBLIC_KEY"),
-		LangfuseSecretKey: os.Getenv("LANGFUSE_SECRET_KEY"),
 
 		S3Endpoint:  os.Getenv("S3_ENDPOINT"),
 		S3Bucket:    os.Getenv("S3_BUCKET"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,8 +12,8 @@ func TestLoad_LLMFromEnv(t *testing.T) {
 	t.Setenv("LLM_MODEL", "some-model")
 
 	s := Load()
-	if s.LLMBaseURL != "https://gw.example/v1" || s.LLMAPIKey != "key-123" || s.LLMModel != "some-model" {
-		t.Errorf("LLM settings = %q/%q/%q, want the env values", s.LLMBaseURL, s.LLMAPIKey, s.LLMModel)
+	if s.LLM.BaseURL != "https://gw.example/v1" || s.LLM.APIKey != "key-123" || s.LLM.Model != "some-model" {
+		t.Errorf("LLM settings = %q/%q/%q, want the env values", s.LLM.BaseURL, s.LLM.APIKey, s.LLM.Model)
 	}
 }
 
@@ -124,8 +124,8 @@ func TestLoad_LLMEmptyWhenUnset(t *testing.T) {
 	t.Setenv("LLM_MODEL", "")
 
 	s := Load()
-	if s.LLMBaseURL != "" || s.LLMAPIKey != "" || s.LLMModel != "" {
-		t.Errorf("LLM settings should be empty when unset, got %q/%q/%q", s.LLMBaseURL, s.LLMAPIKey, s.LLMModel)
+	if s.LLM.BaseURL != "" || s.LLM.APIKey != "" || s.LLM.Model != "" {
+		t.Errorf("LLM settings should be empty when unset, got %q/%q/%q", s.LLM.BaseURL, s.LLM.APIKey, s.LLM.Model)
 	}
 }
 

--- a/internal/config/enrich.go
+++ b/internal/config/enrich.go
@@ -1,54 +1,30 @@
 package config
 
-import (
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-)
+import "strconv"
 
 // Enrich holds configuration for the enrichment command. The LLM settings are
 // provider-agnostic: any OpenAI-compatible endpoint (a LiteLLM gateway, a Chinese
 // model provider, etc.) is reached via base URL + key + model. No vendor name or
 // default model is baked in — the three LLM settings are required.
 type Enrich struct {
-	LLMBaseURL string
-	LLMAPIKey  string
-	LLMModel   string
+	// LLM carries the six shared connection/tracing values. Enrich keeps only the knobs that
+	// are genuinely its own below — two other workers used to load THIS type purely to reach
+	// the LLM half, and inherited the ENRICH_* validation with it.
+	LLM
 
 	Concurrency  int // LLM calls in flight; also the claim wave size (keeps each wave's lease window short)
 	LeaseSeconds int // how long a claim is held before it can be reclaimed
 	MaxAttempts  int // failed attempts before an entry is dead-lettered
-
-	// Langfuse LLM tracing is optional observability, shared by both LLM workers.
-	// Unlike the LLM settings it is never required: all three empty simply means
-	// tracing is off (LangfuseEnabled reports false) and the worker runs unchanged.
-	LangfuseBaseURL   string
-	LangfusePublicKey string
-	LangfuseSecretKey string
-}
-
-// LangfuseEnabled reports whether LLM tracing should be wired: true only when all
-// three Langfuse settings are present. A partial configuration is treated as off,
-// mirroring how a missing MEILI_MASTER_KEY disables search.
-func (e Enrich) LangfuseEnabled() bool {
-	return e.LangfuseBaseURL != "" && e.LangfusePublicKey != "" && e.LangfuseSecretKey != ""
 }
 
 // LoadEnrich reads enrichment configuration from the environment. It fails fast,
 // naming every missing required LLM setting, so a misconfigured run enriches nothing.
 func LoadEnrich() (Enrich, error) {
 	e := Enrich{
-		LLMBaseURL:   os.Getenv("LLM_BASE_URL"),
-		LLMAPIKey:    os.Getenv("LLM_API_KEY"),
-		LLMModel:     os.Getenv("LLM_MODEL"),
+		LLM:          LoadLLM(),
 		Concurrency:  envInt("ENRICH_CONCURRENCY", 4),
 		LeaseSeconds: envInt("ENRICH_LEASE_SECONDS", 300),
 		MaxAttempts:  envInt("ENRICH_MAX_ATTEMPTS", 3),
-
-		LangfuseBaseURL:   os.Getenv("LANGFUSE_BASE_URL"),
-		LangfusePublicKey: os.Getenv("LANGFUSE_PUBLIC_KEY"),
-		LangfuseSecretKey: os.Getenv("LANGFUSE_SECRET_KEY"),
 	}
 
 	// A non-positive concurrency would make the claim's LIMIT 0 (silently no-op) or
@@ -57,18 +33,8 @@ func LoadEnrich() (Enrich, error) {
 		e.Concurrency = 1
 	}
 
-	var missing []string
-	if e.LLMBaseURL == "" {
-		missing = append(missing, "LLM_BASE_URL")
-	}
-	if e.LLMAPIKey == "" {
-		missing = append(missing, "LLM_API_KEY")
-	}
-	if e.LLMModel == "" {
-		missing = append(missing, "LLM_MODEL")
-	}
-	if len(missing) > 0 {
-		return Enrich{}, fmt.Errorf("config: missing required env: %s", strings.Join(missing, ", "))
+	if err := e.Require(); err != nil {
+		return Enrich{}, err
 	}
 	return e, nil
 }

--- a/internal/config/enrich_test.go
+++ b/internal/config/enrich_test.go
@@ -38,9 +38,14 @@ func TestLoadEnrich_namesOnlyTheMissingOne(t *testing.T) {
 	}
 }
 
-func TestLoadEnrich_langfuseOptionalAndGated(t *testing.T) {
-	// Langfuse tracing is optional: the required LLM_* must still be set, but the
-	// worker must load fine with no Langfuse vars and report tracing disabled.
+// Langfuse tracing is optional: the required LLM_* must still be set, but a worker must load
+// fine with no Langfuse vars at all.
+//
+// What config is responsible for is CARRYING the three values through, whole or empty. Whether
+// tracing switches on is internal/llm's decision (NewTracer returns nil unless all three are
+// present) — Enrich used to carry a LangfuseEnabled() of its own, which nothing outside its own
+// test called: a second answer to a question the library already owned.
+func TestLoadEnrich_langfuseIsOptionalAndCarriedThrough(t *testing.T) {
 	t.Setenv("LLM_BASE_URL", "http://gateway:4000/v1")
 	t.Setenv("LLM_API_KEY", "sk-test")
 	t.Setenv("LLM_MODEL", "qwen2.5-72b")
@@ -52,32 +57,25 @@ func TestLoadEnrich_langfuseOptionalAndGated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnrich with no Langfuse vars: %v", err)
 	}
-	if got.LangfuseEnabled() {
-		t.Error("LangfuseEnabled() = true with no vars set, want false")
+	if got.LLM.LangfuseBaseURL != "" || got.LLM.LangfusePublicKey != "" || got.LLM.LangfuseSecretKey != "" {
+		t.Errorf("Langfuse fields = %+v, want empty", got.LLM)
 	}
 
-	// Only two of three set is still disabled — all three are required.
+	// A partial configuration still loads — refusing here would make optional observability
+	// able to stop a worker.
 	t.Setenv("LANGFUSE_BASE_URL", "https://us.cloud.langfuse.com")
 	t.Setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-x")
-	got, err = LoadEnrich()
-	if err != nil {
-		t.Fatalf("LoadEnrich: %v", err)
-	}
-	if got.LangfuseEnabled() {
-		t.Error("LangfuseEnabled() = true with secret key missing, want false")
+	if _, err := LoadEnrich(); err != nil {
+		t.Fatalf("LoadEnrich with partial Langfuse config: %v", err)
 	}
 
-	// All three set: fields populated and tracing enabled.
 	t.Setenv("LANGFUSE_SECRET_KEY", "sk-lf-y")
 	got, err = LoadEnrich()
 	if err != nil {
 		t.Fatalf("LoadEnrich: %v", err)
 	}
-	if !got.LangfuseEnabled() {
-		t.Fatal("LangfuseEnabled() = false with all three set, want true")
-	}
-	if got.LangfuseBaseURL != "https://us.cloud.langfuse.com" ||
-		got.LangfusePublicKey != "pk-lf-x" || got.LangfuseSecretKey != "sk-lf-y" {
+	if got.LLM.LangfuseBaseURL != "https://us.cloud.langfuse.com" ||
+		got.LLM.LangfusePublicKey != "pk-lf-x" || got.LLM.LangfuseSecretKey != "sk-lf-y" {
 		t.Errorf("Langfuse fields not populated: %+v", got)
 	}
 }
@@ -91,7 +89,7 @@ func TestLoadEnrich_defaultsAndOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnrich: %v", err)
 	}
-	if got.LLMBaseURL != "http://gateway:4000/v1" || got.LLMModel != "qwen2.5-72b" {
+	if got.LLM.BaseURL != "http://gateway:4000/v1" || got.LLM.Model != "qwen2.5-72b" {
 		t.Errorf("unexpected config: %+v", got)
 	}
 	// Tunables fall back to conservative defaults.

--- a/internal/config/llm.go
+++ b/internal/config/llm.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/llm"
+)
+
+// LLM holds the six environment values every LLM entrypoint needs: the provider-agnostic
+// connection triple, and the optional Langfuse tracing triple.
+//
+// It exists because two config types read the same six env keys — the server's Settings and the
+// enrichment worker's Enrich — and two workers that are neither loaded the ENRICHMENT config
+// purely to reach them, inheriting ENRICH_* validation they have no use for. What differs between
+// those callers is POLICY, not shape: the server degrades when the LLM is unconfigured, a worker
+// that exists to spend LLM calls must fail fast. So the values are shared and the policy is the
+// caller's, expressed by whether it calls Require.
+//
+// llm.Settings is deliberately NOT folded in here: it is the env-free shape the library takes, so
+// internal/llm depends on no configuration package. Settings() is the one mapping between them.
+type LLM struct {
+	BaseURL string
+	APIKey  string
+	Model   string
+
+	// Langfuse tracing is optional observability. All three empty simply means tracing is off
+	// and the caller runs unchanged; a partial configuration is treated as off, mirroring how a
+	// missing MEILI_MASTER_KEY disables search.
+	LangfuseBaseURL   string
+	LangfusePublicKey string
+	LangfuseSecretKey string
+}
+
+// LoadLLM reads the six values permissively. Nothing is required here — see Require.
+func LoadLLM() LLM {
+	return LLM{
+		BaseURL:           os.Getenv("LLM_BASE_URL"),
+		APIKey:            os.Getenv("LLM_API_KEY"),
+		Model:             os.Getenv("LLM_MODEL"),
+		LangfuseBaseURL:   os.Getenv("LANGFUSE_BASE_URL"),
+		LangfusePublicKey: os.Getenv("LANGFUSE_PUBLIC_KEY"),
+		LangfuseSecretKey: os.Getenv("LANGFUSE_SECRET_KEY"),
+	}
+}
+
+// Require reports every missing connection setting at once, for the callers whose whole job is
+// to spend LLM calls: a worker that starts without a model enriches nothing and says nothing.
+// Naming all three in one error means one run fixes the configuration rather than three.
+//
+// Tracing is never required — it is observability, not capability.
+func (l LLM) Require() error {
+	var missing []string
+	for _, v := range []struct {
+		key, value string
+	}{
+		{"LLM_BASE_URL", l.BaseURL},
+		{"LLM_API_KEY", l.APIKey},
+		{"LLM_MODEL", l.Model},
+	} {
+		if v.value == "" {
+			missing = append(missing, v.key)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("config: missing required env: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// Settings maps onto the shape internal/llm takes. It is the only place the two vocabularies
+// meet, so a field added to either is a one-line change here rather than seven copies at the
+// entrypoints.
+func (l LLM) Settings(model string) llm.Settings {
+	return llm.Settings{
+		BaseURL:           l.BaseURL,
+		APIKey:            l.APIKey,
+		Model:             model,
+		LangfuseBaseURL:   l.LangfuseBaseURL,
+		LangfusePublicKey: l.LangfusePublicKey,
+		LangfuseSecretKey: l.LangfuseSecretKey,
+	}
+}

--- a/internal/config/llm_test.go
+++ b/internal/config/llm_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Require names EVERY missing setting, not the first: a worker whose whole job is to spend LLM
+// calls should be fixable in one run rather than three.
+func TestLLMRequireNamesEveryMissingSetting(t *testing.T) {
+	t.Setenv("LLM_BASE_URL", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+
+	err := LoadLLM().Require()
+	if err == nil {
+		t.Fatal("an entirely unset LLM config was accepted")
+	}
+	for _, key := range []string{"LLM_BASE_URL", "LLM_API_KEY", "LLM_MODEL"} {
+		if !strings.Contains(err.Error(), key) {
+			t.Errorf("error %q does not name %s", err, key)
+		}
+	}
+}
+
+// Tracing is observability, not capability: it is never required.
+func TestLLMRequireIgnoresTracing(t *testing.T) {
+	t.Setenv("LLM_BASE_URL", "http://gw/v1")
+	t.Setenv("LLM_API_KEY", "k")
+	t.Setenv("LLM_MODEL", "m")
+	t.Setenv("LANGFUSE_BASE_URL", "")
+	t.Setenv("LANGFUSE_PUBLIC_KEY", "")
+	t.Setenv("LANGFUSE_SECRET_KEY", "")
+
+	if err := LoadLLM().Require(); err != nil {
+		t.Errorf("Require rejected a config whose only gap is tracing: %v", err)
+	}
+}
+
+// The server's policy is the opposite of a worker's and must stay that way: an unconfigured LLM
+// degrades the AI layer rather than refusing to boot, so Load must not validate.
+func TestLoadLeavesTheLLMUnvalidated(t *testing.T) {
+	t.Setenv("LLM_BASE_URL", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
+
+	s := Load()
+	if s.LLM.BaseURL != "" || s.LLM.Model != "" {
+		t.Errorf("LLM = %+v, want empty", s.LLM)
+	}
+}
+
+// Settings takes the model as an argument because two clients share one connection and differ
+// only by it — the assistant runs on ASSISTANT_MODEL where the rest run on LLM_MODEL.
+func TestLLMSettingsTakesTheModelFromTheCaller(t *testing.T) {
+	l := LLM{BaseURL: "http://gw/v1", APIKey: "k", Model: "cheap-json", LangfusePublicKey: "pk"}
+
+	if got := l.Settings("tool-calling"); got.Model != "tool-calling" || got.BaseURL != "http://gw/v1" ||
+		got.APIKey != "k" || got.LangfusePublicKey != "pk" {
+		t.Errorf("Settings = %+v, want the caller's model over the shared connection", got)
+	}
+}

--- a/openspec/changes/one-llm-config-shape/.openspec.yaml
+++ b/openspec/changes/one-llm-config-shape/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/one-llm-config-shape/proposal.md
+++ b/openspec/changes/one-llm-config-shape/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Catalogue findings **#19, #34 and #45** — three independent reviewers landed on the same thing.
+Two config types read the same six env keys: `config.Settings` (the server) and `config.Enrich`
+(the enrichment worker). Adding or renaming one LLM setting meant editing two struct definitions,
+two loaders, and **seven** field-by-field `llm.Settings{…}` literals at the entrypoints.
+
+The redundancy had already produced two concrete costs:
+
+- `Enrich.LangfuseEnabled()` was dead — nothing outside its own test called it, because
+  `internal/llm` decides tracing itself (`NewTracer` returns nil unless all three are set, which
+  its own test already pins). A second answer to a question the library owned.
+- **False coupling with a real failure mode.** `cmd/tg-extract` and `cmd/classify-mail` called
+  `config.LoadEnrich()` purely to reach the six LLM values — they touch none of
+  `Concurrency`/`LeaseSeconds`/`MaxAttempts` — so a Telegram extractor and a mail classifier
+  inherited the enrichment worker's `ENRICH_*` validation and would break if it changed.
+
+## What Changes
+
+- `config.LLM` holds the six values, with `LoadLLM()` (permissive) and `Require()` (names every
+  missing setting at once, so one run fixes the configuration rather than three).
+- Both `Settings` and `Enrich` embed it. **The policy difference is preserved deliberately** — it
+  is the reason the two structs existed: the server degrades when the LLM is unconfigured and so
+  never calls `Require`; a worker whose whole job is to spend LLM calls does.
+- `LLM.Settings(model)` is the one mapping into `llm.Settings`. The model is an argument because
+  two clients share one connection and differ only by it (the assistant on `ASSISTANT_MODEL`).
+  The seven literals become one call each.
+- `cmd/tg-extract` and `cmd/classify-mail` load their own `config.LoadLLM()` and drop the
+  enrichment dependency.
+- `Enrich.LangfuseEnabled` and its test are deleted; the replacement test asserts what config is
+  actually responsible for — carrying the three values through, whole or empty.
+
+**`llm.Settings` is deliberately left alone.** The finding's own verifier is right that it is not
+a third copy: it is the env-free shape the library takes so `internal/llm` depends on no
+configuration package. Folding it in would break that split to remove a mapping that should exist.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. The same env keys are read with the same
+strictness per caller; `tasks.md` is the real artifact and the change archives with
+`--skip-specs`.
+
+## Impact
+
+- `internal/config` (a new `llm.go` + tests, `config.go`, `enrich.go` and their tests).
+- Six entrypoints: `cmd/server` (×2), `cmd/enrich`, `cmd/tg-extract`, `cmd/classify-mail`,
+  `cmd/backfill-resume-structured`, `cmd/backfill-experience`.
+- Net −93 lines. No env key changes: every variable is read exactly as before.

--- a/openspec/changes/one-llm-config-shape/tasks.md
+++ b/openspec/changes/one-llm-config-shape/tasks.md
@@ -1,0 +1,26 @@
+## 1. One shape, two policies
+
+- [x] 1.1 `config.LLM` with `LoadLLM()` and `Require()`, the latter naming EVERY missing setting
+      rather than the first.
+- [x] 1.2 Embed it in `Settings` and `Enrich`. Preserve the policy split — the server must not
+      gain a `Require` call, because degrading is its documented behaviour.
+- [x] 1.3 `LLM.Settings(model)` as the one mapping into the library shape, with the model an
+      argument because the assistant and the rest share a connection and differ only by it.
+
+## 2. Collapse the seven literals
+
+- [x] 2.1 All six entrypoints call it.
+- [x] 2.2 `cmd/tg-extract` and `cmd/classify-mail` stop loading the ENRICHMENT config for the LLM
+      half — the coupling that made them inherit `ENRICH_*` validation.
+
+## 3. Delete what the duplication grew
+
+- [x] 3.1 `Enrich.LangfuseEnabled` — dead, and a second answer to a question `internal/llm`
+      already owns. Confirm `NewTracer`'s all-three rule is tested there before deleting.
+- [x] 3.2 Replace its test with one asserting carry-through, which is config's actual job.
+
+## 4. Verify and close
+
+- [x] 4.1 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 4.2 Confirm no `llm.Settings{…}` literal remains outside the one mapping.
+- [x] 4.3 Mark #19/#34/#45 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
Catalogue findings **#19, #34 and #45** — three independent reviewers landed on the same thing,
which is why I took it first out of the remaining catalogue.

`config.Settings` (the server) and `config.Enrich` (the enrichment worker) read the same six env
keys. Adding or renaming one LLM setting meant editing two struct definitions, two loaders, and
**seven** field-by-field `llm.Settings{…}` literals.

## Two costs it had already grown

**A dead method.** `Enrich.LangfuseEnabled()` had no caller outside its own test, because
`internal/llm` decides tracing itself — `NewTracer` returns nil unless all three values are set,
and `langfuse_test.go` already pins that. A second answer to a question the library owned.

**False coupling with a real failure mode.** `cmd/tg-extract` and `cmd/classify-mail` called
`config.LoadEnrich()` purely to reach the six LLM values — they touch none of
`Concurrency`/`LeaseSeconds`/`MaxAttempts`. So a Telegram extractor and a mail classifier
inherited the enrichment worker's `ENRICH_*` validation and would have broken if it changed.

## The policy difference is preserved on purpose

This is the part worth arguing for. The two structs existed because the two callers have
**different policies**, not because someone forgot to share: the server degrades when the LLM is
unconfigured (documented, enforced at its call site), while a worker whose whole job is to spend
LLM calls must fail fast.

So `config.LLM` carries the values and the policy stays the caller's, expressed by whether it
calls `Require()` — which names *every* missing setting at once, so one run fixes the
configuration rather than three.

## What I deliberately did NOT do

**`llm.Settings` is untouched.** The finding's own verifier is right that it is not a third copy:
it is the env-free shape the library takes so `internal/llm` depends on no configuration package.
Folding it in would break that split in order to remove a mapping that *should* exist. What
changed is that the mapping now lives in one place — `LLM.Settings(model)` — instead of seven.

The model is an argument because two clients share one connection and differ only by it (the
assistant on `ASSISTANT_MODEL`, the rest on `LLM_MODEL`).

## Verification

`go test ./...` **and** `go test -tags=integration ./...` green. No env key changes: every
variable is read exactly as before, with the same strictness per caller. No `llm.Settings{…}`
literal remains outside the single mapping.

Net **−93 lines**.
