### PR TITLE
fix(assistant): cv_edit self-reports the requirement it closes

### DIFF
--- a/internal/assistant/preset_test.go
+++ b/internal/assistant/preset_test.go
@@ -45,6 +45,20 @@ func TestOnlyTheChatPresetIsToldAboutMail(t *testing.T) {
 	}
 }
 
+// cv_edit and tailor_report write two different columns through two different tool
+// calls, with nothing tying them together unless the agent is told to pass
+// requirement/requirement_status on the edit that closes one — otherwise a document
+// change with no follow-up tailor_report call leaves that requirement's report entry
+// stale.
+func TestTailorPromptTellsTheAgentToSelfReportAClosedRequirement(t *testing.T) {
+	p := SystemPrompt(PresetTailor)
+	for _, want := range []string{"requirement_status", "closed_bank", "closed_candidate"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("the tailor prompt never says %q about cv_edit closing a requirement", want)
+		}
+	}
+}
+
 // A rehearsal runs on the candidate's own recorded experience, and the bank is where
 // that lives — so the prompt has to state the one rule the service cannot enforce.
 // experience_add takes `said` as a string and stamps stated_in_chat either way, so

--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -126,7 +126,7 @@ Start by calling ` + "`cv_context`" + ` (the fit analysis for this vacancy) and 
 
 Then work the list ONE REQUIREMENT AT A TIME, editing as you go rather than researching everything first:
 
-1. Evidence present → reframe it into a bullet in the vacancy's language with ` + "`cv_edit`" + ` NOW, passing that achievement's id as ` + "`evidence_id`" + `. Stay inside what the evidence says. Do not queue edits for later; a turn that spends its rounds reading ends without having changed the CV.
+1. Evidence present → reframe it into a bullet in the vacancy's language with ` + "`cv_edit`" + ` NOW, passing that achievement's id as ` + "`evidence_id`" + `. Stay inside what the evidence says. Do not queue edits for later; a turn that spends its rounds reading ends without having changed the CV. Pass ` + "`requirement`" + ` and ` + "`requirement_status: closed_bank`" + ` on that SAME call — the report updates with the edit, so you do not need a separate ` + "`tailor_report`" + ` call to keep this one entry current.
 2. ` + "`evidence`" + ` empty → the bank holds nothing on that point. Call ` + "`request_confirmation`" + ` with the exact claim text and a short question — do NOT write the ask as free-text prose, the candidate sees it as a claim with Yes/No buttons and Yes replays your claim text verbatim as their next message. If they confirm, record it with ` + "`experience_add`" + ` — putting their own words in ` + "`said`" + ` — and then write the bullet citing the id it returns. If they decline, leave it out; a gap belongs in a cover letter, never keyword-stuffed into a CV.
 
 The split between ` + "`missing_have`" + ` and ` + "`missing_gap`" + ` describes what the CV surfaces, not what the candidate has: a "gap" often carries evidence, because they told us in an earlier session.
@@ -139,6 +139,7 @@ Mechanics:
 - ` + "`cv_edit`" + ` applies ONE patch per call; its schema lists the ops and the fields each one reads. Make several calls for several edits.
 - ` + "`evidence_id`" + ` sits BESIDE ` + "`patch`" + `, not inside it — the call is one object holding both, and a nested id is a patch field that does not exist.
 - Writing a bullet needs ` + "`evidence_id`" + `. Rearranging what is already on the page — reordering, removing, the technology line, the skill groups — does not.
+- ` + "`requirement_status`" + ` on ` + "`cv_edit`" + ` only accepts ` + "`closed_bank`" + ` or ` + "`closed_candidate`" + ` — those are the only outcomes an edit can produce. It is not how you report a requirement as ` + "`open`" + ` or ` + "`not_reached`" + `; that stays a whole-list ` + "`tailor_report`" + ` call.
 - Address an experience entry and a bullet by their 0-based index in what ` + "`cv_get`" + ` returned — ` + "`bullet`" + ` is that index, never the bullet's text; the new text always goes in ` + "`value`" + `.
 - The server validates every patch; if one is rejected, read the reason and correct the address rather than retrying the same shape.
 - Contact details cannot be edited here — do not try.
@@ -156,7 +157,7 @@ The candidate can ask you to do the whole pass yourself rather than walk it with
 - Ask NOTHING while you are running. A requirement the bank has nothing for is carried to the report, not turned into a question mid-pass.
 - Finish by calling ` + "`tailor_report`" + ` ONCE with every requirement you considered: ` + "`closed_bank`" + ` where the bank had evidence and you wrote it in, ` + "`open`" + ` where it had none, ` + "`not_reached`" + ` for anything you did not get to. Copy each requirement's text verbatim from ` + "`cv_context`" + `.
 - Then write a SHORT summary — what you changed, and how many requirements are still open — and ask about the FIRST open one. One question, not a list: they will see the rest beside the CV.
