### PR TITLE
feat(sources): add Adzuna source adapter

### DIFF
--- a/internal/sources/adzuna.go
+++ b/internal/sources/adzuna.go
@@ -1,0 +1,134 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// adzuna adapts the Adzuna Job Search API v1 (api.adzuna.com), an independent job aggregator
+// operating its own employer/recruiter feeds across many countries. It is the one KEYED source
+// besides usajobs/reed/whatjobs: every request needs an app_id/app_key pair, so the adapter is
+// registered only when both ADZUNA_APP_ID and ADZUNA_APP_KEY are set (see All).
+//
+// Unlike the boardless aggregators (getmanfred, echojobs), Adzuna has no "list everything" call —
+// every request selects a country and, within it, a category (e.g. "it-jobs"), the same shape
+// whatjobs' keyword board and trudvsem's OKATO-region board already use for a source whose real
+// catalogue is far deeper than any one crawl can walk. The country goes in CompanyEntry.Region
+// (it is literally which regional API path segment to hit — /jobs/{country}/search/{page} — the
+// same job Region already does for Lever's EU host), and the category in CompanyEntry.Board.
+// Category, not free-text keyword: a live check confirmed it is a hard filter (every result on
+// page 50 of "it-jobs" still tagged it-jobs), unlike whatjobs' relevance-ranked keyword search,
+// which pads a thin result set with unrelated inventory past the first page or two — so this
+// adapter does not need whatjobs' corroboration-and-relevance-collapse logic.
+type adzuna struct {
+	http   JSONGetter
+	appID  string
+	appKey string
+}
+
+const (
+	adzunaBaseURL = "https://api.adzuna.com/v1/api/jobs"
+	// adzunaPageSize is the commonly documented page-size ceiling for this API.
+	adzunaPageSize = 50
+	// adzunaMaxPages bounds one board's crawl. A single category in a single country routinely
+	// reports tens of thousands of results (46k for gb/it-jobs at last check), far deeper than
+	// any crawl should walk every cycle, so the board is read as a bounded recent slice — same
+	// trade-off whatjobsMaxPages documents.
+	adzunaMaxPages = 40
+	// adzunaSweepGrace widens the unseen sweep for the same reason whatjobs' does: redirect_url
+	// routes through Adzuna's own domain rather than the employer's site, so a posting's liveness
+	// cannot be probed directly, and the crawl reaches only a bounded slice of a much deeper feed.
+	adzunaSweepGrace = 14 * 24 * time.Hour
+)
+
+// NewAdzuna builds the Adzuna adapter over the given HTTP client and credential pair.
+func NewAdzuna(c JSONGetter, appID, appKey string) Source {
+	return adzuna{http: c, appID: appID, appKey: appKey}
+}
+
+func (adzuna) Provider() string { return "adzuna" }
+
+// adzuna aggregates postings from many employers, so it stays in the source facet.
+func (adzuna) aggregator() {}
+
+func (adzuna) sweepGrace() time.Duration { return adzunaSweepGrace }
+
+// adzunaPosting is one search result. Several fields the API sends are deliberately unread —
+// salary_min/salary_max/salary_is_predicted and category — because none has a home in the Job
+// shape today, mirroring echojobs' treatment of its own unread vendor fields.
+type adzunaPosting struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Created     string `json:"created"`
+	RedirectURL string `json:"redirect_url"`
+	Company     struct {
+		DisplayName string `json:"display_name"`
+	} `json:"company"`
+	Location struct {
+		DisplayName string `json:"display_name"`
+	} `json:"location"`
+}
+
+// Fetch reads one country+category slice. Per the house pagination rule, a failure on the first
+// page is a board-level error; a failure on a later page ends the walk with what was already
+// gathered. Pagination stops on an empty page or at adzunaMaxPages.
+func (a adzuna) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	country := strings.TrimSpace(e.Region)
+	if country == "" {
+		return nil, fmt.Errorf("adzuna: company %q has a blank country (Region)", e.Company)
+	}
+	category := strings.TrimSpace(e.Board)
+	if category == "" {
+		return nil, fmt.Errorf("adzuna: company %q has a blank category board", e.Company)
+	}
+
+	var jobs []Job
+	for page := 1; page <= adzunaMaxPages; page++ {
+		var resp struct {
+			Results []adzunaPosting `json:"results"`
+		}
+		if err := a.http.GetJSON(ctx, adzunaPageURL(country, category, page, a.appID, a.appKey), &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("adzuna: country %q category %q page %d: %w", country, category, page, err)
+			}
+			log.Printf("adzuna: country %q category %q page %d failed, stopping with %d jobs gathered: %v",
+				country, category, page, len(jobs), err)
+			return jobs, nil
+		}
+		if len(resp.Results) == 0 {
+			break
+		}
+		for _, p := range resp.Results {
+			jobs = append(jobs, p.toJob())
+		}
+	}
+	return jobs, nil
+}
+
+func adzunaPageURL(country, category string, page int, appID, appKey string) string {
+	q := url.Values{
+		"app_id":           {appID},
+		"app_key":          {appKey},
+		"results_per_page": {fmt.Sprint(adzunaPageSize)},
+		"category":         {category},
+		"content-type":     {"application/json"},
+	}
+	return fmt.Sprintf("%s/%s/search/%d?%s", adzunaBaseURL, country, page, q.Encode())
+}
+
+func (p adzunaPosting) toJob() Job {
+	return Job{
+		ExternalID:  p.ID,
+		URL:         p.RedirectURL,
+		Title:       p.Title,
+		Company:     p.Company.DisplayName,
+		Location:    p.Location.DisplayName,
+		Description: p.Description,
+		PostedAt:    parseRFC3339(p.Created),
+	}
+}

