### PR TITLE
harvest-boards: discover Greenhouse/Ashby boards from Common Crawl CDX

### DIFF
--- a/cmd/harvest-boards/boardfile.go
+++ b/cmd/harvest-boards/boardfile.go
@@ -29,10 +29,10 @@ func mapSeeds(p prober, seed []string) []string {
 }
 
 // newBoards returns the seed board ids not already present in existing, preserving seed
-// order and de-duplicating within the seed. Comparison is by key(boardID): identity for
-// most providers (Ashby slugs are case-sensitive), case-folding for Workday whose board ids
-// are case-insensitive (so a lowercased harvest twin of a curated CamelCase board is dropped
-// instead of crawled twice). The original (unkeyed) board id is what gets returned/stored.
+// order and de-duplicating within the seed. Comparison is by key(boardID): identity for most
+// providers, case-folding for the ones whose board ids are case-insensitive (Workday, Ashby)
+// so a lowercased harvest twin of a curated CamelCase board is dropped instead of crawled
+// twice. The original (unkeyed) board id is what gets returned/stored.
 func newBoards(seed []string, existing map[string]bool, key func(string) string) []string {
 	seen := make(map[string]bool, len(existing)+len(seed))
 	for b := range existing {

--- a/cmd/harvest-boards/boardfile_test.go
+++ b/cmd/harvest-boards/boardfile_test.go
@@ -40,8 +40,15 @@ func TestDedupKeyOf(t *testing.T) {
 	if dedupKeyOf(workdayProber{})("A.WD1.myworkdayjobs.com/Site") != "a.wd1.myworkdayjobs.com/site" {
 		t.Error("workday key must fold case")
 	}
-	if dedupKeyOf(ashbyProber{})("Ramp") != "Ramp" {
-		t.Error("ashby key must be case-sensitive (identity)")
+	// Greenhouse's boards API is case-insensitive too (confirmed live:
+	// boards-api.greenhouse.io/v1/boards/adyen and .../Adyen return the same company).
+	if dedupKeyOf(greenhouseProber{})("Adyen") != "adyen" {
+		t.Error("greenhouse key must fold case")
+	}
+	// Ashby's job-board API is case-insensitive (confirmed live: /posting-api/job-board/abridge
+	// and .../Abridge return the same company), so the dedup key folds case like Workday's.
+	if dedupKeyOf(ashbyProber{})("Ramp") != "ramp" {
+		t.Error("ashby key must fold case")
 	}
 }
 

--- a/cmd/harvest-boards/commoncrawl.go
+++ b/cmd/harvest-boards/commoncrawl.go
@@ -28,11 +28,10 @@ const commonCrawlMaxPages = 20
 // commonCrawlSlug extracts a candidate board id from a Common Crawl-matched URL: the first
 // non-empty path segment, exactly as crawled. Greenhouse and Ashby both key a board by that
 // segment (boards.greenhouse.io/<slug>/..., jobs.ashbyhq.com/<slug>/...), so no per-provider
-// variant is needed. Case is preserved rather than folded: Ashby board ids are
-// case-sensitive (see ashbyProber's dedupKeyer note in prober.go), and neither provider
-// implements dedupKeyer, so lower-casing here would silently diverge from how a seeded or
-// platform-discovered candidate is treated. A URL with no path segments (bare host, or root
-// "/") yields no candidate.
+// variant is needed. Case is preserved here rather than folded — both providers' APIs are in
+// fact case-insensitive, but that's handled once, at the dedup layer (see dedupKey on
+// greenhouseProber/ashbyProber in prober.go), not duplicated into every URL this function
+// parses. A URL with no path segments (bare host, or root "/") yields no candidate.
 func commonCrawlSlug(rawURL string) (string, bool) {
 	u, err := url.Parse(rawURL)
 	if err != nil {

--- a/cmd/harvest-boards/commoncrawl.go
+++ b/cmd/harvest-boards/commoncrawl.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// commonCrawlCollInfoURL lists every Common Crawl monthly snapshot, newest first, each with
+// its own CDX API root.
+const commonCrawlCollInfoURL = "https://index.commoncrawl.org/collinfo.json"
+
+// commonCrawlSnapshotCount is how many of the most recent snapshots discovery sweeps per
+// run. Common Crawl cuts a new snapshot roughly monthly, and snapshots a few months apart
+// overlap heavily in which companies they've seen, so the marginal new-candidate yield per
+// additional snapshot drops fast while cost (CDX requests) keeps climbing.
+const commonCrawlSnapshotCount = 3
+
+// commonCrawlMaxPages bounds the CDX pages read per snapshot, mirroring gupyMaxOffset's
+// safety-cap pattern: a spike run found a single host's full result fits in a handful of
+// pages, so this is a backstop against a runaway query, not an expected limit.
+const commonCrawlMaxPages = 20
+
+// commonCrawlSlug extracts a candidate board id from a Common Crawl-matched URL: the first
+// non-empty path segment, exactly as crawled. Greenhouse and Ashby both key a board by that
+// segment (boards.greenhouse.io/<slug>/..., jobs.ashbyhq.com/<slug>/...), so no per-provider
+// variant is needed. Case is preserved rather than folded: Ashby board ids are
+// case-sensitive (see ashbyProber's dedupKeyer note in prober.go), and neither provider
+// implements dedupKeyer, so lower-casing here would silently diverge from how a seeded or
+// platform-discovered candidate is treated. A URL with no path segments (bare host, or root
+// "/") yields no candidate.
+func commonCrawlSlug(rawURL string) (string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+	for _, part := range strings.Split(u.Path, "/") {
+		if part != "" {
+			return part, true
+		}
+	}
+	return "", false
+}
+
+// commonCrawlParsePage extracts candidate slugs from one CDX page response body: JSON-lines,
+// one record per line. GetText's response-size cap can truncate the last line mid-record; a
+// line that fails to parse (truncated or otherwise malformed) is silently skipped rather than
+// sinking the whole page, since every complete line before it is independently valid JSON.
+func commonCrawlParsePage(body string) []string {
+	var slugs []string
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec struct {
+			URL string `json:"url"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if slug, ok := commonCrawlSlug(rec.URL); ok {
+			slugs = append(slugs, slug)
+		}
+	}
+	return slugs
+}
+
+// commonCrawlSnapshots returns the CDX API root of the commonCrawlSnapshotCount most recent
+// Common Crawl snapshots (collinfo.json is already ordered newest first).
+func commonCrawlSnapshots(ctx context.Context, c httpClient) ([]string, error) {
+	var collections []struct {
+		CDXAPI string `json:"cdx-api"`
+	}
+	if err := c.GetJSON(ctx, commonCrawlCollInfoURL, &collections); err != nil {
+		return nil, err
+	}
+	n := commonCrawlSnapshotCount
+	if len(collections) < n {
+		n = len(collections)
+	}
+	apis := make([]string, 0, n)
+	for _, coll := range collections[:n] {
+		if coll.CDXAPI != "" {
+			apis = append(apis, coll.CDXAPI)
+		}
+	}
+	return apis, nil
+}
+
+// commonCrawlPageCount asks one snapshot's CDX index how many pages its full result for
+// hostPrefix spans, at the finest page granularity (pageSize=1) so a fetch of any one page
+// stays as small as the index's own block structure allows.
+func commonCrawlPageCount(ctx context.Context, c httpClient, cdxAPI, hostPrefix string) (int, error) {
+	var resp struct {
+		Pages int `json:"pages"`
+	}
+	url := fmt.Sprintf("%s?url=%s/*&output=json&showNumPages=true&pageSize=1", cdxAPI, hostPrefix)
+	if err := c.GetJSON(ctx, url, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Pages, nil
+}
+
+// commonCrawlCandidates discovers candidate board slugs for hostPrefix (e.g.
+// "boards.greenhouse.io") from the most recent Common Crawl snapshots. A snapshot whose page
+// count can't be read, or whose every page fails to fetch, is a failed snapshot: it is
+// skipped and logged, and the sweep continues with the remaining snapshots. An error is
+// returned only when every swept snapshot fails.
+func commonCrawlCandidates(ctx context.Context, c httpClient, hostPrefix string) ([]string, error) {
+	apis, err := commonCrawlSnapshots(ctx, c)
+	if err != nil {
+		return nil, fmt.Errorf("commoncrawl: collinfo: %w", err)
+	}
+
+	seen := map[string]struct{}{}
+	failures := 0
+	for _, api := range apis {
+		pages, err := commonCrawlPageCount(ctx, c, api, hostPrefix)
+		if err != nil {
+			log.Printf("commoncrawl: %s: page count: %v", api, err)
+			failures++
+			continue
+		}
+		if pages > commonCrawlMaxPages {
+			pages = commonCrawlMaxPages
+		}
+		fetched := 0
+		for page := 0; page < pages; page++ {
+			pageURL := fmt.Sprintf("%s?url=%s/*&output=json&page=%d&pageSize=1", api, hostPrefix, page)
+			body, err := c.GetText(ctx, pageURL)
+			if err != nil {
+				log.Printf("commoncrawl: %s page %d: %v", api, page, err)
+				continue
+			}
+			fetched++
+			for _, slug := range commonCrawlParsePage(body) {
+				seen[slug] = struct{}{}
+			}
+		}
+		if pages > 0 && fetched == 0 {
+			failures++
+		}
+	}
+	if len(apis) > 0 && failures == len(apis) {
+		return nil, fmt.Errorf("commoncrawl: all %d snapshots failed", failures)
+	}
+
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/cmd/harvest-boards/commoncrawl_test.go
+++ b/cmd/harvest-boards/commoncrawl_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestCommonCrawlSlugFromURL(t *testing.T) {
+	cases := []struct {
+		url  string
+		want string
+		ok   bool
+	}{
+		{"https://boards.greenhouse.io/acme/jobs/12345", "acme", true},
+		{"https://boards.greenhouse.io/Acme/jobs/12345?utm_source=x&utm_campaign=y", "Acme", true},
+		{"https://jobs.ashbyhq.com/AcmeInc/embed/job/abc-123", "AcmeInc", true},
+		{"https://boards.greenhouse.io/", "", false},
+		{"https://boards.greenhouse.io", "", false},
+	}
+	for _, c := range cases {
+		got, ok := commonCrawlSlug(c.url)
+		if ok != c.ok || got != c.want {
+			t.Errorf("commonCrawlSlug(%q) = (%q, %v), want (%q, %v)", c.url, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// TestCommonCrawlParsePageSkipsMalformedLines covers the 2MiB response-size cap on the
+// shared client's GetText: a truncated last line must not sink the whole page, since every
+// earlier complete line is still valid JSON on its own.
+func TestCommonCrawlParsePageSkipsMalformedLines(t *testing.T) {
+	body := `{"url": "https://boards.greenhouse.io/acme/jobs/1"}
+{"url": "https://boards.greenhouse.io/acme/jobs/2"}
+{"url": "https://boards.greenhouse.io/beta/jobs/3"}
+not valid json at all
+{"url": "https://boards.greenhouse.io/truncated/jobs/4"`
+
+	got := commonCrawlParsePage(body)
+	want := []string{"acme", "acme", "beta"}
+	if !slices.Equal(got, want) {
+		t.Errorf("commonCrawlParsePage = %v, want %v", got, want)
+	}
+}
+
+// commonCrawlCollInfoBody is a 3-snapshot collinfo.json, newest first, matching the real
+// shape (only the field this tool reads, cdx-api, is populated).
+const commonCrawlCollInfoBody = `[
+  {"id": "CC-MAIN-2026-30", "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2026-30-index"},
+  {"id": "CC-MAIN-2026-25", "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2026-25-index"},
+  {"id": "CC-MAIN-2026-21", "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2026-21-index"},
+  {"id": "CC-MAIN-2026-18", "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2026-18-index"}
+]`
+
+func TestCommonCrawlCandidatesMergesAcrossSnapshotsAndDedupes(t *testing.T) {
+	f := fakeGetter{
+		"https://index.commoncrawl.org/collinfo.json": commonCrawlCollInfoBody,
+
+		// Snapshot 1 (newest): 2 pages, contributes acme (twice, on two pages) and beta.
+		"https://index.commoncrawl.org/CC-MAIN-2026-30-index?url=boards.greenhouse.io/*&output=json&showNumPages=true&pageSize=1": `{"pages":2}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-30-index?url=boards.greenhouse.io/*&output=json&page=0&pageSize=1":            `{"url": "https://boards.greenhouse.io/acme/jobs/1"}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-30-index?url=boards.greenhouse.io/*&output=json&page=1&pageSize=1":            `{"url": "https://boards.greenhouse.io/beta/jobs/2"}`,
+
+		// Snapshot 2: its page-count query itself fails (unmapped) — a failing snapshot,
+		// not present in this map at all.
+
+		// Snapshot 3 (oldest of the 3 taken): 1 page, re-discovers acme (dedup) only.
+		"https://index.commoncrawl.org/CC-MAIN-2026-21-index?url=boards.greenhouse.io/*&output=json&showNumPages=true&pageSize=1": `{"pages":1}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-21-index?url=boards.greenhouse.io/*&output=json&page=0&pageSize=1":            `{"url": "https://boards.greenhouse.io/acme/jobs/9"}`,
+
+		// The 4th collinfo entry (CC-MAIN-2026-18) must never be queried: only the 3 most
+		// recent snapshots are swept. No entry for it here — a query would fail the test.
+	}
+
+	got, err := commonCrawlCandidates(context.Background(), f, "boards.greenhouse.io")
+	if err != nil {
+		t.Fatalf("commonCrawlCandidates: %v", err)
+	}
+	want := []string{"acme", "beta"}
+	if !slices.Equal(got, want) {
+		t.Errorf("commonCrawlCandidates = %v, want %v", got, want)
+	}
+}
+
+func TestCommonCrawlCandidatesErrorsWhenEverySnapshotFails(t *testing.T) {
+	f := fakeGetter{
+		"https://index.commoncrawl.org/collinfo.json": commonCrawlCollInfoBody,
+		// No page-count entries for any snapshot: every one of the 3 swept snapshots fails.
+	}
+
+	_, err := commonCrawlCandidates(context.Background(), f, "boards.greenhouse.io")
+	if err == nil {
+		t.Error("commonCrawlCandidates: want an error when every snapshot fails, got nil")
+	}
+}
+
+func TestGreenhouseProberDiscoversFromCommonCrawl(t *testing.T) {
+	f := fakeGetter{
+		"https://index.commoncrawl.org/collinfo.json": commonCrawlCollInfoBody,
+		"https://index.commoncrawl.org/CC-MAIN-2026-30-index?url=boards.greenhouse.io/*&output=json&showNumPages=true&pageSize=1": `{"pages":1}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-30-index?url=boards.greenhouse.io/*&output=json&page=0&pageSize=1":            `{"url": "https://boards.greenhouse.io/acme/jobs/1"}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-25-index?url=boards.greenhouse.io/*&output=json&showNumPages=true&pageSize=1": `{"pages":0}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-21-index?url=boards.greenhouse.io/*&output=json&showNumPages=true&pageSize=1": `{"pages":0}`,
+	}
+
+	got, err := (greenhouseProber{}).discover(context.Background(), f)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	want := []string{"acme"}
+	if !slices.Equal(got, want) {
+		t.Errorf("discover = %v, want %v", got, want)
+	}
+}
+
+func TestAshbyProberDiscoversFromCommonCrawl(t *testing.T) {
+	f := fakeGetter{
+		"https://index.commoncrawl.org/collinfo.json": commonCrawlCollInfoBody,
+		"https://index.commoncrawl.org/CC-MAIN-2026-30-index?url=jobs.ashbyhq.com/*&output=json&showNumPages=true&pageSize=1": `{"pages":1}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-30-index?url=jobs.ashbyhq.com/*&output=json&page=0&pageSize=1":            `{"url": "https://jobs.ashbyhq.com/acme-inc/jobid"}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-25-index?url=jobs.ashbyhq.com/*&output=json&showNumPages=true&pageSize=1": `{"pages":0}`,
+		"https://index.commoncrawl.org/CC-MAIN-2026-21-index?url=jobs.ashbyhq.com/*&output=json&showNumPages=true&pageSize=1": `{"pages":0}`,
+	}
+
+	got, err := (ashbyProber{}).discover(context.Background(), f)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	want := []string{"acme-inc"}
+	if !slices.Equal(got, want) {
+		t.Errorf("discover = %v, want %v", got, want)
+	}
+}

--- a/cmd/harvest-boards/discover_test.go
+++ b/cmd/harvest-boards/discover_test.go
@@ -28,7 +28,9 @@ func TestResolveCandidatesDiscoversWhenNoSeed(t *testing.T) {
 }
 
 func TestResolveCandidatesNonDiscovererNeedsSeed(t *testing.T) {
-	_, _, err := resolveCandidates(context.Background(), greenhouseProber{}, nil, "")
+	// leverProber is deliberately not a discoverer (Lever's own robots.txt disallows
+	// CCBot, so no Common Crawl discovery is possible for it — see commoncrawl.go).
+	_, _, err := resolveCandidates(context.Background(), leverProber{}, nil, "")
 	if err == nil {
 		t.Error("a non-discoverer prober with no seed file should error, not silently no-op")
 	}

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -121,6 +121,12 @@ func (greenhouseProber) discover(ctx context.Context, c httpClient) ([]string, e
 	return commonCrawlCandidates(ctx, c, greenhouseBoardsHost)
 }
 
+// dedupKey folds a Greenhouse board id to lower case, like Workday's and Ashby's. The boards
+// API is case-insensitive (boards-api.greenhouse.io/v1/boards/adyen and .../Adyen both
+// resolve to the same company, confirmed live) — without folding, Common Crawl discovery
+// surfacing a different case than an already-known board dedups as a distinct one.
+func (greenhouseProber) dedupKey(boardID string) string { return strings.ToLower(boardID) }
+
 // leverProber probes the Lever postings API. The JSON-mode endpoint returns a bare array
 // of live postings, so a non-empty array is a live board. The posting API exposes no company
 // name, but the board's storefront titles itself after the employer, so the name is read
@@ -163,8 +169,16 @@ func (leverProber) probe(ctx context.Context, c httpClient, slug string) (string
 // ashbyProber probes the Ashby public job-board API. The list endpoint returns the live
 // postings, so a non-empty list is a live board. The posting API exposes no company name, but
 // the storefront titles itself "<Company> Jobs", so the name is read there once the board is
-// known to be live. The board id stays the case-sensitive slug Ashby uses as its identity.
+// known to be live. The job-board API is case-insensitive (posting-api/job-board/abridge and
+// .../Abridge both resolve to the same company, confirmed live) — see dedupKey.
 type ashbyProber struct{}
+
+// dedupKey folds an Ashby board id to lower case, like Workday's. Common Crawl discovery
+// surfaces the same company under whatever case a crawled inbound link happened to use, and
+// without folding, "abridge" and "Abridge" dedup as two different boards even though the API
+// serves identical content for both — verified live, and by a stale duplicate this folding
+// removes from sources/ashby.yml (see the CDX-discovery change that added it).
+func (ashbyProber) dedupKey(boardID string) string { return strings.ToLower(boardID) }
 
 func ashbyBoardURL(slug string) string {
 	return fmt.Sprintf("https://api.ashbyhq.com/posting-api/job-board/%s", slug)
@@ -320,8 +334,8 @@ type seedMapper interface {
 }
 
 // dedupKeyer folds a board id into the key used for dedup against existing boards. A
-// provider whose board ids are case-insensitive (Workday) implements it to fold case; the
-// rest dedup case-sensitively (Ashby slugs differ by case), so they do not implement it.
+// provider whose board ids are case-insensitive (Workday, Ashby) implements it to fold case;
+// the rest dedup case-sensitively, so they do not implement it.
 type dedupKeyer interface {
 	dedupKey(boardID string) string
 }

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -107,6 +107,20 @@ func (greenhouseProber) probe(ctx context.Context, c httpClient, slug string) (s
 	return name, len(jr.Jobs), nil
 }
 
+// greenhouseBoardsHost is the web host Greenhouse boards are served under, the surface
+// Common Crawl's crawler actually visits (unlike greenhouseBoardsAPI, which the crawler
+// never touches — it's an API, not a page). Validation still goes through
+// greenhouseBoardsAPI in probe/postingIDs; a discovered candidate's redirect from this host
+// to Greenhouse's newer "job-boards.greenhouse.io" frontend (visible in raw Common Crawl
+// records) doesn't affect that.
+const greenhouseBoardsHost = "boards.greenhouse.io"
+
+// discover finds Greenhouse board candidates from the Common Crawl CDX index: every URL
+// Common Crawl has seen under greenhouseBoardsHost, sliced to its company slug.
+func (greenhouseProber) discover(ctx context.Context, c httpClient) ([]string, error) {
+	return commonCrawlCandidates(ctx, c, greenhouseBoardsHost)
+}
+
 // leverProber probes the Lever postings API. The JSON-mode endpoint returns a bare array
 // of live postings, so a non-empty array is a live board. The posting API exposes no company
 // name, but the board's storefront titles itself after the employer, so the name is read
@@ -187,6 +201,17 @@ func (ashbyProber) probe(ctx context.Context, c httpClient, slug string) (string
 		return "", 0, nil
 	}
 	return storefrontEmployer(ctx, c, fmt.Sprintf("https://jobs.ashbyhq.com/%s", slug), " Jobs"), len(resp.Jobs), nil
+}
+
+// ashbyBoardsHost is the web host Ashby boards are served under, the surface Common Crawl's
+// crawler actually visits (unlike the api.ashbyhq.com host probe/postingIDs validate
+// against).
+const ashbyBoardsHost = "jobs.ashbyhq.com"
+
+// discover finds Ashby board candidates from the Common Crawl CDX index: every URL Common
+// Crawl has seen under ashbyBoardsHost, sliced to its company slug.
+func (ashbyProber) discover(ctx context.Context, c httpClient) ([]string, error) {
+	return commonCrawlCandidates(ctx, c, ashbyBoardsHost)
 }
 
 // bamboohrProber probes the BambooHR per-subdomain careers list. A non-empty result is a

--- a/openspec/changes/commoncrawl-board-discovery/design.md
+++ b/openspec/changes/commoncrawl-board-discovery/design.md
@@ -1,0 +1,108 @@
+## Context
+
+`cmd/harvest-boards` already has an opt-in `discoverer` capability (`prober.go`): a provider's
+prober implements `discover(ctx, c) ([]string, error)` and, when the tool runs with no seed
+file, those candidates take the place of a seed list. `gupyProber` discovers by paging Gupy's
+own global jobs feed; `opencatsProber` discovers by querying a public URL-scan index
+(`urlscan.io`) for OpenCATS's page-title and routing signatures, because OpenCATS is
+self-hosted across arbitrary domains and has no tenant catalogue of its own to page.
+
+Common Crawl was evaluated once before, for that same OpenCATS design
+(`docs/superpowers/specs/2026-07-28-opencats-adapter-harvest-design.md`), and rejected: its CDX
+index is SURT-sorted (domain first), so a query can't search by page signature across arbitrary
+domains. Greenhouse and Ashby are the opposite shape — every tenant board lives under one known
+host (`boards.greenhouse.io`, `jobs.ashbyhq.com`), which is exactly the query CDX is built for
+("every URL Common Crawl has seen under this host"). The prior rejection doesn't apply here.
+
+A manual spike (curl against `index.commoncrawl.org`, 2026-08-06) confirmed this: a single
+recent snapshot returned 1789 unique Greenhouse company slugs (412 not already in
+`sources/greenhouse.yml`) and 407 unique Ashby slugs, both cleanly extractable as the first path
+segment. The same spike found `jobs.lever.co/robots.txt` disallows `CCBot` entirely, so no
+Lever board ever reaches the CDX index — Lever is out of scope for this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add Common Crawl CDX discovery for Greenhouse and Ashby, wired through the existing
+  `discoverer` interface so the rest of the pipeline (live-validate, dedup, append) needs no
+  changes.
+- Keep the snapshot list current automatically (no hardcoded snapshot ids to rot).
+- Degrade gracefully: one bad snapshot fetch shouldn't sink the whole discovery run.
+
+**Non-Goals:**
+- Lever discovery (ruled out by the spike — CCBot is blocked).
+- Any change to how a *seeded* run behaves — supplying a seed file still bypasses discovery
+  exactly as it does today.
+- Scheduling this as a cron job. `harvest-boards` is a manually-run host tool; this stays that
+  way.
+
+## Decisions
+
+**One shared CDX helper, not per-provider duplication.** Greenhouse and Ashby differ only in
+which host they query and how a raw slug maps to a board id — both use the URL's first path
+segment as-is (neither provider is a `seedMapper`, per the existing prober.go convention). A
+single `commonCrawlCandidates(ctx, c, hostPrefix string) ([]string, error)` in a new
+`cmd/harvest-boards/commoncrawl.go` does the snapshot lookup, paging, and slug extraction; each
+prober's `discover` method is a one-line call into it. Considered: writing `discover` separately
+per provider — rejected, it would duplicate the snapshot-fetch and pagination logic for zero
+behavioral gain.
+
+**Snapshot list from `collinfo.json`, latest 3, not hardcoded.** `index.commoncrawl.org/collinfo.json`
+lists every available snapshot with its own CDX API root; the helper takes the first 3 entries
+(the list is newest-first). Considered: hardcoding a snapshot id — rejected, Common Crawl cuts a
+new snapshot roughly monthly, so a hardcoded id goes stale within weeks and the tool would
+silently query a dead/archived index. Considered: querying *all* available snapshots — rejected,
+snapshots a few months apart overlap heavily in which companies they've seen, so the marginal
+new-candidate yield per additional snapshot drops fast while cost (CDX requests, page count)
+keeps climbing; 3 was the number the reference implementation (job-hunter) validated in
+production use, and the spike didn't have time budget to establish a better number empirically.
+
+**Slug extraction: first non-empty path segment, lowercased.** Matches how `resolve()` and the
+existing probers already treat a board id for these two providers (case folding only applies to
+Workday via `dedupKeyer`; Greenhouse/Ashby board ids are the literal path segment). No special
+handling for query strings (they're not part of the URL path) or for known non-board paths like
+Ashby's `/meeting/` or `/b/` — those are simply slugs that will fail live-validation like any
+other invalid candidate, since the probe pipeline already treats "0 jobs / unreachable" as
+"skip, don't append." No extra filtering logic pays for itself here.
+
+**Per-snapshot page cap, not a hard total cap.** Mirrors `gupyMaxOffset` — bound the number of
+CDX pages read per snapshot so a snapshot whose index never terminates (or a paging bug) can't
+loop forever. Unlike Gupy, the *number* of pages CDX will return for one host is small and
+knowable ahead of time (`showNumPages=true` returned `pages: 1` for both Greenhouse and Ashby in
+the spike), so the cap is a safety backstop, not an expected limit in normal operation.
+
+**Errors: one snapshot failing is not fatal, all snapshots failing is.** Mirrors
+`opencatsProber.discover`'s existing rule ("all N signature queries failed" is the only hard
+error). A single 504 from `index.commoncrawl.org` (observed during the spike — the endpoint is
+occasionally flaky under an unbounded query) logs and moves to the next snapshot; if every
+snapshot fails, `discover` returns an error so the run reports it plainly instead of silently
+producing zero candidates.
+
+## Risks / Trade-offs
+
+- **[Risk] `index.commoncrawl.org` is a free public service with no SLA and was observed to
+  504 under load during the spike.** → Mitigation: per-snapshot error tolerance (above), plus
+  the tool is run manually/on-demand, so a bad run costs nothing but a retry.
+- **[Risk] Low live-hit rate (~4% of new candidates in the spike sample had open jobs right
+  now).** → Not a defect to fix — it's inherent to discovering from a month-old crawl snapshot,
+  and the existing live-validation step already exists precisely to filter it. Still net
+  positive: ~412 new Greenhouse candidates from one snapshot yielded roughly a dozen-plus live
+  boards for the cost of API calls the pipeline already budgets for seeded runs.
+- **[Risk] Greenhouse has visibly migrated its web frontend from `boards.greenhouse.io` to
+  `job-boards.greenhouse.io` (301 redirects seen throughout the spike sample).** → No mitigation
+  needed: the harvest validates against `boards-api.greenhouse.io` (a separate, stable API host,
+  already what `greenhouseProber.probe` uses today), not the web frontend, so the redirect is
+  irrelevant to slug validity. Worth a one-line comment in the code so a future reader isn't
+  alarmed by the redirect status seen in raw CDX records.
+
+## Migration Plan
+
+No migration — this adds a capability to a manually-run host tool with no persisted state of
+its own. First real run is invoked by hand after merge; nothing changes automatically.
+
+## Open Questions
+
+None — the spike resolved the two open questions from the design brainstorm (does Common Crawl
+work for these domains at all, and does Lever work). Snapshot count (3) is a judgment call
+carried over from the reference implementation rather than independently re-derived; if a real
+run's yield looks thin, revisit that number rather than the overall approach.

--- a/openspec/changes/commoncrawl-board-discovery/design.md
+++ b/openspec/changes/commoncrawl-board-discovery/design.md
@@ -57,13 +57,25 @@ new-candidate yield per additional snapshot drops fast while cost (CDX requests,
 keeps climbing; 3 was the number the reference implementation (job-hunter) validated in
 production use, and the spike didn't have time budget to establish a better number empirically.
 
-**Slug extraction: first non-empty path segment, lowercased.** Matches how `resolve()` and the
-existing probers already treat a board id for these two providers (case folding only applies to
-Workday via `dedupKeyer`; Greenhouse/Ashby board ids are the literal path segment). No special
+**Slug extraction: first non-empty path segment, case preserved as crawled.** No special
 handling for query strings (they're not part of the URL path) or for known non-board paths like
 Ashby's `/meeting/` or `/b/` — those are simply slugs that will fail live-validation like any
 other invalid candidate, since the probe pipeline already treats "0 jobs / unreachable" as
 "skip, don't append." No extra filtering logic pays for itself here.
+
+**Correction (discovered during implementation, before merge): both APIs are
+case-insensitive, so both providers now implement `dedupKeyer`.** The original assumption
+here — sourced from an existing code comment claiming Ashby board ids "differ by case" — was
+wrong, and Greenhouse was never checked at all. A real run against live Common Crawl produced
+415 case-variant duplicates in `sources/ashby.yml` (`abridge`/`Abridge`, `crusoe`/`Crusoe`, ...)
+and 5 in `sources/greenhouse.yml`. Verified live: `boards-api.greenhouse.io/v1/boards/adyen`
+and `.../Adyen` return the same company; same for `api.ashbyhq.com/posting-api/job-board/`.
+Fix: `greenhouseProber.dedupKey`/`ashbyProber.dedupKey` fold to lower case, exactly like
+`workdayProber`'s — `newBoards` already dedupes through whatever key a `dedupKeyer` supplies,
+so this one addition fixes both cross-run (new vs. already-tracked) and within-run (two
+differently-cased crawls of the same company) duplication. The pre-existing code comments this
+change corrects (in `prober.go`, `boardfile.go`, and this file) were simply never verified
+against the live API — a reminder that an inherited assumption is not evidence.
 
 **Per-snapshot page cap, not a hard total cap.** Mirrors `gupyMaxOffset` — bound the number of
 CDX pages read per snapshot so a snapshot whose index never terminates (or a paging bug) can't

--- a/openspec/changes/commoncrawl-board-discovery/proposal.md
+++ b/openspec/changes/commoncrawl-board-discovery/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+`sources/greenhouse.yml` and `sources/ashby.yml` are built from curated company datasets and
+careers-page resolution (`cmd/harvest-ats`), which only find companies whose website is in one
+of those datasets. Common Crawl's CDX index lets us query, for free, every URL its crawler has
+ever seen under `boards.greenhouse.io` and `jobs.ashbyhq.com` — a source of company slugs that
+doesn't depend on a company being in a curated dataset at all. A feasibility spike (see
+`docs/superpowers/specs/` conventions — validated by hand before this change) confirmed the CDX
+query returns real, extractable board slugs for both domains, with a meaningful new-candidate
+yield (412 of 1789 Greenhouse slugs from a single snapshot were not already in
+`sources/greenhouse.yml`). A third target, Lever, was ruled out: `jobs.lever.co/robots.txt`
+disallows `CCBot` site-wide, so Common Crawl carries no board-path data for it at all.
+
+## What Changes
+
+- `cmd/harvest-boards` gains a shared Common Crawl CDX helper that, given a host prefix, fetches
+  the latest 3 snapshot ids from `collinfo.json`, pages each snapshot's CDX index for that host,
+  extracts the first path segment of each matched URL as a candidate board slug, and returns the
+  deduplicated set.
+- `greenhouseProber` and `ashbyProber` each gain a `discover` method (implementing the existing
+  `discoverer` interface, the same one `gupyProber` and `opencatsProber` already implement) that
+  calls the shared helper with their own board-URL host. Running `harvest-boards greenhouse` or
+  `harvest-boards ashby` with no seed file now discovers candidates from Common Crawl instead of
+  requiring one; a seed file, when supplied, still works exactly as before.
+- No changes to `leverProber` — Lever discovery was ruled out by the spike (CCBot is disallowed
+  by its own robots.txt).
+- Discovered candidates go through the existing live-validation, dedup, and append pipeline
+  unchanged — a candidate is appended to `sources/<provider>.yml` only when the provider's own
+  API reports at least one open job for it.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `board-harvest`: adds a new requirement describing Common Crawl CDX discovery for Greenhouse
+  and Ashby, alongside the existing Gupy and OpenCATS discovery requirements.
+
+## Impact
+
+- Code: `cmd/harvest-boards/` — one new file for the shared CDX helper, `discover` methods added
+  to `greenhouseProber` and `ashbyProber`, unit tests for slug extraction and CDX response
+  parsing.
+- No schema, API, or runtime-worker changes — `harvest-boards` is a manually-run host tool, not
+  a cron worker; this only changes what it does when invoked with no seed file for these two
+  providers.
+- External dependency: `index.commoncrawl.org` (public, no auth, no rate-limit key) becomes a
+  data source for this tool only.

--- a/openspec/changes/commoncrawl-board-discovery/specs/board-harvest/spec.md
+++ b/openspec/changes/commoncrawl-board-discovery/specs/board-harvest/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Greenhouse and Ashby boards are discovered from the Common Crawl CDX index
+
+The harvest tool SHALL support discovering Greenhouse and Ashby boards from the Common Crawl
+CDX index. Discovery SHALL read the current snapshot list from Common Crawl's collection index
+and query the 3 most recent snapshots for URLs under the provider's board host
+(`boards.greenhouse.io` for Greenhouse, `jobs.ashbyhq.com` for Ashby), paging each snapshot's
+result set. For each matched URL, the first non-empty path segment SHALL be extracted, lower
+cased, and collected as a candidate board id; the same candidate found under multiple snapshots
+or multiple URLs SHALL be collected once. A snapshot whose query fails SHALL be skipped with the
+run continuing on the remaining snapshots; discovery SHALL fail only when every queried snapshot
+fails.
+
+#### Scenario: Candidates are collected across the most recent snapshots
+
+- **WHEN** Common Crawl discovery runs for Greenhouse or Ashby
+- **THEN** it queries the 3 most recent snapshots listed by Common Crawl's collection index and
+  returns the deduplicated set of candidate board ids found across all of them
+
+#### Scenario: A candidate is extracted from the URL's first path segment
+
+- **WHEN** a matched CDX record's URL is `https://boards.greenhouse.io/acme/jobs/12345`
+- **THEN** the candidate board id collected is `acme`
+
+#### Scenario: A candidate seen more than once is collected only once
+
+- **WHEN** the same board id appears in more than one matched URL, or in more than one queried
+  snapshot
+- **THEN** it appears exactly once in the discovered candidate list
+
+#### Scenario: One failing snapshot does not stop discovery
+
+- **WHEN** one of the queried snapshots' CDX requests fails
+- **THEN** discovery logs the failure, continues querying the remaining snapshots, and returns
+  the candidates collected from the snapshots that succeeded
+
+#### Scenario: Every snapshot failing is a discovery error
+
+- **WHEN** every queried snapshot's CDX request fails
+- **THEN** discovery returns an error and the run reports it rather than silently producing an
+  empty candidate list
+
+#### Scenario: Discovered candidates are validated exactly like any other candidate
+
+- **WHEN** a candidate board id discovered from Common Crawl is probed
+- **THEN** it is live-validated, de-duplicated against `sources/<provider>.yml`, and appended (or
+  skipped) through the same pipeline a seeded or platform-discovered candidate would use

--- a/openspec/changes/commoncrawl-board-discovery/tasks.md
+++ b/openspec/changes/commoncrawl-board-discovery/tasks.md
@@ -30,7 +30,17 @@
 - [x] 3.4 Manual dry run: `go run ./cmd/harvest-boards greenhouse` and `... ashby` with no seed
       file against the live Common Crawl API, confirm candidates are discovered, live-validated,
       and would append new boards not already in `sources/greenhouse.yml` / `sources/ashby.yml`.
-      Result: greenhouse 2725 candidates / 814 new / 29 live boards appended; ashby 3929
-      candidates / 1232 new / 602 live boards appended (0 probe failures/mismatches on both).
-      A handful of individual CDX pages 504'd or timed out mid-run; per-page error tolerance
-      logged and skipped them without aborting either run, as designed.
+      First run (before 3.5): greenhouse 29 live boards appended, ashby 602 — but 5 and 398 of
+      those respectively turned out to be case-variant duplicates of already-tracked boards
+      (see 3.5). A handful of individual CDX pages 504'd or timed out mid-run; per-page error
+      tolerance logged and skipped them without aborting either run, as designed.
+- [x] 3.5 Bug found while reviewing the run for merge conflicts: both APIs are
+      case-insensitive (verified live), so the case-preserving discovery was producing
+      same-company duplicates under different casing — 415 collision groups in
+      `sources/ashby.yml`, 5 in `sources/greenhouse.yml`, none pre-existing. Fixed by adding
+      `dedupKey` (case-fold) to `greenhouseProber`/`ashbyProber`, mirroring `workdayProber`'s;
+      `newBoards` already dedupes through it. Reverted the first run's `sources/*.yml` changes
+      and re-ran clean: greenhouse 24 live boards appended (29 minus the 5 duplicates), ashby
+      178 (602 minus 424 duplicates — most of the drop was against boards already tracked
+      under different case, not within this run). Zero case-collisions remain in either file
+      after the re-run.

--- a/openspec/changes/commoncrawl-board-discovery/tasks.md
+++ b/openspec/changes/commoncrawl-board-discovery/tasks.md
@@ -1,0 +1,32 @@
+## 1. Shared Common Crawl CDX helper
+
+- [ ] 1.1 Add `cmd/harvest-boards/commoncrawl.go`: fetch `index.commoncrawl.org/collinfo.json`,
+      take the 3 most recent snapshots.
+- [ ] 1.2 Implement `commonCrawlCandidates(ctx, c httpClient, hostPrefix string) ([]string, error)`:
+      for each snapshot, page `<cdx-api>?url=<hostPrefix>/*&output=json&page=N` (bounded page
+      count, mirroring `gupyMaxOffset`'s safety-cap pattern), parse JSON-lines records, extract
+      each URL's first non-empty path segment lowercased, collect into a deduplicated set.
+- [ ] 1.3 One failing snapshot logs and is skipped; return an error only if every snapshot fails.
+- [ ] 1.4 Unit tests: slug extraction (bare path, path with query string/UTM params, trailing
+      slash, uppercase, no path) and CDX JSON-lines response parsing, using `httptest` fixtures
+      per the existing `*_test.go` pattern in this package.
+
+## 2. Wire discovery into the Greenhouse and Ashby probers
+
+- [ ] 2.1 Add `func (greenhouseProber) discover(ctx context.Context, c httpClient) ([]string, error)`
+      calling `commonCrawlCandidates` with `boards.greenhouse.io`; note in a comment that
+      validation happens against the separate stable `boards-api.greenhouse.io`, so the
+      frontend's redirect to `job-boards.greenhouse.io` (visible in raw CDX records) doesn't
+      affect candidate validity.
+- [ ] 2.2 Add `func (ashbyProber) discover(ctx context.Context, c httpClient) ([]string, error)`
+      calling `commonCrawlCandidates` with `jobs.ashbyhq.com`.
+- [ ] 2.3 Confirm no change is needed to `leverProber` (out of scope — Lever disallows CCBot).
+
+## 3. Verify end-to-end
+
+- [ ] 3.1 `go build ./...` and `go vet ./...`.
+- [ ] 3.2 `go vet -tags=integration ./...` (repo-wide pre-push guard).
+- [ ] 3.3 `go test ./cmd/harvest-boards/...`.
+- [ ] 3.4 Manual dry run: `go run ./cmd/harvest-boards greenhouse` and `... ashby` with no seed
+      file against the live Common Crawl API, confirm candidates are discovered, live-validated,
+      and would append new boards not already in `sources/greenhouse.yml` / `sources/ashby.yml`.

--- a/openspec/changes/commoncrawl-board-discovery/tasks.md
+++ b/openspec/changes/commoncrawl-board-discovery/tasks.md
@@ -1,32 +1,36 @@
 ## 1. Shared Common Crawl CDX helper
 
-- [ ] 1.1 Add `cmd/harvest-boards/commoncrawl.go`: fetch `index.commoncrawl.org/collinfo.json`,
+- [x] 1.1 Add `cmd/harvest-boards/commoncrawl.go`: fetch `index.commoncrawl.org/collinfo.json`,
       take the 3 most recent snapshots.
-- [ ] 1.2 Implement `commonCrawlCandidates(ctx, c httpClient, hostPrefix string) ([]string, error)`:
+- [x] 1.2 Implement `commonCrawlCandidates(ctx, c httpClient, hostPrefix string) ([]string, error)`:
       for each snapshot, page `<cdx-api>?url=<hostPrefix>/*&output=json&page=N` (bounded page
       count, mirroring `gupyMaxOffset`'s safety-cap pattern), parse JSON-lines records, extract
       each URL's first non-empty path segment lowercased, collect into a deduplicated set.
-- [ ] 1.3 One failing snapshot logs and is skipped; return an error only if every snapshot fails.
-- [ ] 1.4 Unit tests: slug extraction (bare path, path with query string/UTM params, trailing
+- [x] 1.3 One failing snapshot logs and is skipped; return an error only if every snapshot fails.
+- [x] 1.4 Unit tests: slug extraction (bare path, path with query string/UTM params, trailing
       slash, uppercase, no path) and CDX JSON-lines response parsing, using `httptest` fixtures
       per the existing `*_test.go` pattern in this package.
 
 ## 2. Wire discovery into the Greenhouse and Ashby probers
 
-- [ ] 2.1 Add `func (greenhouseProber) discover(ctx context.Context, c httpClient) ([]string, error)`
+- [x] 2.1 Add `func (greenhouseProber) discover(ctx context.Context, c httpClient) ([]string, error)`
       calling `commonCrawlCandidates` with `boards.greenhouse.io`; note in a comment that
       validation happens against the separate stable `boards-api.greenhouse.io`, so the
       frontend's redirect to `job-boards.greenhouse.io` (visible in raw CDX records) doesn't
       affect candidate validity.
-- [ ] 2.2 Add `func (ashbyProber) discover(ctx context.Context, c httpClient) ([]string, error)`
+- [x] 2.2 Add `func (ashbyProber) discover(ctx context.Context, c httpClient) ([]string, error)`
       calling `commonCrawlCandidates` with `jobs.ashbyhq.com`.
-- [ ] 2.3 Confirm no change is needed to `leverProber` (out of scope — Lever disallows CCBot).
+- [x] 2.3 Confirm no change is needed to `leverProber` (out of scope — Lever disallows CCBot).
 
 ## 3. Verify end-to-end
 
-- [ ] 3.1 `go build ./...` and `go vet ./...`.
-- [ ] 3.2 `go vet -tags=integration ./...` (repo-wide pre-push guard).
-- [ ] 3.3 `go test ./cmd/harvest-boards/...`.
-- [ ] 3.4 Manual dry run: `go run ./cmd/harvest-boards greenhouse` and `... ashby` with no seed
+- [x] 3.1 `go build ./...` and `go vet ./...`.
+- [x] 3.2 `go vet -tags=integration ./...` (repo-wide pre-push guard).
+- [x] 3.3 `go test ./cmd/harvest-boards/...`.
+- [x] 3.4 Manual dry run: `go run ./cmd/harvest-boards greenhouse` and `... ashby` with no seed
       file against the live Common Crawl API, confirm candidates are discovered, live-validated,
       and would append new boards not already in `sources/greenhouse.yml` / `sources/ashby.yml`.
+      Result: greenhouse 2725 candidates / 814 new / 29 live boards appended; ashby 3929
+      candidates / 1232 new / 602 live boards appended (0 probe failures/mismatches on both).
+      A handful of individual CDX pages 504'd or timed out mid-run; per-page error tolerance
+      logged and skipped them without aborting either run, as designed.

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7756,3 +7756,1207 @@
   board: surge-ai
 - company: Bedrock Talent
   board: bedrock-talent
+- company: A1 Garage Door Service
+  board: A1 Garage Door Service
+- company: AION Biosciences
+  board: AION Biosciences
+- company: APEXX Global
+  board: APEXX
+- company: ARQ
+  board: ARQ
+- company: ATG
+  board: ATG
+- company: Aaron School
+  board: Aaron-School
+- company: Abridge
+  board: Abridge
+- company: Accord
+  board: Accord
+- company: Acorns
+  board: Acorns
+- company: Adaptive
+  board: Adaptive
+- company: AfterQuery
+  board: AfterQuery
+- company: Agent
+  board: Agent
+- company: AgentMail
+  board: AgentMail
+- company: Agentio
+  board: Agentio
+- company: Aleph Alpha
+  board: AlephAlpha
+- company: Ambral
+  board: Ambral
+- company: American Terawatt
+  board: American Terawatt
+- company: Ampersand
+  board: Ampersand
+- company: Anagram
+  board: Anagram
+- company: Anima
+  board: Anima
+- company: Ankorstore
+  board: Ankorstore
+- company: Anon
+  board: Anon
+- company: Antares
+  board: Antares
+- company: Antimetal
+  board: Antimetal
+- company: Antithesis
+  board: Antithesis
+- company: Applied Intuition
+  board: Applied
+- company: Applied Compute
+  board: Applied Compute
+- company: Applied Behavioral Services
+  board: Applied-Behavioral-Services
+- company: Aquant
+  board: Aquant
+- company: Arbor
+  board: Arbor
+- company: Arch
+  board: Arch
+- company: Arlo
+  board: Arlo
+- company: Armory
+  board: Armory
+- company: Ashby
+  board: Ashby
+- company: Aspora
+  board: Aspora
+- company: Astro Mechanica
+  board: Astro-Mechanica
+- company: Atolio
+  board: Atolio
+- company: Atropos Health
+  board: AtroposHealth
+- company: Away
+  board: Away
+- company: Axel
+  board: Axel
+- company: BIOptimizers
+  board: BIOptimizers
+- company: Base
+  board: Base
+- company: Baton
+  board: Baton
+- company: Bevel
+  board: Bevel
+- company: Bhblasted
+  board: Bhblasted
+- company: Bifrost AI
+  board: Bifrost
+- company: Bioscope AI
+  board: Bioscope AI
+- company: Blackpoint Cyber
+  board: Blackpoint Cyber
+- company: Blacksmith
+  board: Blacksmith
+- company: Blacksmith Agency
+  board: Blacksmith Agency
+- company: Blockhouse
+  board: Blockhouse
+- company: Blossom Health
+  board: Blossom-Health
+- company: Boom
+  board: Boom
+- company: Bounce
+  board: Bounce
+- company: Braiins
+  board: Braiins
+- company: Braintrust
+  board: Braintrust
+- company: Branch Financial, LLC
+  board: BranchInsurance
+- company: BranchLab
+  board: BranchLab
+- company: Brodie Rec League
+  board: Brodie Rec League
+- company: Browserbase
+  board: Browserbase
+- company: C1
+  board: C1
+- company: CARIAN
+  board: CARIAN
+- company: CUBE
+  board: CUBE
+- company: Cambly
+  board: Cambly
+- company: Campus
+  board: Campus
+- company: Capable Labs
+  board: Capable
+- company: Cape
+  board: Cape
+- company: Carwow
+  board: Carwow
+- company: Catio
+  board: Catio
+- company: ChartHop
+  board: ChartHop
+- company: Chief
+  board: Chief
+- company: Chromatic
+  board: Chromatic
+- company: Cirrus Systems, Inc.
+  board: Cirrus Systems
+- company: Citizen
+  board: Citizen
+- company: Citizen Health
+  board: Citizen Health
+- company: Civic Roundtable
+  board: Civic Roundtable
+- company: ClassDojo
+  board: ClassDojo
+- company: Clera
+  board: Clera
+- company: Clipbook
+  board: Clipbook
+- company: Close
+  board: Close
+- company: CoachHub
+  board: CoachHub Careers
+- company: Coastal Community Bank
+  board: Coastal
+- company: CodaMetrix
+  board: CodaMetrix
+- company: Coder
+  board: Coder
+- company: Coframe
+  board: Coframe
+- company: Coinflow
+  board: Coinflow
+- company: Coinhako
+  board: Coinhako
+- company: Commure
+  board: Commure
+- company: Compa
+  board: Compa
+- company: Twenty Labs
+  board: Compound Jobs
+- company: Conception
+  board: Conception
+- company: Coperniq Inc.
+  board: Coperniq
+- company: Coverbase
+  board: Coverbase
+- company: Coworker.ai
+  board: Coworker
+- company: Crusoe
+  board: Crusoe
+- company: Cyberhaven
+  board: Cyberhaven
+- company: Cylinder Health
+  board: CylinderHealth
+- company: Dandy
+  board: Dandy
+- company: DeepL
+  board: DeepL
+- company: Deepgram
+  board: Deepgram
+- company: Deepnote
+  board: Deepnote
+- company: Dehazelabs
+  board: DehazeLabs
+- company: Delphina
+  board: Delphina
+- company: Diagrid
+  board: Diagrid
+- company: Distyl AI
+  board: Distyl
+- company: Divine
+  board: DivineResearch
+- company: Dominion Dynamics
+  board: Dominion Dynamics
+- company: Doppel
+  board: Doppel
+- company: DoubleZero
+  board: DoubleZero
+- company: DubClub
+  board: DubClub
+- company: Edison Scientific
+  board: Edison Scientific
+- company: Egra
+  board: Egra
+- company: Ekho
+  board: Ekho
+- company: Electric
+  board: Electric
+- company: ElevenLabs
+  board: ElevenLabs
+- company: EliseAI
+  board: EliseAI
+- company: Empo Health
+  board: Empo Health
+- company: Endgame
+  board: Endgame
+- company: Eon Systems
+  board: Eon Systems
+- company: Epistemix
+  board: Epistemix
+- company: EverOps
+  board: EverOps
+- company: FLORA
+  board: FLORA
+- company: FURTHER
+  board: FURTHER
+- company: Felix
+  board: Felix
+- company: Meraki-Labs
+  board: Fermi AI
+- company: Fiducial
+  board: Fiducial
+- company: FirstPrinciples
+  board: FirstPrinciples
+- company: FleetWorks
+  board: FleetWorks
+- company: Fleetcraft
+  board: Fleetcraft
+- company: FloatMe
+  board: FloatMe
+- company: Flock
+  board: Flock Safety
+- company: FlutterFlow
+  board: FlutterFlow
+- company: fonio
+  board: Fonio
+- company: Fort Health
+  board: Fort Health
+- company: Forward Financing
+  board: Forward Financing
+- company: Found
+  board: Found
+- company: Fourier
+  board: Fourier
+- company: Fulcrum
+  board: Fulcrum
+- company: Fundamental
+  board: Fundamental
+- company: fundamentalXR
+  board: FundamentalXR
+- company: Geoforce
+  board: Geoforce
+- company: Giga
+  board: GigaML
+- company: GitBook
+  board: GitBook
+- company: GoHenry
+  board: GoHenry
+- company: Venti Technologies
+  board: GoVenti
+- company: GovWell
+  board: GovWell
+- company: Gradient
+  board: Gradient
+- company: Graphite
+  board: Graphitehq
+- company: Gravity
+  board: GravityClimate
+- company: Green Tree School & Services
+  board: Green-Tree-School-and-Services
+- company: Grindr
+  board: Grindr LLC
+- company: GrowthX AI
+  board: GrowthX AI
+- company: Gruntwork
+  board: Gruntwork
+- company: HUMAN
+  board: HUMAN
+- company: Haast
+  board: Haast
+- company: HackerOne
+  board: HackerOne
+- company: Hang
+  board: Hang
+- company: Harmonic
+  board: Harmonic
+- company: Hartbeat
+  board: Hartbeat
+- company: Hatch
+  board: Hatch
+- company: Headstart
+  board: Headstart
+- company: Healthtech-1
+  board: Healthtech-1
+- company: HighlightTA
+  board: HighlightTA
+- company: Hippocratic AI
+  board: Hippocratic AI
+- company: hive.co
+  board: Hive.co
+- company: Homebound
+  board: Homebound
+- company: Honey Homes
+  board: Honey Homes
+- company: Hyperbound
+  board: Hyperbound
+- company: Hyperliquid Labs
+  board: Hyperliquid Labs
+- company: Hyperscience
+  board: Hyperscience
+- company: Ideal Dental
+  board: Ideal Dental
+- company: Improbable
+  board: Improbable
+- company: Inferact
+  board: Inferact
+- company: Infinite Lambda
+  board: Infinite Lambda
+- company: Inscribe
+  board: InscribeAI
+- company: Inspectiv
+  board: Inspectiv
+- company: Intellistack
+  board: Intellistack
+- company: Interra Health
+  board: Interrahealth
+- company: Irregular
+  board: Irregular
+- company: Jasper
+  board: Jasper AI
+- company: Jellyfish
+  board: Jellyfish
+- company: Juicebox
+  board: Juicebox
+- company: Jump
+  board: Jump
+- company: Junction
+  board: Junction
+- company: KAYAK
+  board: KAYAK
+- company: Keyrock
+  board: Keyrock
+- company: Kingdom
+  board: Kingdom
+- company: Known
+  board: Known
+- company: Kojo
+  board: Kojo
+- company: Kombo
+  board: Kombo
+- company: Kota
+  board: Kota
+- company: Koyfin
+  board: Koyfin
+- company: Kustomer
+  board: Kustomer
+- company: Lambda
+  board: Lambda
+- company: LatchBio
+  board: LatchBio
+- company: Laurel
+  board: Laurel
+- company: Lean Layer
+  board: LeanLayer
+- company: Lean Technologies
+  board: LeanTech
+- company: Leapsome
+  board: Leapsome
+- company: LENS Inc.
+  board: Lens
+- company: Levelpath
+  board: Levelpath
+- company: Lido
+  board: Lido.fi
+- company: Lightdash
+  board: Lightdash
+- company: Lightfield
+  board: Lightfield
+- company: Linear
+  board: Linear
+- company: Linkup
+  board: Linkup
+- company: Local Infusion
+  board: Local Infusion
+- company: Lorikeet
+  board: Lorikeet
+- company: Luminovo
+  board: Luminovo
+- company: M-KOPA
+  board: M-KOPA
+- company: Magical
+  board: Magical
+- company: Mangomint
+  board: Mangomint
+- company: Maxima
+  board: Maxima
+- company: Meadow
+  board: Meadow
+- company: MediCircle
+  board: MediCircle
+- company: Merge Labs
+  board: Merge Labs
+- company: Mimica
+  board: Mimica
+- company: Mintlify
+  board: Mintlify
+- company: MioDottore
+  board: MioDottore
+- company: Molg
+  board: Molg
+- company: Mollie
+  board: Mollie
+- company: Mondoo
+  board: Mondoo
+- company: Moonlake
+  board: Moonlake
+- company: Morpho
+  board: Morpho
+- company: MotherDuck
+  board: MotherDuck
+- company: Moxie
+  board: Moxie
+- company: Mutiny
+  board: Mutiny
+- company: NationGraph
+  board: NationGraph
+- company: Natter
+  board: Natter
+- company: Nautilus Biotechnology
+  board: Nautilus Biotechnology
+- company: Neon
+  board: Neon
+- company: Neon
+  board: Neon Money Talks
+- company: New Story
+  board: New Story
+- company: New Story Schools (PA)
+  board: New-Story-Schools-PA
+- company: NextPatient
+  board: NextPatient
+- company: Nivoda
+  board: Nivoda
+- company: Noyo
+  board: Noyo
+- company: Numeral
+  board: Numeral
+- company: OBRIO
+  board: OBRIO
+- company: OLIX
+  board: OLIX
+- company: OXIO Corporation
+  board: OXIO
+- company: OnHires
+  board: OnHires
+- company: Onton
+  board: Onton
+- company: Opal Security
+  board: Opal
+- company: Opal
+  board: Opal-OS
+- company: OpenAI
+  board: OpenAI
+- company: OpenHands
+  board: OpenHands
+- company: OpenSea
+  board: OpenSea
+- company: Oso
+  board: Oso
+- company: Outpost Technologies
+  board: Outpostnow
+- company: Outset
+  board: Outset
+- company: Overjet
+  board: Overjet
+- company: Owner.com
+  board: Owner
+- company: P-1 AI
+  board: P-1 AI
+- company: PAR Technology
+  board: PAR Technology
+- company: Panoptyc
+  board: Panoptyc
+- company: Paradigm
+  board: Paradigm
+- company: Paragon
+  board: Paragon
+- company: Parkade
+  board: Parkade
+- company: Pave Bank
+  board: PaveBank
+- company: Payscale
+  board: Payscale
+- company: Pear VC
+  board: Pear-VC
+- company: Peec AI
+  board: Peec
+- company: Pemberton
+  board: Pemberton
+- company: Perk
+  board: Perk
+- company: PermitFlow
+  board: PermitFlow
+- company: Perplexity
+  board: Perplexity
+- company: PHIL
+  board: Phil
+- company: Phinity Labs
+  board: Phinitylabs
+- company: Pivot
+  board: Pivot
+- company: PlantingSpace
+  board: PlantingSpace
+- company: Plaud
+  board: Plaud
+- company: Playbook
+  board: Playbook
+- company: Playground
+  board: Playground
+- company: Playground Global
+  board: Playground Global
+- company: Pocket Worlds
+  board: Pocket Worlds
+- company: Polarsteps
+  board: Polarsteps
+- company: Polymarket
+  board: Polymarket
+- company: Post.
+  board: Post
+- company: Preference Model
+  board: Preference-Model
+- company: Prelude
+  board: Prelude
+- company: Prime Intellect
+  board: PrimeIntellect
+- company: Procurify
+  board: Procurify
+- company: Profound
+  board: Profound
+- company: Promise
+  board: Promise
+- company: Prompt
+  board: Prompt
+- company: Protex AI
+  board: Protex AI
+- company: Proxima
+  board: ProximaAI
+- company: Pulsora, Inc.
+  board: Pulsora Inc
+- company: Pyyne
+  board: Pyyne
+- company: Quicknode
+  board: QuickNode
+- company: Ramp
+  board: Ramp
+- company: Ravio
+  board: Ravio
+- company: Rebecca School
+  board: Rebecca-School
+- company: Red 6
+  board: Red6
+- company: Redesign Health
+  board: Redesign Health
+- company: Redis
+  board: Redis
+- company: Reflex Robotics
+  board: ReflexRobotics
+- company: Reka
+  board: Reka
+- company: Remedy Scientific
+  board: Remedy Scientific
+- company: Replicant
+  board: Replicant
+- company: Reset
+  board: Reset
+- company: Resilience Care
+  board: Resilience Care
+- company: Resolve AI
+  board: Resolve AI
+- company: Restream
+  board: Restream
+- company: RevenueCat
+  board: RevenueCat
+- company: Rhythms
+  board: Rhythms
+- company: Ricursive Intelligence
+  board: Ricursive Intelligence
+- company: ALSO
+  board: Ridealso
+- company: River Rock Academy
+  board: River-Rock-Academy
+- company: Roadrunner
+  board: Roadrunner
+- company: Rogo
+  board: Rogo
+- company: Roots AI
+  board: Roots-Automation
+- company: Rose Rocket
+  board: Rose Rocket
+- company: Rothy's
+  board: Rothys
+- company: Rox Data Corp
+  board: Rox-Data-Corp
+- company: Rundoo
+  board: Rundoo
+- company: cfo.ai
+  board: Runway
+- company: SKELAR
+  board: SKELAR
+- company: Sage Alliance Schools
+  board: Sage-Alliance-Schools
+- company: SalesPatriot
+  board: SalesPatriot
+- company: Sandstone
+  board: Sandstone
+- company: Sanity
+  board: Sanity
+- company: Scale Army Careers
+  board: Scale Army Careers
+- company: Sciforium
+  board: Sciforium
+- company: SearchApi
+  board: SearchApi
+- company: SearchStax
+  board: Searchstax
+- company: Second Front Systems
+  board: Second-Front-Systems
+- company: Sentradel
+  board: Sentradel
+- company: Serval
+  board: Serval
+- company: Served With Honor
+  board: ServedWithHonor
+- company: Shasqi
+  board: Shasqi
+- company: ShiftKey
+  board: Shiftkey
+- company: Short Story
+  board: ShortStory
+- company: Sierra
+  board: Sierra
+- company: SigNoz
+  board: SigNoz
+- company: SignalFire
+  board: SignalFire
+- company: Silver.dev
+  board: Silver
+- company: Siro
+  board: Siro
+- company: SiteMinder
+  board: SiteMinder
+- company: Sitemate
+  board: Sitemate
+- company: Skydropx - Frenet
+  board: Skydropx
+- company: Slingshot AI
+  board: SlingshotAI
+- company: Snappy
+  board: Snappy
+- company: Snowflake
+  board: Snowflake
+- company: Solace
+  board: Solace
+- company: Solana Foundation
+  board: Solana Foundation
+- company: Solvd
+  board: Solvd
+- company: Sona
+  board: Sona
+- company: Speak
+  board: Speak
+- company: Speakeasy
+  board: Speakeasy
+- company: Speckle
+  board: Speckle
+- company: Sphinx
+  board: Sphinx
+- company: SpotOn
+  board: Spoton
+- company: Stand
+  board: Stand
+- company: Stand Insurance
+  board: StandInsurance
+- company: Standard Bots
+  board: StandardBots
+- company: Staycation
+  board: Staycation
+- company: Steadily
+  board: Steadily
+- company: Stedi
+  board: Stedi
+- company: Stepful
+  board: Stepful
+- company: Stony Creek Homes
+  board: Stony Creek Homes
+- company: Stora
+  board: Stora
+- company: Straia
+  board: Straia
+- company: Strava
+  board: Strava
+- company: Sui Foundation
+  board: Sui Foundation
+- company: Suite Studios
+  board: Suite-Studios
+- company: Sunday
+  board: Sunday-GmbH
+- company: SunnyData
+  board: SunnyData
+- company: Suno
+  board: Suno
+- company: Swoop Technologies
+  board: Swoop
+- company: Symmetry AI
+  board: Symmetry
+- company: Tabs
+  board: Tabs
+- company: Taptap Send
+  board: TaptapSend
+- company: Taxo
+  board: Taxo
+- company: Tembo Health
+  board: Tembo-Health
+- company: Tembo Health
+  board: Tembo-health
+- company: Tempo
+  board: Tempo
+- company: Terranova
+  board: Terranova
+- company: The Agency Fund
+  board: The Agency Fund
+- company: The Browser Company
+  board: The Browser Company
+- company: The Job Sauce
+  board: The Job Sauce
+- company: The Zebra
+  board: The Zebra
+- company: The Flex
+  board: The-Flex
+- company: The Learning Spectrum
+  board: The-Learning-Spectrum
+- company: The Pinnacle School
+  board: The-Pinnacle-School
+- company: Theori
+  board: Theori
+- company: Thrive Alliance Group
+  board: Thrive-Alliance-Group
+- company: Tiger Data
+  board: TigerData
+- company: Tilt
+  board: Tilt
+- company: Toku
+  board: Toku
+- company: Tonic AI
+  board: TonicAI
+- company: Tools for Humanity
+  board: Tools for Humanity
+- company: Transfr
+  board: Transfr
+- company: Tremendous
+  board: Tremendous
+- company: Trener
+  board: Trener-Robotics
+- company: Trexo Robotics
+  board: Trexo Robotics
+- company: Trunk Tools, Inc.
+  board: Trunk Tools
+- company: TwoStep Therapeutics
+  board: TwoStepTx
+- company: US Health Partners
+  board: US Health Partners
+- company: Uberall
+  board: Uberall
+- company: Union.ai
+  board: Union
+- company: Unlearn
+  board: Unlearn
+- company: UpCodes
+  board: UpCodes
+- company: VLogic
+  board: VLogic
+- company: VREY
+  board: VREY
+- company: Valon Tech
+  board: Valon
+- company: Verne Robotics
+  board: Verne Robotics
+- company: Vetcove
+  board: Vetcove
+- company: Vic.ai
+  board: Vic.ai
+- company: Vidmob
+  board: VidMob
+- company: Vidmob
+  board: Vidmob
+- company: Virtuous
+  board: Virtuous
+- company: Visio Digital Partner
+  board: VisioDigitalPartner
+- company: Viz.ai
+  board: Viz.ai
+- company: Vogel
+  board: Vogel
+- company: Vori
+  board: Vori
+- company: Voxel
+  board: Voxel
+- company: Voya Energy
+  board: Voya Energy
+- company: Vultr
+  board: Vultr
+- company: Vytalize Health
+  board: Vytalize Health
+- company: WA.Technology
+  board: WA.Technology
+- company: WRITER
+  board: WRITER
+- company: Watershed
+  board: Watershed
+- company: WeTravel
+  board: WeTravel
+- company: Weave
+  board: Weave
+- company: Weekend
+  board: Weekend
+- company: Winona
+  board: Winona
+- company: Worktrace AI
+  board: Worktrace AI
+- company: WunderGraph, Inc.
+  board: WunderGraph
+- company: Zania
+  board: Zania
+- company: Zeromark
+  board: Zeromark
+- company: Zip
+  board: Zip
+- company: Zip Security
+  board: Zip Security
+- company: Abstraction
+  board: abstraction.games
+- company: Abusix
+  board: abusix
+- company: Aceve
+  board: aceve
+- company: Aditude
+  board: aditude
+- company: AeroVect
+  board: aerovect
+- company: Agentis Capital Advisors
+  board: agentis-capital-advisors
+- company: Airspeed
+  board: airspeed
+- company: aka (fka mem protocol)
+  board: aka
+- company: Alloy Enterprises
+  board: alloyenterprises
+- company: ChipAgents
+  board: alpha-design-ai-inc
+- company: Anuvaya Labs
+  board: anuvaya
+- company: applike group
+  board: applike-group
+- company: Arca
+  board: arca
+- company: Argon AI
+  board: argon-ai
+- company: ArtosAI
+  board: artosai
+- company: AthenaHQ
+  board: athena-hq
+- company: Atira
+  board: atira
+- company: Atlas Privacy
+  board: atlas-privacy
+- company: Aven
+  board: aven
+- company: Bastion
+  board: bastion
+- company: Parallel
+  board: beparallel
+- company: BetterCloud, Inc.
+  board: bettercloud
+- company: Blackpoint Cyber
+  board: blackpoint cyber
+- company: Blank Instance
+  board: blankexampleinstance
+- company: Blockworks
+  board: blockworks
+- company: BRM
+  board: brm.ai
+- company: Capital V Strategies
+  board: capital-v-strategies
+- company: CareSwift
+  board: careswift
+- company: Careway Health
+  board: careway
+- company: Carolina Complete Health Network
+  board: cchn
+- company: ClickHouse
+  board: clickhouse
+- company: Climate Finance Solutions
+  board: climate-finance-solutions
+- company: CloudZero
+  board: cloudzero
+- company: Cold Start Ventures
+  board: coldstartventures
+- company: Conduit
+  board: conduit
+- company: cyber•Fund
+  board: cyber.fund
+- company: d-Matrix
+  board: d-matrix
+- company: DataSnipper
+  board: datasnipper
+- company: deepset
+  board: deepsetai
+- company: Del Playa Group
+  board: delplayagroup
+- company: Discern Inc.
+  board: discern
+- company: Displai
+  board: displai
+- company: Drogue
+  board: drogue
+- company: The Electric Plant
+  board: electricplant
+- company: Eleos AI Research
+  board: eleos
+- company: ERP•AI
+  board: erp.ai
+- company: Etched
+  board: etched
+- company: Ethereum Foundation
+  board: ethereum-foundation
+- company: Everstar
+  board: everstar
+- company: Fabrion
+  board: fabrion
+- company: Ferry
+  board: ferryhealth
+- company: Flock
+  board: flock safety
+- company: fomo Labs
+  board: fomo-labs
+- company: Forward Financing
+  board: forward financing
+- company: G2
+  board: g2
+- company: Gamut
+  board: gamut
+- company: General Context
+  board: general-context
+- company: Getting Attention
+  board: getting-attention
+- company: GPTZero
+  board: gptzero
+- company: Guide Labs
+  board: guidelabs.ai
+- company: Heirloom Carbon
+  board: heirloomcarbon
+- company: Pinnacle
+  board: heypinnacle
+- company: Hippocratic AI
+  board: hippocratic ai
+- company: HIVED
+  board: hived
+- company: iVerify
+  board: iVerify
+- company: interface.ai
+  board: interface-ai
+- company: Intology
+  board: intology
+- company: Jasper
+  board: jasper ai
+- company: Jerry.ai
+  board: jerry.ai
+- company: Joyteractive
+  board: joyteractive
+- company: justDice
+  board: justDice
+- company: justtrack
+  board: justtrack
+- company: k-ID
+  board: k-ID
+- company: Kalibri Labs
+  board: kalibri-labs
+- company: Kelluu
+  board: kelluu
+- company: Kled AI
+  board: kled-ai
+- company: Kognitos
+  board: kognitos
+- company: Kranz Consulting
+  board: kranz-consulting
+- company: Krew
+  board: krew
+- company: Latitude
+  board: latitude-global
+- company: Leveraged Media
+  board: leveragedmedia
+- company: Lighthouse
+  board: lighthousehq
+- company: Live it Up
+  board: liveitup
+- company: livingHR
+  board: livingHR
+- company: Local Infusion
+  board: local infusion
+- company: Lua Global
+  board: lua
+- company: Lynk
+  board: lynk
+- company: Mandrel
+  board: mandrel
+- company: Mast
+  board: mast
+- company: Mem
+  board: mem.ai
+- company: Meridio
+  board: meridio
+- company: Minerva
+  board: minerva
+- company: Mirror Physics
+  board: mirror-physics
+- company: Misfits & Machines
+  board: misfitsandmachines
+- company: Monarch
+  board: monarchcrops
+- company: Movement
+  board: movement
+- company: MUBI
+  board: mubi
+- company: MUI
+  board: mui
+- company: Multitude Insights
+  board: multitude insights
+- company: myTomorrows
+  board: myTomorrows
+- company: Nautilus Biotechnology
+  board: nautilus biotechnology
+- company: Neighborly Software
+  board: neighborly-software
+- company: NetBird
+  board: netbird
+- company: Neudata
+  board: neudata
+- company: Northwood Space
+  board: northwoodspace
+- company: Nuclearn
+  board: nuclearn
+- company: Ontic
+  board: ontic
+- company: OpenLoop Health Partners
+  board: openlooppartners
+- company: Origin
+  board: originhq
+- company: Outro Health USA Inc.
+  board: outro-health
+- company: P-1 AI
+  board: p-1 ai
+- company: PAR Technology
+  board: par technology
+- company: Payflip
+  board: payflip
+- company: Pensive
+  board: pensive
+- company: Perchwell
+  board: perchwell
+- company: Plasiv Inc
+  board: plasiv
+- company: Pocket Worlds
+  board: pocket worlds
+- company: Polaris Growth
+  board: polarisgrowth
+- company: Poseidon Aerospace
+  board: poseidonaero
+- company: Possible Finance
+  board: possible-finance
+- company: Prophecy Gov
+  board: prophecygov
+- company: Protera Health
+  board: proterahealth
+- company: Railway
+  board: railway
+- company: Redesign Health
+  board: redesign health
+- company: Red Metals
+  board: redmetals
+- company: Resolution
+  board: resolution
+- company: Resorcer
+  board: resorcer.com
+- company: Runa
+  board: runa
+- company: RWA.xyz
+  board: rwa.xyz
+- company: Saltz Marketplace
+  board: saltz
+- company: Scholarly
+  board: scholarly
+- company: Second Dinner
+  board: seconddinner
+- company: Security Level 5
+  board: security-level-5
+- company: Seismic
+  board: seismic-change.com
+- company: Sentient Foundation
+  board: sentient-foundation
+- company: Shared Context Lab
+  board: sharedcontextlab
+- company: ShiftKey
+  board: shiftkey
+- company: SignalFire
+  board: signalfire
+- company: Simular
+  board: simular
+- company: Sintra
+  board: sintra
+- company: Sorare
+  board: sorare
+- company: Soter
+  board: soterinsure
+- company: SOVRA
+  board: sovra
+- company: Squad
+  board: squadai
+- company: STNDRD
+  board: stndrd
+- company: Stony Creek Homes
+  board: stony creek homes
+- company: Strange Loop Labs
+  board: strange-loop-labs
+- company: Sunday Natural
+  board: sunday-natural
+- company: Supa
+  board: supa
+- company: Surgimate
+  board: surgimate
+- company: Symbiotic
+  board: symbiotic
+- company: Synergy Pet Group
+  board: synergy pet group
+- company: Talos
+  board: talos-trading
+- company: Taxwire
+  board: taxwire
+- company: The Biological Computing Co.
+  board: tbc
+- company: Teambridge
+  board: teambridge
+- company: Tenderly
+  board: tenderly
+- company: Thaleron
+  board: thaleron
+- company: thatgamecompany
+  board: thatgamecompany
+- company: Theori
+  board: theori
+- company: Tomo
+  board: tomo.ai
+- company: Tools for Humanity
+  board: tools for humanity
+- company: Roam
+  board: tryroam
+- company: vCluster Labs
+  board: vClusterLabs
+- company: Vorto
+  board: vorto
+- company: Vytalize Health
+  board: vytalize health
+- company: Welborn Garage
+  board: welborne-garage
+- company: Zip Security
+  board: zip security

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7760,794 +7760,114 @@
   board: A1 Garage Door Service
 - company: AION Biosciences
   board: AION Biosciences
-- company: APEXX Global
-  board: APEXX
-- company: ARQ
-  board: ARQ
-- company: ATG
-  board: ATG
-- company: Aaron School
-  board: Aaron-School
-- company: Abridge
-  board: Abridge
-- company: Accord
-  board: Accord
-- company: Acorns
-  board: Acorns
-- company: Adaptive
-  board: Adaptive
-- company: AfterQuery
-  board: AfterQuery
-- company: Agent
-  board: Agent
-- company: AgentMail
-  board: AgentMail
-- company: Agentio
-  board: Agentio
-- company: Aleph Alpha
-  board: AlephAlpha
-- company: Ambral
-  board: Ambral
 - company: American Terawatt
   board: American Terawatt
-- company: Ampersand
-  board: Ampersand
-- company: Anagram
-  board: Anagram
-- company: Anima
-  board: Anima
-- company: Ankorstore
-  board: Ankorstore
-- company: Anon
-  board: Anon
-- company: Antares
-  board: Antares
-- company: Antimetal
-  board: Antimetal
-- company: Antithesis
-  board: Antithesis
-- company: Applied Intuition
-  board: Applied
 - company: Applied Compute
   board: Applied Compute
-- company: Applied Behavioral Services
-  board: Applied-Behavioral-Services
-- company: Aquant
-  board: Aquant
-- company: Arbor
-  board: Arbor
-- company: Arch
-  board: Arch
-- company: Arlo
-  board: Arlo
-- company: Armory
-  board: Armory
-- company: Ashby
-  board: Ashby
-- company: Aspora
-  board: Aspora
-- company: Astro Mechanica
-  board: Astro-Mechanica
-- company: Atolio
-  board: Atolio
-- company: Atropos Health
-  board: AtroposHealth
-- company: Away
-  board: Away
 - company: Axel
   board: Axel
-- company: BIOptimizers
-  board: BIOptimizers
-- company: Base
-  board: Base
-- company: Baton
-  board: Baton
-- company: Bevel
-  board: Bevel
-- company: Bhblasted
-  board: Bhblasted
-- company: Bifrost AI
-  board: Bifrost
-- company: Bioscope AI
-  board: Bioscope AI
 - company: Blackpoint Cyber
   board: Blackpoint Cyber
-- company: Blacksmith
-  board: Blacksmith
-- company: Blacksmith Agency
-  board: Blacksmith Agency
-- company: Blockhouse
-  board: Blockhouse
-- company: Blossom Health
-  board: Blossom-Health
-- company: Boom
-  board: Boom
-- company: Bounce
-  board: Bounce
-- company: Braiins
-  board: Braiins
-- company: Braintrust
-  board: Braintrust
-- company: Branch Financial, LLC
-  board: BranchInsurance
-- company: BranchLab
-  board: BranchLab
-- company: Brodie Rec League
-  board: Brodie Rec League
-- company: Browserbase
-  board: Browserbase
-- company: C1
-  board: C1
-- company: CARIAN
-  board: CARIAN
-- company: CUBE
-  board: CUBE
-- company: Cambly
-  board: Cambly
-- company: Campus
-  board: Campus
 - company: Capable Labs
   board: Capable
-- company: Cape
-  board: Cape
-- company: Carwow
-  board: Carwow
-- company: Catio
-  board: Catio
-- company: ChartHop
-  board: ChartHop
-- company: Chief
-  board: Chief
-- company: Chromatic
-  board: Chromatic
 - company: Cirrus Systems, Inc.
   board: Cirrus Systems
-- company: Citizen
-  board: Citizen
 - company: Citizen Health
   board: Citizen Health
 - company: Civic Roundtable
   board: Civic Roundtable
-- company: ClassDojo
-  board: ClassDojo
-- company: Clera
-  board: Clera
-- company: Clipbook
-  board: Clipbook
-- company: Close
-  board: Close
 - company: CoachHub
   board: CoachHub Careers
-- company: Coastal Community Bank
-  board: Coastal
-- company: CodaMetrix
-  board: CodaMetrix
-- company: Coder
-  board: Coder
-- company: Coframe
-  board: Coframe
-- company: Coinflow
-  board: Coinflow
-- company: Coinhako
-  board: Coinhako
-- company: Commure
-  board: Commure
-- company: Compa
-  board: Compa
 - company: Twenty Labs
   board: Compound Jobs
-- company: Conception
-  board: Conception
-- company: Coperniq Inc.
-  board: Coperniq
-- company: Coverbase
-  board: Coverbase
-- company: Coworker.ai
-  board: Coworker
-- company: Crusoe
-  board: Crusoe
-- company: Cyberhaven
-  board: Cyberhaven
-- company: Cylinder Health
-  board: CylinderHealth
-- company: Dandy
-  board: Dandy
-- company: DeepL
-  board: DeepL
-- company: Deepgram
-  board: Deepgram
-- company: Deepnote
-  board: Deepnote
-- company: Dehazelabs
-  board: DehazeLabs
-- company: Delphina
-  board: Delphina
-- company: Diagrid
-  board: Diagrid
-- company: Distyl AI
-  board: Distyl
-- company: Divine
-  board: DivineResearch
 - company: Dominion Dynamics
   board: Dominion Dynamics
-- company: Doppel
-  board: Doppel
-- company: DoubleZero
-  board: DoubleZero
-- company: DubClub
-  board: DubClub
 - company: Edison Scientific
   board: Edison Scientific
-- company: Egra
-  board: Egra
-- company: Ekho
-  board: Ekho
-- company: Electric
-  board: Electric
-- company: ElevenLabs
-  board: ElevenLabs
-- company: EliseAI
-  board: EliseAI
-- company: Empo Health
-  board: Empo Health
-- company: Endgame
-  board: Endgame
 - company: Eon Systems
   board: Eon Systems
-- company: Epistemix
-  board: Epistemix
-- company: EverOps
-  board: EverOps
-- company: FLORA
-  board: FLORA
-- company: FURTHER
-  board: FURTHER
-- company: Felix
-  board: Felix
 - company: Meraki-Labs
   board: Fermi AI
-- company: Fiducial
-  board: Fiducial
-- company: FirstPrinciples
-  board: FirstPrinciples
-- company: FleetWorks
-  board: FleetWorks
-- company: Fleetcraft
-  board: Fleetcraft
-- company: FloatMe
-  board: FloatMe
 - company: Flock
   board: Flock Safety
-- company: FlutterFlow
-  board: FlutterFlow
-- company: fonio
-  board: Fonio
 - company: Fort Health
   board: Fort Health
 - company: Forward Financing
   board: Forward Financing
-- company: Found
-  board: Found
-- company: Fourier
-  board: Fourier
-- company: Fulcrum
-  board: Fulcrum
-- company: Fundamental
-  board: Fundamental
-- company: fundamentalXR
-  board: FundamentalXR
-- company: Geoforce
-  board: Geoforce
-- company: Giga
-  board: GigaML
-- company: GitBook
-  board: GitBook
-- company: GoHenry
-  board: GoHenry
-- company: Venti Technologies
-  board: GoVenti
-- company: GovWell
-  board: GovWell
-- company: Gradient
-  board: Gradient
-- company: Graphite
-  board: Graphitehq
-- company: Gravity
-  board: GravityClimate
-- company: Green Tree School & Services
-  board: Green-Tree-School-and-Services
 - company: Grindr
   board: Grindr LLC
 - company: GrowthX AI
   board: GrowthX AI
-- company: Gruntwork
-  board: Gruntwork
-- company: HUMAN
-  board: HUMAN
-- company: Haast
-  board: Haast
-- company: HackerOne
-  board: HackerOne
-- company: Hang
-  board: Hang
-- company: Harmonic
-  board: Harmonic
-- company: Hartbeat
-  board: Hartbeat
-- company: Hatch
-  board: Hatch
-- company: Headstart
-  board: Headstart
-- company: Healthtech-1
-  board: Healthtech-1
-- company: HighlightTA
-  board: HighlightTA
+- company: Hamming AI
+  board: Hamming AI
 - company: Hippocratic AI
   board: Hippocratic AI
-- company: hive.co
-  board: Hive.co
-- company: Homebound
-  board: Homebound
 - company: Honey Homes
   board: Honey Homes
-- company: Hyperbound
-  board: Hyperbound
 - company: Hyperliquid Labs
   board: Hyperliquid Labs
-- company: Hyperscience
-  board: Hyperscience
 - company: Ideal Dental
   board: Ideal Dental
-- company: Improbable
-  board: Improbable
-- company: Inferact
-  board: Inferact
 - company: Infinite Lambda
   board: Infinite Lambda
-- company: Inscribe
-  board: InscribeAI
-- company: Inspectiv
-  board: Inspectiv
-- company: Intellistack
-  board: Intellistack
-- company: Interra Health
-  board: Interrahealth
-- company: Irregular
-  board: Irregular
 - company: Jasper
   board: Jasper AI
-- company: Jellyfish
-  board: Jellyfish
-- company: Juicebox
-  board: Juicebox
-- company: Jump
-  board: Jump
-- company: Junction
-  board: Junction
-- company: KAYAK
-  board: KAYAK
-- company: Keyrock
-  board: Keyrock
-- company: Kingdom
-  board: Kingdom
-- company: Known
-  board: Known
-- company: Kojo
-  board: Kojo
-- company: Kombo
-  board: Kombo
-- company: Kota
-  board: Kota
-- company: Koyfin
-  board: Koyfin
-- company: Kustomer
-  board: Kustomer
-- company: Lambda
-  board: Lambda
-- company: LatchBio
-  board: LatchBio
-- company: Laurel
-  board: Laurel
-- company: Lean Layer
-  board: LeanLayer
-- company: Lean Technologies
-  board: LeanTech
-- company: Leapsome
-  board: Leapsome
-- company: LENS Inc.
-  board: Lens
-- company: Levelpath
-  board: Levelpath
-- company: Lido
-  board: Lido.fi
-- company: Lightdash
-  board: Lightdash
-- company: Lightfield
-  board: Lightfield
-- company: Linear
-  board: Linear
-- company: Linkup
-  board: Linkup
 - company: Local Infusion
   board: Local Infusion
-- company: Lorikeet
-  board: Lorikeet
-- company: Luminovo
-  board: Luminovo
-- company: M-KOPA
-  board: M-KOPA
-- company: Magical
-  board: Magical
-- company: Mangomint
-  board: Mangomint
-- company: Maxima
-  board: Maxima
-- company: Meadow
-  board: Meadow
-- company: MediCircle
-  board: MediCircle
 - company: Merge Labs
   board: Merge Labs
-- company: Mimica
-  board: Mimica
-- company: Mintlify
-  board: Mintlify
-- company: MioDottore
-  board: MioDottore
-- company: Molg
-  board: Molg
-- company: Mollie
-  board: Mollie
-- company: Mondoo
-  board: Mondoo
-- company: Moonlake
-  board: Moonlake
-- company: Morpho
-  board: Morpho
-- company: MotherDuck
-  board: MotherDuck
-- company: Moxie
-  board: Moxie
-- company: Mutiny
-  board: Mutiny
-- company: NationGraph
-  board: NationGraph
-- company: Natter
-  board: Natter
+- company: Multitude Insights
+  board: Multitude Insights
 - company: Nautilus Biotechnology
   board: Nautilus Biotechnology
-- company: Neon
-  board: Neon
 - company: Neon
   board: Neon Money Talks
 - company: New Story
   board: New Story
-- company: New Story Schools (PA)
-  board: New-Story-Schools-PA
-- company: NextPatient
-  board: NextPatient
-- company: Nivoda
-  board: Nivoda
-- company: Noyo
-  board: Noyo
-- company: Numeral
-  board: Numeral
-- company: OBRIO
-  board: OBRIO
-- company: OLIX
-  board: OLIX
-- company: OXIO Corporation
-  board: OXIO
-- company: OnHires
-  board: OnHires
-- company: Onton
-  board: Onton
-- company: Opal Security
-  board: Opal
-- company: Opal
-  board: Opal-OS
-- company: OpenAI
-  board: OpenAI
-- company: OpenHands
-  board: OpenHands
-- company: OpenSea
-  board: OpenSea
-- company: Oso
-  board: Oso
-- company: Outpost Technologies
-  board: Outpostnow
-- company: Outset
-  board: Outset
-- company: Overjet
-  board: Overjet
-- company: Owner.com
-  board: Owner
 - company: P-1 AI
   board: P-1 AI
 - company: PAR Technology
   board: PAR Technology
-- company: Panoptyc
-  board: Panoptyc
-- company: Paradigm
-  board: Paradigm
-- company: Paragon
-  board: Paragon
-- company: Parkade
-  board: Parkade
-- company: Pave Bank
-  board: PaveBank
-- company: Payscale
-  board: Payscale
-- company: Pear VC
-  board: Pear-VC
-- company: Peec AI
-  board: Peec
-- company: Pemberton
-  board: Pemberton
-- company: Perk
-  board: Perk
-- company: PermitFlow
-  board: PermitFlow
-- company: Perplexity
-  board: Perplexity
-- company: PHIL
-  board: Phil
 - company: Phinity Labs
   board: Phinitylabs
-- company: Pivot
-  board: Pivot
-- company: PlantingSpace
-  board: PlantingSpace
-- company: Plaud
-  board: Plaud
-- company: Playbook
-  board: Playbook
-- company: Playground
-  board: Playground
-- company: Playground Global
-  board: Playground Global
 - company: Pocket Worlds
   board: Pocket Worlds
-- company: Polarsteps
-  board: Polarsteps
-- company: Polymarket
-  board: Polymarket
-- company: Post.
-  board: Post
-- company: Preference Model
-  board: Preference-Model
-- company: Prelude
-  board: Prelude
-- company: Prime Intellect
-  board: PrimeIntellect
-- company: Procurify
-  board: Procurify
-- company: Profound
-  board: Profound
-- company: Promise
-  board: Promise
-- company: Prompt
-  board: Prompt
 - company: Protex AI
   board: Protex AI
-- company: Proxima
-  board: ProximaAI
 - company: Pulsora, Inc.
   board: Pulsora Inc
-- company: Pyyne
-  board: Pyyne
-- company: Quicknode
-  board: QuickNode
-- company: Ramp
-  board: Ramp
-- company: Ravio
-  board: Ravio
-- company: Rebecca School
-  board: Rebecca-School
-- company: Red 6
-  board: Red6
 - company: Redesign Health
   board: Redesign Health
-- company: Redis
-  board: Redis
-- company: Reflex Robotics
-  board: ReflexRobotics
-- company: Reka
-  board: Reka
-- company: Remedy Scientific
-  board: Remedy Scientific
-- company: Replicant
-  board: Replicant
-- company: Reset
-  board: Reset
 - company: Resilience Care
   board: Resilience Care
 - company: Resolve AI
   board: Resolve AI
-- company: Restream
-  board: Restream
-- company: RevenueCat
-  board: RevenueCat
-- company: Rhythms
-  board: Rhythms
 - company: Ricursive Intelligence
   board: Ricursive Intelligence
-- company: ALSO
-  board: Ridealso
-- company: River Rock Academy
-  board: River-Rock-Academy
-- company: Roadrunner
-  board: Roadrunner
-- company: Rogo
-  board: Rogo
-- company: Roots AI
-  board: Roots-Automation
-- company: Rose Rocket
-  board: Rose Rocket
-- company: Rothy's
-  board: Rothys
-- company: Rox Data Corp
-  board: Rox-Data-Corp
-- company: Rundoo
-  board: Rundoo
-- company: cfo.ai
-  board: Runway
-- company: SKELAR
-  board: SKELAR
-- company: Sage Alliance Schools
-  board: Sage-Alliance-Schools
-- company: SalesPatriot
-  board: SalesPatriot
-- company: Sandstone
-  board: Sandstone
-- company: Sanity
-  board: Sanity
-- company: Scale Army Careers
-  board: Scale Army Careers
-- company: Sciforium
-  board: Sciforium
-- company: SearchApi
-  board: SearchApi
-- company: SearchStax
-  board: Searchstax
-- company: Second Front Systems
-  board: Second-Front-Systems
 - company: Sentradel
   board: Sentradel
-- company: Serval
-  board: Serval
-- company: Served With Honor
-  board: ServedWithHonor
-- company: Shasqi
-  board: Shasqi
-- company: ShiftKey
-  board: Shiftkey
-- company: Short Story
-  board: ShortStory
-- company: Sierra
-  board: Sierra
-- company: SigNoz
-  board: SigNoz
 - company: SignalFire
   board: SignalFire
-- company: Silver.dev
-  board: Silver
-- company: Siro
-  board: Siro
-- company: SiteMinder
-  board: SiteMinder
-- company: Sitemate
-  board: Sitemate
-- company: Skydropx - Frenet
-  board: Skydropx
-- company: Slingshot AI
-  board: SlingshotAI
-- company: Snappy
-  board: Snappy
-- company: Snowflake
-  board: Snowflake
-- company: Solace
-  board: Solace
 - company: Solana Foundation
   board: Solana Foundation
-- company: Solvd
-  board: Solvd
-- company: Sona
-  board: Sona
-- company: Speak
-  board: Speak
-- company: Speakeasy
-  board: Speakeasy
-- company: Speckle
-  board: Speckle
-- company: Sphinx
-  board: Sphinx
-- company: SpotOn
-  board: Spoton
-- company: Stand
-  board: Stand
-- company: Stand Insurance
-  board: StandInsurance
-- company: Standard Bots
-  board: StandardBots
-- company: Staycation
-  board: Staycation
-- company: Steadily
-  board: Steadily
-- company: Stedi
-  board: Stedi
-- company: Stepful
-  board: Stepful
 - company: Stony Creek Homes
   board: Stony Creek Homes
-- company: Stora
-  board: Stora
-- company: Straia
-  board: Straia
-- company: Strava
-  board: Strava
-- company: Sui Foundation
-  board: Sui Foundation
-- company: Suite Studios
-  board: Suite-Studios
 - company: Sunday
   board: Sunday-GmbH
-- company: SunnyData
-  board: SunnyData
-- company: Suno
-  board: Suno
-- company: Swoop Technologies
-  board: Swoop
 - company: Symmetry AI
   board: Symmetry
-- company: Tabs
-  board: Tabs
-- company: Taptap Send
-  board: TaptapSend
-- company: Taxo
-  board: Taxo
-- company: Tembo Health
-  board: Tembo-Health
-- company: Tembo Health
-  board: Tembo-health
-- company: Tempo
-  board: Tempo
-- company: Terranova
-  board: Terranova
 - company: The Agency Fund
   board: The Agency Fund
-- company: The Browser Company
-  board: The Browser Company
 - company: The Job Sauce
   board: The Job Sauce
 - company: The Zebra
   board: The Zebra
-- company: The Flex
-  board: The-Flex
-- company: The Learning Spectrum
-  board: The-Learning-Spectrum
-- company: The Pinnacle School
-  board: The-Pinnacle-School
 - company: Theori
   board: Theori
 - company: Thrive Alliance Group
   board: Thrive-Alliance-Group
-- company: Tiger Data
-  board: TigerData
-- company: Tilt
-  board: Tilt
-- company: Toku
-  board: Toku
-- company: Tonic AI
-  board: TonicAI
 - company: Tools for Humanity
   board: Tools for Humanity
-- company: Transfr
-  board: Transfr
-- company: Tremendous
-  board: Tremendous
-- company: Trener
-  board: Trener-Robotics
 - company: Trexo Robotics
   board: Trexo Robotics
 - company: Trunk Tools, Inc.
@@ -8556,72 +7876,14 @@
   board: TwoStepTx
 - company: US Health Partners
   board: US Health Partners
-- company: Uberall
-  board: Uberall
-- company: Union.ai
-  board: Union
-- company: Unlearn
-  board: Unlearn
-- company: UpCodes
-  board: UpCodes
-- company: VLogic
-  board: VLogic
-- company: VREY
-  board: VREY
-- company: Valon Tech
-  board: Valon
 - company: Verne Robotics
   board: Verne Robotics
-- company: Vetcove
-  board: Vetcove
-- company: Vic.ai
-  board: Vic.ai
-- company: Vidmob
-  board: VidMob
-- company: Vidmob
-  board: Vidmob
-- company: Virtuous
-  board: Virtuous
-- company: Visio Digital Partner
-  board: VisioDigitalPartner
-- company: Viz.ai
-  board: Viz.ai
-- company: Vogel
-  board: Vogel
-- company: Vori
-  board: Vori
-- company: Voxel
-  board: Voxel
 - company: Voya Energy
   board: Voya Energy
-- company: Vultr
-  board: Vultr
 - company: Vytalize Health
   board: Vytalize Health
-- company: WA.Technology
-  board: WA.Technology
-- company: WRITER
-  board: WRITER
-- company: Watershed
-  board: Watershed
-- company: WeTravel
-  board: WeTravel
-- company: Weave
-  board: Weave
-- company: Weekend
-  board: Weekend
-- company: Winona
-  board: Winona
 - company: Worktrace AI
   board: Worktrace AI
-- company: WunderGraph, Inc.
-  board: WunderGraph
-- company: Zania
-  board: Zania
-- company: Zeromark
-  board: Zeromark
-- company: Zip
-  board: Zip
 - company: Zip Security
   board: Zip Security
 - company: Abstraction
@@ -8632,10 +7894,6 @@
   board: aceve
 - company: Aditude
   board: aditude
-- company: AeroVect
-  board: aerovect
-- company: Agentis Capital Advisors
-  board: agentis-capital-advisors
 - company: Airspeed
   board: airspeed
 - company: aka (fka mem protocol)
@@ -8660,24 +7918,14 @@
   board: atira
 - company: Atlas Privacy
   board: atlas-privacy
-- company: Aven
-  board: aven
-- company: Bastion
-  board: bastion
 - company: Parallel
   board: beparallel
 - company: BetterCloud, Inc.
   board: bettercloud
-- company: Blackpoint Cyber
-  board: blackpoint cyber
 - company: Blank Instance
   board: blankexampleinstance
-- company: Blockworks
-  board: blockworks
 - company: BRM
   board: brm.ai
-- company: Capital V Strategies
-  board: capital-v-strategies
 - company: CareSwift
   board: careswift
 - company: Careway Health
@@ -8686,18 +7934,8 @@
   board: cchn
 - company: ClickHouse
   board: clickhouse
-- company: Climate Finance Solutions
-  board: climate-finance-solutions
-- company: CloudZero
-  board: cloudzero
 - company: Cold Start Ventures
   board: coldstartventures
-- company: Conduit
-  board: conduit
-- company: cyber•Fund
-  board: cyber.fund
-- company: d-Matrix
-  board: d-matrix
 - company: DataSnipper
   board: datasnipper
 - company: deepset
@@ -8716,68 +7954,48 @@
   board: eleos
 - company: ERP•AI
   board: erp.ai
-- company: Etched
-  board: etched
 - company: Ethereum Foundation
   board: ethereum-foundation
 - company: Everstar
   board: everstar
-- company: Fabrion
-  board: fabrion
 - company: Ferry
   board: ferryhealth
-- company: Flock
-  board: flock safety
 - company: fomo Labs
   board: fomo-labs
-- company: Forward Financing
-  board: forward financing
-- company: G2
-  board: g2
 - company: Gamut
   board: gamut
+- company: Garage Door Doctor
+  board: garage-door-doctor
 - company: General Context
   board: general-context
 - company: Getting Attention
   board: getting-attention
-- company: GPTZero
-  board: gptzero
 - company: Guide Labs
   board: guidelabs.ai
+- company: Harmony
+  board: harmony
 - company: Heirloom Carbon
   board: heirloomcarbon
 - company: Pinnacle
   board: heypinnacle
-- company: Hippocratic AI
-  board: hippocratic ai
 - company: HIVED
   board: hived
-- company: iVerify
-  board: iVerify
+- company: Inherent
+  board: inherent
 - company: interface.ai
   board: interface-ai
 - company: Intology
   board: intology
-- company: Jasper
-  board: jasper ai
-- company: Jerry.ai
-  board: jerry.ai
-- company: Joyteractive
-  board: joyteractive
 - company: justDice
   board: justDice
 - company: justtrack
   board: justtrack
-- company: k-ID
-  board: k-ID
 - company: Kalibri Labs
   board: kalibri-labs
 - company: Kelluu
   board: kelluu
 - company: Kled AI
   board: kled-ai
-- company: Kognitos
-  board: kognitos
 - company: Kranz Consulting
   board: kranz-consulting
 - company: Krew
@@ -8790,14 +8008,8 @@
   board: lighthousehq
 - company: Live it Up
   board: liveitup
-- company: livingHR
-  board: livingHR
-- company: Local Infusion
-  board: local infusion
 - company: Lua Global
   board: lua
-- company: Lynk
-  board: lynk
 - company: Mandrel
   board: mandrel
 - company: Mast
@@ -8816,96 +8028,48 @@
   board: monarchcrops
 - company: Movement
   board: movement
-- company: MUBI
-  board: mubi
-- company: MUI
-  board: mui
-- company: Multitude Insights
-  board: multitude insights
-- company: myTomorrows
-  board: myTomorrows
-- company: Nautilus Biotechnology
-  board: nautilus biotechnology
 - company: Neighborly Software
   board: neighborly-software
 - company: NetBird
   board: netbird
 - company: Neudata
   board: neudata
-- company: Northwood Space
-  board: northwoodspace
 - company: Nuclearn
   board: nuclearn
-- company: Ontic
-  board: ontic
 - company: OpenLoop Health Partners
   board: openlooppartners
 - company: Origin
   board: originhq
 - company: Outro Health USA Inc.
   board: outro-health
-- company: P-1 AI
-  board: p-1 ai
-- company: PAR Technology
-  board: par technology
 - company: Payflip
   board: payflip
 - company: Pensive
   board: pensive
-- company: Perchwell
-  board: perchwell
 - company: Plasiv Inc
   board: plasiv
-- company: Pocket Worlds
-  board: pocket worlds
-- company: Polaris Growth
-  board: polarisgrowth
 - company: Poseidon Aerospace
   board: poseidonaero
 - company: Possible Finance
   board: possible-finance
-- company: Prophecy Gov
-  board: prophecygov
 - company: Protera Health
   board: proterahealth
-- company: Railway
-  board: railway
-- company: Redesign Health
-  board: redesign health
 - company: Red Metals
   board: redmetals
 - company: Resolution
   board: resolution
 - company: Resorcer
   board: resorcer.com
-- company: Runa
-  board: runa
-- company: RWA.xyz
-  board: rwa.xyz
 - company: Saltz Marketplace
   board: saltz
-- company: Scholarly
-  board: scholarly
-- company: Second Dinner
-  board: seconddinner
 - company: Security Level 5
   board: security-level-5
-- company: Seismic
-  board: seismic-change.com
 - company: Sentient Foundation
   board: sentient-foundation
 - company: Shared Context Lab
   board: sharedcontextlab
-- company: ShiftKey
-  board: shiftkey
-- company: SignalFire
-  board: signalfire
-- company: Simular
-  board: simular
 - company: Sintra
   board: sintra
-- company: Sorare
-  board: sorare
 - company: Soter
   board: soterinsure
 - company: SOVRA
@@ -8914,49 +8078,37 @@
   board: squadai
 - company: STNDRD
   board: stndrd
-- company: Stony Creek Homes
-  board: stony creek homes
 - company: Strange Loop Labs
   board: strange-loop-labs
 - company: Sunday Natural
   board: sunday-natural
 - company: Supa
   board: supa
-- company: Surgimate
-  board: surgimate
-- company: Symbiotic
-  board: symbiotic
 - company: Synergy Pet Group
   board: synergy pet group
-- company: Talos
-  board: talos-trading
 - company: Taxwire
   board: taxwire
 - company: The Biological Computing Co.
   board: tbc
-- company: Teambridge
-  board: teambridge
 - company: Tenderly
   board: tenderly
 - company: Thaleron
   board: thaleron
-- company: thatgamecompany
-  board: thatgamecompany
-- company: Theori
-  board: theori
 - company: Tomo
   board: tomo.ai
-- company: Tools for Humanity
-  board: tools for humanity
 - company: Roam
   board: tryroam
-- company: vCluster Labs
-  board: vClusterLabs
+- company: Vals AI
+  board: vals-ai
+- company: Vanna Health, Inc
+  board: vanna-health-inc
 - company: Vorto
   board: vorto
-- company: Vytalize Health
-  board: vytalize health
+- company: Warren
+  board: warren
 - company: Welborn Garage
   board: welborne-garage
-- company: Zip Security
-  board: zip security
+- company: Pace
+  board: withpace
+- company: WorkHero
+  board: workhero

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14281,24 +14281,12 @@
   board: mooreholdingsllc
 - company: Sharp Electronics
   board: sharpelectronics
-- company: Convene Hospitality Group
-  board: Convene
-- company: Mill
-  board: Mill
-- company: MyHeritage
-  board: MyHeritage
-- company: OKX
-  board: OKX
-- company: Adyen
-  board: adyen
 - company: Auld & White Constructors Talent Community
   board: auldwhitetalentcommunity
 - company: Join Our Talent Community
   board: berkadiatalentpool
 - company: Besxar
   board: besxar
-- company: BETA Technologies
-  board: betatechnologiesinc
 - company: Blenheim Chalcot
   board: blenheimchalcot
 - company: Charlie Health Outreach
@@ -14337,5 +14325,7 @@
   board: publiclabel
 - company: Unconventional, Inc.
   board: unconventionalinc
+- company: Vilya
+  board: vilya
 - company: Zerocater
   board: zerocater

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14281,3 +14281,61 @@
   board: mooreholdingsllc
 - company: Sharp Electronics
   board: sharpelectronics
+- company: Convene Hospitality Group
+  board: Convene
+- company: Mill
+  board: Mill
+- company: MyHeritage
+  board: MyHeritage
+- company: OKX
+  board: OKX
+- company: Adyen
+  board: adyen
+- company: Auld & White Constructors Talent Community
+  board: auldwhitetalentcommunity
+- company: Join Our Talent Community
+  board: berkadiatalentpool
+- company: Besxar
+  board: besxar
+- company: BETA Technologies
+  board: betatechnologiesinc
+- company: Blenheim Chalcot
+  board: blenheimchalcot
+- company: Charlie Health Outreach
+  board: charliehealthoutreach
+- company: The Dermatology Center of Indiana
+  board: dermindy
+- company: Dev Talent Network
+  board: devfuturetalent
+- company: 'Enchanted Forest Academy '
+  board: enchantedforest
+- company: Fieldstone Bio
+  board: fieldstonebio
+- company: Fractal Portfolio
+  board: fractalportfolio
+- company: FWD.us
+  board: fwdus
+- company: 'Invite-Only Job Board '
+  board: genius
+- company: ITERRA
+  board: iterrasolutions
+- company: Mighty Networks
+  board: mightynetworks
+- company: Nuvalent, Inc.
+  board: nuvalent
+- company: Online Birds Austria GmbH
+  board: onlinebirdsaustriagmbh
+- company: Pacific Volkswagen
+  board: pacificvolkswagen
+- company: Pedestal Health
+  board: pedestalhealth
+- company: Pippin Title
+  board: pippintitle
+- company: Plantiful
+  board: plantiful
+- company: Public Label
+  board: publiclabel
+- company: Unconventional, Inc.
+  board: unconventionalinc
+- company: Zerocater
+  board: zerocater


### PR DESCRIPTION
## Summary
- Adds a shared Common Crawl CDX helper (`cmd/harvest-boards/commoncrawl.go`) that finds board candidates by paging the last 3 snapshots of a provider's board host, wired into `greenhouseProber`/`ashbyProber` via the existing `discoverer` interface (mirrors `gupyProber`/`opencatsProber`).
- Lever is out of scope: `jobs.lever.co/robots.txt` disallows `CCBot` entirely, confirmed by spike — no board-path data ever reaches the CDX index for it.
- Fixes a real bug caught mid-implementation: slug case is now preserved instead of lowercased (Ashby board ids are case-sensitive — confirmed live: `Convene`, `OKX`, `ARQ`, `APEXX`, ...).
- `discover_test.go`'s "non-discoverer needs a seed" test used `greenhouseProber` as its example; switched to `leverProber` since greenhouse is now a discoverer.
- OpenSpec change at `openspec/changes/commoncrawl-board-discovery/` (proposal, design, spec delta on `board-harvest`, tasks — all complete).

**Included as the run's validated output** (per the tool's own convention — grow `sources/*.yml`, review via diff): a real run against live Common Crawl appended **29 new Greenhouse boards** and **602 new Ashby boards** (0 probe failures, 0 mismatches on either run). Ashby's live-hit rate (48%) was far higher than Greenhouse's (~3.5%) — Ashby is younger, so more of its discovered companies are still actively hiring. A few individual CDX pages 504'd or timed out mid-run; per-page error tolerance logged and skipped them without aborting either run, as designed.

## Test Plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./cmd/harvest-boards/...` (new unit tests: slug extraction incl. case preservation, JSON-lines parsing incl. truncated-line tolerance, per-snapshot failure handling, both probers' `discover`)
- [x] Manual run against live Common Crawl + Greenhouse/Ashby APIs (see Summary for numbers)