### PR TITLE
feat(harvest-boards): read the employer from the provider portals

### DIFF
--- a/cmd/harvest-boards/opencats_prober.go
+++ b/cmd/harvest-boards/opencats_prober.go
@@ -156,25 +156,5 @@ var opencatsTitleSuffix = regexp.MustCompile(`(?i)\s*[-–—|]\s*careers\s*$`)
 // corroboration gate tests, so a derived one would gate a board against a token the employer
 // never chose. An unnamed board falls back to the seed's name, then to the board id.
 func opencatsCompanyName(root *html.Node, _ string) string {
-	return strings.TrimSpace(opencatsTitleSuffix.ReplaceAllString(opencatsPageTitle(root), ""))
-}
-
-// opencatsPageTitle returns the document's <title> text, or "".
-func opencatsPageTitle(root *html.Node) string {
-	var title string
-	var walk func(*html.Node)
-	walk = func(n *html.Node) {
-		if title != "" {
-			return
-		}
-		if n.Type == html.ElementNode && n.Data == "title" && n.FirstChild != nil {
-			title = strings.TrimSpace(n.FirstChild.Data)
-			return
-		}
-		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
-			walk(ch)
-		}
-	}
-	walk(root)
-	return title
+	return strings.TrimSpace(opencatsTitleSuffix.ReplaceAllString(pageTitle(root), ""))
 }

--- a/cmd/harvest-boards/oracle_jazzhr_prober.go
+++ b/cmd/harvest-boards/oracle_jazzhr_prober.go
@@ -47,8 +47,9 @@ func (oracleProber) probe(ctx context.Context, c httpClient, boardID string) (st
 
 // jazzhrProber validates a JazzHR board "<slug>" by counting the postings linked from its
 // single /apply listing page ("<slug>.applytojob.com/apply"). JazzHR's listing exposes no
-// employer name (the adapter reads it from each posting's JSON-LD at ingest), so the prober
-// returns an empty name.
+// employer name, but the page titles itself "<Company> - Career Page", so the prober reads
+// the employer there and the board can be gated against the name the seed expected rather
+// than accepted on liveness alone.
 type jazzhrProber struct{}
 
 // jazzhrApplyHref captures a posting's token from a JazzHR job link (/apply/<token>/<slug>),
@@ -80,5 +81,17 @@ func (jazzhrProber) probe(ctx context.Context, c httpClient, slug string) (strin
 	if len(tokens) == 0 {
 		return "", 0, nil
 	}
-	return "", len(tokens), nil
+	return jazzhrEmployer(pageTitle(root)), len(tokens), nil
+}
+
+// jazzhrEmployer pulls the employer out of a JazzHR career-page title, which renders as
+// "<Company> - Career Page". A title without that suffix names nobody in particular, so it
+// yields "" and the board falls back to the seed's label rather than being gated against a
+// generic word.
+func jazzhrEmployer(title string) string {
+	name, ok := strings.CutSuffix(strings.TrimSpace(title), " - Career Page")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(name)
 }

--- a/cmd/harvest-boards/pagetitle.go
+++ b/cmd/harvest-boards/pagetitle.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// pageTitle returns the document's <title> text, or "". Three probers read it: opencats for
+// the portal's own name, and jazzhr and trakstar because their platforms publish the employer
+// nowhere else the prober looks.
+func pageTitle(root *html.Node) string {
+	var title string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if title != "" {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "title" && n.FirstChild != nil {
+			title = strings.TrimSpace(n.FirstChild.Data)
+			return
+		}
+		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
+			walk(ch)
+		}
+	}
+	walk(root)
+	return title
+}

