### PR TITLE
docs(assistant): note REALTIME_MODEL needs the provider prefix

### DIFF
--- a/internal/assistant/AGENTS.md
+++ b/internal/assistant/AGENTS.md
@@ -154,6 +154,15 @@ the ordinary tool-calling turn loop, not inside it:
   else here, gated by its own `REALTIME_MODEL` (no default, same posture as
   `STTModel` in `internal/config` — unset means the feature is absent, not billed for
   by accident).
+- **`REALTIME_MODEL` must carry the provider prefix** (`openai/gpt-realtime-2.1`, not
+  the bare `gpt-realtime-2.1`), unlike every other model name in this file. The
+  litellm proxy's realtime WebRTC feature is lazy-loaded and does not resolve a
+  `model_name` alias the way the rest of the proxy does — `can_key_call_resolved_model`
+  accepts the alias, but the actual upstream call then fails with `litellm.BadRequestError:
+  LLM Provider NOT provided`. Confirmed live against the production proxy
+  (`root@204.168.137.149:/opt/litellm`) on 2026-08-10: a `model_name: gpt-realtime-2.1`
+  entry in `config.yaml` is harmless but unnecessary — what actually works is the
+  client passing the provider-prefixed string directly.
 
 **Interview debrief** is the rehearsal's mirror: the review of an interview that has
 already happened, minted from `POST /assistant/sessions?preset=debrief&job=<slug>`. It


### PR DESCRIPTION
Rebased replacement for #1721 (that branch carried pre-squash history from #1716 and showed as conflicting). Doc-only, no code change.

Discovered while wiring the prod litellm proxy: `REALTIME_MODEL` needs the provider prefix (`openai/gpt-realtime-2.1`), not the bare alias — the litellm proxy's realtime WebRTC feature doesn't resolve a `model_name` alias the way the rest of the proxy does. Prod is already configured correctly; this just writes it down.