### PR TITLE
Decode the structured country field on Ashby/Lever/Workday

### DIFF
--- a/docs/superpowers/specs/2026-08-06-workday-facet-split-design.md
+++ b/docs/superpowers/specs/2026-08-06-workday-facet-split-design.md
@@ -1,0 +1,150 @@
+# Workday: subdivide capped boards by facet, retry 403
+
+## Problem
+
+Workday's CXS jobs-listing API caps the `total` it reports at 2,000 for some tenants.
+Past `offset=2000` those tenants return page 1 again rather than an empty page or an
+error. `listPostings` (`internal/sources/workday.go:142-177`) latches the first
+non-zero `total` and pages until it reaches that number, so on a capped board one
+crawl reads at most 2,000 postings and exits cleanly — nothing distinguishes "read the
+whole board" from "hit the ceiling."
+
+Verified live against `accenture.wd103.myworkdayjobs.com/AccentureCareers`
+(2026-08-06): reported `total: 2000`; the `jobFamilyGroup` facet in that same response
+sums to ~51,500; `offset=0` and `offset=2000` return the identical first posting.
+A random sample of 120 boards from `sources/workday.yml` (seed 11) found the ceiling
+on 2/119 reachable boards (~1.7%), extrapolating to roughly 110 of the file's 6,462
+boards — skewed toward the largest employers.
+
+Second, smaller gap: `internal/sources/http.go:493-519` treats HTTP 403 as fatal
+(`default` branch, immediate return), failing the whole board on one rate-limit
+response. `internal/sources/eightfold.go:133-164` already treats 403 as a retryable
+rate-limit signal for that provider (Eightfold returns 403 for throttling, not auth);
+Workday needs the same per-provider judgment call.
+
+## Goal
+
+A single Workday crawl must retrieve every posting on a board, even when the board's
+own `total` is capped at 2,000, without adding hardcoded per-company logic and without
+extra "probe" requests beyond what listing already returns. A transient 403 must not
+fail the whole board.
+
+## Non-goals
+
+- Not fixing the general "some boards report total only on page one" case — that is
+  already handled (the existing latch).
+- Not building a generic cross-provider facet-subdivision abstraction. This is a
+  Workday-specific mechanism; nothing today suggests another provider needs it.
+- Not guaranteeing 100% completeness on every conceivable board shape — depth is
+  bounded (below), and exhausting it without resolving the cap is logged, not silently
+  dropped.
+
+## Design
+
+### 1. Detecting a capped board
+
+Trigger condition: the first listing page's `total == workdayCapTotal` (2000, named
+constant). A board that genuinely has exactly 2,000 postings triggers the same path
+harmlessly — subdivision still returns the correct (smaller) set of extra requests, it
+just does more work than strictly necessary. No false negatives are possible from this
+threshold; false positives cost extra requests, not correctness.
+
+### 2. Facet-based subdivision
+
+Workday's listing response carries a `facets` array alongside `jobPostings`, e.g.:
+
+```json
+{"facetParameter": "jobFamilyGroup", "values": [{"id": "...", "count": 24224}, ...]}
+```
+
+Re-querying with `appliedFacets: {"jobFamilyGroup": ["<id>"]}` scopes both the
+postings and the *other* facet dimensions in the response to that slice (verified
+live: applying `jobFamilyGroup=Security` returns `total: 817` matching the facet's
+own count). The dimension used to filter does **not** rescope against itself — Workday
+returns the same global breakdown for it — so going deeper on an oversized slice
+means adding a **different**, not-yet-applied facet dimension (e.g. `workerSubType`,
+`timeType`, `locationMainGroup`), verified live to properly rescope under an applied
+`jobFamilyGroup` filter.
+
+Algorithm (`listPostings` becomes recursive):
+
+```
+fetchSlice(appliedFacets, usedDimensions, depth):
+    page 1 of the slice (offset=0)
+    if total < workdayCapTotal or depth == maxFacetDepth:
+        page normally (existing loop) and return postings
+    pick the facet dimension present in this response, not in usedDimensions,
+      with the highest single-value count (best split for an uneven slice)
+    if no such dimension exists:
+        log.Printf warning: board capped, no further dimension to split on
+        page normally (existing loop) and return postings  // best effort
+    for each value in that dimension's facet:
+        recurse: fetchSlice(appliedFacets + {dimension: [value.id]}, usedDimensions + dimension, depth+1)
+    merge all recursed results
+```
+
+`maxFacetDepth = 3` — bounded, not tuned per company. Confirmed sufficient for the
+worst known case: Accenture's top-level split still leaves "Software Engineering" at
+~24k, but a second dimension resolves it (verified live). Three combined dimensions
+gives headroom beyond that without unbounded recursion.
+
+### 3. Dedup across slices
+
+`workerSubType` (and potentially others) multi-counts — a posting can carry more than
+one value, so its facet sum exceeds the true total and the same posting can appear in
+more than one recursed slice. Merge results into a map keyed by `ExternalPath` before
+returning from `listPostings`, same identity key the pipeline already dedups on
+(`jobs.UNIQUE (source, external_id)`). This makes over-inclusive splits safe by
+construction — extra requests, never extra rows.
+
+### 4. Boards below the cap: unaffected
+
+`total < workdayCapTotal` on page 1 skips the whole mechanism and pages exactly as
+today. Zero behavior change for the ~6,350 boards that were never capped.
+
+### 5. 403 retry
+
+Mirror `eightfold.go`'s `getJSONRetrying`/`isRateLimited` shape for Workday's
+`PostJSON`/`GetJSON` calls: retry on 403 or 429 with capped exponential backoff (a
+small, fixed retry count — match Eightfold's constants unless Workday's own throttling
+proves different during testing). Kept as a Workday-local helper, not a shared-client
+change — 403 semantics are provider-specific (Eightfold: rate-limit; some Workday
+tenants: CSRF/auth, per the existing `ats-scrapers` note) and freehire's convention is
+already to layer this per-provider over the shared client.
+
+### 6. Observability
+
+`log.Printf("workday: board %s capped at %d, splitting by %s", ...)` when
+subdivision triggers, and a distinct warning when depth is exhausted without dropping
+under the cap — matching the existing `log.Printf` convention in this package
+(`config.go`, `eightfold.go`, `djinni.go`, etc.). No new logging infrastructure.
+
+### 7. Cost
+
+Requests scale with true board size for the ~110 affected boards only (e.g. Accenture
+goes from ~100 listing requests to on the order of 50,000/20 ≈ 2,500 across all
+slices). This runs under the crawl's existing concurrency and retry handling; no new
+rate-limiting mechanism is being introduced.
+
+## Testing
+
+Extend `internal/sources/workday_test.go` using the existing `routedHTTP` /
+`pagedWorkday` mock patterns:
+
+- Capped total (`total: 2000` on page 1, with a `facets` array) triggers a
+  facet-scoped re-query instead of paging past 2000.
+- A slice that is itself still capped recurses into a second, different facet
+  dimension (not the one already applied).
+- Overlapping postings returned by two different facet values are deduped by
+  `ExternalPath` in the final result.
+- Depth exhausted (`maxFacetDepth` reached) without resolving under the cap: logs a
+  warning and returns what was collected, rather than erroring or looping.
+- A board below the cap (`total < 2000`) is unaffected — same request count as today.
+- 403 on a listing or detail request retries and eventually succeeds; a non-retryable
+  error (e.g. 404) returns immediately.
+
+## Open questions resolved during brainstorming
+
+- Scope: fix both the 2,000 cap and the 403-fatal gap together (user confirmed).
+- Approach: generic adaptive facet-splitting, not a hardcoded per-company list (user
+  confirmed) — it must work for the ~110 affected boards, not just Accenture.

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -31,11 +31,12 @@ import (
 // heuristic an adapter inferred from free text; an adapter with no signal leaves them
 // empty/nil so the dictionary decides.
 //
-// Regions and Cities are the caller's structured GEOGRAPHY signal (macro-region codes
-// and city names the submitter/moderator stated by hand). Unlike the scalars they fully
-// replace the location-dictionary derivation for that facet when present — an explicit
-// place is authoritative, not a hint the dictionary refines — and when empty the
-// dictionary derives as before.
+// Countries, Regions and Cities are the caller's structured GEOGRAPHY signal (a country
+// code the platform states directly, macro-region codes, and city names the
+// submitter/moderator stated by hand). Unlike the scalars they fully replace the
+// location-dictionary derivation for that facet when present — an explicit place is
+// authoritative, not a hint the dictionary refines — and when empty the dictionary
+// derives as before.
 type Input struct {
 	Title              string
 	Company            string
@@ -44,6 +45,7 @@ type Input struct {
 	Location           string
 	Description        string
 	WorkMode           string
+	Countries          []string
 	Regions            []string
 	Cities             []string
 	Seniority          string
@@ -100,8 +102,18 @@ func Derive(in Input) Derived {
 	if usOnly(countries, regions, in.Description) {
 		countries, regions = []string{"us"}, []string{"north_america"}
 	}
+	// An explicit country signal is authoritative: it fully replaces the derived/US-override
+	// countries, the same way a stated work mode replaces the hint — and pulls its region
+	// along with it (the same pairing Parse itself does for a country it resolves), so a
+	// structured country with no separate region statement still lands under the right
+	// region facet instead of falling back to whatever the free-text location parsed.
+	if len(in.Countries) > 0 {
+		countries = in.Countries
+		regions = regionsForCountries(in.Countries)
+	}
 	// An explicit region signal is authoritative: it fully replaces the derived regions
-	// (and the US override above), the same way a stated work mode replaces the hint.
+	// (and the country-derived regions above), the same way a stated work mode replaces
+	// the hint.
 	if len(in.Regions) > 0 {
 		regions = in.Regions
 	}
@@ -204,6 +216,22 @@ func deriveIsTech(category, title string) *bool {
 // veto "Backend Engineer — Teller Systems" is removed on its accidental match.
 func TechEvidence(category, title string) bool {
 	return slices.Contains(vocab.TechCategories, category) || classify.IsTech(title)
+}
+
+// regionsForCountries derives the region codes for a set of already-resolved country
+// codes via the same country→region grouping Parse itself consults (location.CountryToRegion),
+// so a structured country signal with no separate region statement still lands under its
+// region facet. A country outside the curated ~133-country set silently contributes no
+// region — the same never-guess contract the location dictionary follows.
+func regionsForCountries(countries []string) []string {
+	countryToRegion := location.CountryToRegion()
+	set := make(map[string]struct{}, len(countries))
+	for _, c := range countries {
+		if r, ok := countryToRegion[c]; ok {
+			set[r] = struct{}{}
+		}
+	}
+	return stringset.Sorted(set)
 }
 
 // usOnly reports whether a job's geography is unpinned by the location dictionary —

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -464,3 +464,41 @@ func TestDerive_ExplicitRegionCityOverride(t *testing.T) {
 		t.Errorf("Cities = %v, want [Austin] (explicit wins over derived)", got.Cities)
 	}
 }
+
+// A structured country signal (Ashby/Lever/Workday's own country field) overrides the
+// location-dictionary derivation AND pulls its region along with it, so a job whose
+// free-text location the dictionary cannot parse ("UAE" as a bare name) still lands
+// under both facets instead of just the country.
+func TestDerive_ExplicitCountryOverrideAlsoDerivesRegion(t *testing.T) {
+	got := Derive(Input{
+		Title:      "Ops Manager",
+		Company:    "Acme",
+		Source:     "lever",
+		ExternalID: "1",
+		Location:   "Some Office", // resolves no geography on its own
+		Countries:  []string{"ae"},
+	})
+	if !reflect.DeepEqual(got.Countries, []string{"ae"}) {
+		t.Errorf("Countries = %v, want [ae] (explicit wins over derived)", got.Countries)
+	}
+	if !reflect.DeepEqual(got.Regions, []string{"mena"}) {
+		t.Errorf("Regions = %v, want [mena] (paired from the explicit country)", got.Regions)
+	}
+}
+
+// An explicit Regions signal still wins over the region an explicit Countries signal
+// would otherwise pair in — the same "most specific wins" precedence Regions already
+// has over the dictionary.
+func TestDerive_ExplicitRegionOverridesCountryPairedRegion(t *testing.T) {
+	got := Derive(Input{
+		Title:      "Ops Manager",
+		Company:    "Acme",
+		Source:     "manual",
+		ExternalID: "1",
+		Countries:  []string{"ae"},
+		Regions:    []string{"apac"},
+	})
+	if !reflect.DeepEqual(got.Regions, []string{"apac"}) {
+		t.Errorf("Regions = %v, want [apac] (explicit Regions beats the country-paired one)", got.Regions)
+	}
+}

--- a/internal/location/country.go
+++ b/internal/location/country.go
@@ -1,0 +1,54 @@
+package location
+
+import "strings"
+
+// alpha3ToAlpha2 maps the ISO 3166-1 alpha-3 code of every country this package already
+// places on the region map (countryToRegion) to its alpha-2 equivalent, so a source that
+// states its country as an alpha-3 code (Ashby) normalizes the same as one using alpha-2
+// (Lever, Workday). It deliberately covers only the curated 133-country set rather than
+// the full ISO-3166 list: a code outside it "resolves to nothing" everywhere else in this
+// package, and NormalizeCountry keeps that same contract.
+var alpha3ToAlpha2 = map[string]string{
+	"deu": "de", "fra": "fr", "nld": "nl", "esp": "es", "swe": "se", "pol": "pl",
+	"irl": "ie", "prt": "pt", "ita": "it", "bel": "be", "dnk": "dk", "fin": "fi",
+	"aut": "at", "cze": "cz", "rou": "ro", "grc": "gr", "hun": "hu", "bgr": "bg",
+	"hrv": "hr", "svk": "sk", "svn": "si", "ltu": "lt", "lva": "lv", "est": "ee",
+	"lux": "lu", "che": "ch", "nor": "no", "ukr": "ua", "isl": "is",
+	"srb": "rs", "bih": "ba", "mkd": "mk", "alb": "al", "mne": "me", "xkx": "xk",
+	"cyp": "cy", "mlt": "mt", "lie": "li", "mco": "mc", "and": "ad", "smr": "sm",
+	"gbr": "gb",
+	"usa": "us", "can": "ca",
+	"arg": "ar", "bra": "br", "mex": "mx", "chl": "cl", "col": "co", "per": "pe",
+	"ury": "uy", "ecu": "ec", "bol": "bo", "pry": "py", "ven": "ve", "cri": "cr",
+	"pan": "pa", "gtm": "gt", "dom": "do", "hnd": "hn", "slv": "sv", "nic": "ni",
+	"pri": "pr",
+	"sgp": "sg", "jpn": "jp", "aus": "au", "nzl": "nz", "ind": "in", "hkg": "hk",
+	"twn": "tw", "kor": "kr", "chn": "cn", "mys": "my", "tha": "th", "phl": "ph",
+	"vnm": "vn", "idn": "id", "bgd": "bd", "pak": "pk", "lka": "lk", "npl": "np",
+	"khm": "kh", "lao": "la", "mmr": "mm", "mng": "mn", "brn": "bn", "mac": "mo",
+	"are": "ae", "sau": "sa", "isr": "il", "egy": "eg", "tur": "tr", "qat": "qa",
+	"kwt": "kw", "bhr": "bh", "omn": "om", "jor": "jo", "lbn": "lb", "irq": "iq",
+	"irn": "ir", "mar": "ma", "dza": "dz", "tun": "tn", "lby": "ly", "yem": "ye",
+	"pse": "ps",
+	"zaf": "za", "nga": "ng", "ken": "ke", "gha": "gh", "eth": "et", "tza": "tz",
+	"uga": "ug", "rwa": "rw", "sen": "sn", "civ": "ci", "cmr": "cm", "ago": "ao",
+	"moz": "mz", "zmb": "zm", "zwe": "zw", "mus": "mu",
+	"rus": "ru", "blr": "by", "mda": "md", "arm": "am", "aze": "az", "geo": "ge",
+	"uzb": "uz", "kaz": "kz", "kgz": "kg", "tjk": "tj", "tkm": "tm",
+}
+
+// NormalizeCountry maps an ATS-supplied ISO 3166-1 country code — alpha-2 or alpha-3, in
+// any case — to freehire's canonical lowercase alpha-2 code. It returns "" for a code
+// outside the curated country set Parse itself resolves (countryToRegion): the same
+// never-guess contract, so a country this package cannot place on the region map is left
+// for the location/description dictionaries to fill instead of being recorded ungrouped.
+func NormalizeCountry(code string) string {
+	c := strings.ToLower(strings.TrimSpace(code))
+	if _, ok := countryToRegion[c]; ok {
+		return c
+	}
+	if a2, ok := alpha3ToAlpha2[c]; ok {
+		return a2
+	}
+	return ""
+}

--- a/internal/location/country_test.go
+++ b/internal/location/country_test.go
@@ -1,0 +1,27 @@
+package location
+
+import "testing"
+
+func TestNormalizeCountry(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"alpha-2 lowercase", "ae", "ae"},
+		{"alpha-2 uppercase (Lever/Workday style)", "AE", "ae"},
+		{"alpha-3 uppercase (Ashby style)", "USA", "us"},
+		{"alpha-3 lowercase", "deu", "de"},
+		{"padded", "  gb  ", "gb"},
+		{"empty", "", ""},
+		{"country outside the curated region set", "AFG", ""},
+		{"garbage", "not-a-code", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeCountry(tc.in); got != tc.want {
+				t.Errorf("NormalizeCountry(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -609,6 +609,7 @@ func normalizeJob(e sources.CompanyEntry, j sources.Job) (job.Job, error) {
 			Location:           j.Location,
 			Description:        j.Description,
 			WorkMode:           j.WorkMode,
+			Countries:          j.Countries,
 			Seniority:          j.Seniority,
 			Category:           j.Category,
 			EmploymentType:     j.EmploymentType,

--- a/internal/sources/ashby.go
+++ b/internal/sources/ashby.go
@@ -51,6 +51,11 @@ type AshbyPosting struct {
 	IsRemote        bool   `json:"isRemote"`
 	WorkplaceType   string `json:"workplaceType"`
 	EmploymentType  string `json:"employmentType"`
+	Address         struct {
+		PostalAddress struct {
+			AddressCountry string `json:"addressCountry"`
+		} `json:"postalAddress"`
+	} `json:"address"`
 }
 
 // MapAshbyPosting maps an Ashby API posting into a Job, so the board adapter and the
@@ -72,6 +77,7 @@ func MapAshbyPosting(j AshbyPosting) Job {
 		Description:    sanitizeHTML(j.DescriptionHTML),
 		Remote:         mode == "remote" || isRemote(j.Location),
 		WorkMode:       mode,
+		Countries:      countryFromCode(j.Address.PostalAddress.AddressCountry),
 		PostedAt:       parseRFC3339(j.PublishedAt),
 		EmploymentType: ashbyEmploymentType(j.EmploymentType),
 	}

--- a/internal/sources/ashby_test.go
+++ b/internal/sources/ashby_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -114,5 +115,54 @@ func TestAshbyFetchWorkplaceTypeBeatsIsRemote(t *testing.T) {
 	// text carries no "remote" to trigger the heuristic either.
 	if j.Remote {
 		t.Error("Remote = true, want false: a hybrid role is not remote")
+	}
+}
+
+// Ashby states the country as an alpha-3 code under address.postalAddress.addressCountry
+// — a structured field the location string ("New York, NY (HQ)") does not spell out.
+func TestAshbyFetchDecodesStructuredCountry(t *testing.T) {
+	fake := &fakeHTTP{body: `{
+		"jobs": [
+			{
+				"id": "ny-uuid",
+				"title": "Backend Engineer",
+				"location": "New York, NY (HQ)",
+				"jobUrl": "https://jobs.ashbyhq.com/ramp/ny-uuid",
+				"address": {"postalAddress": {"addressRegion": "NY", "addressCountry": "USA"}}
+			}
+		]
+	}`}
+
+	jobs, err := NewAshby(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Ramp", Provider: "ashby", Board: "ramp",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if got, want := jobs[0].Countries, []string{"us"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Countries = %v, want %v (normalized from the alpha-3 addressCountry)", got, want)
+	}
+}
+
+// A posting whose address carries no addressCountry (most non-US boards) leaves
+// Countries nil rather than guessing from the free-text location.
+func TestAshbyFetchNoAddressLeavesCountriesEmpty(t *testing.T) {
+	fake := &fakeHTTP{body: `{
+		"jobs": [
+			{"id": "no-addr", "title": "Support Engineer", "location": "Remote"}
+		]
+	}`}
+
+	jobs, err := NewAshby(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "ashby", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := jobs[0].Countries; got != nil {
+		t.Errorf("Countries = %v, want nil", got)
 	}
 }

--- a/internal/sources/helpers.go
+++ b/internal/sources/helpers.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/strelov1/freehire/internal/location"
 )
 
 // defaultDetailWorkers bounds the per-board detail-fetch fan-out for adapters whose
@@ -119,6 +121,18 @@ func workplaceTypeMode(t string) string {
 	default:
 		return ""
 	}
+}
+
+// countryFromCode normalizes an ATS-supplied country code (Lever/Workday alpha-2, Ashby
+// alpha-3) into the []string Job.Countries expects, via location.NormalizeCountry.
+// Returns nil for an empty or unresolved code — never a one-element slice holding "" —
+// so an adapter can wire it straight into Job.Countries without an extra empty check.
+func countryFromCode(code string) []string {
+	c := location.NormalizeCountry(code)
+	if c == "" {
+		return nil
+	}
+	return []string{c}
 }
 
 // distinctJoin maps each item to a label, drops blank and duplicate labels (keeping first-seen

--- a/internal/sources/helpers_test.go
+++ b/internal/sources/helpers_test.go
@@ -4,10 +4,33 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"reflect"
 	"strings"
+	"testing"
 
 	"golang.org/x/net/html"
 )
+
+func TestCountryFromCode(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"alpha-2 lowercase", "ae", []string{"ae"}},
+		{"alpha-2 uppercase", "AE", []string{"ae"}},
+		{"alpha-3 as Ashby sends it", "USA", []string{"us"}},
+		{"empty", "", nil},
+		{"unresolved code outside the curated set", "ZZZ", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countryFromCode(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("countryFromCode(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
 
 // fakeHTTP is a test HTTPClient: it records the requested URL and decodes a canned
 // body, so adapter tests exercise field mapping without the network. Shared by every

--- a/internal/sources/lever.go
+++ b/internal/sources/lever.go
@@ -41,6 +41,7 @@ func (l lever) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		Description   string `json:"description"`
 		Additional    string `json:"additional"`
 		WorkplaceType string `json:"workplaceType"`
+		Country       string `json:"country"`
 		Lists         []struct {
 			Text    string `json:"text"`
 			Content string `json:"content"`
@@ -80,6 +81,7 @@ func (l lever) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Description:    sanitizeHTML(body.String()),
 			Remote:         isRemote(p.Categories.Location),
 			WorkMode:       workplaceTypeMode(p.WorkplaceType),
+			Countries:      countryFromCode(p.Country),
 			PostedAt:       parseEpochMillis(p.CreatedAt),
 			EmploymentType: leverEmploymentType(p.Categories.Commitment),
 		})

--- a/internal/sources/lever_test.go
+++ b/internal/sources/lever_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -69,6 +70,32 @@ func TestLeverFetch(t *testing.T) {
 	}
 	if got := j.PostedAt.UTC().Year(); got != 2024 {
 		t.Errorf("PostedAt year = %d, want 2024", got)
+	}
+}
+
+// Lever states the country as its own field ("AE") separate from the free-text
+// categories.location ("UAE"), which the location dictionary would have to recognize
+// as a name rather than just reading off the code.
+func TestLeverFetchDecodesStructuredCountry(t *testing.T) {
+	fake := &fakeHTTP{body: `[
+		{
+			"id": "uae-1",
+			"text": "Ops Manager",
+			"hostedUrl": "https://jobs.lever.co/1inch/uae-1",
+			"categories": {"location": "UAE"},
+			"country": "AE",
+			"description": "<p>Run ops.</p>"
+		}
+	]`}
+
+	jobs, err := NewLever(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "1inch", Provider: "lever", Board: "1inch",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got, want := jobs[0].Countries, []string{"ae"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Countries = %v, want %v (normalized from the country field)", got, want)
 	}
 }
 

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -58,6 +58,14 @@ type Job struct {
 	EmploymentType     string
 	Skills             []string
 	ExperienceYearsMin *int
+	// Countries mirrors the same contract for geography: an adapter sets it only when
+	// the platform states the country in a STRUCTURED field (not the free-text location
+	// the description/location string carries), normalized through
+	// internal/location.NormalizeCountry into freehire's canonical lowercase alpha-2
+	// codes. Left nil for adapters that expose only free-text location, so the
+	// pipeline's location dictionary derives it instead — the same fallback WorkMode
+	// and the other structured facets already follow.
+	Countries []string
 	// Removed marks a posting the source reports as taken down (e.g. an item flagged
 	// removed in JobStream's incremental feed). A streaming, self-closing source emits
 	// these so the pipeline closes the job by identity instead of upserting it; all other

--- a/internal/sources/workday.go
+++ b/internal/sources/workday.go
@@ -183,13 +183,18 @@ func (s workday) detail(ctx context.Context, e CompanyEntry, b workdayBoard, p w
 
 	var d struct {
 		JobPostingInfo struct {
-			Title          string `json:"title"`
-			JobDescription string `json:"jobDescription"`
-			Location       string `json:"location"`
-			StartDate      string `json:"startDate"`
-			ExternalURL    string `json:"externalUrl"`
-			RemoteType     string `json:"remoteType"`
-			TimeType       string `json:"timeType"`
+			Title                  string `json:"title"`
+			JobDescription         string `json:"jobDescription"`
+			Location               string `json:"location"`
+			StartDate              string `json:"startDate"`
+			ExternalURL            string `json:"externalUrl"`
+			RemoteType             string `json:"remoteType"`
+			TimeType               string `json:"timeType"`
+			JobRequisitionLocation struct {
+				Country struct {
+					Alpha2Code string `json:"alpha2Code"`
+				} `json:"country"`
+			} `json:"jobRequisitionLocation"`
 		} `json:"jobPostingInfo"`
 	}
 	if err := s.http.GetJSON(ctx, url, &d); err != nil {
@@ -213,6 +218,7 @@ func (s workday) detail(ctx context.Context, e CompanyEntry, b workdayBoard, p w
 		Location:    location,
 		Description: sanitizeHTML(info.JobDescription),
 		Remote:      remote,
+		Countries:   countryFromCode(info.JobRequisitionLocation.Country.Alpha2Code),
 		PostedAt:    parseWorkdayDate(info.StartDate),
 		// timeType is Workday's structured full/part-time enum; the pipeline prefers it
 		// over the free-text employment-type parse. Workday's timeType only distinguishes

--- a/internal/sources/workday_test.go
+++ b/internal/sources/workday_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -42,7 +43,8 @@ func TestWorkdayFetchListsAndFetchesDetail(t *testing.T) {
 			"startDate": "2024-06-11",
 			"externalUrl": "https://acme.wd1.myworkdayjobs.com/en-US/Careers/job/Berlin/Backend_JR-1",
 			"remoteType": "On-site",
-			"timeType": "Full time"
+			"timeType": "Full time",
+			"jobRequisitionLocation": {"country": {"descriptor": "Germany", "alpha2Code": "DE"}}
 		}}`).
 		route("Data_JR-2", `{"jobPostingInfo": {
 			"title": "Data Engineer",
@@ -92,10 +94,17 @@ func TestWorkdayFetchListsAndFetchesDetail(t *testing.T) {
 	if j.EmploymentType != "full_time" {
 		t.Errorf("EmploymentType = %q, want full_time (from timeType)", j.EmploymentType)
 	}
+	if got, want := j.Countries, []string{"de"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Countries = %v, want %v (normalized from jobRequisitionLocation.country.alpha2Code)", got, want)
+	}
 
 	d := byID["/job/Remote/Data_JR-2"]
 	if !d.Remote {
 		t.Error("Remote = false, want true from remoteType")
+	}
+	// This posting's detail carries no jobRequisitionLocation at all.
+	if d.Countries != nil {
+		t.Errorf("Countries = %v, want nil when the detail states no country", d.Countries)
 	}
 	if d.URL != "https://acme.wd1.myworkdayjobs.com/Careers/job/Remote/Data_JR-2" {
 		t.Errorf("URL = %q, want the path constructed from host+site when externalUrl is absent", d.URL)


### PR DESCRIPTION
## Summary
- Ashby, Lever and Workday each state a posting's country in a structured field the adapter is already parsing, but none of the three decoded it — country was left entirely to the location dictionary's free-text guess, which misses on 13-19% of postings per source (~23k live jobs unfilterable by country today).
- Adds `sources.Job.Countries`, following the same "structured signal, precedence over the dictionary" contract as `WorkMode`/`Seniority`/etc.
- Adds `location.NormalizeCountry` to fold Ashby's alpha-3 codes and Lever/Workday's alpha-2 codes onto freehire's canonical country set (never guesses outside the curated ~133-country set).
- Wires the new field through `jobderive.Derive`: an explicit country overrides the dictionary-derived one and also pairs its region, so a structured-country job doesn't lose the region facet.
- Greenhouse's own 11.8% country-miss rate is out of scope — it has no country field, only `offices[]`, a different signal.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...`
- [x] New unit tests: adapter-level country decoding (Ashby/Lever/Workday), `location.NormalizeCountry`, and `jobderive.Derive` precedence (explicit country beats dictionary, region pairing, explicit region still wins over the paired one)