### PR TITLE
feat(matchanalysis): surface hidden signals from posting wording

### DIFF
--- a/internal/matchanalysis/analyzer.go
+++ b/internal/matchanalysis/analyzer.go
@@ -95,7 +95,8 @@ type Input struct {
 
 // stage1Out is the Extract & Match stage's raw output.
 type stage1Out struct {
-	Requirements []Requirement `json:"requirements"`
+	Requirements  []Requirement `json:"requirements"`
+	HiddenSignals []Signal      `json:"hidden_signals"`
 }
 
 // EventKind tags a streaming Event (see AnalyzeStream).
@@ -105,19 +106,20 @@ const (
 	EventStageStart   EventKind = "stage_start"  // a stage began (Stage set)
 	EventStageDone    EventKind = "stage_done"   // a stage finished (Stage set)
 	EventThinking     EventKind = "thinking"     // a reasoning-token delta (Stage + Thinking)
-	EventRequirements EventKind = "requirements" // Stage-1 result (Requirements)
+	EventRequirements EventKind = "requirements" // Stage-1 result (Requirements + HiddenSignals)
 	EventDimensions   EventKind = "dimensions"   // interim post-Stage-2 analysis (Analysis)
 	EventFinal        EventKind = "final"        // the audited final analysis (Analysis)
 )
 
 // Event is one step of a streaming analysis. Only the fields relevant to Kind are set.
 type Event struct {
-	Kind         EventKind     `json:"kind"`
-	Stage        int           `json:"stage,omitempty"`
-	Label        string        `json:"label,omitempty"`
-	Thinking     string        `json:"thinking,omitempty"`
-	Requirements []Requirement `json:"requirements,omitempty"`
-	Analysis     *Analysis     `json:"analysis,omitempty"`
+	Kind          EventKind     `json:"kind"`
+	Stage         int           `json:"stage,omitempty"`
+	Label         string        `json:"label,omitempty"`
+	Thinking      string        `json:"thinking,omitempty"`
+	Requirements  []Requirement `json:"requirements,omitempty"`
+	HiddenSignals []Signal      `json:"hidden_signals,omitempty"`
+	Analysis      *Analysis     `json:"analysis,omitempty"`
 }
 
 var stageLabels = map[int]string{1: "Extract & Match", 2: "Recruiter verdict", 3: "Adversarial audit"}
@@ -154,7 +156,8 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 		return nil, fmt.Errorf("matchanalysis: stage 1: %w", err)
 	}
 	reqs := sanitizeRequirements(s1.Requirements)
-	emit(Event{Kind: EventRequirements, Requirements: reqs})
+	signals := sanitizeSignals(s1.HiddenSignals)
+	emit(Event{Kind: EventRequirements, Requirements: reqs, HiddenSignals: signals})
 	emit(Event{Kind: EventStageDone, Stage: 1, Label: stageLabels[1]})
 
 	// Stage 2 — Recruiter verdict (the human lens).
@@ -164,7 +167,7 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 		return nil, fmt.Errorf("matchanalysis: stage 2: %w", err)
 	}
 	sanitizeVerdict(&verdict)
-	interim := buildAnalysis(reqs, verdict)
+	interim := buildAnalysis(reqs, verdict, signals)
 	emit(Event{Kind: EventDimensions, Analysis: &interim})
 	emit(Event{Kind: EventStageDone, Stage: 2, Label: stageLabels[2]})
 
@@ -192,7 +195,7 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 	}
 	emit(Event{Kind: EventStageDone, Stage: 3, Label: stageLabels[3]})
 
-	analysis := buildAnalysis(reqs, verdict)
+	analysis := buildAnalysis(reqs, verdict, signals)
 	emit(Event{Kind: EventFinal, Analysis: &analysis})
 	return &analysis, nil
 }
@@ -257,7 +260,7 @@ func stage1SystemPrompt() string {
 	b.WriteString("You are an ATS (applicant tracking system) parser. Return ONLY a JSON object.\n\n")
 	b.WriteString("From the job posting, extract the explicit requirements (skills, tools, experience, ")
 	b.WriteString("responsibilities) plus the role-title and seniority signals. Classify each against the ")
-	b.WriteString("candidate's CV. Return exactly one key:\n")
+	b.WriteString("candidate's CV. Return exactly these keys:\n")
 	b.WriteString("- \"requirements\": an array (max 30) of objects, each:\n")
 	b.WriteString("  - \"text\": the requirement, short.\n")
 	b.WriteString("  - \"priority\": \"required\" or \"preferred\".\n")
@@ -272,7 +275,15 @@ func stage1SystemPrompt() string {
 	b.WriteString("tools or methods), or \"keyword\" (the term is present but only a bare mention or ")
 	b.WriteString("duty). Omit it for \"missing-have\"/\"missing-gap\".\n")
 	b.WriteString("Base every judgement only on the CV text. NEVER fabricate a skill the CV does not ")
-	b.WriteString("evidence — a genuine gap is \"missing-gap\", never hidden.\n")
+	b.WriteString("evidence — a genuine gap is \"missing-gap\", never hidden.\n\n")
+	b.WriteString("Also return \"hidden_signals\": an array (max 5) of unstated culture/pace/team-stage ")
+	b.WriteString("signals read from the posting's own wording — not from any explicit requirement. Each ")
+	b.WriteString("object has \"quote\" (a short verbatim excerpt from the job description) and \"insight\" ")
+	b.WriteString("(one line on what that wording implies about pace, ownership expectations, team stage, ")
+	b.WriteString("or culture — e.g. \"comfortable with ambiguity\" implies no one will hand the candidate a ")
+	b.WriteString("spec). Base every signal on wording actually present in the posting; if the posting is ")
+	b.WriteString("short or generic and carries no distinctive wording, return an empty array — never invent ")
+	b.WriteString("a signal to fill it.\n")
 	return b.String()
 }
 

--- a/internal/matchanalysis/analyzer_test.go
+++ b/internal/matchanalysis/analyzer_test.go
@@ -343,6 +343,41 @@ func TestAnalyzeStream_EmitsOrderedEventsAndMatchesSyncFinal(t *testing.T) {
 	}
 }
 
