### PR TITLE
fix(cv): resolve preview's default font to the template's actual PDF face

### DIFF
--- a/web/src/lib/tailor/CvHtmlPreview.svelte
+++ b/web/src/lib/tailor/CvHtmlPreview.svelte
@@ -62,6 +62,10 @@
   const mr = $derived((doc.margins?.right || 0.5) * PX_PER_IN);
   const mb = $derived((doc.margins?.bottom || 0.5) * PX_PER_IN);
   const ml = $derived((doc.margins?.left || 0.5) * PX_PER_IN);
+  // The registry id each template falls back to when the candidate has not chosen a font — must
+  // match that template's own Typst default face (`fontFamily` in templates/<id>.typ).
+  const defaultFontId = $derived(isSans ? 'liberation-sans' : 'libertinus-serif');
+
   // Typography, resolved once and spread onto BOTH the visible sheets and the hidden
   // measurement layer below. One value, two consumers — measuring in one type and drawing in
   // another would make pagination disagree with what is on screen, and nothing would report it.
@@ -70,8 +74,17 @@
   // stack therefore falls through to whatever the machine has, which on Windows is the very face
   // the registry entry matches (Times New Roman, Arial, Calibri) and elsewhere may be a generic.
   // The preview has always approximated the PDF; this keeps it in the same family, not identical.
+  //
+  // Falls back to the template's own default id (not just the candidate's explicit choice) so an
+  // unset font_family still resolves a real CSS stack: measuring against the browser's OS-default
+  // serif/sans (e.g. macOS's "New York") instead of the registry's Georgia-anchored fallback for
+  // Libertinus Serif wraps text onto more lines than Typst does, and the preview overflows onto a
+  // second page well before the PDF would.
   const typography = $derived(
-    previewTypography(doc.style ?? {}, fonts.find((f) => f.id === doc.style?.font_family)?.css ?? ''),
+    previewTypography(
+      doc.style ?? {},
+      fonts.find((f) => f.id === (doc.style?.font_family || defaultFontId))?.css ?? '',
+    ),
   );
   const typeStyle = $derived(
     `font-size: ${typography.fontSizePx}px; line-height: ${typography.lineHeight};` +
@@ -79,7 +92,9 @@
   );
   // NOTE: the `13` in the text-[calc(N/13*1em)] classes below is PREVIEW_FONT_SIZE_PX — the base
   // those ratios were taken over. Change the constant and those class strings must follow.
-  // The template's own face applies only while the document names none.
+  // `typography.fontFamily` is empty only in the brief window before `fonts` (GET /cv-fonts) has
+  // loaded, since `defaultFontId` above always resolves once the registry is in — this Tailwind
+  // generic is a loading-state fallback, not a steady-state one.
   const useTemplateFace = $derived(typography.fontFamily === '');
 
   const contentWidth = $derived(PAGE_W - ml - mr);

--- a/web/src/lib/tailor/geometry.test.ts
+++ b/web/src/lib/tailor/geometry.test.ts
@@ -57,8 +57,13 @@ describe('previewTypography', () => {
     );
   });
 
-  it('ignores a stack when no family is set', () => {
-    expect(previewTypography({}, 'Carlito, Calibri, sans-serif').fontFamily).toBe('');
+  // The function no longer decides whether a stack applies — the caller resolves it (the
+  // candidate's choice, or the active template's own default face) and hands it in, so an unset
+  // font_family still measures against a real CSS stack instead of an empty one.
+  it('passes a caller-resolved default stack through even when font_family is unset', () => {
+    expect(previewTypography({}, '"Libertinus Serif", "Linux Libertine", Georgia, serif').fontFamily).toBe(
+      '"Libertinus Serif", "Linux Libertine", Georgia, serif',
+    );
   });
 });
 

--- a/web/src/lib/tailor/geometry.ts
+++ b/web/src/lib/tailor/geometry.ts
@@ -74,7 +74,10 @@ export function stepFontSize(value: number, delta: number): number {
 
 /** The typography the live preview renders (and measures) with, resolved from the document's
  *  style block. Every unset value falls back to what the preview used before the style block
- *  existed; `cssStack` is the selected font's CSS stack, ignored when no family is set.
+ *  existed; `cssStack` is passed straight through as `fontFamily` — the caller resolves it,
+ *  whether that's the candidate's chosen font or the active template's own default face, so an
+ *  unset font_family still measures against the face the PDF will actually use rather than
+ *  whatever generic serif/sans the browser's OS happens to default to.
  *
  *  Pure so the calibration above is testable: the component only spreads the result onto both
  *  its visible sheets and its hidden measurement layer. */
@@ -90,7 +93,7 @@ export function previewTypography(
     // and left the preview still — in a feature whose whole point is that they agree.
     fontSizePx: pt > 0 ? (pt * 4) / 3 : PREVIEW_FONT_SIZE_PX,
     lineHeight: leading > 0 ? leading + LEADING_TO_LINE_HEIGHT : PREVIEW_LINE_HEIGHT,
-    fontFamily: (style.font_family ?? '') !== '' ? cssStack : '',
+    fontFamily: cssStack,
   };
 }
 


### PR DESCRIPTION
## Summary
- The live CV HTML preview approximates Typst pagination by measuring block heights in the browser and packing them onto A4 pages.
- When a CV has no explicit `font_family`, the preview measured text using a browser-default generic serif/sans font instead of the template's real default face (Libertinus Serif / Liberation Sans), which the font registry already defines a correct CSS stack for.
- Because the substitute font's metrics don't match the actual PDF font, text wraps onto more lines in the preview than in the real Typst render — blocks measure taller than they actually are, and content overflows onto a second page well before the PDF would.
- Fix: when `font_family` is unset, resolve the CSS stack from the template's own default font id (`libertinus-serif` for serif templates, `liberation-sans` for sans templates) instead of falling back to a generic.

## Test plan
- [x] `npx vitest run src/lib/tailor/geometry.test.ts` — 29 passed
- [x] `npx svelte-check` — 0 errors
- [ ] Visually confirm in the live `/tailor/:slug` preview that pagination now lines up closer to the exported PDF