### PR TITLE
feat(sources): add The Muse source adapter

### DIFF
--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -220,6 +220,7 @@ func All(c HTTPClient) map[string]Source {
 		NewPowerToFly(c),
 		NewHimalayas(c),
 		NewRemotive(c),
+		NewTheMuse(c),
 		NewJustJoin(c),
 		NewNoFluffJobs(c),
 		NewWantapply(c),

--- a/internal/sources/themuse.go
+++ b/internal/sources/themuse.go
@@ -1,0 +1,130 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// themuse adapts themuse.com, a well-known-brands job aggregator (US-heavy). Boardless (one
+// public API, no per-tenant board) and multi-company, so it stays in the source facet and
+// takes each posting's company from the feed. The /api/public/jobs endpoint pages by page
+// number and ships each posting's full description inline (no detail call).
+//
+// The response's own page_count/total (verified live: 20356 pages, 407108 jobs) is NOT a
+// walkable bound: despite reporting that count, the API itself rejects any page beyond ~99
+// with a 400 ("Value `page` is too high") — the true depth is roughly 2 orders of magnitude
+// smaller than what the metadata claims (the same shape of surprise WhatJobs' feed has, see
+// internal/sources/AGENTS.md). No special-casing is needed for it: the adapter walks forward
+// from page 1 and, per the paginated-walk convention (AGENTS.md — first page failing is a
+// board error, a later page failing ends the walk with what was gathered), the 400 on the
+// real ceiling is just a later-page failure that stops the crawl and returns the partial
+// catalogue already collected.
+type themuse struct {
+	http JSONGetter
+}
+
+const themuseListURL = "https://www.themuse.com/api/public/jobs?page=%d"
+
+// NewTheMuse builds the The Muse adapter over the given HTTP client.
+func NewTheMuse(c JSONGetter) Source { return themuse{http: c} }
+
+func (themuse) Provider() string { return "themuse" }
+
+func (themuse) boardless() {}
+
+func (themuse) aggregator() {}
+
+// themuseResponse is one page: postings plus the (unreliable, see above) catalogue-wide page
+// count used only as a defensive upper bound.
+type themuseResponse struct {
+	PageCount int              `json:"page_count"`
+	Results   []themusePosting `json:"results"`
+}
+
+// themusePosting is one posting, body inline (no detail call). Levels carries the platform's
+// own seniority taxonomy; a posting can list more than one, so the first is taken as primary.
+type themusePosting struct {
+	ID              int64  `json:"id"`
+	Name            string `json:"name"`
+	Contents        string `json:"contents"`
+	PublicationDate string `json:"publication_date"`
+	Locations       []struct {
+		Name string `json:"name"`
+	} `json:"locations"`
+	Levels []struct {
+		ShortName string `json:"short_name"`
+	} `json:"levels"`
+	Refs struct {
+		LandingPage string `json:"landing_page"`
+	} `json:"refs"`
+	Company struct {
+		Name string `json:"name"`
+	} `json:"company"`
+}
+
+func (s themuse) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; ; page++ {
+		var resp themuseResponse
+		url := fmt.Sprintf(themuseListURL, page)
+		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("themuse: list page %d: %w", page, err)
+			}
+			return jobs, nil
+		}
+		for _, p := range resp.Results {
+			if job, ok := p.toJob(); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		if len(resp.Results) == 0 || (resp.PageCount > 0 && page >= resp.PageCount) {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
+// native id, or no company which would break the slug).
+func (p themusePosting) toJob() (Job, bool) {
+	if p.ID == 0 || p.Company.Name == "" {
+		return Job{}, false
+	}
+	var location string
+	if len(p.Locations) > 0 {
+		location = p.Locations[0].Name
+	}
+	var seniority string
+	if len(p.Levels) > 0 {
+		seniority = museSeniority(p.Levels[0].ShortName)
+	}
+	return Job{
+		ExternalID:  strconv.FormatInt(p.ID, 10),
+		URL:         p.Refs.LandingPage,
+		Title:       p.Name,
+		Company:     p.Company.Name,
+		Location:    location,
+		Description: sanitizeHTML(p.Contents),
+		Seniority:   seniority,
+		PostedAt:    parseRFC3339(p.PublicationDate),
+	}, true
+}
+
+// museSeniority maps The Muse's own level taxonomy (verified live: "entry", "mid", "senior" —
+// no other short_name observed across a multi-page sample) to freehire's controlled
+// vocabulary. An unrecognized value maps to "" rather than a guess (vocab.SeniorityValues is
+// dict-only).
+func museSeniority(shortName string) string {
+	switch shortName {
+	case "entry":
+		return "junior"
+	case "mid":
+		return "middle"
+	case "senior":
+		return "senior"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/themuse_test.go
+++ b/internal/sources/themuse_test.go
@@ -1,0 +1,124 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestTheMuseProvider(t *testing.T) {
+	if got := NewTheMuse(nil).Provider(); got != "themuse" {
+		t.Errorf("Provider() = %q, want themuse", got)
+	}
+}
+
+func TestTheMuseIsBoardlessAggregator(t *testing.T) {
+	s := NewTheMuse(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("themuse should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("themuse should implement the aggregator marker")
+	}
+}
+
+func TestTheMuseRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["themuse"]; !ok {
+		t.Error("All() should register provider themuse")
+	}
+	if !slices.Contains(FilterableProviders(), "themuse") {
+		t.Error("FilterableProviders() should include themuse")
+	}
+}
+
+func TestTheMuseBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/themuse.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/themuse.yml fails validation: %v", err)
+	}
+}
+
+func TestTheMuseFetchPaginatesAndMaps(t *testing.T) {
+	page1 := `{"page_count":2,"results":[
+{"id":123,"name":"Senior Specialist Electrical Engineer","contents":"<p>Build.</p>","publication_date":"2026-03-17T13:37:20Z","locations":[{"name":"Anaheim, CA"}],"levels":[{"name":"Senior Level","short_name":"senior"}],"refs":{"landing_page":"https://www.themuse.com/jobs/acme/senior-ee"},"company":{"name":"L3Harris Technologies"}},
+{"id":0,"name":"NoID","company":{"name":"Ghost"}}
+]}`
+	page2 := `{"page_count":2,"results":[
+{"id":124,"name":"Junior Analyst","contents":"<p>Analyze.</p>","publication_date":"2026-01-01T00:00:00Z","locations":[{"name":"Remote"}],"levels":[{"name":"Entry Level","short_name":"entry"}],"refs":{"landing_page":"https://www.themuse.com/jobs/acme/jr-analyst"},"company":{"name":"Acme"}}
+]}`
+	fake := (&routedHTTP{}).route("page=1", page1).route("page=2", page2)
+	jobs, err := NewTheMuse(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.calls != 2 {
+		t.Errorf("made %d requests, want 2 (one per page)", fake.calls)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (zero-id dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "123" || j.Company != "L3Harris Technologies" || j.Title != "Senior Specialist Electrical Engineer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://www.themuse.com/jobs/acme/senior-ee" {
+		t.Errorf("URL = %q, want refs.landing_page", j.URL)
+	}
+	if j.Location != "Anaheim, CA" {
+		t.Errorf("Location = %q, want locations[0].name", j.Location)
+	}
+	if j.Seniority != "senior" {
+		t.Errorf("Seniority = %q, want senior", j.Seniority)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed RFC3339 timestamp")
+	}
+	if jobs[1].Seniority != "junior" {
+		t.Errorf("Seniority = %q, want junior (entry mapped)", jobs[1].Seniority)
+	}
+}
+
+// The live API's own page_count/total wildly overstates what is actually walkable — a page
+// far short of that count 400s with "Value `page` is too high" (verified live: page 100 fails
+// while page 99 succeeds, despite page_count reporting in the tens of thousands). This
+// reproduces that shape: page 2 fails even though page_count claims more pages exist, and the
+// walk must end with the partial result rather than erroring the whole crawl.
+func TestTheMuseFetchReturnsPartialWhenRealCeilingIsBelowReportedPageCount(t *testing.T) {
+	page1 := `{"page_count":20356,"results":[
+{"id":123,"name":"Role","contents":"<p>Build.</p>","publication_date":"2026-03-17T13:37:20Z","locations":[{"name":"Remote"}],"refs":{"landing_page":"https://www.themuse.com/jobs/acme/role"},"company":{"name":"Acme"}}
+]}`
+	fake := (&routedHTTP{}).route("page=1", page1)
+	jobs, err := NewTheMuse(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (partial result kept from the successful first page)", len(jobs))
+	}
+}
+
+func TestTheMuseFetchStopsOnFirstPageFailure(t *testing.T) {
+	fake := &routedHTTP{}
+	_, err := NewTheMuse(fake).Fetch(context.Background(), CompanyEntry{})
+	if err == nil {
+		t.Fatal("Fetch: want error on first-page failure, got nil")
+	}
+}
+
+func TestMuseSeniority(t *testing.T) {
+	cases := map[string]string{
+		"entry":   "junior",
+		"mid":     "middle",
+		"senior":  "senior",
+		"unknown": "",
+		"":        "",
+	}
+	for in, want := range cases {
+		if got := museSeniority(in); got != want {
+			t.Errorf("museSeniority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/sources/themuse.yml
+++ b/sources/themuse.yml
@@ -1,0 +1,5 @@
+# The Muse job aggregator (well-known brands, US-heavy). Boardless: one public API
+# (themuse.com/api/public/jobs), so the entry carries no board; each job's company comes
+# from the posting, not this placeholder.
+- company: The Muse
+  provider: themuse


### PR DESCRIPTION
## Summary
- Adds a boardless JSON adapter for The Muse (`themuse.com/api/public/jobs`), a well-known-brands job aggregator. Paginated by page number, each posting's full HTML body ships inline.
- Field mapping per the issue: title = `name`, url = `refs.landing_page`, company = `company.name`, location = `locations[0].name`, postedAt = `publication_date`. Also maps `levels[].short_name` (the platform's own seniority taxonomy) into freehire's controlled vocabulary — `entry`→`junior`, `mid`→`middle`, `senior`→`senior` (the only three values observed across a multi-page live sample), unrecognized values left empty rather than guessed.
- Registers the adapter in `sources.All` and adds `sources/themuse.yml`.

**One live finding worth flagging:** the issue says to walk `page_count`/`total` as the real page budget, but verified live, those numbers (20356 pages / 407108 jobs) are not actually walkable — the API 400s on any page past ~99 ("Value \`page\` is too high") regardless of what the metadata claims, the same shape of surprise `internal/sources/AGENTS.md` already documents for WhatJobs' feed. No special-casing was needed for it: this repo's existing paginated-walk convention (a first-page failure is a board error, a later-page failure ends the walk with the partial result already gathered) handles it correctly as-is — the adapter just walks forward from page 1 and lets that convention do its job. Documented in the adapter's doc comment for the next person who touches it.

Fixes #1628

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/...` (pagination + field mapping, seniority mapping, first-page-hard-fail vs later-page-partial-result reproducing the real page-99 ceiling)