### PR TITLE
feat(web): ask for a GitHub star once the Product Hunt strip stops asking

### DIFF
--- a/docs/superpowers/specs/2026-08-02-github-star-support-toast-design.md
+++ b/docs/superpowers/specs/2026-08-02-github-star-support-toast-design.md
@@ -101,8 +101,13 @@ noise.
 project's vitest environment does not resolve the alias, and an aliased import fails at
 module load rather than in a test body.
 
-Untouched: `ProductHuntBanner.svelte`, `productHunt.ts`, `github.svelte.ts`,
-`app.html`, `svelte.config.js`.
+Untouched: `productHunt.ts`, `github.svelte.ts`, `app.html`, `svelte.config.js`.
+
+Superseded during implementation, after code review: `ProductHuntBanner.svelte` also
+changes, and `web/src/lib/phBanner.svelte.ts` is added. A dismissal snapshot taken at the
+toast's mount would not fire in the session where the visitor closed the strip — which,
+before the launch day, is the only path to the toast. The authoritative record is
+`openspec/changes/github-star-support-toast/design.md`.
 
 ## Copy
 

--- a/docs/superpowers/specs/2026-08-02-github-star-support-toast-design.md
+++ b/docs/superpowers/specs/2026-08-02-github-star-support-toast-design.md
@@ -1,0 +1,124 @@
+# GitHub star support toast
+
+**Date:** 2026-08-02
+**Status:** approved, ready for planning
+
+## Problem
+
+freehire is open source and nothing on the site asks for the one form of support
+that costs a visitor nothing: a GitHub star. The footer carries a "View source on
+GitHub" link and the header carries a star badge, but neither asks.
+
+A second ask cannot simply be added on top of the Product Hunt strip. Until 26
+August that strip already occupies the "support us" slot under the header, and two
+simultaneous pleas read as nagging. The asks must queue, not stack.
+
+## Solution
+
+A dismissible toast, floating bottom-right, that appears only once the Product Hunt
+strip has stopped asking — either because the visitor closed it, or because the
+launch day has passed and it retired itself.
+
+### Why a toast and not a second strip
+
+The Product Hunt banner renders on the server and hides via a class set before first
+paint. That machinery exists for one reason: the strip sits in the document flow, so
+mounting it after hydration would shove the page down under someone already reading.
+
+A `fixed` toast moves nothing, so none of that applies. It renders after mount, which
+means **`app.html` is not touched at all** — and the SHA-256 CSP hash covering its
+single inline script, which breaks silently and takes the anti-FOUC theme script down
+with it, stays intact.
+
+### Show condition
+
+Pure, testable, no clock beyond what Product Hunt already exposes:
+
+```
+show = !selfDismissed && (phBannerDismissed || launchPhase(now) === 'over')
+```
+
+The second disjunct is load-bearing. After 26 August `ProductHuntBanner` returns
+nothing, so its dismissal key can never be written; gating on the key alone would
+mean the toast never appears for anyone who arrives after launch day.
+
+`phBannerDismissed` reads the existing `hire.ph-banner-dismissed` key. "The visitor
+closed the Product Hunt strip" is already an observable fact — no new state is
+introduced to represent it.
+
+### Deferring to the cookie banner
+
+`CookieConsent` is `fixed inset-x-4 bottom-4 z-50 … sm:right-4 sm:max-w-md` — the
+same corner. While `bannerVisible()` is true the toast does not render. Consent is an
+obligation; a promo is not. This mirrors the rule already recorded in the layout, that
+a promo strip must not push a security notice further from the header.
+
+`bannerVisible` is a rune-backed getter, so the toast appears on its own the moment
+consent is settled. No timer, no subscription.
+
+### Stacking
+
+`z-30` — below `HiddenToast` (`z-40`). Undo-after-hide has a five-second window; a
+promo has no right to cover it.
+
+### Star count
+
+`web/src/lib/github.svelte.ts` already provides everything: a singleton store with
+`$state`, an idempotent `load()`, a 6-hour `localStorage` cache, silent degradation to
+no-number on API failure, and `formatStars` (10870 → "10.9k"). The toast calls
+`githubStars.load()` and reads `githubStars.count`. Because the cache is shared with
+the header badge, the toast adds no GitHub request in the common case.
+
+`connect-src` is deliberately unset in `web/svelte.config.js` (and there is no
+`default-src`), so the call to `api.github.com` is not a CSP concern. The pinned
+`img-src` is untouched — the toast ships no external image.
+
+### Dismissal
+
+Key `hire.support-toast-dismissed`, permanent. Clicking through to GitHub dismisses it
+exactly as the close button does: someone who went to star the repo must not be asked
+again.
+
+Storage failures follow the Product Hunt precedent — an unreadable store reads as "not
+dismissed", an unwritable one makes the dismissal last for the page only. A promo
+banner must never throw inside the layout.
+
+### Route exclusion
+
+Not shown on `/open`. That page is the open-source pitch; a toast repeating it is
+noise.
+
+## Components
+
+| File | Role |
+|---|---|
+| `web/src/lib/supportToast.ts` | new — show condition and dismissal persistence, no runes, no `$lib` imports |
+| `web/src/lib/supportToast.test.ts` | new — gate table and storage-failure cases |
+| `web/src/lib/components/SupportToast.svelte` | new — markup, mount gate, route exclusion |
+| `web/src/routes/+layout.svelte` | edit — mount beside `<CookieConsent />` |
+
+`supportToast.ts` imports `./productHunt` by relative path, not through `$lib`: the
+project's vitest environment does not resolve the alias, and an aliased import fails at
+module load rather than in a test body.
+
+Untouched: `ProductHuntBanner.svelte`, `productHunt.ts`, `github.svelte.ts`,
+`app.html`, `svelte.config.js`.
+
+## Copy
+
+> **freehire is open source.** Free to use, and it stays that way because people star it.
+>
+> Star on GitHub ★ 1.2k →
+
+The count is omitted when `githubStars.count` is null, leaving a working link.
+
+## Testing
+
+`supportToast.test.ts` covers the gate — before launch with the strip untouched, strip
+dismissed, after launch, self-dismissed — and dismissal persistence when `localStorage`
+throws. Markup is not tested: the project has no `.svelte` test runner, and the unit
+suite runs plain `.ts` in a node environment.
+
+Manual check in a live browser, because two failure modes here are invisible to the
+build: the toast must not overlap the cookie banner on a narrow viewport, and it must
+not cover `HiddenToast`'s Undo.

--- a/openspec/changes/github-star-support-toast/.openspec.yaml
+++ b/openspec/changes/github-star-support-toast/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/github-star-support-toast/design.md
+++ b/openspec/changes/github-star-support-toast/design.md
@@ -62,6 +62,21 @@ Alternative considered: a new "the PH ask is done" flag written by the banner. R
 "the visitor closed the strip" is already an observable fact, and a second flag would have
 to be kept in step with the first.
 
