### PR TITLE
feat(cv): freshen tailor bootstrap, experience order, and profile skills

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,11 +70,42 @@ S3_SECRET_KEY=
 # prod image bakes the binary in and sets TYPST_BIN=/app/typst.
 TYPST_BIN=typst
 
+# Per-role bullet ceiling (default 20). Raise in deploy if needed (e.g. 1000).
+# Restart required after change.
+# CV_MAX_BULLETS=20
+
+# Allow silent Sanitize truncation past that ceiling (default false = refuse).
+# Ops kill switch; restart required.
+# CV_EDIT_ALLOW_BULLET_TRUNCATION=false
+
 # Keys the visitor hash of a click on a traced CV link (opt-in, per CV). Leave it EMPTY and the
 # feature cannot be switched on at all: enabling the toggle returns 409, no token is minted, and
 # nothing is recorded. That is the intended state until the privacy policy describes what a traced
 # link stores. Any long random string; changing it makes past visitors look like new ones.
 TRACER_LINK_SALT=
+
+# --- LLM (optional) ----------------------------------------------------------
+# Any OpenAI-compatible /v1 endpoint. Unset → AI features stay disabled (catalogue
+# still works). Local AWS Bedrock via compose profile `bedrock` (SSO — no long-lived
+# IAM keys in this file):
+#
+#   aws sso login --profile dev
+#   podman compose --profile bedrock up -d --build bedrock-proxy
+#
+#   LLM_BASE_URL=http://127.0.0.1:4000/v1
+#   LLM_API_KEY=local-litellm
+#   LLM_MODEL=bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+#   ASSISTANT_MODEL=bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+#
+# Do NOT put AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY here for Bedrock — they are
+# long-lived, land in shell history and `podman inspect`, and skip SSO MFA.
+LLM_BASE_URL=
+LLM_API_KEY=
+LLM_MODEL=
+# ASSISTANT_MODEL=
+# Max runes in one user message to the assistant (default 8000). Raise locally if you
+# paste long briefs (e.g. 15000). Restart required after change.
+# ASSISTANT_MAX_PROMPT=8000
 
 # Speech-to-text for the assistant composer's microphone (optional, and OFF until you
 # name a model). It runs on the SAME gateway and key as the rest of the LLM stack — an

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,12 @@ hire
 .agents/
 skills-lock.json
 
+# Spec Kit — local-only (not part of the freehire tree). Keep on disk for personal
+# workflows; never commit tooling, constitution memory, or generated feature specs.
+.specify/
+.cursor/
+/specs/
+
 # Python
 __pycache__/
 *.pyc

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/strelov1/freehire/internal/blobstore"
 	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/credits"
+	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/gmailsync"
 	"github.com/strelov1/freehire/internal/handler"
