### PR TITLE
SEO see-also: simplify page load structure

### DIFF
--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -8,7 +8,58 @@ import {
   type SeeAlsoCard,
 } from '$lib/collections';
 import { serverApi } from '$lib/server/api';
+import type { FacetCounts, Job } from '$lib/types';
 import type { PageServerLoad } from './$types';
+
+type Api = ReturnType<typeof serverApi>;
+
+// A see-also card's live count. Every current collection is a single facet's
+// value under the whole catalogue (skills=react, category=backend,
+// collections=yc, …) — read straight off the shared, unfiltered
+// facetCounts() distribution passed in, no per-card request. Only the
+// remote+region/country combos (two AND'd keys, e.g. work_mode + regions)
+// need their own direct query: a facet distribution is a marginal count per
+// field under a filter, not a joint count across two fields.
+async function seeAlsoCount(
+  params: Record<string, string>,
+  facetsResult: FacetCounts | null,
+  api: Api
+): Promise<number | null> {
+  const entries = Object.entries(params);
+  if (entries.length > 1) {
+    return (await api.searchJobs(new URLSearchParams(params), 0, 0).catch(() => null))?.total ?? null;
+  }
+  const [key, value] = entries[0]!; // length === 1 just checked above
+  // A missing entry here is never a genuine zero: every card reaching this
+  // branch is either the job's own facet/collection (so the job itself is
+  // ≥1) or a fallback pool entry curated to have a healthy count. It means
+  // Meilisearch's MaxValuesPerFacet cap dropped this value from the
+  // distribution — degrade to unresolved, not a false "0 jobs".
+  return facetsResult ? (facetsResult.facets[key]?.[value] ?? null) : null;
+}
+
+// The "see also" block's matched collections, each with its live open-job
+// count. Callers kick this off the moment `job` resolves (it needs `job`'s
+// own facets) so it overlaps with the page's other fetches instead of adding
+// a second sequential wave after them. In practice a job matches at most one
+// remote+region/country collection, so this is usually 1 request total
+// (the shared facetCounts() call), never more than 2.
+async function buildSeeAlso(job: Job, api: Api): Promise<SeeAlsoCard[]> {
+  const links = relatedCollectionLinks(jobFacetsFromJob(job));
+  const facetsResult = await api.facetCounts(new URLSearchParams()).catch(() => null);
+
+  return Promise.all(
+    links.map(async (link): Promise<SeeAlsoCard> => {
+      const mark = backerBadges([link.slug])[0]?.mark ?? null;
+      // relatedCollectionLinks already resolves every slug it returns via this
+      // same collectionBySlug, so `resolved` is guaranteed here — this is TS
+      // narrowing, not a real fallback path.
+      const resolved = collectionBySlug(link.slug);
+      const count = resolved ? await seeAlsoCount(resolved.params, facetsResult, api) : null;
+      return { slug: link.slug, title: link.title, count, mark };
+    })
+  );
+}
 
 // Server-render the job detail: fetch by slug so the article content is in the
 // initial HTML. All fetches stay awaited (not streamed) so every section is in
@@ -20,56 +71,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
     if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
     throw e;
   });
-
-  // The "see also" block's matched collections, each with its live open-job
-  // count. It needs `job`'s own facets, so it can only start once `job`
-  // resolves — but it's kicked off right here (not after the Promise.all
-  // below) so it overlaps with similar/copies/applyForm instead of adding a
-  // second sequential wave after them.
-  //
-  // Every current collection's count is a single facet's value under the
-  // WHOLE catalogue (skills=react, category=backend, collections=yc, …) —
-  // readable straight off one shared, unfiltered facetCounts() distribution,
-  // no per-card request needed. Only the remote+region/country combos
-  // (work_mode AND regions/countries — two keys) can't be read that way: a
-  // facet distribution is a marginal count per field under a filter, not a
-  // joint count across two fields, so those still need their own direct
-  // query. In practice a job matches at most one such combo, so this is
-  // usually 1 request total, never more than 2.
-  const seeAlsoPromise = jobPromise.then(async (job) => {
-    const links = relatedCollectionLinks(jobFacetsFromJob(job));
-    const facetsResult = await api.facetCounts(new URLSearchParams()).catch(() => null);
-
-    return Promise.all(
-      links.map(async (link): Promise<SeeAlsoCard> => {
-        const mark = backerBadges([link.slug])[0]?.mark ?? null;
-        // relatedCollectionLinks already resolves every slug it returns via this
-        // same collectionBySlug, so `resolved` is guaranteed here — this is TS
-        // narrowing for the `resolved.params` access below, not a real fallback path.
-        const resolved = collectionBySlug(link.slug);
-        if (!resolved) return { slug: link.slug, title: link.title, count: null, mark };
-
-        const paramEntries = Object.entries(resolved.params);
-        let count: number | null;
-        if (paramEntries.length === 1) {
-          // Just verified length === 1, so index 0 exists; noUncheckedIndexedAccess
-          // can't see that from the length check alone.
-          const [key, value] = paramEntries[0]!;
-          // A missing entry here is never a genuine zero: every card reaching this
-          // branch is either the job's own facet/collection (so the job itself is
-          // ≥1) or a fallback pool entry curated to have a healthy count. It means
-          // Meilisearch's MaxValuesPerFacet cap dropped this value from the
-          // distribution — degrade to unresolved, not a false "0 jobs".
-          count = facetsResult ? (facetsResult.facets[key]?.[value] ?? null) : null;
-        } else {
-          count =
-            (await api.searchJobs(new URLSearchParams(resolved.params), 0, 0).catch(() => null))
-              ?.total ?? null;
-        }
-        return { slug: link.slug, title: link.title, count, mark };
-      })
-    );
-  });
+  const seeAlsoPromise = jobPromise.then((job) => buildSeeAlso(job, api));
 
   // Similar jobs are a non-essential discovery aid: a failure (search disabled,
   // no neighbours yet) must not break the page, so it degrades to an empty list.


### PR DESCRIPTION
## Summary

Pure refactor, no behavior change (`/simplify` pass on #1674). The job
detail page's `load()` had grown a fairly deep inline see-also computation
(single-key vs. multi-key facet branching, per-card async mapping)
alongside its main job/similar/copies/applyForm fetch. Pulled it into two
named, single-purpose helpers (`seeAlsoCount`, `buildSeeAlso`) above
`load()`, which now reads as a short, flat list of what the page fetches.

## Test plan

- [x] `pnpm vitest run` — 856/856 passing (unchanged)
- [x] `pnpm svelte-check` — 0 errors