### PR TITLE
feat(sources): onboard 336 more ATS boards from the Himalayas orphan-company harvest

### DIFF
--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -18703,3 +18703,169 @@
   board: oddingg
 - company: Intercept
   board: intercept
+- company: 360 Direct Access
+  board: 360directaccess
+- company: Adastra
+  board: adastra
+- company: another
+  board: another
+- company: Asymchem
+  board: asymchem
+- company: Attivo Investments
+  board: attivoinvestments
+- company: AWL, Inc.
+  board: awl
+- company: Bizee
+  board: bizee
+- company: Bridge33 Capital
+  board: bridge33capital
+- company: Broadnet
+  board: broadnet
+- company: BSV Association
+  board: bsvassociation
+- company: California Closets
+  board: californiaclosets
+- company: CDMS
+  board: cdms
+- company: Chalmers Center
+  board: chalmerscenter
+- company: Cloud Range
+  board: cloudrange
+- company: CMG
+  board: cmg
+- company: Collectors
+  board: collectors
+- company: Contáctica
+  board: contactica
+- company: Cuso International
+  board: cusointernational
+- company: Deploy
+  board: deploy
+- company: DigitalFish, Inc
+  board: digitalfish
+- company: DVT
+  board: dvt
+- company: Eleos
+  board: eleos
+- company: Endavant
+  board: endavant
+- company: EnterpriseAlumni
+  board: enterprisealumni
+- company: Eventbase
+  board: eventbase
+- company: Fin-X
+  board: finx
+- company: Forj
+  board: forj
+- company: Forterra
+  board: forterra
+- company: Freebird
+  board: freebird
+- company: Frima Studio
+  board: frimastudio
+- company: FXGT
+  board: fxgt
+- company: Hands Up Communications
+  board: handsupcommunications
+- company: Healthy Learners
+  board: healthylearners
+- company: Helpware
+  board: helpware
+- company: Inner Circle
+  board: innercircle
+- company: Innovative Solutions
+  board: innovativesolutions
+- company: Innovior
+  board: innovior
+- company: Inspire Direct Marketing
+  board: inspiredirectmarketing
+- company: Invicti
+  board: invicti
+- company: Kosmos Corp
+  board: kosmos
+- company: LandTech
+  board: landtech
+- company: LingoAid
+  board: lingoaid
+- company: Lucky 21
+  board: lucky21
+- company: Mango Languages
+  board: mangolanguages
+- company: MCS
+  board: mcs
+- company: Morningside Group
+  board: morningsidegroup
+- company: NCH Corporation
+  board: nch
+- company: NetFoundry
+  board: netfoundry
+- company: NextGen America
+  board: nextgenamerica
+- company: NirYu
+  board: niryu
+- company: Ntara
+  board: ntara
+- company: NTT Limited
+  board: ntt
+- company: ObserveAI
+  board: observeai
+- company: Payforge
+  board: payforge
+- company: Praying Pelican Missions
+  board: prayingpelicanmissions
+- company: ProCircular
+  board: procircular
+- company: Promethean
+  board: promethean
+- company: Propane
+  board: propane
+- company: Public Sector Network
+  board: publicsectornetwork
+- company: QWERTY
+  board: qwerty
+- company: Sabre Corporation
+  board: sabre
+- company: Safeguard Global
+  board: safeguardglobal
+- company: SafePaaS
+  board: safepaas
+- company: SalesRabbit
+  board: salesrabbit
+- company: SDG Group
+  board: sdggroup
+- company: SD Worx
+  board: sdworx
+- company: Seer Interactive
+  board: seerinteractive
+- company: Shorthand
+  board: shorthand
+- company: Skift
+  board: skift
+- company: Smart WFM
+  board: smartwfm
+- company: Squiz
+  board: squiz
+- company: Stanford Health Care
+  board: stanfordhealthcare
+- company: TradeQuo
+  board: tradequo
+- company: Trax
+  board: trax
+- company: Trellis
+  board: trellis
+- company: Trinetix
+  board: trinetix
+- company: US Cloud
+  board: uscloud
+- company: Valeo Foods
+  board: valeofoods
+- company: Ventures Unlimited Inc
+  board: venturesunlimited
+- company: Vivo Gaming
+  board: vivogaming
+- company: WaterFurnace
+  board: waterfurnace
+- company: West Africa Blue
+  board: westafricablue
+- company: WMC
+  board: wmc

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -3839,3 +3839,43 @@
   board: wrstbnd
 - company: YiYiEnglish
   board: yiyienglish
