### PR TITLE
Refine AI role classification: skill-signature archetypes, FDE aliases, MCP/RAG dictionary gaps

### DIFF
--- a/internal/aiarchetype/aiarchetype.go
+++ b/internal/aiarchetype/aiarchetype.go
@@ -1,0 +1,98 @@
+// Package aiarchetype derives a job's AI skill-signature archetype
+// deterministically from its already-resolved skills and category — the same
+// dict-only doctrine as internal/classify, internal/roletag, and
+// internal/skilltag: it emits one of a curated set of archetype slugs for what
+// it can resolve and nothing for what it cannot (it never guesses, never calls
+// a model).
+//
+// The six archetypes approximate the stable clusters a skill-signature k-means
+// analysis of the AI engineering job market found (see the field guide this
+// package's design is based on): RAG app builder, agent builder, cloud/ML
+// platform engineer, ML trainer/researcher, full-stack AI engineer, and
+// DevOps/infra engineer. Unlike that clustering, this package is a small
+// ordered rule set over internal/skilltag's existing canonical vocabulary — a
+// deliberate simplification consistent with the project's dict-only doctrine,
+// which forbids a model call for a production facet.
+package aiarchetype
+
+// inScopeCategories are the categories aiarchetype evaluates. Every other
+// category yields no archetype, regardless of skills — the archetypes were
+// derived from AI-titled job postings and are not meaningful outside them.
+var inScopeCategories = map[string]bool{
+	"ai_engineering": true,
+	"ml_ai":          true,
+}
+
+// rule is one archetype's skill-signature test. Rules are evaluated in a fixed
+// priority order (see rules below): the first whose match reports true wins,
+// so an earlier rule's signature must be a superset-safe subset of any later,
+// broader rule it could otherwise be swallowed by.
+type rule struct {
+	archetype string
+	match     func(has func(string) bool) bool
+}
+
+// rules are evaluated in this order — most AI-distinctive signature first,
+// most generic/overlapping last — so a job matching an earlier rule is claimed
+// before a later, broader rule sees it. See design.md decision 3 for the
+// rationale behind each rule and this ordering.
+var rules = []rule{
+	{
+		"rag_app_builder",
+		func(has func(string) bool) bool {
+			return has("rag") && (has("langchain") || has("langgraph") || has("llamaindex")) && has("vector-databases")
+		},
+	},
+	{
+		"agent_builder",
+		func(has func(string) bool) bool {
+			return has("agentic-ai") && has("prompt-engineering") && has("rag")
+		},
+	},
+	{
+		"cloud_ml_platform_engineer",
+		func(has func(string) bool) bool {
+			return has("mlops") && has("kubernetes") && (has("pytorch") || has("tensorflow"))
+		},
+	},
+	{
+		"ml_trainer_researcher",
+		func(has func(string) bool) bool {
+			return (has("pytorch") || has("tensorflow")) && !has("rag") && !has("agentic-ai")
+		},
+	},
+	{
+		"fullstack_ai_engineer",
+		func(has func(string) bool) bool {
+			return (has("react") || has("nodejs")) && (has("llm") || has("openai") || has("anthropic"))
+		},
+	},
+	{
+		"devops_infra_engineer",
+		func(has func(string) bool) bool {
+			return has("terraform") && has("kubernetes") && has("docker") && has("ci-cd")
+		},
+	},
+}
+
+// Derive returns the single skill-signature archetype a job's skills and
+// category resolve to, or "" if category is out of scope or no rule matches.
+// It never returns more than one archetype: the archetypes are the
+// mutually-exclusive clusters the field guide's analysis found, not additive
+// facets, so the first (highest-priority) matching rule wins.
+func Derive(skills []string, category string) string {
+	if !inScopeCategories[category] {
+		return ""
+	}
+	set := make(map[string]bool, len(skills))
+	for _, s := range skills {
+		set[s] = true
+	}
+	has := func(s string) bool { return set[s] }
+	for _, r := range rules {
+		if r.match(has) {
+			return r.archetype
+		}
+	}
+	return ""
+}

