### PR TITLE
feat(tailor): move the template gallery to the left panel

### DIFF
--- a/openspec/changes/templates-move-to-left-panel/.openspec.yaml
+++ b/openspec/changes/templates-move-to-left-panel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/templates-move-to-left-panel/proposal.md
+++ b/openspec/changes/templates-move-to-left-panel/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Choosing a template is a decision about how the CV LOOKS, and everything else that decides that
+— the font, its size, the page margins — is a tab of the left panel. The template gallery sits
+in the right panel instead, among the tabs that MEASURE the document: the job match, the ATS
+score, the vacancy it is being tailored to. So changing a font and changing a template, one
+question in the user's head, are two panels apart.
+
+The right panel already states its own rule: its tabs are divided by what each one measures,
+and none may mix baselines. The template gallery measures nothing. It is the one tab there that
+does not answer "how does this document compare", and moving it to where the rest of the
+document's appearance lives leaves both panels saying one thing each.
+
+## What Changes
+
+- The template gallery becomes a tab of the LEFT panel, beside the editor, the appearance
+  settings and the chat. Picking a template keeps working exactly as it does now — the preview
+  re-renders and the choice is saved against the CV.
+- The right panel loses its Templates tab and keeps the three that measure the document: the job
+  description, the job match and the score. Its stated rule — tabs divided by what they measure
+  — now holds without an exception.
+- On a narrow viewport the same move applies to the mobile tab strip, so the surface has one
+  arrangement rather than one per width.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `tailor-workspace`: the three-column layout names which tabs each side panel holds, so moving
+  a tab between them changes the requirement rather than only the markup.
+
+## Impact
+
+- `web/src/routes/tailor/[slug]/+page.svelte` — the left panel's tab set and its mobile strip.
+- `web/src/lib/tailor/ArtifactPanel.svelte` — the right panel drops a tab from its `Tab` union
+  and its list.
+- The template picker component itself is unchanged: it is moved, not rewritten.
+- No API change, no stored state change. A CV's template is already a field of the CV.

--- a/openspec/changes/templates-move-to-left-panel/specs/tailor-workspace/spec.md
+++ b/openspec/changes/templates-move-to-left-panel/specs/tailor-workspace/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: The workspace is a three-column surface
+
+The workspace SHALL lay out its ready state in three columns: a left panel tabbed between the CV
+editor, the templates, the appearance settings and the chat, a centre column showing the live CV
+preview, and a right panel tabbed between the job description, the job match, and the score. The
+left and right panels SHALL be width-adjustable via draggable splitters clamped to a sensible
+range, with the centre column taking the remaining width.
+
+The left panel SHALL hold what CHANGES the document — its text, its template, its typography —
+and the right panel SHALL hold what MEASURES it. The template gallery belongs to the first: it
+decides how the CV looks, exactly as the font and the margins do, and nothing about it compares
+the document to anything.
+
+The right panel's tabs SHALL be divided by what each one measures, and no tab SHALL mix
+measurements taken against different baselines:
+
+- **Job Match** — the live job-anchored score of the tailored document against this vacancy, with
+  the cached fit analysis beneath it labelled as a snapshot of the base profile;
+- **Score** — the ATS-readability delta of the tailored document against the base CV, and the log
+  of the last autopilot run;
+- **Job description** — unchanged.
+
+#### Scenario: The three columns render
+
+- **WHEN** the workspace ready state renders on a wide viewport
+- **THEN** the left tabbed panel (Editor/Templates/Settings/Chat), the centre CV preview, and the right tabbed panel (Job description/Job Match/Score) are all visible side by side
+
+#### Scenario: A side panel resizes and clamps
+
+- **WHEN** the user drags a side-panel splitter beyond the allowed range
+- **THEN** the panel width is clamped to the minimum/maximum rather than collapsing or overflowing, and the centre column absorbs the change
+
+#### Scenario: Choosing a template from the left panel
+
+- **WHEN** the user opens the Templates tab and picks a template
+- **THEN** the centre preview re-renders in that template and the choice is stored against the CV

