### PR TITLE
fix(web): add missing BingSiteAuth.xml

### DIFF
--- a/web/static/BingSiteAuth.xml
+++ b/web/static/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>8736203715BB6E4FBCDE9457A2B92A63</user>
+</users>


### PR DESCRIPTION
## Summary
- `web/static/BingSiteAuth.xml` (Bing Webmaster site-verification file) existed on disk locally but was never committed to git, so it never shipped — `https://freehire.me/BingSiteAuth.xml` 404s.
- Adds the file, same pattern as the earlier `install.sh` fix (SvelteKit only serves `web/static/`, and this file was simply never staged).

## Test plan
- [x] File is plain static XML, no build/runtime logic touched.