+**The strip's dismissal becomes a shared reactive flag.** It used to live in
+`ProductHuntBanner`'s own `$state`, which was enough while that component was its only
+reader. A snapshot taken in the toast's `onMount` would leave the toast invisible for the
+rest of the session in which the visitor actually closed the strip — and before the launch
+day, closing the strip is the *only* way the toast can appear at all. So the flag moves to
+`phBanner.svelte.ts` and both surfaces read it. This removes a second source of truth
+rather than adding one; the strip's own behaviour is unchanged.
+
+**The corner has an order of precedence.** It now holds four surfaces, so the rule is
+worth stating: consent banner (an obligation) > Undo (a five-second window on a reversible
+action) > a page's own bottom-anchored call to action > this promo. The last of these is
+why the toast waits for `lg` on a job page, where the Apply bar is `lg:hidden` and sits on
+the same layer in the same box. Excluding job pages outright was rejected — they are the
+highest-traffic surface on the site, and the conflict only exists below `lg`.
+
 **Yield to consent, sit under Undo.** Consent is an obligation and a promo is not, so the
 toast does not render while `bannerVisible()` is true; because that is a rune-backed
 getter, the toast appears on its own once consent is settled, with no timer and no

--- a/openspec/changes/github-star-support-toast/design.md
+++ b/openspec/changes/github-star-support-toast/design.md
@@ -1,0 +1,110 @@
+## Context
+
+Two promo surfaces already exist and both are relevant.
+
+`ProductHuntBanner.svelte` is a strip under the header. It renders on the server and is
+hidden by a class the no-flash script in `app.html` sets before first paint, because the
+strip sits in the document flow and mounting it after hydration would shove the page down
+under someone already reading. Its wording follows the clock through `launchPhase()`, so
+it turns itself from "launches on 26 August" into "live today" and then retires — nobody
+ships a web build on launch day. It records dismissal under
+`hire.ph-banner-dismissed`.
+
+`github.svelte.ts` already fetches and caches the star count for the header badge: a
+singleton store with `$state`, an idempotent `load()`, a 6-hour `localStorage` cache under
+`hire.gh_stars`, silent degradation to no-number on failure, and `formatStars`.
+
+`CookieConsent.svelte` occupies the same corner the toast wants —
+`fixed inset-x-4 bottom-4 z-50 … sm:right-4 sm:max-w-md` — and gates on `bannerVisible()`
+from `consent.svelte.ts`. `HiddenToast.svelte` is the feed's Undo affordance at `z-40`.
+
+Constraint worth restating: the single inline `<script>` in `app.html` is allowed by the
+SHA-256 hash of its exact contents. Editing it breaks the hash silently, and the browser
+then blocks the whole block, anti-FOUC theme script included. `svelte-check`, vitest and
+`vite build` all stay green; the only symptom is a flash of the wrong theme.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ask for a GitHub star without ever competing with another ask on screen.
+- Reuse the star count already cached for the header badge — no second fetch path.
+- Keep the show condition pure and unit-tested.
+
+**Non-Goals:**
+
+- Changing the Product Hunt banner, its copy, or its retirement date.
+- Any backend, database, or API work.
+- Re-asking on a schedule. A dismissal is permanent.
+- Server-side rendering of the toast.
+
+## Decisions
+
+**Render after mount, not on the server.** The strip needed SSR plus a pre-paint class
+because it is in the document flow. A `fixed` toast moves nothing, so it can simply appear
+on mount. The payoff is that `app.html` is not touched, and the CSP hash stays intact.
+
+Alternative considered: mirroring the strip's SSR machinery for consistency. Rejected —
+it would mean editing the inline script for a second dismissal key, buying a silent CSP
+failure mode for a surface that does not need it.
+
+**Gate on the Product Hunt key plus the clock.**
+
+```
+show = !selfDismissed && (phBannerDismissed || launchPhase(now) === 'over')
+```
+
+The second disjunct is load-bearing: after 26 August the strip does not render, so its key
+can never be written, and a gate on the key alone would hide the toast from everyone
+arriving after launch day.
+
+Alternative considered: a new "the PH ask is done" flag written by the banner. Rejected —
+"the visitor closed the strip" is already an observable fact, and a second flag would have
+to be kept in step with the first.
+
+**Yield to consent, sit under Undo.** Consent is an obligation and a promo is not, so the
+toast does not render while `bannerVisible()` is true; because that is a rune-backed
+getter, the toast appears on its own once consent is settled, with no timer and no
+subscription. `z-30` puts the toast under `HiddenToast`'s `z-40`: Undo has a five-second
+window and a promo has no right to cover it.
+
+**Following the link dismisses.** Someone who went to star the repository has answered the
+ask. Treating only the close button as an answer would keep pestering exactly the people
+who complied.
+
+**Pure module, relative import.** The gate and the persistence live in
+`web/src/lib/supportToast.ts`, free of runes and of SvelteKit imports, so it unit-tests in
+the plain-node vitest environment the way `productHunt.ts` does. It imports
+`./productHunt` by relative path: the project's vitest setup does not resolve `$lib`, and
+an aliased import fails at module load rather than inside a test.
+
+**Storage failures follow the Product Hunt precedent.** An unreadable store reads as "not
+dismissed"; an unwritable one limits the dismissal to the current page. Showing a banner
+to someone who closed it is a smaller harm than a throw inside the layout.
+
+## Risks / Trade-offs
+
+- **The toast and the cookie banner both want the bottom-right corner** → they are mutually
+  exclusive by gate, so they can share the position; the exclusion is what makes it safe,
+  and it is covered by a scenario.
+- **On a narrow viewport the toast spans the width and can meet the centred Undo toast** →
+  `z-30` keeps Undo on top and clickable. Neither collision is visible to the build, so
+  both are on the manual check list.
+- **The gate depends on another surface's storage key** → a rename of
+  `hire.ph-banner-dismissed` would silently delay the toast until after launch day rather
+  than break a build. Mitigated by importing the key from `productHunt.ts` instead of
+  restating the literal.
+- **A permanent dismissal means one shot per visitor** → accepted. Re-asking a person who
+  already said no costs more goodwill than the marginal star is worth.
+- **The count can be stale by up to six hours** → accepted; it is the same number the header
+  badge shows, and a stale-but-instant number beats a spinner.
+
+## Migration Plan
+
+None. Additive frontend change, no schema and no API. Rollback is reverting the commit;
+the only residue is a `hire.support-toast-dismissed` key in some visitors' local storage,
+which is inert.
+
+## Open Questions
+
+None. Copy is set in the proposal and may be tuned at review without changing behaviour.

--- a/openspec/changes/github-star-support-toast/proposal.md
+++ b/openspec/changes/github-star-support-toast/proposal.md
@@ -14,11 +14,16 @@ read as nagging. The asks have to queue.
   repository, with the live star count when one is available.
 - The toast appears only once the Product Hunt strip has stopped asking — either the
   visitor closed it, or the launch day has passed and it retired itself.
