### PR TITLE
fix(sources): fetch pageup job description from detail page when listing has none

### DIFF
--- a/internal/sources/pageup.go
+++ b/internal/sources/pageup.go
@@ -13,11 +13,13 @@ import (
 // education. Every tenant is served keylessly through the canonical host
 // careers.pageuppeople.com/<instID>/, so the board is the numeric institution id (e.g.
 // "513"). The listing endpoint returns a JSON envelope whose "results" field is a rendered
-// HTML fragment; the row wrapper differs per tenant (a <tr> table or a <li> list), so parsing
-// keys on the cross-tenant-stable a.job-link anchor and pairs each job with the location and
-// summary that follow it in document order. Posted date and the full description live only on
-// the per-tenant detail page (whose markup varies too), so this list-only adapter carries the
-// listing's summary snippet; a detail fan-out is a possible later enrichment.
+// HTML fragment; the row wrapper differs per tenant (a <tr> table, a <li> list, or a <div>
+// card), so parsing keys on the cross-tenant-stable a.job-link anchor and pairs each job
+// with the location and summary that follow it in document order. Most tenants' listings
+// carry a usable summary; a minority render nothing of the kind, so a job that comes out of
+// pageupParseListing with no description gets one more fetch against its own detail page
+// (see detailDescription) — bounded so tenants whose listing already has a summary never
+// pay the extra request. Posted date is not exposed by either endpoint.
 type pageup struct {
 	http pageupHTTP
 }
@@ -63,7 +65,53 @@ func (p pageup) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	for i := range jobs {
 		jobs[i].Company = e.Company
 	}
+
+	// Some tenants' listing rows carry no summary of any shape (e.g. board 798) — the
+	// full text lives only on the job's own detail page. Fan out just for those, so
+	// tenants whose listing already carries a summary never pay the extra request.
+	var need []int
+	for i, j := range jobs {
+		if j.Description == "" {
+			need = append(need, i)
+		}
+	}
+	if len(need) > 0 {
+		filled := fetchDetails(need, defaultDetailWorkers, func(i int) (Job, bool) {
+			j := jobs[i]
+			j.Description = p.detailDescription(ctx, j.URL)
+			return j, true
+		})
+		for k, i := range need {
+			jobs[i] = filled[k]
+		}
+	}
 	return jobs, nil
+}
+
+// pageupDetailDescriptionID is the container the detail page's XHR envelope wraps the full
+// posting body in, on tenants whose listing omits a summary (confirmed on board 798). It
+// is a platform template id, not something a tenant's own theme reliably reuses — a tenant
+// whose detail markup uses a different container (board 709, which needs no detail fetch
+// since its listing already carries a summary) simply yields "" here, same as a fetch
+// failure: the posting keeps its empty description rather than being dropped.
+const pageupDetailDescriptionID = "job-details"
+
+// detailDescription fetches one job's detail page and returns its sanitized description
+// HTML, or "" when the fetch fails or the known container is absent.
+func (p pageup) detailDescription(ctx context.Context, jobURL string) string {
+	var env pageupEnvelope
+	if err := p.http.GetJSONWithHeaders(ctx, jobURL, pageupXHR, &env); err != nil {
+		return ""
+	}
+	root, err := html.Parse(strings.NewReader(env.Results))
+	if err != nil {
+		return ""
+	}
+	node := firstByID(root, pageupDetailDescriptionID)
+	if node == nil {
+		return ""
+	}
+	return sanitizeHTML(innerHTML(node))
 }
 
 // pageupParseListing parses a search-results HTML fragment into jobs. It walks the DOM in
@@ -114,6 +162,10 @@ func pageupParseListing(fragment, board string) ([]Job, error) {
 		case hasClass(n, "location") && cur.Location == "":
 			cur.Location = textContent(n)
 		case (hasClass(n, "jobs-summary") || hasClass(n, "summary")) && cur.Description == "":
+			cur.Description = textContent(n)
+		// Some tenants render the summary as a bare <p> with no class at all (e.g. board
+		// 709); catch it too, so long as nothing has claimed the description yet.
+		case n.Data == "p" && attr(n, "class") == "" && cur.Description == "":
 			cur.Description = textContent(n)
 		}
 		return true

