### PR TITLE
One slug-set store instead of three

### DIFF
--- a/openspec/changes/one-slug-set/.openspec.yaml
+++ b/openspec/changes/one-slug-set/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/one-slug-set/proposal.md
+++ b/openspec/changes/one-slug-set/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Catalogue **#38**: `savedJobs`, `viewedJobs` and `dismissedJobs` are three copies of one class
+differing only in which endpoint they call.
+
+They already shared the load-once/reset scaffolding through `UserResource<T>`. What stayed
+duplicated is the payload half — a `SvelteSet` in `$state`, `has`, `mark`, sometimes `unmark`, and
+the two hooks that swap the set on load and drop it on reset. Thirty lines, three times, differing
+by one method call.
+
+## What Changes
+
+- `SlugSet` extends `UserResource<string[]>` and owns the set. A subclass supplies `load()` and
+  nothing else — each of the three shrinks to five lines.
+- `unmark` lives on the base rather than in the two subclasses that had it: `viewedJobs` simply
+  had no caller for it, and an absent caller is not a different rule. It stays unreachable from
+  outside `viewedJobs` because no `unmarkViewed` is exported.
+
+## Also checked, and already done
+
+**Catalogue #36** — "the single source of display labels is forked" — is **already closed by S1**
+(`unify-facet-display-labels`, #1393). There is now one `titleCase`, one `categoryLabel` and one
+`RELOCATION_LABELS` in `labels.ts`, imported by both `enrichment.ts` and `facets.ts`, with a test
+pinning `not_supported → 'Not supported'`. Verified rather than assumed: the catalogue's numbering
+and the shortlist's ids do not line up, so overlap has to be checked in the code.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change; `tasks.md` is the real artifact and the change
+archives with `--skip-specs`.
+
+## Impact
+
+- `web/src/lib/userResource.svelte.ts`, `savedJobs.svelte.ts`, `viewedJobs.svelte.ts`,
+  `dismissedJobs.svelte.ts`.
+- **No unit test, and the reason is not laziness.** `SlugSet` is all runes, and this repo's own
+  precedent says so out loud: `paginated.svelte.test.ts` carries the comment "the reactive
+  Paginator can't be instantiated here — its `$state` fields need a Svelte runtime this test env
+  doesn't provide". The collapse is verified by reading the three bodies side by side before
+  merging them, and by `pnpm run check` staying at its baseline.

--- a/openspec/changes/one-slug-set/tasks.md
+++ b/openspec/changes/one-slug-set/tasks.md
@@ -1,0 +1,19 @@
+## 1. Check what is actually left
+
+- [x] 1.1 Confirm the three bodies are identical before merging them, rather than trusting the
+      finding's summary.
+- [x] 1.2 Check catalogue #36 against the code first — it turned out to be already closed by S1,
+      which the title-based mapping between the catalogue and the shortlist did not show.
+
+## 2. Collapse the payload half
+
+- [x] 2.1 `SlugSet` owns the set, `has`, `mark`, `unmark` and the two hooks; subclasses supply
+      only `load()`.
+- [x] 2.2 Put `unmark` on the base and say why — one of the three lacked it only because nothing
+      called it.
+
+## 3. Verify and close
+
+- [x] 3.1 `pnpm run check` no worse than the baseline (0 errors, 18 warnings, 9 files).
+- [x] 3.2 Record that no unit test is possible here, with the repo's own precedent for why.
+- [x] 3.3 Mark #36 and #38 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.

--- a/web/src/lib/dismissedJobs.svelte.ts
+++ b/web/src/lib/dismissedJobs.svelte.ts
@@ -11,42 +11,12 @@
 // and the set stays empty for signed-out users. A failed load leaves the set empty —
 // nothing is excluded, the correct degraded state.
 
-import { SvelteSet } from 'svelte/reactivity';
 import { api } from '$lib/api';
-import { UserResource } from '$lib/userResource.svelte';
+import { SlugSet } from '$lib/userResource.svelte';
 
-class DismissedJobs extends UserResource<string[]> {
-  // SvelteSet (not a plain Set): a plain Set in $state is not deeply reactive, so
-  // an in-place `.add`/`.delete` would not re-run readers. SvelteSet makes both the
-  // mutation and the load reassignment trigger dependent $derived/$effect (e.g.
-  // the feed's dismissed exclusion).
-  #slugs = $state(new SvelteSet<string>());
-
-  has(slug: string): boolean {
-    return this.#slugs.has(slug);
-  }
-
-  /** Mark a slug hidden locally (e.g. right after a successful dismiss), so its
-   *  card drops out of the feed immediately without re-fetching the whole set. */
-  mark(slug: string) {
-    this.#slugs.add(slug);
-  }
-
-  /** Clear a slug's hidden mark locally (e.g. right after a successful undo). */
-  unmark(slug: string) {
-    this.#slugs.delete(slug);
-  }
-
+class DismissedJobs extends SlugSet {
   protected load(): Promise<string[]> {
     return api.listDismissedSlugs();
-  }
-
-  protected apply(slugs: string[]) {
-    this.#slugs = new SvelteSet(slugs);
-  }
-
-  protected clearState() {
-    this.#slugs = new SvelteSet();
   }
 }
 

--- a/web/src/lib/savedJobs.svelte.ts
+++ b/web/src/lib/savedJobs.svelte.ts
@@ -12,42 +12,12 @@
 // and the set stays empty for signed-out users. A failed load leaves the set empty —
 // nothing shows filled, the correct degraded state.
 
-import { SvelteSet } from 'svelte/reactivity';
 import { api } from '$lib/api';
-import { UserResource } from '$lib/userResource.svelte';
+import { SlugSet } from '$lib/userResource.svelte';
 
-class SavedJobs extends UserResource<string[]> {
-  // SvelteSet (not a plain Set): a plain Set in $state is not deeply reactive, so
-  // an in-place `.add`/`.delete` would not re-run readers. SvelteSet makes both the
-  // mutation and the load reassignment trigger dependent $derived/$effect (e.g.
-  // JobRow's `saved`).
-  #slugs = $state(new SvelteSet<string>());
-
-  has(slug: string): boolean {
-    return this.#slugs.has(slug);
-  }
-
-  /** Mark a slug saved locally (e.g. right after a successful save), so its card's
-   *  bookmark fills immediately without re-fetching the whole set. */
-  mark(slug: string) {
-    this.#slugs.add(slug);
-  }
-
-  /** Clear a slug's saved mark locally (e.g. right after a successful unsave). */
-  unmark(slug: string) {
-    this.#slugs.delete(slug);
-  }
-
+class SavedJobs extends SlugSet {
   protected load(): Promise<string[]> {
     return api.listSavedSlugs();
-  }
-
-  protected apply(slugs: string[]) {
-    this.#slugs = new SvelteSet(slugs);
-  }
-
-  protected clearState() {
-    this.#slugs = new SvelteSet();
   }
 }
 

--- a/web/src/lib/userResource.svelte.ts
+++ b/web/src/lib/userResource.svelte.ts
@@ -8,6 +8,7 @@
 // viewed-jobs leak: the reset list lived apart from the store definitions).
 
 import { browser } from '$app/environment';
+import { SvelteSet } from 'svelte/reactivity';
 
 // Every UserResource registers here on construction; resetUserStores() (called from
 // the root layout on sign-out) drops them all, so a new per-user store participates
@@ -79,5 +80,45 @@ export abstract class UserResource<T> {
     this.clearState();
     this.#loaded = false;
     this.#loading = null;
+  }
+}
+
+/**
+ * SlugSet is a UserResource whose payload is a set of job slugs — "which jobs has this user
+ * saved / viewed / dismissed". All three answered that question with the same thirty lines:
+ * a SvelteSet in $state, `has`, `mark`, sometimes `unmark`, and the two hooks that swap the
+ * set on load and drop it on reset. Only the endpoint differed.
+ *
+ * A subclass supplies `load()` and nothing else. `unmark` is here rather than in the two
+ * subclasses that had it because the third simply never needed it — an absent caller is not a
+ * different rule.
+ *
+ * SvelteSet, not a plain Set: a plain Set in $state is not deeply reactive, so an in-place
+ * `.add`/`.delete` would not re-run readers. SvelteSet makes both the mutation and the load
+ * reassignment trigger dependent $derived/$effect.
+ */
+export abstract class SlugSet extends UserResource<string[]> {
+  #slugs = $state(new SvelteSet<string>());
+
+  has(slug: string): boolean {
+    return this.#slugs.has(slug);
+  }
+
+  /** Record a slug locally, so the card reacts immediately without re-fetching the set. */
+  mark(slug: string) {
+    this.#slugs.add(slug);
+  }
+
+  /** Drop a slug's mark locally, after the write that undid it succeeded. */
+  unmark(slug: string) {
+    this.#slugs.delete(slug);
+  }
+
+  protected apply(slugs: string[]) {
+    this.#slugs = new SvelteSet(slugs);
+  }
+
+  protected clearState() {
+    this.#slugs = new SvelteSet();
   }
 }

--- a/web/src/lib/viewedJobs.svelte.ts
+++ b/web/src/lib/viewedJobs.svelte.ts
@@ -8,37 +8,12 @@
 // and the set stays empty for signed-out users. A failed load leaves the set empty —
 // nothing dims, the correct degraded state.
 
-import { SvelteSet } from 'svelte/reactivity';
 import { api } from '$lib/api';
-import { UserResource } from '$lib/userResource.svelte';
+import { SlugSet } from '$lib/userResource.svelte';
 
-class ViewedJobs extends UserResource<string[]> {
-  // SvelteSet (not a plain Set): a plain Set in $state is not deeply reactive, so
-  // an in-place `.add` in `mark` would not re-run readers. SvelteSet makes both
-  // the `.add` mutation and the load reassignment trigger dependent
-  // $derived/$effect (e.g. JobRow's `isViewed`).
-  #slugs = $state(new SvelteSet<string>());
-
-  has(slug: string): boolean {
-    return this.#slugs.has(slug);
-  }
-
-  /** Mark a slug viewed locally (e.g. right after recording a view), so its card
-   *  dims immediately without re-fetching the whole set. */
-  mark(slug: string) {
-    this.#slugs.add(slug);
-  }
-
+class ViewedJobs extends SlugSet {
   protected load(): Promise<string[]> {
     return api.listViewedSlugs();
-  }
-
-  protected apply(slugs: string[]) {
-    this.#slugs = new SvelteSet(slugs);
-  }
-
-  protected clearState() {
-    this.#slugs = new SvelteSet();
   }
 }
 


### PR DESCRIPTION
Catalogue **#38** — `savedJobs`, `viewedJobs` and `dismissedJobs` are three copies of one class
differing only in which endpoint they call.

They already shared the load-once/reset scaffolding through `UserResource<T>`. What stayed
duplicated was the payload half: a `SvelteSet` in `$state`, `has`, `mark`, sometimes `unmark`, and
the two hooks that swap the set on load and drop it on reset. Thirty lines, three times, differing
by one method call.

`SlugSet` owns that now. A subclass supplies `load()` and nothing else — each store is five lines.

`unmark` goes on the base rather than into the two subclasses that had it: `viewedJobs` simply had
no caller for it, and an absent caller is not a different rule. It stays unreachable from outside
because no `unmarkViewed` is exported.

## Also checked: #36 was already done

Catalogue **#36** ("the single source of display labels is forked — two `categoryLabel`, four
humanize fallbacks, a drifted relocation map") is **already closed by S1** (#1393). There is now
one `titleCase`, one `categoryLabel` and one `RELOCATION_LABELS` in `labels.ts`, imported by both
`enrichment.ts` and `facets.ts`, with a test pinning `not_supported → 'Not supported'`.

Worth stating because the catalogue's `#N` numbering and the shortlist's reviewer ids do **not**
line up — overlap has to be checked in the code, not inferred from titles. I nearly re-did work
that was already merged.

## No unit test, and the reason is the repo's own

`SlugSet` is all runes. `paginated.svelte.test.ts` already records why that cannot be
instantiated here:

> the reactive Paginator can't be instantiated here — its `$state` fields need a Svelte runtime
> this test env doesn't provide

So the collapse is verified the only ways available: by reading the three bodies side by side
**before** merging them, and by `pnpm run check` staying at its baseline — **0 errors, 18
warnings, 9 files**, identical to main.

Net **−44 lines**.
