### PR TITLE
Accept comma-separated job-filter query params, alongside repeated-key

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -27,7 +27,7 @@ Base URL: `https://freehire.me/api/v1`
 - [Saved searches & subscriptions](#saved-searches-subscriptions)
 - [Account, credits & extension](#account-credits-extension)
 - [Link intake & discovery](#link-intake-discovery)
-- [Votes, reminders & discussions](#votes-reminders-discussions)
+- [Votes, notifications & discussions](#votes-notifications-discussions)
 - [Market insights & stats](#market-insights-stats)
 - [Employee referrals](#employee-referrals)
 - [CV builder & tailoring](#cv-builder-tailoring)
@@ -80,8 +80,8 @@ Most of this API is also a CLI. If you are writing an agent rather than an integ
 
 These parameters apply to `GET /jobs/search` and `GET /jobs/facets`. Combine any of them with full-text `q`.
 
-- Repeat any facet param to OR its values: `skills=go&skills=rust` matches either.
-- Add `<param>_mode=and` to require all selected values: `skills=go&skills=rust&skills_mode=and` matches both.
+- Pass multiple values as a comma-separated list to OR them: `skills=go,rust` matches either. Repeating the param (`skills=go&skills=rust`) also works.
+- Add `<param>_mode=and` to require all selected values: `skills=go,rust&skills_mode=and` matches both.
 - Add `<param>_exclude=<value>` to exclude matches: `company_type_exclude=outstaff` drops outstaff jobs.
 - Different facets are ANDed together; numeric and boolean filters are ANDed too.
 - Use `regions=none` to match jobs with no resolved geography (an empty region set); it ORs with real region values and supports `_exclude` like any region.
@@ -95,9 +95,9 @@ Every facet below supports repeat-OR, `_mode=and`, and `_exclude` as described a
 | `collections` | Collection | yc, techstars, a16z-portfolio, a16z-speedrun, european, ai, mag7, bigtech, unicorn, fortune500, eastern-roots, ai-native, uk-skilled-worker-sponsor, nl-recognised-sponsor, us-h1b-sponsor |
 | `regions` | Region | global, north_america, latam, eu, uk, mena, africa, apac, cis, none |
 | `work_mode` | Work format | remote, hybrid, onsite |
-| `is_tech` | Tech / Non-tech | tech, non_tech |
 | `role` | Role | Open vocabulary — call /jobs/facets for live values |
 | `category` | Specialization | backend, frontend, fullstack, mobile, devops, sre, network_engineering, data_engineering, data_science, data_analytics, ml_ai, ai_engineering, qa, security, hardware, embedded, blockchain, architecture, design, engineering_design, product, project_management, management, marketing, sales, support, business_analysis, solutions_engineering, developer_relations, technical_writing, recruiting, hr, finance, legal, operations, customer_success, other |
+| `ai_archetype` | AI Specialization | rag_app_builder, agent_builder, cloud_ml_platform_engineer, ml_trainer_researcher, fullstack_ai_engineer, devops_infra_engineer |
 | `seniority` | Seniority | intern, junior, middle, senior, lead, staff, principal, c_level |
 | `skills` | Skills | Open vocabulary — call /jobs/facets for live values |
 | `domains` | Industry | fintech, crypto, ecommerce, gambling, gamedev, media, travel, healthcare, edtech, govtech, devtools, cybersecurity, ai, hrtech, adtech, proptech, logistics, mobility, climatetech, other |
@@ -130,7 +130,7 @@ Every facet below supports repeat-OR, `_mode=and`, and `_exclude` as described a
 
 - **Senior Go, remote, in the CIS region** — `q=go&seniority=senior&work_mode=remote&regions=cis`
 - **Backend roles, freshest first, in Germany** — `category=backend&countries=DE&sort=posted_at&order=desc`
-- **Must use both Go and Rust** — `skills=go&skills=rust&skills_mode=and`
+- **Must use both Go and Rust** — `skills=go,rust&skills_mode=and`
 - **Exclude outstaff companies** — `company_type_exclude=outstaff`
 - **At least $100k, with visa sponsorship** — `salary_currency=USD&salary_min=100000&visa_sponsorship=true`
 
@@ -943,25 +943,21 @@ curl -X POST "https://freehire.me/api/v1/jobs/<slug>/view" -H "Authorization: Be
 
 Mark the job as applied to.
 
+Send `applied_on` to record an application on the day it was actually sent — importing a history, or correcting a date already stored. A date you state overrides one we inferred. The day is stored at noon UTC, because you are stating a day and midnight reads as the previous date west of Greenwich. A date in the future, older than a year, or not a calendar date, is a 400. Without a body the application is stamped now, as before.
+
 **Path parameters**
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `slug` | string | yes | The job `public_slug`. |
 
-**Body** (optional)
+**Body**
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `applied_on` | string | no | The day you actually applied, as `YYYY-MM-DD`. Omit it and the application is stamped now, as before. |
-
-Send `applied_on` to record a history after the fact — importing past applications, or correcting a date already stored. A date you state overrides one we recorded, because you know when you applied and we inferred it. A date in the future, or more than a year old, is a `400`, as is one that is not a calendar date.
-
-The day is stored at noon UTC. You are stating a day, not an instant, and midnight would render as the previous date for anyone west of Greenwich.
+| `applied_on` | string | no | The day the application was sent (`YYYY-MM-DD`). Defaults to today. (e.g. `2026-07-27`) |
 
 ```bash
-curl -X POST "https://freehire.me/api/v1/jobs/<slug>/apply" -H "Authorization: Bearer $FREEHIRE_API_KEY"
-
 curl -X POST "https://freehire.me/api/v1/jobs/<slug>/apply" \
   -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \
   -d '{"applied_on":"2026-07-27"}'
@@ -1017,9 +1013,7 @@ curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/save" -H "Authorization: 
 
 Set the application stage and/or notes.
 
-A null field is left unchanged. `stage` is a controlled vocabulary: `applied`, `screening`, `responded`, `interview`, `offer`, `accepted`, `rejected`, `withdrawn`, `expired` (an unknown value is a 400).
-
-`expired` is the outcome for an application nobody answered — the employer never replied, or the posting went away. Nothing sets it for you: silence is reported separately, by `silence_state` on the tracking list, and this stage is your own conclusion that no answer is coming. Setting it settles the application, so it stops accruing silence.
+A null field is left unchanged. `stage` is a controlled vocabulary: `applied`, `screening`, `responded`, `interview`, `offer`, `accepted`, `rejected`, `withdrawn`, `expired` (an unknown value is a 400). `expired` is the outcome for an application nobody answered; nothing sets it for you.
 
 **Path parameters**
 
@@ -1133,11 +1127,7 @@ curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/dismiss" -H "Authorizatio
 
 Your tracked jobs joined with the job data.
 
-Each item carries a **card** of the job with your interaction timestamps alongside it. `meta.counts` gives the per-filter totals for tab badges. Closed jobs stay listed so your history never shrinks.
-
-The card is what a list row draws: `public_slug`, `title`, `company`, `closed_at`, the stated facets (`work_mode`, `seniority`, `employment_type`, `countries`, `regions`), `skills`, `collections`, `posted_at`, and `blurb` — a short summary already cut to length. It does **not** carry the posting's description; the full public job view, description included, is on `GET /me/tracking/:slug`.
-
-> **Changed:** this listing previously returned the complete job view on every row. Over 500 applications the descriptions alone were 2.37 MB of a 2.83 MB response, for text no row renders.
+Each item carries a card of the job with your interaction timestamps alongside it — what a list row draws: slug, title, company, closed_at, the stated facets, skills, collections, posted_at, and a `blurb` already cut to length. It does NOT carry the description; the full job view is on `GET /me/tracking/:slug`. `meta.counts` gives the per-filter totals for tab badges. Closed jobs stay listed so your history never shrinks.
 
 **Query parameters**
 
@@ -1274,16 +1264,11 @@ curl "https://freehire.me/api/v1/me/tracking/pipeline" -H "Authorization: Bearer
       "offer": 1,
       "accepted": 1,
       "rejected": 1,
-      "withdrawn": 0,
-      "expired": 3
+      "withdrawn": 0
     }
   }
 }
 ```
-
-Group the stages yourself if you want the four coarse states the tracking board shows: `applied`/`screening`/`responded` → **Applied**, `interview` → **Interview**, `offer` → **Offer**, `accepted`/`rejected`/`withdrawn`/`expired` → **Closed**.
-
-> **Changed:** this response previously carried a `buckets` object with seven differently-named keys (`no_answer`, `in_progress`, `declined`, …). Those names existed nowhere else in the product and have been removed in favour of the stage vocabulary you already set through `PUT /me/tracking/:slug`.
 
 ### `GET /me/tracking/swipe`
 
@@ -2251,9 +2236,7 @@ curl "https://freehire.me/api/v1/me/credits/history" -H "Authorization: Bearer f
 
 One tracked application, with the mail linked to it and its history.
 
-`events` is the application's ledger, newest first — what happened to it: the apply, employer replies, follow-ups, stage changes, scheduled interviews. Each carries the same shape `GET /me/timeline` serves, and `observed` says whether anybody other than you set its date. Bounded at 100; empty on an application nothing has happened to yet. This is also where the full public job view lives, description included — the listing at `GET /me/tracking` carries only a card.
-
-A slug you do not track is a 404.
+`events` is the application's ledger, newest first — the apply, employer replies, follow-ups, stage changes, scheduled interviews — in the shape `GET /me/timeline` serves, bounded at 100 and empty when nothing has happened yet. This read also carries the full job view; the listing carries only a card. A slug you do not track is a 404.
 
 **Path parameters**
 
@@ -2266,7 +2249,18 @@ curl "https://freehire.me/api/v1/me/tracking/senior-backend-engineer-acme-1a2b" 
 ```
 
 ```json
-{ "data": { "slug": "senior-backend-engineer-acme-1a2b", "stage": "interview", "applied_at": "2026-07-24T09:00:00Z", "emails": [ { "id": 4821, "subject": "Interview for …", "status_signal": "interview_invitation" } ] } }
+{
+  "data": {
+    "slug": "senior-backend-engineer-acme-1a2b",
+    "stage": "interview",
+    "applied_at": "2026-07-24T09:00:00Z",
+    "emails": [ { "id": 4821, "subject": "Interview for …", "status_signal": "interview_invitation" } ],
+    "events": [
+      { "id": 991, "kind": "employer_reply", "signal": "interview_invitation", "source": "mail_gmail", "observed": true, "occurred_at": "2026-07-29T11:04:00Z" },
+      { "id": 802, "kind": "applied", "source": "user", "observed": false, "occurred_at": "2026-07-24T09:00:00Z" }
+    ]
+  }
+}
 ```
 
 ### `GET /me/tracking/dismissed`
@@ -2427,9 +2421,9 @@ curl -X POST "https://freehire.me/api/v1/me/contributions" \
 { "data": { "source": "greenhouse", "board": "acme", "state": "pending" } }
 ```
 
-## Votes, reminders & discussions
+## Votes, notifications & discussions
 
-The lighter per-user surfaces: a vote on a job or company, a reminder to come back to an application, and the public discussion threads. Votes and reminders take a key; posting to a thread is browser-owned.
+The lighter per-user surfaces: a vote on a job or company, the account-level notification rule (gates the saved-job apply reminder and both lifecycle nudges), and the public discussion threads. Votes and notification settings take a key; posting to a thread is browser-owned.
 
 ### `POST /jobs/{slug}/vote`
 
@@ -2525,83 +2519,40 @@ curl -X DELETE "https://freehire.me/api/v1/companies/acme/vote" -H "Authorizatio
 { "data": { "score": 41, "my_vote": 0 } }
 ```
 
-### `PATCH /jobs/{slug}/reminder`
+### `GET /me/notification-settings`
 
-**Auth:** Session or API key
+**Auth:** Session only
 
-Set or move the reminder on a saved job.
+Your notification rule (gates saved-job reminders and both lifecycle nudges).
 
-**Path parameters**
+```bash
+curl "https://freehire.me/api/v1/me/notification-settings" -b cookies.txt
+```
 
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `slug` | string | yes | The job `public_slug`. |
+```json
+{ "data": { "enabled": true, "channels": ["email"] } }
+```
+
+### `PUT /me/notification-settings`
+
+**Auth:** Session only
+
+Change your notification rule.
 
 **Body**
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `fire_at` | string (RFC3339) | yes | When to remind you. |
+| `enabled` | boolean | no | Turn notifications on or off. |
+| `channels` | string[] | no | Delivery channels: `email`, `telegram`. |
 
 ```bash
-curl -X PATCH "https://freehire.me/api/v1/jobs/senior-backend-engineer-acme-1a2b/reminder" \
-  -H "Authorization: Bearer fhk_…" -H 'Content-Type: application/json' -d '{"fire_at":"2026-08-04T09:00:00Z"}'
+curl -X PUT "https://freehire.me/api/v1/me/notification-settings" -b cookies.txt \
+  -H 'Content-Type: application/json' -d '{"enabled":true,"channels":["email"]}'
 ```
 
 ```json
-{ "data": { "fire_at": "2026-08-04T09:00:00Z" } }
-```
-
-### `DELETE /jobs/{slug}/reminder`
-
-**Auth:** Session or API key
-
-Cancel the reminder.
-
-**Path parameters**
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `slug` | string | yes | The job `public_slug`. |
-
-```bash
-curl -X DELETE "https://freehire.me/api/v1/jobs/senior-backend-engineer-acme-1a2b/reminder" -H "Authorization: Bearer fhk_…"
-```
-
-### `GET /me/reminder-settings`
-
-**Auth:** Session only
-
-Your reminder defaults.
-
-```bash
-curl "https://freehire.me/api/v1/me/reminder-settings" -b cookies.txt
-```
-
-```json
-{ "data": { "enabled": true, "default_days": 7 } }
-```
-
-### `PUT /me/reminder-settings`
-
-**Auth:** Session only
-
-Change your reminder defaults.
-
-**Body**
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `enabled` | boolean | no | Turn reminders on or off. |
-| `default_days` | integer | no | How long after saving to remind you. |
-
-```bash
-curl -X PUT "https://freehire.me/api/v1/me/reminder-settings" -b cookies.txt \
-  -H 'Content-Type: application/json' -d '{"enabled":true,"default_days":5}'
-```
-
-```json
-{ "data": { "enabled": true, "default_days": 5 } }
+{ "data": { "enabled": true, "channels": ["email"] } }
 ```
 
 ### `GET /threads`
@@ -3391,6 +3342,28 @@ curl -X POST "https://freehire.me/api/v1/me/cvs/7d1a…/tailor-session" -b cooki
 
 ```json
 { "data": { "tailor_cv_id": "7d1a…", "base_cv_id": "0f2c…", "session_id": "s_9f…" } }
+```
+
+### `POST /me/cvs/{id}/reset-from-resume`
+
+**Auth:** Session only
+
+Rebuild this tailored CV from your résumé.
+
+Replaces the tailored document's content from the current résumé seed (experience bank + structured extract) and refreshes your base CV from the same seed. Keeps the same tailored id and agent session; preserves template and typography on each row. 409 when the CV is not tailored or there is no usable résumé seed. Upload alone does not do this — this is the explicit apply.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (uuid) | yes | The tailored CV id. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/cvs/7d1a…/reset-from-resume" -b cookies.txt
+```
+
+```json
+{ "data": { "id": "7d1a…", "title": "Tailored for …", "template_id": "classic-ats", "document": { … } } }
 ```
 
 ### `GET /me/cvs/{id}/tailor-context`

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -3,6 +3,7 @@ package search
 import (
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -101,7 +102,7 @@ func filterFromValues(v url.Values, now time.Time) any {
 	var locationGroup []string
 
 	for param, attr := range StringFacets {
-		included := nonEmpty(v[param])
+		included := splitFacetValues(v[param])
 		switch {
 		case locationFacets[param]:
 			for _, val := range included {
@@ -120,7 +121,7 @@ func filterFromValues(v url.Values, now time.Time) any {
 			groups = append(groups, group)
 		}
 		// Excluded values: each is its own AND group so all are filtered out.
-		for _, val := range nonEmpty(v[param+"_exclude"]) {
+		for _, val := range splitFacetValues(v[param+"_exclude"]) {
 			groups = append(groups, []string{facetNeq(param, attr, val)})
 		}
 	}
@@ -151,6 +152,22 @@ func filterFromValues(v url.Values, now time.Time) any {
 	}
 
 	return Filter(groups...)
+}
+
+// splitFacetValues splits each raw query value on comma and flattens the
+// result, dropping empty fragments (a stray comma, or a bare `?skills=`) — so
+// a repeated key (`skills=go&skills=rust`) and a comma-joined value
+// (`skills=go,rust`) resolve to the same set of facet values.
+func splitFacetValues(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		for _, part := range strings.Split(s, ",") {
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
 }
 
 // nonEmpty drops empty strings so a bare `?seniority=` emits no fragment.

--- a/internal/search/query_filter_test.go
+++ b/internal/search/query_filter_test.go
@@ -102,6 +102,41 @@ func TestFilterFromValues_Role(t *testing.T) {
 	}
 }
 
+func TestFilterFromValues_CommaSeparatedIsORed(t *testing.T) {
+	// A single comma-joined value resolves the same way as repeated keys.
+	got := normalizeGroups(t, FilterFromValues(vals("skills=go,rust")))
+	want := [][]string{{`skills = "go"`, `skills = "rust"`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("comma-separated: got %v, want %v", got, want)
+	}
+}
+
+func TestFilterFromValues_CommaSeparatedExclude(t *testing.T) {
+	got := normalizeGroups(t, FilterFromValues(vals("skills_exclude=java,cpp")))
+	want := [][]string{{`skills != "cpp"`}, {`skills != "java"`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("comma-separated exclude: got %v, want %v", got, want)
+	}
+}
+
+func TestFilterFromValues_CommaAndRepeatedKeyMix(t *testing.T) {
+	// A comma-joined entry and a repeated key for the same param union together.
+	got := normalizeGroups(t, FilterFromValues(vals("skills=go,rust&skills=aws")))
+	want := [][]string{{`skills = "aws"`, `skills = "go"`, `skills = "rust"`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mixed comma+repeated: got %v, want %v", got, want)
+	}
+}
+
+func TestFilterFromValues_StrayCommasIgnored(t *testing.T) {
+	// A leading/trailing/doubled comma must not produce an empty facet value.
+	got := normalizeGroups(t, FilterFromValues(vals("skills=go,,rust,")))
+	want := [][]string{{`skills = "go"`, `skills = "rust"`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("stray commas: got %v, want %v", got, want)
+	}
+}
+
 func TestFilterFromValues_AndMode(t *testing.T) {
 	// skills_mode=and → each value its own AND group (a job must have both).
 	got := normalizeGroups(t, FilterFromValues(vals("skills=go&skills=rust&skills_mode=and")))

--- a/openspec/changes/compact-filter-url-format/.openspec.yaml
+++ b/openspec/changes/compact-filter-url-format/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/compact-filter-url-format/design.md
+++ b/openspec/changes/compact-filter-url-format/design.md
@@ -1,0 +1,126 @@
+## Context
+
+Job-filter query params are list-valued: a facet like `skills` can carry dozens
+of selected values. Today both the web app (`web/src/lib/facetModel.ts`) and
+the backend (`internal/search/query_filter.go`) only understand the
+repeated-key encoding, `skills=go&skills=react&skills=aws`. Every consumer of
+that URL shape — the web app's own filter bar, saved `search_profiles`,
+`notify` subscription alert URLs (`internal/notify/match.go` replays the
+stored query string through the same `FilterFromValues`), and third-party
+clients such as `../freehire-cli` — must keep working unmodified.
+
+The backend reads query params through `queryValues(c)`
+(`internal/handler/helpers.go`), which uses `net/url.ParseQuery` specifically
+to preserve repeated keys (Fiber's own accessors collapse them). That parsed
+`url.Values` flows into `search.FilterFromValues`
+(`internal/search/query_filter.go`), which resolves each facet in the
+`StringFacets` map by reading `v[param]` as a slice.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Accept a compact comma-separated form (`skills=go,react,aws`) for every
+  list-valued facet param (every entry in `StringFacets`, both the include
+  param and its `_exclude` counterpart).
+- Keep accepting the existing repeated-key form with no behavior change for
+  any existing caller.
+- Make the web app's own filter bar emit the compact form going forward.
+- Do this with one parsing path, not two — so there is no "legacy branch" to
+  track or remove later.
+
+**Non-Goals:**
+- Company filters (`stagedCompanyFilters.ts` / `companyFilters.ts`) — a
+  separate codec with its own param set; out of scope for this change.
+- Changing `../freehire-cli` — it already works unchanged against a
+  backward-compatible backend; revisit only if it's later found to break.
+- A version flag, feature flag, or content-negotiation mechanism to pick a
+  format. Both formats are always accepted.
+- Comma-escaping within a single facet value. All current `StringFacets`
+  values are dict-only kebab-case slugs (see `internal/search/query_filter.go`
+  and the frontend facet dictionaries) — none legitimately contain a literal
+  comma, so no escaping scheme is needed.
+
+## Decisions
+
+**One flatten step, not a format switch.** Instead of detecting "is this
+comma-separated or repeated-key" and branching, both the backend and the
+frontend apply the same transform to whatever raw values they read for a
+param: split every individual value on `,`, flatten the results into one
+list, drop empties from stray commas. A `url.Values`/`URLSearchParams` for
+`skills=go&skills=react` yields raw values `["go", "react"]`, each with no
+comma — splitting is a no-op and flattening returns them unchanged. A
+`skills=go,react` yields one raw value `["go,react"]`, split into `["go",
+"react"]`. Mixed input (`skills=go,react&skills=aws`) resolves correctly too.
+The alternative — detect-and-branch — would work equally well today but
+leaves a format check as permanent code and as something to eventually decide
+to prune; unifying the two forms into one code path means there is nothing
+to remove later, addressing that concern from the outset.
+
+- Backend: `internal/search/query_filter.go`, `filterFromValues` — replace the
+  direct `v[param]` (and `v[param+"_exclude"]`) reads with a small
+  `splitFacetValues(raw []string) []string` helper that does the split-and-
+  flatten, applied identically to include and exclude params for every facet
+  in `StringFacets`.
+- Frontend: `web/src/lib/facetModel.ts` —
+  - `filtersToParams` (serialize): for each facet with selected values, write
+    one `p.set(def.param, values.join(','))` instead of repeated
+    `p.append(def.param, v)`; same for `${def.param}_exclude`. Omit the param
+    entirely when there are no selected values (existing behavior).
+  - `filtersFromParams` (parse): replace `p.getAll(def.param)` with
+    `p.getAll(def.param).flatMap(v => v.split(',')).filter(Boolean)` — the
+    same split-and-flatten shape as the backend, kept as one small shared
+    helper rather than duplicated inline in both functions.
+- Docs: `web/src/lib/docs/filters.ts` — the worked example changes from
+  `skills=go&skills=rust` to `skills=go,rust`, with a line noting the
+  repeated-key form is still accepted. `docs/API.md` picks this up through the
+  existing generator (`gen:api-docs`), no separate hand-edit.
+
+**Comma as the separator.** Matches the user's own mental model
+(`skill=[go,react]`) and is the conventional choice for compact multi-value
+query params. Confirmed safe because every `StringFacets` value is a
+dict-only slug (no free text, no commas).
+
+**Scope: all `StringFacets`, not just `skills`.** `filterFromValues` already
+treats every facet in that map uniformly; special-casing only `skills` would
+mean a second code path for everything else and no real reduction in
+complexity. Applying the same helper to all of them is not more work than
+scoping it down.
+
+## Risks / Trade-offs
+
+- **A dict-value later gains a legitimate comma** → would silently split into
+  two facet values. Mitigation: `StringFacets` values are dict-only and
+  validated at the source (skill/region/category dictionaries) — a comma
+  would already be an odd dictionary entry; no such value exists today and
+  none of the dictionary-generation code introduces one.
+- **A client sends both a comma-joined value and a repeated key for the same
+  param** (`skills=go,react&skills=aws`) → resolves as the union of both
+  (`go`, `react`, `aws`), matching the OR semantics the facet already has
+  for repeated keys. This is a superset behavior, not a break.
+- **`freehire-cli` or another external client parses the URL it built itself
+  and assumes repeated-key shape** → not affected, since nothing forces a
+  caller to send the compact form; the backend still accepts (and the web
+  app still round-trips) whatever a caller already sends.
+
+## Migration Plan
+
+No data migration. This is additive on the parsing side (a strict superset of
+accepted input) and a serialization-only change on the web app's filter bar.
+Deploy order: land the backend change first (or together — the change is
+backward compatible either order, but landing backend-first means the
+frontend's new compact links are understood immediately when it ships).
+Rollback is a plain revert; no stored data depends on the new encoding since
+saved `search_profiles`/subscription query strings are stored verbatim and
+replayed through the same now-unified parser regardless of which form they
+were captured in.
+
+## Open Questions
+
+None — resolved during brainstorming with the user:
+- Backward compatibility: support both formats indefinitely (not a
+  time-boxed deprecation).
+- Scope: all `StringFacets`, not just `skills`.
+- Nothing to prune later on the code side, per the "Decisions" section above;
+  the only future follow-up is dropping the repeated-key mention from docs
+  once external consumers are confirmed migrated, which is a documentation
+  edit, not a code change.

--- a/openspec/changes/compact-filter-url-format/proposal.md
+++ b/openspec/changes/compact-filter-url-format/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Job-search filter URLs grow one query pair per selected value (`skills=go&skills=react&skills=aws&...`), so a filter set with dozens of skills produces URLs thousands of characters long — unwieldy to share, paste, or read. A comma-separated encoding (`skills=go,react,aws`) carries the same information far more compactly, and can be added without breaking any URL that already exists.
+
+## What Changes
+
+- The job-filter query encoding accepts comma-separated values within a single query-string entry (`skills=go,react`) for every list-valued facet param (the `StringFacets` set: skills, skills_exclude, regions, category, and the rest) — the `<param>_exclude` and `<param>_mode=and` modifiers are unaffected.
+- The existing repeated-key encoding (`skills=go&skills=react`) keeps working — both forms are parsed the same way, so old bookmarks, saved searches, subscription alert URLs, and third-party clients (`freehire-cli`) that build repeated-key URLs need no migration.
+- The web app's filter UI now serializes selections into the URL using the compact comma-separated form instead of repeated keys.
+- The public API docs (`/docs/api`, generated `docs/API.md`) show the compact form as the primary example and note the repeated-key form still works.
+
+## Capabilities
+
+### New Capabilities
+- `filter-query-encoding`: how list-valued job-filter params are encoded in a query string and decoded on read — accepts both comma-separated and repeated-key forms, on both the web app's own URL state and the public `/jobs*` API.
+
+### Modified Capabilities
+- `api-documentation`: the filter vocabulary documentation (`Filter vocabulary is documented in depth` requirement in `api-documentation`) now shows the compact comma-separated form as the documented convention alongside the existing repeated-key form.
+
+## Impact
+
+- `internal/search/query_filter.go` — `filterFromValues` gains a comma-split-and-flatten step applied uniformly to every facet's include and exclude values.
+- `web/src/lib/facetModel.ts` — `filtersToParams` serializes each facet's selected values into one comma-joined query entry; `filtersFromParams` decodes both comma-joined and repeated-key entries.
+- `web/src/lib/docs/filters.ts` and the generated `docs/API.md` — filter-format wording and examples updated.
+- Not touched: company filters (`stagedCompanyFilters.ts`/`companyFilters.ts`, a separate codec) and `../freehire-cli` (already works unchanged against the backward-compatible backend).

--- a/openspec/changes/compact-filter-url-format/specs/api-documentation/spec.md
+++ b/openspec/changes/compact-filter-url-format/specs/api-documentation/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Documented API coverage
+
+The documentation SHALL cover the whole public API surface: the base URL, the
+response envelope and pagination conventions, the public job reads
+(`/jobs`, `/jobs/search`, `/jobs/facets`, `/jobs/:slug`, `/jobs/:slug/similar`),
+companies, authentication, API keys, per-user job interactions, submissions,
+reports, and saved searches/subscriptions. Each endpoint SHALL state its method,
+path, authentication requirement, parameters, and a copyable curl example.
+
+#### Scenario: Endpoint entry is complete
+
+- **WHEN** the documentation lists an endpoint
+- **THEN** it shows the HTTP method, the path, an authentication badge
+  (none / cookie-or-key / cookie / moderator), its parameters, and a curl example
+
+#### Scenario: Filter vocabulary is documented in depth
+
+- **WHEN** a reader looks up how to query jobs by filters
+- **THEN** the docs list every search facet param, the `<param>_mode=and` and
+  `<param>_exclude` modifiers, the numeric (`salary_min`/`salary_max`/
+  `experience_years_min`) and boolean (`visa_sponsorship`) filters, full-text
+  `q`, `sort`/`order`, and `semantic_ratio`, with at least one worked recipe
+
+#### Scenario: Multi-value params show the compact form
+
+- **WHEN** a reader looks up how to pass multiple values for a facet param
+- **THEN** the docs show the comma-separated form (e.g. `skills=go,react`) as
+  the primary example, with a note that repeating the key
+  (`skills=go&skills=react`) is also accepted

--- a/openspec/changes/compact-filter-url-format/specs/filter-query-encoding/spec.md
+++ b/openspec/changes/compact-filter-url-format/specs/filter-query-encoding/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: List-valued filter params accept comma-separated values
+
+For every list-valued job-filter facet param (every entry in the `StringFacets`
+set, e.g. `skills`, `regions`, `category`, and their `<param>_exclude`
+counterparts), the system SHALL accept a single query-string entry whose value
+is a comma-separated list, resolving it to the same set of selected values as
+if each item had been sent as its own repeated key. This applies wherever job
+filters are read from a query string: the public `/jobs`-family API endpoints
+and the web app's own filter-bar URL state.
+
+#### Scenario: Comma-separated values resolve to multiple selections
+
+- **WHEN** a request includes `skills=go,react`
+- **THEN** the `skills` facet filters on both `go` and `react`, the same as
+  `skills=go&skills=react` would
+
+#### Scenario: Comma-separated values apply to exclude params too
+
+- **WHEN** a request includes `skills_exclude=java,cpp`
+- **THEN** jobs tagged `java` or `cpp` are excluded, the same as
+  `skills_exclude=java&skills_exclude=cpp` would
+
+### Requirement: Repeated-key values remain accepted
+
+The system SHALL continue to accept the existing repeated-key form
+(`skills=go&skills=react`) for every list-valued facet param, with unchanged
+behavior, so that URLs built before this change — bookmarks, saved
+`search_profiles`, subscription alert URLs, and third-party clients — continue
+to work with no migration.
+
+#### Scenario: Existing repeated-key URLs behave unchanged
+
+- **WHEN** a request includes `skills=go&skills=react` (no commas)
+- **THEN** the `skills` facet filters on both `go` and `react`, exactly as
+  before this change
+
+#### Scenario: Repeated keys and comma-separated values can mix
+
+- **WHEN** a request includes `skills=go,react&skills=aws`
+- **THEN** the `skills` facet filters on `go`, `react`, and `aws` — the union
+  of every value found across all occurrences of the param
+
+### Requirement: Web app filter bar serializes selections compactly
+
+The web app's job-filter URL state SHALL serialize each facet's selected
+values as one comma-joined query-string entry rather than one query pair per
+value, for both the include and `_exclude` params.
+
+#### Scenario: Multiple selected skills produce one query entry
+
+- **WHEN** a user selects the skills "go" and "react" in the filter UI
+- **THEN** the resulting URL contains one `skills=go,react` entry rather than
+  two `skills=` entries
+
+#### Scenario: No selection omits the param
+
+- **WHEN** a user has no values selected for a facet
+- **THEN** that facet's param is absent from the URL, unchanged from prior
+  behavior

--- a/openspec/changes/compact-filter-url-format/tasks.md
+++ b/openspec/changes/compact-filter-url-format/tasks.md
@@ -7,10 +7,11 @@
 
 ## 2. Frontend: compact serialization and dual-format parsing
 
-- [ ] 2.1 Add a shared split-and-flatten helper (or inline the same logic) used by both include and exclude parsing in `web/src/lib/facetModel.ts`
-- [ ] 2.2 Update `filtersToParams` to write one comma-joined `p.set(def.param, values.join(','))` per facet with selections, instead of repeated `p.append`
-- [ ] 2.3 Update `filtersFromParams` to decode both comma-joined and repeated-key entries via the shared helper
-- [ ] 2.4 Tests/verification: round-trip a filter set through `filtersToParams` → `filtersFromParams` and confirm the same selections come back; confirm an existing repeated-key URL still parses correctly
+- [x] 2.1 Add a shared split-and-flatten helper (or inline the same logic) used by both include and exclude parsing in `web/src/lib/facetModel.ts`
+- [x] 2.2 Update `filtersToParams` to write one comma-joined `p.set(def.param, values.join(','))` per facet with selections, instead of repeated `p.append`
+- [x] 2.3 Update `filtersFromParams` to decode both comma-joined and repeated-key entries via the shared helper
+- [x] 2.4 Tests/verification: round-trip a filter set through `filtersToParams` → `filtersFromParams` and confirm the same selections come back; confirm an existing repeated-key URL still parses correctly
+- [x] 2.5 (found in review) `URLSearchParams.toString()` percent-encodes commas to `%2C`; added `urlSearchString.ts#toSearchString` and wired it into every place that writes the address bar from a facet query: `UrlSyncedState#write`, `JobsView#openSwipe`, `SwipeDeck#close`, `SavedSearchesView`'s "Open" link
 
 ## 3. Docs
 

--- a/openspec/changes/compact-filter-url-format/tasks.md
+++ b/openspec/changes/compact-filter-url-format/tasks.md
@@ -1,0 +1,25 @@
+## 1. Backend: unify facet value parsing
+
+- [ ] 1.1 Add a `splitFacetValues` helper in `internal/search/query_filter.go` that splits each raw value on `,`, flattens, and drops empty entries
+- [ ] 1.2 Apply `splitFacetValues` to every `StringFacets` include-param read in `filterFromValues`
+- [ ] 1.3 Apply `splitFacetValues` to every `StringFacets` `_exclude`-param read in `filterFromValues`
+- [ ] 1.4 Unit tests covering: comma-separated single entry, repeated-key entries, mixed comma+repeated, empty/stray-comma values, and the exclude variant of each
+
+## 2. Frontend: compact serialization and dual-format parsing
+
+- [ ] 2.1 Add a shared split-and-flatten helper (or inline the same logic) used by both include and exclude parsing in `web/src/lib/facetModel.ts`
+- [ ] 2.2 Update `filtersToParams` to write one comma-joined `p.set(def.param, values.join(','))` per facet with selections, instead of repeated `p.append`
+- [ ] 2.3 Update `filtersFromParams` to decode both comma-joined and repeated-key entries via the shared helper
+- [ ] 2.4 Tests/verification: round-trip a filter set through `filtersToParams` → `filtersFromParams` and confirm the same selections come back; confirm an existing repeated-key URL still parses correctly
+
+## 3. Docs
+
+- [ ] 3.1 Update the filter-format example and wording in `web/src/lib/docs/filters.ts` to show `skills=go,react` as primary, with a note that `skills=go&skills=react` still works
+- [ ] 3.2 Regenerate `docs/API.md` via `gen:api-docs` and confirm the new wording appears
+
+## 4. Verification
+
+- [ ] 4.1 `go build ./...` and `go vet ./...`
+- [ ] 4.2 `go test ./...`
+- [ ] 4.3 Manually load a job-search page, select several skills, confirm the URL uses the compact form, then reload the page from that URL and confirm the same filters are applied
+- [ ] 4.4 Manually load an old-style URL with repeated `skills=` keys and confirm filters still apply correctly

--- a/openspec/changes/compact-filter-url-format/tasks.md
+++ b/openspec/changes/compact-filter-url-format/tasks.md
@@ -15,8 +15,8 @@
 
 ## 3. Docs
 
-- [ ] 3.1 Update the filter-format example and wording in `web/src/lib/docs/filters.ts` to show `skills=go,react` as primary, with a note that `skills=go&skills=react` still works
-- [ ] 3.2 Regenerate `docs/API.md` via `gen:api-docs` and confirm the new wording appears
+- [x] 3.1 Update the filter-format example and wording in `web/src/lib/docs/filters.ts` to show `skills=go,react` as primary, with a note that `skills=go&skills=react` still works
+- [x] 3.2 Regenerate `docs/API.md` via `gen:api-docs` and confirm the new wording appears
 
 ## 4. Verification
 

--- a/openspec/changes/compact-filter-url-format/tasks.md
+++ b/openspec/changes/compact-filter-url-format/tasks.md
@@ -20,7 +20,6 @@
 
 ## 4. Verification
 
-- [ ] 4.1 `go build ./...` and `go vet ./...`
-- [ ] 4.2 `go test ./...`
-- [ ] 4.3 Manually load a job-search page, select several skills, confirm the URL uses the compact form, then reload the page from that URL and confirm the same filters are applied
-- [ ] 4.4 Manually load an old-style URL with repeated `skills=` keys and confirm filters still apply correctly
+- [x] 4.1 `go build ./...` and `go vet ./...` — clean; also ran `go vet -tags=integration ./...` per AGENTS.md pre-push convention, clean
+- [x] 4.2 `go test ./...` — all packages pass, no failures
+- [x] 4.3 / 4.4 Skipped live browser verification: the dev Docker stack is occupied by other concurrent worktrees on this machine (port 5432 held, no Redis instance available for the recently-added rate-limit dependency), and standing up an isolated stack was judged not worth the port/resource risk for this change — decided with the user. Covered instead by: `facetModel.test.ts`'s explicit round-trip test (compact serialize → parse) and backward-compat test (old repeated-key URL → same filter state as the new form), plus `urlSearchString.test.ts` verifying the literal-comma address-bar output and that it re-parses correctly — the same mechanics a live browser check would exercise.

--- a/openspec/changes/compact-filter-url-format/tasks.md
+++ b/openspec/changes/compact-filter-url-format/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Backend: unify facet value parsing
 
-- [ ] 1.1 Add a `splitFacetValues` helper in `internal/search/query_filter.go` that splits each raw value on `,`, flattens, and drops empty entries
-- [ ] 1.2 Apply `splitFacetValues` to every `StringFacets` include-param read in `filterFromValues`
-- [ ] 1.3 Apply `splitFacetValues` to every `StringFacets` `_exclude`-param read in `filterFromValues`
-- [ ] 1.4 Unit tests covering: comma-separated single entry, repeated-key entries, mixed comma+repeated, empty/stray-comma values, and the exclude variant of each
+- [x] 1.1 Add a `splitFacetValues` helper in `internal/search/query_filter.go` that splits each raw value on `,`, flattens, and drops empty entries
+- [x] 1.2 Apply `splitFacetValues` to every `StringFacets` include-param read in `filterFromValues`
+- [x] 1.3 Apply `splitFacetValues` to every `StringFacets` `_exclude`-param read in `filterFromValues`
+- [x] 1.4 Unit tests covering: comma-separated single entry, repeated-key entries, mixed comma+repeated, empty/stray-comma values, and the exclude variant of each
 
 ## 2. Frontend: compact serialization and dual-format parsing
 

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -30,6 +30,7 @@
   import OnboardingBanner from './onboarding/OnboardingBanner.svelte';
   import OnboardingAlertBanner from './onboarding/OnboardingAlertBanner.svelte';
   import { syncOnNavigation } from '$lib/urlSynced.svelte';
+  import { toSearchString } from '$lib/urlSearchString';
   import { setListSearchTarget } from '$lib/listSearch.svelte';
   import { track } from '$lib/analytics';
   import type { Job, FacetCounts } from '$lib/types';
@@ -346,7 +347,7 @@
   // fixed context (e.g. company_slug) and go along too.
   function openSwipe() {
     const params = scopedParams();
-    const qs = params.toString();
+    const qs = toSearchString(params);
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() applied to the path; the rule can't see through the appended query string
     goto(resolve('/jobs/swipe') + (qs ? `?${qs}` : ''));
   }

--- a/web/src/lib/components/SavedSearchesView.svelte
+++ b/web/src/lib/components/SavedSearchesView.svelte
@@ -8,6 +8,7 @@
   import { notifications } from '$lib/notifications.svelte';
   import type { SavedSearch } from '$lib/types';
   import { Button, Input } from '$lib/ui';
+  import { toSearchString } from '$lib/urlSearchString';
   import ProviderIcon from './ProviderIcon.svelte';
   import AlertChannels from './filters/AlertChannels.svelte';
   import States from './States.svelte';
@@ -99,6 +100,13 @@
   // renders after auth on the client, so origin is always available here.
   function boardUrl(slug: string): string {
     return `${location.origin}/b/${slug}`;
+  }
+
+  // The stored query may carry a %2C from URLSearchParams' own encoding (see
+  // urlSearchString.ts); normalize it back to a literal comma for the "Open" link
+  // so a multi-value facet reads the same compact way it does everywhere else.
+  function openHref(query: string): string {
+    return `/?${toSearchString(new URLSearchParams(query))}`;
   }
 
   function startShare(s: SavedSearch) {
@@ -246,7 +254,7 @@
                 </span>
               </div>
               <div class="flex shrink-0 items-center gap-1">
-                <Button variant="secondary" size="sm" href={`/?${s.query}`}>Open</Button>
+                <Button variant="secondary" size="sm" href={openHref(s.query)}>Open</Button>
                 <button
                   type="button"
                   aria-label="Rename “{s.name}”"

--- a/web/src/lib/components/SwipeDeck.svelte
+++ b/web/src/lib/components/SwipeDeck.svelte
@@ -8,6 +8,7 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { cardTags, formatSalary } from '$lib/enrichment';
   import { FilterStore, filtersToParams } from '$lib/filters';
+  import { toSearchString } from '$lib/urlSearchString';
   import { latestOnly } from '$lib/latestOnly';
   import type { Job, FacetCounts } from '$lib/types';
   import { Badge } from '$lib/ui';
@@ -182,7 +183,7 @@
   // Leave the deck. Carry the (possibly refined) filters back to the list so it
   // reflects what the swipe session ended on.
   function close() {
-    const qs = deckParams().toString();
+    const qs = toSearchString(deckParams());
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() applied to the path; the rule can't see through the appended query string
     goto(resolve('/') + (qs ? `?${qs}` : ''));
   }

--- a/web/src/lib/docs/filters.ts
+++ b/web/src/lib/docs/filters.ts
@@ -74,8 +74,8 @@ export const FILTER_EXTRAS: FilterRow[] = [
 
 /** How the cross-facet modifiers behave — they apply to every string facet. */
 export const FILTER_MODIFIERS = [
-  'Repeat any facet param to OR its values: `skills=go&skills=rust` matches either.',
-  'Add `<param>_mode=and` to require all selected values: `skills=go&skills=rust&skills_mode=and` matches both.',
+  'Pass multiple values as a comma-separated list to OR them: `skills=go,rust` matches either. Repeating the param (`skills=go&skills=rust`) also works.',
+  'Add `<param>_mode=and` to require all selected values: `skills=go,rust&skills_mode=and` matches both.',
   'Add `<param>_exclude=<value>` to exclude matches: `company_type_exclude=outstaff` drops outstaff jobs.',
   'Different facets are ANDed together; numeric and boolean filters are ANDed too.',
   'Use `regions=none` to match jobs with no resolved geography (an empty region set); it ORs with real region values and supports `_exclude` like any region.',
@@ -90,7 +90,7 @@ export interface Recipe {
 export const RECIPES: Recipe[] = [
   { title: 'Senior Go, remote, in the CIS region', query: 'q=go&seniority=senior&work_mode=remote&regions=cis' },
   { title: 'Backend roles, freshest first, in Germany', query: 'category=backend&countries=DE&sort=posted_at&order=desc' },
-  { title: 'Must use both Go and Rust', query: 'skills=go&skills=rust&skills_mode=and' },
+  { title: 'Must use both Go and Rust', query: 'skills=go,rust&skills_mode=and' },
   { title: 'Exclude outstaff companies', query: 'company_type_exclude=outstaff' },
   { title: 'At least $100k, with visa sponsorship', query: 'salary_currency=USD&salary_min=100000&visa_sponsorship=true' },
 ];

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -37,10 +37,10 @@ describe('emptyFacet', () => {
 });
 
 describe('filtersToParams', () => {
-  it('serializes include to the bare param and exclude to <param>_exclude', () => {
-    const p = filtersToParams(withSkills({ include: ['nodejs', 'react'], exclude: ['php'] }));
-    expect(p.getAll('skills')).toEqual(['nodejs', 'react']);
-    expect(p.getAll('skills_exclude')).toEqual(['php']);
+  it('serializes include to one comma-joined bare param and exclude to <param>_exclude', () => {
+    const p = filtersToParams(withSkills({ include: ['nodejs', 'react'], exclude: ['php', 'java'] }));
+    expect(p.getAll('skills')).toEqual(['nodejs,react']);
+    expect(p.getAll('skills_exclude')).toEqual(['php,java']);
   });
 
   it('emits <param>_mode=and only when matchAll and more than one included value', () => {
@@ -76,6 +76,46 @@ describe('filtersFromParams', () => {
     const f = filtersFromParams(new URLSearchParams('skills=go&skills=go'));
     expect(sk(f).include).toEqual(['go']);
   });
+
+  it('splits a comma-joined value into multiple included values', () => {
+    const f = filtersFromParams(new URLSearchParams('skills=go,react'));
+    expect(sk(f).include).toEqual(['go', 'react']);
+  });
+
+  it('splits a comma-joined value in <param>_exclude too', () => {
+    const f = filtersFromParams(new URLSearchParams('skills_exclude=java,cpp'));
+    expect(sk(f).exclude).toEqual(['java', 'cpp']);
+  });
+
+  it('still parses the old repeated-key form (backward compatibility)', () => {
+    const f = filtersFromParams(new URLSearchParams('skills=go&skills=react&skills=aws'));
+    expect(sk(f).include).toEqual(['go', 'react', 'aws']);
+  });
+
+  it('unions a comma-joined entry with a repeated key for the same param', () => {
+    const f = filtersFromParams(new URLSearchParams('skills=go,react&skills=aws'));
+    expect(sk(f).include).toEqual(['go', 'react', 'aws']);
+  });
+
+  it('drops stray/doubled commas without producing an empty value', () => {
+    const f = filtersFromParams(new URLSearchParams('skills=go,,react,'));
+    expect(sk(f).include).toEqual(['go', 'react']);
+  });
+});
+
+describe('filtersToParams / filtersFromParams round-trip', () => {
+  it('round-trips a multi-value facet through the new comma-joined serialization', () => {
+    const f = withSkills({ include: ['go', 'react', 'aws'], exclude: ['java'] });
+    const back = filtersFromParams(filtersToParams(f));
+    expect(sk(back).include).toEqual(['go', 'react', 'aws']);
+    expect(sk(back).exclude).toEqual(['java']);
+  });
+
+  it('round-trips an old-style repeated-key URL to the same filter state as the new form', () => {
+    const oldStyle = filtersFromParams(new URLSearchParams('skills=go&skills=react'));
+    const newStyle = filtersFromParams(new URLSearchParams('skills=go,react'));
+    expect(oldStyle).toEqual(newStyle);
+  });
 });
 
 describe('role facet round-trips through the generic param path', () => {
@@ -85,7 +125,7 @@ describe('role facet round-trips through the generic param path', () => {
     f.facets.role = { include: ['senior_backend', 'lead_frontend'], exclude: ['fractional_cto'], matchAll: true };
 
     const p = filtersToParams(f);
-    expect(p.getAll('role')).toEqual(['senior_backend', 'lead_frontend']);
+    expect(p.getAll('role')).toEqual(['senior_backend,lead_frontend']);
     expect(p.getAll('role_exclude')).toEqual(['fractional_cto']);
     expect(p.get('role_mode')).toBe('and');
 

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -46,6 +46,14 @@ export interface JobFilters {
   sort: SortField;
 }
 
+/** Splits every raw query value on comma and flattens the result, dropping
+ *  empty fragments (a stray comma) — so a repeated key (`skills=go&skills=react`)
+ *  and a comma-joined value (`skills=go,react`) resolve to the same values.
+ *  Mirrors the backend's `splitFacetValues` (internal/search/query_filter.go). */
+function splitParamValues(raw: string[]): string[] {
+  return raw.flatMap((v) => v.split(',')).filter((v) => v !== '');
+}
+
 export function emptyFacet(): FacetState {
   return { include: [], exclude: [], matchAll: false };
 }
@@ -69,8 +77,8 @@ export function filtersToParams(f: JobFilters): URLSearchParams {
   for (const def of FACETS) {
     const st = f.facets[def.param];
     if (!st) continue;
-    for (const v of st.include) p.append(def.param, v);
-    for (const v of st.exclude) p.append(`${def.param}_exclude`, v);
+    if (st.include.length > 0) p.set(def.param, st.include.join(','));
+    if (st.exclude.length > 0) p.set(`${def.param}_exclude`, st.exclude.join(','));
     // AND-mode is per facet and only meaningful with more than one included value.
     if (st.matchAll && st.include.length > 1) p.set(`${def.param}_mode`, 'and');
   }
@@ -93,9 +101,9 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
     // facet's values are a set — the store's transitions enforce that on user
     // input, so the URL parse must too. A repeated value otherwise reaches a chip
     // list keyed by value, and Svelte throws `each_key_duplicate` on hydration.
-    const exclude = [...new Set(p.getAll(`${def.param}_exclude`))];
+    const exclude = [...new Set(splitParamValues(p.getAll(`${def.param}_exclude`)))];
     const excludeSet = new Set(exclude);
-    const include = [...new Set(p.getAll(def.param))].filter((v) => !excludeSet.has(v));
+    const include = [...new Set(splitParamValues(p.getAll(def.param)))].filter((v) => !excludeSet.has(v));
     const matchAll = p.get(`${def.param}_mode`) === 'and';
     f.facets[def.param] = { include, exclude, matchAll };
   }

--- a/web/src/lib/profileFilters.test.ts
+++ b/web/src/lib/profileFilters.test.ts
@@ -29,10 +29,10 @@ describe('filtersFromProfile', () => {
   it('seeds category from specializations and skills from skills, and nothing else', () => {
     const f = filtersFromProfile(mkProfile(['backend', 'devops'], ['go', 'kubernetes']));
     const p = filtersToParams(f);
-    expect(p.getAll('category')).toEqual(['backend', 'devops']);
-    expect(p.getAll('skills')).toEqual(['go', 'kubernetes']);
+    expect(p.getAll('category')).toEqual(['backend,devops']);
+    expect(p.getAll('skills')).toEqual(['go,kubernetes']);
     // No other facet or field leaks in.
-    expect([...p.keys()].sort()).toEqual(['category', 'category', 'skills', 'skills'].sort());
+    expect([...p.keys()].sort()).toEqual(['category', 'skills']);
   });
 
   it('starts from a clean slate (independent of any prior state)', () => {
@@ -66,15 +66,15 @@ describe('filtersFromProfile', () => {
       relocation: { open: true, regions: ['eu'], cities: ['Berlin'] },
     };
     const p = filtersToParams(filtersFromProfile(mkProfile(['backend'], ['go'], location)));
-    expect(p.getAll('work_mode')).toEqual(['remote', 'onsite']);
+    expect(p.getAll('work_mode')).toEqual(['remote,onsite']);
     // regions = remote ∪ relocation targets.
-    expect(p.getAll('regions')).toEqual(['latam', 'eu']);
+    expect(p.getAll('regions')).toEqual(['latam,eu']);
     // countries = remote ∪ base ∪ relocation; base 'br' dedupes against remote 'br'.
     expect(p.getAll('countries')).toEqual(['br']);
     // cities = base ∪ relocation targets.
-    expect(p.getAll('cities')).toEqual(['Florianópolis', 'Berlin']);
+    expect(p.getAll('cities')).toEqual(['Florianópolis,Berlin']);
     // open to relocation → both relocation-supporting values.
-    expect(p.getAll('relocation')).toEqual(['supported', 'required']);
+    expect(p.getAll('relocation')).toEqual(['supported,required']);
   });
 
   it('seeds no relocation facet when the user is not open to relocating', () => {
@@ -94,7 +94,7 @@ describe('filtersFromProfile', () => {
     const f = filtersFromProfile(mkProfile(['backend'], ['go'], null, ['php', 'wordpress']));
     const p = filtersToParams(f);
     expect(p.getAll('skills')).toEqual(['go']);
-    expect(p.getAll('skills_exclude')).toEqual(['php', 'wordpress']);
+    expect(p.getAll('skills_exclude')).toEqual(['php,wordpress']);
   });
 
   it('keeps a skill wanted when it also appears in excluded_skills (include wins)', () => {

--- a/web/src/lib/urlSearchString.test.ts
+++ b/web/src/lib/urlSearchString.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { toSearchString } from './urlSearchString';
+
+describe('toSearchString', () => {
+  it('keeps a comma-joined facet value literal instead of percent-encoded', () => {
+    const p = new URLSearchParams();
+    p.set('skills', 'go,react');
+    expect(toSearchString(p)).toBe('skills=go,react');
+  });
+
+  it('leaves a value with no comma unaffected', () => {
+    const p = new URLSearchParams();
+    p.set('work_mode', 'remote');
+    expect(toSearchString(p)).toBe('work_mode=remote');
+  });
+
+  it('the decoded string still parses back to the original value', () => {
+    const p = new URLSearchParams();
+    p.set('skills', 'go,react');
+    const reparsed = new URLSearchParams(toSearchString(p));
+    expect(reparsed.get('skills')).toBe('go,react');
+  });
+});

--- a/web/src/lib/urlSearchString.ts
+++ b/web/src/lib/urlSearchString.ts
@@ -1,0 +1,13 @@
+// URLSearchParams.toString() percent-encodes a literal comma to %2C, per the
+// application/x-www-form-urlencoded serializer it implements. A comma is not a
+// delimiter for URLSearchParams (a value containing one parses back identically
+// whether escaped or literal) and is valid unescaped in a URI query component
+// (RFC 3986 sub-delims), so decoding it back keeps a compact comma-joined value
+// (see facetModel.ts's filtersToParams) human-readable in the address bar
+// without changing what the string parses back to.
+
+/** Serialize URLSearchParams for display/storage, undoing the %2C encoding of
+ *  literal commas. */
+export function toSearchString(params: URLSearchParams): string {
+  return params.toString().replace(/%2C/g, ',');
+}

--- a/web/src/lib/urlSynced.svelte.ts
+++ b/web/src/lib/urlSynced.svelte.ts
@@ -15,6 +15,7 @@ import { untrack } from 'svelte';
 import { browser } from '$app/environment';
 import { page } from '$app/state';
 import { replaceState } from '$app/navigation';
+import { toSearchString } from './urlSearchString';
 
 /** Translates the model to/from URL query params — the only screen-specific part. */
 export interface UrlCodec<T> {
@@ -129,7 +130,7 @@ export class UrlSyncedState<T> {
 
   #write(next: T) {
     this.value = next;
-    const qs = this.#codec.serialize(next).toString();
+    const qs = toSearchString(this.#codec.serialize(next));
     // Shallow routing: updates the URL in place without a navigation or load, so the
     // write is cheap and synchronous. Browser-only (mutations are user events).
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- in-place query write to the current pathname; there is no route to resolve


### PR DESCRIPTION
## Summary
- Job-filter query params (`skills`, `regions`, `category`, and the rest of the `StringFacets` set) now accept a compact comma-separated form — `skills=go,react` — in addition to the existing repeated-key form (`skills=go&skills=react`). Both are accepted forever through one unified parse path (`splitFacetValues`/`splitParamValues`), no format-detection branch, nothing to deprecate later.
- The web app's own filter bar now serializes selections into the compact form.
- Fixes an encoding pitfall found in review: `URLSearchParams.toString()` percent-encodes a literal comma to `%2C`, which would have silently defeated the whole readability goal. Added `toSearchString()` and wired it into every place that writes the address bar from a facet query (filter bar, swipe mode enter/exit, "Open" on a saved search).
- Docs (`web/src/lib/docs/filters.ts` → generated `docs/API.md`) updated to show the compact form as primary, noting the repeated-key form still works.
- Out of scope: company filters (a separate codec) and `../freehire-cli` — untouched, since the backend stays backward compatible.

See `openspec/changes/compact-filter-url-format/` for the full proposal/design/specs/tasks.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] Web: `vitest run` (875 tests) and `svelte-check` — clean
- [x] New unit tests cover: comma-separated OR/exclude, mixed comma+repeated-key union, stray commas, round-trip serialize↔parse, backward-compat old-style URLs, and the literal-comma address-bar encoding
- [ ] Live browser click-through — not done (shared dev Docker stack was occupied by other concurrent worktrees; decided with the user to rely on the automated coverage above instead)