### PR TITLE
The fixtures obey the evidence gate production always has

### DIFF
--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -90,9 +90,15 @@ var testCVID = uuid.MustParse("55555555-5555-4555-8555-555555555555")
 // cvToolsAPI wires an API whose CV store serves one document owned by user 3.
 func cvToolsAPI(t *testing.T, doc string) (*assistantHandlers, *cvRepo) {
 	t.Helper()
+	// An EMPTY bank, not a nil gate. Production always constructs the editor with one
+	// (Register passes bankGate{bank}), so a nil gate is a configuration that does not ship
+	// — a fixture using it asserts behaviour nobody can reach. An empty bank is the honest
+	// stand-in: the gate is present and refuses every citation, which is what a user with
+	// nothing banked actually experiences.
 	repo := &cvRepo{id: testCVID, userID: 3, jobID: 9, data: []byte(doc)}
-	editor := cvedit.NewEditor(&memRevisions{cv: repo}, nil)
-	return &assistantHandlers{cv: &cvHandlers{cvStore: cv.NewStore(repo), editor: editor}}, repo
+	bank := newStubBank()
+	editor := cvedit.NewEditor(&memRevisions{cv: repo}, bankGate{bank: bank})
+	return &assistantHandlers{experience: bank, cv: &cvHandlers{cvStore: cv.NewStore(repo), editor: editor}}, repo
 }
 
 // cvToolsAPIWithBank is cvToolsAPI for the cases that exercise the evidence gate. The
