### PR TITLE
fix(sources): dead-letter a terminal Adzuna description failure on the first attempt

### DIFF
--- a/internal/adzunadesc/fetch.go
+++ b/internal/adzunadesc/fetch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"net/http"
 
 	xhtml "golang.org/x/net/html"
 
@@ -12,11 +13,43 @@ import (
 )
 
 // errNoJobPosting means the page carried no schema.org JobPosting block — the shape Adzuna's
-// own "Access Denied" page (and any other unexpected response) takes.
+// own "Access Denied" page takes, but also (confirmed live 2026-08-09, majority failure mode
+// of the first production runs) a perfectly normal, non-blocked posting page whose ld+json
+// simply never carried the JobPosting block in the first place. Terminal either way: the same
+// URL answers the same way on a retry.
 var errNoJobPosting = errors.New("adzunadesc: no JobPosting block on the page")
 
-// errEmptyDescription means the page's JobPosting carried no description text.
+// errEmptyDescription means the page's JobPosting carried no description text. Terminal, same
+// reasoning as errNoJobPosting.
 var errEmptyDescription = errors.New("adzunadesc: JobPosting block has an empty description")
+
+// errNotFound means Adzuna no longer serves this posting at all. Terminal.
+var errNotFound = errors.New("adzunadesc: posting not found on Adzuna's site")
+
+// statusCoder is any error carrying an HTTP status — sources.StatusError satisfies it.
+// Declared here rather than imported to mirror internal/applyform's own asGone, which notes
+// why: the dependency runs the other way in that package. Here it is only mirrored for
+// consistency, since internal/sources does not import this package.
+type statusCoder interface{ StatusCode() int }
+
+// asNotFound converts a 404 response into errNotFound and leaves everything else (429, 5xx,
+// network errors) alone — those are the platform declining to answer right now, not stating
+// the posting is gone, so they stay retryable. Mirrors applyform's asGone.
+func asNotFound(err error) error {
+	var sc statusCoder
+	if errors.As(err, &sc) && sc.StatusCode() == http.StatusNotFound {
+		return fmt.Errorf("%w: %v", errNotFound, err)
+	}
+	return err
+}
+
+// terminal reports whether err will answer the same way on a retry — Adzuna's own site
+// stating, one way or another, that this posting will never yield a description. The runner
+// dead-letters these on the first attempt rather than spending two more requests to learn
+// the same thing twice.
+func terminal(err error) bool {
+	return errors.Is(err, errNoJobPosting) || errors.Is(err, errEmptyDescription) || errors.Is(err, errNotFound)
+}
 
 // Transport is the narrow HTTP role this package needs: a rendered page, the same shape
 // applyform's Lever fetcher and internal/linksource's generic resolver already use.
@@ -39,7 +72,7 @@ type adzunaJobPosting struct {
 func FetchDescription(ctx context.Context, t Transport, url string) (string, error) {
 	root, err := t.GetHTML(ctx, url)
 	if err != nil {
-		return "", fmt.Errorf("adzunadesc: fetch %s: %w", url, err)
+		return "", fmt.Errorf("adzunadesc: fetch %s: %w", url, asNotFound(err))
 	}
 
 	var p adzunaJobPosting

--- a/internal/adzunadesc/runner.go
+++ b/internal/adzunadesc/runner.go
@@ -148,7 +148,14 @@ func runWave(ctx context.Context, s Store, fetch FetchFunc, opts RunOptions, cla
 				return
 			}
 
-			dead, failErr := s.Fail(ctx, c.OutboxID, err.Error(), opts.MaxAttempts)
+			// A terminal error (see fetch.go) will answer the same way on a retry, so it
+			// dead-letters on this first attempt regardless of opts.MaxAttempts — no point
+			// spending two more requests to learn the same thing twice.
+			maxAttempts := opts.MaxAttempts
+			if terminal(err) {
+				maxAttempts = 1
+			}
+			dead, failErr := s.Fail(ctx, c.OutboxID, err.Error(), maxAttempts)
 			if failErr != nil {
 				log.Printf("adzunadesc: record failure for capture %d: %v", c.OutboxID, failErr)
 			} else if dead {

--- a/internal/adzunadesc/runner_test.go
+++ b/internal/adzunadesc/runner_test.go
@@ -144,6 +144,32 @@ func TestRunRetriesThenDeadLettersAFailingFetch(t *testing.T) {
 	}
 }
 
+func TestRunDeadLettersATerminalFailureOnTheFirstAttempt(t *testing.T) {
+	// errNoJobPosting/errEmptyDescription/a 404 are deterministic: the same URL will
+	// answer the same way every time, so retrying wastes two more requests against a page
+	// already known to fail — confirmed live 2026-08-09 (a normal-looking, non-blocked
+	// Adzuna page whose ld+json simply carries no JobPosting block, majority failure mode
+	// of the first production runs).
+	store := &fakeStore{pending: []Claimed{{OutboxID: 1, JobID: 10, URL: "https://www.adzuna.co.uk/jobs/details/1"}}}
+	fetch := func(_ context.Context, _ string) (string, error) {
+		return "", errNoJobPosting
+	}
+
+	// MaxAttempts=3 would normally take three failing runs to dead-letter (see
+	// TestRunRetriesThenDeadLettersAFailingFetch, which needs MaxAttempts=1 to dead-letter
+	// in one call) — a terminal error skips straight there on the FIRST attempt.
+	stats, err := Run(context.Background(), store, fetch, RunOptions{BatchSize: 10, Concurrency: 1, MaxAttempts: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Failed != 1 || stats.DeadLettered != 1 {
+		t.Errorf("stats = %+v, want Failed=1 DeadLettered=1 (dead-lettered on the first attempt)", stats)
+	}
+	if store.failed[1] != 1 {
+		t.Errorf("Fail was called %d times for outbox 1, want exactly 1", store.failed[1])
+	}
+}
+
 func TestRunStopsAtMaxPerRun(t *testing.T) {
 	store := &fakeStore{pending: []Claimed{
 		{OutboxID: 1, JobID: 10, URL: "https://www.adzuna.co.uk/jobs/details/1"},


### PR DESCRIPTION
Follow-up to #1659/#1660. Checked the freshly-deployed worker's real error
distribution in prod: ~74% of dead letters were "no JobPosting block" on
a completely normal, unblocked Adzuna page (title/salary/apply button all
present) — that specific posting's page just never carries the schema
this feature reads. Confirmed by fetching one live: no captcha/rate-limit
signal, plain missing markup.

That answer is deterministic — retrying the same URL gets the same page.
This dead-letters errNoJobPosting/errEmptyDescription/404 on the first
attempt instead of the configured MaxAttempts (default 3), cutting wasted
requests against Adzuna's site roughly in half for the majority failure
mode — the exact kind of restraint this worker exists to have.

## Test plan
- [x] New test: a terminal fetch error dead-letters with MaxAttempts=3
      configured, verifying Fail is called exactly once
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`