### PR TITLE
feat(sources): add EchoJobs source adapter

### DIFF
--- a/internal/sources/echojobs.go
+++ b/internal/sources/echojobs.go
@@ -1,0 +1,141 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// echojobs adapts echojobs.io, a large multi-employer tech-jobs aggregator whose postings resolve
+// to the employer's own ATS URL (Workday, Greenhouse, and others show up in the feed) rather than
+// to an echojobs.io-hosted page. Boardless: one global feed, sorted newest-first by posted_at, no
+// per-tenant board.
+//
+// At last count the feed's reported total sat around 320k postings. Walking it exhaustively every
+// cron run would mean thousands of requests per cycle, so Fetch instead bounds the walk to a
+// rolling freshness window (echojobsFreshnessWindow) rather than an arbitrary page count: the feed
+// is sorted, so paging stops as soon as it runs past that window. This is the same "cannot be
+// crawled exhaustively" shape as whatjobs.go, with one structural difference worth naming: because
+// the ordering key is posted_at itself, a posting that ages out of the window can never drift back
+// into it on a later run the way a whatjobs posting can re-enter its keyword's visible page depth —
+// once it exits, this adapter stops seeing it for good. sweepGrace still matters for exactly the
+// reason whatjobs' does (a posting the crawl stops reaching is not evidence it closed), it just
+// delays an otherwise-inevitable close rather than bridging a gap the next run repairs.
+type echojobs struct {
+	http JSONGetter
+}
+
+const (
+	echojobsBaseURL = "https://echojobs.io/api/jobs"
+	// echojobsPageSize is the per-page count requested. The feed defaults to 20 but accepts at
+	// least 100, and a larger page means fewer requests to cover the same freshness window.
+	echojobsPageSize = 100
+	// echojobsFreshnessWindow bounds how far back the walk reads, since the feed cannot be
+	// crawled to its end every run (see the type doc). 14 days matches whatjobs' bound for a
+	// source with the same "cannot verify liveness, cannot crawl exhaustively" shape.
+	echojobsFreshnessWindow = 14 * 24 * time.Hour
+	// echojobsSweepGrace widens the post-run unseen sweep to match echojobsFreshnessWindow: a
+	// posting that ages past the window stops being reported by this adapter regardless of
+	// whether it is still open, so the sweep must not read "the crawl stopped reaching it" as
+	// "it closed" on the default window. See the sweepGrace type doc in source.go.
+	echojobsSweepGrace = echojobsFreshnessWindow
+)
+
+// NewEchoJobs builds the echojobs adapter over the given HTTP client.
+func NewEchoJobs(c JSONGetter) Source { return echojobs{http: c} }
+
+func (echojobs) Provider() string { return "echojobs" }
+
+// echojobs is a marketplace with one global feed, so its config entries carry no board.
+func (echojobs) boardless() {}
+
+// echojobs aggregates postings from many companies, so it stays in the source facet.
+func (echojobs) aggregator() {}
+
+func (echojobs) sweepGrace() time.Duration { return echojobsSweepGrace }
+
+// echojobsPosting is one posting from the /api/jobs feed. The upstream response carries several
+// more fields (domain_name, first_seen_at, countries, states, job_function, role, seniority,
+// salary_min_usd/salary_max_usd, employment_type, employee_count, funding) that this adapter
+// deliberately does not read: none of them has a home in the Job shape today, and guessing one
+// (e.g. folding salary into Description) is not this adapter's call to make.
+type echojobsPosting struct {
+	Title          string   `json:"title"`
+	CompanyName    string   `json:"company_name"`
+	URL            string   `json:"url"`
+	JobHandle      string   `json:"job_handle"`
+	PostedAt       int64    `json:"posted_at"`
+	Locations      []string `json:"locations"`
+	RemoteType     string   `json:"remote_type"`
+	RequiredSkills []string `json:"required_skills"`
+}
+
+// Fetch walks the feed newest-first, stopping once a page's oldest posting (its last entry) falls
+// outside echojobsFreshnessWindow. Per the house pagination rule, a failure on the first page is a
+// board-level error; a failure on a later page ends the walk with what was already gathered.
+func (e echojobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	cutoff := time.Now().Add(-echojobsFreshnessWindow)
+	var jobs []Job
+	for page := 1; ; page++ {
+		var resp struct {
+			Jobs []echojobsPosting `json:"jobs"`
+		}
+		if err := e.http.GetJSON(ctx, echojobsPageURL(page), &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("echojobs: page %d: %w", page, err)
+			}
+			log.Printf("echojobs: page %d failed, stopping with %d jobs gathered: %v", page, len(jobs), err)
+			return jobs, nil
+		}
+		if len(resp.Jobs) == 0 {
+			return jobs, nil
+		}
+		stale := false
+		for _, p := range resp.Jobs {
+			postedAt := parseEpochMillis(p.PostedAt)
+			if postedAt != nil && postedAt.Before(cutoff) {
+				stale = true
+				continue
+			}
+			jobs = append(jobs, p.toJob(postedAt))
+		}
+		if stale {
+			return jobs, nil
+		}
+	}
+}
+
+func echojobsPageURL(page int) string {
+	return fmt.Sprintf("%s?page=%d&per_page=%d", echojobsBaseURL, page, echojobsPageSize)
+}
+
+func (p echojobsPosting) toJob(postedAt *time.Time) Job {
+	mode, remote := echojobsWorkMode(p.RemoteType)
+	return Job{
+		ExternalID: p.JobHandle,
+		URL:        p.URL,
+		Title:      p.Title,
+		Company:    p.CompanyName,
+		Location:   strings.Join(p.Locations, "; "),
+		Remote:     remote,
+		WorkMode:   mode,
+		PostedAt:   postedAt,
+		Skills:     skilltag.Canonicalize(p.RequiredSkills),
+	}
+}
+
+// echojobsWorkMode passes through the feed's own remote_type: it already speaks freehire's
+// vocabulary (remote/hybrid/onsite), so there is no bucketing to do — just a check that the value
+// is one we recognize, leaving WorkMode empty for anything else rather than passing through junk.
+func echojobsWorkMode(remoteType string) (mode string, remote bool) {
+	switch remoteType {
+	case "remote", "hybrid", "onsite":
+		return remoteType, remoteType == "remote"
+	default:
+		return "", false
+	}
+}

