### PR TITLE
fix(sources): remove duplicate board entries added in #1623

### DIFF
--- a/sources/gupy.yml
+++ b/sources/gupy.yml
@@ -2913,7 +2913,3 @@
 # --- contributed boards ---
 - company: Realco Soluções em Gestão de Pessoas
   board: "21289"
-- company: PhizChat
-  board: "91018"
-- company: Porto
-  board: "54421"

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -1276,5 +1276,3 @@
 # --- from the contribution queue (2026-08-07, live-validated) ---
 - company: PicPay
   board: epdm.fa.la1.oraclecloud.com/PicPay
-- company: JPMorgan Chase
-  board: jpmc.fa.oraclecloud.com/CX_1001


### PR DESCRIPTION
## Summary
- Removes 3 duplicate YAML rows added by #1623: `PhizChat`/91018 and `Porto`/54421 (gupy) and `JPMorgan Chase`/CX_1001 (oracle) were already tracked under different company labels (`PWS Cloud`, `Porto`, `JP Morgan Chase`). Same `(source, board)`, so a duplicate row — caught when promoting the corresponding `link_contributions` rows hit the DB unique constraint.
- `PicPay` (oracle) is untouched — it was genuinely new.

## Test plan
- [x] `go build ./...`
- [x] Diff confirmed to be exactly the 3 duplicate-row removals, nothing else