### PR TITLE
feat(telegram): read the Ukrainian-language segment

### DIFF
--- a/docs/superpowers/specs/2026-08-01-telegram-ukrainian-intake-design.md
+++ b/docs/superpowers/specs/2026-08-01-telegram-ukrainian-intake-design.md
@@ -1,0 +1,192 @@
+# Telegram Ukrainian intake — design
+
+**Date:** 2026-08-01
+**Status:** approved, ready for planning
+
+## Problem
+
+The Telegram crawl covers 88 channels, all Russian- or English-language. The Ukrainian IT
+segment is absent from the catalogue, and the reason is not that no channels exist — it is
+that the extraction queue's prefilter cannot recognise a Ukrainian vacancy.
+
+`internal/telegram/prefilter.go` carries hiring markers in RU and EN only. Ukrainian
+"вакансія" does not match the RU alternative `ваканси`: Cyrillic `і` (U+0456) and `и`
+(U+0438) are distinct runes. A post that says «Шукаємо Golang розробника» reaches the
+prefilter, fails it, is stored as done with zero vacancies, and never reaches the LLM.
+
+Measured against live channel previews on 2026-08-01 (20 newest posts each, the `t.me/s`
+web preview):
+
+| Channel | posts | pass the current prefilter | Ukrainian markers would add |
+|---|---|---|---|
+| wwjobs | 20 | 4 | +15 |
+| naymarnya | 18 | 3 | +7 |
+| junior_dou_ua | 20 | 4 | +5 |
+| halepnyirecruiting | 18 | 0 | +3 |
+
+The same measurement on eight channels already in `sources/telegram.yml`
+(`it_vakansii_jobs`, `vakansii_it`, `jobforjunior`, `huntmejob`, `normrabota`, `zrabota`,
+`budujobs`, `product_jobs`) gives 17–19 of 20 passing and **zero** rescued by Ukrainian
+markers. Nothing is leaking in production today — the gap only opens when Ukrainian channels
+are onboarded, which is exactly what this change does.
+
+A second gap sits downstream. `Львів`, `Харків`, `Одеса`, `Дніпро` resolve to a city name but
+carry no country and no region, while `Berlin`, `Warsaw`, `Kraków` carry both. This is not a
+bug in the parser: `internal/location/location.go:78-82` documents the contract that the
+generated GeoNames `cityDict` supplies the canonical *name* only, never a country, so an
+ambiguous city can never guess a geography. Country comes from the curated map in
+`dictionaries.go`, which holds `kyiv`/`киев`/`київ` and no other Ukrainian entry. Without
+this, a Lviv vacancy lands in the catalogue invisible to `country=ua` and to the `eu` region.
+
+## Goal
+
+Make the Ukrainian-language Telegram segment visible to the catalogue: recognised by the
+prefilter, placed on the map, and represented by a vetted set of channels.
+
+## Non-goals
+
+- **Telegram group chats.** The source list carries 97 of them. `cmd/tg-ingest` reads the
+  public `t.me/s` web preview, which serves posts for channels and nothing for groups —
+  verified: `t.me/s/aiogramua`, `t.me/s/angular_community_ua`, `t.me/s/angularkyiv` all
+  return HTTP 200 with zero message nodes. Reading them needs an MTProto client with a
+  logged-in account, a different class of infrastructure.
+- **`jobs.dou.ua`.** Returns HTTP 403 to a plain request; onboarding it is an anti-bot
+  problem, not a source-file problem.
+- **`wwjobs`.** Highest vacancy density of any candidate (81 keyword hits across 20 posts)
+  but its newest post is 2026-06-10, 52 days old. `sources/telegram.yml` states its own
+  admission gate — public preview plus a post within the last 30 days — and this channel
+  fails it. Backlog item: revisit if it revives.
+- **Telegram vacancy expiry.** Telegram jobs are reached by none of the three lifecycle
+  close mechanisms and never close. That is catalogue-wide (all 88 channels), independent of
+  this change, and gets its own spec. See Follow-up.
+- No schema change, no migration.
+
+## Decisions
+
+### 1. Extend the existing prefilter regexp rather than restructuring it
+
+The prefilter is one regexp organised into commented per-language blocks. Ukrainian becomes
+a fourth block; `грн|₴` joins the currency alternation.
+
+```go
+// UA hiring verbs/nouns. Ukrainian "вакансія" does NOT match the RU "ваканси"
+// above — the Cyrillic і and и are distinct runes.
+`вакансі|шукаємо|шукає|запрошуємо|стажуванн|досвід роботи|` +
+```
+
+Rejected: splitting into named per-language regexps combined at init. Three languages do not
+justify four variables, and one regexp compiles to one automaton scanned once per post,
+where four mean up to four passes on the crawler's hot path. Rejected: language detection
+before filtering — a detector is its own error source and the posts are routinely bilingual
+(«Вакансія: Senior Go Developer, requirements below»).
+
+### 2. The marker set is the measured one, not the plausible one
+
+Each candidate was scored over 156 posts from eight job channels and 150 posts from eight
+news channels, counting only posts the current prefilter rejects:
+
+| marker | rescued in job channels | let through in news channels |
+|---|---|---|
+| `вакансі` | 22 | 0 |
+| `досвід роботи` | 10 | 1 |
+| `шукаємо\|шукає` | 8 | 1 |
+| `грн`/`₴` amounts | 8 | 2 |
+| `стажуванн` | 5 | 1 |
+| `запрошуємо` | 4 | 0 |
+| `потрібен\|потрібна\|потрібні` | 1 | 1 |
+| `відгук` | 2 | 1 |
+| `наймаємо` | 0 | 0 |
+| `зарплатн` | 0 | 0 |
+
+Adopted: the first six. Dropped: `наймаємо` (never fires), `зарплатн` (never fires — the RU
+marker `зарплат` is already its prefix), `потрібен` and `відгук` (1:1 signal to noise).
+
+The asymmetry that settles the borderline cases: `internal/telegram/AGENTS.md` states the LLM
+is the real classifier. A false positive costs one LLM call returning `{"jobs": []}`. A false
+negative loses a vacancy permanently and silently. Recall is worth more than precision here.
+
+### 3. Ukrainian geography goes into the curated map, not the generated one
+
+Two additions to `nameToCountry` in `internal/location/dictionaries.go`, in the blocks that
+already hold `kyiv` and `київ`:
+
+- Latin, beside line 98: `lviv`, `kharkiv`, `odesa`, `odessa`, `dnipro`, `vinnytsia`,
+  `ivano-frankivsk`, `zaporizhzhia`, `chernivtsi`, `ternopil`, `uzhhorod`, `rivne`, `lutsk`,
+  `poltava`, `khmelnytskyi`, `zhytomyr`, `cherkasy`, `sumy`, `mykolaiv`, `chernihiv`,
+  `kryvyi rih` → `ua`.
+- Cyrillic, beside line 146: the same cities in Ukrainian and Russian spelling, plus
+  `україна`/`украина` → `ua`.
+
+This respects the dict-only contract: country still comes only from the curated map, and
+GeoNames still supplies nothing but the display name. With both sides agreeing on `ua`, the
+agreement branch at `location.go:88` emits city *and* country.
+
+### 4. Seven channels, two tiers
+
+Verified 2026-08-01 — public `t.me/s` preview enabled and a post within the last 30 days.
+
+| Channel | kind | newest post |
+|---|---|---|
+| `naymarnya` | board | 2026-07-10 |
+| `halepnyirecruiting` | board | 2026-07-30 |
+| `devops_dou` | authored | 2026-08-01 |
+| `dou_qa` | authored | 2026-08-01 |
+| `frontend_dou` | authored | 2026-08-01 |
+| `gamedev_dou` | authored | 2026-08-01 |
+| `junior_dou_ua` | authored | 2026-08-01 |
+
+The DOU verticals are `authored`, not `board`: they publish digests where one post can carry
+several roles, which is precisely what `KindAuthored` instructs the model to split
+(`internal/telegram/llm.go:104`).
+
+Source: [nikit0ns/Ukrainian_IT_Communities](https://github.com/nikit0ns/Ukrainian_IT_Communities),
+192 entries — 97 group chats, 68 channels, 12 websites, 15 other platforms. Of the 68 channel
+entries, 55 carry a public username (the rest are `t.me/+…` invite links, unreachable without
+joining). Exactly one of those 55, `job_it_junior`, was already in `sources/telegram.yml`, so
+the list is genuinely new material. Of the 54 new ones, about 32 posted within the last 30
+days, 8 carry vacancies, and 7 also clear the freshness gate.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `internal/telegram/prefilter.go` | UA marker block; `грн\|₴` in the currency alternation |
+| `internal/telegram/prefilter_test.go` | UA pass and reject cases |
+| `internal/location/dictionaries.go` | Ukrainian cities and country, Latin + Cyrillic |
+| `internal/location/location_test.go` | `Львів`, `Lviv, Ukraine` → `ua` / `eu` / `Lviv` |
+| `sources/telegram.yml` | 7 channels under two commented headings |
+| `docs/telegram-channels.md` | new dated section; header count 88 → 95 (17 authored, 78 board) |
+
+`docs/telegram-channels.md` declares itself a mirror of `sources/telegram.yml`. It is in sync
+today (88 table rows against 88 YAML entries) and must stay so in the same commit.
+
+## Testing
+
+- `prefilter_test.go` gains UA rows in both existing tables. Pass: «Вакансія: Golang
+  розробник», «Шукаємо QA у продуктову команду», «Досвід роботи від 2 років, зарплата 60 000
+  грн». Reject: «Дайджест новин тижня», «Знижка на курс — встигни записатись».
+- `location_test.go` gains cases mirroring the existing `Київ` one: `Львів` and
+  `Lviv, Ukraine` → `Geo{Countries: ["ua"], Regions: ["eu"], Cities: ["Lviv"]}`.
+- `go test ./...` and `go test -tags=integration ./internal/db/` both before push.
+- Before/after measurement on live previews: `naymarnya` rises from 3/18, `halepnyirecruiting`
+  from 0/18, and the eight RU channels already in production show **no change**. Extending an
+  alternation can only add matches, so the only way to do harm is to start admitting noise in
+  channels that already work — this measurement is what catches that.
+
+## Follow-up
+
+Telegram vacancy expiry, as its own change:
+
+- Telegram jobs never close. The ingest sweep skips them (`telegram` is not a board provider;
+  `cmd/tg-extract` writes through `UpsertJob` directly), there is no change feed to self-close
+  from, and the liveness probe excludes them by name (`cmd/liveness/main.go:55`) because the
+  stored URL is the post, which outlives the vacancy.
+- `openspec/specs/job-lifecycle/spec.md:97` still requires the opposite — that a
+  `source = 'telegram'` job be probed. The code comment cites a "job-lifecycle spec's telegram
+  limitation" that exists in neither `docs/agents/job-lifecycle.md` nor openspec. Behaviour
+  changed and the spec did not follow; that reconciliation belongs to the same change.
+- Open question for that design: `docs/agents/job-lifecycle.md:8` fixes `closed_at` to mean
+  "the employer took this down", and the project has already once declined to overload it
+  (catalogue pruning got `pruned_jobs` instead). An age-based expiry is a third meaning —
+  "presumed stale". Whether it writes `closed_at` anyway needs a deliberate answer.
+- `wwjobs` — revisit if it starts posting again.

--- a/docs/telegram-channels.md
+++ b/docs/telegram-channels.md
@@ -4,7 +4,7 @@ Human-readable index of the public Telegram channels crawled by `cmd/tg-ingest`
 (see `internal/telegram`). **The source of truth is [`sources/telegram.yml`](../sources/telegram.yml)** —
 this document mirrors it for browsing; when the YAML changes, regenerate this list.
 
-**88 channels** (12 `authored`, 76 `board`) as of the last update.
+**95 channels** (17 `authored`, 78 `board`) as of the last update.
 
 `kind` steers the extraction prompt:
 
@@ -32,10 +32,8 @@ Verified 2026-06-12: public `t.me/s` preview enabled and a post within the last 
 | Channel | kind |
 |---|---|
 | [it_vakansii_jobs](https://t.me/it_vakansii_jobs) | board |
-| [geekjobs](https://t.me/geekjobs) | board |
 | [vakansii_it](https://t.me/vakansii_it) | board |
 | [zrabota](https://t.me/zrabota) | board |
-| [habr_career](https://t.me/habr_career) | board |
 | [huntmejob](https://t.me/huntmejob) | board |
 | [newdirections](https://t.me/newdirections) | board |
 
@@ -102,7 +100,6 @@ aggregators — geography the curated tier above did not cover.
 |---|---|
 | [dot_aware](https://t.me/dot_aware) | board |
 | [gocareers](https://t.me/gocareers) | board |
-| [getjobss](https://t.me/getjobss) | board |
 | [jobs_and_internships_updates](https://t.me/jobs_and_internships_updates) | board |
 | [jobsandinternshipsupdates](https://t.me/jobsandinternshipsupdates) | board |
 | [off_campus_jobs_and_internships](https://t.me/off_campus_jobs_and_internships) | board |
@@ -198,7 +195,6 @@ executive / top-management / marketing roles rather than pure IT.
 | Channel | kind |
 |---|---|
 | [evacuatejobs](https://t.me/evacuatejobs) | board |
-| [remotegeekjob](https://t.me/remotegeekjob) | board |
 | [zarubezhom_jobs](https://t.me/zarubezhom_jobs) | board |
 
 ### Marketing niche
@@ -208,3 +204,46 @@ executive / top-management / marketing roles rather than pure IT.
 | [marketing_jobs](https://t.me/marketing_jobs) | board |
 | [forallmarketing](https://t.me/forallmarketing) | board |
 | [wantapply_marketing](https://t.me/wantapply_marketing) | board |
+| [wantapply_managers](https://t.me/wantapply_managers) | board |
+| [wantapply_design](https://t.me/wantapply_design) | board |
+| [wantapply_analytics](https://t.me/wantapply_analytics) | board |
+| [wantapply_qa_jobs](https://t.me/wantapply_qa_jobs) | board |
+
+## Added 2026-08-01 (Ukrainian_IT_Communities)
+
+Mined from [nikit0ns/Ukrainian_IT_Communities](https://github.com/nikit0ns/Ukrainian_IT_Communities)
+(192 entries). Verified 2026-08-01: public `t.me/s` preview enabled and a post within the
+last 30 days. This is the first Ukrainian-language cohort, and it only yields vacancies
+because `internal/telegram/prefilter.go` gained UA markers in the same change — the RU
+marker `ваканси` cannot match `вакансія`, since Cyrillic `і` and `и` are distinct runes.
+Do not add a channel in a language the prefilter does not yet cover.
+
+Excluded, with reasons, so the next reader does not re-derive them:
+
+- **The list's 97 Telegram *chats*.** `cmd/tg-ingest` reads the public `t.me/s` preview,
+  which serves posts for channels and nothing for groups (checked on `aiogramua`,
+  `angular_community_ua`, `angularkyiv`: HTTP 200, zero messages). Reading them needs an
+  MTProto client with a logged-in account.
+- **`wwjobs`.** The densest candidate of the cohort — 81 hiring-keyword hits across 20
+  posts — but its newest post is 2026-06-10, past the 30-day gate. Revisit if it revives.
+- **`jobs.dou.ua`.** Returns HTTP 403 to a plain request; an anti-bot problem, not a
+  source-file one.
+
+### Ukrainian job boards
+
+| Channel | kind |
+|---|---|
+| [naymarnya](https://t.me/naymarnya) | board |
+| [halepnyirecruiting](https://t.me/halepnyirecruiting) | board |
+
+### Ukrainian editorial (DOU verticals)
+
+Digests that can bundle several roles in one post.
+
+| Channel | kind |
+|---|---|
+| [devops_dou](https://t.me/devops_dou) | authored |
+| [dou_qa](https://t.me/dou_qa) | authored |
+| [frontend_dou](https://t.me/frontend_dou) | authored |
+| [gamedev_dou](https://t.me/gamedev_dou) | authored |
+| [junior_dou_ua](https://t.me/junior_dou_ua) | authored |

--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -96,16 +96,23 @@ var nameToCountry = map[string]string{
 	// the US state; the country resolves via its capital "tbilisi" only.
 	"russia": "ru", "moscow": "ru", "saint petersburg": "ru", "st petersburg": "ru",
 	"kyiv": "ua", "kiev": "ua",
-	// The remaining Ukrainian oblast centres, added with the Telegram UA cohort.
-	// "odessa" (the double-s transliteration) is deliberately absent — it collides
-	// with Odessa, Texas, the same reason "georgia" is absent above; the Ukrainian
-	// "odesa" carries the city on its own.
-	"lviv": "ua", "kharkiv": "ua", "odesa": "ua", "dnipro": "ua",
-	"vinnytsia": "ua", "ivano-frankivsk": "ua", "zaporizhzhia": "ua",
-	"chernivtsi": "ua", "ternopil": "ua", "uzhhorod": "ua", "rivne": "ua",
-	"lutsk": "ua", "poltava": "ua", "khmelnytskyi": "ua", "zhytomyr": "ua",
-	"cherkasy": "ua", "sumy": "ua", "mykolaiv": "ua", "chernihiv": "ua",
-	"kryvyi rih": "ua",
+	// Other Ukrainian oblast centres, added with the Telegram UA cohort, in the
+	// Ukrainian and the Russian transliteration. Every key here is Ukraine-only in
+	// cities15000.tsv. Omitted because GeoNames lists the alias in more than one
+	// country, the same reason "georgia" is omitted above: "odesa"/"odessa" (also
+	// Odessa, Texas), "lutsk" (Belarus), "cherkasy"/"cherkassy" and "donetsk"
+	// (Russia), "nikolaev" (Bulgaria, Russia). Those keep resolving to a bare city
+	// name — under-resolving is what the never-guess contract asks for.
+	"lviv": "ua", "lvov": "ua", "kharkiv": "ua", "kharkov": "ua",
+	"dnipro": "ua", "dnepr": "ua", "dnepropetrovsk": "ua",
+	"vinnytsia": "ua", "ivano-frankivsk": "ua",
+	"zaporizhzhia": "ua", "zaporozhye": "ua",
+	"chernivtsi": "ua", "chernovtsy": "ua", "ternopil": "ua", "ternopol": "ua",
+	"uzhhorod": "ua", "uzhgorod": "ua", "rivne": "ua", "rovno": "ua",
+	"poltava": "ua", "khmelnytskyi": "ua", "zhytomyr": "ua", "zhitomir": "ua",
+	"sumy": "ua", "mykolaiv": "ua", "chernihiv": "ua", "chernigov": "ua",
+	"kryvyi rih": "ua", "krivoy rog": "ua",
+	"kherson": "ua", "kropyvnytskyi": "ua", "luhansk": "ua",
 	"uzbekistan": "uz", "tashkent": "uz", "toshkent": "uz", "samarkand": "uz",
 	"kazakhstan": "kz", "almaty": "kz", "astana": "kz", "nur-sultan": "kz",
 	"kyrgyzstan": "kg", "bishkek": "kg",
@@ -156,15 +163,20 @@ var nameToCountry = map[string]string{
 	"киев": "ua", "київ": "ua", "україна": "ua", "украина": "ua",
 	// Oblast centres in both spellings: the Telegram UA channels write Ukrainian,
 	// the RU-segment ATS sources write Russian, and a location field carries either.
+	// A Cyrillic key is dropped only when GeoNames places the alias in another
+	// Cyrillic-writing country, since those are the postings that could carry this
+	// spelling: "луцьк"/"луцк" (Belarus), "черкассы" (Russia), "николаев" (Bulgaria,
+	// Russia). The Latin block above is stricter — a Latin field can come from
+	// anywhere, so "odesa" is absent there and present here.
 	"львів": "ua", "львов": "ua", "харків": "ua", "харьков": "ua",
 	"одеса": "ua", "одесса": "ua", "дніпро": "ua", "днепр": "ua",
 	"вінниця": "ua", "винница": "ua", "івано-франківськ": "ua", "ивано-франковск": "ua",
 	"запоріжжя": "ua", "запорожье": "ua", "чернівці": "ua", "черновцы": "ua",
 	"тернопіль": "ua", "тернополь": "ua", "ужгород": "ua", "рівне": "ua", "ровно": "ua",
-	"луцьк": "ua", "луцк": "ua", "полтава": "ua", "хмельницький": "ua", "хмельницкий": "ua",
-	"житомир": "ua", "черкаси": "ua", "черкассы": "ua", "суми": "ua", "сумы": "ua",
-	"миколаїв": "ua", "николаев": "ua", "чернігів": "ua", "чернигов": "ua",
-	"кривий ріг": "ua", "кривой рог": "ua",
+	"полтава": "ua", "хмельницький": "ua", "хмельницкий": "ua", "житомир": "ua",
+	"черкаси": "ua", "суми": "ua", "сумы": "ua", "миколаїв": "ua",
+	"чернігів": "ua", "чернигов": "ua", "кривий ріг": "ua", "кривой рог": "ua",
+	"херсон": "ua", "кропивницький": "ua", "луганськ": "ua",
 
 	// --- Country names: English + native + ES/PT/DE, seeded from the unresolved
 	// production strings. (Names already keyed above are not repeated.)

--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -96,6 +96,16 @@ var nameToCountry = map[string]string{
 	// the US state; the country resolves via its capital "tbilisi" only.
 	"russia": "ru", "moscow": "ru", "saint petersburg": "ru", "st petersburg": "ru",
 	"kyiv": "ua", "kiev": "ua",
+	// The remaining Ukrainian oblast centres, added with the Telegram UA cohort.
+	// "odessa" (the double-s transliteration) is deliberately absent — it collides
+	// with Odessa, Texas, the same reason "georgia" is absent above; the Ukrainian
+	// "odesa" carries the city on its own.
+	"lviv": "ua", "kharkiv": "ua", "odesa": "ua", "dnipro": "ua",
+	"vinnytsia": "ua", "ivano-frankivsk": "ua", "zaporizhzhia": "ua",
+	"chernivtsi": "ua", "ternopil": "ua", "uzhhorod": "ua", "rivne": "ua",
+	"lutsk": "ua", "poltava": "ua", "khmelnytskyi": "ua", "zhytomyr": "ua",
+	"cherkasy": "ua", "sumy": "ua", "mykolaiv": "ua", "chernihiv": "ua",
+	"kryvyi rih": "ua",
 	"uzbekistan": "uz", "tashkent": "uz", "toshkent": "uz", "samarkand": "uz",
 	"kazakhstan": "kz", "almaty": "kz", "astana": "kz", "nur-sultan": "kz",
 	"kyrgyzstan": "kg", "bishkek": "kg",
@@ -143,7 +153,18 @@ var nameToCountry = map[string]string{
 	"ташкент": "uz", "узбекистан": "uz",
 	"алматы": "kz", "астана": "kz", "казахстан": "kz",
 	"ереван": "am", "баку": "az", "бишкек": "kg",
-	"киев": "ua", "київ": "ua",
+	"киев": "ua", "київ": "ua", "україна": "ua", "украина": "ua",
+	// Oblast centres in both spellings: the Telegram UA channels write Ukrainian,
+	// the RU-segment ATS sources write Russian, and a location field carries either.
+	"львів": "ua", "львов": "ua", "харків": "ua", "харьков": "ua",
+	"одеса": "ua", "одесса": "ua", "дніпро": "ua", "днепр": "ua",
+	"вінниця": "ua", "винница": "ua", "івано-франківськ": "ua", "ивано-франковск": "ua",
+	"запоріжжя": "ua", "запорожье": "ua", "чернівці": "ua", "черновцы": "ua",
+	"тернопіль": "ua", "тернополь": "ua", "ужгород": "ua", "рівне": "ua", "ровно": "ua",
+	"луцьк": "ua", "луцк": "ua", "полтава": "ua", "хмельницький": "ua", "хмельницкий": "ua",
+	"житомир": "ua", "черкаси": "ua", "черкассы": "ua", "суми": "ua", "сумы": "ua",
+	"миколаїв": "ua", "николаев": "ua", "чернігів": "ua", "чернигов": "ua",
+	"кривий ріг": "ua", "кривой рог": "ua",
 
 	// --- Country names: English + native + ES/PT/DE, seeded from the unresolved
 	// production strings. (Names already keyed above are not repeated.)

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -212,12 +212,13 @@ func resolveGeoName(tok string, countrySet, regionSet map[string]struct{}) bool 
 	return false
 }
 
-// cityMarkerPrefixes are the Russian "city" abbreviations that RU-segment ATS
-// data prepends to a bare city name ("г Москва", "город Самара"). Stripped from a
-// token before lookup so the city resolves; checked longest-first so "город "
-// wins over "г ". A city whose name merely starts with "г" ("Грозный") is
-// untouched — every prefix ends in a separator the name doesn't.
-var cityMarkerPrefixes = []string{"город ", "г. ", "г.", "г "}
+// cityMarkerPrefixes are the "city" abbreviations that Cyrillic-writing sources
+// prepend to a bare city name — Russian "г Москва" / "город Самара", Ukrainian
+// "м. Львів" / "місто Київ". Stripped from a token before lookup so the city
+// resolves; checked longest-first so "город " wins over "г ". A city whose name
+// merely starts with "г" or "м" ("Грозный", "Мурманск") is untouched — every
+// prefix ends in a separator the name doesn't.
+var cityMarkerPrefixes = []string{"город ", "місто ", "г. ", "м. ", "г.", "м.", "г ", "м "}
 
 // noiseTokenWords are dropped from a geography token so an embedded place still
 // resolves: work-mode words ("US Remote" -> "us") and site suffixes ("San

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -404,9 +404,19 @@ func TestParseCyrillic(t *testing.T) {
 			want:     Geo{Countries: []string{"ua"}, Regions: []string{"eu"}},
 		},
 		{
+			name:     "Ukrainian city marker м. is stripped like the Russian г.",
+			location: "м. Львів",
+			want:     Geo{Countries: []string{"ua"}, Regions: []string{"eu"}, Cities: []string{"Lviv"}},
+		},
+		{
 			name:     "city starting with г is not mistaken for the marker",
 			location: "Грозный",
 			want:     Geo{Cities: []string{"Grozny"}},
+		},
+		{
+			name:     "city starting with м is not mistaken for the marker",
+			location: "Мурманск",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}, Cities: []string{"Murmansk"}},
 		},
 	}
 

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -384,6 +384,26 @@ func TestParseCyrillic(t *testing.T) {
 			want:     Geo{Countries: []string{"ua"}, Regions: []string{"eu"}, Cities: []string{"Kyiv"}},
 		},
 		{
+			name:     "Ukrainian spelling Львів maps to Ukraine / eu",
+			location: "Львів",
+			want:     Geo{Countries: []string{"ua"}, Regions: []string{"eu"}, Cities: []string{"Lviv"}},
+		},
+		{
+			name:     "Russian spelling Харьков maps to Ukraine / eu",
+			location: "Харьков",
+			want:     Geo{Countries: []string{"ua"}, Regions: []string{"eu"}, Cities: []string{"Kharkiv"}},
+		},
+		{
+			name:     "Latin Lviv maps to Ukraine / eu without a country token",
+			location: "Lviv",
+			want:     Geo{Countries: []string{"ua"}, Regions: []string{"eu"}, Cities: []string{"Lviv"}},
+		},
+		{
+			name:     "Ukrainian spelling of the country yields the code without a city",
+			location: "Україна",
+			want:     Geo{Countries: []string{"ua"}, Regions: []string{"eu"}},
+		},
+		{
 			name:     "city starting with г is not mistaken for the marker",
 			location: "Грозный",
 			want:     Geo{Cities: []string{"Grozny"}},

--- a/internal/telegram/AGENTS.md
+++ b/internal/telegram/AGENTS.md
@@ -14,4 +14,10 @@ Telegram-channel crawl (web preview → `telegram_posts`) and LLM vacancy extrac
 Public Telegram channels carry vacancies as free-form posts, so unlike the structured ATS adapters they need an extraction step. The work is split into two stages mirroring the ingest/enrich shape: `cmd/tg-ingest` is the cheap crawl that fetches each channel's web preview and enqueues raw posts, and `cmd/tg-extract` is the LLM-driven extraction that drains the queue into normalized jobs. The `kind` field on each channel entry steers which extraction prompt is used, so different channel formats (e.g. a pure-vacancy channel vs a mixed discussion channel) get the right parsing strategy.
 
 ## Limitations
-None currently listed.
+- The prefilter's marker set is per-language and hand-maintained (RU, EN, UA). Adding a
+  channel that publishes in a language the markers do not cover silently rejects all of its
+  vacancies — the failure looks like a weak channel, not a blind filter. Extend
+  `internal/telegram/prefilter.go` before adding the channel.
+- Telegram jobs have no lifecycle close signal: the ingest sweep does not reach them, there is
+  no change feed, and `cmd/liveness` excludes them because the stored URL is the post, which
+  outlives the vacancy. They stay open until something else closes them.

--- a/internal/telegram/llm.go
+++ b/internal/telegram/llm.go
@@ -96,7 +96,7 @@ func repairJSONControlChars(s string) string {
 // authored post may bundle several (or none — channels mix in ads and digests).
 func extractSystemPrompt(kind Kind) string {
 	var b strings.Builder
-	b.WriteString("You read a Telegram channel post (Russian or English) and decide whether it advertises job vacancies.\n")
+	b.WriteString("You read a Telegram channel post (Ukrainian, Russian, or English) and decide whether it advertises job vacancies.\n")
 	b.WriteString("Return ONLY a JSON object: {\"jobs\": [...]}. If the post is not a job advertisement ")
 	b.WriteString("(news, digest, course ad, meme), return {\"jobs\": []}.\n\n")
 

--- a/internal/telegram/prefilter.go
+++ b/internal/telegram/prefilter.go
@@ -14,14 +14,19 @@ var vacancyMarkers = regexp.MustCompile(`(?i)` +
 	// EN hiring
 	`hiring|vacanc|looking for|join (our|the) team|apply|salary|` +
 	// UA hiring verbs/nouns. Ukrainian "вакансія" does NOT match the RU "ваканси"
-	// above — Cyrillic і (U+0456) and и (U+0438) are distinct runes. Each stem is the
-	// shortest that covers its inflections ("шукає" also covers "шукаємо"). Excluded
-	// after scoring 306 live posts: "наймаємо" and "зарплатн" never fired (the RU
-	// "зарплат" already prefixes the latter), and "потрібен"/"відгук" matched as much
-	// editorial content as hiring.
+	// above — Cyrillic і (U+0456) and и (U+0438) are distinct runes. "шукає" covers
+	// "шукаємо"/"шукаєте" but deliberately not "шукаю", the job-SEEKER form. Excluded
+	// after scoring live posts: "наймаємо" and "зарплатн" never fired (the RU "зарплат"
+	// already prefixes the latter), and "потрібен"/"відгук" matched as much editorial
+	// content as hiring.
+	//
+	// Hryvnia amounts are deliberately NOT a marker, unlike руб/₽/€/$. The currency is
+	// low-denomination, so the amount pattern's 3-digit floor cannot separate a salary
+	// from a conference ticket: on the Ukrainian cohort every post it admitted on its
+	// own was an event ticket, a fundraiser, or a raffle, and none was a vacancy.
 	`вакансі|шукає|запрошуємо|стажуванн|досвід роботи|` +
-	// salary amounts: "250 000 руб", "60 000 грн", "$120k", "120k-200k", "€80k"
-	`\d[\d\s]{2,}\s*(руб|₽|грн|₴|€|\$)|[$€£]\s?\d+\s?k|\d+\s?k\s*[-–—]\s*\$?\d+\s?k`)
+	// salary amounts: "250 000 руб", "$120k", "120k-200k", "€80k"
+	`\d[\d\s]{2,}\s*(руб|₽|€|\$)|[$€£]\s?\d+\s?k|\d+\s?k\s*[-–—]\s*\$?\d+\s?k`)
 
 // LooksLikeVacancy reports whether a post should enter the extraction queue.
 // Posts that fail are still stored (so re-crawls skip them) but marked done with

--- a/internal/telegram/prefilter.go
+++ b/internal/telegram/prefilter.go
@@ -13,8 +13,15 @@ var vacancyMarkers = regexp.MustCompile(`(?i)` +
 	`зарплат|оклад|на руки|стажировк|резюме|` +
 	// EN hiring
 	`hiring|vacanc|looking for|join (our|the) team|apply|salary|` +
-	// salary amounts: "250 000 руб", "$120k", "120k-200k", "€80k"
-	`\d[\d\s]{2,}\s*(руб|₽|€|\$)|[$€£]\s?\d+\s?k|\d+\s?k\s*[-–—]\s*\$?\d+\s?k`)
+	// UA hiring verbs/nouns. Ukrainian "вакансія" does NOT match the RU "ваканси"
+	// above — Cyrillic і (U+0456) and и (U+0438) are distinct runes. Each stem is the
+	// shortest that covers its inflections ("шукає" also covers "шукаємо"). Excluded
+	// after scoring 306 live posts: "наймаємо" and "зарплатн" never fired (the RU
+	// "зарплат" already prefixes the latter), and "потрібен"/"відгук" matched as much
+	// editorial content as hiring.
+	`вакансі|шукає|запрошуємо|стажуванн|досвід роботи|` +
+	// salary amounts: "250 000 руб", "60 000 грн", "$120k", "120k-200k", "€80k"
+	`\d[\d\s]{2,}\s*(руб|₽|грн|₴|€|\$)|[$€£]\s?\d+\s?k|\d+\s?k\s*[-–—]\s*\$?\d+\s?k`)
 
 // LooksLikeVacancy reports whether a post should enter the extraction queue.
 // Posts that fail are still stored (so re-crawls skip them) but marked done with

--- a/internal/telegram/prefilter_test.go
+++ b/internal/telegram/prefilter_test.go
@@ -12,6 +12,13 @@ func TestLooksLikeVacancy(t *testing.T) {
 		{"board template", "Senior Fullstack Engineer\n#удаленка #senior\nCompany: RugsDotFun\nSalary: $120k - $200k"},
 		{"required experience", "Требуется опыт от 2 лет, стек: Go, Postgres. Резюме в личку"},
 		{"recall bias: weak but plausible", "Команде нужен продакт. Подробности у @someone"},
+		// Ukrainian. None of these carry a RU or EN marker: "вакансія" cannot match the
+		// RU "ваканси" (і and и are distinct runes), and "зарплат" is kept out of the
+		// salary case so it rests on the hryvnia amount alone.
+		{"ua marker вакансія", "Вакансія: Golang розробник у продуктову команду"},
+		{"ua marker шукаємо", "Шукаємо QA Engineer у команду"},
+		{"ua experience + hryvnia amount", "Досвід роботи від 2 років, 60 000 грн на місяць"},
+		{"ua internship", "Запрошуємо на стажування студентів"},
 	}
 	for _, tc := range pass {
 		t.Run("pass/"+tc.name, func(t *testing.T) {
@@ -26,6 +33,8 @@ func TestLooksLikeVacancy(t *testing.T) {
 		{"news digest", "Дайджест новостей недели: Яндекс выпустил новую модель, OpenAI снова в суде"},
 		{"course ad", "Скидка 50% на курс по Python до конца недели! Успей записаться"},
 		{"empty-ish", "🔥🔥🔥"},
+		{"ua news digest", "Дайджест новин тижня: Google оновив пошук"},
+		{"ua course ad", "Знижка 50% на курс — встигни записатись"},
 	}
 	for _, tc := range reject {
 		t.Run("reject/"+tc.name, func(t *testing.T) {

--- a/internal/telegram/prefilter_test.go
+++ b/internal/telegram/prefilter_test.go
@@ -12,13 +12,14 @@ func TestLooksLikeVacancy(t *testing.T) {
 		{"board template", "Senior Fullstack Engineer\n#удаленка #senior\nCompany: RugsDotFun\nSalary: $120k - $200k"},
 		{"required experience", "Требуется опыт от 2 лет, стек: Go, Postgres. Резюме в личку"},
 		{"recall bias: weak but plausible", "Команде нужен продакт. Подробности у @someone"},
-		// Ukrainian. None of these carry a RU or EN marker: "вакансія" cannot match the
-		// RU "ваканси" (і and и are distinct runes), and "зарплат" is kept out of the
-		// salary case so it rests on the hryvnia amount alone.
+		// Ukrainian. Each case rests on exactly ONE Ukrainian alternative, so removing
+		// that alternative fails this case and nothing else. None carries a RU or EN
+		// marker: "вакансія" cannot match the RU "ваканси" (і and и are distinct runes).
 		{"ua marker вакансія", "Вакансія: Golang розробник у продуктову команду"},
 		{"ua marker шукаємо", "Шукаємо QA Engineer у команду"},
-		{"ua experience + hryvnia amount", "Досвід роботи від 2 років, 60 000 грн на місяць"},
-		{"ua internship", "Запрошуємо на стажування студентів"},
+		{"ua marker запрошуємо", "Запрошуємо Java-інженера до продуктової команди"},
+		{"ua marker стажування", "Оплачуване стажування для студентів, Київ"},
+		{"ua marker досвід роботи", "Бекенд-інженер, досвід роботи від 3 років, Львів"},
 	}
 	for _, tc := range pass {
 		t.Run("pass/"+tc.name, func(t *testing.T) {
@@ -35,6 +36,9 @@ func TestLooksLikeVacancy(t *testing.T) {
 		{"empty-ish", "🔥🔥🔥"},
 		{"ua news digest", "Дайджест новин тижня: Google оновив пошук"},
 		{"ua course ad", "Знижка 50% на курс — встигни записатись"},
+		// A hryvnia amount is not a hiring signal: the editorial channels price event
+		// tickets in the same three-digit range a salary would occupy.
+		{"ua event ticket priced in hryvnia", "Встигніть купити квиток на DOU Day Picnic за 500 грн"},
 	}
 	for _, tc := range reject {
 		t.Run("reject/"+tc.name, func(t *testing.T) {

--- a/openspec/changes/ukrainian-telegram-intake/.openspec.yaml
+++ b/openspec/changes/ukrainian-telegram-intake/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/ukrainian-telegram-intake/design.md
+++ b/openspec/changes/ukrainian-telegram-intake/design.md
@@ -1,0 +1,144 @@
+## Context
+
+`cmd/tg-ingest` crawls each configured channel's public `t.me/s` preview and enqueues posts;
+`cmd/tg-extract` drains that queue through an LLM. Between them sits `LooksLikeVacancy`
+(`internal/telegram/prefilter.go`) — one regexp organised into commented per-language blocks
+(RU, EN, plus salary-amount patterns). Its job is to spare the metered stage from posts that
+are obviously not vacancies; `internal/telegram/AGENTS.md` states the LLM is the real
+classifier.
+
+The regexp has no Ukrainian block, and the Russian one does not reach Ukrainian by accident:
+`ваканси` cannot match `вакансія` because `и` (U+0438) and `і` (U+0456) are distinct runes.
+
+Measured 2026-08-01 against live previews (20 newest posts per channel):
+
+| Channel | posts | pass today | Ukrainian markers add |
+|---|---|---|---|
+| wwjobs | 20 | 4 | +15 |
+| naymarnya | 18 | 3 | +7 |
+| junior_dou_ua | 20 | 4 | +5 |
+| halepnyirecruiting | 18 | 0 | +3 |
+
+The same measurement over eight channels already in `sources/telegram.yml` gives 17–19 of 20
+passing and zero rescued — production is not leaking today. The gap opens only when Ukrainian
+channels are onboarded.
+
+Downstream, `internal/location` resolves an extracted `location` string. `Львів`, `Харків`,
+`Одеса`, `Дніпро` yield a city name with no country and no region, while `Berlin`, `Warsaw`,
+`Kraków` yield both. That is the documented contract at `internal/location/location.go:78-82`
+working as designed: the generated GeoNames `cityDict` supplies the canonical name only, never
+a country, so an ambiguous city can never guess a geography. Country comes from the curated
+`nameToCountry` map, which holds `kyiv`/`киев`/`київ` and no other Ukrainian entry.
+
+Source of candidates: [nikit0ns/Ukrainian_IT_Communities](https://github.com/nikit0ns/Ukrainian_IT_Communities),
+192 entries — 97 group chats, 68 channels, 12 websites, 15 other platforms.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The prefilter recognises Ukrainian vacancy posts.
+- Ukrainian cities resolve to `ua` and to the `eu` region, so the vacancies are reachable by
+  the country and region filters.
+- Seven vetted Ukrainian channels enter the crawl, and the human-readable mirror stays in sync.
+
+**Non-Goals:**
+
+- **Telegram group chats** (97 in the source list). `t.me/s` serves posts for channels and
+  nothing for groups — verified on `aiogramua`, `angular_community_ua`, `angularkyiv`: HTTP
+  200, zero message nodes. Reading them needs an MTProto client with a logged-in account.
+- **`jobs.dou.ua`** — HTTP 403 to a plain request; an anti-bot problem, not a source-file one.
+- **`wwjobs`** — the densest candidate (81 keyword hits across 20 posts) but its newest post
+  is 2026-06-10, 52 days old, failing the 30-day admission gate `sources/telegram.yml` states
+  for itself. Revisit if it revives.
+- **Telegram vacancy expiry** — Telegram jobs are reached by none of the three lifecycle close
+  mechanisms and never close. Catalogue-wide, independent of this change, own spec.
+- No schema change, no migration, no new dependency.
+
+## Decisions
+
+### Extend the existing regexp rather than restructure it
+
+Ukrainian becomes a fourth commented block; `грн|₴` joins the currency alternation.
+
+*Alternative — named per-language regexps combined at init.* Rejected: three languages do not
+justify four variables, and one regexp compiles to one automaton scanned once per post, where
+four mean up to four passes on the crawler's hot path. The split would earn its keep if the
+markers were config-driven; they are static.
+
+*Alternative — detect the post's language, then apply a language-specific filter.* Rejected:
+a detector is its own error source, and these posts are routinely bilingual («Вакансія: Senior
+Go Developer, requirements below»).
+
+### The marker set is the measured one
+
+Each candidate scored over 156 posts from eight job channels and 150 from eight news channels,
+counting only posts the current prefilter rejects:
+
+| marker | rescued (job) | admitted (news) |
+|---|---|---|
+| `вакансі` | 22 | 0 |
+| `досвід роботи` | 10 | 1 |
+| `шукаємо\|шукає` | 8 | 1 |
+| `грн`/`₴` amounts | 8 | 2 |
+| `стажуванн` | 5 | 1 |
+| `запрошуємо` | 4 | 0 |
+| `потрібен\|потрібна\|потрібні` | 1 | 1 |
+| `відгук` | 2 | 1 |
+| `наймаємо` | 0 | 0 |
+| `зарплатн` | 0 | 0 |
+
+Adopted: the first six. Dropped: `наймаємо` and `зарплатн` (never fire — `зарплатн` is already
+covered by the RU prefix `зарплат`), `потрібен` and `відгук` (1:1 signal to noise).
+
+The shipped regexp writes `шукає` alone rather than `шукаємо|шукає`: the shorter stem is a
+prefix of the longer, so it matches everything the pair did. Each adopted marker is the
+shortest stem covering its inflections, for the same reason.
+
+The asymmetry settling the borderline cases: a false positive costs one LLM call returning
+`{"jobs": []}`; a false negative loses a vacancy permanently and silently.
+
+### Ukrainian geography goes into the curated map, not the generated one
+
+Two additions to `nameToCountry` in `internal/location/dictionaries.go`, in the blocks that
+already hold `kyiv` and `київ`: the 21 regional capitals in Latin, and the same in Ukrainian
+and Russian Cyrillic plus `україна`/`украина`.
+
+This keeps the dict-only contract intact — country still comes only from the curated map, and
+GeoNames still supplies nothing but a display name. With both sides agreeing on `ua`, the
+agreement branch at `location.go:88` emits city *and* country.
+
+*Alternative — attach the country from `cityDict`.* Rejected: it would let every ambiguous
+city in the GeoNames table guess a geography, which is the exact failure the contract exists
+to prevent.
+
+### DOU verticals are `authored`, not `board`
+
+They publish digests where one post can carry several roles, which is what `KindAuthored`
+instructs the model to split (`internal/telegram/llm.go:104`). The two recruiter channels are
+`board` — one post, one vacancy.
+
+## Risks / Trade-offs
+
+- **More posts reach the metered LLM stage.** → Bounded by seven channels; the adopted set's
+  false-positive rate is 5 posts per 150 on channels carrying no vacancies at all.
+- **A broader alternation could admit noise in channels that already work.** → Extending an
+  alternation is monotonic: it can only add matches, so this is the only way the change can do
+  harm. The before/after measurement on the eight production RU channels must show no change.
+- **`досвід роботи` can appear in course advertising.** → 1 admission per 150 news posts,
+  accepted given the recall asymmetry. If it degrades, it is one alternative to remove.
+- **The docs mirror can drift from the YAML.** → Both edited in the same commit; the counts are
+  in sync today (88 rows against 88 entries) and verified after the change (95).
+- **Ukrainian city names are added by hand.** → Confined to the 21 regional capitals; long-tail
+  towns keep resolving to a bare city name, the same as any other country's long tail.
+
+## Migration Plan
+
+No migration. The change is data plus one regexp; deploying it changes only which posts the
+next `cmd/tg-ingest` run enqueues. Rollback is reverting the commit — already-extracted jobs
+stay in the catalogue and are unaffected.
+
+## Open Questions
+
+None. Channel liveness, preview availability, marker scoring, and the geography gap were all
+measured before this document was written.

--- a/openspec/changes/ukrainian-telegram-intake/design.md
+++ b/openspec/changes/ukrainian-telegram-intake/design.md
@@ -53,13 +53,13 @@ Source of candidates: [nikit0ns/Ukrainian_IT_Communities](https://github.com/nik
   for itself. Revisit if it revives.
 - **Telegram vacancy expiry** — Telegram jobs are reached by none of the three lifecycle close
   mechanisms and never close. Catalogue-wide, independent of this change, own spec.
-- No schema change, no migration, no new dependency.
+- No schema change and no new dependency. The rollout is not a no-op — see Migration Plan.
 
 ## Decisions
 
 ### Extend the existing regexp rather than restructure it
 
-Ukrainian becomes a fourth commented block; `грн|₴` joins the currency alternation.
+Ukrainian becomes a fourth commented block alongside RU and EN.
 
 *Alternative — named per-language regexps combined at init.* Rejected: three languages do not
 justify four variables, and one regexp compiles to one automaton scanned once per post, where
@@ -88,12 +88,22 @@ counting only posts the current prefilter rejects:
 | `наймаємо` | 0 | 0 |
 | `зарплатн` | 0 | 0 |
 
-Adopted: the first six. Dropped: `наймаємо` and `зарплатн` (never fire — `зарплатн` is already
+Dropped on the numbers above: `наймаємо` and `зарплатн` (never fire — `зарплатн` is already
 covered by the RU prefix `зарплат`), `потрібен` and `відгук` (1:1 signal to noise).
 
-The shipped regexp writes `шукає` alone rather than `шукаємо|шукає`: the shorter stem is a
-prefix of the longer, so it matches everything the pair did. Each adopted marker is the
-shortest stem covering its inflections, for the same reason.
+**`грн`/`₴` was dropped after code review, and the scoring above is why it nearly shipped.**
+The table counts *marker matches inside job channels*, which is a proxy for "rescued a
+vacancy" — and the proxy breaks on this cohort, because five of the seven channels are
+editorial. Reading the posts the alternative admitted on its own: seven of seven are DOU Day
+Picnic ticket prices, an army fundraiser, and a vinyl raffle. Zero vacancies. The hryvnia is
+low-denomination, so the amount pattern's three-digit floor cannot separate «500 грн» for a
+ticket from a salary, where the same floor works for «250 000 руб» and «$120k». Its measured
+value on the shipped cohort is negative, so the currency alternation is left untouched.
+
+Adopted, therefore: `вакансі`, `шукає`, `запрошуємо`, `стажуванн`, `досвід роботи`. The
+regexp writes `шукає` rather than `шукаємо|шукає` — the shorter stem is a prefix of the
+longer, so it matches everything the pair did, while still excluding `шукаю`, the
+job-seeker form.
 
 The asymmetry settling the borderline cases: a false positive costs one LLM call returning
 `{"jobs": []}`; a false negative loses a vacancy permanently and silently.
@@ -101,8 +111,17 @@ The asymmetry settling the borderline cases: a false positive costs one LLM call
 ### Ukrainian geography goes into the curated map, not the generated one
 
 Two additions to `nameToCountry` in `internal/location/dictionaries.go`, in the blocks that
-already hold `kyiv` and `київ`: the 21 regional capitals in Latin, and the same in Ukrainian
-and Russian Cyrillic plus `україна`/`украина`.
+already hold `kyiv` and `київ`: the oblast centres in Latin (Ukrainian and Russian
+transliteration), and the same in Cyrillic plus `україна`/`украина`.
+
+A name is omitted where GeoNames places the alias in more than one country, the precedent the
+file already sets for `georgia` (the US state). The two blocks apply that test at different
+strengths, because a Latin location field can come from anywhere while a Cyrillic one comes
+from a Cyrillic-writing source: `odesa`/`odessa`, `lutsk`, `cherkasy`, `donetsk`, `nikolaev`
+are absent from the Latin block, and only the ones colliding with Belarus, Bulgaria, or
+Russia (`луцьк`, `черкассы`, `николаев`) are absent from the Cyrillic one. `donetsk` is
+ambiguous in both scripts and appears in neither. Those cities keep resolving to a bare city
+name — under-resolving is what the never-guess contract asks for.
 
 This keeps the dict-only contract intact — country still comes only from the curated map, and
 GeoNames still supplies nothing but a display name. With both sides agreeing on `ua`, the
@@ -120,23 +139,44 @@ instructs the model to split (`internal/telegram/llm.go:104`). The two recruiter
 
 ## Risks / Trade-offs
 
-- **More posts reach the metered LLM stage.** → Bounded by seven channels; the adopted set's
-  false-positive rate is 5 posts per 150 on channels carrying no vacancies at all.
+- **More posts reach the metered LLM stage.** → Bounded by seven channels: 16 posts to 39
+  across their latest 136. The five DOU verticals are editorial, so some of the additions are
+  course digests and event invitations; each costs one call returning `{"jobs": []}`, and the
+  extraction prompt already lists "course ad" as a negative.
 - **A broader alternation could admit noise in channels that already work.** → Extending an
   alternation is monotonic: it can only add matches, so this is the only way the change can do
   harm. The before/after measurement on the eight production RU channels must show no change.
-- **`досвід роботи` can appear in course advertising.** → 1 admission per 150 news posts,
-  accepted given the recall asymmetry. If it degrades, it is one alternative to remove.
+- **`досвід роботи` and `стажуванн` can appear in course advertising.** → Accepted given the
+  recall asymmetry; each is one alternative to remove if it degrades. Every adopted
+  alternative has a test that fails when it alone is deleted, so removing one is a
+  one-line change with immediate feedback.
 - **The docs mirror can drift from the YAML.** → Both edited in the same commit; the counts are
   in sync today (88 rows against 88 entries) and verified after the change (95).
-- **Ukrainian city names are added by hand.** → Confined to the 21 regional capitals; long-tail
-  towns keep resolving to a bare city name, the same as any other country's long tail.
+- **Ukrainian city names are added by hand.** → Confined to oblast centres; long-tail towns
+  keep resolving to a bare city name, the same as any other country's long tail.
+- **A curated name could collide with a place in another country.** → Every added key was
+  checked against `cities15000.tsv`; the ambiguous ones are omitted and listed in the code
+  comment. Verified after the fact: `Parse("Odesa, TX")` still resolves to `us` alone.
 
 ## Migration Plan
 
-No migration. The change is data plus one regexp; deploying it changes only which posts the
-next `cmd/tg-ingest` run enqueues. Rollback is reverting the commit — already-extracted jobs
-stay in the catalogue and are unaffected.
+No schema migration. The rollout is not a no-op, though: `internal/location/AGENTS.md` states
+that a dictionary change needs a re-derive to reach existing rows, because geography lives as
+Meilisearch facets rather than SQL columns. Without it the prefilter half takes effect on the
+next `cmd/tg-ingest` run while every job already in the catalogue with a Ukrainian location
+keeps its empty `countries`/`regions` — the precise benefit this change promises.
+
+Order:
+
+1. Deploy.
+2. `cmd/backfill-derive` — re-derives the facet columns from the new dictionary.
+3. `make reindex` — rebuilds the search index so the facets are served.
+
+Never stack step 3 with `reindex-companies`, and stop `freehire-reindexw.timer` before a
+manual reindex.
+
+Rollback is reverting the commit; the same two steps then restore the previous facets.
+Already-extracted jobs stay in the catalogue either way.
 
 ## Open Questions
 

--- a/openspec/changes/ukrainian-telegram-intake/proposal.md
+++ b/openspec/changes/ukrainian-telegram-intake/proposal.md
@@ -10,12 +10,13 @@ look like the channels are weak rather than the filter blind.
 
 ## What Changes
 
-- Ukrainian hiring markers join the prefilter regexp as a fourth language block, and
-  `грн`/`₴` join its currency alternation. The marker set is the measured one: `вакансі`,
-  `шукаємо|шукає`, `запрошуємо`, `стажуванн`, `досвід роботи`. Candidates that never fired or
-  that scored 1:1 signal-to-noise over 306 live posts are excluded.
-- Ukraine's regional capitals and the native country spelling enter the curated
-  `nameToCountry` map, in Latin and in both Cyrillic spellings. Today only `kyiv`/`киев`/`київ`
+- Ukrainian hiring markers join the prefilter regexp as a fourth language block: `вакансі`,
+  `шукає`, `запрошуємо`, `стажуванн`, `досвід роботи`. Candidates that never fired or that
+  scored 1:1 signal-to-noise over 306 live posts are excluded, as is `грн`/`₴` — reading the
+  posts it admitted showed event tickets and fundraisers, not salaries.
+- Ukraine's oblast centres and the native country spelling enter the curated
+  `nameToCountry` map, in Latin and in both Cyrillic spellings, minus the names GeoNames
+  places in more than one country. Today only `kyiv`/`киев`/`київ`
   are present, so a Lviv or Kharkiv vacancy lands with a city name but no country and no
   region — invisible to `country=ua` and to the `eu` region filter.
 - Seven vetted Ukrainian channels join `sources/telegram.yml`: two job boards
@@ -51,7 +52,9 @@ would imply the rule changed.
 - `sources/telegram.yml` — 88 channels → 95
 - `docs/telegram-channels.md` — mirror and header count
 - Cost: the prefilter admits more posts to the metered LLM extraction stage, bounded by the
-  seven new channels. The measured false-positive rate of the adopted marker set is 5 posts
-  per 150 on channels that carry no vacancies at all.
+  seven new channels — 16 posts to 39 across their latest 136. Not all of the additions are
+  vacancies: the five DOU verticals are editorial, so course digests and event invitations
+  reach the LLM and come back as `{"jobs": []}`. That is one call each, and the extraction
+  prompt already lists "course ad" as a negative.
 - No effect on the 88 channels already crawled: the same measurement over eight of them
   showed zero posts rescued by Ukrainian markers, because they publish in Russian.

--- a/openspec/changes/ukrainian-telegram-intake/proposal.md
+++ b/openspec/changes/ukrainian-telegram-intake/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The Telegram crawl covers 88 channels, all Russian- or English-language, and the prefilter
+that guards the extraction queue carries hiring markers in those two languages only. A
+Ukrainian post is silently discarded: `вакансія` does not match the Russian alternative
+`ваканси`, because Cyrillic `і` (U+0456) and `и` (U+0438) are different runes. Measured on
+live channel previews, the current prefilter passes 3 of 18 posts on `naymarnya` and 0 of 18
+on `halepnyirecruiting` — so onboarding Ukrainian channels without fixing the filter would
+look like the channels are weak rather than the filter blind.
+
+## What Changes
+
+- Ukrainian hiring markers join the prefilter regexp as a fourth language block, and
+  `грн`/`₴` join its currency alternation. The marker set is the measured one: `вакансі`,
+  `шукаємо|шукає`, `запрошуємо`, `стажуванн`, `досвід роботи`. Candidates that never fired or
+  that scored 1:1 signal-to-noise over 306 live posts are excluded.
+- Ukraine's regional capitals and the native country spelling enter the curated
+  `nameToCountry` map, in Latin and in both Cyrillic spellings. Today only `kyiv`/`киев`/`київ`
+  are present, so a Lviv or Kharkiv vacancy lands with a city name but no country and no
+  region — invisible to `country=ua` and to the `eu` region filter.
+- Seven vetted Ukrainian channels join `sources/telegram.yml`: two job boards
+  (`naymarnya`, `halepnyirecruiting`) and five DOU editorial verticals (`devops_dou`,
+  `dou_qa`, `frontend_dou`, `gamedev_dou`, `junior_dou_ua`).
+- `docs/telegram-channels.md`, which declares itself a mirror of the YAML, gains a dated
+  section and an updated header count.
+
+No breaking changes. No schema change, no migration.
+
+## Capabilities
+
+### New Capabilities
+
+None. Both affected areas already have specs.
+
+### Modified Capabilities
+
+- `telegram-ingest`: the prefilter requirement gains an explicit obligation that marker
+  coverage span the languages the configured channels publish in. The gap this change fixes
+  was not a coding slip — it was an unstated invariant, so it belongs in the spec rather than
+  in a comment.
+
+`job-geography` is deliberately **not** modified. Its requirement already says the parser
+resolves tokens against curated dictionaries and emits only what those dictionaries contain,
+never guessing. Adding Ukrainian entries is data under an unchanged rule; changing the spec
+would imply the rule changed.
+
+## Impact
+
+- `internal/telegram/prefilter.go`, `internal/telegram/prefilter_test.go`
+- `internal/location/dictionaries.go`, `internal/location/location_test.go`
+- `sources/telegram.yml` — 88 channels → 95
+- `docs/telegram-channels.md` — mirror and header count
+- Cost: the prefilter admits more posts to the metered LLM extraction stage, bounded by the
+  seven new channels. The measured false-positive rate of the adopted marker set is 5 posts
+  per 150 on channels that carry no vacancies at all.
+- No effect on the 88 channels already crawled: the same measurement over eight of them
+  showed zero posts rescued by Ukrainian markers, because they publish in Russian.

--- a/openspec/changes/ukrainian-telegram-intake/specs/telegram-ingest/spec.md
+++ b/openspec/changes/ukrainian-telegram-intake/specs/telegram-ingest/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Obvious non-vacancy posts are filtered before extraction
+
+The crawl SHALL apply a heuristic prefilter at insert: a post with no vacancy
+markers SHALL be stored as already-processed with zero vacancies, so it is
+never sent to the LLM, while remaining recorded against re-crawls. The filter
+SHALL favor recall: any post with plausible vacancy markers proceeds to
+extraction. The marker set SHALL cover every language the configured channels
+publish in, and a channel SHALL NOT be added to `sources/telegram.yml` in a
+language the markers do not yet cover — an uncovered language makes the filter
+reject that channel's vacancies wholesale, which is indistinguishable from the
+channel having none.
+
+#### Scenario: A non-vacancy post is recorded but not queued
+
+- **WHEN** a crawled post contains no vacancy markers
+- **THEN** it is stored as processed with zero vacancies and is not claimable
+  by the extraction worker
+
+#### Scenario: A Ukrainian-language vacancy reaches extraction
+
+- **WHEN** a crawled post advertises a role in Ukrainian (e.g. «Шукаємо Golang
+  розробника», «Вакансія: QA Engineer») and contains no Russian or English
+  marker
+- **THEN** it is stored as pending and is claimable by the extraction worker
+
+#### Scenario: A Ukrainian-language non-vacancy post is still filtered
+
+- **WHEN** a crawled post is Ukrainian editorial content carrying no hiring
+  markers (e.g. «Дайджест новин тижня»)
+- **THEN** it is stored as processed with zero vacancies and is not claimable
+  by the extraction worker

--- a/openspec/changes/ukrainian-telegram-intake/tasks.md
+++ b/openspec/changes/ukrainian-telegram-intake/tasks.md
@@ -1,0 +1,54 @@
+## 1. Prefilter recognises Ukrainian
+
+- [x] 1.1 Add failing Ukrainian cases to `internal/telegram/prefilter_test.go`, in the two
+  tables that already exist. Pass: «Вакансія: Golang розробник», «Шукаємо QA у продуктову
+  команду», «Досвід роботи від 2 років, зарплата 60 000 грн», «Запрошуємо на стажування».
+  Reject: «Дайджест новин тижня», «Знижка 50% на курс — встигни записатись». Confirm the pass
+  cases fail today and the reject cases already hold.
+- [x] 1.2 Add the Ukrainian marker block to the regexp in `internal/telegram/prefilter.go`
+  (`вакансі|шукаємо|шукає|запрошуємо|стажуванн|досвід роботи`) with a comment recording why
+  `ваканси` does not reach it, and extend the currency alternation with `грн|₴`. Tests green.
+
+## 2. Ukrainian geography resolves to a country
+
+- [x] 2.1 Add failing cases to `internal/location/location_test.go`, mirroring the existing
+  `Київ` case: `Львів`, `Харків`, `Lviv, Ukraine`, and `Україна` → the expected `Geo`
+  (countries `["ua"]`, regions `["eu"]`, city where a city is named).
+- [x] 2.2 Add the Latin entries (21 regional capitals) to `nameToCountry` in
+  `internal/location/dictionaries.go`, in the CIS block beside `kyiv`. Tests for the Latin
+  cases green.
+- [x] 2.3 Add the Cyrillic entries — the same cities in Ukrainian and Russian spelling, plus
+  `україна`/`украина` — in the Cyrillic block beside `київ`. All of 2.1 green.
+
+## 3. Channels and their mirror
+
+- [x] 3.1 Add the seven channels to `sources/telegram.yml` under two commented headings:
+  `naymarnya` and `halepnyirecruiting` as `board`, and `devops_dou`, `dou_qa`, `frontend_dou`,
+  `gamedev_dou`, `junior_dou_ua` as `authored`. Record in the comment that the cohort was
+  verified 2026-08-01 and that `wwjobs` was held back as stale.
+- [x] 3.2 Add the dated section to `docs/telegram-channels.md` and update the header count from
+  `88 channels (12 authored, 76 board)` to `95 channels (17 authored, 78 board)`. Note there
+  why the source list's 97 group chats are unusable. Verify the table row count matches the
+  YAML entry count.
+
+## 4. Verification
+
+- [x] 4.1 Run `go test ./...` and `go test -tags=integration ./internal/db/`. Both green.
+- [x] 4.2 Re-run the prefilter measurement against live `t.me/s` previews: `naymarnya` and
+  `halepnyirecruiting` pass materially more posts than before, and the eight production RU
+  channels (`it_vakansii_jobs`, `vakansii_it`, `jobforjunior`, `huntmejob`, `normrabota`,
+  `zrabota`, `budujobs`, `product_jobs`) show no change. Record the numbers.
+
+  Measured 2026-08-01 with the shipped `LooksLikeVacancy` against the pre-change regexp,
+  over live `t.me/s` previews:
+
+  | cohort | posts | before | after | delta |
+  |---|---|---|---|---|
+  | Ukrainian (7 channels) | 136 | 16 | 39 | **+23** |
+  | production RU (8 channels) | 159 | 120 | 120 | **+0** |
+
+  Per channel, the largest gains are `junior_dou_ua` +7, `naymarnya` +6, and
+  `halepnyirecruiting` +3 (from zero). `gamedev_dou` gained nothing — its latest 20 posts
+  carry no vacancy at all, which is a property of the window, not of the filter. Every
+  production channel moved by exactly zero, which is the safety property this task exists
+  to check.

--- a/openspec/changes/ukrainian-telegram-intake/tasks.md
+++ b/openspec/changes/ukrainian-telegram-intake/tasks.md
@@ -6,19 +6,27 @@
   Reject: «Дайджест новин тижня», «Знижка 50% на курс — встигни записатись». Confirm the pass
   cases fail today and the reject cases already hold.
 - [x] 1.2 Add the Ukrainian marker block to the regexp in `internal/telegram/prefilter.go`
-  (`вакансі|шукаємо|шукає|запрошуємо|стажуванн|досвід роботи`) with a comment recording why
-  `ваканси` does not reach it, and extend the currency alternation with `грн|₴`. Tests green.
+  (`вакансі|шукає|запрошуємо|стажуванн|досвід роботи`) with a comment recording why `ваканси`
+  does not reach it. Tests green.
+
+  `грн|₴` was scored as a candidate and **not** shipped: reading the posts it admitted on its
+  own showed seven event tickets, fundraisers and a raffle, and zero vacancies. A reject test
+  pins that decision.
 
 ## 2. Ukrainian geography resolves to a country
 
 - [x] 2.1 Add failing cases to `internal/location/location_test.go`, mirroring the existing
   `Київ` case: `Львів`, `Харків`, `Lviv, Ukraine`, and `Україна` → the expected `Geo`
   (countries `["ua"]`, regions `["eu"]`, city where a city is named).
-- [x] 2.2 Add the Latin entries (21 regional capitals) to `nameToCountry` in
-  `internal/location/dictionaries.go`, in the CIS block beside `kyiv`. Tests for the Latin
-  cases green.
+- [x] 2.2 Add the Latin entries (oblast centres, Ukrainian and Russian transliteration) to
+  `nameToCountry` in `internal/location/dictionaries.go`, in the CIS block beside `kyiv`.
+  Check every key against `cities15000.tsv` and omit the ones GeoNames places in more than
+  one country. Tests for the Latin cases green.
 - [x] 2.3 Add the Cyrillic entries — the same cities in Ukrainian and Russian spelling, plus
   `україна`/`украина` — in the Cyrillic block beside `київ`. All of 2.1 green.
+- [x] 2.4 Teach `cityMarkerPrefixes` the Ukrainian city marker (`м.`, `місто `) alongside the
+  Russian `г.`/`город `, with a regression case proving a city merely starting with `м`
+  (`Мурманск`) is untouched. Found in review: `м. Львів` resolved to nothing at all.
 
 ## 3. Channels and their mirror
 
@@ -30,6 +38,13 @@
   `88 channels (12 authored, 76 board)` to `95 channels (17 authored, 78 board)`. Note there
   why the source list's 97 group chats are unusable. Verify the table row count matches the
   YAML entry count.
+
+## 4. Rollout
+
+- [ ] 4.0 After deploy, run `cmd/backfill-derive` and then `make reindex`. Geography lives as
+  Meilisearch facets, so a dictionary change reaches existing rows only through a re-derive
+  (`internal/location/AGENTS.md`); without it only newly-ingested jobs get `ua`/`eu`. Stop
+  `freehire-reindexw.timer` first and never stack the reindex with `reindex-companies`.
 
 ## 4. Verification
 

--- a/sources/telegram.yml
+++ b/sources/telegram.yml
@@ -236,3 +236,27 @@ channels:
     kind: board
   - channel: wantapply_qa_jobs
     kind: board
+
+  # --- Ukrainian, from the 2026-08-01 Ukrainian_IT_Communities mining ---
+  # Verified 2026-08-01: public t.me/s preview enabled and a post within 30 days.
+  # The source list's 97 Telegram *chats* are unusable — a group's preview serves no
+  # posts. wwjobs is held back: densest candidate of the cohort, but its newest post
+  # is 2026-06-10, past the 30-day gate; revisit if it revives.
+  # Ukrainian-language posts only reach extraction because prefilter.go carries UA
+  # markers — do not add a channel in a language those markers do not cover.
+  - channel: naymarnya
+    kind: board
+  - channel: halepnyirecruiting
+    kind: board
+
+  # DOU verticals: digests that can bundle several roles in one post.
+  - channel: devops_dou
+    kind: authored
+  - channel: dou_qa
+    kind: authored
+  - channel: frontend_dou
+    kind: authored
+  - channel: gamedev_dou
+    kind: authored
+  - channel: junior_dou_ua
+    kind: authored


### PR DESCRIPTION
## Why

The Telegram crawl covered 88 channels, all Russian- or English-language, and the prefilter guarding the extraction queue carried markers in those two languages only. Russian does not reach Ukrainian by accident: `ваканси` cannot match `вакансія`, because Cyrillic `і` (U+0456) and `и` (U+0438) are distinct runes. A Ukrainian vacancy was stored as processed with zero vacancies and never shown to the LLM.

## What changed

- **Prefilter** — a Ukrainian marker block: `вакансі|шукає|запрошуємо|стажуванн|досвід роботи`.
- **Geography** — Ukraine's oblast centres and the native country spelling enter the curated `nameToCountry` map, in Latin and Cyrillic. Until now only Kyiv was there, so a Lviv or Kharkiv vacancy resolved to a city name with no country and no region, invisible to `country=ua` and the `eu` region filter. The dict-only contract is untouched: country still comes from the curated map alone, never from the generated GeoNames dictionary.
- **City marker** — `м. Львів` resolved to nothing at all, where `г. Львів` resolved fully.
- **Channels** — 7 vetted Ukrainian channels (88 → 95): 2 recruiter boards and 5 DOU editorial verticals, the latter `authored` because their digests bundle several roles per post.
- **Extraction prompt** — now declares a Ukrainian input.

## Measurements

Against live `t.me/s` previews, comparing the shipped `LooksLikeVacancy` with the pre-change regexp:

| cohort | posts | before | after |
|---|---|---|---|
| Ukrainian (7 channels) | 136 | 16 | **39** |
| production RU (8 channels) | 159 | 120 | **120** |

The second row is the property that matters. Extending an alternation is monotonic — it can only add matches — so the only way this change can do harm is by admitting noise in channels that already work. Every one of them moved by exactly zero.

## Notable decisions

**`грн`/`₴` was scored and deliberately not shipped.** The marker scoring counted matches inside job channels and treated them as rescued vacancies; the proxy breaks here because five of the seven channels are editorial. Reading the posts the alternative admitted on its own: seven DOU Day Picnic ticket prices, an army fundraiser and a vinyl raffle, and no vacancy. The hryvnia is low-denomination, so the amount pattern's three-digit floor cannot tell a ticket from a salary the way it can for `руб` and `$`. A reject test pins the decision.

**Ambiguous city names are omitted, not guessed.** Every key was checked against `cities15000.tsv`. `odesa`, `lutsk`, `cherkasy`, `donetsk`, `nikolaev` are absent from the Latin block and `луцьк`, `черкассы`, `николаев` from the Cyrillic one — the two blocks apply the test at different strengths, because a Latin location field can come from anywhere while a Cyrillic one comes from a Cyrillic-writing source. `Parse("Odesa, TX")` still answers `us` alone.

**Excluded from the source list, with reasons recorded in the docs** so they are not re-derived: its 97 Telegram *chats* (a group's `t.me/s` preview serves no posts — verified on three), `wwjobs` (densest candidate, but 52 days stale, past the gate the YAML states for itself), and `jobs.dou.ua` (HTTP 403).

**Docs mirror drift, fixed in passing.** `docs/telegram-channels.md` declares itself a mirror of the YAML. At base both counted 88 while differing by four entries each way — four channels dropped in #893 lingered, four `wantapply_*` additions were missing. The totals matched by coincidence, which is why nobody noticed. Both sides now agree, verified by parsing rather than eyeballing.

## Rollout — not a no-op

Geography lives as Meilisearch facets, so a dictionary change reaches existing rows only through a re-derive (`internal/location/AGENTS.md`). After deploy:

1. `cmd/backfill-derive`
2. `make reindex` — stop `freehire-reindexw.timer` first, and never stack it with `reindex-companies`.

Without this, only newly-ingested jobs get `ua`/`eu`.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...`, `go test -tags=integration ./internal/db/` — all green. Each Ukrainian alternative has a test that fails when that alternative alone is deleted, verified by ablation.

## Follow-up

Telegram vacancies never close: the ingest sweep does not reach them, there is no change feed, and `cmd/liveness` excludes them because the stored URL is the post, which outlives the vacancy. Recorded as a limitation in `internal/telegram/AGENTS.md`; the mechanism needs its own change. Note that `openspec/specs/job-lifecycle/spec.md:97` still requires the opposite of what `cmd/liveness` does — that reconciliation belongs with it.