### PR TITLE
fix(web): float the skills picker under its input, fix stuck-empty race

### DIFF
--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -122,6 +122,9 @@
   // The universe of skills (canonical tokens with job counts) for the typeahead, from
   // the facet-distribution endpoint — the same source the filter panel uses.
   let skillDist = $state.raw<FacetOption[]>([]);
+  // See RemoteSearchSelect's `ready` prop: without it, a dictionary fetch slower
+  // than the picker's 250ms debounce leaves the popular first page stuck empty.
+  let skillDistReady = $state(false);
 
   const canSubmit = $derived(specializations.length > 0 && skills.length > 0);
 
@@ -141,7 +144,10 @@
   const searchExcludedSkills = (query: string) => searchSkillsExcept(query, skills);
 
   $effect(() => {
-    void loadSkillDistribution().then((dist) => (skillDist = dist));
+    void loadSkillDistribution().then((dist) => {
+      skillDist = dist;
+      skillDistReady = true;
+    });
   });
 
   // Derive skills + specialization from a résumé PDF. Before a profile exists, both merge
@@ -453,6 +459,7 @@
       onToggle={toggleSkill}
       fallbackLabel={(v) => v}
       clearOnSelect
+      ready={skillDistReady}
     />
   </div>
 
@@ -473,6 +480,7 @@
       onToggle={toggleExcludedSkill}
       fallbackLabel={(v) => v}
       clearOnSelect
+      ready={skillDistReady}
     />
     <span class="text-xs text-muted-foreground">
       Filtered out when you apply your profile to the job filters.

--- a/web/src/lib/components/SkillsView.svelte
+++ b/web/src/lib/components/SkillsView.svelte
@@ -14,8 +14,15 @@
   // The universe of skills (canonical tokens with job counts) for the typeahead, from the
   // same source ProfileForm's set-up form and the job-search filter panel use.
   let skillDist = $state.raw<FacetOption[]>([]);
+  // Flips true once the dictionary lands — passed to RemoteSearchSelect as `ready` so
+  // its debounced search re-fires if it opens before the fetch resolves (see that
+  // component's `ready` prop for why this is needed, not just a nicety).
+  let skillDistReady = $state(false);
   $effect(() => {
-    void loadSkillDistribution().then((dist) => (skillDist = dist));
+    void loadSkillDistribution().then((dist) => {
+      skillDist = dist;
+      skillDistReady = true;
+    });
   });
 
   function searchSkillsExcept(query: string, avoid: string[]): Promise<FacetOption[]> {
@@ -92,6 +99,7 @@
       onToggle={toggleSkill}
       fallbackLabel={(v) => v}
       clearOnSelect
+      ready={skillDistReady}
     />
   </div>
 
@@ -108,6 +116,7 @@
       onToggle={toggleExcludedSkill}
       fallbackLabel={(v) => v}
       clearOnSelect
+      ready={skillDistReady}
     />
     <span class="text-xs text-muted-foreground">
       Filtered out when you apply your profile to the job filters.

--- a/web/src/lib/components/facets/RemoteSearchSelect.svelte
+++ b/web/src/lib/components/facets/RemoteSearchSelect.svelte
@@ -13,6 +13,13 @@
   // seen, falling back to `fallbackLabel` for a value restored from the URL. A chip
   // is included or excluded; clicking it calls `onToggle` (cycle for excludable
   // facets, plain include toggle otherwise).
+  //
+  // Compact mode (expand=false, the default) renders the picker as a floating panel
+  // anchored to the input — the same pattern as CompanyPicker.svelte — so it always
+  // opens right under the field being typed into, however many chips are already
+  // stacked below it. Expand mode keeps the picker inline instead: it's used only
+  // inside the filter modal's own scroll pane, which already gives it room and
+  // wants it visible without a focus/blur dance.
   let {
     search,
     include,
@@ -22,6 +29,7 @@
     fallbackLabel,
     clearOnSelect = false,
     expand = false,
+    ready = true,
   }: {
     search: (query: string) => Promise<FacetOption[]>;
     include: string[];
@@ -32,13 +40,19 @@
     // When set, the search field is cleared after picking an option (search →
     // pick a chip → search the next), suited to a build-a-set form.
     clearOnSelect?: boolean;
-    // Drop the scroll cap on the results list — for the roomy modal pane.
+    // Drop the floating panel for a roomy inline pane — for the modal's own scroll area.
     expand?: boolean;
+    // False while the candidate list behind `search` (e.g. a facet dictionary) is
+    // still loading. Blocks the debounced search until it flips true, so a load
+    // that outruns the 250ms debounce gets its popular first page fetched once it
+    // lands, instead of the query staying stuck on the empty result it raced into.
+    ready?: boolean;
   } = $props();
 
   let query = $state('');
   let results = $state<FacetOption[]>([]);
   let loading = $state(false);
+  let open = $state(false);
   // value → display label, accumulated from every result we have rendered, so a
   // selected company shows its real name. A reactive SvelteMap so a chip rendered
   // from the URL fallback upgrades to the real name once a later search reveals it
@@ -63,9 +77,15 @@
   }
 
   // Debounce: re-run on every query change, cancelling the pending run. Fires once
