### PR TITLE
feat(sources): onboard 348 boards from the re-run, minus two providers' demo tenants

### DIFF
--- a/sources/applicantpro.yml
+++ b/sources/applicantpro.yml
@@ -3950,3 +3950,13 @@
   board: tyonekjobs
 - company: waynecountygovernment
   board: waynecountygovernment
+- company: Aaron's, LLC
+  board: aarons
+- company: Electric Power Systems
+  board: electricpowersystems
+- company: NEXA
+  board: nexa
+- company: Starkey
+  board: starkey
+- company: Talent
+  board: talent

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -3651,3 +3651,191 @@
   board: goate-lab
 - company: NicePlay Games
   board: niceplay-games
+- company: 1perTInent
+  board: 1pertinent
+- company: 20four7VA
+  board: 20four7va
+- company: 360dialog
+  board: 360dialog
+- company: Accordus
+  board: accordus
+- company: AdNet AccountNet, Inc.
+  board: adnet-accountnet-inc
+- company: AEFIS
+  board: aefis
+- company: Aion
+  board: aion
+- company: American Logistics Authority
+  board: american-logistics-authority
+- company: Amuse
+  board: amuse
+- company: Anka
+  board: anka
+- company: Argus Medical Management, LLC
+  board: argus-medical-management-llc
+- company: Arpio
+  board: arpio
+- company: Artemis Connection
+  board: artemis-connection
+- company: Assignar
+  board: assignar
+- company: Bellhop
+  board: bellhop
+- company: BetterMynd
+  board: bettermynd
+- company: Bettersource
+  board: bettersource
+- company: Blenderbox
+  board: blenderbox
+- company: BusPlanner
+  board: busplanner
+- company: Cabin
+  board: cabin
+- company: career
+  board: career
+- company: Christopher O'Keeffe CPA LLC
+  board: christopher-o-keeffe-cpa-llc
+- company: Climavision
+  board: climavision
+- company: Cloudasta
+  board: cloudasta
+- company: CloudCure
+  board: cloudcure
+- company: Codeminders
+  board: codeminders
+- company: Collectiv
+  board: collectiv
+- company: Compose.ly
+  board: compose-ly
+- company: Cybervance
+  board: cybervance
+- company: DeepAR
+  board: deepar
+- company: Drips
+  board: drips
+- company: EdOps
+  board: edops
+- company: Elafent
+  board: elafent
+- company: Eleken
+  board: eleken
+- company: Fivestaff
+  board: fivestaff
+- company: GhangorCloud
+  board: ghangorcloud
+- company: Good Life Sorted
+  board: good-life-sorted
+- company: GroupSolver
+  board: groupsolver
+- company: Herbal Goodness
+  board: herbal-goodness
+- company: Inspire
+  board: inspire
+- company: Inspiring Lives Today
+  board: inspiring-lives-today
+- company: Jabu
+  board: jabu
+- company: JWay Group
+  board: jway-group
+- company: Kimmel & Associates
+  board: kimmel-associates
+- company: Kindred Bravely
+  board: kindred-bravely
+- company: Linkserve Solutions BPO Inc.
+  board: linkserve-solutions-bpo-inc
+- company: LURECRUITER
+  board: lurecruiter
+- company: Modern Pediatrics
+  board: modern-pediatrics
+- company: MTM LLC
+  board: mtm-llc
+- company: Newfangled Studios
+  board: newfangled-studios
+- company: Nexist
+  board: nexist
+- company: NuBinary
+  board: nubinary
+- company: Open Mind Health
+  board: openmindhealth
+- company: OptiMindHealth
+  board: optimindhealth
+- company: OurAssistants
+  board: ourassistants
+- company: Ownify
+  board: ownify
+- company: PeopleFluent
+  board: peoplefluent
+- company: Pillr Health
+  board: pillrhealth
+- company: Pixery
+  board: pixery
+- company: Procentrix
+  board: procentrix
+- company: Replayed
+  board: replayed
+- company: ResultStack
+  board: resultstack
+- company: Revelo Talent Corp
+  board: revelo-talent-corp
+- company: Rooted Talent Solutions
+  board: rooted-talent-solutions
+- company: Routeware, Inc
+  board: routeware-inc
+- company: Sage Haus
+  board: sage-haus
+- company: Salesberry Group
+  board: salesberry-group
+- company: SalesRabbit
+  board: salesrabbit
+- company: Savvital
+  board: savvital
+- company: SD Solutions
+  board: sd-solutions
+- company: Serv Recruitment Agency
+  board: serv-recruitment-agency
+- company: SMDigital
+  board: smdigital
+- company: SnappyCX
+  board: snappycx
+- company: Snipebridge
+  board: snipebridge
+- company: Software Secured
+  board: software-secured
+- company: Sourcefit
+  board: sourcefit
+- company: SpeedlineHub
+  board: speedlinehub
+- company: StartupBlink
+  board: startupblink
+- company: The Dyrt
+  board: the-dyrt
+- company: Thirdwave
+  board: thirdwave
+- company: Tuva
+  board: tuva
+- company: Tuyo
+  board: tuyo
+- company: Under Armour
+  board: under-armour
+- company: Unio Digital
+  board: unio-digital
+- company: Uptech
+  board: uptech
+- company: Urrly
+  board: urrly
+- company: Vanguard-IP
+  board: vanguard-ip
+- company: Vector Trading
+  board: vector-trading
+- company: Verified First
+  board: verified-first
+- company: Voyage Foods
+  board: voyage-foods
+- company: Whym
+  board: whym
+- company: WMC
+  board: wmc
+- company: WRSTBND
+  board: wrstbnd
+- company: YiYiEnglish
+  board: yiyienglish

