### PR TITLE
fix(cvedit): close the bullet-cap refuse gap in whole-document saves

### DIFF
--- a/internal/cv/AGENTS.md
+++ b/internal/cv/AGENTS.md
@@ -145,7 +145,15 @@ Three things that follow, and are easy to get backwards:
 current résumé seed (`bankedSeeder`: experience bank + `resume_structured`) and refreshes the
 base CV from the same seed. Same tailored id and agent session; template/margins/style on each
 row are preserved. Upload alone does **not** write `cvs` — it only refreshes the seed source;
-this endpoint is the explicit apply. 409 when the target is not tailored or the seed is unusable.
+this endpoint is the explicit apply. 409 when the target is not tailored, the seed is unusable,
+or the seed itself exceeds the bullet ceiling (see `internal/cvedit/AGENTS.md`).
+
+The tailored copy commits **before** the base refresh, not after: these are two separate
+`CommitDocument` calls, not one transaction, so ordering decides which one a mid-request
+failure leaves stale. Committing the caller's actual target first means a refused/failed
+write touches nothing at all; a failure in the base refresh after that leaves only the base
+stale (self-heals on the next bootstrap freshness check or Reset) rather than a request that
+reports failure while having silently rewritten a CV nobody asked to touch.
 
 **Bootstrap freshness:** `POST /me/cvs/tailor` refreshes a base whose `updated_at` is strictly
 before `resume_uploaded_at` (when the seed is usable) before copying into a **new** tailored

--- a/internal/cvedit/AGENTS.md
+++ b/internal/cvedit/AGENTS.md
@@ -147,11 +147,21 @@ documents on the table behind every CV page.
 ## Bullet ceiling
 
 `cv.MaxBullets` (default 20, override with `CV_MAX_BULLETS`) is enforced by `Sanitize`,
-which keeps the first N and drops the rest. Commit refuses that class of loss up front
-(`ErrListCap` / `bullet_cap`) so an insert into a full list cannot look like a successful
-add while trailing originals vanish. The guard is on by default; `Editor.SetRefuseListCap(false)`
-(env `CV_EDIT_ALLOW_BULLET_TRUNCATION=true` on the server) restores the old sanitize-and-drop
-behaviour without a code change.
+which keeps the first N and drops the rest. Both `Commit` (an ops batch — cv_edit, template
+picks) and `CommitDocument` (a whole-document save — the editor's PATCH autosave, Reset from
+résumé) refuse that class of loss up front (`ErrListCap` / `bullet_cap`) so neither an
+agent's insert into a full list nor a pasted/seeded document that is itself over the cap can
+look like a successful write while content vanishes. The guard is on by default;
+`Editor.SetRefuseListCap(false)` (env `CV_EDIT_ALLOW_BULLET_TRUNCATION=true` on the server)
+restores the old sanitize-and-drop behaviour without a code change, for both paths.
+
+`CommitDocument` checks the RAW incoming document, before its own pre-diff `Sanitize()` call
+— that Sanitize existed first (so the diff is against what will actually be stored) and would
+otherwise erase the overflow before the guard ever saw it, making the refuse a no-op for
+every whole-document save. Get this ordering backwards again and the guard silently stops
+protecting PATCH /me/cvs/:id and Reset from résumé while still working for cv_edit —
+`TestCommitDocumentRefusesAWholeDocumentSaveOverTheCap` and
+`TestUpdateCV_RefusesAWholeDocumentSaveOverTheBulletCap` pin it.
 
 Sibling Sanitize `limit()`s — experience/education/skills/languages/projects/certifications
 counts, skill items, links — still drop trailing entries silently. Extending refuse to those

