### PR TITLE
feat(assistant): job_match tool for live deterministic feedback during tailoring

### DIFF
--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -145,6 +145,7 @@ Mechanics:
 - Keep the CV to one or two pages. Prefer sharpening existing bullets over adding new ones.
 - Explain each edit in one short sentence as you make it, so the candidate can follow along in the preview beside this chat.
 - Do NOT restate the fit analysis. The verdict, the score and the dimension comments are open in a panel beside this chat; repeating them spends the turn on something the candidate is already looking at. Open with what you are about to do, not with what you read.
+- ` + "`job_match`" + ` reads a DIFFERENT score than the fit analysis above — recomputed fresh from what the CV currently says, no model call, so it moves as you edit. Call it after a batch of edits to check their effect; it costs nothing and needs no explaining to the candidate, who has the same panel open beside this chat.
 - If the conversation turns to other vacancies, show them ONLY by calling ` + "`present_jobs`" + ` — never write a vacancy's link into your text. Tailoring this CV stays the job; do not go looking for vacancies unasked.
 
 UNATTENDED RUNS

--- a/internal/handler/assistant_cv_job_match_test.go
+++ b/internal/handler/assistant_cv_job_match_test.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// jobMatchToolAPI wires job_match over the same fakes cv_job_match_test.go and
+// assistant_cv_context_test.go already use, so this test needs no renderer, no database,
+// and no model.
+func jobMatchToolAPI(t *testing.T, doc string, job db.Job, analysis string) (*assistantHandlers, *cvRepo) {
+	t.Helper()
+	repo := &cvRepo{id: testCVID, userID: 3, jobID: 9, data: []byte(doc)}
+	h := &cvHandlers{
+		cvStore:            cv.NewStore(repo),
+		cvRenderer:         &fakeCVRenderer{pdf: []byte(scorableCV)},
+		extractPDFText:     textFromPDF,
+		jobReader:          jobStub{job: job},
+		matchAnalysisCache: analysisCache{analysis: analysis},
+	}
+	return &assistantHandlers{cv: h}, repo
+}
+
+func TestJobMatchToolScoresTheCurrentCV(t *testing.T) {
+	a, _ := jobMatchToolAPI(t, oneExperienceCV,
+		db.Job{Title: "Senior Backend Engineer", Skills: []string{"go", "kafka", "terraform"}},
+		twoRequirementAnalysis)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "job_match")
+	out, err := tool.Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("job_match: %v", err)
+	}
+	payload, _ := json.Marshal(out)
+	var got struct {
+		Available bool `json:"available"`
+		Score     struct {
+			Overall       int      `json:"overall"`
+			MissingSkills []string `json:"missing_skills"`
+		} `json:"score"`
+	}
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal: %v (payload=%s)", err, payload)
+	}
+	if !got.Available {
+		t.Fatalf("available = false, want true (payload=%s)", payload)
+	}
+	// The fake renderer's text layer (scorableCV) names Go and Kafka but not Terraform.
+	if len(got.Score.MissingSkills) != 1 || got.Score.MissingSkills[0] != "terraform" {
+		t.Errorf("missing skills = %v, want [terraform]", got.Score.MissingSkills)
+	}
+	if got.Score.Overall <= 0 {
+		t.Errorf("overall = %d, want a positive score", got.Score.Overall)
+	}
+}
+
+// A CV re-scores after an edit changes what its rendered text says — this is the whole
+// point of the tool over the cached fit analysis, which must NOT be recomputed mid-turn.
+func TestJobMatchToolReflectsAnEditedDocument(t *testing.T) {
+	a, repo := jobMatchToolAPI(t, oneExperienceCV,
+		db.Job{Title: "Senior Backend Engineer", Skills: []string{"go", "kafka", "terraform"}},
+		twoRequirementAnalysis)
+	tools := a.assistantCVTools(testCVID, 9, uuid.New())
+
+	before, err := toolByName(t, tools, "job_match").Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("job_match (before): %v", err)
+	}
+
+	// Swap in a CV whose rendered text now names Terraform too — the renderer is a fake
+	// keyed on nothing but its own field, so this stands in for the workspace's own
+	// render-after-save without touching cvedit at all.
+	a.cv.cvRenderer = &fakeCVRenderer{pdf: []byte(scorableCV + "\nTerraform")}
+	_ = repo // repo's stored document is irrelevant here — the renderer decides the text.
+
+	after, err := toolByName(t, tools, "job_match").Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("job_match (after): %v", err)
+	}
+
+	beforePayload, _ := json.Marshal(before)
+	afterPayload, _ := json.Marshal(after)
+	if string(beforePayload) == string(afterPayload) {
+		t.Errorf("score did not change after the rendered text changed: %s", beforePayload)
+	}
+}

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -14,6 +14,7 @@ import (
 	"github.com/strelov1/freehire/internal/assistant"
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/cvedit"
+	"github.com/strelov1/freehire/internal/cvmatch"
 	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/matchanalysis"
 )
