### PR TITLE
SEO see-also: card carousel with live counts

### DIFF
--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -4,9 +4,11 @@ import {
   POPULAR_COLLECTION_FALLBACK,
   collectionBySlug,
   collectionSlugs,
+  jobFacetsFromJob,
   relatedCollectionLinks,
   relatedCollectionSlugs,
 } from './collections';
+import type { Job } from './types';
 import { FACETS } from './facets';
 
 // Minimal JobFacets fixture — every field defaults to "no signal" so a test
@@ -233,5 +235,43 @@ describe('relatedCollectionLinks', () => {
   it('produces the same slugs, in the same order, as relatedCollectionSlugs', () => {
     const job = jobFacets({ skills: ['react'], collections: ['yc'] });
     expect(relatedCollectionLinks(job).map((l) => l.slug)).toEqual(relatedCollectionSlugs(job));
+  });
+});
+
+describe('jobFacetsFromJob', () => {
+  it('reads category/seniority from enrichment, the rest from top-level Job fields', () => {
+    const job = {
+      skills: ['react'],
+      work_mode: 'remote',
+      countries: ['us'],
+      regions: ['global'],
+      collections: ['yc'],
+      enrichment: { category: 'backend', seniority: 'senior' },
+    } as Job;
+
+    expect(jobFacetsFromJob(job)).toEqual({
+      category: 'backend',
+      seniority: 'senior',
+      skills: ['react'],
+      workMode: 'remote',
+      countries: ['us'],
+      regions: ['global'],
+      collections: ['yc'],
+    });
+  });
+
+  it('leaves category/seniority undefined when the job carries neither', () => {
+    const job = {
+      skills: [],
+      countries: [],
+      regions: [],
+      collections: [],
+      enrichment: {},
+    } as unknown as Job;
+
+    const facets = jobFacetsFromJob(job);
+    expect(facets.category).toBeUndefined();
+    expect(facets.seniority).toBeUndefined();
+    expect(facets.workMode).toBeUndefined();
   });
 });

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -1,3 +1,5 @@
+import type { Job } from './types';
+
 // A filter collection is the second kind of collection: a curated card that maps
 // to an arbitrary /jobs facet filter rather than company membership. Unlike
 // COLLECTIONS it is frontend-only — no Go registry, no `collections` search-facet
@@ -598,6 +600,21 @@ export type ResolvedCollection = {
   params: Record<string, string>;
 };
 
+// One card in a "see also" style block (JobSeeAlso), mirroring the /collections
+// hub's CollectionCard: count is the collection's live open-job total, or null
+// when it couldn't be fetched — decorative, so a failure degrades to no count
+// rather than breaking the block. mark is the backing brand's icon (Y
+// Combinator, Techstars, …), null for a filter collection or unbranded
+// editorial collection. The type lives here (not in a route file) so both the
+// server load that computes it and the component that renders it import from
+// one place.
+export type SeeAlsoCard = {
+  slug: string;
+  title: string;
+  count: number | null;
+  mark: string | null;
+};
+
 // Flatten a filter collection's params to the single-valued scope shape. A
 // single-element list collapses to its element; a genuine multi-value param is
 // unsupported by `scope` today and takes its first value (no such data exists).
@@ -656,6 +673,22 @@ export type JobFacets = {
   regions: string[];
   collections: string[];
 };
+
+// Builds JobFacets from a wire Job — the one place that knows the
+// enrichment.* vs top-level split documented on JobFacets above. Callers
+// (currently jobs/[slug]/+page.server.ts) use this instead of hand-mapping
+// fields, so a future Job shape change only needs updating here.
+export function jobFacetsFromJob(job: Job): JobFacets {
+  return {
+    category: job.enrichment.category,
+    seniority: job.enrichment.seniority,
+    skills: job.skills,
+    workMode: job.work_mode,
+    countries: job.countries,
+    regions: job.regions,
+    collections: job.collections,
+  };
+}
 
 // Popular collections padding a sparse "see also" block so it's never empty
 // or too thin. Slugs are verified to exist in FILTER_COLLECTIONS by a test.

--- a/web/src/lib/components/JobSeeAlso.svelte
+++ b/web/src/lib/components/JobSeeAlso.svelte
@@ -1,36 +1,34 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { relatedCollectionLinks, type JobFacets } from '$lib/collections';
-  import type { Job } from '$lib/types';
+  import type { SeeAlsoCard } from '$lib/collections';
 