+func TestAnalyzeStream_ThreadsHiddenSignals(t *testing.T) {
+	stage1WithSignals := `{"requirements":[{"text":"Go","priority":"required","status":"covered","evidence":"5y at Acme"}],` +
+		`"hidden_signals":[{"quote":"fast-paced, high ownership","insight":"expect a self-driven pace"},` +
+		`{"quote":"  ","insight":"blank quote, must be dropped"}]}`
+	m := &queuedModel{resp: []string{stage1WithSignals, stage2JSON, stage3JSON}}
+
+	var events []Event
+	final, err := NewAnalyzer(llm.NewWithModel(m)).AnalyzeStream(context.Background(), sampleInput(), func(e Event) {
+		events = append(events, e)
+	})
+	if err != nil {
+		t.Fatalf("AnalyzeStream: %v", err)
+	}
+
+	// The requirements event (Stage 1's output) carries the sanitized signals alongside the
+	// requirement match, at the same point in the stream.
+	var reqEvent Event
+	for _, e := range events {
+		if e.Kind == EventRequirements {
+			reqEvent = e
+		}
+	}
+	if len(reqEvent.HiddenSignals) != 1 {
+		t.Fatalf("requirements event HiddenSignals = %+v, want 1 (blank-quote entry dropped)", reqEvent.HiddenSignals)
+	}
+	if reqEvent.HiddenSignals[0].Quote != "fast-paced, high ownership" {
+		t.Errorf("HiddenSignals[0].Quote = %q, want the sanitized quote", reqEvent.HiddenSignals[0].Quote)
+	}
+
+	// The final served analysis carries the same sanitized signals.
+	if len(final.HiddenSignals) != 1 || final.HiddenSignals[0].Insight != "expect a self-driven pace" {
+		t.Errorf("final.HiddenSignals = %+v, want the sanitized signal to survive to the served analysis", final.HiddenSignals)
+	}
+}
+
 func TestAnalyzeStream_NilClientIsNoOp(t *testing.T) {
 	got, err := NewAnalyzer(nil).AnalyzeStream(context.Background(), sampleInput(), func(Event) {
 		t.Error("no events expected from a nil client")

--- a/internal/matchanalysis/matchanalysis.go
+++ b/internal/matchanalysis/matchanalysis.go
@@ -98,6 +98,10 @@ const (
 	maxStrengths        = 6
 	maxGaps             = 6
 	maxRequirements     = 30
+
+	maxSignals            = 5
+	maxSignalQuoteRunes   = 200
+	maxSignalInsightRunes = 200
 )
 
 // Dimension is one scored fit dimension on the wire.
@@ -117,11 +121,21 @@ type Requirement struct {
 	EvidenceStrength string `json:"evidence_strength"` // metric|scope|responsibility|keyword for positive statuses; empty for missing-*
 }
 
+// Signal is one interpretive read of the job posting's own wording — a verbatim quote plus
+// what it implies about pace, ownership expectations, team stage, or culture. Freeform text
+// bounded by length only (the same tier as Recommendation/comment), not a controlled
+// vocabulary: there is no fixed set of "signal types" to coerce into.
+type Signal struct {
+	Quote   string `json:"quote"`
+	Insight string `json:"insight"`
+}
+
 // Analysis is the full served fit verdict — the single wire contract exported to TS
 // via cmd/gen-contracts.
 type Analysis struct {
 	Dimensions       []Dimension              `json:"dimensions"`
 	RequirementMatch []Requirement            `json:"requirement_match"`
+	HiddenSignals    []Signal                 `json:"hidden_signals"`
 	OverallScore     int                      `json:"overall_score"`
 	Verdict          string                   `json:"verdict"`
 	Strengths        []string                 `json:"strengths"`
@@ -164,10 +178,10 @@ type recruiterVerdict struct {
 	Recommendation      string   `json:"recommendation"`
 }
 
-// buildAnalysis assembles the served Analysis from the (sanitized) requirement match
-// and recruiter verdict: the six dimensions in fixed order, the weighted overall, and
-// the derived verdict label.
-func buildAnalysis(reqs []Requirement, v recruiterVerdict) Analysis {
+// buildAnalysis assembles the served Analysis from the (sanitized) requirement match,
+// recruiter verdict, and hidden signals: the six dimensions in fixed order, the weighted
+// overall, and the derived verdict label.
+func buildAnalysis(reqs []Requirement, v recruiterVerdict, signals []Signal) Analysis {
 	scores := map[string]dimScore{
 		DimTitleAlignment:      v.TitleAlignment,
 		DimExperienceRelevance: v.ExperienceRelevance,
@@ -195,9 +209,13 @@ func buildAnalysis(reqs []Requirement, v recruiterVerdict) Analysis {
 	if gaps == nil {
 		gaps = []string{}
 	}
+	if signals == nil {
+		signals = []Signal{}
+	}
 	return Analysis{
 		Dimensions:       dims,
 		RequirementMatch: reqs,
+		HiddenSignals:    signals,
 		OverallScore:     overall,
 		Verdict:          verdictFor(overall),
 		Strengths:        strengths,
@@ -255,6 +273,28 @@ func sanitizeRequirements(in []Requirement) []Requirement {
 			EvidenceStrength: coerceEvidenceStrength(status, r.EvidenceStrength),
 		})
 		if len(out) >= maxRequirements {
+			break
+		}
+	}
+	return out
+}
+
+// sanitizeSignals drops any signal missing a quote or an insight — an interpretive claim with
+// nothing to ground it is not useful half-formed, so it is dropped rather than coerced — trims
+// and length-bounds what remains, and caps the count.
+func sanitizeSignals(in []Signal) []Signal {
+	out := make([]Signal, 0, len(in))
+	for _, s := range in {
+		quote := strings.TrimSpace(s.Quote)
+		insight := strings.TrimSpace(s.Insight)
+		if quote == "" || insight == "" {
+			continue
+		}
+		out = append(out, Signal{
+			Quote:   llm.TruncateRunes(quote, maxSignalQuoteRunes),
+			Insight: llm.TruncateRunes(insight, maxSignalInsightRunes),
+		})
+		if len(out) >= maxSignals {
 			break
 		}
 	}

--- a/internal/matchanalysis/matchanalysis_test.go
+++ b/internal/matchanalysis/matchanalysis_test.go
@@ -1,6 +1,9 @@
 package matchanalysis
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestBuildAnalysis_WeightedOverallAndVerdict(t *testing.T) {
 	// A strong, uniform verdict → weighted overall equals the common score, Strong Fit.
@@ -13,7 +16,7 @@ func TestBuildAnalysis_WeightedOverallAndVerdict(t *testing.T) {
 		LocationFit:         dimScore{Score: 80},
 		Recommendation:      "Apply.",
 	}
-	got := buildAnalysis(nil, v)
+	got := buildAnalysis(nil, v, nil)
 	if got.OverallScore != 80 {
 		t.Errorf("OverallScore = %d, want 80 (weights sum to 100)", got.OverallScore)
 	}
@@ -39,7 +42,7 @@ func TestBuildAnalysis_WeightingFavoursTitleAndExperience(t *testing.T) {
 		TitleAlignment:      dimScore{Score: 100},
 		ExperienceRelevance: dimScore{Score: 100},
 	}
-	got := buildAnalysis(nil, v)
+	got := buildAnalysis(nil, v, nil)
 	if got.OverallScore != 45 {
 		t.Errorf("OverallScore = %d, want 45 (Title 20 + Experience 25)", got.OverallScore)
 	}
@@ -112,6 +115,60 @@ func TestSanitizeRequirements_CoercesAndDrops(t *testing.T) {
 	}
 	if got[1].Priority != PriorityPreferred {
 		t.Errorf("req[1].Priority = %q, want coerced to %q", got[1].Priority, PriorityPreferred)
+	}
+}
+
+func TestBuildAnalysis_ThreadsHiddenSignals(t *testing.T) {
+	signals := []Signal{{Quote: "fast-paced", Insight: "expect overtime risk"}}
+	got := buildAnalysis(nil, recruiterVerdict{}, signals)
+	if len(got.HiddenSignals) != 1 || got.HiddenSignals[0].Quote != "fast-paced" {
+		t.Errorf("HiddenSignals = %+v, want the passed-in signal", got.HiddenSignals)
+	}
+}
+
+func TestBuildAnalysis_NilSignalsYieldsEmptyNotNil(t *testing.T) {
+	got := buildAnalysis(nil, recruiterVerdict{}, nil)
+	if got.HiddenSignals == nil {
+		t.Error("HiddenSignals = nil, want an empty (non-nil) slice")
+	}
+}
+
+func TestSanitizeSignals_DropsBlankTruncatesCaps(t *testing.T) {
+	in := []Signal{
+		{Quote: "  \"fast-paced, high ownership\"  ", Insight: "  Expect a self-driven pace.  "},
+		{Quote: "", Insight: "Should be dropped — blank quote"},
+		{Quote: "Some quote", Insight: ""},                                   // blank insight → dropped
+		{Quote: strings.Repeat("q", 250), Insight: strings.Repeat("i", 250)}, // over-length → truncated
+		{Quote: "extra 1", Insight: "extra 1"},
+		{Quote: "extra 2", Insight: "extra 2"},
+		{Quote: "extra 3", Insight: "extra 3"},
+		{Quote: "extra 4", Insight: "extra 4"}, // 8 total in, cap at maxSignals=5
+	}
+	got := sanitizeSignals(in)
+	if len(got) != maxSignals {
+		t.Fatalf("sanitizeSignals len = %d, want %d (blanks dropped, rest capped)", len(got), maxSignals)
+	}
+	if got[0].Quote != `"fast-paced, high ownership"` {
+		t.Errorf("Quote[0] = %q, want trimmed", got[0].Quote)
+	}
+	if got[0].Insight != "Expect a self-driven pace." {
+		t.Errorf("Insight[0] = %q, want trimmed", got[0].Insight)
+	}
+	if n := len([]rune(got[1].Quote)); n != maxSignalQuoteRunes {
+		t.Errorf("Quote[1] rune len = %d, want truncated to %d", n, maxSignalQuoteRunes)
+	}
+	if n := len([]rune(got[1].Insight)); n != maxSignalInsightRunes {
+		t.Errorf("Insight[1] rune len = %d, want truncated to %d", n, maxSignalInsightRunes)
+	}
+}
+
+func TestSanitizeSignals_NilInYieldsEmptyNotNil(t *testing.T) {
+	got := sanitizeSignals(nil)
+	if got == nil {
+		t.Error("sanitizeSignals(nil) = nil, want an empty (non-nil) slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("sanitizeSignals(nil) len = %d, want 0", len(got))
 	}
 }
 

--- a/internal/matchanalysis/prompt_test.go
+++ b/internal/matchanalysis/prompt_test.go
@@ -125,6 +125,17 @@ func TestStage1SystemPrompt_GradesEvidenceStrength(t *testing.T) {
 	}
 }
 
+func TestStage1SystemPrompt_RequestsHiddenSignals(t *testing.T) {
+	// Stage 1 must ask for hidden_signals (quote + insight, max 5) alongside the requirement
+	// table, and must not force one on a generic posting.
+	sp := stage1SystemPrompt()
+	for _, want := range []string{"hidden_signals", "quote", "insight"} {
+		if !strings.Contains(sp, want) {
+			t.Errorf("stage1 system prompt must request hidden signals (missing %q):\n%s", want, sp)
+		}
+	}
+}
+
 func TestWriteRequirements_RendersStrengthForPositiveOnly(t *testing.T) {
 	var b strings.Builder
 	writeRequirements(&b, []Requirement{

--- a/openspec/changes/fit-analysis-hidden-signals/.openspec.yaml
+++ b/openspec/changes/fit-analysis-hidden-signals/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/fit-analysis-hidden-signals/design.md
+++ b/openspec/changes/fit-analysis-hidden-signals/design.md
@@ -1,0 +1,107 @@
+## Context
+
+`internal/matchanalysis` runs a fixed three-stage LLM prompt-chain per (user, job): Stage 1
+(Extract & Match) turns the posting into a requirement table classified against the candidate's
+structured résumé; Stage 2 scores six recruiter dimensions; Stage 3 is an adversarial audit of
+Stage 2. The served `Analysis` struct is cached, keyed on CV upload time + job `content_hash` +
+model, and streamed to the frontend over SSE (`analyzer.go`'s `AnalyzeStream`, consumed by
+`web/src/lib/matchAnalysis.ts`'s `reduceMatchEvent`).
+
+The chain only ever runs for a candidate with banked/structured experience (`candidateContext`
+returns empty and the whole chain no-ops otherwise) — this design adds no new gate, it rides the
+existing one.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface up to 5 short, JD-quote-grounded interpretive signals about pace, ownership
+  expectations, team stage, or culture, as part of the existing fit analysis.
+- Zero additional LLM calls, zero new cache-invalidation logic, zero new endpoints.
+- Degrade cleanly to nothing when the posting is too generic to read anything from.
+
+**Non-Goals:**
+- Not a standalone feature usable without a fit analysis (no bank/résumé, no signals) — see the
+  brainstorming decision already made with the user.
+- Not a fixed-vocabulary classification (no enum of signal "types"). Each signal is freeform
+  quote + freeform interpretation, sanitized by bounds only, the same tier as the existing
+  `Recommendation` and dimension `comment` fields — not the controlled-vocabulary tier that
+  `status`/`priority`/`evidence_strength` belong to.
+- Not a deterministic/dictionary-based extraction. This is interpretive text, same category as
+  the rest of Stage 1/2/3's free-text output, and is expected to vary slightly across runs the
+  same way `recommendation` already does.
+
+## Decisions
+
+**Extend Stage 1's existing call rather than add a new stage.** Stage 1 already reads the full
+job description to extract requirements; hidden signals are read from the same text with no
+extra context needed. Alternatives considered: a dedicated Stage 1.5/new stage (rejected — an
+extra model round-trip per analysis for output that shares its entire input with Stage 1), or
+a deterministic Go-side keyword dictionary (rejected in the brainstorming discussion — shallower
+than an LLM read of actual phrasing, and this package's existing free-text fields are already
+LLM-derived rather than dict-based).
+
+**Wire shape: `Signal { Quote string; Insight string }`, field `HiddenSignals []Signal` on
+`Analysis`.** Mirrors the existing `Requirement`/`Dimension` naming pattern in
+`matchanalysis.go`. JSON keys: `hidden_signals`, each entry `{"quote": ..., "insight": ...}`.
+
+**Bounds:** cap at 5 signals (`maxSignals = 5`, same order of magnitude as `maxStrengths`/
+`maxGaps` at 6). `Quote` bounded to 200 runes (mirrors `maxReqTextRunes`, since a quote is
+JD-length text like a requirement's text). `Insight` bounded to 200 runes (mirrors
+`maxListItemRunes`, since it is a single-sentence interpretation like a strength/gap entry).
+
+**Sanitize by dropping, not coercing.** A signal with a blank quote or blank insight is dropped
+entirely (same rule `sanitizeRequirements` applies to a blank requirement text) rather than
+substituting a placeholder — an interpretive claim with nothing to ground it is not useful
+half-formed.
+
+**No new SSE event kind.** The existing `EventRequirements` event (emitted right after Stage 1
+sanitization, `analyzer.go` `AnalyzeStream`) gets one more field, `HiddenSignals []Signal`,
+alongside `Requirements`. Both are Stage 1's output and become visible to the frontend at the
+same moment; a new event kind would only duplicate that timing for no benefit.
+
+**Persisted on `Analysis`, not held stage-1-only.** `HiddenSignals` threads through
+`buildAnalysis` into the final `Analysis` exactly as `RequirementMatch` does today, so it is
+part of the cached/served payload and needs no cache-key change (still triple-stamped on CV
+upload time, job `content_hash`, model — the signals are a pure function of the same job text
+and the same Stage 1 call already covered by that stamp).
+
+**Frontend placement:** the Hidden Signals section renders directly after the Requirement Match
+table and before Strengths/Gaps — it reads as "extra color on the posting itself" rather than
+part of the scored verdict, so it sits with the other posting-derived content (the requirement
+table) rather than the recruiter-verdict content. Omitted entirely (no heading, no empty state)
+when `hidden_signals` is an empty array.
+
+Correction found during implementation: the standalone `/match/[slug]` page named in the
+proposal no longer exists — it now redirects to `/tailor/[slug]` (the fit-analysis surface
+moved into the Tailor workspace, per the already-shipped "Fit analysis surfaces in the
+tailoring workspace" requirement). The actual integration point is
+`web/src/lib/components/MatchAnalysisFull.svelte`, the single component both the Tailor
+workspace's `ArtifactPanel` and `JobDrawer` embed — placement logic is unchanged (same
+section, same rule), only the file path differs from what the proposal assumed.
+
+## Risks / Trade-offs
+
+- **[Risk] Stage 1's completion grows slightly (one more JSON key with up to 5 entries), adding
+  marginal latency to a stage already budgeted for the requirement table.** → Mitigation: same
+  call, same timeout budget (`stageAttempts`/existing per-call deadline); an extra bounded field
+  is a small fraction of Stage 1's existing output size (up to 30 requirements today).
+- **[Risk] Freeform interpretive text carries the same prompt-injection surface as the rest of
+  Stage 1's untrusted-input handling (the JD is caller-uncontrolled but adversary-reachable via
+  job ingest).** → Mitigation: identical bounding/truncation discipline already applied to
+  every other free-text field in this package (`llm.TruncateRunes`, count caps); no new
+  injection surface, just one more bounded field.
+- **[Risk] A candidate with no banked résumé never sees hidden signals, even though they are
+  purely JD-derived and don't need a CV.** → Accepted per the already-approved brainstorming
+  decision: this rides the existing fit-analysis gate rather than becoming a second, ungated
+  code path and cost surface.
+
+## Migration Plan
+
+No data migration. Purely additive wire field; existing cached `Analysis` rows simply lack
+`hidden_signals` until the job's analysis is next recomputed (cache miss/refresh), where the
+zero-value/omitted field renders as no signals shown — never an error.
+
+## Open Questions
+
+None outstanding — all decisions above were confirmed with the user before this document was
+written.

--- a/openspec/changes/fit-analysis-hidden-signals/proposal.md
+++ b/openspec/changes/fit-analysis-hidden-signals/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The AI fit analysis already tells a candidate whether their CV covers a posting's stated
+requirements, but a job posting also carries unstated expectations — pace, ownership, team
+stage — that live in word choice rather than in any explicit requirement line. Today none of
+that is surfaced, so a candidate reads the same requirement table for a calm, structured
+0-to-1 team and a scrappy, ambiguity-heavy one and gets no signal about which they're walking
+into.
+
+## What Changes
+
+- Extend the existing Stage 1 (Extract & Match) LLM call in `internal/matchanalysis` to also
+  return up to 5 "hidden signals" — each a short verbatim quote from the job description plus
+  a one-line interpretation of what it implies about pace, ownership expectations, team stage,
+  or culture. No new model call, no new stage.
+- Sanitize the new output the same way the rest of Stage 1's untrusted output is handled today
+  (drop blank entries, bound field lengths, cap the count) before it is persisted or served.
+- Thread the sanitized signals through the existing pipeline into the served/cached `Analysis`
+  wire struct, alongside `RequirementMatch`, using the existing triple-stamp cache with no new
+  invalidation rule.
+- Stream the signals to the frontend via the existing Stage-1 SSE event, so they appear at the
+  same moment the requirement match does, before Stage 2/3 finish.
+- Render a new section on the fit analysis page showing the quote + interpretation pairs; the
+  section is omitted entirely when the model returns zero signals (a generic/uninformative
+  posting is not forced to produce filler).
+- Regenerate the TS wire contract for the new field via `cmd/gen-contracts`.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this extends the existing fit-analysis capability rather than introducing a new one)
+
+### Modified Capabilities
+
+- `job-fit-analysis`: the served analysis payload gains a `hidden_signals` field (0-5
+  quote+interpretation pairs) produced and sanitized as part of the existing Stage 1 extraction,
+  with no new endpoint, model call, or cache-invalidation rule.
+
+## Impact
+
+- `internal/matchanalysis/matchanalysis.go` — new `Signal` type, `HiddenSignals` field on
+  `Analysis` and `stage1Out`, a `sanitizeSignals` function, new bound constants.
+- `internal/matchanalysis/analyzer.go` — Stage 1 system prompt gains the hidden-signals
+  instruction block; `stage1Out` decode picks up the new key; the Stage-1 SSE event payload
+  carries the sanitized signals.
+- `cmd/gen-contracts` output (generated TS types) regenerated for the new field.
+- `web/src/lib/matchAnalysis.ts` — SSE reducer carries `hidden_signals` through from the
+  Stage-1 event onward.
+- `web/src/routes/match/[slug]/` — new UI section rendering the signals, empty-state omitted.
+- No new migration, no new endpoint, no new background worker.

--- a/openspec/changes/fit-analysis-hidden-signals/specs/job-fit-analysis/spec.md
+++ b/openspec/changes/fit-analysis-hidden-signals/specs/job-fit-analysis/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Hidden signals from posting wording
+
+The fit analysis SHALL include a `hidden_signals` field: an array of up to 5 objects, each
+carrying a verbatim `quote` excerpted from the job description and a short `insight`
+interpreting what that wording implies about pace, ownership expectations, team stage, or
+culture. The signals MUST be extracted as part of the existing Stage 1 (Extract & Match) LLM
+call — no additional model call or stage. Both `quote` and `insight` MUST be non-empty,
+length-bounded, and drawn only from the job description text; the field MUST NOT require or
+depend on the candidate's résumé/CV content, even though the analysis as a whole (and therefore
+this field) is only produced for a candidate with banked/structured experience.
+
+#### Scenario: Posting wording implies pace and ownership expectations
+
+- **WHEN** a job description repeatedly uses phrasing like "thrive in ambiguity" and "high
+  ownership, fast-paced"
+- **THEN** the served analysis's `hidden_signals` includes an entry quoting that wording with an
+  insight naming the implied self-driven/fast-pace expectation
+
+#### Scenario: Generic posting yields no signals
+
+- **WHEN** a job description is short or carries no distinctive wording to interpret
+- **THEN** `hidden_signals` is an empty array, and the analysis is served normally with no error
+  and no fabricated signal
+
+#### Scenario: Malformed model output is dropped, not coerced
+
+- **WHEN** the model returns a signal entry with a blank `quote` or a blank `insight`
+- **THEN** that entry is dropped from the served `hidden_signals` rather than served with a
+  placeholder value
+
+#### Scenario: Signals are cached with the rest of the analysis
+
+- **WHEN** an analysis with `hidden_signals` is served from cache on a subsequent request for the
+  same (user, job) with unchanged CV upload time, job `content_hash`, and model
+- **THEN** the same `hidden_signals` are served without a new LLM call, under the analysis's
+  existing cache stamp

--- a/openspec/changes/fit-analysis-hidden-signals/tasks.md
+++ b/openspec/changes/fit-analysis-hidden-signals/tasks.md
@@ -1,0 +1,31 @@
+## 1. Backend wire shape and sanitization
+
+- [x] 1.1 Add `Signal` type (`Quote`, `Insight` string fields) and `HiddenSignals []Signal` field on `Analysis` in `internal/matchanalysis/matchanalysis.go`
+- [x] 1.2 Add `maxSignals`, `maxSignalQuoteRunes`, `maxSignalInsightRunes` bound constants alongside the existing `max*` constants
+- [x] 1.3 Add `sanitizeSignals` function: drop entries with a blank `quote` or `insight`, truncate each to its bound, cap the count at `maxSignals`
+- [x] 1.4 Thread `HiddenSignals` through `buildAnalysis` (new parameter, nil-safe default to `[]Signal{}` matching the existing `reqs`/`strengths`/`gaps` nil-handling pattern)
+
+## 2. Stage 1 extraction
+
+- [x] 2.1 Add `HiddenSignals []Signal` to `stage1Out` in `internal/matchanalysis/analyzer.go`
+- [x] 2.2 Extend `stage1SystemPrompt()` with the hidden-signals instruction block: return `"hidden_signals"` (array, max 5) with `"quote"` (verbatim JD excerpt) and `"insight"` (one line on pace/ownership/team-stage/culture implication); explicit instruction that an empty array is correct for a generic posting, never force an entry
+- [x] 2.3 In `AnalyzeStream`, call `sanitizeSignals` on `s1.HiddenSignals` alongside the existing `sanitizeRequirements(s1.Requirements)` call, and pass the result into `buildAnalysis`
+- [x] 2.4 Extend the `Event` struct and the `EventRequirements` emission with the sanitized `HiddenSignals`, so the SSE payload carries both `Requirements` and `HiddenSignals` at the same point in the stream
+
+## 3. Backend tests
+
+- [x] 3.1 Unit tests for `sanitizeSignals`: drops blank quote, drops blank insight, truncates over-length fields, caps count at 5 (mirror the existing `sanitizeRequirements`/`cleanList` test style)
+- [x] 3.2 `prompt_test.go`: assert `stage1SystemPrompt()` contains the new `hidden_signals` instruction
+- [x] 3.3 `analyzer_test.go`: assert Stage 1's `HiddenSignals` output threads into the final `Analysis.HiddenSignals`, and that a Stage-1 response omitting the key yields an empty (not nil) slice on the served `Analysis`
+
+## 4. Contract + frontend wiring
+
+- [x] 4.1 Run `cmd/gen-contracts` to regenerate the TS wire types for the new `Analysis.HiddenSignals`/`Signal` shape
+- [x] 4.2 Update `reduceMatchEvent` in `web/src/lib/matchAnalysis.ts` to carry `hidden_signals` through from the Stage-1 (`requirements`) event and the final analysis
+- [x] 4.3 Add a "Hidden Signals" section to the match analysis page (`web/src/routes/match/[slug]/`), rendered directly after the Requirement Match table and before Strengths/Gaps; each entry shows the quote and its insight; the section renders nothing when `hidden_signals` is empty
+
+## 5. Verification
+
+- [x] 5.1 `go build ./...`, `go vet ./...`, `go test ./...`
+- [x] 5.2 `go vet -tags=integration ./...`
+- [x] 5.3 Manually exercise the match analysis page against a real posting with distinctive wording (e.g. "fast-paced", "high ownership") and confirm the Hidden Signals section renders; confirm it is absent for a bland/short posting

--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -44,6 +44,7 @@
     if (f?.analysis) {
       s.analysis = f.analysis;
       s.requirements = f.analysis.requirement_match;
+      s.hiddenSignals = f.analysis.hidden_signals;
       s.done = true;
       s.stages = s.stages.map((x) => ({ ...x, state: 'done' as const }));
     }
@@ -81,6 +82,9 @@
   const dimensions = $derived(analysis?.dimensions ?? []);
   const requirements = $derived(
     analysis?.requirement_match?.length ? analysis.requirement_match : stream.requirements,
+  );
+  const hiddenSignals = $derived(
+    analysis?.hidden_signals?.length ? analysis.hidden_signals : stream.hiddenSignals,
   );
   // Coverage tally for the ATS-view header: covered folds in synonym-only matches (both are
   // positive, matching the hero's count), `addit` is the fixable near-miss, `gap` the genuine
@@ -513,6 +517,23 @@
             </div>
           {/if}
         </section>
+
+        <!-- Hidden signals: unstated culture/pace/team-stage reads from the posting's own
+             wording, quoted verbatim alongside the interpretation. Omitted entirely when the
+             posting was too generic to read anything from. -->
+        {#if hiddenSignals.length}
+          <section class="flex flex-col gap-5">
+            <h2 class="{headingClass} text-muted-foreground">Hidden signals</h2>
+            <ul class="flex flex-col gap-3">
+              {#each hiddenSignals as sig, i (i)}
+                <li class="rounded-lg border border-border/60 bg-secondary/30 p-3.5">
+                  <p class="text-sm italic leading-relaxed text-muted-foreground">"{sig.quote}"</p>
+                  <p class="mt-1.5 text-sm font-medium leading-relaxed text-foreground">{sig.insight}</p>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/if}
       </div>
 
       {#if analysis.strengths.length || analysis.gaps.length}

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -741,12 +741,23 @@ export interface Requirement {
   evidence_strength: string; // metric|scope|responsibility|keyword for positive statuses; empty for missing-*
 }
 /**
+ * Signal is one interpretive read of the job posting's own wording — a verbatim quote plus
+ * what it implies about pace, ownership expectations, team stage, or culture. Freeform text
+ * bounded by length only (the same tier as Recommendation/comment), not a controlled
+ * vocabulary: there is no fixed set of "signal types" to coerce into.
+ */
+export interface Signal {
+  quote: string;
+  insight: string;
+}
+/**
  * Analysis is the full served fit verdict — the single wire contract exported to TS
  * via cmd/gen-contracts.
  */
 export interface Analysis {
   dimensions: Dimension[];
   requirement_match: Requirement[];
+  hidden_signals: Signal[];
   overall_score: number /* int */;
   verdict: string;
   strengths: string[];

--- a/web/src/lib/matchAnalysis.test.ts
+++ b/web/src/lib/matchAnalysis.test.ts
@@ -69,6 +69,29 @@ describe('reduceMatchEvent', () => {
     expect(next).not.toBe(prev);
   });
 
+  it('carries hidden signals from the requirements event', () => {
+    const s = reduceMatchEvent(initMatchStream(), 'requirements', {
+      requirements: [],
+      hidden_signals: [{ quote: 'fast-paced, high ownership', insight: 'expect a self-driven pace' }],
+    });
+    expect(s.hiddenSignals).toHaveLength(1);
+    expect(s.hiddenSignals[0]?.insight).toBe('expect a self-driven pace');
+  });
+
+  it('starts with no hidden signals', () => {
+    expect(initMatchStream().hiddenSignals).toEqual([]);
+  });
+
+  it('ignores a malformed hidden_signals payload (not an array)', () => {
+    const seeded = reduceMatchEvent(initMatchStream(), 'requirements', {
+      requirements: [],
+      hidden_signals: [{ quote: 'fast-paced', insight: 'overtime risk' }],
+    });
+    const next = reduceMatchEvent(seeded, 'requirements', { requirements: [], hidden_signals: { bogus: true } });
+    expect(Array.isArray(next.hiddenSignals)).toBe(true);
+    expect(next.hiddenSignals).toEqual(seeded.hiddenSignals);
+  });
+
   it('ignores a malformed requirements payload (not an array)', () => {
     const seeded = reduceMatchEvent(
       initMatchStream(),

--- a/web/src/lib/matchAnalysis.ts
+++ b/web/src/lib/matchAnalysis.ts
@@ -3,7 +3,7 @@
 // tone, the ATS requirement-status → label + tone, and the SSE stream reducer. The wire
 // shapes come from the Go contract.
 
-import type { MatchAnalysis, MatchRequirement } from './types';
+import type { MatchAnalysis, MatchRequirement, Signal } from './types';
 
 /** A colour tone bucket the component maps to Tailwind classes. */
 export type Tone = 'strong' | 'good' | 'moderate' | 'weak' | 'poor';
@@ -56,6 +56,7 @@ export interface MatchStreamState {
   stages: MatchStage[];
   thinking: string;
   requirements: MatchRequirement[];
+  hiddenSignals: Signal[];
   analysis: MatchAnalysis | null;
   done: boolean;
   error: string | null;
@@ -72,6 +73,7 @@ export function initMatchStream(): MatchStreamState {
     ],
     thinking: '',
     requirements: [],
+    hiddenSignals: [],
     analysis: null,
     done: false,
     error: null,
@@ -100,6 +102,7 @@ export function reduceMatchEvent(prev: MatchStreamState, name: string, data: unk
       // Guard the shape, not just null: a present-but-wrong-typed frame must not
       // replace good data with a value a component would then .filter() and crash on.
       if (Array.isArray(d.requirements)) s.requirements = d.requirements as MatchRequirement[];
+      if (Array.isArray(d.hidden_signals)) s.hiddenSignals = d.hidden_signals as Signal[];
       return s;
     case 'dimensions':
       if (isObject(d.analysis)) s.analysis = d.analysis as MatchAnalysis;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -43,6 +43,7 @@ export type {
   Analysis as MatchAnalysis,
   Dimension as MatchDimension,
   Requirement as MatchRequirement,
+  Signal,
 } from './generated/contracts';
 
 /** The caller's AI-credits balance. Present on GET reads (with a CV); `remaining` is the


### PR DESCRIPTION
## Summary
- Stage 1 of the AI fit-analysis chain now also extracts up to 5 "hidden signals" from a job posting's own wording — a verbatim quote plus a one-line read on what it implies about pace, ownership expectations, team stage, or culture.
- No new LLM call, no new endpoint, no new SSE event kind — rides the existing Stage 1 completion, the existing `requirements` SSE event, and the existing cached `Analysis` payload (same triple-stamp cache).
- New `Analysis.HiddenSignals` / `Signal{Quote, Insight}` wire field, sanitized by dropping blank entries and bounding length/count (mirrors `sanitizeRequirements`).
- New "Hidden signals" section on `MatchAnalysisFull.svelte`, placed after the Requirement Match table and before Strengths/Gaps; omitted entirely when the posting is too generic to read anything from.

Full design/spec: `openspec/changes/fit-analysis-hidden-signals/`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all green
- [x] `go vet -tags=integration ./...` — green
- [x] `web/`: `vitest run` — 865/865 passing
- [x] `web/`: `svelte-check` — 0 errors
- [x] Visually verified via a throwaway route + headless Chrome: renders correctly with signals, and the section is correctly omitted when `hidden_signals` is empty
- [x] Backend and frontend diffs each independently code-reviewed, no unresolved Critical/Important issues