### PR TITLE
fix(sources): drop 44 harvested boards the portal page says belong elsewhere

### DIFF
--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8129,8 +8129,6 @@
   board: 83bar
 - company: acre security
   board: acresecurity
-- company: Aequilibrium
-  board: aequilibrium
 - company: Airitos
   board: airitos
 - company: Alia Services
@@ -8161,8 +8159,6 @@
   board: cleargov
 - company: ClearStar
   board: clearstar
-- company: CME
-  board: cme
 - company: Collider
   board: collider
 - company: Cytovale
@@ -8223,8 +8219,6 @@
   board: inair
 - company: Indigo Slate
   board: indigoslate
-- company: Industrial Electric Manufacturing
-  board: industrialelectricmanufacturing
 - company: iPromo
   board: ipromo
 - company: Jets.com
@@ -8235,8 +8229,6 @@
   board: legacyhrconsulting
 - company: Leggett & Platt
   board: leggettplatt
-- company: Leverify
-  board: leverify
 - company: Lexipol LLC
   board: lexipol
 - company: Life Science Connect
@@ -8247,5 +8239,3 @@
   board: longbowadvantage
 - company: LTD Global
   board: ltdglobal
-- company: Xpanxion
-  board: xpanxion

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1072,18 +1072,10 @@
   board: bridgit
 - company: Brighton Science
   board: brightonscience
-- company: Canon
-  board: canon
 - company: career
   board: career
-- company: Charterhouse
-  board: charterhouse
-- company: CIS College
-  board: ciscollege
 - company: ClearStar
   board: clearstar
-- company: CloudFactory
-  board: cloudfactory
 - company: 'Coalition Technologies '
   board: coalitiontechnologies
 - company: Conifer
@@ -1096,38 +1088,20 @@
   board: darwinbox
 - company: DataBank
   board: databank
-- company: Digital
-  board: digital
 - company: DigitalOnUs
   board: digitalonus
 - company: Dimagi, Inc.
   board: dimagi
 - company: Education Northwest
   board: educationnorthwest
-- company: Ellevation Education
-  board: ellevationeducation
 - company: Engine Digital
   board: enginedigital
 - company: Envato
   board: envato
 - company: E-SPACE
   board: espace
-- company: Excel
-  board: excel
-- company: Farmers
-  board: farmers
-- company: Fever
-  board: fever
 - company: Finance active
   board: financeactive
-- company: Find.co
-  board: find
-- company: First Student
-  board: firststudent
-- company: Flinks
-  board: flinks
-- company: Future PLC
-  board: future
 - company: George Jon
   board: georgejon
 - company: Guardian
@@ -1148,54 +1122,34 @@
   board: iflip4
 - company: IJL Select
   board: ijlselect
-- company: Infinity Group
-  board: infinitygroup
 - company: Infosys Limited
   board: infosys
 - company: Innovaccer
   board: innovaccer
 - company: Inspectorio
   board: inspectorio
-- company: Intel Corporation
-  board: intel
-- company: intellect
-  board: intellect
 - company: Irex Consulting
   board: irexconsulting
 - company: Island
   board: island
 - company: iTutor
   board: itutor
-- company: Jeeves
-  board: jeeves
-- company: Jones
-  board: jones
 - company: JumpstartMD
   board: jumpstartmd
 - company: Justworks, Inc.
   board: justworks
 - company: Kaizen
   board: kaizen
-- company: King Law Offices
-  board: kinglawoffices
 - company: kWallet
   board: kwallet
-- company: Magnum
-  board: magnum
 - company: Manila Recruitment
   board: manilarecruitment
-- company: Marco
-  board: marco
-- company: MAX & TAX
-  board: maxtax
 - company: Meet Cute
   board: meetcute
 - company: Méliuz
   board: meliuz
 - company: Milestone
   board: milestone
-- company: Mind
-  board: mind
 - company: mindbodygreen
   board: mindbodygreen
 - company: Mindlance
@@ -1210,10 +1164,6 @@
   board: motif
 - company: Motive International
   board: motiveinternational
-- company: Moving Walls
-  board: movingwalls
-- company: MP Solutions Ltd.
-  board: mpsolutions
 - company: Multi Media LLC
   board: multimedia
 - company: Nebo Agency
@@ -1226,8 +1176,6 @@
   board: nexus
 - company: NGP VAN
   board: ngpvan
-- company: Nimble
-  board: nimble
 - company: North American Bancard
   board: northamericanbancard
 - company: nterra
@@ -1242,30 +1190,18 @@
   board: penbrothers
 - company: Penn Foster
   board: pennfoster
