### PR TITLE
Exclude blank-description jobs from the LLM enrichment queue

### DIFF
--- a/internal/db/enrichment.sql.go
+++ b/internal/db/enrichment.sql.go
@@ -91,19 +91,20 @@ WHERE closed_at IS NULL
   AND duplicate_of IS NULL
   AND (enriched_at IS NULL OR enrichment_version < $1::int)
   AND is_tech IS TRUE
+  AND description <> ''
 ON CONFLICT (job_id, target_version) DO NOTHING
 `
 
 // Idempotent backfill: enqueue every OPEN job that is unenriched or below the target
 // schema version. Closed jobs (closed_at IS NOT NULL) are skipped — a dead posting no
-// user will see should not consume LLM budget. Gated on the same is_tech = true
-// condition EnqueueJobEnrichment uses (see that query's comment for why the
-// is_tech IS NULL bucket — unresolved by both the title dictionary and the
+// user will see should not consume LLM budget. Gated on the same is_tech = true and
+// description <> ” conditions EnqueueJobEnrichment uses (see that query's comment for
+// why the is_tech IS NULL bucket — unresolved by both the title dictionary and the
 // description — is deliberately excluded, not just the confirmed-non-tech
-// is_tech = false one) so a version bump or a fresh backfill run re-evaluates the
-// whole catalogue under the identical rule, not a looser one. ON CONFLICT keeps
-// exactly one entry per (job_id, target_version), so running this every command
-// invocation never duplicates work.
+// is_tech = false one, and why a blank description is excluded regardless of category)
+// so a version bump or a fresh backfill run re-evaluates the whole catalogue under the
+// identical rule, not a looser one. ON CONFLICT keeps exactly one entry per (job_id,
+// target_version), so running this every command invocation never duplicates work.
 func (q *Queries) EnqueuePendingJobs(ctx context.Context, targetVersion int32) (int64, error) {
 	result, err := q.db.Exec(ctx, enqueuePendingJobs, targetVersion)
 	if err != nil {

--- a/internal/db/enrichment_integration_test.go
+++ b/internal/db/enrichment_integration_test.go
@@ -22,15 +22,16 @@ func startPostgres(t *testing.T) *pgxpool.Pool {
 	return testdb.Pool(t)
 }
 
-// insertJob inserts a job with is_tech = true (the enrichment enqueue gate's default
-// requirement — see TestEnqueueGatesOnIsTech for the tri-state gating itself), so every
-// other test in this file that enqueues and expects it to succeed doesn't have to set it.
+// insertJob inserts a job with is_tech = true and a non-empty description (the
+// enrichment enqueue gate's default requirements — see TestEnqueueGatesOnIsTech and
+// TestEnqueueGatesOnDescription for the gating itself), so every other test in this
+// file that enqueues and expects it to succeed doesn't have to set either.
 func insertJob(t *testing.T, pool *pgxpool.Pool, externalID string) int64 {
 	t.Helper()
 	var id int64
 	err := pool.QueryRow(context.Background(),
-		`INSERT INTO jobs (source, external_id, url, title, public_slug, is_tech)
-		 VALUES ('test', $1, 'http://example.test', 'A job', 'job-' || $1, true) RETURNING id`,
+		`INSERT INTO jobs (source, external_id, url, title, description, public_slug, is_tech)
+		 VALUES ('test', $1, 'http://example.test', 'A job', 'Build things.', 'job-' || $1, true) RETURNING id`,
 		externalID).Scan(&id)
 	if err != nil {
 		t.Fatalf("insert job: %v", err)
@@ -71,6 +72,16 @@ func setIsTech(t *testing.T, pool *pgxpool.Pool, jobID int64, isTech *bool) {
 	if _, err := pool.Exec(context.Background(),
 		"UPDATE jobs SET is_tech = $1 WHERE id = $2", isTech, jobID); err != nil {
 		t.Fatalf("set is_tech: %v", err)
+	}
+}
+
+// setDescription stamps a job's description so the enrichment enqueue gate's
+// description <> ” condition can be tested.
+func setDescription(t *testing.T, pool *pgxpool.Pool, jobID int64, description string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		"UPDATE jobs SET description = $1 WHERE id = $2", description, jobID); err != nil {
+		t.Fatalf("set description: %v", err)
 	}
 }
 
@@ -366,6 +377,49 @@ func TestEnqueueGatesOnIsTech(t *testing.T) {
 		}
 		if n != 0 {
 			t.Errorf("enqueued rows = %d, want 0 for an is_tech-unresolved job", n)
+		}
+		if got := enqueuedJobIDs(t, pool); len(got) != 0 {
+			t.Errorf("outbox = %v, want empty", got)
+		}
+	})
+}
+
+// TestEnqueueGatesOnDescription covers the other half of the AI-budget gate: a job
+// with no description is never enqueued, whatever its is_tech state — the LLM has
+// nothing to extract from a blank one. A 2026-08-06 prod sweep found ~53K such rows
+// already queued for no reason (see EnqueueJobEnrichment's doc comment).
+func TestEnqueueGatesOnDescription(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	t.Run("backfill enqueue skips a tech job with a blank description", func(t *testing.T) {
+		truncate(t, pool)
+		blank := insertJob(t, pool, "blank")
+		setDescription(t, pool, blank, "")
+
+		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+			t.Fatal(err)
+		}
+		if got := enqueuedJobIDs(t, pool); len(got) != 0 {
+			t.Errorf("enqueued = %v, want none (blank description)", got)
+		}
+	})
+
+	t.Run("transactional enqueue skips a tech job with a blank description", func(t *testing.T) {
+		truncate(t, pool)
+		blank := insertJob(t, pool, "blank")
+		setDescription(t, pool, blank, "")
+
+		n, err := q.EnqueueJobEnrichment(ctx, EnqueueJobEnrichmentParams{
+			TargetVersion: targetVersion,
+			JobID:         blank,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Errorf("enqueued rows = %d, want 0 for a blank-description job", n)
 		}
 		if got := enqueuedJobIDs(t, pool); len(got) != 0 {
 			t.Errorf("outbox = %v, want empty", got)

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -352,6 +352,7 @@ FROM jobs
 WHERE id = $2::bigint
   AND (enriched_at IS NULL OR enrichment_version < $1::int)
   AND is_tech IS TRUE
+  AND description <> ''
 ON CONFLICT (job_id, target_version) DO NOTHING
 `
 