--- a/cmd/harvest-boards/portal_name_test.go
+++ b/cmd/harvest-boards/portal_name_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// jazzhr and trakstar publish no employer name in the payload the prober reads for liveness,
+// but both put one in the portal itself. Reading it is what lets the corroboration gate fire
+// for them at all — without it their boards are accepted on liveness alone, which is how 44
+// boards were filed under the wrong employer (jones → "Test Company", intel → "IntelContact",
+// cme → a guitar shop) before an out-of-band audit caught them.
+func TestJazzHRProbeReadsTheEmployerFromTheCareerPage(t *testing.T) {
+	getter := fakeGetter{
+		"https://83bar.applytojob.com/apply": `<html><head><title>83BAR - Career Page</title></head>
+			<body><a href="/apply/aBcDeF123456/nurse">Nurse</a></body></html>`,
+		// A portal whose title carries no employer name still counts as live; it just
+		// reports no name, and the seed's label stands.
+		"https://nameless.applytojob.com/apply": `<html><head><title>Careers</title></head>
+			<body><a href="/apply/zZyYxX987654/engineer">Engineer</a></body></html>`,
+	}
+	p := jazzhrProber{}
+
+	if name, n, err := p.probe(context.Background(), getter, "83bar"); err != nil || name != "83BAR" || n != 1 {
+		t.Errorf("got (%q,%d,%v), want (\"83BAR\",1,nil)", name, n, err)
+	}
+	if name, n, err := p.probe(context.Background(), getter, "nameless"); err != nil || name != "" || n != 1 {
+		t.Errorf("titleless portal: got (%q,%d,%v), want (\"\",1,nil)", name, n, err)
+	}
+}
+
+func TestTrakstarProbeReadsTheEmployerFromTheFeed(t *testing.T) {
+	getter := fakeGetter{
+		"https://aflac.hire.trakstar.com/jobfeeds/aflac": `<rss><channel>
+			<title>Jobs at AFLAC</title><item><title>Agent</title></item></channel></rss>`,
+		"https://plain.hire.trakstar.com/jobfeeds/plain": `<rss><channel>
+			<title>Jobs</title><item><title>Agent</title></item></channel></rss>`,
+	}
+	p := trakstarProber{}
+
+	if name, n, err := p.probe(context.Background(), getter, "aflac"); err != nil || name != "AFLAC" || n != 1 {
+		t.Errorf("got (%q,%d,%v), want (\"AFLAC\",1,nil)", name, n, err)
+	}
+	// "Jobs" alone names nobody — reporting it would gate every board against a word.
+	if name, n, err := p.probe(context.Background(), getter, "plain"); err != nil || name != "" || n != 1 {
+		t.Errorf("nameless feed: got (%q,%d,%v), want (\"\",1,nil)", name, n, err)
+	}
+}

--- a/cmd/harvest-boards/portal_name_test.go
+++ b/cmd/harvest-boards/portal_name_test.go
@@ -46,3 +46,43 @@ func TestTrakstarProbeReadsTheEmployerFromTheFeed(t *testing.T) {
 		t.Errorf("nameless feed: got (%q,%d,%v), want (\"\",1,nil)", name, n, err)
 	}
 }
+
+// lever and ashby publish the employer on their storefront page but not in the posting API
+// the prober reads for liveness. The storefront is fetched only once a board is known to
+// have jobs, so the extra request costs one per live board, not one per candidate.
+func TestLeverProbeReadsTheEmployerFromTheStorefront(t *testing.T) {
+	getter := fakeGetter{
+		"https://api.lever.co/v0/postings/findhelp?mode=json": `[{"id":"a"},{"id":"b"}]`,
+		"https://jobs.lever.co/findhelp":                      `<html><head><title>Findhelp, A Public Benefit Corporation</title></head></html>`,
+		// A live board whose storefront cannot be read still counts as live.
+		"https://api.lever.co/v0/postings/quiet?mode=json": `[{"id":"a"}]`,
+	}
+	p := leverProber{}
+
+	name, n, err := p.probe(context.Background(), getter, "findhelp")
+	if err != nil || name != "Findhelp, A Public Benefit Corporation" || n != 2 {
+		t.Errorf("got (%q,%d,%v), want the storefront name and 2", name, n, err)
+	}
+	if name, n, err := p.probe(context.Background(), getter, "quiet"); err != nil || name != "" || n != 1 {
+		t.Errorf("unreadable storefront: got (%q,%d,%v), want (\"\",1,nil)", name, n, err)
+	}
+}
+
+func TestAshbyProbeReadsTheEmployerFromTheStorefront(t *testing.T) {
+	getter := fakeGetter{
+		"https://api.ashbyhq.com/posting-api/job-board/ddn": `{"jobs":[{"id":"a"}]}`,
+		"https://jobs.ashbyhq.com/ddn":                      `<html><head><title>DDN Jobs</title></head></html>`,
+		// An unknown ashby slug still serves a 200 titled just "Jobs" — stripping the suffix
+		// leaves nothing, which must read as "no name" rather than as an employer.
+		"https://api.ashbyhq.com/posting-api/job-board/bare": `{"jobs":[{"id":"a"}]}`,
+		"https://jobs.ashbyhq.com/bare":                      `<html><head><title>Jobs</title></head></html>`,
+	}
+	p := ashbyProber{}
+
+	if name, n, err := p.probe(context.Background(), getter, "ddn"); err != nil || name != "DDN" || n != 1 {
+		t.Errorf("got (%q,%d,%v), want (\"DDN\",1,nil)", name, n, err)
+	}
+	if name, n, err := p.probe(context.Background(), getter, "bare"); err != nil || name != "" || n != 1 {
+		t.Errorf("bare title: got (%q,%d,%v), want (\"\",1,nil)", name, n, err)
+	}
+}

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -475,11 +475,13 @@ func (teamtailorProber) probe(ctx context.Context, c httpClient, host string) (s
 }
 
 // trakstarProber probes the Trakstar Hire per-subdomain RSS feed. A non-empty channel of
