### PR TITLE
refactor(handler): Register owns the shared services it says it owns

### DIFF
--- a/internal/handler/AGENTS.md
+++ b/internal/handler/AGENTS.md
@@ -24,8 +24,20 @@ Fiber HTTP handlers: feature handler structs, route registration, auth surface, 
   behind: `optional` (attach caller, never reject), `key` (cookie or API key), `cookie`
   (cookie-only), `moderator` (role gate, stacked after `key`/`cookie`).
 - Services shared across features (résumé store, profile, credits, CV store/renderer,
-  match analyzer, contribution, moderation) are built once in `Register` and passed to
-  each constructor; single-feature services are built inside the feature's constructor.
+  conversation store, match analyzer, contribution, moderation, the LLM spend resolver)
+  are built once in `Register` and passed to each constructor; single-feature services are
+  built inside the feature's constructor. **A constructor that builds a shared service is
+  the bug, not the `Register` line that digs it back out** — `cvH.cvStore` and
+  `assistantH.store` were both read out of a handler for a second consumer until the
+  service moved up. When a second feature needs one, hoist it; do not reach into the
+  first feature's struct.
+- **No post-construction setter for a dependency that exists before construction.** Three
+  of them (`withAssistantSessions`, `withFollowUps`, `withKeys`) existed only because of
+  the ownership above, and each made a handler's field nil for part of its life. The two
+  that survive — `withAccountDeletion`, `accounts.WithCodes`/`report.WithNotifier` — are
+  conditioned on an SES client built inside an `if`, which is a different thing: the
+  dependency genuinely does not exist yet. Two same-typed clients go in a named struct
+  (`assistantModels`), not as adjacent parameters — a swap there compiles.
 - Tests construct the feature struct directly with fakes/stubs (e.g.
   `&trackingHandlers{tracking: ...}`) and mount routes on a bare `fiber.App`.
 - Central `handler.RenderError` (wired in `cmd/server` via `fiber.Config{ErrorHandler: handler.RenderError}`) renders JSON envelope: `*fiber.Error`→its code, `pgx.ErrNoRows`→404, FK-violation (SQLSTATE 23503)→404, everything else→500.

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -76,16 +76,32 @@ type assistantHandlers struct {
 	invitation invitationReader
 }
 
