### PR TITLE
fix(sources): drop 4 more harvested boards that belong elsewhere

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7528,8 +7528,6 @@
   board: ediphi
 - company: FYST
   board: fyst
-- company: GlossGenius
-  board: glossgenius
 - company: Hamster Garage
   board: hamstergarage
 - company: Hire Digital
@@ -7554,12 +7552,8 @@
   board: revecore
 - company: Seekeasy
   board: seekeasy
-- company: TBC Corporation
-  board: tbc
 - company: True Classic Tees LLC
   board: true-classic-tees
-- company: Visier
-  board: visier
 - company: Whiskey Library
   board: whiskeylibrary
 - company: Wonderly

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4425,8 +4425,6 @@
   board: audinate
 - company: Big Health
   board: bighealth
-- company: career
-  board: career
 - company: Find.co
   board: find
 - company: GTI Fabrication


### PR DESCRIPTION
lever and ashby became verifiable in #1485 — both storefronts title themselves after the employer — so the 42 boards they contributed in #1472 could finally be checked against the same rule every gated board is judged by.

## Result

| provider | checked | wrong | unverifiable |
|---|---:|---:|---:|
| ashby | 28 | 3 | 0 |
| lever | 14 | 1 | 1 |

| board | filed as | actually |
|---|---|---|
| `ashby/glossgenius` | GlossGenius | **Genius AI** — 26 live jobs |
| `ashby/tbc` | TBC Corporation | **The Biological Computing Co.** — "Staff AI Researcher", not auto parts |
| `ashby/visier` | Visier | titles itself with a bare UUID |
| `lever/career` | career | serves one posting: **"Test Job"** |

`lever/career` is the whole pattern in one line: a dictionary word as a slug, a test tenant behind it, and a company in our catalogue literally named "career".

## Two near-misses kept, by hand

n=4 allows individual judgement where n=39 (#1477) did not, so both were checked rather than swept:

- **`ashby/true-classic-tees`** reports "True Classic" and serves apparel roles — the same company after a rebrand.
- **`lever/healthmark-group`** has no public storefront at all (a consistent 404), but its API serves a real "Backend Engineer" posting. Unverifiable, not wrong — the same standing as gem, deel and hireology.

## Running total

Together with the 44 from #1477, **48 of 262 verifiable harvested boards were filed under the wrong employer** — 18%. The collisions concentrate exactly where expected: short, generic or dictionary slugs.

`go test ./internal/sources/` passes.
