### PR TITLE
feat(mail): fetch the wordings employers use, let the classifier keep the inbox clean

### DIFF
--- a/docs/agents/mail-stack.md
+++ b/docs/agents/mail-stack.md
@@ -42,6 +42,31 @@ the point: it is the tier that costs us nothing. See the `external` bullets belo
 
 ## Always true
 
+- **The fetch is scoped to hiring-SHAPED mail, not to ATS senders, and the inbox filters at
+  DISPLAY.** `gmailsync.BuildQueryFor` admits mail from a curated ATS domain OR carrying one
+  of the recognised application/interview phrasings, minus anything the connected address
+  itself sent. Two things about it are measured rather than assumed.
+  *The phrase list's shape was the defect.* It held one canonical wording per idea, so over
+  120 days it fetched 431 messages from a mailbox where a hiring-shaped query found 1151 —
+  and the 739 misses were NEAR misses: an acknowledgement reading "we've received your …
+  application" where the list knew only "your application at", an invitation reading
+  "interview invite" where it knew only "invite you to interview". When adding, add the
+  SIBLINGS of a wording, not the wording.
+  *The junk filter is the classifier, and it runs at display.* Roughly 40% of any widening is
+  aggregator and course marketing, and the answer is NOT a blocklist of domains: that is a
+  second judge, curated by hand forever against people whose business is registering domains,
+  judging by sender where `mailclassify` already judges by content on a call we already pay
+  for. The listing therefore omits `status_signal = 'other'` by default and reports how many
+  it omitted, under the SAME filters — a hidden count computed separately would describe a
+  different mailbox the moment any filter is on. Two rules keep it honest: unclassified mail
+  is NEVER hidden (nothing has judged it), and asking FOR the label overrides the default
+  (`inbox.Query.showsOther`), or `?status=other` and the hide rule cancel and the filter
+  answers nothing about its own subject.
+  **Why display and not fetch:** the sync carries a watermark, so mail not fetched today is
+  never fetched. A fetch-time filter loses silently and permanently, and fixing the rule
+  brings nothing back. A display filter loses nothing — and it became affordable only once
+  the recall sweep stopped reading our copy (it searches Gmail now), so extra rows degrade a
+  list a person reads and nothing else.
 - **Never match on the sender-address domain.** Inbox mail arrives from ATS relay domains
   (`ashbyhq.com`, `greenhouse-mail.io`, …), not from employer domains. `mailmatch` matches on
   thread continuity and the company name carried in the sender *name* / subject. A

--- a/docs/superpowers/specs/2026-08-02-widen-the-mail-fetch-design.md
+++ b/docs/superpowers/specs/2026-08-02-widen-the-mail-fetch-design.md
@@ -1,0 +1,96 @@
+# Widen the mail fetch, and let the classifier keep the inbox clean
+
+`gmailsync.BuildQuery` fetches too little, and the mail it misses is the mail that matters
+most. Widening it is cheap; the thing that needs designing is what the inbox looks like
+afterwards.
+
+## What the measurements said
+
+Production, 2026-08-02, one connected mailbox.
+
+Over 120 days the sync fetched **431** messages. A loosely hiring-shaped query finds
+**1151**, and the mailbox holds **3297**. So **739** hiring-shaped messages are invisible to
+us. A 42-message sample of them contains:
+
+- an acknowledgement — `We've received your a16z speedrun application!`
+- three interview invitations — `micro1 interview invite`, `AI interview with micro1`,
+  `start micro1 interview`
+- four live recruiter threads from personal and corporate domains — `Re: Senior Backend
+  Engineer` from `@op.tech`, `Re: Вакансия Senior Backend developer` from `@headshotit.com`
+- nine of the candidate's **own replies** in those threads
+- and roughly seventeen marketing messages — Jobright ×5, Jobgether ×4, Careerist ×2, an
+  English course, job-board blasts
+
+**The misses are near misses on wording.** The phrase list knows `invite you to interview`
+but not `interview invite`; it knows `your application at` but not `we've received your …
+application`. The second class is deeper and no phrase list reaches it: a recruiter writing
+from a company domain in their own words.
+
+**Cost is not the constraint, and I was wrong to think it was.** The whole production
+corpus is **544** messages. 739 over 120 days is **~6 a day** — six extra classifications on
+the cheap model. What widening actually costs is the inbox: about 40% of the addition is
+marketing, and the inbox is where a person looks for their applications.
+
+## Decisions
+
+### The classifier already judges this; do not build a second judge
+
+The obvious design is a blocklist of aggregator and course domains. It is the wrong one.
+`mailclassify` already labels every message, and `other` means precisely "not about an
+application at all". A Jobright digest is `other` by the vocabulary's own definition.
+
+| | domain blocklist | the `other` label |
+|---|---|---|
+| New code | a list, and forever maintaining it | none |
+| Who judges | us, in advance, by sender | the classifier, by content |
+| A new marketing sender | lands in the inbox until we notice | hidden immediately |
+| A mistake | invisible until somebody reports it | visible under "show all" |
+
+The list would have to be curated indefinitely against an adversary who registers domains
+for a living. The label is already computed, on a call we are already paying for.
+
+### The filter belongs at DISPLAY, not at fetch
+
+The sync carries a watermark: `BuildQuery(afterUnix)` plus the `SetSynced` cursor. A message
+not fetched today is **never** fetched — the cursor has moved past it. Excluding at fetch
+time is therefore silent and permanent, and a mistake in the rule cannot be repaired by
+fixing the rule.
+
+At display nothing is lost: the message is in the store, and correcting the filter reveals
+it. This is the same reasoning that made the recall net rank rather than drop, and it is
+newly affordable because **the recall sweep no longer reads our copy** — since #1531 it
+searches Gmail directly, so extra rows in `emails` no longer degrade it. The only thing they
+degrade is a list a person reads, and that is exactly what a display filter fixes.
+
+### Hidden must be visible as a number
+
+An inbox that quietly drops `other` is an inbox where a misclassification cannot be found.
+The listing therefore reports how much it hid, and one control shows it. A filter with no
+indicator is the silent-failure class this codebase keeps re-learning.
+
+### The candidate's own mail is not incoming mail
+
+Nine of 42 sampled misses were the candidate's own replies. `gmailsync` already carries the
+connected address to skip own replies while walking a thread; the widened query needs the
+same exclusion at the top level, or every conversation arrives twice — once as the
+employer's message and once as the answer to it.
+
+## Risks / Trade-offs
+
+- **A marketing message classified as something other than `other`** → it shows in the
+  inbox, exactly as today. No regression; the widening only adds candidates.
+- **A real message classified `other`** → hidden, and this is the change's sharpest edge.
+  Mitigated by the count and the control, not by a promise.
+- **~6 extra classifications a day, plus a one-off backfill of ~739** → negligible against a
+  544-message corpus, and the model is the cheap one.
+- **The wider query is a Gmail search string that must stay under its length limits** →
+  the phrase list is already long; the addition is bounded and tested.
+
+## Out of scope
+
+- `mailmatch.ExtractCompany`'s five `to`-only subject templates. Measured separately: 24
+  unattached messages have an unparseable subject and only **9** of those name an employer
+  the caller has applied to. The prize is small and the risk is not — `ExtractCompany` feeds
+  `TierName`, which auto-links, so a loose template creates wrong links rather than merely
+  missing right ones.
+- Any change to linking, stages, or the ledger.