@@ -371,9 +372,11 @@ type EnqueueJobEnrichmentParams struct {
 // silently skip a tech job the dictionary missed" — but measured at catalogue scale it
 // was ~65% of the open catalogue and enrichment returned nothing useful for ~91% of it
 // (broad multi-industry ATS crawls: painters, stockers, drivers), so the LLM spend was
-// not buying the coverage it cost. Idempotent via the outbox's UNIQUE (job_id,
-// target_version). Run in the same transaction as the job's UpsertJob so a newly
-// ingested job is queued atomically with its write.
+// not buying the coverage it cost. Also requires a non-empty description: the LLM has
+// nothing to extract from a blank one regardless of category, and a 2026-08-06 prod
+// sweep found ~53K such rows already sitting in the queue for no reason. Idempotent via
+// the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+// job's UpsertJob so a newly ingested job is queued atomically with its write.
 func (q *Queries) EnqueueJobEnrichment(ctx context.Context, arg EnqueueJobEnrichmentParams) (int64, error) {
 	result, err := q.db.Exec(ctx, enqueueJobEnrichment, arg.TargetVersion, arg.JobID)
 	if err != nil {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -682,9 +682,11 @@ type Querier interface {
 	// silently skip a tech job the dictionary missed" — but measured at catalogue scale it
 	// was ~65% of the open catalogue and enrichment returned nothing useful for ~91% of it
 	// (broad multi-industry ATS crawls: painters, stockers, drivers), so the LLM spend was
-	// not buying the coverage it cost. Idempotent via the outbox's UNIQUE (job_id,
-	// target_version). Run in the same transaction as the job's UpsertJob so a newly
-	// ingested job is queued atomically with its write.
+	// not buying the coverage it cost. Also requires a non-empty description: the LLM has
+	// nothing to extract from a blank one regardless of category, and a 2026-08-06 prod
+	// sweep found ~53K such rows already sitting in the queue for no reason. Idempotent via
+	// the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+	// job's UpsertJob so a newly ingested job is queued atomically with its write.
 	EnqueueJobEnrichment(ctx context.Context, arg EnqueueJobEnrichmentParams) (int64, error)
 	// Idempotent backfill: enqueue every email not yet classified. classified_at is the
 	// "done" marker; ON CONFLICT keeps one entry per email, so running this each worker
@@ -698,14 +700,14 @@ type Querier interface {
 	EnqueuePendingEmailClassification(ctx context.Context) (int64, error)
 	// Idempotent backfill: enqueue every OPEN job that is unenriched or below the target
 	// schema version. Closed jobs (closed_at IS NOT NULL) are skipped — a dead posting no
-	// user will see should not consume LLM budget. Gated on the same is_tech = true
-	// condition EnqueueJobEnrichment uses (see that query's comment for why the
-	// is_tech IS NULL bucket — unresolved by both the title dictionary and the
+	// user will see should not consume LLM budget. Gated on the same is_tech = true and
+	// description <> '' conditions EnqueueJobEnrichment uses (see that query's comment for
+	// why the is_tech IS NULL bucket — unresolved by both the title dictionary and the
 	// description — is deliberately excluded, not just the confirmed-non-tech
-	// is_tech = false one) so a version bump or a fresh backfill run re-evaluates the
-	// whole catalogue under the identical rule, not a looser one. ON CONFLICT keeps
-	// exactly one entry per (job_id, target_version), so running this every command
-	// invocation never duplicates work.
+	// is_tech = false one, and why a blank description is excluded regardless of category)
+	// so a version bump or a fresh backfill run re-evaluates the whole catalogue under the
+	// identical rule, not a looser one. ON CONFLICT keeps exactly one entry per (job_id,
+	// target_version), so running this every command invocation never duplicates work.
 	EnqueuePendingJobs(ctx context.Context, targetVersion int32) (int64, error)
 	// Idempotent backfill for the incremental semantic-embedding queue. Enqueues two
 	// kinds of outstanding work at the target embedder model:

--- a/internal/db/queries/enrichment.sql
+++ b/internal/db/queries/enrichment.sql
@@ -1,14 +1,14 @@
 -- name: EnqueuePendingJobs :execrows
 -- Idempotent backfill: enqueue every OPEN job that is unenriched or below the target
 -- schema version. Closed jobs (closed_at IS NOT NULL) are skipped — a dead posting no
--- user will see should not consume LLM budget. Gated on the same is_tech = true
--- condition EnqueueJobEnrichment uses (see that query's comment for why the
--- is_tech IS NULL bucket — unresolved by both the title dictionary and the
+-- user will see should not consume LLM budget. Gated on the same is_tech = true and
+-- description <> '' conditions EnqueueJobEnrichment uses (see that query's comment for
+-- why the is_tech IS NULL bucket — unresolved by both the title dictionary and the
 -- description — is deliberately excluded, not just the confirmed-non-tech
--- is_tech = false one) so a version bump or a fresh backfill run re-evaluates the
--- whole catalogue under the identical rule, not a looser one. ON CONFLICT keeps
--- exactly one entry per (job_id, target_version), so running this every command
--- invocation never duplicates work.
+-- is_tech = false one, and why a blank description is excluded regardless of category)
+-- so a version bump or a fresh backfill run re-evaluates the whole catalogue under the
+-- identical rule, not a looser one. ON CONFLICT keeps exactly one entry per (job_id,
+-- target_version), so running this every command invocation never duplicates work.
 INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, sqlc.arg(target_version)::int
 FROM jobs
@@ -16,6 +16,7 @@ WHERE closed_at IS NULL
   AND duplicate_of IS NULL
   AND (enriched_at IS NULL OR enrichment_version < sqlc.arg(target_version)::int)
   AND is_tech IS TRUE
+  AND description <> ''
 ON CONFLICT (job_id, target_version) DO NOTHING;
 
 -- name: ClaimEnrichmentBatch :many

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -1093,15 +1093,18 @@ WHERE id = sqlc.arg(id) AND liveness_strikes <> 0;
 -- silently skip a tech job the dictionary missed" — but measured at catalogue scale it
 -- was ~65% of the open catalogue and enrichment returned nothing useful for ~91% of it
 -- (broad multi-industry ATS crawls: painters, stockers, drivers), so the LLM spend was
--- not buying the coverage it cost. Idempotent via the outbox's UNIQUE (job_id,
--- target_version). Run in the same transaction as the job's UpsertJob so a newly
--- ingested job is queued atomically with its write.
+-- not buying the coverage it cost. Also requires a non-empty description: the LLM has
+-- nothing to extract from a blank one regardless of category, and a 2026-08-06 prod
+-- sweep found ~53K such rows already sitting in the queue for no reason. Idempotent via
+-- the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+-- job's UpsertJob so a newly ingested job is queued atomically with its write.
 INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, sqlc.arg(target_version)::int
 FROM jobs
 WHERE id = sqlc.arg(job_id)::bigint
   AND (enriched_at IS NULL OR enrichment_version < sqlc.arg(target_version)::int)
   AND is_tech IS TRUE
+  AND description <> ''
 ON CONFLICT (job_id, target_version) DO NOTHING;
 
 -- name: SetJobEnrichment :exec

--- a/internal/jdresolve/resolve_integration_test.go
+++ b/internal/jdresolve/resolve_integration_test.go
@@ -57,10 +57,11 @@ func (boardServing) Provider() string { return "recruitee" }
 
 func (b boardServing) Fetch(_ context.Context, e sources.CompanyEntry) ([]sources.Job, error) {
 	return []sources.Job{{
-		ExternalID: "senior-go",
-		URL:        "https://" + e.Board + ".recruitee.com/o/senior-go",
-		Title:      string(b),
-		Company:    "Acme",
+		ExternalID:  "senior-go",
+		URL:         "https://" + e.Board + ".recruitee.com/o/senior-go",
+		Title:       string(b),
+		Company:     "Acme",
+		Description: "We build things.",
 	}}, nil
 }
 


### PR DESCRIPTION
## Summary
- `EnqueueJobEnrichment`/`EnqueuePendingJobs` now also require `description <> ''` — the LLM has nothing to extract from a blank description regardless of category or `is_tech`.
- Follow-up to #1597 (the `is_tech = true` gate); a prod sweep after that deploy found ~53K blank-description rows already queued for no reason. Cleaned up manually on prod alongside this deploy.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` / `go vet -tags=integration ./...`
- [x] `go test ./...`
- [x] `go test -tags=integration ./...` (full module, real Postgres via testcontainers)