### PR TITLE
fix(extension): resolve 47 TypeScript errors under noUncheckedIndexedAccess

### DIFF
--- a/extension/lib/assistant/api.test.ts
+++ b/extension/lib/assistant/api.test.ts
@@ -26,8 +26,8 @@ describe('the assistant API', () => {
     await createSession('tok-123');
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].init.headers).toMatchObject({ Authorization: 'Bearer tok-123' });
-    expect(calls[0].init.credentials).toBeUndefined();
+    expect(calls[0]!.init.headers).toMatchObject({ Authorization: 'Bearer tok-123' });
+    expect(calls[0]!.init.credentials).toBeUndefined();
   });
 
   // The panel's agent is the one with eyes; a chat session would have no page tool.
@@ -36,8 +36,8 @@ describe('the assistant API', () => {
 
     await createSession('tok-123');
 
-    expect(calls[0].url).toContain('preset=browse');
-    expect(calls[0].init.method).toBe('POST');
+    expect(calls[0]!.url).toContain('preset=browse');
+    expect(calls[0]!.init.method).toBe('POST');
   });
 
   it('reaches hire by absolute origin, since an extension page has none of its own', async () => {
@@ -45,7 +45,7 @@ describe('the assistant API', () => {
 
     await createSession('tok-123');
 
-    expect(calls[0].url).toMatch(/^https?:\/\/.+\/api\/v1\/assistant\/sessions/);
+    expect(calls[0]!.url).toMatch(/^https?:\/\/.+\/api\/v1\/assistant\/sessions/);
   });
 
   // A conversation deleted from the web is a dead id the panel holds. It has to be
@@ -69,6 +69,6 @@ describe('the assistant API', () => {
     const calls = stubFetch({ status: 204 });
 
     await expect(deleteSession('s1', 'tok')).resolves.toBeUndefined();
-    expect(calls[0].init.method).toBe('DELETE');
+    expect(calls[0]!.init.method).toBe('DELETE');
   });
 });

--- a/extension/lib/assistant/client.test.ts
+++ b/extension/lib/assistant/client.test.ts
@@ -53,8 +53,8 @@ describe('sendTurn', () => {
 
     await sendTurn('s1', 'hello there', 'tok-9', () => {}).done;
 
-    expect(calls[0].init.headers).toMatchObject({ Authorization: 'Bearer tok-9' });
-    expect(JSON.parse(calls[0].init.body as string)).toEqual({ text: 'hello there' });
+    expect(calls[0]!.init.headers).toMatchObject({ Authorization: 'Bearer tok-9' });
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ text: 'hello there' });
   });
 
   // Stopping is something the user chose. It has to arrive as a terminal event, or

--- a/extension/lib/combobox.ts
+++ b/extension/lib/combobox.ts
@@ -143,7 +143,8 @@ function findWidget(doc: Document, label: string): { widget: Element | null; sta
     .map((q) => q.controls[0])
     .filter(isComboWidget);
 
-  if (widgets.length === 1) return { widget: widgets[0], status: 'not_found' };
+  // Guarded by the length check above: index 0 exists.
+  if (widgets.length === 1) return { widget: widgets[0]!, status: 'not_found' };
   return { widget: null, status: widgets.length > 1 ? 'ambiguous' : 'not_found' };
 }
 