-- company: People Corporation
-  board: people
 - company: Pilot
   board: pilot
-- company: Pinpoint
-  board: pinpoint
-- company: Pipe
-  board: pipe
 - company: Pitchbox
   board: pitchbox
 - company: Planate Management Group
   board: planatemanagementgroup
-- company: Plum Inc
-  board: plum
 - company: PopuTrust
   board: poputrust
 - company: Port
   board: port
 - company: Positively Partners
   board: positivelypartners
-- company: Premier Inc.
-  board: premier
-- company: PRISM+
-  board: prism
 - company: Proficio
   board: proficio
 - company: Prominence Advisors
@@ -1292,22 +1228,16 @@
   board: satori
 - company: Schnabel Engineering
   board: schnabelengineering
-- company: Scopic
-  board: scopic
 - company: SD Solutions
   board: sdsolutions
 - company: Signal Vine, Inc
   board: signalvine
-- company: Sika AG
-  board: sika
 - company: STAFFVIRTUAL
   board: staffvirtual
 - company: Stefanini
   board: stefanini
 - company: strategic HR, inc.
   board: strategichr
-- company: Summit
-  board: summit
 - company: Team Delegate, LLC
   board: teamdelegate
 - company: Teamswell
@@ -1324,8 +1254,6 @@
   board: thepersimmongroup
 - company: Thought Industries, Inc.
   board: thoughtindustries
-- company: Tive
-  board: tive
 - company: TOTVS
   board: totvs
 - company: Trusted
@@ -1334,8 +1262,6 @@
   board: uniplaces
 - company: Unit4
   board: unit4
-- company: Veda
-  board: veda
 - company: Vestmark
   board: vestmark
 - company: Viaggio Partners, Inc.
@@ -1346,8 +1272,6 @@
   board: vsolvit
 - company: Wagepoint
   board: wagepoint
-- company: WealthForge
-  board: wealthforge
 - company: Web Partners
   board: webpartners
 - company: Whistle
@@ -1358,7 +1282,5 @@
   board: xideral
 - company: Xtremax
   board: xtremax
-- company: YOUNG
-  board: young
 - company: Zadara
   board: zadara


### PR DESCRIPTION
## Why this audit exists

The corroboration gate (#1413) can only fire where the platform publishes an employer name. Everything harvested on jazzhr, trakstar, lever, ashby, gem, deel and hireology (#1472, #1473) was accepted on **liveness alone**, and the only estimate of what that costs came from breezy — a gated provider — at about 8% wrong.

jazzhr and trakstar turn out to publish a name on their **portal page** even though their API does not:

```
jazzhr    <title>83BAR - Career Page
trakstar  <title>Jobs at AFLAC
```

So the gate's own rule could be applied to them retroactively. It was, over all 220 boards these two contributed.

## Result: 44 of 220 do not belong to the company we filed them under

| provider | dropped | of |
|---|---:|---:|
| trakstar | 39 | 158 (25%) |
| jazzhr | 5 | 62 (8%) |

These are not near-misses:

| board | we filed it as | the portal says |
|---|---|---|
| `jones` | Jones | **Test Company** |
| `marco` | Marco | **Company X** |
| `intel` | Intel Corporation | IntelContact |
| `find` | Find.co | find a job |
| `flinks` | Flinks | Flink |
| `future` | Future PLC | Future Drive |
| `mpsolutions` | MP Solutions Ltd. | Recruitment Expert |
| `cme` | CME | Chicago Music Exchange, LLC |

`cme` is the clearest: our CME was advertising a remote Senior Java Engineer; `cme.applytojob.com` belongs to a guitar shop.

The pattern is a single short generic word — `find`, `digital`, `excel`, `farmers`, `future`, `intel`, `summit` — landing on whichever company happens to own that slug.

## On the rule used

A containment rule was tried first and rejected: it keeps `digital` against "Digital Outsource Services" and `intel` against "IntelContact", which are precisely the collisions being hunted. What shipped is `normalize.SameCompany` — the same rule every gated board was judged by — with HTML entities unescaped first, so `Leggett &amp; Platt` is not mistaken for a different employer.

That costs a handful of legitimate boards (Scopic / "Scopic Software", WealthForge / "WealthForge Holdings Inc"). Applying a weaker rule to data already known to be 25% wrong would not be defensible.

## What this says about the rest

**25% on trakstar against 8% on breezy.** The ungated providers are meaningfully worse than the gated estimate suggested, and lever, ashby, gem, deel and hireology (54 boards) publish no name anywhere and remain unverifiable by this method.

`go test ./internal/sources/` passes.