-- The toast yields the corner to the cookie-consent banner and sits below the
-  hide-a-job Undo toast, so neither is ever covered.
+- The toast yields the corner to the cookie-consent banner, sits below the hide-a-job
+  Undo toast, and waits for desktop width on pages that anchor their own primary action
+  to the bottom of a narrow viewport — so nothing it does covers something that matters
+  more.
 - Dismissal is permanent, and following the link counts as dismissal.
 - Not shown on `/open`, which is itself the open-source pitch.
-- No change to the Product Hunt banner, the star store, `app.html`, or the CSP.
+- The Product Hunt strip's dismissal moves from its own component state into a shared
+  reactive flag, so the toast sees it as it happens rather than on the next page load.
+  The strip's behaviour, copy and retirement date are unchanged.
+- No change to the star store, `app.html`, or the CSP.
 
 ## Capabilities
 
@@ -34,12 +39,16 @@ dismissal it already records.
 
 ## Impact
 
-- `web/src/lib/supportToast.ts` (new) — show condition and dismissal persistence.
-- `web/src/lib/supportToast.test.ts` (new) — unit coverage for the gate.
-- `web/src/lib/components/SupportToast.svelte` (new) — markup and mount gate.
+- `web/src/lib/supportToast.ts` (new) — show condition, route rules, dismissal.
+- `web/src/lib/supportToast.test.ts` (new) — unit coverage for both.
+- `web/src/lib/phBanner.svelte.ts` (new) — the Product Hunt strip's dismissal as a shared
+  reactive flag.
+- `web/src/lib/components/SupportToast.svelte` (new) — markup and gate.
+- `web/src/lib/components/ProductHuntBanner.svelte` — reads and writes that flag instead
+  of holding its own copy.
 - `web/src/routes/+layout.svelte` — mounts the toast beside `<CookieConsent />`.
 
-Reads, without modifying: `productHunt.ts` (`launchPhase`, the dismissal key),
+Reads, without modifying: `productHunt.ts` (`launchPhase`, the dismissal helpers),
 `github.svelte.ts` (`githubStars`, `formatStars`, `GITHUB_URL`), `consent.svelte.ts`
 (`bannerVisible`).
 

--- a/openspec/changes/github-star-support-toast/proposal.md
+++ b/openspec/changes/github-star-support-toast/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+freehire is open source, but nothing on the site ever asks for the one form of support
+that costs a visitor nothing — a GitHub star. The footer links to the repository and the
+header shows a star count, yet neither asks.
+
+The ask cannot simply be stacked on what is already there: until 26 August the Product
+Hunt strip under the header occupies the "support us" slot, and two simultaneous pleas
+read as nagging. The asks have to queue.
+
+## What Changes
+
+- A new dismissible toast, floating bottom-right, asking the visitor to star the
+  repository, with the live star count when one is available.
+- The toast appears only once the Product Hunt strip has stopped asking — either the
+  visitor closed it, or the launch day has passed and it retired itself.
+- The toast yields the corner to the cookie-consent banner and sits below the
+  hide-a-job Undo toast, so neither is ever covered.
+- Dismissal is permanent, and following the link counts as dismissal.
+- Not shown on `/open`, which is itself the open-source pitch.
+- No change to the Product Hunt banner, the star store, `app.html`, or the CSP.
+
+## Capabilities
+
+### New Capabilities
+- `open-source-support-toast`: when the site may ask a visitor to star the repository,
+  how that ask queues behind the Product Hunt strip and the consent banner, and when it
+  stops being shown.
+
+### Modified Capabilities
+
+None. The Product Hunt banner keeps its current behaviour; the new toast only reads the
+dismissal it already records.
+
+## Impact
+
+- `web/src/lib/supportToast.ts` (new) — show condition and dismissal persistence.
+- `web/src/lib/supportToast.test.ts` (new) — unit coverage for the gate.
+- `web/src/lib/components/SupportToast.svelte` (new) — markup and mount gate.
+- `web/src/routes/+layout.svelte` — mounts the toast beside `<CookieConsent />`.
+
+Reads, without modifying: `productHunt.ts` (`launchPhase`, the dismissal key),
+`github.svelte.ts` (`githubStars`, `formatStars`, `GITHUB_URL`), `consent.svelte.ts`
+(`bannerVisible`).
+
+No backend, database, or API surface is touched. No new external request in the common
+case: the star count comes from the cache the header badge already fills.

--- a/openspec/changes/github-star-support-toast/specs/open-source-support-toast/spec.md
+++ b/openspec/changes/github-star-support-toast/specs/open-source-support-toast/spec.md
@@ -40,7 +40,7 @@ support, so that the visitor never faces two pleas at once.
 
 - **WHEN** the visitor has closed the Product Hunt strip and the launch day has not
   passed
-- **THEN** the toast is shown
+- **THEN** the toast is shown, in that same session and without a reload
 
 #### Scenario: The launch day has passed
 
@@ -48,10 +48,11 @@ support, so that the visitor never faces two pleas at once.
   can no longer be closed
 - **THEN** the toast is shown, whether or not the strip was ever closed
 
-### Requirement: The ask yields to obligations and to reversible actions
+### Requirement: The ask yields to obligations, reversible actions, and primary actions
 
-The toast SHALL NOT be shown while the cookie-consent banner awaits a decision, and
-SHALL be layered below the hide-a-job Undo toast.
+The toast SHALL NOT be shown while the cookie-consent banner awaits a decision, SHALL be
+layered below the hide-a-job Undo toast, and SHALL NOT cover a page's own call to action
+anchored to the bottom of the viewport.
 
 #### Scenario: Consent is undecided
 
@@ -67,6 +68,13 @@ SHALL be layered below the hide-a-job Undo toast.
 
 - **WHEN** the hide-a-job Undo toast and the support toast are on screen together
 - **THEN** the Undo toast is drawn above the support toast and stays clickable
+
+#### Scenario: A page anchors its own action to the bottom
+
+- **WHEN** the visitor is on a job page at a width where its Apply bar is anchored to the
+  bottom of the viewport
+- **THEN** the toast is not shown, and it returns at the width where that bar is no longer
+  rendered
 
 ### Requirement: The ask is made once
 

