### PR TITLE
SEO: live counts, more collections, and a job-page see-also block

### DIFF
--- a/docs/superpowers/specs/2026-08-09-programmatic-seo-filter-and-company-collections-design.md
+++ b/docs/superpowers/specs/2026-08-09-programmatic-seo-filter-and-company-collections-design.md
@@ -1,26 +1,38 @@
-# Programmatic SEO: cross-linked filter & company collections
+# Programmatic SEO: collection count-in-title & job-page cross-links
 
 **Date:** 2026-08-09
 **Status:** approved, not yet planned/implemented
 
 ## Problem
 
-`freehire` already has a job-facet-based programmatic SEO surface
-(`/collections/[slug]`, backed by `FILTER_COLLECTIONS` in `web/src/lib/collections.ts`)
-covering remote-region and skill landing pages. Three gaps limit its SEO value:
+`freehire` already has a unified `/collections/[slug]` programmatic SEO surface
+covering **two** kinds of collection: filter collections (`FILTER_COLLECTIONS` in
+`web/src/lib/collections.ts` — remote-region, skill, category, seniority, role
+landings, frontend-only) and company collections (`internal/collections`'s
+registry — YC, Techstars, a16z, Big Tech, Unicorns, visa-sponsor registers —
+propagated onto every job as `jobs.collections` and resolved through the same
+route via `COLLECTIONS` in `web/src/lib/generated/contracts.ts`). Two gaps limit
+its SEO value:
 
 1. Its `<title>`/`<h1>`/OG tags are static strings — they never surface the live
    job count, so search snippets look generic and don't communicate freshness/scale.
-2. The collection list is small and hand-picked; several obvious high-intent
-   patterns (more countries, more roles, more skills) aren't covered.
-3. There's no internal-link path from a job posting into these collection pages,
-   so Google has to discover and re-crawl them independently rather than reaching
-   them from the highest-volume page type on the site (job postings).
-4. Company-level facets that already exist as filterable data — YC status
-   (`yc_flags`, `yc_batch`), industry, company type — have no landing-page
-   equivalent at all; they're only reachable via manual `/companies?...` filters.
+   This applies to both collection kinds, since they render through the one route.
+2. The filter-collection list is small and hand-picked; several obvious
+   high-intent patterns (more countries, more roles, more skills) aren't covered.
+3. There's no internal-link path from a job posting into either collection kind's
+   landing pages, so Google has to discover and re-crawl them independently
+   rather than reaching them from the highest-volume page type on the site (job
+   postings).
+
+Company-level landing pages (YC, Big Tech, etc.) already exist and are
+out of scope here — the only gap for them is #1 and #3 above, both already
+covered by the design below since the two kinds share one route.
 
 ## Non-goals
+
+- No new company-collection page type or route — `/collections/yc` and its
+  siblings already exist (`internal/collections`'s registry, unified with
+  `FILTER_COLLECTIONS` through `collectionBySlug`). Nothing here duplicates that.
 
 - No auto-generated cross-product of every facet combination. Combinations stay
   hand-curated (same discipline as today's `FILTER_COLLECTIONS`: each entry is
@@ -78,68 +90,50 @@ that already exist as first-class dictionary entries (`internal/skilltag`,
 No structural change to the `FilterCollection` type or the route — this is
 purely growing the array.
 
-### 3. New company-collection page type
-
-Mirrors the job-collection pattern one-to-one for company-level facets
-(`yc_flags`, `yc_batch`, `company_type`, `subindustry` — all already
-filterable on `GET /api/v1/companies`, per `internal/ycdir/AGENTS.md` and
-`internal/handler/companies.go`).
-
-- New data file, same shape as `FilterCollection`: `slug`, `title`,
-  `description`, `params` (company-search facet params instead of job-search
-  ones). Lives alongside `FILTER_COLLECTIONS` in `collections.ts` as e.g.
-  `COMPANY_FILTER_COLLECTIONS`, or a sibling file if that keeps the module
-  focused — implementation's call.
-- New route `web/src/routes/companies/collections/[slug]/+page.svelte` +
-  `+page.server.ts`, structurally mirroring `collections/[slug]`: resolve slug
-  → params, SSR the first page of `/companies` filtered by those params, live
-  count from the list response total.
-- Title/H1/OG pattern matches part 1: `"{total} {title} · freehire"`, e.g.
-  `"142 YC Companies Hiring · freehire"`.
-- First entries: YC-backed (`yc_flags` overlap on `hiring` and/or `top_company`),
-  possibly split by `yc_batch` era if counts justify it. Do not import YC
-  `tier` as a facet (project convention, per `hire-backer-badges-shipped`:
-  tier is not meant to be surfaced as a market-facing facet).
-
-### 4. "See also" block on the job posting page
+### 3. "See also" block on the job posting page
 
 New component (or inline block) on `web/src/routes/jobs/[slug]` (the job
-detail page) rendering a fixed-size set of internal links
-(target ~4-6) built from two independent sources, evaluated at SSR time using
-data the job page already has loaded (its own facets, and its company's
-`yc_flags`):
+detail page) rendering a fixed-size set of internal links (target ~4-6) built
+from two independent sources, evaluated at SSR time using data the job page
+already has loaded — its own facets, and its own `collections` field (already
+populated by the existing propagation from company membership, per
+`internal/collections`):
 
 - **Source A — job facets:** the current job's role/category, region
   (country/remote-region), and skills, matched against existing
   `FILTER_COLLECTIONS` entries (exact `params` match against the job's own
   facet values — e.g. job has `skills: ['react']` → matches the `react`
   collection entry).
-- **Source B — company facts:** if the job's company has YC flags set, match
-  against `COMPANY_FILTER_COLLECTIONS` (e.g. `yc_flags` includes `hiring` →
-  link to the YC-hiring company collection).
+- **Source B — company collections:** the job's own `collections` field (e.g.
+  `['yc']` for a YC-backed company's job) matched against the existing
+  `COLLECTIONS` registry (`web/src/lib/generated/contracts.ts`, mirroring
+  `internal/collections`) — no new data source, this field already exists on
+  every job today.
 - **Fill logic:** concatenate A then B matches (order: most specific first —
-  skill/role before region, job facets before company facts), dedupe by slug,
-  then if the combined count is below the target size, pad with a fixed
+  skill/role before region, job facets before company collections), dedupe by
+  slug, then if the combined count is below the target size, pad with a fixed
   fallback list of the most general/popular collections (e.g.
   `remote-worldwide`, top 1-2 skill collections) until the target is reached
   or the available collection pool is exhausted (never fabricate a link to a
   non-existent slug).
-- Every link target is a real, already-existing `/collections/[slug]` or
-  `/companies/collections/[slug]` page — this block never links to a slug
-  that isn't in one of the two curated arrays.
+- Every link target is a real, already-existing `/collections/[slug]` page
+  (the one unified route resolves both `FILTER_COLLECTIONS` and `COLLECTIONS`
+  slugs already) — this block never links to a slug that isn't in one of the
+  two curated arrays.
 - No live count fetch needed for the block itself (the linked pages compute
   their own count on load); the block only needs the two static arrays plus
-  the current job/company's already-loaded facet values.
+  the current job's already-loaded `collections`/facet values.
 
 ## Testing
 
 - Unit test for the "see also" matching/padding logic (source A + source B +
   dedupe + fallback-fill + never-exceed-available-pool), independent of any
