### PR TITLE
One predicate, one membership test, one day count

### DIFF
--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -6,17 +6,23 @@ Two independent delivery use cases share one channel abstraction:
 |---|---|---|
 | `internal/notify` | Filter subscriptions — new jobs matching a saved search | `cmd/notify` |
 | `internal/reminder` | Saved-job nudges — come back before the vacancy goes stale | `cmd/remind` |
-| `internal/emailnotify` | Email channel (SES) — implements both `Notifier` interfaces | — |
+| `internal/emailnotify` | Email channel (SES) — implements `notify.Notifier` (the reminder-side email transport lives in `internal/reminder/transports.go`) | — |
 | `internal/telegramnotify` | Telegram channel (Bot API, deep-link token) | — |
 
 ## Always true
 
-- **A new channel is a new `Notifier` implementation, never an engine change.** Both engines
-  depend only on their `Notifier` interface plus a `Router` (a `map[channel]Notifier`).
-  Adding webhooks means adding a package, not touching `notify` or `reminder`.
-- **`notify.Channels` is the single source of truth** for the channel vocabulary, shared by
-  the router's dispatch and the subscription use case's create-time allowlist so the two
-  cannot drift. Add a channel there or it will be creatable but undeliverable.
+- **A new channel is a new `Notifier` implementation — but there are TWO of them.** Each engine
+  depends only on its own `Notifier` interface plus a `Router` (a `map[channel]Notifier`); the
+  two interfaces share a signature and differ in payload, and `notify`/`reminder` each carry
+  their own `Router`, `ErrChannelNotConfigured` and `recipient`. So adding webhooks is a digest
+  notifier, a reminder transport in `internal/reminder/transports.go`, a case in BOTH `recipient`
+  functions and a wire-up in both `cmd` mains. That is the real cost; the earlier claim that it
+  "means adding a package, not touching `notify` or `reminder`" was not true. Collapsing the pair
+  is deliberately deferred until a third channel actually lands and shows which half generalises.
+- **`notify.Channels` is the single source of truth** for the channel vocabulary, and
+  `notify.ValidChannel` is the membership test both create-time gates use. Subscriptions and
+  reminders each built their own `map[string]bool` from the slice until the test was exported.
+  Add a channel there or it will be creatable but undeliverable.
 - **An unconfigured channel is a soft-skip, not a failure.** `Router.Send` returns
   `ErrChannelNotConfigured` (e.g. email while SES is unset) and the engine skips it. Don't
   promote that to a delivery error — it would fail every run in environments without SES.

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -298,7 +298,14 @@ SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.not
             FROM emails e
            WHERE e.user_id = uj.user_id
              AND e.suggested_job_id = jobs.id
-             AND e.job_id IS NULL
+             -- "Pending" means the caller has not confirmed it, and confirming is what
+             -- attaches the application — the same test the follow-up gate, the ghost
+             -- signal and the inbox's link filter make, so the two cannot disagree about
+             -- one message. This used to ask `e.job_id IS NULL`, which is the same set
+             -- today only because every writer that sets job_id also either clears the
+             -- suggestion or attaches the application. Two spellings of one rule held
+             -- apart by that coincidence is not an invariant.
+             AND e.application_id IS NULL
              AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -386,7 +386,14 @@ SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.compan
             FROM emails e
            WHERE e.user_id = uj.user_id
              AND e.suggested_job_id = jobs.id
-             AND e.job_id IS NULL
+             -- "Pending" means the caller has not confirmed it, and confirming is what
+             -- attaches the application — the same test the follow-up gate, the ghost
+             -- signal and the inbox's link filter make, so the two cannot disagree about
+             -- one message. This used to ask ` + "`" + `e.job_id IS NULL` + "`" + `, which is the same set
+             -- today only because every writer that sets job_id also either clears the
+             -- suggestion or attaches the application. Two spellings of one rule held
+             -- apart by that coincidence is not an invariant.
+             AND e.application_id IS NULL
              AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id

--- a/internal/ghost/evidence.go
+++ b/internal/ghost/evidence.go
@@ -70,7 +70,7 @@ func Aggregate(now time.Time, apps []Application, reports []Report) map[int64]Ev
 		// terminal stage, reads an unset stage as `applied`, softens a silence
 		// into a question when unconfirmed mail contradicts it, and applies the
 		// stage's own threshold. Only an outright `silent` is a fact.
