### PR TITLE
fix(web): dedupe job list pages to stop each_key_duplicate crashes

### DIFF
--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -68,7 +68,7 @@
       hidden = page.hidden;
       return page;
     },
-    PAGE_SIZE,
+    { limit: PAGE_SIZE },
   );
 
   let syncing = $state(false);

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -30,7 +30,6 @@
   import OnboardingBanner from './onboarding/OnboardingBanner.svelte';
   import OnboardingAlertBanner from './onboarding/OnboardingAlertBanner.svelte';
   import { syncOnNavigation } from '$lib/urlSynced.svelte';
-  import { toSearchString } from '$lib/urlSearchString';
   import { setListSearchTarget } from '$lib/listSearch.svelte';
   import { track } from '$lib/analytics';
   import type { Job, FacetCounts } from '$lib/types';
@@ -117,8 +116,10 @@
   // browses via keyword search. Both take the same facet params and return the same
   // Job shape, so only the fetch fn differs. CV sort is standalone-only.
   const makePaginator = () =>
-    new Paginator<Job>((limit, offset) =>
-      cvMode ? api.recommendations(scopedParams(), limit, offset) : api.searchJobs(scopedParams(), limit, offset),
+    new Paginator<Job>(
+      (limit, offset) =>
+        cvMode ? api.recommendations(scopedParams(), limit, offset) : api.searchJobs(scopedParams(), limit, offset),
+      { keyOf: (job) => job.public_slug },
     );
 
   // Seeded with the server-rendered first page (an intentional one-time snapshot
@@ -347,7 +348,7 @@
   // fixed context (e.g. company_slug) and go along too.
   function openSwipe() {
     const params = scopedParams();
-    const qs = toSearchString(params);
+    const qs = params.toString();
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() applied to the path; the rule can't see through the appended query string
     goto(resolve('/jobs/swipe') + (qs ? `?${qs}` : ''));
   }

--- a/web/src/lib/paginated.svelte.test.ts
+++ b/web/src/lib/paginated.svelte.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { loadWithRetry } from './paginated.svelte';
+import { loadWithRetry, dedupeByKey } from './paginated.svelte';
 import { ApiError } from './api';
 
 // The reactive Paginator can't be instantiated here — its `$state` fields need a
@@ -47,5 +47,43 @@ describe('loadWithRetry', () => {
     await assertion;
     expect(fetch).toHaveBeenCalledTimes(3); // initial + 2 retries
     vi.useRealTimers();
+  });
+});
+
+describe('dedupeByKey', () => {
+  it('keeps every item the first time its key is seen', () => {
+    const seen = new Set<unknown>();
+    const result = dedupeByKey([{ id: 'a' }, { id: 'b' }], (i) => i.id, seen);
+    expect(result).toEqual([{ id: 'a' }, { id: 'b' }]);
+    expect(seen).toEqual(new Set(['a', 'b']));
+  });
+
+  it('drops an item whose key was already seen in a prior call', () => {
+    const seen = new Set<unknown>(['a']);
+    const result = dedupeByKey([{ id: 'a' }, { id: 'b' }], (i) => i.id, seen);
+    expect(result).toEqual([{ id: 'b' }]);
+  });
+
+  it('drops a repeat within the same call, keeping the first occurrence', () => {
+    const seen = new Set<unknown>();
+    const result = dedupeByKey([{ id: 'a' }, { id: 'a' }], (i) => i.id, seen);
+    expect(result).toEqual([{ id: 'a' }]);
+  });
+
+  it('models the real bug: a job reshuffled into the next offset window is dropped, not double-keyed', () => {
+    const seen = new Set<unknown>();
+    const page1 = dedupeByKey(
+      [{ public_slug: 'job-1' }, { public_slug: 'job-2' }],
+      (j) => j.public_slug,
+      seen,
+    );
+    // Between requests the ranking shifted job-1 into the next offset window.
+    const page2 = dedupeByKey(
+      [{ public_slug: 'job-1' }, { public_slug: 'job-3' }],
+      (j) => j.public_slug,
+      seen,
+    );
+    expect(page1).toEqual([{ public_slug: 'job-1' }, { public_slug: 'job-2' }]);
+    expect(page2).toEqual([{ public_slug: 'job-3' }]);
   });
 });

--- a/web/src/lib/paginated.svelte.ts
+++ b/web/src/lib/paginated.svelte.ts
@@ -32,6 +32,24 @@ export async function loadWithRetry<T>(fetch: () => Promise<T>, maxRetries = 2):
   }
 }
 
