### PR TITLE
fix(cv): stop the tailor bootstrap from bouncing silently on unrelated 409s

### DIFF
--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -74,9 +74,12 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	// When the base CV is behind the latest résumé upload, refresh it from the seed before
 	// Tailor copies it into a new vacancy-bound row. Reload of an existing tailored copy
 	// still returns that copy unchanged (Tailor is idempotent); the base refresh is a no-op
-	// once updated_at catches the upload stamp.
+	// once updated_at catches the upload stamp. Best-effort: this refresh exists to keep the
+	// base in sync, not to gate opening the tailor workspace — a role over the bullet cap (or
+	// any other refresh failure) must not block bootstrap. Tailor below falls back to the base
+	// as it currently stands.
 	if err := h.reseedBaseIfStaleVsUpload(c, userID); err != nil {
-		return err
+		log.Printf("cv: base refresh before tailor bootstrap user=%d: %v", userID, err)
 	}
 	base, tailored, err := h.cvStore.Tailor(c.Context(), userID, job.ID, tailoredCVTitle(job.Title), h.seedSource())
 	if errors.Is(err, cv.ErrNoResume) {

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -272,14 +272,17 @@
       // and the preview falls back to the template's own face meanwhile.
       void api.listCvFonts().then((f) => (fonts = f)).catch(() => {});
     } catch (e) {
-      if (e instanceof ApiError && e.status === 409) {
+      if (e instanceof ApiError && e.status === 409 && e.message === 'run the fit analysis first') {
         // The bootstrap (tailorCv) requires a cached match to already exist — true for
         // every vacancy reached the normal way (the match page's "Tailor my CV" button
         // only ever appears once one has run), but never true for a job that just came
         // through the JD-intake dialog (paste text/URL/pick a vacancy — none of those
         // run a match first). Rather than surface that as an error, send the candidate
         // straight to the match page, which auto-runs on a cold start and hands them
-        // back here once it lands.
+        // back here once it lands. Matched on the exact message, not just the 409 status:
+        // TailorCV also 409s when the account has no résumé to seed a base CV from, and
+        // that reason has no fix on the match page — silently bouncing there looks like a
+        // dead loop instead of the "add a résumé" error it actually is.
         void goto(resolve('/match/[slug]', { slug }));
         return;
       }


### PR DESCRIPTION
## Summary
- Reported symptom: https://freehire.me/match/full-stack-developer-easyaudit-ai-inc-b2fchpk4 — clicking "Tailor" immediately redirects back to the match page, no error shown.
- Root cause traced in prod logs (journalctl on host-2): `POST /api/v1/me/cvs/tailor` returned repeated 409s with `experience[10] already has 20 bullets (the maximum)...` — the bootstrap's stale-base refresh (résumé changed since the last tailor) hits the bullet cap and refuses to write, which blocked the whole bootstrap. The frontend then treated *any* 409 from that endpoint as "no cached match" and silently redirected to `/match/[slug]`, so the user saw an infinite bounce loop with no explanation.
- `internal/handler/cv_tailor.go`: the stale-base refresh is now best-effort — a failure (bullet cap or otherwise) is logged and bootstrap continues with the base as it currently stands, instead of blocking the whole request.
- `web/src/routes/tailor/[slug]/+page.svelte`: only redirects to the match page on the specific 409 that redirect exists for ("run the fit analysis first"); any other 409 (e.g. bullet-cap, no résumé) now surfaces as a visible error instead of a silent bounce.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/handler/...`
- [ ] Manual: confirm Tailor opens for the affected account without the loop