--- a/sources/freshteam.yml
+++ b/sources/freshteam.yml
@@ -378,3 +378,41 @@
   board: zetpy
 - company: zolve
   board: zolve
+- company: 1perTInent
+  board: 1pertinent
+- company: Avomind
+  board: avomind
+- company: darwinhomes
+  board: darwinhomes
+- company: ELVTR
+  board: elvtr
+- company: Firefly
+  board: firefly
+- company: Impact
+  board: impact
+- company: Impact BPO
+  board: impactbpo
+- company: Kalam
+  board: kalam
+- company: MapTiler
+  board: maptiler
+- company: Mesh
+  board: mesh
+- company: Mind
+  board: mind
+- company: Ottimate
+  board: ottimate
+- company: PhillyTech.Co
+  board: phillytech
+- company: Purple Rain
+  board: purplerain
+- company: '&samhoud'
+  board: samhoud
+- company: Seer
+  board: seer
+- company: strikingly
+  board: strikingly
+- company: Terra
+  board: terra
+- company: Watermark Insights
+  board: watermarkinsights

--- a/sources/isolvedhire.yml
+++ b/sources/isolvedhire.yml
@@ -4404,3 +4404,7 @@
   board: stonebriarautoservices
 - company: veteransplaceusa
   board: veteransplaceusa
+- company: Home Instead
+  board: homeinstead
+- company: Village Capital
+  board: villagecapital

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1046,3 +1046,319 @@
   board: valtasgroup
 - company: vuopartners
   board: vuopartners