--- a/internal/cvedit/editor.go
+++ b/internal/cvedit/editor.go
@@ -345,6 +345,17 @@ func (e *Editor) CommitDocument(ctx context.Context, cvID uuid.UUID, userID int6
 		if err != nil {
 			return err
 		}
+		// Refuse BEFORE Sanitize can truncate what the caller sent. Sanitize below keeps the
+		// first cv.MaxBullets and drops the rest; checking after it ran would see a document
+		// that already lost the excess and could never trip ErrListCap. This is the same
+		// guard commit() applies to an agent's Ops batch, extended to a whole-document save —
+		// PATCH /me/cvs/:id (the editor's autosave) and Reset from résumé both go through
+		// here, and a pasted section or a bank seed can carry more than the cap.
+		if e.refuseListCap {
+			if err := refuseIfSanitizeDropsContent(next, State{}); err != nil {
+				return err
+			}
+		}
 		// Sanitize the incoming state first, so the diff is against what would be stored
 		// rather than against what was sent — otherwise a value the sanitizer clamps would
 		// show up as an edit on every save.

--- a/internal/cvedit/listcap_test.go
+++ b/internal/cvedit/listcap_test.go
@@ -195,3 +195,77 @@ func TestCommitStillDropsWhitespaceOnlyBulletsWithoutRefusing(t *testing.T) {
 		t.Fatalf("bullets = %d, want 1 after empty cleanup", got)
 	}
 }
+
+// CommitDocument (the editor's autosave PATCH, and Reset from résumé) sanitizes the incoming
+// state before diffing against what is stored — so the refuse check must run against the RAW
+// next document, before that sanitize can truncate it away. A whole-document save that carries
+// more than the cap for one role must be refused exactly like an agent's over-cap insert.
+func TestCommitDocumentRefusesAWholeDocumentSaveOverTheCap(t *testing.T) {
+	prev := cv.MaxBullets
+	cv.SetMaxBullets(20)
+	t.Cleanup(func() { cv.SetMaxBullets(prev) })
+
+	repo := newFakeRepo()
+	e, _ := newEditor(repo, nil)
+
+	next := sample()
+	bullets := make([]string, cv.MaxBullets+1)
+	for i := range bullets {
+		bullets[i] = fmt.Sprintf("Seeded bullet %d", i+1)
+	}
+	next.Experience[0].Bullets = bullets
+
+	_, _, err := e.CommitDocument(context.Background(), repo.cvID, 1, ActorCandidate, OriginImport, next)
+	if !errors.Is(err, ErrListCap) {
+		t.Fatalf("CommitDocument = %v, want ErrListCap", err)
+	}
+	if repo.saves != 0 || len(repo.revisions) != 0 {
+		t.Fatal("a refused whole-document save must not save or file a revision")
+	}
+	if got := len(repo.state.Experience[0].Bullets); got != 2 {
+		t.Fatalf("stored bullets = %d, want the original 2 untouched", got)
+	}
+}
+
+// SetRefuseListCap(false) is the ops kill switch (CV_EDIT_ALLOW_BULLET_TRUNCATION=true) and must
+// restore the exact pre-refuse behaviour for a whole-document save too: Sanitize keeps the
+// first MaxBullets and silently drops the rest.
+func TestCommitDocumentAllowsOverCapWhenRefuseIsDisabled(t *testing.T) {
+	prev := cv.MaxBullets
+	cv.SetMaxBullets(20)
+	t.Cleanup(func() { cv.SetMaxBullets(prev) })
+
+	repo := newFakeRepo()
+	e := NewEditor(repo, nil).SetRefuseListCap(false)
+
+	next := sample()
+	bullets := make([]string, cv.MaxBullets+5)
+	for i := range bullets {
+		bullets[i] = fmt.Sprintf("Seeded bullet %d", i+1)
+	}
+	next.Experience[0].Bullets = bullets
+
+	_, _, err := e.CommitDocument(context.Background(), repo.cvID, 1, ActorCandidate, OriginImport, next)
+	if err != nil {
+		t.Fatalf("CommitDocument with refuse off: %v", err)
+	}
+	if got := len(repo.state.Experience[0].Bullets); got != cv.MaxBullets {
+		t.Fatalf("bullets = %d, want Sanitize to keep %d when refuse is off", got, cv.MaxBullets)
+	}
+}
+
+// A whole-document save under the cap must not be affected by the new guard at all.
+func TestCommitDocumentAllowsAWholeDocumentSaveUnderTheCap(t *testing.T) {
+	repo := newFakeRepo()
+	e, _ := newEditor(repo, nil)
+
+	next := sample()
+	next.Summary = "Distributed systems"
+
+	if _, _, err := e.CommitDocument(context.Background(), repo.cvID, 1, ActorCandidate, OriginEditor, next); err != nil {
+		t.Fatalf("CommitDocument under the cap: %v", err)
+	}
+	if repo.state.Summary != "Distributed systems" {
+		t.Fatalf("summary = %q, want the save applied", repo.state.Summary)
+	}
+}

