### PR TITLE
fix(pipeline): scope board_health by region, not just (provider, board)

### DIFF
--- a/cmd/ingest/board_health.go
+++ b/cmd/ingest/board_health.go
@@ -27,8 +27,8 @@ func newBoardHealth(pool *pgxpool.Pool) *boardHealth { return &boardHealth{q: db
 
 // Cooldown returns the board's cooldown_until; an absent row or a NULL cooldown means
 // eligible.
-func (h *boardHealth) Cooldown(ctx context.Context, provider, board string) (time.Time, bool, error) {
-	ts, err := h.q.GetBoardCooldown(ctx, db.GetBoardCooldownParams{Provider: provider, Board: board})
+func (h *boardHealth) Cooldown(ctx context.Context, provider, board, region string) (time.Time, bool, error) {
+	ts, err := h.q.GetBoardCooldown(ctx, db.GetBoardCooldownParams{Provider: provider, Board: board, Region: region})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return time.Time{}, false, nil
 	}
@@ -42,10 +42,11 @@ func (h *boardHealth) Cooldown(ctx context.Context, provider, board string) (tim
 }
 
 // RecordSuccess clears the board's failure state and stamps freshness.
-func (h *boardHealth) RecordSuccess(ctx context.Context, provider, board string, ingested int) error {
+func (h *boardHealth) RecordSuccess(ctx context.Context, provider, board, region string, ingested int) error {
 	return h.q.RecordBoardSuccess(ctx, db.RecordBoardSuccessParams{
 		Provider:          provider,
 		Board:             board,
+		Region:            region,
 		LastIngestedCount: pgtype.Int4{Int32: int32(ingested), Valid: true},
 	})
 }
@@ -53,10 +54,11 @@ func (h *boardHealth) RecordSuccess(ctx context.Context, provider, board string,
 // RecordFailure bumps the failure count (the query returns the new count), then applies
 // the Go-owned backoff policy: it sets a cooldown only once the count crosses the
 // threshold.
-func (h *boardHealth) RecordFailure(ctx context.Context, provider, board, errMsg string) error {
+func (h *boardHealth) RecordFailure(ctx context.Context, provider, board, region, errMsg string) error {
 	failures, err := h.q.RecordBoardFailure(ctx, db.RecordBoardFailureParams{
 		Provider:  provider,
 		Board:     board,
+		Region:    region,
 		LastError: pgtype.Text{String: errMsg, Valid: true},
 	})
 	if err != nil {
@@ -69,13 +71,23 @@ func (h *boardHealth) RecordFailure(ctx context.Context, provider, board, errMsg
 	return h.q.SetBoardCooldown(ctx, db.SetBoardCooldownParams{
 		Provider:      provider,
 		Board:         board,
+		Region:        region,
 		CooldownUntil: pgtype.Timestamptz{Time: time.Now().Add(d), Valid: true},
 	})
 }
 
-// CooledBoards returns up to limit boards of the provider currently in an active cooldown.
-func (h *boardHealth) CooledBoards(ctx context.Context, provider string, limit int) ([]string, error) {
-	return h.q.ListCooledBoards(ctx, db.ListCooledBoardsParams{Provider: provider, Limit: int32(limit)})
+// CooledBoards returns up to limit (board, region) pairs of the provider currently in an
+// active cooldown.
+func (h *boardHealth) CooledBoards(ctx context.Context, provider string, limit int) ([]pipeline.CooledBoard, error) {
+	rows, err := h.q.ListCooledBoards(ctx, db.ListCooledBoardsParams{Provider: provider, Limit: int32(limit)})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]pipeline.CooledBoard, len(rows))
+	for i, r := range rows {
+		out[i] = pipeline.CooledBoard{Board: r.Board, Region: r.Region}
+	}
+	return out, nil
 }
 
 // ClearCooldowns clears the active cooldown and failure count of every currently-cooled
@@ -99,7 +111,11 @@ func logUnhealthyBoards(ctx context.Context, q *db.Queries) {
 	}
 	parts := make([]string, 0, len(rows))
 	for _, r := range rows {
-		desc := fmt.Sprintf("%s/%s(fails=%d", r.Provider, r.Board, r.ConsecutiveFailures)
+		id := r.Provider + "/" + r.Board
+		if r.Region != "" {
+			id += "/" + r.Region
+		}
+		desc := fmt.Sprintf("%s(fails=%d", id, r.ConsecutiveFailures)
 		if r.CooldownUntil.Valid && r.CooldownUntil.Time.After(time.Now()) {
 			desc += ",cooled_until=" + r.CooldownUntil.Time.UTC().Format(time.RFC3339)
 		}

--- a/cmd/ingest/board_health_integration_test.go
+++ b/cmd/ingest/board_health_integration_test.go
@@ -29,25 +29,25 @@ func TestBoardHealth_FailureCooldownSelfHeal(t *testing.T) {
 	h := newBoardHealth(pool)
 
 	// Never seen → eligible.
-	if _, cooled, err := h.Cooldown(ctx, "greenhouse", "acme"); err != nil || cooled {
+	if _, cooled, err := h.Cooldown(ctx, "greenhouse", "acme", ""); err != nil || cooled {
 		t.Fatalf("fresh board Cooldown = (_, %v, %v), want (_, false, nil)", cooled, err)
 	}
 
 	// The first two failures stay below the threshold — no cooldown, cron retries.
 	for i := 0; i < 2; i++ {
-		if err := h.RecordFailure(ctx, "greenhouse", "acme", "boom"); err != nil {
+		if err := h.RecordFailure(ctx, "greenhouse", "acme", "", "boom"); err != nil {
 			t.Fatalf("RecordFailure: %v", err)
 		}
 	}
-	if _, cooled, _ := h.Cooldown(ctx, "greenhouse", "acme"); cooled {
+	if _, cooled, _ := h.Cooldown(ctx, "greenhouse", "acme", ""); cooled {
 		t.Error("board should not be cooled below the threshold (2 failures)")
 	}
 
 	// The third consecutive failure crosses the threshold → cooldown is set.
-	if err := h.RecordFailure(ctx, "greenhouse", "acme", "boom again"); err != nil {
+	if err := h.RecordFailure(ctx, "greenhouse", "acme", "", "boom again"); err != nil {
 		t.Fatalf("RecordFailure: %v", err)
 	}
-	until, cooled, err := h.Cooldown(ctx, "greenhouse", "acme")
+	until, cooled, err := h.Cooldown(ctx, "greenhouse", "acme", "")
 	if err != nil || !cooled {
 		t.Fatalf("after 3 failures Cooldown = (%v, %v, %v), want a future cooldown", until, cooled, err)
 	}
@@ -56,10 +56,10 @@ func TestBoardHealth_FailureCooldownSelfHeal(t *testing.T) {
 	}
 
 	// A success self-heals: failure state cleared, cooldown gone.
-	if err := h.RecordSuccess(ctx, "greenhouse", "acme", 7); err != nil {
+	if err := h.RecordSuccess(ctx, "greenhouse", "acme", "", 7); err != nil {
 		t.Fatalf("RecordSuccess: %v", err)
 	}
-	if _, cooled, _ := h.Cooldown(ctx, "greenhouse", "acme"); cooled {
+	if _, cooled, _ := h.Cooldown(ctx, "greenhouse", "acme", ""); cooled {
 		t.Error("a success must clear the cooldown (self-heal)")
 	}
 
@@ -85,7 +85,7 @@ func TestBoardHealth_CooledBoardsAndClear(t *testing.T) {
 	cool := func(provider, board string) {
 		t.Helper()
 		for i := 0; i < 3; i++ { // crosses the cooldown threshold
-			if err := h.RecordFailure(ctx, provider, board, "boom"); err != nil {
+			if err := h.RecordFailure(ctx, provider, board, "", "boom"); err != nil {
 				t.Fatalf("RecordFailure %s/%s: %v", provider, board, err)
 			}
 		}
@@ -94,7 +94,7 @@ func TestBoardHealth_CooledBoardsAndClear(t *testing.T) {
 	cool("breezy", "b1")
 	cool("breezy", "b2")
 	cool("breezy", "b3")
-	if err := h.RecordSuccess(ctx, "breezy", "b-ok", 1); err != nil {
+	if err := h.RecordSuccess(ctx, "breezy", "b-ok", "", 1); err != nil {
 		t.Fatalf("RecordSuccess: %v", err)
 	}
 	// join: an unrelated provider's cooled board, to prove clearing is provider-scoped.
@@ -103,7 +103,7 @@ func TestBoardHealth_CooledBoardsAndClear(t *testing.T) {
 	// The limit caps the sample, soonest-to-expire first — b1, b2 cooled before b3.
 	if got, err := h.CooledBoards(ctx, "breezy", 2); err != nil {
 		t.Fatalf("CooledBoards: %v", err)
-	} else if len(got) != 2 || got[0] != "b1" || got[1] != "b2" {
+	} else if len(got) != 2 || got[0].Board != "b1" || got[1].Board != "b2" {
 		t.Errorf("CooledBoards(breezy, 2) = %v, want [b1 b2]", got)
 	}
 	// Above the count: exactly the three cooled boards, never the fresh one.
@@ -126,7 +126,47 @@ func TestBoardHealth_CooledBoardsAndClear(t *testing.T) {
 	}
 
 	// join's cooled board is untouched — clearing is scoped to the one provider.
-	if _, cooled, err := h.Cooldown(ctx, "join", "j1"); err != nil || !cooled {
+	if _, cooled, err := h.Cooldown(ctx, "join", "j1", ""); err != nil || !cooled {
 		t.Errorf("join/j1 Cooldown = (_, %v, %v), want still cooled after clearing breezy", cooled, err)
+	}
+}
+
+// A board id that repeats across independent regional slices (Adzuna's "it-jobs" once per
+// country) must not share health state across regions: cooling one region's board leaves a
+// same-named board in another region eligible, and CooledBoards/ClearCooldowns distinguish them.
+func TestBoardHealth_RegionDisambiguates(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	h := newBoardHealth(pool)
+
+	for i := 0; i < 3; i++ { // crosses the cooldown threshold
+		if err := h.RecordFailure(ctx, "adzuna", "it-jobs", "gb", "boom"); err != nil {
+			t.Fatalf("RecordFailure gb: %v", err)
+		}
+	}
+	if err := h.RecordSuccess(ctx, "adzuna", "it-jobs", "us", 42); err != nil {
+		t.Fatalf("RecordSuccess us: %v", err)
+	}
+
+	if _, cooled, err := h.Cooldown(ctx, "adzuna", "it-jobs", "gb"); err != nil || !cooled {
+		t.Fatalf("gb Cooldown = (_, %v, %v), want cooled", cooled, err)
+	}
+	if _, cooled, err := h.Cooldown(ctx, "adzuna", "it-jobs", "us"); err != nil || cooled {
+		t.Fatalf("us Cooldown = (_, %v, %v), want eligible — gb's failures must not bleed into us", cooled, err)
+	}
+
+	got, err := h.CooledBoards(ctx, "adzuna", 10)
+	if err != nil {
+		t.Fatalf("CooledBoards: %v", err)
+	}
+	if len(got) != 1 || got[0].Board != "it-jobs" || got[0].Region != "gb" {
+		t.Fatalf("CooledBoards(adzuna) = %v, want exactly [{it-jobs gb}]", got)
+	}
+
+	if n, err := h.ClearCooldowns(ctx, "adzuna"); err != nil || n != 1 {
+		t.Fatalf("ClearCooldowns(adzuna) = (%d, %v), want (1, nil)", n, err)
+	}
+	if _, cooled, err := h.Cooldown(ctx, "adzuna", "it-jobs", "us"); err != nil || cooled {
+		t.Fatalf("us Cooldown after clearing gb = (_, %v, %v), want still eligible", cooled, err)
 	}
 }

--- a/internal/db/board_health.sql.go
+++ b/internal/db/board_health.sql.go
@@ -32,28 +32,31 @@ func (q *Queries) ClearProviderCooldowns(ctx context.Context, provider string) (
 const getBoardCooldown = `-- name: GetBoardCooldown :one
 SELECT cooldown_until
 FROM board_health
-WHERE provider = $1 AND board = $2
+WHERE provider = $1 AND board = $2 AND region = $3
 `
 
 type GetBoardCooldownParams struct {
 	Provider string `json:"provider"`
 	Board    string `json:"board"`
+	Region   string `json:"region"`
 }
 
 // The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
-// which the caller treats as "never seen, eligible".
+// which the caller treats as "never seen, eligible". region disambiguates a board id that
+// repeats across independent regional slices (e.g. Adzuna's "it-jobs" once per country); every
+// other provider passes ” here, matching the column's default.
 func (q *Queries) GetBoardCooldown(ctx context.Context, arg GetBoardCooldownParams) (pgtype.Timestamptz, error) {
-	row := q.db.QueryRow(ctx, getBoardCooldown, arg.Provider, arg.Board)
+	row := q.db.QueryRow(ctx, getBoardCooldown, arg.Provider, arg.Board, arg.Region)
 	var cooldown_until pgtype.Timestamptz
 	err := row.Scan(&cooldown_until)
 	return cooldown_until, err
 }
 
 const listCooledBoards = `-- name: ListCooledBoards :many
-SELECT board
+SELECT board, region
 FROM board_health
 WHERE provider = $1 AND cooldown_until IS NOT NULL AND cooldown_until > now()
-ORDER BY cooldown_until, board
+ORDER BY cooldown_until, board, region
 LIMIT $2
 `
 
@@ -62,22 +65,27 @@ type ListCooledBoardsParams struct {
 	Limit    int32  `json:"limit"`
 }
 
-// Up to $2 boards currently in an active cooldown for a provider, soonest-to-expire
-// first — the recovery probe's candidates. The ordering rotates the sample as cooldowns
-// lapse, so a run does not keep probing the same few boards.
-func (q *Queries) ListCooledBoards(ctx context.Context, arg ListCooledBoardsParams) ([]string, error) {
+type ListCooledBoardsRow struct {
+	Board  string `json:"board"`
+	Region string `json:"region"`
+}
+
+// Up to $2 (board, region) pairs currently in an active cooldown for a provider,
+// soonest-to-expire first — the recovery probe's candidates. The ordering rotates the sample as
+// cooldowns lapse, so a run does not keep probing the same few boards.
+func (q *Queries) ListCooledBoards(ctx context.Context, arg ListCooledBoardsParams) ([]ListCooledBoardsRow, error) {
 	rows, err := q.db.Query(ctx, listCooledBoards, arg.Provider, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []string{}
+	items := []ListCooledBoardsRow{}
 	for rows.Next() {
-		var board string
-		if err := rows.Scan(&board); err != nil {
+		var i ListCooledBoardsRow
+		if err := rows.Scan(&i.Board, &i.Region); err != nil {
 			return nil, err
 		}
-		items = append(items, board)
+		items = append(items, i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -86,15 +94,16 @@ func (q *Queries) ListCooledBoards(ctx context.Context, arg ListCooledBoardsPara
 }
 
 const listUnhealthyBoards = `-- name: ListUnhealthyBoards :many
-SELECT provider, board, consecutive_failures, cooldown_until, last_error, last_error_at
+SELECT provider, board, region, consecutive_failures, cooldown_until, last_error, last_error_at
 FROM board_health
 WHERE consecutive_failures > 0 OR (cooldown_until IS NOT NULL AND cooldown_until > now())
-ORDER BY consecutive_failures DESC, provider, board
+ORDER BY consecutive_failures DESC, provider, board, region
 `
 
 type ListUnhealthyBoardsRow struct {
 	Provider            string             `json:"provider"`
 	Board               string             `json:"board"`
+	Region              string             `json:"region"`
 	ConsecutiveFailures int32              `json:"consecutive_failures"`
 	CooldownUntil       pgtype.Timestamptz `json:"cooldown_until"`
 	LastError           pgtype.Text        `json:"last_error"`
@@ -115,6 +124,7 @@ func (q *Queries) ListUnhealthyBoards(ctx context.Context) ([]ListUnhealthyBoard
 		if err := rows.Scan(
 			&i.Provider,
 			&i.Board,
+			&i.Region,
 			&i.ConsecutiveFailures,
 			&i.CooldownUntil,
 			&i.LastError,
@@ -192,9 +202,9 @@ func (q *Queries) ProviderHealthRollup(ctx context.Context) ([]ProviderHealthRol
 }
 
 const recordBoardFailure = `-- name: RecordBoardFailure :one
-INSERT INTO board_health (provider, board, consecutive_failures, last_error, last_error_at, last_run_at)
-VALUES ($1, $2, 1, $3, now(), now())
-ON CONFLICT (provider, board) DO UPDATE SET
+INSERT INTO board_health (provider, board, region, consecutive_failures, last_error, last_error_at, last_run_at)
+VALUES ($1, $2, $3, 1, $4, now(), now())
+ON CONFLICT (provider, board, region) DO UPDATE SET
     consecutive_failures = board_health.consecutive_failures + 1,
     last_error           = EXCLUDED.last_error,
     last_error_at        = now(),
@@ -205,6 +215,7 @@ RETURNING consecutive_failures
 type RecordBoardFailureParams struct {
 	Provider  string      `json:"provider"`
 	Board     string      `json:"board"`
+	Region    string      `json:"region"`
 	LastError pgtype.Text `json:"last_error"`
 }
 
@@ -212,17 +223,22 @@ type RecordBoardFailureParams struct {
 // and RETURN the new failure count so the caller can compute the cooldown (the backoff
 // policy lives in Go, not here). The cooldown itself is applied by SetBoardCooldown.
 func (q *Queries) RecordBoardFailure(ctx context.Context, arg RecordBoardFailureParams) (int32, error) {
-	row := q.db.QueryRow(ctx, recordBoardFailure, arg.Provider, arg.Board, arg.LastError)
+	row := q.db.QueryRow(ctx, recordBoardFailure,
+		arg.Provider,
+		arg.Board,
+		arg.Region,
+		arg.LastError,
+	)
 	var consecutive_failures int32
 	err := row.Scan(&consecutive_failures)
 	return consecutive_failures, err
 }
 
 const recordBoardSuccess = `-- name: RecordBoardSuccess :exec
-INSERT INTO board_health (provider, board, consecutive_failures, cooldown_until,
+INSERT INTO board_health (provider, board, region, consecutive_failures, cooldown_until,
                           last_success_at, last_ingested_count, last_run_at)
-VALUES ($1, $2, 0, NULL, now(), $3, now())
-ON CONFLICT (provider, board) DO UPDATE SET
+VALUES ($1, $2, $3, 0, NULL, now(), $4, now())
+ON CONFLICT (provider, board, region) DO UPDATE SET
     consecutive_failures = 0,
     cooldown_until       = NULL,
     last_success_at      = now(),
@@ -233,31 +249,43 @@ ON CONFLICT (provider, board) DO UPDATE SET
 type RecordBoardSuccessParams struct {
 	Provider          string      `json:"provider"`
 	Board             string      `json:"board"`
+	Region            string      `json:"region"`
 	LastIngestedCount pgtype.Int4 `json:"last_ingested_count"`
 }
 
 // A successful crawl clears the failure state and stamps freshness. Upsert so a
 // first-ever crawl creates the row.
 func (q *Queries) RecordBoardSuccess(ctx context.Context, arg RecordBoardSuccessParams) error {
-	_, err := q.db.Exec(ctx, recordBoardSuccess, arg.Provider, arg.Board, arg.LastIngestedCount)
+	_, err := q.db.Exec(ctx, recordBoardSuccess,
+		arg.Provider,
+		arg.Board,
+		arg.Region,
+		arg.LastIngestedCount,
+	)
 	return err
 }
 
 const setBoardCooldown = `-- name: SetBoardCooldown :exec
 UPDATE board_health
-SET cooldown_until = $3
-WHERE provider = $1 AND board = $2
+SET cooldown_until = $4
+WHERE provider = $1 AND board = $2 AND region = $3
 `
 
 type SetBoardCooldownParams struct {
 	Provider      string             `json:"provider"`
 	Board         string             `json:"board"`
+	Region        string             `json:"region"`
 	CooldownUntil pgtype.Timestamptz `json:"cooldown_until"`
 }
 
 // Apply the Go-computed cooldown window to a board (called only when the backoff
 // policy says to cool down).
 func (q *Queries) SetBoardCooldown(ctx context.Context, arg SetBoardCooldownParams) error {
-	_, err := q.db.Exec(ctx, setBoardCooldown, arg.Provider, arg.Board, arg.CooldownUntil)
+	_, err := q.db.Exec(ctx, setBoardCooldown,
+		arg.Provider,
+		arg.Board,
+		arg.Region,
+		arg.CooldownUntil,
+	)
 	return err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -113,6 +113,7 @@ type BoardHealth struct {
 	LastSuccessAt       pgtype.Timestamptz `json:"last_success_at"`
 	LastIngestedCount   pgtype.Int4        `json:"last_ingested_count"`
 	LastRunAt           pgtype.Timestamptz `json:"last_run_at"`
+	Region              string             `json:"region"`
 }
 
 type CommunityPersona struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -860,7 +860,9 @@ type Querier interface {
 	// several (cv-builder), so there is no uniqueness constraint and the ORDER BY does the choosing.
 	GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVByUserRow, error)
 	// The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
-	// which the caller treats as "never seen, eligible".
+	// which the caller treats as "never seen, eligible". region disambiguates a board id that
+	// repeats across independent regional slices (e.g. Adzuna's "it-jobs" once per country); every
+	// other provider passes '' here, matching the column's default.
 	GetBoardCooldown(ctx context.Context, arg GetBoardCooldownParams) (pgtype.Timestamptz, error)
 	// One CV owned by the user, including the full data blob. Owner-scoped: a foreign or
 	// missing id returns no row (the handler maps it to 404). job_id is NULL for a base CV and
@@ -1399,10 +1401,10 @@ type Querier interface {
 	ListConnectedGmailUsers(ctx context.Context) ([]ListConnectedGmailUsersRow, error)
 	// The "my contributions" list: one user's contributions, newest first.
 	ListContributionsByUser(ctx context.Context, submittedBy int64) ([]LinkContribution, error)
-	// Up to $2 boards currently in an active cooldown for a provider, soonest-to-expire
-	// first — the recovery probe's candidates. The ordering rotates the sample as cooldowns
-	// lapse, so a run does not keep probing the same few boards.
-	ListCooledBoards(ctx context.Context, arg ListCooledBoardsParams) ([]string, error)
+	// Up to $2 (board, region) pairs currently in an active cooldown for a provider,
+	// soonest-to-expire first — the recovery probe's candidates. The ordering rotates the sample as
+	// cooldowns lapse, so a run does not keep probing the same few boards.
+	ListCooledBoards(ctx context.Context, arg ListCooledBoardsParams) ([]ListCooledBoardsRow, error)
 	// The caller's credit-ledger entries, newest first, for the transaction-history page. Bounded
 	// by a caller-supplied limit and served by the (user_id, created_at DESC) index. The handler
 	// resolves each debit's ref to a human label (the job/CV it named).

--- a/internal/db/queries/board_health.sql
+++ b/internal/db/queries/board_health.sql
@@ -1,17 +1,19 @@
 -- name: GetBoardCooldown :one
 -- The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
--- which the caller treats as "never seen, eligible".
+-- which the caller treats as "never seen, eligible". region disambiguates a board id that
+-- repeats across independent regional slices (e.g. Adzuna's "it-jobs" once per country); every
+-- other provider passes '' here, matching the column's default.
 SELECT cooldown_until
 FROM board_health
-WHERE provider = $1 AND board = $2;
+WHERE provider = $1 AND board = $2 AND region = $3;
 
 -- name: RecordBoardSuccess :exec
 -- A successful crawl clears the failure state and stamps freshness. Upsert so a
 -- first-ever crawl creates the row.
-INSERT INTO board_health (provider, board, consecutive_failures, cooldown_until,
+INSERT INTO board_health (provider, board, region, consecutive_failures, cooldown_until,
                           last_success_at, last_ingested_count, last_run_at)
-VALUES ($1, $2, 0, NULL, now(), $3, now())
-ON CONFLICT (provider, board) DO UPDATE SET
+VALUES ($1, $2, $3, 0, NULL, now(), $4, now())
+ON CONFLICT (provider, board, region) DO UPDATE SET
     consecutive_failures = 0,
     cooldown_until       = NULL,
     last_success_at      = now(),
@@ -22,9 +24,9 @@ ON CONFLICT (provider, board) DO UPDATE SET
 -- Count a failed crawl: bump consecutive_failures, record the error, stamp the run,
 -- and RETURN the new failure count so the caller can compute the cooldown (the backoff
 -- policy lives in Go, not here). The cooldown itself is applied by SetBoardCooldown.
-INSERT INTO board_health (provider, board, consecutive_failures, last_error, last_error_at, last_run_at)
-VALUES ($1, $2, 1, $3, now(), now())
-ON CONFLICT (provider, board) DO UPDATE SET
+INSERT INTO board_health (provider, board, region, consecutive_failures, last_error, last_error_at, last_run_at)
+VALUES ($1, $2, $3, 1, $4, now(), now())
+ON CONFLICT (provider, board, region) DO UPDATE SET
     consecutive_failures = board_health.consecutive_failures + 1,
     last_error           = EXCLUDED.last_error,
     last_error_at        = now(),
@@ -35,25 +37,25 @@ RETURNING consecutive_failures;
 -- Apply the Go-computed cooldown window to a board (called only when the backoff
 -- policy says to cool down).
 UPDATE board_health
-SET cooldown_until = $3
-WHERE provider = $1 AND board = $2;
+SET cooldown_until = $4
+WHERE provider = $1 AND board = $2 AND region = $3;
 
 -- name: ListUnhealthyBoards :many
 -- Every board currently failing or cooled down, worst first — the operator's
 -- "what's broken" query and the source of the per-run summary log.
-SELECT provider, board, consecutive_failures, cooldown_until, last_error, last_error_at
+SELECT provider, board, region, consecutive_failures, cooldown_until, last_error, last_error_at
 FROM board_health
 WHERE consecutive_failures > 0 OR (cooldown_until IS NOT NULL AND cooldown_until > now())
-ORDER BY consecutive_failures DESC, provider, board;
+ORDER BY consecutive_failures DESC, provider, board, region;
 
 -- name: ListCooledBoards :many
--- Up to $2 boards currently in an active cooldown for a provider, soonest-to-expire
--- first — the recovery probe's candidates. The ordering rotates the sample as cooldowns
--- lapse, so a run does not keep probing the same few boards.
-SELECT board
+-- Up to $2 (board, region) pairs currently in an active cooldown for a provider,
+-- soonest-to-expire first — the recovery probe's candidates. The ordering rotates the sample as
+-- cooldowns lapse, so a run does not keep probing the same few boards.
+SELECT board, region
 FROM board_health
 WHERE provider = $1 AND cooldown_until IS NOT NULL AND cooldown_until > now()
-ORDER BY cooldown_until, board
+ORDER BY cooldown_until, board, region
 LIMIT $2;
 
 -- name: ClearProviderCooldowns :execrows

--- a/internal/pipeline/board_health_test.go
+++ b/internal/pipeline/board_health_test.go
@@ -16,56 +16,63 @@ import (
 // cooldowns map is the single source of truth for both the recovery probe's candidates
 // (any board with a future cooldown) and the per-board gate, so ClearCooldowns removing a
 // provider's entries lets the subsequent crawl actually reach those boards — modelling the
-// real DB round-trip end to end.
+// real DB round-trip end to end. The key is "provider/board/region" so a board id that
+// repeats across regions (Adzuna's "it-jobs" once per country) gets independent state,
+// mirroring the real board_health table's (provider, board, region) primary key.
 type fakeHealth struct {
-	cooldowns map[string]time.Time // "provider/board" → cooldown_until
+	cooldowns map[string]time.Time // "provider/board/region" → cooldown_until
 	successes []string
 	failures  []string
 	cleared   []string // providers passed to ClearCooldowns, in call order
 }
 
-func (f *fakeHealth) Cooldown(_ context.Context, provider, board string) (time.Time, bool, error) {
-	t, ok := f.cooldowns[provider+"/"+board]
+func healthKey(provider, board, region string) string { return provider + "/" + board + "/" + region }
+
+func (f *fakeHealth) Cooldown(_ context.Context, provider, board, region string) (time.Time, bool, error) {
+	t, ok := f.cooldowns[healthKey(provider, board, region)]
 	return t, ok, nil
 }
 
-func (f *fakeHealth) RecordSuccess(_ context.Context, provider, board string, _ int) error {
-	f.successes = append(f.successes, provider+"/"+board)
+func (f *fakeHealth) RecordSuccess(_ context.Context, provider, board, region string, _ int) error {
+	f.successes = append(f.successes, healthKey(provider, board, region))
 	return nil
 }
 
-func (f *fakeHealth) RecordFailure(_ context.Context, provider, board, _ string) error {
-	f.failures = append(f.failures, provider+"/"+board)
+func (f *fakeHealth) RecordFailure(_ context.Context, provider, board, region, _ string) error {
+	f.failures = append(f.failures, healthKey(provider, board, region))
 	return nil
 }
 
-// CooledBoards serves up to limit boards of the provider whose canned cooldown is still in
-// the future, soonest-to-expire first — mirroring ListCooledBoards.
-func (f *fakeHealth) CooledBoards(_ context.Context, provider string, limit int) ([]string, error) {
+// CooledBoards serves up to limit (board, region) pairs of the provider whose canned cooldown
+// is still in the future, soonest-to-expire first — mirroring ListCooledBoards.
+func (f *fakeHealth) CooledBoards(_ context.Context, provider string, limit int) ([]CooledBoard, error) {
 	type cand struct {
-		board string
-		until time.Time
+		board, region string
+		until         time.Time
 	}
 	var cands []cand
 	for k, until := range f.cooldowns {
-		p, board, ok := strings.Cut(k, "/")
-		if !ok || p != provider || !until.After(time.Now()) {
+		parts := strings.SplitN(k, "/", 3)
+		if len(parts) != 3 || parts[0] != provider || !until.After(time.Now()) {
 			continue
 		}
-		cands = append(cands, cand{board, until})
+		cands = append(cands, cand{parts[1], parts[2], until})
 	}
 	sort.Slice(cands, func(i, j int) bool {
 		if cands[i].until.Equal(cands[j].until) {
+			if cands[i].board == cands[j].board {
+				return cands[i].region < cands[j].region
+			}
 			return cands[i].board < cands[j].board
 		}
 		return cands[i].until.Before(cands[j].until)
 	})
-	boards := make([]string, 0, limit)
+	boards := make([]CooledBoard, 0, limit)
 	for _, c := range cands {
 		if len(boards) == limit {
 			break
 		}
-		boards = append(boards, c.board)
+		boards = append(boards, CooledBoard{Board: c.board, Region: c.region})
 	}
 	return boards, nil
 }
@@ -155,7 +162,7 @@ func TestRecoverSkipsSingleBoardProvider(t *testing.T) {
 	fetches := 0
 	src := spySource{provider: "gulftalent", fetches: &fetches} // healthy, but must not be probed
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"gulftalent/": time.Now().Add(24 * time.Hour), // one boardless entry, cooled
+		"gulftalent//": time.Now().Add(24 * time.Hour), // one boardless entry, cooled
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
@@ -182,8 +189,8 @@ func TestRecoverLeavesDownMultiBoardProviderCooled(t *testing.T) {
 	fetches := 0
 	src := spySource{provider: "workday", fetches: &fetches, err: errors.New("provider down")}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"workday/a": time.Now().Add(6 * time.Hour),
-		"workday/b": time.Now().Add(6 * time.Hour),
+		"workday/a/": time.Now().Add(6 * time.Hour),
+		"workday/b/": time.Now().Add(6 * time.Hour),
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
@@ -210,8 +217,8 @@ func TestRecoverProbeRecoversProvider(t *testing.T) {
 	fetches := 0
 	src := spySource{provider: "breezy", fetches: &fetches}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"breezy/acme": time.Now().Add(24 * time.Hour),
-		"breezy/beta": time.Now().Add(24 * time.Hour),
+		"breezy/acme/": time.Now().Add(24 * time.Hour),
+		"breezy/beta/": time.Now().Add(24 * time.Hour),
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
@@ -230,6 +237,36 @@ func TestRecoverProbeRecoversProvider(t *testing.T) {
 	}
 }
 
+// A board id that repeats across independent regional slices of one provider (Adzuna's
+// "it-jobs" once per country) must not collide: probing and recovering one region's cooled
+// board must not make the main loop treat a DIFFERENT region's same-named board as already
+// handled and skip crawling it. Without region in boardKey/entriesByProvider, the probe's
+// answer for "it-jobs"/gb would satisfy handled["adzuna"/"it-jobs"] for "it-jobs"/us too, so
+// fetches would stop at 1 and us would silently go uncrawled this cycle.
+func TestRecoverProbeDoesNotCollideAcrossRegions(t *testing.T) {
+	fetches := 0
+	src := spySource{provider: "adzuna", fetches: &fetches}
+	health := &fakeHealth{cooldowns: map[string]time.Time{
+		"adzuna/it-jobs/gb": time.Now().Add(24 * time.Hour),
+		"adzuna/it-jobs/us": time.Now().Add(24 * time.Hour),
+	}}
+	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
+
+	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "Adzuna GB", Provider: "adzuna", Board: "it-jobs", Region: "gb"},
+		{Company: "Adzuna US", Provider: "adzuna", Board: "it-jobs", Region: "us"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if fetches != 2 {
+		t.Errorf("adapter fetched %d times, want 2 — gb and us are independent boards despite sharing a board id", fetches)
+	}
+	if stats.Total().Ingested != 2 || stats.Total().Cooled != 0 {
+		t.Errorf("stats = %+v, want Ingested=2 Cooled=0 (both regions recovered and crawled)", stats.Total())
+	}
+}
+
 // One genuinely-dead board among the cooled set must not mask a recovered provider: the
 // probe tries past the dead candidate to a live one, then clears. This exercises
 // maxRecoveryProbes > 1 — with a single probe (the dead board, first by cooldown order)
@@ -237,8 +274,8 @@ func TestRecoverProbeRecoversProvider(t *testing.T) {
 func TestRecoverProbeTriesPastDeadBoard(t *testing.T) {
 	src := boardKeyedSource{provider: "join", failBoards: map[string]bool{"dead": true}}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"join/dead": time.Now().Add(1 * time.Hour),  // probed first (soonest to expire)
-		"join/live": time.Now().Add(12 * time.Hour), // probed second
+		"join/dead/": time.Now().Add(1 * time.Hour),  // probed first (soonest to expire)
+		"join/live/": time.Now().Add(12 * time.Hour), // probed second
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
@@ -257,8 +294,8 @@ func TestRecoverProbeTriesPastDeadBoard(t *testing.T) {
 	if stats.Total().Ingested != 1 || stats.Total().Cooled != 0 {
 		t.Errorf("stats = %+v, want Ingested=1 Cooled=0", stats.Total())
 	}
-	if len(health.successes) != 1 || health.successes[0] != "join/live" {
-		t.Errorf("successes = %v, want [join/live]", health.successes)
+	if len(health.successes) != 1 || health.successes[0] != "join/live/" {
+		t.Errorf("successes = %v, want [join/live/]", health.successes)
 	}
 }
 
@@ -271,8 +308,8 @@ func TestRecoverProbeTriesPastDeadBoard(t *testing.T) {
 func TestRecoverProbeReusesTheAnsweringBoardsFetchInsteadOfCrawlingItTwice(t *testing.T) {
 	src := &hydratingSpySource{provider: "workday"}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"workday/acme": time.Now().Add(24 * time.Hour), // probed first (soonest to expire, tie-break by name)
-		"workday/beta": time.Now().Add(24 * time.Hour),
+		"workday/acme/": time.Now().Add(24 * time.Hour), // probed first (soonest to expire, tie-break by name)
+		"workday/beta/": time.Now().Add(24 * time.Hour),
 	}}
 	store := &fakeStore{}
 	r := Runner{Registry: registry(src), Store: store, BoardHealth: health}
@@ -325,11 +362,11 @@ func TestRunRecordsBoardOutcome(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(health.successes) != 1 || health.successes[0] != "greenhouse/good" {
-		t.Errorf("successes = %v, want [greenhouse/good]", health.successes)
+	if len(health.successes) != 1 || health.successes[0] != "greenhouse/good/" {
+		t.Errorf("successes = %v, want [greenhouse/good/]", health.successes)
 	}
-	if len(health.failures) != 1 || health.failures[0] != "lever/bad" {
-		t.Errorf("failures = %v, want [lever/bad]", health.failures)
+	if len(health.failures) != 1 || health.failures[0] != "lever/bad/" {
+		t.Errorf("failures = %v, want [lever/bad/]", health.failures)
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -92,18 +92,28 @@ type SeenLookup interface {
 type BoardHealth interface {
 	// Cooldown reports the board's cooldown_until and whether it is set. The Runner
 	// skips the board when it is set and in the future.
-	Cooldown(ctx context.Context, provider, board string) (time.Time, bool, error)
+	Cooldown(ctx context.Context, provider, board, region string) (time.Time, bool, error)
 	// RecordSuccess clears the board's failure state and stamps freshness.
-	RecordSuccess(ctx context.Context, provider, board string, ingested int) error
+	RecordSuccess(ctx context.Context, provider, board, region string, ingested int) error
 	// RecordFailure counts a failed crawl and cools the board down per the backoff policy.
-	RecordFailure(ctx context.Context, provider, board, errMsg string) error
-	// CooledBoards returns up to limit boards of the provider currently in an active
-	// cooldown — the recovery probe's candidates.
-	CooledBoards(ctx context.Context, provider string, limit int) ([]string, error)
+	RecordFailure(ctx context.Context, provider, board, region, errMsg string) error
+	// CooledBoards returns up to limit (board, region) pairs of the provider currently in
+	// an active cooldown — the recovery probe's candidates.
+	CooledBoards(ctx context.Context, provider string, limit int) ([]CooledBoard, error)
 	// ClearCooldowns clears the active cooldown of every currently-cooled board of the
 	// provider and returns how many were cleared. Called once a probe proves the provider
 	// reachable again.
 	ClearCooldowns(ctx context.Context, provider string) (int, error)
+}
+
+// CooledBoard identifies one board currently in an active cooldown. Region disambiguates a
+// board id that repeats across independent regional slices of one provider (e.g. Adzuna's
+// "it-jobs" once per country) — without it, every region's health/cooldown state would
+// collide on the same (provider, board) identity. A provider whose board is region-invariant
+// (everyone but Adzuna today) reports Region == "".
+type CooledBoard struct {
+	Board  string
+	Region string
 }
 
 // Stats reports what a run did: Ingested counts saved jobs, Failed counts boards that
@@ -203,7 +213,7 @@ func (r Runner) Run(ctx context.Context, entries []sources.CompanyEntry) (RunSta
 				return
 			}
 
-			boardStats, already := handled[boardKey{e.Provider, e.Board}]
+			boardStats, already := handled[boardKey{e.Provider, e.Board, e.Region}]
 			if !already {
 				boardStats = r.ingestBoard(ctx, e)
 			}
@@ -228,7 +238,7 @@ const maxRecoveryProbes = 3
 
 // boardKey identifies one board within a run: the pair a CompanyEntry, a Claimed
 // cooldown, and a recovery probe all key on.
-type boardKey struct{ provider, board string }
+type boardKey struct{ provider, board, region string }
 
 // recoverProviders is the provider-level circuit breaker's half-open transition. Before
 // the main crawl, for each provider with cooled boards it probes up to maxRecoveryProbes
@@ -275,7 +285,7 @@ func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyE
 		}
 		log.Printf("ingest: %s answered a recovery probe — cleared %d cooled board(s) to crawl this cycle", provider, cleared)
 		if reused {
-			handled[boardKey{e.Provider, e.Board}] = st
+			handled[boardKey{e.Provider, e.Board, e.Region}] = st
 		}
 	}
 	return handled
@@ -292,13 +302,13 @@ func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyE
 // exercise, so reused is false for it and the main loop still runs it normally. A board
 // absent from this run's entries is skipped (it cannot be probed without its entry), and
 // a cancelled run stops early. answered=false when nothing responded.
-func (r Runner) probeProvider(ctx context.Context, src sources.Source, boards []string, entries map[string]sources.CompanyEntry) (e sources.CompanyEntry, st Stats, reused, answered bool) {
+func (r Runner) probeProvider(ctx context.Context, src sources.Source, boards []CooledBoard, entries map[entryKey]sources.CompanyEntry) (e sources.CompanyEntry, st Stats, reused, answered bool) {
 	_, streaming := src.(sources.StreamingSource)
 	for _, board := range boards {
 		if ctx.Err() != nil {
 			return sources.CompanyEntry{}, Stats{}, false, false
 		}
-		candidate, ok := entries[board]
+		candidate, ok := entries[entryKey{board.Board, board.Region}]
 		if !ok {
 			continue
 		}
@@ -314,24 +324,29 @@ func (r Runner) probeProvider(ctx context.Context, src sources.Source, boards []
 	return sources.CompanyEntry{}, Stats{}, false, false
 }
 
-// entriesByProvider indexes the run's entries as provider → board → entry, so the
-// recovery probe can find the CompanyEntry for a cooled board id.
-func entriesByProvider(entries []sources.CompanyEntry) map[string]map[string]sources.CompanyEntry {
-	byProvider := make(map[string]map[string]sources.CompanyEntry)
+// entryKey is a board's identity within one provider: board alone collides when a provider's
+// board id repeats across independent regional slices (e.g. Adzuna's "it-jobs" once per
+// country), so region joins it. A region-invariant provider's entries all carry Region == "".
+type entryKey struct{ board, region string }
+
+// entriesByProvider indexes the run's entries as provider → entryKey → entry, so the
+// recovery probe can find the CompanyEntry for a cooled (board, region) pair.
+func entriesByProvider(entries []sources.CompanyEntry) map[string]map[entryKey]sources.CompanyEntry {
+	byProvider := make(map[string]map[entryKey]sources.CompanyEntry)
 	for _, e := range entries {
 		boards := byProvider[e.Provider]
 		if boards == nil {
-			boards = make(map[string]sources.CompanyEntry)
+			boards = make(map[entryKey]sources.CompanyEntry)
 			byProvider[e.Provider] = boards
 		}
-		boards[e.Board] = e
+		boards[entryKey{e.Board, e.Region}] = e
 	}
 	return byProvider
 }
 
 // sortedProviders returns the run's providers deterministically, so recovery probes (and
 // tests) are order-stable.
-func sortedProviders(byProvider map[string]map[string]sources.CompanyEntry) []string {
+func sortedProviders(byProvider map[string]map[entryKey]sources.CompanyEntry) []string {
 	providers := make([]string, 0, len(byProvider))
 	for p := range byProvider {
 		providers = append(providers, p)
@@ -541,7 +556,7 @@ func (r Runner) cooledDown(ctx context.Context, e sources.CompanyEntry) bool {
 	if r.BoardHealth == nil {
 		return false
 	}
-	until, set, err := r.BoardHealth.Cooldown(ctx, e.Provider, e.Board)
+	until, set, err := r.BoardHealth.Cooldown(ctx, e.Provider, e.Board, e.Region)
 	if err != nil {
 		log.Printf("ingest: cooldown check %s/%s: %v", e.Provider, e.Board, err)
 		return false
@@ -556,7 +571,7 @@ func (r Runner) recordSuccess(ctx context.Context, e sources.CompanyEntry, inges
 	if r.BoardHealth == nil {
 		return
 	}
-	if err := r.BoardHealth.RecordSuccess(ctx, e.Provider, e.Board, ingested); err != nil {
+	if err := r.BoardHealth.RecordSuccess(ctx, e.Provider, e.Board, e.Region, ingested); err != nil {
 		log.Printf("ingest: record board success %s/%s: %v", e.Provider, e.Board, err)
 	}
 }
@@ -565,7 +580,7 @@ func (r Runner) recordFailure(ctx context.Context, e sources.CompanyEntry, msg s
 	if r.BoardHealth == nil {
 		return
 	}
-	if err := r.BoardHealth.RecordFailure(ctx, e.Provider, e.Board, msg); err != nil {
+	if err := r.BoardHealth.RecordFailure(ctx, e.Provider, e.Board, e.Region, msg); err != nil {
 		log.Printf("ingest: record board failure %s/%s: %v", e.Provider, e.Board, err)
 	}
 }

--- a/migrations/0077_board_health_region.sql
+++ b/migrations/0077_board_health_region.sql
@@ -1,0 +1,8 @@
+-- board_health: add region so a provider whose board id repeats across independent regional
+-- slices (Adzuna: board = "it-jobs" once per country, region = the country) gets one health row
+-- per (provider, board, region) instead of every region's crawl overwriting the same row. Every
+-- other provider today is region-invariant per board (region unset or a pure host-selector, e.g.
+-- Lever's "eu"), so defaulting existing and future region-less rows to '' needs no backfill.
+ALTER TABLE board_health ADD COLUMN region text NOT NULL DEFAULT '';
+ALTER TABLE board_health DROP CONSTRAINT board_health_pkey;
+ALTER TABLE board_health ADD PRIMARY KEY (provider, board, region);


### PR DESCRIPTION
## Summary
- Found while operating the newly-merged Adzuna adapter (#1639/#1635): it's the first provider whose board id repeats across independent regional slices (`board="it-jobs"` once per country — `us`, `gb`, `de`, `au`).
- `board_health`'s `(provider, board)` primary key collapsed all four countries into **one** health row — confirmed live on prod (a single `it-jobs` row covering all four boards). One region's failures could cool down every region together.
- Worse: the recovery-probe path (`entriesByProvider`/`boardKey` in `internal/pipeline/pipeline.go`) collapsed the same way. A probe answering one region's cooled board could mark a **different** region's same-named board as already handled, silently skipping its crawl for that cycle — a real availability bug, not just an observability gap.

## Fix
- Migration `0077_board_health_region.sql`: adds `region` to `board_health`'s primary key.
- Threads `CompanyEntry.Region` through the `pipeline.BoardHealth` port, its Postgres implementation (`cmd/ingest/board_health.go`), and the SQL queries.
- `boardKey`/`entriesByProvider` in `internal/pipeline/pipeline.go` now key by `(board, region)` instead of `board` alone.
- Every other provider passes `region=""` — unaffected, since none of them repeats a board id within itself.

## Test plan
- [x] New integration test (`TestBoardHealth_RegionDisambiguates`) against real Postgres: two regions of the same board id get independent cooldown/failure state; `CooledBoards`/`ClearCooldowns` distinguish them.
- [x] New pipeline unit test (`TestRecoverProbeDoesNotCollideAcrossRegions`): the recovery probe answering one region does not cause the main loop to skip a different region's same-named board. **Verified failing** with the old region-blind `boardKey` (reverted the fix locally, watched it fail with `fetched 1 times, want 2`, then restored the fix and watched it pass) before committing.
- [x] Updated existing `board_health_test.go`/`board_health_integration_test.go` call sites for the new signatures.
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`, `go test -tags=integration ./cmd/ingest/... -run TestBoardHealth` (real Postgres via testcontainers).