### PR TITLE
fix(sources): stop hardcoding cryptocurrencyjobs postings as remote

### DIFF
--- a/internal/sources/cryptocurrencyjobs.go
+++ b/internal/sources/cryptocurrencyjobs.go
@@ -94,9 +94,9 @@ func (it cryptocurrencyjobsItem) toJob() (Job, bool) {
 	title = strings.TrimSpace(title)
 
 	location, remote, workMode := "Remote", true, "remote"
-	if m := cryptocurrencyjobsOnsiteTitle.FindStringSubmatchIndex(title); m != nil {
-		location, remote, workMode = title[m[2]:m[3]], false, "onsite"
-		title = strings.TrimSpace(title[:m[0]])
+	if m := cryptocurrencyjobsOnsiteTitle.FindStringSubmatch(title); m != nil {
+		location, remote, workMode = m[1], false, "onsite"
+		title = strings.TrimSuffix(title, m[0])
 	}
 
 	return Job{

--- a/internal/sources/cryptocurrencyjobs.go
+++ b/internal/sources/cryptocurrencyjobs.go
@@ -4,16 +4,26 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
 	xhtml "golang.org/x/net/html"
 )
 
-// cryptocurrencyjobs adapts cryptocurrencyjobs.co, a Web3/crypto-niche remote-jobs board.
-// Boardless (one public RSS feed, no per-tenant board) and multi-company, so it stays in the
-// source facet and takes each posting's company from the feed. All-remote board, so every
-// posting is remote. The feed carries every posting's body inline (no detail call).
+// cryptocurrencyjobs adapts cryptocurrencyjobs.co, a Web3/crypto-niche jobs board. Boardless
+// (one public RSS feed, no per-tenant board) and multi-company, so it stays in the source
+// facet and takes each posting's company from the feed. The feed carries every posting's body
+// inline (no detail call).
+//
+// The board is mostly but not entirely remote: a posting the board restricts to one office
+// (confirmed live, e.g. "Product Designer (New York only)" at Loopscale, whose page reads
+// "This role requires working full-time from our New York City office") gets that city
+// appended to its title in parens as "(<City> only)", with no "remote" wording anywhere in
+// the feed's truncated description — unlike a geo-eligibility-restricted remote posting,
+// which this board phrases as e.g. "100% remote ... anywhere in Europe" rather than a title
+// suffix. cryptocurrencyjobsOnsiteTitle strips that suffix and treats it as an onsite
+// location instead of defaulting every posting to remote.
 //
 // Fetched via GetText rather than GetXML and decoded leniently (Strict=false), same as the
 // nodesk adapter: this board runs the same underlying feed generator (identical "Role at
@@ -26,6 +36,10 @@ type cryptocurrencyjobs struct {
 }
 
 const cryptocurrencyjobsFeedURL = "https://cryptocurrencyjobs.co/index.xml"
+
+// cryptocurrencyjobsOnsiteTitle matches the board's "(<City> only)" title suffix that marks a
+// posting restricted to one office, e.g. "Product Designer (New York only)" -> "New York".
+var cryptocurrencyjobsOnsiteTitle = regexp.MustCompile(`\s*\(([^()]+?)\s+only\)\s*$`)
 
 // NewCryptocurrencyJobs builds the Cryptocurrency Jobs adapter over the given HTTP client.
 func NewCryptocurrencyJobs(c TextGetter) Source { return cryptocurrencyjobs{http: c} }
@@ -77,15 +91,23 @@ func (it cryptocurrencyjobsItem) toJob() (Job, bool) {
 	if it.GUID == "" || !ok || company == "" {
 		return Job{}, false
 	}
+	title = strings.TrimSpace(title)
+
+	location, remote, workMode := "Remote", true, "remote"
+	if m := cryptocurrencyjobsOnsiteTitle.FindStringSubmatchIndex(title); m != nil {
+		location, remote, workMode = title[m[2]:m[3]], false, "onsite"
+		title = strings.TrimSpace(title[:m[0]])
+	}
+
 	return Job{
 		ExternalID:  it.GUID,
 		URL:         it.Link,
-		Title:       xhtml.UnescapeString(strings.TrimSpace(title)),
+		Title:       xhtml.UnescapeString(title),
 		Company:     xhtml.UnescapeString(strings.TrimSpace(company)),
-		Location:    "Remote",
+		Location:    location,
 		Description: sanitizeHTML(xhtml.UnescapeString(it.Description)),
-		Remote:      true,
-		WorkMode:    "remote",
+		Remote:      remote,
+		WorkMode:    workMode,
 		PostedAt:    parseLayout(time.RFC1123Z, it.PubDate),
 	}, true
 }

--- a/internal/sources/cryptocurrencyjobs_test.go
+++ b/internal/sources/cryptocurrencyjobs_test.go
@@ -80,3 +80,32 @@ func TestCryptocurrencyJobsFetchSplitsTitleAndMaps(t *testing.T) {
 		t.Error("PostedAt nil, want parsed RFC1123Z timestamp")
 	}
 }
+
+// The board is not all-remote: a "(<City> only)" title suffix marks a posting restricted to
+// one office (confirmed live for "Product Designer (New York only)" at Loopscale, whose page
+// states the role requires working from their NYC office) with no "remote" wording anywhere
+// in the feed, unlike a geo-eligibility-restricted remote posting.
+func TestCryptocurrencyJobsOnsiteTitleSuffix(t *testing.T) {
+	feed := `<?xml version="1.0" encoding="utf-8"?><rss version="2.0"><channel>
+<item><title>Product Designer (New York only) at Loopscale</title>
+<link>https://cryptocurrencyjobs.co/design/loopscale-product-designer-new-york-only/</link>
+<guid>https://cryptocurrencyjobs.co/design/loopscale-product-designer-new-york-only/</guid>
+<pubDate>Wed, 05 Aug 2026 08:00:00 +0200</pubDate>
+<description>Loopscale is looking to hire a Product Designer to join their team. This is a full-time position.</description></item>
+</channel></rss>`
+	fake := (&routedHTTP{}).route("index.xml", feed)
+	jobs, err := NewCryptocurrencyJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.Title != "Product Designer" {
+		t.Errorf("Title = %q, want the (New York only) suffix stripped", j.Title)
+	}
+	if j.Remote || j.WorkMode != "onsite" || j.Location != "New York" {
+		t.Errorf("Remote=%v WorkMode=%q Location=%q, want a non-remote onsite posting in New York", j.Remote, j.WorkMode, j.Location)
+	}
+}


### PR DESCRIPTION
## Summary
- Follow-up to #1718. That PR's adapter hardcoded every `cryptocurrencyjobs` posting as `Remote: true` / `Location: "Remote"`, on the premise the board is 100% remote.
- Live-verified that premise is false: "Product Designer (New York only) at Loopscale" is on the feed, and its page reads "This role requires working full-time from our New York City office" — no "remote" wording anywhere in the feed for that item.
- The board marks such postings with a `(<City> only)` title suffix, distinct from how it phrases geo-restricted-but-remote roles (e.g. "100% remote ... anywhere in Europe" in the description, no title suffix). This PR strips that suffix into `Location` and sets `WorkMode: "onsite"` / `Remote: false` instead of defaulting every posting to remote.
- Postings without the suffix keep the prior behavior (`Remote: true`, `Location: "Remote"`) — that's still the overwhelming majority of the board.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/...` — includes a new regression test reproducing the live New York-only title