--- a/internal/handler/cv_integration_test.go
+++ b/internal/handler/cv_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
@@ -510,5 +512,54 @@ func TestEveryEntryPointLeavesARevision(t *testing.T) {
 	}
 	if after := count(); after != before+1 {
 		t.Errorf("the template pick left %d revisions, want one more than %d", after, before)
+	}
+}
+
+// UpdateCV (PUT /me/cvs/:id, the editor's autosave) goes through CommitDocument, which used
+// to sanitize the incoming document before diffing — so an over-cap experience was silently
+// truncated to cv.MaxBullets with no error, the exact loss cv_edit's ErrListCap refuses for
+// an agent's insert. This pins that the whole-document save path refuses it too.
+func TestUpdateCV_RefusesAWholeDocumentSaveOverTheBulletCap(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	if _, err := pool.Exec(context.Background(), "TRUNCATE cvs, users RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h := &cvHandlers{queries: queries, jobReader: queries,
+		cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
+		editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: experience.NewStore(experience.NewQueriesRepository(queries))}),
+		resume:  resume.New(nil, resume.NewQueriesRepository(queries))}
+	app := buildCVApp(h, iss)
+	tok, _ := iss.Issue(seedAccount(t, pool, "bulletcap@example.test", true), testTokenVersion)
+
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs", tok, createCVRequest{Title: "General"})
+	var created struct {
+		Data cvResponse `json:"data"`
+	}
+	decodeJSON(t, resp, &created)
+	id := created.Data.ID
+
+	bullets := make([]string, cv.MaxBullets+1)
+	for i := range bullets {
+		bullets[i] = fmt.Sprintf("Pasted bullet %d", i+1)
+	}
+	overCap := cv.Document{
+		Header:     cv.Header{FullName: "Ada Lovelace"},
+		Experience: []cv.ExperienceItem{{Role: "Engineer", Company: "Acme", Bullets: bullets}},
+	}
+	upPath := "/api/v1/me/cvs/" + id
+	putResp := doCV(t, app, fiber.MethodPut, upPath, tok, updateCVRequest{Title: "General", Document: overCap})
+	if putResp.StatusCode != fiber.StatusConflict {
+		body, _ := io.ReadAll(putResp.Body)
+		t.Fatalf("over-cap save = %d, want 409: %s", putResp.StatusCode, body)
+	}
+
+	var got struct {
+		Data cvResponse `json:"data"`
+	}
+	decodeJSON(t, doCV(t, app, fiber.MethodGet, upPath, tok, nil), &got)
+	if len(got.Data.Document.Experience) != 0 {
+		t.Fatalf("a refused save must not have written anything: %+v", got.Data.Document.Experience)
 	}
 }

--- a/internal/handler/cv_reset.go
+++ b/internal/handler/cv_reset.go
@@ -44,10 +44,12 @@ func (h *cvHandlers) ResetCVFromResume(c *fiber.Ctx) error {
 	}
 	seeded := cv.Seed(st)
 
