### PR TITLE
fix(web): unique meta descriptions for company/job pages

### DIFF
--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -4,6 +4,7 @@ import {
   collectionHeading,
   collectionPageJsonLd,
   companyListItems,
+  companyMetaDescription,
   datasetJsonLd,
   jobListItems,
   jobPostingJsonLd,
@@ -58,6 +59,43 @@ describe('collectionHeading', () => {
 
   it('renders a zero count honestly rather than hiding it', () => {
     expect(collectionHeading('React', 0)).toBe('0 React jobs');
+  });
+});
+
+describe('companyMetaDescription', () => {
+  it('falls back to the generic template when no facts are present', () => {
+    expect(companyMetaDescription(company())).toBe('Open jobs at Acme, aggregated by freehire.');
+  });
+
+  it('leads with the tagline and appends industries, headcount and HQ', () => {
+    expect(
+      companyMetaDescription(
+        company({
+          tagline: 'Rockets, on demand',
+          industries: ['Aerospace', 'Robotics', 'Defense'],
+          employee_count: 250,
+          hq_country: 'us',
+        })
+      )
+    ).toBe('Rockets, on demand — Aerospace & Robotics, 250+ employees, United States. Open roles on freehire.');
+  });
+
+  it('prefers company_info.description over the tagline when no tagline is set', () => {
+    expect(
+      companyMetaDescription(company({ company_info: { description: 'Acme builds rockets.' } }))
+    ).toBe('Acme builds rockets. Open roles at Acme on freehire.');
+  });
+
+  it('uses only the facts when there is no tagline or description', () => {
+    expect(companyMetaDescription(company({ hq_country: 'de' }))).toBe(
+      'Acme: Germany. Open roles on freehire.'
+    );
+  });
+
+  it('truncates to max length with an ellipsis', () => {
+    const result = companyMetaDescription(company({ tagline: 'x'.repeat(250) }), 50);
+    expect(result.length).toBe(50);
+    expect(result.endsWith('…')).toBe(true);
   });
 });
 

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -3,6 +3,7 @@
 // crawlers and Google Jobs see structured data in the initial HTML.
 
 import type { PostMeta } from './blog';
+import { countryLabel } from './facets';
 import { REGION_NAMES } from './labels';
 import { companyLogoUrl } from './logo';
 import type { Company, Enrichment, Job } from './types';
@@ -23,6 +24,38 @@ export function metaDescription(html: string, max = 200): string {
     .replace(/<[^>]*>/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}
+
+/** Plain-text, length-capped `<meta name="description">` for a company page.
+ *  Prefers the curated `tagline`, then the imported `company_info.description`,
+ *  appending whatever facts (industries, headcount, HQ) are present; falls back
+ *  to the generic "Open jobs at <name>" template only when the company carries
+ *  none of these — the previous behavior for every company, which made 200k+
+ *  pages near-duplicates of each other. */
+export function companyMetaDescription(company: Company, max = 200): string {
+  const rawLead = company.tagline?.trim() || company.company_info?.description?.trim();
+  // Strip a trailing period so it doesn't collide with the one the sentence below adds.
+  const lead = rawLead?.endsWith('.') ? rawLead.slice(0, -1) : rawLead;
+
+  const facts: string[] = [];
+  if (company.industries?.length) facts.push(company.industries.slice(0, 2).join(' & '));
+  if (company.employee_count) facts.push(`${company.employee_count.toLocaleString('en-US')}+ employees`);
+  if (company.hq_country) facts.push(countryLabel(company.hq_country));
+  const factClause = facts.length > 0 ? facts.join(', ') : undefined;
+
+  let text: string;
+  if (lead && factClause) {
+    text = `${lead} — ${factClause}. Open roles on freehire.`;
+  } else if (lead) {
+    text = `${lead}. Open roles at ${company.name} on freehire.`;
+  } else if (factClause) {
+    text = `${company.name}: ${factClause}. Open roles on freehire.`;
+  } else {
+    text = `Open jobs at ${company.name}, aggregated by freehire.`;
+  }
+
   if (text.length <= max) return text;
   return `${text.slice(0, max - 1).trimEnd()}…`;
 }

--- a/web/src/routes/companies/[slug]/+page.svelte
+++ b/web/src/routes/companies/[slug]/+page.svelte
@@ -2,14 +2,14 @@
   import { page } from '$app/state';
   import CompanyView from '$lib/components/CompanyView.svelte';
   import Seo from '$lib/components/Seo.svelte';
-  import { breadcrumbJsonLd, jsonLdScript, organizationJsonLd } from '$lib/seo';
+  import { breadcrumbJsonLd, companyMetaDescription, jsonLdScript, organizationJsonLd } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
   const origin = $derived(page.url.origin);
   const canonical = $derived(`${origin}/companies/${data.slug}`);
-  const description = $derived(`Open jobs at ${data.company.name}, aggregated by freehire.`);
+  const description = $derived(companyMetaDescription(data.company));
   const jsonLd = $derived(
     jsonLdScript([
       organizationJsonLd(data.company, origin),

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -20,7 +20,14 @@
   const canonical = $derived(`${origin}/jobs/${data.job.public_slug}`);
   // The per-job OG preview lives beside the canonical URL; og:image must be absolute.
   const ogImage = $derived(`${canonical}/og.png`);
-  const description = $derived(metaDescription(data.job.description));
+  // A blank job body strips to "", which would otherwise suppress the
+  // <meta name="description"> tag entirely (Seo.svelte omits it when empty).
+  const description = $derived(
+    metaDescription(data.job.description) ||
+      (data.job.company
+        ? `${data.job.title} at ${data.job.company} — apply on freehire.`
+        : `${data.job.title} — apply on freehire.`)
+  );
   const jsonLd = $derived(
     jsonLdScript([
       jobPostingJsonLd(data.job, origin),


### PR DESCRIPTION
## Summary
- Every company page rendered the identical boilerplate `<meta name="description">` ("Open jobs at <name>, aggregated by freehire.") across 200k+ company pages — thin/duplicate content for Google, and nothing distinctive for AI search engines (ChatGPT, Perplexity, etc.) to cite.
- `companyMetaDescription()` now builds a unique sentence from `tagline`, `industries`, `employee_count` and `hq_country` when present, falling back to the previous generic template only when none of these are available.
- Job pages with an empty posting body previously omitted the `<meta name="description">` tag entirely (silently, since `Seo.svelte` skips the tag when the string is empty); now falls back to a title/company-based sentence.

## Test plan
- [x] `npx vitest run src/lib/seo.test.ts` — 26/26 passing (5 new tests covering companyMetaDescription's branches, including a truncation and a double-period edge case caught during review)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on the touched files — clean