### PR TITLE
feat(sources): onboard 4 contributed boards, reject 2 stale

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7756,3 +7756,5 @@
   board: surge-ai
 - company: Bedrock Talent
   board: bedrock-talent
+- company: SignalFire
+  board: signalfire

--- a/sources/phenom.yml
+++ b/sources/phenom.yml
@@ -105,3 +105,7 @@
 # Phenom tenant recovered from the contribution queue (2026-08, refineSearch 1135 postings)
 - company: Kuehne+Nagel
   board: jobs.kuehne-nagel.com
+
+# Phenom tenant from the contribution queue (2026-08-06, refineSearch 1701 postings)
+- company: Allianz
+  board: careers.allianz.com

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3769,3 +3769,5 @@
   board: vebegofacilityservices3
 - company: Veo Worldwide Services
   board: veocareers
+- company: Hygraph
+  board: hygraph

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -2097,3 +2097,5 @@
   board: xcellink
 - company: Stakemate
   board: stakemate
+- company: Greenfly
+  board: work-at-greenfly


### PR DESCRIPTION
## Summary
- Drains the `link_contributions` pending queue (2026-08-04 → 2026-08-06).
- Adds 4 live-validated boards: `phenom/careers.allianz.com` (Allianz), `ashby/signalfire` (SignalFire), `recruitee/hygraph` (Hygraph), `workable/work-at-greenfly` (Greenfly).
- Not added (will be rejected in the DB, not this PR): `cornerstone/talento360` (0 open requisitions), `greenhouse/v1` (recognizer bug — parsed the API version segment as the board for `ledgy.com/careers`; Ledgy is already tracked correctly as `board: ledgy`).

## Test plan
- [x] `go build ./...`
- [x] Each added board live-validated against its adapter's real request shape (phenom refineSearch, ashby posting-api, recruitee /api/offers, workable careers page)