+- company: Bederr
+  board: bederr
+- company: BlockchainSpace
+  board: blockchainspace
+- company: Camber Creative
+  board: camber-creative
+- company: Clovyr
+  board: clovyr
+- company: Cognizo
+  board: cognizo
+- company: ConsumerVoice
+  board: consumervoice
+- company: DeGate
+  board: degate
+- company: Dotsub
+  board: dotsub
+- company: Eventus Advisory Group, LLC
+  board: eventus-advisory-group-llc
+- company: Inspire Direct Marketing
+  board: inspire-direct-marketing
+- company: Jibble Group
+  board: jibble-group
+- company: Lingual Consultancy Services Pvt. Ltd.
+  board: lingual-consultancy-services-pvt-ltd
+- company: Loopring
+  board: loopring
+- company: ManyPixels
+  board: manypixels
+- company: Mettacool
+  board: mettacool
+- company: RN Pad
+  board: rn-pad
+- company: STINSON
+  board: stinson
+- company: Talent Venture Group
+  board: talent-venture-group
+- company: Transparent Search Group
+  board: transparent-search-group
+- company: Wersirius
+  board: wersirius

--- a/sources/freshteam.yml
+++ b/sources/freshteam.yml
@@ -416,3 +416,13 @@
   board: terra
 - company: Watermark Insights
   board: watermarkinsights
+- company: Blueprint
+  board: blueprint
+- company: CRUX
+  board: crux
+- company: Life Trust GmbH & Co. KG
+  board: lifetrust
+- company: Stutzen
+  board: stutzen
+- company: Trovata
+  board: trovata

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8245,3 +8245,131 @@
   board: cyclopsio
 - company: ViaPeople
   board: viapeople
+- company: Audi RED
+  board: audired
+- company: Codelitt
+  board: codelitt
+- company: Condor Agency
+  board: condoragency
+- company: FranDevCo
+  board: frandevco
+- company: Frontline Performance Group
+  board: frontlineperformancegroup
+- company: InvestNext
+  board: investnext
+- company: Macalogic
+  board: macalogic
+- company: Manafa Technologies
+  board: manafatechnologies
+- company: Managed Medical Review Organization
+  board: managedmedicalrevieworganization
+- company: Manatee
+  board: manatee
+- company: Manifest Financial
+  board: manifestfinancial
+- company: Market My Market
+  board: marketmymarket
+- company: MBO Partners
+  board: mbopartners
+- company: MedKoder
+  board: medkoder
+- company: MetaOption, LLC
+  board: metaoption
+- company: Mine Vision Systems
+  board: minevisionsystems
+- company: Nagwa
+  board: nagwa
+- company: Nao Now
+  board: naonow
+- company: Newscape Studios
+  board: newscapestudios
+- company: Nisos
+  board: nisos
+- company: Nonprofit HR
+  board: nonprofithr
+- company: Nuwave Communications, Inc.
+  board: nuwavecommunications
+- company: One World Global Services
+  board: oneworldglobalservices
+- company: Partners for Public Good
+  board: partnersforpublicgood
+- company: PeopleLift
+  board: peoplelift
+- company: Phase 2
+  board: phase2
+- company: Pierce Washington
+  board: piercewashington
+- company: Prometheum
+  board: prometheum
+- company: Protagona
+  board: protagona
+- company: Prove Partners
+  board: provepartners
+- company: Rapid
+  board: rapid
+- company: Riderflex
+  board: riderflex
+- company: Schneider Saddlery
+  board: schneidersaddlery
+- company: Sentinel Group
+  board: sentinelgroup
+- company: Simplified Group BPO
+  board: simplifiedgroupbpo
+- company: SmartScale360
+  board: smartscale360
+- company: SocialPilot
+  board: socialpilot
+- company: Strike
+  board: strike
+- company: Summit 360 Solutions
+  board: summit360solutions
+- company: Susco
+  board: susco
+- company: Talent Hackers
+  board: talenthackers
+- company: Talent on Fire Consulting
+  board: talentonfireconsulting
+- company: Teak
+  board: teak
+- company: The Calendar Group
+  board: thecalendargroup
+- company: The Cornerstone Group
+  board: thecornerstonegroup
+- company: The Good CFO
+  board: thegoodcfo
+- company: The Green Technology Group
+  board: thegreentechnologygroup
+- company: THE LANGUAGE GROUP
+  board: thelanguagegroup
+- company: The Moran Company
+  board: themorancompany
+- company: Third Party CS
+  board: thirdpartycs
+- company: Touch Support
+  board: touchsupport
+- company: Tumblerware
+  board: tumblerware
+- company: UniHomes
+  board: unihomes
+- company: Upwardly Global
+  board: upwardlyglobal
+- company: VaVa Virtual Assistants
+  board: vavavirtualassistants
+- company: VeilSun, Inc.
+  board: veilsun
+- company: Venture University
+  board: ventureuniversity
+- company: Vero Networks
+  board: veronetworks
+- company: VISEO - Spain
+  board: viseospain
+- company: Vita Bella
+  board: vitabella
+- company: Vitalief
+  board: vitalief
+- company: Wesper
+  board: wesper
+- company: Westernacher Solutions GmbH
+  board: westernachersolutions
+- company: You Are Accountable
+  board: youareaccountable

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -210,3 +210,67 @@
   board: zones
 - company: Point of Rental Software
   board: pointofrental
