### PR TITLE
feat(sources): onboard 57 ATS boards found via Himalayas orphan-company harvest

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -8112,3 +8112,5 @@
   board: withpace
 - company: WorkHero
   board: workhero
+- company: Hex
+  board: hex

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14329,3 +14329,37 @@
   board: vilya
 - company: Zerocater
   board: zerocater
+- company: Defuse Labs
+  board: defuselabs
+- company: Dendreon
+  board: dendreon
+- company: Legend
+  board: legend
+- company: mx51
+  board: mx51
+- company: Neighborhoods.com
+  board: neighborhoodscom
+- company: Newfangled Studios
+  board: newfangled-studios
+- company: Operatus
+  board: operatus
+- company: PeopleFinders
+  board: peoplefinders
+- company: PlayOn! Sports
+  board: playonsports
+- company: Podean
+  board: podean
+- company: 'Silvr '
+  board: silvr
+- company: SiriusPoint
+  board: siriuspoint
+- company: Skin Clique
+  board: skinclique
+- company: Studio Science
+  board: studioscience
+- company: whiteSpace
+  board: whitespace
+- company: Yes LLC
+  board: "yes"
+- company: Zoomget
+  board: zoomget

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -6327,3 +6327,81 @@
   board: IOTAGROUP
 - company: SOCOTEC UK & Ireland
   board: SOCOTECUKIreland
+- company: Agile IT
+  board: agileit
+- company: American Montessori Society
+  board: americanmontessorisociety
+- company: Armis
+  board: armis
+- company: Bertoni Solutions
+  board: bertonisolutions
+- company: Blu Selection
+  board: bluselection
+- company: BorderBuddy
+  board: borderbuddy
+- company: Bringle Excellence
+  board: bringleexcellence
+- company: Brushfire
+  board: brushfire
+- company: Center for Applied Linguistics
+  board: centerforappliedlinguistics
+- company: CONFISA INTERNATIONAL GROUP
+  board: confisainternationalgroup
+- company: Domino's
+  board: dominos
+- company: Dotsub
+  board: dotsub
+- company: Dresden Partners
+  board: dresdenpartners
+- company: Hitachi Solutions
+  board: hitachisolutions
+- company: H&M Group
+  board: hmgroup
+- company: Host & Stay
+  board: hoststay
+- company: insightsoftware
+  board: insightsoftware
+- company: InVita Healthcare Technologies
+  board: invitahealthcaretechnologies
+- company: JACOBS DOUWE EGBERTS
+  board: jacobsdouweegberts
+- company: KoiReader Technologies
+  board: koireadertechnologies
+- company: KPMG Australia
+  board: kpmgaustralia
+- company: LegalAndGeneral
+  board: legalandgeneral
+- company: M3 USA
+  board: m3usa
+- company: NECSWS
+  board: necsws
+- company: Nile Bits
+  board: nilebits
+- company: Opportunity@Work
+  board: opportunitywork
+- company: PeopleReady
+  board: peopleready
+- company: Privia Health
+  board: priviahealth
+- company: RealDefense
+  board: realdefense
+- company: REDICA Systems
+  board: redicasystems
+- company: Schoolyear
+  board: schoolyear
+- company: Shaped
+  board: shaped
+- company: Space Inch
+  board: spaceinch
+- company: Syncreon Consulting
+  board: syncreonconsulting
+- company: TBD_14_10_2022_Ludia
+  board: tbd14102022ludia
+- company: The Nielsen Company
+  board: thenielsencompany
+- company: Turner & Townsend
+  board: turnertownsend
+- company: Volunteers of America National Services
+  board: volunteersofamericanationalservices
+- company: XceedSearch.com
+  board: xceedsearchcom


### PR DESCRIPTION
## Summary
- Ran `cmd/harvest-orphans` against companies we only see through the Himalayas aggregator (7632 orphan companies, no first-party ATS coverage).
- Validated candidate boards via `cmd/harvest-boards` (name-gated where the platform publishes a company name).
- Adds 17 greenhouse boards, 39 smartrecruiters boards, 1 ashby board — all live and name-matched.

Remaining providers from the same seed (workable, teamtailor, jobvite, recruitee, breezy, lever, bamboohr, personio, paycom, jazzhr, traffit, trakstar, freshteam, join) are still being probed and will follow in a separate PR.