### PR TITLE
feat(sources): onboard 6 crowdsourced board contributions

### DIFF
--- a/sources/hibob.yml
+++ b/sources/hibob.yml
@@ -37,3 +37,5 @@
   board: thegappartnership
 - company: Unique
   board: unique
+- company: Entrepreneur First
+  board: entrepreneursfirst

--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -746,3 +746,5 @@
   board: vaas
 - company: "ed"
   board: somosed
+- company: Dataside
+  board: dataside

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4453,3 +4453,5 @@
   board: ltjgroup
 - company: Social Influence LLC
   board: print-recruiting
+- company: Volkswagen Group Digital Solutions
+  board: vwgds

--- a/sources/peopleforce.yml
+++ b/sources/peopleforce.yml
@@ -136,3 +136,5 @@
   board: octogamesstudio
 - company: Arctic7
   board: arctic7
+- company: Rootstrap
+  board: rootstrap

--- a/sources/radancy.yml
+++ b/sources/radancy.yml
@@ -7,3 +7,5 @@
   board: careers.ing.com
 - company: Intuit
   board: jobs.intuit.com
+- company: Moody's
+  board: careers.moodys.com

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3241,3 +3241,5 @@
   board: wivetix.teamtailor.com
 - company: Workyn! Recrutement
   board: workyn.teamtailor.com
+- company: Flylance
+  board: careers.flylance.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -2095,3 +2095,5 @@
   board: winthrop-technologies
 - company: Xcellink Pte Ltd
   board: xcellink
+- company: Stakemate
+  board: stakemate


### PR DESCRIPTION
## Summary
Drains 6 `pending` rows from `link_contributions` (the crowdsourced "contribute a board" flow) into their provider board files. Each board was live-validated directly against its ATS endpoint before adding — see per-row notes below.

| id | source/board | company | validation |
|---|---|---|---|
| 171 | workable/stakemate | Stakemate | widget API returns active postings |
| 173 | peopleforce/rootstrap | Rootstrap | `/careers?page=1` lists active postings |
| 177 | inhire/dataside | Dataside | `X-Tenant: dataside` returns non-empty `jobsPage` |
| 185 | radancy/careers.moodys.com | Moody's | sitemap lists live job pages |
| 197 | teamtailor/careers.flylance.com | Flylance | `/jobs` listing has active postings |
| 201 | hibob/entrepreneursfirst | Entrepreneur First | `/api/job-ad` returns postings |
| 203 | lever/vwgds | Volkswagen Group Digital Solutions | EU tenant (`api.eu.lever.co`), adapter's global→EU fallback already handles this |

id=167 (`workable/derq`) was already present in `sources/workable.yml` — no file change needed, just a status flip on the row.

Not included: id=196 (`manatal`, submitted board `jobs`) — this is a recognizer defect, not a dead board. The submitted URL is the subdomain-style Manatal format (`murano-global.careers-page.com/jobs/...`), but `internal/atsboard`'s `careers-page.com` rule only handles the path-style format and read the first path segment (`jobs`) as the board instead of the subdomain (`murano-global`). Flagging as a follow-up rather than onboarding a board field known to be wrong.

Prod `link_contributions.status` will be flipped to `onboarded`/`rejected` after this merges and deploys (crawling begins on the next ingest cycle).

## Test plan
- [x] `go build ./...`