### PR TITLE
Bound every server-side API call

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError, createApi } from './api';
+
+/** A fetch that never answers, and only settles if the caller aborts it. Stands in for
+ *  the failure this timeout exists for: an API call that neither returns nor errors. */
+function hangingFetch(): typeof fetch {
+  return ((_url: string, init?: RequestInit) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(init.signal!.reason));
+    })) as unknown as typeof fetch;
+}
+
+/** A fetch that answers immediately with an empty JSON envelope. */
+function okFetch(seen: { init?: RequestInit } = {}): typeof fetch {
+  return ((_url: string, init?: RequestInit) => {
+    seen.init = init;
+    return Promise.resolve(new Response('{"data":null}', { status: 200 }));
+  }) as unknown as typeof fetch;
+}
+
+describe('createApi request timeout', () => {
+  // Without a bound timeout an unanswered call hangs forever, and on the server that
+  // means the SvelteKit handler never finishes: nginx gives up at 60s and returns 504,
+  // but Node keeps the socket in CLOSE-WAIT. Enough of those fill the accept queue and
+  // the whole site stops responding — this is what took prod down on 2026-08-01.
+  it('fails a hung call with 504 instead of hanging', async () => {
+    const client = createApi(hangingFetch(), '', {}, 20);
+    await expect(client.ingestStatus()).rejects.toBeInstanceOf(ApiError);
+    await expect(client.ingestStatus()).rejects.toMatchObject({ status: 504 });
+  });
+
+  // The browser client is built without a timeout: it drives the LLM-backed calls
+  // (fit analysis, tailoring), which legitimately run for minutes.
+  it('leaves the call unbounded when no timeout is configured', async () => {
+    const seen: { init?: RequestInit } = {};
+    await createApi(okFetch(seen), '', {}).ingestStatus();
+    expect(seen.init?.signal).toBeUndefined();
+  });
+
+  it('arms the abort signal when a timeout is configured', async () => {
+    const seen: { init?: RequestInit } = {};
+    await createApi(okFetch(seen), '', {}, 5000).ingestStatus();
+    expect(seen.init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  // The timeout must not swallow the request body or method of a non-GET call — it is
+  // added to the init, not substituted for it.
+  it('keeps the rest of the request init intact', async () => {
+    const seen: { init?: RequestInit } = {};
+    await createApi(okFetch(seen), '', {}, 5000).login('a@b.co', 'pw');
+    expect(seen.init?.method).toBe('POST');
+    expect(seen.init?.body).toContain('a@b.co');
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -260,17 +260,41 @@ export function createApi(
   fetchImpl: typeof fetch = fetch,
   baseUrl = '',
   defaultHeaders: Record<string, string> = {},
+  /** Abort a call that has not answered within this many milliseconds. Set by the
+   *  SERVER client only (see `$lib/server/api`): a `load` that never finishes holds
+   *  its socket open forever, and enough of those fill the accept queue and take the
+   *  whole SSR process down. The browser client leaves this unset — it drives the
+   *  LLM-backed calls, which legitimately run for minutes. */
+  timeoutMs?: number,
 ) {
   /** The single place this module touches fetch. Always sends credentials so the
    *  auth cookie rides along, and turns a non-2xx into an ApiError. `defaultHeaders`
    *  lets a server caller forward the request's Cookie to an absolute API URL
    *  (where `event.fetch` would not). */
   async function call(path: string, init?: RequestInit): Promise<Response> {
-    const res = await fetchImpl(`${baseUrl}${path}`, {
+    const request: RequestInit = {
       credentials: 'include',
       ...init,
       headers: { ...defaultHeaders, ...init?.headers },
-    });
+    };
+    // Assigned after the spread, so a timeout is added to the init rather than
+    // substituted for it. A caller that brought its own signal keeps it.
+    const timeout = timeoutMs != null && request.signal == null ? AbortSignal.timeout(timeoutMs) : undefined;
+    if (timeout) {
+      request.signal = timeout;
+    }
+
+    let res: Response;
+    try {
+      res = await fetchImpl(`${baseUrl}${path}`, request);
+    } catch (err) {
+      // Report the timeout as the gateway timeout it is, so a `load` renders the
+      // error page for a slow backend instead of surfacing a bare DOMException.
+      if (timeout?.aborted) {
+        throw new ApiError(504, `The API did not answer within ${timeoutMs}ms: ${path}`);
+      }
+      throw err;
+    }
     if (!res.ok) {
       throw await toApiError(res);
     }

--- a/web/src/lib/server/api.ts
+++ b/web/src/lib/server/api.ts
@@ -14,5 +14,19 @@ import { createApi } from '$lib/api';
  *  cookies, so the session cookie is forwarded explicitly when provided. Public
  *  reads can omit it. */
 export function serverApi(fetchImpl: typeof fetch, cookie?: string | null) {
-  return createApi(fetchImpl, env.API_INTERNAL_URL ?? '', cookie ? { cookie } : {});
+  return createApi(fetchImpl, env.API_INTERNAL_URL ?? '', cookie ? { cookie } : {}, timeoutMs());
+}
+
+/** How long a server-side API call may take before it is aborted. Every SSR call is
+ *  a page waiting to render, so this is deliberately far below nginx's 60s
+ *  `proxy_read_timeout`: a `load` that outlives that deadline has already lost its
+ *  reader, and left unbounded it holds its socket open indefinitely. Enough such
+ *  sockets fill the accept queue and the SSR process stops answering at all — the
+ *  outage of 2026-08-01, where nginx returned 504 while the node held 499 sockets in
+ *  CLOSE-WAIT. `SSR_API_TIMEOUT_MS` overrides it if a slow endpoint ever needs room. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function timeoutMs(): number {
+  const configured = Number(env.SSR_API_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_TIMEOUT_MS;
 }


### PR DESCRIPTION
## The outage this fixes

On 2026-08-01 prod returned 504 to ~520 requests, almost all of them Googlebot crawling `/jobs/:slug`. The API was healthy throughout — `/health` answered in 3 ms. The SSR node was not:

```
ss -ltn                     → Recv-Q 500 / backlog 511
ss -tn state close-wait     → 499 sockets
```

nginx gives up at its default `proxy_read_timeout` of 60 s and returns 504. **Node never closes its side** — the handler is still notionally running. Those sockets sit in `CLOSE-WAIT` forever, the accept queue fills, and the process stops answering *anything*. Restarting `freehire-web@blue` cleared it instantly and 504s stopped — which is the tell that the problem was accumulated state, not load.

## Why it could happen at all

`web/src/lib/api.ts` had no deadline on any call. A request that neither returns nor errors leaves its `load` pending indefinitely.

## The fix

The deadline goes where the module already touches fetch — `call()`, the single funnel every endpoint goes through — so no call site can forget it. Same shape as the sanitizer seam on the Go side.

It is armed **only for the server client** (`$lib/server/api`). The browser client stays unbounded on purpose: it drives the LLM-backed calls (fit analysis, tailoring) that legitimately run for minutes. I verified no SSR `load` calls those — `grep` over the 24 `serverApi` call sites finds no `runMatchAnalysis`/`tailor`/`runATSReview`.

A timeout surfaces as `ApiError(504)`, not a bare `DOMException`, so a slow backend renders the error page instead of an unhandled rejection.

**10 s by default.** An SSR call is a page waiting to render; one that outlives that has already lost its reader, and it sits far below nginx's 60 s so the handler loses the race deliberately rather than by accident. `SSR_API_TIMEOUT_MS` is the release valve.

## Tests

Four, in a new `api.test.ts`:

- a hung call fails with `ApiError(504)` instead of hanging
- no timeout configured (browser) → no signal is attached
- timeout configured → signal is armed
- the rest of the init (method, body) survives — the signal is *added*, not substituted

`vitest run` — 739 tests pass. `svelte-check` clean on the touched files.

## Not in this PR

A watchdog on Recv-Q would be the belt to this PR's braces — worth doing if anything else ever manages to wedge a handler.