### PR TITLE
refactor(web): one status chip, one tab strip

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -1,7 +1,7 @@
 {
   "Alert": 0,
   "Avatar": 0,
-  "Badge": 13,
+  "Badge": 12,
   "Button": 50,
   "Card": 0,
   "Chip": 0,

--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -1,7 +1,7 @@
 {
   "Alert": 0,
   "Avatar": 0,
-  "Badge": 12,
+  "Badge": 13,
   "Button": 50,
   "Card": 0,
   "Chip": 0,

--- a/design-system/scripts/web-token-baseline.json
+++ b/design-system/scripts/web-token-baseline.json
@@ -48,7 +48,7 @@
   "web/src/lib/components/InboxLandingView.svelte": 4,
   "web/src/lib/components/InboxView.svelte": 8,
   "web/src/lib/components/InsightsPageShell.svelte": 2,
-  "web/src/lib/components/JobDrawer.svelte": 8,
+  "web/src/lib/components/JobDrawer.svelte": 7,
   "web/src/lib/components/JobMatch.svelte": 1,
   "web/src/lib/components/JobMatchBar.svelte": 1,
   "web/src/lib/components/JobRow.svelte": 4,

--- a/web/src/lib/actions/tablist.ts
+++ b/web/src/lib/actions/tablist.ts
@@ -63,3 +63,21 @@ export const tablist: Action<HTMLElement, unknown> = (node) => {
     destroy: () => node.removeEventListener('keydown', onKeydown),
   };
 };
+
+/**
+ * The pill treatment for a routed `/my/*` tab — the two segment strips over the tracking
+ * board and the activity lists. It lives beside the behaviour rather than in either layout
+ * because both had it, byte for byte, and a pill that drifts between two sibling sections
+ * of the same account area reads as a bug rather than as a choice.
+ *
+ * It is NOT the underline strip (`TabRow`) or the design system's `Tabs`: those weld the
+ * list to a panel, and these tabs are anchors driving a route.
+ */
+export function routeTabClass(active: boolean): string {
+  return [
+    'rounded-md px-3 py-1.5 text-sm transition-colors',
+    active
+      ? 'bg-secondary font-medium text-secondary-foreground'
+      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+  ].join(' ');
+}

--- a/web/src/lib/components/InboxLandingView.svelte
+++ b/web/src/lib/components/InboxLandingView.svelte
@@ -3,7 +3,7 @@
   import { Button } from '$lib/ui';
   import NumberedGrid from '$lib/components/NumberedGrid.svelte';
   import SectionLabel from '$lib/components/SectionLabel.svelte';
-  import { statusClass, statusLabel } from '$lib/emailStatus';
+  import StatusChip from '$lib/components/StatusChip.svelte';
   import { INBOX_FAQ } from '$lib/inboxFaq';
   import { INBOX_STATUS_GUIDE } from '$lib/inboxStatusGuide';
 
@@ -93,12 +93,6 @@
   </div>
 {/snippet}
 
-{#snippet chip(signal: string, size: string)}
-  <span class="inline-block rounded border px-1.5 {size} {statusClass(signal)}">
-    {statusLabel(signal)}
-  </span>
-{/snippet}
-
 <div class="flex flex-col">
   <!-- Hero. Left: the pitch. Right: the inbox itself, chips and all. -->
   <section class="dot-grid -mx-4 grid items-center gap-12 px-4 pb-16 pt-8 lg:grid-cols-[1.05fr_0.95fr]">
@@ -137,7 +131,7 @@
               </div>
               <p class="mt-0.5 truncate text-sm text-muted-foreground">{m.subject}</p>
               <span class="mt-2 inline-block">
-                {@render chip(m.signal, 'text-[10px] leading-4')}
+                <StatusChip signal={m.signal} class="text-[10px] leading-4" />
               </span>
             </div>
           </li>
@@ -203,7 +197,7 @@
         <!-- The chip column is fixed-width so the descriptions line up down the
              grid instead of stepping in and out with each label's length. -->
         <div class="flex items-baseline gap-3 bg-background p-5 sm:p-6">
-          <dt class="w-28 shrink-0">{@render chip(s.signal, 'py-0.5 text-xs')}</dt>
+          <dt class="w-28 shrink-0"><StatusChip signal={s.signal} /></dt>
           <dd class="text-sm leading-relaxed text-muted-foreground">{s.description}</dd>
         </div>
       {/each}
@@ -241,7 +235,7 @@
             <p class="truncate font-medium">Tech Lead, Web Core Product</p>
             <p class="truncate text-sm text-muted-foreground">Speechify</p>
           </div>
-          <span class="ml-auto">{@render chip('interview_invitation', 'py-0.5 text-xs')}</span>
+          <span class="ml-auto"><StatusChip signal="interview_invitation" /></span>
         </div>
 
         <div class="mt-5 flex items-center gap-2 border-b border-border pb-3 text-sm">
@@ -258,7 +252,7 @@
                 <p class="truncate text-sm">{m.from}</p>
                 <p class="truncate text-xs text-muted-foreground">{m.subject}</p>
               </div>
-              <span class="shrink-0">{@render chip(m.signal, 'text-[10px] leading-4')}</span>
+              <span class="shrink-0"><StatusChip signal={m.signal} class="text-[10px] leading-4" /></span>
             </li>
           {/each}
         </ul>

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -16,7 +16,6 @@
   import StatusChip from '$lib/components/StatusChip.svelte';
   import { inboxLinkState, type LastUnlinked } from '$lib/inboxLink';
   import { Paginator } from '$lib/paginated.svelte';
-  import { Badge } from '$lib/ui';
   import GmailConnectDialog from './GmailConnectDialog.svelte';
   import InboxSettings from './InboxSettings.svelte';
   import ApplicationLinkPicker from './ApplicationLinkPicker.svelte';

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -12,7 +12,8 @@
     EmailBody,
   } from '$lib/api';
   import type { EmailLinking } from '$lib/types';
-  import { statusLabel, statusClass, STATUS_LABELS } from '$lib/emailStatus';
+  import { statusLabel, STATUS_LABELS } from '$lib/emailStatus';
+  import StatusChip from '$lib/components/StatusChip.svelte';
   import { inboxLinkState, type LastUnlinked } from '$lib/inboxLink';
   import { Paginator } from '$lib/paginated.svelte';
   import { Badge } from '$lib/ui';
@@ -655,11 +656,7 @@
                       {/if}
                       {#if statusLabel(m.status_signal) || m.linked_slug}
                         <div class="mt-1 flex items-center gap-1">
-                          {#if statusLabel(m.status_signal)}
-                            <span class="inline-block rounded border px-1.5 text-[10px] leading-4 {statusClass(m.status_signal)}">
-                              {statusLabel(m.status_signal)}
-                            </span>
-                          {/if}
+                          <StatusChip signal={m.status_signal} class="text-[10px] leading-4" />
                           {#if m.linked_slug}
                             <span class="truncate text-[10px] text-muted-foreground/70">· {m.linked_company}</span>
                           {:else if m.suggested_slug}
@@ -735,9 +732,7 @@
 
               {@const linkState = inboxLinkState(s, lastUnlinked)}
               <div class="mt-3 flex shrink-0 flex-wrap items-center gap-2">
-                {#if statusLabel(s.status_signal)}
-                  <Badge variant="outline" class={statusClass(s.status_signal)}>{statusLabel(s.status_signal)}</Badge>
-                {/if}
+                <StatusChip signal={s.status_signal} />
                 {#if linkState === 'linked' && s.linked_slug}
                   <a
                     href={resolve('/my/tracking/[id]', { id: s.linked_slug })}

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -17,7 +17,8 @@
   import { api } from '$lib/api';
   import type { EmailBody } from '$lib/api';
   import { currentUser } from '$lib/auth.svelte';
-  import { statusLabel, statusClass, stageImplication } from '$lib/emailStatus';
+  import { statusLabel, stageImplication } from '$lib/emailStatus';
+  import StatusChip from '$lib/components/StatusChip.svelte';
   import { avatarInitials, avatarColor } from '$lib/avatar';
   import type { MyJob, ApplicationEmail, StageSuggestion } from '$lib/types';
   import { focusTrap } from '$lib/actions/focusTrap';
@@ -473,12 +474,14 @@
                       <!-- The chip, and what its signal means for the stage. The chip alone left
                            three different situations looking identical: the signal moved the
                            stage, it named one only the candidate may apply, or it was never
-                           about progress. Both sit in one wrapper carrying the size, so the
-                           explanation matches the chip without restating the class. -->
-                      <span class="mt-1 inline-flex flex-wrap items-baseline gap-1.5 text-[10px] leading-4">
-                        <span class="inline-block rounded border px-1.5 {statusClass(e.status_signal)}">
-                          {statusLabel(e.status_signal)}
-                        </span>
+                           about progress.
+                           Both run at the chip's own size (text-xs) rather than at a 10px the
+                           wrapper used to impose: StatusChip renders a Badge, which carries its
+                           size, so pinning the wrapper smaller would leave the explanation off
+                           the chip's baseline — and this thread has the room the dense inbox
+                           list does not. -->
+                      <span class="mt-1 inline-flex flex-wrap items-baseline gap-1.5 text-xs leading-4">
+                        <StatusChip signal={e.status_signal} />
                         {#if stageImplication(e.status_signal)}
                           <span class="text-muted-foreground">{stageImplication(e.status_signal)}</span>
                         {/if}

--- a/web/src/lib/components/JobRelated.svelte
+++ b/web/src/lib/components/JobRelated.svelte
@@ -3,6 +3,7 @@
   import type { JobCopy } from '$lib/api';
   import type { Job } from '$lib/types';
   import JobRow from './JobRow.svelte';
+  import TabRow, { tabId } from './TabRow.svelte';
 
   // The two "more like this" surfaces for a job, tabbed: semantically similar jobs and,
   // for a collapsed mass-posted role, the other cities it is open in. `copies` is a small
@@ -25,57 +26,61 @@
 
   const preview = $derived(copies.slice(0, 10));
 
-  const tabClass = (isActive: boolean) =>
-    `-mb-px border-b-2 px-1 pb-2 text-sm font-medium transition-colors ${
-      isActive
-        ? 'border-brand text-foreground'
-        : 'border-transparent text-muted-foreground hover:text-foreground'
-    }`;
+  // Only the tabs that have something behind them. The strip is not rendered at all when
+  // that leaves one — a single tab is a heading, not a choice.
+  const tabs = $derived(
+    [
+      ...(hasSimilar ? [{ id: 'similar' as const, label: 'Similar jobs' }] : []),
+      ...(hasCopies ? [{ id: 'copies' as const, label: `Other locations (${copiesTotal})` }] : []),
+    ],
+  );
+
+  const panelId = 'job-related-panel';
 </script>
 
 {#if hasSimilar || hasCopies}
   <section class="mt-10">
-    <div class="mb-4 flex gap-5 border-b border-border">
-      {#if hasSimilar}
-        <button type="button" class={tabClass(active === 'similar')} onclick={() => (selected = 'similar')}>
-          Similar jobs
-        </button>
-      {/if}
-      {#if hasCopies}
-        <button type="button" class={tabClass(active === 'copies')} onclick={() => (selected = 'copies')}>
-          Other locations ({copiesTotal})
-        </button>
+    {#if tabs.length > 1}
+      <TabRow
+        {tabs}
+        {active}
+        onSelect={(id) => (selected = id)}
+        label="More like this job"
+        {panelId}
+        class="mb-4"
+      />
+    {/if}
+
+    <div id={panelId} role="tabpanel" aria-labelledby={tabId(panelId, active)} tabindex="-1">
+      {#if active === 'similar' && hasSimilar}
+        <div class="flex flex-col gap-3">
+          {#each similar as job (job.public_slug)}
+            <JobRow {job} />
+          {/each}
+        </div>
+      {:else if active === 'copies' && hasCopies}
+        <ul class="divide-y divide-border overflow-hidden rounded-lg border border-border">
+          {#each preview as copy (copy.public_slug)}
+            <li>
+              <a
+                href={resolve('/jobs/[slug]', { slug: copy.public_slug })}
+                class="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-accent"
+              >
+                <span class="text-foreground">{copy.location || 'Location not specified'}</span>
+                <span class="text-xs text-muted-foreground">View →</span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+        {#if copiesTotal > preview.length}
+          <a
+            href={resolve('/jobs/[slug]/copies', { slug })}
+            class="mt-3 inline-block text-sm font-medium text-brand-strong hover:underline"
+          >
+            View all {copiesTotal} locations →
+          </a>
+        {/if}
       {/if}
     </div>
-
-    {#if active === 'similar' && hasSimilar}
-      <div class="flex flex-col gap-3">
-        {#each similar as job (job.public_slug)}
-          <JobRow {job} />
-        {/each}
-      </div>
-    {:else if active === 'copies' && hasCopies}
-      <ul class="divide-y divide-border overflow-hidden rounded-lg border border-border">
-        {#each preview as copy (copy.public_slug)}
-          <li>
-            <a
-              href={resolve('/jobs/[slug]', { slug: copy.public_slug })}
-              class="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-accent"
-            >
-              <span class="text-foreground">{copy.location || 'Location not specified'}</span>
-              <span class="text-xs text-muted-foreground">View →</span>
-            </a>
-          </li>
-        {/each}
-      </ul>
-      {#if copiesTotal > preview.length}
-        <a
-          href={resolve('/jobs/[slug]/copies', { slug })}
-          class="mt-3 inline-block text-sm font-medium text-brand-strong hover:underline"
-        >
-          View all {copiesTotal} locations →
-        </a>
-      {/if}
-    {/if}
   </section>
 {/if}

--- a/web/src/lib/components/ReferralsView.svelte
+++ b/web/src/lib/components/ReferralsView.svelte
@@ -5,6 +5,7 @@
   import { replaceState } from '$app/navigation';
   import { FileText } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
+  import { tablist } from '$lib/actions/tablist';
   import { AsyncData } from '$lib/asyncData.svelte';
   import type {
     IncomingReferralRequest,
@@ -137,7 +138,10 @@
 </script>
 
 <div class="flex items-center justify-between gap-4">
-  <div class="flex gap-1 border-b border-border" role="tablist">
+  <!-- use:tablist is what makes role="tablist" true. Without it the group announces
+       itself as one widget and then cannot be stepped through: every tab stays in the
+       Tab sequence and the arrow keys do nothing — the promise without the behaviour. -->
+  <div class="flex gap-1 border-b border-border" role="tablist" use:tablist={tab}>
     {#each [['requests', 'My requests'], ['offers', 'Offers to refer'], ['incoming', 'Incoming']] as [id, label] (id)}
       <button
         type="button"

--- a/web/src/lib/components/StatusChip.svelte
+++ b/web/src/lib/components/StatusChip.svelte
@@ -1,0 +1,27 @@
+<!--
+  The classified status of one email, as a chip. It is the ONE rendering of that datum:
+  the inbox list, the landing preview, the suggestion card and the drawer's mail thread
+  all reach it here rather than each spelling out `rounded border px-1.5` plus a call to
+  statusClass.
+
+  It also owns the rule that an unclassified signal — and `other`, and a signal from a
+  server ahead of this build — renders NOTHING. That rule lived in a `{#if statusLabel(…)}`
+  at every call site, which is three chances to forget it and show an empty bordered box.
+
+  `class` is passed through for the type size, because the callers genuinely differ: the
+  dense list rows set it themselves, while the drawer inherits it from a wrapper so the
+  "→ Interview" explanation beside the chip sits on the same baseline. Colour comes last so
+  the signal's own border/text win over the outline variant's defaults.
+-->
+<script lang="ts">
+  import { Badge } from '$lib/ui';
+  import { statusClass, statusLabel } from '$lib/emailStatus';
+
+  let { signal, class: className = '' }: { signal?: string; class?: string } = $props();
+
+  const label = $derived(statusLabel(signal));
+</script>
+
+{#if label}
+  <Badge variant="outline" class="{className} {statusClass(signal)}">{label}</Badge>
+{/if}

--- a/web/src/routes/my/activity/+layout.svelte
+++ b/web/src/routes/my/activity/+layout.svelte
@@ -2,8 +2,7 @@
   import type { Snippet } from 'svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { cn } from '$lib/ui';
-  import { tablist } from '$lib/actions/tablist';
+  import { routeTabClass, tablist } from '$lib/actions/tablist';
 
   let { children }: { children: Snippet } = $props();
 
@@ -28,13 +27,6 @@
           : 'activity-tab-saved',
   );
 
-  const tabClass = (active: boolean) =>
-    cn(
-      'rounded-md px-3 py-1.5 text-sm transition-colors',
-      active
-        ? 'bg-secondary font-medium text-secondary-foreground'
-        : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-    );
 </script>
 
 <svelte:head>
@@ -52,7 +44,7 @@
       aria-selected={savedActive}
       aria-controls="activity-tabpanel"
       href={resolve('/my/activity')}
-      class={tabClass(savedActive)}
+      class={routeTabClass(savedActive)}
     >
       Saved
     </a>
@@ -62,7 +54,7 @@
       aria-selected={historyActive}
       aria-controls="activity-tabpanel"
       href={resolve('/my/activity/history')}
-      class={tabClass(historyActive)}
+      class={routeTabClass(historyActive)}
     >
       History
     </a>
@@ -72,7 +64,7 @@
       aria-selected={matchesActive}
       aria-controls="activity-tabpanel"
       href={resolve('/my/activity/matches')}
-      class={tabClass(matchesActive)}
+      class={routeTabClass(matchesActive)}
     >
       Matches
     </a>
@@ -82,7 +74,7 @@
       aria-selected={hiddenActive}
       aria-controls="activity-tabpanel"
       href={resolve('/my/activity/hidden')}
-      class={tabClass(hiddenActive)}
+      class={routeTabClass(hiddenActive)}
     >
       Hidden
     </a>

--- a/web/src/routes/my/tracking/+layout.svelte
+++ b/web/src/routes/my/tracking/+layout.svelte
@@ -2,8 +2,7 @@
   import type { Snippet } from 'svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { cn } from '$lib/ui';
-  import { tablist } from '$lib/actions/tablist';
+  import { routeTabClass, tablist } from '$lib/actions/tablist';
 
   let { children }: { children: Snippet } = $props();
 
@@ -28,13 +27,6 @@
           : 'tracking-tab-board',
   );
 
-  const tabClass = (active: boolean) =>
-    cn(
-      'rounded-md px-3 py-1.5 text-sm transition-colors',
-      active
-        ? 'bg-secondary font-medium text-secondary-foreground'
-        : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-    );
 </script>
 
 <svelte:head>
@@ -52,7 +44,7 @@
       aria-selected={boardActive}
       aria-controls="tracking-tabpanel"
       href={resolve('/my/tracking')}
-      class={tabClass(boardActive)}
+      class={routeTabClass(boardActive)}
     >
       Board
     </a>
@@ -62,7 +54,7 @@
       aria-selected={listActive}
       aria-controls="tracking-tabpanel"
       href={resolve('/my/tracking/list')}
-      class={tabClass(listActive)}
+      class={routeTabClass(listActive)}
     >
       List
     </a>
@@ -72,7 +64,7 @@
       aria-selected={pipelineActive}
       aria-controls="tracking-tabpanel"
       href={resolve('/my/tracking/pipeline')}
-      class={tabClass(pipelineActive)}
+      class={routeTabClass(pipelineActive)}
     >
       Pipeline
     </a>
@@ -82,7 +74,7 @@
       aria-selected={calendarActive}
       aria-controls="tracking-tabpanel"
       href={resolve('/my/tracking/calendar')}
-      class={tabClass(calendarActive)}
+      class={routeTabClass(calendarActive)}
     >
       Calendar
     </a>


### PR DESCRIPTION
Findings **#39** (the email status chip) and the proportionate half of **#40** (the tab strips) from `docs/reviews/2026-08-01-architecture-review.md`.

---

## The status chip: five renderings → one

| where | was |
|---|---|
| `InboxView.svelte:659` | raw `inline-block rounded border px-1.5 text-[10px] leading-4` |
| `JobDrawer.svelte:479` | the same span, size inherited from a wrapper |
| `InboxLandingView.svelte:97` | a local `{#snippet chip}`, called **twice** |
| `InboxView.svelte:739` | `<Badge variant="outline">` |

The review counted three a month ago. The snippet is newer — so this was drifting apart, not together, and someone had already had the extraction instinct and stopped at the file boundary.

They collapse into **`StatusChip`**, wrapping the design system's `Badge`. Badge because the chip is a bordered outline rectangle carrying a signal colour, which is exactly what `variant="outline"` is. The DS also ships a `Chip` — but it is a filled `rounded-full` pill with no outline variant, so the name is a false friend.

`StatusChip` also owns the rule that an unclassified signal (and `other`, and a signal from a server ahead of this build) **renders nothing**. That lived in a `{#if statusLabel(…)}` at every call site: three chances to forget it and show an empty bordered box.

### Visual delta — verified, not assumed

The three dense chips gain 2px of radius, 2px of side padding, and `font-medium`. Checked before/after on `/features/inbox`, whose inbox mock is decorative data and therefore renders without a backend:

- **before** — tight rectangles, 4px radius
- **after** — marginally wider and rounder, text slightly heavier; row heights shift ~2px, nothing overflows, alignment holds

### One knock-on worth naming

The drawer's mail thread used to get its 10px from a **wrapper**, so the chip and the `→ Interview` explanation beside it shared a baseline. `Badge` carries its own size, so an inherited one no longer reaches it. Both now run at Badge's `text-xs`, which keeps them aligned **and** removes an arbitrary value: `JobDrawer` goes **8 → 7** on the token ratchet.

---

## The tab strips

The three fixes the review's own verifier judged proportionate — it explicitly rejected moving `TabRow` into the package or growing `Tabs` a variant matrix, and I agree: `tabs.svelte` welds the list to the panel in one wrapper, which the drawer's fixed-header layout and the routed `/my/*` anchors structurally cannot use.

1. **`JobRelated`** — its hand-rolled strip becomes `TabRow`, gaining the roving tabindex and arrow keys it never had (its buttons carried no `role` at all), plus the scroll-fade that stops a two-word label breaking mid-word on a phone. Panels are now a real `role="tabpanel"` pointing back at the active tab. The strip is hidden when only one tab has content — a single tab is a heading, not a choice.
2. **`ReferralsView`** — declared `role="tablist"` and `role="tab"` with **no keyboard behaviour at all**: the group announced itself to assistive tech as one widget and then could not be stepped through. `use:tablist` makes the promise true.
3. **`my/tracking` + `my/activity`** — the byte-identical `tabClass` becomes one exported `routeTabClass` beside the action.

---

## Verification

- `pnpm run check` — **0 errors**, 18 warnings (unchanged baseline, none in the touched files)
- `pnpm run build` — clean
- `pnpm check:tokens` / `pnpm check:adoption` — both green; baselines re-recorded as their own messages instruct (**Badge adoption 12 → 13**, **JobDrawer tokens 8 → 7**)
- Chip verified visually before/after on `/features/inbox`

**Not verified in a browser:** `JobRelated` and `ReferralsView` need live data (a job with similar postings; a signed-in referrals page), so those rest on `svelte-check` plus `TabRow`'s contract. The `JobRelated` delta against its old strip is `pb-2` → `pb-2.5` and, below `sm`, `gap-5` → `gap-4` — the treatment the profile page already uses, which is the point of converging on it.