### PR TITLE
chore(design-system): record adoption baseline drop from PR #1600

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -8,7 +8,7 @@
   "Dialog": 6,
   "EmptyState": 0,
   "FormField": 0,
-  "Input": 12,
+  "Input": 11,
   "Pagination": 0,
   "Skeleton": 1,
   "Table": 0,


### PR DESCRIPTION
## What and why

PR #1600 (profile city autocomplete) replaced a native `<Input>` with
`RemoteSearchSelect` for two ProfileForm fields, dropping the `Input` primitive's
adoption count from 12 files to 11. The `design-system` CI job's adoption ratchet
holds the baseline exact in both directions, so main's `design-system` job has been
red since #1600 merged (not a required check, so it didn't block, but it's wrong).

This records the new count with `pnpm check:adoption --update` — no code change.

## Test plan
- [x] `node scripts/check-adoption.mjs` — passes clean against the new baseline