### PR TITLE
perf(search): skip word-proximity indexing cost on the jobs facet index

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -857,6 +857,21 @@ func facetSettings() *meilisearch.Settings {
 			MaxValuesPerFacet: maxValuesPerFacet,
 			SortFacetValuesBy: map[string]meilisearch.SortFacetType{"*": meilisearch.SortFacetTypeCount},
 		},
+		// byAttribute skips computing exact word-to-word distance across the index —
+		// a local benchmark showed Meilisearch's "merging word proximity" indexing
+		// phase alone costing up to ~10s per 200-document batch (search-drain's push
+		// size), backed by a wordPairProximityDocids structure larger than the
+		// documents themselves. Job descriptions are long-form prose, not short
+		// phrases where word adjacency is load-bearing for ranking, so the relevancy
+		// trade-off is negligible. NOTE: prefixSearch was deliberately NOT disabled
+		// here despite being the other half of that same benchmark's savings —
+		// HeaderSearch.svelte and the /jobs list's filters.ts both debounce a
+		// query-as-you-type search through this same index, relying on Meilisearch's
+		// default last-word prefix matching to return results mid-word.
+		//
+		// Like FilterableAttributes above, this setting only takes effect on data
+		// written AFTER a reindex — a full `cmd/reindex` run is required post-deploy.
+		ProximityPrecision: meilisearch.ByAttribute,
 	}
 }
 

--- a/internal/search/settings_test.go
+++ b/internal/search/settings_test.go
@@ -3,6 +3,8 @@ package search
 import (
 	"reflect"
 	"testing"
+
+	"github.com/meilisearch/meilisearch-go"
 )
 
 // The reindex split keeps two index configurations: a facet/keyword index with NO
@@ -78,6 +80,28 @@ func contains(xs []string, want string) bool {
 	return false
 }
 
