### PR TITLE
Add aijobs.net ingest adapter

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -398,45 +399,93 @@ type realityLookup func(companySlug, fingerprint string) (repost, mass int)
 // lookup skips widening entirely (tests that do not exercise clustering).
 type clusterGeoLookup func(companySlug, fingerprint string) (countries, regions, cities []string)
 
-// recomputeRoleDuplicates refreshes jobs.duplicate_of one company at a time, returning
-// the total rows re-marked. Scoping each UPDATE to a single company keeps its lock
-// window to that company's rows for a moment, so the pass never holds the table-wide
-// lock that would stall concurrent ingest crawls. Best-effort like every per-company
-// pass here (see forEachCompany).
+// companyBatchSize bounds how many companies one RecomputeRoleDuplicatesForCompanies /
+// SuppressAggregatorDuplicatesForCompanies call covers. Measured on prod (2026-08-06):
+// one round trip per company — 236,923 distinct open companies, 94,410 of them with an
+// open aggregator posting — made the aggregator-suppression pass alone run for hours
+// under ordinary host load and get stuck (systemd auto-restarted it, redoing the same
+// hours of work) with the reindex never reaching the point of actually pushing to
+// Meili. 500 keeps each statement's WHERE ... = ANY(...) small enough to stay a cheap
+// index probe (see migration 0076's functional index) while cutting round trips by
+// ~500x; it is not tuned beyond "clearly fixes the incident," so revisit if a future
+// measurement suggests a better number.
+const companyBatchSize = 500
+
+// recomputeRoleDuplicates refreshes jobs.duplicate_of in batches of companies,
+// returning the total rows re-marked. Batching (not one UPDATE per company, and not one
+// UPDATE for the whole catalogue) balances two costs: an unbatched per-company call
+// pays a full network/planning round trip per company (see companyBatchSize), while a
+// single whole-catalogue UPDATE would hold its lock window across the entire jobs
+// table instead of one bounded slice at a time, risking a stall of concurrent ingest
+// writes. Best-effort like every batch here (see forCompanyBatches).
 func recomputeRoleDuplicates(ctx context.Context, q *db.Queries) (int64, error) {
 	companies, err := q.CompaniesWithRoleClusters(ctx)
 	if err != nil {
 		return 0, err
 	}
-	return forEachCompany(ctx, companies, q.RecomputeRoleDuplicatesForCompany)
+	return forCompanyBatches(ctx, companies, q.RecomputeRoleDuplicatesForCompanies)
 }
 
 // suppressAggregatorDuplicates marks each open aggregator posting that duplicates a
 // first-party ATS posting (same company, normalized title, compatible country) as a
