### PR TITLE
feat(web): the other honest answer to a red chip is "I avoid this"

### DIFF
--- a/openspec/changes/avoid-skill-from-job-match/.openspec.yaml
+++ b/openspec/changes/avoid-skill-from-job-match/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/avoid-skill-from-job-match/design.md
+++ b/openspec/changes/avoid-skill-from-job-match/design.md
@@ -1,0 +1,97 @@
+## Context
+
+The claim affordance shipped in #1441 (archived change `claim-skill-from-job-match`): pressing a
+Missing or Close chip expands a row under its group, and confirming writes the skill into
+`user_profiles.skills` through `ProfileStore`, which serialises writes because `PUT /me/profile`
+replaces the whole row.
+
+This adds the opposite answer. It needs no new machinery — the row, the store queue, the pure
+skill-set rules and the confirmation line all exist. What it needs is a second action in the row,
+a second pair of pure rules, and a rendering state the block has never had: a chip that is missing
+*and* deliberately so.
+
+Two facts from the existing code decide the shape:
+
+- **`excluded_skills` already travels with the profile.** `GET /me/profile` returns it and the
+  block already holds that profile (it reads `profile.skills` to resolve its own state). So the
+  avoided marking is a client-side derivation, not a fetch.
+- **`jobmatch.Compute` never reads it.** The match is `job.skills` against `profile.skills` plus the
+  adjacency dictionary. So an avoid cannot change the match, and nothing may be re-fetched or
+  re-scored for one.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Record "I don't want this" at the moment the red chip prompts it.
+- Make the record visible — on this job and on every other job that asks for the skill.
+- Keep the two answers reversible from the same place.
+
+**Non-Goals:**
+
+- Filtering or hiding jobs from the block. `excluded_skills` feeds the *jobs filter* when the user
+  applies their profile; it is not a per-job verdict, and this change does not make it one.
+- An avoid affordance on **You have** chips. Those stay inert, as they were.
+- Any change to the coverage formula. An avoided skill is still a skill the candidate lacks.
+
+## Decisions
+
+### The row names the skill instead of asking a question
+
+"Do you have `bash`?" fitted a single answer. With two, the question form misleads — **Avoid** does
+not answer it. The row becomes the skill's name followed by two pills:
+
+```
+bash   [✓ I have it]   [⊘ Avoid]
+```
+
+and, when the skill is already avoided:
+
+```
+bash   [✓ I have it]   [↺ Stop avoiding]
+```
+
+*Alternative considered:* keeping the question and putting the avoid elsewhere (a second row, a
+long-press, the chip's context). Two rows in a ~285px column for one skill is more chrome than the
+block spends on the match itself, and any hidden gesture is undiscoverable.
+
+### The reverse action lives in the row, not only on the profile page
+
+Without it, avoiding is one-way from this surface: the chip goes grey and the only path back is
+`/my/profile`. Undo covers the misclick in the moment; **Stop avoiding** covers the change of mind a
+week later. It is one more pill on a row that already exists.
+
+### The avoided marking is derived, never stored per job
+
+The chip's avoided state is `profileStore.profile.excluded_skills` ∋ skill, computed where the chip
+renders. Consequences worth stating: it needs no request, it updates every open surface the moment
+the write applies, and it is correct on a job the viewer has never opened before.
+
+### The mutual-exclusion rule stays in the pure module
+
+`withSkill` already drops the skill from `excluded_skills`. `withAvoidedSkill` mirrors it by
+dropping the skill from `skills`. Both live in `profileSkills.ts`, so "a skill is never in both
+lists" is one rule with one test, rather than a convention each caller re-implements.
+
+This matters beyond tidiness: `filtersFromProfile` resolves an overlap by letting the include win
+and dropping the exclude **silently**. A profile that held a skill in both lists would produce a
+filter that quietly ignores the avoid, with nothing in the UI to explain why.
+
+### Nothing is optimistic and nothing is reconciled
+
+The claim path needed an overlay (the chip moves, the percent changes) and a refetch (an adjacency
+the client cannot compute). An avoid needs neither: the only thing that changes is the profile's
+excluded set, and the block reads that from the store, which the write updates on success. So the
+avoid path is the simple one — write, then render what the store now says.
+
+## Risks / Trade-offs
+
+- **A struck-through chip could read as "this requirement is waived".** → The wording of the
+  confirmation and the accessible name both say *avoid*, and the chip stays in the Missing group
+  under its red heading, where the percentage it feeds is unchanged.
+- **Avoiding widens the profile's exclusions, which narrows the feed when the profile is applied.**
+  → That is the point of the action, it is reversible in place, and the filter modal shows the
+  excluded set before it is applied.
+- **Two writes now share one row, and a mis-press writes the wrong one.** → Both are single pills
+  with distinct icons and tone, both are confirmed by name, and both are undoable from the line the
+  write produces.

--- a/openspec/changes/avoid-skill-from-job-match/proposal.md
+++ b/openspec/changes/avoid-skill-from-job-match/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The match block now lets a viewer claim a missing skill they actually hold. The other honest
+answer to a red chip is the opposite one: *I don't have this and I don't want it.* That answer is
+already a first-class part of the profile — `excluded_skills` seeds the jobs filter's
+`skills_exclude` set through "Apply my profile" — but the only way to record it is the profile
+page, reached by leaving the job that prompted the thought.
+
+Both answers belong at the same moment, in the same row. One raises the match; the other stops the
+catalogue offering more of the same.
+
+## What Changes
+
+- The claim row gains a second action. Its prompt drops the question form, which only fitted one
+  answer: the row now names the skill and offers **I have it** and **Avoid**.
+- **Avoid** writes the skill into the profile's `excluded_skills` and removes it from `skills`,
+  mirroring the existing rule that claiming a skill drops it from `excluded_skills`. A skill is
+  never in both lists.
+- An avoided skill's chip stays in **Missing** but renders as struck through and muted, on every
+  job that asks for it — the avoided set is already in the profile store, so this costs no request.
+- Pressing an avoided chip opens the row with **I have it** and **Stop avoiding**, so the mark can
+  be lifted where it was made rather than only on the profile page.
+- The coverage percentage, the bar and the chip groups do NOT move: the server computes the match
+  from `skills` alone, and avoiding a skill changes nothing about whether the candidate has it.
+- Confirmed by the same line the claim uses, naming what happened, with **Undo**.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `job-profile-match`: the claim affordance gains the avoid action, the avoided marking, and the
+  reverse action that lifts it.
+
+## Impact
+
+- `web/src/lib/components/JobMatch.svelte` — the row's two actions, the avoided chip styling, the
+  reverse action, and a confirmation that distinguishes the two writes.
+- `web/src/lib/profileSkills.ts` — `withAvoidedSkill` / `withoutAvoidedSkill` beside the existing
+  pair, holding the "never in both lists" invariant in one place.
+- `web/src/lib/profile.svelte.ts` — `avoidSkill` / `unavoidSkill`, through the same serial queue.
+- No backend, database, or contract change. `jobmatch.Compute` never reads `excluded_skills`, and
+  the profile endpoint already normalises both lists.

--- a/openspec/changes/avoid-skill-from-job-match/specs/job-profile-match/spec.md
+++ b/openspec/changes/avoid-skill-from-job-match/specs/job-profile-match/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: Avoiding a skill from the match block
+
+The claim row SHALL offer, beside the action that claims the skill, an action that records the skill
+as one the viewer wants to avoid — written to the profile's excluded-skills set. Because the row
+carries two answers, it SHALL name the skill rather than pose a yes/no question. Avoiding a skill
+SHALL remove it from the profile's skills, mirroring the rule that claiming one removes it from the
+excluded set: a skill is never in both lists.
+
+#### Scenario: The row offers both answers
+
+- **WHEN** the viewer presses a Missing or Close chip
+- **THEN** the row SHALL name that skill and offer both an action that adds it to the profile's
+  skills and an action that adds it to the profile's avoided skills
+
+#### Scenario: Avoiding writes the excluded set
+
+- **WHEN** the viewer avoids `wordpress`
+- **THEN** the saved profile SHALL carry `wordpress` among its excluded skills and not among its
+  skills
+
+#### Scenario: Avoiding a skill that was somehow held clears the contradiction
+
+- **WHEN** the profile holds `php` among its skills and the viewer avoids `php`
+- **THEN** the saved profile SHALL carry `php` only among its excluded skills
+
+### Requirement: The match does not move when a skill is avoided
+
+Avoiding a skill SHALL leave the coverage percentage, the progress bar and the three chip groups
+exactly as they were. The server computes the match from the profile's skills alone, so an avoided
+skill is still a skill the candidate does not have, and the block MUST NOT imply otherwise by
+re-scoring or by dropping the chip from Missing.
+
+#### Scenario: Coverage is unchanged
+
+- **WHEN** the viewer avoids a skill from the Missing group
+- **THEN** the coverage percentage and the counts SHALL read exactly what they did before, and the
+  skill SHALL remain in the Missing group
+
+#### Scenario: No match request is issued
+
+- **WHEN** an avoid is written successfully
+- **THEN** the block SHALL NOT refetch the match, there being nothing in it that could have changed
+
+### Requirement: An avoided skill is marked wherever it appears
+
+A chip naming a skill in the viewer's excluded set SHALL render as avoided — visually distinct from
+an ordinary missing skill and marked as such for assistive technology. The marking SHALL be derived
+from the profile the block already holds, so it appears on every job asking for that skill without
+any additional request.
+
+#### Scenario: The mark survives to another job
+
+- **WHEN** the viewer avoids `wordpress` on one job and opens another job that also asks for
+  `wordpress`
+- **THEN** that job's `wordpress` chip SHALL render as avoided, with no further request made to
+  obtain the avoided set
+
+#### Scenario: The mark is announced, not merely drawn
+
+- **WHEN** a chip renders as avoided
+- **THEN** its accessible name SHALL say the skill is one the viewer avoids
+
+### Requirement: An avoided skill can be un-avoided where it was marked
+
+Pressing an avoided chip SHALL open the row offering to claim the skill or to stop avoiding it.
+Stopping SHALL remove the skill from the excluded set and leave the skills set untouched, and the
+chip SHALL return to an ordinary missing chip.
+
+#### Scenario: The mark is lifted from the block
+
+- **WHEN** the viewer presses an avoided chip and chooses to stop avoiding it
+- **THEN** the skill SHALL leave the profile's excluded skills and the chip SHALL render as an
+  ordinary missing skill
+
+#### Scenario: An avoided skill can still be claimed
+
+- **WHEN** the viewer presses an avoided chip and chooses to claim it instead
+- **THEN** the skill SHALL be added to the profile's skills and removed from its excluded skills,
+  and the chip SHALL move to You have
+
+### Requirement: An avoid is confirmed, reversible and rolled back on failure
+
+A successful avoid SHALL be confirmed by a line naming the skill and what happened to it, offering
+undo — the same affordance a claim gets, and distinguishable from it in wording. A failed write
+SHALL leave the profile and the chip as they were and state the failure.
+
+#### Scenario: Confirmation distinguishes the two writes
+
+- **WHEN** the viewer avoids `wordpress`
+- **THEN** the confirmation SHALL say the skill was added to the skills the viewer avoids, not that
+  it was added to their profile skills
+
+#### Scenario: Undo lifts the avoid
+
+- **WHEN** the viewer undoes an avoid
+- **THEN** the skill SHALL leave the excluded set and the chip SHALL stop rendering as avoided
+
+#### Scenario: A failed avoid changes nothing
+
+- **WHEN** the profile write for an avoided skill fails
+- **THEN** the chip SHALL render as it did before, no confirmation SHALL be shown, and an error
+  naming the failure SHALL be shown

--- a/openspec/changes/avoid-skill-from-job-match/tasks.md
+++ b/openspec/changes/avoid-skill-from-job-match/tasks.md
@@ -1,0 +1,35 @@
+## 1. The skill-set rules
+
+- [x] 1.1 Add failing tests in `web/src/lib/profileSkills.test.ts` for `withAvoidedSkill`
+      (appends to `excluded_skills`, no duplicate whatever the case, removes the skill from
+      `skills`) and `withoutAvoidedSkill` (removes only that skill from `excluded_skills`, leaves
+      `skills` untouched). Both pure, neither mutating its input.
+- [x] 1.2 Implement the pair in `web/src/lib/profileSkills.ts` beside `withSkill`/`withoutSkill`,
+      so the "never in both lists" invariant has one home.
+
+## 2. The profile writes
+
+- [x] 2.1 Add `avoidSkill`/`unavoidSkill` to `ProfileStore`, routed through the same
+      `#queue`/`#writeSkills` path as the claim so a claim and an avoid issued together cannot
+      clobber each other.
+
+## 3. The row's second action
+
+- [x] 3.1 Replace the row's question with the skill's name plus two pills — **I have it** and
+      **Avoid** — in `web/src/lib/components/JobMatch.svelte`, keeping the existing claim wiring
+      behind the first.
+- [x] 3.2 Render an avoided chip distinctly (struck through, muted) with an accessible name saying
+      the skill is avoided, derived from `profileStore.profile.excluded_skills` so it holds on
+      every job without a request.
+- [x] 3.3 Swap the second pill to **Stop avoiding** when the chip is already avoided, wired to
+      `unavoidSkill`.
+- [x] 3.4 Confirm an avoid with its own wording ("added to skills you avoid") and its own undo,
+      distinct from the claim's; roll back and report a failed write, and issue no match refetch on
+      either avoid path.
+
+## 4. Verification
+
+- [x] 4.1 `pnpm --dir web test`, `pnpm --dir web run check`, and lint on the touched files pass.
+- [x] 4.2 Drive the block in a browser at the sidebar's width: avoid a skill (coverage unchanged,
+      chip struck), reload onto another job asking for it (still struck), stop avoiding, and claim
+      a previously-avoided skill (moves to You have, leaves the excluded set).