+- company: Bravium Consulting
+  board: braviumconsulting
+- company: Builders Mutual
+  board: buildersmutual
+- company: CARFAX
+  board: carfax
+- company: Castle Metals
+  board: castlemetals
+- company: CDW
+  board: cdw
+- company: Cetera
+  board: cetera
+- company: Common Ground
+  board: commonground
+- company: Cronos Group Inc.
+  board: cronosgroup
+- company: Earthjustice
+  board: earthjustice
+- company: Elire Inc
+  board: elire
+- company: Excel
+  board: excel
+- company: GVW Group, LLC
+  board: gvwgroup
+- company: Healthmap Solutions
+  board: healthmapsolutions
+- company: Humble Bundle
+  board: humble-bundle
+- company: LeadVenture
+  board: leadventure
+- company: Mercy Health
+  board: mercy-health
+- company: MetaPhase Consulting
+  board: metaphaseconsulting
+- company: Net Driven
+  board: netdriven
+- company: NRC Health
+  board: nrchealth
+- company: NuScale Power, LLC
+  board: nuscale-power
+- company: Ookla
+  board: ookla
+- company: Pinnacle Treatment
+  board: pinnacletreatment
+- company: PulsePoint
+  board: pulsepoint
+- company: Recurrent Energy
+  board: recurrent-energy
+- company: Salsa
+  board: salsa
+- company: Schneider Geospatial
+  board: schneidergeospatial
+- company: Vail Resorts
+  board: vail-resorts
+- company: Varonis
+  board: varonis
+- company: Ventus Solutions
+  board: ventus-solutions
+- company: VIPRE Security Group
+  board: vipre-security-group
+- company: Ziff Davis
+  board: ziff-davis
+- company: Ziff Davis
+  board: ziffdavis

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4455,3 +4455,9 @@
   board: print-recruiting
 - company: Volkswagen Group Digital Solutions
   board: vwgds
+- company: Appriss Retail
+  board: appriss-retail
+- company: Recast Software
+  board: recast-software
+- company: Trans Lifeline
+  board: translifeline

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3771,3 +3771,241 @@
   board: veocareers
 - company: Hygraph
   board: hygraph
