### PR TITLE
fix(sources): read peopleforce description from the Tailwind-themed detail layout too

### DIFF
--- a/internal/sources/peopleforce.go
+++ b/internal/sources/peopleforce.go
@@ -99,7 +99,14 @@ func (s peopleforce) detail(ctx context.Context, e CompanyEntry, c peopleforceLi
 	fields := peopleforceDefList(root)
 	location := fields["Location"]
 	description := ""
-	if col := firstByClass(root, "col-lg-8"); col != nil {
+	col := firstByClass(root, "col-lg-8")
+	if col == nil {
+		// PeopleForce is mid-rollout of a Tailwind-based theme: a tenant on the new theme
+		// renders the same column prefixed "tw-", so a board can carry a mix of both across
+		// its own postings depending on when each was last touched on their end.
+		col = firstByClass(root, "tw-col-lg-8")
+	}
+	if col != nil {
 		description = sanitizeHTML(innerHTML(col))
 	}
 

--- a/internal/sources/peopleforce_test.go
+++ b/internal/sources/peopleforce_test.go
@@ -45,6 +45,20 @@ func peopleforceDetailHTML(workType, location string) string {
 </div></body></html>`
 }
 
+// peopleforceDetailHTMLTailwind mirrors a tenant already migrated to PeopleForce's newer
+// theme, which renders the same layout with Tailwind-prefixed classes ("tw-col-lg-8"
+// instead of "col-lg-8") — seen live on boards mid-rollout (e.g. vyriy, unitedsoftware).
+func peopleforceDetailHTMLTailwind(location string) string {
+	return `<html><body>
+<h1>Work at Acme</h1>
+<div class="tw-row">
+  <div class="tw-col-lg-8 tw-col-12">
+    <h2>About the role</h2><p>Build things.</p>
+  </div>
+  <div class="tw-col-lg-4 tw-col-12"><dl><dt>Location</dt><dd>` + location + `</dd></dl></div>
+</div></body></html>`
+}
+
 func TestPeopleForceProvider(t *testing.T) {
 	if got := NewPeopleForce(nil).Provider(); got != "peopleforce" {
 		t.Errorf("Provider() = %q, want %q", got, "peopleforce")
@@ -105,6 +119,30 @@ func TestPeopleForceFetchListingThenDetailAndMaps(t *testing.T) {
 	}
 	if !strings.Contains(j.Description, "About the role") || !strings.Contains(j.Description, "Build things") {
 		t.Errorf("Description lost real content: %q", j.Description)
+	}
+}
+
+func TestPeopleForceFetchReadsDescriptionFromTailwindThemedDetailPage(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("?page=1", peopleforceListingHTML([2]string{"229080-marketing-ops", "Marketing Operations Manager"})).
+		route("?page=2", emptyPeopleforceListingHTML).
+		route("/careers/v/229080-marketing-ops", peopleforceDetailHTMLTailwind("Kyiv"))
+
+	jobs, err := NewPeopleForce(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "peopleforce", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.Location != "Kyiv" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if !strings.Contains(j.Description, "About the role") || !strings.Contains(j.Description, "Build things") {
+		t.Errorf("Description empty or lost content on the Tailwind-themed layout: %q", j.Description)
 	}
 }
 


### PR DESCRIPTION
## Summary
- PeopleForce is mid-rollout of a Tailwind-based theme across tenants: a migrated tenant renders the description column as `tw-col-lg-8` instead of the Bootstrap `col-lg-8` the adapter looked for. Confirmed live: 435/1168 currently-open peopleforce postings have an empty description, spread unevenly across ~20 tenants (some 100% affected, some 0% — consistent with a gradual per-tenant rollout rather than a one-time global change).
- `UpsertJob` never overwrites a stored description with an empty re-crawl (`COALESCE(NULLIF(EXCLUDED.description, ''), jobs.description)`), so already-populated postings are safe — but any posting first ingested after its tenant's migration gets stuck permanently empty.
- Fall back to `tw-col-lg-8` when `col-lg-8` is absent. Checked: no public JSON API or JSON-LD behind these pages (`.json` suffix and `Accept: application/json` both 406 `text/html`) — HTML scraping is the only option here, so this keeps the existing approach rather than switching data source.

## Test plan
- [x] `go test ./internal/sources/...` — new + existing peopleforce tests pass
- [x] `go build ./...`, `go vet ./...` clean
- [x] Verified against live tenants (vyriy, kinggroup, unitedsoftware) during investigation that the fixture markup matches production