### PR TITLE
SEO see-also: bump to 10 cards, group multi-key counts by shared filter

### DIFF
--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -691,8 +691,20 @@ export function jobFacetsFromJob(job: Job): JobFacets {
 }
 
 // Popular collections padding a sparse "see also" block so it's never empty
-// or too thin. Slugs are verified to exist in FILTER_COLLECTIONS by a test.
-export const POPULAR_COLLECTION_FALLBACK = ['remote-worldwide', 'javascript', 'python', 'react'];
+// or too thin. Each was verified to have a healthy live count before being
+// added; slugs are verified to exist in FILTER_COLLECTIONS by a test.
+export const POPULAR_COLLECTION_FALLBACK = [
+  'remote-worldwide',
+  'javascript',
+  'typescript',
+  'python',
+  'react',
+  'go',
+  'senior',
+  'backend',
+  'frontend',
+  'aws',
+];
 
 // Whether a single FILTER_COLLECTIONS param entry is satisfied by the job's
 // facets. `role` (and any other key the job carries no data for) never
@@ -732,7 +744,7 @@ function collectionMatchesJob(entry: FilterCollection, job: JobFacets): boolean 
 // then padded with POPULAR_COLLECTION_FALLBACK up to `target`. Every
 // returned slug resolves via collectionBySlug — this never invents a link to
 // a collection that doesn't exist.
