### PR TITLE
feat(web): CLI-edit button in the tailor workspace

### DIFF
--- a/web/src/lib/components/cv/CliEditDialog.svelte
+++ b/web/src/lib/components/cv/CliEditDialog.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { Dialog } from '$lib/ui';
+
+  // Points a candidate's own coding agent at this CV. The commands mirror the
+  // "Tailor a CV to a vacancy" block on /cli exactly, with this CV's own id filled
+  // in — copy-paste-ready rather than another <id> the reader has to substitute.
+  let { cvId, onClose }: { cvId: string; onClose: () => void } = $props();
+
+  let open = $state(true);
+  $effect(() => {
+    if (!open) onClose();
+  });
+</script>
+
+<Dialog bind:open title="Edit this CV from the CLI" class="max-w-lg">
+  <p class="text-sm leading-relaxed text-muted-foreground">
+    Give these commands to your own coding agent — it reads and writes this exact CV the same way
+    the in-app assistant does.
+  </p>
+  <pre
+    class="mt-3 overflow-x-auto rounded-md border border-border bg-background/60 p-3 font-mono text-sm leading-relaxed"><span class="text-muted-foreground">freehire</span> cv context {cvId}        <span class="text-muted-foreground"># the fit analysis to reframe toward</span>
+<span class="text-muted-foreground">freehire</span> cv get {cvId}            <span class="text-muted-foreground"># the CV document as JSON</span>
+<span class="text-muted-foreground">freehire</span> cv edit {cvId} --set …   <span class="text-muted-foreground"># one edit by path (--ops for a batch)</span>
+<span class="text-muted-foreground">freehire</span> cv render {cvId} --out cv.pdf</pre>
+  <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
+    You'll need your own
+    <a
+      href={resolve('/my/api-keys')}
+      class="font-medium text-foreground underline-offset-4 hover:underline">API key</a
+    > first, then install and sign in the CLI — full setup and the rest of the commands (search,
+    tracking, MCP) are on the
+    <a href={resolve('/cli')} class="font-medium text-foreground underline-offset-4 hover:underline"
+      >CLI reference</a
+    >.
+  </p>
+</Dialog>

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -13,11 +13,12 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import { ZoomIn, ZoomOut, Download, Menu, PanelLeftClose, PanelLeftOpen } from '@lucide/svelte';
+  import { ZoomIn, ZoomOut, Download, Menu, PanelLeftClose, PanelLeftOpen, Terminal } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { track } from '$lib/analytics';
   import AssistantChat from '$lib/assistant/AssistantChat.svelte';
   import ArtifactPanel from '$lib/tailor/ArtifactPanel.svelte';
+  import CliEditDialog from '$lib/components/cv/CliEditDialog.svelte';
   import CvHtmlPreview from '$lib/tailor/CvHtmlPreview.svelte';
   import CvSectionForm from '$lib/components/cv/CvSectionForm.svelte';
   import MarginSettings from '$lib/components/cv/MarginSettings.svelte';
@@ -104,6 +105,7 @@
   // Folded to a rail so the centre CV preview can take the width. Desktop-only: below lg the
   // columns already show one at a time, and collapsing there would hide a view with no way back.
   let leftCollapsed = $state(false);
+  let cliDialogOpen = $state(false);
   let leftPanelEl = $state<HTMLElement>();
   let leftResizing = false;
 
@@ -531,6 +533,14 @@
             {/if}
             <button
               type="button"
+              onclick={() => (cliDialogOpen = true)}
+              aria-label="Edit this CV from the CLI"
+              class="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <Terminal class="size-4" />
+            </button>
+            <button
+              type="button"
               onclick={() => (leftCollapsed = true)}
               aria-label="Collapse the editor panel"
               class="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
@@ -660,5 +670,8 @@
         mobileVisible={mobileView === 'jd' || mobileView === 'jobmatch' || mobileView === 'score'}
       />
     </div>
+  {/if}
+  {#if cliDialogOpen}
+    <CliEditDialog {cvId} onClose={() => (cliDialogOpen = false)} />
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- Adds a Terminal-icon button to the tailor workspace's left-panel toolbar (next to the collapse button), opening a dialog with ready-to-run `freehire cv context/get/edit/render <id>` commands for that exact CV — a shortcut into the CLI commands already documented on `/cli`.
- Points to `/my/api-keys` for a key and `/cli` for full setup (auth, MCP, the rest of the reference).
- No backend changes — the CLI/MCP surface and `cv`-scoped key admission already support this.

## Test plan
- [x] `svelte-check` (0 errors), `eslint` on touched files (clean), `vitest run` (827 tests)
- [x] Production `vite build` — clean
- [x] Visual check via a throwaway route + headless Chrome screenshot — dialog renders correctly with the real cv id substituted into each command