-		state := userjob.SilenceStateFor(app.Stage, daysSince(now, app.LastActivityAt), app.HasPendingSuggestion)
+		state := userjob.SilenceStateFor(app.Stage, userjob.DaysSilent(now, app.LastActivityAt), app.HasPendingSuggestion)
 		if state != userjob.SilenceSilent {
 			continue
 		}
@@ -79,7 +79,7 @@ func Aggregate(now time.Time, apps []Application, reports []Report) map[int64]Ev
 
 	for _, report := range reports {
 		threshold, ok := appliedThresholdDays()
-		if !ok || daysSince(now, report.AppliedOn) <= threshold {
+		if !ok || userjob.DaysSilent(now, report.AppliedOn) <= threshold {
 			continue
 		}
 		record(report.JobID, report.UserID, func(ev *Evidence) { ev.Reports++ })
@@ -100,14 +100,4 @@ func Aggregate(now time.Time, apps []Application, reports []Report) map[int64]Ev
 // observed applications.
 func appliedThresholdDays() (int, bool) {
 	return userjob.SilenceThresholdDays("applied")
-}
-
-// daysSince is whole days elapsed, never negative. A part-day does not count,
-// matching jobtracking.Silence so the two surfaces cannot disagree by a day.
-func daysSince(now, t time.Time) int {
-	days := int(now.Sub(t).Hours() / 24)
-	if days < 0 {
-		return 0
-	}
-	return days
 }

--- a/internal/handler/followup.go
+++ b/internal/handler/followup.go
@@ -45,7 +45,7 @@ func (h *inboxHandlers) GetApplicationFollowUp(c *fiber.Ctx) error {
 
 	days := 0
 	if app.LastActivityAt.Valid {
-		days = daysSilent(time.Now(), app.LastActivityAt.Time)
+		days = userjob.DaysSilent(time.Now(), app.LastActivityAt.Time)
 	}
 	if userjob.SilenceStateFor(pgStr(app.Stage), days, app.HasPendingSuggestion) != userjob.SilenceSilent {
 		return fiber.NewError(fiber.StatusConflict, "this application is not waiting on a reply")
@@ -87,15 +87,6 @@ func (h *inboxHandlers) RecordApplicationFollowUp(c *fiber.Ctx) error {
 		return err // ErrNoRows → 404: not an application of this caller's
 	}
 	return c.SendStatus(fiber.StatusNoContent)
-}
-
-// daysSilent is whole days since the application last moved, floored at zero so a clock skew
-// cannot report a negative silence.
-func daysSilent(now, last time.Time) int {
-	if d := int(now.Sub(last).Hours() / 24); d > 0 {
-		return d
-	}
-	return 0
 }
 
 // newestSender returns the address and display name of the most recent mail linked to the

--- a/internal/jobtracking/silence.go
+++ b/internal/jobtracking/silence.go
@@ -45,10 +45,7 @@ func (j TrackedJob) Silence(now time.Time) *Silence {
 	if j.LastActivityAt != nil && j.LastActivityAt.After(last) {
 		last = *j.LastActivityAt
 	}
-	days := int(now.Sub(last).Hours() / 24)
-	if days < 0 {
-		days = 0
-	}
+	days := userjob.DaysSilent(now, last)
 	return &Silence{
 		LastActivityAt: last,
 		DaysSilent:     days,

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/search"
+	"slices"
 )
 
 // ChannelTelegram and ChannelEmail are the delivery channels implemented today;
@@ -30,6 +31,14 @@ const ChannelTelegram = "telegram"
 // by the router's dispatch and the subscription use case's create-time allowlist,
 // so the two can never drift.
 var Channels = []string{ChannelTelegram, ChannelEmail}
+
+// ValidChannel reports whether c is a delivery channel. It exists because the slice alone is
+// not usable as an allowlist, so both create-time gates — subscriptions and reminders — built
+// the same map[string]bool from it. Exposing the membership test is what stops a third caller
+// building a third copy.
+func ValidChannel(c string) bool {
+	return slices.Contains(Channels, c)
+}
 
 // Digest is one subscription's batch of new matches, rendered by a Notifier into
 // a channel-specific message. Jobs is capped to the configured digest size; Total

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -299,3 +299,19 @@ func TestDeliver_UnlinkedTelegramIsSoftSkipped(t *testing.T) {
 		t.Errorf("soft skips = %d, want 1", stats.SoftSkips)
 	}
 }
+
+// ValidChannel is the membership test both create-time gates use. It exists because the slice
+// alone is not usable as an allowlist, so subscriptions and reminders each built the same map
+// from it — and a third caller would have built a third.
+func TestValidChannel(t *testing.T) {
+	for _, c := range Channels {
+		if !ValidChannel(c) {
+			t.Errorf("ValidChannel(%q) = false for a declared channel", c)
+		}
+	}
+	for _, c := range []string{"", "webhook", "Telegram", "e-mail"} {
+		if ValidChannel(c) {
+			t.Errorf("ValidChannel(%q) = true for an undeclared channel", c)
+		}
+	}
+}

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -41,16 +41,6 @@ var (
 	ErrNoReminder = errors.New("reminder: no pending reminder")
 )
 
-// validChannels is the channel allowlist, derived from the notify delivery-channel
-// vocabulary so reminders and subscriptions can never drift on what a channel is.
-var validChannels = func() map[string]bool {
-	m := make(map[string]bool, len(notify.Channels))
-	for _, c := range notify.Channels {
-		m[c] = true
-	}
-	return m
-}()
-
 // Settings is the account-level default rule. An absent stored row reads as this
 // zero-ish default (disabled, DefaultDelayDays, no channels).
 type Settings struct {
@@ -103,7 +93,7 @@ func (s *Service) UpdateSettings(ctx context.Context, userID int64, in Settings)
 		return Settings{}, ErrInvalidDelay
 	}
 	for _, c := range in.Channels {
-		if !validChannels[c] {
+		if !notify.ValidChannel(c) {
 			return Settings{}, ErrInvalidChannel
 		}
 	}

--- a/internal/subscription/subscription.go
+++ b/internal/subscription/subscription.go
@@ -38,16 +38,6 @@ const (
 	ChannelEmail    = notify.ChannelEmail
 )
 
-// validChannels is the create-time allowlist, derived from the notify
-// delivery-channel vocabulary so the two never drift.
-var validChannels = func() map[string]bool {
-	m := make(map[string]bool, len(notify.Channels))
-	for _, c := range notify.Channels {
-		m[c] = true
-	}
-	return m
-}()
-
 // Subscription is a stored filter subscription: the package domain type, decoupled from
 // the generated db row. The internal columns (user_id, the destination and start_at
 // cursor) are dropped — they are never on the wire — while created_at is kept as *time.Time
@@ -100,7 +90,7 @@ func (s *Service) List(ctx context.Context, userID int64) ([]SubscriptionListIte
 // account email for email). Ownership of the saved search is enforced in SQL (a
 // non-owned id surfaces as ErrSavedSearchNotFound).
 func (s *Service) Create(ctx context.Context, userID, savedSearchID int64, channel string) (Subscription, error) {
-	if !validChannels[channel] {
+	if !notify.ValidChannel(channel) {
 		return Subscription{}, ErrInvalidChannel
 	}
 	return s.repo.Create(ctx, userID, savedSearchID, channel)

--- a/internal/userjob/pipeline_test.go
+++ b/internal/userjob/pipeline_test.go
@@ -1,6 +1,9 @@
 package userjob
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // TestEveryStageIsRankedOrTerminal is the direction the old cross-package test lacked. It checked
 // that every stage mailclassify named was a real stage; nothing checked the reverse, so a stage
@@ -93,6 +96,35 @@ func TestForward(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Forward(tt.current, tt.target); got != tt.want {
 				t.Errorf("Forward(%q, %q) = %v, want %v", tt.current, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+// DaysSilent is whole days, floored at zero. It was three separate copies — the tracking board,
+// the follow-up gate and the ghost signal — each with its own spelling of the same arithmetic,
+// held together by comments naming one another. The ladder above it was already shared, so a
+// day's disagreement between the badge and the offer was the one thing left that could split
+// them.
+func TestDaysSilent(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		last time.Time
+		want int
+	}{
+		{"same instant", now, 0},
+		{"a part-day does not count", now.Add(-23 * time.Hour), 0},
+		{"exactly one day", now.Add(-24 * time.Hour), 1},
+		{"a day and a half is one day", now.Add(-36 * time.Hour), 1},
+		{"three weeks", now.AddDate(0, 0, -21), 21},
+		// Clock skew, or a stamp a moment in the future, must not report negative silence.
+		{"the future is not negative silence", now.Add(2 * time.Hour), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DaysSilent(now, tt.last); got != tt.want {
+				t.Errorf("DaysSilent(%v) = %d, want %d", tt.last, got, tt.want)
 			}
 		})
 	}

--- a/internal/userjob/silence.go
+++ b/internal/userjob/silence.go
@@ -1,5 +1,7 @@
 package userjob
 
+import "time"
+
 // Silence states. An application reports one of these, or the empty string when
 // it is settled and so waiting on nobody — a caller must be able to tell "not
 // waiting" from "waiting and fine", which a reassuring `active` would hide.
@@ -47,6 +49,21 @@ var silenceThresholds = map[string]int{
 	"responded": 15,
 	"interview": 12,
 	"offer":     5,
+}
+
+// DaysSilent is whole days between last and now, floored at zero.
+//
+// Part-days do not count and a negative is impossible: clock skew, or a last-activity stamp a
+// moment in the future, must not report negative silence. It lives here beside the ladder it
+// feeds because three surfaces — the tracking board, the follow-up gate and the ghost signal —
+// each had their own copy, held together by comments naming one another. The ladder was already
+// shared; the arithmetic under it was not, and a day's disagreement between the badge and the
+// offer is exactly what the shared ladder exists to prevent.
+func DaysSilent(now, last time.Time) int {
+	if d := int(now.Sub(last).Hours() / 24); d > 0 {
+		return d
+	}
+	return 0
 }
 
 // SilenceThresholdDays returns how many days of silence `stage` tolerates, and

--- a/openspec/changes/mail-and-silence-one-rule-each/.openspec.yaml
+++ b/openspec/changes/mail-and-silence-one-rule-each/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/mail-and-silence-one-rule-each/proposal.md
+++ b/openspec/changes/mail-and-silence-one-rule-each/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+Three catalogue findings in the mail/notifications area, each a rule with more copies than it
+should have. All three verdicts were **overstated**, and checking that before acting changed what
+the work is.
+
+**#27 — the pending-suggestion predicate has two spellings.** Three statements ask
+`e.application_id IS NULL`; the tracking board asks `e.job_id IS NULL`. Two of the three carry a
+comment saying the test is "the same … so the two cannot disagree about one message".
+
+**#28 — the "one channel abstraction" the docs promise is two.** `Notifier`, `Router`,
+`ErrChannelNotConfigured` and `recipient()` each exist twice, and `notifications.md` claimed
+adding a channel "means adding a package, not touching `notify` or `reminder`" — which is false.
+
+**#29 — the silence ladder is shared, the arithmetic under it is not.** Three surfaces each carry
+their own "whole days, floored at zero", held together by comments naming one another.
+
+## What Changes
+
+- **#27:** the board's predicate becomes `e.application_id IS NULL`, matching the other three.
+- **#28:** `notify.ValidChannel` is exported and the two hand-built `map[string]bool` allowlists
+  in `subscription` and `reminder` are deleted. `notifications.md` now states the real cost of a
+  new channel — two notifiers, two `recipient` cases, two mains — instead of the claim that was
+  not true.
+- **#29:** `userjob.DaysSilent(now, last)` beside the ladder it feeds; the three copies call it.
+
+## What I did NOT do, and why
+
+- **No shared view for the last-activity expression (#27).** The remedy says to skip it, and a
+  fifth copy is the trigger to reconsider.
+- **No `notify.Router[T]`/`Notifier[T]` generics (#28).** They would make `notify` depend on both
+  delivery row shapes — worse coupling than the duplication. Deferred until a third channel lands
+  and shows which half generalises.
+- **No single `userjob.Silence(...)` (#29).** The `applied_at` fallback and the "is this even an
+  application" precondition are shaped by three different query results, and `ghost` deliberately
+  does not want `jobtracking`'s fallback semantics.
+
+## Two claims I could not confirm, stated plainly
+
+**#27's live disagreement is not reachable that I can construct.** It requires a message carrying
+a live suggestion *and* a set `job_id`. `LinkEmailToJob` and `ConfirmEmailLink` both clear
+`suggested_job_id` when they link; `SetEmailClassification` can write both but its only producer
+sets one or the other. The change is still right — two spellings of one rule held apart by a
+coincidence of writer behaviour is not an invariant — but it is a drift risk closed, not a bug
+fixed.
+
+**#29's live disagreement was already refuted by the finding's own verifier** and I confirmed the
+reasoning: both queries wrap the expression in `CASE WHEN a.applied_at IS NOT NULL THEN
+GREATEST(...)`, and Postgres `GREATEST` ignores NULLs, so `last_activity_at` is NULL exactly when
+`applied_at` is. What survives is the duplicated arithmetic.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. The predicate change is equivalent under the
+outer `a.applied_at IS NOT NULL` guard; `tasks.md` is the real artifact and the change archives
+with `--skip-specs`.
+
+## Impact
+
+- `internal/db/queries/user_jobs.sql` (+ regenerated), `internal/notify`, `internal/subscription`,
+  `internal/reminder`, `internal/userjob`, `internal/jobtracking`, `internal/handler/followup.go`,
+  `internal/ghost`, `docs/agents/notifications.md`.

--- a/openspec/changes/mail-and-silence-one-rule-each/tasks.md
+++ b/openspec/changes/mail-and-silence-one-rule-each/tasks.md
@@ -1,0 +1,29 @@
+## 1. Check the three verdicts before acting
+
+- [x] 1.1 #27: trace every writer of `emails.job_id`/`suggested_job_id`/`application_id` to see
+      whether the divergent state is reachable. Record the answer either way.
+- [x] 1.2 #29: confirm the verifier's refutation rather than inherit it — `GREATEST` ignoring
+      NULLs is what makes the claimed NULL `last_activity_at` unreachable.
+- [x] 1.3 Confirm the three day-math copies are behaviourally identical before merging them.
+
+## 2. One predicate (#27)
+
+- [x] 2.1 The board asks `e.application_id IS NULL` like the other three; the comment says why the
+      old spelling was equivalent only by coincidence. Regenerate.
+
+## 3. One membership test (#28)
+
+- [x] 3.1 Export `notify.ValidChannel`; delete both hand-built allowlists.
+- [x] 3.2 Correct `notifications.md`: the "adding a package, not touching notify or reminder"
+      claim, and the emailnotify table row that says it implements both interfaces.
+- [x] 3.3 Do NOT collapse the Router/Notifier pair — record why, so the deferral is a decision.
+
+## 4. One day count (#29)
+
+- [x] 4.1 `userjob.DaysSilent` beside `SilenceStateFor`; three call sites.
+- [x] 4.2 Test it, including the future-timestamp case each copy guarded separately.
+
+## 5. Verify and close
+
+- [x] 5.1 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 5.2 Mark #27/#28/#29 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
Catalogue findings **#27, #28 and #29** — three rules in the mail/notifications area with more
copies than they should have. All three carried the verdict **overstated**, and checking that
before acting changed what the work is.

## #27 — one predicate, two spellings

Three statements ask `e.application_id IS NULL`. The tracking board asked `e.job_id IS NULL`. Two
of the three carry a comment saying the test is *"the same … so the two cannot disagree about one
message"*.

**I could not construct the live disagreement the finding claims, and I am saying so rather than
repeating it.** It needs a message carrying a live suggestion *and* a set `job_id`.
`LinkEmailToJob` and `ConfirmEmailLink` both clear `suggested_job_id` when they link;
`SetEmailClassification` can write both, but its only producer sets one or the other.

The change is still right — two spellings of one rule held apart by a coincidence of writer
behaviour is not an invariant — but it closes a drift risk rather than fixing a bug, and the SQL
comment now says exactly that.

## #28 — the "one channel abstraction" is two

`Notifier`, `Router`, `ErrChannelNotConfigured` and `recipient()` each exist twice.
`notifications.md` claimed adding a channel *"means adding a package, not touching `notify` or
`reminder`"*. That is false: it is a digest notifier, a reminder transport, a case in **both**
`recipient` functions and a wire-up in both mains.

Fixed the cheap half and the doc: `notify.ValidChannel` is exported, both hand-built
`map[string]bool` allowlists are deleted, and the doc states the real cost.

**Deliberately not collapsed:** `Router[T]`/`Notifier[T]` generics would make `notify` depend on
both delivery row shapes — worse coupling than the duplication. A third channel is what should
decide which half generalises, and that is now recorded as a decision rather than an omission.

## #29 — the ladder was shared, the arithmetic under it was not

Three surfaces each carried their own "whole days, floored at zero", held together by comments
naming one another. `userjob.DaysSilent` now sits beside the ladder it feeds.

The finding's own verifier had already refuted its live claim, and I confirmed the reasoning
rather than inheriting it: both queries wrap the expression in
`CASE WHEN a.applied_at IS NOT NULL THEN GREATEST(...)`, and Postgres `GREATEST` ignores NULLs, so
`last_activity_at` is NULL exactly when `applied_at` is.

I also verified the three copies were behaviourally identical before merging them — including the
future-timestamp guard each spelled differently, which the new test covers.

## Also not done, on purpose

No shared view for the last-activity expression (#27) — a fifth copy is the trigger. No single
`userjob.Silence(...)` (#29) — the `applied_at` fallback and the "is this even an application"
precondition are shaped by three different query results, and `ghost` deliberately does not want
`jobtracking`'s fallback semantics.

`go test ./...` **and** `go test -tags=integration ./...` green.
