### PR TITLE
docs(openspec): record what actually verified the autofill change

### DIFF
--- a/openspec/changes/archive/2026-08-02-autofill-contact-source/tasks.md
+++ b/openspec/changes/archive/2026-08-02-autofill-contact-source/tasks.md
@@ -33,6 +33,31 @@
 - [x] 3.2 Run the integration pass too (`go test -tags=integration ./internal/db/`) — the
   plain run does not see build-tagged tests.
 - [x] 3.3 `openspec validate --strict` for this change.
-- [ ] 3.4 After deploy, compare the two colours on production for a key-holding account with
+- [x] 3.4 ~~After deploy, compare the two colours on production for a key-holding account with
   a structured résumé and no CV: the inactive colour returns email-only, the active one
-  returns the parsed name and phone.
+  returns the parsed name and phone.~~ **Superseded — the method was unachievable AND would
+  not have discriminated.** Both colours were past the merge within hours (blue on
+  `8067210e`, green on `f16a20c7`), so no "before" reference remained. Worse, the check as
+  written could not have failed: it names a key-holding account, and the accounts that HAVE
+  a key mostly have no CV either, while the ones that do get a byte-identical answer from
+  both code paths.
+
+  Verified instead, read-only against production on 2026-08-02:
+
+  - **Nobody's existing answer changed.** Over all 10 users with a CV, the header the old
+    path would serve (most recently updated CV of any kind) and the one the new path serves
+    (`BaseCV`) are byte-identical — `md5` over `data->'header'` matched for 10 of 10, with
+    0 users losing a source. `cv.Store.CreateTailored` copies the base document, so a
+    tailored copy carries the base's contact block; the "tailored header autofilled into an
+    unrelated application" scenario needs the header to have been edited on the copy, and
+    nobody has.
+  - **The gain is purely additive.** 164 users (7 of the 17 key holders) have a current
+    structured résumé and no base CV. All 7 state contacts — 6 a name, 6 a phone, 6 a
+    location, 6 at least one link — where they previously received their account email alone.
+  - **Deployed and not erroring.** Both colours carry the change. No request has reached
+    `/api/v1/me/autofill-profile` since the deploy, so there is no production traffic to
+    read either way; the endpoint is live and unexercised, not live and failing.
+
+  What is still unproven is one live HTTP call, which needs an API key. It would confirm the
+  wiring answers 200; it cannot exercise the résumé tier, because that needs an account with
+  no CV and those belong to real users.


### PR DESCRIPTION
Documentation only. Closes the one task left unticked from the archived `autofill-contact-source` change (#1478 / #1481).

## Why not just tick it

Task 3.4 asked for a blue/green comparison after deploy. Ticking it silently would teach the next reader to write the same task, because it was wrong in two ways:

- **Unachievable** — both colours were past the merge within hours (blue on `8067210e`, green on `f16a20c7`), so no "before" reference remained.
- **Non-discriminating**, which is worse — it names *a key-holding account with a structured résumé and no CV*, but the key holders who have a CV get a byte-identical answer from either code path, so the comparison could not have failed even while the window was open.

## What actually verified it

Read-only against production, 2026-08-02:

| check | result |
|---|---|
| existing answers changed? | **0 of 10** CV holders — `md5(data->'header')` identical between the old path (most recent CV of any kind) and the new (`BaseCV`) |
| anyone lost a source? | **0** |
| users gaining an answer | **164** total, **7 of the 17** key holders |
| do those 7 have anything to serve? | yes — 6 a name, 6 a phone, 6 a location, 6 ≥1 link |
| deployed? | both colours |
| erroring? | no requests have reached the endpoint since the deploy — live and unexercised, not live and failing |

The byte-identical result is the review verifier's point confirmed in the data: `cv.Store.CreateTailored` copies the base document, so a tailored copy carries the base's contact block. The scenario the finding led with — a tailored header autofilled into an unrelated application — needs the header to have been edited on the copy, and nobody has done that.

So the change is **inert for everyone who had a CV and purely additive for everyone who did not**.

## The residue, named rather than dropped

One live HTTP call is still unproven. It needs an API key, and it could only ever exercise the CV tier: the résumé tier needs an account with no CV, and those belong to real users.