### PR TITLE
fix(harvest-boards): a 503 is not a rate limit

### DIFF
--- a/cmd/harvest-boards/refusals.go
+++ b/cmd/harvest-boards/refusals.go
@@ -34,10 +34,13 @@ func newCountingClient(inner httpClient) *countingClient {
 	return &countingClient{inner: inner}
 }
 
-// record classifies one transport outcome. A 429 (and the 503 a WAF serves under the same
-// conditions) is a refusal; a 404 is the platform answering "no such board", which is an
-// answer and exactly what a harvest is built to read; anything else — a timeout, a DNS
-// failure, a closed connection — is a dead host, which is neither.
+// record classifies one transport outcome. Only a 429 is a refusal: it is the one status that
+// unambiguously means "the platform is there and is declining". Every other status is the
+// platform answering — a 404, or a 503, which reads like a refusal but is not one. Traffit
+// answers an unknown tenant with 503 and a live board with 200, so counting it turned a run
+// where every candidate was simply absent into "refused=15467, nothing written, exit 1".
+// Anything that is not an HTTP status at all — a timeout, a DNS failure, a closed connection
+// — is a dead host, which is neither refused nor answered.
 func (c *countingClient) record(err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -49,12 +52,11 @@ func (c *countingClient) record(err error) {
 	if !errors.As(err, &se) {
 		return
 	}
-	switch se.Code {
-	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+	if se.Code == http.StatusTooManyRequests {
 		c.refusedN++
-	default:
-		c.answeredN++
+		return
 	}
+	c.answeredN++
 }
 
 func (c *countingClient) refused() int {

--- a/cmd/harvest-boards/refusals_test.go
+++ b/cmd/harvest-boards/refusals_test.go
@@ -85,3 +85,19 @@ func TestRefusalsDominated(t *testing.T) {
 		t.Error("a run that made no requests is not a refused run")
 	}
 }
+
+// A 503 is not a rate limit. Traffit answers an unknown tenant with one — 200 for a live
+// board, 503 for a slug nobody owns — so counting it as a refusal turned a completely normal
+// run (every candidate simply absent) into "refused=15467, nothing written, exit 1".
+func TestCountingClientDoesNotCountServiceUnavailableAsRefusal(t *testing.T) {
+	c := newCountingClient(erroringClient{
+		err: &sources.StatusError{Method: http.MethodGet, Code: http.StatusServiceUnavailable, URL: "u"},
+	})
+	_ = c.GetJSON(context.Background(), "u", nil)
+	if got := c.refused(); got != 0 {
+		t.Errorf("a 503 is ambiguous and must not count as a refusal, refused = %d, want 0", got)
+	}
+	if got := c.answered(); got != 1 {
+		t.Errorf("answered = %d, want 1 — the platform did answer", got)
+	}
+}


### PR DESCRIPTION
## What happened

The refusal guard (#1455) counted `503` alongside `429`, on the assumption that a WAF serves it under the same conditions.

Traffit uses it for something else entirely — measured from the production host, idle:

```
live board (cloudfide)   200
unknown slug             503
```

So `503` is traffit's "no such board". Its harvest — a run where every single candidate was genuinely absent — reported `refused=15467 answered=0`, wrote nothing, and exited 1.

## Why this one stings

That is the guard's own failure mode, inverted. It was built so a **blocked run could not pass as an exhausted one**, and it turned an **exhausted run into a blocked-looking one**. Both readings are wrong for the same reason: a status code was taken to mean something the platform never said.

## The fix

Only `429` counts as a refusal — the one status that unambiguously means the platform is there and declining. A `503` is the platform answering, and is counted as an answer.

## Consequence for the harvest

traffit's run has to be redone; it was never actually refused. The other five refusals (bamboohr, personio, jobvite, recruitee, workable) still need re-measuring under the corrected rule — none of them answers a nonexistent slug with 503 when idle (302, 307, 404, 302, 404 respectively), so their counts were probably genuine 429s, but that is now worth confirming rather than assuming.

`gofmt`/`go build`/`go vet` clean; five unit tests cover the classification.