### PR TITLE
fix(search): always return full description on /agent/jobs/search

### DIFF
--- a/internal/handler/agent_search.go
+++ b/internal/handler/agent_search.go
@@ -19,18 +19,19 @@ type jobDescriptions interface {
 }
 
 // AgentSearchJobs is the programmatic-consumer variant of SearchJobs: it runs the
-// exact same query (via the shared runJobSearch core) and, when explicitly asked,
-// rehydrates each result with the full description from Postgres in a selectable
-// format. Public and unauthenticated like the other job reads; full descriptions
-// are already public via the detail endpoint.
+// exact same query (via the shared runJobSearch core) and always rehydrates each
+// result with the full description from Postgres, in a selectable format. The
+// truncated preview stays exclusive to /jobs/search — a caller that wants the
+// lightweight variant uses that endpoint instead. Public and unauthenticated like
+// the other job reads; full descriptions are already public via the detail
+// endpoint.
 func (h *searchHandlers) AgentSearchJobs(c *fiber.Ctx) error {
 	res, limit, offset, err := h.runJobSearch(c)
 	if err != nil {
 		return err
 	}
 
-	includeDescription := c.QueryBool("include_description")
-	if includeDescription && len(res.Hits) > 0 {
+	if len(res.Hits) > 0 {
 		if err := h.hydrateDescriptions(c.Context(), res.Hits); err != nil {
 			return err
 		}
@@ -39,9 +40,7 @@ func (h *searchHandlers) AgentSearchJobs(c *fiber.Ctx) error {
 	format := c.Query("description_format")
 	views := make([]jobview.Job, len(res.Hits))
 	for i, hit := range res.Hits {
-		if includeDescription {
-			hit.Description = formatDescription(hit.Description, format)
-		}
+		hit.Description = formatDescription(hit.Description, format)
 		views[i] = hit.Job
 	}
 

--- a/internal/handler/agent_search_test.go
+++ b/internal/handler/agent_search_test.go
@@ -48,28 +48,7 @@ func TestFormatDescription(t *testing.T) {
 	}
 }
 
-func TestAgentSearchJobs_DefaultKeepsPreview(t *testing.T) {
-	fake := &fakeSearcher{res: search.SearchResult{
-		Hits: []search.JobDocument{{ID: 7, Job: jobview.Job{PublicSlug: "go-dev-x", Description: "<p>trunc...</p>"}}},
-	}}
-	desc := &fakeDescriptions{rows: []db.GetJobDescriptionsByIDsRow{{ID: 7, Description: "<p>the full verbatim description</p>"}}}
-	app := agentSearchApp(fake, desc)
-
-	status, body := doGet(t, app, "/agent/jobs/search")
-	if status != fiber.StatusOK {
-		t.Fatalf("status = %d, want 200", status)
-	}
-	if desc.called {
-		t.Fatal("description loader called for default lightweight search")
-	}
-	data, _ := body["data"].([]any)
-	first, _ := data[0].(map[string]any)
-	if first["description"] != "<p>trunc...</p>" {
-		t.Errorf("description = %v, want search preview", first["description"])
-	}
-}
-
-func TestAgentSearchJobs_IncludeDescriptionHydratesFullDescription(t *testing.T) {
+func TestAgentSearchJobs_HydratesFullDescriptionByDefault(t *testing.T) {
 	fake := &fakeSearcher{res: search.SearchResult{
 		Hits:  []search.JobDocument{{ID: 7, Job: jobview.Job{PublicSlug: "go-dev-x", Description: "<p>trunc...</p>"}}},
 		Total: 3,
@@ -77,7 +56,7 @@ func TestAgentSearchJobs_IncludeDescriptionHydratesFullDescription(t *testing.T)
 	desc := &fakeDescriptions{rows: []db.GetJobDescriptionsByIDsRow{{ID: 7, Description: "<p>the full verbatim description</p>"}}}
 	app := agentSearchApp(fake, desc)
 
-	status, body := doGet(t, app, "/agent/jobs/search?q=go&seniority=senior&semantic_ratio=0.4&limit=10&offset=20&include_description=true")
+	status, body := doGet(t, app, "/agent/jobs/search?q=go&seniority=senior&semantic_ratio=0.4&limit=10&offset=20")
 	if status != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
@@ -114,7 +93,7 @@ func TestAgentSearchJobs_BestEffortKeepsStaleHit(t *testing.T) {
 	desc := &fakeDescriptions{rows: []db.GetJobDescriptionsByIDsRow{{ID: 1, Description: "FULL-a"}}}
 	app := agentSearchApp(fake, desc)
 
-	status, body := doGet(t, app, "/agent/jobs/search?include_description=true")
+	status, body := doGet(t, app, "/agent/jobs/search")
 	if status != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
@@ -135,7 +114,7 @@ func TestAgentSearchJobs_FormatApplies(t *testing.T) {
 	desc := &fakeDescriptions{rows: []db.GetJobDescriptionsByIDsRow{{ID: 1, Description: "<ul><li>alpha</li></ul>"}}}
 	app := agentSearchApp(fake, desc)
 
-	status, body := doGet(t, app, "/agent/jobs/search?include_description=true&description_format=text")
+	status, body := doGet(t, app, "/agent/jobs/search?description_format=text")
 	if status != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -13,7 +13,7 @@ import (
 )
 
 // searchHandlers serves the Meilisearch-backed job search surfaces: the keyword
-// search, the agent search (full descriptions in a selectable format), the
+// search, the agent search (always full descriptions in a selectable format), the
 // similar-jobs read, and the facet distribution. search/facets are two narrow
 // views of the same client, kept separate so the concerns stay decoupled; both
 // nil when Meilisearch is unconfigured (the endpoints then report 503).
@@ -35,7 +35,7 @@ func (h *searchHandlers) register(api fiber.Router, mw middleware) {
 	// Literal routes are registered before the /jobs/:slug param route (see
 	// Register) so they are not read as slugs.
 	api.Get("/jobs/search", h.SearchJobs)
-	// Agent search: same query as /jobs/search, with opt-in full descriptions in a
+	// Agent search: same query as /jobs/search, but always full descriptions in a
 	// selectable format for programmatic consumers. Public, like the other reads.
 	api.Get("/agent/jobs/search", h.AgentSearchJobs)
 	api.Get("/jobs/facets", h.JobFacets)

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -22,10 +22,9 @@ paths:
         - Jobs
       summary: Search open jobs for agents
       description: |
-        Agent-friendly job search. By default this returns compact search results.
-        Set include_description=true only when the user explicitly asks for full
-        descriptions across search results; otherwise use getJob for one selected
-        posting.
+        Agent-friendly job search. Every result carries the job's full description
+        (verbatim from the database, not the search-index preview), in the format
+        selected by description_format.
       x-openai-isConsequential: false
       parameters:
         - name: q
@@ -180,12 +179,6 @@ paths:
           schema:
             type: integer
           description: Maximum salary upper bound.
-        - name: include_description
-          in: query
-          schema:
-            type: boolean
-            default: false
-          description: Include full job descriptions in search results.
         - name: description_format
           in: query
           schema:
@@ -194,8 +187,8 @@ paths:
               - html
               - text
               - markdown
-            default: text
-          description: Format used when include_description=true.
+            default: html
+          description: Format of the full description (html is the stored verbatim markup).
       responses:
         "200":
           description: Matching jobs with pagination metadata.


### PR DESCRIPTION
## Summary
- `/agent/jobs/search` now always rehydrates the full description from Postgres and applies `description_format`, instead of requiring an `include_description=true` opt-in.
- The truncated 1000-rune index preview stays exclusive to `/jobs/search`; `/agent/jobs/search` exists specifically to serve the full text, so the flag was redundant with an endpoint that already offers the compact variant.
- Both `docs/API.md` and `openspec/specs/agent-jobs-search/spec.md` already documented this endpoint as unconditionally full-description — the implementation had drifted from spec since `include_description` was added.
- Also fixed `web/static/openapi.yaml` (ChatGPT Actions schema): dropped the now-gone `include_description` param and corrected `description_format`'s stated default from `text` to `html`, matching actual handler behavior.

## Context / tradeoff
`include_description` was added deliberately in `48ed4708` after a broad ChatGPT Actions query with always-full descriptions blew up the GPT Action response size. Reverting that opt-in reintroduces the same risk for wide `limit` values on this endpoint — accepted as a tradeoff, since the endpoint's entire purpose is serving full descriptions and the lightweight variant already exists at `/jobs/search`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...`
- [x] Rewrote `internal/handler/agent_search_test.go` to assert the endpoint hydrates full descriptions by default