### PR TITLE
chore(design-system): fix red main — update adoption baseline for Button

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -2,7 +2,7 @@
   "Alert": 0,
   "Avatar": 0,
   "Badge": 12,
-  "Button": 51,
+  "Button": 52,
   "Card": 0,
   "Chip": 0,
   "Dialog": 6,


### PR DESCRIPTION
## Summary
- `main`'s CI is currently red: `design-system` job fails on `pnpm check:adoption` — an earlier merge added a new `Button` consumer in `web/src` (51 → 52), which the adoption ratchet correctly flags as an improvement to record, not a regression.
- Unrelated to any other in-flight change — just the baseline bump the tool itself instructs (`rerun with --update and commit the diff`).

## Test plan
- [x] `node scripts/check-adoption.mjs` reproduces the failure on plain `main` before this change
- [x] `node scripts/check-adoption.mjs --update` then `node scripts/check-adoption.mjs` (no flag) passes clean after