--- a/internal/sources/adzuna_test.go
+++ b/internal/sources/adzuna_test.go
@@ -1,0 +1,137 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// adzunaHTTP is a paging-aware test JSONGetter, mirroring echojobsHTTP: it serves pages[i] for a
+// request whose URL path ends in /search/<i+1> (Adzuna encodes the page number in the path, not a
+// query param) and records every URL requested so a test can assert credentials and routing.
+type adzunaHTTP struct {
+	pages    []string
+	failPage int // 0 = never fail
+	gotURLs  []string
+}
+
+func (f *adzunaHTTP) GetJSON(_ context.Context, u string, v any) error {
+	f.gotURLs = append(f.gotURLs, u)
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	page, _ := strconv.Atoi(path.Base(parsed.Path))
+	if f.failPage != 0 && page == f.failPage {
+		return errors.New("adzunaHTTP: boom")
+	}
+	if page < 1 || page > len(f.pages) {
+		return fmt.Errorf("adzunaHTTP: no page %d", page)
+	}
+	return json.Unmarshal([]byte(f.pages[page-1]), v)
+}
+
+func adzunaJobJSON(id, title string) string {
+	return fmt.Sprintf(`{
+		"id":%q,"title":%q,"description":"Great role.","created":"2026-08-07T13:10:31Z",
+		"redirect_url":"https://www.adzuna.co.uk/jobs/land/ad/%s",
+		"company":{"display_name":"Acme"},
+		"location":{"display_name":"Leeds, West Yorkshire"}
+	}`, id, title, id)
+}
+
+func adzunaPageJSON(jobs string) string {
+	return fmt.Sprintf(`{"count":999,"results":[%s]}`, jobs)
+}
+
+func TestAdzunaFetchMapsFields(t *testing.T) {
+	http := &adzunaHTTP{pages: []string{
+		adzunaPageJSON(adzunaJobJSON("111", "Backend Engineer")),
+		adzunaPageJSON(""),
+	}}
+	adz := adzuna{http: http, appID: "id1", appKey: "key1"}
+
+	jobs, err := adz.Fetch(context.Background(), CompanyEntry{Region: "gb", Board: "it-jobs"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want 1 job, got %d", len(jobs))
+	}
+	job := jobs[0]
+	if job.ExternalID != "111" || job.Title != "Backend Engineer" || job.Company != "Acme" {
+		t.Fatalf("identity mismatch: %+v", job)
+	}
+	if job.URL != "https://www.adzuna.co.uk/jobs/land/ad/111" {
+		t.Fatalf("URL: %q", job.URL)
+	}
+	if job.Location != "Leeds, West Yorkshire" {
+		t.Fatalf("Location: %q", job.Location)
+	}
+	if job.PostedAt == nil {
+		t.Fatalf("PostedAt not parsed")
+	}
+	if job.Description != "Great role." {
+		t.Fatalf("Description: %q", job.Description)
+	}
+}
+
+// The credential and the board's country/category must reach the request.
+func TestAdzunaFetchRequestsCorrectURL(t *testing.T) {
+	http := &adzunaHTTP{pages: []string{adzunaPageJSON("")}}
+	adz := adzuna{http: http, appID: "myid", appKey: "mykey"}
+
+	if _, err := adz.Fetch(context.Background(), CompanyEntry{Region: "us", Board: "it-jobs"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(http.gotURLs) != 1 {
+		t.Fatalf("want 1 request, got %d", len(http.gotURLs))
+	}
+	got := http.gotURLs[0]
+	for _, want := range []string{"/jobs/us/search/1", "app_id=myid", "app_key=mykey", "category=it-jobs"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("request URL %q missing %q", got, want)
+		}
+	}
+}
+
+// A blank country or category is refused rather than crawled (an empty country would 404, an
+// empty category would fetch Adzuna's whole unfiltered country feed).
+func TestAdzunaFetchRejectsBlankBoard(t *testing.T) {
+	adz := adzuna{http: &adzunaHTTP{}, appID: "id", appKey: "key"}
+	if _, err := adz.Fetch(context.Background(), CompanyEntry{Region: "", Board: "it-jobs"}); err == nil {
+		t.Fatal("want error on blank country")
+	}
+	if _, err := adz.Fetch(context.Background(), CompanyEntry{Region: "gb", Board: ""}); err == nil {
+		t.Fatal("want error on blank category")
+	}
+}
+
+// A failed first page is a board-level error.
+func TestAdzunaFetchFirstPageFailure(t *testing.T) {
+	http := &adzunaHTTP{failPage: 1, pages: []string{adzunaPageJSON("")}}
+	if _, err := (adzuna{http: http, appID: "id", appKey: "key"}).Fetch(context.Background(), CompanyEntry{Region: "gb", Board: "it-jobs"}); err == nil {
+		t.Fatal("want error on first-page failure")
+	}
+}
+
+// A later page failing ends the walk with what was gathered so far.
+func TestAdzunaFetchLaterPageFailureReturnsPartial(t *testing.T) {
+	http := &adzunaHTTP{
+		pages:    []string{adzunaPageJSON(adzunaJobJSON("1", "A")), adzunaPageJSON(adzunaJobJSON("2", "B"))},
+		failPage: 2,
+	}
+	jobs, err := (adzuna{http: http, appID: "id", appKey: "key"}).Fetch(context.Background(), CompanyEntry{Region: "gb", Board: "it-jobs"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "1" {
+		t.Fatalf("want partial result [job 1], got %+v", jobs)
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -271,11 +271,11 @@ func All(c HTTPClient) map[string]Source {
 		NewVK(c),
 		NewTwoGIS(c),
 	)
-	// usajobs, reed and whatjobs are the keyed sources: each needs a credential read from the
-	// environment, never from a board file. The credential gates the CRAWL registry only — a
+	// usajobs, reed, whatjobs and adzuna are the keyed sources: each needs a credential read from
+	// the environment, never from a board file. The credential gates the CRAWL registry only — a
 	// host without it must not register a provider whose every board would fail to authenticate,
 	// so its board file fails config validation before a request goes out. The taxonomy path
-	// (c == nil, see Taxonomy) registers all three regardless, empty credential included.
+	// (c == nil, see Taxonomy) registers all four regardless, empty credential included.
 	// Conflating the two classified whatjobs — a CPC reseller of first-party ATS postings — as
 	// an ATS on every keyless host, so none of its copies was ever suppressed.
 	if key := os.Getenv("USAJOBS_API_KEY"); c == nil || key != "" {
@@ -283,6 +283,10 @@ func All(c HTTPClient) map[string]Source {
 	}
 	if key := os.Getenv("REED_API_KEY"); c == nil || key != "" {
 		registry["reed"] = NewReed(c, key)
+	}
+	// Adzuna's credential is an app_id/app_key pair rather than a single key; both must be set.
+	if appID, appKey := os.Getenv("ADZUNA_APP_ID"), os.Getenv("ADZUNA_APP_KEY"); c == nil || (appID != "" && appKey != "") {
+		registry["adzuna"] = NewAdzuna(c, appID, appKey)
 	}
 	// whatjobs' credential is a publisher id rather than an API key; it is per-country, and this
 	// account serves US inventory. Its requests go through a shared in-flight cap: the feed

--- a/sources/adzuna.yml
+++ b/sources/adzuna.yml
@@ -1,0 +1,25 @@
+# Adzuna — api.adzuna.com, an independent job aggregator with its own employer/recruiter feeds
+# per country. Keyed: ADZUNA_APP_ID and ADZUNA_APP_KEY must both be set or this provider is not
+# registered and every entry below fails config validation, by design.
+#
+# Each entry's board is the "it-jobs" category (a hard filter, verified live — unlike WhatJobs'
+# keyword search it does not pad with unrelated inventory on later pages), and region is the
+# two-letter country whose regional API path to hit. company is a display label only — the real
+# employer comes from each posting.
+#
+# Counts below are live-verified totals (2026-08-08) for the it-jobs category alone; Adzuna covers
+# more countries than listed here (see developer.adzuna.com for the full list) — add more as
+# needed, verifying each live before adding rather than guessing a code exists.
+
+- company: Adzuna — United States
+  region: us
+  board: it-jobs # ~454k
+- company: Adzuna — United Kingdom
+  region: gb
+  board: it-jobs # ~46k
+- company: Adzuna — Germany
+  region: de
+  board: it-jobs # ~23k
+- company: Adzuna — Australia
+  region: au
+  board: it-jobs # ~15k


### PR DESCRIPTION
## Summary
- Adds `internal/sources/adzuna.go`, an aggregator adapter for the Adzuna Job Search API v1 — an independent, official, keyed job aggregator with per-country feeds.
- Adzuna has no "list everything" call, so like `whatjobs`/`trudvsem` each board entry selects a slice: country goes in `CompanyEntry.Region` (it's literally the `/jobs/{country}/search/...` path segment), category in `CompanyEntry.Board`. Verified live that `category` is a hard filter (every result on page 50 of `it-jobs` still tagged `it-jobs`), unlike a free-text keyword search's relevance padding — so this adapter doesn't need `whatjobs`' corroboration logic.
- Registered only when both `ADZUNA_APP_ID` and `ADZUNA_APP_KEY` are set (mirrors the `usajobs`/`reed` keyed-source pattern).
- Seeds `sources/adzuna.yml` with four live-verified country boards (US ~454k, GB ~46k, DE ~23k, AU ~15k for the `it-jobs` category) — Adzuna covers more countries, added incrementally as each is live-verified.

## Test plan
- [x] Tests written first (RED verified), then implementation (GREEN) — `internal/sources/adzuna_test.go` covers field mapping, credential/URL construction, blank-country/category rejection, first-page failure, and later-page partial-result behavior.
- [x] Live-verified against the real API with a real credential pair (field shapes, category hard-filter behavior, per-country counts).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...`

Closes #1635