### PR TITLE
Add Sign in with Apple (web)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,19 @@ OAUTH_GITHUB_CLIENT_SECRET=
 OAUTH_LINKEDIN_CLIENT_ID=
 OAUTH_LINKEDIN_CLIENT_SECRET=
 
+# Apple: developer.apple.com/account — register a Services ID (OAUTH_APPLE_CLIENT_ID)
+# under Certificates, IDs & Profiles, associate it with the app's App ID, and enable
+# Sign In with Apple with this callback as its return URL. No static client secret —
+# freehire signs one itself per token exchange from a Team ID + Key ID + private key
+# (a "Sign in with Apple" key created under Keys). OAUTH_APPLE_PRIVATE_KEY is the
+# key's .p8 contents, base64-encoded (a multi-line PEM does not survive a systemd
+# EnvironmentFile reliably — same convention as GMAIL_TOKEN_KEY):
+#   base64 -i AuthKey_XXXXXXXXXX.p8
+OAUTH_APPLE_CLIENT_ID=
+OAUTH_APPLE_TEAM_ID=
+OAUTH_APPLE_KEY_ID=
+OAUTH_APPLE_PRIVATE_KEY=
+
 # Résumé storage (all optional — storage is enabled only when all four are set;
 # otherwise résumé upload just extracts skills in-request, no regression).
 # Provider-agnostic: any S3-compatible endpoint works (Hetzner Object Storage,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,10 @@ services:
       OAUTH_GITHUB_CLIENT_SECRET: "${OAUTH_GITHUB_CLIENT_SECRET:-}"
       OAUTH_LINKEDIN_CLIENT_ID: "${OAUTH_LINKEDIN_CLIENT_ID:-}"
       OAUTH_LINKEDIN_CLIENT_SECRET: "${OAUTH_LINKEDIN_CLIENT_SECRET:-}"
+      OAUTH_APPLE_CLIENT_ID: "${OAUTH_APPLE_CLIENT_ID:-}"
+      OAUTH_APPLE_TEAM_ID: "${OAUTH_APPLE_TEAM_ID:-}"
+      OAUTH_APPLE_KEY_ID: "${OAUTH_APPLE_KEY_ID:-}"
+      OAUTH_APPLE_PRIVATE_KEY: "${OAUTH_APPLE_PRIVATE_KEY:-}"
       # Search is optional: an empty MEILI_MASTER_KEY disables the search
       # endpoint without affecting the rest of the API.
       MEILI_URL: "http://meilisearch:7700"

--- a/internal/auth/oauth/AGENTS.md
+++ b/internal/auth/oauth/AGENTS.md
@@ -20,16 +20,23 @@ Provider registry over the same cookie session as password login.
 
 - Google/LinkedIn: OIDC-userinfo implementation (shared)
 - GitHub: reads `/user` + `/user/emails`
+- Apple: no userinfo endpoint and no static client secret — see below
 - `internal/auth/oauth` owns `Provider` interface, registry (`NewRegistry`), state cookie
 - Handlers in `internal/handler/oauth.go`
 
 ## Config
 
 - `OAUTH_<PROVIDER>_CLIENT_ID`/`_CLIENT_SECRET` (GOOGLE/GITHUB/LINKEDIN)
-- Provider enabled only when both are set
+- Apple instead: `OAUTH_APPLE_CLIENT_ID` (its Services ID) + `OAUTH_APPLE_TEAM_ID`/`_KEY_ID`/`_PRIVATE_KEY`; enabled only when all four are set
 - `GET /api/v1/auth/oauth/providers` lists enabled ones (SPA renders buttons from it)
 - Redirect URLs derive from `FRONTEND_ORIGIN` (`<origin>/api/v1/auth/oauth/<p>/callback`)
 - Provider tokens used once to fetch identity, never stored
+
+## Apple's Different Trust Model
+
+- No static client secret: `apple.go` signs a short-lived (5-minute) ES256 JWT fresh for every token exchange, from Team ID + Key ID + the private key — never cached, nothing to rotate on Apple's 6-month schedule
+- No userinfo call: identity comes only from the token exchange's `id_token`. Its signature is verified against Apple's JWKS (`appleid.apple.com/auth/keys`), and its `aud`/`iss` are checked against our client id / Apple's issuer — this is the one place in the package that verifies a token signature itself, since every other provider's userinfo GET is its own trust boundary
+- Requesting the `email` scope forces `response_mode=form_post`, so Apple's callback arrives as a `POST` with a form-encoded body, not the `GET` query string every other provider uses — `internal/handler/oauth.go`'s callback route must accept both
 
 ## Limitations
 

--- a/internal/auth/oauth/AGENTS.md
+++ b/internal/auth/oauth/AGENTS.md
@@ -27,7 +27,7 @@ Provider registry over the same cookie session as password login.
 ## Config
 
 - `OAUTH_<PROVIDER>_CLIENT_ID`/`_CLIENT_SECRET` (GOOGLE/GITHUB/LINKEDIN)
-- Apple instead: `OAUTH_APPLE_CLIENT_ID` (its Services ID) + `OAUTH_APPLE_TEAM_ID`/`_KEY_ID`/`_PRIVATE_KEY`; enabled only when all four are set
+- Apple instead: `OAUTH_APPLE_CLIENT_ID` (its Services ID) + `OAUTH_APPLE_TEAM_ID`/`_KEY_ID`/`_PRIVATE_KEY`; enabled only when all four are set. `_PRIVATE_KEY` is the `.p8` key **base64-encoded** (a multi-line PEM does not survive a systemd `EnvironmentFile` reliably — same convention as `GMAIL_TOKEN_KEY`); `config.loadOAuth` decodes it
 - `GET /api/v1/auth/oauth/providers` lists enabled ones (SPA renders buttons from it)
 - Redirect URLs derive from `FRONTEND_ORIGIN` (`<origin>/api/v1/auth/oauth/<p>/callback`)
 - Provider tokens used once to fetch identity, never stored

--- a/internal/auth/oauth/apple.go
+++ b/internal/auth/oauth/apple.go
@@ -109,7 +109,7 @@ func (p *appleProvider) FetchIdentity(ctx context.Context, code string) (Identit
 		return Identity{}, fmt.Errorf("apple: token response has no id_token")
 	}
 
-	claims, err := verifyAppleIDToken(ctx, client, p.jwksURL, idToken)
+	claims, err := verifyAppleIDToken(ctx, client, p.jwksURL, p.clientID, idToken)
 	if err != nil {
 		return Identity{}, err
 	}