+- company: AapKaPainter
+  board: aapkapainter
+- company: Ad Results Media
+  board: adresultsmedia
+- company: Aflac
+  board: aflac
+- company: American Family Insurance
+  board: americanfamilyinsurance
+- company: Aramark
+  board: aramark
+- company: Aston Carter
+  board: astoncarter
+- company: Atos
+  board: atos
+- company: Big Minds, Tiny Hands
+  board: bigmindstinyhands
+- company: Black Pen Recruitment
+  board: blackpenrecruitment
+- company: Bosch
+  board: bosch
+- company: Branching Minds
+  board: branchingminds
+- company: Bridgit
+  board: bridgit
+- company: Brighton Science
+  board: brightonscience
+- company: Canon
+  board: canon
+- company: career
+  board: career
+- company: Charterhouse
+  board: charterhouse
+- company: CIS College
+  board: ciscollege
+- company: ClearStar
+  board: clearstar
+- company: CloudFactory
+  board: cloudfactory
+- company: 'Coalition Technologies '
+  board: coalitiontechnologies
+- company: Conifer
+  board: conifer
+- company: Contently
+  board: contently
+- company: CosmoProf
+  board: cosmoprof
+- company: Darwinbox
+  board: darwinbox
+- company: DataBank
+  board: databank
+- company: Digital
+  board: digital
+- company: DigitalOnUs
+  board: digitalonus
+- company: Dimagi, Inc.
+  board: dimagi
+- company: Education Northwest
+  board: educationnorthwest
+- company: Ellevation Education
+  board: ellevationeducation
+- company: Engine Digital
+  board: enginedigital
+- company: Envato
+  board: envato
+- company: E-SPACE
+  board: espace
+- company: Excel
+  board: excel
+- company: Farmers
+  board: farmers
+- company: Fever
+  board: fever
+- company: Finance active
+  board: financeactive
+- company: Find.co
+  board: find
+- company: First Student
+  board: firststudent
+- company: Flinks
+  board: flinks
+- company: Future PLC
+  board: future
+- company: George Jon
+  board: georgejon
+- company: Guardian
+  board: guardian
+- company: Hargreaves Lansdown
+  board: hargreaveslansdown
+- company: Hedgehog Lab
+  board: hedgehoglab
+- company: Hired
+  board: hired
+- company: HireVue Inc
+  board: hirevue
+- company: Hyphen
+  board: hyphen
+- company: ICANotes
+  board: icanotes
+- company: iFLIP4
+  board: iflip4
+- company: IJL Select
+  board: ijlselect
+- company: Infinity Group
+  board: infinitygroup
+- company: Infosys Limited
+  board: infosys
+- company: Innovaccer
+  board: innovaccer
+- company: Inspectorio
+  board: inspectorio
+- company: Intel Corporation
+  board: intel
+- company: intellect
+  board: intellect
+- company: Irex Consulting
+  board: irexconsulting
+- company: Island
+  board: island
+- company: iTutor
+  board: itutor
+- company: Jeeves
+  board: jeeves
+- company: Jones
+  board: jones
+- company: JumpstartMD
+  board: jumpstartmd
+- company: Justworks, Inc.
+  board: justworks
+- company: Kaizen
+  board: kaizen
+- company: King Law Offices
+  board: kinglawoffices
+- company: kWallet
+  board: kwallet
+- company: Magnum
+  board: magnum
+- company: Manila Recruitment
+  board: manilarecruitment
+- company: Marco
+  board: marco
+- company: MAX & TAX
+  board: maxtax
+- company: Meet Cute
+  board: meetcute
+- company: Méliuz
+  board: meliuz
+- company: Milestone
+  board: milestone
+- company: Mind
+  board: mind
+- company: mindbodygreen
+  board: mindbodygreen
+- company: Mindlance
+  board: mindlance
+- company: Mine
+  board: mine
+- company: Moosylvania
+  board: moosylvania
+- company: Moravia
+  board: moravia
+- company: Motif
+  board: motif
+- company: Motive International
+  board: motiveinternational
+- company: Moving Walls
+  board: movingwalls
+- company: MP Solutions Ltd.
+  board: mpsolutions
+- company: Multi Media LLC
+  board: multimedia
+- company: Nebo Agency
+  board: neboagency
+- company: New Perspective
+  board: newperspective
+- company: Nexun GmbH
+  board: nexun
+- company: NEXUS AG
+  board: nexus
+- company: NGP VAN
+  board: ngpvan
+- company: Nimble
+  board: nimble
+- company: North American Bancard
+  board: northamericanbancard
+- company: nterra
+  board: nterra
+- company: Oddup
+  board: oddup
+- company: Oliva
+  board: oliva
+- company: Open Labs
+  board: openlabs
+- company: Penbrothers
+  board: penbrothers
+- company: Penn Foster
+  board: pennfoster
+- company: People Corporation
+  board: people
+- company: Pilot
+  board: pilot
+- company: Pinpoint
+  board: pinpoint
+- company: Pipe
+  board: pipe
+- company: Pitchbox
+  board: pitchbox
+- company: Planate Management Group
+  board: planatemanagementgroup
+- company: Plum Inc
+  board: plum
+- company: PopuTrust
+  board: poputrust
+- company: Port
+  board: port
+- company: Positively Partners
+  board: positivelypartners
+- company: Premier Inc.
+  board: premier
+- company: PRISM+
+  board: prism
+- company: Proficio
+  board: proficio
+- company: Prominence Advisors
+  board: prominenceadvisors
+- company: Provide
+  board: provide
+- company: Purple Rain
+  board: purplerain
+- company: Reach Game Studios Pty. Ltd.
+  board: reachgamestudios
+- company: Redpanda
+  board: redpanda
+- company: Relevate Health
+  board: relevatehealth
+- company: Renaissance
+  board: renaissance
+- company: Rhodes Wolfe
+  board: rhodeswolfe
+- company: rtCamp
+  board: rtcamp
+- company: Salesloft
+  board: salesloft
+- company: Satori
+  board: satori
+- company: Schnabel Engineering
+  board: schnabelengineering
+- company: Scopic
+  board: scopic
+- company: SD Solutions
+  board: sdsolutions
+- company: Signal Vine, Inc
+  board: signalvine
+- company: Sika AG
+  board: sika
+- company: STAFFVIRTUAL
+  board: staffvirtual
+- company: Stefanini
+  board: stefanini
+- company: strategic HR, inc.
+  board: strategichr
+- company: Summit
+  board: summit
+- company: Team Delegate, LLC
+  board: teamdelegate
+- company: Teamswell
+  board: teamswell
+- company: Telstra Health
+  board: telstrahealth
+- company: TELUS International
+  board: telusinternational
+- company: Terex Corporation
+  board: terex
+- company: Terra
+  board: terra
+- company: The Persimmon Group
+  board: thepersimmongroup
+- company: Thought Industries, Inc.
+  board: thoughtindustries
+- company: Tive
+  board: tive
+- company: TOTVS
+  board: totvs
+- company: Trusted
+  board: trusted
+- company: Uniplaces
+  board: uniplaces
+- company: Unit4
+  board: unit4
+- company: Veda
+  board: veda
+- company: Vestmark
+  board: vestmark
+- company: Viaggio Partners, Inc.
+  board: viaggiopartners
+- company: VirtusLab
+  board: virtuslab
+- company: VSolvit
+  board: vsolvit
+- company: Wagepoint
+  board: wagepoint
+- company: WealthForge
+  board: wealthforge
+- company: Web Partners
+  board: webpartners
+- company: Whistle
+  board: whistle
+- company: Workforce Source
+  board: workforcesource
+- company: Xideral
+  board: xideral
+- company: Xtremax
+  board: xtremax
+- company: YOUNG
+  board: young
+- company: Zadara
+  board: zadara


