### PR TITLE
Remove stale redirect hijacking /my/notifications

### DIFF
--- a/web/src/routes/my/notifications/+page.ts
+++ b/web/src/routes/my/notifications/+page.ts
@@ -1,7 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-
-// Notifications were merged into the saved-searches page (one tab); a subscription is
-// always tied to a saved search, so alerts are managed there per-row.
-export function load() {
-  redirect(308, '/my/searches');
-}


### PR DESCRIPTION
## Summary

Follow-up to #1684. Post-deploy check on freehire.me found `/my/notifications` returning a 308 to `/my/searches` instead of the new notification-settings page.

Root cause: `web/src/routes/my/notifications/+page.ts` was a leftover from an earlier consolidation ("notifications merged into saved-searches") that unconditionally redirected the route. #1684 added `+page.svelte` in the same directory without noticing the sibling `+page.ts` was still there — SvelteKit's `load()` redirect fires before the page ever renders.

## Test plan

- [x] `svelte-kit sync && svelte-check`: 0 errors
- [ ] Post-merge deploy: verify `curl -I https://freehire.me/my/notifications` returns 200, not a redirect to `/my/searches`