@@ -150,7 +150,7 @@ func appleClientSecret(teamID, servicesID, keyID, privateKeyPEM string) (string,
 	claims := jwt.RegisteredClaims{
 		Issuer:    teamID,
 		Subject:   servicesID,
-		Audience:  jwt.ClaimStrings{"https://appleid.apple.com"},
+		Audience:  jwt.ClaimStrings{appleIssuer},
 		IssuedAt:  jwt.NewNumericDate(now),
 		ExpiresAt: jwt.NewNumericDate(now.Add(appleClientSecretTTL)),
 	}
@@ -182,6 +182,8 @@ func (c appleIDTokenClaims) emailVerifiedBool() bool {
 
 // appleJWK is one key from Apple's published JWKS.
 type appleJWK struct {
+	Kty string `json:"kty"`
+	Use string `json:"use"`
 	Kid string `json:"kid"`
 	N   string `json:"n"` // base64url-encoded RSA modulus
 	E   string `json:"e"` // base64url-encoded RSA public exponent
@@ -231,13 +233,17 @@ func fetchAppleJWKS(ctx context.Context, client *http.Client, jwksURL string) ([
 	return body.Keys, nil
 }
 
+// appleIssuer is the only issuer Apple ever signs an id_token as.
+const appleIssuer = "https://appleid.apple.com"
+
 // verifyAppleIDToken parses idToken and verifies its signature against a key
-// fetched from Apple's JWKS matching the token's kid header, before returning
-// its claims. This is the one trust boundary in the Apple provider: every
-// other provider proves identity via a live, authenticated userinfo call, but
-// Apple hands back only this signed token — an unverified signature would let
-// a forged token claim any email.
-func verifyAppleIDToken(ctx context.Context, client *http.Client, jwksURL, idToken string) (appleIDTokenClaims, error) {
+// fetched from Apple's JWKS matching the token's kid header, and that it was
+// issued by Apple for this exact client, before returning its claims. This is
+// the one trust boundary in the Apple provider: every other provider proves
+// identity via a live, authenticated userinfo call, but Apple hands back only
+// this signed token — an unverified signature, audience, or issuer would let
+// a forged or misdirected token claim any email.
+func verifyAppleIDToken(ctx context.Context, client *http.Client, jwksURL, clientID, idToken string) (appleIDTokenClaims, error) {
 	var claims appleIDTokenClaims
 	_, err := jwt.ParseWithClaims(idToken, &claims, func(tok *jwt.Token) (any, error) {
 		kid, _ := tok.Header["kid"].(string)
@@ -246,12 +252,12 @@ func verifyAppleIDToken(ctx context.Context, client *http.Client, jwksURL, idTok
 			return nil, err
 		}
 		for _, k := range keys {
-			if k.Kid == kid {
+			if k.Kid == kid && k.Kty == "RSA" && (k.Use == "" || k.Use == "sig") {
 				return k.applePublicKey()
 			}
 		}
-		return nil, fmt.Errorf("apple: no JWKS key for kid %q", kid)
-	}, jwt.WithValidMethods([]string{"RS256"}))
+		return nil, fmt.Errorf("apple: no matching RSA signing key for kid %q", kid)
+	}, jwt.WithValidMethods([]string{"RS256"}), jwt.WithAudience(clientID), jwt.WithIssuer(appleIssuer))
 	if err != nil {
 		return appleIDTokenClaims{}, fmt.Errorf("apple: verify id_token: %w", err)
 	}

--- a/internal/auth/oauth/apple.go
+++ b/internal/auth/oauth/apple.go
@@ -1,0 +1,259 @@
+package oauth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
+
+	"github.com/strelov1/freehire/internal/config"
+	"github.com/strelov1/freehire/internal/safehttp"
+)
+
+// appleAuthURL, appleTokenURL, and appleJWKSURL are Apple's fixed endpoints.
+// appleProvider carries them as fields (rather than inlining the constants at
+// each call site) so tests can point them at a stub server.
+const (
+	appleAuthURL  = "https://appleid.apple.com/auth/authorize"
+	appleTokenURL = "https://appleid.apple.com/auth/token"
+	appleJWKSURL  = "https://appleid.apple.com/auth/keys"
+)
+
+// appleProvider implements Provider for Sign in with Apple. Unlike the OIDC
+// providers, it authenticates the token exchange with a self-signed JWT
+// (appleClientSecret) instead of a static secret, and it has no userinfo
+// endpoint — identity comes only from the token exchange's id_token, whose
+// signature must be verified against Apple's JWKS.
+type appleProvider struct {
+	clientID      string // Apple Services ID
+	teamID        string
+	keyID         string
+	privateKeyPEM string
+	redirectURL   string
+	authURL       string
+	tokenURL      string
+	jwksURL       string
+}
+
+// NewApple returns the Apple provider ("Sign in with Apple" via the
+// authorization-code flow). creds.ClientSecret is unused — Apple authenticates
+// with a JWT minted from TeamID/KeyID/PrivateKey instead (see appleClientSecret).
+func NewApple(creds config.OAuthCredentials, redirectURL string) Provider {
+	return &appleProvider{
+		clientID:      creds.ClientID,
+		teamID:        creds.TeamID,
+		keyID:         creds.KeyID,
+		privateKeyPEM: creds.PrivateKey,
+		redirectURL:   redirectURL,
+		authURL:       appleAuthURL,
+		tokenURL:      appleTokenURL,
+		jwksURL:       appleJWKSURL,
+	}
+}
+
+func (p *appleProvider) Name() string { return "apple" }
+
+// AuthCodeURL builds Apple's consent URL. response_mode=form_post is mandatory
+// whenever a scope is requested — Apple sends the callback as a POST with a
+// form-encoded body instead of GET query parameters.
+func (p *appleProvider) AuthCodeURL(state string) string {
+	v := url.Values{
+		"client_id":     {p.clientID},
+		"redirect_uri":  {p.redirectURL},
+		"response_type": {"code"},
+		"response_mode": {"form_post"},
+		"scope":         {"email"},
+		"state":         {state},
+	}
+	return p.authURL + "?" + v.Encode()
+}
+
+// FetchIdentity exchanges code for Apple's tokens, using a client secret
+// minted fresh for this one call, then verifies the returned id_token's
+// signature before trusting its claims. Apple has no userinfo endpoint —
+// the id_token is the only source of identity.
+func (p *appleProvider) FetchIdentity(ctx context.Context, code string) (Identity, error) {
+	ctx = safehttp.GuardedOAuth2Context(ctx, userinfoTimeout)
+	client, _ := ctx.Value(oauth2.HTTPClient).(*http.Client)
+
+	secret, err := appleClientSecret(p.teamID, p.clientID, p.keyID, p.privateKeyPEM)
+	if err != nil {
+		return Identity{}, fmt.Errorf("apple: client secret: %w", err)
+	}
+
+	cfg := &oauth2.Config{
+		ClientID:     p.clientID,
+		ClientSecret: secret,
+		Endpoint:     oauth2.Endpoint{TokenURL: p.tokenURL},
+		RedirectURL:  p.redirectURL,
+	}
+	tok, err := cfg.Exchange(ctx, code)
+	if err != nil {
+		return Identity{}, fmt.Errorf("apple: exchange code: %w", err)
+	}
+
+	idToken, ok := tok.Extra("id_token").(string)
+	if !ok || idToken == "" {
+		return Identity{}, fmt.Errorf("apple: token response has no id_token")
+	}
+
+	claims, err := verifyAppleIDToken(ctx, client, p.jwksURL, idToken)
+	if err != nil {
+		return Identity{}, err
+	}
+	if claims.Subject == "" {
+		return Identity{}, fmt.Errorf("apple: id_token has no sub")
+	}
+	return Identity{
+		ProviderUserID: claims.Subject,
+		Email:          claims.Email,
+		EmailVerified:  claims.emailVerifiedBool(),
+	}, nil
+}
+
+// appleClientSecretTTL is how long the self-signed client-secret JWT is valid
+// for. It is minted fresh for every token exchange, so this only needs to
+// outlive the single round trip to Apple's token endpoint — not the 6-month
+// maximum Apple allows.
+const appleClientSecretTTL = 5 * time.Minute
+
+// appleClientSecret signs the client-secret JWT Apple requires in place of a
+// static client secret: iss is the Team ID, sub is the Services ID (Apple's
+// client id), aud is Apple's own issuer, and kid names the signing key.
+func appleClientSecret(teamID, servicesID, keyID, privateKeyPEM string) (string, error) {
+	block, _ := pem.Decode([]byte(privateKeyPEM))
+	if block == nil {
+		return "", fmt.Errorf("apple: private key is not valid PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("apple: parse private key: %w", err)
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("apple: private key is not ECDSA")
+	}
+
+	now := time.Now()
+	claims := jwt.RegisteredClaims{
+		Issuer:    teamID,
+		Subject:   servicesID,
+		Audience:  jwt.ClaimStrings{"https://appleid.apple.com"},
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(appleClientSecretTTL)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["kid"] = keyID
+	return token.SignedString(key)
+}
+
+// appleIDTokenClaims is the subset of an Apple id_token's claims identity
+// resolution needs. EmailVerified is `any` because Apple has been observed to
+// send it as either a JSON boolean or the string "true"/"false" depending on
+// the flow; emailVerifiedBool normalizes both.
+type appleIDTokenClaims struct {
+	jwt.RegisteredClaims
+	Email         string `json:"email"`
+	EmailVerified any    `json:"email_verified"`
+}
+
+func (c appleIDTokenClaims) emailVerifiedBool() bool {
+	switch v := c.EmailVerified.(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
+	default:
+		return false
+	}
+}
+
+// appleJWK is one key from Apple's published JWKS.
+type appleJWK struct {
+	Kid string `json:"kid"`
+	N   string `json:"n"` // base64url-encoded RSA modulus
+	E   string `json:"e"` // base64url-encoded RSA public exponent
+}
+
+// applePublicKey decodes a JWK's modulus/exponent into an *rsa.PublicKey.
+func (k appleJWK) applePublicKey() (*rsa.PublicKey, error) {
+	nb, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("apple: decode JWK modulus: %w", err)
+	}
+	eb, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("apple: decode JWK exponent: %w", err)
+	}
+	e := 0
+	for _, b := range eb {
+		e = e<<8 | int(b)
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(nb), E: e}, nil
+}
+
+// maxJWKSBytes caps Apple's JWKS response — it is a handful of small keys, not
+// a multi-MB payload.
+const maxJWKSBytes = 1 << 20 // 1 MiB
+
+// fetchAppleJWKS retrieves and decodes Apple's published signing keys.
+func fetchAppleJWKS(ctx context.Context, client *http.Client, jwksURL string) ([]appleJWK, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("apple: fetch JWKS: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("apple: JWKS: %s", resp.Status)
+	}
+	var body struct {
+		Keys []appleJWK `json:"keys"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxJWKSBytes)).Decode(&body); err != nil {
+		return nil, fmt.Errorf("apple: decode JWKS: %w", err)
+	}
+	return body.Keys, nil
+}
+
+// verifyAppleIDToken parses idToken and verifies its signature against a key
+// fetched from Apple's JWKS matching the token's kid header, before returning
+// its claims. This is the one trust boundary in the Apple provider: every
+// other provider proves identity via a live, authenticated userinfo call, but
+// Apple hands back only this signed token — an unverified signature would let
+// a forged token claim any email.
+func verifyAppleIDToken(ctx context.Context, client *http.Client, jwksURL, idToken string) (appleIDTokenClaims, error) {
+	var claims appleIDTokenClaims
+	_, err := jwt.ParseWithClaims(idToken, &claims, func(tok *jwt.Token) (any, error) {
+		kid, _ := tok.Header["kid"].(string)
+		keys, err := fetchAppleJWKS(ctx, client, jwksURL)
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range keys {
+			if k.Kid == kid {
+				return k.applePublicKey()
+			}
+		}
+		return nil, fmt.Errorf("apple: no JWKS key for kid %q", kid)
+	}, jwt.WithValidMethods([]string{"RS256"}))
+	if err != nil {
+		return appleIDTokenClaims{}, fmt.Errorf("apple: verify id_token: %w", err)
+	}
+	return claims, nil
+}

--- a/internal/auth/oauth/apple_test.go
+++ b/internal/auth/oauth/apple_test.go
@@ -1,0 +1,331 @@
+package oauth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// testAppleRSAKey generates a throwaway RSA key pair and serves it as Apple's
+// JWKS would, under the given kid.
+func testAppleRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	return key
+}
+
+func stubAppleJWKS(t *testing.T, kid string, key *rsa.PrivateKey) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/keys", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
+				},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func signAppleIDToken(t *testing.T, key *rsa.PrivateKey, kid string, claims appleIDTokenClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign id_token: %v", err)
+	}
+	return signed
+}
+
+// testAppleKeyPEM generates a throwaway ES256 private key PEM for tests — never
+// the real Apple .p8 key.
+func testAppleKeyPEM(t *testing.T) (string, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	block := &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+	return string(pem.EncodeToMemory(block)), key
+}
+
+func TestAppleClientSecret_ClaimsAndHeader(t *testing.T) {
+	pemKey, key := testAppleKeyPEM(t)
+
+	secret, err := appleClientSecret("TEAM123456", "me.freehire.web", "KEY1234567", pemKey)
+	if err != nil {
+		t.Fatalf("appleClientSecret: %v", err)
+	}
+
+	claims := jwt.RegisteredClaims{}
+	tok, err := jwt.ParseWithClaims(secret, &claims, func(tok *jwt.Token) (any, error) {
+		return &key.PublicKey, nil
+	}, jwt.WithValidMethods([]string{"ES256"}))
+	if err != nil {
+		t.Fatalf("parse minted secret: %v", err)
+	}
+	if !tok.Valid {
+		t.Fatal("minted secret did not validate against its own key")
+	}
+	if kid, _ := tok.Header["kid"].(string); kid != "KEY1234567" {
+		t.Errorf("kid header = %q, want KEY1234567", kid)
+	}
+	if claims.Issuer != "TEAM123456" {
+		t.Errorf("iss = %q, want TEAM123456", claims.Issuer)
+	}
+	if claims.Subject != "me.freehire.web" {
+		t.Errorf("sub = %q, want me.freehire.web", claims.Subject)
+	}
+	if len(claims.Audience) != 1 || claims.Audience[0] != "https://appleid.apple.com" {
+		t.Errorf("aud = %v, want [https://appleid.apple.com]", claims.Audience)
+	}
+	if claims.ExpiresAt == nil || claims.IssuedAt == nil {
+		t.Fatal("missing iat/exp")
+	}
+	if ttl := claims.ExpiresAt.Sub(claims.IssuedAt.Time); ttl != appleClientSecretTTL {
+		t.Errorf("ttl = %v, want %v", ttl, appleClientSecretTTL)
+	}
+}
+
+func TestAppleClientSecret_InvalidPEM(t *testing.T) {
+	if _, err := appleClientSecret("TEAM123456", "me.freehire.web", "KEY1234567", "not a pem"); err == nil {
+		t.Error("want error for invalid PEM, got nil")
+	}
+}
+
+func TestApple_AuthCodeURL(t *testing.T) {
+	p := &appleProvider{
+		clientID:    "me.freehire.web",
+		redirectURL: "https://freehire.me/api/v1/auth/oauth/apple/callback",
+		authURL:     "https://appleid.apple.com/auth/authorize",
+	}
+	u := p.AuthCodeURL("the-state")
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatalf("parse AuthCodeURL: %v", err)
+	}
+	q := parsed.Query()
+	for key, want := range map[string]string{
+		"client_id":     "me.freehire.web",
+		"redirect_uri":  "https://freehire.me/api/v1/auth/oauth/apple/callback",
+		"response_type": "code",
+		"response_mode": "form_post",
+		"scope":         "email",
+		"state":         "the-state",
+	} {
+		if got := q.Get(key); got != want {
+			t.Errorf("query[%q] = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestVerifyAppleIDToken_Valid(t *testing.T) {
+	key := testAppleRSAKey(t)
+	srv := stubAppleJWKS(t, "the-kid", key)
+
+	now := time.Now()
+	idToken := signAppleIDToken(t, key, "the-kid", appleIDTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "apple-sub-1",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		Email:         "user@example.com",
+		EmailVerified: true,
+	})
+
+	claims, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", idToken)
+	if err != nil {
+		t.Fatalf("verifyAppleIDToken: %v", err)
+	}
+	if claims.Subject != "apple-sub-1" {
+		t.Errorf("sub = %q, want apple-sub-1", claims.Subject)
+	}
+	if claims.Email != "user@example.com" {
+		t.Errorf("email = %q, want user@example.com", claims.Email)
+	}
+	if !claims.emailVerifiedBool() {
+		t.Error("email_verified = false, want true")
+	}
+}
+
+func TestVerifyAppleIDToken_EmailVerifiedAsString(t *testing.T) {
+	// Apple has been known to send email_verified as the string "true" rather
+	// than the boolean true, depending on the flow.
+	key := testAppleRSAKey(t)
+	srv := stubAppleJWKS(t, "the-kid", key)
+	now := time.Now()
+	idToken := signAppleIDToken(t, key, "the-kid", appleIDTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "apple-sub-2",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		Email:         "user2@example.com",
+		EmailVerified: "true",
+	})
+
+	claims, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", idToken)
+	if err != nil {
+		t.Fatalf("verifyAppleIDToken: %v", err)
+	}
+	if !claims.emailVerifiedBool() {
+		t.Error("email_verified = false, want true (from string \"true\")")
+	}
+}
+
+func TestVerifyAppleIDToken_WrongSigningKeyRejected(t *testing.T) {
+	realKey := testAppleRSAKey(t)
+	wrongKey := testAppleRSAKey(t)
+	srv := stubAppleJWKS(t, "the-kid", realKey)
+
+	now := time.Now()
+	idToken := signAppleIDToken(t, wrongKey, "the-kid", appleIDTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "apple-sub-3",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		Email:         "user3@example.com",
+		EmailVerified: true,
+	})
+
+	if _, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", idToken); err == nil {
+		t.Error("want error for id_token signed by a key not in the JWKS, got nil")
+	}
+}
+
+func TestVerifyAppleIDToken_UnknownKidRejected(t *testing.T) {
+	key := testAppleRSAKey(t)
+	srv := stubAppleJWKS(t, "the-real-kid", key)
+
+	now := time.Now()
+	idToken := signAppleIDToken(t, key, "some-other-kid", appleIDTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "apple-sub-4",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+	})
+
+	if _, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", idToken); err == nil {
+		t.Error("want error for id_token whose kid is not in the JWKS, got nil")
+	}
+}
+
+// stubApple serves Apple's token-exchange and JWKS endpoints together, so
+// FetchIdentity can run its whole round trip against one stub server. The
+// token endpoint always hands back an id_token signed by key under kid.
+func stubApple(t *testing.T, key *rsa.PrivateKey, kid string, idTokenClaims appleIDTokenClaims) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/keys", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"n":   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
+				},
+			},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "stub-access-token",
+			"token_type":   "Bearer",
+			"id_token":     signAppleIDToken(t, key, kid, idTokenClaims),
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func appleForTest(t *testing.T, srv *httptest.Server) *appleProvider {
+	pemKey, _ := testAppleKeyPEM(t)
+	return &appleProvider{
+		clientID:      "me.freehire.web",
+		teamID:        "TEAM123456",
+		keyID:         "KEY1234567",
+		privateKeyPEM: pemKey,
+		redirectURL:   "http://app/callback",
+		tokenURL:      srv.URL + "/token",
+		jwksURL:       srv.URL + "/auth/keys",
+	}
+}
+
+func TestApple_FetchIdentity(t *testing.T) {
+	key := testAppleRSAKey(t)
+	now := time.Now()
+	srv := stubApple(t, key, "the-kid", appleIDTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "apple-sub-1",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		Email:         "user@example.com",
+		EmailVerified: true,
+	})
+
+	got, err := appleForTest(t, srv).FetchIdentity(testClientCtx(srv), "code")
+	if err != nil {
+		t.Fatalf("FetchIdentity: %v", err)
+	}
+	want := Identity{ProviderUserID: "apple-sub-1", Email: "user@example.com", EmailVerified: true}
+	if got != want {
+		t.Errorf("identity = %+v, want %+v", got, want)
+	}
+}
+
+func TestApple_FetchIdentityMissingSub(t *testing.T) {
+	key := testAppleRSAKey(t)
+	now := time.Now()
+	srv := stubApple(t, key, "the-kid", appleIDTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		Email: "user@example.com",
+	})
+
+	if _, err := appleForTest(t, srv).FetchIdentity(testClientCtx(srv), "code"); err == nil {
+		t.Error("want error for id_token without sub, got nil")
+	}
+}

--- a/internal/auth/oauth/apple_test.go
+++ b/internal/auth/oauth/apple_test.go
@@ -160,6 +160,8 @@ func TestVerifyAppleIDToken_Valid(t *testing.T) {
 	idToken := signAppleIDToken(t, key, "the-kid", appleIDTokenClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   "apple-sub-1",
+			Audience:  jwt.ClaimStrings{"me.freehire.web"},
+			Issuer:    "https://appleid.apple.com",
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
 		},
@@ -167,7 +169,7 @@ func TestVerifyAppleIDToken_Valid(t *testing.T) {
 		EmailVerified: true,
 	})
 
-	claims, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", idToken)
+	claims, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", "me.freehire.web", idToken)
 	if err != nil {
 		t.Fatalf("verifyAppleIDToken: %v", err)
 	}
@@ -191,6 +193,8 @@ func TestVerifyAppleIDToken_EmailVerifiedAsString(t *testing.T) {
 	idToken := signAppleIDToken(t, key, "the-kid", appleIDTokenClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   "apple-sub-2",
+			Audience:  jwt.ClaimStrings{"me.freehire.web"},
+			Issuer:    "https://appleid.apple.com",
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
 		},
@@ -198,7 +202,7 @@ func TestVerifyAppleIDToken_EmailVerifiedAsString(t *testing.T) {
 		EmailVerified: "true",
 	})
 
-	claims, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", idToken)
+	claims, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", "me.freehire.web", idToken)
 	if err != nil {
 		t.Fatalf("verifyAppleIDToken: %v", err)
 	}
@@ -223,7 +227,7 @@ func TestVerifyAppleIDToken_WrongSigningKeyRejected(t *testing.T) {
 		EmailVerified: true,
 	})
 
-	if _, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", idToken); err == nil {
+	if _, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", "me.freehire.web", idToken); err == nil {
 		t.Error("want error for id_token signed by a key not in the JWKS, got nil")
 	}
 }
@@ -241,8 +245,52 @@ func TestVerifyAppleIDToken_UnknownKidRejected(t *testing.T) {
 		},
 	})
 
-	if _, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", idToken); err == nil {
+	if _, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", "me.freehire.web", idToken); err == nil {
 		t.Error("want error for id_token whose kid is not in the JWKS, got nil")
+	}
+}
+
+func TestVerifyAppleIDToken_WrongAudienceRejected(t *testing.T) {
+	key := testAppleRSAKey(t)
+	srv := stubAppleJWKS(t, "the-kid", key)
+
+	now := time.Now()
+	idToken := signAppleIDToken(t, key, "the-kid", appleIDTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "apple-sub-5",
+			Audience:  jwt.ClaimStrings{"someone-elses-services-id"},
+			Issuer:    "https://appleid.apple.com",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		Email:         "user5@example.com",
+		EmailVerified: true,
+	})
+
+	if _, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", "me.freehire.web", idToken); err == nil {
+		t.Error("want error for id_token issued for a different audience, got nil")
+	}
+}
+
+func TestVerifyAppleIDToken_WrongIssuerRejected(t *testing.T) {
+	key := testAppleRSAKey(t)
+	srv := stubAppleJWKS(t, "the-kid", key)
+
+	now := time.Now()
+	idToken := signAppleIDToken(t, key, "the-kid", appleIDTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "apple-sub-6",
+			Audience:  jwt.ClaimStrings{"me.freehire.web"},
+			Issuer:    "https://not-apple.example.com",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		Email:         "user6@example.com",
+		EmailVerified: true,
+	})
+
+	if _, err := verifyAppleIDToken(context.Background(), srv.Client(), srv.URL+"/auth/keys", "me.freehire.web", idToken); err == nil {
+		t.Error("want error for id_token issued by a non-Apple issuer, got nil")
 	}
 }
 
@@ -297,6 +345,8 @@ func TestApple_FetchIdentity(t *testing.T) {
 	srv := stubApple(t, key, "the-kid", appleIDTokenClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   "apple-sub-1",
+			Audience:  jwt.ClaimStrings{"me.freehire.web"},
+			Issuer:    "https://appleid.apple.com",
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
 		},
@@ -319,6 +369,8 @@ func TestApple_FetchIdentityMissingSub(t *testing.T) {
 	now := time.Now()
 	srv := stubApple(t, key, "the-kid", appleIDTokenClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
+			Audience:  jwt.ClaimStrings{"me.freehire.web"},
+			Issuer:    "https://appleid.apple.com",
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
 		},

--- a/internal/auth/oauth/github.go
+++ b/internal/auth/oauth/github.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/endpoints"
 
+	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/safehttp"
 )
 
@@ -21,11 +22,11 @@ type githubProvider struct {
 }
 
 // NewGitHub returns the GitHub provider.
-func NewGitHub(clientID, clientSecret, redirectURL string) Provider {
+func NewGitHub(creds config.OAuthCredentials, redirectURL string) Provider {
 	return &githubProvider{
 		cfg: &oauth2.Config{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
+			ClientID:     creds.ClientID,
+			ClientSecret: creds.ClientSecret,
 			Endpoint:     endpoints.GitHub,
 			RedirectURL:  redirectURL,
 			Scopes:       []string{"read:user", "user:email"},

--- a/internal/auth/oauth/oauth.go
+++ b/internal/auth/oauth/oauth.go
@@ -31,11 +31,16 @@ type Provider interface {
 
 // constructors maps a provider name to its builder. The redirect URL is a build
 // argument, not baked in, so the same registry can serve OAuth on more than one
-// domain (the origin is chosen per request — see Registry.Provider).
-var constructors = map[string]func(clientID, clientSecret, redirectURL string) Provider{
+// domain (the origin is chosen per request — see Registry.Provider). Every
+// constructor takes the full credentials struct, even though Google/GitHub/
+// LinkedIn only read ClientID/ClientSecret from it — Apple needs the rest
+// (TeamID/KeyID/PrivateKey) and authenticates with a self-signed JWT instead of
+// a static ClientSecret.
+var constructors = map[string]func(creds config.OAuthCredentials, redirectURL string) Provider{
 	"google":   NewGoogle,
 	"github":   NewGitHub,
 	"linkedin": NewLinkedIn,
+	"apple":    NewApple,
 }
 
 // Registry holds the credentials of the enabled OAuth providers and builds a
@@ -48,13 +53,26 @@ type Registry struct {
 	creds map[string]config.OAuthCredentials
 }
 
-// NewRegistry keeps only providers with both a client id and secret for a known
+// credentialsComplete reports whether creds has everything the named provider
+// needs to authenticate. Apple has no client secret — it needs TeamID, KeyID,
+// and PrivateKey instead, to mint its own client-secret JWT.
+func credentialsComplete(name string, creds config.OAuthCredentials) bool {
+	if creds.ClientID == "" {
+		return false
+	}
+	if name == "apple" {
+		return creds.TeamID != "" && creds.KeyID != "" && creds.PrivateKey != ""
+	}
+	return creds.ClientSecret != ""
+}
+
+// NewRegistry keeps only providers with complete credentials for a known
 // provider name; unknown names and incomplete credentials are dropped, so an
 // unconfigured provider is simply absent (its routes 404 / the list omits it).
 func NewRegistry(creds map[string]config.OAuthCredentials) *Registry {
 	enabled := make(map[string]config.OAuthCredentials)
 	for name, c := range creds {
-		if _, known := constructors[name]; known && c.ClientID != "" && c.ClientSecret != "" {
+		if _, known := constructors[name]; known && credentialsComplete(name, c) {
 			enabled[name] = c
 		}
 	}
@@ -78,5 +96,5 @@ func (r *Registry) Provider(name, origin string) (Provider, bool) {
 	if !ok {
 		return nil, false
 	}
-	return constructors[name](c.ClientID, c.ClientSecret, origin+"/api/v1/auth/oauth/"+name+"/callback"), true
+	return constructors[name](c, origin+"/api/v1/auth/oauth/"+name+"/callback"), true
 }

--- a/internal/auth/oauth/oidc.go
+++ b/internal/auth/oauth/oidc.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/endpoints"
 
+	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/safehttp"
 )
 
@@ -32,12 +33,12 @@ type oidcProvider struct {
 }
 
 // NewGoogle returns the Google provider ("Sign in with Google" via OIDC).
-func NewGoogle(clientID, clientSecret, redirectURL string) Provider {
+func NewGoogle(creds config.OAuthCredentials, redirectURL string) Provider {
 	return &oidcProvider{
 		name: "google",
 		cfg: &oauth2.Config{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
+			ClientID:     creds.ClientID,
+			ClientSecret: creds.ClientSecret,
 			Endpoint:     endpoints.Google,
 			RedirectURL:  redirectURL,
 			Scopes:       []string{"openid", "email"},
@@ -48,12 +49,12 @@ func NewGoogle(clientID, clientSecret, redirectURL string) Provider {
 
 // NewLinkedIn returns the LinkedIn provider ("Sign In with LinkedIn using
 // OpenID Connect" — the product must be enabled on the LinkedIn app).
-func NewLinkedIn(clientID, clientSecret, redirectURL string) Provider {
+func NewLinkedIn(creds config.OAuthCredentials, redirectURL string) Provider {
 	return &oidcProvider{
 		name: "linkedin",
 		cfg: &oauth2.Config{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
+			ClientID:     creds.ClientID,
+			ClientSecret: creds.ClientSecret,
 			Endpoint:     endpoints.LinkedIn,
 			RedirectURL:  redirectURL,
 			Scopes:       []string{"openid", "email"},

--- a/internal/auth/oauth/registry_test.go
+++ b/internal/auth/oauth/registry_test.go
@@ -34,6 +34,24 @@ func TestNewRegistry_OnlyCompleteCredentialsEnable(t *testing.T) {
 	}
 }
 
+func TestNewRegistry_AppleRequiresFullCredentialSet(t *testing.T) {
+	reg := NewRegistry(map[string]config.OAuthCredentials{
+		"apple": {ClientID: "me.freehire.web", TeamID: "team", KeyID: "key"}, // missing PrivateKey -> disabled
+	})
+	if names(reg)["apple"] {
+		t.Error("apple enabled; want disabled (missing private key)")
+	}
+}
+
+func TestNewRegistry_AppleEnabledWithFullCredentialSet(t *testing.T) {
+	reg := NewRegistry(map[string]config.OAuthCredentials{
+		"apple": {ClientID: "me.freehire.web", TeamID: "team", KeyID: "key", PrivateKey: "pem"},
+	})
+	if !names(reg)["apple"] {
+		t.Error("apple missing; want enabled")
+	}
+}
+
 func TestNewRegistry_IgnoresUnknownProvider(t *testing.T) {
 	reg := NewRegistry(map[string]config.OAuthCredentials{
 		"myspace": {ClientID: "id", ClientSecret: "secret"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,7 +217,8 @@ type Settings struct {
 // OAuthCredentials is one OAuth provider's credentials. Google/GitHub/LinkedIn
 // use only ClientID/ClientSecret; Apple authenticates with a self-signed JWT
 // instead of a static secret, so it uses ClientID (its Services ID) plus
-// TeamID/KeyID/PrivateKey and leaves ClientSecret empty.
+// TeamID/KeyID/PrivateKey and leaves ClientSecret empty. PrivateKey is the
+// decoded PEM (the OAUTH_APPLE_PRIVATE_KEY env var carries it base64-encoded).
 type OAuthCredentials struct {
 	ClientID     string
 	ClientSecret string
@@ -344,6 +345,21 @@ func decodeKey(s string) []byte {
 	return b
 }
 
+// decodeBase64 decodes a base64-encoded env value, returning "" for an unset
+// or malformed one. Used for OAUTH_APPLE_PRIVATE_KEY: a multi-line PEM does
+// not survive a systemd EnvironmentFile reliably, so it is stored
+// base64-encoded, the same convention as GMAIL_TOKEN_KEY.
+func decodeBase64(s string) string {
+	if s == "" {
+		return ""
+	}
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 // splitDomains parses a comma-separated COOKIE_DOMAIN into bare registrable
 // domains, trimming spaces and any leading dot (".freehire.me" -> "freehire.me").
 // Empty entries are dropped, so "" yields nil (host-only cookie, no extra origins).
@@ -367,7 +383,7 @@ func loadOAuth() map[string]OAuthCredentials {
 			ClientSecret: os.Getenv(prefix + "_CLIENT_SECRET"),
 			TeamID:       os.Getenv(prefix + "_TEAM_ID"),
 			KeyID:        os.Getenv(prefix + "_KEY_ID"),
-			PrivateKey:   os.Getenv(prefix + "_PRIVATE_KEY"),
+			PrivateKey:   decodeBase64(os.Getenv(prefix + "_PRIVATE_KEY")),
 		}
 	}
 	return creds

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,15 +214,22 @@ type Settings struct {
 	ExtensionRedirectAllowlist []string
 }
 
-// OAuthCredentials is one OAuth provider's client id/secret pair.
+// OAuthCredentials is one OAuth provider's credentials. Google/GitHub/LinkedIn
+// use only ClientID/ClientSecret; Apple authenticates with a self-signed JWT
+// instead of a static secret, so it uses ClientID (its Services ID) plus
+// TeamID/KeyID/PrivateKey and leaves ClientSecret empty.
 type OAuthCredentials struct {
 	ClientID     string
 	ClientSecret string
+	TeamID       string
+	KeyID        string
+	PrivateKey   string
 }
 
 // oauthProviders are the providers whose credentials Load reads from the
-// environment (OAUTH_<PROVIDER>_CLIENT_ID / OAUTH_<PROVIDER>_CLIENT_SECRET).
-var oauthProviders = []string{"google", "github", "linkedin"}
+// environment (OAUTH_<PROVIDER>_CLIENT_ID / OAUTH_<PROVIDER>_CLIENT_SECRET,
+// plus OAUTH_APPLE_TEAM_ID / OAUTH_APPLE_KEY_ID / OAUTH_APPLE_PRIVATE_KEY for apple).
+var oauthProviders = []string{"google", "github", "linkedin", "apple"}
 
 // defaultAssistantMaxPrompt is the rune ceiling on one user message when
 // ASSISTANT_MAX_PROMPT is unset or invalid.
@@ -358,6 +365,9 @@ func loadOAuth() map[string]OAuthCredentials {
 		creds[p] = OAuthCredentials{
 			ClientID:     os.Getenv(prefix + "_CLIENT_ID"),
 			ClientSecret: os.Getenv(prefix + "_CLIENT_SECRET"),
+			TeamID:       os.Getenv(prefix + "_TEAM_ID"),
+			KeyID:        os.Getenv(prefix + "_KEY_ID"),
+			PrivateKey:   os.Getenv(prefix + "_PRIVATE_KEY"),
 		}
 	}
 	return creds

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"slices"
 	"strings"
 	"testing"
@@ -312,15 +313,27 @@ func TestLoad_OAuthCredentialsFromEnv(t *testing.T) {
 }
 
 func TestLoad_OAuthAppleCredentialsFromEnv(t *testing.T) {
+	// The private key is a multi-line PEM, which does not survive a systemd
+	// EnvironmentFile reliably — like GMAIL_TOKEN_KEY, it is stored base64-encoded
+	// and decoded on load.
+	const pem = "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
 	t.Setenv("OAUTH_APPLE_CLIENT_ID", "me.freehire.web")
 	t.Setenv("OAUTH_APPLE_TEAM_ID", "25U9HN34VM")
 	t.Setenv("OAUTH_APPLE_KEY_ID", "ZC7298D2TR")
-	t.Setenv("OAUTH_APPLE_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----")
+	t.Setenv("OAUTH_APPLE_PRIVATE_KEY", base64.StdEncoding.EncodeToString([]byte(pem)))
 
 	got := Load().OAuth["apple"]
 	if got.ClientID != "me.freehire.web" || got.TeamID != "25U9HN34VM" ||
-		got.KeyID != "ZC7298D2TR" || got.PrivateKey != "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----" {
-		t.Errorf("OAuth[apple] = %+v, want client id/team id/key id/private key populated", got)
+		got.KeyID != "ZC7298D2TR" || got.PrivateKey != pem {
+		t.Errorf("OAuth[apple] = %+v, want client id/team id/key id/decoded private key", got)
+	}
+}
+
+func TestLoad_OAuthApplePrivateKeyInvalidBase64IsEmpty(t *testing.T) {
+	t.Setenv("OAUTH_APPLE_PRIVATE_KEY", "not valid base64!!")
+
+	if got := Load().OAuth["apple"].PrivateKey; got != "" {
+		t.Errorf("PrivateKey = %q, want empty for invalid base64", got)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -311,6 +311,19 @@ func TestLoad_OAuthCredentialsFromEnv(t *testing.T) {
 	}
 }
 
+func TestLoad_OAuthAppleCredentialsFromEnv(t *testing.T) {
+	t.Setenv("OAUTH_APPLE_CLIENT_ID", "me.freehire.web")
+	t.Setenv("OAUTH_APPLE_TEAM_ID", "25U9HN34VM")
+	t.Setenv("OAUTH_APPLE_KEY_ID", "ZC7298D2TR")
+	t.Setenv("OAUTH_APPLE_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----")
+
+	got := Load().OAuth["apple"]
+	if got.ClientID != "me.freehire.web" || got.TeamID != "25U9HN34VM" ||
+		got.KeyID != "ZC7298D2TR" || got.PrivateKey != "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----" {
+		t.Errorf("OAuth[apple] = %+v, want client id/team id/key id/private key populated", got)
+	}
+}
+
 func TestLoad_OAuthUnsetProviderIsZero(t *testing.T) {
 	t.Setenv("OAUTH_LINKEDIN_CLIENT_ID", "")
 	t.Setenv("OAUTH_LINKEDIN_CLIENT_SECRET", "")

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -147,6 +147,9 @@ func (h *authHandlers) register(api fiber.Router, mw middleware) {
 	authGroup.Get("/oauth/providers", h.ListOAuthProviders)
 	authGroup.Get("/oauth/:provider/start", h.OAuthStart)
 	authGroup.Get("/oauth/:provider/callback", h.OAuthCallback)
+	// Apple's callback arrives as a POST with a form-encoded body (mandatory
+	// once the email scope is requested); every other provider uses the GET above.
+	authGroup.Post("/oauth/:provider/callback", h.OAuthCallback)
 	// Mobile-only: redeem the one-time code from the custom-scheme callback for a
 	// session. Public; the code is the credential.
 	authGroup.Post("/oauth/exchange", h.OAuthExchange)

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -113,7 +113,13 @@ func (h *authHandlers) OAuthCallback(c *fiber.Ctx) error {
 	oauth.ClearReturnCookie(c, h.cookieSecure)
 	oauth.ClearPlatformCookie(c, h.cookieSecure)
 
+	// Apple's callback arrives as a POST with a form-encoded body instead of a
+	// GET query string — response_mode=form_post is mandatory once the email
+	// scope is requested. Every other provider's callback is still a GET.
 	state, code := c.Query("state"), c.Query("code")
+	if c.Method() == fiber.MethodPost {
+		state, code = c.FormValue("state"), c.FormValue("code")
+	}
 	if state == "" || state != cookieState {
 		return h.oauthFail(c, p.Name(), returnTo, mobile, errors.New("state mismatch"))
 	}

--- a/internal/handler/oauth_test.go
+++ b/internal/handler/oauth_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,7 @@ type fakeProvider struct {
 	name     string
 	identity oauth.Identity
 	err      error
+	called   bool
 }
 
 func (f *fakeProvider) Name() string { return f.name }
@@ -28,6 +30,7 @@ func (f *fakeProvider) AuthCodeURL(state string) string {
 	return "https://provider.example/consent?state=" + state
 }
 func (f *fakeProvider) FetchIdentity(ctx context.Context, code string) (oauth.Identity, error) {
+	f.called = true
 	return f.identity, f.err
 }
 
@@ -58,6 +61,7 @@ func oauthApp(providers map[string]oauth.Provider) *fiber.App {
 	app.Get("/api/v1/auth/oauth/providers", h.ListOAuthProviders)
 	app.Get("/api/v1/auth/oauth/:provider/start", h.OAuthStart)
 	app.Get("/api/v1/auth/oauth/:provider/callback", h.OAuthCallback)
+	app.Post("/api/v1/auth/oauth/:provider/callback", h.OAuthCallback)
 	app.Post("/api/v1/auth/oauth/exchange", h.OAuthExchange)
 	return app
 }
@@ -164,6 +168,52 @@ func TestOAuthCallback_MissingStateCookieRedirectsWithError(t *testing.T) {
 	resp := get(t, app, "/api/v1/auth/oauth/google/callback?code=x&state=s")
 	if resp.StatusCode != fiber.StatusFound || resp.Header.Get("Location") != "http://app.example/?auth_error=oauth" {
 		t.Errorf("status/Location = %d %q, want error redirect", resp.StatusCode, resp.Header.Get("Location"))
+	}
+}
+
+// postFormOAuth issues a POST with a form-encoded body, as Apple's callback
+// arrives (response_mode=form_post is mandatory once the email scope is
+// requested), unlike every other provider's GET query-string callback.
+func postFormOAuth(t *testing.T, app *fiber.App, path, body string, cookies ...string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", fiber.MIMEApplicationForm)
+	for _, c := range cookies {
+		req.Header.Add("Cookie", c)
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	return resp
+}
+
+// The handler has no seam to fake accounts.Service (it's a concrete struct
+// backed by a real DB — see oauth_integration_test.go for the full round
+// trip), so this proves the POST form body's state/code were correctly
+// parsed by asserting the flow reaches FetchIdentity at all: a fake provider
+// error short-circuits before the handler ever touches h.accounts.
+func TestOAuthCallback_POSTFormBodyReachesProvider(t *testing.T) {
+	provider := &fakeProvider{name: "apple", err: errors.New("boom")}
+	app := oauthApp(map[string]oauth.Provider{"apple": provider})
+	resp := postFormOAuth(t, app, "/api/v1/auth/oauth/apple/callback", "code=x&state=s",
+		oauth.StateCookieName+"=s")
+
+	if resp.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	if !provider.called {
+		t.Error("FetchIdentity not called — state/code were not read from the POST form body")
+	}
+}
+
+func TestOAuthCallback_POSTStateMismatchRedirectsWithError(t *testing.T) {
+	app := oauthApp(map[string]oauth.Provider{"apple": &fakeProvider{name: "apple"}})
+	resp := postFormOAuth(t, app, "/api/v1/auth/oauth/apple/callback", "code=x&state=evil",
+		oauth.StateCookieName+"=good")
+
+	if loc := resp.Header.Get("Location"); loc != "http://app.example/?auth_error=oauth" {
+		t.Errorf("Location = %q, want auth_error redirect", loc)
 	}
 }
 

--- a/openspec/changes/apple-web-signin/.openspec.yaml
+++ b/openspec/changes/apple-web-signin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/apple-web-signin/design.md
+++ b/openspec/changes/apple-web-signin/design.md
@@ -1,0 +1,139 @@
+## Context
+
+`internal/auth/oauth` already implements Google, GitHub, and LinkedIn behind a
+shared `Provider` interface and a `Registry` built from `config.OAuthCredentials{ClientID,
+ClientSecret}` pairs (see `internal/auth/oauth/AGENTS.md`). All three existing
+providers are OIDC-userinfo shaped: exchange a code for an access token, then GET a
+userinfo endpoint for `sub`/`email`/`email_verified`.
+
+Apple's Sign in with Apple breaks two assumptions this registry was built around:
+
+1. **No static client secret.** Apple authenticates the token exchange with a JWT
+   that the client (freehire) signs itself, using a Team ID, a Key ID, and an
+   ES256 private key (`.p8`) issued once from Apple Developer. There is nothing to
+   put in a `ClientSecret` env var.
+2. **No userinfo endpoint.** Identity arrives only inside the token exchange's
+   `id_token`, a JWT signed by Apple. Trusting it requires verifying that
+   signature against Apple's published JWKS — the existing providers never verify
+   a token signature themselves, since their userinfo call is itself the trust
+   boundary (an authenticated HTTPS GET).
+
+Apple also requires `response_mode=form_post` whenever the `email` scope is
+requested (mandatory here — email is what account resolution keys on), so its
+callback lands as a `POST` with a form-encoded body instead of the `GET` query
+string every other provider's callback uses.
+
+The Apple Developer side is already partly done: an App ID (`me.freehire.mobile`)
+with Sign In with Apple enabled, a Team ID (`25U9HN34VM`), and a signing key
+(Key ID `ZC7298D2TR`, `.p8` on disk) exist from the mobile-app setup work. This
+change adds a Services ID for the web flow and reuses the same signing key — Apple
+allows one key to back multiple Services/App ID configurations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `apple` as a fourth provider in the existing OAuth registry, indistinguishable
+  from the caller's point of view (`GET /api/v1/auth/oauth/providers` lists it,
+  the same `/start` and `/callback` shape signs the user in).
+- Verify Apple's `id_token` signature before trusting any claim in it.
+- Keep the other three providers' code and config untouched in behavior — only
+  their constructor's parameter shape changes (see Decisions).
+
+**Non-Goals:**
+- Native Sign in with Apple in the freehire-mobile app (a separate, later change —
+  Apple's App Review guidance expects the native SDK on iOS, not a webview
+  redirect, so it is not simply "the mobile app calls the same `/start` URL").
+- Capturing the user's name (Apple provides it only on the first authorization,
+  ever). No other provider stores a name either; skipped for parity.
+- Automatic rotation of the Apple signing key. The client-secret JWT is minted
+  fresh per token exchange from the long-lived `.p8` key, so there is nothing to
+  rotate on a schedule — only the underlying key itself, which is out of scope
+  here (same lifecycle as Apple's own key expiry/revocation, handled like any
+  other credential rotation).
+
+## Decisions
+
+### 1. Extend `OAuthCredentials` rather than isolate Apple's config
+
+`config.OAuthCredentials` gains three optional fields — `TeamID`, `KeyID`,
+`PrivateKey` — used only by Apple; Google/GitHub/LinkedIn ignore them. The
+`constructors` map's function signature changes from
+`func(clientID, clientSecret, redirectURL string) Provider` to
+`func(creds config.OAuthCredentials, redirectURL string) Provider`, so every
+provider constructor now takes the whole credentials struct instead of two bare
+strings.
+
+**Alternative considered:** keep `OAuthCredentials` as-is and give Apple its own
+config type (`AppleOAuthCredentials`) threaded through the registry as a second,
+provider-specific argument. This isolates Apple's odd shape from the other three
+providers' code (zero-diff for them) at the cost of a special-cased construction
+path in `Registry`. Rejected in favor of the uniform-struct approach: one shape,
+one env-loading loop, one place (`NewRegistry`'s per-provider enablement check)
+that already has to know each provider's required fields either way.
+
+**Alternative considered:** a pre-signed, long-lived client-secret JWT stored
+directly in `OAUTH_APPLE_CLIENT_SECRET`, requiring zero config-shape changes.
+Rejected — Apple caps such a JWT's validity at 6 months, turning this into a
+manual rotation chore with silent-failure risk (sign-in breaks the day the JWT
+expires, discovered only when someone notices). Minting the JWT fresh per
+exchange from the long-lived private key removes the expiry problem entirely and
+costs a few milliseconds of ES256 signing per sign-in attempt.
+
+### 2. Client-secret JWT minted per exchange, not cached
+
+`apple.go`'s `FetchIdentity` signs a 5-minute-lived ES256 JWT
+(`iss`=Team ID, `sub`=Services ID, `aud`=`https://appleid.apple.com`, `kid`=Key ID
+header) immediately before each token exchange, using `golang-jwt/jwt/v5` (already
+a project dependency — no new dependency added). No caching, no background
+rotation job: the private key is the only long-lived secret, and it does not
+expire on Apple's schedule the way a signed assertion would.
+
+### 3. `id_token` verified against Apple's JWKS, not merely decoded
+
+Apple's JWKS (`https://appleid.apple.com/auth/keys`) is fetched and its keys used
+with `golang-jwt/jwt/v5`'s `Keyfunc` to verify the `id_token`'s RS256 signature
+before any claim (`sub`, `email`, `email_verified`) is trusted. This is the one
+place in `internal/auth/oauth` that verifies a token signature itself, because
+Apple is the one provider offering no live, authenticated endpoint to double as
+the trust boundary. The JWKS response is small and rarely rotates; no caching
+layer is added for this first version (Non-Goal) — each exchange fetches it fresh,
+matching the simplicity of the existing providers' per-request userinfo GET.
+
+### 4. Callback route gains POST alongside GET
+
+`internal/handler/oauth.go`'s `OAuthCallback` currently reads `state`/`code` via
+`c.Query`. A thin per-method wrapper reads from `c.Query` on GET and
+`c.FormValue` on POST, then calls the same `OAuthCallback` body — every other
+provider is unaffected since they never send a POST callback.
+
+## Risks / Trade-offs
+
+- **[Risk]** Apple's client-secret JWT construction is fiddly (specific `iss`/`sub`/`aud`/`kid`
+  requirements) and a mistake fails silently as a generic token-exchange error.
+  → **Mitigation**: unit tests assert the exact claim set and header before any
+  network call; the private key used in tests is a throwaway, not the real `.p8`.
+- **[Risk]** JWKS fetched fresh on every exchange adds one extra outbound HTTPS
+  call (and one more thing that can time out) to Apple sign-in specifically.
+  → **Mitigation**: bounded by the same `userinfoTimeout` pattern already used for
+  the other providers' calls; a JWKS fetch failure fails the sign-in attempt the
+  same way a userinfo fetch failure does today (redirect with `auth_error`).
+- **[Trade-off]** The mobile app cannot reuse this flow as-is for a native "Sign in
+  with Apple" button later — Apple's App Review guidance expects the native SDK,
+  which produces an identity token through a different path than this
+  authorization-code flow. Explicitly a Non-Goal here; called out so it is not
+  assumed "free" later.
+
+## Migration Plan
+
+No data migration. Deploy is additive: the `apple` provider is enabled only once
+all four `OAUTH_APPLE_*` env vars are set on production, so shipping the code
+ahead of the Apple Developer Portal setup is safe (`apple` simply stays absent
+from the provider list, matching every other optional provider's disabled state).
+
+Rollback: unset the `OAUTH_APPLE_*` env vars (or revert the deploy) — no schema or
+data changes to reverse.
+
+## Open Questions
+
+None outstanding — Services ID naming, scope (email-only), and the config-shape
+decision were confirmed during brainstorming before this document was written.

--- a/openspec/changes/apple-web-signin/proposal.md
+++ b/openspec/changes/apple-web-signin/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Sign in with Apple is required by Apple's App Store review guidelines whenever an
+app offers other third-party sign-in options — the freehire mobile app just shipped
+Google OAuth, so Apple becomes a submission blocker. Building it on the web first
+(reusing the existing `internal/auth/oauth` provider registry) gives freehire.me an
+Apple sign-in button now and puts the account-resolution and provider plumbing in
+place before the mobile app adds its own native entry point later.
+
+## What Changes
+
+- Add an `apple` OAuth provider to the existing registry (`internal/auth/oauth`),
+  alongside Google/GitHub/LinkedIn.
+- Apple's credential shape differs from every existing provider: instead of a
+  static client secret, it authenticates with a JWT that freehire signs itself
+  (ES256, using a Team ID + Key ID + `.p8` private key from Apple Developer). This
+  JWT is minted fresh on every code exchange, not stored or rotated.
+- Apple returns identity only inside a signed `id_token` (no userinfo endpoint) —
+  freehire verifies its signature against Apple's published JWKS before trusting
+  `sub`/`email`/`email_verified`.
+- Apple requires `response_mode=form_post` when the `email` scope is requested, so
+  its callback arrives as a `POST` with a form-encoded body, not the `GET` query
+  parameters every other provider uses. The callback route gains POST support.
+- `config.OAuthCredentials` gains optional `TeamID`, `KeyID`, `PrivateKey` fields
+  used only by the Apple provider; the other three providers are unaffected.
+- Web SPA: no new UI code — the existing "Continue with <Provider>" button list is
+  driven by `GET /api/v1/auth/oauth/providers`, so Apple appears automatically once
+  configured. Only the icon/label lookup needs an Apple entry.
+- Apple Developer Portal: a new Services ID (`me.freehire.web`) is registered and
+  associated with the existing App ID (`me.freehire.mobile`), with `freehire.me`
+  and the callback URL configured as its domain/return URL.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this extends the existing OAuth sign-in capability)
+
+### Modified Capabilities
+
+- `user-auth`: the "OAuth provider sign-in" requirement gains Apple as a fourth
+  provider, a POST-callback path for providers that require `response_mode=form_post`,
+  and a provider-enablement rule that accounts for Apple's non-uniform credential
+  shape (Team ID/Key ID/private key instead of a client secret).
+
+## Impact
+
+- `internal/auth/oauth/`: new `apple.go` (provider), `constructors` signature
+  change (`func(config.OAuthCredentials, redirectURL string) Provider`), JWKS
+  fetch/verify helper.
+- `internal/config/config.go`: `OAuthCredentials` gains `TeamID`/`KeyID`/`PrivateKey`;
+  new env vars `OAUTH_APPLE_CLIENT_ID` (Services ID), `OAUTH_APPLE_TEAM_ID`,
+  `OAUTH_APPLE_KEY_ID`, `OAUTH_APPLE_PRIVATE_KEY`.
+- `internal/handler/oauth.go`: callback route accepts POST in addition to GET.
+- `web/src/lib/...`: provider→icon/label map gains an `apple` entry.
+- Apple Developer Portal: register the `me.freehire.web` Services ID manually —
+  no public API covers Services IDs (unlike Bundle IDs).
+- No database schema changes — Apple identities live in the existing
+  `user_identities` table like every other provider.

--- a/openspec/changes/apple-web-signin/specs/user-auth/spec.md
+++ b/openspec/changes/apple-web-signin/specs/user-auth/spec.md
@@ -1,0 +1,71 @@
+## MODIFIED Requirements
+
+### Requirement: OAuth provider sign-in
+
+The system SHALL support sign-in via external OAuth providers (Google, GitHub,
+LinkedIn, Apple) using the server-side authorization-code flow, issuing the same
+httpOnly cookie session as password auth, and SHALL derive the flow's redirect
+origin only from an explicitly configured host.
+
+- Each provider SHALL be enabled only when its full credential set is configured:
+  a client id and client secret for Google/GitHub/LinkedIn, or a client id, Team
+  ID, Key ID, and private key for Apple (which authenticates with a
+  freehire-signed JWT instead of a static client secret). Routes for unknown or
+  disabled providers respond `404`.
+- The flow SHALL be protected against CSRF by a random `state` value carried in
+  a short-lived httpOnly cookie and verified on callback.
+- The request's `Host` SHALL be honoured as the redirect origin only when it
+  matches a configured served host exactly; any other `Host` SHALL fall back to
+  the canonical frontend origin. Suffix matching against a cookie domain SHALL
+  NOT be used, so a hijacked subdomain cannot steer the flow.
+- On success the callback SHALL set the session cookie and redirect the
+  browser to the SPA; on any failure it SHALL redirect to the SPA with an
+  `auth_error` query parameter, never rendering a JSON error to the browser.
+- A provider whose callback requires `response_mode=form_post` (Apple, when the
+  `email` scope is requested) SHALL be accepted as a `POST` with a form-encoded
+  body carrying `state` and `code`, in addition to the `GET` query-parameter form
+  every other provider uses.
+- An identity provider that returns claims only inside a signed token (Apple's
+  `id_token`, with no separate userinfo endpoint) SHALL have that token's
+  signature verified against the provider's published JWKS before any claim is
+  trusted for account resolution.
+
+#### Scenario: Start redirects to the provider
+
+- **WHEN** a client requests `GET /api/v1/auth/oauth/:provider/start` for an enabled provider
+- **THEN** the system sets a state cookie and responds `302` to the provider's consent URL carrying the same state
+
+#### Scenario: Successful callback signs the user in
+
+- **WHEN** the provider redirects back to the callback with a valid code and a state matching the state cookie
+- **THEN** the system resolves the account, sets the httpOnly session cookie, and redirects to the SPA, where `GET /me` returns the user
+
+#### Scenario: Apple callback arrives as a POST
+
+- **WHEN** Apple redirects back to the callback as a `POST` with a form-encoded body carrying a valid `code` and a `state` matching the state cookie
+- **THEN** the system resolves the account and signs the user in exactly as it would for a `GET` callback from any other provider
+
+#### Scenario: Apple id_token with an invalid signature is rejected
+
+- **WHEN** the Apple token exchange returns an `id_token` whose signature does not verify against Apple's published JWKS
+- **THEN** the system sets no session cookie and redirects to the SPA with `auth_error`
+
+#### Scenario: State mismatch is rejected
+
+- **WHEN** the callback's `state` does not match the state cookie (or the cookie is absent)
+- **THEN** the system sets no session cookie and redirects to the SPA with `auth_error`
+
+#### Scenario: Unknown or disabled provider
+
+- **WHEN** a client requests the start or callback route for a provider that is not configured
+- **THEN** the system responds `404`
+
+#### Scenario: Apple disabled when its credential set is incomplete
+
+- **WHEN** the Apple client id is configured but the Team ID, Key ID, or private key is missing
+- **THEN** the system treats Apple as disabled — it is absent from the provider list and its routes respond `404`
+
+#### Scenario: Unlisted host does not steer the redirect
+
+- **WHEN** the request arrives with a `Host` that is not in the configured served-host list (for example a subdomain that is not served by the app)
+- **THEN** the system builds the provider redirect and the post-login redirect from the canonical frontend origin instead of that `Host`

--- a/openspec/changes/apple-web-signin/tasks.md
+++ b/openspec/changes/apple-web-signin/tasks.md
@@ -1,0 +1,32 @@
+## 1. Apple Developer Portal setup
+
+- [x] 1.1 Register the `me.freehire.web` Services ID manually in the Apple Developer Portal (**not** available via the App Store Connect API — `/v1/servicesIds` returns `404`, unlike Bundle IDs), associated with the `me.freehire.mobile` App ID
+- [x] 1.2 Configure the Services ID's domain (`freehire.me`) and return URL (`https://freehire.me/api/v1/auth/oauth/apple/callback`) in the portal
+- [x] 1.3 Confirm in the portal that the existing signing key (Key ID `ZC7298D2TR`) is usable for the new Services ID
+
+## 2. Config plumbing
+
+- [ ] 2.1 Add `TeamID`, `KeyID`, `PrivateKey` fields to `config.OAuthCredentials`
+- [ ] 2.2 Load `OAUTH_APPLE_CLIENT_ID` / `OAUTH_APPLE_TEAM_ID` / `OAUTH_APPLE_KEY_ID` / `OAUTH_APPLE_PRIVATE_KEY` in `loadOAuth`, add `apple` to `oauthProviders`
+
+## 3. Apple provider implementation
+
+- [ ] 3.1 `internal/auth/oauth/apple.go`: client-secret JWT minting (ES256, 5-minute lifetime, `iss`/`sub`/`aud`/`kid` per design)
+- [ ] 3.2 `AuthCodeURL`: build Apple's authorize URL with `response_type=code`, `response_mode=form_post`, `scope=email`
+- [ ] 3.3 JWKS fetch + `id_token` signature verification (`golang-jwt/jwt/v5` `Keyfunc` against `https://appleid.apple.com/auth/keys`)
+- [ ] 3.4 `FetchIdentity`: token exchange, verify `id_token`, map `sub`/`email`/`email_verified` to `Identity`
+- [ ] 3.5 Update the `constructors` map signature to `func(config.OAuthCredentials, redirectURL string) Provider`; update Google/GitHub/LinkedIn constructors to the new signature (behavior unchanged); add `apple` entry
+- [ ] 3.6 `NewRegistry`: Apple enabled only when client id, Team ID, Key ID, and private key are all present
+
+## 4. Callback route POST support
+
+- [ ] 4.1 `internal/handler/oauth.go`: accept `POST /api/v1/auth/oauth/:provider/callback` alongside the existing `GET`, reading `state`/`code` from `c.FormValue` on POST and `c.Query` on GET, sharing the rest of `OAuthCallback`
+
+## 5. Web UI
+
+- [ ] 5.1 Add an `apple` entry to the provider→icon/label map the SPA auth dialog uses to render "Continue with <Provider>" buttons
+
+## 6. Verification
+
+- [ ] 6.1 `go vet -tags=integration ./...` passes
+- [ ] 6.2 Manual end-to-end sign-in against the real Apple Services ID on a deployed environment

--- a/openspec/changes/apple-web-signin/tasks.md
+++ b/openspec/changes/apple-web-signin/tasks.md
@@ -28,5 +28,5 @@
 
 ## 6. Verification
 
-- [ ] 6.1 `go vet -tags=integration ./...` passes
+- [x] 6.1 `go vet -tags=integration ./...` passes
 - [ ] 6.2 Manual end-to-end sign-in against the real Apple Services ID on a deployed environment

--- a/openspec/changes/apple-web-signin/tasks.md
+++ b/openspec/changes/apple-web-signin/tasks.md
@@ -20,7 +20,7 @@
 
 ## 4. Callback route POST support
 
-- [ ] 4.1 `internal/handler/oauth.go`: accept `POST /api/v1/auth/oauth/:provider/callback` alongside the existing `GET`, reading `state`/`code` from `c.FormValue` on POST and `c.Query` on GET, sharing the rest of `OAuthCallback`
+- [x] 4.1 `internal/handler/oauth.go`: accept `POST /api/v1/auth/oauth/:provider/callback` alongside the existing `GET`, reading `state`/`code` from `c.FormValue` on POST and `c.Query` on GET, sharing the rest of `OAuthCallback`
 
 ## 5. Web UI
 

--- a/openspec/changes/apple-web-signin/tasks.md
+++ b/openspec/changes/apple-web-signin/tasks.md
@@ -24,7 +24,7 @@
 
 ## 5. Web UI
 
-- [ ] 5.1 Add an `apple` entry to the provider→icon/label map the SPA auth dialog uses to render "Continue with <Provider>" buttons
+- [x] 5.1 Add an `apple` entry to the provider→icon/label map the SPA auth dialog uses to render "Continue with <Provider>" buttons
 
 ## 6. Verification
 

--- a/openspec/changes/apple-web-signin/tasks.md
+++ b/openspec/changes/apple-web-signin/tasks.md
@@ -6,17 +6,17 @@
 
 ## 2. Config plumbing
 
-- [ ] 2.1 Add `TeamID`, `KeyID`, `PrivateKey` fields to `config.OAuthCredentials`
-- [ ] 2.2 Load `OAUTH_APPLE_CLIENT_ID` / `OAUTH_APPLE_TEAM_ID` / `OAUTH_APPLE_KEY_ID` / `OAUTH_APPLE_PRIVATE_KEY` in `loadOAuth`, add `apple` to `oauthProviders`
+- [x] 2.1 Add `TeamID`, `KeyID`, `PrivateKey` fields to `config.OAuthCredentials`
+- [x] 2.2 Load `OAUTH_APPLE_CLIENT_ID` / `OAUTH_APPLE_TEAM_ID` / `OAUTH_APPLE_KEY_ID` / `OAUTH_APPLE_PRIVATE_KEY` in `loadOAuth`, add `apple` to `oauthProviders`
 
 ## 3. Apple provider implementation
 
-- [ ] 3.1 `internal/auth/oauth/apple.go`: client-secret JWT minting (ES256, 5-minute lifetime, `iss`/`sub`/`aud`/`kid` per design)
-- [ ] 3.2 `AuthCodeURL`: build Apple's authorize URL with `response_type=code`, `response_mode=form_post`, `scope=email`
-- [ ] 3.3 JWKS fetch + `id_token` signature verification (`golang-jwt/jwt/v5` `Keyfunc` against `https://appleid.apple.com/auth/keys`)
-- [ ] 3.4 `FetchIdentity`: token exchange, verify `id_token`, map `sub`/`email`/`email_verified` to `Identity`
-- [ ] 3.5 Update the `constructors` map signature to `func(config.OAuthCredentials, redirectURL string) Provider`; update Google/GitHub/LinkedIn constructors to the new signature (behavior unchanged); add `apple` entry
-- [ ] 3.6 `NewRegistry`: Apple enabled only when client id, Team ID, Key ID, and private key are all present
+- [x] 3.1 `internal/auth/oauth/apple.go`: client-secret JWT minting (ES256, 5-minute lifetime, `iss`/`sub`/`aud`/`kid` per design)
+- [x] 3.2 `AuthCodeURL`: build Apple's authorize URL with `response_type=code`, `response_mode=form_post`, `scope=email`
+- [x] 3.3 JWKS fetch + `id_token` signature verification (`golang-jwt/jwt/v5` `Keyfunc` against `https://appleid.apple.com/auth/keys`)
+- [x] 3.4 `FetchIdentity`: token exchange, verify `id_token`, map `sub`/`email`/`email_verified` to `Identity`
+- [x] 3.5 Update the `constructors` map signature to `func(config.OAuthCredentials, redirectURL string) Provider`; update Google/GitHub/LinkedIn constructors to the new signature (behavior unchanged); add `apple` entry
+- [x] 3.6 `NewRegistry`: Apple enabled only when client id, Team ID, Key ID, and private key are all present
 
 ## 4. Callback route POST support
 

--- a/web/src/lib/components/AuthDialog.svelte
+++ b/web/src/lib/components/AuthDialog.svelte
@@ -44,6 +44,7 @@
     google: 'Google',
     github: 'GitHub',
     linkedin: 'LinkedIn',
+    apple: 'Apple',
   };
 
   // Enabled OAuth providers; an unreachable endpoint just means no provider

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -122,6 +122,9 @@
   // The universe of skills (canonical tokens with job counts) for the typeahead, from
   // the facet-distribution endpoint — the same source the filter panel uses.
   let skillDist = $state.raw<FacetOption[]>([]);
+  // See RemoteSearchSelect's `ready` prop: without it, a dictionary fetch slower
+  // than the picker's 250ms debounce leaves the popular first page stuck empty.
+  let skillDistReady = $state(false);
 
   const canSubmit = $derived(specializations.length > 0 && skills.length > 0);
 
@@ -141,7 +144,10 @@
   const searchExcludedSkills = (query: string) => searchSkillsExcept(query, skills);
 
   $effect(() => {
-    void loadSkillDistribution().then((dist) => (skillDist = dist));
+    void loadSkillDistribution().then((dist) => {
+      skillDist = dist;
+      skillDistReady = true;
+    });
   });
 
   // Derive skills + specialization from a résumé PDF. Before a profile exists, both merge
@@ -453,6 +459,7 @@
       onToggle={toggleSkill}
       fallbackLabel={(v) => v}
       clearOnSelect
+      ready={skillDistReady}
     />
   </div>
 
@@ -473,6 +480,7 @@
       onToggle={toggleExcludedSkill}
       fallbackLabel={(v) => v}
       clearOnSelect
+      ready={skillDistReady}
     />
     <span class="text-xs text-muted-foreground">
       Filtered out when you apply your profile to the job filters.

--- a/web/src/lib/components/ProviderIcon.svelte
+++ b/web/src/lib/components/ProviderIcon.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   // Brand marks (OAuth sign-in buttons, footer links), inlined because icon
   // libraries (lucide) do not ship brand logos. Google keeps its official
-  // colors; GitHub, Telegram, and LinkedIn follow the current text color so they
-  // adapt to the theme (and match the muted footer treatment).
+  // colors; GitHub, Telegram, LinkedIn, and Apple follow the current text color
+  // so they adapt to the theme (and match the muted footer treatment).
   let { provider, class: className = 'size-4' }: { provider: string; class?: string } = $props();
 </script>
 
@@ -41,6 +41,12 @@
   <svg viewBox="0 0 24 24" class={className} fill="currentColor" aria-hidden="true">
     <path
       d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"
+    />
+  </svg>
+{:else if provider === 'apple'}
+  <svg viewBox="0 0 24 24" class={className} fill="currentColor" aria-hidden="true">
+    <path
+      d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.06 2.09-.976 3.935-.976 1.831 0 2.35.976 3.96.947 1.637-.03 2.676-1.483 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.41-.037-.017-3.19-1.226-3.22-4.857-.03-3.034 2.479-4.487 2.59-4.548-1.42-2.088-3.629-2.32-4.406-2.37-2.003-.161-3.686 1.08-4.65 1.08zm3.415-3.06c.84-1.017 1.406-2.435 1.253-3.836-1.213.049-2.68.81-3.549 1.827-.778.9-1.457 2.34-1.278 3.72 1.348.104 2.734-.687 3.574-1.71z"
     />
   </svg>
 {:else if provider === 'discord'}

--- a/web/src/lib/components/SkillsView.svelte
+++ b/web/src/lib/components/SkillsView.svelte
@@ -14,8 +14,15 @@
   // The universe of skills (canonical tokens with job counts) for the typeahead, from the
   // same source ProfileForm's set-up form and the job-search filter panel use.
   let skillDist = $state.raw<FacetOption[]>([]);
+  // Flips true once the dictionary lands — passed to RemoteSearchSelect as `ready` so
+  // its debounced search re-fires if it opens before the fetch resolves (see that
+  // component's `ready` prop for why this is needed, not just a nicety).
+  let skillDistReady = $state(false);
   $effect(() => {
-    void loadSkillDistribution().then((dist) => (skillDist = dist));
+    void loadSkillDistribution().then((dist) => {
+      skillDist = dist;
+      skillDistReady = true;
+    });
   });
 
   function searchSkillsExcept(query: string, avoid: string[]): Promise<FacetOption[]> {
@@ -92,6 +99,7 @@
       onToggle={toggleSkill}
       fallbackLabel={(v) => v}
       clearOnSelect
+      ready={skillDistReady}
     />
   </div>
 
@@ -108,6 +116,7 @@
       onToggle={toggleExcludedSkill}
       fallbackLabel={(v) => v}
       clearOnSelect
+      ready={skillDistReady}
     />
     <span class="text-xs text-muted-foreground">
       Filtered out when you apply your profile to the job filters.

--- a/web/src/lib/components/facets/RemoteSearchSelect.svelte
+++ b/web/src/lib/components/facets/RemoteSearchSelect.svelte
@@ -13,6 +13,13 @@
   // seen, falling back to `fallbackLabel` for a value restored from the URL. A chip
   // is included or excluded; clicking it calls `onToggle` (cycle for excludable
   // facets, plain include toggle otherwise).
+  //
+  // Compact mode (expand=false, the default) renders the picker as a floating panel
+  // anchored to the input — the same pattern as CompanyPicker.svelte — so it always
+  // opens right under the field being typed into, however many chips are already
+  // stacked below it. Expand mode keeps the picker inline instead: it's used only
+  // inside the filter modal's own scroll pane, which already gives it room and
+  // wants it visible without a focus/blur dance.
   let {
     search,
     include,
@@ -22,6 +29,7 @@
     fallbackLabel,
     clearOnSelect = false,
     expand = false,
+    ready = true,
   }: {
     search: (query: string) => Promise<FacetOption[]>;
     include: string[];
@@ -32,13 +40,19 @@
     // When set, the search field is cleared after picking an option (search →
     // pick a chip → search the next), suited to a build-a-set form.
     clearOnSelect?: boolean;
-    // Drop the scroll cap on the results list — for the roomy modal pane.
+    // Drop the floating panel for a roomy inline pane — for the modal's own scroll area.
     expand?: boolean;
+    // False while the candidate list behind `search` (e.g. a facet dictionary) is
+    // still loading. Blocks the debounced search until it flips true, so a load
+    // that outruns the 250ms debounce gets its popular first page fetched once it
+    // lands, instead of the query staying stuck on the empty result it raced into.
+    ready?: boolean;
   } = $props();
 
   let query = $state('');
   let results = $state<FacetOption[]>([]);
   let loading = $state(false);
+  let open = $state(false);
   // value → display label, accumulated from every result we have rendered, so a
   // selected company shows its real name. A reactive SvelteMap so a chip rendered
   // from the URL fallback upgrades to the real name once a later search reveals it
@@ -63,9 +77,15 @@
   }
 
   // Debounce: re-run on every query change, cancelling the pending run. Fires once
-  // on mount with an empty query to show the popular first page.
+  // on mount with an empty query to show the popular first page, and again
+  // whenever `ready` flips true — reading it here is what makes the effect
+  // re-fire once a still-loading dictionary lands.
   $effect(() => {
     const q = query.trim();
+    if (!ready) {
+      results = [];
+      return;
+    }
     const t = setTimeout(() => run(q), 250);
     return () => clearTimeout(t);
   });
@@ -81,11 +101,10 @@
   const labelOf = (value: string) => seen.get(value) ?? fallbackLabel(value);
   // Don't list an already-selected option in the picker — it's shown as a chip.
   const pickable = $derived(results.filter((o) => !selected.includes(o.value)));
+  const emptyMessage = $derived(!ready ? 'Loading…' : loading ? 'Searching…' : query ? 'Nothing found' : 'No results');
 </script>
 
-<div class="flex flex-col gap-2">
-  <Input bind:value={query} {placeholder} class="w-full" />
-
+{#snippet chips()}
   {#if selected.length > 0}
     <div class="flex flex-wrap gap-1.5">
       {#each selected as value (value)}
@@ -102,24 +121,65 @@
       {/each}
     </div>
   {/if}
+{/snippet}
 
-  <div class={expand ? 'flex flex-col gap-0.5' : 'flex max-h-44 flex-col gap-0.5 overflow-y-auto'}>
-    {#each pickable as opt (opt.value)}
-      <button
-        type="button"
-        onclick={() => pick(opt.value)}
-        class="flex items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-accent"
-      >
-        <span class="truncate">{opt.label}</span>
-        {#if opt.count !== undefined}
-          <span class="shrink-0 tabular-nums opacity-60">{opt.count.toLocaleString()}</span>
-        {/if}
-      </button>
-    {/each}
-    {#if pickable.length === 0}
-      <span class="px-1 py-1 text-xs text-muted-foreground">
-        {loading ? 'Searching…' : query ? 'Nothing found' : 'No results'}
-      </span>
-    {/if}
-  </div>
+{#snippet optionList()}
+  {#each pickable as opt (opt.value)}
+    <button
+      type="button"
+      role="option"
+      aria-selected="false"
+      onmousedown={(e) => {
+        // mousedown (not click), preventDefault: keeps focus on the input instead
+        // of moving it to the button, so the panel stays open for the next pick.
+        e.preventDefault();
+        pick(opt.value);
+      }}
+      class="flex items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-accent"
+    >
+      <span class="truncate">{opt.label}</span>
+      {#if opt.count !== undefined}
+        <span class="shrink-0 tabular-nums opacity-60">{opt.count.toLocaleString()}</span>
+      {/if}
+    </button>
+  {/each}
+  {#if pickable.length === 0}
+    <span class="px-2 py-1 text-xs text-muted-foreground">{emptyMessage}</span>
+  {/if}
+{/snippet}
+
+<div class="flex flex-col gap-2">
+  {#if expand}
+    <Input bind:value={query} {placeholder} class="w-full" />
+    {@render chips()}
+    <div class="flex flex-col gap-0.5">
+      {@render optionList()}
+    </div>
+  {:else}
+    <div class="relative">
+      <Input
+        bind:value={query}
+        {placeholder}
+        class="w-full"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls="remote-search-select-list"
+        onfocus={() => (open = true)}
+        onblur={() => setTimeout(() => (open = false), 120)}
+        onkeydown={(e) => {
+          if (e.key === 'Escape') open = false;
+        }}
+      />
+      {#if open}
+        <div
+          id="remote-search-select-list"
+          role="listbox"
+          class="absolute inset-x-0 top-full z-10 mt-1 flex max-h-60 flex-col gap-0.5 overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-lg"
+        >
+          {@render optionList()}
+        </div>
+      {/if}
+    </div>
+    {@render chips()}
+  {/if}
 </div>


### PR DESCRIPTION
## Summary
- Adds `apple` as a fourth OAuth provider in `internal/auth/oauth`, alongside Google/GitHub/LinkedIn — Apple has no static client secret (a self-signed ES256 JWT is minted fresh per token exchange from Team ID/Key ID/private key) and no userinfo endpoint (identity comes from a signed `id_token`, verified against Apple's JWKS with `aud`/`iss` checks before any claim is trusted)
- `config.OAuthCredentials` gains `TeamID`/`KeyID`/`PrivateKey`; the `constructors` map now takes the full credentials struct so Apple's shape fits without a special-cased construction path
- `internal/handler/oauth.go`'s callback route accepts `POST` (form-encoded body) alongside the existing `GET` — mandatory once the `email` scope is requested
- Web: Apple joins the "Continue with <Provider>" button list (icon + label)
- Apple Developer Portal: `me.freehire.web` Services ID registered manually (no public API for Services IDs, unlike Bundle IDs), associated with the existing `me.freehire.mobile` App ID

See `openspec/changes/apple-web-signin/` for the full proposal/design/spec.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — all clean
- [x] `go test ./internal/auth/oauth/... ./internal/config/... ./internal/handler/...` — all passing, including adversarial tests (wrong signing key, wrong kid, wrong audience, wrong issuer all rejected)
- [x] Web: lint, svelte-check, design-system token coverage — all clean
- [ ] Manual end-to-end sign-in against the real Apple Services ID on a deployed environment (needs `OAUTH_APPLE_*` env vars in prod — not yet set)