### PR TITLE
fix(sources): tolerate raw control chars inside ld+json string literals

### DIFF
--- a/internal/sources/jsonld.go
+++ b/internal/sources/jsonld.go
@@ -25,7 +25,7 @@ func ldJobPosting(root *html.Node, v any) bool {
 		}
 		if n.Type == html.ElementNode && n.Data == "script" &&
 			attr(n, "type") == "application/ld+json" {
-			if msg, ok := jobPostingNode([]byte(textContent(n))); ok &&
+			if msg, ok := jobPostingNode(sanitizeJSONControlChars([]byte(textContent(n)))); ok &&
 				json.Unmarshal(msg, v) == nil {
 				found = true
 				return false
@@ -45,7 +45,7 @@ func LDJobPostings(root *html.Node) []json.RawMessage {
 	walk(root, func(n *html.Node) bool {
 		if n.Type == html.ElementNode && n.Data == "script" &&
 			attr(n, "type") == "application/ld+json" {
-			out = append(out, jobPostingNodes([]byte(textContent(n)))...)
+			out = append(out, jobPostingNodes(sanitizeJSONControlChars([]byte(textContent(n))))...)
 		}
 		return true
 	})
@@ -109,4 +109,48 @@ func isJobPosting(raw json.RawMessage) bool {
 		Type string `json:"@type"`
 	}
 	return json.Unmarshal(raw, &probe) == nil && strings.EqualFold(probe.Type, "JobPosting")
+}
+
+// jsonControlCharEscapes maps a raw control byte to the two-byte escape json.Unmarshal
+// accepts in its place; a byte absent here (rare outside \n/\r/\t) falls back to \u00XX.
+var jsonControlCharEscapes = map[byte]string{'\n': `\n`, '\r': `\r`, '\t': `\t`}
+
+const hexDigits = "0123456789abcdef"
+
+// sanitizeJSONControlChars escapes raw control bytes (0x00-0x1F) found INSIDE a JSON string
+// literal. Some sites template-render their JobPosting ld+json by interpolating raw HTML into
+// a string without escaping its newlines, which is invalid JSON — Go's decoder rejects it
+// ("invalid character '\n' in string literal") where a lenient decoder (e.g. Python's
+// json.loads(strict=False)) would accept it; live-verified on cryptocurrencyjobs.co. Control
+// bytes outside a string (insignificant whitespace between tokens) are left untouched.
+func sanitizeJSONControlChars(raw []byte) []byte {
+	out := make([]byte, 0, len(raw))
+	inString, escaped := false, false
+	for _, b := range raw {
+		switch {
+		case !inString:
+			if b == '"' {
+				inString = true
+			}
+			out = append(out, b)
+		case escaped:
+			escaped = false
+			out = append(out, b)
+		case b == '\\':
+			escaped = true
+			out = append(out, b)
+		case b == '"':
+			inString = false
+			out = append(out, b)
+		case b < 0x20:
+			if esc, ok := jsonControlCharEscapes[b]; ok {
+				out = append(out, esc...)
+			} else {
+				out = append(out, '\\', 'u', '0', '0', hexDigits[b>>4], hexDigits[b&0xf])
+			}
+		default:
+			out = append(out, b)
+		}
+	}
+	return out
 }

--- a/internal/sources/jsonld_test.go
+++ b/internal/sources/jsonld_test.go
@@ -1,0 +1,49 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeJSONControlCharsEscapesInsideStringOnly(t *testing.T) {
+	raw := []byte("{\"a\":\"line one\nline two\",\n \"b\":1}")
+	got := sanitizeJSONControlChars(raw)
+	want := "{\"a\":\"line one\\nline two\",\n \"b\":1}"
+	if string(got) != want {
+		t.Errorf("sanitizeJSONControlChars = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeJSONControlCharsSkipsEscapedBackslash(t *testing.T) {
+	// A literal backslash-quote inside the string must not flip inString off early.
+	raw := []byte(`{"a":"quote: \" then a real newline` + "\n" + `end"}`)
+	got := sanitizeJSONControlChars(raw)
+	if strings.Contains(string(got), "\n") {
+		t.Errorf("sanitizeJSONControlChars left a raw newline unescaped: %q", got)
+	}
+}
+
+// Live-verified on cryptocurrencyjobs.co: its JobPosting ld+json embeds the description with
+// raw, unescaped newlines, which Go's strict json.Unmarshal rejects ("invalid character '\n'
+// in string literal") — a lenient decoder (e.g. Python's json.loads(strict=False)) accepts it.
+func TestLdJobPostingToleratesRawNewlineInDescription(t *testing.T) {
+	page := `<html><head><script type="application/ld+json">` +
+		"{\"@context\":\"https://schema.org/\",\"@type\":\"JobPosting\",\"title\":\"Engineer\"," +
+		"\"description\":\"Line one.\nLine two.\"}" +
+		`</script></head><body>page</body></html>`
+	fake := (&routedHTTP{}).route("/job", page)
+	node, err := fake.GetHTML(context.Background(), "https://example.com/job")
+	if err != nil {
+		t.Fatalf("GetHTML: %v", err)
+	}
+	var p struct {
+		Description string `json:"description"`
+	}
+	if !ldJobPosting(node, &p) {
+		t.Fatal("ldJobPosting returned false, want it to tolerate the raw newline")
+	}
+	if p.Description != "Line one.\nLine two." {
+		t.Errorf("Description = %q", p.Description)
+	}
+}


### PR DESCRIPTION
## Summary
- Follow-up to #1742, which added a per-posting detail fetch for nodesk/cryptocurrencyjobs so the full description (from the page's schema.org JobPosting ld+json) replaces the feed's short blurb.
- On prod, nodesk picked up the full description correctly, but **cryptocurrencyjobs did not** — every posting kept the short blurb. Root cause: cryptocurrencyjobs.co's ld+json embeds each `description` with raw, unescaped newlines (live-verified, e.g. 93 literal `\n` bytes inside one string value). That's invalid JSON — Go's `encoding/json` is strict about control characters inside a string literal (`invalid character '\n' in string literal`) where some other decoders (e.g. Python's `json.loads(strict=False)`) tolerate it. `ldJobPosting`'s `json.Unmarshal` silently failed for nearly every posting, so #1742's fallback-to-blurb path (meant for network failures) was actually absorbing this on every request.
- `sanitizeJSONControlChars` walks the raw bytes, tracks whether it's inside a JSON string literal (respecting `\"` escapes), and escapes control bytes (0x00–0x1F) found there — `\n`/`\r`/`\t` to their two-byte escapes, anything rarer to `\u00XX`. Whitespace between tokens is left untouched. Applied once in `jsonld.go` where ld+json script bytes enter the shared `ldJobPosting`/`LDJobPostings` helpers, so every adapter using them (breezy, teamtailor, cryptocurrencyjobs, nodesk, wantapply, ...) benefits.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/...` — new tests: the sanitizer only touches control bytes inside a string (not between tokens), correctly tracks escaped-backslash state, and `ldJobPosting` now decodes a fixture reproducing the live raw-newline shape