--- a/openspec/changes/github-star-support-toast/specs/open-source-support-toast/spec.md
+++ b/openspec/changes/github-star-support-toast/specs/open-source-support-toast/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: The site asks the visitor to star the repository
+
+The site SHALL show a dismissible toast inviting the visitor to star the freehire
+repository on GitHub, stating that the project is open source.
+
+The toast SHALL float above the page rather than occupy the document flow, so that it
+never shifts content a visitor is already reading.
+
+#### Scenario: The invitation is shown
+
+- **WHEN** the toast is shown
+- **THEN** it names freehire as open source, and offers a link to the repository on
+  GitHub that opens in a new tab
+
+#### Scenario: The star count is shown when known
+
+- **WHEN** the toast is shown and a star count is available
+- **THEN** the count is rendered next to the link in compact form
+
+#### Scenario: The star count is unavailable
+
+- **WHEN** the toast is shown and no star count is available, because the cache is empty
+  and the GitHub API did not answer
+- **THEN** the toast is still shown, with a working link and no number
+
+### Requirement: The ask queues behind the Product Hunt strip
+
+The toast SHALL NOT be shown while the Product Hunt launch strip is still asking for
+support, so that the visitor never faces two pleas at once.
+
+#### Scenario: The launch strip is still asking
+
+- **WHEN** the launch day has not passed and the visitor has not closed the Product Hunt
+  strip
+- **THEN** the toast is not shown
+
+#### Scenario: The visitor closed the launch strip
+
+- **WHEN** the visitor has closed the Product Hunt strip and the launch day has not
+  passed
+- **THEN** the toast is shown
+
+#### Scenario: The launch day has passed
+
+- **WHEN** the launch day has passed, so the Product Hunt strip no longer renders and
+  can no longer be closed
+- **THEN** the toast is shown, whether or not the strip was ever closed
+
+### Requirement: The ask yields to obligations and to reversible actions
+
+The toast SHALL NOT be shown while the cookie-consent banner awaits a decision, and
+SHALL be layered below the hide-a-job Undo toast.
+
+#### Scenario: Consent is undecided
+
+- **WHEN** the cookie-consent banner is visible
+- **THEN** the toast is not shown
+
+#### Scenario: Consent is settled
+
+- **WHEN** the visitor accepts or rejects cookies and the consent banner disappears
+- **THEN** the toast appears without a reload, provided its other conditions hold
+
+#### Scenario: An Undo is on screen
+
+- **WHEN** the hide-a-job Undo toast and the support toast are on screen together
+- **THEN** the Undo toast is drawn above the support toast and stays clickable
+
+### Requirement: The ask is made once
+
+Once the visitor has answered the ask — by closing the toast or by following the link —
+the toast SHALL NOT be shown again.
+
+#### Scenario: The visitor closes the toast
+
+- **WHEN** the visitor closes the toast
+- **THEN** it is not shown again on any later page or visit
+
+#### Scenario: The visitor follows the link
+
+- **WHEN** the visitor follows the link to GitHub
+- **THEN** the toast is treated as answered and is not shown again
+
+#### Scenario: Local storage is unavailable
+
+- **WHEN** local storage cannot be read or written, as in a private-mode or blocked
+  origin
+- **THEN** the toast neither throws nor blocks the page; an unreadable store reads as
+  "not answered", and an unwritable one limits the dismissal to the current page
+
+### Requirement: The ask is absent where it would be redundant
+
+The toast SHALL NOT be shown on the open-source page, which already makes the same case
+at length.
+
+#### Scenario: Visiting the open-source page
+
+- **WHEN** the visitor is on `/open`
+- **THEN** the toast is not shown, and no dismissal is recorded

--- a/openspec/changes/github-star-support-toast/tasks.md
+++ b/openspec/changes/github-star-support-toast/tasks.md
@@ -1,34 +1,50 @@
 ## 1. Show condition and dismissal (pure module)
 
-- [ ] 1.1 Write `web/src/lib/supportToast.test.ts` covering the gate: the Product Hunt
+- [x] 1.1 Write `web/src/lib/supportToast.test.ts` covering the gate: the Product Hunt
       strip still asking, the strip dismissed before launch day, the launch day passed
       with the strip never dismissed, and the toast already dismissed. Watch it fail.
-- [ ] 1.2 Write `web/src/lib/supportToast.ts` with the dismissal key, `readDismissed` /
-      `writeDismissed`, and a pure `shouldShow`. Import `./productHunt` by relative path
-      and reuse its dismissal key rather than restating the literal.
-- [ ] 1.3 Extend the test with storage failures — an unreadable store reads as "not
+- [x] 1.2 Write `web/src/lib/supportToast.ts` with the dismissal key, `readDismissed` /
+      `writeDismissed`, and a pure `shouldShow`. Import `./productHunt` by relative path.
+- [x] 1.3 Extend the test with storage failures — an unreadable store reads as "not
       dismissed", an unwritable one throws nothing — and make them pass.
 
 ## 2. The toast
 
-- [ ] 2.1 Create `web/src/lib/components/SupportToast.svelte`: read the gate on mount,
+- [x] 2.1 Create `web/src/lib/components/SupportToast.svelte`: read the gate on mount,
       call `githubStars.load()`, render the count via `formatStars` when present and the
       bare link when not, close on the button and on following the link.
-- [ ] 2.2 Gate the render on `bannerVisible()` from `consent.svelte` and on the route not
+- [x] 2.2 Gate the render on `bannerVisible()` from `consent.svelte` and on the route not
       being `/open`.
-- [ ] 2.3 Position it bottom-right at `z-30`, matching the consent banner's box so the
+- [x] 2.3 Position it bottom-right at `z-30`, matching the consent banner's box so the
       two never disagree about the corner.
 
 ## 3. Wiring
 
-- [ ] 3.1 Mount `<SupportToast />` in `web/src/routes/+layout.svelte` beside
+- [x] 3.1 Mount `<SupportToast />` in `web/src/routes/+layout.svelte` beside
       `<CookieConsent />`, outside the flex column, with a comment saying why it is not
       next to `<ProductHuntBanner />`.
 
 ## 4. Verification
 
-- [ ] 4.1 Run the unit suite and `svelte-check`; both green.
-- [ ] 4.2 Check in a live browser: the toast does not appear while the consent banner is
+- [x] 4.1 Run the unit suite and `svelte-check`; both green.
+- [x] 4.2 Check in a live browser: the toast does not appear while the consent banner is
       up, appears once consent is settled and the Product Hunt strip is closed, does not
       cover the hide-a-job Undo, and does not overlap the consent banner on a narrow
       viewport.
+
+## 5. From code review
+
+- [x] 5.1 Move the Product Hunt strip's dismissal into a shared reactive flag
+      (`web/src/lib/phBanner.svelte.ts`), so closing the strip reveals the toast in the
+      same session rather than on the next page load — before the launch day that is the
+      only path to the toast at all.
+- [x] 5.2 Stop the toast covering the job page's sticky mobile Apply bar: add the pure
+      `ownsMobileStickyCta` rule and hold the toast to `lg` and up on those routes.
+- [x] 5.3 Move the route rules into the pure module and cover them with tests; add the
+      missing `'live'`-phase case; replace the tautological key-comparison test with one
+      asserting `writeDismissed()` leaves the Product Hunt key alone.
+- [x] 5.4 Accessibility and copy: `role="complementary"` with a label instead of
+      `role="status"` (a standing promo must not be announced as a live status), a
+      qualified dismiss label, and copy that no longer claims stars keep the site free.
+- [x] 5.5 Update the proposal, design and spec to match — including the new scenarios for
+      the in-session reveal and for a page's own bottom-anchored action.