### PR DESCRIPTION
Re-run of the seven providers that phase 2 (#1472) found boards for but could not commit.

## Why they failed

The descriptor ceiling was still 8192 — my `ulimit` raise landed after the shell had already started, so the whole pass inherited the old value. Every per-subdomain provider stopped at ~8,185 answers with its findings unwritten. Re-run at 262144 with a narrower pool, the counts roughly doubled, which is exactly what a run that reached half its candidates looks like:

| provider | truncated | re-run |
|---|---:|---:|
| trakstar | 67 | **158** |
| breezy | 47 | **94** |
| freshteam | 12 | 28 → **19 after filtering** |
| applicantpro | 3 | 6 → **5 after filtering** |
| isolvedhire | 1 | **2** |

348 boards committed.

## Two providers seed sandbox tenants named after prospects

**pinpoint is dropped entirely** — 149 boards, none committed. 14 of 20 sampled serve the identical fixture:

```
accesspartnership   Head of DEI - Belfast
acresecurity        Head of DEI - Belfast
adaptavist          Head of DEI - Belfast
adzuna              Head of DEI - UK
ametek              Head of DEI - Belfast
bosch               Head of DEI - UK
```

An unknown pinpoint slug 404s cleanly, so this is not a catch-all: these are **real accounts with fake content**, created under prospect companies' names. No liveness probe can tell one from a working board, and pinpoint publishes no employer name, so the gate cannot help either. Harvesting pinpoint needs a fixture filter first.

**freshteam** lost 9 of 28 whose only postings are `sample-job-posting` (blueprint, braven, crux, lifetrust, penbrothers, stutzen, summit, trovata, wvi). **applicantpro** lost `celeste` ("Celeste Demo Jobs").

## What breezy tells us about the ungated ones

breezy publishes employer names, so its 94 passed the corroboration gate — which rejected 8:

```
absolute-security  → "Zeus Fire and Security"
eroad              → "Jersey Initiatives Demo"
twelve-consulting  → "Argano"
oscar              → "Oscar Mobility B.V."
```

Roughly an **8% wrong-tenant rate** on a gated provider. That is the first real estimate of what the ungated providers in this and the previous batch carry unchecked, and it is worth stating plainly rather than leaving implied.

## Noted, not fixed

Some trakstar boards' only posting is a test (`test4`, `Test`). The board genuinely belongs to the company, so this is posting-level noise for the pipeline's own quality gates, not a wrong-board problem.

`go test ./internal/sources/` passes.
