### PR TITLE
fix(capture-apply-form): retire a posting the platform no longer has

### DIFF
--- a/cmd/capture-apply-form/main.go
+++ b/cmd/capture-apply-form/main.go
@@ -50,8 +50,8 @@ func run() int {
 		return 1
 	}
 
-	log.Printf("capture-apply-form done: captured=%d failed=%d dead_lettered=%d",
-		stats.Captured, stats.Failed, stats.DeadLettered)
+	log.Printf("capture-apply-form done: captured=%d gone=%d failed=%d dead_lettered=%d",
+		stats.Captured, stats.Gone, stats.Failed, stats.DeadLettered)
 	// Deliberately not worker.ExitCode: see RunStats.Degraded for why a few retryable
 	// failures are the healthy shape of this particular worker rather than a bad run.
 	if stats.Degraded() {

--- a/cmd/capture-apply-form/store.go
+++ b/cmd/capture-apply-form/store.go
@@ -75,6 +75,12 @@ func (s *dbStore) Save(ctx context.Context, outboxID, jobID int64, form applyfor
 	return tx.Commit(ctx)
 }
 
+// Discard retires a capture whose posting the platform no longer has. No form is stored:
+// there is nothing to store, and the posting itself will be closed by the unseen sweep.
+func (s *dbStore) Discard(ctx context.Context, outboxID int64) error {
+	return s.q.DeleteApplyFormEntry(ctx, outboxID)
+}
+
 func (s *dbStore) Fail(ctx context.Context, outboxID int64, errMsg string, maxAttempts int) (bool, error) {
 	row, err := s.q.RecordApplyFormFailure(ctx, db.RecordApplyFormFailureParams{
 		ID:          outboxID,

--- a/internal/applyform/fetch.go
+++ b/internal/applyform/fetch.go
@@ -2,10 +2,38 @@ package applyform
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 )
+
+// ErrPostingGone marks a form the platform will never serve because the posting is no
+// longer on the board. It is not a failure to retry: the catalogue simply still holds a
+// posting the employer took down, and the unseen sweep closes it within 48h.
+//
+// The distinction earns its keep at scale. Across a backlog of a quarter of a million
+// postings there are thousands of these; retried, each burns three requests and then
+// dead-letters, and a queue steadily accumulating dead letters is indistinguishable from
+// one that is genuinely broken.
+var ErrPostingGone = errors.New("posting is gone")
+
+// statusCoder is any error carrying an HTTP status. Declared here rather than imported
+// because internal/sources imports THIS package (for the form its Recruitee adapter
+// yields), so the dependency cannot run both ways; sources.StatusError satisfies it.
+type statusCoder interface{ StatusCode() int }
+
+// asGone converts a not-found response into ErrPostingGone and leaves everything else
+// retryable. A 404 is the platform stating the posting does not exist; a 429 or a 5xx is
+// the platform declining to answer right now, which is a different thing entirely.
+func asGone(err error) error {
+	var sc statusCoder
+	if errors.As(err, &sc) && sc.StatusCode() == http.StatusNotFound {
+		return fmt.Errorf("%w: %v", ErrPostingGone, err)
+	}
+	return err
+}
 
 // Transport is the narrow HTTP role a fetcher needs: a JSON GET for Greenhouse's REST
 // endpoint and a JSON POST for Ashby's GraphQL one. It is declared here rather than
@@ -95,7 +123,7 @@ func (g greenhouseFetcher) Fetch(ctx context.Context, board, postingID string) (
 
 	var job GreenhouseJob
 	if err := g.http.GetJSON(ctx, url, &job); err != nil {
-		return Form{}, fmt.Errorf("greenhouse: fetch form for %s/%s: %w", board, postingID, err)
+		return Form{}, fmt.Errorf("greenhouse: fetch form for %s/%s: %w", board, postingID, asGone(err))
 	}
 	return FromGreenhouse(job), nil
 }
@@ -140,13 +168,13 @@ func (a ashbyFetcher) Fetch(ctx context.Context, board, postingID string) (Form,
 	}
 	headers := map[string]string{"content-type": "application/json"}
 	if err := a.http.PostJSONWithHeaders(ctx, ashbyGraphQLURL, headers, body, &resp); err != nil {
-		return Form{}, fmt.Errorf("ashby: fetch form for %s/%s: %w", board, postingID, err)
+		return Form{}, fmt.Errorf("ashby: fetch form for %s/%s: %w", board, postingID, asGone(err))
 	}
 	// A posting Ashby does not have answers 200 with a null jobPosting rather than an
 	// error, so an absent posting would otherwise be captured as an empty form — which
 	// reads as "this employer asks nothing" and is a lie.
 	if resp.Data.JobPosting == nil {
-		return Form{}, fmt.Errorf("ashby: no posting %s/%s", board, postingID)
+		return Form{}, fmt.Errorf("ashby: no posting %s/%s: %w", board, postingID, ErrPostingGone)
 	}
 	return FromAshby(resp.Data.JobPosting.ApplicationForm), nil
 }

--- a/internal/applyform/fetch_test.go
+++ b/internal/applyform/fetch_test.go
@@ -181,3 +181,48 @@ func TestAshbyFetcherKeepsAnUndecodableBoardName(t *testing.T) {
 		t.Errorf("organization = %q, want the literal name kept", got)
 	}
 }
+
+// A posting the platform no longer has is not a failure to retry. Our catalogue still
+// holds postings employers have taken down — the unseen sweep closes them within 48h — and
+// there will be thousands across a 226k backlog. Retried, each burns three requests and
+// then dead-letters, and a queue steadily accumulating dead letters is indistinguishable
+// from one that is genuinely broken.
+type statusErr struct{ code int }
+
+func (e statusErr) Error() string   { return "status" }
+func (e statusErr) StatusCode() int { return e.code }
+
+func TestGreenhouseFetcherMarksAGonePostingAsGone(t *testing.T) {
+	tr := &fakeTransport{err: statusErr{code: 404}}
+
+	_, err := Fetchers(tr)["greenhouse"].Fetch(context.Background(), "sentinellabs", "7819844003")
+
+	if !errors.Is(err, ErrPostingGone) {
+		t.Errorf("Fetch() error = %v, want it to mark the posting gone", err)
+	}
+}
+
+// Anything else is worth another try: a 429 clears on its own, and giving up on it would
+// throw away a form the platform is perfectly willing to serve.
+func TestGreenhouseFetcherKeepsARateLimitRetryable(t *testing.T) {
+	tr := &fakeTransport{err: statusErr{code: 429}}
+
+	_, err := Fetchers(tr)["greenhouse"].Fetch(context.Background(), "b", "1")
+
+	if err == nil {
+		t.Fatal("Fetch() = nil error on a rate limit")
+	}
+	if errors.Is(err, ErrPostingGone) {
+		t.Errorf("Fetch() error = %v, want a rate limit kept retryable", err)
+	}
+}
+
+func TestAshbyFetcherMarksAnAbsentPostingAsGone(t *testing.T) {
+	tr := &fakeTransport{body: `{"data": {"jobPosting": null}}`}
+
+	_, err := Fetchers(tr)["ashby"].Fetch(context.Background(), "n8n", "gone")
+
+	if !errors.Is(err, ErrPostingGone) {
+		t.Errorf("Fetch() error = %v, want it to mark the posting gone", err)
+	}
+}

--- a/internal/applyform/runner.go
+++ b/internal/applyform/runner.go
@@ -2,6 +2,7 @@ package applyform
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -29,6 +30,8 @@ type Store interface {
 	Save(ctx context.Context, outboxID, jobID int64, form Form) error
 	// Fail records a failed attempt for one entry; it reports whether it dead-lettered.
 	Fail(ctx context.Context, outboxID int64, errMsg string, maxAttempts int) (deadLettered bool, err error)
+	// Discard retires an entry whose posting the platform no longer has, storing nothing.
+	Discard(ctx context.Context, outboxID int64) error
 }
 
 // RunOptions are the per-run knobs.
@@ -61,8 +64,12 @@ type RunOptions struct {
 // failure is a retry and a dead letter is work abandoned — a queue quietly filling with
 // the latter is not a healthy queue.
 type RunStats struct {
-	Captured     int
-	Failed       int
+	Captured int
+	Failed   int
+	// Gone counts postings the platform no longer has. They are retired from the queue
+	// rather than retried, and counted apart from Failed because they are ordinary
+	// attrition — an employer took the posting down and our sweep has not caught up yet.
+	Gone         int
 	DeadLettered int
 }
 
@@ -99,7 +106,7 @@ func Run(ctx context.Context, s Store, fetchers map[string]Fetcher, opts RunOpti
 		if opts.MaxPerRun > 0 {
 			// Never claim past the budget: a leased entry this run will not touch is one
 			// no other run can take until its lease lapses.
-			remaining := opts.MaxPerRun - (stats.Captured + stats.Failed)
+			remaining := opts.MaxPerRun - (stats.Captured + stats.Failed + stats.Gone)
 			if remaining <= 0 {
 				return stats, nil
 			}
@@ -117,6 +124,7 @@ func Run(ctx context.Context, s Store, fetchers map[string]Fetcher, opts RunOpti
 		wave := runWave(ctx, s, fetchers, opts, claims)
 		stats.Captured += wave.Captured
 		stats.Failed += wave.Failed
+		stats.Gone += wave.Gone
 		stats.DeadLettered += wave.DeadLettered
 
 		// A context cancellation shows up as every capture in the wave failing; stopping
@@ -150,6 +158,19 @@ func runWave(ctx context.Context, s Store, fetchers map[string]Fetcher, opts Run
 			if err == nil {
 				mu.Lock()
 				stats.Captured++
+				mu.Unlock()
+				return
+			}
+
+			// The platform does not have this posting and never will again. Retrying to
+			// reach the same answer spends requests and ends in a dead letter that reads
+			// like a fault, so the entry is retired instead.
+			if errors.Is(err, ErrPostingGone) {
+				if discardErr := s.Discard(ctx, c.OutboxID); discardErr != nil {
+					log.Printf("apply-form: retire gone capture %d: %v", c.OutboxID, discardErr)
+				}
+				mu.Lock()
+				stats.Gone++
 				mu.Unlock()
 				return
 			}

--- a/internal/applyform/runner_test.go
+++ b/internal/applyform/runner_test.go
@@ -3,6 +3,7 @@ package applyform
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 )
@@ -18,6 +19,7 @@ type fakeStore struct {
 	saved     map[int64]Form
 	failures  map[int64]string
 	attempts  map[int64]int
+	discarded []int64
 	maxClaims int
 }
 
@@ -375,5 +377,52 @@ func TestRunOutcomeSeparatesPostponedFromAbandoned(t *testing.T) {
 		if got := tc.stats.Degraded(); got != tc.degraded {
 			t.Errorf("%s: Degraded() = %v, want %v (%+v)", tc.name, got, tc.degraded, tc.stats)
 		}
+	}
+}
+
+func (s *fakeStore) Discard(_ context.Context, outboxID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.discarded = append(s.discarded, outboxID)
+	return nil
+}
+
+// A posting the platform no longer has is retired from the queue outright: there is
+// nothing to capture and no later run will do better, so retrying it three times to reach
+// the same answer only spends requests and leaves a dead letter that reads like a fault.
+func TestRunDiscardsAGonePosting(t *testing.T) {
+	store := newFakeStore([]Claimed{
+		claim(1, 100, "greenhouse", "b:live"),
+		claim(2, 200, "greenhouse", "b:gone"),
+	})
+	fetcher := &fakeFetcher{
+		forms: map[string]Form{"live": {Provider: "greenhouse"}},
+		errs:  map[string]error{"gone": fmt.Errorf("greenhouse: %w", ErrPostingGone)},
+	}
+
+	stats, err := Run(context.Background(), store, map[string]Fetcher{"greenhouse": fetcher}, testOptions())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if stats.Gone != 1 || stats.Failed != 0 || stats.DeadLettered != 0 {
+		t.Errorf("stats = %+v, want the gone posting counted apart and not failed", stats)
+	}
+	if len(store.discarded) != 1 || store.discarded[0] != 2 {
+		t.Errorf("discarded = %v, want the gone capture retired from the queue", store.discarded)
+	}
+	if store.failures[2] != "" {
+		t.Error("the gone capture was failed as well as discarded")
+	}
+	if _, ok := store.saved[100]; !ok {
+		t.Error("the live posting beside it was not captured")
+	}
+}
+
+// Postings going away is ordinary attrition, not a fault, so a run full of them is not a
+// run worth waking anyone for.
+func TestRunOfGonePostingsIsNotDegraded(t *testing.T) {
+	if (RunStats{Captured: 100, Gone: 40}).Degraded() {
+		t.Error("a run that retired taken-down postings reads as degraded, want it healthy")
 	}
 }

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -405,6 +405,12 @@ func (e *StatusError) Error() string {
 	return fmt.Sprintf("sources: %s %s: status %d", e.Method, e.URL, e.Code)
 }
 
+// StatusCode reports the response status. It exists so a package this one IMPORTS can
+// still branch on the code: internal/applyform is imported by the Recruitee adapter, so
+// it cannot import sources back, and a one-method interface it declares locally is
+// satisfied by this without either package naming the other.
+func (e *StatusError) StatusCode() int { return e.Code }
+
 // ChallengeError is an AWS-WAF Challenge response — a request the WAF answered with an
 // interactive JS proof-of-work shell instead of the real content (marked by the
 // "x-amzn-waf-action: challenge" header, served with HTTP 202). It is NOT a transient


### PR DESCRIPTION
Third follow-up to #1506, found by the first timer-driven production run.

## What the run showed

```
capture-apply-form done: captured=7864 failed=136 dead_lettered=1
```

The single dead letter was a plain **404**: `sentinellabs/7819844003` is gone from the board while our catalogue still holds it — as it will for up to 48 hours, until the unseen sweep closes it.

## Why that matters more than one row

Postings being taken down is ordinary attrition, and across a quarter-million backlog there are thousands of them. Treated as failures, each burns three requests to reach the same answer and then leaves a dead letter. The queue fills with entries that look like a broken worker, and the one dead letter that *does* mean something is buried among them — which undoes the alerting distinction #1510 had just drawn.

## The fix

A not-found response yields `ErrPostingGone`; the runner retires the entry outright and counts it as `Gone` — work finished, not work failed. Everything else stays retryable: a 429 or a 5xx is the platform declining to answer *right now*, which is a different thing from the posting not existing.

`sources.StatusError` gains a `StatusCode()` method so `internal/applyform` can branch on the code without importing `sources` — it cannot, because `sources` imports *it* for the form the Recruitee adapter yields. A one-method interface declared locally is satisfied without either package naming the other.

## Also visible in that run

136 of 137 retryable failures were **429s from Ashby** at concurrency 4. Not a code change — the unit's concurrency comes down to 2 alongside this deploy.