--- a/openspec/changes/github-star-support-toast/tasks.md
+++ b/openspec/changes/github-star-support-toast/tasks.md
@@ -1,0 +1,34 @@
+## 1. Show condition and dismissal (pure module)
+
+- [ ] 1.1 Write `web/src/lib/supportToast.test.ts` covering the gate: the Product Hunt
+      strip still asking, the strip dismissed before launch day, the launch day passed
+      with the strip never dismissed, and the toast already dismissed. Watch it fail.
+- [ ] 1.2 Write `web/src/lib/supportToast.ts` with the dismissal key, `readDismissed` /
+      `writeDismissed`, and a pure `shouldShow`. Import `./productHunt` by relative path
+      and reuse its dismissal key rather than restating the literal.
+- [ ] 1.3 Extend the test with storage failures — an unreadable store reads as "not
+      dismissed", an unwritable one throws nothing — and make them pass.
+
+## 2. The toast
+
+- [ ] 2.1 Create `web/src/lib/components/SupportToast.svelte`: read the gate on mount,
+      call `githubStars.load()`, render the count via `formatStars` when present and the
+      bare link when not, close on the button and on following the link.
+- [ ] 2.2 Gate the render on `bannerVisible()` from `consent.svelte` and on the route not
+      being `/open`.
+- [ ] 2.3 Position it bottom-right at `z-30`, matching the consent banner's box so the
+      two never disagree about the corner.
+
+## 3. Wiring
+
+- [ ] 3.1 Mount `<SupportToast />` in `web/src/routes/+layout.svelte` beside
+      `<CookieConsent />`, outside the flex column, with a comment saying why it is not
+      next to `<ProductHuntBanner />`.
+
+## 4. Verification
+
+- [ ] 4.1 Run the unit suite and `svelte-check`; both green.
+- [ ] 4.2 Check in a live browser: the toast does not appear while the consent banner is
+      up, appears once consent is settled and the Product Hunt strip is closed, does not
+      cover the hide-a-job Undo, and does not overlap the consent banner on a narrow
+      viewport.

--- a/web/src/lib/components/ProductHuntBanner.svelte
+++ b/web/src/lib/components/ProductHuntBanner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { launchPhase, PH_URL, readDismissed, writeDismissed } from '$lib/productHunt';
+  import { launchPhase, PH_URL } from '$lib/productHunt';
+  import { dismissPhBanner, loadPhBannerDismissed, phBannerDismissed } from '$lib/phBanner.svelte';
 
   // A strip under the header pointing at the Product Hunt page, dismissible and
   // remembered. Self-gating like EmailVerificationBanner, so the layout mounts it
@@ -18,21 +19,16 @@
 
   const phase = launchPhase(Date.now());
 
-  // Starts false so the hydrated markup matches the server's; the real value arrives
-  // on mount, by which point CSS has already hidden the strip for anyone who closed it.
-  let dismissed = $state(false);
-
+  // The flag starts false so the hydrated markup matches the server's; the real value
+  // arrives on mount, by which point CSS has already hidden the strip for anyone who
+  // closed it. It lives in a shared store rather than here because SupportToast queues
+  // behind this strip and must see the dismissal as it happens.
   onMount(() => {
-    dismissed = readDismissed();
+    loadPhBannerDismissed();
   });
-
-  function dismiss() {
-    dismissed = true;
-    writeDismissed();
-  }
 </script>
 
