### PR TITLE
fix(web): route the WebRTC SDP exchange through our own gateway

### DIFF
--- a/internal/handler/assistant_interview_voice.go
+++ b/internal/handler/assistant_interview_voice.go
@@ -17,6 +17,7 @@ import (
 type realtimeMinter interface {
 	MintClientSecret(ctx context.Context, instructions string) (string, error)
 	Model() string
+	CallsURL() string
 }
 
 // voiceTokensPerHour bounds how many calls one caller may start per hour. A mint is
@@ -27,10 +28,10 @@ type realtimeMinter interface {
 // and far below anything worth doing with a stolen session.
 const voiceTokensPerHour = 20
 
-// PostAssistantVoiceToken mints a short-lived OpenAI Realtime API client secret for a
+// PostAssistantVoiceToken mints a short-lived Realtime API client secret for a
 // hands-free voice call on an existing `interview` session. The audio itself never
-// reaches this server: the browser takes the returned secret straight to the
-// Realtime API over WebRTC.
+// reaches this server: the browser takes the returned secret to the gateway's own
+// /realtime/calls (see CallsURL) to negotiate the WebRTC call directly.
 func (h *assistantHandlers) PostAssistantVoiceToken(c *fiber.Ctx) error {
 	sess, err := h.ownedSession(c)
 	if err != nil {
@@ -58,10 +59,16 @@ func (h *assistantHandlers) PostAssistantVoiceToken(c *fiber.Ctx) error {
 		// could not read. The caller did nothing wrong and has no remedy.
 		return fiber.NewError(fiber.StatusBadGateway, "could not start voice mode")
 	}
-	// The browser's WebRTC SDP exchange names the model on its own URL, and it has no
-	// other way to learn which one this deployment runs — the value must come from
-	// here, not from a name hardcoded in the frontend that could drift from REALTIME_MODEL.
-	return c.JSON(fiber.Map{"data": fiber.Map{"value": value, "model": h.realtime.Model()}})
+	// model: the WebRTC SDP exchange names the model on its own URL, and the browser
+	// has no other way to learn which one this deployment runs.
+	// calls_url: the minted value is NOT a raw OpenAI ephemeral key — it is this
+	// gateway's own wrapped token, redeemable only at the SAME gateway's
+	// /realtime/calls (see realtime.Client.CallsURL's doc). Hardcoding
+	// api.openai.com in the frontend sends that wrapped value to an endpoint that
+	// cannot read it and rejects it as a malformed API key.
+	return c.JSON(fiber.Map{"data": fiber.Map{
+		"value": value, "model": h.realtime.Model(), "calls_url": h.realtime.CallsURL(),
+	}})
 }
 
 // assistantVoiceTurnRequest is one completed exchange from a voice-mode call: the

--- a/internal/handler/assistant_interview_voice_integration_test.go
+++ b/internal/handler/assistant_interview_voice_integration_test.go
@@ -36,7 +36,8 @@ func (s *realtimeStub) MintClientSecret(_ context.Context, instructions string) 
 	return s.value, s.err
 }
 
-func (s *realtimeStub) Model() string { return "gpt-realtime-2.1" }
+func (s *realtimeStub) Model() string    { return "gpt-realtime-2.1" }
+func (s *realtimeStub) CallsURL() string { return "https://gw.example/v1/realtime/calls" }
 
 func TestPostAssistantVoiceTokenReportsUnconfigured(t *testing.T) {
 	pool := startPostgres(t)
@@ -106,8 +107,9 @@ func TestPostAssistantVoiceTokenMintsAScopedSecret(t *testing.T) {
 	}
 	var got struct {
 		Data struct {
-			Value string `json:"value"`
-			Model string `json:"model"`
+			Value    string `json:"value"`
+			Model    string `json:"model"`
+			CallsURL string `json:"calls_url"`
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
@@ -121,6 +123,11 @@ func TestPostAssistantVoiceTokenMintsAScopedSecret(t *testing.T) {
 	// REALTIME_MODEL.
 	if got.Data.Model != "gpt-realtime-2.1" {
 		t.Errorf("model = %q, want gpt-realtime-2.1", got.Data.Model)
+	}
+	// The minted value is our gateway's own wrapped token, not a raw OpenAI ephemeral
+	// key — the browser must redeem it at OUR gateway, never at api.openai.com.
+	if got.Data.CallsURL != "https://gw.example/v1/realtime/calls" {
+		t.Errorf("calls_url = %q, want https://gw.example/v1/realtime/calls", got.Data.CallsURL)
 	}
 	if stub.calls != 1 {
 		t.Fatalf("MintClientSecret called %d times, want 1", stub.calls)

--- a/internal/realtime/realtime.go
+++ b/internal/realtime/realtime.go
@@ -107,6 +107,17 @@ func (c *Client) Model() string {
 	return c.model
 }
 
+// CallsURL is where the browser POSTs its WebRTC SDP offer — at THIS gateway, never
+// at api.openai.com directly. The value MintClientSecret returns is not a raw OpenAI
+// ephemeral key: it is this gateway's own wrapped token (a real upstream key
+// encrypted inside it, alongside routing metadata), redeemable only at this
+// gateway's matching /realtime/calls, which decrypts it and forwards to OpenAI on
+// the caller's behalf. Sent to OpenAI directly, it looks like a malformed API key,
+// because it is not one.
+func (c *Client) CallsURL() string {
+	return c.baseURL + "/realtime/calls"
+}
+
 // MintClientSecret returns a short-lived credential scoped to one Realtime session.
 func (c *Client) MintClientSecret(ctx context.Context, instructions string) (string, error) {
 	var payload mintRequest

--- a/internal/realtime/realtime_test.go
+++ b/internal/realtime/realtime_test.go
@@ -96,6 +96,25 @@ func TestModelReturnsWhatTheClientWasConfiguredWith(t *testing.T) {
 	}
 }
 
+// The value MintClientSecret returns is NOT a raw OpenAI ephemeral key — it is our
+// gateway's own wrapped token (a real OpenAI key encrypted inside it, plus routing
+// metadata), meant to be redeemed at the SAME gateway's own /realtime/calls, not sent
+// to api.openai.com directly. A browser that skips this and calls OpenAI itself gets
+// "Incorrect API key provided" — the wrapped value simply is not one.
+func TestCallsURLPointsAtOurOwnGatewayNotOpenAI(t *testing.T) {
+	c := New("https://gw.example/v1", "sk-test", "gpt-realtime-2.1")
+	if got := c.CallsURL(); got != "https://gw.example/v1/realtime/calls" {
+		t.Errorf("CallsURL() = %q, want https://gw.example/v1/realtime/calls", got)
+	}
+}
+
+func TestCallsURLJoinsTheBaseURLWithoutDoublingTheSlash(t *testing.T) {
+	c := New("https://gw.example/v1/", "sk-test", "gpt-realtime-2.1")
+	if got := c.CallsURL(); got != "https://gw.example/v1/realtime/calls" {
+		t.Errorf("CallsURL() = %q, want https://gw.example/v1/realtime/calls", got)
+	}
+}
+
 func TestMintClientSecretSendsInstructionsAndReturnsTheValue(t *testing.T) {
 	srv, got := gateway(t, http.StatusOK, `{"value":"ek_abc123","expires_at":1234}`)
 	c := New(srv.URL+"/v1", "sk-test", "gpt-realtime-2.1")

--- a/web/src/lib/assistant/VoiceCall.svelte
+++ b/web/src/lib/assistant/VoiceCall.svelte
@@ -13,7 +13,6 @@
     initVoiceCallState,
     MAX_CALL_MS,
     END_WARNING_MS,
-    openaiModelID,
     type RealtimeServerEvent,
   } from '$lib/assistant/voiceCall';
 
@@ -107,10 +106,10 @@
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
 
-      // token.model is the litellm-routing name (may carry a provider prefix our
-      // proxy needed to mint the secret); this call bypasses the proxy and talks to
-      // OpenAI directly, which needs its own bare model id — see openaiModelID.
-      const sdpResp = await fetch(`https://api.openai.com/v1/realtime/calls?model=${encodeURIComponent(openaiModelID(token.model))}`, {
+      // token.value is our own gateway's wrapped token, not a raw OpenAI ephemeral
+      // key — it is only redeemable at that SAME gateway's calls_url, never at
+      // api.openai.com directly (see VoiceToken's doc in api.ts).
+      const sdpResp = await fetch(`${token.calls_url}?model=${encodeURIComponent(token.model)}`, {
         method: 'POST',
         body: offer.sdp,
         headers: { Authorization: `Bearer ${token.value}`, 'Content-Type': 'application/sdp' },

--- a/web/src/lib/assistant/api.ts
+++ b/web/src/lib/assistant/api.ts
@@ -94,18 +94,22 @@ export class VoiceModeUnavailable extends Error {
   }
 }
 
-/** A one-call Realtime credential: the ephemeral secret, and which model it was
- *  minted for. The model rides along because the WebRTC SDP exchange names it on its
- *  own URL — the browser has no other way to learn which one this deployment runs,
- *  and hardcoding it here would drift silently from the backend's REALTIME_MODEL. */
+/** A one-call Realtime credential. `value` is NOT a raw OpenAI ephemeral key — it is
+ *  our gateway's own wrapped token (a real upstream key encrypted inside it), and it
+ *  only means anything redeemed at `calls_url`, that SAME gateway's own
+ *  /realtime/calls. Sent to api.openai.com directly, OpenAI reads it as a malformed
+ *  API key and 401s. `model` rides along for the same reason `calls_url` does — the
+ *  browser has no way to learn either fact on its own, and hardcoding either would
+ *  drift silently from the backend's REALTIME_MODEL/LLM_BASE_URL. */
 export interface VoiceToken {
   value: string;
   model: string;
+  calls_url: string;
 }
 
 /** Mint a short-lived Realtime API client secret scoped to one interview session. The
- *  browser takes this straight to OpenAI over WebRTC — it never transits our backend
- *  again after this call. */
+ *  browser takes this to the gateway's own `callsUrl` to negotiate the WebRTC call —
+ *  never to OpenAI directly, see VoiceToken's doc. */
 export async function mintVoiceToken(sessionId: string): Promise<VoiceToken> {
   const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/voice-token`, {
     method: 'POST',

--- a/web/src/lib/assistant/voiceCall.test.ts
+++ b/web/src/lib/assistant/voiceCall.test.ts
@@ -1,21 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyRealtimeEvent, canUseVoiceCall, initVoiceCallState, openaiModelID } from './voiceCall';
-
-describe('openaiModelID', () => {
-  it('strips a litellm provider prefix', () => {
-    expect(openaiModelID('openai/gpt-realtime-2.1')).toBe('gpt-realtime-2.1');
-  });
-
-  it('leaves a bare model id alone', () => {
-    // A deployment whose REALTIME_MODEL never needed a routing prefix (e.g. talking
-    // to OpenAI directly, no litellm in front) must not be mangled.
-    expect(openaiModelID('gpt-realtime-2.1')).toBe('gpt-realtime-2.1');
-  });
-
-  it('takes the LAST segment, for a routing alias with more than one slash', () => {
-    expect(openaiModelID('privateclaw/openai/gpt-realtime-2.1')).toBe('gpt-realtime-2.1');
-  });
-});
+import { applyRealtimeEvent, canUseVoiceCall, initVoiceCallState } from './voiceCall';
 
 describe('canUseVoiceCall', () => {
   it('is true only when both APIs are present', () => {

--- a/web/src/lib/assistant/voiceCall.ts
+++ b/web/src/lib/assistant/voiceCall.ts
@@ -18,24 +18,6 @@ export const MAX_CALL_MS = 15 * 60 * 1000;
  *  end from a dropped connection. */
 export const END_WARNING_MS = 60 * 1000;
 
-/** Strips a litellm-routing provider prefix (`openai/gpt-realtime-2.1` →
- *  `gpt-realtime-2.1`) from the model name the backend hands back with the minted
- *  token.
- *
- *  Two different systems read that name for two different reasons, and they
- *  disagree on its shape. The backend mints the client secret by POSTing to OUR
- *  litellm proxy, which needs the provider prefix to route the request to the right
- *  upstream account — that's why `REALTIME_MODEL` is configured as
- *  `openai/gpt-realtime-2.1` in the first place. But the browser then takes that
- *  same ephemeral token and negotiates the WebRTC call DIRECTLY against OpenAI's own
- *  `/v1/realtime/calls`, bypassing our proxy entirely — and OpenAI's real API has no
- *  concept of a litellm provider prefix; it 401s on a model id it does not
- *  recognise. This is the one place that mismatch has to be undone. */
-export function openaiModelID(model: string): string {
-  const slash = model.lastIndexOf('/');
-  return slash === -1 ? model : model.slice(slash + 1);
-}
-
 /** The bits of `window` a call needs, as a shape rather than as the global, so the
  *  support check can be exercised for browsers this test run is not. */
 export type VoiceCallEnv = {


### PR DESCRIPTION
Live prod bug: `Could not connect the call (401)` — `Incorrect API key provided` from OpenAI, verified via the browser's Network tab.

Root cause: the value our litellm proxy's `/realtime/client_secrets` mints is NOT a raw OpenAI ephemeral key. It's the proxy's own wrapped token (a real OpenAI key encrypted inside it, plus routing metadata) — redeemable only at that SAME proxy's own `/realtime/calls`, which decrypts it and forwards to OpenAI. The frontend was sending it to `api.openai.com` directly, which reads it as a malformed API key.

(My previous fix in #1723, stripping a provider prefix from the model string, treated the wrong symptom — a 401 that looked model-related but wasn't. Reverted that stripping here since it's now not needed at all: we're calling our own gateway, which expects its own prefixed model names.)

Confirmed live: minting through the real `/voice-token` endpoint, then POSTing to the gateway's own `calls_url` with the wrapped token gets past auth (400 on a deliberately malformed SDP — same as every legitimate attempt) instead of 401.