### PR TITLE
fixes and tool for vacancies filtering

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts run inside Linux containers (Docker entrypoints) or are
+# piped straight into `sh` — a CRLF-mangled shebang breaks both. Force LF
+# regardless of core.autocrlf on a Windows checkout.
+*.sh text eol=lf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: hire
       POSTGRES_DB: hire
     ports:
-      - "5432:5432"
+      - "${DB_HOST_PORT:-5432}:5432"
     volumes:
       # postgres:18+ stores data in a version-specific subdirectory and expects
       # the volume at /var/lib/postgresql (not the legacy .../data path, which it

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -311,6 +311,13 @@
     }),
   );
 
+  // `jobs.total` is the server's raw count for the query — accurate for every facet,
+  // which all narrow the actual search, but not for the match slider, which only
+  // trims the already-fetched page client-side. Showing the raw total next to a
+  // shrunk list would read as a lie ("500 open jobs" over three visible cards), so
+  // swap in what's actually on screen while the threshold is active.
+  const listTotal = $derived(matchFilterAvailable && minMatch != null ? visibleJobs.length : jobs.total);
+
   // The pending "Job hidden — Undo" toast, or null. Set when a card is hidden; the
   // toast owns its auto-dismiss. Undo clears the slug's hidden mark (card returns via
   // visibleJobs) and confirms with the server; a failed undo is swallowed — the
@@ -435,37 +442,14 @@
              mobile, where there's no sidebar), so it lives here instead. -->
         <div class="rounded-xl border border-border bg-card px-4 py-3">
           <p class="text-3xl font-semibold leading-none tracking-tight tabular-nums">
-            {jobs.total.toLocaleString()}
+            {listTotal.toLocaleString()}
           </p>
           <p class="mt-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            {jobs.total === 1 ? 'open job' : 'open jobs'}
+            {listTotal === 1 ? 'open job' : 'open jobs'}
           </p>
         </div>
       {/if}
       {@render sidebarTop?.()}
-      {#if matchFilterAvailable}
-        <!-- Client-only post-filter (see `minMatch` above): drags apply immediately,
-             no debounce, since it only re-filters the page already in memory. -->
-        <div class="rounded-xl border border-border bg-card p-4">
-          <div class="mb-2 flex items-center justify-between">
-            <h3 class="text-sm font-semibold tracking-tight">Minimum match</h3>
-            <span class="text-xs font-medium text-muted-foreground">{minMatch != null ? `${minMatch}%+` : 'Any'}</span>
-          </div>
-          <input
-            type="range"
-            min="0"
-            max="100"
-            step="5"
-            value={minMatch ?? 0}
-            oninput={(e) => {
-              const n = Number(e.currentTarget.value);
-              minMatch = n > 0 ? n : null;
-            }}
-            aria-label="Minimum profile match"
-            class="w-full accent-primary"
-          />
-        </div>
-      {/if}
       <div class="rounded-xl border border-border bg-card p-4">
         <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} canSave={standalone} />
       </div>
@@ -474,8 +458,8 @@
 
   <div class="min-w-0 flex-1">
     <ListToolbar
-      total={!cvSignInPrompt && jobs.items.length > 0 ? jobs.total : null}
-      unit={jobs.total === 1 ? 'job' : 'jobs'}
+      total={!cvSignInPrompt && jobs.items.length > 0 ? listTotal : null}
+      unit={listTotal === 1 ? 'job' : 'jobs'}
       onSwipe={standalone ? openSwipe : undefined}
       showDesktopTotal={standalone}
       sortControl={standalone && isAuthenticated() ? sortSelect : undefined}
@@ -605,6 +589,9 @@
   open={modalOpen}
   onClose={() => (modalOpen = false)}
   {stagedCounts}
+  matchAvailable={matchFilterAvailable}
+  {minMatch}
+  onMinMatchChange={(v) => (minMatch = v)}
 />
 
 {#if standalone}

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -7,6 +7,8 @@
   import { page } from '$app/state';
   import { api, type Slice } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
+  import { profileStore } from '$lib/profile.svelte';
+  import { computeClientMatch } from '$lib/jobMatch';
   import { ensureViewedLoaded } from '$lib/viewedJobs.svelte';
   import { ensureSavedLoaded } from '$lib/savedJobs.svelte';
   import { ensureDismissedLoaded, isDismissed, markUndismissed } from '$lib/dismissedJobs.svelte';
@@ -134,6 +136,28 @@
     () => api.facetCounts(scopedParams()),
     (c) => (counts = c),
   );
