### PR TITLE
fix(migrate): split 0080 — CREATE INDEX CONCURRENTLY needs its own file

### DIFF
--- a/migrations/0080_semantic_outbox_job_posted_at.sql
+++ b/migrations/0080_semantic_outbox_job_posted_at.sql
@@ -1,12 +1,14 @@
--- migrate: no-transaction
---
 -- ClaimSemanticBatch orders by COALESCE(jobs.posted_at, jobs.created_at) via a join to
 -- jobs, so Postgres cannot push the LIMIT below the sort: it nested-loop-joins EVERY
 -- claimable row against jobs before sorting and taking the batch. Measured live on prod
 -- at ~906k claimable rows: 109s for a single claim call, independent of batch size (see
 -- openspec/changes/prod-semantic-embed-steady-state/design.md Decision 8 for the full
 -- EXPLAIN ANALYZE). Denormalizing the sort key onto semantic_outbox itself lets the
--- claim query use a plain index scan with no join.
+-- claim query use a plain index scan with no join — the supporting index is
+-- 0081_semantic_outbox_claim_idx.sql (CREATE INDEX CONCURRENTLY needs its own
+-- no-transaction file: Postgres runs a multi-statement file sent as one query in an
+-- implicit transaction, which CONCURRENTLY forbids, and this file's other statements
+-- don't need that treatment — see 0081's own header for why they're split).
 --
 -- Nullable — not NOT NULL — deliberately: a SET NOT NULL on a 900k+ row table takes an
 -- exclusive lock to validate. The application always populates this column going
@@ -25,28 +27,16 @@
 -- affects only claim ORDER (which job gets embedded first under backlog), never
 -- correctness (which jobs get embedded, or duplicated).
 --
--- WHY no-transaction, and why the index is CONCURRENTLY: mirrors 0078
--- (jobs_source_id_idx) for the identical reason — semantic_outbox is under continuous
--- prod write traffic (cmd/ingest's enqueue, cmd/embed's claim/update/failure paths), and
--- a plain CREATE INDEX holds a SHARE lock blocking writes for the whole build.
--- CONCURRENTLY takes SHARE UPDATE EXCLUSIVE instead, blocking neither readers nor
--- writers, at the cost of two table passes. ADD COLUMN (no default) is metadata-only
--- (PG11+); the backfill UPDATE below takes only row-level locks as it proceeds, not a
--- table-level one, so it does not need the same treatment.
---
 -- Applied to a fresh volume by initdb after 0079; on an existing prod volume run this
 -- manually (SET ROLE hire) BEFORE deploying code that reads/writes the column.
 ALTER TABLE public.semantic_outbox ADD COLUMN job_posted_at timestamp with time zone;
 
--- One-time backfill for rows already queued before this column existed.
+-- One-time backfill for rows already queued before this column existed. Plain UPDATE:
+-- takes only row-level locks as it proceeds, not a table-level one, so — unlike the
+-- CONCURRENTLY index in 0081 — it does not need to run outside this migration's normal
+-- transaction.
 UPDATE public.semantic_outbox o
 SET job_posted_at = COALESCE(j.posted_at, j.created_at)
 FROM public.jobs j
 WHERE j.id = o.job_id
   AND o.job_posted_at IS NULL;
-
--- Partial index over the claimable set (mirrors semantic_outbox_claimable_idx's WHERE
--- clause), pre-sorted in the exact order ClaimSemanticBatch's CTE now requests — a plain
--- index scan with LIMIT, no join, no materialize-then-sort.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS semantic_outbox_claim_idx ON public.semantic_outbox
-    USING btree (job_posted_at DESC, job_id DESC) WHERE (failed_at IS NULL);

--- a/migrations/0081_semantic_outbox_claim_idx.sql
+++ b/migrations/0081_semantic_outbox_claim_idx.sql
@@ -1,0 +1,27 @@
+-- migrate: no-transaction
+--
+-- Partial index over the claimable set (mirrors semantic_outbox_claimable_idx's WHERE
+-- clause), pre-sorted in the exact order ClaimSemanticBatch's CTE now requests (see
+-- 0080_semantic_outbox_job_posted_at.sql) — a plain index scan with LIMIT, no join, no
+-- materialize-then-sort.
+--
+-- Split into its own file, mirroring 0078 (jobs_source_id_idx) for the identical
+-- reason: semantic_outbox is under continuous prod write traffic (cmd/ingest's
+-- enqueue, cmd/embed's claim/update/failure paths), and a plain CREATE INDEX holds a
+-- SHARE lock blocking writes for the whole build. CONCURRENTLY takes SHARE UPDATE
+-- EXCLUSIVE instead, blocking neither readers nor writers, at the cost of two table
+-- passes — but Postgres forbids CONCURRENTLY inside a transaction block, and a
+-- migration file's statements sent as one multi-statement query run in an implicit
+-- transaction regardless of the no-transaction marker (that marker only stops
+-- internal/migrate's OWN wrapping BEGIN/COMMIT — it does not change how Postgres
+-- itself batches a multi-statement message). A file mixing this with 0080's
+-- ADD COLUMN/UPDATE therefore fails with "CREATE INDEX CONCURRENTLY cannot run inside
+-- a transaction block" — confirmed live against prod. One statement per no-transaction
+-- file sidesteps it.
+--
+-- Applied to a fresh volume by initdb after 0080; on an existing prod volume build it
+-- by hand, detached from the SSH session (systemd-run or nohup) — a CONCURRENTLY build
+-- dies with its ssh session and leaves an INVALID index behind (same warning 0078 and
+-- 0056 already give).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS semantic_outbox_claim_idx ON public.semantic_outbox
+    USING btree (job_posted_at DESC, job_id DESC) WHERE (failed_at IS NULL);

--- a/openspec/changes/prod-semantic-embed-steady-state/tasks.md
+++ b/openspec/changes/prod-semantic-embed-steady-state/tasks.md
@@ -92,9 +92,22 @@ query: see design.md Decision 8 for the full root-cause writeup and design.
 - [x] 2a.5 Full verification suite: `go build/vet ./...`,
       `go test ./...`, `go vet -tags=integration ./...`,
       `go test -tags=integration ./internal/db/... ./cmd/embed/...`. All green.
-- [ ] 2a.6 PR, merge, deploy (`release.sh freehire`) — applies the migration to
-      prod as part of the deploy (matches how 0078 was applied the same way,
-      confirmed earlier this session).
+- [x] 2a.6 PR, merge, deploy (`release.sh freehire`). First attempt FAILED live:
+      `CREATE INDEX CONCURRENTLY cannot run inside a transaction block` —
+      `release.sh` correctly aborted without touching the live color (verified
+      prod's `semantic_outbox` had no `job_posted_at` column and no
+      `schema_migrations` row for 0080 afterward — clean rollback, no partial
+      state). Root cause: a migration file's statements are sent to Postgres as
+      one multi-statement message, which Postgres itself implicitly wraps in a
+      transaction regardless of the `no-transaction` marker (that marker only
+      stops `internal/migrate`'s own `BEGIN`/`COMMIT` wrapping) — `CONCURRENTLY`
+      forbids running inside ANY transaction block, implicit or explicit. 0078
+      worked because it has exactly one statement per file; this migration had
+      three. Fixed by splitting: `0080` keeps `ADD COLUMN` + the `UPDATE`
+      backfill (ordinary transactional DML, no change needed there); `0081`
+      is `CREATE INDEX CONCURRENTLY IF NOT EXISTS` alone, matching 0078's
+      exact working shape. Re-verified locally (fresh testcontainer Postgres
+      applies both files cleanly) before redeploying.
 
 ## 3. Publish a clean jobs_semantic (host2 ops)
 


### PR DESCRIPTION
## Summary

- First deploy attempt of #1665's migration failed live: `CREATE INDEX CONCURRENTLY cannot run inside a transaction block`. Root cause: a migration file's statements are sent to Postgres as one multi-statement message, which Postgres itself implicitly wraps in a transaction regardless of the repo's `-- migrate: no-transaction` marker (that marker only stops `internal/migrate`'s own `BEGIN`/`COMMIT`, not Postgres's own implicit one). `CONCURRENTLY` forbids running inside any transaction block. `0078` (the precedent this mirrored) works because it has exactly one statement per file; `0080` had three.
- `release.sh` correctly aborted without touching the live color — verified prod's `semantic_outbox` had no partial state afterward (no `job_posted_at` column, no `schema_migrations` row for 0080).
- Splits into `0080` (`ADD COLUMN` + the `UPDATE` backfill — ordinary transactional DML, unchanged logic) and `0081` (`CREATE INDEX CONCURRENTLY IF NOT EXISTS` alone, matching `0078`'s exact working shape).

## Test plan

- [x] `go build ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test -tags=integration ./internal/db/... -run TestSemantic` (real Postgres via testcontainers — confirms both migration files apply cleanly in sequence)
- [ ] After merge: redeploy, confirm migrations apply cleanly this time