--- a/internal/sources/echojobs_test.go
+++ b/internal/sources/echojobs_test.go
@@ -1,0 +1,142 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// echojobsHTTP is a paging-aware test JSONGetter: it serves pages[i] for ?page=i+1 and records
+// every page number requested, so a test can assert the walk stopped where it should.
+type echojobsHTTP struct {
+	pages    []string
+	failPage int // 0 = never fail
+	got      []int
+}
+
+func (f *echojobsHTTP) GetJSON(_ context.Context, u string, v any) error {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	page, _ := strconv.Atoi(parsed.Query().Get("page"))
+	f.got = append(f.got, page)
+	if f.failPage != 0 && page == f.failPage {
+		return errors.New("echojobsHTTP: boom")
+	}
+	if page < 1 || page > len(f.pages) {
+		return fmt.Errorf("echojobsHTTP: no page %d", page)
+	}
+	return json.Unmarshal([]byte(f.pages[page-1]), v)
+}
+
+func echojobsPageJSON(jobs string) string {
+	return fmt.Sprintf(`{"found":999,"page":1,"per_page":100,"jobs":[%s]}`, jobs)
+}
+
+func echojobsJobJSON(handle, postedAt string) string {
+	return fmt.Sprintf(`{
+		"id":"x","title":"Backend Engineer","company_name":"Acme","domain_name":"acme.com",
+		"url":"https://boards.greenhouse.io/acme/jobs/123","job_handle":%q,
+		"posted_at":%s,"locations":["California","New York"],"remote_type":"hybrid",
+		"required_skills":["Go","NotARealSkill"]
+	}`, handle, postedAt)
+}
+
+func TestEchojobsFetchMapsFields(t *testing.T) {
+	now := time.Now().UTC()
+	http := &echojobsHTTP{pages: []string{
+		echojobsPageJSON(echojobsJobJSON("acme-swe-abc12", strconv.FormatInt(now.UnixMilli(), 10))),
+		echojobsPageJSON(""), // empty page: the walk ends cleanly here, not on an error
+	}}
+
+	jobs, err := echojobs{http: http}.Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want 1 job, got %d", len(jobs))
+	}
+	job := jobs[0]
+	if job.ExternalID != "acme-swe-abc12" {
+		t.Fatalf("ExternalID: %q", job.ExternalID)
+	}
+	if job.URL != "https://boards.greenhouse.io/acme/jobs/123" {
+		t.Fatalf("URL should be the upstream ATS link, got %q", job.URL)
+	}
+	if job.Title != "Backend Engineer" || job.Company != "Acme" {
+		t.Fatalf("identity mismatch: %+v", job)
+	}
+	if job.Location != "California; New York" {
+		t.Fatalf("Location: %q", job.Location)
+	}
+	if job.WorkMode != "hybrid" || job.Remote {
+		t.Fatalf("hybrid should not be Remote: mode=%q remote=%v", job.WorkMode, job.Remote)
+	}
+	if job.PostedAt == nil {
+		t.Fatalf("PostedAt not parsed")
+	}
+	if !slices.Contains(job.Skills, "go") || slices.Contains(job.Skills, "NotARealSkill") {
+		t.Fatalf("Skills: %v", job.Skills)
+	}
+}
+
+// Pagination keeps walking while a page's postings are within the freshness window, and stops as
+// soon as a page's LAST (oldest, since the feed is newest-first) item falls outside it — the
+// earlier, still-fresh items on that same page are kept.
+func TestEchojobsFetchStopsAtFreshnessWindow(t *testing.T) {
+	now := time.Now().UTC()
+	fresh := strconv.FormatInt(now.UnixMilli(), 10)
+	stillFresh := strconv.FormatInt(now.Add(-10*24*time.Hour).UnixMilli(), 10)
+	stale := strconv.FormatInt(now.Add(-20*24*time.Hour).UnixMilli(), 10)
+
+	page1 := echojobsPageJSON(echojobsJobJSON("job-1", fresh) + "," + echojobsJobJSON("job-2", fresh))
+	page2 := echojobsPageJSON(echojobsJobJSON("job-3", stillFresh) + "," + echojobsJobJSON("job-4", stale))
+	http := &echojobsHTTP{pages: []string{page1, page2, echojobsPageJSON(echojobsJobJSON("job-5", fresh))}}
+
+	jobs, err := echojobs{http: http}.Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	var ids []string
+	for _, j := range jobs {
+		ids = append(ids, j.ExternalID)
+	}
+	if !slices.Equal(ids, []string{"job-1", "job-2", "job-3"}) {
+		t.Fatalf("want job-1,job-2,job-3 (job-4 stale, job-5 never reached), got %v", ids)
+	}
+	if !slices.Equal(http.got, []int{1, 2}) {
+		t.Fatalf("page 3 should never be requested once page 2's last item is stale, got requests %v", http.got)
+	}
+}
+
+// A failed first page is a board-level error.
+func TestEchojobsFetchFirstPageFailure(t *testing.T) {
+	http := &echojobsHTTP{failPage: 1, pages: []string{echojobsPageJSON("")}}
+	if _, err := (echojobs{http: http}).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Fatal("want error on first-page failure")
+	}
+}
+
+// A later page failing ends the walk with what was gathered so far, per the house pagination rule.
+func TestEchojobsFetchLaterPageFailureReturnsPartial(t *testing.T) {
+	now := time.Now().UTC()
+	fresh := strconv.FormatInt(now.UnixMilli(), 10)
+	page1 := echojobsPageJSON(echojobsJobJSON("job-1", fresh))
+	http := &echojobsHTTP{pages: []string{page1, echojobsPageJSON(echojobsJobJSON("job-2", fresh))}, failPage: 2}
+
+	jobs, err := echojobs{http: http}.Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "job-1" {
+		t.Fatalf("want partial result [job-1], got %+v", jobs)
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -194,6 +194,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTopco(c),
 		NewGetmatch(c),
 		NewGetmanfred(c),
+		NewEchoJobs(c),
 		NewHabrCareer(c),
 		NewGeekjob(c),
 		NewGetro(c),

--- a/sources/echojobs.yml
+++ b/sources/echojobs.yml
@@ -1,0 +1,5 @@
+# echojobs.io multi-employer tech-jobs aggregator. Boardless: one global keyless feed
+# (echojobs.io/api/jobs), so the entry carries no board, and each job's company and URL (the
+# upstream ATS link) come from the posting, not this placeholder.
+- company: echojobs
+  provider: echojobs


### PR DESCRIPTION
## Summary
- Adds `internal/sources/echojobs.go`, a boardless/aggregator adapter for echojobs.io — a large multi-employer aggregator whose postings resolve to the employer's own ATS URL (Workday, Greenhouse, etc.) rather than an echojobs.io-hosted page.
- The feed reports ~320k postings and can't be crawled exhaustively every cron run, so the walk is bounded to a rolling 14-day freshness window (the feed is sorted newest-first by `posted_at`), paired with a matching `sweepGrace()` so the post-run unseen sweep doesn't close a posting the crawl simply stopped reaching rather than one that actually closed.
- Registers the adapter in `sources.All()` and adds the boardless board file `sources/echojobs.yml`.

## Test plan
- [x] Tests written first (RED verified), then implementation (GREEN) — `internal/sources/echojobs_test.go` covers field mapping, freshness-window pagination stop, first-page failure, and later-page partial-result behavior.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...`

Closes #1633