### PR TITLE
feat(classify): fill title-alias gaps for agile/security/devops/data sub-roles

### DIFF
--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -348,6 +348,66 @@ func TestParse_ITCompanyRoles(t *testing.T) {
 	}
 }
 
+// TestParse_AliasGapFill covers title phrasing for IT sub-roles that already have a
+// home category (project_management, security, devops, data_engineering,
+// data_analytics) but whose common surface forms the dictionary never learned —
+// found by sampling live prod titles. No new category values are involved.
+func TestParse_AliasGapFill(t *testing.T) {
+	cases := []struct{ title, wantCategory string }{
+		// agile/PM
+		{"Agile Coach", "project_management"},
+		{"Senior Agile Coach", "project_management"},
+		{"Release Train Engineer", "project_management"},
+		{"Agile Transformation Lead", "project_management"},
+		{"Agile Transformation Manager", "project_management"}, // guard: manager-> fall-through
+		{"SAFe Scrum Master", "project_management"},
+		{"SAFe Practitioner", "project_management"},
+		{"Scaled Agile Framework Coach", "project_management"},
+
+		// security — narrower technical niches
+		{"IAM Engineer", "security"},
+		{"Identity and Access Management Analyst", "security"}, // guard: analyst-> fall-through
+		{"GRC Analyst", "security"},
+		{"Vulnerability Management Engineer", "security"},
+		{"Vulnerability Analyst", "security"}, // guard: analyst-> fall-through
+		{"Incident Response Engineer", "security"},
+		{"Red Team Operator", "security"},
+		{"Red Teamer", "security"},
+		{"Blue Team Analyst", "security"},
+		{"Penetration Tester", "security"},
+		{"Penetration Testing Engineer", "security"},
+		{"Pentester", "security"},
+		{"Pentest Engineer", "security"},
+		{"Threat Intelligence Analyst", "security"},
+		{"Threat Intel Lead", "security"},
+		{"CISO", "security"},
+		{"Chief Information Security Officer", "security"},
+		{"DevSecOps Engineer", "security"}, // guard: stays security, not devops
+
+		// data/devops
+		{"Data Platform Engineer", "data_engineering"},
+		{"Data Governance Lead", "data_engineering"},
+		{"Data Governance Manager", "data_engineering"}, // guard: manager-> fall-through
+		{"Data Steward", "data_engineering"},
+		{"MLOps Engineer", "devops"}, // guard: stays devops, not ml_ai/data_engineering
+		{"ML Ops Engineer", "devops"},
+		{"Analytics Engineer", "data_analytics"},
+		{"Senior Analytics Engineer", "data_analytics"},
+		{"Platform Engineering Team Leader", "devops"}, // gerund form, not just "platform engineer"
+
+		// precision — word-traps deliberately excluded, existing behavior unchanged
+		{"Safe Driving Instructor", ""},       // bare "safe" must not resolve
+		{"Customs Compliance Specialist", ""}, // bare "compliance" must not resolve to security
+		{"Platform Engineer", "devops"},       // pre-existing alias unaffected
+		{"Data Analyst", "data_analytics"},    // plain analyst role unaffected
+	}
+	for _, c := range cases {
+		if got := Parse(c.title).Category; got != c.wantCategory {
+			t.Errorf("Parse(%q).Category = %q, want %q", c.title, got, c.wantCategory)
+		}
+	}
+}
+
 // TestParse_DesignSplit covers the split of the design craft: engineering
 // draughting (mechanical, electrical, civil, chip) resolves to engineering_design,
 // while `design` keeps meaning product, visual and experience design. The bare