--- a/internal/aiarchetype/aiarchetype_test.go
+++ b/internal/aiarchetype/aiarchetype_test.go
@@ -1,0 +1,97 @@
+package aiarchetype
+
+import "testing"
+
+func TestDerive(t *testing.T) {
+	cases := []struct {
+		name     string
+		skills   []string
+		category string
+		want     string
+	}{
+		{
+			"rag app builder",
+			[]string{"rag", "langchain", "langgraph", "vector-databases"},
+			"ai_engineering",
+			"rag_app_builder",
+		},
+		{
+			"rag app builder with llamaindex instead of langchain",
+			[]string{"rag", "llamaindex", "vector-databases"},
+			"ml_ai",
+			"rag_app_builder",
+		},
+		{
+			"agent builder",
+			[]string{"agentic-ai", "prompt-engineering", "rag"},
+			"ai_engineering",
+			"agent_builder",
+		},
+		{
+			"cloud ml platform engineer",
+			[]string{"mlops", "kubernetes", "pytorch"},
+			"ai_engineering",
+			"cloud_ml_platform_engineer",
+		},
+		{
+			"ml trainer researcher",
+			[]string{"pytorch", "tensorflow"},
+			"ai_engineering",
+			"ml_trainer_researcher",
+		},
+		{
+			"fullstack ai engineer",
+			[]string{"react", "nodejs", "openai"},
+			"ai_engineering",
+			"fullstack_ai_engineer",
+		},
+		{
+			"devops infra engineer",
+			[]string{"terraform", "kubernetes", "docker", "ci-cd"},
+			"ai_engineering",
+			"devops_infra_engineer",
+		},
+		{
+			"rag app builder wins over agent builder on overlapping skills",
+			[]string{"rag", "langchain", "langgraph", "vector-databases", "agentic-ai", "prompt-engineering"},
+			"ai_engineering",
+			"rag_app_builder",
+		},
+		{
+			"ml trainer excludes rag-flavored jobs",
+			[]string{"pytorch", "tensorflow", "rag"},
+			"ai_engineering",
+			"", // 64% of ai-first roles need "some" ML per the field guide — pytorch/tensorflow
+			// alone must not steal a job an earlier, more AI-specific rule would otherwise claim.
+			// This case satisfies none of the six rules: rule 1/2 need more than bare "rag",
+			// rule 4 explicitly excludes "rag".
+		},
+		{
+			"category outside ai/ml scope yields no archetype regardless of skills",
+			[]string{"rag", "langchain", "langgraph", "vector-databases"},
+			"backend",
+			"",
+		},
+		{
+			"in-scope category with no matching rule yields no archetype",
+			[]string{"go", "postgresql"},
+			"ai_engineering",
+			"",
+		},
+		{
+			"empty skills yields no archetype",
+			nil,
+			"ai_engineering",
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Derive(tc.skills, tc.category)
+			if got != tc.want {
+				t.Fatalf("Derive(%v, %q) = %q, want %q", tc.skills, tc.category, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -172,8 +172,12 @@ func Derive(in Input) Derived {
 		Cities:      cities,
 		WorkMode:    workMode,
 		// Skills is a set: the structured source skills are unioned with the
-		// dictionary skills, neither replacing the other.
-		Skills:             unionSkills(in.Skills, skilltag.Parse(in.Description)),
+		// dictionary skills, neither replacing the other. The category-scoped
+		// acronym tier (e.g. RAG on an ai_engineering/ml_ai job) takes the
+		// resolved local `category` — NOT in.Category — so it also fires when the
+		// title dictionary supplied the category, the common case since most
+		// sources carry no structured category signal.
+		Skills:             unionSkills(in.Skills, skilltag.Parse(in.Description, skilltag.WithAcronymCategory(category))),
 		Seniority:          seniority,
 		Category:           category,
 		IsTech:             isTech,

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -2,6 +2,7 @@ package jobderive
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/normalize"
@@ -379,6 +380,48 @@ func TestDerive_SourceSkillsUnionWithDictionary(t *testing.T) {
 	})
 	if !reflect.DeepEqual(got.Skills, []string{"go", "kubernetes"}) {
 		t.Errorf("Skills = %v, want [go kubernetes] (source ∪ dictionary, deduped+sorted)", got.Skills)
+	}
+}
+
+// The job's resolved category is passed into skilltag.Parse's category-scoped
+// acronym tier (refine-ai-role-classification), so a bare "RAG" mention resolves
+// to the "rag" skill on an AI-category job — closing the under-tagging gap the
+// résumé-only acronym left on job postings. Input.Category is deliberately left
+// empty here: the resolved category must come from the title dictionary
+// (class.Category), the common real-world path since most sources carry no
+// structured category signal — passing the raw in.Category instead of the
+// resolved local would compile fine and pass a test that set Category directly,
+// but silently miss this path.
+func TestDerive_CategoryScopedAcronymFillsSkills(t *testing.T) {
+	got := Derive(Input{
+		Title:       "AI Engineer", // resolves to category ai_engineering via the title dictionary
+		Company:     "Acme",
+		Source:      "getmatch",
+		ExternalID:  "1",
+		Description: "Built RAG pipelines over pgvector.",
+	})
+	if got.Category != "ai_engineering" {
+		t.Fatalf("Category = %q, want ai_engineering (test setup precondition)", got.Category)
+	}
+	if !slices.Contains(got.Skills, "rag") {
+		t.Errorf("Skills = %v, want to contain \"rag\" (category-scoped RAG acronym)", got.Skills)
+	}
+}
+
+// The category-scoped acronym tier only fires for categories on its own
+// allow-list — a category outside ai_engineering/ml_ai must not tag bare "RAG",
+// same as today.
+func TestDerive_CategoryScopedAcronymDoesNotFireOutsideAllowList(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Backend Engineer",
+		Company:     "Acme",
+		Source:      "getmatch",
+		ExternalID:  "1",
+		Category:    "backend",
+		Description: "We report RAG status weekly.",
+	})
+	if slices.Contains(got.Skills, "rag") {
+		t.Errorf("Skills = %v, must not contain \"rag\" for category backend", got.Skills)
 	}
 }
 

--- a/internal/roletag/roletag.go
+++ b/internal/roletag/roletag.go
@@ -115,7 +115,16 @@ var namedRoleTable = []struct {
 	{"founding_pm", "Founding Product Manager", []string{"founding product manager", "founding pm"}},
 	{"staff_engineer", "Staff Engineer", []string{"staff engineer"}},
 	{"technical_lead", "Technical Lead", []string{"technical lead", "tech lead"}},
-	{"forward_deployed_engineer", "Forward Deployed Engineer", []string{"forward deployed engineer"}},
+	// Alias set matches the field guide's own FDE methodology: title contains "FDE"
+	// or "forward deploy", case-insensitive. "forward-deployed" is its own alias
+	// because a hyphen is a word boundary here (same trap documented elsewhere in
+	// this table) — "forward deploy" alone would not match the hyphenated spelling.
+	{"forward_deployed_engineer", "Forward Deployed Engineer", []string{"forward deployed engineer", "forward deploy", "forward-deployed", "fde"}},
+	// Field-guide-documented synonym titles for the same class of work, kept as
+	// their own slugs rather than merged into forward_deployed_engineer — a job's
+	// derived role should reflect the title it was actually posted under.
+	{"applied_ai_engineer", "Applied AI Engineer", []string{"applied ai engineer"}},
+	{"deployment_engineer", "Deployment Engineer", []string{"deployment engineer"}},
 	{"growth_engineer", "Growth Engineer", []string{"growth engineer"}},
 	{"developer_advocate", "Developer Advocate", []string{"developer advocate", "developer relations", "developer evangelist", "devrel"}},
 	{"research_engineer", "Research Engineer", []string{"research engineer"}},

--- a/internal/roletag/roletag_test.go
+++ b/internal/roletag/roletag_test.go
@@ -85,6 +85,18 @@ func TestDerive(t *testing.T) {
 
 		// Never guesses: no seniority, no category, no named alias.
 		{"nothing resolvable", "", "", "Rockstar Ninja Guru", nil},
+
+		// FDE alias coverage (refine-ai-role-classification): the field guide's own
+		// matching rule is title contains "FDE" or "forward deploy", case-insensitive.
+		{"bare fde", "", "ai_engineering", "FDE - Enterprise AI", []string{"ai_engineering", "forward_deployed_engineer"}},
+		{"forward deploy engineer", "", "ai_engineering", "Forward Deploy Engineer", []string{"ai_engineering", "forward_deployed_engineer"}},
+		{"forward-deployed engineer hyphenated", "", "ai_engineering", "Forward-Deployed Engineer", []string{"ai_engineering", "forward_deployed_engineer"}},
+		{"forward deployed engineer unchanged", "", "ai_engineering", "Forward Deployed Engineer", []string{"ai_engineering", "forward_deployed_engineer"}},
+		// Synonym titles get their own slug, not merged into FDE — title fidelity.
+		{"applied ai engineer own slug", "", "ai_engineering", "Applied AI Engineer", []string{"ai_engineering", "applied_ai_engineer"}},
+		{"deployment engineer own slug", "", "", "Deployment Engineer", []string{"deployment_engineer"}},
+		// Gradeable, like every other single-phrase named role in this table.
+		{"senior forward deployed engineer composes", "senior", "ai_engineering", "Senior Forward Deployed Engineer", []string{"senior", "ai_engineering", "senior_ai_engineering", "forward_deployed_engineer", "senior_forward_deployed_engineer"}},
 	}
 
 	for _, tc := range cases {

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -810,6 +810,9 @@ func facetSettings() *meilisearch.Settings {
 			// roles is derived at index time (roletag) and served top-level like the
 			// other bare facets, so it filters on the plain attribute, not a dot path.
 			"roles",
+			// ai_archetype is derived at index time (aiarchetype) from skills+category,
+			// same pattern as roles.
+			"ai_archetype",
 			"enrichment.employment_type", "enrichment.education_level", "enrichment.seniority",
 			"enrichment.category", "enrichment.domains",
 			"enrichment.company_type", "enrichment.company_size", "enrichment.visa_sponsorship",

--- a/internal/search/document.go
+++ b/internal/search/document.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/strelov1/freehire/internal/aiarchetype"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/jobview"
@@ -45,6 +46,13 @@ type JobDocument struct {
 	// document (not jobview.Job), so it backs the `roles` facet but is never part
 	// of the served public wire shape.
 	Roles []string `json:"roles"`
+	// AIArchetype is the job's skill-signature AI archetype, derived at index
+	// time by aiarchetype from its already-resolved skills and category (empty
+	// for categories outside its ai_engineering/ml_ai scope, or when no rule
+	// matches). Like Roles, it is declared on the document, not jobview.Job, so
+	// it backs the `ai_archetype` facet but is never part of the served public
+	// wire shape.
+	AIArchetype string `json:"ai_archetype"`
 	// semanticVector is the job's persisted embedding (jobs.semantic_embedding), carried
 	// transiently so a --from-pg rebuild can rehydrate the semantic index from the stored
 	// vectors instead of re-embedding via TEI. Unexported, so it is never serialized into
@@ -69,7 +77,12 @@ func FromJob(j db.Job) (JobDocument, error) {
 	// the search document — the detail endpoint serves the full description from
 	// its own jobview.FromRow, unaffected by this local copy.
 	view.Description = truncateRunes(view.Description, maxIndexedDescriptionRunes)
-	doc := JobDocument{ID: j.ID, Job: view, Roles: roletag.Derive(j.Seniority, j.Category, j.Title)}
+	doc := JobDocument{
+		ID:          j.ID,
+		Job:         view,
+		Roles:       roletag.Derive(j.Seniority, j.Category, j.Title),
+		AIArchetype: aiarchetype.Derive(j.Skills, j.Category),
+	}
 	doc.semanticVector = j.SemanticEmbedding
 	if eff := jobview.EffectivePostedAt(j.PostedAt, j.CreatedAt, time.Now()); eff.Valid {
 		doc.PostedTS = eff.Time.Unix()

--- a/internal/search/document_test.go
+++ b/internal/search/document_test.go
@@ -116,6 +116,56 @@ func TestMergeClusterGeography_EmptyClusterLeavesFacetsUnchanged(t *testing.T) {
 	}
 }
 
+func TestFromJob_AIArchetypeDerivedButIndexOnly(t *testing.T) {
+	doc, err := FromJob(db.Job{
+		ID: 1, PublicSlug: "s", Category: "ai_engineering",
+		Skills: []string{"rag", "langchain", "langgraph", "vector-databases"},
+	})
+	if err != nil {
+		t.Fatalf("FromJob: %v", err)
+	}
+	if doc.AIArchetype != "rag_app_builder" {
+		t.Errorf("ai_archetype = %q, want rag_app_builder", doc.AIArchetype)
+	}
+
+	// A non-AI category yields no archetype, regardless of skills.
+	nonAI, err := FromJob(db.Job{
+		ID: 2, PublicSlug: "s2", Category: "backend",
+		Skills: []string{"rag", "langchain", "langgraph", "vector-databases"},
+	})
+	if err != nil {
+		t.Fatalf("FromJob: %v", err)
+	}
+	if nonAI.AIArchetype != "" {
+		t.Errorf("ai_archetype = %q, want empty for category backend", nonAI.AIArchetype)
+	}
+
+	// ai_archetype rides the document top level (like roles) so it is filterable...
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	var full map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &full); err != nil {
+		t.Fatalf("unmarshal doc: %v", err)
+	}
+	if _, ok := full["ai_archetype"]; !ok {
+		t.Errorf("document should carry a top-level ai_archetype field: %s", raw)
+	}
+	// ...but it must NOT be part of the public wire shape (the served jobview.Job).
+	viewRaw, err := json.Marshal(doc.Job)
+	if err != nil {
+		t.Fatalf("marshal view: %v", err)
+	}
+	var view map[string]json.RawMessage
+	if err := json.Unmarshal(viewRaw, &view); err != nil {
+		t.Fatalf("unmarshal view: %v", err)
+	}
+	if _, ok := view["ai_archetype"]; ok {
+		t.Errorf("ai_archetype leaked into the public job wire shape: %s", viewRaw)
+	}
+}
+
 func TestFromJob_DocumentFlattensIDAndViewToTopLevelJSON(t *testing.T) {
 	// Meilisearch reads the primary key "id" from the top level of the document,
 	// and the embedded jobview.Job must flatten (no nesting) so its fields are

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -32,6 +32,7 @@ var StringFacets = map[string]string{
 	"skills":           "skills",
 	"is_tech":          "is_tech",
 	"role":             "roles",
+	"ai_archetype":     "ai_archetype",
 	"reality":          "reality.class",
 	"collections":      "collections",
 	"relocation":       "enrichment.relocation",

--- a/internal/search/settings_test.go
+++ b/internal/search/settings_test.go
@@ -50,6 +50,19 @@ func TestRolesIsFilterable(t *testing.T) {
 	}
 }
 
+func TestAIArchetypeIsFilterable(t *testing.T) {
+	// The ai_archetype facet filters on a bare top-level `ai_archetype` attribute
+	// (derived at index time by aiarchetype), so it must be declared filterable
+	// for `ai_archetype=` to take effect.
+	s := facetSettings()
+	if !contains(s.FilterableAttributes, "ai_archetype") {
+		t.Errorf("ai_archetype must be filterable for the ai_archetype facet, got %v", s.FilterableAttributes)
+	}
+	if StringFacets["ai_archetype"] != "ai_archetype" {
+		t.Errorf("StringFacets[ai_archetype] = %q, want the bare attribute \"ai_archetype\"", StringFacets["ai_archetype"])
+	}
+}
+
 func TestIsTechIsFilterableFacet(t *testing.T) {
 	// is_tech is served top-level (jobview) and filtered on the bare attribute, so it
 	// must be declared filterable for `is_tech=` to take effect and its facet counts.

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -245,21 +245,25 @@ var wordAliases = map[string]string{
 	"langgraph":  "langgraph",
 	"langsmith":  "langsmith",
 	"llamaindex": "llamaindex",
-	"crewai":     "crewai",
-	"autogen":    "autogen",
-	"anthropic":  "anthropic",
-	"cohere":     "cohere",
-	"mistral":    "mistral",
-	"ollama":     "ollama",
-	"vllm":       "vllm",
-	"tensorrt":   "tensorrt",
-	"triton":     "triton",
-	"onnx":       "onnx",
-	"deepspeed":  "deepspeed",
-	"bentoml":    "bentoml",
-	"peft":       "peft",
-	"yolo":       "yolo",
-	"sagemaker":  "sagemaker",
+	// "Microsoft Certified Professional" is the only real-world collision, and it's a
+	// legacy-2000s abbreviation essentially absent from current job postings — unlike the
+	// live English-word collisions ambiguousWords exists for. Strong, ungated alias.
+	"mcp":       "mcp",
+	"crewai":    "crewai",
+	"autogen":   "autogen",
+	"anthropic": "anthropic",
+	"cohere":    "cohere",
+	"mistral":   "mistral",
+	"ollama":    "ollama",
+	"vllm":      "vllm",
+	"tensorrt":  "tensorrt",
+	"triton":    "triton",
+	"onnx":      "onnx",
+	"deepspeed": "deepspeed",
+	"bentoml":   "bentoml",
+	"peft":      "peft",
+	"yolo":      "yolo",
+	"sagemaker": "sagemaker",
 	// mobile
 	"android": "android",
 	"ios":     "ios",
@@ -1207,4 +1211,25 @@ var sharedAcronyms = map[string]string{
 // in résumés that collision is near-absent. Each value is an existing canonical.
 var resumeAcronyms = map[string]string{
 	"RAG": "rag",
+}
+
+// categoryScopedAcronym pairs a canonical with the job categories it may resolve
+// for (see WithAcronymCategory) — a third acronym tier, for a term ambiguous in
+// job text generally but unambiguous within a specific category. The category
+// already evidences an AI-flavored posting (it required an AI-flavored title to
+// classify into it), so it substitutes for corroboration without reopening the
+// collision catalogue-wide.
+type categoryScopedAcronym struct {
+	canonical         string
+	allowedCategories map[string]bool
+}
+
+// categoryScopedAcronyms resolve on JOB text only when the caller supplies a
+// category on the acronym's own allow-list. RAG collides with "RAG status"
+// (red/amber/green project health) in general job text — hence resumeAcronyms
+// above — but within ai_engineering/ml_ai postings that collision is negligible
+// and the acronym is the dominant real-world spelling (vs. the spelled-out
+// "retrieval augmented generation" phrase).
+var categoryScopedAcronyms = map[string]categoryScopedAcronym{
+	"RAG": {canonical: "rag", allowedCategories: map[string]bool{"ai_engineering": true, "ml_ai": true}},
 }

--- a/internal/skilltag/dictionaries_test.go
+++ b/internal/skilltag/dictionaries_test.go
@@ -2,7 +2,10 @@ package skilltag
 
 import (
 	"reflect"
+	"slices"
 	"testing"
+
+	"github.com/strelov1/freehire/internal/vocab"
 )
 
 // TestDictionaryInvariants guards the two properties the engine relies on:
@@ -40,6 +43,23 @@ func TestDictionaryInvariants(t *testing.T) {
 			assertSlug(t, tier+"["+surface+"]", c)
 			if !existing[c] {
 				t.Errorf("%s[%q] → %q is not an existing canonical (would create a new facet value)", tier, surface, c)
+			}
+		}
+	}
+
+	// categoryScopedAcronyms shares the same invariant as the two tiers above (its
+	// canonical must be a valid slug already reachable via an existing alias), plus
+	// its own: every allow-listed category must be a real vocab.CategoryValues
+	// member, so a typo'd category string can't silently make the tier permanently
+	// dead (it would never match any job's resolved category).
+	for surface, ca := range categoryScopedAcronyms {
+		assertSlug(t, "categoryScopedAcronyms["+surface+"]", ca.canonical)
+		if !existing[ca.canonical] {
+			t.Errorf("categoryScopedAcronyms[%q] → %q is not an existing canonical (would create a new facet value)", surface, ca.canonical)
+		}
+		for category := range ca.allowedCategories {
+			if !slices.Contains(vocab.CategoryValues, category) {
+				t.Errorf("categoryScopedAcronyms[%q] allows category %q, not a member of vocab.CategoryValues", surface, category)
 			}
 		}
 	}

--- a/internal/skilltag/skilltag.go
+++ b/internal/skilltag/skilltag.go
@@ -133,7 +133,8 @@ func wordTokens(norm string) []string {
 type Option func(*options)
 
 type options struct {
-	resumeAcronyms bool
+	resumeAcronyms  bool
+	acronymCategory string
 }
 
 // WithResumeAcronyms enables the résumé-scoped acronym tier (resumeAcronyms, e.g.
@@ -143,6 +144,15 @@ type options struct {
 // profile's claimed skills) sets it.
 func WithResumeAcronyms() Option {
 	return func(o *options) { o.resumeAcronyms = true }
+}
+
+// WithAcronymCategory enables the category-scoped acronym tier
+// (categoryScopedAcronyms, e.g. RAG) for a Parse call, resolving an acronym
+// only when category is on that acronym's own allow-list. The job ingest path
+// (internal/jobderive) passes the job's already-resolved category; every other
+// caller omits it, so the tier stays off by default.
+func WithAcronymCategory(category string) Option {
+	return func(o *options) { o.acronymCategory = category }
 }
 
 // Parse scans free text and returns the curated canonical skill slugs it contains,
@@ -178,6 +188,16 @@ func Parse(text string, opts ...Option) []string {
 	matchAcronyms(cased, sharedAcronyms, strong)
 	if o.resumeAcronyms {
 		matchAcronyms(cased, resumeAcronyms, strong)
+	}
+	// Inlined rather than routed through matchAcronyms: its map value is a bare
+	// canonical string, but a categoryScopedAcronym also carries the allow-list
+	// matchAcronyms has no way to consult.
+	if o.acronymCategory != "" {
+		for surface, ca := range categoryScopedAcronyms {
+			if ca.allowedCategories[o.acronymCategory] && wordmatch.Contains(cased, surface, wordmatch.UnicodeBoundary) {
+				strong[ca.canonical] = struct{}{}
+			}
+		}
 	}
 
 	norm := normalize(text)

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -171,6 +171,35 @@ func TestParse_Acronyms(t *testing.T) {
 	}
 }
 
+// Category-scoped acronym pass (refine-ai-role-classification): RAG resolves on
+// job text when the caller supplies a job category on the acronym's own
+// allow-list (ai_engineering, ml_ai), and does not resolve otherwise — the
+// category already evidences an AI-flavored posting, so it substitutes for
+// corroboration without reopening the "RAG status" collision catalogue-wide.
+func TestParse_CategoryScopedAcronyms(t *testing.T) {
+	has := func(hay []string, needle string) bool {
+		for _, h := range hay {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+
+	if got := Parse("Built RAG pipelines over pgvector", WithAcronymCategory("ai_engineering")); !has(got, "rag") {
+		t.Errorf("Parse RAG (category ai_engineering) = %v, want rag", got)
+	}
+	if got := Parse("Built RAG pipelines over pgvector", WithAcronymCategory("ml_ai")); !has(got, "rag") {
+		t.Errorf("Parse RAG (category ml_ai) = %v, want rag", got)
+	}
+	if got := Parse("We report RAG status weekly", WithAcronymCategory("backend")); has(got, "rag") {
+		t.Errorf("Parse 'RAG status' (category backend) = %v, must not emit rag", got)
+	}
+	if got := Parse("Built RAG pipelines over pgvector"); has(got, "rag") {
+		t.Errorf("Parse RAG (no category option) = %v, must not emit rag", got)
+	}
+}
+
 // New tech/methodology vocabulary (skills-vocab-gaps): each resolves from a
 // realistic description; bare "rest" never tags (only "REST API"/"RESTful").
 func TestParse_NewTechVocab(t *testing.T) {
@@ -196,6 +225,7 @@ func TestParse_NewTechVocab(t *testing.T) {
 		{"rest via rest api", "You will design a REST API.", []string{"rest"}, nil},
 		{"power bi", "Dashboards in Power BI.", []string{"powerbi"}, nil},
 		{"rest trap", "You will support the rest of the team and ship features.", nil, []string{"rest"}},
+		{"mcp", "Experience building tools with MCP and LangGraph.", []string{"mcp"}, nil},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/openspec/changes/refine-ai-role-classification/.openspec.yaml
+++ b/openspec/changes/refine-ai-role-classification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/refine-ai-role-classification/design.md
+++ b/openspec/changes/refine-ai-role-classification/design.md
@@ -1,0 +1,204 @@
+## Context
+
+`internal/roletag` and `internal/skilltag` are both curated, dict-only
+dictionaries (never guess, never persist out-of-vocabulary). `roletag`
+resolves a job's `roles` facet from **title only** (plus already-resolved
+seniority/category); `skilltag` resolves the `skills` facet from job text via
+a word/phrase alias dictionary, with a gate (`ambiguousWords`) that requires
+corroboration for tokens that collide with ordinary English.
+
+Prod validation (`https://freehire.me/api/v1/jobs/search`, read-only, 2026-08-09):
+
+| Check | Result |
+|---|---|
+| `category=ai_engineering` | 7,766 jobs |
+| `category=ml_ai` | 7,196 jobs |
+| `q=MCP&category=ai_engineering` (free-text mentions) | 159 jobs |
+| `skills=mcp` (currently tagged) | 1 job |
+| `skills=rag&category=ai_engineering` (currently tagged) | 1,181 / 7,766 = 15.2% |
+| Field guide baseline for RAG mentions in "AI Engineer" titled jobs | 35.9% |
+| `role=forward_deployed_engineer` (current single-phrase alias) | 1,570 jobs |
+
+This confirms both dictionary gaps are real (MCP near-total miss; RAG
+under-tagged by more than half) and that the existing FDE alias already
+produces a meaningful base to extend rather than a broken signal to replace.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Derive a new `ai_archetype` facet from a job's already-resolved `skills` and
+  `category` — no new free-text parsing, no LLM call, no migration.
+- Close the two confirmed `skilltag` dictionary gaps (MCP, RAG) without
+  reopening the RAG/"RAG status" collision on the rest of the catalogue.
+- Widen `forward_deployed_engineer`'s alias coverage and add the two
+  field-guide-documented synonym titles as their own named roles.
+
+**Non-Goals:**
+- Not replacing or reweighting the existing `roles` facet — `ai_archetype` is
+  additive, scoped to `category ∈ {ai_engineering, ml_ai}`.
+- Not reproducing the field guide's k-means clustering exactly — the six
+  archetypes are approximated with a small ordered rule set over the existing
+  skill dictionary, not a model. A rule-based approximation is the only option
+  consistent with the project's dict-only doctrine (`internal/classify`,
+  `internal/roletag`, `internal/skilltag` all forbid a model call for a
+  production facet).
+- Not touching the declining trainer-stack skills (`PyTorch`, `Fine-Tuning`,
+  `RLHF`) the field guide flags — they're already present or out of this
+  change's confirmed-gap scope.
+
+## Decisions
+
+### 1. `ai_archetype` lives in a new package, not inside `roletag` or `skilltag`
+
+`roletag` and `skilltag` are independent dictionaries with no cross-dependency
+today (`roletag` never imports `skilltag`, and vice versa). `ai_archetype`'s
+whole job is to consume `skilltag`'s *output* (the resolved skill slugs) plus
+`category`, so it is a distinct responsibility layered on top of both — the
+same relationship `roletag` has to `classify`. New package: `internal/aiarchetype`.
+
+```go
+// Derive returns the single skill-signature archetype a job's skills and
+// category resolve to, or "" if category is out of scope or no rule
+// matches. Dict-only: never guesses, never returns more than one archetype
+// (the archetypes are the mutually-exclusive clusters the field guide's
+// k-means analysis found, not additive facets).
+func Derive(skills []string, category string) string
+```
+
+Alternative considered: extend `roletag.Derive`'s signature to also take
+`skills` and append archetype slugs to its existing multi-value `[]string`
+return. Rejected — `roletag`'s existing return value is additive (seniority +
+category + named role can all coexist on one job); an archetype is a single
+mutually-exclusive cluster assignment, a different shape that would need its
+own sub-slice convention inside the same return value regardless.
+
+### 2. Wiring follows the `roles` facet pattern exactly: computed at index time, never persisted
+
+Confirmed via investigation: `roletag`'s `roles` are not stored in Postgres at
+all. They're recomputed on every `internal/search/document.go` `FromJob()`
+call from already-persisted `jobs.seniority`/`category`/`title`, added to
+`JobDocument` (not `jobview.Job` — it backs a facet, not the public wire
+shape), and reach historic jobs the next time `cmd/reindex` runs (unconditional
+full rebuild). `ai_archetype` follows the same shape: a field on
+`JobDocument`, set via `aiarchetype.Derive(doc.Skills, doc.Category)` inside
+`FromJob`, plus:
+- `internal/search/client.go` `facetSettings()`: add `"ai_archetype"` to
+  `FilterableAttributes`.
+- `internal/search/query_filter.go` `StringFacets`: add
+  `"ai_archetype": "ai_archetype"`.
+- `internal/search/settings_test.go`: a sibling to `TestRolesIsFilterable`.
+
+No migration, no `cmd/backfill-derive` change — nothing new is written to
+Postgres. Per `internal/search/AGENTS.md`, adding a filterable attribute opens
+a brief hard-500 window if the app starts filtering on it before the settings
+push/reindex has run — the task order pushes settings first.
+
+### 3. Archetype rules: an ordered, first-match-wins rule set over confirmed `skilltag` canonicals
+
+Six archetypes, checked in this order (most AI-distinctive signature first,
+most generic/overlapping last — a job matching an earlier rule is claimed
+before a later, broader rule sees it):
+
+| Order | Archetype | Rule (all canonicals already exist in `skilltag`) |
+|---|---|---|
+| 1 | `rag_app_builder` | `rag` AND (`langchain` OR `langgraph` OR `llamaindex`) AND `vector-databases` |
+| 2 | `agent_builder` | `agentic-ai` AND `prompt-engineering` AND `rag` |
+| 3 | `cloud_ml_platform_engineer` | `mlops` AND `kubernetes` AND (`pytorch` OR `tensorflow`) |
+| 4 | `ml_trainer_researcher` | (`pytorch` OR `tensorflow`) AND NOT `rag` AND NOT `agentic-ai` |
+| 5 | `fullstack_ai_engineer` | (`react` OR `nodejs`) AND (`llm` OR `openai` OR `anthropic`) |
+| 6 | `devops_infra_engineer` | `terraform` AND `kubernetes` AND `docker` AND `ci-cd` |
+
+Rule 1 before rule 2: `rag_app_builder`'s signature (RAG + a named
+orchestration framework + vector DB) is strictly more specific than
+`agent_builder`'s (agents + prompting + RAG with no framework/DB requirement),
+so every job rule 1 would claim is also a superset match for rule 2 — checking
+rag_app_builder first prevents it from losing those jobs to the broader rule.
+Rule 4 explicitly excludes `rag`/`agentic-ai` so a job that mentions both
+training basics and RAG (64% of ai-first roles need "some" ML per the field
+guide) lands in `rag_app_builder`/`agent_builder`, not `ml_trainer_researcher`
+— consistent with the field guide's own framing of ML knowledge as a baseline
+skill, not the archetype-defining one, for AI-first roles.
+
+This is a deliberate simplification of a statistical clustering into a
+deterministic ordered rule set — see Risks.
+
+### 4. `mcp` added as a plain (non-gated) word alias
+
+`"Microsoft Certified Professional"` is the only real-world collision for the
+bare token, and it's a legacy-2000s abbreviation effectively absent from
+current job postings — unlike the live English-word collisions
+(`react`/`swift`/`spring`/…) `ambiguousWords` exists for. Added as a strong,
+ungated alias: `"mcp": "mcp"`, consistent with `langgraph`/`crewai`/other
+modern single-token framework names already in the same block.
+
+### 5. `RAG` acronym: category-scoped strong match, not global
+
+`resumeAcronyms["RAG"]` already proves the acronym is desired but gated
+specifically because job postings (not résumés) carry "RAG status" reporting
+prose. Rather than a blanket move to `sharedAcronyms` (reopening that
+collision catalogue-wide) or leaving the gap, `skilltag.Parse` gains a new
+functional option, `WithAcronymCategory(category string)`, that the job
+ingest path (which already resolves `category` via `classify.Parse` before
+calling `skilltag.Parse`) opts into. A new `categoryScopedAcronyms` table
+(mirroring `sharedAcronyms`'s shape) resolves `RAG → rag` only when the
+caller-supplied category is in its own allow-list
+(`ai_engineering`, `ml_ai`) — colocated with the acronym entry, same
+self-documenting pattern the file already uses for `ambiguousWords`. Every
+existing `Parse` call site is unaffected (the option defaults to unset); only
+the job ingest path (`internal/jobderive`) is updated to pass it.
+
+Alternative considered: gate on `ambiguousWords`-style corroboration instead
+(only tag bare "RAG" when another strong AI token is also present). Rejected
+as strictly worse here — a job in `ai_engineering`/`ml_ai` already carries that
+corroboration by construction (it required an AI-flavored title to classify
+into the category in the first place via `classify`), so the category check
+already does the corroboration's job with one lookup instead of a text re-scan.
+
+## Risks / Trade-offs
+
+- **[Risk]** The six ordered rules are a hand-authored approximation of a
+  k-means clustering fit on a different (smaller, differently-sourced)
+  dataset — they will not reproduce the field guide's exact archetype
+  percentages on freehire's catalogue. → **Mitigation**: dict-only facets in
+  this codebase are already approximations by design (`classify`, `roletag`
+  make the same trade); ship the rule set, and treat a follow-up recalibration
+  against freehire's own `ai_archetype` facet distribution (once populated) as
+  a natural next iteration, not a blocker for this change.
+- **[Risk]** A job matching no rule (most jobs even within
+  `ai_engineering`/`ml_ai`) gets no archetype — expected under the dict-only
+  "never guess" doctrine, but means the facet's coverage will be partial from
+  day one. → **Mitigation**: this is the same trade-off `roletag`'s named
+  roles already make; no action needed, just documented so it isn't mistaken
+  for a bug.
+- **[Risk]** `WithAcronymCategory` is a new kind of option for `skilltag`
+  (category-aware, where every existing option is category-agnostic) —
+  a second category-scoped acronym added carelessly later could turn this
+  into a maze of special cases. → **Mitigation**: the design keeps exactly one
+  table (`categoryScopedAcronyms`) for this class of exception, mirroring how
+  `ambiguousWords`/`nonCorroboratingPhrases` are each a single table already;
+  a future addition extends that table, it doesn't add a new mechanism.
+
+## Migration Plan
+
+1. `internal/skilltag` dictionary + `WithAcronymCategory` option (independent,
+   no dependents yet).
+2. `internal/roletag` alias/named-role additions (independent).
+3. `internal/aiarchetype` new package, consuming `skilltag` canonicals only
+   (unit-testable in isolation).
+4. `internal/jobderive` — pass category into `skilltag.Parse` via the new
+   option.
+5. `internal/search` wiring — `document.go`, `client.go` (push settings first),
+   `query_filter.go`.
+6. `cmd/reindex` — full rebuild so `ai_archetype` reaches every historic job
+   in `ai_engineering`/`ml_ai` category. Standard operational step for any new
+   filterable attribute (`internal/search/AGENTS.md`), not a new mechanism.
+
+No rollback complexity: every change is additive (new dictionary entries, new
+facet); removing the facet later is a revert with no data cleanup, since
+nothing is persisted to Postgres.
+
+## Open Questions
+
+None outstanding — scope, taxonomy shape, RAG-gap fix, and FDE-synonym
+handling were each resolved during brainstorming (see proposal.md's
+Capabilities section for the resulting scope).

--- a/openspec/changes/refine-ai-role-classification/proposal.md
+++ b/openspec/changes/refine-ai-role-classification/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+`internal/roletag` classifies a job's role from its title alone, but the
+[AI Engineering Field Guide](https://github.com/i-strelov/ai-engineering-field-guide)'s
+job-market analysis shows title is an unreliable signal for AI roles: the
+single title "AI Engineer" spans three functionally different profiles
+(AI-First 69.4%, AI-Support 28.5%, classical ML rebranded 1.8%), and a
+skill-signature k-means clustering surfaces six stable archetypes — the
+largest, "RAG app builder" (25.6% of the market), has no dedicated facet today.
+Separately, `internal/skilltag`'s dictionary has a confirmed gap on `MCP`
+(159 free-text mentions in prod AI-category jobs, 1 tagged) and an
+under-tagging gap on `RAG` itself (15.2% tagged vs. the field guide's 35.9%
+baseline, because the bare acronym is gated to résumés only to avoid a
+collision with "RAG status"). `forward_deployed_engineer` already resolves
+1,570 prod jobs from one exact title phrase, but misses the bare "FDE" title
+and the field-guide-documented synonym titles (Applied AI Engineer,
+Deployment Engineer).
+
+## What Changes
+
+- Add a new derived, dict-only facet `ai_archetype` (`internal/aiarchetype`,
+  new package) that classifies a job into one of six skill-signature
+  archetypes — `rag_app_builder`, `agent_builder`, `cloud_ml_platform_engineer`,
+  `devops_infra_engineer`, `ml_trainer_researcher`, `fullstack_ai_engineer` —
+  from its already-resolved `skills` and `category`. Scoped to
+  `category ∈ {ai_engineering, ml_ai}`. Wired into `internal/search` as a new
+  filterable Meilisearch facet, following the same "compute at index time,
+  never persisted" pattern as `roletag`'s `roles` facet.
+- Widen `forward_deployed_engineer`'s title aliases in `internal/roletag` to
+  match the field guide's own matching rule (bare `FDE`, `forward deploy*`),
+  and add two new named roles, `applied_ai_engineer` and `deployment_engineer`,
+  for the synonym titles the field guide documents as the same work under a
+  different name — kept as separate slugs, not merged into FDE, to preserve
+  title fidelity.
+- Add `mcp` to `internal/skilltag`'s word-alias dictionary.
+- Move the `RAG` acronym from résumé-only (`resumeAcronyms`) to a
+  category-scoped strong match on job postings
+  (`category ∈ {ai_engineering, ml_ai}`), closing the under-tagging gap
+  without reopening the "RAG status" collision on the rest of the catalogue.
+
+## Capabilities
+
+### New Capabilities
+- `ai-role-archetype`: derives a dict-only `ai_archetype` facet from a job's
+  skills and category, for the six AI-engineering skill-signature archetypes;
+  exposed as a filterable Meilisearch facet.
+
+### Modified Capabilities
+- `role-facet`: `internal/roletag`'s named-role table gains broader
+  `forward_deployed_engineer` aliases and two new named roles
+  (`applied_ai_engineer`, `deployment_engineer`).
+- `skill-tag-matching`: the dictionary gains an `mcp` word alias and a
+  category-scoped strong match for the `RAG` acronym on job postings.
+
+## Impact
+
+- New package `internal/aiarchetype` (pure function, no persistence, no
+  migration).
+- `internal/search/document.go` (`JobDocument`, `FromJob`), `client.go`
+  (`FilterableAttributes`), `query_filter.go` (`StringFacets`) — new facet
+  wiring, same pattern as `roles`.
+- `internal/roletag/roletag.go` — `namedRoleTable` additions/edits only.
+- `internal/skilltag/dictionaries.go` — `wordAliases`, `sharedAcronyms`/
+  `resumeAcronyms` additions; `Parse` gains a category-aware acronym path.
+- No schema migration. No backfill: `ai_archetype` is computed at Meilisearch
+  index time from already-persisted `jobs.skills`/`jobs.category`, so a full
+  `cmd/reindex` (already required whenever a new filterable attribute is
+  added, per `internal/search/AGENTS.md`) picks up historic jobs.

--- a/openspec/changes/refine-ai-role-classification/specs/ai-role-archetype/spec.md
+++ b/openspec/changes/refine-ai-role-classification/specs/ai-role-archetype/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: A deterministic rule set derives a job's AI skill-signature archetype
+
+The system SHALL provide `internal/aiarchetype`, a curated deterministic rule
+set (mirroring the dict-only doctrine of `internal/classify`,
+`internal/roletag`, and `internal/skilltag`) that derives a job's
+`ai_archetype` — at most one canonical archetype slug — from its already-
+resolved `skills` and `category`. It SHALL only evaluate jobs whose category is
+`ai_engineering` or `ml_ai`; every other category SHALL yield no archetype.
+
+The archetypes and their rules, evaluated in this fixed priority order (first
+match wins):
+
+1. `rag_app_builder` — `rag` AND (`langchain` OR `langgraph` OR `llamaindex`)
+   AND `vector-databases`
+2. `agent_builder` — `agentic-ai` AND `prompt-engineering` AND `rag`
+3. `cloud_ml_platform_engineer` — `mlops` AND `kubernetes` AND (`pytorch` OR
+   `tensorflow`)
+4. `ml_trainer_researcher` — (`pytorch` OR `tensorflow`) AND NOT `rag` AND NOT
+   `agentic-ai`
+5. `fullstack_ai_engineer` — (`react` OR `nodejs`) AND (`llm` OR `openai` OR
+   `anthropic`)
+6. `devops_infra_engineer` — `terraform` AND `kubernetes` AND `docker` AND
+   `ci-cd`
+
+It SHALL never guess: a job whose skills and category satisfy none of the six
+rules yields no archetype, and a job matching more than one rule's skill
+requirements SHALL resolve to the single highest-priority (first) matching
+archetype only.
+
+#### Scenario: A job matching the most specific rule resolves to it
+
+- **WHEN** `aiarchetype` derives the archetype for a job in category
+  `ai_engineering` whose skills include `rag`, `langchain`, `langgraph`, and
+  `vector-databases`
+- **THEN** the derived archetype is `rag_app_builder`
+
+#### Scenario: Priority order resolves overlapping matches to the higher-priority archetype
+
+- **WHEN** a job's skills satisfy both the `rag_app_builder` rule and the
+  `agent_builder` rule
+- **THEN** the derived archetype is `rag_app_builder`, not `agent_builder`
+
+#### Scenario: A job outside the AI/ML category yields no archetype
+
+- **WHEN** `aiarchetype` derives the archetype for a job whose category is
+  `backend`
+- **THEN** no archetype is derived, regardless of its skills
+
+#### Scenario: No rule matches yields no archetype
+
+- **WHEN** a job's category is `ai_engineering` but its skills satisfy none of
+  the six rules
+- **THEN** no archetype is derived
+
+### Requirement: The archetype is derived at index time, not stored or backfilled
+
+The `ai_archetype` facet SHALL be computed at index time by `search.FromJob`
+from the job's already-resolved `skills` and `category`. There SHALL be no
+`jobs.ai_archetype` column, no schema migration, and no `backfill-derive`
+support for it; a reindex SHALL populate `ai_archetype` on existing documents
+(the same index-only pattern `roletag`'s `roles` facet uses).
+`ai_archetype` is an index/search concern and SHALL NOT be added to the public
+job wire shape returned by the job read endpoints.
+
+#### Scenario: A reindex populates the archetype without a schema change
+
+- **WHEN** the jobs index is rebuilt for existing jobs in category
+  `ai_engineering` or `ml_ai`
+- **THEN** each matching document carries an `ai_archetype` value derived from
+  its skills and category, and no Postgres column or backfill was required
+
+#### Scenario: The archetype does not appear in the public job read shape
+
+- **WHEN** a job is read through a public job read endpoint (list, detail,
+  company, or search result)
+- **THEN** the returned job wire shape does not include an `ai_archetype`
+  field
+
+### Requirement: The archetype is a filterable search facet
+
+`ai_archetype` SHALL be a filterable Meilisearch attribute, queryable by the
+public param name `ai_archetype`, following the same wiring as the `roles`
+facet's `role` param.
+
+#### Scenario: Jobs can be filtered by archetype
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?ai_archetype=rag_app_builder`
+- **THEN** the results include only jobs whose derived archetype is
+  `rag_app_builder`

--- a/openspec/changes/refine-ai-role-classification/specs/role-facet/spec.md
+++ b/openspec/changes/refine-ai-role-classification/specs/role-facet/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Forward Deployed Engineer resolves from FDE and its synonym titles
+
+The `forward_deployed_engineer` named role SHALL resolve from the bare
+whole-word title token `FDE` and from any title containing the phrase
+`forward deploy` (covering `Forward Deployed Engineer`, `Forward Deploy
+Engineer`, and the hyphenated `Forward-Deployed Engineer` spelling), matching
+the same case-insensitive rule the field guide's own FDE analysis uses.
+
+The system SHALL additionally provide two separate named roles for the
+synonym titles the field guide documents as the same class of work under a
+different name — `applied_ai_engineer` (alias: "applied ai engineer") and
+`deployment_engineer` (alias: "deployment engineer") — kept as their own
+slugs rather than merged into `forward_deployed_engineer`, so a job's derived
+role reflects the title it was actually posted under.
+
+#### Scenario: Bare FDE title resolves
+
+- **WHEN** `roletag` derives roles for a job titled "FDE - Enterprise AI"
+- **THEN** the derived `roles` include `forward_deployed_engineer`
+
+#### Scenario: Hyphenated forward-deployed spelling resolves
+
+- **WHEN** `roletag` derives roles for a job titled "Forward-Deployed Engineer"
+- **THEN** the derived `roles` include `forward_deployed_engineer`
+
+#### Scenario: Applied AI Engineer resolves to its own role, not FDE
+
+- **WHEN** `roletag` derives roles for a job titled "Applied AI Engineer"
+- **THEN** the derived `roles` include `applied_ai_engineer` and do NOT
+  include `forward_deployed_engineer`
+
+#### Scenario: Deployment Engineer resolves to its own role
+
+- **WHEN** `roletag` derives roles for a job titled "Deployment Engineer"
+- **THEN** the derived `roles` include `deployment_engineer`

--- a/openspec/changes/refine-ai-role-classification/specs/skill-tag-matching/spec.md
+++ b/openspec/changes/refine-ai-role-classification/specs/skill-tag-matching/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Case-preserving acronym matching
+
+The matcher SHALL resolve a curated set of technology acronyms by their exact
+case-sensitive surface form, matched as whole words over the original-case text,
+while their ambiguous lowercase forms SHALL NOT resolve. Each acronym SHALL map to
+a canonical that already exists in the vocabulary (an acronym is an additional
+alias, never a new facet value).
+
+Acronyms SHALL be split into three tiers: a **shared** set applied to all text
+(jobs and résumés), a **résumé-scoped** set applied only when the caller opts in
+for résumé parsing, and a **category-scoped** set applied to job text only when
+the caller supplies a job category present in that acronym's own allow-list. An
+acronym whose uppercase form is ambiguous in job descriptions generally (e.g.
+"RAG status") but unambiguous within a specific job category SHALL be
+category-scoped rather than omitted from job parsing entirely; an acronym with no
+such safe category SHALL remain résumé-scoped.
+
+`RAG` SHALL be category-scoped, resolving to `rag` (retrieval-augmented
+generation) on job postings whose category is `ai_engineering` or `ml_ai`, and
+SHALL remain résumé-scoped for résumé parsing regardless of any category.
+
+#### Scenario: Shared acronym resolves everywhere
+- **WHEN** any text contains "ML" as a standalone token
+- **THEN** the matcher emits "machine-learning"
+
+#### Scenario: Résumé-scoped acronym resolves in résumé mode
+- **WHEN** a résumé is parsed with the résumé option and contains "RAG"
+- **THEN** the matcher emits "rag" (retrieval-augmented generation)
+
+#### Scenario: Category-scoped acronym resolves for its allow-listed job category
+- **WHEN** job text in category `ai_engineering` contains "RAG" as a standalone token
+- **THEN** the matcher emits "rag"
+
+#### Scenario: Category-scoped acronym does not resolve outside its allow-list
+- **WHEN** job text in category `backend` contains "RAG" — including "RAG status"
+- **THEN** the matcher does NOT emit "rag"
+
+#### Scenario: Category-scoped acronym does not resolve when no category is supplied
+- **WHEN** default (job) parsing with no category option sees "RAG"
+- **THEN** the matcher does NOT emit "rag"
+
+#### Scenario: Ambiguous lowercase form does not resolve
+- **WHEN** the text contains the lowercase word "rag" or "ml"
+- **THEN** the matcher does NOT emit the corresponding canonical
+
+#### Scenario: Acronym matched as a whole word only
+- **WHEN** "ML" appears embedded in a larger token (e.g. "HTML")
+- **THEN** it does NOT emit "machine-learning"

--- a/openspec/changes/refine-ai-role-classification/tasks.md
+++ b/openspec/changes/refine-ai-role-classification/tasks.md
@@ -1,0 +1,72 @@
+## 1. skilltag: MCP alias + category-scoped RAG acronym
+
+- [x] 1.1 Add `"mcp": "mcp"` to `wordAliases` in `internal/skilltag/dictionaries.go`
+- [x] 1.2 Add a `categoryScopedAcronyms` table (mirroring `sharedAcronyms`'s
+      shape) with `RAG → rag`, gated to an allow-list of `ai_engineering`,
+      `ml_ai`. Leave `RAG` in `resumeAcronyms` unchanged — résumé parsing
+      stays acronym-scoped independent of category (design.md decision 5)
+- [x] 1.3 Add a `WithAcronymCategory(category string)` functional option to
+      `skilltag.Parse`; when set and the category is in a scoped acronym's
+      allow-list, resolve that acronym on job text (default: unset, no
+      behavior change for existing callers)
+- [x] 1.4 Unit tests: MCP resolves as a plain word alias; RAG resolves for
+      `ai_engineering`/`ml_ai` category via the new option; RAG does not
+      resolve for other categories or when the option is unset; existing
+      résumé-scoped RAG behavior is unchanged
+
+## 2. roletag: FDE alias coverage + two new named roles
+
+- [x] 2.1 Broaden `forward_deployed_engineer`'s aliases to also match bare
+      `FDE` and the `forward deploy` prefix (covering the hyphenated
+      `forward-deployed` spelling — check the existing hyphen-as-word-boundary
+      handling other entries in `namedRoleTable` already document)
+- [x] 2.2 Add `applied_ai_engineer` ("Applied AI Engineer") and
+      `deployment_engineer` ("Deployment Engineer") to `namedRoleTable` as
+      their own slugs
+- [x] 2.3 Unit tests: bare "FDE" title resolves to `forward_deployed_engineer`;
+      "Forward-Deployed Engineer" resolves; "Applied AI Engineer" resolves to
+      `applied_ai_engineer` and NOT `forward_deployed_engineer`; "Deployment
+      Engineer" resolves to `deployment_engineer`; catalog includes labels for
+      both new slugs
+
+## 3. New package internal/aiarchetype
+
+- [x] 3.1 Create `internal/aiarchetype/aiarchetype.go` with
+      `Derive(skills []string, category string) string` implementing the
+      six-rule ordered priority table from design.md
+- [x] 3.2 Unit tests per spec scenario: each archetype's rule matches in
+      isolation; `rag_app_builder` wins over `agent_builder` on overlapping
+      skills; out-of-scope category yields ""; no-match yields ""
+
+## 4. Wire category into job ingest
+
+- [x] 4.1 Update `internal/jobderive` to pass the job's resolved category into
+      `skilltag.Parse` via `WithAcronymCategory`
+- [x] 4.2 Integration test: a job description mentioning bare "RAG" in
+      category `ai_engineering` ends up with `rag` in `jobs.skills` after
+      `jobderive.Derive`
+
+## 5. Wire ai_archetype into search
+
+- [x] 5.1 Add `AIArchetype string` (or equivalent) field to `JobDocument` in
+      `internal/search/document.go`; set it via `aiarchetype.Derive` in
+      `FromJob`
+- [x] 5.2 Add `"ai_archetype"` to `FilterableAttributes` in
+      `internal/search/client.go` `facetSettings()`
+- [x] 5.3 Add `"ai_archetype": "ai_archetype"` to `StringFacets` in
+      `internal/search/query_filter.go`
+- [x] 5.4 Add a filterability test sibling to `TestRolesIsFilterable` in
+      `internal/search/settings_test.go`
+- [x] 5.5 Integration/unit test: `FromJob` sets `ai_archetype` correctly for a
+      job with `rag_app_builder`-matching skills and category, and leaves it
+      empty for a non-AI category
+
+## 6. Reindex
+
+- [ ] 6.1 Push updated Meilisearch settings (filterable attributes) to prod
+      ahead of the reindex, per `internal/search/AGENTS.md`'s ordering
+      requirement for a new filterable attribute
+- [ ] 6.2 Run a full `cmd/reindex` so `ai_archetype` (and the widened
+      `roles`/`skills` from steps 1-2) reach every historic job — coordinate
+      with the ingest-slot flock and the "never stack with reindex-companies"
+      rule


### PR DESCRIPTION
## Summary

- Adds a new dict-only `ai_archetype` facet (`internal/aiarchetype`) that classifies `ai_engineering`/`ml_ai` jobs into six skill-signature archetypes (`rag_app_builder`, `agent_builder`, `cloud_ml_platform_engineer`, `ml_trainer_researcher`, `fullstack_ai_engineer`, `devops_infra_engineer`), since a job's title alone (e.g. "AI Engineer") hides functionally different profiles. Wired into `internal/search` as a new filterable Meilisearch facet — computed at index time, no migration, no backfill (same pattern as `roletag`'s `roles`).
- Widens `internal/roletag`'s `forward_deployed_engineer` alias coverage (bare `FDE`, `forward deploy`, hyphenated `forward-deployed`) and adds `applied_ai_engineer` / `deployment_engineer` as their own named roles.
- Closes two confirmed `internal/skilltag` dictionary gaps, validated against prod (`freehire.me/api/v1/jobs/search`): an `mcp` word alias (159 free-text mentions in AI-category jobs vs. 1 previously tagged), and a category-scoped `RAG` acronym that now resolves on `ai_engineering`/`ml_ai` job postings (not just résumés), closing an under-tagging gap (15.2% tagged vs. 35.9% expected baseline).

OpenSpec change: `openspec/changes/refine-ai-role-classification/` (proposal, design, specs, tasks — all code tasks 1-5 complete; task group 6 is the deploy-time reindex step, not code).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...` (139 packages, 0 failures)
- [x] `gofmt -l` clean
- [x] Each task group individually reviewed (code-reviewer agent) with fixes applied per feedback
- [ ] After merge: push updated Meilisearch filterable-attribute settings, then run a full `cmd/reindex` so `ai_archetype` and the widened `roles`/`skills` reach historic jobs (see `internal/search/AGENTS.md`'s settings-before-reindex ordering)