### PR TITLE
fix(web): stack the support toast's two sentences and name the site

### DIFF
--- a/web/src/lib/components/SupportToast.svelte
+++ b/web/src/lib/components/SupportToast.svelte
@@ -61,7 +61,7 @@
 {#if visible}
   <div
     role="complementary"
-    aria-label="Support freehire"
+    aria-label="Support freehire.me"
     class={cn(
       'fixed inset-x-4 bottom-4 z-30 rounded-lg border border-border bg-background/95 px-4 py-3 shadow-lg backdrop-blur sm:inset-x-auto sm:right-4 sm:max-w-md',
       // The job page anchors its Apply button to the same corner on the same layer below
@@ -71,10 +71,14 @@
     )}
   >
     <div class="flex items-start gap-3">
-      <p class="min-w-0 flex-1 text-sm text-muted-foreground">
-        <span class="font-medium text-foreground">freehire is open source.</span>
-        Stars are how people find it.
-      </p>
+      <!-- Two lines, not one wrapping paragraph. At phone width the single
+           paragraph broke after "find", leaving "it." alone on the second line;
+           stacking the sentences makes the break a layout decision instead of a
+           consequence of the string's length. -->
+      <div class="min-w-0 flex-1 text-sm">
+        <p class="font-medium text-foreground">freehire.me is open source.</p>
+        <p class="text-muted-foreground">Stars are how people find it.</p>
+      </div>
 
       <button
         type="button"


### PR DESCRIPTION
Follow-up to #1502, from looking at it on a real phone.

At phone width the toast's single paragraph broke after "find", leaving "it." alone on the second line. Picking shorter words would only move the problem to the next viewport, so the two sentences are now two elements: the break is a layout decision instead of a consequence of the string's length. Checked at 320, 360 and 430px — one line each.

The headline also names the site as **freehire.me** rather than freehire, and the toast's accessible label follows.

No logic touched: the gate, the route rules and the dismissal are unchanged.