### PR TITLE
feat(sources): onboard 9 boards drained from the review queue

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7752,3 +7752,5 @@
 # the posting URL carries it — "it-labs" 404s, "it labs" is the real board.
 - company: IT Labs
   board: it%20labs
+- company: Surge AI
+  board: surge-ai

--- a/sources/comeet.yml
+++ b/sources/comeet.yml
@@ -46,3 +46,7 @@
   board: musegroup/FA.001
 - company: Zesty
   board: zesty/06.000
+- company: Dream
+  board: dreamgroup/99.002
+- company: Cognyte
+  board: cognyte/F2.009

--- a/sources/join.yml
+++ b/sources/join.yml
@@ -8394,3 +8394,12 @@
 
 - company: Wowflow GmbH # wowflow
   board: "101037"
+
+- company: Your Software Supplier # yoursoftwaresuppliercom
+  board: "163368"
+- company: Revent # revent1
+  board: "48627"
+- company: Stetig # stetigcom
+  board: "185256"
+- company: senvo GmbH # senvo
+  board: "143084"

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -1268,3 +1268,5 @@
   board: messiah-ibvrjb.fa.ocs.oraclecloud.com/CX_1
 - company: Saint Michael's College
   board: stmichaels-ibukjb.fa.ocs.oraclecloud.com/CX_2
+- company: Dell
+  board: enterpriseplatform.dell.com/CX_1001

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -8145,3 +8145,5 @@
   board: tierarztpluspartner
 - company: Viva 1 GmbH & Co. KG
   board: viva-fitness
+- company: Holidu
+  board: holidu


### PR DESCRIPTION
## Summary
Drains the `review` queue of `link_contributions` (unrecognized-link submissions where `atsboard.Recognize` couldn't map the URL to a supported ATS) — 9 rows turned out to already be on a platform we support once fetched by hand and checked against the adapter's real API, not the URL pattern.

| id | url | source/board | company | validation |
|---|---|---|---|---|
| 169 | join.com/companies/yoursoftwaresuppliercom/... | join/163368 | Your Software Supplier | resolved numeric company id via `/api/public/jobs/<jobId>`, list API returns 2 jobs |
| 176 | join.com/companies/revent1/... | join/48627 | Revent | same method, 3 jobs |
| 178 | join.com/companies/stetigcom/... | join/185256 | Stetig | same method, 1 job |
| 189 | join.com/companies/senvo/... | join/143084 | senvo GmbH | same method, 1 job |
| 179 | enterpriseplatform.dell.com/hcmUI/... | oracle/enterpriseplatform.dell.com/CX_1001 | Dell | Dell fronts Oracle Recruiting Cloud on its own vanity domain; `recruitingCEJobRequisitions` on that same host returns live requisitions |
| 79 | dreamgroup.com/comeet-positions/... | comeet/dreamgroup/99.002 | Dream | Comeet widget embed, careers-api returns 32 positions |
| 195 | cognyte.com/careers/... | comeet/cognyte/F2.009 | Cognyte | Comeet widget embed, careers-api returns 51 positions |
| 187 | surgehq.ai/careers | ashby/surge-ai | Surge AI | posting-api returns 31 jobs |
| 194 | holidu.com/careers/... | personio/holidu | Holidu | `holidu.jobs.personio.com/xml` returns 66 positions |

Not included (handled separately, no file change needed):
- id=198 (`realcorecrutamento.gupy.io`, companyId 21289) — already onboarded by an earlier pass (#1107); just needs its `link_contributions` row promoted.
- ids 170/175 (Gupy `unicredbr`→6670, `techne`→189) — same board already tracked under different discovery; row promotion only.
- 15 other review rows are dead links, already covered by another source, or recruiting-agency intermediaries — rejected, not onboarded.
- A handful (mission.dev, JobConvo, HRPanda, Aptrack, recrut.ai) are real multi-tenant ATS platforms we don't support yet — left in `review` as new-adapter leads rather than forced or rejected.

## Test plan
- [x] `go build ./...`