### PR TITLE
Wait for a database that is not answering yet

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -18,7 +18,21 @@ import (
 // an individual process by adding pool_max_conns to its DATABASE_URL.
 const defaultMaxConns = 10
 
-// Connect creates a Postgres connection pool and verifies it is reachable.
+// reachableWindow bounds how long Connect keeps retrying a database that is not answering yet.
+//
+// It exists because "not answering yet" is the normal case at two moments, and a single ping
+// loses to both. A Postgres container running its init scripts serves a TEMPORARY server on a
+// unix socket only, so every TCP connect is refused until init finishes and the real server
+// starts — the window grows with each migration added, and CI's smoke run began losing that race
+// (freehire#1461: the app died one second before "database system is ready"). The same shape
+// happens in production whenever the database restarts under a worker.
+//
+// Thirty seconds is chosen against the failure it must not cause: a cron worker whose DSN is
+// simply wrong should still fail its slot promptly rather than hold it. The caller's context
+// wins if it is shorter, so a SIGTERM during startup cancels immediately.
+const reachableWindow = 30 * time.Second
+
+// Connect creates a Postgres connection pool and waits for it to become reachable.
 func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	config, err := poolConfig(dsn)
 	if err != nil {
@@ -30,14 +44,46 @@ func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("create pool: %w", err)
 	}
 
-	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if err := pool.Ping(pingCtx); err != nil {
+	if err := waitReachable(ctx, pool); err != nil {
 		pool.Close()
-		return nil, fmt.Errorf("ping: %w", err)
+		return nil, err
 	}
-
 	return pool, nil
+}
+
+// waitReachable pings until the database answers, the window closes, or the caller's context
+// ends — whichever comes first. The backoff doubles to a two-second ceiling: the common case is
+// a database that becomes ready within a second or two, and a tight loop against a container
+// still unpacking its data directory is just noise in the log.
+func waitReachable(ctx context.Context, pool *pgxpool.Pool) error {
+	deadline := time.Now().Add(reachableWindow)
+	backoff := 100 * time.Millisecond
+
+	for attempt := 1; ; attempt++ {
+		pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		err := pool.Ping(pingCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		// The caller's context ending is not a database fault, and must not be retried:
+		// a worker cancelled by SIGTERM mid-startup stops now, not in thirty seconds.
+		if ctx.Err() != nil {
+			return fmt.Errorf("ping: %w", ctx.Err())
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("ping: database unreachable after %s (%d attempts): %w",
+				reachableWindow, attempt, err)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("ping: %w", ctx.Err())
+		case <-time.After(backoff):
+		}
+		if backoff < 2*time.Second {
+			backoff *= 2
+		}
+	}
 }
 
 // poolConfig parses the DSN and applies defaultMaxConns unless the DSN sets its

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,6 +1,11 @@
 package database
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
 
 // poolConfig must cap MaxConns when the DSN is silent (so the worker fleet can't
 // exhaust Postgres slots) but yield to an explicit pool_max_conns override.
@@ -34,4 +39,66 @@ func TestPoolConfig_MaxConns(t *testing.T) {
 			t.Errorf("MaxConns = %d, want %d (the substring sits in the password, not the settings)", cfg.MaxConns, defaultMaxConns)
 		}
 	})
