### PR TITLE
fix(cv): close the remaining preview/PDF pagination gap on dense CVs

### DIFF
--- a/web/src/lib/tailor/CvHtmlPreview.svelte
+++ b/web/src/lib/tailor/CvHtmlPreview.svelte
@@ -181,7 +181,7 @@
 </script>
 
 {#snippet sectionHeading(title: string)}
-  <h2 class={['mb-1 mt-2 font-bold uppercase tracking-wide', isCentered ? 'text-center' : '']}>{title}</h2>
+  <h2 class={['mb-1 mt-1.5 font-bold uppercase tracking-wide', isCentered ? 'text-center' : '']}>{title}</h2>
   {#if ruled}<hr class="mb-2 -mt-0.5 border-neutral-300" />{/if}
 {/snippet}
 
@@ -236,13 +236,13 @@
     </div>
     {#if isHeadshot}{@render photoFrame('size-[98px]')}{/if}
   </header>
-  <hr class={['my-1', isSans || twoColumn ? 'border-neutral-500' : 'border-neutral-300']} />
+  <hr class={['my-0.5', isSans || twoColumn ? 'border-neutral-500' : 'border-neutral-300']} />
 {/snippet}
 
 {#snippet experienceItem(e: ExperienceItem, at: number)}
   {@const bullets = keepIndex(e.bullets ?? [], (b) => b.trim() !== '')}
   {@const stack = (e.stack ?? []).filter((s) => s.trim())}
-  <div class="mb-1.5">
+  <div class="mb-1">
     <p class="font-bold" class:cv-lit={lit(`experience[${at}].role`) || lit(`experience[${at}].company`)}>
       {experienceHeader(e)}
     </p>
@@ -250,7 +250,11 @@
       <p class="text-neutral-800" class:cv-lit={lit(`experience[${at}].summary`)}>{e.summary}</p>
     {/if}
     {#if bullets.length}
-      <ul class="ml-4 list-disc space-y-0.5">
+      <!-- No inter-item gap: Typst's list() advances consecutive bullets at the same rate as
+           wrapped lines within one bullet — a PDF text layer shows both at 11.0pt, no extra
+           list.spacing on top. A Tailwind space-y here would look nicer but drift pagination
+           again on a bullet-heavy CV. -->
+      <ul class="ml-4 list-disc">
         {#each bullets as b (b.index)}
           <li class:cv-lit={lit(`experience[${at}].bullets[${b.index}]`)}>{b.item}</li>
         {/each}

--- a/web/src/lib/tailor/geometry.ts
+++ b/web/src/lib/tailor/geometry.ts
@@ -49,11 +49,11 @@ export const FONT_SIZE_STEP = 0.5;
  *  the document means "use this", so the stepper starts from it rather than from zero. */
 export const TEMPLATE_FONT_SIZE_PT = 9.5;
 
-/** What the preview renders body text at: 13px, paired with PREVIEW_LINE_HEIGHT below. These
- *  stay the fallback for an unset style so an existing CV paginates exactly as it did — the
- *  preview approximates Typst by measurement, and re-deriving these from the point size would
- *  move every existing preview for no gain. */
-export const PREVIEW_FONT_SIZE_PX = 13;
+/** The unset-style fallback in CSS px: TEMPLATE_FONT_SIZE_PT at 96dpi (1pt = 4/3px), kept
+ *  fractional for the same reason `stepFontSize`'s own conversion is — this used to be a
+ *  rounded 13px, which is 9.75pt-equivalent, not the template's actual 9.5pt. A ~2.6% oversized
+ *  baseline is invisible on one line and compounds on a dense CV like every other constant here. */
+export const PREVIEW_FONT_SIZE_PX = (TEMPLATE_FONT_SIZE_PT * 4) / 3;
 
 /** Measured, not guessed: a classic-ats PDF's text layer (PyMuPDF span bboxes) advances a
  *  consistent 11.0pt between two lines of the same paragraph at the template's default 9.5pt /


### PR DESCRIPTION
## Summary
Follow-up to #1652 — the reporter confirmed the preview was much closer but still broke one role early (their last role instead of Education, where the real PDF breaks). Re-measured against the same real PDF and found three more small, real discrepancies:

- `PREVIEW_FONT_SIZE_PX` was a rounded `13px` (9.75pt-equivalent) fallback, inconsistent with both the fractional `pt*4/3` conversion used for an explicit font size and the template's actual 9.5pt default. Corrected to `TEMPLATE_FONT_SIZE_PT*4/3` (12.667px).
- Bullet items had a Tailwind `space-y-0.5` gap the PDF doesn't: the PDF's text layer shows consecutive bullets advancing at the exact same 11.0pt as wrapped lines within one bullet, i.e. Typst adds zero extra spacing between list items.
- Trimmed the experience-entry gap, header rule, and section-heading margins a bit further — still measurably looser than the PDF.

## Verification
Same harness as #1652, same reporter CV: before this fix the preview measurement overflowed at the very last role (matches the reporter's live report); after, it agrees with the PDF on every role and project fitting page one, off by ~3px right at the Education boundary.

## Test plan
- [x] `npx vitest run src/lib/tailor/geometry.test.ts` — 29 passed (verified in primary checkout)
- [x] `npx svelte-check` — 0 new errors (verified in primary checkout)
- [ ] Visually confirm in the live `/tailor/:slug` preview