### PR TITLE
refactor: close three latent gaps from the architecture review

### DIFF
--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobdedup"
 	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/pipeline"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/vocab"
@@ -36,6 +37,19 @@ type dbStore struct {
 	indexer       jobIndexer
 	crawled       *crawledSet
 }
+
+// dbStore is the only non-test implementation of pipeline.Store, and it is expected to carry
+// all three optional capabilities — the pipeline discovers them by type assertion and
+// silently degrades on a miss, which is right for a test fake and wrong for this one. A
+// dropped Touch stops refreshing a re-listed posting's last_seen_at, and the 48h unseen sweep
+// then closes live jobs. These state that expectation to the compiler, the way board_health.go
+// already does for the one port that was exported.
+var (
+	_ pipeline.Store      = (*dbStore)(nil)
+	_ pipeline.Closer     = (*dbStore)(nil)
+	_ pipeline.Toucher    = (*dbStore)(nil)
+	_ pipeline.SeenLookup = (*dbStore)(nil)
+)
 
 func newDBStore(pool *pgxpool.Pool, targetVersion int, indexer jobIndexer, crawled *crawledSet) *dbStore {
 	return &dbStore{pool: pool, q: db.New(pool), targetVersion: int32(targetVersion), indexer: indexer, crawled: crawled}

--- a/internal/boardresolve/boardresolve.go
+++ b/internal/boardresolve/boardresolve.go
@@ -20,13 +20,23 @@ import (
 )
 
 // trusted lists the providers whose atsdetect (provider, board) equals the ingest
-// external_id namespace, so a resolved board is dedup-correct. Greenhouse/Lever/Ashby/Workable
-// embed the board slug directly (verified against prod external_ids).
+// external_id namespace, so a resolved board is dedup-correct. These three embed the board
+// slug directly in the linked URL (verified against prod external_ids).
+//
+// It gates atsdetect's output only. atsdetect can also return icims/oracle/taleo/neogov/
+// paycom (via FromURL) and radancy/phenom/jibe/teamtailor (via the self-hosted markers);
+// those are deliberately NOT accepted here, because their board identity is a host or a
+// host+path that has not been checked against how ingest namespaces external_id. Widening
+// the set is a feature, and it needs that check first.
+//
+// Do not list a provider atsdetect cannot produce: the entry reads as coverage and is
+// unreachable. "workable" sat here doing exactly that — atsdetect's matcher table covers
+// greenhouse/lever/ashby, FromURL has no apply.workable.com case, and the self-hosted
+// markers explicitly exclude it.
 var trusted = map[string]bool{
 	"greenhouse": true,
 	"lever":      true,
 	"ashby":      true,
-	"workable":   true,
 }
 
 // textFetcher is the slice of the sources client this package needs (a raw, SSRF-guarded,

--- a/internal/cv/cv.go
+++ b/internal/cv/cv.go
@@ -169,18 +169,22 @@ type Header struct {
 	Links    []string `json:"links,omitempty"`
 }
 
-// withoutContacts returns a copy of the document with the candidate's identifiers
-// cleared. Location stays: it is not an identifier, and a tailoring agent reasons about
-// it when the vacancy is tied to a place. Links go, because a personal profile URL names
-// the candidate as squarely as their address does.
+// withoutContacts returns a copy of the document carrying only the parts of the header a
+// model may see. Location stays: it is not an identifier, and a tailoring agent reasons
+// about it when the vacancy is tied to a place. Everything else goes — a name, an address,
+// a number, and a personal profile URL all name the candidate equally.
+//
+// It REBUILDS the header from what is allowed through rather than clearing the fields it
+// knows to be identifiers, so a field added to Header is withheld until someone decides
+// otherwise here. A list of what to remove discloses whatever it has not been taught about,
+// which is the reading internal/resumeextract already rejected for its own projection
+// (structured.go: "A blacklist ... would disclose that new field by default, which is the
+// wrong way round"). This projection reaches the same models, so it follows the same rule.
 //
 // The receiver is a value, so the stored document is untouched — only the copy handed
 // to a reader is stripped.
 func (d Document) withoutContacts() Document {
-	d.Header.FullName = ""
-	d.Header.Email = ""
-	d.Header.Phone = ""
-	d.Header.Links = nil
+	d.Header = Header{Location: d.Header.Location}
 	return d
 }
 

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -3,6 +3,7 @@ package cv
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -210,6 +211,62 @@ func TestStoreGetForModelStripsTheContactBlock(t *testing.T) {
 	if stored.Document.Header.FullName != "Ada Lovelace" || stored.Document.Header.Email != "ada@example.com" {
 		t.Errorf("stored contacts were mutated: %+v", stored.Document.Header)
 	}
+}
+
+// TestRedactedHeaderKeepsOnlyLocation states the rule by the SHAPE of Header rather than by
+// naming the fields to clear, so a field added to the struct is covered the moment it is
+// declared.
+//
+// That direction is the whole point. Header reaches a model through GetForModel, and a
+// redaction that lists what to remove discloses anything it has not been taught about —
+// which is the reading internal/resumeextract already rejected for its own projection: "A
+// blacklist — dropping the four known contact keys — would disclose that new field by
+// default, which is the wrong way round."
+func TestRedactedHeaderKeepsOnlyLocation(t *testing.T) {
+	full := headerWithEveryFieldSet(t)
+
+	got := Document{Header: full}.withoutContacts().Header
+
+	v := reflect.ValueOf(got)
+	for i := range v.NumField() {
+		name := v.Type().Field(i).Name
+		if name == "Location" {
+			if got.Location != full.Location {
+				t.Errorf("Location = %q, want it kept: it is not an identifier", got.Location)
+			}
+			continue
+		}
+		if !v.Field(i).IsZero() {
+			t.Errorf("Header.%s survived the redaction (%v) — every field but Location must be withheld, "+
+				"including one added after this test was written", name, v.Field(i).Interface())
+		}
+	}
+}
+
+// headerWithEveryFieldSet builds a Header with a non-zero value in EVERY field, derived from
+// the struct rather than written out, so a newly declared field arrives populated and the
+// redaction is actually asked about it. A field of a kind this helper cannot fill fails the
+// test on purpose: a new kind in the contact block is a decision, not a default.
+func headerWithEveryFieldSet(t *testing.T) Header {
+	t.Helper()
+	var h Header
+	v := reflect.ValueOf(&h).Elem()
+	for i := range v.NumField() {
+		f, name := v.Field(i), v.Type().Field(i).Name
+		switch f.Kind() {
+		case reflect.String:
+			f.SetString("set-" + name)
+		case reflect.Slice:
+			f.Set(reflect.MakeSlice(f.Type(), 1, 1))
+			if e := f.Index(0); e.Kind() == reflect.String {
+				e.SetString("set-" + name)
+			}
+		default:
+			t.Fatalf("Header.%s is a %s, which this test cannot populate — teach it, and decide "+
+				"whether the field is an identifier while you are here", name, f.Kind())
+		}
+	}
+	return h
 }
 
 func TestStoreGetForModelForeignUserIsNotFound(t *testing.T) {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -34,25 +34,25 @@ type Store interface {
 	Save(ctx context.Context, j job.Job) error
 }
 
-// closer is the optional Store capability a self-closing streaming source needs: closing a
+// Closer is the optional Store capability a self-closing streaming source needs: closing a
 // posting by its (source, external_id) identity when the feed reports it removed. Only the
 // ingest dbStore implements it; ingestStream type-asserts for it and skips removals when a
 // Store lacks it, so other Store implementations (and test fakes) are unaffected.
-type closer interface {
+type Closer interface {
 	Close(ctx context.Context, source, externalID string) error
 }
 
-// toucher is the optional Store capability a HydratingSource needs: refresh a posting's liveness
+// Toucher is the optional Store capability a HydratingSource needs: refresh a posting's liveness
 // (last_seen_at, reopen if closed) by its (source, external_id) identity, WITHOUT rewriting its
 // content. The pipeline uses it for a posting the adapter re-listed but did not re-fetch (its
 // stored content is already current); a full upsert of the content-less listing would wipe the
 // hydrated description/facets. Only the ingest dbStore implements it; the pipeline type-asserts
-// for it and drops the refresh when a Store lacks it (test fakes), like closer.
-type toucher interface {
+// for it and drops the refresh when a Store lacks it (test fakes), like Closer.
+type Toucher interface {
 	Touch(ctx context.Context, source, externalID string) error
 }
 
-// seenLookup is the optional Store capability a HydratingSource needs: the external_ids already
+// SeenLookup is the optional Store capability a HydratingSource needs: the external_ids already
 // stored for the board about to be crawled, so the adapter fetches expensive per-posting detail
 // only for postings the catalogue lacks. Only the ingest dbStore implements it; the runner
 // type-asserts for it and falls back to the list-only Fetch when a Store lacks it (test fakes,
@@ -65,7 +65,7 @@ type toucher interface {
 // Each id maps to whether its stored row carries tech evidence (is_tech). Membership drives the
 // hydration decision; the flag lets a liveness refresh face the catalogue filter on the same
 // evidence a write would, which a content-less listing cannot supply.
-type seenLookup interface {
+type SeenLookup interface {
 	ExistingExternalIDs(ctx context.Context, source, board string) (map[string]bool, error)
 }
 
@@ -73,7 +73,7 @@ type seenLookup interface {
 // board is currently cooled down (skip it) and records each crawl's outcome so a
 // repeatedly-failing board backs off. A nil BoardHealth disables the feature entirely
 // (the Runner behaves exactly as before), so unit tests and non-DB callers are
-// unaffected — the same shape as the optional closer.
+// unaffected — the same shape as the optional Closer.
 type BoardHealth interface {
 	// Cooldown reports the board's cooldown_until and whether it is set. The Runner
 	// skips the board when it is set and in the future.
@@ -434,7 +434,7 @@ func (r Runner) saveOne(ctx context.Context, e sources.CompanyEntry, j sources.J
 // every lookup — harmless, because such a board yields no refreshes.
 func (r Runner) fetchBoard(ctx context.Context, e sources.CompanyEntry, src sources.Source) ([]sources.Job, map[string]bool, error) {
 	hs, hydrating := src.(sources.HydratingSource)
-	sl, canLookUp := r.Store.(seenLookup)
+	sl, canLookUp := r.Store.(SeenLookup)
 	if !hydrating || !canLookUp {
 		jobs, err := src.Fetch(ctx, e)
 		return jobs, nil, err
@@ -454,10 +454,10 @@ func (r Runner) fetchBoard(ctx context.Context, e sources.CompanyEntry, src sour
 }
 
 // touch refreshes an already-ingested posting's liveness (last_seen_at, reopen) by identity,
-// without rewriting its content. It routes through the Store's optional toucher capability; a
-// Store without it (a test fake) drops the refresh, matching how ingestStream handles closer.
+// without rewriting its content. It routes through the Store's optional Toucher capability; a
+// Store without it (a test fake) drops the refresh, matching how ingestStream handles Closer.
 func (r Runner) touch(ctx context.Context, e sources.CompanyEntry, j sources.Job) error {
-	t, ok := r.Store.(toucher)
+	t, ok := r.Store.(Toucher)
 	if !ok {
 		return nil
 	}
@@ -519,10 +519,10 @@ func (r Runner) ingestStream(ctx context.Context, e sources.CompanyEntry, ss sou
 		defer mu.Unlock()
 		total++
 		// A self-closing source emits removed postings: close by identity instead of
-		// upserting. The Store must implement closer (the ingest dbStore does); a Store
+		// upserting. The Store must implement Closer (the ingest dbStore does); a Store
 		// without it simply drops the removal (e.g. a test fake that never sees them).
 		if j.Removed {
-			c, ok := r.Store.(closer)
+			c, ok := r.Store.(Closer)
 			if !ok {
 				return
 			}


### PR DESCRIPTION
Three findings from `docs/reviews/2026-08-01-architecture-review.md`. **None changes behaviour today** — each turns a rule that currently holds by hand into one the compiler or a test holds instead. No spec delta, no migration.

Each fix was verified by breaking it on purpose and watching the new guard fire.

---

### #24 — the CV redaction handed to a model becomes a whitelist

`Document.withoutContacts` cleared four named fields. `Store.GetForModel` applies it as its **only** redaction and feeds both the `cv_get` tool and the API-key `GET /me/cvs/:id` — so a field added to `cv.Header` would have reached a model by default.

```go
-	d.Header.FullName = ""
-	d.Header.Email = ""
-	d.Header.Phone = ""
-	d.Header.Links = nil
+	d.Header = Header{Location: d.Header.Location}
```

This is the direction `internal/resumeextract` already argued for its own projection — *"A blacklist — dropping the four known contact keys — would disclose that new field by default, which is the wrong way round"*. That projection and this one reach the same models; they now follow the same rule.

Output is byte-identical today: `Header` has exactly five fields.

**The test derives both sides from the struct** — it fills every field by reflection, so a newly declared field arrives populated and the redaction is actually asked about it. A field of a kind the helper cannot fill fails on purpose: a new kind in the contact block is a decision, not a default.

> Verified: added a sixth field `Website` to `Header`. Old code → `Header.Website survived the redaction (set-Website)`. New code → pass. Field removed.

### #15 — the pipeline's three optional Store capabilities are exported

`closer` / `toucher` / `seenLookup` were unexported, so `cmd/ingest` could not assert that `dbStore` satisfies them — while `board_health.go:24` already does exactly that for `BoardHealth`, showing the intended discipline.

The Runner discovers these by type assertion and **silently degrades on a miss**. That is right for a test fake and wrong for the one production implementation: a dropped `Touch` stops refreshing a re-listed posting's `last_seen_at`, and the 48h unseen sweep then closes live jobs.

> Verified: widened `Touch` to take a fourth argument. Now → `*dbStore does not implement pipeline.Toucher (wrong type for method Touch)`. Before → compiled clean.

### #9 — the dead `workable` entry in `boardresolve.trusted`

`atsdetect.Detect` can return greenhouse/lever/ashby (matcher table), icims/oracle/taleo/neogov/paycom (`FromURL`) and radancy/phenom/jibe/teamtailor (self-hosted markers). Never workable — and `selfHosted`'s own doc says so: *"Greenhouse, Lever, Ashby, Workable and plain non-ATS careers pages carry none."*

The entry read as coverage the package did not have. The comment now records which providers are deliberately excluded and why, so the next reader does not re-add one on the same misreading.

---

## Verification

- `go build ./...`, `go vet ./...`, **`go vet -tags=integration ./...`** — clean
- `go test ./...` — clean; `go test -tags=integration ./internal/db/` — ok, 33.4s
- `gofmt -l` — clean

(The tagged vet run is the guard added in #1481, used here for the first time — this diff changes an unexported constructor's neighbours and a shared interface, exactly its case.)