### PR TITLE
fix(capture-apply-form): a retried capture is not a degraded run

### DIFF
--- a/cmd/capture-apply-form/main.go
+++ b/cmd/capture-apply-form/main.go
@@ -52,5 +52,10 @@ func run() int {
 
 	log.Printf("capture-apply-form done: captured=%d failed=%d dead_lettered=%d",
 		stats.Captured, stats.Failed, stats.DeadLettered)
-	return worker.ExitCode(stats.Failed, stats.DeadLettered)
+	// Deliberately not worker.ExitCode: see RunStats.Degraded for why a few retryable
+	// failures are the healthy shape of this particular worker rather than a bad run.
+	if stats.Degraded() {
+		return 1
+	}
+	return 0
 }

--- a/internal/applyform/runner.go
+++ b/internal/applyform/runner.go
@@ -66,6 +66,23 @@ type RunStats struct {
 	DeadLettered int
 }
 
+// Degraded reports whether a run deserves an alert, and it deliberately does NOT use the
+// shared worker.ExitCode rule that every other worker here applies.
+//
+// That rule — non-zero on any per-item failure — fits a worker whose items rarely fail. This
+// one issues hundreds of thousands of requests to other companies' APIs, where a handful of
+// transient failures per run is the normal, healthy shape: the queue retries them, and the
+// first production run measured 10 in 2490. Marking that degraded paints the unit red on
+// nearly every firing, and a status that is always red carries no information.
+//
+// What does deserve an alert is work ABANDONED rather than postponed: a dead letter is a
+// capture nobody will look at again. And a run that captured nothing at all while failing is
+// not a blip either — that is the platform being gone, and it must not hide behind the same
+// forgiveness the blips get.
+func (s RunStats) Degraded() bool {
+	return s.DeadLettered > 0 || (s.Captured == 0 && s.Failed > 0)
+}
+
 // Run drains the capture queue and returns. It is the whole worker: claim a wave, fetch
 // each posting's form through its provider's fetcher, store it, and keep going until a
 // wave comes back empty.

--- a/internal/applyform/runner_test.go
+++ b/internal/applyform/runner_test.go
@@ -352,3 +352,28 @@ func TestRunStopsWhenCancelled(t *testing.T) {
 		t.Error("a cancelled run drained every wave, want it to stop")
 	}
 }
+
+// A run's exit status has to separate work POSTPONED from work ABANDONED. Against
+// hundreds of thousands of third-party endpoints a handful of transient failures per run
+// is normal and self-healing — the queue retries them — so treating them as a degraded run
+// paints the unit red on nearly every firing and the status stops meaning anything. A dead
+// letter is different: that work is given up on, and nobody will look at it again.
+func TestRunOutcomeSeparatesPostponedFromAbandoned(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		stats    RunStats
+		degraded bool
+	}{
+		{"a clean run", RunStats{Captured: 2500}, false},
+		{"a few transient failures among many captures", RunStats{Captured: 2490, Failed: 10}, false},
+		{"an abandoned capture", RunStats{Captured: 2490, Failed: 10, DeadLettered: 1}, true},
+		// Nothing captured while everything failed is not a blip — it is the platform
+		// being gone, and it must not hide behind the same forgiveness.
+		{"every capture failed", RunStats{Failed: 40}, true},
+		{"an empty queue", RunStats{}, false},
+	} {
+		if got := tc.stats.Degraded(); got != tc.degraded {
+			t.Errorf("%s: Degraded() = %v, want %v (%+v)", tc.name, got, tc.degraded, tc.stats)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #1506, found by the first timer-driven run in production.

## What happened

```
capture-apply-form done: captured=2490 failed=10 dead_lettered=0
systemd: Failed with result 'exit-code'
```

The run was healthy. Ten captures hit transient upstream errors out of 2500, none were abandoned, and the queue will retry every one of them.

## Why the shared rule does not fit here

`worker.ExitCode(failed, deadLettered)` returns non-zero on any per-item failure. That is right for a worker whose items rarely fail — most of the fleet. This one issues hundreds of thousands of requests to other companies' public APIs, where a 0.4% transient failure rate is the normal shape rather than a symptom.

Left as-is, essentially every firing would mark the unit failed. A status that is always red carries no information, and it would train whoever reads it to ignore the one run that actually mattered.

## The line this draws

`RunStats.Degraded()`: work **abandoned**, not work **postponed**.

- a dead letter — a capture nobody will look at again → degraded
- captured nothing while failing — the platform is gone, not a blip → degraded
- a few transient failures among many captures → healthy, the queue retries them

Table-driven test over all five cases.