@@ -31,6 +32,7 @@ import (
 
 func main() {
 	cfg := config.Load()
+	cv.SetMaxBullets(cfg.CVMaxBullets)
 
 	// Never boot the auth surface with a guessable signing key. HS256 security rests
 	// entirely on secret entropy, so a short secret is brute-forceable offline against
@@ -205,26 +207,28 @@ func main() {
 	creditsConfig := credits.Config(config.LoadCredits())
 
 	handler.Register(app, handler.Config{
-		Pool:              pool,
-		FrontendOrigin:    cfg.FrontendOrigin,
-		JWTSecret:         cfg.JWTSecret,
-		JWTTTL:            cfg.JWTTTL,
-		CookieSecure:      cfg.CookieSecure,
-		CookieDomains:     cfg.CookieDomains,
-		OAuthRegistry:     oauthRegistry,
-		GmailConnector:    gmailConnector,
-		GmailCipher:       gmailCipher,
-		MailboxDomain:     cfg.MailboxDomain,
-		Search:            searchClient,
-		Blob:              blobStore,
-		TypstBin:          cfg.TypstBin,
-		TracerLinkSalt:    cfg.TracerLinkSalt,
-		LLM:               llmClient,
-		AssistantLLM:      assistantLLM,
-		AssistantMaxSteps: cfg.AssistantMaxSteps,
-		LLMKeys:           llmKeys,
-		Speech:            speechClient,
-		PIIDetector:       piiDetector,
+		Pool:                        pool,
+		FrontendOrigin:              cfg.FrontendOrigin,
+		JWTSecret:                   cfg.JWTSecret,
+		JWTTTL:                      cfg.JWTTTL,
+		CookieSecure:                cfg.CookieSecure,
+		CookieDomains:               cfg.CookieDomains,
+		OAuthRegistry:               oauthRegistry,
+		GmailConnector:              gmailConnector,
+		GmailCipher:                 gmailCipher,
+		MailboxDomain:               cfg.MailboxDomain,
+		Search:                      searchClient,
+		Blob:                        blobStore,
+		TypstBin:                    cfg.TypstBin,
+		CVEditAllowBulletTruncation: cfg.CVEditAllowBulletTruncation,
+		TracerLinkSalt:              cfg.TracerLinkSalt,
+		LLM:                         llmClient,
+		AssistantLLM:                assistantLLM,
+		AssistantMaxSteps:           cfg.AssistantMaxSteps,
+		AssistantMaxPrompt:          cfg.AssistantMaxPrompt,
+		LLMKeys:                     llmKeys,
+		Speech:                      speechClient,
+		PIIDetector:                 piiDetector,
 
 		TelegramBotToken:      cfg.TelegramBotToken,
 		TelegramBotUsername:   cfg.TelegramBotUsername,

--- a/design-system/scripts/web-token-baseline.json
+++ b/design-system/scripts/web-token-baseline.json
@@ -82,7 +82,7 @@
   "web/src/lib/server/og/card.ts": 3,
   "web/src/lib/server/og/company.ts": 3,
   "web/src/lib/server/og/shared.ts": 7,
-  "web/src/lib/tailor/ArtifactPanel.svelte": 2,
+  "web/src/lib/tailor/ArtifactPanel.svelte": 1,
   "web/src/lib/tailor/AtsDelta.svelte": 3,
   "web/src/lib/tailor/AutopilotReport.svelte": 2,
   "web/src/lib/tailor/CvHtmlPreview.svelte": 27,

--- a/internal/assistant/AGENTS.md
+++ b/internal/assistant/AGENTS.md
@@ -59,6 +59,11 @@ POST /api/v1/assistant/sessions/:id/messages
                                               emit tool_use/tool_result,
                                               persist, append to history
             └─ cap reached → one final Chat with NO tools → result(max_steps)
+
+POST /api/v1/assistant/sessions/:id/retry
+  └─ Runner.Continue — same loop, NO new user message (a failed turn already
+     recorded the prompt; re-sending it would duplicate context). History rebuild
+     still heals dangling tool_use from the interrupted turn.
 ```
 
 **Files.** `runner.go` is the loop and the event shapes; `tool.go` the tool

--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -143,7 +143,7 @@ Mechanics:
 - Address an experience entry and a bullet by their 0-based index in what ` + "`cv_get`" + ` returned — ` + "`bullet`" + ` is that index, never the bullet's text; the new text always goes in ` + "`value`" + `.
 - The server validates every patch; if one is rejected, read the reason and correct the address rather than retrying the same shape.
 - Contact details cannot be edited here — do not try.
-- Keep the CV to one or two pages. Prefer sharpening existing bullets over adding new ones.
+- Keep the CV to one or two pages. Prefer sharpening existing bullets over adding new ones. Each experience has a bullet ceiling; when a role is full, ` + "`set`" + ` an existing bullet or ` + "`remove`" + ` one first — inserting past the cap is refused and does not delete anything.
 - Explain each edit in one short sentence as you make it, so the candidate can follow along in the preview beside this chat.
 - Do NOT restate the fit analysis. The verdict, the score and the dimension comments are open in a panel beside this chat; repeating them spends the turn on something the candidate is already looking at. Open with what you are about to do, not with what you read.
 - ` + "`job_match`" + ` reads a DIFFERENT score than the fit analysis above — recomputed fresh from what the CV currently says, no model call, so it moves as you edit. Call it after a batch of edits to check their effect; it costs nothing and needs no explaining to the candidate, who has the same panel open beside this chat.

--- a/internal/assistant/prompt_test.go
+++ b/internal/assistant/prompt_test.go
@@ -76,6 +76,20 @@ func TestTailorPromptCarriesTheHonestyRule(t *testing.T) {
 	}
 }
 
+func TestTailorPromptStatesTheBulletCeilingRule(t *testing.T) {
+	p := SystemPrompt(PresetTailor)
+	lower := strings.ToLower(p)
+	if !strings.Contains(lower, "bullet ceiling") && !strings.Contains(lower, "at most") {
+		t.Error("the tailor prompt must tell the model each experience has a bullet ceiling")
+	}
+	if !strings.Contains(lower, "refused") {
+		t.Error("the tailor prompt must say inserting past the cap is refused")
+	}
+	if !strings.Contains(p, "`set`") || !strings.Contains(p, "`remove`") {
+		t.Error("the tailor prompt must tell the model to set or remove before inserting when full")
+	}
+}
+
 func TestAnUnknownPresetFallsBackToTheChatPrompt(t *testing.T) {
 	if SystemPrompt("wizard") != SystemPrompt(PresetChat) {
 		t.Error("an unknown preset must still get a prompt; a session with none would answer unguided")

--- a/internal/assistant/runner.go
+++ b/internal/assistant/runner.go
@@ -3,6 +3,7 @@ package assistant
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"time"
 
@@ -149,6 +150,10 @@ func persisting(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(ctx), persistTimeout)
 }
 
+// ErrNothingToContinue is returned by Continue when the session has no user
+// message to resume from. The handler maps it to HTTP 409.
+var ErrNothingToContinue = errors.New("assistant: nothing to continue")
+
 // Run executes one turn: it records the prompt, then alternates model calls and
 // tool calls until the model answers, the step cap is reached, or the caller goes
 // away. Every frame is emitted through emit and persisted as it is produced, so a
@@ -161,7 +166,43 @@ func (r *Runner) Run(ctx context.Context, sess Session, reg *Registry, system, p
 	if err := r.recordPrompt(ctx, sess, prompt, emit); err != nil {
 		return err
 	}
+	return r.runFromHistory(ctx, sess, reg, system, turn, emit)
+}
 
+// Continue resumes after a failed turn without appending another user message.
+// The transcript already holds the prompt (and any partial tool work); replaying
+// a second copy would duplicate the candidate's request in the model's context.
+// Dangling tool_use rows from the interrupted turn are healed when history is
+// rebuilt — same path every other turn uses — so Bedrock stays provider-legal.
+func (r *Runner) Continue(ctx context.Context, sess Session, reg *Registry, system string, turn TurnConfig, emit func(Event)) error {
+	stored, err := r.store.Transcript(ctx, sess.ID)
+	if err != nil {
+		return r.fail(emit, err)
+	}
+	if !hasUserMessage(stored) {
+		return ErrNothingToContinue
+	}
+	// Activity only — no new prompt, no re-label.
+	writeCtx, cancel := persisting(ctx)
+	defer cancel()
+	if err := r.store.Touch(writeCtx, sess.ID); err != nil {
+		log.Printf("assistant: touch session %s: %v", sess.ID, err)
+	}
+	return r.runFromHistory(ctx, sess, reg, system, turn, emit)
+}
+
+func hasUserMessage(msgs []Message) bool {
+	for _, m := range msgs {
+		if m.Role == RoleUser {
+			return true
+		}
+	}
+	return false
+}
+
+// runFromHistory is the shared tool-calling loop. Run records a prompt first;
+// Continue skips that so a retry does not rewrite the conversation.
+func (r *Runner) runFromHistory(ctx context.Context, sess Session, reg *Registry, system string, turn TurnConfig, emit func(Event)) error {
 	history, err := r.history(ctx, sess.ID, system)
 	if err != nil {
 		return r.fail(emit, err)

--- a/internal/assistant/runner_test.go
+++ b/internal/assistant/runner_test.go
@@ -507,3 +507,62 @@ func TestACancelledToolRoundKeepsItsResults(t *testing.T) {
 		t.Fatalf("transcript has %v, want %v", roles, want)
 	}
 }
+
+// A retry after a transport failure must not append another copy of the user's
+// prompt — that would leave the model answering a conversation that asked twice.
+func TestContinueDoesNotRecordAnotherUserPrompt(t *testing.T) {
+	failing := &scriptedModel{err: errors.New("upstream 502")}
+	q := &fakeQueries{}
+	r := testRunner(failing, q)
+
+	var failed []Event
+	err := r.Run(context.Background(), Session{ID: sessionID, UserID: 3}, NewRegistry(),
+		"sys", "tailor this for me", TurnConfig{}, func(e Event) { failed = append(failed, e) })
+	if err == nil {
+		t.Fatal("want the first turn to fail")
+	}
+	if res := lastResult(t, failed); !res.IsError {
+		t.Fatalf("first turn result = %+v, want is_error", res)
+	}
+	users := 0
+	for _, m := range q.messages {
+		if m.Role == RoleUser {
+			users++
+		}
+	}
+	if users != 1 {
+		t.Fatalf("after the failed turn: %d user messages, want 1", users)
+	}
+
+	ok := &scriptedModel{replies: []*llms.ContentChoice{textReply("Picking up where we left off.")}}
+	r = testRunner(ok, q)
+	var events []Event
+	if err := r.Continue(context.Background(), Session{ID: sessionID, UserID: 3}, NewRegistry(),
+		"sys", TurnConfig{}, func(e Event) { events = append(events, e) }); err != nil {
+		t.Fatalf("Continue: %v", err)
+	}
+	if hasKind(events, EventUserPrompt) {
+		t.Fatal("Continue emitted user_prompt — that would duplicate the request in the UI and the model")
+	}
+	users = 0
+	for _, m := range q.messages {
+		if m.Role == RoleUser {
+			users++
+		}
+	}
+	if users != 1 {
+		t.Fatalf("after Continue: %d user messages, want still 1", users)
+	}
+	if res := lastResult(t, events); res.StopReason != StopEndTurn || res.IsError {
+		t.Fatalf("Continue result = %+v, want a clean end_turn", res)
+	}
+}
+
+func TestContinueWithEmptyTranscriptIsRefused(t *testing.T) {
+	r := testRunner(&scriptedModel{}, &fakeQueries{})
+	err := r.Continue(context.Background(), Session{ID: sessionID, UserID: 3}, NewRegistry(),
+		"sys", TurnConfig{}, func(Event) {})
+	if !errors.Is(err, ErrNothingToContinue) {
+		t.Fatalf("Continue on empty session: %v, want ErrNothingToContinue", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,10 @@ type Settings struct {
 	// zero uses the package default.
 	AssistantModel    string
 	AssistantMaxSteps int
+	// AssistantMaxPrompt is the max rune length of one user message to the
+	// assistant. Default 8000; override with ASSISTANT_MAX_PROMPT. Values below 1
+	// fall back to the default so a typo cannot erase the ceiling.
+	AssistantMaxPrompt int
 
 	// STTModel transcribes dictated audio, through the same gateway and key the LLM
 	// settings above name — an OpenAI-compatible endpoint serves /chat/completions and
@@ -129,6 +133,18 @@ type Settings struct {
 	// exec.LookPath(TYPST_BIN|"typst") so "disabled" means the binary is genuinely
 	// absent, not merely misconfigured — enforced at the cmd/server call site, not here.
 	TypstBin string
+
+	// CVEditAllowBulletTruncation restores the old Sanitize behaviour that keeps the
+	// first MaxBullets and silently drops the rest. Default false — Commit refuses
+	// that class of loss. Set CV_EDIT_ALLOW_BULLET_TRUNCATION=true as an ops kill
+	// switch (restart required). Named as the escape hatch so an unset Go bool keeps
+	// the safety on.
+	CVEditAllowBulletTruncation bool
+
+	// CVMaxBullets is the per-experience / per-project bullet ceiling (cv.MaxBullets).
+	// Default 20. Override with CV_MAX_BULLETS; values below 1 fall back to the
+	// package default so a typo cannot erase the ceiling.
+	CVMaxBullets int
 
 	// TracerLinkSalt keys the visitor hash of a click on a traced CV link. Empty disables the
 	// feature's consent toggle outright: without a salt there is no way to tell one visitor from
@@ -201,9 +217,13 @@ type OAuthCredentials struct {
 // environment (OAUTH_<PROVIDER>_CLIENT_ID / OAUTH_<PROVIDER>_CLIENT_SECRET).
 var oauthProviders = []string{"google", "github", "linkedin"}
 
+// defaultAssistantMaxPrompt is the rune ceiling on one user message when
+// ASSISTANT_MAX_PROMPT is unset or invalid.
+const defaultAssistantMaxPrompt = 8000
+
 // Load reads configuration from the environment, falling back to sensible defaults.
 func Load() Settings {
-	return Settings{
+	s := Settings{
 		LLM:            LoadLLM(),
 		Port:           env("PORT", "8080"),
 		DatabaseURL:    env("DATABASE_URL", "postgres://hire:hire@localhost:5432/hire?sslmode=disable"),
@@ -224,8 +244,9 @@ func Load() Settings {
 		LLMUserRPMLimit:     envInt("LLM_USER_RPM_LIMIT", 0),
 		LLMUserBudgetWindow: env("LLM_USER_BUDGET_WINDOW", "30d"),
 
-		AssistantModel:    os.Getenv("ASSISTANT_MODEL"),
-		AssistantMaxSteps: envInt("ASSISTANT_MAX_STEPS", 0),
+		AssistantModel:     os.Getenv("ASSISTANT_MODEL"),
+		AssistantMaxSteps:  envInt("ASSISTANT_MAX_STEPS", 0),
+		AssistantMaxPrompt: envInt("ASSISTANT_MAX_PROMPT", defaultAssistantMaxPrompt),
 
 		STTModel: os.Getenv("STT_MODEL"),
 
@@ -236,7 +257,9 @@ func Load() Settings {
 		S3AccessKey: os.Getenv("S3_ACCESS_KEY"),
 		S3SecretKey: os.Getenv("S3_SECRET_KEY"),
 
-		TypstBin: resolveTypstBin(env("TYPST_BIN", "typst")),
+		TypstBin:                    resolveTypstBin(env("TYPST_BIN", "typst")),
+		CVEditAllowBulletTruncation: envBool("CV_EDIT_ALLOW_BULLET_TRUNCATION", false),
+		CVMaxBullets:                envInt("CV_MAX_BULLETS", 20),
 
 		SentryDSN:         os.Getenv("SENTRY_DSN"),
 		SentryEnvironment: env("SENTRY_ENVIRONMENT", "development"),
@@ -257,6 +280,10 @@ func Load() Settings {
 		TracerLinkSalt:             os.Getenv("TRACER_LINK_SALT"),
 		ExtensionRedirectAllowlist: splitCSV(os.Getenv("EXTENSION_REDIRECT_ALLOWLIST")),
 	}
+	if s.AssistantMaxPrompt < 1 {
+		s.AssistantMaxPrompt = defaultAssistantMaxPrompt
+	}
+	return s
 }
 
 // splitCSV parses a comma-separated env value into trimmed, non-empty entries.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -83,6 +83,55 @@ func TestLoad_AnUnparseableCeilingIsNoCeiling(t *testing.T) {
 	}
 }
 
+func TestLoad_BulletTruncationEscapeHatchDefaultsOff(t *testing.T) {
+	t.Setenv("CV_EDIT_ALLOW_BULLET_TRUNCATION", "")
+	if s := Load(); s.CVEditAllowBulletTruncation {
+		t.Fatal("CVEditAllowBulletTruncation defaults on — an unset env must keep the refuse")
+	}
+}
+
+func TestLoad_BulletTruncationEscapeHatchFromEnv(t *testing.T) {
+	t.Setenv("CV_EDIT_ALLOW_BULLET_TRUNCATION", "true")
+	if s := Load(); !s.CVEditAllowBulletTruncation {
+		t.Fatal("CVEditAllowBulletTruncation = false, want true from env")
+	}
+}
+
+func TestLoad_MaxBulletsDefaultsToTwenty(t *testing.T) {
+	t.Setenv("CV_MAX_BULLETS", "")
+	if s := Load(); s.CVMaxBullets != 20 {
+		t.Fatalf("CVMaxBullets = %d, want 20", s.CVMaxBullets)
+	}
+}
+
+func TestLoad_AssistantMaxPromptDefaultsTo8000(t *testing.T) {
+	t.Setenv("ASSISTANT_MAX_PROMPT", "")
+	if s := Load(); s.AssistantMaxPrompt != 8000 {
+		t.Fatalf("AssistantMaxPrompt = %d, want 8000", s.AssistantMaxPrompt)
+	}
+}
+
+func TestLoad_AssistantMaxPromptFromEnv(t *testing.T) {
+	t.Setenv("ASSISTANT_MAX_PROMPT", "15000")
+	if s := Load(); s.AssistantMaxPrompt != 15000 {
+		t.Fatalf("AssistantMaxPrompt = %d, want 15000", s.AssistantMaxPrompt)
+	}
+}
+
+func TestLoad_AssistantMaxPromptRejectsNonPositive(t *testing.T) {
+	t.Setenv("ASSISTANT_MAX_PROMPT", "0")
+	if s := Load(); s.AssistantMaxPrompt != 8000 {
+		t.Fatalf("AssistantMaxPrompt = %d after 0, want 8000", s.AssistantMaxPrompt)
+	}
+}
+
+func TestLoad_MaxBulletsFromEnv(t *testing.T) {
+	t.Setenv("CV_MAX_BULLETS", "50")
+	if s := Load(); s.CVMaxBullets != 50 {
+		t.Fatalf("CVMaxBullets = %d, want 50", s.CVMaxBullets)
+	}
+}
+
 func TestLoad_STTModelHasNoDefault(t *testing.T) {
 	t.Setenv("STT_MODEL", "")
 

--- a/internal/cv/AGENTS.md
+++ b/internal/cv/AGENTS.md
@@ -139,6 +139,19 @@ Three things that follow, and are easy to get backwards:
   tailored copy whose vacancy is gone is refused with "the vacancy … no longer exists". They are
   different situations, and `job_id == 0` alone cannot tell them apart.
 
+### Reset from résumé
+
+`POST /me/cvs/:id/reset-from-resume` (cookie-only) rebuilds a **tailored** CV's content from the
+current résumé seed (`bankedSeeder`: experience bank + `resume_structured`) and refreshes the
+base CV from the same seed. Same tailored id and agent session; template/margins/style on each
+row are preserved. Upload alone does **not** write `cvs` — it only refreshes the seed source;
+this endpoint is the explicit apply. 409 when the target is not tailored or the seed is unusable.
+
+**Bootstrap freshness:** `POST /me/cvs/tailor` refreshes a base whose `updated_at` is strictly
+before `resume_uploaded_at` (when the seed is usable) before copying into a **new** tailored
+row. Reloading an existing tailored-for-job stays idempotent and does not rewrite that copy.
+Does not write the profile.
+
 Backfill caveat: `0058` reads `job_id` to set the flag, so it is right about every row only because
 no prune had orphaned one yet. A row orphaned before that migration would stay marked non-tailored
 and would need a heuristic repair.

--- a/internal/cv/cv.go
+++ b/internal/cv/cv.go
@@ -33,9 +33,28 @@ const (
 	maxLanguages      = 20
 	maxProjects       = 30
 	maxCertifications = 30
-	maxBullets        = 20
 	maxLinks          = 20
+
+	// DefaultMaxBullets is the per-experience / per-project bullet ceiling when
+	// CV_MAX_BULLETS is unset. Writers must refuse growth past MaxBullets rather
+	// than let Sanitize drop trailing content silently.
+	DefaultMaxBullets = 20
 )
+
+// MaxBullets is the hard ceiling on bullets per experience (and per project).
+// Sanitize keeps the first MaxBullets and drops the rest. Mutable so a deployment
+// can raise or lower it via CV_MAX_BULLETS without a code change; SetMaxBullets
+// is the only writer.
+var MaxBullets = DefaultMaxBullets
+
+// SetMaxBullets sets the per-role bullet ceiling. Values below 1 fall back to
+// DefaultMaxBullets — a typo must not erase the ceiling.
+func SetMaxBullets(n int) {
+	if n < 1 {
+		n = DefaultMaxBullets
+	}
+	MaxBullets = n
+}
 
 // Page margins are in inches. Sanitize clamps each side to this résumé-sane band and
 // defaults a zero (unset) side to defaultMargin, so a fresh skeleton and an old document
@@ -276,7 +295,7 @@ func sanitizeExperience(e ExperienceItem) (ExperienceItem, bool) {
 	e.Start = clip(e.Start, maxShortRunes)
 	e.End = clip(e.End, maxShortRunes)
 	e.Summary = clip(e.Summary, maxBulletRunes)
-	e.Bullets = limit(nonEmpty(mapStrings(e.Bullets, maxBulletRunes)), maxBullets)
+	e.Bullets = limit(nonEmpty(mapStrings(e.Bullets, maxBulletRunes)), MaxBullets)
 	e.Stack = limit(nonEmpty(mapStrings(e.Stack, maxShortRunes)), maxSkillItems)
 	keep := e.Role != "" || e.Company != "" || e.Location != "" ||
 		e.Start != "" || e.End != "" || e.Summary != "" || len(e.Bullets) > 0
@@ -309,7 +328,7 @@ func sanitizeLanguage(l Language) (Language, bool) {
 func sanitizeProject(p Project) (Project, bool) {
 	p.Name = clip(p.Name, maxShortRunes)
 	p.Link = clip(p.Link, maxShortRunes)
-	p.Bullets = limit(nonEmpty(mapStrings(p.Bullets, maxBulletRunes)), maxBullets)
+	p.Bullets = limit(nonEmpty(mapStrings(p.Bullets, maxBulletRunes)), MaxBullets)
 	return p, p.Name != "" || p.Link != "" || len(p.Bullets) > 0
 }
 

--- a/internal/cv/cv_test.go
+++ b/internal/cv/cv_test.go
@@ -5,6 +5,20 @@ import (
 	"testing"
 )
 
+func TestSetMaxBulletsRejectsNonPositive(t *testing.T) {
+	prev := MaxBullets
+	t.Cleanup(func() { SetMaxBullets(prev) })
+
+	SetMaxBullets(0)
+	if MaxBullets != DefaultMaxBullets {
+		t.Fatalf("MaxBullets = %d after SetMaxBullets(0), want DefaultMaxBullets %d", MaxBullets, DefaultMaxBullets)
+	}
+	SetMaxBullets(50)
+	if MaxBullets != 50 {
+		t.Fatalf("MaxBullets = %d, want 50", MaxBullets)
+	}
+}
+
 func TestSanitizeBoundsStrings(t *testing.T) {
 	doc := Document{
 		Header: Header{
@@ -35,6 +49,10 @@ func TestSanitizeBoundsStrings(t *testing.T) {
 }
 
 func TestSanitizeCapsArrays(t *testing.T) {
+	prev := MaxBullets
+	SetMaxBullets(20)
+	t.Cleanup(func() { SetMaxBullets(prev) })
+
 	doc := Document{}
 	for i := 0; i < maxExperience+10; i++ {
 		doc.Experience = append(doc.Experience, ExperienceItem{Role: "eng"})
@@ -42,7 +60,7 @@ func TestSanitizeCapsArrays(t *testing.T) {
 	for i := 0; i < maxSkillGroups+10; i++ {
 		doc.Skills = append(doc.Skills, SkillGroup{Group: "g", Items: []string{"go"}})
 	}
-	bullets := make([]string, maxBullets+10)
+	bullets := make([]string, MaxBullets+10)
 	for i := range bullets {
 		bullets[i] = "did a thing"
 	}
@@ -57,7 +75,7 @@ func TestSanitizeCapsArrays(t *testing.T) {
 		t.Errorf("Skills not capped: %d", len(doc.Skills))
 	}
 	for _, e := range doc.Experience {
-		if len(e.Bullets) > maxBullets {
+		if len(e.Bullets) > MaxBullets {
 			t.Errorf("Bullets not capped: %d", len(e.Bullets))
 		}
 	}

--- a/internal/cvedit/AGENTS.md
+++ b/internal/cvedit/AGENTS.md
@@ -143,3 +143,17 @@ read, and an operation addressing a path that has since disappeared is refused w
 The feed is capped at 100 revisions per CV, trimmed in the same transaction as the insert: this is
 an aid to the candidate's current work, not an archive, and each row carries two operation
 documents on the table behind every CV page.
+
+## Bullet ceiling
+
+`cv.MaxBullets` (default 20, override with `CV_MAX_BULLETS`) is enforced by `Sanitize`,
+which keeps the first N and drops the rest. Commit refuses that class of loss up front
+(`ErrListCap` / `bullet_cap`) so an insert into a full list cannot look like a successful
+add while trailing originals vanish. The guard is on by default; `Editor.SetRefuseListCap(false)`
+(env `CV_EDIT_ALLOW_BULLET_TRUNCATION=true` on the server) restores the old sanitize-and-drop
+behaviour without a code change.
+
+Sibling Sanitize `limit()`s — experience/education/skills/languages/projects/certifications
+counts, skill items, links — still drop trailing entries silently. Extending refuse to those
+lists is a follow-up if an incident appears; it is intentionally out of scope for the bullet
+fix.

--- a/internal/cvedit/editor.go
+++ b/internal/cvedit/editor.go
@@ -116,6 +116,10 @@ type Editor struct {
 	policy Policy
 	gate   EvidenceGate
 	now    func() time.Time
+	// refuseListCap refuses a commit that would leave more than cv.MaxBullets
+	// non-empty bullets on one role — otherwise Sanitize silently drops the rest.
+	// On by default; SetRefuseListCap(false) is the ops escape hatch.
+	refuseListCap bool
 }
 
 // NewEditor builds the editor over its repository and the gate an agent's claims answer
@@ -126,7 +130,15 @@ type Editor struct {
 // who is the source the bank exists to record. It is what the candidate-only test editors
 // pass, and it is not a configuration an agent write path may be built on.
 func NewEditor(repo Repository, gate EvidenceGate) *Editor {
-	return &Editor{repo: repo, policy: DefaultPolicy(), gate: gate, now: time.Now}
+	return &Editor{repo: repo, policy: DefaultPolicy(), gate: gate, now: time.Now, refuseListCap: true}
+}
+
+// SetRefuseListCap turns the over-cap refuse on or off. When off, Sanitize may drop
+// trailing bullets again — the pre-refuse behaviour. Returns the editor so callers can
+// chain it at construction (e.g. NewEditor(...).SetRefuseListCap(cfg.On)).
+func (e *Editor) SetRefuseListCap(on bool) *Editor {
+	e.refuseListCap = on
+	return e
 }
 
 // Commit applies a batch and records it. The document and its revision are written in one
@@ -178,6 +190,16 @@ func (e *Editor) commit(ctx context.Context, tx Tx, cvID uuid.UUID, userID int64
 	// has: a change states what was asked for, and the sanitizer decides what is kept.
 	after := applied
 	after.Document.Sanitize()
+
+	// Sanitize used to silently keep the first MaxBullets and drop the rest. An
+	// agent insert into a full list then looked like a successful "add" while
+	// original trailing bullets vanished. Refuse that class of loss before Save
+	// unless an operator turned the guard off (SetRefuseListCap(false)).
+	if e.refuseListCap {
+		if err := refuseIfSanitizeDropsContent(applied, after); err != nil {
+			return cv.Meta{}, Revision{}, err
+		}
+	}
 
 	// Which inverse to store depends on whether the sanitizer moved anything.
 	//

--- a/internal/cvedit/listcap.go
+++ b/internal/cvedit/listcap.go
@@ -1,0 +1,94 @@
+package cvedit
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/cv"
+)
+
+// ErrListCap is returned when Apply would leave more than cv.MaxBullets
+// non-empty bullets on one experience or project — Sanitize would keep the
+// first MaxBullets and drop the rest. The edit is refused so trailing content
+// cannot vanish while History still claims an "add".
+var ErrListCap = errors.New("cvedit: this edit would drop existing CV content")
+
+// ListCapCode is a stable token in ErrListCap messages so the SPA can surface a
+// candidate-facing alert without scraping free-form text. The model still reads
+// the full sentence.
+const ListCapCode = "bullet_cap"
+
+// refuseIfSanitizeDropsContent returns ErrListCap when the applied document
+// already exceeds the per-role bullet ceiling. Comparing applied vs after by
+// index is unsafe: Sanitize also drops empty experience/project rows, which
+// shifts later roles and looks like bullet loss.
+// Dropping whitespace-only bullets is allowed — that is cleanup, not content loss.
+func refuseIfSanitizeDropsContent(applied, _ State) error {
+	for i, e := range applied.Document.Experience {
+		if countNonEmpty(e.Bullets) > cv.MaxBullets {
+			return listCapErr(experienceLabel(e, i))
+		}
+	}
+	for i, p := range applied.Document.Projects {
+		if countNonEmpty(p.Bullets) > cv.MaxBullets {
+			return listCapErr(projectLabel(p, i))
+		}
+	}
+	return nil
+}
+
+func listCapErr(where string) error {
+	return fmt.Errorf("%w: %s: %s already has %d bullets (the maximum). "+
+		"The edit was not applied and no existing bullets were deleted. "+
+		"Set an existing bullet or remove one before inserting",
+		ErrListCap, ListCapCode, where, cv.MaxBullets)
+}
+
+func countNonEmpty(bullets []string) int {
+	n := 0
+	for _, b := range bullets {
+		if strings.TrimSpace(b) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+func experienceLabel(e cv.ExperienceItem, i int) string {
+	role := strings.TrimSpace(e.Role)
+	company := strings.TrimSpace(e.Company)
+	switch {
+	case role != "" && company != "":
+		return role + " at " + company
+	case role != "":
+		return role
+	case company != "":
+		return company
+	default:
+		return fmt.Sprintf("experience[%d]", i)
+	}
+}
+
+func projectLabel(p cv.Project, i int) string {
+	if name := strings.TrimSpace(p.Name); name != "" {
+		return "project " + name
+	}
+	return fmt.Sprintf("projects[%d]", i)
+}
+
+// UserListCapMessage turns an ErrListCap into the sentence shown to the candidate.
+// Internal prefixes and model-facing remedy stay out of the banner.
+func UserListCapMessage(err error) string {
+	if err == nil || !errors.Is(err, ErrListCap) {
+		return ""
+	}
+	msg := err.Error()
+	if _, rest, ok := strings.Cut(msg, ListCapCode+": "); ok {
+		msg = rest
+	}
+	if before, _, ok := strings.Cut(msg, ". Set an existing"); ok {
+		return before + ". Your existing bullets were kept."
+	}
+	return msg
+}

--- a/internal/cvedit/listcap_test.go
+++ b/internal/cvedit/listcap_test.go
@@ -1,0 +1,197 @@
+package cvedit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/cv"
+)
+
+func TestCommitRefusesInsertThatWouldDropExistingBullets(t *testing.T) {
+	prev := cv.MaxBullets
+	cv.SetMaxBullets(20)
+	t.Cleanup(func() { cv.SetMaxBullets(prev) })
+
+	repo := newFakeRepo()
+	bullets := make([]string, cv.MaxBullets)
+	for i := range bullets {
+		bullets[i] = fmt.Sprintf("Original bullet %d — keep me", i+1)
+	}
+	repo.state.Experience = []cv.ExperienceItem{{
+		Role: "Staff Engineer", Company: "Neon", Bullets: bullets,
+	}}
+	e, _ := newEditor(repo, &bank{})
+
+	err := agentEdit(t, e, Op{
+		Kind: OpInsert, Path: mustParse(t, "experience[0].bullets[0]"),
+		Value:      "Brand new keyword bullet",
+		EvidenceID: "banked",
+	})
+	if !errors.Is(err, ErrListCap) {
+		t.Fatalf("Commit = %v, want ErrListCap", err)
+	}
+	if !strings.Contains(err.Error(), ListCapCode) {
+		t.Fatalf("error %q missing stable code %q for the UI", err, ListCapCode)
+	}
+	if !strings.Contains(err.Error(), "not applied") {
+		t.Fatalf("error %q should tell the model nothing was written", err)
+	}
+	if repo.saves != 0 || len(repo.revisions) != 0 {
+		t.Fatal("a refused over-cap insert must not save or file a revision")
+	}
+	if got := repo.state.Experience[0].Bullets[0]; got != bullets[0] {
+		t.Fatalf("first bullet = %q, want the original kept", got)
+	}
+	if got := len(repo.state.Experience[0].Bullets); got != cv.MaxBullets {
+		t.Fatalf("bullet count = %d, want still %d", got, cv.MaxBullets)
+	}
+}
+
+func TestCommitRefusesOverCapInsertOnAProject(t *testing.T) {
+	prev := cv.MaxBullets
+	cv.SetMaxBullets(20)
+	t.Cleanup(func() { cv.SetMaxBullets(prev) })
+
+	repo := newFakeRepo()
+	bullets := make([]string, cv.MaxBullets)
+	for i := range bullets {
+		bullets[i] = fmt.Sprintf("Project bullet %d", i+1)
+	}
+	repo.state.Projects = []cv.Project{{Name: "freehire", Bullets: bullets}}
+	e, _ := newEditor(repo, &bank{})
+
+	err := agentEdit(t, e, Op{
+		Kind: OpInsert, Path: mustParse(t, "projects[0].bullets[0]"),
+		Value:      "Extra project claim",
+		EvidenceID: "banked",
+	})
+	if !errors.Is(err, ErrListCap) {
+		t.Fatalf("Commit = %v, want ErrListCap", err)
+	}
+	if !strings.Contains(err.Error(), "project freehire") {
+		t.Fatalf("error %q should name the project", err)
+	}
+	if repo.saves != 0 || len(repo.revisions) != 0 {
+		t.Fatal("a refused over-cap project insert must not save")
+	}
+	if got := repo.state.Projects[0].Bullets[0]; got != bullets[0] {
+		t.Fatalf("first bullet = %q, want the original kept", got)
+	}
+}
+
+func TestCommitRefusesOverCapForTheCandidateEditor(t *testing.T) {
+	prev := cv.MaxBullets
+	cv.SetMaxBullets(20)
+	t.Cleanup(func() { cv.SetMaxBullets(prev) })
+
+	repo := newFakeRepo()
+	bullets := make([]string, cv.MaxBullets)
+	for i := range bullets {
+		bullets[i] = fmt.Sprintf("Original bullet %d", i+1)
+	}
+	repo.state.Experience = []cv.ExperienceItem{{
+		Role: "Eng", Company: "Acme", Bullets: bullets,
+	}}
+	e := NewEditor(repo, nil)
+
+	_, _, err := e.Commit(context.Background(), uuid.Nil, 1, Change{
+		Actor: ActorCandidate, Origin: OriginEditor,
+		Ops: []Op{{Kind: OpInsert, Path: mustParse(t, "experience[0].bullets[0]"), Value: "One more"}},
+	})
+	if !errors.Is(err, ErrListCap) {
+		t.Fatalf("Commit = %v, want ErrListCap", err)
+	}
+	if repo.saves != 0 {
+		t.Fatal("candidate over-cap insert must not save")
+	}
+}
+
+func TestCommitAllowsInsertWhenUnderTheCap(t *testing.T) {
+	repo := newFakeRepo()
+	repo.state.Experience = []cv.ExperienceItem{{
+		Role: "Eng", Company: "Acme", Bullets: []string{"Only one"},
+	}}
+	e, _ := newEditor(repo, &bank{})
+
+	if err := agentEdit(t, e, Op{
+		Kind: OpInsert, Path: mustParse(t, "experience[0].bullets[1]"),
+		Value:      "Second bullet",
+		EvidenceID: "banked",
+	}); err != nil {
+		t.Fatalf("Commit under the cap: %v", err)
+	}
+	if got := len(repo.state.Experience[0].Bullets); got != 2 {
+		t.Fatalf("bullets = %d, want 2", got)
+	}
+}
+
+func TestUserListCapMessageStripsModelRemedy(t *testing.T) {
+	err := listCapErr("Staff Engineer at Neon")
+	got := UserListCapMessage(err)
+	if got == "" {
+		t.Fatal("empty user message")
+	}
+	if strings.Contains(got, ListCapCode) || strings.Contains(got, "Set an existing") {
+		t.Fatalf("user message still has internals: %q", got)
+	}
+	if !strings.Contains(got, "Your existing bullets were kept") {
+		t.Fatalf("user message %q should reassure that nothing was deleted", got)
+	}
+	if !strings.Contains(got, "Staff Engineer at Neon") {
+		t.Fatalf("user message %q should name the role", got)
+	}
+}
+
+func TestCommitAllowsOverCapWhenRefuseIsDisabled(t *testing.T) {
+	prev := cv.MaxBullets
+	cv.SetMaxBullets(20)
+	t.Cleanup(func() { cv.SetMaxBullets(prev) })
+
+	repo := newFakeRepo()
+	bullets := make([]string, cv.MaxBullets)
+	for i := range bullets {
+		bullets[i] = fmt.Sprintf("Original bullet %d", i+1)
+	}
+	repo.state.Experience = []cv.ExperienceItem{{
+		Role: "Staff Engineer", Company: "Neon", Bullets: bullets,
+	}}
+	e := NewEditor(repo, &bank{}).SetRefuseListCap(false)
+
+	if err := agentEdit(t, e, Op{
+		Kind: OpInsert, Path: mustParse(t, "experience[0].bullets[0]"),
+		Value:      "Brand new keyword bullet",
+		EvidenceID: "banked",
+	}); err != nil {
+		t.Fatalf("Commit with refuse off: %v", err)
+	}
+	if got := len(repo.state.Experience[0].Bullets); got != cv.MaxBullets {
+		t.Fatalf("bullets = %d, want Sanitize to keep %d when refuse is off", got, cv.MaxBullets)
+	}
+	if got := repo.state.Experience[0].Bullets[0]; got != "Brand new keyword bullet" {
+		t.Fatalf("first bullet = %q, want the insert kept and the trailing original dropped", got)
+	}
+}
+
+func TestCommitStillDropsWhitespaceOnlyBulletsWithoutRefusing(t *testing.T) {
+	repo := newFakeRepo()
+	repo.state.Experience = []cv.ExperienceItem{{
+		Role: "Eng", Company: "Acme", Bullets: []string{"Keep", "   "},
+	}}
+	e := NewEditor(repo, nil)
+
+	_, _, err := e.Commit(context.Background(), uuid.Nil, 1, Change{
+		Actor: ActorCandidate, Origin: OriginEditor,
+		Ops: []Op{{Kind: OpSet, Path: mustParse(t, "experience[0].bullets[0]"), Value: "Keep edited"}},
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if got := len(repo.state.Experience[0].Bullets); got != 1 {
+		t.Fatalf("bullets = %d, want 1 after empty cleanup", got)
+	}
+}

--- a/internal/experience/AGENTS.md
+++ b/internal/experience/AGENTS.md
@@ -17,6 +17,13 @@ is one piece of evidence at the grain of a CV bullet.
 - **Import is additive.** Employments match case-insensitively on `(company, role)` and only
   their BLANK fields are filled; atoms match on the normalized claim and duplicates are
   skipped. A user who uploads a trimmed one-page CV must not lose the bank they built.
+- **Listing is reverse-chronological in the domain, not via `ORDER BY period_start`.** Dates
+  stay free-form display labels (`"October 2018"`, `"2024"`). Lexicographic SQL order puts
+  month names above years; `ListEmployments` re-sorts with a best-effort parsed key
+  (`internal/experience/period_sort.go`) so WorkHistory / CV seed / Professional agree.
+  Placeless publishable atoms are appended **after** dated roles (empty company/title,
+  highlights only) — they are not a titled job. A role-only row with empty company is a
+  normal employment from import/edit, not that placeless path.
 - **`is_current` is never written by import.** A CV that still reads "Present" for a role
   the user has ended would otherwise resurrect it.
 - **Ownership is a `WHERE user_id = $1`.** An entry the caller does not own is reported as

--- a/internal/experience/period_sort.go
+++ b/internal/experience/period_sort.go
@@ -1,0 +1,149 @@
+package experience
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/google/uuid"
+)
+
+// periodSortKey is a comparable YYYYMM (or 999999 for "current/present"). Zero means
+// unparseable — those rows sort after dated ones when ordering reverse-chronologically.
+type periodSortKey int
+
+const (
+	periodKeyUnknown periodSortKey = 0
+	periodKeyCurrent periodSortKey = 999999
+)
+
+// sortKeyForEmployment derives a reverse-chrono sort key from free-form period labels.
+// Prefer a concrete end date; treat Present/current as "now"; fall back to start.
+func sortKeyForEmployment(start, end string, current bool) periodSortKey {
+	if current || isPresentLabel(end) {
+		return periodKeyCurrent
+	}
+	if k, ok := parsePeriodLabel(end); ok {
+		return k
+	}
+	if k, ok := parsePeriodLabel(start); ok {
+		return k
+	}
+	return periodKeyUnknown
+}
+
+func isPresentLabel(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "present", "current", "now", "today":
+		return true
+	default:
+		return false
+	}
+}
+
+// parsePeriodLabel best-effort parses CV date labels into YYYYMM.
+// Supported: "2024", "2023-09", "2023/09", "Jan 2018", "January 2018", "Oct 2018".
+func parsePeriodLabel(raw string) (periodSortKey, bool) {
+	s := strings.TrimSpace(raw)
+	if s == "" || isPresentLabel(s) {
+		return 0, false
+	}
+	// Normalize separators and collapse spaces.
+	s = strings.ReplaceAll(s, "/", "-")
+	s = strings.Join(strings.Fields(s), " ")
+
+	if k, ok := parseYearMonth(s); ok {
+		return k, true
+	}
+	if k, ok := parseMonthYear(s); ok {
+		return k, true
+	}
+	if y, err := strconv.Atoi(s); err == nil && y >= 1900 && y <= 2100 {
+		return periodSortKey(y*100 + 1), true // January of that year as a floor
+	}
+	return 0, false
+}
+
+func parseYearMonth(s string) (periodSortKey, bool) {
+	// YYYY-MM or YYYY-M
+	parts := strings.Split(s, "-")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	y, errY := strconv.Atoi(parts[0])
+	m, errM := strconv.Atoi(parts[1])
+	if errY != nil || errM != nil || y < 1900 || y > 2100 || m < 1 || m > 12 {
+		return 0, false
+	}
+	return periodSortKey(y*100 + m), true
+}
+
+func parseMonthYear(s string) (periodSortKey, bool) {
+	parts := strings.Split(s, " ")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	m, ok := monthNumber(parts[0])
+	if !ok {
+		return 0, false
+	}
+	y, err := strconv.Atoi(parts[1])
+	if err != nil || y < 1900 || y > 2100 {
+		return 0, false
+	}
+	return periodSortKey(y*100 + m), true
+}
+
+func monthNumber(name string) (int, bool) {
+	n := strings.ToLower(strings.TrimFunc(name, func(r rune) bool {
+		return !unicode.IsLetter(r)
+	}))
+	months := map[string]int{
+		"january": 1, "jan": 1,
+		"february": 2, "feb": 2,
+		"march": 3, "mar": 3,
+		"april": 4, "apr": 4,
+		"may":  5,
+		"june": 6, "jun": 6,
+		"july": 7, "jul": 7,
+		"august": 8, "aug": 8,
+		"september": 9, "sep": 9, "sept": 9,
+		"october": 10, "oct": 10,
+		"november": 11, "nov": 11,
+		"december": 12, "dec": 12,
+	}
+	m, ok := months[n]
+	return m, ok
+}
+
+// sortEmploymentsChronological orders current roles first, then reverse-chronological by
+// derived period keys, then by id for stability. Display labels are not rewritten.
+func sortEmploymentsChronological(list []Employment) {
+	if len(list) < 2 {
+		return
+	}
+	type keyed struct {
+		e   Employment
+		key periodSortKey
+		id  uuid.UUID
+	}
+	items := make([]keyed, len(list))
+	for i, e := range list {
+		items[i] = keyed{e: e, key: sortKeyForEmployment(e.Start, e.End, e.Current), id: e.ID}
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a.e.Current != b.e.Current {
+			return a.e.Current // current first
+		}
+		if a.key != b.key {
+			return a.key > b.key // more recent first; unknown (0) last among non-current
+		}
+		// uuid string compare is enough for a stable deterministic tie-break in tests.
+		return a.id.String() < b.id.String()
+	})
+	for i := range items {
+		list[i] = items[i].e
+	}
+}

--- a/internal/experience/period_sort_test.go
+++ b/internal/experience/period_sort_test.go
@@ -1,0 +1,175 @@
+package experience
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestParsePeriodLabel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want periodSortKey
+		ok   bool
+	}{
+		{"2024", periodSortKey(202401), true},
+		{"2023-09", periodSortKey(202309), true},
+		{"2023/09", periodSortKey(202309), true},
+		{"Jan 2018", periodSortKey(201801), true},
+		{"January 2018", periodSortKey(201801), true},
+		{"Oct 2018", periodSortKey(201810), true},
+		{"October 2018", periodSortKey(201810), true},
+		{"May 2018", periodSortKey(201805), true},
+		{"Jun 2017", periodSortKey(201706), true},
+		{"Present", 0, false},
+		{"", 0, false},
+		{"sometime", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parsePeriodLabel(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("parsePeriodLabel(%q) = %d,%v want %d,%v", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestSortKeyPrefersEndThenStart(t *testing.T) {
+	if got := sortKeyForEmployment("2018-01", "2024", false); got != periodSortKey(202401) {
+		t.Errorf("end wins: got %d", got)
+	}
+	if got := sortKeyForEmployment("October 2018", "", false); got != periodSortKey(201810) {
+		t.Errorf("start fallback: got %d", got)
+	}
+	if got := sortKeyForEmployment("2010", "Present", false); got != periodKeyCurrent {
+		t.Errorf("Present end: got %d", got)
+	}
+	if got := sortKeyForEmployment("2010", "2020", true); got != periodKeyCurrent {
+		t.Errorf("current flag: got %d", got)
+	}
+	if got := sortKeyForEmployment("", "", false); got != periodKeyUnknown {
+		t.Errorf("unknown: got %d", got)
+	}
+}
+
+// Fixture matching a career scramble: lexicographic period_start DESC puts
+// Fabrikam ("2024") under month-named 2017–2018 roles. Chronological sort must not.
+func TestSortEmploymentsChronological_FabrikamBeforeNorthwind(t *testing.T) {
+	contoso := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	fabrikam := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	northwind := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	litware := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	woodgrove := uuid.MustParse("55555555-5555-5555-5555-555555555555")
+	adventure := uuid.MustParse("66666666-6666-6666-6666-666666666666")
+	unknown := uuid.MustParse("77777777-7777-7777-7777-777777777777")
+
+	// Deliberately inserted in the wrong (lexicographic-ish) order.
+	list := []Employment{
+		{ID: northwind, Company: "Northwind", Start: "October 2018", End: "2024"},
+		{ID: litware, Company: "Litware", Start: "May 2018", End: "Aug 2018"},
+		{ID: adventure, Company: "Adventure Works", Start: "Jun 2017", End: "Dec 2017"},
+		{ID: woodgrove, Company: "Woodgrove", Start: "Jan 2018", End: "Apr 2018"},
+		{ID: fabrikam, Company: "Fabrikam", Start: "2024", End: "2025"},
+		{ID: contoso, Company: "Contoso", Start: "2025", End: "Present", Current: true},
+		{ID: unknown, Company: "Mystery", Start: "", End: ""},
+	}
+	sortEmploymentsChronological(list)
+
+	want := []string{"Contoso", "Fabrikam", "Northwind", "Litware", "Woodgrove", "Adventure Works", "Mystery"}
+	got := make([]string, len(list))
+	for i, e := range list {
+		got[i] = e.Company
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestListEmployments_SortsChronologically(t *testing.T) {
+	s, _ := newStore()
+	ctx := context.Background()
+	for _, e := range []Employment{
+		{Kind: KindJob, Company: "Northwind", Role: "Staff", Start: "October 2018", End: "2024"},
+		{Kind: KindJob, Company: "Adventure Works", Role: "BE", Start: "Jun 2017", End: "Dec 2017"},
+		{Kind: KindJob, Company: "Fabrikam", Role: "Staff", Start: "2024", End: "2025"},
+		{Kind: KindJob, Company: "Contoso", Role: "Staff", Start: "2025", End: "Present", Current: true},
+	} {
+		if _, err := s.CreateEmployment(ctx, owner, e); err != nil {
+			t.Fatalf("CreateEmployment: %v", err)
+		}
+	}
+	got, err := s.ListEmployments(ctx, owner)
+	if err != nil {
+		t.Fatalf("ListEmployments: %v", err)
+	}
+	want := []string{"Contoso", "Fabrikam", "Northwind", "Adventure Works"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Company != want[i] {
+			t.Fatalf("order companies = %v, want %v", employmentCompanies(got), want)
+		}
+	}
+
+	hist, err := s.WorkHistory(ctx, owner)
+	if err != nil {
+		t.Fatalf("WorkHistory: %v", err)
+	}
+	for i := range want {
+		if hist[i].Company != want[i] {
+			comps := make([]string, len(hist))
+			for j, h := range hist {
+				comps[j] = h.Company
+			}
+			t.Fatalf("WorkHistory order = %v, want %v", comps, want)
+		}
+	}
+}
+
+// Placeless publishable atoms trail dated roles — they must not sort into the middle of
+// the career list as a fake titled job (US1b scenario 4).
+func TestWorkHistory_PlacelessTrailsChronologicalRoles(t *testing.T) {
+	s, _ := newStore()
+	ctx := context.Background()
+	for _, e := range []Employment{
+		{Kind: KindJob, Company: "Northwind", Role: "Staff", Start: "October 2018", End: "2024"},
+		{Kind: KindJob, Company: "Contoso", Role: "Staff", Start: "2025", End: "Present", Current: true},
+	} {
+		if _, err := s.CreateEmployment(ctx, owner, e); err != nil {
+			t.Fatalf("CreateEmployment: %v", err)
+		}
+	}
+	if _, err := s.AddAtom(ctx, owner, Atom{
+		Claim: "Certified cloud architect", Provenance: ProvenanceStatedInChat,
+	}); err != nil {
+		t.Fatalf("AddAtom placeless: %v", err)
+	}
+	hist, err := s.WorkHistory(ctx, owner)
+	if err != nil {
+		t.Fatalf("WorkHistory: %v", err)
+	}
+	if len(hist) != 3 {
+		t.Fatalf("len = %d, want 3 (2 roles + placeless)", len(hist))
+	}
+	if hist[0].Company != "Contoso" || hist[1].Company != "Northwind" {
+		t.Fatalf("roles = %q, %q, want Contoso then Northwind", hist[0].Company, hist[1].Company)
+	}
+	last := hist[2]
+	if last.Company != "" || last.Title != "" {
+		t.Fatalf("placeless entry = %+v, want empty company/title", last)
+	}
+	if len(last.Highlights) != 1 || last.Highlights[0] != "Certified cloud architect" {
+		t.Fatalf("placeless highlights = %q", last.Highlights)
+	}
+}
+
+func employmentCompanies(list []Employment) []string {
+	out := make([]string, len(list))
+	for i, e := range list {
+		out[i] = e.Company
+	}
+	return out
+}

--- a/internal/experience/professional.go
+++ b/internal/experience/professional.go
@@ -95,6 +95,10 @@ func experienceFromBank(employments []Employment, atoms []Atom) []resumeextract.
 	// in an entry that names NO place rather than under an invented one: an empty company
 	// is how this shape says "no place", and inventing a heading would be a fabrication in
 	// the projection whose whole job is to carry only what is true.
+	//
+	// Always appended AFTER dated employments so chronological sort of roles cannot place
+	// a blank-header evidence block between jobs. A titled orphan with empty company (role
+	// set, no company) is a separate bank row from import/edit — not this placeless path.
 	if len(placeless) > 0 {
 		out = append(out, resumeextract.Experience{Highlights: placeless})
 	}

--- a/internal/experience/professional_test.go
+++ b/internal/experience/professional_test.go
@@ -134,6 +134,44 @@ func TestProfessionalWithholdsUnpublishableAtoms(t *testing.T) {
 	}
 }
 
+// Chronological re-sort must not widen what reaches a CV: agent_inferred stays bank-only
+// while free-form period labels still order roles correctly for Reset / stale-base reseed.
+func TestWorkHistory_ChronologyKeepsProvenanceGate(t *testing.T) {
+	s := seedBank(t, []Employment{
+		{Kind: KindJob, Company: "Northwind", Role: "Staff", Start: "October 2018", End: "2024"},
+		{Kind: KindJob, Company: "Fabrikam", Role: "Staff", Start: "2024", End: "2025"},
+	}, []Atom{
+		{Claim: "Confirmed at Fabrikam", Provenance: ProvenanceCVImport},
+		{Claim: "Model paraphrase at Fabrikam", Provenance: ProvenanceAgentInferred},
+		{Claim: "Confirmed at Northwind", Provenance: ProvenanceStatedInChat},
+		{Claim: "Unplaced model guess", Provenance: ProvenanceAgentInferred},
+		{Claim: "Unplaced confirmed cert", Provenance: ProvenanceManual},
+	}, []int{1, 1, 0, -1, -1})
+
+	hist, err := s.WorkHistory(context.Background(), owner)
+	if err != nil {
+		t.Fatalf("WorkHistory: %v", err)
+	}
+	if len(hist) != 3 {
+		t.Fatalf("roles = %d, want Fabrikam + Northwind + placeless bucket", len(hist))
+	}
+	if hist[0].Company != "Fabrikam" || hist[1].Company != "Northwind" {
+		t.Fatalf("order = [%s, %s], want Fabrikam then Northwind (not lexicographic label order)", hist[0].Company, hist[1].Company)
+	}
+	if len(hist[0].Highlights) != 1 || hist[0].Highlights[0] != "Confirmed at Fabrikam" {
+		t.Errorf("Fabrikam highlights = %q, want only the confirmed claim", hist[0].Highlights)
+	}
+	if len(hist[1].Highlights) != 1 || hist[1].Highlights[0] != "Confirmed at Northwind" {
+		t.Errorf("Northwind highlights = %q, want only the confirmed claim", hist[1].Highlights)
+	}
+	if hist[2].Company != "" || hist[2].Title != "" {
+		t.Errorf("placeless entry = %+v, want blank place", hist[2])
+	}
+	if len(hist[2].Highlights) != 1 || hist[2].Highlights[0] != "Unplaced confirmed cert" {
+		t.Errorf("placeless highlights = %q, want only the confirmed claim", hist[2].Highlights)
+	}
+}
+
 // Evidence with no place is still evidence. Dropping it would defeat the change's whole
 // claim — that the fit analysis begins to see what a candidate confirmed in chat — so it
 // is carried in an entry that names no place rather than a fabricated one.

--- a/internal/experience/store.go
+++ b/internal/experience/store.go
@@ -49,7 +49,9 @@ type Store struct{ repo Repository }
 // NewStore builds a Store over an owner-scoped Repository.
 func NewStore(repo Repository) *Store { return &Store{repo: repo} }
 
-// ListEmployments returns the owner's places of work, current roles first.
+// ListEmployments returns the owner's places of work in reverse chronological order
+// (current roles first). Free-form period labels are sorted via a parsed key — not raw
+// `ORDER BY period_start` text order.
 func (s *Store) ListEmployments(ctx context.Context, userID int64) ([]Employment, error) {
 	rows, err := s.repo.ListEmployments(ctx, userID)
 	if err != nil {
@@ -59,6 +61,10 @@ func (s *Store) ListEmployments(ctx context.Context, userID int64) ([]Employment
 	for _, row := range rows {
 		out = append(out, employmentFromRow(row))
 	}
+	// SQL ORDER BY period_start is lexicographic on free-form labels ("October 2018"
+	// ranks above "2024"). Re-sort here so every bank reader (WorkHistory, seed,
+	// Professional) sees reverse-chronological roles.
+	sortEmploymentsChronological(out)
 	return out, nil
 }
 

--- a/internal/handler/AGENTS.md
+++ b/internal/handler/AGENTS.md
@@ -89,6 +89,7 @@ has not replaced it yet:
 | `GET /assistant/sessions/:id` | one conversation with its stored transcript, for replay |
 | `DELETE /assistant/sessions/:id` | remove a conversation and its transcript |
 | `POST /assistant/sessions/:id/messages` | run one turn, streamed as named SSE events |
+| `POST /assistant/sessions/:id/retry` | resume after a failed turn without appending another user message (same SSE stream) |
 | `POST /assistant/sessions/:id/autopilot` | run the tailoring pass unattended — same stream, server-owned brief and ceiling (**cookie-only**) |
 
 A session the caller does not own is a 404, never a 403, so ids stay unprobeable.

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -39,6 +40,8 @@ type assistantHandlers struct {
 	// keys resolves the credential a turn spends under. Nil in a deployment that does
 	// not attribute spend, which every path treats as "spend on the service credential".
 	keys *llmkey.Resolver
+	// maxPrompt is the rune ceiling on one user message (ASSISTANT_MAX_PROMPT).
+	maxPrompt int
 
 	// turns are the turns running right now, so a cancel request can reach one that is
 	// streaming on a goroutine no request owns any more, and so a session keeps to one turn
@@ -81,8 +84,9 @@ type assistantModels struct {
 	Agent *llm.Client
 	// Keys names the caller on the gateway. Nil is ordinary rather than degraded: every
 	// turn then spends on the service credential, exactly as it did before attribution.
-	Keys     *llmkey.Resolver
-	MaxSteps int
+	Keys      *llmkey.Resolver
+	MaxSteps  int
+	MaxPrompt int
 }
 
 // newAssistantHandlers wires the agent.
@@ -114,6 +118,10 @@ func newAssistantHandlers(queries *db.Queries, models assistantModels, store *as
 		h.runner = assistant.NewRunner(models.Agent, h.store, assistant.RunnerConfig{MaxSteps: models.MaxSteps})
 	}
 	h.keys = models.Keys
+	h.maxPrompt = models.MaxPrompt
+	if h.maxPrompt < 1 {
+		h.maxPrompt = defaultAssistantMaxPrompt
+	}
 	return h
 }
 
@@ -135,14 +143,17 @@ func (h *assistantHandlers) register(api fiber.Router, mw middleware) {
 	api.Post("/assistant/sessions/:id/messages", mw.key, h.PostAssistantMessage)
 	api.Post("/assistant/sessions/:id/cancel", mw.key, h.CancelAssistantTurn)
 	api.Post("/assistant/sessions/:id/opening", mw.key, h.PostAssistantOpening)
+	// Resume after a transport/model failure without appending another user message —
+	// re-sending the prompt would duplicate it in the model's context.
+	api.Post("/assistant/sessions/:id/retry", mw.key, h.PostAssistantRetry)
 	// Cookie-only: an unattended run rewrites a CV, and the browser is the only place
 	// the candidate can watch it happen and undo it.
 	api.Post("/assistant/sessions/:id/autopilot", mw.cookie, h.PostAssistantAutopilot)
 }
 
-// assistantMaxPrompt bounds one user message. The agent's context is finite and a
-// pasted job board is not a question; the limit is generous for prose.
-const assistantMaxPrompt = 8000
+// defaultAssistantMaxPrompt bounds one user message when ASSISTANT_MAX_PROMPT is
+// unset. The agent's context is finite and a pasted job board is not a question.
+const defaultAssistantMaxPrompt = 8000
 
 // sessionResponse is the wire shape of one conversation.
 type sessionResponse struct {
@@ -440,10 +451,55 @@ func (h *assistantHandlers) PostAssistantMessage(c *fiber.Ctx) error {
 	if prompt == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "text is required")
 	}
-	if len([]rune(prompt)) > assistantMaxPrompt {
+	if len([]rune(prompt)) > h.maxPrompt {
 		return fiber.NewError(fiber.StatusBadRequest, "message is too long")
 	}
 	return h.streamTurn(c, sess, prompt, assistant.TurnConfig{})
+}
+
+// PostAssistantRetry resumes a session after a model/transport failure without recording
+// another user message. Re-posting the same prompt would leave two copies in the
+// transcript and in the model's context; Continue keeps the history as it is (healing
+// any dangling tool_use from the interrupted turn) and runs the loop again.
+func (h *assistantHandlers) PostAssistantRetry(c *fiber.Ctx) error {
+	sess, err := h.ownedSession(c)
+	if err != nil {
+		return err
+	}
+	if h.runner == nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "the assistant is not available")
+	}
+	transcript, err := h.store.Transcript(c.Context(), sess.ID)
+	if err != nil {
+		return err
+	}
+	if lastUserText(transcript) == "" {
+		return fiber.NewError(fiber.StatusConflict, "nothing to retry — send a message first")
+	}
+	turn := assistant.TurnConfig{}
+	// A failed unattended run already spent under the raised ceiling; keep it so a retry
+	// is not cut short at the ordinary chat bound.
+	if sess.Preset == assistant.PresetTailor && lastUserText(transcript) == autopilotBrief {
+		turn.MaxSteps = autopilotMaxSteps
+	}
+	return h.streamContinue(c, sess, turn)
+}
+
+// lastUserText returns the text of the most recent user message, or "" when none.
+func lastUserText(transcript []assistant.Message) string {
+	for i := len(transcript) - 1; i >= 0; i-- {
+		if transcript[i].Role != assistant.RoleUser {
+			continue
+		}
+		var c struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(transcript[i].Content, &c); err != nil {
+			return ""
+		}
+		return c.Text
+	}
+	return ""
 }
 
 // streamTurn runs one turn and writes it to the response as SSE. It is shared by every
@@ -454,6 +510,25 @@ func (h *assistantHandlers) PostAssistantMessage(c *fiber.Ctx) error {
 // body: an unattended run's brief and its raised ceiling are ours to choose, and a ceiling
 // a client can set is not a bound.
 func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, prompt string, turn assistant.TurnConfig) error {
+	return h.streamSSE(c, sess, func(ctx context.Context, runner *assistant.Runner, reg *assistant.Registry, system string, emit func(assistant.Event)) error {
+		return runner.Run(ctx, sess, reg, system, prompt, turn, emit)
+	})
+}
+
+// streamContinue is streamTurn for a retry: same SSE machinery, no new prompt.
+func (h *assistantHandlers) streamContinue(c *fiber.Ctx, sess assistant.Session, turn assistant.TurnConfig) error {
+	return h.streamSSE(c, sess, func(ctx context.Context, runner *assistant.Runner, reg *assistant.Registry, system string, emit func(assistant.Event)) error {
+		return runner.Continue(ctx, sess, reg, system, turn, emit)
+	})
+}
+
+// streamSSE owns the SSE headers, turn claim/queue, keepalive and writer. start is the
+// one difference between a fresh message and a retry.
+func (h *assistantHandlers) streamSSE(
+	c *fiber.Ctx,
+	sess assistant.Session,
+	start func(context.Context, *assistant.Runner, *assistant.Registry, string, func(assistant.Event)) error,
+) error {
 	// One batch per turn. Every CV edit the agent makes in this turn is filed under it, so
 	// the history can group them and "undo the run" is undoing a batch — which is what
 	// retires the single pre-run snapshot and the edge two concurrent runs used to create.
@@ -531,7 +606,7 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 		}
 		defer h.turns.release(sess.ID, slot)
 
-		err = turnRunner.Run(ctx, sess, registry, system, prompt, turn, func(e assistant.Event) {
+		err = start(ctx, turnRunner, registry, system, func(e assistant.Event) {
 			// A write that fails means THIS reader is not listening: a phone froze its tab,
 			// a tunnel dropped, a laptop slept. It does not mean the work should stop, and
 			// treating it that way threw away live runs — a tailoring pass lost its report
@@ -544,6 +619,11 @@ func (h *assistantHandlers) streamTurn(c *fiber.Ctx, sess assistant.Session, pro
 			stream.event(string(e.Kind), e)
 		})
 		if err != nil {
+			// Nothing to continue is a client mistake (empty session), not a turn fault —
+			// surface it as a conflict on the still-open stream rather than Sentry noise.
+			if errors.Is(err, assistant.ErrNothingToContinue) {
+				return
+			}
 			// The loop has already emitted its terminal error event; this is for us —
 			// and for Sentry, which would otherwise never learn of it: this handler
 			// returned nil long before the turn ran, so RenderError never sees the

--- a/internal/handler/assistant_cv_tools.go
+++ b/internal/handler/assistant_cv_tools.go
@@ -410,12 +410,15 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 		Name: "cv_edit",
 		Description: "Edit the CV. Send every edit that belongs together in one call — they land as one " +
 			"entry in the candidate's history and cost one round instead of several. Address things by " +
-			"their path from cv_get. Anything that states what the candidate did (a bullet, a summary, a " +
-			"technology, a skill) needs `evidence_id` from experience_search; if the bank holds nothing " +
-			"on the point, ask the candidate and record their answer with experience_add first. Contact " +
-			"details are not editable here. If this batch closes a requirement from cv_context, pass " +
-			"`requirement` and `requirement_status` — the report updates in this same call, so you do not " +
-			"need a separate tailor_report call for it.",
+			"their path from cv_get. Each experience (and project) holds at most " + fmt.Sprintf("%d", cv.MaxBullets) +
+			" bullets; when full, " +
+			"`set` an existing index or `remove` one before inserting — an insert past the cap is refused " +
+			"and no existing bullet is deleted. Anything that states what the candidate did (a bullet, a " +
+			"summary, a technology, a skill) needs `evidence_id` from experience_search; if the bank holds " +
+			"nothing on the point, ask the candidate and record their answer with experience_add first. " +
+			"Contact details are not editable here. If this batch closes a requirement from cv_context, " +
+			"pass `requirement` and `requirement_status` — the report updates in this same call, so you " +
+			"do not need a separate tailor_report call for it.",
 		Schema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -496,6 +497,57 @@ func TestCVEditWritesACitedBullet(t *testing.T) {
 	}
 	if !strings.Contains(string(repo.written), "Kafka") {
 		t.Errorf("the bullet was not written: %s", repo.written)
+	}
+}
+
+func TestCVEditToolRefusesAnOverCapInsert(t *testing.T) {
+	prev := cv.MaxBullets
+	cv.SetMaxBullets(20)
+	t.Cleanup(func() { cv.SetMaxBullets(prev) })
+
+	bullets := make([]string, cv.MaxBullets)
+	for i := range bullets {
+		bullets[i] = fmt.Sprintf("Original bullet %d", i+1)
+	}
+	doc, err := json.Marshal(cv.Document{
+		Experience: []cv.ExperienceItem{{
+			Role: "Staff Engineer", Company: "Contoso", Bullets: bullets,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "extra", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, string(doc), bank)
+	before := append([]byte(nil), repo.data...)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err = tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"insert","path":"experience[0].bullets[0]","value":"extra claim",`+
+			`"evidence_id":"`+atom.ID.String()+`"}]}`))
+	if err == nil {
+		t.Fatal("over-cap insert was accepted")
+	}
+	if !errors.Is(err, cvedit.ErrListCap) && !strings.Contains(err.Error(), cvedit.ListCapCode) {
+		t.Fatalf("error = %v, want ErrListCap / %s", err, cvedit.ListCapCode)
+	}
+	if repo.written != nil {
+		t.Fatalf("CV was written on refuse: %s", repo.written)
+	}
+	if string(repo.data) != string(before) {
+		t.Fatal("stored CV data changed on a refused over-cap edit")
+	}
+}
+
+func TestCVEditToolDescriptionNamesTheBulletCeiling(t *testing.T) {
+	tool := toolByName(t, (&assistantHandlers{}).assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	want := fmt.Sprintf("%d", cv.MaxBullets)
+	if !strings.Contains(tool.Description, want) {
+		t.Fatalf("cv_edit description missing live MaxBullets %s: %s", want, tool.Description)
+	}
+	if !strings.Contains(strings.ToLower(tool.Description), "refused") {
+		t.Fatalf("cv_edit description should say an over-cap insert is refused: %s", tool.Description)
 	}
 }
 

--- a/internal/handler/assistant_integration_test.go
+++ b/internal/handler/assistant_integration_test.go
@@ -60,6 +60,7 @@ func newAssistantApp(pool *pgxpool.Pool, iss *auth.Issuer, model assistant.Model
 	bank := experience.NewStore(experience.NewQueriesRepository(queries))
 	h := &assistantHandlers{
 		store: assistant.NewStore(queries), queries: queries,
+		maxPrompt: defaultAssistantMaxPrompt,
 		// A rehearsal resolves its application through the same store the production
 		// wiring gives it; without this the ownership check reports the assistant
 		// unavailable and the 404 under test would never be reached.

--- a/internal/handler/assistant_profile_tool_integration_test.go
+++ b/internal/handler/assistant_profile_tool_integration_test.go
@@ -77,6 +77,7 @@ func newProfileAssistantApp(pool *pgxpool.Pool, iss *auth.Issuer, model assistan
 	)
 	h := &assistantHandlers{
 		store: assistant.NewStore(queries), queries: queries, profile: profileH, experience: bank,
+		maxPrompt: defaultAssistantMaxPrompt,
 	}
 	h.runner = assistant.NewRunner(model, h.store, assistant.RunnerConfig{MaxSteps: 3})
 

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -74,7 +74,9 @@ type jobReader interface {
 	GetJob(ctx context.Context, id int64) (db.Job, error)
 }
 
-func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, assistantSessions *assistant.Store, cvRenderer cv.Renderer, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate) *cvHandlers {
+// refuseListCap is normally true (Commit refuses over-cap edits). Pass false only when
+// an operator has turned on CV_EDIT_ALLOW_BULLET_TRUNCATION.
+func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, assistantSessions *assistant.Store, cvRenderer cv.Renderer, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate, refuseListCap bool) *cvHandlers {
 	h := &cvHandlers{
 		cvStore:           cvStore,
 		assistantSessions: assistantSessions,
@@ -93,7 +95,7 @@ func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, a
 		// something attached afterwards: PATCH /me/cvs/:id edits as the agent for any
 		// API-key caller, so the wall cannot depend on which other features the assembly
 		// built.
-		editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), gate),
+		editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), gate).SetRefuseListCap(refuseListCap),
 		jobReader:          queries,
 		resume:             resumeStore,
 		photos:             photoStore,
@@ -145,6 +147,9 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 	// the edit + context/get/render reads with its minted API key (keyAuth = cookie or Bearer).
 	api.Post("/me/cvs/tailor", mw.cookie, h.TailorCV)
 	api.Post("/me/cvs/:id/tailor-session", mw.cookie, h.StartTailorSession)
+	// Rebuild this tailored CV (and the base) from the current résumé seed. Cookie-only:
+	// destructive whole-document replace; the browser is where the candidate confirms it.
+	api.Post("/me/cvs/:id/reset-from-resume", mw.cookie, h.ResetCVFromResume)
 	api.Patch("/me/cvs/:id", mw.key, h.PatchCV)
 	api.Put("/me/cvs/:id/session", mw.key, h.SetCVSession)
 	api.Get("/me/cvs/:id/tailor-context", mw.key, h.TailorContext)
@@ -624,6 +629,13 @@ func mapCVError(err error) error {
 			strings.TrimPrefix(err.Error(), cvedit.ErrInvalidOp.Error()+": "))
 	case errors.Is(err, cvedit.ErrForbiddenPath), errors.Is(err, cvedit.ErrEvidenceRequired):
 		return fiber.NewError(fiber.StatusForbidden, err.Error())
+	case errors.Is(err, cvedit.ErrListCap):
+		// Candidate-facing: no internal prefixes, clear that nothing was deleted.
+		if msg := cvedit.UserListCapMessage(err); msg != "" {
+			return fiber.NewError(fiber.StatusConflict, msg)
+		}
+		return fiber.NewError(fiber.StatusConflict,
+			"this role already has the maximum number of bullet points; nothing was changed")
 	case errors.Is(err, cvedit.ErrNothingToUndo):
 		return fiber.NewError(fiber.StatusConflict, "there is nothing to undo")
 	case errors.Is(err, cvedit.ErrCannotUndo):

--- a/internal/handler/cv_evidence_gate_integration_test.go
+++ b/internal/handler/cv_evidence_gate_integration_test.go
@@ -55,6 +55,7 @@ func newCVAPIWithoutAssistant(t *testing.T) (*cvHandlers, *auth.Issuer, *fiber.A
 		creditsStore,
 		&matchHandlers{credits: creditsStore},
 		bankGate{bank: bank},
+		true,
 	)
 
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})