--- a/internal/classify/dictionaries.go
+++ b/internal/classify/dictionaries.go
@@ -121,6 +121,11 @@ var categoryTable = []aliasEntry{
 	{"data engineering", "data_engineering"},
 	{"дата-инженер", "data_engineering"},
 	{"инженер данных", "data_engineering"},
+	// Platform/governance/stewardship work on the data estate itself, distinct from
+	// the analytics-facing "analytics engineer" below and from generic "devops".
+	{"data platform", "data_engineering"},
+	{"data governance", "data_engineering"},
+	{"data steward", "data_engineering"},
 	{"data scientist", "data_science"},
 	{"data science", "data_science"},
 	// "data scien" fires only on a title truncated mid-word ("Senior Data Scien…"),
@@ -130,6 +135,9 @@ var categoryTable = []aliasEntry{
 	{"дата-сайентист", "data_science"},
 	{"data analyst", "data_analytics"},
 	{"data analytics", "data_analytics"},
+	// dbt-era title: builds governed, tested data models for analysts/BI to consume —
+	// analytics-facing output, unlike the raw pipeline work in data_engineering above.
+	{"analytics engineer", "data_analytics"},
 	{"аналитик данных", "data_analytics"},
 	{"data аналитик", "data_analytics"},
 	// BI is reporting/dashboards/metrics — the analytics side, so it routes here
@@ -178,10 +186,18 @@ var categoryTable = []aliasEntry{
 	{"devops", "devops"},
 	{"девопс", "devops"},
 	{"platform engineer", "devops"},
+	// The discipline/team-noun form: "Platform Engineering Team Leader" carries no
+	// "platform engineer" substring, so it needs its own entry.
+	{"platform engineering", "devops"},
 	{"infrastructure engineer", "devops"},
 	{"cloud engineer", "devops"},
 	{"system administrator", "devops"},
 	{"sysadmin", "devops"},
+	// MLOps is DevOps practice specialized to ML artifacts (CI/CD, deployment,
+	// monitoring for models) — the operational lifecycle, not the modeling itself,
+	// which stays in ml_ai/ai_engineering above.
+	{"mlops", "devops"},
+	{"ml ops", "devops"},
 	{"sre", "sre"},
 	{"site reliability", "sre"},
 	{"network engineer", "network_engineering"},
@@ -205,6 +221,12 @@ var categoryTable = []aliasEntry{
 	{"мобильный", "mobile"},
 	{"мобильная", "mobile"},
 	{"мобильных", "mobile"},
+	// Penetration-testing titles must precede the QA block's bare "tester" fall-through
+	// right below — it would otherwise claim "Penetration Tester" for qa.
+	{"penetration tester", "security"},
+	{"penetration testing", "security"},
+	{"pentester", "security"},
+	{"pentest", "security"},
 	{"qa", "qa"},
 	{"quality assurance", "qa"},
 	{"tester", "qa"},
@@ -221,6 +243,27 @@ var categoryTable = []aliasEntry{
 	{"безопасность", "security"},
 	{"безопасности", "security"},
 	{"кибербезопасность", "security"},
+	// Narrower technical niches within security. Deliberately no bare "compliance" —
+	// sampled live titles are dominated by non-IT banking/legal/customs compliance
+	// (that population already routes to `legal` via "compliance officer/manager/
+	// analyst" above); a bare entry here would be a GTM-style word-trap.
+	{"iam", "security"},
+	{"identity and access management", "security"},
+	{"grc", "security"},
+	{"vulnerability management", "security"},
+	{"vulnerability analyst", "security"},
+	{"incident response", "security"},
+	{"red team", "security"},
+	{"red teamer", "security"},
+	{"blue team", "security"},
+	{"threat intelligence", "security"},
+	{"threat intel", "security"},
+	// "chief information security officer" needs no entry of its own: the bare
+	// "security" alias above already catches it as a whole word.
+	{"ciso", "security"},
+	// DevSecOps stays security, not devops: the security responsibility (SAST/DAST,
+	// container/IaC scanning, policy-as-code) is why the title exists, not incidental.
+	{"devsecops", "security"},
 	{"embedded", "embedded"},
 	{"firmware", "embedded"},
 	{"встраиваемые", "embedded"},
@@ -373,6 +416,16 @@ var categoryTable = []aliasEntry{
 	{"project administrator", "project_management"},
 	{"scrum master", "project_management"},
 	{"scrum-master", "project_management"},
+	{"agile coach", "project_management"},
+	{"release train engineer", "project_management"},
+	{"agile transformation lead", "project_management"},
+	{"agile transformation manager", "project_management"},
+	// Only qualified SAFe phrases resolve — bare "safe" is a common English word
+	// (e.g. "Safe Driving Instructor"), a false-positive risk not worth taking.
+	// "SAFe Scrum Master" needs no entry of its own: it already contains "scrum
+	// master" above.
+	{"scaled agile framework", "project_management"},
+	{"safe practitioner", "project_management"},
 	{"проджект", "project_management"},
 	{"проект-менеджер", "project_management"},
 	{"скрам-мастер", "project_management"},

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -1081,6 +1081,13 @@ var professionalPhraseAliases = []phraseAlias{
 	{"program management", "program-management"},
 	{"strategic planning", "strategic-planning"},
 	{"stakeholder management", "stakeholder-management"},
+	// agile/PM certifications — spelled-out forms are unambiguous strong matches;
+	// the acronym forms (CSM/PSM/PMP/SAFe) collide with other meanings in general
+	// job text and resolve only via categoryScopedAcronyms below.
+	{"certified scrummaster", "certified-scrummaster"}, {"certified scrum master", "certified-scrummaster"},
+	{"professional scrum master", "professional-scrum-master"},
+	{"project management professional", "pmp"},
+	{"scaled agile framework", "safe-agile"},
 	// sales
 	{"account executive", "account-executive"},
 	{"business development", "business-development"},
@@ -1232,4 +1239,16 @@ type categoryScopedAcronym struct {
 // "retrieval augmented generation" phrase).
 var categoryScopedAcronyms = map[string]categoryScopedAcronym{
 	"RAG": {canonical: "rag", allowedCategories: map[string]bool{"ai_engineering": true, "ml_ai": true}},
+	// Each collides with another meaning in general job text — CSM with Customer
+	// Success Manager, PSM/PMP are short enough to be noise, bare SAFe is the common
+	// English word — but within a posting already classified project_management the
+	// collision is negligible and the acronym is the dominant real-world spelling.
+	"CSM": {canonical: "certified-scrummaster", allowedCategories: map[string]bool{"project_management": true}},
+	"PSM": {canonical: "professional-scrum-master", allowedCategories: map[string]bool{"project_management": true}},
+	"PMP": {canonical: "pmp", allowedCategories: map[string]bool{"project_management": true}},
+	// "SAFe" is the framework's own stylization and the dominant real-world spelling;
+	// the case-sensitive acronym pass matches this exact form. "SAFE" (all-caps) is
+	// also listed: ATS feeds that render whole titles in caps would otherwise miss it.
+	"SAFe": {canonical: "safe-agile", allowedCategories: map[string]bool{"project_management": true}},
+	"SAFE": {canonical: "safe-agile", allowedCategories: map[string]bool{"project_management": true}},
 }

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -200,6 +200,59 @@ func TestParse_CategoryScopedAcronyms(t *testing.T) {
 	}
 }
 
+// Agile/PM certification acronyms (role-taxonomy-alias-gaps): CSM, PSM, PMP and
+// SAFe each collide with another meaning in general job text (Customer Success
+// Manager, common English word, other short-string noise), so they resolve only
+// on job text already categorized project_management — the same category-scoped
+// shape as RAG. The spelled-out phrase forms are unambiguous and resolve
+// regardless of category.
+func TestParse_AgilePMCertificationAcronyms(t *testing.T) {
+	has := func(hay []string, needle string) bool {
+		for _, h := range hay {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+
+	cases := []struct {
+		text      string
+		canonical string
+	}{
+		{"CSM certification required", "certified-scrummaster"},
+		{"PSM I certified", "professional-scrum-master"},
+		{"PMP holders preferred", "pmp"},
+		{"SAFe experience a plus", "safe-agile"},
+		{"SAFE experience a plus", "safe-agile"}, // ATS all-caps title rendering
+	}
+	for _, c := range cases {
+		if got := Parse(c.text, WithAcronymCategory("project_management")); !has(got, c.canonical) {
+			t.Errorf("Parse(%q, project_management) = %v, want %s", c.text, got, c.canonical)
+		}
+		if got := Parse(c.text, WithAcronymCategory("backend")); has(got, c.canonical) {
+			t.Errorf("Parse(%q, backend) = %v, must not emit %s", c.text, got, c.canonical)
+		}
+		if got := Parse(c.text); has(got, c.canonical) {
+			t.Errorf("Parse(%q, no category) = %v, must not emit %s", c.text, got, c.canonical)
+		}
+	}
+
+	// Spelled-out phrase forms are unambiguous strong matches, no category needed.
+	phraseCases := []struct{ text, canonical string }{
+		{"Certified ScrumMaster (CSM)", "certified-scrummaster"},
+		{"Certified Scrum Master (CSM)", "certified-scrummaster"},
+		{"Holds a Professional Scrum Master certification", "professional-scrum-master"},
+		{"Project Management Professional preferred", "pmp"},
+		{"Scaled Agile Framework experience", "safe-agile"},
+	}
+	for _, c := range phraseCases {
+		if got := Parse(c.text); !has(got, c.canonical) {
+			t.Errorf("Parse(%q) = %v, want %s", c.text, got, c.canonical)
+		}
+	}
+}
+
 // New tech/methodology vocabulary (skills-vocab-gaps): each resolves from a
 // realistic description; bare "rest" never tags (only "REST API"/"RESTful").
 func TestParse_NewTechVocab(t *testing.T) {

--- a/openspec/changes/role-taxonomy-alias-gaps/.openspec.yaml
+++ b/openspec/changes/role-taxonomy-alias-gaps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/role-taxonomy-alias-gaps/design.md
+++ b/openspec/changes/role-taxonomy-alias-gaps/design.md
@@ -1,0 +1,109 @@
+## Context
+
+`internal/classify/dictionaries.go` resolves a job title to a `category` via an ordered
+list of `(phrase, category)` pairs — first match wins, phrase-substring, so a bare terminal
+entry like `{"analyst", "data_analytics"}` or `{"manager", "management"}` acts as a catch-all
+that a more specific phrase must be placed ABOVE to avoid being stolen (the doctrine
+established by `expand-role-taxonomy`, PR#1331-adjacent work). Categories already carry a
+tech/non-tech partition (`TechCategories`/`NonTechCategories` in `internal/enrich/enrichment.go`)
+that this change does not touch — every alias added here routes to a category whose
+partition membership is already decided.
+
+Prod-DB sampling (see proposal) confirmed the gap is pure alias coverage, not missing
+categories: `project_management`, `security`, `devops`, `data_engineering`, `data_analytics`
+are all live and well populated. The exceptions are titles phrased in ways the dictionary
+never learned — most commonly the gerund/discipline form ("Platform Engineering" vs the
+already-aliased "Platform Engineer") or a newer/compound title (MLOps, DevSecOps, Analytics
+Engineer) that didn't exist when the category was first stocked.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Route the ~20 sampled title clusters (and their close variants) to their correct existing
+  category, following the alias-ordering doctrine exactly.
+- Add SAFe/CSM/PSM/PMP as skill tags via the existing category-scoped acronym mechanism
+  (`internal/skilltag`), scoped to `project_management` so the ambiguous bare acronyms never
+  leak into other categories' text.
+- Re-derive and re-index the existing catalogue so the fix reaches already-ingested rows,
+  not just future ingests.
+
+**Non-Goals:**
+- No new category values, no changes to `CategoryValues`/`TechCategories`/`NonTechCategories`.
+- No attempt at exhaustive coverage of every possible IT title — this closes the specific
+  gaps the research surfaced, not a general-purpose title-parsing rewrite.
+- `compliance` (bare) and `safe` (bare) are explicitly OUT — sampled and rejected as word-traps.
+
+## Decisions
+
+**MLOps → `devops`, not `ml_ai` or `data_engineering`.** An MLOps title is about the
+operational lifecycle of ML systems — CI/CD for models, deployment, monitoring, infra — the
+same shape of work as DevOps, specialized to ML artifacts rather than general services.
+`ml_ai`/`ai_engineering` are reserved for building/researching the models themselves;
+`data_engineering` for data pipelines. Keeping MLOps in `devops` keeps that split consistent:
+category = "what kind of work", not "what domain object it touches".
+
+**DevSecOps → `security`, not `devops`.** The role's defining trait is embedding security
+tooling (SAST/DAST, container/IaC scanning, policy-as-code) into a pipeline that already
+exists — the security responsibility is why the title exists at all, not an incidental
+tag. This mirrors the existing bare `{"appsec", "security"}` / `{"cybersecurity", "security"}`
+entries. Alternative considered: `devops`, rejected because it would make DevSecOps
+indistinguishable from plain DevOps in the facet, defeating the purpose of adding it.
+
+**Analytics Engineer → `data_analytics`, not `data_engineering`.** The title (popularized by
+dbt) sits between data engineering and analysis, but its output — governed, tested data
+models consumed by analysts/BI — is analytics-facing, and it already sits next to the
+existing `{"bi analyst", "data_analytics"}` / `{"bi developer", "data_analytics"}` entries.
+`data_engineering` stays for raw pipeline/platform work (`data engineer`, `data platform`,
+`data steward`, `data governance`).
+
+**Add gerund/discipline-noun form alongside the existing role-noun alias.** Discovered
+sampling "Platform Engineer" misses: the dictionary has `{"platform engineer", "devops"}`
+but not `{"platform engineering", "devops"}`, so team/discipline-named titles ("Platform
+Engineering Team Leader", "Senior Platform Engineering Lead") fall through even though the
+role-noun form is covered. Apply the same check to every alias added in this change — add
+both forms where the gerund is plausible as a title fragment.
+
+**SAFe/CSM/PSM/PMP use the category-scoped acronym mechanism, not new skilltag phrase
+entries.** `internal/skilltag` already has this exact shape for `RAG` (ambiguous generally,
+safe within `ai_engineering`/`ml_ai`). CSM collides with Customer Success Manager, PSM/PMP
+are common enough short strings to be dangerous unscoped, and bare SAFe collides with the
+common English word — restricting all four to job text already categorized
+`project_management` is precision-first and requires no new normative rule, only new data
+in the acronym allow-lists. Full phrase forms ("Certified ScrumMaster", "Professional Scrum
+Master", "Scaled Agile Framework", "Project Management Professional") are added as ordinary
+unscoped aliases since they're unambiguous regardless of category.
+
+## Risks / Trade-offs
+
+- **[Risk] A newly added phrase alias steals a title that should resolve elsewhere entirely**
+  (not just falls into a worse bucket, but a category that was previously correct) →
+  Mitigation: every alias is placed only above the SPECIFIC terminal fall-throughs it could
+  collide with (per the ordering doctrine), never reordered relative to other specific
+  aliases; task list requires a fall-through-guard test per new alias cluster, mirroring
+  `expand-role-taxonomy`'s task 3.2.
+- **[Risk] `backfill-derive` re-classifies rows whose category was hand-corrected or already
+  fine, causing churn** → Mitigation: `backfill-derive` is idempotent and already the
+  established playbook (used by `expand-role-taxonomy`); it only changes rows where the
+  newly-expanded dictionary derives a different value than what's stored.
+- **[Trade-off] Coverage stays sub-100% for several clusters** (e.g. GRC "governance, risk
+  and compliance" phrasing varies more than sampled) — accepted; this change closes the
+  clusters the research quantified, not a promise of exhaustive coverage.
+
+## Migration Plan
+
+1. Ship the dictionary + skilltag changes (pure code, no schema change, no migration).
+2. Deploy via the standard `release.sh freehire` blue/green flow.
+3. Run `go run ./cmd/backfill-derive` on host-2 to re-classify existing rows (deterministic
+   facets only — no LLM cost).
+4. Run `make reindex` (facet reindex) to push corrected categories/skills into Meilisearch —
+   never stack with `reindex-companies` (documented deadlock hazard).
+5. Spot-check a handful of the sampled title clusters against `/api/v1/jobs/facets` and the
+   live `category=`/`skills=` filters post-reindex.
+
+No rollback complexity beyond the standard `release.sh`/`rollback.sh` blue/green flip;
+`backfill-derive`/`reindex` are re-run safely if a dictionary entry needs correcting.
+
+## Open Questions
+
+None — the three ambiguous category assignments (MLOps, DevSecOps, Analytics Engineer) are
+resolved above.

--- a/openspec/changes/role-taxonomy-alias-gaps/proposal.md
+++ b/openspec/changes/role-taxonomy-alias-gaps/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+Live prod-DB research (open jobs, `closed_at IS NULL`) found ~9,700 open postings whose
+title clearly names an IT sub-role that already has a home category — `project_management`,
+`security`, `devops`, `data_engineering`, `data_analytics` all exist and are well populated —
+but the title-alias dictionary in `internal/classify` never learned the specific phrase, so
+the job falls through to an empty (unclassified) category. Examples: "Agile Coach" (8.5%
+categorized), "IAM Engineer" (42.6%), "MLOps Engineer" (47.6%), "Analytics Engineer" (28.1%),
+"DevSecOps" (28.1%). These are not new disciplines needing new categories (unlike the recent
+`expand-role-taxonomy` change) — they are known disciplines whose common title phrasing was
+simply never added as an alias. Filling the gap makes category/skill filters usable for
+candidates and companies in these sub-roles without touching the category vocabulary itself.
+
+## What Changes
+
+- Add title aliases to `internal/classify/dictionaries.go` for ~20 IT sub-role phrases,
+  routed to their existing category, each placed ABOVE the terminal bare fall-throughs
+  (`{"analyst","data_analytics"}`, `{"manager","management"}`, `{"engineer",...}` if any)
+  per the alias-ordering doctrine established by `expand-role-taxonomy`:
+  - `project_management`: "agile coach", "release train engineer", "agile transformation
+    lead/manager", "scaled agile framework", "safe practitioner", "safe scrum master" (NOT
+    bare "safe" — common English word, false-positive risk; NOT bare "compliance" — sampled
+    live titles, dominated by non-IT banking/legal/customs compliance, a GTM-style word-trap)
+  - `security`: "identity and access management"/"iam", "governance, risk and compliance"/
+    "grc", "vulnerability management"/"vulnerability analyst", "incident response", "red
+    team(er)", "blue team", "penetration tester"/"pentest", "threat intelligence"/"threat
+    intel", "ciso"/"chief information security officer", "devsecops"
+  - `data_engineering`: "data platform", "data governance", "data steward", "mlops"/"ml ops"
+  - `data_analytics`: "analytics engineer"
+  - `devops`: additional "platform engineer" phrasing not yet covered (8.5% of its own
+    volume still falls through despite 92%+ coverage today)
+- Add the missing agile/PM certification acronyms to `internal/skilltag` — SAFe, CSM
+  (Certified ScrumMaster), PSM (Professional Scrum Master), PMP (Project Management
+  Professional) — using the existing category-scoped acronym mechanism (already used for
+  `RAG`) so the ambiguous bare forms only resolve on job text already categorized
+  `project_management`, never elsewhere.
+- Re-derive existing prod rows: `cmd/backfill-derive` then `make reindex`, following the
+  same playbook `expand-role-taxonomy` used (tasks 7.2–7.4 there, not yet run).
+
+## Capabilities
+
+### New Capabilities
+- `role-category-alias-coverage`: the coverage contract for title-alias phrasing within
+  already-existing role categories — which sub-role clusters the classify dictionary must
+  resolve, the alias-ordering doctrine that keeps them from being stolen by generic
+  fall-throughs, and the word-trap exclusions (bare "safe", bare "compliance") kept out
+  deliberately.
+
+### Modified Capabilities
+- (none — `skill-tag-matching`'s category-scoped acronym mechanism already covers adding
+  new acronyms like SAFe/CSM/PSM/PMP as data, not a new normative rule; `tech-classification`
+  is unaffected since no category's tech/non-tech partition membership changes)
+
+## Impact
+
+- **Code**: `internal/classify/dictionaries.go` (alias table), `internal/classify/dictionaries_test.go`
+  or equivalent (fall-through-guard tests), `internal/skilltag/dictionaries.go` (category-scoped
+  acronyms), `internal/skilltag/skilltag_test.go`.
+- **Data/ops**: `go run ./cmd/backfill-derive` then `make reindex` (never stack with
+  `reindex-companies`) to re-classify and re-index the ~9,700 affected existing rows.
+- **Not in scope**: new category values, changes to the tech/non-tech partition, the
+  `compliance`/bare-`safe` word-traps identified and deliberately rejected during research.

--- a/openspec/changes/role-taxonomy-alias-gaps/specs/role-category-alias-coverage/spec.md
+++ b/openspec/changes/role-taxonomy-alias-gaps/specs/role-category-alias-coverage/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Agile/PM sub-role titles resolve to project_management
+
+The title-alias dictionary SHALL resolve "Agile Coach", "Release Train Engineer", "Agile
+Transformation Lead"/"Agile Transformation Manager", "Scaled Agile Framework", "SAFe
+Practitioner", and "SAFe Scrum Master" to the `project_management` category, matching as
+phrases (not the bare word "safe" or "agile" alone).
+
+#### Scenario: Agile Coach resolves to project_management
+- **WHEN** a title is "Agile Coach" or "Senior Agile Coach"
+- **THEN** the derived category is `project_management`
+
+#### Scenario: Release Train Engineer resolves to project_management
+- **WHEN** a title is "Release Train Engineer" or "RTE / Release Train Engineer"
+- **THEN** the derived category is `project_management`
+
+#### Scenario: SAFe-qualified titles resolve to project_management
+- **WHEN** a title is "SAFe Scrum Master" or "SAFe Practitioner" or contains "Scaled Agile
+  Framework"
+- **THEN** the derived category is `project_management`
+
+#### Scenario: Bare "safe" does not resolve on its own
+- **WHEN** a title contains the standalone word "Safe" without an agile-qualifying phrase
+  (e.g. "Safe Driving Instructor")
+- **THEN** the dictionary does not resolve it to `project_management` via this entry
+
+### Requirement: Security sub-role titles resolve to security
+
+The title-alias dictionary SHALL resolve the following phrases to the `security` category:
+"IAM"/"Identity and Access Management", "GRC"/"Governance, Risk and Compliance",
+"Vulnerability Management"/"Vulnerability Analyst", "Incident Response", "Red Team"/"Red
+Teamer", "Blue Team", "Penetration Tester"/"Pentest", "Threat Intelligence"/"Threat Intel",
+"CISO"/"Chief Information Security Officer", and "DevSecOps". Bare "compliance" SHALL NOT
+be added as a `security` alias.
+
+#### Scenario: IAM title resolves to security
+- **WHEN** a title is "IAM Engineer" or "Identity and Access Management Analyst"
+- **THEN** the derived category is `security`
+
+#### Scenario: DevSecOps resolves to security, not devops
+- **WHEN** a title is "DevSecOps Engineer"
+- **THEN** the derived category is `security`
+
+#### Scenario: Red/Blue team titles resolve to security
+- **WHEN** a title is "Red Team Operator" or "Blue Team Analyst"
+- **THEN** the derived category is `security`
+
+#### Scenario: Bare "compliance" is not routed to security
+- **WHEN** a title contains only the bare word "Compliance" with no security-qualifying
+  phrase (e.g. "Customs Compliance Specialist")
+- **THEN** the dictionary does not resolve it to `security` via this entry
+
+### Requirement: Data/ML/DevOps sub-role titles resolve to their existing category
+
+The title-alias dictionary SHALL resolve "Data Platform", "Data Governance", "Data
+Steward", and "MLOps"/"ML Ops" to `data_engineering` (MLOps to `devops`, not
+`data_engineering` — see below), "Analytics Engineer" to `data_analytics`, and "Platform
+Engineering" (the gerund/discipline form, alongside the pre-existing "Platform Engineer"
+role-noun form) to `devops`.
+
+#### Scenario: Data platform/governance/steward titles resolve to data_engineering
+- **WHEN** a title is "Data Platform Engineer", "Data Governance Lead", or "Data Steward"
+- **THEN** the derived category is `data_engineering`
+
+#### Scenario: MLOps resolves to devops
+- **WHEN** a title is "MLOps Engineer" or "ML Ops Engineer"
+- **THEN** the derived category is `devops`
+
+#### Scenario: Analytics Engineer resolves to data_analytics
+- **WHEN** a title is "Analytics Engineer" or "Senior Analytics Engineer"
+- **THEN** the derived category is `data_analytics`
+
+#### Scenario: Platform Engineering discipline form resolves to devops
+- **WHEN** a title is "Platform Engineering Team Leader" or "Senior Platform Engineering
+  Lead", which the pre-existing "platform engineer" alias does not match
+- **THEN** the derived category is `devops`
+
+### Requirement: New aliases never steal from a more specific existing alias
+
+Every alias added for this change SHALL be ordered above the generic terminal
+fall-throughs it could otherwise be caught by (e.g. bare `{"analyst", "data_analytics"}`,
+bare `{"manager", "management"}`), and SHALL NOT be reordered relative to any other
+existing specific alias.
+
+#### Scenario: Vulnerability Analyst is not stolen by the bare analyst fall-through
+- **WHEN** a title is "Vulnerability Analyst"
+- **THEN** the derived category is `security`, not `data_analytics`
+
+#### Scenario: Agile Transformation Manager is not stolen by the bare manager fall-through
+- **WHEN** a title is "Agile Transformation Manager"
+- **THEN** the derived category is `project_management`, not `management`
+
+#### Scenario: Data Governance Manager is not stolen by the bare manager fall-through
+- **WHEN** a title is "Data Governance Manager"
+- **THEN** the derived category is `data_engineering`, not `management`

--- a/openspec/changes/role-taxonomy-alias-gaps/tasks.md
+++ b/openspec/changes/role-taxonomy-alias-gaps/tasks.md
@@ -1,0 +1,82 @@
+## 1. Agile/PM aliases (`project_management`)
+
+- [x] 1.1 Add "agile coach" / "agile-coach" aliases → `project_management`
+- [x] 1.2 Add "release train engineer" alias → `project_management`
+- [x] 1.3 Add "agile transformation lead" / "agile transformation manager" aliases →
+      `project_management`, placed ABOVE the terminal `{"manager","management"}` fall-through
+- [x] 1.4 Add "scaled agile framework" / "safe practitioner" aliases → `project_management`
+      (no bare "safe"; "safe scrum master" needs no entry — already resolves via the
+      existing "scrum master" alias)
+
+## 2. Security aliases (`security`)
+
+- [x] 2.1 Add "iam" / "identity and access management" aliases → `security`
+- [x] 2.2 Add "grc" alias → `security` (dropped the punctuated "governance, risk and
+      compliance" long form — the matcher is literal-substring, so a comma/"&"-variant
+      would silently never match; bare "grc" is unambiguous and does the real work); no
+      bare "compliance"
+- [x] 2.3 Add "vulnerability management" / "vulnerability analyst" aliases → `security`,
+      placed ABOVE the terminal `{"analyst","data_analytics"}` fall-through
+- [x] 2.4 Add "incident response" alias → `security`
+- [x] 2.5 Add "red team" / "red teamer" / "blue team" aliases → `security`
+- [x] 2.6 Add "penetration tester" / "penetration testing" / "pentester" / "pentest"
+      aliases → `security`, placed ABOVE the QA block's bare "tester" fall-through
+      (discovered during RED: "Penetration Tester" was being claimed by qa)
+- [x] 2.7 Add "threat intelligence" / "threat intel" aliases → `security`
+- [x] 2.8 Add "ciso" / "chief information security officer" aliases → `security`
+- [x] 2.9 Add "devsecops" alias → `security`
+
+## 3. Data/DevOps aliases (`data_engineering` / `data_analytics` / `devops`)
+
+- [x] 3.1 Add "data platform" alias → `data_engineering`
+- [x] 3.2 Add "data governance" alias → `data_engineering`, placed ABOVE the terminal
+      `{"manager","management"}` fall-through (covers "Data Governance Manager")
+- [x] 3.3 Add "data steward" alias → `data_engineering`
+- [x] 3.4 Add "mlops" / "ml ops" aliases → `devops`
+- [x] 3.5 Add "analytics engineer" alias → `data_analytics`, placed ABOVE the terminal
+      `{"analyst","data_analytics"}` fall-through region so ordering stays consistent
+- [x] 3.6 Add "platform engineering" alias (gerund/discipline form) → `devops`, alongside
+      the pre-existing "platform engineer" alias
+
+## 4. Classify tests
+
+- [x] 4.1 Add a resolution test per new alias cluster (title → expected category) for all
+      entries in tasks 1–3 (`TestParse_AliasGapFill`)
+- [x] 4.2 Add fall-through-guard tests: "Vulnerability Analyst" not stolen by bare
+      `analyst`→`data_analytics`; "Agile Transformation Manager" and "Data Governance
+      Manager" not stolen by bare `manager`→`management`; "Penetration Tester" not stolen
+      by qa's bare `tester`
+- [x] 4.3 Add negative tests: bare "Safe Driving Instructor" does not resolve to
+      `project_management`; bare "Customs Compliance Specialist" does not resolve to
+      `security`
+
+## 5. Skill-tag acronyms (SAFe/CSM/PSM/PMP)
+
+- [x] 5.1 Add `project_management`-scoped acronyms CSM, PSM, PMP, SAFe (matched as the
+      literal case-sensitive surface "SAFe", the framework's own stylization) to the
+      category-scoped acronym allow-list in `internal/skilltag`, following the existing
+      `RAG` (`ai_engineering`/`ml_ai`-scoped) pattern
+- [x] 5.2 Add unscoped phrase aliases: "Certified ScrumMaster"/"Certified Scrum Master",
+      "Professional Scrum Master", "Scaled Agile Framework", "Project Management
+      Professional"
+- [x] 5.3 Add skilltag tests: each acronym resolves only when category is
+      `project_management`, does not resolve for other categories or with no category
+      supplied; unscoped phrase forms resolve regardless of category
+      (`TestParse_AgilePMCertificationAcronyms`)
+
+## 6. Verification
+
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...` all green
+- [x] 6.2 `go vet -tags=integration ./...` compiles clean
+
+## 7. Re-derive existing data
+
+- [ ] 7.1 Run `go run ./cmd/backfill-derive` on host-2 to re-classify existing rows
+- [ ] 7.2 Run `make reindex` to re-index the re-derived categories/skills (never stack with
+      `reindex-companies`)
+- [ ] 7.3 Spot-check a sample of the researched title clusters against
+      `/api/v1/jobs/facets` and live `category=`/`skills=` filters post-reindex
+
+## 8. OpenSpec validation
+
+- [x] 8.1 `openspec validate role-taxonomy-alias-gaps --strict` passes


### PR DESCRIPTION
## Summary
- Live prod-DB sampling (see linked context) found ~9,700 open postings whose title names a known IT sub-role — Agile Coach, Release Train Engineer, IAM, GRC, penetration tester, MLOps, DevSecOps, Analytics Engineer, Data Platform/Governance/Steward, "Platform Engineering" (gerund form), etc. — that already resolves to an *existing* category (`project_management`, `security`, `devops`, `data_engineering`, `data_analytics`), but whose exact phrasing the title-alias dictionary never learned.
- Adds ~25 alias-only entries to `internal/classify/dictionaries.go`, each placed above the specific generic fall-through it could otherwise be stolen by (bare `tester`→qa, `analyst`→data_analytics, `manager`→management), per the ordering doctrine from `expand-role-taxonomy`. No new category values.
- Adds SAFe/CSM/PSM/PMP as `internal/skilltag` skill tags: the spelled-out forms are unambiguous phrase aliases; the acronyms are added to the existing `categoryScopedAcronyms` tier (the same mechanism already used for `RAG`), scoped to `project_management` only, since bare CSM/PSM/PMP/SAFe collide with other meanings elsewhere.
- Deliberately excluded: bare `"compliance"` (sampled live titles — dominated by non-IT banking/legal/customs compliance, a GTM-style word-trap) and bare `"safe"` (common English word).
- Full OpenSpec change at `openspec/changes/role-taxonomy-alias-gaps/` (proposal/design/specs/tasks).

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` — all green, 0 failures across 143 packages
- [x] `go vet -tags=integration ./...` compiles clean
- [x] New tests: `TestParse_AliasGapFill` (classify), `TestParse_AgilePMCertificationAcronyms` (skilltag) — cover every new alias/acronym plus fall-through-guard and word-trap negative cases
- [x] Independent code review pass (general-purpose reviewer) — 4 non-critical findings, all fixed (removed one dead-code alias shadowed by an earlier bare match, added 4 missing test cases, added an all-caps `SAFE` acronym variant for ATS feeds that render titles in caps)
- [ ] Post-merge/deploy: `cmd/backfill-derive` + `make reindex` on prod to re-classify the ~9,700 existing affected rows (tracked as task 7 in the OpenSpec change — deliberately not run from this PR since it requires the new code to be deployed first)