### PR TITLE
chore(sources): drop the dead peopleforce board miltech-1 (Frontline Robotics)

### DIFF
--- a/sources/peopleforce.yml
+++ b/sources/peopleforce.yml
@@ -72,8 +72,6 @@
   board: magnetics
 - company: Media24
   board: media24
-- company: Frontline
-  board: miltech-1
 - company: Мрія
   board: mriia
 - company: Multiplex


### PR DESCRIPTION
## Summary
- `miltech-1.peopleforce.io` (Frontline Robotics) has been 404ing on its listing since at least 2026-07-18 and is in `board_health` cooldown. The company moved off PeopleForce entirely to its own Webflow site (career.frontline-robotics.tech) — the root domain now redirects to `app.peopleforce.io/tenants/new`, i.e. the tenant is gone, not renamed.
- Drop the dead entry from `sources/peopleforce.yml`. Its 145 open jobs will be closed separately (a removed board is never re-crawled, so the ingest sweep's company-scoped close never reaches it — see `cmd/ingest/main.go`'s documented under-close trade-off).
- Onboarding their new Webflow site as a source is a separate, larger piece of work (no existing adapter fits it) — not part of this change.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./internal/sources/...` clean