--- a/web/src/lib/components/JobMatch.svelte
+++ b/web/src/lib/components/JobMatch.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { Check, FileText, Lock, TriangleAlert } from '@lucide/svelte';
+  import { Ban, Check, FileText, Lock, RotateCcw, TriangleAlert } from '@lucide/svelte';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
@@ -42,14 +42,28 @@
     }),
   );
 
-  // A claim in progress or already made. `overlay` is the match as it reads once a skill
-  // is claimed, rendered in place of the fetched one until the server's own answer lands;
-  // `claimed` keeps the pre-claim match so undo can put it back.
+  // A write in progress or just made. `overlay` is the match as it reads once a skill is
+  // claimed, rendered in place of the fetched one until the server's own answer lands.
+  // `done` is the last write, which the confirmation line names and undoes: only a claim
+  // moved the match, so only it carries the reading to put back.
+  type Done =
+    | { kind: 'claim'; skill: string; before: JobMatchResult }
+    | { kind: 'avoid'; skill: string }
+    | { kind: 'unavoid'; skill: string };
+
   let claiming = $state<string | null>(null);
   let overlay = $state.raw<JobMatchResult | null>(null);
-  let claimed = $state.raw<{ skill: string; before: JobMatchResult } | null>(null);
+  let done = $state.raw<Done | null>(null);
   let failed = $state<string | null>(null);
   let pending = $state(false);
