### PR TITLE
feat(sources): onboard Cedars-Sinai (radancy)

### DIFF
--- a/sources/radancy.yml
+++ b/sources/radancy.yml
@@ -9,3 +9,5 @@
   board: jobs.intuit.com
 - company: Moody's
   board: careers.moodys.com
+- company: Cedars-Sinai
+  board: careers.cshs.org


### PR DESCRIPTION
## Summary
Drains the last live pending contribution — id=205, `radancy/careers.cshs.org` — into `sources/radancy.yml`. Live-validated: the sitemap lists 1755 job pages.

Not included (handled separately, no file change):
- id=208 (`cornerstone/linde`) — `linde.csod.com` root redirects to a SAML SSO login ("Welcome to Elevate", an internal portal), and the public careersite API path returns zero requisitions. Rejecting, not onboarding.

## Test plan
- [x] `go build ./...`