### PR TITLE
feat(sources): 19 boards behind an application history

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7560,3 +7560,9 @@
   board: wonderly
 - company: Zego
   board: zego
+
+# --- boards behind an application history, live-validated 2026-08-02 ---
+# Ashby answers 200 for any spelling of a board, so the space is URL-encoded exactly as
+# the posting URL carries it — "it-labs" 404s, "it labs" is the real board.
+- company: IT Labs
+  board: it%20labs

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8239,3 +8239,9 @@
   board: longbowadvantage
 - company: LTD Global
   board: ltdglobal
+
+# --- boards behind an application history, live-validated 2026-08-02 ---
+- company: Cyclops
+  board: cyclopsio
+- company: ViaPeople
+  board: viapeople

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -49,3 +49,9 @@
   board: hiretidal
 - company: Nearshore Business Solutions
   board: nearshore-business-solutions
+
+# --- boards behind an application history, live-validated 2026-08-02 ---
+- company: Initiumsoft
+  board: initiumsoft
+- company: Keppri
+  board: keppri

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3111,3 +3111,17 @@
   board: jobs.paris64.com
 - company: Onwelo
   board: kariera.onwelo.com
+
+# --- boards behind an application history, live-validated 2026-08-02 ---
+# Custom-domain sites list under /jobs like a *.teamtailor.com board does; vairix is
+# deliberately absent — its /jobs listing is empty, so only cmd/resolve-url reaches it.
+- company: Cashea
+  board: cashea.na.teamtailor.com
+- company: CodiLime
+  board: jobs.codilime.com
+- company: Consultec-TI
+  board: empleo.consultec-ti.com
+- company: Keyrus Brazil
+  board: jobs.keyrus.com.br
+- company: Magoya
+  board: magoya-1732912701.na.teamtailor.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1538,3 +1538,26 @@
   board: wavestrong
 - company: Yodeck
   board: yodeck
+
+# --- boards behind an application history, live-validated 2026-08-02 ---
+# Reached via apply.workable.com/j/<id> short-links and jobs.workable.com/view/<id>
+# marketplace pages, which name no board: the widget account was resolved from the
+# employer's own name/careers site, then confirmed against the widget API (jobs > 0).
+- company: DaCodes
+  board: dacodes-mx
+- company: Derq
+  board: derq
+- company: Exec
+  board: exec
+- company: Forager
+  board: forager
+- company: LMG Staffing Solutions
+  board: lmg-staffing-solutions
+- company: Seez
+  board: seezcareers
+- company: Sur
+  board: surglobal
+- company: Tenchi Security
+  board: tenchi-security
+- company: Walter
+  board: walter-careers


### PR DESCRIPTION
Auditing 311 postings from an auto-apply queue export against the catalogue left
163 the catalogue could not name. cmd/resolve-url imported what was still live;
this adds the boards behind them, so the next posting from these employers
arrives by the crawl instead of a one-off URL resolve.

Every board is validated at its adapter's own endpoint and carries jobs > 0 — a
board file entry that yields nothing is a corpse the ingest reports as success.

Four candidates are deliberately absent:

- ashby "clickhouse": the applied posting already arrives via the greenhouse
  board of the same name. The dedup key is (source, external_id), so it cannot
  collapse one employer listed under two ATS — the second entry would double
  every row.
- ashby "blacksmith agency": already present, spelled blacksmith%20agency.
- breezy "tekton-labs": /json is empty (private-link postings only).
- ashby "chainlink-labs": the posting API 404s.

Workable short-links (/j/<id>) and marketplace pages (/view/<id>) name no board
at all, so those widget accounts were resolved from the employer's own name and
careers site. Workana stays out: it already crawls as workana-premium.