### PR TITLE
feat(tracking): the application panel shows what happened

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gzuidhof/tygo/tygo"
 
+	"github.com/strelov1/freehire/internal/appevent"
 	"github.com/strelov1/freehire/internal/classify"
 	"github.com/strelov1/freehire/internal/collections"
 	"github.com/strelov1/freehire/internal/location"
@@ -283,6 +284,10 @@ func genVocab() string {
 	var b strings.Builder
 	b.WriteString(emitVocab("Source", "SOURCE_VALUES", source))
 	b.WriteString(emitVocab("Stage", "STAGE_VALUES", userjob.Stages))
+	// The ledger's event kinds. Generated for the reason the mail signals are: the panel and
+	// the calendar each render a label per kind, and a kind added in Go but missing from the
+	// SPA's map rendered as a blank row with every test green.
+	b.WriteString(emitVocab("ApplicationEventKind", "APPLICATION_EVENT_KINDS", appevent.Kinds))
 	// The stage's human label and the group it belongs to, generated for the same reason the
 	// mail signals are: the board, the funnel, the drawer's selector and the home page each kept
 	// their own copy, and three of the four disagreed about what to call a settled application.

--- a/docs/API.md
+++ b/docs/API.md
@@ -2232,7 +2232,9 @@ curl "https://freehire.me/api/v1/me/credits/history" -H "Authorization: Bearer f
 
 **Auth:** Session or API key
 
-One tracked application, with the mail linked to it.
+One tracked application, with the mail linked to it and its history.
+
+`events` is the application's ledger, newest first — what happened to it: the apply, employer replies, follow-ups, stage changes, scheduled interviews. Each carries the same shape `GET /me/timeline` serves, and `observed` says whether anybody other than you set its date. Bounded at 100; empty on an application nothing has happened to yet. This is also where the full public job view lives, description included — the listing at `GET /me/tracking` carries only a card.
 
 A slug you do not track is a 404.
 

--- a/docs/superpowers/specs/2026-08-02-application-history-design.md
+++ b/docs/superpowers/specs/2026-08-02-application-history-design.md
@@ -1,0 +1,93 @@
+# The application panel shows what happened
+
+## Problem
+
+The panel's header carries a strip that reads as a timeline and is not one:
+
+```
+● Viewed yesterday ————————————— ● Applied 6 days ago
+```
+
+Left to right runs *backwards in time*. The strip is an engagement funnel — viewed, then saved,
+then applied — ordered by depth rather than by date, and `JobDrawer.svelte` says so in a comment:
+"Applied is the deepest step, so it anchors the right end regardless of the raw last-viewed
+timestamp". A reader has no way to know that. They see dates in a row and read a sequence.
+
+It is also nearly empty. It draws three timestamps from `user_jobs`, so an application with seven
+linked emails, two stage changes and a follow-up shows none of them. The facts exist: every
+movement is written to `application_events`, and `internal/apptimeline` already reads that ledger
+for the Calendar tab. Nothing reads it for one application.
+
+## Goals
+
+1. The panel shows the application's real history, newest first, from the ledger.
+2. The event vocabulary — labels and colours — has one definition, shared with the Calendar.
+
+## Non-goals
+
+- `viewed` and `saved` do not appear. They are marks on a posting, not events of an application,
+  and `viewed_at` is refreshed on every view — placed at the foot of a history it would claim to
+  be a first view while holding the date of the most recent one, which is a worse lie than the
+  strip it replaces.
+- Events do not link anywhere. A mail event reads as a line, not a link: the Emails tab is one
+  click away and does that job properly.
+- The Calendar tab is untouched beyond taking its labels from the shared module.
+
+## Design
+
+### Reading one application's ledger
+
+A new query beside the calendar's, in `internal/db/queries/application_events.sql`:
+
+```sql
+-- name: ListApplicationEvents :many
+SELECT ... FROM application_events ae
+ WHERE ae.user_id = $1 AND ae.job_id = $2 AND ae.retracted_at IS NULL
+ ORDER BY ae.occurred_at DESC, ae.id DESC
+ LIMIT $3;
+```
+
+Same columns as `ListApplicationEventsInRange`, same exclusion of retracted rows, same joins for
+the role title and the message subject — and the same reason for each, so the two reads cannot
+disagree about what an event is. It is served by the existing partial index
+`application_events_app_idx (user_id, job_id, kind) WHERE retracted_at IS NULL`.
+
+`internal/apptimeline` gains `ForApplication`. The package is already "the ledger's first dated
+reader"; this is its second shape of read, and it belongs there rather than in a handler for the
+reason `internal/inbox` states — the in-app assistant calls services directly and never passes
+through Fiber, so "what happened to this application" put in a handler is a question it cannot
+ask.
+
+### The wire
+
+Events ride on the existing `GET /me/tracking/:slug` as `events`. The panel already makes that
+call — for the linked mail and the stage suggestion — so the history costs no new route and no
+new request from the browser.
+
+The cap is 100 events. An application accrues a handful; the limit is hygiene, matching
+`apptimeline.MaxRangeDays`'s reasoning — an unbounded read of an append-only table costs nothing
+now and something later.
+
+### One event vocabulary
+
+`TrackingCalendar.svelte` holds the labels (`Applied`, `Employer replied — …`, `Followed up`,
+`Moved to …`) and a colour per kind. Those move to `web/src/lib/events.ts`, and `appevent.Kinds`
+is emitted into the generated contracts so the SPA's map can be checked against it — the same
+treatment the stage vocabulary just received, for the same reason: a kind added in Go and missed
+in the SPA renders as a blank row with every test green.
+
+### The panel
+
+The header strip is deleted. The history renders in the Application tab, above Stage and Notes,
+newest first, each row a dot, a relative time, and the event's label. An application with no
+events yet — saved but never applied — shows nothing rather than an empty frame.
+
+## Testing
+
+- `ListApplicationEvents` under `-tags=integration`: newest-first order, retracted rows absent,
+  another user's events absent, the limit respected.
+- `apptimeline.ForApplication`: the mapping from row to event, and that a deleted message yields
+  an event with no subject rather than dropping the event.
+- The label map covers every kind in the generated vocabulary — verified by mutation, by adding
+  a kind and watching the check fail.
+- The panel renders newest-first and renders nothing when the ledger is empty.

--- a/internal/apptimeline/apptimeline.go
+++ b/internal/apptimeline/apptimeline.go
@@ -35,6 +35,7 @@ import (
 type Queries interface {
 	ListApplicationEventsInRange(ctx context.Context, arg db.ListApplicationEventsInRangeParams) ([]db.ListApplicationEventsInRangeRow, error)
 	ListApplicationInterviewsInRange(ctx context.Context, arg db.ListApplicationInterviewsInRangeParams) ([]db.ListApplicationInterviewsInRangeRow, error)
+	ListApplicationEvents(ctx context.Context, arg db.ListApplicationEventsParams) ([]db.ListApplicationEventsRow, error)
 }
 
 // MaxRangeDays caps one request at a year and a day — enough for any calendar span a
@@ -44,6 +45,12 @@ type Queries interface {
 // so this is hygiene rather than a fix: an unbounded range over an append-only table is
 // the kind of thing that costs nothing now and something later.
 const MaxRangeDays = 366
+
+// MaxApplicationEvents caps one application's history. An application accrues a handful of
+// events — an apply, some mail, a stage change or two — so this is the same hygiene
+// MaxRangeDays is rather than a limit anyone meets: an unbounded read of an append-only
+// table costs nothing now and something later.
+const MaxApplicationEvents = 100
 
 // ErrInvalidRange is a from/to pair the reader cannot answer for. Callers wrap it with
 // what was wrong; both readers need only to recognise it — the handler renders a 400,
@@ -86,6 +93,47 @@ func New(q Queries) *Service { return &Service{q: q} }
 // validRange is the one bound rule, shared by both reads. Two copies would drift, and the
 // calendar asks them for the same window — a range one accepted and the other refused
 // would paint half a month with no way to tell why.
+// ForApplication reads one application's events, newest first — the history the application
+// panel renders, where Range paints a month for the calendar.
+//
+// Same rows, same rules, one order each: the panel's reader wants what just happened, the
+// calendar's wants a month laid out. The mapping is shared with Range for the reason the two
+// queries share their joins — an event that meant one thing on the calendar and another in the
+// panel would be exactly the drift the ledger exists to remove.
+func (s *Service) ForApplication(ctx context.Context, userID, jobID int64) ([]Event, error) {
+	rows, err := s.q.ListApplicationEvents(ctx, db.ListApplicationEventsParams{
+		UserID: userID,
+		JobID:  pgtype.Int8{Int64: jobID, Valid: true},
+		Limit:  MaxApplicationEvents,
+		// Which sources carry an emails.id in source_ref — see Range.
+		SrcGmail:    appevent.SourceMailGmail,
+		SrcHosted:   appevent.SourceMailHosted,
+		SrcExternal: appevent.SourceMailExternal,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]Event, 0, len(rows))
+	for _, r := range rows {
+		events = append(events, Event{
+			ID:            r.ID,
+			Kind:          r.Kind,
+			Signal:        r.Signal,
+			Source:        r.Source,
+			Observed:      appevent.TrustedForDayMath(r.Source),
+			OccurredAt:    r.OccurredAt.Time,
+			CompanySlug:   r.CompanySlug,
+			RoleTitle:     r.RoleTitle.String,
+			ApplicationID: r.ApplicationID.Int64,
+			JobSlug:       r.JobSlug.String,
+			EmailID:       r.EmailID.Int64,
+			EmailSubject:  r.EmailSubject.String,
+		})
+	}
+	return events, nil
+}
+
 func validRange(from, to time.Time) error {
 	if from.IsZero() || to.IsZero() {
 		return fmt.Errorf("%w: both bounds are required", ErrInvalidRange)

--- a/internal/apptimeline/apptimeline_test.go
+++ b/internal/apptimeline/apptimeline_test.go
@@ -15,8 +15,9 @@ import (
 // stubStore answers with a fixed set of rows, so the service's own rules — validation and
 // the observed verdict — are tested without a pool.
 type stubStore struct {
-	rows       []db.ListApplicationEventsInRangeRow
-	interviews []db.ListApplicationInterviewsInRangeRow
+	rows            []db.ListApplicationEventsInRangeRow
+	interviews      []db.ListApplicationInterviewsInRangeRow
+	applicationRows []db.ListApplicationEventsRow
 }
 
 func (s stubStore) ListApplicationEventsInRange(context.Context, db.ListApplicationEventsInRangeParams) ([]db.ListApplicationEventsInRangeRow, error) {
@@ -114,4 +115,65 @@ func TestAnUnknownSourceIsNotObserved(t *testing.T) {
 
 func (s stubStore) ListApplicationInterviewsInRange(context.Context, db.ListApplicationInterviewsInRangeParams) ([]db.ListApplicationInterviewsInRangeRow, error) {
 	return s.interviews, nil
+}
+
+func (s stubStore) ListApplicationEvents(context.Context, db.ListApplicationEventsParams) ([]db.ListApplicationEventsRow, error) {
+	return s.applicationRows, nil
+}
+
+func applicationRow(source, subject string) db.ListApplicationEventsRow {
+	return db.ListApplicationEventsRow{
+		ID:           7,
+		Kind:         appevent.KindEmployerReply,
+		Source:       source,
+		OccurredAt:   pgtype.Timestamptz{Time: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC), Valid: true},
+		CompanySlug:  "derq",
+		EmailSubject: pgtype.Text{String: subject, Valid: subject != ""},
+	}
+}
+
+// One application's history is the same Event the calendar renders, resolved by the same
+// rules — including the observed verdict, which is appevent's to give and this package's to
+// ask for. A second mapping would be a second chance to disagree about what an event is.
+func TestForApplicationMapsRowsThroughTheSameRules(t *testing.T) {
+	svc := New(stubStore{applicationRows: []db.ListApplicationEventsRow{
+		applicationRow(appevent.SourceMailGmail, "Invitation to interview"),
+	}})
+
+	events, err := svc.ForApplication(context.Background(), 1, 2)
+	if err != nil {
+		t.Fatalf("ForApplication: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	got := events[0]
+	if got.ID != 7 || got.Kind != appevent.KindEmployerReply || got.CompanySlug != "derq" {
+		t.Errorf("event = %+v, want the row's own id, kind and employer", got)
+	}
+	if got.EmailSubject != "Invitation to interview" {
+		t.Errorf("subject = %q, want the message's own", got.EmailSubject)
+	}
+	if !got.Observed {
+		t.Error("a gmail-sourced event is not observed; the trust rule is appevent's and this reads it")
+	}
+}
+
+// Deletion hides content and does not un-happen the reply: the query withholds the subject
+// and keeps the event, and the mapping must not turn that into a dropped row.
+func TestForApplicationKeepsAnEventWhoseMessageIsGone(t *testing.T) {
+	svc := New(stubStore{applicationRows: []db.ListApplicationEventsRow{
+		applicationRow(appevent.SourceMailGmail, ""),
+	}})
+
+	events, err := svc.ForApplication(context.Background(), 1, 2)
+	if err != nil {
+		t.Fatalf("ForApplication: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want the event to stand without its message", len(events))
+	}
+	if events[0].EmailSubject != "" {
+		t.Errorf("subject = %q, want none", events[0].EmailSubject)
+	}
 }

--- a/internal/db/application_events.sql.go
+++ b/internal/db/application_events.sql.go
@@ -109,6 +109,104 @@ func (q *Queries) LastStageSetAt(ctx context.Context, arg LastStageSetAtParams) 
 	return last_stage_set_at, err
 }
 
+const listApplicationEvents = `-- name: ListApplicationEvents :many
+SELECT ae.id, ae.kind, ae.signal, ae.source, ae.occurred_at, ae.company_slug,
+       ae.application_id,
+       a.role_title,
+       j.public_slug AS job_slug,
+       em.id         AS email_id,
+       em.subject    AS email_subject
+  FROM application_events ae
+  LEFT JOIN applications a ON a.id = ae.application_id
+                          AND a.user_id = ae.user_id
+  LEFT JOIN jobs j         ON j.id = ae.job_id
+  LEFT JOIN emails em      ON em.id = ae.source_ref
+                          AND em.user_id = ae.user_id
+                          AND em.deleted_at IS NULL
+                          AND ae.source IN ($4, $5, $6)
+ WHERE ae.user_id      = $1
+   AND ae.job_id       = $2
+   AND ae.retracted_at IS NULL
+ ORDER BY ae.occurred_at DESC, ae.id DESC
+ LIMIT $3
+`
+
+type ListApplicationEventsParams struct {
+	UserID      int64       `json:"user_id"`
+	JobID       pgtype.Int8 `json:"job_id"`
+	Limit       int32       `json:"limit"`
+	SrcGmail    string      `json:"src_gmail"`
+	SrcHosted   string      `json:"src_hosted"`
+	SrcExternal string      `json:"src_external"`
+}
+
+type ListApplicationEventsRow struct {
+	ID            int64              `json:"id"`
+	Kind          string             `json:"kind"`
+	Signal        string             `json:"signal"`
+	Source        string             `json:"source"`
+	OccurredAt    pgtype.Timestamptz `json:"occurred_at"`
+	CompanySlug   string             `json:"company_slug"`
+	ApplicationID pgtype.Int8        `json:"application_id"`
+	RoleTitle     pgtype.Text        `json:"role_title"`
+	JobSlug       pgtype.Text        `json:"job_slug"`
+	EmailID       pgtype.Int8        `json:"email_id"`
+	EmailSubject  pgtype.Text        `json:"email_subject"`
+}
+
+// One application's live events, newest first — what the application panel renders as its
+// history, where ListApplicationEventsInRange paints a month for the calendar.
+//
+// Same columns, same joins and the same retraction rule as that range read, deliberately: the
+// two answer different questions about the same ledger, and a row that meant one thing on the
+// calendar and another in the panel would be the drift this table exists to remove. See that
+// query for why the employer comes from the event's own slug, why the message is joined for
+// its subject alone, and why the join is restricted to mail-derived sources.
+//
+// Newest first because it is a history: the reader wants what just happened, not what started
+// it. `id` breaks ties so a batch landing on one timestamp keeps a stable order.
+//
+// Served by application_events_app_idx (user_id, job_id, kind) WHERE retracted_at IS NULL —
+// the predicate here is that index's leading pair.
+func (q *Queries) ListApplicationEvents(ctx context.Context, arg ListApplicationEventsParams) ([]ListApplicationEventsRow, error) {
+	rows, err := q.db.Query(ctx, listApplicationEvents,
+		arg.UserID,
+		arg.JobID,
+		arg.Limit,
+		arg.SrcGmail,
+		arg.SrcHosted,
+		arg.SrcExternal,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListApplicationEventsRow{}
+	for rows.Next() {
+		var i ListApplicationEventsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Kind,
+			&i.Signal,
+			&i.Source,
+			&i.OccurredAt,
+			&i.CompanySlug,
+			&i.ApplicationID,
+			&i.RoleTitle,
+			&i.JobSlug,
+			&i.EmailID,
+			&i.EmailSubject,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listApplicationEventsInRange = `-- name: ListApplicationEventsInRange :many
 SELECT ae.id, ae.kind, ae.signal, ae.source, ae.occurred_at, ae.company_slug,
        ae.application_id,

--- a/internal/db/application_timeline_integration_test.go
+++ b/internal/db/application_timeline_integration_test.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // linkedReply seeds a message against the caller's application to jobID and reconciles it
@@ -275,5 +277,132 @@ func TestListApplicationEventsInRange_BoundsAreInclusiveAndExcludeTheRest(t *tes
 	}
 	if !rows[0].OccurredAt.Time.Before(rows[1].OccurredAt.Time) {
 		t.Errorf("events came back as %v then %v, want oldest first", rows[0].OccurredAt.Time, rows[1].OccurredAt.Time)
+	}
+}
+
+// listApplication reads one application's history the way the panel does.
+func listApplication(t *testing.T, q *Queries, userID, jobID int64, limit int32) []ListApplicationEventsRow {
+	t.Helper()
+	rows, err := q.ListApplicationEvents(context.Background(), ListApplicationEventsParams{
+		UserID:      userID,
+		JobID:       pgtype.Int8{Int64: jobID, Valid: true},
+		Limit:       limit,
+		SrcGmail:    "mail_gmail",
+		SrcHosted:   "mail_hosted",
+		SrcExternal: "mail_external",
+	})
+	if err != nil {
+		t.Fatalf("list application events: %v", err)
+	}
+	return rows
+}
+
+// The panel reads a history, so the newest thing that happened comes first — the opposite of
+// the calendar's range read, which paints a month forwards. Same rows, same rules, one order
+// each because each is answering a different question.
+func TestListApplicationEvents_NewestFirstAndScopedToTheCaller(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "history-order@example.test", true)
+	other := seedResponseUser(t, q, "history-other@example.test", true)
+	job := seedResponseJob(t, q, "history-order-1", "derq")
+
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	linkedReply(t, q, user, job, "Thanks for applying", time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC))
+	linkedReply(t, q, user, job, "Invitation to interview", time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC))
+
+	// The other caller's application to the SAME job, which must not leak into this history.
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: other, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply (other): %v", err)
+	}
+
+	rows := listApplication(t, q, user, job, 100)
+	if len(rows) != 3 {
+		t.Fatalf("got %d events, want 3 (one apply, two replies)", len(rows))
+	}
+	for i := 1; i < len(rows); i++ {
+		if rows[i].OccurredAt.Time.After(rows[i-1].OccurredAt.Time) {
+			t.Errorf("event %d is newer than the one before it — the history is not newest-first", i)
+		}
+	}
+	// The two replies are seeded in the past and the apply is stamped now(), so the mail
+	// orders among itself and the apply leads. Asserting the order rather than a fixed row
+	// keeps this about the ORDER BY, which is what the query owns.
+	var replies []string
+	for _, r := range rows {
+		if r.Kind == "employer_reply" {
+			replies = append(replies, r.EmailSubject.String)
+		}
+	}
+	if len(replies) != 2 || replies[0] != "Invitation to interview" || replies[1] != "Thanks for applying" {
+		t.Errorf("replies came back as %v, want the July 20th one before the July 10th one", replies)
+	}
+}
+
+// A re-linked message retracts its old event and records a new one. A history that still
+// showed the retraction would show the correction's author a correction they cannot see they
+// made — the same rule the range read follows.
+func TestListApplicationEvents_RetractedEventsAreAbsent(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "history-retract@example.test", true)
+	job := seedResponseJob(t, q, "history-retract-1", "derq")
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	linkedReply(t, q, user, job, "Thanks for applying", time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC))
+
+	if _, err := q.db.Exec(ctx,
+		`UPDATE application_events SET retracted_at = now() WHERE user_id = $1 AND kind = 'employer_reply'`,
+		user); err != nil {
+		t.Fatalf("retract: %v", err)
+	}
+
+	for _, r := range listApplication(t, q, user, job, 100) {
+		if r.Kind == "employer_reply" {
+			t.Error("a retracted employer_reply is still in the application's history")
+		}
+	}
+}
+
+// Hygiene rather than a fix: an application accrues a handful of events, and an unbounded read
+// of an append-only table costs nothing now and something later.
+func TestListApplicationEvents_RespectsTheLimit(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "history-limit@example.test", true)
+	job := seedResponseJob(t, q, "history-limit-1", "derq")
+	if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: user, JobID: job, EventSource: "user"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for i := range 5 {
+		linkedReply(t, q, user, job, fmt.Sprintf("Reply %d", i),
+			time.Date(2026, 7, 10+i, 9, 0, 0, 0, time.UTC))
+	}
+
+	all := listApplication(t, q, user, job, 100)
+	if len(all) != 6 {
+		t.Fatalf("got %d events unbounded, want 6 (one apply, five replies)", len(all))
+	}
+
+	rows := listApplication(t, q, user, job, 2)
+	if len(rows) != 2 {
+		t.Fatalf("got %d events, want the 2 the limit allows", len(rows))
+	}
+	// The limit keeps the newest, whichever those are — the apply is stamped now() and the
+	// replies are seeded in the past, so naming one here would pin the test to that accident.
+	for i, r := range rows {
+		if r.ID != all[i].ID {
+			t.Errorf("bounded row %d is event %d, want %d — the limit dropped from the wrong end",
+				i, r.ID, all[i].ID)
+		}
 	}
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1115,6 +1115,21 @@ type Querier interface {
 	// Requires jobs_source_id_open_idx (migration 0056); without it this is the same scan
 	// restricted to one source.
 	ListAggregatorJobsForCrosscheckBySource(ctx context.Context, arg ListAggregatorJobsForCrosscheckBySourceParams) ([]ListAggregatorJobsForCrosscheckBySourceRow, error)
+	// One application's live events, newest first — what the application panel renders as its
+	// history, where ListApplicationEventsInRange paints a month for the calendar.
+	//
+	// Same columns, same joins and the same retraction rule as that range read, deliberately: the
+	// two answer different questions about the same ledger, and a row that meant one thing on the
+	// calendar and another in the panel would be the drift this table exists to remove. See that
+	// query for why the employer comes from the event's own slug, why the message is joined for
+	// its subject alone, and why the join is restricted to mail-derived sources.
+	//
+	// Newest first because it is a history: the reader wants what just happened, not what started
+	// it. `id` breaks ties so a batch landing on one timestamp keeps a stable order.
+	//
+	// Served by application_events_app_idx (user_id, job_id, kind) WHERE retracted_at IS NULL —
+	// the predicate here is that index's leading pair.
+	ListApplicationEvents(ctx context.Context, arg ListApplicationEventsParams) ([]ListApplicationEventsRow, error)
 	// One caller's live events over a date range, oldest first — the ledger's first dated
 	// read, behind internal/apptimeline and the tracking calendar.
 	//

--- a/internal/db/queries/application_events.sql
+++ b/internal/db/queries/application_events.sql
@@ -173,3 +173,38 @@ SELECT max(occurred_at)::timestamptz AS last_stage_set_at
    AND job_id = $2
    AND kind = 'stage_set'
    AND retracted_at IS NULL;
+
+-- name: ListApplicationEvents :many
+-- One application's live events, newest first — what the application panel renders as its
+-- history, where ListApplicationEventsInRange paints a month for the calendar.
+--
+-- Same columns, same joins and the same retraction rule as that range read, deliberately: the
+-- two answer different questions about the same ledger, and a row that meant one thing on the
+-- calendar and another in the panel would be the drift this table exists to remove. See that
+-- query for why the employer comes from the event's own slug, why the message is joined for
+-- its subject alone, and why the join is restricted to mail-derived sources.
+--
+-- Newest first because it is a history: the reader wants what just happened, not what started
+-- it. `id` breaks ties so a batch landing on one timestamp keeps a stable order.
+--
+-- Served by application_events_app_idx (user_id, job_id, kind) WHERE retracted_at IS NULL —
+-- the predicate here is that index's leading pair.
+SELECT ae.id, ae.kind, ae.signal, ae.source, ae.occurred_at, ae.company_slug,
+       ae.application_id,
+       a.role_title,
+       j.public_slug AS job_slug,
+       em.id         AS email_id,
+       em.subject    AS email_subject
+  FROM application_events ae
+  LEFT JOIN applications a ON a.id = ae.application_id
+                          AND a.user_id = ae.user_id
+  LEFT JOIN jobs j         ON j.id = ae.job_id
+  LEFT JOIN emails em      ON em.id = ae.source_ref
+                          AND em.user_id = ae.user_id
+                          AND em.deleted_at IS NULL
+                          AND ae.source IN (sqlc.arg(src_gmail), sqlc.arg(src_hosted), sqlc.arg(src_external))
+ WHERE ae.user_id      = $1
+   AND ae.job_id       = $2
+   AND ae.retracted_at IS NULL
+ ORDER BY ae.occurred_at DESC, ae.id DESC
+ LIMIT $3;

--- a/internal/handler/gmail.go
+++ b/internal/handler/gmail.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/strelov1/freehire/internal/apptimeline"
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/auth/oauth"
 	"github.com/strelov1/freehire/internal/db"
@@ -45,6 +46,10 @@ type inboxHandlers struct {
 	// mail tools call the same service, so a rule can never hold for one reader and
 	// not the other.
 	inbox *inbox.Service
+	// timeline reads the ledger for the application panel's history. The panel already
+	// fetches this endpoint for its linked mail, so the history rides along rather than
+	// costing a second request.
+	timeline *apptimeline.Service
 }
 
 // trackingApplications adapts the tracking service to the one call the mail
@@ -64,6 +69,7 @@ func newInboxHandlers(queries *db.Queries, pool *pgxpool.Pool, gmailConnector *g
 		pool:           pool,
 		tracking:       tracking,
 		inbox:          inbox.New(queries, trackingApplications{tracking}),
+		timeline:       apptimeline.New(queries),
 		gmailConnector: gmailConnector,
 		gmailCipher:    gmailCipher,
 		frontendOrigin: frontendOrigin,

--- a/internal/handler/inbox_linking.go
+++ b/internal/handler/inbox_linking.go
@@ -38,6 +38,10 @@ type applicationDetail struct {
 	// for never. It says nothing about whether anybody replied.
 	FollowedUpAt *time.Time         `json:"followed_up_at"`
 	Emails       []applicationEmail `json:"emails"`
+	// Events is the application's history from the ledger, newest first — what happened to
+	// it, as against the marks on the posting the row carries. Empty on an application
+	// nothing has happened to yet, and the panel renders no history section for it.
+	Events []timelineEvent `json:"events"`
 	// StageSuggestion is the stage the newest classified message implies when it differs
 	// from the current one, and null when there is nothing to offer. It changes nothing by
 	// itself: mail never settles an application, and this is how that rule is said out loud
@@ -95,6 +99,14 @@ func (h *inboxHandlers) GetTrackedApplication(c *fiber.Ctx) error {
 		lastStageSet = pgtype.Timestamptz{}
 	}
 
+	// The history. A failure here must not cost the caller their application: it is one
+	// section of a panel whose other four tabs do not depend on it, so it degrades to an
+	// empty history rather than a 500 on a page that was otherwise ready to render.
+	events, err := h.timeline.ForApplication(c.Context(), userID, job.ID)
+	if err != nil {
+		events = nil
+	}
+
 	return c.JSON(fiber.Map{"data": applicationDetail{
 		Job:             jv,
 		ViewedAt:        tsPtr(app.ViewedAt),
@@ -104,6 +116,7 @@ func (h *inboxHandlers) GetTrackedApplication(c *fiber.Ctx) error {
 		Notes:           pgStr(app.Notes),
 		FollowedUpAt:    tsPtr(app.FollowedUpAt),
 		Emails:          emails,
+		Events:          timelineEvents(events),
 		StageSuggestion: jobtracking.SuggestStage(pgStr(app.Stage), forSuggestion, lastStageSet.Time),
 	}})
 }

--- a/internal/handler/me_timeline.go
+++ b/internal/handler/me_timeline.go
@@ -66,21 +66,10 @@ type timelineEvent struct {
 	EmailSubject  string    `json:"email_subject,omitempty"`
 }
 
-// Timeline serves the caller's events between from and to inclusive, oldest first.
-func (h *timelineHandlers) Timeline(c *fiber.Ctx) error {
-	userID, from, to, err := timelineRequest(c)
-	if err != nil {
-		return err
-	}
-
-	events, err := h.timeline.Range(c.Context(), userID, from, to)
-	if err != nil {
-		if errors.Is(err, apptimeline.ErrInvalidRange) {
-			return fiber.NewError(fiber.StatusBadRequest, err.Error())
-		}
-		return err
-	}
-
+// timelineEvents projects the service's events onto the wire. Shared by the range read and
+// the single application's history, so an event published by one cannot carry a field the
+// other withholds.
+func timelineEvents(events []apptimeline.Event) []timelineEvent {
 	out := make([]timelineEvent, 0, len(events))
 	for _, e := range events {
 		out = append(out, timelineEvent{
@@ -98,6 +87,25 @@ func (h *timelineHandlers) Timeline(c *fiber.Ctx) error {
 			EmailSubject:  e.EmailSubject,
 		})
 	}
+	return out
+}
+
+// Timeline serves the caller's events between from and to inclusive, oldest first.
+func (h *timelineHandlers) Timeline(c *fiber.Ctx) error {
+	userID, from, to, err := timelineRequest(c)
+	if err != nil {
+		return err
+	}
+
+	events, err := h.timeline.Range(c.Context(), userID, from, to)
+	if err != nil {
+		if errors.Is(err, apptimeline.ErrInvalidRange) {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		return err
+	}
+
+	out := timelineEvents(events)
 	return c.JSON(fiber.Map{
 		"data": out,
 		"meta": fiber.Map{"from": from, "to": to, "count": len(out)},

--- a/internal/handler/me_timeline_test.go
+++ b/internal/handler/me_timeline_test.go
@@ -27,6 +27,11 @@ func (s timelineStore) ListApplicationEventsInRange(context.Context, db.ListAppl
 	return s.rows, nil
 }
 
+// The single-application read. These cases exercise the range endpoint, which never calls it.
+func (s timelineStore) ListApplicationEvents(context.Context, db.ListApplicationEventsParams) ([]db.ListApplicationEventsRow, error) {
+	return nil, nil
+}
+
 // meTimelineApp mounts the range read behind RequireAuth. The store is nil unless a case
 // supplies one: the auth and range cases must refuse before the service reaches it, and a
 // nil dereference here is how a regression that queried first would announce itself.

--- a/openspec/changes/application-panel-shows-its-history/.openspec.yaml
+++ b/openspec/changes/application-panel-shows-its-history/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/application-panel-shows-its-history/proposal.md
+++ b/openspec/changes/application-panel-shows-its-history/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+The application panel's header carries a strip that reads as a timeline and is not one:
+
+```
+● Viewed yesterday ————————————— ● Applied 6 days ago
+```
+
+Left to right runs backwards in time. It is an engagement funnel — viewed, saved, applied —
+ordered by depth rather than by date, and the component says so in a comment the reader never
+sees. It is also nearly empty: three timestamps from `user_jobs`, so an application with seven
+linked emails, two stage changes and a follow-up displays none of them.
+
+Those facts are already recorded. Every movement writes to `application_events`, and
+`internal/apptimeline` reads that ledger for the Calendar tab. Nothing reads it for one
+application, so the panel shows a funnel dressed as history while the history sits unread.
+
+## What Changes
+
+- `ListApplicationEvents(user_id, job_id, limit)` reads one application's live events,
+  newest first — the same columns, joins and retraction rule as the calendar's range read, so
+  the two cannot disagree about what an event is. Served by the existing partial index
+  `application_events_app_idx`.
+- `internal/apptimeline` gains `ForApplication`, its second shape of read. It belongs in the
+  service rather than a handler because the in-app assistant calls services directly and never
+  passes through Fiber — "what happened to this application" is a question it should be able to
+  ask.
+- `GET /me/tracking/:slug` carries the events. The panel already makes that call for its linked
+  mail and its stage suggestion, so the history costs no new route and no new browser request.
+- The event labels and colours move out of `TrackingCalendar.svelte` into a shared module, and
+  `appevent.Kinds` is emitted into the generated contracts so the map can be checked against the
+  vocabulary — the treatment the stage vocabulary just received, for the same reason.
+- The header strip is deleted. The history renders in the Application tab, above Stage and Notes.
+
+Deliberately not done: `viewed` and `saved` stay out — they are marks on a posting, and
+`viewed_at` is refreshed on every view, so at the foot of a history it would claim to be a first
+view while holding the most recent date, a worse lie than the strip it replaces. Events do not
+link anywhere; the Emails tab is one click away and does that job properly.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `application-timeline`: the ledger becomes readable for a single application, not only as a
+  dated range, and that read is what the application panel renders as its history.
+
+## Impact
+
+- **Go**: `internal/db/queries/application_events.sql`, `internal/apptimeline`,
+  `internal/handler/inbox_linking.go` (the detail response), `cmd/gen-contracts`.
+- **SQL**: one new query. No migration — the index it needs exists.
+- **Frontend**: new `web/src/lib/events.ts`, `TrackingCalendar.svelte` (reads it),
+  `JobDrawer.svelte` (strip out, history in), `web/src/lib/types.ts`.
+- **Docs**: `docs/API.md`, `web/src/lib/docs/api-spec.ts`.

--- a/openspec/changes/application-panel-shows-its-history/specs/application-timeline/spec.md
+++ b/openspec/changes/application-panel-shows-its-history/specs/application-timeline/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: The ledger is readable for one application
+
+The system SHALL read a single application's live events, newest first, scoped to the caller and
+bounded by a limit. The read SHALL exclude retracted events, join the message for its subject
+under the same conditions the range read uses, and take the employer from the event's own
+denormalized slug rather than through the posting — the same rules, so the two reads cannot
+disagree about what an event is or which employer it belongs to.
+
+The rule SHALL live in `internal/apptimeline` beside the range read rather than in an HTTP
+handler: the in-app assistant calls services directly with the session owner's id and issues no
+HTTP request, and "what happened to this application" is a question it should be able to ask.
+
+#### Scenario: Newest first
+
+- **WHEN** an application has an apply, a reply and a stage change
+- **THEN** they are returned newest first, with a stable order between events sharing a timestamp
+
+#### Scenario: Retracted events are absent
+
+- **WHEN** an event has been retracted, as a re-linked message's employer_reply is
+- **THEN** it does not appear in the application's history
+
+#### Scenario: Scoped to the caller
+
+- **WHEN** two users have events against the same job
+- **THEN** each reads only their own
+
+#### Scenario: An event outlives its message
+
+- **WHEN** the message an event was derived from has been deleted
+- **THEN** the event is still returned, carrying no subject — deletion hides content, it does not
+  un-happen the reply
+
+#### Scenario: The read is bounded
+
+- **WHEN** an application has accrued more events than the limit
+- **THEN** the newest are returned, up to the limit
+
+### Requirement: The application panel renders its history
+
+The application panel SHALL show the application's events as its history: newest first, each with
+its time and what happened, rendered from the shared event vocabulary so a row reads the same
+there as on the calendar. The events SHALL arrive on the existing single-application read rather
+than on a request of their own.
+
+The panel SHALL NOT show an engagement funnel in place of a history. Ordering `viewed`, `saved`
+and `applied` by depth put the newest fact on the left and the oldest on the right, which reads
+as a sequence and is not one.
+
+`viewed` and `saved` SHALL be absent from the history. They are marks on a posting rather than
+events of an application, and `viewed_at` is refreshed on every view, so presenting it as the
+first step would state a first view while holding the date of the most recent one.
+
+#### Scenario: A settled application shows how it settled
+
+- **WHEN** an application was applied to, chased, moved to interview and then rejected by mail
+- **THEN** the panel lists all four, newest first
+
+#### Scenario: An application with no events
+
+- **WHEN** an application has been saved but never applied to, so the ledger holds nothing
+- **THEN** the panel shows no history section rather than an empty frame
+
+#### Scenario: One vocabulary with the calendar
+
+- **WHEN** the same event is shown in the panel and on the calendar
+- **THEN** it carries the same label in both, read from one definition
+
+#### Scenario: A kind without a label fails the build
+
+- **WHEN** an event kind is added to the Go vocabulary and not given a label
+- **THEN** the frontend check fails rather than rendering a blank row

--- a/openspec/changes/application-panel-shows-its-history/tasks.md
+++ b/openspec/changes/application-panel-shows-its-history/tasks.md
@@ -1,0 +1,33 @@
+## 1. Read one application's ledger
+
+- [x] 1.1 Write the failing integration test for `ListApplicationEvents`: newest first, retracted
+      absent, another caller's events absent, the limit respected, a deleted message leaving the
+      event standing without a subject.
+- [x] 1.2 Add the query beside `ListApplicationEventsInRange` and run `make sqlc`.
+- [x] 1.3 Add `apptimeline.ForApplication` with its own test over the row→event mapping.
+
+## 2. The events reach the panel
+
+- [x] 2.1 Carry the events on `GET /me/tracking/:slug`, bounded by the limit.
+- [x] 2.2 Update `web/src/lib/types.ts` for the new field.
+
+## 3. One event vocabulary
+
+- [x] 3.1 Emit `appevent.Kinds` into the generated contracts.
+- [x] 3.2 Move the labels and colours out of `TrackingCalendar.svelte` into `web/src/lib/events.ts`,
+      with a check that every generated kind has a label. Verify by mutation.
+- [x] 3.3 Point `TrackingCalendar.svelte` at the shared module and confirm the calendar is
+      unchanged on screen.
+
+## 4. The panel
+
+- [x] 4.1 Delete the header strip from `JobDrawer.svelte`.
+- [x] 4.2 Render the history in the Application tab above Stage and Notes, newest first, and
+      nothing at all when the ledger is empty.
+
+## 5. Documentation
+
+- [x] 5.1 Update `docs/API.md` and `web/src/lib/docs/api-spec.ts` for the detail response's
+      `events`.
+- [x] 5.2 Run both Go suites, all four web gates, and the design-system token ratchet.
+- [x] 5.3 Offer a `/blog` changelog entry.

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -18,9 +18,10 @@
   import type { EmailBody } from '$lib/api';
   import { currentUser } from '$lib/auth.svelte';
   import { statusLabel, stageImplication } from '$lib/emailStatus';
+  import { eventLabel, eventTone } from '$lib/events';
   import StatusChip from '$lib/components/StatusChip.svelte';
   import { avatarInitials, avatarColor } from '$lib/avatar';
-  import type { Job, MyJob, ApplicationEmail, StageSuggestion } from '$lib/types';
+  import type { Job, MyJob, ApplicationEmail, StageSuggestion, TimelineEvent } from '$lib/types';
   import { focusTrap } from '$lib/actions/focusTrap';
   import { lockScroll, unlockScroll } from '$lib/scrollLock';
 
@@ -130,6 +131,7 @@
       emails = app.emails;
       stageSuggestion = app.stage_suggestion ?? null;
       posting = app.job;
+      events = app.events ?? [];
     } catch (e) {
       emailsError = errorMessage(e, 'Failed to load emails.');
     } finally {
@@ -171,16 +173,12 @@
   let tags = $derived(item.job ? cardTagsFromCard(item.job) : []);
   let stageLabel = $derived(item.stage ? humanizeStage(item.stage) : null);
 
-  // Interaction timeline shown as a wizard-style stepper up top, in engagement-funnel
-  // order (viewed → saved → applied): Applied is the deepest step, so it anchors the
-  // right end regardless of the raw last-viewed timestamp.
-  let activity = $derived(
-    [
-      { label: 'Viewed', at: item.viewed_at },
-      item.saved_at ? { label: 'Saved', at: item.saved_at } : null,
-      item.applied_at ? { label: 'Applied', at: item.applied_at } : null,
-    ].filter((x): x is { label: string; at: string } => x !== null),
-  );
+  // The application's history, newest first, from the ledger. It replaces a strip that read
+  // as a timeline and was not one: viewed/saved/applied ordered by depth, so the newest fact
+  // sat on the left and the oldest on the right. `viewed` and `saved` are gone from it on
+  // purpose — they are marks on a posting, and viewed_at is refreshed on every view, so at
+  // the foot of a history it would state a first view while holding the latest date.
+  let events = $state.raw<TimelineEvent[]>([]);
 
   // Lock background scroll while the fullscreen panel is open, released on unmount
   // (close / job switch). A DOM side-effect — the legitimate use of $effect.
@@ -269,23 +267,6 @@
             <span class="rounded-full bg-brand-muted px-2.5 py-0.5 text-xs font-medium text-brand-strong">{stageLabel}</span>
           {/if}
         </div>
-      {/if}
-
-      {#if activity.length}
-        <ol class="flex items-center gap-2">
-          {#each activity as a, i (a.label)}
-            <li class="flex shrink-0 items-center gap-1.5">
-              <span class="size-2 rounded-full bg-brand"></span>
-              <span class="whitespace-nowrap text-xs">
-                <span class="font-medium text-foreground">{a.label}</span>
-                <span class="text-muted-foreground">{timeAgo(a.at)}</span>
-              </span>
-            </li>
-            {#if i < activity.length - 1}
-              <li aria-hidden="true" class="h-px min-w-4 flex-1 bg-border"></li>
-            {/if}
-          {/each}
-        </ol>
       {/if}
 
       <!-- What the candidate can do about this application, on every tab. The card used
@@ -379,6 +360,24 @@
                   <Button variant="outline" onclick={() => onchooseoutcome(o)}>{humanizeStage(o)}</Button>
                 {/each}
               </div>
+            </div>
+          {/if}
+
+          <!-- What happened, newest first. Absent entirely when the ledger holds nothing:
+               an application saved but never applied to has no history, and an empty frame
+               would say otherwise. -->
+          {#if events.length}
+            <div class="flex flex-col gap-1 text-sm">
+              <span class="font-medium">History</span>
+              <ol class="flex flex-col gap-1.5">
+                {#each events as e (e.id)}
+                  <li class="flex items-baseline gap-2">
+                    <span class="shrink-0 text-xs {eventTone(e.kind)}" aria-hidden="true">●</span>
+                    <span class="w-24 shrink-0 text-xs text-muted-foreground">{timeAgo(e.occurred_at)}</span>
+                    <span class="min-w-0 text-sm">{eventLabel(e)}</span>
+                  </li>
+                {/each}
+              </ol>
             </div>
           {/if}
 

--- a/web/src/lib/components/TrackingCalendar.svelte
+++ b/web/src/lib/components/TrackingCalendar.svelte
@@ -3,6 +3,7 @@
   import { onMount, tick } from 'svelte';
   import { resolve } from '$app/paths';
   import { api } from '$lib/api';
+  import { eventLabel, eventTone } from '$lib/events';
   import {
     buildCalendarMonth,
     monthLabel,
@@ -123,37 +124,11 @@
   }
 
   // The mark colours carry the kind; filled versus hollow carries whether anybody but the
-  // candidate set the date. An unrecognised kind gets the neutral mark rather than none —
-  // a fifth kind is coming and must be visible before this file knows its name.
-  //
-  // Tokens, not raw palette hues. Four arbitrary colours would read as a fifth vocabulary
-  // nobody owns, and `pnpm check:tokens` counts them per file; the neighbouring status maps
-  // predate the check and carry a recorded baseline, which is not a reason to add to it.
-  //
-  // Only four token colours are actually distinct: primary and secondary-foreground hold
-  // the SAME value in both themes (oklch(0.13 0 0) light, oklch(0.985 0 0) dark), so
-  // reaching for the second to separate two kinds silently collapses them into one mark.
-  const KIND_TONE: Record<string, string> = {
-    applied: 'text-primary',
-    employer_reply: 'text-brand-strong',
-    follow_up_sent: 'text-warning-strong',
-    stage_set: 'text-muted-foreground',
-  };
-  const tone = (kind: string) => KIND_TONE[kind] ?? 'text-muted-foreground';
-
-  /** Sentence-case an unknown kind so a new one reads as words, not as a column name. */
-  function humanKind(kind: string): string {
-    const words = kind.replace(/_/g, ' ');
-    return words.charAt(0).toUpperCase() + words.slice(1);
-  }
-
-  const KIND_LABEL: Record<string, (e: TimelineEvent) => string> = {
-    applied: () => 'Applied',
-    employer_reply: (e) => (e.signal ? `Employer replied — ${e.signal.replace(/_/g, ' ')}` : 'Employer replied'),
-    follow_up_sent: () => 'Followed up',
-    stage_set: (e) => (e.signal ? `Moved to ${e.signal}` : 'Stage changed'),
-  };
-  const label = (e: TimelineEvent) => (KIND_LABEL[e.kind] ?? (() => humanKind(e.kind)))(e);
+  // candidate set the date. Both the label and the tone come from $lib/events, shared with
+  // the application panel:
+  // the same event captioned two ways on two screens is what putting them here caused.
+  const tone = (kind: string) => eventTone(kind);
+  const label = (e: TimelineEvent) => eventLabel(e);
 
   const timeOf = (e: TimelineEvent) => clockOf(e.occurred_at);
   const clockOf = (instant: string) =>

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -1641,11 +1641,27 @@ ${BASE_URL}/auth/oauth/google/start`,
         method: 'GET',
         path: '/me/tracking/{slug}',
         auth: 'cookie-or-key',
-        summary: 'One tracked application, with the mail linked to it.',
-        description: 'A slug you do not track is a 404.',
+        summary: 'One tracked application, with the mail linked to it and its history.',
+        description:
+          '`events` is the application\'s ledger, newest first — the apply, employer ' +
+          'replies, follow-ups, stage changes, scheduled interviews — in the shape ' +
+          '`GET /me/timeline` serves, bounded at 100 and empty when nothing has happened ' +
+          'yet. This read also carries the full job view; the listing carries only a card. ' +
+          'A slug you do not track is a 404.',
         pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
         curl: `curl "${BASE_URL}/me/tracking/senior-backend-engineer-acme-1a2b" -H "Authorization: Bearer fhk_…"`,
-        responseExample: `{ "data": { "slug": "senior-backend-engineer-acme-1a2b", "stage": "interview", "applied_at": "2026-07-24T09:00:00Z", "emails": [ { "id": 4821, "subject": "Interview for …", "status_signal": "interview_invitation" } ] } }`,
+        responseExample: `{
+  "data": {
+    "slug": "senior-backend-engineer-acme-1a2b",
+    "stage": "interview",
+    "applied_at": "2026-07-24T09:00:00Z",
+    "emails": [ { "id": 4821, "subject": "Interview for …", "status_signal": "interview_invitation" } ],
+    "events": [
+      { "id": 991, "kind": "employer_reply", "signal": "interview_invitation", "source": "mail_gmail", "observed": true, "occurred_at": "2026-07-29T11:04:00Z" },
+      { "id": 802, "kind": "applied", "source": "user", "observed": false, "occurred_at": "2026-07-24T09:00:00Z" }
+    ]
+  }
+}`,
       },
       {
         method: 'GET',

--- a/web/src/lib/events.test.ts
+++ b/web/src/lib/events.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { APPLICATION_EVENT_KINDS } from './generated/contracts';
+import { eventLabel, eventTone, KIND_LABEL } from './events';
+import type { TimelineEvent } from './types';
+
+const event = (kind: string, signal?: string): TimelineEvent =>
+  ({ id: 1, kind, signal, source: 'mail_gmail', observed: true, occurred_at: '2026-08-01T09:00:00Z', company_slug: 'acme' }) as TimelineEvent;
+
+// The panel and the calendar render the same ledger. A kind the Go side knows and this map
+// does not would fall through to the sentence-cased fallback — which reads plausibly and
+// silently drops what the label was meant to add ("Employer replied — rejection" becomes
+// "Employer reply"). The fallback is for a server NEWER than this build, not for a kind we
+// simply forgot.
+describe('KIND_LABEL', () => {
+  it('names every kind the contract carries', () => {
+    for (const kind of APPLICATION_EVENT_KINDS) {
+      expect(KIND_LABEL[kind], kind).toBeDefined();
+    }
+  });
+});
+
+describe('eventLabel', () => {
+  it('reads the signal into the sentence where there is one', () => {
+    expect(eventLabel(event('employer_reply', 'rejection'))).toBe('Employer replied — rejection');
+    expect(eventLabel(event('stage_set', 'interview'))).toBe('Moved to interview');
+  });
+
+  it('says the plain thing where there is no signal', () => {
+    expect(eventLabel(event('employer_reply'))).toBe('Employer replied');
+    expect(eventLabel(event('stage_set'))).toBe('Stage changed');
+    expect(eventLabel(event('applied'))).toBe('Applied');
+    expect(eventLabel(event('follow_up_sent'))).toBe('Followed up');
+    expect(eventLabel(event('interview_scheduled'))).toBe('Interview scheduled');
+  });
+
+  // A server ahead of this build can name a kind it has never heard of. Sentence-casing it
+  // reads as words rather than as a column name, which is better than a blank row.
+  it('sentence-cases a kind from a newer server', () => {
+    expect(eventLabel(event('offer_withdrawn'))).toBe('Offer withdrawn');
+  });
+});
+
+describe('eventTone', () => {
+  it('gives every known kind a tone', () => {
+    for (const kind of APPLICATION_EVENT_KINDS) {
+      expect(eventTone(kind), kind).toMatch(/^text-/);
+    }
+  });
+
+  it('falls back quietly for an unknown kind', () => {
+    expect(eventTone('offer_withdrawn')).toBe('text-muted-foreground');
+  });
+});

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -1,0 +1,48 @@
+// How a ledger event reads: its label and the tone it is drawn in.
+//
+// One definition for the two surfaces that render the same events — the calendar, which paints
+// a month, and the application panel, which lists one application's history. These labels lived
+// inside TrackingCalendar.svelte until the panel needed them; copying them would have meant the
+// same event captioned two ways on two screens.
+//
+// `KIND_LABEL` is checked against the generated vocabulary (`APPLICATION_EVENT_KINDS`), so a
+// kind added in Go and forgotten here fails a test rather than falling through to the fallback,
+// which reads plausibly while dropping what the label was for.
+
+import type { TimelineEvent } from './types';
+
+/** Sentence-case an unknown kind so a new one reads as words, not as a column name. */
+function humanKind(kind: string): string {
+  const words = kind.replace(/_/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+export const KIND_LABEL: Record<string, (e: TimelineEvent) => string> = {
+  applied: () => 'Applied',
+  employer_reply: (e) => (e.signal ? `Employer replied — ${e.signal.replace(/_/g, ' ')}` : 'Employer replied'),
+  follow_up_sent: () => 'Followed up',
+  stage_set: (e) => (e.signal ? `Moved to ${e.signal}` : 'Stage changed'),
+  interview_scheduled: () => 'Interview scheduled',
+};
+
+/** What happened, in a phrase. A kind from a server newer than this build is sentence-cased
+ *  rather than left blank. */
+export function eventLabel(e: TimelineEvent): string {
+  return (KIND_LABEL[e.kind] ?? (() => humanKind(e.kind)))(e);
+}
+
+// Design tokens, not palette utilities: `pnpm check:tokens` counts raw colours per file, and
+// only four of these read as distinct — `primary` and `secondary-foreground` hold the same
+// value in both themes, so reaching for the second to separate two kinds collapses them.
+const KIND_TONE: Record<string, string> = {
+  applied: 'text-primary',
+  employer_reply: 'text-brand-strong',
+  follow_up_sent: 'text-warning-strong',
+  stage_set: 'text-muted-foreground',
+  interview_scheduled: 'text-brand-strong',
+};
+
+/** The tone a kind is drawn in; quiet for anything unrecognised. */
+export function eventTone(kind: string): string {
+  return KIND_TONE[kind] ?? 'text-muted-foreground';
+}

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -1058,6 +1058,8 @@ export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', '
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];
+export const APPLICATION_EVENT_KINDS = ['applied', 'employer_reply', 'follow_up_sent', 'stage_set', 'interview_scheduled'] as const;
+export type ApplicationEventKind = (typeof APPLICATION_EVENT_KINDS)[number];
 export const STAGE_LABELS = {
   'accepted': 'Accepted',
   'applied': 'Applied',

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -528,6 +528,9 @@ export interface TrackedApplication {
   cv_opened_at: string | null;
   emails: ApplicationEmail[];
   stage_suggestion?: StageSuggestion;
+  /** The application's history from the ledger, newest first — what happened to it, as
+   *  against the marks on the posting the listing row carries. Empty when nothing has. */
+  events: TimelineEvent[];
 }
 
 /** The assembled follow-up message for a silent application. Deterministic and

--- a/web/src/posts/2026-08-02-what-actually-happened.svx
+++ b/web/src/posts/2026-08-02-what-actually-happened.svx
@@ -1,0 +1,42 @@
+---
+title: What actually happened to this application
+date: 2026-08-02
+summary: The strip at the top of an application read left to right and ran backwards in time. It's gone, replaced by the application's real history — the apply, every employer reply, every stage change — newest first.
+type: changelog
+tags:
+  - job-seekers
+  - tracking
+---
+
+Open an application and the panel used to greet you with this:
+
+```
+● Viewed yesterday ————————————— ● Applied 6 days ago
+```
+
+Read it left to right and you read it backwards. It was never a timeline — it was an
+engagement funnel, ordered viewed → saved → applied, with "applied" pinned to the right
+because it is the deepest step, not because it is the latest. Nothing on screen said so.
+
+It was also almost empty. Three timestamps, whatever else had happened. An application with
+seven linked emails, two stage changes and a follow-up showed none of them.
+
+**The panel now shows the application's actual history**, newest first, on the Application
+tab:
+
+```
+● 3 days ago    Employer replied — rejection
+● 5 days ago    Moved to interview
+● 8 days ago    Followed up
+● 14 days ago   Applied
+```
+
+Every one of those was already recorded — the same ledger the Calendar tab paints a month
+from. It just had never been read for a single application, so the panel showed a funnel
+where a history belonged.
+
+Two things are deliberately not in it. **Viewed and saved are gone**: they are marks on a
+posting rather than events of an application, and "viewed" is refreshed every time you open
+the job, so at the foot of a history it would claim to be the first time while holding the
+date of the most recent one. And the rows don't link anywhere — the Emails tab is one click
+away and shows you the message properly.


### PR DESCRIPTION
## What and why

The panel's header carried a strip that read as a timeline and was not one:

```
● Viewed yesterday ————————————— ● Applied 6 days ago
```

Left to right ran **backwards in time**. It was an engagement funnel — viewed, saved, applied — ordered by depth, with the newest fact on the left, and the component said so in a comment the reader never sees. It was also nearly empty: three timestamps from `user_jobs`, so an application with seven linked emails, two stage changes and a follow-up displayed none of them.

Those facts were already recorded. `application_events` has them; `internal/apptimeline` reads that ledger for the Calendar tab. Nothing read it for one application.

### The history

`ListApplicationEvents` reads one application's live events newest-first, beside the range read the calendar uses and with the same columns, joins and retraction rule. The two answer different questions about one ledger, and a row meaning one thing on the calendar and another in the panel is the drift the ledger exists to remove. Served by the existing partial index `application_events_app_idx` — no migration.

`apptimeline.ForApplication` is its second shape of read. It lives in the service because the in-app assistant calls services directly and never passes through Fiber — "what happened to this application" should be a question it can ask.

The events ride on `GET /me/tracking/:slug`, which the panel already fetches for its linked mail and its stage suggestion, so the history costs **no new route and no second request**. A failure reading them degrades to an empty history rather than a 500 on a panel whose other tabs do not depend on it.

### One event vocabulary

Labels and tones move out of `TrackingCalendar.svelte` into `$lib/events.ts`, and `appevent.Kinds` is emitted into the contracts so the map can be checked against it.

**That check paid for itself immediately:** the calendar knew four kinds and the vocabulary has five — `interview_scheduled` had been falling through to the sentence-cased fallback. It now has a label of its own.

## Notes

- `viewed` and `saved` stay out of the history: they are marks on a posting, and `viewed_at` is refreshed on every view, so at the foot of a history it would state a first view while holding the date of the most recent one — a worse lie than the strip it replaces.
- Events don't link anywhere. The Emails tab is one click away and does that job properly.
- Every guard verified by mutation: reversing `ORDER BY` fails the order test, dropping the fifth kind fails the label check.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` pass.
- [x] `go test ./...` (130 packages) and `go test -tags=integration ./internal/db ./internal/handler` pass.
- [x] Regenerated committed artifacts: `make sqlc`, `make gen-contracts`.
- [ ] `design-system/` not modified — its token ratchet was run and is clean.
- [x] For `web/` changes: `check` (0 errors), `lint` (0 errors), `test` (812), `build` pass.
- [x] This stays within freehire's core/extension boundary.