### PR TITLE
fix(web): strip litellm provider prefix before the direct OpenAI call

### DIFF
--- a/web/src/lib/assistant/VoiceCall.svelte
+++ b/web/src/lib/assistant/VoiceCall.svelte
@@ -13,6 +13,7 @@
     initVoiceCallState,
     MAX_CALL_MS,
     END_WARNING_MS,
+    openaiModelID,
     type RealtimeServerEvent,
   } from '$lib/assistant/voiceCall';
 
@@ -106,7 +107,10 @@
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
 
-      const sdpResp = await fetch(`https://api.openai.com/v1/realtime/calls?model=${encodeURIComponent(token.model)}`, {
+      // token.model is the litellm-routing name (may carry a provider prefix our
+      // proxy needed to mint the secret); this call bypasses the proxy and talks to
+      // OpenAI directly, which needs its own bare model id — see openaiModelID.
+      const sdpResp = await fetch(`https://api.openai.com/v1/realtime/calls?model=${encodeURIComponent(openaiModelID(token.model))}`, {
         method: 'POST',
         body: offer.sdp,
         headers: { Authorization: `Bearer ${token.value}`, 'Content-Type': 'application/sdp' },

--- a/web/src/lib/assistant/voiceCall.test.ts
+++ b/web/src/lib/assistant/voiceCall.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { applyRealtimeEvent, canUseVoiceCall, initVoiceCallState } from './voiceCall';
+import { applyRealtimeEvent, canUseVoiceCall, initVoiceCallState, openaiModelID } from './voiceCall';
+
+describe('openaiModelID', () => {
+  it('strips a litellm provider prefix', () => {
+    expect(openaiModelID('openai/gpt-realtime-2.1')).toBe('gpt-realtime-2.1');
+  });
+
+  it('leaves a bare model id alone', () => {
+    // A deployment whose REALTIME_MODEL never needed a routing prefix (e.g. talking
+    // to OpenAI directly, no litellm in front) must not be mangled.
+    expect(openaiModelID('gpt-realtime-2.1')).toBe('gpt-realtime-2.1');
+  });
+
+  it('takes the LAST segment, for a routing alias with more than one slash', () => {
+    expect(openaiModelID('privateclaw/openai/gpt-realtime-2.1')).toBe('gpt-realtime-2.1');
+  });
+});
 
 describe('canUseVoiceCall', () => {
   it('is true only when both APIs are present', () => {

--- a/web/src/lib/assistant/voiceCall.ts
+++ b/web/src/lib/assistant/voiceCall.ts
@@ -18,6 +18,24 @@ export const MAX_CALL_MS = 15 * 60 * 1000;
  *  end from a dropped connection. */
 export const END_WARNING_MS = 60 * 1000;
 
+/** Strips a litellm-routing provider prefix (`openai/gpt-realtime-2.1` →
+ *  `gpt-realtime-2.1`) from the model name the backend hands back with the minted
+ *  token.
+ *
+ *  Two different systems read that name for two different reasons, and they
+ *  disagree on its shape. The backend mints the client secret by POSTing to OUR
+ *  litellm proxy, which needs the provider prefix to route the request to the right
+ *  upstream account — that's why `REALTIME_MODEL` is configured as
+ *  `openai/gpt-realtime-2.1` in the first place. But the browser then takes that
+ *  same ephemeral token and negotiates the WebRTC call DIRECTLY against OpenAI's own
+ *  `/v1/realtime/calls`, bypassing our proxy entirely — and OpenAI's real API has no
+ *  concept of a litellm provider prefix; it 401s on a model id it does not
+ *  recognise. This is the one place that mismatch has to be undone. */
+export function openaiModelID(model: string): string {
+  const slash = model.lastIndexOf('/');
+  return slash === -1 ? model : model.slice(slash + 1);
+}
+
 /** The bits of `window` a call needs, as a shape rather than as the global, so the
  *  support check can be exercised for browsers this test run is not. */
 export type VoiceCallEnv = {


### PR DESCRIPTION
Live-broke voice mode right after deploy: `Could not connect the call (401)`.

`REALTIME_MODEL` is provider-prefixed (`openai/gpt-realtime-2.1`) so litellm can route the client-secret mint. But the WebRTC SDP exchange bypasses our proxy and talks straight to OpenAI's own `/v1/realtime/calls` — which doesn't understand a litellm routing prefix and 401s on it. `openaiModelID()` strips it before that one request.