-// items is a live board; the feed carries no company name, so it falls back to the slug.
+// items is a live board, and the channel title names the employer, so the board can be gated
+// against the name the seed expected instead of accepted on liveness alone.
 type trakstarProber struct{}
 
 func (trakstarProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
 	var feed struct {
+		Title string     `xml:"channel>title"`
 		Items []struct{} `xml:"channel>item"`
 	}
 	if err := c.GetXML(ctx, fmt.Sprintf("https://%s.hire.trakstar.com/jobfeeds/%s", slug, slug), &feed); err != nil {
@@ -488,7 +490,17 @@ func (trakstarProber) probe(ctx context.Context, c httpClient, slug string) (str
 	if len(feed.Items) == 0 {
 		return "", 0, nil
 	}
-	return "", len(feed.Items), nil
+	return trakstarEmployer(feed.Title), len(feed.Items), nil
+}
+
+// trakstarEmployer pulls the employer out of a Trakstar feed title, which renders as
+// "Jobs at <Company>". A title without that prefix names nobody, so it yields "".
+func trakstarEmployer(title string) string {
+	name, ok := strings.CutPrefix(strings.TrimSpace(title), "Jobs at ")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(name)
 }
 
 // personioProber probes the Personio public XML feed on the .com host (the host the adapter

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -108,8 +108,9 @@ func (greenhouseProber) probe(ctx context.Context, c httpClient, slug string) (s
 }
 
 // leverProber probes the Lever postings API. The JSON-mode endpoint returns a bare array
-// of live postings, so a non-empty array is a live board. Lever exposes no company name, so
-// the name falls back to the slug.
+// of live postings, so a non-empty array is a live board. The posting API exposes no company
+// name, but the board's storefront titles itself after the employer, so the name is read
+// there once the board is known to be live.
 type leverProber struct{}
 
 func leverPostingsURL(slug string) string {
@@ -142,12 +143,13 @@ func (leverProber) probe(ctx context.Context, c httpClient, slug string) (string
 	if len(postings) == 0 {
 		return "", 0, nil
 	}
-	return "", len(postings), nil
+	return storefrontEmployer(ctx, c, fmt.Sprintf("https://jobs.lever.co/%s", slug), ""), len(postings), nil
 }
 
 // ashbyProber probes the Ashby public job-board API. The list endpoint returns the live
-// postings, so a non-empty list is a live board; the name falls back to the (case-sensitive)
-// slug, which Ashby itself uses as the board identity.
+// postings, so a non-empty list is a live board. The posting API exposes no company name, but
+// the storefront titles itself "<Company> Jobs", so the name is read there once the board is
+// known to be live. The board id stays the case-sensitive slug Ashby uses as its identity.
 type ashbyProber struct{}
 
 func ashbyBoardURL(slug string) string {
@@ -184,7 +186,7 @@ func (ashbyProber) probe(ctx context.Context, c httpClient, slug string) (string
 	if len(resp.Jobs) == 0 {
 		return "", 0, nil
 	}
-	return "", len(resp.Jobs), nil
+	return storefrontEmployer(ctx, c, fmt.Sprintf("https://jobs.ashbyhq.com/%s", slug), " Jobs"), len(resp.Jobs), nil
 }
 
 // bamboohrProber probes the BambooHR per-subdomain careers list. A non-empty result is a
@@ -332,6 +334,31 @@ func (workableProber) probe(ctx context.Context, c httpClient, slug string) (str
 		return "", 0, nil
 	}
 	return resp.Name, len(resp.Jobs), nil
+}
+
+// storefrontEmployer reads the employer name from a board's public storefront page title,
+// trimming the platform's boilerplate suffix. It is called only once a board is known to have
+// jobs, so it costs one request per LIVE board rather than one per candidate — the same
+// discipline greenhouse's board-metadata fetch follows.
+//
+// Anything unreadable yields "": an unreachable page, a title that is only the boilerplate
+// (an unknown ashby slug still serves a 200 titled just "Jobs"), or a platform 404. A board
+// whose name cannot be read is kept on liveness and labelled from the seed, exactly as before
+// — the gate simply cannot fire for it.
+func storefrontEmployer(ctx context.Context, c httpClient, url, suffix string) string {
+	root, err := c.GetHTML(ctx, url)
+	if err != nil {
+		return ""
+	}
+	title := strings.TrimSpace(pageTitle(root))
+	if suffix != "" {
+		trimmed, ok := strings.CutSuffix(title, suffix)
+		if !ok {
+			return ""
+		}
+		title = trimmed
+	}
+	return strings.TrimSpace(title)
 }
 
 // smartRecruitersProber probes the SmartRecruiters public postings API. The listing carries


### PR DESCRIPTION
## Why

Four providers publish no employer name in the payload the prober reads for liveness, so their boards were kept on liveness alone. An audit (#1477) then found **44 of jazzhr's and trakstar's 220 harvested boards filed under the wrong company** and they had to be removed:

| board | filed as | actually |
|---|---|---|
| `jones` | Jones | Test Company |
| `intel` | Intel Corporation | IntelContact |
| `cme` | CME | Chicago Music Exchange, LLC |

That audit was out-of-band and manual. It should not have to be.

## The general point

**"The API exposes no name" is not "the platform publishes no name."** All four put one on the page meant for humans and search engines, just not in the JSON or RSS a machine reads:

```
jazzhr    <title>83BAR - Career Page</title>
trakstar  <title>Jobs at AFLAC</title>
lever     <title>Findhelp, A Public Benefit Corporation</title>
ashby     <title>DDN Jobs</title>
```

Reading it there makes the corroboration gate (#1413) fire for all four, so the next harvest rejects what the last one needed an audit to catch.

## Cost

jazzhr and trakstar already fetched the page they need. lever and ashby gain one extra request — but only **once the API says the board has jobs**, the discipline greenhouse's board-metadata fetch already follows. On the last harvest that is 42 extra requests against 31k probes.

## Boilerplate is not a name

A title carrying no employer yields `""`, and the board is kept on liveness and labelled from the seed exactly as before:

- `Careers`, `Jobs` — generic titles. Gating a board against a word would reject every board on the platform.
- ashby's unknown-slug page serves a **200 titled just `Jobs`**; stripping the suffix leaves nothing.
- lever's unknown slug 404s, so the fetch errors and yields `""` naturally.

`opencatsPageTitle` moves out of the opencats file as `pageTitle` — four probers read a `<title>` now, and it never belonged to one of them.

## Verification

Live, against the real platforms:

```
jazzhr    cme:   expected "CME", board reports "Chicago Music Exchange, LLC" — skipped
trakstar  intel: expected "Intel Corporation", board reports "IntelContact" — skipped
trakstar  jones: skipped
          → every live board disagreed with what its seed expected, exit 1
```

`83bar`, `aflac`, `findhelp`, `1inch`, `hevo` and `ddn` all pass and report their names. Unit tests cover each extraction plus the titleless case.

This makes **42 of the 54 boards that had no verification path verifiable**. gem, deel and hireology remain without one — gem's storefront title is the slug echoed back.

`gofmt`/`go build`/`go vet` clean; package tests pass. One full-suite run showed `TestHeartbeatFiresUntilStopped` failing in `internal/worker`, which this change does not touch — re-run 5× green, it is timing-flaky.