### PR TITLE
fix(mail-recall): send mail-recall link requests as JSON

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1438,7 +1438,7 @@ export function createApi(
   async function linkRecalledMail(slug: string, providerId: string): Promise<EmailBody> {
     return requestData<EmailBody>(
       `/api/v1/me/tracking/${encodeURIComponent(slug)}/mail-recall/link`,
-      { method: 'POST', body: JSON.stringify({ provider_id: providerId }) }
+      jsonBody('POST', { provider_id: providerId })
     );
   }
 


### PR DESCRIPTION
## Summary
- `linkRecalledMail` in `web/src/lib/api.ts` built its POST init by hand (`{ method, body: JSON.stringify(...) }`) instead of the shared `jsonBody` helper, so it never set `Content-Type: application/json`.
- With no explicit content type, the browser sends `text/plain;charset=UTF-8` for a string body — Fiber's `BodyParser` then skips JSON decoding and `provider_id` comes through empty, so the server correctly rejects it with `400 provider_id is required`.
- Prod logs (`freehire-api@blue/green`) confirm every real call to `POST /me/tracking/:slug/mail-recall/link` returns this same 400, since the endpoint shipped in #1531 — the "Link" button on a mail-recall suggestion has never worked.

## Fix
Route the call through `jsonBody('POST', { provider_id: providerId })`, the same helper every other JSON POST call site in `api.ts` already uses.

## Test plan
- [x] `pnpm exec tsc --noEmit` (after `svelte-kit sync`) shows no errors touching `api.ts`
- [ ] Manually click "Link" on a mail-recall suggestion in `/my/tracking/:slug` and confirm the message links instead of 400ing