### PR TITLE
feat(apply-forms): show what a job's application will ask

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -77,6 +77,7 @@ func genStructs() (string, error) {
 	resumeextractTS := filepath.Join(tmp, "resumeextract.ts")
 	cvTS := filepath.Join(tmp, "cv.ts")
 	cveditTS := filepath.Join(tmp, "cvedit.ts")
+	applyformTS := filepath.Join(tmp, "applyform.ts")
 
 	cfg := &tygo.Config{
 		Packages: []*tygo.PackageConfig{
@@ -104,6 +105,15 @@ func genStructs() (string, error) {
 				OutputPath:   verdictTS,
 				IncludeFiles: []string{"verdict.go"},
 				TypeMappings: map[string]string{"skillbundle.Bundle": "Bundle"},
+			},
+			{
+				// The application-form display shape (Display + Question). Only display.go —
+				// the rest of the package is the capture: the stored Form keeps each
+				// platform's own identifiers and option values, which exist to be handed
+				// back to that platform and are of no use to a browser.
+				Path:         "github.com/strelov1/freehire/internal/applyform",
+				OutputPath:   applyformTS,
+				IncludeFiles: []string{"display.go"},
 			},
 			{
 				// The CV ATS-readiness report wire shape (Report + Check + Status) and the
@@ -224,7 +234,11 @@ func genStructs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return enrichBody + "\n" + jobviewBody + "\n" + bundleBody + "\n" + verdictBody + "\n" + atscheckBody + "\n" + cvmatchBody + "\n" + jobmatchBody + "\n" + hardconstraintBody + "\n" + matchanalysisBody + "\n" + resumeextractBody + "\n" + cvBody + "\n" + cveditBody, nil
+	applyformBody, err := readBody(applyformTS)
+	if err != nil {
+		return "", err
+	}
+	return enrichBody + "\n" + jobviewBody + "\n" + bundleBody + "\n" + verdictBody + "\n" + atscheckBody + "\n" + cvmatchBody + "\n" + jobmatchBody + "\n" + hardconstraintBody + "\n" + matchanalysisBody + "\n" + resumeextractBody + "\n" + cvBody + "\n" + cveditBody + "\n" + applyformBody, nil
 }
 
 // readBody returns a tygo output file's body with its leading preamble removed, so

--- a/docs/superpowers/specs/2026-08-02-show-apply-questions-design.md
+++ b/docs/superpowers/specs/2026-08-02-show-apply-questions-design.md
@@ -1,0 +1,113 @@
+# Show the questions a job's application form asks
+
+## Why
+
+`apply_forms` already holds the application form for every posting on Recruitee,
+Greenhouse and Ashby — the questions, their types, whether an answer is required.
+Nothing reads it. A candidate still cannot tell a one-click apply from an evening
+of essay writing until they have committed to the form.
+
+This shows the questions on the job page. It is the smallest possible reader over
+a store that is already full.
+
+## What it does
+
+A block on the job detail page listing the questions the employer will ask:
+
+```
+What this application asks                        Greenhouse
+
+  Name, email, phone, CV
+  LinkedIn profile                                optional
+  Which country do you currently reside in?       choose one
+  Will you require visa sponsorship?              choose one
+  What made you apply for this role?              written answer
+```
+
+Nothing is computed. The questions are shown as the platform published them, with
+the control kind rendered as a word — that word is what separates a question worth
+a minute from one worth twenty.
+
+The interface is English (`<html lang="en">`), so the copy is English; only the
+question text itself carries whatever language the employer wrote it in.
+
+The control kinds map to display words as follows. A kind the capture could not
+normalize (`Field.Type` empty, its `RawType` kept) gets no word rather than a
+guessed one — the question is still shown, just without a hint about its cost.
+
+| `applyform.FieldType` | word |
+|---|---|
+| `text`, `number`, `date` | — (nothing; a one-line answer is the default expectation) |
+| `textarea` | written answer |
+| `select` | choose one |
+| `multiselect` | choose any |
+| `boolean` | yes / no |
+| `file` | upload |
+| `hidden`, `info` | not shown at all — neither is a question |
+
+## Decisions
+
+**Verbatim question text is shown.** An earlier decision on the capture change was
+to store the text but display only a derived summary, because the questions are the
+employer's own writing and showing them is republication. That was reversed here
+deliberately: the summary is a worse answer to "what will they ask me" than the
+questions themselves.
+
+**Standard fields collapse into one line.** Name, email, phone and CV appear on
+every form; one bullet each would pad the list with what everyone already expects.
+They are listed together, once, so their absence is still visible.
+
+**The EEO survey is not shown.** It is not the employer's questions — it is the
+mandated diversity survey the platform serves in a separate block, always optional
+and near-identical everywhere. Listing it would bury the real questions in noise.
+It stays in the store; the capture already marks it (`Field.Demographic`).
+
+**No derived facts of any kind.** No question count, no time estimate, no detection
+of whether salary or visa is asked. Counting is exact; reading meaning out of
+employer prose is guessing, and a wrong guess sitting beside the apply button would
+discredit the accurate parts of the block along with itself.
+
+**No provider fallback.** A posting whose platform we cannot read shows nothing.
+Saying something general about the platform was considered and dropped as
+unnecessary for a first reader.
+
+## Shape
+
+- `GET /jobs/:slug/apply-form` — returns the stored form for one posting. 404 when
+  there is none, which is the common case today and always will be for the
+  providers whose forms cannot be read.
+- The SSR loader fetches it as a fourth parallel request beside `similar` and
+  `copies`, degrading to nothing on any failure — the same pattern those two
+  already use, for the same reason: a discovery aid must not break the page.
+- A Svelte component renders the list.
+
+`internal/jobview` is deliberately untouched. That projection is also what goes
+into the Meilisearch documents, so a field added there would inflate every indexed
+job for the sake of one page — and keeping it out leaves a future filter as its own
+clean piece of work.
+
+## Coverage, and why it is fine
+
+The three readable providers are 8.8% of the open catalogue and 15.8% of technical
+postings. Workday (553k), Oracle (209k), SmartRecruiters (194k) and UKG (157k) are
+walls or unexamined. So the block is absent from most job pages, and that is the
+honest state of the world rather than a defect to design around: where it appears,
+it is exact.
+
+Capture is still draining at the time of writing (Greenhouse 11.5k of 134k), so in
+development most Greenhouse postings will have no form. That is the ordinary
+absent case, not a broken one.
+
+## Testing
+
+- The handler: a posting with a form, a posting without one (404), and a form whose
+  only fields are the standard ones.
+- The projection: standard fields collapsed, demographic fields excluded, control
+  kinds mapped to their display words.
+- The component: renders a list, renders nothing when the fetch returned nothing.
+
+## Out of scope
+
+A filter on how much applying costs. It needs a filterable attribute in the search
+index and a full reindex to register it, which doubles the work and cannot be
+justified before anyone has shown they read this block at all.

--- a/internal/applyform/display.go
+++ b/internal/applyform/display.go
@@ -1,0 +1,110 @@
+package applyform
+
+import (
+	"slices"
+	"strings"
+)
+
+// Display is a captured form shaped for a candidate to read rather than for a
+// machine to submit. It is the near-inverse of what the store keeps: the store holds
+// the platform's identifiers and option values because they exist to be handed back,
+// and a reader wants none of that — only the question and one word about the answer.
+type Display struct {
+	// Provider is the platform the form was read from, so a reader can say where the
+	// answer came from.
+	Provider string `json:"provider"`
+	// Basics are the controls every application demands — name, contact details, CV —
+	// listed once instead of one entry each. Stated rather than dropped, because a
+	// form that does NOT want a CV is worth knowing too.
+	Basics []string `json:"basics"`
+	// Questions are the employer's own, in the order the form presents them.
+	Questions []Question `json:"questions"`
+}
+
+// Question is one thing the employer will ask.
+type Question struct {
+	// Text is the question as the employer wrote it, unedited.
+	Text string `json:"text"`
+	// Required is whether the platform refuses the application without an answer.
+	Required bool `json:"required"`
+	// Answer names the kind of answer expected, empty where naming it would add
+	// nothing (a one-line answer is the default expectation) or where the capture
+	// could not normalize the control's kind.
+	Answer string `json:"answer,omitempty"`
+}
+
+// answerWords name each control kind for a reader. The absent entries are deliberate:
+// a single-line answer is what anyone assumes, so naming it is noise, and a kind the
+// capture left unnormalized gets no word rather than the nearest one — the same
+// dict-only rule the capture follows, carried through to display.
+var answerWords = map[FieldType]string{
+	TypeTextarea:    "written answer",
+	TypeSelect:      "choose one",
+	TypeMultiSelect: "choose any",
+	TypeBoolean:     "yes / no",
+	TypeFile:        "upload",
+}
+
+// standardFieldIDs are the controls each platform puts on every form. They are
+// identified by the identifiers OUR OWN mappers produce, not by guessing from labels:
+// the mappers are deterministic, so this set is exact rather than heuristic.
+//
+// Ashby is absent because it needs no list — it prefixes every standard field's path
+// with `_systemfield_`, which isStandard checks directly.
+var standardFieldIDs = map[string][]string{
+	"greenhouse": {
+		"first_name", "last_name", "email", "phone",
+		"resume", "resume_text", "cover_letter", "cover_letter_text",
+		"location", "longitude", "latitude",
+	},
+	"recruitee": {
+		"name", "email", "phone", "cv", "cover_letter", "photo", "salutation", "title",
+	},
+}
+
+// isStandard reports whether a field is one every application demands rather than
+// something this employer chose to ask.
+func isStandard(provider string, f Field) bool {
+	if strings.HasPrefix(f.ID, "_systemfield_") {
+		return true
+	}
+	return slices.Contains(standardFieldIDs[provider], f.ID)
+}
+
+// ForDisplay projects a captured form into what a candidate reads. It is pure: no
+// database, no network, so what it includes and what it refuses can be tested
+// without a fixture of either.
+func (f Form) ForDisplay() Display {
+	d := Display{Provider: f.Provider}
+
+	for _, field := range f.Fields {
+		switch {
+		// Neither is a question: one the platform fills itself and the candidate
+		// never sees, and one that is a block of text the employer placed mid-form.
+		case field.Type == TypeHidden || field.Type == TypeInfo:
+			continue
+
+		// Not the employer's questions — the platform's mandated diversity survey,
+		// always optional and near-identical everywhere. Listing it would bury what
+		// a candidate actually has to prepare for.
+		case field.Demographic:
+			continue
+
+		case isStandard(f.Provider, field):
+			// One label may cover several controls (Greenhouse offers the CV as an
+			// upload OR pasted text under a single label), so the reader sees it once.
+			if !slices.Contains(d.Basics, field.Label) {
+				d.Basics = append(d.Basics, field.Label)
+			}
+
+		default:
+			d.Questions = append(d.Questions, Question{
+				Text:     field.Label,
+				Required: field.Required,
+				Answer:   answerWords[field.Type],
+			})
+		}
+	}
+
+	return d
+}

--- a/internal/applyform/display_test.go
+++ b/internal/applyform/display_test.go
@@ -1,0 +1,222 @@
+package applyform
+
+import "testing"
+
+func questionTexts(d Display) []string {
+	out := make([]string, 0, len(d.Questions))
+	for _, q := range d.Questions {
+		out = append(out, q.Text)
+	}
+	return out
+}
+
+func findQuestion(t *testing.T, d Display, text string) Question {
+	t.Helper()
+	for _, q := range d.Questions {
+		if q.Text == text {
+			return q
+		}
+	}
+	t.Fatalf("no question %q among %v", text, questionTexts(d))
+	return Question{}
+}
+
+func TestForDisplayShowsTheEmployersQuestionsWhole(t *testing.T) {
+	form := Form{
+		Provider: "greenhouse",
+		Fields: []Field{
+			{ID: "first_name", Label: "First Name", Type: TypeText, Required: true},
+			{ID: "question_1", Label: "Why did you apply?", Type: TypeTextarea, Required: true},
+			{ID: "question_2", Label: "LinkedIn profile", Type: TypeText},
+		},
+	}
+
+	d := form.ForDisplay()
+
+	if d.Provider != "greenhouse" {
+		t.Errorf("provider = %q, want %q", d.Provider, "greenhouse")
+	}
+	essay := findQuestion(t, d, "Why did you apply?")
+	if !essay.Required || essay.Answer != "written answer" {
+		t.Errorf("essay = %+v, want required with a written-answer hint", essay)
+	}
+	optional := findQuestion(t, d, "LinkedIn profile")
+	if optional.Required {
+		t.Error("LinkedIn profile came back required")
+	}
+	// The question text is the employer's, shown as published — the whole point of
+	// preferring the questions over a summary of them.
+	if got := len(d.Questions); got != 2 {
+		t.Errorf("questions = %v, want only the employer's two", questionTexts(d))
+	}
+}
+
+// Name, email, phone and a CV are on every form. One bullet each would pad the list
+// with what everyone already expects, so they are stated once — but stated, because
+// a form that does NOT want a CV is worth knowing too.
+func TestForDisplayCollapsesTheStandardFields(t *testing.T) {
+	for _, tc := range []struct {
+		provider string
+		fields   []Field
+		want     []string
+	}{
+		{
+			provider: "greenhouse",
+			fields: []Field{
+				{ID: "first_name", Label: "First Name", Type: TypeText},
+				{ID: "last_name", Label: "Last Name", Type: TypeText},
+				{ID: "email", Label: "Email", Type: TypeText},
+				{ID: "resume", Label: "Resume/CV", Type: TypeFile},
+				{ID: "resume_text", Label: "Resume/CV", Type: TypeTextarea},
+			},
+			// Greenhouse offers the CV as an upload OR pasted text under one label;
+			// the reader should see it once.
+			want: []string{"First Name", "Last Name", "Email", "Resume/CV"},
+		},
+		{
+			provider: "recruitee",
+			fields: []Field{
+				{ID: "name", Label: "Full name", Type: TypeText},
+				{ID: "email", Label: "Email", Type: TypeText},
+				{ID: "cv", Label: "CV", Type: TypeFile},
+				{ID: "phone", Label: "Phone", Type: TypeText},
+			},
+			want: []string{"Full name", "Email", "CV", "Phone"},
+		},
+		{
+			provider: "ashby",
+			fields: []Field{
+				{ID: "_systemfield_name", Label: "Name", Type: TypeText},
+				{ID: "_systemfield_email", Label: "Email", Type: TypeText},
+				{ID: "_systemfield_resume", Label: "Resume", Type: TypeFile},
+			},
+			want: []string{"Name", "Email", "Resume"},
+		},
+	} {
+		d := Form{Provider: tc.provider, Fields: tc.fields}.ForDisplay()
+
+		if len(d.Questions) != 0 {
+			t.Errorf("%s: questions = %v, want none — these are all standard fields",
+				tc.provider, questionTexts(d))
+		}
+		if len(d.Basics) != len(tc.want) {
+			t.Errorf("%s: basics = %v, want %v", tc.provider, d.Basics, tc.want)
+			continue
+		}
+		for i, b := range d.Basics {
+			if b != tc.want[i] {
+				t.Errorf("%s: basics = %v, want %v", tc.provider, d.Basics, tc.want)
+				break
+			}
+		}
+	}
+}
+
+// The equal-opportunity survey is not the employer's questions. It is a mandated
+// survey the platform serves in its own block, always optional and near-identical
+// everywhere; listing it would bury the questions a candidate has to prepare for.
+func TestForDisplayDropsTheDemographicSurvey(t *testing.T) {
+	form := Form{
+		Provider: "greenhouse",
+		Fields: []Field{
+			{ID: "question_1", Label: "Why did you apply?", Type: TypeTextarea},
+			{ID: "race", Label: "Race", Type: TypeSelect, Demographic: true},
+			{ID: "gender", Label: "Gender", Type: TypeSelect, Demographic: true},
+			{ID: "disability_status", Label: "Disability Status", Type: TypeSelect, Demographic: true},
+		},
+	}
+
+	d := form.ForDisplay()
+
+	if got := questionTexts(d); len(got) != 1 || got[0] != "Why did you apply?" {
+		t.Errorf("questions = %v, want only the employer's own", got)
+	}
+}
+
+// A hidden control and a block of explanatory text are not questions: nobody answers
+// either one.
+func TestForDisplayDropsNonQuestions(t *testing.T) {
+	form := Form{
+		Provider: "greenhouse",
+		Fields: []Field{
+			{ID: "longitude", Label: "Longitude", Type: TypeHidden},
+			{ID: "note", Label: "Please read our remote-work policy below.", Type: TypeInfo},
+			{ID: "question_1", Label: "Where do you live?", Type: TypeText},
+		},
+	}
+
+	d := form.ForDisplay()
+
+	if got := questionTexts(d); len(got) != 1 || got[0] != "Where do you live?" {
+		t.Errorf("questions = %v, want the hidden control and the info block dropped", got)
+	}
+}
+
+func TestForDisplayNamesTheAnswerKind(t *testing.T) {
+	for _, tc := range []struct {
+		kind FieldType
+		want string
+	}{
+		{TypeTextarea, "written answer"},
+		{TypeSelect, "choose one"},
+		{TypeMultiSelect, "choose any"},
+		{TypeBoolean, "yes / no"},
+		{TypeFile, "upload"},
+		// A one-line answer is the default expectation, so naming it adds noise.
+		{TypeText, ""},
+		{TypeNumber, ""},
+		{TypeDate, ""},
+		// A kind the capture could not normalize gets no word rather than a guessed
+		// one — the same dict-only rule the capture itself follows. The question is
+		// still shown; only the hint about its cost is withheld.
+		{"", ""},
+	} {
+		d := Form{
+			Provider: "ashby",
+			Fields:   []Field{{ID: "q", Label: "Q", Type: tc.kind, RawType: "whatever"}},
+		}.ForDisplay()
+
+		got := findQuestion(t, d, "Q")
+		if got.Answer != tc.want {
+			t.Errorf("kind %q -> answer %q, want %q", tc.kind, got.Answer, tc.want)
+		}
+	}
+}
+
+// A form asking nothing beyond a CV is itself worth knowing — it is the one-click
+// apply a candidate is hunting for.
+func TestForDisplayOfAFormWithNoQuestions(t *testing.T) {
+	d := Form{
+		Provider: "recruitee",
+		Fields: []Field{
+			{ID: "name", Label: "Full name", Type: TypeText},
+			{ID: "email", Label: "Email", Type: TypeText},
+			{ID: "cv", Label: "CV", Type: TypeFile},
+		},
+	}.ForDisplay()
+
+	if len(d.Questions) != 0 {
+		t.Errorf("questions = %v, want none", questionTexts(d))
+	}
+	if len(d.Basics) != 3 {
+		t.Errorf("basics = %v, want the three standard fields", d.Basics)
+	}
+}
+
+// An employer's question keeps its place in the order the platform presented it —
+// that order is how the form will actually read.
+func TestForDisplayKeepsTheFormsOrder(t *testing.T) {
+	d := Form{
+		Provider: "ashby",
+		Fields: []Field{
+			{ID: "q1", Label: "First", Type: TypeText},
+			{ID: "_systemfield_email", Label: "Email", Type: TypeText},
+			{ID: "q2", Label: "Second", Type: TypeText},
+		},
+	}.ForDisplay()
+
+	got := questionTexts(d)
+	if len(got) != 2 || got[0] != "First" || got[1] != "Second" {
+		t.Errorf("questions = %v, want them in the platform's order", got)
+	}
+}

--- a/internal/applyform/form.go
+++ b/internal/applyform/form.go
@@ -9,6 +9,11 @@
 // field's identifier is not for comparing. `question_67165648` means nothing except to
 // Greenhouse, and it exists to be handed back to Greenhouse. Any mapping of it is loss.
 //
+// The store has one reader: display.go projects a captured form into what a candidate
+// sees on the job page, which wants almost none of the above — the question text and one
+// word about the answer. The verbatim identifiers exist for the consumer that has not
+// been built yet, the one that fills a form rather than describing it.
+//
 // The one thing that IS normalized is the kind of control, because "is this a dropdown"
 // is a question every consumer asks and no consumer should answer three times. That
 // mapping follows the repository's dict-only rule: a word the dictionary does not know

--- a/internal/db/apply_forms.sql.go
+++ b/internal/db/apply_forms.sql.go
@@ -125,6 +125,28 @@ func (q *Queries) EnqueueApplyFormCapture(ctx context.Context, jobID int64) (int
 	return result.RowsAffected(), nil
 }
 
+const getApplyFormByJobID = `-- name: GetApplyFormByJobID :one
+SELECT provider, captured_at, payload
+FROM apply_forms
+WHERE job_id = $1
+`
+
+type GetApplyFormByJobIDRow struct {
+	Provider   string             `json:"provider"`
+	CapturedAt pgtype.Timestamptz `json:"captured_at"`
+	Payload    []byte             `json:"payload"`
+}
+
+// Read one job's captured form for display. The only read path over this store, and it
+// is by primary key — the display surface asks for exactly one posting's form, never a
+// page of them, which is also why nothing here joins jobs.
+func (q *Queries) GetApplyFormByJobID(ctx context.Context, jobID int64) (GetApplyFormByJobIDRow, error) {
+	row := q.db.QueryRow(ctx, getApplyFormByJobID, jobID)
+	var i GetApplyFormByJobIDRow
+	err := row.Scan(&i.Provider, &i.CapturedAt, &i.Payload)
+	return i, err
+}
+
 const recordApplyFormFailure = `-- name: RecordApplyFormFailure :one
 UPDATE apply_form_outbox
 SET attempts   = attempts + 1,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -787,6 +787,10 @@ type Querier interface {
 	// duplicate that logic in a second language and let the two drift apart; titles are cheap to
 	// ship, descriptions are not.
 	FuzzyDedupCandidateTitlesForCompany(ctx context.Context, company string) ([]FuzzyDedupCandidateTitlesForCompanyRow, error)
+	// Read one job's captured form for display. The only read path over this store, and it
+	// is by primary key — the display surface asks for exactly one posting's form, never a
+	// page of them, which is also why nothing here joins jobs.
+	GetApplyFormByJobID(ctx context.Context, jobID int64) (GetApplyFormByJobIDRow, error)
 	// One session owned by the caller. Owner-scoped: a foreign or missing id returns no row,
 	// which the handler maps to 404 — so a probe cannot tell the two apart.
 	GetAssistantSession(ctx context.Context, arg GetAssistantSessionParams) (GetAssistantSessionRow, error)

--- a/internal/db/queries/apply_forms.sql
+++ b/internal/db/queries/apply_forms.sql
@@ -85,3 +85,11 @@ SET attempts   = attempts + 1,
                  END
 WHERE id = sqlc.arg(id)
 RETURNING attempts, failed_at;
+
+-- name: GetApplyFormByJobID :one
+-- Read one job's captured form for display. The only read path over this store, and it
+-- is by primary key — the display surface asks for exactly one posting's form, never a
+-- page of them, which is also why nothing here joins jobs.
+SELECT provider, captured_at, payload
+FROM apply_forms
+WHERE job_id = sqlc.arg(job_id);

--- a/internal/handler/AGENTS.md
+++ b/internal/handler/AGENTS.md
@@ -134,6 +134,19 @@ every later turn, so a name that lands there stays for the conversation's life. 
 caller with no profile gets a result naming `/my/profile`, never an error and never an
 empty profile the model would read as "no preferences".
 
+## Application forms (`apply_form.go`)
+
+- `GET /jobs/:slug/apply-form` serves the questions a posting's application will ask,
+  projected for reading by `applyform.Display` — not the stored form, which keeps each
+  platform's own field identifiers and option values so an autofiller can hand them back.
+- **A 404 is the ordinary answer.** Forms can be read from three ATS platforms, roughly a
+  sixth of technical postings, so most of the catalogue has none and never will. Do not
+  treat it as an error worth logging or alerting on.
+- Two queries, not one join — mirroring `JobCopies` on the same resource. An unknown slug
+  fails at `GetJobIDBySlug`, a posting with no captured form at `GetApplyFormByJobID`.
+  Both render 404, and keeping them distinguishable is the point: "this employer asks
+  nothing" and "we cannot read this platform" are different statements.
+
 ## Error Convention
 
 - Genuinely domain-specific status choices (e.g. `Me` returning 401 for a gone user token) stay in the handler.

--- a/internal/handler/apply_form.go
+++ b/internal/handler/apply_form.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/applyform"
+)
+
+// JobApplyForm serves the application form captured for the job addressed by :slug —
+// the questions a candidate will have to answer, shaped for reading. Public
+// (unauthenticated) like the other job reads. Response: {"data": {...}}.
+//
+// Two queries rather than one join, mirroring JobCopies on the same resource: an
+// unknown slug fails at the first exactly as /copies does, while a posting that exists
+// but has no captured form fails at the second with its own message. Both are 404s, and
+// keeping them distinguishable matters — "this employer asks nothing" and "we cannot
+// read this platform" are different statements, and only the second is usually true.
+//
+// A form is captured for a minority of postings (the platforms whose forms can be read
+// at all are roughly a sixth of technical ones), so the 404 is the ordinary case rather
+// than an error worth logging.
+func (h *jobsHandlers) JobApplyForm(c *fiber.Ctx) error {
+	id, err := h.queries.GetJobIDBySlug(c.Context(), c.Params("slug"))
+	if err != nil {
+		// RenderError maps pgx.ErrNoRows to 404, anything else to 500.
+		return err
+	}
+
+	row, err := h.queries.GetApplyFormByJobID(c.Context(), id)
+	if err != nil {
+		return err
+	}
+
+	var form applyform.Form
+	if err := json.Unmarshal(row.Payload, &form); err != nil {
+		return fmt.Errorf("decode apply form for job %d: %w", id, err)
+	}
+	// The provider is authoritative on the row rather than inside the payload: the row
+	// is what a re-capture rewrites and what a per-provider purge would select on.
+	form.Provider = row.Provider
+
+	return c.JSON(fiber.Map{"data": form.ForDisplay()})
+}

--- a/internal/handler/apply_form_integration_test.go
+++ b/internal/handler/apply_form_integration_test.go
@@ -1,0 +1,176 @@
+//go:build integration
+
+// End-to-end HTTP verification of the apply-form read: GET /api/v1/jobs/:slug/apply-form
+// drives the real path — GetJobIDBySlug → GetApplyFormByJobID → applyform.ForDisplay →
+// JSON — so what a client receives is what these tests assert.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/applyform"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func seedApplyFormJob(t *testing.T, q *db.Queries, extID, slug string) int64 {
+	t.Helper()
+	saved, err := q.UpsertJob(context.Background(), db.UpsertJobParams{
+		Source: "greenhouse", ExternalID: extID, URL: "https://ex.test/" + extID,
+		Title: "Staff Engineer", Company: "Acme", CompanySlug: "acme",
+		PublicSlug: slug, Location: "Remote", Description: "We need a staff engineer.",
+	})
+	if err != nil {
+		t.Fatalf("seed %s: %v", extID, err)
+	}
+	return saved.Job.ID
+}
+
+func seedApplyForm(t *testing.T, q *db.Queries, jobID int64, form applyform.Form) {
+	t.Helper()
+	payload, err := json.Marshal(form)
+	if err != nil {
+		t.Fatalf("encode form: %v", err)
+	}
+	if err := q.UpsertApplyForm(context.Background(), db.UpsertApplyFormParams{
+		JobID: jobID, Provider: form.Provider, Payload: payload,
+	}); err != nil {
+		t.Fatalf("seed form: %v", err)
+	}
+}
+
+func applyFormApp(q *db.Queries) *fiber.App {
+	h := &jobsHandlers{queries: q}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/jobs/:slug/apply-form", h.JobApplyForm)
+	return app
+}
+
+func getApplyForm(t *testing.T, app *fiber.App, slug string) (int, []byte) {
+	t.Helper()
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/jobs/"+slug+"/apply-form", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, body
+}
+
+func truncateApplyFormJobs(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		"TRUNCATE jobs, companies RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+}
+
+func TestJobApplyForm_ServesTheStoredQuestions(t *testing.T) {
+	pool := startPostgres(t)
+	q := db.New(pool)
+	truncateApplyFormJobs(t, pool)
+
+	jobID := seedApplyFormJob(t, q, "acme:1", "staff-engineer-acme-1")
+	seedApplyForm(t, q, jobID, applyform.Form{
+		Provider: "greenhouse",
+		Fields: []applyform.Field{
+			{ID: "first_name", Label: "First Name", Type: applyform.TypeText, Required: true},
+			{ID: "resume", Label: "Resume/CV", Type: applyform.TypeFile, Required: true},
+			{ID: "question_1", Label: "Why did you apply?", Type: applyform.TypeTextarea, Required: true},
+			{ID: "race", Label: "Race", Type: applyform.TypeSelect, Demographic: true},
+		},
+	})
+
+	status, body := getApplyForm(t, applyFormApp(q), "staff-engineer-acme-1")
+	if status != fiber.StatusOK {
+		t.Fatalf("status %d: %s", status, body)
+	}
+
+	var out struct {
+		Data applyform.Display `json:"data"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+	if out.Data.Provider != "greenhouse" {
+		t.Errorf("provider = %q, want %q", out.Data.Provider, "greenhouse")
+	}
+	if len(out.Data.Questions) != 1 || out.Data.Questions[0].Text != "Why did you apply?" {
+		t.Errorf("questions = %+v, want only the employer's own", out.Data.Questions)
+	}
+	if out.Data.Questions[0].Answer != "written answer" {
+		t.Errorf("answer = %q, want the written-answer hint", out.Data.Questions[0].Answer)
+	}
+	if len(out.Data.Basics) != 2 {
+		t.Errorf("basics = %v, want the two standard fields collapsed", out.Data.Basics)
+	}
+}
+
+// "This employer asks nothing" and "we could not read this platform" are different
+// statements, and only one of them is true — so a posting with no stored form must not
+// answer with an empty form.
+func TestJobApplyForm_PostingWithoutAStoredForm(t *testing.T) {
+	pool := startPostgres(t)
+	q := db.New(pool)
+	truncateApplyFormJobs(t, pool)
+
+	seedApplyFormJob(t, q, "acme:2", "staff-engineer-acme-2")
+
+	status, body := getApplyForm(t, applyFormApp(q), "staff-engineer-acme-2")
+	if status != fiber.StatusNotFound {
+		t.Fatalf("status %d: %s, want 404", status, body)
+	}
+}
+
+func TestJobApplyForm_UnknownSlug(t *testing.T) {
+	pool := startPostgres(t)
+	q := db.New(pool)
+	truncateApplyFormJobs(t, pool)
+
+	status, body := getApplyForm(t, applyFormApp(q), "no-such-job")
+	if status != fiber.StatusNotFound {
+		t.Fatalf("status %d: %s, want 404", status, body)
+	}
+}
+
+// A form asking nothing beyond a CV is the one-click apply a candidate is hunting for,
+// so it is served rather than treated as an absent form.
+func TestJobApplyForm_FormWithNoEmployerQuestions(t *testing.T) {
+	pool := startPostgres(t)
+	q := db.New(pool)
+	truncateApplyFormJobs(t, pool)
+
+	jobID := seedApplyFormJob(t, q, "acme:3", "staff-engineer-acme-3")
+	seedApplyForm(t, q, jobID, applyform.Form{
+		Provider: "recruitee",
+		Fields: []applyform.Field{
+			{ID: "name", Label: "Full name", Type: applyform.TypeText, Required: true},
+			{ID: "cv", Label: "CV", Type: applyform.TypeFile, Required: true},
+		},
+	})
+
+	status, body := getApplyForm(t, applyFormApp(q), "staff-engineer-acme-3")
+	if status != fiber.StatusOK {
+		t.Fatalf("status %d: %s", status, body)
+	}
+
+	var out struct {
+		Data applyform.Display `json:"data"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+	if len(out.Data.Questions) != 0 {
+		t.Errorf("questions = %+v, want none", out.Data.Questions)
+	}
+	if len(out.Data.Basics) != 2 {
+		t.Errorf("basics = %v, want both standard fields", out.Data.Basics)
+	}
+}

--- a/internal/handler/jobs.go
+++ b/internal/handler/jobs.go
@@ -36,6 +36,7 @@ func (h *jobsHandlers) register(api fiber.Router, mw middleware) {
 	api.Get("/jobs/find", h.FindJob)
 	api.Get("/jobs/:slug", mw.optional, h.GetJob)
 	api.Get("/jobs/:slug/copies", h.JobCopies)
+	api.Get("/jobs/:slug/apply-form", h.JobApplyForm)
 
 	// Moderator-authored jobs: create a hand-curated vacancy and edit it. Authenticated
 	// by cookie or API key (the CLI uses a key), then gated on the moderator role. The

--- a/openspec/changes/show-apply-questions/.openspec.yaml
+++ b/openspec/changes/show-apply-questions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/show-apply-questions/design.md
+++ b/openspec/changes/show-apply-questions/design.md
@@ -1,0 +1,106 @@
+## Context
+
+The brainstormed and approved design is
+`docs/superpowers/specs/2026-08-02-show-apply-questions-design.md`. This records the
+technical shape and the reasoning that is specific to fitting it into the codebase.
+
+`apply_forms` was shipped by `collect-ats-apply-forms` and is filling: Recruitee is
+complete at ~36k, Greenhouse and Ashby are draining a ~214k queue at roughly 8k an
+hour. The store keeps each platform's own vocabulary verbatim — field identifiers,
+option values, question text — because those tokens exist to be handed back to the
+platform that issued them.
+
+Reading it for display is the first consumer, and it wants almost none of that. It
+wants the question text and one word about the answer.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Show a candidate what a posting's application will ask, before they open it.
+- Cost nothing on the pages where no form is known — the majority.
+- Leave a future filter as a clean, separate piece of work.
+
+**Non-Goals:**
+
+- Any derived fact: counts, time estimates, "they will ask about salary".
+- Any change to the list endpoint, the search index, or `internal/jobview`.
+- Any fallback for a provider whose form cannot be read.
+
+## Decisions
+
+### The projection lives in `internal/applyform`, beside the capture
+
+`applyform` owns the shape of a captured form. A display projection over it belongs
+there rather than in `internal/handler`, for the reason the capture's own mappers
+live there: the knowledge of what a `Field` means is one thing, and splitting it
+across the handler would put half of it where nothing else can reach it.
+
+It is a pure function — stored `Form` in, display shape out. No database, no HTTP,
+so the exclusions are unit-testable without a fixture server.
+
+*Alternative rejected:* project in the handler. Cheaper by one file, and it would
+put "a demographic field is not an employer question" in the same package as route
+wiring, where the next reader would not look for it.
+
+### The endpoint follows `JobCopies` exactly
+
+Resolve the slug to an id (`GetJobIDBySlug`), then load the form. Two queries rather
+than one join, because that is what the sibling endpoint on the same resource does,
+and because it separates the two 404s cleanly: an unknown slug fails at the first
+query exactly as `/copies` does, while a known posting with no stored form fails at
+the second with its own message.
+
+`RenderError` already maps `pgx.ErrNoRows` to 404, so neither case needs handling
+written for it.
+
+### The page fetches it as a fourth parallel request
+
+`+page.server.ts` already runs three requests in parallel and degrades two of them
+to empty on failure, with the comment explaining why: a discovery aid must not break
+the page. The form is the same class of thing and takes the same treatment — a
+`.catch(() => null)` beside the other two.
+
+*Consequence, accepted:* one more API round trip per job page render. It is parallel
+with the existing three, so it costs latency only if it is the slowest, and it is a
+single indexed lookup by primary key.
+
+### The answer-kind vocabulary is a display concern, not a stored one
+
+`applyform.FieldType` already normalizes each platform's control names into ten
+values. The projection maps those to the words a reader sees, and maps the ones that
+are not questions — `hidden`, `info` — to exclusion rather than a word.
+
+An empty `FieldType` (a control the capture could not normalize, its `RawType` kept)
+yields no word. This is the capture's dict-only rule carried through to display: the
+question is real and is shown, but nothing is invented about what answering it
+costs.
+
+## Risks / Trade-offs
+
+- **The block is absent on most job pages** (8.8% of the open catalogue carries a
+  readable provider, 15.8% of technical postings) → Accepted rather than mitigated.
+  Where it appears it is exact, and the alternative — saying something generic about
+  the platform — was considered and dropped as noise.
+
+- **A form captured weeks ago may no longer match the live page** → The capture is
+  gated on "this job has no stored form", so it is written once and never refreshed;
+  an employer editing their form afterwards goes unnoticed. For telling a candidate
+  roughly what awaits them this is overwhelmingly right, and a freshness policy
+  belongs to whoever needs one — autofill will, this does not.
+
+- **Showing employer-authored text is republication** → A deliberate reversal of the
+  capture change's display decision, made by the product owner with the trade-off
+  stated. Recorded in the proposal so the next reader does not "fix" it back.
+
+## Migration Plan
+
+None. No schema change, no index change, no worker change. The endpoint is additive
+and the page degrades to today's behaviour without it, so the deploy has no ordering
+constraint and rollback is reverting the code.
+
+## Open Questions
+
+- Whether the block belongs near the apply button or lower on the page is a layout
+  question the implementation can settle by looking at it; the approved design says
+  beside the apply action, and nothing downstream depends on that choice.

--- a/openspec/changes/show-apply-questions/proposal.md
+++ b/openspec/changes/show-apply-questions/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+`apply_forms` holds the application form for every posting we can read one from —
+the questions, their kinds, whether an answer is required. Nothing reads it. The
+capture change shipped the store deliberately without a reader, on the grounds that
+the reader's shape was a product decision it should not make.
+
+That decision has been made. A candidate still cannot tell a one-click apply from
+an evening of essay writing until they have committed to the form, and the answer
+to "what will they ask me" is sitting in a table nobody queries.
+
+## What Changes
+
+- A new endpoint serves one posting's stored application form, shaped for display:
+  `GET /jobs/:slug/apply-form`. It answers 404 when there is no stored form, which
+  is the common case and always will be for the providers whose forms cannot be
+  read.
+- The job detail page fetches it alongside the similar-jobs and other-locations
+  requests it already makes, degrading to nothing on any failure, and renders the
+  questions in a block on the page.
+- The display projection collapses the standard fields into one entry, drops the
+  platform's equal-opportunity survey, and renders each question's control kind as
+  a word.
+
+Two deliberate reversals and exclusions, recorded because they contradict either a
+previous decision or an obvious expectation:
+
+- **The question text is shown verbatim.** The capture change decided the opposite —
+  store the text, display only a derived summary — because the questions are the
+  employer's writing. That is reversed here: a summary is a worse answer to "what
+  will they ask me" than the questions themselves.
+- **No derived facts at all.** No question count, no time estimate, no detection of
+  whether salary or a visa is asked. Counting is exact but reading meaning out of
+  employer prose is guessing, and a wrong guess beside the apply button would
+  discredit the accurate parts of the block along with itself.
+- **No provider fallback.** A posting whose platform we cannot read shows nothing
+  rather than something generic about the platform.
+- **Out of scope: a filter.** Filtering the catalogue by what applying costs needs a
+  filterable attribute in the search index and a full reindex to register it. That
+  cannot be justified before anyone has shown they read this block at all.
+
+## Capabilities
+
+### New Capabilities
+- `apply-form-display`: serving a stored application form for one posting and
+  showing its questions on the job page — the endpoint, the display projection, and
+  what it deliberately omits.
+
+### Modified Capabilities
+<!-- none: the endpoint is new, and internal/jobview is deliberately untouched -->
+
+## Impact
+
+- `internal/applyform` — a display projection over the stored `Form`.
+- `internal/handler` — one new read endpoint and its route.
+- `internal/db` — one query, loading a job's form by public slug.
+- `web/src/routes/jobs/[slug]/` — a fourth parallel fetch in the SSR loader.
+- `web/src/lib/components/` — one new component.
+- No migration, no search-index change, no change to `internal/jobview` and
+  therefore none to the indexed documents.

--- a/openspec/changes/show-apply-questions/specs/apply-form-display/spec.md
+++ b/openspec/changes/show-apply-questions/specs/apply-form-display/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: A posting's stored application form is served for display
+
+The system SHALL serve, for one posting identified by its public slug, the
+application form stored for it, in a shape meant for reading rather than for
+submitting. Where no form is stored the system SHALL answer that none exists rather
+than an empty form, because "this employer asks nothing" and "we could not read
+this platform" are different statements and only one of them is true.
+
+The served shape SHALL carry the provider the form was read from, so a reader can
+say where the answer came from.
+
+#### Scenario: A posting with a stored form
+
+- **WHEN** the form of a posting that has one is requested
+- **THEN** the response carries that posting's questions and the provider they were
+  read from
+
+#### Scenario: A posting with no stored form
+
+- **WHEN** the form of a posting that has none is requested
+- **THEN** the response says no form exists, and is distinguishable from a form
+  with no questions
+
+#### Scenario: A posting that does not exist
+
+- **WHEN** a form is requested for a slug no posting carries
+- **THEN** the response says so, in the same way the posting's own endpoint does
+
+### Requirement: The display projection shows the employer's questions and nothing else
+
+The served form SHALL carry, for each question the employer authored: the question
+text exactly as the platform published it, whether an answer is required, and the
+kind of answer expected.
+
+The projection SHALL exclude:
+
+- The controls every application demands — the candidate's name, contact details
+  and CV — presented instead as one entry, so their presence is stated once rather
+  than padding the list with what everyone expects.
+- Every control the platform itself classifies as an equal-opportunity or
+  demographic survey question. Those are not the employer's questions; they are a
+  mandated survey the platform serves in its own block, always optional and
+  near-identical everywhere, and listing them would bury the questions a candidate
+  actually needs to prepare for.
+- Every control that is not a question at all: one the platform fills itself and the
+  candidate never sees, and any block of text an employer placed in the middle of
+  the form.
+
+#### Scenario: An employer's question is shown whole
+
+- **WHEN** a stored form carries an employer's question
+- **THEN** the projection shows its text as published, whether it is required, and
+  the kind of answer it expects
+
+#### Scenario: The standard fields are stated once
+
+- **WHEN** a stored form carries the name, email, phone and CV controls
+- **THEN** the projection presents them as a single entry rather than one per control
+
+#### Scenario: The survey questions are dropped
+
+- **WHEN** a stored form carries controls the platform marked as demographic
+- **THEN** none of them appear in the projection, and the employer's own questions
+  are unaffected
+
+#### Scenario: Non-questions are dropped
+
+- **WHEN** a stored form carries a hidden control or a block of explanatory text
+- **THEN** neither appears in the projection
+
+#### Scenario: A form of nothing but standard fields
+
+- **WHEN** a stored form carries no employer questions at all
+- **THEN** the projection is served and says so — a form that asks only for a CV is
+  itself worth knowing
+
+### Requirement: A question's answer kind is named, and never guessed
+
+The projection SHALL name the kind of answer each question expects, drawn from a
+fixed vocabulary, so that a question answerable in a word is distinguishable from
+one demanding an essay — which is the difference that decides whether applying
+costs a minute or an evening.
+
+Where the stored form's control kind is one the capture could not normalize, the
+projection SHALL name no kind at all rather than the nearest one. The question is
+still shown; only the hint about its cost is withheld.
+
+#### Scenario: A written answer is distinguishable from a one-liner
+
+- **WHEN** the projection carries a long-form question and a single-line question
+- **THEN** the long-form one is named as expecting a written answer and the other
+  is not
+
+#### Scenario: An unrecognized kind yields no name
+
+- **WHEN** a question's stored kind is one the capture left unnormalized
+- **THEN** the question appears with no answer kind named
+
+### Requirement: The job page shows the questions, and its absence costs nothing
+
+The job detail page SHALL request the posting's form alongside the other
+non-essential requests it already makes, and SHALL render the questions when one
+comes back.
+
+A failure or an absent form SHALL leave the rest of the page untouched: the block is
+simply not rendered. The form is a discovery aid, and a discovery aid must never
+be able to break the page it sits on.
+
+#### Scenario: A posting whose form is known
+
+- **WHEN** the page is rendered for a posting with a stored form
+- **THEN** the questions appear on it
+
+#### Scenario: A posting whose form is not known
+
+- **WHEN** the page is rendered for a posting with no stored form
+- **THEN** the page renders exactly as it does today, with no block and no error
+
+#### Scenario: The request fails
+
+- **WHEN** the form request fails for any reason
+- **THEN** the page still renders, without the block

--- a/openspec/changes/show-apply-questions/tasks.md
+++ b/openspec/changes/show-apply-questions/tasks.md
@@ -1,8 +1,8 @@
 ## 1. The display projection
 
-- [ ] 1.1 Add the display shape and projection to `internal/applyform`: a pure function from a stored `Form` to the questions a reader sees, carrying the provider, each question's published text, whether it is required, and the word naming its answer kind
-- [ ] 1.2 Cover the exclusions: the standard name/email/phone/CV controls collapsed into one entry, every control the platform marked demographic dropped, and every non-question (`hidden`, `info`) dropped
-- [ ] 1.3 Cover the answer-kind vocabulary, including that an unnormalized kind yields no word while the question is still shown
+- [x] 1.1 Add the display shape and projection to `internal/applyform`: a pure function from a stored `Form` to the questions a reader sees, carrying the provider, each question's published text, whether it is required, and the word naming its answer kind
+- [x] 1.2 Cover the exclusions: the standard name/email/phone/CV controls collapsed into one entry, every control the platform marked demographic dropped, and every non-question (`hidden`, `info`) dropped
+- [x] 1.3 Cover the answer-kind vocabulary, including that an unnormalized kind yields no word while the question is still shown
 
 ## 2. The endpoint
 

--- a/openspec/changes/show-apply-questions/tasks.md
+++ b/openspec/changes/show-apply-questions/tasks.md
@@ -1,0 +1,22 @@
+## 1. The display projection
+
+- [ ] 1.1 Add the display shape and projection to `internal/applyform`: a pure function from a stored `Form` to the questions a reader sees, carrying the provider, each question's published text, whether it is required, and the word naming its answer kind
+- [ ] 1.2 Cover the exclusions: the standard name/email/phone/CV controls collapsed into one entry, every control the platform marked demographic dropped, and every non-question (`hidden`, `info`) dropped
+- [ ] 1.3 Cover the answer-kind vocabulary, including that an unnormalized kind yields no word while the question is still shown
+
+## 2. The endpoint
+
+- [ ] 2.1 Add the query loading a job's stored form by job id, then `make sqlc`
+- [ ] 2.2 Add `GET /jobs/:slug/apply-form` following `JobCopies`: resolve the slug to an id, load the form, respond `{"data": ...}`; an unknown slug and a posting with no stored form both 404, distinguishably
+- [ ] 2.3 Integration-test the three cases against a real database: a posting with a form, a posting without one, an unknown slug
+
+## 3. The page
+
+- [ ] 3.1 Add the API client call and wire it into `+page.server.ts` as a fourth parallel request, degrading to nothing on any failure like `similar` and `copies` already do
+- [ ] 3.2 Add the component rendering the questions, and cover that it renders nothing when there is no form
+- [ ] 3.3 Place it on the job page beside the apply action and check it visually against a posting that has a form
+
+## 4. Finish
+
+- [ ] 4.1 Run `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, both Go test passes, and the web gates (`lint` and `check` catch different things)
+- [ ] 4.2 Note the new endpoint in `internal/handler/AGENTS.md` and the reader in `internal/applyform`'s package doc, so the store no longer reads as write-only

--- a/openspec/changes/show-apply-questions/tasks.md
+++ b/openspec/changes/show-apply-questions/tasks.md
@@ -6,9 +6,9 @@
 
 ## 2. The endpoint
 
-- [ ] 2.1 Add the query loading a job's stored form by job id, then `make sqlc`
-- [ ] 2.2 Add `GET /jobs/:slug/apply-form` following `JobCopies`: resolve the slug to an id, load the form, respond `{"data": ...}`; an unknown slug and a posting with no stored form both 404, distinguishably
-- [ ] 2.3 Integration-test the three cases against a real database: a posting with a form, a posting without one, an unknown slug
+- [x] 2.1 Add the query loading a job's stored form by job id, then `make sqlc`
+- [x] 2.2 Add `GET /jobs/:slug/apply-form` following `JobCopies`: resolve the slug to an id, load the form, respond `{"data": ...}`; an unknown slug and a posting with no stored form both 404, distinguishably
+- [x] 2.3 Integration-test the three cases against a real database: a posting with a form, a posting without one, an unknown slug
 
 ## 3. The page
 

--- a/openspec/changes/show-apply-questions/tasks.md
+++ b/openspec/changes/show-apply-questions/tasks.md
@@ -12,9 +12,9 @@
 
 ## 3. The page
 
-- [ ] 3.1 Add the API client call and wire it into `+page.server.ts` as a fourth parallel request, degrading to nothing on any failure like `similar` and `copies` already do
-- [ ] 3.2 Add the component rendering the questions, and cover that it renders nothing when there is no form
-- [ ] 3.3 Place it on the job page beside the apply action and check it visually against a posting that has a form
+- [x] 3.1 Add the API client call and wire it into `+page.server.ts` as a fourth parallel request, degrading to nothing on any failure like `similar` and `copies` already do
+- [x] 3.2 Add the component rendering the questions. NOT unit-tested: vitest here runs in plain Node with no Svelte compilation (`vitest.config.ts`), so component tests are not a thing in this repo — the "renders nothing without a form" branch is verified visually in 3.3 instead
+- [x] 3.3 Place it on the job page beside the apply action and check it visually against a posting that has a form
 
 ## 4. Finish
 

--- a/openspec/changes/show-apply-questions/tasks.md
+++ b/openspec/changes/show-apply-questions/tasks.md
@@ -18,5 +18,5 @@
 
 ## 4. Finish
 
-- [ ] 4.1 Run `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, both Go test passes, and the web gates (`lint` and `check` catch different things)
-- [ ] 4.2 Note the new endpoint in `internal/handler/AGENTS.md` and the reader in `internal/applyform`'s package doc, so the store no longer reads as write-only
+- [x] 4.1 Run `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, both Go test passes, and the web gates (`lint` and `check` catch different things)
+- [x] 4.2 Note the new endpoint in `internal/handler/AGENTS.md` and the reader in `internal/applyform`'s package doc, so the store no longer reads as write-only

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -10,7 +10,7 @@
 // fetch per call site — not a module-level variable — keeps concurrent SSR
 // requests from sharing (and racing on) a session.
 
-import type { RevisionView } from '$lib/generated/contracts';
+import type { Display, RevisionView } from '$lib/generated/contracts';
 import type {
   CvAtsDelta,
   CvJobMatch,
@@ -338,6 +338,13 @@ export function createApi(
    *  renders them; the source job is excluded by the backend. */
   async function getSimilarJobs(slug: string): Promise<Job[]> {
     return requestData<Job[]>(`/api/v1/jobs/${slug}/similar`);
+  }
+
+  /** The questions this job's application will ask, as the ATS published them. 404s for
+   *  the majority of postings — a form can only be read from a few platforms — so callers
+   *  treat a failure as "not known" rather than as an error worth surfacing. */
+  async function getApplyForm(slug: string): Promise<Display> {
+    return requestData<Display>(`/api/v1/jobs/${slug}/apply-form`);
   }
 
   /** The open postings sharing this job's role cluster — the "openings across cities"
@@ -1656,6 +1663,7 @@ export function createApi(
     getJob,
     getSimilarJobs,
     getJobCopies,
+    getApplyForm,
     getJobMatch,
     getMatchAnalysis,
     runMatchAnalysis,

--- a/web/src/lib/components/JobApplyForm.svelte
+++ b/web/src/lib/components/JobApplyForm.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { Display } from '$lib/generated/contracts';
+
+  // What the application will ask, as the ATS published it. `form` is null for most
+  // postings — only a few platforms publish a form we can read — and the block simply
+  // does not render, which is the ordinary case rather than a degraded one.
+  let { form }: { form: Display | null } = $props();
+
+  // A form worth showing has either questions or a statement of what it wants uploaded.
+  // Neither is a reason to render a heading over nothing.
+  const worthShowing = $derived(
+    !!form && (form.questions?.length > 0 || form.basics?.length > 0)
+  );
+</script>
+
+{#if form && worthShowing}
+  <section class="mt-6 rounded-lg border border-border bg-card p-4">
+    <div class="mb-3 flex items-baseline justify-between gap-3">
+      <h2 class="text-sm font-semibold tracking-tight">What this application asks</h2>
+      <span class="text-xs text-muted-foreground capitalize">{form.provider}</span>
+    </div>
+
+    {#if form.basics?.length}
+      <!-- The controls every application demands, said once. Listed rather than dropped:
+           a form that does NOT want a CV is worth knowing too. -->
+      <p class="mb-2 max-w-3xl text-sm text-muted-foreground">
+        {form.basics.join(', ')}
+      </p>
+    {/if}
+
+    {#if form.questions?.length}
+      <!-- The hint follows the question rather than being pinned to the right edge. On a
+           wide viewport that pinning left ~900px of empty space between a question and the
+           word describing its answer, which is a long way to travel to read one line. -->
+      <ul class="flex max-w-3xl flex-col gap-2">
+        {#each form.questions as question (question.text)}
+          <li class="text-sm">
+            <span>{question.text}</span>
+            {#if question.answer || !question.required}
+              <span class="ml-2 whitespace-nowrap text-xs text-muted-foreground">
+                {#if question.answer}{question.answer}{/if}
+                {#if question.answer && !question.required}&middot;{/if}
+                {#if !question.required}optional{/if}
+              </span>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+{/if}

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -1054,6 +1054,49 @@ export interface RevisionView {
   created_at: string;
 }
 
+/**
+ * Display is a captured form shaped for a candidate to read rather than for a
+ * machine to submit. It is the near-inverse of what the store keeps: the store holds
+ * the platform's identifiers and option values because they exist to be handed back,
+ * and a reader wants none of that — only the question and one word about the answer.
+ */
+export interface Display {
+  /**
+   * Provider is the platform the form was read from, so a reader can say where the
+   * answer came from.
+   */
+  provider: string;
+  /**
+   * Basics are the controls every application demands — name, contact details, CV —
+   * listed once instead of one entry each. Stated rather than dropped, because a
+   * form that does NOT want a CV is worth knowing too.
+   */
+  basics: string[];
+  /**
+   * Questions are the employer's own, in the order the form presents them.
+   */
+  questions: Question[];
+}
+/**
+ * Question is one thing the employer will ask.
+ */
+export interface Question {
+  /**
+   * Text is the question as the employer wrote it, unedited.
+   */
+  text: string;
+  /**
+   * Required is whether the platform refuses the application without an answer.
+   */
+  required: boolean;
+  /**
+   * Answer names the kind of answer expected, empty where naming it would add
+   * nothing (a one-line answer is the default expectation) or where the capture
+   * could not normalize the control's kind.
+   */
+  answer?: string;
+}
+
 export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', '4dayweek', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'arbeitsagentur', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'betterteam', 'breezy', 'briefhq', 'bullhorn', 'careerplug', 'careerspage', 'catsone', 'cleverstaff', 'clinch', 'comeet', 'compleo', 'cornerstone', 'crelate', 'deel', 'djinni', 'earcu', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'functionalworks', 'geekjob', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'getro', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'hh', 'hibob', 'himalayas', 'hireology', 'huntflow', 'hurma', 'icims', 'infojobs', 'inhire', 'instaffo', 'ismartrecruit', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobscore', 'jobspresso', 'jobstash', 'jobtech', 'jobvite', 'jobylon', 'join', 'justjoin', 'lever', 'likeit', 'loxo', 'luxoft', 'manatal', 'mindsight', 'mycareersfuture', 'neogov', 'nofluffjobs', 'northstone', 'odoo', 'opencats', 'oracle', 'pageup', 'paycom', 'paylocity', 'peopleforce', 'personio', 'phenom', 'pinpoint', 'powertofly', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'reed', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'softgarden', 'solides', 'spark', 'speedrun', 'startupandvc', 'successfactors', 'talentadore', 'talenthr', 'talentlyft', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'trudvsem', 'tyomarkkinatori', 'ukg', 'usajobs', 'vagas', 'vention', 'vouch', 'wantapply', 'wantedkr', 'weworkremotely', 'whatjobs', 'workable', 'workablemarketplace', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn', 'expired'] as const;

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -15,7 +15,12 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
   //
   // Similar jobs are a non-essential discovery aid: a failure (search disabled,
   // no neighbours yet) must not break the page, so it degrades to an empty list.
-  const [job, similar, copiesResult] = await Promise.all([
+  //
+  // The application form is known for a minority of postings — only a few ATS platforms
+  // publish one we can read — so its absence is the ordinary case, not a failure. It
+  // degrades to null for the same reason the two below degrade to empty: nothing on this
+  // page may be able to break the page.
+  const [job, similar, copiesResult, applyForm] = await Promise.all([
     api.getJob(params.slug).catch((e) => {
       if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
       throw e;
@@ -24,6 +29,13 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
     // A small preview of the other-locations tab (the full list is /jobs/:slug/copies).
     // Non-essential and only meaningful for a mass-posted role, so it degrades to empty.
     api.getJobCopies(params.slug, 10).catch(() => ({ copies: [], total: 0 })),
+    api.getApplyForm(params.slug).catch(() => null),
   ]);
-  return { job, similar, copies: copiesResult.copies, copiesTotal: copiesResult.total };
+  return {
+    job,
+    similar,
+    copies: copiesResult.copies,
+    copiesTotal: copiesResult.total,
+    applyForm,
+  };
 };

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import JobApplyForm from '$lib/components/JobApplyForm.svelte';
   import JobRelated from '$lib/components/JobRelated.svelte';
   import JobView from '$lib/components/JobView.svelte';
   import Seo from '$lib/components/Seo.svelte';
@@ -44,6 +45,8 @@
      back to the shared px-4 rhythm. -->
 <div class="mx-auto w-full max-w-6xl px-5 py-6 sm:px-4">
   <JobView job={data.job} />
+
+  <JobApplyForm form={data.applyForm} />
 
   <JobRelated
     similar={data.similar}


### PR DESCRIPTION
The first reader over `apply_forms` — the store #1506 shipped deliberately without one, because the reader's shape was a product decision the capture should not make.

## What it does

A block on the job page listing the employer's questions, each with one word for the kind of answer:

```
What this application asks                        Greenhouse

  First Name, Last Name, Email, Phone, Resume/CV
  LinkedIn profile                     optional
  Which country do you currently reside in?      choose one
  Will you require visa sponsorship now or in the future?   choose one
  What made you apply for this role?             written answer
```

That one word is the whole point: it separates a question worth a minute from one worth an evening.

## Four things it deliberately refuses

- **A derived summary.** #1506 decided to store the text and display only counts, because the questions are the employer's writing. Reversed here by the product owner: a summary is a worse answer to "what will they ask me" than the questions.
- **Any derived fact at all** — no question count, no time estimate, no "they will ask about salary". Counting is exact; reading meaning out of employer prose is guessing, and a wrong guess beside the apply button would discredit the accurate parts of the block along with itself.
- **The EEO survey.** Not the employer's questions but a mandated one the platform serves in its own block, always optional and near-identical everywhere. The capture already marks it, so this is a filter rather than a judgement.
- **A provider fallback.** A posting whose platform we cannot read shows nothing rather than something generic.

## Shape

- `GET /jobs/:slug/apply-form`. Two queries rather than one join, mirroring `JobCopies` on the same resource, so an unknown slug and a posting with no captured form stay distinguishable — both 404, and "this employer asks nothing" is a different statement from "we cannot read this platform".
- **A 404 is the ordinary answer.** Forms are readable from three platforms — 8.8% of the open catalogue, 15.8% of technical postings — so most of the catalogue has none and never will. Documented in `internal/handler/AGENTS.md` so nobody alerts on it.
- The SSR loader takes it as a fourth parallel request degrading to `null`, the same treatment `similar` and `copies` already get: nothing on this page may be able to break the page.
- `internal/jobview` untouched. That projection is also what goes into the Meilisearch documents, so a field there would inflate every indexed job for one page — and keeping it out leaves a future filter as its own clean piece of work.
- The wire type is generated, not hand-written: `internal/applyform` joins the contract codegen, restricted to `display.go`.

## Verified by looking at it

The first layout pinned each hint to the right edge — on a 1280px viewport that left ~900px of empty space between a question and the word describing its answer. The hint now follows the question and wraps under it on a narrow screen, where the block also lands directly beneath the apply button.

Checked against a real server and a throwaway database seeded with a 16-field Greenhouse form: `Resume/CV` collapsed from two controls to one entry, the demographic questions and the hidden longitude dropped, every answer kind named.

Component behaviour is not unit-tested and cannot be: `vitest.config.ts` runs plain Node with no Svelte compilation, so there is no component test infrastructure in this repo. The "renders nothing without a form" branch is covered visually instead, and the task list says so rather than implying coverage that does not exist.

## Out of scope

A filter on what applying costs. It needs a filterable attribute in the search index and a full reindex to register it, and that cannot be justified before anyone has shown they read this block.

## Verification

```
gofmt / go build / go vet / go vet -tags=integration     clean
go test ./...                                            131 packages ok
go test -tags=integration ./internal/{handler,db,applyform}/   ok
pnpm run check      0 errors      pnpm run lint   0 errors
vitest              826 tests, 77 files
```

OpenSpec change `show-apply-questions`, all tasks complete, `openspec validate` clean. Design: `docs/superpowers/specs/2026-08-02-show-apply-questions-design.md`.