### PR TITLE
Describe the mechanisms the code actually has

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Worker gotchas (`go run ./cmd/<name>`, all need `DATABASE_URL`; run `ls cmd/` fo
 - `enrich` / `tg-extract` — need `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL`.
 - `embed` / `rollup-facets` / `reindex-companies` — need `MEILI_URL` / `MEILI_MASTER_KEY`.
 - `backfill-derive` — re-derives every deterministic column (facets, `role_fingerprint`, slugs) in one keyset pass; `BACKFILL_CONCURRENCY` tunes the pool. Follow with `make reindex` — it collapses newly-clustered reposts and unions their geography.
-- `reindex-companies` and `rollup-views` hold their own flock. **Never stack `reindex-companies` with `make reindex`** — Meilisearch deadlocks.
+- **Nothing holds a flock** — `grep flock` finds none in Go and none in the systemd units. What keeps a cron worker from stacking on itself is systemd: a `Type=oneshot` unit will not start a second instance while the first is active. That protects the TIMER path only, so a run started by hand has no lock at all. **Never stack `reindex-companies` with `make reindex`** — Meilisearch deadlocks, and nothing will stop you. Two workers additionally take a Postgres advisory lock (`cmd/liveness`, `cmd/ghost-crosscheck`); their keys are listed in `internal/migrate`.
 - `prune` — the **only** hard-delete path. Dry-run by default; archives every removal to `pruned_jobs`.
 
 ## Module files

--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -37,6 +37,23 @@
 // those facets for the dictionary-derived majority. A boardless adapter like
 // getmatch re-supplies the structured facets on its next full crawl.
 //
+// Regions and cities go the same way, and they are the case the sentence above does NOT cover:
+// a moderator- or submission-authored vacancy may STATE them (internal/moderation passes them as
+// authoritative structured geography), and this command re-derives both from the free-text
+// location — which for such a row usually yields nothing. Unlike getmatch, a manual job is never
+// crawled again, so nothing restores them.
+//
+// That is deliberate rather than an oversight, and it is not this command's decision to make
+// alone: internal/moderation's own edit path already re-derives every facet from content and
+// passes no structured overrides, so ANY moderator edit — a title typo fix — does the same thing.
+// The project treats stored geography as re-derivable. Measured on production 2026-08-02, the
+// blast radius is seven manually-authored rows, all of which still carry regions.
+//
+// If that ever stops being the intent, the fix is in BOTH places at once (skip the two columns
+// for `created_by IS NOT NULL` rows in UpdateJobDerived, and stop blanking them in moderation),
+// never in one — two doors disagreeing about whether stated geography survives is worse than
+// either answer.
+//
 // When a slug moves (a deliberate slug-builder change), the run re-keys the companies
 // catalogue afterwards (SyncCompaniesFromJobs + DeleteOrphanCompanies), exactly as the
 // former cmd/reslug did. Follow the run with a reindex (make reindex), whose

--- a/cmd/ghost-crosscheck/main.go
+++ b/cmd/ghost-crosscheck/main.go
@@ -42,7 +42,7 @@ const (
 	// would not corrupt anything, but they would double the read load for no gain
 	// and interleave their reports into nonsense. A run that cannot take the lock
 	// exits cleanly. Arbitrary constant unique to this worker.
-	lockKey = 0x66686763 // "fhgc" — freehire ghost crosscheck
+	lockKey = 0x66686763 // "fhgc" — freehire ghost crosscheck; the key list lives in internal/migrate
 	// sampleSize is how many stamped titles a dry run prints. A report is read by a
 	// person deciding whether to open the gate, and they need examples, not a count.
 	sampleSize = 25

--- a/cmd/liveness/main.go
+++ b/cmd/liveness/main.go
@@ -42,7 +42,7 @@ const (
 	// orphan seconds apart would collapse the "two consecutive expired reads" grace
 	// into one burst — closing a job on a transient blip. A second run that can't take
 	// the lock exits cleanly. The value is an arbitrary constant unique to this worker.
-	lockKey = 0x66686c76 // "fhlv" — freehire liveness
+	lockKey = 0x66686c76 // "fhlv" — freehire liveness; the key list lives in internal/migrate
 )
 
 // unprobableSources are open-job sources excluded from the probe on top of the ATS

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -35,9 +35,16 @@ import (
 // safe only if such files are written idempotently (IF NOT EXISTS / IF EXISTS).
 const noTxMarker = "migrate: no-transaction"
 
-// advisoryLockKey serializes concurrent migrate runs (e.g. a deploy racing a
-// cron-triggered run). Arbitrary but stable — it only needs to not collide with
-// other advisory-lock users, and the project has none.
+// advisoryLockKey serializes concurrent migrate runs (e.g. a deploy racing a cron-triggered
+// run). Arbitrary but stable — it only needs to not collide with the project's other
+// advisory-lock users, which is the list a fourth one should read before picking its own:
+//
+//	728391      internal/migrate     — this one, a blocking pg_advisory_lock
+//	0x66686c76  cmd/liveness         — "fhlv", a non-blocking pg_try_advisory_lock
+//	0x66686763  cmd/ghost-crosscheck — "fhgc", likewise
+//
+// The comment here used to say "the project has none", which stopped being true when those two
+// arrived and left the only place anyone would look asserting there was nothing to collide with.
 const advisoryLockKey int64 = 728391
 
 // lockTimeout bounds how long a migration may WAIT for a lock. It does not bound how long a

--- a/openspec/changes/docs-describe-the-real-mechanism/.openspec.yaml
+++ b/openspec/changes/docs-describe-the-real-mechanism/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/docs-describe-the-real-mechanism/proposal.md
+++ b/openspec/changes/docs-describe-the-real-mechanism/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Catalogue **#16** and **#32**, both verdict *overstated*, and both the same shape once the
+overstatement is stripped away: **an operational document describing a mechanism the code does not
+have.** That is the most expensive kind of wrong comment, because a reader trusts it and stops
+looking — six of the twenty shortlist findings turned out to be exactly this.
+
+**#32.** `internal/migrate` says its lock key "only needs to not collide with other advisory-lock
+users, and the project has none". There are two: `cmd/liveness` (`0x66686c76`) and
+`cmd/ghost-crosscheck` (`0x66686763`). The one place a fourth worker would look asserted there was
+nothing to collide with.
+
+`CLAUDE.md` says "`reindex-companies` and `rollup-views` hold their own flock". **Verified on
+production: there is no flock — not in Go, not in the systemd units.** What actually serializes a
+cron worker against itself is systemd (`Type=oneshot` will not start a second instance while the
+first is active), which protects the *timer* path only. A run started by hand has no lock at all —
+and that is precisely the basis of the "never stack `reindex-companies` with `make reindex`"
+warning, which the flock story obscured.
+
+**#16.** `cmd/backfill-derive` re-derives regions and cities from free-text location, blanking the
+structured geography a moderator stated. Its header enumerates what is deliberately not preserved
+and omits those two.
+
+## What Changes
+
+Documentation only — no behaviour, no code path.
+
+- `internal/migrate` lists all three advisory-lock keys, with what each is and whether it blocks,
+  so the fourth has somewhere to read. Both other sites point at that list.
+- `CLAUDE.md` states what actually serializes cron workers, and that a manual run is unprotected.
+- `cmd/backfill-derive` records that regions/cities go the same way as the other structured
+  facets, that this is **not this command's decision alone** — `internal/moderation`'s edit path
+  already re-derives every facet and passes no overrides, so a title typo fix does the same thing
+  — and what the measured blast radius is.
+
+## The measurement is the point of #16
+
+Rather than argue about whether stated geography should be durable, I measured it on production:
+**7 manually-authored rows, all 7 still carrying regions.** That settles proportionality — this is
+a decision to write down, not a data-integrity incident. The note also says where the fix would go
+if the intent ever changes: **both** doors at once, never one.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — documentation only. `tasks.md` is the real artifact; archives with `--skip-specs`.
+
+## Impact
+
+- `internal/migrate/migrate.go`, `cmd/liveness/main.go`, `cmd/ghost-crosscheck/main.go`,
+  `cmd/backfill-derive/main.go`, `CLAUDE.md`.
+- **Not done, per the findings' own advice:** no `worker.TryAdvisoryLock` (optional at two
+  callers, and `worker` pulls config/database/observability that the migration runner must not
+  import), and no shared lock-key package (three constants do not earn one — the list earns a
+  place to be read, which is what they got).

--- a/openspec/changes/docs-describe-the-real-mechanism/tasks.md
+++ b/openspec/changes/docs-describe-the-real-mechanism/tasks.md
@@ -1,0 +1,22 @@
+## 1. Check each claim against the world, not the finding
+
+- [x] 1.1 #32's flock claim: grep Go, then read the actual systemd units on production. `flock`
+      appears in neither — but systemd's oneshot serialization does the job for timer-started
+      runs, which is a better correction than deleting the sentence.
+- [x] 1.2 #32's "the project has none": enumerate the real advisory-lock users and their keys.
+- [x] 1.3 #16's erasure: measure it on production rather than reason about it — 7 manual rows,
+      all 7 still carrying regions.
+
+## 2. Put each fact where someone will read it
+
+- [x] 2.1 The lock-key list in `internal/migrate`, with both other sites pointing at it.
+- [x] 2.2 `CLAUDE.md`: what serializes cron workers, and that a manual run is unprotected.
+- [x] 2.3 `cmd/backfill-derive`: regions/cities are re-derived like the other structured facets,
+      it is not this command's decision alone, the measured radius, and where the fix goes if the
+      intent changes — both doors, never one.
+
+## 3. Verify and close
+
+- [x] 3.1 `go build`, `go vet`, `go test ./...` and `-tags=integration` — comment-only, but the
+      claims are about code that must still compile and pass.
+- [x] 3.2 Mark #16 and #32 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
Catalogue **#16** and **#32** — both verdict *overstated*, and both the same shape once the
overstatement is stripped away: **an operational document describing a mechanism the code does not
have.** That is the most expensive kind of wrong comment, because a reader trusts it and stops
looking. Six of the twenty shortlist findings turned out to be exactly this.

Documentation only. No behaviour, no code path.

## #32 — two claims, both checked against the world

**"the project has none."** `internal/migrate` said its lock key "only needs to not collide with
other advisory-lock users, and the project has none". There are two — `cmd/liveness`
(`0x66686c76`) and `cmd/ghost-crosscheck` (`0x66686763`). The one place a fourth worker would look
asserted there was nothing to collide with. All three are listed there now, with what each is and
whether it blocks; both other sites point at the list.

**"hold their own flock."** `CLAUDE.md` said `reindex-companies` and `rollup-views` do. I checked
Go *and then read the actual systemd units on production*:

```
$ grep flock  → none in Go
$ systemctl cat "freehire-*" | grep -c flock  → 0
```

There is no flock. What serializes a cron worker against itself is **systemd**: a `Type=oneshot`
unit will not start a second instance while the first is active — which protects the **timer**
path only. **A run started by hand has no lock at all**, and that is precisely the basis of the
"never stack `reindex-companies` with `make reindex`" warning that the flock story obscured.

That is a better correction than deleting the sentence, and it is why I read the units instead of
stopping at the grep the finding cited.

## #16 — measured instead of argued

`cmd/backfill-derive` re-derives regions and cities from free-text location, blanking the
structured geography a moderator stated, and its header enumerates what it deliberately does not
preserve while omitting those two.

Rather than debate whether stated geography should be durable, I measured it on production:

```
manual rows: 7   |   manual rows with no regions: 0
```

**Seven rows, all seven still carrying regions.** That settles proportionality — this is a
decision to write down, not a data-integrity incident.

The note also records that it is **not this command's decision alone**: `internal/moderation`'s
edit path already re-derives every facet and passes no structured overrides, so a moderator fixing
a title typo does the same thing today. And it says where the fix goes if the intent ever changes
— **both doors at once**, because two doors disagreeing about whether stated geography survives is
worse than either answer.

## Not done, per the findings' own advice

No `worker.TryAdvisoryLock` — optional at two callers, and `worker` pulls config/database/
observability that the migration runner must not import. No shared lock-key package — three
constants do not earn one; what they needed was a place to be *read*, which is what they got.

`go build`, `go vet`, `go test ./...` and `-tags=integration` all green: comment-only, but the
claims are about code that must still compile and pass.
