### PR TITLE
Fold Minimum skill match into Skills tab, drop Tech/Non-tech filter

### DIFF
--- a/docs/superpowers/specs/2026-08-08-match-tailor-merge-design.md
+++ b/docs/superpowers/specs/2026-08-08-match-tailor-merge-design.md
@@ -1,0 +1,54 @@
+# Match/Tailor page merge — design
+
+## Problem
+
+The job-match/CV-tailoring experience is spread across four places that don't know about each other:
+
+- `/match/[slug]` — full AI fit report (`MatchAnalysisFull`).
+- Tailor's **Job Match** tab — the same `MatchAnalysisFull` re-embedded read-only, stacked under a separate live deterministic score (`JobMatch.svelte` / `cvmatch`).
+- Tailor's **Score** tab — an unrelated ATS-readability delta (`AtsDelta.svelte`) plus `AutopilotReport`.
+- `/my/profile` — a fourth, job-agnostic ATS report (`ATSReportView`), out of scope here.
+
+Getting from "here's a job" to "here's my tailored CV" requires a full page hop (`/match` → `/tailor`), and the Job Match tab duplicates the Match page verbatim instead of linking to it. This spec removes the standalone Match page and reorganizes Tailor's right panel so there is one home for match/fit/ATS information.
+
+## Out of scope
+
+- **Colored underline overlay** marking specific problem spans inside the CV preview. The anchor mechanism already exists (`CvHtmlPreview.svelte`'s `highlightPaths` prop + `.cv-lit` dotted-underline styling, currently used for revision diffing) and is reusable, but none of the three issue-producing analyses (ATS delta, match analysis, experience evidence) currently emit a path into that vocabulary — that's backend work in the analyzers. Separate spec, follows this one.
+- **Merging the scoring engines themselves.** `cvmatch` (deterministic, scores the *tailored document text* against the posting, moves as you edit) and `matchanalysis` (LLM-driven, scores the *candidate* against the job from the base résumé, doesn't move on edit) measure genuinely different things — one document quality, one candidate fit. Averaging them into one number would misrepresent both. Resolved here instead by picking one as the visually primary ("hero") number and demoting the other to a supporting block, not by mechanical unification.
+- `/my/profile`'s `ATSReportView` (job-agnostic) is untouched.
+
+## Routing
+
+- Delete the `/match/[slug]` route (`web/src/routes/match/[slug]/+page.svelte` + `+page.server.ts`).
+- `/jobs/[slug]/fit` (legacy redirect) now 308s to `/tailor/[slug]` instead of `/match/[slug]`.
+- Every current entry point that links to `/match/[slug]` — job cards, `JobDrawer.svelte`, `SwipeDeck.svelte`, `MatchSummary.svelte`, the "Tailor my CV" CTA — points to `/tailor/[slug]` instead.
+- Add a plain redirect at `/match/[slug]` → `/tailor/[slug]` for old links already out in the wild (bookmarks, shared URLs), same pattern as the existing `/jobs/[slug]/fit` redirect.
+
+## Tailor bootstrap
+
+Today, opening `/tailor/[slug]` requires a cached fit analysis to already exist; if not, the backend returns 409 and the frontend `goto`s back to `/match/[slug]` to run it. With `/match` gone, `/tailor/[slug]` must trigger the AI fit compute itself on first open when no cached analysis exists, instead of redirecting elsewhere. This reuses the existing SSE-streamed compute path (`$lib/matchAnalysis.ts`) that `/match` used to kick off — only the trigger site moves.
+
+## Tab structure
+
+`ArtifactPanel.svelte` top-level tabs change from `jobmatch | score | history | jd` to:
+
+**`jobmatch | history | jd`**
+
+The `score` tab is removed as a top-level tab; its content moves inside `jobmatch` (see below). `history` and `jd` are unchanged.
+
+`jobmatch` becomes the default tab (already is). Inside it, a sub-tab switcher with three panes:
+
+| Sub-tab | Default | Content | Source |
+|---|---|---|---|
+| **Score** | yes | Live deterministic score of the current tailored text vs. the posting — the "hero" number, large, updates as the CV is edited. | `JobMatch.svelte` / `cvmatch` (unchanged) |
+| **Fit** | no | AI fit snapshot — verdict, per-dimension scores, strengths/gaps. Explicitly a snapshot of the base profile; doesn't move as you edit. | `MatchAnalysisFull.svelte` (`autoRun=false`, `stacked`), unchanged, just relocated |
+| **ATS** | no | ATS readability delta (base vs. tailored PDF text layer) + autopilot report. | `AtsDelta.svelte` + `AutopilotReport.svelte`, unchanged, just relocated from the old top-level `score` tab |
+
+Rationale for Score-as-hero: Tailor is where the user is actively editing text, so the number that responds to their edits belongs up front. The AI fit verdict is a heavier, less immediate signal — useful, but supporting rather than primary in this specific context. (On job-browsing surfaces like cards/drawer, the AI fit teaser remains the primary signal shown today — this change only affects the Tailor workspace's internal layout.)
+
+Naming note for implementation: the old top-level `score` tab (AtsDelta) and the new `Score` sub-tab (cvmatch) are different things with the same word — pick distinct internal keys (e.g. `ats` vs `score`) to avoid confusion in the component/prop names, even though the user-facing label for the hero sub-tab can stay "Score."
+
+## Non-goals / explicit decisions already made
+
+- No shared cross-page store is introduced. Each page still fetches its own data; the simplification is in navigation and layout, not in data-fetching architecture.
+- `/my/activity/matches` (history list) is unaffected.

--- a/openspec/changes/match-tailor-merge/.openspec.yaml
+++ b/openspec/changes/match-tailor-merge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/match-tailor-merge/design.md
+++ b/openspec/changes/match-tailor-merge/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Full background and the brainstorming trail (including two approaches that were considered and
+rejected) live in `docs/superpowers/specs/2026-08-08-match-tailor-merge-design.md`. Summary:
+
+The AI fit report currently has two homes — the standalone `/match/[slug]` page and the Tailor
+workspace's Job Match tab, which re-embeds the same `MatchAnalysisFull` component read-only. Tailor
+cannot bootstrap without a cached analysis; today it 409s and sends the candidate to `/match` to
+produce one. This design removes the standalone page and moves that trigger into Tailor itself.
+
+Two adjacent ideas were raised and explicitly rejected during brainstorming:
+
+1. **Folding the Score (ATS-delta) tab into Job Match.** `tailor-ats-delta/spec.md` already
+   documents why not: it "MUST NOT share a tab with the job-anchored match score... stacking them
+   under one heading is what made the previous Verdict tab unreadable." This is prior, paid-for
+   product learning, not a fresh opinion — it stands.
+2. **Merging the `cvmatch` (deterministic, document-vs-posting) and `matchanalysis` (LLM,
+   candidate-vs-job) scores into one number.** They score different subjects (the edited document
+   vs. the candidate) and are not commensurable — averaging them would misrepresent both. Resolved
+   instead by keeping the existing visual hierarchy (live score primary, fit snapshot secondary),
+   which the Job Match tab already implements correctly.
+
+Both are recorded here so the tasks phase doesn't quietly reopen them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One entry point for "how do I match this job and tailor my CV for it": `/tailor/[slug]`.
+- No page hop required to produce a first fit analysis for a vacancy.
+- Old `/match/[slug]` and `/jobs/[slug]/fit` links keep working (redirect, not 404).
+
+**Non-Goals:**
+- Changing the Job Match tab's internal layout (live score + labelled snapshot stays as-is).
+- Changing the Score/ATS-delta tab in any way — it keeps its own top-level tab, unchanged.
+- Colored underline overlay of analysis findings on the CV preview (separate, later change — the
+  anchor mechanism exists via `CvHtmlPreview.svelte`'s `highlightPaths`, but no analysis emits a
+  path yet).
+- Unifying the `cvmatch`/`matchanalysis` scoring engines.
+
+## Decisions
+
+**Redirect, don't 404, on the old page.** `/match/[slug]` becomes a permanent (308) redirect to
+`/tailor/[slug]`, mirroring the existing `/jobs/[slug]/fit` → (today) `/match/[slug]` pattern. This
+covers bookmarks and any external links already in the wild without a content negotiation on our
+side.
+
+**Frontend absorbs the 409, not the backend.** The tailoring bootstrap's contract (409 "run the fit
+analysis first" when no cached analysis exists) is left alone — `cv-tailoring` isn't touched. The
+`/tailor/[slug]` page catches that specific 409 (matched on message, as it already discriminates it
+from the "no résumé" 409) and, instead of `goto`-ing to `/match`, opens the existing SSE fit stream
+(`$lib/matchAnalysis.ts`) inline, then retries the bootstrap once the stream completes. This reuses
+100% of the existing compute/streaming path; only the trigger site moves. Alternative considered:
+make the bootstrap endpoint itself run the analysis synchronously when missing — rejected, because
+the fit chain is a multi-second, three-stage LLM call and the bootstrap is expected to be fast; the
+SPA already knows how to show streaming progress, the server endpoint does not.
+
+**`MatchAnalysisFull` is not deleted or forked.** It keeps rendering inside the Job Match tab
+exactly as it does today (`autoRun=false`, `stacked`, seeded from the cached analysis). Only its
+former standalone-page caller goes away.
+
+## Risks / Trade-offs
+
+- **[Risk]** Deleting the page could silently break a deep link some external tool or saved search
+  already points at. → **Mitigation**: the redirect, not a hard delete, and it's covered by the
+  same pattern as the existing `/jobs/[slug]/fit` alias.
+- **[Risk]** Moving the fit-analysis trigger into Tailor changes what "opening Tailor" costs (it
+  may now kick off an LLM chain the first time). → **Mitigation**: this was already true one hop
+  earlier (opening `/match` triggered it); the total number of LLM calls per candidate journey is
+  unchanged, only the page that issues it moves. The existing monthly quota
+  (`job-fit-analysis`'s 10-analyses/30-day limit) still applies unmodified.
+- **[Risk]** A future contributor reopens the "fold Score into Job Match" idea without seeing why
+  it was rejected. → **Mitigation**: recorded here and left untouched in `tailor-ats-delta/spec.md`;
+  no spec delta touches that file in this change.
+
+## Migration Plan
+
+1. Land the frontend 409-handling change in `/tailor/[slug]` (safe on its own — the redirect
+   pattern isn't wired to it yet, so this alone gives the workspace a self-serve path even if a
+   candidate happens to arrive without an existing analysis via a link that doesn't go through
+   `/match`).
+2. Repoint `/jobs/[slug]/fit` to `/tailor/[slug]`.
+3. Repoint every in-app link to `/match/[slug]` (`MatchSummary.svelte` and any other job-card/drawer
+   entry points) to `/tailor/[slug]`.
+4. Add the `/match/[slug]` → `/tailor/[slug]` redirect route.
+5. Delete the standalone `/match/[slug]` page implementation (`+page.svelte`, `+page.server.ts`)
+   only after step 4 lands, so there's no window where the route exists but serves nothing.
+
+No data migration; no rollback beyond reverting the commits (no destructive schema or data change
+in this scope).
+
+## Open Questions
+
+None outstanding — scope was narrowed twice during brainstorming (dropping the Score-tab merge and
+the scoring-engine merge) specifically to close open questions before this document was written.

--- a/openspec/changes/match-tailor-merge/proposal.md
+++ b/openspec/changes/match-tailor-merge/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+`/match/[slug]` and the Tailor workspace's Job Match tab both show the AI fit report — the Job
+Match tab re-embeds `MatchAnalysisFull` verbatim, read-only, beneath the workspace's own live
+document score. Getting from "here's a job" to "here's my tailored CV" requires a full page hop
+through `/match` before Tailor will even bootstrap: the tailoring bootstrap 409s with "run the fit
+analysis first" when no cached analysis exists, and the frontend sends the candidate to `/match`
+to produce one, then back. Removing `/match` and letting the Tailor workspace run the fit analysis
+itself collapses two page hops into one entry point.
+
+## What Changes
+
+- Delete the standalone `/match/[slug]` route (`+page.svelte` + `+page.server.ts`).
+- Add a permanent redirect at `/match/[slug]` → `/tailor/[slug]` for existing outbound links
+  (job cards, `JobDrawer`, `SwipeDeck`, `MatchSummary`'s "view fit" links, and any bookmarked URLs).
+- Repoint the existing `/jobs/[slug]/fit` legacy redirect from `/match/[slug]` to `/tailor/[slug]`
+  (it currently 308s to `/match/[slug]`, which would otherwise redirect a second time).
+- **BREAKING**: the tailoring bootstrap's `409 "run the fit analysis first"` response is no longer
+  handled by navigating away from Tailor. The Tailor workspace now runs the same SSE fit-analysis
+  stream itself on catching that 409, then retries the bootstrap — the candidate never leaves
+  the workspace. The bootstrap's server contract (still 409s without a cached analysis) is
+  unchanged; only the frontend's response to it changes.
+- The Job Match tab's internal layout (live score above the labelled fit-analysis snapshot) is
+  **unchanged** — it was already the correct separation. The Score (ATS-readability) tab is
+  **explicitly not folded in**: `tailor-ats-delta` already forbids sharing a tab with the
+  job-anchored match score, a lesson kept from a prior "Verdict tab" design that mixed them and
+  was reverted for being unreadable.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `job-fit-analysis`: the "Dedicated fit analysis page" and "Sidebar reduced to a summary linking
+  to the page" requirements described a standalone page (drifted in the current spec text to the
+  superseded `/jobs/[slug]/fit` path; the page actually lives at `/match/[slug]` today). Both
+  requirements are replaced: there is no dedicated fit-analysis page any more, and the entry point
+  for running/viewing the analysis is the Tailor workspace's Job Match tab, which triggers the
+  stream itself when no cached analysis exists.
+- `tailor-workspace`: the CV-list requirement's premise that "a tailored CV is created only from
+  the match page" no longer holds — a tailored CV (and its fit analysis) can now be created
+  directly by opening `/tailor/[slug]` for a vacancy that has none yet.
+
+## Impact
+
+- Removed: `web/src/routes/match/[slug]/+page.svelte`, `+page.server.ts`.
+- Changed: `web/src/routes/jobs/[slug]/fit/+page.ts` (redirect target); a new redirect at
+  `web/src/routes/match/[slug]/+page.ts`; `web/src/routes/tailor/[slug]/+page.svelte` (409 handling
+  runs the fit stream inline instead of `goto`-ing away).
+- Changed link targets: `web/src/lib/components/MatchSummary.svelte` (two `resolve('/match/[slug]', ...)`
+  call sites) and any other job-card/drawer entry points that link to `/match/[slug]`.
+- Unaffected: `ArtifactPanel.svelte` tab set and the Score/ATS-delta tab, `MatchAnalysisFull.svelte`
+  itself (still used, just no longer given its own route), `cvmatch`/`matchanalysis` scoring logic,
+  `/my/activity/matches`, `/my/profile`'s `ATSReportView`.

--- a/openspec/changes/match-tailor-merge/specs/job-fit-analysis/spec.md
+++ b/openspec/changes/match-tailor-merge/specs/job-fit-analysis/spec.md
@@ -1,0 +1,67 @@
+## REMOVED Requirements
+
+### Requirement: Dedicated fit analysis page
+
+**Reason**: The standalone fit-analysis page is removed; the Tailor workspace's Job Match tab
+(`/tailor/[slug]`) becomes the sole surface for viewing and triggering the analysis, so a candidate
+never leaves the tailoring workspace to produce a first analysis.
+
+**Migration**: Requests to the former page path (`/match/[slug]`, and its earlier legacy alias
+`/jobs/[slug]/fit`) redirect (308) to `/tailor/[slug]`. See the new "Fit analysis surfaces in the
+tailoring workspace" requirement below for the replacement behavior.
+
+## ADDED Requirements
+
+### Requirement: Fit analysis surfaces in the tailoring workspace
+
+The SPA SHALL NOT provide a dedicated, standalone fit-analysis page. The Tailor workspace's Job
+Match tab (`/tailor/[slug]`) is the sole surface presenting the full analysis (overall score +
+verdict, the six dimensions with their rationale, the ATS requirement match, strengths, gaps,
+recommendation). When the tailoring bootstrap returns an existing cached analysis, the tab renders
+it immediately from that response. When the bootstrap reports no cached analysis exists (`409 "run
+the fit analysis first"`), the workspace SHALL open the fit-analysis stream itself and render the
+stage progress, the thinking panel, and each section progressively as it resolves, retrying the
+bootstrap once the stream completes — the candidate is never sent to a separate page to produce a
+first analysis.
+
+Requests to the former standalone page path (`/match/[slug]`) and its earlier legacy alias
+(`/jobs/[slug]/fit`) SHALL redirect (308) to `/tailor/[slug]`.
+
+#### Scenario: Cached analysis renders from the bootstrap response
+
+- **WHEN** the user opens `/tailor/[slug]` for a vacancy with a fresh cached analysis
+- **THEN** the Job Match tab shows the full analysis immediately, with no separate fetch or stream
+
+#### Scenario: No cached analysis streams inline
+
+- **WHEN** the user opens `/tailor/[slug]` for a vacancy with no cached analysis
+- **THEN** the workspace opens the fit-analysis stream in place, shows the stage stepper and fills
+  the overall/dimensions/requirements/verdict sections as each stage resolves, then retries the
+  tailoring bootstrap so the workspace loads with the completed analysis
+
+#### Scenario: Old links redirect into the workspace
+
+- **WHEN** a request is made to `/match/[slug]` or `/jobs/[slug]/fit`
+- **THEN** the system responds with a 308 redirect to `/tailor/[slug]`
+
+## MODIFIED Requirements
+
+### Requirement: Sidebar reduced to a summary linking to the page
+
+The Profile-match sidebar block SHALL show only a short fit summary — the overall percentage, the
+verdict label, and the single most important gap — with a link to the dedicated page. It MUST NOT
+run the analysis inline. When no analysis is cached it MUST show an action that navigates to the
+page (which starts the stream) rather than computing in the sidebar.
+
+The "dedicated page" this links to is the Tailor workspace (`/tailor/[slug]`), not a separate
+fit-analysis page — see "Fit analysis surfaces in the tailoring workspace".
+
+#### Scenario: Sidebar summarizes and links
+
+- **WHEN** a cached analysis exists and the user views the job
+- **THEN** the sidebar shows the overall %, the verdict, and the top gap, with a link to `/tailor/[slug]`
+
+#### Scenario: Sidebar with no analysis links to the workspace
+
+- **WHEN** no analysis is cached
+- **THEN** the sidebar shows an action that navigates to `/tailor/[slug]` instead of computing inline

--- a/openspec/changes/match-tailor-merge/specs/tailor-workspace/spec.md
+++ b/openspec/changes/match-tailor-merge/specs/tailor-workspace/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: The CV list re-opens sessions and has no create action
+
+The CV list SHALL show the user's tailored CVs, each linking to its tailoring workspace
+(`/tailor/[slug]?cv=<id>`, resume), and SHALL NOT offer a create action — a tailored CV is created
+by opening the tailoring workspace for a vacancy (`/tailor/[slug]`), which bootstraps one if none
+exists yet; there is no separate page to create it from. The list MUST carry the job slug and the
+session id needed to build each re-open link.
+
+#### Scenario: A list item re-opens its workspace
+
+- **WHEN** the user clicks a tailored CV in the list
+- **THEN** they land on that CV's tailoring workspace with its existing session
+
+#### Scenario: There is no create button
+
+- **WHEN** the user views the CV list
+- **THEN** no "create CV" action is shown

--- a/openspec/changes/match-tailor-merge/tasks.md
+++ b/openspec/changes/match-tailor-merge/tasks.md
@@ -1,0 +1,45 @@
+## 1. Tailor workspace absorbs the fit-analysis trigger
+
+- [ ] 1.1 In `web/src/routes/tailor/[slug]/+page.svelte`, replace the `409 "run the fit analysis
+      first"` handler (currently `goto(resolve('/match/[slug]', { slug }))`) with logic that opens
+      the existing fit-analysis SSE stream (`$lib/matchAnalysis.ts`) in place.
+- [ ] 1.2 Render the stream's stage progress (stepper, thinking panel, progressive section fill) in
+      the Job Match tab while it runs, reusing the presentation already built for `MatchAnalysisFull`
+      rather than duplicating it.
+- [ ] 1.3 On stream completion, retry the tailoring bootstrap so the workspace loads normally with
+      the now-cached analysis. On stream failure, surface the error state the stream already emits
+      (do not silently fall back to a dead workspace).
+
+## 2. Repoint in-app links to `/tailor/[slug]`
+
+- [ ] 2.1 Update `web/src/lib/components/MatchSummary.svelte`'s two `resolve('/match/[slug]', ...)`
+      call sites to `resolve('/tailor/[slug]', ...)`.
+- [ ] 2.2 Grep the rest of `web/src` for other `/match/[slug]` link targets (job cards, `JobDrawer`,
+      `SwipeDeck`, `JobView`) and repoint each to `/tailor/[slug]`.
+
+## 3. Redirects for old paths
+
+- [ ] 3.1 Update `web/src/routes/jobs/[slug]/fit/+page.ts` to redirect (308) to
+      `/tailor/${params.slug}` instead of `/match/${params.slug}`.
+- [ ] 3.2 Add `web/src/routes/match/[slug]/+page.ts` (new file) redirecting (308) to
+      `/tailor/${params.slug}`.
+
+## 4. Remove the standalone page
+
+- [ ] 4.1 Delete `web/src/routes/match/[slug]/+page.svelte` and its `+page.server.ts`, only after
+      task 3.2's redirect route is in place so the path never dead-ends.
+
+## 5. Verify
+
+- [ ] 5.1 `pnpm check` / `pnpm build` in `web/` pass with no route-resolution errors from the
+      removed page or the changed link targets.
+- [ ] 5.2 Manually open `/tailor/[slug]` for a vacancy with no cached analysis; confirm the stream
+      runs inline, the workspace never navigates away, and the Job Match tab ends up showing the
+      completed analysis.
+- [ ] 5.3 Manually open `/tailor/[slug]` for a vacancy with a fresh cached analysis; confirm it
+      renders immediately from the bootstrap response with no stream.
+- [ ] 5.4 Manually hit the old `/match/[some-slug]` and `/jobs/[some-slug]/fit` URLs; confirm both
+      308-redirect to `/tailor/[some-slug]`.
+- [ ] 5.5 Confirm the Job Match tab's internal layout (live score above the labelled fit snapshot)
+      and the separate Score/ATS-delta tab are both visually unchanged from before this change —
+      this change touches routing and the bootstrap trigger only, not tab layout.

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -72,10 +72,10 @@
     // Extra content rendered above the pane, handed the staged store so it can edit it
     // (e.g. the profile editor's "import skills from CV").
     extra?: Snippet<[StagedFilters]>;
-    // The "Match" pane: a client-only threshold over the viewer's own profile skills,
-    // not a JobFilters facet (the match percent depends on who's looking, so there's
-    // nothing to put in JobFilters/the URL — see JobsView's `minMatch`). The rail entry
-    // is hidden unless the caller has a real percent to filter on.
+    // The "Minimum skill match" slider atop the Skills pane: a client-only threshold
+    // over the viewer's own profile skills, not a JobFilters facet (the match percent
+    // depends on who's looking, so there's nothing to put in JobFilters/the URL — see
+    // JobsView's `minMatch`). Hidden unless the caller has a real percent to filter on.
     matchAvailable?: boolean;
     minMatch?: number | null;
     onMinMatchChange?: (value: number | null) => void;
@@ -120,15 +120,11 @@
   const SECTIONS: RailSection[] = ['SAVED', ...RAIL_SECTIONS];
 
   // Rail entries visible under the current scope: restricted to `railKeys` when given,
-  // a 'facet' entry is hidden when its param is excluded (e.g. Company on a company
-  // page), and 'match' is hidden unless the caller has a real percent to filter on.
+  // and a 'facet' entry is hidden when its param is excluded (e.g. Company on a company page).
   const visibleRail = $derived([
     ...(hasSavedTab ? [SAVED_ENTRY] : []),
     ...RAIL.filter(
-      (e) =>
-        (!railKeys || railKeys.includes(e.key)) &&
-        !(e.facetParam && exclude.includes(e.facetParam)) &&
-        (e.kind !== 'match' || matchAvailable),
+      (e) => (!railKeys || railKeys.includes(e.key)) && !(e.facetParam && exclude.includes(e.facetParam)),
     ),
   ]);
 
@@ -149,7 +145,9 @@
     if (e.kind === 'language') return selCount(f, 'english_level') + selCount(f, 'posting_language');
     if (e.kind === 'relocation') return selCount(f, 'relocation') + (f.visa ? 1 : 0);
     if (e.kind === 'posted') return f.postedWithinDays != null ? 1 : 0;
-    if (e.kind === 'match') return minMatch != null ? 1 : 0;
+    // The Minimum skill match threshold lives at the top of the Skills pane, so it
+    // counts toward that tab's badge alongside the skills facet selections.
+    if (e.key === 'skills') return selCount(f, 'skills') + (minMatch != null ? 1 : 0);
     return selCount(f, e.facetParam ?? e.key);
   }
 
@@ -268,6 +266,24 @@
     <LocationPane store={staged} counts={c} />
   {:else if entry.kind === 'facet'}
     {@const def = facetDefFor(entry.facetParam)}
+    {#if entry.key === 'skills' && matchAvailable}
+      <!-- Client-only post-filter (see `minMatch`/`onMinMatchChange` props): re-filters
+           the already-fetched page in memory, so it applies immediately, no debounce. -->
+      <div class="mb-2 flex items-center justify-between">
+        <h3 class="text-sm font-semibold tracking-tight">Minimum skill match</h3>
+        <span class="text-xs font-medium text-muted-foreground">{minMatch != null ? `${minMatch}%+` : 'Any'}</span>
+      </div>
+      <input
+        type="range"
+        min="0"
+        max="100"
+        step="5"
+        value={minMatch ?? 0}
+        oninput={(e) => onMinMatchChange?.(Number(e.currentTarget.value) || null)}
+        aria-label="Minimum skill match"
+        class="mb-6 w-full accent-primary"
+      />
+    {/if}
     {#if def}<FacetSection {def} store={staged} counts={c} expand />{/if}
   {:else if entry.kind === 'salary'}
     <ChipFacet store={staged} param="salary_currency" label="Currency" counts={c} />
@@ -322,23 +338,6 @@
       value={freshnessIndex}
       oninput={(e) => staged.setPostedWithinDays(FRESHNESS_PRESETS[Number(e.currentTarget.value)]?.days ?? null)}
       aria-label="Posted within"
-      class="w-full accent-primary"
-    />
-  {:else if entry.kind === 'match'}
-    <!-- Client-only post-filter (see `minMatch`/`onMinMatchChange` props): re-filters
-         the already-fetched page in memory, so it applies immediately, no debounce. -->
-    <div class="mb-2 flex items-center justify-between">
-      <h3 class="text-sm font-semibold tracking-tight">Minimum skill match</h3>
-      <span class="text-xs font-medium text-muted-foreground">{minMatch != null ? `${minMatch}%+` : 'Any'}</span>
-    </div>
-    <input
-      type="range"
-      min="0"
-      max="100"
-      step="5"
-      value={minMatch ?? 0}
-      oninput={(e) => onMinMatchChange?.(Number(e.currentTarget.value) || null)}
-      aria-label="Minimum skill match"
       class="w-full accent-primary"
     />
   {/if}

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -396,15 +396,6 @@ const REALITY: FacetOption[] = [
   { value: 'likely-evergreen', label: 'Likely evergreen' },
 ];
 
-// Tech vs non-tech: the deterministic is_tech facet (internal/jobderive), a small
-// closed set spelled out like REALITY. Unknown jobs carry no value (absent) and are
-// matched by neither bucket. Offered excludable so the common use is "exclude
-// Non-tech" to hide the non-engineering roles generic ATS boards pull in.
-const IS_TECH: FacetOption[] = [
-  { value: 'tech', label: 'Tech' },
-  { value: 'non_tech', label: 'Non-tech' },
-];
-
 const CURRENCY: FacetOption[] = [
   { value: 'USD', label: 'USD' },
   { value: 'EUR', label: 'EUR' },
@@ -532,7 +523,6 @@ export const FACETS: FacetDef[] = [
   { param: 'collections', label: 'Collection', control: 'pills', options: COLLECTION, excludable: false },
   { param: 'regions', label: 'Region', control: 'pills', options: JOB_REGION, excludable: true },
   { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
-  { param: 'is_tech', label: 'Tech / Non-tech', control: 'pills', options: IS_TECH, excludable: true },
   { param: 'role', label: 'Role', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search roles', cap: 8, related: ROLE_RELATED, searchAliases: ROLE_ALIASES },
   { param: 'category', label: 'Specialization', control: 'select', options: CATEGORY, excludable: true, placeholder: 'Search specializations' },
   { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -112,9 +112,6 @@ export type RailKind =
   | 'language'
   | 'relocation'
   | 'posted'
-  // Client-only profile-match threshold — not a facet param, see FilterModal's
-  // `minMatch` prop. Only shown when the caller marks it available.
-  | 'match'
   // The job modal's "My filters" (saved searches) tab — renders SavedSearches, not a facet control.
   | 'saved';
 
@@ -135,7 +132,6 @@ export const RAIL: RailEntry[] = [
   // reachable via the seniority pill); the picker is the natural-language entry,
   // the pills/chips the browse-by-axis entry.
   { key: 'category', label: 'Role', section: 'ROLE', kind: 'category' },
-  { key: 'is_tech', label: 'Tech / Non-tech', section: 'ROLE', kind: 'facet', facetParam: 'is_tech' },
   { key: 'location', label: 'Location', section: 'ROLE', kind: 'location' },
   { key: 'work', label: 'Work & employment', section: 'ROLE', kind: 'work' },
   { key: 'skills', label: 'Skills', section: 'ROLE', kind: 'facet', facetParam: 'skills' },
@@ -145,7 +141,4 @@ export const RAIL: RailEntry[] = [
   { key: 'language', label: 'Language', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'language' },
   { key: 'relocation', label: 'Relocation', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'relocation' },
   { key: 'posted', label: 'Posted', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'posted' },
-  // Hidden unless the caller marks it available (signed in, profile has skills) — see
-  // FilterModal's `matchAvailable` prop and the `visibleRail` filter.
-  { key: 'match', label: 'Match', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'match' },
 ];


### PR DESCRIPTION
## Summary
- Moves the "Minimum skill match" slider from its own "Match" rail tab to the top of the Skills tab in the job filters modal.
- Removes the standalone "Tech / Non-tech" facet toggle from the filters modal (and its now-unused facet definition).

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run` — 844/844 passed
- [x] `npx eslint` on changed files — clean