### PR TITLE
Batch cmd/reindex's per-company duplicate passes

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -398,45 +399,93 @@ type realityLookup func(companySlug, fingerprint string) (repost, mass int)
 // lookup skips widening entirely (tests that do not exercise clustering).
 type clusterGeoLookup func(companySlug, fingerprint string) (countries, regions, cities []string)
 
-// recomputeRoleDuplicates refreshes jobs.duplicate_of one company at a time, returning
-// the total rows re-marked. Scoping each UPDATE to a single company keeps its lock
-// window to that company's rows for a moment, so the pass never holds the table-wide
-// lock that would stall concurrent ingest crawls. Best-effort like every per-company
-// pass here (see forEachCompany).
+// companyBatchSize bounds how many companies one RecomputeRoleDuplicatesForCompanies /
+// SuppressAggregatorDuplicatesForCompanies call covers. Measured on prod (2026-08-06):
+// one round trip per company — 236,923 distinct open companies, 94,410 of them with an
+// open aggregator posting — made the aggregator-suppression pass alone run for hours
+// under ordinary host load and get stuck (systemd auto-restarted it, redoing the same
+// hours of work) with the reindex never reaching the point of actually pushing to
+// Meili. 500 keeps each statement's WHERE ... = ANY(...) small enough to stay a cheap
+// index probe (see migration 0076's functional index) while cutting round trips by
+// ~500x; it is not tuned beyond "clearly fixes the incident," so revisit if a future
+// measurement suggests a better number.
+const companyBatchSize = 500
+
+// recomputeRoleDuplicates refreshes jobs.duplicate_of in batches of companies,
+// returning the total rows re-marked. Batching (not one UPDATE per company, and not one
+// UPDATE for the whole catalogue) balances two costs: an unbatched per-company call
+// pays a full network/planning round trip per company (see companyBatchSize), while a
+// single whole-catalogue UPDATE would hold its lock window across the entire jobs
+// table instead of one bounded slice at a time, risking a stall of concurrent ingest
+// writes. Best-effort like every batch here (see forCompanyBatches).
 func recomputeRoleDuplicates(ctx context.Context, q *db.Queries) (int64, error) {
 	companies, err := q.CompaniesWithRoleClusters(ctx)
 	if err != nil {
 		return 0, err
 	}
-	return forEachCompany(ctx, companies, q.RecomputeRoleDuplicatesForCompany)
+	return forCompanyBatches(ctx, companies, q.RecomputeRoleDuplicatesForCompanies)
 }
 
 // suppressAggregatorDuplicates marks each open aggregator posting that duplicates a
 // first-party ATS posting (same company, normalized title, compatible country) as a
