### PR TITLE
profile: split Skills into its own autosaving tab

### DIFF
--- a/docs/superpowers/specs/2026-08-04-profile-skills-tab-design.md
+++ b/docs/superpowers/specs/2026-08-04-profile-skills-tab-design.md
@@ -1,0 +1,92 @@
+# Profile Skills tab
+
+## Problem
+
+On `/my/profile`, the "Skills" and "Skills to avoid" fields live inside the Settings
+tab's "Skills & role" form section, alongside Role/specializations, CV upload, and
+headshot. They deserve their own top-level tab.
+
+## Scope
+
+Split Skills / Skills to avoid out into a dedicated top-level page tab, editable
+independently of the rest of the profile form (no shared "Save changes" button).
+
+Out of scope: changing the Role/specializations field, the CV upload flow's storage,
+or the `user_profiles` schema. No backend changes — the same `PUT /me/profile`
+endpoint is called, just from a different place on the frontend.
+
+## Design
+
+### Tab placement
+
+`web/src/routes/my/profile/+page.svelte`: add `{ id: 'skills', label: 'Skills' }` to
+`TABS`, right after `settings`. Like the other data tabs, it is only reachable once a
+profile exists (`profile !== null`) — during first-time set-up there are no top-level
+tabs at all, only the bare `ProfileForm`.
+
+### `ProfileForm.svelte`
+
+The Skills / Skills to avoid blocks currently in the `main` form-tab stay there **only
+while creating a profile** (`profile === null`, i.e. `!editing`) — the server requires
+at least one skill to create a profile, and the new Skills tab isn't reachable yet at
+that point. Once a profile exists (`editing`), those two blocks are removed from
+`ProfileForm`; the `main` form-tab's label changes from "Skills & role" to "Role".
+
+CV upload (`analyzeResume`):
+- `!editing` (creation flow): unchanged — extracted skills merge into the local
+  `skills` buffer, persisted together with Role on the next explicit Save.
+- `editing`: extracted skills are written straight to the profile via
+  `profileStore.addSkills(cv.skills)` (one PUT), not buffered locally. The existing
+  "Added N skills from your CV" note stays, wording adjusted to point at the Skills tab
+  instead of "below".
+
+### `profileStore` (`web/src/lib/profile.svelte.ts`)
+
+New method:
+
+```ts
+addSkills(skills: string[]): Promise<UserProfile>
+```
+
+Folds `withSkill` (from `profileSkills.ts`) over each new skill and issues a single
+PUT — the bulk counterpart to the existing one-at-a-time `addSkill`. Queued through the
+same `#queue` as the other mutators so it can't race a manual toggle made from the new
+Skills tab.
+
+### `SkillsView.svelte` (new)
+
+`web/src/lib/components/SkillsView.svelte`, modeled on `ExperienceBankView` /
+`VerdictView`. No local buffered skill state — reads `profileStore.profile?.skills` /
+`?.excluded_skills` reactively, same as `JobMatch.svelte`'s existing `avoided` derived
+set. Renders the same two `RemoteSearchSelect` blocks (counts, chip styling, copy) that
+exist today in `ProfileForm`.
+
+Toggling a chip calls `profileStore.addSkill` / `removeSkill` / `avoidSkill` /
+`unavoidSkill` directly — writes go out immediately, no Save button. Error/pending
+handling mirrors `JobMatch.svelte`: one `pending` boolean disables both controls while
+a write is in flight; a `failed: string | null` renders
+`Could not update {failed} in your profile. Try again.` on rejection.
+
+### Shared skill-dictionary loader
+
+Both `ProfileForm` and `SkillsView` need the typeahead's skill universe (currently
+`ProfileForm.loadSkills()`: `api.facetCounts` → sort by count). Extract this into
+`web/src/lib/skillDictionary.ts`, exporting `loadSkillDistribution(): Promise<FacetOption[]>`,
+so the fetch/sort logic isn't duplicated between the two components.
+
+## Error handling
+
+No new error-handling design needed — reuses the `JobMatch.svelte` pattern verbatim
+(try/catch per mutator call, `failed` state, generic per-skill message).
+
+## Testing
+
+No backend changes, so no Go-side tests. No frontend unit-test runner in this repo
+(vitest config edits are inert here). Manual verification via dev server:
+
+1. Create a profile from scratch — Skills and Role still required together, form
+   behaves as today.
+2. Edit an existing profile — toggle a skill and an avoided skill on the new Skills
+   tab; confirm each persists immediately with no Save click, and survives a reload.
+3. Upload a CV against an existing profile — confirm extracted skills land in the
+   profile automatically (visible on the Skills tab) without touching Save.

--- a/openspec/changes/profile-skills-tab/.openspec.yaml
+++ b/openspec/changes/profile-skills-tab/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/profile-skills-tab/design.md
+++ b/openspec/changes/profile-skills-tab/design.md
@@ -71,6 +71,20 @@ universe — `api.facetCounts` → sort by descending job count. Extracted to
 `web/src/lib/skillDictionary.ts` (`loadSkillDistribution(): Promise<FacetOption[]>`)
 rather than duplicated, since it's now needed in two independent components.
 
+**The Skills tab refuses to remove or avoid a profile's one remaining skill,
+client-side, before attempting a write.**
+`normalizeSkills` (`internal/userprofile/userprofile.go`) requires a non-empty
+skill set on every save, not only at creation — `Save` is the single path both
+flows go through. Without a `ProfileForm`-style Save-button gate, an autosaving
+Skills tab has no other checkpoint before the request goes out, so removing (or
+avoiding, which also un-claims) the last skill would always come back a 400.
+Caught in `SkillsView.svelte` before the call: `skills.length === 1 &&
+skills.includes(skill)` blocks the toggle and shows a message that a skill is
+required, instead of sending a request that cannot succeed and reporting it
+through the generic (retry-implying) failed-write copy. Found during review of
+task 3 — see the "Removing the one remaining skill is refused client-side"
+scenario added to the spec delta.
+
 ## Risks / Trade-offs
 
 - **[Risk]** A user toggles a skill on the new tab while `ProfileForm`'s