-// newAssistantHandlers wires the agent. A nil LLM client leaves the runner nil:
-// old conversations stay readable and a new turn reports the assistant as
-// unavailable, rather than the whole surface disappearing.
-func newAssistantHandlers(queries *db.Queries, model *llm.Client, maxSteps int,
+// assistantModels names the two model clients the assistant runs on and the resolver that
+// bills them. It exists because Agent and FollowUps are the SAME TYPE and different models
+// — as two adjacent parameters a swap would compile and quietly move every turn onto the
+// cheap model — so the call site names each one instead of relying on argument order.
+type assistantModels struct {
+	// Agent is the model the turn loop runs on. Nil leaves the runner nil: old
+	// conversations stay readable and a new turn reports the assistant as unavailable,
+	// rather than the whole surface disappearing.
+	Agent *llm.Client
+	// FollowUps is the cheap general-purpose model the suggestion strip runs on. The whole
+	// argument for generating suggestions outside the turn is that they cost almost nothing.
+	FollowUps *llm.Client
+	// Keys names the caller on the gateway. Nil is ordinary rather than degraded: every
+	// turn then spends on the service credential, exactly as it did before attribution.
+	Keys     *llmkey.Resolver
+	MaxSteps int
+}
+
+// newAssistantHandlers wires the agent.
+func newAssistantHandlers(queries *db.Queries, models assistantModels, store *assistant.Store,
 	search *searchHandlers, resumeH *resumeHandlers, tracking *trackingHandlers, cvH *cvHandlers,
 	profileH *profileHandlers, browserTools *browsertools.Hub, mail *inboxHandlers,
 	bank experienceBankTools) *assistantHandlers {
 	h := &assistantHandlers{
 		experience:   bank,
-		store:        assistant.NewStore(queries),
+		store:        store,
 		queries:      queries,
 		search:       search,
 		resume:       resumeH,
@@ -102,19 +118,14 @@ func newAssistantHandlers(queries *db.Queries, model *llm.Client, maxSteps int,
 	if mail != nil {
 		h.invitation = mail.inbox
 	}
-	if model != nil {
-		h.llm = model
-		h.runner = assistant.NewRunner(model, h.store, assistant.RunnerConfig{MaxSteps: maxSteps})
+	if models.Agent != nil {
+		h.llm = models.Agent
+		h.runner = assistant.NewRunner(models.Agent, h.store, assistant.RunnerConfig{MaxSteps: models.MaxSteps})
 	}
+	h.keys = models.Keys
+	h.followUps = assistant.NewFollowUps(models.FollowUps)
+	h.followUpLLM = llmBinding{client: models.FollowUps, keys: models.Keys}
 	return h
-}
-
-// withKeys gives the assistant the resolver that names the caller on the gateway. Separate
-// from the constructor because a deployment without it is ordinary rather than degraded:
-// every turn then spends on the service credential, exactly as it did before.
-func (h *assistantHandlers) withKeys(keys *llmkey.Resolver) {
-	h.keys = keys
-	h.followUpLLM.keys = keys
 }
 
 // register mounts the assistant. A browser drives it, but not always the web app:
@@ -647,15 +658,6 @@ func (h *assistantHandlers) layDownRunPlan(ctx context.Context, sess assistant.S
 	if err := h.cv.cvStore.SetAutopilotReport(ctx, *sess.CVID, sess.UserID, plan); err != nil {
 		log.Printf("assistant: could not lay down the run plan cv=%s: %v", sess.CVID, err)
 	}
-}
-
-// withFollowUps gives the assistant the model its suggestions run on. Separate from
-// the constructor because it is a DIFFERENT model from the agent's — the cheap
-// general-purpose one — and threading a second client through an already long
-// parameter list would invite passing the wrong one.
-func (h *assistantHandlers) withFollowUps(model *llm.Client) {
-	h.followUps = assistant.NewFollowUps(model)
-	h.followUpLLM.client = model
 }
 
 // ownedSession resolves the :id route param to a session the caller owns.

--- a/internal/handler/assistant_followups_integration_test.go
+++ b/internal/handler/assistant_followups_integration_test.go
@@ -60,7 +60,7 @@ func TestFollowUpsOnAnEmptyConversationSpendNothing(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	app, h := newAssistantApp(pool, iss, nil)
-	h.withFollowUps(llm.NewWithModel(jsonModel{body: `{"follow_ups":["never asked?"]}`}))
+	setFollowUpModel(h, llm.NewWithModel(jsonModel{body: `{"follow_ups":["never asked?"]}`}))
 	_, cookie := assistantUser(t, pool, iss, "quiet@example.test", true)
 
 	got, status := followUpsOf(t, app, createSession(t, app, cookie), cookie)
@@ -79,7 +79,7 @@ func TestFollowUpsSurviveAFailingModel(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	app, h := newAssistantApp(pool, iss, &turnModel{replies: []*llms.ContentChoice{{Content: "here are three roles"}}})
-	h.withFollowUps(llm.NewWithModel(jsonModel{err: errors.New("gateway down")}))
+	setFollowUpModel(h, llm.NewWithModel(jsonModel{err: errors.New("gateway down")}))
 	_, cookie := assistantUser(t, pool, iss, "unlucky@example.test", true)
 
 	id := createSession(t, app, cookie)
@@ -102,7 +102,7 @@ func TestFollowUpsFollowTheAnswerThatWasGiven(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	app, h := newAssistantApp(pool, iss, &turnModel{replies: []*llms.ContentChoice{{Content: "here are three roles"}}})
-	h.withFollowUps(llm.NewWithModel(jsonModel{
+	setFollowUpModel(h, llm.NewWithModel(jsonModel{
 		body: `{"follow_ups":["compare the first two?","tailor my CV to the first?","  ","which pays most?","a fifth?"]}`,
 	}))
 	_, cookie := assistantUser(t, pool, iss, "curious@example.test", true)
@@ -130,7 +130,7 @@ func TestFollowUpsWithoutAModelAreEmpty(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	app, h := newAssistantApp(pool, iss, &turnModel{replies: []*llms.ContentChoice{{Content: "an answer"}}})
-	h.withFollowUps(nil)
+	setFollowUpModel(h, nil)
 	_, cookie := assistantUser(t, pool, iss, "plain@example.test", true)
 
 	id := createSession(t, app, cookie)
@@ -149,7 +149,7 @@ func TestFollowUpsRequireACredential(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	app, h := newAssistantApp(pool, iss, nil)
-	h.withFollowUps(llm.NewWithModel(jsonModel{body: `{"follow_ups":["never?"]}`}))
+	setFollowUpModel(h, llm.NewWithModel(jsonModel{body: `{"follow_ups":["never?"]}`}))
 	_, cookie := assistantUser(t, pool, iss, "owner@example.test", true)
 
 	id := createSession(t, app, cookie)
@@ -193,4 +193,12 @@ func TestFollowUpsReadTheStoredTranscript(t *testing.T) {
 	if ex.Prompt != "the question" || ex.Answer != "the spoken answer" {
 		t.Errorf("exchange = %+v, want the turn that was just run", ex)
 	}
+}
+
+// setFollowUpModel binds the suggestion model the way newAssistantHandlers does. It exists
+// as ONE helper so a fixture cannot bind half of it — the client without the spend
+// resolver — which is the shape of divergence a partial struct literal invites.
+func setFollowUpModel(h *assistantHandlers, model *llm.Client) {
+	h.followUps = assistant.NewFollowUps(model)
+	h.followUpLLM = llmBinding{client: model, keys: h.keys}
 }

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -56,7 +56,6 @@ type cvHandlers struct {
 	jobReader jobReader
 	match     *matchHandlers
 	// assistantSessions mints the conversation a tailoring workspace runs in.
-	// Assigned after construction (see withAssistantSessions).
 	assistantSessions *assistant.Store
 	// seeder answers what a new CV starts from: the banked work history plus the sections
 	// the stored structure still owns.
@@ -75,10 +74,12 @@ type jobReader interface {
 	GetJob(ctx context.Context, id int64) (db.Job, error)
 }
 
-func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, typstBin, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate) *cvHandlers {
+func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, assistantSessions *assistant.Store, cvRenderer cv.Renderer, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate) *cvHandlers {
 	h := &cvHandlers{
-		cvStore:    cvStore,
-		tracerSalt: tracerSalt,
+		cvStore:           cvStore,
+		assistantSessions: assistantSessions,
+		cvRenderer:        cvRenderer,
+		tracerSalt:        tracerSalt,
 		tracerMinter: tracerlink.NewMinter(tracerlink.NewRepository(
 			func(ctx context.Context, cvID uuid.UUID, userID int64, token, sourcePath, destURL, destHash string) (string, error) {
 				return queries.UpsertTracerLink(ctx, db.UpsertTracerLinkParams{
@@ -103,20 +104,7 @@ func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, t
 		match:              match,
 		extractPDFText:     resume.ExtractPDFText,
 	}
-	// The renderer is enabled only when a typst binary was resolved (assign only a
-	// non-nil renderer so the interface stays nil when disabled — a typed-nil would
-	// defeat the 501 gate).
-	if r := cv.NewTypstRenderer(typstBin); r != nil {
-		h.cvRenderer = r
-	}
 	return h
-}
-
-// withAssistantSessions gives the tailoring bootstrap the conversation store it
-// mints a session in. Assigned after construction because the assistant is built
-// from these handlers — the same shape authH.withAccountDeletion uses.
-func (h *cvHandlers) withAssistantSessions(store *assistant.Store) {
-	h.assistantSessions = store
 }
 
 // seedSource returns what a new CV starts from, and is never nil.

--- a/internal/handler/cv_evidence_gate_integration_test.go
+++ b/internal/handler/cv_evidence_gate_integration_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/strelov1/freehire/internal/assistant"
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/credits"
 	"github.com/strelov1/freehire/internal/cv"
@@ -44,7 +45,10 @@ func newCVAPIWithoutAssistant(t *testing.T) (*cvHandlers, *auth.Issuer, *fiber.A
 	bank := experience.NewStore(experience.NewQueriesRepository(queries))
 
 	h := newCVHandlers(pool, queries, cv.NewStore(cv.NewQueriesRepository(queries)),
-		"", "test-salt", "https://freehire.test",
+		assistant.NewStore(queries),
+		// No renderer: this fixture exercises the edit path, and the PDF endpoint's 501
+		// gate is what a nil one means.
+		nil, "test-salt", "https://freehire.test",
 		[]string{"freehire.test"},
 		resume.New(nil, resume.NewQueriesRepository(queries)),
 		headshot.New(nil, headshot.NewQueriesRepository(queries)),

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -55,10 +55,10 @@ func newTailorAPI(t *testing.T) (*cvHandlers, *auth.Issuer, *pgxpool.Pool) {
 		matchAnalysisCache: queries,
 		credits:            creditsStore,
 		match:              &matchHandlers{credits: creditsStore},
+		// The tailoring bootstrap mints its conversation through the assistant's store,
+		// exactly as Register wires it.
+		assistantSessions: assistant.NewStore(queries),
 	}
-	// The tailoring bootstrap mints its conversation through the assistant's store,
-	// exactly as Register wires it.
-	h.withAssistantSessions(assistant.NewStore(queries))
 	return h, iss, pool
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/accountdelete"
 	"github.com/strelov1/freehire/internal/accounts"
+	"github.com/strelov1/freehire/internal/assistant"
 	"github.com/strelov1/freehire/internal/atscheck"
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/auth/oauth"
@@ -246,12 +247,15 @@ func Register(app *fiber.App, cfg Config) {
 			"sign-in on them (state mismatch). List every served host in SERVED_HOSTS.",
 			cfg.CookieDomains, cfg.FrontendOrigin)
 	}
-	jobsH := newJobsHandlers(queries, moderation.New(moderation.NewQueriesRepository(queries, cfg.Pool, enrich.Version)))
+	// Moderation is shared by the jobs surface and the submission queue, so it is built
+	// here rather than inside whichever of the two is constructed first.
+	moderationSvc := moderation.New(moderation.NewQueriesRepository(queries, cfg.Pool, enrich.Version))
+	jobsH := newJobsHandlers(queries, moderationSvc)
 	sitemapH := newSitemapHandlers(queries)
 	statsH := newStatsHandlers(queries)
 	votesH := newVoteHandlers(queries, cfg.Pool)
 	communityH := newCommunityHandlers(queries)
-	submissionsH := newSubmissionHandlers(queries, jobsH.moderation)
+	submissionsH := newSubmissionHandlers(queries, moderationSvc)
 	// Contributions detect the ATS board from the URL alone (network-free, board.go), with a
 	// network fallback (boardresolve) that fetches a company careers page and detects an
 	// embedded ATS — so vanity-domain links (company.com/careers?gh_jid=…) resolve too.
@@ -298,7 +302,23 @@ func Register(app *fiber.App, cfg Config) {
 	// and autofill reads the base CV's contact header out of it. AGENTS.md puts shared
 	// services here rather than inside whichever feature happened to need one first.
 	cvStore := cv.NewStore(cv.NewQueriesRepository(queries))
-	cvH := newCVHandlers(cfg.Pool, queries, cvStore, cfg.TypstBin, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank})
+	// The conversation store is shared the same way: the assistant runs turns in it and the
+	// tailoring bootstrap mints a session in it. Built here, both are handed the same one —
+	// which is what lets the CV handlers take it as an argument instead of being patched
+	// with it after the assistant exists.
+	assistantStore := assistant.NewStore(queries)
+	// The renderer is shared with referrals, and is enabled only when a typst binary was
+	// resolved. Assign only a NON-NIL renderer: a typed-nil satisfies cv.Renderer and would
+	// defeat the 501 gate that answers when rendering is off.
+	var cvRenderer cv.Renderer
+	if r := cv.NewTypstRenderer(cfg.TypstBin); r != nil {
+		cvRenderer = r
+	}
+	// Who each model call is spent as. One resolver serves every per-user surface, so the
+	// account a call is attributed to is decided in one place rather than per feature. A nil
+	// gateway client leaves it inert and every call on the service credential.
+	llmKeys := llmkey.NewResolver(queries, cfg.LLMKeys)
+	cvH := newCVHandlers(cfg.Pool, queries, cvStore, assistantStore, cvRenderer, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank})
 	telegramH := newTelegramHandlers(queries, cfg.JWTSecret, cfg.TelegramBotToken, cfg.TelegramBotUsername, cfg.TelegramWebhookSecret, cfg.FrontendOrigin, contributionsH.intake)
 	inboxH := newInboxHandlers(queries, cfg.Pool, cfg.GmailConnector, cfg.GmailCipher, cfg.FrontendOrigin, cfg.CookieSecure, cfg.MailboxDomain)
 	// Account deletion reaches past the FK cascade: cfg.Blob is nil when storage is
@@ -337,18 +357,11 @@ func Register(app *fiber.App, cfg Config) {
 	// disagree. The tailoring bootstrap mints its conversations through the same
 	// store, which is why the CV handlers get it back. It also takes the browser-tool
 	// hub, which a browsing session reads the caller's open page through.
-	assistantH := newAssistantHandlers(queries, cfg.AssistantLLM, cfg.AssistantMaxSteps, searchH, resumeH, trackingH, cvH, profileH, a.browserTools, inboxH, bank)
-	cvH.withAssistantSessions(assistantH.store)
 	// Suggestions run on LLM (cheap, one-shot) rather than on AssistantLLM: the whole
 	// argument for generating them outside the turn is that they cost almost nothing.
-	assistantH.withFollowUps(cfg.LLM)
-
-	// Who each model call is spent as. One resolver serves every per-user surface, so
-	// the account a call is attributed to is decided in one place rather than per
-	// feature. A nil gateway client leaves it inert and every call on the service
-	// credential.
-	llmKeys := llmkey.NewResolver(queries, cfg.LLMKeys)
-	assistantH.withKeys(llmKeys)
+	assistantH := newAssistantHandlers(queries,
+		assistantModels{Agent: cfg.AssistantLLM, FollowUps: cfg.LLM, Keys: llmKeys, MaxSteps: cfg.AssistantMaxSteps},
+		assistantStore, searchH, resumeH, trackingH, cvH, profileH, a.browserTools, inboxH, bank)
 	resumeH.llm = llmBinding{client: cfg.LLM, keys: llmKeys}
 	matchH.llm = llmBinding{client: cfg.LLM, keys: llmKeys}
 	// The autofill planner is one cheap structured call per run, so it travels on the
@@ -391,7 +404,7 @@ func Register(app *fiber.App, cfg Config) {
 	referralCabinetURL := strings.TrimRight(cfg.FrontendOrigin, "/") + "/my/referrals?tab=incoming"
 	referralSvc := referral.New(referral.NewQueriesRepository(queries), referralPinger, cfg.Blob,
 		referral.Config{CabinetURL: referralCabinetURL})
-	referralsH := newReferralHandlers(referralSvc, cfg.Blob, cvH.cvRenderer, cvStore, photoStore)
+	referralsH := newReferralHandlers(referralSvc, cfg.Blob, cvRenderer, cvStore, photoStore)
 
 	// Allow the canonical frontend origin plus every served domain's https apex,
 	// so a cross-origin (non-credentialed) read works from either domain during a


### PR DESCRIPTION
Closes finding **#4** from `docs/reviews/2026-08-01-architecture-review.md`. **No behaviour change** — this only moves where things are built.

## The contradiction

`internal/handler/AGENTS.md` has said all along:

> Services shared across features … are built once in `Register` and passed to each constructor.

Five were not. Each was built inside whichever feature needed one first, and `Register` dug it back out:

| service | was built in | was reached out of |
|---|---|---|
| `moderation.Service` | inline in the `newJobsHandlers` call | `jobsH.moderation` |
| `cv.Store` | `newCVHandlers` | `cvH.cvStore` — *hoisted in #1478* |
| `cv.Renderer` | `newCVHandlers` | `cvH.cvRenderer` |
| `assistant.Store` | `newAssistantHandlers` | `assistantH.store` |
| `llmkey.Resolver` | built after its consumer | — |

## What it cost

That ownership is what produced the two-phase wiring. Three setters existed only to close cycles it created, and each left a field nil for part of a handler's life:

- `cvH.withAssistantSessions(assistantH.store)` — the CV handlers were patched with a store built inside the assistant, which was itself built *from* the CV handlers
- `assistantH.withFollowUps(cfg.LLM)` — `cfg.LLM` exists before construction; this was a missing argument, not a cycle
- `assistantH.withKeys(llmKeys)` — the resolver was simply constructed too late

**All three are gone.** The two that survive are a genuinely different shape and stay: `withAccountDeletion` and the `WithCodes` / `WithNotifier` pair are conditioned on an SES client built inside an `if cfg.AWSRegion != "" && …` block, so the dependency really does not exist at construction time.

## The one place a setter was load-bearing

`withFollowUps` documented itself as deliberate, and the argument was real:

> it is a DIFFERENT model from the agent's — the cheap general-purpose one — and threading a second client through an already long parameter list would invite passing the wrong one.

True: two adjacent `*llm.Client` parameters, and a swap compiles and quietly moves every turn onto the cheap model. So they travel in a named struct instead:

```go
assistantModels{Agent: cfg.AssistantLLM, FollowUps: cfg.LLM, Keys: llmKeys, MaxSteps: cfg.AssistantMaxSteps}
```

The call site names each one. The hazard the setter defended against is answered without the setter.

## Care taken

- **The renderer's typed-nil guard moved intact.** `NewTypstRenderer` returns a concrete `*TypstRenderer`, so the nil check happens on the pointer and `cv.Renderer` stays a true nil when no typst binary is configured — a typed-nil would satisfy the interface and defeat the 501. `GET /me/cvs/:id/pdf` still answers 501.
- **Fixtures follow the constructor.** `cv_tailor_integration_test.go` sets `assistantSessions` in the struct literal; the follow-ups tests bind through one helper rather than five partial literals, so a fixture cannot bind the client without the spend resolver. (That is the I1 lesson: a fixture that bypasses the constructor is immune to the fix that hardens it.)

## Verification

- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — clean
- `go test ./...` — clean
- **`go test -tags=integration ./internal/handler/` — ok, 22.2s** (the suite that actually exercises this wiring)
- `gofmt -l` — clean

The tagged vet caught two broken fixtures during the work, which is its second catch since #1481 added it.

## AGENTS.md

The rule is restated as a diagnosis rather than an aspiration — *a constructor that builds a shared service is the bug, not the `Register` line that digs it back out* — plus the setter rule and the same-typed-parameters rule, each naming the case that produced it.