### PR TITLE
fix(applyform): a Lever consent box carries its own label

### DIFF
--- a/internal/applyform/display.go
+++ b/internal/applyform/display.go
@@ -133,6 +133,12 @@ func (f Form) ForDisplay() Display {
 		case field.Demographic:
 			continue
 
+		// A control nothing could name cannot be described to anyone. It stays in the
+		// store — the identifier is still what a form-filler needs — but an unnamed
+		// entry on the page is a stray comma at best and a blank bullet at worst.
+		case strings.TrimSpace(field.Label) == "":
+			continue
+
 		case isStandard(f.Provider, field):
 			// One label may cover several controls (Greenhouse offers the CV as an
 			// upload OR pasted text under a single label), so the reader sees it once.

--- a/internal/applyform/lever.go
+++ b/internal/applyform/lever.go
@@ -128,14 +128,29 @@ func leverControl(group []*html.Node) (FieldType, string, []Option) {
 
 // blockLabel reads the question as the employer wrote it, with the required marker
 // removed and whitespace collapsed — the markup lays the label out across several nodes.
+//
+// A consent block carries no application-label at all: the text a candidate reads sits
+// beside the checkbox instead. Without that fallback the control was captured with an
+// empty label, which reached production as a stray comma at the end of the standard
+// fields line.
 func blockLabel(block *html.Node) string {
 	for _, n := range descendants(block) {
 		if hasClass(n, "application-label") {
-			return strings.Join(strings.Fields(
-				strings.ReplaceAll(textOf(n), requiredGlyph, " ")), " ")
+			return tidyLabel(textOf(n))
+		}
+	}
+	for _, n := range descendants(block) {
+		if hasClass(n, "application-answer-alternative") {
+			return tidyLabel(textOf(n))
 		}
 	}
 	return ""
+}
+
+// tidyLabel drops the required marker and collapses the whitespace the markup used for
+// layout rather than for the sentence.
+func tidyLabel(text string) string {
+	return strings.Join(strings.Fields(strings.ReplaceAll(text, requiredGlyph, " ")), " ")
 }
 
 // controls returns the block's form controls in document order.

--- a/internal/applyform/lever_test.go
+++ b/internal/applyform/lever_test.go
@@ -70,6 +70,14 @@ const leverPage = `<html><body><form>
   <div class="application-field"><p>Just a note from the employer.</p></div>
 </li>
 
+<li class="application-question">
+  <div class="application-field full-width"><ul><li><label>
+    <input type="hidden" name="consent[marketing]" value="0" />
+    <input type="checkbox" name="consent[marketing]" value="1" />
+    <p class="application-answer-alternative">Yes, Acme can contact me about future roles for up to 1 year</p>
+  </label></li></ul></div>
+</li>
+
 </ul></form></body></html>`
 
 func parseLever(t *testing.T) Form {
@@ -214,5 +222,20 @@ func TestFromLeverFoldsTheConsentPair(t *testing.T) {
 	}
 	if seen != 1 {
 		t.Errorf("consent produced %d controls, want 1", seen)
+	}
+}
+
+// The marketing-consent block carries no application-label at all: the text a candidate
+// reads sits beside the checkbox instead. Without a fallback the control is captured
+// with an empty label, which reached production as a stray comma at the end of the
+// standard-fields line.
+func TestFromLeverLabelsAConsentBoxFromItsOwnText(t *testing.T) {
+	got := leverField(t, parseLever(t), "consent[marketing]")
+
+	if got.Label != "Yes, Acme can contact me about future roles for up to 1 year" {
+		t.Errorf("label = %q, want the text presented beside the checkbox", got.Label)
+	}
+	if got.Type != TypeBoolean {
+		t.Errorf("type = %q, want %q", got.Type, TypeBoolean)
 	}
 }


### PR DESCRIPTION
Follow-up to #1527, found by capturing a live Lever board and reading the record.

## The bug

Every Lever question block was assumed to hold an `application-label`. The marketing-consent block does not — the text sits beside the checkbox in an `application-answer-alternative` instead:

```html
<li class="application-question"><div class="application-field full-width"><ul><li><label>
  <input type="hidden" name="consent[marketing]" value="0">
  <input type="checkbox" name="consent[marketing]" value="1">
  <p class="application-answer-alternative">Yes, Shield AI can contact me about future job opportunities…</p>
```

So the control was captured unnamed, and the standard-fields line rendered as:

```
Resume/CV, Full name, Email, Phone, Current location, Current company, 
```

— with a stray comma and nothing after it.

## The fix

The parser falls back to that text. It is what the candidate is agreeing to, so it is the right label rather than a placeholder.

The display also stops emitting a control it cannot name — belt and braces rather than the fix itself. An unnamed entry is a stray comma at best and a blank bullet at worst, and no future platform should be able to put one on the page. The control stays in the store; its identifier is still what a form-filler needs.