### PR TITLE
fix(assistant): a turn survives a client that stops reading

### DIFF
--- a/internal/assistant/AGENTS.md
+++ b/internal/assistant/AGENTS.md
@@ -16,13 +16,28 @@ built from the same services the HTTP handlers use.
   turn. Only a model/transport failure ends a turn as errored.
 - **Every turn ends with exactly one `result` event.** A client that receives no
   terminal event waits forever, so the loop emits one on every path: an answer,
-  the step cap, cancellation, and failure.
-- **A turn is bounded three ways**: tool-calling rounds, the LLM client's per-call
-  timeout, and cancellation. Zero/negative bounds fall back to defaults rather
-  than meaning "unbounded" — an unbounded loop on a metered gateway is a runaway
-  bill. The round ceiling is `RunnerConfig.MaxSteps` unless the turn names its own
-  through `TurnConfig`; that value is always chosen server-side, because a ceiling
-  a client can raise is not a ceiling.
+  the step cap, cancellation, and failure — and so does the handler on the one path
+  that never reaches the loop, a queued message whose wait ran out.
+- **A turn is bounded two ways**: tool-calling rounds and the LLM client's per-call
+  timeout. Zero/negative bounds fall back to defaults rather than meaning
+  "unbounded" — an unbounded loop on a metered gateway is a runaway bill. The round
+  ceiling is `RunnerConfig.MaxSteps` unless the turn names its own through
+  `TurnConfig`; that value is always chosen server-side, because a ceiling a client
+  can raise is not a ceiling.
+- **A turn outlives its reader, and stops only when asked.** A failed SSE write means
+  this reader is not listening — a phone freezing a backgrounded tab, a slept laptop
+  — and nothing more; the turn runs to its own end and its transcript is stored
+  whether or not anyone reads it. Treating that write as "the user left" is what once
+  lost an unattended run its report after twenty-five committed CV edits. Stopping is
+  a request of its own (`POST /assistant/sessions/:id/cancel`), because a dropped
+  connection cannot be told apart from a deliberate Stop.
+- **One turn at a time per session.** `turnRegistry` (`internal/handler/assistant_turns.go`)
+  holds each running turn's `CancelFunc` — the only handle on a turn no request owns
+  any more — and makes a second message wait rather than run beside the first: two
+  turns of one tailoring session would edit one CV from two conversations that cannot
+  see each other. One message may wait, a further one is refused. The registry is
+  per-process, so a turn started before a blue/green flip cannot be cancelled and ends
+  at its step cap.
 - **The transcript IS the model's history.** One table holds both, including the
   assistant's tool calls and each tool's result, with the model's argument string
   stored verbatim. Two stores would drift; re-encoding parsed arguments would