-{#if phase !== 'over' && !dismissed}
+{#if phase !== 'over' && !phBannerDismissed()}
   <div data-ph-banner class="border-b border-border bg-brand/5">
     <div class="mx-auto flex w-full max-w-6xl items-center gap-3 px-4 py-2.5 text-sm">
       <p class="min-w-0 flex-1 text-muted-foreground">
@@ -62,7 +58,7 @@
 
       <button
         type="button"
-        onclick={dismiss}
+        onclick={dismissPhBanner}
         aria-label="Dismiss"
         class="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
       >

--- a/web/src/lib/components/SupportToast.svelte
+++ b/web/src/lib/components/SupportToast.svelte
@@ -4,7 +4,15 @@
   import { Star, X } from '@lucide/svelte';
   import { githubStars, formatStars, GITHUB_URL } from '$lib/github.svelte';
   import { bannerVisible } from '$lib/consent.svelte';
-  import { readDismissed, readPhBannerDismissed, shouldShow, writeDismissed } from '$lib/supportToast';
+  import { phBannerDismissed } from '$lib/phBanner.svelte';
+  import { cn } from '$lib/ui';
+  import {
+    ownsMobileStickyCta,
+    readDismissed,
+    shouldShow,
+    suppressesToast,
+    writeDismissed,
+  } from '$lib/supportToast';
 
   // A floating ask for a GitHub star, self-gating so the layout mounts it unconditionally.
   //
@@ -14,51 +22,64 @@
   // class in app.html, and why that file (and the CSP hash over its inline script) stays
   // untouched.
   //
-  // It also yields the bottom-right corner to the consent banner, which wants the same
-  // box: consent is an obligation, a promo is not. `bannerVisible` is rune-backed, so the
-  // toast appears on its own the moment consent is settled — no timer, no subscription.
+  // Everything it depends on is reactive: the strip's dismissal, the consent banner, the
+  // route. Only the visitor's own answer is read once, on mount, because nothing else in
+  // the session can change it.
 
-  // Starts false so nothing flashes before the gate has been read; storage is only
-  // reachable after mount anyway.
-  let allowed = $state(false);
+  // Starts true so the gate is decided by mount-time storage rather than flashing first;
+  // `mounted` keeps the toast off the server-rendered pass.
+  let mounted = $state(false);
+  let answered = $state(true);
 
   onMount(() => {
-    allowed = shouldShow({
-      now: Date.now(),
-      phBannerDismissed: readPhBannerDismissed(),
-      selfDismissed: readDismissed(),
-    });
-    if (allowed) void githubStars.load();
+    answered = readDismissed();
+    mounted = true;
+    if (!answered) void githubStars.load();
   });
 
-  // /open is the open-source pitch in full; repeating it in a toast is noise.
-  const visible = $derived(allowed && !bannerVisible() && page.url.pathname !== '/open');
+  const visible = $derived(
+    mounted &&
+      shouldShow({
+        now: Date.now(),
+        phBannerDismissed: phBannerDismissed(),
+        selfDismissed: answered,
+      }) &&
+      !bannerVisible() &&
+      !suppressesToast(page.url.pathname),
+  );
 
   const count = $derived(githubStars.count);
 
   // Following the link answers the ask as surely as closing the toast does — someone who
   // went to star the repo must not be asked again.
   function dismiss() {
-    allowed = false;
+    answered = true;
     writeDismissed();
   }
 </script>
 
 {#if visible}
   <div
-    role="status"
-    class="fixed inset-x-4 bottom-4 z-30 rounded-lg border border-border bg-background/95 px-4 py-3 shadow-lg backdrop-blur sm:inset-x-auto sm:right-4 sm:max-w-md"
+    role="complementary"
+    aria-label="Support freehire"
+    class={cn(
+      'fixed inset-x-4 bottom-4 z-30 rounded-lg border border-border bg-background/95 px-4 py-3 shadow-lg backdrop-blur sm:inset-x-auto sm:right-4 sm:max-w-md',
+      // The job page anchors its Apply button to the same corner on the same layer below
+      // `lg`. A promo never covers a page's own primary action, so here the toast waits
+      // for the width at which that bar is gone.
+      ownsMobileStickyCta(page.url.pathname) && 'hidden lg:block',
+    )}
   >
     <div class="flex items-start gap-3">
       <p class="min-w-0 flex-1 text-sm text-muted-foreground">
         <span class="font-medium text-foreground">freehire is open source.</span>
-        Free to use, and it stays that way because people star it.
+        Stars are how people find it.
       </p>
 
       <button
         type="button"
         onclick={dismiss}
-        aria-label="Dismiss"
+        aria-label="Dismiss support request"
         class="-mr-1 -mt-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
       >
         <X class="size-4" aria-hidden="true" />

--- a/web/src/lib/components/SupportToast.svelte
+++ b/web/src/lib/components/SupportToast.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/state';
+  import { Star, X } from '@lucide/svelte';
+  import { githubStars, formatStars, GITHUB_URL } from '$lib/github.svelte';
+  import { bannerVisible } from '$lib/consent.svelte';
+  import { readDismissed, readPhBannerDismissed, shouldShow, writeDismissed } from '$lib/supportToast';
+
+  // A floating ask for a GitHub star, self-gating so the layout mounts it unconditionally.
+  //
+  // It queues behind the Product Hunt strip rather than competing with it: `shouldShow`
+  // holds it back until that strip has stopped asking. Unlike the strip, this surface is
+  // `fixed` and so moves nothing — which is why it needs neither SSR nor the pre-paint
+  // class in app.html, and why that file (and the CSP hash over its inline script) stays
+  // untouched.
+  //
+  // It also yields the bottom-right corner to the consent banner, which wants the same
+  // box: consent is an obligation, a promo is not. `bannerVisible` is rune-backed, so the
+  // toast appears on its own the moment consent is settled — no timer, no subscription.
+
+  // Starts false so nothing flashes before the gate has been read; storage is only
+  // reachable after mount anyway.
+  let allowed = $state(false);
+
+  onMount(() => {
+    allowed = shouldShow({
+      now: Date.now(),
+      phBannerDismissed: readPhBannerDismissed(),
+      selfDismissed: readDismissed(),
+    });
+    if (allowed) void githubStars.load();
+  });
+
+  // /open is the open-source pitch in full; repeating it in a toast is noise.
+  const visible = $derived(allowed && !bannerVisible() && page.url.pathname !== '/open');
+
+  const count = $derived(githubStars.count);
+
+  // Following the link answers the ask as surely as closing the toast does — someone who
+  // went to star the repo must not be asked again.
+  function dismiss() {
+    allowed = false;
+    writeDismissed();
+  }
+</script>
+
+{#if visible}
+  <div
+    role="status"
+    class="fixed inset-x-4 bottom-4 z-30 rounded-lg border border-border bg-background/95 px-4 py-3 shadow-lg backdrop-blur sm:inset-x-auto sm:right-4 sm:max-w-md"
+  >
+    <div class="flex items-start gap-3">
+      <p class="min-w-0 flex-1 text-sm text-muted-foreground">
+        <span class="font-medium text-foreground">freehire is open source.</span>
+        Free to use, and it stays that way because people star it.
+      </p>
+
+      <button
+        type="button"
+        onclick={dismiss}
+        aria-label="Dismiss"
+        class="-mr-1 -mt-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      >
+        <X class="size-4" aria-hidden="true" />
+      </button>
+    </div>
+
+    <!-- Block form, not disable-next-line: the tag spans several lines, so the href the
+         rule fires on is not the line after the comment. -->
+    <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an internal route -->
+    <a
+      href={GITHUB_URL}
+      target="_blank"
+      rel="noreferrer"
+      onclick={dismiss}
+      class="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-brand underline-offset-4 hover:underline"
+    >
+      <Star class="size-4" aria-hidden="true" />
+      Star on GitHub
+      {#if count != null}
+        <span class="tabular-nums text-muted-foreground">{formatStars(count)}</span>
+      {/if}
+    </a>
+    <!-- eslint-enable svelte/no-navigation-without-resolve -->
+  </div>
+{/if}

--- a/web/src/lib/phBanner.svelte.ts
+++ b/web/src/lib/phBanner.svelte.ts
@@ -1,0 +1,28 @@
+import { readDismissed, writeDismissed } from './productHunt';
+
+// Whether the Product Hunt strip has stopped asking, as a reactive fact rather than a
+// storage read taken once.
+//
+// The strip used to keep this in its own `$state`, which was enough while it was the only
+// reader. The support toast queues behind it and has to notice the moment it happens: a
+// snapshot taken at mount would leave the toast invisible for the rest of the session the
+// visitor actually closed the strip in — and before the launch day that is the only way
+// the toast can appear at all.
+
+let dismissed = $state(false);
+
+/** Reactive: whether the visitor has closed the strip. */
+export function phBannerDismissed(): boolean {
+  return dismissed;
+}
+
+/** Seed the flag from storage. Called from the strip's `onMount`; safe to call again. */
+export function loadPhBannerDismissed(): void {
+  dismissed = readDismissed();
+}
+
+/** Record the dismissal for this session and the next. */
+export function dismissPhBanner(): void {
+  dismissed = true;
+  writeDismissed();
+}

--- a/web/src/lib/supportToast.test.ts
+++ b/web/src/lib/supportToast.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { LAUNCH_OPENS_AT, PH_DISMISSED_KEY } from './productHunt';
+import {
+  readDismissed,
+  readPhBannerDismissed,
+  shouldShow,
+  SUPPORT_DISMISSED_KEY,
+  writeDismissed,
+} from './supportToast';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+const BEFORE_LAUNCH = LAUNCH_OPENS_AT - DAY;
+const AFTER_LAUNCH = LAUNCH_OPENS_AT + DAY + 1;
+
+describe('shouldShow', () => {
+  it('stays hidden while the Product Hunt strip is still asking', () => {
+    expect(
+      shouldShow({ now: BEFORE_LAUNCH, phBannerDismissed: false, selfDismissed: false }),
+    ).toBe(false);
+  });
+
+  it('appears once the visitor has closed the Product Hunt strip', () => {
+    expect(
+      shouldShow({ now: BEFORE_LAUNCH, phBannerDismissed: true, selfDismissed: false }),
+    ).toBe(true);
+  });
+
+  it('appears after the launch day, when the strip can no longer be closed', () => {
+    expect(
+      shouldShow({ now: AFTER_LAUNCH, phBannerDismissed: false, selfDismissed: false }),
+    ).toBe(true);
+  });
+
+  it('stays hidden once the visitor has answered it', () => {
+    expect(
+      shouldShow({ now: AFTER_LAUNCH, phBannerDismissed: true, selfDismissed: true }),
+    ).toBe(false);
+  });
+});
+
+// The node environment has no localStorage at all, so each test installs the one it
+// needs and removes it afterwards.
+function installStorage(store: Map<string, string>) {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+    },
+  });
+}
+
+/** A blocked origin or Safari private mode: every access throws. */
+function installHostileStorage() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    get() {
+      throw new Error('access denied');
+    },
+  });
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'localStorage');
+});
+
+describe('dismissal', () => {
+  it('round-trips through storage', () => {
+    installStorage(new Map());
+
+    expect(readDismissed()).toBe(false);
+    writeDismissed();
+    expect(readDismissed()).toBe(true);
+  });
+
+  it('reads the Product Hunt strip’s own key', () => {
+    installStorage(new Map([[PH_DISMISSED_KEY, '1']]));
+
+    expect(readPhBannerDismissed()).toBe(true);
+    expect(readDismissed()).toBe(false);
+  });
+
+  it('reads as unanswered when storage is unavailable', () => {
+    installHostileStorage();
+
+    expect(readDismissed()).toBe(false);
+    expect(readPhBannerDismissed()).toBe(false);
+  });
+
+  it('does not throw when the dismissal cannot be stored', () => {
+    installHostileStorage();
+
+    expect(() => writeDismissed()).not.toThrow();
+  });
+
+  it('keeps the two surfaces on separate keys', () => {
+    expect(SUPPORT_DISMISSED_KEY).not.toBe(PH_DISMISSED_KEY);
+  });
+});

