### PR TITLE
feat(header): add Discord link next to GitHub stars

### DIFF
--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -34,6 +34,12 @@
   import { cn } from '$lib/ui';
   import BrandMark from './BrandMark.svelte';
   import GithubStars from './GithubStars.svelte';
+  import ProviderIcon from './ProviderIcon.svelte';
+
+  // Same invite link as the footer's socials row (Footer.svelte) — no shared
+  // constant exists for it yet, so it's kept inline here like GITHUB_URL's
+  // counterpart in Footer.
+  const DISCORD_URL = 'https://discord.gg/aAXS2rghW';
 
   // The single menu absorbs the site nav, the signed-in account items, the theme
   // toggle, and the auth action — the header's only control besides search.
@@ -178,6 +184,17 @@
        into the drawer (below), leaving just the menu button here. -->
   <GithubStars class="hidden sm:inline-flex" />
 
+  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Discord invite, not an internal route -->
+  <a
+    href={DISCORD_URL}
+    target="_blank"
+    rel="noreferrer"
+    aria-label="freehire on Discord"
+    class={cn('hidden sm:inline-flex', iconButton)}
+  >
+    <ProviderIcon provider="discord" />
+  </a>
+
   <!-- Desktop only: theme toggle sits second, before the menu button. -->
   <button
     type="button"
@@ -316,6 +333,18 @@
       <!-- Mobile-only: GitHub + theme + auth pinned to the bottom of the drawer. -->
       <div class="shrink-0 border-t border-border p-2 sm:hidden">
         <GithubStars variant="row" class={cn(rowBase, 'text-muted-foreground')} />
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Discord invite, not an internal route -->
+        <a
+          href={DISCORD_URL}
+          target="_blank"
+          rel="noreferrer"
+          role="menuitem"
+          aria-label="freehire on Discord"
+          class={cn(rowBase, 'text-muted-foreground')}
+        >
+          <ProviderIcon provider="discord" class="size-4 shrink-0" />
+          <span>Discord</span>
+        </a>
         {@render themeButton()}
         {@render authButton()}
       </div>


### PR DESCRIPTION
## Summary
- Adds a Discord icon link next to the GitHub stars badge in the site header, on both the desktop bar and the mobile drawer's bottom action row.
- Mirrors the existing Discord invite and `ProviderIcon` glyph already used in the footer (`https://discord.gg/aAXS2rghW`).

## Test plan
- [x] `npx eslint src/lib/components/HeaderMenu.svelte` — clean
- [x] `npx svelte-check` — no new errors introduced (one pre-existing, unrelated error in `routes/jobs/[slug]/+page.svelte`)
- [x] Verified visually in a local dev server (desktop viewport): icon renders between the GitHub star count and the theme toggle