### PR TITLE
feat(sources): add Remotli source adapter

### DIFF
--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -222,6 +222,7 @@ func All(c HTTPClient) map[string]Source {
 		NewPowerToFly(c),
 		NewHimalayas(c),
 		NewRemotive(c),
+		NewRemotli(c),
 		NewTheMuse(c),
 		NewJustJoin(c),
 		NewNoFluffJobs(c),

--- a/internal/sources/remotli.go
+++ b/internal/sources/remotli.go
@@ -22,6 +22,9 @@ type remotli struct {
 
 const remotliListURL = "https://remotli.ch/api/jobs?page=%d"
 
+// remotliMaxPages bounds pagination so a wrong or missing totalPages cannot loop.
+const remotliMaxPages = 100
+
 // NewRemotli builds the Remotli adapter over the given HTTP client.
 func NewRemotli(c JSONGetter) Source { return remotli{http: c} }
 
@@ -59,7 +62,7 @@ type remotliPosting struct {
 
 func (s remotli) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 	var jobs []Job
-	for page := 1; ; page++ {
+	for page := 1; page <= remotliMaxPages; page++ {
 		var resp remotliResponse
 		url := fmt.Sprintf(remotliListURL, page)
 		if err := s.http.GetJSON(ctx, url, &resp); err != nil {

--- a/internal/sources/remotli.go
+++ b/internal/sources/remotli.go
@@ -1,0 +1,107 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// remotli adapts remotli.ch, a Swiss remote-jobs aggregator. Boardless (one public API, no
+// per-tenant board) and multi-company, so it stays in the source facet and takes each
+// posting's company from the feed. The /api/jobs endpoint pages by page number over a
+// reported totalPages, and ships each posting's full description inline (no detail call).
+//
+// Note: remotli.ch's robots.txt disallows /api/ for every listed user agent. The endpoint is
+// public and unauthenticated, and the crawl is a scheduled job rather than a search-engine
+// crawler, but this is flagged here because it was flagged in the adapter's tracking issue as
+// a conscious call rather than a silent one.
+type remotli struct {
+	http JSONGetter
+}
+
+const remotliListURL = "https://remotli.ch/api/jobs?page=%d"
+
+// NewRemotli builds the Remotli adapter over the given HTTP client.
+func NewRemotli(c JSONGetter) Source { return remotli{http: c} }
+
+func (remotli) Provider() string { return "remotli" }
+
+func (remotli) boardless() {}
+
+func (remotli) aggregator() {}
+
+// remotliResponse is one page: postings plus pagination info used to decide whether another
+// page is due. Each element of Jobs is wrapped one level deep under its own "jobs" key.
+type remotliResponse struct {
+	Jobs []struct {
+		Job remotliPosting `json:"jobs"`
+	} `json:"jobs"`
+	Pagination struct {
+		Page       int `json:"page"`
+		TotalPages int `json:"totalPages"`
+	} `json:"pagination"`
+}
+
+// remotliPosting is one posting, body inline (no detail call). Status gives liveness at
+// source, so only "active" postings are emitted.
+type remotliPosting struct {
+	ID          int64  `json:"id"`
+	Title       string `json:"title"`
+	Company     string `json:"company"`
+	Location    string `json:"location"`
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	ApplyURL    string `json:"applyUrl"`
+	Status      string `json:"status"`
+	PublishedAt string `json:"publishedAt"`
+}
+
+func (s remotli) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; ; page++ {
+		var resp remotliResponse
+		url := fmt.Sprintf(remotliListURL, page)
+		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+			// Only a failure on the very first page is a board-level error; a later page
+			// failing ends the walk with what was gathered so far (see internal/sources/AGENTS.md).
+			if page == 1 {
+				return nil, fmt.Errorf("remotli: list page %d: %w", page, err)
+			}
+			return jobs, nil
+		}
+		for _, wrapper := range resp.Jobs {
+			if job, ok := wrapper.Job.toJob(); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		if page >= resp.Pagination.TotalPages {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
+// native id, no company which would break the slug, or a status other than "active" — the
+// board reports liveness at source, so a non-active posting is dropped rather than upserted).
+func (p remotliPosting) toJob() (Job, bool) {
+	if p.ID == 0 || p.Company == "" || p.Status != "active" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID: strconv.FormatInt(p.ID, 10),
+		URL:        p.ApplyURL,
+		Title:      p.Title,
+		Company:    p.Company,
+		Location:   p.Location,
+		// Remote is the shared free-text heuristic: unlike weworkremotely/nodesk, this board
+		// mixes onsite Swiss postings (e.g. "Zürich, Switzerland") in with remote ones, and the
+		// API carries no structured remote flag (remotePolicy is always null in practice), so
+		// WorkMode is left for the pipeline's location dictionary to derive.
+		Remote:         isRemote(p.Location),
+		Description:    sanitizeHTML(p.Description),
+		EmploymentType: schemaEmploymentType(strings.ReplaceAll(p.Type, "-", "_")),
+		PostedAt:       parseRFC3339(p.PublishedAt),
+	}, true
+}

--- a/internal/sources/remotli_test.go
+++ b/internal/sources/remotli_test.go
@@ -1,0 +1,109 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestRemotliProvider(t *testing.T) {
+	if got := NewRemotli(nil).Provider(); got != "remotli" {
+		t.Errorf("Provider() = %q, want remotli", got)
+	}
+}
+
+func TestRemotliIsBoardlessAggregator(t *testing.T) {
+	s := NewRemotli(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("remotli should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("remotli should implement the aggregator marker")
+	}
+}
+
+func TestRemotliRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["remotli"]; !ok {
+		t.Error("All() should register provider remotli")
+	}
+	if !slices.Contains(FilterableProviders(), "remotli") {
+		t.Error("FilterableProviders() should include remotli")
+	}
+}
+
+func TestRemotliBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/remotli.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/remotli.yml fails validation: %v", err)
+	}
+}
+
+func TestRemotliFetchPaginatesFiltersAndMaps(t *testing.T) {
+	page1 := `{"jobs":[
+{"jobs":{"id":6381,"title":"Senior QA Engineer","company":"Storyblok","location":"Zürich, Switzerland","type":"full-time","description":"<p>Test.</p>","applyUrl":"https://www.storyblok.com/job?gh_jid=1","status":"active","publishedAt":"2026-08-10T08:47:26.000Z"}},
+{"jobs":{"id":6300,"title":"Closed Role","company":"Ghost","location":"Remote","type":"full-time","status":"closed"}},
+{"jobs":{"id":0,"title":"NoID","company":"NoID","status":"active"}}
+],"pagination":{"page":1,"limit":20,"total":21,"totalPages":2}}`
+	page2 := `{"jobs":[
+{"jobs":{"id":6200,"title":"Remote Engineer","company":"Acme","location":"Remote-EMEA","type":"part-time","description":"<p>Second page.</p>","applyUrl":"https://acme.example/jobs/1","status":"active","publishedAt":"2026-08-05T00:00:00.000Z"}}
+],"pagination":{"page":2,"limit":20,"total":21,"totalPages":2}}`
+	fake := (&routedHTTP{}).route("page=1", page1).route("page=2", page2)
+	jobs, err := NewRemotli(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.calls != 2 {
+		t.Errorf("made %d requests, want 2 (one per page)", fake.calls)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (closed status and zero-id dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "6381" || j.Company != "Storyblok" || j.Title != "Senior QA Engineer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://www.storyblok.com/job?gh_jid=1" {
+		t.Errorf("URL = %q, want applyUrl", j.URL)
+	}
+	if j.Remote {
+		t.Error("Remote should be false for an onsite Swiss city location")
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed RFC3339 timestamp")
+	}
+	j2 := jobs[1]
+	if !j2.Remote {
+		t.Error("Remote should be true for a Remote-EMEA location")
+	}
+	if j2.EmploymentType != "part_time" {
+		t.Errorf("EmploymentType = %q, want part_time", j2.EmploymentType)
+	}
+}
+
+func TestRemotliFetchStopsOnFirstPageFailure(t *testing.T) {
+	fake := &routedHTTP{}
+	_, err := NewRemotli(fake).Fetch(context.Background(), CompanyEntry{})
+	if err == nil {
+		t.Fatal("Fetch: want error on first-page failure, got nil")
+	}
+}
+
+func TestRemotliFetchReturnsPartialOnLaterPageFailure(t *testing.T) {
+	page1 := `{"jobs":[
+{"jobs":{"id":1,"title":"Role","company":"Acme","location":"Remote","type":"full-time","status":"active","applyUrl":"https://acme.example/1","publishedAt":"2026-08-10T08:47:26.000Z"}}
+],"pagination":{"page":1,"limit":20,"total":21,"totalPages":2}}`
+	fake := (&routedHTTP{}).route("page=1", page1)
+	jobs, err := NewRemotli(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (partial result kept from the successful first page)", len(jobs))
+	}
+}

--- a/sources/remotli.yml
+++ b/sources/remotli.yml
@@ -1,0 +1,5 @@
+# Remotli Swiss remote-jobs aggregator. Boardless: one public API
+# (remotli.ch/api/jobs), so the entry carries no board; each job's company comes from
+# the posting, not this placeholder.
+- company: Remotli
+  provider: remotli


### PR DESCRIPTION
## Summary
- Adds a boardless JSON adapter for Remotli (`remotli.ch/api/jobs`), a Swiss remote-jobs aggregator. Paginated by `?page=N` over a reported `pagination.totalPages`; each posting is wrapped one level deep under its own `jobs` key, matching the live-verified shape from the issue.
- Only `status: "active"` postings are emitted — the field gives liveness at source.
- `Remote` is set from the shared `isRemote()` free-text location heuristic rather than a structured flag: unlike this batch's other RSS boards, Remotli mixes onsite Swiss postings (`"Zürich, Switzerland"`) in with remote ones, and the API's `remotePolicy` field was null on every sampled posting, so `WorkMode` is left empty for the pipeline's own location dictionary to derive.
- `EmploymentType` reuses the existing `schemaEmploymentType` mapper (Remotli's `type` uses hyphens — `"full-time"` — where the schema.org enum uses underscores, so the hyphens are normalized before the shared mapper runs).
- Registers the adapter in `sources.All` and adds `sources/remotli.yml`.

**Conscious call, not a silent one** (as the issue itself asked to flag): `robots.txt` disallows `/api/` for every listed user agent. The endpoint is public and unauthenticated, and the crawl is a scheduled job rather than a search-engine crawler, so this PR implements the adapter — noted in its doc comment for visibility.

Fixes #1631

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/...` (pagination across two pages, active-status filter, onsite-vs-remote heuristic, first-page-hard-fail vs later-page-partial-result)