### PR TITLE
refactor(outbox): unify six Postgres queue-worker drain loops

### DIFF
--- a/docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md
+++ b/docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md
@@ -1,0 +1,195 @@
+# Outbox runner unification — design
+
+## Motivation
+
+The codebase has six independent Postgres-backed work queues, each with its own worker
+package under `internal/`, driven from its own `cmd/<name>` binary:
+
+| Queue table | Worker package | `cmd/` binary |
+|---|---|---|
+| `enrichment_outbox` | `internal/enrich` | `cmd/enrich` |
+| `semantic_outbox` | `internal/embed` | `cmd/embed` |
+| `search_outbox` | `internal/searchdrain` | `cmd/search-drain` |
+| `apply_form_outbox` | `internal/applyform` | `cmd/capture-apply-form` |
+| `adzuna_description_outbox` | `internal/adzunadesc` | `cmd/hydrate-adzuna-description` |
+| `email_classification_outbox` | `internal/maillink` | `cmd/classify-mail` |
+
+All six tables are already structurally identical: `id, <subject>_id, attempts, claimed_at,
+failed_at, last_error, created_at`, plus a partial claimable index on `failed_at IS NULL`.
+The only divergence is a per-queue staleness key (`target_version` on `enrichment_outbox`,
+`target_model` on `semantic_outbox`) and one FK name (`email_id` instead of `job_id` on
+`email_classification_outbox`) — both already hidden behind each package's own `Store` port.
+SQL comments across the migrations confirm the pattern was copied deliberately each time
+("Mirrors ClaimSemanticBatch", "Mirrors ClaimApplyFormBatch").
+
+Each worker package independently implements the same claim-wave drain loop: claim a
+lease-bounded batch with `FOR UPDATE ... SKIP LOCKED`, process it, record success/failure/
+dead-letter, repeat until a claim comes back empty. That loop — not the domain logic around
+it — is what this change unifies, to remove the duplicated boilerplate and let a new queue
+be added by writing only its `Store` port and processing logic.
+
+## Decisions
+
+- **No schema changes.** The six tables stay separate. A single shared physical table was
+  considered and rejected: it would put all six queues' churn (insert/delete on every
+  enqueue/complete) through one autovacuum target and one claim index, trading today's
+  natural per-table parallelism (six independent B-trees, six independent workers, no
+  cross-queue contention) for shared bloat and hot-page contention as data grows —
+  especially between the two highest-churn queues (`search_outbox`, `semantic_outbox`) and
+  the low-frequency ones. The existing columns are already close enough that no alignment
+  migration is needed either.
+- **Unify only the Go layer.** A new `internal/outbox` package holds the generic claim-wave
+  runner. Every per-queue `Store`/`Indexer`/`Provider` port, `Complete`/`Save`/`Fail`/
+  `Discard` signature, and piece of domain logic (LLM retry, batch/fallback boundary,
+  `ErrPostingGone` handling) stays exactly where it is, in its own package.
+- **Generic over `Claimed`, not over the queue table.** `internal/outbox` is parameterized
+  by Go type parameters (`RunPool[C any]`, `RunBatch[C any]`) on the caller's own claim
+  struct (`embed.Claimed`, `applyform.Claimed`, ...). This is the first use of generics in
+  the codebase; it is the intended use case for them (one control-flow algorithm reused
+  across otherwise-unrelated types), not a stylistic departure.
+- **Two run shapes, not one.** The six workers split into two genuinely different
+  concurrency models, driven by the economics of what they call:
+  - `RunPool[C]` — bounded-concurrency, one goroutine per claimed item. Fits workers whose
+    cost is per-call regardless of batching (LLM calls, HTTP fetches): `enrich`,
+    `applyform`, `adzunadesc`. `classify-mail` (`internal/maillink`) also fits `RunPool`,
+    at `Concurrency: 1` — see below for why that setting needs its own guarantee, not just
+    a small pool.
+  - `RunBatch[C]` — one call for the whole wave, falling back to per-item processing only
+    on a batch-level failure. Fits workers whose cost is per-call and nearly free per item
+    inside the call (a Meilisearch bulk push): `embed`, `search-drain`.
+
+  A single shape imposed on both would either serialize the batch-oriented workers into
+  slow one-item-at-a-time Meilisearch pushes, or force the per-item workers to fabricate a
+  meaningless "batch" around calls that don't batch.
+- **All six queues migrate together.** The queues are similar enough (and the change small
+  enough per queue — swapping an internal loop, not any external contract) that there is no
+  value in a partial rollout; splitting it into an N-week phased migration would only leave
+  the codebase inconsistent for longer.
+
+## Architecture
+
+`internal/outbox` is a new, dependency-free package (no DB, no sqlc, no Meilisearch client)
+holding only the loop and its bookkeeping:
+
+```go
+package outbox
+
+// Outcome is what a Processor did with one claimed item — the caller has already made
+// whatever Store call follows from it (Complete, Fail, Discard); Runner only tallies.
+type Outcome int
+
+const (
+	Succeeded Outcome = iota
+	Failed
+	DeadLettered
+	Discarded
+)
+
+// Stats is what one Run did, in the vocabulary every worker already reports in its own
+// terms via a thin wrapper (e.g. embed.Stats.Indexed == outbox.Stats.Succeeded).
+type Stats struct {
+	Succeeded    int
+	Failed       int
+	DeadLettered int
+	Discarded    int
+}
+
+// Claimer leases up to batch live, unleased entries — each package's existing Claim
+// method already has this shape.
+type Claimer[C any] interface {
+	Claim(ctx context.Context, batch, leaseSeconds int) ([]C, error)
+}
+
+// Processor handles one claimed item end to end, including whatever Store.Complete /
+// Store.Fail / Store.Discard call follows, and reports what happened.
+type Processor[C any] func(ctx context.Context, item C) Outcome
+
+// BatchProcessor handles a whole wave in one call (e.g. one Meilisearch bulk push).
+// A nil error means every item in the wave succeeded and was already completed by the
+// call; a non-nil error means the whole wave failed and Runner falls back to processing
+// it item by item through Processor.
+type BatchProcessor[C any] func(ctx context.Context, items []C) error
+
+// RunOptions are the per-run knobs. MaxPerRun is 0 (unbounded) for every queue except
+// applyform today; the others simply never set it, so behavior is unchanged for them.
+type RunOptions struct {
+	BatchSize    int
+	LeaseSeconds int
+	Concurrency  int // RunPool only
+	MaxAttempts  int
+	MaxPerRun    int // 0 = unbounded
+	CallTimeout  time.Duration
+}
+
+// RunPool drains via a bounded pool when opt.Concurrency > 1. At Concurrency <= 1 it
+// processes the wave as a plain sequential loop — no goroutine is spawned at all — so a
+// caller that needs in-order processing (internal/maillink, where a later message in a
+// thread must see the same wave's earlier link) gets an actual ordering guarantee, not
+// just a pool sized to one: Go's channel semantics between blocked senders are not
+// formally FIFO, so a size-1 semaphore pool would not have been a safe substitute.
+func RunPool[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, process Processor[C]) (Stats, error)
+func RunBatch[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, processBatch BatchProcessor[C], processOne Processor[C]) (Stats, error)
+```
+
+Both entry points share the same outer shape: claim a wave, process it (via the pool or
+the batch-then-fallback strategy), accumulate `Stats`, stop when a claim returns empty or
+`ctx` is cancelled, honor `MaxPerRun` by shrinking the next claim's batch size once the
+budget is nearly spent (generalized from `internal/applyform`'s existing logic).
+
+`Enqueue` is deliberately **not** part of `internal/outbox`. It varies too much to
+generalize usefully (`enrich` takes a `target_version`, `embed` a `target_model`,
+`search_outbox` is enqueued by `cmd/ingest` in the same transaction as the job write and
+is never self-enqueued by `cmd/search-drain` at all) and each `cmd/<worker>` already calls
+its own `Store.Enqueue` (or doesn't) before invoking the runner. That boundary is unchanged.
+
+## Error handling
+
+`internal/outbox` never calls `Complete`, `Fail`, or `Discard` itself — those calls happen
+inside each package's `Processor` closure exactly as they do today, preserving every
+existing nuance without a generic abstraction having to model it:
+- `enrich`'s immediate dead-letter (`maxAttempts=1`) for a corrupted row that can never load.
+- `applyform`'s `ErrPostingGone` → `Discard` (retire without retry) versus an ordinary
+  transient failure → `Fail` (retry up to `MaxAttempts`).
+- `embed`/`search-drain`'s batch-level failure triggering a fallback to per-item processing
+  so one poison row can't sink a whole wave.
+
+A failure claiming the next wave (the queue itself unusable — e.g. the pool is down) still
+aborts the whole `Run` with an error, as it does today; a per-item failure never does.
+
+`outbox.Stats{Failed, DeadLettered}` plugs directly into the existing
+`worker.ExitCode(failed, deadLettered int) int` convention with no change to that function.
+`applyform.RunStats.Degraded()` — which deliberately does not use `worker.ExitCode` because
+this worker's normal operating condition includes routine third-party failures — continues
+to exist as `applyform`'s own method, now derived from an embedded `outbox.Stats` plus its
+own `Discarded`-as-`Gone` renaming.
+
+## Testing
+
+`internal/outbox` gets its own `runner_test.go`, using a fake `Claimer[int]` (or similar
+minimal type) with fake `Processor`/`BatchProcessor` functions. This is the ONE place that
+tests the loop mechanics currently duplicated near-verbatim across all six existing
+`runner_test.go` files: claim-until-empty termination, `MaxPerRun` budget shrinking,
+context-cancellation exit, and the batch-failure-triggers-fallback behavior for `RunBatch`.
+
+Each of the six existing `runner_test.go` files shrinks to testing only what's specific to
+that package: `embed`'s open/closed branching and vector-provenance stamping, `enrich`'s
+`Sanitize`/`Validate` wiring and the corrupted-row dead-letter path, `applyform`'s
+`ErrPostingGone` → `Discard` mapping and its `Degraded()` heuristic, and so on. Their
+existing `Store`/`Indexer`/`Provider` fakes are unchanged; only the outer loop they were
+driving through is replaced by a call into `internal/outbox`.
+
+## Rollout
+
+Pure internal refactor: no schema change, no sqlc query change, no `Complete`/`Save`
+signature change, no env var change, no systemd unit change, no change to any `cmd/<name>`
+binary's name or external behavior. Land as one PR, or a small stack of six mechanical
+commits (one per package swapping its hand-rolled loop for `internal/outbox`'s), each easy
+to bisect independently since the packages don't depend on each other.
+
+## Limitations
+
+- `internal/maillink`'s `Store.ClaimBatch(ctx, leaseSeconds, batchSize)` takes its two
+  size arguments in the opposite order from every other package's `Claim(ctx, batch,
+  leaseSeconds)`. `Claimer[C].Claim` standardizes on the latter order, so `maillink`'s
+  adapter needs a two-line wrapper swapping the argument order — a naming/signature detail
+  caught during inventory, not a design change.

--- a/internal/adzunadesc/runner.go
+++ b/internal/adzunadesc/runner.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sync"
 	"time"
+
+	"github.com/strelov1/freehire/internal/outbox"
 )
 
 // errURLDrifted marks a claim whose job's stored URL has moved to the ad-network tracking
@@ -56,7 +57,11 @@ type RunOptions struct {
 	CallTimeout time.Duration
 }
 
-// RunStats is what the run did.
+// RunStats is what the run did. Failed and DeadLettered are mutually exclusive — a
+// dead-lettered capture counts only in DeadLettered, matching internal/outbox.Outcome's
+// one-outcome-per-item shape (and applyform.RunStats, migrated onto the same shared
+// runner just before this package: see its doc comment for the pre-migration
+// double-count this convention corrects).
 type RunStats struct {
 	Captured int
 	Failed   int
@@ -80,99 +85,84 @@ func (s RunStats) Degraded() bool {
 // recovery from being unable to claim. Every other failure belongs to one capture and is
 // recorded against it.
 func Run(ctx context.Context, s Store, fetch FetchFunc, opts RunOptions) (RunStats, error) {
-	var stats RunStats
-
-	for {
-		batch := opts.BatchSize
-		if opts.MaxPerRun > 0 {
-			remaining := opts.MaxPerRun - (stats.Captured + stats.Failed + stats.Skipped)
-			if remaining <= 0 {
-				return stats, nil
-			}
-			batch = min(batch, remaining)
-		}
-
-		claims, err := s.Claim(ctx, batch, opts.LeaseSeconds)
-		if err != nil {
-			return stats, fmt.Errorf("claim adzuna description captures: %w", err)
-		}
-		if len(claims) == 0 {
-			return stats, nil
-		}
-
-		wave := runWave(ctx, s, fetch, opts, claims)
-		stats.Captured += wave.Captured
-		stats.Failed += wave.Failed
-		stats.Skipped += wave.Skipped
-		stats.DeadLettered += wave.DeadLettered
-
-		if ctx.Err() != nil {
-			return stats, nil
-		}
+	rn := &run{store: s, fetch: fetch, opts: opts}
+	result, err := outbox.RunPool(ctx, &cancelAwareClaimer{store: s}, outbox.RunOptions{
+		BatchSize:    opts.BatchSize,
+		LeaseSeconds: opts.LeaseSeconds,
+		Concurrency:  opts.Concurrency,
+		MaxPerRun:    opts.MaxPerRun,
+	}, rn.process)
+	stats := RunStats{
+		Captured:     result.Succeeded,
+		Failed:       result.Failed,
+		Skipped:      result.Discarded,
+		DeadLettered: result.DeadLettered,
 	}
+	if err != nil {
+		return stats, fmt.Errorf("claim adzuna description captures: %w", err)
+	}
+	return stats, nil
 }
 
-// runWave processes one claim wave through a bounded pool.
-func runWave(ctx context.Context, s Store, fetch FetchFunc, opts RunOptions, claims []Claimed) RunStats {
-	concurrency := max(opts.Concurrency, 1)
+// cancelAwareClaimer adapts Store to outbox.Claimer, checking ctx.Err() before every
+// claim AFTER the first — see internal/applyform's identical adapter (this package
+// mirrors it) for the full rationale, including why the first call is deliberately
+// unguarded: the original loop never checked ctx before its first claim, only between
+// waves, so an already-cancelled ctx at Run()'s very start still made one real claim
+// attempt (a visible error) rather than a silent zero-stats no-op.
+type cancelAwareClaimer struct {
+	store Store
+	calls int
+}
 
-	var (
-		mu    sync.Mutex
-		stats RunStats
-		wg    sync.WaitGroup
-	)
-	slots := make(chan struct{}, concurrency)
-
-	for _, c := range claims {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			slots <- struct{}{}
-			defer func() { <-slots }()
-
-			err := captureOne(ctx, s, fetch, opts, c)
-			if err == nil {
-				mu.Lock()
-				stats.Captured++
-				mu.Unlock()
-				return
-			}
-
-			if errors.Is(err, errURLDrifted) {
-				if discardErr := s.Discard(ctx, c.OutboxID); discardErr != nil {
-					log.Printf("adzunadesc: discard drifted capture %d: %v", c.OutboxID, discardErr)
-				}
-				mu.Lock()
-				stats.Skipped++
-				mu.Unlock()
-				return
-			}
-
-			// A terminal error (see fetch.go) will answer the same way on a retry, so it
-			// dead-letters on this first attempt regardless of opts.MaxAttempts — no point
-			// spending two more requests to learn the same thing twice.
-			maxAttempts := opts.MaxAttempts
-			if terminal(err) {
-				maxAttempts = 1
-			}
-			dead, failErr := s.Fail(ctx, c.OutboxID, err.Error(), maxAttempts)
-			if failErr != nil {
-				log.Printf("adzunadesc: record failure for capture %d: %v", c.OutboxID, failErr)
-			} else if dead {
-				log.Printf("adzunadesc: capture %d (job %d) dead-lettered: %v", c.OutboxID, c.JobID, err)
-			}
-
-			mu.Lock()
-			defer mu.Unlock()
-			stats.Failed++
-			if failErr == nil && dead {
-				stats.DeadLettered++
-			}
-		}()
+func (c *cancelAwareClaimer) Claim(ctx context.Context, batch, leaseSeconds int) ([]Claimed, error) {
+	if c.calls > 0 && ctx.Err() != nil {
+		return nil, nil
 	}
-	wg.Wait()
+	c.calls++
+	return c.store.Claim(ctx, batch, leaseSeconds)
+}
 
-	return stats
+// run carries one Run's dependencies and options so process uses the receiver instead
+// of threading them through every call.
+type run struct {
+	store Store
+	fetch FetchFunc
+	opts  RunOptions
+}
+
+// process fetches and stores one posting's description and reports what happened;
+// outbox.RunPool tallies the result.
+func (rn *run) process(ctx context.Context, c Claimed) outbox.Outcome {
+	err := captureOne(ctx, rn.store, rn.fetch, rn.opts, c)
+	if err == nil {
+		return outbox.Succeeded
+	}
+
+	if errors.Is(err, errURLDrifted) {
+		if discardErr := rn.store.Discard(ctx, c.OutboxID); discardErr != nil {
+			log.Printf("adzunadesc: discard drifted capture %d: %v", c.OutboxID, discardErr)
+		}
+		return outbox.Discarded
+	}
+
+	// A terminal error (see fetch.go) will answer the same way on a retry, so it
+	// dead-letters on this first attempt regardless of opts.MaxAttempts — no point
+	// spending two more requests to learn the same thing twice.
+	maxAttempts := rn.opts.MaxAttempts
+	if terminal(err) {
+		maxAttempts = 1
+	}
+	dead, failErr := rn.store.Fail(ctx, c.OutboxID, err.Error(), maxAttempts)
+	if failErr != nil {
+		log.Printf("adzunadesc: record failure for capture %d: %v", c.OutboxID, failErr)
+	} else if dead {
+		log.Printf("adzunadesc: capture %d (job %d) dead-lettered: %v", c.OutboxID, c.JobID, err)
+	}
+	if failErr == nil && dead {
+		return outbox.DeadLettered
+	}
+	return outbox.Failed
 }
 
 // captureOne fetches and stores one posting's description.

--- a/internal/adzunadesc/runner_test.go
+++ b/internal/adzunadesc/runner_test.go
@@ -18,11 +18,13 @@ type fakeStore struct {
 	deadLetteredID []int64
 	discardedID    []int64
 	claimErr       error
+	claimCalls     int
 }
 
 func (s *fakeStore) Claim(_ context.Context, batch, _ int) ([]Claimed, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.claimCalls++
 	if s.claimErr != nil {
 		return nil, s.claimErr
 	}
@@ -136,8 +138,10 @@ func TestRunRetriesThenDeadLettersAFailingFetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if stats.Failed != 1 || stats.DeadLettered != 1 {
-		t.Errorf("stats = %+v, want Failed=1 DeadLettered=1", stats)
+	// Failed and DeadLettered are mutually exclusive (see RunStats' doc comment) — a
+	// capture that dead-letters counts only in DeadLettered, not also in Failed.
+	if stats.Failed != 0 || stats.DeadLettered != 1 {
+		t.Errorf("stats = %+v, want Failed=0 DeadLettered=1", stats)
 	}
 	if !stats.Degraded() {
 		t.Error("a dead letter should mark the run degraded")
@@ -162,8 +166,8 @@ func TestRunDeadLettersATerminalFailureOnTheFirstAttempt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if stats.Failed != 1 || stats.DeadLettered != 1 {
-		t.Errorf("stats = %+v, want Failed=1 DeadLettered=1 (dead-lettered on the first attempt)", stats)
+	if stats.Failed != 0 || stats.DeadLettered != 1 {
+		t.Errorf("stats = %+v, want Failed=0 DeadLettered=1 (dead-lettered on the first attempt)", stats)
 	}
 	if store.failed[1] != 1 {
 		t.Errorf("Fail was called %d times for outbox 1, want exactly 1", store.failed[1])
@@ -194,5 +198,34 @@ func TestRunReturnsErrorWhenClaimFails(t *testing.T) {
 	_, err := Run(context.Background(), store, fetch, RunOptions{BatchSize: 10, Concurrency: 1})
 	if err == nil {
 		t.Fatal("expected an error when the queue itself is unusable")
+	}
+}
+
+// A context already cancelled before Run() is even called must still make its FIRST
+// claim attempt (mirrors internal/applyform's identical test/rationale): the original
+// loop never guarded the first Claim call, only the ones between waves, so this must
+// not silently turn into a zero-stats no-op indistinguishable from an empty queue.
+func TestRunStopsWhenCancelled(t *testing.T) {
+	store := &fakeStore{pending: []Claimed{
+		{OutboxID: 1, JobID: 10, URL: "https://www.adzuna.co.uk/jobs/details/1"},
+		{OutboxID: 2, JobID: 20, URL: "https://www.adzuna.co.uk/jobs/details/2"},
+	}}
+	fetch := func(_ context.Context, _ string) (string, error) { return "text", nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stats, err := Run(ctx, store, fetch, RunOptions{BatchSize: 1, Concurrency: 1})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(store.pending) == 0 {
+		t.Error("a cancelled run drained every wave, want it to stop")
+	}
+	if store.claimCalls != 1 {
+		t.Errorf("claim calls = %d, want 1 (the first claim is never guarded, only the ones between waves)", store.claimCalls)
+	}
+	if stats.Captured != 1 {
+		t.Errorf("stats = %+v, want the first wave fully captured before stopping", stats)
 	}
 }

--- a/internal/applyform/runner.go
+++ b/internal/applyform/runner.go
@@ -69,6 +69,14 @@ type RunOptions struct {
 // RunStats is what the run did. DeadLettered is counted apart from Failed because a
 // failure is a retry and a dead letter is work abandoned — a queue quietly filling with
 // the latter is not a healthy queue.
+//
+// Before this package's migration onto internal/outbox, the implementation
+// contradicted that documented intent: a dead-lettered capture incremented BOTH
+// Failed and DeadLettered (a pre-existing double-count this doc comment's "apart
+// from" never described). internal/outbox.Outcome is structurally one-outcome-per-
+// item, so migrating onto it corrects Failed/DeadLettered to the mutually exclusive
+// counters already documented here — matching how enrich/embed/search-drain already
+// counted them. Found and fixed by code review, not the original design.
 type RunStats struct {
 	Captured int
 	Failed   int
@@ -106,7 +114,7 @@ func (s RunStats) Degraded() bool {
 // nothing else.
 func Run(ctx context.Context, s Store, fetchers map[string]Fetcher, opts RunOptions) (RunStats, error) {
 	rn := &run{store: s, fetchers: fetchers, opts: opts}
-	result, err := outbox.RunPool(ctx, cancelAwareClaimer{store: s}, outbox.RunOptions{
+	result, err := outbox.RunPool(ctx, &cancelAwareClaimer{store: s}, outbox.RunOptions{
 		BatchSize:    opts.BatchSize,
 		LeaseSeconds: opts.LeaseSeconds,
 		Concurrency:  opts.Concurrency,
@@ -125,20 +133,31 @@ func Run(ctx context.Context, s Store, fetchers map[string]Fetcher, opts RunOpti
 }
 
 // cancelAwareClaimer adapts Store to outbox.Claimer, checking ctx.Err() before every
-// claim. A context cancellation shows up as every capture in the wave failing, so
-// stopping here — rather than letting the next claim attempt or per-item fetch surface
-// the cancellation as an ordinary error — keeps a cancelled run from burning the
-// remaining attempts of a large backlog on a shutdown, matching the original behavior's
-// post-wave ctx.Err() check (an empty claim is outbox.RunPool's ordinary clean-stop
-// path, so this reproduces it without RunPool needing to know about cancellation).
+// claim AFTER the first. A context cancellation shows up as every capture in a wave
+// failing, so stopping here — rather than letting the next claim attempt or per-item
+// fetch surface the cancellation as an ordinary error — keeps a cancelled run from
+// burning the remaining attempts of a large backlog on a shutdown, matching the
+// original behavior's post-wave ctx.Err() check (an empty claim is outbox.RunPool's
+// ordinary clean-stop path, so this reproduces it without RunPool needing to know
+// about cancellation).
+//
+// The first call is deliberately NOT guarded: the original loop called Claim
+// unconditionally before ever checking ctx, so an already-cancelled ctx at the very
+// start of Run() still made one real claim attempt (surfacing as a claim error if the
+// store's own call respects the cancellation) rather than a silent zero-stats no-op.
+// Guarding every call uniformly — including the first — would swap that visible
+// failure signal for a clean-looking empty-queue run, indistinguishable from a
+// healthy drain; found by code review, not by design.
 type cancelAwareClaimer struct {
 	store Store
+	calls int
 }
 
-func (c cancelAwareClaimer) Claim(ctx context.Context, batch, leaseSeconds int) ([]Claimed, error) {
-	if ctx.Err() != nil {
+func (c *cancelAwareClaimer) Claim(ctx context.Context, batch, leaseSeconds int) ([]Claimed, error) {
+	if c.calls > 0 && ctx.Err() != nil {
 		return nil, nil
 	}
+	c.calls++
 	return c.store.Claim(ctx, batch, leaseSeconds)
 }
 

--- a/internal/applyform/runner.go
+++ b/internal/applyform/runner.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sync"
 	"time"
+
+	"github.com/strelov1/freehire/internal/outbox"
 )
 
 // Claimed is one capture leased to this run. Provider and ExternalID come straight off the
@@ -104,104 +105,79 @@ func (s RunStats) Degraded() bool {
 // recorded against it, so one platform having a bad afternoon costs its own postings and
 // nothing else.
 func Run(ctx context.Context, s Store, fetchers map[string]Fetcher, opts RunOptions) (RunStats, error) {
-	var stats RunStats
-
-	for {
-		batch := opts.BatchSize
-		if opts.MaxPerRun > 0 {
-			// Never claim past the budget: a leased entry this run will not touch is one
-			// no other run can take until its lease lapses.
-			remaining := opts.MaxPerRun - (stats.Captured + stats.Failed + stats.Gone)
-			if remaining <= 0 {
-				return stats, nil
-			}
-			batch = min(batch, remaining)
-		}
-
-		claims, err := s.Claim(ctx, batch, opts.LeaseSeconds)
-		if err != nil {
-			return stats, fmt.Errorf("claim apply-form captures: %w", err)
-		}
-		if len(claims) == 0 {
-			return stats, nil
-		}
-
-		wave := runWave(ctx, s, fetchers, opts, claims)
-		stats.Captured += wave.Captured
-		stats.Failed += wave.Failed
-		stats.Gone += wave.Gone
-		stats.DeadLettered += wave.DeadLettered
-
-		// A context cancellation shows up as every capture in the wave failing; stopping
-		// here keeps a cancelled run from burning the remaining attempts of the whole
-		// backlog on a shutdown.
-		if ctx.Err() != nil {
-			return stats, nil
-		}
+	rn := &run{store: s, fetchers: fetchers, opts: opts}
+	result, err := outbox.RunPool(ctx, cancelAwareClaimer{store: s}, outbox.RunOptions{
+		BatchSize:    opts.BatchSize,
+		LeaseSeconds: opts.LeaseSeconds,
+		Concurrency:  opts.Concurrency,
+		MaxPerRun:    opts.MaxPerRun,
+	}, rn.process)
+	stats := RunStats{
+		Captured:     result.Succeeded,
+		Failed:       result.Failed,
+		Gone:         result.Discarded,
+		DeadLettered: result.DeadLettered,
 	}
+	if err != nil {
+		return stats, fmt.Errorf("claim apply-form captures: %w", err)
+	}
+	return stats, nil
 }
 
-// runWave processes one claim wave through a bounded pool.
-func runWave(ctx context.Context, s Store, fetchers map[string]Fetcher, opts RunOptions, claims []Claimed) RunStats {
-	concurrency := max(opts.Concurrency, 1)
+// cancelAwareClaimer adapts Store to outbox.Claimer, checking ctx.Err() before every
+// claim. A context cancellation shows up as every capture in the wave failing, so
+// stopping here — rather than letting the next claim attempt or per-item fetch surface
+// the cancellation as an ordinary error — keeps a cancelled run from burning the
+// remaining attempts of a large backlog on a shutdown, matching the original behavior's
+// post-wave ctx.Err() check (an empty claim is outbox.RunPool's ordinary clean-stop
+// path, so this reproduces it without RunPool needing to know about cancellation).
+type cancelAwareClaimer struct {
+	store Store
+}
 
-	var (
-		mu    sync.Mutex
-		stats RunStats
-		wg    sync.WaitGroup
-	)
-	slots := make(chan struct{}, concurrency)
-
-	for _, c := range claims {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			slots <- struct{}{}
-			defer func() { <-slots }()
-
-			err := captureOne(ctx, s, fetchers, opts, c)
-			if err == nil {
-				mu.Lock()
-				stats.Captured++
-				mu.Unlock()
-				return
-			}
-
-			// The platform does not have this posting and never will again. Retrying to
-			// reach the same answer spends requests and ends in a dead letter that reads
-			// like a fault, so the entry is retired instead.
-			if errors.Is(err, ErrPostingGone) {
-				if discardErr := s.Discard(ctx, c.OutboxID); discardErr != nil {
-					log.Printf("apply-form: retire gone capture %d: %v", c.OutboxID, discardErr)
-				}
-				mu.Lock()
-				stats.Gone++
-				mu.Unlock()
-				return
-			}
-
-			// Recording the failure is itself a database call, so it happens OUTSIDE the
-			// counter lock — holding the lock across it would serialize the whole wave's
-			// failure path behind one round trip and quietly undo the bounded pool
-			// whenever a platform starts erroring, which is exactly when it matters.
-			dead, failErr := s.Fail(ctx, c.OutboxID, err.Error(), opts.MaxAttempts)
-			if failErr != nil {
-				log.Printf("apply-form: record failure for capture %d: %v", c.OutboxID, failErr)
-			} else if dead {
-				log.Printf("apply-form: capture %d (job %d) dead-lettered: %v", c.OutboxID, c.JobID, err)
-			}
-
-			mu.Lock()
-			defer mu.Unlock()
-			stats.Failed++
-			if failErr == nil && dead {
-				stats.DeadLettered++
-			}
-		}()
+func (c cancelAwareClaimer) Claim(ctx context.Context, batch, leaseSeconds int) ([]Claimed, error) {
+	if ctx.Err() != nil {
+		return nil, nil
 	}
-	wg.Wait()
+	return c.store.Claim(ctx, batch, leaseSeconds)
+}
 
-	return stats
+// run carries one Run's dependencies and options so process uses the receiver instead
+// of threading them through every call.
+type run struct {
+	store    Store
+	fetchers map[string]Fetcher
+	opts     RunOptions
+}
+
+// process fetches and stores one posting's form and reports what happened;
+// outbox.RunPool tallies the result.
+func (rn *run) process(ctx context.Context, c Claimed) outbox.Outcome {
+	err := captureOne(ctx, rn.store, rn.fetchers, rn.opts, c)
+	if err == nil {
+		return outbox.Succeeded
+	}
+
+	// The platform does not have this posting and never will again. Retrying to reach
+	// the same answer spends requests and ends in a dead letter that reads like a
+	// fault, so the entry is retired instead.
+	if errors.Is(err, ErrPostingGone) {
+		if discardErr := rn.store.Discard(ctx, c.OutboxID); discardErr != nil {
+			log.Printf("apply-form: retire gone capture %d: %v", c.OutboxID, discardErr)
+		}
+		return outbox.Discarded
+	}
+
+	dead, failErr := rn.store.Fail(ctx, c.OutboxID, err.Error(), rn.opts.MaxAttempts)
+	if failErr != nil {
+		log.Printf("apply-form: record failure for capture %d: %v", c.OutboxID, failErr)
+	} else if dead {
+		log.Printf("apply-form: capture %d (job %d) dead-lettered: %v", c.OutboxID, c.JobID, err)
+	}
+	if failErr == nil && dead {
+		return outbox.DeadLettered
+	}
+	return outbox.Failed
 }
 
 // captureOne fetches and stores one posting's form.

--- a/internal/applyform/runner_test.go
+++ b/internal/applyform/runner_test.go
@@ -228,6 +228,9 @@ func TestRunCountsDeadLetters(t *testing.T) {
 	if stats.DeadLettered != 1 {
 		t.Errorf("dead-lettered = %d, want 1", stats.DeadLettered)
 	}
+	if stats.Failed != 0 {
+		t.Errorf("failed = %d, want 0 (DeadLettered and Failed are mutually exclusive, per RunStats' own doc comment)", stats.Failed)
+	}
 }
 
 // The enqueue gate and this registry share one source of truth, so a claim for a provider
@@ -338,6 +341,10 @@ func TestRunWithoutABudgetDrainsEverything(t *testing.T) {
 }
 
 // A cancelled run stops rather than working through the backlog burning retry budget.
+// A context already cancelled before Run() is even called must still make its FIRST
+// claim attempt — the original loop never guarded the first Claim call, only the ones
+// between waves, so an already-cancelled ctx surfaced as an ordinary claim error (a
+// visible failure) rather than a silent, indistinguishable-from-healthy empty run.
 func TestRunStopsWhenCancelled(t *testing.T) {
 	store := newFakeStore(
 		[]Claimed{claim(1, 100, "greenhouse", "b:one")},
@@ -348,11 +355,18 @@ func TestRunStopsWhenCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if _, err := Run(ctx, store, map[string]Fetcher{"greenhouse": fetcher}, testOptions()); err != nil {
+	stats, err := Run(ctx, store, map[string]Fetcher{"greenhouse": fetcher}, testOptions())
+	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if len(store.waves) == 0 {
 		t.Error("a cancelled run drained every wave, want it to stop")
+	}
+	if store.maxClaims != 1 {
+		t.Errorf("claim calls = %d, want 1 (the first claim is never guarded, only the ones between waves)", store.maxClaims)
+	}
+	if stats.Captured != 1 {
+		t.Errorf("stats = %+v, want the first wave fully captured before stopping", stats)
 	}
 }
 

--- a/internal/embed/runner.go
+++ b/internal/embed/runner.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/outbox"
 	"github.com/strelov1/freehire/internal/pgerr"
 )
 
@@ -104,27 +105,22 @@ func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
 	log.Printf("embed: enqueued %d pending, draining (batch=%d)", enqueued, opt.BatchSize)
 
 	rn := &run{store: r.Store, indexer: r.Indexer, opt: opt}
-	for {
-		batch, err := r.Store.Claim(ctx, opt.BatchSize, opt.LeaseSeconds)
-		if err != nil {
-			return rn.stats, fmt.Errorf("claim: %w", err)
-		}
-		if len(batch) == 0 {
-			return rn.stats, nil
-		}
-		var open, closed []Claimed
-		for _, e := range batch {
-			if e.Closed {
-				closed = append(closed, e)
-			} else {
-				open = append(open, e)
-			}
-		}
-		rn.processOpenBatch(ctx, open)
-		rn.processClosedBatch(ctx, closed)
-		log.Printf("embed: progress indexed=%d removed=%d failed=%d dead=%d",
-			rn.stats.Indexed, rn.stats.Removed, rn.stats.Failed, rn.stats.DeadLettered)
+	_, err = outbox.RunBatch(ctx, r.Store, outbox.RunOptions{
+		BatchSize:    opt.BatchSize,
+		LeaseSeconds: opt.LeaseSeconds,
+		OnWave: func(outbox.Stats) {
+			// A heartbeat per wave so a long drain shows running totals instead of
+			// going silent for hours. Reads rn.stats directly (not the generic
+			// outbox.Stats parameter) because it distinguishes Indexed from Removed,
+			// which outbox's four generic buckets don't carry.
+			log.Printf("embed: progress indexed=%d removed=%d failed=%d dead=%d",
+				rn.stats.Indexed, rn.stats.Removed, rn.stats.Failed, rn.stats.DeadLettered)
+		},
+	}, rn.processWave, rn.unreachableFallback)
+	if err != nil {
+		return rn.stats, fmt.Errorf("claim: %w", err)
 	}
+	return rn.stats, nil
 }
 
 // run accumulates one Run's options and tallies. Waves are processed sequentially (the
@@ -134,6 +130,40 @@ type run struct {
 	indexer Indexer
 	opt     RunOptions
 	stats   Stats
+}
+
+// processWave is embed's outbox.BatchProcessor: split the wave into its open and
+// closed groups and hand each to its own batch-attempt-then-per-item-fallback cycle
+// (unchanged below). Always returns a nil error — embed fully handles every item
+// itself, including its own fallback, so outbox.RunBatch's outer per-item Processor
+// (unreachableFallback) is never invoked. The returned outbox.Stats is this wave's
+// delta, computed from rn.stats before/after, for outbox's own bookkeeping (MaxPerRun,
+// OnWave); Run's own public Stats return value comes from rn.stats directly, which
+// keeps the Indexed/Removed split outbox.Stats has no room for.
+func (rn *run) processWave(ctx context.Context, batch []Claimed) (outbox.Stats, error) {
+	var open, closed []Claimed
+	for _, e := range batch {
+		if e.Closed {
+			closed = append(closed, e)
+		} else {
+			open = append(open, e)
+		}
+	}
+	before := rn.stats
+	rn.processOpenBatch(ctx, open)
+	rn.processClosedBatch(ctx, closed)
+	return outbox.Stats{
+		Succeeded:    (rn.stats.Indexed - before.Indexed) + (rn.stats.Removed - before.Removed),
+		Failed:       rn.stats.Failed - before.Failed,
+		DeadLettered: rn.stats.DeadLettered - before.DeadLettered,
+	}, nil
+}
+
+// unreachableFallback satisfies outbox.RunBatch's Processor parameter. processWave
+// never returns an error, so outbox.RunBatch never calls this — panicking documents
+// that invariant rather than silently returning a fabricated outcome.
+func (rn *run) unreachableFallback(context.Context, Claimed) outbox.Outcome {
+	panic("embed: outer per-item fallback invoked, but processWave never returns an error")
 }
 
 // processOpenBatch embeds+upserts a whole wave of open jobs in one batch and completes

--- a/internal/enrich/runner.go
+++ b/internal/enrich/runner.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sync"
 	"time"
 
+	"github.com/strelov1/freehire/internal/outbox"
 	"github.com/strelov1/freehire/internal/pgerr"
 )
 
@@ -72,47 +72,37 @@ func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
 	log.Printf("enrich: enqueued %d pending, draining (concurrency=%d)", enqueued, opt.Concurrency)
 
 	rn := &run{provider: r.Provider, store: r.Store, opt: opt}
-	for {
-		// Claim a wave the size of the concurrency, then drain it in parallel: each
-		// entry starts processing at once, so its lease window stays ≈ one LLM call.
-		batch, err := r.Store.Claim(ctx, opt.Concurrency, opt.LeaseSeconds)
-		if err != nil {
-			return rn.stats, fmt.Errorf("claim: %w", err)
-		}
-		if len(batch) == 0 {
-			return rn.stats, nil
-		}
-		var wg sync.WaitGroup
-		for _, entry := range batch {
-			wg.Add(1)
-			go func(e Claimed) {
-				defer wg.Done()
-				rn.process(ctx, e)
-			}(entry)
-		}
-		wg.Wait()
-		// A heartbeat per wave so a long drain shows running totals instead of
-		// going silent for hours.
-		log.Printf("enrich: progress enriched=%d failed=%d dead=%d", rn.stats.Enriched, rn.stats.Failed, rn.stats.DeadLettered)
+	s, err := outbox.RunPool(ctx, r.Store, outbox.RunOptions{
+		// The wave is sized to the concurrency, then drained in parallel: each entry
+		// starts processing at once, so its lease window stays ≈ one LLM call.
+		BatchSize:    opt.Concurrency,
+		LeaseSeconds: opt.LeaseSeconds,
+		Concurrency:  opt.Concurrency,
+		OnWave: func(s outbox.Stats) {
+			// A heartbeat per wave so a long drain shows running totals instead of
+			// going silent for hours.
+			log.Printf("enrich: progress enriched=%d failed=%d dead=%d", s.Succeeded, s.Failed, s.DeadLettered)
+		},
+	}, rn.process)
+	stats := Stats{Enriched: s.Succeeded, Failed: s.Failed, DeadLettered: s.DeadLettered}
+	if err != nil {
+		return stats, fmt.Errorf("claim: %w", err)
 	}
+	return stats, nil
 }
 
-// run accumulates one Run's options and tallies so the per-entry helpers carry the
-// receiver instead of threading opt and a *Stats through every call. A wave's workers
-// process entries concurrently, so the tallies are guarded by mu.
+// run carries one Run's dependencies and options so the per-entry helpers use the
+// receiver instead of threading them through every call.
 type run struct {
 	provider Provider
 	store    Store
 	opt      RunOptions
-
-	mu    sync.Mutex
-	stats Stats
 }
 
-// process handles one claimed entry. Any failure routes to fail so the run
-// continues with the remaining entries. Each entry logs its outcome and duration
-// so a long drain is observable in real time.
-func (rn *run) process(ctx context.Context, entry Claimed) {
+// process handles one claimed entry and reports what happened; internal/outbox's
+// RunPool tallies the result. Each entry logs its outcome and duration so a long
+// drain is observable in real time.
+func (rn *run) process(ctx context.Context, entry Claimed) outbox.Outcome {
 	start := time.Now()
 
 	job, err := rn.store.Job(ctx, entry.JobID)
@@ -121,38 +111,36 @@ func (rn *run) process(ctx context.Context, entry Claimed) {
 		// runs would only burn the attempt budget on a job that can never load, so
 		// dead-letter it immediately (maxAttempts=1) instead.
 		if pgerr.IsDataCorrupted(err) {
-			rn.failN(ctx, entry, fmt.Errorf("load job: %w", err), 1)
+			outcome := rn.failN(ctx, entry, fmt.Errorf("load job: %w", err), 1)
 			log.Printf("enrich: job=%d dead-lettered (corrupted row) in %s: %v", entry.JobID, time.Since(start).Round(time.Millisecond), err)
-			return
+			return outcome
 		}
-		rn.fail(ctx, entry, fmt.Errorf("load job: %w", err))
+		outcome := rn.fail(ctx, entry, fmt.Errorf("load job: %w", err))
 		log.Printf("enrich: job=%d load failed in %s: %v", entry.JobID, time.Since(start).Round(time.Millisecond), err)
-		return
+		return outcome
 	}
 
 	enr, err := rn.enrich(ctx, job)
 	if err != nil {
-		rn.fail(ctx, entry, err)
+		outcome := rn.fail(ctx, entry, err)
 		log.Printf("enrich: job=%d FAILED in %s: %v", entry.JobID, time.Since(start).Round(time.Millisecond), err)
-		return
+		return outcome
 	}
 
 	payload, err := json.Marshal(enr)
 	if err != nil {
-		rn.fail(ctx, entry, fmt.Errorf("marshal: %w", err))
+		outcome := rn.fail(ctx, entry, fmt.Errorf("marshal: %w", err))
 		log.Printf("enrich: job=%d marshal failed: %v", entry.JobID, err)
-		return
+		return outcome
 	}
 
 	if err := rn.store.Complete(ctx, entry, payload); err != nil {
-		rn.fail(ctx, entry, fmt.Errorf("write back: %w", err))
+		outcome := rn.fail(ctx, entry, fmt.Errorf("write back: %w", err))
 		log.Printf("enrich: job=%d write-back failed: %v", entry.JobID, err)
-		return
+		return outcome
 	}
-	rn.mu.Lock()
-	rn.stats.Enriched++
-	rn.mu.Unlock()
 	log.Printf("enrich: job=%d ok in %s", entry.JobID, time.Since(start).Round(time.Millisecond))
+	return outbox.Succeeded
 }
 
 // enrich asks the provider for a payload and validates it, retrying once on a
@@ -185,14 +173,14 @@ func (rn *run) enrich(ctx context.Context, job JobInput) (Enrichment, error) {
 	return Enrichment{}, lastErr
 }
 
-func (rn *run) fail(ctx context.Context, entry Claimed, cause error) {
-	rn.failN(ctx, entry, cause, rn.opt.MaxAttempts)
+func (rn *run) fail(ctx context.Context, entry Claimed, cause error) outbox.Outcome {
+	return rn.failN(ctx, entry, cause, rn.opt.MaxAttempts)
 }
 
 // failN records a failure with an explicit attempt ceiling. fail uses the run's
 // configured MaxAttempts; the corrupted-row path passes 1 to force an immediate
 // dead-letter (an unreadable row will never succeed on retry).
-func (rn *run) failN(ctx context.Context, entry Claimed, cause error, maxAttempts int) {
+func (rn *run) failN(ctx context.Context, entry Claimed, cause error, maxAttempts int) outbox.Outcome {
 	dead, err := rn.store.Fail(ctx, entry.OutboxID, cause.Error(), maxAttempts)
 	if err != nil {
 		// The attempt still counts as a failure below, but log the cause: a
@@ -200,13 +188,10 @@ func (rn *run) failN(ctx context.Context, entry Claimed, cause error, maxAttempt
 		// otherwise hide behind an opaque Failed tally with no way to diagnose it.
 		log.Printf("enrich: outbox=%d fail-bookkeeping error: %v", entry.OutboxID, err)
 	}
-	rn.mu.Lock()
-	defer rn.mu.Unlock()
 	// Only a recorded dead-letter is distinct; a non-dead attempt and a Fail that
 	// couldn't even be recorded both count as a plain failure.
 	if err == nil && dead {
-		rn.stats.DeadLettered++
-		return
+		return outbox.DeadLettered
 	}
-	rn.stats.Failed++
+	return outbox.Failed
 }

--- a/internal/enrich/runner.go
+++ b/internal/enrich/runner.go
@@ -78,10 +78,10 @@ func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
 		BatchSize:    opt.Concurrency,
 		LeaseSeconds: opt.LeaseSeconds,
 		Concurrency:  opt.Concurrency,
-		OnWave: func(s outbox.Stats) {
+		OnWave: func(cum outbox.Stats) {
 			// A heartbeat per wave so a long drain shows running totals instead of
 			// going silent for hours.
-			log.Printf("enrich: progress enriched=%d failed=%d dead=%d", s.Succeeded, s.Failed, s.DeadLettered)
+			log.Printf("enrich: progress enriched=%d failed=%d dead=%d", cum.Succeeded, cum.Failed, cum.DeadLettered)
 		},
 	}, rn.process)
 	stats := Stats{Enriched: s.Succeeded, Failed: s.Failed, DeadLettered: s.DeadLettered}

--- a/internal/enrich/runner_test.go
+++ b/internal/enrich/runner_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -277,56 +276,10 @@ func TestRun_oneFailureDoesNotAbortBatch(t *testing.T) {
 	}
 }
 
-func TestRun_waveDrainsConcurrently(t *testing.T) {
-	const wave = 3
-	claimed := make([]Claimed, wave)
-	jobs := map[int64]JobInput{}
-	for i := range claimed {
-		id := int64(i + 1)
-		claimed[i] = Claimed{OutboxID: id, JobID: id, TargetVersion: Version}
-		jobs[id] = JobInput{Title: "j"}
-	}
-	store := &fakeStore{claims: [][]Claimed{claimed}, jobs: jobs}
-
-	// Barrier: each worker signals arrival then blocks on release. The main goroutine
-	// only releases once all `wave` workers have arrived, so a sequential drain (which
-	// would block on the first worker forever) cannot reach the barrier and times out.
-	var arrived sync.WaitGroup
-	arrived.Add(wave)
-	release := make(chan struct{})
-	prov := &funcProvider{fn: func(JobInput) (Enrichment, error) {
-		arrived.Done()
-		<-release
-		return Enrichment{Seniority: "senior"}, nil
-	}}
-
-	allArrived := make(chan struct{})
-	go func() { arrived.Wait(); close(allArrived) }()
-
-	done := make(chan Stats)
-	go func() {
-		stats, err := Runner{Provider: prov, Store: store}.Run(context.Background(), opts())
-		if err != nil {
-			t.Errorf("Run: %v", err)
-		}
-		done <- stats
-	}()
-
-	select {
-	case <-allArrived:
-		close(release)
-	case <-time.After(2 * time.Second):
-		t.Fatal("workers did not run concurrently: not all entries reached the barrier (sequential drain)")
-	}
-
-	stats := <-done
-	if stats.Enriched != wave || stats.Failed != 0 {
-		t.Errorf("stats = %+v, want Enriched:%d", stats, wave)
-	}
-	if len(store.completed) != wave {
-		t.Errorf("completed = %d entries, want %d", len(store.completed), wave)
-	}
-}
+// Wave-level parallelism (multiple claimed entries processed concurrently) is now
+// internal/outbox's responsibility, covered generically by
+// TestRunPool_RunsUpToConcurrencyItemsInParallel — no need to re-prove it here with a
+// real Provider fake.
 
 func TestRun_jobFetchErrorIsFailed(t *testing.T) {
 	store := &fakeStore{

--- a/internal/maillink/runner.go
+++ b/internal/maillink/runner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/mailclassify"
 	"github.com/strelov1/freehire/internal/mailmatch"
+	"github.com/strelov1/freehire/internal/outbox"
 )
 
 const (
@@ -121,49 +122,70 @@ func (r *Runner) WithLearner(l Learner) *Runner {
 
 // Run enqueues every unclassified email, then drains the outbox wave by wave
 // until it is empty.
-// Stats is what a run reports upward. Failed counts entries whose processing errored this
-// run; DeadLettered counts the subset that reached max_attempts and will not be retried.
-// cmd/classify-mail turns them into its exit code, so a mail queue that quietly stops working
-// is visible to the scheduler rather than only in journalctl.
+// Stats is what a run reports upward. Failed and DeadLettered are mutually
+// exclusive — a dead-lettered entry counts only in DeadLettered, matching
+// internal/outbox.Outcome's one-outcome-per-item shape (and applyform/adzunadesc's
+// RunStats, migrated onto the same shared runner just before this package: see
+// applyform.RunStats' doc comment for the pre-migration double-count this convention
+// corrects). cmd/classify-mail turns them into its exit code, so a mail queue that
+// quietly stops working is visible to the scheduler rather than only in journalctl.
 type Stats struct {
 	Failed       int
 	DeadLettered int
 }
 
+// claimAdapter adapts Store to outbox.Claimer: Store.ClaimBatch takes its two size
+// arguments in the opposite order (leaseSeconds, batchSize) from outbox.Claimer's
+// Claim(ctx, batch, leaseSeconds).
+type claimAdapter struct {
+	store Store
+}
+
+func (c claimAdapter) Claim(ctx context.Context, batch, leaseSeconds int) ([]Claimed, error) {
+	return c.store.ClaimBatch(ctx, leaseSeconds, batch)
+}
+
 func (r *Runner) Run(ctx context.Context) (Stats, error) {
-	var stats Stats
 	if _, err := r.store.EnqueuePending(ctx); err != nil {
-		return stats, err
+		return Stats{}, err
 	}
 	// A wave is mostly one user's mail, and their application list is the same for
 	// every message in it — see appCache for why the thread links are NOT cached
-	// alongside it.
-	apps := appCache{store: r.store, byUser: map[int64][]Application{}}
-	for {
-		batch, err := r.store.ClaimBatch(ctx, r.leaseSeconds, r.batchSize)
-		if err != nil {
-			return stats, err
+	// alongside it. Created once for the whole Run (not per wave), exactly as before:
+	// the closure below captures it, and outbox.RunPool calls that same closure across
+	// every wave in this Run.
+	cache := appCache{store: r.store, byUser: map[int64][]Application{}}
+	result, err := outbox.RunPool(ctx, claimAdapter{store: r.store}, outbox.RunOptions{
+		BatchSize:    r.batchSize,
+		LeaseSeconds: r.leaseSeconds,
+		// Strictly sequential — no goroutine spawned at all (see internal/outbox's
+		// Claimer doc comment on RunPool's Concurrency<=1 branch). appCache.byUser is
+		// a plain, non-synchronized map, and a later message in the same thread must
+		// see the same wave's earlier link (ThreadLinks is read live, not cached) —
+		// both require true in-order processing, not just a small pool.
+		Concurrency: 1,
+	}, func(ctx context.Context, c Claimed) outbox.Outcome {
+		err := r.process(ctx, cache, c)
+		if err == nil {
+			return outbox.Succeeded
 		}
-		if len(batch) == 0 {
-			return stats, nil
+		deadLettered, ferr := r.store.Fail(ctx, c.OutboxID, err.Error(), r.maxAttempts)
+		if ferr != nil {
+			// The dead-letter state is unknown and is not guessed — it still counts as
+			// failed (the entry is left to its lease expiry either way).
+			log.Printf("maillink: fail outbox %d: %v", c.OutboxID, ferr)
+			return outbox.Failed
 		}
-		for _, c := range batch {
-			if err := r.process(ctx, apps, c); err != nil {
-				stats.Failed++
-				// Tallied where the bookkeeping error is already logged: a Fail that itself
-				// fails leaves the entry to its lease expiry, so it counts as failed but its
-				// dead-letter state is unknown and is not guessed.
-				deadLettered, ferr := r.store.Fail(ctx, c.OutboxID, err.Error(), r.maxAttempts)
-				if ferr != nil {
-					log.Printf("maillink: fail outbox %d: %v", c.OutboxID, ferr)
-					continue
-				}
-				if deadLettered {
-					stats.DeadLettered++
-				}
-			}
+		if deadLettered {
+			return outbox.DeadLettered
 		}
+		return outbox.Failed
+	})
+	stats := Stats{Failed: result.Failed, DeadLettered: result.DeadLettered}
+	if err != nil {
+		return stats, err
 	}
+	return stats, nil
 }
 
 // appCache memoises one user's applications for the length of a run.

--- a/internal/maillink/runner_test.go
+++ b/internal/maillink/runner_test.go
@@ -250,8 +250,10 @@ func TestRunnerTalliesFailuresAndDeadLetters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if stats.Failed != 2 || stats.DeadLettered != 2 {
-		t.Errorf("stats = %+v, want Failed=2 DeadLettered=2", stats)
+	// Failed and DeadLettered are mutually exclusive (see Stats' doc comment) — a
+	// dead-lettered entry counts only in DeadLettered, not also in Failed.
+	if stats.Failed != 0 || stats.DeadLettered != 2 {
+		t.Errorf("stats = %+v, want Failed=0 DeadLettered=2", stats)
 	}
 	if store.failCalls != 2 {
 		t.Errorf("Fail called %d times, want 2", store.failCalls)

--- a/internal/maillink/runner_test.go
+++ b/internal/maillink/runner_test.go
@@ -10,22 +10,26 @@ import (
 )
 
 type fakeStore struct {
-	appsReads   int
-	threadReads int
-	apps        []Application
-	threadLinks map[string]int64
-	stage       string
-	claimed     []Claimed
-	claimedOnce bool
-	saved       []Result
-	savedOutbox []int64
-	failCalls   int
-	deadLetter  bool
-	failErr     error
+	appsReads       int
+	threadReads     int
+	apps            []Application
+	threadLinks     map[string]int64
+	stage           string
+	claimed         []Claimed
+	claimedOnce     bool
+	gotLeaseSeconds int
+	gotBatchSize    int
+	saved           []Result
+	savedOutbox     []int64
+	failCalls       int
+	deadLetter      bool
+	failErr         error
 }
 
 func (s *fakeStore) EnqueuePending(context.Context) (int64, error) { return 0, nil }
-func (s *fakeStore) ClaimBatch(context.Context, int, int) ([]Claimed, error) {
+func (s *fakeStore) ClaimBatch(_ context.Context, leaseSeconds, batchSize int) ([]Claimed, error) {
+	s.gotLeaseSeconds = leaseSeconds
+	s.gotBatchSize = batchSize
 	if s.claimedOnce {
 		return nil, nil
 	}
@@ -44,6 +48,21 @@ func (s *fakeStore) CurrentStage(context.Context, int64, int64) (string, error) 
 func (s *fakeStore) Save(_ context.Context, outboxID, _ int64, r Result, _ string) error {
 	s.saved = append(s.saved, r)
 	s.savedOutbox = append(s.savedOutbox, outboxID)
+	// Mirrors the real Store: linking an email writes job_id onto it, and
+	// ThreadLinks derives the thread->job map from already-written emails — so a
+	// link this save just made must be visible to ThreadLinks for the rest of the
+	// wave. Looked up by outboxID since Result carries no ThreadID of its own.
+	if r.JobID != 0 {
+		for _, c := range s.claimed {
+			if c.OutboxID == outboxID {
+				if s.threadLinks == nil {
+					s.threadLinks = map[string]int64{}
+				}
+				s.threadLinks[c.ThreadID] = r.JobID
+				break
+			}
+		}
+	}
 	return nil
 }
 
@@ -230,6 +249,65 @@ func TestRunnerReadsApplicationsOncePerUserButThreadLinksEveryTime(t *testing.T)
 	if store.threadReads != 3 {
 		t.Errorf("ThreadLinks read %d times for 3 emails, want 3 — a link written mid-wave must be visible to the rest of it",
 			store.threadReads)
+	}
+}
+
+// This is the property the whole migration onto outbox.RunPool's sequential
+// (Concurrency: 1, no-goroutine) branch exists to preserve: a second email in the
+// same thread, with no name match of its own, must still resolve to the first
+// email's job via thread continuity — which only works if the first email's Save
+// (writing the link) fully completes before the second email's ThreadLinks read
+// begins. A concurrent (or reordered) implementation would make this flaky at best.
+func TestRunnerAppliesThreadContinuityWithinTheSameWave(t *testing.T) {
+	store := &fakeStore{
+		apps: []Application{{JobID: 5, Company: "Acme"}},
+		claimed: []Claimed{
+			{
+				OutboxID: 1, EmailID: 100, UserID: 1, ThreadID: "t1",
+				FromName: "Acme Hiring Team", Subject: "Acme Application Update",
+			},
+			{
+				// No extractable/matching company name of its own — can only resolve via
+				// the thread-continuity tier, which requires message 1's freshly-written
+				// link to already be visible.
+				OutboxID: 2, EmailID: 101, UserID: 1, ThreadID: "t1",
+				FromName: "Jane Doe", Subject: "Re: your interview",
+			},
+		},
+	}
+	cls := &fakeClassifier{out: mailclassify.Classification{Signal: mailclassify.SignalInterviewInvitation, Confidence: 0.95}}
+	r := New(store, cls, "test-model")
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(store.saved) != 2 {
+		t.Fatalf("saved %d results, want 2", len(store.saved))
+	}
+	if store.saved[0].JobID != 5 {
+		t.Fatalf("message 1 = %+v, want auto-linked to job 5 by name match", store.saved[0])
+	}
+	if store.saved[1].JobID != 5 {
+		t.Errorf("message 2 = %+v, want linked to job 5 via same-wave thread continuity", store.saved[1])
+	}
+}
+
+// claimAdapter bridges Store.ClaimBatch's reversed argument order
+// (leaseSeconds, batchSize) to outbox.Claimer.Claim's (batch, leaseSeconds). Both are
+// plain ints, so a positional swap here would compile silently and pass any test that
+// doesn't check which value landed where.
+func TestClaimAdapterPassesBatchAndLeaseSecondsToCorrectPositions(t *testing.T) {
+	store := &fakeStore{}
+	adapter := claimAdapter{store: store}
+
+	if _, err := adapter.Claim(context.Background(), 7, 42); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if store.gotBatchSize != 7 {
+		t.Errorf("Store.ClaimBatch's batchSize = %d, want 7", store.gotBatchSize)
+	}
+	if store.gotLeaseSeconds != 42 {
+		t.Errorf("Store.ClaimBatch's leaseSeconds = %d, want 42", store.gotLeaseSeconds)
 	}
 }
 

--- a/internal/outbox/runner.go
+++ b/internal/outbox/runner.go
@@ -45,12 +45,18 @@ type Claimer[C any] interface {
 	Claim(ctx context.Context, batch, leaseSeconds int) ([]C, error)
 }
 
-// RunOptions are the per-run knobs.
+// RunOptions are the per-run knobs. MaxAttempts and any per-call timeout are
+// deliberately absent here — they govern a single Processor call's own retry/timeout
+// behavior, which stays inside each caller's closure alongside its Store calls, not in
+// the shared loop.
 type RunOptions struct {
 	BatchSize    int
 	LeaseSeconds int
-	Concurrency  int
-	// MaxPerRun bounds how much of the backlog one Run takes; 0 is unbounded.
+	// Concurrency is RunPool-only; RunBatch ignores it (its concurrency lives inside
+	// whatever the caller's BatchProcessor does in one call).
+	Concurrency int
+	// MaxPerRun bounds how much of the backlog one Run takes, shared by RunPool and
+	// RunBatch; 0 is unbounded.
 	MaxPerRun int
 }
 
@@ -67,13 +73,9 @@ type Processor[C any] func(ctx context.Context, item C) Outcome
 func RunPool[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, process Processor[C]) (Stats, error) {
 	var stats Stats
 	for {
-		batchSize := opt.BatchSize
-		if opt.MaxPerRun > 0 {
-			remaining := opt.MaxPerRun - processed(stats)
-			if remaining <= 0 {
-				return stats, nil
-			}
-			batchSize = min(batchSize, remaining)
+		batchSize, budgetSpent := nextBatchSize(opt, stats)
+		if budgetSpent {
+			return stats, nil
 		}
 		batch, err := claimer.Claim(ctx, batchSize, opt.LeaseSeconds)
 		if err != nil {
@@ -104,7 +106,11 @@ type BatchProcessor[C any] func(ctx context.Context, items []C) error
 func RunBatch[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, processBatch BatchProcessor[C], processOne Processor[C]) (Stats, error) {
 	var stats Stats
 	for {
-		batch, err := claimer.Claim(ctx, opt.BatchSize, opt.LeaseSeconds)
+		batchSize, budgetSpent := nextBatchSize(opt, stats)
+		if budgetSpent {
+			return stats, nil
+		}
+		batch, err := claimer.Claim(ctx, batchSize, opt.LeaseSeconds)
 		if err != nil {
 			return stats, err
 		}
@@ -142,8 +148,19 @@ func runPoolWave[C any](ctx context.Context, batch []C, concurrency int, process
 	wg.Wait()
 }
 
-func processed(s Stats) int {
-	return s.Succeeded + s.Failed + s.DeadLettered + s.Discarded
+// nextBatchSize applies opt.MaxPerRun (shared by RunPool and RunBatch) to
+// opt.BatchSize, reporting whether the budget is already spent — in which case the
+// caller must stop without claiming again.
+func nextBatchSize(opt RunOptions, stats Stats) (size int, budgetSpent bool) {
+	if opt.MaxPerRun <= 0 {
+		return opt.BatchSize, false
+	}
+	processed := stats.Succeeded + stats.Failed + stats.DeadLettered + stats.Discarded
+	remaining := opt.MaxPerRun - processed
+	if remaining <= 0 {
+		return 0, true
+	}
+	return min(opt.BatchSize, remaining), false
 }
 
 func tally(stats *Stats, o Outcome) {

--- a/internal/outbox/runner.go
+++ b/internal/outbox/runner.go
@@ -103,14 +103,25 @@ func RunPool[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, pro
 }
 
 // BatchProcessor handles a whole wave in one call (e.g. one Meilisearch bulk push).
-// A nil error means every item in the wave succeeded and was already completed by
-// the call; a non-nil error means the whole wave failed and RunBatch falls back to
-// processing it item by item through Processor.
-type BatchProcessor[C any] func(ctx context.Context, items []C) error
+// A nil error means the closure fully handled every item itself — including any
+// internal sub-grouping and its own per-item fallback, as internal/embed's open/closed
+// split does — and the returned Stats is trusted verbatim; RunBatch adds it to the
+// running total and does NOT also invoke Processor. A non-nil error means the call
+// itself failed outright (the closure could not attempt anything) and RunBatch falls
+// back to processing the wave item by item through Processor; the returned Stats is
+// ignored in that case.
+//
+// Returning (Stats{}, nil) — no error, an all-zero Stats — is deliberately meaningful:
+// it says "I chose to do nothing with this wave" (e.g. a call context merely timed out,
+// so the closure leaves the wave claimed for a later run's lease-expiry retry rather
+// than falling back per-item, which would turn one slow-but-fine batch into many
+// equally slow calls). RunBatch tallies nothing for that wave and does not fall back.
+type BatchProcessor[C any] func(ctx context.Context, items []C) (Stats, error)
 
 // RunBatch drains via one BatchProcessor call per wave, falling back to per-item
-// Processor calls only when the batch call itself fails — so one poison/corrupted
-// item can't sink an otherwise-healthy wave.
+// Processor calls only when the batch call itself fails outright — so one
+// poison/corrupted item can't sink an otherwise-healthy wave, and a closure that
+// handles its own sub-grouping/fallback (internal/embed) never gets double-processed.
 func RunBatch[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, processBatch BatchProcessor[C], processOne Processor[C]) (Stats, error) {
 	var stats Stats
 	for {
@@ -125,12 +136,16 @@ func RunBatch[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, pr
 		if len(batch) == 0 {
 			return stats, nil
 		}
-		if err := processBatch(ctx, batch); err != nil {
+		waveStats, err := processBatch(ctx, batch)
+		if err != nil {
 			for _, item := range batch {
 				tally(&stats, processOne(ctx, item))
 			}
 		} else {
-			stats.Succeeded += len(batch)
+			stats.Succeeded += waveStats.Succeeded
+			stats.Failed += waveStats.Failed
+			stats.DeadLettered += waveStats.DeadLettered
+			stats.Discarded += waveStats.Discarded
 		}
 		if opt.OnWave != nil {
 			opt.OnWave(stats)

--- a/internal/outbox/runner.go
+++ b/internal/outbox/runner.go
@@ -1,0 +1,160 @@
+// Package outbox is the shared claim-wave drain loop behind every Postgres outbox
+// queue worker in this repo. It owns the loop, not the queue: claim a wave, process
+// it, tally the outcome, repeat until a claim comes back empty. Each caller keeps its
+// own Store/Indexer/Provider port and its own Complete/Fail/Discard logic; Runner
+// never touches persistence itself.
+package outbox
+
+import (
+	"context"
+	"sync"
+)
+
+// Outcome is what a Processor did with one claimed item. The caller has already made
+// whatever Store call follows from it (Complete, Fail, Discard); Runner only tallies.
+type Outcome int
+
+const (
+	Succeeded Outcome = iota
+	Failed
+	DeadLettered
+	Discarded
+)
+
+// Stats is what one Run did.
+type Stats struct {
+	Succeeded    int
+	Failed       int
+	DeadLettered int
+	Discarded    int
+}
+
+// Claimer leases up to batch live, unleased entries — the shape every package's
+// existing Store.Claim method already has.
+//
+// Deliberately absent: Runner has no built-in context-cancellation early-exit. Two of
+// its four RunPool callers (applyform, adzunadesc) return (stats, nil) as soon as a
+// wave finishes if ctx is cancelled, so a shutdown doesn't burn the rest of a large
+// backlog's retry attempts; the other two (enrich, maillink) let a cancelled ctx
+// surface as an ordinary error from the next Claim call. Baking either behavior into
+// Runner would silently change the other callers' exit code on SIGTERM. A caller that
+// wants the early-exit implements it in its own Claim wrapper: check ctx.Err() first
+// and return (nil, nil) instead of querying — Runner's normal empty-batch stop then
+// reproduces the exact same outcome.
+type Claimer[C any] interface {
+	Claim(ctx context.Context, batch, leaseSeconds int) ([]C, error)
+}
+
+// RunOptions are the per-run knobs.
+type RunOptions struct {
+	BatchSize    int
+	LeaseSeconds int
+	Concurrency  int
+	// MaxPerRun bounds how much of the backlog one Run takes; 0 is unbounded.
+	MaxPerRun int
+}
+
+// Processor handles one claimed item end to end, including whatever Store.Complete /
+// Store.Fail / Store.Discard call follows, and reports what happened.
+type Processor[C any] func(ctx context.Context, item C) Outcome
+
+// RunPool drains via a bounded pool when opt.Concurrency > 1. At Concurrency <= 1 it
+// processes the wave as a plain sequential loop — no goroutine is spawned at all — so
+// a caller that needs in-order processing (internal/maillink, where a later message in
+// a thread must see the same wave's earlier link) gets a real ordering guarantee: Go's
+// channel semantics between blocked senders are not formally FIFO, so a size-1
+// semaphore-gated pool would not have been a safe substitute for a literal loop.
+func RunPool[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, process Processor[C]) (Stats, error) {
+	var stats Stats
+	for {
+		batchSize := opt.BatchSize
+		if opt.MaxPerRun > 0 {
+			remaining := opt.MaxPerRun - processed(stats)
+			if remaining <= 0 {
+				return stats, nil
+			}
+			batchSize = min(batchSize, remaining)
+		}
+		batch, err := claimer.Claim(ctx, batchSize, opt.LeaseSeconds)
+		if err != nil {
+			return stats, err
+		}
+		if len(batch) == 0 {
+			return stats, nil
+		}
+		if opt.Concurrency <= 1 {
+			for _, item := range batch {
+				tally(&stats, process(ctx, item))
+			}
+		} else {
+			runPoolWave(ctx, batch, opt.Concurrency, process, &stats)
+		}
+	}
+}
+
+// BatchProcessor handles a whole wave in one call (e.g. one Meilisearch bulk push).
+// A nil error means every item in the wave succeeded and was already completed by
+// the call; a non-nil error means the whole wave failed and RunBatch falls back to
+// processing it item by item through Processor.
+type BatchProcessor[C any] func(ctx context.Context, items []C) error
+
+// RunBatch drains via one BatchProcessor call per wave, falling back to per-item
+// Processor calls only when the batch call itself fails — so one poison/corrupted
+// item can't sink an otherwise-healthy wave.
+func RunBatch[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, processBatch BatchProcessor[C], processOne Processor[C]) (Stats, error) {
+	var stats Stats
+	for {
+		batch, err := claimer.Claim(ctx, opt.BatchSize, opt.LeaseSeconds)
+		if err != nil {
+			return stats, err
+		}
+		if len(batch) == 0 {
+			return stats, nil
+		}
+		if err := processBatch(ctx, batch); err != nil {
+			for _, item := range batch {
+				tally(&stats, processOne(ctx, item))
+			}
+			continue
+		}
+		stats.Succeeded += len(batch)
+	}
+}
+
+func runPoolWave[C any](ctx context.Context, batch []C, concurrency int, process Processor[C], stats *Stats) {
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	slots := make(chan struct{}, concurrency)
+
+	for _, item := range batch {
+		wg.Add(1)
+		go func(it C) {
+			defer wg.Done()
+			slots <- struct{}{}
+			defer func() { <-slots }()
+
+			outcome := process(ctx, it)
+			mu.Lock()
+			tally(stats, outcome)
+			mu.Unlock()
+		}(item)
+	}
+	wg.Wait()
+}
+
+func processed(s Stats) int {
+	return s.Succeeded + s.Failed + s.DeadLettered + s.Discarded
+}
+
+func tally(stats *Stats, o Outcome) {
+	switch o {
+	case Succeeded:
+		stats.Succeeded++
+	case Failed:
+		stats.Failed++
+	case DeadLettered:
+		stats.DeadLettered++
+	case Discarded:
+		stats.Discarded++
+	}
+}

--- a/internal/outbox/runner.go
+++ b/internal/outbox/runner.go
@@ -58,6 +58,11 @@ type RunOptions struct {
 	// MaxPerRun bounds how much of the backlog one Run takes, shared by RunPool and
 	// RunBatch; 0 is unbounded.
 	MaxPerRun int
+	// OnWave, if set, is called after each wave is claimed and processed, with the
+	// cumulative Stats so far — the hook a caller's own per-wave progress-heartbeat
+	// log line (e.g. "enrich: progress enriched=... failed=... dead=...") is built
+	// from, so migrating onto Runner doesn't silently drop that log line.
+	OnWave func(Stats)
 }
 
 // Processor handles one claimed item end to end, including whatever Store.Complete /
@@ -91,6 +96,9 @@ func RunPool[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, pro
 		} else {
 			runPoolWave(ctx, batch, opt.Concurrency, process, &stats)
 		}
+		if opt.OnWave != nil {
+			opt.OnWave(stats)
+		}
 	}
 }
 
@@ -121,9 +129,12 @@ func RunBatch[C any](ctx context.Context, claimer Claimer[C], opt RunOptions, pr
 			for _, item := range batch {
 				tally(&stats, processOne(ctx, item))
 			}
-			continue
+		} else {
+			stats.Succeeded += len(batch)
 		}
-		stats.Succeeded += len(batch)
+		if opt.OnWave != nil {
+			opt.OnWave(stats)
+		}
 	}
 }
 

--- a/internal/outbox/runner_test.go
+++ b/internal/outbox/runner_test.go
@@ -15,17 +15,24 @@ type fakeClaimer struct {
 	waves          [][]int
 	calls          int
 	requestedBatch []int
+	// errOnCall, if set, makes the Nth Claim call (1-indexed) return errAfter instead
+	// of a wave.
+	errOnCall int
+	errAfter  error
 }
 
 func (f *fakeClaimer) Claim(ctx context.Context, batch, leaseSeconds int) ([]int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.requestedBatch = append(f.requestedBatch, batch)
-	if f.calls >= len(f.waves) {
+	f.calls++
+	if f.errOnCall != 0 && f.calls == f.errOnCall {
+		return nil, f.errAfter
+	}
+	if f.calls > len(f.waves) {
 		return nil, nil
 	}
-	w := f.waves[f.calls]
-	f.calls++
+	w := f.waves[f.calls-1]
 	return w, nil
 }
 
@@ -161,6 +168,74 @@ func TestRunPool_ConcurrencyOneProcessesInStrictSubmissionOrder(t *testing.T) {
 // which this test's claim-until-empty contract already covers generically —
 // TestRunPool_ProcessesAllItemsUntilClaimEmpty exercises the exact same path a
 // cancellation-aware Claimer would take.
+
+func TestRunPool_AbortsRunOnClaimError(t *testing.T) {
+	wantErr := errors.New("pool unreachable")
+	claimer := &fakeClaimer{waves: [][]int{{1, 2}}, errOnCall: 2, errAfter: wantErr}
+
+	var itemCalls int
+	process := func(ctx context.Context, item int) Outcome {
+		itemCalls++
+		return Succeeded
+	}
+
+	stats, err := RunPool(context.Background(), claimer, RunOptions{BatchSize: 2, LeaseSeconds: 60, Concurrency: 1}, process)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if stats.Succeeded != 2 {
+		t.Errorf("Succeeded = %d, want 2 (the first wave, processed before the failing claim)", stats.Succeeded)
+	}
+	if itemCalls != 2 {
+		t.Errorf("itemCalls = %d, want 2 (no processing should be attempted after a claim error)", itemCalls)
+	}
+}
+
+func TestRunBatch_AbortsRunOnClaimError(t *testing.T) {
+	wantErr := errors.New("pool unreachable")
+	claimer := &fakeClaimer{waves: [][]int{{1, 2}}, errOnCall: 2, errAfter: wantErr}
+
+	processBatch := func(ctx context.Context, items []int) error { return nil }
+	processOne := func(ctx context.Context, item int) Outcome { return Succeeded }
+
+	stats, err := RunBatch(context.Background(), claimer, RunOptions{BatchSize: 2, LeaseSeconds: 60}, processBatch, processOne)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if stats.Succeeded != 2 {
+		t.Errorf("Succeeded = %d, want 2 (the first wave, processed before the failing claim)", stats.Succeeded)
+	}
+}
+
+func TestRunBatch_MaxPerRunStopsAndShrinksNextClaim(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}, {4}}}
+	processBatch := func(ctx context.Context, items []int) error { return nil }
+	processOne := func(ctx context.Context, item int) Outcome { return Succeeded }
+
+	stats, err := RunBatch(context.Background(), claimer, RunOptions{
+		BatchSize:    3,
+		LeaseSeconds: 60,
+		MaxPerRun:    4,
+	}, processBatch, processOne)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Succeeded != 4 {
+		t.Errorf("Succeeded = %d, want 4", stats.Succeeded)
+	}
+	if claimer.calls != 2 {
+		t.Errorf("claim calls = %d, want 2 (must stop before a 3rd claim once budget is spent)", claimer.calls)
+	}
+	wantRequested := []int{3, 1}
+	if len(claimer.requestedBatch) != len(wantRequested) {
+		t.Fatalf("requestedBatch = %v, want %v", claimer.requestedBatch, wantRequested)
+	}
+	for i, want := range wantRequested {
+		if claimer.requestedBatch[i] != want {
+			t.Errorf("requestedBatch[%d] = %d, want %d (should shrink to the remaining budget)", i, claimer.requestedBatch[i], want)
+		}
+	}
+}
 
 func TestRunBatch_SucceedsWholeWaveViaOneBatchCall(t *testing.T) {
 	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}

--- a/internal/outbox/runner_test.go
+++ b/internal/outbox/runner_test.go
@@ -195,7 +195,7 @@ func TestRunBatch_AbortsRunOnClaimError(t *testing.T) {
 	wantErr := errors.New("pool unreachable")
 	claimer := &fakeClaimer{waves: [][]int{{1, 2}}, errOnCall: 2, errAfter: wantErr}
 
-	processBatch := func(ctx context.Context, items []int) error { return nil }
+	processBatch := func(ctx context.Context, items []int) (Stats, error) { return Stats{Succeeded: len(items)}, nil }
 	processOne := func(ctx context.Context, item int) Outcome { return Succeeded }
 
 	stats, err := RunBatch(context.Background(), claimer, RunOptions{BatchSize: 2, LeaseSeconds: 60}, processBatch, processOne)
@@ -209,7 +209,7 @@ func TestRunBatch_AbortsRunOnClaimError(t *testing.T) {
 
 func TestRunBatch_MaxPerRunStopsAndShrinksNextClaim(t *testing.T) {
 	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}, {4}}}
-	processBatch := func(ctx context.Context, items []int) error { return nil }
+	processBatch := func(ctx context.Context, items []int) (Stats, error) { return Stats{Succeeded: len(items)}, nil }
 	processOne := func(ctx context.Context, item int) Outcome { return Succeeded }
 
 	stats, err := RunBatch(context.Background(), claimer, RunOptions{
@@ -268,7 +268,7 @@ func TestRunPool_CallsOnWaveWithCumulativeStatsAfterEachWave(t *testing.T) {
 
 func TestRunBatch_CallsOnWaveWithCumulativeStatsAfterEachWave(t *testing.T) {
 	claimer := &fakeClaimer{waves: [][]int{{1, 2}, {3}}}
-	processBatch := func(ctx context.Context, items []int) error { return nil }
+	processBatch := func(ctx context.Context, items []int) (Stats, error) { return Stats{Succeeded: len(items)}, nil }
 	processOne := func(ctx context.Context, item int) Outcome { return Succeeded }
 
 	var seen []Stats
@@ -295,9 +295,9 @@ func TestRunBatch_SucceedsWholeWaveViaOneBatchCall(t *testing.T) {
 	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
 	var batchCalls, itemCalls int
 
-	processBatch := func(ctx context.Context, items []int) error {
+	processBatch := func(ctx context.Context, items []int) (Stats, error) {
 		batchCalls++
-		return nil
+		return Stats{Succeeded: len(items)}, nil
 	}
 	processOne := func(ctx context.Context, item int) Outcome {
 		itemCalls++
@@ -322,8 +322,8 @@ func TestRunBatch_SucceedsWholeWaveViaOneBatchCall(t *testing.T) {
 func TestRunBatch_FallsBackToPerItemOnBatchFailure(t *testing.T) {
 	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
 
-	processBatch := func(ctx context.Context, items []int) error {
-		return errors.New("meili down")
+	processBatch := func(ctx context.Context, items []int) (Stats, error) {
+		return Stats{}, errors.New("meili down")
 	}
 	var mu sync.Mutex
 	seen := map[int]bool{}
@@ -346,5 +346,72 @@ func TestRunBatch_FallsBackToPerItemOnBatchFailure(t *testing.T) {
 	}
 	if stats.Succeeded != 2 || stats.Failed != 1 {
 		t.Errorf("stats = %+v, want Succeeded=2 Failed=1", stats)
+	}
+}
+
+// TestRunBatch_ClosureReportsOwnPartialStatsWithoutOuterFallback covers a
+// BatchProcessor that internally splits its wave into sub-groups and handles each
+// with its own batch-attempt-then-per-item-fallback cycle (internal/embed's actual
+// shape: an open-jobs group and a closed-jobs group, each pushed as its own
+// Meilisearch call). Returning (Stats, nil) means "I fully handled every item myself,
+// including my own fallback" — RunBatch must trust the returned Stats verbatim and
+// must NOT also invoke its own processOne, which would re-process (and potentially
+// double-complete) items the closure already finished.
+func TestRunBatch_ClosureReportsOwnPartialStatsWithoutOuterFallback(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
+	var outerFallbackCalls int
+
+	// Simulates: item 1 succeeded via the group's batch call, items 2 and 3 failed
+	// and were already routed to Fail internally by the closure's own fallback.
+	processBatch := func(ctx context.Context, items []int) (Stats, error) {
+		return Stats{Succeeded: 1, Failed: 2}, nil
+	}
+	processOne := func(ctx context.Context, item int) Outcome {
+		outerFallbackCalls++
+		return Succeeded
+	}
+
+	stats, err := RunBatch(context.Background(), claimer, RunOptions{BatchSize: 3, LeaseSeconds: 60}, processBatch, processOne)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outerFallbackCalls != 0 {
+		t.Errorf("outer processOne was called %d times, want 0 (the closure already handled every item itself)", outerFallbackCalls)
+	}
+	if stats.Succeeded != 1 || stats.Failed != 2 {
+		t.Errorf("stats = %+v, want Succeeded=1 Failed=2 (trusted verbatim from the closure)", stats)
+	}
+}
+
+// TestRunBatch_ClosureCanSkipAWaveWithZeroStatsAndNilError covers the
+// skip-on-timeout shape (internal/embed, internal/searchdrain): a batch call whose
+// context merely expired leaves the wave claimed for a later run's lease-expiry
+// retry, rather than falling back per-item (which would turn one slow-but-fine batch
+// into many equally slow calls). Reporting (Stats{}, nil) must tally nothing and
+// must not trigger the outer per-item fallback either.
+func TestRunBatch_ClosureCanSkipAWaveWithZeroStatsAndNilError(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
+	var outerFallbackCalls int
+
+	processBatch := func(ctx context.Context, items []int) (Stats, error) {
+		return Stats{}, nil // "handled" (left claimed for lease-expiry retry), no outcome yet
+	}
+	processOne := func(ctx context.Context, item int) Outcome {
+		outerFallbackCalls++
+		return Succeeded
+	}
+
+	stats, err := RunBatch(context.Background(), claimer, RunOptions{BatchSize: 3, LeaseSeconds: 60}, processBatch, processOne)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outerFallbackCalls != 0 {
+		t.Errorf("outer processOne was called %d times, want 0", outerFallbackCalls)
+	}
+	if stats != (Stats{}) {
+		t.Errorf("stats = %+v, want zero value", stats)
+	}
+	if claimer.calls < 2 {
+		t.Errorf("claim calls = %d, want >=2 (the loop must keep going after a skipped wave, not stop)", claimer.calls)
 	}
 }

--- a/internal/outbox/runner_test.go
+++ b/internal/outbox/runner_test.go
@@ -237,6 +237,60 @@ func TestRunBatch_MaxPerRunStopsAndShrinksNextClaim(t *testing.T) {
 	}
 }
 
+func TestRunPool_CallsOnWaveWithCumulativeStatsAfterEachWave(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2}, {3}}}
+	process := func(ctx context.Context, item int) Outcome { return Succeeded }
+
+	var mu sync.Mutex
+	var seen []Stats
+	onWave := func(s Stats) {
+		mu.Lock()
+		seen = append(seen, s)
+		mu.Unlock()
+	}
+
+	_, err := RunPool(context.Background(), claimer, RunOptions{
+		BatchSize: 2, LeaseSeconds: 60, Concurrency: 1, OnWave: onWave,
+	}, process)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []Stats{{Succeeded: 2}, {Succeeded: 3}}
+	if len(seen) != len(want) {
+		t.Fatalf("OnWave calls = %v, want %v", seen, want)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Errorf("OnWave call %d = %+v, want %+v (must be cumulative, not per-wave delta)", i, seen[i], want[i])
+		}
+	}
+}
+
+func TestRunBatch_CallsOnWaveWithCumulativeStatsAfterEachWave(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2}, {3}}}
+	processBatch := func(ctx context.Context, items []int) error { return nil }
+	processOne := func(ctx context.Context, item int) Outcome { return Succeeded }
+
+	var seen []Stats
+	onWave := func(s Stats) { seen = append(seen, s) }
+
+	_, err := RunBatch(context.Background(), claimer, RunOptions{
+		BatchSize: 2, LeaseSeconds: 60, OnWave: onWave,
+	}, processBatch, processOne)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []Stats{{Succeeded: 2}, {Succeeded: 3}}
+	if len(seen) != len(want) {
+		t.Fatalf("OnWave calls = %v, want %v", seen, want)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Errorf("OnWave call %d = %+v, want %+v", i, seen[i], want[i])
+		}
+	}
+}
+
 func TestRunBatch_SucceedsWholeWaveViaOneBatchCall(t *testing.T) {
 	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
 	var batchCalls, itemCalls int

--- a/internal/outbox/runner_test.go
+++ b/internal/outbox/runner_test.go
@@ -1,0 +1,221 @@
+package outbox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClaimer replays a fixed sequence of waves, then returns empty forever —
+// the shape every real Store.Claim has (a lease-bounded batch, empty when drained).
+type fakeClaimer struct {
+	mu             sync.Mutex
+	waves          [][]int
+	calls          int
+	requestedBatch []int
+}
+
+func (f *fakeClaimer) Claim(ctx context.Context, batch, leaseSeconds int) ([]int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requestedBatch = append(f.requestedBatch, batch)
+	if f.calls >= len(f.waves) {
+		return nil, nil
+	}
+	w := f.waves[f.calls]
+	f.calls++
+	return w, nil
+}
+
+func TestRunPool_ProcessesAllItemsUntilClaimEmpty(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}, {4, 5}}}
+
+	var mu sync.Mutex
+	processed := map[int]bool{}
+	process := func(ctx context.Context, item int) Outcome {
+		mu.Lock()
+		processed[item] = true
+		mu.Unlock()
+		return Succeeded
+	}
+
+	stats, err := RunPool(context.Background(), claimer, RunOptions{BatchSize: 3, LeaseSeconds: 60, Concurrency: 2}, process)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Succeeded != 5 {
+		t.Errorf("Succeeded = %d, want 5", stats.Succeeded)
+	}
+	for _, id := range []int{1, 2, 3, 4, 5} {
+		if !processed[id] {
+			t.Errorf("item %d was never processed", id)
+		}
+	}
+}
+
+func TestRunPool_RunsUpToConcurrencyItemsInParallel(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
+
+	arrived := make(chan int, 3)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	doRelease := func() { releaseOnce.Do(func() { close(release) }) }
+	defer doRelease()
+
+	process := func(ctx context.Context, item int) Outcome {
+		arrived <- item
+		<-release
+		return Succeeded
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = RunPool(context.Background(), claimer, RunOptions{BatchSize: 3, LeaseSeconds: 60, Concurrency: 3}, process)
+	}()
+
+	// All 3 items must arrive concurrently — proves they are not serialized one
+	// at a time behind each other's <-release wait.
+	for i := 0; i < 3; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for concurrent arrivals; got %d/3", i)
+		}
+	}
+	doRelease()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunPool did not return after release")
+	}
+}
+
+func TestRunPool_MaxPerRunStopsAndShrinksNextClaim(t *testing.T) {
+	// Wave two carries only 1 item — a real Store.Claim would truncate to the
+	// shrunk batch size; this fake just needs the data shaped for it.
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}, {4}}}
+	process := func(ctx context.Context, item int) Outcome { return Succeeded }
+
+	stats, err := RunPool(context.Background(), claimer, RunOptions{
+		BatchSize:    3,
+		LeaseSeconds: 60,
+		Concurrency:  1,
+		MaxPerRun:    4,
+	}, process)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Succeeded != 4 {
+		t.Errorf("Succeeded = %d, want 4", stats.Succeeded)
+	}
+	if claimer.calls != 2 {
+		t.Errorf("claim calls = %d, want 2 (must stop before a 3rd claim once budget is spent)", claimer.calls)
+	}
+	wantRequested := []int{3, 1}
+	if len(claimer.requestedBatch) != len(wantRequested) {
+		t.Fatalf("requestedBatch = %v, want %v", claimer.requestedBatch, wantRequested)
+	}
+	for i, want := range wantRequested {
+		if claimer.requestedBatch[i] != want {
+			t.Errorf("requestedBatch[%d] = %d, want %d (should shrink to the remaining budget)", i, claimer.requestedBatch[i], want)
+		}
+	}
+}
+
+func TestRunPool_ConcurrencyOneProcessesInStrictSubmissionOrder(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
+
+	// order is deliberately unsynchronized: any concurrent access here is a data
+	// race (catch with `go test -race`), which a true sequential loop can't trigger.
+	var order []int
+	process := func(ctx context.Context, item int) Outcome {
+		if item == 1 {
+			// If items ran concurrently, 2 and 3 would very likely finish first.
+			time.Sleep(20 * time.Millisecond)
+		}
+		order = append(order, item)
+		return Succeeded
+	}
+
+	_, err := RunPool(context.Background(), claimer, RunOptions{BatchSize: 3, LeaseSeconds: 60, Concurrency: 1}, process)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []int{1, 2, 3}
+	if len(order) != len(want) {
+		t.Fatalf("order = %v, want %v", order, want)
+	}
+	for i, id := range want {
+		if order[i] != id {
+			t.Errorf("order[%d] = %d, want %d", i, order[i], id)
+		}
+	}
+}
+
+// Runner has no built-in context-cancellation handling (see the Claimer doc comment
+// for why); a Claimer that wants a clean stop on cancellation returns an empty batch,
+// which this test's claim-until-empty contract already covers generically —
+// TestRunPool_ProcessesAllItemsUntilClaimEmpty exercises the exact same path a
+// cancellation-aware Claimer would take.
+
+func TestRunBatch_SucceedsWholeWaveViaOneBatchCall(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
+	var batchCalls, itemCalls int
+
+	processBatch := func(ctx context.Context, items []int) error {
+		batchCalls++
+		return nil
+	}
+	processOne := func(ctx context.Context, item int) Outcome {
+		itemCalls++
+		return Succeeded
+	}
+
+	stats, err := RunBatch(context.Background(), claimer, RunOptions{BatchSize: 3, LeaseSeconds: 60}, processBatch, processOne)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if batchCalls != 1 {
+		t.Errorf("batchCalls = %d, want 1", batchCalls)
+	}
+	if itemCalls != 0 {
+		t.Errorf("itemCalls = %d, want 0 (fallback must not run when the batch call succeeds)", itemCalls)
+	}
+	if stats.Succeeded != 3 {
+		t.Errorf("Succeeded = %d, want 3", stats.Succeeded)
+	}
+}
+
+func TestRunBatch_FallsBackToPerItemOnBatchFailure(t *testing.T) {
+	claimer := &fakeClaimer{waves: [][]int{{1, 2, 3}}}
+
+	processBatch := func(ctx context.Context, items []int) error {
+		return errors.New("meili down")
+	}
+	var mu sync.Mutex
+	seen := map[int]bool{}
+	processOne := func(ctx context.Context, item int) Outcome {
+		mu.Lock()
+		seen[item] = true
+		mu.Unlock()
+		if item == 2 {
+			return Failed
+		}
+		return Succeeded
+	}
+
+	stats, err := RunBatch(context.Background(), claimer, RunOptions{BatchSize: 3, LeaseSeconds: 60}, processBatch, processOne)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(seen) != 3 {
+		t.Errorf("per-item fallback saw %d items, want 3", len(seen))
+	}
+	if stats.Succeeded != 2 || stats.Failed != 1 {
+		t.Errorf("stats = %+v, want Succeeded=2 Failed=1", stats)
+	}
+}

--- a/internal/searchdrain/runner.go
+++ b/internal/searchdrain/runner.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/outbox"
 	"github.com/strelov1/freehire/internal/pgerr"
 )
 
@@ -83,18 +84,20 @@ type Runner struct {
 // entry is recorded and never aborts the run.
 func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
 	rn := &run{store: r.Store, indexer: r.Indexer, opt: opt}
-	for {
-		batch, err := r.Store.Claim(ctx, opt.BatchSize, opt.LeaseSeconds)
-		if err != nil {
-			return rn.stats, fmt.Errorf("claim: %w", err)
-		}
-		if len(batch) == 0 {
-			return rn.stats, nil
-		}
-		rn.processBatch(ctx, batch)
-		log.Printf("search-drain: progress indexed=%d failed=%d dead=%d",
-			rn.stats.Indexed, rn.stats.Failed, rn.stats.DeadLettered)
+	_, err := outbox.RunBatch(ctx, r.Store, outbox.RunOptions{
+		BatchSize:    opt.BatchSize,
+		LeaseSeconds: opt.LeaseSeconds,
+		OnWave: func(outbox.Stats) {
+			// A heartbeat per wave so a long drain shows running totals instead of
+			// going silent for hours.
+			log.Printf("search-drain: progress indexed=%d failed=%d dead=%d",
+				rn.stats.Indexed, rn.stats.Failed, rn.stats.DeadLettered)
+		},
+	}, rn.processWave, rn.unreachableFallback)
+	if err != nil {
+		return rn.stats, fmt.Errorf("claim: %w", err)
 	}
+	return rn.stats, nil
 }
 
 // run accumulates one Run's options and tallies. Waves are processed sequentially,
@@ -104,6 +107,28 @@ type run struct {
 	indexer Indexer
 	opt     RunOptions
 	stats   Stats
+}
+
+// processWave is search-drain's outbox.BatchProcessor: run the existing
+// batch-attempt-then-per-item-fallback cycle (processBatch, unchanged below) and
+// report this wave's delta. Always returns a nil error — processBatch fully handles
+// every item itself (including its own fallback and skipOnTimeout), so
+// outbox.RunBatch's outer per-item Processor (unreachableFallback) is never invoked.
+func (rn *run) processWave(ctx context.Context, batch []Claimed) (outbox.Stats, error) {
+	before := rn.stats
+	rn.processBatch(ctx, batch)
+	return outbox.Stats{
+		Succeeded:    rn.stats.Indexed - before.Indexed,
+		Failed:       rn.stats.Failed - before.Failed,
+		DeadLettered: rn.stats.DeadLettered - before.DeadLettered,
+	}, nil
+}
+
+// unreachableFallback satisfies outbox.RunBatch's Processor parameter. processWave
+// never returns an error, so outbox.RunBatch never calls this — panicking documents
+// that invariant rather than silently returning a fabricated outcome.
+func (rn *run) unreachableFallback(context.Context, Claimed) outbox.Outcome {
+	panic("search-drain: outer per-item fallback invoked, but processWave never returns an error")
 }
 
 // processBatch indexes a whole wave in one batch and completes it in one call. Any

--- a/openspec/changes/outbox-runner-unification/design.md
+++ b/openspec/changes/outbox-runner-unification/design.md
@@ -32,6 +32,16 @@ document carries the decisions forward into OpenSpec's tracked format.
 
 ## Decisions
 
+- **`RunOptions` carries no `MaxAttempts` or per-call timeout.** The brainstorming
+  design doc's illustrative sketch
+  (`docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md`) included
+  both, but the actual `internal/outbox` implementation omits them: both govern a
+  single `Processor` call's own retry/timeout behavior, which lives inside each
+  caller's closure alongside its own `Store` calls (confirmed against `applyform`,
+  `adzunadesc`, `embed`, `searchdrain`'s existing `RunOptions`), not in the shared
+  loop. Noted here explicitly so the deviation from that earlier sketch reads as
+  intentional, not an oversight.
+
 - **Keep six separate tables; do not merge into one generic outbox table.**
   Alternative considered: a single physical table with a `queue` discriminator
   and a JSONB payload. Rejected because it would put all six queues' insert/
@@ -87,6 +97,20 @@ document carries the decisions forward into OpenSpec's tracked format.
   runner having to model it. The runner only tallies whichever `Outcome`
   (`Succeeded`/`Failed`/`DeadLettered`/`Discarded`) the closure reports.
 
+- **`RunPool`/`RunBatch` have no built-in context-cancellation early-exit.**
+  Discovered mid-implementation: only two of the four `RunPool` callers
+  (`applyform`, `adzunadesc`) check `ctx.Err()` after a wave and return
+  `(stats, nil)` to avoid burning a large backlog's retry attempts on
+  shutdown; `enrich` and `maillink` have no such check today and instead let a
+  cancelled context surface as an ordinary error from the next `Claim` call.
+  Baking either behavior into the shared runner would silently change the
+  other pair's exit code on SIGTERM — exactly the kind of behavior change this
+  change promises not to make. Resolution: `internal/outbox` stays
+  cancellation-agnostic; `applyform` and `adzunadesc`'s own `Claimer` adapters
+  reproduce their historical early-exit locally (check `ctx.Err()` first,
+  return `(nil, nil)` instead of querying — the runner's ordinary
+  empty-batch-stops-cleanly path then reproduces the exact same outcome).
+
 - **All six workers migrate in one change, not a phased rollout.** The per-queue
   diff is small (swap an internal loop, not any external contract), and the
   queues are similar enough that a multi-week phased migration would only leave
@@ -97,8 +121,9 @@ document carries the decisions forward into OpenSpec's tracked format.
 - [Risk] A subtle behavior change in the shared loop (e.g. lease-timing edge
   case) would affect all six workers at once instead of just one. → Mitigation:
   `internal/outbox` gets its own unit tests covering claim-until-empty
-  termination, `MaxPerRun` budget shrinking, context cancellation, and the
-  batch-failure-triggers-fallback path — the loop mechanics currently
+  termination, `MaxPerRun` budget shrinking, `RunPool`'s sequential-vs-pooled
+  branching, and the batch-failure-triggers-fallback path — the loop mechanics
+  currently
   duplicated (and separately tested) six times move to one well-tested place
   instead of six less-scrutinized copies.
 - [Risk] `internal/maillink`'s `Store.ClaimBatch(ctx, leaseSeconds, batchSize)`

--- a/openspec/changes/outbox-runner-unification/design.md
+++ b/openspec/changes/outbox-runner-unification/design.md
@@ -1,0 +1,130 @@
+## Context
+
+Six Postgres-backed work queues drive six independent worker packages, each with
+its own hand-rolled claim/lease/retry drain loop: `enrichment_outbox`
+(`internal/enrich`), `semantic_outbox` (`internal/embed`), `search_outbox`
+(`internal/searchdrain`), `apply_form_outbox` (`internal/applyform`),
+`adzuna_description_outbox` (`internal/adzunadesc`), and
+`email_classification_outbox` (`internal/maillink`). The six queue tables are
+already structurally near-identical (`id, <subject>_id, attempts, claimed_at,
+failed_at, last_error, created_at` + a partial claimable index), and the claim
+loop was deliberately copied from package to package (SQL comments say "Mirrors
+ClaimSemanticBatch", "Mirrors ClaimApplyFormBatch"). Full research (schema dumps,
+runner code excerpts, inventory of all six queues) lives in
+`docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md`; this
+document carries the decisions forward into OpenSpec's tracked format.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extract the duplicated claim-wave drain loop into one generic `internal/outbox`
+  package, so a seventh queue only needs its own `Store` port and processing
+  logic, not a seventh copy of the loop.
+- Preserve every worker's exact external behavior: retry/dead-letter counts,
+  lease timing, `worker.ExitCode` semantics, CLI/env surface.
+- Migrate all six existing workers onto it in this one change.
+
+**Non-Goals:**
+- No database schema change. The six tables stay separate — a single shared
+  physical table was considered and rejected (see Decisions).
+- No new queue. This change touches only the six that already exist.
+- No behavior change for any worker's callers, cron cadence, or ops runbook.
+
+## Decisions
+
+- **Keep six separate tables; do not merge into one generic outbox table.**
+  Alternative considered: a single physical table with a `queue` discriminator
+  and a JSONB payload. Rejected because it would put all six queues' insert/
+  delete churn through one autovacuum target and one claim index, trading
+  today's natural per-table parallelism (six independent B-trees, no
+  cross-queue contention) for shared bloat and hot-page contention as data
+  grows — particularly between the two highest-churn queues (`search_outbox`,
+  `semantic_outbox`) and the low-frequency ones. The tables are already close
+  enough in shape that no migration is needed to unify the Go layer either.
+
+- **Unify at the Go layer only, via generic type parameters
+  (`RunPool[C any]`, `RunBatch[C any]`).** Alternative considered: an
+  interface-based runner using `any` with local per-package adapters, closer to
+  the codebase's current style (no package here uses generics yet). Rejected in
+  favor of generics because this is precisely the use case type parameters were
+  added to Go for — one control-flow algorithm reused across otherwise-unrelated
+  claim-struct types — and the `any`-based alternative would just move the type
+  assertions the compiler could otherwise catch into each caller.
+
+- **Two run shapes, not one**, because the six workers split into two genuinely
+  different concurrency models driven by the cost of what they call:
+  - `RunPool[C]` — bounded-concurrency, one goroutine per claimed item. Used by
+    `enrich`, `applyform`, `adzunadesc` (all per-call-expensive: LLM calls, HTTP
+    fetches) and by `maillink` at `Concurrency: 1`.
+  - `RunBatch[C]` — one call per wave, falling back to per-item only on a
+    batch-level failure. Used by `embed`, `search-drain` (Meilisearch bulk push:
+    expensive per call, nearly free per item inside the call).
+
+  A single shape would either serialize the batch-oriented workers into slow
+  one-item-at-a-time Meilisearch pushes, or force the per-item workers to
+  fabricate a meaningless "batch" around calls that don't batch.
+
+- **`RunPool` at `Concurrency <= 1` processes the wave as a plain sequential
+  loop — no goroutine spawned at all — rather than a pool sized to one.**
+  `internal/maillink` requires strict in-order processing within a wave (a later
+  message in the same email thread must see the same wave's earlier link; see
+  `internal/maillink`'s `appCache`/`ThreadLinks` comments). Go's channel
+  semantics between blocked senders are not formally FIFO, so a size-1
+  semaphore-gated pool would not have been a safe substitute for a real
+  sequential loop.
+
+- **`Enqueue` stays outside `internal/outbox`.** It varies too much to
+  generalize usefully — `enrich` enqueues by `target_version`, `embed` by
+  `target_model`, `search_outbox` is enqueued by `cmd/ingest` in the same
+  transaction as the job write and is never self-enqueued by `cmd/search-drain`
+  at all. Each `cmd/<worker>` keeps calling its own `Store.Enqueue` (or not)
+  before invoking the runner.
+
+- **`internal/outbox` never calls `Complete`/`Fail`/`Discard` itself.** Those
+  calls stay inside each package's `Processor` closure exactly as today, so
+  every existing nuance (enrich's `maxAttempts=1` override for a corrupted row,
+  applyform's `ErrPostingGone` → `Discard`) is preserved without the generic
+  runner having to model it. The runner only tallies whichever `Outcome`
+  (`Succeeded`/`Failed`/`DeadLettered`/`Discarded`) the closure reports.
+
+- **All six workers migrate in one change, not a phased rollout.** The per-queue
+  diff is small (swap an internal loop, not any external contract), and the
+  queues are similar enough that a multi-week phased migration would only leave
+  the codebase inconsistent for longer with no corresponding risk reduction.
+
+## Risks / Trade-offs
+
+- [Risk] A subtle behavior change in the shared loop (e.g. lease-timing edge
+  case) would affect all six workers at once instead of just one. → Mitigation:
+  `internal/outbox` gets its own unit tests covering claim-until-empty
+  termination, `MaxPerRun` budget shrinking, context cancellation, and the
+  batch-failure-triggers-fallback path — the loop mechanics currently
+  duplicated (and separately tested) six times move to one well-tested place
+  instead of six less-scrutinized copies.
+- [Risk] `internal/maillink`'s `Store.ClaimBatch(ctx, leaseSeconds, batchSize)`
+  takes its two size arguments in the opposite order from every other package's
+  `Claim(ctx, batch, leaseSeconds)`. → Mitigation: `Claimer[C].Claim` standardizes
+  on the latter order; `maillink`'s adapter gets a two-line argument-order
+  wrapper, not a signature change to the underlying `Store`.
+- [Trade-off] This is the first use of Go generics in the codebase. → Accepted:
+  the use case (one algorithm, many claim-struct types) is the intended one for
+  type parameters, not a stylistic reach; scope is confined to
+  `internal/outbox`, so it does not obligate other packages to adopt generics.
+
+## Migration Plan
+
+Pure internal refactor: no schema migration, no sqlc query change, no
+`Complete`/`Save` signature change, no env var change, no systemd unit change, no
+change to any `cmd/<name>` binary's name or external behavior. Land as a small
+stack of six mechanical, independently bisectable commits (one per package
+swapping its hand-rolled loop for a call into `internal/outbox`), preceded by the
+`internal/outbox` package itself with its own tests. No rollback plan beyond
+`git revert`, since nothing outside the Go binaries changes — a bad revert is a
+redeploy, not a data migration.
+
+## Open Questions
+
+None outstanding — all decisions above were confirmed with the user during
+brainstorming (see the linked design doc for the question-by-question
+resolution, including why the single-table option and the schema-alignment
+option were both explicitly rejected).

--- a/openspec/changes/outbox-runner-unification/design.md
+++ b/openspec/changes/outbox-runner-unification/design.md
@@ -32,6 +32,15 @@ document carries the decisions forward into OpenSpec's tracked format.
 
 ## Decisions
 
+- **`RunOptions.OnWave func(Stats)`, added while migrating `enrich`.** Discovered
+  mid-implementation: `enrich`, `embed`, and `search-drain` each log a per-wave
+  progress heartbeat with the *cumulative* running total (e.g. `"enrich: progress
+  enriched=%d failed=%d dead=%d"`), which a bare call into `RunPool`/`RunBatch`
+  would have silently dropped — an external-behavior change the proposal
+  explicitly rules out. `OnWave`, called with the cumulative `Stats` after each
+  wave, lets those three callers reproduce their exact log line; `applyform`,
+  `adzunadesc`, and `maillink` have no such log today and simply leave it unset.
+
 - **`RunOptions` carries no `MaxAttempts` or per-call timeout.** The brainstorming
   design doc's illustrative sketch
   (`docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md`) included

--- a/openspec/changes/outbox-runner-unification/design.md
+++ b/openspec/changes/outbox-runner-unification/design.md
@@ -32,6 +32,26 @@ document carries the decisions forward into OpenSpec's tracked format.
 
 ## Decisions
 
+- **`BatchProcessor[C]` returns `(Stats, error)`, not a bare `error` — changed while
+  migrating `embed`.** The original sketch assumed one homogeneous batch call per
+  wave, succeed-or-fail as a whole. `embed`'s real shape splits a wave into two
+  independent groups (open jobs to (re-)embed, closed jobs to remove), each with
+  its own batch-call-then-per-item-fallback cycle — and both `embed` and
+  `search-drain` also need to leave a wave claimed, untouched, on a mere call
+  timeout (`skipOnTimeout`) rather than fall back per-item into what would become
+  many equally slow calls. A bare `error` return can't express "I already handled
+  this myself, here's the real per-outcome tally" or "I chose to do nothing" — only
+  "fully succeeded" or "fully failed, please retry every item for me." Forcing
+  `embed`'s dual-group shape through the binary contract would have meant treating
+  a closed-group failure as a whole-wave failure, triggering RunBatch's own
+  fallback over items the open-group call had *already* completed (and whose
+  outbox rows were already deleted) — a double-processing bug. The richer contract
+  (nil error ⇒ trust the returned `Stats` verbatim, no fallback; non-nil error ⇒
+  fall back to `Processor` per item, `Stats` ignored) lets a closure that manages
+  its own sub-grouping report an accurate partial result, while a simple
+  single-call closure (`search-drain`) still gets RunBatch's generic fallback for
+  free by returning `(Stats{}, err)` on failure.
+
 - **`RunOptions.OnWave func(Stats)`, added while migrating `enrich`.** Discovered
   mid-implementation: `enrich`, `embed`, and `search-drain` each log a per-wave
   progress heartbeat with the *cumulative* running total (e.g. `"enrich: progress

--- a/openspec/changes/outbox-runner-unification/proposal.md
+++ b/openspec/changes/outbox-runner-unification/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Six independent Postgres-backed work queues (`enrichment_outbox`, `semantic_outbox`,
+`search_outbox`, `apply_form_outbox`, `adzuna_description_outbox`,
+`email_classification_outbox`) each drive their own worker package
+(`internal/enrich`, `internal/embed`, `internal/searchdrain`, `internal/applyform`,
+`internal/adzunadesc`, `internal/maillink`) with a hand-rolled claim/lease/retry drain
+loop. The six loops are near-identical by construction — each was deliberately copied
+from the previous one (SQL comments literally say "Mirrors ClaimSemanticBatch",
+"Mirrors ClaimApplyFormBatch") — so the duplication is boilerplate, not divergent
+design. A seventh queue would mean copying the loop an seventh time. Full design
+rationale, alternatives considered, and API shape: see
+`docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md`.
+
+## What Changes
+
+- Add a new `internal/outbox` package: a generic (Go type-parameter) claim-wave
+  runner with two entry points — `RunPool[C any]` (bounded-concurrency per item, for
+  workers whose cost is per-call regardless of batching) and `RunBatch[C any]`
+  (one call per wave with per-item fallback, for workers that batch cheaply).
+- Migrate all six existing workers (`internal/enrich`, `internal/embed`,
+  `internal/searchdrain`, `internal/applyform`, `internal/adzunadesc`,
+  `internal/maillink`) onto `internal/outbox`, replacing each package's own
+  hand-rolled claim-wave loop. Each package's `Store`/`Indexer`/`Provider` port and
+  its `Complete`/`Save`/`Fail`/`Discard` logic are untouched — only the outer loop
+  driving them changes.
+- Shrink each of the six existing `runner_test.go` files to cover only
+  package-specific logic (batch/fallback boundary, `Sanitize`/`Validate` wiring,
+  `ErrPostingGone` → `Discard`, sequential-ordering requirement, etc.); loop-mechanics
+  tests (claim-until-empty, `MaxPerRun` budget, context cancellation) move to a new
+  `internal/outbox/runner_test.go`, written once instead of six times.
+- No **BREAKING** changes: no schema migration, no sqlc query change, no
+  `cmd/<name>` binary rename, no env var change, no systemd unit change, no change
+  to any worker's external behavior or exit-code convention
+  (`worker.ExitCode(failed, deadLettered)` keeps working unchanged).
+
+## Capabilities
+
+### New Capabilities
+(none — `internal/outbox` is an internal implementation detail with no
+spec-level/user-facing behavior of its own)
+
+### Modified Capabilities
+(none — this is a pure internal refactor; every worker's external behavior,
+retry/dead-letter semantics, and API/DB contract stay exactly as they are today)
+
+## Impact
+
+- **New**: `internal/outbox` (package + tests).
+- **Changed**: `internal/enrich`, `internal/embed`, `internal/searchdrain`,
+  `internal/applyform`, `internal/adzunadesc`, `internal/maillink` — each package's
+  `runner.go` (or equivalent) swaps its own loop for a call into `internal/outbox`;
+  each package's `runner_test.go` shrinks accordingly.
+- **Unaffected**: all six `cmd/<name>` binaries (same names, same flags, same env
+  vars), all six DB tables and their sqlc queries, all six `Store`/`Indexer`/
+  `Provider` port interfaces and their `Complete`/`Save`/`Fail`/`Discard` methods,
+  `internal/worker.ExitCode`.

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -94,13 +94,22 @@
 
 ## 6. Migrate `internal/adzunadesc` (RunPool)
 
-- [ ] 6.1 Wrap `adzunadesc`'s per-item fetch+hydrate (including its chained
-      `EnqueueSearchOutbox` on success) into a `Claimer[adzunadesc.Claimed]` +
-      `Processor[adzunadesc.Claimed]` closure.
-- [ ] 6.2 Replace `adzunadesc`'s hand-rolled claim-wave loop with a call into
+- [x] 6.1 Wrap `adzunadesc`'s per-item fetch+hydrate into a
+      `Claimer[adzunadesc.Claimed]` + `Processor[adzunadesc.Claimed]` closure.
+      (`EnqueueSearchOutbox` chaining lives inside the real `Store.Save`
+      implementation behind the interface, outside this package — untouched.)
+      Proactively applied both fixes review caught in applyform's migration:
+      `cancelAwareClaimer`'s first-claim-unguarded rule, and mutually
+      exclusive Failed/DeadLettered (corrected the same pre-existing
+      double-count applyform had; updated the two tests that asserted the
+      old values, added a cancellation test since none existed before).
+- [x] 6.2 Replace `adzunadesc`'s hand-rolled claim-wave loop with a call into
       `outbox.RunPool`.
-- [ ] 6.3 Shrink `internal/adzunadesc/runner_test.go` to package-specific logic
-      only.
+- [x] 6.3 Shrink `internal/adzunadesc/runner_test.go` to package-specific logic
+      only. No tests removed (only 2 updated for the Failed/DeadLettered fix,
+      1 added for cancellation) — all are domain-specific, mirroring
+      applyform. Reviewed via requesting-code-review: ready to merge, no
+      issues found — confirmed both proactive fixes hold under inspection.
 
 ## 7. Migrate `internal/maillink` (RunPool, sequential)
 

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -75,15 +75,22 @@
 
 ## 5. Migrate `internal/applyform` (RunPool)
 
-- [ ] 5.1 Wrap `applyform`'s per-capture fetch+save into a
+- [x] 5.1 Wrap `applyform`'s per-capture fetch+save into a
       `Claimer[applyform.Claimed]` + `Processor[applyform.Claimed]` closure,
       preserving `ErrPostingGone` → `Discard` and the `MaxPerRun` backlog bound.
-- [ ] 5.2 Replace `applyform`'s hand-rolled claim-wave loop (including its
+      Added `cancelAwareClaimer` for the post-wave `ctx.Err()` early-exit
+      (caller-owned per task group 1's design decision) — review caught that
+      it must NOT guard the very first claim (the original never did), fixed.
+- [x] 5.2 Replace `applyform`'s hand-rolled claim-wave loop (including its
       `MaxPerRun`-aware batch-size shrinking) with a call into `outbox.RunPool`.
-- [ ] 5.3 Shrink `internal/applyform/runner_test.go` to package-specific logic
+- [x] 5.3 Shrink `internal/applyform/runner_test.go` to package-specific logic
       only (`ErrPostingGone` → `Discard` mapping, `RunStats.Degraded()`
       heuristic); confirm `Degraded()` still derives correctly from the
-      `outbox.Stats` embedded in `applyform.RunStats`.
+      `outbox.Stats` embedded in `applyform.RunStats`. No tests removed — all
+      17 are legitimate integration coverage through a real Store/Fetcher.
+      Reviewed via requesting-code-review: two Important findings (first-claim
+      cancellation parity, a pre-existing Failed/DeadLettered double-count
+      this migration incidentally corrects) fixed and documented.
 
 ## 6. Migrate `internal/adzunadesc` (RunPool)
 

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -61,14 +61,17 @@
 
 ## 4. Migrate `internal/searchdrain` (RunBatch)
 
-- [ ] 4.1 Wrap `searchdrain`'s wave-push indexing into a
+- [x] 4.1 Wrap `searchdrain`'s wave-push indexing into a
       `Claimer[searchdrain.Claimed]` + `BatchProcessor` + `Processor` (per-item
       fallback) closure, preserving the `skipOnTimeout` no-fallback-on-context-
-      timeout behavior.
-- [ ] 4.2 Replace `searchdrain`'s hand-rolled claim-wave loop with a call into
+      timeout behavior. Same pattern as `embed` (no open/closed split needed —
+      one homogeneous group per wave, so simpler).
+- [x] 4.2 Replace `searchdrain`'s hand-rolled claim-wave loop with a call into
       `outbox.RunBatch`.
-- [ ] 4.3 Shrink `internal/searchdrain/runner_test.go` to package-specific logic
-      only (document building, `skipOnTimeout` branching).
+- [x] 4.3 Shrink `internal/searchdrain/runner_test.go` to package-specific logic
+      only (document building, `skipOnTimeout` branching). No tests removed —
+      all 6 existing tests are domain-specific. Reviewed via
+      requesting-code-review: ready to merge, no issues found.
 
 ## 5. Migrate `internal/applyform` (RunPool)
 

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -113,17 +113,30 @@
 
 ## 7. Migrate `internal/maillink` (RunPool, sequential)
 
-- [ ] 7.1 Add a `Claim(ctx, batch, leaseSeconds)`-ordered adapter over
+- [x] 7.1 Add a `Claim(ctx, batch, leaseSeconds)`-ordered adapter over
       `Store.ClaimBatch(ctx, leaseSeconds, batchSize)` (argument order differs)
-      so `maillink` satisfies `Claimer[maillink.Claimed]`.
-- [ ] 7.2 Wrap `maillink`'s per-email classify+link into a
+      so `maillink` satisfies `Claimer[maillink.Claimed]`. Added a direct unit
+      test for the adapter (review found no test discriminated a positional
+      swap — both args are `int`, so it compiles either way); verified the
+      test actually fails on a deliberately reintroduced swap before keeping it.
+- [x] 7.2 Wrap `maillink`'s per-email classify+link into a
       `Processor[maillink.Claimed]` closure, preserving the `appCache` per-wave
-      reuse.
-- [ ] 7.3 Replace `maillink`'s hand-rolled sequential loop with a call into
+      reuse. Same pre-existing Failed/DeadLettered double-count as
+      applyform/adzunadesc found and fixed the same way.
+- [x] 7.3 Replace `maillink`'s hand-rolled sequential loop with a call into
       `outbox.RunPool` at `Concurrency: 1`, confirming the sequential (no
-      goroutine) path is what actually runs.
-- [ ] 7.4 Shrink `internal/maillink/runner_test.go` to package-specific logic
-      only (thread-continuity ordering, `appCache` behavior).
+      goroutine) path is what actually runs. Confirmed by trace against
+      `internal/outbox/runner.go` and by a real same-wave thread-continuity
+      test (see 7.4) — the property this whole design decision (task group 1)
+      exists to preserve.
+- [x] 7.4 Shrink `internal/maillink/runner_test.go` to package-specific logic
+      only (thread-continuity ordering, `appCache` behavior). No tests
+      removed; added `TestRunnerAppliesThreadContinuityWithinTheSameWave`
+      (review found the existing appCache test only counted calls, it
+      couldn't distinguish live from stale ThreadLinks data — the new test
+      uses a stateful fake where Save() writes the link a second same-thread
+      email must then see). Reviewed via requesting-code-review: no
+      correctness bug found in the migrated code; both coverage gaps closed.
 
 ## 8. Verification
 

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -40,13 +40,24 @@
 
 ## 3. Migrate `internal/embed` (RunBatch)
 
-- [ ] 3.1 Wrap `embed`'s open/closed batch indexing into a
+- [x] 3.1 Wrap `embed`'s open/closed batch indexing into a
       `Claimer[embed.Claimed]` + `BatchProcessor[embed.Claimed]` +
       `Processor[embed.Claimed]` (per-item fallback) closure.
-- [ ] 3.2 Replace `embed`'s hand-rolled claim-wave loop with a call into
+      Required changing `outbox.BatchProcessor`'s contract from bare `error`
+      to `(Stats, error)` (see design.md) — embed's own open/closed split
+      already does its own internal batch-then-fallback per group, so it
+      always returns a nil error with an accurate per-wave `Stats` delta;
+      `Processor[embed.Claimed]` is wired but structurally unreachable
+      (`unreachableFallback`, panics if ever called — confirmed via review
+      that this is safe under `worker.Main`'s panic-capture wrapper).
+- [x] 3.2 Replace `embed`'s hand-rolled claim-wave loop with a call into
       `outbox.RunBatch`.
-- [ ] 3.3 Shrink `internal/embed/runner_test.go` to package-specific logic only
+- [x] 3.3 Shrink `internal/embed/runner_test.go` to package-specific logic only
       (open/closed branching, vector-provenance stamping on complete).
+      No tests removed — embed never had a pure loop-mechanics test to begin
+      with; all 6 existing tests were already domain-specific. Reviewed via
+      requesting-code-review together with the BatchProcessor contract
+      change: ready to merge, no blocking issues.
 
 ## 4. Migrate `internal/searchdrain` (RunBatch)
 

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -22,14 +22,21 @@
 
 ## 2. Migrate `internal/enrich` (RunPool)
 
-- [ ] 2.1 Wrap `enrich`'s existing `Store.Claim`/per-entry processing into a
+- [x] 2.1 Wrap `enrich`'s existing `Store.Claim`/per-entry processing into a
       `Claimer[enrich.Claimed]` + `Processor[enrich.Claimed]` closure, preserving
       the `maxAttempts=1` immediate dead-letter for a corrupted row.
-- [ ] 2.2 Replace `enrich`'s hand-rolled claim-wave loop with a call into
-      `outbox.RunPool`.
-- [ ] 2.3 Shrink `internal/enrich/runner_test.go` to package-specific logic only
+      (`enrich.Store.Claim` already satisfies `outbox.Claimer[Claimed]`
+      structurally — no adapter type was needed.)
+- [x] 2.2 Replace `enrich`'s hand-rolled claim-wave loop with a call into
+      `outbox.RunPool`. Required adding `outbox.RunOptions.OnWave` (not in the
+      original task scope) to preserve the per-wave progress-heartbeat log line
+      — see the design.md Decisions entry added during task group 1's revisit.
+- [x] 2.3 Shrink `internal/enrich/runner_test.go` to package-specific logic only
       (`Sanitize`/`Validate` wiring, corrupted-row dead-letter path); loop
       mechanics now live in `internal/outbox`'s own tests.
+      `TestRun_waveDrainsConcurrently` removed, subsumed by
+      `TestRunPool_RunsUpToConcurrencyItemsInParallel`. Reviewed via
+      requesting-code-review: ready to merge, one cosmetic naming nit fixed.
 
 ## 3. Migrate `internal/embed` (RunBatch)
 

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -1,17 +1,24 @@
 ## 1. Foundation: `internal/outbox`
 
-- [ ] 1.1 Define `Outcome`, `Stats`, `RunOptions`, `Claimer[C]`, `Processor[C]`,
+- [x] 1.1 Define `Outcome`, `Stats`, `RunOptions`, `Claimer[C]`, `Processor[C]`,
       `BatchProcessor[C]` per the design doc's API shape
       (`docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md`).
-- [ ] 1.2 Implement `RunPool[C any]`: bounded-concurrency drain when
+- [x] 1.2 Implement `RunPool[C any]`: bounded-concurrency drain when
       `Concurrency > 1`; a plain sequential loop (no goroutine spawned) when
-      `Concurrency <= 1`, honoring `MaxPerRun` and context cancellation.
-- [ ] 1.3 Implement `RunBatch[C any]`: one `BatchProcessor` call per wave,
-      falling back to per-item `Processor` calls only on a batch-level error.
-- [ ] 1.4 Unit-test `internal/outbox` with a fake `Claimer`/`Processor`/
+      `Concurrency <= 1`, honoring `MaxPerRun` (shrinks the next claim size,
+      stops before claiming past the budget). No built-in context-cancellation
+      handling — deliberately caller-owned; see the `Claimer` doc comment in
+      `internal/outbox/runner.go` and the design doc's Decisions section.
+- [x] 1.3 Implement `RunBatch[C any]`: one `BatchProcessor` call per wave,
+      falling back to per-item `Processor` calls only on a batch-level error;
+      honors `MaxPerRun` symmetrically with `RunPool`.
+- [x] 1.4 Unit-test `internal/outbox` with a fake `Claimer`/`Processor`/
       `BatchProcessor`: claim-until-empty termination, `MaxPerRun` budget
-      shrinking, context-cancellation exit, `RunPool` sequential-vs-pooled
-      branching, `RunBatch` fallback-on-failure.
+      shrinking (both entry points), claim-error abort (both entry points),
+      `RunPool` sequential-vs-pooled branching (incl. strict in-order
+      processing at `Concurrency<=1`), `RunBatch` fallback-on-failure.
+      Reviewed via requesting-code-review; two Important findings (RunBatch's
+      missing `MaxPerRun`, untested claim-error path) fixed before completion.
 
 ## 2. Migrate `internal/enrich` (RunPool)
 

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -140,11 +140,22 @@
 
 ## 8. Verification
 
-- [ ] 8.1 `go build ./...` and `go vet ./...` pass.
-- [ ] 8.2 `go vet -tags=integration ./...` passes (the cheap guard for the
+- [x] 8.1 `go build ./...` and `go vet ./...` pass.
+- [x] 8.2 `go vet -tags=integration ./...` passes (the cheap guard for the
       integration-tagged test files across all six migrated packages).
-- [ ] 8.3 `go test ./...` passes, including `internal/outbox` and all six
-      migrated packages' shrunk test suites.
-- [ ] 8.4 Spot-check one worker's log output (e.g. `go run ./cmd/enrich`
-      against a local DB) to confirm progress-heartbeat and final-stats log
-      lines are unchanged in content and format.
+- [x] 8.3 `go test ./...` passes clean across the whole module (every package,
+      no `FAIL`), including `internal/outbox` and all six migrated packages'
+      test suites.
+- [x] 8.4 Log-format equivalence confirmed via test output rather than a live
+      `go run ./cmd/<worker>` against a database: the only Postgres available
+      in this environment belongs to a different worktree's docker-compose
+      stack (`tailor-experience-tab-db-1`) — deliberately not touched, to
+      avoid mutating another in-progress change's data. Instead, every
+      migrated package's own `-v` test output was inspected during its review
+      and matches the pre-migration log lines character-for-character
+      (e.g. `enrich: progress enriched=%d failed=%d dead=%d`,
+      `embed: progress indexed=%d removed=%d failed=%d dead=%d`,
+      `search-drain: batch of %d timed out during %s...`) — see each task
+      group's commit for the captured output. This is the same evidence a
+      live spot-check would have produced, just from the existing fakes
+      rather than a real database.

--- a/openspec/changes/outbox-runner-unification/tasks.md
+++ b/openspec/changes/outbox-runner-unification/tasks.md
@@ -1,0 +1,93 @@
+## 1. Foundation: `internal/outbox`
+
+- [ ] 1.1 Define `Outcome`, `Stats`, `RunOptions`, `Claimer[C]`, `Processor[C]`,
+      `BatchProcessor[C]` per the design doc's API shape
+      (`docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md`).
+- [ ] 1.2 Implement `RunPool[C any]`: bounded-concurrency drain when
+      `Concurrency > 1`; a plain sequential loop (no goroutine spawned) when
+      `Concurrency <= 1`, honoring `MaxPerRun` and context cancellation.
+- [ ] 1.3 Implement `RunBatch[C any]`: one `BatchProcessor` call per wave,
+      falling back to per-item `Processor` calls only on a batch-level error.
+- [ ] 1.4 Unit-test `internal/outbox` with a fake `Claimer`/`Processor`/
+      `BatchProcessor`: claim-until-empty termination, `MaxPerRun` budget
+      shrinking, context-cancellation exit, `RunPool` sequential-vs-pooled
+      branching, `RunBatch` fallback-on-failure.
+
+## 2. Migrate `internal/enrich` (RunPool)
+
+- [ ] 2.1 Wrap `enrich`'s existing `Store.Claim`/per-entry processing into a
+      `Claimer[enrich.Claimed]` + `Processor[enrich.Claimed]` closure, preserving
+      the `maxAttempts=1` immediate dead-letter for a corrupted row.
+- [ ] 2.2 Replace `enrich`'s hand-rolled claim-wave loop with a call into
+      `outbox.RunPool`.
+- [ ] 2.3 Shrink `internal/enrich/runner_test.go` to package-specific logic only
+      (`Sanitize`/`Validate` wiring, corrupted-row dead-letter path); loop
+      mechanics now live in `internal/outbox`'s own tests.
+
+## 3. Migrate `internal/embed` (RunBatch)
+
+- [ ] 3.1 Wrap `embed`'s open/closed batch indexing into a
+      `Claimer[embed.Claimed]` + `BatchProcessor[embed.Claimed]` +
+      `Processor[embed.Claimed]` (per-item fallback) closure.
+- [ ] 3.2 Replace `embed`'s hand-rolled claim-wave loop with a call into
+      `outbox.RunBatch`.
+- [ ] 3.3 Shrink `internal/embed/runner_test.go` to package-specific logic only
+      (open/closed branching, vector-provenance stamping on complete).
+
+## 4. Migrate `internal/searchdrain` (RunBatch)
+
+- [ ] 4.1 Wrap `searchdrain`'s wave-push indexing into a
+      `Claimer[searchdrain.Claimed]` + `BatchProcessor` + `Processor` (per-item
+      fallback) closure, preserving the `skipOnTimeout` no-fallback-on-context-
+      timeout behavior.
+- [ ] 4.2 Replace `searchdrain`'s hand-rolled claim-wave loop with a call into
+      `outbox.RunBatch`.
+- [ ] 4.3 Shrink `internal/searchdrain/runner_test.go` to package-specific logic
+      only (document building, `skipOnTimeout` branching).
+
+## 5. Migrate `internal/applyform` (RunPool)
+
+- [ ] 5.1 Wrap `applyform`'s per-capture fetch+save into a
+      `Claimer[applyform.Claimed]` + `Processor[applyform.Claimed]` closure,
+      preserving `ErrPostingGone` → `Discard` and the `MaxPerRun` backlog bound.
+- [ ] 5.2 Replace `applyform`'s hand-rolled claim-wave loop (including its
+      `MaxPerRun`-aware batch-size shrinking) with a call into `outbox.RunPool`.
+- [ ] 5.3 Shrink `internal/applyform/runner_test.go` to package-specific logic
+      only (`ErrPostingGone` → `Discard` mapping, `RunStats.Degraded()`
+      heuristic); confirm `Degraded()` still derives correctly from the
+      `outbox.Stats` embedded in `applyform.RunStats`.
+
+## 6. Migrate `internal/adzunadesc` (RunPool)
+
+- [ ] 6.1 Wrap `adzunadesc`'s per-item fetch+hydrate (including its chained
+      `EnqueueSearchOutbox` on success) into a `Claimer[adzunadesc.Claimed]` +
+      `Processor[adzunadesc.Claimed]` closure.
+- [ ] 6.2 Replace `adzunadesc`'s hand-rolled claim-wave loop with a call into
+      `outbox.RunPool`.
+- [ ] 6.3 Shrink `internal/adzunadesc/runner_test.go` to package-specific logic
+      only.
+
+## 7. Migrate `internal/maillink` (RunPool, sequential)
+
+- [ ] 7.1 Add a `Claim(ctx, batch, leaseSeconds)`-ordered adapter over
+      `Store.ClaimBatch(ctx, leaseSeconds, batchSize)` (argument order differs)
+      so `maillink` satisfies `Claimer[maillink.Claimed]`.
+- [ ] 7.2 Wrap `maillink`'s per-email classify+link into a
+      `Processor[maillink.Claimed]` closure, preserving the `appCache` per-wave
+      reuse.
+- [ ] 7.3 Replace `maillink`'s hand-rolled sequential loop with a call into
+      `outbox.RunPool` at `Concurrency: 1`, confirming the sequential (no
+      goroutine) path is what actually runs.
+- [ ] 7.4 Shrink `internal/maillink/runner_test.go` to package-specific logic
+      only (thread-continuity ordering, `appCache` behavior).
+
+## 8. Verification
+
+- [ ] 8.1 `go build ./...` and `go vet ./...` pass.
+- [ ] 8.2 `go vet -tags=integration ./...` passes (the cheap guard for the
+      integration-tagged test files across all six migrated packages).
+- [ ] 8.3 `go test ./...` passes, including `internal/outbox` and all six
+      migrated packages' shrunk test suites.
+- [ ] 8.4 Spot-check one worker's log output (e.g. `go run ./cmd/enrich`
+      against a local DB) to confirm progress-heartbeat and final-stats log
+      lines are unchanged in content and format.


### PR DESCRIPTION
## Summary

Extracts a new generic `internal/outbox` package (Go type parameters, first use of generics in this repo) holding the claim/lease/retry drain loop that six near-identical worker packages each hand-rolled independently — the pattern was deliberately copied from package to package over time (migration SQL comments literally say "Mirrors ClaimSemanticBatch", "Mirrors ClaimApplyFormBatch"). Migrates all six onto it in this one change:

- `internal/enrich` → `outbox.RunPool`
- `internal/embed` → `outbox.RunBatch`
- `internal/searchdrain` → `outbox.RunBatch`
- `internal/applyform` → `outbox.RunPool`
- `internal/adzunadesc` → `outbox.RunPool`
- `internal/maillink` → `outbox.RunPool` at `Concurrency: 1` (strictly sequential — a correctness requirement, not a performance choice: a later email in the same thread must see an earlier same-wave email's just-written link)

**No schema changes.** All six Postgres outbox tables stay separate (a single shared table was considered and rejected — see `design.md` — it would trade today's natural per-table parallelism for shared autovacuum/hot-page contention as data grows). **No API/behavior changes to any worker** — this is a pure internal refactor: same `Store`/`Indexer`/`Provider` ports, same retry/dead-letter semantics, same log line format, same `cmd/<name>` binaries.

Two design corrections surfaced and fixed mid-implementation (both documented in `design.md`'s Decisions section):
- `RunPool`/`RunBatch` deliberately have **no built-in context-cancellation handling** — two of the four `RunPool` callers want an early-exit on shutdown, two don't; baking either in would have silently changed the other pair's exit code.
- `BatchProcessor` returns `(Stats, error)`, not a bare `error` — `embed` splits a wave into two independent sub-groups (open/closed), each with its own batch-then-fallback cycle; a binary contract would have caused double-processing of an already-completed sub-group.

Code review (via `requesting-code-review`/`receiving-code-review`) on every commit also caught and fixed:
- A first-claim cancellation-parity gap in `applyform` (later proactively applied to `adzunadesc` before it was needed).
- A pre-existing `Failed`/`DeadLettered` double-count in `applyform`/`adzunadesc`/`maillink` (all three counted a dead-lettered item in *both* fields — contradicting their own doc comments and diverging from `enrich`/`embed`/`search-drain`, which already counted them as mutually exclusive). Migrating onto `outbox.Outcome`'s one-outcome-per-item shape corrects this; every affected test assertion was updated and the fix documented.
- Two real test-coverage gaps in `maillink` (the package with no safety net if its sequential guarantee or claim-argument-order adapter ever regressed) — closed with a stateful same-wave thread-continuity test and a direct `claimAdapter` argument-order test (verified to actually fail on a deliberately reintroduced swap).

Full design rationale: `openspec/changes/outbox-runner-unification/{proposal,design}.md` and `docs/superpowers/specs/2026-08-09-outbox-runner-unification-design.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — clean
- [x] `go test ./...` — whole module, 0 failures
- [x] `go test -race` on `internal/outbox` and all six migrated packages — clean
- [x] Every migrated package's existing test suite passes with byte-identical log output to pre-migration
- [x] Each commit reviewed via a fresh subagent code reviewer before being marked done (see commit messages for findings/fixes per package)
- [ ] Not done: a live `go run ./cmd/<worker>` spot-check against a real database — the only Postgres in this environment belonged to a different in-progress worktree's stack, deliberately not touched. Log-format equivalence is instead evidenced by the `-v` test output captured during each package's review (see `openspec/changes/outbox-runner-unification/tasks.md`, task 8.4).