@@ -265,11 +271,15 @@ func TestCVGetToolOmitsTheContactBlock(t *testing.T) {
 }
 
 func TestCVEditToolAppliesAPatch(t *testing.T) {
-	a, repo := cvToolsAPI(t, oneExperienceCV)
+	// Through a bank holding what the claim rests on, because the agent must cite: the tool
+	// runs as ActorAgent and production always constructs the editor with the gate.
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
 
 	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
 	_, err := tool.Run(context.Background(), 3, json.RawMessage(
-		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer"}]}`))
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"`+atom.ID.String()+`"}]}`))
 	if err != nil {
 		t.Fatalf("cv_edit: %v", err)
 	}
@@ -413,13 +423,18 @@ func TestCVEditWritesACitedBullet(t *testing.T) {
 // A batch is one entry in the candidate's history and one round of the turn's budget, which
 // is why closing a requirement no longer costs three calls.
 func TestCVEditAppliesAWholeBatchAtOnce(t *testing.T) {
-	a, repo := cvToolsAPI(t, oneExperienceCV)
+	// Every claim-bearing op in the batch cites, because one uncited op refuses the whole
+	// batch — that rule is why a batch is worth testing through the real gate at all.
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Ran the cluster", Provenance: experience.ProvenanceCVImport})
+	id := atom.ID.String()
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
 
 	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
 	_, err := tool.Run(context.Background(), 3, json.RawMessage(
-		`{"ops":[{"kind":"set","path":"summary","value":"Platform engineer"},`+
-			`{"kind":"insert","path":"experience[0].bullets[1]","value":"Ran the cluster"},`+
-			`{"kind":"set","path":"experience[0].company","value":"Acme Corp"}],"note":"under the Kubernetes requirement"}`))
+		`{"ops":[{"kind":"set","path":"summary","value":"Platform engineer","evidence_id":"`+id+`"},`+
+			`{"kind":"insert","path":"experience[0].bullets[1]","value":"Ran the cluster","evidence_id":"`+id+`"},`+
+			`{"kind":"set","path":"experience[0].company","value":"Acme Corp","evidence_id":"`+id+`"}],"note":"under the Kubernetes requirement"}`))
 	if err != nil {
 		t.Fatalf("cv_edit: %v", err)
 	}

--- a/internal/handler/cv_ats_delta_integration_test.go
+++ b/internal/handler/cv_ats_delta_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/cvedit"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/resume"
 )
 
@@ -75,7 +76,7 @@ func newATSDeltaFixture(t *testing.T, pool *pgxpool.Pool) atsDeltaFixture {
 	}}
 	h := &cvHandlers{
 		queries: queries, jobReader: queries, cvStore: store,
-		editor:         cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		editor:         cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
 		resume:         resume.New(nil, resume.NewQueriesRepository(queries)),
 		cvRenderer:     renderer,
 		extractPDFText: textFromPDF,

--- a/internal/handler/cv_gate_rule_test.go
+++ b/internal/handler/cv_gate_rule_test.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoEditorIsConstructedWithoutAnEvidenceGate makes a fixture's configuration answerable to
+// the same rule production obeys.
+//
+// newCVHandlers always receives bankGate{bank} (handler.go), so PATCH /me/cvs/:id edits as the
+// AGENT for any API-key caller and an uncited claim is refused. Fixtures that built the editor
+// with a nil gate were asserting a configuration that does not ship — one of them recorded the
+// divergence in a comment as though it were a decision, and it survived the change that made the
+// gate a constructor argument precisely because it bypassed the constructor.
+//
+// The rule is written against the nil rather than against the assembly because that is the shape
+// the mistake takes: a struct literal with `editor:` set by hand. A fixture that genuinely has no
+// bank should pass an empty one — the gate is then present and refuses, which is what a user with
+// nothing banked actually experiences.
+func TestNoEditorIsConstructedWithoutAnEvidenceGate(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var scanned int
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		text := string(body)
+		if !strings.Contains(text, "cvedit.NewEditor(") {
+			continue
+		}
+		scanned++
+		if strings.Contains(text, ", nil)") && strings.Contains(text, "cvedit.NewEditor(") {
+			for _, line := range strings.Split(text, "\n") {
+				if strings.Contains(line, "cvedit.NewEditor(") && strings.HasSuffix(strings.TrimSpace(line), ", nil)") {
+					t.Errorf("%s constructs an editor with a nil evidence gate: %s\n"+
+						"Production never does — pass bankGate{bank} (an empty bank is fine), or the "+
+						"fixture asserts behaviour nobody can reach.", name, strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("no file constructs an editor — the scan is not seeing the package")
+	}
+}

--- a/internal/handler/cv_integration_test.go
+++ b/internal/handler/cv_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/cvedit"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
 )
@@ -91,7 +92,7 @@ func TestCVTemplatesEndpoint_OpenToAuthed(t *testing.T) {
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
-		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
 	app := buildCVApp(h, iss)
 
@@ -127,7 +128,7 @@ func TestSetCVTemplateEndpoint(t *testing.T) {
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
-		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
 	app := buildCVApp(h, iss)
 
@@ -187,7 +188,7 @@ func TestCVEndpoints_CRUDAndIsolation(t *testing.T) {
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
-		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))} // storage disabled → seed no-ops
 	app := buildCVApp(h, iss)
 
@@ -279,7 +280,7 @@ func TestCVCreate_SeedsFromStructuredResume(t *testing.T) {
 	store := resume.New(nil, resume.NewQueriesRepository(queries))
 	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
-		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil), resume: store}
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}), resume: store}
 	app := buildCVApp(h, iss)
 
 	user := seedAccount(t, pool, "seed@example.test", true)
@@ -320,7 +321,7 @@ func TestCVRevisionHistoryAndUndo(t *testing.T) {
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
-		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
 	app := buildCVApp(h, iss)
 
@@ -411,7 +412,7 @@ func TestTheActorIsNeverReadFromTheRequestBody(t *testing.T) {
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
-		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
 	app := buildCVApp(h, iss)
 
@@ -469,7 +470,7 @@ func TestEveryEntryPointLeavesARevision(t *testing.T) {
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	h := &cvHandlers{queries: queries, jobReader: queries,
 		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
-		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
 		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
 	app := buildCVApp(h, iss)
 

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/cvedit"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/matchanalysis"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
@@ -37,14 +38,19 @@ func newTailorAPI(t *testing.T) (*cvHandlers, *auth.Issuer, *pgxpool.Pool) {
 	pool := startPostgres(t)
 	queries := db.New(pool)
 	if _, err := pool.Exec(context.Background(),
-		"TRUNCATE cvs, users, jobs, user_job_analysis, api_keys, assistant_sessions RESTART IDENTITY CASCADE"); err != nil {
+		"TRUNCATE cvs, users, jobs, user_job_analysis, api_keys, assistant_sessions, experience_employments, experience_atoms RESTART IDENTITY CASCADE"); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	creditsStore := credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3})
 	h := &cvHandlers{queries: queries, jobReader: queries,
-		cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
-		editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), nil),
+		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
+		// The REAL gate, built exactly as Register builds it. A nil gate here would be a
+		// configuration production does not have: newCVHandlers always receives
+		// bankGate{bank}, so an API-key PATCH edits as the agent and an uncited claim is
+		// refused. A fixture asserting otherwise tests nothing that ships.
+		editor: cvedit.NewEditor(cvedit.NewRepository(pool, queries),
+			bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
 		resume:             resume.New(nil, resume.NewQueriesRepository(queries)),
 		matchAnalysisCache: queries,
 		credits:            creditsStore,
@@ -273,13 +279,31 @@ func TestPatchCVViaKey(t *testing.T) {
 	ownerKey := cvScopedKey(t, h, owner)
 	otherKey := cvScopedKey(t, h, other)
 
-	// A valid batch applies. The key edits as the AGENT, so a bullet has to cite banked
-	// evidence — except that this fixture wires no bank, which is "no gate" rather than
-	// "gate that refuses" (the CLI is not a place to enforce provenance it cannot query).
+	// The key edits as the AGENT, so a bullet stating something about the candidate has to
+	// cite banked evidence. Uncited is refused — this is the rule the tailoring capability
+	// exists to enforce, and it must hold for an API-key caller with no assistant in sight.
 	if resp := doBearer(t, app, fiber.MethodPatch, path, ownerKey, map[string]any{
 		"ops": []map[string]any{{"kind": "insert", "path": "experience[0].bullets[1]", "value": "Cut latency"}},
+	}); resp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("uncited patch = %d, want 403", resp.StatusCode)
+	}
+
+	// Cited by an atom the candidate asserted, the same batch applies — so the gate is a
+	// wall with a door, not a blanket refusal.
+	bank := experience.NewStore(experience.NewQueriesRepository(h.queries))
+	atom, err := bank.AddAtom(ctx, owner, experience.Atom{
+		Claim: "Cut latency", Provenance: experience.ProvenanceStatedInChat,
+	})
+	if err != nil {
+		t.Fatalf("AddAtom: %v", err)
+	}
+	if resp := doBearer(t, app, fiber.MethodPatch, path, ownerKey, map[string]any{
+		"ops": []map[string]any{{
+			"kind": "insert", "path": "experience[0].bullets[1]",
+			"value": "Cut latency", "evidence_id": atom.ID.String(),
+		}},
 	}); resp.StatusCode != fiber.StatusOK {
-		t.Fatalf("patch = %d, want 200", resp.StatusCode)
+		t.Fatalf("cited patch = %d, want 200", resp.StatusCode)
 	}
 	rec, _ := h.cvStore.Get(ctx, base.ID, owner)
 	if got := rec.Document.Experience[0].Bullets; len(got) != 2 || got[1] != "Cut latency" {
@@ -311,16 +335,35 @@ func TestPatchCVViaKey(t *testing.T) {
 		t.Fatalf("patch full_name via key = %d, want 403", resp.StatusCode)
 	}
 
-	// Bad addressing is a 422.
+	// Bad addressing is a 422 — but only once the evidence gate has let the op through. The
+	// gate is the OUTER check: an uncited claim is 403 whatever its path addresses, which the
+	// old nil-gate fixture could never show. Citing the banked atom is what makes this case
+	// about addressing again.
 	if resp := doBearer(t, app, fiber.MethodPatch, path, ownerKey, map[string]any{
-		"ops": []map[string]any{{"kind": "set", "path": "experience[0].bullets[9]", "value": "x"}},
+		"ops": []map[string]any{{
+			"kind": "set", "path": "experience[0].bullets[9]",
+			"value": "x", "evidence_id": atom.ID.String(),
+		}},
 	}); resp.StatusCode != fiber.StatusUnprocessableEntity {
 		t.Fatalf("bad-patch = %d, want 422", resp.StatusCode)
 	}
 
-	// Another user's key cannot touch this CV (owner isolation → 404, not 403).
+	// And the ordering itself, pinned: the same malformed op WITHOUT evidence is refused by
+	// the gate rather than reaching the addressing check.
+	if resp := doBearer(t, app, fiber.MethodPatch, path, ownerKey, map[string]any{
+		"ops": []map[string]any{{"kind": "set", "path": "experience[0].bullets[9]", "value": "x"}},
+	}); resp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("uncited bad-patch = %d, want 403 — the gate runs before addressing", resp.StatusCode)
+	}
+
+	// Another user's key cannot touch this CV (owner isolation → 404, not 403). The op is a
+	// REMOVE because the evidence gate runs first and only gates claim-bearing set/insert:
+	// with a claim-bearing op the foreign caller is refused at the gate (403) and never
+	// reaches the ownership check. Isolation is intact either way — 403 is what an uncited
+	// claim gets whether or not the CV exists, so neither answer discloses one — but only a
+	// non-claiming op actually exercises the 404.
 	if resp := doBearer(t, app, fiber.MethodPatch, path, otherKey, map[string]any{
-		"ops": []map[string]any{{"kind": "set", "path": "summary", "value": "hijack"}},
+		"ops": []map[string]any{{"kind": "remove", "path": "experience[0].bullets[0]"}},
 	}); resp.StatusCode != fiber.StatusNotFound {
 		t.Fatalf("foreign patch = %d, want 404", resp.StatusCode)
 	}

--- a/openspec/changes/fixtures-obey-the-evidence-gate/.openspec.yaml
+++ b/openspec/changes/fixtures-obey-the-evidence-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/fixtures-obey-the-evidence-gate/proposal.md
+++ b/openspec/changes/fixtures-obey-the-evidence-gate/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+Finding **I1**, raised while implementing S5. Three fixtures built `cvHandlers` as a struct
+literal — bypassing `newCVHandlers` — with a **nil** evidence gate, then edited as `ActorAgent`.
+One recorded the divergence in a comment as though it were a decision:
+
+> the key edits as the AGENT, so a bullet has to cite banked evidence — except that this fixture
+> wires no bank, which is "no gate" rather than "gate that refuses"
+
+Production disagrees, and always has: `Register` passes `bankGate{bank}` unconditionally, so an
+API-key `PATCH` inserting an uncited bullet is **403**. The fixture asserted **200**. Because it
+bypassed the constructor, making the gate a construction-time argument in S5 neither fixed nor
+broke it — it kept asserting a configuration that does not ship.
+
+## The product question, answered the conservative way
+
+The finding says to decide first: must an API-key caller editing as the agent cite banked
+evidence? **Production already says yes**, in one place, unconditionally. So aligning the fixtures
+changes **no product behaviour** — it changes tests that describe a configuration nobody can
+reach. The alternative reading (move the gate behind a per-actor policy) *would* be a product
+change, and remains a separate proposal for the owner to make.
+
+Not settled by editing the comment, which the finding explicitly forbids.
+
+## What Changes
+
+- Every fixture constructs the editor with the real gate, exactly as `Register` does. Where a
+  fixture genuinely has no bank it passes an **empty** one — the gate is then present and refuses,
+  which is what a user with nothing banked actually experiences.
+- The cases that expect a write to land now bank an atom and cite it, so they exercise
+  production's success path instead of its absence.
+- `TestNoEditorIsConstructedWithoutAnEvidenceGate` makes the rule enforceable: no file in the
+  package may construct an editor with a nil gate. Verified to fire by restoring one.
+
+## Three things the real gate revealed that the nil gate could not
+
+1. **The gate is the OUTER check.** An uncited malformed op is 403, not the 422 the addressing
+   check would give — so the "bad addressing is a 422" case had to cite evidence to stay about
+   addressing. Both orderings are now pinned.
+2. **It runs before ownership too.** A foreign caller sending a claim-bearing op is refused at the
+   gate (403) and never reaches the 404. Isolation is intact — 403 is what an uncited claim gets
+   whether or not the CV exists, so neither answer discloses one — but only a non-claiming op
+   actually exercises the 404, so that case now uses `remove`.
+3. **Eight more fixtures had nil gates** that I1 does not name. They never edit as the agent
+   (`grep` finds no `doBearer`/`ActorAgent` in those files), so the gate was inert for them — but
+   an agent-path case added later would have lost the wall silently. They now pass a real gate,
+   which is what makes the rule test possible.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none) — no requirement-level behaviour change. The gate's behaviour is unchanged; the fixtures
+now describe it. Archives with `--skip-specs`.
+
+## Impact
+
+- `internal/handler/cv_tailor_integration_test.go`, `assistant_cv_tools_test.go`,
+  `cv_integration_test.go`, `cv_ats_delta_integration_test.go`, and a new rule test.

--- a/openspec/changes/fixtures-obey-the-evidence-gate/tasks.md
+++ b/openspec/changes/fixtures-obey-the-evidence-gate/tasks.md
@@ -1,0 +1,26 @@
+## 1. Answer the product question before touching a fixture
+
+- [x] 1.1 Read what production actually assembles — `Register` passes `bankGate{bank}`
+      unconditionally, so the answer is already "yes" and aligning the fixtures changes no
+      product behaviour.
+- [x] 1.2 Record that the other reading (a per-actor policy) is a product change and stays a
+      separate proposal.
+
+## 2. Make the fixtures describe production
+
+- [x] 2.1 The integration fixture builds the real bank the way `Register` does, from its own
+      queries — an integration test with a live database has no reason to stub it.
+- [x] 2.2 The uncited PATCH is 403; a cited one lands. Both, because a gate that only ever
+      refuses would pass a one-sided test.
+- [x] 2.3 The tool fixtures: an empty bank rather than a nil gate, and the two cases that expect
+      a write to land bank an atom and cite it.
+- [x] 2.4 Eight fixtures I1 does not name also had nil gates. Check whether they reach the agent
+      path (they do not) before deciding, then give them the real gate anyway so the rule can be
+      enforced.
+
+## 3. Keep it
+
+- [x] 3.1 A rule test: no file constructs an editor with a nil gate. Verify it fires by restoring
+      one.
+- [x] 3.2 `go test ./...` AND `go test -tags=integration ./...`.
+- [x] 3.3 Mark I1 ✅ in `docs/reviews/2026-08-01-architecture-review.md`.


### PR DESCRIPTION
Finding **I1** — the one raised *while implementing* S5, and the only open item outside the
catalogue.

Three fixtures built `cvHandlers` as a struct literal — bypassing `newCVHandlers` — with a **nil**
evidence gate, then edited as `ActorAgent`. One recorded the divergence in a comment as though it
were a decision:

> the key edits as the AGENT, so a bullet has to cite banked evidence — except that this fixture
> wires no bank, which is "no gate" rather than "gate that refuses"

**Production disagrees, and always has.** `Register` passes `bankGate{bank}` unconditionally, so
an API-key `PATCH` inserting an uncited bullet is **403**. The fixture asserted **200**. And
because it bypassed the constructor, making the gate a construction-time argument in S5 neither
fixed nor broke it — it kept asserting a configuration that does not ship.

## The product question, answered before touching anything

The finding says to decide first, and forbids settling it by editing the comment. So:

**Must an API-key caller editing as the agent cite banked evidence?** Production already answers
yes, in one place, unconditionally. Aligning the fixtures therefore changes **no product
behaviour** — it changes tests that describe a configuration nobody can reach.

The other reading — moving the gate behind a per-actor policy — *would* be a product change. It
stays a separate proposal for the owner to make, not something to smuggle in through a test fix.

## Three things the real gate revealed that a nil gate could not

1. **The gate is the OUTER check.** An uncited malformed op returns 403, not the 422 the
   addressing check would give — so the "bad addressing is a 422" case had to cite evidence to
   stay a test about addressing. Both orderings are pinned now.
2. **It runs before ownership, too.** A foreign caller sending a claim-bearing op is refused at
   the gate and never reaches the 404. Isolation is intact either way — 403 is what an uncited
   claim gets whether or not the CV exists, so neither answer discloses one — but only a
   non-claiming op actually exercises the 404, so that case now uses `remove`.
3. **Eight more fixtures had nil gates** that I1 does not name. They never edit as the agent
   (no `doBearer`, no `ActorAgent` in those files), so the gate was inert for them — but an
   agent-path case added later would have lost the wall silently.

## What keeps it

`TestNoEditorIsConstructedWithoutAnEvidenceGate`: no file in the package may construct an editor
with a nil gate. Verified to fire by restoring one:

```
cv_gate_rule_test.go:47: assistant_cv_tools_test.go constructs an editor with a nil
evidence gate: cvedit.NewEditor(&memRevisions{cv: repo}, nil)
```

Where a fixture genuinely has no bank it passes an **empty** one — the gate is then present and
refuses, which is what a user with nothing banked actually experiences. The cases that expect a
write to land bank an atom and cite it, so they exercise production's success path rather than
its absence.

`go test ./...` **and** `go test -tags=integration ./...` green.