--- a/internal/db/gmail.sql.go
+++ b/internal/db/gmail.sql.go
@@ -12,31 +12,34 @@ import (
 )
 
 const countEmails = `-- name: CountEmails :one
-SELECT count(*)
+SELECT
+    count(*) FILTER (WHERE $2::bool OR coalesce(status_signal, '') <> 'other')::bigint AS total,
+    count(*) FILTER (WHERE NOT $2::bool AND coalesce(status_signal, '') = 'other')::bigint AS hidden
 FROM emails
 WHERE user_id = $1
   AND deleted_at IS NULL
-  AND ($2::text = '' OR source = $2)
-  AND ($3::bool = false OR read_at IS NULL)
-  AND ($4::text = '' OR status_signal = $4)
-  AND ($5::bool = false OR classified_at IS NULL)
-  AND (
-    $6::text = ''
-    OR ($6 = 'linked'    AND application_id IS NOT NULL)
-    OR ($6 = 'suggested' AND application_id IS NULL AND suggested_job_id IS NOT NULL)
-    OR ($6 = 'unlinked'  AND application_id IS NULL AND suggested_job_id IS NULL)
-  )
+  AND ($3::text = '' OR source = $3)
+  AND ($4::bool = false OR read_at IS NULL)
+  AND ($5::text = '' OR status_signal = $5)
+  AND ($6::bool = false OR classified_at IS NULL)
   AND (
     $7::text = ''
-    OR subject   ILIKE '%' || $7 || '%'
-    OR from_name ILIKE '%' || $7 || '%'
-    OR from_addr ILIKE '%' || $7 || '%'
-    OR body_text ILIKE '%' || $7 || '%'
+    OR ($7 = 'linked'    AND application_id IS NOT NULL)
+    OR ($7 = 'suggested' AND application_id IS NULL AND suggested_job_id IS NOT NULL)
+    OR ($7 = 'unlinked'  AND application_id IS NULL AND suggested_job_id IS NULL)
+  )
+  AND (
+    $8::text = ''
+    OR subject   ILIKE '%' || $8 || '%'
+    OR from_name ILIKE '%' || $8 || '%'
+    OR from_addr ILIKE '%' || $8 || '%'
+    OR body_text ILIKE '%' || $8 || '%'
   )
 `
 
 type CountEmailsParams struct {
 	UserID       int64  `json:"user_id"`
+	IncludeOther bool   `json:"include_other"`
 	Src          string `json:"src"`
 	Unread       bool   `json:"unread"`
 	Status       string `json:"status"`
@@ -45,11 +48,22 @@ type CountEmailsParams struct {
 	Q            string `json:"q"`
 }
 
-// Total live messages for the caller (same optional filters as ListEmails), for
-// pagination.
-func (q *Queries) CountEmails(ctx context.Context, arg CountEmailsParams) (int64, error) {
+type CountEmailsRow struct {
+	Total  int64 `json:"total"`
+	Hidden int64 `json:"hidden"`
+}
+
+// Total live messages for the caller under the same optional filters as ListEmails, plus
+// how many of them the `other` default omitted.
+//
+// Both numbers come from one statement and one set of predicates on purpose: a hidden count
+// computed separately would describe a different mailbox from the one on screen the moment
+// any filter is active. The count is not decoration — a filter that hides silently makes a
+// misclassification impossible to find, and the classifier reads attacker-controlled text.
+func (q *Queries) CountEmails(ctx context.Context, arg CountEmailsParams) (CountEmailsRow, error) {
 	row := q.db.QueryRow(ctx, countEmails,
 		arg.UserID,
+		arg.IncludeOther,
 		arg.Src,
 		arg.Unread,
 		arg.Status,
@@ -57,9 +71,9 @@ func (q *Queries) CountEmails(ctx context.Context, arg CountEmailsParams) (int64
 		arg.Link,
 		arg.Q,
 	)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
+	var i CountEmailsRow
+	err := row.Scan(&i.Total, &i.Hidden)
+	return i, err
 }
 
 const countEmailsByState = `-- name: CountEmailsByState :many
@@ -415,8 +429,17 @@ WHERE emails.user_id = $1
     OR emails.from_addr ILIKE '%' || $8 || '%'
     OR emails.body_text ILIKE '%' || $8 || '%'
   )
+  -- The inbox's default: mail the classifier judged not to be about an application at
+  -- all is omitted. The judgement is ` + "`" + `mailclassify` + "`" + `'s, on a call already made, rather
+  -- than a curated list of senders — a list would be a second judge, maintained by hand
+  -- forever against people whose business is registering domains, and it would judge by
+  -- sender where the classifier judges by content.
+  --
+  -- Unclassified mail is NEVER hidden. A message nothing has judged has not been found
+  -- irrelevant; it has not been looked at.
+  AND ($9::bool OR coalesce(emails.status_signal, '') <> 'other')
 ORDER BY emails.received_at DESC, emails.id DESC
-LIMIT $10 OFFSET $9
+LIMIT $11 OFFSET $10
 `
 
 type ListEmailsParams struct {
@@ -428,6 +451,7 @@ type ListEmailsParams struct {
 	Unclassified bool   `json:"unclassified"`
 	Link         string `json:"link"`
 	Q            string `json:"q"`
+	IncludeOther bool   `json:"include_other"`
 	Off          int32  `json:"off"`
 	Lim          int32  `json:"lim"`
 }
@@ -486,6 +510,7 @@ func (q *Queries) ListEmails(ctx context.Context, arg ListEmailsParams) ([]ListE
 		arg.Unclassified,
 		arg.Link,
 		arg.Q,
+		arg.IncludeOther,
 		arg.Off,
 		arg.Lim,
 	)

--- a/internal/db/mail_external_integration_test.go
+++ b/internal/db/mail_external_integration_test.go
@@ -417,7 +417,7 @@ func listIDs(t *testing.T, q *Queries, p ListEmailsParams) ([]int64, int64) {
 	if err != nil {
 		t.Fatalf("count emails: %v", err)
 	}
-	return ids, total
+	return ids, total.Total
 }
 
 // TestUnclassifiedFilterIsTheAgentsWorkQueue asserts the listing can answer "what

--- a/internal/db/mail_hide_other_integration_test.go
+++ b/internal/db/mail_hide_other_integration_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+// Integration tests for the inbox's default: mail the classifier judged not to be about an
+// application at all is omitted, and the listing says how much it omitted.
+//
+// The count is the point. A filter that hides silently makes a misclassification impossible
+// to find, and the classifier reads attacker-controlled text.
+//
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func seedLabelled(t *testing.T, q *Queries, userID int64, extID, signal string, classified bool) int64 {
+	t.Helper()
+	var id int64
+	var sig any
+	if signal != "" {
+		sig = signal
+	}
+	var at any
+	if classified {
+		at = time.Now()
+	}
+	if err := q.db.QueryRow(context.Background(),
+		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at, status_signal, classified_at)
+		 VALUES ($1,'gmail',$2,'Subject','body', now(), $3, $4) RETURNING id`,
+		userID, extID, sig, at).Scan(&id); err != nil {
+		t.Fatalf("seed %s: %v", extID, err)
+	}
+	return id
+}
+
+func listed(t *testing.T, q *Queries, userID int64, includeOther bool) map[int64]bool {
+	t.Helper()
+	rows, err := q.ListEmails(context.Background(), ListEmailsParams{
+		UserID: userID, Lim: 50, IncludeOther: includeOther,
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	out := map[int64]bool{}
+	for _, r := range rows {
+		out[r.ID] = true
+	}
+	return out
+}
+
+// The default hides what the classifier called `other`, keeps everything it judged
+// otherwise, and NEVER hides a message nothing has judged — an unclassified message has not
+// been found irrelevant, it has not been looked at.
+func TestListEmailsHidesOtherByDefault(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	user := seedResponseUser(t, q, "hide-other@example.test", true)
+
+	noise := seedLabelled(t, q, user, "hide-noise", "other", true)
+	real := seedLabelled(t, q, user, "hide-real", "acknowledgement", true)
+	unjudged := seedLabelled(t, q, user, "hide-unjudged", "", false)
+
+	got := listed(t, q, user, false)
+	if got[noise] {
+		t.Error("mail labelled `other` was listed by default")
+	}
+	for id, what := range map[int64]string{real: "classified mail", unjudged: "unclassified mail"} {
+		if !got[id] {
+			t.Errorf("%s was hidden", what)
+		}
+	}
+
+	all := listed(t, q, user, true)
+	for id, what := range map[int64]string{noise: "`other` mail", real: "classified mail", unjudged: "unclassified mail"} {
+		if !all[id] {
+			t.Errorf("%s was missing when the caller asked for everything", what)
+		}
+	}
+}
+
+// The number is what makes a misclassification findable, so it is counted under the SAME
+// filters as the listing — a hidden count that ignored the active filters would describe a
+// different mailbox from the one on screen.
+func TestCountEmailsReportsWhatItHid(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	user := seedResponseUser(t, q, "hide-count@example.test", true)
+
+	seedLabelled(t, q, user, "count-noise-1", "other", true)
+	seedLabelled(t, q, user, "count-noise-2", "other", true)
+	seedLabelled(t, q, user, "count-real", "rejection", true)
+
+	got, err := q.CountEmails(context.Background(), CountEmailsParams{UserID: user})
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if got.Total != 1 {
+		t.Errorf("total %d, want the 1 message the default lists", got.Total)
+	}
+	if got.Hidden != 2 {
+		t.Errorf("hidden %d, want 2 — the number is what makes a misclassification findable", got.Hidden)
+	}
+
+	all, err := q.CountEmails(context.Background(), CountEmailsParams{UserID: user, IncludeOther: true})
+	if err != nil {
+		t.Fatalf("count all: %v", err)
+	}
+	if all.Total != 3 {
+		t.Errorf("total %d when asked for everything, want 3", all.Total)
+	}
+	if all.Hidden != 0 {
+		t.Errorf("hidden %d when nothing is hidden, want 0", all.Hidden)
+	}
+}
+
+// The hidden count answers "under these filters", not "in this mailbox".
+func TestHiddenCountRespectsTheActiveFilters(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	user := seedResponseUser(t, q, "hide-filtered@example.test", true)
+
+	seedLabelled(t, q, user, "filt-noise-gmail", "other", true)
+	hosted := seedLabelled(t, q, user, "filt-noise-hosted", "other", true)
+	if _, err := q.db.Exec(context.Background(),
+		`UPDATE emails SET source = 'hosted' WHERE id = $1`, hosted); err != nil {
+		t.Fatalf("move source: %v", err)
+	}
+
+	got, err := q.CountEmails(context.Background(), CountEmailsParams{UserID: user, Src: "gmail"})
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if got.Hidden != 1 {
+		t.Errorf("hidden %d under a source filter, want 1 — the count must describe the "+
+			"mailbox on screen, not the whole one", got.Hidden)
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -384,9 +384,14 @@ type Querier interface {
 	// so search/filter pagination reports the filtered total. Keep this WHERE identical
 	// to ListCompanies (including the job_count > 0 hiring scope).
 	CountCompanies(ctx context.Context, arg CountCompaniesParams) (int64, error)
-	// Total live messages for the caller (same optional filters as ListEmails), for
-	// pagination.
-	CountEmails(ctx context.Context, arg CountEmailsParams) (int64, error)
+	// Total live messages for the caller under the same optional filters as ListEmails, plus
+	// how many of them the `other` default omitted.
+	//
+	// Both numbers come from one statement and one set of predicates on purpose: a hidden count
+	// computed separately would describe a different mailbox from the one on screen the moment
+	// any filter is active. The count is not decoration — a filter that hides silently makes a
+	// misclassification impossible to find, and the classifier reads attacker-controlled text.
+	CountEmails(ctx context.Context, arg CountEmailsParams) (CountEmailsRow, error)
 	// The mailbox's shape in one pass: one row per classification label (the empty
 	// label being mail nothing has judged yet), carrying that label's total plus how
 	// many of it are unread, unclassified, linked to an application, or carrying a

--- a/internal/db/queries/gmail.sql
+++ b/internal/db/queries/gmail.sql
@@ -150,13 +150,29 @@ WHERE emails.user_id = $1
     OR emails.from_addr ILIKE '%' || sqlc.arg(q) || '%'
     OR emails.body_text ILIKE '%' || sqlc.arg(q) || '%'
   )
+  -- The inbox's default: mail the classifier judged not to be about an application at
+  -- all is omitted. The judgement is `mailclassify`'s, on a call already made, rather
+  -- than a curated list of senders — a list would be a second judge, maintained by hand
+  -- forever against people whose business is registering domains, and it would judge by
+  -- sender where the classifier judges by content.
+  --
+  -- Unclassified mail is NEVER hidden. A message nothing has judged has not been found
+  -- irrelevant; it has not been looked at.
+  AND (sqlc.arg(include_other)::bool OR coalesce(emails.status_signal, '') <> 'other')
 ORDER BY emails.received_at DESC, emails.id DESC
 LIMIT sqlc.arg(lim) OFFSET sqlc.arg(off);
 
 -- name: CountEmails :one
--- Total live messages for the caller (same optional filters as ListEmails), for
--- pagination.
-SELECT count(*)
+-- Total live messages for the caller under the same optional filters as ListEmails, plus
+-- how many of them the `other` default omitted.
+--
+-- Both numbers come from one statement and one set of predicates on purpose: a hidden count
+-- computed separately would describe a different mailbox from the one on screen the moment
+-- any filter is active. The count is not decoration — a filter that hides silently makes a
+-- misclassification impossible to find, and the classifier reads attacker-controlled text.
+SELECT
+    count(*) FILTER (WHERE sqlc.arg(include_other)::bool OR coalesce(status_signal, '') <> 'other')::bigint AS total,
+    count(*) FILTER (WHERE NOT sqlc.arg(include_other)::bool AND coalesce(status_signal, '') = 'other')::bigint AS hidden
 FROM emails
 WHERE user_id = $1
   AND deleted_at IS NULL

--- a/internal/gmailsync/gmailapi.go
+++ b/internal/gmailsync/gmailapi.go
@@ -33,8 +33,8 @@ func NewAPIReader(client *http.Client, learned []string) GmailReader {
 }
 
 // ListATSMessageIDs pages through the ATS-scoped search, returning all matching ids.
-func (r *apiReader) ListATSMessageIDs(ctx context.Context, afterUnix int64) ([]string, error) {
-	q := BuildQuery(afterUnix, r.learned)
+func (r *apiReader) ListATSMessageIDs(ctx context.Context, selfAddr string, afterUnix int64) ([]string, error) {
+	q := BuildQueryFor(selfAddr, afterUnix, r.learned)
 	var ids []string
 	pageToken := ""
 	for {

--- a/internal/gmailsync/reader.go
+++ b/internal/gmailsync/reader.go
@@ -25,9 +25,13 @@ type Message struct {
 // the worker is unit-tested with a fake and the live client is exercised only in
 // the dry run.
 type GmailReader interface {
-	// ListATSMessageIDs returns the ids of ATS messages received after the Unix
-	// watermark (0 = full backfill).
-	ListATSMessageIDs(ctx context.Context, afterUnix int64) ([]string, error)
+	// ListATSMessageIDs returns the ids of hiring-shaped messages received after the Unix
+	// watermark (0 = full backfill), excluding mail the connected address itself sent.
+	//
+	// The address is a parameter rather than reader state because the worker is the one
+	// that knows it, and because a reader built for a search (see MailboxSearcher) has no
+	// business carrying it.
+	ListATSMessageIDs(ctx context.Context, selfAddr string, afterUnix int64) ([]string, error)
 	// ListThreadMessageIDs returns the ids of every message in a thread, so replies
 	// that carry no ATS marker (personal recruiters, scheduling) are ingested
 	// alongside the matched message that anchors the thread.

--- a/internal/gmailsync/senders.go
+++ b/internal/gmailsync/senders.go
@@ -71,6 +71,23 @@ var recallPhrases = []string{
 	"приглашаем вас",             // ru: we invite you
 	"hemos recibido tu",          // es: we have received your
 	"invitación a la entrevista", // es: interview invitation
+
+	// Added 2026-08-02 from a measurement rather than from imagination. Over 120 days on a
+	// live mailbox this list fetched 431 messages where a hiring-shaped query found 1151,
+	// and the misses were near misses: an acknowledgement reading "we've received your …
+	// application" (a16z) where the list knew only "your application at", and invitations
+	// reading "interview invite" (micro1) where it knew only "invite you to interview".
+	//
+	// The lesson generalises past these six. Each entry above was one canonical wording of
+	// a thing employers phrase several ways, so the list's shape — one phrasing per idea —
+	// was the defect. When adding, add the SIBLINGS of a wording, not the wording.
+	"received your application",
+	"interview invite",
+	"interview invitation",
+	"next steps",
+	"schedule a call",
+	"приглашение на собеседование", // ru: interview invitation
+	"собеседование",                // ru: interview
 }
 
 // BuildQuery builds a Gmail search query for job-application mail newer than the
@@ -80,6 +97,20 @@ var recallPhrases = []string{
 // time-bounded by after:. A zero watermark omits the time clause for a first-run
 // backfill.
 func BuildQuery(afterUnix int64, extraDomains []string) string {
+	return BuildQueryFor("", afterUnix, extraDomains)
+}
+
+// BuildQueryFor is BuildQuery with the connected address excluded.
+//
+// The candidate's own replies match these phrasings as readily as an employer's — they are
+// replies to them — and fetching one buys nothing: the worker drops a message whose sender
+// is the connected address before storing it. What it costs is a listed id and a full body
+// retrieval each, and room in the page a widened query returns. An empty address adds no
+// clause, so a caller that has none is unchanged.
+//
+// The exclusion sits OUTSIDE the alternation. Inside it, `-from:` would be one more thing a
+// message could match rather than a condition every message must meet.
+func BuildQueryFor(selfAddr string, afterUnix int64, extraDomains []string) string {
 	senders := make([]string, 0, len(ATSDomains)+len(extraDomains))
 	senders = append(senders, ATSDomains...)
 	senders = append(senders, extraDomains...)
@@ -92,6 +123,9 @@ func BuildQuery(afterUnix int64, extraDomains []string) string {
 	}
 
 	q := "(" + strings.Join(clauses, " OR ") + ")"
+	if selfAddr != "" {
+		q += " -from:" + selfAddr
+	}
 	if afterUnix > 0 {
 		q += fmt.Sprintf(" after:%d", afterUnix)
 	}

--- a/internal/gmailsync/senders_test.go
+++ b/internal/gmailsync/senders_test.go
@@ -175,3 +175,45 @@ func TestBuildRecallQueryWithoutARole(t *testing.T) {
 		t.Errorf("the rest of the gate went missing with the role:\n%s", q)
 	}
 }
+
+// The list knew one canonical wording of each thing and employers use several. These are
+// the wordings a live mailbox proved were being missed: an acknowledgement reading
+// "we've received your … application" where the list knew only "your application at", and
+// an invitation reading "interview invite" where it knew only "invite you to interview".
+func TestBuildQueryCoversTheWordingsEmployersActuallyUse(t *testing.T) {
+	q := BuildQuery(0, nil)
+	for _, phrase := range []string{
+		"received your application", "interview invite", "interview invitation",
+	} {
+		if !strings.Contains(q, `"`+phrase+`"`) {
+			t.Errorf("the query does not look for %q — measured as missed on a live mailbox", phrase)
+		}
+	}
+	// The wordings that were already there must survive: this list only ever grows, and a
+	// phrase silently dropped is mail silently missed for as long as nobody notices.
+	for _, phrase := range []string{
+		"thank you for applying", "we regret to inform", "recebemos sua candidatura",
+		"ваш отклик", "hemos recibido tu",
+	} {
+		if !strings.Contains(q, `"`+phrase+`"`) {
+			t.Errorf("the query lost the existing phrase %q", phrase)
+		}
+	}
+}
+
+// Fetching the candidate's own replies buys nothing: worker.go drops them before storing.
+// What it costs is a body retrieval each, and room in the page the widened query returns.
+func TestBuildQueryExcludesTheConnectedAddress(t *testing.T) {
+	q := BuildQueryFor("me@example.test", 0, nil)
+	if !strings.Contains(q, "-from:me@example.test") {
+		t.Errorf("the query does not exclude the connected address:\n%s", q)
+	}
+	// The exclusion sits OUTSIDE the OR group. Inside it, it would be one more alternative
+	// and would match everything rather than removing anything.
+	if strings.Contains(q, `OR -from:`) {
+		t.Errorf("the exclusion was OR-ed into the alternatives:\n%s", q)
+	}
+	if plain := BuildQuery(0, nil); strings.Contains(plain, "-from:") {
+		t.Errorf("an address nobody gave leaked into the query:\n%s", plain)
+	}
+}

--- a/internal/gmailsync/worker.go
+++ b/internal/gmailsync/worker.go
@@ -93,7 +93,7 @@ func (w *Worker) syncUser(ctx context.Context, u Connection) {
 	}
 	reader := w.newReader(ctx, refresh, learned)
 
-	ids, err := reader.ListATSMessageIDs(ctx, u.Cursor)
+	ids, err := reader.ListATSMessageIDs(ctx, u.Email, u.Cursor)
 	if err != nil {
 		// A revoked/expired grant surfaces here; flag it for re-consent and move on.
 		log.Printf("gmail-sync: user %d: list: %v — marking needs_reconsent", u.UserID, err)

--- a/internal/gmailsync/worker_test.go
+++ b/internal/gmailsync/worker_test.go
@@ -51,7 +51,7 @@ type fakeReader struct {
 	listErr error
 }
 
-func (f *fakeReader) ListATSMessageIDs(context.Context, int64) ([]string, error) {
+func (f *fakeReader) ListATSMessageIDs(context.Context, string, int64) ([]string, error) {
 	return f.ids, f.listErr
 }
 func (f *fakeReader) ListThreadMessageIDs(_ context.Context, threadID string) ([]string, error) {

--- a/internal/handler/assistant_inbox_tools_test.go
+++ b/internal/handler/assistant_inbox_tools_test.go
@@ -31,8 +31,8 @@ func (m *mailStore) ListEmails(_ context.Context, arg db.ListEmailsParams) ([]db
 	m.lastList = arg
 	return m.list, nil
 }
-func (m *mailStore) CountEmails(context.Context, db.CountEmailsParams) (int64, error) {
-	return m.total, nil
+func (m *mailStore) CountEmails(context.Context, db.CountEmailsParams) (db.CountEmailsRow, error) {
+	return db.CountEmailsRow{Total: m.total}, nil
 }
 func (m *mailStore) CountEmailsByState(context.Context, int64) ([]db.CountEmailsByStateRow, error) {
 	return m.state, nil

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -152,6 +152,22 @@ func listResponse(c *fiber.Ctx, data any, total int64, limit, offset int) error 
 	})
 }
 
+// listResponseWithHidden is listResponse plus the count a default filter suppressed.
+//
+// Separate from listResponse rather than a widened one: every other listing hides nothing,
+// and a `hidden: 0` on all of them would be a field readers have to learn to ignore.
+func listResponseWithHidden(c *fiber.Ctx, data any, total, hidden int64, limit, offset int) error {
+	return c.JSON(fiber.Map{
+		"data": data,
+		"meta": fiber.Map{
+			"total":  total,
+			"limit":  limit,
+			"offset": offset,
+			"hidden": hidden,
+		},
+	})
+}
+
 // Config is the dependency bundle Register wires onto the app: the DB pool, the
 // single browser origin allowed cross-origin (FrontendOrigin), the token-issuer
 // settings (JWTSecret/JWTTTL), the HTTPS-only cookie flag (CookieSecure), the

--- a/internal/handler/inbox.go
+++ b/internal/handler/inbox.go
@@ -99,8 +99,12 @@ func bodyOf(m inbox.Message) emailBody {
 
 // parseInboxQuery reads the listing filters off the query string:
 // ?source=(gmail|hosted|external), ?unread=1, ?status=<signal>, ?q=<term>,
-// ?unclassified=1, ?link=<state>. The vocabularies are checked by the service, so
-// an unknown value is one 400 wherever it arrives from.
+// ?unclassified=1, ?link=<state>, ?include_other=1. The vocabularies are checked by the
+// service, so an unknown value is one 400 wherever it arrives from.
+//
+// include_other is opt-IN because the listing's default is the applications a person came
+// to find, not everything a mailbox holds. What that default costs them is reported as a
+// number rather than left to be discovered.
 func parseInboxQuery(c *fiber.Ctx) inbox.Query {
 	return inbox.Query{
 		Source:       c.Query("source"),
@@ -109,6 +113,7 @@ func parseInboxQuery(c *fiber.Ctx) inbox.Query {
 		Q:            c.Query("q"),
 		Unread:       c.QueryBool("unread"),
 		Unclassified: c.QueryBool("unclassified"),
+		IncludeOther: c.QueryBool("include_other"),
 	}
 }
 
@@ -151,7 +156,10 @@ func (h *inboxHandlers) GetInbox(c *fiber.Ctx) error {
 			emailLinking: linkingOf(m),
 		})
 	}
-	return listResponse(c, out, page.Total, limit, offset)
+	// The hidden count rides in the listing's meta rather than in a second request: a
+	// number nobody fetches is a number nobody sees, and this one exists precisely so a
+	// misclassification is findable.
+	return listResponseWithHidden(c, out, page.Total, page.Hidden, limit, offset)
 }
 
 // GetEmail returns one message body, scoped to the caller (404 for another user's),

--- a/internal/inbox/fake_test.go
+++ b/internal/inbox/fake_test.go
@@ -75,8 +75,8 @@ func (f *fakeQueries) ListEmails(_ context.Context, arg db.ListEmailsParams) ([]
 	return f.list, nil
 }
 
-func (f *fakeQueries) CountEmails(context.Context, db.CountEmailsParams) (int64, error) {
-	return f.total, nil
+func (f *fakeQueries) CountEmails(context.Context, db.CountEmailsParams) (db.CountEmailsRow, error) {
+	return db.CountEmailsRow{Total: f.total}, nil
 }
 
 func (f *fakeQueries) CountEmailsByState(context.Context, int64) ([]db.CountEmailsByStateRow, error) {

--- a/internal/inbox/inbox.go
+++ b/internal/inbox/inbox.go
@@ -37,7 +37,7 @@ import (
 // stays in the handler, where the caller is a person opening a message.
 type Queries interface {
 	ListEmails(ctx context.Context, arg db.ListEmailsParams) ([]db.ListEmailsRow, error)
-	CountEmails(ctx context.Context, arg db.CountEmailsParams) (int64, error)
+	CountEmails(ctx context.Context, arg db.CountEmailsParams) (db.CountEmailsRow, error)
 	CountEmailsByState(ctx context.Context, userID int64) ([]db.CountEmailsByStateRow, error)
 	GetEmail(ctx context.Context, arg db.GetEmailParams) (db.GetEmailRow, error)
 	GetInterviewInvitation(ctx context.Context, arg db.GetInterviewInvitationParams) (db.GetInterviewInvitationRow, error)
@@ -164,9 +164,21 @@ type Query struct {
 	// WithBody asks for each message's readable body. It is opt-in because bodies
 	// are the one listing payload heavy enough to matter.
 	WithBody bool
-	Limit    int
-	Offset   int
+	// IncludeOther asks for mail the classifier judged not to be about an application at
+	// all. It is opt-IN, so the inbox defaults to the applications a person came to find —
+	// and Page.Hidden reports how much that default cost them, because a filter nobody can
+	// see is a misclassification nobody can find.
+	IncludeOther bool
+	Limit        int
+	Offset       int
 }
+
+// showsOther reports whether this query wants the mail the default omits.
+//
+// Asking FOR the label is asking for it. Without this, `?status=other` and the hide default
+// cancel each other out and the filter returns an empty page — a filter that answers
+// "nothing" to its own subject is worse than one that does not exist.
+func (q Query) showsOther() bool { return q.IncludeOther || q.Status == "other" }
 
 // Validate checks the filters against their controlled vocabularies. Search calls
 // it; it is exported for the one caller that reuses the same filters for a
@@ -188,10 +200,15 @@ func (q Query) Validate() error {
 // DefaultLimit is the page size a caller gets when it names none.
 const DefaultLimit = 20
 
-// Page is one listing page and the total matching the same filters.
+// Page is one listing page, the total matching the same filters, and how many the `other`
+// default omitted under those same filters.
 type Page struct {
 	Messages []Message
 	Total    int64
+	// Hidden is the count the default suppressed. Zero when the caller asked for
+	// everything, and zero when there was nothing to suppress — the two are the same
+	// answer to "what am I not seeing".
+	Hidden int64
 }
 
 // Search lists the caller's live mail, newest first, under the given filters.
@@ -212,14 +229,15 @@ func (s *Service) Search(ctx context.Context, userID int64, q Query) (Page, erro
 	rows, err := s.q.ListEmails(ctx, db.ListEmailsParams{
 		UserID: userID, Src: q.Source, Unread: q.Unread, Status: q.Status, Q: q.Q,
 		Unclassified: q.Unclassified, Link: q.Link, WithBody: q.WithBody,
-		Lim: int32(limit), Off: int32(max(q.Offset, 0)),
+		IncludeOther: q.showsOther(),
+		Lim:          int32(limit), Off: int32(max(q.Offset, 0)),
 	})
 	if err != nil {
 		return Page{}, err
 	}
-	total, err := s.q.CountEmails(ctx, db.CountEmailsParams{
+	counts, err := s.q.CountEmails(ctx, db.CountEmailsParams{
 		UserID: userID, Src: q.Source, Unread: q.Unread, Status: q.Status, Q: q.Q,
-		Unclassified: q.Unclassified, Link: q.Link,
+		Unclassified: q.Unclassified, Link: q.Link, IncludeOther: q.showsOther(),
 	})
 	if err != nil {
 		return Page{}, err
@@ -247,7 +265,7 @@ func (s *Service) Search(ctx context.Context, userID int64, q Query) (Page, erro
 		}
 		out = append(out, m)
 	}
-	return Page{Messages: out, Total: total}, nil
+	return Page{Messages: out, Total: counts.Total, Hidden: counts.Hidden}, nil
 }
 
 // Get reads one message without touching its read state. It is the shared tail of

--- a/internal/inbox/inbox_test.go
+++ b/internal/inbox/inbox_test.go
@@ -147,3 +147,19 @@ func TestLinkStatePartitionsTheMailbox(t *testing.T) {
 		})
 	}
 }
+
+// Asking for the label the default hides is asking for it. Without this the two rules
+// cancel and `?status=other` answers "nothing" about its own subject.
+func TestAskingForOtherOverridesTheDefault(t *testing.T) {
+	for name, q := range map[string]Query{
+		"the default":       {},
+		"another label":     {Status: "rejection"},
+		"asking for other":  {Status: "other"},
+		"asking for it all": {IncludeOther: true},
+	} {
+		want := name == "asking for other" || name == "asking for it all"
+		if got := q.showsOther(); got != want {
+			t.Errorf("%s: showsOther() = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/openspec/changes/widen-the-mail-fetch/.openspec.yaml
+++ b/openspec/changes/widen-the-mail-fetch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/widen-the-mail-fetch/design.md
+++ b/openspec/changes/widen-the-mail-fetch/design.md
@@ -49,11 +49,18 @@ An inbox that silently drops `other` is one where a misclassification cannot be 
 omitted, and one control shows them. Unclassified mail is never hidden: nothing has judged
 it.
 
-### The candidate's own mail is excluded at the query
+### The candidate's own mail is excluded at the query, and storage was already safe
 
-Nine of 42 sampled misses were the candidate's own replies. `gmailsync` already holds the
-connected address for exactly this reason while walking threads; the widened top-level query
-needs the same exclusion, or every conversation is stored twice.
+Nine of 42 sampled misses were the candidate's own replies. It is worth being exact about
+what that costs, because the first draft of this design was wrong about it:
+`worker.go` already drops them before storing (`strings.EqualFold(msg.FromAddr, u.Email)`),
+so nothing was ever going to be stored twice.
+
+What they cost is the fetch. Every one is a message id listed and a full message body
+retrieved, only to be discarded — and under a widened query they compete for the page the
+search returns. Excluding them at the query is therefore an efficiency measure with no
+behavioural change, which is the honest reason to do it and a much smaller one than
+"correctness".
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/widen-the-mail-fetch/design.md
+++ b/openspec/changes/widen-the-mail-fetch/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`gmailsync.BuildQuery` scopes the fetch to a curated ATS sender list OR twelve multilingual
+phrases. Everything it fetches enters `email_classification_outbox` and is labelled by
+`mailclassify`, whose vocabulary already includes `other` — "anything not about an
+application".
+
+Measured on production, 2026-08-02, one connected mailbox: **431** fetched over 120 days,
+**1151** found by a hiring-shaped query, **3297** in the mailbox. The **739** difference
+contains an acknowledgement, three interview invitations, four live recruiter threads from
+personal and corporate domains, nine of the candidate's own replies, and about seventeen
+marketing messages. The whole corpus we hold is **544** messages, so the addition is roughly
+**six a day**.
+
+## Goals / Non-Goals
+
+**Goals:** fetch the mail employers actually send; keep the inbox a place to find
+applications; add no state that needs maintaining.
+
+**Non-Goals:** back-filling the 739 already missed (the watermark has passed them; a re-sync
+is an operator action, not this change); `ExtractCompany`'s subject templates; anything
+touching linking, stages or the ledger.
+
+## Decisions
+
+### The classifier is the filter; no blocklist is introduced
+
+The obvious design is a list of aggregator and course domains. Rejected. `mailclassify`
+already labels every message, `other` already means "not about an application", and the
+label is produced by a call the system already makes. A domain list would be a second judge,
+curated by hand, forever, against senders whose business is registering domains — and it
+judges by sender where the classifier judges by content, so a marketing message from a new
+domain lands in the inbox until somebody notices.
+
+### The filter is at DISPLAY, and that is load-bearing
+
+The sync carries a watermark (`BuildQuery(afterUnix)` + the `SetSynced` cursor), so a
+message not fetched today is never fetched. Filtering at fetch time is silent and permanent:
+a wrong rule loses mail that fixing the rule will not bring back.
+
+At display nothing is lost — the row is stored, and correcting the filter reveals it. This
+became affordable in #1531: the recall sweep now searches Gmail rather than our copy, so
+extra rows no longer degrade it. The only thing they degrade is a list a person reads.
+
+### Hidden is reported as a number
+
+An inbox that silently drops `other` is one where a misclassification cannot be found, and
+`mailclassify` reads attacker-controlled text. The listing therefore returns how many it
+omitted, and one control shows them. Unclassified mail is never hidden: nothing has judged
+it.
+
+### The candidate's own mail is excluded at the query
+
+Nine of 42 sampled misses were the candidate's own replies. `gmailsync` already holds the
+connected address for exactly this reason while walking threads; the widened top-level query
+needs the same exclusion, or every conversation is stored twice.
+
+## Risks / Trade-offs
+
+- **A real message labelled `other` is hidden** → the change's sharpest edge, mitigated by
+  the count and the control rather than by a promise.
+- **Marketing labelled as something else** → shows in the inbox, exactly as today.
+- **~6 extra classifications a day** → negligible on a 544-message corpus and the cheap
+  model.
+- **Query length** → Gmail bounds search strings; the addition is bounded and tested.
+
+## Migration Plan
+
+No migration, no new column, no backfill. The widened query applies from the next sync; the
+already-missed 739 remain missed unless an operator re-syncs from an earlier watermark.
+
+## Open Questions
+
+None blocking. Worth revisiting with data: whether `other` proves too coarse a filter — if
+real mail lands in it often, the answer is to sharpen the classifier, not to add the
+blocklist this design rejected.

--- a/openspec/changes/widen-the-mail-fetch/proposal.md
+++ b/openspec/changes/widen-the-mail-fetch/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+The Gmail sync fetches too little, and what it misses is what matters most.
+
+Over 120 days it fetched **431** messages from a mailbox holding **3297**; a loosely
+hiring-shaped query finds **1151**. So **739** hiring-shaped messages are invisible. A
+42-message sample contains an acknowledgement (`We've received your a16z speedrun
+application!`), three interview invitations (`micro1 interview invite`), and four live
+recruiter threads from personal and corporate domains (`Re: Senior Backend Engineer` from
+`@op.tech`).
+
+The misses are near misses on wording: the phrase list knows `invite you to interview` but
+not `interview invite`, `your application at` but not `we've received your … application`.
+
+**Cost is not what constrains this.** The whole production corpus is **544** messages; 739
+over 120 days is about **six a day** on the cheap model. What widening costs is the inbox —
+roughly 40% of the addition is marketing, and the inbox is where a person looks for their
+applications.
+
+## What Changes
+
+- **The fetch widens**: the measured near-miss phrasings plus broader hiring vocabulary,
+  which took the same mailbox from 431 to 1151 over the window.
+- **The candidate's own replies are excluded.** Nine of 42 sampled misses were their own
+  mail; the sync already carries the connected address to skip them while walking a thread
+  and needs the same exclusion at the top level.
+- **The inbox hides `other` by default** — the label the classifier already applies to mail
+  that is not about an application at all. No blocklist is introduced: the classifier
+  already judges every message on a call we already pay for, and a curated domain list would
+  need maintaining forever against senders who register domains for a living.
+- **The listing reports how much it hid**, and one control shows it. A filter with no
+  indicator makes a misclassification unfindable.
+- The `gmail-ats-sync` spec is corrected while we are here: it claims non-ATS mail is
+  "never fetched or stored", which stopped being true when the phrase clauses were added.
+
+No change to linking, stages, or the ledger.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `gmail-ats-sync`: the fetch is scoped to hiring-shaped mail rather than to ATS senders,
+  and excludes the caller's own messages.
+- `email-inbox`: the listing hides mail classified `other` by default, reports the count it
+  hid, and can show it.
+
+## Impact
+
+- **`internal/gmailsync/senders.go`**: the phrase list and the query builder; an exclusion
+  for the connected address.
+- **`internal/db/queries/gmail.sql`**: the listing gains a "hide `other`" predicate and the
+  count of what it hid. `make sqlc`.
+- **`internal/inbox`**: the query option and the count on the page.
+- **Web**: the inbox surfaces the hidden count and the control.
+- **No migration.** No new column: the label already exists.
+- **Backfill**: none required. The widened query picks new mail up from the next sync
+  onward; the 739 already-missed messages stay missed unless somebody re-syncs from an
+  earlier watermark, which is deliberately not part of this change.

--- a/openspec/changes/widen-the-mail-fetch/specs/email-inbox/spec.md
+++ b/openspec/changes/widen-the-mail-fetch/specs/email-inbox/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: The inbox hides mail that is not about an application
+
+The inbox listing SHALL, by default, omit messages the classifier labelled as not being
+about an application at all, and SHALL report how many it omitted. A caller SHALL be able
+to ask for them.
+
+The judgement is the classifier's, not a curated list of senders. It already labels every
+message on a call the system already makes, it judges by content rather than by who sent
+it, and a sender nobody has seen before is judged on arrival rather than after somebody
+notices it. A domain list would need maintaining indefinitely against senders who register
+domains for a living.
+
+The count is not decoration. A filter that hides silently makes a misclassification
+impossible to find, and the classifier reads attacker-controlled text.
+
+#### Scenario: Mail that is not about an application is omitted by default
+
+- **WHEN** a caller lists their inbox and some of their mail is labelled as not about an
+  application
+- **THEN** that mail is absent from the listing
+
+#### Scenario: The listing says how much it hid
+
+- **WHEN** a listing omits such mail
+- **THEN** it reports the number omitted
+
+#### Scenario: The caller can see what was hidden
+
+- **WHEN** a caller asks for the hidden mail
+- **THEN** it is listed
+
+#### Scenario: An unclassified message is never hidden
+
+- **WHEN** a message has no classification yet
+- **THEN** it is listed, because nothing has judged it

--- a/openspec/changes/widen-the-mail-fetch/specs/gmail-ats-sync/spec.md
+++ b/openspec/changes/widen-the-mail-fetch/specs/gmail-ats-sync/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Hiring-shaped Gmail sync
+
+The system SHALL, for each connected user, read their mail via the Gmail API restricted to
+mail that is hiring-shaped — sent from a curated ATS sender domain, OR carrying one of the
+recognised application and interview phrasings — and MUST NOT ingest mail matching neither.
+
+The phrasings SHALL cover the wordings employers actually use rather than one canonical
+form of each. Measured against a live mailbox, the sync fetched 431 messages over 120 days
+where a hiring-shaped query found 1151: the misses were near misses, an acknowledgement
+reading "we've received your … application" where the list knew only "your application at",
+and an invitation reading "interview invite" where it knew only "invite you to interview".
+
+The sync SHALL NOT ingest messages the connected account itself sent. The worker already
+skips them while walking a thread; a top-level fetch that did not would store both halves
+of every conversation.
+
+#### Scenario: Mail from an ATS sender is ingested
+
+- **WHEN** the sync worker runs and the mailbox holds mail from a configured ATS domain
+- **THEN** that mail is fetched and stored
+
+#### Scenario: Mail phrased as an application or an interview is ingested
+
+- **WHEN** the mailbox holds a message from a domain on no list whose text carries a
+  recognised application or interview phrasing
+- **THEN** that mail is fetched and stored
+
+#### Scenario: Mail that is neither is ignored
+
+- **WHEN** the mailbox holds mail from an unrecognised sender with no recognised phrasing
+- **THEN** that mail is never fetched or stored
+
+#### Scenario: The candidate's own mail is not ingested
+
+- **WHEN** the mailbox holds a message the connected account sent
+- **THEN** it is not stored, whether or not its text is hiring-shaped
+
+## REMOVED Requirements
+
+### Requirement: ATS-scoped Gmail sync
+
+**Reason**: Replaced by "Hiring-shaped Gmail sync". The name and the rule had both drifted
+from the code: it required that the sync "MUST NOT ingest non-ATS mail" and that non-ATS
+mail is "never fetched or stored", which stopped being true when the multilingual phrase
+clauses were added — mail from a domain on no list has been ingested for as long as those
+have existed. Widening the phrasings makes the gap wider still, so the requirement is
+restated around what the fetch is actually scoped to rather than corrected in place.
+
+**Migration**: None. No behaviour is removed; the successor covers ATS senders as one of
+its two admitted classes.

--- a/openspec/changes/widen-the-mail-fetch/specs/gmail-ats-sync/spec.md
+++ b/openspec/changes/widen-the-mail-fetch/specs/gmail-ats-sync/spec.md
@@ -12,9 +12,9 @@ where a hiring-shaped query found 1151: the misses were near misses, an acknowle
 reading "we've received your … application" where the list knew only "your application at",
 and an invitation reading "interview invite" where it knew only "invite you to interview".
 
-The sync SHALL NOT ingest messages the connected account itself sent. The worker already
-skips them while walking a thread; a top-level fetch that did not would store both halves
-of every conversation.
+The sync SHALL NOT ingest messages the connected account itself sent, and SHOULD NOT fetch
+them. The storage guard already exists; the fetch-side exclusion is what stops those
+messages consuming the query's results and a body retrieval each.
 
 #### Scenario: Mail from an ATS sender is ingested
 
@@ -32,10 +32,11 @@ of every conversation.
 - **WHEN** the mailbox holds mail from an unrecognised sender with no recognised phrasing
 - **THEN** that mail is never fetched or stored
 
-#### Scenario: The candidate's own mail is not ingested
+#### Scenario: The candidate's own mail is neither fetched nor stored
 
 - **WHEN** the mailbox holds a message the connected account sent
-- **THEN** it is not stored, whether or not its text is hiring-shaped
+- **THEN** the query does not ask for it
+- **AND** it is not stored, whether or not its text is hiring-shaped
 
 ## REMOVED Requirements
 

--- a/openspec/changes/widen-the-mail-fetch/tasks.md
+++ b/openspec/changes/widen-the-mail-fetch/tasks.md
@@ -14,13 +14,16 @@
 
 ## 2. The listing
 
-- [ ] 2.1 Add the hide predicate and the hidden count to `ListEmails`/`CountEmails` in
+- [x] 2.1 Add the hide predicate and the hidden count to `ListEmails`/`CountEmails` in
       `internal/db/queries/gmail.sql`: omit `status_signal = 'other'` unless asked, never
       omit an unclassified message, and report how many were omitted under the same filters.
       `make sqlc`.
-- [ ] 2.2 Carry the option and the count through `inbox.Query` / `inbox.Page`, with unit
-      tests for the default (hidden), the opt-in (shown), and the unclassified case.
-- [ ] 2.3 Integration test over a real Postgres: a mailbox holding `other`, a signal, and an
+- [x] 2.2 Carry the option and the count through `inbox.Query` / `inbox.Page`, with unit
+      tests for the default (hidden), the opt-in (shown), and the unclassified case. Found
+      during implementation: `?status=other` and the hide default cancelled each other and
+      returned an empty page, so asking FOR the label now overrides the default
+      (`Query.showsOther`).
+- [x] 2.3 Integration test over a real Postgres: a mailbox holding `other`, a signal, and an
       unclassified message lists two by default and three when asked, and reports one hidden.
 
 ## 3. HTTP and web

--- a/openspec/changes/widen-the-mail-fetch/tasks.md
+++ b/openspec/changes/widen-the-mail-fetch/tasks.md
@@ -28,17 +28,17 @@
 
 ## 3. HTTP and web
 
-- [ ] 3.1 Accept the opt-in on `GET /me/inbox` and `GET /me/emails`, and return the hidden
+- [x] 3.1 Accept the opt-in on `GET /me/inbox` and `GET /me/emails`, and return the hidden
       count in the listing's meta.
-- [ ] 3.2 Show the count and the control in the inbox. A hidden filter with no indicator is
+- [x] 3.2 Show the count and the control in the inbox. A hidden filter with no indicator is
       the failure this design exists to avoid, so the number is visible without opening
       anything.
-- [ ] 3.3 Run `pnpm run check`, `pnpm run lint`, and the design-system ratchets.
+- [x] 3.3 Run `pnpm run check`, `pnpm run lint`, and the design-system ratchets.
 
 ## 4. Documentation and gates
 
-- [ ] 4.1 Update `docs/agents/mail-stack.md`: what the fetch is scoped to now, that the
+- [x] 4.1 Update `docs/agents/mail-stack.md`: what the fetch is scoped to now, that the
       classifier is the inbox filter and why no blocklist exists, and that the filter is at
       display because the watermark makes a fetch-time filter permanent.
-- [ ] 4.2 Run `go build ./...`, `go vet ./...`, `go test ./...`, and
+- [x] 4.2 Run `go build ./...`, `go vet ./...`, `go test ./...`, and
       `go vet -tags=integration ./...` before pushing.

--- a/openspec/changes/widen-the-mail-fetch/tasks.md
+++ b/openspec/changes/widen-the-mail-fetch/tasks.md
@@ -6,8 +6,9 @@
       multilingual entries and adding their obvious siblings. Tests assert each new phrase
       appears in the built query and that the existing ones survive.
 - [ ] 1.2 Exclude the connected account's own mail from the query (`-from:<address>`), and
-      test it: the address is already carried for thread walking, and a top-level fetch
-      without it stores both halves of every conversation.
+      test it. NOTE, corrected during implementation: `worker.go:128` already drops these
+      before storing, so this changes no stored data — it stops the widened query spending
+      its page and a body retrieval each on mail that is discarded on arrival.
 - [ ] 1.3 Test that the query stays a single well-formed clause as the list grows — the
       phrases are OR-ed inside one group and the exclusion sits outside it.
 

--- a/openspec/changes/widen-the-mail-fetch/tasks.md
+++ b/openspec/changes/widen-the-mail-fetch/tasks.md
@@ -1,0 +1,40 @@
+## 1. The fetch
+
+- [ ] 1.1 Extend `recallPhrases` in `internal/gmailsync/senders.go` with the wordings
+      measured as missed — `received your application`, `interview invite`, `interview
+      invitation`, `next steps`, `schedule a call`, `screening` — keeping the existing
+      multilingual entries and adding their obvious siblings. Tests assert each new phrase
+      appears in the built query and that the existing ones survive.
+- [ ] 1.2 Exclude the connected account's own mail from the query (`-from:<address>`), and
+      test it: the address is already carried for thread walking, and a top-level fetch
+      without it stores both halves of every conversation.
+- [ ] 1.3 Test that the query stays a single well-formed clause as the list grows — the
+      phrases are OR-ed inside one group and the exclusion sits outside it.
+
+## 2. The listing
+
+- [ ] 2.1 Add the hide predicate and the hidden count to `ListEmails`/`CountEmails` in
+      `internal/db/queries/gmail.sql`: omit `status_signal = 'other'` unless asked, never
+      omit an unclassified message, and report how many were omitted under the same filters.
+      `make sqlc`.
+- [ ] 2.2 Carry the option and the count through `inbox.Query` / `inbox.Page`, with unit
+      tests for the default (hidden), the opt-in (shown), and the unclassified case.
+- [ ] 2.3 Integration test over a real Postgres: a mailbox holding `other`, a signal, and an
+      unclassified message lists two by default and three when asked, and reports one hidden.
+
+## 3. HTTP and web
+
+- [ ] 3.1 Accept the opt-in on `GET /me/inbox` and `GET /me/emails`, and return the hidden
+      count in the listing's meta.
+- [ ] 3.2 Show the count and the control in the inbox. A hidden filter with no indicator is
+      the failure this design exists to avoid, so the number is visible without opening
+      anything.
+- [ ] 3.3 Run `pnpm run check`, `pnpm run lint`, and the design-system ratchets.
+
+## 4. Documentation and gates
+
+- [ ] 4.1 Update `docs/agents/mail-stack.md`: what the fetch is scoped to now, that the
+      classifier is the inbox filter and why no blocklist exists, and that the filter is at
+      display because the watermark makes a fetch-time filter permanent.
+- [ ] 4.2 Run `go build ./...`, `go vet ./...`, `go test ./...`, and
+      `go vet -tags=integration ./...` before pushing.

--- a/openspec/changes/widen-the-mail-fetch/tasks.md
+++ b/openspec/changes/widen-the-mail-fetch/tasks.md
@@ -1,15 +1,15 @@
 ## 1. The fetch
 
-- [ ] 1.1 Extend `recallPhrases` in `internal/gmailsync/senders.go` with the wordings
+- [x] 1.1 Extend `recallPhrases` in `internal/gmailsync/senders.go` with the wordings
       measured as missed — `received your application`, `interview invite`, `interview
       invitation`, `next steps`, `schedule a call`, `screening` — keeping the existing
       multilingual entries and adding their obvious siblings. Tests assert each new phrase
       appears in the built query and that the existing ones survive.
-- [ ] 1.2 Exclude the connected account's own mail from the query (`-from:<address>`), and
+- [x] 1.2 Exclude the connected account's own mail from the query (`-from:<address>`), and
       test it. NOTE, corrected during implementation: `worker.go:128` already drops these
       before storing, so this changes no stored data — it stops the widened query spending
       its page and a body retrieval each on mail that is discarded on arrival.
-- [ ] 1.3 Test that the query stays a single well-formed clause as the list grows — the
+- [x] 1.3 Test that the query stays a single well-formed clause as the list grows — the
       phrases are OR-ed inside one group and the exclusion sits outside it.
 
 ## 2. The listing

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1350,8 +1350,11 @@ export function createApi(
       source?: InboxSource;
       unread?: boolean;
       status?: string;
+      /** Ask for mail the classifier judged not to be about an application at all. The
+       *  listing hides it by default and reports how many it hid. */
+      includeOther?: boolean;
     } = {},
-  ): Promise<Slice<InboxMessage>> {
+  ): Promise<Slice<InboxMessage> & { hidden: number }> {
     const params = new URLSearchParams({
       limit: String(opts.limit ?? 20),
       offset: String(opts.offset ?? 0),
@@ -1360,7 +1363,11 @@ export function createApi(
     if (opts.source) params.set('source', opts.source);
     if (opts.unread) params.set('unread', '1');
     if (opts.status) params.set('status', opts.status);
-    return toSlice(await request<Page<InboxMessage>>(`/api/v1/me/inbox?${params.toString()}`), opts.offset ?? 0);
+    if (opts.includeOther) params.set('include_other', '1');
+    const page = await request<Page<InboxMessage> & { meta: { hidden?: number } }>(
+      `/api/v1/me/inbox?${params.toString()}`
+    );
+    return { ...toSlice(page, opts.offset ?? 0), hidden: page.meta.hidden ?? 0 };
   }
 
   /** Mark every unread message matching the active filters as read; returns the

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -41,6 +41,12 @@
   // Triage filters: unread-only and one classification label ('' = all).
   let unread = $state(false);
   let label = $state('');
+  // Mail the classifier judged not to be about an application at all is hidden by default —
+  // the inbox is where a person looks for their applications. How much that costs them is
+  // shown as a number rather than left to be discovered, because a filter nobody can see is
+  // a misclassification nobody can find.
+  let includeOther = $state(false);
+  let hidden = $state(0);
   // The dropdown offers only signals with a human label (drops 'other' → blank).
   const LABEL_OPTIONS = Object.entries(STATUS_LABELS).filter(([, l]) => l !== '');
   const filterActive = $derived(unread || label !== '' || search !== '');
@@ -49,7 +55,19 @@
   // fetch closure reads the live filters (search, account, unread, label) at
   // call time, so a filter change just re-fetches the first page.
   const pager = new Paginator<InboxMessage>(
-    (limit, offset) => api.getInbox({ q: search, limit, offset, source, unread, status: label }),
+    async (limit, offset) => {
+      const page = await api.getInbox({
+        q: search,
+        limit,
+        offset,
+        source,
+        unread,
+        status: label,
+        includeOther,
+      });
+      hidden = page.hidden;
+      return page;
+    },
     PAGE_SIZE,
   );
 
@@ -606,6 +624,38 @@
           <span aria-hidden="true">·</span>
           <button type="button" onclick={undoDelete} class="font-medium text-brand-strong hover:underline">Undo</button>
         </div>
+      {/if}
+
+      <!-- The number the default cost them, where they are already looking. It appears only
+           when something was hidden, so a clean mailbox says nothing at all. -->
+      {#if hidden > 0 && !includeOther}
+        <p class="pb-3 text-sm text-muted-foreground">
+          {hidden} message{hidden === 1 ? '' : 's'} not about an application {hidden === 1 ? 'is' : 'are'} hidden.
+          <button
+            type="button"
+            class="font-medium text-brand-strong underline-offset-2 hover:underline"
+            onclick={() => {
+              includeOther = true;
+              void fetchFirstPage('Could not load the hidden mail.');
+            }}
+          >
+            Show
+          </button>
+        </p>
+      {:else if includeOther}
+        <p class="pb-3 text-sm text-muted-foreground">
+          Showing mail that is not about an application.
+          <button
+            type="button"
+            class="font-medium text-brand-strong underline-offset-2 hover:underline"
+            onclick={() => {
+              includeOther = false;
+              void fetchFirstPage('Could not reload the inbox.');
+            }}
+          >
+            Hide
+          </button>
+        </p>
       {/if}
 
       {#if pager.items.length === 0}


### PR DESCRIPTION
## What and why

The Gmail sync fetches too little, and what it misses is what matters most.

Over 120 days it fetched **431** messages from a mailbox holding **3297**; a hiring-shaped
query finds **1151**. The **739** difference contains an acknowledgement (`We've received
your a16z speedrun application!`), three interview invitations (`micro1 interview invite`),
and four live recruiter threads from personal and corporate domains.

**The misses are near misses on wording.** The phrase list knew `invite you to interview`
but not `interview invite`; `your application at` but not `we've received your …
application`. Its shape was the defect: one canonical wording per idea. The comment now says
so, and tells the next person to add the *siblings* of a wording rather than the wording.

**Cost is not the constraint.** The whole production corpus is **544** messages, so 739 over
120 days is about six a day on the cheap model. What widening costs is the inbox — roughly
40% of the addition is aggregator and course marketing.

## The junk filter is the classifier, at display

**No blocklist is introduced.** A curated domain list would be a second judge, maintained by
hand forever against people whose business is registering domains, judging by *sender* where
`mailclassify` already judges by *content* on a call we already pay for. The listing omits
`status_signal = 'other'` by default and reports how many it omitted.

**At display, not at fetch, and that is load-bearing.** The sync carries a watermark, so
mail not fetched today is never fetched: a fetch-time filter loses silently and permanently,
and fixing the rule brings nothing back. A display filter loses nothing — and it became
affordable only in #1531, when the recall sweep stopped reading our copy, so extra rows now
degrade a list a person reads and nothing else.

Three rules keep the filter honest:

- **Unclassified mail is never hidden.** A message nothing has judged has not been found
  irrelevant; it has not been looked at.
- **Asking FOR the label overrides the default.** Found in implementation: `?status=other`
  and the hide rule cancelled each other and the filter answered nothing about its own
  subject.
- **The count rides in the listing's meta**, computed by the same statement under the same
  filters. A separately-computed hidden count would describe a different mailbox the moment
  any filter is on, and a filter nobody can see is a misclassification nobody can find.

## Also

`gmail-ats-sync`'s spec claimed non-ATS mail is "never fetched or stored". That stopped being
true when the phrase clauses were added; it is restated rather than patched.

**No migration, no new column, no backfill.** The widened query applies from the next sync;
the 739 already missed stay missed unless an operator re-syncs from an earlier watermark,
which is deliberately out of scope.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` pass.
- [x] `go test ./...` (132 packages), `go vet -tags=integration ./...`, and
      `go test -tags=integration ./internal/db/ ./internal/handler/ ./internal/inbox/` pass.
- [x] I regenerated committed artifacts when their source changed (`make sqlc`).
- [x] For `web/` changes: `pnpm run check` (0 errors), `pnpm run lint` (0 errors),
      `pnpm run test` (831/831); design-system `check:tokens` and `check:adoption` hold.
- [x] This stays within freehire's core/extension boundary.

### Not verified

The inbox change has not been opened in a browser.

### Corrected during implementation

The design claimed excluding the candidate's own mail prevented storing "both halves of
every conversation". It did not — `worker.go:128` already dropped them before storing. The
real benefit is smaller and honest: not spending a listed id and a body retrieval on mail
discarded on arrival. The OpenSpec artifacts were corrected rather than the justification
kept.