--- a/openspec/changes/templates-move-to-left-panel/tasks.md
+++ b/openspec/changes/templates-move-to-left-panel/tasks.md
@@ -1,0 +1,18 @@
+## 1. Move the tab
+
+- [x] 1.1 Add `templates` to the left panel's tab set in `web/src/routes/tailor/[slug]/+page.svelte`, ordered before Settings — a template is picked first, then tuned
+- [x] 1.2 Render the template gallery in the left panel, reusing the existing picker unchanged and keeping `onTemplateSelected` wired to the preview
+- [x] 1.3 Remove `templates` from `ArtifactPanel.svelte`'s `Tab` union, its tab list and its body
+- [x] 1.4 Move the entry in the mobile tab strip so the narrow layout matches the wide one
+
+## 2. Keep the surface coherent
+
+- [x] 2.1 Check the right panel's default tab and its `mobileVisible` condition still make sense with one fewer tab
+- [x] 2.2 Check nothing else routes to the templates tab by name (deep links, host props, analytics events)
+
+## 3. Verification
+
+- [x] 3.1 `pnpm test`, `pnpm lint`, `pnpm check` in `web/`
+- [x] 3.2 `pnpm run build` — the PR template asks for it on any `web/` change
+- [x] 3.3 Design-system gates: `check:tokens` and `check:adoption` (the token count is held per file, so moved markup must not raise it)
+- [ ] 3.4 Look at the page: template picks from the left panel, preview re-renders, both panels still resize

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -7,7 +7,10 @@
   //    base profile that it is.
   //  - Score — what tailoring did to the CV's ATS readability against the base CV, and the
   //    last autopilot run's log.
-  //  - Job and Templates — the vacancy's own text, and the template gallery.
+  //  - Job — the vacancy's own text.
+  //
+  // Every tab here MEASURES the document or is the thing it is measured against; what CHANGES
+  // the document — its text, its template, its typography — lives in the left panel.
   //
   // JD and the fit analysis reuse the SAME components the job page / fit page use, so they
   // read identically. Splitter width is clamped by the vitest-covered clampWidth.
@@ -17,7 +20,6 @@
   import JobDescription from '$lib/components/JobDescription.svelte';
   import MatchAnalysisFull from '$lib/components/MatchAnalysisFull.svelte';
   import CompanyLogo from '$lib/components/CompanyLogo.svelte';
-  import TemplateGallery from './TemplateGallery.svelte';
   import RevisionHistory from './RevisionHistory.svelte';
   import AutopilotReport from './AutopilotReport.svelte';
   import AtsDelta from './AtsDelta.svelte';
@@ -26,13 +28,11 @@
   import type { Job, MatchAnalysisResponse } from '$lib/types';
   import type { CvAtsDelta, CvJobMatch } from '$lib/cv';
 
