### PR TITLE
feat(sources): add EchoJobs description backfill for pre-hydration rows

### DIFF
--- a/cmd/backfill-echojobs/main.go
+++ b/cmd/backfill-echojobs/main.go
@@ -1,0 +1,124 @@
+// Command backfill-echojobs fills the description of echojobs jobs ingested before per-posting
+// detail hydration existed. The echojobs adapter originally read only the list endpoint, which
+// omits the posting body entirely, so those rows were stored with an empty description (a blank,
+// broken job page — reported live on freehire.me). This one-off worker pages every
+// source='echojobs' row, re-fetches the posting's detail (GET /api/jobs/{job_handle}) via the
+// shared HTTP client, and rewrites the description plus a refreshed content_hash so the row
+// re-indexes. Follow it with `make reindex` (and cmd/backfill-derive to re-derive skills/facets
+// from the new descriptions).
+//
+// echojobs is boardless, so its stored external_id carries the empty-board namespace prefix
+// (NamespaceExternalID("", jobHandle) == ":jobHandle") — jobHandle strips that colon before
+// calling the detail endpoint, which is keyed by the raw handle.
+//
+// It pages by keyset and exits. Idempotent: a row whose stored description already equals the
+// fetched one is skipped, so a second run (e.g. after a rate-limit interruption) rewrites only
+// what a prior run missed. A single posting whose detail fetch fails is counted and skipped,
+// never aborting the run.
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobhash"
+	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+// backfillBatchSize bounds how many rows are read per keyset page.
+const backfillBatchSize = 500
+
+// jobStore is the slice of the data layer the backfill needs: page one provider's rows by keyset
+// and rewrite a row's description + content_hash. *db.Queries satisfies it; the test uses a fake.
+type jobStore interface {
+	ListJobsBySourceAfter(ctx context.Context, arg db.ListJobsBySourceAfterParams) ([]db.Job, error)
+	UpdateJobDescription(ctx context.Context, arg db.UpdateJobDescriptionParams) (int64, error)
+}
+
+// descriptionFetcher fetches the sanitized description for a stored job's job_handle, returning
+// ok=false when the detail is unavailable (failed request or empty body).
+type descriptionFetcher func(ctx context.Context, jobHandle string) (string, bool)
+
+func main() {
+	worker.Main(run)
+}
+
+func run() int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	client := sources.NewClient()
+	fetch := func(ctx context.Context, jobHandle string) (string, bool) {
+		return sources.EchoJobsDescription(ctx, client, jobHandle)
+	}
+
+	scanned, updated, failed, err := backfillAll(ctx, db.New(pool), fetch)
+	if err != nil {
+		log.Printf("backfill-echojobs: %v", err)
+		return 1
+	}
+	log.Printf("backfill-echojobs done: scanned=%d updated=%d failed=%d", scanned, updated, failed)
+	return 0
+}
+
+// jobHandle strips echojobs' empty-board namespace prefix from a stored external_id, recovering
+// the raw job_handle the detail endpoint is keyed by.
+func jobHandle(externalID string) string {
+	return strings.TrimPrefix(externalID, ":")
+}
+
+// backfillAll pages every echojobs row and rewrites the description of rows whose fetched detail
+// body differs from what is stored. It pages by keyset (id > last seen) so concurrent writes
+// cannot skip or repeat rows. A row whose detail fetch fails is counted (failed) and skipped.
+func backfillAll(ctx context.Context, store jobStore, fetch descriptionFetcher) (scanned, updated, failed int, err error) {
+	var afterID int64
+	for {
+		jobs, err := store.ListJobsBySourceAfter(ctx, db.ListJobsBySourceAfterParams{
+			Source:    "echojobs",
+			AfterID:   afterID,
+			BatchSize: backfillBatchSize,
+		})
+		if err != nil {
+			return scanned, updated, failed, err
+		}
+		if len(jobs) == 0 {
+			break
+		}
+		afterID = jobs[len(jobs)-1].ID
+
+		for _, j := range jobs {
+			scanned++
+			desc, ok := fetch(ctx, jobHandle(j.ExternalID))
+			if !ok {
+				failed++
+				continue
+			}
+			if desc == j.Description {
+				continue // already current — idempotent skip
+			}
+			hash := jobhash.OfRow(j, desc)
+			if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
+				ID:          j.ID,
+				Description: desc,
+				ContentHash: pgtype.Text{String: hash, Valid: true},
+			}); err != nil {
+				return scanned, updated, failed, err
+			}
+			updated++
+		}
+
+		if len(jobs) < backfillBatchSize {
+			break
+		}
+	}
+	return scanned, updated, failed, nil
+}

