### PR TITLE
Add a job-closed lifecycle nudge

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -608,12 +608,6 @@ type PrunedJob struct {
 	PrunedAt    pgtype.Timestamptz `json:"pruned_at"`
 }
 
-type RateLimit struct {
-	Key          string             `json:"key"`
-	WindowStart  pgtype.Timestamptz `json:"window_start"`
-	RequestCount int32              `json:"request_count"`
-}
-
 type ReferralOffer struct {
 	UserID         int64              `json:"user_id"`
 	CompanySlug    string             `json:"company_slug"`

--- a/internal/db/nudges.sql.go
+++ b/internal/db/nudges.sql.go
@@ -256,6 +256,53 @@ func (q *Queries) ListInterviewPrepCandidates(ctx context.Context, windowDays in
 	return items, nil
 }
 
+const listJobClosedCandidates = `-- name: ListJobClosedCandidates :many
+SELECT a.user_id, a.job_id, a.stage, j.closed_at
+FROM applications a
+JOIN notification_settings ns ON ns.user_id = a.user_id AND ns.enabled
+JOIN jobs j ON j.id = a.job_id
+WHERE a.applied_at IS NOT NULL
+  AND j.closed_at IS NOT NULL
+  AND j.closed_at > now() - make_interval(days => $1::int)
+`
+
+type ListJobClosedCandidatesRow struct {
+	UserID   int64              `json:"user_id"`
+	JobID    pgtype.Int8        `json:"job_id"`
+	Stage    pgtype.Text        `json:"stage"`
+	ClosedAt pgtype.Timestamptz `json:"closed_at"`
+}
+
+// Jobs that closed recently while the tracking user still has an application in a
+// non-terminal stage on them (any stage userjob.SilenceThresholdDays accrues
+// silence for — the same active/terminal split every other silence reader uses).
+// Bounded to a recency window on closed_at for the same first-deploy reason as
+// the other two candidate scans.
+func (q *Queries) ListJobClosedCandidates(ctx context.Context, windowDays int32) ([]ListJobClosedCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listJobClosedCandidates, windowDays)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListJobClosedCandidatesRow{}
+	for rows.Next() {
+		var i ListJobClosedCandidatesRow
+		if err := rows.Scan(
+			&i.UserID,
+			&i.JobID,
+			&i.Stage,
+			&i.ClosedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markNudgeDelivered = `-- name: MarkNudgeDelivered :execrows
 UPDATE application_nudges
 SET status = 'delivered', delivered_at = now()

--- a/internal/db/nudges_integration_test.go
+++ b/internal/db/nudges_integration_test.go
@@ -148,6 +148,65 @@ func TestListInterviewPrepCandidates(t *testing.T) {
 	}
 }
 
+func TestListJobClosedCandidates(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	resetNudgeTables(t, pool)
+
+	uid := insertUser(t, pool, "closed@example.test")
+	if _, err := q.UpsertNotificationSettings(ctx, UpsertNotificationSettingsParams{UserID: uid, Enabled: true, Channels: []string{"email"}}); err != nil {
+		t.Fatalf("upsert settings: %v", err)
+	}
+
+	// Truncated to microsecond precision — see the same note in TestListFollowUpCandidates.
+	recentClose := time.Now().Add(-2 * 24 * time.Hour).Truncate(time.Microsecond)
+	staleClose := time.Now().Add(-10 * 24 * time.Hour).Truncate(time.Microsecond)
+	appliedAt := time.Now().Add(-30 * 24 * time.Hour)
+
+	activeJob := insertJob(t, pool, "closed-active")
+	insertApplication(t, pool, uid, activeJob, appliedAt, "screening")
+	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = $1 WHERE id = $2", recentClose, activeJob); err != nil {
+		t.Fatalf("close active job: %v", err)
+	}
+
+	settledJob := insertJob(t, pool, "closed-settled")
+	insertApplication(t, pool, uid, settledJob, appliedAt, "withdrawn")
+	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = $1 WHERE id = $2", recentClose, settledJob); err != nil {
+		t.Fatalf("close settled job: %v", err)
+	}
+
+	staleJob := insertJob(t, pool, "closed-stale")
+	insertApplication(t, pool, uid, staleJob, appliedAt, "screening")
+	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = $1 WHERE id = $2", staleClose, staleJob); err != nil {
+		t.Fatalf("close stale job: %v", err)
+	}
+
+	openJob := insertJob(t, pool, "still-open")
+	insertApplication(t, pool, uid, openJob, appliedAt, "screening")
+
+	rows, err := q.ListJobClosedCandidates(ctx, 7)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("candidates = %d, want 2 (both in-window closures; the Go-side active-stage filter drops the settled one)", len(rows))
+	}
+	byJob := map[int64]ListJobClosedCandidatesRow{}
+	for _, r := range rows {
+		byJob[r.JobID.Int64] = r
+	}
+	if _, ok := byJob[activeJob]; !ok {
+		t.Errorf("missing the active application's closed job, got %+v", rows)
+	}
+	if _, ok := byJob[settledJob]; !ok {
+		t.Errorf("missing the settled application's closed job (SQL doesn't filter stage; Go does), got %+v", rows)
+	}
+	if got := byJob[activeJob]; !got.ClosedAt.Valid || !got.ClosedAt.Time.Equal(recentClose) {
+		t.Errorf("closed_at = %v, want %v", got.ClosedAt, recentClose)
+	}
+}
+
 func TestRecordNudge_IsIdempotentPerEpisode(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1638,6 +1638,12 @@ type Querier interface {
 	// requested bucket (day/week/month) so empty buckets still appear as zeros. `unit`
 	// is a caller-validated date_trunc field (day/week/month), never raw user input.
 	ListJobActivity(ctx context.Context, arg ListJobActivityParams) ([]ListJobActivityRow, error)
+	// Jobs that closed recently while the tracking user still has an application in a
+	// non-terminal stage on them (any stage userjob.SilenceThresholdDays accrues
+	// silence for — the same active/terminal split every other silence reader uses).
+	// Bounded to a recency window on closed_at for the same first-deploy reason as
+	// the other two candidate scans.
+	ListJobClosedCandidates(ctx context.Context, windowDays int32) ([]ListJobClosedCandidatesRow, error)
 	// The emails linked to one of the caller's applications, newest first, for the
 	// application detail page.
 	ListJobEmails(ctx context.Context, arg ListJobEmailsParams) ([]ListJobEmailsRow, error)

--- a/internal/db/queries/nudges.sql
+++ b/internal/db/queries/nudges.sql
@@ -37,6 +37,20 @@ WHERE ev.kind = 'stage_set'
   AND ev.job_id IS NOT NULL
   AND ev.occurred_at > now() - make_interval(days => sqlc.arg(window_days)::int);
 
+-- name: ListJobClosedCandidates :many
+-- Jobs that closed recently while the tracking user still has an application in a
+-- non-terminal stage on them (any stage userjob.SilenceThresholdDays accrues
+-- silence for — the same active/terminal split every other silence reader uses).
+-- Bounded to a recency window on closed_at for the same first-deploy reason as
+-- the other two candidate scans.
+SELECT a.user_id, a.job_id, a.stage, j.closed_at
+FROM applications a
+JOIN notification_settings ns ON ns.user_id = a.user_id AND ns.enabled
+JOIN jobs j ON j.id = a.job_id
+WHERE a.applied_at IS NOT NULL
+  AND j.closed_at IS NOT NULL
+  AND j.closed_at > now() - make_interval(days => sqlc.arg(window_days)::int);
+
 -- name: RecordNudge :execrows
 -- Record one matched nudge candidate. The unique index on
 -- (user_id, job_id, kind, episode_key) makes this idempotent — re-scanning the

--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -1,8 +1,9 @@
 // Package nudge is the lifecycle-notification decision layer: it watches tracked
-// applications and drives two one-shot nudges — follow-up (an application has gone
-// silent past its stage's tolerated threshold, per userjob.SilenceStateFor) and
-// interview-prep (a stage_set moved an application into `interview`) — over the
-// same account-level notification_settings rule internal/reminder reads.
+// applications and drives three one-shot nudges — follow-up (an application has
+// gone silent past its stage's tolerated threshold, per userjob.SilenceStateFor),
+// interview-prep (a stage_set moved an application into `interview`), and
+// job-closed (a listing the candidate is still actively tracking closed) — over
+// the same account-level notification_settings rule internal/reminder reads.
 //
 // One pass (Runner.Run) does MATCH then DELIVER, mirroring internal/notify: MATCH
 // re-scans current state and records new candidates in the application_nudges
@@ -32,10 +33,12 @@ import (
 	"github.com/strelov1/freehire/internal/userjob"
 )
 
-// Nudge kinds. Also the CHECK constraint on application_nudges.kind (migration 0083).
+// Nudge kinds. Also the CHECK constraint on application_nudges.kind (migrations
+// 0083, widened by 0084).
 const (
 	KindFollowUp      = "follow_up"
 	KindInterviewPrep = "interview_prep"
+	KindJobClosed     = "job_closed"
 )
 
 // Message is the display shape of one nudge, rendered by a Notifier into a
@@ -83,6 +86,7 @@ var _ Store = (*db.Queries)(nil)
 type Store interface {
 	ListFollowUpCandidates(ctx context.Context, windowDays int32) ([]db.ListFollowUpCandidatesRow, error)
 	ListInterviewPrepCandidates(ctx context.Context, windowDays int32) ([]db.ListInterviewPrepCandidatesRow, error)
+	ListJobClosedCandidates(ctx context.Context, windowDays int32) ([]db.ListJobClosedCandidatesRow, error)
 	RecordNudge(ctx context.Context, arg db.RecordNudgeParams) (int64, error)
 	ClaimDueNudges(ctx context.Context, arg db.ClaimDueNudgesParams) ([]int64, error)
 	GetNudgeForDelivery(ctx context.Context, id int64) (db.GetNudgeForDeliveryRow, error)
@@ -101,6 +105,8 @@ type Config struct {
 	// InterviewPrepWindowDays is the same bound on ListInterviewPrepCandidates'
 	// occurred_at.
 	InterviewPrepWindowDays int32
+	// JobClosedWindowDays is the same bound on ListJobClosedCandidates' closed_at.
+	JobClosedWindowDays int32
 	// LeaseSeconds is the delivery lease: a claimed-but-unfinished nudge is
 	// reclaimable after this, which doubles as the crash reaper.
 	LeaseSeconds int32
@@ -116,6 +122,7 @@ func DefaultConfig() Config {
 	return Config{
 		FollowUpWindowDays:      30,
 		InterviewPrepWindowDays: 7,
+		JobClosedWindowDays:     7,
 		LeaseSeconds:            600,
 		ClaimBatch:              500,
 		MaxAttempts:             5,
@@ -160,9 +167,9 @@ func (r *Runner) Run(ctx context.Context) (Stats, error) {
 	return stats, nil
 }
 
-// match records every current follow-up and interview-prep candidate. Re-running
-// over an unchanged episode is a no-op (the ledger's unique key), so this can
-// freely re-scan the same candidates every pass.
+// match records every current follow-up, interview-prep, and job-closed candidate.
+// Re-running over an unchanged episode is a no-op (the ledger's unique key), so
+// this can freely re-scan the same candidates every pass.
 func (r *Runner) match(ctx context.Context, stats *Stats) error {
 	candidates, err := r.store.ListFollowUpCandidates(ctx, r.cfg.FollowUpWindowDays)
 	if err != nil {
@@ -204,6 +211,31 @@ func (r *Runner) match(ctx context.Context, stats *Stats) error {
 		})
 		if err != nil {
 			return fmt.Errorf("record interview-prep nudge: %w", err)
+		}
+		stats.Matched += int(affected)
+	}
+
+	closed, err := r.store.ListJobClosedCandidates(ctx, r.cfg.JobClosedWindowDays)
+	if err != nil {
+		return fmt.Errorf("list job-closed candidates: %w", err)
+	}
+	for _, c := range closed {
+		if !c.JobID.Valid || !c.ClosedAt.Valid {
+			continue // defensive: the query's WHERE clause already guarantees both are set
+		}
+		stage := ""
+		if c.Stage.Valid {
+			stage = c.Stage.String
+		}
+		if _, active := userjob.SilenceThresholdDays(stage); !active {
+			continue // a settled application does not care that the listing closed
+		}
+		affected, err := r.store.RecordNudge(ctx, db.RecordNudgeParams{
+			UserID: c.UserID, JobID: c.JobID.Int64, Kind: KindJobClosed,
+			EpisodeKey: c.ClosedAt,
+		})
+		if err != nil {
+			return fmt.Errorf("record job-closed nudge: %w", err)
 		}
 		stats.Matched += int(affected)
 	}
@@ -277,11 +309,13 @@ func (r *Runner) fire(ctx context.Context, id int64, stats *Stats) {
 }
 
 // actionable re-derives the triggering condition from the live delivery context: a
-// closed job or a disabled notification rule cancels either kind; a follow-up needs
-// the current silence state still Silent, an interview-prep needs the current
-// stage still `interview`.
+// disabled notification rule cancels every kind. follow-up and interview-prep
+// additionally need the job still open (closing settles the application one way
+// or another) and their own live condition; job-closed needs the opposite — the
+// job stays closed once closed, so it only needs the application to still be in a
+// stage that accrues silence (a settled one no longer cares that the listing shut).
 func (r *Runner) actionable(info db.GetNudgeForDeliveryRow) bool {
-	if !info.JobOpen || !info.NotificationsEnabled {
+	if !info.NotificationsEnabled {
 		return false
 	}
 	stage := ""
@@ -290,13 +324,19 @@ func (r *Runner) actionable(info db.GetNudgeForDeliveryRow) bool {
 	}
 	switch info.Kind {
 	case KindFollowUp:
+		if !info.JobOpen {
+			return false
+		}
 		days := 0
 		if info.LastActivityAt.Valid {
 			days = userjob.DaysSilent(r.now(), info.LastActivityAt.Time)
 		}
 		return userjob.SilenceStateFor(stage, days, info.HasPendingSuggestion) == userjob.SilenceSilent
 	case KindInterviewPrep:
-		return stage == "interview"
+		return info.JobOpen && stage == "interview"
+	case KindJobClosed:
+		_, active := userjob.SilenceThresholdDays(stage)
+		return active
 	default:
 		return false
 	}

--- a/internal/nudge/nudge_test.go
+++ b/internal/nudge/nudge_test.go
@@ -16,6 +16,7 @@ import (
 type fakeStore struct {
 	followUp      []db.ListFollowUpCandidatesRow
 	interviewPrep []db.ListInterviewPrepCandidatesRow
+	jobClosed     []db.ListJobClosedCandidatesRow
 	recorded      []db.RecordNudgeParams
 
 	due []int64
@@ -32,6 +33,9 @@ func (s *fakeStore) ListFollowUpCandidates(context.Context, int32) ([]db.ListFol
 }
 func (s *fakeStore) ListInterviewPrepCandidates(context.Context, int32) ([]db.ListInterviewPrepCandidatesRow, error) {
 	return s.interviewPrep, nil
+}
+func (s *fakeStore) ListJobClosedCandidates(context.Context, int32) ([]db.ListJobClosedCandidatesRow, error) {
+	return s.jobClosed, nil
 }
 func (s *fakeStore) RecordNudge(_ context.Context, arg db.RecordNudgeParams) (int64, error) {
 	for _, r := range s.recorded {
@@ -176,6 +180,48 @@ func TestMatch_InterviewPrep_RecordsCandidate(t *testing.T) {
 	}
 }
 
+// --- MATCH: job-closed ---------------------------------------------------------
+
+func TestMatch_JobClosed_ActiveApplicationIsRecorded(t *testing.T) {
+	closedAt := fixedNow.Add(-2 * time.Hour)
+	store := &fakeStore{jobClosed: []db.ListJobClosedCandidatesRow{
+		{UserID: 5, JobID: pgtype.Int8{Int64: 6, Valid: true}, Stage: pgtype.Text{String: "screening", Valid: true}, ClosedAt: ts(closedAt)},
+	}}
+	r := newRunner(store, &fakeNotifier{})
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.recorded) != 1 {
+		t.Fatalf("recorded = %d, want 1", len(store.recorded))
+	}
+	got := store.recorded[0]
+	if got.UserID != 5 || got.JobID != 6 || got.Kind != KindJobClosed {
+		t.Errorf("recorded = %+v, want (5,6,job_closed)", got)
+	}
+	if !got.EpisodeKey.Time.Equal(closedAt) {
+		t.Errorf("episode key = %v, want closed_at %v", got.EpisodeKey.Time, closedAt)
+	}
+	if stats.Matched != 1 {
+		t.Errorf("stats.Matched = %d, want 1", stats.Matched)
+	}
+}
+
+func TestMatch_JobClosed_SettledApplicationIsNotRecorded(t *testing.T) {
+	store := &fakeStore{jobClosed: []db.ListJobClosedCandidatesRow{
+		{UserID: 5, JobID: pgtype.Int8{Int64: 6, Valid: true}, Stage: pgtype.Text{String: "withdrawn", Valid: true}, ClosedAt: ts(fixedNow)},
+	}}
+	r := newRunner(store, &fakeNotifier{})
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.recorded) != 0 {
+		t.Errorf("recorded = %d, want 0 (a settled application does not care that the listing closed)", len(store.recorded))
+	}
+}
+
 // --- DELIVER -----------------------------------------------------------------
 
 func deliveryRow(kind string, stage string, daysSilent int, notificationsEnabled, jobOpen bool, channels []string, chatID *int64, email string) db.GetNudgeForDeliveryRow {
@@ -267,6 +313,41 @@ func TestDeliver_InterviewPrep_CancelsWhenStageMoved(t *testing.T) {
 	}
 	if len(notifier.sent) != 0 {
 		t.Errorf("must not send once the stage has moved on, sent %v", notifier.sent)
+	}
+	if len(store.cancelled) != 1 {
+		t.Errorf("must cancel at fire, cancelled = %v", store.cancelled)
+	}
+}
+
+func TestDeliver_JobClosed_DeliversWhileApplicationStillActive(t *testing.T) {
+	chat := int64(555)
+	// jobOpen=false: the job stays closed, which is the whole point of this kind.
+	store := &fakeStore{due: []int64{1}, row: deliveryRow(KindJobClosed, "screening", 0, true, false, []string{"telegram"}, &chat, "")}
+	notifier := &fakeNotifier{}
+	r := newRunner(store, notifier)
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.sent) != 1 {
+		t.Errorf("sent = %v, want 1 message", notifier.sent)
+	}
+	if len(store.delivered) != 1 {
+		t.Errorf("delivered = %v, want [1]", store.delivered)
+	}
+}
+
+func TestDeliver_JobClosed_CancelsWhenApplicationSettled(t *testing.T) {
+	chat := int64(555)
+	store := &fakeStore{due: []int64{1}, row: deliveryRow(KindJobClosed, "withdrawn", 0, true, false, []string{"telegram"}, &chat, "")}
+	notifier := &fakeNotifier{}
+	r := newRunner(store, notifier)
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.sent) != 0 {
+		t.Errorf("must not send once the application has settled, sent %v", notifier.sent)
 	}
 	if len(store.cancelled) != 1 {
 		t.Errorf("must cancel at fire, cancelled = %v", store.cancelled)

--- a/internal/nudge/transports.go
+++ b/internal/nudge/transports.go
@@ -52,6 +52,10 @@ func (n *TelegramNotifier) render(m Message) string {
 		return fmt.Sprintf(
 			"🎯 You're interviewing for <b>%s</b> at <b>%s</b>. Ready to rehearse?\n<a href=\"%s\">Open your tracking board →</a>",
 			title, company, n.trackingURL)
+	case KindJobClosed:
+		return fmt.Sprintf(
+			"📪 The listing for <b>%s</b> at <b>%s</b> has closed while your application was still active.\n<a href=\"%s\">Open your tracking board →</a>",
+			title, company, n.trackingURL)
 	default:
 		return fmt.Sprintf("<b>%s</b> at <b>%s</b>: <a href=\"%s\">Open your tracking board →</a>", title, company, n.trackingURL)
 	}
@@ -95,6 +99,14 @@ func (n *EmailNotifier) render(m Message) (subject, htmlBody, textBody string) {
 				`<p><a href="%s">Open your tracking board to rehearse →</a></p>`,
 			title, company, n.trackingURL)
 		textBody = fmt.Sprintf("You're interviewing for %s at %s.\n\nOpen your tracking board: %s\n",
+			m.JobTitle, m.Company, n.trackingURL)
+	case KindJobClosed:
+		subject = fmt.Sprintf("Listing closed: %s at %s", m.JobTitle, m.Company)
+		htmlBody = fmt.Sprintf(
+			`<p>The listing for <strong>%s</strong> at <strong>%s</strong> has closed while your application was still active.</p>`+
+				`<p><a href="%s">Open your tracking board →</a></p>`,
+			title, company, n.trackingURL)
+		textBody = fmt.Sprintf("The listing for %s at %s has closed while your application was still active.\n\nOpen your tracking board: %s\n",
 			m.JobTitle, m.Company, n.trackingURL)
 	default:
 		subject = fmt.Sprintf("%s at %s", m.JobTitle, m.Company)

--- a/migrations/0084_application_nudges_job_closed_kind.sql
+++ b/migrations/0084_application_nudges_job_closed_kind.sql
@@ -1,0 +1,10 @@
+-- Widen application_nudges.kind to add job_closed: the third lifecycle nudge —
+-- a listing the candidate is still actively tracking (an application in any
+-- silence-accruing stage, per userjob.SilenceThresholdDays) closes. See the
+-- centralize-lifecycle-notifications change (0082/0083) for the table itself.
+
+ALTER TABLE public.application_nudges DROP CONSTRAINT application_nudges_kind_check;
+
+ALTER TABLE public.application_nudges
+    ADD CONSTRAINT application_nudges_kind_check
+    CHECK (kind IN ('follow_up', 'interview_prep', 'job_closed'));

--- a/web/src/lib/components/ReminderSettings.svelte
+++ b/web/src/lib/components/ReminderSettings.svelte
@@ -7,14 +7,14 @@
   import ProviderIcon from './ProviderIcon.svelte';
 
   // The single account-level notification rule: turn notifications on and pick
-  // the delivery channels. It gates three things at once — the saved-job apply
-  // reminder, the follow-up nudge (an application has gone quiet), and the
-  // interview-prep nudge (a stage moved to interview) — there is no separate
-  // control for any of them, and no per-job override. Changes autosave — there is
-  // no Save button. The UI keeps the rule valid so an invalid payload never
-  // reaches the server: enabling defaults to the email channel, and the last
-  // channel can't be removed while notifications are on (an enabled rule
-  // requires at least one channel).
+  // the delivery channels. It gates four things at once — the saved-job apply
+  // reminder, the follow-up nudge (an application has gone quiet), the
+  // interview-prep nudge (a stage moved to interview), and the job-closed nudge
+  // (a tracked listing closed) — there is no separate control for any of them,
+  // and no per-job override. Changes autosave — there is no Save button. The UI
+  // keeps the rule valid so an invalid payload never reaches the server: enabling
+  // defaults to the email channel, and the last channel can't be removed while
+  // notifications are on (an enabled rule requires at least one channel).
 
   let enabled = $state(false);
   let channels = $state<string[]>([]);
@@ -105,7 +105,7 @@
     <div class="min-w-0 flex-1">
       <h2 class="text-sm font-semibold leading-tight">Notifications</h2>
       <p class="text-xs text-muted-foreground">
-        Come back to a saved job before it goes stale, follow up when an application goes quiet, and prepare before an interview.
+        Come back to a saved job before it goes stale, follow up when an application goes quiet, prepare before an interview, and hear about it if a listing you're tracking closes.
       </p>
     </div>
 
@@ -185,6 +185,10 @@
           <div class="flex gap-1.5">
             <dt class="shrink-0 font-medium text-foreground">Interview prep —</dt>
             <dd>right when you move a card to Interview.</dd>
+          </div>
+          <div class="flex gap-1.5">
+            <dt class="shrink-0 font-medium text-foreground">Listing closed —</dt>
+            <dd>right when a job you're still actively tracking closes.</dd>
           </div>
         </dl>
       </div>


### PR DESCRIPTION
## Summary

Follow-up to #1684 (per direct user request during rollout): a third lifecycle nudge kind — notify the candidate when a job listing they're still actively tracking closes.

- MATCH: `ListJobClosedCandidates` scans `jobs.closed_at` within a recency window (7 days, same first-deploy-backlog reasoning as the other two kinds), joined to an application whose stage still accrues silence (`userjob.SilenceThresholdDays`) — a settled application (accepted/rejected/withdrawn/expired) doesn't care that the listing shut.
- DELIVER: re-checks the application is still in an active stage before sending. Unlike the other two kinds, this one does **not** require the job to still be open — closing is the trigger, not a disqualifier — so `actionable()` now branches per kind instead of a shared `!JobOpen` short-circuit.
- Migration 0084 widens `application_nudges.kind`'s CHECK constraint (on top of 0083 from #1684).
- Settings page (`/my/notifications`) "Timing" info block gets a fourth line.
- No `cmd/nudge` or settings-API changes — the engine and the account-level toggle were already kind-agnostic.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...` — all green (6 new unit tests in `internal/nudge`)
- [x] `go test -tags=integration ./internal/db/` — all green (1 new integration test against real Postgres)
- [x] `svelte-check`: 0 errors; token-coverage: no drift