### PR TITLE
feat(handler): POST /me/experience/employments and /atoms

### DIFF
--- a/internal/handler/assistant_cv_gate_test.go
+++ b/internal/handler/assistant_cv_gate_test.go
@@ -71,6 +71,13 @@ func (b *stubBank) UpdateAtom(_ context.Context, id uuid.UUID, userID int64, a e
 	return a, nil
 }
 
+func (b *stubBank) CreateEmployment(_ context.Context, userID int64, e experience.Employment) (experience.Employment, error) {
+	if err := e.Validate(); err != nil {
+		return experience.Employment{}, err
+	}
+	return b.addEmployment(userID, e), nil
+}
+
 func (b *stubBank) UpdateEmployment(_ context.Context, id uuid.UUID, userID int64, e experience.Employment) (experience.Employment, error) {
 	for i, existing := range b.employments {
 		if existing.ID == id && b.owner[id] == userID {

--- a/internal/handler/me_experience.go
+++ b/internal/handler/me_experience.go
@@ -27,8 +27,10 @@ type experienceBankOwner interface {
 	ListEmployments(ctx context.Context, userID int64) ([]experience.Employment, error)
 	ListAtoms(ctx context.Context, userID int64) ([]experience.Atom, error)
 	GetAtom(ctx context.Context, id uuid.UUID, userID int64) (experience.Atom, error)
+	CreateEmployment(ctx context.Context, userID int64, e experience.Employment) (experience.Employment, error)
 	UpdateEmployment(ctx context.Context, id uuid.UUID, userID int64, e experience.Employment) (experience.Employment, error)
 	DeleteEmployment(ctx context.Context, id uuid.UUID, userID int64) error
+	AddAtom(ctx context.Context, userID int64, a experience.Atom) (experience.Atom, error)
 	UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a experience.Atom) (experience.Atom, error)
 	DeleteAtom(ctx context.Context, id uuid.UUID, userID int64) error
 }
@@ -39,11 +41,17 @@ func newExperienceHandlers(bank experienceBankOwner) *experienceHandlers {
 
 func (h *experienceHandlers) register(api fiber.Router, mw middleware) {
 	// The read takes a key, like the profile read, so a programmatic consumer can ground
-	// itself in what the candidate has actually done. The writes stay cookie-only: a key
-	// that leaks out of a script's environment must not edit or erase someone's career.
+	// itself in what the candidate has actually done. Correcting or removing an EXISTING
+	// entry stays cookie-only: a key that leaks out of a script's environment must not edit
+	// or erase someone's career. Creating a new one takes a key too — it is additive-only,
+	// and a full-scope key already reaches everything more destructive than this (cv edit,
+	// apply) through the rest of the CLI's surface, so gating this narrower than that would
+	// protect a boundary the same key crosses everywhere else.
 	api.Get("/me/experience", mw.key, h.ListExperience)
+	api.Post("/me/experience/employments", mw.key, h.AddEmployment)
 	api.Put("/me/experience/employments/:id", mw.cookie, h.UpdateEmployment)
 	api.Delete("/me/experience/employments/:id", mw.cookie, h.DeleteEmployment)
+	api.Post("/me/experience/atoms", mw.key, h.AddAtom)
 	api.Put("/me/experience/atoms/:id", mw.cookie, h.UpdateAtom)
 	api.Delete("/me/experience/atoms/:id", mw.cookie, h.DeleteAtom)
 }
@@ -107,6 +115,47 @@ func (h *experienceHandlers) ListExperience(c *fiber.Ctx) error {
 		resp.Employments = append(resp.Employments, entry)
 	}
 	return c.JSON(fiber.Map{"data": resp})
+}
+
+// AddEmployment records a new place — a job or a project — under the caller. Unlike
+// UpdateEmployment this creates rather than corrects, so nothing about provenance applies:
+// an employment carries no claim of its own, only the atoms attached to it do.
+func (h *experienceHandlers) AddEmployment(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	var in experience.Employment
+	if err := c.BodyParser(&in); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid body")
+	}
+	created, err := h.bank.CreateEmployment(c.Context(), userID, in)
+	if err != nil {
+		return experienceError(err)
+	}
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": created})
+}
+
+// AddAtom records a new achievement under the caller. This is the only route that can add
+// evidence outside a chat session — the assistant's own experience_add tool is the other —
+// so provenance is forced to manual regardless of what the body sends, the same way
+// UpdateAtom already forces it on a correction: an authenticated POST with no chat
+// transcript behind it can only ever honestly be "the owner typed this themselves".
+func (h *experienceHandlers) AddAtom(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	var in experience.Atom
+	if err := c.BodyParser(&in); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid body")
+	}
+	in.Provenance = experience.ProvenanceManual
+	created, err := h.bank.AddAtom(c.Context(), userID, in)
+	if err != nil {
+		return experienceError(err)
+	}
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": created})
 }
 
 // UpdateEmployment replaces one place's fields with what the owner typed — blanks