-  HTTP call — pure function over (job facets, company facts, both collection
+  HTTP call — pure function over (job facets, job collections, both registry
   arrays) → ordered slug list.
-- Verify title/H1/OG count interpolation on both collection route types with
-  a fixture total (e.g. snapshot the rendered `<title>` string given a known
-  `meta.total`).
-- Manual check per new `FILTER_COLLECTIONS`/`COMPANY_FILTER_COLLECTIONS` entry
-  during implementation: live count is non-empty (same discipline as existing
-  entries), per the design's non-goal on avoiding thin pages.
+- Verify title/H1/OG count interpolation on `/collections/[slug]` with a
+  fixture total (e.g. snapshot the rendered `<title>` string given a known
+  `meta.total`), covering one filter-collection slug and one company-collection
+  slug since they share the route.
+- Manual check per new `FILTER_COLLECTIONS` entry during implementation: live
+  count is non-empty (same discipline as existing entries), per the design's
+  non-goal on avoiding thin pages.

--- a/docs/superpowers/specs/2026-08-09-programmatic-seo-filter-and-company-collections-design.md
+++ b/docs/superpowers/specs/2026-08-09-programmatic-seo-filter-and-company-collections-design.md
@@ -1,0 +1,145 @@
+# Programmatic SEO: cross-linked filter & company collections
+
+**Date:** 2026-08-09
+**Status:** approved, not yet planned/implemented
+
+## Problem
+
+`freehire` already has a job-facet-based programmatic SEO surface
+(`/collections/[slug]`, backed by `FILTER_COLLECTIONS` in `web/src/lib/collections.ts`)
+covering remote-region and skill landing pages. Three gaps limit its SEO value:
+
+1. Its `<title>`/`<h1>`/OG tags are static strings — they never surface the live
+   job count, so search snippets look generic and don't communicate freshness/scale.
+2. The collection list is small and hand-picked; several obvious high-intent
+   patterns (more countries, more roles, more skills) aren't covered.
+3. There's no internal-link path from a job posting into these collection pages,
+   so Google has to discover and re-crawl them independently rather than reaching
+   them from the highest-volume page type on the site (job postings).
+4. Company-level facets that already exist as filterable data — YC status
+   (`yc_flags`, `yc_batch`), industry, company type — have no landing-page
+   equivalent at all; they're only reachable via manual `/companies?...` filters.
+
+## Non-goals
+
+- No auto-generated cross-product of every facet combination. Combinations stay
+  hand-curated (same discipline as today's `FILTER_COLLECTIONS`: each entry is
+  added because it has a healthy non-empty live count and a plausible real
+  search pattern), to avoid thin/duplicate-content pages.
+- No new backend endpoint. Every count needed here is already returned by
+  `searchJobs(..., limit=0)` / `searchCompanies` list totals or `facetCounts`.
+- No keyword-volume-driven prioritization for the initial list — Search Console
+  isn't connected yet for this project. The initial expanded list is judgment-based
+  on standard job-board search patterns; it should be revisited once GSC data
+  or GA4 data is available.
+
+## Design
+
+### 1. Live job count in `/collections/[slug]` title / H1 / OG
+
+`collections/[slug]/+page.server.ts` already calls `serverApi(fetch).searchJobs(...)`
+to SSR the first page of jobs, and that response's `meta.total` is the exact
+same live count already available today (see `internal/handler` job list
+response shape: `{"data": ..., "meta": {"total": ...}}`). No new fetch, no
+caching — the number is already in hand at render time.
+
+- `<title>`: `"{total.toLocaleString()} {collection.title} · freehire"`
+  (e.g. `"1,234 React Jobs · freehire"`) — exact count, not rounded, per
+  explicit product decision (accepting that Google's cached snippet may lag
+  the live number between re-crawls, same tradeoff every job board with a
+  live counter makes).
+- `<h1>`: same count, e.g. `"1,234 React Jobs"` (today's H1 is just
+  `"{collection.title} jobs"` — insert the count).
+- OG title: mirrors `<title>`.
+- Edge case: `total === 0`. This shouldn't occur for collections already in
+  `FILTER_COLLECTIONS` (each is required to have a healthy non-empty count
+  before shipping), so no special empty-state copy is needed — if it ever
+  happens, it reads as "0 X Jobs," which is honest and not broken.
+
+### 2. Expand `FILTER_COLLECTIONS`
+
+Straightforward data addition to `web/src/lib/collections.ts`, following the
+existing entry shape (`slug`, `title`, `description`, `params`) and existing
+discipline (verify each new entry has a healthy live count via
+`searchJobs(params, 0, 0).total` before adding it — do this as part of
+implementation, not design). Candidate axes to grow, using only facet values
+that already exist as first-class dictionary entries (`internal/skilltag`,
+`internal/location` region/country codes, `internal/classify` role/category):
+
+- More country-level remote landings beyond the current six regions (e.g.
+  additional single-country remote pages where demand is plausible: Canada,
+  UK, India, Poland — verify count at implementation time).
+- More skill landings beyond the current set, for skilltag canonicals not yet
+  covered.
+- Role-level landings (e.g. `frontend-engineer`, `data-engineer`) alongside
+  the existing hand-curated `role` entries, reusing `internal/classify`
+  category/role vocabulary.
+
+No structural change to the `FilterCollection` type or the route — this is
+purely growing the array.
+
+### 3. New company-collection page type
+
+Mirrors the job-collection pattern one-to-one for company-level facets
+(`yc_flags`, `yc_batch`, `company_type`, `subindustry` — all already
+filterable on `GET /api/v1/companies`, per `internal/ycdir/AGENTS.md` and
+`internal/handler/companies.go`).
+
+- New data file, same shape as `FilterCollection`: `slug`, `title`,
+  `description`, `params` (company-search facet params instead of job-search
+  ones). Lives alongside `FILTER_COLLECTIONS` in `collections.ts` as e.g.
+  `COMPANY_FILTER_COLLECTIONS`, or a sibling file if that keeps the module
+  focused — implementation's call.
+- New route `web/src/routes/companies/collections/[slug]/+page.svelte` +
+  `+page.server.ts`, structurally mirroring `collections/[slug]`: resolve slug
+  → params, SSR the first page of `/companies` filtered by those params, live
+  count from the list response total.
+- Title/H1/OG pattern matches part 1: `"{total} {title} · freehire"`, e.g.
+  `"142 YC Companies Hiring · freehire"`.
+- First entries: YC-backed (`yc_flags` overlap on `hiring` and/or `top_company`),
+  possibly split by `yc_batch` era if counts justify it. Do not import YC
+  `tier` as a facet (project convention, per `hire-backer-badges-shipped`:
+  tier is not meant to be surfaced as a market-facing facet).
+
+### 4. "See also" block on the job posting page
+
+New component (or inline block) on `web/src/routes/jobs/[slug]` (the job
+detail page) rendering a fixed-size set of internal links
+(target ~4-6) built from two independent sources, evaluated at SSR time using
+data the job page already has loaded (its own facets, and its company's
+`yc_flags`):
+
+- **Source A — job facets:** the current job's role/category, region
+  (country/remote-region), and skills, matched against existing
+  `FILTER_COLLECTIONS` entries (exact `params` match against the job's own
+  facet values — e.g. job has `skills: ['react']` → matches the `react`
+  collection entry).
+- **Source B — company facts:** if the job's company has YC flags set, match
+  against `COMPANY_FILTER_COLLECTIONS` (e.g. `yc_flags` includes `hiring` →
+  link to the YC-hiring company collection).
+- **Fill logic:** concatenate A then B matches (order: most specific first —
+  skill/role before region, job facets before company facts), dedupe by slug,
+  then if the combined count is below the target size, pad with a fixed
+  fallback list of the most general/popular collections (e.g.
+  `remote-worldwide`, top 1-2 skill collections) until the target is reached
+  or the available collection pool is exhausted (never fabricate a link to a
+  non-existent slug).
+- Every link target is a real, already-existing `/collections/[slug]` or
+  `/companies/collections/[slug]` page — this block never links to a slug
+  that isn't in one of the two curated arrays.
+- No live count fetch needed for the block itself (the linked pages compute
+  their own count on load); the block only needs the two static arrays plus
+  the current job/company's already-loaded facet values.
+
+## Testing
+
+- Unit test for the "see also" matching/padding logic (source A + source B +
+  dedupe + fallback-fill + never-exceed-available-pool), independent of any
+  HTTP call — pure function over (job facets, company facts, both collection
+  arrays) → ordered slug list.
+- Verify title/H1/OG count interpolation on both collection route types with
+  a fixture total (e.g. snapshot the rendered `<title>` string given a known
+  `meta.total`).
+- Manual check per new `FILTER_COLLECTIONS`/`COMPANY_FILTER_COLLECTIONS` entry
+  during implementation: live count is non-empty (same discipline as existing
+  entries), per the design's non-goal on avoiding thin pages.

--- a/openspec/changes/programmatic-seo-collections/.openspec.yaml
+++ b/openspec/changes/programmatic-seo-collections/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/programmatic-seo-collections/design.md
+++ b/openspec/changes/programmatic-seo-collections/design.md
@@ -1,0 +1,99 @@
+## Context
+
+`/collections/[slug]` (`web/src/routes/collections/[slug]/+page.svelte` +
+`+page.server.ts`) already unifies two collection kinds behind one route via
+`collectionBySlug()` in `web/src/lib/collections.ts`:
+
+- **Filter collections** (`FILTER_COLLECTIONS`): frontend-only, map a slug to
+  a fixed set of `/jobs` facet params (`work_mode`, `regions`, `countries`,
+  `skills`, `category`, `seniority`, `role`).
+- **Company collections** (`COLLECTIONS`, generated from `internal/collections`
+  by `cmd/gen-contracts` into `web/src/lib/generated/contracts.ts`): a Go
+  registry (YC, Techstars, a16z, Big Tech, Unicorns, visa-sponsor registers)
+  whose membership is propagated onto every job as `jobs.collections`, served
+  by the `collections` search facet.
+
+Both kinds' landing pages already SSR the collection's job feed and already
+have the resulting `meta.total` in hand — that's the number this change
+surfaces in the document metadata. A full initial code survey (subagent
+research) missed the company-collection registry entirely on the first pass
+and an earlier draft of this design proposed rebuilding it as a new
+`/companies/collections/[slug]` page type; that was corrected once
+`internal/collections` was found — this design does not touch it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Interpolate the live, exact job count into `<title>`/`<h1>`/OG title on
+  `/collections/[slug]`, for both collection kinds.
+- Grow `FILTER_COLLECTIONS` with more verified high-intent combinations.
+- Add a bounded "see also" block to the job detail page that links into
+  existing `/collections/[slug]` pages, sourced from the viewed job's own
+  facets and its `collections` field.
+
+**Non-Goals:**
+- No new page type, route, or backend endpoint. No cross-product / auto-generated
+  combinations — every collection stays hand-curated with a verified live count.
+- No change to `internal/collections`, its registry, or the `jobs.collections`
+  propagation — this change only *reads* the field, never writes it.
+- No keyword-volume-driven prioritization for the initial `FILTER_COLLECTIONS`
+  growth — Search Console isn't connected for this project yet; the list is
+  judgment-based on standard job-board search patterns and should be revisited
+  once GSC or GA4 data is available.
+
+## Decisions
+
+**Exact count, not rounded.** `"1,234 React Jobs"` rather than `"500+ React
+Jobs"`. Trades a snippet that can look stale between Google re-crawls for a
+number that's always literally true when someone lands on the page. Product
+decision, not a technical constraint — rounding is a one-line change later if
+this proves noisy in Search Console.
+
+**"See also" fill order: job facets before job collections, then popular
+fallback.** Source A (role/region/skills → `FILTER_COLLECTIONS`) is more
+specific to the exact posting than Source B (company membership →
+`COLLECTIONS`), so A's matches are listed first. Both sources are matched
+against data the job page already loads — no new fetch. When the combined
+match count is below the target (~4-6), the block pads with a fixed popular-collections
+fallback (`remote-worldwide` + top skill collections) so the block is never
+sparse or absent, without ever inventing a link to a non-existent slug.
+
+**No live count in the see-also block itself.** Only the block's *target*
+pages compute and show counts (per the title/H1 change above); the block is a
+pure link list built from two in-memory arrays plus the current job's
+already-loaded facets, so it adds no request and no latency to the job page.
+
+**Matching logic as a pure function.** The see-also selection (facets + job
+collections + both registries → ordered, deduped slug list) is implemented as
+a pure function independent of any HTTP call, so it's unit-testable without
+mocking the job page's data loading.
+
+## Risks / Trade-offs
+
+- **Stale-looking snippet** → Google caches titles for days/weeks; an exact
+  live count can visibly lag the cached SERP snippet. Mitigation: accepted
+  trade-off (see Decisions); revisit rounding if Search Console flags it once
+  connected.
+- **Empty match pool for an obscure job** → the popular-collections fallback
+  guarantees the block is never empty as long as at least one collection
+  exists at all; if the entire fallback pool is somehow exhausted (won't
+  happen with the current registry sizes), the block silently renders fewer
+  than the target rather than fabricating a link.
+- **`FILTER_COLLECTIONS` growth reintroducing thin pages** → mitigated by the
+  same per-entry live-count verification the existing entries already require,
+  carried into implementation as a manual/scripted check before each new entry
+  ships (see proposal's Impact).
+
+## Migration Plan
+
+No data migration. Frontend-only change, deployed with the normal release
+process. No feature flag — the count-in-title change and the see-also block
+are both additive and low-risk (worst case: a wrong or missing count, or a
+short link list), not worth gating behind a flag per project convention
+(MVP-stage, no infra before there's a concrete need).
+
+## Open Questions
+
+None outstanding — see the proposal's Non-Goals for deliberately deferred
+scope (keyword-volume-driven list prioritization, once Search Console is
+connected).

--- a/openspec/changes/programmatic-seo-collections/design.md
+++ b/openspec/changes/programmatic-seo-collections/design.md
@@ -50,7 +50,10 @@ decision, not a technical constraint — rounding is a one-line change later if
 this proves noisy in Search Console.
 
 **"See also" fill order: job facets before job collections, then popular
-fallback.** Source A (role/region/skills → `FILTER_COLLECTIONS`) is more
+fallback.** Source A (category/seniority/skills/region → `FILTER_COLLECTIONS`,
+matched only on facets the job wire object actually carries — there is no
+client-side `role` field, and deriving one would duplicate the Go-side
+`internal/roletag` composition the dict-only convention keeps server-side) is more
 specific to the exact posting than Source B (company membership →
 `COLLECTIONS`), so A's matches are listed first. Both sources are matched
 against data the job page already loads — no new fetch. When the combined

--- a/openspec/changes/programmatic-seo-collections/proposal.md
+++ b/openspec/changes/programmatic-seo-collections/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The `/collections/[slug]` programmatic-SEO pages (both filter collections like
+`react`/`remote-europe` and company collections like `yc`/`bigtech`, unified
+behind one route) carry static titles that never surface the live job count,
+so search snippets look generic. They're also invisible from the
+highest-traffic page type on the site — job postings link to none of them —
+so Google has to discover and re-crawl them independently. The filter-collection
+list itself is also thinner than the realistic set of high-intent search
+patterns ("react jobs", "remote jobs germany") it could cover.
+
+## What Changes
+
+- `/collections/[slug]` (and its hub cards) interpolate the live, exact job
+  count into `<title>`, `<h1>`, and the OG title — e.g.
+  `"1,234 React Jobs · freehire"` — for both collection kinds, since they
+  render through the same route and already have the count in hand at SSR
+  time (`meta.total` from the existing job-list fetch).
+- `FILTER_COLLECTIONS` (`web/src/lib/collections.ts`) grows with more
+  high-intent country/skill/role combinations, each verified to have a
+  healthy live count before being added — a data addition under the
+  registry's existing contract, not a behavior change.
+- A new "see also" block on the job detail page (`/jobs/[slug]`) links to a
+  handful of existing `/collections/[slug]` pages, matched from the viewed
+  job's own facets (role, region, skills) and from its `collections` field
+  (company membership, e.g. `yc`) — padded with popular collections when a
+  job has few matches. Every link targets an already-existing collection
+  slug; no thin or empty pages are ever linked.
+
+## Capabilities
+
+### New Capabilities
+- `related-collections`: the job-detail-page "see also" block — matching a
+  viewed job's own facets and company collections against the two existing
+  collection registries to produce a bounded, deduped, always-full list of
+  internal links into `/collections/[slug]`.
+
+### Modified Capabilities
+- `web-ssr-seo`: the "Collection landing pages are indexable" requirement's
+  `<title>`/`<h1>`/OG-title format changes from a static collection name to
+  include the collection's live, exact job count.
+
+## Impact
+
+- Frontend only (SvelteKit, `web/`): no new backend endpoint — every count
+  needed is already returned by the existing job-list SSR fetch on
+  `/collections/[slug]`.
+- Touches `web/src/routes/collections/[slug]/+page.svelte` (title/H1/OG),
+  `web/src/lib/collections.ts` (expanded `FILTER_COLLECTIONS`, new matching
+  helper for the see-also block), and `web/src/routes/jobs/[slug]` (new
+  block).
+- No change to `internal/collections`, the `jobs.collections` propagation, or
+  any existing backend facet/search behavior.

--- a/openspec/changes/programmatic-seo-collections/proposal.md
+++ b/openspec/changes/programmatic-seo-collections/proposal.md
@@ -22,8 +22,8 @@ patterns ("react jobs", "remote jobs germany") it could cover.
   registry's existing contract, not a behavior change.
 - A new "see also" block on the job detail page (`/jobs/[slug]`) links to a
   handful of existing `/collections/[slug]` pages, matched from the viewed
-  job's own facets (role, region, skills) and from its `collections` field
-  (company membership, e.g. `yc`) — padded with popular collections when a
+  job's own facets (category, seniority, region, skills) and from its
+  `collections` field (company membership, e.g. `yc`) — padded with popular collections when a
   job has few matches. Every link targets an already-existing collection
   slug; no thin or empty pages are ever linked.
 

--- a/openspec/changes/programmatic-seo-collections/specs/related-collections/spec.md
+++ b/openspec/changes/programmatic-seo-collections/specs/related-collections/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Job detail page links to related collections
+
+The job detail page (`GET /jobs/:slug`) SHALL render a bounded "see also"
+block of internal links into existing `/collections/:slug` landing pages,
+built from the viewed job's own data with no additional HTTP request. Link
+candidates SHALL be drawn from two sources: the job's own facets (role,
+region, skills) matched against the `FILTER_COLLECTIONS` registry, and the
+job's `collections` field matched against the company-collection registry.
+Every rendered link SHALL target a slug that exists in one of these two
+registries — the block SHALL NOT construct or link to a slug that maps to no
+collection.
+
+#### Scenario: A job's skill facet produces a matching link
+
+- **WHEN** a job detail page is rendered for a job whose `skills` include
+  `react`, and a `react` filter collection exists
+- **THEN** the see-also block includes a link to `/collections/react`
+
+#### Scenario: A job's company collection produces a matching link
+
+- **WHEN** a job detail page is rendered for a job whose `collections` field
+  includes `yc`
+- **THEN** the see-also block includes a link to `/collections/yc`
+
+#### Scenario: Job-facet matches are ordered before company-collection matches
+
+- **WHEN** a job matches both a filter collection (via its own facets) and a
+  company collection (via its `collections` field)
+- **THEN** the filter-collection link appears before the company-collection
+  link in the block
+
+### Requirement: The see-also block is always full and never links to a dead slug
+
+When a job's own facet and company-collection matches fall short of the
+block's target size, the system SHALL pad the block with a fixed fallback
+list of popular collections until the target size is reached or the
+available collection pool is exhausted, whichever comes first. The block
+SHALL de-duplicate by slug across both sources and the fallback list. The
+system SHALL NOT render a link to a collection slug that does not exist in
+`FILTER_COLLECTIONS` or the company-collection registry.
+
+#### Scenario: A job with no facet or collection matches still shows links
+
+- **WHEN** a job detail page is rendered for a job whose facets and
+  `collections` field match no existing collection
+- **THEN** the see-also block renders the fallback list of popular
+  collections instead of an empty block
+
+#### Scenario: A duplicate match is not shown twice
+
+- **WHEN** a job's own facets and the fallback list would both produce a link
+  to the same collection slug
+- **THEN** that slug appears only once in the rendered block
+
+#### Scenario: The block never exceeds the available collection pool
+
+- **WHEN** the combined set of matched and fallback collections is smaller
+  than the block's target size
+- **THEN** the block renders exactly that smaller set rather than a
+  placeholder or a broken link

--- a/openspec/changes/programmatic-seo-collections/specs/related-collections/spec.md
+++ b/openspec/changes/programmatic-seo-collections/specs/related-collections/spec.md
@@ -5,12 +5,13 @@
 The job detail page (`GET /jobs/:slug`) SHALL render a bounded "see also"
 block of internal links into existing `/collections/:slug` landing pages,
 built from the viewed job's own data with no additional HTTP request. Link
-candidates SHALL be drawn from two sources: the job's own facets (role,
-region, skills) matched against the `FILTER_COLLECTIONS` registry, and the
-job's `collections` field matched against the company-collection registry.
-Every rendered link SHALL target a slug that exists in one of these two
-registries — the block SHALL NOT construct or link to a slug that maps to no
-collection.
+candidates SHALL be drawn from two sources: the job's own facets (category,
+seniority, region, skills — the facets the job wire object actually carries;
+there is no client-side `role` field) matched against the `FILTER_COLLECTIONS`
+registry, and the job's `collections` field matched against the
+company-collection registry. Every rendered link SHALL target a slug that
+exists in one of these two registries — the block SHALL NOT construct or link
+to a slug that maps to no collection.
 
 #### Scenario: A job's skill facet produces a matching link
 

