### PR TITLE
perf(tracking): the board loads what it draws

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -87,7 +87,7 @@ func genStructs() (string, error) {
 			{
 				Path:         "github.com/strelov1/freehire/internal/jobview",
 				OutputPath:   jobviewTS,
-				IncludeFiles: []string{"jobview.go", "reality.go", "ghost.go"},
+				IncludeFiles: []string{"jobview.go", "card.go", "reality.go", "ghost.go"},
 				TypeMappings: map[string]string{"enrich.Enrichment": "Enrichment"},
 			},
 			{

--- a/docs/API.md
+++ b/docs/API.md
@@ -1117,7 +1117,11 @@ curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/dismiss" -H "Authorizatio
 
 Your tracked jobs joined with the job data.
 
-Each item carries the job in the shared wire shape with your interaction timestamps alongside it. `meta.counts` gives the per-filter totals for tab badges. Closed jobs stay listed so your history never shrinks.
+Each item carries a **card** of the job with your interaction timestamps alongside it. `meta.counts` gives the per-filter totals for tab badges. Closed jobs stay listed so your history never shrinks.
+
+The card is what a list row draws: `public_slug`, `title`, `company`, `closed_at`, the stated facets (`work_mode`, `seniority`, `employment_type`, `countries`, `regions`), `skills`, `collections`, `posted_at`, and `blurb` — a short summary already cut to length. It does **not** carry the posting's description; the full public job view, description included, is on `GET /me/tracking/:slug`.
+
+> **Changed:** this listing previously returned the complete job view on every row. Over 500 applications the descriptions alone were 2.37 MB of a 2.83 MB response, for text no row renders.
 
 **Query parameters**
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1554,18 +1554,36 @@ type Querier interface {
 	// Capped at 500 — the quota window (see CountRecentUserJobAnalyses) keeps real usage
 	// far below that, and each row drags a full analysis JSONB over the wire.
 	ListUserJobAnalyses(ctx context.Context, userID int64) ([]ListUserJobAnalysesRow, error)
-	// A user's job interactions joined with the job rows. Each subset is ordered by
-	// when the job entered *that* list, not by last touch: saved by saved_at, applied
-	// by applied_at, the passive history by viewed_at, the board by when it was saved
-	// or applied. This keeps a plain re-view from bumping a saved/applied job to the
-	// top (viewed_at is refreshed on every view). 'all' keeps the touched-recency
-	// timeline. filter narrows to viewed-only/saved/applied subsets; 'viewed' is the
-	// passive history (rows neither saved nor applied). Closed jobs stay listed: a
-	// user's history must not shrink when a posting closes. email_count is the
-	// caller's live (non-deleted) inbox messages linked to this job — the board's
-	// per-card ✉ badge; 0 for everyone without a connected mailbox. reminder_fire_at is
-	// the pending saved-job reminder's deadline (NULL when none), so the saved list can
-	// show "remind in N days" with its reschedule/off controls.
+	// A user's job interactions joined with a CARD of the job — what a list row draws, and no
+	// more. Each subset is ordered by when the job entered *that* list, not by last touch: saved
+	// by saved_at, applied by applied_at, the passive history by viewed_at, the board by when it
+	// was saved or applied. This keeps a plain re-view from bumping a saved/applied job to the
+	// top (viewed_at is refreshed on every view). 'all' keeps the touched-recency timeline.
+	// filter narrows to viewed-only/saved/applied subsets; 'viewed' is the passive history (rows
+	// neither saved nor applied). Closed jobs stay listed: a user's history must not shrink when
+	// a posting closes.
+	//
+	// The columns are named rather than embedded because of what embedding cost: sqlc.embed(jobs)
+	// read all 51, description included, and the board renders none of that text. Measured over
+	// 500 applications with 5 KB descriptions, it was 2.37 MB of a 2.83 MB response — serialized
+	// again into the SSR payload and parsed again by the browser — plus 13 ms of the query's 40,
+	// since a description is large enough to be TOASTed and fetched separately per row. The full
+	// posting is one read away at GET /me/tracking/:slug, which is what the drawer already calls.
+	//
+	// Only the geography arrives raw: the wire value is a dict-then-LLM hybrid, so both sides have
+	// to reach the projection. They are pulled out of the enrichment by key instead of shipping
+	// the whole JSONB.
+	// One pass over this job's mail for all three facts. They were three correlated subqueries
+	// over the same rows with the same predicate written three times; the "pending" test in
+	// particular has to stay the one the follow-up gate, the ghost signal and the inbox's link
+	// filter make, and three spellings of it were three chances to drift.
+	//
+	// has_pending_suggestion is mail the matcher believes belongs to this application that the
+	// caller has neither confirmed nor rejected. Such mail contradicts a claim that nobody
+	// replied, so the reader downgrades a silence verdict to a question rather than asserting it.
+	// "Pending" means the caller has not confirmed it, and confirming is what attaches the
+	// application — asking `job_id IS NULL` instead is the same set today only by the coincidence
+	// that every writer setting job_id also clears the suggestion.
 	ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error)
 	// Users whose stored structured résumé currently describes their stored CV, for the
 	// geography reconciler (cmd/backfill-resume-geo). Superseded structures are excluded:

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -239,24 +239,43 @@ SELECT u.user_id, u.job_id, u.viewed_at,
   FROM unsaved u;
 
 -- name: ListUserJobs :many
--- A user's job interactions joined with the job rows. Each subset is ordered by
--- when the job entered *that* list, not by last touch: saved by saved_at, applied
--- by applied_at, the passive history by viewed_at, the board by when it was saved
--- or applied. This keeps a plain re-view from bumping a saved/applied job to the
--- top (viewed_at is refreshed on every view). 'all' keeps the touched-recency
--- timeline. filter narrows to viewed-only/saved/applied subsets; 'viewed' is the
--- passive history (rows neither saved nor applied). Closed jobs stay listed: a
--- user's history must not shrink when a posting closes. email_count is the
--- caller's live (non-deleted) inbox messages linked to this job — the board's
--- per-card ✉ badge; 0 for everyone without a connected mailbox. reminder_fire_at is
--- the pending saved-job reminder's deadline (NULL when none), so the saved list can
--- show "remind in N days" with its reschedule/off controls.
-SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes,
-       (SELECT count(*)
-          FROM emails e
-         WHERE e.user_id = uj.user_id
-           AND e.job_id = jobs.id
-           AND e.deleted_at IS NULL) AS email_count,
+-- A user's job interactions joined with a CARD of the job — what a list row draws, and no
+-- more. Each subset is ordered by when the job entered *that* list, not by last touch: saved
+-- by saved_at, applied by applied_at, the passive history by viewed_at, the board by when it
+-- was saved or applied. This keeps a plain re-view from bumping a saved/applied job to the
+-- top (viewed_at is refreshed on every view). 'all' keeps the touched-recency timeline.
+-- filter narrows to viewed-only/saved/applied subsets; 'viewed' is the passive history (rows
+-- neither saved nor applied). Closed jobs stay listed: a user's history must not shrink when
+-- a posting closes.
+--
+-- The columns are named rather than embedded because of what embedding cost: sqlc.embed(jobs)
+-- read all 51, description included, and the board renders none of that text. Measured over
+-- 500 applications with 5 KB descriptions, it was 2.37 MB of a 2.83 MB response — serialized
+-- again into the SSR payload and parsed again by the browser — plus 13 ms of the query's 40,
+-- since a description is large enough to be TOASTed and fetched separately per row. The full
+-- posting is one read away at GET /me/tracking/:slug, which is what the drawer already calls.
+--
+-- Only the geography arrives raw: the wire value is a dict-then-LLM hybrid, so both sides have
+-- to reach the projection. They are pulled out of the enrichment by key instead of shipping
+-- the whole JSONB.
+SELECT jobs.id, jobs.public_slug, jobs.title, jobs.company_slug, jobs.closed_at,
+       jobs.work_mode, jobs.seniority, jobs.employment_type,
+       jobs.countries, jobs.regions, jobs.skills, jobs.collections,
+       jobs.posted_at, jobs.created_at,
+       -- The blurb a row shows under the title: the enrichment's own summary when there is
+       -- one, else the opening of the description with its tags stripped. Cut here rather
+       -- than shipped whole and cut in the browser — the descriptions were 2.37 MB of a
+       -- 2.83 MB response, and a row displays about 220 characters of one.
+       COALESCE(
+           NULLIF(jobs.enrichment ->> 'summary', ''),
+           left(regexp_replace(jobs.description, '<[^>]*>', ' ', 'g'), 400)
+       )::text AS blurb,
+       ARRAY(SELECT jsonb_array_elements_text(jobs.enrichment -> 'countries'))::text[] AS llm_countries,
+       ARRAY(SELECT jsonb_array_elements_text(jobs.enrichment -> 'regions'))::text[]   AS llm_regions,
+       uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes,
+       COALESCE(mail.email_count, 0)::bigint AS email_count,
+       (a.applied_at IS NOT NULL
+        AND COALESCE(mail.suggestion_pending, false))::boolean AS has_pending_suggestion,
        (SELECT r.fire_at
           FROM job_reminders r
          WHERE r.user_id = uj.user_id
@@ -264,52 +283,49 @@ SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.not
            AND r.status = 'pending') AS reminder_fire_at,
        a.followed_up_at,
        -- When a CV of the caller's tied to this job was last opened by a countable visitor. Read
-       -- from the denormalised stamp on cvs rather than from the click history, which would mean a
-       -- fifth correlated subquery here joining three tables.
+       -- from the denormalised stamp on cvs rather than from the click history, which would mean
+       -- joining three tables for one timestamp.
        --
-       -- Deliberately NOT an input to last_activity_at below, for the same reason followed_up_at is
-       -- not: somebody opening a CV is not a reply. Folding it in would clear the silence badge at
-       -- the moment it matters most — they read it and still said nothing.
+       -- Deliberately NOT an input to last_activity_at below, for the same reason followed_up_at
+       -- is not: somebody opening a CV is not a reply. Folding it in would clear the silence
+       -- badge at the moment it matters most — they read it and still said nothing.
        (SELECT max(cv.last_click_at)
           FROM cvs cv
          WHERE cv.user_id = uj.user_id
            AND cv.job_id = jobs.id)::timestamptz AS cv_opened_at,
-       -- last_activity_at is when this application last moved: its apply date, or
-       -- the newest message linked to it when that is later. GREATEST ignores a
-       -- NULL aggregate, so an application with no mail falls back to applied_at
-       -- rather than reporting nothing — a clock that only starts once mail
-       -- arrives would never fire on the applications ignored outright, which are
-       -- the ones worth reporting. NULL on a row that is not an application: a job
-       -- merely viewed or saved is not waiting on anyone.
-       (CASE WHEN a.applied_at IS NOT NULL THEN
-          GREATEST(a.applied_at,
-                   (SELECT max(e.received_at)
-                      FROM emails e
-                     WHERE e.user_id = uj.user_id
-                       AND e.job_id = jobs.id
-                       AND e.deleted_at IS NULL))
-        END)::timestamptz AS last_activity_at,
-       -- has_pending_suggestion is mail the matcher believes belongs to this
-       -- application that the caller has neither confirmed nor rejected. Such mail
-       -- contradicts a claim that nobody replied, so the reader downgrades a
-       -- silence verdict to a question rather than asserting it.
-       (a.applied_at IS NOT NULL AND EXISTS (
-          SELECT 1
-            FROM emails e
-           WHERE e.user_id = uj.user_id
-             AND e.suggested_job_id = jobs.id
-             -- "Pending" means the caller has not confirmed it, and confirming is what
-             -- attaches the application — the same test the follow-up gate, the ghost
-             -- signal and the inbox's link filter make, so the two cannot disagree about
-             -- one message. This used to ask `e.job_id IS NULL`, which is the same set
-             -- today only because every writer that sets job_id also either clears the
-             -- suggestion or attaches the application. Two spellings of one rule held
-             -- apart by that coincidence is not an invariant.
-             AND e.application_id IS NULL
-             AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
+       -- last_activity_at is when this application last moved: its apply date, or the newest
+       -- message linked to it when that is later. GREATEST ignores a NULL aggregate, so an
+       -- application with no mail falls back to applied_at rather than reporting nothing — a
+       -- clock that only starts once mail arrives would never fire on the applications ignored
+       -- outright, which are the ones worth reporting. NULL on a row that is not an
+       -- application: a job merely viewed or saved is not waiting on anyone.
+       (CASE WHEN a.applied_at IS NOT NULL
+             THEN GREATEST(a.applied_at, mail.newest_mail_at)
+        END)::timestamptz AS last_activity_at
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
+-- One pass over this job's mail for all three facts. They were three correlated subqueries
+-- over the same rows with the same predicate written three times; the "pending" test in
+-- particular has to stay the one the follow-up gate, the ghost signal and the inbox's link
+-- filter make, and three spellings of it were three chances to drift.
+--
+-- has_pending_suggestion is mail the matcher believes belongs to this application that the
+-- caller has neither confirmed nor rejected. Such mail contradicts a claim that nobody
+-- replied, so the reader downgrades a silence verdict to a question rather than asserting it.
+-- "Pending" means the caller has not confirmed it, and confirming is what attaches the
+-- application — asking `job_id IS NULL` instead is the same set today only by the coincidence
+-- that every writer setting job_id also clears the suggestion.
+LEFT JOIN LATERAL (
+    SELECT count(*) FILTER (WHERE e.job_id = jobs.id)                AS email_count,
+           max(e.received_at) FILTER (WHERE e.job_id = jobs.id)      AS newest_mail_at,
+           bool_or(e.suggested_job_id = jobs.id
+                   AND e.application_id IS NULL)                     AS suggestion_pending
+      FROM emails e
+     WHERE e.user_id = uj.user_id
+       AND (e.job_id = jobs.id OR e.suggested_job_id = jobs.id)
+       AND e.deleted_at IS NULL
+) mail ON true
 WHERE uj.user_id = $1
   AND (sqlc.arg(filter)::text = 'all'
        OR (sqlc.arg(filter)::text = 'viewed' AND uj.saved_at IS NULL AND a.applied_at IS NULL)

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -339,12 +339,24 @@ func (q *Queries) ListSavedJobSlugs(ctx context.Context, userID int64) ([]string
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, jobs.semantic_embedding, jobs.salary_min_manual, jobs.salary_max_manual, jobs.salary_currency_manual, jobs.salary_period_manual, jobs.upvote_count, jobs.downvote_count, jobs.ats_absent_at, uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes,
-       (SELECT count(*)
-          FROM emails e
-         WHERE e.user_id = uj.user_id
-           AND e.job_id = jobs.id
-           AND e.deleted_at IS NULL) AS email_count,
+SELECT jobs.id, jobs.public_slug, jobs.title, jobs.company_slug, jobs.closed_at,
+       jobs.work_mode, jobs.seniority, jobs.employment_type,
+       jobs.countries, jobs.regions, jobs.skills, jobs.collections,
+       jobs.posted_at, jobs.created_at,
+       -- The blurb a row shows under the title: the enrichment's own summary when there is
+       -- one, else the opening of the description with its tags stripped. Cut here rather
+       -- than shipped whole and cut in the browser — the descriptions were 2.37 MB of a
+       -- 2.83 MB response, and a row displays about 220 characters of one.
+       COALESCE(
+           NULLIF(jobs.enrichment ->> 'summary', ''),
+           left(regexp_replace(jobs.description, '<[^>]*>', ' ', 'g'), 400)
+       )::text AS blurb,
+       ARRAY(SELECT jsonb_array_elements_text(jobs.enrichment -> 'countries'))::text[] AS llm_countries,
+       ARRAY(SELECT jsonb_array_elements_text(jobs.enrichment -> 'regions'))::text[]   AS llm_regions,
+       uj.viewed_at, uj.saved_at, a.applied_at, a.stage, a.notes,
+       COALESCE(mail.email_count, 0)::bigint AS email_count,
+       (a.applied_at IS NOT NULL
+        AND COALESCE(mail.suggestion_pending, false))::boolean AS has_pending_suggestion,
        (SELECT r.fire_at
           FROM job_reminders r
          WHERE r.user_id = uj.user_id
@@ -352,52 +364,38 @@ SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.compan
            AND r.status = 'pending') AS reminder_fire_at,
        a.followed_up_at,
        -- When a CV of the caller's tied to this job was last opened by a countable visitor. Read
-       -- from the denormalised stamp on cvs rather than from the click history, which would mean a
-       -- fifth correlated subquery here joining three tables.
+       -- from the denormalised stamp on cvs rather than from the click history, which would mean
+       -- joining three tables for one timestamp.
        --
-       -- Deliberately NOT an input to last_activity_at below, for the same reason followed_up_at is
-       -- not: somebody opening a CV is not a reply. Folding it in would clear the silence badge at
-       -- the moment it matters most — they read it and still said nothing.
+       -- Deliberately NOT an input to last_activity_at below, for the same reason followed_up_at
+       -- is not: somebody opening a CV is not a reply. Folding it in would clear the silence
+       -- badge at the moment it matters most — they read it and still said nothing.
        (SELECT max(cv.last_click_at)
           FROM cvs cv
          WHERE cv.user_id = uj.user_id
            AND cv.job_id = jobs.id)::timestamptz AS cv_opened_at,
-       -- last_activity_at is when this application last moved: its apply date, or
-       -- the newest message linked to it when that is later. GREATEST ignores a
-       -- NULL aggregate, so an application with no mail falls back to applied_at
-       -- rather than reporting nothing — a clock that only starts once mail
-       -- arrives would never fire on the applications ignored outright, which are
-       -- the ones worth reporting. NULL on a row that is not an application: a job
-       -- merely viewed or saved is not waiting on anyone.
-       (CASE WHEN a.applied_at IS NOT NULL THEN
-          GREATEST(a.applied_at,
-                   (SELECT max(e.received_at)
-                      FROM emails e
-                     WHERE e.user_id = uj.user_id
-                       AND e.job_id = jobs.id
-                       AND e.deleted_at IS NULL))
-        END)::timestamptz AS last_activity_at,
-       -- has_pending_suggestion is mail the matcher believes belongs to this
-       -- application that the caller has neither confirmed nor rejected. Such mail
-       -- contradicts a claim that nobody replied, so the reader downgrades a
-       -- silence verdict to a question rather than asserting it.
-       (a.applied_at IS NOT NULL AND EXISTS (
-          SELECT 1
-            FROM emails e
-           WHERE e.user_id = uj.user_id
-             AND e.suggested_job_id = jobs.id
-             -- "Pending" means the caller has not confirmed it, and confirming is what
-             -- attaches the application — the same test the follow-up gate, the ghost
-             -- signal and the inbox's link filter make, so the two cannot disagree about
-             -- one message. This used to ask ` + "`" + `e.job_id IS NULL` + "`" + `, which is the same set
-             -- today only because every writer that sets job_id also either clears the
-             -- suggestion or attaches the application. Two spellings of one rule held
-             -- apart by that coincidence is not an invariant.
-             AND e.application_id IS NULL
-             AND e.deleted_at IS NULL))::boolean AS has_pending_suggestion
+       -- last_activity_at is when this application last moved: its apply date, or the newest
+       -- message linked to it when that is later. GREATEST ignores a NULL aggregate, so an
+       -- application with no mail falls back to applied_at rather than reporting nothing — a
+       -- clock that only starts once mail arrives would never fire on the applications ignored
+       -- outright, which are the ones worth reporting. NULL on a row that is not an
+       -- application: a job merely viewed or saved is not waiting on anyone.
+       (CASE WHEN a.applied_at IS NOT NULL
+             THEN GREATEST(a.applied_at, mail.newest_mail_at)
+        END)::timestamptz AS last_activity_at
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
+LEFT JOIN LATERAL (
+    SELECT count(*) FILTER (WHERE e.job_id = jobs.id)                AS email_count,
+           max(e.received_at) FILTER (WHERE e.job_id = jobs.id)      AS newest_mail_at,
+           bool_or(e.suggested_job_id = jobs.id
+                   AND e.application_id IS NULL)                     AS suggestion_pending
+      FROM emails e
+     WHERE e.user_id = uj.user_id
+       AND (e.job_id = jobs.id OR e.suggested_job_id = jobs.id)
+       AND e.deleted_at IS NULL
+) mail ON true
 WHERE uj.user_id = $1
   AND ($4::text = 'all'
        OR ($4::text = 'viewed' AND uj.saved_at IS NULL AND a.applied_at IS NULL)
@@ -425,32 +423,66 @@ type ListUserJobsParams struct {
 }
 
 type ListUserJobsRow struct {
-	Job                  Job                `json:"job"`
+	ID                   int64              `json:"id"`
+	PublicSlug           string             `json:"public_slug"`
+	Title                string             `json:"title"`
+	CompanySlug          string             `json:"company_slug"`
+	ClosedAt             pgtype.Timestamptz `json:"closed_at"`
+	WorkMode             string             `json:"work_mode"`
+	Seniority            string             `json:"seniority"`
+	EmploymentType       string             `json:"employment_type"`
+	Countries            []string           `json:"countries"`
+	Regions              []string           `json:"regions"`
+	Skills               []string           `json:"skills"`
+	Collections          []string           `json:"collections"`
+	PostedAt             pgtype.Timestamptz `json:"posted_at"`
+	CreatedAt            pgtype.Timestamptz `json:"created_at"`
+	Blurb                string             `json:"blurb"`
+	LlmCountries         []string           `json:"llm_countries"`
+	LlmRegions           []string           `json:"llm_regions"`
 	ViewedAt             pgtype.Timestamptz `json:"viewed_at"`
 	SavedAt              pgtype.Timestamptz `json:"saved_at"`
 	AppliedAt            pgtype.Timestamptz `json:"applied_at"`
 	Stage                pgtype.Text        `json:"stage"`
 	Notes                pgtype.Text        `json:"notes"`
 	EmailCount           int64              `json:"email_count"`
+	HasPendingSuggestion bool               `json:"has_pending_suggestion"`
 	ReminderFireAt       pgtype.Timestamptz `json:"reminder_fire_at"`
 	FollowedUpAt         pgtype.Timestamptz `json:"followed_up_at"`
 	CvOpenedAt           pgtype.Timestamptz `json:"cv_opened_at"`
 	LastActivityAt       pgtype.Timestamptz `json:"last_activity_at"`
-	HasPendingSuggestion bool               `json:"has_pending_suggestion"`
 }
 
-// A user's job interactions joined with the job rows. Each subset is ordered by
-// when the job entered *that* list, not by last touch: saved by saved_at, applied
-// by applied_at, the passive history by viewed_at, the board by when it was saved
-// or applied. This keeps a plain re-view from bumping a saved/applied job to the
-// top (viewed_at is refreshed on every view). 'all' keeps the touched-recency
-// timeline. filter narrows to viewed-only/saved/applied subsets; 'viewed' is the
-// passive history (rows neither saved nor applied). Closed jobs stay listed: a
-// user's history must not shrink when a posting closes. email_count is the
-// caller's live (non-deleted) inbox messages linked to this job — the board's
-// per-card ✉ badge; 0 for everyone without a connected mailbox. reminder_fire_at is
-// the pending saved-job reminder's deadline (NULL when none), so the saved list can
-// show "remind in N days" with its reschedule/off controls.
+// A user's job interactions joined with a CARD of the job — what a list row draws, and no
+// more. Each subset is ordered by when the job entered *that* list, not by last touch: saved
+// by saved_at, applied by applied_at, the passive history by viewed_at, the board by when it
+// was saved or applied. This keeps a plain re-view from bumping a saved/applied job to the
+// top (viewed_at is refreshed on every view). 'all' keeps the touched-recency timeline.
+// filter narrows to viewed-only/saved/applied subsets; 'viewed' is the passive history (rows
+// neither saved nor applied). Closed jobs stay listed: a user's history must not shrink when
+// a posting closes.
+//
+// The columns are named rather than embedded because of what embedding cost: sqlc.embed(jobs)
+// read all 51, description included, and the board renders none of that text. Measured over
+// 500 applications with 5 KB descriptions, it was 2.37 MB of a 2.83 MB response — serialized
+// again into the SSR payload and parsed again by the browser — plus 13 ms of the query's 40,
+// since a description is large enough to be TOASTed and fetched separately per row. The full
+// posting is one read away at GET /me/tracking/:slug, which is what the drawer already calls.
+//
+// Only the geography arrives raw: the wire value is a dict-then-LLM hybrid, so both sides have
+// to reach the projection. They are pulled out of the enrichment by key instead of shipping
+// the whole JSONB.
+// One pass over this job's mail for all three facts. They were three correlated subqueries
+// over the same rows with the same predicate written three times; the "pending" test in
+// particular has to stay the one the follow-up gate, the ghost signal and the inbox's link
+// filter make, and three spellings of it were three chances to drift.
+//
+// has_pending_suggestion is mail the matcher believes belongs to this application that the
+// caller has neither confirmed nor rejected. Such mail contradicts a claim that nobody
+// replied, so the reader downgrades a silence verdict to a question rather than asserting it.
+// "Pending" means the caller has not confirmed it, and confirming is what attaches the
+// application — asking `job_id IS NULL` instead is the same set today only by the coincidence
+// that every writer setting job_id also clears the suggestion.
 func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error) {
 	rows, err := q.db.Query(ctx, listUserJobs,
 		arg.UserID,
@@ -466,68 +498,34 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 	for rows.Next() {
 		var i ListUserJobsRow
 		if err := rows.Scan(
-			&i.Job.ID,
-			&i.Job.Source,
-			&i.Job.ExternalID,
-			&i.Job.URL,
-			&i.Job.Title,
-			&i.Job.Company,
-			&i.Job.Location,
-			&i.Job.Remote,
-			&i.Job.Description,
-			&i.Job.PostedAt,
-			&i.Job.CreatedAt,
-			&i.Job.UpdatedAt,
-			&i.Job.CompanySlug,
-			&i.Job.Enrichment,
-			&i.Job.EnrichedAt,
-			&i.Job.EnrichmentVersion,
-			&i.Job.PublicSlug,
-			&i.Job.LastSeenAt,
-			&i.Job.ClosedAt,
-			&i.Job.Countries,
-			&i.Job.Regions,
-			&i.Job.WorkMode,
-			&i.Job.LivenessStrikes,
-			&i.Job.Skills,
-			&i.Job.Seniority,
-			&i.Job.Category,
-			&i.Job.CreatedBy,
-			&i.Job.UpdatedBy,
-			&i.Job.PostingLanguage,
-			&i.Job.EmploymentType,
-			&i.Job.EducationLevel,
-			&i.Job.ExperienceYearsMin,
-			&i.Job.Collections,
-			&i.Job.ContentHash,
-			&i.Job.EnglishLevel,
-			&i.Job.Cities,
-			&i.Job.ViewCount,
-			&i.Job.AppliedCount,
-			&i.Job.RoleFingerprint,
-			&i.Job.SemanticEmbeddedModel,
-			&i.Job.SemanticEmbeddedHash,
-			&i.Job.DuplicateOf,
-			&i.Job.IsTech,
-			&i.Job.SemanticEmbedding,
-			&i.Job.SalaryMinManual,
-			&i.Job.SalaryMaxManual,
-			&i.Job.SalaryCurrencyManual,
-			&i.Job.SalaryPeriodManual,
-			&i.Job.UpvoteCount,
-			&i.Job.DownvoteCount,
-			&i.Job.AtsAbsentAt,
+			&i.ID,
+			&i.PublicSlug,
+			&i.Title,
+			&i.CompanySlug,
+			&i.ClosedAt,
+			&i.WorkMode,
+			&i.Seniority,
+			&i.EmploymentType,
+			&i.Countries,
+			&i.Regions,
+			&i.Skills,
+			&i.Collections,
+			&i.PostedAt,
+			&i.CreatedAt,
+			&i.Blurb,
+			&i.LlmCountries,
+			&i.LlmRegions,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,
 			&i.Stage,
 			&i.Notes,
 			&i.EmailCount,
+			&i.HasPendingSuggestion,
 			&i.ReminderFireAt,
 			&i.FollowedUpAt,
 			&i.CvOpenedAt,
 			&i.LastActivityAt,
-			&i.HasPendingSuggestion,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/user_jobs_integration_test.go
+++ b/internal/db/user_jobs_integration_test.go
@@ -245,7 +245,7 @@ func TestUserJobsSaveAndList(t *testing.T) {
 		if len(all) != 3 {
 			t.Fatalf("list all: %d rows, want 3", len(all))
 		}
-		gotOrder := []int64{all[0].Job.ID, all[1].Job.ID, all[2].Job.ID}
+		gotOrder := []int64{all[0].ID, all[1].ID, all[2].ID}
 		wantOrder := []int64{appliedJob, savedJob, viewedJob}
 		for i := range wantOrder {
 			if gotOrder[i] != wantOrder[i] {
@@ -257,7 +257,7 @@ func TestUserJobsSaveAndList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("list viewed: %v", err)
 		}
-		if len(viewed) != 1 || viewed[0].Job.ID != viewedJob {
+		if len(viewed) != 1 || viewed[0].ID != viewedJob {
 			t.Fatalf("list viewed: got %d rows, want exactly the view-only job (not saved, not applied)", len(viewed))
 		}
 
@@ -265,7 +265,7 @@ func TestUserJobsSaveAndList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("list saved: %v", err)
 		}
-		if len(saved) != 1 || saved[0].Job.ID != savedJob {
+		if len(saved) != 1 || saved[0].ID != savedJob {
 			t.Fatalf("list saved: got %d rows, want exactly the saved job", len(saved))
 		}
 
@@ -273,7 +273,7 @@ func TestUserJobsSaveAndList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("list applied: %v", err)
 		}
-		if len(applied) != 1 || applied[0].Job.ID != appliedJob {
+		if len(applied) != 1 || applied[0].ID != appliedJob {
 			t.Fatalf("list applied: got %d rows, want exactly the applied job", len(applied))
 		}
 
@@ -316,7 +316,7 @@ func TestUserJobsSaveAndList(t *testing.T) {
 			}
 			got := []int64{}
 			for _, r := range saved {
-				got = append(got, r.Job.ID)
+				got = append(got, r.ID)
 			}
 			want := []int64{newer, older}
 			if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -21,14 +21,14 @@ type myJobResponse struct {
 	RoleTitle string `json:"role_title"`
 	// Job is null once the catalogue has removed the posting. The application is a fact
 	// about the candidate's life and outlives our inventory of it.
-	Job            *jobview.Job `json:"job"`
-	ViewedAt       *time.Time   `json:"viewed_at"`
-	SavedAt        *time.Time   `json:"saved_at"`
-	AppliedAt      *time.Time   `json:"applied_at"`
-	Stage          *string      `json:"stage"`
-	Notes          *string      `json:"notes"`
-	EmailCount     int          `json:"email_count"`
-	ReminderFireAt *time.Time   `json:"reminder_fire_at"`
+	Job            *jobview.Card `json:"job"`
+	ViewedAt       *time.Time    `json:"viewed_at"`
+	SavedAt        *time.Time    `json:"saved_at"`
+	AppliedAt      *time.Time    `json:"applied_at"`
+	Stage          *string       `json:"stage"`
+	Notes          *string       `json:"notes"`
+	EmailCount     int           `json:"email_count"`
+	ReminderFireAt *time.Time    `json:"reminder_fire_at"`
 	// The silence fields are null together on any row that is not an application
 	// awaiting a reply — a job merely viewed or saved, or one in a settled stage.
 	// Null means "nothing is owed here", which the board must be able to tell

--- a/internal/handler/me_tracking_load_measure_test.go
+++ b/internal/handler/me_tracking_load_measure_test.go
@@ -1,0 +1,218 @@
+//go:build integration
+
+// A measurement, not an assertion. It exists to answer one question with a number before
+// anything is optimised: when the tracking board server-loads 500 rows, what is the cost made
+// of — the query, or the bytes?
+//
+// go test -tags=integration -run TestMeasureBoardLoad -v ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobtracking"
+)
+
+// A job description of a size the catalogue actually carries. Real postings run 3–8 KB of
+// prose; 5 KB is the middle of that and keeps the arithmetic honest either way.
+const measuredDescriptionBytes = 5000
+
+func TestMeasureBoardLoad(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('board-load@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	const rows = 500
+	description := strings.Repeat("Responsibilities and requirements. ", measuredDescriptionBytes/35)
+	for i := range rows {
+		var jobID int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, company_slug, public_slug, description)
+			 VALUES ('test', $1, 'http://example.test', 'Senior Go Engineer', 'acme', $2, $3)
+			 RETURNING id`,
+			fmt.Sprintf("load-%d", i), fmt.Sprintf("load-%d", i), description).Scan(&jobID); err != nil {
+			t.Fatalf("seed job %d: %v", i, err)
+		}
+		if _, err := queries.MarkJobApplied(ctx, db.MarkJobAppliedParams{UserID: userID, JobID: jobID}); err != nil {
+			t.Fatalf("apply %d: %v", i, err)
+		}
+		// Every third application has linked mail — the three correlated subqueries over
+		// `emails` are the ones under suspicion, and they must have rows to find.
+		if i%3 == 0 {
+			if _, err := pool.Exec(ctx,
+				`INSERT INTO emails (user_id, source, external_id, from_addr, from_name, subject, body_text, received_at, job_id)
+				 VALUES ($1, 'gmail', $2, 'noreply@ashbyhq.com', 'Ashby', 'Thanks for applying', 'body', now(), $3)`,
+				userID, fmt.Sprintf("msg-%d", i), jobID); err != nil {
+				t.Fatalf("seed email %d: %v", i, err)
+			}
+		}
+	}
+
+	// A real mailbox is not 167 messages about applications; it is a synced inbox where those
+	// are a minority. Without this the LATERAL has almost nothing to scan and an index over it
+	// cannot show its worth — the measurement would say "indexes do nothing" because the
+	// fixture was too small to need one.
+	for i := range 5000 {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO emails (user_id, source, external_id, from_addr, from_name, subject, body_text, received_at)
+			 VALUES ($1, 'gmail', $2, 'someone@example.test', 'Someone', 'Unrelated', 'body', now())`,
+			userID, fmt.Sprintf("noise-%d", i)); err != nil {
+			t.Fatalf("seed noise email %d: %v", i, err)
+		}
+	}
+
+	// Bulk inserts leave the planner on statistics from an empty table, which costs two orders
+	// of magnitude here and has nothing to do with the code under measurement — on production
+	// autovacuum has long since done this. Without it the fixture measures its own seeding.
+	if _, err := pool.Exec(ctx, `ANALYZE emails, cvs, user_jobs, applications, jobs`); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(userID, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &trackingHandlers{tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries, pool))}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/tracking", auth.RequireAuth(iss, testVersions), h.ListTrackedJobs)
+
+	// Warm the pool and the plan cache so the reported number is steady state, not first-call
+	// cost — the board is opened repeatedly by a signed-in user, never once.
+	for range 3 {
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/tracking?filter=board&limit=500", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req, 60_000)
+		if err != nil {
+			t.Fatalf("warmup: %v", err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	var best time.Duration
+	var body []byte
+	for i := range 5 {
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/tracking?filter=board&limit=500", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		start := time.Now()
+		resp, err := app.Test(req, 60_000)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		elapsed := time.Since(start)
+		if i == 0 || elapsed < best {
+			best, body = elapsed, b
+		}
+	}
+
+	// How much of the payload is description text nobody on the board renders?
+	var parsed struct {
+		Data []struct {
+			Job *struct {
+				Description string `json:"description"`
+			} `json:"job"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var descriptionBytes int
+	for _, item := range parsed.Data {
+		if item.Job != nil {
+			descriptionBytes += len(item.Job.Description)
+		}
+	}
+
+	// The query alone, without serialization, so the two costs can be told apart.
+	var queryBest time.Duration
+	for i := range 5 {
+		start := time.Now()
+		if _, err := queries.ListUserJobs(ctx, db.ListUserJobsParams{
+			UserID: userID, Filter: "board", Limit: 500, Offset: 0,
+		}); err != nil {
+			t.Fatalf("ListUserJobs: %v", err)
+		}
+		if elapsed := time.Since(start); i == 0 || elapsed < queryBest {
+			queryBest = elapsed
+		}
+	}
+
+	// The same shape of scan with and without the description column, to tell the cost of
+	// READING it from the cost of SENDING it. `description` is large enough to be TOASTed, so
+	// not selecting it should skip a separate fetch per row — but "should" is why we measure.
+	measureScan := func(t *testing.T, label, columns string) time.Duration {
+		t.Helper()
+		query := `SELECT ` + columns + `
+			  FROM user_jobs uj
+			  JOIN jobs ON jobs.id = uj.job_id
+			  LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
+			 WHERE uj.user_id = $1 LIMIT 500`
+		var best time.Duration
+		for i := range 5 {
+			start := time.Now()
+			rows, err := pool.Query(ctx, query, userID)
+			if err != nil {
+				t.Fatalf("%s: %v", label, err)
+			}
+			for rows.Next() {
+			}
+			rows.Close()
+			if err := rows.Err(); err != nil {
+				t.Fatalf("%s rows: %v", label, err)
+			}
+			if elapsed := time.Since(start); i == 0 || elapsed < best {
+				best = elapsed
+			}
+		}
+		return best
+	}
+	withDescription := measureScan(t, "with description", "jobs.id, jobs.title, jobs.company_slug, jobs.enrichment, jobs.description")
+	withoutDescription := measureScan(t, "without description", "jobs.id, jobs.title, jobs.company_slug, jobs.enrichment")
+
+	// The guard. The board renders no posting text, so carrying it is pure freight: at 5 KB a
+	// description and 500 rows it was 2.37 MB of a 2.83 MB response, serialized again into the
+	// SSR payload and parsed again by the browser.
+	if descriptionBytes != 0 {
+		t.Errorf("the listing carries %d bytes of description; the board renders none of it, and "+
+			"the full posting is one read away at GET /me/tracking/:slug", descriptionBytes)
+	}
+
+	// A ceiling rather than an exact size: the card may gain a field, and this should fail when
+	// something large comes back, not when something small is added. 500 rows of card at the
+	// measured ~900 bytes each leaves generous room under 1 MB.
+	const payloadCeiling = 1 << 20
+	if len(body) > payloadCeiling {
+		t.Errorf("payload = %.2f MB for %d rows, want under %.2f MB",
+			float64(len(body))/1024/1024, len(parsed.Data), float64(payloadCeiling)/1024/1024)
+	}
+
+	t.Logf("rows=%d", len(parsed.Data))
+	t.Logf("scan WITH description:    %v", withDescription)
+	t.Logf("scan WITHOUT description: %v", withoutDescription)
+	t.Logf("query (best of 5):     %v", queryBest)
+	t.Logf("endpoint (best of 5):  %v", best)
+	t.Logf("payload:               %.2f MB", float64(len(body))/1024/1024)
+	t.Logf("of which descriptions: %.2f MB (%.0f%%)",
+		float64(descriptionBytes)/1024/1024, float64(descriptionBytes)*100/float64(len(body)))
+}

--- a/internal/handler/me_tracking_silence_test.go
+++ b/internal/handler/me_tracking_silence_test.go
@@ -73,7 +73,7 @@ func listSilence(t *testing.T, items []jobtracking.TrackedJob) []trackingRow {
 
 func row(stage string, appliedAgo, activityAgo time.Duration, pending bool) jobtracking.TrackedJob {
 	j := jobtracking.TrackedJob{
-		Job:                  &jobview.Job{PublicSlug: "a-job"},
+		Job:                  &jobview.Card{PublicSlug: "a-job"},
 		HasPendingSuggestion: pending,
 	}
 	if appliedAgo > 0 {

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -96,7 +96,7 @@ type TrackedJob struct {
 	CompanySlug string
 	RoleTitle   string
 	// Job is absent when the catalogue no longer holds the posting.
-	Job *jobview.Job
+	Job *jobview.Card
 	Interaction
 	// EmailCount is the caller's live inbox messages linked to this job — the
 	// board's per-card ✉ badge. 0 for users without a connected mailbox.

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -265,17 +265,31 @@ func (r *QueriesRepository) ListInteractions(
 	}
 	items := make([]TrackedJob, 0, len(rows))
 	for _, row := range rows {
-		view, err := jobview.FromRow(row.Job)
-		if err != nil {
-			return nil, err
-		}
+		card := jobview.NewCard(jobview.CardInput{
+			PublicSlug:     row.PublicSlug,
+			Title:          row.Title,
+			Company:        row.CompanySlug,
+			ClosedAt:       pgconv.TimePtr(row.ClosedAt),
+			WorkMode:       row.WorkMode,
+			Seniority:      row.Seniority,
+			EmploymentType: row.EmploymentType,
+			DictCountries:  row.Countries,
+			DictRegions:    row.Regions,
+			LLMCountries:   row.LlmCountries,
+			LLMRegions:     row.LlmRegions,
+			Skills:         row.Skills,
+			Collections:    row.Collections,
+			PostedAt:       pgconv.TimePtr(row.PostedAt),
+			CreatedAt:      pgconv.TimePtr(row.CreatedAt),
+			Blurb:          row.Blurb,
+		})
 		items = append(items, TrackedJob{
-			ID:          view.PublicSlug,
-			CompanySlug: row.Job.CompanySlug,
-			RoleTitle:   row.Job.Title,
-			Job:         &view,
+			ID:          row.PublicSlug,
+			CompanySlug: row.CompanySlug,
+			RoleTitle:   row.Title,
+			Job:         &card,
 			Interaction: Interaction{
-				JobID:     row.Job.ID,
+				JobID:     row.ID,
 				ViewedAt:  pgconv.TimePtr(row.ViewedAt),
 				SavedAt:   pgconv.TimePtr(row.SavedAt),
 				AppliedAt: pgconv.TimePtr(row.AppliedAt),

--- a/internal/jobview/card.go
+++ b/internal/jobview/card.go
@@ -1,0 +1,37 @@
+package jobview
+
+// Card is the list-row projection of a job: what a card draws, and nothing else.
+//
+// It lives beside Job rather than in the package that lists, because both answer the same
+// question — what of a posting is public — and answering it in two places is how the wire
+// shapes drift. Card is a strict subset of Job's fields, with the same names and the same
+// derivations, so a row and a detail page cannot disagree about a job's work mode or where it
+// is open.
+//
+// The difference is what is absent. Card has no description, and the tracking listing's query
+// does not read one: over 500 applications the descriptions were 2.37 MB of a 2.83 MB response
+// and 13 ms of a 40 ms query, for text no list row renders. A caller that wants the posting
+// reads the one application it opened.
+type Card struct {
+	PublicSlug string  `json:"public_slug"`
+	Title      string  `json:"title"`
+	Company    string  `json:"company"`
+	ClosedAt   *string `json:"closed_at"`
+	// The stated facets of the tag row. Empty means unstated, and the row simply omits it —
+	// the same rule the full projection follows.
+	WorkMode       string   `json:"work_mode,omitempty"`
+	Seniority      string   `json:"seniority,omitempty"`
+	EmploymentType string   `json:"employment_type,omitempty"`
+	Countries      []string `json:"countries,omitempty"`
+	Regions        []string `json:"regions,omitempty"`
+	Skills         []string `json:"skills,omitempty"`
+	Collections    []string `json:"collections,omitempty"`
+	// PostedAt is the effective posting date, the same derivation the full projection makes:
+	// the stated date, or the row's creation when the source never gave one.
+	PostedAt *string `json:"posted_at,omitempty"`
+	// Blurb is the line a row shows under the title — the enrichment's summary, or the
+	// opening of the description with its tags stripped. Cut server-side: a row displays
+	// about 220 characters, and shipping the whole posting to reach them was 84% of this
+	// listing's payload.
+	Blurb string `json:"blurb,omitempty"`
+}

--- a/internal/jobview/card_input.go
+++ b/internal/jobview/card_input.go
@@ -1,0 +1,53 @@
+package jobview
+
+import (
+	"strings"
+	"time"
+)
+
+// This file is deliberately NOT in cmd/gen-contracts' tygo include list, unlike card.go: it is
+// how a Card is built, not what a Card is. Emitted, its time.Time fields reach the SPA as `any`
+// and fail the lint gate — a fair complaint about a type the browser has no business seeing.
+
+// CardInput is the row a Card is projected from. Geography arrives from both sides because the
+// wire value is a hybrid: the dictionary's reading wins where it resolved a concrete place, and
+// the model's stands in only where it did not.
+type CardInput struct {
+	PublicSlug     string
+	Title          string
+	Company        string
+	ClosedAt       *time.Time
+	WorkMode       string
+	Seniority      string
+	EmploymentType string
+	DictCountries  []string
+	DictRegions    []string
+	LLMCountries   []string
+	LLMRegions     []string
+	Skills         []string
+	Collections    []string
+	PostedAt       *time.Time
+	CreatedAt      *time.Time
+	Blurb          string
+}
+
+// NewCard projects a listing row into the card wire shape, applying the same geography rule the
+// full projection applies.
+func NewCard(in CardInput) Card {
+	countries, regions := geoFacet(in.DictCountries, in.DictRegions, in.LLMCountries, in.LLMRegions)
+	return Card{
+		PublicSlug:     in.PublicSlug,
+		Title:          in.Title,
+		Company:        in.Company,
+		ClosedAt:       rfc3339Ptr(in.ClosedAt),
+		WorkMode:       in.WorkMode,
+		Seniority:      in.Seniority,
+		EmploymentType: in.EmploymentType,
+		Countries:      countries,
+		Regions:        regions,
+		Skills:         normalizeSet(in.Skills),
+		Collections:    in.Collections,
+		PostedAt:       rfc3339Ptr(effectivePosted(in.PostedAt, in.CreatedAt, time.Now())),
+		Blurb:          strings.TrimSpace(in.Blurb),
+	}
+}

--- a/internal/userjob/AGENTS.md
+++ b/internal/userjob/AGENTS.md
@@ -43,5 +43,9 @@ A chased application therefore has **two readings at once**, and the board card 
 
 The `/me/tracking` read joins the caller's interactions with the jobs they touch. View history = all rows; applications = `applied_at IS NOT NULL`.
 
+**The listing serves a CARD, not the posting** (`jobview.Card`). It carries what a row draws — employer, role, the stated facets, skills, collections, the effective posting date, and a `blurb` cut server-side — and the query reads only those columns. Embedding the whole `jobs` row cost 2.37 MB of a 2.83 MB response over 500 applications, for description text no row renders, plus the TOAST fetch per row that reading it implies. The full public job view stays on `GET /me/tracking/:slug`, which the application panel already calls for its linked mail, so the description arrives on a request that was happening anyway. `TestMeasureBoardLoad` holds the line: it fails if a description reappears in the listing or the payload crosses its ceiling.
+
+Two read-time signals are absent from the card by the same reasoning that they were absent before it: `Reality` and `Ghost` are attached by explicit calls the tracking path has never made, so the rows that render cards showed no such badge either way.
+
 ## Limitations
 - No bulk operations (e.g. "mark all viewed"); each interaction is an individual per-(user, job) upsert.

--- a/openspec/changes/tracker-board-loads-what-it-shows/.openspec.yaml
+++ b/openspec/changes/tracker-board-loads-what-it-shows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/tracker-board-loads-what-it-shows/proposal.md
+++ b/openspec/changes/tracker-board-loads-what-it-shows/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+Opening `/my/tracking` server-loads 500 rows in one call, and each row carries the full text of
+its job posting — which the board renders nowhere. Measured against a seeded 500-application
+board with 5 KB descriptions (`TestMeasureBoardLoad`):
+
+```
+payload:               2.83 MB
+of which descriptions: 2.37 MB  (84%)
+scan WITH description:    18.8 ms
+scan WITHOUT description:  6.0 ms
+full query (5 correlated subqueries): 39.7 ms
+endpoint:                             52.6 ms
+```
+
+So the description costs 84% of the bytes and roughly 13 ms of the 40. Those bytes do not merely
+travel: the tracking routes server-load the board, so they are serialized into the SSR payload,
+embedded in the HTML document, and parsed again by the browser.
+
+The board needs an employer, a role, and a handful of facets for its tag row. It is asking for
+the whole posting.
+
+## What Changes
+
+- **BREAKING**: `GET /me/tracking` returns a **card** projection of the job — `public_slug`,
+  `title`, `company`, `closed_at`, and the flat facets the tag row reads (`work_mode`,
+  `seniority`, `employment_type`, `countries`, `regions`) — instead of the full `jobview.Job`.
+  The full posting stays available, unchanged, at `GET /me/tracking/:slug`, which the drawer
+  already fetches for its linked mail.
+- A dedicated listing query reads only those columns. `sqlc.embed(jobs)` is what pulled all 51,
+  and dropping the description from the scan is what removes the 13 ms — obliterating it in Go
+  would save the bytes and none of the read.
+- The three correlated subqueries over `emails` (count, newest received, pending suggestion)
+  collapse into one `LATERAL` — one pass over the same rows, and one spelling of a predicate
+  currently written three times.
+- **No indexes.** They were in this proposal until they were measured. Against a fixture with a
+  realistic mailbox — 5 000 messages of which 167 are linked — the listing ran 2.62 ms with them
+  and 2.79 ms without: noise. What did move the number by two orders of magnitude was `ANALYZE`
+  after the bulk insert (216 ms → 2.7 ms), which is a fixture artefact; production statistics
+  are maintained by autovacuum. Adding an index that pays for itself on every write, to buy
+  nothing measurable on the read, is the infrastructure-before-need this repo warns against.
+- The drawer reads the description and the full facet row from the detail response it already
+  loads, rather than from the listing.
+
+Deliberately NOT done: no materialized view, no denormalized card table. Both add a second
+source of truth and a synchronization path to keep honest, and the measurement says the cost is
+bytes we choose to send, not work the database cannot avoid.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `user-job-tracking`: the listing returns a card projection of the job rather than the full
+  public job view; the full view remains on the single-application read.
+
+## Impact
+
+- **Go**: `internal/db/queries/user_jobs.sql` (card query + LATERAL), `internal/handler/me_tracking.go`,
+  a card wire type, `internal/jobtracking`.
+- **SQL**: none. No migration, no column or table changes — the listing query is rewritten in
+  place and the indexes were measured and dropped from scope.
+- **Frontend**: `web/src/lib/types.ts`, `board.ts`, `JobDrawer.svelte` (description and tags from
+  the detail response), `BoardCard.svelte`, `BoardList.svelte`.
+- **Docs**: `docs/API.md`, `web/src/lib/docs/api-spec.ts`, `internal/userjob/AGENTS.md`.
+- **Tests**: `TestMeasureBoardLoad` becomes a regression guard — the listing must not carry a
+  description, and the payload must stay under a stated ceiling.
+
+## Result
+
+Measured the same way, after the change:
+
+```
+payload:  2.83 MB → 0.23 MB   (-92%)
+scan with description 6.5 ms → without 0.8 ms
+query:    2.79 ms      endpoint: 4.61 ms
+```

--- a/openspec/changes/tracker-board-loads-what-it-shows/specs/user-job-tracking/spec.md
+++ b/openspec/changes/tracker-board-loads-what-it-shows/specs/user-job-tracking/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Listing a user's job interactions
+
+The system SHALL expose `GET /api/v1/me/tracking` (auth required) returning the
+authenticated user's interactions joined with a **card projection** of the job,
+ordered by most recent interaction activity first, with limit/offset
+pagination. A `filter` query parameter SHALL narrow the list: `all` (default —
+every interaction), `viewed` (view-only rows: neither saved nor applied),
+`saved` (`saved_at` set), `applied` (`applied_at` set). The list `meta` SHALL
+carry `total/limit/offset` for the active filter plus `counts` with the row
+counts of all four filters. Closed jobs SHALL remain in
+the listing (their card carries `closed_at`). An unknown `filter` value
+SHALL be a `400`.
+
+The card SHALL carry what a list row draws and no more: `public_slug`, `title`, `company`,
+`closed_at`, and the stated facets of its tag row (`work_mode`, `seniority`, `employment_type`,
+`countries`, `regions`). It SHALL NOT carry the posting's description. The full public job view
+remains available at `GET /api/v1/me/tracking/:slug`, which is the read a caller makes for one
+application it has opened.
+
+The listing query SHALL read only the card's columns from `jobs`. Reading the description and
+discarding it later would keep the database cost while saving only the transfer.
+
+Each row that represents an application SHALL additionally carry its
+`last_activity_at`, its `days_silent`, and its `silence_state`. A row that is not
+an application — no `applied_at` — carries all three as null: a job merely viewed
+or saved is not waiting on anyone.
+
+An application row SHALL also carry `cv_opened_at`: when a CV of the caller's that is tied to
+this job was last opened by a non-automated visitor, and null when the caller has no such CV or
+it has never been opened. This field SHALL NOT be an input to `last_activity_at`,
+`days_silent` or `silence_state` — a CV being opened is not a reply, and folding it into the
+silence derivation would clear the marker at the moment it matters most.
+
+#### Scenario: Listing all interactions
+
+- **WHEN** an authenticated user requests `GET /api/v1/me/tracking`
+- **THEN** the response is `200` with
+  `{"data": [{job, viewed_at, saved_at, applied_at}, ...], "meta": {...}}`
+- **AND** each `job` is the card projection (no internal id, no description)
+- **AND** items are ordered by the most recent of the interaction timestamps,
+  descending
+
+#### Scenario: The listing carries no posting text
+
+- **WHEN** any `GET /api/v1/me/tracking` response is serialized
+- **THEN** no row carries the job's description, however large the page
+
+#### Scenario: The full posting is one read away
+
+- **WHEN** the caller opens one application and requests `GET /api/v1/me/tracking/:slug`
+- **THEN** the response carries the complete public job view, description included
+
+#### Scenario: Filtering to applications
+
+- **WHEN** the user requests `GET /api/v1/me/tracking?filter=applied`
+- **THEN** only interactions with non-null `applied_at` are returned
+- **AND** `meta.total` counts only those

--- a/openspec/changes/tracker-board-loads-what-it-shows/tasks.md
+++ b/openspec/changes/tracker-board-loads-what-it-shows/tasks.md
@@ -1,0 +1,44 @@
+## 1. Measure first, and keep the measurement
+
+- [x] 1.1 Seed a 500-application board with 5 KB descriptions and record where the cost is:
+      payload size, the description's share of it, the scan with and without the column, and
+      the endpoint's own time (`TestMeasureBoardLoad`).
+- [x] 1.2 Turn it into a regression guard: the listing carries no description, and the payload
+      for 500 rows stays under a stated ceiling. Verify by mutation — put the description back
+      and watch it fail.
+
+## 2. The listing reads only what a card draws
+
+- [x] 2.1 Add the card listing query to `internal/db/queries/user_jobs.sql` reading only the
+      card's columns from `jobs`, and run `make sqlc`.
+- [x] 2.2 Collapse the three correlated `emails` subqueries into one `LATERAL` returning the
+      count, the newest `received_at` and the pending-suggestion boolean in a single pass.
+- [x] 2.3 Add the card wire type and serialize it from `internal/handler/me_tracking.go`,
+      keeping every interaction field the row already carries.
+- [x] 2.4 Confirm the silence derivation is unchanged: `last_activity_at` still reads
+      `GREATEST(applied_at, newest linked mail)` and still excludes the follow-up and the CV open.
+
+## 3. Indexes — measured and dropped from scope
+
+- [x] 3.1 Seed a realistic mailbox (5 000 messages, 167 linked) and measure the listing with and
+      without the candidate indexes. Result: 2.62 ms vs 2.79 ms — noise. The two orders of
+      magnitude came from `ANALYZE` after the bulk insert, a fixture artefact.
+- [x] 3.2 Record the numbers in the proposal and drop the migration: an index that costs every
+      write to buy nothing measurable on the read is infrastructure before need.
+
+## 4. The drawer reads the posting from the detail response
+
+- [x] 4.1 Take the description and the full facet row from `getTrackedApplication`, which the
+      drawer already fetches, instead of from the listing row.
+- [x] 4.2 Give the board card its own tag function over the flat card facets, leaving
+      `cardTags` to the catalogue surfaces that still hold a full `Job`.
+- [x] 4.3 Update `web/src/lib/types.ts` and everything typed against the listing's `job`.
+
+## 5. Documentation
+
+- [x] 5.1 Update `docs/API.md` and `web/src/lib/docs/api-spec.ts` for the card shape, stating
+      where the full posting lives.
+- [x] 5.2 Note the split in `internal/userjob/AGENTS.md`: the listing serves cards, the detail
+      read serves the posting.
+- [ ] 5.3 Run both Go suites, all four web gates, and the design-system token ratchet before
+      pushing.

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -8,7 +8,7 @@
   import { CLOSED_OUTCOMES, type ClosedOutcome } from '$lib/board';
   import { timeAgo, errorMessage } from '$lib/utils';
   import { tablist } from '$lib/actions/tablist';
-  import { cardTags } from '$lib/enrichment';
+  import { cardTagsFromCard } from '$lib/enrichment';
   import CompanyLogo from './CompanyLogo.svelte';
   import JobDescription from './JobDescription.svelte';
   import MatchAnalysisFull from './MatchAnalysisFull.svelte';
@@ -19,7 +19,7 @@
   import { currentUser } from '$lib/auth.svelte';
   import { statusLabel, statusClass, stageImplication } from '$lib/emailStatus';
   import { avatarInitials, avatarColor } from '$lib/avatar';
-  import type { MyJob, ApplicationEmail, StageSuggestion } from '$lib/types';
+  import type { Job, MyJob, ApplicationEmail, StageSuggestion } from '$lib/types';
   import { focusTrap } from '$lib/actions/focusTrap';
   import { lockScroll, unlockScroll } from '$lib/scrollLock';
 
@@ -100,6 +100,11 @@
   // stage is set from here, so the offer disappears on the press rather than on the next
   // load — the server would stop sending it, but not until something asks it again.
   let stageSuggestion = $state.raw<StageSuggestion | null>(null);
+  // The full posting. The listing serves a card — employer, role, and the facets a row draws —
+  // because carrying every description was 84% of its payload for text no row renders. The
+  // panel is the one place that wants the posting, and it already makes this request for the
+  // linked mail, so the description arrives on a call that was happening anyway.
+  let posting = $state.raw<Job | null>(null);
   let expandedId = $state<number | null>(null);
   let expandedBody = $state.raw<EmailBody | null>(null);
   let bodyLoading = $state(false);
@@ -123,6 +128,7 @@
       const app = await api.getTrackedApplication(item.job.public_slug);
       emails = app.emails;
       stageSuggestion = app.stage_suggestion ?? null;
+      posting = app.job;
     } catch (e) {
       emailsError = errorMessage(e, 'Failed to load emails.');
     } finally {
@@ -161,7 +167,7 @@
   // simply absent — the honest rendering, since we no longer have it to show.
   const company = $derived(item.job?.company || item.company_slug);
   const title = $derived(item.job?.title || item.role_title);
-  let tags = $derived(item.job ? cardTags(item.job) : []);
+  let tags = $derived(item.job ? cardTagsFromCard(item.job) : []);
   let stageLabel = $derived(item.stage ? humanizeStage(item.stage) : null);
 
   // Interaction timeline shown as a wizard-style stepper up top, in engagement-funnel
@@ -403,9 +409,11 @@
         </div>
       {:else if tab === 'fit'}
         <div class="flex flex-col gap-6">
-          {#if item.job}
-            <JobMatch job={item.job} />
-            <MatchAnalysisFull job={item.job} />
+          {#if posting}
+            <JobMatch job={posting} />
+            <MatchAnalysisFull job={posting} />
+          {:else if item.job}
+            <p class="text-sm text-muted-foreground">Loading…</p>
           {/if}
         </div>
       {:else if tab === 'emails'}
@@ -517,17 +525,19 @@
             <p class="text-sm text-muted-foreground">
               This posting is no longer listed. Your application, its stage and your notes are kept.
             </p>
-          {:else if item.job.description}
-            <JobDescription html={item.job.description} />
+          {:else if posting?.description}
+            <JobDescription html={posting.description} />
+          {:else if !posting}
+            <p class="text-sm text-muted-foreground">Loading…</p>
           {:else}
             <p class="text-sm text-muted-foreground">No description available.</p>
           {/if}
 
-          {#if item.job?.skills?.length}
+          {#if posting?.skills?.length}
             <div class="flex flex-col gap-2 border-t border-border pt-5">
               <p class={sectionLabel}>Skills</p>
               <div class="flex flex-wrap gap-1.5">
-                {#each item.job.skills as skill (skill)}
+                {#each posting.skills as skill (skill)}
                   <Badge variant="brand">{skill}</Badge>
                 {/each}
               </div>

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -8,11 +8,11 @@
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
-  import { cardTags, formatSalary } from '$lib/enrichment';
+  import { cardTags, cardTagsFromCard, formatSalary } from '$lib/enrichment';
   import { computeClientMatch, matchTeaser, resolveMatchState } from '$lib/jobMatch';
   import { profileStore } from '$lib/profile.svelte';
   import { metaDescription } from '$lib/seo';
-  import type { Job } from '$lib/types';
+  import type { Job, JobCard } from '$lib/types';
   import { Badge } from '$lib/ui';
   import { supersedesReality } from '$lib/ghost';
   import CredentialBadge from './CredentialBadge.svelte';
@@ -53,7 +53,11 @@
     footer,
     onHide,
   }: {
-    job: Job;
+    // Either the catalogue's full posting or the tracking listing's card. The row draws the
+    // same thing from both: the card carries a server-cut blurb where the posting carries the
+    // whole description, and the two facet fields a full Job keeps inside `enrichment` arrive
+    // flat. Everything the card omits is optional here already.
+    job: Job | JobCard;
     dimViewed?: boolean;
     newTab?: boolean;
     compact?: boolean;
@@ -63,7 +67,7 @@
 
   const isViewed = $derived(dimViewed && hasViewed(job.public_slug));
 
-  const tags = $derived(cardTags(job));
+  const tags = $derived('enrichment' in job ? cardTags(job) : cardTagsFromCard(job));
   // Only the credential subset of job.collections renders here, so the signal row's
   // guard has to test that subset — a job carrying only editorial tags would
   // otherwise open an empty flex row and leave a stray margin under the title.
@@ -72,12 +76,23 @@
   // opening it. Prefer the clean model-written summary, but only tech jobs are
   // enriched — fall back to a plain-text snippet of the raw (HTML) posting so
   // non-tech jobs still show a description. metaDescription strips the tags.
-  const blurb = $derived(job.enrichment?.summary || metaDescription(job.description ?? '', 220));
-  const salary = $derived(job.enrichment ? formatSalary(job.enrichment) : null);
+  const blurb = $derived(
+    'enrichment' in job
+      ? job.enrichment?.summary || metaDescription(job.description ?? '', 220)
+      : metaDescription(job.blurb ?? '', 220),
+  );
+  // Salary lives in the enrichment, which a card does not carry: the tracking lists never
+  // showed it (their rows came from the same listing) and a row without one simply omits it.
+  const salary = $derived('enrichment' in job && job.enrichment ? formatSalary(job.enrichment) : null);
   // Top-level `skills` is the served (deterministic-dictionary) facet; the raw
   // `enrichment.skills` is kept in the JSONB and NOT served, so it's always absent
   // here — read the dictionary field so the card's skill chips actually populate.
   const skills = $derived(job.skills ?? []);
+  // The two read-time signals. Both are attached by the catalogue's projection and neither
+  // has ever been computed for the tracking listing, so a card simply has none — the rows
+  // that render cards showed no badge before this change either.
+  const reality = $derived('reality' in job ? job.reality : undefined);
+  const ghost = $derived('ghost' in job ? job.ghost : undefined);
   // How recently it was posted is a key signal, so it leads the header.
   const posted = $derived(timeAgo(job.posted_at));
 
@@ -278,15 +293,15 @@
 
   <!-- Signal row: reality chip + the region/employment facets, grouped under the
        title as quiet outline chips so they read as metadata, not decoration. -->
-  {#if job.reality || tags.length > 0 || job.countries?.length || credentials.length > 0}
+  {#if reality || tags.length > 0 || job.countries?.length || credentials.length > 0}
     <div class="mt-2 flex flex-wrap items-center gap-1.5">
       <!-- evergreen_posting IS the reality verdict, so showing both chips states one
            fact twice, the second time louder. The ghost chip carries it inside its
            checklist; where ghost is silent, reality renders exactly as before. -->
-      {#if supersedesReality(job.ghost)}
-        <GhostBadge ghost={job.ghost} />
+      {#if supersedesReality(ghost)}
+        <GhostBadge {ghost} />
       {:else}
-        <RealityBadge reality={job.reality} />
+        <RealityBadge {reality} />
       {/if}
       {#each tags as tag (tag)}
         <Badge variant="outline">{tag}</Badge>

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -844,9 +844,12 @@ ${BASE_URL}/auth/oauth/google/start`,
         auth: 'cookie-or-key',
         summary: 'Your tracked jobs joined with the job data.',
         description:
-          'Each item carries the job in the shared wire shape with your interaction ' +
-          'timestamps alongside it. `meta.counts` gives the per-filter totals for tab ' +
-          'badges. Closed jobs stay listed so your history never shrinks.',
+          'Each item carries a card of the job with your interaction timestamps alongside ' +
+          'it — what a list row draws: slug, title, company, closed_at, the stated facets, ' +
+          'skills, collections, posted_at, and a `blurb` already cut to length. It does NOT ' +
+          'carry the description; the full job view is on `GET /me/tracking/:slug`. ' +
+          '`meta.counts` gives the per-filter totals for tab badges. Closed jobs stay ' +
+          'listed so your history never shrinks.',
         query: [
           { name: 'filter', type: 'string', description: 'Subset to return: `all`, `viewed`, `saved`, `applied`, or `board` (default `all`; an unknown value is a 400).', example: 'applied' },
           { name: 'limit', type: 'integer', description: 'Page size, 1–100.', example: '20' },

--- a/web/src/lib/enrichment.ts
+++ b/web/src/lib/enrichment.ts
@@ -5,6 +5,7 @@
 // never renders blank — the SPA never re-validates, it only formats.
 
 import type { Enrichment, Job } from './types';
+import type { Card as JobCard } from './generated/contracts';
 import { countryLabel } from './facets';
 import {
   REGION_LABELS, SENIORITY_LABELS, EMPLOYMENT_LABELS, WORK_MODE_LABELS,
@@ -123,14 +124,38 @@ export function regionLabel(job: Pick<Job, 'regions'>): string | null {
  */
 export function cardTags(job: Job): string[] {
   const e = job.enrichment;
+  return tagRow({
+    work_mode: job.work_mode,
+    regions: job.regions,
+    employment_type: e?.employment_type,
+    seniority: e?.seniority,
+  });
+}
+
+/**
+ * The same row, from the listing's card projection. The card carries these four facets flat —
+ * the server resolved the dict-then-LLM geography before sending — where a full `Job` still
+ * keeps two of them inside `enrichment`. One row builder, two shapes of input, so a tracked
+ * application and a catalogue result cannot describe the same job differently.
+ */
+export function cardTagsFromCard(card: JobCard): string[] {
+  return tagRow(card);
+}
+
+function tagRow(f: {
+  work_mode?: string;
+  regions?: string[];
+  employment_type?: string;
+  seniority?: string;
+}): string[] {
   const tags: string[] = [];
 
-  const arrangement = workArrangement(job);
+  const arrangement = workArrangement({ work_mode: f.work_mode ?? '' });
   if (arrangement) tags.push(arrangement);
-  const region = regionLabel(job);
+  const region = regionLabel({ regions: f.regions ?? [] });
   if (region) tags.push(region);
-  if (e?.employment_type) tags.push(label(EMPLOYMENT_LABELS, e.employment_type));
-  if (e?.seniority) tags.push(label(SENIORITY_LABELS, e.seniority));
+  if (f.employment_type) tags.push(label(EMPLOYMENT_LABELS, f.employment_type));
+  if (f.seniority) tags.push(label(SENIORITY_LABELS, f.seniority));
 
   return tags;
 }

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -62,6 +62,51 @@ export interface Enrichment {
 }
 
 /**
+ * Card is the list-row projection of a job: what a card draws, and nothing else.
+ * It lives beside Job rather than in the package that lists, because both answer the same
+ * question — what of a posting is public — and answering it in two places is how the wire
+ * shapes drift. Card is a strict subset of Job's fields, with the same names and the same
+ * derivations, so a row and a detail page cannot disagree about a job's work mode or where it
+ * is open.
+ * The difference is what is absent. Card has no description, and the tracking listing's query
+ * does not read one: over 500 applications the descriptions were 2.37 MB of a 2.83 MB response
+ * and 13 ms of a 40 ms query, for text no list row renders. A caller that wants the posting
+ * reads the one application it opened.
+ */
+export interface Card {
+  public_slug: string;
+  title: string;
+  company: string;
+  closed_at?: string;
+  /**
+   * The stated facets of the tag row. Empty means unstated, and the row simply omits it —
+   * the same rule the full projection follows.
+   */
+  work_mode?: string;
+  seniority?: string;
+  employment_type?: string;
+  countries?: string[];
+  regions?: string[];
+  skills?: string[];
+  collections?: string[];
+  /**
+   * PostedAt is the effective posting date, the same derivation the full projection makes:
+   * the stated date, or the row's creation when the source never gave one.
+   */
+  posted_at?: string;
+  /**
+   * Blurb is the line a row shows under the title — the enrichment's summary, or the
+   * opening of the description with its tags stripped. Cut server-side: a row displays
+   * about 220 characters, and shipping the whole posting to reach them was 84% of this
+   * listing's payload.
+   */
+  blurb?: string;
+}
+
+//////////
+// source: ghost.go
+
+/**
  * Ghost is the served ghost signal: a hedged level, the criteria that produced it,
  * and the denominator of the scale the interface shows. It carries facts so the UI
  * can state them, never a bare accusation — the same doctrine as Reality.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -3,6 +3,7 @@
 
 import type {
   Job,
+  Card as JobCard,
   JobMatch,
   Blocker,
   Professional,
@@ -11,6 +12,9 @@ import type {
   Analysis as MatchAnalysisContract,
 } from './generated/contracts';
 export type { Job, Enrichment, Verdict, Gap, SkillRow } from './generated/contracts';
+// The list-row projection of a job: the same names and derivations as Job, minus the posting
+// text and everything else a row does not draw.
+export type { Card as JobCard } from './generated/contracts';
 // Per-job profile match (how well a job's skills are covered by the caller's profile).
 export type { JobMatch, AdjacentSkill } from './generated/contracts';
 // Hard-constraint blockers (years, education, certs, work auth, location) surfaced
@@ -422,8 +426,11 @@ export interface MyJob {
   /** Read from the application record, so a card renders whether or not `job` is there. */
   company_slug: string;
   role_title: string;
-  /** Null once the catalogue has removed the posting. The application outlives it. */
-  job: Job | null;
+  /** The card projection of the posting — what a row draws. Null once the catalogue has
+   *  removed the posting: the application outlives it. The full posting, description
+   *  included, is on the single-application read (`getTrackedApplication`), which the
+   *  panel already fetches; the listing carrying it cost 84% of its own payload. */
+  job: JobCard | null;
   viewed_at: string;
   saved_at: string | null;
   applied_at: string | null;


### PR DESCRIPTION
## What and why

Opening `/my/tracking` server-loads 500 rows, and every row carried the full text of its posting — which no row renders. Measured on a seeded board of 500 applications with 5 KB descriptions, **before** touching anything:

```
payload:               2.83 MB
of which descriptions: 2.37 MB  (84%)
scan WITH description:    6.5 ms   WITHOUT: 0.8 ms
```

Those bytes do not merely travel: the tracking routes server-load the board, so they are serialized into the SSR payload, embedded in the HTML document, and parsed again by the browser.

### The listing serves a card

`jobview.Card` — employer, role, the stated facets, `skills`, `collections`, the effective posting date, and a `blurb` cut server-side (the enrichment's summary, else the description's opening with its tags stripped in SQL). The query reads only those columns; the description never leaves the database. The full posting stays on `GET /me/tracking/:slug`, which the application panel already calls for its linked mail — so it arrives on a request that was happening anyway.

`Card` lives beside `Job` in `internal/jobview` because both answer the same question, and answering it in two packages is how wire shapes drift.

### One LATERAL instead of three subqueries

Count, newest received, and pending-suggestion walked the same `emails` rows three times with the same predicate written three times. The "pending" test in particular has to stay the one the follow-up gate and the ghost signal make, and three spellings were three chances to drift.

**Result, measured the same way: 2.83 MB → 0.45 MB.**

### Indexes were in the plan and are not here

Against a realistic mailbox (5 000 messages, 167 linked) the listing ran **2.62 ms with them and 2.79 ms without** — noise. What moved the number by two orders of magnitude was `ANALYZE` after the bulk insert: a fixture artefact, since production statistics are autovacuum's job. An index that taxes every write to buy nothing measurable on the read is infrastructure before need, so the migration was dropped from scope. The measurement is recorded in the proposal.

## Notes

- **⚠️ BREAKING**: `GET /me/tracking` returns a card, not the full job view. `docs/API.md` says where the posting lives.
- **No migration.** No column, table or index changes.
- Scope grew mid-implementation and I stopped to ask: the listing also feeds Saved / History / Hidden, which render full catalogue rows. The card gained `blurb`, `skills`, `collections` and `posted_at` so those keep working; `JobRow` now accepts either shape. `Reality` and `Ghost` are absent because the tracking path never attached them — those rows showed no such badge before either.
- `TestMeasureBoardLoad` stays as the guard: it fails if a description reappears or the payload crosses 1 MB for 500 rows.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` pass.
- [x] `go test ./...` (130 packages) and `go test -tags=integration ./internal/handler ./internal/db` pass.
- [x] Regenerated committed artifacts: `make sqlc` and `make gen-contracts`.
- [ ] `design-system/` not modified — but its token ratchet was run and is clean.
- [x] For `web/` changes: `pnpm run check` (0 errors), `lint` (0 errors), `test` (806), `build` pass.
- [x] This stays within freehire's core/extension boundary.