### PR TITLE
feat(sources): add SolidJobs source adapter (IT division)

### DIFF
--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -251,6 +251,9 @@ func All(c HTTPClient) map[string]Source {
 		// hh.ru: multi-company aggregator, enumerated by professional_role (board), reading the
 		// server-rendered search page's embedded state.
 		NewHH(c),
+		// SolidJobs: Polish job board, multi-company aggregator enumerated by division (board),
+		// same keyword-as-board shape as whatjobs.
+		NewSolidJobs(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),

--- a/internal/sources/solidjobs.go
+++ b/internal/sources/solidjobs.go
@@ -1,0 +1,143 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// solidjobs adapts solid.jobs, a Polish job board split into divisions (IT, finance, ...).
+// Not boardless: like whatjobs, each board-file entry's board is a SEARCH SLICE rather than a
+// tenant id — here a division slug (e.g. "it") rather than a keyword — so it stays an
+// aggregator without the boardless marker. company is a display label only; each job's real
+// employer comes from the posting.
+//
+// The public endpoint requires a campaign query param (any lowercase-alphanumeric-dash value;
+// it is echoed back into every posting's own URL, so a stable identifier is used rather than a
+// throwaway one) and ships each posting's full description inline (no detail call).
+//
+// KNOWN LIMITATION, verified live 2026-08-10: the response reports totalPages/totalCount (3
+// pages, 1399 jobs for the "it" division) but the endpoint has no discoverable way to reach
+// pages beyond the first — pageIndex, pageNumber, page, skip, offset and a POST body were all
+// tried and every one of them silently returns page 0 again. Only the first (fixed) 500
+// postings per division are reachable through this adapter today; the rest is a real gap, not
+// an oversight, left for whoever finds the actual paging mechanism (or an authenticated one).
+type solidjobs struct {
+	http JSONGetter
+}
+
+// solidjobsCampaign is the stable identifying value sent as the required campaign param. It is
+// echoed into every posting's returned url (".../o/<key>/<campaign>"), which is also why it is
+// fixed rather than randomly generated per request.
+const solidjobsCampaign = "freehire"
+
+const solidjobsListURL = "https://solid.jobs/public-api/offers/%s?campaign=" + solidjobsCampaign
+
+// NewSolidJobs builds the SolidJobs adapter over the given HTTP client.
+func NewSolidJobs(c JSONGetter) Source { return solidjobs{http: c} }
+
+func (solidjobs) Provider() string { return "solidjobs" }
+
+func (solidjobs) aggregator() {}
+
+// solidjobsResponse is the one reachable page (see the KNOWN LIMITATION doc above).
+type solidjobsResponse struct {
+	Jobs []solidjobsPosting `json:"jobs"`
+}
+
+// solidjobsPosting is one posting, body inline (no detail call).
+type solidjobsPosting struct {
+	JobOfferKey     string   `json:"jobOfferKey"`
+	Title           string   `json:"title"`
+	Company         string   `json:"company"`
+	Locations       []string `json:"locations"`
+	Description     string   `json:"description"`
+	URL             string   `json:"url"`
+	IsRemote        bool     `json:"isRemote"`
+	IsHybrid        bool     `json:"isHybrid"`
+	ContractTime    string   `json:"contractTime"`
+	ExperienceLevel string   `json:"experienceLevel"`
+	ValidFrom       string   `json:"validFrom"`
+	Skills          []struct {
+		Name string `json:"name"`
+	} `json:"skills"`
+}
+
+func (s solidjobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	division := strings.TrimSpace(e.Board)
+	if division == "" {
+		return nil, fmt.Errorf("solidjobs: company %q has a blank division board", e.Company)
+	}
+	var resp solidjobsResponse
+	url := fmt.Sprintf(solidjobsListURL, division)
+	if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+		return nil, fmt.Errorf("solidjobs: division %q: %w", division, err)
+	}
+	jobs := make([]Job, 0, len(resp.Jobs))
+	for _, p := range resp.Jobs {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
+// native id, or no company which would break the slug).
+func (p solidjobsPosting) toJob() (Job, bool) {
+	if p.JobOfferKey == "" || p.Company == "" {
+		return Job{}, false
+	}
+	names := make([]string, len(p.Skills))
+	for i, sk := range p.Skills {
+		names[i] = sk.Name
+	}
+	return Job{
+		ExternalID:     p.JobOfferKey,
+		URL:            p.URL,
+		Title:          p.Title,
+		Company:        p.Company,
+		Location:       joinNonEmpty(p.Locations...),
+		Description:    sanitizeHTML(p.Description),
+		Remote:         p.IsRemote,
+		WorkMode:       workModeFromRemoteHybrid(p.IsRemote, p.IsHybrid),
+		EmploymentType: solidjobsEmploymentType(p.ContractTime),
+		Seniority:      solidjobsSeniority(p.ExperienceLevel),
+		Skills:         skilltag.Canonicalize(names),
+		PostedAt:       parseRFC3339(p.ValidFrom),
+	}, true
+}
+
+// solidjobsEmploymentType maps the platform's contractTime field, which already uses
+// freehire's own vocabulary spelling for the two values verified live ("full_time",
+// "part_time"). Anything else maps to "" rather than a guess (vocab.EmploymentTypeValues is
+// dict-only).
+func solidjobsEmploymentType(contractTime string) string {
+	switch contractTime {
+	case "full_time", "part_time":
+		return contractTime
+	default:
+		return ""
+	}
+}
+
+// solidjobsSeniority maps the platform's own experienceLevel taxonomy (verified live: "Intern",
+// "Junior", "Regular", "Senior" — no other value observed) to freehire's controlled
+// vocabulary. "Regular" is the Polish IT market's usual label for a mid-level developer.
+// An unrecognized value maps to "" rather than a guess.
+func solidjobsSeniority(level string) string {
+	switch level {
+	case "Intern":
+		return "intern"
+	case "Junior":
+		return "junior"
+	case "Regular":
+		return "middle"
+	case "Senior":
+		return "senior"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/solidjobs_test.go
+++ b/internal/sources/solidjobs_test.go
@@ -1,0 +1,116 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestSolidJobsProvider(t *testing.T) {
+	if got := NewSolidJobs(nil).Provider(); got != "solidjobs" {
+		t.Errorf("Provider() = %q, want solidjobs", got)
+	}
+}
+
+func TestSolidJobsIsAggregatorNotBoardless(t *testing.T) {
+	s := NewSolidJobs(nil)
+	if _, ok := s.(boardless); ok {
+		t.Error("solidjobs should NOT implement the boardless marker (board is a required division slug)")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("solidjobs should implement the aggregator marker")
+	}
+}
+
+func TestSolidJobsRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["solidjobs"]; !ok {
+		t.Error("All() should register provider solidjobs")
+	}
+	if !slices.Contains(FilterableProviders(), "solidjobs") {
+		t.Error("FilterableProviders() should include solidjobs")
+	}
+}
+
+func TestSolidJobsBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/solidjobs.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/solidjobs.yml fails validation: %v", err)
+	}
+}
+
+func TestSolidJobsFetchRejectsBlankBoard(t *testing.T) {
+	_, err := NewSolidJobs(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{Company: "SolidJobs"})
+	if err == nil {
+		t.Fatal("Fetch: want error for a blank division board, got nil")
+	}
+}
+
+func TestSolidJobsFetchMapsFields(t *testing.T) {
+	body := `{"pageIndex":0,"pageSize":500,"totalCount":2,"totalPages":1,"jobs":[
+{"jobOfferKey":"3aa5b098-aa6d-4f6c-950a-b92a81363cf8","title":"DevOps Engineer","company":"Sollers Consulting","locations":["Bydgoszcz"],"description":"<p>Build.</p>","url":"https://solid.jobs/o/s6evgozq/freehire","isRemote":false,"isHybrid":true,"contractTime":"full_time","experienceLevel":"Junior","validFrom":"2026-08-10T17:45:00.8735683+02:00","skills":[{"level":"Basic","name":"Docker"},{"level":"Basic","name":"Kubernetes"}]},
+{"jobOfferKey":"","title":"NoID","company":"Ghost"}
+]}`
+	fake := (&routedHTTP{}).route("offers/it", body)
+	jobs, err := NewSolidJobs(fake).Fetch(context.Background(), CompanyEntry{Company: "SolidJobs — IT", Board: "it"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (blank jobOfferKey dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "3aa5b098-aa6d-4f6c-950a-b92a81363cf8" || j.Company != "Sollers Consulting" || j.Title != "DevOps Engineer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.Location != "Bydgoszcz" {
+		t.Errorf("Location = %q, want Bydgoszcz", j.Location)
+	}
+	if j.Remote || j.WorkMode != "hybrid" {
+		t.Errorf("Remote=%v WorkMode=%q, want Remote=false WorkMode=hybrid", j.Remote, j.WorkMode)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.Seniority != "junior" {
+		t.Errorf("Seniority = %q, want junior", j.Seniority)
+	}
+	if !slices.Contains(j.Skills, "docker") || !slices.Contains(j.Skills, "kubernetes") {
+		t.Errorf("Skills = %v, want canonicalized docker and kubernetes", j.Skills)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed RFC3339 timestamp")
+	}
+}
+
+func TestSolidJobsSeniority(t *testing.T) {
+	cases := map[string]string{
+		"Intern":  "intern",
+		"Junior":  "junior",
+		"Regular": "middle",
+		"Senior":  "senior",
+		"Expert":  "",
+		"":        "",
+	}
+	for in, want := range cases {
+		if got := solidjobsSeniority(in); got != want {
+			t.Errorf("solidjobsSeniority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSolidJobsEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"full_time": "full_time",
+		"part_time": "part_time",
+		"contract":  "",
+		"":          "",
+	}
+	for in, want := range cases {
+		if got := solidjobsEmploymentType(in); got != want {
+			t.Errorf("solidjobsEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/sources/solidjobs.yml
+++ b/sources/solidjobs.yml
@@ -1,0 +1,10 @@
+# SolidJobs — a Polish job board split into divisions. Each entry's board is a DIVISION SLUG,
+# not a tenant id (same keyword-as-board shape as sources/whatjobs.yml); company is a display
+# label only, the real employer comes from each posting.
+#
+# Only the "it" division is onboarded here — the board has at least 8 divisions total, but
+# their slugs were not enumerated/verified live. See internal/sources/solidjobs.go for a known
+# limitation: only the first 500 of "it"'s ~1400 postings are reachable (no working pagination
+# parameter was found for this public endpoint).
+- company: SolidJobs — IT
+  board: it


### PR DESCRIPTION
## Summary
- Adds a board-based (not boardless) aggregator adapter for SolidJobs (`solid.jobs/public-api/offers/<division>`), a Polish job board split into divisions. Same keyword-as-board shape as `whatjobs`: the board-file entry's `board` carries a division slug rather than a tenant id.
- Maps `company`, `locations[]`, `description` (full HTML inline, no detail call), `isRemote`/`isHybrid` (structured → `Remote`/`WorkMode` via the existing `workModeFromRemoteHybrid`), `contractTime` → `EmploymentType`, `experienceLevel` → `Seniority` (the platform's own taxonomy, mapped through a small dict — `"Regular"` is the Polish market's usual label for mid-level), and `skills[].name` → `Skills` via the existing `skilltag.Canonicalize`.
- Registers the adapter in `sources.All` and adds `sources/solidjobs.yml` with one entry for the `it` division. The other ~7 divisions mentioned in the tracking issue were never enumerated live, so they're left for a follow-up rather than guessed.
- Requires a `campaign` query param (any lowercase-alphanumeric-dash string); used a stable `"freehire"` value since it's echoed back into every posting's own returned URL.

**Known limitation, verified live (2026-08-10) — flagging for visibility:** the response reports `totalPages`/`totalCount` (3 pages, 1399 jobs for `it`), but I could not find any way to reach a page past the first: `pageIndex`, `pageNumber`, `page`, `skip`, `offset` as query params, and a POST body, all silently return page 0 again. So only the first fixed 500 postings per division are reachable through this adapter today. Documented in the adapter's doc comment as a real gap for whoever finds the actual paging mechanism — real, deduped, live data either way, just a partial slice of the division rather than all of it.

Fixes #1630

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/...` (field mapping, remote/hybrid work-mode, seniority + employment-type dictionaries, skill canonicalization, blank-board rejection)