### PR TITLE
perf(db): denormalize semantic_outbox's claim sort key, drop the join

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -638,6 +638,7 @@ type SemanticOutbox struct {
 	FailedAt    pgtype.Timestamptz `json:"failed_at"`
 	LastError   string             `json:"last_error"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	JobPostedAt pgtype.Timestamptz `json:"job_posted_at"`
 }
 
 type Subscription struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -177,16 +177,26 @@ type Querier interface {
 	// Claim a batch of live, unleased entries, freshest job first, by stamping claimed_at.
 	// Unlike ClaimEnrichmentBatch this does NOT filter unindexable jobs out: a closed OR
 	// non-canonical (duplicate_of) entry is the removal signal, so the worker must receive
-	// it and branch on `closed` (true = remove the document). The jobs join supplies both
-	// the freshness order and that flag. Freshness is
-	// COALESCE(posted_at, created_at): jobs without a source post date fall back to ingest
-	// time so they rank by recency instead of starving under NULLS LAST. FOR UPDATE OF o
-	// locks only outbox rows (a bare FOR UPDATE would also lock jobs, making concurrent
-	// claim waves contend); SKIP LOCKED lets concurrent workers take disjoint rows; the
-	// lease predicate reclaims entries whose worker died (stale claimed_at), so no separate
-	// reaper process is needed.
+	// it and branch on `closed` (true = remove the document).
+	//
+	// Orders by the outbox's OWN job_posted_at (denormalized at enqueue time from
+	// COALESCE(jobs.posted_at, jobs.created_at) — see EnqueuePendingSemanticJobs) rather
+	// than joining jobs to compute it. A join-for-ordering here means Postgres cannot push
+	// the LIMIT below the sort — it has to nested-loop-join and sort the ENTIRE claimable
+	// set before taking the batch, independent of batch_size. Measured live on prod at
+	// ~906k claimable rows: 109s for a single claim call. See
+	// openspec/changes/prod-semantic-embed-steady-state/design.md Decision 8. NULLS LAST
+	// is defensive (every row written by EnqueuePendingSemanticJobs always populates the
+	// column; this only guards a row that predates the backfill migration).
+	//
+	// FOR UPDATE OF o locks only outbox rows (a bare FOR UPDATE would also lock jobs,
+	// making concurrent claim waves contend); SKIP LOCKED lets concurrent workers take
+	// disjoint rows; the lease predicate reclaims entries whose worker died (stale
+	// claimed_at), so no separate reaper process is needed.
 	// Join jobs off the claimable CTE (not the UPDATE target o, which Postgres forbids in
-	// FROM) so the removal branch gets the job's closed flag without a second query.
+	// FROM) so the removal branch gets the job's closed flag without a second query. This
+	// join is over just the claimed batch (batch_size rows), not the whole claimable set —
+	// cheap, unlike the ordering join this replaces above.
 	ClaimSemanticBatch(ctx context.Context, arg ClaimSemanticBatchParams) ([]ClaimSemanticBatchRow, error)
 	// Lease a batch of pending, live matches for active subscriptions by stamping
 	// claimed_at, oldest-claimable first, ordered by subscription so the worker can
@@ -751,7 +761,9 @@ type Querier interface {
 	//      mirrors the facet index: the full reindex --semantic also drops reposts (shared
 	//      splitJobs), so the incremental path must not re-add them.
 	// ON CONFLICT keeps exactly one entry per (job_id, target_model), so running this every
-	// command invocation never duplicates work.
+	// command invocation never duplicates work. job_posted_at denormalizes
+	// COALESCE(posted_at, created_at) onto the outbox row so ClaimSemanticBatch can sort by
+	// it without joining jobs on every claim (see that query's doc comment).
 	EnqueuePendingSemanticJobs(ctx context.Context, targetModel string) (int64, error)
 	// Queue a job for the live facet index. Called by cmd/ingest inside the same
 	// transaction as the job's upsert, only when the write inserted or changed indexed

--- a/internal/db/queries/semantic.sql
+++ b/internal/db/queries/semantic.sql
@@ -21,9 +21,11 @@
 --      mirrors the facet index: the full reindex --semantic also drops reposts (shared
 --      splitJobs), so the incremental path must not re-add them.
 -- ON CONFLICT keeps exactly one entry per (job_id, target_model), so running this every
--- command invocation never duplicates work.
-INSERT INTO semantic_outbox (job_id, target_model)
-SELECT id, sqlc.arg(target_model)::text
+-- command invocation never duplicates work. job_posted_at denormalizes
+-- COALESCE(posted_at, created_at) onto the outbox row so ClaimSemanticBatch can sort by
+-- it without joining jobs on every claim (see that query's doc comment).
+INSERT INTO semantic_outbox (job_id, target_model, job_posted_at)
+SELECT id, sqlc.arg(target_model)::text, COALESCE(posted_at, created_at)
 FROM jobs
 WHERE (
         closed_at IS NULL AND duplicate_of IS NULL
@@ -38,29 +40,38 @@ ON CONFLICT (job_id, target_model) DO NOTHING;
 -- Claim a batch of live, unleased entries, freshest job first, by stamping claimed_at.
 -- Unlike ClaimEnrichmentBatch this does NOT filter unindexable jobs out: a closed OR
 -- non-canonical (duplicate_of) entry is the removal signal, so the worker must receive
--- it and branch on `closed` (true = remove the document). The jobs join supplies both
--- the freshness order and that flag. Freshness is
--- COALESCE(posted_at, created_at): jobs without a source post date fall back to ingest
--- time so they rank by recency instead of starving under NULLS LAST. FOR UPDATE OF o
--- locks only outbox rows (a bare FOR UPDATE would also lock jobs, making concurrent
--- claim waves contend); SKIP LOCKED lets concurrent workers take disjoint rows; the
--- lease predicate reclaims entries whose worker died (stale claimed_at), so no separate
--- reaper process is needed.
+-- it and branch on `closed` (true = remove the document).
+--
+-- Orders by the outbox's OWN job_posted_at (denormalized at enqueue time from
+-- COALESCE(jobs.posted_at, jobs.created_at) — see EnqueuePendingSemanticJobs) rather
+-- than joining jobs to compute it. A join-for-ordering here means Postgres cannot push
+-- the LIMIT below the sort — it has to nested-loop-join and sort the ENTIRE claimable
+-- set before taking the batch, independent of batch_size. Measured live on prod at
+-- ~906k claimable rows: 109s for a single claim call. See
+-- openspec/changes/prod-semantic-embed-steady-state/design.md Decision 8. NULLS LAST
+-- is defensive (every row written by EnqueuePendingSemanticJobs always populates the
+-- column; this only guards a row that predates the backfill migration).
+--
+-- FOR UPDATE OF o locks only outbox rows (a bare FOR UPDATE would also lock jobs,
+-- making concurrent claim waves contend); SKIP LOCKED lets concurrent workers take
+-- disjoint rows; the lease predicate reclaims entries whose worker died (stale
+-- claimed_at), so no separate reaper process is needed.
 WITH claimable AS (
     SELECT o.id, o.job_id
     FROM semantic_outbox o
-    JOIN jobs j ON j.id = o.job_id
     WHERE o.failed_at IS NULL
       AND (o.claimed_at IS NULL
            OR o.claimed_at < now() - make_interval(secs => sqlc.arg(lease_seconds)::int))
-    ORDER BY COALESCE(j.posted_at, j.created_at) DESC, j.id DESC
+    ORDER BY o.job_posted_at DESC NULLS LAST, o.job_id DESC
     FOR UPDATE OF o SKIP LOCKED
     LIMIT sqlc.arg(batch_size)
 )
 UPDATE semantic_outbox o
 SET claimed_at = now()
 -- Join jobs off the claimable CTE (not the UPDATE target o, which Postgres forbids in
--- FROM) so the removal branch gets the job's closed flag without a second query.
+-- FROM) so the removal branch gets the job's closed flag without a second query. This
+-- join is over just the claimed batch (batch_size rows), not the whole claimable set —
+-- cheap, unlike the ordering join this replaces above.
 FROM claimable c
 JOIN jobs j ON j.id = c.job_id
 WHERE o.id = c.id

--- a/internal/db/semantic.sql.go
+++ b/internal/db/semantic.sql.go
@@ -15,11 +15,10 @@ const claimSemanticBatch = `-- name: ClaimSemanticBatch :many
 WITH claimable AS (
     SELECT o.id, o.job_id
     FROM semantic_outbox o
-    JOIN jobs j ON j.id = o.job_id
     WHERE o.failed_at IS NULL
       AND (o.claimed_at IS NULL
            OR o.claimed_at < now() - make_interval(secs => $1::int))
-    ORDER BY COALESCE(j.posted_at, j.created_at) DESC, j.id DESC
+    ORDER BY o.job_posted_at DESC NULLS LAST, o.job_id DESC
     FOR UPDATE OF o SKIP LOCKED
     LIMIT $2
 )
@@ -45,16 +44,26 @@ type ClaimSemanticBatchRow struct {
 // Claim a batch of live, unleased entries, freshest job first, by stamping claimed_at.
 // Unlike ClaimEnrichmentBatch this does NOT filter unindexable jobs out: a closed OR
 // non-canonical (duplicate_of) entry is the removal signal, so the worker must receive
-// it and branch on `closed` (true = remove the document). The jobs join supplies both
-// the freshness order and that flag. Freshness is
-// COALESCE(posted_at, created_at): jobs without a source post date fall back to ingest
-// time so they rank by recency instead of starving under NULLS LAST. FOR UPDATE OF o
-// locks only outbox rows (a bare FOR UPDATE would also lock jobs, making concurrent
-// claim waves contend); SKIP LOCKED lets concurrent workers take disjoint rows; the
-// lease predicate reclaims entries whose worker died (stale claimed_at), so no separate
-// reaper process is needed.
+// it and branch on `closed` (true = remove the document).
+//
+// Orders by the outbox's OWN job_posted_at (denormalized at enqueue time from
+// COALESCE(jobs.posted_at, jobs.created_at) — see EnqueuePendingSemanticJobs) rather
+// than joining jobs to compute it. A join-for-ordering here means Postgres cannot push
+// the LIMIT below the sort — it has to nested-loop-join and sort the ENTIRE claimable
+// set before taking the batch, independent of batch_size. Measured live on prod at
+// ~906k claimable rows: 109s for a single claim call. See
+// openspec/changes/prod-semantic-embed-steady-state/design.md Decision 8. NULLS LAST
+// is defensive (every row written by EnqueuePendingSemanticJobs always populates the
+// column; this only guards a row that predates the backfill migration).
+//
+// FOR UPDATE OF o locks only outbox rows (a bare FOR UPDATE would also lock jobs,
+// making concurrent claim waves contend); SKIP LOCKED lets concurrent workers take
+// disjoint rows; the lease predicate reclaims entries whose worker died (stale
+// claimed_at), so no separate reaper process is needed.
 // Join jobs off the claimable CTE (not the UPDATE target o, which Postgres forbids in
-// FROM) so the removal branch gets the job's closed flag without a second query.
+// FROM) so the removal branch gets the job's closed flag without a second query. This
+// join is over just the claimed batch (batch_size rows), not the whole claimable set —
+// cheap, unlike the ordering join this replaces above.
 func (q *Queries) ClaimSemanticBatch(ctx context.Context, arg ClaimSemanticBatchParams) ([]ClaimSemanticBatchRow, error) {
 	rows, err := q.db.Query(ctx, claimSemanticBatch, arg.LeaseSeconds, arg.BatchSize)
 	if err != nil {
@@ -103,8 +112,8 @@ func (q *Queries) DeleteSemanticEntriesBatch(ctx context.Context, ids []int64) e
 }
 
 const enqueuePendingSemanticJobs = `-- name: EnqueuePendingSemanticJobs :execrows
-INSERT INTO semantic_outbox (job_id, target_model)
-SELECT id, $1::text
+INSERT INTO semantic_outbox (job_id, target_model, job_posted_at)
+SELECT id, $1::text, COALESCE(posted_at, created_at)
 FROM jobs
 WHERE (
         closed_at IS NULL AND duplicate_of IS NULL
@@ -139,7 +148,9 @@ ON CONFLICT (job_id, target_model) DO NOTHING
 //     splitJobs), so the incremental path must not re-add them.
 //
 // ON CONFLICT keeps exactly one entry per (job_id, target_model), so running this every
-// command invocation never duplicates work.
+// command invocation never duplicates work. job_posted_at denormalizes
+// COALESCE(posted_at, created_at) onto the outbox row so ClaimSemanticBatch can sort by
+// it without joining jobs on every claim (see that query's doc comment).
 func (q *Queries) EnqueuePendingSemanticJobs(ctx context.Context, targetModel string) (int64, error) {
 	result, err := q.db.Exec(ctx, enqueuePendingSemanticJobs, targetModel)
 	if err != nil {

--- a/internal/db/semantic_integration_test.go
+++ b/internal/db/semantic_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -57,6 +58,19 @@ func semanticOutboxJobIDs(t *testing.T, pool *pgxpool.Pool) []int64 {
 		ids = append(ids, id)
 	}
 	return ids
+}
+
+// semanticOutboxJobPostedAt reads the denormalized freshness key ClaimSemanticBatch
+// sorts by directly, avoiding a join to jobs on every claim (see
+// openspec/changes/prod-semantic-embed-steady-state/design.md Decision 8).
+func semanticOutboxJobPostedAt(t *testing.T, pool *pgxpool.Pool, jobID int64) time.Time {
+	t.Helper()
+	var ts time.Time
+	if err := pool.QueryRow(context.Background(),
+		"SELECT job_posted_at FROM semantic_outbox WHERE job_id = $1", jobID).Scan(&ts); err != nil {
+		t.Fatalf("read job_posted_at: %v", err)
+	}
+	return ts
 }
 
 func semanticStamp(t *testing.T, pool *pgxpool.Pool, jobID int64) (model, hash *string) {
@@ -166,6 +180,26 @@ func TestSemanticEnqueue(t *testing.T) {
 		sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
 		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 			t.Errorf("enqueued = %v, want %v (closed+embedded queued for removal, closed+unembedded skipped)", got, want)
+		}
+	})
+
+	t.Run("job_posted_at is denormalized from COALESCE(posted_at, created_at)", func(t *testing.T) {
+		// ClaimSemanticBatch sorts by this column directly instead of joining jobs on
+		// every claim (design.md Decision 8) — it must stay in sync with the same
+		// COALESCE the claim ordering has always promised (the "undated jobs rank by
+		// created_at" test below asserts the ordering behavior this value feeds).
+		truncate(t, pool)
+		dated := insertJob(t, pool, "dated-posted")
+		setPostedAt(t, pool, dated, "2024-01-01T00:00:00Z")
+		undated := insertJob(t, pool, "undated-posted") // posted_at NULL, falls back to created_at
+		enqueue(t)
+		gotDated := semanticOutboxJobPostedAt(t, pool, dated)
+		if !gotDated.Equal(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)) {
+			t.Errorf("dated job_posted_at = %v, want 2024-01-01", gotDated)
+		}
+		gotUndated := semanticOutboxJobPostedAt(t, pool, undated)
+		if gotUndated.Before(time.Now().Add(-time.Minute)) {
+			t.Errorf("undated job_posted_at = %v, want ~now (fell back to created_at)", gotUndated)
 		}
 	})
 

--- a/migrations/0080_semantic_outbox_job_posted_at.sql
+++ b/migrations/0080_semantic_outbox_job_posted_at.sql
@@ -1,0 +1,52 @@
+-- migrate: no-transaction
+--
+-- ClaimSemanticBatch orders by COALESCE(jobs.posted_at, jobs.created_at) via a join to
+-- jobs, so Postgres cannot push the LIMIT below the sort: it nested-loop-joins EVERY
+-- claimable row against jobs before sorting and taking the batch. Measured live on prod
+-- at ~906k claimable rows: 109s for a single claim call, independent of batch size (see
+-- openspec/changes/prod-semantic-embed-steady-state/design.md Decision 8 for the full
+-- EXPLAIN ANALYZE). Denormalizing the sort key onto semantic_outbox itself lets the
+-- claim query use a plain index scan with no join.
+--
+-- Nullable — not NOT NULL — deliberately: a SET NOT NULL on a 900k+ row table takes an
+-- exclusive lock to validate. The application always populates this column going
+-- forward (EnqueuePendingSemanticJobs); ORDER BY ... NULLS LAST in the claim query is
+-- defensive insurance for any row that predates the backfill below, not a load-bearing
+-- requirement — jobs.created_at (the COALESCE fallback) is itself NOT NULL DEFAULT
+-- now(), so a NULL can only arise from a row this migration's own backfill missed.
+--
+-- Correction: jobs.posted_at is NOT immutable post-ingest — UpsertJob's ON CONFLICT DO
+-- UPDATE overwrites it unconditionally on every re-ingest (internal/db/queries/jobs.sql),
+-- and a moderator edit can change it too. semantic_outbox's ON CONFLICT (job_id,
+-- target_model) DO NOTHING means an already-queued row's job_posted_at can go stale
+-- relative to a later posted_at change — the same staleness class this table's
+-- created_at column already accepts under the identical ON CONFLICT DO NOTHING. Accepted:
+-- it self-heals the moment the row is claimed and re-derived fresh next enqueue, and
+-- affects only claim ORDER (which job gets embedded first under backlog), never
+-- correctness (which jobs get embedded, or duplicated).
+--
+-- WHY no-transaction, and why the index is CONCURRENTLY: mirrors 0078
+-- (jobs_source_id_idx) for the identical reason — semantic_outbox is under continuous
+-- prod write traffic (cmd/ingest's enqueue, cmd/embed's claim/update/failure paths), and
+-- a plain CREATE INDEX holds a SHARE lock blocking writes for the whole build.
+-- CONCURRENTLY takes SHARE UPDATE EXCLUSIVE instead, blocking neither readers nor
+-- writers, at the cost of two table passes. ADD COLUMN (no default) is metadata-only
+-- (PG11+); the backfill UPDATE below takes only row-level locks as it proceeds, not a
+-- table-level one, so it does not need the same treatment.
+--
+-- Applied to a fresh volume by initdb after 0079; on an existing prod volume run this
+-- manually (SET ROLE hire) BEFORE deploying code that reads/writes the column.
+ALTER TABLE public.semantic_outbox ADD COLUMN job_posted_at timestamp with time zone;
+
+-- One-time backfill for rows already queued before this column existed.
+UPDATE public.semantic_outbox o
+SET job_posted_at = COALESCE(j.posted_at, j.created_at)
+FROM public.jobs j
+WHERE j.id = o.job_id
+  AND o.job_posted_at IS NULL;
+
+-- Partial index over the claimable set (mirrors semantic_outbox_claimable_idx's WHERE
+-- clause), pre-sorted in the exact order ClaimSemanticBatch's CTE now requests — a plain
+-- index scan with LIMIT, no join, no materialize-then-sort.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS semantic_outbox_claim_idx ON public.semantic_outbox
+    USING btree (job_posted_at DESC, job_id DESC) WHERE (failed_at IS NULL);

--- a/openspec/changes/prod-semantic-embed-steady-state/.openspec.yaml
+++ b/openspec/changes/prod-semantic-embed-steady-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/prod-semantic-embed-steady-state/design.md
+++ b/openspec/changes/prod-semantic-embed-steady-state/design.md
@@ -1,0 +1,226 @@
+## Context
+
+`cmd/embed` (`internal/embed`) already implements exactly the pattern wanted: drain
+`semantic_outbox`, embed via TEI, write the vector to `jobs.semantic_embedding`
+(Postgres) and upsert into `jobs_semantic` (Meilisearch) in one transaction per batch
+— the semantic-index sibling of `search-drain`. `EnqueuePendingSemanticJobs` already
+gates on `is_tech IS TRUE` (durable code, not a hack) and `reindex --semantic
+--from-pg` already rebuilds `jobs_semantic` cleanly from Postgres-persisted vectors
+without re-embedding. None of this needs to be built — it needs to be **run and
+scheduled**, which never happened after the incremental worker shipped (PR #522,
+2026-07-09 — the steady-state cron was a TODO that was never done).
+
+What's running instead is a leftover: `/opt/freehire/embed-supervisor.sh` +
+`freehire-embed-supervisor.service`, a one-off wrapper for a since-abandoned
+HuggingFace-GPU-endpoint bulk-embed. It restarted `cmd/embed` every ~16 minutes,
+paying `EnsureSemanticIndex`'s `settingsUpdate` tax (~150-217s) on every restart —
+the 2026-07-23 livelock. It last completed 2026-07-26 and has been dormant since.
+
+Systemd units for host2 live in a separate repo, `~/Projects/freehire-ops`
+(`provision/host2/systemd/`). `freehire-search-drain.service`/`.timer` is the direct
+template — same shape of problem (a Postgres-outbox-driven, Meilisearch-writing,
+run-until-empty worker on a shared single-task-queue engine), including a scar from
+a real incident (2026-08-06: search-drain's CPU/IO weight cut 40→10 after it
+coincided with nginx accept-queue starvation). **Correction (caught in code
+review):** as of this writing `origin/main`'s `freehire-search-drain.service` does
+NOT yet have a guard against the facet reindex — that guard exists only on an
+unrelated, unmerged local branch (`ops/web-accept-queue-watchdog`) in the same repo.
+This change's `freehire-embed.service` adds an equivalent guard on its own merits
+(design.md Decision 4), not by copying an already-shipped convention.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Close the current ~380k un-embedded backlog once.
+- Stand up a real, boring, recurring cron for `cmd/embed` — no custom supervisor,
+  no hang-detection heuristics, no HF-endpoint lifecycle management.
+- Publish a `jobs_semantic` index that reflects current reality (no closed jobs).
+
+**Non-Goals:**
+- Not enabling hybrid search for end users (`web/src/lib/api.ts`'s `semantic_ratio`
+  stays 0) — a separate, later product decision.
+- Not changing `cmd/embed`, the `is_tech` gate, or the `--from-pg` path — all
+  already correct.
+- Not moving off local TEI to a GPU/HF endpoint — local TEI throughput (~33 docs/s
+  at batch=2000) is adequate for both the one-time catch-up (hours, not days) and
+  hourly steady-state deltas (small).
+
+## Decisions
+
+**1. One-time backfill: run `cmd/embed` directly, not through any supervisor**
+The 07-23 livelock was caused by a wrapper restarting the worker every 16 minutes,
+not by the worker itself. `cmd/embed`'s own `Run()` loop already drains until
+`ClaimSemanticBatch` returns empty (same shape as `search-drain`), so a single
+un-supervised run is sufficient — the `settingsUpdate` tax is paid once (~150-217s),
+not repeatedly. Launch as a transient `systemd-run` unit (survives an SSH drop,
+journal-logged) with `EMBED_BATCH_SIZE=2000` (measured ~33 docs/s vs. ~500's slower
+per-batch overhead) and no other overrides — default `EMBED_CONCURRENCY=1` is kept
+because raising it was measured not to help (TEI's e5-base is thread-bound
+regardless of client concurrency, per prior investigation).
+
+**2. Pause `search-drain`'s timer during the one-time backfill only**
+The backfill and `search-drain` write to different Meilisearch indexes
+(`jobs_semantic` vs `jobs`) but share ONE task queue engine-wide — confirmed
+repeatedly this session (the facet-reindex-vs-search-drain contention). A ~380k-doc
+backfill running for hours next to a 2-minute-cadence facet drain would slow both.
+Stop `freehire-search-drain.timer` before launching the backfill, restart it after.
+This is a manual one-off ops step, not baked into any unit file.
+
+**3. The steady-state hourly timer does NOT pause search-drain**
+Unlike the one-time backfill, an hourly steady-state run only has a small delta to
+embed (new/changed jobs since the last hour) — brief, infrequent contention with
+search-drain's 2-minute cadence is not worth adding cross-unit coordination for.
+
+**4. The steady-state timer guards against the facet reindex, independently justified
+(not copying an already-shipped convention — see the Context correction above)**
+`freehire-reindexw` is the one worker whose lost progress is expensive (a multi-hour
+swap-rebuild, atomic). `cmd/embed` gets a guard: skip this tick entirely if
+`freehire-reindexw.service` is running, never contend for it.
+
+**Bug found and fixed before shipping**: the first version used
+`ExecStartPre=/bin/sh -c '! systemctl is-active --quiet freehire-reindexw.service'`.
+`systemctl is-active --quiet` reports success (exit 0) ONLY for the exact `active`
+state — a `Type=oneshot` unit mid-`ExecStart` (`freehire-reindexw`'s state for its
+*entire* multi-hour run, confirmed live on host2 this session) reports `activating`,
+which `is-active --quiet` treats as NOT active. The naive guard would have silently
+no-op'd during the one window it exists to catch — verified empirically on host2
+with a synthetic oneshot "blocker" unit before this shipped: the naive guard let a
+guarded test unit start while the blocker was still `activating`. Fixed by matching
+on the known-clear states instead of the busy ones (`case ... in inactive|failed)
+exit 0;; *) exit 1;; esac` — fails safe/blocks on any state it doesn't recognize).
+
+**Also verified empirically**: a code-review concern was whether a failing
+`ExecStartPre` could desync the timer's `OnUnitActiveSec` scheduling into a rapid
+retry storm (risking `start-limit-hit` and a silently-stuck, permanently-failed
+unit). Observed on host2 over several real cycles with the blocker held active: the
+timer rescheduled cleanly on its normal interval every time, regardless of whether
+`ExecStartPre` passed or failed — no rapid retries, no `start-limit-hit`. No
+`StartLimitIntervalSec`/`StartLimitBurst` override needed.
+
+**5. Conservative CPU/IO weight from day one**
+`search-drain` shipped at `CPUWeight=40`/`IOWeight=40` and only got cut to 10/10
+after causing nginx accept-queue starvation. `cmd/embed`'s per-doc cost (a TEI call
++ a Postgres write + a Meili push) is heavier than search-drain's (Meili push only),
+and it has zero steady-state track record. Ship the new unit at `CPUWeight=10` /
+`IOWeight=10` from the start rather than repeat the same discovery-by-incident.
+
+**6. Hourly cadence (`OnUnitActiveSec=1h`)**
+User's explicit choice. Slower than search-drain's 2min (embedding costs more per
+doc than a facet push) but still far more current than the status quo (nothing,
+indefinitely). Revisit if product ever turns hybrid search on for users and 1h
+staleness proves noticeable.
+
+**7. Delete the old supervisor outright, not disable-in-place**
+It is not tracked in `freehire-ops` (a hand-placed file/unit on host2 only) and its
+entire purpose (HF-GPU-endpoint lifecycle + hang-detection for a flaky restart loop)
+is obsolete once a plain recurring timer exists. Nothing depends on it.
+
+**8. Denormalize the freshness sort key into `semantic_outbox` — `ClaimSemanticBatch`
+was doing an O(claimable-set) join+sort on every call, not an O(batch-size) one
+(found live during the backfill, code change, scope revised from the original
+"no Go code changes" premise)**
+The one-time backfill measured `EMBED_BATCH_SIZE=2000` at only ~6.2 docs/s
+(not the ~33-49 docs/s the Risk mitigation below originally assumed), and bumping
+to 5000 only reached ~14 docs/s — a real fix, not just a bigger lever on the same
+one. `EXPLAIN (ANALYZE, BUFFERS)` on the live query (~906k claimable rows at the
+time) showed why: `ClaimSemanticBatch`'s CTE does `ORDER BY
+COALESCE(j.posted_at, j.created_at) DESC, j.id DESC` via a join to `jobs` — since
+the sort key lives on the JOINED table, Postgres cannot push the `LIMIT` down
+before the join; it nested-loop-joins ALL ~906k claimable rows against `jobs`
+(906,305 individual index lookups, ~96.6s of I/O alone) THEN sorts the whole
+result (external merge, spilling 47MB to disk) THEN takes the batch. Total: 109s
+for a single claim, regardless of `batch_size` — the fixed cost search-drain's own
+`EMBED_BATCH_SIZE` mitigation *was* correctly amortizing on `cmd/embed`'s TEI/PG
+per-doc costs, but not on this one, which scales with the CLAIMABLE SET size, not
+the requested batch size.
+
+Fix: add `semantic_outbox.job_posted_at timestamptz` (copy of
+`COALESCE(jobs.posted_at, jobs.created_at)`, written once at enqueue time by
+`EnqueuePendingSemanticJobs`) plus a partial index
+`(job_posted_at DESC, job_id DESC) WHERE failed_at IS NULL`. `ClaimSemanticBatch`'s
+CTE then orders by `o.job_posted_at` directly — no join needed for the ordering,
+so Postgres can walk the index in exactly the required order and stop at `LIMIT`,
+the same shape `search_outbox_claimable_idx` already gives `search-drain` (though
+that index isn't freshness-ordered — `ClaimSearchOutboxBatch` has the textually
+identical join-for-ordering pattern and is presumably exposed to the same cost at
+a large enough backlog; NOT fixed here, out of scope, flagged for awareness only).
+**Correction (caught in code review): `jobs.posted_at` is NOT immutable
+post-ingest.** `UpsertJob`'s `ON CONFLICT DO UPDATE` overwrites it unconditionally
+on every re-ingest (`internal/db/queries/jobs.sql`), and a moderator edit can
+change it too. Combined with `semantic_outbox`'s `ON CONFLICT (job_id,
+target_model) DO NOTHING`, an already-queued row's `job_posted_at` can go stale
+relative to a later `posted_at` change on the same job — a real behavior change
+from the old live-join query, which always read current `posted_at`. Accepted:
+this is the identical staleness class the outbox's own `created_at` column
+already carries under the same `ON CONFLICT DO NOTHING` (the fresh-first ordering
+comment on `EnqueuePendingSemanticJobs` never claimed otherwise for that column),
+it self-heals the moment the row is claimed and would be re-derived fresh on the
+job's next real change, and it affects only claim ORDER (which job embeds first
+under backlog) — never correctness (which jobs get embedded, or duplicated).
+
+Column left nullable (no `SET NOT NULL`) to avoid an extra full-table-scan-under-
+lock on a 900k+ row table mid-migration — the app always populates it going
+forward and the migration backfills existing rows; `ORDER BY ... NULLS LAST` is
+defensive insurance, not load-bearing (`jobs.created_at`, the COALESCE fallback,
+is itself `NOT NULL DEFAULT now()`, so a NULL can only arise from a row this
+migration's own backfill missed).
+
+**Also corrected in review: the index needs `CONCURRENTLY`, not a plain
+`CREATE INDEX`.** `semantic_outbox` is under continuous prod write traffic
+(`cmd/ingest`'s enqueue, `cmd/embed`'s claim/update/failure paths); a plain
+`CREATE INDEX` holds a `SHARE` lock blocking writes for the whole build. This
+repo has an established, recent precedent for exactly this
+(`migrations/0078_jobs_source_id_idx.sql`, applied to prod the same day this
+change was authored): `-- migrate: no-transaction` plus
+`CREATE INDEX CONCURRENTLY IF NOT EXISTS`. The migration now follows that
+pattern.
+
+## Risks / Trade-offs
+
+- **[Risk] The one-time backfill hits the same TEI/Postgres contention pattern that
+  made the July HF bulk-embed slow (~19 docs/s effective vs. GPU's raw throughput,
+  dominated by `ClaimSemanticBatch`'s sort + full job-row loads)** → **Mitigation,
+  REVISED**: `EMBED_BATCH_SIZE=2000`/`5000` alone was NOT sufficient (measured
+  ~6.2 then ~14 docs/s, not 33-49) — the actual fix is Decision 8's denormalized
+  sort key, a real code change. Batch size still matters for the OTHER per-wave
+  costs (TEI call batching, Meili push) but was masking, not causing, the
+  dominant cost here.
+- **[Risk] Backfill runs unattended for hours; TEI or the process could die
+  mid-run** → **Mitigation**: `cmd/embed`'s claim/lease design (mirrors
+  `search-drain`/`enrich`) means a dead worker just leaves its leased batch to
+  expire and get reclaimed by the next run — safe to simply restart the same
+  `systemd-run` command if it dies, no cleanup needed.
+- **[Risk] Publishing via `reindex --semantic --from-pg` while the hourly timer might
+  also fire** → **Mitigation**: run the one-time publish manually, watching it
+  complete, before considering the change "done" — don't rely on the timer's first
+  automatic fire to also happen to catch a clean state. No code-level mutual
+  exclusion exists between them, but this is a one-time launch step, not a repeating
+  hazard (both `cmd/embed` steady-state and `reindex --semantic --from-pg` are
+  idempotent — an accidental overlap wastes some duplicate work, doesn't corrupt
+  anything).
+
+## Migration Plan
+
+1. Author `freehire-embed.service` + `freehire-embed.timer` in `freehire-ops`
+   (`provision/host2/systemd/`), PR + merge that repo (separately from `hire` — no
+   `hire` code changes in this proposal).
+2. On host2: stop `freehire-search-drain.timer`.
+3. Launch the one-time backfill as a transient `systemd-run` unit,
+   `EMBED_BATCH_SIZE=2000`, monitor to completion (~380k / ~33/s ≈ 3-4h, best-effort
+   estimate — could be worse under load, matching this session's facet-reindex
+   experience).
+4. Restart `freehire-search-drain.timer`.
+5. Run `reindex --semantic --from-pg` once, monitor to completion, verify
+   `jobs_semantic`'s doc count and spot-check that previously-stale (closed) ids are
+   gone.
+6. Delete `/opt/freehire/embed-supervisor.sh`, `/opt/freehire/embed-supervisor.log`,
+   and disable+delete `freehire-embed-supervisor.service`.
+7. Install + enable the new `freehire-embed.timer`; verify one live tick completes
+   cleanly (small delta, fast).
+8. **Rollback**: `systemctl disable --now freehire-embed.timer` — no data loss risk,
+   the worker is a pure incremental drain; stopping it just means semantic freshness
+   reverts to "stale until next manual run," the same state this change started from.
+
+## Open Questions
+
+None.

--- a/openspec/changes/prod-semantic-embed-steady-state/proposal.md
+++ b/openspec/changes/prod-semantic-embed-steady-state/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+`cmd/embed` (the incremental semantic-embedding worker, `internal/embed`) shipped in
+PR #522 (2026-07-09) — it drains `semantic_outbox` and, per job, embeds via TEI and
+writes the vector to both Postgres (`jobs.semantic_embedding`) and the live
+`jobs_semantic` Meilisearch index in one transaction, exactly mirroring how
+`search-drain` drains `search_outbox` into the facet index. But the steady-state cron
+for it was a TODO that was never completed. What exists instead is an ad-hoc
+one-off bulk-backfill wrapper (`/opt/freehire/embed-supervisor.sh` +
+`freehire-embed-supervisor.service`) built for an abandoned HuggingFace-GPU-endpoint
+approach, which livelocked in July and has been dormant since it last completed on
+2026-07-26. Nothing has embedded a job since then.
+
+Measured live on host2 (2026-08-09): 439,054 jobs are eligible (open, non-duplicate,
+`is_tech=TRUE`), only 59,061 carry a current vector — a ~380k backlog. The live
+`jobs_semantic` index (729,078 docs) is stale: a 40-id sample found 70% no longer
+exist in the live facet index. TEI is alive, idle, with real host headroom.
+
+## What Changes
+
+- One-time manual backfill run of `cmd/embed` to close the ~380k gap (not via the old
+  supervisor script).
+- New `freehire-embed.service` + `freehire-embed.timer` in `freehire-ops`
+  (`provision/host2/systemd/`), modeled on `freehire-search-drain`'s pair, hourly
+  cadence (`OnUnitActiveSec=1h` — embedding is heavier per-doc than a facet push, and
+  hourly freshness is acceptable for now).
+- Delete the dormant `/opt/freehire/embed-supervisor.sh` +
+  `freehire-embed-supervisor.service` on host2 (not tracked in `freehire-ops` — a
+  hand-placed file, so this is a host2-only cleanup, no repo change for the deletion
+  itself).
+- After the backfill, run `reindex --semantic --from-pg` (already-shipped) once to
+  publish a clean `jobs_semantic` built fresh from Postgres-persisted vectors —
+  drops the stale/closed entries the dormant worker left behind.
+- **Explicitly out of scope**: `web/src/lib/api.ts`'s hardcoded `semantic_ratio=0`
+  stays untouched. Enabling hybrid search for end users is a separate future decision.
+- **Scope revised mid-flight (design.md Decision 8)**: the backfill itself surfaced a
+  real `ClaimSemanticBatch` performance bug (an O(claimable-set) join+sort instead of
+  O(batch-size) — 109s per claim call, measured live via `EXPLAIN ANALYZE`, not fixed
+  by batch-size tuning alone). This now includes ONE Go/SQL code change: a new
+  `semantic_outbox.job_posted_at` column (denormalized freshness key) + a migration +
+  updated `EnqueuePendingSemanticJobs`/`ClaimSemanticBatch` queries. Everything else
+  (`cmd/embed` itself, the `is_tech` gate, `--from-pg` rehydration) is still unchanged,
+  already-shipped code.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+(none — no application-code requirement changes; this restores an already-designed
+worker to its intended steady-state operation and cleans up its live index.)
+
+## Impact
+
+- `freehire-ops` repo: new `provision/host2/systemd/freehire-embed.service` +
+  `freehire-embed.timer`.
+- host2: delete `/opt/freehire/embed-supervisor.sh` +
+  `freehire-embed-supervisor.service` (+ its `.log` if present); install and enable
+  the new timer.
+- Data: `jobs.semantic_embedding` gains ~380k more current vectors; `jobs_semantic`
+  Meilisearch index gets rebuilt clean via `--from-pg`.
+- `hire` repo: new migration (`semantic_outbox.job_posted_at` + index),
+  `internal/db/queries/semantic.sql` (`EnqueuePendingSemanticJobs`,
+  `ClaimSemanticBatch`), regenerated `internal/db` — see design.md Decision 8.
+- Note: `freehire-ops`'s working tree currently carries OTHER unrelated uncommitted
+  changes (`.env.example`, `README.md`, a modified `freehire-search-drain.service`,
+  new `freehire-site-alert.*` files) — pre-existing work from elsewhere. This change
+  must not touch, revert, or bundle those; only the new embed unit files are staged.

--- a/openspec/changes/prod-semantic-embed-steady-state/tasks.md
+++ b/openspec/changes/prod-semantic-embed-steady-state/tasks.md
@@ -1,0 +1,131 @@
+## 1. Author systemd units (freehire-ops repo)
+
+- [x] 1.1 Create `provision/host2/systemd/freehire-embed.service` in
+      `freehire-ops`, modeled on `freehire-search-drain.service`: `Type=oneshot`,
+      `User=freehire`, `WorkingDirectory=/opt/freehire/src/hire-current`,
+      `EnvironmentFile=/opt/freehire/.env`, `CPUWeight=10`, `IOWeight=10`, a
+      reindexw guard (skip this tick if a facet reindex is running — design.md
+      Decision 4), `ExecStart=/opt/freehire/src/hire-current/embed`.
+      Did NOT touch the already-modified `freehire-search-drain.service` in the same
+      directory — confirmed via `git status`/`git diff origin/main` (proposal.md
+      Impact note).
+      **Code review + empirical host2 testing found the initial guard
+      (`! systemctl is-active --quiet freehire-reindexw.service`) silently
+      no-ops during reindexw's actual multi-hour run (state=`activating`, not
+      `active`) — fixed to match on the known-clear states instead. Also verified
+      the timer reschedules cleanly regardless of ExecStartPre outcome (no
+      start-limit-hit risk). See design.md Decision 4.**
+- [x] 1.2 Create `provision/host2/systemd/freehire-embed.timer`: hourly
+      (`OnUnitActiveSec=1h`, `OnBootSec=5min`, `Persistent=true`,
+      `WantedBy=timers.target`) — design.md Decision 6.
+- [x] 1.3 Stage ONLY the two new files (`git add` by exact path, not `-A`) — the
+      working tree has unrelated uncommitted changes that must not be bundled
+      (proposal.md Impact note). Verified: worktree branched fresh from
+      `origin/main`, isolated from the parent checkout's WIP branch entirely.
+
+## 2. One-time backfill (host2 ops)
+
+- [x] 2.1 Confirm current backlog size and `freehire-reindexw.service` is not
+      active before starting (don't stack with a facet reindex — same class of
+      hazard this session hit repeatedly). Confirmed: 378,604 pending, reindexw
+      inactive.
+- [x] 2.2 `systemctl stop freehire-search-drain.timer` (design.md Decision 2). Its
+      already-running service instance (not just the timer) also had to be
+      stopped directly — same permanent-daemon pattern hit earlier this session.
+- [x] 2.3 Launch `cmd/embed` as a transient `systemd-run` unit with
+      `EMBED_BATCH_SIZE=2000` (design.md Decision 1). Do NOT use the old
+      `embed-supervisor.sh`. First real batch: 1941 docs in 5m12s (~6.2/s) — far
+      below the ~33/s expected. Retried at `EMBED_BATCH_SIZE=5000`: 4857 in
+      5m46s (~14/s) — better but still not the expected rate. `EXPLAIN ANALYZE`
+      isolated the real cause to `ClaimSemanticBatch` itself (109s/call,
+      independent of batch size) — see the new Section 2a below; the backfill
+      was paused (worker stopped) pending that fix.
+- [ ] 2.4 Once Section 2a ships, relaunch the backfill (same command) and monitor
+      to completion (journal + `semantic_outbox` claimable count trending to 0).
+      If the process dies, just relaunch the same command — safe per design.md's
+      lease-based risk mitigation.
+- [ ] 2.5 `systemctl start freehire-search-drain.timer`.
+
+## 2a. Fix ClaimSemanticBatch's O(claimable-set) claim cost (hire repo, code)
+
+Discovered mid-backfill (task 2.3) via `EXPLAIN (ANALYZE, BUFFERS)` on the live
+query: see design.md Decision 8 for the full root-cause writeup and design.
+
+- [ ] 2a.1 RED: add a failing integration test in `internal/db` asserting
+      `ClaimSemanticBatch` returns rows in `job_posted_at DESC` order using the
+      new column (not a join to `jobs`), and that `EnqueuePendingSemanticJobs`
+      populates `job_posted_at` correctly (`COALESCE(posted_at, created_at)`) for
+      both the add/update and closed-removal enqueue paths.
+- [ ] 2a.2 Add migration `0080_semantic_outbox_job_posted_at.sql`:
+      `ALTER TABLE semantic_outbox ADD COLUMN job_posted_at timestamptz`
+      (nullable — no `SET NOT NULL`, design.md Decision 8), a one-time
+      `UPDATE ... FROM jobs` backfill for existing rows, and
+      `CREATE INDEX semantic_outbox_claim_idx ON semantic_outbox
+      (job_posted_at DESC, job_id DESC) WHERE failed_at IS NULL`. Apply to prod
+      BEFORE deploying the code that reads/writes the column (existing repo
+      convention for outbox-table migrations, per 0004/0076's own header
+      comments).
+- [ ] 2a.3 GREEN: update `EnqueuePendingSemanticJobs` to write `job_posted_at =
+      COALESCE(posted_at, created_at)` on insert; update `ClaimSemanticBatch`'s
+      CTE to `ORDER BY o.job_posted_at DESC NULLS LAST, o.job_id DESC` with no
+      join (the outer `UPDATE ... RETURNING` join to `jobs` for the `closed` flag
+      stays — it's only over the small claimed batch, not the whole claimable
+      set). `make sqlc` (or the pinned local binary — Docker timed out earlier
+      today) to regenerate.
+- [x] 2a.4a Code review found two real issues, both fixed:
+      **(1)** the migration used a plain `CREATE INDEX` on a 900k+ row table under
+      continuous prod write traffic — no lock safety. Fixed to
+      `-- migrate: no-transaction` + `CREATE INDEX CONCURRENTLY IF NOT EXISTS`,
+      matching the exact precedent `migrations/0078_jobs_source_id_idx.sql`
+      already set. **(2)** design.md's "jobs.posted_at is immutable post-ingest"
+      claim was checked against the code and is false — `UpsertJob`'s
+      `ON CONFLICT DO UPDATE` overwrites it every re-ingest. Impact is low
+      (ordering staleness only, self-heals, no data loss/duplication — the same
+      class of staleness `created_at` already accepts under the same
+      `ON CONFLICT DO NOTHING`), corrected in design.md rather than requiring a
+      redesign. Re-ran the full integration suite after both fixes — all green,
+      including `CREATE INDEX CONCURRENTLY` inside `no-transaction` applying
+      cleanly against a fresh test Postgres.
+- [ ] 2a.4b Verify the fix live: re-run `EXPLAIN (ANALYZE, BUFFERS)` against prod
+      with the new query/index and confirm claim time drops from ~109s to
+      near-instant.
+- [x] 2a.5 Full verification suite: `go build/vet ./...`,
+      `go test ./...`, `go vet -tags=integration ./...`,
+      `go test -tags=integration ./internal/db/... ./cmd/embed/...`. All green.
+- [ ] 2a.6 PR, merge, deploy (`release.sh freehire`) — applies the migration to
+      prod as part of the deploy (matches how 0078 was applied the same way,
+      confirmed earlier this session).
+
+## 3. Publish a clean jobs_semantic (host2 ops)
+
+- [ ] 3.1 Run `reindex --semantic --from-pg`, monitor to completion.
+- [ ] 3.2 Verify: `jobs_semantic` doc count is sane (close to the eligible-jobs
+      count from proposal.md's measurement, adjusted for backlog closed since);
+      spot-check a few ids that were confirmed stale/closed before this change no
+      longer appear.
+
+## 4. Retire the old supervisor (host2 ops)
+
+- [ ] 4.1 `systemctl disable --now freehire-embed-supervisor.service`.
+- [ ] 4.2 `rm /opt/freehire/embed-supervisor.sh /opt/freehire/embed-supervisor.log`
+      (and `/etc/systemd/system/freehire-embed-supervisor.service`) — confirmed not
+      tracked in `freehire-ops` (only mentioned in an unrelated runbook doc), so no
+      repo-side deletion needed.
+
+## 5. Install and verify the new steady-state timer (host2 ops)
+
+- [ ] 5.1 Copy the two new unit files from the merged `freehire-ops` checkout to
+      `/etc/systemd/system/`, `systemctl daemon-reload`,
+      `systemctl enable --now freehire-embed.timer`.
+- [ ] 5.2 Wait for (or manually trigger) one tick; verify it completes cleanly with
+      a small delta (journal shows a normal drain-to-empty, not a multi-hour run —
+      confirms the backlog from Section 2 actually cleared).
+
+## 6. Verify
+
+- [ ] 6.1 `semantic_outbox` claimable count near 0 in steady state.
+- [ ] 6.2 `jobs_semantic` doc count matches the eligible-jobs count within normal
+      drift.
+- [ ] 6.3 No `freehire-embed-supervisor` unit or leftover files remain on host2.
+- [ ] 6.4 `web/src/lib/api.ts`'s `semantic_ratio` unchanged (still 0) — confirms
+      scope discipline (proposal.md's explicit out-of-scope item).


### PR DESCRIPTION
## Summary

- `ClaimSemanticBatch` ordered by `COALESCE(jobs.posted_at, jobs.created_at)` via a join to `jobs`, so Postgres couldn't push the `LIMIT` below the sort — it nested-loop-joined EVERY claimable row against `jobs` before sorting and taking the batch, independent of batch size. Measured live on prod via `EXPLAIN (ANALYZE, BUFFERS)` at ~906k claimable rows: **109 seconds for a single claim call**, dominated by 906,305 individual index lookups (~96.6s of I/O). Found mid-flight running the one-time semantic-embedding backfill in `openspec/changes/prod-semantic-embed-steady-state/` — bumping `EMBED_BATCH_SIZE` only amortized this cost (6.2 → 14 docs/s), it didn't fix the cause.
- Adds `semantic_outbox.job_posted_at` (denormalized at enqueue time by `EnqueuePendingSemanticJobs`) plus a partial index matching the claim's exact `WHERE`+`ORDER BY` shape, so `ClaimSemanticBatch` can walk the index directly with no join.
- **Found and fixed during review:**
  1. The migration originally used a plain `CREATE INDEX` on a 900k+ row table under continuous prod write traffic — no lock safety. Fixed to `-- migrate: no-transaction` + `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, matching this repo's own established precedent (`migrations/0078_jobs_source_id_idx.sql`).
  2. The design doc's "`jobs.posted_at` is immutable post-ingest" claim was checked against the code and is false — `UpsertJob`'s `ON CONFLICT DO UPDATE` overwrites it on every re-ingest. Impact is low (ordering staleness only — the same class already accepted for the outbox's own `created_at` under the identical `ON CONFLICT DO NOTHING`; self-heals on claim, never affects correctness), corrected in the design doc rather than requiring a redesign.
- All existing claim-ordering tests (`fresher jobs are claimed first`, `undated jobs rank by created_at`) pass unchanged against the new implementation — pure performance change, verified behavior-preserving.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test -tags=integration ./internal/db/... ./cmd/embed/... ./internal/embed/...` (real Postgres via testcontainers, includes `CREATE INDEX CONCURRENTLY` inside `no-transaction` applying cleanly)
- [ ] After merge + deploy: re-run `EXPLAIN (ANALYZE, BUFFERS)` on prod, confirm claim time drops from ~109s to near-instant; resume the one-time backfill