--- a/openspec/changes/profile-skills-tab/design.md
+++ b/openspec/changes/profile-skills-tab/design.md
@@ -1,0 +1,101 @@
+## Context
+
+`/my/profile`'s Settings tab renders `ProfileForm.svelte`, a two-tab form
+("Skills & role" / "Location & work") sharing one "Save changes" button that PUTs
+the whole profile row. Skills and Skills to avoid currently sit in the "Skills &
+role" tab next to Role/specializations, CV upload, and headshot.
+
+`profileStore` (`web/src/lib/profile.svelte.ts`) already exposes single-skill
+autosave mutators — `addSkill`/`removeSkill`/`avoidSkill`/`unavoidSkill` — each
+issuing its own `PUT /me/profile` through a serial queue (so two edits made a
+moment apart don't clobber each other, since the endpoint replaces the whole
+row). These are used today by `JobMatch.svelte`'s "I have it" / "Avoid" chips on
+a job posting — proof the autosave pattern already works end-to-end, just not
+yet exposed as a standalone profile-editing surface.
+
+Top-level page tabs on `/my/profile` (`web/src/routes/my/profile/+page.svelte`)
+only render once a profile exists; before that, the bare `ProfileForm` is the
+entire page (no tab strip). The server also requires at least one skill to
+create a profile (`skills` must be non-empty on `PUT /me/profile`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give Skills / Skills to avoid their own top-level tab, edited with immediate
+  per-toggle autosave (no shared Save button).
+- Keep first-time profile creation working unchanged (Role + Skills entered
+  together, one Save, since no profile — and no tab strip — exists yet).
+- Keep CV-driven skill extraction working for an existing profile without a
+  Settings-tab skills field to merge into.
+
+**Non-Goals:**
+- No change to the `PUT /api/v1/me/profile` contract or `user_profiles` schema.
+- No change to Role/specializations, location preferences, headshot, or CV
+  storage/readiness behavior.
+- No new "review before applying" UI for CV-extracted skills (out of scope per
+  the resolved design question — extraction autosaves directly).
+
+## Decisions
+
+**Skills tab reads/writes the store directly; no local buffer.**
+`SkillsView.svelte` renders straight off `profileStore.profile?.skills` /
+`?.excluded_skills` and calls `addSkill`/`removeSkill`/`avoidSkill`/`unavoidSkill`
+on each chip toggle — mirroring `JobMatch.svelte`'s existing `avoided` derived-set
+pattern. Alternative considered: give the new tab its own buffered
+skills/excludedSkills state plus a local Save button, matching `ProfileForm`'s
+existing shape. Rejected — it would duplicate the buffer-and-PUT machinery
+`ProfileForm` already has, when the per-skill mutators already do exactly this
+job and are proven in production by `JobMatch`.
+
+**Skills stays inside `ProfileForm` during creation, leaves it once editing.**
+`ProfileForm` keeps its skills/excluded-skills fields when `profile === null`
+(`!editing`) because the create flow has no tab strip yet and the server won't
+accept a skill-less profile. Once a profile exists, those fields disappear from
+the form; the "Skills & role" tab is relabeled "Role". Alternative considered:
+always show a placeholder/link in Settings pointing at the new tab. Rejected as
+unnecessary indirection — the new top-level tab is one click away in the same
+tab strip.
+
+**CV upload against an existing profile autosaves extracted skills via a new
+bulk mutator, not N sequential single-skill calls.**
+`profileStore.addSkills(skills: string[])` folds `withSkill` over every
+extracted skill and issues one `PUT`, queued through the same `#queue` as the
+other mutators (so it can't race a manual toggle from the Skills tab). Looping
+the existing single-skill `addSkill` was considered and rejected: it would issue
+one full-row `PUT` per extracted skill (5-15 typically), all serialized, for no
+benefit over one bulk write.
+
+**Shared skill-dictionary loader.**
+Both `ProfileForm` (create flow) and `SkillsView` need the same typeahead
+universe — `api.facetCounts` → sort by descending job count. Extracted to
+`web/src/lib/skillDictionary.ts` (`loadSkillDistribution(): Promise<FacetOption[]>`)
+rather than duplicated, since it's now needed in two independent components.
+
+## Risks / Trade-offs
+
+- **[Risk]** A user toggles a skill on the new tab while `ProfileForm`'s
+  Settings tab is also mounted (both subscribe to the same `profileStore`,
+  possible only in the create-flow's absence of tabs — not reachable once
+  editing, since Settings and Skills are mutually exclusive tab panels). →
+  **Mitigation**: not reachable in practice; the two are never both mounted for
+  an existing profile since `TabRow` shows one panel at a time.
+- **[Risk]** Losing the explicit Save affordance could surprise a user used to
+  reviewing before committing. → **Mitigation**: this mirrors the existing,
+  shipped `JobMatch` skill-editing UX exactly, so the interaction pattern is
+  already validated in this codebase, not a novel one.
+- **[Trade-off]** CV-extracted skills for an existing profile now write
+  immediately with no review step, vs. the "surface as suggestions" alternative
+  considered and declined during brainstorming (adds a review UI for a case that
+  behaves acceptably today: false extractions can simply be removed on the
+  Skills tab, same as an unwanted manual entry).
+
+## Migration Plan
+
+Frontend-only, single deploy, no data migration, no feature flag. Rollback is a
+plain revert (no schema/API change to unwind).
+
+## Open Questions
+
+None outstanding — placement, autosave-vs-Save, and CV-extraction behavior were
+resolved during brainstorming (see
+`docs/superpowers/specs/2026-08-04-profile-skills-tab-design.md`).

--- a/openspec/changes/profile-skills-tab/design.md
+++ b/openspec/changes/profile-skills-tab/design.md
@@ -56,14 +56,27 @@ always show a placeholder/link in Settings pointing at the new tab. Rejected as
 unnecessary indirection — the new top-level tab is one click away in the same
 tab strip.
 
-**CV upload against an existing profile autosaves extracted skills via a new
-bulk mutator, not N sequential single-skill calls.**
-`profileStore.addSkills(skills: string[])` folds `withSkill` over every
-extracted skill and issues one `PUT`, queued through the same `#queue` as the
-other mutators (so it can't race a manual toggle from the Skills tab). Looping
-the existing single-skill `addSkill` was considered and rejected: it would issue
-one full-row `PUT` per extracted skill (5-15 typically), all serialized, for no
-benefit over one bulk write.
+**CV upload against an existing profile autosaves extracted skills AND any
+specialization the same extraction resolved, together, in one write — not two,
+and not N sequential single-skill calls.**
+`profileStore.mergeResumeExtraction(newSkills, specializations)` folds
+`withSkills` over the extracted skills and saves them alongside the caller's
+already-locally-merged specializations, queued through the same `#queue` as the
+other mutators. Two candidates were rejected:
+- Looping the single-skill `addSkill`: one full-row `PUT` per extracted skill
+  (5-15 typically), all serialized, for no benefit over one bulk write.
+- A skills-only bulk mutator (the first version of this decision, `addSkills`,
+  called alone): found in review of task 4 to silently drop any specialization
+  the same CV resolved. `ProfileForm` is wrapped in `{#key profile.updated_at}`
+  (`+page.svelte`), so ANY write to the profile row remounts it fresh from the
+  server — including a write this same component triggers for skills alone. A
+  specialization merged into `ProfileForm`'s local (unsaved) state moments
+  earlier, in the same `analyzeResume()` call, would still be sitting in that
+  local state when the remount discarded it — the user would never get a
+  chance to save it via the visible Role field, because the field's own
+  component instance is already gone. Committing specializations in the SAME
+  write as the skills closes this: nothing is left in local-only state for the
+  remount to orphan.
 
 **Shared skill-dictionary loader.**
 Both `ProfileForm` (create flow) and `SkillsView` need the same typeahead
@@ -102,6 +115,17 @@ scenario added to the spec delta.
   considered and declined during brainstorming (adds a review UI for a case that
   behaves acceptably today: false extractions can simply be removed on the
   Skills tab, same as an unwanted manual entry).
+- **[Risk]** The same `{#key profile.updated_at}` remount that would have
+  discarded an unsaved specialization (see the decision above) may also mean
+  `ProfileForm`'s own `resumeNote` confirmation ("Added N skills…") never
+  renders for an editing-mode CV upload — by the time `mergeResumeExtraction`'s
+  write resolves and the component would show the note, the remount may already
+  have replaced it with a fresh instance. → **Mitigation**: the DATA is
+  unaffected (this is display-only, unlike the specialization-loss bug), and the
+  result is directly visible on the Skills tab regardless. Verify empirically
+  in a browser during task 5 (Verification) rather than guessing at Svelte's
+  effect-flush timing; not worth a structural fix (e.g. lifting the note to the
+  parent) unless that verification shows it matters in practice.
 
 ## Migration Plan
 

--- a/openspec/changes/profile-skills-tab/design.md
+++ b/openspec/changes/profile-skills-tab/design.md
@@ -122,10 +122,12 @@ scenario added to the spec delta.
   write resolves and the component would show the note, the remount may already
   have replaced it with a fresh instance. → **Mitigation**: the DATA is
   unaffected (this is display-only, unlike the specialization-loss bug), and the
-  result is directly visible on the Skills tab regardless. Verify empirically
-  in a browser during task 5 (Verification) rather than guessing at Svelte's
-  effect-flush timing; not worth a structural fix (e.g. lifting the note to the
-  parent) unless that verification shows it matters in practice.
+  result is directly visible on the Skills tab regardless. Meant to be verified
+  empirically in a browser during task 5 (Verification) rather than guessed at
+  from Svelte's effect-flush timing — that verification was skipped (see task
+  5's notes), so this remains unconfirmed either way. Not worth a structural
+  fix (e.g. lifting the note to the parent) unless a future check shows it
+  matters in practice.
 
 ## Migration Plan
 

--- a/openspec/changes/profile-skills-tab/proposal.md
+++ b/openspec/changes/profile-skills-tab/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+On `/my/profile`, Skills and Skills to avoid live inside the Settings tab's form,
+bundled with Role, CV upload, headshot, and location preferences under one shared
+"Save changes" button. They deserve their own top-level tab, edited independently
+with immediate autosave — matching how the job-match block already edits a single
+skill today.
+
+## What Changes
+
+- Add a top-level "Skills" tab to `/my/profile` (visible once a profile exists),
+  containing the Skills and Skills to avoid controls.
+- Toggling a skill or an avoided skill on the new tab writes to the profile
+  immediately (one `PUT /me/profile` per toggle, via the existing per-skill
+  mutators) — no Save button on this tab.
+- Remove the Skills / Skills to avoid controls from the Settings form once a
+  profile exists; the Settings form's first section becomes "Role" only. During
+  first-time profile creation (no profile yet, no tabs), Skills stays in the
+  creation form alongside Role, since creating a profile still requires at least
+  one skill up front.
+- CV upload against an **existing** profile now writes extracted skills straight
+  to the profile (one bulk `PUT`) instead of buffering them in the Settings form
+  until a manual Save. CV upload during first-time creation is unchanged.
+- Add a bulk `addSkills` mutator to the frontend profile store (single PUT for
+  multiple new skills), and a shared skill-dictionary loader used by both the
+  Settings form and the new Skills tab.
+- No backend changes: same `PUT /api/v1/me/profile` endpoint, called from a
+  different place in the frontend.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `search-profiles`: the "Profile management UI" and "Populate profile skills
+  from a resume" requirements change — skills editing moves to its own tab with
+  autosave instead of being part of the shared-Save settings form.
+
+## Impact
+
+- Frontend only: `web/src/routes/my/profile/+page.svelte`,
+  `web/src/lib/components/ProfileForm.svelte`,
+  `web/src/lib/profile.svelte.ts`, `web/src/lib/skillDictionary.ts` (new),
+  `web/src/lib/components/SkillsView.svelte` (new).
+- No migrations, no API contract change, no other package affected.

--- a/openspec/changes/profile-skills-tab/proposal.md
+++ b/openspec/changes/profile-skills-tab/proposal.md
@@ -18,12 +18,13 @@ skill today.
   first-time profile creation (no profile yet, no tabs), Skills stays in the
   creation form alongside Role, since creating a profile still requires at least
   one skill up front.
-- CV upload against an **existing** profile now writes extracted skills straight
-  to the profile (one bulk `PUT`) instead of buffering them in the Settings form
-  until a manual Save. CV upload during first-time creation is unchanged.
-- Add a bulk `addSkills` mutator to the frontend profile store (single PUT for
-  multiple new skills), and a shared skill-dictionary loader used by both the
-  Settings form and the new Skills tab.
+- CV upload against an **existing** profile now writes extracted skills — and
+  any specialization the same extraction resolved — straight to the profile in
+  one PUT, instead of buffering them in the Settings form until a manual Save.
+  CV upload during first-time creation is unchanged.
+- Add a `mergeResumeExtraction` mutator to the frontend profile store (single
+  PUT for new skills plus specializations together), and a shared
+  skill-dictionary loader used by both the Settings form and the new Skills tab.
 - No backend changes: same `PUT /api/v1/me/profile` endpoint, called from a
   different place in the frontend.
 

--- a/openspec/changes/profile-skills-tab/specs/search-profiles/spec.md
+++ b/openspec/changes/profile-skills-tab/specs/search-profiles/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: Profile management UI
+The web app SHALL present signed-in users a view at `/my/profile` that shows their
+one profile and lets them edit or clear it, and SHALL prompt anonymous users to sign
+in instead. There is no profile name and no list of profiles. Before a profile
+exists, the view SHALL show a single inline set-up form covering Role
+(specializations, capped at 5), CV upload, headshot, and Skills together — the
+server requires at least one specialization and at least one skill to create a
+profile, so both SHALL be collected before the first save, and the set-up form's
+Save control SHALL be enabled exactly when at least one specialization and at
+least one skill are present. Once a profile exists, the view SHALL present a
+top-level tab strip including a "Settings" tab (CV upload, headshot, Role, and
+location & work preferences, saved together via one Save control scoped to that
+tab's fields) and a separate "Skills" tab holding the Skills and Skills to avoid
+controls. Skill and skill-to-avoid edits on the Skills tab SHALL take effect
+immediately (no Save control on that tab) per the "Autosave skill edits on an
+existing profile" requirement below. Skills and skills-to-avoid selection SHALL
+use a searchable multi-select sourcing its candidates from the live skills facet
+endpoint, with a skill never selectable in both sets at once.
+
+#### Scenario: Create the profile from the set-up form
+- **WHEN** a signed-in user with no profile yet picks one or more specializations and skills in the set-up form and saves
+- **THEN** the app calls `PUT /api/v1/me/profile` and the view switches to the tabbed, existing-profile layout
+
+#### Scenario: Edit Role on an existing profile
+- **WHEN** a signed-in user who already has a profile opens the Settings tab
+- **THEN** its controls are pre-seeded with their current Role, CV, headshot, and location preferences, and saving them does not require re-entering skills
+
+#### Scenario: Skills use a live facet-backed search control
+- **WHEN** a signed-in user edits skills or skills-to-avoid on the Skills tab, or Role in Settings' set-up-time skills field
+- **THEN** the control lists canonical skills sourced from the live skills facet endpoint, filtered to the typed query (not a static/bundled list)
+
+#### Scenario: Set-up Save control reflects completeness
+- **WHEN** a signed-in user with no profile yet has entered at least one specialization and at least one skill in the set-up form
+- **THEN** the Save control is enabled; when either is missing it is disabled
+
+#### Scenario: Anonymous prompt
+- **WHEN** an anonymous (signed-out) user opens `/my/profile`
+- **THEN** the view shows a "sign in" affordance instead of the profile
+
+### Requirement: Populate profile skills from a resume
+The profile view SHALL let a user upload a resume (PDF) from the Settings tab and
+extract skills from it via the `resume-skill-extraction` capability, merged as a
+union with skills already on the profile (deduplicated) — it SHALL NOT remove or
+overwrite skills already present. Before a profile exists, extracted skills merge
+into the set-up form's in-memory skills field, editable before the first save.
+Once a profile exists, extracted skills SHALL be written to the profile
+immediately (one additional `PUT /api/v1/me/profile` beyond whatever the Settings
+tab itself saves), visible on the Skills tab; the user can remove any unwanted
+extracted skill there afterwards, same as any other skill.
+
+#### Scenario: Merge extracted skills into an empty set-up form
+- **WHEN** a user with no profile and an empty skills field uploads a resume and extraction returns `[go, postgresql]`
+- **THEN** the set-up form's skills field contains exactly `[go, postgresql]`, unsaved until the user saves
+
+#### Scenario: Merge extracted skills without wiping existing entries
+- **WHEN** a user whose set-up form already has `[docker]` uploads a resume returning `[go, docker, postgresql]`
+- **THEN** the form's skills field contains the union `[docker, go, postgresql]` with no duplicates
+
+#### Scenario: Extraction in progress shows a loading state
+- **WHEN** the resume is being uploaded and analyzed
+- **THEN** the upload control shows a loading/disabled state until extraction completes or fails
+
+#### Scenario: Extracted skills autosave to an existing profile
+- **WHEN** a user who already has a profile with skills `[docker]` uploads a resume from the Settings tab returning `[go, docker, postgresql]`
+- **THEN** the profile's skills become `[docker, go, postgresql]` immediately, without the user pressing Settings' Save control, and are visible on the Skills tab
+
+## ADDED Requirements
+
+### Requirement: Autosave skill edits on an existing profile
+For a signed-in user who already has a profile, toggling a skill or an avoided
+skill on the Skills tab SHALL write to the profile immediately via
+`PUT /api/v1/me/profile`, without a Save control on that tab. Claiming a skill
+SHALL also stop avoiding it if it was avoided, and avoiding a skill SHALL also
+un-claim it if it was claimed — a skill is never in both sets. While a write from
+one toggle is in flight, the Skills tab's controls SHALL be disabled so a second
+toggle cannot be started against a stale pre-write state. A write that fails
+SHALL leave the profile's stored skills unchanged and SHALL show an inline error
+naming the skill that failed.
+
+#### Scenario: Claiming a skill autosaves
+- **WHEN** a signed-in user with an existing profile toggles on a skill on the Skills tab
+- **THEN** the app calls `PUT /api/v1/me/profile` with that skill added, with no Save control involved
+
+#### Scenario: Avoiding a skill drops it from the held set
+- **WHEN** a signed-in user's profile holds skill `go` and they mark `go` as avoided on the Skills tab
+- **THEN** the saved profile's skills no longer include `go` and its excluded_skills does
+
+#### Scenario: A second toggle is blocked while the first is saving
+- **WHEN** a signed-in user toggles a skill on the Skills tab and the write to the server has not yet completed
+- **THEN** the tab's skill controls are disabled until that write settles
+
+#### Scenario: A failed write is surfaced without silently reverting
+- **WHEN** a signed-in user toggles a skill on the Skills tab and the save request fails
+- **THEN** the profile's stored skills remain whatever they were before the toggle, and the tab shows an inline error naming the skill

--- a/openspec/changes/profile-skills-tab/specs/search-profiles/spec.md
+++ b/openspec/changes/profile-skills-tab/specs/search-profiles/spec.md
@@ -45,10 +45,16 @@ extract skills from it via the `resume-skill-extraction` capability, merged as a
 union with skills already on the profile (deduplicated) — it SHALL NOT remove or
 overwrite skills already present. Before a profile exists, extracted skills merge
 into the set-up form's in-memory skills field, editable before the first save.
-Once a profile exists, extracted skills SHALL be written to the profile
-immediately (one additional `PUT /api/v1/me/profile` beyond whatever the Settings
-tab itself saves), visible on the Skills tab; the user can remove any unwanted
-extracted skill there afterwards, same as any other skill.
+Once a profile exists, extracted skills — and any specialization the same
+extraction resolved — SHALL be written to the profile together, in one
+additional `PUT /api/v1/me/profile` beyond whatever the Settings tab itself
+saves. Skills and specializations SHALL commit in the SAME write, not two
+separate ones: the Settings tab is remounted from the server's own row on any
+write to it, so a specialization merged only into this component's local state
+by a skills-only write would be discarded, unsaved, before the user could ever
+save it through the visible Role field. Extracted skills are visible on the
+Skills tab; the user can remove any unwanted extracted skill there afterwards,
+same as any other skill.
 
 #### Scenario: Merge extracted skills into an empty set-up form
 - **WHEN** a user with no profile and an empty skills field uploads a resume and extraction returns `[go, postgresql]`
@@ -65,6 +71,10 @@ extracted skill there afterwards, same as any other skill.
 #### Scenario: Extracted skills autosave to an existing profile
 - **WHEN** a user who already has a profile with skills `[docker]` uploads a resume from the Settings tab returning `[go, docker, postgresql]`
 - **THEN** the profile's skills become `[docker, go, postgresql]` immediately, without the user pressing Settings' Save control, and are visible on the Skills tab
+
+#### Scenario: An extraction-resolved specialization commits in the same write as its skills
+- **WHEN** a user who already has a profile uploads a resume that resolves both new skills and a specialization not yet on the profile
+- **THEN** both land in the profile from that single upload, without the user pressing Settings' Save control
 
 ## ADDED Requirements
 

--- a/openspec/changes/profile-skills-tab/specs/search-profiles/spec.md
+++ b/openspec/changes/profile-skills-tab/specs/search-profiles/spec.md
@@ -77,7 +77,12 @@ un-claim it if it was claimed — a skill is never in both sets. While a write f
 one toggle is in flight, the Skills tab's controls SHALL be disabled so a second
 toggle cannot be started against a stale pre-write state. A write that fails
 SHALL leave the profile's stored skills unchanged and SHALL show an inline error
-naming the skill that failed.
+naming the skill that failed. The server requires at least one skill on every
+save, not only at profile creation — removing the profile's one remaining skill,
+or avoiding it (which also un-claims it), would always be rejected. The Skills
+tab SHALL refuse that specific toggle client-side, without attempting the write,
+and SHALL show a message stating a skill is required rather than the generic
+retry error.
 
 #### Scenario: Claiming a skill autosaves
 - **WHEN** a signed-in user with an existing profile toggles on a skill on the Skills tab
@@ -94,3 +99,7 @@ naming the skill that failed.
 #### Scenario: A failed write is surfaced without silently reverting
 - **WHEN** a signed-in user toggles a skill on the Skills tab and the save request fails
 - **THEN** the profile's stored skills remain whatever they were before the toggle, and the tab shows an inline error naming the skill
+
+#### Scenario: Removing the one remaining skill is refused client-side
+- **WHEN** a signed-in user's profile holds exactly one skill and they try to remove it, or to mark it as avoided, on the Skills tab
+- **THEN** no write is sent to the server, the skill remains in the profile's `skills`, and the tab shows a message that a skill is required

--- a/openspec/changes/profile-skills-tab/tasks.md
+++ b/openspec/changes/profile-skills-tab/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Profile store: bulk skill autosave
 
-- [ ] 1.1 Add `addSkills(skills: string[])` to `ProfileStore` (`web/src/lib/profile.svelte.ts`): fold `withSkill` (from `profileSkills.ts`) over every new skill and issue a single `PUT` through the existing `#writeSkills`/`#queue` machinery.
+- [x] 1.1 Add `addSkills(skills: string[])` to `ProfileStore` (`web/src/lib/profile.svelte.ts`): fold `withSkill` (from `profileSkills.ts`) over every new skill and issue a single `PUT` through the existing `#writeSkills`/`#queue` machinery.
 
 ## 2. Shared skill-dictionary loader
 

--- a/openspec/changes/profile-skills-tab/tasks.md
+++ b/openspec/changes/profile-skills-tab/tasks.md
@@ -4,8 +4,8 @@
 
 ## 2. Shared skill-dictionary loader
 
-- [ ] 2.1 Extract the skills-typeahead fetch+sort (`api.facetCounts` → `FacetOption[]` sorted by descending count) out of `ProfileForm.svelte`'s `loadSkills()` into `web/src/lib/skillDictionary.ts`, exporting `loadSkillDistribution(): Promise<FacetOption[]>`.
-- [ ] 2.2 Update `ProfileForm.svelte` to call the shared loader instead of its inline copy.
+- [x] 2.1 Extract the skills-typeahead fetch+sort (`api.facetCounts` → `FacetOption[]` sorted by descending count) out of `ProfileForm.svelte`'s `loadSkills()` into `web/src/lib/skillDictionary.ts`, exporting `loadSkillDistribution(): Promise<FacetOption[]>`.
+- [x] 2.2 Update `ProfileForm.svelte` to call the shared loader instead of its inline copy.
 
 ## 3. New Skills tab
 

--- a/openspec/changes/profile-skills-tab/tasks.md
+++ b/openspec/changes/profile-skills-tab/tasks.md
@@ -9,9 +9,9 @@
 
 ## 3. New Skills tab
 
-- [ ] 3.1 Create `web/src/lib/components/SkillsView.svelte`: reads `profileStore.profile?.skills` / `?.excluded_skills` reactively (no local buffer), renders the Skills and Skills to avoid `RemoteSearchSelect` blocks (moved from `ProfileForm`, same copy/styling), loads its typeahead universe via `loadSkillDistribution()`.
-- [ ] 3.2 Wire toggle handlers to `profileStore.addSkill`/`removeSkill`/`avoidSkill`/`unavoidSkill`, with a single `pending` boolean disabling both controls while a write is in flight, and a `failed: string | null` rendering `Could not update {failed} in your profile. Try again.` on rejection (mirrors `JobMatch.svelte`).
-- [ ] 3.3 Add `{ id: 'skills', label: 'Skills' }` to `TABS` in `web/src/routes/my/profile/+page.svelte` (after `settings`) and render `<SkillsView />` in the tab body for that id.
+- [x] 3.1 Create `web/src/lib/components/SkillsView.svelte`: reads `profileStore.profile?.skills` / `?.excluded_skills` reactively (no local buffer), renders the Skills and Skills to avoid `RemoteSearchSelect` blocks (moved from `ProfileForm`, same copy/styling), loads its typeahead universe via `loadSkillDistribution()`.
+- [x] 3.2 Wire toggle handlers to `profileStore.addSkill`/`removeSkill`/`avoidSkill`/`unavoidSkill`, with a single `pending` boolean disabling both controls while a write is in flight, and a `failed: string | null` rendering `Could not update {failed} in your profile. Try again.` on rejection (mirrors `JobMatch.svelte`). Also blocks — client-side, before the write — removing or avoiding the profile's one remaining skill, which the server would always reject.
+- [x] 3.3 Add `{ id: 'skills', label: 'Skills' }` to `TABS` in `web/src/routes/my/profile/+page.svelte` (after `settings`) and render `<SkillsView />` in the tab body for that id.
 
 ## 4. Settings form: drop Skills once a profile exists
 

--- a/openspec/changes/profile-skills-tab/tasks.md
+++ b/openspec/changes/profile-skills-tab/tasks.md
@@ -1,0 +1,26 @@
+## 1. Profile store: bulk skill autosave
+
+- [ ] 1.1 Add `addSkills(skills: string[])` to `ProfileStore` (`web/src/lib/profile.svelte.ts`): fold `withSkill` (from `profileSkills.ts`) over every new skill and issue a single `PUT` through the existing `#writeSkills`/`#queue` machinery.
+
+## 2. Shared skill-dictionary loader
+
+- [ ] 2.1 Extract the skills-typeahead fetch+sort (`api.facetCounts` → `FacetOption[]` sorted by descending count) out of `ProfileForm.svelte`'s `loadSkills()` into `web/src/lib/skillDictionary.ts`, exporting `loadSkillDistribution(): Promise<FacetOption[]>`.
+- [ ] 2.2 Update `ProfileForm.svelte` to call the shared loader instead of its inline copy.
+
+## 3. New Skills tab
+
+- [ ] 3.1 Create `web/src/lib/components/SkillsView.svelte`: reads `profileStore.profile?.skills` / `?.excluded_skills` reactively (no local buffer), renders the Skills and Skills to avoid `RemoteSearchSelect` blocks (moved from `ProfileForm`, same copy/styling), loads its typeahead universe via `loadSkillDistribution()`.
+- [ ] 3.2 Wire toggle handlers to `profileStore.addSkill`/`removeSkill`/`avoidSkill`/`unavoidSkill`, with a single `pending` boolean disabling both controls while a write is in flight, and a `failed: string | null` rendering `Could not update {failed} in your profile. Try again.` on rejection (mirrors `JobMatch.svelte`).
+- [ ] 3.3 Add `{ id: 'skills', label: 'Skills' }` to `TABS` in `web/src/routes/my/profile/+page.svelte` (after `settings`) and render `<SkillsView />` in the tab body for that id.
+
+## 4. Settings form: drop Skills once a profile exists
+
+- [ ] 4.1 In `ProfileForm.svelte`, gate the Skills / Skills to avoid blocks behind `!editing` (keep them for first-time profile creation only); relabel the `main` form-tab from "Skills & role" to "Role" when `editing`.
+- [ ] 4.2 Update `analyzeResume()`: when `!editing`, keep merging extracted skills into the local `skills` buffer (unchanged creation-flow behavior); when `editing`, call `profileStore.addSkills(cv.skills)` directly instead of touching local state. Adjust the `resumeNote` copy for the `editing` case to point at the Skills tab instead of "below".
+
+## 5. Verification
+
+- [ ] 5.1 `go vet ./...` and the web build/lint/check scripts pass (no backend behavior changed, but confirm nothing else broke).
+- [ ] 5.2 Manual: create a profile from scratch — Role and Skills still required together in the set-up form, Save gating unchanged.
+- [ ] 5.3 Manual: edit an existing profile — toggle a skill and an avoided skill on the new Skills tab, confirm each persists immediately with no Save click and survives a reload; spot-check the disabled-while-pending and error states.
+- [ ] 5.4 Manual: upload a CV against an existing profile — confirm extracted skills land in the profile automatically and are visible on the Skills tab, without touching Settings' Save.

--- a/openspec/changes/profile-skills-tab/tasks.md
+++ b/openspec/changes/profile-skills-tab/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Profile store: bulk skill autosave
 
-- [x] 1.1 Add `addSkills(skills: string[])` to `ProfileStore` (`web/src/lib/profile.svelte.ts`): fold `withSkill` (from `profileSkills.ts`) over every new skill and issue a single `PUT` through the existing `#writeSkills`/`#queue` machinery.
+- [x] 1.1 Add `addSkills(skills: string[])` to `ProfileStore` (`web/src/lib/profile.svelte.ts`): fold `withSkill` (from `profileSkills.ts`) over every new skill and issue a single `PUT` through the existing `#writeSkills`/`#queue` machinery. **Superseded in task 4.2**: replaced by `mergeResumeExtraction`, its only call site's needs having grown to include specializations too — see task 4.2's note.
 
 ## 2. Shared skill-dictionary loader
 
@@ -15,8 +15,8 @@
 
 ## 4. Settings form: drop Skills once a profile exists
 
-- [ ] 4.1 In `ProfileForm.svelte`, gate the Skills / Skills to avoid blocks behind `!editing` (keep them for first-time profile creation only); relabel the `main` form-tab from "Skills & role" to "Role" when `editing`.
-- [ ] 4.2 Update `analyzeResume()`: when `!editing`, keep merging extracted skills into the local `skills` buffer (unchanged creation-flow behavior); when `editing`, call `profileStore.addSkills(cv.skills)` directly instead of touching local state. Adjust the `resumeNote` copy for the `editing` case to point at the Skills tab instead of "below".
+- [x] 4.1 In `ProfileForm.svelte`, gate the Skills / Skills to avoid blocks behind `!editing` (keep them for first-time profile creation only); relabel the `main` form-tab from "Skills & role" to "Role" when `editing`.
+- [x] 4.2 Update `analyzeResume()`: when `!editing`, keep merging extracted skills into the local `skills` buffer (unchanged creation-flow behavior); when `editing`, persist extracted skills directly instead of touching local state. Adjust the `resumeNote` copy for the `editing` case to point at the Skills tab instead of "below". **Revised during review**: a skills-only write (the originally-planned `profileStore.addSkills(cv.skills)`) triggers `ProfileForm`'s own `{#key profile.updated_at}` remount and silently discards any specialization the same extraction resolved into local state. Fixed by committing both together via `profileStore.mergeResumeExtraction(cv.skills, nextSpecializations)` (replaces the task-1.1 `addSkills` mutator, since it had no other caller) — see `design.md`'s "CV upload against an existing profile autosaves..." decision.
 
 ## 5. Verification
 

--- a/openspec/changes/profile-skills-tab/tasks.md
+++ b/openspec/changes/profile-skills-tab/tasks.md
@@ -20,7 +20,7 @@
 
 ## 5. Verification
 
-- [ ] 5.1 `go vet ./...` and the web build/lint/check scripts pass (no backend behavior changed, but confirm nothing else broke).
-- [ ] 5.2 Manual: create a profile from scratch — Role and Skills still required together in the set-up form, Save gating unchanged.
-- [ ] 5.3 Manual: edit an existing profile — toggle a skill and an avoided skill on the new Skills tab, confirm each persists immediately with no Save click and survives a reload; spot-check the disabled-while-pending and error states.
-- [ ] 5.4 Manual: upload a CV against an existing profile — confirm extracted skills land in the profile automatically and are visible on the Skills tab, without touching Settings' Save.
+- [x] 5.1 `go vet ./...` and the web build/lint/check scripts pass (no backend behavior changed, but confirm nothing else broke). Verified: `go build ./...`, `go vet ./...`, `pnpm run build`, `pnpm run check` (0 errors), `pnpm run lint` (exit 0, no touched-file findings), `pnpm exec vitest run` (830/830) all green.
+- [ ] 5.2 Manual: create a profile from scratch — Role and Skills still required together in the set-up form, Save gating unchanged. **Skipped**: user opted out of standing up a full local stack (Postgres/Meilisearch/env) for browser QA in this worktree, given the automated coverage above plus two rounds of independent code review. Not verified in a live browser.
+- [ ] 5.3 Manual: edit an existing profile — toggle a skill and an avoided skill on the new Skills tab, confirm each persists immediately with no Save click and survives a reload; spot-check the disabled-while-pending and error states. **Skipped**, same reason as 5.2.
+- [ ] 5.4 Manual: upload a CV against an existing profile — confirm extracted skills land in the profile automatically and are visible on the Skills tab, without touching Settings' Save. **Skipped**, same reason as 5.2. This was also meant to empirically settle whether `resumeNote` renders under the `{#key profile.updated_at}` remount timing (see `design.md`'s residual-risk entry) — that question remains open.

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -57,11 +57,16 @@
   let busy = $state(false);
   // Which form section is shown — the profile is long, so split it into two tabs sharing
   // one Save (both tabs feed the same PUT). The list drives TabRow, and typing it `as const`
-  // ties `formTab` to it: an id that is not a section stops being expressible.
-  const formTabs = [
-    { id: 'main', label: 'Skills & role' },
-    { id: 'location', label: 'Location & work' },
-  ] as const;
+  // ties `formTab` to it: an id that is not a section stops being expressible. The first
+  // tab's label drops "Skills" once a profile exists — Skills and Skills to avoid live on
+  // their own top-level tab then (see /my/profile's Skills tab); they stay here only for
+  // first-time set-up, before that tab is reachable.
+  const formTabs = $derived(
+    [
+      { id: 'main', label: editing ? 'Role' : 'Skills & role' },
+      { id: 'location', label: 'Location & work' },
+    ] as const,
+  );
   const formPanelId = 'profile-form-panel';
   let formTab = $state<'main' | 'location'>('main');
 
@@ -138,9 +143,13 @@
     void loadSkillDistribution().then((dist) => (skillDist = dist));
   });
 
-  // Derive skills + specialization from a résumé PDF and merge them into the fields as a
-  // deduplicated union, preserving anything already entered (the specialization respects
-  // the cap). The upload also stores the CV server-side, so notify the parent to refresh
+  // Derive skills + specialization from a résumé PDF. Specializations always merge into the
+  // local field, respecting the cap, saved together with Role on the next Save click. Skills
+  // differ by mode: before a profile exists, they merge into the local field the same way
+  // (Save persists both together, since a profile needs both up front); once a profile
+  // exists, Skills has moved to its own autosaving tab, so extracted skills are written
+  // straight to the profile in one bulk PUT instead of buffering into a field that no longer
+  // renders here. The upload also stores the CV server-side, so notify the parent to refresh
   // the CV-readiness state.
   async function analyzeResume(file: File) {
     resumeBusy = true;
@@ -151,9 +160,16 @@
       track('cv_upload', { ok: true, origin: 'profile' });
       onCvUploaded?.();
 
-      const beforeSkills = skills.length;
-      skills = [...new Set([...skills, ...cv.skills])];
-      const addedSkills = skills.length - beforeSkills;
+      let addedSkills: number;
+      if (editing) {
+        const before = new Set(skills);
+        addedSkills = cv.skills.filter((s) => !before.has(s)).length;
+        if (addedSkills > 0) await profileStore.addSkills(cv.skills);
+      } else {
+        const beforeSkills = skills.length;
+        skills = [...new Set([...skills, ...cv.skills])];
+        addedSkills = skills.length - beforeSkills;
+      }
 
       // Merge every specialization the CV resolved, respecting the cap; track how many
       // were added vs. left out by the cap so the note is accurate.
@@ -172,8 +188,11 @@
       const parts: string[] = [];
       if (addedSkills > 0) parts.push(`${addedSkills} skill${addedSkills === 1 ? '' : 's'}`);
       if (addedSpecs > 0) parts.push(`${addedSpecs} specialization${addedSpecs === 1 ? '' : 's'}`);
-      if (parts.length) resumeNote = `Added ${parts.join(' and ')} from your CV.`;
-      else if (cappedSpecs > 0)
+      if (parts.length) {
+        resumeNote = editing
+          ? `Added ${parts.join(' and ')} from your CV — see the Skills tab.`
+          : `Added ${parts.join(' and ')} from your CV.`;
+      } else if (cappedSpecs > 0)
         resumeNote = `Reached the ${MAX_SPECIALIZATIONS}-specialization limit — nothing more added.`;
       else if (cv.skills.length === 0 && cv.categories.length === 0) resumeNote = 'No known skills found in the CV.';
       else resumeNote = 'Everything from your CV was already listed.';
@@ -400,7 +419,9 @@
       {/if}
     </button>
     <span class="text-xs text-muted-foreground">
-      PDF with selectable text, up to {RESUME_MAX_MB} MB · extracts your skills below; the file is stored to score its readiness.
+      PDF with selectable text, up to {RESUME_MAX_MB} MB ·
+      {editing ? 'adds new skills to your profile' : 'extracts your skills below'}; the file is
+      stored to score its readiness.
     </span>
     {#if resumeError}
       <p class="text-sm text-destructive">{resumeError}</p>
@@ -413,7 +434,11 @@
        Renders nothing when object storage is unconfigured. -->
   <HeadshotField />
 
-  <!-- Skills -->
+  {#if !editing}
+  <!-- Skills — set-up only. Once a profile exists, Skills and Skills to avoid move to
+       their own top-level tab (autosaving, no Save button); the server also requires at
+       least one skill to create a profile in the first place, so they stay here until
+       there is a profile — and a Skills tab — to move to. -->
   <div class="flex flex-col gap-2">
     <div class="flex items-baseline justify-between">
       <span class="text-sm font-medium">Skills</span>
@@ -451,6 +476,7 @@
       Filtered out when you apply your profile to the job filters.
     </span>
   </div>
+  {/if}
 
   <!-- Role / specializations -->
   <div class="flex flex-col gap-2">
@@ -597,7 +623,9 @@
     </Button>
     {#if !canSubmit}
       <span class="text-xs text-muted-foreground">
-        Add a role and at least one skill in the “Skills &amp; role” tab to save.
+        {editing
+          ? 'Add a role in the Role tab to save.'
+          : 'Add a role and at least one skill in the “Skills & role” tab to save.'}
       </span>
     {/if}
   </div>

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -12,6 +12,7 @@
   import { categoryLabel } from '$lib/labels';
   import { profileStore } from '$lib/profile.svelte';
   import { buildLocationPreferences } from '$lib/profileLocation';
+  import { loadSkillDistribution } from '$lib/skillDictionary';
   import type { LocationPreferences, UserProfile } from '$lib/types';
   import { Button, Input } from '$lib/ui';
   import HeadshotField from './HeadshotField.svelte';
@@ -133,20 +134,8 @@
   const searchSkills = (query: string) => searchSkillsExcept(query, excludedSkills);
   const searchExcludedSkills = (query: string) => searchSkillsExcept(query, skills);
 
-  async function loadSkills() {
-    try {
-      const counts = await api.facetCounts(new URLSearchParams());
-      const dist = counts.facets?.skills ?? {};
-      skillDist = Object.entries(dist)
-        .map(([value, count]) => ({ value, label: value, count }))
-        .toSorted((a, b) => b.count - a.count || a.label.localeCompare(b.label));
-    } catch {
-      // best-effort: the typeahead just has nothing to suggest.
-    }
-  }
-
   $effect(() => {
-    void loadSkills();
+    void loadSkillDistribution().then((dist) => (skillDist = dist));
   });
 
   // Derive skills + specialization from a résumé PDF and merge them into the fields as a

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -12,6 +12,7 @@
   import { categoryLabel } from '$lib/labels';
   import { profileStore } from '$lib/profile.svelte';
   import { buildLocationPreferences } from '$lib/profileLocation';
+  import { withSkills } from '$lib/profileSkills';
   import { loadSkillDistribution } from '$lib/skillDictionary';
   import type { LocationPreferences, UserProfile } from '$lib/types';
   import { Button, Input } from '$lib/ui';
@@ -143,13 +144,15 @@
     void loadSkillDistribution().then((dist) => (skillDist = dist));
   });
 
-  // Derive skills + specialization from a résumé PDF. Specializations always merge into the
-  // local field, respecting the cap, saved together with Role on the next Save click. Skills
-  // differ by mode: before a profile exists, they merge into the local field the same way
-  // (Save persists both together, since a profile needs both up front); once a profile
-  // exists, Skills has moved to its own autosaving tab, so extracted skills are written
-  // straight to the profile in one bulk PUT instead of buffering into a field that no longer
-  // renders here. The upload also stores the CV server-side, so notify the parent to refresh
+  // Derive skills + specialization from a résumé PDF. Before a profile exists, both merge
+  // into local fields the same way (a profile needs both up front, so Save persists them
+  // together). Once a profile exists, Skills has moved to its own autosaving tab, so the
+  // extraction writes both fields straight to the profile in one PUT instead: not skills
+  // alone, because a specialization it also resolved would otherwise sit in this
+  // component's local (unsaved) state right as a skills-only write's reseed discards it —
+  // this component is keyed on the profile's own `updated_at` (see +page.svelte), so any
+  // write to the row remounts it fresh from the server, wiping whatever wasn't included in
+  // that write. The upload also stores the CV server-side, so notify the parent to refresh
   // the CV-readiness state.
   async function analyzeResume(file: File) {
     resumeBusy = true;
@@ -160,38 +163,45 @@
       track('cv_upload', { ok: true, origin: 'profile' });
       onCvUploaded?.();
 
+      // Merge every specialization the CV resolved, respecting the cap; track how many
+      // were added vs. left out by the cap so the note is accurate. Always local first —
+      // `nextSpecializations` is what an editing-mode write below persists alongside skills.
+      let addedSpecs = 0;
+      let cappedSpecs = 0; // resolved but the cap left no room
+      const nextSpecializations = [...specializations];
+      for (const cat of cv.categories) {
+        if (nextSpecializations.includes(cat)) continue;
+        if (nextSpecializations.length < MAX_SPECIALIZATIONS) {
+          nextSpecializations.push(cat);
+          addedSpecs++;
+        } else {
+          cappedSpecs++;
+        }
+      }
+      specializations = nextSpecializations;
+
       let addedSkills: number;
       if (editing) {
-        const before = new Set(skills);
-        addedSkills = cv.skills.filter((s) => !before.has(s)).length;
-        if (addedSkills > 0) await profileStore.addSkills(cv.skills);
+        const current = profileStore.profile;
+        const before = current?.skills ?? [];
+        addedSkills = current ? withSkills(current, cv.skills).skills.length - before.length : 0;
+        if (addedSkills > 0 || addedSpecs > 0) {
+          await profileStore.mergeResumeExtraction(cv.skills, nextSpecializations);
+        }
       } else {
         const beforeSkills = skills.length;
         skills = [...new Set([...skills, ...cv.skills])];
         addedSkills = skills.length - beforeSkills;
       }
 
-      // Merge every specialization the CV resolved, respecting the cap; track how many
-      // were added vs. left out by the cap so the note is accurate.
-      let addedSpecs = 0;
-      let cappedSpecs = 0; // resolved but the cap left no room
-      for (const cat of cv.categories) {
-        if (specializations.includes(cat)) continue;
-        if (specializations.length < MAX_SPECIALIZATIONS) {
-          specializations = [...specializations, cat];
-          addedSpecs++;
-        } else {
-          cappedSpecs++;
-        }
-      }
-
       const parts: string[] = [];
       if (addedSkills > 0) parts.push(`${addedSkills} skill${addedSkills === 1 ? '' : 's'}`);
       if (addedSpecs > 0) parts.push(`${addedSpecs} specialization${addedSpecs === 1 ? '' : 's'}`);
       if (parts.length) {
-        resumeNote = editing
-          ? `Added ${parts.join(' and ')} from your CV — see the Skills tab.`
-          : `Added ${parts.join(' and ')} from your CV.`;
+        resumeNote =
+          editing && addedSkills > 0
+            ? `Added ${parts.join(' and ')} from your CV — see the Skills tab.`
+            : `Added ${parts.join(' and ')} from your CV.`;
       } else if (cappedSpecs > 0)
         resumeNote = `Reached the ${MAX_SPECIALIZATIONS}-specialization limit — nothing more added.`;
       else if (cv.skills.length === 0 && cv.categories.length === 0) resumeNote = 'No known skills found in the CV.';

--- a/web/src/lib/components/SkillsView.svelte
+++ b/web/src/lib/components/SkillsView.svelte
@@ -32,11 +32,23 @@
   // the first settles would race against a profile row it hasn't seen yet.
   let pending = $state(false);
   let failed = $state<string | null>(null);
+  // Set instead of attempting a doomed write: the server requires at least one skill on
+  // every save, not just at creation (normalizeSkills in internal/userprofile), so removing
+  // — or avoiding, which also un-claims — the one skill left would always 400. Caught here
+  // so the message names the real, permanent reason instead of a retry that can never work.
+  let lastSkillBlocked = $state(false);
+
+  const isOnlySkill = (skill: string) => skills.length === 1 && skills.includes(skill);
 
   async function toggleSkill(skill: string) {
     if (pending) return;
+    if (skills.includes(skill) && isOnlySkill(skill)) {
+      lastSkillBlocked = true;
+      return;
+    }
     pending = true;
     failed = null;
+    lastSkillBlocked = false;
     try {
       await (skills.includes(skill) ? profileStore.removeSkill(skill) : profileStore.addSkill(skill));
     } catch {
@@ -48,8 +60,13 @@
 
   async function toggleExcludedSkill(skill: string) {
     if (pending) return;
+    if (!excludedSkills.includes(skill) && isOnlySkill(skill)) {
+      lastSkillBlocked = true;
+      return;
+    }
     pending = true;
     failed = null;
+    lastSkillBlocked = false;
     try {
       await (excludedSkills.includes(skill)
         ? profileStore.unavoidSkill(skill)
@@ -97,7 +114,9 @@
     </span>
   </div>
 
-  {#if failed}
+  {#if lastSkillBlocked}
+    <p class="text-sm text-muted-foreground">You need at least one skill — add another before removing or avoiding this one.</p>
+  {:else if failed}
     <p class="text-sm text-destructive">Could not update {failed} in your profile. Try again.</p>
   {/if}
 </div>

--- a/web/src/lib/components/SkillsView.svelte
+++ b/web/src/lib/components/SkillsView.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import { profileStore } from '$lib/profile.svelte';
+  import { loadSkillDistribution } from '$lib/skillDictionary';
+  import type { FacetOption } from '$lib/facets';
+  import RemoteSearchSelect from './facets/RemoteSearchSelect.svelte';
+
+  // Skills and Skills to avoid, autosaving on every toggle (no Save control here) — the
+  // same store mutators JobMatch.svelte already uses for its "I have it" / "Avoid" chips.
+  // No local buffer: both lists read straight off the profile, so a write's effect on the
+  // chips comes purely from the store's own reactive state changing.
+  const skills = $derived(profileStore.profile?.skills ?? []);
+  const excludedSkills = $derived(profileStore.profile?.excluded_skills ?? []);
+
+  // The universe of skills (canonical tokens with job counts) for the typeahead, from the
+  // same source ProfileForm's set-up form and the job-search filter panel use.
+  let skillDist = $state.raw<FacetOption[]>([]);
+  $effect(() => {
+    void loadSkillDistribution().then((dist) => (skillDist = dist));
+  });
+
+  function searchSkillsExcept(query: string, avoid: string[]): Promise<FacetOption[]> {
+    const q = query.trim().toLowerCase();
+    const pool = skillDist.filter((o) => !avoid.includes(o.value));
+    const matches = q ? pool.filter((o) => o.label.toLowerCase().includes(q)) : pool;
+    return Promise.resolve(matches.slice(0, q ? 50 : 8));
+  }
+
+  const searchSkills = (query: string) => searchSkillsExcept(query, excludedSkills);
+  const searchExcludedSkills = (query: string) => searchSkillsExcept(query, skills);
+
+  // One write in flight at a time (mirrors JobMatch.svelte): a second toggle started before
+  // the first settles would race against a profile row it hasn't seen yet.
+  let pending = $state(false);
+  let failed = $state<string | null>(null);
+
+  async function toggleSkill(skill: string) {
+    if (pending) return;
+    pending = true;
+    failed = null;
+    try {
+      await (skills.includes(skill) ? profileStore.removeSkill(skill) : profileStore.addSkill(skill));
+    } catch {
+      failed = skill;
+    } finally {
+      pending = false;
+    }
+  }
+
+  async function toggleExcludedSkill(skill: string) {
+    if (pending) return;
+    pending = true;
+    failed = null;
+    try {
+      await (excludedSkills.includes(skill)
+        ? profileStore.unavoidSkill(skill)
+        : profileStore.avoidSkill(skill));
+    } catch {
+      failed = skill;
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-6 rounded-xl border border-border bg-card p-5 sm:p-6">
+  <div class="flex flex-col gap-2 {pending ? 'pointer-events-none opacity-60' : ''}">
+    <div class="flex items-baseline justify-between">
+      <span class="text-sm font-medium">Skills</span>
+      <span class="text-xs tabular-nums text-muted-foreground">{skills.length}</span>
+    </div>
+    <RemoteSearchSelect
+      search={searchSkills}
+      include={skills}
+      placeholder="Search skills"
+      onToggle={toggleSkill}
+      fallbackLabel={(v) => v}
+      clearOnSelect
+    />
+  </div>
+
+  <div class="flex flex-col gap-2 {pending ? 'pointer-events-none opacity-60' : ''}">
+    <div class="flex items-baseline justify-between">
+      <span class="text-sm font-medium">Skills to avoid</span>
+      <span class="text-xs tabular-nums text-muted-foreground">{excludedSkills.length}</span>
+    </div>
+    <RemoteSearchSelect
+      search={searchExcludedSkills}
+      include={[]}
+      exclude={excludedSkills}
+      placeholder="Search skills to exclude"
+      onToggle={toggleExcludedSkill}
+      fallbackLabel={(v) => v}
+      clearOnSelect
+    />
+    <span class="text-xs text-muted-foreground">
+      Filtered out when you apply your profile to the job filters.
+    </span>
+  </div>
+
+  {#if failed}
+    <p class="text-sm text-destructive">Could not update {failed} in your profile. Try again.</p>
+  {/if}
+</div>

--- a/web/src/lib/profile.svelte.ts
+++ b/web/src/lib/profile.svelte.ts
@@ -9,6 +9,7 @@
 import { api } from '$lib/api';
 import {
   withSkill,
+  withSkills,
   withoutSkill,
   withAvoidedSkill,
   withoutAvoidedSkill,
@@ -68,6 +69,13 @@ class ProfileStore extends UserResource<UserProfile | null> {
    *  when the write is refused, leaving the stored copy untouched either way. */
   addSkill(skill: string): Promise<UserProfile> {
     return this.#queue(() => this.#writeSkills((sets) => withSkill(sets, skill)));
+  }
+
+  /** Add several skills at once, in a single write — what a résumé extraction merges into an
+   *  already-existing profile (the set-up form does this itself, unsaved, before there is a
+   *  profile to write to). Rejects when there is no profile, same as `addSkill`. */
+  addSkills(skills: string[]): Promise<UserProfile> {
+    return this.#queue(() => this.#writeSkills((sets) => withSkills(sets, skills)));
   }
 
   /** Take one skill back out — undoing a claim. Subtracts only that skill, so a claim made

--- a/web/src/lib/profile.svelte.ts
+++ b/web/src/lib/profile.svelte.ts
@@ -71,11 +71,23 @@ class ProfileStore extends UserResource<UserProfile | null> {
     return this.#queue(() => this.#writeSkills((sets) => withSkill(sets, skill)));
   }
 
-  /** Add several skills at once, in a single write — what a résumé extraction merges into an
-   *  already-existing profile (the set-up form does this itself, unsaved, before there is a
-   *  profile to write to). Rejects when there is no profile, same as `addSkill`. */
-  addSkills(skills: string[]): Promise<UserProfile> {
-    return this.#queue(() => this.#writeSkills((sets) => withSkills(sets, skills)));
+  /** Merge résumé-extracted skills into the profile, replacing its specializations with
+   *  `specializations` in the same write — what a résumé upload against an already-existing
+   *  profile does with both fields the extraction resolved (the set-up form instead merges
+   *  both into its own unsaved fields, before there is a profile to write to). Both land in
+   *  one PUT rather than two, so a specialization the extraction also found never sits in
+   *  the caller's local state alone — a second, skills-only write would trigger the same
+   *  reseed-from-profile the caller's own save does, discarding an unsaved specialization
+   *  before the caller ever gets to persist it separately. Reads `#profile` at call time,
+   *  inside the queue, so a concurrent skill edit elsewhere isn't clobbered. Rejects when
+   *  there is no profile, same as `addSkill`. */
+  mergeResumeExtraction(newSkills: string[], specializations: string[]): Promise<UserProfile> {
+    return this.#queue(() => {
+      const current = this.#profile;
+      if (!current) return Promise.reject(new Error('No profile to edit.'));
+      const sets = withSkills(current, newSkills);
+      return this.save(specializations, sets.skills, sets.excluded_skills, current.location_preferences);
+    });
   }
 
   /** Take one skill back out — undoing a claim. Subtracts only that skill, so a claim made

--- a/web/src/lib/profileSkills.test.ts
+++ b/web/src/lib/profileSkills.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   withSkill,
+  withSkills,
   withoutSkill,
   withAvoidedSkill,
   withoutAvoidedSkill,
@@ -32,6 +33,33 @@ describe('withSkill', () => {
     const before = { skills: ['docker'], excluded_skills: ['bash'] };
     withSkill(before, 'bash');
     expect(before).toEqual({ skills: ['docker'], excluded_skills: ['bash'] });
+  });
+});
+
+describe('withSkills', () => {
+  it('claims every skill in the list', () => {
+    expect(withSkills({ skills: ['docker'], excluded_skills: [] }, ['go', 'postgresql'])).toEqual(
+      { skills: ['docker', 'go', 'postgresql'], excluded_skills: [] },
+    );
+  });
+
+  it('drops each claimed skill from the excluded set, whatever its case', () => {
+    expect(
+      withSkills({ skills: [], excluded_skills: ['Go', 'php'] }, ['go', 'postgresql']),
+    ).toEqual({ skills: ['go', 'postgresql'], excluded_skills: ['php'] });
+  });
+
+  it('adds nothing already held, whatever its case', () => {
+    expect(withSkills({ skills: ['Docker'], excluded_skills: [] }, ['docker', 'go'])).toEqual({
+      skills: ['Docker', 'go'],
+      excluded_skills: [],
+    });
+  });
+
+  it('does not mutate what it was given', () => {
+    const before = { skills: ['docker'], excluded_skills: ['go'] };
+    withSkills(before, ['go']);
+    expect(before).toEqual({ skills: ['docker'], excluded_skills: ['go'] });
   });
 });
 

--- a/web/src/lib/profileSkills.ts
+++ b/web/src/lib/profileSkills.ts
@@ -31,6 +31,12 @@ export function withSkill(sets: ProfileSkillSets, skill: string): ProfileSkillSe
   };
 }
 
+/** The skill sets once the viewer claims every skill in `skills` — the fold of `withSkill`
+ *  over a list, for a bulk claim (e.g. a résumé extraction) in one write. */
+export function withSkills(sets: ProfileSkillSets, skills: string[]): ProfileSkillSets {
+  return skills.reduce(withSkill, sets);
+}
+
 /** The skill sets once the viewer undoes a claim. It subtracts that one skill rather than
  *  restoring a snapshot, so undoing an earlier claim leaves a later one standing. The
  *  exclusion `withSkill` dropped is not restored — that would re-create the contradiction

--- a/web/src/lib/skillDictionary.ts
+++ b/web/src/lib/skillDictionary.ts
@@ -1,0 +1,18 @@
+// The skills typeahead's candidate universe — canonical tokens with live job counts,
+// shared by the profile form and the Skills tab (both need the same source the job-search
+// filter panel uses, not a bundled/static list).
+
+import { api } from '$lib/api';
+import { dynamicOptions, type FacetOption } from '$lib/facets';
+
+/** Fetch the live skills distribution and shape it into sorted typeahead options.
+ *  Best-effort: any failure (network, decode) resolves to an empty list rather than
+ *  throwing, so a caller can render "nothing to suggest yet" instead of an error. */
+export async function loadSkillDistribution(): Promise<FacetOption[]> {
+  try {
+    const counts = await api.facetCounts(new URLSearchParams());
+    return dynamicOptions('skills', counts.facets?.skills ?? {}, []);
+  } catch {
+    return [];
+  }
+}

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -13,6 +13,7 @@
   import FilterEdgeTab from '$lib/components/FilterEdgeTab.svelte';
   import ProfileForm from '$lib/components/ProfileForm.svelte';
   import ResumeStructuredView from '$lib/components/ResumeStructuredView.svelte';
+  import SkillsView from '$lib/components/SkillsView.svelte';
   import States from '$lib/components/States.svelte';
   import TabRow, { tabId } from '$lib/components/TabRow.svelte';
   import VerdictView from '$lib/components/VerdictView.svelte';
@@ -40,13 +41,16 @@
   // referenced by an id the strip doesn't offer.
   const TABS = [
     { id: 'settings', label: 'Settings' },
+    { id: 'skills', label: 'Skills' },
     { id: 'structured', label: 'Profile' },
     { id: 'experience', label: 'Experience' },
     { id: 'coverage', label: 'Market coverage' },
     { id: 'readiness', label: 'CV readiness' },
   ] as const;
   const PANEL_ID = 'profile-panel';
-  let tab = $state<'settings' | 'structured' | 'experience' | 'coverage' | 'readiness'>('settings');
+  let tab = $state<'settings' | 'skills' | 'structured' | 'experience' | 'coverage' | 'readiness'>(
+    'settings',
+  );
   let modalOpen = $state(false);
   let actionError = $state<string | null>(null);
 
@@ -290,6 +294,8 @@
             </Button>
             <DeleteAccountButton />
           </div>
+        {:else if tab === 'skills'}
+          <SkillsView />
         {:else if tab === 'structured'}
           <!-- Profile: the read-only structured résumé parsed from the CV. Loaded
                independently of the filter-driven reload, so no verdict gate. -->


### PR DESCRIPTION
## Summary
- Add a top-level "Skills" tab to `/my/profile` (visible once a profile exists), holding Skills / Skills to avoid with immediate per-toggle autosave — no Save button, mirroring the existing `JobMatch.svelte` skill-editing pattern.
- Remove Skills / Skills to avoid from the Settings form once a profile exists (stays there only during first-time set-up, since the server requires ≥1 skill to create a profile and the new tab isn't reachable before one exists); the form-tab relabels from "Skills & role" to "Role".
- CV upload against an existing profile now writes extracted skills — and any specialization the same extraction resolved — straight to the profile in one PUT (`profileStore.mergeResumeExtraction`), instead of buffering into a field that no longer renders. Found via review that a skills-only write would trigger `ProfileForm`'s own `{#key profile.updated_at}` remount and silently discard an unsaved specialization from the same upload — fixed by committing both together.
- Skills tab blocks removing/avoiding a profile's last remaining skill client-side (the server requires ≥1 skill on every save, not just creation) instead of sending a doomed write.
- Adds a shared `skillDictionary.ts` loader (`loadSkillDistribution`) used by both the Settings form and the new Skills tab.

No backend changes — same `PUT /api/v1/me/profile` endpoint, called from a different place in the frontend.

Full design/spec/task history: `openspec/changes/profile-skills-tab/`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...` — all green
- [x] `pnpm run build`, `pnpm run check` (0 errors), `pnpm run lint` (exit 0), `pnpm exec vitest run` (830/830) — all green
- [x] Two rounds of independent code review per task, including a fix for a Critical bug found in review (CV-extracted specializations silently discarded by a self-triggered remount)
- [ ] Manual browser QA (create profile, edit skills on the new tab, CV upload against an existing profile) — **not done**, skipped by explicit decision given the automated coverage above; see `openspec/changes/profile-skills-tab/tasks.md` task 5 for the honest record of what's verified vs not