### PR TITLE
fix(sources): tolerate Adzuna's occasional numeric job id

### DIFF
--- a/internal/sources/adzuna.go
+++ b/internal/sources/adzuna.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/url"
@@ -57,15 +58,35 @@ func (adzuna) aggregator() {}
 
 func (adzuna) sweepGrace() time.Duration { return adzunaSweepGrace }
 
+// adzunaID reads a posting's id, which the API emits as a JSON string for most postings but as a
+// bare JSON number for some (observed live 2026-08-08, gb/it-jobs page 7) — an upstream
+// inconsistency, not a documented alternate shape. A page hitting it must decode instead of
+// failing the whole page, mirroring habrJobLocations/habrAddress's shape-tolerant UnmarshalJSON.
+type adzunaID string
+
+func (id *adzunaID) UnmarshalJSON(b []byte) error {
+	var s string
+	if json.Unmarshal(b, &s) == nil {
+		*id = adzunaID(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*id = adzunaID(n.String())
+	return nil
+}
+
 // adzunaPosting is one search result. Several fields the API sends are deliberately unread —
 // salary_min/salary_max/salary_is_predicted and category — because none has a home in the Job
 // shape today, mirroring echojobs' treatment of its own unread vendor fields.
 type adzunaPosting struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Created     string `json:"created"`
-	RedirectURL string `json:"redirect_url"`
+	ID          adzunaID `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Created     string   `json:"created"`
+	RedirectURL string   `json:"redirect_url"`
 	Company     struct {
 		DisplayName string `json:"display_name"`
 	} `json:"company"`
@@ -123,7 +144,7 @@ func adzunaPageURL(country, category string, page int, appID, appKey string) str
 
 func (p adzunaPosting) toJob() Job {
 	return Job{
-		ExternalID:  p.ID,
+		ExternalID:  string(p.ID),
 		URL:         p.RedirectURL,
 		Title:       p.Title,
 		Company:     p.Company.DisplayName,

--- a/internal/sources/adzuna_test.go
+++ b/internal/sources/adzuna_test.go
@@ -82,6 +82,27 @@ func TestAdzunaFetchMapsFields(t *testing.T) {
 	}
 }
 
+// Adzuna emits id as a JSON string for most postings but as a bare JSON number for some
+// (observed live 2026-08-08, gb/it-jobs page 7) — an upstream inconsistency, not a documented
+// alternate shape. A page hitting it must not fail the whole page's decode.
+func TestAdzunaFetchAcceptsNumericID(t *testing.T) {
+	numericIDJob := `{
+		"id":123456789,"title":"Backend Engineer","description":"Great role.",
+		"created":"2026-08-07T13:10:31Z",
+		"redirect_url":"https://www.adzuna.co.uk/jobs/land/ad/123456789",
+		"company":{"display_name":"Acme"},"location":{"display_name":"Leeds, West Yorkshire"}
+	}`
+	http := &adzunaHTTP{pages: []string{adzunaPageJSON(numericIDJob), adzunaPageJSON("")}}
+
+	jobs, err := (adzuna{http: http, appID: "id", appKey: "key"}).Fetch(context.Background(), CompanyEntry{Region: "gb", Board: "it-jobs"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "123456789" {
+		t.Fatalf("want ExternalID \"123456789\", got %+v", jobs)
+	}
+}
+
 // The credential and the board's country/category must reach the request.
 func TestAdzunaFetchRequestsCorrectURL(t *testing.T) {
 	http := &adzunaHTTP{pages: []string{adzunaPageJSON("")}}


### PR DESCRIPTION
## Summary
- Live-verified bug from the first prod run of the just-merged Adzuna adapter (#1639): the API emits `id` as a JSON string for most postings but as a bare JSON number for some — hit on `gb`/`it-jobs` page 7 (2026-08-08), which failed that page's decode and truncated the board's crawl to what had been gathered so far (300 jobs instead of continuing).
- `adzunaID` now accepts either JSON shape, mirroring this package's existing shape-tolerant `UnmarshalJSON` pattern (`habrJobLocations`/`habrAddress` in `habrcareer.go`).

## Test plan
- [x] Test written first reproducing the exact failure (numeric `id` in a page), verified RED, then GREEN.
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`