### PR TITLE
feat(sources): onboard 116 own-ATS boards from the ungated providers

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7510,3 +7510,59 @@
   board: lark
 - company: Meliora Academy
   board: meliora-academy
+- company: 5Blue Software
+  board: 5bluesoftware
+- company: Amplify
+  board: amplify
+- company: Berlitz
+  board: berlitz
+- company: Colibri Group
+  board: colibri-group
+- company: Collider
+  board: collider
+- company: DDN
+  board: ddn
+- company: Eastwood & Cleef, LLC
+  board: eastwoodcleef
+- company: Ediphi
+  board: ediphi
+- company: FYST
+  board: fyst
+- company: GlossGenius
+  board: glossgenius
+- company: Hamster Garage
+  board: hamstergarage
+- company: Hire Digital
+  board: hiredigital
+- company: iSpeedtoLead
+  board: ispeedtolead
+- company: Menlo
+  board: menlo
+- company: Midnite
+  board: midnite
+- company: Novidea
+  board: novidea
+- company: Paires
+  board: paires
+- company: Plenful
+  board: plenful
+- company: Raintree Systems
+  board: raintree-systems
+- company: Reactive Markets
+  board: reactivemarkets
+- company: Revecore
+  board: revecore
+- company: Seekeasy
+  board: seekeasy
+- company: TBC Corporation
+  board: tbc
+- company: True Classic Tees LLC
+  board: true-classic-tees
+- company: Visier
+  board: visier
+- company: Whiskey Library
+  board: whiskeylibrary
+- company: Wonderly
+  board: wonderly
+- company: Zego
+  board: zego

--- a/sources/deel.yml
+++ b/sources/deel.yml
@@ -130,3 +130,7 @@
   board: vev-services-limited
 - company: Zonos
   board: zonos
+- company: PTV Logistics
+  board: ptv-logistics
+- company: Talent
+  board: talent

--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -438,3 +438,19 @@
   board: propel
 - company: EdgeTrace
   board: edgetrace-ai
+- company: Chef Robotics
+  board: chef-robotics
+- company: Clipster
+  board: clipster
+- company: GrowthBook
+  board: growthbook
+- company: Mesh
+  board: mesh
+- company: MindTech
+  board: mindtech
+- company: Nimble
+  board: nimble
+- company: SoundHound Inc.
+  board: soundhound
+- company: Taro
+  board: taro

--- a/sources/hireology.yml
+++ b/sources/hireology.yml
@@ -4954,3 +4954,7 @@
   board: zotabeachresort
 - company: Mosaic Auto Group
   board: zumbrotaford
+- company: Artis Senior Living
+  board: artisseniorliving
+- company: Harley-Davidson
+  board: harleydavidson

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8125,3 +8125,127 @@
   board: zoomdrainindianapolis
 - company: zuum
   board: zuum
+- company: 83BAR
+  board: 83bar
+- company: acre security
+  board: acresecurity
+- company: Aequilibrium
+  board: aequilibrium
+- company: Airitos
+  board: airitos
+- company: Alia Services
+  board: aliaservices
+- company: Ark Financial
+  board: arkfinancial
+- company: AttackIQ
+  board: attackiq
+- company: Autism Diagnosis Group
+  board: autismdiagnosisgroup
+- company: Beyond Type 1
+  board: beyondtype1
+- company: Bureau Veritas
+  board: bureauveritas
+- company: Buyerlink
+  board: buyerlink
+- company: Capio Group
+  board: capiogroup
+- company: Celeste
+  board: celeste
+- company: Christianson PLLP
+  board: christiansonpllp
+- company: CID Design Group
+  board: ciddesigngroup
+- company: Clark Creative Solutions
+  board: clarkcreativesolutions
+- company: ClearGov
+  board: cleargov
+- company: ClearStar
+  board: clearstar
+- company: CME
+  board: cme
+- company: Collider
+  board: collider
+- company: Cytovale
+  board: cytovale
+- company: Data Meaning
+  board: datameaning
+- company: Dauntless Discovery
+  board: dauntlessdiscovery
+- company: DecisionPoint Corporation
+  board: decisionpoint
+- company: demandDrive
+  board: demanddrive
+- company: DREAMLABS
+  board: dreamlabs
+- company: Dwight School
+  board: dwightschool
+- company: Dynatron Software
+  board: dynatronsoftware
+- company: Elephant Teams
+  board: elephantteams
+- company: Empower Project
+  board: empowerproject
+- company: Enjoin
+  board: enjoin
+- company: ENO8
+  board: eno8
+- company: eSentio
+  board: esentio
+- company: Expert Link
+  board: expertlink
+- company: FocusKPI
+  board: focuskpi
+- company: Furnished Finder
+  board: furnishedfinder
+- company: Geo Owl
+  board: geoowl
+- company: George Jon
+  board: georgejon
+- company: Gray Hawk Land Solutions
+  board: grayhawklandsolutions
+- company: Greenhouse Agency
+  board: greenhouseagency
+- company: Helium SEO
+  board: heliumseo
+- company: Here Now Health
+  board: herenowhealth
+- company: Hobbs Madison
+  board: hobbsmadison
+- company: Home Instead
+  board: homeinstead
+- company: Huntress Talent
+  board: huntresstalent
+- company: Idea Evolver
+  board: ideaevolver
+- company: Idera, Inc.
+  board: idera
+- company: InAir
+  board: inair
+- company: Indigo Slate
+  board: indigoslate
+- company: Industrial Electric Manufacturing
+  board: industrialelectricmanufacturing
+- company: iPromo
+  board: ipromo
+- company: Jets.com
+  board: jetscom
+- company: K2 Services
+  board: k2services
+- company: Legacy HR Consulting
+  board: legacyhrconsulting
+- company: Leggett & Platt
+  board: leggettplatt
+- company: Leverify
+  board: leverify
+- company: Lexipol LLC
+  board: lexipol
+- company: Life Science Connect
+  board: lifescienceconnect
+- company: Living Goods
+  board: livinggoods
+- company: Longbow Advantage
+  board: longbowadvantage
+- company: LTD Global
+  board: ltdglobal
+- company: Xpanxion
+  board: xpanxion

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4415,3 +4415,31 @@
   board: jupiterintel
 - company: Modern Intelligence
   board: ModernIntelligence
