### PR TITLE
atscheck: add LinkedIn, bullets-per-role, chronology, summary-length checks

### DIFF
--- a/internal/atscheck/atscheck.go
+++ b/internal/atscheck/atscheck.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/strelov1/freehire/internal/skilltag"
@@ -40,9 +41,9 @@ const (
 	categoryLength   = "length_density"
 )
 
-// Category maxima. Keyword and Content are named; Format (8+6+3+3=20), Sections
-// (5+4+3+3=15), and Length (5+5=10) are the sums of their item weights below. All
-// five sum to 100.
+// Category maxima. Keyword (40) is named; Format (8+4+2+2+2+2=20), Sections
+// (4+3+3+2+2+1=15), Content (6+6+3=15), and Length (5+5=10) are the sums of their
+// item weights below. All five sum to 100.
 const (
 	keywordMax = 40
 	contentMax = 15
@@ -94,14 +95,23 @@ const (
 	minQuantified    = 2    // quantified results → Content passes
 	minDensitySkills = 3    // distinct parsed skills → Density passes
 	minSummarySkills = 2    // skill tags in the summary section → Summary keyword-density passes
+	maxSummaryWords  = 70   // recruiters scan a summary in ~6 seconds; longer buries the point
+	minRoleBullets   = 3    // per-role bullet count band → Bullets-per-role passes
+	maxRoleBullets   = 5    //
 )
 
 var (
-	emailRE  = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
-	phoneRE  = regexp.MustCompile(`(?:\+\d[\d\s().\-]{7,}\d)|(?:\(\d{3}\)\s?\d{3}[\s.\-]?\d{4})|(?:\b\d{3}[\s.\-]\d{3}[\s.\-]\d{4}\b)`)
-	dateRE   = regexp.MustCompile(`\b(?:19|20)\d{2}\b|\b\d{1,2}[/.\-]\d{4}\b`)
-	bulletRE = regexp.MustCompile(`(?m)^[ \t]*[-*•‣●·][ \t]+\S`)
-	quantRE  = regexp.MustCompile(`\d+(?:\.\d+)?\s?%|\$\s?\d|\b\d+x\b`)
+	emailRE    = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+	phoneRE    = regexp.MustCompile(`(?:\+\d[\d\s().\-]{7,}\d)|(?:\(\d{3}\)\s?\d{3}[\s.\-]?\d{4})|(?:\b\d{3}[\s.\-]\d{3}[\s.\-]\d{4}\b)`)
+	dateRE     = regexp.MustCompile(`\b(?:19|20)\d{2}\b|\b\d{1,2}[/.\-]\d{4}\b`)
+	bulletRE   = regexp.MustCompile(`(?m)^[ \t]*[-*•‣●·][ \t]+\S`)
+	quantRE    = regexp.MustCompile(`\d+(?:\.\d+)?\s?%|\$\s?\d|\b\d+x\b`)
+	linkedinRE = regexp.MustCompile(`(?i)linkedin\.com/\S+`)
+	// dateRangeRE matches a role's date range ("2021 - 2026", "Jan 2023 – Present",
+	// "Mar 2020 - Dec 2022") and captures the start year, which is all roleBlocks needs
+	// to order roles and count their bullets. The end side tolerates a leading month
+	// word the same way the start side's \b does implicitly.
+	dateRangeRE = regexp.MustCompile(`(?i)\b((?:19|20)\d{2})\s*[-–—]\s*(?:present|(?:[a-z]+\.?\s+)?(?:19|20)\d{2})\b`)
 )
 
 var sectionKeywords = map[string][]string{
@@ -204,29 +214,62 @@ func formatCategory(cv string, words int) ScoreCategory {
 	return ScoreCategory{ID: categoryFormat, Label: "Format Compliance", Items: []LineItem{
 		item(words >= minReadableWords, 8, "Text is machine-readable",
 			"Export a text-based PDF (not a scan or image) so an ATS can read it", StatusFail),
-		item(emailRE.MatchString(cv) && phoneRE.MatchString(cv), 6, "Contact info present (email and phone)",
+		item(emailRE.MatchString(cv) && phoneRE.MatchString(cv), 4, "Contact info present (email and phone)",
 			"Add both an email and a phone number near the top", StatusWarn),
-		item(len(bulletRE.FindAllString(cv, -1)) >= 2, 3, "Bulleted achievements",
+		item(len(bulletRE.FindAllString(cv, -1)) >= 2, 2, "Bulleted achievements",
 			"Use bullet points for your achievements instead of dense paragraphs", StatusWarn),
-		item(dateRE.MatchString(cv), 3, "Dated work history",
+		item(dateRE.MatchString(cv), 2, "Dated work history",
 			"Add start/end dates (years) to each role so tenure is parseable", StatusWarn),
+		item(linkedinRE.MatchString(cv), 2, "LinkedIn profile linked",
+			"Add your LinkedIn profile URL near the top", StatusWarn),
+		chronologyItem(cv, 2),
 	}}
 }
 
+// chronologyItem rewards a résumé that lists roles most-recent-first, the order both an
+// ATS and a recruiter expect. Fewer than two dated roles in the Experience section can't
+// be out of order, so it passes vacuously; zero dated roles fails, matching the "Dated
+// work history" item above.
+func chronologyItem(cv string, weight int) LineItem {
+	blocks := roleBlocks(cv)
+	if len(blocks) == 0 {
+		return LineItem{Points: weight, Text: "Add start/end dates to each role so recency reads in order", Status: StatusWarn}
+	}
+	ok := true
+	for i := 1; i < len(blocks); i++ {
+		if blocks[i].startYear > blocks[i-1].startYear {
+			ok = false
+			break
+		}
+	}
+	return item(ok, weight, "Roles are listed most recent first",
+		"List your roles most recent first (reverse-chronological order)", StatusWarn)
+}
+
 func sectionsCategory(lower, cvText string) ScoreCategory {
-	// Weights re-balanced to fit the summary keyword-density item while keeping the
-	// category maximum at 15 (and the five-category total at 100).
+	// Weights re-balanced to fit the summary keyword-density and summary-length items
+	// while keeping the category maximum at 15 (and the five-category total at 100).
 	return ScoreCategory{ID: categorySections, Label: "Section Completeness", Items: []LineItem{
 		item(hasAny(lower, sectionKeywords["experience"]), 4, "Experience section",
 			"Add a clearly labelled Experience section", StatusWarn),
-		item(hasAny(lower, sectionKeywords["skills"]), 4, "Skills section",
+		item(hasAny(lower, sectionKeywords["skills"]), 3, "Skills section",
 			"Add a clearly labelled Skills section", StatusWarn),
 		item(hasAny(lower, sectionKeywords["education"]), 3, "Education section",
 			"Add an Education section", StatusWarn),
 		item(hasAny(lower, sectionKeywords["summary"]), 2, "Professional summary",
 			"Add a short professional summary at the top", StatusWarn),
 		summaryDensityItem(cvText, 2),
+		summaryLengthItem(cvText, 1),
 	}}
+}
+
+// summaryLengthItem rewards a summary a recruiter can read in one glance — the same
+// ~6-second-scan rationale as summaryDensityItem, applied to length instead of density.
+// An absent summary (0 words) fails, matching the "Professional summary" item above.
+func summaryLengthItem(cvText string, weight int) LineItem {
+	n := len(strings.Fields(summaryText(cvText)))
+	return item(n > 0 && n <= maxSummaryWords, weight, "Summary is concise (≤70 words)",
+		"Trim your summary to about 70 words or fewer", StatusWarn)
 }
 
 // summaryDensityItem rewards a keyword-dense professional summary — recruiters scan
@@ -275,11 +318,65 @@ func headingSection(line string) (string, bool) {
 // is present (see ApplyReview for the LLM path).
 func contentCategory(cv string) ScoreCategory {
 	return ScoreCategory{ID: categoryContent, Label: "Content Quality", Items: []LineItem{
-		item(actionVerbLines(cv) >= minActionVerbs, 8, "Bullets lead with strong action verbs",
+		item(actionVerbLines(cv) >= minActionVerbs, 6, "Bullets lead with strong action verbs",
 			"Start bullets with strong action verbs (Built, Led, Shipped…)", StatusWarn),
-		item(len(quantRE.FindAllString(cv, -1)) >= minQuantified, 7, "Quantified, measurable results",
+		item(len(quantRE.FindAllString(cv, -1)) >= minQuantified, 6, "Quantified, measurable results",
 			"Quantify achievements with concrete numbers (%, ×, $)", StatusWarn),
+		bulletsPerRoleItem(cv, 3),
 	}}
+}
+
+// bulletsPerRoleItem rewards each Experience-section role carrying 3 to 5 bullet points —
+// enough to show depth, not so many a recruiter skims past them. Zero dated roles fails,
+// matching the "Dated work history" format item.
+func bulletsPerRoleItem(cv string, weight int) LineItem {
+	blocks := roleBlocks(cv)
+	if len(blocks) == 0 {
+		return LineItem{Points: weight, Text: "Give each recent role 3 to 5 bullet points", Status: StatusWarn}
+	}
+	ok := true
+	for _, b := range blocks {
+		if b.bullets < minRoleBullets || b.bullets > maxRoleBullets {
+			ok = false
+			break
+		}
+	}
+	return item(ok, weight, "Each role has 3 to 5 bullet points",
+		"Give each recent role 3 to 5 bullet points", StatusWarn)
+}
+
+// roleBlock is one Experience-section role: the start year from its date range, and how
+// many bullet lines follow it before the next role or section.
+type roleBlock struct {
+	startYear int
+	bullets   int
+}
+
+// roleBlocks scans the CV's Experience section for role headers stating a date range
+// ("2021 - 2026", "Jan 2023 – Present") and counts the bullet lines under each, in
+// document order. It never looks outside Experience, so an Education line carrying its
+// own date range ("BSc, MIT (2014 - 2018)") is not mistaken for a role.
+func roleBlocks(cvText string) []roleBlock {
+	var blocks []roleBlock
+	inExperience := false
+	for _, line := range strings.Split(cvText, "\n") {
+		if section, ok := headingSection(line); ok {
+			inExperience = section == "experience"
+			continue
+		}
+		if !inExperience {
+			continue
+		}
+		if m := dateRangeRE.FindStringSubmatch(line); m != nil {
+			year, _ := strconv.Atoi(m[1])
+			blocks = append(blocks, roleBlock{startYear: year})
+			continue
+		}
+		if len(blocks) > 0 && bulletRE.MatchString(line) {
+			blocks[len(blocks)-1].bullets++
+		}
+	}
+	return blocks
 }
 
 func lengthCategory(words int, cvSkills []string) ScoreCategory {

--- a/internal/atscheck/atscheck_test.go
+++ b/internal/atscheck/atscheck_test.go
@@ -16,6 +16,26 @@ func sectionItem(t *testing.T, r Report, substr string) (LineItem, bool) {
 	return LineItem{}, false
 }
 
+func formatItem(t *testing.T, r Report, substr string) (LineItem, bool) {
+	t.Helper()
+	for _, it := range catByID(t, r, "format_compliance").Items {
+		if strings.Contains(strings.ToLower(it.Text), substr) {
+			return it, true
+		}
+	}
+	return LineItem{}, false
+}
+
+func contentItem(t *testing.T, r Report, substr string) (LineItem, bool) {
+	t.Helper()
+	for _, it := range catByID(t, r, "content_quality").Items {
+		if strings.Contains(strings.ToLower(it.Text), substr) {
+			return it, true
+		}
+	}
+	return LineItem{}, false
+}
+
 func TestScore_SummaryKeywordDensity_Dense(t *testing.T) {
 	cv := "Jane Roe\njane@example.com  +1 415 555 0134\n\nSummary\nBackend engineer. Core stack: Golang, Kafka, Kubernetes, PostgreSQL.\n\nExperience\n- Built services\n\nSkills\nGolang, Kafka"
 	r := Score(cv, []string{"go", "kafka"}, nil)
@@ -54,7 +74,7 @@ func TestScore_CategoryMaximaSumTo100(t *testing.T) {
 // cleanCV is a realistic plain-text CV that should pass every deterministic check
 // (kept > the length floor so the length check passes honestly).
 const cleanCV = `Ilya Ivanov
-ilya@example.com  +1 415 555 0134  San Francisco, CA
+ilya@example.com  +1 415 555 0134  San Francisco, CA  linkedin.com/in/ilyaivanov
 
 Summary
 Senior backend engineer with eight years building high-throughput distributed
@@ -212,5 +232,127 @@ func TestApplyReview_NilIsNoOp(t *testing.T) {
 	r.ApplyReview(nil)
 	if !reflect.DeepEqual(r, before) {
 		t.Errorf("nil review changed the report")
+	}
+}
+
+func TestScore_SummaryLength_Concise(t *testing.T) {
+	cv := "Jane Roe\njane@example.com +1 415 555 0134\n\nSummary\nBackend engineer with five years shipping Go services.\n\nExperience\n- Built services\n\nSkills\nGolang"
+	r := Score(cv, []string{"go"}, nil)
+	it, ok := sectionItem(t, r, "concise")
+	if !ok {
+		t.Fatalf("no summary length item in %+v", catByID(t, r, "section_completeness").Items)
+	}
+	if it.Status != StatusPass {
+		t.Errorf("summary length = %s, want pass for a 9-word summary", it.Status)
+	}
+}
+
+func TestScore_SummaryLength_TooLong(t *testing.T) {
+	longSummary := strings.Repeat("word ", 80)
+	cv := "Jane Roe\njane@example.com +1 415 555 0134\n\nSummary\n" + longSummary + "\n\nExperience\n- Built services\n\nSkills\nGolang"
+	r := Score(cv, []string{"go"}, nil)
+	it, ok := sectionItem(t, r, "70 words")
+	if !ok {
+		t.Fatal("no summary length item")
+	}
+	if it.Status == StatusPass {
+		t.Errorf("summary length = pass, want recoverable for an 80-word summary")
+	}
+}
+
+func TestScore_LinkedInPresent(t *testing.T) {
+	r := Score(cleanCV, cleanSkills, nil)
+	it, ok := formatItem(t, r, "linkedin")
+	if !ok {
+		t.Fatalf("no linkedin item in %+v", catByID(t, r, "format_compliance").Items)
+	}
+	if it.Status != StatusPass {
+		t.Errorf("linkedin = %s, want pass", it.Status)
+	}
+}
+
+func TestScore_LinkedInMissing(t *testing.T) {
+	cv := "Jane Roe\njane@example.com +1 415 555 0134\n\nExperience\n- Built things"
+	r := Score(cv, nil, nil)
+	it, ok := formatItem(t, r, "linkedin")
+	if !ok {
+		t.Fatal("no linkedin item")
+	}
+	if it.Status == StatusPass {
+		t.Errorf("linkedin = pass, want warn when absent")
+	}
+}
+
+func TestScore_BulletsPerRole_WithinRange(t *testing.T) {
+	r := Score(cleanCV, cleanSkills, nil)
+	it, ok := contentItem(t, r, "3 to 5 bullet")
+	if !ok {
+		t.Fatalf("no bullets-per-role item in %+v", catByID(t, r, "content_quality").Items)
+	}
+	if it.Status != StatusPass {
+		t.Errorf("bullets-per-role = %s, want pass", it.Status)
+	}
+}
+
+func TestScore_BulletsPerRole_TooFew(t *testing.T) {
+	cv := "Jane Roe\njane@example.com +1 415 555 0134\n\nExperience\nEngineer, Acme (2021 - 2024)\n- Built a thing\n\nEducation\nBSc, MIT (2014 - 2018)"
+	r := Score(cv, nil, nil)
+	it, ok := contentItem(t, r, "3 to 5 bullet")
+	if !ok {
+		t.Fatal("no bullets-per-role item")
+	}
+	if it.Status == StatusPass {
+		t.Errorf("bullets-per-role = pass, want warn for a single-bullet role")
+	}
+}
+
+func TestScore_BulletsPerRole_MonthYearRangeSeparatesRoles(t *testing.T) {
+	// Regression: "Mar 2020 - Dec 2022" (a month word before the END year too) must
+	// still start a new role block, not get folded into the previous role's bullets.
+	cv := "Jane Roe\njane@example.com +1 415 555 0134\n\nExperience\n" +
+		"Engineer, Acme (Jan 2023 - Present)\n- Built a\n- Shipped a\n- Fixed a\n- Owned a\n\n" +
+		"Engineer, Globex (Mar 2020 - Dec 2022)\n- Built b\n- Shipped b\n- Fixed b"
+	r := Score(cv, nil, nil)
+	it, ok := contentItem(t, r, "3 to 5 bullet")
+	if !ok {
+		t.Fatal("no bullets-per-role item")
+	}
+	if it.Status != StatusPass {
+		t.Errorf("bullets-per-role = %s, want pass: a 4-bullet and a 3-bullet role, not one 7-bullet role", it.Status)
+	}
+}
+
+func TestScore_BulletsPerRole_NoDatedRoleFails(t *testing.T) {
+	cv := "Jane Roe\njane@example.com +1 415 555 0134\n\nExperience\n- Built a thing\n- Shipped a thing\n- Fixed a thing"
+	r := Score(cv, nil, nil)
+	it, ok := contentItem(t, r, "3 to 5 bullet")
+	if !ok {
+		t.Fatal("no bullets-per-role item")
+	}
+	if it.Status == StatusPass {
+		t.Errorf("bullets-per-role = pass, want warn when no role carries a date range")
+	}
+}
+
+func TestScore_ChronologicalOrder_Reverse(t *testing.T) {
+	r := Score(cleanCV, cleanSkills, nil)
+	it, ok := formatItem(t, r, "most recent first")
+	if !ok {
+		t.Fatalf("no chronology item in %+v", catByID(t, r, "format_compliance").Items)
+	}
+	if it.Status != StatusPass {
+		t.Errorf("chronology = %s, want pass for reverse-chronological order", it.Status)
+	}
+}
+
+func TestScore_ChronologicalOrder_OutOfOrder(t *testing.T) {
+	cv := "Jane Roe\njane@example.com +1 415 555 0134\n\nExperience\nEngineer, Globex (2018 - 2021)\n- Built things\n- Shipped things\n- Fixed things\n\nEngineer, Acme (2021 - 2024)\n- Led things\n- Owned things\n- Ran things"
+	r := Score(cv, nil, nil)
+	it, ok := formatItem(t, r, "most recent first")
+	if !ok {
+		t.Fatal("no chronology item")
+	}
+	if it.Status == StatusPass {
+		t.Errorf("chronology = pass, want warn for out-of-order roles")
 	}
 }


### PR DESCRIPTION
## Summary
- Added four deterministic ATS-readiness checks to `internal/atscheck` that a shared ATS-friendly-CV checklist flags as basics but the scorer didn't cover: a linked LinkedIn profile, 3–5 bullet points per role, roles listed most-recent-first (reverse-chronological), and a summary short enough to scan (≤70 words).
- Rebalanced category item weights so each category's max — and the five-category total of 100 — is unchanged; no wire-shape change, so the SPA (`ATSReportView.svelte`) renders the new items with no frontend edits.
- Fixed a regex bug found while smoke-testing against a real CV: the role date-range matcher didn't handle a month word before the *end* year ("Mar 2020 - Dec 2022"), which silently merged two roles' bullets into one and produced a false "too many/few bullets" warning.

## Test plan
- [x] `go test ./internal/atscheck/...` — all tests pass, including new regression coverage for the date-range parsing bug
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — clean
- [x] `go test ./...` — full suite green
- [x] Smoke-tested `atscheck.Score()` against the PDF's own "strong CV" example end to end; verified the new items score correctly after the regex fix