-export function relatedCollectionSlugs(job: JobFacets, target = 5): string[] {
+export function relatedCollectionSlugs(job: JobFacets, target = 10): string[] {
   const slugs: string[] = [];
   const seen = new Set<string>();
   const add = (slug: string) => {
@@ -768,7 +780,7 @@ export function relatedCollectionSlugs(job: JobFacets, target = 5): string[] {
 // this module, matching web/'s no-component-test-harness convention.
 export function relatedCollectionLinks(
   job: JobFacets,
-  target = 5
+  target = 10
 ): { slug: string; title: string }[] {
   return relatedCollectionSlugs(job, target)
     .map((slug) => {

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -13,52 +13,77 @@ import type { PageServerLoad } from './$types';
 
 type Api = ReturnType<typeof serverApi>;
 
-// A see-also card's live count. Every current collection is a single facet's
-// value under the whole catalogue (skills=react, category=backend,
-// collections=yc, …) — read straight off the shared, unfiltered
-// facetCounts() distribution passed in, no per-card request. Only the
-// remote+region/country combos (two AND'd keys, e.g. work_mode + regions)
-// need their own direct query: a facet distribution is a marginal count per
-// field under a filter, not a joint count across two fields.
-async function seeAlsoCount(
-  params: Record<string, string>,
-  facetsResult: FacetCounts | null,
-  api: Api
-): Promise<number | null> {
-  const entries = Object.entries(params);
-  if (entries.length > 1) {
-    return (await api.searchJobs(new URLSearchParams(params), 0, 0).catch(() => null))?.total ?? null;
-  }
-  const [key, value] = entries[0]!; // length === 1 just checked above
-  // A missing entry here is never a genuine zero: every card reaching this
-  // branch is either the job's own facet/collection (so the job itself is
-  // ≥1) or a fallback pool entry curated to have a healthy count. It means
-  // Meilisearch's MaxValuesPerFacet cap dropped this value from the
-  // distribution — degrade to unresolved, not a false "0 jobs".
+// A missing facets[key][value] entry is never a genuine zero: every card
+// reaching seeAlsoCount is either the job's own facet/collection (so the job
+// itself is ≥1) or a fallback pool entry curated to have a healthy count. It
+// means Meilisearch's MaxValuesPerFacet cap dropped this value from the
+// distribution — degrade to unresolved, not a false "0 jobs".
+function readCount(facetsResult: FacetCounts | null, key: string, value: string): number | null {
   return facetsResult ? (facetsResult.facets[key]?.[value] ?? null) : null;
 }
 
 // The "see also" block's matched collections, each with its live open-job
-// count. Callers kick this off the moment `job` resolves (it needs `job`'s
-// own facets) so it overlaps with the page's other fetches instead of adding
-// a second sequential wave after them. In practice a job matches at most one
-// remote+region/country collection, so this is usually 1 request total
-// (the shared facetCounts() call), never more than 2.
+// count. Kicked off the moment `job` resolves (it needs `job`'s own facets)
+// so it overlaps with the page's other fetches instead of adding a second
+// sequential wave after them.
+//
+// Every current collection's count is readable off a facetCounts()
+// distribution, never a per-card searchJobs call:
+// - A single-key collection (skills=react, category=backend, collections=yc,
+//   …) reads straight off ONE shared, unfiltered distribution covering the
+//   whole catalogue.
+// - A multi-key collection (the ten remote+region/country combos, e.g.
+//   work_mode=remote AND regions=global) needs its LAST key's value read
+//   from a distribution filtered by its other keys — a facet distribution is
+//   a marginal count per field under a filter, not a joint count across
+//   fields. All ten currently share the same filter (work_mode=remote), so
+//   they're grouped by filter and share ONE extra call: a job open in
+//   several countries at once (matching several remote-* collections) still
+//   costs one request, not one per match.
 async function buildSeeAlso(job: Job, api: Api): Promise<SeeAlsoCard[]> {
   const links = relatedCollectionLinks(jobFacetsFromJob(job));
-  const facetsResult = await api.facetCounts(new URLSearchParams()).catch(() => null);
+  const resolvedLinks = links.map((link) => ({ link, resolved: collectionBySlug(link.slug) }));
 
-  return Promise.all(
-    links.map(async (link): Promise<SeeAlsoCard> => {
-      const mark = backerBadges([link.slug])[0]?.mark ?? null;
-      // relatedCollectionLinks already resolves every slug it returns via this
-      // same collectionBySlug, so `resolved` is guaranteed here — this is TS
-      // narrowing, not a real fallback path.
-      const resolved = collectionBySlug(link.slug);
-      const count = resolved ? await seeAlsoCount(resolved.params, facetsResult, api) : null;
-      return { slug: link.slug, title: link.title, count, mark };
-    })
+  const baseFacets = await api.facetCounts(new URLSearchParams()).catch(() => null);
+
+  const multiKeyGroups = new Map<string, { filter: Record<string, string>; lastKey: string }>();
+  for (const { resolved } of resolvedLinks) {
+    const entries = resolved ? Object.entries(resolved.params) : [];
+    if (entries.length <= 1) continue;
+    const [lastKey] = entries[entries.length - 1]!;
+    const filter = Object.fromEntries(entries.slice(0, -1));
+    multiKeyGroups.set(new URLSearchParams(filter).toString(), { filter, lastKey });
+  }
+  const groupedFacets = new Map<string, FacetCounts | null>(
+    await Promise.all(
+      [...multiKeyGroups.entries()].map(
+        async ([groupKey, { filter }]): Promise<[string, FacetCounts | null]> => [
+          groupKey,
+          await api.facetCounts(new URLSearchParams(filter)).catch(() => null),
+        ]
+      )
+    )
   );
+
+  return resolvedLinks.map(({ link, resolved }): SeeAlsoCard => {
+    const mark = backerBadges([link.slug])[0]?.mark ?? null;
+    // relatedCollectionLinks already resolves every slug it returns via this
+    // same collectionBySlug, so `resolved` is guaranteed here — this is TS
+    // narrowing, not a real fallback path.
+    if (!resolved) return { slug: link.slug, title: link.title, count: null, mark };
+
+    const entries = Object.entries(resolved.params);
+    let count: number | null;
+    if (entries.length === 1) {
+      const [key, value] = entries[0]!;
+      count = readCount(baseFacets, key, value);
+    } else {
+      const [lastKey, lastValue] = entries[entries.length - 1]!;
+      const groupKey = new URLSearchParams(Object.fromEntries(entries.slice(0, -1))).toString();
+      count = readCount(groupedFacets.get(groupKey) ?? null, lastKey, lastValue);
+    }
+    return { slug: link.slug, title: link.title, count, mark };
+  });
 }
 
 // Server-render the job detail: fetch by slug so the article content is in the

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -13,10 +13,31 @@ import type { PageServerLoad } from './$types';
 
 type Api = ReturnType<typeof serverApi>;
 
+// Splits a resolved collection's params into a filter (every key but the
+// last) and the one "variable" key/value a facet distribution under that
+// filter can read a count off. A single-key collection's filter is simply
+// empty — reading its count is then the whole-catalogue case, not a special
+// one: every collection sharing the same filter (every single-key one,
+// grouped under the empty filter; all ten remote+region/country combos,
+// grouped under work_mode=remote) reads off ONE shared facetCounts() call, no
+// matter how many of that group a job matches at once. A facet distribution
+// is a marginal count per field under a filter, not a joint count across
+// fields — which is why the OTHER keys have to be the filter, not also read
+// from the distribution.
+function splitParams(params: Record<string, string>): {
+  filter: Record<string, string>;
+  lastKey: string;
+  lastValue: string;
+} {
+  const entries = Object.entries(params);
+  const [lastKey, lastValue] = entries[entries.length - 1]!;
+  return { filter: Object.fromEntries(entries.slice(0, -1)), lastKey, lastValue };
+}
+
 // A missing facets[key][value] entry is never a genuine zero: every card
-// reaching seeAlsoCount is either the job's own facet/collection (so the job
-// itself is ≥1) or a fallback pool entry curated to have a healthy count. It
-// means Meilisearch's MaxValuesPerFacet cap dropped this value from the
+// reaching this is either the job's own facet/collection (so the job itself
+// is ≥1) or a fallback pool entry curated to have a healthy count. It means
+// Meilisearch's MaxValuesPerFacet cap dropped this value from the
 // distribution — degrade to unresolved, not a false "0 jobs".
 function readCount(facetsResult: FacetCounts | null, key: string, value: string): number | null {
   return facetsResult ? (facetsResult.facets[key]?.[value] ?? null) : null;
@@ -26,38 +47,20 @@ function readCount(facetsResult: FacetCounts | null, key: string, value: string)
 // count. Kicked off the moment `job` resolves (it needs `job`'s own facets)
 // so it overlaps with the page's other fetches instead of adding a second
 // sequential wave after them.
-//
-// Every current collection's count is readable off a facetCounts()
-// distribution, never a per-card searchJobs call:
-// - A single-key collection (skills=react, category=backend, collections=yc,
-//   …) reads straight off ONE shared, unfiltered distribution covering the
-//   whole catalogue.
-// - A multi-key collection (the ten remote+region/country combos, e.g.
-//   work_mode=remote AND regions=global) needs its LAST key's value read
-//   from a distribution filtered by its other keys — a facet distribution is
-//   a marginal count per field under a filter, not a joint count across
-//   fields. All ten currently share the same filter (work_mode=remote), so
-//   they're grouped by filter and share ONE extra call: a job open in
-//   several countries at once (matching several remote-* collections) still
-//   costs one request, not one per match.
 async function buildSeeAlso(job: Job, api: Api): Promise<SeeAlsoCard[]> {
   const links = relatedCollectionLinks(jobFacetsFromJob(job));
   const resolvedLinks = links.map((link) => ({ link, resolved: collectionBySlug(link.slug) }));
 
-  const baseFacets = await api.facetCounts(new URLSearchParams()).catch(() => null);
-
-  const multiKeyGroups = new Map<string, { filter: Record<string, string>; lastKey: string }>();
+  const filterGroups = new Map<string, Record<string, string>>();
   for (const { resolved } of resolvedLinks) {
-    const entries = resolved ? Object.entries(resolved.params) : [];
-    if (entries.length <= 1) continue;
-    const [lastKey] = entries[entries.length - 1]!;
-    const filter = Object.fromEntries(entries.slice(0, -1));
-    multiKeyGroups.set(new URLSearchParams(filter).toString(), { filter, lastKey });
+    if (!resolved) continue;
+    const { filter } = splitParams(resolved.params);
+    filterGroups.set(new URLSearchParams(filter).toString(), filter);
   }
   const groupedFacets = new Map<string, FacetCounts | null>(
     await Promise.all(
-      [...multiKeyGroups.entries()].map(
-        async ([groupKey, { filter }]): Promise<[string, FacetCounts | null]> => [
+      [...filterGroups.entries()].map(
+        async ([groupKey, filter]): Promise<[string, FacetCounts | null]> => [
           groupKey,
           await api.facetCounts(new URLSearchParams(filter)).catch(() => null),
         ]
@@ -72,16 +75,9 @@ async function buildSeeAlso(job: Job, api: Api): Promise<SeeAlsoCard[]> {
     // narrowing, not a real fallback path.
     if (!resolved) return { slug: link.slug, title: link.title, count: null, mark };
 
-    const entries = Object.entries(resolved.params);
-    let count: number | null;
-    if (entries.length === 1) {
-      const [key, value] = entries[0]!;
-      count = readCount(baseFacets, key, value);
-    } else {
-      const [lastKey, lastValue] = entries[entries.length - 1]!;
-      const groupKey = new URLSearchParams(Object.fromEntries(entries.slice(0, -1))).toString();
-      count = readCount(groupedFacets.get(groupKey) ?? null, lastKey, lastValue);
-    }
+    const { filter, lastKey, lastValue } = splitParams(resolved.params);
+    const groupKey = new URLSearchParams(filter).toString();
+    const count = readCount(groupedFacets.get(groupKey) ?? null, lastKey, lastValue);
     return { slug: link.slug, title: link.title, count, mark };
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #1677. User asked why the see-also block still capped at 5 now
that counts are batched — it no longer needs to be that small:

- Bumped `relatedCollectionSlugs`/`relatedCollectionLinks`'s default `target`
  from 5 to 10, and expanded `POPULAR_COLLECTION_FALLBACK` from 4 to 10
  verified-healthy entries so a facet-poor job still fills the block.
- Code review on that bump caught an edge case: a job open in several
  countries at once (e.g. remote US+Canada) could match multiple of the ten
  multi-key `remote-*` collections (work_mode=remote AND regions/countries)
  simultaneously, each previously firing its own `searchJobs()` call — up to
  10 extra requests in the worst case. Fixed by grouping every collection
  (single- and multi-key alike) by its shared filter — a single-key
  collection's "filter" is simply empty, so it's not a special case, just the
  same grouping mechanism with the whole-catalogue group. Every group fires
  once via one shared `Promise.all`.

## Test plan

- [x] `pnpm vitest run` — 856/856 passing
- [x] `pnpm svelte-check` — 0 errors
- [x] Manual verification against production data: a full-stack job now
  shows 10 cards (picking up matches the old cap crowded out); a real job
  with `countries: [ca, us]` renders both Remote US (52,289) and Remote
  Canada (4,316) cards with counts matching their own collection pages
  exactly
- [x] Two independent code-review passes (subagents) — findings from the
  first (multi-key request-count edge case) fixed in this same PR; findings
  from the second (unused field, sequential-not-concurrent fetches) fixed via
  the unification refactor