### PR TITLE
feat(web): expose ai_archetype as a filterable "AI Specialization" facet

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -320,6 +320,9 @@ func genVocab() string {
 	b.WriteString(emitVocab("EnglishLevel", "ENGLISH_LEVEL_VALUES", vocab.EnglishLevelValues))
 	b.WriteString(emitVocab("CompanyType", "COMPANY_TYPE_VALUES", vocab.CompanyTypeValues))
 	b.WriteString(emitVocab("Domain", "DOMAIN_VALUES", vocab.DomainValues))
+	// The six AI skill-signature archetype slugs (internal/aiarchetype), generated
+	// so the AI Specialization filter's valid values can't drift from the rule table.
+	b.WriteString(emitVocab("AIArchetype", "AI_ARCHETYPE_VALUES", vocab.AIArchetypeValues))
 	// The classified-mail vocabulary. It is generated rather than retyped because the
 	// inbox renders a label and a badge colour per signal, and a signal added in Go
 	// but missing from the SPA's maps rendered as a blank chip with every test green.

--- a/internal/aiarchetype/aiarchetype.go
+++ b/internal/aiarchetype/aiarchetype.go
@@ -75,6 +75,18 @@ var rules = []rule{
 	},
 }
 
+// Archetypes returns every archetype slug the rule table can derive, in
+// priority order. Exposed so callers outside this package (a cross-check test,
+// a future catalog) can enumerate the vocabulary without duplicating the rule
+// table.
+func Archetypes() []string {
+	out := make([]string, len(rules))
+	for i, r := range rules {
+		out[i] = r.archetype
+	}
+	return out
+}
+
 // Derive returns the single skill-signature archetype a job's skills and
 // category resolve to, or "" if category is out of scope or no rule matches.
 // It never returns more than one archetype: the archetypes are the

