### PR TITLE
fix(web): patch transitive cookie CVE-2024-47764 (Dependabot #2)

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  cookie@<0.7.0: 0.7.2
+
 importers:
 
   .:
@@ -1493,8 +1496,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   core-js@3.49.0:
@@ -3638,7 +3641,7 @@ snapshots:
       '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
       '@types/cookie': 0.6.0
       acorn: 8.17.0
-      cookie: 0.6.0
+      cookie: 0.7.2
       devalue: 5.8.2
       esm-env: 1.2.2
       kleur: 4.1.5
@@ -4005,7 +4008,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@0.6.0: {}
+  cookie@0.7.2: {}
 
   core-js@3.49.0: {}
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -6,3 +6,10 @@ allowBuilds:
 # build scripts are skipped. @sentry/cli is only needed for source-map upload
 # (gated on SENTRY_AUTH_TOKEN); core-js postinstall is non-critical.
 strictDepBuilds: false
+# @sveltejs/kit pins cookie@^0.6.0 on every 2.x release (GHSA-pxg6-pf52-xh8x /
+# CVE-2024-47764, low: out-of-bounds characters in cookie name/path/domain).
+# Pinned to the last 0.7.x patch, not an open '>=0.7.0' range: cookie has since
+# jumped to 1.x/2.x, and @sveltejs/kit has never declared support past 0.6/0.7 —
+# an unbounded override would silently ride a major bump its own tests never ran.
+overrides:
+  cookie@<0.7.0: 0.7.2


### PR DESCRIPTION
## Summary
- Fixes [Dependabot alert #2](https://github.com/strelov1/freehire/security/dependabot/2): `cookie` < 0.7.0 (GHSA-pxg6-pf52-xh8x / CVE-2024-47764, low) — out-of-bounds characters in cookie name/path/domain could overwrite other cookie fields.
- `@sveltejs/kit` pins `cookie@^0.6.0` on every 2.x release including the latest (2.70.2) and has never bumped it; added a pnpm override in `web/pnpm-workspace.yaml` pinning to `0.7.2` — the last 0.7.x patch, not an open `>=0.7.0` range, since `cookie` has since jumped to 1.x/2.x and SvelteKit's own tests have never run against those majors.

## Test plan
- [x] `svelte-check` — 0 errors (same 18 pre-existing baseline warnings)
- [x] `vitest run` — 78 files / 831 tests pass
- [x] `vite build` — succeeds