+/** Drop items whose key is already in `seen`, adding the rest. Offset-based paging
+ *  re-derives "page 2" as items.length, so a re-ranked or re-ingested result set
+ *  between requests can shift an already-shown item into the next page's window —
+ *  appended again under the same key, which Svelte's keyed `#each` rejects
+ *  (svelte.dev/e/each_key_duplicate). `seen` is mutated in place (carried across
+ *  calls by the caller) so a repeat is caught however many pages back it first
+ *  appeared. Kept as a free function so it's unit-testable without a Svelte runtime. */
+export function dedupeByKey<T>(items: T[], keyOf: (item: T) => unknown, seen: Set<unknown>): T[] {
+  const fresh: T[] = [];
+  for (const item of items) {
+    const key = keyOf(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    fresh.push(item);
+  }
+  return fresh;
+}
+
 export class Paginator<T> {
   // Slices are whole API responses, only ever reassigned (never mutated in
   // place), so `raw` skips the per-item proxy overhead of deep `$state`.
@@ -48,17 +66,26 @@ export class Paginator<T> {
 
   #fetch: FetchSlice<T>;
   #limit: number;
+  // Only set when the caller has a stable identity for T; see `dedupeByKey`.
+  #keyOf?: (item: T) => unknown;
+  #seen = new Set<unknown>();
 
-  constructor(fetch: FetchSlice<T>, limit = 20) {
+  constructor(fetch: FetchSlice<T>, opts: { limit?: number; keyOf?: (item: T) => unknown } = {}) {
     this.#fetch = fetch;
-    this.#limit = limit;
+    this.#limit = opts.limit ?? 20;
+    this.#keyOf = opts.keyOf;
+  }
+
+  #dedupe(slice: T[]): T[] {
+    return this.#keyOf ? dedupeByKey(slice, this.#keyOf, this.#seen) : slice;
   }
 
   /** Seed the first page from data already fetched (e.g. server-rendered) so the
    *  view renders it immediately and only fetches on `loadMore`. Use instead of
    *  `start()` when the route's `load` has already produced page one. */
   seed(slice: Slice<T>) {
-    this.items = slice.items;
+    this.#seen = new Set();
+    this.items = this.#dedupe(slice.items);
     this.total = slice.total ?? 0;
     this.hasMore = slice.hasMore;
     this.status = 'ready';
@@ -71,7 +98,8 @@ export class Paginator<T> {
   async start() {
     try {
       const slice = await loadWithRetry(() => this.#fetch(this.#limit, 0));
-      this.items = slice.items;
+      this.#seen = new Set();
+      this.items = this.#dedupe(slice.items);
       this.total = slice.total ?? 0;
       this.hasMore = slice.hasMore;
       this.status = 'ready';
@@ -87,7 +115,7 @@ export class Paginator<T> {
     this.loadMoreError = false;
     try {
       const slice = await this.#fetch(this.#limit, this.items.length);
-      this.items = [...this.items, ...slice.items];
+      this.items = [...this.items, ...this.#dedupe(slice.items)];
       this.total = slice.total ?? 0;
       this.hasMore = slice.hasMore;
     } catch {

--- a/web/src/lib/paginated.svelte.ts
+++ b/web/src/lib/paginated.svelte.ts
@@ -68,6 +68,7 @@ export class Paginator<T> {
   #limit: number;
   // Only set when the caller has a stable identity for T; see `dedupeByKey`.
   #keyOf?: (item: T) => unknown;
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deliberately non-reactive dedup registry; never read in a reactive context
   #seen = new Set<unknown>();
 
   constructor(fetch: FetchSlice<T>, opts: { limit?: number; keyOf?: (item: T) => unknown } = {}) {
@@ -84,6 +85,7 @@ export class Paginator<T> {
    *  view renders it immediately and only fetches on `loadMore`. Use instead of
    *  `start()` when the route's `load` has already produced page one. */
   seed(slice: Slice<T>) {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deliberately non-reactive dedup registry; never read in a reactive context
     this.#seen = new Set();
     this.items = this.#dedupe(slice.items);
     this.total = slice.total ?? 0;
@@ -98,6 +100,7 @@ export class Paginator<T> {
   async start() {
     try {
       const slice = await loadWithRetry(() => this.#fetch(this.#limit, 0));
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deliberately non-reactive dedup registry; never read in a reactive context
       this.#seen = new Set();
       this.items = this.#dedupe(slice.items);
       this.total = slice.total ?? 0;

--- a/web/src/routes/b/[slug]/+page.svelte
+++ b/web/src/routes/b/[slug]/+page.svelte
@@ -26,8 +26,9 @@
   // page, so rows are in the initial HTML; "load more" fetches client-side. The query can
   // carry repeated keys (multi-value facets), passed through URLSearchParams verbatim.
   const jobs = $derived.by(() => {
-    const p = new Paginator<Job>((limit, offset) =>
-      api.searchJobs(new URLSearchParams(data.board.query), limit, offset),
+    const p = new Paginator<Job>(
+      (limit, offset) => api.searchJobs(new URLSearchParams(data.board.query), limit, offset),
+      { keyOf: (job) => job.public_slug },
     );
     p.seed(data.initial);
     return p;


### PR DESCRIPTION
## Summary
- The homepage/board job feed pages by offset (`items.length`), re-derived per request. When the underlying ranking shifts between page requests, an already-shown job can land in the next page's offset window and get appended again, crashing Svelte's keyed `#each` (`each_key_duplicate`).
- Sentry: TG-CATALOG-49 / -56 / -4F, ~170 occurrences over the last 3 weeks, still recurring daily on `freehire.me/`.
- `Paginator` (`web/src/lib/paginated.svelte.ts`) now takes an optional `keyOf`; a new pure `dedupeByKey` helper tracks seen keys across `seed`/`start`/`loadMore` and drops repeats on append. Wired into `JobsView` (homepage/search) and `/b/[slug]` (shared boards), both keyed on `job.public_slug`.
- `InboxView`'s positional `limit` arg moved into the new options object (`{ limit: PAGE_SIZE }`) — the only other `Paginator` call site passing a second positional arg.

## Test plan
- [x] `npx vitest run` — 884 passed (added 4 cases for `dedupeByKey`, including one modeling the actual bug: an item reshuffled into the next offset window is dropped, not double-keyed)
- [x] `npx svelte-check` — 0 errors in touched files