### PR TITLE
fix(cv): trim two more margins toward PDF parity, verified against the real component

### DIFF
--- a/web/src/lib/tailor/CvHtmlPreview.svelte
+++ b/web/src/lib/tailor/CvHtmlPreview.svelte
@@ -181,7 +181,7 @@
 </script>
 
 {#snippet sectionHeading(title: string)}
-  <h2 class={['mb-1 mt-1.5 font-bold uppercase tracking-wide', isCentered ? 'text-center' : '']}>{title}</h2>
+  <h2 class={['mb-1 mt-1 font-bold uppercase tracking-wide', isCentered ? 'text-center' : '']}>{title}</h2>
   {#if ruled}<hr class="mb-2 -mt-0.5 border-neutral-300" />{/if}
 {/snippet}
 
@@ -242,7 +242,7 @@
 {#snippet experienceItem(e: ExperienceItem, at: number)}
   {@const bullets = keepIndex(e.bullets ?? [], (b) => b.trim() !== '')}
   {@const stack = (e.stack ?? []).filter((s) => s.trim())}
-  <div class="mb-1">
+  <div class="mb-0.5">
     <p class="font-bold" class:cv-lit={lit(`experience[${at}].role`) || lit(`experience[${at}].company`)}>
       {experienceHeader(e)}
     </p>


### PR DESCRIPTION
## Summary
Small follow-up to #1653. This time verified against the real `CvHtmlPreview.svelte` component (not a hand-built HTML approximation) rendered in a throwaway dev-server route against the reporter's actual CV, inspected via the DOM — closes the harness-fidelity gap that made the previous round's numbers hard to trust.

Found the true break point: page one held all five roles but stopped right at the "Projects" heading (one section earlier than the PDF, which fits all four project items before Education). Trimmed the section-heading top margin (`mt-1.5`→`mt-1`) and the experience-entry bottom margin (`mb-1`→`mb-0.5`) a notch further.

## Verification
Re-checked on the same real component: the page break now falls after the first project item instead of before it — closer, though not full parity (three more project bullets still land on page two).

Not chasing this further: the real PDF's own Projects/Education boundary sits within ~7px of its own page limit for this CV, so tuning shared margins to force exact parity on one document risks visual crowding or overshooting the boundary the other way on a shorter CV.

## Test plan
- [x] `npx vitest run src/lib/tailor/geometry.test.ts` — 29 passed (verified in primary checkout)
- [x] `npx svelte-check` — 0 new errors (verified in primary checkout)
- [x] Verified against the real component with real CV data via a throwaway dev-server route (not committed)