### PR TITLE
fix(applyform): decode the board name Ashby's GraphQL takes as a variable

### DIFF
--- a/internal/applyform/fetch.go
+++ b/internal/applyform/fetch.go
@@ -3,6 +3,7 @@ package applyform
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -64,6 +65,23 @@ func splitBoardPosting(externalID string) (board, posting string, ok bool) {
 	return board, posting, true
 }
 
+// decodeBoardName undoes the percent-encoding a board name carries.
+//
+// Board names are stored as they appear in the board file, where they are already encoded
+// for the URL PATH the crawl adapter builds — Greenhouse and Ashby's posting API both take
+// the board as a path segment, so "stony%20creek%20homes" is correct there. Ashby's GraphQL
+// takes the organization as a VARIABLE, and an encoded name is simply a wrong name: the API
+// answers 200 with a null posting, so every board whose name carries a space would fail
+// every capture forever. A name that is not valid encoding is returned as it stands —
+// refusing to fetch would be worse than trying the literal.
+func decodeBoardName(board string) string {
+	decoded, err := url.PathUnescape(board)
+	if err != nil {
+		return board
+	}
+	return decoded
+}
+
 // greenhouseBaseURL is the job-board API. One host serves EU-hosted boards too, so unlike
 // Lever there is no regional base URL to pick between.
 const greenhouseBaseURL = "https://boards-api.greenhouse.io/v1/boards"
@@ -107,7 +125,7 @@ func (a ashbyFetcher) Fetch(ctx context.Context, board, postingID string) (Form,
 	body := map[string]any{
 		"operationName": "ApiJobPosting",
 		"variables": map[string]any{
-			"organizationHostedJobsPageName": board,
+			"organizationHostedJobsPageName": decodeBoardName(board),
 			"jobPostingId":                   postingID,
 		},
 		"query": ashbyQuery,

--- a/internal/applyform/fetch_test.go
+++ b/internal/applyform/fetch_test.go
@@ -142,3 +142,42 @@ func TestSplitBoardPosting(t *testing.T) {
 		}
 	}
 }
+
+// Board names reach us percent-encoded, because that is what belongs in the URL PATH the
+// crawl adapter builds. Ashby's GraphQL takes the organization as a VARIABLE, where an
+// encoded name is just a wrong name: the API answers 200 with a null posting, so without
+// decoding, every board whose name carries a space fails every capture forever. Found on
+// the first supervised production drain — "stony%20creek%20homes" returned nothing while
+// "stony creek homes" returned the posting.
+func TestAshbyFetcherDecodesTheBoardName(t *testing.T) {
+	tr := &fakeTransport{body: `{"data":{"jobPosting":{"applicationForm":{"sections":[]}}}}`}
+
+	if _, err := Fetchers(tr)["ashby"].Fetch(context.Background(), "stony%20creek%20homes", "x"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	body, ok := tr.gotBody.(map[string]any)
+	if !ok {
+		t.Fatalf("request body = %T, want a JSON object", tr.gotBody)
+	}
+	vars, _ := body["variables"].(map[string]any)
+	if got := vars["organizationHostedJobsPageName"]; got != "stony creek homes" {
+		t.Errorf("organization = %q, want the decoded name", got)
+	}
+}
+
+// A board name that is not valid percent-encoding is passed through rather than dropped:
+// a name is a name, and refusing to fetch would be worse than trying the literal one.
+func TestAshbyFetcherKeepsAnUndecodableBoardName(t *testing.T) {
+	tr := &fakeTransport{body: `{"data":{"jobPosting":{"applicationForm":{"sections":[]}}}}`}
+
+	if _, err := Fetchers(tr)["ashby"].Fetch(context.Background(), "100%discount", "x"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	body := tr.gotBody.(map[string]any)
+	vars := body["variables"].(map[string]any)
+	if got := vars["organizationHostedJobsPageName"]; got != "100%discount" {
+		t.Errorf("organization = %q, want the literal name kept", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #1506, found by its first supervised production drain.

## The bug

Board names are stored as they appear in the board file, already percent-encoded for the URL **path** the crawl adapter builds — Ashby's own posting API takes the board as a path segment, so `stony%20creek%20homes` is correct there.

Its GraphQL takes the organization as a **variable**, where an encoded name is simply a wrong name. And Ashby answers `200` with a null `jobPosting` rather than an error, so the failure read like the posting had been taken down:

```
ashby: no posting stony%20creek%20homes/2bba4390-...
```

Every Ashby board whose name carries a space would have failed every capture, forever, until its retries ran out and it dead-lettered.

## Evidence

The first drain, budgeted to 60: `captured=55 failed=5` — all five failures one board. Verified against the live API:

| organization variable | response |
|---|---|
| `stony%20creek%20homes` | `{"data":{"jobPosting":null}}` |
| `stony creek homes` | `{"data":{"jobPosting":{"id":"2bba4390-…","title":"Fractional Recruiter Sought…"}}}` |
| `stony-creek-homes` | `{"data":{"jobPosting":null}}` |

## The fix

Decode the board before it becomes a GraphQL variable. Greenhouse is untouched — it takes the board as a path segment, where the stored encoding is already right.

An undecodable name is passed through as it stands: refusing to fetch would be worse than trying the literal.

Two tests, one per branch.