### PR TITLE
fix(assistant): close dangling tool_use when replaying history

### DIFF
--- a/internal/assistant/AGENTS.md
+++ b/internal/assistant/AGENTS.md
@@ -189,7 +189,11 @@ it is the only tool whose completion depends on a client we do not control.
 **History trimming.** `trim` keeps the most recent N messages and then drops any
 leading tool results whose originating call was trimmed away — providers reject a
 tool result that answers no call in the conversation, so an orphan at the head
-turns a context loss into a failed turn.
+turns a context loss into a failed turn. It also closes the inverse shape: a
+`tool_use` whose `tool_result` never landed (a turn that died after persisting
+the calls). Replay synthesises an error result for each unanswered call so the
+next turn stays provider-legal — Bedrock in particular rejects the whole request
+otherwise.
 
 **Streaming.** `llm.Chat` splits the model's two delta channels: answer text goes
 to `OnText`, reasoning to `OnThinking`. The chat renders them apart, so reasoning

--- a/internal/assistant/runner.go
+++ b/internal/assistant/runner.go
@@ -329,7 +329,10 @@ func (r *Runner) history(ctx context.Context, sessionID uuid.UUID, system string
 // trim keeps the most recent limit messages, then drops any leading tool results
 // whose originating call was trimmed away. Providers reject a tool result that
 // answers no call in the conversation, so an orphan at the head would fail the
-// whole turn rather than merely losing context.
+// whole turn rather than merely losing context. It then closes any tool_use that
+// still has no matching tool_result — a turn that died after persisting the
+// calls but before their results leaves exactly that shape, and Bedrock rejects
+// the whole next turn for it.
 func trim(msgs []Message, limit int) []Message {
 	if limit > 0 && len(msgs) > limit {
 		msgs = msgs[len(msgs)-limit:]
@@ -337,7 +340,72 @@ func trim(msgs []Message, limit int) []Message {
 	for len(msgs) > 0 && msgs[0].Role == RoleTool {
 		msgs = msgs[1:]
 	}
-	return msgs
+	return closeDanglingToolCalls(msgs)
+}
+
+// closeDanglingToolCalls inserts synthetic error tool results for any assistant
+// tool_use that is not followed by its tool_result before the next non-tool
+// message (or the end of the transcript). Replay must stay provider-legal even
+// when a prior turn was interrupted mid-round.
+func closeDanglingToolCalls(msgs []Message) []Message {
+	if len(msgs) == 0 {
+		return msgs
+	}
+	out := make([]Message, 0, len(msgs)+4)
+	for i := 0; i < len(msgs); i++ {
+		msg := msgs[i]
+		out = append(out, msg)
+		if msg.Role != RoleAssistant {
+			continue
+		}
+		calls := assistantToolCalls(msg)
+		if len(calls) == 0 {
+			continue
+		}
+		answered := make(map[string]struct{}, len(calls))
+		j := i + 1
+		for j < len(msgs) && msgs[j].Role == RoleTool {
+			answered[toolResultCallID(msgs[j])] = struct{}{}
+			out = append(out, msgs[j])
+			j++
+		}
+		for _, call := range calls {
+			if _, ok := answered[call.ID]; ok || call.ID == "" {
+				continue
+			}
+			if syn := syntheticToolError(call); syn.Role != "" {
+				out = append(out, syn)
+			}
+		}
+		i = j - 1
+	}
+	return out
+}
+
+func assistantToolCalls(msg Message) []toolCall {
+	var c assistantContent
+	if err := json.Unmarshal(msg.Content, &c); err != nil {
+		return nil
+	}
+	return c.ToolCalls
+}
+
+func toolResultCallID(msg Message) string {
+	var c toolResultContent
+	if err := json.Unmarshal(msg.Content, &c); err != nil {
+		return ""
+	}
+	return c.ToolCallID
+}
+
+func syntheticToolError(call toolCall) Message {
+	msg, err := EncodeToolResult(call.ID, call.Name,
+		`{"error":"previous turn interrupted before this tool result was recorded; retry if still needed"}`)
+	if err != nil {
+		log.Printf("assistant: encode synthetic tool result for %s: %v", call.ID, err)
+		return Message{}
+	}
+	return msg
 }
 
 // fail emits the terminal error event and returns the cause. The event goes out

--- a/internal/assistant/runner_test.go
+++ b/internal/assistant/runner_test.go
@@ -402,6 +402,46 @@ func TestHistoryNeverStartsWithAnOrphanToolResult(t *testing.T) {
 	}
 }
 
+func TestHistoryClosesDanglingToolCallsBeforeReplay(t *testing.T) {
+	// A turn that persisted the model's tool_use and then died leaves a transcript
+	// Bedrock rejects on the next turn. Replay must synthesise the missing results.
+	q := &fakeQueries{}
+	store := NewStore(q)
+	ctx := context.Background()
+	call, _ := EncodeAssistant("", []llms.ToolCall{{ID: "c1", Type: "function", FunctionCall: &llms.FunctionCall{Name: "echo", Arguments: `{}`}}})
+	user, _ := EncodeUser("still there?")
+	for _, msg := range []Message{call, user} {
+		if _, err := store.Append(ctx, sessionID, msg); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	m := &scriptedModel{replies: []*llms.ContentChoice{textReply("ok")}}
+	r := NewRunner(m, store, RunnerConfig{MaxSteps: 3, HistoryLimit: 50})
+
+	if _, err := collect(t, r, Session{ID: sessionID, UserID: 3}, NewRegistry(), "retry"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	hist := m.gotHist[0]
+	var sawCall, sawResult bool
+	for _, msg := range hist {
+		for _, part := range msg.Parts {
+			switch p := part.(type) {
+			case llms.ToolCall:
+				if p.ID == "c1" {
+					sawCall = true
+				}
+			case llms.ToolCallResponse:
+				if p.ToolCallID == "c1" {
+					sawResult = true
+				}
+			}
+		}
+	}
+	if !sawCall || !sawResult {
+		t.Fatalf("replayed history missing closed tool pair: call=%v result=%v", sawCall, sawResult)
+	}
+}
+
 func TestTheFirstUserMessageLabelsTheSession(t *testing.T) {
 	q := &fakeQueries{}
 	m := &scriptedModel{replies: []*llms.ContentChoice{textReply("ok")}}


### PR DESCRIPTION
## What and why

A mid-turn failure (cancelled request, transport error, process restart) can leave an assistant `tool_use` in the transcript without its matching `tool_result`. The next user message then fails at the provider — Bedrock returns 500 with `tool_use ids were found without tool_result blocks` — so the tailor/assistant session looks dead even though infra is fine.

`trim` already dropped *leading* orphan tool results after history windowing. This change also closes the inverse: before replay, synthesise an error `tool_result` for any unanswered `tool_use` so the conversation stays provider-legal and the session remains resumable (matching the package’s “partial transcript must be resumable” rule).

Closes #

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass. *(scoped to `./internal/assistant/` for this change)*
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers). *(unit tests for `./internal/assistant/`; no DB/handler signature change — `go vet -tags=integration ./internal/assistant/` clean)*
- [x] I regenerated committed artifacts when their source changed (`make sqlc` for SQL/migrations, `make gen-contracts` for contract types). *(n/a)*
- [x] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass. *(n/a)*
- [x] For `web/` changes: `pnpm run check` and `pnpm run build` pass. *(n/a)*
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.

## Test plan

- [ ] `go test ./internal/assistant/ -run TestHistoryClosesDanglingToolCallsBeforeReplay`
- [ ] Reproduce with a transcript that has assistant `tool_calls` followed by a user message and no tool result — next turn should succeed instead of provider 500
- [ ] Normal tool rounds (tool_use → tool_result → answer) unchanged