### PR TITLE
fix(seo): disallow empty discussion/new form from robots.txt

### DIFF
--- a/web/src/routes/robots.txt/+server.ts
+++ b/web/src/routes/robots.txt/+server.ts
@@ -7,10 +7,19 @@ import type { RequestHandler } from './$types';
 // …), so no per-bot Allow block is listed — a redundant one would only invite
 // drift from this rule. llms.txt has no robots directive of its own, so it is
 // advertised as a comment, the convention crawlers look for.
+//
+// /jobs/*/discussion/new and /companies/*/discussion/new are the empty
+// new-thread form, linked from every single job and company page — crawling it
+// costs a full SSR render per job/company for a page with no unique content, and
+// it drove a real accept-queue incident (2026-08-05, ClaudeBot alone made
+// ~108k requests to it in 12.5h). Actual thread pages (/discussion,
+// /discussion/[id]) hold real content and stay crawlable.
 export const GET: RequestHandler = ({ url }) => {
   const body = `User-agent: *
 Allow: /
 Disallow: /my/
+Disallow: /jobs/*/discussion/new
+Disallow: /companies/*/discussion/new
 
 Sitemap: ${url.origin}/sitemap.xml
 # llms.txt: ${url.origin}/llms.txt


### PR DESCRIPTION
Promotes #1592 to main for deploy — incident follow-up, see that PR for details.