--- a/internal/aiarchetype/aiarchetype_test.go
+++ b/internal/aiarchetype/aiarchetype_test.go
@@ -1,6 +1,22 @@
 package aiarchetype
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/vocab"
+)
+
+// Archetypes() is the source of truth for the frontend-facing enum
+// (vocab.AIArchetypeValues, generated into the web contracts); this cross-check
+// guards against the two silently drifting apart.
+func TestArchetypesMatchesVocabValues(t *testing.T) {
+	got := Archetypes()
+	want := vocab.AIArchetypeValues
+	if !slices.Equal(got, want) {
+		t.Errorf("Archetypes() = %v, want vocab.AIArchetypeValues = %v", got, want)
+	}
+}
 
 func TestDerive(t *testing.T) {
 	cases := []struct {

--- a/internal/vocab/vocab.go
+++ b/internal/vocab/vocab.go
@@ -130,4 +130,13 @@ var (
 	}
 	CompanyTypeValues = []string{"product", "startup", "outsource", "outstaff", "agency", "inhouse", "government"}
 	CompanySizeValues = []string{"1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"}
+	// AIArchetypeValues is the six AI skill-signature archetype slugs
+	// internal/aiarchetype's rule table can derive, in priority order. Kept here
+	// (rather than only inside internal/aiarchetype) so cmd/gen-contracts can emit
+	// it into the web contracts without importing the AI-enrichment layer; a test
+	// in internal/aiarchetype cross-checks this list against the rule table itself.
+	AIArchetypeValues = []string{
+		"rag_app_builder", "agent_builder", "cloud_ml_platform_engineer",
+		"ml_trainer_researcher", "fullstack_ai_engineer", "devops_infra_engineer",
+	}
 )

--- a/openspec/changes/ai-archetype-filter-ui/.openspec.yaml
+++ b/openspec/changes/ai-archetype-filter-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/ai-archetype-filter-ui/design.md
+++ b/openspec/changes/ai-archetype-filter-ui/design.md
@@ -1,0 +1,109 @@
+## Context
+
+`internal/search`'s `ai_archetype` facet (PR #1673) is a filterable Meilisearch
+attribute and already flows through `GET /api/v1/jobs/facets` with live
+counts — nothing server-side needs to change. `web/src/lib/facets.ts` is a
+single data-driven registry (`FACETS: FacetDef[]`) that every downstream
+piece (URL sync, the filter modal, the store, live-count merging) iterates
+generically by `param`; adding a facet is adding one entry plus its
+value/label source, not touching multiple components.
+
+Two existing small, fixed-vocabulary facets are the direct precedent:
+`category` (`CATEGORY_VALUES` generated from Go, `CATEGORY_LABELS`
+hand-maintained in `labels.ts`) and `domains` (same shape). `role` is a
+different shape — a ~200-entry dynamically curated dictionary
+(`roletag.Catalog()`), generated end-to-end because hand-maintaining that
+many labels twice would rot. `ai_archetype` has six fixed, rarely-changing
+values, so it fits the `category`/`domains` shape, not `role`'s.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `ai_archetype` selectable in the filter modal and sidebar, with live
+  counts, using the existing generic facet machinery.
+- Keep the frontend's valid-value list generated from the Go source of
+  truth, so it cannot silently drift from what the backend actually derives.
+
+**Non-Goals:**
+- No backend behavior change (PR #1673 already wired the API/index side).
+- No `roletag.Catalog()`-style generated label map — six values don't
+  warrant it; see Decisions.
+- Not blocking on the prod reindex that populates `ai_archetype` on existing
+  jobs (a separate, already-tracked ops step) — the UI code is correct
+  regardless of when that runs, and holding it back would gate unrelated work
+  the user has explicitly chosen to trade off.
+
+## Decisions
+
+### 1. Values generated from Go, labels hand-maintained in `labels.ts`
+
+Add `vocab.AIArchetypeValues []string` (the six literal slugs), consumed by
+one new `emitVocab(...)` line in `cmd/gen-contracts/main.go` — the same path
+`CATEGORY_VALUES`/`SENIORITY_VALUES` already use, so `make gen-contracts`
+regenerates `AI_ARCHETYPE_VALUES` into `web/src/lib/generated/contracts.ts`.
+A test cross-checks `vocab.AIArchetypeValues` against `internal/aiarchetype`'s
+own rule-table archetype slugs (mirroring how `internal/roletag`'s test suite
+cross-checks against `vocab.CategoryValues`), so the two can't drift apart.
+
+`AI_ARCHETYPE_LABELS` is added to `web/src/lib/labels.ts` by hand, in the
+same block/pattern as `CATEGORY_LABELS`, matched 1:1 against the generated
+values:
+
+```ts
+export const AI_ARCHETYPE_LABELS: Record<string, string> = {
+  rag_app_builder: 'RAG Application Builder',
+  agent_builder: 'Agent Builder',
+  cloud_ml_platform_engineer: 'Cloud/ML Platform Engineer',
+  ml_trainer_researcher: 'ML Trainer/Researcher',
+  fullstack_ai_engineer: 'Full-Stack AI Engineer',
+  devops_infra_engineer: 'DevOps/Infra Engineer',
+};
+```
+
+Alternative considered: mirror `roletag.Catalog()` (a Go-owned slug→label
+map, generated end-to-end like `ROLE_LABELS`). Rejected — that machinery
+exists because `roletag` curates ~200 dynamically-growing named roles, where
+hand-maintaining labels twice would rot. `ai_archetype`'s six values are
+fixed by the rule table in `internal/aiarchetype/aiarchetype.go` and change
+about as often as `category`'s do; `category`'s lighter
+generated-values-plus-hand-labels shape is the correct-weight precedent, not
+`role`'s.
+
+### 2. Registration in `facets.ts`: static `select`, not dynamic
+
+```ts
+const AI_ARCHETYPE: FacetOption[] = options(AI_ARCHETYPE_VALUES, AI_ARCHETYPE_LABELS);
+...
+{ param: 'ai_archetype', label: 'AI Specialization', control: 'select', options: AI_ARCHETYPE, excludable: true, placeholder: 'Search AI specializations' },
+```
+
+placed immediately after the `category` entry (`facets.ts:527`). `dynamic:
+true` (the `role`/`skills`/`countries` shape, options built from the live
+distribution) is deliberately not used — with only six values there's
+nothing to search or paginate, and a static list keeps the panel's option
+order stable regardless of which values currently have zero counts (useful
+before the reindex backfills historic jobs, and still correct after).
+
+### 3. Ship ahead of the prod reindex
+
+The facet will show 0 for every option until the backend's reindex (a
+separate, already-tracked ops task, not part of this change) runs on
+historic jobs. The user explicitly chose to ship the UI now rather than gate
+it on that ops step — the code path is identical either way, and newly
+ingested/reindexed AI jobs will populate counts incrementally regardless of
+when the full reindex happens.
+
+## Risks / Trade-offs
+
+- **[Risk]** Empty-looking filter until the reindex runs — a user opening the
+  filter modal sees "AI Specialization" with every option at 0. →
+  **Mitigation**: accepted trade-off (see Decision 3); the reindex is already
+  tracked as the backend change's task group 6 and is independent ops work.
+- **[Risk]** `AI_ARCHETYPE_LABELS` hand-maintained in TS could drift from the
+  Go rule table's slugs if a future change adds/renames an archetype without
+  updating the frontend label map. → **Mitigation**: `AI_ARCHETYPE_VALUES` is
+  generated (not hand-typed) and `options()` (the same helper `CATEGORY`
+  already uses) falls back to a title-cased raw slug for any value missing
+  from the label map — matching `categoryLabel`'s own fallback pattern in
+  `labels.ts:135` — so a drift degrades gracefully (an ugly-but-correct label)
+  rather than breaking.

--- a/openspec/changes/ai-archetype-filter-ui/proposal.md
+++ b/openspec/changes/ai-archetype-filter-ui/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The `ai_archetype` facet (added in `refine-ai-role-classification`, PR #1673)
+is filterable through the API today but has no presence in the web UI — a
+user cannot discover or select it. `internal/search`'s facet-count endpoint
+already returns live counts for it with zero further backend work, so the gap
+is purely on the frontend: the facet needs a place in the filter registry, a
+label for itself and its six values, and a spot in the filter modal.
+
+## What Changes
+
+- Expose the six `ai_archetype` values as a generated enum
+  (`vocab.AIArchetypeValues` → `AI_ARCHETYPE_VALUES` in the web contracts),
+  the same generation path `CATEGORY_VALUES` already uses — so the frontend's
+  valid-value list can never drift from the backend's.
+- Add `AI_ARCHETYPE_LABELS` to `web/src/lib/labels.ts`, hand-maintained
+  against the generated values (the same pattern `CATEGORY_LABELS` and
+  `DOMAIN_LABELS` already follow) — a small, fixed 6-value vocabulary does
+  not warrant `internal/roletag`'s heavier generated-`Catalog()` machinery,
+  which exists for its ~200-entry dynamically curated dictionary.
+- Register a new "AI Specialization" facet in `web/src/lib/facets.ts`
+  (`control: 'select'`, static options built from the values/labels above,
+  live counts merged in automatically — the same mechanism `category` and
+  `domains` already use), positioned immediately after `category` in the
+  facet list and the filter modal's rail.
+- Ship with the facet live even though it will show zero results everywhere
+  until the backend's pending prod reindex populates `ai_archetype` on
+  existing jobs — the code path is independent of that data and correct
+  either way, and holding the UI back would gate an unrelated ops step.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `ai-role-archetype`: the six archetype slugs are additionally exposed as a
+  generated web-contracts enum (`AI_ARCHETYPE_VALUES`), not only as an
+  internal Go rule set.
+
+`filter-modal` and `facet-display-labels` are deliberately NOT listed here:
+registering `ai_archetype` in `facets.ts` and labelling it in `labels.ts`
+are new *instances* of those capabilities' existing generic requirements
+("every facet control shows a live match count", "a facet code renders as
+one string on every surface" via `labels.ts`) — no new requirement or
+mechanism is introduced, so there is nothing for a delta spec to state that
+those capabilities don't already cover.
+
+## Impact
+
+- `internal/vocab`: new `AIArchetypeValues []string` (6 literal slugs,
+  cross-checked against `internal/aiarchetype`'s rule table by a test).
+- `cmd/gen-contracts/main.go`: one new `emitVocab(...)` line; regenerates
+  `web/src/lib/generated/contracts.ts`.
+- `web/src/lib/labels.ts`: new `AI_ARCHETYPE_LABELS` map.
+- `web/src/lib/facets.ts`: new static options array + one `FACETS` entry.
+- No change to `internal/search` (already wired in PR #1673) and no schema
+  migration.

--- a/openspec/changes/ai-archetype-filter-ui/specs/ai-role-archetype/spec.md
+++ b/openspec/changes/ai-archetype-filter-ui/specs/ai-role-archetype/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: The six archetype values are exposed as a generated frontend enum
+
+The six `ai_archetype` slugs SHALL be exposed as `vocab.AIArchetypeValues` (a
+literal Go string slice), consumed by `cmd/gen-contracts` into the generated
+web contracts as `AI_ARCHETYPE_VALUES`, so the frontend's valid-value list is
+generated from the same source of truth as `internal/aiarchetype`'s rule
+table rather than hand-duplicated. `vocab.AIArchetypeValues` SHALL be
+cross-checked by a test against the archetype slugs `internal/aiarchetype`'s
+rule table actually derives, so the two cannot silently drift apart.
+
+#### Scenario: The generated enum matches the rule table
+
+- **WHEN** `cmd/gen-contracts` emits `AI_ARCHETYPE_VALUES`
+- **THEN** it contains exactly the six archetype slugs `internal/aiarchetype`
+  can derive: `rag_app_builder`, `agent_builder`,
+  `cloud_ml_platform_engineer`, `ml_trainer_researcher`,
+  `fullstack_ai_engineer`, `devops_infra_engineer`
+
+#### Scenario: A drift between the vocab list and the rule table fails a test
+
+- **WHEN** `vocab.AIArchetypeValues` and `internal/aiarchetype`'s rule-table
+  archetype slugs disagree (a slug added to one but not the other)
+- **THEN** the cross-check test fails, naming the mismatch

--- a/openspec/changes/ai-archetype-filter-ui/tasks.md
+++ b/openspec/changes/ai-archetype-filter-ui/tasks.md
@@ -1,0 +1,55 @@
+## 1. Backend: generated values enum
+
+- [x] 1.1 Add `AIArchetypeValues []string` to `internal/vocab` (the six
+      literal archetype slugs)
+- [x] 1.2 Unit test cross-checking `vocab.AIArchetypeValues` against
+      `internal/aiarchetype`'s rule-table archetype slugs, so the two cannot
+      drift apart
+- [x] 1.3 Add one `emitVocab(...)` line to `cmd/gen-contracts/main.go`'s
+      `genVocab()` for `AI_ARCHETYPE_VALUES` (mirroring the
+      `CATEGORY_VALUES`/`SENIORITY_VALUES` lines)
+- [x] 1.4 Run `make gen-contracts`; verify `AI_ARCHETYPE_VALUES` appears in
+      `web/src/lib/generated/contracts.ts`
+
+## 2. Frontend: labels and facet registration
+
+- [x] 2.1 Add `AI_ARCHETYPE_LABELS` to `web/src/lib/labels.ts` (the six
+      hand-written labels: "RAG Application Builder", "Agent Builder",
+      "Cloud/ML Platform Engineer", "ML Trainer/Researcher", "Full-Stack AI
+      Engineer", "DevOps/Infra Engineer"), matched against the generated
+      `AI_ARCHETYPE_VALUES`
+- [x] 2.2 Add a static `AI_ARCHETYPE` options array (`options(AI_ARCHETYPE_VALUES,
+      AI_ARCHETYPE_LABELS)`) and one new `FACETS` entry — `param:
+      'ai_archetype'`, `label: 'AI Specialization'`, `control: 'select'`,
+      `options: AI_ARCHETYPE`, `excludable: true` — positioned immediately
+      after the `category` entry in `web/src/lib/facets.ts`
+- [x] 2.3 Wire the facet into the actual UI: a `RailEntry` in
+      `web/src/lib/filterSections.ts` (`RAIL`, right after `category`,
+      `kind: 'facet'`) so the modal renders it; a live-count merge fix in
+      `web/src/lib/components/facets/FacetSection.svelte`'s static-select
+      branch (it previously only merged counts for `dynamic: true` facets —
+      a generic fix, not ai_archetype-special-cased); a
+      `facetGroup('ai_archetype', ...)` line in `FilterSummary.svelte` so an
+      applied selection shows as a sidebar chip. Registering a `FacetDef` in
+      `FACETS` alone is necessary but not sufficient — `RAIL` and
+      `FilterSummary` are separate hand-maintained lists
+
+## 3. Verification
+
+- [x] 3.1 `go build ./...`, `go vet ./...`, `go test ./...` (backend) — clean
+- [x] 3.2 Web type-check / lint per `web/AGENTS.md` conventions — `svelte-check`
+      0 errors, `vitest run` 79 files / 862 tests passing, `oxlint` clean on
+      every changed file
+- [x] 3.3 Live-browser visual check attempted but not completed: the only
+      free local Postgres/Meilisearch belonged to a concurrent worktree
+      (`tailor-experience-tab`) whose Meilisearch had no `jobs` index yet
+      (empty dev instance, unrelated to this change), so the SSR jobs page
+      500s on load regardless of this diff. Seeding data or reindexing that
+      shared instance was ruled out to avoid disturbing concurrent work.
+      Substituted with the automated tests (`facets.test.ts`,
+      `filterSections.test.ts`, `labels.test.ts`) asserting the exact
+      behavior a visual check would confirm — position, control type, label
+      text, live-count merge — plus a second code-review pass that traced
+      the actual `FilterModal.svelte` render path end-to-end. A real
+      browser check should still happen post-deploy against a populated
+      environment.

--- a/web/src/lib/components/facets/FacetSection.svelte
+++ b/web/src/lib/components/facets/FacetSection.svelte
@@ -20,13 +20,16 @@
   // Excludable facets cycle through the exclude state; the rest only toggle include.
   const onToggle = (v: string) => (def.excludable ? store.cycle(def.param, v) : store.pick(def.param, v));
 
-  // Options for a select facet: static for closed vocabularies, or built from the
+  // Options for a select facet: static for closed vocabularies (with the live
+  // distribution merged in, same as ChipFacet does for its pills), or built from the
   // live distribution (value → count, busiest first) for dynamic ones. Selected
   // values absent from the current distribution are still listed so they stay
   // removable.
   const selectOptions = $derived.by((): FacetOption[] => {
-    if (!def.dynamic) return def.options ?? [];
-    return dynamicOptions(def.param, counts?.facets?.[def.param] ?? {}, [...st.include, ...st.exclude]);
+    if (def.dynamic) return dynamicOptions(def.param, counts?.facets?.[def.param] ?? {}, [...st.include, ...st.exclude]);
+    const dist = counts?.facets?.[def.param];
+    const base = def.options ?? [];
+    return dist ? base.map((o) => ({ ...o, count: dist[o.value] ?? 0 })) : base;
   });
   // The match/clear actions only appear once something is selected — so their
   // meaning is clear ("you picked these — match all, or clear them") rather than

--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -47,6 +47,7 @@
     push('Search', f.q.trim() ? [{ text: f.q, exclude: false, remove: () => store.setQuery('') }] : []);
 
     facetGroup('category', 'Specialization');
+    facetGroup('ai_archetype', 'AI Specialization');
     // Location: regions + countries + cities under one heading.
     push('Location', [...facetChips('regions'), ...facetChips('countries'), ...facetChips('cities')]);
 

--- a/web/src/lib/facets.test.ts
+++ b/web/src/lib/facets.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { COLLECTIONS } from './generated/contracts';
+import { COLLECTIONS, AI_ARCHETYPE_VALUES } from './generated/contracts';
 import { cityOption, countryLabel, FACETS } from './facets';
 
 const collectionOptions = () => FACETS.find((f) => f.param === 'collections')?.options ?? [];
+
+describe('the ai_archetype facet', () => {
+  it('is registered right after category', () => {
+    const categoryIndex = FACETS.findIndex((f) => f.param === 'category');
+    const archetypeIndex = FACETS.findIndex((f) => f.param === 'ai_archetype');
+    expect(archetypeIndex).toBe(categoryIndex + 1);
+  });
+
+  it('offers every generated archetype value as a static select option, with counts', () => {
+    const facet = FACETS.find((f) => f.param === 'ai_archetype');
+    expect(facet?.control).toBe('select');
+    expect(facet?.dynamic).toBeFalsy();
+    const offered = (facet?.options ?? []).map((o) => o.value).toSorted();
+    expect(offered).toEqual(AI_ARCHETYPE_VALUES.toSorted());
+  });
+});
 
 describe('the collections facet', () => {
   it('offers every collection in the registry as a filter option', () => {

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -17,12 +17,13 @@ import {
   WORK_MODE_VALUES, SENIORITY_VALUES, CATEGORY_VALUES,
   EMPLOYMENT_TYPE_VALUES, RELOCATION_VALUES, ENGLISH_LEVEL_VALUES,
   COMPANY_TYPE_VALUES, DOMAIN_VALUES, ROLE_LABELS, ROLE_ALIASES,
+  AI_ARCHETYPE_VALUES,
 } from './generated/contracts';
 import { fuzzyMatch } from './fuzzy';
 import {
   REGION_LABELS, SENIORITY_LABELS, EMPLOYMENT_LABELS, WORK_MODE_LABELS,
   CATEGORY_LABELS, DOMAIN_LABELS, COMPANY_TYPE_LABELS, ENGLISH_LEVEL_LABELS,
-  RELOCATION_LABELS, titleCase,
+  RELOCATION_LABELS, AI_ARCHETYPE_LABELS, titleCase,
 } from './labels';
 import { COLLECTIONS } from './collections';
 import { ROLE_RELATED } from './roleRelated';
@@ -380,6 +381,10 @@ const CATEGORY: FacetOption[] = options(CATEGORY_VALUES, CATEGORY_LABELS);
 // profile's specialization picker) so the same labels/order are shared, not duplicated.
 export const CATEGORY_OPTIONS: FacetOption[] = CATEGORY;
 
+// Six fixed values (internal/aiarchetype) — a static select like CATEGORY/DOMAINS,
+// not a dynamic (distribution-driven) control like role/skills.
+const AI_ARCHETYPE: FacetOption[] = options(AI_ARCHETYPE_VALUES, AI_ARCHETYPE_LABELS);
+
 // Work-mode and region options, exported for the profile's location preferences editor so
 // it shares the filter panel's vocabulary/order instead of duplicating it.
 export const WORK_MODE_OPTIONS: FacetOption[] = WORK_MODE;
@@ -525,6 +530,7 @@ export const FACETS: FacetDef[] = [
   { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
   { param: 'role', label: 'Role', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search roles', cap: 8, related: ROLE_RELATED, searchAliases: ROLE_ALIASES },
   { param: 'category', label: 'Specialization', control: 'select', options: CATEGORY, excludable: true, placeholder: 'Search specializations' },
+  { param: 'ai_archetype', label: 'AI Specialization', control: 'select', options: AI_ARCHETYPE, excludable: true, placeholder: 'Search AI specializations' },
   { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },
   { param: 'skills', label: 'Skills', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search skills' },
   { param: 'domains', label: 'Industry', control: 'select', options: DOMAINS, excludable: true, placeholder: 'Search industries' },

--- a/web/src/lib/filterSections.test.ts
+++ b/web/src/lib/filterSections.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { RAIL } from './filterSections';
+
+describe('the ai_archetype rail entry', () => {
+  it('is registered right after category, so the facet is reachable in the modal', () => {
+    const categoryIndex = RAIL.findIndex((e) => e.key === 'category');
+    const archetypeIndex = RAIL.findIndex((e) => e.key === 'ai_archetype');
+    expect(archetypeIndex).toBeGreaterThan(-1);
+    expect(archetypeIndex).toBe(categoryIndex + 1);
+  });
+
+  it('renders through the generic facet path with the ai_archetype param', () => {
+    const entry = RAIL.find((e) => e.key === 'ai_archetype');
+    expect(entry?.kind).toBe('facet');
+    expect(entry?.facetParam).toBe('ai_archetype');
+  });
+});

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -132,6 +132,7 @@ export const RAIL: RailEntry[] = [
   // reachable via the seniority pill); the picker is the natural-language entry,
   // the pills/chips the browse-by-axis entry.
   { key: 'category', label: 'Role', section: 'ROLE', kind: 'category' },
+  { key: 'ai_archetype', label: 'AI Specialization', section: 'ROLE', kind: 'facet', facetParam: 'ai_archetype' },
   { key: 'location', label: 'Location', section: 'ROLE', kind: 'location' },
   { key: 'work', label: 'Work & employment', section: 'ROLE', kind: 'work' },
   { key: 'skills', label: 'Skills', section: 'ROLE', kind: 'facet', facetParam: 'skills' },

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -872,6 +872,12 @@ seeding from the extracted résumé, and PDF rendering behind a Renderer interfa
 */
 
 /**
+ * DefaultMaxBullets is the per-experience / per-project bullet ceiling when
+ * CV_MAX_BULLETS is unset. Writers must refuse growth past MaxBullets rather
+ * than let Sanitize drop trailing content silently.
+ */
+export const DefaultMaxBullets = 20;
+/**
  * Document is the typed, sanitized CV. Every field is optional; sections the user has
  * not filled in are left empty rather than invented, and Sanitize drops empty entries.
  */
@@ -1097,7 +1103,7 @@ export interface Question {
   answer?: string;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', '4dayweek', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'arbeitsagentur', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'betterteam', 'breezy', 'briefhq', 'bullhorn', 'careerplug', 'careerspage', 'catsone', 'cleverstaff', 'clinch', 'comeet', 'compleo', 'cornerstone', 'crelate', 'deel', 'djinni', 'earcu', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'functionalworks', 'geekjob', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'getro', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'hh', 'hibob', 'himalayas', 'hireology', 'huntflow', 'hurma', 'icims', 'infojobs', 'inhire', 'instaffo', 'ismartrecruit', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobscore', 'jobspresso', 'jobstash', 'jobtech', 'jobvite', 'jobylon', 'join', 'justjoin', 'lever', 'likeit', 'loxo', 'luxoft', 'manatal', 'mindsight', 'mycareersfuture', 'neogov', 'nofluffjobs', 'northstone', 'odoo', 'opencats', 'oracle', 'pageup', 'paycom', 'paylocity', 'peopleforce', 'personio', 'phenom', 'pinpoint', 'powertofly', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'reed', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'softgarden', 'solides', 'spark', 'speedrun', 'startupandvc', 'successfactors', 'talentadore', 'talenthr', 'talentlyft', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'trudvsem', 'tyomarkkinatori', 'ukg', 'usajobs', 'vagas', 'vention', 'vouch', 'wantapply', 'wantedkr', 'weworkremotely', 'whatjobs', 'workable', 'workablemarketplace', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', '4dayweek', 'adp', 'adzuna', 'aijobs', 'applicantpro', 'apploi', 'arbeitnow', 'arbeitsagentur', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'betterteam', 'breezy', 'briefhq', 'bullhorn', 'careerplug', 'careerspage', 'catsone', 'cleverstaff', 'clinch', 'comeet', 'compleo', 'cornerstone', 'crelate', 'deel', 'djinni', 'earcu', 'echojobs', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'functionalworks', 'geekjob', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'getro', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'hh', 'hibob', 'himalayas', 'hireology', 'huntflow', 'hurma', 'icims', 'infojobs', 'inhire', 'instaffo', 'ismartrecruit', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobscore', 'jobspresso', 'jobstash', 'jobtech', 'jobvite', 'jobylon', 'join', 'justjoin', 'lever', 'likeit', 'loxo', 'luxoft', 'manatal', 'mindsight', 'mycareersfuture', 'neogov', 'nofluffjobs', 'northstone', 'odoo', 'opencats', 'oracle', 'pageup', 'paycom', 'paylocity', 'peopleforce', 'personio', 'phenom', 'pinpoint', 'powertofly', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'reed', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'softgarden', 'solides', 'spark', 'speedrun', 'startupandvc', 'successfactors', 'talentadore', 'talenthr', 'talentlyft', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'trudvsem', 'tyomarkkinatori', 'ukg', 'usajobs', 'vagas', 'vention', 'vouch', 'wantapply', 'wantedkr', 'weworkremotely', 'whatjobs', 'workable', 'workablemarketplace', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn', 'expired'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];
@@ -1138,6 +1144,8 @@ export const COMPANY_TYPE_VALUES = ['product', 'startup', 'outsource', 'outstaff
 export type CompanyType = (typeof COMPANY_TYPE_VALUES)[number];
 export const DOMAIN_VALUES = ['fintech', 'crypto', 'ecommerce', 'gambling', 'gamedev', 'media', 'travel', 'healthcare', 'edtech', 'govtech', 'devtools', 'cybersecurity', 'ai', 'hrtech', 'adtech', 'proptech', 'logistics', 'mobility', 'climatetech', 'other'] as const;
 export type Domain = (typeof DOMAIN_VALUES)[number];
+export const AI_ARCHETYPE_VALUES = ['rag_app_builder', 'agent_builder', 'cloud_ml_platform_engineer', 'ml_trainer_researcher', 'fullstack_ai_engineer', 'devops_infra_engineer'] as const;
+export type AIArchetype = (typeof AI_ARCHETYPE_VALUES)[number];
 export const EMAIL_STATUS_SIGNAL_VALUES = ['acknowledgement', 'screening', 'interview_invitation', 'assessment', 'offer', 'rejection', 'info_request', 'incomplete_application', 'other'] as const;
 export type EmailStatusSignal = (typeof EMAIL_STATUS_SIGNAL_VALUES)[number];
 export const SIGNAL_STAGE = {
@@ -1297,6 +1305,7 @@ export const ROLE_LABELS = {
   'ai_product_engineer': 'AI Product Engineer',
   'analytics_engineer': 'Analytics Engineer',
   'android_developer': 'Android Developer',
+  'applied_ai_engineer': 'Applied AI Engineer',
   'architecture': 'Architect',
   'art_director': 'Art Director',
   'backend': 'Backend Engineer',
@@ -1316,6 +1325,7 @@ export const ROLE_LABELS = {
   'c_level_ai_product_engineer': 'C-Level AI Product Engineer',
   'c_level_analytics_engineer': 'C-Level Analytics Engineer',
   'c_level_android_developer': 'C-Level Android Developer',
+  'c_level_applied_ai_engineer': 'C-Level Applied AI Engineer',
   'c_level_architecture': 'C-Level Architect',
   'c_level_backend': 'C-Level Backend Engineer',
   'c_level_bdr': 'C-Level Business Development Representative',
@@ -1346,6 +1356,7 @@ export const ROLE_LABELS = {
   'c_level_data_science': 'C-Level Data Scientist',
   'c_level_deep_learning_engineer': 'C-Level Deep Learning Engineer',
   'c_level_demand_generation_manager': 'C-Level Demand Generation Manager',
+  'c_level_deployment_engineer': 'C-Level Deployment Engineer',
   'c_level_design': 'C-Level Designer',
   'c_level_design_engineer': 'C-Level Design Engineer',
   'c_level_developer_advocate': 'C-Level Developer Advocate',
@@ -1468,6 +1479,7 @@ export const ROLE_LABELS = {
   'data_science': 'Data Scientist',
   'deep_learning_engineer': 'Deep Learning Engineer',
   'demand_generation_manager': 'Demand Generation Manager',
+  'deployment_engineer': 'Deployment Engineer',
   'design': 'Designer',
   'design_engineer': 'Design Engineer',
   'design_ops': 'Design Ops',
@@ -1526,6 +1538,7 @@ export const ROLE_LABELS = {
   'intern_ai_product_engineer': 'Intern AI Product Engineer',
   'intern_analytics_engineer': 'Intern Analytics Engineer',
   'intern_android_developer': 'Intern Android Developer',
+  'intern_applied_ai_engineer': 'Intern Applied AI Engineer',
   'intern_architecture': 'Intern Architect',
   'intern_backend': 'Intern Backend Engineer',
   'intern_bdr': 'Intern Business Development Representative',
@@ -1556,6 +1569,7 @@ export const ROLE_LABELS = {
   'intern_data_science': 'Intern Data Scientist',
   'intern_deep_learning_engineer': 'Intern Deep Learning Engineer',
   'intern_demand_generation_manager': 'Intern Demand Generation Manager',
+  'intern_deployment_engineer': 'Intern Deployment Engineer',
   'intern_design': 'Intern Designer',
   'intern_design_engineer': 'Intern Design Engineer',
   'intern_developer_advocate': 'Intern Developer Advocate',
@@ -1665,6 +1679,7 @@ export const ROLE_LABELS = {
   'junior_ai_product_engineer': 'Junior AI Product Engineer',
   'junior_analytics_engineer': 'Junior Analytics Engineer',
   'junior_android_developer': 'Junior Android Developer',
+  'junior_applied_ai_engineer': 'Junior Applied AI Engineer',
   'junior_architecture': 'Junior Architect',
   'junior_backend': 'Junior Backend Engineer',
   'junior_bdr': 'Junior Business Development Representative',
@@ -1695,6 +1710,7 @@ export const ROLE_LABELS = {
   'junior_data_science': 'Junior Data Scientist',
   'junior_deep_learning_engineer': 'Junior Deep Learning Engineer',
   'junior_demand_generation_manager': 'Junior Demand Generation Manager',
+  'junior_deployment_engineer': 'Junior Deployment Engineer',
   'junior_design': 'Junior Designer',
   'junior_design_engineer': 'Junior Design Engineer',
   'junior_developer_advocate': 'Junior Developer Advocate',
@@ -1803,6 +1819,7 @@ export const ROLE_LABELS = {
   'lead_ai_product_engineer': 'Lead AI Product Engineer',
   'lead_analytics_engineer': 'Lead Analytics Engineer',
   'lead_android_developer': 'Lead Android Developer',
+  'lead_applied_ai_engineer': 'Lead Applied AI Engineer',
   'lead_architecture': 'Lead Architect',
   'lead_backend': 'Lead Backend Engineer',
   'lead_bdr': 'Lead Business Development Representative',
@@ -1833,6 +1850,7 @@ export const ROLE_LABELS = {
   'lead_data_science': 'Lead Data Scientist',
   'lead_deep_learning_engineer': 'Lead Deep Learning Engineer',
   'lead_demand_generation_manager': 'Lead Demand Generation Manager',
+  'lead_deployment_engineer': 'Lead Deployment Engineer',
   'lead_design': 'Lead Designer',
   'lead_design_engineer': 'Lead Design Engineer',
   'lead_developer_advocate': 'Lead Developer Advocate',
@@ -1951,6 +1969,7 @@ export const ROLE_LABELS = {
   'middle_ai_product_engineer': 'Middle AI Product Engineer',
   'middle_analytics_engineer': 'Middle Analytics Engineer',
   'middle_android_developer': 'Middle Android Developer',
+  'middle_applied_ai_engineer': 'Middle Applied AI Engineer',
   'middle_architecture': 'Middle Architect',
   'middle_backend': 'Middle Backend Engineer',
   'middle_bdr': 'Middle Business Development Representative',
@@ -1981,6 +2000,7 @@ export const ROLE_LABELS = {
   'middle_data_science': 'Middle Data Scientist',
   'middle_deep_learning_engineer': 'Middle Deep Learning Engineer',
   'middle_demand_generation_manager': 'Middle Demand Generation Manager',
+  'middle_deployment_engineer': 'Middle Deployment Engineer',
   'middle_design': 'Middle Designer',
   'middle_design_engineer': 'Middle Design Engineer',
   'middle_developer_advocate': 'Middle Developer Advocate',
@@ -2101,6 +2121,7 @@ export const ROLE_LABELS = {
   'principal_ai_product_engineer': 'Principal AI Product Engineer',
   'principal_analytics_engineer': 'Principal Analytics Engineer',
   'principal_android_developer': 'Principal Android Developer',
+  'principal_applied_ai_engineer': 'Principal Applied AI Engineer',
   'principal_architecture': 'Principal Architect',
   'principal_backend': 'Principal Backend Engineer',
   'principal_bdr': 'Principal Business Development Representative',
@@ -2131,6 +2152,7 @@ export const ROLE_LABELS = {
   'principal_data_science': 'Principal Data Scientist',
   'principal_deep_learning_engineer': 'Principal Deep Learning Engineer',
   'principal_demand_generation_manager': 'Principal Demand Generation Manager',
+  'principal_deployment_engineer': 'Principal Deployment Engineer',
   'principal_design': 'Principal Designer',
   'principal_design_engineer': 'Principal Design Engineer',
   'principal_developer_advocate': 'Principal Developer Advocate',
@@ -2259,6 +2281,7 @@ export const ROLE_LABELS = {
   'senior_ai_product_engineer': 'Senior AI Product Engineer',
   'senior_analytics_engineer': 'Senior Analytics Engineer',
   'senior_android_developer': 'Senior Android Developer',
+  'senior_applied_ai_engineer': 'Senior Applied AI Engineer',
   'senior_architecture': 'Senior Architect',
   'senior_backend': 'Senior Backend Engineer',
   'senior_bdr': 'Senior Business Development Representative',
@@ -2289,6 +2312,7 @@ export const ROLE_LABELS = {
   'senior_data_science': 'Senior Data Scientist',
   'senior_deep_learning_engineer': 'Senior Deep Learning Engineer',
   'senior_demand_generation_manager': 'Senior Demand Generation Manager',
+  'senior_deployment_engineer': 'Senior Deployment Engineer',
   'senior_design': 'Senior Designer',
   'senior_design_engineer': 'Senior Design Engineer',
   'senior_developer_advocate': 'Senior Developer Advocate',
@@ -2407,6 +2431,7 @@ export const ROLE_LABELS = {
   'staff_ai_product_engineer': 'Staff AI Product Engineer',
   'staff_analytics_engineer': 'Staff Analytics Engineer',
   'staff_android_developer': 'Staff Android Developer',
+  'staff_applied_ai_engineer': 'Staff Applied AI Engineer',
   'staff_architecture': 'Staff Architect',
   'staff_backend': 'Staff Backend Engineer',
   'staff_bdr': 'Staff Business Development Representative',
@@ -2437,6 +2462,7 @@ export const ROLE_LABELS = {
   'staff_data_science': 'Staff Data Scientist',
   'staff_deep_learning_engineer': 'Staff Deep Learning Engineer',
   'staff_demand_generation_manager': 'Staff Demand Generation Manager',
+  'staff_deployment_engineer': 'Staff Deployment Engineer',
   'staff_design': 'Staff Designer',
   'staff_design_engineer': 'Staff Design Engineer',
   'staff_developer_advocate': 'Staff Developer Advocate',
@@ -2563,6 +2589,7 @@ export const ROLE_ALIASES = {
   'ai_product_engineer': ['ai product engineer', 'ai-product engineer'],
   'analytics_engineer': ['analytics engineer'],
   'android_developer': ['android developer', 'android engineer', 'android software engineer'],
+  'applied_ai_engineer': ['applied ai engineer'],
   'architecture': ['architect', 'cloud architect', 'enterprise architect', 'software architect', 'solutions architect', 'архитектор'],
   'art_director': ['art director'],
   'backend': ['1c', '1с', 'back end', 'back-end', 'backend', 'бекенд', 'бэкенд'],
@@ -2597,6 +2624,7 @@ export const ROLE_ALIASES = {
   'data_science': ['data scien', 'data science', 'data scientist', 'дата-сайентист'],
   'deep_learning_engineer': ['deep learning engineer'],
   'demand_generation_manager': ['demand gen', 'demand generation'],
+  'deployment_engineer': ['deployment engineer'],
   'design': ['design', 'design engineer, product', 'design system engineer', 'design systems engineer', 'designer', 'experience design engineer', 'game design engineer', 'product design engineer', 'service design engineer', 'sound design engineer', 'ui', 'ui design engineer', 'ui/ux design engineer', 'ux', 'ux design engineer', 'web design engineer', 'дизайн', 'дизайнер'],
   'design_engineer': ['design engineer', 'design system engineer', 'design systems engineer', 'product design engineer'],
   'design_ops': ['design operations', 'design ops', 'designops'],
@@ -2615,7 +2643,7 @@ export const ROLE_ALIASES = {
   'financial_analyst': ['financial analyst'],
   'firmware_engineer': ['firmware engineer'],
   'flutter_developer': ['flutter'],
-  'forward_deployed_engineer': ['forward deployed engineer'],
+  'forward_deployed_engineer': ['fde', 'forward deploy', 'forward deployed engineer', 'forward-deployed'],
   'founder': ['co-founder', 'cofounder', 'founder', 'technical co-founder'],
   'founding_designer': ['founding designer'],
   'founding_engineer': ['founding engineer'],

--- a/web/src/lib/labels.test.ts
+++ b/web/src/lib/labels.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { CATEGORY_LABELS, RELOCATION_LABELS, categoryLabel, titleCase } from './labels';
+import {
+  CATEGORY_LABELS,
+  RELOCATION_LABELS,
+  AI_ARCHETYPE_LABELS,
+  categoryLabel,
+  titleCase,
+} from './labels';
+import { AI_ARCHETYPE_VALUES } from './generated/contracts';
 
 // Exhaustiveness over the generated vocabulary is enforced by the type checker rather
 // than here: CATEGORY_LABELS carries `satisfies Record<Category, string>`, so
@@ -31,6 +38,18 @@ describe('categoryLabel', () => {
 describe('titleCase', () => {
   it('capitalizes every word of a snake_case code', () => {
     expect(titleCase('network_engineering')).toBe('Network Engineering');
+  });
+});
+
+describe('AI_ARCHETYPE_LABELS', () => {
+  it('covers every generated archetype value with a human label', () => {
+    for (const value of AI_ARCHETYPE_VALUES) {
+      expect(AI_ARCHETYPE_LABELS[value], `missing label for ${value}`).toBeTruthy();
+    }
+  });
+
+  it('spells out RAG rather than title-casing the acronym', () => {
+    expect(AI_ARCHETYPE_LABELS.rag_app_builder).toBe('RAG Application Builder');
   });
 });
 

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -152,3 +152,16 @@ export const DOMAIN_LABELS: Record<string, string> = {
 };
 
 export const COMPANY_TYPE_LABELS: Record<string, string> = { inhouse: 'In-house' };
+
+// The six AI skill-signature archetypes (vocab.AIArchetypeValues). Listed in full
+// rather than override-only: the title-cased fallback would render "Rag App
+// Builder" for an acronym that must read "RAG", so every value needs an explicit
+// entry regardless.
+export const AI_ARCHETYPE_LABELS: Record<string, string> = {
+  rag_app_builder: 'RAG Application Builder',
+  agent_builder: 'Agent Builder',
+  cloud_ml_platform_engineer: 'Cloud/ML Platform Engineer',
+  ml_trainer_researcher: 'ML Trainer/Researcher',
+  fullstack_ai_engineer: 'Full-Stack AI Engineer',
+  devops_infra_engineer: 'DevOps/Infra Engineer',
+};


### PR DESCRIPTION
## Summary

- Exposes the `ai_archetype` job facet (merged in #1673) in the web filter UI, following the `category`/`domains` static-select pattern (not the dynamic `role`/`skills` one) — six fixed values, live counts.
- `internal/vocab.AIArchetypeValues` generated into `web/src/lib/generated/contracts.ts` as `AI_ARCHETYPE_VALUES`, cross-checked by a test against `internal/aiarchetype`'s own rule table so the two can't drift.
- Frontend: registered in `facets.ts`, and — this is the part a first pass missed and a follow-up review caught — actually wired into the modal (`RAIL` entry in `filterSections.ts`) and the sidebar (`FilterSummary.svelte` chip). Registering a `FacetDef` in `FACETS` alone doesn't make a facet reachable; `RAIL` and `FilterSummary` are separate hand-maintained lists.
- Fixed a real gap in `FacetSection.svelte`: it only merged live counts for `dynamic: true` facets, so a static `select` facet (like this one) would have rendered with no counts at all. This is a generic fix to the shared component, not special-cased to `ai_archetype`.

OpenSpec change: `openspec/changes/ai-archetype-filter-ui/`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` — clean
- [x] `npx vitest run` — 79 files / 862 tests passing (new: `facets.test.ts`, `filterSections.test.ts`, `labels.test.ts` cases)
- [x] `npx svelte-check` — 0 errors
- [x] `npx oxlint` on every changed file — clean (no new warnings)
- [x] Two rounds of independent code review (first caught the reachability + live-count gaps above; second confirmed the fixes by tracing the actual `FilterModal.svelte` render path)
- [ ] Live-browser check: attempted but blocked — the only free local Meilisearch (a concurrent worktree's) had no `jobs` index yet, unrelated to this change; seeding/reindexing that shared instance was avoided to not disturb concurrent work. Worth a manual pass against a populated environment post-deploy.
- [ ] Counts will read 0 for every option until the prod reindex from #1673's task group 6 runs (separate, already-tracked ops step)