--- a/extension/lib/form.test.ts
+++ b/extension/lib/form.test.ts
@@ -239,7 +239,7 @@ describe('extractForm combo flag', () => {
     select.setAttribute('aria-label', 'Country');
     document.body.append(select);
 
-    expect(extractForm(document)[0].combo).toBe(false);
+    expect(extractForm(document)[0]!.combo).toBe(false);
   });
 
   it("carries a widget's options when it exposes them without being opened", () => {
@@ -270,8 +270,8 @@ describe('extractForm combo flag', () => {
     labeledInput('co', 'Country', { type: 'text', role: 'combobox', 'aria-autocomplete': 'list' });
 
     const [field] = extractForm(document);
-    expect(field.combo).toBe(true);
-    expect(field.options).toBeUndefined();
+    expect(field!.combo).toBe(true);
+    expect(field!.options).toBeUndefined();
   });
 
   it("does not lift a neighbouring widget's options onto a closed one", () => {
@@ -289,8 +289,8 @@ describe('extractForm combo flag', () => {
     document.body.append(listbox);
 
     const [sponsorship, country] = extractForm(document);
-    expect(sponsorship.options).toBeUndefined();
-    expect(country.options).toEqual(['Germany']);
+    expect(sponsorship!.options).toBeUndefined();
+    expect(country!.options).toEqual(['Germany']);
   });
 });
 
@@ -426,9 +426,9 @@ describe('extractForm grouping', () => {
 
   it('reports which options of a group are already chosen as its value', () => {
     const [, poland] = checkboxGroup('Countries', ['Germany', 'Poland', 'Spain']);
-    poland.checked = true;
+    poland!.checked = true;
 
-    expect(extractForm(document)[0].value).toBe('Poland');
+    expect(extractForm(document)[0]!.value).toBe('Poland');
   });
 
   it('does not group text inputs that merely share a fieldset', () => {
@@ -554,7 +554,7 @@ describe('extractForm grouping', () => {
     fillByLabel(document, [{ label: emailField.label, value: 'ilya@example.com' }]);
 
     expect(email.value).toBe('ilya@example.com');
-    expect(germany.checked).toBe(false);
+    expect(germany!.checked).toBe(false);
   });
 });
 
@@ -566,8 +566,8 @@ describe('fillByLabel on a group', () => {
 
     const outcomes = fillByLabel(document, [{ label: 'Which countries?', value: 'Poland' }]);
 
-    expect(poland.checked).toBe(true);
-    expect(germany.checked).toBe(false);
+    expect(poland!.checked).toBe(true);
+    expect(germany!.checked).toBe(false);
     expect(outcomes).toEqual([{ label: 'Which countries?', status: 'filled' }]);
   });
 
@@ -576,7 +576,7 @@ describe('fillByLabel on a group', () => {
 
     const outcomes = fillByLabel(document, [{ label: 'Which countries?', value: 'Germany, Spain' }]);
 
-    expect([germany.checked, poland.checked, spain.checked]).toEqual([true, false, true]);
+    expect([germany!.checked, poland!.checked, spain!.checked]).toEqual([true, false, true]);
     expect(outcomes).toEqual([{ label: 'Which countries?', status: 'filled' }]);
   });
 
@@ -587,7 +587,7 @@ describe('fillByLabel on a group', () => {
 
     fillByLabel(document, [{ label: 'Which countries?', value: 'Korea, Republic of' }]);
 
-    expect(korea.checked).toBe(true);
+    expect(korea!.checked).toBe(true);
   });
 
   it('round-trips a value whose options contain commas of their own', () => {
@@ -595,16 +595,16 @@ describe('fillByLabel on a group', () => {
     // splits into three parts the group has never heard of. Only matching the
     // longest offered option at each step recovers the two real answers.
     const [germany, korea] = checkboxGroup('Which countries?', ['Germany', 'Korea, Republic of']);
-    germany.checked = true;
-    korea.checked = true;
-    const reported = extractForm(document)[0].value;
+    germany!.checked = true;
+    korea!.checked = true;
+    const reported = extractForm(document)[0]!.value;
     expect(reported).toBe('Germany, Korea, Republic of');
 
-    germany.checked = false;
-    korea.checked = false;
+    germany!.checked = false;
+    korea!.checked = false;
     const outcomes = fillByLabel(document, [{ label: 'Which countries?', value: reported }]);
 
-    expect([germany.checked, korea.checked]).toEqual([true, true]);
+    expect([germany!.checked, korea!.checked]).toEqual([true, true]);
     expect(outcomes).toEqual([{ label: 'Which countries?', status: 'filled' }]);
   });
 
@@ -619,22 +619,22 @@ describe('fillByLabel on a group', () => {
 
   it("leaves the user's own choice alone rather than clearing it", () => {
     const [germany, poland] = checkboxGroup('Which countries?', ['Germany', 'Poland']);
-    poland.checked = true;
+    poland!.checked = true;
 
     fillByLabel(document, [{ label: 'Which countries?', value: 'Germany' }]);
 
-    expect(germany.checked).toBe(true);
-    expect(poland.checked).toBe(true);
+    expect(germany!.checked).toBe(true);
+    expect(poland!.checked).toBe(true);
   });
 
   it('lets a radio group hold one answer, unchecking the sibling the browser clears', () => {
     const [yes, no] = checkboxGroup('Do you require sponsorship?', ['Yes', 'No'], 'radio', 'visa');
-    yes.checked = true;
+    yes!.checked = true;
 
     fillByLabel(document, [{ label: 'Do you require sponsorship?', value: 'No' }]);
 
-    expect(no.checked).toBe(true);
-    expect(yes.checked).toBe(false);
+    expect(no!.checked).toBe(true);
+    expect(yes!.checked).toBe(false);
   });
 
   it('leaves the group untouched when the option is not one it offers', () => {

--- a/extension/lib/form.ts
+++ b/extension/lib/form.ts
@@ -37,8 +37,13 @@ export function collectFillable(doc: Document): Fillable[] {
 export interface Question {
   /** The question's own text: a control's label, or the group's legend. */
   label: string;
-  /** One control, or the group's controls in document order. */
-  controls: Fillable[];
+  /**
+   * One control, or the group's controls in document order. Never empty —
+   * every construction site starts it from a single control — encoded as a
+   * non-empty tuple so `controls[0]` and single-element destructuring stay
+   * typed as `Fillable`, not `Fillable | undefined`.
+   */
+  controls: [Fillable, ...Fillable[]];
 }
 
 /** The ordered list of questions — the index space for observe + act. */

--- a/extension/lib/freehire.ts
+++ b/extension/lib/freehire.ts
@@ -20,7 +20,7 @@ export function freehireSlugFromUrl(rawUrl: string): string | null {
   }
   if (!JOB_HOSTS.includes(u.hostname)) return null;
   const m = u.pathname.match(/^\/jobs\/([^/]+)\/?$/);
-  return m ? m[1] : null;
+  return m ? (m[1] ?? null) : null;
 }
 
 /** freehire's company-logo proxy URL for a company name (404s → placeholder).


### PR DESCRIPTION
## Summary
- WXT's generated tsconfig sets `noUncheckedIndexedAccess: true`, which makes array indexing/destructuring yield `T | undefined` — this was causing 47 type errors that blocked the `extension` CI build job.
- `Question.controls` in `extension/lib/form.ts` is changed from `Fillable[]` to the non-empty tuple `[Fillable, ...Fillable[]]`, encoding the actual invariant (a question always has at least one control) so the type checker no longer flags every access as possibly-undefined.
- The remaining errors are fixed with `!` non-null assertions only at genuinely runtime-guarded sites (e.g. `extension/lib/combobox.ts`'s `widgets[0]!`, guarded by a preceding length check), plus one real null-coalescing fix in `extension/lib/freehire.ts` (`m[1] ?? null`).
- Test files (`form.test.ts`, `assistant/api.test.ts`, `assistant/client.test.ts`) get the same `!` treatment at destructured/indexed access sites.

## Test plan
- [x] `npm run check` — 0 errors (was 47)
- [x] `npm test` — 205 passed
- [x] `npm run zip` — production build succeeds