### PR TITLE
fix(web): redirect cold tailor bootstrap to match instead of erroring

### DIFF
--- a/web/src/routes/match/[slug]/+page.svelte
+++ b/web/src/routes/match/[slug]/+page.svelte
@@ -17,7 +17,7 @@
   }
 </script>
 
-<svelte:head><title>Fit analysis · {data.job.title}</title></svelte:head>
+<svelte:head><title>Match · {data.job.title}</title></svelte:head>
 
 <div class="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 sm:py-10">
   <!-- Editorial masthead -->

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -266,6 +266,17 @@
       // and the preview falls back to the template's own face meanwhile.
       void api.listCvFonts().then((f) => (fonts = f)).catch(() => {});
     } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        // The bootstrap (tailorCv) requires a cached match to already exist — true for
+        // every vacancy reached the normal way (the match page's "Tailor my CV" button
+        // only ever appears once one has run), but never true for a job that just came
+        // through the JD-intake dialog (paste text/URL/pick a vacancy — none of those
+        // run a match first). Rather than surface that as an error, send the candidate
+        // straight to the match page, which auto-runs on a cold start and hands them
+        // back here once it lands.
+        void goto(resolve('/match/[slug]', { slug }));
+        return;
+      }
       if (e instanceof ApiError && e.status === 402) {
         // Out of AI credits: surface the message plus when the monthly grant renews.
         const resetsAt = typeof e.body?.resets_at === 'string' ? e.body.resets_at : null;
@@ -435,7 +446,7 @@
   {:else if status === 'error'}
     <div class="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
       <p class="max-w-md text-sm text-destructive">{errorMsg}</p>
-      <a href={resolve('/match/[slug]', { slug })} class="text-sm text-brand hover:underline">Back to the fit analysis</a>
+      <a href={resolve('/match/[slug]', { slug })} class="text-sm text-brand hover:underline">Back to the match</a>
     </div>
   {:else}
     <div class="flex min-w-0 flex-1 flex-col lg:flex-row">


### PR DESCRIPTION
## Summary
- `/tailor/[slug]`'s bootstrap (`TailorCV`) requires a cached match analysis to already exist (409 otherwise). That was always true for the pre-existing entry point (the match page's "Tailor my CV" button only appears once a match has run), but is never true for any of the new jd-tailor-intake dialog's three tabs on `/my/cvs` (pick our vacancy / paste URL / paste text) — none of them run a match first, so all three landed on a raw 409 error on first use.
- On a 409, the bootstrap now redirects to `/match/[slug]` instead of showing an error. That page auto-runs the match on a cold start (`MatchAnalysisFull`'s `autoRun=true`) and hands the candidate back to `/tailor/[slug]` via its own "Tailor my CV" button once it lands.
- Renamed "fit analysis" -> "match" in the two places on this path (the `/match` page `<title>`, the tailor page's error-recovery link) to match the actual feature/route naming used everywhere else ("Analyze match" / "Tailor my CV").

## Test plan
- [x] `svelte-check` — 0 errors (same 18 pre-existing baseline warnings)
- [x] `vitest run` — 78 files / 831 tests pass
- [x] `vite build` — succeeds
- [ ] Not re-verified against a live backend in a browser (same limitation as the original jd-tailor-intake PR)