### PR TITLE
fixup(skilltag): tighten sales/support vocab docs and coverage

### DIFF
--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -1082,11 +1082,14 @@ var professionalPhraseAliases = []phraseAlias{
 	{"business development", "business-development"},
 	{"pipeline management", "pipeline-management"},
 	{"cold outreach", "cold-outreach"},
+	{"sales enablement", "sales-enablement"},
+	{"lead generation", "lead-generation"},
 	// customer success
 	{"customer onboarding", "customer-onboarding"},
 	{"customer retention", "customer-retention"},
 	{"churn prevention", "churn-prevention"},
 	{"customer health score", "customer-health-score"},
+	{"renewal management", "renewal-management"},
 	{"gainsight", "gainsight"}, {"churnzero", "churnzero"},
 	// support
 	{"help desk", "help-desk"},
@@ -1170,6 +1173,8 @@ var nonCorroboratingPhrases = map[string]bool{
 	"business-development": true,
 	"pipeline-management":  true,
 	"cold-outreach":        true,
+	"sales-enablement":     true,
+	"lead-generation":      true,
 	"help-desk":            true,
 	"service-desk":         true,
 	"ticket-resolution":    true,

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -964,8 +964,9 @@ var engineeringPhraseAliases = []phraseAlias{
 	//     "a key lever", "a flexible workday". Same doctrine as burp/druid above: such
 	//     a name may only return through a qualifying phrase, never as a bare token.
 	//
-	// The recruiting/HR/finance/legal/operations/customer-success half of this seed set
-	// lives in professionalPhraseAliases below — same matching, separate list.
+	// The recruiting/HR/finance/legal/operations/customer-success/sales/support half of
+	// this seed set lives in professionalPhraseAliases below — same matching, separate
+	// list.
 	// business analysis
 	{"requirements gathering", "requirements-gathering"},
 	{"requirements elicitation", "requirements-elicitation"},
@@ -1162,13 +1163,16 @@ var nonCorroboratingPhrases = map[string]bool{
 	"influencer-marketing":           true,
 	"copywriting":                    true,
 	"go-to-market":                   true,
-	"account-executive":              true,
-	"business-development":           true,
-	"pipeline-management":            true,
-	"cold-outreach":                  true,
-	"help-desk":                      true,
-	"service-desk":                   true,
-	"ticket-resolution":              true,
+	// sales / support — same doctrine as the marketing disciplines above: "manage our
+	// CRM as an account executive" names the gated word "crm" without evidencing any
+	// technical involvement with it, and that phrasing recurs at scale in this category.
+	"account-executive":    true,
+	"business-development": true,
+	"pipeline-management":  true,
+	"cold-outreach":        true,
+	"help-desk":            true,
+	"service-desk":         true,
+	"ticket-resolution":    true,
 }
 
 // nonEngineeringCanonicals is derived from professionalPhraseAliases, never written by

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -1029,11 +1029,11 @@ var engineeringPhraseAliases = []phraseAlias{
 }
 
 // professionalPhraseAliases is the non-engineering half of the IT-company role
-// vocabulary: the recruiting, HR, finance, legal, operations and customer-success
-// craft a technical company hires for without hiring an engineer. Parse matches these
-// exactly like any other phrase — a skills facet describes every posting, not only the
-// technical ones — but they are declared apart so a caller can ask the narrower
-// question HasEngineering answers.
+// vocabulary: the recruiting, HR, finance, legal, operations, sales, customer-success
+// and support craft a technical company hires for without hiring an engineer. Parse
+// matches these exactly like any other phrase — a skills facet describes every posting,
+// not only the technical ones — but they are declared apart so a caller can ask the
+// narrower question HasEngineering answers.
 //
 // What is NOT here is the point: developer relations, technical writing, business
 // analysis and pre-sales stay in engineeringPhraseAliases. They are tech-industry
@@ -1076,12 +1076,21 @@ var professionalPhraseAliases = []phraseAlias{
 	{"program management", "program-management"},
 	{"strategic planning", "strategic-planning"},
 	{"stakeholder management", "stakeholder-management"},
+	// sales
+	{"account executive", "account-executive"},
+	{"business development", "business-development"},
+	{"pipeline management", "pipeline-management"},
+	{"cold outreach", "cold-outreach"},
 	// customer success
 	{"customer onboarding", "customer-onboarding"},
 	{"customer retention", "customer-retention"},
 	{"churn prevention", "churn-prevention"},
 	{"customer health score", "customer-health-score"},
 	{"gainsight", "gainsight"}, {"churnzero", "churnzero"},
+	// support
+	{"help desk", "help-desk"},
+	{"service desk", "service-desk"},
+	{"ticket resolution", "ticket-resolution"},
 	// marketing — search optimization tooling. These are unambiguous product names,
 	// so they are strong matches, which also makes them corroborators for the gated
 	// `seo` canonical: before this block a posting could name its whole toolchain and
@@ -1153,6 +1162,13 @@ var nonCorroboratingPhrases = map[string]bool{
 	"influencer-marketing":           true,
 	"copywriting":                    true,
 	"go-to-market":                   true,
+	"account-executive":              true,
+	"business-development":           true,
+	"pipeline-management":            true,
+	"cold-outreach":                  true,
+	"help-desk":                      true,
+	"service-desk":                   true,
+	"ticket-resolution":              true,
 }
 
 // nonEngineeringCanonicals is derived from professionalPhraseAliases, never written by

--- a/internal/skilltag/dictionaries_test.go
+++ b/internal/skilltag/dictionaries_test.go
@@ -132,7 +132,7 @@ func TestNonCorroboratingPhrasesAllExist(t *testing.T) {
 	}
 }
 
-func TestParse_UncoveredProfessionalRoleSkills(t *testing.T) {
+func TestParse_SalesAndSupportVocab(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string

--- a/internal/skilltag/dictionaries_test.go
+++ b/internal/skilltag/dictionaries_test.go
@@ -77,8 +77,9 @@ func TestHasEngineering(t *testing.T) {
 		{"pure legal", []string{"contract-negotiation", "regulatory-compliance"}, false},
 		{"pure operations", []string{"stakeholder-management", "process-improvement"}, false},
 		{"pure customer success", []string{"customer-onboarding", "churn-prevention"}, false},
-		{"pure sales", []string{"account-executive", "pipeline-management"}, false},
+		{"pure sales", []string{"account-executive", "pipeline-management", "lead-generation"}, false},
 		{"pure support", []string{"help-desk", "ticket-resolution"}, false},
+		{"pure customer success renewal", []string{"renewal-management"}, false},
 		// One engineering canonical is enough — the board has posted something technical.
 		{"recruiter who also names a stack", []string{"talent-sourcing", "python"}, true},
 		{"plain engineering", []string{"kubernetes"}, true},
@@ -140,12 +141,14 @@ func TestParse_SalesAndSupportVocab(t *testing.T) {
 	}{
 		{
 			name: "sales",
-			in:   "Account executive responsible for business development, pipeline management, and cold outreach",
+			in:   "Account executive responsible for business development, pipeline management, cold outreach, sales enablement, and lead generation",
 			want: []string{
 				"account-executive",
 				"business-development",
 				"cold-outreach",
+				"lead-generation",
 				"pipeline-management",
+				"sales-enablement",
 			},
 		},
 		{
@@ -155,6 +158,13 @@ func TestParse_SalesAndSupportVocab(t *testing.T) {
 				"help-desk",
 				"service-desk",
 				"ticket-resolution",
+			},
+		},
+		{
+			name: "customer success renewal",
+			in:   "Customer success manager owning renewal management for the book of business",
+			want: []string{
+				"renewal-management",
 			},
 		},
 	}

--- a/internal/skilltag/dictionaries_test.go
+++ b/internal/skilltag/dictionaries_test.go
@@ -1,6 +1,9 @@
 package skilltag
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 // TestDictionaryInvariants guards the two properties the engine relies on:
 // every canonical is a stable slug (lowercase, no spaces), and the vocabulary is
@@ -50,10 +53,10 @@ func assertSlug(t *testing.T, what, s string) {
 }
 
 // The dictionary deliberately covers the NON-engineering roles an IT company hires
-// for — recruiting, HR, finance, legal, operations, customer success. That is right
-// for a skills facet, which describes any posting. It is wrong as evidence that a
-// board is a technical employer: cmd/prune's board report treated "has any skill" as
-// "has posted something technical", so a recruiting coordinator tagged
+// for — recruiting, HR, finance, legal, operations, customer success, sales and support.
+// That is right for a skills facet, which describes any posting. It is wrong as
+// evidence that a board is a technical employer: cmd/prune's board report treated
+// "has any skill" as "has posted something technical", so a recruiting coordinator tagged
 // {stakeholder-management, candidate-experience} vouched for the whole board.
 //
 // HasEngineering is the narrower question that report should have been asking.
@@ -74,6 +77,8 @@ func TestHasEngineering(t *testing.T) {
 		{"pure legal", []string{"contract-negotiation", "regulatory-compliance"}, false},
 		{"pure operations", []string{"stakeholder-management", "process-improvement"}, false},
 		{"pure customer success", []string{"customer-onboarding", "churn-prevention"}, false},
+		{"pure sales", []string{"account-executive", "pipeline-management"}, false},
+		{"pure support", []string{"help-desk", "ticket-resolution"}, false},
 		// One engineering canonical is enough — the board has posted something technical.
 		{"recruiter who also names a stack", []string{"talent-sourcing", "python"}, true},
 		{"plain engineering", []string{"kubernetes"}, true},
@@ -124,5 +129,41 @@ func TestNonCorroboratingPhrasesAllExist(t *testing.T) {
 		if !declared[c] {
 			t.Errorf("nonCorroboratingPhrases names %q, which no phrase alias emits", c)
 		}
+	}
+}
+
+func TestParse_UncoveredProfessionalRoleSkills(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "sales",
+			in:   "Account executive responsible for business development, pipeline management, and cold outreach",
+			want: []string{
+				"account-executive",
+				"business-development",
+				"cold-outreach",
+				"pipeline-management",
+			},
+		},
+		{
+			name: "support",
+			in:   "Help desk specialist responsible for ticket resolution and service desk operations",
+			want: []string{
+				"help-desk",
+				"service-desk",
+				"ticket-resolution",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Parse(c.in); !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Parse(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
 	}
 }

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -1120,6 +1120,28 @@ func TestParse_SalesAndSupportDoNotCorroborate(t *testing.T) {
 			}
 		}
 	})
+	t.Run("lead generation does not pull in the gated concept", func(t *testing.T) {
+		got := Parse("Lead generation using our CRM and analytics tools.")
+		if !slices.Contains(got, "lead-generation") {
+			t.Errorf("Parse(...) = %v, want lead-generation", got)
+		}
+		for _, unwanted := range []string{"crm", "analytics"} {
+			if slices.Contains(got, unwanted) {
+				t.Errorf("Parse(...) = %v, must not contain %q", got, unwanted)
+			}
+		}
+	})
+	t.Run("sales enablement does not pull in the gated concept", func(t *testing.T) {
+		got := Parse("Sales enablement lead supporting reps with our CRM and analytics stack.")
+		if !slices.Contains(got, "sales-enablement") {
+			t.Errorf("Parse(...) = %v, want sales-enablement", got)
+		}
+		for _, unwanted := range []string{"crm", "analytics"} {
+			if slices.Contains(got, unwanted) {
+				t.Errorf("Parse(...) = %v, must not contain %q", got, unwanted)
+			}
+		}
+	})
 }
 
 // TestParse_MarketingSeparatorInsensitive checks that the separator rule the

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -1090,6 +1090,38 @@ func TestParse_DisciplinePhrasesDoNotCorroborate(t *testing.T) {
 	})
 }
 
+// TestParse_SalesAndSupportDoNotCorroborate mirrors
+// TestParse_DisciplinePhrasesDoNotCorroborate for the sales/support phrases: they tag
+// on their own but must not rescue a gated word that merely appears beside them.
+func TestParse_SalesAndSupportDoNotCorroborate(t *testing.T) {
+	t.Run("sales phrase does not pull in the gated concept", func(t *testing.T) {
+		got := Parse("Manage our CRM as an account executive.")
+		if !slices.Contains(got, "account-executive") {
+			t.Errorf("Parse(...) = %v, want account-executive", got)
+		}
+		if slices.Contains(got, "crm") {
+			t.Errorf("Parse(...) = %v, must not contain %q", got, "crm")
+		}
+	})
+	t.Run("support phrase does not pull in the gated concept", func(t *testing.T) {
+		got := Parse("Ticket resolution specialist troubleshooting via shell scripts the eng team wrote.")
+		if !slices.Contains(got, "ticket-resolution") {
+			t.Errorf("Parse(...) = %v, want ticket-resolution", got)
+		}
+		if slices.Contains(got, "shell") {
+			t.Errorf("Parse(...) = %v, must not contain %q", got, "shell")
+		}
+	})
+	t.Run("sales and support phrases stand alone", func(t *testing.T) {
+		got := Parse("Business development lead driving cold outreach and pipeline management.")
+		for _, want := range []string{"business-development", "cold-outreach", "pipeline-management"} {
+			if !slices.Contains(got, want) {
+				t.Errorf("Parse(...) = %v, want %q", got, want)
+			}
+		}
+	})
+}
+
 // TestParse_MarketingSeparatorInsensitive checks that the separator rule the
 // matcher already guarantees holds for the new multi-word canonicals too — the
 // dictionary lists only the space form, so the hyphen and underscore spellings


### PR DESCRIPTION
Follow-up to #1617 — small documentation/test-coverage fixes plus a couple of vocab gaps, on top of that PR's sales/support vocabulary addition.

**Commit 1 — doc/coverage fixes for the original PR:**
- Fixes the stale `engineeringPhraseAliases` pointer comment, which listed the professional categories but hadn't been updated to mention sales/support.
- Adds a short rationale comment to the new `nonCorroboratingPhrases` entries, explaining why they're marked non-corroborating (mirrors the existing marketing-disciplines doctrine comment).
- Renames `TestParse_UncoveredProfessionalRoleSkills` to `TestParse_SalesAndSupportVocab` to match this file's naming convention (`TestParse_MarketingDisciplines`, `TestParse_ExpansionBatch3`, etc).
- Adds `TestParse_SalesAndSupportDoNotCorroborate`, the missing counterpart to `TestParse_DisciplinePhrasesDoNotCorroborate` — the original PR marks 7 new phrases as non-corroborating but had no test asserting that behavior (only one of the seven was incidentally covered by a pre-existing test).

**Commit 2 — a few vocab gaps in the same spirit as #1617:**
- `sales enablement`, `lead generation` (sales) — join the non-corroborating set, same reasoning as `account-executive` etc.
- `renewal management` (customer success) — corroborates like its `churn-prevention`/`customer-retention` siblings, not added to the non-corroborating set.
- Considered `service level agreement`/SLA and dropped it: the spelled-out phrase has poor recall (postings say "SLA"), and the bare acronym collides with non-tech readings (Sri Lanka, statute of limitations) — not worth resolving inside this small follow-up.

Verified: `gofmt`, `go vet ./internal/skilltag/...`, `go vet -tags=integration ./internal/skilltag/...`, and `go test ./internal/skilltag/...` all pass.

## Test plan
- [x] `go test ./internal/skilltag/...`
- [x] `go vet ./internal/skilltag/...`
- [x] `go vet -tags=integration ./internal/skilltag/...`
- [x] `gofmt -l internal/skilltag/`