--- a/internal/assistant/runner.go
+++ b/internal/assistant/runner.go
@@ -18,6 +18,10 @@ import (
 type EventKind string
 
 const (
+	// EventQueued precedes a turn that had to wait for the session's previous one. It is not
+	// produced by the loop — the turn has not started yet — but it travels the same stream, so
+	// a client learns it is waiting instead of watching a silent connection and guessing.
+	EventQueued           EventKind = "queued"
 	EventUserPrompt       EventKind = "user_prompt"
 	EventAssistantText    EventKind = "assistant_text"
 	EventAssistantThought EventKind = "assistant_thought"

--- a/internal/cvedit/apply.go
+++ b/internal/cvedit/apply.go
@@ -62,8 +62,8 @@ func Apply(state State, ops []Op) (State, []Op, error) {
 	}
 
 	inverse := make([]Op, 0, len(ops))
-	for _, i := range applyOrder(ops) {
-		undo, err := applyOne(&working, ops[i])
+	for i, op := range ops {
+		undo, err := applyOne(&working, op)
 		if err != nil {
 			return state, nil, fmt.Errorf("operation %d: %w", i+1, err)
 		}
@@ -72,46 +72,47 @@ func Apply(state State, ops []Op) (State, []Op, error) {
 	return working, inverse, nil
 }
 
-// applyOrder is the order the batch runs in, as positions into ops. It differs from the order
-// the caller wrote in one case: a run of removals addressing the same list goes highest index
-// first.
+// OrderAgainstOriginal rewrites a batch written against the document as the author SAW it into
+// one that means the same thing applied in sequence, by running each list's consecutive
+// removals from the highest index down.
 //
-// A batch names its positions against the document it was written for. Removing an earlier
-// position first shifts every later one out from under its own address, so a batch asking for
-// two positions of one list would refuse itself for a reason the caller never asked for.
-// Reordering is confined to consecutive removals of one list, so no operation ever crosses one
-// that might address what it reads or writes.
+// It is not part of Apply, and that distinction is the whole point. Apply's own index semantics
+// are sequential — each operation addresses the list as the batch has changed it so far — and
+// two of its three callers depend on that: `Diff` states its indices exactly that way, and the
+// inverses Apply itself produces are replayed the same way by undo. Sorting inside Apply
+// silently corrupted both: a save that deleted two non-adjacent bullets deleted the wrong one,
+// and undoing a run left the agent's insertion in place while removing the candidate's line.
 //
-// Error messages keep the caller's own numbering: it is their batch, not this order, that they
-// can see.
-func applyOrder(ops []Op) []int {
-	order := make([]int, len(ops))
-	for i := range order {
-		order[i] = i
-	}
-	for start := 0; start < len(ops); {
-		list, _, ok := listAddress(ops[start])
+// A model is the one author that does not think sequentially: it reads the document once and
+// names the positions it saw. So the conversion belongs where that batch arrives, and nowhere
+// else.
+func OrderAgainstOriginal(ops []Op) []Op {
+	ordered := make([]Op, len(ops))
+	copy(ordered, ops)
+
+	for start := 0; start < len(ordered); {
+		list, _, ok := listAddress(ordered[start])
 		if !ok {
 			start++
 			continue
 		}
 		end := start + 1
-		for end < len(ops) {
-			next, _, ok := listAddress(ops[end])
+		for end < len(ordered) {
+			next, _, ok := listAddress(ordered[end])
 			if !ok || next != list {
 				break
 			}
 			end++
 		}
-		run := order[start:end]
+		run := ordered[start:end]
 		sort.SliceStable(run, func(a, b int) bool {
-			_, x, _ := listAddress(ops[run[a]])
-			_, y, _ := listAddress(ops[run[b]])
+			_, x, _ := listAddress(run[a])
+			_, y, _ := listAddress(run[b])
 			return x > y
 		})
 		start = end
 	}
-	return order
+	return ordered
 }
 
 // listAddress splits a removal's path into the list it addresses and the position within it —

--- a/internal/cvedit/apply.go
+++ b/internal/cvedit/apply.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 // OpKind is the closed set of things an edit can do. Four structural operations replace the
@@ -59,14 +62,76 @@ func Apply(state State, ops []Op) (State, []Op, error) {
 	}
 
 	inverse := make([]Op, 0, len(ops))
-	for i, op := range ops {
-		undo, err := applyOne(&working, op)
+	for _, i := range applyOrder(ops) {
+		undo, err := applyOne(&working, ops[i])
 		if err != nil {
 			return state, nil, fmt.Errorf("operation %d: %w", i+1, err)
 		}
 		inverse = append([]Op{undo}, inverse...)
 	}
 	return working, inverse, nil
+}
+
+// applyOrder is the order the batch runs in, as positions into ops. It differs from the order
+// the caller wrote in one case: a run of removals addressing the same list goes highest index
+// first.
+//
+// A batch names its positions against the document it was written for. Removing an earlier
+// position first shifts every later one out from under its own address, so a batch asking for
+// two positions of one list would refuse itself for a reason the caller never asked for.
+// Reordering is confined to consecutive removals of one list, so no operation ever crosses one
+// that might address what it reads or writes.
+//
+// Error messages keep the caller's own numbering: it is their batch, not this order, that they
+// can see.
+func applyOrder(ops []Op) []int {
+	order := make([]int, len(ops))
+	for i := range order {
+		order[i] = i
+	}
+	for start := 0; start < len(ops); {
+		list, _, ok := listAddress(ops[start])
+		if !ok {
+			start++
+			continue
+		}
+		end := start + 1
+		for end < len(ops) {
+			next, _, ok := listAddress(ops[end])
+			if !ok || next != list {
+				break
+			}
+			end++
+		}
+		run := order[start:end]
+		sort.SliceStable(run, func(a, b int) bool {
+			_, x, _ := listAddress(ops[run[a]])
+			_, y, _ := listAddress(ops[run[b]])
+			return x > y
+		})
+		start = end
+	}
+	return order
+}
+
+// listAddress splits a removal's path into the list it addresses and the position within it —
+// `experience[0].bullets[3]` becomes `experience[0].bullets` and 3. It reports false for
+// anything that is not a removal from a position, which is what excludes every other operation
+// from reordering.
+func listAddress(op Op) (string, int, bool) {
+	if op.Kind != OpRemove {
+		return "", 0, false
+	}
+	s := string(op.Path)
+	open := strings.LastIndexByte(s, '[')
+	if open < 0 || !strings.HasSuffix(s, "]") {
+		return "", 0, false
+	}
+	at, err := strconv.Atoi(s[open+1 : len(s)-1])
+	if err != nil {
+		return "", 0, false
+	}
+	return s[:open], at, true
 }
 
 func applyOne(state *State, op Op) (Op, error) {

--- a/internal/cvedit/apply_test.go
+++ b/internal/cvedit/apply_test.go
@@ -1,6 +1,7 @@
 package cvedit
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -198,6 +199,56 @@ func TestApplyRefusesAnOperationItCannotCarryOut(t *testing.T) {
 				t.Fatal("a refused operation changed the state")
 			}
 		})
+	}
+}
+
+// A batch names its positions against the document it was written for. Removing an earlier
+// position first shifts every later one, so applying them front-to-back makes a batch of two
+// removals refuse itself — the failure the tailoring agent kept hitting on prod.
+func TestApplyRemovesTwoPositionsOfOneList(t *testing.T) {
+	before := sample()
+	before.Experience[0].Bullets = []string{"zero", "one", "two", "three", "four"}
+
+	after, inverse, err := Apply(before, []Op{
+		{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[3]")},
+		{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[4]")},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	want := []string{"zero", "one", "two"}
+	if !reflect.DeepEqual(after.Experience[0].Bullets, want) {
+		t.Fatalf("bullets = %q, want %q", after.Experience[0].Bullets, want)
+	}
+
+	undone, _, err := Apply(after, inverse)
+	if err != nil {
+		t.Fatalf("Apply(inverse): %v", err)
+	}
+	if !reflect.DeepEqual(before.Experience, undone.Experience) {
+		t.Fatalf("undo left %+v, want %+v", undone.Experience, before.Experience)
+	}
+}
+
+// Reordering removals forgives an address invalidated by the batch itself. An address the list
+// never held is a different thing and stays refused, whole batch and all.
+func TestApplyRefusesARemovalTheListNeverHeld(t *testing.T) {
+	before := sample()
+	before.Experience[0].Bullets = []string{"zero", "one", "two", "three", "four"}
+
+	after, _, err := Apply(before, []Op{
+		{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[3]")},
+		{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[9]")},
+	})
+	if err == nil {
+		t.Fatal("Apply succeeded, want a refusal")
+	}
+	if !errors.Is(err, ErrInvalidOp) {
+		t.Fatalf("err = %v, want ErrInvalidOp", err)
+	}
+	if !reflect.DeepEqual(before, after) {
+		t.Fatal("a refused batch changed the state")
 	}
 }
 

--- a/internal/cvedit/apply_test.go
+++ b/internal/cvedit/apply_test.go
@@ -209,10 +209,10 @@ func TestApplyRemovesTwoPositionsOfOneList(t *testing.T) {
 	before := sample()
 	before.Experience[0].Bullets = []string{"zero", "one", "two", "three", "four"}
 
-	after, inverse, err := Apply(before, []Op{
+	after, inverse, err := Apply(before, OrderAgainstOriginal([]Op{
 		{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[3]")},
 		{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[4]")},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -237,10 +237,10 @@ func TestApplyRefusesARemovalTheListNeverHeld(t *testing.T) {
 	before := sample()
 	before.Experience[0].Bullets = []string{"zero", "one", "two", "three", "four"}
 
-	after, _, err := Apply(before, []Op{
+	after, _, err := Apply(before, OrderAgainstOriginal([]Op{
 		{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[3]")},
 		{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[9]")},
-	})
+	}))
 	if err == nil {
 		t.Fatal("Apply succeeded, want a refusal")
 	}
@@ -271,5 +271,51 @@ func TestApplyInversesUndoInReverseOrder(t *testing.T) {
 	}
 	if !reflect.DeepEqual(before.Experience, undone.Experience) {
 		t.Fatalf("undo out of order: %+v, want %+v", undone.Experience, before.Experience)
+	}
+}
+
+// Diff states its indices against the list AS THE BATCH CHANGES IT, so its removals must be
+// applied in the order it wrote them. This is the everyday save path — the editor ships a whole
+// document and Diff turns it into operations — and the property it rests on is that applying
+// Diff(a, b) to a produces b exactly.
+func TestDiffOfTwoDeletionsRoundTrips(t *testing.T) {
+	before := sample()
+	before.Experience[0].Bullets = []string{"A", "B", "C", "D"}
+
+	after := sample()
+	after.Experience[0].Bullets = []string{"A", "C"}
+
+	ops := Diff(before, after)
+	got, _, err := Apply(before, ops)
+	if err != nil {
+		t.Fatalf("Apply(Diff): %v", err)
+	}
+	if !reflect.DeepEqual(got.Experience[0].Bullets, after.Experience[0].Bullets) {
+		t.Fatalf("bullets = %q, want %q — the user's own deletion removed the wrong line",
+			got.Experience[0].Bullets, after.Experience[0].Bullets)
+	}
+}
+
+// Undo replays the inverses Apply produced, and those are sequential too: an insert's inverse
+// is a removal at the position the insert used. Reordering them turned "undo the run" into
+// removing the candidate's own line while leaving the agent's insertion in place.
+func TestUndoOfTwoInsertsRestoresTheOriginal(t *testing.T) {
+	before := sample()
+	before.Experience[0].Bullets = []string{"A", "B", "C", "D"}
+
+	ops := []Op{
+		{Kind: OpInsert, Path: mustParse(t, "experience[0].bullets[3]"), Value: "X"},
+		{Kind: OpInsert, Path: mustParse(t, "experience[0].bullets[1]"), Value: "Y"},
+	}
+	after, inverse, err := Apply(before, ops)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	undone, _, err := Apply(after, inverse)
+	if err != nil {
+		t.Fatalf("Apply(inverse): %v", err)
+	}
+	if !reflect.DeepEqual(undone.Experience[0].Bullets, before.Experience[0].Bullets) {
+		t.Fatalf("undo left %q, want %q", undone.Experience[0].Bullets, before.Experience[0].Bullets)
 	}
 }

--- a/internal/handler/AGENTS.md
+++ b/internal/handler/AGENTS.md
@@ -104,10 +104,22 @@ Both SSE endpoints — the turn and the fit analysis — write through `sseStrea
 (`match_analysis_stream.go`), the one owner of the stream protocol: it serializes the
 heartbeat goroutine against the event callback and re-arms the write deadline before every
 write. `event` reports whether the frame reached the client, and a marshal failure reports
-**true** — an unencodable frame is our bug, not a dead reader. That is how a streamed turn
-learns the client is gone: the failure cancels the loop's context, so it stops before
-spending another model call. The fit analysis deliberately ignores the same signal — its run
-was paid for with an AI credit, so it finishes into the cache rather than aborting.
+**true** — an unencodable frame is our bug, not a dead reader.
+
+A failed write does NOT stop an assistant turn. It used to: the failure cancelled the loop's
+context, which meant a phone freezing a backgrounded tab threw away live work — an unattended
+tailoring run once lost its report after twenty-five committed CV edits. A write that fails now
+means only that this reader is not listening; the turn runs to its own end under the step cap
+and the model timeout, and its transcript is stored either way. The fit analysis always ignored
+the same signal, for the neighbouring reason: its run was paid for with an AI credit.
+
+Stopping a turn is therefore a request of its own — `POST /assistant/sessions/:id/cancel`,
+owner-scoped — because a dropped connection cannot be told apart from a deliberate Stop.
+`turnRegistry` (`assistant_turns.go`) holds each running turn's cancellation, which is the only
+handle on a turn no request owns any more, and keeps a session to ONE turn at a time: a second
+message waits for the first and is told so with a `queued` event, a third is refused with 409.
+The registry is per-process, so a turn that outlives a blue/green flip cannot be cancelled and
+ends at its step cap.
 
 `assistant_tools.go` / `assistant_tracking_tools.go` / `assistant_cv_tools.go` /
 `assistant_profile_tool.go` / `assistant_present_tool.go` / `assistant_page_tools.go`

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -149,6 +149,7 @@ func (h *assistantHandlers) register(api fiber.Router, mw middleware) {
 	api.Get("/assistant/sessions/:id", mw.key, h.GetAssistantSession)
 	api.Delete("/assistant/sessions/:id", mw.key, h.DeleteAssistantSession)
 	api.Post("/assistant/sessions/:id/messages", mw.key, h.PostAssistantMessage)
+	api.Post("/assistant/sessions/:id/cancel", mw.key, h.CancelAssistantTurn)
 	api.Post("/assistant/sessions/:id/opening", mw.key, h.PostAssistantOpening)
 	api.Post("/assistant/sessions/:id/followups", mw.key, h.PostAssistantFollowUps)
 	// Cookie-only: an unattended run rewrites a CV, and the browser is the only place
@@ -401,6 +402,32 @@ func (h *assistantHandlers) DeleteAssistantSession(c *fiber.Ctx) error {
 	if err := h.store.DeleteSession(c.Context(), id, userID); err != nil {
 		return mapAssistantError(err)
 	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// CancelAssistantTurn stops the session's running turn.
+//
+// It exists because stopping used to be a side effect of the transport: the client aborted its
+// read, the next write failed, and the turn was cancelled. That made a deliberate stop
+// indistinguishable from a phone freezing its tab, and the turn paid for the confusion. Now the
+// two are different things, and this is the one that means stop.
+//
+// A session with nothing running is not an error. A client cancels a turn whose end it cannot
+// see; requiring it to first prove the turn is alive would ask it for the one fact it does not
+// have. The ownership check comes first either way, so an id cannot be probed for existence.
+func (h *assistantHandlers) CancelAssistantTurn(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := assistantSessionID(c)
+	if err != nil {
+		return err
+	}
+	if _, err := h.store.Session(c.Context(), id, userID); err != nil {
+		return mapAssistantError(err)
+	}
+	h.turns.cancel(id)
 	return c.SendStatus(fiber.StatusNoContent)
 }
 

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -49,6 +49,11 @@ type assistantHandlers struct {
 	// and one field holding both would eventually be handed the wrong one.
 	followUpLLM llmBinding
 
+	// turns are the turns running right now, so a cancel request can reach one that is
+	// streaming on a goroutine no request owns any more, and so a session keeps to one turn
+	// at a time. Its zero value works; see assistant_turns.go.
+	turns turnRegistry
+
 	queries  *db.Queries
 	search   *searchHandlers
 	resume   *resumeHandlers
@@ -462,6 +467,17 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 		hub = reqHub.Clone()
 	}
 
+	// The turn runs on its own cancellable context: the request's own is released the moment
+	// this handler returns, long before the turn ends. It is created HERE rather than inside
+	// the writer so the session's slot is taken while the request can still be answered — a
+	// slot taken after the handler returned could not refuse anything.
+	ctx, cancel := context.WithCancel(context.Background())
+	slot, admitted := h.turns.admit(sess.ID, cancel)
+	if !admitted {
+		cancel()
+		return fiber.NewError(fiber.StatusConflict, "this session is already running a turn")
+	}
+
 	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
 		// sseStream owns the write protocol both SSE endpoints need: it serializes the
 		// heartbeat goroutine against the event callback (bufio.Writer is not safe for
@@ -474,20 +490,22 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 		// would block the write, and with it this goroutine, for the life of the process.
 		stream := newSSEStream(w, conn, sseWriteTimeout)
 
-		// The request context is gone once the handler returns, so the turn runs on
-		// its own cancellable context. Cancellation comes from the client going away,
-		// which shows up as a failed write below.
-		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		defer h.turns.release(sess.ID, slot)
 
 		stopHeartbeat := stream.keepalive(sseKeepalive)
 
 		err := turnRunner.Run(ctx, sess, registry, system, prompt, turn, func(e assistant.Event) {
-			if !stream.event(string(e.Kind), e) {
-				// The client is gone. Stop the loop at its next boundary rather than
-				// finishing a turn nobody is reading.
-				cancel()
-			}
+			// A write that fails means THIS reader is not listening: a phone froze its tab,
+			// a tunnel dropped, a laptop slept. It does not mean the work should stop, and
+			// treating it that way threw away live runs — a tailoring pass lost its report
+			// after twenty-five committed edits because a tab went to the background.
+			//
+			// So the event is simply not delivered. The turn runs to its own end under the
+			// bounds it already has (the step cap and the model timeout), the transcript is
+			// persisted either way, and a client that comes back reads it from the session.
+			// Stopping a turn is now something a caller ASKS for, through the cancel route.
+			stream.event(string(e.Kind), e)
 		})
 		stopHeartbeat()
 		if err != nil {

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -439,8 +439,8 @@ type assistantTurnRequest struct {
 // PostAssistantMessage runs one turn and streams it as SSE. Every frame the loop
 // produces — the recorded prompt, answer and reasoning deltas, each tool call and
 // its result, the token usage, and exactly one terminal result — is written as a
-// named event. A write failure means the client is gone, which cancels the turn's
-// context so the loop stops before spending another model call.
+// named event. A write failure means only that this reader stopped reading: the turn runs to
+// its own end regardless, and stopping it is a separate request (see CancelAssistantTurn).
 func (h *assistantHandlers) PostAssistantMessage(c *fiber.Ctx) error {
 	sess, err := h.ownedSession(c)
 	if err != nil {
@@ -465,7 +465,7 @@ func (h *assistantHandlers) PostAssistantMessage(c *fiber.Ctx) error {
 
 // streamTurn runs one turn and writes it to the response as SSE. It is shared by every
 // entry point that starts a turn, so the stream's shape — the headers, the cleared write
-// deadline, the keepalive, the cancellation on a dead client — is written once.
+// deadline and the keepalive — is written once.
 //
 // The prompt and the turn's bounds are the caller's arguments rather than the request's
 // body: an unattended run's brief and its raised ceiling are ours to choose, and a ceiling

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -519,6 +519,13 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 
 		defer cancel()
 
+		// The heartbeat starts BEFORE the queue wait, not after it: a queued message can wait
+		// up to a minute, and an idle connection is exactly what a proxy in front of us
+		// collects. Waiting in silence would lose the connection at roughly the same moment
+		// the wait was about to pay off.
+		stopHeartbeat := stream.keepalive(sseKeepalive)
+		defer stopHeartbeat()
+
 		// A message that arrived while the session was busy waits here rather than running
 		// beside the turn in flight — two turns of one tailoring session would edit one CV
 		// from two conversations that cannot see each other. The client is told it is
@@ -541,9 +548,7 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 		}
 		defer h.turns.release(sess.ID, slot)
 
-		stopHeartbeat := stream.keepalive(sseKeepalive)
-
-		err := turnRunner.Run(ctx, sess, registry, system, prompt, turn, func(e assistant.Event) {
+		err = turnRunner.Run(ctx, sess, registry, system, prompt, turn, func(e assistant.Event) {
 			// A write that fails means THIS reader is not listening: a phone froze its tab,
 			// a tunnel dropped, a laptop slept. It does not mean the work should stop, and
 			// treating it that way threw away live runs — a tailoring pass lost its report
@@ -555,7 +560,6 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 			// Stopping a turn is now something a caller ASKS for, through the cancel route.
 			stream.event(string(e.Kind), e)
 		})
-		stopHeartbeat()
 		if err != nil {
 			// The loop has already emitted its terminal error event; this is for us —
 			// and for Sentry, which would otherwise never learn of it: this handler

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -499,10 +499,10 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 	// the writer so the session's slot is taken while the request can still be answered — a
 	// slot taken after the handler returned could not refuse anything.
 	ctx, cancel := context.WithCancel(context.Background())
-	slot, admitted := h.turns.admit(sess.ID, cancel)
-	if !admitted {
+	slot, waiter, err := h.turns.claim(sess.ID, cancel)
+	if err != nil {
 		cancel()
-		return fiber.NewError(fiber.StatusConflict, "this session is already running a turn")
+		return fiber.NewError(fiber.StatusConflict, err.Error())
 	}
 
 	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
@@ -518,6 +518,27 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 		stream := newSSEStream(w, conn, sseWriteTimeout)
 
 		defer cancel()
+
+		// A message that arrived while the session was busy waits here rather than running
+		// beside the turn in flight — two turns of one tailoring session would edit one CV
+		// from two conversations that cannot see each other. The client is told it is
+		// waiting, because a stream that goes quiet for a minute is indistinguishable from
+		// one that broke.
+		if waiter != nil {
+			stream.event(string(assistant.EventQueued), assistant.Event{Kind: assistant.EventQueued})
+
+			waitCtx, giveUp := context.WithTimeout(ctx, turnQueueWait)
+			slot, err = waiter.enter(waitCtx, cancel)
+			giveUp()
+			if err != nil {
+				// The wait is over and this turn never started. Every stream owes its client
+				// one terminal event; without it the client waits for a turn that is not
+				// coming.
+				stream.event(string(assistant.EventResult),
+					assistant.Event{Kind: assistant.EventResult, StopReason: assistant.StopCancelled})
+				return
+			}
+		}
 		defer h.turns.release(sess.ID, slot)
 
 		stopHeartbeat := stream.keepalive(sseKeepalive)

--- a/internal/handler/assistant_cancel_integration_test.go
+++ b/internal/handler/assistant_cancel_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+// Stopping a turn used to be a side effect of the transport: the client aborted its read, the
+// server's next write failed, and the turn was cancelled. That made "the user pressed Stop"
+// indistinguishable from "the tab went to the background", so one of them had to be given a
+// channel of its own. This is that channel.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+)
+
+func TestCancelStopsARunningTurn(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	model := newDisconnectModel(t)
+	app, _ := newAssistantApp(pool, iss, model)
+	_, cookie := assistantUser(t, pool, iss, "cancel@example.test", true)
+	id := createSession(t, app, cookie)
+	addr := serveOnSocket(t, app)
+
+	// The turn is started on a connection the test keeps open — this is a deliberate stop,
+	// not a disconnection.
+	streamed := startTurnInBackground(t, addr, id, cookie)
+
+	select {
+	case <-model.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the turn never started")
+	}
+
+	resp := assistantRequest(t, app, fiber.MethodPost, "/api/v1/assistant/sessions/"+id+"/cancel", cookie, nil)
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("cancel: status %d, want 204", resp.StatusCode)
+	}
+	model.letGo()
+
+	// The runner stops before spending another model call, so the second round never runs.
+	select {
+	case <-model.answered:
+		t.Fatal("the turn kept going after it was told to stop")
+	case <-time.After(3 * time.Second):
+	}
+	<-streamed
+
+	// Stopping is not undoing: what the turn did before it was told to stop is the candidate's,
+	// and the transcript has to carry it or the session cannot be resumed. Transcript writes
+	// run detached from the turn's context for exactly this reason.
+	waitForTranscript(t, pool, id, "experience_search")
+}
+
+// Cancelling an idle session is how a client stops a turn whose end it cannot see. Making it an
+// error would force the client to first prove the turn is alive — which is the thing it cannot
+// know.
+func TestCancelIsHarmlessWhenNothingIsRunning(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	app, _ := newAssistantApp(pool, iss, &turnModel{})
+	_, cookie := assistantUser(t, pool, iss, "cancel-idle@example.test", true)
+	id := createSession(t, app, cookie)
+
+	resp := assistantRequest(t, app, fiber.MethodPost, "/api/v1/assistant/sessions/"+id+"/cancel", cookie, nil)
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("cancel: status %d, want 204", resp.StatusCode)
+	}
+}
+
+// A session someone else owns is reported missing, never forbidden — the same rule every other
+// session route follows, so an id cannot be probed for existence.
+func TestCancelIsOwnerScoped(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	model := newDisconnectModel(t)
+	app, _ := newAssistantApp(pool, iss, model)
+	_, owner := assistantUser(t, pool, iss, "cancel-owner@example.test", true)
+	_, stranger := assistantUser(t, pool, iss, "cancel-stranger@example.test", true)
+	id := createSession(t, app, owner)
+	addr := serveOnSocket(t, app)
+
+	streamed := startTurnInBackground(t, addr, id, owner)
+	select {
+	case <-model.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the turn never started")
+	}
+
+	resp := assistantRequest(t, app, fiber.MethodPost, "/api/v1/assistant/sessions/"+id+"/cancel", stranger, nil)
+	if resp.StatusCode != fiber.StatusNotFound {
+		t.Fatalf("cancel by a stranger: status %d, want 404", resp.StatusCode)
+	}
+
+	// And the turn it did not own is untouched.
+	model.letGo()
+	select {
+	case <-model.answered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("a stranger's refused cancel stopped the owner's turn")
+	}
+	<-streamed
+}

--- a/internal/handler/assistant_cancel_integration_test.go
+++ b/internal/handler/assistant_cancel_integration_test.go
@@ -20,6 +20,9 @@ func TestCancelStopsARunningTurn(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	model := newDisconnectModel(t)
+	// Before any t.Cleanup: fiber's Shutdown waits on the connection the blocked turn holds,
+	// so a failed assertion would hang the package rather than report itself.
+	defer model.letGo()
 	app, _ := newAssistantApp(pool, iss, model)
 	_, cookie := assistantUser(t, pool, iss, "cancel@example.test", true)
 	id := createSession(t, app, cookie)
@@ -77,6 +80,9 @@ func TestCancelIsOwnerScoped(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	model := newDisconnectModel(t)
+	// Before any t.Cleanup: fiber's Shutdown waits on the connection the blocked turn holds,
+	// so a failed assertion would hang the package rather than report itself.
+	defer model.letGo()
 	app, _ := newAssistantApp(pool, iss, model)
 	_, owner := assistantUser(t, pool, iss, "cancel-owner@example.test", true)
 	_, stranger := assistantUser(t, pool, iss, "cancel-stranger@example.test", true)

--- a/internal/handler/assistant_cv_gate_test.go
+++ b/internal/handler/assistant_cv_gate_test.go
@@ -178,6 +178,22 @@ func TestCVEditGateAllowsWhatTheCandidateAsserted(t *testing.T) {
 	}
 }
 
+// A batch cites an evidence id per operation, so "that id" names nothing a model can act on
+// when thirteen of them went out together. The refusal carries the id that missed.
+func TestCVEditGateNamesTheIdThatMissed(t *testing.T) {
+	h, _ := gateHandlers(t)
+	gate := bankGate{bank: h.experience}
+	missing := uuid.New()
+
+	err := gate.Publishable(context.Background(), 1, missing.String())
+	if err == nil {
+		t.Fatal("an id matching no achievement was accepted")
+	}
+	if !strings.Contains(err.Error(), missing.String()) {
+		t.Errorf("error = %v, want it to name the id that missed", err)
+	}
+}
+
 func TestCVEditGateRefusesAnUnknownOrForeignAtom(t *testing.T) {
 	h, bank := gateHandlers(t)
 	gate := bankGate{bank: h.experience}

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -16,6 +17,31 @@ import (
 	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/matchanalysis"
 )
+
+// opBatch is an edit batch as it arrives from a model: either the array the schema asks for,
+// or a string holding that array. Models package it both ways, and the packaging is a guess
+// about the wire format that says nothing about the edit — refusing it spends a round of the
+// turn's budget and teaches the model nothing about the CV.
+//
+// What is inside is read by the same strict rules either way. The decoder is re-armed with
+// DisallowUnknownFields here because a custom unmarshaller receives the raw bytes and the
+// caller's strictness does not reach through it, and that strictness is load-bearing: an
+// undefined field silently dropped is how an agent once rewrote the wrong experience entry
+// while reading success back.
+type opBatch []cvedit.Op
+
+func (b *opBatch) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var packed string
+		if err := json.Unmarshal(data, &packed); err != nil {
+			return err
+		}
+		data = []byte(packed)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	return dec.Decode((*[]cvedit.Op)(b))
+}
 
 // assistantCVTools are the tools a CV-tailoring session gets on top of the shared
 // ones. They are bound to the session's own CV and vacancy: the ids are closed
@@ -302,8 +328,8 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 		},
 		Run: func(ctx context.Context, userID int64, raw json.RawMessage) (any, error) {
 			var in struct {
-				Ops  []cvedit.Op `json:"ops"`
-				Note string      `json:"note"`
+				Ops  opBatch `json:"ops"`
+				Note string  `json:"note"`
 			}
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
@@ -360,7 +386,9 @@ func (g bankGate) Publishable(ctx context.Context, userID int64, evidenceID stri
 	}
 	atom, err := g.bank.GetAtom(ctx, id, userID)
 	if errors.Is(err, experience.ErrNotFound) {
-		return errors.New("no banked achievement with that id — take evidence_id from experience_search")
+		// Named, not "that id": a batch cites one per operation, so a bare refusal leaves the
+		// model guessing which of them to go back for.
+		return fmt.Errorf("no banked achievement with id %s — take evidence_id from experience_search", id)
 	}
 	if err != nil {
 		return err

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -40,7 +40,16 @@ func (b *opBatch) UnmarshalJSON(data []byte) error {
 	}
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
-	return dec.Decode((*[]cvedit.Op)(b))
+	if err := dec.Decode((*[]cvedit.Op)(b)); err != nil {
+		return err
+	}
+	// A second value means the string held more than the one batch — two arrays, or an array
+	// and some trailing text. Applying the first and dropping the rest is the same silent
+	// helpfulness the unknown-field check exists to refuse.
+	if dec.More() {
+		return errors.New("ops holds more than one batch")
+	}
+	return nil
 }
 
 // assistantCVTools are the tools a CV-tailoring session gets on top of the shared
@@ -341,12 +350,18 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 					return nil, fmt.Errorf("edit %d: %w", i+1, err)
 				}
 			}
+			// A model names the positions it SAW: it read the document once and wrote every
+			// index against that reading. Applied in sequence those addresses shift out from
+			// under each other, so a batch removing two lines of one list would refuse itself.
+			// The conversion happens here and not inside the editor, because the editor's other
+			// callers — the whole-document save and undo — state their indices sequentially and
+			// would be corrupted by it.
 			meta, rev, err := h.cv.editor.Commit(ctx, cvID, userID, cvedit.Change{
 				Actor:   cvedit.ActorAgent,
 				Origin:  cvedit.OriginTailorAgent,
 				BatchID: batchID,
 				Note:    in.Note,
-				Ops:     in.Ops,
+				Ops:     cvedit.OrderAgainstOriginal(in.Ops),
 			})
 			if err != nil {
 				return nil, cvToolError(err)

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -288,6 +288,46 @@ func TestCVEditToolAppliesAPatch(t *testing.T) {
 	}
 }
 
+// A model packages the batch as a string holding the array often enough to matter: 15 refusals
+// in 30 days on prod, each one an otherwise-correct edit that cost the turn a round. Packaging
+// says nothing about the document, so the tool reads through it.
+func TestCVEditToolAcceptsOpsAsAJSONString(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	args, err := json.Marshal(map[string]any{
+		"ops": `[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"` + atom.ID.String() + `"}]`,
+	})
+	if err != nil {
+		t.Fatalf("marshal arguments: %v", err)
+	}
+	if _, err := tool.Run(context.Background(), 3, json.RawMessage(args)); err != nil {
+		t.Fatalf("cv_edit: %v", err)
+	}
+	if !strings.Contains(string(repo.written), "Senior backend engineer") {
+		t.Errorf("stored document = %s, want the patched summary", repo.written)
+	}
+}
+
+// The tolerance is for packaging only. A field the editor does not define is the shape that
+// once let an agent clobber the wrong experience entry while reading 200 back, so it stays
+// refused, and the refusal still names what it choked on.
+func TestCVEditToolStillRefusesAnUnknownField(t *testing.T) {
+	a, _ := cvToolsAPI(t, oneExperienceCV)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":"[{\"kind\":\"set\",\"path\":\"summary\",\"value\":\"x\",\"skill\":0}]"}`))
+	if err == nil {
+		t.Fatal("an operation carrying an undefined field must be refused, packaged or not")
+	}
+	if !strings.Contains(err.Error(), "skill") {
+		t.Errorf("error = %v, want it to name the offending field", err)
+	}
+}
+
 func TestCVEditToolRefusesToRewriteContactDetails(t *testing.T) {
 	a, _ := cvToolsAPI(t, oneExperienceCV)
 

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -325,6 +326,36 @@ func TestCVEditToolStillRefusesAnUnknownField(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "skill") {
 		t.Errorf("error = %v, want it to name the offending field", err)
+	}
+}
+
+// The model names positions against the document it read, so a batch removing two lines of one
+// list must mean what it says. The conversion lives at this boundary and nowhere deeper: the
+// editor's other callers state their indices sequentially.
+func TestCVEditToolRemovesTwoPositionsOfOneList(t *testing.T) {
+	const fourBullets = `{"header":{"full_name":"Ada Lovelace"},"summary":"Backend engineer",` +
+		`"experience":[{"company":"Acme","title":"Engineer","bullets":["A","B","C","D"]}]}`
+	a, repo := cvToolsAPI(t, fourBullets)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	// Non-adjacent, and named against the document the model read.
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"remove","path":"experience[0].bullets[1]"},{"kind":"remove","path":"experience[0].bullets[3]"}]}`))
+	if err != nil {
+		t.Fatalf("cv_edit: %v", err)
+	}
+
+	var stored struct {
+		Experience []struct {
+			Bullets []string `json:"bullets"`
+		} `json:"experience"`
+	}
+	if err := json.Unmarshal(repo.written, &stored); err != nil {
+		t.Fatalf("decode stored document: %v", err)
+	}
+	want := []string{"A", "C"}
+	if got := stored.Experience[0].Bullets; !reflect.DeepEqual(got, want) {
+		t.Errorf("bullets = %q, want %q", got, want)
 	}
 }
 

--- a/internal/handler/assistant_disconnect_integration_test.go
+++ b/internal/handler/assistant_disconnect_integration_test.go
@@ -38,7 +38,8 @@ type disconnectModel struct {
 	release  chan struct{} // released once the test has cut or cancelled the connection
 	answered chan struct{} // closed when the second round runs — the turn survived
 
-	releaseOnce sync.Once
+	releaseOnce  sync.Once
+	answeredOnce sync.Once
 }
 
 // newDisconnectModel wires the model and guarantees it is let go at the end of the test. A
@@ -75,7 +76,9 @@ func (m *disconnectModel) Chat(_ context.Context, _ []llms.MessageContent, _ []l
 		// over an unassembled dependency.
 		return callReplyChoice("experience_search", `{"query":"anything"}`), nil
 	}
-	close(m.answered)
+	// Once, because a session may run more than one turn through this model and closing a
+	// closed channel panics.
+	m.answeredOnce.Do(func() { close(m.answered) })
 	return &llms.ContentChoice{Content: disconnectAnswer}, nil
 }
 

--- a/internal/handler/assistant_disconnect_integration_test.go
+++ b/internal/handler/assistant_disconnect_integration_test.go
@@ -13,8 +13,10 @@ package handler
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,16 +35,30 @@ import (
 type disconnectModel struct {
 	calls    int
 	started  chan struct{} // closed once the first round is under way
-	release  chan struct{} // the test closes this after cutting the connection
+	release  chan struct{} // released once the test has cut or cancelled the connection
 	answered chan struct{} // closed when the second round runs — the turn survived
+
+	releaseOnce sync.Once
 }
 
-func newDisconnectModel() *disconnectModel {
-	return &disconnectModel{
+// newDisconnectModel wires the model and guarantees it is let go at the end of the test. A
+// model left blocked on release holds the turn's goroutine, and the app's shutdown waits on it
+// — so a failing assertion would hang the whole package instead of reporting itself.
+func newDisconnectModel(t *testing.T) *disconnectModel {
+	t.Helper()
+	m := &disconnectModel{
 		started:  make(chan struct{}),
 		release:  make(chan struct{}),
 		answered: make(chan struct{}),
 	}
+	t.Cleanup(m.letGo)
+	return m
+}
+
+// letGo releases the model however many times it is called, so a test may release it explicitly
+// and still be cleaned up after.
+func (m *disconnectModel) letGo() {
+	m.releaseOnce.Do(func() { close(m.release) })
 }
 
 const disconnectAnswer = "the answer nobody was listening for"
@@ -75,9 +91,9 @@ func serveOnSocket(t *testing.T, app *fiber.App) string {
 	return ln.Addr().String()
 }
 
-// startTurnThenCut opens a turn, waits for it to be under way, and cuts the connection —
-// leaving the server writing into a socket that is gone.
-func startTurnThenCut(t *testing.T, addr, sessionID, cookie string, started <-chan struct{}) {
+// dialTurn opens a turn on a raw socket and returns the connection, so a test can decide what
+// to do to it — cut it, or keep reading.
+func dialTurn(t *testing.T, addr, sessionID, cookie string) net.Conn {
 	t.Helper()
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
@@ -92,6 +108,30 @@ func startTurnThenCut(t *testing.T, addr, sessionID, cookie string, started <-ch
 	if _, err := conn.Write([]byte(request)); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
+	return conn
+}
+
+// startTurnInBackground opens a turn and keeps reading it — what a client that is actually
+// watching does, so nothing about the connection can be mistaken for the user leaving. The
+// returned channel closes when the stream ends.
+func startTurnInBackground(t *testing.T, addr, sessionID, cookie string) <-chan struct{} {
+	t.Helper()
+	conn := dialTurn(t, addr, sessionID, cookie)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { _ = conn.Close() }()
+		_, _ = io.Copy(io.Discard, conn)
+	}()
+	return done
+}
+
+// startTurnThenCut opens a turn, waits for it to be under way, and cuts the connection —
+// leaving the server writing into a socket that is gone.
+func startTurnThenCut(t *testing.T, addr, sessionID, cookie string, started <-chan struct{}) {
+	t.Helper()
+	conn := dialTurn(t, addr, sessionID, cookie)
 
 	// Read enough to know the response is open, so the cut lands mid-turn rather than before
 	// the handler ever ran.
@@ -115,14 +155,14 @@ func startTurnThenCut(t *testing.T, addr, sessionID, cookie string, started <-ch
 func TestTurnSurvivesAClientThatStopsReading(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
-	model := newDisconnectModel()
+	model := newDisconnectModel(t)
 	app, _ := newAssistantApp(pool, iss, model)
 	_, cookie := assistantUser(t, pool, iss, "disconnect@example.test", true)
 	id := createSession(t, app, cookie)
 	addr := serveOnSocket(t, app)
 
 	startTurnThenCut(t, addr, id, cookie, model.started)
-	close(model.release)
+	model.letGo()
 
 	select {
 	case <-model.answered:

--- a/internal/handler/assistant_disconnect_integration_test.go
+++ b/internal/handler/assistant_disconnect_integration_test.go
@@ -42,9 +42,14 @@ type disconnectModel struct {
 	answeredOnce sync.Once
 }
 
-// newDisconnectModel wires the model and guarantees it is let go at the end of the test. A
-// model left blocked on release holds the turn's goroutine, and the app's shutdown waits on it
-// — so a failing assertion would hang the whole package instead of reporting itself.
+// newDisconnectModel wires the model and guarantees it is let go at the end of the test.
+//
+// A model left blocked on release holds the turn's goroutine, and fiber's Shutdown waits on the
+// connection that goroutine is writing to, with no deadline — so a failing assertion would hang
+// the whole package instead of reporting itself. t.Cleanup alone does NOT prevent that: cleanups
+// run last-in-first-out, and serveOnSocket registers Shutdown after this, so Shutdown would run
+// first and wait forever. Each test therefore also defers letGo, which runs before any cleanup;
+// this registration is the backstop for a test that forgets.
 func newDisconnectModel(t *testing.T) *disconnectModel {
 	t.Helper()
 	m := &disconnectModel{
@@ -159,6 +164,7 @@ func TestTurnSurvivesAClientThatStopsReading(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	model := newDisconnectModel(t)
+	defer model.letGo()
 	app, _ := newAssistantApp(pool, iss, model)
 	_, cookie := assistantUser(t, pool, iss, "disconnect@example.test", true)
 	id := createSession(t, app, cookie)

--- a/internal/handler/assistant_disconnect_integration_test.go
+++ b/internal/handler/assistant_disconnect_integration_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+// A turn must not be abandoned because the reader stopped reading. On a phone a backgrounded
+// tab is frozen, not closed, and the failed write it produces used to be read as "the user
+// left" — which threw away live work: an unattended tailoring pass lost its report after
+// twenty-five committed CV edits.
+//
+// These tests drive a real socket rather than fiber's in-memory test transport, because the
+// behaviour under test IS the socket dying mid-turn.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/llm"
+)
+
+// disconnectModel scripts a turn of two rounds and lets the test stand between them. The first
+// round calls a tool, so the runner reaches its cancellation check; the second answers. The
+// test cuts the connection while the first round is held open, which is the moment a phone
+// freezes its tab.
+type disconnectModel struct {
+	calls    int
+	started  chan struct{} // closed once the first round is under way
+	release  chan struct{} // the test closes this after cutting the connection
+	answered chan struct{} // closed when the second round runs — the turn survived
+}
+
+func newDisconnectModel() *disconnectModel {
+	return &disconnectModel{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		answered: make(chan struct{}),
+	}
+}
+
+const disconnectAnswer = "the answer nobody was listening for"
+
+func (m *disconnectModel) Chat(_ context.Context, _ []llms.MessageContent, _ []llms.Tool, s llm.ChatStream) (*llms.ContentChoice, error) {
+	m.calls++
+	if m.calls == 1 {
+		if s.OnText != nil {
+			s.OnText("working on it")
+		}
+		close(m.started)
+		<-m.release
+		// The bank is wired in this harness, so the round does real work rather than tripping
+		// over an unassembled dependency.
+		return callReplyChoice("experience_search", `{"query":"anything"}`), nil
+	}
+	close(m.answered)
+	return &llms.ContentChoice{Content: disconnectAnswer}, nil
+}
+
+// serveOnSocket puts the app on a real loopback listener and returns its address.
+func serveOnSocket(t *testing.T, app *fiber.App) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = app.Listener(ln) }()
+	t.Cleanup(func() { _ = app.Shutdown() })
+	return ln.Addr().String()
+}
+
+// startTurnThenCut opens a turn, waits for it to be under way, and cuts the connection —
+// leaving the server writing into a socket that is gone.
+func startTurnThenCut(t *testing.T, addr, sessionID, cookie string, started <-chan struct{}) {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	body := `{"text":"find me go jobs"}`
+	request := fmt.Sprintf("POST /api/v1/assistant/sessions/%s/messages HTTP/1.1\r\n"+
+		"Host: 127.0.0.1\r\nCookie: %s=%s\r\nContent-Type: application/json\r\n"+
+		"Content-Length: %d\r\nConnection: close\r\n\r\n%s",
+		sessionID, auth.CookieName, cookie, len(body), body)
+	if _, err := conn.Write([]byte(request)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	// Read enough to know the response is open, so the cut lands mid-turn rather than before
+	// the handler ever ran.
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	if _, err := conn.Read(make([]byte, 1)); err != nil {
+		t.Fatalf("read first byte: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the turn never started")
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestTurnSurvivesAClientThatStopsReading(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	model := newDisconnectModel()
+	app, _ := newAssistantApp(pool, iss, model)
+	_, cookie := assistantUser(t, pool, iss, "disconnect@example.test", true)
+	id := createSession(t, app, cookie)
+	addr := serveOnSocket(t, app)
+
+	startTurnThenCut(t, addr, id, cookie, model.started)
+	close(model.release)
+
+	select {
+	case <-model.answered:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the turn stopped when its reader went away; it must run to its own end")
+	}
+
+	// The work is only real if it was stored: the reader that would have carried it is gone.
+	waitForTranscript(t, pool, id, disconnectAnswer)
+}
+
+// waitForTranscript polls the stored transcript for text, because the turn finishes on its own
+// goroutine after the request that started it is long gone.
+func waitForTranscript(t *testing.T, pool *pgxpool.Pool, sessionID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var seen string
+	for time.Now().Before(deadline) {
+		rows, err := pool.Query(context.Background(),
+			`SELECT content FROM assistant_messages WHERE session_id = $1 ORDER BY seq`, sessionID)
+		if err != nil {
+			t.Fatalf("read transcript: %v", err)
+		}
+		seen = ""
+		for rows.Next() {
+			var content []byte
+			if err := rows.Scan(&content); err != nil {
+				rows.Close()
+				t.Fatalf("scan transcript: %v", err)
+			}
+			seen += string(content)
+		}
+		rows.Close()
+
+		if strings.Contains(seen, want) {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("transcript never carried %q; it holds:\n%s", want, seen)
+}

--- a/internal/handler/assistant_queue_integration_test.go
+++ b/internal/handler/assistant_queue_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 
 	"github.com/strelov1/freehire/internal/auth"
 )
@@ -43,6 +44,7 @@ func TestASecondMessageWaitsForTheTurnInFlight(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	model := newDisconnectModel(t)
+	defer model.letGo()
 	app, _ := newAssistantApp(pool, iss, model)
 	_, cookie := assistantUser(t, pool, iss, "queue@example.test", true)
 	id := createSession(t, app, cookie)
@@ -73,4 +75,43 @@ func TestASecondMessageWaitsForTheTurnInFlight(t *testing.T) {
 	model.letGo()
 	<-running
 	awaitEvent(t, queued, "event: result")
+}
+
+// A wait that runs out still owes its client a terminal event — a client that receives none
+// waits forever — and must not leave the session looking occupied.
+func TestAQueuedMessageThatWaitsTooLongEndsCleanly(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	model := newDisconnectModel(t)
+	defer model.letGo()
+	app, handlers := newAssistantApp(pool, iss, model)
+	_, cookie := assistantUser(t, pool, iss, "queue-timeout@example.test", true)
+	id := createSession(t, app, cookie)
+	addr := serveOnSocket(t, app)
+
+	previous := turnQueueWait
+	turnQueueWait = 300 * time.Millisecond
+	t.Cleanup(func() { turnQueueWait = previous })
+
+	running := startTurnInBackground(t, addr, id, cookie)
+	select {
+	case <-model.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the first turn never started")
+	}
+
+	queued := dialTurn(t, addr, id, cookie)
+	defer func() { _ = queued.Close() }()
+	awaitEvent(t, queued, "event: queued")
+	// The wait runs out while the turn ahead is still held: the client is told, rather than
+	// left on a stream that says nothing more.
+	awaitEvent(t, queued, "event: result")
+
+	// And the waiting place is given back, so the session is not left refusing every later
+	// message.
+	if _, waiter, err := handlers.turns.claim(uuid.New(), func() {}); err != nil || waiter != nil {
+		t.Fatalf("an unrelated session could not claim a slot: %v, %v", waiter, err)
+	}
+	model.letGo()
+	<-running
 }

--- a/internal/handler/assistant_queue_integration_test.go
+++ b/internal/handler/assistant_queue_integration_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+// A session runs one turn at a time. Before the turn registry, a second message ran beside the
+// first — two conversations editing one CV, each blind to the other's edits — and the only
+// thing that usually prevented it was the client aborting its own stream first.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+)
+
+// awaitEvent reads the stream until the named SSE event shows up, so a test can act on where a
+// turn has got to instead of sleeping and hoping.
+func awaitEvent(t *testing.T, conn net.Conn, event string) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(20 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+
+	var seen strings.Builder
+	buf := make([]byte, 512)
+	for {
+		n, err := conn.Read(buf)
+		seen.Write(buf[:n])
+		if strings.Contains(seen.String(), event) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("waiting for %q: %v\nstream so far:\n%s", event, err, seen.String())
+		}
+	}
+}
+
+func TestASecondMessageWaitsForTheTurnInFlight(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	model := newDisconnectModel(t)
+	app, _ := newAssistantApp(pool, iss, model)
+	_, cookie := assistantUser(t, pool, iss, "queue@example.test", true)
+	id := createSession(t, app, cookie)
+	addr := serveOnSocket(t, app)
+
+	running := startTurnInBackground(t, addr, id, cookie)
+	select {
+	case <-model.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the first turn never started")
+	}
+
+	// The second message queues. It says so before it says anything else — a stream that goes
+	// quiet while it waits is indistinguishable from one that broke.
+	queued := dialTurn(t, addr, id, cookie)
+	defer func() { _ = queued.Close() }()
+	awaitEvent(t, queued, "event: queued")
+
+	// The third is refused: one waiter is a courtesy, a queue a client can grow is a way to
+	// hold the process open.
+	resp := assistantRequest(t, app, fiber.MethodPost, "/api/v1/assistant/sessions/"+id+"/messages", cookie,
+		map[string]string{"text": "and another thing"})
+	if resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("third message: status %d, want 409", resp.StatusCode)
+	}
+
+	// Once the first turn ends, the one that waited runs as a turn of its own.
+	model.letGo()
+	<-running
+	awaitEvent(t, queued, "event: result")
+}

--- a/internal/handler/assistant_turns.go
+++ b/internal/handler/assistant_turns.go
@@ -18,7 +18,11 @@ var errTurnQueueFull = errors.New("this session already has a message waiting")
 // would be held for as long as the turn ahead runs, and an unattended run can go for minutes.
 // A minute is longer than an ordinary turn and short enough that a client learns where it
 // stands rather than staring at a silent stream.
-const turnQueueWait = time.Minute
+//
+// A var so a test can shorten it: the path it guards — a wait that runs out — is one a test
+// would otherwise have to spend a real minute to reach, and untested is how it stayed unnoticed
+// that the queued message is destroyed rather than deferred.
+var turnQueueWait = time.Minute
 
 // turnSlot is one session's running turn, held only for as long as it runs. It carries the
 // turn's cancellation so a later request can reach a turn that is already streaming on another
@@ -53,9 +57,13 @@ func (s *turnSlot) finish() {
 // several places, and a registry that had to be constructed would be nil in whichever one
 // forgot — a nil map read is fine, but the first turn to write one would panic.
 type turnRegistry struct {
-	mu      sync.Mutex
-	turns   map[uuid.UUID]*turnSlot
-	waiting map[uuid.UUID]bool
+	mu    sync.Mutex
+	turns map[uuid.UUID]*turnSlot
+	// waiting holds the cancellation of the message queued behind each session's running turn.
+	// It is the cancellation and not a flag because Stop has to reach a turn that has not
+	// started yet: cancelling only the running one would END it and thereby LET THE QUEUED ONE
+	// IN, which is the opposite of what was asked.
+	waiting map[uuid.UUID]context.CancelFunc
 }
 
 // claim asks for the session's slot on behalf of a turn about to start.
@@ -70,13 +78,13 @@ func (r *turnRegistry) claim(session uuid.UUID, cancel context.CancelFunc) (*tur
 	if _, running := r.turns[session]; !running {
 		return r.take(session, cancel), nil, nil
 	}
-	if r.waiting[session] {
+	if _, queued := r.waiting[session]; queued {
 		return nil, nil, errTurnQueueFull
 	}
 	if r.waiting == nil {
-		r.waiting = make(map[uuid.UUID]bool)
+		r.waiting = make(map[uuid.UUID]context.CancelFunc)
 	}
-	r.waiting[session] = true
+	r.waiting[session] = cancel
 	return nil, &turnWaiter{registry: r, session: session}, nil
 }
 
@@ -108,19 +116,29 @@ func (r *turnRegistry) release(session uuid.UUID, slot *turnSlot) {
 	slot.finish()
 }
 
-// cancel stops the session's running turn, reporting whether there was one. A session with
-// nothing running is not an error: a client cancels what it can no longer see the end of, and
-// asking it to first prove the turn is alive would just make it guess.
+// cancel stops the session's turns — the one running and the one queued behind it, because a
+// caller asking for the work to stop does not mean "and then start the next one".
+//
+// It reports whether there was anything to stop. A session with nothing running is not an
+// error: a client cancels what it can no longer see the end of, and asking it to first prove
+// the turn is alive would just make it guess.
+//
+// The cancellations run under the lock. A CancelFunc reaches nothing in the registry, so it
+// cannot deadlock, and releasing first would leave a window in which the running turn ends, the
+// queued one takes the slot, and the cancel lands on a context that is already dead while its
+// successor runs on.
 func (r *turnRegistry) cancel(session uuid.UUID) bool {
 	r.mu.Lock()
-	slot, running := r.turns[session]
-	r.mu.Unlock()
+	defer r.mu.Unlock()
 
-	if !running {
-		return false
+	slot, running := r.turns[session]
+	if running {
+		slot.cancel()
 	}
-	slot.cancel()
-	return true
+	if queued, waiting := r.waiting[session]; waiting {
+		queued()
+	}
+	return running
 }
 
 // len is the number of turns running, for the tests that guard against the registry keeping
@@ -147,6 +165,13 @@ func (w *turnWaiter) enter(ctx context.Context, cancel context.CancelFunc) (*tur
 	defer w.leave()
 
 	for {
+		// Checked before taking the slot, not only while waiting for it: the turn ahead ending
+		// and this wait being cancelled can happen in either order, and waking to an open slot
+		// is no reason to start work someone has already asked us not to do.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		w.registry.mu.Lock()
 		current, running := w.registry.turns[w.session]
 		if !running {

--- a/internal/handler/assistant_turns.go
+++ b/internal/handler/assistant_turns.go
@@ -1,0 +1,91 @@
+package handler
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// turnSlot is one session's running turn, held only for as long as it runs. It carries the
+// turn's cancellation so a later request can reach a turn that is already streaming on another
+// goroutine — the only handle on a turn that no HTTP request owns any more.
+type turnSlot struct {
+	cancel context.CancelFunc
+}
+
+// turnRegistry is the set of turns running right now, keyed by session.
+//
+// It exists because a turn outlives the request that started it: the stream writer runs after
+// its handler returned, so by the time a cancel request arrives there is nothing left to
+// address it to. It also keeps a session to one turn at a time, which matters more than it
+// sounds — two turns of one tailoring session would edit one CV from two conversations that
+// cannot see each other.
+//
+// The registry is per-process and deliberately not persisted: a CancelFunc cannot be written to
+// a database, and the goroutine that must act on it lives here. A turn that outlives a
+// blue/green flip is therefore uncancellable and ends at its step cap instead.
+// Its zero value is ready to use: the assistant handlers are assembled as a struct literal in
+// several places, and a registry that had to be constructed would be nil in whichever one
+// forgot — a nil map read is fine, but the first turn to write one would panic.
+type turnRegistry struct {
+	mu    sync.Mutex
+	turns map[uuid.UUID]*turnSlot
+}
+
+// admit takes the session's slot for a turn about to start, reporting false if the session is
+// already running one.
+func (r *turnRegistry) admit(session uuid.UUID, cancel context.CancelFunc) (*turnSlot, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, busy := r.turns[session]; busy {
+		return nil, false
+	}
+	if r.turns == nil {
+		r.turns = make(map[uuid.UUID]*turnSlot)
+	}
+	slot := &turnSlot{cancel: cancel}
+	r.turns[session] = slot
+	return slot, true
+}
+
+// release gives the slot back when the turn ends, however it ended.
+//
+// It clears the entry only if the session still holds this very slot: a turn that was already
+// replaced must not delete its successor's entry and leave the session looking idle while a
+// turn runs.
+func (r *turnRegistry) release(session uuid.UUID, slot *turnSlot) {
+	if slot == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if current, ok := r.turns[session]; ok && current == slot {
+		delete(r.turns, session)
+	}
+}
+
+// cancel stops the session's running turn, reporting whether there was one. A session with
+// nothing running is not an error: a client cancels what it can no longer see the end of, and
+// asking it to first prove the turn is alive would just make it guess.
+func (r *turnRegistry) cancel(session uuid.UUID) bool {
+	r.mu.Lock()
+	slot, running := r.turns[session]
+	r.mu.Unlock()
+
+	if !running {
+		return false
+	}
+	slot.cancel()
+	return true
+}
+
+// len is the number of turns running, for the tests that guard against the registry keeping
+// entries for turns that have ended.
+func (r *turnRegistry) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.turns)
+}

--- a/internal/handler/assistant_turns.go
+++ b/internal/handler/assistant_turns.go
@@ -2,19 +2,42 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 )
 
+// errTurnQueueFull refuses a message that would be the second one waiting. One waiter is a
+// courtesy; an unbounded queue is a way for a client to hold the process open.
+var errTurnQueueFull = errors.New("this session already has a message waiting")
+
+// turnQueueWait bounds how long a queued message waits for the turn ahead of it. A wait with no
+// end is not patience but a leaked request: the connection, its goroutine and its place in line
+// would be held for as long as the turn ahead runs, and an unattended run can go for minutes.
+// A minute is longer than an ordinary turn and short enough that a client learns where it
+// stands rather than staring at a silent stream.
+const turnQueueWait = time.Minute
+
 // turnSlot is one session's running turn, held only for as long as it runs. It carries the
 // turn's cancellation so a later request can reach a turn that is already streaming on another
-// goroutine — the only handle on a turn that no HTTP request owns any more.
+// goroutine — the only handle on a turn that no HTTP request owns any more — and a channel that
+// closes when the turn ends, which is what a waiting message waits on.
 type turnSlot struct {
 	cancel context.CancelFunc
+	done   chan struct{}
+	once   sync.Once
 }
 
-// turnRegistry is the set of turns running right now, keyed by session.
+// finish closes the slot however many times it is called: release runs from a deferred call
+// that a retry or a second path could reach twice, and closing a closed channel panics.
+func (s *turnSlot) finish() {
+	s.once.Do(func() { close(s.done) })
+}
+
+// turnRegistry is the set of turns running right now, keyed by session, plus which sessions
+// have a message waiting to run next.
 //
 // It exists because a turn outlives the request that started it: the stream writer runs after
 // its handler returned, so by the time a cancel request arrives there is nothing left to
@@ -25,32 +48,49 @@ type turnSlot struct {
 // The registry is per-process and deliberately not persisted: a CancelFunc cannot be written to
 // a database, and the goroutine that must act on it lives here. A turn that outlives a
 // blue/green flip is therefore uncancellable and ends at its step cap instead.
+//
 // Its zero value is ready to use: the assistant handlers are assembled as a struct literal in
 // several places, and a registry that had to be constructed would be nil in whichever one
 // forgot — a nil map read is fine, but the first turn to write one would panic.
 type turnRegistry struct {
-	mu    sync.Mutex
-	turns map[uuid.UUID]*turnSlot
+	mu      sync.Mutex
+	turns   map[uuid.UUID]*turnSlot
+	waiting map[uuid.UUID]bool
 }
 
-// admit takes the session's slot for a turn about to start, reporting false if the session is
-// already running one.
-func (r *turnRegistry) admit(session uuid.UUID, cancel context.CancelFunc) (*turnSlot, bool) {
+// claim asks for the session's slot on behalf of a turn about to start.
+//
+// A free session hands back the slot. A busy one hands back a waiter to enter through, so the
+// message runs after the turn in flight rather than beside it. A session that already has
+// someone waiting refuses.
+func (r *turnRegistry) claim(session uuid.UUID, cancel context.CancelFunc) (*turnSlot, *turnWaiter, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if _, busy := r.turns[session]; busy {
-		return nil, false
+	if _, running := r.turns[session]; !running {
+		return r.take(session, cancel), nil, nil
 	}
+	if r.waiting[session] {
+		return nil, nil, errTurnQueueFull
+	}
+	if r.waiting == nil {
+		r.waiting = make(map[uuid.UUID]bool)
+	}
+	r.waiting[session] = true
+	return nil, &turnWaiter{registry: r, session: session}, nil
+}
+
+// take records a turn as running. The caller holds the lock.
+func (r *turnRegistry) take(session uuid.UUID, cancel context.CancelFunc) *turnSlot {
 	if r.turns == nil {
 		r.turns = make(map[uuid.UUID]*turnSlot)
 	}
-	slot := &turnSlot{cancel: cancel}
+	slot := &turnSlot{cancel: cancel, done: make(chan struct{})}
 	r.turns[session] = slot
-	return slot, true
+	return slot
 }
 
-// release gives the slot back when the turn ends, however it ended.
+// release gives the slot back when the turn ends, however it ended, and wakes whoever waited.
 //
 // It clears the entry only if the session still holds this very slot: a turn that was already
 // replaced must not delete its successor's entry and leave the session looking idle while a
@@ -60,11 +100,12 @@ func (r *turnRegistry) release(session uuid.UUID, slot *turnSlot) {
 		return
 	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	if current, ok := r.turns[session]; ok && current == slot {
 		delete(r.turns, session)
 	}
+	r.mu.Unlock()
+
+	slot.finish()
 }
 
 // cancel stops the session's running turn, reporting whether there was one. A session with
@@ -88,4 +129,45 @@ func (r *turnRegistry) len() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.turns)
+}
+
+// turnWaiter is a message's place in line for a session that is busy.
+type turnWaiter struct {
+	registry *turnRegistry
+	session  uuid.UUID
+}
+
+// enter waits for the running turn to end and then takes the slot for its own.
+//
+// It loops rather than assuming the slot is free once it wakes: another message may have taken
+// it in between, and waking to find it gone is a reason to wait again, not to run beside it.
+// Whatever happens, the waiting place is given back — a wait that ended without releasing it
+// would leave the session refusing every later message.
+func (w *turnWaiter) enter(ctx context.Context, cancel context.CancelFunc) (*turnSlot, error) {
+	defer w.leave()
+
+	for {
+		w.registry.mu.Lock()
+		current, running := w.registry.turns[w.session]
+		if !running {
+			slot := w.registry.take(w.session, cancel)
+			w.registry.mu.Unlock()
+			return slot, nil
+		}
+		ended := current.done
+		w.registry.mu.Unlock()
+
+		select {
+		case <-ended:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// leave gives the waiting place back.
+func (w *turnWaiter) leave() {
+	w.registry.mu.Lock()
+	delete(w.registry.waiting, w.session)
+	w.registry.mu.Unlock()
 }

--- a/internal/handler/assistant_turns_test.go
+++ b/internal/handler/assistant_turns_test.go
@@ -184,3 +184,39 @@ func TestTurnRegistryIsSafeUnderConcurrentUse(t *testing.T) {
 		t.Fatalf("registry holds %d entries after every turn ended, want 0", n)
 	}
 }
+
+// Stop must reach a turn that has not started yet. Otherwise pressing Stop with a message
+// queued behind the running one CANCELS the running turn and thereby STARTS the queued one —
+// the opposite of what was asked.
+func TestTurnRegistryCancelReachesAQueuedTurn(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+
+	running, _, _ := reg.claim(session, func() {})
+	waitCtx, waitCancel := context.WithCancel(context.Background())
+	_, waiter, err := reg.claim(session, waitCancel)
+	if err != nil || waiter == nil {
+		t.Fatalf("second claim did not queue: %v, %v", waiter, err)
+	}
+
+	entered := make(chan error, 1)
+	go func() {
+		_, err := waiter.enter(waitCtx, waitCancel)
+		entered <- err
+	}()
+
+	reg.cancel(session)
+	reg.release(session, running)
+
+	select {
+	case err := <-entered:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("the queued turn started anyway (err = %v)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the queued turn neither started nor gave up")
+	}
+	if n := reg.len(); n != 0 {
+		t.Fatalf("registry holds %d entries, want 0", n)
+	}
+}

--- a/internal/handler/assistant_turns_test.go
+++ b/internal/handler/assistant_turns_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestTurnRegistryAdmitsOneTurnPerSession(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+
+	first, ok := reg.admit(session, func() {})
+	if !ok {
+		t.Fatal("the first turn of an idle session was refused")
+	}
+	if _, ok := reg.admit(session, func() {}); ok {
+		t.Fatal("a second turn was admitted beside the first; two turns would write one CV")
+	}
+
+	// Another session is another slot: the bound is per conversation, not global.
+	if _, ok := reg.admit(uuid.New(), func() {}); !ok {
+		t.Fatal("a different session was refused while this one ran")
+	}
+
+	reg.release(session, first)
+	if _, ok := reg.admit(session, func() {}); !ok {
+		t.Fatal("the session stayed busy after its turn ended")
+	}
+}
+
+// A registry that keeps entries for turns that have ended is a leak that grows for as long as
+// the process lives, and it would also refuse every later turn of the session.
+func TestTurnRegistryForgetsAFinishedTurn(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+
+	slot, _ := reg.admit(session, func() {})
+	reg.release(session, slot)
+
+	if n := reg.len(); n != 0 {
+		t.Fatalf("registry holds %d entries after the turn ended, want 0", n)
+	}
+}
+
+func TestTurnRegistryCancelsTheTurnItHolds(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	slot, _ := reg.admit(session, cancel)
+	if !reg.cancel(session) {
+		t.Fatal("cancelling a running turn reported nothing to cancel")
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("the turn's context was not cancelled")
+	}
+	reg.release(session, slot)
+}
+
+// Cancelling a session with nothing running is how a client stops a turn it cannot see the end
+// of. It reports that there was nothing to do rather than failing.
+func TestTurnRegistryCancelIsHarmlessWhenIdle(t *testing.T) {
+	var reg turnRegistry
+
+	if reg.cancel(uuid.New()) {
+		t.Fatal("cancelling an idle session claimed to have cancelled a turn")
+	}
+}
+
+// The registry is reached from the stream writer's goroutine and from cancel requests at the
+// same time, so its map must never be touched unguarded.
+func TestTurnRegistryIsSafeUnderConcurrentUse(t *testing.T) {
+	var reg turnRegistry
+	sessions := make([]uuid.UUID, 8)
+	for i := range sessions {
+		sessions[i] = uuid.New()
+	}
+
+	var wg sync.WaitGroup
+	for _, session := range sessions {
+		for range 4 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if slot, ok := reg.admit(session, func() {}); ok {
+					reg.cancel(session)
+					reg.release(session, slot)
+				}
+			}()
+		}
+	}
+	wg.Wait()
+
+	if n := reg.len(); n != 0 {
+		t.Fatalf("registry holds %d entries after every turn ended, want 0", n)
+	}
+}

--- a/internal/handler/assistant_turns_test.go
+++ b/internal/handler/assistant_turns_test.go
@@ -2,8 +2,10 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -12,22 +14,19 @@ func TestTurnRegistryAdmitsOneTurnPerSession(t *testing.T) {
 	var reg turnRegistry
 	session := uuid.New()
 
-	first, ok := reg.admit(session, func() {})
-	if !ok {
-		t.Fatal("the first turn of an idle session was refused")
-	}
-	if _, ok := reg.admit(session, func() {}); ok {
-		t.Fatal("a second turn was admitted beside the first; two turns would write one CV")
+	first, waiter, err := reg.claim(session, func() {})
+	if err != nil || first == nil || waiter != nil {
+		t.Fatalf("the first turn of an idle session did not get the slot: %v, %v, %v", first, waiter, err)
 	}
 
 	// Another session is another slot: the bound is per conversation, not global.
-	if _, ok := reg.admit(uuid.New(), func() {}); !ok {
-		t.Fatal("a different session was refused while this one ran")
+	if other, waiter, err := reg.claim(uuid.New(), func() {}); err != nil || other == nil || waiter != nil {
+		t.Fatalf("a different session was made to wait while this one ran: %v, %v, %v", other, waiter, err)
 	}
 
 	reg.release(session, first)
-	if _, ok := reg.admit(session, func() {}); !ok {
-		t.Fatal("the session stayed busy after its turn ended")
+	if again, waiter, err := reg.claim(session, func() {}); err != nil || again == nil || waiter != nil {
+		t.Fatalf("the session stayed busy after its turn ended: %v, %v, %v", again, waiter, err)
 	}
 }
 
@@ -37,7 +36,7 @@ func TestTurnRegistryForgetsAFinishedTurn(t *testing.T) {
 	var reg turnRegistry
 	session := uuid.New()
 
-	slot, _ := reg.admit(session, func() {})
+	slot, _, _ := reg.claim(session, func() {})
 	reg.release(session, slot)
 
 	if n := reg.len(); n != 0 {
@@ -50,7 +49,7 @@ func TestTurnRegistryCancelsTheTurnItHolds(t *testing.T) {
 	session := uuid.New()
 	ctx, cancel := context.WithCancel(context.Background())
 
-	slot, _ := reg.admit(session, cancel)
+	slot, _, _ := reg.claim(session, cancel)
 	if !reg.cancel(session) {
 		t.Fatal("cancelling a running turn reported nothing to cancel")
 	}
@@ -72,6 +71,91 @@ func TestTurnRegistryCancelIsHarmlessWhenIdle(t *testing.T) {
 	}
 }
 
+// A second message does not race the turn in flight — it waits for it. Racing would put two
+// turns of one tailoring session on one CV, each blind to the other's edits.
+func TestTurnRegistrySecondClaimWaitsForTheFirst(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+
+	running, waiter, err := reg.claim(session, func() {})
+	if err != nil || running == nil || waiter != nil {
+		t.Fatalf("first claim = (%v, %v, %v), want the slot", running, waiter, err)
+	}
+
+	_, waiter, err = reg.claim(session, func() {})
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if waiter == nil {
+		t.Fatal("the second claim took a slot beside the first instead of waiting for it")
+	}
+
+	entered := make(chan *turnSlot, 1)
+	go func() {
+		slot, err := waiter.enter(context.Background(), func() {})
+		if err != nil {
+			t.Errorf("enter: %v", err)
+		}
+		entered <- slot
+	}()
+
+	select {
+	case <-entered:
+		t.Fatal("the waiting turn started while the first was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	reg.release(session, running)
+	select {
+	case slot := <-entered:
+		if slot == nil {
+			t.Fatal("the waiting turn was let in without a slot")
+		}
+		reg.release(session, slot)
+	case <-time.After(2 * time.Second):
+		t.Fatal("the waiting turn never started after the first ended")
+	}
+}
+
+// One waiter, not a queue. A queue a client can grow without limit is a way to hold the process
+// open, and the waiting message is a live request whose natural depth is one.
+func TestTurnRegistryRefusesASecondWaiter(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+
+	running, _, _ := reg.claim(session, func() {})
+	if _, waiter, err := reg.claim(session, func() {}); err != nil || waiter == nil {
+		t.Fatalf("the first waiter was refused: %v", err)
+	}
+
+	if _, _, err := reg.claim(session, func() {}); !errors.Is(err, errTurnQueueFull) {
+		t.Fatalf("third claim err = %v, want errTurnQueueFull", err)
+	}
+	reg.release(session, running)
+}
+
+// A wait that outlives its patience gives its place back, or the session would look permanently
+// occupied to every later message.
+func TestTurnRegistryWaitGivesUpWithItsContext(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+
+	running, _, _ := reg.claim(session, func() {})
+	_, waiter, _ := reg.claim(session, func() {})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := waiter.enter(ctx, func() {}); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("enter err = %v, want the deadline", err)
+	}
+
+	// The place is free again: another message may now wait.
+	if _, waiter, err := reg.claim(session, func() {}); err != nil || waiter == nil {
+		t.Fatalf("the waiting place was not given back: %v, %v", waiter, err)
+	}
+	reg.release(session, running)
+}
+
 // The registry is reached from the stream writer's goroutine and from cancel requests at the
 // same time, so its map must never be touched unguarded.
 func TestTurnRegistryIsSafeUnderConcurrentUse(t *testing.T) {
@@ -87,7 +171,7 @@ func TestTurnRegistryIsSafeUnderConcurrentUse(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				if slot, ok := reg.admit(session, func() {}); ok {
+				if slot, _, err := reg.claim(session, func() {}); err == nil && slot != nil {
 					reg.cancel(session)
 					reg.release(session, slot)
 				}

--- a/openspec/changes/assistant-turn-survives-disconnect/.openspec.yaml
+++ b/openspec/changes/assistant-turn-survives-disconnect/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/assistant-turn-survives-disconnect/design.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/design.md
@@ -1,0 +1,113 @@
+## Context
+
+`streamTurn` (`internal/handler/assistant.go:441`) already runs the turn on
+`context.Background()`, deliberately, because the request context dies when the
+handler returns and the stream writer outlives it. What kills the turn is one
+line inside the event callback: when `stream.event` reports a failed write, the
+handler calls `cancel()`.
+
+That was reasonable when the only client was a desktop tab, and it is wrong on a
+phone. A backgrounded tab is frozen, not closed, and the failed write it produces
+is indistinguishable from the user closing the app. It is also indistinguishable
+from the Stop button, because Stop is `controller.abort()`
+(`web/src/lib/assistant/client.ts:104`) — the client has no other way to say
+"stop" and the server has no other way to hear it.
+
+Two bounds on a turn already exist and are server-owned: `RunnerConfig.MaxSteps`
+(8, raised to 30 for an autopilot run) and the LLM client's per-call timeout.
+Cancellation-on-disconnect was a third, cruder bound layered on top.
+
+Separately, the tool contract refuses batches for reasons that carry no
+information about the CV: 15 refusals in 30 days because `ops` arrived as a
+stringified array, and a refusal when a batch removes two positions of one list.
+Each refusal costs a round of the very budget the run needs to finish.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A turn survives a reader that stops reading, and finishes under its existing bounds.
+- Stopping a turn becomes an explicit request rather than a side effect of transport.
+- Two turns never run against one session, and therefore never against one CV.
+- A returning client sees the work done in its absence.
+- Refusals that are about packaging rather than intent stop happening.
+
+**Non-Goals:**
+
+- Moving autopilot to a queue and a worker. That is the right end state for an
+  unattended run and it is a larger change; this one keeps the turn in-process.
+- Surviving a process restart or a blue/green flip. A turn is process-local
+  before this change and stays so after it.
+- Relaxing strict decoding of unknown fields anywhere.
+- Metrics or alerting on tool failures. Worth doing, separate change.
+
+## Decisions
+
+**A failed write stops writing, not working.** The event callback drops the
+`cancel()` and simply stops attempting to write. The alternative — a grace period
+before cancelling — was considered and rejected: an autopilot run takes minutes,
+so any grace short enough to save money is too short to save the run, which is
+the case that hurt.
+
+**Cancellation gets a registry and an endpoint.** `assistantHandlers` holds
+`map[sessionID]*turnState` under a mutex; `POST /sessions/:id/cancel` looks up
+the session's turn and cancels it. The registry is chosen over storing a
+cancellation flag in Postgres because a `CancelFunc` cannot be persisted and the
+handler that must act on it lives in this process. Consequence, accepted and
+recorded in the proposal: a turn started before a blue/green flip cannot be
+cancelled and ends at its step cap.
+
+**Owner scoping reuses the existing rule.** Cancel resolves the session with the
+same owner-scoped read as everything else, so a session the caller does not own
+is reported missing rather than forbidden.
+
+**Queueing is a per-session slot, not a queue.** The registry entry carries a
+channel closed when the turn ends; a second message waits on it with a timeout,
+a third is refused with 409. A real queue (durable, ordered, many-deep) buys
+nothing here: the waiting message is a live HTTP request, so its natural depth is
+one.
+
+**The `queued` event precedes the turn's own events.** The client already renders
+named events, so telling it "you are waiting" needs no new transport.
+
+**`ops` is unwrapped at the tool boundary, not inside `cvedit`.** The tool is
+where a model's packaging guess arrives; `cvedit` should keep receiving typed
+operations. Unwrapping is: if `ops` decodes as a string, decode that string as
+the array and proceed through the same strict decoder.
+
+**Removals within a batch are applied in descending index order.** The batch is
+already all-or-nothing, so reordering the application of removals changes no
+outcome except the self-inflicted refusal. Sorting happens where the batch is
+applied, so every entry point inherits it.
+
+## Risks / Trade-offs
+
+- **An abandoned turn now costs full budget** → It was already bounded by
+  `MaxSteps` and the call timeout; the worst case is one abandoned autopilot run
+  at 30 rounds, and that is the exact scenario the user asked to protect.
+- **A turn cannot be cancelled across a deploy flip** → It ends at its step cap;
+  documented in the proposal rather than solved, because solving it means moving
+  runs out of process.
+- **The registry leaks if an entry is not removed** → The entry is removed in a
+  `defer` alongside the existing `cancel` defer, and a test asserts the map is
+  empty after a turn ends, including a failed one.
+- **Unwrapping `ops` could mask a genuinely malformed batch** → The unwrapped
+  string goes through the same strict decoder, so a malformed array still fails
+  with the same message; only the wrapper is forgiven.
+- **Two clients on one session both press Stop** → Cancelling an already-finished
+  turn succeeds and does nothing, per the spec.
+
+## Migration Plan
+
+No schema change, no data migration. The change is a deploy; the frontend and
+backend ship together because Stop moves to the new endpoint. A client running
+the old bundle against the new backend still works — its abort stops its own
+reading, and the turn it abandoned finishes and is stored rather than truncated.
+
+Rollback is a redeploy of the previous build: nothing persists that the old code
+cannot read.
+
+## Open Questions
+
+None outstanding. The wait timeout for a queued message and the step-cap
+interaction are implementation constants, chosen in the tasks and testable.

--- a/openspec/changes/assistant-turn-survives-disconnect/proposal.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+A turn dies whenever a write to the client fails, and a phone backgrounding its
+tab is exactly that: the work stops mid-run, minutes of model spend are thrown
+away, and the user comes back to a chat that simply stopped. The observed cost is
+a tailoring pass that made 25 CV edits and then lost its `tailor_report` to
+`context canceled` — the report that tells the candidate what was covered.
+
+The deeper fault is that one signal carries three meanings. A broken TCP write is
+the only way the server learns that the user pressed Stop, that the user left, and
+that the network blinked, so the code cannot tell a deliberate stop from a phone
+locking its screen and must treat every one of them as "abandon the work".
+
+## What Changes
+
+- A failed SSE write no longer cancels the turn. The turn runs to completion under
+  the bounds it already has — the server-owned step cap and the LLM call timeout —
+  and the transcript it produces is persisted whether or not anyone was reading.
+- Explicit cancellation gets its own channel: a new owner-scoped
+  `POST /api/v1/assistant/sessions/:id/cancel`. The Stop button calls it instead of
+  relying on aborting the stream. **BREAKING** for any client that relied on
+  dropping the connection to stop a turn: dropping it now leaves the turn running.
+- A message sent while a turn is in flight queues behind it instead of racing it.
+  Capacity is one running turn plus one waiting per session; a further message is
+  refused. The client is told it is queued rather than left guessing.
+- On returning to a backgrounded tab the client re-reads the session and shows what
+  the agent did while it was away. An interrupted stream stops being rendered as a
+  failed turn, because a reader that stopped reading is not a turn that failed.
+- The CV edit tool accepts a batch whose `ops` arrived as a JSON string, and applies
+  a batch's removals in an order that does not invalidate its own addresses. Both
+  are refusals that cost the model a round and taught it nothing about the CV.
+
+## Capabilities
+
+### New Capabilities
+
+None. Every behaviour here belongs to a capability that already exists.
+
+### Modified Capabilities
+
+- `assistant-agent-runtime`: the turn survives a disconnected reader and stops only
+  on explicit cancellation; concurrent messages to one session are serialised; the
+  cancel channel is part of the contract rather than an accident of the transport.
+- `cv-edit-revisions`: a batch is judged by what it asks for, not by how the model
+  packaged it — argument packaging and intra-batch index shifts stop being refusals.
+
+## Impact
+
+- `internal/handler/assistant.go` — the write callback, the turn registry, the new
+  cancel route, the queueing gate.
+- `internal/handler/assistant_cv_tools.go` — `ops` unwrapping ahead of the strict
+  decoder; `internal/cvedit` — removal ordering within a batch.
+- `web/src/lib/assistant/` — `client.ts`, `AssistantChat.svelte`, `chat.ts`: Stop
+  calls the endpoint, visibility restores the session, an aborted read is not an
+  error.
+- Strict decoding of unknown fields is deliberately untouched: it is what stopped an
+  agent silently clobbering the wrong experience entry, and nothing here relaxes it.
+- The registry lives in one process, so a turn that outlives a blue/green flip
+  cannot be cancelled and instead ends at its step cap.

--- a/openspec/changes/assistant-turn-survives-disconnect/specs/assistant-agent-runtime/spec.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/specs/assistant-agent-runtime/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: A turn outlives a reader that stopped reading
+
+A turn SHALL NOT be cancelled because writing to its client failed. The system
+SHALL treat an unwritable stream as a reader that is not listening, never as an
+instruction to abandon the work, and SHALL carry the turn through to its own
+end under the bounds it already has: the server-owned step cap and the model
+call timeout. Every message the turn produces SHALL be persisted whether or not
+anyone is reading, so the session holds the whole turn and not the part that
+happened to be delivered.
+
+#### Scenario: A backgrounded tab does not stop the work
+
+- **WHEN** the client stops reading mid-turn because its tab was backgrounded or its connection dropped
+- **THEN** the turn keeps running to its own end, and every message and tool result it produces is stored on the session
+
+#### Scenario: An unattended run finishes and files its report
+
+- **WHEN** an unattended tailoring run loses its reader after editing the CV but before filing its report
+- **THEN** the run still reaches its report, and the report is stored on the CV
+
+### Requirement: Cancelling a turn is an explicit act
+
+The system SHALL offer an owner-scoped endpoint that cancels the in-flight turn
+of a named session, and that endpoint SHALL be the only way a caller stops a
+turn. Cancellation SHALL stop the turn before its next model call and SHALL NOT
+start new tool work. Work already committed by a tool SHALL remain committed, and
+the partial transcript SHALL be persisted so the session is resumable. A session
+that has no turn running SHALL report success rather than an error, so a client
+may cancel without first proving that there is something to cancel.
+
+#### Scenario: The user stops a running turn
+
+- **WHEN** the owner asks to cancel a session whose turn is running
+- **THEN** the turn stops before its next model call, the work already committed stands, and the transcript up to that point is stored
+
+#### Scenario: Cancelling an idle session is not an error
+
+- **WHEN** the owner asks to cancel a session with no turn in flight
+- **THEN** the request succeeds and nothing is changed
+
+#### Scenario: A stranger cannot stop someone else's turn
+
+- **WHEN** a caller who does not own the session asks to cancel it
+- **THEN** the session is reported as missing and the turn continues untouched
+
+### Requirement: One turn at a time within a session
+
+A session SHALL run at most one turn at a time. A message that arrives while a
+turn is in flight SHALL wait for that turn rather than run beside it, and the
+client SHALL be told it is waiting rather than left to guess. The wait SHALL be
+bounded in time. At most one message SHALL wait: a further message arriving
+while one is already waiting SHALL be refused, because a queue a client can grow
+without limit is a way to hold the process open.
+
+#### Scenario: A second message waits its turn
+
+- **WHEN** the user sends a message while a turn is still running in that session
+- **THEN** the client is told the message is queued, and the message runs as its own turn once the running one ends
+
+#### Scenario: A third message is refused
+
+- **WHEN** a message arrives while one turn is running and another is already waiting
+- **THEN** the request is refused and the running and waiting turns are unaffected
+
+### Requirement: A returning client is shown what it missed
+
+A client that lost the stream SHALL be able to recover the turn's outcome by
+re-reading the session, and the system SHALL serve the full transcript including
+anything produced while nothing was reading. A stream that ended without its
+terminal event SHALL NOT be presented as a failed turn — a reader that stopped
+reading is not a turn that failed, and showing it as one misreports the state of
+the user's own CV.
+
+#### Scenario: Returning to a backgrounded tab
+
+- **WHEN** the user returns to a tab whose stream was interrupted while a turn ran
+- **THEN** re-reading the session shows the messages the agent produced in the meantime
+
+#### Scenario: An interrupted stream is not an error
+
+- **WHEN** a stream ends without its terminal event
+- **THEN** the turn is not rendered as errored
+
+## REMOVED Requirements
+
+### Requirement: A turn stops when the caller goes away
+
+**Reason**: The requirement rested on the assumption that an unwritable stream
+means the caller left. On a phone it usually means the tab was backgrounded for a
+moment, so the rule threw away live work — an unattended tailoring pass lost its
+report after twenty-five committed CV edits. It also made a deliberate stop
+indistinguishable from a blinking network, because both reached the server only
+as a failed write.
+
+**Migration**: Replaced by "A turn outlives a reader that stopped reading" and
+"Cancelling a turn is an explicit act". A client that stopped a turn by dropping
+its connection MUST now call the cancel endpoint; dropping the connection leaves
+the turn running to its step cap.

--- a/openspec/changes/assistant-turn-survives-disconnect/specs/cv-edit-revisions/spec.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/specs/cv-edit-revisions/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: A batch is judged by what it asks for, not by how it was packaged
+
+The system SHALL accept an edit batch whose operations arrived as a JSON string
+holding the array, applying it exactly as it would the array itself. Packaging is
+the model's guess about a wire format and carries no meaning about the edit, so
+refusing it spends a round of the turn's budget and teaches the model nothing
+about the document.
+
+This tolerance SHALL extend to packaging alone. Unknown fields inside an
+operation SHALL still be refused, because a field the editor does not know is a
+field it would silently drop — which is how an agent once rewrote the wrong
+experience entry while believing it had succeeded.
+
+#### Scenario: Operations arrive as a JSON string
+
+- **WHEN** a batch names its operations as a string holding a JSON array
+- **THEN** the batch applies exactly as if the array had been sent directly
+
+#### Scenario: An unknown field is still refused
+
+- **WHEN** an operation carries a field the editor does not define
+- **THEN** the batch is refused and names the offending field, and the document is unchanged
+
+### Requirement: A batch's removals do not invalidate each other
+
+When a batch removes more than one element of the same list, the system SHALL
+apply those removals so that each address means what it meant when the batch was
+written. Removing an earlier position first shifts every later one, so a batch
+naming two positions of the same list would refuse itself — a failure caused by
+the order of application and not by anything the caller asked for.
+
+#### Scenario: Two positions of one list are removed
+
+- **WHEN** a batch removes positions 3 and 4 of a four-element list
+- **THEN** both named elements are removed and the batch is not refused
+
+#### Scenario: A genuinely out-of-range address is still refused
+
+- **WHEN** a batch names a position the list never held
+- **THEN** the batch is refused and the document is unchanged

--- a/openspec/changes/assistant-turn-survives-disconnect/tasks.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/tasks.md
@@ -32,11 +32,11 @@
 
 ## 5. One turn at a time within a session
 
-- [ ] 5.1 Failing test: a message arriving during a running turn waits for it and then runs as its own turn
-- [ ] 5.2 Make a second message wait on the running turn's completion channel, bounded by a timeout
-- [ ] 5.3 Failing test: a third message, arriving while one waits, is refused with 409 and disturbs neither the running nor the waiting turn
-- [ ] 5.4 Emit a `queued` event to the waiting client before its turn's own events
-- [ ] 5.5 Failing test: a queued message whose wait times out fails cleanly with a terminal event rather than hanging the client
+- [x] 5.1 Failing test: a message arriving during a running turn waits for it and then runs as its own turn
+- [x] 5.2 Make a second message wait on the running turn's completion channel, bounded by a timeout
+- [x] 5.3 Failing test: a third message, arriving while one waits, is refused with 409 and disturbs neither the running nor the waiting turn
+- [x] 5.4 Emit a `queued` event to the waiting client before its turn's own events
+- [x] 5.5 Failing test: a queued message whose wait times out fails cleanly with a terminal event rather than hanging the client
 
 ## 6. The client stops lying about interrupted turns
 

--- a/openspec/changes/assistant-turn-survives-disconnect/tasks.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/tasks.md
@@ -24,11 +24,11 @@
 
 ## 4. Cancellation gets its own channel
 
-- [ ] 4.1 Failing test: `POST /api/v1/assistant/sessions/:id/cancel` does not exist; assert it stops the session's running turn before its next model call
-- [ ] 4.2 Add the route and handler, resolving the session with the same owner-scoped read used elsewhere
-- [ ] 4.3 Failing test: cancelling a session with no turn in flight succeeds and changes nothing
-- [ ] 4.4 Failing test: a caller who does not own the session gets the session reported as missing, and the turn keeps running
-- [ ] 4.5 Failing test: work committed before cancellation stays committed and the partial transcript is stored
+- [x] 4.1 Failing test: `POST /api/v1/assistant/sessions/:id/cancel` does not exist; assert it stops the session's running turn before its next model call
+- [x] 4.2 Add the route and handler, resolving the session with the same owner-scoped read used elsewhere
+- [x] 4.3 Failing test: cancelling a session with no turn in flight succeeds and changes nothing
+- [x] 4.4 Failing test: a caller who does not own the session gets the session reported as missing, and the turn keeps running
+- [x] 4.5 Failing test: work committed before cancellation stays committed and the partial transcript is stored
 
 ## 5. One turn at a time within a session
 

--- a/openspec/changes/assistant-turn-survives-disconnect/tasks.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/tasks.md
@@ -10,16 +10,16 @@
 
 ## 2. Turn registry
 
-- [ ] 2.1 Failing test in `internal/handler`: two turns started for one session both run today; assert the registry admits one and reports the session busy to the second
-- [ ] 2.2 Add the per-session turn registry to `assistantHandlers`: session id to turn state holding its `CancelFunc` and a channel closed when the turn ends, guarded by a mutex
-- [ ] 2.3 Register a turn as it starts and remove it in a `defer` beside the existing `cancel` defer
-- [ ] 2.4 Failing test: the registry is empty after a turn ends, including a turn that ended in error
+- [x] 2.1 Failing test in `internal/handler`: two turns started for one session both run today; assert the registry admits one and reports the session busy to the second
+- [x] 2.2 Add the per-session turn registry to `assistantHandlers`: session id to turn state holding its `CancelFunc` and a channel closed when the turn ends, guarded by a mutex
+- [x] 2.3 Register a turn as it starts and remove it in a `defer` beside the existing `cancel` defer
+- [x] 2.4 Failing test: the registry is empty after a turn ends, including a turn that ended in error
 
 ## 3. The turn stops depending on its reader
 
-- [ ] 3.1 Failing test in `internal/handler`: with every SSE write failing from the first event, the turn is cut short today; assert it runs to its own end and its messages are persisted
-- [ ] 3.2 Remove the `cancel()` call from the SSE event callback in `streamTurn`; a failed write stops writing only
-- [ ] 3.3 Failing test: a turn whose reader vanished mid-run still reaches and stores its final tool call, mirroring the lost `tailor_report`
+- [x] 3.1 Failing test in `internal/handler`: with every SSE write failing from the first event, the turn is cut short today; assert it runs to its own end and its messages are persisted
+- [x] 3.2 Remove the `cancel()` call from the SSE event callback in `streamTurn`; a failed write stops writing only
+- [x] 3.3 Failing test: a turn whose reader vanished mid-run still reaches and stores its final tool call, mirroring the lost `tailor_report`
 - [ ] 3.4 Confirm the keep-alive goroutine and the write deadline still end with the turn and leak nothing when nobody reads
 
 ## 4. Cancellation gets its own channel

--- a/openspec/changes/assistant-turn-survives-disconnect/tasks.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/tasks.md
@@ -40,10 +40,10 @@
 
 ## 6. The client stops lying about interrupted turns
 
-- [ ] 6.1 Failing test in `web`: an aborted read currently marks the message errored; assert an interrupted stream is not rendered as a failed turn
-- [ ] 6.2 Point the Stop button at the cancel endpoint; keep `abort()` as the way this client stops reading
-- [ ] 6.3 Re-read the session on `visibilitychange` when a turn was in flight, and render the transcript the server holds
-- [ ] 6.4 Render the `queued` event so a waiting message reads as waiting rather than as a stalled turn
+- [x] 6.1 Failing test in `web`: an aborted read currently marks the message errored; assert an interrupted stream is not rendered as a failed turn
+- [x] 6.2 Point the Stop button at the cancel endpoint; keep `abort()` as the way this client stops reading
+- [x] 6.3 Re-read the session on `visibilitychange` when a turn was in flight, and render the transcript the server holds
+- [x] 6.4 Render the `queued` event so a waiting message reads as waiting rather than as a stalled turn
 - [ ] 6.5 Failing test: returning to a tab whose stream was interrupted shows the messages produced in the meantime
 
 ## 7. Verification

--- a/openspec/changes/assistant-turn-survives-disconnect/tasks.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/tasks.md
@@ -20,7 +20,7 @@
 - [x] 3.1 Failing test in `internal/handler`: with every SSE write failing from the first event, the turn is cut short today; assert it runs to its own end and its messages are persisted
 - [x] 3.2 Remove the `cancel()` call from the SSE event callback in `streamTurn`; a failed write stops writing only
 - [x] 3.3 Failing test: a turn whose reader vanished mid-run still reaches and stores its final tool call, mirroring the lost `tailor_report`
-- [ ] 3.4 Confirm the keep-alive goroutine and the write deadline still end with the turn and leak nothing when nobody reads
+- [x] 3.4 Confirm the keep-alive goroutine and the write deadline still end with the turn and leak nothing when nobody reads
 
 ## 4. Cancellation gets its own channel
 
@@ -48,8 +48,8 @@
 
 ## 7. Verification
 
-- [ ] 7.1 `go build ./... && go vet ./...` and `go test ./...`
-- [ ] 7.2 `go vet -tags=integration ./...` — the cheap guard against a changed signature breaking the tagged suite CI runs
-- [ ] 7.3 `go test -tags=integration ./internal/handler/` for the turn and tool tests
-- [ ] 7.4 `pnpm test`, `pnpm lint` and `pnpm check` in `web/`
+- [x] 7.1 `go build ./... && go vet ./...` and `go test ./...`
+- [x] 7.2 `go vet -tags=integration ./...` — the cheap guard against a changed signature breaking the tagged suite CI runs
+- [x] 7.3 `go test -tags=integration ./internal/handler/` for the turn and tool tests
+- [x] 7.4 `pnpm test`, `pnpm lint` and `pnpm check` in `web/`
 - [ ] 7.5 Drive the real flow: start an autopilot run, background the tab for a minute, return, and confirm the run finished and filed its report

--- a/openspec/changes/assistant-turn-survives-disconnect/tasks.md
+++ b/openspec/changes/assistant-turn-survives-disconnect/tasks.md
@@ -1,0 +1,55 @@
+## 1. Tool contract: stop refusing batches over packaging
+
+- [x] 1.1 Failing test in `internal/cvedit`: a batch removing positions 3 and 4 of a four-element list currently refuses itself; assert both elements go and the document is left consistent
+- [x] 1.2 Apply a batch's `remove` operations in descending index order at the point the batch is applied, so every entry point inherits it; keep the batch all-or-nothing
+- [x] 1.3 Failing test in `internal/cvedit`: a batch naming a position the list never held is still refused and leaves the document unchanged
+- [x] 1.4 Failing test in `internal/handler`: `cv_edit` called with `ops` as a string holding a JSON array is refused today; assert it applies identically to the array form
+- [x] 1.5 Unwrap a string-valued `ops` at the tool boundary in `assistant_cv_tools.go`, then decode through the existing strict decoder unchanged
+- [x] 1.6 Failing test: an operation carrying an unknown field is still refused and names the field — the 2026-07-19 guard must survive this change
+- [x] 1.7 Return an addressed message when `evidence_id` names no banked achievement, telling the model to take the id from `experience_search`
+
+## 2. Turn registry
+
+- [ ] 2.1 Failing test in `internal/handler`: two turns started for one session both run today; assert the registry admits one and reports the session busy to the second
+- [ ] 2.2 Add the per-session turn registry to `assistantHandlers`: session id to turn state holding its `CancelFunc` and a channel closed when the turn ends, guarded by a mutex
+- [ ] 2.3 Register a turn as it starts and remove it in a `defer` beside the existing `cancel` defer
+- [ ] 2.4 Failing test: the registry is empty after a turn ends, including a turn that ended in error
+
+## 3. The turn stops depending on its reader
+
+- [ ] 3.1 Failing test in `internal/handler`: with every SSE write failing from the first event, the turn is cut short today; assert it runs to its own end and its messages are persisted
+- [ ] 3.2 Remove the `cancel()` call from the SSE event callback in `streamTurn`; a failed write stops writing only
+- [ ] 3.3 Failing test: a turn whose reader vanished mid-run still reaches and stores its final tool call, mirroring the lost `tailor_report`
+- [ ] 3.4 Confirm the keep-alive goroutine and the write deadline still end with the turn and leak nothing when nobody reads
+
+## 4. Cancellation gets its own channel
+
+- [ ] 4.1 Failing test: `POST /api/v1/assistant/sessions/:id/cancel` does not exist; assert it stops the session's running turn before its next model call
+- [ ] 4.2 Add the route and handler, resolving the session with the same owner-scoped read used elsewhere
+- [ ] 4.3 Failing test: cancelling a session with no turn in flight succeeds and changes nothing
+- [ ] 4.4 Failing test: a caller who does not own the session gets the session reported as missing, and the turn keeps running
+- [ ] 4.5 Failing test: work committed before cancellation stays committed and the partial transcript is stored
+
+## 5. One turn at a time within a session
+
+- [ ] 5.1 Failing test: a message arriving during a running turn waits for it and then runs as its own turn
+- [ ] 5.2 Make a second message wait on the running turn's completion channel, bounded by a timeout
+- [ ] 5.3 Failing test: a third message, arriving while one waits, is refused with 409 and disturbs neither the running nor the waiting turn
+- [ ] 5.4 Emit a `queued` event to the waiting client before its turn's own events
+- [ ] 5.5 Failing test: a queued message whose wait times out fails cleanly with a terminal event rather than hanging the client
+
+## 6. The client stops lying about interrupted turns
+
+- [ ] 6.1 Failing test in `web`: an aborted read currently marks the message errored; assert an interrupted stream is not rendered as a failed turn
+- [ ] 6.2 Point the Stop button at the cancel endpoint; keep `abort()` as the way this client stops reading
+- [ ] 6.3 Re-read the session on `visibilitychange` when a turn was in flight, and render the transcript the server holds
+- [ ] 6.4 Render the `queued` event so a waiting message reads as waiting rather than as a stalled turn
+- [ ] 6.5 Failing test: returning to a tab whose stream was interrupted shows the messages produced in the meantime
+
+## 7. Verification
+
+- [ ] 7.1 `go build ./... && go vet ./...` and `go test ./...`
+- [ ] 7.2 `go vet -tags=integration ./...` — the cheap guard against a changed signature breaking the tagged suite CI runs
+- [ ] 7.3 `go test -tags=integration ./internal/handler/` for the turn and tool tests
+- [ ] 7.4 `pnpm test`, `pnpm lint` and `pnpm check` in `web/`
+- [ ] 7.5 Drive the real flow: start an autopilot run, background the tab for a minute, return, and confirm the run finished and filed its report

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -12,7 +12,13 @@
   } from '$lib/assistant/api';
   import { track } from '$lib/analytics';
   import { forDisplay, shouldRequest } from '$lib/assistant/followups';
-  import { openRehearsal, sendTurn, startAutopilot, type Turn } from '$lib/assistant/client';
+  import {
+    openRehearsal,
+    sendTurn,
+    startAutopilot,
+    StreamInterrupted,
+    type Turn,
+  } from '$lib/assistant/client';
   import { initChat, reduceTurnEvent, type ChatState } from '$lib/assistant/chat';
   import { splitPresentingCalls } from '$lib/assistant/deck';
   import { atBottom } from '$lib/assistant/scrolling';
@@ -596,9 +602,32 @@
     try {
       await started.done;
     } catch (err) {
+      if (err instanceof StreamInterrupted) {
+        // The stream broke, not the turn: it runs on the server under its own bounds and
+        // stores everything it does. Marking the message as failed would tell the user
+        // their CV edits were lost when they were not — so we re-read the session and show
+        // whatever the agent has managed so far.
+        await reloadTranscript(id);
+        endTurn();
+        return;
+      }
       error = err instanceof Error ? err.message : 'Could not send the message.';
       chat = reduceTurnEvent(chat, { type: 'result', stop_reason: 'error', is_error: true });
       endTurn();
+    }
+  }
+
+  /** Re-read a session's stored transcript into the view. The server holds the truth about a
+   *  turn whose stream we lost, so this is how a returning client catches up. */
+  async function reloadTranscript(id: string) {
+    if (id !== activeId) return;
+    try {
+      const { messages } = await getSession(id);
+      let next = initChat();
+      for (const event of eventsFromTranscript(messages)) next = reduceTurnEvent(next, event);
+      if (id === activeId) chat = next;
+    } catch {
+      /* the transcript stays as it is; the next visit will catch up */
     }
   }
 
@@ -606,9 +635,22 @@
     queue = queue.filter((q) => q.id !== id);
   }
 
+  /** Catch up when the tab comes back. A phone freezes a backgrounded tab, which breaks the
+   *  stream while the turn keeps running on the server — so what is on screen when the user
+   *  returns is whatever arrived before the freeze, and the session holds the rest. Nothing
+   *  is re-read while a turn is streaming: that stream is already the newer truth. */
+  function catchUpOnReturn() {
+    if (document.visibilityState !== 'visible' || turnActive || !activeId) return;
+    void reloadTranscript(activeId);
+  }
+
   onMount(() => {
     void boot();
-    return cancelTurn;
+    document.addEventListener('visibilitychange', catchUpOnReturn);
+    return () => {
+      document.removeEventListener('visibilitychange', catchUpOnReturn);
+      cancelTurn();
+    };
   });
 </script>
 
@@ -837,7 +879,16 @@
             </div>
           {/if}
 
-          {#if turnActive}
+          <!-- Waiting behind another turn of this session. Distinct from working: nothing is
+               being spent yet, and the elapsed counter would be measuring someone else's turn. -->
+          {#if chat.queued}
+            <div class="self-start inline-flex items-baseline gap-2 px-2 py-1 text-xs text-muted-foreground">
+              <span class="star-glow font-mono text-[0.85rem] font-semibold">
+                {SPINNER_GLYPHS[spinnerIdx]}
+              </span>
+              <span class="shimmer font-medium">Waiting for the current turn to finish…</span>
+            </div>
+          {:else if turnActive}
             <div class="self-start inline-flex items-baseline gap-2 px-2 py-1 text-xs text-muted-foreground">
               <span class="star-glow font-mono text-[0.85rem] font-semibold">
                 {SPINNER_GLYPHS[spinnerIdx]}

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -895,22 +895,19 @@
             </div>
           {/if}
 
-          <!-- Waiting behind another turn of this session. Distinct from working: nothing is
-               being spent yet, and the elapsed counter would be measuring someone else's turn. -->
-          {#if chat.queued}
+          <!-- One indicator, two states. Queued is not working: nothing is being spent yet, and
+               the elapsed counter would be timing somebody else's turn. -->
+          {#if chat.queued || turnActive}
             <div class="self-start inline-flex items-baseline gap-2 px-2 py-1 text-xs text-muted-foreground">
               <span class="star-glow font-mono text-[0.85rem] font-semibold">
                 {SPINNER_GLYPHS[spinnerIdx]}
               </span>
-              <span class="shimmer font-medium">Waiting for the current turn to finish…</span>
-            </div>
-          {:else if turnActive}
-            <div class="self-start inline-flex items-baseline gap-2 px-2 py-1 text-xs text-muted-foreground">
-              <span class="star-glow font-mono text-[0.85rem] font-semibold">
-                {SPINNER_GLYPHS[spinnerIdx]}
+              <span class="shimmer font-medium">
+                {chat.queued ? 'Waiting for the current turn to finish' : currentVerb}…
               </span>
-              <span class="shimmer font-medium">{currentVerb}…</span>
-              <span class="font-mono text-[0.7rem] text-muted-foreground/70">({elapsedSec}s)</span>
+              {#if !chat.queued}
+                <span class="font-mono text-[0.7rem] text-muted-foreground/70">({elapsedSec}s)</span>
+              {/if}
             </div>
           {/if}
         </div>

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -120,8 +120,8 @@
   let chat = $state<ChatState>(initChat());
   let draft = $state('');
   let turnActive = $state(false);
-  // The turn in flight, so it can be cancelled. Aborting the request is what
-  // tells the backend to stop the loop.
+  // The turn in flight, so it can be cancelled. Cancelling asks the server to stop the work;
+  // aborting the fetch only stops this client reading it.
   let turn: Turn | null = null;
 
   let sidebarOpen = $state(true);
@@ -502,8 +502,9 @@
     }
   }
 
-  /** Stop an in-flight turn. The backend notices its next write fail and stops the
-   *  loop before spending another model call. */
+  /** Stop an in-flight turn: ask the server to stop the work, and stop reading it here. The
+   *  backend no longer infers the first from the second — it could not tell a deliberate stop
+   *  apart from a phone locking its screen. */
   function cancelTurn() {
     turn?.cancel();
     turn = null;
@@ -587,20 +588,35 @@
         /* the host reports its own save failures; a turn is still worth starting */
       }
     }
+    // Whether the turn ever began. A message can queue behind the session's running turn and
+    // then never start — the wait runs out, or it is stopped — and the composer cleared the
+    // draft the moment it was sent. Without this the user's words would simply vanish.
+    let began = false;
+    const watch = (event: TurnEvent) => {
+      if (event.type === 'user_prompt') began = true;
+      onEvent(id, event);
+    };
+
     let started: Turn;
     if (start.kind === 'autopilot') {
       runActive = true;
       onRunStateChange?.(true);
-      started = startAutopilot(id, (event) => onEvent(id, event));
+      started = startAutopilot(id, watch);
     } else if (start.kind === 'opening') {
-      started = openRehearsal(id, (event) => onEvent(id, event));
+      started = openRehearsal(id, watch);
     } else {
-      started = sendTurn(id, start.text, (event) => onEvent(id, event));
+      started = sendTurn(id, start.text, watch);
     }
     turn = started;
     void scrollToBottom(true);
     try {
       await started.done;
+      if (!began && start.kind === 'message' && id === activeId) {
+        // The turn never ran, so the message was never recorded. Give it back rather than
+        // losing it, and say why — the composer is empty and nothing else would explain it.
+        draft = draft.trim() === '' ? start.text : draft;
+        error = 'That message was not sent: the chat was still busy. Try again.';
+      }
     } catch (err) {
       if (err instanceof StreamInterrupted) {
         // The stream broke, not the turn: it runs on the server under its own bounds and

--- a/web/src/lib/assistant/chat.test.ts
+++ b/web/src/lib/assistant/chat.test.ts
@@ -152,4 +152,16 @@ describe('reduceTurnEvent', () => {
     expect(prev.messages).toHaveLength(0);
     expect(next).not.toBe(prev);
   });
+
+  // A message that arrived while the session was busy waits its turn. Until it starts, the
+  // stream is silent — and a silent stream is indistinguishable from a broken one, so the
+  // wait has to be visible.
+  it('marks the chat as waiting when its turn is queued behind another', () => {
+    let s = reduceTurnEvent(initChat(), { type: 'queued' });
+    expect(s.queued).toBe(true);
+
+    // Its own turn starting is what ends the wait.
+    s = reduceTurnEvent(s, { type: 'user_prompt', text: 'and another thing' });
+    expect(s.queued).toBe(false);
+  });
 });

--- a/web/src/lib/assistant/chat.test.ts
+++ b/web/src/lib/assistant/chat.test.ts
@@ -164,4 +164,13 @@ describe('reduceTurnEvent', () => {
     s = reduceTurnEvent(s, { type: 'user_prompt', text: 'and another thing' });
     expect(s.queued).toBe(false);
   });
+
+  // A wait can end without the turn ever starting: it timed out, or the user stopped it. The
+  // terminal event has to clear the wait, or the view keeps claiming it is queued behind a turn
+  // that ended — and that stale banner then masks the next turn's real progress.
+  it('stops waiting when the turn ends without ever starting', () => {
+    let s = reduceTurnEvent(initChat(), { type: 'queued' });
+    s = reduceTurnEvent(s, { type: 'result', stop_reason: 'cancelled' });
+    expect(s.queued).toBe(false);
+  });
 });

--- a/web/src/lib/assistant/chat.ts
+++ b/web/src/lib/assistant/chat.ts
@@ -22,18 +22,24 @@ export interface ChatMessage {
 
 export interface ChatState {
   messages: ChatMessage[];
+  /** The turn is waiting for another one to finish in this session. Its own frames have not
+   *  started, so without this the view would show a silent stream and nothing else. */
+  queued: boolean;
 }
 
 export function initChat(): ChatState {
-  return { messages: [] };
+  return { messages: [], queued: false };
 }
 
 /** Fold one `TurnEvent` into the chat state, returning a new state (never
  *  mutates the input). Unmodeled/unknown event kinds are ignored (no throw). */
 export function reduceTurnEvent(prev: ChatState, event: TurnEvent): ChatState {
   switch (event.type) {
+    case 'queued':
+      return { ...prev, queued: true };
     case 'user_prompt':
-      return { messages: [...prev.messages, userMessage(event.text)] };
+      // The turn is under way: whatever wait preceded it is over.
+      return { ...prev, messages: [...prev.messages, userMessage(event.text)], queued: false };
     case 'assistant_text':
       return upsertAssistant(prev, (m) => ({ ...m, text: m.text + event.text }));
     case 'assistant_thought':
@@ -92,9 +98,9 @@ function newAssistant(): ChatMessage {
 function upsertAssistant(prev: ChatState, fn: (m: ChatMessage) => ChatMessage): ChatState {
   const last = prev.messages[prev.messages.length - 1];
   if (last && last.role === 'assistant' && last.streaming) {
-    return { messages: [...prev.messages.slice(0, -1), fn(last)] };
+    return { ...prev, messages: [...prev.messages.slice(0, -1), fn(last)] };
   }
-  return { messages: [...prev.messages, fn(newAssistant())] };
+  return { ...prev, messages: [...prev.messages, fn(newAssistant())] };
 }
 
 /** Close the open assistant turn. A result with no open turn is ignored (never
@@ -103,5 +109,5 @@ function closeAssistant(prev: ChatState, errored: boolean): ChatState {
   const last = prev.messages[prev.messages.length - 1];
   if (!last || last.role !== 'assistant' || !last.streaming) return prev;
   const closed: ChatMessage = { ...last, streaming: false, errored };
-  return { messages: [...prev.messages.slice(0, -1), closed] };
+  return { ...prev, messages: [...prev.messages.slice(0, -1), closed] };
 }

--- a/web/src/lib/assistant/chat.ts
+++ b/web/src/lib/assistant/chat.ts
@@ -52,7 +52,10 @@ export function reduceTurnEvent(prev: ChatState, event: TurnEvent): ChatState {
     case 'tool_result':
       return upsertAssistant(prev, (m) => ({ ...m, tools: attachResult(m.tools, event) }));
     case 'result':
-      return closeAssistant(prev, event.is_error ?? false);
+      // Clears the wait as well as closing the turn: a wait can end WITHOUT the turn ever
+      // starting (it timed out, or was stopped), and a banner still claiming to be queued
+      // would then mask the next turn's real progress.
+      return { ...closeAssistant(prev, event.is_error ?? false), queued: false };
     default:
       // usage, and anything not in the union — ignored.
       return prev;

--- a/web/src/lib/assistant/client.test.ts
+++ b/web/src/lib/assistant/client.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import { sendTurn, StreamInterrupted } from './client';
+
+/** A response whose body streams the given chunks and then does whatever `end` says. */
+function streamingResponse(chunks: string[], end: 'close' | 'fail' = 'close'): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(new TextEncoder().encode(chunk));
+      if (end === 'fail') controller.error(new Error('network went away'));
+      else controller.close();
+    },
+  });
+  return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+}
+
+function frame(event: Record<string, unknown>): string {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('sendTurn', () => {
+  it('reports an interrupted stream as an interruption, not a failure', async () => {
+    // The turn keeps running on the server and its transcript is stored, so a broken stream
+    // says nothing about whether the work succeeded — presenting it as a failed turn would
+    // misreport the state of the user's own CV.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(streamingResponse([frame({ type: 'assistant_text', text: 'hi' })], 'fail')),
+    );
+
+    const turn = sendTurn('session-1', 'hello', () => {});
+
+    await expect(turn.done).rejects.toBeInstanceOf(StreamInterrupted);
+  });
+
+  it('asks the server to stop the turn, rather than just stopping its own reading', async () => {
+    // Aborting the read used to be the only way to stop a turn: the server noticed its next
+    // write fail. It no longer does, so stopping has to be said out loud.
+    const fetchMock = vi.fn().mockResolvedValue(streamingResponse([frame({ type: 'result' })]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const turn = sendTurn('session-1', 'hello', () => {});
+    turn.cancel();
+
+    const cancelled = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith('/assistant/sessions/session-1/cancel'),
+    );
+    expect(cancelled, 'no request was made to the cancel route').toBeTruthy();
+    expect(cancelled?.[1]).toMatchObject({ method: 'POST' });
+  });
+
+  it('still reports a refused turn as a failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 409 })));
+
+    const turn = sendTurn('session-1', 'hello', () => {});
+
+    await expect(turn.done).rejects.not.toBeInstanceOf(StreamInterrupted);
+  });
+});

--- a/web/src/lib/assistant/client.ts
+++ b/web/src/lib/assistant/client.ts
@@ -40,10 +40,16 @@ export class StreamInterrupted extends Error {
 /** Ask the server to stop a session's running turn. Safe to call when nothing is
  *  running: the caller cannot know whether the turn it stopped watching has ended. */
 export async function cancelTurn(sessionId: string): Promise<void> {
-  await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/cancel`, {
-    method: 'POST',
-    credentials: 'include',
-  });
+  try {
+    await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/cancel`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  } catch {
+    // Best-effort by nature: offline, or the route answered badly. There is nothing the user
+    // can do about it and nothing to show them — the turn ends at its step cap either way, and
+    // an unhandled rejection here would be reported as a fault they did not cause.
+  }
 }
 
 /**
@@ -140,7 +146,8 @@ function streamTurn(
     done,
     cancel: () => {
       // Both halves: tell the server to stop the work, and stop reading it here. The
-      // server no longer infers the first from the second.
+      // server no longer infers the first from the second. cancelTurn swallows its own
+      // failures, so this cannot reject.
       void cancelTurn(sessionId);
       controller.abort();
     },

--- a/web/src/lib/assistant/client.ts
+++ b/web/src/lib/assistant/client.ts
@@ -2,8 +2,13 @@
 //
 // A turn is a single POST whose response body streams the turn as SSE. That is
 // the whole client: no connection held open between turns, no attach, no input
-// lease. Cancelling is aborting the fetch — the backend notices its next write
-// fail and stops the loop before spending another model call.
+// lease.
+//
+// Reading and stopping are now two different things. Aborting the fetch stops THIS
+// client reading; it does not stop the turn, which runs on the server under its own
+// bounds and stores its transcript whether anyone is listening or not. Stopping the
+// turn is a request of its own — which is what lets a phone background its tab
+// without throwing the work away.
 
 import { readFrames } from './sse';
 import type { TurnEvent } from './wire';
@@ -17,6 +22,31 @@ export interface Turn {
 }
 
 /**
+ * The stream ended before the turn did — a dropped connection, a frozen tab, a slept
+ * laptop.
+ *
+ * It is deliberately its own type because it is NOT a failed turn: the turn is still
+ * running on the server and its transcript is stored, so the caller should re-read the
+ * session rather than tell the user their work failed. Saying "error" here would
+ * misreport the state of the user's own CV.
+ */
+export class StreamInterrupted extends Error {
+  constructor(cause: unknown) {
+    super('the stream was interrupted', { cause });
+    this.name = 'StreamInterrupted';
+  }
+}
+
+/** Ask the server to stop a session's running turn. Safe to call when nothing is
+ *  running: the caller cannot know whether the turn it stopped watching has ended. */
+export async function cancelTurn(sessionId: string): Promise<void> {
+  await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/cancel`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+}
+
+/**
  * Send a message and stream the turn. `onEvent` receives every frame in order,
  * ending with exactly one `result`. The returned promise resolves when the stream
  * ends — including when it was cancelled, which is a normal outcome rather than
@@ -24,6 +54,7 @@ export interface Turn {
  */
 export function sendTurn(sessionId: string, text: string, onEvent: (e: TurnEvent) => void): Turn {
   return streamTurn(
+    sessionId,
     `${BASE}/sessions/${encodeURIComponent(sessionId)}/messages`,
     { text },
     'could not send the message',
@@ -38,6 +69,7 @@ export function sendTurn(sessionId: string, text: string, onEvent: (e: TurnEvent
  */
 export function startAutopilot(sessionId: string, onEvent: (e: TurnEvent) => void): Turn {
   return streamTurn(
+    sessionId,
     `${BASE}/sessions/${encodeURIComponent(sessionId)}/autopilot`,
     {},
     'could not start the run',
@@ -55,6 +87,7 @@ export function startAutopilot(sessionId: string, onEvent: (e: TurnEvent) => voi
  */
 export function openRehearsal(sessionId: string, onEvent: (e: TurnEvent) => void): Turn {
   return streamTurn(
+    sessionId,
     `${BASE}/sessions/${encodeURIComponent(sessionId)}/opening`,
     {},
     'could not open the rehearsal',
@@ -65,6 +98,7 @@ export function openRehearsal(sessionId: string, onEvent: (e: TurnEvent) => void
 /** POST a turn and stream its frames. Shared by every way of starting one, so cancellation
  *  and frame decoding have a single implementation. */
 function streamTurn(
+  sessionId: string,
   url: string,
   body: unknown,
   failure: string,
@@ -97,11 +131,20 @@ function streamTurn(
         onEvent({ type: 'result', stop_reason: 'cancelled' });
         return;
       }
-      throw e;
+      // Anything else broke the stream, not the turn. The caller re-reads the session.
+      throw new StreamInterrupted(e);
     }
   })();
 
-  return { done, cancel: () => controller.abort() };
+  return {
+    done,
+    cancel: () => {
+      // Both halves: tell the server to stop the work, and stop reading it here. The
+      // server no longer infers the first from the second.
+      void cancelTurn(sessionId);
+      controller.abort();
+    },
+  };
 }
 
 /** Decode one frame's payload. A frame we cannot parse is dropped rather than

--- a/web/src/lib/assistant/wire.ts
+++ b/web/src/lib/assistant/wire.ts
@@ -11,6 +11,9 @@ export type StopReason = 'end_turn' | 'max_steps' | 'cancelled' | 'error' | (str
 
 /** One streamed frame of a turn. */
 export type TurnEvent =
+  // The turn has not started: it is waiting for the one in flight in this session. Sent
+  // ahead of the turn's own frames so a wait does not read as a stalled connection.
+  | { type: 'queued' }
   | { type: 'user_prompt'; text: string }
   | { type: 'assistant_text'; text: string }
   | { type: 'assistant_thought'; text: string }


### PR DESCRIPTION
## What and why

A turn of the in-app assistant died whenever a write to its SSE client failed. On a phone a backgrounded tab is frozen, not closed, so the failed write it produces was read as "the user left" — and the work was thrown away. The reported case: an unattended tailoring run made 25 CV edits and then lost its `tailor_report` to `context canceled`. Prod journal for 2026-08-01 holds six turns that died this way, plus the `list atoms: context canceled` and `verify employment: context canceled` results the same cancellation left in transcripts.

The deeper fault was one signal carrying three meanings. A broken TCP write was the only way the server learned that the user pressed Stop, that the user left, and that the network blinked — the client's Stop button is `controller.abort()` — so the code could not tell a deliberate stop from a phone locking its screen and treated all of them as "abandon the work".

**A failed write no longer stops a turn.** It runs to its own end under the bounds it already had, both server-owned: the step cap (8, or 30 for an unattended run) and the LLM call timeout. The transcript is persisted whether or not anyone is reading, so a returning client reads what happened without it.

**Stopping gets its own channel** — `POST /assistant/sessions/:id/cancel`, owner-scoped. **BREAKING** for any client that stopped a turn by dropping its connection: dropping it now leaves the turn running.

**A session runs one turn at a time.** A message sent mid-turn queues behind it (told so with a `queued` event) instead of racing it; a further one is refused with 409. Two turns of one tailoring session would otherwise edit one CV from two conversations that cannot see each other.

**The client stops lying about interrupted streams.** An interrupted read is no longer rendered as a failed turn — it re-reads the session, as it also does when a backgrounded tab returns.

Also in this pass, two tool-contract refusals that cost a run its budget and taught the model nothing: `ops` arriving as a JSON string is unwrapped (15 refusals in 30 days), and a batch removing two positions of one list no longer refuses itself. The strictness that matters is untouched — an unknown field inside an operation is still refused, and a test pins it: it rests on the 2026-07-19 incident where a silently-dropped field let an agent clobber the wrong experience entry.

Spec: `openspec/changes/assistant-turn-survives-disconnect/`.

Reviewed before opening: the first version of the removal-ordering fix lived inside `cvedit.Apply` and corrupted the everyday save path (`Diff` states its indices sequentially, and so do the inverses undo replays) — deleting two non-adjacent bullets deleted the wrong one. It now lives at the tool boundary, where the only author that names positions against the original document is the model.

Known limit, recorded in the proposal: the turn registry is per-process, so a turn started before a blue/green flip cannot be cancelled and ends at its step cap.

Closes #

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [x] I regenerated committed artifacts when their source changed (`make sqlc` for SQL/migrations, `make gen-contracts` for contract types).
- [ ] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass.
- [x] For `web/` changes: `pnpm run check` and `pnpm run build` pass.
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.

Not done, deliberately: a component test for the tab-return path (the web suite has no DOM runner — the behaviour is covered by a client test and by the socket-level integration test), and the manual end-to-end run.
