### PR TITLE
feat(sources): onboard companies mined from remote.io

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14363,3 +14363,7 @@
   board: "yes"
 - company: Zoomget
   board: zoomget
+
+# greenhouse board mined from remote.io (2026-08-09, live-validated)
+- company: Greenplaces
+  board: greenplaces

--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -3851,3 +3851,7 @@
   board: miniso-us
 - company: nscglobal
   board: nscglobal
+
+# icims board mined from remote.io (2026-08-09, live-validated; vanity host, careers-home product)
+- company: Avalara
+  board: careers.avalara.com

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -274,3 +274,7 @@
   board: ziff-davis
 - company: Ziff Davis
   board: ziffdavis
+
+# jobvite board mined from remote.io (2026-08-09, live-validated)
+- company: ForeScout
+  board: forescout

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4461,3 +4461,13 @@
   board: recast-software
 - company: Trans Lifeline
   board: translifeline
+
+# lever boards mined from remote.io (2026-08-09, live-validated)
+- company: Ridezum
+  board: ridezum
+- company: Thinkahead
+  board: thinkahead
+- company: TrueML
+  board: trueml
+- company: VeryGoodSecurity
+  board: verygoodsecurity

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3259,3 +3259,7 @@
   board: careers.zexter.com
 - company: Vitec Software
   board: jobs.vitecsoftware.fi
+
+# teamtailor board mined from remote.io (2026-08-09, live-validated)
+- company: Sophie Society
+  board: sophiesociety-1744788360.teamtailor.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -2103,3 +2103,11 @@
 # workable board from the contribution queue (2026-08-07, live-validated)
 - company: HelloGov AI
   board: hellogov
+
+# workable boards mined from remote.io (2026-08-09, live-validated)
+- company: IntellaTriage
+  board: intellatriage
+- company: Motia
+  board: motia
+- company: Virtual Staff 365
+  board: virtual-staff-365


### PR DESCRIPTION
## Summary
- Cross-referenced remote.io's live job postings (via their undocumented `/api/v2/jobs` API) against our company catalog: 629/651 (96.6%) already onboarded.
- Live-validated each of the 22 gaps directly against its ATS's own public API before adding — 11 resolved to a supported provider, 11 didn't (3 boards 404/redirect despite looking live; 8 sit on unsupported ATS platforms).

## Added
| Provider | Companies |
|---|---|
| workable | IntellaTriage, Motia, Virtual Staff 365 |
| lever | Ridezum, Thinkahead, TrueML (rebrand of TrueAccord), VeryGoodSecurity |
| greenhouse | Greenplaces |
| jobvite | ForeScout |
| teamtailor | Sophie Society |
| icims | Avalara (vanity-host careers-home product) |

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open(f))"` for all 6 files)
- [x] Each board's public ATS API confirmed to return live postings before adding