@@ -63,6 +64,7 @@ func (h *assistantHandlers) assistantCVTools(cvID uuid.UUID, jobID int64, batchI
 		h.cvEditTool(cvID, batchID),
 		h.tailorReportTool(cvID),
 		h.requestConfirmationTool(),
+		h.cvJobMatchTool(cvID, jobID),
 	}
 }
 
@@ -194,6 +196,55 @@ func (h *assistantHandlers) cvContextTool(jobID int64) assistant.Tool {
 				return nil, err
 			}
 			return h.withBankEvidence(ctx, userID, base), nil
+		},
+	}
+}
+
+// cvJobMatchTool lets the tailoring agent read the deterministic CV-vs-vacancy score as
+// feedback on what it has changed. It is a different signal from cv_context's Verdict/
+// OverallScore: those come from the cached LLM fit analysis and MUST NOT be recomputed
+// mid-tailoring (internal/matchanalysis, cv-tailoring spec), while this recomputes fresh off
+// the CV's own rendered text every call — the same read GetCVJobMatch serves the workspace
+// panel, which already refreshes after every saved edit. No model call, so it costs nothing
+// to check after a batch of edits.
+func (h *assistantHandlers) cvJobMatchTool(cvID uuid.UUID, jobID int64) assistant.Tool {
+	return assistant.Tool{
+		Name: "job_match",
+		Description: "Read how well the CV currently scores against this vacancy — Requirements Coverage, " +
+			"Keyword Match, Job Title Match, Seniority Fit — recomputed fresh from what the CV says right now, " +
+			"not the cached fit analysis. Call it after a batch of edits to see their effect; no model call.",
+		Schema: map[string]any{"type": "object", "properties": map[string]any{}},
+		Run: func(ctx context.Context, userID int64, raw json.RawMessage) (any, error) {
+			var in struct{}
+			if err := assistant.DecodeArgs(raw, &in); err != nil {
+				return nil, err
+			}
+			rec, err := h.cv.cvStore.GetForModel(ctx, cvID, userID)
+			if err != nil {
+				return nil, cvToolError(err)
+			}
+			tmpl, err := cv.ResolveTemplate(rec.TemplateID)
+			if err != nil {
+				return nil, cvToolError(err)
+			}
+			job, err := h.cv.jobReader.GetJob(ctx, jobID)
+			if err != nil {
+				return nil, err
+			}
+			analysis, hasAnalysis := h.cv.cachedAnalysisOrNone(ctx, userID, jobID)
+			score, err := h.cv.cvJobMatchScore(ctx, rec.Document, tmpl, cvmatch.Input{
+				JobTitle:     job.Title,
+				JobSkills:    job.Skills,
+				Requirements: cvJobMatchRequirements(analysis),
+				HasAnalysis:  hasAnalysis,
+			})
+			if err != nil {
+				return map[string]any{"available": false, "reason": "could not compute a score right now"}, nil
+			}
+			if len(score.Contributing) == 0 {
+				return map[string]any{"available": false, "reason": "nothing about this vacancy could be matched automatically"}, nil
+			}
+			return map[string]any{"available": true, "score": score}, nil
 		},
 	}
 }


### PR DESCRIPTION
## Summary
The tailor workspace's Job Match panel already refreshes live off the deterministic `internal/cvmatch` score after every saved edit, agent turn, and undo (per `openspec/specs/tailor-job-match`) — but the tailoring agent itself had no way to read it during a turn, only the cached LLM fit-analysis verdict via `cv_context` (which must not be recomputed mid-tailoring).

Adds `job_match`, a new read-only tool for the `tailor` preset: recomputes the score fresh from the CV's current rendered text on every call (no model call, mirrors `GetCVJobMatch`), so the agent can check the effect of a batch of edits — Requirements Coverage, Keyword Match, Job Title Match, Seniority Fit.

## Test plan
- [x] `go build`, `go vet`, `go vet -tags=integration`, `go test ./...` — all clean
- [x] New tests: score reflects the current CV; `TestPromptOnlyNamesToolsThePresetHas` still passes with the new tool named in the prompt and registered only for `tailor`