### PR TITLE
fix(applyform): a question's text is not always plain text

### DIFF
--- a/internal/applyform/display.go
+++ b/internal/applyform/display.go
@@ -1,8 +1,11 @@
 package applyform
 
 import (
+	"html"
 	"slices"
 	"strings"
+
+	"github.com/microcosm-cc/bluemonday"
 )
 
 // Display is a captured form shaped for a candidate to read rather than for a
@@ -71,6 +74,31 @@ func isStandard(provider string, f Field) bool {
 	return slices.Contains(standardFieldIDs[provider], f.ID)
 }
 
+// labelPolicy strips all markup, leaving text. Compiled once, safe for concurrent use —
+// the same shape internal/sources uses for the same purpose.
+var labelPolicy = bluemonday.StrictPolicy()
+
+// asText flattens a label to plain text. Some platforms author question text as HTML —
+// Recruitee's consent questions arrive as a full <p> with an anchor inside — and the store
+// keeps what the platform sent, which is right. The reader shows text, so the tags come
+// off here.
+//
+// Deliberately flattened rather than rendered: this is employer-controlled markup, and a
+// block listing questions has no reason to be the one place it gets injected into our own
+// page.
+//
+// Not htmltext.ToText, which renders for reading and turns <b>CV</b> into *CV* — emphasis
+// markers are noise in a one-line label. Sanitize-then-unescape is what internal/sources
+// already does when it wants text rather than a rendering.
+func asText(label string) string {
+	if !strings.ContainsRune(label, '<') && !strings.ContainsRune(label, '&') {
+		return label
+	}
+	// Whitespace is normalized because stripping tags leaves the newlines and runs of
+	// spaces that were laying out the markup, not the sentence.
+	return strings.Join(strings.Fields(html.UnescapeString(labelPolicy.Sanitize(label))), " ")
+}
+
 // ForDisplay projects a captured form into what a candidate reads. It is pure: no
 // database, no network, so what it includes and what it refuses can be tested
 // without a fixture of either.
@@ -93,13 +121,13 @@ func (f Form) ForDisplay() Display {
 		case isStandard(f.Provider, field):
 			// One label may cover several controls (Greenhouse offers the CV as an
 			// upload OR pasted text under a single label), so the reader sees it once.
-			if !slices.Contains(d.Basics, field.Label) {
-				d.Basics = append(d.Basics, field.Label)
+			if label := asText(field.Label); !slices.Contains(d.Basics, label) {
+				d.Basics = append(d.Basics, label)
 			}
 
 		default:
 			d.Questions = append(d.Questions, Question{
-				Text:     field.Label,
+				Text:     asText(field.Label),
 				Required: field.Required,
 				Answer:   answerWords[field.Type],
 			})

--- a/internal/applyform/display_test.go
+++ b/internal/applyform/display_test.go
@@ -1,6 +1,9 @@
 package applyform
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func questionTexts(d Display) []string {
 	out := make([]string, 0, len(d.Questions))
@@ -218,5 +221,62 @@ func TestForDisplayKeepsTheFormsOrder(t *testing.T) {
 	got := questionTexts(d)
 	if len(got) != 2 || got[0] != "First" || got[1] != "Second" {
 		t.Errorf("questions = %v, want them in the platform's order", got)
+	}
+}
+
+// A question's text is not always plain text. Recruitee's consent questions arrive as
+// HTML — this one shipped to production and rendered as visible markup on the job page:
+//
+//	<p>Ik heb de <a href="...">privacyverklaring</a> van Pon Holding B.V. gelezen...</p>
+//
+// The store keeps what the platform sent, which is right; the reader shows text, so the
+// tags come off here. Not rendered as HTML: it is employer-controlled markup, and this
+// block has no reason to be the one place we inject it into our own page.
+func TestForDisplayFlattensHTMLInAQuestion(t *testing.T) {
+	d := Form{
+		Provider: "recruitee",
+		Fields: []Field{{
+			ID:    "q",
+			Label: `<p>Ik heb de <a href="https://example.test/privacy" target="_blank" rel="noopener">privacyverklaring</a> gelezen.</p>`,
+			Type:  TypeBoolean,
+		}},
+	}.ForDisplay()
+
+	if len(d.Questions) != 1 {
+		t.Fatalf("questions = %v, want one", questionTexts(d))
+	}
+	got := d.Questions[0].Text
+	if strings.Contains(got, "<") || strings.Contains(got, "href") {
+		t.Errorf("text = %q, want the markup stripped", got)
+	}
+	if !strings.Contains(got, "privacyverklaring") || !strings.Contains(got, "gelezen") {
+		t.Errorf("text = %q, want the words kept", got)
+	}
+}
+
+// Plain text is the overwhelming majority and must survive untouched — no stray
+// whitespace, no escaping, no reflowing.
+func TestForDisplayLeavesPlainTextAlone(t *testing.T) {
+	const plain = "What made you apply for this role?"
+	d := Form{
+		Provider: "greenhouse",
+		Fields:   []Field{{ID: "q", Label: plain, Type: TypeTextarea}},
+	}.ForDisplay()
+
+	if got := d.Questions[0].Text; got != plain {
+		t.Errorf("text = %q, want it unchanged (%q)", got, plain)
+	}
+}
+
+// The standard fields are labelled by our own mappers, but they go through the same
+// flattening — nothing should be able to put markup on the page by that route either.
+func TestForDisplayFlattensHTMLInABasic(t *testing.T) {
+	d := Form{
+		Provider: "recruitee",
+		Fields:   []Field{{ID: "cv", Label: "<b>CV</b>", Type: TypeFile}},
+	}.ForDisplay()
+
+	if len(d.Basics) != 1 || d.Basics[0] != "CV" {
+		t.Errorf("basics = %v, want the markup stripped", d.Basics)
 	}
 }


### PR DESCRIPTION
Follow-up to #1516, found by crawling a single board on production and reading the record it produced.

## The bug, live

Recruitee authors its consent questions as HTML. One rendered on the job page as visible markup:

```
<p>Ik heb de <a href="https://www.jobsatpon.com/nl/nl/privacy-statement" target="_blank"
rel="noopener">privacyverklaring</a> van Pon Holding B.V. gelezen en begrijp hoe mijn
persoonsgegevens worden verwerkt.</p>   yes / no
```

Seen at https://freehire.me/jobs/technisch-trainer-pon3-euvuwa27 — the last question in the block.

## The fix

The store keeps what the platform sent; that stays right. The reader is what shows text, so the tags come off in the display projection.

**Flattened, not rendered.** This is employer-authored markup, and a block listing questions has no business being the one place we inject it into our own page.

**Not `htmltext.ToText`** — that renders HTML for reading and turns `<b>CV</b>` into `*CV*`; emphasis markers are noise in a one-line label. Sanitize-then-unescape is what `internal/sources` already does where it wants text rather than a rendering. Whitespace is normalized afterwards, because stripping tags leaves the newlines that were laying out the markup rather than the sentence.

Three tests: HTML in a question, HTML in a standard-field label, and plain text passing through byte-identical.