+- company: Acadoro GmbH
+  board: acadoro
+- company: Adzuna
+  board: adzuna
+- company: Agentur für Haushaltshilfe GmbH
+  board: agenturfurhaushaltshilfe
+- company: Allshore Talent
+  board: allshoretalent
+- company: All Your BI
+  board: allyourbi
+- company: Amperecloud GmbH
+  board: amperecloud
+- company: AnywhereNow
+  board: anywherenow
+- company: AnywhereWorks
+  board: anywhereworks
+- company: Baulig Consulting GmbH
+  board: bauligconsulting
+- company: Biztech Lawyers
+  board: biztechlawyers
+- company: Bluerock TMS
+  board: bluerocktms
+- company: Braavo Capital Inc.
+  board: braavocapital
+- company: BSI
+  board: bsi
+- company: Camelback Ventures
+  board: camelbackventures
+- company: Castolin Eutectic
+  board: castolineutectic
+- company: CC.Talent
+  board: cctalent
+- company: celebrate company GmbH
+  board: celebratecompany
+- company: Channext
+  board: channext
+- company: City Science
+  board: cityscience
+- company: CLANX
+  board: clanx
+- company: Code & Pepper
+  board: codepepper
+- company: conlab GmbH
+  board: conlab
+- company: consulting1x1 GmbH
+  board: consulting1x1
+- company: CoreX
+  board: corex
+- company: Custom Connect
+  board: customconnect
+- company: DebtHammer
+  board: debthammer
+- company: Denova Consulting
+  board: denovaconsulting
+- company: Destination Sport
+  board: destinationsport
+- company: Dev Partners
+  board: devpartners
+- company: digital dna
+  board: digitaldna
+- company: Distribusion Technologies
+  board: distribusiontechnologies
+- company: DVT
+  board: dvt
+- company: Economic Security Project
+  board: economicsecurityproject
+- company: EDC
+  board: edc
+- company: Ehrenkind  GmbH
+  board: ehrenkind
+- company: elockers
+  board: elockers
+- company: Emergent Software
+  board: emergentsoftware
+- company: Evolve Digital GmbH
+  board: evolvedigital
+- company: Fair Doctors
+  board: fairdoctors
+- company: Filestage
+  board: filestage
+- company: FMTC
+  board: fmtc
+- company: Foxelli Group
+  board: foxelligroup
+- company: Friday Recruitment
+  board: fridayrecruitment
+- company: Global Jet Luxembourg
+  board: globaljetluxembourg
+- company: GoodRec
+  board: goodrec
+- company: Go RH
+  board: gorh
+- company: gravity9
+  board: gravity9
+- company: Herrera Headhunters
+  board: herreraheadhunters
+- company: Impact Brands, LLC
+  board: impactbrands
+- company: Impact Valuation Group, LLC
+  board: impactvaluationgroup
+- company: INDG
+  board: indg
+- company: Instagrid
+  board: instagrid
+- company: Intuition Staffing
+  board: intuitionstaffing
+- company: ITQ
+  board: itq
+- company: JetRails
+  board: jetrails
+- company: Jimmy Technologies
+  board: jimmytechnologies
+- company: Jumpseller
+  board: jumpseller
+- company: Kapten & Son
+  board: kaptenson
+- company: Klant Contact Diensten
+  board: klantcontactdiensten
+- company: Knuddels GmbH & Co. KG
+  board: knuddels
+- company: Laborde Earles
+  board: labordeearles
+- company: Leadership Pathway
+  board: leadershippathway
+- company: Leaped
+  board: leaped
+- company: Les Pépites
+  board: lespepites
+- company: limehome
+  board: limehome
+- company: Lippe Personal GmbH
+  board: lippepersonal
+- company: Manual
+  board: manual
+- company: Miaplaza
+  board: miaplaza
+- company: Miebach Consulting GmbH
+  board: miebachconsulting
+- company: Mindful Souls
+  board: mindfulsouls
+- company: MOC 't Kabouterhuis
+  board: moctkabouterhuis
+- company: Momentum Data
+  board: momentumdata
+- company: NAXCON
+  board: naxcon
+- company: Nearfield Instruments
+  board: nearfieldinstruments
+- company: Neho
+  board: neho
+- company: netzbest GmbH
+  board: netzbest
+- company: NutriSense
+  board: nutrisense
+- company: OGC Global
+  board: ogcglobal
+- company: OnlineDialog GmbH
+  board: onlinedialog
+- company: Outbound Operators
+  board: outboundoperators
+- company: Oxygen Conservation
+  board: oxygenconservation
+- company: Paragon Germany GmbH
+  board: paragongermany
+- company: Paragon Partners GmbH
+  board: paragonpartners
+- company: Paralucent
+  board: paralucent
+- company: Parent ApS
+  board: parentaps
+- company: Peoplefinders
+  board: peoplefinders
+- company: Quooker
+  board: quooker
+- company: Ruby Berlin HR Consulting GmbH
+  board: rubyberlinhrconsulting
+- company: RWC
+  board: rwc
+- company: Santana Consulting GmbH
+  board: santanaconsulting
+- company: Schmalenberg GmbH
+  board: schmalenberg
+- company: Session Media
+  board: sessionmedia
+- company: Sharpist GmbH
+  board: sharpist
+- company: ShortPoint
+  board: shortpoint
+- company: Shums Coda Associates
+  board: shumscodaassociates
+- company: SichtbarerWerden GmbH
+  board: sichtbarerwerden
+- company: SingularitySales
+  board: singularitysales
+- company: Sint Maartenskliniek
+  board: sintmaartenskliniek
+- company: SKM Group
+  board: skmgroup
+- company: S. Med
+  board: smed
+- company: sofatutor GmbH
+  board: sofatutor
+- company: SOFTGAMES
+  board: softgames
+- company: Student Medicover
+  board: studentmedicover
+- company: SUPERP
+  board: superp
+- company: teccle group GmbH
+  board: tecclegroup
+- company: TechBiz Global GmbH
+  board: techbizglobal
+- company: The Event Academy
+  board: theeventacademy
+- company: The Mortgage Talent Network
+  board: themortgagetalentnetwork
+- company: The Trainee Company
+  board: thetraineecompany
+- company: Tornator Oyj
+  board: tornatoroyj
+- company: Transferz
+  board: transferz
+- company: United Nations Watch
+  board: unitednationswatch
+- company: US Cloud
+  board: uscloud
+- company: Viderity Inc.
+  board: viderity
+- company: Virtual Identity
+  board: virtualidentity
+- company: Wajer Yachts B.V.
+  board: wajeryachtsbv
+- company: Waracle
+  board: waracle
+- company: Weekday
+  board: weekday
+- company: Young & Laramore
+  board: younglaramore