--- a/internal/handler/cv_listcap_test.go
+++ b/internal/handler/cv_listcap_test.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/cvedit"
+)
+
+func TestMapCVErrorListCapIsConflictWithSafeMessage(t *testing.T) {
+	raw := fmt.Errorf("%w: %s: Staff Engineer at Contoso already has %d bullets (the maximum). "+
+		"The edit was not applied and no existing bullets were deleted. "+
+		"Set an existing bullet or remove one before inserting",
+		cvedit.ErrListCap, cvedit.ListCapCode, cv.MaxBullets)
+
+	mapped := mapCVError(raw)
+	var fe *fiber.Error
+	if !errors.As(mapped, &fe) {
+		t.Fatalf("mapCVError = %T %v, want *fiber.Error", mapped, mapped)
+	}
+	if fe.Code != fiber.StatusConflict {
+		t.Fatalf("status = %d, want %d", fe.Code, fiber.StatusConflict)
+	}
+	want := cvedit.UserListCapMessage(raw)
+	if fe.Message != want {
+		t.Fatalf("message = %q, want %q", fe.Message, want)
+	}
+	if want == "" || fe.Message == raw.Error() {
+		t.Fatal("HTTP message must be the candidate-safe UserListCapMessage, not the raw ErrListCap")
+	}
+}

