### PR TITLE
fix(deps): bump nanoid to 3.3.17 and dompurify to 3.4.13

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   cookie@<0.7.0: 0.7.2
   postcss@<8.5.23: 8.5.23
+  nanoid@<3.3.17: 3.3.17
+  dompurify@<3.4.13: 3.4.13
 
 importers:
 
@@ -1586,8 +1588,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -2163,8 +2165,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4102,7 +4104,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -4391,7 +4393,7 @@ snapshots:
 
   isomorphic-dompurify@3.19.0:
     dependencies:
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       jsdom: 29.1.1
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -4640,7 +4642,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -4756,7 +4758,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4766,7 +4768,7 @@ snapshots:
       '@posthog/core': 1.44.0
       '@posthog/types': 1.397.1
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       fflate: 0.4.9
       preact: 10.29.7
       query-selector-shadow-dom: 1.0.1

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -17,3 +17,10 @@ overrides:
   # path when `from` is unset, letting a crafted stylesheet exfiltrate
   # arbitrary local .map files. Pulled in transitively by vite/eslint-plugin-svelte.
   postcss@<8.5.23: 8.5.23
+  # GHSA-qrpm-p2h7-hrv2: nanoid's custom-alphabet generator can loop forever
+  # when passed size 0. Pulled in transitively by postcss.
+  nanoid@<3.3.17: 3.3.17
+  # GHSA-jjrf-c9pj-88w6: DOMPurify's IN_PLACE hook path leaves a detached DOM
+  # subtree with executable content, allowing XSS despite sanitization.
+  # isomorphic-dompurify is used directly for XSS sanitization in this app.
+  dompurify@<3.4.13: 3.4.13


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #9 (GHSA-qrpm-p2h7-hrv2, high): `nanoid`'s custom-alphabet generator can loop indefinitely when passed size 0. Transitive via `postcss`.
- Resolves Dependabot alert #8 (GHSA-jjrf-c9pj-88w6, moderate): DOMPurify's `IN_PLACE` hook path leaves a detached DOM subtree with executable content, allowing XSS despite sanitization. `isomorphic-dompurify` (used directly for XSS sanitization in this app) and `posthog-js` pull it in transitively.
- Both pinned via `pnpm-workspace.yaml` overrides, same pattern as the recent `postcss`/`cookie` GHSA fixes.

## Test plan
- [x] `pnpm install` in `web/` — lockfile now resolves `nanoid@3.3.17` and `dompurify@3.4.13`
- [x] `pnpm run check` passes (0 errors)