### PR TITLE
fix(applyform): read a Lever consent label from its own <label>

### DIFF
--- a/internal/applyform/lever.go
+++ b/internal/applyform/lever.go
@@ -130,9 +130,13 @@ func leverControl(group []*html.Node) (FieldType, string, []Option) {
 // removed and whitespace collapsed — the markup lays the label out across several nodes.
 //
 // A consent block carries no application-label at all: the text a candidate reads sits
-// beside the checkbox instead. Without that fallback the control was captured with an
-// empty label, which reached production as a stray comma at the end of the standard
-// fields line.
+// inside the <label> beside the checkbox. The wrapper around it varies by tenant — one
+// board puts it in a `p.application-answer-alternative`, another in a bare `span` — so
+// the fallback reads the enclosing <label> itself, which is what makes that text a label
+// in the first place and does not depend on how the employer styled it.
+//
+// Without a fallback the control was captured unnamed and reached production as a stray
+// comma at the end of the standard-fields line.
 func blockLabel(block *html.Node) string {
 	for _, n := range descendants(block) {
 		if hasClass(n, "application-label") {
@@ -140,8 +144,10 @@ func blockLabel(block *html.Node) string {
 		}
 	}
 	for _, n := range descendants(block) {
-		if hasClass(n, "application-answer-alternative") {
-			return tidyLabel(textOf(n))
+		if n.Data == "label" {
+			if text := tidyLabel(textOf(n)); text != "" {
+				return text
+			}
 		}
 	}
 	return ""

--- a/internal/applyform/lever_test.go
+++ b/internal/applyform/lever_test.go
@@ -78,6 +78,17 @@ const leverPage = `<html><body><form>
   </label></li></ul></div>
 </li>
 
+<li class="application-question">
+  <div class="application-field full-width">
+    <p data-qa="legitimate-interest-copy"><div>Acme collects and processes your personal data solely for your application.</div></p>
+    <ul><li><label>
+      <span class=""><div>Yes, notify me about future roles that match my profile.</div></span>
+      <input type="hidden" name="consent[notify]" value="0" />
+      <input type="checkbox" name="consent[notify]" value="1" />
+    </label></li></ul>
+  </div>
+</li>
+
 </ul></form></body></html>`
 
 func parseLever(t *testing.T) Form {
@@ -230,12 +241,19 @@ func TestFromLeverFoldsTheConsentPair(t *testing.T) {
 // with an empty label, which reached production as a stray comma at the end of the
 // standard-fields line.
 func TestFromLeverLabelsAConsentBoxFromItsOwnText(t *testing.T) {
-	got := leverField(t, parseLever(t), "consent[marketing]")
-
-	if got.Label != "Yes, Acme can contact me about future roles for up to 1 year" {
-		t.Errorf("label = %q, want the text presented beside the checkbox", got.Label)
-	}
-	if got.Type != TypeBoolean {
-		t.Errorf("type = %q, want %q", got.Type, TypeBoolean)
+	// Two tenants, two different wrappers around the same idea — the first fix read one
+	// of them and left the other unnamed on production. The rule that covers both is the
+	// enclosing <label>, which is what makes the text a label in the first place.
+	for _, tc := range []struct{ id, want string }{
+		{"consent[marketing]", "Yes, Acme can contact me about future roles for up to 1 year"},
+		{"consent[notify]", "Yes, notify me about future roles that match my profile."},
+	} {
+		got := leverField(t, parseLever(t), tc.id)
+		if got.Label != tc.want {
+			t.Errorf("%s label = %q, want %q", tc.id, got.Label, tc.want)
+		}
+		if got.Type != TypeBoolean {
+			t.Errorf("%s type = %q, want %q", tc.id, got.Type, TypeBoolean)
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to #1528, which fixed one tenant's markup and left another's unnamed.

## Why the first fix was not enough

Lever lets employers style the consent block, and the wrapper around the text varies:

```html
<!-- one board -->
<label><input …><p class="application-answer-alternative">Yes, Shield AI can contact me…</p></label>

<!-- another -->
<label><span class=""><div>Yes, I would like to receive notifications…</div></span><input …></label>
```

Matching either class matches only that board. #1528 matched the first and shipped; the second still rendered as a stray comma at the end of the standard-fields line.

## The rule that covers both

The enclosing `<label>`. That is what makes the text a label in the first place, and it does not depend on how the employer styled the inside of it.

## Verified against a real page, not a fixture

Ran the parser over an unedited live apply page: **27 controls, none unnamed**, consent included. The committed fixture now carries both wrappers, so a parser written against one of them fails in the test rather than on the job page.

This is the second bug in this area found by reading real captured data and the second that no fixture would have caught — the first fixture was itself copied from a single tenant.