### PR TITLE
feat(harvest): mine ATS boards from LinkedIn's public job search

### DIFF
--- a/cmd/harvest-ats/candidates.go
+++ b/cmd/harvest-ats/candidates.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// hit is one (provider, board) the resolve step wants written to a seed: either detected on a
+// company's careers page, or — with expectID set — guessed offline for a company whose pages
+// yielded nothing.
+type hit struct{ provider, slug, company, expectID string }
+
+// guessedCandidates proposes seed entries for a company the careers walk could not resolve,
+// pairing every candidate slug with every provider the posting id's shape allows. It performs
+// no I/O and yields nothing without an id, because the id is the only thing that makes a
+// guessed slug safe to propose — harvest-boards keeps such a candidate only if the platform
+// reports a live posting carrying it.
+//
+// The fan-out is bounded by construction: at most maxCandidateSlugs slugs times the providers
+// one id shape can belong to (never more than two).
+func guessedCandidates(site companySite) []hit {
+	providers := providersForID(site.ExternalID)
+	if len(providers) == 0 {
+		return nil
+	}
+	slugs := candidateSlugs(site)
+	out := make([]hit, 0, len(slugs)*len(providers))
+	for _, p := range providers {
+		for _, s := range slugs {
+			out = append(out, hit{provider: p, slug: s, company: site.Name, expectID: site.ExternalID})
+		}
+	}
+	return out
+}
+
+// maxCandidateSlugs bounds how many board slugs one company may propose. The slugs are
+// guesses; the point of bounding them is that each one costs a probe at harvest-boards, and
+// past three the guesses stop being informed by anything (a fourth spelling of a name we
+// already tried three ways is not new evidence).
+const maxCandidateSlugs = 3
+
+// legalFormSuffixes are the company-form tails a platform profile slug commonly carries while
+// the board itself does not (linkedin.com/company/doodle-ag → the teamtailor board `doodle`).
+var legalFormSuffixes = []string{
+	"-ag", "-gmbh", "-inc", "-llc", "-ltd", "-limited", "-bv", "-nv", "-sa", "-se",
+	"-srl", "-spa", "-oy", "-ab", "-as", "-aps", "-plc", "-pty", "-co", "-corp", "-group",
+}
+
+// careersHostPrefixes are the sub-domains a company puts its careers site on. Their labels
+// are not the company, so `jobs.picnic.app` must contribute `picnic`, not `jobs`.
+var careersHostPrefixes = map[string]bool{
+	"jobs": true, "careers": true, "career": true, "hire": true, "hiring": true,
+	"work": true, "join": true, "apply": true, "www": true,
+}
+
+// candidateSlugs proposes the board slugs a company might use, drawn from what we already know
+// about it: the label of its own domain, the slug of its platform profile (with and without a
+// legal-form tail), and its normalized name. It performs no I/O.
+//
+// These are guesses and are only safe to emit alongside an expected posting id, which
+// harvest-boards checks against the platform's live postings — a slug that happens to be some
+// other employer's real board is then rejected on evidence rather than accepted on a
+// resemblance. Results are sorted and de-duplicated so a run's seeds are deterministic.
+// The order is the order of confidence, and the cap cuts from the tail: a company's own domain
+// label is the best guess, its profile slug next, and a slug folded out of its display name
+// last — so a bounded list keeps the guesses most likely to be right.
+func candidateSlugs(site companySite) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s == "" || seen[s] || len(out) >= maxCandidateSlugs {
+			return
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	add(domainLabel(site.Website))
+	for _, s := range profileSlugs(site.LinkedIn) {
+		add(s)
+	}
+	// Both spellings of the name: boards are registered hyphenated (`delivery-hero`) about as
+	// often as run together (`deliveryhero`), and neither is derivable from the other.
+	nameSlug := trimLegalForm(normalize.Slug(site.Name))
+	add(nameSlug)
+	add(strings.ReplaceAll(nameSlug, "-", ""))
+	return out
+}
+
+// trimLegalForm drops a trailing company-form label from a slug (`delivery-hero-se` →
+// `delivery-hero`), which boards routinely omit.
+func trimLegalForm(slug string) string {
+	for _, suffix := range legalFormSuffixes {
+		if bare := strings.TrimSuffix(slug, suffix); bare != slug && bare != "" {
+			return bare
+		}
+	}
+	return slug
+}
+
+// domainLabel returns the company-bearing label of a website's host: the registrable name with
+// any careers sub-domain stripped (jobs.picnic.app → picnic, www.deliveryhero.com →
+// deliveryhero). It returns "" when the URL carries no usable host.
+func domainLabel(website string) string {
+	if website == "" {
+		return ""
+	}
+	if !strings.Contains(website, "//") {
+		website = "https://" + website
+	}
+	u, err := url.Parse(website)
+	if err != nil {
+		return ""
+	}
+	labels := strings.Split(strings.ToLower(u.Hostname()), ".")
+	for len(labels) > 1 && careersHostPrefixes[labels[0]] {
+		labels = labels[1:]
+	}
+	if len(labels) < 2 {
+		return ""
+	}
+	return normalize.Slug(labels[0])
+}
+
+// profileSlugRe captures the slug out of a company profile URL
+// (https://ch.linkedin.com/company/doodle-ag → doodle-ag).
+var profileSlugRe = regexp.MustCompile(`/company/([a-z0-9][a-z0-9-]*)`)
+
+// profileSlugs returns the profile's own slug and, when it ends in a legal-form tail, the slug
+// without it — boards are commonly registered under the bare name.
+func profileSlugs(profileURL string) []string {
+	m := profileSlugRe.FindStringSubmatch(strings.ToLower(profileURL))
+	if m == nil {
+		return nil
+	}
+	slug := m[1]
+	out := []string{slug}
+	for _, suffix := range legalFormSuffixes {
+		if bare := strings.TrimSuffix(slug, suffix); bare != slug && bare != "" {
+			out = append(out, bare)
+			break
+		}
+	}
+	return out
+}
+
+var (
+	// greenhouseIDRe is Greenhouse's job id: a ten-digit number.
+	greenhouseIDRe = regexp.MustCompile(`^\d{10}$`)
+	// uuidRe is the id shape Lever and Ashby both use for a posting.
+	uuidRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	// prefixedIDRe is the shape that names its own platform (teamtailor-8094978).
+	prefixedIDRe = regexp.MustCompile(`^([a-z][a-z0-9]+)-\d+$`)
+)
+
+// knownPrefixes are the platform names an id may carry as its own prefix.
+var knownPrefixes = map[string]bool{"teamtailor": true, "greenhouse": true, "lever": true, "ashby": true}
+
+// providersForID narrows an ATS-native posting id to the providers whose id space it could
+// belong to, so a candidate slug is only proposed to boards that could plausibly hold it.
+//
+// A shape that narrows to nothing yields nothing: fanning a guess across every provider would
+// spend probes proportional to the provider count for no added evidence. The narrowing is a
+// heuristic and is never trusted on its own — it only decides which boards get asked, and the
+// id itself decides the answer.
+func providersForID(externalID string) []string {
+	id := strings.ToLower(strings.TrimSpace(externalID))
+	switch {
+	case id == "":
+		return nil
+	case greenhouseIDRe.MatchString(id):
+		return []string{"greenhouse"}
+	case uuidRe.MatchString(id):
+		return []string{"ashby", "lever"}
+	}
+	if m := prefixedIDRe.FindStringSubmatch(id); m != nil && knownPrefixes[m[1]] {
+		return []string{m[1]}
+	}
+	return nil
+}

