### PR TITLE
Mobile app groundwork: universal links, terms, delete-account

### DIFF
--- a/design-system/scripts/web-token-baseline.json
+++ b/design-system/scripts/web-token-baseline.json
@@ -90,6 +90,7 @@
   "web/src/lib/tailor/ScoreCategoryRow.svelte": 2,
   "web/src/lib/tailor/TemplateGallery.svelte": 2,
   "web/src/routes/companies/[slug]/discussion/+page.svelte": 1,
+  "web/src/routes/delete-account/+page.svelte": 2,
   "web/src/routes/docs/api/+layout.svelte": 1,
   "web/src/routes/docs/api/+page.svelte": 9,
   "web/src/routes/insights/+page.svelte": 4,
@@ -104,5 +105,6 @@
   "web/src/routes/open/+page.svelte": 8,
   "web/src/routes/privacy/+page.svelte": 2,
   "web/src/routes/status/+page.svelte": 1,
-  "web/src/routes/tailor/[slug]/+page.svelte": 2
+  "web/src/routes/tailor/[slug]/+page.svelte": 2,
+  "web/src/routes/terms/+page.svelte": 2
 }

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -46,6 +46,7 @@
         { label: 'Contribute', href: resolve('/contribute') },
         { label: 'Submit a job', href: resolve('/submit') },
         { label: 'Privacy', href: resolve('/privacy') },
+        { label: 'Terms', href: resolve('/terms') },
       ],
     },
   ];

--- a/web/src/routes/delete-account/+page.svelte
+++ b/web/src/routes/delete-account/+page.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+
+  const contactEmail = 'hello@freehire.me';
+  const canonical = $derived(`${page.url.origin}/delete-account`);
+</script>
+
+<Seo
+  title="Delete Your Account — freehire"
+  description="How to permanently delete your freehire account and data, on the web or in the mobile app."
+  {canonical}
+/>
+
+<div class="mx-auto w-full max-w-3xl px-4 py-6">
+  <div class="flex flex-col gap-8">
+    <header class="flex flex-col gap-3">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// legal</p>
+      <h1 class="text-4xl font-semibold leading-[1.0] tracking-tighter sm:text-5xl">
+        Delete Your Account
+      </h1>
+    </header>
+
+    <p class="text-base leading-relaxed text-muted-foreground">
+      You can permanently delete your freehire account and its data at any time, from the website
+      or the mobile app. This cannot be undone — there is no grace period and no recovery.
+    </p>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">How</h2>
+      <ol class="flex flex-col gap-2 text-sm leading-relaxed text-muted-foreground list-decimal pl-5">
+        <li>Sign in, then go to <span class="font-medium text-foreground">Account settings</span> (Profile).</li>
+        <li>Find <span class="font-medium text-foreground">Delete account</span> and open it.</li>
+        <li>Type your account email to confirm, then confirm the deletion.</li>
+      </ol>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        The same flow is available inside the mobile app, under Account settings.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">What gets deleted</h2>
+      <ul class="flex flex-col gap-2 text-sm leading-relaxed text-muted-foreground list-disc pl-5">
+        <li>Your CV, its parsed profile, and every CV you built or tailored</li>
+        <li>Your hosted mailbox, connected Gmail, and all stored messages</li>
+        <li>Saved jobs, applications, reminders, and match analyses</li>
+        <li>AI credits, saved searches, filters, and API keys</li>
+        <li>Your anonymous community handle</li>
+        <li>Your account and login credentials</li>
+      </ul>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        Deletion is immediate and permanent — we don't keep a recoverable copy afterward.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">Can't sign in?</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        If you can't access your account to delete it yourself, email us at
+        <a
+          href="mailto:{contactEmail}"
+          class="font-medium text-foreground underline-offset-4 hover:underline">{contactEmail}</a
+        >
+        from the address on the account and we'll delete it for you.
+      </p>
+    </section>
+  </div>
+</div>

--- a/web/src/routes/terms/+page.svelte
+++ b/web/src/routes/terms/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { resolve } from '$app/paths';
   import Seo from '$lib/components/Seo.svelte';
 
   const repoUrl = 'https://github.com/strelov1/freehire';
@@ -51,7 +52,7 @@
         You're responsible for the activity on your account and for keeping your credentials
         secure. You can delete your account at any time from account settings, or from the app —
         see <a
-          href="/delete-account"
+          href={resolve('/delete-account')}
           class="font-medium text-foreground underline-offset-4 hover:underline">Account Deletion</a
         > for how.
       </p>