-	if err := h.reseedBaseFromSeed(c, userID, seeded); err != nil {
-		return err
-	}
-
+	// The requested target commits first: if the tailored copy is what the seed cannot
+	// satisfy (e.g. a role over the bullet cap refuses the whole-document write), nothing
+	// is written at all. Refreshing the base second means a failure there after the target
+	// already succeeded leaves the base merely stale — the same state a plain page reload
+	// would find it in before this call — rather than a request that "failed" while having
+	// silently rewritten a CV the caller did not ask to touch.
 	_, _, err = h.editor.CommitDocument(c.Context(), id, userID,
 		cvedit.ActorCandidate, cvedit.OriginImport,
 		applySeedContent(cvedit.State{
@@ -57,6 +59,10 @@ func (h *cvHandlers) ResetCVFromResume(c *fiber.Ctx) error {
 		}, seeded))
 	if err != nil {
 		return mapCVError(err)
+	}
+
+	if err := h.reseedBaseFromSeed(c, userID, seeded); err != nil {
+		return err
 	}
 
 	out, err := h.cvStore.Get(c.Context(), id, userID)

--- a/internal/handler/cv_reset_integration_test.go
+++ b/internal/handler/cv_reset_integration_test.go
@@ -5,6 +5,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/experience"
 	"github.com/strelov1/freehire/internal/resumeextract"
 )
 
