### PR TITLE
fix(sources): populate Company on UKG-sourced jobs

### DIFF
--- a/internal/sources/ukg.go
+++ b/internal/sources/ukg.go
@@ -99,7 +99,7 @@ func (u ukg) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	// The listing already carries title/location/brief description, so every posting yields
 	// a job; the detail fetch only upgrades the brief body to the full one (best-effort).
 	return fetchDetails(opps, defaultDetailWorkers, func(o ukgOpportunity) (Job, bool) {
-		return u.toJob(ctx, host, tenant, guid, o), true
+		return u.toJob(ctx, host, tenant, guid, e, o), true
 	}), nil
 }
 
@@ -131,7 +131,7 @@ func (u ukg) list(ctx context.Context, host, tenant, guid string) ([]ukgOpportun
 
 // toJob maps a listing opportunity to a Job, upgrading the brief description to the full
 // body from the detail page when that fetch succeeds.
-func (u ukg) toJob(ctx context.Context, host, tenant, guid string, o ukgOpportunity) Job {
+func (u ukg) toJob(ctx context.Context, host, tenant, guid string, e CompanyEntry, o ukgOpportunity) Job {
 	url := fmt.Sprintf("https://%s/%s/JobBoard/%s/OpportunityDetail?opportunityId=%s", host, tenant, guid, o.ID)
 	body := o.BriefDescription
 	var employmentType string
@@ -144,6 +144,7 @@ func (u ukg) toJob(ctx context.Context, host, tenant, guid string, o ukgOpportun
 		ExternalID:  o.ID,
 		URL:         url,
 		Title:       o.Title,
+		Company:     e.Company,
 		Location:    location,
 		Description: sanitizeHTML(html.UnescapeString(body)),
 		Remote:      isRemote(location),

--- a/internal/sources/ukg_test.go
+++ b/internal/sources/ukg_test.go
@@ -98,6 +98,9 @@ func TestUKGFetch(t *testing.T) {
 	if j.ExternalID != "id-1" || j.Title != "Backend Engineer" {
 		t.Errorf("job0 id/title = %q/%q", j.ExternalID, j.Title)
 	}
+	if j.Company != "Acme" {
+		t.Errorf("job0 Company = %q, want %q", j.Company, "Acme")
+	}
 	if want := "recruiting.ultipro.com/van5000vcscu/JobBoard/the-guid/OpportunityDetail"; !strings.Contains(j.URL, want) || !strings.Contains(j.URL, "opportunityId=id-1") {
 		t.Errorf("job0 URL = %q", j.URL)
 	}


### PR DESCRIPTION
## Summary
- The `ukg` adapter (`internal/sources/ukg.go`) never set `Job.Company`, so every posting ingested from a UKG/UltiPro board landed with an empty company name — surfaced on freehire.me as "Unknown company" (e.g. `/jobs/ai-software-engineer-a3gfljel`).
- `sources/ukg.yml` configures ~3000 boards, so this affected all of them.
- Fixed by passing `CompanyEntry.Company` through to the returned `Job`, matching every other adapter (e.g. `workday.go`).

## Test plan
- [x] `go build ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...`
- [x] Added a `Company` assertion to `TestUKGFetch`