--- a/cmd/backfill-echojobs/main_test.go
+++ b/cmd/backfill-echojobs/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobhash"
+)
+
+// fakeStore serves one keyset page of echojobs rows and records every description update.
+type fakeStore struct {
+	jobs    []db.Job
+	updates []db.UpdateJobDescriptionParams
+	served  bool
+}
+
+func (f *fakeStore) ListJobsBySourceAfter(_ context.Context, _ db.ListJobsBySourceAfterParams) ([]db.Job, error) {
+	if f.served {
+		return nil, nil
+	}
+	f.served = true
+	return f.jobs, nil
+}
+
+func (f *fakeStore) UpdateJobDescription(_ context.Context, arg db.UpdateJobDescriptionParams) (int64, error) {
+	f.updates = append(f.updates, arg)
+	return 1, nil
+}
+
+func TestBackfillUpdatesOnlyChangedDescriptions(t *testing.T) {
+	// echojobs is boardless, so its stored external_id carries the empty-board namespace
+	// prefix (":job-handle") — jobHandle strips it before the fetch keys on the raw handle.
+	store := &fakeStore{jobs: []db.Job{
+		{ID: 1, Source: "echojobs", ExternalID: ":a", Title: "A", Description: ""},
+		{ID: 2, Source: "echojobs", ExternalID: ":b", Title: "B", Description: "same"},
+		{ID: 3, Source: "echojobs", ExternalID: ":c", Title: "C", Description: ""},
+	}}
+	fetch := func(_ context.Context, jobHandle string) (string, bool) {
+		switch jobHandle {
+		case "a":
+			return "New body A", true // empty → gets filled
+		case "b":
+			return "same", true // unchanged → skipped
+		default:
+			return "", false // detail failed → counted, skipped
+		}
+	}
+
+	scanned, updated, failed, err := backfillAll(context.Background(), store, fetch)
+	if err != nil {
+		t.Fatalf("backfillAll: %v", err)
+	}
+	if scanned != 3 || updated != 1 || failed != 1 {
+		t.Fatalf("scanned=%d updated=%d failed=%d, want 3/1/1", scanned, updated, failed)
+	}
+	if len(store.updates) != 1 || store.updates[0].ID != 1 {
+		t.Fatalf("updates = %+v, want one update of job 1", store.updates)
+	}
+	u := store.updates[0]
+	if u.Description != "New body A" {
+		t.Errorf("Description = %q, want %q", u.Description, "New body A")
+	}
+	want := jobhash.OfRow(store.jobs[0], "New body A")
+	if !u.ContentHash.Valid || u.ContentHash.String != want {
+		t.Errorf("ContentHash = %+v, want %q", u.ContentHash, want)
+	}
+}
+
+func TestJobHandleStripsNamespacePrefix(t *testing.T) {
+	if got := jobHandle(":acme-swe-abc12"); got != "acme-swe-abc12" {
+		t.Errorf("jobHandle(%q) = %q, want %q", ":acme-swe-abc12", got, "acme-swe-abc12")
+	}
+}

--- a/internal/sources/echojobs.go
+++ b/internal/sources/echojobs.go
@@ -59,14 +59,16 @@ func (echojobs) aggregator() {}
 func (echojobs) sweepGrace() time.Duration { return echojobsSweepGrace }
 
 // echojobsPosting is one posting from the /api/jobs list. The upstream response carries several
-// more fields (domain_name, first_seen_at, countries, states, job_function, role, seniority,
+// more fields (id, domain_name, first_seen_at, countries, states, job_function, role, seniority,
 // salary_min_usd/salary_max_usd, employment_type, employee_count, funding) that this adapter