@@ -202,6 +251,8 @@ func experienceError(err error) error {
 		errors.Is(err, experience.ErrEmptyEmployment),
 		errors.Is(err, experience.ErrInvalidKind):
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	case errors.Is(err, experience.ErrAlreadyBanked):
+		return fiber.NewError(fiber.StatusConflict, err.Error())
 	default:
 		return err
 	}

--- a/internal/handler/me_experience_test.go
+++ b/internal/handler/me_experience_test.go
@@ -153,6 +153,143 @@ func TestDeleteExperienceIsOwnerScoped(t *testing.T) {
 	}
 }
 
+// The only way in for a caller with no chat session — a script, freehire-cli — is this
+// route, and it must land under the SAME caller the token names, the same as every other
+// write in this file.
+func TestAddAtomCreatesUnderTheCaller(t *testing.T) {
+	app, token, bank := experienceApp(t)
+
+	resp := experienceReq(t, app, http.MethodPost, "/me/experience/atoms",
+		`{"claim":"Cut latency 20s to 1s"}`, token)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+	var body struct {
+		Data struct {
+			ID    uuid.UUID `json:"id"`
+			Claim string    `json:"claim"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	resp.Body.Close()
+	if body.Data.Claim != "Cut latency 20s to 1s" {
+		t.Errorf("claim = %q, want it echoed back", body.Data.Claim)
+	}
+
+	stored, err := bank.GetAtom(t.Context(), body.Data.ID, 1)
+	if err != nil {
+		t.Fatalf("the atom was not persisted under caller 1: %v", err)
+	}
+	if stored.Claim != "Cut latency 20s to 1s" {
+		t.Errorf("stored claim = %q", stored.Claim)
+	}
+}
+
+// There is no chat transcript to check a stated_in_chat claim against outside a chat
+// turn, so a plain authenticated POST can only ever honestly produce manual — the same
+// provenance PUT already forces on a correction.
+func TestAddAtomForcesManualProvenance(t *testing.T) {
+	app, token, bank := experienceApp(t)
+
+	resp := experienceReq(t, app, http.MethodPost, "/me/experience/atoms",
+		`{"claim":"Led the migration","provenance":"stated_in_chat"}`, token)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+	var body struct {
+		Data struct {
+			ID uuid.UUID `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	resp.Body.Close()
+
+	stored, err := bank.GetAtom(t.Context(), body.Data.ID, 1)
+	if err != nil {
+		t.Fatalf("GetAtom: %v", err)
+	}
+	if stored.Provenance != experience.ProvenanceManual {
+		t.Errorf("provenance = %q, want it forced to manual regardless of what the caller sent", stored.Provenance)
+	}
+}
+
+func TestAddAtomRefusesAnEmptyClaim(t *testing.T) {
+	app, token, bank := experienceApp(t)
+
+	resp := experienceReq(t, app, http.MethodPost, "/me/experience/atoms", `{"claim":""}`, token)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	resp.Body.Close()
+	if len(bank.list) != 0 {
+		t.Error("a refused atom was persisted anyway")
+	}
+}
+
+// AddAtom shares the store's dedup with experience_add: a claim already banked, under any
+// spelling, must not silently create a second row nor a generic 500 — the caller needs to
+// know it already exists.
+func TestAddAtomOnAnAlreadyBankedClaimIsAConflict(t *testing.T) {
+	app, token, bank := experienceApp(t)
+	bank.addErr = experience.ErrAlreadyBanked
+
+	resp := experienceReq(t, app, http.MethodPost, "/me/experience/atoms", `{"claim":"Cut latency 20s to 1s"}`, token)
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("status = %d, want 409", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestAddEmploymentCreatesUnderTheCaller(t *testing.T) {
+	app, token, bank := experienceApp(t)
+
+	resp := experienceReq(t, app, http.MethodPost, "/me/experience/employments",
+		`{"kind":"job","company":"RingCentral","role":"SWE"}`, token)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+	var body struct {
+		Data struct {
+			ID      uuid.UUID `json:"id"`
+			Company string    `json:"company"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	resp.Body.Close()
+	if body.Data.Company != "RingCentral" {
+		t.Errorf("company = %q, want it echoed back", body.Data.Company)
+	}
+
+	found := false
+	for _, e := range bank.employments {
+		if e.ID == body.Data.ID && bank.owner[e.ID] == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the employment was not persisted under caller 1")
+	}
+}
+
+func TestAddEmploymentRefusesOneWithNeitherCompanyNorRole(t *testing.T) {
+	app, token, bank := experienceApp(t)
+
+	resp := experienceReq(t, app, http.MethodPost, "/me/experience/employments", `{"kind":"job"}`, token)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	resp.Body.Close()
+	if len(bank.employments) != 0 {
+		t.Error("a refused employment was persisted anyway")
+	}
+}
+
 func TestExperienceRoutesRefuseAMalformedID(t *testing.T) {
 	app, token, _ := experienceApp(t)
 
@@ -174,6 +311,12 @@ func TestExperienceRoutesRequireAuth(t *testing.T) {
 	}
 	if resp := experienceReq(t, app, http.MethodDelete, "/me/experience/atoms/"+uuid.New().String(), "", ""); resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("unauthenticated delete = %d, want 401", resp.StatusCode)
+	}
+	if resp := experienceReq(t, app, http.MethodPost, "/me/experience/atoms", `{"claim":"x"}`, ""); resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated atom create = %d, want 401", resp.StatusCode)
+	}
+	if resp := experienceReq(t, app, http.MethodPost, "/me/experience/employments", `{"kind":"job","company":"x"}`, ""); resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated employment create = %d, want 401", resp.StatusCode)
 	}
 }
 

--- a/internal/handler/me_experience_test.go
+++ b/internal/handler/me_experience_test.go
@@ -290,6 +290,20 @@ func TestAddEmploymentRefusesOneWithNeitherCompanyNorRole(t *testing.T) {
 	}
 }
 
+func TestAddEmploymentRefusesAKindOutsideTheVocabulary(t *testing.T) {
+	app, token, bank := experienceApp(t)
+
+	resp := experienceReq(t, app, http.MethodPost, "/me/experience/employments",
+		`{"kind":"hobby","company":"RingCentral"}`, token)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	resp.Body.Close()
+	if len(bank.employments) != 0 {
+		t.Error("an employment with an out-of-vocabulary kind was persisted anyway")
+	}
+}
+
 func TestExperienceRoutesRefuseAMalformedID(t *testing.T) {
 	app, token, _ := experienceApp(t)
 

--- a/openspec/changes/experience-bank-create-routes/.openspec.yaml
+++ b/openspec/changes/experience-bank-create-routes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/experience-bank-create-routes/design.md
+++ b/openspec/changes/experience-bank-create-routes/design.md
@@ -1,0 +1,71 @@
+## Context
+
+`internal/handler/me_experience.go` already serves the owner's whole bank
+(`GET /me/experience`, full-scope key or cookie) and lets them correct or remove any entry
+(`PUT`/`DELETE`, cookie-only — the file's own comment explains why: "a key that leaks out
+of a script's environment must not edit or erase someone's career"). `Store.AddAtom` and
+`Store.CreateEmployment` (`internal/experience/store.go`) already exist and are exercised
+today only by the in-process assistant tools (`experience_add`, `internal/handler/assistant_experience_tools.go`),
+which run inside a chat turn and can check a claim's `said` text against the session
+transcript to decide `stated_in_chat` vs `agent_inferred` provenance.
+
+`freehire-cli` is a separate repo (`github.com/strelov1/freehire-cli`), a thin HTTP client
+authenticated by one full-scope API key (`fhk_...`) that already drives `cv edit`, `apply`,
+`save`, etc. It has no bank-write command today because no route exists for it to call.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let a full-scope key create a new employment or a new atom, the same way it can already
+  read every existing one.
+- Keep the provenance rule the honest wall depends on intact: an atom created this way must
+  never be indistinguishable from one the candidate stated in a chat the server can verify.
+
+**Non-Goals:**
+- A new, narrower API-key scope for bank writes. Investigated and rejected for this change:
+  scope selection at key-creation time does not exist for user-facing keys at all today
+  (`mintAPIKey` hardcodes `ScopeFull`) — building it would mean a migration, a new
+  `createAPIKeyRequest` field, and new UI, for a narrower boundary around a capability
+  (adding) that is strictly less destructive than the edit/delete this same key can already
+  reach through the web UI's own key. If a future change wants a genuinely narrower key
+  (e.g. so a compromised automation script can add but never delete), that is its own
+  proposal, not a prerequisite for this one.
+- Letting the write side accept `stated_in_chat` or `cv_import` provenance from the caller.
+  Only the server may assert those — see Decisions.
+
+## Decisions
+
+- **Both new routes sit behind the SAME `mw.key` the existing `GET /me/experience` already
+  uses** (full scope, no new middleware instance). A full-scope key already carries the
+  power to `cv edit` a fabricated bullet's summary line or `apply` on the candidate's
+  behalf; gating an *additive* bank write behind anything narrower would protect a boundary
+  the same key already crosses everywhere else in the CLI.
+- **The handler forces `Provenance: experience.ProvenanceManual`; any value the caller sends
+  is discarded** — identical to what `UpdateAtom` already does. This is the one place the
+  honest wall is enforced on this new write path: `Provenance.Publishable()` treats `manual`
+  as citable into a CV precisely because it means "the owner typed this themselves, outside
+  a verified chat", which is exactly what an authenticated HTTP POST is. Accepting a
+  caller-supplied `stated_in_chat` here would let a full-scope key mint an atom that *looks*
+  chat-verified without ever having been said in a transcript the server checked.
+- **`CreateEmployment`/`AddAtom` reuse the Store's existing `Sanitize`/`Validate` — no new
+  validation is written.** Both already run on the assistant's write path; a second,
+  hand-rolled check here would be the exact kind of forked validation the codebase's own
+  conventions warn against (parallel to `internal/cv`'s token-coverage script comment about
+  a forked detector drifting from the one it copied).
+- **Response is `201` with `{"data": <created entity>}`**, matching the wire convention
+  every other creating endpoint in this handler layer uses (`POST /me/cvs`, `jobs add`,
+  etc.) — no new envelope shape.
+
+## Risks / Trade-offs
+
+- [A leaked full-scope key can now also spam the bank with junk `manual` atoms, not just
+  read it] → Mitigation: the same key already lets the leak holder do worse (edit a CV
+  bullet's text directly, mark applications applied). This does not open a new class of
+  harm, it adds one more thing an already-critical leak can do. `Sanitize`/`Validate` bound
+  size and shape, and the owner can still delete a junk atom from the web UI
+  (`DELETE /me/experience/atoms/:id`, cookie-only, unaffected by this change).
+- [A future reader of `me_experience.go` assumes the write side is symmetric with the read
+  side's auth (both full-scope-or-cookie) and widens `PUT`/`DELETE` to `mw.key` by analogy,
+  re-opening the exact hazard the file's own comment warns about] → Mitigation: none beyond
+  the existing comment; noted here so this change's diff doesn't read as license to do that
+  in a later one.

--- a/openspec/changes/experience-bank-create-routes/proposal.md
+++ b/openspec/changes/experience-bank-create-routes/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The experience bank can only be written from two places: the in-process assistant tools
+(`experience_add`, only reachable from a chat turn) and the owner's own web UI edit form
+(`PUT /me/experience/atoms/:id`, cookie-only — it corrects an existing entry, it cannot
+create one). There is no way for a programmatic, API-key-authenticated caller — the
+`freehire-cli`, or any future script the candidate runs themselves — to add a new
+achievement or role outside a chat session. `GET /me/experience` already answers to a
+full-scope key; only the write side is missing.
+
+## What Changes
+
+- Add `POST /me/experience/employments` and `POST /me/experience/atoms`, both admitted by
+  the same full-scope key `GET /me/experience` already accepts (`mw.key`) — no new API-key
+  scope. A leaked full-scope key already reaches everything else the CLI does (`cv edit`,
+  `apply`); this adds one more additive-only capability to that same trust boundary rather
+  than inventing a narrower one, which the key-minting flow does not support choosing today
+  (every user key is minted `full`, unconditionally).
+- A created atom is stamped `manual` provenance regardless of what the caller sends — the
+  same rule `PUT /me/experience/atoms/:id` already applies to an edit. There is no chat
+  transcript to check a `stated_in_chat` claim against outside a session, so `manual` (typed
+  by the owner themselves, or on their behalf with their own key) is the only provenance an
+  HTTP caller can honestly produce.
+- `freehire-cli` gains `experience list`, `experience employments add`, and `experience atoms add`
+  commands over the new and existing routes.
+
+## Capabilities
+
+### Modified Capabilities
+- `experience-bank`: gains the ability to create an employment or an atom through the
+  owner-facing HTTP surface, alongside the existing read/correct/remove.
+
+## Impact
+
+- Backend: `internal/handler/me_experience.go` (two new handlers, two new routes, the
+  `experienceBankOwner` interface gains `AddAtom` and `CreateEmployment` — both already
+  implemented on `*experience.Store`, no `internal/experience` changes needed).
+- No migration, no new API-key scope.
+- `freehire-cli` (separate repo): `internal/client/experience.go` (new),
+  `internal/cli/experience.go` (new) — `experience list`, `experience employments add`,
+  `experience atoms add`.

--- a/openspec/changes/experience-bank-create-routes/specs/experience-bank/spec.md
+++ b/openspec/changes/experience-bank-create-routes/specs/experience-bank/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: A full-scope key may create an employment or an atom
+
+The system SHALL expose `POST /me/experience/employments` and `POST /me/experience/atoms`,
+admitted by the same authentication the existing `GET /me/experience` accepts — a cookie or
+a full-scope API key. Both SHALL run the entity's existing `Sanitize`/`Validate` before
+persisting and SHALL respond `201` with `{"data": <created entity>}`. Neither SHALL require
+a narrower API-key scope than `full`, since no user-facing key-minting path can produce one
+today.
+
+#### Scenario: A full-scope key creates an employment
+
+- **WHEN** a caller authenticated with a full-scope API key posts a valid employment
+- **THEN** the employment is persisted under that caller and returned with its assigned id
+
+#### Scenario: A full-scope key creates an atom
+
+- **WHEN** a caller authenticated with a full-scope API key posts a valid atom
+- **THEN** the atom is persisted under that caller and returned with its assigned id
+
+#### Scenario: An invalid employment is refused
+
+- **WHEN** a posted employment has neither a company nor a role, or names a kind outside
+  the fixed vocabulary
+- **THEN** the request is refused and nothing is persisted
+
+#### Scenario: An invalid atom is refused
+
+- **WHEN** a posted atom carries an empty claim
+- **THEN** the request is refused and nothing is persisted
+
+### Requirement: An atom created through the API is always manual provenance
+
+Regardless of what provenance the caller sends, `POST /me/experience/atoms` SHALL persist
+the atom with `manual` provenance. This is the same rule the existing owner-edit path
+(`PUT /me/experience/atoms/:id`) already applies: `manual` means the owner typed this
+themselves, outside a chat session the server can verify — the only provenance an HTTP
+caller can honestly produce, since there is no transcript to check a `stated_in_chat` claim
+against outside a chat turn.
+
+#### Scenario: A caller-supplied provenance is discarded
+
+- **WHEN** a posted atom's body sets `provenance` to `stated_in_chat`, `cv_import`, or
+  `agent_inferred`
+- **THEN** the atom is persisted with `manual` provenance regardless of the value sent
+
+#### Scenario: A manually created atom is publishable
+
+- **WHEN** an atom created through `POST /me/experience/atoms` is later cited by its id as
+  `evidence_id` on a `cv_edit`
+- **THEN** the citation is accepted, the same as any other `manual`-provenance atom

--- a/openspec/changes/experience-bank-create-routes/tasks.md
+++ b/openspec/changes/experience-bank-create-routes/tasks.md
@@ -1,0 +1,46 @@
+## 1. Backend: POST /me/experience/employments and /atoms
+
+- [ ] 1.1 Extend `experienceBankOwner` in `internal/handler/me_experience.go` with
+  `AddAtom(ctx, userID, experience.Atom) (experience.Atom, error)` and
+  `CreateEmployment(ctx, userID, experience.Employment) (experience.Employment, error)` —
+  both already implemented on `*experience.Store`.
+- [ ] 1.2 Add `AddEmployment` and `AddAtom` handler methods: parse the body, for the atom
+  handler force `Provenance: experience.ProvenanceManual` before calling the store (mirror
+  `UpdateAtom`'s existing pattern), map `experience.ErrEmptyClaim` /
+  `ErrInvalidProvenance` / `ErrEmptyEmployment` / `ErrInvalidKind` through the existing
+  `experienceError` helper, respond `201` with `{"data": <created>}`.
+- [ ] 1.3 Register `POST /me/experience/employments` and `POST /me/experience/atoms` under
+  `mw.key` (the same middleware `GET /me/experience` already uses — full scope or cookie,
+  no new scope).
+- [ ] 1.4 Tests in `internal/handler/me_experience_test.go` (or wherever the existing
+  `/me/experience` tests live): creating a valid employment/atom persists and returns 201;
+  an invalid one is refused and nothing persists; a caller-supplied non-manual provenance on
+  an atom is silently overridden to `manual`; a cookie-only or full-scope-key caller can
+  reach both routes (matching the existing GET's auth test, if one exists) — a request with
+  no credential is refused.
+
+## 2. freehire-cli: experience list / employments add / atoms add
+
+- [ ] 2.1 `internal/client/experience.go` (new, in `github.com/strelov1/freehire-cli`):
+  `ListExperience`, `CreateEmployment`, `CreateAtom`, following the shape of
+  `internal/client/cv.go`'s existing methods (`c.do(...)`, typed params structs).
+- [ ] 2.2 `internal/cli/experience.go` (new): `experience` command group with `list`,
+  `employments add`, `atoms add` subcommands, following `internal/cli/jobs_authoring.go`'s
+  `add`-verb convention and flag style (`mustString`/`mustBool` helpers). `atoms add` takes
+  `--claim` (required), `--context`, `--metric` (repeatable), `--skill` (repeatable),
+  `--employment` (id, optional). `employments add` takes `--kind` (job|project, default
+  job), `--company`, `--role`, `--location`, `--start`, `--end`, `--current`, `--summary`.
+- [ ] 2.3 Tests in `internal/cli/experience_test.go` and `internal/client/experience_test.go`
+  (`httptest.Server`, matching the existing `cv_test.go` pattern in both packages).
+- [ ] 2.4 Update the CLI's own README/help text and bump the version per
+  `hire-cli-release-ops` convention (new commands ⇒ minor bump).
+
+## 3. Verify
+
+- [ ] 3.1 Backend: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`,
+  `go test ./...`.
+- [ ] 3.2 `openspec validate --all --strict`.
+- [ ] 3.3 freehire-cli: `go build ./...`, `go vet ./...`, `go test ./...` in that repo.
+- [ ] 3.4 Manual smoke: mint/use a real full-scope key against a local or prod server,
+  `experience employments add`, `experience atoms add` citing the returned id, `cv edit
+  --evidence <id>` with it.

--- a/openspec/changes/experience-bank-create-routes/tasks.md
+++ b/openspec/changes/experience-bank-create-routes/tasks.md
@@ -21,26 +21,29 @@
 
 ## 2. freehire-cli: experience list / employments add / atoms add
 
-- [ ] 2.1 `internal/client/experience.go` (new, in `github.com/strelov1/freehire-cli`):
+- [x] 2.1 `internal/client/experience.go` (new, in `github.com/strelov1/freehire-cli`):
   `ListExperience`, `CreateEmployment`, `CreateAtom`, following the shape of
   `internal/client/cv.go`'s existing methods (`c.do(...)`, typed params structs).
-- [ ] 2.2 `internal/cli/experience.go` (new): `experience` command group with `list`,
+- [x] 2.2 `internal/cli/experience.go` (new): `experience` command group with `list`,
   `employments add`, `atoms add` subcommands, following `internal/cli/jobs_authoring.go`'s
   `add`-verb convention and flag style (`mustString`/`mustBool` helpers). `atoms add` takes
   `--claim` (required), `--context`, `--metric` (repeatable), `--skill` (repeatable),
   `--employment` (id, optional). `employments add` takes `--kind` (job|project, default
   job), `--company`, `--role`, `--location`, `--start`, `--end`, `--current`, `--summary`.
-- [ ] 2.3 Tests in `internal/cli/experience_test.go` and `internal/client/experience_test.go`
+- [x] 2.3 Tests in `internal/cli/experience_test.go` and `internal/client/experience_test.go`
   (`httptest.Server`, matching the existing `cv_test.go` pattern in both packages).
-- [ ] 2.4 Update the CLI's own README/help text and bump the version per
-  `hire-cli-release-ops` convention (new commands ⇒ minor bump).
+- [x] 2.4 Updated the CLI's own README (`## Use` command list + an "Experience bank"
+  explainer paragraph). The version bump / release (new tag, cross-built binaries, `gh
+  release create`) is deliberately NOT done here — that is a real deploy of the public
+  installer real users pull from (`hire-cli-release-ops`), left for when the change is
+  actually ready to ship, not bundled into this commit.
 
 ## 3. Verify
 
-- [ ] 3.1 Backend: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`,
-  `go test ./...`.
-- [ ] 3.2 `openspec validate --all --strict`.
-- [ ] 3.3 freehire-cli: `go build ./...`, `go vet ./...`, `go test ./...` in that repo.
+- [x] 3.1 Backend: `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`,
+  `go test ./...` — clean. Also `go test -tags=integration ./internal/handler/...`.
+- [x] 3.2 `openspec validate --all --strict` — 213/213.
+- [x] 3.3 freehire-cli: `go build ./...`, `go vet ./...`, `go test ./...` in that repo — clean.
 - [ ] 3.4 Manual smoke: mint/use a real full-scope key against a local or prod server,
   `experience employments add`, `experience atoms add` citing the returned id, `cv edit
   --evidence <id>` with it.


### PR DESCRIPTION
## Summary
- Adds `POST /me/experience/employments` and `POST /me/experience/atoms`, admitted by the same full-scope key `GET /me/experience` already accepts — no new API-key scope. Correcting/removing an existing entry stays cookie-only, unchanged.
- An atom created this way is always stamped `manual` provenance regardless of what the caller sends, mirroring the existing `PUT /me/experience/atoms/:id` behavior — there's no chat transcript to verify a `stated_in_chat` claim against outside a session.
- `ErrAlreadyBanked` (a claim already recorded, under any spelling) now maps to `409` instead of falling through to a generic default.
- Enables `freehire-cli`'s new `experience` command group (companion PR: strelov1/freehire-cli#… — read/add to the bank without a chat session).
- OpenSpec change `experience-bank-create-routes`, reviewed by an independent agent per task (task 1: clean, no Critical/Important findings; a minor coverage gap it flagged — an out-of-vocabulary employment `kind` — is closed in a follow-up commit).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...` — clean
- [x] `go test -tags=integration ./internal/handler/...` — clean
- [x] `openspec validate --all --strict` — 213/213