### PR TITLE
SEO see-also: batch counts into one facetCounts() call

### DIFF
--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -55,7 +55,12 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
           // Just verified length === 1, so index 0 exists; noUncheckedIndexedAccess
           // can't see that from the length check alone.
           const [key, value] = paramEntries[0]!;
-          count = facetsResult ? (facetsResult.facets[key]?.[value] ?? 0) : null;
+          // A missing entry here is never a genuine zero: every card reaching this
+          // branch is either the job's own facet/collection (so the job itself is
+          // ≥1) or a fallback pool entry curated to have a healthy count. It means
+          // Meilisearch's MaxValuesPerFacet cap dropped this value from the
+          // distribution — degrade to unresolved, not a false "0 jobs".
+          count = facetsResult ? (facetsResult.facets[key]?.[value] ?? null) : null;
         } else {
           count =
             (await api.searchJobs(new URLSearchParams(resolved.params), 0, 0).catch(() => null))

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -25,23 +25,46 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
   // count. It needs `job`'s own facets, so it can only start once `job`
   // resolves — but it's kicked off right here (not after the Promise.all
   // below) so it overlaps with similar/copies/applyForm instead of adding a
-  // second sequential wave after them. Bounded to relatedCollectionLinks'
-  // target (~5), so this is a handful of small parallel requests, not a scan.
-  const seeAlsoPromise = jobPromise.then((job) =>
-    Promise.all(
-      relatedCollectionLinks(jobFacetsFromJob(job)).map(async (link): Promise<SeeAlsoCard> => {
+  // second sequential wave after them.
+  //
+  // Every current collection's count is a single facet's value under the
+  // WHOLE catalogue (skills=react, category=backend, collections=yc, …) —
+  // readable straight off one shared, unfiltered facetCounts() distribution,
+  // no per-card request needed. Only the remote+region/country combos
+  // (work_mode AND regions/countries — two keys) can't be read that way: a
+  // facet distribution is a marginal count per field under a filter, not a
+  // joint count across two fields, so those still need their own direct
+  // query. In practice a job matches at most one such combo, so this is
+  // usually 1 request total, never more than 2.
+  const seeAlsoPromise = jobPromise.then(async (job) => {
+    const links = relatedCollectionLinks(jobFacetsFromJob(job));
+    const facetsResult = await api.facetCounts(new URLSearchParams()).catch(() => null);
+
+    return Promise.all(
+      links.map(async (link): Promise<SeeAlsoCard> => {
+        const mark = backerBadges([link.slug])[0]?.mark ?? null;
         // relatedCollectionLinks already resolves every slug it returns via this
         // same collectionBySlug, so `resolved` is guaranteed here — this is TS
         // narrowing for the `resolved.params` access below, not a real fallback path.
         const resolved = collectionBySlug(link.slug);
-        const count = resolved
-          ? ((await api.searchJobs(new URLSearchParams(resolved.params), 0, 0).catch(() => null))
-              ?.total ?? null)
-          : null;
-        return { slug: link.slug, title: link.title, count, mark: backerBadges([link.slug])[0]?.mark ?? null };
+        if (!resolved) return { slug: link.slug, title: link.title, count: null, mark };
+
+        const paramEntries = Object.entries(resolved.params);
+        let count: number | null;
+        if (paramEntries.length === 1) {
+          // Just verified length === 1, so index 0 exists; noUncheckedIndexedAccess
+          // can't see that from the length check alone.
+          const [key, value] = paramEntries[0]!;
+          count = facetsResult ? (facetsResult.facets[key]?.[value] ?? 0) : null;
+        } else {
+          count =
+            (await api.searchJobs(new URLSearchParams(resolved.params), 0, 0).catch(() => null))
+              ?.total ?? null;
+        }
+        return { slug: link.slug, title: link.title, count, mark };
       })
-    )
-  );
+    );
+  });
 
   // Similar jobs are a non-essential discovery aid: a failure (search disabled,
   // no neighbours yet) must not break the page, so it degrades to an empty list.


### PR DESCRIPTION
## Summary

Follow-up to #1672 (merged/deployed). User asked why the see-also block's
per-card count needed a separate request each — it mostly doesn't:

- Every current collection's count is a single facet's value under the whole
  catalogue (skills=react, category=backend, collections=yc, ...), readable
  off ONE shared, unfiltered `facetCounts()` distribution — no per-card
  request. Mirrors (and extends) the pattern the `/collections` hub already
  uses for its company-collection cards.
- Only the remote+region/country combos (two AND'd keys — a facet
  distribution gives marginal per-field counts, not a joint count across two
  fields) still need their own direct `searchJobs` query. A job matches at
  most one such combo in practice, so this is usually 1 request total instead
  of up to 5, never more than 2.
- Fixed during this PR's own review: a missing facet-distribution entry
  (Meilisearch's `MaxValuesPerFacet` cap, dormant today but not guaranteed
  forever) now degrades to `null` (unresolved), not a false "0 jobs" — every
  card reaching that branch is either the job's own facet (so ≥1 by
  construction) or a curated fallback entry with a healthy count, so a
  missing entry can only mean truncation, never a genuine zero.

## Test plan

- [x] `pnpm vitest run` — 856/856 passing
- [x] `pnpm svelte-check` — 0 errors
- [x] Manual verification against production data: counts for
  react/javascript/typescript/go/python/senior/aws cards match exactly what
  the previous per-card implementation produced; the remote-worldwide
  multi-key card's count matches that collection's own landing-page title
  exactly (12,426)
- [x] Independent code-review pass (subagent) — traced param-name vocabulary
  parity against the Go facet handler, confirmed failure-mode correctness,
  caught the `?? 0` truncation issue fixed above