### PR TITLE
fix(web): let the tailor tab bar scroll instead of clipping

### DIFF
--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -573,18 +573,18 @@
       >
         <!-- Own tab bar (and save status) is desktop-only; the mobile bar drives the tab there. -->
         <div class="hidden items-center justify-between gap-2 border-b border-border px-2 py-1.5 text-sm lg:flex">
-          <div class="flex items-center gap-1">
+          <div class="flex min-w-0 flex-nowrap items-center gap-1 overflow-x-auto">
             {#each leftTabs as [id, label] (id)}
               <button
                 type="button"
                 onclick={() => (leftTab = id)}
-                class={['rounded px-2 py-1 transition-colors', leftTab === id ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
+                class={['shrink-0 rounded px-2 py-1 transition-colors', leftTab === id ? 'bg-brand-muted font-semibold text-brand-strong' : 'text-muted-foreground hover:text-foreground']}
               >
                 {label}
               </button>
             {/each}
           </div>
-          <div class="flex items-center gap-1">
+          <div class="flex shrink-0 items-center gap-1">
             {#if leftTab === 'editor' || leftTab === 'settings'}
               <span
                 class={['text-xs', saveState === 'error' ? 'text-destructive' : 'text-muted-foreground']}


### PR DESCRIPTION
## Summary
- The tailor editor's tab row (Chat/Editor/Experience/Templates/Settings) had no overflow handling — at the panel's default width, later tabs and the CLI/collapse buttons got clipped instead of staying reachable.
- Tabs now scroll horizontally on their own (`overflow-x-auto`); the CLI and collapse buttons stay pinned at the right edge (`shrink-0`).

## Test plan
- [x] Verified locally: at default panel width, scrolled the tab bar and confirmed "Settings" becomes reachable while CLI/collapse icons stay fixed on the right.