### PR TITLE
feat(sources): add NoDesk source adapter

### DIFF
--- a/internal/sources/nodesk.go
+++ b/internal/sources/nodesk.go
@@ -1,0 +1,92 @@
+package sources
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"time"
+
+	xhtml "golang.org/x/net/html"
+)
+
+// nodesk adapts nodesk.co, a remote-jobs board. Boardless (one public RSS feed, no
+// per-tenant board) and multi-company, so it stays in the source facet and takes each
+// posting's company from the feed. All-remote board, so every posting is remote. The feed
+// carries every posting's body inline (no detail call).
+//
+// Fetched via GetText rather than GetXML: unlike weworkremotely's feed (which wraps its body
+// in CDATA, leaving embedded entities as literal text), NoDesk's <description> contains raw,
+// unwrapped named entities such as "&rsquo;" that are not part of the XML entity set — the
+// standard library's strict decoder rejects them ("invalid character entity"). Decoding with
+// Strict=false leaves an unrecognized entity as literal text instead of erroring, and
+// html.UnescapeString (same helper weworkremotely already uses for its CDATA content) then
+// resolves it.
+type nodesk struct {
+	http TextGetter
+}
+
+const nodeskFeedURL = "https://nodesk.co/remote-jobs/index.xml"
+
+// NewNoDesk builds the NoDesk adapter over the given HTTP client.
+func NewNoDesk(c TextGetter) Source { return nodesk{http: c} }
+
+func (nodesk) Provider() string { return "nodesk" }
+
+func (nodesk) boardless() {}
+
+func (nodesk) aggregator() {}
+
+// nodeskItem is one RSS <item>: the title is "Role at Company", description is the plain-text
+// body, and guid is the native posting id (same value as link).
+type nodeskItem struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	GUID        string `xml:"guid"`
+	PubDate     string `xml:"pubDate"`
+	Description string `xml:"description"`
+}
+
+func (s nodesk) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	raw, err := s.http.GetText(ctx, nodeskFeedURL)
+	if err != nil {
+		return nil, fmt.Errorf("nodesk: feed: %w", err)
+	}
+	var feed struct {
+		Channel struct {
+			Items []nodeskItem `xml:"item"`
+		} `xml:"channel"`
+	}
+	dec := xml.NewDecoder(strings.NewReader(raw))
+	dec.Strict = false
+	if err := dec.Decode(&feed); err != nil {
+		return nil, fmt.Errorf("nodesk: feed: %w", err)
+	}
+	jobs := make([]Job, 0, len(feed.Channel.Items))
+	for _, it := range feed.Channel.Items {
+		if job, ok := it.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an RSS item to a Job, returning ok=false for an unusable item (no guid to key
+// on, or no " at " split which would leave the company empty and break the slug).
+func (it nodeskItem) toJob() (Job, bool) {
+	title, company, ok := strings.Cut(it.Title, " at ")
+	if it.GUID == "" || !ok || company == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:  it.GUID,
+		URL:         it.Link,
+		Title:       xhtml.UnescapeString(strings.TrimSpace(title)),
+		Company:     xhtml.UnescapeString(strings.TrimSpace(company)),
+		Location:    "Remote",
+		Description: sanitizeHTML(xhtml.UnescapeString(it.Description)),
+		Remote:      true,
+		WorkMode:    "remote",
+		PostedAt:    parseLayout(time.RFC1123Z, it.PubDate),
+	}, true
+}

--- a/internal/sources/nodesk_test.go
+++ b/internal/sources/nodesk_test.go
@@ -1,0 +1,83 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestNoDeskProvider(t *testing.T) {
+	if got := NewNoDesk(nil).Provider(); got != "nodesk" {
+		t.Errorf("Provider() = %q, want nodesk", got)
+	}
+}
+
+func TestNoDeskIsBoardlessAggregator(t *testing.T) {
+	s := NewNoDesk(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("nodesk should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("nodesk should implement the aggregator marker")
+	}
+}
+
+func TestNoDeskRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["nodesk"]; !ok {
+		t.Error("All() should register provider nodesk")
+	}
+	if !slices.Contains(FilterableProviders(), "nodesk") {
+		t.Error("FilterableProviders() should include nodesk")
+	}
+}
+
+func TestNoDeskBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/nodesk.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/nodesk.yml fails validation: %v", err)
+	}
+}
+
+// The live feed embeds raw named entities like "&rsquo;" outside CDATA, which the strict
+// XML decoder rejects ("invalid character entity") — this fixture reproduces that shape
+// rather than a hand-cleaned one, so a regression back to GetXML/strict decoding fails loudly.
+func TestNoDeskFetchSplitsTitleAndMaps(t *testing.T) {
+	feed := `<?xml version="1.0" encoding="utf-8"?><rss version="2.0"><channel>
+<item><title>Senior Backend Engineer at Skylight</title>
+<link>https://nodesk.co/remote-jobs/skylight-senior-backend-engineer/</link>
+<guid>https://nodesk.co/remote-jobs/skylight-senior-backend-engineer/</guid>
+<pubDate>Thu, 06 Aug 2026 08:00:00 +0200</pubDate>
+<description>Join today&rsquo;s team.</description></item>
+<item><title>NoCompanySeparator Role</title>
+<link>https://nodesk.co/remote-jobs/x-1/</link>
+<guid>https://nodesk.co/remote-jobs/x-1/</guid>
+<pubDate>Thu, 06 Aug 2026 08:00:00 +0200</pubDate></item>
+</channel></rss>`
+	fake := (&routedHTTP{}).route("index.xml", feed)
+	jobs, err := NewNoDesk(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (the no-separator title dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.Company != "Skylight" || j.Title != "Senior Backend Engineer" {
+		t.Errorf("title split wrong: company=%q title=%q", j.Company, j.Title)
+	}
+	if j.ExternalID != "https://nodesk.co/remote-jobs/skylight-senior-backend-engineer/" {
+		t.Errorf("ExternalID = %q", j.ExternalID)
+	}
+	if j.Description != "Join today’s team." {
+		t.Errorf("Description = %q, want the &rsquo; entity resolved to U+2019", j.Description)
+	}
+	if !j.Remote || j.WorkMode != "remote" || j.Location != "Remote" {
+		t.Errorf("Remote=%v WorkMode=%q Location=%q", j.Remote, j.WorkMode, j.Location)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed RFC1123Z timestamp")
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -205,6 +205,7 @@ func All(c HTTPClient) map[string]Source {
 		NewRemoteOK(c),
 		NewJobicy(c),
 		NewWeWorkRemotely(c),
+		NewNoDesk(c),
 		NewCryptocurrencyJobs(c),
 		NewJobspresso(c),
 		NewStartupAndVC(c),

--- a/sources/nodesk.yml
+++ b/sources/nodesk.yml
@@ -1,0 +1,5 @@
+# NoDesk remote-jobs board. Boardless: one public RSS feed
+# (nodesk.co/remote-jobs/index.xml), so the entry carries no board; each job's company
+# comes from the posting, not this placeholder.
+- company: NoDesk
+  provider: nodesk


### PR DESCRIPTION
## Summary
- Adds a boardless RSS adapter for NoDesk (`nodesk.co/remote-jobs/index.xml`), mirroring the existing `weworkremotely` adapter's shape (title split, all-remote board).
- The live feed embeds raw named entities (e.g. `&rsquo;`) outside CDATA, which the standard library's strict XML decoder rejects with "invalid character entity". Unlike `weworkremotely` (whose body is CDATA-wrapped, sidestepping this), NoDesk needed a lenient decode: fetched via `GetText`, decoded with `Strict = false` (leaves an unrecognized entity as literal text instead of erroring), then `html.UnescapeString` resolves it — the same helper `weworkremotely` already uses for its CDATA content.
- Registers the adapter in `sources.All` and adds `sources/nodesk.yml`.

Fixes #1629

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/...` (includes a fixture reproducing the live feed's raw-entity shape, so a regression back to strict `GetXML` decoding fails loudly)