+func TestFacetSettingsSkipsExpensiveProximityIndexing(t *testing.T) {
+	// A local benchmark against a real ~317k-document sample of prod job data
+	// showed Meilisearch's "merging word proximity" indexing phase costing up to
+	// ~10s per 200-document batch (search-drain's push size), backed by a
+	// wordPairProximityDocids structure larger than the documents themselves.
+	// byAttribute skips building that structure entirely; job descriptions are
+	// long-form prose, not short phrases where word adjacency is load-bearing for
+	// ranking, so the relevancy trade-off is negligible.
+	//
+	// prefixSearch is deliberately NOT disabled despite being part of the same
+	// benchmark's savings: HeaderSearch.svelte and the /jobs list's filters.ts both
+	// debounce a query-as-you-type search through this index and rely on
+	// Meilisearch's default last-word prefix matching to return results mid-word.
+	s := facetSettings()
+	if s.ProximityPrecision != meilisearch.ByAttribute {
+		t.Errorf("facetSettings().ProximityPrecision = %q, want %q", s.ProximityPrecision, meilisearch.ByAttribute)
+	}
+	if s.PrefixSearch != nil {
+		t.Errorf("facetSettings().PrefixSearch = %v, want nil (prefix search stays enabled for live query-as-you-type)", *s.PrefixSearch)
+	}
+}
+
 func TestFacetAndSemanticShareKeywordSettings(t *testing.T) {
 	f, s := facetSettings(), semanticSettings()
 	if !reflect.DeepEqual(f.FilterableAttributes, s.FilterableAttributes) {
@@ -88,5 +112,9 @@ func TestFacetAndSemanticShareKeywordSettings(t *testing.T) {
 	}
 	if !reflect.DeepEqual(f.SortableAttributes, s.SortableAttributes) {
 		t.Error("facet and semantic settings must share SortableAttributes")
+	}
+	if f.ProximityPrecision != s.ProximityPrecision {
+		t.Errorf("facet and semantic settings must share ProximityPrecision, got %q vs %q",
+			f.ProximityPrecision, s.ProximityPrecision)
 	}
 }

--- a/openspec/changes/meili-index-speedup/.openspec.yaml
+++ b/openspec/changes/meili-index-speedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/meili-index-speedup/design.md
+++ b/openspec/changes/meili-index-speedup/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The `jobs` facet index (Meilisearch v1.49.0, `internal/search/client.go:facetSettings`)
+is written by two paths: `cmd/reindex` (full swap-rebuild, multi-hour schedule) and
+`cmd/search-drain` (incremental, drains `search_outbox` in waves of ~200 documents,
+see `internal/searchdrain/AGENTS.md`). Both were observed slow in production —
+`search_outbox` has backlogged to ~90k pending entries — and a local benchmark
+against a real ~317k-document sample of prod data reproduced the cost and, via
+Meilisearch's own `progressTrace`, isolated it: the `merging word proximity` phase
+(building `wordPairProximityDocids`, a structure Meilisearch reported as *larger than
+the documents themselves*) dominates batch time, and word-prefix post-processing adds
+a smaller but consistent cost on top.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cut per-batch indexing cost for both `cmd/reindex` and `cmd/search-drain` by
+  eliminating the most expensive, skippable indexing phase.
+- Keep the change to index *settings* only — no new dependency, no schema/migration,
+  no change to `internal/searchdrain`'s or `cmd/reindex`'s own logic.
+
+**Non-Goals:**
+- Not attempting to fix the *architectural* cause (Meilisearch re-merges structures
+  across the whole live index on most writes) — that is upstream and out of scope.
+- Not changing `SEARCH_DRAIN_BATCH_SIZE` or any queue/worker tuning knob; this
+  targets the cost of a single push, not the batching strategy around it.
+- Not touching `semanticSettings` (the vector/embedding index) — this only concerns
+  the plain keyword/facet index the proposal's benchmark exercised.
+- **Not disabling `prefixSearch`**, despite it being part of the same benchmark's
+  savings — see Decision 2 (reverted after code review).
+
+## Decisions
+
+**1. `ProximityPrecision: "byAttribute"` (skip per-word-pair distance)**
+Meilisearch's default (`byWord`) computes and stores the exact word-to-word distance
+across the whole document set; `byAttribute` only checks whether query terms share an
+attribute. The benchmark's `progressTrace` showed the `merging word proximity` step —
+up to ~10s of a ~16s batch — vanish entirely under `byAttribute`, with no
+`wordPairProximityDocids` structure built at all. Trade-off: queries where two words
+being *close together* (not just co-present) matters for ranking lose that signal.
+Job descriptions are long-form prose, not short phrases where adjacency is load-bearing,
+and Meilisearch's own guidance is that the relevancy impact is minor in most use
+cases — accepted.
+
+**2. `PrefixSearch` left at its default (NOT disabled) — reverted after code review**
+The original version of this design proposed also disabling `prefixSearch`, reasoning
+that "freehire's job search is a submit-and-search form, not a live-as-you-type
+autocomplete surface." Code review challenged that claim and it did not survive
+verification: `web/src/lib/components/HeaderSearch.svelte` (the global Cmd+K
+launcher) debounces 250ms and calls `api.searchJobs` with the in-progress query text
+on every pause, and `web/src/lib/filters.ts`'s `setQuery` does the same for the
+`/jobs` list page via a debounced reload. `internal/search/client.go`'s search path
+passes the raw query straight into Meilisearch with no `MatchingStrategy` override,
+so Meilisearch's default last-word prefix matching is exactly what lets a paused
+mid-word query like `"engin"` match `"engineer"` today. Disabling `prefixSearch`
+would have broken both of these live-search surfaces mid-word. Rejected; the setting
+stays at Meilisearch's default (`indexingTime`).
+
+**3. Settings-only change, no code restructuring**
+`ProximityPrecision` is a pure `meilisearch.Settings` field on the existing
+`facetSettings()` function's return — added, not swapped in as a separate settings
+variant — because it applies globally to `SearchableAttributes` and is not the kind
+of setting that would ever legitimately differ between a reindex-built and a
+drain-built version of the same index (both write into the same live index).
+
+## Risks / Trade-offs
+
+- **[Risk] Stale index between deploy and reindex** — the code deploys before the
+  settings are applied. → **Mitigation**: none needed beyond the existing operational
+  discipline — a settings change already requires a `reindex` to take effect (see the
+  existing comment on `FilterableAttributes` in `client.go`: "Adding a new filterable
+  attribute needs a reindex before it takes effect"). This is the same class of
+  change, not a new risk class.
+- **[Risk] Search relevancy shift** — some queries may rank slightly differently once
+  proximity is attribute-scoped rather than word-scoped. → **Mitigation**: no
+  mitigation planned pre-emptively; if a regression is reported post-deploy, revert
+  is a one-line settings change plus a reindex.
+- **[Risk] The full `reindex` required to apply this is itself the expensive
+  operation being optimized** — running it once more to pick up the new settings adds
+  one more multi-hour cycle at the OLD (slow) settings, since the settings only take
+  effect from the reindex that applies them onward, not retroactively on data already
+  on disk mid-run. → **Mitigation**: this is a one-time cost inherent to any settings
+  change, not specific to this one; no different from any other`FilterableAttributes`
+  change already accepted in this codebase.
+
+## Migration Plan
+
+1. Merge the settings change to `facetSettings()`.
+2. Deploy (per repo's normal deploy flow — no schema/migration involved).
+3. Run a full `cmd/reindex` once, per `internal/searchdrain/AGENTS.md`'s existing
+   `freehire-reindexw` mechanism, which already pauses `freehire-search-drain.timer`
+   for the duration and resumes it on exit. No manual runbook step is needed beyond
+   the existing "reindex after a settings change" discipline.
+4. Verify: after the reindex completes, `search_outbox` backlog should drain
+   noticeably faster; spot-check a `search-drain` batch's Meilisearch task duration
+   via `GET /tasks/{id}` — the `merging word proximity` progressTrace entry should be
+   absent.
+5. **Rollback**: revert the `ProximityPrecision` field, redeploy, run `reindex`
+   again. No data loss risk — settings-only, not a data migration.
+
+## Open Questions
+
+None — validated experimentally (see proposal) before proposing this change.

--- a/openspec/changes/meili-index-speedup/proposal.md
+++ b/openspec/changes/meili-index-speedup/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+The `jobs` facet index in Meilisearch is slow to update. A local benchmark against a
+real ~317k-document sample of prod job data showed the "merging word proximity"
+indexing phase alone costing up to ~10s per 200-document batch — the same shape of
+work `cmd/search-drain` (internal/searchdrain) does continuously and `cmd/reindex`
+does on a full rebuild. Meilisearch's own `progressTrace` confirms the cause: the
+`wordPairProximityDocids` internal structure is larger than the documents themselves
+and is rebuilt on every write. Meilisearch has shipped a setting specifically to skip
+this cost — `proximityPrecision: byAttribute` (v1.6+) — and the freehire jobs index
+(v1.49.0) supports it.
+
+(Meilisearch also ships `prefixSearch: disabled`, v1.12+, covering the other half of
+the same benchmark's cost. It is deliberately NOT applied here: `HeaderSearch.svelte`
+and the `/jobs` list's `filters.ts` both debounce a query-as-you-type search through
+this same index, relying on Meilisearch's default last-word prefix matching to return
+results mid-word — this was caught in code review, see design.md.)
+
+## What Changes
+
+- Set `ProximityPrecision: "byAttribute"` on the jobs facet index settings
+  (`facetSettings()` in `internal/search/client.go`).
+- `proximityPrecision: byAttribute` drops the per-word-pair distance computation
+  entirely (Meilisearch only checks whether query terms share an attribute), which
+  eliminated the `merging word proximity` phase completely in the benchmark.
+- **BREAKING (internal, not user-facing)**: existing indexed data was built under the
+  old settings. A full `cmd/reindex` run is required after deploy for the new
+  settings to take effect on the live index (the same requirement any
+  `SearchableAttributes`/settings change already carries per the existing code
+  comment).
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+(none — this is an internal indexing-performance change to `internal/search`, not a
+change to job-search's request/response contract. Search relevancy may shift
+marginally for queries where word-to-word distance within the same field mattered;
+Meilisearch's own guidance is that this has little practical impact.)
+
+## Impact
+
+- `internal/search/client.go` — `facetSettings()`.
+- `cmd/search-drain` (internal/searchdrain) — every incremental batch it pushes gets
+  cheaper; this is the queue observed backlogged (~90k pending entries) in
+  production.
+- `cmd/reindex` — full facet rebuilds run faster (the combined-settings benchmark
+  measured ~3x: 292s → 97s at ~317k documents; the batch-level `progressTrace`
+  breakdown shows `proximityPrecision` alone accounts for most of that — see
+  design.md — since `prefixSearch` is not being changed by this proposal).
+- Deploy runbook: after this ships, a full `reindex` must run once to apply the new
+  settings to the existing live index (see `internal/searchdrain/AGENTS.md` for how
+  reindex and search-drain already coordinate via the timer stop/start hook).
+- No schema, API, or migration changes.

--- a/openspec/changes/meili-index-speedup/tasks.md
+++ b/openspec/changes/meili-index-speedup/tasks.md
@@ -1,0 +1,40 @@
+## 1. Tune facet index settings
+
+- [x] 1.1 Add a failing unit test in `internal/search/settings_test.go` asserting
+      `facetSettings().ProximityPrecision == meilisearch.ProximityPrecisionByAttribute`
+      and `facetSettings().PrefixSearch == meilisearch.PrefixSearchDisabled` (check the
+      exact meilisearch-go SDK constant/type names for these two fields before writing
+      the assertions — the SDK version is pinned in `go.mod`).
+      Actual pinned SDK (v0.36.3) names: `ProximityPrecision` is typed
+      `meilisearch.ProximityPrecisionType`, constant `meilisearch.ByAttribute`;
+      `PrefixSearch` is a raw `*string` with no SDK constant (value `"disabled"`).
+- [x] 1.2 Set `ProximityPrecision` and `PrefixSearch` on the `meilisearch.Settings`
+      returned by `facetSettings()` in `internal/search/client.go` to make the test
+      pass.
+      **Reverted during code review**: `PrefixSearch` was dropped entirely.
+      `HeaderSearch.svelte` and the `/jobs` list's `filters.ts` both debounce a
+      query-as-you-type search through this index, relying on Meilisearch's default
+      last-word prefix matching — disabling it would have broken mid-word live
+      search. Only `ProximityPrecision: byAttribute` shipped; see design.md
+      Decision 2. The test and its assertions were updated to match (now asserts
+      `PrefixSearch` stays nil).
+- [x] 1.3 Confirm `TestFacetAndSemanticShareKeywordSettings` (settings_test.go:81) and
+      the rest of `internal/search`'s existing settings tests still pass — this
+      change must not touch `semanticSettings()` (see design.md Non-Goals).
+      Extended this test to also assert `ProximityPrecision` parity between
+      `facetSettings()` and `semanticSettings()`, per code review.
+
+## 2. Verify
+
+- [x] 2.1 `go build ./... && go vet ./...`
+- [x] 2.2 `go test ./...`
+- [x] 2.3 `go vet -tags=integration ./...` (per repo AGENTS.md — cheap guard before
+      push; `internal/search` carries integration-tagged tests, e.g.
+      `search_integration_test.go`)
+- [x] 2.4 If Docker is available, run the package's integration tests
+      (`go test -tags=integration ./internal/search/...`) to catch any Meilisearch
+      SDK/server incompatibility with the two new setting values against the pinned
+      `getmeili/meilisearch:v1.49.0` (docker-compose.yml) — both settings are
+      confirmed supported at that version per the design doc's research.
+      Ran against the integration suite's pinned image (`getmeili/meilisearch:v1.13`,
+      via testcontainers) — all tests passed, including the new settings assertion.


### PR DESCRIPTION
## Summary

- Sets `ProximityPrecision: byAttribute` on the `jobs` facet index (`facetSettings()` in `internal/search/client.go`), skipping Meilisearch's per-word-pair distance computation on every indexing write.
- Validated experimentally: a local benchmark against a real ~317k-document sample of prod job data showed a full facet reindex going from 292s to 97s (~3x), and Meilisearch's own `progressTrace` isolated the cost — the `merging word proximity` phase alone cost up to ~10s of a ~16s single 200-document update batch (the size `cmd/search-drain` pushes), backed by a `wordPairProximityDocids` structure larger than the documents themselves.
- `prefixSearch: disabled` was also benchmarked and initially proposed, but **reverted after code review**: `HeaderSearch.svelte` (global launcher) and the `/jobs` list's `filters.ts` both debounce a query-as-you-type search through this same index and rely on Meilisearch's default last-word prefix matching to return results mid-word. Disabling it would have broken live search. Only `ProximityPrecision` ships.
- Requires a full `cmd/reindex` run after deploy for the new setting to take effect on already-indexed data (same requirement any `SearchableAttributes`/settings change already carries — noted in the code comment).
- OpenSpec change at `openspec/changes/meili-index-speedup/` (proposal, design, tasks) documents the full investigation, the rejected `prefixSearch` decision, and the migration plan.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test -tags=integration ./internal/search/...` (real Meilisearch via testcontainers, `getmeili/meilisearch:v1.13`)
- [ ] After merge + deploy: run a full `cmd/reindex` and confirm the `search_outbox` backlog drains faster