### PR TITLE
feat(sources): onboard CBTS (eightfold) and Bedrock Talent (ashby)

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7754,3 +7754,5 @@
   board: it%20labs
 - company: Surge AI
   board: surge-ai
+- company: Bedrock Talent
+  board: bedrock-talent

--- a/sources/eightfold.yml
+++ b/sources/eightfold.yml
@@ -119,3 +119,5 @@
   board: netapp.eightfold.ai/netapp.com
 - company: Hasbro
   board: careers.hasbro.com/hasbro.com
+- company: CBTS
+  board: jobs.cbts.com/cbts.com


### PR DESCRIPTION
## Summary
Two small follow-ups found while closing out the review-queue drain:
- id=166 (`jobs.cbts.com`) was a review row missed in #1566's triage — it's Eightfold (`api/pcsx/search?domain=cbts.com`), 72 live postings.
- id=204 (`ashby/bedrock-talent`) is a fresh pending contribution that arrived mid-session — already recognized, 14 live postings, no triage needed.

## Test plan
- [x] `go build ./...`