### PR TITLE
perf(reindex): purge search_outbox entries a full reindex already covers

### DIFF
--- a/cmd/ingest/board_health.go
+++ b/cmd/ingest/board_health.go
@@ -27,8 +27,8 @@ func newBoardHealth(pool *pgxpool.Pool) *boardHealth { return &boardHealth{q: db
 
 // Cooldown returns the board's cooldown_until; an absent row or a NULL cooldown means
 // eligible.
-func (h *boardHealth) Cooldown(ctx context.Context, provider, board string) (time.Time, bool, error) {
-	ts, err := h.q.GetBoardCooldown(ctx, db.GetBoardCooldownParams{Provider: provider, Board: board})
+func (h *boardHealth) Cooldown(ctx context.Context, provider, board, region string) (time.Time, bool, error) {
+	ts, err := h.q.GetBoardCooldown(ctx, db.GetBoardCooldownParams{Provider: provider, Board: board, Region: region})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return time.Time{}, false, nil
 	}
@@ -42,10 +42,11 @@ func (h *boardHealth) Cooldown(ctx context.Context, provider, board string) (tim
 }
 
 // RecordSuccess clears the board's failure state and stamps freshness.
-func (h *boardHealth) RecordSuccess(ctx context.Context, provider, board string, ingested int) error {
+func (h *boardHealth) RecordSuccess(ctx context.Context, provider, board, region string, ingested int) error {
 	return h.q.RecordBoardSuccess(ctx, db.RecordBoardSuccessParams{
 		Provider:          provider,
 		Board:             board,
+		Region:            region,
 		LastIngestedCount: pgtype.Int4{Int32: int32(ingested), Valid: true},
 	})
 }
@@ -53,10 +54,11 @@ func (h *boardHealth) RecordSuccess(ctx context.Context, provider, board string,
 // RecordFailure bumps the failure count (the query returns the new count), then applies
 // the Go-owned backoff policy: it sets a cooldown only once the count crosses the
 // threshold.
-func (h *boardHealth) RecordFailure(ctx context.Context, provider, board, errMsg string) error {
+func (h *boardHealth) RecordFailure(ctx context.Context, provider, board, region, errMsg string) error {
 	failures, err := h.q.RecordBoardFailure(ctx, db.RecordBoardFailureParams{
 		Provider:  provider,
 		Board:     board,
+		Region:    region,
 		LastError: pgtype.Text{String: errMsg, Valid: true},
 	})
 	if err != nil {
@@ -69,13 +71,23 @@ func (h *boardHealth) RecordFailure(ctx context.Context, provider, board, errMsg
 	return h.q.SetBoardCooldown(ctx, db.SetBoardCooldownParams{
 		Provider:      provider,
 		Board:         board,
+		Region:        region,
 		CooldownUntil: pgtype.Timestamptz{Time: time.Now().Add(d), Valid: true},
 	})
 }
 
-// CooledBoards returns up to limit boards of the provider currently in an active cooldown.
-func (h *boardHealth) CooledBoards(ctx context.Context, provider string, limit int) ([]string, error) {
-	return h.q.ListCooledBoards(ctx, db.ListCooledBoardsParams{Provider: provider, Limit: int32(limit)})
+// CooledBoards returns up to limit (board, region) pairs of the provider currently in an
+// active cooldown.
+func (h *boardHealth) CooledBoards(ctx context.Context, provider string, limit int) ([]pipeline.CooledBoard, error) {
+	rows, err := h.q.ListCooledBoards(ctx, db.ListCooledBoardsParams{Provider: provider, Limit: int32(limit)})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]pipeline.CooledBoard, len(rows))
+	for i, r := range rows {
+		out[i] = pipeline.CooledBoard{Board: r.Board, Region: r.Region}
+	}
+	return out, nil
 }
 
 // ClearCooldowns clears the active cooldown and failure count of every currently-cooled
@@ -99,7 +111,11 @@ func logUnhealthyBoards(ctx context.Context, q *db.Queries) {
 	}
 	parts := make([]string, 0, len(rows))
 	for _, r := range rows {
-		desc := fmt.Sprintf("%s/%s(fails=%d", r.Provider, r.Board, r.ConsecutiveFailures)
+		id := r.Provider + "/" + r.Board
+		if r.Region != "" {
+			id += "/" + r.Region
+		}
+		desc := fmt.Sprintf("%s(fails=%d", id, r.ConsecutiveFailures)
 		if r.CooldownUntil.Valid && r.CooldownUntil.Time.After(time.Now()) {
 			desc += ",cooled_until=" + r.CooldownUntil.Time.UTC().Format(time.RFC3339)
 		}

--- a/cmd/ingest/board_health_integration_test.go
+++ b/cmd/ingest/board_health_integration_test.go
@@ -29,25 +29,25 @@ func TestBoardHealth_FailureCooldownSelfHeal(t *testing.T) {
 	h := newBoardHealth(pool)
 
 	// Never seen → eligible.
-	if _, cooled, err := h.Cooldown(ctx, "greenhouse", "acme"); err != nil || cooled {
+	if _, cooled, err := h.Cooldown(ctx, "greenhouse", "acme", ""); err != nil || cooled {
 		t.Fatalf("fresh board Cooldown = (_, %v, %v), want (_, false, nil)", cooled, err)
 	}
 
 	// The first two failures stay below the threshold — no cooldown, cron retries.
 	for i := 0; i < 2; i++ {
-		if err := h.RecordFailure(ctx, "greenhouse", "acme", "boom"); err != nil {
+		if err := h.RecordFailure(ctx, "greenhouse", "acme", "", "boom"); err != nil {
 			t.Fatalf("RecordFailure: %v", err)
 		}
 	}
-	if _, cooled, _ := h.Cooldown(ctx, "greenhouse", "acme"); cooled {
+	if _, cooled, _ := h.Cooldown(ctx, "greenhouse", "acme", ""); cooled {
 		t.Error("board should not be cooled below the threshold (2 failures)")
 	}
 
 	// The third consecutive failure crosses the threshold → cooldown is set.
-	if err := h.RecordFailure(ctx, "greenhouse", "acme", "boom again"); err != nil {
+	if err := h.RecordFailure(ctx, "greenhouse", "acme", "", "boom again"); err != nil {
 		t.Fatalf("RecordFailure: %v", err)
 	}
-	until, cooled, err := h.Cooldown(ctx, "greenhouse", "acme")
+	until, cooled, err := h.Cooldown(ctx, "greenhouse", "acme", "")
 	if err != nil || !cooled {
 		t.Fatalf("after 3 failures Cooldown = (%v, %v, %v), want a future cooldown", until, cooled, err)
 	}
@@ -56,10 +56,10 @@ func TestBoardHealth_FailureCooldownSelfHeal(t *testing.T) {
 	}
 
 	// A success self-heals: failure state cleared, cooldown gone.
-	if err := h.RecordSuccess(ctx, "greenhouse", "acme", 7); err != nil {
+	if err := h.RecordSuccess(ctx, "greenhouse", "acme", "", 7); err != nil {
 		t.Fatalf("RecordSuccess: %v", err)
 	}
-	if _, cooled, _ := h.Cooldown(ctx, "greenhouse", "acme"); cooled {
+	if _, cooled, _ := h.Cooldown(ctx, "greenhouse", "acme", ""); cooled {
 		t.Error("a success must clear the cooldown (self-heal)")
 	}
 
@@ -85,7 +85,7 @@ func TestBoardHealth_CooledBoardsAndClear(t *testing.T) {
 	cool := func(provider, board string) {
 		t.Helper()
 		for i := 0; i < 3; i++ { // crosses the cooldown threshold
-			if err := h.RecordFailure(ctx, provider, board, "boom"); err != nil {
+			if err := h.RecordFailure(ctx, provider, board, "", "boom"); err != nil {
 				t.Fatalf("RecordFailure %s/%s: %v", provider, board, err)
 			}
 		}
@@ -94,7 +94,7 @@ func TestBoardHealth_CooledBoardsAndClear(t *testing.T) {
 	cool("breezy", "b1")
 	cool("breezy", "b2")
 	cool("breezy", "b3")
-	if err := h.RecordSuccess(ctx, "breezy", "b-ok", 1); err != nil {
+	if err := h.RecordSuccess(ctx, "breezy", "b-ok", "", 1); err != nil {
 		t.Fatalf("RecordSuccess: %v", err)
 	}
 	// join: an unrelated provider's cooled board, to prove clearing is provider-scoped.
@@ -103,7 +103,7 @@ func TestBoardHealth_CooledBoardsAndClear(t *testing.T) {
 	// The limit caps the sample, soonest-to-expire first — b1, b2 cooled before b3.
 	if got, err := h.CooledBoards(ctx, "breezy", 2); err != nil {
 		t.Fatalf("CooledBoards: %v", err)
-	} else if len(got) != 2 || got[0] != "b1" || got[1] != "b2" {
+	} else if len(got) != 2 || got[0].Board != "b1" || got[1].Board != "b2" {
 		t.Errorf("CooledBoards(breezy, 2) = %v, want [b1 b2]", got)
 	}
 	// Above the count: exactly the three cooled boards, never the fresh one.
@@ -126,7 +126,47 @@ func TestBoardHealth_CooledBoardsAndClear(t *testing.T) {
 	}
 
 	// join's cooled board is untouched — clearing is scoped to the one provider.
-	if _, cooled, err := h.Cooldown(ctx, "join", "j1"); err != nil || !cooled {
+	if _, cooled, err := h.Cooldown(ctx, "join", "j1", ""); err != nil || !cooled {
 		t.Errorf("join/j1 Cooldown = (_, %v, %v), want still cooled after clearing breezy", cooled, err)
+	}
+}
+
+// A board id that repeats across independent regional slices (Adzuna's "it-jobs" once per
+// country) must not share health state across regions: cooling one region's board leaves a
+// same-named board in another region eligible, and CooledBoards/ClearCooldowns distinguish them.
+func TestBoardHealth_RegionDisambiguates(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	h := newBoardHealth(pool)
+
+	for i := 0; i < 3; i++ { // crosses the cooldown threshold
+		if err := h.RecordFailure(ctx, "adzuna", "it-jobs", "gb", "boom"); err != nil {
+			t.Fatalf("RecordFailure gb: %v", err)
+		}
+	}
+	if err := h.RecordSuccess(ctx, "adzuna", "it-jobs", "us", 42); err != nil {
+		t.Fatalf("RecordSuccess us: %v", err)
+	}
+
+	if _, cooled, err := h.Cooldown(ctx, "adzuna", "it-jobs", "gb"); err != nil || !cooled {
+		t.Fatalf("gb Cooldown = (_, %v, %v), want cooled", cooled, err)
+	}
+	if _, cooled, err := h.Cooldown(ctx, "adzuna", "it-jobs", "us"); err != nil || cooled {
+		t.Fatalf("us Cooldown = (_, %v, %v), want eligible — gb's failures must not bleed into us", cooled, err)
+	}
+
+	got, err := h.CooledBoards(ctx, "adzuna", 10)
+	if err != nil {
+		t.Fatalf("CooledBoards: %v", err)
+	}
+	if len(got) != 1 || got[0].Board != "it-jobs" || got[0].Region != "gb" {
+		t.Fatalf("CooledBoards(adzuna) = %v, want exactly [{it-jobs gb}]", got)
+	}
+
+	if n, err := h.ClearCooldowns(ctx, "adzuna"); err != nil || n != 1 {
+		t.Fatalf("ClearCooldowns(adzuna) = (%d, %v), want (1, nil)", n, err)
+	}
+	if _, cooled, err := h.Cooldown(ctx, "adzuna", "it-jobs", "us"); err != nil || cooled {
+		t.Fatalf("us Cooldown after clearing gb = (_, %v, %v), want still eligible", cooled, err)
 	}
 }

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -26,6 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
@@ -58,6 +60,13 @@ func run() int {
 		return 1
 	}
 	defer cleanup()
+
+	// Captured before anything else runs (including the duplicate-marker recompute
+	// passes below, which can themselves take minutes under load): a full facet
+	// reindex reads every job's CURRENT content, so any search_outbox row queued
+	// before this instant is provably already reflected in what the scan reads.
+	// Purged after a successful facet-only swap — see the call site near the bottom.
+	startedAt := time.Now()
 
 	// Bootstrap owns config + pool, so this required-config check lands just after
 	// the pool opens rather than before it. The connect is cheap and cleanup closes
@@ -198,6 +207,18 @@ func run() int {
 		return 1
 	}
 	log.Printf("reindex done: target=%s scope=%s indexed=%d skipped=%d", target, scope, indexed, skipped)
+
+	// search_outbox belongs only to the facet index (the semantic index has its own,
+	// unrelated semantic_outbox) — see the startedAt comment above for the safety
+	// argument. Best-effort: the reindex itself already succeeded, so a purge failure
+	// just leaves those rows for the next cycle rather than failing this run.
+	if !semantic {
+		if n, err := q.DeleteSearchOutboxCreatedBefore(ctx, pgtype.Timestamptz{Time: startedAt, Valid: true}); err != nil {
+			log.Printf("reindex: purge stale search_outbox entries: %v", err)
+		} else if n > 0 {
+			log.Printf("reindex: purged %d stale search_outbox entries queued before this run", n)
+		}
+	}
 	return 0
 }
 

--- a/internal/db/board_health.sql.go
+++ b/internal/db/board_health.sql.go
@@ -32,28 +32,31 @@ func (q *Queries) ClearProviderCooldowns(ctx context.Context, provider string) (
 const getBoardCooldown = `-- name: GetBoardCooldown :one
 SELECT cooldown_until
 FROM board_health
-WHERE provider = $1 AND board = $2
+WHERE provider = $1 AND board = $2 AND region = $3
 `
 
 type GetBoardCooldownParams struct {
 	Provider string `json:"provider"`
 	Board    string `json:"board"`
+	Region   string `json:"region"`
 }
 
 // The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
-// which the caller treats as "never seen, eligible".
+// which the caller treats as "never seen, eligible". region disambiguates a board id that
+// repeats across independent regional slices (e.g. Adzuna's "it-jobs" once per country); every
+// other provider passes ” here, matching the column's default.
 func (q *Queries) GetBoardCooldown(ctx context.Context, arg GetBoardCooldownParams) (pgtype.Timestamptz, error) {
-	row := q.db.QueryRow(ctx, getBoardCooldown, arg.Provider, arg.Board)
+	row := q.db.QueryRow(ctx, getBoardCooldown, arg.Provider, arg.Board, arg.Region)
 	var cooldown_until pgtype.Timestamptz
 	err := row.Scan(&cooldown_until)
 	return cooldown_until, err
 }
 
 const listCooledBoards = `-- name: ListCooledBoards :many
-SELECT board
+SELECT board, region
 FROM board_health
 WHERE provider = $1 AND cooldown_until IS NOT NULL AND cooldown_until > now()
-ORDER BY cooldown_until, board
+ORDER BY cooldown_until, board, region
 LIMIT $2
 `
 
@@ -62,22 +65,27 @@ type ListCooledBoardsParams struct {
 	Limit    int32  `json:"limit"`
 }
 
-// Up to $2 boards currently in an active cooldown for a provider, soonest-to-expire
-// first — the recovery probe's candidates. The ordering rotates the sample as cooldowns
-// lapse, so a run does not keep probing the same few boards.
-func (q *Queries) ListCooledBoards(ctx context.Context, arg ListCooledBoardsParams) ([]string, error) {
+type ListCooledBoardsRow struct {
+	Board  string `json:"board"`
+	Region string `json:"region"`
+}
+
+// Up to $2 (board, region) pairs currently in an active cooldown for a provider,
+// soonest-to-expire first — the recovery probe's candidates. The ordering rotates the sample as
+// cooldowns lapse, so a run does not keep probing the same few boards.
+func (q *Queries) ListCooledBoards(ctx context.Context, arg ListCooledBoardsParams) ([]ListCooledBoardsRow, error) {
 	rows, err := q.db.Query(ctx, listCooledBoards, arg.Provider, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []string{}
+	items := []ListCooledBoardsRow{}
 	for rows.Next() {
-		var board string
-		if err := rows.Scan(&board); err != nil {
+		var i ListCooledBoardsRow
+		if err := rows.Scan(&i.Board, &i.Region); err != nil {
 			return nil, err
 		}
-		items = append(items, board)
+		items = append(items, i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -86,15 +94,16 @@ func (q *Queries) ListCooledBoards(ctx context.Context, arg ListCooledBoardsPara
 }
 
 const listUnhealthyBoards = `-- name: ListUnhealthyBoards :many
-SELECT provider, board, consecutive_failures, cooldown_until, last_error, last_error_at
+SELECT provider, board, region, consecutive_failures, cooldown_until, last_error, last_error_at
 FROM board_health
 WHERE consecutive_failures > 0 OR (cooldown_until IS NOT NULL AND cooldown_until > now())
-ORDER BY consecutive_failures DESC, provider, board
+ORDER BY consecutive_failures DESC, provider, board, region
 `
 
 type ListUnhealthyBoardsRow struct {
 	Provider            string             `json:"provider"`
 	Board               string             `json:"board"`
+	Region              string             `json:"region"`
 	ConsecutiveFailures int32              `json:"consecutive_failures"`
 	CooldownUntil       pgtype.Timestamptz `json:"cooldown_until"`
 	LastError           pgtype.Text        `json:"last_error"`
@@ -115,6 +124,7 @@ func (q *Queries) ListUnhealthyBoards(ctx context.Context) ([]ListUnhealthyBoard
 		if err := rows.Scan(
 			&i.Provider,
 			&i.Board,
+			&i.Region,
 			&i.ConsecutiveFailures,
 			&i.CooldownUntil,
 			&i.LastError,
@@ -192,9 +202,9 @@ func (q *Queries) ProviderHealthRollup(ctx context.Context) ([]ProviderHealthRol
 }
 
 const recordBoardFailure = `-- name: RecordBoardFailure :one
-INSERT INTO board_health (provider, board, consecutive_failures, last_error, last_error_at, last_run_at)
-VALUES ($1, $2, 1, $3, now(), now())
-ON CONFLICT (provider, board) DO UPDATE SET
+INSERT INTO board_health (provider, board, region, consecutive_failures, last_error, last_error_at, last_run_at)
+VALUES ($1, $2, $3, 1, $4, now(), now())
+ON CONFLICT (provider, board, region) DO UPDATE SET
     consecutive_failures = board_health.consecutive_failures + 1,
     last_error           = EXCLUDED.last_error,
     last_error_at        = now(),
@@ -205,6 +215,7 @@ RETURNING consecutive_failures
 type RecordBoardFailureParams struct {
 	Provider  string      `json:"provider"`
 	Board     string      `json:"board"`
+	Region    string      `json:"region"`
 	LastError pgtype.Text `json:"last_error"`
 }
 
@@ -212,17 +223,22 @@ type RecordBoardFailureParams struct {
 // and RETURN the new failure count so the caller can compute the cooldown (the backoff
 // policy lives in Go, not here). The cooldown itself is applied by SetBoardCooldown.
 func (q *Queries) RecordBoardFailure(ctx context.Context, arg RecordBoardFailureParams) (int32, error) {
-	row := q.db.QueryRow(ctx, recordBoardFailure, arg.Provider, arg.Board, arg.LastError)
+	row := q.db.QueryRow(ctx, recordBoardFailure,
+		arg.Provider,
+		arg.Board,
+		arg.Region,
+		arg.LastError,
+	)
 	var consecutive_failures int32
 	err := row.Scan(&consecutive_failures)
 	return consecutive_failures, err
 }
 
 const recordBoardSuccess = `-- name: RecordBoardSuccess :exec
-INSERT INTO board_health (provider, board, consecutive_failures, cooldown_until,
+INSERT INTO board_health (provider, board, region, consecutive_failures, cooldown_until,
                           last_success_at, last_ingested_count, last_run_at)
-VALUES ($1, $2, 0, NULL, now(), $3, now())
-ON CONFLICT (provider, board) DO UPDATE SET
+VALUES ($1, $2, $3, 0, NULL, now(), $4, now())
+ON CONFLICT (provider, board, region) DO UPDATE SET
     consecutive_failures = 0,
     cooldown_until       = NULL,
     last_success_at      = now(),
@@ -233,31 +249,43 @@ ON CONFLICT (provider, board) DO UPDATE SET
 type RecordBoardSuccessParams struct {
 	Provider          string      `json:"provider"`
 	Board             string      `json:"board"`
+	Region            string      `json:"region"`
 	LastIngestedCount pgtype.Int4 `json:"last_ingested_count"`
 }
 
 // A successful crawl clears the failure state and stamps freshness. Upsert so a
 // first-ever crawl creates the row.
 func (q *Queries) RecordBoardSuccess(ctx context.Context, arg RecordBoardSuccessParams) error {
-	_, err := q.db.Exec(ctx, recordBoardSuccess, arg.Provider, arg.Board, arg.LastIngestedCount)
+	_, err := q.db.Exec(ctx, recordBoardSuccess,
+		arg.Provider,
+		arg.Board,
+		arg.Region,
+		arg.LastIngestedCount,
+	)
 	return err
 }
 
 const setBoardCooldown = `-- name: SetBoardCooldown :exec
 UPDATE board_health
-SET cooldown_until = $3
-WHERE provider = $1 AND board = $2
+SET cooldown_until = $4
+WHERE provider = $1 AND board = $2 AND region = $3
 `
 
 type SetBoardCooldownParams struct {
 	Provider      string             `json:"provider"`
 	Board         string             `json:"board"`
+	Region        string             `json:"region"`
 	CooldownUntil pgtype.Timestamptz `json:"cooldown_until"`
 }
 
 // Apply the Go-computed cooldown window to a board (called only when the backoff
 // policy says to cool down).
 func (q *Queries) SetBoardCooldown(ctx context.Context, arg SetBoardCooldownParams) error {
-	_, err := q.db.Exec(ctx, setBoardCooldown, arg.Provider, arg.Board, arg.CooldownUntil)
+	_, err := q.db.Exec(ctx, setBoardCooldown,
+		arg.Provider,
+		arg.Board,
+		arg.Region,
+		arg.CooldownUntil,
+	)
 	return err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -113,6 +113,7 @@ type BoardHealth struct {
 	LastSuccessAt       pgtype.Timestamptz `json:"last_success_at"`
 	LastIngestedCount   pgtype.Int4        `json:"last_ingested_count"`
 	LastRunAt           pgtype.Timestamptz `json:"last_run_at"`
+	Region              string             `json:"region"`
 }
 
 type CommunityPersona struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -860,7 +860,9 @@ type Querier interface {
 	// several (cv-builder), so there is no uniqueness constraint and the ORDER BY does the choosing.
 	GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVByUserRow, error)
 	// The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
-	// which the caller treats as "never seen, eligible".
+	// which the caller treats as "never seen, eligible". region disambiguates a board id that
+	// repeats across independent regional slices (e.g. Adzuna's "it-jobs" once per country); every
+	// other provider passes '' here, matching the column's default.
 	GetBoardCooldown(ctx context.Context, arg GetBoardCooldownParams) (pgtype.Timestamptz, error)
 	// One CV owned by the user, including the full data blob. Owner-scoped: a foreign or
 	// missing id returns no row (the handler maps it to 404). job_id is NULL for a base CV and
@@ -1399,10 +1401,10 @@ type Querier interface {
 	ListConnectedGmailUsers(ctx context.Context) ([]ListConnectedGmailUsersRow, error)
 	// The "my contributions" list: one user's contributions, newest first.
 	ListContributionsByUser(ctx context.Context, submittedBy int64) ([]LinkContribution, error)
-	// Up to $2 boards currently in an active cooldown for a provider, soonest-to-expire
-	// first — the recovery probe's candidates. The ordering rotates the sample as cooldowns
-	// lapse, so a run does not keep probing the same few boards.
-	ListCooledBoards(ctx context.Context, arg ListCooledBoardsParams) ([]string, error)
+	// Up to $2 (board, region) pairs currently in an active cooldown for a provider,
+	// soonest-to-expire first — the recovery probe's candidates. The ordering rotates the sample as
+	// cooldowns lapse, so a run does not keep probing the same few boards.
+	ListCooledBoards(ctx context.Context, arg ListCooledBoardsParams) ([]ListCooledBoardsRow, error)
 	// The caller's credit-ledger entries, newest first, for the transaction-history page. Bounded
 	// by a caller-supplied limit and served by the (user_id, created_at DESC) index. The handler
 	// resolves each debit's ref to a human label (the job/CV it named).

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -638,6 +638,21 @@ type Querier interface {
 	// Returns the affected row count: 0 means it does not exist or is not the caller's
 	// (the handler maps that to 404).
 	DeleteSavedSearch(ctx context.Context, arg DeleteSavedSearchParams) (int64, error)
+	// A full facet reindex reads every job's CURRENT content directly from Postgres, so
+	// any entry queued before the run started is provably already reflected in the
+	// freshly-swapped live index — cmd/reindex calls this once, after a successful
+	// Promote(), with the run's own start timestamp. Entries queued during the run are
+	// left alone: some represent a job that changed again after the reindex's scan
+	// already passed its row, so a future search-drain run still needs them.
+	//
+	// created_at alone is NOT enough: EnqueueSearchOutbox's ON CONFLICT (job_id) DO
+	// NOTHING means created_at is stamped only on a job's FIRST enqueue since its last
+	// drain, so a job re-changed while its outbox row is still pending (e.g. because
+	// search-drain is paused for the reindex's whole duration) keeps its OLD created_at.
+	// jobs.updated_at is stamped in the same transaction as every EnqueueSearchOutbox
+	// call (cmd/ingest/store.go), so requiring it to also predate the cutoff catches a
+	// job re-changed during the run even when its outbox row's created_at did not move.
+	DeleteSearchOutboxCreatedBefore(ctx context.Context, before pgtype.Timestamptz) (int64, error)
 	DeleteSearchOutboxEntries(ctx context.Context, ids []int64) error
 	DeleteSemanticEntriesBatch(ctx context.Context, ids []int64) error
 	// Unsubscribe, scoped to its owner. Returns the affected row count: 0 means it

--- a/internal/db/queries/board_health.sql
+++ b/internal/db/queries/board_health.sql
@@ -1,17 +1,19 @@
 -- name: GetBoardCooldown :one
 -- The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
--- which the caller treats as "never seen, eligible".
+-- which the caller treats as "never seen, eligible". region disambiguates a board id that
+-- repeats across independent regional slices (e.g. Adzuna's "it-jobs" once per country); every
+-- other provider passes '' here, matching the column's default.
 SELECT cooldown_until
 FROM board_health
-WHERE provider = $1 AND board = $2;
+WHERE provider = $1 AND board = $2 AND region = $3;
 
 -- name: RecordBoardSuccess :exec
 -- A successful crawl clears the failure state and stamps freshness. Upsert so a
 -- first-ever crawl creates the row.
-INSERT INTO board_health (provider, board, consecutive_failures, cooldown_until,
+INSERT INTO board_health (provider, board, region, consecutive_failures, cooldown_until,
                           last_success_at, last_ingested_count, last_run_at)
-VALUES ($1, $2, 0, NULL, now(), $3, now())
-ON CONFLICT (provider, board) DO UPDATE SET
+VALUES ($1, $2, $3, 0, NULL, now(), $4, now())
+ON CONFLICT (provider, board, region) DO UPDATE SET
     consecutive_failures = 0,
     cooldown_until       = NULL,
     last_success_at      = now(),
@@ -22,9 +24,9 @@ ON CONFLICT (provider, board) DO UPDATE SET
 -- Count a failed crawl: bump consecutive_failures, record the error, stamp the run,
 -- and RETURN the new failure count so the caller can compute the cooldown (the backoff
 -- policy lives in Go, not here). The cooldown itself is applied by SetBoardCooldown.
-INSERT INTO board_health (provider, board, consecutive_failures, last_error, last_error_at, last_run_at)
-VALUES ($1, $2, 1, $3, now(), now())
-ON CONFLICT (provider, board) DO UPDATE SET
+INSERT INTO board_health (provider, board, region, consecutive_failures, last_error, last_error_at, last_run_at)
+VALUES ($1, $2, $3, 1, $4, now(), now())
+ON CONFLICT (provider, board, region) DO UPDATE SET
     consecutive_failures = board_health.consecutive_failures + 1,
     last_error           = EXCLUDED.last_error,
     last_error_at        = now(),
@@ -35,25 +37,25 @@ RETURNING consecutive_failures;
 -- Apply the Go-computed cooldown window to a board (called only when the backoff
 -- policy says to cool down).
 UPDATE board_health
-SET cooldown_until = $3
-WHERE provider = $1 AND board = $2;
+SET cooldown_until = $4
+WHERE provider = $1 AND board = $2 AND region = $3;
 
 -- name: ListUnhealthyBoards :many
 -- Every board currently failing or cooled down, worst first — the operator's
 -- "what's broken" query and the source of the per-run summary log.
-SELECT provider, board, consecutive_failures, cooldown_until, last_error, last_error_at
+SELECT provider, board, region, consecutive_failures, cooldown_until, last_error, last_error_at
 FROM board_health
 WHERE consecutive_failures > 0 OR (cooldown_until IS NOT NULL AND cooldown_until > now())
-ORDER BY consecutive_failures DESC, provider, board;
+ORDER BY consecutive_failures DESC, provider, board, region;
 
 -- name: ListCooledBoards :many
--- Up to $2 boards currently in an active cooldown for a provider, soonest-to-expire
--- first — the recovery probe's candidates. The ordering rotates the sample as cooldowns
--- lapse, so a run does not keep probing the same few boards.
-SELECT board
+-- Up to $2 (board, region) pairs currently in an active cooldown for a provider,
+-- soonest-to-expire first — the recovery probe's candidates. The ordering rotates the sample as
+-- cooldowns lapse, so a run does not keep probing the same few boards.
+SELECT board, region
 FROM board_health
 WHERE provider = $1 AND cooldown_until IS NOT NULL AND cooldown_until > now()
-ORDER BY cooldown_until, board
+ORDER BY cooldown_until, board, region
 LIMIT $2;
 
 -- name: ClearProviderCooldowns :execrows

--- a/internal/db/queries/search_outbox.sql
+++ b/internal/db/queries/search_outbox.sql
@@ -39,6 +39,27 @@ RETURNING o.id, o.job_id;
 DELETE FROM search_outbox
 WHERE id = ANY(sqlc.arg(ids)::bigint[]);
 
+-- name: DeleteSearchOutboxCreatedBefore :execrows
+-- A full facet reindex reads every job's CURRENT content directly from Postgres, so
+-- any entry queued before the run started is provably already reflected in the
+-- freshly-swapped live index — cmd/reindex calls this once, after a successful
+-- Promote(), with the run's own start timestamp. Entries queued during the run are
+-- left alone: some represent a job that changed again after the reindex's scan
+-- already passed its row, so a future search-drain run still needs them.
+--
+-- created_at alone is NOT enough: EnqueueSearchOutbox's ON CONFLICT (job_id) DO
+-- NOTHING means created_at is stamped only on a job's FIRST enqueue since its last
+-- drain, so a job re-changed while its outbox row is still pending (e.g. because
+-- search-drain is paused for the reindex's whole duration) keeps its OLD created_at.
+-- jobs.updated_at is stamped in the same transaction as every EnqueueSearchOutbox
+-- call (cmd/ingest/store.go), so requiring it to also predate the cutoff catches a
+-- job re-changed during the run even when its outbox row's created_at did not move.
+DELETE FROM search_outbox o
+USING jobs j
+WHERE o.job_id = j.id
+  AND o.created_at < sqlc.arg(before)
+  AND j.updated_at < sqlc.arg(before);
+
 -- name: RecordSearchOutboxFailure :one
 -- Count a failed attempt: bump attempts, record the error, and dead-letter (set
 -- failed_at) once attempts reach the max. The lease (claimed_at) is intentionally

--- a/internal/db/search_outbox.sql.go
+++ b/internal/db/search_outbox.sql.go
@@ -69,6 +69,36 @@ func (q *Queries) ClaimSearchOutboxBatch(ctx context.Context, arg ClaimSearchOut
 	return items, nil
 }
 
+const deleteSearchOutboxCreatedBefore = `-- name: DeleteSearchOutboxCreatedBefore :execrows
+DELETE FROM search_outbox o
+USING jobs j
+WHERE o.job_id = j.id
+  AND o.created_at < $1
+  AND j.updated_at < $1
+`
+
+// A full facet reindex reads every job's CURRENT content directly from Postgres, so
+// any entry queued before the run started is provably already reflected in the
+// freshly-swapped live index — cmd/reindex calls this once, after a successful
+// Promote(), with the run's own start timestamp. Entries queued during the run are
+// left alone: some represent a job that changed again after the reindex's scan
+// already passed its row, so a future search-drain run still needs them.
+//
+// created_at alone is NOT enough: EnqueueSearchOutbox's ON CONFLICT (job_id) DO
+// NOTHING means created_at is stamped only on a job's FIRST enqueue since its last
+// drain, so a job re-changed while its outbox row is still pending (e.g. because
+// search-drain is paused for the reindex's whole duration) keeps its OLD created_at.
+// jobs.updated_at is stamped in the same transaction as every EnqueueSearchOutbox
+// call (cmd/ingest/store.go), so requiring it to also predate the cutoff catches a
+// job re-changed during the run even when its outbox row's created_at did not move.
+func (q *Queries) DeleteSearchOutboxCreatedBefore(ctx context.Context, before pgtype.Timestamptz) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteSearchOutboxCreatedBefore, before)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteSearchOutboxEntries = `-- name: DeleteSearchOutboxEntries :exec
 DELETE FROM search_outbox
 WHERE id = ANY($1::bigint[])

--- a/internal/db/search_outbox_integration_test.go
+++ b/internal/db/search_outbox_integration_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+// Integration test for DeleteSearchOutboxCreatedBefore: a full facet reindex reads
+// every job's CURRENT content directly from Postgres, so any search_outbox row queued
+// before the run started is provably already reflected in the freshly-built index.
+// The purge must delete only those rows and leave rows queued at or after the cutoff
+// alone — those may still represent a job changed after the reindex's scan passed it.
+// Verifiable only against real Postgres.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestDeleteSearchOutboxCreatedBefore(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	stale, err := ingestUpsert(ctx, q, ingestParams("acme:stale", "Stale"))
+	if err != nil {
+		t.Fatalf("upsert stale: %v", err)
+	}
+	atCutoff, err := ingestUpsert(ctx, q, ingestParams("acme:at-cutoff", "At Cutoff"))
+	if err != nil {
+		t.Fatalf("upsert at-cutoff: %v", err)
+	}
+	fresh, err := ingestUpsert(ctx, q, ingestParams("acme:fresh", "Fresh"))
+	if err != nil {
+		t.Fatalf("upsert fresh: %v", err)
+	}
+
+	if err := q.EnqueueSearchOutbox(ctx, stale.ID); err != nil {
+		t.Fatalf("enqueue stale: %v", err)
+	}
+	if err := q.EnqueueSearchOutbox(ctx, atCutoff.ID); err != nil {
+		t.Fatalf("enqueue at-cutoff: %v", err)
+	}
+	if err := q.EnqueueSearchOutbox(ctx, fresh.ID); err != nil {
+		t.Fatalf("enqueue fresh: %v", err)
+	}
+
+	// Pin created_at (and, for the row expected to be purged, the job's own
+	// updated_at too — the query requires both to predate the cutoff, see
+	// DeleteSearchOutboxCreatedBefore's doc comment) to controlled instants:
+	// EnqueueSearchOutbox and ingestUpsert both stamp now(), which would put every
+	// row on the same side of any cutoff.
+	before := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	cutoff := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	after := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `UPDATE search_outbox SET created_at = $1 WHERE job_id = $2`, before, stale.ID); err != nil {
+		t.Fatalf("pin stale created_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET updated_at = $1 WHERE id = $2`, before, stale.ID); err != nil {
+		t.Fatalf("pin stale job's updated_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE search_outbox SET created_at = $1 WHERE job_id = $2`, cutoff, atCutoff.ID); err != nil {
+		t.Fatalf("pin at-cutoff created_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE search_outbox SET created_at = $1 WHERE job_id = $2`, after, fresh.ID); err != nil {
+		t.Fatalf("pin fresh created_at: %v", err)
+	}
+
+	n, err := q.DeleteSearchOutboxCreatedBefore(ctx, pgtype.Timestamptz{Time: cutoff, Valid: true})
+	if err != nil {
+		t.Fatalf("DeleteSearchOutboxCreatedBefore: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("purged %d rows, want exactly 1 (the strictly-before-cutoff row)", n)
+	}
+
+	remaining := remainingOutboxJobIDs(ctx, t, pool)
+	if len(remaining) != 2 || !containsInt64(remaining, atCutoff.ID) || !containsInt64(remaining, fresh.ID) {
+		t.Fatalf("remaining outbox job_ids = %v, want exactly [%d %d]", remaining, atCutoff.ID, fresh.ID)
+	}
+	if containsInt64(remaining, stale.ID) {
+		t.Fatalf("stale job %d's outbox row survived the purge", stale.ID)
+	}
+}
+
+// TestDeleteSearchOutboxCreatedBefore_SurvivesRepeatChangeUnderConflictDoNothing covers
+// the gap EnqueueSearchOutbox's ON CONFLICT (job_id) DO NOTHING opens: created_at is
+// stamped only on a job's FIRST enqueue since its last drain, so a job re-changed while
+// its outbox row is still pending keeps the OLD created_at. If the purge trusted
+// created_at alone, a job modified again during the reindex's own scan window — after
+// the scan already read its (now stale) row — would have its still-needed outbox entry
+// deleted right along with the genuinely-redundant ones. The purge must also check the
+// job's own updated_at (stamped in the same transaction as EnqueueSearchOutbox, per
+// cmd/ingest/store.go) to catch this.
+func TestDeleteSearchOutboxCreatedBefore_SurvivesRepeatChangeUnderConflictDoNothing(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	job, err := ingestUpsert(ctx, q, ingestParams("acme:repeat-change", "Repeat Change"))
+	if err != nil {
+		t.Fatalf("upsert job: %v", err)
+	}
+	if err := q.EnqueueSearchOutbox(ctx, job.ID); err != nil {
+		t.Fatalf("enqueue job: %v", err)
+	}
+
+	firstEnqueue := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	reindexStart := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	changedDuringRun := time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `UPDATE search_outbox SET created_at = $1 WHERE job_id = $2`, firstEnqueue, job.ID); err != nil {
+		t.Fatalf("pin outbox created_at to the first enqueue: %v", err)
+	}
+	// Simulates the job changing again while its outbox row is still pending: a real
+	// second EnqueueSearchOutbox call would leave created_at untouched (ON CONFLICT DO
+	// NOTHING), which is exactly what NOT re-pinning search_outbox.created_at here
+	// reproduces — only jobs.updated_at moves.
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET updated_at = $1 WHERE id = $2`, changedDuringRun, job.ID); err != nil {
+		t.Fatalf("pin job updated_at to the repeat change: %v", err)
+	}
+
+	n, err := q.DeleteSearchOutboxCreatedBefore(ctx, pgtype.Timestamptz{Time: reindexStart, Valid: true})
+	if err != nil {
+		t.Fatalf("DeleteSearchOutboxCreatedBefore: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("purged %d rows, want 0 — the job changed again after reindexStart and still needs draining", n)
+	}
+
+	remaining := remainingOutboxJobIDs(ctx, t, pool)
+	if !containsInt64(remaining, job.ID) {
+		t.Fatalf("job %d's outbox row was purged despite a repeat change during the run", job.ID)
+	}
+}
+
+func remainingOutboxJobIDs(ctx context.Context, t *testing.T, pool *pgxpool.Pool) []int64 {
+	t.Helper()
+	rows, err := pool.Query(ctx, `SELECT job_id FROM search_outbox ORDER BY job_id`)
+	if err != nil {
+		t.Fatalf("query remaining outbox rows: %v", err)
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var jobID int64
+		if err := rows.Scan(&jobID); err != nil {
+			t.Fatalf("scan job_id: %v", err)
+		}
+		out = append(out, jobID)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return out
+}
+
+func containsInt64(xs []int64, want int64) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pipeline/board_health_test.go
+++ b/internal/pipeline/board_health_test.go
@@ -16,56 +16,63 @@ import (
 // cooldowns map is the single source of truth for both the recovery probe's candidates
 // (any board with a future cooldown) and the per-board gate, so ClearCooldowns removing a
 // provider's entries lets the subsequent crawl actually reach those boards — modelling the
-// real DB round-trip end to end.
+// real DB round-trip end to end. The key is "provider/board/region" so a board id that
+// repeats across regions (Adzuna's "it-jobs" once per country) gets independent state,
+// mirroring the real board_health table's (provider, board, region) primary key.
 type fakeHealth struct {
-	cooldowns map[string]time.Time // "provider/board" → cooldown_until
+	cooldowns map[string]time.Time // "provider/board/region" → cooldown_until
 	successes []string
 	failures  []string
 	cleared   []string // providers passed to ClearCooldowns, in call order
 }
 
-func (f *fakeHealth) Cooldown(_ context.Context, provider, board string) (time.Time, bool, error) {
-	t, ok := f.cooldowns[provider+"/"+board]
+func healthKey(provider, board, region string) string { return provider + "/" + board + "/" + region }
+
+func (f *fakeHealth) Cooldown(_ context.Context, provider, board, region string) (time.Time, bool, error) {
+	t, ok := f.cooldowns[healthKey(provider, board, region)]
 	return t, ok, nil
 }
 
-func (f *fakeHealth) RecordSuccess(_ context.Context, provider, board string, _ int) error {
-	f.successes = append(f.successes, provider+"/"+board)
+func (f *fakeHealth) RecordSuccess(_ context.Context, provider, board, region string, _ int) error {
+	f.successes = append(f.successes, healthKey(provider, board, region))
 	return nil
 }
 
-func (f *fakeHealth) RecordFailure(_ context.Context, provider, board, _ string) error {
-	f.failures = append(f.failures, provider+"/"+board)
+func (f *fakeHealth) RecordFailure(_ context.Context, provider, board, region, _ string) error {
+	f.failures = append(f.failures, healthKey(provider, board, region))
 	return nil
 }
 
-// CooledBoards serves up to limit boards of the provider whose canned cooldown is still in
-// the future, soonest-to-expire first — mirroring ListCooledBoards.
-func (f *fakeHealth) CooledBoards(_ context.Context, provider string, limit int) ([]string, error) {
+// CooledBoards serves up to limit (board, region) pairs of the provider whose canned cooldown
+// is still in the future, soonest-to-expire first — mirroring ListCooledBoards.
+func (f *fakeHealth) CooledBoards(_ context.Context, provider string, limit int) ([]CooledBoard, error) {
 	type cand struct {
-		board string
-		until time.Time
+		board, region string
+		until         time.Time
 	}
 	var cands []cand
 	for k, until := range f.cooldowns {
-		p, board, ok := strings.Cut(k, "/")
-		if !ok || p != provider || !until.After(time.Now()) {
+		parts := strings.SplitN(k, "/", 3)
+		if len(parts) != 3 || parts[0] != provider || !until.After(time.Now()) {
 			continue
 		}
-		cands = append(cands, cand{board, until})
+		cands = append(cands, cand{parts[1], parts[2], until})
 	}
 	sort.Slice(cands, func(i, j int) bool {
 		if cands[i].until.Equal(cands[j].until) {
+			if cands[i].board == cands[j].board {
+				return cands[i].region < cands[j].region
+			}
 			return cands[i].board < cands[j].board
 		}
 		return cands[i].until.Before(cands[j].until)
 	})
-	boards := make([]string, 0, limit)
+	boards := make([]CooledBoard, 0, limit)
 	for _, c := range cands {
 		if len(boards) == limit {
 			break
 		}
-		boards = append(boards, c.board)
+		boards = append(boards, CooledBoard{Board: c.board, Region: c.region})
 	}
 	return boards, nil
 }
@@ -155,7 +162,7 @@ func TestRecoverSkipsSingleBoardProvider(t *testing.T) {
 	fetches := 0
 	src := spySource{provider: "gulftalent", fetches: &fetches} // healthy, but must not be probed
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"gulftalent/": time.Now().Add(24 * time.Hour), // one boardless entry, cooled
+		"gulftalent//": time.Now().Add(24 * time.Hour), // one boardless entry, cooled
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
@@ -182,8 +189,8 @@ func TestRecoverLeavesDownMultiBoardProviderCooled(t *testing.T) {
 	fetches := 0
 	src := spySource{provider: "workday", fetches: &fetches, err: errors.New("provider down")}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"workday/a": time.Now().Add(6 * time.Hour),
-		"workday/b": time.Now().Add(6 * time.Hour),
+		"workday/a/": time.Now().Add(6 * time.Hour),
+		"workday/b/": time.Now().Add(6 * time.Hour),
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
@@ -210,8 +217,8 @@ func TestRecoverProbeRecoversProvider(t *testing.T) {
 	fetches := 0
 	src := spySource{provider: "breezy", fetches: &fetches}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"breezy/acme": time.Now().Add(24 * time.Hour),
-		"breezy/beta": time.Now().Add(24 * time.Hour),
+		"breezy/acme/": time.Now().Add(24 * time.Hour),
+		"breezy/beta/": time.Now().Add(24 * time.Hour),
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
@@ -230,6 +237,36 @@ func TestRecoverProbeRecoversProvider(t *testing.T) {
 	}
 }
 
+// A board id that repeats across independent regional slices of one provider (Adzuna's
+// "it-jobs" once per country) must not collide: probing and recovering one region's cooled
+// board must not make the main loop treat a DIFFERENT region's same-named board as already
+// handled and skip crawling it. Without region in boardKey/entriesByProvider, the probe's
+// answer for "it-jobs"/gb would satisfy handled["adzuna"/"it-jobs"] for "it-jobs"/us too, so
+// fetches would stop at 1 and us would silently go uncrawled this cycle.
+func TestRecoverProbeDoesNotCollideAcrossRegions(t *testing.T) {
+	fetches := 0
+	src := spySource{provider: "adzuna", fetches: &fetches}
+	health := &fakeHealth{cooldowns: map[string]time.Time{
+		"adzuna/it-jobs/gb": time.Now().Add(24 * time.Hour),
+		"adzuna/it-jobs/us": time.Now().Add(24 * time.Hour),
+	}}
+	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
+
+	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "Adzuna GB", Provider: "adzuna", Board: "it-jobs", Region: "gb"},
+		{Company: "Adzuna US", Provider: "adzuna", Board: "it-jobs", Region: "us"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if fetches != 2 {
+		t.Errorf("adapter fetched %d times, want 2 — gb and us are independent boards despite sharing a board id", fetches)
+	}
+	if stats.Total().Ingested != 2 || stats.Total().Cooled != 0 {
+		t.Errorf("stats = %+v, want Ingested=2 Cooled=0 (both regions recovered and crawled)", stats.Total())
+	}
+}
+
 // One genuinely-dead board among the cooled set must not mask a recovered provider: the
 // probe tries past the dead candidate to a live one, then clears. This exercises
 // maxRecoveryProbes > 1 — with a single probe (the dead board, first by cooldown order)
@@ -237,8 +274,8 @@ func TestRecoverProbeRecoversProvider(t *testing.T) {
 func TestRecoverProbeTriesPastDeadBoard(t *testing.T) {
 	src := boardKeyedSource{provider: "join", failBoards: map[string]bool{"dead": true}}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"join/dead": time.Now().Add(1 * time.Hour),  // probed first (soonest to expire)
-		"join/live": time.Now().Add(12 * time.Hour), // probed second
+		"join/dead/": time.Now().Add(1 * time.Hour),  // probed first (soonest to expire)
+		"join/live/": time.Now().Add(12 * time.Hour), // probed second
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
@@ -257,8 +294,8 @@ func TestRecoverProbeTriesPastDeadBoard(t *testing.T) {
 	if stats.Total().Ingested != 1 || stats.Total().Cooled != 0 {
 		t.Errorf("stats = %+v, want Ingested=1 Cooled=0", stats.Total())
 	}
-	if len(health.successes) != 1 || health.successes[0] != "join/live" {
-		t.Errorf("successes = %v, want [join/live]", health.successes)
+	if len(health.successes) != 1 || health.successes[0] != "join/live/" {
+		t.Errorf("successes = %v, want [join/live/]", health.successes)
 	}
 }
 
@@ -271,8 +308,8 @@ func TestRecoverProbeTriesPastDeadBoard(t *testing.T) {
 func TestRecoverProbeReusesTheAnsweringBoardsFetchInsteadOfCrawlingItTwice(t *testing.T) {
 	src := &hydratingSpySource{provider: "workday"}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"workday/acme": time.Now().Add(24 * time.Hour), // probed first (soonest to expire, tie-break by name)
-		"workday/beta": time.Now().Add(24 * time.Hour),
+		"workday/acme/": time.Now().Add(24 * time.Hour), // probed first (soonest to expire, tie-break by name)
+		"workday/beta/": time.Now().Add(24 * time.Hour),
 	}}
 	store := &fakeStore{}
 	r := Runner{Registry: registry(src), Store: store, BoardHealth: health}
@@ -325,11 +362,11 @@ func TestRunRecordsBoardOutcome(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(health.successes) != 1 || health.successes[0] != "greenhouse/good" {
-		t.Errorf("successes = %v, want [greenhouse/good]", health.successes)
+	if len(health.successes) != 1 || health.successes[0] != "greenhouse/good/" {
+		t.Errorf("successes = %v, want [greenhouse/good/]", health.successes)
 	}
-	if len(health.failures) != 1 || health.failures[0] != "lever/bad" {
-		t.Errorf("failures = %v, want [lever/bad]", health.failures)
+	if len(health.failures) != 1 || health.failures[0] != "lever/bad/" {
+		t.Errorf("failures = %v, want [lever/bad/]", health.failures)
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -92,18 +92,28 @@ type SeenLookup interface {
 type BoardHealth interface {
 	// Cooldown reports the board's cooldown_until and whether it is set. The Runner
 	// skips the board when it is set and in the future.
-	Cooldown(ctx context.Context, provider, board string) (time.Time, bool, error)
+	Cooldown(ctx context.Context, provider, board, region string) (time.Time, bool, error)
 	// RecordSuccess clears the board's failure state and stamps freshness.
-	RecordSuccess(ctx context.Context, provider, board string, ingested int) error
+	RecordSuccess(ctx context.Context, provider, board, region string, ingested int) error
 	// RecordFailure counts a failed crawl and cools the board down per the backoff policy.
-	RecordFailure(ctx context.Context, provider, board, errMsg string) error
-	// CooledBoards returns up to limit boards of the provider currently in an active
-	// cooldown — the recovery probe's candidates.
-	CooledBoards(ctx context.Context, provider string, limit int) ([]string, error)
+	RecordFailure(ctx context.Context, provider, board, region, errMsg string) error
+	// CooledBoards returns up to limit (board, region) pairs of the provider currently in
+	// an active cooldown — the recovery probe's candidates.
+	CooledBoards(ctx context.Context, provider string, limit int) ([]CooledBoard, error)
 	// ClearCooldowns clears the active cooldown of every currently-cooled board of the
 	// provider and returns how many were cleared. Called once a probe proves the provider
 	// reachable again.
 	ClearCooldowns(ctx context.Context, provider string) (int, error)
+}
+
+// CooledBoard identifies one board currently in an active cooldown. Region disambiguates a
+// board id that repeats across independent regional slices of one provider (e.g. Adzuna's
+// "it-jobs" once per country) — without it, every region's health/cooldown state would
+// collide on the same (provider, board) identity. A provider whose board is region-invariant
+// (everyone but Adzuna today) reports Region == "".
+type CooledBoard struct {
+	Board  string
+	Region string
 }
 
 // Stats reports what a run did: Ingested counts saved jobs, Failed counts boards that
@@ -203,7 +213,7 @@ func (r Runner) Run(ctx context.Context, entries []sources.CompanyEntry) (RunSta
 				return
 			}
 
-			boardStats, already := handled[boardKey{e.Provider, e.Board}]
+			boardStats, already := handled[boardKey{e.Provider, e.Board, e.Region}]
 			if !already {
 				boardStats = r.ingestBoard(ctx, e)
 			}
@@ -228,7 +238,7 @@ const maxRecoveryProbes = 3
 
 // boardKey identifies one board within a run: the pair a CompanyEntry, a Claimed
 // cooldown, and a recovery probe all key on.
-type boardKey struct{ provider, board string }
+type boardKey struct{ provider, board, region string }
 
 // recoverProviders is the provider-level circuit breaker's half-open transition. Before
 // the main crawl, for each provider with cooled boards it probes up to maxRecoveryProbes
@@ -275,7 +285,7 @@ func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyE
 		}
 		log.Printf("ingest: %s answered a recovery probe — cleared %d cooled board(s) to crawl this cycle", provider, cleared)
 		if reused {
-			handled[boardKey{e.Provider, e.Board}] = st
+			handled[boardKey{e.Provider, e.Board, e.Region}] = st
 		}
 	}
 	return handled
@@ -292,13 +302,13 @@ func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyE
 // exercise, so reused is false for it and the main loop still runs it normally. A board
 // absent from this run's entries is skipped (it cannot be probed without its entry), and
 // a cancelled run stops early. answered=false when nothing responded.
-func (r Runner) probeProvider(ctx context.Context, src sources.Source, boards []string, entries map[string]sources.CompanyEntry) (e sources.CompanyEntry, st Stats, reused, answered bool) {
+func (r Runner) probeProvider(ctx context.Context, src sources.Source, boards []CooledBoard, entries map[entryKey]sources.CompanyEntry) (e sources.CompanyEntry, st Stats, reused, answered bool) {
 	_, streaming := src.(sources.StreamingSource)
 	for _, board := range boards {
 		if ctx.Err() != nil {
 			return sources.CompanyEntry{}, Stats{}, false, false
 		}
-		candidate, ok := entries[board]
+		candidate, ok := entries[entryKey{board.Board, board.Region}]
 		if !ok {
 			continue
 		}
@@ -314,24 +324,29 @@ func (r Runner) probeProvider(ctx context.Context, src sources.Source, boards []
 	return sources.CompanyEntry{}, Stats{}, false, false
 }
 
-// entriesByProvider indexes the run's entries as provider → board → entry, so the
-// recovery probe can find the CompanyEntry for a cooled board id.
-func entriesByProvider(entries []sources.CompanyEntry) map[string]map[string]sources.CompanyEntry {
-	byProvider := make(map[string]map[string]sources.CompanyEntry)
+// entryKey is a board's identity within one provider: board alone collides when a provider's
+// board id repeats across independent regional slices (e.g. Adzuna's "it-jobs" once per
+// country), so region joins it. A region-invariant provider's entries all carry Region == "".
+type entryKey struct{ board, region string }
+
+// entriesByProvider indexes the run's entries as provider → entryKey → entry, so the
+// recovery probe can find the CompanyEntry for a cooled (board, region) pair.
+func entriesByProvider(entries []sources.CompanyEntry) map[string]map[entryKey]sources.CompanyEntry {
+	byProvider := make(map[string]map[entryKey]sources.CompanyEntry)
 	for _, e := range entries {
 		boards := byProvider[e.Provider]
 		if boards == nil {
-			boards = make(map[string]sources.CompanyEntry)
+			boards = make(map[entryKey]sources.CompanyEntry)
 			byProvider[e.Provider] = boards
 		}
-		boards[e.Board] = e
+		boards[entryKey{e.Board, e.Region}] = e
 	}
 	return byProvider
 }
 
 // sortedProviders returns the run's providers deterministically, so recovery probes (and
 // tests) are order-stable.
-func sortedProviders(byProvider map[string]map[string]sources.CompanyEntry) []string {
+func sortedProviders(byProvider map[string]map[entryKey]sources.CompanyEntry) []string {
 	providers := make([]string, 0, len(byProvider))
 	for p := range byProvider {
 		providers = append(providers, p)
@@ -541,7 +556,7 @@ func (r Runner) cooledDown(ctx context.Context, e sources.CompanyEntry) bool {
 	if r.BoardHealth == nil {
 		return false
 	}
-	until, set, err := r.BoardHealth.Cooldown(ctx, e.Provider, e.Board)
+	until, set, err := r.BoardHealth.Cooldown(ctx, e.Provider, e.Board, e.Region)
 	if err != nil {
 		log.Printf("ingest: cooldown check %s/%s: %v", e.Provider, e.Board, err)
 		return false
@@ -556,7 +571,7 @@ func (r Runner) recordSuccess(ctx context.Context, e sources.CompanyEntry, inges
 	if r.BoardHealth == nil {
 		return
 	}
-	if err := r.BoardHealth.RecordSuccess(ctx, e.Provider, e.Board, ingested); err != nil {
+	if err := r.BoardHealth.RecordSuccess(ctx, e.Provider, e.Board, e.Region, ingested); err != nil {
 		log.Printf("ingest: record board success %s/%s: %v", e.Provider, e.Board, err)
 	}
 }
@@ -565,7 +580,7 @@ func (r Runner) recordFailure(ctx context.Context, e sources.CompanyEntry, msg s
 	if r.BoardHealth == nil {
 		return
 	}
-	if err := r.BoardHealth.RecordFailure(ctx, e.Provider, e.Board, msg); err != nil {
+	if err := r.BoardHealth.RecordFailure(ctx, e.Provider, e.Board, e.Region, msg); err != nil {
 		log.Printf("ingest: record board failure %s/%s: %v", e.Provider, e.Board, err)
 	}
 }

--- a/migrations/0077_board_health_region.sql
+++ b/migrations/0077_board_health_region.sql
@@ -1,0 +1,8 @@
+-- board_health: add region so a provider whose board id repeats across independent regional
+-- slices (Adzuna: board = "it-jobs" once per country, region = the country) gets one health row
+-- per (provider, board, region) instead of every region's crawl overwriting the same row. Every
+-- other provider today is region-invariant per board (region unset or a pure host-selector, e.g.
+-- Lever's "eu"), so defaulting existing and future region-less rows to '' needs no backfill.
+ALTER TABLE board_health ADD COLUMN region text NOT NULL DEFAULT '';
+ALTER TABLE board_health DROP CONSTRAINT board_health_pkey;
+ALTER TABLE board_health ADD PRIMARY KEY (provider, board, region);

--- a/openspec/changes/reindex-search-outbox-purge/.openspec.yaml
+++ b/openspec/changes/reindex-search-outbox-purge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/reindex-search-outbox-purge/design.md
+++ b/openspec/changes/reindex-search-outbox-purge/design.md
@@ -1,0 +1,117 @@
+## Context
+
+`cmd/reindex/main.go`'s `run()` builds a `db.Queries` handle (`q := db.New(pool)`),
+optionally runs several best-effort duplicate-marker recompute passes (none of which
+touch `search_outbox` — they're raw `UPDATE jobs SET duplicate_of = ...`), then either
+rehydrates the semantic index in place or builds-and-swaps a fresh index via the
+`rebuilder` interface (`Prepare` → `Push` per batch → `Promote`). The **facet** rebuild
+(`client.NewFacetRebuild()`, selected whenever `!semantic`) is *always* a full,
+unscoped scan — `--posted-within` is rejected outright unless `--semantic` is also set
+— so every facet reindex run reads the entire `jobs` table's current state.
+
+`search_outbox` (`internal/searchdrain`) is the facet index's own incremental queue,
+independent of `semantic_outbox` (the semantic index's queue, owned by
+`internal/embed`). A full facet reindex and `cmd/search-drain` are already
+mutually-exclusive by design (`freehire-reindexw.service`'s `ExecStartPre` stops
+`freehire-search-drain.timer` for the run's duration, per
+`internal/searchdrain/AGENTS.md`), but nothing currently drains or trims the queue
+itself once the reindex it made redundant finishes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- After a successful full facet reindex, remove `search_outbox` rows that are
+  provably redundant — their job's content is already in the newly-swapped live index.
+- Never remove a row that might still represent real, un-pushed work.
+
+**Non-Goals:**
+- Not touching `semantic_outbox` or the semantic reindex path — that queue and index
+  are unrelated to this one.
+- Not changing `cmd/search-drain`'s own claim/complete/fail logic — the purge is purely
+  additive cleanup from the reindex side.
+- Not attempting to purge mid-run (e.g., as each batch is scanned) — a single purge
+  after `Promote()` succeeds is simpler and the staleness window it leaves (rows queued
+  during the run, kept until next cycle) is harmless.
+
+## Decisions
+
+**1. Capture the start timestamp at the very top of `run()`, before anything else**
+The safety argument: any `search_outbox` row with `created_at < startedAt` was queued
+before this run began, and the reindex's keyset scan reads each job's row at-or-after
+`startedAt` — so whatever caused that row to be queued is necessarily already reflected
+in the content the scan read. Capturing the timestamp as early as possible (before the
+disk guard and the duplicate-marker recompute passes, which can themselves take
+significant wall-clock time under load) is *more* conservative than capturing it right
+before the scan starts — it only means a slightly smaller set of rows qualifies for
+purge this cycle, never an unsafe one. Simplicity favored the earliest sensible point
+over shaving that margin.
+
+**1a. `created_at` alone is not sufficient — also require `jobs.updated_at < startedAt`
+(found in code review, before merge)**
+The first-pass argument above has a gap: `EnqueueSearchOutbox`'s `ON CONFLICT (job_id)
+DO NOTHING` stamps `created_at` only on a job's FIRST enqueue since its last drain. A
+job whose outbox row is already pending (very plausible — search-drain is paused for
+the reindex's whole duration, and the backlog runs 90-113k deep in production) and
+that changes AGAIN during the reindex's own scan window keeps its OLD `created_at`,
+even though the reindex's keyset scan (ordered by `id`, not by modification recency)
+may have already read that job's row before the second change landed. Purging on
+`created_at` alone would then delete a genuinely-still-needed entry. `jobs.updated_at`
+is stamped in the same transaction as every `EnqueueSearchOutbox` call
+(`cmd/ingest/store.go`) and is already the trusted "last real change" signal elsewhere
+in this codebase (`ListJobsUpdatedAfter`, `reindex --since`), so the purge query now
+requires BOTH `search_outbox.created_at < startedAt` AND the row's `jobs.updated_at <
+startedAt` — closing the gap without needing to touch `EnqueueSearchOutbox` itself.
+Covered by
+`TestDeleteSearchOutboxCreatedBefore_SurvivesRepeatChangeUnderConflictDoNothing`.
+
+**2. Purge only on the facet rebuild path, gated on `!semantic`**
+`search_outbox` has no relationship to the semantic index or its `--posted-within`
+scoping. Gating on the same `!semantic` boolean `run()` already branches on (the only
+condition under which `search_outbox` is even semantically relevant) avoids adding a
+new flag or config knob.
+
+**3. Delete, not soft-mark**
+`search_outbox` rows have no "already covered by a reindex" state to set — the
+existing `DeleteSearchOutboxEntries` query already deletes rows by id after a
+successful drain, so a bulk `DELETE ... WHERE created_at < $1` is the same operation
+at a coarser grain, not a new pattern.
+
+**4. Best-effort, not fatal**
+Mirrors the file's existing style for the duplicate-marker recompute passes (log and
+continue rather than fail the run) — but for a different reason: those passes run
+*before* the expensive scan/swap and a failure there risks stale markers, while this
+purge runs *after* the reindex has already fully succeeded, so a purge failure has
+already-safe fallback: the rows just survive one more (harmless) search-drain cycle
+before the next reindex tries again.
+
+## Risks / Trade-offs
+
+- **[Risk] Off-by-window race if `created_at` and the reindex's read happen in the same
+  instant** → **Mitigation**: none needed — Postgres timestamps have microsecond
+  resolution and `time.Now()` is captured in Go before any Postgres round-trip in this
+  run, so `startedAt` is provably earlier than the first row the scan reads. Even a
+  tied timestamp errs toward NOT purging (strict `<`), which is the safe direction.
+- **[Risk] The purge query itself becomes another expensive full-table-ish scan under
+  host load** → **Mitigation**: `search_outbox` is a queue table, not the `jobs` table
+  — its total row count is the pending backlog (tens of thousands, not millions), and
+  `created_at` should use its default/insertion order, so a `WHERE created_at < $1`
+  delete is cheap relative to the reindex's own multi-minute precompute passes it
+  follows. Not adding an index for this — reassess only if it's measured as a cost.
+
+## Migration Plan
+
+1. Add the sqlc query, regenerate, wire the call into `cmd/reindex/main.go`.
+2. Ship as a normal code deploy — no data migration, no reindex required for this fix
+   itself (unlike the `proximityPrecision` settings change, this doesn't touch
+   Meilisearch index settings at all).
+3. Verify: after the next full facet reindex completes on prod, check
+   `search_outbox`'s row count and oldest `created_at` before vs. after — the backlog
+   predating that reindex run should be gone, and the log line
+   (`reindex: purged N stale search_outbox entries...`) should report a count.
+4. **Rollback**: revert the purge call (or the whole commit) and redeploy — no data
+   loss risk, since a missed purge only means the (harmless, if wasteful) redundant
+   entries stay in the queue.
+
+## Open Questions
+
+None.

--- a/openspec/changes/reindex-search-outbox-purge/proposal.md
+++ b/openspec/changes/reindex-search-outbox-purge/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+`cmd/reindex`'s full facet rebuild never touches `search_outbox`, even though it makes
+that queue's pending entries provably stale in bulk. A full reindex reads every job's
+CURRENT content straight from Postgres and swaps in a brand-new live index — so any
+`search_outbox` row queued *before* that run started is redundant the instant the swap
+succeeds: the job's current content is already in the freshly-built index.
+`cmd/search-drain` doesn't know this and will re-push that same content again for no
+reason, burning the queue's (expensive — see the already-merged `proximityPrecision`
+fix, PR #1637) capacity on pure duplicate work. Discovered operationally: `search_outbox`
+was observed backlogged to ~90-113k pending entries in production even while
+search-drain ran continuously and error-free.
+
+## What Changes
+
+- `cmd/reindex` captures the run's start time before it does anything else.
+- After a **full, unscoped facet rebuild** (`cmd/reindex`'s default target — the only
+  path search_outbox is even relevant to; the semantic index has its own separate
+  `semantic_outbox`) successfully swaps in (`Promote()` returns without error), delete
+  every `search_outbox` row whose `created_at` **and** its job's `jobs.updated_at` are
+  both strictly before that captured start time (see design.md Decision 1a for why
+  `created_at` alone isn't enough — `ON CONFLICT DO NOTHING` can leave it stale).
+- Rows queued **during** the run are left untouched — some represent a job that changed
+  again after the reindex's scan already passed its row, so a future search-drain run
+  still needs them to catch up.
+- A best-effort step: a failure to purge logs and does not fail the reindex run (the
+  reindex itself already succeeded; a missed purge just means those rows survive one
+  extra, harmless cycle).
+- New sqlc query `DeleteSearchOutboxCreatedBefore` in
+  `internal/db/queries/search_outbox.sql` (no migration — `search_outbox.created_at`
+  already exists).
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+(none — this is an internal efficiency fix to the reindex worker's own pipeline, not a
+change to any capability's request/response contract or observable behavior other than
+a smaller queue backlog.)
+
+## Impact
+
+- `internal/db/queries/search_outbox.sql` + regenerated `internal/db` (`make sqlc`).
+- `cmd/reindex/main.go` — `run()` captures a start timestamp; the facet-swap branch
+  calls the new purge query after a successful `Promote()`.
+- `cmd/search-drain` (internal/searchdrain) — sees a smaller backlog after every full
+  reindex (currently every 3h on prod's normal schedule) at no cost to it; no code
+  changes needed there.
+- No schema, API, or migration changes.

--- a/openspec/changes/reindex-search-outbox-purge/tasks.md
+++ b/openspec/changes/reindex-search-outbox-purge/tasks.md
@@ -1,0 +1,59 @@
+## 1. Add the purge query
+
+- [x] 1.1 Add a failing integration test `internal/db/search_outbox_integration_test.go`
+      (`//go:build integration`, testcontainers, mirrors
+      `internal/db/jobs_reindex_integration_test.go`'s style) for
+      `DeleteSearchOutboxCreatedBefore`: seed rows with `created_at` before and at/after
+      a cutoff timestamp, call the query, assert only the before-cutoff rows are gone
+      and the at/after ones survive.
+      `search_outbox.created_at DEFAULT now()` — backdated via a plain
+      `UPDATE search_outbox SET created_at = $1 WHERE job_id = $2` after
+      `EnqueueSearchOutbox`, same pattern `jobs_reindex_integration_test.go` uses for
+      `jobs.updated_at`.
+- [x] 1.2 Add `DeleteSearchOutboxCreatedBefore` (`:execrows`) to
+      `internal/db/queries/search_outbox.sql`: `DELETE FROM search_outbox WHERE
+      created_at < sqlc.arg(before)`. Run `make sqlc` to regenerate `internal/db`.
+      Confirm the test from 1.1 passes.
+      `docker run sqlc/sqlc` timed out pulling the image; used the pinned local
+      `sqlc v1.31.1` binary instead (`$(go env GOPATH)/bin/sqlc generate`), matching
+      the version header already in the generated files.
+
+## 2. Wire the purge into cmd/reindex
+
+- [x] 2.1 In `cmd/reindex/main.go`'s `run()`, capture `startedAt := time.Now()` at the
+      very top (before the disk guard and duplicate-marker recompute passes — see
+      design.md Decision 1 for why earliest-is-safest).
+- [x] 2.2 After the facet-swap branch's `reindexFull(...)` call returns successfully
+      (guarded on `!semantic` — search_outbox has no relationship to the semantic
+      index), call `q.DeleteSearchOutboxCreatedBefore(ctx, startedAt)`. Best-effort:
+      log and continue on error (mirrors the file's existing style for the
+      duplicate-marker passes), log the count when `n > 0`.
+- [x] 2.3 Considered a dedicated test for the `!semantic` purge gate and skipped it:
+      the gate is a one-line conditional identical in shape to the untested `if
+      semantic { b = client.NewSemanticRebuild() }` two lines above it in the same
+      function — `run()` is not structured for unit testing without a refactor this
+      change has no other reason to make, and the query's actual behavior (the part
+      that can be silently wrong) is already covered by the real-Postgres integration
+      test in 1.1. Verified by reading, not a new test.
+
+## 2a. Code review fix
+
+- [x] 2a.1 Code review (dispatched subagent) found the purge's safety argument broke
+      under `EnqueueSearchOutbox`'s `ON CONFLICT (job_id) DO NOTHING`: a job re-changed
+      while its outbox row was still pending keeps its OLD `created_at`, so a purge on
+      `created_at` alone could delete a row that still represents real, un-pushed work.
+      Reproduced with a new RED test
+      (`TestDeleteSearchOutboxCreatedBefore_SurvivesRepeatChangeUnderConflictDoNothing`),
+      fixed by also requiring `jobs.updated_at < before` in the query (GREEN), and
+      updated the original `TestDeleteSearchOutboxCreatedBefore` to pin the purged row's
+      `jobs.updated_at` too (it was relying on the now-closed gap without realizing it).
+      design.md Decision 1a documents the gap and fix.
+
+## 3. Verify
+
+- [x] 3.1 `go build ./... && go vet ./...`
+- [x] 3.2 `go test ./...`
+- [x] 3.3 `go vet -tags=integration ./...`
+- [x] 3.4 If Docker is available, `go test -tags=integration ./internal/db/... ./cmd/reindex/...`
+      All green, including the new `TestDeleteSearchOutboxCreatedBefore` and the
+      existing `cmd/reindex` integration suite (`TestReindexFull_*`).


### PR DESCRIPTION
## Summary

- A full facet reindex reads every job's current content directly from Postgres and swaps in a brand-new live index, so any `search_outbox` row queued **before** that run started is redundant the instant the swap succeeds — `cmd/search-drain` would otherwise re-push that same content again for no reason, burning the queue's (expensive — see the already-merged `proximityPrecision` fix, #1637) capacity on pure duplicate work. Discovered operationally: `search_outbox` was observed backlogged to ~90-113k pending entries in production even while search-drain ran continuously and error-free.
- `cmd/reindex` now captures its start time before doing anything else, and after a successful **full, unscoped facet rebuild** (the only path `search_outbox` is relevant to — the semantic index has its own separate `semantic_outbox`), deletes every `search_outbox` row that's provably redundant.
- **Found in code review and fixed before this PR**: `created_at` alone isn't a safe cutoff. `EnqueueSearchOutbox`'s `ON CONFLICT (job_id) DO NOTHING` means a job re-changed while its outbox row is still pending (very plausible — search-drain is paused for the reindex's whole duration) keeps its OLD `created_at`, even though the reindex's `id`-ordered scan may have already read that job's row before the second change landed. The purge now also requires the job's own `jobs.updated_at` to predate the run's start — closing the gap without touching `EnqueueSearchOutbox`. Covered by a regression test (`TestDeleteSearchOutboxCreatedBefore_SurvivesRepeatChangeUnderConflictDoNothing`).
- New sqlc query `DeleteSearchOutboxCreatedBefore`, no migration (`search_outbox.created_at` and `jobs.updated_at` both already exist).
- OpenSpec change at `openspec/changes/reindex-search-outbox-purge/` documents the full investigation, the review-driven fix, and the migration/rollback plan.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test -tags=integration ./internal/db/... ./cmd/reindex/...` (real Postgres via testcontainers) — includes the new query's happy path and the `ON CONFLICT DO NOTHING` regression test
- [ ] After merge + deploy: watch `search_outbox`'s row count and oldest `created_at` across the next full prod reindex — the pre-reindex backlog should drop, and the `reindex: purged N stale search_outbox entries...` log line should report a count