-// deliberately does not read: none of them has a home in the Job shape today, and guessing one
-// (e.g. folding salary into Description) is not this adapter's call to make. Notably absent from
-// this list: description — the list endpoint omits the body entirely (verified live), which is
-// why FetchNew hydrates it from the per-posting detail endpoint (see echojobsDetail).
+// deliberately does not read: id is redundant (the detail endpoint accepts job_handle just as
+// well — verified live — so ExternalID doubles as the detail key without storing a second
+// identifier nothing else needs), and none of the rest has a home in the Job shape today, and
+// guessing one (e.g. folding salary into Description) is not this adapter's call to make.
+// Notably absent from this list: description — the list endpoint omits the body entirely
+// (verified live), which is why FetchNew hydrates it from the per-posting detail endpoint (see
+// echojobsDetail).
 type echojobsPosting struct {
-	ID             string   `json:"id"`
 	Title          string   `json:"title"`
 	CompanyName    string   `json:"company_name"`
 	URL            string   `json:"url"`
@@ -110,9 +112,9 @@ func (e echojobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(extern
 			base.SeenRefresh = true
 			return base, true
 		}
-		d, ok := e.detail(ctx, p.ID)
+		d, ok := e.detail(ctx, p.JobHandle)
 		if !ok {
-			log.Printf("echojobs: detail %q failed; ingesting list-only", p.ID)
+			log.Printf("echojobs: detail %q failed; ingesting list-only", p.JobHandle)
 			return base, true
 		}
 		return d.apply(base), true
@@ -159,23 +161,23 @@ func echojobsPageURL(page int) string {
 	return fmt.Sprintf("%s?page=%d&per_page=%d", echojobsBaseURL, page, echojobsPageSize)
 }
 
-// echojobsDetailURL is the per-posting detail endpoint. It is keyed by the feed's internal id,
-// NOT job_handle (echojobs' own slug, which is what ExternalID carries) — the two are unrelated
-// identifiers on the same posting.
+// echojobsDetailURL is the per-posting detail endpoint. It accepts either the feed's internal id
+// or job_handle (echojobs' own slug) interchangeably — verified live — so this adapter always
+// passes job_handle, the identifier it already carries as ExternalID.
 const echojobsDetailURL = echojobsBaseURL + "/%s"
 
-// echojobsDetail is the per-posting detail payload (GET /api/jobs/{id}). Only Description is
-// read; the detail response also repeats several list fields plus salary/education/yoe ones this
-// adapter does not map, for the same reason echojobsPosting's doc gives.
+// echojobsDetail is the per-posting detail payload (GET /api/jobs/{job_handle}). Only Description
+// is read; the detail response also repeats several list fields plus salary/education/yoe ones
+// this adapter does not map, for the same reason echojobsPosting's doc gives.
 type echojobsDetail struct {
 	Description string `json:"description"`
 }
 
-// detail fetches a posting's detail, returning ok=false on a failed request so the caller falls
-// back to the list-only job — a posting is never dropped over a missing detail.
-func (e echojobs) detail(ctx context.Context, id string) (echojobsDetail, bool) {
+// detail fetches a posting's detail by job_handle, returning ok=false on a failed request so the
+// caller falls back to the list-only job — a posting is never dropped over a missing detail.
+func (e echojobs) detail(ctx context.Context, jobHandle string) (echojobsDetail, bool) {
 	var d echojobsDetail
-	if err := e.http.GetJSON(ctx, fmt.Sprintf(echojobsDetailURL, id), &d); err != nil {
+	if err := e.http.GetJSON(ctx, fmt.Sprintf(echojobsDetailURL, jobHandle), &d); err != nil {
 		return echojobsDetail{}, false
 	}
 	return d, true
@@ -185,6 +187,24 @@ func (e echojobs) detail(ctx context.Context, id string) (echojobsDetail, bool) 
 func (d echojobsDetail) apply(base Job) Job {
 	base.Description = sanitizeHTML(d.Description)
 	return base
+}
+
+// EchoJobsDescription fetches the sanitized description for a stored echojobs job by its
+// job_handle (ExternalID) — the stored URL cannot be used for this the way JustJoinDescription
+// uses justjoin's, because echojobs' URL is the upstream ATS link, not an echojobs.io one. It
+// exists for a backfill worker filling the description of rows ingested before detail hydration
+// existed; the crawl path uses (echojobs).detail directly. Returns ok=false when the detail
+// request fails or the posting has no body.
+func EchoJobsDescription(ctx context.Context, c JSONGetter, jobHandle string) (string, bool) {
+	d, ok := echojobs{http: c}.detail(ctx, jobHandle)
+	if !ok {
+		return "", false
+	}
+	body := sanitizeHTML(d.Description)
+	if body == "" {
+		return "", false
+	}
+	return body, true
 }
 
 func (p echojobsPosting) toJob(postedAt *time.Time) Job {

--- a/internal/sources/echojobs_test.go
+++ b/internal/sources/echojobs_test.go
@@ -62,16 +62,12 @@ func echojobsPageJSON(jobs string) string {
 }
 
 func echojobsJobJSON(handle, postedAt string) string {
-	return echojobsJobJSONWithID(handle, handle, postedAt)
-}
-
-func echojobsJobJSONWithID(id, handle, postedAt string) string {
 	return fmt.Sprintf(`{
-		"id":%q,"title":"Backend Engineer","company_name":"Acme","domain_name":"acme.com",
+		"title":"Backend Engineer","company_name":"Acme","domain_name":"acme.com",
 		"url":"https://boards.greenhouse.io/acme/jobs/123","job_handle":%q,
 		"posted_at":%s,"locations":["California","New York"],"remote_type":"hybrid",
 		"required_skills":["Go","NotARealSkill"]
-	}`, id, handle, postedAt)
+	}`, handle, postedAt)
 }
 
 func TestEchojobsFetchMapsFields(t *testing.T) {
@@ -172,8 +168,8 @@ func TestEchojobsFetchNewHydratesUnseenPosting(t *testing.T) {
 	now := time.Now().UTC()
 	fresh := strconv.FormatInt(now.UnixMilli(), 10)
 	http := &echojobsHTTP{
-		pages:   []string{echojobsPageJSON(echojobsJobJSONWithID("det1", "acme-swe", fresh)), echojobsPageJSON("")},
-		details: map[string]string{"det1": `{"description":"<p>Great role.</p>"}`},
+		pages:   []string{echojobsPageJSON(echojobsJobJSON("acme-swe", fresh)), echojobsPageJSON("")},
+		details: map[string]string{"acme-swe": `{"description":"<p>Great role.</p>"}`},
 	}
 
 	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
@@ -186,8 +182,8 @@ func TestEchojobsFetchNewHydratesUnseenPosting(t *testing.T) {
 	if jobs[0].Description != "<p>Great role.</p>" {
 		t.Fatalf("Description not hydrated: %q", jobs[0].Description)
 	}
-	if !slices.Equal(http.gotDetails, []string{"det1"}) {
-		t.Fatalf("detail requests = %v, want [det1]", http.gotDetails)
+	if !slices.Equal(http.gotDetails, []string{"acme-swe"}) {
+		t.Fatalf("detail requests = %v, want [acme-swe]", http.gotDetails)
 	}
 }
 
@@ -198,7 +194,7 @@ func TestEchojobsFetchNewSkipsDetailForSeenPosting(t *testing.T) {
 	now := time.Now().UTC()
 	fresh := strconv.FormatInt(now.UnixMilli(), 10)
 	http := &echojobsHTTP{
-		pages: []string{echojobsPageJSON(echojobsJobJSONWithID("det1", "acme-swe", fresh)), echojobsPageJSON("")},
+		pages: []string{echojobsPageJSON(echojobsJobJSON("acme-swe", fresh)), echojobsPageJSON("")},
 	}
 
 	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(externalID string) bool {
@@ -220,8 +216,8 @@ func TestEchojobsFetchNewDetailFailureKeepsPosting(t *testing.T) {
 	now := time.Now().UTC()
 	fresh := strconv.FormatInt(now.UnixMilli(), 10)
 	http := &echojobsHTTP{
-		pages:     []string{echojobsPageJSON(echojobsJobJSONWithID("det1", "acme-swe", fresh)), echojobsPageJSON("")},
-		detailErr: map[string]bool{"det1": true},
+		pages:     []string{echojobsPageJSON(echojobsJobJSON("acme-swe", fresh)), echojobsPageJSON("")},
+		detailErr: map[string]bool{"acme-swe": true},
 	}
 
 	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })


### PR DESCRIPTION
## Summary
- Follow-up to #1645 (description hydration): rows ingested *before* that fix landed still carry an empty description on prod.
- `cmd/backfill-echojobs` mirrors `cmd/backfill-justjoin`: pages every `source='echojobs'` row and re-fetches its detail keyed by `job_handle` (recovered from the stored `external_id`, stripping echojobs' empty-board namespace prefix `:`), rewriting `description` + `content_hash`.
- Simplifies `internal/sources/echojobs.go`'s detail lookup along the way: verified live that the detail endpoint accepts `job_handle` interchangeably with the feed's internal `id`, so the `id` field is dropped — `ExternalID` now doubles as the detail key. This is also what makes a backfill possible without a URL-derived key: echojobs' stored `URL` is the upstream ATS link, not a slug the backfill could parse a lookup key from (unlike justjoin's own-hosted URL).

## Test plan
- [x] Updated `echojobs_test.go` for the id→job_handle simplification (still RED→GREEN discipline: reused/adjusted the existing FetchNew tests).
- [x] New `cmd/backfill-echojobs/main_test.go` (mirrors `backfill-justjoin`'s test exactly): only changed descriptions get written, a failed fetch is counted and skipped, and a dedicated test for the namespace-prefix strip.
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`

## Rollout
Run `backfill-echojobs` on prod after this merges + deploys, then `make reindex` (+ `cmd/backfill-derive`) to pick up the newly-filled descriptions in search/derived facets.