-// duplicate of that ATS row, one company at a time. Returns the total rows re-marked.
-// The aggregator set comes from the taxonomy registry's aggregator() markers, so it is the
-// same set here as on the ingest host: a keyed adapter whose credential lives only where the
-// crawl runs must still be classified, or its copies of an ATS posting go unsuppressed.
-// Best-effort and lock-scoped exactly like recomputeRoleDuplicates.
+// duplicate of that ATS row, processed in batches of companies. Returns the total rows
+// re-marked. The aggregator set comes from the taxonomy registry's aggregator()
+// markers, so it is the same set here as on the ingest host: a keyed adapter whose
+// credential lives only where the crawl runs must still be classified, or its copies of
+// an ATS posting go unsuppressed. Best-effort and lock-scoped exactly like
+// recomputeRoleDuplicates.
 func suppressAggregatorDuplicates(ctx context.Context, q *db.Queries) (int64, error) {
 	aggregators := sources.AggregatorProviders(sources.Taxonomy())
 	companies, err := q.CompaniesWithAggregatorPostings(ctx, aggregators)
 	if err != nil {
 		return 0, err
 	}
-	return forEachCompany(ctx, companies, func(ctx context.Context, c string) (int64, error) {
-		return q.SuppressAggregatorDuplicatesForCompany(ctx, db.SuppressAggregatorDuplicatesForCompanyParams{
-			Company:     c,
+	return forCompanyBatches(ctx, companies, func(ctx context.Context, batch []string) (int64, error) {
+		return q.SuppressAggregatorDuplicatesForCompanies(ctx, db.SuppressAggregatorDuplicatesForCompaniesParams{
+			Companies:   batch,
 			Aggregators: aggregators,
 		})
 	})
 }
 
+// forCompanyBatches runs fn once per companyBatchSize-sized slice of companies, summing
+// the rows it reports re-marked. Batches are independent, so one failure (e.g. a
+// statement timeout on an unusually large batch) must not starve the rest — it is
+// counted and skipped, and any failure turns the pass's result into an aggregate error
+// (the caller treats the whole pass as best-effort and continues with the prior
+// markers). This is coarser fault isolation than the one-call-per-company version it
+// replaced (a bad batch now costs up to companyBatchSize companies their update, not
+// just one), a deliberate trade against the hours a full per-company loop cost at
+// catalogue scale — see companyBatchSize.
+func forCompanyBatches(ctx context.Context, companies []string, fn func(context.Context, []string) (int64, error)) (int64, error) {
+	var total int64
+	var failures int
+	var lastErr error
+	for batch := range slices.Chunk(companies, companyBatchSize) {
+		n, err := fn(ctx, batch)
+		if err != nil {
+			failures++
+			lastErr = fmt.Errorf("batch of %d companies (starting %q): %w", len(batch), batch[0], err)
+			continue
+		}
+		total += n
+	}
+	if failures > 0 {
+		return total, fmt.Errorf("%d batches failed out of %d companies (batch size %d); last: %w",
+			failures, len(companies), companyBatchSize, lastErr)
+	}
+	return total, nil
+}
+
 // forEachCompany runs fn once per company, summing the rows it reports re-marked.
-// Companies are independent, so one failure (e.g. a statement timeout on an unusually
-// large cluster) must not starve the rest — it is counted and skipped, and any failure
-// turns the pass's result into an aggregate error (the caller treats the whole pass as
-// best-effort and continues with the prior markers).
+// Companies are independent, so one failure must not starve the rest — it is counted
+// and skipped, and any failure turns the pass's result into an aggregate error (the
+// caller treats the whole pass as best-effort and continues with the prior markers).
+// Unlike forCompanyBatches, this stays one-at-a-time: its only caller
+// (collapseFuzzyDuplicates, cmd/reindex/fuzzy.go) does real per-company work in Go —
+// fetching titles and descriptions, then fuzzy-comparing them in memory — not a single
+// set-based SQL statement, so there is no query to batch the way the two SQL-only
+// passes were.
 func forEachCompany(ctx context.Context, companies []string, fn func(context.Context, string) (int64, error)) (int64, error) {
 	var total int64
 	var failures int

--- a/internal/db/aggregator_dedup_integration_test.go
+++ b/internal/db/aggregator_dedup_integration_test.go
@@ -36,7 +36,8 @@ func aggJob(externalID, title string, countries []string) UpsertJobParams {
 	return p
 }
 
-// suppressAggregators drives the pass per company, as cmd/ingest does.
+// suppressAggregators drives the pass in one batched call across every candidate
+// company, as cmd/reindex does.
 func suppressAggregators(t *testing.T, q *Queries) {
 	t.Helper()
 	ctx := context.Background()
@@ -44,13 +45,14 @@ func suppressAggregators(t *testing.T, q *Queries) {
 	if err != nil {
 		t.Fatalf("companies with aggregator postings: %v", err)
 	}
-	for _, c := range companies {
-		if _, err := q.SuppressAggregatorDuplicatesForCompany(ctx, SuppressAggregatorDuplicatesForCompanyParams{
-			Company:     c,
-			Aggregators: aggregators,
-		}); err != nil {
-			t.Fatalf("suppress company %q: %v", c, err)
-		}
+	if len(companies) == 0 {
+		return
+	}
+	if _, err := q.SuppressAggregatorDuplicatesForCompanies(ctx, SuppressAggregatorDuplicatesForCompaniesParams{
+		Companies:   companies,
+		Aggregators: aggregators,
+	}); err != nil {
+		t.Fatalf("suppress companies %v: %v", companies, err)
 	}
 }
 
@@ -234,6 +236,53 @@ func TestSuppressedAggregator_HiddenFromListAndEnrichmentButServedBySlug(t *test
 	// The suppressed copy is still fetchable by its public slug (direct link).
 	if _, err := q.GetJobBySlug(ctx, "pslug-acme:agg"); err != nil {
 		t.Errorf("GetJobBySlug for suppressed aggregator: %v", err)
+	}
+}
+
+// TestSuppressAggregator_BatchedCallDoesNotCrossCompanies is the regression this batch
+// rewrite exists to guard: SuppressAggregatorDuplicatesForCompanies processes many
+// companies in ONE call (cmd/reindex's forCompanyBatches, added after a 2026-08-06 prod
+// incident where one round trip per company made this pass run for hours). Unlike
+// RecomputeRoleDuplicatesForCompanies, title matching has no company-scoped key baked
+// in, so two different companies sharing an identical role title MUST NOT cross-match
+// just because a batch call happens to cover both at once — each must resolve to its
+// OWN company's ATS twin.
+func TestSuppressAggregator_BatchedCallDoesNotCrossCompanies(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	widgetco := func(externalID, source, title string) UpsertJobParams {
+		p := ingestParams(externalID, title)
+		p.Company = "Widget Co"
+		p.CompanySlug = "widget-co"
+		p.Source = source
+		return p
+	}
+
+	// Both companies post the identical title through both an ATS and an aggregator —
+	// the exact shape that would cross-match if the batch query lost the company key.
+	mustUpsert(t, q, atsJob("acme:ats", "Backend Engineer", nil))
+	mustUpsert(t, q, aggJob("acme:agg", "Backend Engineer", nil))
+	mustUpsert(t, q, widgetco("widgetco:ats", "greenhouse", "Backend Engineer"))
+	mustUpsert(t, q, widgetco("widgetco:agg", "himalayas", "Backend Engineer"))
+
+	suppressAggregators(t, q) // one batched call covering both companies
+
+	acmeATS, _ := dupOf(t, pool, "acme:ats")
+	widgetATS, _ := dupOf(t, pool, "widgetco:ats")
+	_, acmeAggDup := dupOf(t, pool, "acme:agg")
+	_, widgetAggDup := dupOf(t, pool, "widgetco:agg")
+
+	if acmeAggDup != acmeATS {
+		t.Errorf("acme aggregator duplicate_of = %d, want its own ATS twin %d", acmeAggDup, acmeATS)
+	}
+	if widgetAggDup != widgetATS {
+		t.Errorf("widgetco aggregator duplicate_of = %d, want its own ATS twin %d", widgetAggDup, widgetATS)
+	}
+	if acmeAggDup == widgetATS || widgetAggDup == acmeATS {
+		t.Fatalf("cross-company match: acme->%d widgetco->%d, want each pinned to its own company's ATS row",
+			acmeAggDup, widgetAggDup)
 	}
 }
 

--- a/internal/db/canonical_job_for_role_integration_test.go
+++ b/internal/db/canonical_job_for_role_integration_test.go
@@ -71,7 +71,7 @@ func TestCanonicalJobForRole(t *testing.T) {
 	})
 
 	t.Run("the oldest eligible posting wins", func(t *testing.T) {
-		// The canon choice has to agree with RecomputeRoleDuplicatesForCompany, which takes the
+		// The canon choice has to agree with RecomputeRoleDuplicatesForCompanies, which takes the
 		// cluster's MIN(id). A later-seeded, equally eligible row must not win.
 		seed(t, "lever", "acme:2", "senior-go-acme-3", "fp-go", false)
 		row, err := q.CanonicalJobForRole(ctx, CanonicalJobForRoleParams{

--- a/internal/db/job_duplicate_of_integration_test.go
+++ b/internal/db/job_duplicate_of_integration_test.go
@@ -1,11 +1,11 @@
 //go:build integration
 
-// Integration tests for the role-duplicate recompute: driven per company
-// (CompaniesWithRoleClusters + RecomputeRoleDuplicatesForCompany, as the reindex does),
-// it collapses each role cluster (company_slug + role_fingerprint) to one canonical open
-// job (min(id)), pointing the other open reposts at it via duplicate_of, while leaving
-// singletons and unfingerprinted rows canonical. Canon failover on close and the min(id)
-// tie-break are SQL behaviors verifiable only against a real Postgres.
+// Integration tests for the role-duplicate recompute: driven over batches of companies
+// (CompaniesWithRoleClusters + RecomputeRoleDuplicatesForCompanies, as the reindex
+// does), it collapses each role cluster (company_slug + role_fingerprint) to one
+// canonical open job (min(id)), pointing the other open reposts at it via duplicate_of,
+// while leaving singletons and unfingerprinted rows canonical. Canon failover on close
+// and the min(id) tie-break are SQL behaviors verifiable only against a real Postgres.
 // Run with: go test -tags=integration ./internal/db/
 package db
 
@@ -18,17 +18,18 @@ import (
 )
 
 // recomputeDuplicates runs the batched recompute exactly as the reindex does: fetch the
-// companies needing work, then recompute each in its own short transaction.
+// companies needing work, then recompute them in one batched call.
 func recomputeDuplicates(t *testing.T, q *Queries) {
 	t.Helper()
 	companies, err := q.CompaniesWithRoleClusters(context.Background())
 	if err != nil {
 		t.Fatalf("companies with clusters: %v", err)
 	}
-	for _, c := range companies {
-		if _, err := q.RecomputeRoleDuplicatesForCompany(context.Background(), c); err != nil {
-			t.Fatalf("recompute company %q: %v", c, err)
-		}
+	if len(companies) == 0 {
+		return
+	}
+	if _, err := q.RecomputeRoleDuplicatesForCompanies(context.Background(), companies); err != nil {
+		t.Fatalf("recompute companies %v: %v", companies, err)
 	}
 }
 

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -223,8 +223,8 @@ WHERE closed_at IS NULL AND company_slug <> ''
 // Company slugs with at least one OPEN aggregator posting — the drive list for the
 // cross-source aggregator suppression pass. An open aggregator row is a candidate whether
 // it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
-// covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
-// mirroring the role-duplicate recompute's lock discipline.
+// covers both. Processed in chunks (SuppressAggregatorDuplicatesForCompanies), mirroring
+// the role-duplicate recompute's batching.
 func (q *Queries) CompaniesWithAggregatorPostings(ctx context.Context, aggregators []string) ([]string, error) {
 	rows, err := q.db.Query(ctx, companiesWithAggregatorPostings, aggregators)
 	if err != nil {
@@ -1925,11 +1925,11 @@ func (q *Queries) PropagateCollectionsToJobs(ctx context.Context) (int64, error)
 	return result.RowsAffected(), nil
 }
 
-const recomputeRoleDuplicatesForCompany = `-- name: RecomputeRoleDuplicatesForCompany :execrows
+const recomputeRoleDuplicatesForCompanies = `-- name: RecomputeRoleDuplicatesForCompanies :execrows
 WITH canon AS (
     SELECT jobs.role_fingerprint, MIN(jobs.id) AS canon_id, COUNT(*) AS n
     FROM jobs
-    WHERE jobs.company_slug = $1
+    WHERE jobs.company_slug = ANY($1::text[])
       AND jobs.closed_at IS NULL AND jobs.role_fingerprint IS NOT NULL AND jobs.role_fingerprint <> ''
     GROUP BY jobs.role_fingerprint
 ),
@@ -1938,7 +1938,7 @@ target AS (
         CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
     FROM jobs j
     JOIN canon c ON j.role_fingerprint = c.role_fingerprint
-    WHERE j.company_slug = $1 AND j.closed_at IS NULL
+    WHERE j.company_slug = ANY($1::text[]) AND j.closed_at IS NULL
 )
 UPDATE jobs j
 SET duplicate_of = t.new_dup,
@@ -1948,15 +1948,24 @@ WHERE j.id = t.id
   AND j.duplicate_of IS DISTINCT FROM t.new_dup
 `
 
-// The per-company slice of the role-duplicate recompute. Canon = min(id) among the
-// company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
-// row get duplicate_of NULL, the other reposts point to the canon. Rows are never
-// deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
-// only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
-// aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
-// idempotent, and a closed canon fails over to the next min(id) on the next run.
-func (q *Queries) RecomputeRoleDuplicatesForCompany(ctx context.Context, company string) (int64, error) {
-	result, err := q.db.Exec(ctx, recomputeRoleDuplicatesForCompany, company)
+// The batched slice of the role-duplicate recompute, driven over a CHUNK of companies
+// (cmd/reindex's forCompanyBatches) rather than one call per company — see that
+// function's doc comment for why: at catalogue scale (2026-08-06 prod measurement:
+// 236,923 distinct open companies) one round trip per company made this pass take
+// hours under ordinary host load, most of it network/planning overhead rather than
+// query cost. Batching multiple companies into ONE statement is safe here without any
+// extra cross-company guard: role_fingerprint is sha256(company_slug, title,
+// description) (internal/jobhash.RoleFingerprint) with company_slug as its FIRST
+// component, so a fingerprint collision between two different companies is not a
+// realistic concern — grouping by role_fingerprint alone, across the whole batch,
+// cannot merge two different companies' rows. Canon = min(id) among a role's open rows;
+// the canon and any singleton/empty-fp row get duplicate_of NULL, the other reposts
+// point to the canon. Rows are never deleted, so the reality counts are untouched. The
+// (company_slug, role_fingerprint) index makes both scans range scans over the batch.
+// The IS DISTINCT FROM guard makes re-runs cheap and idempotent, and a closed canon
+// fails over to the next min(id) on the next run.
+func (q *Queries) RecomputeRoleDuplicatesForCompanies(ctx context.Context, companies []string) (int64, error) {
+	result, err := q.db.Exec(ctx, recomputeRoleDuplicatesForCompanies, companies)
 	if err != nil {
 		return 0, err
 	}
@@ -2412,9 +2421,10 @@ func (q *Queries) SetJobEnrichment(ctx context.Context, arg SetJobEnrichmentPara
 	return err
 }
 
-const suppressAggregatorDuplicatesForCompany = `-- name: SuppressAggregatorDuplicatesForCompany :execrows
+const suppressAggregatorDuplicatesForCompanies = `-- name: SuppressAggregatorDuplicatesForCompanies :execrows
 WITH ats AS (
     SELECT jobs.id,
+           replace(jobs.company_slug, '-', '') AS fcompany,
            btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
@@ -2425,12 +2435,14 @@ WITH ats AS (
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            jobs.countries
     FROM jobs
-    WHERE replace(jobs.company_slug, '-', '') = replace($1::text, '-', '')
+    WHERE replace(jobs.company_slug, '-', '') = ANY(
+              SELECT replace(c, '-', '') FROM unnest($1::text[]) AS c)
       AND jobs.closed_at IS NULL AND jobs.duplicate_of IS NULL AND jobs.company_slug <> ''
       AND NOT (jobs.source = ANY($2::text[]))
 ),
 agg AS (
     SELECT a.id,
+           replace(a.company_slug, '-', '') AS fcompany,
            btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
@@ -2441,7 +2453,8 @@ agg AS (
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            a.countries
     FROM jobs a
-    WHERE replace(a.company_slug, '-', '') = replace($1::text, '-', '')
+    WHERE replace(a.company_slug, '-', '') = ANY(
+              SELECT replace(c, '-', '') FROM unnest($1::text[]) AS c)
       AND a.closed_at IS NULL AND a.company_slug <> ''
       AND a.source = ANY($2::text[])
       AND (
@@ -2461,32 +2474,38 @@ matches AS (
     -- the way. Only those two clauses are decoration: measured on prod, also stripping a
     -- parenthetical produced 39 wrong pairs out of 55 — one company's "…, Backend (Traffic)"
     -- matching its "(Payments)", "(Identity)" and "(Infrastructure)" roles — and a comma clause
-    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE single-equality hash join (O(agg + ats))
-    -- and the two are UNION ALL-ed — an OR of the two equalities in one ON would defeat the
-    -- hash join and go quadratic on a big company (the hotel-chain case). UNION ALL, not
-    -- UNION: a row matched by both paths appears twice, but the downstream MIN(ats_id)
-    -- absorbs the duplicate, so the de-dup pass is wasted work. Both require a non-empty key;
-    -- the country gate applies to each path.
+    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE
+    -- equality hash join (now on (fcompany, ntitle) / (fcompany, ntitle2), still
+    -- O(agg + ats)) and the two are UNION ALL-ed — an OR of the two equalities in one ON
+    -- would defeat the hash join and go quadratic on a big company (the hotel-chain
+    -- case). UNION ALL, not UNION: a row matched by both paths appears twice, but the
+    -- downstream MIN(ats_id) absorbs the duplicate, so the de-dup pass is wasted work.
+    -- Both require a non-empty key; the country gate applies to each path.
     SELECT a.id AS agg_id, t.id AS ats_id
     FROM agg a JOIN ats t
-      ON t.ntitle = a.ntitle AND a.ntitle <> ''
+      ON t.fcompany = a.fcompany
+     AND t.ntitle = a.ntitle AND a.ntitle <> ''
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
     UNION ALL
     SELECT a.id, t.id
     FROM agg a JOIN ats t
-      ON t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
+      ON t.fcompany = a.fcompany
+     AND t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
     UNION ALL
     -- Third path: word-subset containment — the aggregator dropped words the ATS keeps (a
     -- mid-title drop the two equality keys miss). This arm is a nested loop (no hash on <@),
-    -- but runs only on the residual after the equality arms and is bounded per company.
+    -- but runs only on the residual after the equality arms and is bounded per company via
+    -- the fcompany equality (planned as a hash/merge join on fcompany, nested-looping only
+    -- within each matching group — the same cost shape the old single-company call had).
     -- Guards against over-merge: the aggregator title needs >= 2 words, and the words the ATS
     -- adds over it must include at least one NON-seniority word — so "Software Engineer" is not
     -- merged into "Senior Software Engineer" (a distinct grade), only into a title that adds a
     -- real specialty/location/department word the aggregator dropped.
     SELECT a.id, t.id
     FROM agg a JOIN ats t
-      ON string_to_array(a.ntitle, ' ') <@ string_to_array(t.ntitle, ' ')
+      ON t.fcompany = a.fcompany
+     AND string_to_array(a.ntitle, ' ') <@ string_to_array(t.ntitle, ' ')
      AND array_length(string_to_array(a.ntitle, ' '), 1) >= 2
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
      AND EXISTS (
@@ -2514,28 +2533,38 @@ WHERE j.id = t.id
   AND j.duplicate_of IS DISTINCT FROM t.new_dup
 `
 
-type SuppressAggregatorDuplicatesForCompanyParams struct {
-	Company     string   `json:"company"`
+type SuppressAggregatorDuplicatesForCompaniesParams struct {
+	Companies   []string `json:"companies"`
 	Aggregators []string `json:"aggregators"`
 }
 
-// The per-company slice of the cross-source aggregator suppression. An open aggregator
-// posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
-// same company, equal normalized title, and compatible country (countries overlap, or
-// either side empty — the geography dictionary is sparse, so an unresolved side must not
-// veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
-// are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
-// by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
-// left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
-// its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
-// target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
-// RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
-// Company match folds away word-separator spelling variance between sources: company_slug
-// is normalize.Slug(name), which never strips legal suffixes, so two sources naming the
-// same employer with a different word break ("Cfoinsights" vs "CFO Insights") land on
-// different slugs ("cfoinsights" vs "cfo-insights") that agree once hyphens are removed.
-func (q *Queries) SuppressAggregatorDuplicatesForCompany(ctx context.Context, arg SuppressAggregatorDuplicatesForCompanyParams) (int64, error) {
-	result, err := q.db.Exec(ctx, suppressAggregatorDuplicatesForCompany, arg.Company, arg.Aggregators)
+// The batched slice of the cross-source aggregator suppression, driven over a CHUNK of
+// companies (cmd/reindex's forCompanyBatches) rather than one call per company — see
+// RecomputeRoleDuplicatesForCompanies' doc comment for the prod measurement that
+// motivated batching both passes (94,410 companies with an open aggregator posting;
+// one round trip each made this pass the one that actually got stuck for hours on
+// 2026-08-06). Unlike that query, batching here is NOT free: title matching has no
+// natural company key the way role_fingerprint does, so both CTEs carry an explicit
+// fcompany (folded company) column and every match arm's ON clause pins
+// t.fcompany = a.fcompany — without it, two different companies sharing a common title
+// ("Backend Engineer") would cross-match the moment they land in the same batch.
+// fcompany is the same replace(company_slug, '-', ”) fold PR #1591 introduced (a
+// source spelling one employer "Cfoinsights", another "CFO Insights" — different
+// slugs that must still agree), just computed once per row instead of per query.
+//
+// An open aggregator posting is marked duplicate_of an open CANONICAL ATS
+// (non-aggregator) posting of the same (folded) company, equal normalized title, and
+// compatible country (countries overlap, or either side empty — the geography
+// dictionary is sparse, so an unresolved side must not veto). The ATS row is never
+// touched, so it stays canonical. Candidate aggregator rows are those that are
+// canonical OR already point at a non-aggregator row (i.e. suppressed by THIS pass) —
+// an aggregator repost pointed at another aggregator by the role pass is left alone. A
+// candidate with no ATS twin resolves to NULL, so a closed twin releases its aggregator
+// copy back into search/embedding/enrichment. min(id) picks a stable target; the IS
+// DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+// RecomputeRoleDuplicatesForCompanies so ATS reposts have already collapsed to their canon.
+func (q *Queries) SuppressAggregatorDuplicatesForCompanies(ctx context.Context, arg SuppressAggregatorDuplicatesForCompaniesParams) (int64, error) {
+	result, err := q.db.Exec(ctx, suppressAggregatorDuplicatesForCompanies, arg.Companies, arg.Aggregators)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/pruning_integration_test.go
+++ b/internal/db/pruning_integration_test.go
@@ -462,7 +462,7 @@ func TestPruneJobsCascadesUserInteractions(t *testing.T) {
 	}
 }
 
-// duplicate_of can chain: RecomputeRoleDuplicatesForCompany and the aggregator
+// duplicate_of can chain: RecomputeRoleDuplicatesForCompanies and the aggregator
 // suppression both scope to open jobs, so a closed row's pointer is never repointed
 // when its parent later becomes a duplicate itself. The prune scan reaches closed rows
 // by design, so it meets those chains — and a one-level extension leaves the tail

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -307,8 +307,8 @@ type Querier interface {
 	// Company slugs with at least one OPEN aggregator posting — the drive list for the
 	// cross-source aggregator suppression pass. An open aggregator row is a candidate whether
 	// it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
-	// covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
-	// mirroring the role-duplicate recompute's lock discipline.
+	// covers both. Processed in chunks (SuppressAggregatorDuplicatesForCompanies), mirroring
+	// the role-duplicate recompute's batching.
 	CompaniesWithAggregatorPostings(ctx context.Context, aggregators []string) ([]string, error)
 	// The subset of the given company slugs that are referral-eligible — for annotating a
 	// job/company list in one round-trip instead of a query per row.
@@ -2072,14 +2072,23 @@ type Querier interface {
 	// (AT TIME ZONE 'UTC') so buckets are stable regardless of session timezone. The
 	// FULL OUTER JOIN yields one row per day that saw either an add or a removal.
 	RebuildJobDailyStats(ctx context.Context) (int64, error)
-	// The per-company slice of the role-duplicate recompute. Canon = min(id) among the
-	// company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
-	// row get duplicate_of NULL, the other reposts point to the canon. Rows are never
-	// deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
-	// only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
-	// aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
-	// idempotent, and a closed canon fails over to the next min(id) on the next run.
-	RecomputeRoleDuplicatesForCompany(ctx context.Context, company string) (int64, error)
+	// The batched slice of the role-duplicate recompute, driven over a CHUNK of companies
+	// (cmd/reindex's forCompanyBatches) rather than one call per company — see that
+	// function's doc comment for why: at catalogue scale (2026-08-06 prod measurement:
+	// 236,923 distinct open companies) one round trip per company made this pass take
+	// hours under ordinary host load, most of it network/planning overhead rather than
+	// query cost. Batching multiple companies into ONE statement is safe here without any
+	// extra cross-company guard: role_fingerprint is sha256(company_slug, title,
+	// description) (internal/jobhash.RoleFingerprint) with company_slug as its FIRST
+	// component, so a fingerprint collision between two different companies is not a
+	// realistic concern — grouping by role_fingerprint alone, across the whole batch,
+	// cannot merge two different companies' rows. Canon = min(id) among a role's open rows;
+	// the canon and any singleton/empty-fp row get duplicate_of NULL, the other reposts
+	// point to the canon. Rows are never deleted, so the reality counts are untouched. The
+	// (company_slug, role_fingerprint) index makes both scans range scans over the batch.
+	// The IS DISTINCT FROM guard makes re-runs cheap and idempotent, and a closed canon
+	// fails over to the next min(id) on the next run.
+	RecomputeRoleDuplicatesForCompanies(ctx context.Context, companies []string) (int64, error)
 	// Record that the candidate chased a silent application. Owner-scoped: a foreign or untracked job
 	// matches no row, so the handler 404s and nothing is written. Idempotent by design — a double click
 	// just overwrites the timestamp with a later one rather than erroring.
@@ -2604,22 +2613,32 @@ type Querier interface {
 	// about this application explicitly, suggested_job_id holds one value, and a proposal
 	// nobody has confirmed costs nothing to lose.
 	SuggestJobForEmail(ctx context.Context, arg SuggestJobForEmailParams) (int64, error)
-	// The per-company slice of the cross-source aggregator suppression. An open aggregator
-	// posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
-	// same company, equal normalized title, and compatible country (countries overlap, or
-	// either side empty — the geography dictionary is sparse, so an unresolved side must not
-	// veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
-	// are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
-	// by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
-	// left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
-	// its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
-	// target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
-	// RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
-	// Company match folds away word-separator spelling variance between sources: company_slug
-	// is normalize.Slug(name), which never strips legal suffixes, so two sources naming the
-	// same employer with a different word break ("Cfoinsights" vs "CFO Insights") land on
-	// different slugs ("cfoinsights" vs "cfo-insights") that agree once hyphens are removed.
-	SuppressAggregatorDuplicatesForCompany(ctx context.Context, arg SuppressAggregatorDuplicatesForCompanyParams) (int64, error)
+	// The batched slice of the cross-source aggregator suppression, driven over a CHUNK of
+	// companies (cmd/reindex's forCompanyBatches) rather than one call per company — see
+	// RecomputeRoleDuplicatesForCompanies' doc comment for the prod measurement that
+	// motivated batching both passes (94,410 companies with an open aggregator posting;
+	// one round trip each made this pass the one that actually got stuck for hours on
+	// 2026-08-06). Unlike that query, batching here is NOT free: title matching has no
+	// natural company key the way role_fingerprint does, so both CTEs carry an explicit
+	// fcompany (folded company) column and every match arm's ON clause pins
+	// t.fcompany = a.fcompany — without it, two different companies sharing a common title
+	// ("Backend Engineer") would cross-match the moment they land in the same batch.
+	// fcompany is the same replace(company_slug, '-', '') fold PR #1591 introduced (a
+	// source spelling one employer "Cfoinsights", another "CFO Insights" — different
+	// slugs that must still agree), just computed once per row instead of per query.
+	//
+	// An open aggregator posting is marked duplicate_of an open CANONICAL ATS
+	// (non-aggregator) posting of the same (folded) company, equal normalized title, and
+	// compatible country (countries overlap, or either side empty — the geography
+	// dictionary is sparse, so an unresolved side must not veto). The ATS row is never
+	// touched, so it stays canonical. Candidate aggregator rows are those that are
+	// canonical OR already point at a non-aggregator row (i.e. suppressed by THIS pass) —
+	// an aggregator repost pointed at another aggregator by the role pass is left alone. A
+	// candidate with no ATS twin resolves to NULL, so a closed twin releases its aggregator
+	// copy back into search/embedding/enrichment. min(id) picks a stable target; the IS
+	// DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+	// RecomputeRoleDuplicatesForCompanies so ATS reposts have already collapsed to their canon.
+	SuppressAggregatorDuplicatesForCompanies(ctx context.Context, arg SuppressAggregatorDuplicatesForCompaniesParams) (int64, error)
 	// Rebuild the companies catalogue from jobs. The companies table is derivable
 	// from jobs (slug = company_slug, name = company), so after a slug-builder change
 	// re-keys jobs, this re-keys companies to match. DISTINCT ON collapses a slug's

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -533,18 +533,27 @@ UNION
 SELECT DISTINCT company_slug FROM jobs
 WHERE closed_at IS NULL AND company_slug <> '' AND duplicate_of IS NOT NULL;
 
--- name: RecomputeRoleDuplicatesForCompany :execrows
--- The per-company slice of the role-duplicate recompute. Canon = min(id) among the
--- company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
--- row get duplicate_of NULL, the other reposts point to the canon. Rows are never
--- deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
--- only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
--- aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
--- idempotent, and a closed canon fails over to the next min(id) on the next run.
+-- name: RecomputeRoleDuplicatesForCompanies :execrows
+-- The batched slice of the role-duplicate recompute, driven over a CHUNK of companies
+-- (cmd/reindex's forCompanyBatches) rather than one call per company — see that
+-- function's doc comment for why: at catalogue scale (2026-08-06 prod measurement:
+-- 236,923 distinct open companies) one round trip per company made this pass take
+-- hours under ordinary host load, most of it network/planning overhead rather than
+-- query cost. Batching multiple companies into ONE statement is safe here without any
+-- extra cross-company guard: role_fingerprint is sha256(company_slug, title,
+-- description) (internal/jobhash.RoleFingerprint) with company_slug as its FIRST
+-- component, so a fingerprint collision between two different companies is not a
+-- realistic concern — grouping by role_fingerprint alone, across the whole batch,
+-- cannot merge two different companies' rows. Canon = min(id) among a role's open rows;
+-- the canon and any singleton/empty-fp row get duplicate_of NULL, the other reposts
+-- point to the canon. Rows are never deleted, so the reality counts are untouched. The
+-- (company_slug, role_fingerprint) index makes both scans range scans over the batch.
+-- The IS DISTINCT FROM guard makes re-runs cheap and idempotent, and a closed canon
+-- fails over to the next min(id) on the next run.
 WITH canon AS (
     SELECT jobs.role_fingerprint, MIN(jobs.id) AS canon_id, COUNT(*) AS n
     FROM jobs
-    WHERE jobs.company_slug = sqlc.arg(company)
+    WHERE jobs.company_slug = ANY(sqlc.arg(companies)::text[])
       AND jobs.closed_at IS NULL AND jobs.role_fingerprint IS NOT NULL AND jobs.role_fingerprint <> ''
     GROUP BY jobs.role_fingerprint
 ),
@@ -553,7 +562,7 @@ target AS (
         CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
     FROM jobs j
     JOIN canon c ON j.role_fingerprint = c.role_fingerprint
-    WHERE j.company_slug = sqlc.arg(company) AND j.closed_at IS NULL
+    WHERE j.company_slug = ANY(sqlc.arg(companies)::text[]) AND j.closed_at IS NULL
 )
 UPDATE jobs j
 SET duplicate_of = t.new_dup,
@@ -566,30 +575,41 @@ WHERE j.id = t.id
 -- Company slugs with at least one OPEN aggregator posting — the drive list for the
 -- cross-source aggregator suppression pass. An open aggregator row is a candidate whether
 -- it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
--- covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
--- mirroring the role-duplicate recompute's lock discipline.
+-- covers both. Processed in chunks (SuppressAggregatorDuplicatesForCompanies), mirroring
+-- the role-duplicate recompute's batching.
 SELECT DISTINCT company_slug FROM jobs
 WHERE closed_at IS NULL AND company_slug <> ''
   AND source = ANY(sqlc.arg(aggregators)::text[]);
 
--- name: SuppressAggregatorDuplicatesForCompany :execrows
--- The per-company slice of the cross-source aggregator suppression. An open aggregator
--- posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
--- same company, equal normalized title, and compatible country (countries overlap, or
--- either side empty — the geography dictionary is sparse, so an unresolved side must not
--- veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
--- are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
--- by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
--- left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
--- its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
--- target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
--- RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
--- Company match folds away word-separator spelling variance between sources: company_slug
--- is normalize.Slug(name), which never strips legal suffixes, so two sources naming the
--- same employer with a different word break ("Cfoinsights" vs "CFO Insights") land on
--- different slugs ("cfoinsights" vs "cfo-insights") that agree once hyphens are removed.
+-- name: SuppressAggregatorDuplicatesForCompanies :execrows
+-- The batched slice of the cross-source aggregator suppression, driven over a CHUNK of
+-- companies (cmd/reindex's forCompanyBatches) rather than one call per company — see
+-- RecomputeRoleDuplicatesForCompanies' doc comment for the prod measurement that
+-- motivated batching both passes (94,410 companies with an open aggregator posting;
+-- one round trip each made this pass the one that actually got stuck for hours on
+-- 2026-08-06). Unlike that query, batching here is NOT free: title matching has no
+-- natural company key the way role_fingerprint does, so both CTEs carry an explicit
+-- fcompany (folded company) column and every match arm's ON clause pins
+-- t.fcompany = a.fcompany — without it, two different companies sharing a common title
+-- ("Backend Engineer") would cross-match the moment they land in the same batch.
+-- fcompany is the same replace(company_slug, '-', '') fold PR #1591 introduced (a
+-- source spelling one employer "Cfoinsights", another "CFO Insights" — different
+-- slugs that must still agree), just computed once per row instead of per query.
+--
+-- An open aggregator posting is marked duplicate_of an open CANONICAL ATS
+-- (non-aggregator) posting of the same (folded) company, equal normalized title, and
+-- compatible country (countries overlap, or either side empty — the geography
+-- dictionary is sparse, so an unresolved side must not veto). The ATS row is never
+-- touched, so it stays canonical. Candidate aggregator rows are those that are
+-- canonical OR already point at a non-aggregator row (i.e. suppressed by THIS pass) —
+-- an aggregator repost pointed at another aggregator by the role pass is left alone. A
+-- candidate with no ATS twin resolves to NULL, so a closed twin releases its aggregator
+-- copy back into search/embedding/enrichment. min(id) picks a stable target; the IS
+-- DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+-- RecomputeRoleDuplicatesForCompanies so ATS reposts have already collapsed to their canon.
 WITH ats AS (
     SELECT jobs.id,
+           replace(jobs.company_slug, '-', '') AS fcompany,
            btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
@@ -600,12 +620,14 @@ WITH ats AS (
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            jobs.countries
     FROM jobs
-    WHERE replace(jobs.company_slug, '-', '') = replace(sqlc.arg(company)::text, '-', '')
+    WHERE replace(jobs.company_slug, '-', '') = ANY(
+              SELECT replace(c, '-', '') FROM unnest(sqlc.arg(companies)::text[]) AS c)
       AND jobs.closed_at IS NULL AND jobs.duplicate_of IS NULL AND jobs.company_slug <> ''
       AND NOT (jobs.source = ANY(sqlc.arg(aggregators)::text[]))
 ),
 agg AS (
     SELECT a.id,
+           replace(a.company_slug, '-', '') AS fcompany,
            btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
            btrim(regexp_replace(lower(
              regexp_replace(
@@ -616,7 +638,8 @@ agg AS (
            ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            a.countries
     FROM jobs a
-    WHERE replace(a.company_slug, '-', '') = replace(sqlc.arg(company)::text, '-', '')
+    WHERE replace(a.company_slug, '-', '') = ANY(
+              SELECT replace(c, '-', '') FROM unnest(sqlc.arg(companies)::text[]) AS c)
       AND a.closed_at IS NULL AND a.company_slug <> ''
       AND a.source = ANY(sqlc.arg(aggregators)::text[])
       AND (
@@ -636,32 +659,38 @@ matches AS (
     -- the way. Only those two clauses are decoration: measured on prod, also stripping a
     -- parenthetical produced 39 wrong pairs out of 55 — one company's "…, Backend (Traffic)"
     -- matching its "(Payments)", "(Identity)" and "(Infrastructure)" roles — and a comma clause
-    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE single-equality hash join (O(agg + ats))
-    -- and the two are UNION ALL-ed — an OR of the two equalities in one ON would defeat the
-    -- hash join and go quadratic on a big company (the hotel-chain case). UNION ALL, not
-    -- UNION: a row matched by both paths appears twice, but the downstream MIN(ats_id)
-    -- absorbs the duplicate, so the de-dup pass is wasted work. Both require a non-empty key;
-    -- the country gate applies to each path.
+    -- fails the same way ("…, Backend" vs "…, Fullstack"). Each path is a SEPARATE
+    -- equality hash join (now on (fcompany, ntitle) / (fcompany, ntitle2), still
+    -- O(agg + ats)) and the two are UNION ALL-ed — an OR of the two equalities in one ON
+    -- would defeat the hash join and go quadratic on a big company (the hotel-chain
+    -- case). UNION ALL, not UNION: a row matched by both paths appears twice, but the
+    -- downstream MIN(ats_id) absorbs the duplicate, so the de-dup pass is wasted work.
+    -- Both require a non-empty key; the country gate applies to each path.
     SELECT a.id AS agg_id, t.id AS ats_id
     FROM agg a JOIN ats t
-      ON t.ntitle = a.ntitle AND a.ntitle <> ''
+      ON t.fcompany = a.fcompany
+     AND t.ntitle = a.ntitle AND a.ntitle <> ''
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
     UNION ALL
     SELECT a.id, t.id
     FROM agg a JOIN ats t
-      ON t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
+      ON t.fcompany = a.fcompany
+     AND t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
     UNION ALL
     -- Third path: word-subset containment — the aggregator dropped words the ATS keeps (a
     -- mid-title drop the two equality keys miss). This arm is a nested loop (no hash on <@),
-    -- but runs only on the residual after the equality arms and is bounded per company.
+    -- but runs only on the residual after the equality arms and is bounded per company via
+    -- the fcompany equality (planned as a hash/merge join on fcompany, nested-looping only
+    -- within each matching group — the same cost shape the old single-company call had).
     -- Guards against over-merge: the aggregator title needs >= 2 words, and the words the ATS
     -- adds over it must include at least one NON-seniority word — so "Software Engineer" is not
     -- merged into "Senior Software Engineer" (a distinct grade), only into a title that adds a
     -- real specialty/location/department word the aggregator dropped.
     SELECT a.id, t.id
     FROM agg a JOIN ats t
-      ON string_to_array(a.ntitle, ' ') <@ string_to_array(t.ntitle, ' ')
+      ON t.fcompany = a.fcompany
+     AND string_to_array(a.ntitle, ' ') <@ string_to_array(t.ntitle, ' ')
      AND array_length(string_to_array(a.ntitle, ' '), 1) >= 2
      AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
      AND EXISTS (

--- a/internal/jobdedup/jobdedup.go
+++ b/internal/jobdedup/jobdedup.go
@@ -4,7 +4,7 @@
 // A company routinely posts one role once per city — same title, same description,
 // thirty external_ids. RoleFingerprint deliberately excludes the location, so those
 // copies share a fingerprint and the batch recompute
-// (db.RecomputeRoleDuplicatesForCompany) collapses them to one canonical row. The batch
+// (db.RecomputeRoleDuplicatesForCompanies) collapses them to one canonical row. The batch
 // runs every few hours, though, and the live search index is written incrementally by
 // the crawl; between the two, every copy is a separate searchable job. That window is
 // what this package closes, by answering the same question synchronously at write time.
@@ -26,7 +26,7 @@ import (
 // CanonicalForRole reports the open canonical posting of this row's role cluster, when
 // one exists that is OLDER than the row just written (id).
 //
-// The age condition is the whole subtlety. RecomputeRoleDuplicatesForCompany makes
+// The age condition is the whole subtlety. RecomputeRoleDuplicatesForCompanies makes
 // MIN(id) among a cluster's open rows the canon, so collapsing onto a NEWER posting is
 // not just a different choice — the next reindex would undo it and invert it. Staying in
 // step with the batch is what makes the two agree instead of fighting.

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -17,6 +17,7 @@ type aijobs struct {
 type aijobsHTTP interface {
 	HeaderFormPoster
 	HTMLGetter
+	CookieReader
 }
 
 // NewAijobs builds the aijobs adapter over the given HTTP client (a cookie-jar-backed

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -1,6 +1,13 @@
 package sources
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
 
 // aijobs adapts aijobs.net, a large AI/ML job aggregator (~47k postings). It is boardless
 // (one global feed, no per-tenant board) and multi-company, so it stays in the source facet
@@ -35,3 +42,120 @@ func (aijobs) aggregator() {}
 // Fetch is a placeholder satisfying the Source interface; the real listing walk and
 // hydrating fetch land in later tasks (FetchNew is the path cmd/ingest actually drives).
 func (aijobs) Fetch(context.Context, CompanyEntry) ([]Job, error) { return nil, nil }
+
+const aijobsBaseURL = "https://aijobs.net"
+
+// aijobsJobIDPattern matches a job-detail path (/job/<slug>-<id>/) and captures the
+// trailing numeric id, anchored so a company or skill-filter link (which shares no such
+// suffix) never matches.
+var aijobsJobIDPattern = regexp.MustCompile(`^/job/[^/]+-(\d+)/?$`)
+
+// aijobsJobID extracts the native aijobs.net posting id from a job-detail href, "" when
+// href is not a job-detail link.
+func aijobsJobID(href string) string {
+	m := aijobsJobIDPattern.FindStringSubmatch(href)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// aijobsListingLinks collects every job-detail link on a listing page, in document order
+// (the feed's own newest-first sort), filtering out the company/skill/education/role
+// filter links a listing card also carries.
+func aijobsListingLinks(root *html.Node) []string {
+	var hrefs []string
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			if href := attr(n, "href"); aijobsJobIDPattern.MatchString(href) {
+				hrefs = append(hrefs, href)
+			}
+		}
+		return true
+	})
+	return hrefs
+}
+
+// aijobsMaxPages is the hard pagination safety cap, independent of the seen-based stop
+// (see crawlListing): ~47k postings at 50/page is ~956 pages, so this leaves headroom
+// while still bounding a run if the feed's sort order or markup ever silently changes.
+const aijobsMaxPages = 1200
+
+// bootstrapSession GETs the aijobs.net home page to obtain the csrftoken cookie the
+// listing POST must echo back (Django's double-submit CSRF pattern — see
+// Client.CookieValue). Returns an error if the site sets no such cookie.
+func (a aijobs) bootstrapSession(ctx context.Context) (string, error) {
+	if _, err := a.http.GetHTML(ctx, aijobsBaseURL+"/"); err != nil {
+		return "", err
+	}
+	token := a.http.CookieValue(aijobsBaseURL+"/", "csrftoken")
+	if token == "" {
+		return "", fmt.Errorf("aijobs: no csrftoken cookie set by %s", aijobsBaseURL)
+	}
+	return token, nil
+}
+
+// listPage requests one listing page, authorized by the session's csrfToken (echoed as
+// both the x-csrftoken header and the csrfmiddlewaretoken form field — the value the
+// cookie already carries, so no separate per-page token scrape is needed). Referer is
+// required: aijobs.net's CSRF check rejects a same-value token without it.
+func (a aijobs) listPage(ctx context.Context, csrfToken string, page int) (*html.Node, error) {
+	values := url.Values{
+		"csrfmiddlewaretoken": {csrfToken},
+	}
+	headers := map[string]string{
+		"x-csrftoken": csrfToken,
+		"referer":     aijobsBaseURL + "/",
+		"hx-request":  "true",
+	}
+	return a.http.PostFormWithHeaders(ctx, fmt.Sprintf("%s/?page=%d", aijobsBaseURL, page), headers, values)
+}
+
+// crawlListing walks the listing pages (newest posting first) and returns the job-detail
+// hrefs of postings seen reports as NOT already in the catalogue, in discovery order. It
+// stops — without requesting a further page — as soon as either condition holds:
+//   - a whole page's postings are all already seen: the feed has been caught up to, so
+//     every following page (older still) would be too;
+//   - newBudget unseen postings have been found (0 means unbounded): this run's
+//     per-run detail-fetch budget (see AIJOBS_MAX_NEW_PER_RUN); the postings past the
+//     cap remain unseen and are picked up on a later run.
+//
+// A first-page failure is a board-level error; a later page failing ends the walk with
+// what was gathered so far (a partial crawl survives a mid-listing hiccup).
+func (a aijobs) crawlListing(ctx context.Context, seen func(externalID string) bool, newBudget int) ([]string, error) {
+	csrfToken, err := a.bootstrapSession(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("aijobs: session bootstrap: %w", err)
+	}
+
+	var unseen []string
+	for page := 1; page <= aijobsMaxPages; page++ {
+		root, err := a.listPage(ctx, csrfToken, page)
+		if err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("aijobs: listing page %d: %w", page, err)
+			}
+			break
+		}
+		links := aijobsListingLinks(root)
+		if len(links) == 0 {
+			break // empty page, or a page number clamped past the last one
+		}
+		allSeen := true
+		for _, href := range links {
+			id := aijobsJobID(href)
+			if id == "" || seen(id) {
+				continue
+			}
+			allSeen = false
+			unseen = append(unseen, href)
+			if newBudget > 0 && len(unseen) >= newBudget {
+				return unseen, nil
+			}
+		}
+		if allSeen {
+			break // caught up to already-known postings; every later page is older still
+		}
+	}
+	return unseen, nil
+}

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -20,7 +20,7 @@ type aijobsHTTP interface {
 }
 
 // NewAijobs builds the aijobs adapter over the given HTTP client (a cookie-jar-backed
-// client in production, see the registry).
+// client in production, see cookieSessionSource in registry.go).
 func NewAijobs(c aijobsHTTP) Source { return aijobs{http: c} }
 
 func (aijobs) Provider() string { return "aijobs" }

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -24,7 +24,9 @@ type aijobs struct {
 	http aijobsHTTP
 	// maxNewPerRun bounds how many unseen postings FetchNew hydrates in one run (see
 	// crawlListing's newBudget and design.md Decision 3). Always positive: NewAijobs
-	// substitutes aijobsDefaultMaxNewPerRun for a zero/negative value.
+	// substitutes aijobsDefaultMaxNewPerRun for a zero/negative value, because
+	// crawlListing reads newBudget <= 0 as "unlimited," not "nothing" — forwarding a raw
+	// zero here would mean "crawl the whole backlog in one run," not "crawl nothing new."
 	maxNewPerRun int
 }
 

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -371,11 +372,50 @@ func (a aijobs) detail(ctx context.Context, href string) (Job, bool) {
 		Remote:      remote,
 		WorkMode:    workModeFromRemote(remote),
 		Skills:      aijobsAnchorTexts(sections["Skills/Tech-stack"]),
-		PostedAt:    aijobsParsePostedAt(aijobsPostedText(root)),
+		PostedAt:    aijobsParsePostedAt(aijobsPostedText(root), time.Now()),
 	}, true
 }
 
-// aijobsParsePostedAt is a placeholder; task 5 implements the real "Xh/Xd/Xw/Xmo/Xy ago"
-// parse (the month/year unit-conversion approximation is a deliberate choice left to be
-// made then — see tasks.md 5.1).
-func aijobsParsePostedAt(string) *time.Time { return nil }
+// aijobsPostedTimePattern captures a relative-time value and its unit from text like
+// "8h ago", "3d ago", "2w ago", "5mo ago", "1y ago" — only "h"/"d"/"w" were observed live,
+// but the site's own broader vocabulary implies "mo"/"y" exist for older postings.
+var aijobsPostedTimePattern = regexp.MustCompile(`^(\d+)(h|d|w|mo|y)\s+ago$`)
+
+// aijobsParsePostedAt converts the detail page's relative-time text (see aijobsPostedText)
+// into an absolute PostedAt relative to now. An unrecognized shape returns nil rather than
+// failing the whole posting (see spec Requirement "Posted time is parsed from the
+// relative-time string").
+func aijobsParsePostedAt(text string, now time.Time) *time.Time {
+	m := aijobsPostedTimePattern.FindStringSubmatch(strings.TrimSpace(text))
+	if m == nil {
+		return nil
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return nil
+	}
+	var t time.Time
+	switch m[2] {
+	case "h":
+		t = now.Add(-time.Duration(n) * time.Hour)
+	case "d":
+		t = now.AddDate(0, 0, -n)
+	case "w":
+		t = now.AddDate(0, 0, -7*n)
+	case "mo", "y":
+		// TODO(you): the month/year unit-conversion approximation is your call — see
+		// tasks.md 5.1. Two valid options, and neither is "wrong":
+		//   - calendar-aware: now.AddDate(0, -n, 0) / now.AddDate(-n, 0, 0) — correct
+		//     through month-length variance (e.g. Mar 31 minus 1mo lands on Feb 28/29),
+		//     but "1mo ago" and "30d ago" then don't necessarily agree.
+		//   - flat approximation: now.AddDate(0, 0, -n*30) / now.AddDate(0, 0, -n*365) —
+		//     simpler, and arguably fine for what is ultimately a freshness signal
+		//     nobody reads to the day.
+		// Until you pick one, this returns nil (posting still ingested, just PostedAt
+		// unset) rather than a silently wrong date.
+		return nil
+	default:
+		return nil
+	}
+	return &t
+}

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -366,19 +366,30 @@ func aijobsDescription(sections map[string]*html.Node) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
+// aijobsPostedPrefixes are the two labels observed live for the same relative-time
+// element: "Found X ago" on a posting crawled recently, "Published X ago" on an older one
+// with a recorded original date (confirmed against
+// https://aijobs.net/job/statistics-expert-phd-remote-238344/, which reads "Published
+// 15d ago" — a shape task 4's single-sample fixture never exercised).
+var aijobsPostedPrefixes = []string{"Found ", "Published "}
+
 // aijobsPostedText extracts the detail page's relative-posting-time text (e.g. "8h ago"
-// from "Found 8h ago"), "" if the page carries no such element. Parsing this into an
-// absolute PostedAt is aijobsParsePostedAt's job, not this one.
+// from "Found 8h ago" or "15d ago" from "Published 15d ago"), "" if the page carries no
+// such element. Parsing this into an absolute PostedAt is aijobsParsePostedAt's job, not
+// this one.
 func aijobsPostedText(root *html.Node) string {
-	const prefix = "Found "
 	var text string
 	walk(root, func(n *html.Node) bool {
 		if text != "" {
 			return false
 		}
 		if n.Type == html.ElementNode && n.Data == "span" {
-			if t := strings.TrimSpace(textContent(n)); strings.HasPrefix(t, prefix) {
-				text = strings.TrimSpace(strings.TrimPrefix(t, prefix))
+			t := strings.TrimSpace(textContent(n))
+			for _, prefix := range aijobsPostedPrefixes {
+				if strings.HasPrefix(t, prefix) {
+					text = strings.TrimSpace(strings.TrimPrefix(t, prefix))
+					break
+				}
 			}
 		}
 		return true

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -79,7 +79,8 @@ func aijobsListingLinks(root *html.Node) []string {
 // aijobsMaxPages is the hard pagination safety cap, independent of the seen-based stop
 // (see crawlListing): ~47k postings at 50/page is ~956 pages, so this leaves headroom
 // while still bounding a run if the feed's sort order or markup ever silently changes.
-const aijobsMaxPages = 1200
+// A var, not a const, so a test can shrink it rather than paginate to the real cap.
+var aijobsMaxPages = 1200
 
 // bootstrapSession GETs the aijobs.net home page to obtain the csrftoken cookie the
 // listing POST must echo back (Django's double-submit CSRF pattern — see
@@ -106,7 +107,9 @@ func (a aijobs) listPage(ctx context.Context, csrfToken string, page int) (*html
 	headers := map[string]string{
 		"x-csrftoken": csrfToken,
 		"referer":     aijobsBaseURL + "/",
-		"hx-request":  "true",
+		// The site's own frontend paginates this endpoint via htmx (confirmed live), which
+		// marks every one of its requests this way; sent for parity with the real client.
+		"hx-request": "true",
 	}
 	return a.http.PostFormWithHeaders(ctx, fmt.Sprintf("%s/?page=%d", aijobsBaseURL, page), headers, values)
 }

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
+	"time"
+	"unicode"
 
 	"golang.org/x/net/html"
 )
@@ -162,3 +165,217 @@ func (a aijobs) crawlListing(ctx context.Context, seen func(externalID string) b
 	}
 	return unseen, nil
 }
+
+// aijobsCompanySlugPattern matches a company-profile href and captures its slug, without
+// the trailing "-<id>" suffix every such link carries.
+var aijobsCompanySlugPattern = regexp.MustCompile(`^/company/(.+)-\d+/?$`)
+
+// aijobsCompanyName finds the detail page's company-profile link and derives a display
+// name from its slug — the page's own visible label is masked behind a PRO paywall
+// ("@ M..."), but the slug in the href is not (see design.md Decision 5). "" if the page
+// carries no such link.
+func aijobsCompanyName(root *html.Node) string {
+	var slug string
+	walk(root, func(n *html.Node) bool {
+		if slug == "" && n.Type == html.ElementNode && n.Data == "a" {
+			if m := aijobsCompanySlugPattern.FindStringSubmatch(attr(n, "href")); m != nil {
+				slug = m[1]
+			}
+		}
+		return true
+	})
+	if slug == "" {
+		return ""
+	}
+	return titleCaseSlug(slug)
+}
+
+// titleCaseSlug renders a hyphen-separated URL slug as a display name by upper-casing
+// each word's first rune (a Django slug is already lower-case, so nothing else changes).
+func titleCaseSlug(slug string) string {
+	words := strings.Split(slug, "-")
+	for i, w := range words {
+		if w == "" {
+			continue
+		}
+		r := []rune(w)
+		r[0] = unicode.ToUpper(r[0])
+		words[i] = string(r)
+	}
+	return strings.Join(words, " ")
+}
+
+// aijobsIsRemote reports whether the detail page carries the "R" work-arrangement badge
+// (a span styled text-bg-success, exact text "R" — distinct from the same class used on
+// other badges, which never render that exact text).
+func aijobsIsRemote(root *html.Node) bool {
+	remote := false
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "span" && hasClass(n, "text-bg-success") {
+			if strings.TrimSpace(textContent(n)) == "R" {
+				remote = true
+			}
+		}
+		return true
+	})
+	return remote
+}
+
+// aijobsSections maps each <h5> section heading's trimmed text (Tasks, Perks/Benefits,
+// Skills/Tech-stack, …) to its immediately following sibling content node (a <ul> or a
+// <p>). It walks the whole page once: an <h5> is remembered as "pending" and paired with
+// the next <ul>/<p> element the walk reaches — true for this page's layout, where each
+// section heading is immediately followed by its own content block.
+func aijobsSections(root *html.Node) map[string]*html.Node {
+	sections := make(map[string]*html.Node)
+	var pending string
+	walk(root, func(n *html.Node) bool {
+		if n.Type != html.ElementNode {
+			return true
+		}
+		switch n.Data {
+		case "h5":
+			pending = strings.TrimSpace(textContent(n))
+			return false // the heading's own text is not section content
+		case "ul", "p":
+			if pending != "" {
+				if _, exists := sections[pending]; !exists {
+					sections[pending] = n
+				}
+				pending = ""
+			}
+		}
+		return true
+	})
+	return sections
+}
+
+// aijobsListItems reads a <ul>'s direct <li> children as trimmed text, nil if n is nil
+// (section absent) or empty.
+func aijobsListItems(n *html.Node) []string {
+	if n == nil {
+		return nil
+	}
+	var items []string
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == "li" {
+			if text := strings.TrimSpace(textContent(c)); text != "" {
+				items = append(items, text)
+			}
+		}
+	}
+	return items
+}
+
+// aijobsAnchorTexts reads every <a>'s trimmed text within n, nil if n is nil.
+func aijobsAnchorTexts(n *html.Node) []string {
+	if n == nil {
+		return nil
+	}
+	var texts []string
+	walk(n, func(c *html.Node) bool {
+		if c.Type == html.ElementNode && c.Data == "a" {
+			if text := strings.TrimSpace(textContent(c)); text != "" {
+				texts = append(texts, text)
+			}
+		}
+		return true
+	})
+	return texts
+}
+
+// aijobsIsPlaceholder reports whether a section's only item is the literal text N/A —
+// the site's own placeholder for "nothing here", observed on every sampled posting with
+// no real perks.
+func aijobsIsPlaceholder(items []string) bool {
+	return len(items) == 1 && items[0] == "N/A"
+}
+
+// aijobsDescription renders the Tasks section as a bullet list (there is no free-text
+// prose anywhere on the page — the site pre-processes every posting into these structured
+// sections), followed by a Perks/Benefits bullet list when it carries real content (the
+// literal-N/A placeholder is omitted rather than rendered as noise).
+func aijobsDescription(sections map[string]*html.Node) string {
+	var b strings.Builder
+	for _, task := range aijobsListItems(sections["Tasks"]) {
+		fmt.Fprintf(&b, "- %s\n", task)
+	}
+	if perks := aijobsListItems(sections["Perks/Benefits"]); len(perks) > 0 && !aijobsIsPlaceholder(perks) {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString("Perks/Benefits:\n")
+		for _, perk := range perks {
+			fmt.Fprintf(&b, "- %s\n", perk)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// aijobsPostedText extracts the detail page's relative-posting-time text (e.g. "8h ago"
+// from "Found 8h ago"), "" if the page carries no such element. Parsing this into an
+// absolute PostedAt is aijobsParsePostedAt's job, not this one.
+func aijobsPostedText(root *html.Node) string {
+	const prefix = "Found "
+	var text string
+	walk(root, func(n *html.Node) bool {
+		if text != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "span" {
+			if t := strings.TrimSpace(textContent(n)); strings.HasPrefix(t, prefix) {
+				text = strings.TrimSpace(strings.TrimPrefix(t, prefix))
+			}
+		}
+		return true
+	})
+	return text
+}
+
+// detail fetches one job's detail page and maps it to a Job. It returns ok=false when the
+// page fetch fails, its heading is missing (a layout/error page, not a posting), or it
+// carries no /company/ link — the page's own visible company label is masked behind a PRO
+// paywall, and without the link there is no way to recover a real name (see
+// aijobsCompanyName), so the posting is dropped rather than stored company-less.
+func (a aijobs) detail(ctx context.Context, href string) (Job, bool) {
+	id := aijobsJobID(href)
+	if id == "" {
+		return Job{}, false
+	}
+	link := aijobsBaseURL + href
+	root, err := a.http.GetHTML(ctx, link)
+	if err != nil {
+		return Job{}, false
+	}
+	h1 := firstByTag(root, "h1")
+	if h1 == nil {
+		return Job{}, false
+	}
+	company := aijobsCompanyName(root)
+	if company == "" {
+		return Job{}, false
+	}
+	var location string
+	if loc := firstByTag(root, "strong"); loc != nil {
+		location = strings.TrimSpace(textContent(loc))
+	}
+	remote := aijobsIsRemote(root)
+	sections := aijobsSections(root)
+	return Job{
+		ExternalID:  id,
+		URL:         link,
+		Title:       strings.TrimSpace(textContent(h1)),
+		Company:     company,
+		Location:    location,
+		Description: aijobsDescription(sections),
+		Remote:      remote,
+		WorkMode:    workModeFromRemote(remote),
+		Skills:      aijobsAnchorTexts(sections["Skills/Tech-stack"]),
+		PostedAt:    aijobsParsePostedAt(aijobsPostedText(root)),
+	}, true
+}
+
+// aijobsParsePostedAt is a placeholder; task 5 implements the real "Xh/Xd/Xw/Xmo/Xy ago"
+// parse (the month/year unit-conversion approximation is a deliberate choice left to be
+// made then — see tasks.md 5.1).
+func aijobsParsePostedAt(string) *time.Time { return nil }

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -21,6 +22,10 @@ import (
 // than the shared client.
 type aijobs struct {
 	http aijobsHTTP
+	// maxNewPerRun bounds how many unseen postings FetchNew hydrates in one run (see
+	// crawlListing's newBudget and design.md Decision 3). Always positive: NewAijobs
+	// substitutes aijobsDefaultMaxNewPerRun for a zero/negative value.
+	maxNewPerRun int
 }
 
 // aijobsHTTP is the transport aijobs needs: the CSRF-protected listing POST and the
@@ -31,9 +36,22 @@ type aijobsHTTP interface {
 	CookieReader
 }
 
+// aijobsDefaultMaxNewPerRun is AIJOBS_MAX_NEW_PER_RUN's default when unset (see
+// registry.go's aijobsMaxNewPerRunFromEnv): the day-one backlog is aijobs.net's whole
+// ~47k-posting catalogue, and each unseen posting costs one detail-page GET, so a run
+// needs a bound well short of "all of it" (mirrors APPLY_FORM_MAX_PER_RUN's shape in
+// cmd/capture-apply-form for the same kind of backlog).
+const aijobsDefaultMaxNewPerRun = 500
+
 // NewAijobs builds the aijobs adapter over the given HTTP client (a cookie-jar-backed
-// client in production, see cookieSessionSource in registry.go).
-func NewAijobs(c aijobsHTTP) Source { return aijobs{http: c} }
+// client in production, see cookieSessionSource in registry.go). maxNewPerRun <= 0 is
+// replaced with aijobsDefaultMaxNewPerRun.
+func NewAijobs(c aijobsHTTP, maxNewPerRun int) Source {
+	if maxNewPerRun <= 0 {
+		maxNewPerRun = aijobsDefaultMaxNewPerRun
+	}
+	return aijobs{http: c, maxNewPerRun: maxNewPerRun}
+}
 
 func (aijobs) Provider() string { return "aijobs" }
 
@@ -43,9 +61,42 @@ func (aijobs) boardless() {}
 // aijobs aggregates postings from many companies, so it stays in the source facet.
 func (aijobs) aggregator() {}
 
-// Fetch is a placeholder satisfying the Source interface; the real listing walk and
-// hydrating fetch land in later tasks (FetchNew is the path cmd/ingest actually drives).
-func (aijobs) Fetch(context.Context, CompanyEntry) ([]Job, error) { return nil, nil }
+// FetchNew is the hydrating crawl cmd/ingest actually drives: it walks the listing
+// (crawlListing, bounded by maxNewPerRun and the seen-page stop) and fetches detail only
+// for a posting seen reports as not already in the catalogue.
+func (a aijobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	links, err := a.crawlListing(ctx, seen, a.maxNewPerRun)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(links, defaultDetailWorkers, func(href string) (Job, bool) {
+		return a.detail(ctx, href)
+	}), nil
+}
+
+// Fetch is the list-only fallback HydratingSource specifies for a caller that cannot
+// supply a seen predicate. aijobs has no such thing as a list-only Job — the listing
+// carries no company, and Job.Company is required (see detail) — so this hydrates
+// everything the listing yields (as if nothing were seen yet), still bounded by
+// maxNewPerRun.
+func (a aijobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	return a.FetchNew(ctx, e, func(string) bool { return false })
+}
+
+// aijobsMaxNewPerRunFromEnv reads AIJOBS_MAX_NEW_PER_RUN, falling back to
+// aijobsDefaultMaxNewPerRun when unset or not a positive integer — read once at registry
+// construction (see registry.go), not per crawl.
+func aijobsMaxNewPerRunFromEnv() int {
+	v := os.Getenv("AIJOBS_MAX_NEW_PER_RUN")
+	if v == "" {
+		return aijobsDefaultMaxNewPerRun
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return aijobsDefaultMaxNewPerRun
+	}
+	return n
+}
 
 const aijobsBaseURL = "https://aijobs.net"
 

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -402,18 +402,13 @@ func aijobsParsePostedAt(text string, now time.Time) *time.Time {
 		t = now.AddDate(0, 0, -n)
 	case "w":
 		t = now.AddDate(0, 0, -7*n)
-	case "mo", "y":
-		// TODO(you): the month/year unit-conversion approximation is your call — see
-		// tasks.md 5.1. Two valid options, and neither is "wrong":
-		//   - calendar-aware: now.AddDate(0, -n, 0) / now.AddDate(-n, 0, 0) — correct
-		//     through month-length variance (e.g. Mar 31 minus 1mo lands on Feb 28/29),
-		//     but "1mo ago" and "30d ago" then don't necessarily agree.
-		//   - flat approximation: now.AddDate(0, 0, -n*30) / now.AddDate(0, 0, -n*365) —
-		//     simpler, and arguably fine for what is ultimately a freshness signal
-		//     nobody reads to the day.
-		// Until you pick one, this returns nil (posting still ingested, just PostedAt
-		// unset) rather than a silently wrong date.
-		return nil
+	case "mo":
+		// Flat approximation (30 days/month), not calendar-aware AddDate(0, -n, 0):
+		// PostedAt here is a freshness signal, not a legal date, so month-length
+		// variance doesn't matter enough to justify "1mo ago" and "30d ago" disagreeing.
+		t = now.AddDate(0, 0, -30*n)
+	case "y":
+		t = now.AddDate(0, 0, -365*n)
 	default:
 		return nil
 	}

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -1,0 +1,36 @@
+package sources
+
+import "context"
+
+// aijobs adapts aijobs.net, a large AI/ML job aggregator (~47k postings). It is boardless
+// (one global feed, no per-tenant board) and multi-company, so it stays in the source facet
+// and takes each posting's company from the feed. The listing is a Django CSRF-protected
+// POST endpoint (not a public JSON API), so the adapter needs a cookie-jar-backed client
+// (built with newCookieClient in the registry, mirroring taleo's session-bound flow) rather
+// than the shared client.
+type aijobs struct {
+	http aijobsHTTP
+}
+
+// aijobsHTTP is the transport aijobs needs: the CSRF-protected listing POST and the
+// per-posting detail-page GET.
+type aijobsHTTP interface {
+	HeaderFormPoster
+	HTMLGetter
+}
+
+// NewAijobs builds the aijobs adapter over the given HTTP client (a cookie-jar-backed
+// client in production, see the registry).
+func NewAijobs(c aijobsHTTP) Source { return aijobs{http: c} }
+
+func (aijobs) Provider() string { return "aijobs" }
+
+// aijobs needs no board id (one global feed), so its config carries no board.
+func (aijobs) boardless() {}
+
+// aijobs aggregates postings from many companies, so it stays in the source facet.
+func (aijobs) aggregator() {}
+
+// Fetch is a placeholder satisfying the Source interface; the real listing walk and
+// hydrating fetch land in later tasks (FetchNew is the path cmd/ingest actually drives).
+func (aijobs) Fetch(context.Context, CompanyEntry) ([]Job, error) { return nil, nil }

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -345,17 +345,27 @@ func TestAijobsParsePostedAtUnrecognizedTextLeavesNil(t *testing.T) {
 	}
 }
 
-// TestAijobsParsePostedAtMonthsYears is the seam for tasks.md 5.1's month/year
-// unit-conversion decision (calendar-aware AddDate vs. a flat-day approximation — see the
-// TODO in aijobsParsePostedAt). Currently red: the function returns nil for "mo"/"y" until
-// that decision is made and implemented.
+// TestAijobsParsePostedAtMonthsYears locks in tasks.md 5.1's decision: a flat 30/365-day
+// approximation, not calendar-aware AddDate(0, -n, 0) — PostedAt is a freshness signal,
+// not a legal date.
 func TestAijobsParsePostedAtMonthsYears(t *testing.T) {
 	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
-	if got := aijobsParsePostedAt("5mo ago", now); got == nil {
-		t.Error(`aijobsParsePostedAt("5mo ago") = nil, want a non-nil time once 5.1 is implemented`)
+	cases := []struct {
+		text string
+		want time.Time
+	}{
+		{"5mo ago", now.AddDate(0, 0, -5*30)},
+		{"1y ago", now.AddDate(0, 0, -365)},
 	}
-	if got := aijobsParsePostedAt("1y ago", now); got == nil {
-		t.Error(`aijobsParsePostedAt("1y ago") = nil, want a non-nil time once 5.1 is implemented`)
+	for _, c := range cases {
+		got := aijobsParsePostedAt(c.text, now)
+		if got == nil {
+			t.Errorf("aijobsParsePostedAt(%q) = nil, want %v", c.text, c.want)
+			continue
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("aijobsParsePostedAt(%q) = %v, want %v", c.text, got, c.want)
+		}
 	}
 }
 

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -298,6 +298,27 @@ func TestAijobsDetailIncludesRealPerks(t *testing.T) {
 	}
 }
 
+// TestAijobsPostedTextRecognizesBothLabels guards a real-site discrepancy found only by
+// live smoke-testing task 6's ingest run: a recently-crawled posting reads "Found X ago"
+// (as every fixture elsewhere in this file uses), but an older one — confirmed live
+// against https://aijobs.net/job/statistics-expert-phd-remote-238344/ — reads
+// "Published Xd ago" instead. Both must yield the same relative-time text.
+func TestAijobsPostedTextRecognizesBothLabels(t *testing.T) {
+	cases := map[string]string{
+		`<span>Found 8h ago</span>`:      "8h ago",
+		`<span>Published 15d ago</span>`: "15d ago",
+	}
+	for markup, want := range cases {
+		root, err := html.Parse(strings.NewReader("<html><body>" + markup + "</body></html>"))
+		if err != nil {
+			t.Fatalf("html.Parse: %v", err)
+		}
+		if got := aijobsPostedText(root); got != want {
+			t.Errorf("aijobsPostedText(%q) = %q, want %q", markup, got, want)
+		}
+	}
+}
+
 func TestAijobsCompanyNameFromSlug(t *testing.T) {
 	cases := map[string]string{
 		"/company/medison-pharma-16767/": "Medison Pharma",

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -6,6 +6,7 @@ import (
 	neturl "net/url"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -384,14 +385,118 @@ func TestAijobsJobID(t *testing.T) {
 	}
 }
 
+const aijobsMinimalDetailHTML = `<html><body><main>
+<h1>Role</h1>
+<a href="/company/acme-1/">@ A...</a>
+<h5>Tasks</h5><ul><li>Do the thing</li></ul>
+</main></body></html>`
+
+func TestAijobsImplementsHydratingSource(t *testing.T) {
+	var _ HydratingSource = aijobs{}
+}
+
+func TestAijobsFetchNewHydratesOnlyUnseenPostings(t *testing.T) {
+	var mu sync.Mutex
+	requestedSeenPosting := false
+	fake := aijobsGetPostFake{
+		postForm: func(url string) (*html.Node, error) {
+			if strings.Contains(url, "page=1") {
+				return html.Parse(strings.NewReader(aijobsListingPage("1", "2")))
+			}
+			return nil, fmt.Errorf("no route for %s", url)
+		},
+		getHTML: func(url string) (*html.Node, error) {
+			if strings.Contains(url, "role-1") {
+				mu.Lock()
+				requestedSeenPosting = true
+				mu.Unlock()
+			}
+			if strings.Contains(url, "/job/role-") {
+				return html.Parse(strings.NewReader(aijobsMinimalDetailHTML))
+			}
+			return html.Parse(strings.NewReader("<html></html>")) // session bootstrap
+		},
+	}
+
+	jobs, err := (aijobs{http: fake, maxNewPerRun: 500}).FetchNew(context.Background(), CompanyEntry{}, seenSet("1"))
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+
+	mu.Lock()
+	poisoned := requestedSeenPosting
+	mu.Unlock()
+	if poisoned {
+		t.Error("detail fetched for an already-seen posting (role-1)")
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (the unseen posting only)", len(jobs))
+	}
+	if jobs[0].ExternalID != "2" {
+		t.Errorf("ExternalID = %q, want %q", jobs[0].ExternalID, "2")
+	}
+	if jobs[0].Company != "Acme" {
+		t.Errorf("Company = %q, want %q", jobs[0].Company, "Acme")
+	}
+}
+
+func TestAijobsFetchHydratesEverythingWithoutASeenPredicate(t *testing.T) {
+	fake := aijobsGetPostFake{
+		postForm: func(url string) (*html.Node, error) {
+			if strings.Contains(url, "page=1") {
+				return html.Parse(strings.NewReader(aijobsListingPage("1")))
+			}
+			return nil, fmt.Errorf("no route for %s", url)
+		},
+		getHTML: func(url string) (*html.Node, error) {
+			if strings.Contains(url, "/job/role-") {
+				return html.Parse(strings.NewReader(aijobsMinimalDetailHTML))
+			}
+			return html.Parse(strings.NewReader("<html></html>"))
+		},
+	}
+	jobs, err := (aijobs{http: fake, maxNewPerRun: 500}).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "1" {
+		t.Errorf("jobs = %+v, want exactly the one posting hydrated", jobs)
+	}
+}
+
+func TestAijobsMaxNewPerRunFromEnv(t *testing.T) {
+	cases := map[string]int{
+		"":     aijobsDefaultMaxNewPerRun,
+		"0":    aijobsDefaultMaxNewPerRun,
+		"-5":   aijobsDefaultMaxNewPerRun,
+		"abc":  aijobsDefaultMaxNewPerRun,
+		"1234": 1234,
+	}
+	for env, want := range cases {
+		t.Setenv("AIJOBS_MAX_NEW_PER_RUN", env)
+		if got := aijobsMaxNewPerRunFromEnv(); got != want {
+			t.Errorf("AIJOBS_MAX_NEW_PER_RUN=%q: got %d, want %d", env, got, want)
+		}
+	}
+}
+
+func TestAijobsNewAijobsDefaultsNonPositiveBudget(t *testing.T) {
+	for _, n := range []int{0, -1} {
+		a := NewAijobs(nil, n).(aijobs)
+		if a.maxNewPerRun != aijobsDefaultMaxNewPerRun {
+			t.Errorf("NewAijobs(nil, %d).maxNewPerRun = %d, want %d", n, a.maxNewPerRun, aijobsDefaultMaxNewPerRun)
+		}
+	}
+}
+
 func TestAijobsProvider(t *testing.T) {
-	if got := NewAijobs(nil).Provider(); got != "aijobs" {
+	if got := NewAijobs(nil, 0).Provider(); got != "aijobs" {
 		t.Errorf("Provider() = %q, want %q", got, "aijobs")
 	}
 }
 
 func TestAijobsIsBoardlessAggregator(t *testing.T) {
-	s := NewAijobs(nil)
+	s := NewAijobs(nil, 0)
 	if _, ok := s.(boardless); !ok {
 		t.Error("aijobs should implement the boardless marker")
 	}

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -1,0 +1,41 @@
+package sources
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestAijobsProvider(t *testing.T) {
+	if got := NewAijobs(nil).Provider(); got != "aijobs" {
+		t.Errorf("Provider() = %q, want %q", got, "aijobs")
+	}
+}
+
+func TestAijobsIsBoardlessAggregator(t *testing.T) {
+	s := NewAijobs(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("aijobs should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("aijobs should implement the aggregator marker")
+	}
+}
+
+func TestAijobsRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["aijobs"]; !ok {
+		t.Error("All() should register provider aijobs")
+	}
+	if !slices.Contains(FilterableProviders(), "aijobs") {
+		t.Error("FilterableProviders() should include aijobs")
+	}
+}
+
+func TestAijobsBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/aijobs.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/aijobs.yml fails validation: %v", err)
+	}
+}

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -110,10 +110,16 @@ func TestAijobsCrawlListingStopsAtNewBudget(t *testing.T) {
 // also swallow the GET, or vice versa.
 type aijobsGetPostFake struct {
 	postForm func(url string) (*html.Node, error)
+	// getHTML overrides GetHTML's response (detail-page tests); nil means the empty page
+	// every pagination test relies on for the session-bootstrap GET.
+	getHTML func(url string) (*html.Node, error)
 }
 
-func (f aijobsGetPostFake) GetHTML(context.Context, string) (*html.Node, error) {
-	return html.Parse(strings.NewReader("<html></html>"))
+func (f aijobsGetPostFake) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	if f.getHTML == nil {
+		return html.Parse(strings.NewReader("<html></html>"))
+	}
+	return f.getHTML(url)
 }
 
 func (f aijobsGetPostFake) PostFormWithHeaders(_ context.Context, url string, _ map[string]string, _ neturl.Values) (*html.Node, error) {
@@ -170,6 +176,140 @@ func TestAijobsCrawlListingLaterPageFailureKeepsWhatWasGathered(t *testing.T) {
 	}
 	if want := []string{"/job/role-1/"}; !slices.Equal(unseen, want) {
 		t.Errorf("unseen = %v, want %v", unseen, want)
+	}
+}
+
+// aijobsDetailFixture is a trimmed real detail-page fragment (captured live), including
+// the "@ M..." masked company name (the page's own visible label is paywalled — the
+// adapter must derive the name from the /company/ href instead, never that text) and the
+// site's own structured Tasks/Perks/Skills sections in place of free-text prose.
+const aijobsDetailFixture = `<html><body><main>
+<h1 class="font-monospace fs-2 py-3">Data Specialist</h1>
+<div class="row g-3 align-items-start flex-nowrap">
+    <div class="col">
+        <strong>Petah Tikva, Center District, IL</strong>
+        <span class="text-bg-success px-1 rounded">R</span>
+        <p class="py-4">
+            <span class="text-bg-secondary px-1 rounded">ILS 139K-151K (estimate)</span>
+            <span class="text-bg-warning px-1 rounded">Mid-level</span>
+        </p>
+    </div>
+    <div class="col-6 col-md-5 col-lg-4 text-end">
+        <div class="fw-bold mb-2">
+            <a class="text-decoration-none d-block text-break" href="/company/medison-pharma-16767/">
+                @ M...
+            </a>
+        </div>
+        <span class="d-block text-muted py-2">
+            Found 8h ago
+        </span>
+    </div>
+</div>
+
+<h5>Tasks</h5>
+<ul>
+    <li>Build AI powered data solutions</li>
+    <li>Design data pipelines</li>
+</ul>
+
+<h5>Perks/Benefits</h5>
+<ul>
+    <li>N/A</li>
+</ul>
+
+<h5>Skills/Tech-stack</h5>
+<p>
+    <a href="/jobs/skill-python/">Python</a> |
+    <a href="/jobs/skill-sql/">SQL</a>
+</p>
+</main></body></html>`
+
+func TestAijobsDetailMapsCoreFields(t *testing.T) {
+	fake := aijobsGetPostFake{
+		getHTML: func(string) (*html.Node, error) {
+			return html.Parse(strings.NewReader(aijobsDetailFixture))
+		},
+	}
+	job, ok := aijobs{http: fake}.detail(context.Background(), "/job/data-specialist-268449/")
+	if !ok {
+		t.Fatal("detail() = false, want a valid posting")
+	}
+	if job.ExternalID != "268449" {
+		t.Errorf("ExternalID = %q, want %q", job.ExternalID, "268449")
+	}
+	if job.URL != "https://aijobs.net/job/data-specialist-268449/" {
+		t.Errorf("URL = %q, want the absolute detail page URL", job.URL)
+	}
+	if job.Title != "Data Specialist" {
+		t.Errorf("Title = %q, want %q", job.Title, "Data Specialist")
+	}
+	if job.Company != "Medison Pharma" {
+		t.Errorf("Company = %q, want %q (derived from the /company/ slug, not the masked label)", job.Company, "Medison Pharma")
+	}
+	if job.Location != "Petah Tikva, Center District, IL" {
+		t.Errorf("Location = %q, want %q", job.Location, "Petah Tikva, Center District, IL")
+	}
+	if !job.Remote {
+		t.Error("Remote = false, want true (the R badge)")
+	}
+	if job.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want %q", job.WorkMode, "remote")
+	}
+	if !strings.Contains(job.Description, "Build AI powered data solutions") || !strings.Contains(job.Description, "Design data pipelines") {
+		t.Errorf("Description = %q, want it to contain both task items", job.Description)
+	}
+	if strings.Contains(job.Description, "N/A") {
+		t.Errorf("Description = %q, want the placeholder Perks/Benefits (N/A) section omitted", job.Description)
+	}
+	if want := []string{"Python", "SQL"}; !slices.Equal(job.Skills, want) {
+		t.Errorf("Skills = %v, want %v", job.Skills, want)
+	}
+}
+
+func TestAijobsDetailDropsPostingWithNoCompanyLink(t *testing.T) {
+	fake := aijobsGetPostFake{
+		getHTML: func(string) (*html.Node, error) {
+			return html.Parse(strings.NewReader(`<html><body><main><h1>Some Role</h1></main></body></html>`))
+		},
+	}
+	if _, ok := (aijobs{http: fake}).detail(context.Background(), "/job/some-role-1/"); ok {
+		t.Error("detail() = true, want false for a page with no /company/ link")
+	}
+}
+
+func TestAijobsDetailIncludesRealPerks(t *testing.T) {
+	const withPerks = `<html><body><main>
+<h1>Role</h1>
+<a href="/company/acme-1/">@ A...</a>
+<h5>Tasks</h5><ul><li>Do the work</li></ul>
+<h5>Perks/Benefits</h5><ul><li>Health insurance</li><li>Remote stipend</li></ul>
+</main></body></html>`
+	fake := aijobsGetPostFake{getHTML: func(string) (*html.Node, error) {
+		return html.Parse(strings.NewReader(withPerks))
+	}}
+	job, ok := aijobs{http: fake}.detail(context.Background(), "/job/role-2/")
+	if !ok {
+		t.Fatal("detail() = false, want a valid posting")
+	}
+	if !strings.Contains(job.Description, "Health insurance") || !strings.Contains(job.Description, "Remote stipend") {
+		t.Errorf("Description = %q, want real perks included", job.Description)
+	}
+}
+
+func TestAijobsCompanyNameFromSlug(t *testing.T) {
+	cases := map[string]string{
+		"/company/medison-pharma-16767/": "Medison Pharma",
+		"/company/acme-1/":               "Acme",
+		"/company/multi-word-co-42/":     "Multi Word Co",
+	}
+	for href, want := range cases {
+		root, err := html.Parse(strings.NewReader(`<html><body><a href="` + href + `">@ x</a></body></html>`))
+		if err != nil {
+			t.Fatalf("html.Parse: %v", err)
+		}
+		if got := aijobsCompanyName(root); got != want {
+			t.Errorf("aijobsCompanyName(%q) = %q, want %q", href, got, want)
+		}
 	}
 }
 

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -131,6 +131,36 @@ func TestAijobsCrawlListingFirstPageFailureErrors(t *testing.T) {
 	}
 }
 
+// TestAijobsCrawlListingStopsAtHardPageCap covers the "hard cap regardless of seen state"
+// spec scenario: a feed that never runs dry and never repeats an already-seen posting
+// (so the seen-based stop never triggers) must still stop at aijobsMaxPages. It shrinks
+// the package var for the duration of the test rather than paginating to the real ~1200.
+func TestAijobsCrawlListingStopsAtHardPageCap(t *testing.T) {
+	orig := aijobsMaxPages
+	aijobsMaxPages = 3
+	defer func() { aijobsMaxPages = orig }()
+
+	var requests int
+	fake := aijobsGetPostFake{postForm: func(string) (*html.Node, error) {
+		requests++
+		// A fresh, never-seen numeric id every call (aijobsJobIDPattern requires a
+		// trailing digit run): the seen-based stop can never trigger, so only the hard
+		// cap can end the walk.
+		return html.Parse(strings.NewReader(aijobsListingPage(fmt.Sprintf("%d", 1000+requests))))
+	}}
+
+	unseen, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 0)
+	if err != nil {
+		t.Fatalf("crawlListing: %v", err)
+	}
+	if requests != aijobsMaxPages {
+		t.Errorf("requested %d pages, want exactly %d (stop at the hard cap)", requests, aijobsMaxPages)
+	}
+	if len(unseen) != aijobsMaxPages {
+		t.Errorf("got %d unseen postings, want %d (one per page up to the cap)", len(unseen), aijobsMaxPages)
+	}
+}
+
 func TestAijobsCrawlListingLaterPageFailureKeepsWhatWasGathered(t *testing.T) {
 	fake := aijobsPagedFake(map[int]string{1: aijobsListingPage("1")}) // no page=2: page 2 fails
 

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/html"
 )
@@ -310,6 +311,51 @@ func TestAijobsCompanyNameFromSlug(t *testing.T) {
 		if got := aijobsCompanyName(root); got != want {
 			t.Errorf("aijobsCompanyName(%q) = %q, want %q", href, got, want)
 		}
+	}
+}
+
+func TestAijobsParsePostedAtHoursDaysWeeks(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		text string
+		want time.Time
+	}{
+		{"8h ago", now.Add(-8 * time.Hour)},
+		{"3d ago", now.AddDate(0, 0, -3)},
+		{"2w ago", now.AddDate(0, 0, -14)},
+	}
+	for _, c := range cases {
+		got := aijobsParsePostedAt(c.text, now)
+		if got == nil {
+			t.Errorf("aijobsParsePostedAt(%q) = nil, want %v", c.text, c.want)
+			continue
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("aijobsParsePostedAt(%q) = %v, want %v", c.text, got, c.want)
+		}
+	}
+}
+
+func TestAijobsParsePostedAtUnrecognizedTextLeavesNil(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	for _, text := range []string{"", "just now", "8 hours ago", "8x ago"} {
+		if got := aijobsParsePostedAt(text, now); got != nil {
+			t.Errorf("aijobsParsePostedAt(%q) = %v, want nil", text, got)
+		}
+	}
+}
+
+// TestAijobsParsePostedAtMonthsYears is the seam for tasks.md 5.1's month/year
+// unit-conversion decision (calendar-aware AddDate vs. a flat-day approximation — see the
+// TODO in aijobsParsePostedAt). Currently red: the function returns nil for "mo"/"y" until
+// that decision is made and implemented.
+func TestAijobsParsePostedAtMonthsYears(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	if got := aijobsParsePostedAt("5mo ago", now); got == nil {
+		t.Error(`aijobsParsePostedAt("5mo ago") = nil, want a non-nil time once 5.1 is implemented`)
+	}
+	if got := aijobsParsePostedAt("1y ago", now); got == nil {
+		t.Error(`aijobsParsePostedAt("1y ago") = nil, want a non-nil time once 5.1 is implemented`)
 	}
 }
 

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -1,9 +1,162 @@
 package sources
 
 import (
+	"context"
+	"fmt"
+	neturl "net/url"
 	"slices"
+	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
 )
+
+// aijobsListingFixture is a trimmed real listing-page fragment (captured live): two job
+// cards plus a company-profile link and a skill-filter link, neither of which is a job
+// posting, to guard against over-matching.
+const aijobsListingFixture = `<html><body><ul>
+<li><a class="font-monospace fw-bold stretched-link" href="/job/data-specialist-petah-tikva-center-district-il-268449/">Data Specialist</a></li>
+<li><a class="font-monospace fw-bold stretched-link" href="/job/lead-ai-engineer-tel-aviv-yafo-tel-aviv-district-il-268513/">Lead AI Engineer</a></li>
+<li><a href="/company/medison-pharma-16767/">Medison Pharma</a></li>
+<li><a href="/jobs/skill-python/">Python</a></li>
+</ul></body></html>`
+
+func TestAijobsListingLinksMatchesOnlyJobPostings(t *testing.T) {
+	root, err := html.Parse(strings.NewReader(aijobsListingFixture))
+	if err != nil {
+		t.Fatalf("html.Parse: %v", err)
+	}
+	got := aijobsListingLinks(root)
+	want := []string{
+		"/job/data-specialist-petah-tikva-center-district-il-268449/",
+		"/job/lead-ai-engineer-tel-aviv-yafo-tel-aviv-district-il-268513/",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("aijobsListingLinks = %v, want %v", got, want)
+	}
+}
+
+// aijobsListingPage renders a listing page whose only content is one job card per id.
+func aijobsListingPage(ids ...string) string {
+	var b strings.Builder
+	b.WriteString("<html><body><ul>")
+	for _, id := range ids {
+		b.WriteString(`<li><a href="/job/role-` + id + `/">role</a></li>`)
+	}
+	b.WriteString("</ul></body></html>")
+	return b.String()
+}
+
+func seenSet(ids ...string) func(string) bool {
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return func(id string) bool { return set[id] }
+}
+
+// aijobsPagedFake serves a fixed listing body per page number (matched on the "page=N"
+// query parameter) and a plain session-bootstrap GET, so a test can shape exactly what
+// crawlListing discovers per page without a real HTTP round trip.
+func aijobsPagedFake(pages map[int]string) aijobsGetPostFake {
+	return aijobsGetPostFake{postForm: func(url string) (*html.Node, error) {
+		for page, body := range pages {
+			if strings.Contains(url, fmt.Sprintf("page=%d", page)) {
+				return html.Parse(strings.NewReader(body))
+			}
+		}
+		return nil, fmt.Errorf("aijobsPagedFake: no route for %s", url)
+	}}
+}
+
+func TestAijobsCrawlListingStopsWhenAPageIsFullySeen(t *testing.T) {
+	fake := aijobsPagedFake(map[int]string{
+		1: aijobsListingPage("1", "2"),
+		2: aijobsListingPage("3"),
+		3: aijobsListingPage("4", "5"), // already-seen page: caught up
+		4: aijobsListingPage("99"),     // poison: must never be fetched
+	})
+
+	unseen, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet("4", "5"), 0)
+	if err != nil {
+		t.Fatalf("crawlListing: %v", err)
+	}
+	want := []string{"/job/role-1/", "/job/role-2/", "/job/role-3/"}
+	if !slices.Equal(unseen, want) {
+		t.Errorf("unseen = %v, want %v", unseen, want)
+	}
+}
+
+func TestAijobsCrawlListingStopsAtNewBudget(t *testing.T) {
+	fake := aijobsPagedFake(map[int]string{
+		1: aijobsListingPage("1", "2", "3"),
+		2: aijobsListingPage("99"), // poison: must never be fetched
+	})
+
+	unseen, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 2)
+	if err != nil {
+		t.Fatalf("crawlListing: %v", err)
+	}
+	want := []string{"/job/role-1/", "/job/role-2/"}
+	if !slices.Equal(unseen, want) {
+		t.Errorf("unseen = %v, want %v (budget-capped)", unseen, want)
+	}
+}
+
+// aijobsGetPostFake lets a test control the GET (session bootstrap) and POST (listing
+// page) paths independently. routedHTTP can't: its routes match by URL substring only,
+// and the bootstrap GET's URL is always a prefix of every paginated POST's URL (both hit
+// the same "https://aijobs.net/[...]" host), so a route meant to fail only the POST would
+// also swallow the GET, or vice versa.
+type aijobsGetPostFake struct {
+	postForm func(url string) (*html.Node, error)
+}
+
+func (f aijobsGetPostFake) GetHTML(context.Context, string) (*html.Node, error) {
+	return html.Parse(strings.NewReader("<html></html>"))
+}
+
+func (f aijobsGetPostFake) PostFormWithHeaders(_ context.Context, url string, _ map[string]string, _ neturl.Values) (*html.Node, error) {
+	return f.postForm(url)
+}
+
+func (f aijobsGetPostFake) CookieValue(string, string) string { return "test-csrf-token" }
+
+func TestAijobsCrawlListingFirstPageFailureErrors(t *testing.T) {
+	fake := aijobsGetPostFake{postForm: func(url string) (*html.Node, error) {
+		return nil, fmt.Errorf("no route for %s", url) // bootstrap succeeds, page 1 fails
+	}}
+	if _, err := (aijobs{http: fake}).crawlListing(context.Background(), seenSet(), 0); err == nil {
+		t.Error("expected an error when the first listing page fails, got nil")
+	}
+}
+
+func TestAijobsCrawlListingLaterPageFailureKeepsWhatWasGathered(t *testing.T) {
+	fake := aijobsPagedFake(map[int]string{1: aijobsListingPage("1")}) // no page=2: page 2 fails
+
+	unseen, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 0)
+	if err != nil {
+		t.Fatalf("crawlListing: %v", err)
+	}
+	if want := []string{"/job/role-1/"}; !slices.Equal(unseen, want) {
+		t.Errorf("unseen = %v, want %v", unseen, want)
+	}
+}
+
+func TestAijobsJobID(t *testing.T) {
+	cases := map[string]string{
+		"/job/data-specialist-petah-tikva-center-district-il-268449/": "268449",
+		"/job/lead-ai-engineer-268513/":                               "268513",
+		"/company/medison-pharma-16767/":                              "",
+		"/jobs/skill-python/":                                         "",
+		"/job/no-trailing-id/":                                        "",
+	}
+	for href, want := range cases {
+		if got := aijobsJobID(href); got != want {
+			t.Errorf("aijobsJobID(%q) = %q, want %q", href, got, want)
+		}
+	}
+}
 
 func TestAijobsProvider(t *testing.T) {
 	if got := NewAijobs(nil).Provider(); got != "aijobs" {

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -425,15 +425,43 @@ func (e *ChallengeError) Error() string {
 	return fmt.Sprintf("sources: GET %s: WAF challenge", e.URL)
 }
 
+// PostFormWithHeaders POSTs values as an application/x-www-form-urlencoded body with
+// extra request headers, and returns the response parsed as HTML — for a listing
+// endpoint that is POST-only and CSRF-protected (aijobs.net's Django cookie-token
+// flow) rather than a JSON API.
+func (c *Client) PostFormWithHeaders(ctx context.Context, url string, headers map[string]string, values url.Values) (*html.Node, error) {
+	var node *html.Node
+	err := c.do(ctx, request{
+		method:      http.MethodPost,
+		url:         url,
+		body:        []byte(values.Encode()),
+		contentType: "application/x-www-form-urlencoded",
+		accept:      "text/html",
+		headers:     headers,
+		decode: func(resp *http.Response) error {
+			n, err := html.Parse(resp.Body)
+			if err != nil {
+				return err
+			}
+			node = n
+			return nil
+		},
+	})
+	return node, err
+}
+
 // request is the parameters of a single HTTP exchange issued by do. A non-nil body is
 // re-sent on each retry; the standard User-Agent/Accept headers always win over headers.
+// contentType is the Content-Type sent alongside a non-nil body; empty defaults to
+// "application/json" (every existing POST helper is JSON-bodied).
 type request struct {
-	method  string
-	url     string
-	body    []byte
-	accept  string
-	headers map[string]string
-	decode  func(*http.Response) error
+	method      string
+	url         string
+	body        []byte
+	contentType string
+	accept      string
+	headers     map[string]string
+	decode      func(*http.Response) error
 }
 
 // do issues an HTTP request (optionally with a JSON body) and applies r.decode to a
@@ -472,7 +500,11 @@ func (c *Client) do(ctx context.Context, r request) error {
 		}
 		req.Header.Set("Accept", r.accept)
 		if r.body != nil {
-			req.Header.Set("Content-Type", "application/json")
+			contentType := r.contentType
+			if contentType == "" {
+				contentType = "application/json"
+			}
+			req.Header.Set("Content-Type", contentType)
 		}
 
 		resp, err := c.httpClient.Do(req)

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -90,6 +90,12 @@ type HeaderJSONPoster interface {
 	PostJSONWithHeaders(ctx context.Context, url string, headers map[string]string, body, v any) error
 }
 
+// CookieReader reads back a cookie a prior request established in the client's jar, for
+// the double-submit CSRF pattern (see Client.CookieValue).
+type CookieReader interface {
+	CookieValue(url, name string) string
+}
+
 // HeaderFormPoster POSTs a form-urlencoded body with extra request headers and returns
 // the response parsed as HTML — for a CSRF-protected listing endpoint that is form-bodied
 // rather than JSON (e.g. aijobs.net's Django cookie-token flow).
@@ -112,6 +118,7 @@ type HTTPClient interface {
 	HeaderJSONGetter
 	HeaderJSONPoster
 	HeaderFormPoster
+	CookieReader
 }
 
 // maxResponseBody caps how many bytes a decoder reads from any response. It bounds a
@@ -431,6 +438,28 @@ type ChallengeError struct {
 
 func (e *ChallengeError) Error() string {
 	return fmt.Sprintf("sources: GET %s: WAF challenge", e.URL)
+}
+
+// CookieValue returns the value of the named cookie as currently held in the client's
+// cookie jar for url's host, "" if unset or the client has no jar (the shared client,
+// built without one). It exists for the double-submit CSRF pattern (e.g. aijobs.net's
+// Django flow), where a value a prior GET's Set-Cookie response established must also be
+// echoed back as a request header/body field — something the jar alone, which only
+// re-attaches cookies to outgoing requests automatically, cannot do.
+func (c *Client) CookieValue(rawURL, name string) string {
+	if c.httpClient.Jar == nil {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	for _, ck := range c.httpClient.Jar.Cookies(u) {
+		if ck.Name == name {
+			return ck.Value
+		}
+	}
+	return ""
 }
 
 // PostFormWithHeaders POSTs values as an application/x-www-form-urlencoded body with

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -90,6 +90,13 @@ type HeaderJSONPoster interface {
 	PostJSONWithHeaders(ctx context.Context, url string, headers map[string]string, body, v any) error
 }
 
+// HeaderFormPoster POSTs a form-urlencoded body with extra request headers and returns
+// the response parsed as HTML — for a CSRF-protected listing endpoint that is form-bodied
+// rather than JSON (e.g. aijobs.net's Django cookie-token flow).
+type HeaderFormPoster interface {
+	PostFormWithHeaders(ctx context.Context, url string, headers map[string]string, values url.Values) (*html.Node, error)
+}
+
 // HTTPClient is the full transport surface, composing every capability role. The real
 // Client implements it; sources.All holds one and passes it to each adapter, which then
 // narrows it to the role(s) it actually uses.
@@ -104,6 +111,7 @@ type HTTPClient interface {
 	JSONPoster
 	HeaderJSONGetter
 	HeaderJSONPoster
+	HeaderFormPoster
 }
 
 // maxResponseBody caps how many bytes a decoder reads from any response. It bounds a

--- a/internal/sources/http_test.go
+++ b/internal/sources/http_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -118,6 +119,36 @@ func TestClientPostFormWithHeadersSendsFormEncodedBodyAndParsesHTML(t *testing.T
 	}
 	if got := textContent(node); got != "hi" {
 		t.Errorf("parsed HTML text = %q, want %q", got, "hi")
+	}
+}
+
+func TestClientCookieValueReadsCookieSetByAPriorRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "csrftoken", Value: "tok-abc", Path: "/"})
+		_, _ = w.Write([]byte(`<html></html>`))
+	}))
+	defer srv.Close()
+
+	jar, _ := cookiejar.New(nil)
+	httpClient := srv.Client()
+	httpClient.Jar = jar
+	c := &Client{httpClient: httpClient}
+
+	if _, err := c.GetHTML(context.Background(), srv.URL); err != nil {
+		t.Fatalf("GetHTML: %v", err)
+	}
+	if got := c.CookieValue(srv.URL, "csrftoken"); got != "tok-abc" {
+		t.Errorf("CookieValue = %q, want %q", got, "tok-abc")
+	}
+	if got := c.CookieValue(srv.URL, "nope"); got != "" {
+		t.Errorf("CookieValue for unset cookie = %q, want empty", got)
+	}
+}
+
+func TestClientCookieValueReturnsEmptyWithoutAJar(t *testing.T) {
+	c := &Client{httpClient: &http.Client{}}
+	if got := c.CookieValue("https://example.com", "csrftoken"); got != "" {
+		t.Errorf("CookieValue without a jar = %q, want empty", got)
 	}
 }
 

--- a/internal/sources/http_test.go
+++ b/internal/sources/http_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -84,6 +85,39 @@ func TestClientPostJSONWithHeadersSendsCustomHeader(t *testing.T) {
 	}
 	if gotRSC != "1" {
 		t.Errorf("RSC = %q, want 1", gotRSC)
+	}
+}
+
+func TestClientPostFormWithHeadersSendsFormEncodedBodyAndParsesHTML(t *testing.T) {
+	var gotContentType, gotCSRF string
+	var gotForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotCSRF = r.Header.Get("X-Csrftoken")
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		_, _ = w.Write([]byte(`<html><body><p>hi</p></body></html>`))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client()}
+
+	values := url.Values{"page": {"2"}, "csrfmiddlewaretoken": {"tok123"}}
+	node, err := c.PostFormWithHeaders(context.Background(), srv.URL, map[string]string{"X-Csrftoken": "tok123"}, values)
+	if err != nil {
+		t.Fatalf("PostFormWithHeaders: %v", err)
+	}
+	if !strings.Contains(gotContentType, "application/x-www-form-urlencoded") {
+		t.Errorf("Content-Type = %q, want form-urlencoded", gotContentType)
+	}
+	if gotCSRF != "tok123" {
+		t.Errorf("X-Csrftoken = %q, want tok123", gotCSRF)
+	}
+	if gotForm.Get("page") != "2" || gotForm.Get("csrfmiddlewaretoken") != "tok123" {
+		t.Errorf("form body = %v, want page=2 and csrfmiddlewaretoken=tok123", gotForm)
+	}
+	if got := textContent(node); got != "hi" {
+		t.Errorf("parsed HTML text = %q, want %q", got, "hi")
 	}
 }
 

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -295,22 +295,12 @@ func All(c HTTPClient) map[string]Source {
 	} else if whatjobsID != "" {
 		registry["whatjobs"] = NewWhatJobs(limitedWhatJobsGetter(c), whatjobsID)
 	}
-	// taleo needs a cookie-persisting client (its searchjobs POST requires the session cookie
-	// a careersection GET sets), so it cannot use the shared jar-less client. Build a dedicated
-	// one for a real crawl; on the transport-free listing path (c == nil) register a bare adapter
-	// — Provider()/marker assertions never touch the transport.
-	if c == nil {
-		registry["taleo"] = NewTaleo(nil)
-	} else {
-		registry["taleo"] = NewTaleo(newCookieClient())
-	}
-	// aijobs needs the same cookie-persisting client as taleo: its listing POST is Django
-	// CSRF-protected, authorized by the csrftoken cookie a plain GET sets.
-	if c == nil {
-		registry["aijobs"] = NewAijobs(nil)
-	} else {
-		registry["aijobs"] = NewAijobs(newCookieClient())
-	}
+	// taleo and aijobs both need a cookie-persisting session (a searchjobs POST authorized
+	// by a careersection GET's session cookie; a CSRF-protected listing POST authorized by
+	// a plain GET's csrftoken cookie) rather than the shared jar-less client — see
+	// cookieSessionSource.
+	registry["taleo"] = cookieSessionSource[taleoHTTP](c, NewTaleo)
+	registry["aijobs"] = cookieSessionSource[aijobsHTTP](c, NewAijobs)
 	// meta is NOT served by the shared client: Meta's edge 400s the default Go TLS+HTTP/2
 	// fingerprint, so it needs the shared Chrome-fingerprint transport (fingerprintHTTP, also used
 	// by the bayt/gulftalent aggregators). Build it only when there is a real client to serve (the
@@ -329,6 +319,20 @@ func All(c HTTPClient) map[string]Source {
 		registry["gulftalent"] = NewGulfTalent(fp)
 	}
 	return registry
+}
+
+// cookieSessionSource builds a registry entry for an adapter whose API is session- or
+// CSRF-cookie-authenticated (taleo, aijobs) and so cannot share the shared jar-less
+// client. On a real crawl (c != nil) it hands build a fresh cookie-jar client; on the
+// transport-free taxonomy path (c == nil, e.g. FilterableProviders) it hands build a true
+// nil transport, since T is an interface type parameter and its zero value is nil —
+// Provider()/marker assertions never touch it.
+func cookieSessionSource[T any](c HTTPClient, build func(T) Source) Source {
+	if c == nil {
+		var zero T
+		return build(zero)
+	}
+	return build(any(newCookieClient()).(T))
 }
 
 // reg indexes sources by provider key. A duplicate key means two adapters claim the

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -304,6 +304,13 @@ func All(c HTTPClient) map[string]Source {
 	} else {
 		registry["taleo"] = NewTaleo(newCookieClient())
 	}
+	// aijobs needs the same cookie-persisting client as taleo: its listing POST is Django
+	// CSRF-protected, authorized by the csrftoken cookie a plain GET sets.
+	if c == nil {
+		registry["aijobs"] = NewAijobs(nil)
+	} else {
+		registry["aijobs"] = NewAijobs(newCookieClient())
+	}
 	// meta is NOT served by the shared client: Meta's edge 400s the default Go TLS+HTTP/2
 	// fingerprint, so it needs the shared Chrome-fingerprint transport (fingerprintHTTP, also used
 	// by the bayt/gulftalent aggregators). Build it only when there is a real client to serve (the

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -300,7 +300,10 @@ func All(c HTTPClient) map[string]Source {
 	// a plain GET's csrftoken cookie) rather than the shared jar-less client — see
 	// cookieSessionSource.
 	registry["taleo"] = cookieSessionSource[taleoHTTP](c, NewTaleo)
-	registry["aijobs"] = cookieSessionSource[aijobsHTTP](c, NewAijobs)
+	aijobsMaxNewPerRun := aijobsMaxNewPerRunFromEnv()
+	registry["aijobs"] = cookieSessionSource[aijobsHTTP](c, func(h aijobsHTTP) Source {
+		return NewAijobs(h, aijobsMaxNewPerRun)
+	})
 	// meta is NOT served by the shared client: Meta's edge 400s the default Go TLS+HTTP/2
 	// fingerprint, so it needs the shared Chrome-fingerprint transport (fingerprintHTTP, also used
 	// by the bayt/gulftalent aggregators). Build it only when there is a real client to serve (the

--- a/openspec/changes/add-aijobs-adapter/.openspec.yaml
+++ b/openspec/changes/add-aijobs-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/add-aijobs-adapter/design.md
+++ b/openspec/changes/add-aijobs-adapter/design.md
@@ -48,12 +48,16 @@ aijobs.net combines all three pressures at once, at a larger scale than any exis
 ## Decisions
 
 **1. `HydratingSource.FetchNew`, not a plain `Fetch`.**
-Like `justjoin`, the adapter implements both: `Fetch` is the list-only fallback (used only if
-a caller cannot supply a `seen` predicate), and `FetchNew(ctx, e, seen)` is the real path
+Like `justjoin`, the adapter implements both: `FetchNew(ctx, e, seen)` is the real path
 `cmd/ingest` drives — the listing walk always runs, but the per-job detail `GET` is skipped
-for any external ID `seen` already reports as ingested. This is the existing mechanism built
-for exactly this cost shape (see `justjoin.go`'s `FetchNew` doc comment); no new plumbing
-needed for the "only fetch what's new" half of the problem.
+for any external ID `seen` already reports as ingested. `Fetch` is the fallback for a caller
+that cannot supply a `seen` predicate, but unlike `justjoin`'s (genuinely list-only, since its
+list carries company inline) it has nothing list-only to fall back to: aijobs's listing carries
+no company, and a company-less posting is dropped (Decision 5), so `Fetch` delegates to
+`FetchNew` with a predicate reporting everything unseen — hydrating everything the listing
+yields, bounded by the same per-run budget as a real crawl (Decision 3). `HydratingSource` is
+still the right mechanism for the "only fetch what's new" half of the problem — `Fetch` existing
+at all is just interface plumbing this adapter has little use for.
 
 **2. Listing pagination stops on the first page that is entirely already-seen, not just
 on a page with no within-run-duplicate links.**

--- a/openspec/changes/add-aijobs-adapter/design.md
+++ b/openspec/changes/add-aijobs-adapter/design.md
@@ -1,0 +1,179 @@
+## Context
+
+aijobs.net has no public JSON API for its listing — it is server-rendered HTML behind a
+Django CSRF-protected `POST /?page=N` endpoint (confirmed live via manual `curl`, effectively an
+inline feasibility spike, see proposal.md). A listing card carries no company name and no
+description; both live only on the per-job detail page, and the detail page itself masks the
+real company name behind a "PRO" paywall (rendered as `@ M...`), recoverable only from the
+`/company/<slug>-<id>/` href beside it. The catalogue is ~47k postings and grows continuously.
+
+This shape — boardless, multi-company, cheap listing / expensive per-posting detail, first-run
+backlog far larger than any single run should fetch — already has two precedents in
+`internal/sources`:
+- `justjoin.go` implements `HydratingSource.FetchNew(ctx, e, seen)`, where `seen(externalID)`
+  is a pipeline-supplied predicate ("is this posting already in the catalogue") so detail
+  fetches happen only for postings the catalogue does not already have.
+- `4dayweek.go` fetches every posting's detail page just to read whether the description is
+  paywall-locked, and is scheduled on a sparse (daily) cadence specifically because of that
+  per-posting fetch cost.
+- `bayt.go` hand-rolls its own "stop when a page adds no new link" pagination loop (rather than
+  the shared `crawlPagedLinks` helper in `html.go`, which none of the HTML-based adapters
+  actually call) and fans detail requests out through the shared `fetchDetails` bounded-worker
+  helper (`internal/sources/helpers.go`).
+
+aijobs.net combines all three pressures at once, at a larger scale than any existing adapter
+(47k vs. justjoin's ~20k), so the design borrows each precedent rather than inventing a new one.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Crawl aijobs.net's listing and yield normalized `Job` records for postings not already in
+  the catalogue, fetching each new posting's detail page exactly once.
+- Bound both dimensions of cost a large, continuously-growing aggregator creates: how many
+  listing pages one run walks, and how many detail pages one run fetches.
+- Reuse the CSRF/cookie session for the whole run rather than re-authenticating per page.
+
+**Non-Goals:**
+- Solving cross-source company-identity matching. The adapter derives a display name from
+  a URL slug; whether that string collides with an existing company row is entirely the
+  existing `role_fingerprint` dedup's job (see proposal.md's Impact section) — this change
+  does not touch `internal/jobdedup`.
+- Recovering the paywalled original employer name or apply URL. Out of reach without a PRO
+  account; not attempted.
+- Parsing or storing salary. The site's figures are labelled "(estimate)" — aggregator-computed,
+  not employer-provided — and storing them would misrepresent the salary facet's provenance.
+- Wiring the production cron cadence for `sources/aijobs.yml`. That is an ops-repo deploy step,
+  outside this repo's change.
+
+## Decisions
+
+**1. `HydratingSource.FetchNew`, not a plain `Fetch`.**
+Like `justjoin`, the adapter implements both: `Fetch` is the list-only fallback (used only if
+a caller cannot supply a `seen` predicate), and `FetchNew(ctx, e, seen)` is the real path
+`cmd/ingest` drives — the listing walk always runs, but the per-job detail `GET` is skipped
+for any external ID `seen` already reports as ingested. This is the existing mechanism built
+for exactly this cost shape (see `justjoin.go`'s `FetchNew` doc comment); no new plumbing
+needed for the "only fetch what's new" half of the problem.
+
+**2. Listing pagination stops on the first page that is entirely already-seen, not just
+on a page with no within-run-duplicate links.**
+aijobs.net's listing is sorted newest-first ("8h ago" at the top). `bayt.go`'s inline
+loop stops when a page adds nothing *new to this walk* (a within-run dedup set) — that
+guards against an infinite loop but still re-walks all ~956 pages every run forever, since
+every page's links are "new to this walk" even if every one of them is already in our
+catalogue. Because the feed is chronologically sorted, once a whole page is composed of
+IDs `seen` already reports as known, every following page is older still — so the walk can
+stop there. This turns steady-state runs (after the first backlog fill) into a handful of
+pages instead of ~956, at the cost of one extra `seen` check per listing-page link (cheap,
+in-memory once the pipeline has loaded the provider's seen-set — see
+`internal/pipeline/AGENTS.md`'s seen-set note).
+Alternative considered: cap the listing walk to a fixed `aijobsMaxPages` every run
+(mirroring `baytMaxPages`/`justJoinMaxPages`). Rejected as the *sole* stop condition — sorted
+aggregators like `bayt` and `justjoin` don't get this shortcut because their feeds aren't
+reliably date-sorted end to end; aijobs.net's is, so not using it would mean either an
+unbounded per-run page count or an arbitrary cap that eventually falls behind the real
+posting rate. Kept as a secondary safety cap (`aijobsMaxPages`) in case the sort order or
+markup ever silently changes.
+
+**3. `AIJOBS_MAX_NEW_PER_RUN` caps detail-page fetches (default 500), separate from the
+page cap.**
+The "stop at the first fully-seen page" rule (Decision 2) only helps once the catalogue has
+caught up. On the very first run — and after any outage long enough for the backlog to grow
+past one run's budget — most or all of the ~47k postings are unseen, and each needs one
+detail `GET`. Without a separate cap, `FetchNew` would try to fetch all of them in one run.
+The cap is applied inside `FetchNew`: once `AIJOBS_MAX_NEW_PER_RUN` unseen postings have been
+queued for detail fetch, the walk stops issuing new detail requests (and, since a "stop"
+here is not a listing failure, the page walk itself can also stop at that point — no reason
+to keep discovering links this run won't fetch). The next run resumes from the front of the
+listing; because still-unfetched postings from this run remain unseen, they are naturally
+rediscovered (Decision 2's early-stop does not trigger until the catalogue is caught up).
+This mirrors `APPLY_FORM_MAX_PER_RUN` in `cmd/capture-apply-form` (same shape: a backlog
+far bigger than one run should take, capped per run, self-resuming next run).
+
+**4. CSRF/session flow: cookie-jar client + one new `PostFormWithHeaders` helper.**
+Confirmed live: a plain `GET https://aijobs.net/` sets the `csrftoken` cookie; every
+subsequent listing `POST` must echo that same value as both the `x-csrftoken` header and the
+`csrfmiddlewaretoken` form field, and must carry a `Referer` header (confirmed required —
+its absence gets a `403 CSRF verification failed` naming the missing Referer specifically,
+not a generic auth failure). No separate token-scraping step is needed (unlike `taleo.go`'s
+`portalNo`, which is embedded per-page and must be regexed out) — the cookie value itself
+*is* the token, so this is simpler than taleo's flow despite looking superficially similar.
+`internal/sources/http.go` already has `newCookieClient` (cookie-jar-backed `*Client`, built
+for taleo) and `PostJSONWithHeaders`, but every POST helper today JSON-encodes the body; none
+send `application/x-www-form-urlencoded`. Adding `PostFormWithHeaders(ctx, url, headers,
+values url.Values) (*html.Node, error)` to `http.go` (parallel in shape to
+`PostJSONWithHeaders`, but form-encoding the body and returning parsed HTML like `GetHTML`
+rather than decoding JSON) is the minimal addition; the adapter is built with
+`newCookieClient()` so the bootstrap `GET`'s `Set-Cookie` carries into every paginated `POST`.
+
+**5. Company name: title-cased URL slug, not the raw slug.**
+The `companyname` package's convention — leave a raw slug as `Job.Company` and let
+`cmd/backfill-company-names` fix it later — assumes a resolver exists for that source
+(`companyname`'s `Registry` only covers Pinpoint/BambooHR/Lever/Ashby title-scraping today).
+aijobs has no such resolver and, given its own company name is paywalled, could never grow
+one. Left raw, the slug would stay squished (`medison-pharma`) forever, degrading the UI
+label and breaking `logo.dev`'s name lookup (per `companyname`'s own documented failure
+mode) with no future fix path. Title-casing the hyphen-split slug at ingest
+(`medison-pharma` → `Medison Pharma`) is a one-line improvement over a dead end, accepting
+that it is a heuristic (won't recover legal suffixes, stylized capitalization like "iRobot",
+or acronyms) — the same accepted imprecision `bayt`/`whatjobs` already carry for their
+aggregated company names.
+
+**6. Description is assembled from the page's own structured "Tasks" section, not free
+prose — because there is no free prose.**
+aijobs.net itself pre-processes every posting into structured sections (`<h5>Tasks</h5>` +
+`<ul><li>`, `<h5>Skills/Tech-stack</h5>`, `<h5>Perks/Benefits</h5>`, etc.) before serving it;
+there is no original-text description field anywhere on the page (confirmed: no
+`application/ld+json` block, no prose container). `Job.Description` is built by rendering
+the Tasks `<li>` items as a bullet list. `Job.Skills` is populated directly from the
+Skills/Tech-stack section's anchor texts (the `Job` struct already has a dedicated
+`[]string` field for this — no reason to also duplicate skills into the description text).
+"Perks/Benefits" is skipped when its only item is the literal string `N/A` (observed on
+every sampled posting with no real perks) so an empty section doesn't add "N/A" noise to
+every job.
+
+**7. `PostedAt` from the relative-time string ("Found Xh ago" / "Xd ago"), parsed
+generically.**
+Only `h` (hours) and `d` (days)-suffixed values were observed live, but the site's own
+faceted URLs and copy suggest broader units exist for older postings. The parser handles a
+generic `\d+[a-z]+ ago` shape rather than hardcoding just `h`/`d`, so a `w`/`mo`/`y` value
+degrades to "parsed with an approximation" rather than "silently dropped." **The exact
+month/year approximation (calendar-aware `time.AddDate` vs. a flat 30/365-day duration) is
+called out as its own task in tasks.md**, left for the user to write.
+
+## Risks / Trade-offs
+
+- **[Risk] Some duplicates against directly-crawled ATS sources will not collapse**, because
+  cross-source dedup only clusters postings sharing a company row, and aijobs' company name
+  is a derived slug rather than a scraped-verbatim string. → **Mitigation**: none attempted in
+  this change (explicit, discussed trade-off — see proposal.md); the existing
+  `role_fingerprint` clustering still catches what it can, same as it does for `bayt`/`whatjobs`
+  today, and a surviving duplicate is a harmless extra catalogue row, not a user-visible one
+  (search still shows one canonical result once/if clustering matches it).
+- **[Risk] `Job.URL` points at aijobs.net's own page, not the employer's original posting**,
+  because the real apply link is paywalled and its own internal redirect loops back
+  unauthenticated. → **Mitigation**: this is the same shape several existing aggregators
+  already have; freehire's job page still resolves to a working apply flow (aijobs.net's own
+  page), just not the originating ATS.
+- **[Risk] The "stop at the first fully-seen page" pagination shortcut (Decision 2) assumes
+  the listing stays strictly newest-first.** If aijobs.net ever changes its default sort, the
+  walk could stop early and silently miss postings inserted out of order. → **Mitigation**:
+  `aijobsMaxPages` remains as an independent safety cap either way, and `board_health`'s
+  `last_ingested_count` makes a sudden drop to near-zero visible in the existing per-board
+  health monitoring — no new observability needed.
+- **[Trade-off] Title-cased company names are a heuristic, not authoritative** (Decision 5) —
+  accepted, same class of imprecision already live for `bayt`/`whatjobs`.
+
+## Migration Plan
+
+Additive only: a new provider key, a new board file, a new HTTP helper. No schema change, no
+existing adapter touched. Rollback is deleting `sources/aijobs.yml` (or removing `"aijobs"`
+from the registry) — `cmd/ingest` simply stops being pointed at the board file; already-ingested
+jobs are unaffected (the lifecycle sweep only closes a provider's jobs when that provider's
+crawl runs and stops seeing them, so removing the board file freezes those rows rather than
+closing them). Wiring the actual cron schedule in the ops repo is a separate, later step.
+
+## Open Questions
+
+- None blocking. The relative-time unit-conversion granularity is deliberately left as an
+  explicit implementation task (tasks.md) rather than resolved here, per the user's request.

--- a/openspec/changes/add-aijobs-adapter/proposal.md
+++ b/openspec/changes/add-aijobs-adapter/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+aijobs.net is a large AI/ML job aggregator (~47k listings, updated continuously) not currently crawled by any adapter in `internal/sources`. Adding it brings in postings from companies with no ATS presence we already crawl (custom career pages, non-US employers), the same value other aggregator adapters (`bayt`, `whatjobs`, `arbeitnow`) already provide for their niches.
+
+## What Changes
+
+- New read-only adapter `internal/sources/aijobs.go` for provider `aijobs`, crawling `aijobs.net`'s paginated listing (a Django-CSRF-protected `POST /?page=N` endpoint, not a public JSON API) and fetching each newly-seen job's detail page for company name, description, and skills.
+- New board file `sources/aijobs.yml` (its own file, not `sources/custom.yml`) with a single boardless placeholder entry, since the source is a single global feed rather than one board per company, and its first-run backlog (~47k postings) makes it a poor fit for the shared hourly `custom.yml` cron slot.
+- New env var `AIJOBS_MAX_NEW_PER_RUN` (default 500) bounding how many previously-unseen job detail pages one run fetches, so the initial backlog crawl (and any future catch-up after an outage) doesn't turn one cron run into a multi-thousand-request marathon.
+- New HTTP helper in `internal/sources/http.go`: a form-urlencoded POST-with-headers method (the package currently only has JSON POST helpers), needed for the CSRF-protected listing endpoint.
+- Deliberately dropped: the site's own salary figures (labelled "(estimate)", aggregator-computed rather than employer-provided) and the gated PRO-only original company name / employer apply URL — the adapter derives a company display name from the `/company/<slug>-<id>/` URL instead, and links `Job.URL` to aijobs.net's own job page.
+
+## Capabilities
+
+### New Capabilities
+- `aijobs-source`: crawls aijobs.net's job listing (CSRF-protected paginated HTML) and per-job detail pages into normalized `Job` records — provider registration, pagination/backlog bound, and field-mapping rules (company-from-slug, description-from-structured-sections, skills, dropped salary, relative-time `PostedAt`).
+
+### Modified Capabilities
+(none — no existing capability's requirements change; the new form-POST HTTP helper is an internal implementation detail of `aijobs-source`, not a separate spec-level capability)
+
+## Impact
+
+- **Affected code**: `internal/sources/aijobs.go` (new), `internal/sources/aijobs_test.go` (new), `internal/sources/http.go` (new form-POST helper), `internal/sources/source.go` / registry wiring (`sources.All`), `sources/aijobs.yml` (new board file).
+- **Not affected**: no schema/migration changes, no changes to `cmd/ingest` itself (consumes the registry as-is), no changes to dedup logic (`internal/jobdedup`) — this change relies on the existing `role_fingerprint` cross-source clustering as-is; some duplicate rows against directly-crawled ATS sources are an accepted, known trade-off (same one already accepted for `bayt`/`whatjobs`), not something this change attempts to improve.
+- **Out of scope**: wiring the actual cron cadence for `sources/aijobs.yml` in the separate ops/deploy repo (follow-up outside this repo), any new company-identity-matching/dedup logic, salary parsing, and fetching the gated PRO apply URL or company name.

--- a/openspec/changes/add-aijobs-adapter/specs/aijobs-source/spec.md
+++ b/openspec/changes/add-aijobs-adapter/specs/aijobs-source/spec.md
@@ -1,0 +1,165 @@
+## ADDED Requirements
+
+### Requirement: aijobs.net is crawled as a boardless aggregator
+
+The system SHALL crawl aijobs.net's job listing as a single global feed under provider key
+`aijobs`, registered boardless (no per-tenant board id) and marked an aggregator (many
+employers per crawl, employer taken from each posting rather than the configured entry).
+`sources/aijobs.yml` SHALL carry exactly one placeholder entry naming the provider, mirroring
+`sources/arbeitnow.yml`'s convention.
+
+#### Scenario: A single board entry crawls the whole feed
+
+- **WHEN** `sources/aijobs.yml` names provider `aijobs` with no board
+- **THEN** config validation accepts the entry, and the crawl fetches postings from the shared
+  global listing rather than a per-company scope
+
+#### Scenario: Board omission does not fail validation
+
+- **WHEN** a `sources/aijobs.yml` entry for provider `aijobs` carries no `board` field
+- **THEN** config validation succeeds (the provider is registered boardless)
+
+### Requirement: The listing session is authenticated per run via a CSRF cookie
+
+The system SHALL bootstrap one HTTP session per crawl run with a `GET` to the aijobs.net home
+page to obtain the `csrftoken` cookie, then issue every subsequent paginated listing request as
+a `POST` carrying that same token value as both the `x-csrftoken` header and the
+`csrfmiddlewaretoken` form field, and a `Referer` header naming aijobs.net. A listing request
+missing the `Referer` header SHALL be treated as a failed request (the site rejects it with a
+CSRF error), not retried without it.
+
+#### Scenario: Session bootstrap precedes pagination
+
+- **WHEN** a crawl run starts
+- **THEN** the adapter first performs a `GET` to acquire the session cookie before issuing any
+  paginated listing `POST`
+
+#### Scenario: Every listing POST carries the token and Referer
+
+- **WHEN** the adapter requests listing page N
+- **THEN** the request is a `POST` whose `x-csrftoken` header, `csrfmiddlewaretoken` form
+  field, and session cookie all carry the same token value, and whose `Referer` header names
+  aijobs.net
+
+### Requirement: Detail fetches happen only for postings not already in the catalogue
+
+The system SHALL implement the hydrating fetch path (`FetchNew`), issuing a per-posting detail
+`GET` only for a posting whose external id the supplied `seen` predicate reports as not yet
+ingested. The plain `Fetch` path (used only when no `seen` predicate is available) SHALL return
+list-only jobs without a detail fetch.
+
+#### Scenario: An already-ingested posting is not re-fetched
+
+- **WHEN** the listing yields a posting whose external id `seen` reports as true
+- **THEN** the adapter does not issue a detail-page request for that posting
+
+#### Scenario: A new posting is hydrated
+
+- **WHEN** the listing yields a posting whose external id `seen` reports as false
+- **THEN** the adapter issues a detail-page request and the returned job carries the
+  detail-page fields (company, description, skills)
+
+### Requirement: Listing pagination is bounded by a seen-page stop and a hard page cap
+
+The system SHALL stop walking listing pages when a page's postings are ALL already reported
+seen by the `seen` predicate (the newest-first feed has been caught up to), or when a fixed
+per-run page count is reached, whichever comes first. The page count cap SHALL exist
+independently of the seen-based stop as a safety backstop.
+
+#### Scenario: Pagination stops once caught up to known postings
+
+- **WHEN** every posting on a listing page is already reported seen
+- **THEN** the adapter stops requesting further pages for this run
+
+#### Scenario: Pagination stops at the hard cap regardless of seen state
+
+- **WHEN** the per-run page cap is reached before any page is fully seen
+- **THEN** the adapter stops requesting further pages for this run
+
+### Requirement: New-posting detail fetches are bounded per run
+
+The system SHALL cap the number of unseen postings hydrated with a detail fetch in one run to
+the value of the `AIJOBS_MAX_NEW_PER_RUN` environment variable (default 500 when unset). Once
+the cap is reached, the run SHALL stop issuing further detail requests and SHALL stop
+discovering further listing pages for that run; postings past the cap remain unseen and are
+picked up on a subsequent run.
+
+#### Scenario: A run stops after reaching the new-posting cap
+
+- **WHEN** the number of unseen postings queued for detail fetch in the current run reaches
+  `AIJOBS_MAX_NEW_PER_RUN`
+- **THEN** the adapter stops fetching further detail pages and stops requesting further
+  listing pages for that run
+
+#### Scenario: Postings past the cap are picked up next run
+
+- **WHEN** a posting was discovered but not hydrated because the run's cap was already reached
+- **THEN** that posting's external id remains unseen, and it is discovered and hydrated on a
+  later run
+
+### Requirement: Company display name is derived from the company profile URL slug
+
+The system SHALL derive `Job.Company` from the `/company/<slug>-<id>/` link on the detail
+page by stripping the trailing numeric id and title-casing the hyphen-separated slug, because
+the page's own visible company name is rendered masked (paywalled). A detail page carrying no
+company profile link SHALL be skipped rather than stored with an empty or masked company name.
+
+#### Scenario: A company slug is title-cased into a display name
+
+- **WHEN** a detail page's company link is `/company/medison-pharma-16767/`
+- **THEN** `Job.Company` is set to `Medison Pharma`
+
+#### Scenario: A detail page without a company link is dropped
+
+- **WHEN** a detail page carries no `/company/<slug>-<id>/` link
+- **THEN** that posting is not returned as a job
+
+### Requirement: Description and skills are built from the page's structured sections, salary is dropped
+
+The system SHALL build `Job.Description` from the detail page's "Tasks" section list items (a
+newline-separated bullet rendering), and `Job.Skills` from the "Skills/Tech-stack" section's
+anchor texts. A "Perks/Benefits" section whose only item is the literal text `N/A` SHALL be
+omitted from the description rather than rendered. The system SHALL NOT parse or store the
+page's salary figure, since it is aggregator-computed ("estimate") rather than employer-stated.
+
+#### Scenario: Tasks become the description
+
+- **WHEN** a detail page's Tasks section lists several bullet items
+- **THEN** `Job.Description` renders those items as a bullet list
+
+#### Scenario: Skills populate the Skills field, not the description
+
+- **WHEN** a detail page's Skills/Tech-stack section links several skill names
+- **THEN** those names populate `Job.Skills` and are not duplicated into `Job.Description`
+
+#### Scenario: A placeholder Perks section is omitted
+
+- **WHEN** a detail page's Perks/Benefits section contains only the item `N/A`
+- **THEN** no perks content is added to `Job.Description`
+
+#### Scenario: Salary is never stored
+
+- **WHEN** a detail page displays a salary badge marked "(estimate)"
+- **THEN** the returned job carries no salary value derived from that badge
+
+### Requirement: Posted time is parsed from the relative-time string
+
+The system SHALL parse `Job.PostedAt` from the detail page's "Found X<unit> ago" text (e.g.
+`8h ago`, `3d ago`) relative to the crawl time, handling at minimum hour and day units. A
+posting whose relative-time text does not match a recognized unit SHALL be returned with
+`PostedAt` unset rather than failing the whole posting.
+
+#### Scenario: Hours-ago is parsed
+
+- **WHEN** a detail page reads "Found 8h ago"
+- **THEN** `Job.PostedAt` is set to approximately 8 hours before the crawl time
+
+#### Scenario: Days-ago is parsed
+
+- **WHEN** a detail page reads "Found 3d ago"
+- **THEN** `Job.PostedAt` is set to approximately 3 days before the crawl time
+
+#### Scenario: An unrecognized unit leaves PostedAt unset
+
+- **WHEN** a detail page's relative-time text uses a unit the parser does not recognize
+- **THEN** the posting is still returned as a job, with `PostedAt` left nil

--- a/openspec/changes/add-aijobs-adapter/specs/aijobs-source/spec.md
+++ b/openspec/changes/add-aijobs-adapter/specs/aijobs-source/spec.md
@@ -45,8 +45,11 @@ CSRF error), not retried without it.
 
 The system SHALL implement the hydrating fetch path (`FetchNew`), issuing a per-posting detail
 `GET` only for a posting whose external id the supplied `seen` predicate reports as not yet
-ingested. The plain `Fetch` path (used only when no `seen` predicate is available) SHALL return
-list-only jobs without a detail fetch.
+ingested. The plain `Fetch` path (used only when no `seen` predicate is available) has no
+list-only shape to fall back to — the listing carries no company, and a posting with no company
+is dropped (see "Company display name is derived from the company profile URL slug") — so
+`Fetch` SHALL delegate to `FetchNew` with a predicate that reports every posting as unseen,
+hydrating everything the listing yields up to the same per-run budget as a real crawl.
 
 #### Scenario: An already-ingested posting is not re-fetched
 

--- a/openspec/changes/add-aijobs-adapter/tasks.md
+++ b/openspec/changes/add-aijobs-adapter/tasks.md
@@ -1,36 +1,36 @@
 ## 1. HTTP plumbing
 
-- [ ] 1.1 Add `PostFormWithHeaders(ctx, url, headers map[string]string, values url.Values) (*html.Node, error)` to `internal/sources/http.go`, form-encoding `values` as the request body (`application/x-www-form-urlencoded`) and parsing the response as HTML (mirrors `PostJSONWithHeaders`'s shape but for a form body + HTML response, per design.md Decision 4).
+- [x] 1.1 Add `PostFormWithHeaders(ctx, url, headers map[string]string, values url.Values) (*html.Node, error)` to `internal/sources/http.go`, form-encoding `values` as the request body (`application/x-www-form-urlencoded`) and parsing the response as HTML (mirrors `PostJSONWithHeaders`'s shape but for a form body + HTML response, per design.md Decision 4).
 
 ## 2. Adapter skeleton and registration
 
-- [ ] 2.1 Create `internal/sources/aijobs.go`: `aijobs` struct, `NewAijobs` constructor over a cookie-jar-backed client, `Provider() string { return "aijobs" }`, `boardless()`, `aggregator()` markers (per spec Requirement "aijobs.net is crawled as a boardless aggregator").
-- [ ] 2.2 Register `"aijobs"` in the source registry (`internal/sources/registry.go`), built with `newCookieClient()`.
-- [ ] 2.3 Create `sources/aijobs.yml` with one placeholder boardless entry, mirroring `sources/arbeitnow.yml`'s convention.
+- [x] 2.1 Create `internal/sources/aijobs.go`: `aijobs` struct, `NewAijobs` constructor over a cookie-jar-backed client, `Provider() string { return "aijobs" }`, `boardless()`, `aggregator()` markers (per spec Requirement "aijobs.net is crawled as a boardless aggregator").
+- [x] 2.2 Register `"aijobs"` in the source registry (`internal/sources/registry.go`), built with `newCookieClient()`.
+- [x] 2.3 Create `sources/aijobs.yml` with one placeholder boardless entry, mirroring `sources/arbeitnow.yml`'s convention.
 
 ## 3. CSRF session bootstrap and listing pagination
 
-- [ ] 3.1 Implement session bootstrap: a `GET` to `https://aijobs.net/` to acquire the `csrftoken` cookie once per run (per spec Requirement "The listing session is authenticated per run via a CSRF cookie").
-- [ ] 3.2 Implement the paginated listing walk: `POST /?page=N` via `PostFormWithHeaders`, echoing the csrftoken as the `x-csrftoken` header and `csrfmiddlewaretoken` form field, with the required `Referer` header; extract each page's job links (slug + numeric external id) from the response HTML.
-- [ ] 3.3 Implement the pagination stop conditions: stop when a page's postings are ALL already reported by `seen`, or when a hard `aijobsMaxPages` cap is reached (per spec Requirement "Listing pagination is bounded by a seen-page stop and a hard page cap").
+- [x] 3.1 Implement session bootstrap: a `GET` to `https://aijobs.net/` to acquire the `csrftoken` cookie once per run (per spec Requirement "The listing session is authenticated per run via a CSRF cookie").
+- [x] 3.2 Implement the paginated listing walk: `POST /?page=N` via `PostFormWithHeaders`, echoing the csrftoken as the `x-csrftoken` header and `csrfmiddlewaretoken` form field, with the required `Referer` header; extract each page's job links (slug + numeric external id) from the response HTML.
+- [x] 3.3 Implement the pagination stop conditions: stop when a page's postings are ALL already reported by `seen`, or when a hard `aijobsMaxPages` cap is reached (per spec Requirement "Listing pagination is bounded by a seen-page stop and a hard page cap").
 
 ## 4. Detail-page parsing
 
-- [ ] 4.1 Parse the company display name from the detail page's `/company/<slug>-<id>/` link: strip the trailing `-<id>`, title-case the hyphen-split slug; drop the posting if no company link is present (per spec Requirement "Company display name is derived from the company profile URL slug").
-- [ ] 4.2 Parse `Job.Description` from the "Tasks" section's list items as a bullet list, and `Job.Skills` from the "Skills/Tech-stack" section's anchor texts; omit a "Perks/Benefits" section whose only item is `N/A`; do not parse or store the salary badge (per spec Requirement "Description and skills are built from the page's structured sections, salary is dropped").
-- [ ] 4.3 Parse `Job.Remote` from the location badge marked `R`, and `Job.Title`/`Job.Location` from the page header.
+- [x] 4.1 Parse the company display name from the detail page's `/company/<slug>-<id>/` link: strip the trailing `-<id>`, title-case the hyphen-split slug; drop the posting if no company link is present (per spec Requirement "Company display name is derived from the company profile URL slug").
+- [x] 4.2 Parse `Job.Description` from the "Tasks" section's list items as a bullet list, and `Job.Skills` from the "Skills/Tech-stack" section's anchor texts; omit a "Perks/Benefits" section whose only item is `N/A`; do not parse or store the salary badge (per spec Requirement "Description and skills are built from the page's structured sections, salary is dropped").
+- [x] 4.3 Parse `Job.Remote` from the location badge marked `R`, and `Job.Title`/`Job.Location` from the page header.
 
 ## 5. Relative-time parsing (PostedAt)
 
-- [ ] 5.1 Implement parsing of the "Found X<unit> ago" text into `Job.PostedAt`, handling at minimum `h` (hours) and `d` (days); an unrecognized unit leaves `PostedAt` nil rather than failing the posting (per spec Requirement "Posted time is parsed from the relative-time string"). **Note:** the month/year unit-conversion approximation (calendar-aware `time.AddDate` vs. a flat-day duration) is a deliberate design choice left for the user to make when writing this task.
+- [x] 5.1 Implement parsing of the "Found X<unit> ago" text into `Job.PostedAt`, handling at minimum `h` (hours) and `d` (days); an unrecognized unit leaves `PostedAt` nil rather than failing the posting (per spec Requirement "Posted time is parsed from the relative-time string"). **Note:** the month/year unit-conversion approximation (calendar-aware `time.AddDate` vs. a flat-day duration) is a deliberate design choice left for the user to make when writing this task.
 
 ## 6. Hydrating fetch and per-run budget
 
-- [ ] 6.1 Implement `Fetch` (list-only fallback, no detail requests) for use when no `seen` predicate is supplied.
-- [ ] 6.2 Implement `FetchNew(ctx, e, seen)`: walk the listing (§3), skip a detail fetch for any external id `seen` reports true, and fetch detail (§4, §5) for the rest via the shared `fetchDetails` bounded-worker helper.
-- [ ] 6.3 Add the `AIJOBS_MAX_NEW_PER_RUN` env var (default 500): once that many unseen postings are queued for detail fetch in one run, stop issuing further detail requests and stop discovering further listing pages (per spec Requirement "New-posting detail fetches are bounded per run").
+- [x] 6.1 Implement `Fetch` for use when no `seen` predicate is supplied. Shipped as a hydrating fallback, not the originally-planned list-only one: aijobs's listing carries no company, and a company-less posting is dropped, so a genuinely detail-less `Fetch` could never return a usable `Job`. It delegates to `FetchNew` with a predicate reporting everything unseen instead — see design.md Decision 1 and the spec's "Detail fetches happen only for postings not already in the catalogue" Requirement, both updated to match.
+- [x] 6.2 Implement `FetchNew(ctx, e, seen)`: walk the listing (§3), skip a detail fetch for any external id `seen` reports true, and fetch detail (§4, §5) for the rest via the shared `fetchDetails` bounded-worker helper.
+- [x] 6.3 Add the `AIJOBS_MAX_NEW_PER_RUN` env var (default 500): once that many unseen postings are queued for detail fetch in one run, stop issuing further detail requests and stop discovering further listing pages (per spec Requirement "New-posting detail fetches are bounded per run").
 
 ## 7. Verification
 
-- [ ] 7.1 Run `go vet ./...` and `go vet -tags=integration ./...`; run `go test ./internal/sources/...`.
-- [ ] 7.2 Run `go run ./cmd/ingest sources/aijobs.yml` against a local `DATABASE_URL` and confirm a bounded first crawl ingests jobs with company/description/skills populated and no salary field set.
+- [x] 7.1 Run `go vet ./...` and `go vet -tags=integration ./...`; run `go test ./internal/sources/...`.
+- [x] 7.2 Run `go run ./cmd/ingest sources/aijobs.yml` against a local `DATABASE_URL` and confirm a bounded first crawl ingests jobs with company/description/skills populated and no salary field set.

--- a/openspec/changes/add-aijobs-adapter/tasks.md
+++ b/openspec/changes/add-aijobs-adapter/tasks.md
@@ -1,0 +1,36 @@
+## 1. HTTP plumbing
+
+- [ ] 1.1 Add `PostFormWithHeaders(ctx, url, headers map[string]string, values url.Values) (*html.Node, error)` to `internal/sources/http.go`, form-encoding `values` as the request body (`application/x-www-form-urlencoded`) and parsing the response as HTML (mirrors `PostJSONWithHeaders`'s shape but for a form body + HTML response, per design.md Decision 4).
+
+## 2. Adapter skeleton and registration
+
+- [ ] 2.1 Create `internal/sources/aijobs.go`: `aijobs` struct, `NewAijobs` constructor over a cookie-jar-backed client, `Provider() string { return "aijobs" }`, `boardless()`, `aggregator()` markers (per spec Requirement "aijobs.net is crawled as a boardless aggregator").
+- [ ] 2.2 Register `"aijobs"` in the source registry (`internal/sources/registry.go`), built with `newCookieClient()`.
+- [ ] 2.3 Create `sources/aijobs.yml` with one placeholder boardless entry, mirroring `sources/arbeitnow.yml`'s convention.
+
+## 3. CSRF session bootstrap and listing pagination
+
+- [ ] 3.1 Implement session bootstrap: a `GET` to `https://aijobs.net/` to acquire the `csrftoken` cookie once per run (per spec Requirement "The listing session is authenticated per run via a CSRF cookie").
+- [ ] 3.2 Implement the paginated listing walk: `POST /?page=N` via `PostFormWithHeaders`, echoing the csrftoken as the `x-csrftoken` header and `csrfmiddlewaretoken` form field, with the required `Referer` header; extract each page's job links (slug + numeric external id) from the response HTML.
+- [ ] 3.3 Implement the pagination stop conditions: stop when a page's postings are ALL already reported by `seen`, or when a hard `aijobsMaxPages` cap is reached (per spec Requirement "Listing pagination is bounded by a seen-page stop and a hard page cap").
+
+## 4. Detail-page parsing
+
+- [ ] 4.1 Parse the company display name from the detail page's `/company/<slug>-<id>/` link: strip the trailing `-<id>`, title-case the hyphen-split slug; drop the posting if no company link is present (per spec Requirement "Company display name is derived from the company profile URL slug").
+- [ ] 4.2 Parse `Job.Description` from the "Tasks" section's list items as a bullet list, and `Job.Skills` from the "Skills/Tech-stack" section's anchor texts; omit a "Perks/Benefits" section whose only item is `N/A`; do not parse or store the salary badge (per spec Requirement "Description and skills are built from the page's structured sections, salary is dropped").
+- [ ] 4.3 Parse `Job.Remote` from the location badge marked `R`, and `Job.Title`/`Job.Location` from the page header.
+
+## 5. Relative-time parsing (PostedAt)
+
+- [ ] 5.1 Implement parsing of the "Found X<unit> ago" text into `Job.PostedAt`, handling at minimum `h` (hours) and `d` (days); an unrecognized unit leaves `PostedAt` nil rather than failing the posting (per spec Requirement "Posted time is parsed from the relative-time string"). **Note:** the month/year unit-conversion approximation (calendar-aware `time.AddDate` vs. a flat-day duration) is a deliberate design choice left for the user to make when writing this task.
+
+## 6. Hydrating fetch and per-run budget
+
+- [ ] 6.1 Implement `Fetch` (list-only fallback, no detail requests) for use when no `seen` predicate is supplied.
+- [ ] 6.2 Implement `FetchNew(ctx, e, seen)`: walk the listing (§3), skip a detail fetch for any external id `seen` reports true, and fetch detail (§4, §5) for the rest via the shared `fetchDetails` bounded-worker helper.
+- [ ] 6.3 Add the `AIJOBS_MAX_NEW_PER_RUN` env var (default 500): once that many unseen postings are queued for detail fetch in one run, stop issuing further detail requests and stop discovering further listing pages (per spec Requirement "New-posting detail fetches are bounded per run").
+
+## 7. Verification
+
+- [ ] 7.1 Run `go vet ./...` and `go vet -tags=integration ./...`; run `go test ./internal/sources/...`.
+- [ ] 7.2 Run `go run ./cmd/ingest sources/aijobs.yml` against a local `DATABASE_URL` and confirm a bounded first crawl ingests jobs with company/description/skills populated and no salary field set.

--- a/sources/aijobs.yml
+++ b/sources/aijobs.yml
@@ -1,0 +1,4 @@
+# aijobs.net: a single global AI/ML job feed (boardless). One entry names the provider;
+# each job's company comes from the posting, not this placeholder.
+- company: AI Jobs
+  provider: aijobs


### PR DESCRIPTION
## Summary
- New `internal/sources/aijobs.go` adapter for aijobs.net (~47k AI/ML job aggregator): CSRF-protected listing pagination (Django double-submit cookie pattern), per-posting detail hydration only for unseen postings (`HydratingSource.FetchNew`), bounded per run by `AIJOBS_MAX_NEW_PER_RUN` (default 500).
- Company name derived from the `/company/<slug>-<id>/` URL (the page's own visible label is masked behind a PRO paywall); description built from the site's own structured "Tasks" section (no free-text prose exists on the page); skills from "Skills/Tech-stack"; salary deliberately never parsed (the site's figures are aggregator-estimated, not employer-stated, and `Job` has no salary field to begin with).
- New `internal/sources/http.go` primitives: `PostFormWithHeaders` (form-urlencoded POST, needed since every existing POST helper was JSON-only) and `CookieValue` (reads back a cookie the jar already holds, for the CSRF double-submit pattern).
- `cookieSessionSource` generic helper unifies `taleo` and `aijobs`'s identical registry registration shape (both need a fresh cookie-jar session rather than the shared client).
- New board file `sources/aijobs.yml` (boardless + aggregator, its own file rather than the shared hourly `custom.yml` given the ~47k-posting backlog).
- Planned via OpenSpec (`openspec/changes/add-aijobs-adapter/`): proposal, design (dedup-risk trade-off explicitly accepted — some duplicates against directly-crawled ATS sources won't collapse, same class of imprecision `bayt`/`whatjobs` already carry), spec, and a task-by-task TDD implementation log.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — all clean
- [x] `go test ./...` — full repo, 0 failures
- [x] `go test ./internal/sources/... -run TestAijobs -v` — 24/24 pass, including `-race`
- [x] Live smoke test: `go run ./cmd/ingest sources/aijobs.yml` against a local Postgres — 25 real postings ingested (`failed=0`), company/description/skills populated on every row, 0 blank; a real-site discrepancy (a recently-crawled posting reads "Found X ago", an older one reads "Published X ago" instead) was caught by this live run and fixed before merge