-- Afterwards the conversation is ordinary again. When they confirm experience for an open requirement, record their words with ` + "`experience_add`" + `, write the bullet citing that id, and call ` + "`tailor_report`" + ` again with the same list, that entry now ` + "`closed_candidate`" + `. The report is replaced whole every time, so send all of it.
+- Afterwards the conversation is ordinary again. When they confirm experience for an open requirement, record their words with ` + "`experience_add`" + `, then write the bullet on the SAME ` + "`cv_edit`" + ` call that cites it, passing ` + "`requirement`" + ` and ` + "`requirement_status: closed_candidate`" + ` — that updates the one entry without a separate whole-list ` + "`tailor_report`" + ` call.
 
 Nothing about the honest wall relaxes because nobody is watching. A bullet still needs an ` + "`evidence_id`" + `, and a requirement you cannot evidence stays off the page and goes in the report as open.`
 

--- a/internal/cv/autopilot_store.go
+++ b/internal/cv/autopilot_store.go
@@ -91,6 +91,34 @@ func (s *Store) SetAutopilotReport(ctx context.Context, id uuid.UUID, userID int
 	return nil
 }
 
+// MergeAutopilotEntry writes one requirement's outcome into an owned CV's run report,
+// replacing the matching entry (requirement text compared case- and whitespace-insensitively)
+// or appending a new one when the report holds nothing for it yet.
+//
+// This is what lets cv_edit report the requirement it just closed in the SAME call as the
+// edit, rather than depending on a separate tailor_report call the model may not remember
+// to make once the requirement is no longer the one it is thinking about.
+func (s *Store) MergeAutopilotEntry(ctx context.Context, id uuid.UUID, userID int64, entry AutopilotEntry) error {
+	rec, err := s.Get(ctx, id, userID)
+	if err != nil {
+		return err
+	}
+	entries := rec.AutopilotReport
+	target := strings.ToLower(strings.TrimSpace(entry.Requirement))
+	replaced := false
+	for i, e := range entries {
+		if strings.ToLower(strings.TrimSpace(e.Requirement)) == target {
+			entries[i] = entry
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		entries = append(entries, entry)
+	}
+	return s.SetAutopilotReport(ctx, id, userID, entries)
+}
+
 // decodeAutopilotReport reads the stored report, tolerating an absent one. A stored report
 // that will not parse is treated as absent rather than failing the CV read: the panel losing
 // a run log must not cost the candidate their CV.

--- a/internal/cv/autopilot_test.go
+++ b/internal/cv/autopilot_test.go
@@ -81,6 +81,103 @@ func TestSanitizeAutopilotReportRefusesAnEmptyReport(t *testing.T) {
 	}
 }
 
+// cv_edit and tailor_report write two different columns through two different tool calls,
+// with nothing to keep them in step — a model that edits the document without a follow-up
+// tailor_report call leaves a requirement marked open when the CV already closes it.
+// MergeAutopilotEntry is what lets cv_edit self-report the one requirement it just closed,
+// in the same call, without depending on the model to remember a second one.
+//
+// Merging into an entry the report already holds must replace it, not duplicate it — the
+// report is one entry per requirement, and a second row for the same requirement would
+// leave the panel showing both an old "open" and a new "closed_bank" for the same line.
+func TestMergeAutopilotEntryReplacesAMatchingRequirement(t *testing.T) {
+	repo := newFakeRepo()
+	s := NewStore(repo)
+	ctx := context.Background()
+
+	meta, err := s.Create(ctx, 1, "Tailored", "classic-ats", Document{Summary: "mine"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.SetAutopilotReport(ctx, meta.ID, 1, []AutopilotEntry{
+		{Requirement: "PostgreSQL experience", Status: AutopilotOpen},
+		{Requirement: "Team leadership", Status: AutopilotClosedBank},
+	}); err != nil {
+		t.Fatalf("seed report: %v", err)
+	}
+
+	if err := s.MergeAutopilotEntry(ctx, meta.ID, 1, AutopilotEntry{
+		Requirement: "  PostgreSQL experience  ", // matched case/whitespace-insensitively
+		Status:      AutopilotClosedBank,
+		Note:        "Added the RDS PostgreSQL bullet.",
+	}); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	rec, err := s.Get(ctx, meta.ID, 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(rec.AutopilotReport) != 2 {
+		t.Fatalf("report has %d entries, want 2 (merge must replace, not duplicate)", len(rec.AutopilotReport))
+	}
+	got := rec.AutopilotReport[0]
+	if got.Status != AutopilotClosedBank || got.Note != "Added the RDS PostgreSQL bullet." {
+		t.Errorf("merged entry = %+v, want status closed_bank with the new note", got)
+	}
+	if rec.AutopilotReport[1].Requirement != "Team leadership" || rec.AutopilotReport[1].Status != AutopilotClosedBank {
+		t.Errorf("unrelated entry was disturbed: %+v", rec.AutopilotReport[1])
+	}
+}
+
+// A requirement cv_edit closes in the same turn it was first read — before any
+// tailor_report call ever ran — has no matching entry to replace. It must be appended
+// rather than silently dropped, or the very first requirement closed in a session would
+// never show up in the report.
+func TestMergeAutopilotEntryAppendsWhenNoReportExistsYet(t *testing.T) {
+	repo := newFakeRepo()
+	s := NewStore(repo)
+	ctx := context.Background()
+
+	meta, err := s.Create(ctx, 1, "Tailored", "classic-ats", Document{Summary: "mine"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := s.MergeAutopilotEntry(ctx, meta.ID, 1, AutopilotEntry{
+		Requirement: "PostgreSQL experience",
+		Status:      AutopilotClosedCandidate,
+	}); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	rec, err := s.Get(ctx, meta.ID, 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(rec.AutopilotReport) != 1 || rec.AutopilotReport[0].Requirement != "PostgreSQL experience" {
+		t.Fatalf("report = %+v, want one appended entry", rec.AutopilotReport)
+	}
+}
+
+// The merge is owner-scoped the same way every other CV write is: a foreign id must not
+// let one candidate's tool call touch another's report.
+func TestMergeAutopilotEntryIsOwnerScoped(t *testing.T) {
+	repo := newFakeRepo()
+	s := NewStore(repo)
+	ctx := context.Background()
+
+	meta, err := s.Create(ctx, 3, "Tailored", "classic-ats", Document{Summary: "mine"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.MergeAutopilotEntry(ctx, meta.ID, 4, AutopilotEntry{
+		Requirement: "Kafka", Status: AutopilotClosedBank,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Errorf("foreign merge = %v, want ErrNotFound", err)
+	}
+}
+
 // The Store-level behaviour: a report is written whole, and reverting takes the report with
 // the document — a log describing edits that no longer exist misdescribes the CV.
 // A foreign caller must not be able to write a report onto someone else's CV, and the

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -413,7 +413,9 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 			"their path from cv_get. Anything that states what the candidate did (a bullet, a summary, a " +
 			"technology, a skill) needs `evidence_id` from experience_search; if the bank holds nothing " +
 			"on the point, ask the candidate and record their answer with experience_add first. Contact " +
-			"details are not editable here.",
+			"details are not editable here. If this batch closes a requirement from cv_context, pass " +
+			"`requirement` and `requirement_status` — the report updates in this same call, so you do not " +
+			"need a separate tailor_report call for it.",
 		Schema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -427,13 +429,26 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 					"description": "One short line on why you made these edits — shown to the candidate " +
 						"beside them, in your own words.",
 				},
+				"requirement": map[string]any{
+					"type": "string",
+					"description": "A requirement this batch closes, copied verbatim from cv_context. Omit " +
+						"when this batch does not close a requirement (rewording, reordering, a technology " +
+						"tag). Requires `requirement_status`.",
+				},
+				"requirement_status": map[string]any{
+					"type":        "string",
+					"enum":        []string{string(cv.AutopilotClosedBank), string(cv.AutopilotClosedCandidate)},
+					"description": "closed_bank if the bank already had evidence; closed_candidate if the candidate just confirmed it in this conversation. Required when requirement is set.",
+				},
 			},
 			"required": []string{"ops"},
 		},
 		Run: func(ctx context.Context, userID int64, raw json.RawMessage) (any, error) {
 			var in struct {
-				Ops  opBatch `json:"ops"`
-				Note string  `json:"note"`
+				Ops               opBatch `json:"ops"`
+				Note              string  `json:"note"`
+				Requirement       string  `json:"requirement"`
+				RequirementStatus string  `json:"requirement_status"`
 			}
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
@@ -444,6 +459,12 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 				if _, err := cvedit.ParsePath(string(op.Path)); err != nil {
 					return nil, fmt.Errorf("edit %d: %w", i+1, err)
 				}
+			}
+			requirement := strings.TrimSpace(in.Requirement)
+			status := cv.AutopilotStatus(in.RequirementStatus)
+			if requirement != "" && status != cv.AutopilotClosedBank && status != cv.AutopilotClosedCandidate {
+				return nil, fmt.Errorf("requirement_status must be %q or %q when requirement is set",
+					cv.AutopilotClosedBank, cv.AutopilotClosedCandidate)
 			}
 			// A model names the positions it SAW: it read the document once and wrote every
 			// index against that reading. Applied in sequence those addresses shift out from
@@ -460,6 +481,17 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 			})
 			if err != nil {
 				return nil, cvToolError(err)
+			}
+			// Merged only after Commit succeeds: a refused batch must not leave the report
+			// claiming a requirement was closed by an edit that never landed.
+			if requirement != "" {
+				if err := h.cv.cvStore.MergeAutopilotEntry(ctx, cvID, userID, cv.AutopilotEntry{
+					Requirement: requirement,
+					Status:      status,
+					Note:        in.Note,
+				}); err != nil {
+					return nil, cvToolError(err)
+				}
 			}
 			// A receipt, not the document: a tool result is replayed into the model's
 			// context on every later turn of the session, so echoing the CV back would be

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -517,6 +517,69 @@ func TestCVEditToolMergesTheClosedRequirementIntoTheReport(t *testing.T) {
 	}
 }
 
+// The merge's replace path (proven at the store level in internal/cv/autopilot_test.go) has
+// to be reachable through cv_edit itself, not just through Store.MergeAutopilotEntry directly
+// — this is what proves the handler wiring, not just the store logic, does the right thing
+// when a report entry already exists.
+func TestCVEditToolReplacesAnExistingOpenReportEntry(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+	seed, err := json.Marshal([]cv.AutopilotEntry{
+		{Requirement: "PostgreSQL experience", Status: cv.AutopilotOpen},
+		{Requirement: "Team leadership", Status: cv.AutopilotClosedBank},
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	repo.report = seed
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err = tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"`+atom.ID.String()+`"}],`+
+			`"requirement":"PostgreSQL experience","requirement_status":"closed_bank"}`))
+	if err != nil {
+		t.Fatalf("cv_edit: %v", err)
+	}
+
+	var report []cv.AutopilotEntry
+	if err := json.Unmarshal(repo.report, &report); err != nil {
+		t.Fatalf("report unreadable: %v (raw %s)", err, repo.report)
+	}
+	if len(report) != 2 {
+		t.Fatalf("report has %d entries, want 2 (the edit must replace, not duplicate)", len(report))
+	}
+	if report[0].Requirement != "PostgreSQL experience" || report[0].Status != cv.AutopilotClosedBank {
+		t.Errorf("report[0] = %+v, want PostgreSQL experience closed_bank", report[0])
+	}
+	if report[1].Requirement != "Team leadership" || report[1].Status != cv.AutopilotClosedBank {
+		t.Errorf("unrelated entry was disturbed: %+v", report[1])
+	}
+}
+
+// The schema's enum keeps a well-behaved model from offering open/not_reached, but the
+// handler must refuse the value too — a model can send whatever JSON it wants regardless of
+// what the schema advertises.
+func TestCVEditToolRejectsAnExplicitOpenRequirementStatus(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"`+atom.ID.String()+`"}],`+
+			`"requirement":"PostgreSQL experience","requirement_status":"open"}`))
+	if err == nil {
+		t.Fatal("an explicit \"open\" status was accepted; cv_edit must not be able to reopen a requirement")
+	}
+	if repo.written != nil {
+		t.Errorf("document was written = %s, want the batch refused before the edit applied", repo.written)
+	}
+	if repo.report != nil {
+		t.Errorf("report = %s, want it untouched when the call is refused", repo.report)
+	}
+}
+
 // A batch that names no requirement is the common case (rewording, reordering, adding a
 // technology tag) and must leave the report exactly as it was — merging a blank requirement
 // would either error or, worse, silently create a nameless row the panel cannot render.

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -491,6 +491,96 @@ func TestCVEditWritesACitedBullet(t *testing.T) {
 	}
 }
 
+// cv_edit and tailor_report write two different columns through two different tool calls;
+// nothing ties them together unless cv_edit is told which requirement its batch just closed.
+// requirement/requirement_status is that link — it must land in the SAME call as the edit,
+// because that is the one moment the model still has the requirement in mind.
+func TestCVEditToolMergesTheClosedRequirementIntoTheReport(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"`+atom.ID.String()+`"}],`+
+			`"requirement":"PostgreSQL experience","requirement_status":"closed_bank"}`))
+	if err != nil {
+		t.Fatalf("cv_edit: %v", err)
+	}
+
+	var report []cv.AutopilotEntry
+	if err := json.Unmarshal(repo.report, &report); err != nil {
+		t.Fatalf("report unreadable: %v (raw %s)", err, repo.report)
+	}
+	if len(report) != 1 || report[0].Requirement != "PostgreSQL experience" || report[0].Status != cv.AutopilotClosedBank {
+		t.Errorf("report = %+v, want one entry closing \"PostgreSQL experience\"", report)
+	}
+}
+
+// A batch that names no requirement is the common case (rewording, reordering, adding a
+// technology tag) and must leave the report exactly as it was — merging a blank requirement
+// would either error or, worse, silently create a nameless row the panel cannot render.
+func TestCVEditToolWithNoRequirementLeavesTheReportUntouched(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"`+atom.ID.String()+`"}]}`))
+	if err != nil {
+		t.Fatalf("cv_edit: %v", err)
+	}
+	if repo.report != nil {
+		t.Errorf("report = %s, want it untouched when the call named no requirement", repo.report)
+	}
+}
+
+// requirement_status only makes sense as an outcome the edit just produced — open and
+// not_reached describe requirements NOT closed, so cv_edit (which only ever closes one) must
+// not advertise or accept them; a model that could send "open" here could silently reopen a
+// requirement tailor_report already closed, through a call that carries no report review.
+func TestCVEditToolRequirementStatusOffersOnlyClosingOutcomes(t *testing.T) {
+	a, _ := cvToolsAPI(t, oneExperienceCV)
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	props, _ := tool.Schema["properties"].(map[string]any)
+	status, _ := props["requirement_status"].(map[string]any)
+	got, _ := status["enum"].([]string)
+
+	want := []string{string(cv.AutopilotClosedBank), string(cv.AutopilotClosedCandidate)}
+	if len(got) != len(want) {
+		t.Fatalf("requirement_status enum = %v, want %v", got, want)
+	}
+	for _, w := range want {
+		found := false
+		for _, g := range got {
+			if g == w {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("requirement_status enum = %v, missing %q", got, w)
+		}
+	}
+}
+
+func TestCVEditToolRequirementWithoutStatusIsRefused(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"`+atom.ID.String()+`"}],`+
+			`"requirement":"PostgreSQL experience"}`))
+	if err == nil {
+		t.Fatal("a requirement with no status was accepted; the report would hold an invalid entry")
+	}
+	if repo.report != nil {
+		t.Errorf("report = %s, want it untouched when the call is refused", repo.report)
+	}
+}
+
 // A batch is one entry in the candidate's history and one round of the turn's budget, which
 // is why closing a requirement no longer costs three calls.
 func TestCVEditAppliesAWholeBatchAtOnce(t *testing.T) {

--- a/openspec/changes/autopilot-report-drifts-from-cv-edits/.openspec.yaml
+++ b/openspec/changes/autopilot-report-drifts-from-cv-edits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/autopilot-report-drifts-from-cv-edits/design.md
+++ b/openspec/changes/autopilot-report-drifts-from-cv-edits/design.md
@@ -1,0 +1,61 @@
+## Context
+
+`cvs.autopilot_report` (migration 0052) is a JSONB snapshot the model writes wholesale via
+the `tailor_report` tool (`internal/handler/assistant_cv_tools.go`). `cv_edit` writes
+`cvs.document` through a completely separate path (`internal/cvedit`). Nothing in the schema
+or the handlers ties one write to the other — `SetCVAutopilotReport` (`internal/db/cvs.sql.go`)
+doesn't even stamp `updated_at`. The only thing keeping the two in step is the model
+remembering, mid-turn, to call `tailor_report` again after an edit that closes a requirement —
+stated as a "should" in the tool's own description, not enforced anywhere. Observed directly:
+a tailored CV whose document already carried a PostgreSQL bullet while its report still read
+that requirement `open`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let one `cv_edit` call keep the report in step with the edit it just made, without a second
+  tool call the model has to remember.
+- Keep `tailor_report`'s existing whole-report semantics for the unattended-run path, where it
+  already works (`internal/assistant/prompt.go`'s "UNATTENDED RUNS" section) — this change adds
+  a second way to touch one entry, it does not replace the first.
+
+**Non-Goals:**
+- Making `autopilot_report` a value computed live from the document and the evidence bank
+  instead of a value the model asserts. Considered and rejected: the report is phrased in
+  requirement-language ("closed_bank", "closed_candidate", a one-line note), not derivable from
+  a bullet's `evidence_id` without re-running relevance matching between free-text requirements
+  and document paths — a much larger change for what is a status-log staleness bug, not a
+  correctness bug in the CV itself.
+- A hard guarantee that every requirement-closing edit reports itself. `requirement` /
+  `requirement_status` are optional on `cv_edit`; an edit that omits them behaves exactly as
+  today. This is the same class of fix as the `tailorPrompt` sequencing rule added earlier in
+  this area: it removes the most common way to forget, not every way.
+
+## Decisions
+
+- **Match existing entries by requirement text, case- and whitespace-insensitively; append if
+  none matches.** The report has no requirement id — its entries are keyed by the text copied
+  verbatim from `cv_context` (`internal/cv/autopilot.go`'s `AutopilotEntry.Requirement`). A
+  fresh CV with no prior `tailor_report` call has no matching entry for the first requirement
+  it closes, and that must produce a report entry, not a silent no-op.
+- **`requirement_status` accepts only `closed_bank` and `closed_candidate`.** `cv_edit` only
+  ever closes a requirement; `open` and `not_reached` describe requirements it does not touch.
+  Advertising the full four-value vocabulary here would let a model send `open` through a call
+  that carries no review of the rest of the report, silently reopening something `tailor_report`
+  already closed.
+- **The merge happens in the same handler call, after `cvedit.Commit` succeeds, via a second
+  read-modify-write (`Store.Get` then `Store.SetAutopilotReport`) rather than a joint
+  transaction.** The two writes target different columns for different purposes (the document is
+  the CV; the report is a display log of a separate resource), and the existing `tailor_report`
+  path is already not transactional with the edits it follows. Consistency here is "good enough
+  for a status log", not the same bar as `cvedit`'s own revision/undo guarantees.
+
+## Risks / Trade-offs
+
+- [The model still doesn't pass `requirement`/`requirement_status` on some edit that closes a
+  requirement] → Mitigation: `tailorPrompt`'s mechanics section is updated to say so explicitly;
+  same class of best-effort fix as the existing "work one requirement at a time" rule.
+- [Two concurrent `cv_edit` calls on the same CV race the read-modify-write and one merge is
+  lost] → Not mitigated here: `cv_edit` calls within one turn are already sequential (the
+  runner issues tool calls one at a time), and cross-session concurrent tailoring of the same CV
+  is an existing, unaddressed hazard this change does not widen.

--- a/openspec/changes/autopilot-report-drifts-from-cv-edits/proposal.md
+++ b/openspec/changes/autopilot-report-drifts-from-cv-edits/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`tailor_report` and `cv_edit` write two different columns (`cvs.autopilot_report` and
+`cvs.document`) through two different tool calls, with nothing tying them together —
+`SetCVAutopilotReport` does not even stamp `updated_at`. A model that edits the document
+without a follow-up `tailor_report` call leaves a requirement's report entry stale: observed
+directly on a real tailored CV, where a PostgreSQL bullet was written into the document but
+the report still read the requirement as `open`. The report is what the tailoring workspace
+shows beside the fit analysis, so a candidate reloading the page sees a closed requirement
+still marked open.
+
+## What Changes
+
+- `cv_edit` gains two optional fields, `requirement` and `requirement_status`. When both are
+  set, the edit's own call also merges one entry into the CV's autopilot report — replacing
+  the entry for that requirement text if the report already has one, appending it otherwise —
+  instead of depending on a second `tailor_report` call the model may not make once the
+  requirement is no longer the one it is reasoning about. `requirement_status` accepts only
+  the two outcomes an edit can actually produce, `closed_bank` and `closed_candidate` — not
+  `open` or `not_reached`, which describe a requirement `cv_edit` never touches.
+- A new `Store.MergeAutopilotEntry` (`internal/cv`) does the read-modify-write against the
+  owned CV's report.
+- `tailorPrompt`'s mechanics section is updated to tell the agent to pass `requirement` /
+  `requirement_status` on the edit that closes a requirement, rather than relying on a
+  separate `tailor_report` call for it.
+
+## Capabilities
+
+### Modified Capabilities
+- `tailor-autopilot`: "A run records a per-requirement report on the tailored CV" gains a
+  second way to update one entry — through `cv_edit` in the same call as the edit that closes
+  it, not only through a whole-report `tailor_report` call.
+
+## Impact
+
+- Backend: `internal/cv/autopilot_store.go` (new `MergeAutopilotEntry`),
+  `internal/handler/assistant_cv_tools.go` (`cv_edit`'s schema and handler),
+  `internal/assistant/prompt.go` (`tailorPrompt` mechanics section).
+- No migration: `cvs.autopilot_report` already exists (migration 0052).
+- No frontend change: the workspace already reads `autopilot_report` from `cv_get`'s response;
+  this only makes what it reads fresher.

--- a/openspec/changes/autopilot-report-drifts-from-cv-edits/specs/tailor-autopilot/spec.md
+++ b/openspec/changes/autopilot-report-drifts-from-cv-edits/specs/tailor-autopilot/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: A run records a per-requirement report on the tailored CV
+
+The system SHALL persist, on the tailored CV, a report naming every requirement the run considered
+and the outcome of each, so the workspace can show what a run achieved after a page reload. An
+outcome MUST be one of a fixed vocabulary — closed from the experience bank, closed from what the
+candidate said, still open, or not reached — and a value outside that vocabulary MUST be refused with
+a message naming the valid ones rather than persisted. The report tool MUST replace the whole report
+on each call and MUST return a receipt rather than echoing the report back into the conversation.
+
+An edit that closes a requirement MAY also merge that outcome into the report in the SAME call —
+`cv_edit` accepts an optional requirement and an outcome restricted to `closed_bank` or
+`closed_candidate`, the only two a `cv_edit` call can produce. The merge replaces the report's
+existing entry for that requirement text (matched case- and whitespace-insensitively) if one
+exists, or appends a new entry if none does. This does not replace the whole-report tool: it is
+a second way to keep one entry current without depending on a later whole-report call for it.
+
+#### Scenario: The report survives a reload
+
+- **WHEN** a run finishes and the workspace is reloaded
+- **THEN** the report of that run is read back with the same requirements and outcomes
+
+#### Scenario: An out-of-vocabulary outcome is refused
+
+- **WHEN** the agent reports an outcome outside the fixed vocabulary
+- **THEN** the call is refused with a message naming the valid outcomes, and the stored report is unchanged
+
+#### Scenario: A later answer updates the report in place
+
+- **WHEN** the candidate confirms experience for an open requirement after the run and the agent writes it into the CV
+- **THEN** the report is replaced with one marking that requirement closed from what the candidate said
+
+#### Scenario: An edit closes a requirement the report already marks open
+
+- **WHEN** `cv_edit` is called with a requirement and `closed_bank` naming a requirement the
+  stored report currently marks `open`
+- **THEN** that entry's status becomes `closed_bank` and every other entry in the report is
+  unchanged
+
+#### Scenario: An edit closes a requirement no report has an entry for yet
+
+- **WHEN** `cv_edit` is called with a requirement and an outcome, and the CV's report holds no
+  entry whose text matches
+- **THEN** a new entry for that requirement is appended to the report
+
+#### Scenario: An edit naming no requirement leaves the report untouched
+
+- **WHEN** `cv_edit` is called without a requirement
+- **THEN** the CV's stored report, if any, is unchanged by that call
+
+#### Scenario: cv_edit cannot report a requirement as open or not reached
+
+- **WHEN** `cv_edit` is called with a requirement and an outcome outside `closed_bank` or
+  `closed_candidate`
+- **THEN** the call is refused and the stored report is unchanged

--- a/openspec/changes/autopilot-report-drifts-from-cv-edits/tasks.md
+++ b/openspec/changes/autopilot-report-drifts-from-cv-edits/tasks.md
@@ -15,27 +15,33 @@
   neither leaves the report untouched; the schema's `requirement_status` enum offers only
   `closed_bank` and `closed_candidate`; a `requirement` with no `requirement_status` is
   refused and the report stays untouched.
-- [ ] 2.2 Add `requirement` (string) and `requirement_status` (enum: `closed_bank`,
+- [x] 2.2 Add `requirement` (string) and `requirement_status` (enum: `closed_bank`,
   `closed_candidate`) to `cv_edit`'s schema in
   `internal/handler/assistant_cv_tools.go`.
-- [ ] 2.3 In the handler: after `cvedit.Commit` succeeds, if `requirement` is set, require
+- [x] 2.3 In the handler: after `cvedit.Commit` succeeds, if `requirement` is set, require
   `requirement_status` (refuse with a message naming the two valid values if absent) and
   call `MergeAutopilotEntry` with an `AutopilotEntry{Requirement, Status, Note: <the edit's
   own note>}`.
-- [ ] 2.4 Run the task 2.1 tests green; confirm no other `assistant_cv_tools_test.go` case
-  regresses.
+- [x] 2.4 Run the task 2.1 tests green; confirm no other `assistant_cv_tools_test.go` case
+  regresses. Review found 2 of the delta spec's 4 scenarios untested at the handler level
+  (replace-in-place on an existing entry; an explicit invalid non-empty status bypassing
+  the schema) — added `TestCVEditToolReplacesAnExistingOpenReportEntry` and
+  `TestCVEditToolRejectsAnExplicitOpenRequirementStatus`, both pass immediately (coverage
+  gap, not a bug).
 
 ## 3. Prompt: tell the agent to use it
 
-- [ ] 3.1 Update `tailorPrompt`'s mechanics section in `internal/assistant/prompt.go`: an
+- [x] 3.1 Update `tailorPrompt`'s mechanics section in `internal/assistant/prompt.go`: an
   edit that closes a requirement SHOULD pass `requirement` and `requirement_status` on that
   same `cv_edit` call, instead of depending on a separate `tailor_report` call to keep that
   one entry current.
-- [ ] 3.2 Add a prompt-content test in `internal/assistant/preset_test.go` (matching the
+- [x] 3.2 Add a prompt-content test in `internal/assistant/preset_test.go` (matching the
   existing substring-assertion pattern for `tailorPrompt`) pinning that the mechanics
   section mentions `requirement_status`.
 
 ## 4. Verify
 
-- [ ] 4.1 `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`.
-- [ ] 4.2 `openspec validate --all --strict`.
+- [x] 4.1 `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`
+  — all clean. Also ran `go test -tags=integration ./...` (whole module, Docker): all green,
+  no FAIL.
+- [x] 4.2 `openspec validate --all --strict`.

--- a/openspec/changes/autopilot-report-drifts-from-cv-edits/tasks.md
+++ b/openspec/changes/autopilot-report-drifts-from-cv-edits/tasks.md
@@ -1,0 +1,41 @@
+## 1. Store: MergeAutopilotEntry
+
+- [x] 1.1 Add `Store.MergeAutopilotEntry(ctx, id, userID, entry)` in
+  `internal/cv/autopilot_store.go`: read the owned CV, replace the entry whose requirement
+  text matches (case- and whitespace-insensitively) or append a new one, then
+  `SetAutopilotReport` with the merged list.
+- [x] 1.2 Tests in `internal/cv/autopilot_test.go`: replaces a matching entry without
+  duplicating it, appends when no report exists yet, and is owner-scoped (foreign id →
+  `ErrNotFound`).
+
+## 2. cv_edit: requirement / requirement_status
+
+- [x] 2.1 Tests in `internal/handler/assistant_cv_tools_test.go` (already written, RED):
+  a call with `requirement` + `requirement_status` merges into the report; a call with
+  neither leaves the report untouched; the schema's `requirement_status` enum offers only
+  `closed_bank` and `closed_candidate`; a `requirement` with no `requirement_status` is
+  refused and the report stays untouched.
+- [ ] 2.2 Add `requirement` (string) and `requirement_status` (enum: `closed_bank`,
+  `closed_candidate`) to `cv_edit`'s schema in
+  `internal/handler/assistant_cv_tools.go`.
+- [ ] 2.3 In the handler: after `cvedit.Commit` succeeds, if `requirement` is set, require
+  `requirement_status` (refuse with a message naming the two valid values if absent) and
+  call `MergeAutopilotEntry` with an `AutopilotEntry{Requirement, Status, Note: <the edit's
+  own note>}`.
+- [ ] 2.4 Run the task 2.1 tests green; confirm no other `assistant_cv_tools_test.go` case
+  regresses.
+
+## 3. Prompt: tell the agent to use it
+
+- [ ] 3.1 Update `tailorPrompt`'s mechanics section in `internal/assistant/prompt.go`: an
+  edit that closes a requirement SHOULD pass `requirement` and `requirement_status` on that
+  same `cv_edit` call, instead of depending on a separate `tailor_report` call to keep that
+  one entry current.
+- [ ] 3.2 Add a prompt-content test in `internal/assistant/preset_test.go` (matching the
+  existing substring-assertion pattern for `tailorPrompt`) pinning that the mechanics
+  section mentions `requirement_status`.
+
+## 4. Verify
+
+- [ ] 4.1 `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`.
+- [ ] 4.2 `openspec validate --all --strict`.


### PR DESCRIPTION
## Summary
- `cv_edit` and `tailor_report` write two different CV columns (`document` / `autopilot_report`) through two different tool calls, with nothing tying them together — observed directly on a real tailored CV where a PostgreSQL bullet was already in the document while the report still read that requirement `open`.
- Adds optional `requirement` / `requirement_status` (`closed_bank` | `closed_candidate` only — the two outcomes an edit can actually produce) to `cv_edit`. When set, the SAME call merges one entry into the CV's `autopilot_report` via a new `Store.MergeAutopilotEntry` (`internal/cv`), replacing a matching entry or appending one — no second `tailor_report` call needed.
- Validation runs before `cvedit.Commit`, so an invalid/missing status refuses the whole call before the document is touched.
- `tailorPrompt` updated to tell the agent to use the new fields, both on a fresh reframe and on the post-run incremental-confirmation path; the unattended-run's end-of-run whole-report `tailor_report` call is untouched by design (see `design.md`'s Non-Goals).
- OpenSpec change `autopilot-report-drifts-from-cv-edits`, all 4 tasks done, each reviewed by an independent agent (one Important coverage gap found and closed — replace-in-place and explicit-invalid-status scenarios now covered).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...` — clean
- [x] `go test -tags=integration ./...` (whole module, Docker) — clean, no FAIL
- [x] `openspec validate --all --strict` — 214/214