@@ -232,5 +234,78 @@ func TestResetCVFromResume_DoesNotChangeProfile(t *testing.T) {
 	}
 	if len(skills) != 1 || skills[0] != "go" {
 		t.Fatalf("profile skills = %v, want [go] unchanged (Reset must not merge)", skills)
+	}
+}
+
+// A bank role with more banked, publishable claims than cv.MaxBullets is exactly the seed
+// CommitDocument used to truncate silently (it sanitizes before diffing, so the refuse
+// guard never saw the overflow). Reset must refuse instead — and because the tailored
+// target now commits before the base refresh, a refusal must leave BOTH untouched rather
+// than a base already rewritten under a request that reports failure.
+func TestResetCVFromResume_RefusesWhenTheBankSeedExceedsTheBulletCap(t *testing.T) {
+	prevMax := cv.MaxBullets
+	cv.SetMaxBullets(20)
+	t.Cleanup(func() { cv.SetMaxBullets(prevMax) })
+
+	h, iss, pool := newTailorAPI(t)
+	bank := experience.NewStore(experience.NewQueriesRepository(h.queries))
+	h.seeder = bankedSeeder{resume: h.resume, bank: bank}
+
+	userID := seedAccount(t, pool, "overcap-reset@example.com", false)
+	tok, _ := iss.Issue(userID, 1)
+	ctx := context.Background()
+
+	emp, err := bank.CreateEmployment(ctx, userID, experience.Employment{
+		Kind: experience.KindJob, Company: "Neon", Role: "Staff Engineer",
+		Start: "2018", End: "2024",
+	})
+	if err != nil {
+		t.Fatalf("CreateEmployment: %v", err)
+	}
+	for i := 0; i < cv.MaxBullets+1; i++ {
+		if _, err := bank.AddAtom(ctx, userID, experience.Atom{
+			EmploymentID: &emp.ID,
+			Claim:        fmt.Sprintf("Banked achievement %d", i+1),
+			Provenance:   experience.ProvenanceStatedInChat,
+		}); err != nil {
+			t.Fatalf("AddAtom %d: %v", i, err)
+		}
+	}
+
+	store := h.cvStore
+	base, err := store.Create(ctx, userID, "My CV", cv.DefaultTemplateID, cv.Document{
+		Header: cv.Header{FullName: "Old Base"}, Summary: "old base summary",
+	})
+	if err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	jobID := seedJobSlug(t, pool, "overcap-reset-job")
+	tailored, err := store.CreateTailored(ctx, userID, jobID, "Tailored for Role", cv.DefaultTemplateID, cv.Document{
+		Header: cv.Header{FullName: "Old Tailored"}, Summary: "old tailored summary",
+	})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/"+tailored.ID.String()+"/reset-from-resume", tok, nil)
+	if resp.StatusCode != fiber.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, body)
+	}
+
+	gotTailored, err := store.Get(ctx, tailored.ID, userID)
+	if err != nil {
+		t.Fatalf("get tailored: %v", err)
+	}
+	if gotTailored.Document.Summary != "old tailored summary" {
+		t.Fatalf("tailored summary = %q, want untouched by a refused reset", gotTailored.Document.Summary)
+	}
+	gotBase, ok, err := store.BaseCV(ctx, userID)
+	if err != nil || !ok {
+		t.Fatalf("BaseCV: ok=%v err=%v", ok, err)
+	}
+	if gotBase.ID != base.ID || gotBase.Document.Summary != "old base summary" {
+		t.Fatalf("base = %+v, want untouched — the target failed before the base refresh ran", gotBase.Document)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1622. Code review of that PR found that the new bullet-cap
refuse guard (`ErrListCap` / `bullet_cap`) doesn't actually protect the two
production paths where a candidate is most likely to hit it:

- `PUT /me/cvs/:id` (`UpdateCV`) — the CV editor's autosave, the primary way
  a candidate manually edits a CV.
- `POST /me/cvs/:id/reset-from-resume` (new in #1622) — rebuilds a tailored
  CV and the base CV from the résumé/experience-bank seed.

Both go through `Editor.CommitDocument` (a whole-document save), which calls
`next.Document.Sanitize()` **before** diffing against the stored state — so
by the time the refuse check ran (inside the shared `commit()`), the incoming
document had already been silently truncated to `cv.MaxBullets`, and the
check could never see the overflow. Only the ops-based `Commit` path (the
`cv_edit` agent tool, template switches) was actually protected — exactly
the one path the original PR's own tests exercised.

Net effect before this fix: pasting a long CV section into the editor and
letting autosave fire, or resetting from a résumé where one banked role has
more than `cv.MaxBullets` (default 20) confirmed achievements, both silently
dropped the excess — the exact class of loss #1622's changelog says is fixed
("No more silent bullet truncation").

## Changes

- `internal/cvedit/editor.go`: `CommitDocument` now runs the same
  `refuseIfSanitizeDropsContent` check against the raw incoming document
  *before* its own pre-diff `Sanitize()` call, when `refuseListCap` is on
  (the default; `CV_EDIT_ALLOW_BULLET_TRUNCATION=true` still restores the
  old silent-truncate behaviour for both paths).
- `internal/handler/cv_reset.go`: `ResetCVFromResume` now commits the
  tailored target **before** refreshing the base. Previously the base was
  rewritten first — if the (now-guarded) tailored commit then failed, the
  request reported an error while having already silently rewritten a CV
  nobody asked to touch. Committing the actual target first means a refusal
  leaves both untouched; a failure in the best-effort base refresh after
  that only leaves the base stale (self-heals on the next tailor bootstrap
  or Reset).
- Tests: `TestCommitDocumentRefusesAWholeDocumentSaveOverTheCap` /
  `TestCommitDocumentAllowsOverCapWhenRefuseIsDisabled` /
  `TestCommitDocumentAllowsAWholeDocumentSaveUnderTheCap` (cvedit),
  `TestUpdateCV_RefusesAWholeDocumentSaveOverTheBulletCap` (handler,
  integration), `TestResetCVFromResume_RefusesWhenTheBankSeedExceedsTheBulletCap`
  (handler, integration) — the last two fail against `main` before this fix
  and pass after.
- `internal/cvedit/AGENTS.md`, `internal/cv/AGENTS.md`: documented the fix
  and the commit-order rationale so the ordering doesn't regress silently.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test -tags=integration ./internal/cvedit/... ./internal/handler/...` (Docker/testcontainers)