--- a/internal/handler/cv_reset.go
+++ b/internal/handler/cv_reset.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"log"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/cvedit"
+)
+
+// ResetCVFromResume rebuilds a tailored CV's content from the current résumé seed
+// (experience bank + structured extract — the same source first-time tailor uses), keeps
+// the same CV id and agent session, and refreshes the base CV from that same seed so ATS
+// delta and future bootstraps stay aligned. Cookie-only: destructive whole-document replace.
+//
+// Upload does not do this. Upload refreshes the seed source; this is the explicit apply.
+func (h *cvHandlers) ResetCVFromResume(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := cvPathID(c)
+	if err != nil {
+		return err
+	}
+
+	// Ownership before seed: a foreign id must 404 even when the caller has no résumé
+	// (otherwise "add a résumé" would leak that the CV exists).
+	rec, err := h.cvStore.Get(c.Context(), id, userID)
+	if err != nil {
+		return mapCVError(err)
+	}
+	if !rec.IsTailored {
+		return fiber.NewError(fiber.StatusConflict, "reset from résumé is only for a tailored CV")
+	}
+
+	st, ok, err := h.seedSource().Structured(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fiber.NewError(fiber.StatusConflict, "add a résumé before resetting from it")
+	}
+	seeded := cv.Seed(st)
+
+	if err := h.reseedBaseFromSeed(c, userID, seeded); err != nil {
+		return err
+	}
+
+	_, _, err = h.editor.CommitDocument(c.Context(), id, userID,
+		cvedit.ActorCandidate, cvedit.OriginImport,
+		applySeedContent(cvedit.State{
+			Title:      rec.Title,
+			TemplateID: rec.TemplateID,
+			Document:   rec.Document,
+		}, seeded))
+	if err != nil {
+		return mapCVError(err)
+	}
+
+	out, err := h.cvStore.Get(c.Context(), id, userID)
+	if err != nil {
+		return mapCVError(err)
+	}
+	return c.JSON(fiber.Map{"data": recordResponse(out)})
+}
+
+// reseedBaseFromSeed refreshes the current base CV from seeded content, or creates one when
+// the user has none. Presentation on an existing base is preserved.
+func (h *cvHandlers) reseedBaseFromSeed(c *fiber.Ctx, userID int64, seeded cv.Document) error {
+	base, ok, err := h.cvStore.BaseCV(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		meta, err := h.cvStore.Create(c.Context(), userID, "My CV", cv.DefaultTemplateID, seeded)
+		if err != nil {
+			return err
+		}
+		// Best-effort history milestone — same pattern as TailorCV opening a tailored copy.
+		if _, err := h.editor.Seed(c.Context(), meta.ID, userID, "Created from your résumé"); err != nil {
+			log.Printf("cv: seeding the revision history for base %s: %v", meta.ID, err)
+		}
+		return nil
+	}
+	_, _, err = h.editor.CommitDocument(c.Context(), base.ID, userID,
+		cvedit.ActorCandidate, cvedit.OriginImport,
+		applySeedContent(cvedit.State{
+			Title:      base.Title,
+			TemplateID: base.TemplateID,
+			Document:   base.Document,
+		}, seeded))
+	return mapCVError(err)
+}
+
+// reseedBaseIfStaleVsUpload refreshes the base from bankedSeeder when it predates the
+// caller's current résumé upload. No-op when there is no base, no upload stamp, the base
+// was edited at/after the upload, or the seed is unusable.
+func (h *cvHandlers) reseedBaseIfStaleVsUpload(c *fiber.Ctx, userID int64) error {
+	if h.resume == nil {
+		return nil
+	}
+	uploadedAt, err := h.resume.UploadedAt(c.Context(), userID)
+	if err != nil || uploadedAt == nil {
+		return err
+	}
+	base, ok, err := h.cvStore.BaseCV(c.Context(), userID)
+	if err != nil || !ok {
+		return err
+	}
+	if !base.UpdatedAt.Before(*uploadedAt) {
+		return nil
+	}
+	st, usable, err := h.seedSource().Structured(c.Context(), userID)
+	if err != nil || !usable {
+		return err
+	}
+	return h.reseedBaseFromSeed(c, userID, cv.Seed(st))
+}