-  // A bounded row of links into existing /collections/:slug pages, built from
-  // this job's own facets and its company's collections — see design's
-  // relatedCollectionLinks. No fetch: everything it needs is already on `job`.
-  let { job }: { job: Job } = $props();
-
-  const facets = $derived<JobFacets>({
-    category: job.enrichment.category,
-    seniority: job.enrichment.seniority,
-    skills: job.skills,
-    workMode: job.work_mode,
-    countries: job.countries,
-    regions: job.regions,
-    collections: job.collections,
-  });
-
-  const links = $derived(relatedCollectionLinks(facets));
+  // A horizontally-scrolling row of links into existing /collections/:slug
+  // pages, each showing the collection's live open-job count — mirrors the
+  // /collections hub's card, minus the description (this block is a
+  // secondary discovery aid, not the hub itself). `cards` is computed
+  // server-side (+page.server.ts) from this job's own facets and its
+  // company's collections; no client-side fetch.
+  let { cards }: { cards: SeeAlsoCard[] } = $props();
 </script>
 
-{#if links.length > 0}
+{#if cards.length > 0}
   <section class="mt-8">
     <h2 class="mb-3 text-sm font-semibold text-muted-foreground">See also</h2>
-    <div class="flex flex-wrap gap-2">
-      {#each links as link (link.slug)}
+    <div class="flex gap-3 overflow-x-auto pb-1">
+      {#each cards as card (card.slug)}
         <a
-          href={resolve('/collections/[slug]', { slug: link.slug })}
-          class="rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+          href={resolve('/collections/[slug]', { slug: card.slug })}
+          class="flex w-40 shrink-0 flex-col items-start gap-2 rounded-lg border border-border p-3 transition-colors hover:bg-muted"
         >
-          {link.title}
+          {#if card.mark}
+            <img src={card.mark} alt="" class="size-6 shrink-0 rounded-sm object-contain" />
+          {/if}
+          <span class="text-sm font-medium text-foreground">{card.title} jobs</span>
+          {#if card.count !== null}
+            <span class="rounded-full bg-secondary px-2 py-0.5 font-mono text-xs text-muted-foreground">
+              {card.count.toLocaleString()} jobs
+            </span>
+          {/if}
         </a>
       {/each}
     </div>

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -1,5 +1,12 @@
 import { error } from '@sveltejs/kit';
 import { ApiError } from '$lib/api';
+import { backerBadges } from '$lib/backers';
+import {
+  collectionBySlug,
+  jobFacetsFromJob,
+  relatedCollectionLinks,
+  type SeeAlsoCard,
+} from '$lib/collections';
 import { serverApi } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
@@ -31,11 +38,29 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
     api.getJobCopies(params.slug, 10).catch(() => ({ copies: [], total: 0 })),
     api.getApplyForm(params.slug).catch(() => null),
   ]);
+
+  // The "see also" block's matched collections, each with its live open-job
+  // count — needs `job`'s own facets, so it can't join the Promise.all above.
+  // Bounded to relatedCollectionLinks' target (~5), so this is a handful of
+  // small parallel requests, not a scan.
+  const seeAlso: SeeAlsoCard[] = await Promise.all(
+    relatedCollectionLinks(jobFacetsFromJob(job)).map(async (link): Promise<SeeAlsoCard> => {
+      const resolved = collectionBySlug(link.slug);
+      let count: number | null = null;
+      if (resolved) {
+        count = (await api.searchJobs(new URLSearchParams(resolved.params), 0, 0).catch(() => null))
+          ?.total ?? null;
+      }
+      return { slug: link.slug, title: link.title, count, mark: backerBadges([link.slug])[0]?.mark ?? null };
+    })
+  );
+
   return {
     job,
     similar,
     copies: copiesResult.copies,
     copiesTotal: copiesResult.total,
     applyForm,
+    seeAlso,
   };
 };

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -11,15 +11,38 @@ import { serverApi } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
 // Server-render the job detail: fetch by slug so the article content is in the
-// initial HTML. A 404 from the API becomes a SvelteKit 404 page (not a 200
-// shell); other failures bubble to the 500 page.
+// initial HTML. All fetches stay awaited (not streamed) so every section is in
+// the SSR HTML for internal-link crawlability.
 export const load: PageServerLoad = async ({ params, fetch }) => {
   const api = serverApi(fetch);
-  // Both fetches key only on the slug and are independent, so run them in parallel
-  // — serialising them cost a full API round-trip on every job page. They stay
-  // awaited (not streamed) so the "Similar jobs" rows remain in the SSR HTML for
-  // internal-link crawlability.
-  //
+
+  const jobPromise = api.getJob(params.slug).catch((e) => {
+    if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
+    throw e;
+  });
+
+  // The "see also" block's matched collections, each with its live open-job
+  // count. It needs `job`'s own facets, so it can only start once `job`
+  // resolves — but it's kicked off right here (not after the Promise.all
+  // below) so it overlaps with similar/copies/applyForm instead of adding a
+  // second sequential wave after them. Bounded to relatedCollectionLinks'
+  // target (~5), so this is a handful of small parallel requests, not a scan.
+  const seeAlsoPromise = jobPromise.then((job) =>
+    Promise.all(
+      relatedCollectionLinks(jobFacetsFromJob(job)).map(async (link): Promise<SeeAlsoCard> => {
+        // relatedCollectionLinks already resolves every slug it returns via this
+        // same collectionBySlug, so `resolved` is guaranteed here — this is TS
+        // narrowing for the `resolved.params` access below, not a real fallback path.
+        const resolved = collectionBySlug(link.slug);
+        const count = resolved
+          ? ((await api.searchJobs(new URLSearchParams(resolved.params), 0, 0).catch(() => null))
+              ?.total ?? null)
+          : null;
+        return { slug: link.slug, title: link.title, count, mark: backerBadges([link.slug])[0]?.mark ?? null };
+      })
+    )
+  );
+
   // Similar jobs are a non-essential discovery aid: a failure (search disabled,
   // no neighbours yet) must not break the page, so it degrades to an empty list.
   //
@@ -27,33 +50,15 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
   // publish one we can read — so its absence is the ordinary case, not a failure. It
   // degrades to null for the same reason the two below degrade to empty: nothing on this
   // page may be able to break the page.
-  const [job, similar, copiesResult, applyForm] = await Promise.all([
-    api.getJob(params.slug).catch((e) => {
-      if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
-      throw e;
-    }),
+  const [job, similar, copiesResult, applyForm, seeAlso] = await Promise.all([
+    jobPromise,
     api.getSimilarJobs(params.slug).catch(() => []),
     // A small preview of the other-locations tab (the full list is /jobs/:slug/copies).
     // Non-essential and only meaningful for a mass-posted role, so it degrades to empty.
     api.getJobCopies(params.slug, 10).catch(() => ({ copies: [], total: 0 })),
     api.getApplyForm(params.slug).catch(() => null),
+    seeAlsoPromise,
   ]);
-
-  // The "see also" block's matched collections, each with its live open-job
-  // count — needs `job`'s own facets, so it can't join the Promise.all above.
-  // Bounded to relatedCollectionLinks' target (~5), so this is a handful of
-  // small parallel requests, not a scan.
-  const seeAlso: SeeAlsoCard[] = await Promise.all(
-    relatedCollectionLinks(jobFacetsFromJob(job)).map(async (link): Promise<SeeAlsoCard> => {
-      const resolved = collectionBySlug(link.slug);
-      let count: number | null = null;
-      if (resolved) {
-        count = (await api.searchJobs(new URLSearchParams(resolved.params), 0, 0).catch(() => null))
-          ?.total ?? null;
-      }
-      return { slug: link.slug, title: link.title, count, mark: backerBadges([link.slug])[0]?.mark ?? null };
-    })
-  );
 
   return {
     job,

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -56,5 +56,5 @@
     slug={data.job.public_slug}
   />
 
-  <JobSeeAlso job={data.job} />
+  <JobSeeAlso cards={data.seeAlso} />
 </div>


### PR DESCRIPTION
## Summary

Follow-up to #1671 (already merged/deployed). The job-page "see also" block gets a
visual redesign, matching the /collections hub's already-shipped card pattern:

- Replaces plain text-chip links with a horizontal card row: brand mark (when the
  collection has one, e.g. Y Combinator), `"{title} jobs"` text, and a live open-job
  count pill — same data shape as `/collections`' `CollectionCard`.
- `jobFacetsFromJob()` extracts the job→facets mapping into a tested pure function
  (previously inline in the component).
- `+page.server.ts` computes each card's live count via a bounded (~5) set of
  `searchJobs(..., 0, 0)` calls, kicked off the moment `job` resolves so they overlap
  with the similar/copies/applyForm fetches rather than adding a second sequential
  wave (caught and fixed during this PR's own code review).

## Test plan

- [x] `pnpm vitest run` — 856/856 passing
- [x] `pnpm svelte-check` — 0 errors
- [x] Manual verification in browser against production data: a regular job's
  see-also cards show correct titles + live counts (e.g. "React jobs · 24,468 jobs");
  a YC-backed company's job additionally shows the Y Combinator brand mark
- [x] Independent code-review pass (subagent) — one Important finding (sequential
  vs. overlapped fetch waves) fixed before this PR