-// duplicate of that ATS row, one company at a time. Returns the total rows re-marked.
-// The aggregator set comes from the taxonomy registry's aggregator() markers, so it is the
-// same set here as on the ingest host: a keyed adapter whose credential lives only where the
-// crawl runs must still be classified, or its copies of an ATS posting go unsuppressed.
-// Best-effort and lock-scoped exactly like recomputeRoleDuplicates.
+// duplicate of that ATS row, processed in batches of companies. Returns the total rows
+// re-marked. The aggregator set comes from the taxonomy registry's aggregator()
+// markers, so it is the same set here as on the ingest host: a keyed adapter whose
+// credential lives only where the crawl runs must still be classified, or its copies of
+// an ATS posting go unsuppressed. Best-effort and lock-scoped exactly like
+// recomputeRoleDuplicates.
 func suppressAggregatorDuplicates(ctx context.Context, q *db.Queries) (int64, error) {
 	aggregators := sources.AggregatorProviders(sources.Taxonomy())
 	companies, err := q.CompaniesWithAggregatorPostings(ctx, aggregators)
 	if err != nil {
 		return 0, err
 	}
-	return forEachCompany(ctx, companies, func(ctx context.Context, c string) (int64, error) {
-		return q.SuppressAggregatorDuplicatesForCompany(ctx, db.SuppressAggregatorDuplicatesForCompanyParams{
-			Company:     c,
+	return forCompanyBatches(ctx, companies, func(ctx context.Context, batch []string) (int64, error) {
+		return q.SuppressAggregatorDuplicatesForCompanies(ctx, db.SuppressAggregatorDuplicatesForCompaniesParams{
+			Companies:   batch,
 			Aggregators: aggregators,
 		})
 	})
 }
 
+// forCompanyBatches runs fn once per companyBatchSize-sized slice of companies, summing
+// the rows it reports re-marked. Batches are independent, so one failure (e.g. a
+// statement timeout on an unusually large batch) must not starve the rest — it is
+// counted and skipped, and any failure turns the pass's result into an aggregate error
+// (the caller treats the whole pass as best-effort and continues with the prior
+// markers). This is coarser fault isolation than the one-call-per-company version it
+// replaced (a bad batch now costs up to companyBatchSize companies their update, not
+// just one), a deliberate trade against the hours a full per-company loop cost at
+// catalogue scale — see companyBatchSize.
+func forCompanyBatches(ctx context.Context, companies []string, fn func(context.Context, []string) (int64, error)) (int64, error) {
+	var total int64
+	var failures int
+	var lastErr error
+	for batch := range slices.Chunk(companies, companyBatchSize) {
+		n, err := fn(ctx, batch)
+		if err != nil {
+			failures++
+			lastErr = fmt.Errorf("batch of %d companies (starting %q): %w", len(batch), batch[0], err)
+			continue
+		}
+		total += n
+	}
+	if failures > 0 {
+		return total, fmt.Errorf("%d batches failed out of %d companies (batch size %d); last: %w",
+			failures, len(companies), companyBatchSize, lastErr)
+	}
+	return total, nil
+}
+
 // forEachCompany runs fn once per company, summing the rows it reports re-marked.
-// Companies are independent, so one failure (e.g. a statement timeout on an unusually
-// large cluster) must not starve the rest — it is counted and skipped, and any failure
-// turns the pass's result into an aggregate error (the caller treats the whole pass as
-// best-effort and continues with the prior markers).
+// Companies are independent, so one failure must not starve the rest — it is counted
+// and skipped, and any failure turns the pass's result into an aggregate error (the
+// caller treats the whole pass as best-effort and continues with the prior markers).
+// Unlike forCompanyBatches, this stays one-at-a-time: its only caller
+// (collapseFuzzyDuplicates, cmd/reindex/fuzzy.go) does real per-company work in Go —
+// fetching titles and descriptions, then fuzzy-comparing them in memory — not a single
+// set-based SQL statement, so there is no query to batch the way the two SQL-only
+// passes were.
 func forEachCompany(ctx context.Context, companies []string, fn func(context.Context, string) (int64, error)) (int64, error) {
 	var total int64
 	var failures int

--- a/internal/db/aggregator_dedup_integration_test.go
+++ b/internal/db/aggregator_dedup_integration_test.go
@@ -36,7 +36,8 @@ func aggJob(externalID, title string, countries []string) UpsertJobParams {
 	return p
 }
 
-// suppressAggregators drives the pass per company, as cmd/ingest does.
+// suppressAggregators drives the pass in one batched call across every candidate
+// company, as cmd/reindex does.
 func suppressAggregators(t *testing.T, q *Queries) {
 	t.Helper()
 	ctx := context.Background()
@@ -44,13 +45,14 @@ func suppressAggregators(t *testing.T, q *Queries) {
 	if err != nil {
 		t.Fatalf("companies with aggregator postings: %v", err)
 	}
-	for _, c := range companies {
-		if _, err := q.SuppressAggregatorDuplicatesForCompany(ctx, SuppressAggregatorDuplicatesForCompanyParams{
-			Company:     c,
-			Aggregators: aggregators,
-		}); err != nil {
-			t.Fatalf("suppress company %q: %v", c, err)
-		}
+	if len(companies) == 0 {
+		return
+	}
+	if _, err := q.SuppressAggregatorDuplicatesForCompanies(ctx, SuppressAggregatorDuplicatesForCompaniesParams{
+		Companies:   companies,
+		Aggregators: aggregators,
+	}); err != nil {
+		t.Fatalf("suppress companies %v: %v", companies, err)
 	}
 }
 
@@ -234,6 +236,53 @@ func TestSuppressedAggregator_HiddenFromListAndEnrichmentButServedBySlug(t *test
 	// The suppressed copy is still fetchable by its public slug (direct link).
 	if _, err := q.GetJobBySlug(ctx, "pslug-acme:agg"); err != nil {
 		t.Errorf("GetJobBySlug for suppressed aggregator: %v", err)
+	}
+}
+
+// TestSuppressAggregator_BatchedCallDoesNotCrossCompanies is the regression this batch
+// rewrite exists to guard: SuppressAggregatorDuplicatesForCompanies processes many
+// companies in ONE call (cmd/reindex's forCompanyBatches, added after a 2026-08-06 prod
+// incident where one round trip per company made this pass run for hours). Unlike
+// RecomputeRoleDuplicatesForCompanies, title matching has no company-scoped key baked
+// in, so two different companies sharing an identical role title MUST NOT cross-match
+// just because a batch call happens to cover both at once — each must resolve to its
+// OWN company's ATS twin.
+func TestSuppressAggregator_BatchedCallDoesNotCrossCompanies(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	widgetco := func(externalID, source, title string) UpsertJobParams {
+		p := ingestParams(externalID, title)
+		p.Company = "Widget Co"
+		p.CompanySlug = "widget-co"
+		p.Source = source
+		return p
+	}
+
+	// Both companies post the identical title through both an ATS and an aggregator —
+	// the exact shape that would cross-match if the batch query lost the company key.
+	mustUpsert(t, q, atsJob("acme:ats", "Backend Engineer", nil))
+	mustUpsert(t, q, aggJob("acme:agg", "Backend Engineer", nil))
+	mustUpsert(t, q, widgetco("widgetco:ats", "greenhouse", "Backend Engineer"))
+	mustUpsert(t, q, widgetco("widgetco:agg", "himalayas", "Backend Engineer"))
+
+	suppressAggregators(t, q) // one batched call covering both companies
+
+	acmeATS, _ := dupOf(t, pool, "acme:ats")
+	widgetATS, _ := dupOf(t, pool, "widgetco:ats")
+	_, acmeAggDup := dupOf(t, pool, "acme:agg")
+	_, widgetAggDup := dupOf(t, pool, "widgetco:agg")
+
+	if acmeAggDup != acmeATS {
+		t.Errorf("acme aggregator duplicate_of = %d, want its own ATS twin %d", acmeAggDup, acmeATS)
+	}
+	if widgetAggDup != widgetATS {
+		t.Errorf("widgetco aggregator duplicate_of = %d, want its own ATS twin %d", widgetAggDup, widgetATS)
+	}
+	if acmeAggDup == widgetATS || widgetAggDup == acmeATS {
+		t.Fatalf("cross-company match: acme->%d widgetco->%d, want each pinned to its own company's ATS row",
+			acmeAggDup, widgetAggDup)
 	}
 }
 

--- a/internal/db/canonical_job_for_role_integration_test.go
+++ b/internal/db/canonical_job_for_role_integration_test.go
@@ -71,7 +71,7 @@ func TestCanonicalJobForRole(t *testing.T) {
 	})
 
 	t.Run("the oldest eligible posting wins", func(t *testing.T) {
-		// The canon choice has to agree with RecomputeRoleDuplicatesForCompany, which takes the
+		// The canon choice has to agree with RecomputeRoleDuplicatesForCompanies, which takes the
 		// cluster's MIN(id). A later-seeded, equally eligible row must not win.
 		seed(t, "lever", "acme:2", "senior-go-acme-3", "fp-go", false)
 		row, err := q.CanonicalJobForRole(ctx, CanonicalJobForRoleParams{

--- a/internal/db/job_duplicate_of_integration_test.go
+++ b/internal/db/job_duplicate_of_integration_test.go
@@ -1,11 +1,11 @@
 //go:build integration
 
-// Integration tests for the role-duplicate recompute: driven per company
-// (CompaniesWithRoleClusters + RecomputeRoleDuplicatesForCompany, as the reindex does),
-// it collapses each role cluster (company_slug + role_fingerprint) to one canonical open
-// job (min(id)), pointing the other open reposts at it via duplicate_of, while leaving
-// singletons and unfingerprinted rows canonical. Canon failover on close and the min(id)
-// tie-break are SQL behaviors verifiable only against a real Postgres.
+// Integration tests for the role-duplicate recompute: driven over batches of companies
+// (CompaniesWithRoleClusters + RecomputeRoleDuplicatesForCompanies, as the reindex
+// does), it collapses each role cluster (company_slug + role_fingerprint) to one
+// canonical open job (min(id)), pointing the other open reposts at it via duplicate_of,
+// while leaving singletons and unfingerprinted rows canonical. Canon failover on close
+// and the min(id) tie-break are SQL behaviors verifiable only against a real Postgres.
 // Run with: go test -tags=integration ./internal/db/
 package db
 
@@ -18,17 +18,18 @@ import (
 )
 
 // recomputeDuplicates runs the batched recompute exactly as the reindex does: fetch the
-// companies needing work, then recompute each in its own short transaction.
+// companies needing work, then recompute them in one batched call.
 func recomputeDuplicates(t *testing.T, q *Queries) {
 	t.Helper()
 	companies, err := q.CompaniesWithRoleClusters(context.Background())
 	if err != nil {
 		t.Fatalf("companies with clusters: %v", err)
 	}
-	for _, c := range companies {
-		if _, err := q.RecomputeRoleDuplicatesForCompany(context.Background(), c); err != nil {
-			t.Fatalf("recompute company %q: %v", c, err)
-		}
+	if len(companies) == 0 {
+		return
+	}
+	if _, err := q.RecomputeRoleDuplicatesForCompanies(context.Background(), companies); err != nil {
+		t.Fatalf("recompute companies %v: %v", companies, err)
 	}
 }
 

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -223,8 +223,8 @@ WHERE closed_at IS NULL AND company_slug <> ''
 // Company slugs with at least one OPEN aggregator posting — the drive list for the
 // cross-source aggregator suppression pass. An open aggregator row is a candidate whether
 // it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
-// covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
-// mirroring the role-duplicate recompute's lock discipline.
+// covers both. Processed in chunks (SuppressAggregatorDuplicatesForCompanies), mirroring
+// the role-duplicate recompute's batching.
 func (q *Queries) CompaniesWithAggregatorPostings(ctx context.Context, aggregators []string) ([]string, error) {
 	rows, err := q.db.Query(ctx, companiesWithAggregatorPostings, aggregators)
 	if err != nil {
@@ -1925,11 +1925,11 @@ func (q *Queries) PropagateCollectionsToJobs(ctx context.Context) (int64, error)
 	return result.RowsAffected(), nil
 }
 
-const recomputeRoleDuplicatesForCompany = `-- name: RecomputeRoleDuplicatesForCompany :execrows
+const recomputeRoleDuplicatesForCompanies = `-- name: RecomputeRoleDuplicatesForCompanies :execrows
 WITH canon AS (
     SELECT jobs.role_fingerprint, MIN(jobs.id) AS canon_id, COUNT(*) AS n
     FROM jobs
-    WHERE jobs.company_slug = $1
+    WHERE jobs.company_slug = ANY($1::text[])
       AND jobs.closed_at IS NULL AND jobs.role_fingerprint IS NOT NULL AND jobs.role_fingerprint <> ''
     GROUP BY jobs.role_fingerprint
 ),
@@ -1938,7 +1938,7 @@ target AS (
         CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
     FROM jobs j
     JOIN canon c ON j.role_fingerprint = c.role_fingerprint
-    WHERE j.company_slug = $1 AND j.closed_at IS NULL
+    WHERE j.company_slug = ANY($1::text[]) AND j.closed_at IS NULL
 )
 UPDATE jobs j
 SET duplicate_of = t.new_dup,
@@ -1948,15 +1948,24 @@ WHERE j.id = t.id
   AND j.duplicate_of IS DISTINCT FROM t.new_dup
 `
 
-// The per-company slice of the role-duplicate recompute. Canon = min(id) among the
-// company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
-// row get duplicate_of NULL, the other reposts point to the canon. Rows are never
-// deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
-// only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
-// aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
-// idempotent, and a closed canon fails over to the next min(id) on the next run.
-func (q *Queries) RecomputeRoleDuplicatesForCompany(ctx context.Context, company string) (int64, error) {
-	result, err := q.db.Exec(ctx, recomputeRoleDuplicatesForCompany, company)
+// The batched slice of the role-duplicate recompute, driven over a CHUNK of companies
+// (cmd/reindex's forCompanyBatches) rather than one call per company — see that
+// function's doc comment for why: at catalogue scale (2026-08-06 prod measurement:
+// 236,923 distinct open companies) one round trip per company made this pass take
+// hours under ordinary host load, most of it network/planning overhead rather than
+// query cost. Batching multiple companies into ONE statement is safe here without any
+// extra cross-company guard: role_fingerprint is sha256(company_slug, title,
+// description) (internal/jobhash.RoleFingerprint) with company_slug as its FIRST
+// component, so a fingerprint collision between two different companies is not a
+// realistic concern — grouping by role_fingerprint alone, across the whole batch,
+// cannot merge two different companies' rows. Canon = min(id) among a role's open rows;
+// the canon and any singleton/empty-fp row get duplicate_of NULL, the other reposts
+// point to the canon. Rows are never deleted, so the reality counts are untouched. The
+// (company_slug, role_fingerprint) index makes both scans range scans over the batch.
+// The IS DISTINCT FROM guard makes re-runs cheap and idempotent, and a closed canon
+// fails over to the next min(id) on the next run.
+func (q *Queries) RecomputeRoleDuplicatesForCompanies(ctx context.Context, companies []string) (int64, error) {
+	result, err := q.db.Exec(ctx, recomputeRoleDuplicatesForCompanies, companies)
 	if err != nil {
 		return 0, err
 	}
@@ -2412,9 +2421,10 @@ func (q *Queries) SetJobEnrichment(ctx context.Context, arg SetJobEnrichmentPara
 	return err
 }
 
-const suppressAggregatorDuplicatesForCompany = `-- name: SuppressAggregatorDuplicatesForCompany :execrows
+const suppressAggregatorDuplicatesForCompanies = `-- name: SuppressAggregatorDuplicatesForCompanies :execrows
 WITH ats AS (
     SELECT jobs.id,
+           replace(jobs.company_slug, '-', '') AS fcompany,
            btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
@@ -2425,12 +2435,14 @@ WITH ats AS (
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            jobs.countries
     FROM jobs
-    WHERE replace(jobs.company_slug, '-', '') = replace($1::text, '-', '')
+    WHERE replace(jobs.company_slug, '-', '') = ANY(
+              SELECT replace(c, '-', '') FROM unnest($1::text[]) AS c)
       AND jobs.closed_at IS NULL AND jobs.duplicate_of IS NULL AND jobs.company_slug <> ''
       AND NOT (jobs.source = ANY($2::text[]))
 ),
 agg AS (
     SELECT a.id,
+           replace(a.company_slug, '-', '') AS fcompany,
            btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
@@ -2441,7 +2453,8 @@ agg AS (
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            a.countries
     FROM jobs a
-    WHERE replace(a.company_slug, '-', '') = replace($1::text, '-', '')
+    WHERE replace(a.company_slug, '-', '') = ANY(
+              SELECT replace(c, '-', '') FROM unnest($1::text[]) AS c)
       AND a.closed_at IS NULL AND a.company_slug <> ''
       AND a.source = ANY($2::text[])
       AND (
@@ -2461,32 +2474,38 @@ matches AS (
     -- the way. Only those two clauses are decoration: measured on prod, also stripping a
     -- parenthetical produced 39 wrong pairs out of 55 — one company's "…, Backend (Traffic)"
     -- matching its "(Payments)", "(Identity)" and "(Infrastructure)" roles — and a comma clause
-    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE single-equality hash join (O(agg + ats))
-    -- and the two are UNION ALL-ed — an OR of the two equalities in one ON would defeat the
-    -- hash join and go quadratic on a big company (the hotel-chain case). UNION ALL, not
-    -- UNION: a row matched by both paths appears twice, but the downstream MIN(ats_id)
-    -- absorbs the duplicate, so the de-dup pass is wasted work. Both require a non-empty key;
-    -- the country gate applies to each path.
+    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE
+    -- equality hash join (now on (fcompany, ntitle) / (fcompany, ntitle2), still
+    -- O(agg + ats)) and the two are UNION ALL-ed — an OR of the two equalities in one ON
+    -- would defeat the hash join and go quadratic on a big company (the hotel-chain
+    -- case). UNION ALL, not UNION: a row matched by both paths appears twice, but the
+    -- downstream MIN(ats_id) absorbs the duplicate, so the de-dup pass is wasted work.
+    -- Both require a non-empty key; the country gate applies to each path.
     SELECT a.id AS agg_id, t.id AS ats_id
     FROM agg a JOIN ats t
-      ON t.ntitle = a.ntitle AND a.ntitle <> ''
+      ON t.fcompany = a.fcompany
+     AND t.ntitle = a.ntitle AND a.ntitle <> ''
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
     UNION ALL
     SELECT a.id, t.id
     FROM agg a JOIN ats t
-      ON t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
+      ON t.fcompany = a.fcompany
+     AND t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
     UNION ALL
     -- Third path: word-subset containment — the aggregator dropped words the ATS keeps (a
     -- mid-title drop the two equality keys miss). This arm is a nested loop (no hash on <@),
-    -- but runs only on the residual after the equality arms and is bounded per company.
+    -- but runs only on the residual after the equality arms and is bounded per company via
+    -- the fcompany equality (planned as a hash/merge join on fcompany, nested-looping only
+    -- within each matching group — the same cost shape the old single-company call had).
     -- Guards against over-merge: the aggregator title needs >= 2 words, and the words the ATS
     -- adds over it must include at least one NON-seniority word — so "Software Engineer" is not
     -- merged into "Senior Software Engineer" (a distinct grade), only into a title that adds a
     -- real specialty/location/department word the aggregator dropped.
     SELECT a.id, t.id
     FROM agg a JOIN ats t
-      ON string_to_array(a.ntitle, ' ') <@ string_to_array(t.ntitle, ' ')
+      ON t.fcompany = a.fcompany
+     AND string_to_array(a.ntitle, ' ') <@ string_to_array(t.ntitle, ' ')
      AND array_length(string_to_array(a.ntitle, ' '), 1) >= 2
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
      AND EXISTS (
@@ -2514,28 +2533,38 @@ WHERE j.id = t.id
   AND j.duplicate_of IS DISTINCT FROM t.new_dup
 `
 
-type SuppressAggregatorDuplicatesForCompanyParams struct {
-	Company     string   `json:"company"`
+type SuppressAggregatorDuplicatesForCompaniesParams struct {
+	Companies   []string `json:"companies"`
 	Aggregators []string `json:"aggregators"`
 }
 
-// The per-company slice of the cross-source aggregator suppression. An open aggregator
-// posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
-// same company, equal normalized title, and compatible country (countries overlap, or
-// either side empty — the geography dictionary is sparse, so an unresolved side must not
-// veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
-// are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
-// by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
-// left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
-// its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
-// target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
-// RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
-// Company match folds away word-separator spelling variance between sources: company_slug
-// is normalize.Slug(name), which never strips legal suffixes, so two sources naming the
-// same employer with a different word break ("Cfoinsights" vs "CFO Insights") land on
-// different slugs ("cfoinsights" vs "cfo-insights") that agree once hyphens are removed.
-func (q *Queries) SuppressAggregatorDuplicatesForCompany(ctx context.Context, arg SuppressAggregatorDuplicatesForCompanyParams) (int64, error) {
-	result, err := q.db.Exec(ctx, suppressAggregatorDuplicatesForCompany, arg.Company, arg.Aggregators)
+// The batched slice of the cross-source aggregator suppression, driven over a CHUNK of
+// companies (cmd/reindex's forCompanyBatches) rather than one call per company — see
+// RecomputeRoleDuplicatesForCompanies' doc comment for the prod measurement that
+// motivated batching both passes (94,410 companies with an open aggregator posting;
+// one round trip each made this pass the one that actually got stuck for hours on
+// 2026-08-06). Unlike that query, batching here is NOT free: title matching has no
+// natural company key the way role_fingerprint does, so both CTEs carry an explicit
+// fcompany (folded company) column and every match arm's ON clause pins
+// t.fcompany = a.fcompany — without it, two different companies sharing a common title
+// ("Backend Engineer") would cross-match the moment they land in the same batch.
+// fcompany is the same replace(company_slug, '-', ”) fold PR #1591 introduced (a
+// source spelling one employer "Cfoinsights", another "CFO Insights" — different
+// slugs that must still agree), just computed once per row instead of per query.
+//
+// An open aggregator posting is marked duplicate_of an open CANONICAL ATS
+// (non-aggregator) posting of the same (folded) company, equal normalized title, and
+// compatible country (countries overlap, or either side empty — the geography
+// dictionary is sparse, so an unresolved side must not veto). The ATS row is never
+// touched, so it stays canonical. Candidate aggregator rows are those that are
+// canonical OR already point at a non-aggregator row (i.e. suppressed by THIS pass) —
+// an aggregator repost pointed at another aggregator by the role pass is left alone. A
+// candidate with no ATS twin resolves to NULL, so a closed twin releases its aggregator
+// copy back into search/embedding/enrichment. min(id) picks a stable target; the IS
+// DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+// RecomputeRoleDuplicatesForCompanies so ATS reposts have already collapsed to their canon.
+func (q *Queries) SuppressAggregatorDuplicatesForCompanies(ctx context.Context, arg SuppressAggregatorDuplicatesForCompaniesParams) (int64, error) {
+	result, err := q.db.Exec(ctx, suppressAggregatorDuplicatesForCompanies, arg.Companies, arg.Aggregators)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/pruning_integration_test.go
+++ b/internal/db/pruning_integration_test.go
@@ -462,7 +462,7 @@ func TestPruneJobsCascadesUserInteractions(t *testing.T) {
 	}
 }
 
-// duplicate_of can chain: RecomputeRoleDuplicatesForCompany and the aggregator
+// duplicate_of can chain: RecomputeRoleDuplicatesForCompanies and the aggregator
 // suppression both scope to open jobs, so a closed row's pointer is never repointed
 // when its parent later becomes a duplicate itself. The prune scan reaches closed rows
 // by design, so it meets those chains — and a one-level extension leaves the tail

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -307,8 +307,8 @@ type Querier interface {
 	// Company slugs with at least one OPEN aggregator posting — the drive list for the
 	// cross-source aggregator suppression pass. An open aggregator row is a candidate whether
 	// it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
-	// covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
-	// mirroring the role-duplicate recompute's lock discipline.
+	// covers both. Processed in chunks (SuppressAggregatorDuplicatesForCompanies), mirroring
+	// the role-duplicate recompute's batching.
 	CompaniesWithAggregatorPostings(ctx context.Context, aggregators []string) ([]string, error)
 	// The subset of the given company slugs that are referral-eligible — for annotating a
 	// job/company list in one round-trip instead of a query per row.
@@ -2072,14 +2072,23 @@ type Querier interface {
 	// (AT TIME ZONE 'UTC') so buckets are stable regardless of session timezone. The
 	// FULL OUTER JOIN yields one row per day that saw either an add or a removal.
 	RebuildJobDailyStats(ctx context.Context) (int64, error)
-	// The per-company slice of the role-duplicate recompute. Canon = min(id) among the
-	// company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
-	// row get duplicate_of NULL, the other reposts point to the canon. Rows are never
-	// deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
-	// only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
-	// aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
-	// idempotent, and a closed canon fails over to the next min(id) on the next run.
-	RecomputeRoleDuplicatesForCompany(ctx context.Context, company string) (int64, error)
+	// The batched slice of the role-duplicate recompute, driven over a CHUNK of companies
+	// (cmd/reindex's forCompanyBatches) rather than one call per company — see that
+	// function's doc comment for why: at catalogue scale (2026-08-06 prod measurement:
+	// 236,923 distinct open companies) one round trip per company made this pass take
+	// hours under ordinary host load, most of it network/planning overhead rather than
+	// query cost. Batching multiple companies into ONE statement is safe here without any
+	// extra cross-company guard: role_fingerprint is sha256(company_slug, title,
+	// description) (internal/jobhash.RoleFingerprint) with company_slug as its FIRST
+	// component, so a fingerprint collision between two different companies is not a
+	// realistic concern — grouping by role_fingerprint alone, across the whole batch,
+	// cannot merge two different companies' rows. Canon = min(id) among a role's open rows;
+	// the canon and any singleton/empty-fp row get duplicate_of NULL, the other reposts
+	// point to the canon. Rows are never deleted, so the reality counts are untouched. The
+	// (company_slug, role_fingerprint) index makes both scans range scans over the batch.
+	// The IS DISTINCT FROM guard makes re-runs cheap and idempotent, and a closed canon
+	// fails over to the next min(id) on the next run.
+	RecomputeRoleDuplicatesForCompanies(ctx context.Context, companies []string) (int64, error)
 	// Record that the candidate chased a silent application. Owner-scoped: a foreign or untracked job
 	// matches no row, so the handler 404s and nothing is written. Idempotent by design — a double click
 	// just overwrites the timestamp with a later one rather than erroring.
@@ -2604,22 +2613,32 @@ type Querier interface {
 	// about this application explicitly, suggested_job_id holds one value, and a proposal
 	// nobody has confirmed costs nothing to lose.
 	SuggestJobForEmail(ctx context.Context, arg SuggestJobForEmailParams) (int64, error)
-	// The per-company slice of the cross-source aggregator suppression. An open aggregator
-	// posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
-	// same company, equal normalized title, and compatible country (countries overlap, or
-	// either side empty — the geography dictionary is sparse, so an unresolved side must not
-	// veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
-	// are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
-	// by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
-	// left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
-	// its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
-	// target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
-	// RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
-	// Company match folds away word-separator spelling variance between sources: company_slug
-	// is normalize.Slug(name), which never strips legal suffixes, so two sources naming the
-	// same employer with a different word break ("Cfoinsights" vs "CFO Insights") land on
-	// different slugs ("cfoinsights" vs "cfo-insights") that agree once hyphens are removed.
-	SuppressAggregatorDuplicatesForCompany(ctx context.Context, arg SuppressAggregatorDuplicatesForCompanyParams) (int64, error)
+	// The batched slice of the cross-source aggregator suppression, driven over a CHUNK of
+	// companies (cmd/reindex's forCompanyBatches) rather than one call per company — see
+	// RecomputeRoleDuplicatesForCompanies' doc comment for the prod measurement that
+	// motivated batching both passes (94,410 companies with an open aggregator posting;
+	// one round trip each made this pass the one that actually got stuck for hours on
+	// 2026-08-06). Unlike that query, batching here is NOT free: title matching has no
+	// natural company key the way role_fingerprint does, so both CTEs carry an explicit
+	// fcompany (folded company) column and every match arm's ON clause pins
+	// t.fcompany = a.fcompany — without it, two different companies sharing a common title
+	// ("Backend Engineer") would cross-match the moment they land in the same batch.
+	// fcompany is the same replace(company_slug, '-', '') fold PR #1591 introduced (a
+	// source spelling one employer "Cfoinsights", another "CFO Insights" — different
+	// slugs that must still agree), just computed once per row instead of per query.
+	//
+	// An open aggregator posting is marked duplicate_of an open CANONICAL ATS
+	// (non-aggregator) posting of the same (folded) company, equal normalized title, and
+	// compatible country (countries overlap, or either side empty — the geography
+	// dictionary is sparse, so an unresolved side must not veto). The ATS row is never
+	// touched, so it stays canonical. Candidate aggregator rows are those that are
+	// canonical OR already point at a non-aggregator row (i.e. suppressed by THIS pass) —
+	// an aggregator repost pointed at another aggregator by the role pass is left alone. A
+	// candidate with no ATS twin resolves to NULL, so a closed twin releases its aggregator
+	// copy back into search/embedding/enrichment. min(id) picks a stable target; the IS
+	// DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+	// RecomputeRoleDuplicatesForCompanies so ATS reposts have already collapsed to their canon.
+	SuppressAggregatorDuplicatesForCompanies(ctx context.Context, arg SuppressAggregatorDuplicatesForCompaniesParams) (int64, error)
 	// Rebuild the companies catalogue from jobs. The companies table is derivable
 	// from jobs (slug = company_slug, name = company), so after a slug-builder change
 	// re-keys jobs, this re-keys companies to match. DISTINCT ON collapses a slug's

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -533,18 +533,27 @@ UNION
 SELECT DISTINCT company_slug FROM jobs
 WHERE closed_at IS NULL AND company_slug <> '' AND duplicate_of IS NOT NULL;
 
--- name: RecomputeRoleDuplicatesForCompany :execrows
--- The per-company slice of the role-duplicate recompute. Canon = min(id) among the
--- company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
--- row get duplicate_of NULL, the other reposts point to the canon. Rows are never
--- deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
--- only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
--- aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
--- idempotent, and a closed canon fails over to the next min(id) on the next run.
+-- name: RecomputeRoleDuplicatesForCompanies :execrows
+-- The batched slice of the role-duplicate recompute, driven over a CHUNK of companies
+-- (cmd/reindex's forCompanyBatches) rather than one call per company — see that
+-- function's doc comment for why: at catalogue scale (2026-08-06 prod measurement:
+-- 236,923 distinct open companies) one round trip per company made this pass take
+-- hours under ordinary host load, most of it network/planning overhead rather than
+-- query cost. Batching multiple companies into ONE statement is safe here without any
+-- extra cross-company guard: role_fingerprint is sha256(company_slug, title,
+-- description) (internal/jobhash.RoleFingerprint) with company_slug as its FIRST
+-- component, so a fingerprint collision between two different companies is not a
+-- realistic concern — grouping by role_fingerprint alone, across the whole batch,
+-- cannot merge two different companies' rows. Canon = min(id) among a role's open rows;
+-- the canon and any singleton/empty-fp row get duplicate_of NULL, the other reposts
+-- point to the canon. Rows are never deleted, so the reality counts are untouched. The
+-- (company_slug, role_fingerprint) index makes both scans range scans over the batch.
+-- The IS DISTINCT FROM guard makes re-runs cheap and idempotent, and a closed canon
+-- fails over to the next min(id) on the next run.
 WITH canon AS (
     SELECT jobs.role_fingerprint, MIN(jobs.id) AS canon_id, COUNT(*) AS n
     FROM jobs
-    WHERE jobs.company_slug = sqlc.arg(company)
+    WHERE jobs.company_slug = ANY(sqlc.arg(companies)::text[])
       AND jobs.closed_at IS NULL AND jobs.role_fingerprint IS NOT NULL AND jobs.role_fingerprint <> ''
     GROUP BY jobs.role_fingerprint
 ),
@@ -553,7 +562,7 @@ target AS (
         CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
     FROM jobs j
     JOIN canon c ON j.role_fingerprint = c.role_fingerprint
-    WHERE j.company_slug = sqlc.arg(company) AND j.closed_at IS NULL
+    WHERE j.company_slug = ANY(sqlc.arg(companies)::text[]) AND j.closed_at IS NULL
 )
 UPDATE jobs j
 SET duplicate_of = t.new_dup,
@@ -566,30 +575,41 @@ WHERE j.id = t.id
 -- Company slugs with at least one OPEN aggregator posting — the drive list for the
 -- cross-source aggregator suppression pass. An open aggregator row is a candidate whether
 -- it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
--- covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
--- mirroring the role-duplicate recompute's lock discipline.
+-- covers both. Processed in chunks (SuppressAggregatorDuplicatesForCompanies), mirroring
+-- the role-duplicate recompute's batching.
 SELECT DISTINCT company_slug FROM jobs
 WHERE closed_at IS NULL AND company_slug <> ''
   AND source = ANY(sqlc.arg(aggregators)::text[]);
 
--- name: SuppressAggregatorDuplicatesForCompany :execrows
--- The per-company slice of the cross-source aggregator suppression. An open aggregator
--- posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
--- same company, equal normalized title, and compatible country (countries overlap, or
--- either side empty — the geography dictionary is sparse, so an unresolved side must not
--- veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
--- are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
--- by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
--- left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
--- its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
--- target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
--- RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
--- Company match folds away word-separator spelling variance between sources: company_slug
--- is normalize.Slug(name), which never strips legal suffixes, so two sources naming the
--- same employer with a different word break ("Cfoinsights" vs "CFO Insights") land on
--- different slugs ("cfoinsights" vs "cfo-insights") that agree once hyphens are removed.
+-- name: SuppressAggregatorDuplicatesForCompanies :execrows
+-- The batched slice of the cross-source aggregator suppression, driven over a CHUNK of
+-- companies (cmd/reindex's forCompanyBatches) rather than one call per company — see
+-- RecomputeRoleDuplicatesForCompanies' doc comment for the prod measurement that
+-- motivated batching both passes (94,410 companies with an open aggregator posting;
+-- one round trip each made this pass the one that actually got stuck for hours on
+-- 2026-08-06). Unlike that query, batching here is NOT free: title matching has no
+-- natural company key the way role_fingerprint does, so both CTEs carry an explicit
+-- fcompany (folded company) column and every match arm's ON clause pins
+-- t.fcompany = a.fcompany — without it, two different companies sharing a common title
+-- ("Backend Engineer") would cross-match the moment they land in the same batch.
+-- fcompany is the same replace(company_slug, '-', '') fold PR #1591 introduced (a
+-- source spelling one employer "Cfoinsights", another "CFO Insights" — different
+-- slugs that must still agree), just computed once per row instead of per query.
+--
+-- An open aggregator posting is marked duplicate_of an open CANONICAL ATS
+-- (non-aggregator) posting of the same (folded) company, equal normalized title, and
+-- compatible country (countries overlap, or either side empty — the geography
+-- dictionary is sparse, so an unresolved side must not veto). The ATS row is never
+-- touched, so it stays canonical. Candidate aggregator rows are those that are
+-- canonical OR already point at a non-aggregator row (i.e. suppressed by THIS pass) —
+-- an aggregator repost pointed at another aggregator by the role pass is left alone. A
+-- candidate with no ATS twin resolves to NULL, so a closed twin releases its aggregator
+-- copy back into search/embedding/enrichment. min(id) picks a stable target; the IS
+-- DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+-- RecomputeRoleDuplicatesForCompanies so ATS reposts have already collapsed to their canon.
 WITH ats AS (
     SELECT jobs.id,
+           replace(jobs.company_slug, '-', '') AS fcompany,
            btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
@@ -600,12 +620,14 @@ WITH ats AS (
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            jobs.countries
     FROM jobs
-    WHERE replace(jobs.company_slug, '-', '') = replace(sqlc.arg(company)::text, '-', '')
+    WHERE replace(jobs.company_slug, '-', '') = ANY(
+              SELECT replace(c, '-', '') FROM unnest(sqlc.arg(companies)::text[]) AS c)
       AND jobs.closed_at IS NULL AND jobs.duplicate_of IS NULL AND jobs.company_slug <> ''
       AND NOT (jobs.source = ANY(sqlc.arg(aggregators)::text[]))
 ),
 agg AS (
     SELECT a.id,
+           replace(a.company_slug, '-', '') AS fcompany,
            btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
@@ -616,7 +638,8 @@ agg AS (
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            a.countries
     FROM jobs a
-    WHERE replace(a.company_slug, '-', '') = replace(sqlc.arg(company)::text, '-', '')
+    WHERE replace(a.company_slug, '-', '') = ANY(
+              SELECT replace(c, '-', '') FROM unnest(sqlc.arg(companies)::text[]) AS c)
       AND a.closed_at IS NULL AND a.company_slug <> ''
       AND a.source = ANY(sqlc.arg(aggregators)::text[])
       AND (
@@ -636,32 +659,38 @@ matches AS (
     -- the way. Only those two clauses are decoration: measured on prod, also stripping a
     -- parenthetical produced 39 wrong pairs out of 55 — one company's "…, Backend (Traffic)"
     -- matching its "(Payments)", "(Identity)" and "(Infrastructure)" roles — and a comma clause
-    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE single-equality hash join (O(agg + ats))
-    -- and the two are UNION ALL-ed — an OR of the two equalities in one ON would defeat the
-    -- hash join and go quadratic on a big company (the hotel-chain case). UNION ALL, not
-    -- UNION: a row matched by both paths appears twice, but the downstream MIN(ats_id)
-    -- absorbs the duplicate, so the de-dup pass is wasted work. Both require a non-empty key;
-    -- the country gate applies to each path.
+    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE
+    -- equality hash join (now on (fcompany, ntitle) / (fcompany, ntitle2), still
+    -- O(agg + ats)) and the two are UNION ALL-ed — an OR of the two equalities in one ON
+    -- would defeat the hash join and go quadratic on a big company (the hotel-chain
+    -- case). UNION ALL, not UNION: a row matched by both paths appears twice, but the
+    -- downstream MIN(ats_id) absorbs the duplicate, so the de-dup pass is wasted work.
+    -- Both require a non-empty key; the country gate applies to each path.
     SELECT a.id AS agg_id, t.id AS ats_id
     FROM agg a JOIN ats t
-      ON t.ntitle = a.ntitle AND a.ntitle <> ''
+      ON t.fcompany = a.fcompany
+     AND t.ntitle = a.ntitle AND a.ntitle <> ''
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
     UNION ALL
     SELECT a.id, t.id
     FROM agg a JOIN ats t
-      ON t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
+      ON t.fcompany = a.fcompany
+     AND t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
     UNION ALL
     -- Third path: word-subset containment — the aggregator dropped words the ATS keeps (a
     -- mid-title drop the two equality keys miss). This arm is a nested loop (no hash on <@),
-    -- but runs only on the residual after the equality arms and is bounded per company.
+    -- but runs only on the residual after the equality arms and is bounded per company via
+    -- the fcompany equality (planned as a hash/merge join on fcompany, nested-looping only
+    -- within each matching group — the same cost shape the old single-company call had).
     -- Guards against over-merge: the aggregator title needs >= 2 words, and the words the ATS
     -- adds over it must include at least one NON-seniority word — so "Software Engineer" is not
     -- merged into "Senior Software Engineer" (a distinct grade), only into a title that adds a
     -- real specialty/location/department word the aggregator dropped.
     SELECT a.id, t.id
     FROM agg a JOIN ats t
-      ON string_to_array(a.ntitle, ' ') <@ string_to_array(t.ntitle, ' ')
+      ON t.fcompany = a.fcompany
+     AND string_to_array(a.ntitle, ' ') <@ string_to_array(t.ntitle, ' ')
      AND array_length(string_to_array(a.ntitle, ' '), 1) >= 2
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
      AND EXISTS (

--- a/internal/jobdedup/jobdedup.go
+++ b/internal/jobdedup/jobdedup.go
@@ -4,7 +4,7 @@
 // A company routinely posts one role once per city — same title, same description,
 // thirty external_ids. RoleFingerprint deliberately excludes the location, so those
 // copies share a fingerprint and the batch recompute
-// (db.RecomputeRoleDuplicatesForCompany) collapses them to one canonical row. The batch
+// (db.RecomputeRoleDuplicatesForCompanies) collapses them to one canonical row. The batch
 // runs every few hours, though, and the live search index is written incrementally by
 // the crawl; between the two, every copy is a separate searchable job. That window is
 // what this package closes, by answering the same question synchronously at write time.
@@ -26,7 +26,7 @@ import (
 // CanonicalForRole reports the open canonical posting of this row's role cluster, when
 // one exists that is OLDER than the row just written (id).
 //
-// The age condition is the whole subtlety. RecomputeRoleDuplicatesForCompany makes
+// The age condition is the whole subtlety. RecomputeRoleDuplicatesForCompanies makes
 // MIN(id) among a cluster's open rows the canon, so collapsing onto a NEWER posting is
 // not just a different choice — the next reindex would undo it and invert it. Staying in
 // step with the batch is what makes the two agree instead of fighting.


### PR DESCRIPTION
## Summary
- `RecomputeRoleDuplicatesForCompany`/`SuppressAggregatorDuplicatesForCompany` ran once per company via `forEachCompany` — one network round trip each. At catalogue scale (236,923 distinct open companies, 94,410 with an open aggregator posting) this made the aggregator-suppression pass alone take hours under ordinary host load.
- On 2026-08-06 the scheduled `freehire-reindexw` run got stuck in this exact pass for ~4 hours (confirmed via SIGQUIT goroutine dump — blocked reading the next per-company query's result, not deadlocked) and never reached the point of pushing documents to Meili; systemd auto-restarted it into the same slow loop.
- Both passes now run in batches of 500 companies (`forCompanyBatches`):
  - `RecomputeRoleDuplicatesForCompanies` — safe with no extra guard; `role_fingerprint` is `sha256(company_slug, title, description)`, so grouping by it across a batch cannot merge two different companies' rows.
  - `SuppressAggregatorDuplicatesForCompanies` — title matching has no company key baked in, so both CTEs now carry a folded-company column and every match arm's `ON` clause pins it, or two companies sharing a common title would cross-match once batched. Added `TestSuppressAggregator_BatchedCallDoesNotCrossCompanies` as the regression guard.
- `collapseFuzzyDuplicates` (`cmd/reindex/fuzzy.go`) keeps the original one-company-at-a-time `forEachCompany` — it does real per-company work in Go, not a single set-based SQL statement.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` / `go vet -tags=integration ./...`
- [x] `go test ./...`
- [x] `go test -tags=integration ./...` (full module, real Postgres via testcontainers), including the new cross-company regression test