### PR TITLE
feat(autofill): resolve the contact block from CV, then résumé

### DIFF
--- a/internal/handler/autofill_agent.go
+++ b/internal/handler/autofill_agent.go
@@ -12,24 +12,24 @@ import (
 //
 // The extension triggers this and then watches its own socket do the work — the
 // agent never touches the DOM itself, it only drives the primitives.
-func (a *API) RunAgentAutofill(c *fiber.Ctx) error {
+func (h *autofillHandlers) RunAgentAutofill(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
 		return err
 	}
 
-	profile, err := a.autofillProfile(c.Context(), userID)
+	profile, err := h.autofillProfile(c.Context(), userID)
 	if err != nil {
 		return err
 	}
 
-	caller := a.browserTools.NewCaller(userID)
+	caller := h.browserTools.NewCaller(userID)
 	defer caller.Close()
 
 	report, err := autofillagent.Run(
 		c.Context(),
 		caller,
-		autofillagent.LLMPlanner{Client: a.llm.bind(c.Context(), userID, tagAutofill)},
+		autofillagent.LLMPlanner{Client: h.llm.bind(c.Context(), userID, tagAutofill)},
 		profileFields(profile),
 	)
 	if err != nil {

--- a/internal/handler/autofill_profile.go
+++ b/internal/handler/autofill_profile.go
@@ -2,14 +2,14 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/jackc/pgx/v5"
 
+	"github.com/strelov1/freehire/internal/browsertools"
 	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/resumeextract"
 )
 
 // autofillProfile is the canonical set of fields the browser extension writes
@@ -24,6 +24,93 @@ type autofillProfile struct {
 	LinkedIn  string `json:"linkedin"`
 	GitHub    string `json:"github"`
 	Portfolio string `json:"portfolio"`
+}
+
+// baseCVReader is the one CV read autofill makes. Tailored copies are excluded by the
+// query behind it (GetBaseCVByUser filters NOT is_tailored), not by anything here: a
+// tailored CV is written for one vacancy and the autofill block carries none.
+type baseCVReader interface {
+	BaseCV(ctx context.Context, userID int64) (cv.Record, bool, error)
+}
+
+// resumeContactReader is the one résumé read autofill makes. The bool reports whether a
+// structure current with the uploaded résumé exists: the store compares the structure's
+// stamp against the résumé's upload time, so one derived from a superseded file reads as
+// absent rather than being served.
+type resumeContactReader interface {
+	Structured(ctx context.Context, userID int64) (resumeextract.Structured, bool, error)
+}
+
+// accountReader supplies the address that backstops a contact block stating no email.
+type accountReader interface {
+	GetUserByID(ctx context.Context, id int64) (db.GetUserByIDRow, error)
+}
+
+// autofillHandlers serves the contact block the browser extension fills application forms
+// with, both as a plain read and as an agent-driven run over the caller's own browser.
+//
+// It holds the two contact sources in precedence order (see autofillProfile) plus the
+// account read, the browser-tool hub the agent run drives the caller's page through, and
+// the model binding that run plans on.
+type autofillHandlers struct {
+	cvs      baseCVReader
+	resumes  resumeContactReader
+	accounts accountReader
+	// browserTools is shared with /tools/ws and the assistant — the hub is per-process and
+	// routes strictly within one user's channel.
+	browserTools *browsertools.Hub
+	// llm plans the agent-driven fill. A nil client is the LLM being unconfigured: the run
+	// reports the feature is off and the deterministic read still works.
+	llm llmBinding
+}
+
+func newAutofillHandlers(cvs baseCVReader, resumes resumeContactReader, accounts accountReader, tools *browsertools.Hub, llm llmBinding) *autofillHandlers {
+	return &autofillHandlers{cvs: cvs, resumes: resumes, accounts: accounts, browserTools: tools, llm: llm}
+}
+
+func (h *autofillHandlers) register(api fiber.Router, mw middleware) {
+	// Canonical autofill fields (name/email/phone/location/links) for the browser
+	// extension to write into application forms. keyAuth (Bearer).
+	api.Get("/me/autofill-profile", mw.key, h.AutofillProfile)
+	// Agent-driven autofill: the caller's own browser is driven over the browser-tool
+	// wire. keyAuth (Bearer) so the extension can trigger it.
+	api.Post("/me/autofill/run", mw.key, h.RunAgentAutofill)
+}
+
+// statesContact reports whether a header carries any contact value at all. A source that
+// exists but states nothing is passed over rather than allowed to answer, so a CV created
+// empty does not silence a résumé that has the values.
+func statesContact(h cv.Header) bool {
+	return h.FullName != "" || h.Email != "" || h.Phone != "" || h.Location != "" || len(h.Links) > 0
+}
+
+// firstStatedHeader returns the first header that states any contact value, or the zero
+// header when none does.
+//
+// The chosen header answers for the WHOLE block: fields are never merged across sources.
+// The résumé structure is what seeds a CV (cv.Seed), so the two sources hold the same
+// fields with the CV holding the corrected ones — a merge would restore precisely the
+// value the candidate deleted from their CV.
+func firstStatedHeader(headers ...cv.Header) cv.Header {
+	for _, h := range headers {
+		if statesContact(h) {
+			return h
+		}
+	}
+	return cv.Header{}
+}
+
+// contactHeaderFromStructured projects the structured résumé's contact fields into a
+// header, so the résumé can be offered to firstStatedHeader as one more source. It is the
+// same five-field mapping cv.Seed makes when it seeds a CV from the same structure.
+func contactHeaderFromStructured(st resumeextract.Structured) cv.Header {
+	return cv.Header{
+		FullName: st.FullName,
+		Email:    st.Email,
+		Phone:    st.Phone,
+		Location: st.Location,
+		Links:    st.Links,
+	}
 }
 
 // buildAutofillProfile projects a CV contact header (plus the account email as a
@@ -68,37 +155,46 @@ func splitName(full string) (first, last string) {
 	}
 }
 
-// autofillProfile assembles a user's canonical autofill fields from their most
-// recent CV's contact header plus their account email. Shared by the endpoint the
-// extension reads and the agent that fills forms with it.
-func (a *API) autofillProfile(ctx context.Context, userID int64) (autofillProfile, error) {
-	var accountEmail string
-	_ = a.pool.QueryRow(ctx, `SELECT email FROM users WHERE id = $1`, userID).Scan(&accountEmail)
-
-	var header cv.Header
-	var raw []byte
-	err := a.pool.QueryRow(ctx,
-		`SELECT data FROM cvs WHERE user_id = $1 ORDER BY updated_at DESC LIMIT 1`, userID).Scan(&raw)
-	if err == nil {
-		var doc cv.Document
-		if json.Unmarshal(raw, &doc) == nil {
-			header = doc.Header
-		}
-	} else if !errors.Is(err, pgx.ErrNoRows) {
+// autofillProfile assembles a user's canonical autofill fields from the first source that
+// states a contact, backstopped by their account email. Shared by the endpoint the
+// extension reads and the agent that fills forms with it, so the values a person sees in a
+// form and the values the agent plans on cannot diverge.
+//
+// The sources are ordered: the base CV first, because it is the copy the candidate
+// authored and the only one the tailoring agent cannot rewrite (the edit policy denies it
+// the header's name, email, phone and links); the structured résumé second, because it is
+// what seeded that CV in the first place. Corrected beats derived.
+func (h *autofillHandlers) autofillProfile(ctx context.Context, userID int64) (autofillProfile, error) {
+	var fromCV cv.Header
+	if rec, ok, err := h.cvs.BaseCV(ctx, userID); err != nil {
 		return autofillProfile{}, err
+	} else if ok {
+		fromCV = rec.Document.Header
 	}
 
-	return buildAutofillProfile(header, accountEmail), nil
+	var fromResume cv.Header
+	if st, ok, err := h.resumes.Structured(ctx, userID); err != nil {
+		return autofillProfile{}, err
+	} else if ok {
+		fromResume = contactHeaderFromStructured(st)
+	}
+
+	account, err := h.accounts.GetUserByID(ctx, userID)
+	if err != nil {
+		return autofillProfile{}, err
+	}
+	return buildAutofillProfile(firstStatedHeader(fromCV, fromResume), account.Email), nil
 }
 
 // AutofillProfile returns the caller's canonical autofill fields. keyAuth so the
-// browser extension (Bearer) can read it. All-empty (bar email) with no CV.
-func (a *API) AutofillProfile(c *fiber.Ctx) error {
+// browser extension (Bearer) can read it. All-empty (bar the account email) when no
+// source states a contact.
+func (h *autofillHandlers) AutofillProfile(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
 		return err
 	}
-	profile, err := a.autofillProfile(c.Context(), userID)
+	profile, err := h.autofillProfile(c.Context(), userID)
 	if err != nil {
 		return err
 	}

--- a/internal/handler/autofill_sources_test.go
+++ b/internal/handler/autofill_sources_test.go
@@ -1,0 +1,258 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/resumeextract"
+)
+
+// fakeBaseCV is a baseCVReader returning a canned base CV. ok=false models a user with no
+// base CV — including one whose only CVs are tailored copies, which the store's query
+// excludes.
+type fakeBaseCV struct {
+	doc cv.Document
+	ok  bool
+	err error
+}
+
+func (f fakeBaseCV) BaseCV(context.Context, int64) (cv.Record, bool, error) {
+	return cv.Record{Document: f.doc}, f.ok, f.err
+}
+
+// fakeAccount is an accountReader returning a canned account row.
+type fakeAccount struct {
+	email string
+	err   error
+}
+
+func (f fakeAccount) GetUserByID(context.Context, int64) (db.GetUserByIDRow, error) {
+	return db.GetUserByIDRow{Email: f.email}, f.err
+}
+
+func autofillWith(cvs fakeBaseCV, st resumeextract.Structured, stOK bool, email string) *autofillHandlers {
+	return &autofillHandlers{
+		cvs:      cvs,
+		resumes:  fakeStructuredResume{ret: st, ok: stOK},
+		accounts: fakeAccount{email: email},
+	}
+}
+
+func TestAutofillProfile_PrefersBaseCVOverStructuredResume(t *testing.T) {
+	h := autofillWith(
+		fakeBaseCV{doc: cv.Document{Header: cv.Header{FullName: "Ilya Strelov", Phone: "+1 555 0100"}}, ok: true},
+		resumeextract.Structured{FullName: "I. Strelov", Phone: "+1 555 0199"}, true,
+		"account@example.com",
+	)
+
+	got, err := h.autofillProfile(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("autofillProfile: %v", err)
+	}
+	if got.FullName != "Ilya Strelov" || got.Phone != "+1 555 0100" {
+		t.Errorf("got %q / %q, want the base CV's values", got.FullName, got.Phone)
+	}
+}
+
+func TestAutofillProfile_FallsBackToStructuredResume(t *testing.T) {
+	h := autofillWith(
+		fakeBaseCV{ok: false},
+		resumeextract.Structured{
+			FullName: "Ilya Strelov",
+			Phone:    "+1 555 0100",
+			Links:    []string{"https://linkedin.com/in/ilya"},
+		}, true,
+		"account@example.com",
+	)
+
+	got, err := h.autofillProfile(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("autofillProfile: %v", err)
+	}
+	if got.FullName != "Ilya Strelov" || got.FirstName != "Ilya" || got.LastName != "Strelov" {
+		t.Errorf("name = %q (%q / %q), want the structured résumé's", got.FullName, got.FirstName, got.LastName)
+	}
+	if got.Phone != "+1 555 0100" {
+		t.Errorf("phone = %q, want the structured résumé's", got.Phone)
+	}
+	if got.LinkedIn != "https://linkedin.com/in/ilya" {
+		t.Errorf("linkedin = %q, want the structured résumé's link sorted by host", got.LinkedIn)
+	}
+}
+
+func TestAutofillProfile_EmptyBaseCVFallsThroughToStructuredResume(t *testing.T) {
+	h := autofillWith(
+		fakeBaseCV{doc: cv.Document{Header: cv.Header{}}, ok: true},
+		resumeextract.Structured{FullName: "Ilya Strelov", Phone: "+1 555 0100"}, true,
+		"account@example.com",
+	)
+
+	got, err := h.autofillProfile(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("autofillProfile: %v", err)
+	}
+	if got.FullName != "Ilya Strelov" || got.Phone != "+1 555 0100" {
+		t.Errorf("got %q / %q, want the résumé's values through the empty CV", got.FullName, got.Phone)
+	}
+}
+
+// The chosen source answers for the whole block. A gap in the base CV is a gap the
+// candidate left there — the résumé that seeded it must not fill the gap back in.
+func TestAutofillProfile_DoesNotMergeTheResumeIntoTheBaseCV(t *testing.T) {
+	h := autofillWith(
+		fakeBaseCV{doc: cv.Document{Header: cv.Header{FullName: "Ilya Strelov"}}, ok: true},
+		resumeextract.Structured{
+			FullName: "Ilya Strelov",
+			Phone:    "+1 555 0199",
+			Links:    []string{"https://linkedin.com/in/ilya"},
+		}, true,
+		"account@example.com",
+	)
+
+	got, err := h.autofillProfile(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("autofillProfile: %v", err)
+	}
+	if got.Phone != "" {
+		t.Errorf("phone = %q, want empty: the résumé must not fill a gap in the chosen CV", got.Phone)
+	}
+	if got.LinkedIn != "" {
+		t.Errorf("linkedin = %q, want empty for the same reason", got.LinkedIn)
+	}
+}
+
+func TestAutofillProfile_NoSourceYieldsAccountEmailOnly(t *testing.T) {
+	h := autofillWith(fakeBaseCV{ok: false}, resumeextract.Structured{}, false, "account@example.com")
+
+	got, err := h.autofillProfile(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("autofillProfile: %v", err)
+	}
+	if got.Email != "account@example.com" {
+		t.Errorf("email = %q, want the account address", got.Email)
+	}
+	if got.FullName != "" || got.Phone != "" || got.Location != "" || got.LinkedIn != "" {
+		t.Errorf("got %+v, want every other field empty", got)
+	}
+}
+
+func TestAutofillProfile_SourceWithoutEmailGetsAccountAddress(t *testing.T) {
+	h := autofillWith(
+		fakeBaseCV{doc: cv.Document{Header: cv.Header{FullName: "Ilya Strelov", Phone: "+1 555 0100"}}, ok: true},
+		resumeextract.Structured{}, false,
+		"account@example.com",
+	)
+
+	got, err := h.autofillProfile(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("autofillProfile: %v", err)
+	}
+	if got.Email != "account@example.com" {
+		t.Errorf("email = %q, want the account address completing a source that states none", got.Email)
+	}
+	if got.FullName != "Ilya Strelov" {
+		t.Errorf("full name = %q, want the CV's", got.FullName)
+	}
+}
+
+// A failing CV read is a server fault, not an empty profile: silently autofilling a form
+// with a blank identity is worse than reporting the failure.
+func TestAutofillProfile_CVReadErrorIsReturned(t *testing.T) {
+	h := autofillWith(fakeBaseCV{err: errors.New("boom")}, resumeextract.Structured{}, false, "account@example.com")
+
+	if _, err := h.autofillProfile(context.Background(), 7); err == nil {
+		t.Fatal("autofillProfile returned no error, want the store's failure surfaced")
+	}
+}
+
+func TestFirstStatedHeader_EarlierSourceWins(t *testing.T) {
+	base := cv.Header{FullName: "Ilya Strelov", Phone: "+1 555 0100"}
+	fallback := cv.Header{FullName: "I. Strelov", Phone: "+1 555 0199"}
+
+	got := firstStatedHeader(base, fallback)
+
+	if got.FullName != "Ilya Strelov" || got.Phone != "+1 555 0100" {
+		t.Errorf("got %q / %q, want the first source that states a contact", got.FullName, got.Phone)
+	}
+}
+
+func TestFirstStatedHeader_SkipsASourceStatingNothing(t *testing.T) {
+	empty := cv.Header{}
+	stated := cv.Header{FullName: "Ilya Strelov"}
+
+	got := firstStatedHeader(empty, stated)
+
+	if got.FullName != "Ilya Strelov" {
+		t.Errorf("full name = %q, want the later source when the earlier states nothing", got.FullName)
+	}
+}
+
+// A CV that states only a location has been edited by its owner and answers for the whole
+// block: location is a contact value like any other.
+func TestFirstStatedHeader_LocationAloneCounts(t *testing.T) {
+	locationOnly := cv.Header{Location: "Lisbon, Portugal"}
+	stated := cv.Header{FullName: "Ilya Strelov", Phone: "+1 555 0100"}
+
+	got := firstStatedHeader(locationOnly, stated)
+
+	if got.FullName != "" || got.Phone != "" {
+		t.Errorf("got %q / %q, want the location-only source to answer alone", got.FullName, got.Phone)
+	}
+	if got.Location != "Lisbon, Portugal" {
+		t.Errorf("location = %q, want the location-only source's value", got.Location)
+	}
+}
+
+// The chosen source answers for every field. Merging would restore a value the candidate
+// deliberately removed from their CV, since the résumé is what seeded that CV.
+func TestFirstStatedHeader_DoesNotMergeAcrossSources(t *testing.T) {
+	base := cv.Header{FullName: "Ilya Strelov"}
+	fallback := cv.Header{FullName: "Ilya Strelov", Phone: "+1 555 0199", Links: []string{"https://ilya.dev"}}
+
+	got := firstStatedHeader(base, fallback)
+
+	if got.Phone != "" {
+		t.Errorf("phone = %q, want empty: the later source must not fill a gap in the chosen one", got.Phone)
+	}
+	if len(got.Links) != 0 {
+		t.Errorf("links = %v, want none", got.Links)
+	}
+}
+
+func TestFirstStatedHeader_NoSourceStatesAnything(t *testing.T) {
+	got := firstStatedHeader(cv.Header{}, cv.Header{})
+
+	if got.FullName != "" || got.Email != "" || got.Phone != "" || got.Location != "" || len(got.Links) != 0 {
+		t.Errorf("got %+v, want the zero header", got)
+	}
+}
+
+func TestContactHeaderFromStructured(t *testing.T) {
+	st := resumeextract.Structured{
+		FullName: "Ilya Strelov",
+		Email:    "ilya@example.com",
+		Phone:    "+1 555 0100",
+		Location: "Lisbon, Portugal",
+		Links:    []string{"https://linkedin.com/in/ilya"},
+		Summary:  "Backend engineer",
+	}
+
+	got := contactHeaderFromStructured(st)
+
+	want := cv.Header{
+		FullName: "Ilya Strelov",
+		Email:    "ilya@example.com",
+		Phone:    "+1 555 0100",
+		Location: "Lisbon, Portugal",
+		Links:    []string{"https://linkedin.com/in/ilya"},
+	}
+	if got.FullName != want.FullName || got.Email != want.Email || got.Phone != want.Phone {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+	if got.Location != want.Location || len(got.Links) != 1 || got.Links[0] != want.Links[0] {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -75,9 +75,9 @@ type jobReader interface {
 	GetJob(ctx context.Context, id int64) (db.Job, error)
 }
 
-func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, typstBin, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate) *cvHandlers {
+func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, typstBin, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate) *cvHandlers {
 	h := &cvHandlers{
-		cvStore:    cv.NewStore(cv.NewQueriesRepository(queries)),
+		cvStore:    cvStore,
 		tracerSalt: tracerSalt,
 		tracerMinter: tracerlink.NewMinter(tracerlink.NewRepository(
 			func(ctx context.Context, cvID uuid.UUID, userID int64, token, sourcePath, destURL, destHash string) (string, error) {

--- a/internal/handler/cv_evidence_gate_integration_test.go
+++ b/internal/handler/cv_evidence_gate_integration_test.go
@@ -43,7 +43,8 @@ func newCVAPIWithoutAssistant(t *testing.T) (*cvHandlers, *auth.Issuer, *fiber.A
 	creditsStore := credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3})
 	bank := experience.NewStore(experience.NewQueriesRepository(queries))
 
-	h := newCVHandlers(pool, queries, "", "test-salt", "https://freehire.test",
+	h := newCVHandlers(pool, queries, cv.NewStore(cv.NewQueriesRepository(queries)),
+		"", "test-salt", "https://freehire.test",
 		[]string{"freehire.test"},
 		resume.New(nil, resume.NewQueriesRepository(queries)),
 		headshot.New(nil, headshot.NewQueriesRepository(queries)),

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/strelov1/freehire/internal/browsertools"
 	"github.com/strelov1/freehire/internal/contribution"
 	"github.com/strelov1/freehire/internal/credits"
+	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/emailnotify"
 	"github.com/strelov1/freehire/internal/enrich"
@@ -83,11 +84,6 @@ type API struct {
 	// user's browser extension (the /tools/ws wire). In-memory and per-instance:
 	// both ends of a channel are live connections to this process.
 	browserTools *browsertools.Hub
-	// llm binds the model the agent-driven autofill maps a profile onto a form with,
-	// together with the resolver naming the account it is spent under. A nil client is
-	// the LLM being unconfigured: the run then reports the feature is off, and the
-	// extension's deterministic autofill still works.
-	llm llmBinding
 }
 
 // middleware bundles the auth gates the feature handlers mount their routes
@@ -287,9 +283,6 @@ func Register(app *fiber.App, cfg Config) {
 	// out mid-stage. Nil-safe (a nil client stays nil → Analyze is a no-op).
 	matchAnalyzer := matchanalysis.NewAnalyzer(cfg.LLM.WithTimeout(matchAnalysisLLMTimeout))
 	structuredExtractor := resumeextract.NewExtractor(cfg.LLM.WithTimeout(resumeExtractLLMTimeout), cfg.PIIDetector)
-	// The autofill planner is one cheap structured call per run; the shared client's
-	// default timeout is right for it.
-	a.llm.client = cfg.LLM
 	creditsStore := credits.NewStore(queries, cfg.Pool, cfg.Credits)
 	// Imports fetch a user-supplied page, so they dial through the same SSRF-guarded
 	// client the crawlers use (sources.NewClient). That one client also backs the ingest
@@ -301,7 +294,11 @@ func Register(app *fiber.App, cfg Config) {
 	contributionsH := newContributionHandlers(contributionSvc, creditsStore, queries, importer)
 	creditsH := newCreditsHandlers(creditsStore, queries)
 	matchH := newMatchHandlers(queries, profileSvc, resumeStore, matchAnalyzer, creditsStore)
-	cvH := newCVHandlers(cfg.Pool, queries, cfg.TypstBin, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank})
+	// The CV store is shared: the CV surface owns the write path, referrals render from it
+	// and autofill reads the base CV's contact header out of it. AGENTS.md puts shared
+	// services here rather than inside whichever feature happened to need one first.
+	cvStore := cv.NewStore(cv.NewQueriesRepository(queries))
+	cvH := newCVHandlers(cfg.Pool, queries, cvStore, cfg.TypstBin, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank})
 	telegramH := newTelegramHandlers(queries, cfg.JWTSecret, cfg.TelegramBotToken, cfg.TelegramBotUsername, cfg.TelegramWebhookSecret, cfg.FrontendOrigin, contributionsH.intake)
 	inboxH := newInboxHandlers(queries, cfg.Pool, cfg.GmailConnector, cfg.GmailCipher, cfg.FrontendOrigin, cfg.CookieSecure, cfg.MailboxDomain)
 	// Account deletion reaches past the FK cascade: cfg.Blob is nil when storage is
@@ -352,9 +349,12 @@ func Register(app *fiber.App, cfg Config) {
 	// credential.
 	llmKeys := llmkey.NewResolver(queries, cfg.LLMKeys)
 	assistantH.withKeys(llmKeys)
-	a.llm.keys = llmKeys
 	resumeH.llm = llmBinding{client: cfg.LLM, keys: llmKeys}
 	matchH.llm = llmBinding{client: cfg.LLM, keys: llmKeys}
+	// The autofill planner is one cheap structured call per run, so it travels on the
+	// shared client's default timeout. The contact block it plans over comes from the base
+	// CV, then the structured résumé — see autofillHandlers.autofillProfile.
+	autofillH := newAutofillHandlers(cvStore, resumeStore, queries, a.browserTools, llmBinding{client: cfg.LLM, keys: llmKeys})
 	usageH := newUsageHandlers(cfg.LLMKeys)
 	accountDeletion.WithGatewayKeys(llmKeys.Revoke)
 
@@ -391,7 +391,7 @@ func Register(app *fiber.App, cfg Config) {
 	referralCabinetURL := strings.TrimRight(cfg.FrontendOrigin, "/") + "/my/referrals?tab=incoming"
 	referralSvc := referral.New(referral.NewQueriesRepository(queries), referralPinger, cfg.Blob,
 		referral.Config{CabinetURL: referralCabinetURL})
-	referralsH := newReferralHandlers(referralSvc, cfg.Blob, cvH.cvRenderer, cvH.cvStore, photoStore)
+	referralsH := newReferralHandlers(referralSvc, cfg.Blob, cvH.cvRenderer, cvStore, photoStore)
 
 	// Allow the canonical frontend origin plus every served domain's https apex,
 	// so a cross-origin (non-credentialed) read works from either domain during a
@@ -472,18 +472,15 @@ func Register(app *fiber.App, cfg Config) {
 	votesH.register(api, mw)
 	// Per-job skill match + the on-demand LLM fit analysis (see matchHandlers).
 	matchH.register(api, mw)
-	// Canonical autofill fields (name/email/phone/location/links) for the browser
-	// extension to write into application forms. keyAuth (Bearer).
-	api.Get("/me/autofill-profile", keyAuth, a.AutofillProfile)
+	// The contact block the extension writes into forms, plain and agent-driven (see
+	// autofillHandlers).
+	autofillH.register(api, mw)
 	// The browser-tool wire: a harness on one end, the caller's browser extension
 	// on the other, exchanging raw tool frames. Both ends authenticate with the
 	// session JWT (Bearer for a server-side harness, the subprotocol for the
 	// extension, which can set no headers); the relay routes strictly within one
 	// user's channel. See internal/browsertools.
 	api.Get("/tools/ws", auth.RequireAuthWS(a.issuer, a.queries, apiKeys{a.queries}), a.BrowserToolsWS())
-	// Agent-driven autofill: the caller's own browser is driven over that wire.
-	// keyAuth (Bearer) so the extension can trigger it.
-	api.Post("/me/autofill/run", keyAuth, a.RunAgentAutofill)
 
 	// Public job submissions + review queue (see submissionHandlers).
 	submissionsH.register(api, mw)

--- a/internal/handler/raw_sql_rule_test.go
+++ b/internal/handler/raw_sql_rule_test.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// rawSQLCall matches a query issued straight against a pgx pool or connection —
+// pool.Query(...), h.pool.QueryRow(...), cfg.Pool.Exec(...) and so on.
+var rawSQLCall = regexp.MustCompile(`(?i)\b\w*pool\.(Query|QueryRow|Exec|SendBatch)\(`)
+
+// TestNoRawSQLInHandlers keeps every read and write in this package behind sqlc or a
+// domain store.
+//
+// The rule is not style. A hand-written statement is invisible to sqlc, so a column
+// renamed in migrations/ compiles clean and fails when a user makes the request — which is
+// exactly how the autofill contact read used to break. Stated as a test rather than as a
+// sentence in AGENTS.md, because this codebase's most common defect is a true-sounding
+// sentence that nothing enforces.
+//
+// The population is derived from the package's own sources, not from a hand-kept list, so
+// a new file is covered the moment it is added.
+func TestNoRawSQLInHandlers(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	scanned := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		scanned++
+		for i, line := range strings.Split(string(src), "\n") {
+			if rawSQLCall.MatchString(line) {
+				t.Errorf("%s:%d issues SQL straight at the pool — use sqlc or a domain store:\n\t%s",
+					name, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+
+	// Guard the guard: a rule that silently scans nothing passes forever.
+	if scanned == 0 {
+		t.Fatal("scanned no source files; the rule would pass vacuously")
+	}
+}

--- a/openspec/changes/autofill-contact-source/.openspec.yaml
+++ b/openspec/changes/autofill-contact-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/autofill-contact-source/design.md
+++ b/openspec/changes/autofill-contact-source/design.md
@@ -1,0 +1,145 @@
+## Context
+
+`(*API).autofillProfile` (`internal/handler/autofill_profile.go:74`) assembles the
+extension's contact block from two hand-written statements — `SELECT email FROM users` and
+`SELECT data FROM cvs WHERE user_id = $1 ORDER BY updated_at DESC LIMIT 1` — followed by a
+hand `json.Unmarshal` into `cv.Document`. They are the only raw SQL left in
+`internal/handler`.
+
+Two facts from production (`hire` on host-2, measured 2026-08-02) set the shape of this
+change:
+
+| | all users | API-key holders |
+|---|---|---|
+| total | 408 | 17 |
+| current structured résumé | 174 | 8 |
+| base CV | 10 | 1 |
+| CVs at all (any kind) | 10 | — |
+| tailored CVs but no base | **0** | 0 |
+
+So the source the code reads is present for 10 users while the source it ignores is present
+for 174, and every structured résumé on production is current (all 174 stamps match
+`resume_uploaded_at`). The tailored-only case the original finding demanded a decision
+about does not exist in the data.
+
+Three readers already exist and are the whole implementation: `cv.Store.BaseCV`
+(`internal/cv/store.go:255`), `resume.Store.Structured` (`internal/resume/resume.go:239`,
+which applies the stamp-freshness rule and treats a corrupt blob as absent) and
+`GetUserByID` (`internal/db/queries/users.sql:21`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Serve the contact block from the base CV, then the structured résumé, then the account
+  email alone — so the 164 users whose data is already parsed stop getting an empty form.
+- Read through `cv.Store`, `resume.Store` and sqlc; leave `internal/handler` with no raw SQL.
+- Keep the nine wire fields byte-identical, so no extension release is coupled to this.
+
+**Non-Goals:**
+
+- **Attaching the CV PDF to a form.** The agent's primitive vocabulary is `read_form`,
+  `fill_simple` and the four combobox steps; there is no file primitive in
+  `internal/browsertools`. Uploading the tailored PDF for the vacancy being applied to is a
+  real and larger feature, and it is where the tailored-vs-base question genuinely bites.
+  Out of scope here and worth its own proposal.
+- **Making autofill vacancy-aware.** Neither entry point accepts a job today. With only the
+  contact block on the wire, a `?job=` parameter would change exactly one field
+  (`location`), and change it in a debatable direction.
+- **Reading `userprofile`.** Its `LocationPreferences` answers "where would you move",
+  not "where do you live". It is not a contact source.
+- **Backfilling anything.** This change writes nothing.
+
+## Decisions
+
+### D1. The first source that states a contact answers for the whole block
+
+Rejected: merging field-by-field across sources. `cv.Seed` (`internal/cv/seed.go:18-25`)
+copies the structured résumé's five contact fields into the CV header one-for-one, so the
+two sources hold the same fields with the CV holding the corrected values. A merge would
+therefore restore precisely what the candidate deleted — clear a stale phone from the CV
+header and the résumé would put it back. Whole-block selection makes "the candidate's copy
+wins" true rather than approximately true.
+
+"States a contact" rather than "the row exists" is deliberate: a CV created empty (not
+seeded) would otherwise silence a résumé that has the values.
+
+### D2. The base CV outranks the structured résumé
+
+The CV header is the candidate-authored copy and the only one the tailoring agent cannot
+touch — `cvedit.DefaultPolicy()` (`internal/cvedit/policy.go:33-45`) denies `ActorAgent`
+exactly `header.full_name`, `header.email`, `header.phone` and `header.links`, and denies
+the candidate nothing. The structured résumé is upstream of it: contact fields there come
+from deterministic PII detection over the uploaded file, per the `resume-structured-profile`
+requirement, and flow into the CV through `Seed`. Corrected beats derived.
+
+### D3. Tailored CVs are excluded, and the exclusion comes from `BaseCV`, not a new query
+
+`GetBaseCVByUser` (`internal/db/queries/cvs.sql:70-78`) already filters `NOT is_tailored`
+and documents why it excludes on that column rather than on `job_id IS NULL` (prune nulls
+the vacancy link). Using `BaseCV` inherits that reasoning instead of restating it.
+
+`BaseCV` returning `ok=false` for a user whose only CVs are tailored is not a case that
+needs a policy: the next tier answers, and production has zero such users.
+
+### D4. A feature handler owns the two routes
+
+`internal/handler/AGENTS.md` gives each feature a handler struct with its own
+dependencies and says `API` carries "only the cross-cutting dependencies", yet the three
+autofill routes hang off `*API` and drove the reach for `a.pool` in the first place. A
+small `autofillHandlers{cvStore, resumeStore, queries, browserTools, llm}` with a
+`register` matches the package convention and takes the feature deps off `API`.
+
+Two consequences worth stating:
+
+- `llmBinding` is autofill's alone (`a.llm` is read only at `autofill_agent.go:32`) and is
+  currently assembled across two Register statements (`handler.go:292` and `:355`).
+  Constructing the handler after both are known makes it one constructor argument and
+  removes the two-phase assignment.
+- `browserTools` **stays** on `API` and is passed in: `/tools/ws` (`browsertools.go:49`)
+  and the assistant (`handler.go:343`) share the same hub. It is genuinely cross-cutting.
+
+### D5. `cv.NewStore` is hoisted into `Register`
+
+Tier 1 needs `*cv.Store`, which is built inside `newCVHandlers` (`internal/handler/cv.go:80`)
+and dug back out at `handler.go:394`. Reaching into `cvH.cvStore` for a second consumer
+would add another such reach-in; hoisting it to a `Register` local is what
+`internal/handler/AGENTS.md:26` already says should be true of the CV store. `resume.Store`
+needs nothing — it is already a Register local (`handler.go:270`).
+
+This is the minimum needed to get the dependency, not a wider rewiring: the CV renderer,
+`assistant.Store` and `moderation.Service` are left where they are.
+
+## Risks / Trade-offs
+
+- **A user's CV header is worse than their résumé's** (they seeded a CV, cleared the phone
+  by accident, and the résumé still has it) → they now get the empty phone. This is the
+  intended direction: the CV is the copy they control, and honouring a deletion is the
+  point of D1. The failure mode of the opposite choice — resurrecting a removed number — is
+  worse and silent.
+- **The structured résumé's contacts are only as good as the PII detector** → the tier is
+  reached only when the candidate has no CV, so a wrong value is never preferred over one
+  they authored; and today the alternative for those 164 users is an empty form, not a
+  correct one.
+- **A stale structure is served** → cannot happen through `resume.Store.Structured`: it
+  compares `resume_structured_uploaded_at` against `resume_uploaded_at` and reports absent
+  on a mismatch. Verified on production: 174 of 174 stamps match.
+- **The extension breaks on a changed payload** → the nine fields and their JSON names are
+  unchanged; only the values change, and only from empty to populated for the users this
+  targets.
+
+## Migration Plan
+
+1. No migration. No schema change, no backfill, nothing written.
+2. Deploy normally (blue/green). The change takes effect on the next request.
+3. Verify against production by comparing the two colours: read
+   `GET /api/v1/me/autofill-profile` for a key-holding account with a structured résumé and
+   no CV — the inactive colour is the "before" reference and must return email-only, the
+   new one must return the parsed name and phone.
+4. **Rollback:** revert the deploy. Nothing persists, so there is nothing to undo.
+
+## Open Questions
+
+None blocking. One recorded for later: the PDF-attachment feature named in Non-Goals is the
+question this change deliberately does not answer, and it is the one where choosing between
+the base and the vacancy's tailored copy actually matters.

--- a/openspec/changes/autofill-contact-source/proposal.md
+++ b/openspec/changes/autofill-contact-source/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The browser extension's autofill serves the candidate's contact block into application
+forms, and it reads that block from one place: the most recently updated row in `cvs`.
+On production that source is empty for almost everyone. 174 users have a current
+structured résumé — name, email, phone, location and links, already parsed into typed
+fields — and only 10 of them have a CV. Among the 17 API-key holders who are the
+extension's actual audience, exactly **one** has a CV; seven more have a structured
+résumé and get nothing but their account email.
+
+The read is also the only raw SQL left in `internal/handler`: two `pool.QueryRow` calls
+that sqlc cannot see, so a column rename in `migrations/` breaks autofill at runtime
+rather than at build time. And the `ORDER BY updated_at DESC LIMIT 1` disagrees with the
+domain's own definition of "the user's CV" — `cv.Store.BaseCV` deliberately excludes
+tailored copies, because a tailored copy is written for one vacancy.
+
+## What Changes
+
+- The autofill contact block is assembled from an ordered source list instead of one
+  query: the base CV's header, then the structured résumé's contact fields, then the
+  account email alone. The first source that yields a name wins; the account email
+  continues to backstop an absent or empty address at every tier.
+- **BREAKING (behaviour, narrow):** a user whose only CVs are tailored copies would now
+  be served the base CV or the structured résumé rather than the tailored copy's header.
+  No production user is in this state (0 rows), so the change is observable only in
+  principle.
+- The two raw `pool.QueryRow` calls in `internal/handler/autofill_profile.go` are replaced
+  by `cv.Store`, the existing structured-résumé read, and `GetUserByID`. `internal/handler`
+  is left with no raw SQL.
+- Both callers — `GET /api/v1/me/autofill-profile` (the extension's deterministic fill)
+  and `POST /api/v1/me/autofill/run` (the agent-driven fill) — inherit the change through
+  the one function they share.
+- The endpoints gain an OpenSpec capability; today they have none.
+
+## Capabilities
+
+### New Capabilities
+
+- `extension-autofill`: the canonical autofill contact block the browser extension writes
+  into application forms — which fields it carries, which sources answer for them and in
+  what order, and what an absent source yields.
+
+### Modified Capabilities
+
+None. `resume-structured-profile` gains a reader, not a requirement: this change consumes
+the structure it already guarantees (typed, sanitized, stamped against the current résumé)
+and adds no obligation to it. `cv-autofill` is a different capability despite the name —
+it covers the onboarding wizard's pre-fill from a résumé, not form autofill.
+
+## Impact
+
+- `internal/handler/autofill_profile.go` — the assembly function and its two raw queries.
+- `internal/handler/autofill_agent.go` — unchanged; it calls the same function.
+- `internal/handler/handler.go` — `*API` gains the two dependencies the assembly needs
+  (`*cv.Store` and the queries handle it already holds), or a small feature handler holds
+  them. `browserTools` stays on `API`: the assistant shares it.
+- No migration, no new column, no wire-shape change. `autofillProfile`'s nine JSON fields
+  are unchanged, so the extension needs no release.
+- Read-only against `users` and `cvs`; nothing in this change writes.

--- a/openspec/changes/autofill-contact-source/specs/extension-autofill/spec.md
+++ b/openspec/changes/autofill-contact-source/specs/extension-autofill/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: The autofill profile is one canonical contact block
+
+The system SHALL serve the browser extension a fixed set of contact fields assembled
+server-side, so the extension holds no rule about where a value comes from: `full_name`,
+`first_name`, `last_name`, `email`, `phone`, `location`, `linkedin`, `github` and
+`portfolio`. `first_name` and `last_name` SHALL be derived by splitting the full name on
+whitespace — the first token is the given name, the remainder the family name. The links
+SHALL be sorted by host: the first LinkedIn URL, the first GitHub URL, and the first
+remaining URL as the portfolio. A field the sources do not state SHALL be empty rather
+than guessed.
+
+This block carries the candidate's identity only. It carries no summary, no work history
+and no skills, because it exists to fill the contact section of an application form.
+
+#### Scenario: The block is served with the fields the sources state
+
+- **WHEN** an authenticated caller reads the autofill profile and a source states a name,
+  a phone and a LinkedIn URL
+- **THEN** the response carries those values, the given and family names split from the
+  full name, and empty strings for the fields no source stated
+
+#### Scenario: Links are sorted by host, not by order
+
+- **WHEN** the chosen source states a personal site, then a GitHub URL, then a LinkedIn URL
+- **THEN** `linkedin` is the LinkedIn URL, `github` is the GitHub URL, and `portfolio` is
+  the personal site
+
+### Requirement: The contact block resolves from an ordered list of sources
+
+The system SHALL resolve the contact block from the first source that answers, in this
+order:
+
+1. the user's **base CV** header — the CV that is not a tailored copy;
+2. the user's **structured résumé** contact fields;
+3. **no source**, leaving every field empty.
+
+A source answers when it exists and states at least one contact value; a source that
+exists but states none is passed over, so an empty CV does not silence a résumé that has
+the values. The chosen source answers for the **whole** block: fields SHALL NOT be merged
+across sources. Merging would restore a value the candidate deliberately removed from
+their CV, and the candidate's own copy is the one that must win outright.
+
+The base CV ranks first because it is the copy the candidate authored: the structured
+résumé seeds it, and the candidate corrects it afterwards. It is also the only copy the
+tailoring agent cannot rewrite — the edit policy denies the agent the header's name, email,
+phone and links.
+
+Tailored CVs SHALL NOT be a source at any tier. A tailored copy is written for one vacancy,
+and the autofill profile carries no vacancy.
+
+#### Scenario: The base CV answers when it states contacts
+
+- **WHEN** a user has a base CV whose header states their name, and also has a structured
+  résumé stating a different name
+- **THEN** the block carries the base CV's name
+
+#### Scenario: The structured résumé answers when there is no base CV
+
+- **WHEN** a user has a current structured résumé and no base CV
+- **THEN** the block carries the structured résumé's contact fields
+
+#### Scenario: An empty base CV does not silence the structured résumé
+
+- **WHEN** a user has a base CV whose header states no contact value at all, and a
+  structured résumé that states their name and phone
+- **THEN** the block carries the structured résumé's name and phone
+
+#### Scenario: Sources are not merged
+
+- **WHEN** a user's base CV header states a name but no phone, while their structured
+  résumé states both
+- **THEN** the block carries the base CV's name and an empty phone
+
+#### Scenario: A tailored CV is never a source
+
+- **WHEN** a user's only CVs are tailored copies
+- **THEN** the tailored copies are ignored and the structured résumé answers instead
+
+### Requirement: The account email backstops an unstated address
+
+The system SHALL fall back to the account's own email address whenever the resolved
+contact block states no email — including when no source answered at all. Every other
+field stays empty in that case.
+
+An account address is a verified fact about the caller that needs no CV, so a user who has
+uploaded nothing still gets the one field an application form always asks for.
+
+#### Scenario: A user with no CV and no résumé still gets their address
+
+- **WHEN** an authenticated caller has neither a CV nor a structured résumé
+- **THEN** the block carries the account email and every other field is empty
+
+#### Scenario: A source stating no email falls back to the account address
+
+- **WHEN** the resolved source states a name and a phone but no email
+- **THEN** the block carries that name and phone together with the account email
+
+### Requirement: Both autofill entry points share one assembly
+
+The system SHALL assemble the contact block once and serve it to both the extension's
+deterministic read (`GET /api/v1/me/autofill-profile`) and the agent-driven fill
+(`POST /api/v1/me/autofill/run`), so the values a person sees in a form and the values the
+agent grounds its plan in cannot diverge. Both entry points remain authenticated and
+accept an API key, because the browser extension holds one.
+
+#### Scenario: The agent fills from the same block the endpoint serves
+
+- **WHEN** the agent-driven autofill runs for a user
+- **THEN** it grounds its plan in the same contact block the read endpoint would serve that
+  user
+
+### Requirement: Autofill reads through the domain stores
+
+The system SHALL read the base CV through the CV store and the account and structured
+résumé through generated queries, and SHALL NOT issue hand-written SQL for them. A
+hand-written statement is invisible to the query generator, so a column renamed in a
+migration breaks autofill when a user opens a form rather than when the project is built.
+
+#### Scenario: A renamed column fails the build
+
+- **WHEN** a column the autofill block reads is renamed in a migration and the queries are
+  regenerated
+- **THEN** the project fails to build, rather than compiling and failing at request time

--- a/openspec/changes/autofill-contact-source/tasks.md
+++ b/openspec/changes/autofill-contact-source/tasks.md
@@ -1,0 +1,38 @@
+## 1. Source resolution
+
+- [x] 1.1 Write failing tests for the ordered source list against a fake for each tier: base
+  CV answers over a structured résumé stating different values; structured résumé answers
+  when there is no base CV; a base CV stating no contact value at all is passed over; the
+  chosen source answers for the whole block (a CV name plus no phone yields an empty phone,
+  not the résumé's); tailored CVs are never a source.
+- [x] 1.2 Implement the resolution: the first source that states at least one contact value
+  wins, whole-block. Reads go through `cv.Store.BaseCV` and `resume.Store.Structured`.
+- [x] 1.3 Write failing tests for the account-email backstop — no source at all yields email
+  only; a source stating no email is completed with the account address — then implement it
+  over `GetUserByID`.
+- [x] 1.4 Delete the two `pool.QueryRow` calls and the hand `json.Unmarshal`; assert
+  `internal/handler` holds no raw SQL (a test over the non-test sources of the package, so
+  the rule is enforced by behaviour rather than by review).
+
+## 2. Wiring
+
+- [x] 2.1 Hoist `cv.NewStore(...)` to a `Register` local, pass it into `newCVHandlers`, and
+  replace the `cvH.cvStore` reach-in at the referral construction site.
+- [x] 2.2 Add `autofillHandlers` holding the CV store, the résumé store, the queries, the
+  browser-tool hub and the LLM binding, with a `register` mounting
+  `GET /me/autofill-profile` and `POST /me/autofill/run` behind `keyAuth`.
+- [x] 2.3 Move `AutofillProfile` and `RunAgentAutofill` onto it; drop `llmBinding` from
+  `API` and its two-phase assignment, keeping `browserTools` on `API` for `/tools/ws` and
+  the assistant.
+- [x] 2.4 Confirm the existing agent-autofill tests still pass unchanged — both entry points
+  must go on sharing one assembly.
+
+## 3. Verification
+
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...`, then `gofmt -l` clean.
+- [x] 3.2 Run the integration pass too (`go test -tags=integration ./internal/db/`) — the
+  plain run does not see build-tagged tests.
+- [x] 3.3 `openspec validate --strict` for this change.
+- [ ] 3.4 After deploy, compare the two colours on production for a key-holding account with
+  a structured résumé and no CV: the inactive colour returns email-only, the active one
+  returns the parsed name and phone.


### PR DESCRIPTION
## Why

The extension's autofill read its contact block from one place — the most recently updated row in `cvs` — and on production that source is empty for almost everyone.

Measured on `hire` (host-2) on 2026-08-02:

| | all users | API-key holders |
|---|---|---|
| total | 408 | 17 |
| current structured résumé | **174** | 8 |
| base CV | **10** | **1** |
| tailored CVs but no base | 0 | 0 |

So 164 users have their name, phone, location and links already parsed into typed fields and get an empty form anyway. Every one of the 174 structures is current (stamp matches `resume_uploaded_at`).

## What

The block resolves from an ordered list — base CV header → structured résumé contacts → account email alone. The first source that **states a contact** answers for the **whole** block.

- **No merging.** `cv.Seed` copies the résumé's five contact fields into the CV header, so the two sources hold the same fields with the CV holding the corrected ones. Merging would restore precisely the value the candidate deleted from their CV.
- **CV first.** It is the copy the candidate authored and the only one the tailoring agent cannot rewrite — `cvedit.DefaultPolicy` denies `ActorAgent` the header's name, email, phone and links, and denies the candidate nothing. Corrected beats derived.
- **A source stating nothing is passed over**, so a CV created empty does not silence a résumé that has the values.
- **Tailored copies are never a source.** `BaseCV` excludes them via `NOT is_tailored`. Zero production users are in the tailored-only state, so the branch the original finding demanded a policy for is empty in the data.

## Also

Drops the last raw SQL in `internal/handler` — two `pool.QueryRow` calls sqlc could not see, so a column renamed in a migration broke autofill when a user opened a form rather than when the project was built. `TestNoRawSQLInHandlers` now refuses a query issued straight at the pool anywhere in the package, deriving its population from the package's own sources; verified by restoring one and watching it fail.

The two routes move onto their own `autofillHandlers`, which takes the feature deps off `API` and removes the two-phase assembly of `llmBinding`. `cv.NewStore` moves up to `Register`, where `internal/handler/AGENTS.md` already says shared services belong — which also removes the `cvH.cvStore` reach-in at the referral site.

## Risk

No migration, no schema change, nothing written. The nine JSON fields and their names are unchanged, so no extension release is coupled to this — only the values change, and only from empty to populated.

Auth is unchanged: `mw.key` is the same `keyAuth` (`RequireAuthOrKey`) the routes carried before.

## Verification

- `go build ./... && go vet ./... && go test ./...` clean, `gofmt -l` clean
- `go test -tags=integration ./internal/db/` — ok, 28.8s
- `openspec validate autofill-contact-source --strict` — valid
- Post-deploy check is task 3.4 and deliberately unticked: compare the two colours for a key-holding account with a structured résumé and no CV — the inactive colour must return email-only, the active one the parsed name and phone.

OpenSpec change: `openspec/changes/autofill-contact-source/` (new capability `extension-autofill`; these endpoints had none).