### PR TITLE
fix(sources): nodesk/cryptocurrencyjobs feeds only carry the opening blurb

### DIFF
--- a/internal/sources/breezy_test.go
+++ b/internal/sources/breezy_test.go
@@ -12,9 +12,9 @@ func TestBreezyProvider(t *testing.T) {
 	}
 }
 
-// breezyDetailHTML is a position page carrying the schema.org JobPosting ld+json block
+// jobPostingHTML is a position page carrying the schema.org JobPosting ld+json block
 // Breezy server-renders; the adapter reads only the description from it.
-func breezyDetailHTML(title, desc string) string {
+func jobPostingHTML(title, desc string) string {
 	return `<html><head><script type="application/ld+json">` +
 		`{"@context":"https://schema.org/","@type":"JobPosting","title":"` + title +
 		`","description":"` + desc + `","datePosted":"2025-01-14"}` +
@@ -23,8 +23,8 @@ func breezyDetailHTML(title, desc string) string {
 
 func TestBreezyFetchListsAndFetchesDetail(t *testing.T) {
 	fake := (&routedHTTP{}).
-		route("/p/52-senior-designer", breezyDetailHTML("Senior Designer", "<p>Do the design.</p>")).
-		route("/p/53-remote-engineer", breezyDetailHTML("Remote Engineer", "<p>Work anywhere.</p>")).
+		route("/p/52-senior-designer", jobPostingHTML("Senior Designer", "<p>Do the design.</p>")).
+		route("/p/53-remote-engineer", jobPostingHTML("Remote Engineer", "<p>Work anywhere.</p>")).
 		route("/json", `[
 			{"id": "52", "name": "Senior Designer",
 			 "url": "https://acme.breezy.hr/p/52-senior-designer",
@@ -99,7 +99,7 @@ func TestBreezyFetchSkipsPositionWithoutDescription(t *testing.T) {
 	// description and the posting is dropped (a description-less job is useless to
 	// enrichment).
 	fake := (&routedHTTP{}).
-		route("/p/52-designer", breezyDetailHTML("Designer", "<p>Real work.</p>")).
+		route("/p/52-designer", jobPostingHTML("Designer", "<p>Real work.</p>")).
 		route("/p/53-broken", `<html><head></head><body>no job posting here</body></html>`).
 		route("/json", `[
 			{"id": "52", "name": "Designer", "url": "https://acme.breezy.hr/p/52-designer",

--- a/internal/sources/cryptocurrencyjobs.go
+++ b/internal/sources/cryptocurrencyjobs.go
@@ -13,26 +13,39 @@ import (
 
 // cryptocurrencyjobs adapts cryptocurrencyjobs.co, a Web3/crypto-niche jobs board. Boardless
 // (one public RSS feed, no per-tenant board) and multi-company, so it stays in the source
-// facet and takes each posting's company from the feed. The feed carries every posting's body
-// inline (no detail call).
+// facet and takes each posting's company from the feed.
+//
+// The feed's <description> is only the opening blurb (confirmed live: ~750 chars vs. the
+// ~7000-char full posting), not the body — so each item gets a per-posting detail fetch for
+// its page's schema.org JobPosting ld+json, same as breezy/teamtailor. A failed or
+// description-less detail fetch falls back to the feed's short blurb rather than dropping the
+// posting, since unlike breezy's listing (which carries nothing) the feed already gives a
+// non-empty description.
 //
 // The board is mostly but not entirely remote: a posting the board restricts to one office
 // (confirmed live, e.g. "Product Designer (New York only)" at Loopscale, whose page reads
 // "This role requires working full-time from our New York City office") gets that city
 // appended to its title in parens as "(<City> only)", with no "remote" wording anywhere in
-// the feed's truncated description — unlike a geo-eligibility-restricted remote posting,
-// which this board phrases as e.g. "100% remote ... anywhere in Europe" rather than a title
-// suffix. cryptocurrencyjobsOnsiteTitle strips that suffix and treats it as an onsite
-// location instead of defaulting every posting to remote.
+// the feed's blurb — unlike a geo-eligibility-restricted remote posting, which this board
+// phrases as e.g. "100% remote ... anywhere in Europe" rather than a title suffix.
+// cryptocurrencyjobsOnsiteTitle strips that suffix and treats it as an onsite location instead
+// of defaulting every posting to remote.
 //
-// Fetched via GetText rather than GetXML and decoded leniently (Strict=false), same as the
-// nodesk adapter: this board runs the same underlying feed generator (identical "Role at
-// Company" / plain-text-description / guid-equals-link shape, same host family as nodesk.co),
-// which is known to embed raw named entities such as "&rsquo;" outside CDATA — invalid XML
-// that the strict decoder rejects. html.UnescapeString then resolves whatever the lenient
-// decode left as literal entity text.
+// The feed is fetched via GetText rather than GetXML and decoded leniently (Strict=false),
+// same as the nodesk adapter: this board runs the same underlying feed generator (identical
+// "Role at Company" / plain-text-description / guid-equals-link shape, same host family as
+// nodesk.co), which is known to embed raw named entities such as "&rsquo;" outside CDATA —
+// invalid XML that the strict decoder rejects. html.UnescapeString then resolves whatever the
+// lenient decode left as literal entity text.
 type cryptocurrencyjobs struct {
-	http TextGetter
+	http cryptocurrencyjobsHTTP
+}
+
+// cryptocurrencyjobsHTTP is the transport cryptocurrencyjobs needs: the text feed plus HTML
+// detail pages for the full description.
+type cryptocurrencyjobsHTTP interface {
+	TextGetter
+	HTMLGetter
 }
 
 const cryptocurrencyjobsFeedURL = "https://cryptocurrencyjobs.co/index.xml"
@@ -42,7 +55,7 @@ const cryptocurrencyjobsFeedURL = "https://cryptocurrencyjobs.co/index.xml"
 var cryptocurrencyjobsOnsiteTitle = regexp.MustCompile(`\s*\(([^()]+?)\s+only\)\s*$`)
 
 // NewCryptocurrencyJobs builds the Cryptocurrency Jobs adapter over the given HTTP client.
-func NewCryptocurrencyJobs(c TextGetter) Source { return cryptocurrencyjobs{http: c} }
+func NewCryptocurrencyJobs(c cryptocurrencyjobsHTTP) Source { return cryptocurrencyjobs{http: c} }
 
 func (cryptocurrencyjobs) Provider() string { return "cryptocurrencyjobs" }
 
@@ -75,13 +88,30 @@ func (s cryptocurrencyjobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, e
 	if err := dec.Decode(&feed); err != nil {
 		return nil, fmt.Errorf("cryptocurrencyjobs: feed: %w", err)
 	}
-	jobs := make([]Job, 0, len(feed.Channel.Items))
-	for _, it := range feed.Channel.Items {
-		if job, ok := it.toJob(); ok {
-			jobs = append(jobs, job)
-		}
+	return fetchDetails(feed.Channel.Items, defaultDetailWorkers, func(it cryptocurrencyjobsItem) (Job, bool) {
+		return s.detail(ctx, it)
+	}), nil
+}
+
+// detail maps one RSS item to a Job, then fetches its page for the full description —
+// falling back to the feed's blurb (already set by toJob) when the page fetch fails or
+// carries no JobPosting ld+json.
+func (s cryptocurrencyjobs) detail(ctx context.Context, it cryptocurrencyjobsItem) (Job, bool) {
+	job, ok := it.toJob()
+	if !ok {
+		return Job{}, false
 	}
-	return jobs, nil
+	root, err := s.http.GetHTML(ctx, it.Link)
+	if err != nil {
+		return job, true
+	}
+	var p struct {
+		Description string `json:"description"`
+	}
+	if ldJobPosting(root, &p) && p.Description != "" {
+		job.Description = sanitizeHTML(xhtml.UnescapeString(p.Description))
+	}
+	return job, true
 }
 
 // toJob maps an RSS item to a Job, returning ok=false for an unusable item (no guid to key

--- a/internal/sources/cryptocurrencyjobs_test.go
+++ b/internal/sources/cryptocurrencyjobs_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -107,5 +108,30 @@ func TestCryptocurrencyJobsOnsiteTitleSuffix(t *testing.T) {
 	}
 	if j.Remote || j.WorkMode != "onsite" || j.Location != "New York" {
 		t.Errorf("Remote=%v WorkMode=%q Location=%q, want a non-remote onsite posting in New York", j.Remote, j.WorkMode, j.Location)
+	}
+}
+
+// The feed's <description> is only the opening blurb; the full posting lives on the item's
+// own page as a schema.org JobPosting ld+json block (confirmed live: ~750 vs. ~7000 chars).
+func TestCryptocurrencyJobsFetchUsesDetailDescription(t *testing.T) {
+	feed := `<?xml version="1.0" encoding="utf-8"?><rss version="2.0"><channel>
+<item><title>Senior Platform Engineer at Chronicle</title>
+<link>https://cryptocurrencyjobs.co/engineering/chronicle-senior-platform-engineer/</link>
+<guid>https://cryptocurrencyjobs.co/engineering/chronicle-senior-platform-engineer/</guid>
+<pubDate>Mon, 10 Aug 2026 16:40:02 +0200</pubDate>
+<description>Chronicle is looking to hire a Senior Platform Engineer.</description></item>
+</channel></rss>`
+	fake := (&routedHTTP{}).
+		route("index.xml", feed).
+		route("chronicle-senior-platform-engineer", jobPostingHTML("Senior Platform Engineer", "<p>The full responsibilities and requirements.</p>"))
+	jobs, err := NewCryptocurrencyJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if got := jobs[0].Description; !strings.Contains(got, "full responsibilities and requirements") {
+		t.Errorf("Description = %q, want the detail page's ld+json description, not the feed blurb", got)
 	}
 }

--- a/internal/sources/nodesk.go
+++ b/internal/sources/nodesk.go
@@ -12,24 +12,38 @@ import (
 
 // nodesk adapts nodesk.co, a remote-jobs board. Boardless (one public RSS feed, no
 // per-tenant board) and multi-company, so it stays in the source facet and takes each
-// posting's company from the feed. All-remote board, so every posting is remote. The feed
-// carries every posting's body inline (no detail call).
+// posting's company from the feed. All-remote board (live-verified: every posting's page
+// states it can be done remotely), so every posting is remote.
 //
-// Fetched via GetText rather than GetXML: unlike weworkremotely's feed (which wraps its body
-// in CDATA, leaving embedded entities as literal text), NoDesk's <description> contains raw,
-// unwrapped named entities such as "&rsquo;" that are not part of the XML entity set — the
-// standard library's strict decoder rejects them ("invalid character entity"). Decoding with
-// Strict=false leaves an unrecognized entity as literal text instead of erroring, and
-// html.UnescapeString (same helper weworkremotely already uses for its CDATA content) then
-// resolves it.
+// The feed's <description> is only the opening blurb (confirmed live: ~700 chars vs. the
+// ~7000-char full posting), not the body — so each item gets a per-posting detail fetch for
+// its page's schema.org JobPosting ld+json, same as breezy/teamtailor. A failed or
+// description-less detail fetch falls back to the feed's short blurb rather than dropping the
+// posting, since unlike breezy's listing (which carries nothing) the feed already gives a
+// non-empty description.
+//
+// The feed is fetched via GetText rather than GetXML: unlike weworkremotely's feed (which
+// wraps its body in CDATA, leaving embedded entities as literal text), NoDesk's <description>
+// contains raw, unwrapped named entities such as "&rsquo;" that are not part of the XML
+// entity set — the standard library's strict decoder rejects them ("invalid character
+// entity"). Decoding with Strict=false leaves an unrecognized entity as literal text instead
+// of erroring, and html.UnescapeString (same helper weworkremotely already uses for its CDATA
+// content) then resolves it.
 type nodesk struct {
-	http TextGetter
+	http nodeskHTTP
+}
+
+// nodeskHTTP is the transport nodesk needs: the text feed plus HTML detail pages for the
+// full description.
+type nodeskHTTP interface {
+	TextGetter
+	HTMLGetter
 }
 
 const nodeskFeedURL = "https://nodesk.co/remote-jobs/index.xml"
 
 // NewNoDesk builds the NoDesk adapter over the given HTTP client.
-func NewNoDesk(c TextGetter) Source { return nodesk{http: c} }
+func NewNoDesk(c nodeskHTTP) Source { return nodesk{http: c} }
 
 func (nodesk) Provider() string { return "nodesk" }
 
@@ -62,13 +76,30 @@ func (s nodesk) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 	if err := dec.Decode(&feed); err != nil {
 		return nil, fmt.Errorf("nodesk: feed: %w", err)
 	}
-	jobs := make([]Job, 0, len(feed.Channel.Items))
-	for _, it := range feed.Channel.Items {
-		if job, ok := it.toJob(); ok {
-			jobs = append(jobs, job)
-		}
+	return fetchDetails(feed.Channel.Items, defaultDetailWorkers, func(it nodeskItem) (Job, bool) {
+		return s.detail(ctx, it)
+	}), nil
+}
+
+// detail maps one RSS item to a Job, then fetches its page for the full description —
+// falling back to the feed's blurb (already set by toJob) when the page fetch fails or
+// carries no JobPosting ld+json.
+func (s nodesk) detail(ctx context.Context, it nodeskItem) (Job, bool) {
+	job, ok := it.toJob()
+	if !ok {
+		return Job{}, false
 	}
-	return jobs, nil
+	root, err := s.http.GetHTML(ctx, it.Link)
+	if err != nil {
+		return job, true
+	}
+	var p struct {
+		Description string `json:"description"`
+	}
+	if ldJobPosting(root, &p) && p.Description != "" {
+		job.Description = sanitizeHTML(xhtml.UnescapeString(p.Description))
+	}
+	return job, true
 }
 
 // toJob maps an RSS item to a Job, returning ok=false for an unusable item (no guid to key

--- a/internal/sources/nodesk_test.go
+++ b/internal/sources/nodesk_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -79,5 +80,30 @@ func TestNoDeskFetchSplitsTitleAndMaps(t *testing.T) {
 	}
 	if j.PostedAt == nil {
 		t.Error("PostedAt nil, want parsed RFC1123Z timestamp")
+	}
+}
+
+// The feed's <description> is only the opening blurb; the full posting lives on the item's
+// own page as a schema.org JobPosting ld+json block (confirmed live: ~700 vs. ~7000 chars).
+func TestNoDeskFetchUsesDetailDescription(t *testing.T) {
+	feed := `<?xml version="1.0" encoding="utf-8"?><rss version="2.0"><channel>
+<item><title>Senior Backend Engineer at Skylight</title>
+<link>https://nodesk.co/remote-jobs/skylight-senior-backend-engineer/</link>
+<guid>https://nodesk.co/remote-jobs/skylight-senior-backend-engineer/</guid>
+<pubDate>Thu, 06 Aug 2026 08:00:00 +0200</pubDate>
+<description>Skylight is looking to hire a Senior Backend Engineer.</description></item>
+</channel></rss>`
+	fake := (&routedHTTP{}).
+		route("index.xml", feed).
+		route("skylight-senior-backend-engineer", jobPostingHTML("Senior Backend Engineer", "<p>The full responsibilities and requirements.</p>"))
+	jobs, err := NewNoDesk(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if got := jobs[0].Description; !strings.Contains(got, "full responsibilities and requirements") {
+		t.Errorf("Description = %q, want the detail page's ld+json description, not the feed blurb", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Follow-up to #1717 / #1718 / #1738. Live-verified both boards' RSS `<description>` is only the opening blurb (~700-750 chars, e.g. just a "Who is Credible?" company paragraph), not the full posting — the real body (~7000 chars: Responsibilities, Requirements, etc.) only lives on the item's own page as a schema.org `JobPosting` ld+json block.
- Add a per-posting detail fetch (`fetchDetails` + `ldJobPosting`, the same pattern `breezy`/`teamtailor` already use) that overrides the feed's blurb with the full description.
- A failed or description-less detail fetch falls back to the feed's blurb rather than dropping the posting — unlike breezy's listing (which carries nothing), the feed already gives a non-empty description, so there's no reason to lose the job over one bad detail request.
- Renamed the shared test fixture `breezyDetailHTML` → `jobPostingHTML` since two more adapters now build on it.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/...` — new tests assert the detail page's ld+json description wins over the feed blurb; existing tests (unrouted detail page → fetch errors → falls back to blurb) still pass unchanged