--- a/internal/handler/cv_reset_integration_test.go
+++ b/internal/handler/cv_reset_integration_test.go
@@ -1,0 +1,236 @@
+//go:build integration
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/resumeextract"
+)
+
+func buildResetApp(h *cvHandlers, iss *auth.Issuer) *fiber.App {
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	saved := auth.RequireAuth(iss, testVersions)
+	keyAuth := auth.RequireAuthOrScopedKey(iss, testVersions, apiKeys{h.queries}, auth.ScopeCV)
+	app.Get("/api/v1/me/cvs/:id", keyAuth, h.GetCV)
+	app.Post("/api/v1/me/cvs/:id/reset-from-resume", saved, h.ResetCVFromResume)
+	return app
+}
+
+type resetFixture struct {
+	h        *cvHandlers
+	app      *fiber.App
+	iss      *auth.Issuer
+	pool     *pgxpool.Pool
+	token    string
+	userID   int64
+	base     cv.Meta
+	tailored cv.Meta
+	store    *cv.Store
+}
+
+func newResetFixture(t *testing.T) resetFixture {
+	t.Helper()
+	h, iss, pool := newTailorAPI(t)
+	userID := seedAccount(t, pool, "reset@example.com", false)
+	tok, err := iss.Issue(userID, 1)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+
+	ctx := context.Background()
+	blob, _ := json.Marshal(resumeextract.Structured{
+		FullName: "Ada Lovelace",
+		Email:    "ada@example.com",
+		Summary:  "Résumé seed summary",
+		Skills:   []string{"Go", "PostgreSQL"},
+	})
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = now(),
+		 resume_structured = $2, resume_structured_uploaded_at = now(),
+		 resume_structured_model = 'test' WHERE id = $1`,
+		userID, blob); err != nil {
+		t.Fatalf("seed structured: %v", err)
+	}
+
+	store := h.cvStore
+	base, err := store.Create(ctx, userID, "My CV", cv.DefaultTemplateID, cv.Document{
+		Margins: cv.Margins{Top: 0.75, Right: 0.75, Bottom: 0.75, Left: 0.75},
+		Style:   cv.Style{FontSize: 11},
+		Header:  cv.Header{FullName: "Old Base"},
+		Summary: "old base summary",
+	})
+	if err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	jobID := seedJobSlug(t, pool, "reset-job-"+uuid.NewString()[:8])
+	tailored, err := store.CreateTailored(ctx, userID, jobID, "Tailored for Role", cv.DefaultTemplateID, cv.Document{
+		Margins: cv.Margins{Top: 0.6, Right: 0.6, Bottom: 0.6, Left: 0.6},
+		Style:   cv.Style{FontSize: 10.5, LineHeight: 0.5},
+		Header:  cv.Header{FullName: "Old Tailored"},
+		Summary: "old tailored summary",
+	})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+	if err := store.SetSession(ctx, tailored.ID, userID, "sess-keep"); err != nil {
+		t.Fatalf("set session: %v", err)
+	}
+
+	return resetFixture{
+		h: h, app: buildResetApp(h, iss), iss: iss, pool: pool, token: tok,
+		userID: userID, base: base, tailored: tailored, store: store,
+	}
+}
+
+func TestResetCVFromResume_HappyPath(t *testing.T) {
+	f := newResetFixture(t)
+	path := "/api/v1/me/cvs/" + f.tailored.ID.String() + "/reset-from-resume"
+	resp := doCV(t, f.app, fiber.MethodPost, path, f.token, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var out struct {
+		Data cvResponse `json:"data"`
+	}
+	decodeJSON(t, resp, &out)
+	if out.Data.ID != f.tailored.ID.String() {
+		t.Fatalf("id = %s, want same tailored id %s", out.Data.ID, f.tailored.ID)
+	}
+	if out.Data.Document.Header.FullName != "Ada Lovelace" || out.Data.Document.Summary != "Résumé seed summary" {
+		t.Fatalf("tailored content = %+v / %q, want résumé seed", out.Data.Document.Header, out.Data.Document.Summary)
+	}
+	if out.Data.Document.Margins.Top != 0.6 || out.Data.Document.Style.FontSize != 10.5 {
+		t.Fatalf("tailored presentation clobbered: margins=%+v style=%+v", out.Data.Document.Margins, out.Data.Document.Style)
+	}
+	if out.Data.AgentSessionID != "sess-keep" {
+		t.Fatalf("session = %q, want sess-keep", out.Data.AgentSessionID)
+	}
+
+	base, ok, err := f.store.BaseCV(context.Background(), f.userID)
+	if err != nil || !ok {
+		t.Fatalf("BaseCV: ok=%v err=%v", ok, err)
+	}
+	if base.ID != f.base.ID {
+		t.Fatalf("base id changed: %s → %s", f.base.ID, base.ID)
+	}
+	if base.Document.Header.FullName != "Ada Lovelace" || base.Document.Summary != "Résumé seed summary" {
+		t.Fatalf("base content = %+v / %q", base.Document.Header, base.Document.Summary)
+	}
+	if base.Document.Margins.Top != 0.75 || base.Document.Style.FontSize != 11 {
+		t.Fatalf("base presentation clobbered: margins=%+v style=%+v", base.Document.Margins, base.Document.Style)
+	}
+}
+
+func TestResetCVFromResume_CreatesBaseWhenAbsent(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	userID := seedAccount(t, pool, "nobase@example.com", false)
+	tok, _ := iss.Issue(userID, 1)
+	ctx := context.Background()
+	blob, _ := json.Marshal(resumeextract.Structured{FullName: "New Ada", Summary: "from seed"})
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = now(),
+		 resume_structured = $2, resume_structured_uploaded_at = now() WHERE id = $1`,
+		userID, blob); err != nil {
+		t.Fatalf("seed structured: %v", err)
+	}
+	jobID := seedJobSlug(t, pool, "nobase-"+uuid.NewString()[:8])
+	tailored, err := h.cvStore.CreateTailored(ctx, userID, jobID, "Only Tailored", cv.DefaultTemplateID, cv.Document{
+		Summary: "stale",
+	})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/"+tailored.ID.String()+"/reset-from-resume", tok, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body = %s", resp.StatusCode, body)
+	}
+	base, ok, err := h.cvStore.BaseCV(ctx, userID)
+	if err != nil || !ok {
+		t.Fatalf("expected a base CV after reset: ok=%v err=%v", ok, err)
+	}
+	if base.Document.Header.FullName != "New Ada" {
+		t.Fatalf("new base FullName = %q", base.Document.Header.FullName)
+	}
+}
+
+func TestResetCVFromResume_BaseTarget409(t *testing.T) {
+	f := newResetFixture(t)
+	path := "/api/v1/me/cvs/" + f.base.ID.String() + "/reset-from-resume"
+	resp := doCV(t, f.app, fiber.MethodPost, path, f.token, nil)
+	if resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("status = %d, want 409", resp.StatusCode)
+	}
+}
+
+func TestResetCVFromResume_NoSeed409(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	userID := seedAccount(t, pool, "noseed@example.com", false)
+	tok, _ := iss.Issue(userID, 1)
+	ctx := context.Background()
+	jobID := seedJobSlug(t, pool, "noseed-"+uuid.NewString()[:8])
+	tailored, err := h.cvStore.CreateTailored(ctx, userID, jobID, "T", cv.DefaultTemplateID, cv.Document{Summary: "x"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/"+tailored.ID.String()+"/reset-from-resume", tok, nil)
+	if resp.StatusCode != fiber.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body = %s, want 409", resp.StatusCode, body)
+	}
+}
+
+func TestResetCVFromResume_OtherOwner404(t *testing.T) {
+	f := newResetFixture(t)
+	otherID := seedAccount(t, f.pool, "other-reset@example.com", false)
+	otherTok, err := f.iss.Issue(otherID, 1)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	path := "/api/v1/me/cvs/" + f.tailored.ID.String() + "/reset-from-resume"
+	resp := doCV(t, f.app, fiber.MethodPost, path, otherTok, nil)
+	if resp.StatusCode != fiber.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestResetCVFromResume_DoesNotChangeProfile(t *testing.T) {
+	f := newResetFixture(t)
+	ctx := context.Background()
+	if _, err := f.pool.Exec(ctx,
+		`INSERT INTO user_profiles (user_id, specializations, skills, excluded_skills)
+		 VALUES ($1, ARRAY['backend'], ARRAY['go'], ARRAY[]::text[])`,
+		f.userID); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+
+	path := "/api/v1/me/cvs/" + f.tailored.ID.String() + "/reset-from-resume"
+	resp := doCV(t, f.app, fiber.MethodPost, path, f.token, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	resp.Body.Close()
+
+	var skills []string
+	if err := f.pool.QueryRow(ctx,
+		`SELECT skills FROM user_profiles WHERE user_id = $1`, f.userID).Scan(&skills); err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	if len(skills) != 1 || skills[0] != "go" {
+		t.Fatalf("profile skills = %v, want [go] unchanged (Reset must not merge)", skills)
+	}
+}

--- a/internal/handler/cv_reset_test.go
+++ b/internal/handler/cv_reset_test.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// TestCVRegister_ResetFromResumeIsCookieOnly pins the gate against the real register().
+// Cookie-only is the enforcement: whole-document replace must not be reachable with a
+// CLI/API key the way PATCH is.
+func TestCVRegister_ResetFromResumeIsCookieOnly(t *testing.T) {
+	app := fiber.New()
+	api := app.Group("/api/v1")
+	(&cvHandlers{}).register(api, middleware{
+		key:    namedGate("key"),
+		cvKey:  namedGate("cvKey"),
+		cookie: namedGate("cookie"),
+	})
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/api/v1/me/cvs/"+uuid.New().String()+"/reset-from-resume", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if got := string(body); got != "cookie" {
+		t.Errorf("POST reset-from-resume gated by %q, want cookie", got)
+	}
+}

--- a/internal/handler/cv_seed_apply.go
+++ b/internal/handler/cv_seed_apply.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/cvedit"
+)
+
+// applySeedContent builds the next editable state from a résumé seed while keeping the
+// candidate's presentation choices. Title and template stay on the row; margins and style
+// stay on the document. Everything else comes from cv.Seed (header, summary, experience, …).
+//
+// Shared by Reset from résumé for both the base CV and the tailored copy so the two cannot
+// drift on what "preserve presentation" means.
+func applySeedContent(keep cvedit.State, seeded cv.Document) cvedit.State {
+	doc := seeded
+	doc.Margins = keep.Margins
+	doc.Style = keep.Style
+	return cvedit.State{
+		Title:      keep.Title,
+		TemplateID: keep.TemplateID,
+		Document:   doc,
+	}
+}

--- a/internal/handler/cv_seed_apply_test.go
+++ b/internal/handler/cv_seed_apply_test.go
@@ -1,0 +1,63 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/cvedit"
+)
+
+func TestApplySeedContentPreservesPresentation(t *testing.T) {
+	keep := cvedit.State{
+		Title:      "Tailored for Acme",
+		TemplateID: "compact",
+		Document: cv.Document{
+			Margins: cv.Margins{Top: 0.75, Right: 0.6, Bottom: 0.75, Left: 0.6},
+			Style:   cv.Style{FontFamily: "tinos", FontSize: 11, LineHeight: 0.55},
+			Header:  cv.Header{FullName: "Old Name"},
+			Summary: "old summary",
+		},
+	}
+	seeded := cv.Document{
+		Header:  cv.Header{FullName: "Ada Lovelace", Email: "ada@example.com"},
+		Summary: "new summary from résumé",
+		Skills:  []cv.SkillGroup{{Items: []string{"Go"}}},
+	}
+
+	got := applySeedContent(keep, seeded)
+
+	if got.Title != "Tailored for Acme" || got.TemplateID != "compact" {
+		t.Fatalf("title/template = %q/%q, want preserved", got.Title, got.TemplateID)
+	}
+	if got.Margins != keep.Margins || got.Style != keep.Style {
+		t.Fatalf("presentation not preserved: margins=%+v style=%+v", got.Margins, got.Style)
+	}
+	if got.Header.FullName != "Ada Lovelace" || got.Summary != "new summary from résumé" {
+		t.Fatalf("content not applied: header=%+v summary=%q", got.Header, got.Summary)
+	}
+	if len(got.Skills) != 1 || len(got.Skills[0].Items) != 1 || got.Skills[0].Items[0] != "Go" {
+		t.Fatalf("skills = %+v, want seeded Go", got.Skills)
+	}
+}
+
+func TestApplySeedContentEqualYieldsNoDiff(t *testing.T) {
+	seeded := cv.Document{
+		Header:  cv.Header{FullName: "Ada"},
+		Summary: "same",
+	}
+	keep := cvedit.State{
+		Title:      "My CV",
+		TemplateID: cv.DefaultTemplateID,
+		Document: cv.Document{
+			Margins: cv.DefaultMargins(),
+			Header:  seeded.Header,
+			Summary: seeded.Summary,
+		},
+	}
+	next := applySeedContent(keep, seeded)
+	// Sanitizer runs inside CommitDocument; Diff here checks the structural equality the
+	// helper is responsible for before that step.
+	if ops := cvedit.Diff(keep, next); len(ops) != 0 {
+		t.Fatalf("Diff = %+v, want empty when only seed content already matches", ops)
+	}
+}

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -71,6 +71,13 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	if bal := h.match.creditsBalance(c.Context(), userID); bal != nil && bal.Remaining < h.credits.Cost(credits.FeatureTailor) {
 		return creditsError(c, *bal)
 	}
