### PR TITLE
Fix 22 bugs found in a full backend architecture review

### DIFF
--- a/internal/atsboard/board.go
+++ b/internal/atsboard/board.go
@@ -190,11 +190,20 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 
 	switch mode {
 	case modeSubdomain, modeSubdomainChain, modeHost:
+		// The vendor's own product host must not be read as a tenant, regardless of which of
+		// the three modes matched: all three derive the board from host's leftmost DNS label
+		// (bare, chained, or as the whole host), and a platform label like "app" or "help" sits
+		// in that exact position for a subdomain tenant just as much as for a bare-host one —
+		// e.g. app.recruitee.com and help.bamboohr.com are the vendor's own login/support hosts,
+		// not a company named "app" or "help".
+		if platformHost(host) {
+			return "", "", "", false
+		}
 		if mode == modeSubdomain {
 			board = subdomainLabel(host, apex)
 		} else if mode == modeSubdomainChain {
 			board = subdomainChain(host, apex)
-		} else if !platformHost(host) {
+		} else {
 			board = host // the whole careers host is the tenant identity
 		}
 		if board == "" {

--- a/internal/atsboard/board_test.go
+++ b/internal/atsboard/board_test.go
@@ -131,6 +131,12 @@ func TestRecognize(t *testing.T) {
 		// takes the first recognized ATS URL in a page, recorded it as the employer's board.
 		{"teamtailor platform app host not a tenant", "https://app.teamtailor.com/companies/1/jobs", "", "", "", false},
 		{"teamtailor platform dashboard host not a tenant", "https://dashboard.teamtailor.com/", "", "", "", false},
+		// The same platform-host guard applies to subdomain mode, not just host mode: Recruitee's
+		// own employer app lives at app.recruitee.com and BambooHR's own support center at
+		// help.bamboohr.com — both real, public vendor hosts, neither a tenant named "app" or
+		// "help". Before this guard was wired into modeSubdomain, both resolved as false boards.
+		{"recruitee platform app host not a tenant", "https://app.recruitee.com/", "", "", "", false},
+		{"bamboohr platform help host not a tenant", "https://help.bamboohr.com/s/article/x", "", "", "", false},
 		{"unknown host", "https://example.com/careers/1", "", "", "", false},
 		{"not http", "ftp://acme.recruitee.com", "", "", "", false},
 		{"garbage", "not a url", "", "", "", false},

--- a/internal/auth/oauth/github.go
+++ b/internal/auth/oauth/github.go
@@ -8,6 +8,8 @@ import (
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/endpoints"
+
+	"github.com/strelov1/freehire/internal/safehttp"
 )
 
 // githubProvider implements GitHub sign-in. GitHub is plain OAuth2 (no OIDC
@@ -39,7 +41,7 @@ func (p *githubProvider) AuthCodeURL(state string) string {
 }
 
 func (p *githubProvider) FetchIdentity(ctx context.Context, code string) (Identity, error) {
-	ctx = guardedOAuthContext(ctx)
+	ctx = safehttp.GuardedOAuth2Context(ctx, userinfoTimeout)
 	tok, err := p.cfg.Exchange(ctx, code)
 	if err != nil {
 		return Identity{}, fmt.Errorf("github: exchange code: %w", err)

--- a/internal/auth/oauth/oidc.go
+++ b/internal/auth/oauth/oidc.go
@@ -22,21 +22,6 @@ const maxUserinfoBytes = 1 << 20 // 1 MiB
 // userinfoTimeout bounds the OAuth token-exchange and userinfo round-trips.
 const userinfoTimeout = 15 * time.Second
 
-// guardedOAuthContext returns ctx carrying an SSRF-guarded HTTP client, so the
-// oauth2 token exchange and the userinfo fetch both dial through safehttp — every
-// other outbound fetch in this service does. The provider endpoints are fixed
-// public constants, so this is defense-in-depth and consistency, not a live fix.
-//
-// A caller-supplied oauth2.HTTPClient is respected (tests inject an httptest
-// client for their loopback stub); the production handler never sets one, so it
-// always gets the guard.
-func guardedOAuthContext(ctx context.Context) context.Context {
-	if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
-		return ctx
-	}
-	return context.WithValue(ctx, oauth2.HTTPClient, safehttp.NewClient(userinfoTimeout))
-}
-
 // oidcProvider covers every provider that exposes a standard OIDC userinfo
 // endpoint (Google, LinkedIn): exchange the code, then one GET for
 // sub/email/email_verified.
@@ -84,7 +69,7 @@ func (p *oidcProvider) AuthCodeURL(state string) string {
 }
 
 func (p *oidcProvider) FetchIdentity(ctx context.Context, code string) (Identity, error) {
-	ctx = guardedOAuthContext(ctx)
+	ctx = safehttp.GuardedOAuth2Context(ctx, userinfoTimeout)
 	tok, err := p.cfg.Exchange(ctx, code)
 	if err != nil {
 		return Identity{}, fmt.Errorf("%s: exchange code: %w", p.name, err)

--- a/internal/companyname/gate.go
+++ b/internal/companyname/gate.go
@@ -48,11 +48,13 @@ func SlugLike(name string) bool {
 	return hasLetter
 }
 
-// ExtractTitleName pulls a company name out of a careers-page <title>. It
-// handles the shapes ATS careers pages use — a "<lead-in> at {Name}" prefix
-// (Jobs/Careers/Employment Opportunities at …) and a trailing "{Name} Careers" —
-// then cleans a stray "| …" section and collapsed whitespace off the result.
-// Returns "" when no shape matches.
+// ExtractTitleName pulls a company name out of a Pinpoint careers-page <title>: the shapes
+// validated against real Pinpoint boards (PR #825) — a "<lead-in> at {Name}" prefix
+// (Jobs/Careers/Employment Opportunities at …) and a trailing "{Name} Careers" — then cleans
+// a stray "| …" section and collapsed whitespace off the result. Returns "" when neither shape
+// matches. Other ATSes title their careers pages differently (see ExtractSuffixName,
+// ExtractBareTitle) — this is Pinpoint-specific despite the generic name, kept for the
+// callers/tests already using it.
 func ExtractTitleName(title string) string {
 	title = strings.TrimSpace(html.UnescapeString(title))
 	switch {
@@ -64,6 +66,24 @@ func ExtractTitleName(title string) string {
 		}
 		return ""
 	}
+}
+
+// ExtractSuffixName pulls a company name out of a careers-page <title> that names itself
+// "{Name}{suffix}" with no lead-in prefix — Ashby's storefront titles itself "{Name} Jobs".
+// Returns "" when the title does not carry that exact suffix, rather than guessing.
+func ExtractSuffixName(title, suffix string) string {
+	title = strings.TrimSpace(html.UnescapeString(title))
+	if rest, ok := cutSuffixFold(title, suffix); ok {
+		return clean(rest)
+	}
+	return ""
+}
+
+// ExtractBareTitle pulls a company name out of a careers-page <title> that carries nothing
+// but the name itself — Lever's storefront titles the page with the company name alone, no
+// lead-in and no suffix. Only "| …" trimming and whitespace collapsing apply.
+func ExtractBareTitle(title string) string {
+	return clean(strings.TrimSpace(html.UnescapeString(title)))
 }
 
 // clean drops a trailing "| …" fragment (careers titles append a section name

--- a/internal/companyname/resolver.go
+++ b/internal/companyname/resolver.go
@@ -24,31 +24,48 @@ type Resolver interface {
 // alone rather than guessed.
 type Registry map[string]Resolver
 
-// NewRegistry wires the per-ATS resolvers over the shared HTTP getter. Only ATSes
-// whose board is derivable from a job URL are here (see BoardFromURL): the board
-// is the host label (Pinpoint/BambooHR) or first path segment (Lever/Ashby).
-// Greenhouse is intentionally absent — its job URLs are the company's own vanity
-// careers domain (e.g. a16z.com/about/jobs), so no board can be recovered from
-// the URL; resolving it needs a board-from-source-file lookup, a separate seam.
+// NewRegistry wires the per-ATS resolvers over the shared HTTP getter. Only ATSes whose
+// board is derivable from a job URL are here (see BoardFromURL): the board is the host
+// label (Pinpoint) or first path segment (Lever/Ashby).
+//
+// Each ATS titles its careers page differently, and the extractor is picked per source —
+// this stopped being "the same parser, different host template" the moment it was checked
+// against real boards: Pinpoint alone uses the lead-in-or-"Careers"-suffix shape
+// ExtractTitleName was built and validated for (PR #825); Lever's storefront titles the
+// page with the bare company name (jobs.lever.co/binance -> "Binance"); Ashby's titles
+// itself "{Name} Jobs" (jobs.ashbyhq.com/airgarage -> "AirGarage Jobs"). These two shapes
+// match cmd/harvest-boards/prober.go's storefrontEmployer, which independently discovered
+// them for the same platforms.
+//
+// Greenhouse is intentionally absent — its job URLs are the company's own vanity careers
+// domain (e.g. a16z.com/about/jobs), so no board can be recovered from the URL; resolving
+// it needs a board-from-source-file lookup, a separate seam.
+//
+// BambooHR is intentionally absent too: its careers page is a client-rendered SPA whose
+// static, unrendered <title> is just the platform's own boilerplate ("BambooHR"), never
+// the tenant's name — cmd/harvest-boards' bamboohrProber reached the same conclusion and
+// falls back to the slug rather than trying. A resolver wired here would always return ""
+// while looking like it was attempting something; leaving it out is the honest answer.
 func NewRegistry(text textGetter) Registry {
 	return Registry{
-		// Careers-page <title> ATSes: same parser, different host template.
-		"pinpoint": newTitleResolver(text, "https://%s.pinpointhq.com"),
-		"bamboohr": newTitleResolver(text, "https://%s.bamboohr.com/careers"),
-		"lever":    newTitleResolver(text, "https://jobs.lever.co/%s"),
-		"ashby":    newTitleResolver(text, "https://jobs.ashbyhq.com/%s"),
+		"pinpoint": newTitleResolver(text, "https://%s.pinpointhq.com", ExtractTitleName),
+		"lever":    newTitleResolver(text, "https://jobs.lever.co/%s", ExtractBareTitle),
+		"ashby": newTitleResolver(text, "https://jobs.ashbyhq.com/%s", func(title string) string {
+			return ExtractSuffixName(title, " Jobs")
+		}),
 	}
 }
 
 var titleTag = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
 
 type titleResolver struct {
-	http textGetter
-	tmpl string // host/careers URL template with a single %s for the board
+	http    textGetter
+	tmpl    string                    // host/careers URL template with a single %s for the board
+	extract func(title string) string // this ATS's careers-page <title> shape
 }
 
-func newTitleResolver(http textGetter, tmpl string) *titleResolver {
-	return &titleResolver{http: http, tmpl: tmpl}
+func newTitleResolver(http textGetter, tmpl string, extract func(string) string) *titleResolver {
+	return &titleResolver{http: http, tmpl: tmpl, extract: extract}
 }
 
 func (r *titleResolver) Name(ctx context.Context, board string) (string, error) {
@@ -60,5 +77,5 @@ func (r *titleResolver) Name(ctx context.Context, board string) (string, error) 
 	if m == nil {
 		return "", nil
 	}
-	return ExtractTitleName(m[1]), nil
+	return r.extract(m[1]), nil
 }

--- a/internal/companyname/resolver_test.go
+++ b/internal/companyname/resolver_test.go
@@ -14,7 +14,7 @@ func TestTitleResolver(t *testing.T) {
 		"https://lbresearch.pinpointhq.com": `<html><head><title>Jobs at Centellic | Centellic Careers</title></head></html>`,
 		"https://empty.pinpointhq.com":      `<html><head><title>Just a moment...</title></head></html>`,
 	}
-	r := newTitleResolver(getter, "https://%s.pinpointhq.com")
+	r := newTitleResolver(getter, "https://%s.pinpointhq.com", ExtractTitleName)
 
 	if got, _ := r.Name(context.Background(), "lbresearch"); got != "Centellic" {
 		t.Errorf("Name(lbresearch) = %q, want Centellic", got)
@@ -24,9 +24,33 @@ func TestTitleResolver(t *testing.T) {
 	}
 }
 
+// Lever's storefront titles the page with the bare company name — no lead-in, no suffix.
+// Live-verified against jobs.lever.co/binance, whose <title> is literally "Binance".
+func TestLeverResolverUsesTheBareTitle(t *testing.T) {
+	getter := fakeText{
+		"https://jobs.lever.co/binance": `<html><head><title>Binance</title></head></html>`,
+	}
+	reg := NewRegistry(getter)
+	if got, _ := reg["lever"].Name(context.Background(), "binance"); got != "Binance" {
+		t.Errorf("Name(binance) = %q, want Binance", got)
+	}
+}
+
+// Ashby's storefront titles itself "{Name} Jobs" — not the Pinpoint "Careers" suffix.
+// Live-verified against jobs.ashbyhq.com/airgarage, whose <title> is "AirGarage Jobs".
+func TestAshbyResolverUsesTheJobsSuffix(t *testing.T) {
+	getter := fakeText{
+		"https://jobs.ashbyhq.com/airgarage": `<html><head><title>AirGarage Jobs</title></head></html>`,
+	}
+	reg := NewRegistry(getter)
+	if got, _ := reg["ashby"].Name(context.Background(), "airgarage"); got != "AirGarage" {
+		t.Errorf("Name(airgarage) = %q, want AirGarage", got)
+	}
+}
+
 func TestRegistryLookup(t *testing.T) {
 	reg := NewRegistry(fakeText{})
-	for _, src := range []string{"pinpoint", "bamboohr", "lever", "ashby"} {
+	for _, src := range []string{"pinpoint", "lever", "ashby"} {
 		if _, ok := reg[src]; !ok {
 			t.Errorf("registry missing %s resolver", src)
 		}
@@ -34,6 +58,11 @@ func TestRegistryLookup(t *testing.T) {
 	// Greenhouse job URLs are vanity domains, so it has no URL-derivable board.
 	if _, ok := reg["greenhouse"]; ok {
 		t.Error("registry should not have a greenhouse resolver")
+	}
+	// BambooHR's careers page is a client-rendered SPA: the static <title> is always the
+	// platform's own boilerplate, never the tenant's name, so no resolver can work here.
+	if _, ok := reg["bamboohr"]; ok {
+		t.Error("registry should not have a bamboohr resolver — its static title never carries the name")
 	}
 	if _, ok := reg["nonexistent-ats"]; ok {
 		t.Error("registry should not have a resolver for an unknown source")

--- a/internal/config/embed.go
+++ b/internal/config/embed.go
@@ -27,7 +27,11 @@ func LoadEmbed() Embed {
 		BatchSize:    envInt("EMBED_BATCH_SIZE", 500),
 		LeaseSeconds: envInt("EMBED_LEASE_SECONDS", 300),
 		MaxAttempts:  envInt("EMBED_MAX_ATTEMPTS", 3),
-		CallTimeout:  time.Duration(envInt("EMBED_CALL_TIMEOUT_SECONDS", 300)) * time.Second,
+		// 600s, matching SEARCH_DRAIN_CALL_TIMEOUT_SECONDS: both push into a Meili index
+		// whose cost is a fixed whole-index re-merge, so a normal-but-slow batch under load
+		// is the same failure class the search-drain outage was raised to 600s to absorb —
+		// see internal/config/search_drain.go and Runner.skipOnTimeout in both packages.
+		CallTimeout: time.Duration(envInt("EMBED_CALL_TIMEOUT_SECONDS", 600)) * time.Second,
 	}
 	// A non-positive batch size would make the claim's LIMIT 0 (silently no-op) or feed a
 	// negative LIMIT to Postgres; floor it so the worker always makes progress.

--- a/internal/config/embed_test.go
+++ b/internal/config/embed_test.go
@@ -7,7 +7,9 @@ func TestLoadEmbed_defaultsAndOverrides(t *testing.T) {
 		t.Setenv(k, "")
 	}
 	got := LoadEmbed()
-	if got.BatchSize != 500 || got.LeaseSeconds != 300 || got.MaxAttempts != 3 || got.CallTimeout.Seconds() != 300 {
+	// LeaseSeconds' own default (300) is floored up to CallTimeout's default (600): a lease
+	// shorter than one batch's processing would re-claim it mid-flight.
+	if got.BatchSize != 500 || got.LeaseSeconds != 600 || got.MaxAttempts != 3 || got.CallTimeout.Seconds() != 600 {
 		t.Errorf("defaults wrong: %+v", got)
 	}
 

--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -60,12 +60,22 @@ func ashbyJobID(rawURL string) (string, bool) {
 	return "", false
 }
 
-// stripQueryFragment returns rawURL without its query or fragment; the raw string on parse error.
+// stripQueryFragment returns rawURL without its query or fragment, and without a trailing
+// path slash; the raw string on parse error.
+//
+// The trailing-slash trim matters because this is the canonicalization RecordReview keys
+// its dedup on (migrations/0037_link_contributions_review.sql's partial unique index on
+// url WHERE source IS NULL): two people pasting the same unrecognized page that differ
+// only by a trailing slash (".../title" vs ".../title/") must land as the SAME review-queue
+// row, not two. It stops short of internal/atsboard's fuller canonicalization (which also
+// drops a trailing "/apply" segment) — that extra trim is meaningful for a recognized ATS
+// board and would be over-reaching for an arbitrary unrecognized URL here.
 func stripQueryFragment(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return rawURL
 	}
 	u.RawQuery, u.Fragment = "", ""
+	u.Path = strings.TrimSuffix(u.Path, "/")
 	return u.String()
 }

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -1,0 +1,33 @@
+package contribution
+
+import "testing"
+
+// The partial unique index that backs the review queue's dedup (RecordReview) keys on this
+// function's exact output, so a trailing-slash variant of the same page must canonicalize to
+// the same string or it queues as a second row for a human to triage twice.
+func TestStripQueryFragmentTrimsTrailingSlash(t *testing.T) {
+	with := stripQueryFragment("https://dropbox.jobs/en/jobs/12345/title/")
+	without := stripQueryFragment("https://dropbox.jobs/en/jobs/12345/title")
+	if with != without {
+		t.Errorf("stripQueryFragment diverged on a trailing slash: %q vs %q", with, without)
+	}
+	if with != "https://dropbox.jobs/en/jobs/12345/title" {
+		t.Errorf("stripQueryFragment = %q, want the trailing slash trimmed", with)
+	}
+}
+
+func TestStripQueryFragmentDropsQueryAndFragment(t *testing.T) {
+	got := stripQueryFragment("https://example.com/careers/123?utm=x&ref=y#apply")
+	if want := "https://example.com/careers/123"; got != want {
+		t.Errorf("stripQueryFragment = %q, want %q", got, want)
+	}
+}
+
+// A bare apex has no path to trim — it must not gain a trailing slash it never had, since
+// that would itself be a canonicalization mismatch against a link that omitted it.
+func TestStripQueryFragmentLeavesABareApexAlone(t *testing.T) {
+	got := stripQueryFragment("https://example.com")
+	if want := "https://example.com"; got != want {
+		t.Errorf("stripQueryFragment = %q, want %q", got, want)
+	}
+}

--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -192,43 +192,6 @@ func (s *Service) RecordIntake(ctx context.Context, in SubmitInput, it Intake) (
 	return SubmitResult{Contribution: rec, Source: it.Source, Board: it.Board, Rewardable: err == nil}, err
 }
 
-// Submit inspects and records in one call, for the callers that do not import first. The
-// checks run cheapest-first: unsupported ATS before any DB read; already-tracked before any
-// write; the record insert last, which no longer competes with a unique constraint — a repeat
-// board is recorded, it simply is not rewardable.
-func (s *Service) Submit(ctx context.Context, in SubmitInput) (SubmitResult, error) {
-	surface := NormalizeSurface(in.Surface)
-	source, board, canonical, ok := s.resolveBoard(ctx, in.URL)
-	if !ok {
-		// No board resolved. A non-URL is garbage → 422. A valid http(s) link is a plausible
-		// missed ATS: log it for maintainer visibility and record it in the review queue (no
-		// board, no credit) so it can be triaged by hand instead of being lost.
-		if !isHTTPURL(in.URL) {
-			return SubmitResult{}, ErrUnsupportedATS
-		}
-		logUnrecognized(in.SubmittedBy, in.URL)
-		rec, err := s.repo.RecordReview(ctx, in.SubmittedBy, stripQueryFragment(in.URL), surface)
-		return SubmitResult{Contribution: rec}, err
-	}
-
-	tracked, err := s.repo.BoardTracked(ctx, source, board)
-	if err != nil {
-		return SubmitResult{Source: source, Board: board}, err
-	}
-	if tracked {
-		return SubmitResult{Source: source, Board: board}, ErrBoardAlreadyTracked
-	}
-
-	rec, err := s.repo.Record(ctx, RecordInput{
-		SubmittedBy: in.SubmittedBy,
-		URL:         canonical,
-		Source:      source,
-		Board:       board,
-		Surface:     surface,
-	})
-	return SubmitResult{Contribution: rec, Source: source, Board: board, Rewardable: err == nil}, err
-}
-
 // resolveBoard finds the (source, board, canonical URL) a pasted link belongs to, trying the
 // cheapest strategy first: the network-free URL recognizer; then a page fetch that detects an
 // ATS embedded on a company's own careers domain; then a Greenhouse or Ashby job-id lookup, for

--- a/internal/contribution/contribution_test.go
+++ b/internal/contribution/contribution_test.go
@@ -87,9 +87,18 @@ func newService(repo Repository) *Service {
 	return New(repo, nil)
 }
 
-// submit is the shorthand for one website intake, so a test states only the link it is about.
+// submit is the shorthand for one website intake, so a test states only the link it is
+// about. It calls Inspect then RecordIntake — the same two calls the real intake handler
+// makes (internal/handler/intake.go) — rather than a standalone convenience method, so
+// these tests exercise the actual production path.
 func submit(svc *Service, userID int64, url string) (SubmitResult, error) {
-	return svc.Submit(context.Background(), SubmitInput{SubmittedBy: userID, URL: url, Surface: SurfaceWeb})
+	ctx := context.Background()
+	in := SubmitInput{SubmittedBy: userID, URL: url, Surface: SurfaceWeb}
+	it, err := svc.Inspect(ctx, url)
+	if err != nil {
+		return SubmitResult{}, err
+	}
+	return svc.RecordIntake(ctx, in, it)
 }
 
 func TestSubmitRecordsUnknownHostForReview(t *testing.T) {
@@ -202,19 +211,27 @@ func TestSubmitStoresTheSurfaceItArrivedThrough(t *testing.T) {
 	// to a channel and not only to a user. An unknown tag degrades to "unknown", never a refusal.
 	repo := &fakeRepo{}
 	svc := newService(repo)
-	if _, err := svc.Submit(context.Background(), SubmitInput{
-		SubmittedBy: 7, URL: "https://jobs.ashbyhq.com/blitzy", Surface: SurfaceCLI,
-	}); err != nil {
-		t.Fatalf("Submit: %v", err)
+	ctx := context.Background()
+
+	in := SubmitInput{SubmittedBy: 7, URL: "https://jobs.ashbyhq.com/blitzy", Surface: SurfaceCLI}
+	it, err := svc.Inspect(ctx, in.URL)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if _, err := svc.RecordIntake(ctx, in, it); err != nil {
+		t.Fatalf("RecordIntake: %v", err)
 	}
 	if repo.recorded.Surface != SurfaceCLI {
 		t.Errorf("recorded surface = %q, want %q", repo.recorded.Surface, SurfaceCLI)
 	}
 
-	if _, err := svc.Submit(context.Background(), SubmitInput{
-		SubmittedBy: 7, URL: "https://example.com/careers/1", Surface: "carrier-pigeon",
-	}); err != nil {
-		t.Fatalf("Submit with an unknown surface: %v", err)
+	in = SubmitInput{SubmittedBy: 7, URL: "https://example.com/careers/1", Surface: "carrier-pigeon"}
+	it, err = svc.Inspect(ctx, in.URL)
+	if err != nil {
+		t.Fatalf("Inspect with an unknown surface: %v", err)
+	}
+	if _, err := svc.RecordIntake(ctx, in, it); err != nil {
+		t.Fatalf("RecordIntake with an unknown surface: %v", err)
 	}
 	if repo.reviewedSurf != SurfaceUnknown {
 		t.Errorf("unknown surface stored as %q, want %q", repo.reviewedSurf, SurfaceUnknown)

--- a/internal/cvedit/editor.go
+++ b/internal/cvedit/editor.go
@@ -84,7 +84,7 @@ type Tx interface {
 	Newest(ctx context.Context) (Revision, bool, error)
 	Revision(ctx context.Context, id uuid.UUID) (Revision, bool, error)
 	Insert(ctx context.Context, rev Revision) (Revision, error)
-	Amend(ctx context.Context, id uuid.UUID, ops []Op, title string) (Revision, error)
+	Amend(ctx context.Context, id uuid.UUID, ops []Op, title, note string) (Revision, error)
 	MarkReverted(ctx context.Context, id uuid.UUID) (bool, error)
 	InBatch(ctx context.Context, batchID uuid.UUID) ([]Revision, error)
 	Trim(ctx context.Context, keep int32) error
@@ -236,7 +236,12 @@ func (e *Editor) record(ctx context.Context, tx Tx, cvID uuid.UUID, userID int64
 		//
 		// The inverse is deliberately not touched: it still leads back to the state before
 		// the first of the coalesced edits, which is what undo has to mean for typed text.
-		return tx.Amend(ctx, newest.ID, ch.Ops, title)
+		//
+		// The note IS replaced along with the title: it is the stated reason for the newest
+		// batch's content, and a coalesced save already carries that content whole rather than
+		// accumulating it — restating anything less would attribute the current text to a
+		// reason that no longer describes it.
+		return tx.Amend(ctx, newest.ID, ch.Ops, title, ch.Note)
 	}
 
 	return tx.Insert(ctx, Revision{

--- a/internal/cvedit/editor_test.go
+++ b/internal/cvedit/editor_test.go
@@ -84,11 +84,12 @@ func (r *fakeRepo) Insert(_ context.Context, rev Revision) (Revision, error) {
 	return rev, nil
 }
 
-func (r *fakeRepo) Amend(_ context.Context, id uuid.UUID, ops []Op, title string) (Revision, error) {
+func (r *fakeRepo) Amend(_ context.Context, id uuid.UUID, ops []Op, title, note string) (Revision, error) {
 	for i, rev := range r.revisions {
 		if rev.ID == id {
 			r.revisions[i].Ops = ops
 			r.revisions[i].Title = title
+			r.revisions[i].Note = note
 			r.revisions[i].UpdatedAt = r.updatedAt
 			return r.revisions[i], nil
 		}
@@ -224,6 +225,40 @@ func TestTypingIntoOnePlaceCoalescesIntoOneRevision(t *testing.T) {
 	// The inverse still leads back to where the burst started, not to the previous keystroke.
 	if got := repo.revisions[0].Inverse[0].Value; got != "Ten years of Go" {
 		t.Fatalf("inverse = %v, want the text from before the first save", got)
+	}
+}
+
+// Amend replaces the ops and the title with the coalesced batch's current state — the note
+// must follow the same rule, or the revision keeps citing the first edit's reason for content
+// that is actually the second edit's.
+func TestCoalescingReplacesTheNoteWithTheLatestOne(t *testing.T) {
+	repo := newFakeRepo()
+	e, c := newEditor(repo, nil)
+	batchID := uuid.New()
+
+	_, _, err := e.Commit(context.Background(), repo.cvID, 1, Change{
+		Actor: ActorAgent, Origin: OriginTailorAgent, BatchID: batchID,
+		Note: "Added the cloud-migration line for Requirement A",
+		Ops:  []Op{{Kind: OpSet, Path: mustParse(t, "summary"), Value: "Distributed"}},
+	})
+	if err != nil {
+		t.Fatalf("first Commit: %v", err)
+	}
+	c.at = c.at.Add(2 * time.Second)
+	_, _, err = e.Commit(context.Background(), repo.cvID, 1, Change{
+		Actor: ActorAgent, Origin: OriginTailorAgent, BatchID: batchID,
+		Note: "Reworded for Requirement B",
+		Ops:  []Op{{Kind: OpSet, Path: mustParse(t, "summary"), Value: "Distributed systems"}},
+	})
+	if err != nil {
+		t.Fatalf("second Commit: %v", err)
+	}
+
+	if len(repo.revisions) != 1 {
+		t.Fatalf("got %d revisions, want one for the coalesced batch", len(repo.revisions))
+	}
+	if got := repo.revisions[0].Note; got != "Reworded for Requirement B" {
+		t.Errorf("note = %q, want the second edit's reason, not the stale first one", got)
 	}
 }
 

--- a/internal/cvedit/repository.go
+++ b/internal/cvedit/repository.go
@@ -156,13 +156,14 @@ func (t *queriesTx) Insert(ctx context.Context, rev Revision) (Revision, error) 
 	return revisionFromRow(row)
 }
 
-func (t *queriesTx) Amend(ctx context.Context, id uuid.UUID, ops []Op, title string) (Revision, error) {
+func (t *queriesTx) Amend(ctx context.Context, id uuid.UUID, ops []Op, title, note string) (Revision, error) {
 	blob, err := json.Marshal(ops)
 	if err != nil {
 		return Revision{}, err
 	}
 	row, err := t.q.AmendCVRevision(ctx, db.AmendCVRevisionParams{
 		ID: id, UserID: t.userID, Ops: blob, Title: title,
+		Note: pgtype.Text{String: note, Valid: note != ""},
 	})
 	if err != nil {
 		return Revision{}, err

--- a/internal/cvmatch/requirements.go
+++ b/internal/cvmatch/requirements.go
@@ -170,7 +170,10 @@ func requirementSkills(text string, jobSkills []string) []string {
 const requirementPunctuation = ",;:!?()[]{}\"'“”«»·•/\\|"
 
 func requirementWords(text string) []string {
-	fields := strings.Fields(strings.ToLower(text))
+	// Case is preserved: skilltag.Canonicalize tries case-preserved acronyms (ML, K8s) before
+	// its own lowercase normalization, and lowercasing here would defeat that tier before the
+	// token ever reaches it.
+	fields := strings.Fields(text)
 	out := make([]string, 0, len(fields))
 	for _, f := range fields {
 		w := strings.TrimRight(strings.Trim(f, requirementPunctuation), ".")

--- a/internal/cvmatch/requirements_test.go
+++ b/internal/cvmatch/requirements_test.go
@@ -42,6 +42,18 @@ func TestRequirementSkillsResolveMultiWordSkills(t *testing.T) {
 	}
 }
 
+// skilltag.Canonicalize resolves an acronym only from its exact case ("ML", not "ml" — the
+// lowercase form is reserved, since it also means millilitre). Lowercasing the requirement
+// text before handing it to Canonicalize would destroy that case and silently lose every
+// acronym-only requirement, so this must keep resolving after any change to requirementWords.
+func TestRequirementSkillsResolveAnUppercaseAcronym(t *testing.T) {
+	got := requirementSkills("3+ years of hands-on ML experience", []string{"machine-learning"})
+
+	if !slices.Equal(got, []string{"machine-learning"}) {
+		t.Errorf("requirementSkills = %v, want [machine-learning]", got)
+	}
+}
+
 func reqs() []Requirement {
 	return []Requirement{
 		{Text: "5+ years of Go", Priority: "required", CachedStatus: "missing-gap"},

--- a/internal/db/cv_revisions.sql.go
+++ b/internal/db/cv_revisions.sql.go
@@ -15,7 +15,7 @@ import (
 
 const amendCVRevision = `-- name: AmendCVRevision :one
 UPDATE cv_revisions
-SET ops = $3, title = $4, updated_at = now()
+SET ops = $3, title = $4, note = $5, updated_at = now()
 WHERE id = $1 AND user_id = $2
 RETURNING id, cv_id, user_id, actor, origin, batch_id, title, note, ops, inverse, base_version, reverts_id, reverted_at, created_at, updated_at
 `
@@ -25,17 +25,20 @@ type AmendCVRevisionParams struct {
 	UserID int64           `json:"user_id"`
 	Ops    json.RawMessage `json:"ops"`
 	Title  string          `json:"title"`
+	Note   pgtype.Text     `json:"note"`
 }
 
-// Fold a follow-on edit into the newest revision: replace what it does and restate its
-// description, but LEAVE inverse alone. The inverse still leads back to the state before the
-// first of the coalesced edits, which is what makes undo mean something for typed text.
+// Fold a follow-on edit into the newest revision: replace what it does, restate its
+// description and the reason for the change, but LEAVE inverse alone. The inverse still leads
+// back to the state before the first of the coalesced edits, which is what makes undo mean
+// something for typed text.
 func (q *Queries) AmendCVRevision(ctx context.Context, arg AmendCVRevisionParams) (CvRevision, error) {
 	row := q.db.QueryRow(ctx, amendCVRevision,
 		arg.ID,
 		arg.UserID,
 		arg.Ops,
 		arg.Title,
+		arg.Note,
 	)
 	var i CvRevision
 	err := row.Scan(

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -353,6 +353,7 @@ WHERE id = $2::bigint
   AND (enriched_at IS NULL OR enrichment_version < $1::int)
   AND is_tech IS TRUE
   AND description <> ''
+  AND duplicate_of IS NULL
 ON CONFLICT (job_id, target_version) DO NOTHING
 `
 
@@ -374,8 +375,12 @@ type EnqueueJobEnrichmentParams struct {
 // (broad multi-industry ATS crawls: painters, stockers, drivers), so the LLM spend was
 // not buying the coverage it cost. Also requires a non-empty description: the LLM has
 // nothing to extract from a blank one regardless of category, and a 2026-08-06 prod
-// sweep found ~53K such rows already sitting in the queue for no reason. Idempotent via
-// the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+// sweep found ~53K such rows already sitting in the queue for no reason. Also requires
+// duplicate_of IS NULL, matching EnqueuePendingJobs: the write path's own dedup only
+// sets duplicate_of on the INSERT that first clusters a repost, so a later recrawl of
+// an already-deduped job reaches this call as an UPDATE and would otherwise queue a
+// row ClaimEnrichmentBatch's duplicate_of IS NULL filter can never claim. Idempotent
+// via the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
 // job's UpsertJob so a newly ingested job is queued atomically with its write.
 func (q *Queries) EnqueueJobEnrichment(ctx context.Context, arg EnqueueJobEnrichmentParams) (int64, error) {
 	result, err := q.db.Exec(ctx, enqueueJobEnrichment, arg.TargetVersion, arg.JobID)

--- a/internal/db/jobs_integration_test.go
+++ b/internal/db/jobs_integration_test.go
@@ -156,6 +156,41 @@ func TestEnqueueJobEnrichmentGating(t *testing.T) {
 			t.Errorf("outbox rows = %d, want 0", got)
 		}
 	})
+
+	// A recrawl of an already-deduped repost reaches this call as an UPDATE, not the
+	// clustering INSERT — the write path's own dedup check (cmd/ingest's clustersByRole)
+	// never fires for it, so this gate is the only thing standing between the recrawl and
+	// an outbox row ClaimEnrichmentBatch's duplicate_of IS NULL filter can never claim.
+	t.Run("job already marked a duplicate is not enqueued", func(t *testing.T) {
+		truncate(t, pool)
+		canon, err := ingestUpsert(ctx, q, ingestParams("acme:3", "Canonical Job"))
+		if err != nil {
+			t.Fatalf("upsert canon: %v", err)
+		}
+		p := ingestParams("acme:4", "Reposted Job")
+		p.IsTech = pgtype.Bool{Bool: true, Valid: true}
+		repost, err := ingestUpsert(ctx, q, p)
+		if err != nil {
+			t.Fatalf("upsert repost: %v", err)
+		}
+		if _, err := q.MarkJobDuplicateOf(ctx, MarkJobDuplicateOfParams{
+			ID:          repost.ID,
+			DuplicateOf: pgtype.Int8{Int64: canon.ID, Valid: true},
+		}); err != nil {
+			t.Fatalf("mark duplicate: %v", err)
+		}
+
+		n, err := q.EnqueueJobEnrichment(ctx, EnqueueJobEnrichmentParams{TargetVersion: 1, JobID: repost.ID})
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("enqueue affected %d rows, want 0 (job is a known duplicate)", n)
+		}
+		if got := outboxCount(); got != 0 {
+			t.Errorf("outbox rows = %d, want 0 — a duplicate must never reach ClaimEnrichmentBatch", got)
+		}
+	})
 }
 
 // A failed detail fetch makes an adapter yield a job with an empty description while

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -32,9 +32,10 @@ type Querier interface {
 	// argument unconditionally left rows reading link_source='agent' with a NULL
 	// confidence after a caller merely re-labelled the message.
 	AgentTriageEmail(ctx context.Context, arg AgentTriageEmailParams) (int64, error)
-	// Fold a follow-on edit into the newest revision: replace what it does and restate its
-	// description, but LEAVE inverse alone. The inverse still leads back to the state before the
-	// first of the coalesced edits, which is what makes undo mean something for typed text.
+	// Fold a follow-on edit into the newest revision: replace what it does, restate its
+	// description and the reason for the change, but LEAVE inverse alone. The inverse still leads
+	// back to the state before the first of the coalesced edits, which is what makes undo mean
+	// something for typed text.
 	AmendCVRevision(ctx context.Context, arg AmendCVRevisionParams) (CvRevision, error)
 	// Append one message to a session's transcript, assigning the next sequence number in the
 	// same statement so concurrent writers cannot collide on (session_id, seq) — the primary
@@ -684,8 +685,12 @@ type Querier interface {
 	// (broad multi-industry ATS crawls: painters, stockers, drivers), so the LLM spend was
 	// not buying the coverage it cost. Also requires a non-empty description: the LLM has
 	// nothing to extract from a blank one regardless of category, and a 2026-08-06 prod
-	// sweep found ~53K such rows already sitting in the queue for no reason. Idempotent via
-	// the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+	// sweep found ~53K such rows already sitting in the queue for no reason. Also requires
+	// duplicate_of IS NULL, matching EnqueuePendingJobs: the write path's own dedup only
+	// sets duplicate_of on the INSERT that first clusters a repost, so a later recrawl of
+	// an already-deduped job reaches this call as an UPDATE and would otherwise queue a
+	// row ClaimEnrichmentBatch's duplicate_of IS NULL filter can never claim. Idempotent
+	// via the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
 	// job's UpsertJob so a newly ingested job is queued atomically with its write.
 	EnqueueJobEnrichment(ctx context.Context, arg EnqueueJobEnrichmentParams) (int64, error)
 	// Idempotent backfill: enqueue every email not yet classified. classified_at is the

--- a/internal/db/queries/cv_revisions.sql
+++ b/internal/db/queries/cv_revisions.sql
@@ -19,11 +19,12 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 RETURNING *;
 
 -- name: AmendCVRevision :one
--- Fold a follow-on edit into the newest revision: replace what it does and restate its
--- description, but LEAVE inverse alone. The inverse still leads back to the state before the
--- first of the coalesced edits, which is what makes undo mean something for typed text.
+-- Fold a follow-on edit into the newest revision: replace what it does, restate its
+-- description and the reason for the change, but LEAVE inverse alone. The inverse still leads
+-- back to the state before the first of the coalesced edits, which is what makes undo mean
+-- something for typed text.
 UPDATE cv_revisions
-SET ops = $3, title = $4, updated_at = now()
+SET ops = $3, title = $4, note = $5, updated_at = now()
 WHERE id = $1 AND user_id = $2
 RETURNING *;
 

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -1124,8 +1124,12 @@ WHERE id = sqlc.arg(id) AND liveness_strikes <> 0;
 -- (broad multi-industry ATS crawls: painters, stockers, drivers), so the LLM spend was
 -- not buying the coverage it cost. Also requires a non-empty description: the LLM has
 -- nothing to extract from a blank one regardless of category, and a 2026-08-06 prod
--- sweep found ~53K such rows already sitting in the queue for no reason. Idempotent via
--- the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+-- sweep found ~53K such rows already sitting in the queue for no reason. Also requires
+-- duplicate_of IS NULL, matching EnqueuePendingJobs: the write path's own dedup only
+-- sets duplicate_of on the INSERT that first clusters a repost, so a later recrawl of
+-- an already-deduped job reaches this call as an UPDATE and would otherwise queue a
+-- row ClaimEnrichmentBatch's duplicate_of IS NULL filter can never claim. Idempotent
+-- via the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
 -- job's UpsertJob so a newly ingested job is queued atomically with its write.
 INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, sqlc.arg(target_version)::int
@@ -1134,6 +1138,7 @@ WHERE id = sqlc.arg(job_id)::bigint
   AND (enriched_at IS NULL OR enrichment_version < sqlc.arg(target_version)::int)
   AND is_tech IS TRUE
   AND description <> ''
+  AND duplicate_of IS NULL
 ON CONFLICT (job_id, target_version) DO NOTHING;
 
 -- name: SetJobEnrichment :exec

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -258,7 +258,7 @@ SELECT u.user_id, u.job_id, u.viewed_at,
 -- Only the geography arrives raw: the wire value is a dict-then-LLM hybrid, so both sides have
 -- to reach the projection. They are pulled out of the enrichment by key instead of shipping
 -- the whole JSONB.
-SELECT jobs.id, jobs.public_slug, jobs.title, jobs.company_slug, jobs.closed_at,
+SELECT jobs.id, jobs.public_slug, jobs.title, jobs.company, jobs.company_slug, jobs.closed_at,
        jobs.work_mode, jobs.seniority, jobs.employment_type,
        jobs.countries, jobs.regions, jobs.skills, jobs.collections,
        jobs.posted_at, jobs.created_at,

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -339,7 +339,7 @@ func (q *Queries) ListSavedJobSlugs(ctx context.Context, userID int64) ([]string
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.public_slug, jobs.title, jobs.company_slug, jobs.closed_at,
+SELECT jobs.id, jobs.public_slug, jobs.title, jobs.company, jobs.company_slug, jobs.closed_at,
        jobs.work_mode, jobs.seniority, jobs.employment_type,
        jobs.countries, jobs.regions, jobs.skills, jobs.collections,
        jobs.posted_at, jobs.created_at,
@@ -426,6 +426,7 @@ type ListUserJobsRow struct {
 	ID                   int64              `json:"id"`
 	PublicSlug           string             `json:"public_slug"`
 	Title                string             `json:"title"`
+	Company              string             `json:"company"`
 	CompanySlug          string             `json:"company_slug"`
 	ClosedAt             pgtype.Timestamptz `json:"closed_at"`
 	WorkMode             string             `json:"work_mode"`
@@ -501,6 +502,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.ID,
 			&i.PublicSlug,
 			&i.Title,
+			&i.Company,
 			&i.CompanySlug,
 			&i.ClosedAt,
 			&i.WorkMode,

--- a/internal/embed/runner.go
+++ b/internal/embed/runner.go
@@ -12,6 +12,7 @@ package embed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -148,21 +149,51 @@ func (rn *run) processOpenBatch(ctx context.Context, entries []Claimed) {
 	defer cancel()
 
 	jobs, err := rn.store.Jobs(callCtx, jobIDs(entries))
-	if err != nil || len(jobs) != len(entries) {
+	if err != nil {
+		if rn.skipOnTimeout(callCtx, entries, "load jobs") {
+			return
+		}
+		rn.fallbackOpen(ctx, entries)
+		return
+	}
+	if len(jobs) != len(entries) {
 		rn.fallbackOpen(ctx, entries)
 		return
 	}
 	vectors, err := rn.indexer.IndexOpen(callCtx, jobs)
 	if err != nil {
+		if rn.skipOnTimeout(callCtx, entries, "embed/index") {
+			return
+		}
 		rn.fallbackOpen(ctx, entries)
 		return
 	}
 	if err := rn.store.CompleteOpen(callCtx, entries, rn.opt.TargetModel, vectors); err != nil {
+		if rn.skipOnTimeout(callCtx, entries, "complete open") {
+			return
+		}
 		rn.fallbackOpen(ctx, entries)
 		return
 	}
 	rn.stats.Indexed += len(entries)
 	log.Printf("embed: indexed batch of %d in %s", len(entries), since(start))
+}
+
+// skipOnTimeout reports whether callCtx expired — a normal-but-slow operation simply
+// outran CallTimeout, not a per-document defect the semantic index reported — and, if
+// so, logs and leaves the wave claimed for its lease to expire, so a later run retries
+// the WHOLE batch fresh. Falling back to per-item on a mere timeout would be actively
+// harmful here: this index's cost is dominated by a fixed whole-index re-merge (the
+// same mechanism internal/searchdrain guards against, see its skipOnTimeout), so a
+// single document costs about as much to push as the whole batch, and per-item fallback
+// would turn one slow-but-fine batch into up to len(entries) equally slow calls.
+func (rn *run) skipOnTimeout(callCtx context.Context, entries []Claimed, stage string) bool {
+	if !errors.Is(callCtx.Err(), context.DeadlineExceeded) {
+		return false
+	}
+	log.Printf("embed: batch of %d timed out during %s after %s — leaving claimed for "+
+		"lease-expiry retry, not falling back to per-item", len(entries), stage, rn.opt.CallTimeout)
+	return true
 }
 
 func (rn *run) fallbackOpen(ctx context.Context, entries []Claimed) {
@@ -215,10 +246,16 @@ func (rn *run) processClosedBatch(ctx context.Context, entries []Claimed) {
 	defer cancel()
 
 	if err := rn.indexer.RemoveClosed(callCtx, jobIDs(entries)); err != nil {
+		if rn.skipOnTimeout(callCtx, entries, "remove closed") {
+			return
+		}
 		rn.fallbackClosed(ctx, entries)
 		return
 	}
 	if err := rn.store.CompleteClosed(callCtx, entries); err != nil {
+		if rn.skipOnTimeout(callCtx, entries, "complete closed") {
+			return
+		}
 		rn.fallbackClosed(ctx, entries)
 		return
 	}

--- a/internal/embed/runner_test.go
+++ b/internal/embed/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 
@@ -130,20 +131,35 @@ type fakeIndexer struct {
 	removed    []int64
 	batchFails bool
 	indexErr   map[int64]error
+	// blockUntilCtxDone makes IndexOpen hang until the call context expires and return
+	// its error — simulating a push that is genuinely still working server-side (the
+	// index never reported a failure) but outran the caller's CallTimeout.
+	blockUntilCtxDone bool
 }
 
 func newFakeIndexer() *fakeIndexer { return &fakeIndexer{indexErr: map[int64]error{}} }
 
-func (ix *fakeIndexer) IndexOpen(_ context.Context, jobs []db.Job) (map[int64][]float32, error) {
+func (ix *fakeIndexer) IndexOpen(ctx context.Context, jobs []db.Job) (map[int64][]float32, error) {
 	ix.mu.Lock()
-	defer ix.mu.Unlock()
 	ids := make([]int64, len(jobs))
-	vecs := make(map[int64][]float32, len(jobs))
 	for i, j := range jobs {
 		ids[i] = j.ID
-		vecs[j.ID] = []float32{float32(j.ID)} // deterministic per-job vector
 	}
 	ix.indexCalls = append(ix.indexCalls, ids)
+	block := ix.blockUntilCtxDone
+	ix.mu.Unlock()
+
+	if block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	vecs := make(map[int64][]float32, len(jobs))
+	for _, j := range jobs {
+		vecs[j.ID] = []float32{float32(j.ID)} // deterministic per-job vector
+	}
 	if ix.batchFails && len(jobs) > 1 {
 		return nil, errors.New("batch embed failed")
 	}
@@ -241,6 +257,51 @@ func TestRunnerFallsBackToPerItemOnBatchFailure(t *testing.T) {
 	}
 	if len(store.failCalls) != 1 || store.failCalls[0].outboxID != 20 {
 		t.Errorf("failCalls = %+v, want one for outbox 20 (job 2)", store.failCalls)
+	}
+}
+
+// TestRunnerSkipsWaveOnBatchTimeoutInsteadOfCascading mirrors
+// internal/searchdrain's identically-named test for the 2026-08-05 prod incident: this
+// worker pushes into a Meili index whose cost is a fixed whole-index re-merge, the same
+// mechanism that turned one slow-but-fine batch into a cascade of equally slow per-item
+// pushes and produced a real outage in the sibling worker. A batch that merely outran
+// CallTimeout — with the index still working on it server-side, not actually failed —
+// must NOT cascade into per-item fallback here either.
+func TestRunnerSkipsWaveOnBatchTimeoutInsteadOfCascading(t *testing.T) {
+	store := newFakeStore()
+	ix := newFakeIndexer()
+	ix.blockUntilCtxDone = true // simulates a push that never returns before the deadline
+	for _, id := range []int64{1, 2, 3} {
+		store.jobs[id] = db.Job{ID: id}
+	}
+	store.pending = []Claimed{
+		{OutboxID: 10, JobID: 1, Closed: false},
+		{OutboxID: 20, JobID: 2, Closed: false},
+		{OutboxID: 30, JobID: 3, Closed: false},
+	}
+
+	opts := opt()
+	opts.CallTimeout = 20 * time.Millisecond
+
+	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Indexed != 0 || stats.Failed != 0 || stats.DeadLettered != 0 {
+		t.Fatalf("stats = %+v, want all zero — a timed-out batch is skipped this run, not "+
+			"fallen back to per-item and not counted as a failure", stats)
+	}
+	// The one batch attempt, and NOTHING else: no per-item retries.
+	if len(ix.indexCalls) != 1 {
+		t.Fatalf("IndexOpen calls = %d, want 1 (the batch attempt only) — per-item fallback "+
+			"on a mere timeout would multiply the number of equally-expensive index pushes by "+
+			"the batch size", len(ix.indexCalls))
+	}
+	// No attempts burned: the wave stays claimed and becomes retryable once its lease
+	// expires, so a later run retries the WHOLE batch fresh rather than spending the
+	// entry's limited attempt budget on a timeout that says nothing about the document.
+	if len(store.failCalls) != 0 {
+		t.Errorf("failCalls = %+v, want none — a timeout must not burn the retry budget", store.failCalls)
 	}
 }
 

--- a/internal/experience/experience.go
+++ b/internal/experience/experience.go
@@ -141,7 +141,7 @@ func (a *Atom) Sanitize() {
 	a.Context = clip(a.Context, maxContextRunes)
 	a.SourceRef = clip(a.SourceRef, maxShortRunes)
 	a.Metrics = orEmpty(limit(nonEmpty(mapStrings(a.Metrics, maxShortRunes)), maxMetrics))
-	a.Skills = orEmpty(limit(skilltag.Canonicalize(a.Skills), maxSkills))
+	a.Skills = orEmpty(limit(skilltag.Canonicalize(a.Skills, skilltag.WithResumeAcronyms()), maxSkills))
 }
 
 // Validate reports the first reason this atom cannot be persisted. It runs after
@@ -164,7 +164,7 @@ func (e *Employment) Sanitize() {
 	e.Start = clip(e.Start, maxShortRunes)
 	e.End = clip(e.End, maxShortRunes)
 	e.Summary = clip(e.Summary, maxSummaryRunes)
-	e.Stack = orEmpty(limit(skilltag.Canonicalize(e.Stack), maxSkills))
+	e.Stack = orEmpty(limit(skilltag.Canonicalize(e.Stack, skilltag.WithResumeAcronyms()), maxSkills))
 }
 
 // Validate reports the first reason this employment cannot be persisted.

--- a/internal/experience/retrieve.go
+++ b/internal/experience/retrieve.go
@@ -76,6 +76,8 @@ func (s *Store) Retrieve(ctx context.Context, userID int64, q Query, limit int) 
 		byID[employments[i].ID] = &employments[i]
 	}
 
+	// No WithResumeAcronyms: q.Skills names a VACANCY requirement's skills (see Query's doc
+	// comment), not the candidate's own — the résumé-scoped acronym tier must stay off here.
 	q.Skills = skilltag.Canonicalize(q.Skills)
 
 	matches := make([]Match, 0, len(atoms))

--- a/internal/gmailsync/connector.go
+++ b/internal/gmailsync/connector.go
@@ -94,7 +94,7 @@ func (c *Connector) CalendarAuthCodeURL(state string) string {
 // Exchange turns the callback code into a refresh token and the connected Gmail
 // address. It errors if Google returned no refresh token (consent not offline).
 func (c *Connector) Exchange(ctx context.Context, code string) (refreshToken, email string, scopes []string, err error) {
-	ctx = guardedContext(ctx)
+	ctx = safehttp.GuardedOAuth2Context(ctx, gmailHTTPTimeout)
 	tok, err := c.cfg.Exchange(ctx, code)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("gmail: exchange code: %w", err)
@@ -134,7 +134,7 @@ func (c *Connector) ExchangeCalendar(ctx context.Context, code string) (refreshT
 	cfg := *c.cfg
 	cfg.Scopes = []string{CalendarScope}
 	cfg.RedirectURL = c.calendarRedirect
-	tok, err := cfg.Exchange(guardedContext(ctx), code)
+	tok, err := cfg.Exchange(safehttp.GuardedOAuth2Context(ctx, gmailHTTPTimeout), code)
 	if err != nil {
 		return "", nil, fmt.Errorf("calendar: exchange code: %w", err)
 	}
@@ -147,14 +147,14 @@ func (c *Connector) ExchangeCalendar(ctx context.Context, code string) (refreshT
 // TokenSource mints access tokens from a stored refresh token (used by the sync
 // worker), refreshing transparently.
 func (c *Connector) TokenSource(ctx context.Context, refreshToken string) oauth2.TokenSource {
-	return c.cfg.TokenSource(guardedContext(ctx), &oauth2.Token{RefreshToken: refreshToken})
+	return c.cfg.TokenSource(safehttp.GuardedOAuth2Context(ctx, gmailHTTPTimeout), &oauth2.Token{RefreshToken: refreshToken})
 }
 
 // HTTPClient returns a token-bearing HTTP client for the Gmail API, minting and
 // refreshing access tokens from the stored refresh token. Used to build a live
 // GmailReader per user in the sync worker.
 func (c *Connector) HTTPClient(ctx context.Context, refreshToken string) *http.Client {
-	gctx := guardedContext(ctx)
+	gctx := safehttp.GuardedOAuth2Context(ctx, gmailHTTPTimeout)
 	return oauth2.NewClient(gctx, c.cfg.TokenSource(gctx, &oauth2.Token{RefreshToken: refreshToken}))
 }
 
@@ -205,13 +205,4 @@ func (c *Connector) fetchEmail(ctx context.Context, client *http.Client) (string
 		return "", fmt.Errorf("gmail: profile decode: %w", err)
 	}
 	return body.EmailAddress, nil
-}
-
-// guardedContext routes the OAuth exchange and API calls through the SSRF-guarded
-// client, matching every other outbound fetch in this service (defense in depth).
-func guardedContext(ctx context.Context) context.Context {
-	if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
-		return ctx
-	}
-	return context.WithValue(ctx, oauth2.HTTPClient, safehttp.NewClient(gmailHTTPTimeout))
 }

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -483,14 +483,17 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 				return nil, cvToolError(err)
 			}
 			// Merged only after Commit succeeds: a refused batch must not leave the report
-			// claiming a requirement was closed by an edit that never landed.
+			// claiming a requirement was closed by an edit that never landed. But once Commit
+			// has landed, this merge is best-effort — the document already carries the edit, and
+			// failing the whole tool call now would tell the model the edit never happened,
+			// inviting a retry that reapplies ops Commit has no content-level dedup against.
 			if requirement != "" {
 				if err := h.cv.cvStore.MergeAutopilotEntry(ctx, cvID, userID, cv.AutopilotEntry{
 					Requirement: requirement,
 					Status:      status,
 					Note:        in.Note,
 				}); err != nil {
-					return nil, cvToolError(err)
+					log.Printf("assistant: recording autopilot entry for requirement %q: %v", requirement, err)
 				}
 			}
 			// A receipt, not the document: a tool result is replayed into the model's

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"sort"
 	"strings"
@@ -29,6 +30,9 @@ type cvRepo struct {
 	written []byte
 	// report is what an autopilot run leaves behind: its account of each requirement.
 	report []byte
+	// autopilotErr, when set, is what SetAutopilotReport returns instead of succeeding —
+	// simulating a report write that fails after the document edit has already landed.
+	autopilotErr error
 }
 
 func (r *cvRepo) Get(_ context.Context, id uuid.UUID, userID int64) (db.GetCVByIDRow, error) {
@@ -77,6 +81,9 @@ func (r *cvRepo) GetTailoredForJob(_ context.Context, userID, jobID int64) (db.G
 }
 
 func (r *cvRepo) SetAutopilotReport(_ context.Context, id uuid.UUID, userID int64, report []byte) (int64, error) {
+	if r.autopilotErr != nil {
+		return 0, r.autopilotErr
+	}
 	if id != r.id || userID != r.userID {
 		return 0, nil
 	}
@@ -187,11 +194,12 @@ func (m *memRevisions) Insert(_ context.Context, rev cvedit.Revision) (cvedit.Re
 	return rev, nil
 }
 
-func (m *memRevisions) Amend(_ context.Context, id uuid.UUID, ops []cvedit.Op, title string) (cvedit.Revision, error) {
+func (m *memRevisions) Amend(_ context.Context, id uuid.UUID, ops []cvedit.Op, title, note string) (cvedit.Revision, error) {
 	for i, r := range m.revisions {
 		if r.ID == id {
 			m.revisions[i].Ops = ops
 			m.revisions[i].Title = title
+			m.revisions[i].Note = note
 			return m.revisions[i], nil
 		}
 	}
@@ -554,6 +562,29 @@ func TestCVEditToolReplacesAnExistingOpenReportEntry(t *testing.T) {
 	}
 	if report[1].Requirement != "Team leadership" || report[1].Status != cv.AutopilotClosedBank {
 		t.Errorf("unrelated entry was disturbed: %+v", report[1])
+	}
+}
+
+// A report-merge failure arrives strictly AFTER cvedit.Commit has already durably landed the
+// document edit. Failing the whole tool call at that point would tell the model the edit never
+// happened; a well-behaved model retries, and Commit has no content-level dedup against a
+// retried insert — so the merge must be best-effort, the same way UndoCVRevisionBatch treats
+// the sibling SetAutopilotReport call after RevertBatch has already succeeded.
+func TestCVEditToolSucceedsWhenTheReportMergeFailsAfterTheEditLands(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+	repo.autopilotErr = errors.New("connection reset")
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"`+atom.ID.String()+`"}],`+
+			`"requirement":"PostgreSQL experience","requirement_status":"closed_bank"}`))
+	if err != nil {
+		t.Fatalf("cv_edit returned an error for a report-merge failure after a successful edit: %v", err)
+	}
+	if repo.written == nil {
+		t.Fatal("the edit did not land — Commit should have run before the failing merge")
 	}
 }
 

--- a/internal/handler/assistant_profile_tool.go
+++ b/internal/handler/assistant_profile_tool.go
@@ -157,7 +157,7 @@ func (h *assistantHandlers) experienceSummary(ctx context.Context, userID int64,
 			evidenced[skill] = true
 		}
 	}
-	for _, skill := range skilltag.Canonicalize(claimed) {
+	for _, skill := range skilltag.Canonicalize(claimed, skilltag.WithResumeAcronyms()) {
 		if !evidenced[skill] {
 			out.SkillsWithoutEvidence = append(out.SkillsWithoutEvidence, skill)
 		}

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -319,7 +319,7 @@ func (r *QueriesRepository) ListInteractions(
 		card := jobview.NewCard(jobview.CardInput{
 			PublicSlug:     row.PublicSlug,
 			Title:          row.Title,
-			Company:        row.CompanySlug,
+			Company:        row.Company,
 			ClosedAt:       pgconv.TimePtr(row.ClosedAt),
 			WorkMode:       row.WorkMode,
 			Seniority:      row.Seniority,

--- a/internal/llmkey/llmkey.go
+++ b/internal/llmkey/llmkey.go
@@ -35,13 +35,6 @@ var ErrUpstream = errors.New("llm gateway")
 // throwing it away would orphan a live credential.
 var ErrUnknownKey = fmt.Errorf("%w: key not recognised", ErrUpstream)
 
-// errUnauthorized is a refused credential, and what it means depends entirely on WHICH
-// credential was refused. On a self-read it is the user's own key and means exactly
-// "unknown, re-mint". On an administrative call it is our configured admin key and means
-// the deployment is misconfigured — reading that as a stale user key would turn one
-// wrong environment variable into a re-minting storm across every account.
-var errUnauthorized = fmt.Errorf("%w: credential refused", ErrUpstream)
-
 // requestTimeout bounds one admin call. It is short because these calls sit in front of
 // a user's request: minting is what stands between somebody pressing send and their
 // answer starting, so a slow gateway must give up quickly and let the call proceed
@@ -55,15 +48,6 @@ const (
 	// gateway serves more than one product, so a bare id would collide with another's.
 	ownerPrefix = "freehire-"
 )
-
-// Spend is what the gateway says an account has spent in the current window. Limit is 0
-// when no ceiling is configured and ResetsAt is zero when the gateway reports no window —
-// both are the ordinary state of a deployment that has not chosen a budget.
-type Spend struct {
-	Amount   float64
-	Limit    float64
-	ResetsAt time.Time
-}
 
 // Config is the gateway's administrative endpoint and the policy applied to new keys.
 // MaxBudget, RPMLimit and BudgetWindow are omitted from the mint request when unset,
@@ -134,48 +118,6 @@ func (c *Client) Mint(ctx context.Context, userID int64) (string, error) {
 		return "", fmt.Errorf("%w: minted an empty key", ErrUpstream)
 	}
 	return out.Key, nil
-}
-
-// Spend reports what a credential has spent in the current window.
-//
-// The read authenticates as the credential itself rather than as the administrator, for
-// two reasons. It keeps the secret out of the request URL — the gateway logs
-// `$request_uri`, so a query parameter would file a live credential into an access log on
-// every usage read, in plaintext, forever. And it needs no administrative rights to
-// perform, so the one path a user's request can reach cannot do anything but read that
-// user's own line. A key cannot mint keys (verified: the gateway answers 401).
-func (c *Client) Spend(ctx context.Context, secret string) (Spend, error) {
-	if c == nil {
-		return Spend{}, fmt.Errorf("%w: no admin API configured", ErrUpstream)
-	}
-	var out struct {
-		Info struct {
-			Spend     float64  `json:"spend"`
-			MaxBudget *float64 `json:"max_budget"`
-			ResetAt   *string  `json:"budget_reset_at"`
-		} `json:"info"`
-	}
-	err := c.get(ctx, "/key/info", secret, &out)
-	// Refused here means the gateway does not know this key, because the key IS the
-	// credential being checked. That is the signal to replace it.
-	if errors.Is(err, errUnauthorized) {
-		return Spend{}, ErrUnknownKey
-	}
-	if err != nil {
-		return Spend{}, err
-	}
-	spend := Spend{Amount: out.Info.Spend}
-	if out.Info.MaxBudget != nil {
-		spend.Limit = *out.Info.MaxBudget
-	}
-	if out.Info.ResetAt != nil {
-		// An unparseable instant is not worth failing a usage readout over: the amount is
-		// the answer, and the reset is decoration beside it.
-		if at, err := time.Parse(time.RFC3339, *out.Info.ResetAt); err == nil {
-			spend.ResetsAt = at
-		}
-	}
-	return spend, nil
 }
 
 // Activity is what an account did over a window: how many model calls it made, how many
@@ -285,10 +227,9 @@ func (c *Client) get(ctx context.Context, path, bearer string, out any) error {
 
 // do carries out one call and decodes its answer.
 //
-// 404 and 401 are singled out, but only 404 is classified here: the gateway answers it
-// for a key it does not know regardless of who asked. A 401 depends on whose credential
-// was refused, which only the caller knows, so it comes back as errUnauthorized for them
-// to interpret. Every other non-2xx is the gateway's own problem.
+// 404 is singled out: the gateway answers it for a key it does not know regardless of who
+// asked, which is the signal a caller (Block, Delete) treats as already done. Every other
+// non-2xx, including a 401, is the gateway's own problem.
 //
 // Error messages carry the path and never the query or the credential.
 func (c *Client) do(req *http.Request, bearer string, out any) error {
@@ -301,9 +242,6 @@ func (c *Client) do(req *http.Request, bearer string, out any) error {
 
 	if resp.StatusCode == http.StatusNotFound {
 		return ErrUnknownKey
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		return errUnauthorized
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return fmt.Errorf("%w: %s: status %d", ErrUpstream, req.URL.Path, resp.StatusCode)

--- a/internal/llmkey/llmkey_test.go
+++ b/internal/llmkey/llmkey_test.go
@@ -154,45 +154,6 @@ func TestMintReportsAnEmptyKeyAsAnError(t *testing.T) {
 	}
 }
 
-func TestSpendReadsThePeriodBack(t *testing.T) {
-	srv, got := gateway(t, http.StatusOK, `{"info":{"spend":1.25,"max_budget":10,"budget_reset_at":"2026-09-01T00:00:00Z"}}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
-
-	spend, err := c.Spend(context.Background(), "sk-user")
-	if err != nil {
-		t.Fatalf("Spend: %v", err)
-	}
-	if spend.Amount != 1.25 || spend.Limit != 10 {
-		t.Errorf("Spend = %+v, want the amount and the ceiling", spend)
-	}
-	if spend.ResetsAt.IsZero() || spend.ResetsAt.Year() != 2026 || spend.ResetsAt.Month() != 9 {
-		t.Errorf("ResetsAt = %v, want the parsed reset instant", spend.ResetsAt)
-	}
-	if got.path != "/key/info" || got.method != http.MethodGet {
-		t.Errorf("called %s %s, want GET /key/info", got.method, got.path)
-	}
-	// The read authenticates AS the key, and the key must never travel in the URL: the
-	// gateway logs the request URI, so a query parameter would file a live credential
-	// into an access log in plaintext on every usage read.
-	if got.query != "" {
-		t.Errorf("query = %q, want none — a credential in a URL lands in access logs", got.query)
-	}
-	if got.authz != "Bearer sk-user" {
-		t.Errorf("authorization = %q, want the caller's own key, not the administrator's", got.authz)
-	}
-}
-
-// A self-read is authenticated by the very key being asked about, so a refusal means the
-// gateway has forgotten it — the signal to mint a replacement.
-func TestSpendReportsARefusedSelfReadAsAnUnknownKey(t *testing.T) {
-	srv, _ := gateway(t, http.StatusUnauthorized, `{"error":"invalid key"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
-
-	if _, err := c.Spend(context.Background(), "sk-forgotten"); !errors.Is(err, ErrUnknownKey) {
-		t.Errorf("error = %v, want ErrUnknownKey so the caller can re-mint", err)
-	}
-}
-
 // The same status on an ADMINISTRATIVE call means our own admin credential is wrong.
 // Reading that as a stale user key would turn one bad environment variable into a
 // re-minting storm across every account — so the two must never be conflated.
@@ -206,33 +167,6 @@ func TestARefusedAdminCallIsNotAnUnknownUserKey(t *testing.T) {
 	}
 	if !errors.Is(err, ErrUpstream) {
 		t.Errorf("error = %v, want it to wrap ErrUpstream", err)
-	}
-}
-
-// A gateway that reports no ceiling and no reset is the default deployment, not an error.
-func TestSpendToleratesAnAbsentCeiling(t *testing.T) {
-	srv, _ := gateway(t, http.StatusOK, `{"info":{"spend":0.5,"max_budget":null,"budget_reset_at":null}}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
-
-	spend, err := c.Spend(context.Background(), "sk-user")
-	if err != nil {
-		t.Fatalf("Spend: %v", err)
-	}
-	if spend.Amount != 0.5 || spend.Limit != 0 || !spend.ResetsAt.IsZero() {
-		t.Errorf("Spend = %+v, want the amount with an absent ceiling and reset", spend)
-	}
-}
-
-// The gateway answers 404 for a key it does not know. That is the signal to re-mint, and
-// it has to be distinguishable from "the gateway is down" — one heals itself, the other
-// must not throw away a good credential.
-func TestSpendReportsAnUnknownKeyDistinctly(t *testing.T) {
-	srv, _ := gateway(t, http.StatusNotFound, `{"error":"key not found"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
-
-	_, err := c.Spend(context.Background(), "sk-forgotten")
-	if !errors.Is(err, ErrUnknownKey) {
-		t.Errorf("error = %v, want ErrUnknownKey so the caller can re-mint", err)
 	}
 }
 
@@ -370,9 +304,6 @@ func TestNilClientIsSafe(t *testing.T) {
 	var c *Client
 	if _, err := c.Mint(context.Background(), 1); err == nil {
 		t.Error("Mint on an unconfigured gateway must fail rather than return a usable key")
-	}
-	if _, err := c.Spend(context.Background(), "sk-user"); err == nil {
-		t.Error("Spend on an unconfigured gateway must fail rather than report a false zero")
 	}
 	if err := c.Delete(context.Background(), "sk-user"); err != nil {
 		t.Errorf("Delete on an unconfigured gateway = %v, want nil — there is nothing to erase", err)

--- a/internal/llmkey/resolver.go
+++ b/internal/llmkey/resolver.go
@@ -129,12 +129,19 @@ func (r *Resolver) mint(ctx context.Context, userID int64) string {
 	}
 }
 
-// Forget drops a credential the gateway no longer recognises so the next call mints a
-// replacement. Nil-safe.
+// Forget drops a credential the gateway refused so the next call mints a replacement.
+// Nil-safe.
 //
-// The row is cleared first: that is what makes the very next call work. Revoking at the
-// gateway is mopping up something it has usually already forgotten, which is exactly why
-// this is called at all.
+// The row is cleared first: that is what makes the very next call work. The gateway side
+// BLOCKS rather than deletes, and deliberately does not distinguish why the refusal
+// happened: a credential the gateway has plainly forgotten (the ordinary case) and one
+// this same account's Revoke just BLOCKED moments ago for account deletion look
+// identical from here — both answer 401. Deleting on that ambiguity would occasionally
+// erase the very spend history Revoke blocked the key specifically to keep, if a
+// request already in flight (a second tab, a running assistant turn) gets refused in the
+// window between the block and the row's own removal by the deletion cascade. Blocking an
+// already-blocked or already-unknown key is a safe no-op either way (Client.Block), so
+// there is no case where the gentler action costs anything Delete would have bought.
 func (r *Resolver) Forget(ctx context.Context, userID int64, secret string) {
 	if r == nil || r.q == nil {
 		return
@@ -146,7 +153,9 @@ func (r *Resolver) Forget(ctx context.Context, userID int64, secret string) {
 	if err != nil {
 		log.Printf("llmkey: clear credential for user %d: %v", userID, err)
 	}
-	r.revoke(ctx, secret)
+	if err := r.gateway.Block(ctx, secret); err != nil {
+		log.Printf("llmkey: block refused credential: %v", err)
+	}
 }
 
 // Revoke stops this account's credential from spending, without erasing it and without

--- a/internal/llmkey/resolver_test.go
+++ b/internal/llmkey/resolver_test.go
@@ -73,13 +73,15 @@ func (f *fakeQueries) ClearUserLLMKey(_ context.Context, arg db.ClearUserLLMKeyP
 	return nil
 }
 
-// routedGateway answers /key/generate with successive secrets and records every deletion,
-// so a test can prove an abandoned key was cleaned up rather than orphaned.
+// routedGateway answers /key/generate with successive secrets and records every deletion
+// and block, so a test can prove an abandoned key was cleaned up (or, for a refused live
+// credential, merely retired) rather than orphaned.
 type routedGateway struct {
 	mu       sync.Mutex
 	mints    []string
 	minted   int
 	deleted  []string
+	blocked  []string
 	mintFail bool
 }
 
@@ -109,6 +111,14 @@ func (g *routedGateway) server(t *testing.T) *httptest.Server {
 			_ = json.Unmarshal(raw, &body)
 			g.deleted = append(g.deleted, body.Keys...)
 			_, _ = io.WriteString(w, `{"deleted_keys":[]}`)
+		case "/key/block":
+			var body struct {
+				Key string `json:"key"`
+			}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			g.blocked = append(g.blocked, body.Key)
+			_, _ = io.WriteString(w, `{}`)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -225,7 +235,11 @@ func TestNilResolverIsUnattributed(t *testing.T) {
 // Forget is what a rejected credential triggers. Clearing the row comes first: that is
 // what lets the very next call mint a working replacement, and the gateway delete is
 // mopping up something it has usually already forgotten.
-func TestForgetClearsTheRowAndRevokesTheKey(t *testing.T) {
+// Forget must BLOCK, not delete: a refused credential looks identical whether the gateway
+// has simply forgotten it (the ordinary case) or a concurrent Revoke just blocked it for
+// account deletion — and only the latter has spend history worth keeping. Deleting on that
+// ambiguity would occasionally erase exactly the history Revoke blocked the key to preserve.
+func TestForgetClearsTheRowAndBlocksTheKey(t *testing.T) {
 	q := newFakeQueries()
 	q.stored[7] = "sk-stale"
 	g := &routedGateway{}
@@ -236,8 +250,11 @@ func TestForgetClearsTheRowAndRevokesTheKey(t *testing.T) {
 	if q.stored[7] != "" {
 		t.Errorf("stored %q, want the stale credential cleared so the next call re-mints", q.stored[7])
 	}
-	if len(g.deleted) != 1 || g.deleted[0] != "sk-stale" {
-		t.Errorf("deleted %v, want the stale credential revoked", g.deleted)
+	if len(g.blocked) != 1 || g.blocked[0] != "sk-stale" {
+		t.Errorf("blocked %v, want the stale credential blocked", g.blocked)
+	}
+	if len(g.deleted) != 0 {
+		t.Errorf("deleted %v, want nothing deleted — Forget must not erase spend history", g.deleted)
 	}
 }
 

--- a/internal/matchanalysis/analyzer.go
+++ b/internal/matchanalysis/analyzer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 
 	"github.com/strelov1/freehire/internal/hardconstraint"
@@ -208,6 +209,19 @@ const stageAttempts = 2
 // events for the given stage, and unmarshals the accumulated JSON into out. A parse
 // failure and a timed-out stage are each retried once; anything else returns at once.
 func (a *Analyzer) streamStage(ctx context.Context, stage int, system, user string, emit func(Event), out any) error {
+	// A snapshot of out exactly as the caller handed it in — the zero value for stages 1
+	// and 2, or Stage 2's verdict for Stage 3's seed-and-merge audit (see Analyze: Stage 3
+	// pre-populates out so a field the audit's JSON omits keeps its Stage 2 value, since
+	// json.Unmarshal only overwrites the keys present in the source). Every attempt
+	// restores out to this snapshot before decoding into it: encoding/json does not roll
+	// back a partial decode, so a failed attempt can leave the fields it reached before
+	// erroring still set, and without restoring first a later attempt's valid-but-partial
+	// JSON would silently inherit that stale, never-validated value instead of the seed
+	// (zero, or Stage 2's) it should have started from.
+	dst := reflect.ValueOf(out).Elem()
+	seed := reflect.New(dst.Type()).Elem()
+	seed.Set(dst)
+
 	var parseErr error
 	for attempt := 1; attempt <= stageAttempts; attempt++ {
 		raw, err := a.client.GenerateJSONStream(ctx, system, user, func(t string) {
@@ -225,6 +239,7 @@ func (a *Analyzer) streamStage(ctx context.Context, stage int, system, user stri
 			}
 			return err // transport error, or a caller who is gone — retrying wouldn't help
 		}
+		dst.Set(seed)
 		if parseErr = json.Unmarshal([]byte(strings.TrimSpace(raw)), out); parseErr == nil {
 			return nil
 		}
@@ -473,18 +488,22 @@ func writeLocation(b *strings.Builder, in Input) {
 	b.WriteString("\n")
 }
 
-// remoteWithinReach reports whether the job is remote AND its region falls within the
-// candidate's stated remote reach (their location_preferences remote.regions). A reach of
-// "global", or one naming the job's region, covers the posting regardless of the posted
-// office city/country — a remote worker in that region can take it without relocating. This
-// is deterministic on purpose: it stops the model from reading a remote role's HQ city (e.g.
-// a LATAM-remote job posted from Santo Domingo) as a relocation requirement and scoring
-// location_fit 0. Unset/unparseable prefs or a non-remote job → false (the model judges).
+// remoteWithinReach reports whether the job is remote AND its region or country falls
+// within the candidate's stated remote reach (their location_preferences remote.regions
+// and remote.countries — two independent fields the profile editor lets a candidate set
+// separately, e.g. reach scoped to specific countries with no region picked at all). A
+// reach of "global", or one naming the job's region or country, covers the posting
+// regardless of the posted office city — a remote worker within that reach can take it
+// without relocating. This is deterministic on purpose: it stops the model from reading a
+// remote role's HQ city (e.g. a LATAM-remote job posted from Santo Domingo) as a
+// relocation requirement and scoring location_fit 0. Unset/unparseable prefs or a
+// non-remote job → false (the model judges).
 func remoteWithinReach(in Input) bool {
 	if !in.JobRemote && !strings.EqualFold(in.JobWorkMode, "remote") {
 		return false
 	}
-	for _, r := range candidateRemoteReach(in.LocationPreferences) {
+	regions, countries := candidateRemoteReach(in.LocationPreferences)
+	for _, r := range regions {
 		if strings.EqualFold(r, "global") {
 			return true
 		}
@@ -494,21 +513,30 @@ func remoteWithinReach(in Input) bool {
 			}
 		}
 	}
+	for _, c := range countries {
+		for _, jc := range in.JobCountries {
+			if strings.EqualFold(c, jc) {
+				return true
+			}
+		}
+	}
 	return false
 }
 
-// candidateRemoteReach pulls the remote.regions list out of the raw location_preferences
-// JSON. Empty on unset/unparseable input (the caller then degrades to model judgement).
-func candidateRemoteReach(prefsJSON string) []string {
+// candidateRemoteReach pulls the remote.regions and remote.countries lists out of the raw
+// location_preferences JSON — the same shape userprofile.GeoSet writes. Both empty on
+// unset/unparseable input (the caller then degrades to model judgement).
+func candidateRemoteReach(prefsJSON string) (regions, countries []string) {
 	var p struct {
 		Remote struct {
-			Regions []string `json:"regions"`
+			Regions   []string `json:"regions"`
+			Countries []string `json:"countries"`
 		} `json:"remote"`
 	}
 	if json.Unmarshal([]byte(strings.TrimSpace(prefsJSON)), &p) != nil {
-		return nil
+		return nil, nil
 	}
-	return p.Remote.Regions
+	return p.Remote.Regions, p.Remote.Countries
 }
 
 func writeRequirements(b *strings.Builder, reqs []Requirement) {

--- a/internal/matchanalysis/analyzer_test.go
+++ b/internal/matchanalysis/analyzer_test.go
@@ -73,6 +73,54 @@ func TestStreamStage_RetriesATimedOutStage(t *testing.T) {
 	}
 }
 
+// partialThenOmitsModel's first call returns JSON that decodes field "a" fine before
+// hitting a type mismatch on "b" (encoding/json keeps decoding after a type-mismatched
+// field and only reports the error once done, so "a" really does land in the destination
+// before Unmarshal returns its error). The second call is valid JSON that omits "a"
+// entirely — reproducing a real model retry that answers a narrower question the second
+// time.
+type partialThenOmitsModel struct{ calls int }
+
+func (m *partialThenOmitsModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.calls++
+	if m.calls == 1 {
+		return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: `{"a":999,"b":"not-an-int"}`}}}, nil
+	}
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: `{"b":7}`}}}, nil
+}
+func (*partialThenOmitsModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+// A failed attempt's partial decode must not survive into a later attempt: encoding/json
+// does not roll back the fields it reached before erroring, so out must be restored to
+// its pre-attempt state before every retry, or a field the second, successful attempt
+// never mentions silently keeps the first attempt's never-validated value.
+func TestStreamStage_DiscardsAPartiallyDecodedFailedAttempt(t *testing.T) {
+	m := &partialThenOmitsModel{}
+	a := &Analyzer{client: llm.NewWithModel(m)}
+
+	var out struct {
+		A int `json:"a"`
+		B int `json:"b"`
+	}
+	err := a.streamStage(context.Background(), 1, "sys", "usr", func(Event) {}, &out)
+
+	if err != nil {
+		t.Fatalf("streamStage: %v, want the retry to succeed", err)
+	}
+	if m.calls != 2 {
+		t.Fatalf("model calls = %d, want 2", m.calls)
+	}
+	if out.A != 0 {
+		t.Errorf("out.A = %d, want 0 — the first attempt's value must not survive into the "+
+			"second attempt's result, which never mentioned \"a\"", out.A)
+	}
+	if out.B != 7 {
+		t.Errorf("out.B = %d, want 7 (the second attempt's own answer)", out.B)
+	}
+}
+
 // A retry is only worth spending when there is still someone to answer. When the caller's
 // own context is already dead, a second call would burn tokens on a reply nobody reads.
 func TestStreamStage_DoesNotRetryWhenTheCallerIsGone(t *testing.T) {

--- a/internal/matchanalysis/prompt_test.go
+++ b/internal/matchanalysis/prompt_test.go
@@ -77,6 +77,23 @@ func TestWriteLocation_RemoteOutsideReachNoNote(t *testing.T) {
 	}
 }
 
+// The profile editor lets a candidate scope their remote reach by country independently
+// of region (ProfileForm's "Remote reach" block: region pills + a country search, each
+// toggled on its own). A candidate who picked only countries, no regions, must still get
+// the deterministic vouch for a job in one of those countries.
+func TestWriteLocation_RemoteWithinReachByCountryAddsNote(t *testing.T) {
+	in := Input{
+		JobRemote:           true,
+		JobLocation:         "Berlin, Germany",
+		JobCountries:        []string{"de"},
+		LocationPreferences: `{"remote":{"countries":["de","pl"]}}`,
+	}
+	got := stage2UserPrompt(in, nil, candidateContext(in.StructuredResume))
+	if !strings.Contains(got, "within the candidate's stated remote reach") {
+		t.Errorf("expected remote-reach NOTE for a job in a country the candidate's reach names:\n%s", got)
+	}
+}
+
 func TestStage2SystemPrompt_RemoteLocationRule(t *testing.T) {
 	sp := stage2SystemPrompt()
 	if !strings.Contains(sp, "remote reach") || !strings.Contains(sp, "Relocation matters only for onsite") {

--- a/internal/pipeline/board_health_test.go
+++ b/internal/pipeline/board_health_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -97,6 +98,35 @@ func (s boardKeyedSource) Fetch(_ context.Context, e sources.CompanyEntry) ([]so
 		return nil, errors.New("board down")
 	}
 	return []sources.Job{{ExternalID: "1", Title: "Dev", Company: e.Company}}, nil
+}
+
+// hydratingSpySource implements sources.HydratingSource and counts FetchNew calls per
+// board, so a test can prove a board the recovery probe answered is not hydrated a
+// second time by the main loop — the exact cost the real HydratingSource adapters (e.g.
+// workday) pay for twice when a probe's fetch is discarded instead of reused.
+type hydratingSpySource struct {
+	provider string
+	mu       sync.Mutex
+	calls    map[string]int // board -> FetchNew call count
+}
+
+func (s *hydratingSpySource) Provider() string { return s.provider }
+func (s *hydratingSpySource) Fetch(ctx context.Context, e sources.CompanyEntry) ([]sources.Job, error) {
+	return s.FetchNew(ctx, e, func(string) bool { return false })
+}
+func (s *hydratingSpySource) FetchNew(_ context.Context, e sources.CompanyEntry, _ func(string) bool) ([]sources.Job, error) {
+	s.mu.Lock()
+	if s.calls == nil {
+		s.calls = map[string]int{}
+	}
+	s.calls[e.Board]++
+	s.mu.Unlock()
+	return []sources.Job{{ExternalID: "1", Title: "Dev", Company: e.Company}}, nil
+}
+func (s *hydratingSpySource) callsFor(board string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[board]
 }
 
 // spySource counts Fetch calls (and can error), so a test can tell a probe fetch from a
@@ -229,6 +259,54 @@ func TestRecoverProbeTriesPastDeadBoard(t *testing.T) {
 	}
 	if len(health.successes) != 1 || health.successes[0] != "join/live" {
 		t.Errorf("successes = %v, want [join/live]", health.successes)
+	}
+}
+
+// TestRecoverProbeReusesTheAnsweringBoardsFetchInsteadOfCrawlingItTwice guards the exact
+// gap the two tests above leave open: both use a Source whose Fetch is a cheap single
+// call, so they cannot tell a probe fetch from a genuine double-crawl. A HydratingSource
+// (workday and friends) pays for FetchNew with a full paginated re-crawl plus per-posting
+// detail hydration — running it once to answer the probe and once more, moments later,
+// for the same board is the double-crawl this test would have caught.
+func TestRecoverProbeReusesTheAnsweringBoardsFetchInsteadOfCrawlingItTwice(t *testing.T) {
+	src := &hydratingSpySource{provider: "workday"}
+	health := &fakeHealth{cooldowns: map[string]time.Time{
+		"workday/acme": time.Now().Add(24 * time.Hour), // probed first (soonest to expire, tie-break by name)
+		"workday/beta": time.Now().Add(24 * time.Hour),
+	}}
+	store := &fakeStore{}
+	r := Runner{Registry: registry(src), Store: store, BoardHealth: health}
+
+	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "Acme", Provider: "workday", Board: "acme"},
+		{Company: "Beta", Provider: "workday", Board: "beta"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(health.cleared) != 1 || health.cleared[0] != "workday" {
+		t.Fatalf("cleared = %v, want [workday]", health.cleared)
+	}
+	// The board that answered the probe (acme) must be hydrated exactly once — by the
+	// probe itself — not again by the main loop. The board the probe never tried (beta)
+	// is hydrated exactly once by the main loop, same as any normal crawl.
+	if got := src.callsFor("acme"); got != 1 {
+		t.Errorf("FetchNew(acme) called %d times, want 1 (the probe's fetch must be reused, not repeated)", got)
+	}
+	if got := src.callsFor("beta"); got != 1 {
+		t.Errorf("FetchNew(beta) called %d times, want 1", got)
+	}
+	// Both boards still ingest — reusing the probe's fetch must not lose its jobs.
+	if stats.Total().Ingested != 2 {
+		t.Errorf("stats = %+v, want Ingested=2 (the probed board's fetch must still be saved, not discarded)", stats.Total())
+	}
+	if len(store.saved) != 2 {
+		t.Errorf("saved %d jobs, want 2", len(store.saved))
+	}
+	// recordSuccess must fire exactly once for the reused board too — from inside the
+	// probe's ingestFetched — not once there and once more from a (skipped) main-loop call.
+	if len(health.successes) != 2 {
+		t.Errorf("successes = %v, want exactly 2 (workday/acme once, workday/beta once)", health.successes)
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -165,8 +165,10 @@ type Runner struct {
 func (r Runner) Run(ctx context.Context, entries []sources.CompanyEntry) (RunStats, error) {
 	// Half-open the circuit breaker before the crawl: a provider whose boards were mass-
 	// cooled by a since-resolved outage recovers this cycle instead of each board waiting
-	// out its own backoff.
-	r.recoverProviders(ctx, entries)
+	// out its own backoff. The board that answered the probe was already fully ingested
+	// from that same fetch (see probeProvider) — handled carries its Stats so the loop
+	// below does not crawl it a second time.
+	handled := r.recoverProviders(ctx, entries)
 
 	var (
 		mu     sync.Mutex
@@ -201,7 +203,10 @@ func (r Runner) Run(ctx context.Context, entries []sources.CompanyEntry) (RunSta
 				return
 			}
 
-			boardStats := r.ingestBoard(ctx, e)
+			boardStats, already := handled[boardKey{e.Provider, e.Board}]
+			if !already {
+				boardStats = r.ingestBoard(ctx, e)
+			}
 			crawled.Add(1)
 
 			mu.Lock()
@@ -221,6 +226,10 @@ func (r Runner) Run(ctx context.Context, entries []sources.CompanyEntry) (RunSta
 // a recovered provider, few enough that the probe stays cheap.
 const maxRecoveryProbes = 3
 
+// boardKey identifies one board within a run: the pair a CompanyEntry, a Claimed
+// cooldown, and a recovery probe all key on.
+type boardKey struct{ provider, board string }
+
 // recoverProviders is the provider-level circuit breaker's half-open transition. Before
 // the main crawl, for each provider with cooled boards it probes up to maxRecoveryProbes
 // of them through the adapter; the first probe that succeeds proves the provider is
@@ -228,9 +237,14 @@ const maxRecoveryProbes = 3
 // cycle rather than leaving each board to ride out its per-board backoff (up to a day)
 // after a resolved provider-wide outage. Every probe failing leaves the provider cooled,
 // so a still-down provider is never stampeded. A nil BoardHealth port disables it entirely.
-func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyEntry) {
+//
+// It returns the Stats of any board the probe itself fully ingested (see probeProvider):
+// for such a board the caller must not run ingestBoard again this cycle, or "a few cheap
+// probes" becomes a full second crawl of the one board that happened to answer.
+func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyEntry) map[boardKey]Stats {
+	handled := make(map[boardKey]Stats)
 	if r.BoardHealth == nil {
-		return
+		return handled
 	}
 	byProvider := entriesByProvider(entries)
 	for _, provider := range sortedProviders(byProvider) {
@@ -250,7 +264,8 @@ func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyE
 			log.Printf("ingest: recovery probe %s: list cooled boards: %v", provider, err)
 			continue
 		}
-		if !r.providerAnswers(ctx, src, boards, byProvider[provider]) {
+		e, st, reused, answered := r.probeProvider(ctx, src, boards, byProvider[provider])
+		if !answered {
 			continue
 		}
 		cleared, err := r.BoardHealth.ClearCooldowns(ctx, provider)
@@ -259,26 +274,44 @@ func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyE
 			continue
 		}
 		log.Printf("ingest: %s answered a recovery probe — cleared %d cooled board(s) to crawl this cycle", provider, cleared)
+		if reused {
+			handled[boardKey{e.Provider, e.Board}] = st
+		}
 	}
+	return handled
 }
 
-// providerAnswers fetches each candidate board through the adapter until one succeeds,
-// reporting whether the provider responded. A board absent from this run's entries is
-// skipped (it cannot be probed without its entry), and a cancelled run stops early.
-func (r Runner) providerAnswers(ctx context.Context, src sources.Source, boards []string, entries map[string]sources.CompanyEntry) bool {
+// probeProvider fetches each candidate board through the adapter until one succeeds,
+// reporting the entry that answered. For a non-streaming board — the common case, and
+// the only one fetchBoard's result actually corresponds to — that same fetch is finished
+// into a full ingest (reused=true, st holds its Stats) instead of being thrown away, so
+// the board is not crawled a second time by the main loop; the finding this fixes was a
+// HydratingSource's FetchNew (a full paginated re-crawl plus per-posting hydration, not a
+// cheap reachability check) run once to answer the probe and once more moments later. A
+// streaming adapter's real ingest path is ingestStream, which this fetch does not
+// exercise, so reused is false for it and the main loop still runs it normally. A board
+// absent from this run's entries is skipped (it cannot be probed without its entry), and
+// a cancelled run stops early. answered=false when nothing responded.
+func (r Runner) probeProvider(ctx context.Context, src sources.Source, boards []string, entries map[string]sources.CompanyEntry) (e sources.CompanyEntry, st Stats, reused, answered bool) {
+	_, streaming := src.(sources.StreamingSource)
 	for _, board := range boards {
 		if ctx.Err() != nil {
-			return false
+			return sources.CompanyEntry{}, Stats{}, false, false
 		}
-		e, ok := entries[board]
+		candidate, ok := entries[board]
 		if !ok {
 			continue
 		}
-		if _, _, err := r.fetchBoard(ctx, e, src); err == nil {
-			return true
+		raw, seen, err := r.fetchBoard(ctx, candidate, src)
+		if err != nil {
+			continue
 		}
+		if streaming {
+			return candidate, Stats{}, false, true
+		}
+		return candidate, r.ingestFetched(ctx, candidate, raw, seen), true, true
 	}
-	return false
+	return sources.CompanyEntry{}, Stats{}, false, false
 }
 
 // entriesByProvider indexes the run's entries as provider → board → entry, so the
@@ -355,7 +388,16 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) Stats {
 		r.recordFailure(ctx, e, err.Error())
 		return Stats{Failed: 1}
 	}
+	return r.ingestFetched(ctx, e, raw, seen)
+}
 
+// ingestFetched turns one board's already-fetched raw postings into Stats: applying a
+// HydratingSource's liveness refreshes, filtering and saving the rest through the
+// catalogue, and recording the board's health. Split out of ingestBoard so the recovery
+// probe — which must fetch a board through the adapter to answer it — can finish that
+// same fetch into a full ingest (see probeProvider) instead of discarding the result and
+// having the main loop fetch the board a second time.
+func (r Runner) ingestFetched(ctx context.Context, e sources.CompanyEntry, raw []sources.Job, seen map[string]bool) Stats {
 	var (
 		st       Stats
 		rej      rejections

--- a/internal/safehttp/safehttp.go
+++ b/internal/safehttp/safehttp.go
@@ -20,6 +20,8 @@ import (
 	"net/url"
 	"syscall"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 // cgnat is the RFC6598 shared address space (100.64.0.0/10). IsPrivate does not
@@ -114,4 +116,19 @@ func NewClientWithProxy(timeout time.Duration, proxy *url.URL) *http.Client {
 		Timeout:   timeout,
 		Transport: NewTransportWithProxy(5*time.Second, proxy),
 	}
+}
+
+// GuardedOAuth2Context returns ctx carrying a guarded client under oauth2's own
+// context key, so golang.org/x/oauth2 (Exchange, TokenSource, Client, and any
+// provider call that reads its HTTP client from ctx) dials through this package's
+// guard instead of the library's zero-value default client.
+//
+// A caller-supplied oauth2.HTTPClient is respected and returned unchanged — tests
+// inject an httptest client for their loopback stub, and this must not override
+// that with a guarded client that would reject 127.0.0.1.
+func GuardedOAuth2Context(ctx context.Context, timeout time.Duration) context.Context {
+	if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, oauth2.HTTPClient, NewClient(timeout))
 }

--- a/internal/skilltag/canonicalize.go
+++ b/internal/skilltag/canonicalize.go
@@ -27,8 +27,9 @@ func collapseSeparators(s string) string {
 	return strings.TrimSpace(sepRE.ReplaceAllString(s, " "))
 }
 
-// canonicalSet is every canonical slug the dictionary can emit, so a caller may
-// hand over a canonical form directly.
+// canonicalSet is every canonical slug reachable through an unambiguous route (a word
+// alias, a phrase alias, or a shared acronym), so a caller may hand over that canonical
+// form directly.
 //
 // This is NOT a convenience: a canonical is not automatically an alias of itself.
 // "golang" resolves to "go", but the bare token "go" appears nowhere in the alias
@@ -37,6 +38,15 @@ func collapseSeparators(s string) string {
 // slugs ("go, react, kubernetes"), so without this tier the single most common
 // backend skill would be dropped from every atom the agent recorded, silently.
 // Parse is unaffected: it never consults this set.
+//
+// resumeAcronyms' canonicals are deliberately excluded, even when a phrase alias also
+// names the same canonical (e.g. "rag", reachable via the safe, unambiguous long form
+// "retrieval augmented generation"): letting the BARE canonical pass through here would
+// bypass the résumé-only acronym gate exactly the way the cased acronym pass is gated,
+// since a job-side n-gram caller (cvmatch) can hand over the bare token just as easily
+// as the acronym itself. The long phrase itself stays reachable through phraseExact,
+// untouched by this — it is unambiguous in either context. canonicalSetResume covers
+// the bare form, gated behind WithResumeAcronyms.
 var canonicalSet = func() map[string]struct{} {
 	out := make(map[string]struct{}, len(wordAliases))
 	for _, c := range wordAliases {
@@ -48,6 +58,17 @@ var canonicalSet = func() map[string]struct{} {
 	for _, c := range sharedAcronyms {
 		out[c] = struct{}{}
 	}
+	for _, c := range resumeAcronyms {
+		delete(out, c)
+	}
+	return out
+}()
+
+// canonicalSetResume is the résumé-scoped counterpart of canonicalSet: the canonical
+// slugs reachable ONLY through resumeAcronyms, gated behind WithResumeAcronyms for the
+// same reason the acronym itself is.
+var canonicalSetResume = func() map[string]struct{} {
+	out := make(map[string]struct{}, len(resumeAcronyms))
 	for _, c := range resumeAcronyms {
 		out[c] = struct{}{}
 	}
@@ -69,10 +90,20 @@ var canonicalSet = func() map[string]struct{} {
 // rather than passing through as a pseudo-canonical. Nor does Canonicalize mine: a
 // token must resolve as a WHOLE (as an acronym, a word alias, or a phrase alias),
 // so handing it a sentence yields nothing — that is Parse's job.
-func Canonicalize(tokens []string) []string {
+//
+// The zero set is job-safe (default), mirroring Parse: the résumé-scoped acronym
+// tier (resumeAcronyms, e.g. RAG) is OFF unless a caller passes WithResumeAcronyms(),
+// because tokens Canonicalize resolves are not always a candidate's own — cvmatch
+// canonicalizes n-grams mined from a VACANCY's requirement text, where a résumé-only
+// acronym would collide with the same letters' job-side meaning.
+func Canonicalize(tokens []string, opts ...Option) []string {
+	var o options
+	for _, fn := range opts {
+		fn(&o)
+	}
 	out := make(map[string]struct{}, len(tokens))
 	for _, tok := range tokens {
-		if c, ok := canonicalizeToken(tok); ok {
+		if c, ok := canonicalizeToken(tok, o); ok {
 			out[c] = struct{}{}
 		}
 	}
@@ -80,10 +111,10 @@ func Canonicalize(tokens []string) []string {
 }
 
 // canonicalizeToken resolves one whole token, trying the tiers in the same order
-// Parse does — case-preserved acronyms first (both tiers: a candidate's own skill
-// list is résumé-scoped by definition), then the lowercase word aliases, then the
+// Parse does — case-preserved acronyms first (shared tier always, résumé tier only
+// when o.resumeAcronyms), then the lowercase word aliases, then the
 // separator-insensitive phrases — and finally accepting an already-canonical slug.
-func canonicalizeToken(tok string) (string, bool) {
+func canonicalizeToken(tok string, o options) (string, bool) {
 	cased := strings.TrimSpace(stripMarkup(tok))
 	if cased == "" {
 		return "", false
@@ -91,8 +122,10 @@ func canonicalizeToken(tok string) (string, bool) {
 	if c, ok := sharedAcronyms[cased]; ok {
 		return c, true
 	}
-	if c, ok := resumeAcronyms[cased]; ok {
-		return c, true
+	if o.resumeAcronyms {
+		if c, ok := resumeAcronyms[cased]; ok {
+			return c, true
+		}
 	}
 
 	norm := normalize(tok)
@@ -104,6 +137,11 @@ func canonicalizeToken(tok string) (string, bool) {
 	}
 	if _, ok := canonicalSet[norm]; ok {
 		return norm, true
+	}
+	if o.resumeAcronyms {
+		if _, ok := canonicalSetResume[norm]; ok {
+			return norm, true
+		}
 	}
 	return "", false
 }

--- a/internal/skilltag/canonicalize_test.go
+++ b/internal/skilltag/canonicalize_test.go
@@ -91,3 +91,27 @@ func TestCanonicalizeDoesNotMineSentences(t *testing.T) {
 		t.Errorf("Canonicalize(sentence) = %q, want nil — sentences belong to Parse", got)
 	}
 }
+
+// The zero set is job-safe: a résumé-only acronym like RAG (which collides with "RAG
+// status", project-health shorthand, in job text) must not resolve without an explicit
+// opt-in. cvmatch canonicalizes n-grams mined from a VACANCY's own requirement text, so
+// this is the default every job-side caller relies on.
+func TestCanonicalizeResumeAcronymNeedsOptIn(t *testing.T) {
+	if got := Canonicalize([]string{"RAG"}); got != nil {
+		t.Errorf("Canonicalize([RAG]) = %q, want nil without WithResumeAcronyms — RAG collides with job-side RAG-status", got)
+	}
+	got := Canonicalize([]string{"RAG"}, WithResumeAcronyms())
+	if !reflect.DeepEqual(got, []string{"rag"}) {
+		t.Errorf("Canonicalize([RAG], WithResumeAcronyms()) = %q, want [rag]", got)
+	}
+}
+
+// The full, unambiguous phrase behind a résumé-scoped acronym must resolve regardless
+// of the option — nobody writes "retrieval augmented generation" to mean project-status
+// jargon, so gating it the same way the bare acronym is gated would be over-correction.
+func TestCanonicalizeResumeAcronymsFullPhraseNeedsNoOptIn(t *testing.T) {
+	got := Canonicalize([]string{"retrieval augmented generation"})
+	if !reflect.DeepEqual(got, []string{"rag"}) {
+		t.Errorf("Canonicalize([retrieval augmented generation]) = %q, want [rag] unconditionally", got)
+	}
+}

--- a/internal/skilltag/skilltag.go
+++ b/internal/skilltag/skilltag.go
@@ -129,7 +129,7 @@ func wordTokens(norm string) []string {
 	return wordTokenRE.FindAllString(norm, -1)
 }
 
-// Option configures a Parse call. The zero set is job-safe (default).
+// Option configures a Parse or Canonicalize call. The zero set is job-safe (default).
 type Option func(*options)
 
 type options struct {
@@ -137,8 +137,10 @@ type options struct {
 }
 
 // WithResumeAcronyms enables the résumé-scoped acronym tier (resumeAcronyms, e.g.
-// RAG) for a Parse call. Job callers omit it so those acronyms never tag job
-// facets; the résumé path (handler.ExtractResumeProfile) sets it.
+// RAG) for a Parse or Canonicalize call. Job/vacancy callers omit it so those
+// acronyms never tag job facets; a caller resolving a candidate's own asserted
+// skills (handler.ExtractResumeProfile, an experience atom's Skills/Stack, a
+// profile's claimed skills) sets it.
 func WithResumeAcronyms() Option {
 	return func(o *options) { o.resumeAcronyms = true }
 }

--- a/internal/sources/aijobs.go
+++ b/internal/sources/aijobs.go
@@ -65,15 +65,17 @@ func (aijobs) aggregator() {}
 
 // FetchNew is the hydrating crawl cmd/ingest actually drives: it walks the listing
 // (crawlListing, bounded by maxNewPerRun and the seen-page stop) and fetches detail only
-// for a posting seen reports as not already in the catalogue.
+// for a posting seen reports as not already in the catalogue; a re-listed posting seen
+// already has is refreshed instead, matching every other HydratingSource adapter.
 func (a aijobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
-	links, err := a.crawlListing(ctx, seen, a.maxNewPerRun)
+	links, refreshed, err := a.crawlListing(ctx, seen, a.maxNewPerRun)
 	if err != nil {
 		return nil, err
 	}
-	return fetchDetails(links, defaultDetailWorkers, func(href string) (Job, bool) {
+	jobs := fetchDetails(links, defaultDetailWorkers, func(href string) (Job, bool) {
 		return a.detail(ctx, href)
-	}), nil
+	})
+	return append(jobs, refreshed...), nil
 }
 
 // Fetch is the list-only fallback HydratingSource specifies for a caller that cannot
@@ -172,8 +174,12 @@ func (a aijobs) listPage(ctx context.Context, csrfToken string, page int) (*html
 }
 
 // crawlListing walks the listing pages (newest posting first) and returns the job-detail
-// hrefs of postings seen reports as NOT already in the catalogue, in discovery order. It
-// stops — without requesting a further page — as soon as either condition holds:
+// hrefs of postings seen reports as NOT already in the catalogue, in discovery order, plus
+// a SeenRefresh-only Job for every already-catalogued posting it encounters along the way —
+// without this, a still-open posting's last_seen_at would never advance past its first
+// crawl, and the company-scoped 48h sweep would eventually close it as unseen with no way
+// back in (ExistingExternalIDs counts a closed row as seen, so it can never re-upsert).
+// The walk stops — without requesting a further page — as soon as either condition holds:
 //   - a whole page's postings are all already seen: the feed has been caught up to, so
 //     every following page (older still) would be too;
 //   - newBudget unseen postings have been found (0 means unbounded): this run's
@@ -182,18 +188,17 @@ func (a aijobs) listPage(ctx context.Context, csrfToken string, page int) (*html
 //
 // A first-page failure is a board-level error; a later page failing ends the walk with
 // what was gathered so far (a partial crawl survives a mid-listing hiccup).
-func (a aijobs) crawlListing(ctx context.Context, seen func(externalID string) bool, newBudget int) ([]string, error) {
+func (a aijobs) crawlListing(ctx context.Context, seen func(externalID string) bool, newBudget int) (unseen []string, refreshed []Job, err error) {
 	csrfToken, err := a.bootstrapSession(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("aijobs: session bootstrap: %w", err)
+		return nil, nil, fmt.Errorf("aijobs: session bootstrap: %w", err)
 	}
 
-	var unseen []string
 	for page := 1; page <= aijobsMaxPages; page++ {
 		root, err := a.listPage(ctx, csrfToken, page)
 		if err != nil {
 			if page == 1 {
-				return nil, fmt.Errorf("aijobs: listing page %d: %w", page, err)
+				return nil, nil, fmt.Errorf("aijobs: listing page %d: %w", page, err)
 			}
 			break
 		}
@@ -204,20 +209,24 @@ func (a aijobs) crawlListing(ctx context.Context, seen func(externalID string) b
 		allSeen := true
 		for _, href := range links {
 			id := aijobsJobID(href)
-			if id == "" || seen(id) {
+			if id == "" {
+				continue
+			}
+			if seen(id) {
+				refreshed = append(refreshed, Job{ExternalID: id, URL: aijobsBaseURL + href, SeenRefresh: true})
 				continue
 			}
 			allSeen = false
 			unseen = append(unseen, href)
 			if newBudget > 0 && len(unseen) >= newBudget {
-				return unseen, nil
+				return unseen, refreshed, nil
 			}
 		}
 		if allSeen {
 			break // caught up to already-known postings; every later page is older still
 		}
 	}
-	return unseen, nil
+	return unseen, refreshed, nil
 }
 
 // aijobsCompanySlugPattern matches a company-profile href and captures its slug, without

--- a/internal/sources/aijobs_test.go
+++ b/internal/sources/aijobs_test.go
@@ -79,13 +79,26 @@ func TestAijobsCrawlListingStopsWhenAPageIsFullySeen(t *testing.T) {
 		4: aijobsListingPage("99"),     // poison: must never be fetched
 	})
 
-	unseen, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet("4", "5"), 0)
+	unseen, refreshed, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet("4", "5"), 0)
 	if err != nil {
 		t.Fatalf("crawlListing: %v", err)
 	}
 	want := []string{"/job/role-1/", "/job/role-2/", "/job/role-3/"}
 	if !slices.Equal(unseen, want) {
 		t.Errorf("unseen = %v, want %v", unseen, want)
+	}
+	// The page that stopped the walk is still-live postings, not garbage: both of its ids
+	// must come back as a liveness refresh, or a still-open aijobs.net posting would never
+	// have its last_seen_at advanced past its first crawl.
+	gotIDs := make([]string, len(refreshed))
+	for i, j := range refreshed {
+		gotIDs[i] = j.ExternalID
+		if !j.SeenRefresh {
+			t.Errorf("refreshed[%d].SeenRefresh = false, want true", i)
+		}
+	}
+	if wantIDs := []string{"4", "5"}; !slices.Equal(gotIDs, wantIDs) {
+		t.Errorf("refreshed ids = %v, want %v", gotIDs, wantIDs)
 	}
 }
 
@@ -95,7 +108,7 @@ func TestAijobsCrawlListingStopsAtNewBudget(t *testing.T) {
 		2: aijobsListingPage("99"), // poison: must never be fetched
 	})
 
-	unseen, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 2)
+	unseen, _, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 2)
 	if err != nil {
 		t.Fatalf("crawlListing: %v", err)
 	}
@@ -134,7 +147,7 @@ func TestAijobsCrawlListingFirstPageFailureErrors(t *testing.T) {
 	fake := aijobsGetPostFake{postForm: func(url string) (*html.Node, error) {
 		return nil, fmt.Errorf("no route for %s", url) // bootstrap succeeds, page 1 fails
 	}}
-	if _, err := (aijobs{http: fake}).crawlListing(context.Background(), seenSet(), 0); err == nil {
+	if _, _, err := (aijobs{http: fake}).crawlListing(context.Background(), seenSet(), 0); err == nil {
 		t.Error("expected an error when the first listing page fails, got nil")
 	}
 }
@@ -157,7 +170,7 @@ func TestAijobsCrawlListingStopsAtHardPageCap(t *testing.T) {
 		return html.Parse(strings.NewReader(aijobsListingPage(fmt.Sprintf("%d", 1000+requests))))
 	}}
 
-	unseen, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 0)
+	unseen, _, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 0)
 	if err != nil {
 		t.Fatalf("crawlListing: %v", err)
 	}
@@ -172,7 +185,7 @@ func TestAijobsCrawlListingStopsAtHardPageCap(t *testing.T) {
 func TestAijobsCrawlListingLaterPageFailureKeepsWhatWasGathered(t *testing.T) {
 	fake := aijobsPagedFake(map[int]string{1: aijobsListingPage("1")}) // no page=2: page 2 fails
 
-	unseen, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 0)
+	unseen, _, err := aijobs{http: fake}.crawlListing(context.Background(), seenSet(), 0)
 	if err != nil {
 		t.Fatalf("crawlListing: %v", err)
 	}
@@ -416,7 +429,7 @@ func TestAijobsImplementsHydratingSource(t *testing.T) {
 	var _ HydratingSource = aijobs{}
 }
 
-func TestAijobsFetchNewHydratesOnlyUnseenPostings(t *testing.T) {
+func TestAijobsFetchNewHydratesUnseenAndRefreshesSeenPostings(t *testing.T) {
 	var mu sync.Mutex
 	requestedSeenPosting := false
 	fake := aijobsGetPostFake{
@@ -450,14 +463,28 @@ func TestAijobsFetchNewHydratesOnlyUnseenPostings(t *testing.T) {
 	if poisoned {
 		t.Error("detail fetched for an already-seen posting (role-1)")
 	}
-	if len(jobs) != 1 {
-		t.Fatalf("got %d jobs, want 1 (the unseen posting only)", len(jobs))
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (the unseen posting hydrated, the seen one refreshed)", len(jobs))
 	}
-	if jobs[0].ExternalID != "2" {
-		t.Errorf("ExternalID = %q, want %q", jobs[0].ExternalID, "2")
+	var hydrated, refreshed *Job
+	for i := range jobs {
+		if jobs[i].SeenRefresh {
+			refreshed = &jobs[i]
+		} else {
+			hydrated = &jobs[i]
+		}
 	}
-	if jobs[0].Company != "Acme" {
-		t.Errorf("Company = %q, want %q", jobs[0].Company, "Acme")
+	if hydrated == nil || hydrated.ExternalID != "2" {
+		t.Fatalf("hydrated job = %+v, want ExternalID %q", hydrated, "2")
+	}
+	if hydrated.Company != "Acme" {
+		t.Errorf("Company = %q, want %q", hydrated.Company, "Acme")
+	}
+	// Still-open posting "1" was re-listed but not re-fetched: a SeenRefresh Job, not
+	// silence, or its last_seen_at would never advance and the company-scoped sweep would
+	// eventually close it as unseen with no way back in.
+	if refreshed == nil || refreshed.ExternalID != "1" {
+		t.Fatalf("refreshed job = %+v, want ExternalID %q", refreshed, "1")
 	}
 }
 

--- a/internal/sources/fourdayweek.go
+++ b/internal/sources/fourdayweek.go
@@ -3,7 +3,6 @@ package sources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/strelov1/freehire/internal/skilltag"
 )
@@ -161,8 +160,11 @@ func (p fourDayWeekPosting) toJob() (Job, bool) {
 		WorkMode:   fourDayWeekWorkMode(p.WorkArrangement),
 		Seniority:  fourDayWeekSeniority(p.Level),
 		Category:   fourDayWeekCategory(p.Category),
-		Skills:     skilltag.Parse(strings.Join(names, " ")),
-		PostedAt:   parseEpochSeconds(p.Posted),
+		// Canonicalize, not Parse: names are already-discrete asserted tech names, not
+		// prose — Parse's corroboration rule would drop an unambiguous single-word name
+		// for lack of a second strong term.
+		Skills:   skilltag.Canonicalize(names),
+		PostedAt: parseEpochSeconds(p.Posted),
 	}, true
 }
 

--- a/internal/sources/functionalworks.go
+++ b/internal/sources/functionalworks.go
@@ -3,7 +3,6 @@ package sources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/strelov1/freehire/internal/skilltag"
 )
@@ -100,8 +99,11 @@ func (p functionalWorksPosting) toJob() (Job, bool) {
 		Description: sanitizeHTML(p.DescriptionML),
 		Remote:      p.Remote || isRemote(p.location()),
 		WorkMode:    workModeFromRemote(p.Remote),
-		Skills:      skilltag.Parse(strings.Join(labels, " ")),
-		PostedAt:    parseRFC3339(p.FirstPublished),
+		// Canonicalize, not Parse: labels are already-discrete asserted tag names, not
+		// prose — Parse's corroboration rule would drop an unambiguous single-word tag
+		// for lack of a second strong term.
+		Skills:   skilltag.Canonicalize(labels),
+		PostedAt: parseRFC3339(p.FirstPublished),
 	}, true
 }
 

--- a/internal/sources/getmanfred.go
+++ b/internal/sources/getmanfred.go
@@ -159,12 +159,13 @@ func getmanfredDescription(o getmanfredOffer) string {
 }
 
 // getmanfredSkills canonicalizes an offer's tech stack through the skilltag dictionary, keeping
-// only resolved technologies. The names are joined into one blob so skilltag.Parse applies the
-// same matching it uses on a description.
+// only resolved technologies. Canonicalize, not Parse: these are already-discrete asserted
+// names from a structured field, not prose to mine, so the corroboration rule Parse applies
+// to free text must not drop an unambiguous single-word name for lack of a second strong term.
 func getmanfredSkills(techs []getmanfredTech) []string {
 	names := make([]string, 0, len(techs))
 	for _, t := range techs {
 		names = append(names, t.Name)
 	}
-	return skilltag.Parse(strings.Join(names, " "))
+	return skilltag.Canonicalize(names)
 }

--- a/internal/sources/getmatch.go
+++ b/internal/sources/getmatch.go
@@ -228,14 +228,15 @@ func getmatchCategory(specs []string) string {
 
 // getmatchSkills canonicalizes an offer's skills_objects through the skilltag dictionary,
 // keeping only resolved technologies (so marketplace noise like "Kiss" or "152-ФЗ" is dropped).
-// The names are joined into one text blob so skilltag.Parse applies the same matching it uses on
-// a description.
+// Canonicalize, not Parse: these are already-discrete asserted names, not prose to mine, so
+// the corroboration rule Parse applies to free text must not drop an unambiguous single-word
+// name for lack of a second strong term.
 func getmatchSkills(objs []getmatchSkill) []string {
 	names := make([]string, 0, len(objs))
 	for _, o := range objs {
 		names = append(names, o.Name)
 	}
-	return skilltag.Parse(strings.Join(names, " "))
+	return skilltag.Canonicalize(names)
 }
 
 // getmatchWorkMode derives the structured work mode from the offer's location formats, mapping

--- a/internal/sources/getro.go
+++ b/internal/sources/getro.go
@@ -245,8 +245,11 @@ func (p getroPosting) toJob() (Job, bool) {
 		WorkMode:   workMode,
 		Remote:     workMode == "remote" || isRemote(location),
 		Seniority:  getroSeniority(p.Seniority),
-		Skills:     skilltag.Parse(strings.Join(p.Skills, " ")),
-		PostedAt:   parseEpochSeconds(p.CreatedAt),
+		// Canonicalize, not Parse: p.Skills is already a discrete list of asserted names,
+		// not prose — Parse's corroboration rule would drop an unambiguous single-word
+		// skill for lack of a second strong term.
+		Skills:   skilltag.Canonicalize(p.Skills),
+		PostedAt: parseEpochSeconds(p.CreatedAt),
 	}, true
 }
 

--- a/internal/sources/justjoin.go
+++ b/internal/sources/justjoin.go
@@ -199,14 +199,15 @@ func (d justJoinDetail) apply(base Job) Job {
 }
 
 // justJoinSkills canonicalizes the required skills through the skilltag dictionary, keeping
-// only resolved technologies. The names are joined into one blob so skilltag.Parse applies the
-// same matching it uses on a description.
+// only resolved technologies. Canonicalize, not Parse: these are already-discrete asserted
+// names from a structured field, not prose to mine, so the corroboration rule Parse applies
+// to free text must not drop an unambiguous single-word name for lack of a second strong term.
 func justJoinSkills(skills []justJoinSkill) []string {
 	names := make([]string, 0, len(skills))
 	for _, s := range skills {
 		names = append(names, s.Name)
 	}
-	return skilltag.Parse(strings.Join(names, " "))
+	return skilltag.Canonicalize(names)
 }
 
 // justJoinSeniority maps justjoin's experience level to freehire's seniority vocabulary.

--- a/internal/sources/justjoin_test.go
+++ b/internal/sources/justjoin_test.go
@@ -36,6 +36,17 @@ func TestJustJoinHydrateMapsDetail(t *testing.T) {
 	}
 }
 
+// justjoin's required_skills entries are already-discrete asserted names, not prose — a lone
+// ambiguous word like "React" (which Parse's corroboration rule would drop without a second
+// strong tech term in the same text) must still resolve, because the platform is the one
+// asserting it, not a sentence justJoinSkills is mining.
+func TestJustJoinSkillsResolvesALoneAmbiguousSkill(t *testing.T) {
+	got := justJoinSkills([]justJoinSkill{{Name: "React"}})
+	if !slices.Contains(got, "react") {
+		t.Errorf("justJoinSkills([React]) = %v, want [react] — a platform-asserted skill must not need corroboration", got)
+	}
+}
+
 // TestJustJoinDescription covers the exported backfill helper: it derives the slug from a stored
 // job URL, fetches the detail, and returns the sanitized body — or ok=false when the URL is not a
 // justjoin offer URL, the fetch fails, or the body is empty.

--- a/internal/sources/micro1.go
+++ b/internal/sources/micro1.go
@@ -121,9 +121,16 @@ func micro1WorkMode(locationType string) string {
 	}
 }
 
-// micro1Skills canonicalizes micro1's free-form required_skills (e.g. "GoLang", "Typescript")
-// through the shared skilltag dictionary, so the Skills facet carries canonical names rather
-// than the platform's raw spellings.
+// micro1Skills canonicalizes micro1's required_skills through the shared skilltag dictionary,
+// so the Skills facet carries canonical names rather than the platform's raw spellings.
+//
+// Parse, not Canonicalize, and deliberately: unlike the other aggregators' structured skill
+// lists, micro1's own entries are not always atomic names — a live-captured entry reads
+// "Basics C++", a qualifier word ahead of the actual technology (confirmed in
+// TestMicro1Detail's fixture) — so an entry must still be MINED, not merely matched whole.
+// Joining into one blob keeps that substring-mining ability; the corroboration rule's
+// downside (a lone ambiguous entry needs a second strong term) is the accepted trade-off
+// for it here, same as it always was.
 func micro1Skills(skills []string) []string {
 	return skilltag.Parse(strings.Join(skills, " "))
 }

--- a/internal/sources/nofluffjobs.go
+++ b/internal/sources/nofluffjobs.go
@@ -172,8 +172,10 @@ func (p nofluffjobsPosting) toJob() (Job, bool) {
 		Company:    strings.TrimSpace(p.Name),
 		Location:   nofluffjobsLocation(p),
 		Remote:     p.FullyRemote,
-		Skills:     skilltag.Parse(p.Technology),
-		Seniority:  nofluffjobsSeniority(p.Seniority),
+		// Canonicalize, not Parse: p.Technology is the platform's own single structured
+		// tag, an asserted name rather than prose to mine.
+		Skills:    skilltag.Canonicalize([]string{p.Technology}),
+		Seniority: nofluffjobsSeniority(p.Seniority),
 	}
 	if p.FullyRemote {
 		job.WorkMode = "remote"

--- a/internal/sources/plaintext.go
+++ b/internal/sources/plaintext.go
@@ -76,3 +76,8 @@ func plainTextToHTML(text string) string {
 	flushPara()
 	return out.String()
 }
+
+// PlainTextToHTML is the exported form, for sibling packages that render a plain-text
+// description into the same structural HTML (e.g. internal/telegram, whose extracted
+// descriptions carry the identical bullet/paragraph shape this reconstructs).
+func PlainTextToHTML(text string) string { return plainTextToHTML(text) }

--- a/internal/sources/teamex.go
+++ b/internal/sources/teamex.go
@@ -168,12 +168,13 @@ func teamexLocation(countries []teamexCountry) string {
 }
 
 // teamexSkills canonicalizes the posting's required skills through the skilltag dictionary,
-// keeping only resolved technologies. The names are joined into one blob so skilltag.Parse
-// applies the same matching it uses on a description.
+// keeping only resolved technologies. Canonicalize, not Parse: these are already-discrete
+// asserted names, not prose to mine, so the corroboration rule Parse applies to free text
+// must not drop an unambiguous single-word name for lack of a second strong term.
 func teamexSkills(skills []teamexRequiredSkill) []string {
 	names := make([]string, 0, len(skills))
 	for _, s := range skills {
 		names = append(names, s.Skill.DisplayName)
 	}
-	return skilltag.Parse(strings.Join(names, " "))
+	return skilltag.Canonicalize(names)
 }

--- a/internal/telegram/html.go
+++ b/internal/telegram/html.go
@@ -1,31 +1,20 @@
 package telegram
 
 import (
-	"html"
-	"strings"
+	"github.com/strelov1/freehire/internal/sources"
 )
 
 // TextToHTML converts an extracted plain-text description into minimal safe HTML:
-// blank-line-separated chunks become paragraphs, single newlines become <br>, and
-// everything is entity-escaped so post content can never inject markup. Stored
-// descriptions are HTML across all sources (the SPA renders them directly), so
-// telegram jobs must match that contract.
+// blank-line-separated chunks become paragraphs, single newlines become <br>, a run of
+// bullet-marker lines (•, -, *, –, —, ...) becomes a <ul>, and everything is
+// entity-escaped so post content can never inject markup. Stored descriptions are HTML
+// across all sources (the SPA renders them directly), so telegram jobs must match that
+// contract.
+//
+// Delegates to sources.PlainTextToHTML: the extraction prompt explicitly asks the model
+// to preserve "bullet points, numbered lists, and paragraphs on separate lines," so a
+// Telegram-extracted description carries the exact plain-text-with-bullets shape that
+// helper already reconstructs correctly for the ATS adapters that hand it raw text.
 func TextToHTML(text string) string {
-	var b strings.Builder
-	for _, para := range strings.Split(text, "\n\n") {
-		lines := strings.Split(para, "\n")
-		var kept []string
-		for _, l := range lines {
-			if s := strings.TrimSpace(l); s != "" {
-				kept = append(kept, html.EscapeString(s))
-			}
-		}
-		if len(kept) == 0 {
-			continue
-		}
-		b.WriteString("<p>")
-		b.WriteString(strings.Join(kept, "<br>"))
-		b.WriteString("</p>")
-	}
-	return b.String()
+	return sources.PlainTextToHTML(text)
 }

--- a/internal/telegram/html_test.go
+++ b/internal/telegram/html_test.go
@@ -5,9 +5,12 @@ import "testing"
 func TestTextToHTML(t *testing.T) {
 	cases := []struct{ name, in, want string }{
 		{
-			name: "paragraphs and line breaks",
+			// The extraction prompt asks the model to preserve bullet points, so this is the
+			// norm, not an edge case: a run of "- "-prefixed lines becomes a <ul>, matching
+			// what an ATS adapter's plain-text description already renders for the same shape.
+			name: "bullet lines become a list, not literal hyphens",
 			in:   "Требования:\n- Go\n- Postgres\n\nПишите @hr",
-			want: "<p>Требования:<br>- Go<br>- Postgres</p><p>Пишите @hr</p>",
+			want: "<p>Требования:</p><ul><li>Go</li><li>Postgres</li></ul><p>Пишите @hr</p>",
 		},
 		{
 			name: "markup is escaped, not interpreted",
@@ -18,6 +21,11 @@ func TestTextToHTML(t *testing.T) {
 			name: "surrounding whitespace trimmed",
 			in:   "\n\n  hello  \n\n",
 			want: "<p>hello</p>",
+		},
+		{
+			name: "non-bullet lines within a paragraph join with a line break",
+			in:   "Office in Berlin.\nRemote within the EU.",
+			want: "<p>Office in Berlin.<br>Remote within the EU.</p>",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/viewlog/bot.go
+++ b/internal/viewlog/bot.go
@@ -7,8 +7,12 @@ import "strings"
 // crawlers that hit SSR pages for SEO and link previews, not every possible bot.
 // Missed bots only inflate the page-view number (a transparency figure), so this
 // stays a light filter rather than an exhaustive blocklist.
+//
+// The generic "bot" is deliberately absent, mirroring internal/tracerlink's own
+// classifier: it appears inside "CUBOT," a phone brand, so a bare substring match
+// misclassifies a real visitor's page view as a crawler's. Generic bot names
+// (googlebot, bingbot, ahrefsbot, ...) are caught by botSuffixes instead.
 var botMarkers = []string{
-	"bot",   // googlebot, bingbot, twitterbot, ahrefsbot, semrushbot, ...
 	"crawl", // crawler variants
 	"spider",
 	"slurp", // Yahoo
@@ -17,6 +21,11 @@ var botMarkers = []string{
 	"prerender",
 	"headlesschrome",
 }
+
+// botSuffixes catch the general shape of a bot's name — "…bot" followed by a version
+// separator, as in "Googlebot/2.1" or "bingbot;" — without claiming every product
+// whose name happens to contain those three letters (see botMarkers).
+var botSuffixes = []string{"bot/", "bot;", "bot)", "bot ", "bot-"}
 
 // isBot reports whether a User-Agent looks like a known crawler or link-preview
 // fetcher. Applied only to page-open signals; API reads are never bot-filtered.
@@ -27,5 +36,10 @@ func isBot(ua string) bool {
 			return true
 		}
 	}
-	return false
+	for _, suffix := range botSuffixes {
+		if strings.Contains(lower, suffix) {
+			return true
+		}
+	}
+	return strings.HasSuffix(lower, "bot")
 }

--- a/internal/viewlog/bot_test.go
+++ b/internal/viewlog/bot_test.go
@@ -20,6 +20,9 @@ func TestIsBot(t *testing.T) {
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
 		"curl/8.4.0",
 		"",
+		// A real phone brand, not a crawler — the reason bare "bot" is excluded from
+		// botMarkers (mirrors internal/tracerlink's classifier, tested the same way).
+		"Mozilla/5.0 (Linux; Android 10; CUBOT_X30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
 	}
 	for _, ua := range humans {
 		if isBot(ua) {

--- a/internal/ycdir/ycdir.go
+++ b/internal/ycdir/ycdir.go
@@ -154,13 +154,21 @@ func launchYear(ts int64) int {
 	return time.Unix(ts, 0).UTC().Year()
 }
 
-// hqCountry resolves the first country code from a free-text location via the
-// shared location dictionary, or "" when it resolves nothing.
+// hqCountry resolves the country of the first-listed (HQ) office from yc-oss's
+// semicolon-separated all_locations string, via the shared location dictionary, or ""
+// when it resolves nothing.
+//
+// Only the first segment is parsed, deliberately: location.Parse dedups and SORTS its
+// Countries, so parsing the whole multi-office string would return the alphabetically
+// first country among ALL offices rather than the HQ's — for a company listing
+// "San Francisco, CA, USA; Istanbul, Istanbul, Turkey" that reads "tr", not "us".
 func hqCountry(loc string) string {
-	if strings.TrimSpace(loc) == "" {
+	first, _, _ := strings.Cut(loc, ";")
+	first = strings.TrimSpace(first)
+	if first == "" {
 		return ""
 	}
-	if c := location.Parse(loc).Countries; len(c) > 0 {
+	if c := location.Parse(first).Countries; len(c) > 0 {
 		return c[0]
 	}
 	return ""

--- a/internal/ycdir/ycdir_test.go
+++ b/internal/ycdir/ycdir_test.go
@@ -112,3 +112,16 @@ func TestMapMissingOptionalsOmitted(t *testing.T) {
 		t.Errorf("subindustry = %q, want empty (no subindustry given)", r.Subindustry)
 	}
 }
+
+// A multi-office entry lists all_locations HQ first, semicolon-separated. hqCountry must
+// resolve the FIRST office's country, not the alphabetically-first one location.Parse's
+// sorted, whole-string result would otherwise surface for a later office.
+func TestMapMultiOfficeUsesTheFirstListedLocation(t *testing.T) {
+	r, ok := Map(Entry{Name: "CleverDeck", AllLocations: "San Francisco, CA, USA; Istanbul, Istanbul, Turkey"})
+	if !ok {
+		t.Fatal("ok = false")
+	}
+	if r.HQCountry != "us" {
+		t.Errorf("hq_country = %q, want us (the first-listed office, not alphabetically-first tr)", r.HQCountry)
+	}
+}


### PR DESCRIPTION
## Summary
A comprehensive agentic review of every `internal/` domain package (34 packages, four lenses: simplicity, reuse, DDD boundaries, correctness), cross-checked against the 2026-08-01 architecture review to avoid re-litigating closed items. 24 findings confirmed by adversarial verification; 22 fixed here, each with a regression test proven to fail without its fix.

**Correctness / data integrity**
- `jobtracking`: tracking-board cards showed the company URL slug instead of the display name (perf-refactor regression)
- `auth/oauth` + `gmailsync`: de-duplicated a copy-pasted SSRF guard into `internal/safehttp`
- `cvmatch`: acronym skills (ML, K8s, ...) in vacancy requirements were never matched — text was lowercased before reaching skilltag's case-preserved acronym tier
- `cv`/`handler`: a report-bookkeeping failure after a successful CV edit used to fail the whole tool call, inviting a retry that could duplicate content
- `cvedit`: coalescing a follow-on agent edit dropped the newer edit's stated reason
- `db`: `EnqueueJobEnrichment` was missing the `duplicate_of IS NULL` guard its sibling has, orphaning outbox rows for reposts
- `atsboard`: a vendor's own product host (`app.recruitee.com`, `help.bamboohr.com`) was recognized as a tenant board in 2 of 3 URL-recognition modes
- `sources/aijobs`: re-listed postings were silently dropped instead of refreshing liveness — still-open postings could age out and close for good
- `embed`: ported `searchdrain`'s timeout/fallback fix (2026-08-05 outage) so a slow-but-fine batch push isn't misclassified into a per-item cascade
- `pipeline`: the recovery probe fully re-crawled a `HydratingSource` board, then the main loop crawled it again — the probe's fetch is now reused
- `matchanalysis`: a failed LLM retry could leave a partially-decoded garbage value in place (encoding/json doesn't roll back partial decodes); also fixed `candidateRemoteReach` ignoring stated remote countries
- `skilltag`: `Canonicalize` always resolved the résumé-only acronym tier, letting a vacancy-side caller collide with a job-only meaning of the same letters
- 9 source adapters fed already-discrete skill lists through `Parse`'s corroboration gate instead of `Canonicalize`, dropping unambiguous single-word skills
- `llmkey`: `Forget` hard-deleted a refused credential, which could erase spend history a concurrent `Revoke` had just blocked the same key to preserve
- `companyname`: 3 of 4 registered resolvers (Lever, Ashby, BambooHR) never produced a usable name on any real board — each ATS now gets its own verified title shape
- `viewlog`: the bot detector flagged CUBOT-brand phones as crawlers — ported `tracerlink`'s suffix-anchored fix
- `ycdir`: `hqCountry` read the alphabetically-first of a multi-office company's countries instead of the first-listed HQ office
- `telegram`: `TextToHTML` never recognized bullet-marker lines despite the extraction prompt asking the model to preserve them
- `contribution`: `RecordReview`'s dedup could queue the same unrecognized URL twice if submissions differed only by a trailing slash

**Simplicity / dead code**
- `llmkey`: removed `Client.Spend`, unreachable since the same PR that added it switched every caller to `Activity`
- `contribution`: removed `Service.Submit`, a hand-duplicated twin of `Inspect`+`RecordIntake` with zero production callers

**Deliberately not changed** (investigated, remedy would net-regress or needs a prod migration out of scope for a code-only sweep):
- `cvmatch/seniority.go` — verified live that switching to `classify.SeniorityFromDescription` would break the single most common CV signal (a title line like "Senior Backend Engineer") to fix a narrower false-positive class
- `linksource`'s board-scoped adapters still namespace `external_id` with the URL's own casing, which can diverge from a mixed-case `sources/*.yml` entry (~170 boards) — full fix needs either a coordinated rename of already-crawled `external_id` values or a new cross-command board registry lookup

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...` (full suite, including a Postgres-backed integration test for the new SQL guard)
- [x] Every fix has a dedicated regression test, confirmed to fail on the pre-fix code (`git stash` the fix, rerun, confirm red; restore, confirm green)
- [x] `gofmt -l` clean on every touched file