+- company: America At Work
+  board: americaatwork
+- company: Arbitrum OpCo
+  board: arbitrum-opco
+- company: Arvor Insurance
+  board: arvor-insurance
+- company: Audinate
+  board: audinate
+- company: Big Health
+  board: bighealth
+- company: career
+  board: career
+- company: Find.co
+  board: find
+- company: GTI Fabrication
+  board: gtifabrication
+- company: HealthMark Group
+  board: healthmark-group
+- company: Hevo
+  board: hevo
+- company: ifeel
+  board: ifeel
+- company: Tali AI
+  board: tali-ai
+- company: Thimble
+  board: thimble
+- company: WEP Clinical
+  board: wepclinical


### PR DESCRIPTION
Second harvest pass over the same 15,617 candidates from #1419, this time run **on the production host** instead of a laptop.

## That change alone rewrote the picture

| probe | from laptop | from host |
|---|---|---|
| workable, unknown slug | 429 | 404 in 0.18s |
| recruitee, unknown slug | timeout 20s | 404 in 0.11s |
| bamboohr, unknown slug | 302 in 14.7s | 302 in 0.6s |

"Dead subdomains hang to the client timeout" — the reason every previous estimate ran to hours — was a local network artefact. lever and ashby each answered all 15.5k candidates in about two minutes.

## What committed

| provider | boards |
|---|---:|
| jazzhr | 62 |
| ashby | 28 |
| lever | 14 |
| gem | 8 |
| deel | 2 |
| hireology | 2 |

116 boards. `go test ./internal/sources/` passes.

## These are ungated, and were reviewed as such

None of these platforms publishes an employer name, so the corroboration gate from #1413 cannot fire and each board was kept on liveness alone. The risk that leaves is a short slug belonging to a different company — the iCIMS `prequel` shape.

The eight shortest ids in the diff are `cme`, `ddn`, `tbc`, `find`, `mesh`, `eno8`, `fyst`, `hevo`. Every one belongs to a company whose name really is that short (CME, DDN, TBC Corporation, Find.co, Mesh, ENO8, FYST, Hevo), and three were fetched live to confirm the boards serve that company's postings.

## What is deliberately absent

Ten providers found boards and could not commit them:

- **Refused by the platform** — workable (15,466 refused vs 53 answered), traffit (15,467 vs 0), bamboohr (14,079 vs 283), jobvite (11,463 vs 4,153), personio (8,068 vs 51), recruitee (7,960 vs 225).
- **Descriptor ceiling** — breezy, trakstar, pinpoint, freshteam, isolvedhire, applicantpro, careerplug all stopped at ~8,185 answers with their findings unwritten. My error: the `ulimit` raise landed after the shell had already started, so the whole pass ran at 8192. Re-running now.

Both classes exit non-zero and write nothing. That is the point of #1455 — this file is what the harvest **established**, not what it partly saw. Before that change, workable's run alone would have committed 3 boards and reported success while being blind to 99.7% of its candidates.
