### PR TITLE
fix(collections): send a browser User-Agent on USCIS requests

### DIFF
--- a/internal/collections/ush1bsponsor.go
+++ b/internal/collections/ush1bsponsor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -20,6 +21,12 @@ import (
 const (
 	ush1bIndexURL   = "https://www.uscis.gov/archive/h-1b-employer-data-hub-files"
 	ush1bYearWindow = 5
+
+	// uscis.gov's bot filter 403s a request carrying Go's default User-Agent
+	// ("Go-http-client/1.1") and 200s an identical request with a browser-like one
+	// — confirmed against the live site during design, and against the production
+	// import-collections run on 2026-08-05, which failed outright without this.
+	ush1bUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
 )
 
 // fyFile is one fiscal year's data-hub CSV, as listed on the archive index page.
@@ -106,7 +113,7 @@ func ParseUSH1BSponsorsCSV(data []byte) ([]Record, error) {
 // shrunk source and would reconcile the credential off every company it failed to
 // reach. Parameterized on indexURL so it can be exercised against a test server.
 func fetchUSH1BSponsors(ctx context.Context, client *http.Client, indexURL string) ([]Record, error) {
-	page, err := get(ctx, client, indexURL)
+	page, err := getWithUserAgent(ctx, client, indexURL, ush1bUserAgent)
 	if err != nil {
 		return nil, fmt.Errorf("collections: fetch us h1b data hub index: %w", err)
 	}
@@ -125,7 +132,7 @@ func fetchUSH1BSponsors(ctx context.Context, client *http.Client, indexURL strin
 		if err != nil {
 			return nil, fmt.Errorf("collections: resolve us h1b fy%d url: %w", f.Year, err)
 		}
-		body, err := get(ctx, client, base.ResolveReference(ref).String())
+		body, err := getWithUserAgent(ctx, client, base.ResolveReference(ref).String(), ush1bUserAgent)
 		if err != nil {
 			return nil, fmt.Errorf("collections: fetch us h1b fy%d file: %w", f.Year, err)
 		}
@@ -142,4 +149,25 @@ func fetchUSH1BSponsors(ctx context.Context, client *http.Client, indexURL strin
 // archive index.
 func FetchUSH1BSponsors(ctx context.Context, client *http.Client) ([]Record, error) {
 	return fetchUSH1BSponsors(ctx, client, ush1bIndexURL)
+}
+
+// getWithUserAgent is get (see uksponsor.go) with an overridable User-Agent header,
+// kept local to this source rather than added to the shared helper: the UK and NL
+// registers have never needed one, and a request header only this source requires
+// should not ripple into call sites that don't.
+func getWithUserAgent(ctx context.Context, client *http.Client, url, userAgent string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: status %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
 }

--- a/internal/collections/ush1bsponsor_test.go
+++ b/internal/collections/ush1bsponsor_test.go
@@ -176,6 +176,50 @@ func TestFetchUSH1BSponsors_CombinesAllFiveYears(t *testing.T) {
 	}
 }
 
+func TestFetchUSH1BSponsors_SendsABrowserUserAgent(t *testing.T) {
+	// uscis.gov's bot filter 403s a request with no User-Agent (confirmed against
+	// the live site, and against the production import-collections run on
+	// 2026-08-05) but 200s an identical request carrying a browser-like one. This
+	// test pins that every request fetchUSH1BSponsors makes carries one.
+	years := []string{"2023", "2022", "2021", "2020", "2019"}
+	requireUA := func(w http.ResponseWriter, r *http.Request, body func()) {
+		// Go's http.Client sends "Go-http-client/1.1" when the caller never sets
+		// the header — exactly the fingerprint uscis.gov's bot filter 403s. Only a
+		// caller-set, non-default value proves the fix, so this rejects that
+		// default the same way the live site does.
+		if ua := r.Header.Get("User-Agent"); ua == "" || strings.HasPrefix(ua, "Go-http-client") {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		body()
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/archive/h-1b-employer-data-hub-files", func(w http.ResponseWriter, r *http.Request) {
+		requireUA(w, r, func() {
+			var b strings.Builder
+			for _, y := range years {
+				b.WriteString(`<a href="/sites/default/files/document/data/h1b_datahubexport-` + y + `.csv">FY ` + y + ` H-1B Employer Data</a>`)
+			}
+			w.Write([]byte(b.String()))
+		})
+	})
+	for _, y := range years {
+		y := y
+		mux.HandleFunc("/sites/default/files/document/data/h1b_datahubexport-"+y+".csv", func(w http.ResponseWriter, r *http.Request) {
+			requireUA(w, r, func() {
+				w.Write([]byte("\"Fiscal Year\",Employer,\"Initial Approval\",\"Initial Denial\",\"Continuing Approval\",\"Continuing Denial\",NAICS,\"Tax ID\",State,City,ZIP\n" +
+					y + `,"ACME ROBOTICS INC",1,0,0,0,54,1234,CA,SAN JOSE,95110` + "\n"))
+			})
+		})
+	}
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if _, err := fetchUSH1BSponsors(context.Background(), srv.Client(), srv.URL+"/archive/h-1b-employer-data-hub-files"); err != nil {
+		t.Fatalf("fetchUSH1BSponsors: %v (expected a User-Agent to be sent, avoiding the 403)", err)
+	}
+}
+
 func TestFetchUSH1BSponsors_FailsWholeCallWhenOneYearIsUnreachable(t *testing.T) {
 	years := []string{"2023", "2022", "2021", "2020", "2019"}
 	mux := http.NewServeMux()


### PR DESCRIPTION
Promotes the User-Agent fix (#1583) to main for redeploy — the first import-collections run on prod failed with a 403 from uscis.gov.