--- a/cmd/harvest-ats/candidates_test.go
+++ b/cmd/harvest-ats/candidates_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCandidateSlugs(t *testing.T) {
+	cases := []struct {
+		name string
+		site companySite
+		want []string
+	}{
+		{
+			name: "domain, profile slug and name each contribute",
+			site: companySite{Name: "Doodle", Website: "https://doodle.com", LinkedIn: "https://ch.linkedin.com/company/doodle-ag"},
+			want: []string{"doodle", "doodle-ag"},
+		},
+		{
+			name: "a legal-form suffix on the profile slug yields the bare slug too",
+			site: companySite{Name: "Simplesurance GmbH", Website: "https://www.simplesurance.com", LinkedIn: "https://de.linkedin.com/company/simplesurance-gmbh"},
+			want: []string{"simplesurance", "simplesurance-gmbh"},
+		},
+		{
+			name: "a multi-word name contributes both spellings",
+			site: companySite{Name: "Delivery Hero SE", Website: "https://www.deliveryhero.com"},
+			want: []string{"deliveryhero", "delivery-hero"},
+		},
+		{
+			name: "a careers host does not become the slug",
+			site: companySite{Name: "Picnic Technologies", Website: "https://jobs.picnic.app/en/"},
+			want: []string{"picnic", "picnic-technologies", "picnictechnologies"},
+		},
+		{
+			name: "no website and no profile still yields the name's slug",
+			site: companySite{Name: "Acme"},
+			want: []string{"acme"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := candidateSlugs(tc.site)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("candidateSlugs = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCandidateSlugsAreBounded(t *testing.T) {
+	site := companySite{
+		Name:     "Some Extremely Long Company Name Ltd",
+		Website:  "https://www.someextremelylongcompanyname.example.com",
+		LinkedIn: "https://linkedin.com/company/some-extremely-long-company-name-ltd",
+	}
+	if got := candidateSlugs(site); len(got) > maxCandidateSlugs {
+		t.Errorf("candidateSlugs returned %d slugs (%v), want at most %d", len(got), got, maxCandidateSlugs)
+	}
+}
+
+func TestGuessedCandidates(t *testing.T) {
+	t.Run("every slug is proposed to every narrowed provider, carrying the id", func(t *testing.T) {
+		site := companySite{
+			Name:       "Acme",
+			Website:    "https://acme.com",
+			LinkedIn:   "https://linkedin.com/company/acme-inc",
+			ExternalID: "c2627bcd-915c-4076-98f5-1a2b3c4d5e6f",
+		}
+		got := guessedCandidates(site)
+		// slugs {acme, acme-inc} × providers {ashby, lever}
+		if len(got) != 4 {
+			t.Fatalf("got %d candidates (%v), want 4", len(got), got)
+		}
+		for _, h := range got {
+			if h.expectID != site.ExternalID {
+				t.Errorf("candidate %v carries expectID %q, want the posting id", h, h.expectID)
+			}
+			if h.provider != "ashby" && h.provider != "lever" {
+				t.Errorf("candidate proposed to %q, want only the narrowed providers", h.provider)
+			}
+			if h.company != "Acme" {
+				t.Errorf("candidate company = %q, want Acme", h.company)
+			}
+		}
+	})
+
+	t.Run("no posting id yields no candidates", func(t *testing.T) {
+		site := companySite{Name: "Acme", Website: "https://acme.com"}
+		if got := guessedCandidates(site); len(got) != 0 {
+			t.Errorf("got %v, want none without a posting id", got)
+		}
+	})
+
+	t.Run("an id whose shape narrows to nothing yields no candidates", func(t *testing.T) {
+		site := companySite{Name: "Acme", Website: "https://acme.com", ExternalID: "JR37734"}
+		if got := guessedCandidates(site); len(got) != 0 {
+			t.Errorf("got %v, want none for an unrecognised id shape", got)
+		}
+	})
+}
+
+func TestProvidersForID(t *testing.T) {
+	cases := []struct {
+		id   string
+		want []string
+	}{
+		// The platform names itself in the id.
+		{"teamtailor-8094978", []string{"teamtailor"}},
+		// Ten digits is the Greenhouse job id shape.
+		{"4698693006", []string{"greenhouse"}},
+		{"5788132680", []string{"greenhouse"}},
+		// A UUID is Lever's and Ashby's shape; both are worth asking.
+		{"c2627bcd-915c-4076-98f5-1a2b3c4d5e6f", []string{"ashby", "lever"}},
+		// Shapes that narrow to nothing must yield nothing rather than fan out.
+		{"JR37734", nil},
+		{"R00314608_en", nil},
+		{"3584-en_GB", nil},
+		{"99580", nil},
+		{"", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			got := providersForID(tc.id)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("providersForID(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/harvest-ats/extract.go
+++ b/cmd/harvest-ats/extract.go
@@ -14,6 +14,12 @@ import (
 type companySite struct {
 	Name    string `json:"name"`
 	Website string `json:"website"`
+	// LinkedIn and ExternalID are supplied by a discovery source that read them off a live
+	// posting (harvest-linkedin); the dataset and university worklists leave them empty. They
+	// feed the offline candidate-slug fallback for companies whose careers pages yield no
+	// board — the profile slug is a spelling to try, and the id is what proves it.
+	LinkedIn   string `json:"linkedin,omitempty"`
+	ExternalID string `json:"external_id,omitempty"`
 }
 
 // siteParsers maps a collection slug to a parser that extracts (name, website)

--- a/cmd/harvest-ats/main.go
+++ b/cmd/harvest-ats/main.go
@@ -149,10 +149,9 @@ func runResolve(inputFile string) int {
 		return client.GetText(ctx, u)
 	}
 
-	type hit struct{ provider, slug, company string }
 	var (
 		mu     sync.Mutex
-		byProv = map[string]map[string]string{} // provider -> board -> company (first wins)
+		byProv = map[string]map[string]seedEntry{} // provider -> board -> entry (first wins)
 		done   atomic.Int64
 		jobs   = make(chan companySite)
 		wg     sync.WaitGroup
@@ -161,10 +160,10 @@ func runResolve(inputFile string) int {
 		mu.Lock()
 		defer mu.Unlock()
 		if byProv[h.provider] == nil {
-			byProv[h.provider] = map[string]string{}
+			byProv[h.provider] = map[string]seedEntry{}
 		}
 		if _, seen := byProv[h.provider][h.slug]; !seen {
-			byProv[h.provider][h.slug] = h.company
+			byProv[h.provider][h.slug] = seedEntry{Board: h.slug, Company: h.company, ExpectID: h.expectID}
 		}
 	}
 	for i := 0; i < resolveWorkers; i++ {
@@ -174,6 +173,10 @@ func runResolve(inputFile string) int {
 			for site := range jobs {
 				if p, s, ok := resolve(site.Website, fetch); ok {
 					record(hit{provider: p, slug: s, company: site.Name})
+				} else {
+					for _, h := range guessedCandidates(site) {
+						record(h)
+					}
 				}
 				if n := done.Add(1); n%200 == 0 {
 					log.Printf("harvest-ats: resolved %d/%d", n, len(sites))
@@ -209,14 +212,18 @@ func runResolve(inputFile string) int {
 type seedEntry struct {
 	Board   string `json:"board"`
 	Company string `json:"company,omitempty"`
+	// ExpectID names a posting the board must carry for harvest-boards to keep it. It is set
+	// only on the offline-derived candidates, whose slug is a guess: the id is what turns that
+	// guess into something the platform's own API can confirm or refute.
+	ExpectID string `json:"expect_id,omitempty"`
 }
 
-// toSeedEntries turns a board->company map into board-sorted seed entries, so a run's
-// output is deterministic regardless of goroutine completion order.
-func toSeedEntries(byBoard map[string]string) []seedEntry {
+// toSeedEntries returns the provider's entries board-sorted, so a run's output is
+// deterministic regardless of goroutine completion order.
+func toSeedEntries(byBoard map[string]seedEntry) []seedEntry {
 	out := make([]seedEntry, 0, len(byBoard))
-	for board, company := range byBoard {
-		out = append(out, seedEntry{Board: board, Company: company})
+	for _, e := range byBoard {
+		out = append(out, e)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Board < out[j].Board })
 	return out

--- a/cmd/harvest-ats/main_test.go
+++ b/cmd/harvest-ats/main_test.go
@@ -6,9 +6,13 @@ import (
 )
 
 func TestToSeedEntries(t *testing.T) {
-	got := toSeedEntries(map[string]string{
-		"edzz.fa.em3.oraclecloud.com/CX_6001":  "University of Birmingham",
-		"mcgill.wd3.myworkdayjobs.com/careers": "McGill University",
+	got := toSeedEntries(map[string]seedEntry{
+		"edzz.fa.em3.oraclecloud.com/CX_6001": {
+			Board: "edzz.fa.em3.oraclecloud.com/CX_6001", Company: "University of Birmingham",
+		},
+		"mcgill.wd3.myworkdayjobs.com/careers": {
+			Board: "mcgill.wd3.myworkdayjobs.com/careers", Company: "McGill University",
+		},
 	})
 	want := []seedEntry{
 		// sorted by board so the emitted seed is deterministic

--- a/cmd/harvest-ats/resolve.go
+++ b/cmd/harvest-ats/resolve.go
@@ -103,7 +103,7 @@ func resolve(website string, fetch fetchFunc) (provider, slug string, ok bool) {
 		// give up on this company. (Dead domains dominate the unmatched long tail.)
 		return "", "", false
 	}
-	if p, s, ok := atsdetect.Detect(home); ok {
+	if p, s, ok := detectBoard(home, base); ok {
 		return p, s, true
 	}
 
@@ -126,7 +126,7 @@ func resolve(website string, fetch fetchFunc) (provider, slug string, ok bool) {
 		if err != nil {
 			continue
 		}
-		if p, s, ok := atsdetect.Detect(html); ok {
+		if p, s, ok := detectBoard(html, u); ok {
 			return p, s, true
 		}
 		// One deeper hop: a careers landing page often links to the live vacancy
@@ -134,11 +134,31 @@ func resolve(website string, fetch fetchFunc) (provider, slug string, ok bool) {
 		if link := deeperLink(html, u); link != "" && !seen[link] {
 			seen[link] = true
 			if dh, err := fetch(link); err == nil {
-				if p, s, ok := atsdetect.Detect(dh); ok {
+				if p, s, ok := detectBoard(dh, link); ok {
 					return p, s, true
 				}
 			}
 		}
 	}
 	return "", "", false
+}
+
+// detectBoard finds the ATS board a fetched page belongs to. It first runs the URL-shape scan,
+// which resolves every board that names its platform somewhere in a link. Only when that comes
+// up empty does it ask whether the page IS a board: Radancy, Phenom, Jibe and Teamtailor tenants
+// serve from the employer's own domain and link out to no ATS host at all, so nothing in their
+// markup or URLs can be recognised — the vendor's bundle is the only tell, and the careers host
+// itself is the board, which is exactly how those adapters key jobs.external_id.
+//
+// The order matters: a careers site that merely embeds another ATS must resolve to that board,
+// not to its own host.
+func detectBoard(html, pageURL string) (provider, board string, ok bool) {
+	if p, s, ok := atsdetect.Detect(html); ok {
+		return p, s, true
+	}
+	u, err := url.Parse(pageURL)
+	if err != nil {
+		return "", "", false
+	}
+	return atsdetect.DetectSelfHosted(html, u.Hostname())
 }

--- a/cmd/harvest-ats/resolve_test.go
+++ b/cmd/harvest-ats/resolve_test.go
@@ -98,6 +98,20 @@ func TestResolve(t *testing.T) {
 		}
 	})
 
+	t.Run("detects a career site that is itself the board", func(t *testing.T) {
+		// No ATS host anywhere on the page — the platform's fingerprint names the provider and
+		// the careers host is the board, which is how these adapters key external_id.
+		pages := map[string]string{
+			"https://intuit.com":      `<a href="https://jobs.intuit.com">Careers</a>`,
+			"https://jobs.intuit.com": `<html><head><script src="/assets/talentbrew/app.js"></script></head></html>`,
+		}
+		fetch := func(u string) (string, error) { return pages[u], nil }
+		p, s, ok := resolve("https://intuit.com", fetch)
+		if !ok || p != "radancy" || s != "jobs.intuit.com" {
+			t.Fatalf("resolve = (%q,%q,%v), want (radancy,jobs.intuit.com,true)", p, s, ok)
+		}
+	})
+
 	t.Run("dead homepage skips career-path probes", func(t *testing.T) {
 		var calls int
 		fetch := func(u string) (string, error) {

--- a/cmd/harvest-boards/expectid.go
+++ b/cmd/harvest-boards/expectid.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// expectation is what a seed claims about a candidate board: the employer it should belong to,
+// the id of a posting it should carry, or neither. The two are not equals — a name is a
+// resemblance the platform may spell differently, an id is evidence — so when both are present
+// the id decides.
+type expectation struct {
+	company   string
+	postingID string
+}
+
+// mismatchReason reports why a live board is not the board the seed was looking for, or ""
+// when it is (or when nothing was claimed about it). reportedName is the employer the platform
+// published for the board, empty when it publishes none.
+//
+// An expected posting id settles the question outright where the platform can list its live
+// postings, because it identifies the board by evidence. Everything else falls back to the
+// employer name, which is only a resemblance.
+func mismatchReason(ctx context.Context, c httpClient, p prober, slug, reportedName string, want expectation) string {
+	if carries, answerable := carriesPosting(ctx, c, p, slug, want.postingID); answerable {
+		if carries {
+			return ""
+		}
+		return fmt.Sprintf("expected posting %q absent from the board", want.postingID)
+	}
+	// An expected name that normalizes to nothing (punctuation alone) states no expectation at
+	// all, and is treated as such rather than rejecting every board it is paired with.
+	if normalize.CompanyKey(want.company) == "" || reportedName == "" {
+		return ""
+	}
+	if normalize.SameCompany(want.company, reportedName) {
+		return ""
+	}
+	return fmt.Sprintf("expected %q, board reports %q", want.company, reportedName)
+}
+
+// carriesPosting answers whether a candidate board carries the posting the seed expected.
+//
+// answerable reports whether the question could be answered at all: it is false when the seed
+// named no posting, when the prober cannot list a board's live postings, when listing them
+// failed, or when it returned none despite the board being live. Every one of those is an
+// absence of evidence, not evidence of absence, so the caller falls back to the name
+// comparison rather than rejecting the board.
+func carriesPosting(ctx context.Context, c httpClient, p prober, slug, postingID string) (carries, answerable bool) {
+	if postingID == "" {
+		return false, false
+	}
+	ip, ok := p.(idProber)
+	if !ok {
+		return false, false
+	}
+	ids, err := ip.postingIDs(ctx, c, slug)
+	if err != nil {
+		log.Printf("harvest-boards: %s: listing postings for the expected-id check: %v", slug, err)
+		return false, false
+	}
+	if len(ids) == 0 {
+		return false, false
+	}
+	for _, id := range ids {
+		if id == postingID {
+			return true, true
+		}
+	}
+	return false, true
+}

--- a/cmd/harvest-boards/expectid_test.go
+++ b/cmd/harvest-boards/expectid_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// scriptedIDProber is a scriptedProber that also reports each board's live posting ids, so
+// the expected-id gate can be exercised without touching a platform API.
+type scriptedIDProber struct {
+	scriptedProber
+	ids map[string][]string
+}
+
+func (p scriptedIDProber) postingIDs(_ context.Context, _ httpClient, slug string) ([]string, error) {
+	return p.ids[slug], nil
+}
+
+func TestPostingIDsPerProvider(t *testing.T) {
+	cases := []struct {
+		name   string
+		prober prober
+		client fakeGetter
+		slug   string
+		want   []string
+	}{
+		{
+			name:   "greenhouse",
+			prober: greenhouseProber{},
+			client: fakeGetter{
+				"https://boards-api.greenhouse.io/v1/boards/acme/jobs": `{"jobs":[{"id":4698693006},{"id":4698693007}]}`,
+			},
+			slug: "acme",
+			want: []string{"4698693006", "4698693007"},
+		},
+		{
+			name:   "lever",
+			prober: leverProber{},
+			client: fakeGetter{
+				"https://api.lever.co/v0/postings/acme?mode=json": `[{"id":"c2627bcd-915c-4076-98f5-000000000000"}]`,
+			},
+			slug: "acme",
+			want: []string{"c2627bcd-915c-4076-98f5-000000000000"},
+		},
+		{
+			name:   "ashby",
+			prober: ashbyProber{},
+			client: fakeGetter{
+				"https://api.ashbyhq.com/posting-api/job-board/acme": `{"jobs":[{"id":"01e5aa43-0c4c-4655-be41-000000000000"}]}`,
+			},
+			slug: "acme",
+			want: []string{"01e5aa43-0c4c-4655-be41-000000000000"},
+		},
+		{
+			name:   "recruitee",
+			prober: recruiteeProber{},
+			client: fakeGetter{
+				"https://acme.recruitee.com/api/offers/": `{"offers":[{"id":99580,"company_name":"Acme"}]}`,
+			},
+			slug: "acme",
+			want: []string{"99580"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip, ok := tc.prober.(idProber)
+			if !ok {
+				t.Fatalf("%s prober does not report posting ids", tc.name)
+			}
+			got, err := ip.postingIDs(context.Background(), tc.client, tc.slug)
+			if err != nil {
+				t.Fatalf("postingIDs: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("id[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPostingIDsPartialListersStayInert(t *testing.T) {
+	// SmartRecruiters is probed with limit=1 and Teamtailor reads one page, so an id absent
+	// from what they return would not mean an absent posting. They must not claim otherwise.
+	for _, p := range []prober{smartRecruitersProber{}, teamtailorProber{}} {
+		if _, ok := p.(idProber); ok {
+			t.Errorf("%T lists postings partially and must not implement idProber", p)
+		}
+	}
+}
+
+func TestProbeAllExpectedPostingIDGate(t *testing.T) {
+	prober := scriptedIDProber{
+		scriptedProber: scriptedProber{
+			// The board really does carry the posting the seed expects.
+			"acme": {company: "Acme Inc", openJobs: 12},
+			// A live board that simply belongs to somebody else — the hazard an offline-derived
+			// slug creates, and the reason the id is checked at all.
+			"doodle": {company: "Doodle Digital", openJobs: 3},
+			// A live board whose seed expects an id AND names an employer the platform reports
+			// differently. The id is evidence; the name is a resemblance.
+			"picnic": {company: "Picnic Technologies BV", openJobs: 8},
+		},
+		ids: map[string][]string{
+			"acme":   {"4698693006", "4698693007"},
+			"doodle": {"111", "222"},
+			"picnic": {"5276503008"},
+		},
+	}
+	expected := map[string]expectation{
+		"acme":   {postingID: "4698693006"},
+		"doodle": {postingID: "4698693006"},
+		"picnic": {company: "Totally Different Name", postingID: "5276503008"},
+	}
+	candidates := []string{"acme", "doodle", "picnic"}
+
+	kept, failures, mismatches := probeAll(context.Background(), nil, prober, candidates, expected, defaultProbeWorkers)
+
+	got := make(map[string]string, len(kept))
+	for _, e := range kept {
+		got[e.Board] = e.Company
+	}
+	if got["acme"] != "Acme Inc" {
+		t.Errorf("a board carrying the expected posting should be kept, got %q", got["acme"])
+	}
+	if _, ok := got["doodle"]; ok {
+		t.Error("a board that does not carry the expected posting must not be kept")
+	}
+	if got["picnic"] != "Picnic Technologies BV" {
+		t.Errorf("an expected id should decide the board over a name resemblance, got %q", got["picnic"])
+	}
+	if mismatches != 1 {
+		t.Errorf("mismatches = %d, want 1", mismatches)
+	}
+	if failures != 0 {
+		t.Errorf("failures = %d, want 0", failures)
+	}
+}
+
+func TestProbeAllExpectedPostingIDIsInertWithoutIDProber(t *testing.T) {
+	// The same expectation against a prober that reports no posting ids at all. The board is
+	// validated on liveness alone: supplying an id must never be worse than omitting one.
+	prober := scriptedProber{"acme": {company: "Acme Inc", openJobs: 12}}
+	expected := map[string]expectation{"acme": {postingID: "no-such-posting"}}
+
+	kept, failures, mismatches := probeAll(context.Background(), nil, prober, []string{"acme"}, expected, defaultProbeWorkers)
+
+	if len(kept) != 1 || kept[0].Company != "Acme Inc" {
+		t.Errorf("an expected id must be inert on a prober that reports none, kept %v", kept)
+	}
+	if failures != 0 || mismatches != 0 {
+		t.Errorf("failures = %d, mismatches = %d, want 0 and 0", failures, mismatches)
+	}
+}

--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -17,7 +17,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/strelov1/freehire/internal/normalize"
 	"github.com/strelov1/freehire/internal/sources"
 )
 
@@ -60,7 +59,7 @@ func run() int {
 		log.Printf("harvest-boards: pacing probes at %.2f req/s with %d workers", *pace, *workers)
 	}
 
-	raw, companyByBoard, err := resolveCandidates(ctx, p, client, seedPath)
+	raw, expected, err := resolveCandidates(ctx, p, client, seedPath)
 	if err != nil {
 		log.Printf("harvest-boards: %v", err)
 		return 1
@@ -81,8 +80,8 @@ func run() int {
 	log.Printf("harvest-boards: %s candidates=%d existing=%d new-candidates=%d",
 		provider, len(raw), len(existing), len(candidates))
 
-	kept, failures, mismatches := probeAll(ctx, client, p, candidates, companyByBoard, *workers)
-	log.Printf("harvest-boards: live boards found=%d probe-failures=%d name-mismatches=%d refused=%d answered=%d",
+	kept, failures, mismatches := probeAll(ctx, client, p, candidates, expected, *workers)
+	log.Printf("harvest-boards: live boards found=%d probe-failures=%d mismatches=%d refused=%d answered=%d",
 		len(kept), failures, mismatches, client.refused(), client.answered())
 	// A run the platform mostly turned away found nothing because it was not allowed to look.
 	// The probers cannot say so — they report a refusal as an absent board — so this is the
@@ -102,12 +101,13 @@ func run() int {
 		return 1
 	}
 	// Every live board disagreeing with its seed means the gate itself is wrong — a prober
-	// that started reporting a platform-wide name, or a seed built against the wrong
-	// employers — not "no new boards". Same reasoning as the all-probes-failed guard: an
-	// empty harvest that is really a broken one must not exit 0. A single rejection is the
-	// gate working, not failing, so the alarm needs more than one.
+	// that started reporting a platform-wide name, a seed built against the wrong employers,
+	// or ids drawn from a different id space than the platform's — not "no new boards". Same
+	// reasoning as the all-probes-failed guard: an empty harvest that is really a broken one
+	// must not exit 0. A single rejection is the gate working, not failing, so the alarm
+	// needs more than one.
 	if mismatches > 1 && len(kept) == 0 {
-		log.Printf("harvest-boards: every live board (%d) disagreed with its expected employer", mismatches)
+		log.Printf("harvest-boards: every live board (%d) disagreed with what its seed expected", mismatches)
 		return 1
 	}
 	if len(kept) == 0 {
@@ -144,7 +144,7 @@ func run() int {
 // candidates come from the seed file, mapped through the prober. This is the only step that
 // differs between a discovery provider and a seed-list one — dedup, probe, and append are
 // shared downstream.
-func resolveCandidates(ctx context.Context, p prober, c httpClient, seedPath string) ([]string, map[string]string, error) {
+func resolveCandidates(ctx context.Context, p prober, c httpClient, seedPath string) ([]string, map[string]expectation, error) {
 	if seedPath == "" {
 		d, ok := p.(discoverer)
 		if !ok {
@@ -162,28 +162,29 @@ func resolveCandidates(ctx context.Context, p prober, c httpClient, seedPath str
 		tokens[i] = it.Board
 	}
 	boards := mapSeeds(p, tokens)
-	companyByBoard := make(map[string]string)
+	expected := make(map[string]expectation)
 	for i, b := range boards {
-		if items[i].Company != "" {
-			companyByBoard[b] = items[i].Company
+		if items[i].Company != "" || items[i].ExpectID != "" {
+			expected[b] = expectation{company: items[i].Company, postingID: items[i].ExpectID}
 		}
 	}
-	return boards, companyByBoard, nil
+	return boards, expected, nil
 }
 
 // probeAll probes every candidate concurrently (bounded), returning the live boards as
 // emit-ready entries sorted by board, the number of candidates whose probe errored, and the
-// number rejected because the board named a different employer than the seed expected.
+// number rejected because the board did not match what the seed expected of it.
 // A probe error is logged and the candidate skipped, so one dead board never aborts the
 // harvest; the caller uses the failure count to fail the run when EVERY probe errored
-// (a broken probe or outage, not a legitimately empty harvest). companyByBoard supplies the
-// employer each candidate is expected to belong to: it gates the board when the platform
-// reports a name of its own, and labels it when the platform reports none (chooseCompany).
+// (a broken probe or outage, not a legitimately empty harvest). expected supplies what the
+// seed claims about each candidate: the employer it should belong to, which gates the board
+// when the platform reports a name of its own and labels it when it reports none
+// (chooseCompany), and/or the id of a posting the board should carry.
 //
 // Mismatches are counted apart from failures because they mean something else entirely — a
 // dead board is noise, while a wave of mismatches means the candidates or the prober's name
 // extraction are wrong, and burying them in the failure count would hide that.
-func probeAll(ctx context.Context, client httpClient, p prober, candidates []string, companyByBoard map[string]string, workers int) ([]entry, int, int) {
+func probeAll(ctx context.Context, client httpClient, p prober, candidates []string, expected map[string]expectation, workers int) ([]entry, int, int) {
 	sem := make(chan struct{}, workers)
 	var (
 		mu         sync.Mutex
@@ -209,20 +210,17 @@ func probeAll(ctx context.Context, client httpClient, p prober, candidates []str
 			if n == 0 {
 				return
 			}
-			// The board is live. It still has to be the board we were looking for, and only
-			// a name the platform publishes itself can confirm that. An expected name that
-			// normalizes to nothing (punctuation alone) states no expectation at all, and is
-			// treated as such rather than rejecting every board it is paired with.
-			expected := companyByBoard[slug]
-			if normalize.CompanyKey(expected) != "" && name != "" && !normalize.SameCompany(expected, name) {
-				log.Printf("harvest-boards: %s: expected %q, board reports %q — skipped", slug, expected, name)
+			// The board is live. It still has to be the board we were looking for.
+			want := expected[slug]
+			if reason := mismatchReason(ctx, client, p, slug, name, want); reason != "" {
+				log.Printf("harvest-boards: %s: %s — skipped", slug, reason)
 				mu.Lock()
 				mismatches++
 				mu.Unlock()
 				return
 			}
 			mu.Lock()
-			kept = append(kept, entry{Company: chooseCompany(name, expected, slug), Board: slug})
+			kept = append(kept, entry{Company: chooseCompany(name, want.company, slug), Board: slug})
 			mu.Unlock()
 		}(slug)
 	}

--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -6,6 +6,15 @@
 //
 //	go run ./cmd/harvest-boards <provider> <seed.json>
 //	go run ./cmd/harvest-boards -pace 2 -workers 4 workable seed.json   # rate-limited platform
+//
+// A seed entry is either a bare slug or an object. The object may claim two things about the
+// candidate, and a seed source that knows either should say so:
+//
+//	{"board": "acme", "company": "Acme Inc"}          # the employer it should belong to
+//	{"board": "acme", "expect_id": "4698693006"}      # a posting it must carry
+//
+// The id is the stronger claim — it identifies the board by evidence rather than by a name
+// resemblance — and is what makes a slug derived offline safe to propose at all.
 package main
 
 import (

--- a/cmd/harvest-boards/probe_test.go
+++ b/cmd/harvest-boards/probe_test.go
@@ -42,13 +42,13 @@ func TestProbeAllNameGate(t *testing.T) {
 		// not an expectation, so the board must be kept rather than rejected.
 		"unnameable": {company: "Real Employer", openJobs: 2},
 	}
-	seed := map[string]string{
-		"adoreal":                            "Adoreal",
-		"prequel":                            "Prequel",
-		"nameless":                           "Nameless Co",
-		"broken":                             "Broken",
-		"acme.wd1.myworkdayjobs.com/careers": "Acme Corporation",
-		"unnameable":                         "???",
+	seed := map[string]expectation{
+		"adoreal":                            {company: "Adoreal"},
+		"prequel":                            {company: "Prequel"},
+		"nameless":                           {company: "Nameless Co"},
+		"broken":                             {company: "Broken"},
+		"acme.wd1.myworkdayjobs.com/careers": {company: "Acme Corporation"},
+		"unnameable":                         {company: "???"},
 	}
 	candidates := []string{
 		"adoreal", "prequel", "nameless", "unclaimed", "broken", "unnameable",

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -450,22 +450,28 @@ func (breezyProber) probe(ctx context.Context, c httpClient, slug string) (strin
 // teamtailorProber probes a Teamtailor career site. The board is the site host, and its
 // /jobs listing serves a JSON Feed (title + items) to a JSON Accept header, so a non-empty
 // items array is a live board and the feed title is the company name.
+// teamtailorProber probes a Teamtailor career site, whose board is the host itself (the vendor
+// sub-domain `acme.teamtailor.com` or the employer's own `careers.acme.com`). The platform
+// serves its listing as HTML on both — there is no JSON feed — so liveness is judged the way
+// the ingest adapter reads the same page: a live board links at least one posting permalink.
+// The listing carries no company name worth trusting, so it falls back to the slug.
 type teamtailorProber struct{}
 
+// teamtailorJobPattern is the posting permalink on a Teamtailor listing: /jobs/<numeric id>.
+// It must not match the bare /jobs nav anchor, which every listing carries whether or not it
+// has postings.
+var teamtailorJobPattern = regexp.MustCompile(`/jobs/\d+`)
+
 func (teamtailorProber) probe(ctx context.Context, c httpClient, host string) (string, int, error) {
-	var feed struct {
-		Title string `json:"title"`
-		Items []struct {
-			ID string `json:"id"`
-		} `json:"items"`
-	}
-	if err := c.GetJSON(ctx, fmt.Sprintf("https://%s/jobs?page=1", host), &feed); err != nil {
+	root, err := c.GetHTML(ctx, fmt.Sprintf("https://%s/jobs?page=1", host))
+	if err != nil {
 		return "", 0, nil
 	}
-	if len(feed.Items) == 0 {
+	n := countMatchingLinks(root, teamtailorJobPattern)
+	if n == 0 {
 		return "", 0, nil
 	}
-	return feed.Title, len(feed.Items), nil
+	return "", n, nil
 }
 
 // trakstarProber probes the Trakstar Hire per-subdomain RSS feed. A non-empty channel of

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/strelov1/freehire/internal/sources"
@@ -37,10 +38,49 @@ type prober interface {
 	probe(ctx context.Context, c httpClient, slug string) (company string, openJobs int, err error)
 }
 
+// idProber is the optional half of the prober contract: it reports the ids of a board's live
+// postings, in the platform's own id space, so a seed that knows one posting's id can identify
+// the board by evidence instead of by a name resemblance.
+//
+// It is optional because the check reads a missing id as "wrong board", which is only sound
+// where one request yields the COMPLETE live list. A prober that pages, or that asks for a
+// single posting to settle liveness, must not implement it — its silence leaves the expected
+// id inert, which is the safe reading of partial evidence.
+//
+// This re-requests the listing probe already fetched, rather than widening prober's return to
+// carry ids through the ~35 implementations that have no use for them. The extra request is
+// only spent on the seeds that name a posting — the offline-derived candidates, which are a
+// minority and which produce no board at all without it.
+type idProber interface {
+	postingIDs(ctx context.Context, c httpClient, slug string) ([]string, error)
+}
+
 // greenhouseProber probes the Greenhouse public boards API. The jobs endpoint lists only
 // live postings, so a non-empty list means a live board. The company name comes from the
 // board-metadata endpoint, fetched only once a board is known to have jobs.
 type greenhouseProber struct{}
+
+func greenhouseJobsURL(slug string) string {
+	return fmt.Sprintf("%s/%s/jobs", greenhouseBoardsAPI, slug)
+}
+
+// postingIDs lists the board's live posting ids. The jobs endpoint returns every live posting
+// in one response, so an id it does not carry is genuinely not on the board.
+func (greenhouseProber) postingIDs(ctx context.Context, c httpClient, slug string) ([]string, error) {
+	var jr struct {
+		Jobs []struct {
+			ID int64 `json:"id"`
+		} `json:"jobs"`
+	}
+	if err := c.GetJSON(ctx, greenhouseJobsURL(slug), &jr); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(jr.Jobs))
+	for _, j := range jr.Jobs {
+		ids = append(ids, strconv.FormatInt(j.ID, 10))
+	}
+	return ids, nil
+}
 
 func (greenhouseProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
 	var jr struct {
@@ -50,7 +90,7 @@ func (greenhouseProber) probe(ctx context.Context, c httpClient, slug string) (s
 	}
 	// A missing/moved board returns 4xx and the client surfaces it as an error. For harvest
 	// that simply means "not a live greenhouse board" — skip silently, do not propagate.
-	if err := c.GetJSON(ctx, fmt.Sprintf("%s/%s/jobs", greenhouseBoardsAPI, slug), &jr); err != nil {
+	if err := c.GetJSON(ctx, greenhouseJobsURL(slug), &jr); err != nil {
 		return "", 0, nil
 	}
 	if len(jr.Jobs) == 0 {
@@ -72,11 +112,31 @@ func (greenhouseProber) probe(ctx context.Context, c httpClient, slug string) (s
 // the name falls back to the slug.
 type leverProber struct{}
 
+func leverPostingsURL(slug string) string {
+	return fmt.Sprintf("https://api.lever.co/v0/postings/%s?mode=json", slug)
+}
+
+// postingIDs lists the board's live posting ids. The JSON-mode endpoint returns every live
+// posting in one array, so an id it does not carry is genuinely not on the board.
+func (leverProber) postingIDs(ctx context.Context, c httpClient, slug string) ([]string, error) {
+	var postings []struct {
+		ID string `json:"id"`
+	}
+	if err := c.GetJSON(ctx, leverPostingsURL(slug), &postings); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(postings))
+	for _, p := range postings {
+		ids = append(ids, p.ID)
+	}
+	return ids, nil
+}
+
 func (leverProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
 	var postings []struct {
 		ID string `json:"id"`
 	}
-	if err := c.GetJSON(ctx, fmt.Sprintf("https://api.lever.co/v0/postings/%s?mode=json", slug), &postings); err != nil {
+	if err := c.GetJSON(ctx, leverPostingsURL(slug), &postings); err != nil {
 		return "", 0, nil
 	}
 	if len(postings) == 0 {
@@ -90,13 +150,35 @@ func (leverProber) probe(ctx context.Context, c httpClient, slug string) (string
 // slug, which Ashby itself uses as the board identity.
 type ashbyProber struct{}
 
+func ashbyBoardURL(slug string) string {
+	return fmt.Sprintf("https://api.ashbyhq.com/posting-api/job-board/%s", slug)
+}
+
+// postingIDs lists the board's live posting ids. The list endpoint returns every live posting
+// in one response, so an id it does not carry is genuinely not on the board.
+func (ashbyProber) postingIDs(ctx context.Context, c httpClient, slug string) ([]string, error) {
+	var resp struct {
+		Jobs []struct {
+			ID string `json:"id"`
+		} `json:"jobs"`
+	}
+	if err := c.GetJSON(ctx, ashbyBoardURL(slug), &resp); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(resp.Jobs))
+	for _, j := range resp.Jobs {
+		ids = append(ids, j.ID)
+	}
+	return ids, nil
+}
+
 func (ashbyProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
 	var resp struct {
 		Jobs []struct {
 			ID string `json:"id"`
 		} `json:"jobs"`
 	}
-	if err := c.GetJSON(ctx, fmt.Sprintf("https://api.ashbyhq.com/posting-api/job-board/%s", slug), &resp); err != nil {
+	if err := c.GetJSON(ctx, ashbyBoardURL(slug), &resp); err != nil {
 		return "", 0, nil
 	}
 	if len(resp.Jobs) == 0 {
@@ -286,6 +368,28 @@ func (smartRecruitersProber) probe(ctx context.Context, c httpClient, slug strin
 // against the name the seed expected rather than accepted on liveness alone.
 type recruiteeProber struct{}
 
+func recruiteeOffersURL(slug string) string {
+	return fmt.Sprintf("https://%s.recruitee.com/api/offers/", slug)
+}
+
+// postingIDs lists the board's live posting ids. The offers endpoint returns every live offer
+// in one response, so an id it does not carry is genuinely not on the board.
+func (recruiteeProber) postingIDs(ctx context.Context, c httpClient, slug string) ([]string, error) {
+	var resp struct {
+		Offers []struct {
+			ID int64 `json:"id"`
+		} `json:"offers"`
+	}
+	if err := c.GetJSON(ctx, recruiteeOffersURL(slug), &resp); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(resp.Offers))
+	for _, o := range resp.Offers {
+		ids = append(ids, strconv.FormatInt(o.ID, 10))
+	}
+	return ids, nil
+}
+
 func (recruiteeProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
 	var resp struct {
 		Offers []struct {
@@ -293,7 +397,7 @@ func (recruiteeProber) probe(ctx context.Context, c httpClient, slug string) (st
 			CompanyName string `json:"company_name"`
 		} `json:"offers"`
 	}
-	if err := c.GetJSON(ctx, fmt.Sprintf("https://%s.recruitee.com/api/offers/", slug), &resp); err != nil {
+	if err := c.GetJSON(ctx, recruiteeOffersURL(slug), &resp); err != nil {
 		return "", 0, nil
 	}
 	if len(resp.Offers) == 0 {

--- a/cmd/harvest-boards/prober_test.go
+++ b/cmd/harvest-boards/prober_test.go
@@ -261,6 +261,19 @@ func TestNamelessProbers(t *testing.T) {
 			live: "acme", empty: "empty",
 		},
 		{
+			name: "teamtailor",
+			p:    teamtailorProber{},
+			getter: fakeGetter{
+				// Teamtailor serves its listing as HTML on every board, vendor sub-domain and
+				// employer domain alike — there is no JSON feed to ask. Live: a /jobs/<id>
+				// permalink. Empty: only the nav anchors, which must not be counted.
+				"https://careers.acme.com/jobs?page=1": `<html><body><a href="/jobs/1234-senior-go">Senior Go</a></body></html>`,
+				"https://careers.empty.com/jobs?page=1": `<html><body><a href="/jobs">All jobs</a>` +
+					`<a href="/departments">Departments</a></body></html>`,
+			},
+			live: "careers.acme.com", empty: "careers.empty.com",
+		},
+		{
 			name: "jobvite",
 			p:    jobviteProber{},
 			getter: fakeGetter{
@@ -342,15 +355,10 @@ func TestNamedProbers(t *testing.T) {
 			live: "acme", wantName: "Acme Inc", empty: "empty",
 		},
 		{
-			name: "teamtailor",
-			p:    teamtailorProber{},
-			getter: fakeGetter{
-				"https://jobs.acme.com/jobs?page=1":  `{"title":"Acme","items":[{"id":"1"},{"id":"2"}]}`,
-				"https://jobs.empty.com/jobs?page=1": `{"title":"Empty","items":[]}`,
-			},
-			live: "jobs.acme.com", wantName: "Acme", empty: "jobs.empty.com",
-		},
-		{
+			// Teamtailor used to be listed here, on the strength of a JSON feed that returned a
+			// company name. The platform serves HTML on every board and no such feed exists, so
+			// this case asserted a shape only the fake ever produced. It now lives with the
+			// nameless probers, where it belongs.
 			name: "join",
 			p:    joinProber{},
 			getter: fakeGetter{

--- a/cmd/harvest-boards/seed.go
+++ b/cmd/harvest-boards/seed.go
@@ -10,9 +10,15 @@ import (
 // board tokens (Company empty) or an array of {board, company} objects — the latter lets a
 // discovery source that already knows the employer (e.g. harvest-role, which reads it from
 // role.com's JSON-LD) supply a name for providers whose own API exposes none (Oracle).
+//
+// ExpectID names a posting the board is expected to contain, in the platform's own id space.
+// A discovery source that read the id off a posting elsewhere (harvest-linkedin, harvest-role)
+// can supply it, and the probe then identifies the board by that evidence instead of by a
+// name resemblance — which is what makes a slug guessed offline safe to propose.
 type seedItem struct {
-	Board   string `json:"board"`
-	Company string `json:"company"`
+	Board    string `json:"board"`
+	Company  string `json:"company"`
+	ExpectID string `json:"expect_id"`
 }
 
 // loadSeedItems reads a seed file in either supported shape: a JSON array of strings or a

--- a/cmd/harvest-boards/seed_test.go
+++ b/cmd/harvest-boards/seed_test.go
@@ -46,6 +46,18 @@ func TestLoadSeedItemsObjectArray(t *testing.T) {
 	}
 }
 
+func TestLoadSeedItemsExpectedPostingID(t *testing.T) {
+	path := writeTemp(t, `[{"board":"x","expect_id":"4698693006"},{"board":"y","company":"Y Co"}]`)
+	got, err := loadSeedItems(path)
+	if err != nil {
+		t.Fatalf("loadSeedItems: %v", err)
+	}
+	want := []seedItem{{Board: "x", ExpectID: "4698693006"}, {Board: "y", Company: "Y Co"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
 func writeTemp(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "seed.json")

--- a/cmd/harvest-linkedin/discover.go
+++ b/cmd/harvest-linkedin/discover.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/strelov1/freehire/internal/normalize"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// defaultJobAge bounds a query to recently-posted jobs. The point of searching at all is to
+	// find employers hiring NOW, and a wider window mostly re-surfaces companies an earlier run
+	// already proposed.
+	defaultJobAge = 7
+	// defaultPages is deliberately one. Pages are the multiplier on a run's request count, so
+	// widening coverage is an explicit per-query decision rather than a default.
+	defaultPages = 1
+	// pageSize is the listing's fixed page size, which drives the `start` offset.
+	pageSize = 10
+)
+
+// searchBase is the public, unauthenticated job-search listing. It needs no credentials and
+// serves this project's own User-Agent.
+const searchBase = "https://www.linkedin.com/jobs-guest/jobs/api/seeMoreJobPostings/search"
+
+// query is one entry of the worklist: what to search for, and where.
+type query struct {
+	Keywords string `yaml:"keywords"`
+	Location string `yaml:"location"`
+	JobAge   int    `yaml:"jobage"`
+	Pages    int    `yaml:"pages"`
+}
+
+// loadQueries reads the worklist, applying the bounded defaults. A query naming no market is a
+// usage error: an unbounded market is what turns a bounded harvest into an unbounded crawl.
+func loadQueries(path string) ([]query, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read worklist %s: %w", path, err)
+	}
+	var doc struct {
+		Queries []query `yaml:"queries"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse worklist %s: %w", path, err)
+	}
+	if len(doc.Queries) == 0 {
+		return nil, fmt.Errorf("worklist %s names no queries", path)
+	}
+	for i := range doc.Queries {
+		q := &doc.Queries[i]
+		if q.Location == "" {
+			return nil, fmt.Errorf("worklist %s: query %q names no location", path, q.Keywords)
+		}
+		if q.JobAge <= 0 {
+			q.JobAge = defaultJobAge
+		}
+		if q.Pages <= 0 {
+			q.Pages = defaultPages
+		}
+	}
+	return doc.Queries, nil
+}
+
+// searchURL builds the listing URL for one page (1-indexed) of a query.
+func searchURL(q query, page int) string {
+	params := url.Values{}
+	params.Set("keywords", q.Keywords)
+	params.Set("location", q.Location)
+	if q.JobAge > 0 {
+		params.Set("f_TPR", "r"+strconv.Itoa(q.JobAge*86400))
+	}
+	params.Set("start", strconv.Itoa((page-1)*pageSize))
+	return searchBase + "?" + params.Encode()
+}
+
+// candidate is one hiring company, in the shape `harvest-ats resolve` consumes. The json tags
+// match its companySite, so the output of this command is that command's input verbatim.
+type candidate struct {
+	Name       string `json:"name"`
+	Website    string `json:"website"`
+	LinkedIn   string `json:"linkedin,omitempty"`
+	ExternalID string `json:"external_id,omitempty"`
+}
+
+// stats is what a run needs to judge itself: how many queries ran and how many came back with
+// nothing. A query that succeeds but yields no postings is indistinguishable from a blocked or
+// re-templated one, so the counts — not the candidate list — decide whether the run failed.
+type stats struct {
+	totalQueries int
+	emptyQueries int
+}
+
+// everyQueryEmpty reports the shape that must never be read as success: every query answered,
+// none of them with a posting.
+func (s stats) everyQueryEmpty() bool { return s.totalQueries > 0 && s.emptyQueries == s.totalQueries }
+
+// fetcher retrieves a URL's body. Injected so a run can be exercised without network.
+type fetcher func(ctx context.Context, url string) (string, error)
+
+// discover turns the query worklist into the candidate companies behind its postings.
+//
+// The listing already names the employer and links its profile, so both the collapse of many
+// postings to one employer and the catalogue filter happen on the listing alone — a company we
+// already have, or have already seen this run, costs no further request. Each surviving
+// employer then costs two: its posting (for the ATS-native id) and its profile (for the
+// website). A candidate with no website is dropped, since the resolve step has nothing to
+// follow; a candidate whose posting fetch fails keeps its place without an id.
+func discover(ctx context.Context, fetch fetcher, queries []query, existing map[string]bool) ([]candidate, stats, error) {
+	var (
+		out  []candidate
+		st   stats
+		seen = map[string]bool{}
+	)
+	for _, q := range queries {
+		st.totalQueries++
+		cards := searchCards(ctx, fetch, q)
+		if len(cards) == 0 {
+			log.Printf("harvest-linkedin: %q in %q returned no postings — markup change or block, not an empty market",
+				q.Keywords, q.Location)
+			st.emptyQueries++
+			continue
+		}
+		for _, c := range cards {
+			if c.profileURL == "" || seen[c.profileURL] {
+				continue
+			}
+			seen[c.profileURL] = true
+			if existing[normalize.Slug(c.company)] {
+				continue
+			}
+			if cand, ok := hydrate(ctx, fetch, c); ok {
+				out = append(out, cand)
+			}
+		}
+	}
+	return out, st, nil
+}
+
+// searchCards pages one query, stopping early at the first page that yields nothing (the
+// listing has run out). A page that fails to fetch is logged and skipped.
+func searchCards(ctx context.Context, fetch fetcher, q query) []card {
+	var all []card
+	for page := 1; page <= q.Pages; page++ {
+		body, err := fetch(ctx, searchURL(q, page))
+		if err != nil {
+			log.Printf("harvest-linkedin: search %q/%q page %d: %v", q.Keywords, q.Location, page, err)
+			continue
+		}
+		cards := parseCards(body)
+		if len(cards) == 0 {
+			break
+		}
+		all = append(all, cards...)
+	}
+	return all
+}
+
+// hydrate fetches what the listing does not carry: the posting's ATS-native id and the
+// employer's website. ok is false when the website cannot be determined.
+func hydrate(ctx context.Context, fetch fetcher, c card) (candidate, bool) {
+	externalID := ""
+	if c.postingURL != "" {
+		if body, err := fetch(ctx, c.postingURL); err == nil {
+			externalID = postingExternalID(body)
+		} else {
+			log.Printf("harvest-linkedin: posting %s: %v", c.postingURL, err)
+		}
+	}
+	body, err := fetch(ctx, c.profileURL)
+	if err != nil {
+		log.Printf("harvest-linkedin: profile %s: %v", c.profileURL, err)
+		return candidate{}, false
+	}
+	website := profileWebsite(body)
+	if website == "" {
+		return candidate{}, false
+	}
+	return candidate{Name: c.company, Website: website, LinkedIn: c.profileURL, ExternalID: externalID}, true
+}

--- a/cmd/harvest-linkedin/discover_test.go
+++ b/cmd/harvest-linkedin/discover_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "queries.yml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadQueries(t *testing.T) {
+	path := writeTemp(t, `
+queries:
+  - keywords: golang
+    location: Germany
+    jobage: 30
+    pages: 3
+  - keywords: data engineer
+    location: Poland
+`)
+	got, err := loadQueries(path)
+	if err != nil {
+		t.Fatalf("loadQueries: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d queries, want 2", len(got))
+	}
+	if got[0].Pages != 3 || got[0].JobAge != 30 {
+		t.Errorf("explicit values lost: %+v", got[0])
+	}
+	if got[1].Pages != defaultPages || got[1].JobAge != defaultJobAge {
+		t.Errorf("defaults not applied: %+v, want pages=%d jobage=%d", got[1], defaultPages, defaultJobAge)
+	}
+}
+
+func TestLoadQueriesRefusesAQueryWithoutAMarket(t *testing.T) {
+	// An unbounded market is what turns a bounded harvest into an unbounded crawl.
+	path := writeTemp(t, "queries:\n  - keywords: golang\n")
+	if _, err := loadQueries(path); err == nil {
+		t.Fatal("loadQueries returned no error for a query without a location")
+	}
+}
+
+// stubFetcher answers each URL from a canned map; an unmapped URL is an error.
+type stubFetcher struct {
+	pages map[string]string
+	calls []string
+}
+
+func (s *stubFetcher) fetch(_ context.Context, url string) (string, error) {
+	s.calls = append(s.calls, url)
+	body, ok := s.pages[url]
+	if !ok {
+		return "", errors.New("not found: " + url)
+	}
+	return body, nil
+}
+
+func listing(entries ...string) string { return strings.Join(entries, "\n") }
+
+func cardMarkup(id, company, profile, posting string) string {
+	return `<div data-entity-urn="urn:li:jobPosting:` + id + `">` +
+		`<a class="base-card__full-link" href="` + posting + `"></a>` +
+		`<h3 class="base-search-card__title">Engineer</h3>` +
+		`<h4 class="base-search-card__subtitle"><a href="` + profile + `">` + company + `</a></h4></div>`
+}
+
+func ldPosting(id string) string {
+	return `<script type="application/ld+json">{"@type":"JobPosting","identifier":{"value":"` + id + `"}}</script>`
+}
+
+func ldProfile(site string) string {
+	return `<script type="application/ld+json">{"@type":"Organization","sameAs":"` + site + `"}</script>`
+}
+
+func TestDiscoverCollapsesEmployersAndSkipsKnownOnes(t *testing.T) {
+	queries := []query{{Keywords: "golang", Location: "Germany", Pages: 1, JobAge: 7}}
+	searchURL := searchURL(queries[0], 1)
+	f := &stubFetcher{pages: map[string]string{
+		searchURL: listing(
+			// Two postings by the same employer: the second must cost no request.
+			cardMarkup("1", "Doodle", "https://ch.linkedin.com/company/doodle-ag", "https://x/jobs/view/a-1"),
+			cardMarkup("2", "Doodle", "https://ch.linkedin.com/company/doodle-ag", "https://x/jobs/view/b-2"),
+			// An employer the catalogue already has: dropped before any fetch.
+			cardMarkup("3", "Capgemini", "https://linkedin.com/company/capgemini", "https://x/jobs/view/c-3"),
+		),
+		"https://x/jobs/view/a-1":                   ldPosting("teamtailor-8094978"),
+		"https://ch.linkedin.com/company/doodle-ag": ldProfile("https://doodle.com"),
+		"https://linkedin.com/company/capgemini":    ldProfile("https://capgemini.com"),
+		"https://x/jobs/view/c-3":                   ldPosting("999"),
+	}}
+
+	got, stats, err := discover(context.Background(), f.fetch, queries, map[string]bool{"capgemini": true})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d candidates (%+v), want 1", len(got), got)
+	}
+	c := got[0]
+	if c.Name != "Doodle" || c.Website != "https://doodle.com" || c.ExternalID != "teamtailor-8094978" {
+		t.Errorf("candidate = %+v, want Doodle / doodle.com / teamtailor-8094978", c)
+	}
+	if c.LinkedIn != "https://ch.linkedin.com/company/doodle-ag" {
+		t.Errorf("candidate profile = %q", c.LinkedIn)
+	}
+	for _, u := range f.calls {
+		if strings.Contains(u, "capgemini") {
+			t.Errorf("spent a request on an already-known company: %s", u)
+		}
+	}
+	if stats.emptyQueries != 0 || stats.totalQueries != 1 {
+		t.Errorf("stats = %+v, want 0 empty of 1", stats)
+	}
+}
+
+func TestDiscoverOmitsACandidateWithNoWebsite(t *testing.T) {
+	queries := []query{{Keywords: "golang", Location: "Germany", Pages: 1, JobAge: 7}}
+	f := &stubFetcher{pages: map[string]string{
+		searchURL(queries[0], 1):            cardMarkup("1", "Acme", "https://linkedin.com/company/acme", "https://x/jobs/view/a-1"),
+		"https://x/jobs/view/a-1":           ldPosting("4698693006"),
+		"https://linkedin.com/company/acme": `<html>no structured data</html>`,
+	}}
+	got, _, err := discover(context.Background(), f.fetch, queries, nil)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %+v, want none (nothing for resolve to follow)", got)
+	}
+}
+
+func TestDiscoverKeepsACandidateWhosePostingFetchFails(t *testing.T) {
+	// A failed posting fetch costs the id, not the candidate: the careers-page path still works.
+	queries := []query{{Keywords: "golang", Location: "Germany", Pages: 1, JobAge: 7}}
+	f := &stubFetcher{pages: map[string]string{
+		searchURL(queries[0], 1):            cardMarkup("1", "Acme", "https://linkedin.com/company/acme", "https://x/jobs/view/a-1"),
+		"https://linkedin.com/company/acme": ldProfile("https://acme.com"),
+	}}
+	got, _, err := discover(context.Background(), f.fetch, queries, nil)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(got) != 1 || got[0].ExternalID != "" {
+		t.Errorf("got %+v, want one candidate without an id", got)
+	}
+}
+
+func TestDiscoverCountsEmptyQueries(t *testing.T) {
+	// A 200 with no postings is a markup change or a block, not an empty market.
+	queries := []query{
+		{Keywords: "golang", Location: "Germany", Pages: 1, JobAge: 7},
+		{Keywords: "rust", Location: "Poland", Pages: 1, JobAge: 7},
+	}
+	f := &stubFetcher{pages: map[string]string{
+		searchURL(queries[0], 1): `<html>no cards</html>`,
+		searchURL(queries[1], 1): `<html>no cards either</html>`,
+	}}
+	_, stats, err := discover(context.Background(), f.fetch, queries, nil)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if stats.emptyQueries != 2 || stats.totalQueries != 2 {
+		t.Errorf("stats = %+v, want every query counted empty", stats)
+	}
+	if !stats.everyQueryEmpty() {
+		t.Error("everyQueryEmpty = false, want true (the run must fail)")
+	}
+}
+
+func TestSearchURLCarriesTheQuery(t *testing.T) {
+	u := searchURL(query{Keywords: "data engineer", Location: "Poland", JobAge: 7, Pages: 2}, 2)
+	for _, want := range []string{"keywords=data+engineer", "location=Poland", "f_TPR=r604800", "start=10"} {
+		if !strings.Contains(u, want) {
+			t.Errorf("searchURL = %q, want it to contain %q", u, want)
+		}
+	}
+}

--- a/cmd/harvest-linkedin/main.go
+++ b/cmd/harvest-linkedin/main.go
@@ -1,0 +1,127 @@
+// Command harvest-linkedin supplies the board harvest with a worklist of companies that are
+// demonstrably hiring right now. It pages LinkedIn's public, unauthenticated job-search
+// listing for each query in a worklist file, collapses the postings to one candidate per
+// employer, drops the employers the catalogue already covers, and reads two facts off each
+// survivor: the employer's own website, and — where the posting publishes one — the id that
+// posting carries in the employer's OWN applicant tracking system.
+//
+// The output is exactly the input `harvest-ats resolve` consumes, so the three tools chain:
+//
+//	go run ./cmd/harvest-linkedin harvest/linkedin-queries.yml company-slugs.txt > candidates.json
+//	go run ./cmd/harvest-ats resolve candidates.json          # -> <provider>.seed.json
+//	go run ./cmd/harvest-boards <provider> <provider>.seed.json
+//
+// LinkedIn data never reaches the repository: it is a transient worklist. What gets committed
+// to sources/*.yml is boards harvest-boards validated against each platform's own public API.
+// Requests go out under this project's own User-Agent (LinkedIn serves these endpoints to it)
+// and are rate-limited; run-once host tool, not a cron job.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/strelov1/freehire/internal/sources"
+	"golang.org/x/time/rate"
+)
+
+// defaultPace is the aggregate request rate. It is deliberately gentle: the run is a discovery
+// pass measured in hundreds of requests, and nothing about it is urgent.
+const defaultPace = 1.0
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	pace := flag.Float64("pace", defaultPace, "cap the request rate at this many requests per second")
+	flag.Parse()
+	args := flag.Args()
+	if len(args) != 1 && len(args) != 2 {
+		log.Printf("usage: harvest-linkedin [-pace N] <queries.yml> [company-slugs.txt]")
+		return 2
+	}
+	if *pace <= 0 {
+		log.Printf("harvest-linkedin: -pace must be greater than zero")
+		return 2
+	}
+
+	queries, err := loadQueries(args[0])
+	if err != nil {
+		log.Printf("harvest-linkedin: %v", err)
+		return 1
+	}
+	existing := map[string]bool{}
+	if len(args) == 2 {
+		if existing, err = readSlugSet(args[1]); err != nil {
+			log.Printf("harvest-linkedin: %v", err)
+			return 1
+		}
+	}
+	log.Printf("harvest-linkedin: %d queries, %d existing company slugs, pacing at %.2f req/s",
+		len(queries), len(existing), *pace)
+
+	candidates, st, err := discover(context.Background(), pacedFetch(*pace), queries, existing)
+	if err != nil {
+		log.Printf("harvest-linkedin: %v", err)
+		return 1
+	}
+	log.Printf("harvest-linkedin: %d candidate companies from %d queries (%d returned nothing)",
+		len(candidates), st.totalQueries, st.emptyQueries)
+
+	// A search that answers with no postings looks exactly like an empty market. A run where
+	// EVERY query did that is not a market with no jobs in it — it is a markup change or a
+	// block, and reporting success would leave an empty harvest indistinguishable from a
+	// complete one.
+	if st.everyQueryEmpty() {
+		log.Printf("harvest-linkedin: every query returned no postings — the listing markup changed, " +
+			"or this run is being refused; nothing written")
+		return 1
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(candidates); err != nil {
+		log.Printf("harvest-linkedin: encode: %v", err)
+		return 1
+	}
+	log.Printf("harvest-linkedin done: feed the output to `harvest-ats resolve`")
+	return 0
+}
+
+// pacedFetch returns a fetcher over the shared SSRF-guarded client — which already carries this
+// project's User-Agent, a bounded retry, and Retry-After handling on 429 — gated by a limiter
+// so the run's AGGREGATE rate stays put regardless of how the work is sequenced.
+func pacedFetch(pace float64) fetcher {
+	client := sources.NewClient()
+	limiter := rate.NewLimiter(rate.Limit(pace), 1)
+	return func(ctx context.Context, url string) (string, error) {
+		if err := limiter.Wait(ctx); err != nil {
+			return "", err
+		}
+		ctx, cancel := context.WithTimeout(ctx, perRequestTimeout)
+		defer cancel()
+		return client.GetText(ctx, url)
+	}
+}
+
+// perRequestTimeout is an outer cap on a single fetch so one wedged request cannot stall a run;
+// the client's own transport timeout is the tighter, usual bound.
+const perRequestTimeout = 30 * time.Second
+
+// readSlugSet reads the catalogue's company slugs, one per line, so a company already covered
+// costs no request. A missing file is an error rather than an empty set: silently harvesting
+// against no catalogue would re-propose everything we already have.
+func readSlugSet(path string) (map[string]bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	set := map[string]bool{}
+	for _, line := range strings.Split(string(data), "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			set[s] = true
+		}
+	}
+	return set, nil
+}

--- a/cmd/harvest-linkedin/parse.go
+++ b/cmd/harvest-linkedin/parse.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// card is one posting as the public search listing presents it. The listing already names the
+// employer and links its profile, which is what lets the run drop a company the catalogue
+// already covers before spending a single further request on it.
+type card struct {
+	company    string
+	profileURL string
+	postingURL string
+}
+
+var (
+	// cardSplitRe is the per-posting anchor the listing repeats. Splitting on it and parsing
+	// each fragment on its own means a markup change to one card costs that posting, not the
+	// page — the failure mode a single whole-page regex has.
+	cardSplitRe = regexp.MustCompile(`data-entity-urn="urn:li:jobPosting:`)
+	fullLinkRe  = regexp.MustCompile(`class="base-card__full-link[^"]*"[^>]*href="([^"]+)"`)
+	titleRe     = regexp.MustCompile(`class="base-search-card__title"[^>]*>([\s\S]*?)</h3>`)
+	subtitleRe  = regexp.MustCompile(`class="base-search-card__subtitle"[^>]*>([\s\S]*?)</h4>`)
+	hrefRe      = regexp.MustCompile(`href="([^"]+)"`)
+	tagRe       = regexp.MustCompile(`<[^>]+>`)
+)
+
+// parseCards extracts the postings from a search listing. A fragment without a title or
+// without an employer profile is dropped rather than guessed at: both are needed downstream,
+// and a card missing them is a card whose markup we no longer understand.
+func parseCards(html string) []card {
+	fragments := cardSplitRe.Split(html, -1)
+	if len(fragments) < 2 {
+		return nil
+	}
+	var out []card
+	for _, fragment := range fragments[1:] {
+		title := textOf(titleRe, fragment)
+		subtitle := matchOf(subtitleRe, fragment)
+		if title == "" || subtitle == "" {
+			continue
+		}
+		profile := stripQuery(decodeEntities(matchOf(hrefRe, subtitle)))
+		if profile == "" {
+			continue
+		}
+		out = append(out, card{
+			company:    clean(subtitle),
+			profileURL: profile,
+			postingURL: stripQuery(decodeEntities(matchOf(fullLinkRe, fragment))),
+		})
+	}
+	return out
+}
+
+// ldJSONRe captures each JSON-LD block on a page. A posting publishes one; a company profile
+// publishes one holding an Organization node, sometimes wrapped in an @graph array.
+var ldJSONRe = regexp.MustCompile(`(?s)<script type="application/ld\+json">(.*?)</script>`)
+
+// postingExternalID returns the id the posting carries in the employer's OWN applicant tracking
+// system, published in the posting's structured metadata. It is "" when the posting publishes
+// none, which is common and not an error — roughly half of sampled postings carry no id.
+//
+// This id is what lets a board slug be guessed and then proven: harvest-boards keeps a guessed
+// board only when the platform reports a live posting carrying exactly this id.
+func postingExternalID(html string) string {
+	for _, block := range ldJSONRe.FindAllStringSubmatch(html, -1) {
+		var posting struct {
+			Identifier struct {
+				Value json.RawMessage `json:"value"`
+			} `json:"identifier"`
+		}
+		if err := json.Unmarshal([]byte(block[1]), &posting); err != nil {
+			continue
+		}
+		if v := scalarString(posting.Identifier.Value); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// profileWebsite returns the employer's own website, published as the Organization node's
+// sameAs in the profile's structured metadata. It is "" when the profile publishes none, in
+// which case there is nothing for the resolve step to follow.
+func profileWebsite(html string) string {
+	for _, block := range ldJSONRe.FindAllStringSubmatch(html, -1) {
+		var doc struct {
+			Type   string          `json:"@type"`
+			SameAs json.RawMessage `json:"sameAs"`
+			Graph  []struct {
+				Type   string          `json:"@type"`
+				SameAs json.RawMessage `json:"sameAs"`
+			} `json:"@graph"`
+		}
+		if err := json.Unmarshal([]byte(block[1]), &doc); err != nil {
+			continue
+		}
+		if doc.Type == "Organization" {
+			if s := scalarString(doc.SameAs); s != "" {
+				return s
+			}
+		}
+		for _, node := range doc.Graph {
+			if node.Type != "Organization" {
+				continue
+			}
+			if s := scalarString(node.SameAs); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// scalarString reads a JSON value that is a string, tolerating the array form the same field
+// sometimes takes (sameAs may be one URL or several) by taking the first entry. A number or an
+// object yields "" — those are shapes we do not understand and must not guess at.
+func scalarString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return strings.TrimSpace(s)
+	}
+	var many []string
+	if json.Unmarshal(raw, &many) == nil && len(many) > 0 {
+		return strings.TrimSpace(many[0])
+	}
+	return ""
+}
+
+func matchOf(re *regexp.Regexp, s string) string {
+	if m := re.FindStringSubmatch(s); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+func textOf(re *regexp.Regexp, s string) string { return clean(matchOf(re, s)) }
+
+func clean(html string) string {
+	return decodeEntities(strings.Join(strings.Fields(tagRe.ReplaceAllString(html, " ")), " "))
+}
+
+var entities = strings.NewReplacer(
+	"&amp;", "&", "&lt;", "<", "&gt;", ">", "&quot;", `"`, "&#39;", "'", "&apos;", "'", "&nbsp;", " ",
+)
+
+func decodeEntities(s string) string { return entities.Replace(s) }
+
+// stripQuery drops a URL's tracking query and fragment, leaving the identity-bearing path.
+func stripQuery(rawURL string) string {
+	if i := strings.IndexAny(rawURL, "?#"); i >= 0 {
+		return rawURL[:i]
+	}
+	return rawURL
+}

--- a/cmd/harvest-linkedin/parse_test.go
+++ b/cmd/harvest-linkedin/parse_test.go
@@ -1,0 +1,103 @@
+package main
+
+import "testing"
+
+func TestParseCards(t *testing.T) {
+	// Two cards, the second one malformed (no title). Cards are parsed independently so a
+	// markup change on one costs one posting rather than the whole page.
+	html := `
+<li>
+  <div class="base-card" data-entity-urn="urn:li:jobPosting:4442681548">
+    <a class="base-card__full-link" href="https://de.linkedin.com/jobs/view/backend-go-at-doodle-4442681548?trk=x"></a>
+    <h3 class="base-search-card__title">Software Engineer, Backend (Go)</h3>
+    <h4 class="base-search-card__subtitle"><a href="https://ch.linkedin.com/company/doodle-ag?trk=y">Doodle</a></h4>
+  </div>
+</li>
+<li>
+  <div class="base-card" data-entity-urn="urn:li:jobPosting:999">
+    <h4 class="base-search-card__subtitle"><a href="https://linkedin.com/company/nameless">Nameless</a></h4>
+  </div>
+</li>
+<li>
+  <div class="base-card" data-entity-urn="urn:li:jobPosting:4430237612">
+    <a class="base-card__full-link" href="https://nl.linkedin.com/jobs/view/pm-at-picnic-4430237612"></a>
+    <h3 class="base-search-card__title">Product Manager</h3>
+    <h4 class="base-search-card__subtitle"><a href="https://nl.linkedin.com/company/picnic-technologies">Picnic Technologies</a></h4>
+  </div>
+</li>`
+
+	got := parseCards(html)
+	if len(got) != 2 {
+		t.Fatalf("parsed %d cards (%v), want 2 (the titleless one is dropped)", len(got), got)
+	}
+	first := got[0]
+	if first.company != "Doodle" {
+		t.Errorf("company = %q, want Doodle", first.company)
+	}
+	if first.profileURL != "https://ch.linkedin.com/company/doodle-ag" {
+		t.Errorf("profileURL = %q, want the profile without its tracking query", first.profileURL)
+	}
+	if first.postingURL != "https://de.linkedin.com/jobs/view/backend-go-at-doodle-4442681548" {
+		t.Errorf("postingURL = %q, want the canonical posting URL without its query", first.postingURL)
+	}
+	if got[1].company != "Picnic Technologies" {
+		t.Errorf("second company = %q, want Picnic Technologies", got[1].company)
+	}
+}
+
+func TestParseCardsOnEmptyMarkup(t *testing.T) {
+	if got := parseCards("<html><body>nothing here</body></html>"); len(got) != 0 {
+		t.Errorf("got %v, want no cards", got)
+	}
+}
+
+func TestPostingExternalID(t *testing.T) {
+	// The posting's own structured metadata carries its id in the employer's ATS.
+	html := `<script type="application/ld+json">
+	{"@context":"http://schema.org","@type":"JobPosting",
+	 "identifier":{"@type":"PropertyValue","name":"Doodle","value":"teamtailor-8094978"},
+	 "hiringOrganization":{"@type":"Organization","name":"Doodle"}}
+	</script>`
+	if got := postingExternalID(html); got != "teamtailor-8094978" {
+		t.Errorf("postingExternalID = %q, want teamtailor-8094978", got)
+	}
+}
+
+func TestPostingExternalIDWhenAbsent(t *testing.T) {
+	cases := map[string]string{
+		"no ld+json at all":  `<html><body>sign in to continue</body></html>`,
+		"ld+json without id": `<script type="application/ld+json">{"@type":"JobPosting","title":"x"}</script>`,
+		"unparsable ld+json": `<script type="application/ld+json">{not json</script>`,
+	}
+	for name, html := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := postingExternalID(html); got != "" {
+				t.Errorf("got %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestProfileWebsite(t *testing.T) {
+	html := `<script type="application/ld+json">
+	{"@context":"http://schema.org","@graph":[
+	  {"@type":"Organization","name":"Doodle","sameAs":"https://doodle.com"}]}
+	</script>`
+	if got := profileWebsite(html); got != "https://doodle.com" {
+		t.Errorf("profileWebsite = %q, want https://doodle.com", got)
+	}
+}
+
+func TestProfileWebsiteWithoutGraphWrapper(t *testing.T) {
+	// Some profiles publish the Organization node at the top level rather than inside @graph.
+	html := `<script type="application/ld+json">{"@type":"Organization","sameAs":"https://acme.com"}</script>`
+	if got := profileWebsite(html); got != "https://acme.com" {
+		t.Errorf("profileWebsite = %q, want https://acme.com", got)
+	}
+}
+
+func TestProfileWebsiteWhenAbsent(t *testing.T) {
+	if got := profileWebsite(`<html>no structured data</html>`); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/harvest/linkedin-queries.yml
+++ b/harvest/linkedin-queries.yml
@@ -1,0 +1,33 @@
+# Worklist for cmd/harvest-linkedin: which markets to ask who is hiring right now.
+#
+# Each query pages LinkedIn's public job-search listing and yields the companies behind the
+# postings, which harvest-ats then follows to their ATS board. Keep this list small and
+# deliberate — pages are the multiplier on a run's request count, and the run is a discovery
+# pass, not a crawl.
+#
+#   keywords: what to search for (required)
+#   location: the market, a LinkedIn place string (required — a query without one is refused)
+#   jobage:   only postings from the last N days (optional, default 7)
+#   pages:    result pages to walk, 10 postings each (optional, default 1)
+#
+# This starter set is a first probe, not a considered coverage plan: run it, see how many of
+# the companies it surfaces are genuinely new, and let that decide what to add.
+queries:
+  - keywords: golang
+    location: Germany
+    pages: 3
+  - keywords: backend engineer
+    location: Netherlands
+    pages: 3
+  - keywords: data engineer
+    location: Poland
+    pages: 3
+  - keywords: frontend developer
+    location: Spain
+    pages: 2
+  - keywords: devops
+    location: United Kingdom
+    pages: 2
+  - keywords: product manager
+    location: Remote
+    pages: 2

--- a/openspec/changes/mine-ats-boards-from-linkedin/.openspec.yaml
+++ b/openspec/changes/mine-ats-boards-from-linkedin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/mine-ats-boards-from-linkedin/design.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/design.md
@@ -138,10 +138,32 @@ which run in production or touch the database. The `harvest-ats` detection swap 
 exactly as before. First use is a manual run whose diff to `sources/*.yml` is reviewed like
 any other harvest PR.
 
+## First run
+
+Two queries (golang/Germany, data engineer/Poland), one page each, at 1 req/s:
+
+- **19 candidate companies, 14 of them (74%) carrying an ATS-native posting id** — a better
+  yield than the design sample suggested.
+- `harvest-ats resolve` found a board on the careers pages of 15 of them, across workday,
+  ashby, lever and greenhouse.
+- The one greenhouse board (Nebius) was already in the catalogue — filtered out before probing,
+  as intended.
+- **The offline-derived slugs scored zero.** Twelve candidates were proposed across lever and
+  ashby; every one came back as a dead board, so the expected-id check never even got to run.
+  Delivery Hero's UUID is real, but its board is on neither platform under any of the three
+  spellings tried (verified by hand: 404).
+
+The gate behaved exactly as designed — nothing false was admitted — but the *guessing* half
+has yet to earn its keep. Two readings, and the next run should tell them apart: either the
+slug derivation is too timid (three spellings from name and domain may simply miss how boards
+are actually registered), or a UUID is a weaker signal than assumed and narrows to platforms
+beyond Lever and Ashby. The instrumentation to tell is already there — a wrong slug on a live
+board would have surfaced as an id mismatch rather than as an absent one, and none did.
+
 ## Open Questions
 
-- What share of discovered companies is genuinely new is unknown until the first run; the
-  design sample skewed toward large consultancies we almost certainly already have. The run's
-  own counters answer this, and the query worklist is the dial to adjust.
-- Which markets and keywords to seed the worklist with is deliberately left to the first
-  run's results rather than guessed now.
+- Which markets and keywords to put in the worklist. The starter set is a probe, not a plan;
+  the yield of new-versus-known companies per query should decide what stays.
+- Whether the UUID → {lever, ashby} narrowing is right. The first run gives no evidence either
+  way, since no candidate board existed at all. Worth revisiting against a company whose board
+  we can confirm independently.

--- a/openspec/changes/mine-ats-boards-from-linkedin/design.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/design.md
@@ -79,12 +79,19 @@ them an absent id would mean "not on the page I looked at", and they are left in
 than made to reject boards on partial evidence. Everything else is untouched, and an expected id on a
 provider that cannot check it is inert rather than fatal.
 
-**`harvest-ats` detects through `internal/boardresolve`.** The narrow `atsdetect.Detect`
-recognises three providers; `boardresolve` runs the full `atsboard.Recognize` (~40 ATS) and
-`DetectSelfHosted` for platforms whose tenant host *is* the board. That package exists for
-the paste-a-link contribution flow and is SSRF-guarded, which the harvest wants anyway since
-it follows arbitrary company domains. This is a strict widening of an existing capability,
-useful to the dataset and university worklists too.
+**`harvest-ats` gains self-hosted detection, and nothing else.** The plan had been to detect
+through `internal/boardresolve`, on the belief that `atsdetect.Detect` recognised only three
+providers. Implementation disproved it: `atsdetect.Detect` falls back to scanning every URL
+on the page through `FromURL`, which *itself* calls `atsboard.Recognize` and then adds five
+harvest-only shapes on top. Routing the harvest through `boardresolve` would therefore have
+**narrowed** its coverage by those five, in exchange for one step it genuinely lacked.
+
+So the change is that one step: `atsdetect.DetectSelfHosted`, tried only after the URL scan
+comes up empty. Radancy, Phenom, Jibe and Teamtailor tenants serve from the employer's own
+domain and link to no ATS host, so no URL scan can ever see them; the vendor's bundle in the
+markup is the only tell, and the careers host is the board. Order matters — a careers site
+that merely embeds another ATS must resolve to that board, not to its own host — which is why
+the fallback is last rather than first. `boardresolve` stays untouched.
 
 **Company de-duplication happens before detail fetches.** The search card already names the
 employer and links its profile, so the catalogue filter and the collapse of many postings to

--- a/openspec/changes/mine-ats-boards-from-linkedin/design.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/design.md
@@ -29,8 +29,8 @@ read, and the value of `identifier.value` is that it makes a derived board prova
 
 - Feed the existing harvest a worklist of companies that are demonstrably hiring now, for
   any keyword and market the operator lists.
-- Widen `harvest-ats` detection to the full board recognizer, including platforms that host
-  the careers site themselves.
+- Let `harvest-ats` resolve the platforms that host the careers site themselves, which no URL
+  scan can see.
 - Make a JS-only careers page a solvable case instead of a skipped one, by proposing
   candidate slugs that `harvest-boards` confirms against an exact posting id.
 - Keep every LinkedIn-derived fact transient: only boards this project validated against a
@@ -159,6 +159,23 @@ slug derivation is too timid (three spellings from name and domain may simply mi
 are actually registered), or a UUID is a weaker signal than assumed and narrows to platforms
 beyond Lever and Ashby. The instrumentation to tell is already there — a wrong slug on a live
 board would have surfaced as an id mismatch rather than as an absent one, and none did.
+
+## Second run, and what it found
+
+The full worklist (6 queries) produced **110 companies, 60 of them carrying an ATS-native id**,
+which resolved to **56 boards across 14 providers**. Two boards reached `sources/*.yml`:
+`Freeday` (recruitee) and — after the fix below — five Teamtailor career sites.
+
+The run exposed a pre-existing break the change happens to be the first to hit at scale. The
+Teamtailor prober asked for a JSON feed at `/jobs?page=1`; the platform serves HTML there, on
+vendor sub-domains and employer domains alike, which is exactly how `internal/sources/teamtailor.go`
+already reads it. Every Teamtailor candidate therefore read as a dead board — including
+`careers.arrive.com`, which is *already* in the board file. The prober now counts posting
+permalinks on the listing, as the Freshteam prober does, and the five candidates validate.
+
+Also surfaced, and deliberately left alone: `harvest-ats` can resolve boards for providers
+`harvest-boards` has no prober for (catsone, factorial, jibe, phenom). Those seeds are written
+and then silently never validated. Out of scope here, worth its own change.
 
 ## Open Questions
 

--- a/openspec/changes/mine-ats-boards-from-linkedin/design.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/design.md
@@ -1,0 +1,140 @@
+## Context
+
+The board harvest is already split into three roles: something supplies a worklist of
+companies, `cmd/harvest-ats resolve` follows each company's website to its ATS board, and
+`cmd/harvest-boards` probes every candidate slug against the provider's official API and
+commits only what answered. Only the first role is weak. Its worklists are the curated
+collection datasets and a world-universities directory — static, undated, and silent about
+whether anyone at those companies is hiring.
+
+LinkedIn's public `jobs-guest` endpoints answer that directly, need no credentials, and were
+verified during design to serve both the search listing and each posting's structured
+metadata under this project's own User-Agent. Two facts were confirmed present on a live
+sample:
+
+- the posting's JSON-LD `hiringOrganization.sameAs` leads to the employer's public profile,
+  whose own JSON-LD `Organization.sameAs` is the employer's website — resolved for 20 of 20
+  companies sampled;
+- the posting's JSON-LD `identifier.value` is the posting's id **in the employer's own ATS**
+  (`teamtailor-8094978`, `4698693006`, `JR37734`, …) — present on roughly half the sample.
+
+Three things LinkedIn does *not* give, all checked directly: the offsite apply URL (hidden
+behind a sign-in modal), the legacy `applyUrl` element (removed from the markup), and ATS
+links inside posting descriptions (stripped — 0 of 20). So the board must be *derived*, not
+read, and the value of `identifier.value` is that it makes a derived board provable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Feed the existing harvest a worklist of companies that are demonstrably hiring now, for
+  any keyword and market the operator lists.
+- Widen `harvest-ats` detection to the full board recognizer, including platforms that host
+  the careers site themselves.
+- Make a JS-only careers page a solvable case instead of a skipped one, by proposing
+  candidate slugs that `harvest-boards` confirms against an exact posting id.
+- Keep every LinkedIn-derived fact transient: only boards this project validated against a
+  provider's own API reach `sources/*.yml`.
+
+**Non-Goals:**
+
+- Ingesting LinkedIn postings as a catalogue source. That is a far denser request shape, it
+  duplicates postings we already take from the boards themselves, and it would put LinkedIn
+  content in our database rather than a worklist in `/tmp`.
+- Any persistent state: no table, no cursor, no cron. These are run-once host tools, as the
+  rest of the `harvest-*` family is.
+- Browser impersonation, headless rendering, or proxying. If a page needs JavaScript, the
+  identifier path handles it; if LinkedIn stops serving us, the run fails loudly.
+
+## Decisions
+
+**One thin new binary, two surgical extensions — not one self-contained tool.**
+`cmd/harvest-linkedin` only discovers companies; it never talks to an ATS. The confirmation
+step lives in `harvest-boards` because it is an improvement to *board validation*, not a
+property of LinkedIn — `harvest-role`, which likewise knows a posting's id, can supply the
+same field tomorrow. The rejected alternative was a single binary that probes provider APIs
+itself: it would put second copies of the Greenhouse and Lever probe logic beside the ~15
+probers that already exist.
+
+**Slug candidates are derived offline and confirmed remotely.** Deriving a slug from a
+domain, profile slug or company name is guesswork, and would be unacceptable on its own. It
+becomes acceptable because the seed carries the posting id that decides it: a candidate is
+kept only if the platform reports a live posting with exactly that id. A wrong slug that
+happens to be a real board belonging to someone else is rejected on evidence. This also
+means derivation needs no network, which keeps it a pure, cheaply-tested function.
+
+The identifier's shape narrows the provider set: `teamtailor-<digits>` → teamtailor, ten
+digits → greenhouse, a UUID → lever and ashby. Shapes that narrow nothing (`JR37734`,
+`R00314608_en`) yield no candidates rather than a fan-out across every provider.
+
+**Confirmation rides on an optional interface, not on the `prober` contract.** `prober.go`
+carries ~15 implementations behind one interface; widening that interface would touch all of
+them for the benefit of six. Instead a separate, optional interface reports the ids of a
+board's live postings, and is consulted only when a seed entry carries an expected id.
+
+It is implemented only where a single request yields the board's *complete* live list —
+greenhouse, lever, ashby, recruitee — because the check reads a missing id as a wrong board.
+SmartRecruiters is probed with `limit=1` and Teamtailor reads only its first page, so for
+them an absent id would mean "not on the page I looked at", and they are left inert rather
+than made to reject boards on partial evidence. Everything else is untouched, and an expected id on a
+provider that cannot check it is inert rather than fatal.
+
+**`harvest-ats` detects through `internal/boardresolve`.** The narrow `atsdetect.Detect`
+recognises three providers; `boardresolve` runs the full `atsboard.Recognize` (~40 ATS) and
+`DetectSelfHosted` for platforms whose tenant host *is* the board. That package exists for
+the paste-a-link contribution flow and is SSRF-guarded, which the harvest wants anyway since
+it follows arbitrary company domains. This is a strict widening of an existing capability,
+useful to the dataset and university worklists too.
+
+**Company de-duplication happens before detail fetches.** The search card already names the
+employer and links its profile, so the catalogue filter and the collapse of many postings to
+one employer both run on the listing alone. On the design sample, 48 postings covered 35
+employers — about a third of the detail traffic never needs to be sent.
+
+**An all-empty run exits non-zero.** A blocked or re-templated LinkedIn returns exactly what
+an empty market returns. The project has been burned by this shape before (`ingested=0
+failed=0` reading as a healthy board), so silence is treated as failure at the run level,
+while a single empty query is only a warning.
+
+**Requests go through `sources.Client` plus `internal/sources/pacer.go`.** Retries, `Retry-
+After` handling, body caps and SSRF protection already live there, and the client's
+User-Agent is the project's own. Verified during design: LinkedIn serves both endpoints under
+it, so no browser impersonation is needed and none will be added.
+
+## Risks / Trade-offs
+
+- **LinkedIn changes its markup or starts refusing us** → The run fails loudly instead of
+  quietly: an all-empty run exits non-zero. Parsing follows the sample-per-posting shape, so
+  one changed card costs one posting, not the run. Nothing downstream depends on LinkedIn
+  being available — it is a worklist source, and the other worklists keep working.
+- **Terms-of-service exposure from automated access** → Volume is deliberately small, hand-
+  run, rate-limited and identified as this project. No LinkedIn posting content is stored or
+  republished; what enters the repository is boards confirmed against each provider's own
+  public API, which is the standing rule for `harvest-boards` seeds.
+- **A derived slug is a real board owned by someone else** → Rejected by the expected-id
+  check, and reported as an id mismatch so it is visible rather than silently absent.
+- **Half the sampled postings carried no ATS-native identifier** → Those companies still flow
+  through the ordinary careers-page path; the identifier only adds a second route, it does
+  not gate the first.
+- **Confirmation costs extra probes (up to three slugs × two providers per unresolved
+  company)** → Bounded by construction, and only spent on companies that produced no board
+  at all — which today produce nothing.
+- **Deriving the provider from an id's shape is heuristic** → It never decides anything by
+  itself; it only chooses which boards to ask. A wrong guess costs one API call and is
+  rejected.
+
+## Migration Plan
+
+Nothing to deploy and nothing to roll back: three host tools and one query file, none of
+which run in production or touch the database. The `harvest-ats` detection swap and the
+`harvest-boards` seed field are backward compatible — seeds without an expected id validate
+exactly as before. First use is a manual run whose diff to `sources/*.yml` is reviewed like
+any other harvest PR.
+
+## Open Questions
+
+- What share of discovered companies is genuinely new is unknown until the first run; the
+  design sample skewed toward large consultancies we almost certainly already have. The run's
+  own counters answer this, and the query worklist is the dial to adjust.
+- Which markets and keywords to seed the worklist with is deliberately left to the first
+  run's results rather than guessed now.

--- a/openspec/changes/mine-ats-boards-from-linkedin/proposal.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/proposal.md
@@ -15,10 +15,9 @@ about a board slug into a fact a provider's own API can confirm.
   job search, and emits the companies behind those postings — name, website, and the
   posting's ATS-native id — as the candidate worklist the existing harvest consumes.
   Companies already in the catalogue are dropped before any extra request is made.
-- `harvest-ats resolve` detects boards through `internal/boardresolve` instead of
-  `atsdetect.Detect` alone, widening detection from three providers to the full
-  `atsboard.Recognize` set plus the self-hosted platforms whose board *is* the careers
-  host (Teamtailor, Phenom, Radancy).
+- `harvest-ats resolve` gains the one detection step it lacks: the platforms whose board *is*
+  the careers host (Teamtailor, Phenom, Jibe, Radancy), which link out to no ATS domain and so
+  are invisible to any URL scan. Its existing scan already covers every URL-shaped board.
 - `harvest-ats resolve` additionally emits *candidate* board slugs, derived offline from
   the company's domain, LinkedIn slug and name, for companies whose careers page yields no
   board — today's dead end for JS-only careers pages, which the tool skips outright.

--- a/openspec/changes/mine-ats-boards-from-linkedin/proposal.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+The board harvest is bottlenecked on its worklist, not on its machinery. `harvest-ats`
+follows companies to their ATS board perfectly well, but the only companies it is ever
+handed come from curated collection datasets and a world-universities directory — static
+lists that say nothing about whether anyone there is hiring. LinkedIn's public
+`jobs-guest` endpoints answer exactly that question for any keyword and market, and every
+job page carries two facts we can act on: the employer's own website, and the job's
+identifier **in the employer's ATS**. The second is the valuable one — it turns a guess
+about a board slug into a fact a provider's own API can confirm.
+
+## What Changes
+
+- A new `cmd/harvest-linkedin` host tool reads a query worklist, pages LinkedIn's public
+  job search, and emits the companies behind those postings — name, website, and the
+  posting's ATS-native id — as the candidate worklist the existing harvest consumes.
+  Companies already in the catalogue are dropped before any extra request is made.
+- `harvest-ats resolve` detects boards through `internal/boardresolve` instead of
+  `atsdetect.Detect` alone, widening detection from three providers to the full
+  `atsboard.Recognize` set plus the self-hosted platforms whose board *is* the careers
+  host (Teamtailor, Phenom, Radancy).
+- `harvest-ats resolve` additionally emits *candidate* board slugs, derived offline from
+  the company's domain, LinkedIn slug and name, for companies whose careers page yields no
+  board — today's dead end for JS-only careers pages, which the tool skips outright.
+- `harvest-boards` accepts an expected posting id on a seed entry and confirms a candidate
+  board by finding that id among the board's live postings, rejecting it otherwise. This
+  is what makes an offline-derived slug safe to propose: confirmation is an exact match,
+  not a plausible one.
+- No new runtime surface, no database, no cron. Every new binary is run-once by hand, and
+  only boards confirmed against a provider's official API reach `sources/*.yml`.
+
+## Capabilities
+
+### New Capabilities
+
+- `linkedin-board-discovery`: turning LinkedIn's public job search into a candidate
+  worklist of hiring companies — query worklist, company-level de-duplication, catalogue
+  filtering, the two facts read from each posting, and the empty-result rule that
+  distinguishes "nobody is hiring" from "we have been blocked or the markup moved".
+
+### Modified Capabilities
+
+- `domain-ats-harvest`: board detection during resolution widens from the three-provider
+  HTML scan to the full recognizer including self-hosted platforms; resolution gains
+  candidate-slug emission for companies whose careers page yields no board.
+- `board-harvest`: a seed entry may carry an expected posting id, and a candidate board is
+  then kept only when the platform reports a live posting with that id.
+
+## Impact
+
+- New: `cmd/harvest-linkedin`, `harvest/linkedin-queries.yml`.
+- Modified: `cmd/harvest-ats` (resolve detection + candidate slugs),
+  `cmd/harvest-boards` (seed shape, id confirmation on the providers whose single probe
+  request yields the board's complete live posting list: greenhouse, lever, ashby,
+  recruitee).
+- Reused unchanged: `internal/boardresolve`, `internal/atsboard`, `internal/sources`
+  (SSRF-guarded client, retry/backoff, pacer). LinkedIn serves these endpoints under the
+  project's own User-Agent, so no request forgery is involved.
+- Out of scope: ingesting LinkedIn postings themselves. LinkedIn data is a transient
+  worklist; the repository only ever gains boards this project validated itself.

--- a/openspec/changes/mine-ats-boards-from-linkedin/specs/board-harvest/spec.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/specs/board-harvest/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: The harvest tool validates candidate boards against the live platform API
+
+The `harvest-boards` host tool SHALL expand a board file (`sources/<provider>.yml`)
+only with boards it has live-validated: each candidate board SHALL be probed
+against the platform's own live surface — its official public API, or, for a
+self-hosted platform that exposes no API, the portal's own served pages — and kept
+only if that surface reports at least one open job, so the committed file is the
+project's own validated fact set rather than a redistributed dataset. A candidate
+that is absent, closed, or unreachable SHALL be skipped, never abort the run. A
+kept board SHALL be appended to the provider's board file with the company name
+the platform reports (or the board id when the platform exposes none),
+de-duplicated against the boards already in the file.
+
+Live jobs alone do not make a board the right board. When the seed names the employer a
+candidate is expected to belong to, and the platform reports a company name of its own, the
+two SHALL agree — compared after normalizing case, punctuation and legal-form suffixes — or
+the candidate SHALL be rejected and counted separately from an unreachable one, so a
+mismatch is visible as a mismatch rather than as an absent board. A seed that names no
+expected employer SHALL be validated on live jobs alone, and a platform that reports no name
+of its own SHALL keep taking the seed's name as its label.
+
+A seed entry MAY instead name the ATS-native id of a posting the candidate board is expected
+to contain. When it does, and the platform's probe reads the ids of the board's live
+postings, the board SHALL be kept only if that id is among them, and rejected otherwise —
+counted separately from an unreachable candidate, as a name mismatch is. An expected id
+SHALL take precedence over a name comparison for the same candidate, since it identifies the
+board by evidence rather than by resemblance. An expected id on a provider whose probe reads
+no posting ids SHALL leave validation unchanged rather than rejecting the candidate, so
+supplying one is never worse than omitting it.
+
+#### Scenario: A candidate with open jobs is kept
+
+- **WHEN** a candidate board is probed and the platform API reports one or more
+  open jobs
+- **THEN** the board is appended to `sources/<provider>.yml` with the reported
+  company name (or the board id as a fallback)
+
+#### Scenario: A candidate with no open jobs is skipped
+
+- **WHEN** a candidate board is probed and the platform API reports zero jobs or
+  is unreachable
+- **THEN** the board is not appended and the run continues with the other
+  candidates
+
+#### Scenario: An already-known board is not duplicated
+
+- **WHEN** a candidate board id already appears in `sources/<provider>.yml`
+- **THEN** it is filtered out before probing and not appended again
+
+#### Scenario: A self-hosted portal is validated against its own pages
+
+- **WHEN** a candidate belongs to a platform that publishes no vendor API, and its
+  portal page lists one or more open postings
+- **THEN** the candidate is validated from that page and kept exactly as an
+  API-validated candidate would be
+
+#### Scenario: A live board owned by a different employer is rejected
+
+- **WHEN** the seed expects a candidate to belong to one employer, and the platform reports
+  open jobs under a different company name
+- **THEN** the board is not appended, and the run reports it as a name mismatch rather than
+  as a skipped or unreachable candidate
+
+#### Scenario: Legal-form suffixes and punctuation do not break agreement
+
+- **WHEN** the seed's expected employer and the platform's reported name differ only in
+  case, punctuation, or a legal-form suffix
+- **THEN** the names are treated as agreeing and the board is kept
+
+#### Scenario: A seed without an expected employer is unaffected
+
+- **WHEN** a seed entry names no expected employer
+- **THEN** the candidate is validated on live jobs alone, exactly as before
+
+#### Scenario: A board containing the expected posting is kept
+
+- **WHEN** a seed entry names an expected posting id and the platform reports a live
+  posting with that id on the candidate board
+- **THEN** the board is appended exactly as a live-validated candidate would be
+
+#### Scenario: A board that does not contain the expected posting is rejected
+
+- **WHEN** a seed entry names an expected posting id and the candidate board's live
+  postings do not include it
+- **THEN** the board is not appended, and the run reports it as an id mismatch rather than
+  as a skipped or unreachable candidate
+
+#### Scenario: An expected id is not weakened by a name comparison
+
+- **WHEN** a seed entry names both an expected posting id and an expected employer, and the
+  platform reports the posting under a company name that does not match the seed's
+- **THEN** the expected id decides the outcome and the board is kept
+
+#### Scenario: An expected id on a provider that reports no posting ids is inert
+
+- **WHEN** a seed entry names an expected posting id for a provider whose probe does not
+  read the ids of live postings
+- **THEN** the candidate is validated exactly as it would be without the expected id

--- a/openspec/changes/mine-ats-boards-from-linkedin/specs/domain-ats-harvest/spec.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/specs/domain-ats-harvest/spec.md
@@ -1,0 +1,93 @@
+## MODIFIED Requirements
+
+### Requirement: Website-to-board resolution writes per-provider seeds
+
+The system SHALL provide a resolve step that, for each input company, fetches a
+small fixed set of candidate career pages (the homepage, common careers/jobs paths,
+and a careers/jobs link discovered on the homepage) through the shared HTTP client,
+detects the ATS board each page belongs to, and stops at the first page that yields a
+board. Detection SHALL use the project's full board recognizer rather than the
+three-provider HTML scan alone, so a careers page that links to any supported ATS is
+resolved, and SHALL additionally recognise the platforms whose board *is* the careers
+host and which therefore link out to no ATS domain at all. It
+SHALL accumulate the detected slugs per provider and write one seed file per
+provider (the input format the existing `harvest-boards` consumes). The run SHALL
+be best-effort: a failure fetching or parsing one company (timeout, bot-block,
+missing careers page, JS-only page) SHALL be logged and skipped without aborting
+the run. Resolution SHALL NOT write to `sources/*.yml` directly — the per-provider
+seeds feed `harvest-boards`, which validates each slug against the provider API
+before any board is committed.
+
+#### Scenario: A resolved company contributes to its provider's seed
+
+- **WHEN** a company's careers page links to `jobs.lever.co/acme`
+- **THEN** `acme` appears in the lever seed file
+
+#### Scenario: A careers page linking a provider outside the narrow scan is resolved
+
+- **WHEN** a company's careers page links to a supported ATS board that the
+  three-provider HTML scan does not recognise
+- **THEN** the board is detected and contributes to that provider's seed
+
+#### Scenario: A career site that is itself the board is resolved
+
+- **WHEN** a company's careers site is served by a platform whose tenant host is the
+  board, and the page links to no external ATS domain
+- **THEN** the platform and the host are detected as the board and contribute to that
+  provider's seed
+
+#### Scenario: A failed company does not abort the run
+
+- **WHEN** one company's site times out or has no detectable ATS
+- **THEN** it is skipped and logged, and the remaining companies are still processed
+
+#### Scenario: Seeds feed the existing validation step
+
+- **WHEN** the resolve step finishes
+- **THEN** it has written per-provider seed files (no `sources/*.yml` writes), which
+  `harvest-boards <provider> <seed>` then validates and commits
+
+## ADDED Requirements
+
+### Requirement: Candidate board slugs are derived offline when no page yields a board
+
+When a company's career pages yield no board and the input supplies the ATS-native
+identifier of one of that company's live postings, the resolve step SHALL derive candidate
+board slugs from what it already knows about the company — its domain, its platform profile
+slug, and its name — and SHALL emit each candidate into the seed of every provider the
+identifier's shape is consistent with, carrying the identifier as the expected posting id.
+Derivation SHALL perform no I/O and SHALL be bounded to a small fixed number of slugs per
+company. An identifier whose shape narrows to no provider SHALL yield no candidates, and a
+company with no identifier SHALL be skipped exactly as it is today.
+
+Proposing a slug is safe only because the seed carries the identifier that will confirm it:
+`harvest-boards` keeps such a candidate only when the platform reports a live posting with
+that id, so a slug that happens to belong to some other employer is rejected on the
+evidence rather than on a name resemblance.
+
+#### Scenario: A JS-only careers page still yields candidates
+
+- **WHEN** none of a company's career pages yields a board, and the input carries the
+  ATS-native id of one of its postings
+- **THEN** candidate slugs derived from the company's domain, profile slug and name are
+  emitted with that id as the expected posting id
+
+#### Scenario: Candidates go only to providers the id shape is consistent with
+
+- **WHEN** the identifier's shape is consistent with a subset of the supported providers
+- **THEN** the candidate slugs are emitted into exactly those providers' seeds and no others
+
+#### Scenario: An unrecognised identifier shape yields nothing
+
+- **WHEN** the identifier's shape narrows to no provider
+- **THEN** no candidate slugs are emitted for that company
+
+#### Scenario: A company without an identifier is unaffected
+
+- **WHEN** no board is found and the input carries no ATS-native identifier
+- **THEN** the company is skipped and logged exactly as before, with no candidates emitted
+
+#### Scenario: Derivation costs no requests
+
+- **WHEN** candidate slugs are derived for a company
+- **THEN** no HTTP request is made for the derivation itself

--- a/openspec/changes/mine-ats-boards-from-linkedin/specs/domain-ats-harvest/spec.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/specs/domain-ats-harvest/spec.md
@@ -6,10 +6,11 @@ The system SHALL provide a resolve step that, for each input company, fetches a
 small fixed set of candidate career pages (the homepage, common careers/jobs paths,
 and a careers/jobs link discovered on the homepage) through the shared HTTP client,
 detects the ATS board each page belongs to, and stops at the first page that yields a
-board. Detection SHALL use the project's full board recognizer rather than the
-three-provider HTML scan alone, so a careers page that links to any supported ATS is
-resolved, and SHALL additionally recognise the platforms whose board *is* the careers
-host and which therefore link out to no ATS domain at all. It
+board. Detection SHALL first scan the page for the URL shapes that name a platform, and
+where that yields nothing SHALL additionally recognise the platforms whose board *is* the
+careers host and which therefore link out to no ATS domain at all — resolving them to that
+host. A page that both links a board and is served by such a platform SHALL resolve to the
+linked board. It
 SHALL accumulate the detected slugs per provider and write one seed file per
 provider (the input format the existing `harvest-boards` consumes). The run SHALL
 be best-effort: a failure fetching or parsing one company (timeout, bot-block,
@@ -23,11 +24,11 @@ before any board is committed.
 - **WHEN** a company's careers page links to `jobs.lever.co/acme`
 - **THEN** `acme` appears in the lever seed file
 
-#### Scenario: A careers page linking a provider outside the narrow scan is resolved
+#### Scenario: A linked board wins over the host serving the page
 
-- **WHEN** a company's careers page links to a supported ATS board that the
-  three-provider HTML scan does not recognise
-- **THEN** the board is detected and contributes to that provider's seed
+- **WHEN** a company's careers site is served by a platform whose tenant host is the board,
+  and the page also links to a different ATS board
+- **THEN** the linked board is detected, not the host
 
 #### Scenario: A career site that is itself the board is resolved
 

--- a/openspec/changes/mine-ats-boards-from-linkedin/specs/linkedin-board-discovery/spec.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/specs/linkedin-board-discovery/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: A query worklist drives the public job search
+
+The discovery tool SHALL take its search worklist from a file of queries kept in the
+repository, each query naming the keywords and the market to search, and optionally how
+recent a posting must be and how many result pages to page through. The tool SHALL page
+the platform's public, unauthenticated job-search surface per query, and SHALL treat a
+worklist entry that names no market as a usage error rather than searching globally, since
+an unbounded market is what turns a bounded harvest into an unbounded crawl.
+
+#### Scenario: Each worklist query is searched across its requested pages
+
+- **WHEN** the worklist names a query with keywords, a market, and a page count
+- **THEN** the tool requests that many result pages for that query and collects the
+  postings from all of them
+
+#### Scenario: Recency and page count fall back to bounded defaults
+
+- **WHEN** a worklist query omits the recency window or the page count
+- **THEN** the tool applies its documented defaults rather than paging without bound
+
+#### Scenario: A query without a market is refused
+
+- **WHEN** a worklist query names no market
+- **THEN** the tool reports a usage error and makes no requests
+
+### Requirement: Companies are de-duplicated and filtered before any extra request
+
+The discovery tool SHALL read the employer's name and platform profile from the search
+result itself, and SHALL collapse the postings of one employer to a single candidate
+before fetching anything further. A candidate whose normalized-name slug is present in a
+supplied set of existing company slugs SHALL be dropped at that point, so no request is
+spent on a company the catalogue already covers.
+
+#### Scenario: Several postings by one employer become one candidate
+
+- **WHEN** a search returns multiple postings from the same employer
+- **THEN** the employer is carried forward once, and only one posting of theirs is
+  fetched in detail
+
+#### Scenario: A company already in the catalogue costs no request
+
+- **WHEN** a candidate employer's normalized-name slug is present in the supplied slug set
+- **THEN** the candidate is dropped without fetching its posting or its profile page
+
+### Requirement: Each candidate carries its website and its ATS-native posting id
+
+For every candidate that survives filtering, the discovery tool SHALL emit the employer's
+name, the employer's own website, and — when the posting publishes one — the identifier
+the posting carries in the employer's own applicant tracking system. The website SHALL be
+read from the employer's public profile and the posting identifier from the posting's
+structured job metadata. A candidate whose posting publishes no such identifier SHALL
+still be emitted, without one; a candidate whose website cannot be determined SHALL be
+omitted, since there is nothing for the resolve step to follow.
+
+#### Scenario: A candidate with a website and a posting id is emitted in full
+
+- **WHEN** a candidate's profile publishes a website and its posting's metadata carries an
+  ATS-native identifier
+- **THEN** the candidate is emitted with name, website, and that identifier
+
+#### Scenario: A missing posting id does not disqualify a candidate
+
+- **WHEN** a candidate's posting publishes no ATS-native identifier
+- **THEN** the candidate is still emitted, with its name and website and no identifier
+
+#### Scenario: A candidate without a website is omitted
+
+- **WHEN** a candidate's website cannot be determined from its profile
+- **THEN** the candidate is not emitted
+
+#### Scenario: One unreachable candidate does not abort the run
+
+- **WHEN** fetching one candidate's posting or profile fails
+- **THEN** that candidate is skipped and logged, and the run continues with the others
+
+### Requirement: An empty search result is reported as a failure, not as an absence
+
+A search request that succeeds but yields no postings SHALL be logged as a warning rather
+than silently counted as an empty market, and a run in which **every** query yields no
+postings SHALL exit non-zero. A markup change or a block returns exactly the shape an
+honestly empty market returns, and a harvest that reports success while collecting nothing
+is indistinguishable from one that ran correctly.
+
+#### Scenario: A single empty query warns and continues
+
+- **WHEN** one query returns a successful response containing no postings
+- **THEN** the tool logs a warning for that query and continues with the remaining queries
+
+#### Scenario: An entirely empty run fails
+
+- **WHEN** every query in the worklist returns no postings
+- **THEN** the tool exits non-zero
+
+### Requirement: Requests identify the project and are rate-limited
+
+The discovery tool SHALL issue its requests through the project's shared HTTP client, under
+the project's own User-Agent, and SHALL NOT impersonate a browser. The aggregate request
+rate SHALL be gated by a rate limiter whose default is conservative and which the operator
+can lower further, so the worker pool bounds requests in flight while the limiter bounds
+requests per second.
+
+#### Scenario: Requests carry the project's identity
+
+- **WHEN** the tool issues any request to the platform
+- **THEN** the request goes out under the project's own User-Agent
+
+#### Scenario: The aggregate rate is bounded independently of concurrency
+
+- **WHEN** the tool runs with its default settings
+- **THEN** the outgoing request rate is capped by the rate limiter, and the operator can
+  cap it lower

--- a/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
@@ -61,8 +61,8 @@
 
 ## 6. Verification
 
-- [ ] 6.1 `go build ./... && go vet ./... && go test ./...` clean
-- [ ] 6.2 Live smoke run of `harvest-linkedin` on two or three queries; confirm candidates
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...` clean
+- [x] 6.2 Live smoke run of `harvest-linkedin` on two or three queries; confirm candidates
   are produced and report how many survive the catalogue filter
-- [ ] 6.3 Carry that output through `harvest-ats resolve` and `harvest-boards` for one
+- [x] 6.3 Carry that output through `harvest-ats resolve` and `harvest-boards` for one
   provider, and review the resulting `sources/*.yml` diff before proposing it

--- a/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
@@ -1,0 +1,68 @@
+## 1. Board confirmation by expected posting id (`cmd/harvest-boards`)
+
+- [x] 1.1 Extend `seedItem` in `seed.go` with an optional `expect_id`, keeping both existing
+  seed shapes (array of strings, array of objects) parsing exactly as before
+- [x] 1.2 Add an optional `idProber` interface beside `prober` in `prober.go` that reports
+  the ids of a board's live postings, leaving the `prober` interface itself untouched
+- [x] 1.3 Implement `idProber` on the probers whose single request already yields the board's
+  complete set of live posting ids: greenhouse, lever, ashby, recruitee. SmartRecruiters
+  (probed with `limit=1`) and Teamtailor (first page only) see a partial list, where a missing
+  id would not mean an absent posting — they stay inert
+- [x] 1.4 Wire confirmation into the probe loop: an expected id decides the candidate,
+  outranks the employer-name comparison, and is inert when the provider reports no ids
+- [x] 1.5 Count and report id mismatches separately from unreachable candidates, as name
+  mismatches already are
+
+## 2. Wider board detection during resolution (`cmd/harvest-ats`)
+
+- [ ] 2.1 Replace the three `atsdetect.Detect` calls in `resolve.go` with detection through
+  `internal/boardresolve`, keeping the careers-page walk (paths, careers link, one deeper
+  hop) and the best-effort skip-on-error behaviour unchanged
+- [ ] 2.2 Cover the newly reachable cases: a careers page linking an ATS outside the narrow
+  scan, and a career site whose own host is the board
+
+## 3. Offline candidate slugs for unresolved companies (`cmd/harvest-ats`)
+
+- [ ] 3.1 Add a pure function deriving candidate board slugs from a company's domain,
+  profile slug and name, bounded to a small fixed number and performing no I/O
+- [ ] 3.2 Add a pure function narrowing an ATS-native posting id to the providers its shape
+  is consistent with, yielding nothing for shapes that narrow to none
+- [ ] 3.3 Emit derived candidates into each narrowed provider's seed carrying the expected
+  posting id, only when the careers walk found no board and an id is present
+- [ ] 3.4 Carry the new input fields (`linkedin`, `external_id`) through the resolve input
+  without disturbing the existing `{name, website}` worklists
+
+## 4. LinkedIn discovery tool (`cmd/harvest-linkedin`)
+
+- [ ] 4.1 Parse the query worklist YAML (keywords, location, jobage, pages) with bounded
+  defaults, refusing an entry that names no market
+- [ ] 4.2 Parse the public search listing into postings carrying employer name, employer
+  profile URL and posting URL, one card at a time so a malformed card costs one posting
+- [ ] 4.3 Parse a posting's JSON-LD for the ATS-native identifier, and an employer profile's
+  JSON-LD for the website
+- [ ] 4.4 Collapse postings to one candidate per employer and drop candidates whose
+  normalized-name slug is in the supplied company-slug set, both before any detail fetch
+- [ ] 4.5 Emit surviving candidates as `{name, website, linkedin, external_id}` JSON on
+  stdout, omitting those with no website and skipping-with-log those that fail to fetch
+- [ ] 4.6 Warn on a query that returns no postings and exit non-zero when every query does
+- [ ] 4.7 Wire the run through `sources.NewClient()` and the shared pacer, with a `-pace`
+  flag and a conservative default, and bootstrap the command per `worker.Bootstrap`
+  convention
+
+## 5. Worklist file and documentation
+
+- [ ] 5.1 Add `harvest/linkedin-queries.yml` with a small starter set of keyword×market
+  queries
+- [ ] 5.2 Document the three-step run (`harvest-linkedin` → `harvest-ats resolve` →
+  `harvest-boards`) in the command's package comment, matching how the other `harvest-*`
+  tools document themselves
+- [ ] 5.3 Record the expected-id seed field where the harvest worklist conventions are
+  described, so a future seed source knows it can supply one
+
+## 6. Verification
+
+- [ ] 6.1 `go build ./... && go vet ./... && go test ./...` clean
+- [ ] 6.2 Live smoke run of `harvest-linkedin` on two or three queries; confirm candidates
+  are produced and report how many survive the catalogue filter
+- [ ] 6.3 Carry that output through `harvest-ats resolve` and `harvest-boards` for one
+  provider, and review the resulting `sources/*.yml` diff before proposing it

--- a/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
@@ -15,11 +15,11 @@
 
 ## 2. Wider board detection during resolution (`cmd/harvest-ats`)
 
-- [ ] 2.1 Replace the three `atsdetect.Detect` calls in `resolve.go` with detection through
-  `internal/boardresolve`, keeping the careers-page walk (paths, careers link, one deeper
-  hop) and the best-effort skip-on-error behaviour unchanged
-- [ ] 2.2 Cover the newly reachable cases: a careers page linking an ATS outside the narrow
-  scan, and a career site whose own host is the board
+- [x] 2.1 Add `atsdetect.DetectSelfHosted` as the fallback behind the existing URL scan in
+  `resolve.go`, applied at each page the careers walk fetches, keeping the walk (paths,
+  careers link, one deeper hop) and the best-effort skip-on-error behaviour unchanged
+- [x] 2.2 Cover the newly reachable case (a career site whose own host is the board) and the
+  precedence rule (a linked board wins over the host serving the page)
 
 ## 3. Offline candidate slugs for unresolved companies (`cmd/harvest-ats`)
 

--- a/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
@@ -23,13 +23,13 @@
 
 ## 3. Offline candidate slugs for unresolved companies (`cmd/harvest-ats`)
 
-- [ ] 3.1 Add a pure function deriving candidate board slugs from a company's domain,
+- [x] 3.1 Add a pure function deriving candidate board slugs from a company's domain,
   profile slug and name, bounded to a small fixed number and performing no I/O
-- [ ] 3.2 Add a pure function narrowing an ATS-native posting id to the providers its shape
+- [x] 3.2 Add a pure function narrowing an ATS-native posting id to the providers its shape
   is consistent with, yielding nothing for shapes that narrow to none
-- [ ] 3.3 Emit derived candidates into each narrowed provider's seed carrying the expected
+- [x] 3.3 Emit derived candidates into each narrowed provider's seed carrying the expected
   posting id, only when the careers walk found no board and an id is present
-- [ ] 3.4 Carry the new input fields (`linkedin`, `external_id`) through the resolve input
+- [x] 3.4 Carry the new input fields (`linkedin`, `external_id`) through the resolve input
   without disturbing the existing `{name, website}` worklists
 
 ## 4. LinkedIn discovery tool (`cmd/harvest-linkedin`)

--- a/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
@@ -59,6 +59,13 @@
 - [x] 5.3 Record the expected-id seed field where the harvest worklist conventions are
   described, so a future seed source knows it can supply one
 
+## 7. Teamtailor validation (found by the first end-to-end run)
+
+- [x] 7.1 Probe a Teamtailor board the way the ingest adapter reads it — the HTML listing —
+  instead of a JSON feed the platform does not serve, so a live board stops reading as absent
+- [x] 7.2 Move the Teamtailor case out of the named-prober test: the company name it asserted
+  came from the JSON shape only the fake produced
+
 ## 6. Verification
 
 - [x] 6.1 `go build ./... && go vet ./... && go test ./...` clean

--- a/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
+++ b/openspec/changes/mine-ats-boards-from-linkedin/tasks.md
@@ -34,29 +34,29 @@
 
 ## 4. LinkedIn discovery tool (`cmd/harvest-linkedin`)
 
-- [ ] 4.1 Parse the query worklist YAML (keywords, location, jobage, pages) with bounded
+- [x] 4.1 Parse the query worklist YAML (keywords, location, jobage, pages) with bounded
   defaults, refusing an entry that names no market
-- [ ] 4.2 Parse the public search listing into postings carrying employer name, employer
+- [x] 4.2 Parse the public search listing into postings carrying employer name, employer
   profile URL and posting URL, one card at a time so a malformed card costs one posting
-- [ ] 4.3 Parse a posting's JSON-LD for the ATS-native identifier, and an employer profile's
+- [x] 4.3 Parse a posting's JSON-LD for the ATS-native identifier, and an employer profile's
   JSON-LD for the website
-- [ ] 4.4 Collapse postings to one candidate per employer and drop candidates whose
+- [x] 4.4 Collapse postings to one candidate per employer and drop candidates whose
   normalized-name slug is in the supplied company-slug set, both before any detail fetch
-- [ ] 4.5 Emit surviving candidates as `{name, website, linkedin, external_id}` JSON on
+- [x] 4.5 Emit surviving candidates as `{name, website, linkedin, external_id}` JSON on
   stdout, omitting those with no website and skipping-with-log those that fail to fetch
-- [ ] 4.6 Warn on a query that returns no postings and exit non-zero when every query does
-- [ ] 4.7 Wire the run through `sources.NewClient()` and the shared pacer, with a `-pace`
-  flag and a conservative default, and bootstrap the command per `worker.Bootstrap`
-  convention
+- [x] 4.6 Warn on a query that returns no postings and exit non-zero when every query does
+- [x] 4.7 Wire the run through `sources.NewClient()` behind a rate limiter, with a `-pace`
+  flag and a conservative default, following the run-once host-tool shape the other
+  `harvest-*` commands use (`func main() { os.Exit(run()) }`, no database)
 
 ## 5. Worklist file and documentation
 
-- [ ] 5.1 Add `harvest/linkedin-queries.yml` with a small starter set of keyword×market
+- [x] 5.1 Add `harvest/linkedin-queries.yml` with a small starter set of keyword×market
   queries
-- [ ] 5.2 Document the three-step run (`harvest-linkedin` → `harvest-ats resolve` →
+- [x] 5.2 Document the three-step run (`harvest-linkedin` → `harvest-ats resolve` →
   `harvest-boards`) in the command's package comment, matching how the other `harvest-*`
   tools document themselves
-- [ ] 5.3 Record the expected-id seed field where the harvest worklist conventions are
+- [x] 5.3 Record the expected-id seed field where the harvest worklist conventions are
   described, so a future seed source knows it can supply one
 
 ## 6. Verification

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3747,3 +3747,5 @@
   board: serra
 - company: Ecochain Technologies
   board: ecochain
+- company: Freeday
+  board: freeday

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3101,3 +3101,13 @@
 # already calls the employer rather than the holding company.
 - company: Simple
   board: palta.teamtailor.com
+- company: Camper
+  board: careers.camper.com
+- company: Murphy AI
+  board: careers.getmurphy.ai
+- company: Neat
+  board: careers.neat.no
+- company: PARIS64
+  board: jobs.paris64.com
+- company: Onwelo
+  board: kariera.onwelo.com


### PR DESCRIPTION
## Why

The board harvest was never short of machinery, only of companies to point it at. Its worklists are curated collection datasets and a world-universities directory — static lists that say nothing about whether anyone there is hiring.

LinkedIn's public `jobs-guest` endpoints answer exactly that, without credentials. What they do **not** give, checked directly: the offsite apply URL (behind a sign-in modal), the legacy `applyUrl` element (removed), and ATS links in descriptions (stripped — 0 of 20). So the board is *derived*, not read.

What they do give is better: each posting's JSON-LD carries `identifier.value` — the posting's id **in the employer's own ATS**. That turns a guessed board slug into something the platform's own API can confirm or refute.

## The chain

```
harvest/linkedin-queries.yml
  → cmd/harvest-linkedin   companies hiring now (+ website, + external_id)
  → harvest-ats resolve    board from the careers page, or a slug guess when there is none
  → harvest-boards         board kept only if the API reports a posting with that id
```

## What changed

- **New** `cmd/harvest-linkedin`: pages the public search, collapses postings to one candidate per employer and drops already-known companies *before* any further request, reads website + ATS id off each survivor. An all-empty run exits non-zero — a blocked listing returns exactly what an empty market returns.
- **`harvest-boards`**: a seed entry may carry `expect_id`; the board is then kept only if the platform reports a live posting with it, outranking the employer-name comparison. Implemented only where one request yields the *complete* live list (greenhouse, lever, ashby, recruitee) — SmartRecruiters (`limit=1`) and Teamtailor (one page) stay inert rather than reject on partial evidence.
- **`harvest-ats`**: gains `DetectSelfHosted`, so career sites that *are* their own board (Teamtailor, Phenom, Jibe, Radancy) stop looking like companies with no ATS. Plus offline slug candidates for companies whose careers page yields nothing — bounded to 3 slugs × ≤2 providers, no I/O, and emitted only alongside the id that will refute them.
- **Fix**: the Teamtailor prober asked `/jobs?page=1` for JSON; the platform serves HTML there, exactly as `internal/sources/teamtailor.go` already reads it. Every Teamtailor board probed as dead — including `careers.arrive.com`, already in the board file. Pre-existing; this branch is just the first thing to feed it candidates at scale.

## Verified end to end

6 queries → 110 companies (60 with an ATS id) → 56 boards across 14 providers → **6 boards committed**, each validated against its platform's API and three spot-checked by hand.

Two honest gaps, both written up in `design.md`:
- The offline slug guesses scored **0 of 12** — every guessed board simply does not exist, so the id gate never got to run. Nothing false was admitted; the guessing half has yet to earn its keep.
- `harvest-ats` can resolve providers `harvest-boards` has no prober for (catsone, factorial, jibe, phenom). Those seeds are written and silently never validated. Left for its own change.

## Notes

- Requests go out under freehire's own User-Agent through the shared SSRF-guarded client, rate-limited at 1 req/s. No browser impersonation — LinkedIn serves these endpoints to us as we are.
- No LinkedIn content is stored or republished. It is a transient worklist in `/tmp`; what lands in `sources/*.yml` is boards this project validated itself.
- The `sources/` diff is the last commit, separable from the code if you want them merged apart.

Refs `openspec/changes/mine-ats-boards-from-linkedin`