### PR TITLE
docs(readme): split source breakdown into its own page, refresh counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 ![Go version](https://img.shields.io/github/go-mod/go-version/strelov1/freehire)
 ![Last commit](https://img.shields.io/github/last-commit/strelov1/freehire)
 [![Stars](https://img.shields.io/github/stars/strelov1/freehire?style=social)](https://github.com/strelov1/freehire/stargazers)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/aAXS2rghW)
 
 <br>
 
@@ -185,202 +186,22 @@ search-filter vocabulary: [freehire.me/docs/api](https://freehire.me/docs/api).*
 
 ## Sources
 
-Live catalogue snapshot — **3,458,772 open postings** across **222,652 companies**.
+Live catalogue snapshot — **3,445,246 open postings** across **223,685 companies**.
 Counts are open postings unless noted; a company crawled from two sources is
 counted under each. Every source is one of three kinds:
 
 - **ATS platforms** — one adapter per multi-tenant applicant-tracking system,
   each serving many companies (Workday, Greenhouse, Lever, iCIMS…).
+  **84 platforms · 2,797,390 open postings.**
 - **Aggregators & job boards** — third-party feeds that republish many
   companies' postings (mycareersfuture, himalayas, jobtech, Telegram…).
+  **47 sources · 612,690 open postings.**
 - **Company career sites** — direct single-company feeds crawled from a
   company's own careers page (Amazon, Apple, Google, Yandex, Sber…).
+  **36 feeds · 35,160 open postings.**
 
-### ATS platforms
-
-**83 platforms · 76,775 companies · 2,795,749 open postings.**
-
-| Source | Companies | Open jobs |
-| --- | ---: | ---: |
-| workday | 4,091 | 808,159 |
-| oracle | 526 | 394,586 |
-| smartrecruiters | 2,133 | 266,328 |
-| greenhouse | 6,649 | 173,343 |
-| ukg | 1 | 150,328 |
-| icims | 2,967 | 106,481 |
-| paycom | 5,737 | 93,330 |
-| gupy | 1,428 | 71,908 |
-| lever | 2,133 | 63,579 |
-| apploi | 2,957 | 62,286 |
-| ashby | 3,658 | 58,981 |
-| bamboohr | 8,813 | 53,975 |
-| jazzhr | 3,731 | 44,772 |
-| phenom | 47 | 43,029 |
-| recruitee | 1,829 | 41,280 |
-| personio | 4,001 | 37,802 |
-| paylocity | 2,619 | 26,115 |
-| eightfold | 43 | 25,667 |
-| jibe | 15 | 23,210 |
-| teamtailor | 1,434 | 21,104 |
-| applicantpro | 1,750 | 21,004 |
-| zohorecruit | 1,073 | 20,482 |
-| workable | 681 | 18,951 |
-| hireology | 2,241 | 16,713 |
-| pinpoint | 647 | 15,169 |
-| isolvedhire | 1,984 | 14,657 |
-| careerplug | 4,112 | 14,255 |
-| breezy | 972 | 13,977 |
-| solides | 1,124 | 13,689 |
-| join | 3,940 | 9,780 |
-| jobylon | 872 | 8,578 |
-| inhire | 365 | 8,229 |
-| taleo | 13 | 6,355 |
-| trakstar | 501 | 6,183 |
-| freshteam | 179 | 5,192 |
-| successfactors | 12 | 4,691 |
-| factorial | 476 | 4,563 |
-| erecruiter | 30 | 2,901 |
-| gem | 217 | 2,418 |
-| senior | 82 | 2,309 |
-| traffit | 44 | 2,127 |
-| cornerstone | 14 | 1,720 |
-| radancy | 5 | 1,648 |
-| jobvite | 54 | 1,475 |
-| avature | 3 | 1,331 |
-| rippling | 86 | 1,300 |
-| betterteam | 146 | 1,274 |
-| neogov | 11 | 1,224 |
-| pageup | 8 | 968 |
-| manatal | 13 | 876 |
-| softgarden | 18 | 825 |
-| loxo | 12 | 677 |
-| deel | 58 | 584 |
-| peopleforce | 61 | 572 |
-| comeet | 17 | 450 |
-| clinch | 1 | 409 |
-| wpyoast | 1 | 397 |
-| opencats | 9 | 260 |
-| compleo | 4 | 182 |
-| catsone | 4 | 157 |
-| ashbygraphql | 3 | 138 |
-| huntflow | 19 | 129 |
-| ismartrecruit | 2 | 103 |
-| cleverstaff | 34 | 80 |
-| jobscore | 6 | 79 |
-| bullhorn | 2 | 75 |
-| hurma | 5 | 46 |
-| earcu | 1 | 44 |
-| careerspage | 3 | 43 |
-| recruitingsolutions | 17 | 40 |
-| quickin | 3 | 34 |
-| adp | 1 | 22 |
-| talentlyft | 3 | 19 |
-| odoo | 1 | 13 |
-| speedrun | 10 | 12 |
-| enlizt | 2 | 12 |
-| mindsight | 1 | 12 |
-| vouch | 1 | 10 |
-| spark | 1 | 9 |
-| weblink | 5 | 5 |
-| talenthr | 1 | 4 |
-| talentadore | 1 | 3 |
-| briefhq | 1 | 2 |
-
-### Aggregators & job boards
-
-**45 sources · 147,231 companies · 534,902 open postings.**
-
-| Source | Companies | Open jobs |
-| --- | ---: | ---: |
-| trudvsem | 49,963 | 186,058 |
-| mycareersfuture | 20,053 | 81,661 |
-| jobtech | 8,557 | 28,713 |
-| infojobs | 13,829 | 24,861 |
-| himalayas | 12,173 | 23,368 |
-| gulftalent | 776 | 19,828 |
-| nofluffjobs | 404 | 19,655 |
-| jobdanmark | 5,568 | 16,145 |
-| jobnet | 6,407 | 14,214 |
-| tyomarkkinatori | 3,371 | 11,959 |
-| justjoin | 1,204 | 11,833 |
-| reed | 1,500 | 11,738 |
-| powertofly | 30 | 9,758 |
-| telegram | 3,398 | 9,715 |
-| usajobs | 360 | 9,045 |
-| hh | 4,461 | 8,821 |
-| jobstash | 930 | 7,536 |
-| djinni | 2,140 | 7,065 |
-| wantedkr | 2,368 | 5,976 |
-| workatastartup | 1,424 | 5,195 |
-| arbeitsagentur | 1,793 | 4,420 |
-| arbeitnow | 2,074 | 3,614 |
-| vagas | 455 | 1,903 |
-| likeit | 16 | 1,469 |
-| thehub | 307 | 1,272 |
-| instaffo | 590 | 1,203 |
-| getonbrd | 300 | 1,144 |
-| habr_career | 186 | 1,144 |
-| remoteok | 782 | 897 |
-| functionalworks | 333 | 884 |
-| getmatch | 143 | 838 |
-| jobicy | 424 | 565 |
-| wantapply | 100 | 522 |
-| getro | 119 | 450 |
-| weworkremotely | 314 | 432 |
-| workablemarketplace | 2 | 391 |
-| geekjob | 174 | 283 |
-| startupandvc | 74 | 100 |
-| tecla | 36 | 66 |
-| workingnomads | 20 | 49 |
-| remotive | 23 | 38 |
-| getmanfred | 31 | 37 |
-| jobspresso | 14 | 18 |
-| topco | 4 | 11 |
-| teamex | 1 | 8 |
-
-### Company career sites
-
-**35 feeds · 65 companies · 36,750 open postings.**
-
-| Source | Companies | Open jobs |
-| --- | ---: | ---: |
-| amazon | 1 | 10,901 |
-| apple | 1 | 4,804 |
-| google | 7 | 3,781 |
-| sber | 10 | 3,750 |
-| tbank | 1 | 2,479 |
-| alfabank | 1 | 2,385 |
-| mts | 12 | 1,800 |
-| luxoft | 1 | 1,334 |
-| epam | 1 | 1,143 |
-| yandex | 1 | 935 |
-| meta | 1 | 760 |
-| uber | 1 | 669 |
-| rwb | 1 | 383 |
-| micro1 | 1 | 322 |
-| vk | 1 | 287 |
-| bairesdev | 1 | 172 |
-| avito | 1 | 153 |
-| dataart | 1 | 143 |
-| lamoda | 1 | 106 |
-| vention | 1 | 66 |
-| alignerr | 1 | 55 |
-| globalpayments | 1 | 54 |
-| northstone | 3 | 52 |
-| aviasales | 1 | 32 |
-| yandexcrowd | 1 | 31 |
-| domclick | 1 | 27 |
-| rapyd | 1 | 25 |
-| ozon | 1 | 23 |
-| dodo | 3 | 19 |
-| 2gis | 1 | 18 |
-| onstrider | 1 | 14 |
-| lumenalta | 1 | 13 |
-| mtslink | 1 | 7 |
-| telegramcareers | 1 | 5 |
-| kuper | 1 | 2 |
-
-Plus **7** postings from manual bulk imports.
+Full per-source breakdown — every one of the 167 sources with its own
+companies/open-jobs count — lives on its own page: [docs/sources.md](docs/sources.md).
 
 ## Adding a source
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,0 +1,205 @@
+# Sources
+
+The [README](../README.md) covers what freehire is; this is the full per-source
+breakdown behind the "3.4M+ postings" headline. Live catalogue snapshot —
+**3,445,246 open postings** across **223,685 companies**. Counts are open
+postings unless noted; a company crawled from two sources is counted under
+each, so the per-section company totals below sum to more than the distinct
+figure above. Every source is one of three kinds:
+
+- **ATS platforms** — one adapter per multi-tenant applicant-tracking system,
+  each serving many companies (Workday, Greenhouse, Lever, iCIMS…).
+- **Aggregators & job boards** — third-party feeds that republish many
+  companies' postings (mycareersfuture, himalayas, jobtech, Telegram…).
+- **Company career sites** — direct single-company feeds crawled from a
+  company's own careers page (Amazon, Apple, Google, Yandex, Sber…).
+
+## ATS platforms
+
+**84 platforms · 79,299 companies · 2,797,390 open postings.**
+
+| Source | Companies | Open jobs |
+| --- | ---: | ---: |
+| workday | 4,124 | 790,007 |
+| oracle | 526 | 412,372 |
+| smartrecruiters | 2,557 | 264,647 |
+| greenhouse | 6,697 | 174,370 |
+| ukg | 1 | 157,286 |
+| icims | 2,985 | 100,990 |
+| paycom | 5,748 | 88,329 |
+| lever | 2,168 | 65,182 |
+| gupy | 1,428 | 62,465 |
+| ashby | 3,815 | 59,637 |
+| apploi | 2,957 | 53,388 |
+| bamboohr | 8,843 | 52,310 |
+| jazzhr | 3,802 | 43,162 |
+| phenom | 48 | 42,083 |
+| recruitee | 1,851 | 41,419 |
+| workable | 1,008 | 39,912 |
+| personio | 4,049 | 37,529 |
+| paylocity | 2,624 | 26,823 |
+| eightfold | 43 | 25,011 |
+| breezy | 1,685 | 24,637 |
+| teamtailor | 1,457 | 20,880 |
+| zohorecruit | 1,075 | 19,835 |
+| applicantpro | 1,761 | 19,720 |
+| jibe | 15 | 19,308 |
+| hireology | 2,252 | 16,379 |
+| careerplug | 4,286 | 14,764 |
+| pinpoint | 647 | 14,275 |
+| isolvedhire | 1,997 | 13,863 |
+| solides | 1,125 | 13,177 |
+| join | 3,997 | 9,760 |
+| jobylon | 886 | 8,320 |
+| inhire | 365 | 7,873 |
+| trakstar | 647 | 6,542 |
+| freshteam | 193 | 6,274 |
+| taleo | 13 | 6,133 |
+| successfactors | 12 | 4,521 |
+| factorial | 478 | 4,425 |
+| jobvite | 91 | 4,142 |
+| erecruiter | 30 | 2,553 |
+| gem | 225 | 2,367 |
+| traffit | 44 | 2,069 |
+| radancy | 7 | 1,934 |
+| senior | 83 | 1,725 |
+| cornerstone | 14 | 1,590 |
+| manatal | 17 | 1,373 |
+| rippling | 89 | 1,304 |
+| betterteam | 146 | 1,238 |
+| avature | 3 | 1,233 |
+| neogov | 11 | 1,072 |
+| pageup | 8 | 965 |
+| comeet | 21 | 892 |
+| softgarden | 18 | 815 |
+| loxo | 12 | 669 |
+| deel | 60 | 580 |
+| peopleforce | 63 | 556 |
+| clinch | 1 | 390 |
+| hibob | 17 | 387 |
+| wpyoast | 1 | 355 |
+| opencats | 9 | 238 |
+| compleo | 4 | 180 |
+| huntflow | 24 | 166 |
+| catsone | 4 | 153 |
+| ashbygraphql | 3 | 129 |
+| ismartrecruit | 2 | 104 |
+| cleverstaff | 35 | 84 |
+| jobscore | 6 | 82 |
+| bullhorn | 2 | 71 |
+| weblink | 32 | 51 |
+| hurma | 5 | 43 |
+| careerspage | 3 | 43 |
+| earcu | 1 | 41 |
+| recruitingsolutions | 17 | 40 |
+| quickin | 3 | 32 |
+| talentlyft | 3 | 21 |
+| adp | 1 | 19 |
+| speedrun | 10 | 15 |
+| enlizt | 2 | 13 |
+| odoo | 1 | 12 |
+| mindsight | 1 | 10 |
+| vouch | 1 | 10 |
+| spark | 1 | 8 |
+| talenthr | 1 | 4 |
+| talentadore | 1 | 2 |
+| briefhq | 1 | 2 |
+
+## Aggregators & job boards
+
+**47 sources · 162,917 companies · 612,690 open postings.**
+
+| Source | Companies | Open jobs |
+| --- | ---: | ---: |
+| trudvsem | 56,770 | 231,054 |
+| mycareersfuture | 20,909 | 90,822 |
+| jobtech | 8,858 | 27,329 |
+| himalayas | 13,011 | 23,251 |
+| 4dayweek | 732 | 21,627 |
+| infojobs | 14,556 | 21,341 |
+| gulftalent | 776 | 19,828 |
+| nofluffjobs | 426 | 19,712 |
+| jobdanmark | 5,813 | 15,931 |
+| jobnet | 6,949 | 14,485 |
+| tyomarkkinatori | 3,567 | 11,752 |
+| justjoin | 1,234 | 11,161 |
+| reed | 1,536 | 10,651 |
+| whatjobs | 3,182 | 9,523 |
+| powertofly | 30 | 9,023 |
+| hh | 4,864 | 8,979 |
+| telegram | 2,978 | 8,537 |
+| usajobs | 372 | 7,648 |
+| jobstash | 930 | 7,535 |
+| djinni | 2,202 | 6,904 |
+| arbeitnow | 2,568 | 6,373 |
+| wantedkr | 2,440 | 5,840 |
+| workatastartup | 1,434 | 5,213 |
+| arbeitsagentur | 2,067 | 4,612 |
+| vagas | 468 | 1,641 |
+| likeit | 16 | 1,422 |
+| thehub | 322 | 1,278 |
+| instaffo | 607 | 1,221 |
+| getonbrd | 313 | 1,156 |
+| habr_career | 184 | 1,106 |
+| remoteok | 935 | 1,067 |
+| functionalworks | 333 | 884 |
+| getmatch | 147 | 816 |
+| jobicy | 453 | 606 |
+| wantapply | 102 | 528 |
+| getro | 122 | 436 |
+| weworkremotely | 326 | 420 |
+| workablemarketplace | 2 | 373 |
+| geekjob | 177 | 280 |
+| startupandvc | 74 | 100 |
+| tecla | 37 | 64 |
+| workingnomads | 21 | 49 |
+| remotive | 23 | 38 |
+| getmanfred | 32 | 37 |
+| jobspresso | 14 | 18 |
+| topco | 4 | 11 |
+| teamex | 1 | 8 |
+
+## Company career sites
+
+**36 feeds · 66 companies · 35,160 open postings.**
+
+| Source | Companies | Open jobs |
+| --- | ---: | ---: |
+| amazon | 1 | 10,005 |
+| apple | 1 | 4,707 |
+| google | 7 | 3,582 |
+| sber | 10 | 3,220 |
+| alfabank | 1 | 2,385 |
+| tbank | 1 | 2,095 |
+| mts | 12 | 1,937 |
+| luxoft | 1 | 1,253 |
+| emagine | 1 | 1,033 |
+| epam | 1 | 896 |
+| yandex | 1 | 889 |
+| uber | 1 | 647 |
+| meta | 1 | 639 |
+| micro1 | 1 | 347 |
+| rwb | 1 | 326 |
+| vk | 1 | 259 |
+| bairesdev | 1 | 170 |
+| dataart | 1 | 139 |
+| avito | 1 | 133 |
+| lamoda | 1 | 100 |
+| vention | 1 | 66 |
+| alignerr | 1 | 55 |
+| globalpayments | 1 | 54 |
+| yandexcrowd | 1 | 34 |
+| domclick | 1 | 27 |
+| aviasales | 1 | 26 |
+| rapyd | 1 | 25 |
+| ozon | 1 | 22 |
+| northstone | 3 | 20 |
+| dodo | 3 | 19 |
+| 2gis | 1 | 19 |
+| lumenalta | 1 | 12 |
+| onstrider | 1 | 6 |
+| mtslink | 1 | 6 |
+| telegramcareers | 1 | 5 |
+| kuper | 1 | 2 |
+
+Plus **6** postings from manual bulk imports.


### PR DESCRIPTION
## Summary
- Adds a Discord badge to the README badge row (invite link already used in the site footer).
- Extracts the ~200-line per-source ATS/aggregator/company-site breakdown out of README into `docs/sources.md`, leaving a short summary + link in its place.
- Refreshes the counts from a fresh prod snapshot (3,445,246 open postings / 223,685 companies), including sources onboarded since the last snapshot (4dayweek, whatjobs, hibob, emagine).

## Test plan
- [x] Rendered both README.md and docs/sources.md locally to confirm markdown/table formatting
- [x] Cross-checked that ATS + aggregators + company-sites + manual-imports job counts sum to the total (3,445,246)