+	// When the base CV is behind the latest résumé upload, refresh it from the seed before
+	// Tailor copies it into a new vacancy-bound row. Reload of an existing tailored copy
+	// still returns that copy unchanged (Tailor is idempotent); the base refresh is a no-op
+	// once updated_at catches the upload stamp.
+	if err := h.reseedBaseIfStaleVsUpload(c, userID); err != nil {
+		return err
+	}
 	base, tailored, err := h.cvStore.Tailor(c.Context(), userID, job.ID, tailoredCVTitle(job.Title), h.seedSource())
 	if errors.Is(err, cv.ErrNoResume) {
 		return fiber.NewError(fiber.StatusConflict, "add a résumé before tailoring")

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -549,4 +550,151 @@ func TestTailorCVBootstrapIsIdempotentPerVacancy(t *testing.T) {
 	if debits != 1 {
 		t.Errorf("tailor debits = %d, want 1 — a reload is not a second purchase", debits)
 	}
+}
+
+// TestTailorCVBootstrap_ReseedsStaleBaseAfterUpload: base predates a newer résumé
+// upload → first tailor for a new vacancy refreshes base + tailored from the seed.
+func TestTailorCVBootstrap_ReseedsStaleBaseAfterUpload(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+	ctx := context.Background()
+
+	user := seedAccount(t, pool, "stale-base@example.test", true)
+	tok, _ := iss.Issue(user, testTokenVersion)
+
+	// Old seed stamp + base content that predates the later upload.
+	oldAt := time.Now().Add(-2 * time.Hour).Truncate(time.Microsecond)
+	oldBlob, _ := json.Marshal(resumeextract.Structured{FullName: "Old Name", Summary: "before upload", Skills: []string{"Go"}})
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = $2,
+		 resume_structured = $3, resume_structured_uploaded_at = $2, resume_structured_model = 'test'
+		 WHERE id = $1`, user, oldAt, oldBlob); err != nil {
+		t.Fatalf("seed old résumé: %v", err)
+	}
+	base, err := h.cvStore.Create(ctx, user, "My CV", cv.DefaultTemplateID, cv.Document{
+		Header:  cv.Header{FullName: "Old Name"},
+		Summary: "before upload",
+	})
+	if err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE cvs SET updated_at = $2 WHERE id = $1`, base.ID, oldAt); err != nil {
+		t.Fatalf("backdate base: %v", err)
+	}
+
+	// Newer upload + structure (seed source moves; cvs intentionally untouched).
+	newAt := time.Now().Truncate(time.Microsecond)
+	newBlob, _ := json.Marshal(resumeextract.Structured{FullName: "Ada Lovelace", Summary: "after upload", Skills: []string{"Go", "Kafka"}})
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_uploaded_at = $2,
+		 resume_structured = $3, resume_structured_uploaded_at = $2 WHERE id = $1`,
+		user, newAt, newBlob); err != nil {
+		t.Fatalf("seed new résumé: %v", err)
+	}
+
+	jobID := seedJobSlug(t, pool, "stale-base-job")
+	seedAnalysis(t, h, user, jobID)
+
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "stale-base-job"})
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("bootstrap = %d, want 201", resp.StatusCode)
+	}
+	var got struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&got)
+	resp.Body.Close()
+
+	tailored, err := h.cvStore.Get(ctx, mustParseUUID(t, got.Data.TailorCVID), user)
+	if err != nil {
+		t.Fatalf("get tailored: %v", err)
+	}
+	if tailored.Document.Summary != "after upload" || tailored.Document.Header.FullName != "Ada Lovelace" {
+		t.Fatalf("tailored = %+v / %q, want after-upload seed", tailored.Document.Header, tailored.Document.Summary)
+	}
+	refreshed, ok, err := h.cvStore.BaseCV(ctx, user)
+	if err != nil || !ok {
+		t.Fatalf("BaseCV: ok=%v err=%v", ok, err)
+	}
+	if refreshed.ID != base.ID {
+		t.Fatalf("base id changed: %s → %s", base.ID, refreshed.ID)
+	}
+	if refreshed.Document.Summary != "after upload" {
+		t.Fatalf("base summary = %q, want after upload", refreshed.Document.Summary)
+	}
+
+	// Idempotent reload keeps the same tailored id and does not wipe content.
+	resp2 := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "stale-base-job"})
+	if resp2.StatusCode != fiber.StatusCreated {
+		t.Fatalf("reload = %d", resp2.StatusCode)
+	}
+	var got2 struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(resp2.Body).Decode(&got2)
+	resp2.Body.Close()
+	if got2.Data.TailorCVID != got.Data.TailorCVID {
+		t.Fatalf("reload minted new tailored CV")
+	}
+}
+
+func TestTailorCVBootstrap_KeepsBaseEditedAfterUpload(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+	ctx := context.Background()
+
+	user := seedAccount(t, pool, "edited-base@example.test", true)
+	tok, _ := iss.Issue(user, testTokenVersion)
+
+	uploadAt := time.Now().Add(-time.Hour).Truncate(time.Microsecond)
+	blob, _ := json.Marshal(resumeextract.Structured{FullName: "From Seed", Summary: "from seed", Skills: []string{"Go"}})
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = $2,
+		 resume_structured = $3, resume_structured_uploaded_at = $2 WHERE id = $1`,
+		user, uploadAt, blob); err != nil {
+		t.Fatalf("seed résumé: %v", err)
+	}
+
+	base, err := h.cvStore.Create(ctx, user, "My CV", cv.DefaultTemplateID, cv.Document{
+		Header:  cv.Header{FullName: "Hand Edited"},
+		Summary: "hand edited",
+	})
+	if err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	// Ensure updated_at is after the upload stamp.
+	if _, err := pool.Exec(ctx, `UPDATE cvs SET updated_at = $2 WHERE id = $1`,
+		base.ID, uploadAt.Add(time.Minute)); err != nil {
+		t.Fatalf("stamp base: %v", err)
+	}
+
+	jobID := seedJobSlug(t, pool, "edited-base-job")
+	seedAnalysis(t, h, user, jobID)
+
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "edited-base-job"})
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("bootstrap = %d, want 201", resp.StatusCode)
+	}
+	var got struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&got)
+	resp.Body.Close()
+
+	tailored, err := h.cvStore.Get(ctx, mustParseUUID(t, got.Data.TailorCVID), user)
+	if err != nil {
+		t.Fatalf("get tailored: %v", err)
+	}
+	if tailored.Document.Summary != "hand edited" {
+		t.Fatalf("tailored summary = %q, want hand edited (no forced reseed)", tailored.Document.Summary)
+	}
+}
+
+func mustParseUUID(t *testing.T, s string) uuid.UUID {
+	t.Helper()
+	id, err := uuid.Parse(s)
+	if err != nil {
+		t.Fatalf("uuid: %v", err)
+	}
+	return id
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -190,6 +190,10 @@ type Config struct {
 	// disables rendering: the /me/cvs/:id/pdf endpoint returns 501, the rest works.
 	TypstBin string
 
+	// CVEditAllowBulletTruncation restores silent Sanitize truncation past the
+	// per-role bullet ceiling. Default false (refuse on). Ops kill switch.
+	CVEditAllowBulletTruncation bool
+
 	// TracerLinkSalt keys the visitor hash of a traced click; empty means the CV tracing
 	// toggle cannot be enabled at all.
 	TracerLinkSalt string
@@ -203,6 +207,9 @@ type Config struct {
 	// AssistantMaxSteps bounds the tool-calling rounds of one turn; zero uses the
 	// assistant package's default.
 	AssistantMaxSteps int
+	// AssistantMaxPrompt bounds the rune length of one user message. Zero falls
+	// back to the handler default (8000).
+	AssistantMaxPrompt int
 	// LLMKeys mints the per-user gateway credential each account's model calls are
 	// spent under. Nil is the deployment that does not attribute spend: every call goes
 	// out on the service credential exactly as it did before, and no behaviour changes.
@@ -351,7 +358,7 @@ func Register(app *fiber.App, cfg Config) {
 	// account a call is attributed to is decided in one place rather than per feature. A nil
 	// gateway client leaves it inert and every call on the service credential.
 	llmKeys := llmkey.NewResolver(queries, cfg.LLMKeys)
-	cvH := newCVHandlers(cfg.Pool, queries, cvStore, assistantStore, cvRenderer, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank})
+	cvH := newCVHandlers(cfg.Pool, queries, cvStore, assistantStore, cvRenderer, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank}, !cfg.CVEditAllowBulletTruncation)
 	telegramH := newTelegramHandlers(queries, cfg.JWTSecret, cfg.TelegramBotToken, cfg.TelegramBotUsername, cfg.TelegramWebhookSecret, cfg.FrontendOrigin, contributionsH.intake)
 	discordH := newDiscordHandlers(queries, cfg.JWTSecret, cfg.DiscordBotToken, cfg.DiscordApplicationID, cfg.DiscordPublicKey, cfg.DiscordGuildID, cfg.FrontendOrigin, contributionsH.intake)
 	inboxH := newInboxHandlers(queries, cfg.Pool, cfg.GmailConnector, cfg.GmailCipher, cfg.FrontendOrigin, cfg.CookieSecure, cfg.MailboxDomain)
@@ -405,7 +412,10 @@ func Register(app *fiber.App, cfg Config) {
 	// store, which is why the CV handlers get it back. It also takes the browser-tool
 	// hub, which a browsing session reads the caller's open page through.
 	assistantH := newAssistantHandlers(queries,
-		assistantModels{Agent: cfg.AssistantLLM, Keys: llmKeys, MaxSteps: cfg.AssistantMaxSteps},
+		assistantModels{
+			Agent: cfg.AssistantLLM, Keys: llmKeys,
+			MaxSteps: cfg.AssistantMaxSteps, MaxPrompt: cfg.AssistantMaxPrompt,
+		},
 		assistantStore, searchH, resumeH, trackingH, cvH, profileH, a.browserTools, inboxH, bank)
 	resumeH.llm = llmBinding{client: cfg.LLM, keys: llmKeys}
 	matchH.llm = llmBinding{client: cfg.LLM, keys: llmKeys}

--- a/internal/handler/resume.go
+++ b/internal/handler/resume.go
@@ -336,6 +336,11 @@ func (h *resumeHandlers) embedResume(userID int64, text string) {
 // the CV embedding (/my/recommendations) and the structured résumé (profile view + fit
 // context). Both run detached on their own timeout contexts. Defined once so the two
 // upload paths (PutResume, ExtractResumeProfile) can't drift out of sync.
+//
+// Intentionally does NOT write cvs rows. Applying the seed into a base or tailored CV is
+// the candidate's explicit Reset from résumé on the tailor workspace — or, for a *new*
+// vacancy bootstrap only, TailorCV's stale-base refresh when base.updated_at predates
+// resume_uploaded_at. Upload itself never mutates cvs.
 func (h *resumeHandlers) deriveResumeArtifacts(userID int64, text string, uploadedAt *time.Time) {
 	go h.embedResume(userID, text)
 	go h.extractStructuredResume(userID, text, uploadedAt)

--- a/internal/resume/resume.go
+++ b/internal/resume/resume.go
@@ -270,6 +270,20 @@ func (s *Store) Status(ctx context.Context, userID int64) (Meta, error) {
 	return metaFromPointer(ptr), nil
 }
 
+// UploadedAt returns the résumé upload stamp when one is recorded, without requiring
+// object storage to be configured. Used by CV bootstrap freshness (base behind upload).
+func (s *Store) UploadedAt(ctx context.Context, userID int64) (*time.Time, error) {
+	row, err := s.repo.GetStructured(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !row.ResumeUploadedAt.Valid {
+		return nil, nil
+	}
+	t := row.ResumeUploadedAt.Time
+	return &t, nil
+}
+
 // Text fetches the stored résumé and derives its plain text — parsing a PDF, or reading
 // text as-is (the pasted-text path). ErrNotStored when the user has no résumé; the text
 // is never persisted separately (derived on read, no drift).

--- a/web/docker-entrypoint.sh
+++ b/web/docker-entrypoint.sh
@@ -6,6 +6,13 @@
 # 502s on a healthcheck).
 set -e
 
+# Variable proxy_pass needs a recursive resolver. nginx.conf defaults to Docker's
+# embedded DNS (127.0.0.11); Podman/aardvark put a different nameserver in
+# /etc/resolv.conf — without this swap, /api/* returns 502.
+RESOLVER=$(awk '/^nameserver / { print $2; exit }' /etc/resolv.conf)
+RESOLVER=${RESOLVER:-127.0.0.11}
+sed -i "s/resolver 127\\.0\\.0\\.11 /resolver ${RESOLVER} /" /etc/nginx/http.d/default.conf
+
 node build &
 
 exec nginx -g 'daemon off;'

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -25,9 +25,11 @@ server {
     gzip_min_length 1024;
     gzip_vary on;
 
-    # Resolve the backend hostname at request time (Docker's embedded DNS), not at
-    # startup — so the web container boots even if `app` is briefly down/unresolved
-    # instead of nginx refusing to start. The literal Node upstream needs no resolver.
+    # Resolve the backend hostname at request time, not at startup — so the web
+    # container boots even if `app` is briefly down/unresolved instead of nginx
+    # refusing to start. The literal Node upstream needs no resolver.
+    # Default is Docker's embedded DNS; docker-entrypoint.sh rewrites this to the
+    # first nameserver in /etc/resolv.conf under Podman (aardvark-dns).
     resolver 127.0.0.11 valid=30s ipv6=off;
 
     # Backend service name inside the compose network.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1590,6 +1590,16 @@ export function createApi(
     );
   }
 
+  /** Rebuild this tailored CV (and the base) from the current résumé seed. Cookie-only.
+   *  Same id and agent session; presentation preserved. 409 when the CV is not tailored or
+   *  there is nothing to seed from. */
+  async function resetCvFromResume(id: string): Promise<CvRecord> {
+    return requestData<CvRecord>(
+      `/api/v1/me/cvs/${encodeURIComponent(id)}/reset-from-resume`,
+      jsonBody('POST', {}),
+    );
+  }
+
   async function getCvAtsDelta(id: string): Promise<CvAtsDelta> {
     return requestData<CvAtsDelta>(`/api/v1/me/cvs/${id}/ats-delta`);
   }
@@ -1888,6 +1898,7 @@ export function createApi(
     listCvRevisions,
     undoCvRevision,
     undoCvRevisionRun,
+    resetCvFromResume,
     tailorCv,
     startTailorSession,
     resolveJd,

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, tick, untrack } from 'svelte';
-  import { AlertTriangle, ArrowDown, MessagesSquare, PanelLeft, Plus, Trash2, WandSparkles } from '@lucide/svelte';
+  import { AlertTriangle, ArrowDown, MessagesSquare, PanelLeft, Plus, Trash2, WandSparkles, X } from '@lucide/svelte';
   import { resolve } from '$app/paths';
   import {
     createSession,
@@ -12,12 +12,14 @@
   import { track } from '$lib/analytics';
   import {
     openRehearsal,
+    retryTurn,
     sendTurn,
     startAutopilot,
     StreamInterrupted,
     type Turn,
   } from '$lib/assistant/client';
   import { initChat, reduceTurnEvent, type ChatState } from '$lib/assistant/chat';
+  import { bulletCapUserMessage } from '$lib/assistant/bulletCapAlert';
   import { splitPresentingCalls } from '$lib/assistant/deck';
   import { atBottom } from '$lib/assistant/scrolling';
   import { renderMarkdown } from '$lib/assistant/markdown';
@@ -100,6 +102,10 @@
   // open — deleted, someone else's, or a tailoring chat that belongs to a CV. It is
   // a dead link, not a failure, so it gets an explanation and a way out.
   let notFound = $state(false);
+  // When cv_edit refuses an insert that would silently truncate a full role, show a
+  // dismissible banner — the tool chip alone is easy to miss, and the candidate needs
+  // to know their existing bullets were kept.
+  let bulletCapAlert = $state<string | null>(null);
 
   // Sidebar: the caller's conversations, newest activity first. `switching`
   // disables the composer and list while a session load is in flight.
@@ -365,6 +371,7 @@
     try {
       chat = initChat();
       queue = [];
+      bulletCapAlert = null;
       activeId = id;
       activePreset = null;
       // Raise the guard HERE, not after the fetch below: the URL-following effect reruns
@@ -508,6 +515,11 @@
     if (sessionId !== activeId) return;
     if (event.type === 'user_prompt') {
       sessions = setLabel(sessions, sessionId, labelFromMessage(event.text));
+      bulletCapAlert = null;
+    }
+    if (event.type === 'tool_result' && event.is_error) {
+      const alert = bulletCapUserMessage(event.result);
+      if (alert) bulletCapAlert = alert;
     }
     chat = reduceTurnEvent(chat, event);
     if (event.type === 'result') {
@@ -533,10 +545,14 @@
     void dispatch({ kind: 'message', text });
   }
 
-  // The three ways a turn begins. Two of them carry no text, because their brief is the
-  // server's: the unattended tailoring run, and a rehearsal's opening — the candidate
-  // arrived from an application with nothing to type.
-  type TurnStart = { kind: 'message'; text: string } | { kind: 'autopilot' } | { kind: 'opening' };
+  // The ways a turn begins. Autopilot and opening carry no text (server-owned brief).
+  // Retry continues from the existing transcript without appending another user message —
+  // re-sending the prompt would duplicate it in the model's context.
+  type TurnStart =
+    | { kind: 'message'; text: string }
+    | { kind: 'autopilot' }
+    | { kind: 'opening' }
+    | { kind: 'retry' };
 
   async function dispatch(start: TurnStart) {
     const id = activeId;
@@ -556,9 +572,12 @@
     // Whether the turn ever began. A message can queue behind the session's running turn and
     // then never start — the wait runs out, or it is stopped — and the composer cleared the
     // draft the moment it was sent. Without this the user's words would simply vanish.
-    let began = false;
+    // A retry never emits user_prompt (that is the point), so "began" is not meaningful for it.
+    let began = start.kind === 'retry';
     const watch = (event: TurnEvent) => {
-      if (event.type === 'user_prompt') began = true;
+      if (event.type === 'user_prompt' || event.type === 'assistant_text' || event.type === 'assistant_thought' || event.type === 'tool_use') {
+        began = true;
+      }
       onEvent(id, event);
     };
 
@@ -569,6 +588,14 @@
       started = startAutopilot(id, watch);
     } else if (start.kind === 'opening') {
       started = openRehearsal(id, watch);
+    } else if (start.kind === 'retry') {
+      // A failed autopilot left runActive false after endTurn; if the last user brief was
+      // the unattended run, treat the retry as that run again so the host can keep its
+      // "run in progress" affordances. We cannot see the brief here cheaply — the server
+      // already re-raises the ceiling — so only flip the flag when the host already knew
+      // a run was in play (openingActions with autopilot, or prior runActive). For the
+      // tailor workspace, refreshing after a failed run is enough via onTurnComplete.
+      started = retryTurn(id, watch);
     } else {
       started = sendTurn(id, start.text, watch);
     }
@@ -596,6 +623,11 @@
       chat = reduceTurnEvent(chat, { type: 'result', stop_reason: 'error', is_error: true });
       endTurn();
     }
+  }
+
+  function retryFailedTurn() {
+    if (!canStartTurn()) return;
+    void dispatch({ kind: 'retry' });
   }
 
   /** Re-read a session's stored transcript into the view. The server holds the truth about a
@@ -645,6 +677,23 @@
   >
     <AlertTriangle class="mt-0.5 size-4 shrink-0" />
     <span>{error}</span>
+  </div>
+{/if}
+{#if bulletCapAlert}
+  <div
+    class="m-3 mb-0 flex items-start gap-2 rounded-lg border border-warning/40 bg-warning/5 px-3 py-2 text-sm text-foreground"
+    role="status"
+  >
+    <AlertTriangle class="mt-0.5 size-4 shrink-0 text-warning-strong" />
+    <span class="min-w-0 flex-1">{bulletCapAlert}</span>
+    <button
+      type="button"
+      class="shrink-0 rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      aria-label="Dismiss"
+      onclick={() => (bulletCapAlert = null)}
+    >
+      <X class="size-4" />
+    </button>
   </div>
 {/if}
 
@@ -832,7 +881,19 @@
               {/if}
 
               {#if message.errored}
-                <p class="self-start text-xs text-destructive">The agent ended the turn with an error.</p>
+                <div class="self-start flex flex-wrap items-center gap-2 text-xs">
+                  <p class="text-destructive">The agent ended the turn with an error.</p>
+                  {#if i === chat.messages.length - 1 && !turnActive && !switching}
+                    <button
+                      type="button"
+                      class="rounded-md border border-border bg-background px-2 py-0.5 font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+                      disabled={!canStartTurn()}
+                      onclick={retryFailedTurn}
+                    >
+                      Retry
+                    </button>
+                  {/if}
+                </div>
               {/if}
             {/if}
           {/each}

--- a/web/src/lib/assistant/bulletCapAlert.test.ts
+++ b/web/src/lib/assistant/bulletCapAlert.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { bulletCapUserMessage } from './bulletCapAlert';
+
+describe('bulletCapUserMessage', () => {
+  it('returns null when the tool result is unrelated', () => {
+    expect(bulletCapUserMessage('{"error":"needs evidence_id"}')).toBeNull();
+    expect(bulletCapUserMessage(undefined)).toBeNull();
+  });
+
+  it('surfaces a safe banner from the backend ErrListCap envelope', () => {
+    const raw =
+      '{"error":"cvedit: this edit would drop existing CV content: bullet_cap: Staff Engineer at Neon already has 20 bullets (the maximum). The edit was not applied and no existing bullets were deleted. Set an existing bullet or remove one before inserting"}';
+    const got = bulletCapUserMessage(raw);
+    expect(got).toContain('Staff Engineer at Neon');
+    expect(got).toContain('Your existing bullets were kept');
+    expect(got).not.toContain('bullet_cap');
+    expect(got).not.toContain('Set an existing');
+    expect(got).not.toContain('cvedit:');
+  });
+});

--- a/web/src/lib/assistant/bulletCapAlert.ts
+++ b/web/src/lib/assistant/bulletCapAlert.ts
@@ -1,0 +1,31 @@
+/** Stable token the backend embeds in ErrListCap tool/HTTP errors. */
+export const BULLET_CAP_CODE = 'bullet_cap';
+
+/**
+ * Candidate-facing copy when a cv_edit was refused because a role is at the
+ * bullet ceiling. Safe to show in the UI: no internal prefixes, reassures that
+ * nothing was deleted.
+ */
+export function bulletCapUserMessage(toolResult: string | undefined): string | null {
+  if (!toolResult || !toolResult.includes(BULLET_CAP_CODE)) return null;
+  let raw = toolResult.trim();
+  try {
+    const parsed = JSON.parse(raw) as { error?: unknown };
+    if (typeof parsed.error === 'string') raw = parsed.error;
+  } catch {
+    /* plain string */
+  }
+  const marked = raw.indexOf(`${BULLET_CAP_CODE}:`);
+  if (marked < 0) return null;
+  let msg = raw.slice(marked + BULLET_CAP_CODE.length + 1).trim();
+  const cut = msg.indexOf('. Set an existing');
+  if (cut >= 0) msg = msg.slice(0, cut);
+  if (!msg) {
+    return 'This role already has the maximum number of bullet points. The edit was not applied. Your existing bullets were kept.';
+  }
+  if (!msg.endsWith('.')) msg += '.';
+  if (!/your existing bullets were kept/i.test(msg)) {
+    msg += ' Your existing bullets were kept.';
+  }
+  return msg;
+}

--- a/web/src/lib/assistant/chat.test.ts
+++ b/web/src/lib/assistant/chat.test.ts
@@ -85,7 +85,15 @@ describe('reduceTurnEvent', () => {
     expect(s.messages[1]?.streaming).toBe(true);
   });
 
-  it('ignores a result with no open turn instead of creating a message', () => {
+  it('surfaces an empty errored assistant when a turn fails before any reply', () => {
+    let s = reduceTurnEvent(initChat(), { type: 'user_prompt', text: 'hi' });
+    s = reduceTurnEvent(s, { type: 'result', stop_reason: 'error', is_error: true });
+    expect(s.messages).toHaveLength(2);
+    expect(s.messages[1]?.role).toBe('assistant');
+    expect(s.messages[1]?.errored).toBe(true);
+  });
+
+  it('ignores a successful result with no open turn instead of creating a message', () => {
     const s = reduceTurnEvent(initChat(), {
       type: 'result',
       stop_reason: 'end_turn',

--- a/web/src/lib/assistant/chat.ts
+++ b/web/src/lib/assistant/chat.ts
@@ -51,11 +51,27 @@ export function reduceTurnEvent(prev: ChatState, event: TurnEvent): ChatState {
       }));
     case 'tool_result':
       return upsertAssistant(prev, (m) => ({ ...m, tools: attachResult(m.tools, event) }));
-    case 'result':
+    case 'result': {
       // Clears the wait as well as closing the turn: a wait can end WITHOUT the turn ever
       // starting (it timed out, or was stopped), and a banner still claiming to be queued
       // would then mask the next turn's real progress.
-      return { ...closeAssistant(prev, event.is_error ?? false), queued: false };
+      let next = closeAssistant(prev, event.is_error ?? false);
+      // A failure before any assistant frame left only the user prompt — still surface an
+      // errored assistant so the Retry control has somewhere to sit.
+      if (event.is_error) {
+        const last = next.messages[next.messages.length - 1];
+        if (!last || last.role !== 'assistant' || !last.errored) {
+          next = {
+            ...next,
+            messages: [
+              ...next.messages,
+              { role: 'assistant', text: '', thinking: '', tools: [], streaming: false, errored: true },
+            ],
+          };
+        }
+      }
+      return { ...next, queued: false };
+    }
     default:
       // usage, and anything not in the union — ignored.
       return prev;

--- a/web/src/lib/assistant/client.ts
+++ b/web/src/lib/assistant/client.ts
@@ -101,6 +101,21 @@ export function openRehearsal(sessionId: string, onEvent: (e: TurnEvent) => void
   );
 }
 
+/**
+ * Resume after a failed turn without re-sending the user's message. The server continues
+ * from the existing transcript (healing any dangling tool calls), so the model's context
+ * is not polluted with a duplicate prompt.
+ */
+export function retryTurn(sessionId: string, onEvent: (e: TurnEvent) => void): Turn {
+  return streamTurn(
+    sessionId,
+    `${BASE}/sessions/${encodeURIComponent(sessionId)}/retry`,
+    {},
+    'could not retry the turn',
+    onEvent,
+  );
+}
+
 /** POST a turn and stream its frames. Shared by every way of starting one, so cancellation
  *  and frame decoding have a single implementation. */
 function streamTurn(

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -2355,6 +2355,21 @@ ${BASE_URL}/auth/oauth/google/start`,
         responseExample: `{ "data": { "tailor_cv_id": "7d1a…", "base_cv_id": "0f2c…", "session_id": "s_9f…" } }`,
       },
       {
+        method: 'POST',
+        path: '/me/cvs/{id}/reset-from-resume',
+        auth: 'cookie',
+        summary: 'Rebuild this tailored CV from your résumé.',
+        description:
+          'Replaces the tailored document\'s content from the current résumé seed ' +
+          '(experience bank + structured extract) and refreshes your base CV from the ' +
+          'same seed. Keeps the same tailored id and agent session; preserves template ' +
+          'and typography on each row. 409 when the CV is not tailored or there is no ' +
+          'usable résumé seed. Upload alone does not do this — this is the explicit apply.',
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The tailored CV id.' }],
+        curl: `curl -X POST "${BASE_URL}/me/cvs/7d1a…/reset-from-resume" -b cookies.txt`,
+        responseExample: `{ "data": { "id": "7d1a…", "title": "Tailored for …", "template_id": "classic-ats", "document": { … } } }`,
+      },
+      {
         method: 'GET',
         path: '/me/cvs/{id}/tailor-context',
         auth: 'cookie-or-key',

--- a/web/src/lib/profile.svelte.ts
+++ b/web/src/lib/profile.svelte.ts
@@ -107,6 +107,12 @@ class ProfileStore extends UserResource<UserProfile | null> {
     return this.#queue(() => this.#writeSkills((sets) => withoutAvoidedSkill(sets, skill)));
   }
 
+  /** Merge many skills into the profile in one write — what the tailor "Add new skills to
+   *  profile" control does after confirm. Same queue as single-skill edits. */
+  addSkills(skills: string[]): Promise<UserProfile> {
+    return this.#queue(() => this.#writeSkills((sets) => withSkills(sets, skills)));
+  }
+
   /** Re-save the profile with edited skill sets. Reads `#profile` at call time — inside the
    *  queue — so it sees whatever the preceding write applied rather than a copy that
    *  predates it. */

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -47,6 +47,9 @@
     onPreviewRevision,
     onUndoRevision,
     onUndoRevisionRun,
+    onResetFromResume,
+    resetBusy = false,
+    resetError = '',
   }: {
     job: Job;
     analysis: Analysis | null;
@@ -71,6 +74,12 @@
      *  first, and the re-read that follows. */
     onUndoRevision: (revision: RevisionView) => Promise<void>;
     onUndoRevisionRun: (batchId: string) => Promise<void>;
+    /** Rebuild this tailored CV from the current résumé seed. Page owns confirm + flush. */
+    onResetFromResume?: () => Promise<void>;
+    /** True while a reset round-trip (or a turn) is in flight — disables the control. */
+    resetBusy?: boolean;
+    /** Last reset failure message; cleared by the page on a new attempt. */
+    resetError?: string;
   } = $props();
 
   const tabs: [Tab, string][] = [
@@ -193,7 +202,29 @@
 
   <div class="min-h-0 flex-1 overflow-auto">
     {#if tab === 'history'}
-      <RevisionHistory {revisions} onPreview={onPreviewRevision} onUndo={onUndoRevision} onUndoRun={onUndoRevisionRun} />
+      <div>
+        {#if onResetFromResume}
+          <div class="border-b border-border px-4 py-3">
+            <p class="text-xs leading-snug text-muted-foreground">
+              Replace this CV’s content from your current uploaded résumé / seed (and refresh
+              your base CV). Template and typography stay; this is not “undo last agent edit”
+              alone — History undo covers that. Edits are undoable from the history below.
+            </p>
+            <button
+              type="button"
+              disabled={resetBusy || autopilotBusy}
+              onclick={() => void onResetFromResume()}
+              class="mt-2 inline-flex items-center rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {resetBusy ? 'Resetting…' : 'Reset Changes'}
+            </button>
+            {#if resetError}
+              <p class="mt-1.5 text-xs text-destructive">{resetError}</p>
+            {/if}
+          </div>
+        {/if}
+        <RevisionHistory {revisions} onPreview={onPreviewRevision} onUndo={onUndoRevision} onUndoRun={onUndoRevisionRun} />
+      </div>
     {:else if tab === 'jd'}
       <div class="p-4">
         {#if job.description}
@@ -219,7 +250,7 @@
              this surface as a whole. -->
         <div class="mb-3 rounded-lg border border-border bg-muted/30 px-2.5 py-2">
           <h3 class="text-sm font-semibold text-foreground">Fit analysis</h3>
-          <p class="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+          <p class="mt-0.5 text-xs leading-snug text-muted-foreground">
             A snapshot of your base profile against this vacancy. It does not move as you edit
             this CV — recompute it below to take it again.
           </p>

--- a/web/src/lib/tailor/skillDiff.test.ts
+++ b/web/src/lib/tailor/skillDiff.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import type { Document } from '$lib/generated/contracts';
+import { withSkills } from '../profileSkills';
+import { PROFILE_MAX_SKILLS, skillsFromDocument, skillsToAddToProfile } from './skillDiff';
+
+function docWithSkills(...items: string[]): Document {
+  return {
+    margins: { top: 0.5, right: 0.5, bottom: 0.5, left: 0.5 },
+    style: {},
+    header: {},
+    skills: [{ group: 'Skills', items }],
+  };
+}
+
+describe('skillsFromDocument', () => {
+  it('collects and lowercases items across groups', () => {
+    const doc: Document = {
+      margins: { top: 0.5, right: 0.5, bottom: 0.5, left: 0.5 },
+      style: {},
+      header: {},
+      skills: [
+        { group: 'Lang', items: ['Go', 'TypeScript'] },
+        { group: 'Ops', items: ['kafka', 'Go'] },
+      ],
+    };
+    expect(skillsFromDocument(doc)).toEqual(['go', 'typescript', 'kafka']);
+  });
+
+  it('returns empty when skills are missing', () => {
+    expect(
+      skillsFromDocument({
+        margins: { top: 0.5, right: 0.5, bottom: 0.5, left: 0.5 },
+        style: {},
+        header: {},
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('skillsToAddToProfile', () => {
+  it('returns empty when there is no profile', () => {
+    expect(skillsToAddToProfile(docWithSkills('kafka'), null)).toEqual({
+      skills: [],
+      capped: false,
+    });
+  });
+
+  it('lists CV skills not yet wanted and not excluded', () => {
+    expect(
+      skillsToAddToProfile(docWithSkills('Go', 'kafka', 'Redis'), {
+        skills: ['go'],
+        excluded_skills: ['redis'],
+      }),
+    ).toEqual({ skills: ['kafka'], capped: false });
+  });
+
+  it('returns empty when there is no remaining diff', () => {
+    expect(
+      skillsToAddToProfile(docWithSkills('Go'), {
+        skills: ['go'],
+        excluded_skills: [],
+      }),
+    ).toEqual({ skills: [], capped: false });
+  });
+
+  it('caps additions so wanted skills stay within maxSkills', () => {
+    const held = Array.from({ length: PROFILE_MAX_SKILLS - 1 }, (_, i) => `s${i}`);
+    const result = skillsToAddToProfile(docWithSkills('kafka', 'terraform', 'nix'), {
+      skills: held,
+      excluded_skills: [],
+    });
+    expect(result.skills).toEqual(['kafka']);
+    expect(result.capped).toBe(true);
+  });
+
+  it('matches held/excluded case-insensitively', () => {
+    expect(
+      skillsToAddToProfile(docWithSkills('Kafka'), {
+        skills: ['KAFKA'],
+        excluded_skills: [],
+      }),
+    ).toEqual({ skills: [], capped: false });
+  });
+
+  it('composes with withSkills for the tailor confirm path', () => {
+    const profile = { skills: ['go'], excluded_skills: [] as string[] };
+    const { skills, capped } = skillsToAddToProfile(docWithSkills('kafka', 'redis'), profile);
+    expect(capped).toBe(false);
+    expect(withSkills(profile, skills)).toEqual({
+      skills: ['go', 'kafka', 'redis'],
+      excluded_skills: [],
+    });
+  });
+});

--- a/web/src/lib/tailor/skillDiff.ts
+++ b/web/src/lib/tailor/skillDiff.ts
@@ -1,0 +1,57 @@
+// Skill diff between a tailored CV document and the search/match profile.
+// Used by the tailor "Add new skills to profile" control — never runs as a
+// side effect of save, Download, or Reset.
+
+import type { Document } from '$lib/generated/contracts';
+import type { ProfileSkillSets } from '$lib/profileSkills';
+
+/** Profile wanted-skill cap — mirrors internal/userprofile.maxSkills. */
+export const PROFILE_MAX_SKILLS = 200;
+
+const same = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+
+/** Canonical skill tokens listed on the CV (skill group items), lowercased, de-duped. */
+export function skillsFromDocument(doc: Document): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const group of doc.skills ?? []) {
+    for (const raw of group.items ?? []) {
+      const s = raw.trim().toLowerCase();
+      if (!s || seen.has(s)) continue;
+      seen.add(s);
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+export interface SkillsToAddResult {
+  /** Skills to merge into the profile (already capped). */
+  skills: string[];
+  /** True when more CV skills were eligible than fit under the cap. */
+  capped: boolean;
+}
+
+/**
+ * Skills on the CV that are not yet wanted and not excluded. Empty when there is
+ * no profile (do not invent one) or no remaining diff.
+ */
+export function skillsToAddToProfile(
+  doc: Document,
+  profile: ProfileSkillSets | null,
+  maxSkills: number = PROFILE_MAX_SKILLS,
+): SkillsToAddResult {
+  if (!profile) return { skills: [], capped: false };
+
+  const held = profile.skills;
+  const excluded = profile.excluded_skills;
+  const candidates = skillsFromDocument(doc).filter(
+    (s) => !held.some((h) => same(h, s)) && !excluded.some((e) => same(e, s)),
+  );
+
+  const room = Math.max(0, maxSkills - held.length);
+  if (candidates.length <= room) {
+    return { skills: candidates, capped: false };
+  }
+  return { skills: candidates.slice(0, room), capped: true };
+}

--- a/web/src/posts/2026-08-07-tailor-uses-your-latest-cv.svx
+++ b/web/src/posts/2026-08-07-tailor-uses-your-latest-cv.svx
@@ -1,0 +1,66 @@
+---
+title: Tailor picks up your latest CV — and stops quiet edits
+date: 2026-08-07
+summary: Fresh tailor after upload, chronological work history, an explicit profile-skills control, Reset from your résumé, Continue for interrupted assistant turns, and no more silent bullet truncation.
+type: changelog
+tags:
+  - cv
+  - tailor
+  - profile
+  - ai
+draft: false
+---
+
+Several tailor fixes landed together. None of them rewrite an open tailored CV behind
+your back — each one either starts you from the right document, or asks before a lasting
+change.
+
+### Your latest résumé on a new job
+
+Uploading a new PDF used to leave a quiet trap: tailor for a **new** job could still
+copy an older base CV until you found **Reset Changes**. That first open now checks
+whether your base is behind the upload. When it is, freehire refreshes the base from
+your current résumé seed, then opens the tailored copy from that — so the workspace
+matches what you just uploaded without an extra step.
+
+An open tailor for a job you already started still behaves as before. Upload alone does
+not rewrite it.
+
+### Reset Changes
+
+**Reset Changes** (History tab) rebuilds the open tailored CV — and your base — from the
+current uploaded résumé / experience-bank seed. Template and typography stay. It is not
+“undo the last agent edit” alone; History undo still covers that. Reset does not touch
+your search profile.
+
+### Work history in real date order
+
+Roles seeded from your experience bank are ordered by real time — current roles first,
+then newest to oldest — even when the printed dates are free-form labels like
+`October 2018` and `2024`. Existing tailored CVs pick up the order on Reset (or on that
+fresh first bootstrap after upload).
+
+### Skills go to the profile only when you say so
+
+Skills you add while tailoring stay on that CV until you choose otherwise. When the open
+document lists skills that are not yet on your search profile, the preview toolbar
+(next to zoom) offers **Add N skills to profile**. Confirm, and they merge into the
+profile that drives filters and match. Saving, downloading the PDF, and Reset never do
+that quietly.
+
+### No more silent bullet truncation
+
+If a role or project is already at the per-role bullet ceiling, a new insert past that
+cap is **refused** instead of Sanitize quietly dropping the oldest bullets. The tailor
+UI surfaces the cap when that happens. The default ceiling stays **20** bullets per
+role; deployments can raise it with `CV_MAX_BULLETS`.
+
+### Continue an interrupted assistant turn
+
+If a tailor assistant turn stops mid-flight (connection drop, closed tab), the chat can
+**Continue** from where it left off instead of stranding a half-applied run. Continue
+does **not** append another copy of your request — the transcript already holds the
+prompt and any partial tool work — so the model is not asked the same thing twice.
+Half-finished tool calls from the interrupted turn are healed on the next history
+rebuild (the same path every other turn uses). You still own Undo for anything already
+written to the CV.

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -38,6 +38,8 @@
   } from '$lib/cv';
   import type { Analysis, AutopilotEntry, Document, RevisionView } from '$lib/generated/contracts';
   import type { Job } from '$lib/types';
+  import { profileStore } from '$lib/profile.svelte';
+  import { skillsToAddToProfile } from '$lib/tailor/skillDiff';
 
   const slug = $derived(page.params.slug ?? '');
   const cvParam = $derived(page.url.searchParams.get('cv'));
@@ -111,7 +113,7 @@
 
   // The right context panel's tab, lifted here so the mobile tab bar can drive it (on desktop the
   // panel's own tab bar sets it via the same binding).
-  let artifactTab = $state<'jd' | 'jobmatch' | 'score'>('jobmatch');
+  let artifactTab = $state<'jd' | 'jobmatch' | 'score' | 'history'>('jobmatch');
 
   // Mobile-only navigation: below lg the three columns collapse to one, so a single flat tab bar
   // picks which view fills the screen. At lg it's hidden and every column shows at once as before.
@@ -119,7 +121,7 @@
   // syncs the matching column's own selector (mobile → column) so the wide layout shows the same
   // content once revealed. The reverse (a desktop tab change updating mobileView) is not wired —
   // switching a column tab then narrowing across lg resets the mobile view to that tab's default.
-  type MobileView = 'chat' | 'editor' | 'settings' | 'preview' | 'templates' | 'jd' | 'jobmatch' | 'score';
+  type MobileView = 'chat' | 'editor' | 'settings' | 'preview' | 'templates' | 'jd' | 'jobmatch' | 'score' | 'history';
   const mobileTabs: [MobileView, string][] = [
     ['chat', 'Chat'],
     ['editor', 'Editor'],
@@ -128,6 +130,7 @@
     ['preview', 'Preview'],
     ['jobmatch', 'Job Match'],
     ['score', 'Score'],
+    ['history', 'History'],
     ['jd', 'Job'],
   ];
   let mobileView = $state<MobileView>('chat');
@@ -211,6 +214,7 @@
   }
 
   onMount(async () => {
+    void profileStore.ensureLoaded();
     try {
       if (cvParam) {
         // Resume an existing tailored CV. If it already has a bound session, re-attach it with
@@ -341,6 +345,76 @@
     void loadRevisions();
     void refreshAtsDelta();
     void refreshJobMatch();
+  }
+
+  let resetBusy = $state(false);
+  let resetError = $state('');
+
+  async function resetFromResume() {
+    if (
+      !window.confirm(
+        'Reset this tailored CV from your current uploaded résumé? Your template and typography stay; content edits can be undone from History.',
+      )
+    ) {
+      return;
+    }
+    resetBusy = true;
+    resetError = '';
+    try {
+      await undoRun({
+        flush: flushPendingSave,
+        undo: async () => {
+          const rec = await api.resetCvFromResume(cvId);
+          hydrate(rec);
+        },
+        refetch: async () => {
+          pdfVersion += 1;
+          void loadRevisions();
+          void refreshAtsDelta();
+          void refreshJobMatch();
+        },
+      });
+    } catch (e) {
+      resetError = e instanceof ApiError ? e.message : 'Could not reset changes.';
+    } finally {
+      resetBusy = false;
+    }
+  }
+
+  let addSkillsBusy = $state(false);
+  let addSkillsError = $state('');
+  let addSkillsNote = $state('');
+  const skillsToAdd = $derived(
+    skillsToAddToProfile(doc, profileStore.profile).skills,
+  );
+
+  async function addSkillsToProfile() {
+    const result = skillsToAddToProfile(doc, profileStore.profile);
+    if (!result.skills.length) return;
+    const preview = result.skills.slice(0, 12).join(', ') + (result.skills.length > 12 ? '…' : '');
+    const capNote = result.capped
+      ? '\n\nYour profile is near the skill cap — only as many as fit will be added.'
+      : '';
+    if (
+      !window.confirm(
+        `Add ${result.skills.length} skill(s) to your profile?\n\n${preview}${capNote}`,
+      )
+    ) {
+      return;
+    }
+    addSkillsBusy = true;
+    addSkillsError = '';
+    addSkillsNote = '';
+    try {
+      await profileStore.addSkills(result.skills);
+      addSkillsNote = result.capped
+        ? 'Some skills were skipped because your profile hit the skill limit.'
+        : '';
+    } catch (e) {
+      addSkillsError = e instanceof ApiError ? e.message : 'Could not update profile skills.';
+    } finally {
+      addSkillsBusy = false;
+    }
   }
 
   // ---- Autosave (folded in from the old standalone CvEditor) ----
@@ -626,15 +700,28 @@
       <div
         class={['min-w-0 min-h-0 flex-1 flex-col bg-muted/30 lg:flex', mobileView === 'preview' ? 'flex' : 'hidden']}
       >
-        <div class="flex items-center justify-between gap-2 border-b border-border bg-background px-3 py-1.5 text-sm">
-          <div class="flex items-center gap-1">
-            <button type="button" onclick={zoomOut} aria-label="Zoom out" class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground">
-              <ZoomOut class="size-4" />
-            </button>
-            <span class="w-12 text-center text-xs tabular-nums text-muted-foreground">{zoomPct}%</span>
-            <button type="button" onclick={zoomIn} aria-label="Zoom in" class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground">
-              <ZoomIn class="size-4" />
-            </button>
+        <div class="flex flex-wrap items-center justify-between gap-x-2 gap-y-1.5 border-b border-border bg-background px-3 py-1.5 text-sm">
+          <div class="flex flex-wrap items-center gap-2">
+            <div class="flex items-center gap-1">
+              <button type="button" onclick={zoomOut} aria-label="Zoom out" class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground">
+                <ZoomOut class="size-4" />
+              </button>
+              <span class="w-12 text-center text-xs tabular-nums text-muted-foreground">{zoomPct}%</span>
+              <button type="button" onclick={zoomIn} aria-label="Zoom in" class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground">
+                <ZoomIn class="size-4" />
+              </button>
+            </div>
+            {#if skillsToAdd.length > 0}
+              <button
+                type="button"
+                disabled={addSkillsBusy || turnActive || runActive}
+                title="Add skills from this CV that are missing on your search profile"
+                onclick={() => void addSkillsToProfile()}
+                class="inline-flex items-center rounded-md border border-border px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {addSkillsBusy ? 'Adding…' : `Add ${skillsToAdd.length} skill${skillsToAdd.length === 1 ? '' : 's'} to profile`}
+              </button>
+            {/if}
           </div>
           <!-- eslint-disable svelte/no-navigation-without-resolve -- external CV PDF API URL, not an internal route -->
           <a
@@ -647,6 +734,16 @@
             <Download class="size-4" /> Download PDF
           </a>
         </div>
+        {#if addSkillsError || addSkillsNote}
+          <div class="border-b border-border bg-background px-3 py-1.5 text-xs">
+            {#if addSkillsError}
+              <p class="text-destructive">{addSkillsError}</p>
+            {/if}
+            {#if addSkillsNote}
+              <p class="text-muted-foreground">{addSkillsNote}</p>
+            {/if}
+          </div>
+        {/if}
         <div class="min-h-0 flex-1 overflow-auto p-6">
           <CvHtmlPreview {doc} {templateId} {zoom} {fonts} {photoSrc} highlightPaths={pinnedRevision?.paths ?? []} />
         </div>
@@ -666,8 +763,11 @@
         onPreviewRevision={(r) => (pinnedRevision = r)}
         onUndoRevision={undoRevision}
         onUndoRevisionRun={undoRevisionRun}
+        onResetFromResume={resetFromResume}
+        resetBusy={resetBusy || turnActive || runActive}
+        {resetError}
         bind:tab={artifactTab}
-        mobileVisible={mobileView === 'jd' || mobileView === 'jobmatch' || mobileView === 'score'}
+        mobileVisible={mobileView === 'jd' || mobileView === 'jobmatch' || mobileView === 'score' || mobileView === 'history'}
       />
     </div>
   {/if}


### PR DESCRIPTION
## Summary
- After a résumé upload, first tailor for a **new** job reseeds a base that is behind `resume_uploaded_at`, so the tailored CV starts from the current seed (without discovering Reset first). Open tailored sessions still need Reset; upload still does not write `cvs`.
- Experience-bank roles used for seed / WorkHistory sort by parsed chronology (current first), not lexicographic period labels.
- Tailor preview toolbar offers an explicit **Add N skills to profile** confirm path via existing `PUT /me/profile`; save / Download / Reset never write the profile.
- Includes the prerequisite Reset Changes / bullet-cap work (`fix(cv): refuse silent bullet truncation…`) that `main` did not yet have, plus a `/blog` changelog.

## Test plan
- [x] `go test ./internal/experience/ ./internal/cv/ ./internal/cvedit/`
- [x] `go vet -tags=integration ./...`
- [x] With Podman/Docker: `go test -tags=integration ./internal/handler/ -run 'TailorCVBootstrap_|ResetCVFromResume_DoesNotChangeProfile|ListCap'`
- [x] Manual: upload new PDF → open tailor on a job with no tailored CV → content matches upload (no Reset)
- [x] Manual: add a CV-only skill → toolbar control → confirm → profile updated; Download leaves profile unchanged
- [ ] Confirm `/blog` shows the 2026-08-07 changelog entry