### PR TITLE
fix(sources): hydrate EchoJobs descriptions instead of shipping empty ones

### DIFF
--- a/internal/sources/echojobs.go
+++ b/internal/sources/echojobs.go
@@ -58,12 +58,15 @@ func (echojobs) aggregator() {}
 
 func (echojobs) sweepGrace() time.Duration { return echojobsSweepGrace }
 
-// echojobsPosting is one posting from the /api/jobs feed. The upstream response carries several
+// echojobsPosting is one posting from the /api/jobs list. The upstream response carries several
 // more fields (domain_name, first_seen_at, countries, states, job_function, role, seniority,
 // salary_min_usd/salary_max_usd, employment_type, employee_count, funding) that this adapter
 // deliberately does not read: none of them has a home in the Job shape today, and guessing one
-// (e.g. folding salary into Description) is not this adapter's call to make.
+// (e.g. folding salary into Description) is not this adapter's call to make. Notably absent from
+// this list: description — the list endpoint omits the body entirely (verified live), which is
+// why FetchNew hydrates it from the per-posting detail endpoint (see echojobsDetail).
 type echojobsPosting struct {
+	ID             string   `json:"id"`
 	Title          string   `json:"title"`
 	CompanyName    string   `json:"company_name"`
 	URL            string   `json:"url"`
@@ -74,12 +77,55 @@ type echojobsPosting struct {
 	RequiredSkills []string `json:"required_skills"`
 }
 
-// Fetch walks the feed newest-first, stopping once a page's oldest posting (its last entry) falls
-// outside echojobsFreshnessWindow. Per the house pagination rule, a failure on the first page is a
-// board-level error; a failure on a later page ends the walk with what was already gathered.
+// Fetch is the list-only crawl (no description): kept as the fallback for a caller that does not
+// drive hydration. FetchNew is the hydrating path the pipeline prefers.
 func (e echojobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	postings, err := e.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	jobs := make([]Job, len(postings))
+	for i, p := range postings {
+		jobs[i] = p.toJob(parseEpochMillis(p.PostedAt))
+	}
+	return jobs, nil
+}
+
+// FetchNew is the hydrating crawl: it pages the same list, but fetches a posting's detail (the
+// description the list omits) only for a posting the catalogue does not already have — seen
+// reports whether a posting's external id is already ingested. A seen posting yields the
+// list-only job with SeenRefresh set (liveness refresh only, no content rewrite — a content-less
+// re-upsert would wipe the description hydrated when it was new); an unseen posting is hydrated
+// with its detail; a single posting's detail failure is isolated (logged, falling back to
+// list-only so the posting is still ingested). Detail fetches run under the shared bounded worker
+// pool, mirroring justjoin's FetchNew.
+func (e echojobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	postings, err := e.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(postings, defaultDetailWorkers, func(p echojobsPosting) (Job, bool) {
+		base := p.toJob(parseEpochMillis(p.PostedAt))
+		if seen(base.ExternalID) {
+			base.SeenRefresh = true
+			return base, true
+		}
+		d, ok := e.detail(ctx, p.ID)
+		if !ok {
+			log.Printf("echojobs: detail %q failed; ingesting list-only", p.ID)
+			return base, true
+		}
+		return d.apply(base), true
+	}), nil
+}
+
+// crawl pages the feed newest-first, stopping once a page's oldest posting (its last entry) falls
+// outside echojobsFreshnessWindow, and returns every raw posting gathered — the shared list walk
+// behind Fetch and FetchNew. Per the house pagination rule, a failure on the first page is a
+// board-level error; a failure on a later page ends the walk with what was already gathered.
+func (e echojobs) crawl(ctx context.Context) ([]echojobsPosting, error) {
 	cutoff := time.Now().Add(-echojobsFreshnessWindow)
-	var jobs []Job
+	var postings []echojobsPosting
 	for page := 1; ; page++ {
 		var resp struct {
 			Jobs []echojobsPosting `json:"jobs"`
@@ -88,11 +134,11 @@ func (e echojobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 			if page == 1 {
 				return nil, fmt.Errorf("echojobs: page %d: %w", page, err)
 			}
-			log.Printf("echojobs: page %d failed, stopping with %d jobs gathered: %v", page, len(jobs), err)
-			return jobs, nil
+			log.Printf("echojobs: page %d failed, stopping with %d postings gathered: %v", page, len(postings), err)
+			return postings, nil
 		}
 		if len(resp.Jobs) == 0 {
-			return jobs, nil
+			return postings, nil
 		}
 		stale := false
 		for _, p := range resp.Jobs {
@@ -101,16 +147,44 @@ func (e echojobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 				stale = true
 				continue
 			}
-			jobs = append(jobs, p.toJob(postedAt))
+			postings = append(postings, p)
 		}
 		if stale {
-			return jobs, nil
+			return postings, nil
 		}
 	}
 }
 
 func echojobsPageURL(page int) string {
 	return fmt.Sprintf("%s?page=%d&per_page=%d", echojobsBaseURL, page, echojobsPageSize)
+}
+
+// echojobsDetailURL is the per-posting detail endpoint. It is keyed by the feed's internal id,
+// NOT job_handle (echojobs' own slug, which is what ExternalID carries) — the two are unrelated
+// identifiers on the same posting.
+const echojobsDetailURL = echojobsBaseURL + "/%s"
+
+// echojobsDetail is the per-posting detail payload (GET /api/jobs/{id}). Only Description is
+// read; the detail response also repeats several list fields plus salary/education/yoe ones this
+// adapter does not map, for the same reason echojobsPosting's doc gives.
+type echojobsDetail struct {
+	Description string `json:"description"`
+}
+
+// detail fetches a posting's detail, returning ok=false on a failed request so the caller falls
+// back to the list-only job — a posting is never dropped over a missing detail.
+func (e echojobs) detail(ctx context.Context, id string) (echojobsDetail, bool) {
+	var d echojobsDetail
+	if err := e.http.GetJSON(ctx, fmt.Sprintf(echojobsDetailURL, id), &d); err != nil {
+		return echojobsDetail{}, false
+	}
+	return d, true
+}
+
+// apply enriches a list-derived job with the detail payload's sanitized description.
+func (d echojobsDetail) apply(base Job) Job {
+	base.Description = sanitizeHTML(d.Description)
+	return base
 }
 
 func (p echojobsPosting) toJob(postedAt *time.Time) Job {

--- a/internal/sources/echojobs_test.go
+++ b/internal/sources/echojobs_test.go
@@ -6,24 +6,45 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"slices"
 	"strconv"
 	"testing"
 	"time"
 )
 
-// echojobsHTTP is a paging-aware test JSONGetter: it serves pages[i] for ?page=i+1 and records
-// every page number requested, so a test can assert the walk stopped where it should.
+// echojobsHTTP is a paging-and-detail-aware test JSONGetter: it serves pages[i] for ?page=i+1
+// (recording every page number requested) and, for a detail request (/api/jobs/{id}), routes by
+// the id in the path — mirroring getmanfredHTTP's list/detail split.
 type echojobsHTTP struct {
-	pages    []string
-	failPage int // 0 = never fail
-	got      []int
+	pages      []string
+	failPage   int // 0 = never fail
+	got        []int
+	details    map[string]string
+	detailErr  map[string]bool
+	gotDetails []string
 }
+
+var echojobsDetailRE = regexp.MustCompile(`/jobs/([^/?]+)$`)
 
 func (f *echojobsHTTP) GetJSON(_ context.Context, u string, v any) error {
 	parsed, err := url.Parse(u)
 	if err != nil {
 		return err
+	}
+	if parsed.RawQuery == "" {
+		if m := echojobsDetailRE.FindStringSubmatch(parsed.Path); m != nil {
+			id := m[1]
+			f.gotDetails = append(f.gotDetails, id)
+			if f.detailErr[id] {
+				return errors.New("echojobsHTTP: detail boom")
+			}
+			raw, ok := f.details[id]
+			if !ok {
+				return errors.New("echojobsHTTP: no detail for id")
+			}
+			return json.Unmarshal([]byte(raw), v)
+		}
 	}
 	page, _ := strconv.Atoi(parsed.Query().Get("page"))
 	f.got = append(f.got, page)
@@ -41,12 +62,16 @@ func echojobsPageJSON(jobs string) string {
 }
 
 func echojobsJobJSON(handle, postedAt string) string {
+	return echojobsJobJSONWithID(handle, handle, postedAt)
+}
+
+func echojobsJobJSONWithID(id, handle, postedAt string) string {
 	return fmt.Sprintf(`{
-		"id":"x","title":"Backend Engineer","company_name":"Acme","domain_name":"acme.com",
+		"id":%q,"title":"Backend Engineer","company_name":"Acme","domain_name":"acme.com",
 		"url":"https://boards.greenhouse.io/acme/jobs/123","job_handle":%q,
 		"posted_at":%s,"locations":["California","New York"],"remote_type":"hybrid",
 		"required_skills":["Go","NotARealSkill"]
-	}`, handle, postedAt)
+	}`, id, handle, postedAt)
 }
 
 func TestEchojobsFetchMapsFields(t *testing.T) {
@@ -138,5 +163,72 @@ func TestEchojobsFetchLaterPageFailureReturnsPartial(t *testing.T) {
 	}
 	if len(jobs) != 1 || jobs[0].ExternalID != "job-1" {
 		t.Fatalf("want partial result [job-1], got %+v", jobs)
+	}
+}
+
+// The list endpoint carries no description (verified live), so FetchNew hydrates it from the
+// per-posting detail endpoint — but only for a posting the catalogue does not already have.
+func TestEchojobsFetchNewHydratesUnseenPosting(t *testing.T) {
+	now := time.Now().UTC()
+	fresh := strconv.FormatInt(now.UnixMilli(), 10)
+	http := &echojobsHTTP{
+		pages:   []string{echojobsPageJSON(echojobsJobJSONWithID("det1", "acme-swe", fresh)), echojobsPageJSON("")},
+		details: map[string]string{"det1": `{"description":"<p>Great role.</p>"}`},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want 1 job, got %d", len(jobs))
+	}
+	if jobs[0].Description != "<p>Great role.</p>" {
+		t.Fatalf("Description not hydrated: %q", jobs[0].Description)
+	}
+	if !slices.Equal(http.gotDetails, []string{"det1"}) {
+		t.Fatalf("detail requests = %v, want [det1]", http.gotDetails)
+	}
+}
+
+// A posting the catalogue already has must not cost a detail request: it is refreshed
+// (SeenRefresh) with its list-only identity, preserving whatever description was hydrated when
+// it was new — a content-less re-upsert would wipe it.
+func TestEchojobsFetchNewSkipsDetailForSeenPosting(t *testing.T) {
+	now := time.Now().UTC()
+	fresh := strconv.FormatInt(now.UnixMilli(), 10)
+	http := &echojobsHTTP{
+		pages: []string{echojobsPageJSON(echojobsJobJSONWithID("det1", "acme-swe", fresh)), echojobsPageJSON("")},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(externalID string) bool {
+		return externalID == "acme-swe"
+	})
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 || !jobs[0].SeenRefresh {
+		t.Fatalf("want 1 job with SeenRefresh set, got %+v", jobs)
+	}
+	if len(http.gotDetails) != 0 {
+		t.Fatalf("a seen posting must not cost a detail request, got %v", http.gotDetails)
+	}
+}
+
+// A failed detail request must not drop the posting — it falls back to the list-only job.
+func TestEchojobsFetchNewDetailFailureKeepsPosting(t *testing.T) {
+	now := time.Now().UTC()
+	fresh := strconv.FormatInt(now.UnixMilli(), 10)
+	http := &echojobsHTTP{
+		pages:     []string{echojobsPageJSON(echojobsJobJSONWithID("det1", "acme-swe", fresh)), echojobsPageJSON("")},
+		detailErr: map[string]bool{"det1": true},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Description != "" || jobs[0].ExternalID != "acme-swe" {
+		t.Fatalf("posting should survive a failed detail request: %+v", jobs)
 	}
 }


### PR DESCRIPTION
## Summary
- Reported live: EchoJobs job pages on freehire.me render with no description at all.
- Root cause: the `/api/jobs` list endpoint never carries a `description` field — confirmed by diffing its response keys against the per-posting detail endpoint (`/api/jobs/{id}`), which does.
- Fix: implements `sources.HydratingSource` (mirrors `justjoin.go`'s pattern exactly). `Fetch` stays list-only; `FetchNew` pages the same freshness-bounded crawl but only fetches detail for a posting the catalogue doesn't already have (`seen` predicate), refreshing an already-seen posting's liveness (`SeenRefresh`) without rewriting its content. A failed detail request falls back to the list-only job rather than dropping the posting.

## Why not always fetch detail
EchoJobs ingests ~60k postings/day within the 14-day freshness window. Fetching detail for every posting on every hourly run would balloon request volume by orders of magnitude; hydrating only genuinely-new postings keeps the added cost proportional to actual new inventory per run.

## Test plan
- [x] New tests written first (RED verified): unseen posting gets hydrated with its detail description; a seen posting costs zero detail requests and gets `SeenRefresh`; a failed detail request keeps the posting list-only rather than dropping it.
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`