--- a/sources/traffit.yml
+++ b/sources/traffit.yml
@@ -93,3 +93,9 @@
   board: ritenrg
 - company: Datumo
   board: datumo
+- company: group.one
+  board: groupone
+- company: Helprise
+  board: helprise
+- company: Yes&
+  board: "yes"

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1284,3 +1284,17 @@
   board: xtremax
 - company: Zadara
   board: zadara
+- company: athenahealth
+  board: athenahealth
+- company: eleos
+  board: eleos
+- company: Emco Ltd
+  board: emco
+- company: Frontlineperformancegroup
+  board: frontlineperformancegroup
+- company: Ntara
+  board: ntara
+- company: qwerty
+  board: qwerty
+- company: TapMango
+  board: tapmango


### PR DESCRIPTION
## Summary
Second batch from the same seed as #1642 (companies we only see through the Himalayas aggregator):
- recruitee: 119, bamboohr: 83, jazzhr: 64, jobvite: 32, breezy: 20, trakstar: 7, freshteam: 5, lever: 3, traffit: 3

join, paycom, teamtailor, opencats yielded zero live boards this round (honest zeros, not failures).
personio found 81 live boards but the platform rate-limited the probe mid-run (13646 refused / 119
answered), so `harvest-boards` correctly refused to write a truncated result — it'll ship in a follow-up
once re-run with pacing. workable is still probing (very slow response times from their API, not
rate-limiting) and will also follow separately.

## Test plan
- [x] `harvest-boards` name-gate confirmed each board's reported company against the seed before writing
- [x] zero-result and rate-limited providers verified by log, not silently dropped