-  type Tab = 'templates' | 'jd' | 'jobmatch' | 'score' | 'history';
+  type Tab = 'jd' | 'jobmatch' | 'score' | 'history';
 
   let {
-    cvId,
     job,
     analysis,
-    onTemplateSelected,
     // Which tab is active — bindable so the page's mobile tab bar can drive it (on desktop the
     // panel's own tab bar sets it). mobileVisible is the page's per-breakpoint show/hide on mobile;
     // at lg the aside is always shown regardless (lg:flex overrides the mobile hidden).
@@ -48,10 +48,8 @@
     onUndoRevision,
     onUndoRevisionRun,
   }: {
-    cvId: string;
     job: Job;
     analysis: Analysis | null;
-    onTemplateSelected: (id: string) => void;
     tab?: Tab;
     mobileVisible?: boolean;
     /** The last unattended run's log, shown in the Score tab. The fit analysis is untouched
@@ -80,7 +78,6 @@
     ['score', 'Score'],
     ['history', 'History'],
     ['jd', 'Job'],
-    ['templates', 'Templates'],
   ];
   // 400 rather than the 340 floor: at the floor the tab strip wraps "Job Match" onto two lines
   // and the vacancy title truncates after a couple of words, so the panel opened looking cramped.
@@ -195,11 +192,7 @@
   </div>
 
   <div class="min-h-0 flex-1 overflow-auto">
-    {#if tab === 'templates'}
-      <div class="p-4">
-        <TemplateGallery {cvId} onSelected={onTemplateSelected} />
-      </div>
-    {:else if tab === 'history'}
+    {#if tab === 'history'}
       <RevisionHistory {revisions} onPreview={onPreviewRevision} onUndo={onUndoRevision} onUndoRun={onUndoRevisionRun} />
     {:else if tab === 'jd'}
       <div class="p-4">

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -23,6 +23,7 @@
   import MarginSettings from '$lib/components/cv/MarginSettings.svelte';
   import TracerLinksSettings from '$lib/components/cv/TracerLinksSettings.svelte';
   import StyleSettings from '$lib/components/cv/StyleSettings.svelte';
+  import TemplateGallery from '$lib/tailor/TemplateGallery.svelte';
   import AccountNavRail from '$lib/components/AccountNavRail.svelte';
   import { clampWidth } from '$lib/tailor/geometry';
   import { undoRun, openingActions } from '$lib/tailor/autopilot';
@@ -88,7 +89,17 @@
 
   // Left panel: which tab is shown, and its resizable width. The chat stays mounted across tab
   // switches (hidden, not unmounted) so its live session is never dropped.
-  let leftTab = $state<'chat' | 'editor' | 'settings'>('chat');
+  // The left panel holds what CHANGES the document — its text, its template, its typography —
+  // and the chat that does all three by asking. Measuring the document is the right panel's job.
+  type LeftTab = 'chat' | 'editor' | 'templates' | 'settings';
+  let leftTab = $state<LeftTab>('chat');
+  // Templates before Settings: a template is chosen first and then tuned.
+  const leftTabs: [LeftTab, string][] = [
+    ['editor', 'Editor'],
+    ['templates', 'Templates'],
+    ['settings', 'Settings'],
+    ['chat', 'Chat'],
+  ];
   let leftWidth = $state(350);
   // Folded to a rail so the centre CV preview can take the width. Desktop-only: below lg the
   // columns already show one at a time, and collapsing there would hide a view with no way back.
@@ -98,7 +109,7 @@
 
   // The right context panel's tab, lifted here so the mobile tab bar can drive it (on desktop the
   // panel's own tab bar sets it via the same binding).
-  let artifactTab = $state<'templates' | 'jd' | 'jobmatch' | 'score'>('jobmatch');
+  let artifactTab = $state<'jd' | 'jobmatch' | 'score'>('jobmatch');
 
   // Mobile-only navigation: below lg the three columns collapse to one, so a single flat tab bar
   // picks which view fills the screen. At lg it's hidden and every column shows at once as before.
@@ -110,12 +121,12 @@
   const mobileTabs: [MobileView, string][] = [
     ['chat', 'Chat'],
     ['editor', 'Editor'],
+    ['templates', 'Templates'],
     ['settings', 'Settings'],
     ['preview', 'Preview'],
     ['jobmatch', 'Job Match'],
     ['score', 'Score'],
     ['jd', 'Job'],
-    ['templates', 'Templates'],
   ];
   let mobileView = $state<MobileView>('chat');
 
@@ -124,7 +135,7 @@
   let navOpen = $state(false);
   function pickMobile(v: MobileView) {
     mobileView = v;
-    if (v === 'chat' || v === 'editor' || v === 'settings') leftTab = v;
+    if (v === 'chat' || v === 'editor' || v === 'templates' || v === 'settings') leftTab = v;
     else if (v !== 'preview') artifactTab = v;
   }
 
@@ -477,7 +488,9 @@
         bind:this={leftPanelEl}
         class={[
           'w-full min-h-0 flex-1 flex-col border-r border-border bg-background lg:w-[var(--lw)] lg:flex-none',
-          mobileView === 'chat' || mobileView === 'editor' || mobileView === 'settings' ? 'flex' : 'hidden',
+          mobileView === 'chat' || mobileView === 'editor' || mobileView === 'templates' || mobileView === 'settings'
+            ? 'flex'
+            : 'hidden',
           leftCollapsed ? 'lg:hidden' : 'lg:flex',
         ]}
         style="--lw: {leftWidth}px"
@@ -485,27 +498,15 @@
         <!-- Own tab bar (and save status) is desktop-only; the mobile bar drives the tab there. -->
         <div class="hidden items-center justify-between gap-2 border-b border-border px-2 py-1.5 text-sm lg:flex">
           <div class="flex items-center gap-1">
-            <button
-              type="button"
-              onclick={() => (leftTab = 'editor')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'editor' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
-            >
-              Editor
-            </button>
-            <button
-              type="button"
-              onclick={() => (leftTab = 'settings')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'settings' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
-            >
-              Settings
-            </button>
-            <button
-              type="button"
-              onclick={() => (leftTab = 'chat')}
-              class={['rounded px-2 py-1 transition-colors', leftTab === 'chat' ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
-            >
-              Chat
-            </button>
+            {#each leftTabs as [id, label] (id)}
+              <button
+                type="button"
+                onclick={() => (leftTab = id)}
+                class={['rounded px-2 py-1 transition-colors', leftTab === id ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
+              >
+                {label}
+              </button>
+            {/each}
           </div>
           <div class="flex items-center gap-1">
             {#if leftTab === 'editor' || leftTab === 'settings'}
@@ -543,6 +544,11 @@
           <!-- Presentation, in two blocks of label→control rows. Both write straight into the
                shared document, so the centre preview re-renders live and autosave persists them
                on the same debounce as any other edit. -->
+          <!-- Templates: what the CV looks like, beside the rest of what decides that. The
+               gallery is the same component the right panel used to host — moved, not rewritten. -->
+          <div class="h-full overflow-auto p-4" class:hidden={leftTab !== 'templates'}>
+            <TemplateGallery {cvId} onSelected={onTemplateSelected} />
+          </div>
           <div class="h-full overflow-auto p-4" class:hidden={leftTab !== 'settings'}>
             <div class="space-y-6">
               <section class="space-y-2">
@@ -628,7 +634,6 @@
       <!-- RIGHT: Templates / Job description / Verdict (renders its own splitter). Shown on mobile
            only when one of its tabs is picked; always shown at lg. -->
       <ArtifactPanel
-        {cvId}
         job={job!}
         {analysis}
         {autopilotReport}
@@ -640,12 +645,8 @@
         onPreviewRevision={(r) => (pinnedRevision = r)}
         onUndoRevision={undoRevision}
         onUndoRevisionRun={undoRevisionRun}
-        {onTemplateSelected}
         bind:tab={artifactTab}
-        mobileVisible={mobileView === 'templates' ||
-          mobileView === 'jd' ||
-          mobileView === 'jobmatch' ||
-          mobileView === 'score'}
+        mobileVisible={mobileView === 'jd' || mobileView === 'jobmatch' || mobileView === 'score'}
       />
     </div>
   {/if}


### PR DESCRIPTION
## What and why

Choosing a template decides how the CV **looks**, and everything else that decides that — the font, its size, the page margins — was already a tab of the left panel. The gallery sat in the right panel instead, among the tabs that **measure** the document: the job match, the ATS score, the vacancy being tailored to. So changing a font and changing a template, one question in the user's head, were two panels apart.

The right panel already stated its own rule — its tabs are divided by what each one measures, and none may mix baselines. The template gallery measured nothing; it was the single exception to the rule the panel is built on. After this the split is clean: **the left panel changes the document, the right panel measures it.**

The picker component is moved, not rewritten. Its tab sits before Settings, because a template is picked first and then tuned. The mobile tab strip moves with it, so the narrow layout is not a second arrangement to reason about.

One small cleanup came with it: the left panel's tab bar is now a loop over its tabs. A fourth hand-written button was the point where copying the markup started costing more than it saved.

Spec: `openspec/changes/templates-move-to-left-panel/` — the three-column layout names which tabs each side panel holds, so this changes a requirement rather than only the markup.

Closes #

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [x] I regenerated committed artifacts when their source changed (`make sqlc` for SQL/migrations, `make gen-contracts` for contract types).
- [ ] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass.
- [x] For `web/` changes: `pnpm run check` and `pnpm run build` pass.
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.

Also run: `pnpm test` (826), `pnpm lint`, and the design-system gates `check:tokens` (web/src held at 450, unchanged) and `check:adoption`.

Not done: I could not look at the running page — there is no local stack up on this machine, and the tailoring workspace needs a signed-in account with a tailored CV to render. Worth a glance before merging: the tab order, and that picking a template still re-renders the centre preview.