-  // on mount with an empty query to show the popular first page.
+  // on mount with an empty query to show the popular first page, and again
+  // whenever `ready` flips true — reading it here is what makes the effect
+  // re-fire once a still-loading dictionary lands.
   $effect(() => {
     const q = query.trim();
+    if (!ready) {
+      results = [];
+      return;
+    }
     const t = setTimeout(() => run(q), 250);
     return () => clearTimeout(t);
   });
@@ -81,11 +101,10 @@
   const labelOf = (value: string) => seen.get(value) ?? fallbackLabel(value);
   // Don't list an already-selected option in the picker — it's shown as a chip.
   const pickable = $derived(results.filter((o) => !selected.includes(o.value)));
+  const emptyMessage = $derived(!ready ? 'Loading…' : loading ? 'Searching…' : query ? 'Nothing found' : 'No results');
 </script>
 
-<div class="flex flex-col gap-2">
-  <Input bind:value={query} {placeholder} class="w-full" />
-
+{#snippet chips()}
   {#if selected.length > 0}
     <div class="flex flex-wrap gap-1.5">
       {#each selected as value (value)}
@@ -102,24 +121,65 @@
       {/each}
     </div>
   {/if}
+{/snippet}
 
-  <div class={expand ? 'flex flex-col gap-0.5' : 'flex max-h-44 flex-col gap-0.5 overflow-y-auto'}>
-    {#each pickable as opt (opt.value)}
-      <button
-        type="button"
-        onclick={() => pick(opt.value)}
-        class="flex items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-accent"
-      >
-        <span class="truncate">{opt.label}</span>
-        {#if opt.count !== undefined}
-          <span class="shrink-0 tabular-nums opacity-60">{opt.count.toLocaleString()}</span>
-        {/if}
-      </button>
-    {/each}
-    {#if pickable.length === 0}
-      <span class="px-1 py-1 text-xs text-muted-foreground">
-        {loading ? 'Searching…' : query ? 'Nothing found' : 'No results'}
-      </span>
-    {/if}
-  </div>
+{#snippet optionList()}
+  {#each pickable as opt (opt.value)}
+    <button
+      type="button"
+      role="option"
+      aria-selected="false"
+      onmousedown={(e) => {
+        // mousedown (not click), preventDefault: keeps focus on the input instead
+        // of moving it to the button, so the panel stays open for the next pick.
+        e.preventDefault();
+        pick(opt.value);
+      }}
+      class="flex items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-accent"
+    >
+      <span class="truncate">{opt.label}</span>
+      {#if opt.count !== undefined}
+        <span class="shrink-0 tabular-nums opacity-60">{opt.count.toLocaleString()}</span>
+      {/if}
+    </button>
+  {/each}
+  {#if pickable.length === 0}
+    <span class="px-2 py-1 text-xs text-muted-foreground">{emptyMessage}</span>
+  {/if}
+{/snippet}
+
+<div class="flex flex-col gap-2">
+  {#if expand}
+    <Input bind:value={query} {placeholder} class="w-full" />
+    {@render chips()}
+    <div class="flex flex-col gap-0.5">
+      {@render optionList()}
+    </div>
+  {:else}
+    <div class="relative">
+      <Input
+        bind:value={query}
+        {placeholder}
+        class="w-full"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls="remote-search-select-list"
+        onfocus={() => (open = true)}
+        onblur={() => setTimeout(() => (open = false), 120)}
+        onkeydown={(e) => {
+          if (e.key === 'Escape') open = false;
+        }}
+      />
+      {#if open}
+        <div
+          id="remote-search-select-list"
+          role="listbox"
+          class="absolute inset-x-0 top-full z-10 mt-1 flex max-h-60 flex-col gap-0.5 overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-lg"
+        >
+          {@render optionList()}
+        </div>
+      {/if}
+    </div>
+    {@render chips()}
+  {/if}
 </div>


### PR DESCRIPTION
## Summary
- `RemoteSearchSelect` (used by the profile's Skills tab and onboarding form) now renders its suggestion list as a floating panel anchored right under the input, open while it has focus — matching `CompanyPicker.svelte`'s existing pattern instead of rendering after the selected-chip row, where a long chip list pushed it far away from the field being typed into.
- Fixed a race where the picker's search could get stuck showing nothing: its debounce effect only tracked the query string, so if the skills dictionary fetch took longer than the 250ms debounce, the first render searched an empty dictionary and nothing ever re-triggered it. A new `ready` prop (wired from `SkillsView`/`ProfileForm`) lets the effect re-fire once the dictionary lands.
- The filter modal's "expand" (roomy inline) mode is untouched — verified manually.

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] Manually verified in a local Docker stack: dropdown opens directly under the input regardless of chip count, closes on outside click/blur, reopens on focus, message states (Loading/Searching/Nothing found/No results) transition correctly
- [x] Verified the filter modal's expand-mode Skills/Company facets still render inline, unaffected