### PR TITLE
feat(sources): onboard boards from link_contributions queue

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -8114,3 +8114,7 @@
   board: workhero
 - company: Hex
   board: hex
+- company: Noibu
+  board: noibu
+- company: IGamingHunt
+  board: igaminghunt

--- a/sources/hurma.yml
+++ b/sources/hurma.yml
@@ -13,3 +13,5 @@
   board: workeronai
 - company: Platipus
   board: platipus
+- company: Smarter Contact
+  board: smartercontact

--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -748,3 +748,9 @@
   board: somosed
 - company: Dataside
   board: dataside
+
+# --- link contributions, validated live 2026-08-09 ---
+- company: "Marisa.Care"
+  board: marisacare
+- company: "Solo Recruiter"
+  board: solorecruiter

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3253,3 +3253,9 @@
   board: careers.plotbox.io
 - company: Dustin
   board: jobs.dustingroup.com
+- company: South Pole
+  board: careers.southpole.com
+- company: Zexter
+  board: careers.zexter.com
+- company: Vitec Software
+  board: jobs.vitecsoftware.fi


### PR DESCRIPTION
## Summary
- Drains the pending `link_contributions` queue: 7 new boards added across `ashby.yml`, `inhire.yml`, `hurma.yml`, `teamtailor.yml`.
- All boards live-validated (non-empty listing) before adding.
- One bonus fix: contribution id 253 recorded board `teamtailor:tt.teamtailor.com` — that's the platform's own SSO login host (`/login/sso`), not a real tenant (confirmed 404 on `/jobs`). The real board for that submission is `jobs.vitecsoftware.fi`, a self-hosted teamtailor career site (confirmed via CDN markers + live job listing), added instead.

## Boards added
| source | board | company |
|---|---|---|
| ashby | noibu | Noibu |
| ashby | igaminghunt | IGamingHunt |
| inhire | marisacare | Marisa.Care |
| inhire | solorecruiter | Solo Recruiter |
| hurma | smartercontact | Smarter Contact |
| teamtailor | careers.southpole.com | South Pole |
| teamtailor | careers.zexter.com | Zexter |
| teamtailor | jobs.vitecsoftware.fi | Vitec Software |

## Not onboarded (left as-is on prod, will flip status after merge)
- id 252 (workday `sok.wd502.myworkdayjobs.com/S-ryhman-avoimet-tyopaikat`) — already tracked under a lowercase-case variant of the same tenant/site; confirmed same host serves both cases. Mark `onboarded`, no file change.
- id 253 (teamtailor `tt.teamtailor.com`) — recognizer artifact (SSO login link), 404 on `/jobs`. Reject; real board handled above under a corrected value.
- id 256 (greenhouse `abbycare`) — board 404s on both `job-boards.greenhouse.io` and the boards API (`Job not found`). Reject, dead board.
- id 264 (manatal `jobs`) — literal board is not a real tenant (`No ClientPortalSettings`). Corrected tenant slug `solverogroup` is real (live careers page, real job) but its legacy career-page API isn't enabled (`"Legacy career page is not enabled"`) — not ingestable via the current manatal adapter. Reject.

## Test plan
- [x] `go build ./...`
- [x] Live-validated every board's listing endpoint before adding (ashby JSON, inhire X-Tenant JSON, hurma XHR JSON, teamtailor `/jobs` page + `og:site_name`)
- [ ] CI (`backend` full suite)
- [ ] After merge + deploy: flip `link_contributions.status` on prod for the handled rows (onboarded: 241,243,246,247,252,263,267,269; rejected: 253,256,264)