--- a/internal/sources/pageup_test.go
+++ b/internal/sources/pageup_test.go
@@ -1,6 +1,38 @@
 package sources
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakePageup serves the search envelope from search and each job's detail envelope from
+// detail (keyed by the job's full URL), recording every URL fetched and the XHR header
+// sent — both the listing and the detail endpoint require it, or the tenant 302s to the
+// full HTML page instead of the JSON envelope.
+type fakePageup struct {
+	search string
+	detail map[string]string
+	calls  []string
+}
+
+func (f *fakePageup) GetJSONWithHeaders(_ context.Context, url string, headers map[string]string, v any) error {
+	f.calls = append(f.calls, url)
+	if headers["X-Requested-With"] != "XMLHttpRequest" {
+		return errors.New("fakePageup: missing XHR header")
+	}
+	if strings.Contains(url, "/search/") {
+		return json.Unmarshal([]byte(f.search), v)
+	}
+	raw, ok := f.detail[url]
+	if !ok {
+		return fmt.Errorf("fakePageup: no canned detail for %s", url)
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
 
 // A tenant's fragment is homogeneous — Monash renders a <tr> table, Melbourne Water a <li>
 // list. Each is tested on its own valid fragment (mixing the two in one document would
@@ -30,6 +62,21 @@ const pageupListFixture = `
     <p class="jobs-summary">Lead education and events programs.</p>
   </li>
 </ul>`
+
+// A third tenant shape (e.g. board 709): the summary is a bare, unclassed <p> — no
+// "summary"/"jobs-summary" class anywhere — sitting right after the title, with the
+// location tucked inside a classed <li> further down.
+const pageupCardFixture = `
+<div class="job-listing">
+  <div class="job-listing-left">
+    <h3 class="job-listing-title"><a class="job-link" href="/709/cw/en/job/501297/senior-quantity-surveyor-indonesia">Senior Quantity Surveyor, Indonesia</a></h3>
+    <p>Currently, Leighton Contractors Indonesia is looking for a Quantity Surveyor.</p>
+  </div>
+  <ul class="job-listing-meta">
+    <li><span class="categories">Commercial / Project Finance</span></li>
+    <li><span class="location">Indonesia</span></li>
+  </ul>
+</div>`
 
 func TestPageupParseListing(t *testing.T) {
 	t.Run("table layout", func(t *testing.T) {
@@ -71,4 +118,89 @@ func TestPageupParseListing(t *testing.T) {
 			t.Errorf("Description = %q", j.Description)
 		}
 	})
+
+	t.Run("card layout with unclassed summary paragraph", func(t *testing.T) {
+		jobs, err := pageupParseListing(pageupCardFixture, "709")
+		if err != nil {
+			t.Fatalf("pageupParseListing: %v", err)
+		}
+		if len(jobs) != 1 {
+			t.Fatalf("got %d jobs, want 1: %+v", len(jobs), jobs)
+		}
+		j := jobs[0]
+		if j.ExternalID != "501297" || j.Location != "Indonesia" {
+			t.Errorf("id/loc = %q/%q", j.ExternalID, j.Location)
+		}
+		if j.Description != "Currently, Leighton Contractors Indonesia is looking for a Quantity Surveyor." {
+			t.Errorf("Description = %q", j.Description)
+		}
+	})
+}
+
+// pageupNoSummaryFixture mirrors board 798: the listing row carries nothing but the link
+// and a department name — no summary of any shape — so the description can only come
+// from a detail-page fetch.
+const pageupNoSummaryFixture = `
+  <tr>
+    <td><a class="job-link" href="/798/cw/en/job/496049/senior-application-development-manager">Senior Application Development Manager</a></td>
+    <td>Information Technology Department</td>
+  </tr>`
+
+func TestPageupFetchFallsBackToDetailPageWhenListingHasNoSummary(t *testing.T) {
+	jobURL := "https://careers.pageuppeople.com/798/cw/en/job/496049/senior-application-development-manager"
+	fake := &fakePageup{
+		search: fmt.Sprintf(`{"results":%q}`, pageupNoSummaryFixture),
+		detail: map[string]string{
+			jobURL: `{"results":"<h2>Senior Application Development Manager</h2><div id=\"job-details\"><p>Own the delivery of trading systems.</p></div>"}`,
+		},
+	}
+
+	jobs, err := NewPageUp(fake).Fetch(context.Background(), CompanyEntry{Company: "Bank", Provider: "pageup", Board: "798"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1: %+v", len(jobs), jobs)
+	}
+	if got := jobs[0].Description; got != "<p>Own the delivery of trading systems.</p>" {
+		t.Errorf("Description = %q", got)
+	}
+	if len(fake.calls) != 2 || fake.calls[1] != jobURL {
+		t.Errorf("calls = %v, want the search URL then exactly %q", fake.calls, jobURL)
+	}
+}
+
+func TestPageupFetchSkipsDetailFetchWhenListingAlreadyHasSummary(t *testing.T) {
+	fake := &fakePageup{
+		search: fmt.Sprintf(`{"results":%q}`, pageupTableFixture),
+	}
+
+	jobs, err := NewPageUp(fake).Fetch(context.Background(), CompanyEntry{Company: "Monash", Provider: "pageup", Board: "513"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Description != "Support the University's audiovisual design team." {
+		t.Fatalf("jobs = %+v", jobs)
+	}
+	if len(fake.calls) != 1 {
+		t.Errorf("calls = %v, want only the search request — no detail fetch when the listing already has a summary", fake.calls)
+	}
+}
+
+func TestPageupFetchDetailFailureLeavesDescriptionEmptyRatherThanDroppingTheJob(t *testing.T) {
+	fake := &fakePageup{
+		search: fmt.Sprintf(`{"results":%q}`, pageupNoSummaryFixture),
+		detail: map[string]string{}, // no canned detail → fakePageup errors on the fetch
+	}
+
+	jobs, err := NewPageUp(fake).Fetch(context.Background(), CompanyEntry{Company: "Bank", Provider: "pageup", Board: "798"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (a failed detail fetch must not drop the posting): %+v", len(jobs), jobs)
+	}
+	if jobs[0].Description != "" {
+		t.Errorf("Description = %q, want empty", jobs[0].Description)
+	}
 }


### PR DESCRIPTION
## Summary
- Some PageUp tenants (board 798: 234 postings, 100% of the board) render listing rows with no summary snippet at all, so `description` stayed permanently empty. Others (board 709: 43 postings) do carry a summary in the listing, but under a bare, unclassed `<p>` the parser's class-based matching missed.
- Widen `pageupParseListing`'s summary heuristic to also accept an unclassed `<p>` — fixes board-709-shaped tenants with zero extra HTTP requests.
- For postings that still come out with no description, fall back to a bounded (8-worker) per-job detail-page fetch, reusing the same XHR-header trick as the listing endpoint. Tenants whose listing already has a summary never pay the extra request (asserted by test).
- A failed or unmatched detail fetch leaves the posting with an empty description rather than dropping it — same degrade-gracefully behavior as today.

Root-caused via a live spike against the two affected tenants before implementing (confirmed the XHR envelope works on detail pages too, and that a single cross-tenant CSS selector for the description container isn't reliable across tenants).

## Test plan
- [x] `go test ./internal/sources/...` — new + existing pageup tests pass
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean
- [x] Verified against live PageUp endpoints (boards 798/709) during the spike that the fixture markup matches production