+
+  // The skills the viewer has said they want to avoid. Read straight off the profile the
+  // block already holds, so an avoided chip is marked on every job that asks for it without
+  // a request, and the mark updates the moment a write applies.
+  const avoided = $derived(
+    new Set((profileStore.profile?.excluded_skills ?? []).map((s) => s.toLowerCase())),
+  );
+  const isAvoided = (skill: string) => avoided.has(skill.toLowerCase());
 
   // Fetch the real match only when ready; re-fetch on navigation to another job.
   $effect(() => {
@@ -57,7 +71,7 @@
     match = null;
     overlay = null;
     claiming = null;
-    claimed = null;
+    done = null;
     failed = null;
     if (blockState !== 'ready') return;
     api.getJobMatch(slug)
@@ -104,7 +118,7 @@
       // Navigated on mid-write: the claim stands, but its confirmation belongs to the job
       // that was open, and the next job's block has already reset itself.
       if (job.public_slug !== slug) return;
-      claimed = { skill, before };
+      done = { kind: 'claim', skill, before };
       await reconcile(slug);
     } catch {
       if (job.public_slug !== slug) return;
@@ -115,23 +129,54 @@
     }
   }
 
-  async function undoClaim() {
-    if (!claimed || pending) return;
-    const { skill, before } = claimed;
+  /** Record (or lift) an avoid, answering whether it landed on the job still open. Nothing
+   *  about the match can change — the server scores against the profile's skills, not its
+   *  exclusions — so there is no overlay to apply and no refetch to make. The chip's mark
+   *  follows the store, which the write updates on success. */
+  async function writeAvoid(skill: string, avoid: boolean): Promise<boolean> {
+    if (pending) return false;
+    const slug = job.public_slug;
+    pending = true;
+    failed = null;
+    claiming = null;
+    try {
+      await (avoid ? profileStore.avoidSkill(skill) : profileStore.unavoidSkill(skill));
+      return job.public_slug === slug;
+    } catch {
+      if (job.public_slug === slug) failed = skill;
+      return false;
+    } finally {
+      pending = false;
+    }
+  }
+
+  async function setAvoided(skill: string, avoid: boolean) {
+    if (await writeAvoid(skill, avoid)) done = { kind: avoid ? 'avoid' : 'unavoid', skill };
+  }
+
+  /** Reverse the last write. Only a claim moved the match, so only it restores a reading. */
+  async function undoLast() {
+    if (!done || pending) return;
+    const last = done;
+    if (last.kind !== 'claim') {
+      // Undoing an avoid is the opposite write; a successful one leaves nothing to undo again.
+      if (await writeAvoid(last.skill, last.kind === 'unavoid')) done = null;
+      return;
+    }
     const shown = view;
     const slug = job.public_slug;
     pending = true;
     failed = null;
-    overlay = before;
-    claimed = null;
+    overlay = last.before;
+    done = null;
     try {
-      await profileStore.removeSkill(skill);
+      await profileStore.removeSkill(last.skill);
       await reconcile(slug);
     } catch {
       if (job.public_slug !== slug) return;
       restore(shown);
-      claimed = { skill, before };
-      failed = skill;
+      done = last;
+      failed = last.skill;
     } finally {
       pending = false;
     }
@@ -171,10 +216,21 @@
   const haveChip = `${chip} border-brand/30 bg-brand-muted text-brand-strong`;
   const adjChip = `${chip} border-warning/30 bg-warning/10 text-warning-strong`;
   const missChip = `${chip} border-destructive/30 bg-destructive/10 text-destructive`;
-  // A not-held chip is a control: pressing it asks whether the viewer holds the skill
-  // after all. The ring marks which one the open claim row belongs to.
-  const claimable = (base: string, open: boolean) =>
-    `${base} transition-shadow hover:brightness-95 disabled:opacity-60 ${open ? 'ring-2 ring-foreground/30' : ''}`;
+  // A not-held chip is a control: pressing it asks whether the viewer holds the skill after
+  // all, or wants to be shown less of it. The ring marks which one the open row belongs to.
+  // An avoided skill keeps its place in the group — the job still asks for it and the score
+  // still counts it — but reads as struck out rather than merely unmet.
+  const claimable = (base: string, open: boolean, skill: string) =>
+    [
+      base,
+      'transition-shadow hover:brightness-95 disabled:opacity-60',
+      open && 'ring-2 ring-foreground/30',
+      isAvoided(skill) && 'line-through opacity-55',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+  const chipLabel = (skill: string) => (isAvoided(skill) ? `${skill} — you avoid this skill` : undefined);
 
   const profileHref = resolve('/my/profile');
 
@@ -187,23 +243,41 @@
 </script>
 
 {#snippet claimRow(skill: string)}
-  <!-- The claim row expands under the group rather than floating over it: the sidebar
-       column is too narrow for an anchored popover, and naming the skill in the row's own
-       text keeps it tied to the chip that opened it. Styled as ReminderChip's disclosure —
-       a bare row of pills, not a panel — so the two inline disclosures in the app read the
-       same, and the affordance stays the weight of the chips it sits under. -->
+  <!-- The row expands under the group rather than floating over it: the sidebar column is
+       too narrow for an anchored popover, and naming the skill in the row's own text keeps
+       it tied to the chip that opened it. Styled as ReminderChip's disclosure — a bare row
+       of pills, not a panel — so the two inline disclosures in the app read the same.
+       It names the skill instead of asking "do you have it?": that question fitted one
+       answer, and the row now carries two. -->
   <div class="flex flex-wrap items-center gap-1.5">
-    <span class="text-xs text-muted-foreground">
-      Do you have <span class="font-medium text-foreground">{skill}</span>?
-    </span>
+    <span class="text-xs font-medium text-foreground">{skill}</span>
     <button
       type="button"
       disabled={pending}
       onclick={() => claim(skill)}
       class="inline-flex items-center gap-1.5 rounded-full border border-transparent bg-brand-muted px-2.5 py-1 text-xs font-medium text-brand-strong transition-colors hover:brightness-95 disabled:opacity-50"
     >
-      <Check class="size-3.5" aria-hidden="true" /> Add to profile
+      <Check class="size-3.5" aria-hidden="true" /> I have it
     </button>
+    {#if isAvoided(skill)}
+      <button
+        type="button"
+        disabled={pending}
+        onclick={() => setAvoided(skill, false)}
+        class="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-muted-foreground/40 disabled:opacity-50"
+      >
+        <RotateCcw class="size-3.5" aria-hidden="true" /> Stop avoiding
+      </button>
+    {:else}
+      <button
+        type="button"
+        disabled={pending}
+        onclick={() => setAvoided(skill, true)}
+        class="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-muted-foreground/40 disabled:opacity-50"
+      >
+        <Ban class="size-3.5" aria-hidden="true" /> Avoid
+      </button>
+    {/if}
   </div>
 {/snippet}
 
@@ -311,8 +385,9 @@
           {#each view.adjacent as a (a.name)}
             <button
               type="button"
-              class={claimable(adjChip, claiming === a.name)}
+              class={claimable(adjChip, claiming === a.name, a.name)}
               aria-expanded={claiming === a.name}
+              aria-label={chipLabel(a.name)}
               disabled={pending}
               onclick={() => toggleClaimRow(a.name)}
             >
@@ -335,8 +410,9 @@
           {#each view.missing as skill (skill)}
             <button
               type="button"
-              class={claimable(missChip, claiming === skill)}
+              class={claimable(missChip, claiming === skill, skill)}
               aria-expanded={claiming === skill}
+              aria-label={chipLabel(skill)}
               disabled={pending}
               onclick={() => toggleClaimRow(skill)}
             >
@@ -350,15 +426,30 @@
       </div>
     {/if}
 
-    {#if claimed}
+    {#if done}
       <p class="flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground">
-        <Check class="size-3.5 shrink-0 text-brand" />
-        <span><span class="font-medium text-foreground">{claimed.skill}</span> added to your profile.</span>
+        {#if done.kind === 'claim'}
+          <Check class="size-3.5 shrink-0 text-brand" />
+        {:else if done.kind === 'avoid'}
+          <Ban class="size-3.5 shrink-0" />
+        {:else}
+          <RotateCcw class="size-3.5 shrink-0" />
+        {/if}
+        <span>
+          <span class="font-medium text-foreground">{done.skill}</span>
+          {#if done.kind === 'claim'}
+            added to your profile.
+          {:else if done.kind === 'avoid'}
+            added to skills you avoid.
+          {:else}
+            is no longer avoided.
+          {/if}
+        </span>
         <button
           type="button"
           class="font-medium underline underline-offset-2 hover:text-foreground disabled:opacity-60"
           disabled={pending}
-          onclick={undoClaim}>Undo</button
+          onclick={undoLast}>Undo</button
         >
       </p>
     {/if}

--- a/web/src/lib/profile.svelte.ts
+++ b/web/src/lib/profile.svelte.ts
@@ -7,7 +7,13 @@
 // caller (a bad specialization or empty skills is a 400) so the UI can show them.
 
 import { api } from '$lib/api';
-import { withSkill, withoutSkill, type ProfileSkillSets } from '$lib/profileSkills';
+import {
+  withSkill,
+  withoutSkill,
+  withAvoidedSkill,
+  withoutAvoidedSkill,
+  type ProfileSkillSets,
+} from '$lib/profileSkills';
 import { serialQueue } from '$lib/serialQueue';
 import { UserResource } from '$lib/userResource.svelte';
 import type { LocationPreferences, UserProfile } from '$lib/types';
@@ -68,6 +74,17 @@ class ProfileStore extends UserResource<UserProfile | null> {
    *  after it survives. */
   removeSkill(skill: string): Promise<UserProfile> {
     return this.#queue(() => this.#writeSkills((sets) => withoutSkill(sets, skill)));
+  }
+
+  /** Record a skill as one to avoid — the match block's other answer to a missing skill. Also
+   *  drops it from the held skills, so the profile never claims and avoids the same token. */
+  avoidSkill(skill: string): Promise<UserProfile> {
+    return this.#queue(() => this.#writeSkills((sets) => withAvoidedSkill(sets, skill)));
+  }
+
+  /** Stop avoiding a skill. Lifts the exclusion only — it does not claim the skill. */
+  unavoidSkill(skill: string): Promise<UserProfile> {
+    return this.#queue(() => this.#writeSkills((sets) => withoutAvoidedSkill(sets, skill)));
   }
 
   /** Re-save the profile with edited skill sets. Reads `#profile` at call time — inside the

--- a/web/src/lib/profileSkills.test.ts
+++ b/web/src/lib/profileSkills.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { withSkill, withoutSkill } from './profileSkills';
+import {
+  withSkill,
+  withoutSkill,
+  withAvoidedSkill,
+  withoutAvoidedSkill,
+} from './profileSkills';
 
 describe('withSkill', () => {
   it('appends the claimed skill', () => {
@@ -55,5 +60,62 @@ describe('withoutSkill', () => {
     const before = { skills: ['docker', 'bash'], excluded_skills: [] };
     withoutSkill(before, 'bash');
     expect(before).toEqual({ skills: ['docker', 'bash'], excluded_skills: [] });
+  });
+});
+
+describe('withAvoidedSkill', () => {
+  it('records the skill as one to avoid', () => {
+    expect(withAvoidedSkill({ skills: ['docker'], excluded_skills: [] }, 'wordpress')).toEqual({
+      skills: ['docker'],
+      excluded_skills: ['wordpress'],
+    });
+  });
+
+  it('adds nothing when the skill is already avoided, whatever its case', () => {
+    expect(withAvoidedSkill({ skills: [], excluded_skills: ['WordPress'] }, 'wordpress')).toEqual({
+      skills: [],
+      excluded_skills: ['WordPress'],
+    });
+  });
+
+  it('stops claiming a skill the viewer now avoids — never both lists at once', () => {
+    expect(withAvoidedSkill({ skills: ['PHP', 'go'], excluded_skills: [] }, 'php')).toEqual({
+      skills: ['go'],
+      excluded_skills: ['php'],
+    });
+  });
+
+  it('does not mutate what it was given', () => {
+    const before = { skills: ['php'], excluded_skills: [] };
+    withAvoidedSkill(before, 'php');
+    expect(before).toEqual({ skills: ['php'], excluded_skills: [] });
+  });
+});
+
+describe('withoutAvoidedSkill', () => {
+  it('lifts the avoid, leaving another one standing', () => {
+    expect(
+      withoutAvoidedSkill({ skills: ['go'], excluded_skills: ['php', 'wordpress'] }, 'php'),
+    ).toEqual({ skills: ['go'], excluded_skills: ['wordpress'] });
+  });
+
+  it('matches the avoided skill whatever its case', () => {
+    expect(withoutAvoidedSkill({ skills: [], excluded_skills: ['PHP'] }, 'php')).toEqual({
+      skills: [],
+      excluded_skills: [],
+    });
+  });
+
+  it('leaves the held skills alone — lifting an avoid does not claim the skill', () => {
+    expect(withoutAvoidedSkill({ skills: ['go'], excluded_skills: ['php'] }, 'php')).toEqual({
+      skills: ['go'],
+      excluded_skills: [],
+    });
+  });
+
+  it('does not mutate what it was given', () => {
+    const before = { skills: [], excluded_skills: ['php'] };
+    withoutAvoidedSkill(before, 'php');
+    expect(before).toEqual({ skills: [], excluded_skills: ['php'] });
   });
 });

--- a/web/src/lib/profileSkills.ts
+++ b/web/src/lib/profileSkills.ts
@@ -1,6 +1,12 @@
-// The two skill-set edits behind claiming a skill from the job-match block, kept pure and
-// apart from the store that performs them: `PUT /me/profile` replaces the whole profile
-// row, so every write starts by rebuilding these two lists from the copy currently held.
+// The skill-set edits behind the job-match block's two answers to a missing skill — "I have
+// it" and "I avoid it" — kept pure and apart from the store that performs them: `PUT
+// /me/profile` replaces the whole profile row, so every write starts by rebuilding these two
+// lists from the copy currently held.
+//
+// The invariant they exist to hold: a skill is never in both lists. `filtersFromProfile`
+// resolves such an overlap by letting the include win and dropping the exclude SILENTLY, so a
+// profile carrying one would produce a filter that ignores the viewer's avoid with nothing on
+// screen to explain it. Each of the two adding functions removes the skill from the other list.
 //
 // Case-insensitive throughout. The endpoint lowercases what it is given, so a profile
 // seeded before that (or typed by hand) can hold "Docker" where a job's canonical facet
@@ -33,5 +39,25 @@ export function withoutSkill(sets: ProfileSkillSets, skill: string): ProfileSkil
   return {
     skills: sets.skills.filter((s) => !same(s, skill)),
     excluded_skills: sets.excluded_skills,
+  };
+}
+
+/** The skill sets once the viewer says they want to avoid `skill`: excluded, and no longer
+ *  claimed. The mirror of `withSkill` — the same contradiction resolved from the other side. */
+export function withAvoidedSkill(sets: ProfileSkillSets, skill: string): ProfileSkillSets {
+  return {
+    skills: sets.skills.filter((s) => !same(s, skill)),
+    excluded_skills: sets.excluded_skills.some((s) => same(s, skill))
+      ? sets.excluded_skills
+      : [...sets.excluded_skills, skill],
+  };
+}
+
+/** The skill sets once the viewer stops avoiding `skill`. It only lifts the exclusion: not
+ *  wanting to avoid a skill is not the same as claiming it. */
+export function withoutAvoidedSkill(sets: ProfileSkillSets, skill: string): ProfileSkillSets {
+  return {
+    skills: sets.skills,
+    excluded_skills: sets.excluded_skills.filter((s) => !same(s, skill)),
   };
 }


### PR DESCRIPTION
Follow-up to #1441 / #1446.

## Why

The block lets a viewer claim a missing skill they hold. The opposite answer is just as true and had nowhere to go: `excluded_skills` already feeds the jobs filter's `skills_exclude` through "Apply my profile", but recording one meant leaving the job that prompted the thought.

## What

The row names the skill and offers both answers:

```
wordpress   [✓ I have it]   [⊘ Avoid]
```

An avoided skill's chip stays in **Missing** — the job still asks for it and the score still counts it — but reads struck through and muted, with an accessible name saying it is avoided. The mark shows on **every** job that asks for the skill: the avoided set travels with the profile the block already holds, so it costs no request. Pressing an avoided chip swaps the second pill to **Stop avoiding**.

Nothing about the match moves for an avoid (the server scores against `skills`, not exclusions), so that path applies no overlay and issues no refetch.

`withAvoidedSkill` mirrors `withSkill`: each removes the skill from the other list. That invariant earns its place — `filtersFromProfile` resolves an overlap by letting the include win and dropping the exclude **silently**, so a profile holding one would produce a filter that ignores the viewer's avoid with nothing on screen to explain why.

## Verified

780 unit tests green (16 new pure rules), `svelte-check` 0 errors. Driven in a browser against a stubbed API across two jobs:

| step | result |
|---|---|
| avoid `wordpress` | 29% before and after, chip struck, `wordpress — you avoid this skill` |
| open another job asking for it | still struck, no extra request |
| open its row | offers `I have it` / `Stop avoiding` |
| claim it instead | 25% → 50%, moves to You have |
| resulting profile | `wordpress` in `skills`, **not** in `excluded_skills` |

OpenSpec change: `avoid-skill-from-job-match`.