### PR TITLE
fix(applyform): a consent checkbox is boilerplate, not a question

### DIFF
--- a/internal/applyform/display.go
+++ b/internal/applyform/display.go
@@ -133,6 +133,16 @@ func (f Form) ForDisplay() Display {
 		case field.Demographic:
 			continue
 
+		// A consent checkbox is the platform's legal boilerplate rather than the
+		// employer's question: it is on every application, its text is a paragraph of
+		// data-protection language, and a candidate deciding whether to apply learns
+		// nothing from it. Same reasoning as the equal-opportunity survey above — and
+		// left in, that paragraph sits in the standard-fields line beside "Email".
+		//
+		// It stays in the store. Anything that eventually FILLS a form has to tick it.
+		case strings.HasPrefix(field.ID, "consent["):
+			continue
+
 		// A control nothing could name cannot be described to anyone. It stays in the
 		// store — the identifier is still what a form-filler needs — but an unnamed
 		// entry on the page is a stray comma at best and a blank bullet at worst.

--- a/internal/applyform/display_test.go
+++ b/internal/applyform/display_test.go
@@ -332,7 +332,38 @@ func TestForDisplaySeparatesLeversStandardApplication(t *testing.T) {
 	if len(got) != 2 || got[0] != "Are you authorized to work in the US?" {
 		t.Errorf("questions = %v, want only the two the employer wrote", got)
 	}
-	if len(d.Basics) != 5 {
-		t.Errorf("basics = %v, want the five standard controls", d.Basics)
+	// Four, not five: the consent checkbox is boilerplate and is dropped — see
+	// TestForDisplayDropsLeverConsentBoilerplate.
+	if len(d.Basics) != 4 {
+		t.Errorf("basics = %v, want the four real standard controls", d.Basics)
+	}
+}
+
+// A consent checkbox is the platform's legal boilerplate, not the employer's question:
+// it is on every Lever application, its text is a paragraph, and a candidate deciding
+// whether to apply learns nothing from it. Same reasoning as the EEO survey — and left
+// in, its 250-character paragraph sits in the standard-fields line beside "Email".
+func TestForDisplayDropsLeverConsentBoilerplate(t *testing.T) {
+	d := Form{
+		Provider: "lever",
+		Fields: []Field{
+			{ID: "name", Label: "Full name", Type: TypeText, Required: true},
+			{ID: "email", Label: "Email", Type: TypeText, Required: true},
+			{ID: "consent[store]", Label: "I agree to the storage of my data for up to five years", Type: TypeBoolean, Required: true},
+			{ID: "consent[marketing]", Label: "Yes, I would like to receive notifications about future job opportunities that match my skill profile.", Type: TypeBoolean},
+			{ID: "cards[abc][field0]", Label: "Why this role?", Type: TypeTextarea, Required: true},
+		},
+	}.ForDisplay()
+
+	for _, b := range d.Basics {
+		if strings.Contains(b, "consent") || strings.Contains(b, "storage of my data") || strings.Contains(b, "notifications about future") {
+			t.Errorf("basics = %v, want the consent boilerplate dropped", d.Basics)
+		}
+	}
+	if len(d.Basics) != 2 {
+		t.Errorf("basics = %v, want just the two real ones", d.Basics)
+	}
+	if len(d.Questions) != 1 {
+		t.Errorf("questions = %v, want the employer's own only", questionTexts(d))
 	}
 }


### PR DESCRIPTION
Third thing found by reading a captured Lever form on production rather than a fixture.

## What it looked like

```
Resume/CV, Full name, Email, Phone, Current location, Current company, Yes, I would like to
receive notifications about future job opportunities that match my skill profile. I understand
I can opt out at any time, my data will never be sold, and I will only be contacted about
relevant job openings.
```

A 250-character consent paragraph in a comma-separated list of short field names — on every one of ~42k Lever pages once the backlog drains.

## The call

A consent checkbox is the platform's legal boilerplate, not the employer's question. It is on every application, its text is data-protection language, and a candidate deciding whether to apply learns nothing from it. That is exactly the reasoning already applied to the equal-opportunity survey, which this change makes consistent.

Dropped from the **display** only. It stays in the store — anything that eventually *fills* a form has to tick it.

One earlier test's expectation moves from five standard controls to four, with a comment pointing at the new one, because that is the deliberate behaviour change rather than a regression.