--- a/web/src/lib/supportToast.test.ts
+++ b/web/src/lib/supportToast.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { LAUNCH_OPENS_AT, PH_DISMISSED_KEY } from './productHunt';
 import {
+  ownsMobileStickyCta,
   readDismissed,
-  readPhBannerDismissed,
   shouldShow,
   SUPPORT_DISMISSED_KEY,
+  suppressesToast,
   writeDismissed,
 } from './supportToast';
 
@@ -32,10 +33,41 @@ describe('shouldShow', () => {
     ).toBe(true);
   });
 
+  it('stays hidden through the launch day itself, when the strip asks loudest', () => {
+    expect(
+      shouldShow({
+        now: LAUNCH_OPENS_AT + 12 * 60 * 60 * 1000,
+        phBannerDismissed: false,
+        selfDismissed: false,
+      }),
+    ).toBe(false);
+  });
+
   it('stays hidden once the visitor has answered it', () => {
     expect(
       shouldShow({ now: AFTER_LAUNCH, phBannerDismissed: true, selfDismissed: true }),
     ).toBe(false);
+  });
+});
+
+describe('route rules', () => {
+  it('suppresses the toast on the open-source page', () => {
+    expect(suppressesToast('/open')).toBe(true);
+  });
+
+  it('allows the toast elsewhere', () => {
+    expect(suppressesToast('/')).toBe(false);
+    expect(suppressesToast('/jobs')).toBe(false);
+    expect(suppressesToast('/openings')).toBe(false);
+  });
+
+  it('marks the job page as owning a sticky mobile call to action', () => {
+    expect(ownsMobileStickyCta('/jobs/senior-go-engineer-acme')).toBe(true);
+  });
+
+  it('does not mark the listing or other sections', () => {
+    expect(ownsMobileStickyCta('/jobs')).toBe(false);
+    expect(ownsMobileStickyCta('/companies/acme')).toBe(false);
   });
 });
 
@@ -74,18 +106,20 @@ describe('dismissal', () => {
     expect(readDismissed()).toBe(true);
   });
 