--- a/openspec/changes/programmatic-seo-collections/specs/web-ssr-seo/spec.md
+++ b/openspec/changes/programmatic-seo-collections/specs/web-ssr-seo/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Collection landing pages are indexable
+
+The frontend SHALL serve a server-rendered landing page at `GET /collections/:slug`
+for each curated collection, so the collection's job feed and its curated copy are
+in the initial HTML. The page SHALL emit collection-specific document metadata: a
+`<title>` and `<meta name="description">` distinct from the generic `/jobs` list,
+a `<link rel="canonical">` pointing at its own `/collections/:slug` URL (never the
+bare `/jobs`), and a single visible `<h1>` naming the collection. The `<title>`,
+`<h1>`, and Open Graph title SHALL include the collection's live, exact open-job
+count (e.g. `"1,234 React Jobs · freehire"`), sourced from the same job-list
+response already fetched to render the feed — no separate count request. The page
+SHALL render the collection's open jobs by pinning the collection's facet params
+(e.g. `collections=<slug>`, or `work_mode`/`regions`/`countries` for an attribute
+collection) as a fixed scope the visitor can further filter but cannot remove. An
+unrecognised slug SHALL return a 404 (not a 200 empty or unfiltered page). Each
+collection landing page SHALL be enumerated in the sitemap.
+
+#### Scenario: A collection has its own canonical landing page
+
+- **WHEN** `GET /collections/:slug` is requested for a known collection
+- **THEN** the HTML `<head>` contains a collection-specific `<title>` that
+  includes the collection's live open-job count, a `<meta name="description">`,
+  and a `<link rel="canonical">` whose URL is that same `/collections/:slug`
+  (not `/jobs`)
+
+#### Scenario: The landing page shows the collection's jobs in the initial HTML
+
+- **WHEN** `GET /collections/:slug` is requested for a known collection with open jobs
+- **THEN** the returned HTML body contains a single `<h1>` naming the collection
+  and its live open-job count, and the first page of that collection's job rows
+  (not an empty shell)
+
+#### Scenario: The title count matches the rendered total exactly
+
+- **WHEN** `GET /collections/:slug` is requested for a known collection whose
+  job-list response reports `meta.total` open jobs
+- **THEN** the `<title>`, `<h1>`, and Open Graph title all display that same
+  exact number, not a rounded or cached figure
+
+#### Scenario: An unknown collection slug is a 404
+
+- **WHEN** `GET /collections/:slug` is requested for a slug that maps to no collection
+- **THEN** the server responds with a 404 status and an error page
+
+#### Scenario: Collection landing pages are in the sitemap
+
+- **WHEN** the sitemap's static-pages sub-sitemap is requested
+- **THEN** it lists a `<loc>` for the `/collections` hub and for each collection's
+  `/collections/:slug` landing page