+}
+
+// A database that never answers must not hold the caller past its own deadline. This is the
+// guard on the retry loop's cost: a cron worker with a wrong DSN should fail its slot promptly,
+// not sit for the full window — and a worker cancelled by SIGTERM mid-startup stops now.
+func TestConnectStopsWhenTheCallerDoes(t *testing.T) {
+	// Port 1 has nothing listening, so every ping is refused immediately and the loop is
+	// exercised at full speed.
+	const dsn = "postgres://nobody:nobody@127.0.0.1:1/nothing?sslmode=disable&connect_timeout=1"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	pool, err := Connect(ctx, dsn)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		pool.Close()
+		t.Fatal("Connect succeeded against a port with no listener")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %v, want it to carry the caller's deadline", err)
+	}
+	// Generous, but far below reachableWindow: the point is that the caller's context wins.
+	if elapsed > 5*time.Second {
+		t.Errorf("Connect took %s; the caller's 400ms deadline did not stop the retry loop", elapsed)
+	}
+}
+
+// The window is what bounds a database that is merely slow to arrive. Kept as an explicit
+// assertion because raising it is a real trade — longer waits for a restarting database, longer
+// held cron slots for a misconfigured one — and should be a deliberate edit.
+func TestReachableWindowIsBounded(t *testing.T) {
+	if reachableWindow < 5*time.Second || reachableWindow > time.Minute {
+		t.Errorf("reachableWindow = %s; outside the range this was reasoned about", reachableWindow)
+	}
+}
+
+// The whole point is that it RETRIES — a single ping is what lost the race against Postgres's
+// init scripts. "Connection refused" comes back instantly, so a non-retrying Connect returns in
+// milliseconds; a retrying one keeps going until its window or the caller's deadline closes.
+// Elapsed time is therefore the honest observation, and it fails against the old implementation.
+func TestConnectRetriesRatherThanFailingOnTheFirstPing(t *testing.T) {
+	// Port 1 has nothing listening, so each attempt is refused immediately.
+	const dsn = "postgres://nobody:nobody@127.0.0.1:1/nothing?sslmode=disable&connect_timeout=1"
+	const window = 1200 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), window)
+	defer cancel()
+
+	start := time.Now()
+	pool, err := Connect(ctx, dsn)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		pool.Close()
+		t.Fatal("Connect succeeded against a port with no listener")
+	}
+	if elapsed < window/2 {
+		t.Errorf("Connect gave up after %s against an instantly-refused port; it is not retrying", elapsed)
+	}
 }


### PR DESCRIPTION
Not a review finding — this is the flake that failed #1461, diagnosed rather than re-run past.

`Connect` pinged once with a five-second timeout and no retry, so *"not answering yet"* — which
is the normal case at two distinct moments — was a hard failure.

## Why it started biting now

A Postgres container running its init scripts serves a **temporary** server on a unix socket
only, so every TCP connect is refused until init finishes and the real server starts. That window
grows with each migration added, and there are 69 now. CI's smoke run began losing the race:

```
app-1 | 23:06:38  database: ping: ... 172.18.0.2:5432 (db): connect: connection refused
db-1  | 23:06:39  PostgreSQL init process complete; ready for start up.
```

**One second.** The same commit passed on a re-run — which is what a flake looks like when
nothing is wrong with the change. The same shape happens in production whenever the database
restarts under a worker.

## The fix, and the number

Retry with a doubling backoff to a two-second ceiling, bounded by a **thirty-second** window.

That number is chosen against the failure it must not cause: a cron worker whose DSN is simply
wrong should still fail its slot promptly rather than hold it. And the caller's context wins when
shorter, so a worker cancelled by SIGTERM mid-startup stops immediately rather than in thirty
seconds — the context's own error is returned rather than retried, because a cancelled caller is
not a database fault.

## The test was checked against the old implementation

`TestConnectRetriesRatherThanFailingOnTheFirstPing` fails on the pre-change code:

```
--- FAIL: TestConnectRetriesRatherThanFailingOnTheFirstPing (0.00s)
    Connect gave up after 2.442ms against an instantly-refused port; it is not retrying
```

Elapsed time is the honest observation here, because a refused connection returns instantly, so a
non-retrying `Connect` finishes in milliseconds while a retrying one runs to its deadline. An
earlier version of this test inferred the attempt count from timing through a helper — it passed,
but it could have passed for the wrong reason, so it was replaced with the direct measurement.

A second test pins that the caller's deadline stops the loop (returns in 400ms, not 30s), and a
third keeps the window an explicit, argued-about number rather than a value that drifts.

`go test ./...` **and** `go test -tags=integration ./...` green.