+
+  // Minimum profile-match slider: a client-only post-filter over the already-fetched
+  // page, not a search facet — the match percent depends on the viewer's own profile
+  // skills, which the backend/index never sees, so there's nothing to send server-side
+  // (unlike salary/freshness, which narrow the actual query). Local and URL-free: a
+  // shared link's match filter would mean nothing to whoever opens it. `null` means
+  // "no threshold" (the slider's own default position doubles as "off").
+  let minMatch = $state<number | null>(null);
+
+  // Only a signed-in user with skills on their profile has a real match percent per
+  // card (see resolveMatchState's `ready` state in JobRow) — everyone else sees a
+  // teaser or nothing, so the slider would filter against a number that isn't real.
+  $effect(() => {
+    if (isAuthenticated()) profileStore.ensureLoaded();
+  });
+  const profileSkills = $derived(profileStore.profile?.skills ?? []);
+  const matchFilterAvailable = $derived(isAuthenticated() && profileStore.loaded && profileSkills.length > 0);
+  // Drop a stale threshold the moment the slider would disappear (sign-out, profile
+  // cleared) so it can't silently keep hiding jobs with no control left to reset it.
+  $effect(() => {
+    if (!matchFilterAvailable) minMatch = null;
+  });
 
   let modalOpen = $state(false);
   let started = false;
@@ -269,12 +293,23 @@
     jobs = next;
   }
 
-  // The feed minus the signed-in user's hidden jobs. Cross-referenced client-side
-  // against the shared dismissed set (loaded on mount), mirroring the viewed/saved
-  // sets — the server search is untouched. Re-derives when the page changes or when
-  // a hide/undo mutates the set, so a hidden card drops out (and an undone one
-  // returns) instantly. Empty for a signed-out user, so nothing is filtered.
-  const visibleJobs = $derived(jobs.items.filter((j) => !isDismissed(j.public_slug)));
+  // The feed minus the signed-in user's hidden jobs, and (when the match slider is
+  // active) minus jobs below the chosen match threshold. Dismissal is cross-referenced
+  // client-side against the shared dismissed set (loaded on mount), mirroring the
+  // viewed/saved sets — the server search is untouched. Re-derives when the page
+  // changes, when a hide/undo mutates the dismissed set, or when the slider moves, so
+  // a hidden or filtered-out card drops (and an undone one returns) instantly. A job
+  // with no skills has no percent to test (see computeClientMatch) and stays, matching
+  // the card's own `no-skills` state, which shows no match at all rather than a false 0%.
+  const visibleJobs = $derived(
+    jobs.items.filter((j) => {
+      if (isDismissed(j.public_slug)) return false;
+      if (matchFilterAvailable && minMatch != null && (j.skills ?? []).length > 0) {
+        return computeClientMatch(j.skills ?? [], profileSkills).percent >= minMatch;
+      }
+      return true;
+    }),
+  );
 
   // The pending "Job hidden — Undo" toast, or null. Set when a card is hidden; the
   // toast owns its auto-dismiss. Undo clears the slug's hidden mark (card returns via
@@ -408,6 +443,29 @@
         </div>
       {/if}
       {@render sidebarTop?.()}
+      {#if matchFilterAvailable}
+        <!-- Client-only post-filter (see `minMatch` above): drags apply immediately,
+             no debounce, since it only re-filters the page already in memory. -->
+        <div class="rounded-xl border border-border bg-card p-4">
+          <div class="mb-2 flex items-center justify-between">
+            <h3 class="text-sm font-semibold tracking-tight">Minimum match</h3>
+            <span class="text-xs font-medium text-muted-foreground">{minMatch != null ? `${minMatch}%+` : 'Any'}</span>
+          </div>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            step="5"
+            value={minMatch ?? 0}
+            oninput={(e) => {
+              const n = Number(e.currentTarget.value);
+              minMatch = n > 0 ? n : null;
+            }}
+            aria-label="Minimum profile match"
+            class="w-full accent-primary"
+          />
+        </div>
+      {/if}
       <div class="rounded-xl border border-border bg-card p-4">
         <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} canSave={standalone} />
       </div>

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -43,6 +43,9 @@
     previewCount,
     stagedCounts,
     extra,
+    matchAvailable = false,
+    minMatch = null,
+    onMinMatchChange,
   }: {
     store?: FilterStore;
     seed?: JobFilters;
@@ -69,6 +72,13 @@
     // Extra content rendered above the pane, handed the staged store so it can edit it
     // (e.g. the profile editor's "import skills from CV").
     extra?: Snippet<[StagedFilters]>;
+    // The "Match" pane: a client-only threshold over the viewer's own profile skills,
+    // not a JobFilters facet (the match percent depends on who's looking, so there's
+    // nothing to put in JobFilters/the URL — see JobsView's `minMatch`). The rail entry
+    // is hidden unless the caller has a real percent to filter on.
+    matchAvailable?: boolean;
+    minMatch?: number | null;
+    onMinMatchChange?: (value: number | null) => void;
   } = $props();
 
   const staged = new StagedFilters();