--- a/openspec/changes/programmatic-seo-collections/tasks.md
+++ b/openspec/changes/programmatic-seo-collections/tasks.md
@@ -1,0 +1,47 @@
+## 1. Live job count in collection title/H1/OG
+
+- [ ] 1.1 In `web/src/routes/collections/[slug]/+page.svelte`, interpolate the
+      already-fetched `meta.total` into `<title>`, `<h1>`, and the OG title
+      (exact count, e.g. `"1,234 React Jobs · freehire"`), for both filter
+      and company collections (single shared route/component).
+- [ ] 1.2 Test: rendered `<title>`/`<h1>`/OG-title match a fixture
+      `meta.total` exactly, covering one filter-collection slug (e.g. `react`)
+      and one company-collection slug (e.g. `yc`).
+
+## 2. Expand `FILTER_COLLECTIONS`
+
+- [ ] 2.1 For each candidate new entry (additional country-level remote
+      landings, additional skill landings, additional role landings — see
+      design.md's Context), verify a healthy non-empty live count via
+      `searchJobs(params, 0, 0).total` before adding it.
+- [ ] 2.2 Add the verified entries to `FILTER_COLLECTIONS` in
+      `web/src/lib/collections.ts`, following the existing entry shape and
+      section grouping.
+
+## 3. See-also matching logic
+
+- [ ] 3.1 Implement a pure function in `web/src/lib/collections.ts` (or a
+      sibling module) that takes a job's facets (role, region, skills) and its
+      `collections` field, and returns an ordered, deduped list of collection
+      slugs: Source A (facet match against `FILTER_COLLECTIONS`) before
+      Source B (`collections` match against the company-collection registry),
+      padded with a fixed popular-collections fallback up to a target size,
+      never exceeding the available pool and never inventing a non-existent
+      slug.
+- [ ] 3.2 Unit tests for the matching function: Source A match, Source B
+      match, both together (ordering), dedupe across sources and fallback, a
+      job with zero matches (fallback-only), and a pool smaller than the
+      target size.
+
+## 4. See-also block on the job detail page
+
+- [ ] 4.1 Add a "see also" block to the job detail page
+      (`web/src/routes/jobs/[slug]`) rendering the slugs from the section-3
+      matching function as links to their `/collections/[slug]` pages, using
+      data the job page already loads (no new fetch).
+- [ ] 4.2 Test: the block renders the expected links for a job fixture with
+      facet matches, a job fixture with only company-collection matches, and
+      a job fixture with no matches (fallback list).
+- [ ] 4.3 Manual verification: load a real job page locally and confirm the
+      block shows correct, working links and the linked collection pages show
+      the new live-count title.

--- a/openspec/changes/programmatic-seo-collections/tasks.md
+++ b/openspec/changes/programmatic-seo-collections/tasks.md
@@ -20,7 +20,7 @@
 
 ## 3. See-also matching logic
 
-- [ ] 3.1 Implement a pure function in `web/src/lib/collections.ts` (or a
+- [x] 3.1 Implement a pure function in `web/src/lib/collections.ts` (or a
       sibling module) that takes a job's facets (role, region, skills) and its
       `collections` field, and returns an ordered, deduped list of collection
       slugs: Source A (facet match against `FILTER_COLLECTIONS`) before
@@ -28,7 +28,7 @@
       padded with a fixed popular-collections fallback up to a target size,
       never exceeding the available pool and never inventing a non-existent
       slug.
-- [ ] 3.2 Unit tests for the matching function: Source A match, Source B
+- [x] 3.2 Unit tests for the matching function: Source A match, Source B
       match, both together (ordering), dedupe across sources and fallback, a
       job with zero matches (fallback-only), and a pool smaller than the
       target size.

--- a/openspec/changes/programmatic-seo-collections/tasks.md
+++ b/openspec/changes/programmatic-seo-collections/tasks.md
@@ -35,11 +35,11 @@
 
 ## 4. See-also block on the job detail page
 
-- [ ] 4.1 Add a "see also" block to the job detail page
+- [x] 4.1 Add a "see also" block to the job detail page
       (`web/src/routes/jobs/[slug]`) rendering the slugs from the section-3
       matching function as links to their `/collections/[slug]` pages, using
       data the job page already loads (no new fetch).
-- [ ] 4.2 Test: the block renders the expected links for a job fixture with
+- [x] 4.2 Test: the block renders the expected links for a job fixture with
       facet matches, a job fixture with only company-collection matches, and
       a job fixture with no matches (fallback list).
 - [ ] 4.3 Manual verification: load a real job page locally and confirm the

--- a/openspec/changes/programmatic-seo-collections/tasks.md
+++ b/openspec/changes/programmatic-seo-collections/tasks.md
@@ -42,6 +42,6 @@
 - [x] 4.2 Test: the block renders the expected links for a job fixture with
       facet matches, a job fixture with only company-collection matches, and
       a job fixture with no matches (fallback list).
-- [ ] 4.3 Manual verification: load a real job page locally and confirm the
+- [x] 4.3 Manual verification: load a real job page locally and confirm the
       block shows correct, working links and the linked collection pages show
       the new live-count title.

--- a/openspec/changes/programmatic-seo-collections/tasks.md
+++ b/openspec/changes/programmatic-seo-collections/tasks.md
@@ -10,11 +10,11 @@
 
 ## 2. Expand `FILTER_COLLECTIONS`
 
-- [ ] 2.1 For each candidate new entry (additional country-level remote
+- [x] 2.1 For each candidate new entry (additional country-level remote
       landings, additional skill landings, additional role landings — see
       design.md's Context), verify a healthy non-empty live count via
       `searchJobs(params, 0, 0).total` before adding it.
-- [ ] 2.2 Add the verified entries to `FILTER_COLLECTIONS` in
+- [x] 2.2 Add the verified entries to `FILTER_COLLECTIONS` in
       `web/src/lib/collections.ts`, following the existing entry shape and
       section grouping.
 

--- a/openspec/changes/programmatic-seo-collections/tasks.md
+++ b/openspec/changes/programmatic-seo-collections/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Live job count in collection title/H1/OG
 
-- [ ] 1.1 In `web/src/routes/collections/[slug]/+page.svelte`, interpolate the
+- [x] 1.1 In `web/src/routes/collections/[slug]/+page.svelte`, interpolate the
       already-fetched `meta.total` into `<title>`, `<h1>`, and the OG title
       (exact count, e.g. `"1,234 React Jobs · freehire"`), for both filter
       and company collections (single shared route/component).
-- [ ] 1.2 Test: rendered `<title>`/`<h1>`/OG-title match a fixture
+- [x] 1.2 Test: rendered `<title>`/`<h1>`/OG-title match a fixture
       `meta.total` exactly, covering one filter-collection slug (e.g. `react`)
       and one company-collection slug (e.g. `yc`).
 

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -224,6 +224,12 @@ describe('relatedCollectionLinks', () => {
     expect(links).toContainEqual({ slug: 'yc', title: 'Y Combinator' });
   });
 
+  it('falls back to the popular collections when a job matches nothing', () => {
+    const links = relatedCollectionLinks(jobFacets());
+    expect(links.map((l) => l.slug)).toEqual(POPULAR_COLLECTION_FALLBACK);
+    expect(links.every((l) => typeof l.title === 'string' && l.title.length > 0)).toBe(true);
+  });
+
   it('produces the same slugs, in the same order, as relatedCollectionSlugs', () => {
     const job = jobFacets({ skills: ['react'], collections: ['yc'] });
     expect(relatedCollectionLinks(job).map((l) => l.slug)).toEqual(relatedCollectionSlugs(job));

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -4,6 +4,7 @@ import {
   POPULAR_COLLECTION_FALLBACK,
   collectionBySlug,
   collectionSlugs,
+  relatedCollectionLinks,
   relatedCollectionSlugs,
 } from './collections';
 import { FACETS } from './facets';
@@ -209,5 +210,22 @@ describe('relatedCollectionSlugs', () => {
     for (const slug of slugs) {
       expect(collectionBySlug(slug), `related slug "${slug}"`).toBeDefined();
     }
+  });
+});
+
+describe('relatedCollectionLinks', () => {
+  it('resolves each slug to its collection title, for JobSeeAlso to render', () => {
+    const links = relatedCollectionLinks(jobFacets({ skills: ['react'] }));
+    expect(links).toContainEqual({ slug: 'react', title: 'React' });
+  });
+
+  it('resolves both filter and company collection kinds', () => {
+    const links = relatedCollectionLinks(jobFacets({ collections: ['yc'] }));
+    expect(links).toContainEqual({ slug: 'yc', title: 'Y Combinator' });
+  });
+
+  it('produces the same slugs, in the same order, as relatedCollectionSlugs', () => {
+    const job = jobFacets({ skills: ['react'], collections: ['yc'] });
+    expect(relatedCollectionLinks(job).map((l) => l.slug)).toEqual(relatedCollectionSlugs(job));
   });
 });

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -149,6 +149,31 @@ describe('relatedCollectionSlugs', () => {
     expect(slugs).not.toContain('software-engineer');
   });
 
+  it('matches category, seniority, and region facets, not just skills', () => {
+    // Each of facetMatches' non-skills branches asserted positively, not just
+    // exercised as a side effect of another test.
+    expect(relatedCollectionSlugs(jobFacets({ category: 'backend' }))).toContain('backend');
+    expect(relatedCollectionSlugs(jobFacets({ seniority: 'senior' }))).toContain('senior');
+    expect(
+      relatedCollectionSlugs(jobFacets({ workMode: 'remote', regions: ['global'] }))
+    ).toContain('remote-worldwide');
+  });
+
+  it('requires every param on a multi-key entry (AND across keys, not OR)', () => {
+    // remote-brasil = { work_mode: 'remote', countries: 'br' }. Satisfying only
+    // one of its two keys must not match — this is the property that would
+    // silently break if collectionMatchesJob's `.every()` became `.some()`.
+    expect(relatedCollectionSlugs(jobFacets({ workMode: 'remote' }))).not.toContain(
+      'remote-brasil'
+    );
+    expect(relatedCollectionSlugs(jobFacets({ countries: ['br'] }))).not.toContain(
+      'remote-brasil'
+    );
+    expect(
+      relatedCollectionSlugs(jobFacets({ workMode: 'remote', countries: ['br'] }))
+    ).toContain('remote-brasil');
+  });
+
   it('orders facet matches (Source A) before collection matches (Source B)', () => {
     const slugs = relatedCollectionSlugs(jobFacets({ skills: ['react'], collections: ['yc'] }));
     const reactIndex = slugs.indexOf('react');
@@ -167,8 +192,7 @@ describe('relatedCollectionSlugs', () => {
 
   it('pads with the popular fallback when a job matches nothing', () => {
     const slugs = relatedCollectionSlugs(jobFacets());
-    expect(slugs).toEqual(POPULAR_COLLECTION_FALLBACK.slice(0, slugs.length));
-    expect(slugs.length).toBeGreaterThan(0);
+    expect(slugs).toEqual(POPULAR_COLLECTION_FALLBACK);
   });
 
   it('never renders more than the requested target size', () => {

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { FILTER_COLLECTIONS, collectionBySlug, collectionSlugs } from './collections';
+import {
+  FILTER_COLLECTIONS,
+  POPULAR_COLLECTION_FALLBACK,
+  collectionBySlug,
+  collectionSlugs,
+  relatedCollectionSlugs,
+} from './collections';
 import { FACETS } from './facets';
+
+// Minimal JobFacets fixture — every field defaults to "no signal" so a test
+// only has to set the facet(s) it cares about.
+function jobFacets(overrides: Partial<Parameters<typeof relatedCollectionSlugs>[0]> = {}) {
+  return {
+    skills: [],
+    countries: [],
+    regions: [],
+    collections: [],
+    ...overrides,
+  };
+}
 
 describe('collectionBySlug', () => {
   it('resolves a company-membership collection to a collections facet param', () => {
@@ -98,5 +116,74 @@ describe('credential collections in the job-search facet', () => {
   it('lists credential slugs in the sitemap alongside every other collection', () => {
     expect(collectionSlugs()).toContain('uk-skilled-worker-sponsor');
     expect(collectionSlugs()).toContain('nl-recognised-sponsor');
+  });
+});
+
+describe('POPULAR_COLLECTION_FALLBACK', () => {
+  it('every fallback slug resolves to a real collection', () => {
+    // The fallback pool pads a sparse "see also" block — a typo here would
+    // silently link to a page that 404s.
+    for (const slug of POPULAR_COLLECTION_FALLBACK) {
+      expect(collectionBySlug(slug), `fallback slug "${slug}"`).toBeDefined();
+    }
+  });
+});
+
+describe('relatedCollectionSlugs', () => {
+  it('matches a job facet against FILTER_COLLECTIONS (Source A)', () => {
+    const slugs = relatedCollectionSlugs(jobFacets({ skills: ['react'] }));
+    expect(slugs).toContain('react');
+  });
+
+  it('matches the job collections field against the company registry (Source B)', () => {
+    const slugs = relatedCollectionSlugs(jobFacets({ collections: ['yc'] }));
+    expect(slugs).toContain('yc');
+  });
+
+  it('never matches on role — the job wire object carries no role field', () => {
+    // software-engineer is a `role`-keyed FILTER_COLLECTIONS entry; nothing in
+    // JobFacets can satisfy it, so it must never appear from a facet match.
+    const slugs = relatedCollectionSlugs(
+      jobFacets({ category: 'backend', seniority: 'senior', skills: ['react'] })
+    );
+    expect(slugs).not.toContain('software-engineer');
+  });
+
+  it('orders facet matches (Source A) before collection matches (Source B)', () => {
+    const slugs = relatedCollectionSlugs(jobFacets({ skills: ['react'], collections: ['yc'] }));
+    const reactIndex = slugs.indexOf('react');
+    const ycIndex = slugs.indexOf('yc');
+    expect(reactIndex).toBeGreaterThanOrEqual(0);
+    expect(ycIndex).toBeGreaterThanOrEqual(0);
+    expect(reactIndex).toBeLessThan(ycIndex);
+  });
+
+  it('de-duplicates a slug that both matches a facet and sits in the fallback pool', () => {
+    // 'javascript' is in POPULAR_COLLECTION_FALLBACK; a job that also matches
+    // it by skill must not render it twice.
+    const slugs = relatedCollectionSlugs(jobFacets({ skills: ['javascript'] }));
+    expect(slugs.filter((s) => s === 'javascript')).toHaveLength(1);
+  });
+
+  it('pads with the popular fallback when a job matches nothing', () => {
+    const slugs = relatedCollectionSlugs(jobFacets());
+    expect(slugs).toEqual(POPULAR_COLLECTION_FALLBACK.slice(0, slugs.length));
+    expect(slugs.length).toBeGreaterThan(0);
+  });
+
+  it('never renders more than the requested target size', () => {
+    const slugs = relatedCollectionSlugs(
+      jobFacets({ category: 'backend', seniority: 'senior', skills: ['react', 'python', 'aws'] }),
+      3
+    );
+    expect(slugs.length).toBeLessThanOrEqual(3);
+  });
+
+  it('never exceeds the available collection pool and never links a dead slug', () => {
+    const slugs = relatedCollectionSlugs(jobFacets({ skills: ['react'] }), 1000);
+    expect(new Set(slugs).size).toBe(slugs.length); // no duplicates
+    for (const slug of slugs) {
+      expect(collectionBySlug(slug), `related slug "${slug}"`).toBeDefined();
+    }
   });
 });

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -726,3 +726,21 @@ export function relatedCollectionSlugs(job: JobFacets, target = 5): string[] {
 
   return slugs;
 }
+
+// relatedCollectionSlugs resolved to {slug, title} pairs via collectionBySlug
+// — the same resolver the landing route and sitemap use — so a slug that
+// somehow doesn't resolve is dropped here rather than rendered as a dead
+// link. This is what JobSeeAlso renders; kept as a pure function (rather than
+// resolving inline in the component) so it's unit-testable like the rest of
+// this module, matching web/'s no-component-test-harness convention.
+export function relatedCollectionLinks(
+  job: JobFacets,
+  target = 5
+): { slug: string; title: string }[] {
+  return relatedCollectionSlugs(job, target)
+    .map((slug) => {
+      const collection = collectionBySlug(slug);
+      return collection ? { slug, title: collection.title } : null;
+    })
+    .filter((link) => link !== null);
+}

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -638,12 +638,15 @@ export function collectionSlugs(): string[] {
 
 // The facets of a viewed job that relatedCollectionSlugs matches against —
 // deliberately only what the Job wire object actually carries (see
-// web/src/lib/generated/contracts.ts). There is no `role` here: roletag's
-// seniority×category/named-role composition lives server-side only
-// (internal/roletag), and duplicating it client-side would break the
-// dict-only single-source-of-truth convention. A `role`-keyed
-// FILTER_COLLECTIONS entry (e.g. senior-backend) therefore never matches via
-// facets — it's only reachable through POPULAR_COLLECTION_FALLBACK.
+// web/src/lib/generated/contracts.ts): `category`/`seniority` come from
+// `job.enrichment.category`/`job.enrichment.seniority` (not top-level fields),
+// the rest map straight to `job.skills`/`work_mode`/`countries`/`regions`.
+// There is no `role` here: roletag's seniority×category/named-role
+// composition lives server-side only (internal/roletag), and duplicating it
+// client-side would break the dict-only single-source-of-truth convention. A
+// `role`-keyed FILTER_COLLECTIONS entry (e.g. senior-backend) therefore never
+// matches via facets — it's only reachable through
+// POPULAR_COLLECTION_FALLBACK.
 export type JobFacets = {
   category?: string;
   seniority?: string;

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -374,9 +374,11 @@ export const FILTER_COLLECTIONS: FilterCollection[] = [
     description: 'Internship and trainee roles for students and new graduates in tech.',
     params: { seniority: 'intern' },
   },
-  // Infra-skill landings — the same "<skill> jobs" pattern as the language/framework
-  // set above, extended to cloud & platform tools. `slug`/`params.skills` MUST be the
-  // exact skilltag canonical. Each was confirmed to have a live count before shipping.
+  // Infra & ecosystem skill landings — the same "<skill> jobs" pattern as the
+  // language/framework set above, extended to any other skilltag canonical:
+  // cloud/platform tools, databases, CI/CD, ML frameworks, blockchain.
+  // `slug`/`params.skills` MUST be the exact skilltag canonical. Each was
+  // confirmed to have a live count before shipping.
   {
     slug: 'aws',
     title: 'AWS',
@@ -544,7 +546,7 @@ export const FILTER_COLLECTIONS: FilterCollection[] = [
     params: { role: 'senior_fullstack' },
   },
   {
-    slug: 'senior-data-engineer',
+    slug: 'senior-data-engineering',
     title: 'Senior Data Engineer',
     description: 'Senior data engineering roles building pipelines and data platforms.',
     params: { role: 'senior_data_engineering' },

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -55,6 +55,33 @@ export const FILTER_COLLECTIONS: FilterCollection[] = [
     description: 'Fully remote roles open to candidates across Asia-Pacific.',
     params: { work_mode: 'remote', regions: 'apac' },
   },
+  // Single-country remote landings — the "remote jobs in <country>" pattern,
+  // alongside the regional ones above. Countries are ISO 3166-1 alpha-2. Each
+  // was confirmed to have a healthy live count (thousands) before shipping.
+  {
+    slug: 'remote-canada',
+    title: 'Remote Canada',
+    description: 'Fully remote roles open to candidates in Canada.',
+    params: { work_mode: 'remote', countries: 'ca' },
+  },
+  {
+    slug: 'remote-uk',
+    title: 'Remote UK',
+    description: 'Fully remote roles open to candidates in the United Kingdom.',
+    params: { work_mode: 'remote', countries: 'gb' },
+  },
+  {
+    slug: 'remote-india',
+    title: 'Remote India',
+    description: 'Fully remote roles open to candidates in India.',
+    params: { work_mode: 'remote', countries: 'in' },
+  },
+  {
+    slug: 'remote-poland',
+    title: 'Remote Poland',
+    description: 'Fully remote roles open to candidates in Poland.',
+    params: { work_mode: 'remote', countries: 'pl' },
+  },
   // Language & framework landings — the classic "<lang> jobs" search pattern, one
   // per canonical `skills` facet value. `slug`/`params.skills` MUST be the exact
   // skilltag canonical (e.g. `go` not `golang`, `nodejs` not `node`, `cpp`/`csharp`
@@ -398,6 +425,84 @@ export const FILTER_COLLECTIONS: FilterCollection[] = [
     description: 'Open roles that use GraphQL for API design and data fetching.',
     params: { skills: 'graphql' },
   },
+  {
+    slug: 'mongodb',
+    title: 'MongoDB',
+    description: 'Open roles that use MongoDB as the primary document database.',
+    params: { skills: 'mongodb' },
+  },
+  {
+    slug: 'mysql',
+    title: 'MySQL',
+    description: 'Open roles that use MySQL as the primary relational database.',
+    params: { skills: 'mysql' },
+  },
+  {
+    slug: 'elasticsearch',
+    title: 'Elasticsearch',
+    description: 'Open roles that use Elasticsearch for search and log analytics.',
+    params: { skills: 'elasticsearch' },
+  },
+  {
+    slug: 'dotnet',
+    title: '.NET',
+    description: 'Open roles that use .NET for backend and enterprise applications.',
+    params: { skills: 'dotnet' },
+  },
+  {
+    slug: 'laravel',
+    title: 'Laravel',
+    description: 'Open roles that use Laravel for PHP web backends.',
+    params: { skills: 'laravel' },
+  },
+  {
+    slug: 'flutter',
+    title: 'Flutter',
+    description: 'Open roles that use Flutter for cross-platform mobile apps.',
+    params: { skills: 'flutter' },
+  },
+  {
+    slug: 'azure',
+    title: 'Azure',
+    description: 'Open roles that use Microsoft Azure for cloud infrastructure.',
+    params: { skills: 'azure' },
+  },
+  {
+    slug: 'gcp',
+    title: 'Google Cloud',
+    description: 'Open roles that use Google Cloud Platform for cloud infrastructure.',
+    params: { skills: 'gcp' },
+  },
+  {
+    slug: 'jenkins',
+    title: 'Jenkins',
+    description: 'Open roles that use Jenkins for CI/CD automation.',
+    params: { skills: 'jenkins' },
+  },
+  {
+    slug: 'ansible',
+    title: 'Ansible',
+    description: 'Open roles that use Ansible for infrastructure automation.',
+    params: { skills: 'ansible' },
+  },
+  {
+    slug: 'pytorch',
+    title: 'PyTorch',
+    description: 'Open roles that use PyTorch for machine learning.',
+    params: { skills: 'pytorch' },
+  },
+  {
+    slug: 'tensorflow',
+    title: 'TensorFlow',
+    description: 'Open roles that use TensorFlow for machine learning.',
+    params: { skills: 'tensorflow' },
+  },
+  {
+    slug: 'solidity',
+    title: 'Solidity',
+    description: 'Open roles that use Solidity for smart-contract and blockchain development.',
+    params: { skills: 'solidity' },
+  },
   // Named-role landings — the `role` facet (roletag: named roles + skill×seniority
   // combos). Only clearly-technical roles with an individually-verified live count
   // are listed; the facet also carries non-tech and seniority-only values, which are
@@ -425,6 +530,36 @@ export const FILTER_COLLECTIONS: FilterCollection[] = [
     title: 'Founding Engineer',
     description: 'Founding engineer roles building the first product at early-stage startups.',
     params: { role: 'founding_engineer' },
+  },
+  {
+    slug: 'senior-devops',
+    title: 'Senior DevOps',
+    description: 'Senior DevOps engineering roles owning build, deployment and infrastructure.',
+    params: { role: 'senior_devops' },
+  },
+  {
+    slug: 'senior-fullstack',
+    title: 'Senior Full-Stack',
+    description: 'Senior full-stack engineering roles spanning frontend and backend delivery.',
+    params: { role: 'senior_fullstack' },
+  },
+  {
+    slug: 'senior-data-engineer',
+    title: 'Senior Data Engineer',
+    description: 'Senior data engineering roles building pipelines and data platforms.',
+    params: { role: 'senior_data_engineering' },
+  },
+  {
+    slug: 'staff-engineer',
+    title: 'Staff Engineer',
+    description: 'Staff engineering roles driving technical strategy for a team or product area.',
+    params: { role: 'staff_engineer' },
+  },
+  {
+    slug: 'engineering-manager',
+    title: 'Engineering Manager',
+    description: 'Engineering management roles leading and growing a team of engineers.',
+    params: { role: 'engineering_manager' },
   },
 ];
 

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -635,3 +635,91 @@ export function collectionBySlug(slug: string): ResolvedCollection | undefined {
 export function collectionSlugs(): string[] {
   return [...FILTER_COLLECTIONS.map((c) => c.slug), ...COMPANY_COLLECTIONS.map((c) => c.slug)];
 }
+
+// The facets of a viewed job that relatedCollectionSlugs matches against —
+// deliberately only what the Job wire object actually carries (see
+// web/src/lib/generated/contracts.ts). There is no `role` here: roletag's
+// seniority×category/named-role composition lives server-side only
+// (internal/roletag), and duplicating it client-side would break the
+// dict-only single-source-of-truth convention. A `role`-keyed
+// FILTER_COLLECTIONS entry (e.g. senior-backend) therefore never matches via
+// facets — it's only reachable through POPULAR_COLLECTION_FALLBACK.
+export type JobFacets = {
+  category?: string;
+  seniority?: string;
+  skills: string[];
+  workMode?: string;
+  countries: string[];
+  regions: string[];
+  collections: string[];
+};
+
+// Popular collections padding a sparse "see also" block so it's never empty
+// or too thin. Slugs are verified to exist in FILTER_COLLECTIONS by a test.
+export const POPULAR_COLLECTION_FALLBACK = ['remote-worldwide', 'javascript', 'python', 'react'];
+
+// Whether a single FILTER_COLLECTIONS param entry is satisfied by the job's
+// facets. `role` (and any other key the job carries no data for) never
+// matches — see JobFacets' doc comment.
+function facetMatches(paramKey: string, paramValue: string | string[], job: JobFacets): boolean {
+  const values = Array.isArray(paramValue) ? paramValue : [paramValue];
+  switch (paramKey) {
+    case 'work_mode':
+      return job.workMode !== undefined && values.includes(job.workMode);
+    case 'countries':
+      return values.some((v) => job.countries.includes(v));
+    case 'regions':
+      return values.some((v) => job.regions.includes(v));
+    case 'skills':
+      return values.some((v) => job.skills.includes(v));
+    case 'category':
+      return job.category !== undefined && values.includes(job.category);
+    case 'seniority':
+      return job.seniority !== undefined && values.includes(job.seniority);
+    default:
+      return false;
+  }
+}
+
+// A collection matches a job when every one of its params is satisfied —
+// mirroring how the collection's own landing page pins ALL of its params as
+// a fixed scope (see collections/[slug]/+page.server.ts).
+function collectionMatchesJob(entry: FilterCollection, job: JobFacets): boolean {
+  return Object.entries(entry.params).every(([key, value]) => facetMatches(key, value, job));
+}
+
+// The job-detail-page "see also" block's link targets: a bounded, deduped,
+// always-full list of collection slugs, built with no additional HTTP
+// request from data the job page already has. Source A (the job's own
+// facets, against FILTER_COLLECTIONS) is listed before Source B (the job's
+// `collections` field — company membership — against the company registry),
+// then padded with POPULAR_COLLECTION_FALLBACK up to `target`. Every
+// returned slug resolves via collectionBySlug — this never invents a link to
+// a collection that doesn't exist.
+export function relatedCollectionSlugs(job: JobFacets, target = 5): string[] {
+  const slugs: string[] = [];
+  const seen = new Set<string>();
+  const add = (slug: string) => {
+    if (seen.has(slug)) return;
+    seen.add(slug);
+    slugs.push(slug);
+  };
+
+  for (const entry of FILTER_COLLECTIONS) {
+    if (slugs.length >= target) break;
+    if (collectionMatchesJob(entry, job)) add(entry.slug);
+  }
+
+  const companySlugs = new Set<string>(COMPANY_COLLECTIONS.map((c) => c.slug));
+  for (const slug of job.collections) {
+    if (slugs.length >= target) break;
+    if (companySlugs.has(slug)) add(slug);
+  }
+
+  for (const slug of POPULAR_COLLECTION_FALLBACK) {
+    if (slugs.length >= target) break;
+    add(slug);
+  }
+
+  return slugs;
+}

--- a/web/src/lib/components/JobSeeAlso.svelte
+++ b/web/src/lib/components/JobSeeAlso.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { relatedCollectionLinks, type JobFacets } from '$lib/collections';
+  import type { Job } from '$lib/types';
+
+  // A bounded row of links into existing /collections/:slug pages, built from
+  // this job's own facets and its company's collections — see design's
+  // relatedCollectionLinks. No fetch: everything it needs is already on `job`.
+  let { job }: { job: Job } = $props();
+
+  const facets = $derived<JobFacets>({
+    category: job.enrichment.category,
+    seniority: job.enrichment.seniority,
+    skills: job.skills,
+    workMode: job.work_mode,
+    countries: job.countries,
+    regions: job.regions,
+    collections: job.collections,
+  });
+
+  const links = $derived(relatedCollectionLinks(facets));
+</script>
+
+{#if links.length > 0}
+  <section class="mt-8">
+    <h2 class="mb-3 text-sm font-semibold text-muted-foreground">See also</h2>
+    <div class="flex flex-wrap gap-2">
+      {#each links as link (link.slug)}
+        <a
+          href={resolve('/collections/[slug]', { slug: link.slug })}
+          class="rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+        >
+          {link.title}
+        </a>
+      {/each}
+    </div>
+  </section>
+{/if}

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   articleJsonLd,
+  collectionHeading,
   collectionPageJsonLd,
   companyListItems,
   datasetJsonLd,
@@ -45,6 +46,20 @@ function company(overrides: Partial<Company> = {}): Company {
 }
 
 const ORIGIN = 'https://freehire.me';
+
+describe('collectionHeading', () => {
+  it('includes the exact live count, comma-grouped', () => {
+    expect(collectionHeading('React', 1234)).toBe('1,234 React jobs');
+  });
+
+  it('falls back to the plain title when no count is available', () => {
+    expect(collectionHeading('React', undefined)).toBe('React jobs');
+  });
+
+  it('renders a zero count honestly rather than hiding it', () => {
+    expect(collectionHeading('React', 0)).toBe('0 React jobs');
+  });
+});
 
 describe('organizationJsonLd', () => {
   it('emits every company-info fact the company provides', () => {

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -33,6 +33,13 @@ export function jobPageTitle(job: Job): string {
   return `${lead} · ${SITE}`;
 }
 
+/** "<total> <title> jobs" — a collection's heading with its live open-job
+ *  count, comma-grouped. Falls back to the plain "<title> jobs" when no count
+ *  is available (the count is optional on the underlying job-search response). */
+export function collectionHeading(title: string, total: number | undefined): string {
+  return total === undefined ? `${title} jobs` : `${total.toLocaleString()} ${title} jobs`;
+}
+
 // schema.org employmentType, from the enrich vocabulary (see internal/enrich).
 const EMPLOYMENT_TYPE: Record<string, string> = {
   full_time: 'FULL_TIME',

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -37,7 +37,11 @@ export function jobPageTitle(job: Job): string {
  *  count, comma-grouped. Falls back to the plain "<title> jobs" when no count
  *  is available (the count is optional on the underlying job-search response). */
 export function collectionHeading(title: string, total: number | undefined): string {
-  return total === undefined ? `${title} jobs` : `${total.toLocaleString()} ${title} jobs`;
+  // Pinned locale: this feeds crawler-visible <title>/OG metadata, so SSR and
+  // the post-hydration client recompute must format the number identically
+  // regardless of the visitor's browser locale (relevant for collections like
+  // remote-brasil/remote-europe whose audience isn't en-US by default).
+  return total === undefined ? `${title} jobs` : `${total.toLocaleString('en-US')} ${title} jobs`;
 }
 
 // schema.org employmentType, from the enrich vocabulary (see internal/enrich).

--- a/web/src/routes/collections/[slug]/+page.svelte
+++ b/web/src/routes/collections/[slug]/+page.svelte
@@ -2,7 +2,13 @@
   import { page } from '$app/state';
   import JobsView from '$lib/components/JobsView.svelte';
   import Seo from '$lib/components/Seo.svelte';
-  import { breadcrumbJsonLd, collectionPageJsonLd, jobListItems, jsonLdScript } from '$lib/seo';
+  import {
+    breadcrumbJsonLd,
+    collectionHeading,
+    collectionPageJsonLd,
+    jobListItems,
+    jsonLdScript,
+  } from '$lib/seo';
   import { backerBadges } from '$lib/backers';
   import type { PageData } from './$types';
 
@@ -12,8 +18,9 @@
   // Self-canonical: the landing page is the collection's canonical home, never the
   // bare /jobs the raw ?collections= filter would resolve to.
   const canonical = $derived(`${origin}/collections/${data.slug}`);
-  // Template copy from the collection's display title (see design): "<title> jobs".
-  const heading = $derived(`${data.collection.title} jobs`);
+  // Template copy from the collection's display title, with its live open-job
+  // count (see design): "<total> <title> jobs".
+  const heading = $derived(collectionHeading(data.collection.title, data.initial.total));
   // The backing brand's mark, where this collection names one. A filter collection
   // or an editorial theme has none, and then the heading stands alone.
   const mark = $derived(backerBadges([data.slug])[0]?.mark ?? null);

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/state';
   import JobApplyForm from '$lib/components/JobApplyForm.svelte';
   import JobRelated from '$lib/components/JobRelated.svelte';
+  import JobSeeAlso from '$lib/components/JobSeeAlso.svelte';
   import JobView from '$lib/components/JobView.svelte';
   import Seo from '$lib/components/Seo.svelte';
   import {
@@ -54,4 +55,6 @@
     copiesTotal={data.copiesTotal}
     slug={data.job.public_slug}
   />
+
+  <JobSeeAlso job={data.job} />
 </div>


### PR DESCRIPTION
## Summary

Implements `programmatic-seo-collections` (OpenSpec change, `openspec/changes/programmatic-seo-collections/`):

- **Live job count in `/collections/[slug]` title/H1/OG.** `"1,234 React jobs · freehire"` instead of a static string — for both filter collections (react, remote-europe, ...) and company collections (yc, bigtech, ...), which already share one route.
- **Expanded `FILTER_COLLECTIONS`** with 22 new entries verified against the live prod search API before shipping: 4 single-country remote landings (Canada, UK, India, Poland), 13 skill landings (mongodb, mysql, elasticsearch, dotnet, laravel, flutter, azure, gcp, jenkins, ansible, pytorch, tensorflow, solidity), 5 role landings.
- **A "see also" block on the job detail page** linking into existing `/collections/:slug` pages, matched from the viewed job's own facets (category, seniority, skills, region) and its company's collections (e.g. `yc`) — padded with a popular-collections fallback so it's never sparse. No new fetch; built entirely from data the page already loads.

Mid-implementation correction (see `docs/superpowers/specs/2026-08-09-programmatic-seo-filter-and-company-collections-design.md` and the OpenSpec design.md): the original design proposed a new company-collection page type, which turned out to already exist (`internal/collections`' registry, unified with `FILTER_COLLECTIONS` behind `collectionBySlug`) — dropped from scope. Also discovered the Job wire object has no client-side `role` field (only `category`/`seniority` separately, composed into `role` server-side by `internal/roletag`), so the see-also matcher deliberately never matches on `role` to avoid duplicating that server-side logic.

## Test plan

- [x] `pnpm vitest run` — 854/854 passing (web/)
- [x] `pnpm svelte-check` — 0 errors
- [x] `go build ./...` / `go vet ./...` — clean (no backend changes)
- [x] Manual verification against production data (`VITE_API_URL=https://freehire.me`): a real full-stack job's see-also block correctly links JavaScript/TypeScript/Go/React/Full-Stack; a YC-backed company's job correctly adds `yc` after its facet matches; `/collections/react` and `/collections/yc` both show live exact counts; all linked collection pages (including newly-added ones) resolve 200
- [x] Every new `FILTER_COLLECTIONS` entry individually verified to have a healthy non-empty live count before being added
- [x] Each implementation step went through an independent code-review pass (subagent), with findings fixed before moving on