-  it('reads the Product Hunt strip’s own key', () => {
-    installStorage(new Map([[PH_DISMISSED_KEY, '1']]));
+  it('leaves the Product Hunt strip’s own key alone', () => {
+    const store = new Map([[PH_DISMISSED_KEY, '1']]);
+    installStorage(store);
 
-    expect(readPhBannerDismissed()).toBe(true);
-    expect(readDismissed()).toBe(false);
+    writeDismissed();
+
+    expect(store.get(PH_DISMISSED_KEY)).toBe('1');
+    expect(store.get(SUPPORT_DISMISSED_KEY)).toBe('1');
   });
 
   it('reads as unanswered when storage is unavailable', () => {
     installHostileStorage();
 
     expect(readDismissed()).toBe(false);
-    expect(readPhBannerDismissed()).toBe(false);
   });
 
   it('does not throw when the dismissal cannot be stored', () => {
@@ -94,7 +128,4 @@ describe('dismissal', () => {
     expect(() => writeDismissed()).not.toThrow();
   });
 
-  it('keeps the two surfaces on separate keys', () => {
-    expect(SUPPORT_DISMISSED_KEY).not.toBe(PH_DISMISSED_KEY);
-  });
 });

--- a/web/src/lib/supportToast.ts
+++ b/web/src/lib/supportToast.ts
@@ -11,7 +11,7 @@
 // nothing, so it can appear on mount — which is why `app.html` stays untouched and the
 // SHA-256 CSP hash over its inline script stays intact.
 
-import { launchPhase, PH_DISMISSED_KEY } from './productHunt';
+import { launchPhase } from './productHunt';
 
 /** localStorage key holding the visitor's answer to the star request. */
 export const SUPPORT_DISMISSED_KEY = 'hire.support-toast-dismissed';
@@ -41,16 +41,29 @@ export function shouldShow({ now, phBannerDismissed, selfDismissed }: SupportToa
   return phBannerDismissed || launchPhase(now) === 'over';
 }
 
+/** Pages that make this exact case at length already, where a toast repeating it is
+ *  noise. */
+export function suppressesToast(pathname: string): boolean {
+  return pathname === '/open';
+}
+
+/**
+ * Whether the page owns a sticky call to action anchored to the bottom of a narrow
+ * viewport — currently the job page's mobile Apply bar, which is `lg:hidden` and sits on
+ * the same layer in the same corner.
+ *
+ * A promo must never cover a page's own primary action, so on these routes the toast is
+ * shown from `lg` up only, where the bar is not rendered. The rule deliberately matches
+ * any single segment under `/jobs/`: keeping a list of static siblings in step with the
+ * router would be more fragile than occasionally hiding a promo on a phone.
+ */
+export function ownsMobileStickyCta(pathname: string): boolean {
+  return /^\/jobs\/[^/]+$/.test(pathname);
+}
+
 /** Whether the visitor has answered the ask. */
 export function readDismissed(): boolean {
   return readFlag(SUPPORT_DISMISSED_KEY);
-}
-
-/** Whether the visitor has closed the Product Hunt strip. Reads that surface's own key
- *  rather than restating the literal, so a rename there breaks the build here instead of
- *  leaving a toast that silently waits until after the launch day. */
-export function readPhBannerDismissed(): boolean {
-  return readFlag(PH_DISMISSED_KEY);
 }
 
 /** Record that the visitor answered — by closing the toast, or by following the link.

--- a/web/src/lib/supportToast.ts
+++ b/web/src/lib/supportToast.ts
@@ -1,0 +1,76 @@
+// Open-source support toast: the show condition and the dismissal, kept free of Svelte
+// runes and SvelteKit imports so it unit-tests in the plain-node vitest environment. The
+// markup lives in components/SupportToast.svelte.
+//
+// `./productHunt` is imported by relative path on purpose: the project's vitest setup
+// does not resolve `$lib`, and an aliased import fails at module load rather than inside
+// a test body.
+//
+// Unlike the Product Hunt strip this surface never renders on the server. The strip needs
+// SSR plus a pre-paint class because it sits in the document flow; a fixed toast moves
+// nothing, so it can appear on mount — which is why `app.html` stays untouched and the
+// SHA-256 CSP hash over its inline script stays intact.
+
+import { launchPhase, PH_DISMISSED_KEY } from './productHunt';
+
+/** localStorage key holding the visitor's answer to the star request. */
+export const SUPPORT_DISMISSED_KEY = 'hire.support-toast-dismissed';
+
+/** What the show condition needs to know. Passed in rather than read inside, so the rule
+ *  itself is pure and the storage reads stay at the edge. */
+export type SupportToastState = {
+  /** Now, in epoch milliseconds. */
+  now: number;
+  /** Whether the visitor has closed the Product Hunt strip. */
+  phBannerDismissed: boolean;
+  /** Whether the visitor has already answered this toast. */
+  selfDismissed: boolean;
+};
+
+/**
+ * Whether the site may ask for a star right now.
+ *
+ * Two rules meet here. An answered toast never returns. And the ask queues behind the
+ * Product Hunt strip, which stops asking in two different ways: the visitor closes it, or
+ * the launch day passes and it retires itself. Only the first leaves a key behind — after
+ * the launch day the strip does not render and can never be closed, so gating on the key
+ * alone would hide this toast from everyone who arrives later.
+ */
+export function shouldShow({ now, phBannerDismissed, selfDismissed }: SupportToastState): boolean {
+  if (selfDismissed) return false;
+  return phBannerDismissed || launchPhase(now) === 'over';
+}
+
+/** Whether the visitor has answered the ask. */
+export function readDismissed(): boolean {
+  return readFlag(SUPPORT_DISMISSED_KEY);
+}
+
+/** Whether the visitor has closed the Product Hunt strip. Reads that surface's own key
+ *  rather than restating the literal, so a rename there breaks the build here instead of
+ *  leaving a toast that silently waits until after the launch day. */
+export function readPhBannerDismissed(): boolean {
+  return readFlag(PH_DISMISSED_KEY);
+}
+
+/** Record that the visitor answered — by closing the toast, or by following the link.
+ *  Silently a no-op when storage is unavailable; the toast then returns on the next page
+ *  load. */
+export function writeDismissed(): void {
+  try {
+    localStorage.setItem(SUPPORT_DISMISSED_KEY, '1');
+  } catch {
+    /* storage unavailable; the dismissal lasts for this page only */
+  }
+}
+
+/** Unavailable storage (Safari private mode, a blocked origin) reads as "not set" —
+ *  showing a toast to someone who closed it is a smaller harm than a throw in the
+ *  layout. */
+function readFlag(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
   import EmailVerificationBanner from '$lib/components/EmailVerificationBanner.svelte';
   import Footer from '$lib/components/Footer.svelte';
   import CookieConsent from '$lib/components/CookieConsent.svelte';
+  import SupportToast from '$lib/components/SupportToast.svelte';
   import '../app.css';
   // Country-flag icon sheet (used by $lib/components/Flag.svelte). References its
   // SVGs by URL, so the browser only fetches flags actually rendered.
@@ -117,6 +118,12 @@
 <!-- Consent banner: fixed-position, self-gating (renders only for a
      consent-required visitor with no choice, or when re-opened from the footer). -->
 <CookieConsent />
+
+<!-- Open-source support toast: fixed-position, so it belongs here rather than beside
+     <ProductHuntBanner /> up in the flow. Self-gating — it waits for the Product Hunt
+     strip to stop asking, yields this same corner to the consent banner above, and
+     retires for good once answered. -->
+<SupportToast />
 
 <style>
   /* Indeterminate sweep: the segment slides across the track on repeat while a


### PR DESCRIPTION
freehire is open source, but nothing on the site ever asked for the one form of support that costs a visitor nothing. The footer links to the repository and the header shows a star count; neither asks.

The ask could not simply be stacked on what is already there. Until 26 August the Product Hunt strip owns the "support us" slot, and two simultaneous pleas read as nagging. So the asks queue: the toast stays silent until that strip has stopped asking — either the visitor closed it, or the launch day passed and it retired itself. That second case is load-bearing, because after the launch day the strip does not render and its dismissal key can never be written.

### What it does

A dismissible toast, bottom-right, with the live star count when one is available. It reuses the store that already fills the header badge, so in the common case it adds no GitHub request and no second cache.

It yields the corner in a fixed order of precedence — consent banner, then the hide-a-job Undo, then a page's own bottom-anchored call to action, then this promo. That last rule is why it waits for `lg` on a job page, where the Apply bar is `lg:hidden` and sits on the same layer in the same box.

Dismissal is permanent, and following the link counts as an answer: someone who went to star the repo must not be asked again.

### Notes

`web/src/app.html` and `web/svelte.config.js` are untouched. The toast is `fixed`, so it moves nothing and needs neither SSR nor the pre-paint class the Product Hunt strip requires — which keeps it clear of the SHA-256 CSP hash over that file's inline script, a thing that breaks silently.

`ProductHuntBanner.svelte` changes in one respect: its dismissal moves from component state into a shared reactive flag, so the toast sees it as it happens rather than on the next page load. That removes a second source of truth rather than adding one; the strip's behaviour, copy and retirement date are unchanged.

### Verification

Unit tests cover the gate, the route rules and the storage-failure paths. Everything else was checked in a live browser at 1280x900 and 390x844: the strip-to-toast handoff without a reload, consent suppression and its release, `display: none` on a job page below `lg`, `/open` suppression and client-side navigation back, dismissal surviving a reload, and graceful degradation to a bare link with `api.github.com` blocked.

Not verified live: the layering against the hide-a-job Undo toast, which needs a populated feed. Confirmed by reading the z-index only (`z-30` against Undo's `z-40`).

OpenSpec change: `openspec/changes/github-star-support-toast/`