### PR TITLE
feat(sources): add Cryptocurrency Jobs source adapter

### DIFF
--- a/internal/sources/cryptocurrencyjobs.go
+++ b/internal/sources/cryptocurrencyjobs.go
@@ -1,0 +1,91 @@
+package sources
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"time"
+
+	xhtml "golang.org/x/net/html"
+)
+
+// cryptocurrencyjobs adapts cryptocurrencyjobs.co, a Web3/crypto-niche remote-jobs board.
+// Boardless (one public RSS feed, no per-tenant board) and multi-company, so it stays in the
+// source facet and takes each posting's company from the feed. All-remote board, so every
+// posting is remote. The feed carries every posting's body inline (no detail call).
+//
+// Fetched via GetText rather than GetXML and decoded leniently (Strict=false), same as the
+// nodesk adapter: this board runs the same underlying feed generator (identical "Role at
+// Company" / plain-text-description / guid-equals-link shape, same host family as nodesk.co),
+// which is known to embed raw named entities such as "&rsquo;" outside CDATA — invalid XML
+// that the strict decoder rejects. html.UnescapeString then resolves whatever the lenient
+// decode left as literal entity text.
+type cryptocurrencyjobs struct {
+	http TextGetter
+}
+
+const cryptocurrencyjobsFeedURL = "https://cryptocurrencyjobs.co/index.xml"
+
+// NewCryptocurrencyJobs builds the Cryptocurrency Jobs adapter over the given HTTP client.
+func NewCryptocurrencyJobs(c TextGetter) Source { return cryptocurrencyjobs{http: c} }
+
+func (cryptocurrencyjobs) Provider() string { return "cryptocurrencyjobs" }
+
+func (cryptocurrencyjobs) boardless() {}
+
+func (cryptocurrencyjobs) aggregator() {}
+
+// cryptocurrencyjobsItem is one RSS <item>: the title is "Role at Company", description is
+// the plain-text body, and guid is the native posting id (same value as link).
+type cryptocurrencyjobsItem struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	GUID        string `xml:"guid"`
+	PubDate     string `xml:"pubDate"`
+	Description string `xml:"description"`
+}
+
+func (s cryptocurrencyjobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	raw, err := s.http.GetText(ctx, cryptocurrencyjobsFeedURL)
+	if err != nil {
+		return nil, fmt.Errorf("cryptocurrencyjobs: feed: %w", err)
+	}
+	var feed struct {
+		Channel struct {
+			Items []cryptocurrencyjobsItem `xml:"item"`
+		} `xml:"channel"`
+	}
+	dec := xml.NewDecoder(strings.NewReader(raw))
+	dec.Strict = false
+	if err := dec.Decode(&feed); err != nil {
+		return nil, fmt.Errorf("cryptocurrencyjobs: feed: %w", err)
+	}
+	jobs := make([]Job, 0, len(feed.Channel.Items))
+	for _, it := range feed.Channel.Items {
+		if job, ok := it.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an RSS item to a Job, returning ok=false for an unusable item (no guid to key
+// on, or no " at " split which would leave the company empty and break the slug).
+func (it cryptocurrencyjobsItem) toJob() (Job, bool) {
+	title, company, ok := strings.Cut(it.Title, " at ")
+	if it.GUID == "" || !ok || company == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:  it.GUID,
+		URL:         it.Link,
+		Title:       xhtml.UnescapeString(strings.TrimSpace(title)),
+		Company:     xhtml.UnescapeString(strings.TrimSpace(company)),
+		Location:    "Remote",
+		Description: sanitizeHTML(xhtml.UnescapeString(it.Description)),
+		Remote:      true,
+		WorkMode:    "remote",
+		PostedAt:    parseLayout(time.RFC1123Z, it.PubDate),
+	}, true
+}

--- a/internal/sources/cryptocurrencyjobs_test.go
+++ b/internal/sources/cryptocurrencyjobs_test.go
@@ -1,0 +1,82 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestCryptocurrencyJobsProvider(t *testing.T) {
+	if got := NewCryptocurrencyJobs(nil).Provider(); got != "cryptocurrencyjobs" {
+		t.Errorf("Provider() = %q, want cryptocurrencyjobs", got)
+	}
+}
+
+func TestCryptocurrencyJobsIsBoardlessAggregator(t *testing.T) {
+	s := NewCryptocurrencyJobs(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("cryptocurrencyjobs should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("cryptocurrencyjobs should implement the aggregator marker")
+	}
+}
+
+func TestCryptocurrencyJobsRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["cryptocurrencyjobs"]; !ok {
+		t.Error("All() should register provider cryptocurrencyjobs")
+	}
+	if !slices.Contains(FilterableProviders(), "cryptocurrencyjobs") {
+		t.Error("FilterableProviders() should include cryptocurrencyjobs")
+	}
+}
+
+func TestCryptocurrencyJobsBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/cryptocurrencyjobs.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/cryptocurrencyjobs.yml fails validation: %v", err)
+	}
+}
+
+// Same feed generator family as nodesk (see the adapter's doc comment): reproduces the raw,
+// non-CDATA "&rsquo;" entity shape so a regression back to strict GetXML decoding fails loudly.
+func TestCryptocurrencyJobsFetchSplitsTitleAndMaps(t *testing.T) {
+	feed := `<?xml version="1.0" encoding="utf-8"?><rss version="2.0"><channel>
+<item><title>Senior Platform Engineer at Chronicle</title>
+<link>https://cryptocurrencyjobs.co/engineering/chronicle-senior-platform-engineer/</link>
+<guid>https://cryptocurrencyjobs.co/engineering/chronicle-senior-platform-engineer/</guid>
+<pubDate>Mon, 10 Aug 2026 16:40:02 +0200</pubDate>
+<description>Join today&rsquo;s team.</description></item>
+<item><title>NoCompanySeparator Role</title>
+<link>https://cryptocurrencyjobs.co/x-1/</link>
+<guid>https://cryptocurrencyjobs.co/x-1/</guid>
+<pubDate>Mon, 10 Aug 2026 16:40:02 +0200</pubDate></item>
+</channel></rss>`
+	fake := (&routedHTTP{}).route("index.xml", feed)
+	jobs, err := NewCryptocurrencyJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (the no-separator title dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.Company != "Chronicle" || j.Title != "Senior Platform Engineer" {
+		t.Errorf("title split wrong: company=%q title=%q", j.Company, j.Title)
+	}
+	if j.ExternalID != "https://cryptocurrencyjobs.co/engineering/chronicle-senior-platform-engineer/" {
+		t.Errorf("ExternalID = %q", j.ExternalID)
+	}
+	if j.Description != "Join today’s team." {
+		t.Errorf("Description = %q, want the &rsquo; entity resolved to U+2019", j.Description)
+	}
+	if !j.Remote || j.WorkMode != "remote" || j.Location != "Remote" {
+		t.Errorf("Remote=%v WorkMode=%q Location=%q", j.Remote, j.WorkMode, j.Location)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed RFC1123Z timestamp")
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -205,6 +205,7 @@ func All(c HTTPClient) map[string]Source {
 		NewRemoteOK(c),
 		NewJobicy(c),
 		NewWeWorkRemotely(c),
+		NewCryptocurrencyJobs(c),
 		NewJobspresso(c),
 		NewStartupAndVC(c),
 		NewFourDayWeek(c),

--- a/sources/cryptocurrencyjobs.yml
+++ b/sources/cryptocurrencyjobs.yml
@@ -1,0 +1,5 @@
+# Cryptocurrency Jobs remote-jobs board (Web3/crypto niche). Boardless: one public RSS feed
+# (cryptocurrencyjobs.co/index.xml), so the entry carries no board; each job's company
+# comes from the posting, not this placeholder.
+- company: Cryptocurrency Jobs
+  provider: cryptocurrencyjobs


### PR DESCRIPTION
## Summary
- Adds a boardless RSS adapter for Cryptocurrency Jobs (`cryptocurrencyjobs.co/index.xml`), all-remote Web3/crypto niche board.
- Same feed shape as `weworkremotely`/`nodesk` ("Role at Company" title, plain-text description, guid = link). Uses the same lenient-decode approach just added for `nodesk` (#1629): fetched via `GetText`, decoded with `Strict = false`, then `html.UnescapeString` resolves any raw named entities the feed embeds outside CDATA — this board runs the same underlying feed generator family as nodesk.co (identical item shape), so the same non-standard-entity risk applies even though today's snapshot happened not to hit it.
- Registers the adapter in `sources.All` and adds `sources/cryptocurrencyjobs.yml`.
- robots.txt disallows a handful of named AI-training crawlers plus wildcard query strings, but the plain `/index.xml` fetch this adapter makes isn't in any disallow list.

Fixes #1632

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/...`