@@ -110,11 +120,16 @@
   const SECTIONS: RailSection[] = ['SAVED', ...RAIL_SECTIONS];
 
   // Rail entries visible under the current scope: restricted to `railKeys` when given,
-  // and a 'facet' entry is hidden when its param is excluded (e.g. Company on a company
-  // page).
+  // a 'facet' entry is hidden when its param is excluded (e.g. Company on a company
+  // page), and 'match' is hidden unless the caller has a real percent to filter on.
   const visibleRail = $derived([
     ...(hasSavedTab ? [SAVED_ENTRY] : []),
-    ...RAIL.filter((e) => (!railKeys || railKeys.includes(e.key)) && !(e.facetParam && exclude.includes(e.facetParam))),
+    ...RAIL.filter(
+      (e) =>
+        (!railKeys || railKeys.includes(e.key)) &&
+        !(e.facetParam && exclude.includes(e.facetParam)) &&
+        (e.kind !== 'match' || matchAvailable),
+    ),
   ]);
 
   // Values selected for one facet — included plus excluded — so the rail count reflects
@@ -134,6 +149,7 @@
     if (e.kind === 'language') return selCount(f, 'english_level') + selCount(f, 'posting_language');
     if (e.kind === 'relocation') return selCount(f, 'relocation') + (f.visa ? 1 : 0);
     if (e.kind === 'posted') return f.postedWithinDays != null ? 1 : 0;
+    if (e.kind === 'match') return minMatch != null ? 1 : 0;
     return selCount(f, e.facetParam ?? e.key);
   }
 
@@ -306,6 +322,23 @@
       value={freshnessIndex}
       oninput={(e) => staged.setPostedWithinDays(FRESHNESS_PRESETS[Number(e.currentTarget.value)]?.days ?? null)}
       aria-label="Posted within"
+      class="w-full accent-primary"
+    />
+  {:else if entry.kind === 'match'}
+    <!-- Client-only post-filter (see `minMatch`/`onMinMatchChange` props): re-filters
+         the already-fetched page in memory, so it applies immediately, no debounce. -->
+    <div class="mb-2 flex items-center justify-between">
+      <h3 class="text-sm font-semibold tracking-tight">Minimum skill match</h3>
+      <span class="text-xs font-medium text-muted-foreground">{minMatch != null ? `${minMatch}%+` : 'Any'}</span>
+    </div>
+    <input
+      type="range"
+      min="0"
+      max="100"
+      step="5"
+      value={minMatch ?? 0}
+      oninput={(e) => onMinMatchChange?.(Number(e.currentTarget.value) || null)}
+      aria-label="Minimum skill match"
       class="w-full accent-primary"
     />
   {/if}

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -112,6 +112,9 @@ export type RailKind =
   | 'language'
   | 'relocation'
   | 'posted'
+  // Client-only profile-match threshold — not a facet param, see FilterModal's
+  // `minMatch` prop. Only shown when the caller marks it available.
+  | 'match'
   // The job modal's "My filters" (saved searches) tab — renders SavedSearches, not a facet control.
   | 'saved';
 
@@ -142,4 +145,7 @@ export const RAIL: RailEntry[] = [
   { key: 'language', label: 'Language', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'language' },
   { key: 'relocation', label: 'Relocation', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'relocation' },
   { key: 'posted', label: 'Posted', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'posted' },
+  // Hidden unless the caller marks it available (signed in, profile has skills) — see
+  // FilterModal's `matchAvailable` prop and the `visibleRail` filter.
+  { key: 'match', label: 'Match', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'match' },
 ];


### PR DESCRIPTION
<!--
Do not open a PR unless a maintainer has approved you with `lgtm` on an issue.
PRs from unapproved contributors are auto-closed. Open an issue first.
-->

## What and why

<!-- What does this change do, and why does it matter? Link the approved issue. -->

Closes #

## Checklist

- [ ] I understand this code and can explain how it interacts with the rest of the system.
- [ ] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [ ] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [ ] I regenerated committed artifacts when their source changed (`make sqlc` for SQL/migrations, `make gen-contracts` for contract types).
- [ ] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass.
- [ ] For `web/` changes: `pnpm run check` and `pnpm run build` pass.
- [ ] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.