--- a/web/src/routes/terms/+page.svelte
+++ b/web/src/routes/terms/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+
+  const repoUrl = 'https://github.com/strelov1/freehire';
+  const telegramUrl = 'https://t.me/freehiredev';
+  const contactEmail = 'hello@freehire.me';
+
+  const canonical = $derived(`${page.url.origin}/terms`);
+
+  // Static effective date — bump whenever the terms change.
+  const lastUpdated = 'August 10, 2026';
+</script>
+
+<Seo
+  title="Terms of Service — freehire"
+  description="The terms for using freehire, the open-source IT job aggregator: your account, acceptable use, job listings, AI features, and liability."
+  {canonical}
+/>
+
+<div class="mx-auto w-full max-w-3xl px-4 py-6">
+  <div class="flex flex-col gap-8">
+    <header class="flex flex-col gap-3">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// legal</p>
+      <h1 class="text-4xl font-semibold leading-[1.0] tracking-tighter sm:text-5xl">
+        Terms of Service
+      </h1>
+      <p class="text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
+    </header>
+
+    <p class="text-base leading-relaxed text-muted-foreground">
+      freehire (<a
+        href="https://freehire.me"
+        class="font-medium text-foreground underline-offset-4 hover:underline">freehire.me</a
+      >), including our mobile app, is a free, open-source IT job aggregator. By using it, you
+      agree to these terms.
+    </p>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">The service</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        We aggregate job postings from public company career boards and other public sources,
+        normalise and deduplicate them, and let you search, filter, save, and track them. We also
+        offer optional AI features — CV matching and fit analysis — that you choose to run.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">Your account</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        You're responsible for the activity on your account and for keeping your credentials
+        secure. You can delete your account at any time from account settings, or from the app —
+        see <a
+          href="/delete-account"
+          class="font-medium text-foreground underline-offset-4 hover:underline">Account Deletion</a
+        > for how.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">Acceptable use</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        Don't misuse the service: no scraping beyond our documented API, no attempting to bypass
+        rate limits or authentication, no uploading unlawful content, and no using the service to
+        harass or defraud anyone. We may suspend or terminate accounts that violate this.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">Job listings</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        Job postings are aggregated from third-party sources. We don't control their content or
+        accuracy, we don't guarantee a listing is still open, and applying is between you and the
+        employer — we're not a party to that relationship.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">AI features</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        Features like fit analysis and CV matching use a language model and can be wrong. They're
+        a research aid, not career or legal advice — use your own judgment before acting on them.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">No warranty, limited liability</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        The service is provided "as is," without warranties of any kind. To the extent permitted
+        by law, we're not liable for indirect, incidental, or consequential damages arising from
+        your use of it.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">Changes</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        We may update these terms as the product changes. Material changes will be reflected here
+        with a new "last updated" date.
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3">
+      <h2 class="text-xl font-semibold tracking-tight">Contact</h2>
+      <p class="text-sm leading-relaxed text-muted-foreground">
+        Questions about these terms? Reach us at
+        <a
+          href="mailto:{contactEmail}"
+          class="font-medium text-foreground underline-offset-4 hover:underline">{contactEmail}</a
+        >, on
+        <a href={telegramUrl} class="font-medium text-foreground underline-offset-4 hover:underline"
+          >Telegram</a
+        >, or via
+        <a href={repoUrl} class="font-medium text-foreground underline-offset-4 hover:underline"
+          >GitHub</a
+        >.
+      </p>
+    </section>
+  </div>
+</div>

--- a/web/static/.well-known/apple-app-site-association
+++ b/web/static/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": ["25U9HN34VM.me.freehire.mobile"],
+        "components": [
+          { "/": "/jobs/*" }
+        ]
+      }
+    ]
+  }
+}

--- a/web/static/.well-known/assetlinks.json
+++ b/web/static/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "me.freehire.mobile",
+      "sha256_cert_fingerprints": [
+        "84:D1:CC:CD:7F:2B:80:2F:5A:13:67:1F:16:2C:33:EC:A8:CF:14:59:4A:7C:1E:E9:B2:EF:94:09:2D:FE:51:0C"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Add `apple-app-site-association` and `assetlinks.json` so the freehire-mobile app opens `/jobs/*` links directly (App ID `me.freehire.mobile`, Team ID `25U9HN34VM`)
- Add draft `/terms` and `/delete-account` pages (needed for App Store / Play Store submission)
- Link `/terms` from the footer

## Test plan
- [ ] `pnpm install && pnpm run check` in `web/` (not yet run — this worktree had no `node_modules`)
- [ ] Visually verify `/terms` and `/delete-account` render correctly
- [ ] Confirm `https://freehire.me/.well-known/apple-app-site-association` and `.../assetlinks.json` serve as `application/json` once deployed