### PR TITLE
Auto-expire tracked applications on job-closed, simplify the nudge

### DIFF
--- a/internal/appevent/appevent.go
+++ b/internal/appevent/appevent.go
@@ -51,10 +51,15 @@ const (
 	// for day math like the mail sources and for the same reason: the date was set by an
 	// organiser and observed by us, not typed by the candidate when they got round to it.
 	SourceCalendarGoogle = "calendar_google"
+	// SourceSystem is a stage change the platform made on the candidate's behalf, not one
+	// anybody typed or that mail/calendar evidence dated — e.g. internal/nudge auto-expiring
+	// an application whose listing closed. Not trusted for day math: it records when we
+	// noticed, not an employer-side timing fact.
+	SourceSystem = "system"
 )
 
 // Sources is the canonical, ordered source vocabulary.
-var Sources = []string{SourceMailGmail, SourceMailHosted, SourceMailExternal, SourceUser, SourceAssistant, SourceCalendarGoogle}
+var Sources = []string{SourceMailGmail, SourceMailHosted, SourceMailExternal, SourceUser, SourceAssistant, SourceCalendarGoogle, SourceSystem}
 
 // ValidSource reports whether s is a known event source.
 func ValidSource(s string) bool {

--- a/internal/appevent/appevent_test.go
+++ b/internal/appevent/appevent_test.go
@@ -44,6 +44,7 @@ func TestOnlyObservedSourcesAreTrustedForDayMath(t *testing.T) {
 		SourceCalendarGoogle: true,
 		SourceUser:           false,
 		SourceAssistant:      false,
+		SourceSystem:         false,
 	}
 	if len(trusted) != len(Sources) {
 		t.Fatalf("the vocabulary has %d sources but this test pins %d — a new source needs a verdict here", len(Sources), len(trusted))

--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -28,6 +28,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/appevent"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/notify"
 	"github.com/strelov1/freehire/internal/userjob"
@@ -88,6 +91,11 @@ type Store interface {
 	ListInterviewPrepCandidates(ctx context.Context, windowDays int32) ([]db.ListInterviewPrepCandidatesRow, error)
 	ListJobClosedCandidates(ctx context.Context, windowDays int32) ([]db.ListJobClosedCandidatesRow, error)
 	RecordNudge(ctx context.Context, arg db.RecordNudgeParams) (int64, error)
+	// TrackJob is jobtracking's own stage-set write (upserts applications.stage and
+	// emits the paired application_events row in one statement, only when the stage
+	// actually moves). MATCH reuses it directly, rather than duplicating the CTE,
+	// to auto-settle an application whose listing closed — see the job-closed loop.
+	TrackJob(ctx context.Context, arg db.TrackJobParams) (db.TrackJobRow, error)
 	ClaimDueNudges(ctx context.Context, arg db.ClaimDueNudgesParams) ([]int64, error)
 	GetNudgeForDelivery(ctx context.Context, id int64) (db.GetNudgeForDeliveryRow, error)
 	MarkNudgeDelivered(ctx context.Context, id int64) (int64, error)
@@ -238,6 +246,21 @@ func (r *Runner) match(ctx context.Context, stats *Stats) error {
 			return fmt.Errorf("record job-closed nudge: %w", err)
 		}
 		stats.Matched += int(affected)
+
+		// Auto-settle the board: a closed listing is not something to leave sitting
+		// on an active stage waiting for the candidate to notice and clear by hand.
+		// Ordered AFTER RecordNudge — TrackJob only writes a stage_set event when the
+		// stage actually moves, so it is naturally idempotent on retry, but running it
+		// first would flip the stage to `expired` before the notification is durably
+		// recorded; a failure between the two would then leave the candidate never
+		// notified and the next pass no longer finding an active stage to re-check.
+		if _, err := r.store.TrackJob(ctx, db.TrackJobParams{
+			UserID: c.UserID, JobID: c.JobID.Int64,
+			Stage:       pgtype.Text{String: "expired", Valid: true},
+			EventSource: appevent.SourceSystem,
+		}); err != nil {
+			return fmt.Errorf("auto-expire job-closed application: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/nudge/nudge_test.go
+++ b/internal/nudge/nudge_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/strelov1/freehire/internal/appevent"
 	"github.com/strelov1/freehire/internal/db"
 )
 
@@ -18,6 +19,7 @@ type fakeStore struct {
 	interviewPrep []db.ListInterviewPrepCandidatesRow
 	jobClosed     []db.ListJobClosedCandidatesRow
 	recorded      []db.RecordNudgeParams
+	tracked       []db.TrackJobParams
 
 	due []int64
 	row db.GetNudgeForDeliveryRow
@@ -45,6 +47,10 @@ func (s *fakeStore) RecordNudge(_ context.Context, arg db.RecordNudgeParams) (in
 	}
 	s.recorded = append(s.recorded, arg)
 	return 1, nil
+}
+func (s *fakeStore) TrackJob(_ context.Context, arg db.TrackJobParams) (db.TrackJobRow, error) {
+	s.tracked = append(s.tracked, arg)
+	return db.TrackJobRow{}, nil
 }
 func (s *fakeStore) ClaimDueNudges(context.Context, db.ClaimDueNudgesParams) ([]int64, error) {
 	return s.due, nil
@@ -206,6 +212,16 @@ func TestMatch_JobClosed_ActiveApplicationIsRecorded(t *testing.T) {
 	if stats.Matched != 1 {
 		t.Errorf("stats.Matched = %d, want 1", stats.Matched)
 	}
+	if len(store.tracked) != 1 {
+		t.Fatalf("tracked = %d, want 1 (the board auto-settles alongside the nudge)", len(store.tracked))
+	}
+	tracked := store.tracked[0]
+	if tracked.UserID != 5 || tracked.JobID != 6 || tracked.Stage.String != "expired" || !tracked.Stage.Valid {
+		t.Errorf("tracked = %+v, want (5,6,expired)", tracked)
+	}
+	if tracked.EventSource != appevent.SourceSystem {
+		t.Errorf("event source = %q, want %q", tracked.EventSource, appevent.SourceSystem)
+	}
 }
 
 func TestMatch_JobClosed_SettledApplicationIsNotRecorded(t *testing.T) {
@@ -219,6 +235,9 @@ func TestMatch_JobClosed_SettledApplicationIsNotRecorded(t *testing.T) {
 	}
 	if len(store.recorded) != 0 {
 		t.Errorf("recorded = %d, want 0 (a settled application does not care that the listing closed)", len(store.recorded))
+	}
+	if len(store.tracked) != 0 {
+		t.Errorf("tracked = %d, want 0 (nothing to auto-settle on an already-settled application)", len(store.tracked))
 	}
 }
 

--- a/internal/nudge/transports.go
+++ b/internal/nudge/transports.go
@@ -18,17 +18,20 @@ var (
 )
 
 // TelegramNotifier delivers a nudge as a Telegram HTML message, reusing the
-// telegramnotify Bot API client. The link points at the caller's tracking board so
-// the nudge keeps the user on freehire.
+// telegramnotify Bot API client. Every link stays on-platform: the tracking board
+// for kinds about the application (follow-up, interview-prep), the job's own page
+// for job-closed — there is nothing left to track on the board for a listing that
+// just closed, but the posting itself (and whatever the candidate captured from it)
+// is still worth a look.
 type TelegramNotifier struct {
-	client      *telegramnotify.Client
-	trackingURL string
+	client *telegramnotify.Client
+	origin string
 }
 
-// NewTelegramNotifier builds a TelegramNotifier sending through client, with the
-// tracking link rooted at jobBaseURL (the frontend origin).
-func NewTelegramNotifier(client *telegramnotify.Client, jobBaseURL string) *TelegramNotifier {
-	return &TelegramNotifier{client: client, trackingURL: strings.TrimRight(jobBaseURL, "/") + "/my/tracking"}
+// NewTelegramNotifier builds a TelegramNotifier sending through client, with links
+// rooted at origin (the frontend origin).
+func NewTelegramNotifier(client *telegramnotify.Client, origin string) *TelegramNotifier {
+	return &TelegramNotifier{client: client, origin: strings.TrimRight(origin, "/")}
 }
 
 // Send renders the nudge and posts it to the chat encoded in dest. The channel
@@ -43,36 +46,37 @@ func (n *TelegramNotifier) Send(ctx context.Context, _ string, dest string, m Me
 
 func (n *TelegramNotifier) render(m Message) string {
 	title, company := html.EscapeString(m.JobTitle), html.EscapeString(m.Company)
+	trackingURL, jobURL := n.origin+"/my/tracking", n.origin+"/jobs/"+m.Slug
 	switch m.Kind {
 	case KindFollowUp:
 		return fmt.Sprintf(
 			"👋 It's been %d days since anything moved on <b>%s</b> at <b>%s</b>. Worth a follow-up?\n<a href=\"%s\">Open your tracking board →</a>",
-			m.DaysSilent, title, company, n.trackingURL)
+			m.DaysSilent, title, company, trackingURL)
 	case KindInterviewPrep:
 		return fmt.Sprintf(
 			"🎯 You're interviewing for <b>%s</b> at <b>%s</b>. Ready to rehearse?\n<a href=\"%s\">Open your tracking board →</a>",
-			title, company, n.trackingURL)
+			title, company, trackingURL)
 	case KindJobClosed:
 		return fmt.Sprintf(
-			"📪 The listing for <b>%s</b> at <b>%s</b> has closed while your application was still active.\n<a href=\"%s\">Open your tracking board →</a>",
-			title, company, n.trackingURL)
+			"📪 <b>%s</b> at <b>%s</b> was closed.\n<a href=\"%s\">Open the job →</a>",
+			title, company, jobURL)
 	default:
-		return fmt.Sprintf("<b>%s</b> at <b>%s</b>: <a href=\"%s\">Open your tracking board →</a>", title, company, n.trackingURL)
+		return fmt.Sprintf("<b>%s</b> at <b>%s</b>: <a href=\"%s\">Open your tracking board →</a>", title, company, trackingURL)
 	}
 }
 
 // EmailNotifier delivers a nudge as an email, reusing the emailnotify SES
-// transport. Like the Telegram notifier, its link stays on-platform.
+// transport. Like the Telegram notifier, its links stay on-platform.
 type EmailNotifier struct {
-	sender      emailnotify.Sender
-	from        string
-	trackingURL string
+	sender emailnotify.Sender
+	from   string
+	origin string
 }
 
 // NewEmailNotifier builds an EmailNotifier sending from `from` through sender, with
-// the tracking link rooted at jobBaseURL.
-func NewEmailNotifier(sender emailnotify.Sender, from, jobBaseURL string) *EmailNotifier {
-	return &EmailNotifier{sender: sender, from: from, trackingURL: strings.TrimRight(jobBaseURL, "/") + "/my/tracking?utm_source=email"}
+// links rooted at origin.
+func NewEmailNotifier(sender emailnotify.Sender, from, origin string) *EmailNotifier {
+	return &EmailNotifier{sender: sender, from: from, origin: strings.TrimRight(origin, "/")}
 }
 
 // Send renders the nudge and delivers it to the address in dest.
@@ -83,35 +87,36 @@ func (n *EmailNotifier) Send(ctx context.Context, _ string, dest string, m Messa
 
 func (n *EmailNotifier) render(m Message) (subject, htmlBody, textBody string) {
 	title, company := html.EscapeString(m.JobTitle), html.EscapeString(m.Company)
+	trackingURL := n.origin + "/my/tracking?utm_source=email"
+	jobURL := n.origin + "/jobs/" + m.Slug + "?utm_source=email"
 	switch m.Kind {
 	case KindFollowUp:
 		subject = fmt.Sprintf("Time to follow up: %s at %s", m.JobTitle, m.Company)
 		htmlBody = fmt.Sprintf(
 			`<p>It's been %d days since anything moved on <strong>%s</strong> at <strong>%s</strong>.</p>`+
 				`<p><a href="%s">Open your tracking board and follow up →</a></p>`,
-			m.DaysSilent, title, company, n.trackingURL)
+			m.DaysSilent, title, company, trackingURL)
 		textBody = fmt.Sprintf("It's been %d days since anything moved on %s at %s.\n\nOpen your tracking board: %s\n",
-			m.DaysSilent, m.JobTitle, m.Company, n.trackingURL)
+			m.DaysSilent, m.JobTitle, m.Company, trackingURL)
 	case KindInterviewPrep:
 		subject = fmt.Sprintf("Prepare for your interview: %s at %s", m.JobTitle, m.Company)
 		htmlBody = fmt.Sprintf(
 			`<p>You're interviewing for <strong>%s</strong> at <strong>%s</strong>.</p>`+
 				`<p><a href="%s">Open your tracking board to rehearse →</a></p>`,
-			title, company, n.trackingURL)
+			title, company, trackingURL)
 		textBody = fmt.Sprintf("You're interviewing for %s at %s.\n\nOpen your tracking board: %s\n",
-			m.JobTitle, m.Company, n.trackingURL)
+			m.JobTitle, m.Company, trackingURL)
 	case KindJobClosed:
-		subject = fmt.Sprintf("Listing closed: %s at %s", m.JobTitle, m.Company)
+		subject = fmt.Sprintf("Closed: %s at %s", m.JobTitle, m.Company)
 		htmlBody = fmt.Sprintf(
-			`<p>The listing for <strong>%s</strong> at <strong>%s</strong> has closed while your application was still active.</p>`+
-				`<p><a href="%s">Open your tracking board →</a></p>`,
-			title, company, n.trackingURL)
-		textBody = fmt.Sprintf("The listing for %s at %s has closed while your application was still active.\n\nOpen your tracking board: %s\n",
-			m.JobTitle, m.Company, n.trackingURL)
+			`<p><strong>%s</strong> at <strong>%s</strong> was closed.</p>`+
+				`<p><a href="%s">Open the job →</a></p>`,
+			title, company, jobURL)
+		textBody = fmt.Sprintf("%s at %s was closed.\n\nOpen the job: %s\n", m.JobTitle, m.Company, jobURL)
 	default:
 		subject = fmt.Sprintf("%s at %s", m.JobTitle, m.Company)
-		htmlBody = fmt.Sprintf(`<p><a href="%s">Open your tracking board →</a></p>`, n.trackingURL)
-		textBody = fmt.Sprintf("Open your tracking board: %s\n", n.trackingURL)
+		htmlBody = fmt.Sprintf(`<p><a href="%s">Open your tracking board →</a></p>`, trackingURL)
+		textBody = fmt.Sprintf("Open your tracking board: %s\n", trackingURL)
 	}
 	return subject, htmlBody, textBody
 }

--- a/web/src/lib/components/ReminderSettings.svelte
+++ b/web/src/lib/components/ReminderSettings.svelte
@@ -188,7 +188,7 @@
           </div>
           <div class="flex gap-1.5">
             <dt class="shrink-0 font-medium text-foreground">Listing closed —</dt>
-            <dd>right when a job you're still actively tracking closes.</dd>
+            <dd>right when a job you're still actively tracking closes — the card also moves to Expired on your board.</dd>
           </div>
         </dl>
       </div>


### PR DESCRIPTION
## Summary

Follow-up to #1692, per direct feedback after testing it live:

- **Auto-close in the tracker.** MATCH now also calls the same `TrackJob` write jobtracking's own stage-set path uses, moving the application to `expired` when its listing closes. New `appevent.SourceSystem` event source records this was the platform's own move, not the candidate's. Ordered *after* `RecordNudge` so a partial failure (nudge recorded, TrackJob fails) is safely retried next pass — doing it the other way around would flip the stage before the notification is durably recorded, and a failure between the two would leave the candidate never notified (the next pass would no longer see an active stage to re-check).
- **Shorter copy, job-page link.** "`<title>` at `<company>` was closed" instead of the longer sentence, linking to the job's own page instead of the tracking board — once the board auto-updates there's nothing left to track there for this one.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...` — all green (2 tests extended with TrackJob assertions)
- [x] `go test -tags=integration ./...` — all green (TrackJob itself already has integration coverage elsewhere)
- [x] `svelte-check`: 0 errors; token-coverage: no drift