### PR TITLE
feat(auth): add mobile auth v2 (verifier-bound OAuth, native Apple, recent auth & connected identities)

### DIFF
--- a/cmd/apple-revoke/main.go
+++ b/cmd/apple-revoke/main.go
@@ -1,0 +1,44 @@
+// Command apple-revoke drains durable native Sign in with Apple token
+// revocations. It is run-once-and-exit and should be scheduled every minute.
+package main
+
+import (
+	"context"
+	"log"
+
+	appleauth "github.com/strelov1/freehire/internal/auth/apple"
+	"github.com/strelov1/freehire/internal/auth/applejobs"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+func main() { worker.Main(run) }
+func run() int {
+	ctx, cfg, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+	creds := cfg.OAuth["apple"]
+	if cfg.AppleNativeClientID == "" {
+		log.Print("apple-revoke: native Apple is not configured")
+		return 1
+	}
+	client, err := appleauth.New(appleauth.Config{TeamID: creds.TeamID, KeyID: creds.KeyID, PrivateKeyPEM: creds.PrivateKey, ClientIDs: []string{cfg.AppleNativeClientID}})
+	if err != nil {
+		log.Printf("apple-revoke: %v", err)
+		return 1
+	}
+	ring, err := appleauth.NewKeyRing(cfg.AppleGrantActiveKeyID, cfg.AppleGrantKeys)
+	if err != nil {
+		log.Printf("apple-revoke: %v", err)
+		return 1
+	}
+	done, err := applejobs.New(pool, client, ring).Run(ctx, 100)
+	if err != nil {
+		log.Printf("apple-revoke: %v", err)
+		return 1
+	}
+	log.Printf("apple-revoke: processed=%d", done)
+	return 0
+}

--- a/cmd/auth-cleanup/main.go
+++ b/cmd/auth-cleanup/main.go
@@ -1,0 +1,28 @@
+// Command auth-cleanup deletes bounded batches of expired v2 attempts,
+// exchange codes, and recent-auth proofs. Schedule it every few minutes.
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/strelov1/freehire/internal/auth/mobileauth"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+func main() { worker.Main(run) }
+func run() int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+	count, err := mobileauth.NewStore(pool).Cleanup(ctx, 1000)
+	if err != nil {
+		log.Printf("auth-cleanup: %v", err)
+		return 1
+	}
+	log.Printf("auth-cleanup: deleted=%d", count)
+	return 0
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 
+	appleauth "github.com/strelov1/freehire/internal/auth/apple"
 	"github.com/strelov1/freehire/internal/auth/oauth"
 	"github.com/strelov1/freehire/internal/blobstore"
 	"github.com/strelov1/freehire/internal/config"
@@ -208,6 +209,19 @@ func main() {
 	// auth. Redirect URLs are built per request from the request origin, so one
 	// deployment can complete the flow on more than one served domain.
 	oauthRegistry := oauth.NewRegistry(cfg.OAuth)
+	var appleNative *appleauth.Client
+	var appleGrantKeys *appleauth.KeyRing
+	if cfg.AppleNativeClientID != "" {
+		appleCreds := cfg.OAuth["apple"]
+		appleNative, err = appleauth.New(appleauth.Config{TeamID: appleCreds.TeamID, KeyID: appleCreds.KeyID, PrivateKeyPEM: appleCreds.PrivateKey, ClientIDs: []string{cfg.AppleNativeClientID}})
+		if err != nil {
+			log.Fatalf("native Apple: %v", err)
+		}
+		appleGrantKeys, err = appleauth.NewKeyRing(cfg.AppleGrantActiveKeyID, cfg.AppleGrantKeys)
+		if err != nil {
+			log.Fatalf("native Apple grant encryption: %v", err)
+		}
+	}
 
 	// Connect-Gmail inbox: enabled only when the Google OAuth client and the
 	// token-encryption key are configured. Both nil disables the feature.
@@ -234,6 +248,11 @@ func main() {
 		CookieSecure:                cfg.CookieSecure,
 		CookieDomains:               cfg.CookieDomains,
 		OAuthRegistry:               oauthRegistry,
+		AuthV2Enabled:               cfg.AuthV2Enabled,
+		MobileAuthCallbacks:         cfg.MobileAuthCallbacks,
+		RecentAuthTTL:               cfg.RecentAuthTTL,
+		AppleNative:                 appleNative,
+		AppleGrantKeys:              appleGrantKeys,
 		GmailConnector:              gmailConnector,
 		GmailCipher:                 gmailCipher,
 		MailboxDomain:               cfg.MailboxDomain,

--- a/docs/auth-mobile-v2-runbook.md
+++ b/docs/auth-mobile-v2-runbook.md
@@ -1,0 +1,88 @@
+# Mobile authentication v2 runbook
+
+BE-2 is schema-first and disabled by default. Never place an Apple private key,
+grant-encryption key, authorization code, identity token, refresh token, OAuth
+state, PKCE verifier, or session cookie in Git, CI output, logs, or PR text.
+
+## Deployment order
+
+1. Deploy `0087_mobile_auth_v2.sql` while the old binary is still running.
+2. Deploy the new binary with `AUTH_V2_ENABLED=false`. V1 web OAuth, including
+   the existing Apple Services-ID flow, remains unchanged. The password recent-
+   auth adapter is registered for the paired web bundle, but mobile discovery,
+   exchange, identity unlink, and enforcement remain disabled.
+3. Provision callback, native Apple, and encryption configuration below.
+4. Start `auth-cleanup` every 5 minutes and `apple-revoke` every minute as
+   run-once workers. Alert on non-zero exit and failed revocation jobs.
+5. Set `AUTH_V2_ENABLED=true` in a non-production environment and exercise PKCE
+   across at least two backend replicas. Validate native Apple on a real device.
+6. Enable production v2 only after the verified-link callback is live. Apple is
+   advertised only when its full client and grant-encryption configuration boots.
+7. Do not ship native Apple in a store build until BE-3 queues Apple revocation
+   before account deletion. The grant foreign key deliberately blocks deletion
+   rather than silently orphaning a live Apple grant.
+
+## Configuration
+
+| Variable | Meaning |
+|---|---|
+| `AUTH_V2_ENABLED` | Registers `/api/v2/auth/*`; default `false`. |
+| `MOBILE_AUTH_CALLBACKS` | Comma-separated `platform=https://verified/path` allowlist. Include `web=https://<host>/my/reauth`; add `ios=` and/or `android=` only when each verified-link target is live. |
+| `RECENT_AUTH_TTL` | Recent-auth proof lifetime; default `10m`, allowed `1m` to `1h`. |
+| `APPLE_NATIVE_CLIENT_ID` | Native iOS bundle/client ID, separate from the web Services ID. |
+| `OAUTH_APPLE_TEAM_ID` | Existing Apple developer Team ID. |
+| `OAUTH_APPLE_KEY_ID` | Existing Sign in with Apple key ID. |
+| `OAUTH_APPLE_PRIVATE_KEY` | Existing base64-encoded `.p8` PEM, server secret only. |
+| `APPLE_GRANT_ACTIVE_KEY_ID` | Key ID used for new Apple refresh-grant encryption. |
+| `APPLE_GRANT_KEYS` | `id:base64-32-byte-key,...`; retain old decrypt-only entries during rotation. |
+
+`OAUTH_APPLE_CLIENT_ID` remains the web Services ID and is not reused as the
+native audience. Partial native Apple configuration fails startup without
+printing secret values. Production callback entries must use HTTPS.
+
+Each enabled browser provider must also allow its server-owned v2 redirect URI:
+`https://<served-host>/api/v2/auth/oauth/<provider>/callback`. For Apple web
+reauthentication, add `/api/v2/auth/oauth/apple/callback` to the Services ID's
+return URLs alongside the existing v1 callback. These provider-console redirect
+URIs are separate from `MOBILE_AUTH_CALLBACKS`, which contains only FreeHire's
+final completion targets.
+
+## Key rotation
+
+Add the new 32-byte key to `APPLE_GRANT_KEYS`, deploy, then change
+`APPLE_GRANT_ACTIVE_KEY_ID`. Keep every old key while any grant or revocation job
+names it. Remove an old key only after database counts for that key ID are zero.
+Rotating the Apple `.p8` is independent: provision the new key ID and private key,
+restart server and worker, validate exchange/revoke, then retire the old key in
+Apple Developer.
+
+## Revocation operations
+
+`apple-revoke` claims jobs with `FOR UPDATE SKIP LOCKED`, retries transient
+provider failures with bounded backoff, and completes identity removal only after
+revocation. A delayed `exchange_compensation` job takes encrypted custody before
+grant finalization; successful finalization disarms it, while a crash or failed
+write leaves it revocable. A crash after finalization revokes and removes only
+the grant carrying that compensation job's row ID, never a newer retry grant.
+Completion purges ciphertext, nonce, and encryption key ID while retaining the
+idempotency tombstone. Inspect only `status`,
+`attempts`, `next_attempt_at`, and `last_error_class`; never dump ciphertext or
+try to decrypt a token by hand.
+Permanent/ten-attempt failures require fixing Apple configuration and moving the
+job back to `retry` with a forward operator migration or audited admin procedure.
+
+## Rollback
+
+First set `AUTH_V2_ENABLED=false`; this stops new attempts while v1 web OAuth
+continues. Keep the binary/worker capable of reading grants and pending jobs.
+Never drop BE-2 tables after production has accepted an Apple grant. Roll forward
+with a corrective migration. The v1 mobile exchange can be retired only after the
+minimum supported app version no longer uses it; v1 web callbacks remain separate.
+
+## Production validation owned outside this PR
+
+- verified HTTPS callback/associated-domain files and edge no-cache behavior;
+- Apple Developer native App ID capability and the server key's permissions;
+- real-device first login, repeat login with no email, reauthentication, unlink,
+  revocation, and subsequent sign-in refusal while revocation is pending;
+- two-replica PKCE consume/replay tests and log scans for forbidden fields.

--- a/internal/accounts/repository.go
+++ b/internal/accounts/repository.go
@@ -42,7 +42,9 @@ func (r *QueriesRepository) WithTx(tx pgx.Tx) Repository {
 // UserIDByIdentity returns the local user id for an external identity, or
 // ErrIdentityNotFound when no identity row matches.
 func (r *QueriesRepository) UserIDByIdentity(ctx context.Context, provider, providerUserID string) (int64, error) {
-	row, err := r.q.GetUserByIdentity(ctx, db.GetUserByIdentityParams{
+	// Status is part of authentication, not display metadata: an Apple identity
+	// awaiting provider revocation must not sign in and silently undo unlink.
+	row, err := r.q.GetActiveUserByIdentity(ctx, db.GetActiveUserByIdentityParams{
 		Provider:       provider,
 		ProviderUserID: providerUserID,
 	})

--- a/internal/auth/apple/client.go
+++ b/internal/auth/apple/client.go
@@ -1,0 +1,439 @@
+// Package apple implements the native Sign in with Apple trust boundary. It
+// verifies nonce-bound identity tokens, exchanges authorization codes on the
+// server, encrypts reusable grants, and revokes them without exposing tokens.
+package apple
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	Issuer           = "https://appleid.apple.com"
+	DefaultTokenURL  = "https://appleid.apple.com/auth/token"
+	DefaultJWKSURL   = "https://appleid.apple.com/auth/keys"
+	DefaultRevokeURL = "https://appleid.apple.com/auth/revoke"
+	maxBody          = 1 << 20
+	maxJWKSStale     = 24 * time.Hour
+)
+
+var (
+	ErrInvalidToken = errors.New("apple: invalid identity token")
+	ErrExchange     = errors.New("apple: authorization code exchange failed")
+	ErrRevoke       = errors.New("apple: token revocation failed")
+	ErrPermanent    = errors.New("apple: permanent provider configuration error")
+	ErrGrantDecrypt = errors.New("apple: grant decryption failed")
+)
+
+type Config struct {
+	TeamID, KeyID, PrivateKeyPEM string
+	ClientIDs                    []string
+	TokenURL, JWKSURL, RevokeURL string
+	HTTPClient                   *http.Client
+	Leeway                       time.Duration
+}
+
+type Claims struct {
+	jwt.RegisteredClaims
+	Nonce         string `json:"nonce"`
+	Email         string `json:"email"`
+	EmailVerified any    `json:"email_verified"`
+}
+
+func (c Claims) VerifiedEmail() (string, bool) {
+	verified := false
+	switch v := c.EmailVerified.(type) {
+	case bool:
+		verified = v
+	case string:
+		verified = v == "true"
+	}
+	return c.Email, verified && c.Email != ""
+}
+
+type Grant struct {
+	Subject, ClientID, RefreshToken string
+	Claims                          Claims
+}
+
+type jwk struct{ Kty, Use, Kid, Alg, N, E string }
+type cachedKeys struct {
+	keys    map[string]*rsa.PublicKey
+	expires time.Time
+}
+
+type Client struct {
+	cfg     Config
+	key     *ecdsa.PrivateKey
+	mu      sync.RWMutex
+	cache   cachedKeys
+	refresh singleflight.Group
+	now     func() time.Time
+}
+
+func New(cfg Config) (*Client, error) {
+	if cfg.TeamID == "" || cfg.KeyID == "" || cfg.PrivateKeyPEM == "" || len(cfg.ClientIDs) == 0 {
+		return nil, errors.New("apple: incomplete configuration")
+	}
+	block, _ := pem.Decode([]byte(cfg.PrivateKeyPEM))
+	if block == nil {
+		return nil, errors.New("apple: private key is not PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("apple: parse private key: %w", err)
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("apple: private key is not ECDSA")
+	}
+	if cfg.TokenURL == "" {
+		cfg.TokenURL = DefaultTokenURL
+	}
+	if cfg.JWKSURL == "" {
+		cfg.JWKSURL = DefaultJWKSURL
+	}
+	if cfg.RevokeURL == "" {
+		cfg.RevokeURL = DefaultRevokeURL
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 10 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	}
+	if cfg.Leeway <= 0 {
+		cfg.Leeway = 30 * time.Second
+	}
+	seen := map[string]bool{}
+	for _, id := range cfg.ClientIDs {
+		if strings.TrimSpace(id) == "" || seen[id] {
+			return nil, errors.New("apple: invalid client id allowlist")
+		}
+		seen[id] = true
+	}
+	return &Client{cfg: cfg, key: key, now: time.Now}, nil
+}
+
+func (c *Client) Enabled() bool       { return c != nil }
+func (c *Client) ClientIDs() []string { return append([]string(nil), c.cfg.ClientIDs...) }
+
+func (c *Client) clientAllowed(aud string) bool {
+	for _, id := range c.cfg.ClientIDs {
+		if id == aud {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Client) ClientIDForClaims(claims Claims) (string, bool) {
+	for _, aud := range claims.Audience {
+		if c.clientAllowed(aud) {
+			return aud, true
+		}
+	}
+	return "", false
+}
+
+func parseMaxAge(header string) time.Duration {
+	for _, item := range strings.Split(header, ",") {
+		item = strings.TrimSpace(item)
+		if strings.HasPrefix(item, "max-age=") {
+			if n, err := strconv.Atoi(strings.TrimPrefix(item, "max-age=")); err == nil && n > 0 && n <= 86400 {
+				return time.Duration(n) * time.Second
+			}
+		}
+	}
+	return time.Hour
+}
+
+func (c *Client) fetchKeys(ctx context.Context) (cachedKeys, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.JWKSURL, nil)
+	if err != nil {
+		return cachedKeys{}, err
+	}
+	resp, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return cachedKeys{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return cachedKeys{}, fmt.Errorf("apple: jwks status %d", resp.StatusCode)
+	}
+	var body struct {
+		Keys []jwk `json:"keys"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&body); err != nil {
+		return cachedKeys{}, err
+	}
+	keys := map[string]*rsa.PublicKey{}
+	for _, k := range body.Keys {
+		if k.Kid == "" || k.Kty != "RSA" || (k.Use != "" && k.Use != "sig") || (k.Alg != "" && k.Alg != "RS256") {
+			continue
+		}
+		nb, e1 := base64.RawURLEncoding.DecodeString(k.N)
+		eb, e2 := base64.RawURLEncoding.DecodeString(k.E)
+		if e1 != nil || e2 != nil || len(nb) == 0 || len(eb) == 0 {
+			continue
+		}
+		e := 0
+		for _, b := range eb {
+			e = e<<8 | int(b)
+		}
+		if e < 3 {
+			continue
+		}
+		keys[k.Kid] = &rsa.PublicKey{N: new(big.Int).SetBytes(nb), E: e}
+	}
+	if len(keys) == 0 {
+		return cachedKeys{}, errors.New("apple: jwks contains no usable keys")
+	}
+	return cachedKeys{keys: keys, expires: c.now().Add(parseMaxAge(resp.Header.Get("Cache-Control")))}, nil
+}
+
+func (c *Client) keyFor(ctx context.Context, kid string, force bool) (*rsa.PublicKey, error) {
+	if !force {
+		c.mu.RLock()
+		cached, ok, fresh := c.cache.keys[kid], c.cache.keys != nil, c.cache.expires.After(c.now())
+		c.mu.RUnlock()
+		if cached != nil && fresh {
+			return cached, nil
+		}
+		if ok && fresh {
+			return nil, fmt.Errorf("apple: unknown kid")
+		}
+	}
+	v, err, _ := c.refresh.Do("jwks", func() (any, error) { return c.fetchKeys(ctx) })
+	if err != nil {
+		c.mu.RLock()
+		stale, staleUntil := c.cache.keys[kid], c.cache.expires.Add(maxJWKSStale)
+		c.mu.RUnlock()
+		if stale != nil && c.now().Before(staleUntil) {
+			return stale, nil
+		}
+		return nil, err
+	}
+	cache := v.(cachedKeys)
+	c.mu.Lock()
+	c.cache = cache
+	c.mu.Unlock()
+	key := cache.keys[kid]
+	if key == nil {
+		return nil, errors.New("apple: unknown kid")
+	}
+	return key, nil
+}
+
+func (c *Client) Verify(ctx context.Context, raw, expectedNonce string) (Claims, error) {
+	if raw == "" || expectedNonce == "" {
+		return Claims{}, ErrInvalidToken
+	}
+	var unverified Claims
+	tok, _, err := jwt.NewParser().ParseUnverified(raw, &unverified)
+	if err != nil || tok.Method.Alg() != jwt.SigningMethodRS256.Alg() {
+		return Claims{}, ErrInvalidToken
+	}
+	kid, ok := tok.Header["kid"].(string)
+	if !ok || kid == "" {
+		return Claims{}, ErrInvalidToken
+	}
+	key, err := c.keyFor(ctx, kid, false)
+	if err != nil {
+		key, err = c.keyFor(ctx, kid, true)
+	}
+	if err != nil {
+		return Claims{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	var claims Claims
+	parsed, err := jwt.ParseWithClaims(raw, &claims, func(t *jwt.Token) (any, error) {
+		if t.Method != jwt.SigningMethodRS256 {
+			return nil, ErrInvalidToken
+		}
+		if t.Header["kid"] != kid {
+			return nil, ErrInvalidToken
+		}
+		return key, nil
+	}, jwt.WithValidMethods([]string{"RS256"}), jwt.WithIssuer(Issuer), jwt.WithExpirationRequired(), jwt.WithIssuedAt(), jwt.WithLeeway(c.cfg.Leeway))
+	if err != nil || !parsed.Valid || claims.Subject == "" || claims.Nonce != expectedNonce || len(claims.Audience) == 0 {
+		return Claims{}, ErrInvalidToken
+	}
+	allowed := false
+	for _, aud := range claims.Audience {
+		if c.clientAllowed(aud) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed || claims.IssuedAt == nil || claims.IssuedAt.After(c.now().Add(c.cfg.Leeway)) {
+		return Claims{}, ErrInvalidToken
+	}
+	return claims, nil
+}
+
+func (c *Client) clientSecret(clientID string) (string, error) {
+	if !c.clientAllowed(clientID) {
+		return "", errors.New("apple: client id not allowed")
+	}
+	now := c.now()
+	claims := jwt.RegisteredClaims{Issuer: c.cfg.TeamID, Subject: clientID, Audience: jwt.ClaimStrings{Issuer}, IssuedAt: jwt.NewNumericDate(now), ExpiresAt: jwt.NewNumericDate(now.Add(5 * time.Minute))}
+	t := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	t.Header["kid"] = c.cfg.KeyID
+	return t.SignedString(c.key)
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	Error        string `json:"error"`
+}
+
+func (c *Client) postForm(ctx context.Context, endpoint string, form url.Values, out any) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if out != nil {
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(out); err != nil {
+			return resp.StatusCode, err
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+func (c *Client) Exchange(ctx context.Context, code, clientID, expectedNonce, submittedSubject string) (Grant, error) {
+	if code == "" || submittedSubject == "" {
+		return Grant{}, ErrExchange
+	}
+	secret, err := c.clientSecret(clientID)
+	if err != nil {
+		return Grant{}, err
+	}
+	var tr tokenResponse
+	status, err := c.postForm(ctx, c.cfg.TokenURL, url.Values{"grant_type": {"authorization_code"}, "code": {code}, "client_id": {clientID}, "client_secret": {secret}}, &tr)
+	if err != nil || status != http.StatusOK || tr.Error != "" || tr.IDToken == "" || tr.RefreshToken == "" {
+		return Grant{}, ErrExchange
+	}
+	claims, err := c.Verify(ctx, tr.IDToken, expectedNonce)
+	if err != nil || claims.Subject != submittedSubject {
+		return Grant{}, ErrExchange
+	}
+	audOK := false
+	for _, aud := range claims.Audience {
+		if aud == clientID {
+			audOK = true
+		}
+	}
+	if !audOK {
+		return Grant{}, ErrExchange
+	}
+	return Grant{Subject: claims.Subject, ClientID: clientID, RefreshToken: tr.RefreshToken, Claims: claims}, nil
+}
+
+func (c *Client) Revoke(ctx context.Context, refreshToken, clientID string) error {
+	secret, err := c.clientSecret(clientID)
+	if err != nil {
+		return err
+	}
+	form := url.Values{"token": {refreshToken}, "token_type_hint": {"refresh_token"}, "client_id": {clientID}, "client_secret": {secret}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.RevokeURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	var payload struct {
+		Error string `json:"error"`
+	}
+	_ = json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&payload)
+	if resp.StatusCode == http.StatusBadRequest && payload.Error == "invalid_grant" {
+		return nil
+	}
+	if resp.StatusCode == http.StatusBadRequest && (payload.Error == "invalid_client" || payload.Error == "unauthorized_client") {
+		return fmt.Errorf("%w: %s", ErrPermanent, payload.Error)
+	}
+	return fmt.Errorf("%w: status %d", ErrRevoke, resp.StatusCode)
+}
+
+type KeyRing struct {
+	active string
+	keys   map[string][]byte
+}
+
+func NewKeyRing(active string, keys map[string][]byte) (*KeyRing, error) {
+	if active == "" || len(keys) == 0 {
+		return nil, errors.New("apple: empty grant key ring")
+	}
+	copied := map[string][]byte{}
+	for id, k := range keys {
+		if id == "" || len(k) != 32 {
+			return nil, errors.New("apple: grant keys must be named AES-256 keys")
+		}
+		copied[id] = append([]byte(nil), k...)
+	}
+	if copied[active] == nil {
+		return nil, errors.New("apple: active grant key missing")
+	}
+	return &KeyRing{active: active, keys: copied}, nil
+}
+func (r *KeyRing) Encrypt(plain, aad []byte) (ciphertext, nonce []byte, keyID string, err error) {
+	block, _ := aes.NewCipher(r.keys[r.active])
+	gcm, _ := cipher.NewGCM(block)
+	nonce = make([]byte, gcm.NonceSize())
+	if _, err = rand.Read(nonce); err != nil {
+		return
+	}
+	ciphertext = gcm.Seal(nil, nonce, plain, aad)
+	keyID = r.active
+	return
+}
+func (r *KeyRing) Decrypt(ciphertext, nonce []byte, keyID string, aad []byte) ([]byte, error) {
+	key := r.keys[keyID]
+	if key == nil {
+		return nil, fmt.Errorf("%w: unknown key", ErrGrantDecrypt)
+	}
+	block, _ := aes.NewCipher(key)
+	gcm, _ := cipher.NewGCM(block)
+	plain, err := gcm.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, fmt.Errorf("%w: authentication failed", ErrGrantDecrypt)
+	}
+	return plain, nil
+}
+func GrantAAD(provider, subject, clientID, rowID string) []byte {
+	sum := sha256.Sum256([]byte("v1\x00" + provider + "\x00" + subject + "\x00" + clientID + "\x00" + rowID))
+	return sum[:]
+}

--- a/internal/auth/apple/client_test.go
+++ b/internal/auth/apple/client_test.go
@@ -1,0 +1,201 @@
+package apple
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func jsonResponse(status int, body any) *http.Response {
+	var b bytes.Buffer
+	_ = json.NewEncoder(&b).Encode(body)
+	return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(&b)}
+}
+
+func testPrivatePEM(t *testing.T) (string, *ecdsa.PrivateKey) {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})), k
+}
+func b64int(v *big.Int) string { return base64.RawURLEncoding.EncodeToString(v.Bytes()) }
+func signIdentity(t *testing.T, key *rsa.PrivateKey, kid, aud, sub, nonce string, expires time.Time) string {
+	t.Helper()
+	claims := Claims{RegisteredClaims: jwt.RegisteredClaims{Issuer: Issuer, Subject: sub, Audience: jwt.ClaimStrings{aud}, IssuedAt: jwt.NewNumericDate(time.Now().Add(-time.Second)), ExpiresAt: jwt.NewNumericDate(expires)}, Nonce: nonce, Email: "user@example.com", EmailVerified: true}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	raw, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestVerifyExchangeAndRevoke(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privatePEM, _ := testPrivatePEM(t)
+	nonce := "nonce-challenge"
+	subject := "apple-subject"
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/keys":
+			resp := jsonResponse(200, map[string]any{"keys": []any{map[string]any{"kty": "RSA", "use": "sig", "alg": "RS256", "kid": "kid-1", "n": b64int(rsaKey.N), "e": base64.RawURLEncoding.EncodeToString(big.NewInt(int64(rsaKey.E)).Bytes())}}})
+			resp.Header.Set("Cache-Control", "max-age=300")
+			return resp, nil
+		case "/token":
+			_ = r.ParseForm()
+			if r.Form.Get("code") == "mismatch" {
+				subject = "other"
+			}
+			return jsonResponse(200, map[string]any{"id_token": signIdentity(t, rsaKey, "kid-1", "me.freehire.mobile", subject, nonce, time.Now().Add(time.Minute)), "refresh_token": "refresh-secret"}), nil
+		case "/revoke":
+			return jsonResponse(200, map[string]any{}), nil
+		default:
+			return jsonResponse(404, map[string]any{}), nil
+		}
+	})}
+	client, err := New(Config{TeamID: "TEAM", KeyID: "KEY", PrivateKeyPEM: privatePEM, ClientIDs: []string{"me.freehire.mobile"}, JWKSURL: "https://apple.test/keys", TokenURL: "https://apple.test/token", RevokeURL: "https://apple.test/revoke", HTTPClient: httpClient})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := signIdentity(t, rsaKey, "kid-1", "me.freehire.mobile", "apple-subject", nonce, time.Now().Add(time.Minute))
+	claims, err := client.Verify(context.Background(), raw, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.Subject != "apple-subject" {
+		t.Fatal(claims.Subject)
+	}
+	grant, err := client.Exchange(context.Background(), "good", "me.freehire.mobile", nonce, "apple-subject")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.RefreshToken != "refresh-secret" {
+		t.Fatal("refresh token missing")
+	}
+	if err = client.Revoke(context.Background(), grant.RefreshToken, grant.ClientID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = client.Verify(context.Background(), raw, "wrong"); err == nil {
+		t.Fatal("wrong nonce accepted")
+	}
+	if _, err = client.Verify(context.Background(), signIdentity(t, rsaKey, "kid-1", "other-client", "apple-subject", nonce, time.Now().Add(time.Minute)), nonce); err == nil {
+		t.Fatal("wrong audience accepted")
+	}
+	if _, err = client.Verify(context.Background(), signIdentity(t, rsaKey, "kid-1", "me.freehire.mobile", "apple-subject", nonce, time.Now().Add(-time.Minute)), nonce); err == nil {
+		t.Fatal("expired token accepted")
+	}
+	if _, err = client.Exchange(context.Background(), "mismatch", "me.freehire.mobile", nonce, "apple-subject"); err == nil {
+		t.Fatal("token response subject mismatch accepted")
+	}
+}
+
+func TestKeyRingRotationAndAuthentication(t *testing.T) {
+	old := make([]byte, 32)
+	newKey := make([]byte, 32)
+	_, _ = rand.Read(old)
+	_, _ = rand.Read(newKey)
+	ring, err := NewKeyRing("new", map[string][]byte{"old": old, "new": newKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	aad := GrantAAD("apple", "sub", "client", "row")
+	ciphertext, nonce, kid, err := ring.Encrypt([]byte("refresh"), aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kid != "new" {
+		t.Fatal(kid)
+	}
+	plain, err := ring.Decrypt(ciphertext, nonce, kid, aad)
+	if err != nil || string(plain) != "refresh" {
+		t.Fatalf("decrypt=%q err=%v", plain, err)
+	}
+	ciphertext[0] ^= 1
+	if _, err = ring.Decrypt(ciphertext, nonce, kid, aad); err == nil {
+		t.Fatal("tamper accepted")
+	}
+}
+
+func TestKeyForRefreshesExpiredCachedKey(t *testing.T) {
+	oldKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privatePEM, _ := testPrivatePEM(t)
+	fetches := 0
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		fetches++
+		return jsonResponse(200, map[string]any{"keys": []any{map[string]any{
+			"kty": "RSA", "use": "sig", "alg": "RS256", "kid": "kid-1",
+			"n": b64int(newKey.N), "e": base64.RawURLEncoding.EncodeToString(big.NewInt(int64(newKey.E)).Bytes()),
+		}}}), nil
+	})}
+	client, err := New(Config{TeamID: "TEAM", KeyID: "KEY", PrivateKeyPEM: privatePEM,
+		ClientIDs: []string{"me.freehire.mobile"}, JWKSURL: "https://apple.test/keys", HTTPClient: httpClient})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.cache = cachedKeys{keys: map[string]*rsa.PublicKey{"kid-1": &oldKey.PublicKey}, expires: time.Now().Add(-time.Minute)}
+	got, err := client.keyFor(context.Background(), "kid-1", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetches != 1 || got.N.Cmp(newKey.N) != 0 {
+		t.Fatalf("expired cache was reused: fetches=%d", fetches)
+	}
+}
+
+func TestKeyForRejectsExcessivelyStaleKeyWhenRefreshFails(t *testing.T) {
+	oldKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privatePEM, _ := testPrivatePEM(t)
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("provider unavailable")
+	})}
+	client, err := New(Config{TeamID: "TEAM", KeyID: "KEY", PrivateKeyPEM: privatePEM,
+		ClientIDs: []string{"me.freehire.mobile"}, JWKSURL: "https://apple.test/keys", HTTPClient: httpClient})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.cache = cachedKeys{
+		keys:    map[string]*rsa.PublicKey{"kid-1": &oldKey.PublicKey},
+		expires: time.Now().Add(-maxJWKSStale - time.Minute),
+	}
+	if _, err = client.keyFor(context.Background(), "kid-1", false); err == nil {
+		t.Fatal("excessively stale key accepted")
+	}
+}

--- a/internal/auth/applejobs/worker.go
+++ b/internal/auth/applejobs/worker.go
@@ -1,0 +1,152 @@
+// Package applejobs drains durable Sign in with Apple revocations. Workers are
+// run-once and safe to retry; grant material remains encrypted at rest.
+package applejobs
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/strelov1/freehire/internal/auth/apple"
+)
+
+type revoker interface {
+	Revoke(context.Context, string, string) error
+}
+
+type Worker struct {
+	pool  *pgxpool.Pool
+	apple revoker
+	keys  *apple.KeyRing
+	now   func() time.Time
+}
+
+func New(pool *pgxpool.Pool, client revoker, keys *apple.KeyRing) *Worker {
+	return &Worker{pool: pool, apple: client, keys: keys, now: time.Now}
+}
+
+type job struct {
+	id, grantID              uuid.UUID
+	userID                   *int64
+	reason                   string
+	subject, clientID, keyID string
+	ciphertext, nonce        []byte
+	attempts                 int32
+}
+
+func (w *Worker) claim(ctx context.Context) (job, error) {
+	tx, err := w.pool.Begin(ctx)
+	if err != nil {
+		return job{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var j job
+	err = tx.QueryRow(ctx, `SELECT id,token_aad_row_id,source_user_id,reason,source_provider_user_id,client_id,token_ciphertext,token_nonce,encryption_key_id,attempts FROM apple_revocation_jobs WHERE (status IN ('pending','retry') AND next_attempt_at<=now()) OR (status='processing' AND updated_at < now()-interval '10 minutes') ORDER BY next_attempt_at,created_at FOR UPDATE SKIP LOCKED LIMIT 1`).Scan(&j.id, &j.grantID, &j.userID, &j.reason, &j.subject, &j.clientID, &j.ciphertext, &j.nonce, &j.keyID, &j.attempts)
+	if err != nil {
+		return job{}, err
+	}
+	_, err = tx.Exec(ctx, `UPDATE apple_revocation_jobs SET status='processing',attempts=attempts+1,updated_at=now() WHERE id=$1`, j.id)
+	if err == nil {
+		err = tx.Commit(ctx)
+	}
+	return j, err
+}
+
+func (w *Worker) Run(ctx context.Context, limit int) (int, error) {
+	if w.apple == nil || w.keys == nil {
+		return 0, errors.New("apple revocation: not configured")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	done := 0
+	for done < limit {
+		j, err := w.claim(ctx)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return done, nil
+		}
+		if err != nil {
+			return done, err
+		}
+		done++
+		aad := apple.GrantAAD("apple", j.subject, j.clientID, j.grantID.String())
+		plain, err := w.keys.Decrypt(j.ciphertext, j.nonce, j.keyID, aad)
+		if err == nil {
+			err = w.apple.Revoke(ctx, string(plain), j.clientID)
+		}
+		for i := range plain {
+			plain[i] = 0
+		}
+		if err == nil {
+			if err = w.complete(ctx, j); err != nil {
+				return done, err
+			}
+			continue
+		}
+		if err = w.retry(ctx, j, err); err != nil {
+			return done, err
+		}
+	}
+	return done, nil
+}
+
+func (w *Worker) complete(ctx context.Context, j job) error {
+	tx, err := w.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if j.reason == "unlink" && j.userID != nil {
+		if _, err = tx.Exec(ctx, `DELETE FROM apple_grants WHERE id=$1`, j.grantID); err != nil {
+			return err
+		}
+		if _, err = tx.Exec(ctx, `DELETE FROM user_identities WHERE user_id=$1 AND provider='apple' AND provider_user_id=$2 AND status='revocation_pending'`, *j.userID, j.subject); err != nil {
+			return err
+		}
+	} else if j.reason == "exchange_compensation" {
+		// Finalization uses the compensation job ID as the grant ID. A crash
+		// before disarm can therefore remove exactly the revoked grant, while a
+		// later successful retry has a different ID and is never touched.
+		if _, err = tx.Exec(ctx, `DELETE FROM apple_grants WHERE id=$1`, j.grantID); err != nil {
+			return err
+		}
+	}
+	_, err = tx.Exec(ctx, `UPDATE apple_revocation_jobs SET status='completed',completed_at=now(),updated_at=now(),last_error_class=NULL,token_ciphertext=NULL,token_nonce=NULL,encryption_key_id=NULL WHERE id=$1`, j.id)
+	if err == nil {
+		err = tx.Commit(ctx)
+	}
+	return err
+}
+
+func (w *Worker) retry(ctx context.Context, j job, cause error) error {
+	attempt := j.attempts + 1
+	status := "retry"
+	class := "provider_unavailable"
+	delay := time.Minute*time.Duration(1<<min(int(attempt), 8)) + time.Duration(rand.IntN(30))*time.Second
+	if errors.Is(cause, apple.ErrPermanent) {
+		status = "failed"
+		class = "provider_configuration"
+	} else if errors.Is(cause, apple.ErrGrantDecrypt) {
+		status = "failed"
+		class = "grant_decryption"
+	} else if attempt >= 10 {
+		status = "failed"
+		class = "retry_exhausted"
+	}
+	_, err := w.pool.Exec(ctx, `UPDATE apple_revocation_jobs SET status=$2,next_attempt_at=$3,last_error_class=$4,updated_at=now() WHERE id=$1`, j.id, status, w.now().Add(delay), class)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/auth/applejobs/worker_integration_test.go
+++ b/internal/auth/applejobs/worker_integration_test.go
@@ -1,0 +1,132 @@
+//go:build integration
+
+package applejobs
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/strelov1/freehire/internal/auth/apple"
+	"github.com/strelov1/freehire/internal/auth/mobileauth"
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+type recordingRevoker struct {
+	token, clientID string
+	calls           int
+}
+
+func (r *recordingRevoker) Revoke(_ context.Context, token, clientID string) error {
+	r.calls++
+	r.token, r.clientID = token, clientID
+	return nil
+}
+
+func TestWorkerRevokesThenRemovesGrantAndIdentity(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+	var userID int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users(email) VALUES('apple-worker@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	const subject, clientID, refresh = "apple-subject", "me.freehire.mobile", "refresh-secret"
+	if _, err := pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id,status) VALUES('apple',$1,$2,'revocation_pending')`, subject, userID); err != nil {
+		t.Fatal(err)
+	}
+	key := bytes.Repeat([]byte{9}, 32)
+	ring, err := apple.NewKeyRing("v1", map[string][]byte{"v1": key})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grantID := uuid.New()
+	ciphertext, nonce, keyID, err := ring.Encrypt([]byte(refresh), apple.GrantAAD("apple", subject, clientID, grantID.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO apple_grants(id,user_id,provider_user_id,client_id,refresh_token_ciphertext,refresh_token_nonce,encryption_key_id,revocation_requested_at) VALUES($1,$2,$3,$4,$5,$6,$7,now())`, grantID, userID, subject, clientID, ciphertext, nonce, keyID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO apple_revocation_jobs(idempotency_key,reason,source_user_id,source_provider,source_provider_user_id,token_aad_row_id,client_id,token_ciphertext,token_nonce,encryption_key_id) VALUES($1,'unlink',$2,'apple',$3,$4,$5,$6,$7,$8)`, "unlink:apple:"+grantID.String(), userID, subject, grantID, clientID, ciphertext, nonce, keyID); err != nil {
+		t.Fatal(err)
+	}
+	revoker := &recordingRevoker{}
+	processed, err := New(pool, revoker, ring).Run(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if processed != 1 || revoker.calls != 1 || revoker.token != refresh || revoker.clientID != clientID {
+		t.Fatalf("revocation mismatch: processed=%d revoker=%+v", processed, revoker)
+	}
+	var grants, identities int
+	if err = pool.QueryRow(ctx, `SELECT count(*) FROM apple_grants WHERE user_id=$1`, userID).Scan(&grants); err != nil {
+		t.Fatal(err)
+	}
+	if err = pool.QueryRow(ctx, `SELECT count(*) FROM user_identities WHERE user_id=$1 AND provider='apple'`, userID).Scan(&identities); err != nil {
+		t.Fatal(err)
+	}
+	var status string
+	var retainedCiphertext, retainedNonce []byte
+	var retainedKeyID *string
+	if err = pool.QueryRow(ctx, `SELECT status,token_ciphertext,token_nonce,encryption_key_id FROM apple_revocation_jobs WHERE idempotency_key=$1`, "unlink:apple:"+grantID.String()).Scan(&status, &retainedCiphertext, &retainedNonce, &retainedKeyID); err != nil {
+		t.Fatal(err)
+	}
+	if grants != 0 || identities != 0 || status != "completed" || retainedCiphertext != nil || retainedNonce != nil || retainedKeyID != nil {
+		t.Fatalf("completion not durable: grants=%d identities=%d status=%s", grants, identities, status)
+	}
+}
+
+func TestWorkerRevokesExchangeCompensationWithoutTouchingIdentity(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+	ring, err := apple.NewKeyRing("v1", map[string][]byte{"v1": bytes.Repeat([]byte{6}, 32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := mobileauth.NewStore(pool)
+	var userID int64
+	if err = pool.QueryRow(ctx, `INSERT INTO users(email,password_hash) VALUES('compensation@example.test','hash') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id) VALUES('apple','compensation-subject',$1)`, userID); err != nil {
+		t.Fatal(err)
+	}
+	jobID, err := store.CreateAppleCompensation(ctx, ring, "compensation-subject", "me.freehire.mobile", "orphan-refresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a crash after grant finalization but before compensation disarm.
+	if err = store.FinalizeAppleGrant(ctx, userID, "compensation-subject", "me.freehire.mobile", jobID); err != nil {
+		t.Fatal(err)
+	}
+	if err = store.ActivateAppleCompensation(ctx, jobID); err != nil {
+		t.Fatal(err)
+	}
+	revoker := &recordingRevoker{}
+	processed, err := New(pool, revoker, ring).Run(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if processed != 1 || revoker.token != "orphan-refresh" {
+		t.Fatalf("compensation not revoked: processed=%d revoker=%+v", processed, revoker)
+	}
+	var status, identityStatus string
+	var ciphertext []byte
+	if err = pool.QueryRow(ctx, `SELECT status,token_ciphertext FROM apple_revocation_jobs WHERE id=$1`, jobID).Scan(&status, &ciphertext); err != nil {
+		t.Fatal(err)
+	}
+	if status != "completed" || ciphertext != nil {
+		t.Fatalf("compensation retained secret: status=%s ciphertext=%x", status, ciphertext)
+	}
+	var grants int
+	if err = pool.QueryRow(ctx, `SELECT count(*) FROM apple_grants WHERE id=$1`, jobID).Scan(&grants); err != nil {
+		t.Fatal(err)
+	}
+	if err = pool.QueryRow(ctx, `SELECT status FROM user_identities WHERE user_id=$1 AND provider='apple'`, userID).Scan(&identityStatus); err != nil {
+		t.Fatal(err)
+	}
+	if grants != 0 || identityStatus != "active" {
+		t.Fatalf("compensation cleanup grants=%d identity=%s", grants, identityStatus)
+	}
+}

--- a/internal/auth/mobileauth/identities.go
+++ b/internal/auth/mobileauth/identities.go
@@ -1,0 +1,321 @@
+package mobileauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/strelov1/freehire/internal/auth/apple"
+	"github.com/strelov1/freehire/internal/pgerr"
+)
+
+var (
+	ErrLastMethod = errors.New("mobile auth: last sign-in method")
+	ErrState      = errors.New("mobile auth: identity state conflict")
+)
+
+type Identity struct {
+	Provider  string    `json:"provider"`
+	LinkedAt  time.Time `json:"linked_at"`
+	Status    string    `json:"status"`
+	CanUnlink bool      `json:"can_unlink"`
+}
+
+type IdentityList struct {
+	HasPassword bool       `json:"has_password"`
+	Identities  []Identity `json:"identities"`
+}
+
+func (s *Store) ListIdentities(ctx context.Context, userID int64) (IdentityList, error) {
+	var out IdentityList
+	if err := s.pool.QueryRow(ctx, `SELECT password_hash IS NOT NULL FROM users WHERE id=$1`, userID).Scan(&out.HasPassword); err != nil {
+		return out, err
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT provider,min(created_at),
+		       CASE WHEN bool_and(status='active') THEN 'active' ELSE 'revocation_pending' END
+		FROM user_identities WHERE user_id=$1
+		GROUP BY provider ORDER BY provider`, userID)
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var i Identity
+		if err := rows.Scan(&i.Provider, &i.LinkedAt, &i.Status); err != nil {
+			return out, err
+		}
+		out.Identities = append(out.Identities, i)
+	}
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+	active := 0
+	for _, i := range out.Identities {
+		if i.Status == "active" {
+			active++
+		}
+	}
+	for i := range out.Identities {
+		out.Identities[i].CanUnlink = out.Identities[i].Status == "active" && (out.HasPassword || active > 1)
+	}
+	return out, nil
+}
+
+const appleCompensationDelay = 15 * time.Minute
+
+// FinalizeAppleGrant serializes grant persistence with identity unlink. Both
+// paths lock the user and then the identity, so a login that resolves before an
+// unlink cannot overwrite the queued grant after the identity becomes pending.
+func (s *Store) FinalizeAppleGrant(ctx context.Context, userID int64, subject, clientID string, compensationID uuid.UUID) error {
+	if subject == "" || clientID == "" || compensationID == uuid.Nil {
+		return errors.New("mobile auth: incomplete Apple grant")
+	}
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		err = s.finalizeAppleGrantOnce(ctx, userID, subject, clientID, compensationID)
+		if !pgerr.IsSerializationFailure(err) {
+			return err
+		}
+	}
+	return err
+}
+
+func (s *Store) finalizeAppleGrantOnce(ctx context.Context, userID int64, subject, clientID string, compensationID uuid.UUID) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var lockedUser int64
+	if err = tx.QueryRow(ctx, `SELECT id FROM users WHERE id=$1 FOR UPDATE`, userID).Scan(&lockedUser); err != nil {
+		return err
+	}
+	var status string
+	if err = tx.QueryRow(ctx, `SELECT status FROM user_identities WHERE user_id=$1 AND provider='apple' AND provider_user_id=$2 FOR UPDATE`, userID, subject).Scan(&status); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrIdentity
+		}
+		return err
+	}
+	if status != "active" {
+		return ErrState
+	}
+	var ciphertext, nonce []byte
+	var keyID string
+	if err = tx.QueryRow(ctx, `
+		SELECT token_ciphertext,token_nonce,encryption_key_id
+		FROM apple_revocation_jobs
+		WHERE id=$1 AND reason='exchange_compensation' AND status='pending'
+		  AND source_provider='apple' AND source_provider_user_id=$2 AND client_id=$3
+		FOR UPDATE`, compensationID, subject, clientID).Scan(&ciphertext, &nonce, &keyID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrState
+		}
+		return err
+	}
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO apple_grants
+			(id,user_id,provider,provider_user_id,client_id,refresh_token_ciphertext,
+			 refresh_token_nonce,encryption_key_id)
+		VALUES($1,$2,'apple',$3,$4,$5,$6,$7)
+		ON CONFLICT(provider,provider_user_id) DO UPDATE SET
+			id=EXCLUDED.id,user_id=EXCLUDED.user_id,client_id=EXCLUDED.client_id,
+			refresh_token_ciphertext=EXCLUDED.refresh_token_ciphertext,
+			refresh_token_nonce=EXCLUDED.refresh_token_nonce,
+			encryption_key_id=EXCLUDED.encryption_key_id,updated_at=now(),
+			revocation_requested_at=NULL
+		WHERE apple_grants.user_id=EXCLUDED.user_id`, compensationID, userID, subject, clientID, ciphertext, nonce, keyID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrIdentity
+	}
+	return tx.Commit(ctx)
+}
+
+// CreateAppleCompensation takes durable custody of a newly exchanged refresh
+// token before any later database finalization can fail. The delayed job is
+// disarmed after a successful grant write; a crash leaves it safely revocable.
+func (s *Store) CreateAppleCompensation(ctx context.Context, ring *apple.KeyRing, subject, clientID, refreshToken string) (uuid.UUID, error) {
+	if ring == nil || subject == "" || clientID == "" || refreshToken == "" {
+		return uuid.Nil, errors.New("mobile auth: incomplete Apple compensation")
+	}
+	jobID := uuid.New()
+	aad := apple.GrantAAD("apple", subject, clientID, jobID.String())
+	ciphertext, nonce, keyID, err := ring.Encrypt([]byte(refreshToken), aad)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO apple_revocation_jobs
+			(id,idempotency_key,reason,source_provider,source_provider_user_id,
+			 token_aad_row_id,client_id,token_ciphertext,token_nonce,
+			 encryption_key_id,next_attempt_at)
+		VALUES($1,$2,'exchange_compensation','apple',$3,$1,$4,$5,$6,$7,$8)`,
+		jobID, "exchange-compensation:apple:"+jobID.String(), subject, clientID,
+		ciphertext, nonce, keyID, s.now().Add(appleCompensationDelay))
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return jobID, nil
+}
+
+// DisarmAppleCompensation retains only a secret-free idempotency tombstone.
+func (s *Store) DisarmAppleCompensation(ctx context.Context, jobID uuid.UUID) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE apple_revocation_jobs
+		SET status='completed',completed_at=now(),updated_at=now(),
+		    token_ciphertext=NULL,token_nonce=NULL,encryption_key_id=NULL
+		WHERE id=$1 AND reason='exchange_compensation' AND status IN ('pending','retry')`, jobID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrState
+	}
+	return nil
+}
+
+// ActivateAppleCompensation makes failed finalization eligible for immediate
+// worker pickup. Failure to activate is non-fatal because the delayed pending
+// job already remains durable.
+func (s *Store) ActivateAppleCompensation(ctx context.Context, jobID uuid.UUID) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE apple_revocation_jobs SET next_attempt_at=now(),updated_at=now()
+		WHERE id=$1 AND reason='exchange_compensation' AND status='pending'`, jobID)
+	return err
+}
+
+func proofDigest(raw string) []byte { sum := sha256.Sum256([]byte(raw)); return sum[:] }
+
+// UnlinkIdentity locks every sign-in method, consumes recent-auth, and either
+// removes a grantless identity or durably queues Apple revocation in one serializable transaction.
+func (s *Store) UnlinkIdentity(ctx context.Context, userID int64, tokenVersion int32, sessionHash []byte, provider, recentProof string) (pending bool, err error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		pending, err = s.unlinkIdentityOnce(ctx, userID, tokenVersion, sessionHash, provider, recentProof)
+		if !pgerr.IsSerializationFailure(err) {
+			return pending, err
+		}
+	}
+	return false, err
+}
+
+func (s *Store) unlinkIdentityOnce(ctx context.Context, userID int64, tokenVersion int32, sessionHash []byte, provider, recentProof string) (pending bool, err error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var hasPassword bool
+	if err = tx.QueryRow(ctx, `SELECT password_hash IS NOT NULL FROM users WHERE id=$1 FOR UPDATE`, userID).Scan(&hasPassword); err != nil {
+		return false, err
+	}
+	if len(sessionHash) != sha256.Size {
+		return false, ErrSession
+	}
+	tag, err := tx.Exec(ctx, `UPDATE recent_auth_proofs SET consumed_at=now() WHERE proof_hash=$1 AND user_id=$2 AND token_version=$3 AND session_hash=$4 AND consumed_at IS NULL AND expires_at>now()`, proofDigest(recentProof), userID, tokenVersion, sessionHash)
+	if err != nil {
+		return false, err
+	}
+	if tag.RowsAffected() != 1 {
+		return false, fmt.Errorf("%w", ErrSession)
+	}
+	rows, err := tx.Query(ctx, `SELECT provider,provider_user_id,status FROM user_identities WHERE user_id=$1 ORDER BY provider,provider_user_id FOR UPDATE`, userID)
+	if err != nil {
+		return false, err
+	}
+	activeProviders := map[string]bool{}
+	found := false
+	stateConflict := false
+	for rows.Next() {
+		var p, subject, st string
+		if err = rows.Scan(&p, &subject, &st); err != nil {
+			rows.Close()
+			return false, err
+		}
+		if st == "active" {
+			activeProviders[p] = true
+		}
+		if p == provider {
+			found = true
+			stateConflict = stateConflict || st != "active"
+		}
+	}
+	rows.Close()
+	if err = rows.Err(); err != nil {
+		return false, err
+	}
+	if !found {
+		return false, pgx.ErrNoRows
+	}
+	if stateConflict {
+		return false, ErrState
+	}
+	if !hasPassword && len(activeProviders) <= 1 {
+		return false, ErrLastMethod
+	}
+	if provider != "apple" {
+		_, err = tx.Exec(ctx, `DELETE FROM user_identities WHERE user_id=$1 AND provider=$2`, userID, provider)
+		if err == nil {
+			err = tx.Commit(ctx)
+		}
+		return false, err
+	}
+	type appleGrant struct {
+		id                       uuid.UUID
+		subject, clientID, keyID string
+		ciphertext, nonce        []byte
+	}
+	grantRows, err := tx.Query(ctx, `SELECT id,provider_user_id,client_id,refresh_token_ciphertext,refresh_token_nonce,encryption_key_id FROM apple_grants WHERE user_id=$1 AND provider='apple' ORDER BY provider_user_id FOR UPDATE`, userID)
+	if err != nil {
+		return false, err
+	}
+	var grants []appleGrant
+	for grantRows.Next() {
+		var grant appleGrant
+		if err = grantRows.Scan(&grant.id, &grant.subject, &grant.clientID, &grant.ciphertext, &grant.nonce, &grant.keyID); err != nil {
+			grantRows.Close()
+			return false, err
+		}
+		grants = append(grants, grant)
+	}
+	grantRows.Close()
+	if err = grantRows.Err(); err != nil {
+		return false, err
+	}
+	if len(grants) == 0 {
+		_, err = tx.Exec(ctx, `DELETE FROM user_identities WHERE user_id=$1 AND provider='apple'`, userID)
+		if err == nil {
+			err = tx.Commit(ctx)
+		}
+		return false, err
+	}
+	_, err = tx.Exec(ctx, `DELETE FROM user_identities ui WHERE ui.user_id=$1 AND ui.provider='apple' AND NOT EXISTS (SELECT 1 FROM apple_grants ag WHERE ag.user_id=ui.user_id AND ag.provider=ui.provider AND ag.provider_user_id=ui.provider_user_id)`, userID)
+	if err != nil {
+		return false, err
+	}
+	_, err = tx.Exec(ctx, `UPDATE user_identities SET status='revocation_pending',status_changed_at=now() WHERE user_id=$1 AND provider='apple'`, userID)
+	if err != nil {
+		return false, err
+	}
+	for _, grant := range grants {
+		idempotency := "unlink:apple:" + grant.id.String()
+		_, err = tx.Exec(ctx, `INSERT INTO apple_revocation_jobs(idempotency_key,reason,source_user_id,source_provider,source_provider_user_id,token_aad_row_id,client_id,token_ciphertext,token_nonce,encryption_key_id) VALUES($1,'unlink',$2,'apple',$3,$4,$5,$6,$7,$8) ON CONFLICT(idempotency_key) DO NOTHING`, idempotency, userID, grant.subject, grant.id, grant.clientID, grant.ciphertext, grant.nonce, grant.keyID)
+		if err != nil {
+			return false, err
+		}
+		if _, err = tx.Exec(ctx, `UPDATE apple_grants SET revocation_requested_at=now() WHERE id=$1`, grant.id); err != nil {
+			return false, err
+		}
+	}
+	if err == nil {
+		err = tx.Commit(ctx)
+	}
+	return true, err
+}

--- a/internal/auth/mobileauth/store.go
+++ b/internal/auth/mobileauth/store.go
@@ -1,0 +1,344 @@
+// Package mobileauth owns the durable, verifier-bound hand-off used by native
+// OAuth clients. Raw credentials are returned once and only their SHA-256 hashes
+// are persisted.
+package mobileauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	AttemptTTL = 10 * time.Minute
+	CodeTTL    = time.Minute
+)
+
+var (
+	ErrInvalid       = errors.New("mobile auth: invalid or expired credential")
+	ErrVerifier      = errors.New("mobile auth: invalid verifier")
+	ErrSession       = errors.New("mobile auth: session binding mismatch")
+	ErrIdentity      = errors.New("mobile auth: reauthentication identity mismatch")
+	verifierPattern  = regexp.MustCompile(`^[A-Za-z0-9._~-]{43,128}$`)
+	challengePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{43}$`)
+)
+
+type Binding struct {
+	UserID       int64
+	TokenVersion int32
+	SessionHash  []byte
+}
+
+type Attempt struct {
+	ID                   uuid.UUID
+	Provider             string
+	Platform             string
+	CallbackTarget       string
+	Purpose              string
+	CodeChallenge        string
+	NonceChallenge       string
+	AllowedAudiences     []string
+	ExpectedUserID       *int64
+	ExpectedTokenVersion *int32
+	ExpectedSessionHash  []byte
+	ExpiresAt            time.Time
+}
+
+type Exchange struct {
+	UserID               int64
+	Purpose              string
+	ExpectedUserID       *int64
+	ExpectedTokenVersion *int32
+	ExpectedSessionHash  []byte
+}
+
+type Store struct {
+	pool *pgxpool.Pool
+	now  func() time.Time
+}
+
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool, now: time.Now} }
+
+func ValidateChallenge(challenge, method string) error {
+	if method != "S256" || !challengePattern.MatchString(challenge) {
+		return ErrVerifier
+	}
+	return nil
+}
+
+func ValidateVerifier(verifier string) error {
+	if !verifierPattern.MatchString(verifier) {
+		return ErrVerifier
+	}
+	return nil
+}
+
+func Challenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func randomCredential() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func digest(value string) []byte {
+	sum := sha256.Sum256([]byte(value))
+	return sum[:]
+}
+
+func bindingValues(binding *Binding) (any, any, any) {
+	if binding == nil {
+		return nil, nil, nil
+	}
+	return binding.UserID, binding.TokenVersion, binding.SessionHash
+}
+
+func validatePurpose(purpose string, binding *Binding) error {
+	if purpose != "sign_in" && purpose != "reauth" {
+		return ErrInvalid
+	}
+	if (purpose == "reauth") != (binding != nil) {
+		return ErrSession
+	}
+	if binding != nil && (binding.UserID <= 0 || len(binding.SessionHash) != sha256.Size) {
+		return ErrSession
+	}
+	return nil
+}
+
+// CreateBrowserAttempt stores a v2 attempt and returns its raw browser state.
+func (s *Store) CreateBrowserAttempt(ctx context.Context, provider, platform, callbackTarget, purpose, challenge string, binding *Binding) (Attempt, string, error) {
+	validPlatform := platform == "ios" || platform == "android" || (platform == "web" && purpose == "reauth")
+	if provider == "" || !validPlatform || callbackTarget == "" || (provider == "apple" && platform != "web") {
+		return Attempt{}, "", ErrInvalid
+	}
+	if err := validatePurpose(purpose, binding); err != nil {
+		return Attempt{}, "", err
+	}
+	if err := ValidateChallenge(challenge, "S256"); err != nil {
+		return Attempt{}, "", err
+	}
+	state, err := randomCredential()
+	if err != nil {
+		return Attempt{}, "", err
+	}
+	expires := s.now().Add(AttemptTTL)
+	uid, version, sessionHash := bindingValues(binding)
+	var a Attempt
+	err = s.pool.QueryRow(ctx, `
+		INSERT INTO oauth_auth_attempts
+			(state_hash, provider, platform, callback_target, purpose,
+			 code_challenge, code_challenge_method, expected_user_id,
+			 expected_token_version, expected_session_hash, expires_at)
+		VALUES ($1,$2,$3,$4,$5,$6,'S256',$7,$8,$9,$10)
+		RETURNING id, provider, platform, callback_target, purpose,
+		          code_challenge, expires_at`,
+		digest(state), provider, platform, callbackTarget, purpose, challenge, uid, version, sessionHash, expires,
+	).Scan(&a.ID, &a.Provider, &a.Platform, &a.CallbackTarget, &a.Purpose, &a.CodeChallenge, &a.ExpiresAt)
+	return a, state, err
+}
+
+// ConsumeBrowserAttempt atomically validates and burns state. A callback can
+// therefore resolve at most one account across any number of replicas.
+func (s *Store) ConsumeBrowserAttempt(ctx context.Context, state, provider string) (Attempt, error) {
+	if state == "" || provider == "" {
+		return Attempt{}, ErrInvalid
+	}
+	var a Attempt
+	var uid *int64
+	var version *int32
+	err := s.pool.QueryRow(ctx, `
+		UPDATE oauth_auth_attempts
+		SET consumed_at = now()
+		WHERE state_hash = $1 AND provider = $2 AND protocol_version = 2
+		  AND consumed_at IS NULL AND expires_at > now() AND callback_target <> 'native_apple'
+		RETURNING id, provider, platform, callback_target, purpose,
+		          code_challenge, expected_user_id, expected_token_version,
+		          expected_session_hash, expires_at`,
+		digest(state), provider,
+	).Scan(&a.ID, &a.Provider, &a.Platform, &a.CallbackTarget, &a.Purpose,
+		&a.CodeChallenge, &uid, &version, &a.ExpectedSessionHash, &a.ExpiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Attempt{}, ErrInvalid
+	}
+	a.ExpectedUserID, a.ExpectedTokenVersion = uid, version
+	return a, err
+}
+
+// CreateAppleAttempt stores the nonce challenge to which the signed Apple token
+// must later bind.
+func (s *Store) CreateAppleAttempt(ctx context.Context, nonceChallenge, purpose string, audiences []string, binding *Binding) (Attempt, error) {
+	if !challengePattern.MatchString(nonceChallenge) || len(audiences) == 0 {
+		return Attempt{}, ErrVerifier
+	}
+	if err := validatePurpose(purpose, binding); err != nil {
+		return Attempt{}, err
+	}
+	expires := s.now().Add(AttemptTTL)
+	uid, version, sessionHash := bindingValues(binding)
+	var a Attempt
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO oauth_auth_attempts
+			(provider, platform, callback_target, purpose, nonce_challenge, allowed_audiences,
+			 expected_user_id, expected_token_version, expected_session_hash, expires_at)
+		VALUES ('apple','ios','native_apple',$1,$2,$3,$4,$5,$6,$7)
+		RETURNING id, provider, platform, callback_target, purpose,
+		          nonce_challenge, allowed_audiences, expected_user_id,
+		          expected_token_version, expected_session_hash, expires_at`,
+		purpose, nonceChallenge, audiences, uid, version, sessionHash, expires,
+	).Scan(&a.ID, &a.Provider, &a.Platform, &a.CallbackTarget, &a.Purpose,
+		&a.NonceChallenge, &a.AllowedAudiences, &a.ExpectedUserID,
+		&a.ExpectedTokenVersion, &a.ExpectedSessionHash, &a.ExpiresAt)
+	return a, err
+}
+
+// ConsumeAppleAttempt burns the attempt before any remote exchange, preventing
+// replay even when Apple returns a retryable error.
+func (s *Store) ConsumeAppleAttempt(ctx context.Context, id uuid.UUID) (Attempt, error) {
+	var a Attempt
+	err := s.pool.QueryRow(ctx, `
+		UPDATE oauth_auth_attempts SET consumed_at = now()
+		WHERE id = $1 AND provider = 'apple' AND consumed_at IS NULL AND expires_at > now()
+		RETURNING id, provider, platform, callback_target, purpose,
+		          nonce_challenge, allowed_audiences, expected_user_id,
+		          expected_token_version, expected_session_hash, expires_at`, id,
+	).Scan(&a.ID, &a.Provider, &a.Platform, &a.CallbackTarget, &a.Purpose,
+		&a.NonceChallenge, &a.AllowedAudiences, &a.ExpectedUserID,
+		&a.ExpectedTokenVersion, &a.ExpectedSessionHash, &a.ExpiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Attempt{}, ErrInvalid
+	}
+	return a, err
+}
+
+func (s *Store) MintCode(ctx context.Context, a Attempt, userID int64) (string, error) {
+	code, err := randomCredential()
+	if err != nil {
+		return "", err
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO oauth_exchange_codes
+			(code_hash, user_id, source_attempt_id, code_challenge,
+			 code_challenge_method, purpose, expected_user_id,
+			 expected_token_version, expected_session_hash, expires_at)
+		VALUES ($1,$2,$3,$4,'S256',$5,$6,$7,$8,$9)`,
+		digest(code), userID, a.ID, a.CodeChallenge, a.Purpose,
+		a.ExpectedUserID, a.ExpectedTokenVersion, a.ExpectedSessionHash, s.now().Add(CodeTTL))
+	return code, err
+}
+
+// ConsumeCode always burns a live code, including on verifier mismatch.
+func (s *Store) ConsumeCode(ctx context.Context, code, verifier string) (Exchange, error) {
+	if code == "" {
+		return Exchange{}, ErrInvalid
+	}
+	var e Exchange
+	var storedChallenge string
+	err := s.pool.QueryRow(ctx, `
+		UPDATE oauth_exchange_codes SET consumed_at = now()
+		WHERE code_hash = $1 AND consumed_at IS NULL AND expires_at > now()
+		RETURNING user_id, purpose, code_challenge,
+		          expected_user_id, expected_token_version,
+		          expected_session_hash`, digest(code),
+	).Scan(&e.UserID, &e.Purpose, &storedChallenge,
+		&e.ExpectedUserID, &e.ExpectedTokenVersion, &e.ExpectedSessionHash)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Exchange{}, ErrInvalid
+	}
+	if err != nil {
+		return Exchange{}, err
+	}
+	if err := ValidateVerifier(verifier); err != nil {
+		return Exchange{}, ErrVerifier
+	}
+	actual := Challenge(verifier)
+	if subtle.ConstantTimeCompare([]byte(actual), []byte(storedChallenge)) != 1 {
+		return Exchange{}, ErrVerifier
+	}
+	if e.Purpose == "reauth" && (e.ExpectedUserID == nil || *e.ExpectedUserID != e.UserID || len(e.ExpectedSessionHash) != sha256.Size) {
+		return Exchange{}, ErrIdentity
+	}
+	return e, nil
+}
+
+func (s *Store) VerifyBinding(ctx context.Context, userID int64, expectedVersion int32) error {
+	var version int32
+	if err := s.pool.QueryRow(ctx, `SELECT token_version FROM users WHERE id=$1`, userID).Scan(&version); err != nil {
+		return err
+	}
+	if version != expectedVersion {
+		return ErrSession
+	}
+	return nil
+}
+
+func (s *Store) IdentityOwner(ctx context.Context, provider, providerUserID string) (int64, error) {
+	var id int64
+	err := s.pool.QueryRow(ctx, `
+		SELECT user_id FROM user_identities
+		WHERE provider=$1 AND provider_user_id=$2 AND status='active'`, provider, providerUserID).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, ErrIdentity
+	}
+	return id, err
+}
+
+func (a Attempt) CheckExpectedUser(userID int64) error {
+	if a.Purpose == "reauth" && (a.ExpectedUserID == nil || *a.ExpectedUserID != userID) {
+		return fmt.Errorf("%w", ErrIdentity)
+	}
+	return nil
+}
+
+// Cleanup deletes bounded batches of expired ephemeral credentials.
+func (s *Store) Cleanup(ctx context.Context, limit int) (int64, error) {
+	if limit <= 0 || limit > 10_000 {
+		limit = 1000
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var total int64
+	queries := []string{
+		`DELETE FROM oauth_exchange_codes WHERE ctid IN
+			(SELECT ctid FROM oauth_exchange_codes WHERE expires_at < now() ORDER BY expires_at LIMIT $1)`,
+		`DELETE FROM oauth_auth_attempts a WHERE a.id IN
+			(SELECT candidate.id FROM oauth_auth_attempts candidate
+			 WHERE candidate.expires_at < now()
+			   AND NOT EXISTS (
+			       SELECT 1 FROM oauth_exchange_codes code
+			       WHERE code.source_attempt_id=candidate.id
+			         AND code.consumed_at IS NULL AND code.expires_at > now())
+			 ORDER BY candidate.expires_at LIMIT $1)`,
+		`DELETE FROM recent_auth_proofs WHERE ctid IN
+			(SELECT ctid FROM recent_auth_proofs WHERE expires_at < now() ORDER BY expires_at LIMIT $1)`,
+	}
+	for _, q := range queries {
+		tag, err := tx.Exec(ctx, q, limit)
+		if err != nil {
+			return 0, err
+		}
+		total += tag.RowsAffected()
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return total, nil
+}

--- a/internal/auth/mobileauth/store_integration_test.go
+++ b/internal/auth/mobileauth/store_integration_test.go
@@ -1,0 +1,265 @@
+//go:build integration
+
+package mobileauth
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/auth/apple"
+	"github.com/strelov1/freehire/internal/auth/recentauth"
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+func seedAuthUser(t *testing.T, password bool) (context.Context, int64, *Store) {
+	t.Helper()
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+	var userID int64
+	var err error
+	if password {
+		err = pool.QueryRow(ctx, `INSERT INTO users(email,password_hash) VALUES('mobile-auth@example.test','hash') RETURNING id`).Scan(&userID)
+	} else {
+		err = pool.QueryRow(ctx, `INSERT INTO users(email) VALUES('mobile-auth@example.test') RETURNING id`).Scan(&userID)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ctx, userID, NewStore(pool)
+}
+
+func persistAppleGrant(t *testing.T, ctx context.Context, store *Store, ring *apple.KeyRing, userID int64, subject, clientID, refreshToken string) {
+	t.Helper()
+	jobID, err := store.CreateAppleCompensation(ctx, ring, subject, clientID, refreshToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = store.FinalizeAppleGrant(ctx, userID, subject, clientID, jobID); err != nil {
+		t.Fatal(err)
+	}
+	if err = store.DisarmAppleCompensation(ctx, jobID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReauthCodeCarriesExactSessionBindingAndBurnsOnce(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, true)
+	verifier := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+	sessionHash := bytes.Repeat([]byte{7}, 32)
+	binding := &Binding{UserID: userID, TokenVersion: 1, SessionHash: sessionHash}
+	attempt, state, err := store.CreateBrowserAttempt(ctx, "google", "web", "web", "reauth", Challenge(verifier), binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempt, err = store.ConsumeBrowserAttempt(ctx, state, "google")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(attempt.ExpectedSessionHash, sessionHash) {
+		t.Fatal("attempt lost its session binding")
+	}
+	code, err := store.MintCode(ctx, attempt, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exchange, err := store.ConsumeCode(ctx, code, verifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(exchange.ExpectedSessionHash, sessionHash) {
+		t.Fatal("exchange code lost its session binding")
+	}
+	if _, err = store.ConsumeCode(ctx, code, verifier); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("replayed code accepted: %v", err)
+	}
+}
+
+func TestAppleWebReauthUsesBrowserAttemptNamespace(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, true)
+	verifier := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+	binding := &Binding{UserID: userID, TokenVersion: 1, SessionHash: bytes.Repeat([]byte{8}, 32)}
+	_, state, err := store.CreateBrowserAttempt(ctx, "apple", "web", "web", "reauth", Challenge(verifier), binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.ConsumeBrowserAttempt(ctx, state, "apple"); err != nil {
+		t.Fatalf("Apple Services-ID reauth could not consume browser attempt: %v", err)
+	}
+}
+
+func TestUnlinkCountsProviderAsOneUsableMethod(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, false)
+	pool := store.pool
+	for _, subject := range []string{"google-one", "google-two"} {
+		if _, err := pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id) VALUES('google',$1,$2)`, subject, userID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sessionHash := bytes.Repeat([]byte{3}, 32)
+	proof, _, err := recentauth.NewStore(pool, 0).Issue(ctx, userID, 1, sessionHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.UnlinkIdentity(ctx, userID, 1, sessionHash, "google", proof); !errors.Is(err, ErrLastMethod) {
+		t.Fatalf("same-provider rows bypassed last-method guard: %v", err)
+	}
+	var count int
+	if err = pool.QueryRow(ctx, `SELECT count(*) FROM user_identities WHERE user_id=$1`, userID).Scan(&count); err != nil || count != 2 {
+		t.Fatalf("failed unlink changed identities: count=%d err=%v", count, err)
+	}
+}
+
+func TestFinalizeAppleGrantCannotOverwritePendingUnlink(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, true)
+	const subject, clientID = "apple-race-subject", "me.freehire.mobile"
+	if _, err := store.pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id) VALUES('apple',$1,$2)`, subject, userID); err != nil {
+		t.Fatal(err)
+	}
+	ring, err := apple.NewKeyRing("v1", map[string][]byte{"v1": bytes.Repeat([]byte{4}, 32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	persistAppleGrant(t, ctx, store, ring, userID, subject, clientID, "old-refresh")
+	var originalID string
+	if err = store.pool.QueryRow(ctx, `SELECT id::text FROM apple_grants WHERE provider_user_id=$1`, subject).Scan(&originalID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold the same first lock UnlinkIdentity takes. FinalizeAppleGrant must wait,
+	// then observe the pending identity rather than replacing its queued grant.
+	blocker, err := store.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = blocker.Exec(ctx, `SELECT id FROM users WHERE id=$1 FOR UPDATE`, userID); err != nil {
+		t.Fatal(err)
+	}
+	result := make(chan error, 1)
+	newCompensation, err := store.CreateAppleCompensation(ctx, ring, subject, clientID, "new-refresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { result <- store.FinalizeAppleGrant(ctx, userID, subject, clientID, newCompensation) }()
+	if _, err = blocker.Exec(ctx, `UPDATE user_identities SET status='revocation_pending',status_changed_at=now() WHERE user_id=$1 AND provider='apple'`, userID); err != nil {
+		t.Fatal(err)
+	}
+	if err = blocker.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err = <-result:
+		if !errors.Is(err, ErrState) {
+			t.Fatalf("finalize err=%v, want ErrState", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("grant finalization remained blocked")
+	}
+	var finalID string
+	if err = store.pool.QueryRow(ctx, `SELECT id::text FROM apple_grants WHERE provider_user_id=$1`, subject).Scan(&finalID); err != nil {
+		t.Fatal(err)
+	}
+	if finalID != originalID {
+		t.Fatalf("pending unlink grant replaced: before=%s after=%s", originalID, finalID)
+	}
+}
+
+func TestConcurrentAppleFinalizeAndUnlinkPreserveQueuedGrant(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, true)
+	const subject, clientID = "apple-concurrent-subject", "me.freehire.mobile"
+	ring, err := apple.NewKeyRing("v1", map[string][]byte{"v1": bytes.Repeat([]byte{5}, 32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for round := 0; round < 10; round++ {
+		if _, err = store.pool.Exec(ctx, `DELETE FROM apple_revocation_jobs`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err = store.pool.Exec(ctx, `DELETE FROM apple_grants`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err = store.pool.Exec(ctx, `DELETE FROM user_identities WHERE user_id=$1`, userID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err = store.pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id) VALUES('apple',$1,$2)`, subject, userID); err != nil {
+			t.Fatal(err)
+		}
+		persistAppleGrant(t, ctx, store, ring, userID, subject, clientID, "old-refresh")
+		sessionHash := bytes.Repeat([]byte{byte(round + 1)}, 32)
+		proof, _, issueErr := recentauth.NewStore(store.pool, 0).Issue(ctx, userID, 1, sessionHash)
+		if issueErr != nil {
+			t.Fatal(issueErr)
+		}
+		start := make(chan struct{})
+		unlinkResult := make(chan error, 1)
+		finalizeResult := make(chan error, 1)
+		newCompensation, createErr := store.CreateAppleCompensation(ctx, ring, subject, clientID, "new-refresh")
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		go func() {
+			<-start
+			_, unlinkErr := store.UnlinkIdentity(ctx, userID, 1, sessionHash, "apple", proof)
+			unlinkResult <- unlinkErr
+		}()
+		go func() {
+			<-start
+			finalizeResult <- store.FinalizeAppleGrant(ctx, userID, subject, clientID, newCompensation)
+		}()
+		close(start)
+		unlinkErr, finalizeErr := <-unlinkResult, <-finalizeResult
+
+		var status string
+		if err = store.pool.QueryRow(ctx, `SELECT status FROM user_identities WHERE user_id=$1 AND provider='apple'`, userID).Scan(&status); err != nil {
+			t.Fatalf("round %d identity: unlink=%v finalize=%v query=%v", round, unlinkErr, finalizeErr, err)
+		}
+		if status != "revocation_pending" {
+			continue
+		}
+		var matching int
+		if err = store.pool.QueryRow(ctx, `
+			SELECT count(*) FROM apple_grants grant_row
+			JOIN apple_revocation_jobs job ON job.token_aad_row_id=grant_row.id
+			WHERE grant_row.user_id=$1 AND job.reason='unlink'
+			  AND job.status IN ('pending','processing','retry')`, userID).Scan(&matching); err != nil {
+			t.Fatal(err)
+		}
+		if matching != 1 {
+			t.Fatalf("round %d pending identity lost queued grant: unlink=%v finalize=%v matching=%d", round, unlinkErr, finalizeErr, matching)
+		}
+	}
+}
+
+func TestCleanupPreservesAttemptWithLiveExchangeCode(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, true)
+	verifier := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+	attempt, state, err := store.CreateBrowserAttempt(ctx, "google", "ios", "ios", "sign_in", Challenge(verifier), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempt, err = store.ConsumeBrowserAttempt(ctx, state, "google")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.MintCode(ctx, attempt, userID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.pool.Exec(ctx, `UPDATE oauth_auth_attempts SET expires_at=now()-interval '1 second' WHERE id=$1`, attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.Cleanup(ctx, 100); err != nil {
+		t.Fatal(err)
+	}
+	var attempts, codes int
+	if err = store.pool.QueryRow(ctx, `SELECT count(*) FROM oauth_auth_attempts WHERE id=$1`, attempt.ID).Scan(&attempts); err != nil {
+		t.Fatal(err)
+	}
+	if err = store.pool.QueryRow(ctx, `SELECT count(*) FROM oauth_exchange_codes WHERE source_attempt_id=$1 AND expires_at>now()`, attempt.ID).Scan(&codes); err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 1 || codes != 1 {
+		t.Fatalf("cleanup burned live exchange: attempts=%d codes=%d", attempts, codes)
+	}
+}

--- a/internal/auth/mobileauth/store_test.go
+++ b/internal/auth/mobileauth/store_test.go
@@ -1,0 +1,32 @@
+package mobileauth
+
+import "testing"
+
+func TestChallengeRFC7636Vector(t *testing.T) {
+	const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	const want = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+	if got := Challenge(verifier); got != want {
+		t.Fatalf("Challenge()=%q want %q", got, want)
+	}
+}
+
+func TestVerifierAndChallengeBounds(t *testing.T) {
+	valid := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+	if len(valid) != 43 {
+		t.Fatal("fixture")
+	}
+	if err := ValidateVerifier(valid); err != nil {
+		t.Fatalf("valid verifier: %v", err)
+	}
+	for _, bad := range []string{valid[:42], valid + valid + valid, "abc=def"} {
+		if ValidateVerifier(bad) == nil {
+			t.Errorf("accepted %q", bad)
+		}
+	}
+	if ValidateChallenge(Challenge(valid), "S256") != nil {
+		t.Fatal("valid challenge rejected")
+	}
+	if ValidateChallenge(Challenge(valid), "plain") == nil {
+		t.Fatal("plain accepted")
+	}
+}

--- a/internal/auth/oauth/apple.go
+++ b/internal/auth/oauth/apple.go
@@ -247,6 +247,9 @@ func verifyAppleIDToken(ctx context.Context, client *http.Client, jwksURL, clien
 	var claims appleIDTokenClaims
 	_, err := jwt.ParseWithClaims(idToken, &claims, func(tok *jwt.Token) (any, error) {
 		kid, _ := tok.Header["kid"].(string)
+		if kid == "" {
+			return nil, fmt.Errorf("apple: id_token has no kid")
+		}
 		keys, err := fetchAppleJWKS(ctx, client, jwksURL)
 		if err != nil {
 			return nil, err
@@ -257,9 +260,12 @@ func verifyAppleIDToken(ctx context.Context, client *http.Client, jwksURL, clien
 			}
 		}
 		return nil, fmt.Errorf("apple: no matching RSA signing key for kid %q", kid)
-	}, jwt.WithValidMethods([]string{"RS256"}), jwt.WithAudience(clientID), jwt.WithIssuer(appleIssuer))
+	}, jwt.WithValidMethods([]string{"RS256"}), jwt.WithAudience(clientID), jwt.WithIssuer(appleIssuer), jwt.WithExpirationRequired(), jwt.WithIssuedAt(), jwt.WithLeeway(30*time.Second))
 	if err != nil {
 		return appleIDTokenClaims{}, fmt.Errorf("apple: verify id_token: %w", err)
+	}
+	if claims.Subject == "" {
+		return appleIDTokenClaims{}, fmt.Errorf("apple: id_token has no sub")
 	}
 	return claims, nil
 }

--- a/internal/auth/oauth/oauth.go
+++ b/internal/auth/oauth/oauth.go
@@ -98,3 +98,14 @@ func (r *Registry) Provider(name, origin string) (Provider, bool) {
 	}
 	return constructors[name](c, origin+"/api/v1/auth/oauth/"+name+"/callback"), true
 }
+
+// ProviderV2 builds a browser provider for the verifier-bound native flow.
+// Apple is used here only by the same-origin web recent-auth adapter; native
+// clients use their SDK plus the dedicated nonce-bound exchange endpoint.
+func (r *Registry) ProviderV2(name, origin string) (Provider, bool) {
+	c, ok := r.creds[name]
+	if !ok {
+		return nil, false
+	}
+	return constructors[name](c, origin+"/api/v2/auth/oauth/"+name+"/callback"), true
+}

--- a/internal/auth/recentauth/cookie_test.go
+++ b/internal/auth/recentauth/cookie_test.go
@@ -1,0 +1,45 @@
+package recentauth
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestRecentAuthCookieAttributes(t *testing.T) {
+	app := fiber.New()
+	app.Get("/set", func(c *fiber.Ctx) error {
+		SetCookie(c, "proof", time.Now().Add(time.Minute), true, "freehire.me")
+		return c.SendStatus(204)
+	})
+	resp, err := app.Test(httptest.NewRequest("GET", "/set", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := strings.Join(resp.Header.Values("Set-Cookie"), "\n")
+	lower := strings.ToLower(header)
+	for _, want := range []string{CookieName + "=proof", "path=/", "domain=freehire.me", "httponly", "secure", "samesite=lax"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("Set-Cookie %q missing %q", header, want)
+		}
+	}
+}
+
+func TestClearRecentAuthCookieExpiresSameName(t *testing.T) {
+	app := fiber.New()
+	app.Get("/clear", func(c *fiber.Ctx) error {
+		ClearCookie(c, false, "")
+		return c.SendStatus(204)
+	})
+	resp, err := app.Test(httptest.NewRequest("GET", "/clear", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := strings.Join(resp.Header.Values("Set-Cookie"), "\n")
+	if !strings.Contains(header, CookieName+"=") || !strings.Contains(strings.ToLower(header), "expires=") {
+		t.Fatalf("clear cookie is incomplete: %q", header)
+	}
+}

--- a/internal/auth/recentauth/recentauth.go
+++ b/internal/auth/recentauth/recentauth.go
@@ -1,0 +1,113 @@
+// Package recentauth implements a separate, short-lived proof of recent
+// credential control. It never accepts API-key or bearer authentication.
+package recentauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	CookieName = "hire_recent_auth"
+	DefaultTTL = 10 * time.Minute
+)
+
+var ErrRequired = errors.New("recent authentication required")
+
+type Store struct {
+	pool *pgxpool.Pool
+	ttl  time.Duration
+	now  func() time.Time
+}
+
+func NewStore(pool *pgxpool.Pool, ttl time.Duration) *Store {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	return &Store{pool: pool, ttl: ttl, now: time.Now}
+}
+
+func hash(raw string) []byte {
+	sum := sha256.Sum256([]byte(raw))
+	return sum[:]
+}
+
+func (s *Store) Issue(ctx context.Context, userID int64, tokenVersion int32, sessionHash []byte) (string, time.Time, error) {
+	if len(sessionHash) != sha256.Size {
+		return "", time.Time{}, ErrRequired
+	}
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", time.Time{}, err
+	}
+	raw := base64.RawURLEncoding.EncodeToString(b)
+	expires := s.now().Add(s.ttl)
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO recent_auth_proofs (proof_hash,user_id,token_version,session_hash,expires_at)
+		VALUES ($1,$2,$3,$4,$5)`, hash(raw), userID, tokenVersion, sessionHash, expires)
+	return raw, expires, err
+}
+
+func (s *Store) Validate(ctx context.Context, raw string, userID int64, tokenVersion int32, sessionHash []byte) error {
+	if raw == "" || len(sessionHash) != sha256.Size {
+		return ErrRequired
+	}
+	var stored []byte
+	err := s.pool.QueryRow(ctx, `
+		SELECT proof_hash FROM recent_auth_proofs
+		WHERE proof_hash=$1 AND user_id=$2 AND token_version=$3 AND session_hash=$4
+		  AND consumed_at IS NULL AND expires_at > now()`, hash(raw), userID, tokenVersion, sessionHash).Scan(&stored)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrRequired
+	}
+	if err != nil {
+		return err
+	}
+	if subtle.ConstantTimeCompare(stored, hash(raw)) != 1 {
+		return ErrRequired
+	}
+	return nil
+}
+
+func (s *Store) Consume(ctx context.Context, raw string, userID int64, tokenVersion int32, sessionHash []byte) error {
+	if raw == "" || len(sessionHash) != sha256.Size {
+		return ErrRequired
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE recent_auth_proofs SET consumed_at=now()
+		WHERE proof_hash=$1 AND user_id=$2 AND token_version=$3 AND session_hash=$4
+		  AND consumed_at IS NULL AND expires_at > now()`, hash(raw), userID, tokenVersion, sessionHash)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrRequired
+	}
+	return nil
+}
+
+func (s *Store) Revoke(ctx context.Context, raw string) error {
+	if raw == "" {
+		return nil
+	}
+	_, err := s.pool.Exec(ctx, `UPDATE recent_auth_proofs SET consumed_at=now() WHERE proof_hash=$1 AND consumed_at IS NULL`, hash(raw))
+	return err
+}
+
+func SetCookie(c *fiber.Ctx, raw string, expires time.Time, secure bool, domain string) {
+	c.Cookie(&fiber.Cookie{Name: CookieName, Value: raw, Path: "/", Domain: domain,
+		Expires: expires, HTTPOnly: true, Secure: secure, SameSite: fiber.CookieSameSiteLaxMode})
+}
+
+func ClearCookie(c *fiber.Ctx, secure bool, domain string) {
+	SetCookie(c, "", time.Now().Add(-time.Hour), secure, domain)
+}

--- a/internal/auth/recentauth/recentauth_integration_test.go
+++ b/internal/auth/recentauth/recentauth_integration_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+package recentauth
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+func TestProofIsBoundToExactSessionAndSingleUse(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+	var userID int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users(email) VALUES('recent-auth@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStore(pool, 0)
+	sessionA := bytes.Repeat([]byte{1}, 32)
+	sessionB := bytes.Repeat([]byte{2}, 32)
+	raw, _, err := store.Issue(ctx, userID, 1, sessionA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = store.Validate(ctx, raw, userID, 1, sessionA); err != nil {
+		t.Fatalf("correct session rejected: %v", err)
+	}
+	if err = store.Validate(ctx, raw, userID, 1, sessionB); !errors.Is(err, ErrRequired) {
+		t.Fatalf("other session accepted: %v", err)
+	}
+	if err = store.Consume(ctx, raw, userID, 1, sessionA); err != nil {
+		t.Fatal(err)
+	}
+	if err = store.Validate(ctx, raw, userID, 1, sessionA); !errors.Is(err, ErrRequired) {
+		t.Fatalf("consumed proof accepted: %v", err)
+	}
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -1,6 +1,9 @@
 package auth
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strconv"
@@ -34,6 +37,11 @@ type sessionClaims struct {
 // "revoked by the release" apart from "forged".
 var ErrNoTokenVersion = errors.New("auth: token carries no version claim")
 
+// ErrNoSessionID reports a valid legacy session minted before per-session JTIs
+// were introduced. Such a token may remain usable for ordinary requests during
+// rollout, but it cannot safely bind a recent-auth proof until it is rotated.
+var ErrNoSessionID = errors.New("auth: token carries no session id")
+
 // NewIssuer returns an Issuer signing with secret and stamping each token to
 // expire after ttl.
 func NewIssuer(secret string, ttl time.Duration) *Issuer {
@@ -47,10 +55,15 @@ func (i *Issuer) TTL() time.Duration { return i.ttl }
 // Issue returns a signed token for userID stamped with the account's current
 // tokenVersion, expiring after the Issuer's TTL.
 func (i *Issuer) Issue(userID int64, tokenVersion int32) (string, error) {
+	sessionIDBytes := make([]byte, 16)
+	if _, err := rand.Read(sessionIDBytes); err != nil {
+		return "", fmt.Errorf("generate session id: %w", err)
+	}
 	now := time.Now()
 	claims := sessionClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   strconv.FormatInt(userID, 10),
+			ID:        base64.RawURLEncoding.EncodeToString(sessionIDBytes),
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(i.ttl)),
 		},
@@ -59,11 +72,26 @@ func (i *Issuer) Issue(userID int64, tokenVersion int32) (string, error) {
 	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(i.secret)
 }
 
-// Parse verifies a token's signature and expiry and returns its subject user id
-// and version claim. It rejects any token not signed with HMAC (guarding against
-// algorithm confusion), any whose subject is not a valid id, and any carrying no
-// version claim.
-func (i *Issuer) Parse(token string) (int64, int32, error) {
+func fingerprint(token string) []byte {
+	sum := sha256.Sum256([]byte(token))
+	return sum[:]
+}
+
+// SessionFingerprint verifies token and returns a one-way binding for an exact,
+// JTI-stamped session. Legacy no-JTI sessions must be rotated before this method
+// will authorize a recent-auth proof.
+func (i *Issuer) SessionFingerprint(token string) ([]byte, error) {
+	claims, err := i.parseClaims(token)
+	if err != nil {
+		return nil, err
+	}
+	if claims.ID == "" {
+		return nil, ErrNoSessionID
+	}
+	return fingerprint(token), nil
+}
+
+func (i *Issuer) parseClaims(token string) (*sessionClaims, error) {
 	claims := &sessionClaims{}
 	if _, err := jwt.ParseWithClaims(token, claims, func(t *jwt.Token) (any, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -71,6 +99,18 @@ func (i *Issuer) Parse(token string) (int64, int32, error) {
 		}
 		return i.secret, nil
 	}); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+// Parse verifies a token's signature and expiry and returns its subject user id
+// and version claim. It rejects any token not signed with HMAC (guarding against
+// algorithm confusion), any whose subject is not a valid id, and any carrying no
+// version claim.
+func (i *Issuer) Parse(token string) (int64, int32, error) {
+	claims, err := i.parseClaims(token)
+	if err != nil {
 		return 0, 0, err
 	}
 

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -1,8 +1,12 @@
 package auth
 
 import (
+	"errors"
+	"strconv"
 	"testing"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func TestIssuer_IssueParseRoundTrip(t *testing.T) {
@@ -19,6 +23,55 @@ func TestIssuer_IssueParseRoundTrip(t *testing.T) {
 	}
 	if got != 42 {
 		t.Errorf("Parse returned user id %d, want 42", got)
+	}
+}
+
+func TestIssuer_IssuesDistinctSessionTokens(t *testing.T) {
+	iss := NewIssuer("test-secret", time.Hour)
+	first, err := iss.Issue(42, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := iss.Issue(42, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("two sessions received the same token")
+	}
+	firstFingerprint, err := iss.SessionFingerprint(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondFingerprint, err := iss.SessionFingerprint(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstFingerprint) == string(secondFingerprint) {
+		t.Fatal("two sessions received the same fingerprint")
+	}
+}
+
+func TestIssuer_LegacySessionCannotBindRecentAuth(t *testing.T) {
+	iss := NewIssuer("test-secret", time.Hour)
+	now := time.Now()
+	legacy := sessionClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   strconv.FormatInt(42, 10),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		TokenVersion: func() *int32 { v := int32(1); return &v }(),
+	}
+	raw, err := jwt.NewWithClaims(jwt.SigningMethodHS256, legacy).SignedString(iss.secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err = iss.Parse(raw); err != nil {
+		t.Fatalf("legacy session lost rollout compatibility: %v", err)
+	}
+	if _, err = iss.SessionFingerprint(raw); !errors.Is(err, ErrNoSessionID) {
+		t.Fatalf("legacy session fingerprint err=%v", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/base64"
 	"errors"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -44,6 +45,16 @@ type Settings struct {
 	// incomplete credentials is simply disabled (enforced where the provider
 	// registry is built, not here), and the server starts either way.
 	OAuth map[string]OAuthCredentials
+
+	// AuthV2 enables verifier-bound native OAuth endpoints. Browser-provider v2
+	// can run without Apple; native Apple is advertised only when its separate
+	// bundle client id and refresh-grant encryption key ring are complete.
+	AuthV2Enabled         bool
+	MobileAuthCallbacks   map[string]string
+	AppleNativeClientID   string
+	AppleGrantActiveKeyID string
+	AppleGrantKeys        map[string][]byte
+	RecentAuthTTL         time.Duration
 
 	// GmailTokenKey is the 32-byte AES key (from GMAIL_TOKEN_KEY, base64) that
 	// encrypts stored Gmail refresh tokens. Empty/invalid = the Connect-Gmail
@@ -247,21 +258,27 @@ const defaultAssistantMaxPrompt = 8000
 // Load reads configuration from the environment, falling back to sensible defaults.
 func Load() Settings {
 	s := Settings{
-		Env:            env("ENV", "development"),
-		LLM:            LoadLLM(),
-		Port:           env("PORT", "8080"),
-		DatabaseURL:    env("DATABASE_URL", "postgres://hire:hire@localhost:5432/hire?sslmode=disable"),
-		FrontendOrigin: env("FRONTEND_ORIGIN", "http://localhost:5173"),
-		JWTSecret:      os.Getenv("JWT_SECRET"),
-		JWTTTL:         envDuration("JWT_TTL", 30*24*time.Hour),
-		CookieSecure:   envBool("COOKIE_SECURE", false),
-		CookieDomains:  splitDomains(os.Getenv("COOKIE_DOMAIN")),
-		OAuth:          loadOAuth(),
-		GmailTokenKey:  decodeKey(os.Getenv("GMAIL_TOKEN_KEY")),
-		MailboxDomain:  os.Getenv("MAILBOX_DOMAIN"),
-		MeiliURL:       env("MEILI_URL", "http://localhost:7700"),
-		MeiliKey:       os.Getenv("MEILI_MASTER_KEY"),
-		RedisURL:       env("REDIS_URL", "redis://localhost:6379/0"),
+		Env:                   env("ENV", "development"),
+		LLM:                   LoadLLM(),
+		Port:                  env("PORT", "8080"),
+		DatabaseURL:           env("DATABASE_URL", "postgres://hire:hire@localhost:5432/hire?sslmode=disable"),
+		FrontendOrigin:        env("FRONTEND_ORIGIN", "http://localhost:5173"),
+		JWTSecret:             os.Getenv("JWT_SECRET"),
+		JWTTTL:                envDuration("JWT_TTL", 30*24*time.Hour),
+		CookieSecure:          envBool("COOKIE_SECURE", false),
+		CookieDomains:         splitDomains(os.Getenv("COOKIE_DOMAIN")),
+		OAuth:                 loadOAuth(),
+		AuthV2Enabled:         envBool("AUTH_V2_ENABLED", false),
+		MobileAuthCallbacks:   parseNamedValues(os.Getenv("MOBILE_AUTH_CALLBACKS")),
+		AppleNativeClientID:   strings.TrimSpace(os.Getenv("APPLE_NATIVE_CLIENT_ID")),
+		AppleGrantActiveKeyID: strings.TrimSpace(os.Getenv("APPLE_GRANT_ACTIVE_KEY_ID")),
+		AppleGrantKeys:        parseKeyRing(os.Getenv("APPLE_GRANT_KEYS")),
+		RecentAuthTTL:         envDuration("RECENT_AUTH_TTL", 10*time.Minute),
+		GmailTokenKey:         decodeKey(os.Getenv("GMAIL_TOKEN_KEY")),
+		MailboxDomain:         os.Getenv("MAILBOX_DOMAIN"),
+		MeiliURL:              env("MEILI_URL", "http://localhost:7700"),
+		MeiliKey:              os.Getenv("MEILI_MASTER_KEY"),
+		RedisURL:              env("REDIS_URL", "redis://localhost:6379/0"),
 
 		LLMAdminURL:         os.Getenv("LLM_ADMIN_URL"),
 		LLMAdminKey:         os.Getenv("LLM_ADMIN_KEY"),
@@ -327,7 +344,82 @@ func (s Settings) Validate() error {
 	if len(s.JWTSecret) < 32 {
 		return errors.New("JWT_SECRET is required and must be at least 32 bytes")
 	}
+	if s.RecentAuthTTL != 0 && (s.RecentAuthTTL < time.Minute || s.RecentAuthTTL > time.Hour) {
+		return errors.New("RECENT_AUTH_TTL must be between 1m and 1h")
+	}
+	appleWeb := s.OAuth["apple"]
+	appleFields := []bool{s.AppleNativeClientID != "", s.AppleGrantActiveKeyID != "", len(s.AppleGrantKeys) != 0}
+	partialApple := (appleFields[0] || appleFields[1] || appleFields[2]) && !(appleFields[0] && appleFields[1] && appleFields[2])
+	if partialApple {
+		return errors.New("native Apple requires APPLE_NATIVE_CLIENT_ID, APPLE_GRANT_ACTIVE_KEY_ID, and APPLE_GRANT_KEYS")
+	}
+	if appleFields[0] {
+		if appleWeb.TeamID == "" || appleWeb.KeyID == "" || appleWeb.PrivateKey == "" {
+			return errors.New("native Apple requires OAUTH_APPLE_TEAM_ID, OAUTH_APPLE_KEY_ID, and OAUTH_APPLE_PRIVATE_KEY")
+		}
+		if len(s.AppleGrantKeys[s.AppleGrantActiveKeyID]) != 32 {
+			return errors.New("APPLE_GRANT_ACTIVE_KEY_ID must identify a 32-byte key in APPLE_GRANT_KEYS")
+		}
+	}
+	if s.AuthV2Enabled && len(s.MobileAuthCallbacks) == 0 {
+		return errors.New("MOBILE_AUTH_CALLBACKS is required when AUTH_V2_ENABLED=true")
+	}
+	if s.AuthV2Enabled && s.MobileAuthCallbacks["web"] == "" {
+		return errors.New("MOBILE_AUTH_CALLBACKS must include web when AUTH_V2_ENABLED=true")
+	}
+	for name, raw := range s.MobileAuthCallbacks {
+		u, err := url.Parse(raw)
+		validName := name == "ios" || name == "android" || name == "web"
+		if err != nil || !validName || !u.IsAbs() || u.Host == "" || u.User != nil || u.Fragment != "" {
+			return errors.New("MOBILE_AUTH_CALLBACKS must contain valid ios, android, or web URLs")
+		}
+		if s.Env == "production" && u.Scheme != "https" {
+			return errors.New("MOBILE_AUTH_CALLBACKS must use HTTPS in production")
+		}
+	}
+	if raw := s.MobileAuthCallbacks["web"]; raw != "" {
+		callback, callbackErr := url.Parse(raw)
+		frontend, frontendErr := url.Parse(s.FrontendOrigin)
+		if callbackErr != nil || frontendErr != nil || callback.Scheme != frontend.Scheme || callback.Host != frontend.Host || callback.Path != "/my/reauth" {
+			return errors.New("MOBILE_AUTH_CALLBACKS web must be FRONTEND_ORIGIN/my/reauth")
+		}
+	}
 	return nil
+}
+
+func parseNamedValues(raw string) map[string]string {
+	out := map[string]string{}
+	for _, part := range strings.Split(raw, ",") {
+		name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if ok && strings.TrimSpace(name) != "" && strings.TrimSpace(value) != "" {
+			out[strings.TrimSpace(name)] = strings.TrimSpace(value)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func parseKeyRing(raw string) map[string][]byte {
+	out := map[string][]byte{}
+	for _, part := range strings.Split(raw, ",") {
+		id, encoded, ok := strings.Cut(strings.TrimSpace(part), ":")
+		if !ok || strings.TrimSpace(id) == "" {
+			continue
+		}
+		key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+		if err != nil {
+			key = nil
+		}
+		// Preserve malformed named entries so NewKeyRing fails startup instead of
+		// silently dropping an old decrypt-only key still referenced by grants.
+		out[strings.TrimSpace(id)] = key
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // splitCSV parses a comma-separated env value into trimmed, non-empty entries.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/base64"
 	"slices"
 	"strings"
@@ -353,6 +354,60 @@ func TestLoad_OAuthApplePrivateKeyInvalidBase64IsEmpty(t *testing.T) {
 
 	if got := Load().OAuth["apple"].PrivateKey; got != "" {
 		t.Errorf("PrivateKey = %q, want empty for invalid base64", got)
+	}
+}
+
+func TestLoad_NativeAppleAndAuthV2(t *testing.T) {
+	key := bytes.Repeat([]byte{7}, 32)
+	t.Setenv("AUTH_V2_ENABLED", "true")
+	t.Setenv("MOBILE_AUTH_CALLBACKS", "web=https://freehire.me/my/reauth,ios=https://freehire.me/auth/callback")
+	t.Setenv("APPLE_NATIVE_CLIENT_ID", "me.freehire.mobile")
+	t.Setenv("APPLE_GRANT_ACTIVE_KEY_ID", "v2")
+	t.Setenv("APPLE_GRANT_KEYS", "v1:"+base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{1}, 32))+",v2:"+base64.StdEncoding.EncodeToString(key))
+	s := Load()
+	if !s.AuthV2Enabled || s.MobileAuthCallbacks["ios"] != "https://freehire.me/auth/callback" {
+		t.Fatalf("v2 config not loaded: %+v", s.MobileAuthCallbacks)
+	}
+	if s.AppleNativeClientID != "me.freehire.mobile" || s.AppleGrantActiveKeyID != "v2" || !bytes.Equal(s.AppleGrantKeys["v2"], key) {
+		t.Fatal("native Apple config not loaded")
+	}
+}
+
+func TestSettingsValidateRejectsUnsafeProductionV2Callbacks(t *testing.T) {
+	base := Settings{Env: "production", CookieSecure: true, JWTSecret: strings.Repeat("x", 32),
+		FrontendOrigin: "https://freehire.me", AuthV2Enabled: true,
+		MobileAuthCallbacks: map[string]string{"web": "https://freehire.me/my/reauth"}}
+	for name, callback := range map[string]string{
+		"unknown target": "https://freehire.me/callback",
+		"insecure":       "http://freehire.me/callback",
+		"userinfo":       "https://user@freehire.me/callback",
+		"fragment":       "https://freehire.me/callback#token",
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := base
+			s.MobileAuthCallbacks = map[string]string{"web": "https://freehire.me/my/reauth", "unknown": callback}
+			if name != "unknown target" {
+				s.MobileAuthCallbacks = map[string]string{"web": callback}
+			}
+			if err := s.Validate(); err == nil {
+				t.Fatal("unsafe callback accepted")
+			}
+		})
+	}
+}
+
+func TestSettingsValidateRequiresSameOriginWebReauthCallback(t *testing.T) {
+	s := Settings{JWTSecret: strings.Repeat("x", 32), FrontendOrigin: "https://freehire.me", CookieSecure: true,
+		AuthV2Enabled: true, MobileAuthCallbacks: map[string]string{"web": "https://auth.freehire.me/my/reauth"}}
+	if err := s.Validate(); err == nil || !strings.Contains(err.Error(), "FRONTEND_ORIGIN") {
+		t.Fatalf("Validate()=%v", err)
+	}
+}
+
+func TestSettingsValidateRejectsPartialNativeApple(t *testing.T) {
+	s := Settings{JWTSecret: strings.Repeat("x", 32), AppleNativeClientID: "me.freehire.mobile"}
+	if err := s.Validate(); err == nil || !strings.Contains(err.Error(), "APPLE_GRANT") {
+		t.Fatalf("Validate()=%v", err)
 	}
 }
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -38,6 +38,43 @@ type ApiKey struct {
 	Scope       string             `json:"scope"`
 }
 
+type AppleGrant struct {
+	ID                     pgtype.UUID        `json:"id"`
+	UserID                 int64              `json:"user_id"`
+	Provider               string             `json:"provider"`
+	ProviderUserID         string             `json:"provider_user_id"`
+	ClientID               string             `json:"client_id"`
+	RefreshTokenCiphertext []byte             `json:"refresh_token_ciphertext"`
+	RefreshTokenNonce      []byte             `json:"refresh_token_nonce"`
+	EncryptionKeyID        string             `json:"encryption_key_id"`
+	AadVersion             int16              `json:"aad_version"`
+	CreatedAt              pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt              pgtype.Timestamptz `json:"updated_at"`
+	RevocationRequestedAt  pgtype.Timestamptz `json:"revocation_requested_at"`
+}
+
+type AppleRevocationJob struct {
+	ID                   pgtype.UUID        `json:"id"`
+	IdempotencyKey       string             `json:"idempotency_key"`
+	Reason               string             `json:"reason"`
+	SourceUserID         pgtype.Int8        `json:"source_user_id"`
+	SourceProvider       pgtype.Text        `json:"source_provider"`
+	SourceProviderUserID pgtype.Text        `json:"source_provider_user_id"`
+	TokenAadRowID        pgtype.UUID        `json:"token_aad_row_id"`
+	ClientID             string             `json:"client_id"`
+	TokenCiphertext      []byte             `json:"token_ciphertext"`
+	TokenNonce           []byte             `json:"token_nonce"`
+	EncryptionKeyID      pgtype.Text        `json:"encryption_key_id"`
+	AadVersion           int16              `json:"aad_version"`
+	Status               string             `json:"status"`
+	Attempts             int32              `json:"attempts"`
+	NextAttemptAt        pgtype.Timestamptz `json:"next_attempt_at"`
+	LastErrorClass       pgtype.Text        `json:"last_error_class"`
+	CreatedAt            pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt            pgtype.Timestamptz `json:"updated_at"`
+	CompletedAt          pgtype.Timestamptz `json:"completed_at"`
+}
+
 type Application struct {
 	ID           int64              `json:"id"`
 	UserID       int64              `json:"user_id"`
@@ -592,6 +629,42 @@ type NotificationSetting struct {
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 }
 
+type OauthAuthAttempt struct {
+	ID                   pgtype.UUID        `json:"id"`
+	StateHash            []byte             `json:"state_hash"`
+	Provider             string             `json:"provider"`
+	ProtocolVersion      int16              `json:"protocol_version"`
+	Platform             string             `json:"platform"`
+	CallbackTarget       string             `json:"callback_target"`
+	Purpose              string             `json:"purpose"`
+	CodeChallenge        pgtype.Text        `json:"code_challenge"`
+	CodeChallengeMethod  pgtype.Text        `json:"code_challenge_method"`
+	NonceChallenge       pgtype.Text        `json:"nonce_challenge"`
+	AllowedAudiences     []string           `json:"allowed_audiences"`
+	ExpectedUserID       pgtype.Int8        `json:"expected_user_id"`
+	ExpectedTokenVersion pgtype.Int4        `json:"expected_token_version"`
+	ExpectedSessionHash  []byte             `json:"expected_session_hash"`
+	FailureCount         int32              `json:"failure_count"`
+	CreatedAt            pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt            pgtype.Timestamptz `json:"expires_at"`
+	ConsumedAt           pgtype.Timestamptz `json:"consumed_at"`
+}
+
+type OauthExchangeCode struct {
+	CodeHash             []byte             `json:"code_hash"`
+	UserID               int64              `json:"user_id"`
+	SourceAttemptID      pgtype.UUID        `json:"source_attempt_id"`
+	CodeChallenge        string             `json:"code_challenge"`
+	CodeChallengeMethod  string             `json:"code_challenge_method"`
+	Purpose              string             `json:"purpose"`
+	ExpectedUserID       pgtype.Int8        `json:"expected_user_id"`
+	ExpectedTokenVersion pgtype.Int4        `json:"expected_token_version"`
+	ExpectedSessionHash  []byte             `json:"expected_session_hash"`
+	CreatedAt            pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt            pgtype.Timestamptz `json:"expires_at"`
+	ConsumedAt           pgtype.Timestamptz `json:"consumed_at"`
+}
+
 type ProcessedViewLog struct {
 	Signature   int64              `json:"signature"`
 	Filename    string             `json:"filename"`
@@ -613,6 +686,17 @@ type PushTicketOutbox struct {
 	Token     string             `json:"token"`
 	TicketID  string             `json:"ticket_id"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+type RecentAuthProof struct {
+	ProofHash    []byte             `json:"proof_hash"`
+	UserID       int64              `json:"user_id"`
+	TokenVersion int32              `json:"token_version"`
+	SessionHash  []byte             `json:"session_hash"`
+	PurposeClass string             `json:"purpose_class"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt    pgtype.Timestamptz `json:"expires_at"`
+	ConsumedAt   pgtype.Timestamptz `json:"consumed_at"`
 }
 
 type ReferralOffer struct {
@@ -779,10 +863,12 @@ type UserEmailCode struct {
 }
 
 type UserIdentity struct {
-	Provider       string             `json:"provider"`
-	ProviderUserID string             `json:"provider_user_id"`
-	UserID         int64              `json:"user_id"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	Provider        string             `json:"provider"`
+	ProviderUserID  string             `json:"provider_user_id"`
+	UserID          int64              `json:"user_id"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	Status          string             `json:"status"`
+	StatusChangedAt pgtype.Timestamptz `json:"status_changed_at"`
 }
 
 type UserJob struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -913,6 +913,9 @@ type Querier interface {
 	// duplicate that logic in a second language and let the two drift apart; titles are cheap to
 	// ship, descriptions are not.
 	FuzzyDedupCandidateTitlesForCompany(ctx context.Context, company string) ([]FuzzyDedupCandidateTitlesForCompanyRow, error)
+	// Authentication accepts only active identities. A pending Apple revocation
+	// must not sign the user back in and silently cancel an unlink request.
+	GetActiveUserByIdentity(ctx context.Context, arg GetActiveUserByIdentityParams) (GetActiveUserByIdentityRow, error)
 	// Read one job's captured form for display. The only read path over this store, and it
 	// is by primary key — the display surface asks for exactly one posting's form, never a
 	// page of them, which is also why nothing here joins jobs.

--- a/internal/db/queries/user_identities.sql
+++ b/internal/db/queries/user_identities.sql
@@ -5,6 +5,15 @@ FROM user_identities ui
 JOIN users u ON u.id = ui.user_id
 WHERE ui.provider = $1 AND ui.provider_user_id = $2;
 
+-- name: GetActiveUserByIdentity :one
+-- Authentication accepts only active identities. A pending Apple revocation
+-- must not sign the user back in and silently cancel an unlink request.
+SELECT u.id, u.email, u.created_at
+FROM user_identities ui
+JOIN users u ON u.id = ui.user_id
+WHERE ui.provider = $1 AND ui.provider_user_id = $2
+  AND ui.status = 'active';
+
 -- name: CreateUserIdentity :exec
 -- Link a provider identity to an account (first OAuth sign-in). The composite
 -- primary key rejects a duplicate identity.

--- a/internal/db/user_identities.sql.go
+++ b/internal/db/user_identities.sql.go
@@ -29,6 +29,34 @@ func (q *Queries) CreateUserIdentity(ctx context.Context, arg CreateUserIdentity
 	return err
 }
 
+const getActiveUserByIdentity = `-- name: GetActiveUserByIdentity :one
+SELECT u.id, u.email, u.created_at
+FROM user_identities ui
+JOIN users u ON u.id = ui.user_id
+WHERE ui.provider = $1 AND ui.provider_user_id = $2
+  AND ui.status = 'active'
+`
+
+type GetActiveUserByIdentityParams struct {
+	Provider       string `json:"provider"`
+	ProviderUserID string `json:"provider_user_id"`
+}
+
+type GetActiveUserByIdentityRow struct {
+	ID        int64              `json:"id"`
+	Email     string             `json:"email"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+// Authentication accepts only active identities. A pending Apple revocation
+// must not sign the user back in and silently cancel an unlink request.
+func (q *Queries) GetActiveUserByIdentity(ctx context.Context, arg GetActiveUserByIdentityParams) (GetActiveUserByIdentityRow, error) {
+	row := q.db.QueryRow(ctx, getActiveUserByIdentity, arg.Provider, arg.ProviderUserID)
+	var i GetActiveUserByIdentityRow
+	err := row.Scan(&i.ID, &i.Email, &i.CreatedAt)
+	return i, err
+}
+
 const getUserByIdentity = `-- name: GetUserByIdentity :one
 SELECT u.id, u.email, u.created_at
 FROM user_identities ui

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -11,7 +11,10 @@ import (
 
 	"github.com/strelov1/freehire/internal/accounts"
 	"github.com/strelov1/freehire/internal/auth"
+	appleauth "github.com/strelov1/freehire/internal/auth/apple"
+	"github.com/strelov1/freehire/internal/auth/mobileauth"
 	"github.com/strelov1/freehire/internal/auth/oauth"
+	"github.com/strelov1/freehire/internal/auth/recentauth"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/pushnotify"
 	"github.com/strelov1/freehire/internal/ratelimit"
@@ -55,9 +58,15 @@ type authHandlers struct {
 	// honoured as an OAuth redirect origin; anything else falls back to frontendOrigin.
 	// It is deliberately NOT cookieDomains: a suffix match is right for cookie scope
 	// and wrong for a redirect target (see requestOrigin).
-	servedHosts []string
-	accounts    *accounts.Service
-	throttler   ratelimit.Throttler
+	servedHosts     []string
+	accounts        *accounts.Service
+	throttler       ratelimit.Throttler
+	authV2Enabled   bool
+	mobileCallbacks map[string]string
+	mobileAuth      *mobileauth.Store
+	recentAuth      *recentauth.Store
+	appleNative     *appleauth.Client
+	appleGrantKeys  *appleauth.KeyRing
 	// pushNotifier sends test/device push notifications (see me_push_tokens.go).
 	// pushnotify.Notifier in production; a fake in tests.
 	pushNotifier pushnotify.Notifier
@@ -106,10 +115,14 @@ func (h *authHandlers) register(api fiber.Router, mw middleware) {
 	// Changing the password is cookie-only for the same reason: a leaked credential
 	// must not be able to change the credential it would outlive.
 	meGroup := api.Group("/me", noCache)
-	meGroup.Post("/password", mw.cookie, h.ChangePassword)
-	meGroup.Post("/api-keys", mw.cookie, h.CreateAPIKey)
+	recent := func(c *fiber.Ctx) error { return c.Next() }
+	if h.authV2Enabled {
+		recent = h.requireRecentAuth
+	}
+	meGroup.Post("/password", mw.cookie, recent, h.ChangePassword)
+	meGroup.Post("/api-keys", mw.cookie, recent, h.CreateAPIKey)
 	meGroup.Get("/api-keys", mw.cookie, h.ListAPIKeys)
-	meGroup.Delete("/api-keys/:id", mw.cookie, h.RevokeAPIKey)
+	meGroup.Delete("/api-keys/:id", mw.cookie, recent, h.RevokeAPIKey)
 
 	// Push-token registration is cookie-only for the same reason key management
 	// is: a leaked API key must not be able to redirect another device's push
@@ -175,6 +188,28 @@ func (h *authHandlers) register(api fiber.Router, mw middleware) {
 	// fragment. Both refuse any redirect outside the configured allowlist.
 	authGroup.Get("/extension/connect", mw.cookie, h.ExtensionConnect)
 	authGroup.Post("/extension/connect", mw.cookie, h.ExtensionConnectSubmit)
+}
+
+func (h *authHandlers) requireRecentAuth(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	version, err := h.queries.GetUserTokenVersion(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+	sessionHash, fingerprintErr := h.currentSessionHash(c)
+	if fingerprintErr != nil {
+		return authError(428, "recent_auth_required", "recent authentication required")
+	}
+	if err := h.recentAuth.Validate(c.Context(), c.Cookies(recentauth.CookieName), userID, version, sessionHash); err != nil {
+		if errors.Is(err, recentauth.ErrRequired) {
+			return authError(428, "recent_auth_required", "recent authentication required")
+		}
+		return err
+	}
+	return c.Next()
 }
 
 // userResponse is the public shape of a user. It deliberately omits
@@ -279,7 +314,16 @@ func (h *authHandlers) Login(c *fiber.Ctx) error {
 // Logout clears the auth cookie. It is public and idempotent: clearing an
 // absent or already-expired cookie is a no-op.
 func (h *authHandlers) Logout(c *fiber.Ctx) error {
-	auth.ClearTokenCookie(c, h.cookieSecure, auth.CookieDomainForHost(c.Hostname(), h.cookieDomains))
+	var revokeErr error
+	if h.recentAuth != nil {
+		revokeErr = h.recentAuth.Revoke(c.Context(), c.Cookies(recentauth.CookieName))
+	}
+	domain := auth.CookieDomainForHost(c.Hostname(), h.cookieDomains)
+	auth.ClearTokenCookie(c, h.cookieSecure, domain)
+	recentauth.ClearCookie(c, h.cookieSecure, domain)
+	if revokeErr != nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "service temporarily unavailable")
+	}
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -295,7 +339,9 @@ func (h *authHandlers) LogoutAll(c *fiber.Ctx) error {
 	if _, err := h.queries.BumpUserTokenVersion(c.Context(), userID); err != nil {
 		return err
 	}
-	auth.ClearTokenCookie(c, h.cookieSecure, auth.CookieDomainForHost(c.Hostname(), h.cookieDomains))
+	domain := auth.CookieDomainForHost(c.Hostname(), h.cookieDomains)
+	auth.ClearTokenCookie(c, h.cookieSecure, domain)
+	recentauth.ClearCookie(c, h.cookieSecure, domain)
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -314,12 +360,17 @@ func (h *authHandlers) setSession(c *fiber.Ctx, userID int64) error {
 // the counter (password change, sign-out-everywhere) pass the value they got back, so the
 // caller's replacement cookie cannot race the bump they themselves performed.
 func (h *authHandlers) setSessionAt(c *fiber.Ctx, userID int64, version int32) error {
+	_, err := h.issueSessionAt(c, userID, version)
+	return err
+}
+
+func (h *authHandlers) issueSessionAt(c *fiber.Ctx, userID int64, version int32) (string, error) {
 	token, err := h.issuer.Issue(userID, version)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "failed to start session")
+		return "", fiber.NewError(fiber.StatusInternalServerError, "failed to start session")
 	}
 	auth.SetTokenCookie(c, token, h.issuer.TTL(), h.cookieSecure, auth.CookieDomainForHost(c.Hostname(), h.cookieDomains))
-	return nil
+	return token, nil
 }
 
 // Me returns the authenticated user. It runs behind auth.RequireAuthOrKey (a

--- a/internal/handler/auth_v2.go
+++ b/internal/handler/auth_v2.go
@@ -1,0 +1,512 @@
+package handler
+
+import (
+	"crypto/subtle"
+	"errors"
+	"net/url"
+	"sort"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/strelov1/freehire/internal/accounts"
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/auth/mobileauth"
+	"github.com/strelov1/freehire/internal/auth/oauth"
+	"github.com/strelov1/freehire/internal/auth/recentauth"
+	"github.com/strelov1/freehire/internal/ratelimit"
+)
+
+type oauthV2Registry interface {
+	ProviderV2(name, origin string) (oauth.Provider, bool)
+}
+
+const oauthV2StateCookieName = "hire_oauth_v2_state"
+
+func (h *authHandlers) currentSessionHash(c *fiber.Ctx) ([]byte, error) {
+	raw := c.Cookies(auth.CookieName)
+	if raw == "" {
+		return nil, authError(401, "unauthorized", "unauthorized")
+	}
+	return h.issuer.SessionFingerprint(raw)
+}
+
+func (h *authHandlers) currentSessionHashOrRotate(c *fiber.Ctx, userID int64, version int32) ([]byte, error) {
+	fingerprint, err := h.currentSessionHash(c)
+	if err == nil {
+		return fingerprint, nil
+	}
+	if !errors.Is(err, auth.ErrNoSessionID) {
+		return nil, err
+	}
+	raw, err := h.issueSessionAt(c, userID, version)
+	if err != nil {
+		return nil, err
+	}
+	return h.issuer.SessionFingerprint(raw)
+}
+
+func (h *authHandlers) sessionMatches(expected []byte, c *fiber.Ctx) bool {
+	actual, err := h.currentSessionHash(c)
+	return err == nil && len(expected) == len(actual) && subtle.ConstantTimeCompare(expected, actual) == 1
+}
+
+func (h *authHandlers) registerV2(api fiber.Router, mw middleware) {
+	noStore := func(c *fiber.Ctx) error {
+		c.Set("Cache-Control", "private, no-store")
+		c.Set("Pragma", "no-cache")
+		return c.Next()
+	}
+	g := api.Group("/auth", noStore)
+	exchangeLimit := ratelimit.Middleware(h.throttler, ratelimit.KeyByIP("oauth-v2-exchange"), 20, time.Minute)
+	passwordIPLimit := ratelimit.Middleware(h.throttler, ratelimit.KeyByIP("password-reauth-ip"), 20, time.Minute)
+	passwordUserLimit := ratelimit.Middleware(h.throttler, ratelimit.KeyByUserOrIP("password-reauth-user"), 5, time.Minute)
+	// The same-repository web bundle calls password reauthentication before
+	// protected mutations even during a schema-first rollout where mobile v2 is
+	// still disabled. Keeping this one issuance route available prevents that
+	// compatibility deploy from breaking password and API-key management.
+	g.Post("/reauth/password", passwordIPLimit, mw.cookie, passwordUserLimit, h.PasswordReauthV2)
+	if !h.authV2Enabled {
+		return
+	}
+	g.Get("/providers", h.ListProvidersV2)
+	startLimit := ratelimit.Middleware(h.throttler, ratelimit.KeyByIP("oauth-v2-start"), 20, time.Minute)
+	g.Get("/oauth/:provider/start", startLimit, mw.optionalCookie, h.OAuthStartV2)
+	g.Get("/oauth/:provider/callback", h.OAuthCallbackV2)
+	g.Post("/oauth/:provider/callback", h.OAuthCallbackV2)
+	g.Post("/oauth/exchange", exchangeLimit, mw.optionalCookie, h.OAuthExchangeV2)
+	g.Post("/apple/attempt", startLimit, mw.optionalCookie, h.AppleAttemptV2)
+	g.Post("/apple/exchange", exchangeLimit, mw.optionalCookie, h.AppleExchangeV2)
+	g.Get("/identities", mw.cookie, h.ListIdentitiesV2)
+	g.Delete("/identities/:provider", mw.cookie, h.UnlinkIdentityV2)
+}
+
+func (h *authHandlers) ListProvidersV2(c *fiber.Ctx) error {
+	type provider struct {
+		ID        string   `json:"id"`
+		Flow      string   `json:"flow"`
+		Platforms []string `json:"platforms"`
+		Available bool     `json:"available"`
+	}
+	var providers []provider
+	platforms := make([]string, 0, 2)
+	for _, platform := range []string{"ios", "android"} {
+		if h.mobileCallbacks[platform] != "" {
+			platforms = append(platforms, platform)
+		}
+	}
+	for _, name := range h.oauth.Names() {
+		if name == "apple" || len(platforms) == 0 {
+			continue
+		}
+		providers = append(providers, provider{name, "browser_oauth", append([]string(nil), platforms...), true})
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i].ID < providers[j].ID })
+	if h.appleNative != nil && h.appleGrantKeys != nil {
+		providers = append(providers, provider{"apple", "native_apple", []string{"ios"}, true})
+	}
+	return c.JSON(fiber.Map{"data": fiber.Map{"schema_version": 2, "providers": providers}})
+}
+
+func (h *authHandlers) currentBinding(c *fiber.Ctx, purpose string) (*mobileauth.Binding, error) {
+	if purpose != "reauth" {
+		if purpose != "sign_in" {
+			return nil, authError(400, "invalid_purpose", "invalid purpose")
+		}
+		return nil, nil
+	}
+	uid, err := requireUserID(c)
+	if err != nil {
+		return nil, authError(401, "unauthorized", "unauthorized")
+	}
+	version, err := h.queries.GetUserTokenVersion(c.Context(), uid)
+	if err != nil {
+		return nil, err
+	}
+	sessionHash, err := h.currentSessionHashOrRotate(c, uid, version)
+	if err != nil {
+		return nil, err
+	}
+	return &mobileauth.Binding{UserID: uid, TokenVersion: version, SessionHash: sessionHash}, nil
+}
+
+func (h *authHandlers) OAuthStartV2(c *fiber.Ctx) error {
+	registry, ok := h.oauth.(oauthV2Registry)
+	if !ok {
+		return authError(503, "oauth_unavailable", "sign-in unavailable")
+	}
+	provider := c.Params("provider")
+	p, ok := registry.ProviderV2(provider, h.requestOrigin(c))
+	if !ok {
+		return authError(404, "unknown_provider", "unknown provider")
+	}
+	platform, target, purpose := c.Query("platform"), c.Query("callback_target"), c.Query("purpose")
+	if provider == "apple" && !(platform == "web" && purpose == "reauth") {
+		return authError(404, "unknown_provider", "unknown provider")
+	}
+	callback, ok := h.mobileCallbacks[target]
+	if !ok || callback == "" || target != platform {
+		return authError(400, "invalid_callback_target", "invalid callback target")
+	}
+	_ = callback
+	if c.Query("code_challenge_method") != "S256" {
+		return authError(400, "invalid_code_challenge", "S256 is required")
+	}
+	binding, err := h.currentBinding(c, purpose)
+	if err != nil {
+		return err
+	}
+	_, state, err := h.mobileAuth.CreateBrowserAttempt(c.Context(), provider, platform, target, purpose, c.Query("code_challenge"), binding)
+	if err != nil {
+		return authError(400, "invalid_oauth_attempt", "invalid OAuth attempt")
+	}
+	oauth.SetStateCookieNamed(c, oauthV2StateCookieName, state, h.cookieSecure)
+	return c.Redirect(p.AuthCodeURL(state), fiber.StatusFound)
+}
+
+func callbackWith(raw, key, value string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set(key, value)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (h *authHandlers) OAuthCallbackV2(c *fiber.Ctx) error {
+	registry, ok := h.oauth.(oauthV2Registry)
+	if !ok {
+		return authError(503, "oauth_unavailable", "sign-in unavailable")
+	}
+	provider := c.Params("provider")
+	p, ok := registry.ProviderV2(provider, h.requestOrigin(c))
+	if !ok {
+		return authError(404, "unknown_provider", "unknown provider")
+	}
+	state, code := c.Query("state"), c.Query("code")
+	if c.Method() == fiber.MethodPost {
+		state, code = c.FormValue("state"), c.FormValue("code")
+	}
+	cookieState := c.Cookies(oauthV2StateCookieName)
+	oauth.ClearStateCookieNamed(c, oauthV2StateCookieName, h.cookieSecure)
+	if state == "" || subtle.ConstantTimeCompare([]byte(state), []byte(cookieState)) != 1 {
+		return h.oauthV2Fail(c, "", errors.New("state mismatch"))
+	}
+	attempt, err := h.mobileAuth.ConsumeBrowserAttempt(c.Context(), state, provider)
+	if err != nil {
+		return h.oauthV2Fail(c, "", err)
+	}
+	if code == "" {
+		return h.oauthV2Fail(c, attempt.CallbackTarget, errors.New("missing code"))
+	}
+	identity, err := p.FetchIdentity(c.Context(), code)
+	if err != nil {
+		return h.oauthV2Fail(c, attempt.CallbackTarget, err)
+	}
+	var userID int64
+	if attempt.Purpose == "reauth" {
+		userID, err = h.mobileAuth.IdentityOwner(c.Context(), provider, identity.ProviderUserID)
+		if err == nil {
+			err = attempt.CheckExpectedUser(userID)
+		}
+	} else {
+		userID, err = h.accounts.ResolveOAuthAccount(c.Context(), provider, identity.ProviderUserID, identity.Email, identity.EmailVerified)
+	}
+	if err != nil {
+		return h.oauthV2Fail(c, attempt.CallbackTarget, err)
+	}
+	otc, err := h.mobileAuth.MintCode(c.Context(), attempt, userID)
+	if err != nil {
+		return h.oauthV2Fail(c, attempt.CallbackTarget, err)
+	}
+	target, err := callbackWith(h.mobileCallbacks[attempt.CallbackTarget], "code", otc)
+	if err != nil {
+		return err
+	}
+	return c.Redirect(target, fiber.StatusFound)
+}
+
+func (h *authHandlers) oauthV2Fail(c *fiber.Ctx, target string, cause error) error {
+	code := "oauth_failed"
+	if errors.Is(cause, mobileauth.ErrIdentity) {
+		code = "reauth_identity_mismatch"
+	}
+	base := h.mobileCallbacks[target]
+	if base == "" {
+		return authError(401, code, "sign-in failed")
+	}
+	u, err := callbackWith(base, "auth_error", code)
+	if err != nil {
+		return err
+	}
+	return c.Redirect(u, fiber.StatusFound)
+}
+
+func (h *authHandlers) issueRecent(c *fiber.Ctx, userID int64, version int32, sessionHash []byte) error {
+	raw, expires, err := h.recentAuth.Issue(c.Context(), userID, version, sessionHash)
+	if err != nil {
+		return err
+	}
+	recentauth.SetCookie(c, raw, expires, h.cookieSecure, auth.CookieDomainForHost(c.Hostname(), h.cookieDomains))
+	return c.JSON(fiber.Map{"data": fiber.Map{"recent_auth_expires_at": expires}})
+}
+
+func (h *authHandlers) OAuthExchangeV2(c *fiber.Ctx) error {
+	var in struct {
+		Code     string `json:"code"`
+		Verifier string `json:"code_verifier"`
+	}
+	if err := c.BodyParser(&in); err != nil {
+		return authError(400, "invalid_request", "invalid request body")
+	}
+	ex, err := h.mobileAuth.ConsumeCode(c.Context(), in.Code, in.Verifier)
+	if err != nil {
+		return authError(401, "invalid_exchange_code", "invalid or expired code")
+	}
+	if ex.Purpose == "reauth" {
+		current, currentErr := requireUserID(c)
+		if currentErr != nil || current != ex.UserID || !h.sessionMatches(ex.ExpectedSessionHash, c) {
+			return authError(401, "reauth_session_mismatch", "session changed")
+		}
+		if ex.ExpectedTokenVersion == nil {
+			return authError(401, "reauth_session_mismatch", "session changed")
+		}
+		if err = h.mobileAuth.VerifyBinding(c.Context(), ex.UserID, *ex.ExpectedTokenVersion); err != nil {
+			return authError(401, "reauth_session_mismatch", "session changed")
+		}
+		return h.issueRecent(c, ex.UserID, *ex.ExpectedTokenVersion, ex.ExpectedSessionHash)
+	}
+	user, err := h.accounts.UserByID(c.Context(), ex.UserID)
+	if err != nil {
+		return accountsError(err)
+	}
+	if err = h.setSession(c, ex.UserID); err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": toUserResponse(user)})
+}
+
+func (h *authHandlers) AppleAttemptV2(c *fiber.Ctx) error {
+	if h.appleNative == nil || h.appleGrantKeys == nil {
+		return authError(503, "apple_unavailable", "Apple sign-in unavailable")
+	}
+	var in struct {
+		Purpose        string `json:"purpose"`
+		NonceChallenge string `json:"nonce_challenge"`
+	}
+	if err := c.BodyParser(&in); err != nil {
+		return authError(400, "invalid_request", "invalid request body")
+	}
+	binding, err := h.currentBinding(c, in.Purpose)
+	if err != nil {
+		return err
+	}
+	a, err := h.mobileAuth.CreateAppleAttempt(c.Context(), in.NonceChallenge, in.Purpose, h.appleNative.ClientIDs(), binding)
+	if err != nil {
+		return authError(400, "invalid_apple_attempt", "invalid Apple attempt")
+	}
+	return c.JSON(fiber.Map{"data": fiber.Map{"attempt_id": a.ID, "expires_at": a.ExpiresAt}})
+}
+
+func (h *authHandlers) AppleExchangeV2(c *fiber.Ctx) error {
+	if h.appleNative == nil || h.appleGrantKeys == nil {
+		return authError(503, "apple_unavailable", "Apple sign-in unavailable")
+	}
+	var in struct {
+		AttemptID         string `json:"attempt_id"`
+		IdentityToken     string `json:"identity_token"`
+		AuthorizationCode string `json:"authorization_code"`
+		RawNonce          string `json:"raw_nonce"`
+	}
+	if err := c.BodyParser(&in); err != nil {
+		return authError(400, "invalid_request", "invalid request body")
+	}
+	id, err := uuid.Parse(in.AttemptID)
+	if err != nil {
+		return authError(401, "invalid_apple_attempt", "invalid or expired Apple attempt")
+	}
+	attempt, err := h.mobileAuth.ConsumeAppleAttempt(c.Context(), id)
+	if err != nil {
+		return authError(401, "invalid_apple_attempt", "invalid or expired Apple attempt")
+	}
+	if mobileauth.ValidateVerifier(in.RawNonce) != nil || subtle.ConstantTimeCompare([]byte(mobileauth.Challenge(in.RawNonce)), []byte(attempt.NonceChallenge)) != 1 {
+		return authError(401, "invalid_apple_nonce", "Apple nonce mismatch")
+	}
+	if attempt.Purpose == "reauth" && !h.sessionMatches(attempt.ExpectedSessionHash, c) {
+		return authError(401, "reauth_session_mismatch", "session changed")
+	}
+	claims, err := h.appleNative.Verify(c.Context(), in.IdentityToken, attempt.NonceChallenge)
+	if err != nil {
+		return authError(401, "invalid_apple_token", "invalid Apple identity token")
+	}
+	clientID, ok := h.appleNative.ClientIDForClaims(claims)
+	if !ok {
+		return authError(401, "invalid_apple_token", "invalid Apple identity token")
+	}
+	attemptAudience := false
+	for _, allowed := range attempt.AllowedAudiences {
+		if allowed == clientID {
+			attemptAudience = true
+			break
+		}
+	}
+	if !attemptAudience {
+		return authError(401, "invalid_apple_token", "invalid Apple identity token")
+	}
+	email, verified := claims.VerifiedEmail()
+	var userID int64
+	if attempt.Purpose == "reauth" {
+		current, currentErr := requireUserID(c)
+		if currentErr != nil || attempt.ExpectedUserID == nil || current != *attempt.ExpectedUserID {
+			return authError(401, "reauth_session_mismatch", "session changed")
+		}
+		userID, err = h.mobileAuth.IdentityOwner(c.Context(), "apple", claims.Subject)
+		if err == nil {
+			err = attempt.CheckExpectedUser(userID)
+		}
+	} else {
+		userID, err = h.accounts.ResolveOAuthAccount(c.Context(), "apple", claims.Subject, email, verified)
+	}
+	if errors.Is(err, accounts.ErrNoVerifiedEmail) {
+		return authError(409, "apple_email_unavailable", "Apple account needs support recovery")
+	}
+	if err != nil {
+		if attempt.Purpose == "reauth" {
+			return authError(401, "reauth_identity_mismatch", "Apple identity does not match")
+		}
+		return authError(401, "apple_identity_mismatch", "Apple identity does not match")
+	}
+	if attempt.Purpose == "reauth" && attempt.ExpectedTokenVersion != nil {
+		if err = h.mobileAuth.VerifyBinding(c.Context(), userID, *attempt.ExpectedTokenVersion); err != nil {
+			return authError(401, "reauth_session_mismatch", "session changed")
+		}
+	}
+	grant, err := h.appleNative.Exchange(c.Context(), in.AuthorizationCode, clientID, attempt.NonceChallenge, claims.Subject)
+	if err != nil {
+		return authError(401, "apple_exchange_failed", "Apple sign-in failed")
+	}
+	compensationID, err := h.mobileAuth.CreateAppleCompensation(c.Context(), h.appleGrantKeys, claims.Subject, clientID, grant.RefreshToken)
+	if err != nil {
+		// If durable custody is unavailable, revoke while the only plaintext copy
+		// is still in memory. Joining errors preserves the operational failure
+		// without ever including the token value.
+		if revokeErr := h.appleNative.Revoke(c.Context(), grant.RefreshToken, clientID); revokeErr != nil {
+			return errors.Join(err, revokeErr)
+		}
+		return err
+	}
+	if err = h.mobileAuth.FinalizeAppleGrant(c.Context(), userID, claims.Subject, clientID, compensationID); err != nil {
+		// The delayed job already owns an encrypted copy. Make it immediately
+		// eligible when possible; a failed activation still leaves the durable
+		// delayed job for crash recovery.
+		_ = h.mobileAuth.ActivateAppleCompensation(c.Context(), compensationID)
+		if errors.Is(err, mobileauth.ErrState) || errors.Is(err, mobileauth.ErrIdentity) {
+			return authError(409, "apple_identity_unavailable", "Apple identity is unavailable")
+		}
+		return err
+	}
+	if err = h.mobileAuth.DisarmAppleCompensation(c.Context(), compensationID); err != nil {
+		// Do not issue a session while the compensation job can still revoke the
+		// newly stored grant. A retry creates a new grant and safely supersedes it.
+		return err
+	}
+	if attempt.Purpose == "reauth" {
+		if attempt.ExpectedTokenVersion == nil {
+			return authError(401, "reauth_session_mismatch", "session changed")
+		}
+		if err = h.mobileAuth.VerifyBinding(c.Context(), userID, *attempt.ExpectedTokenVersion); err != nil {
+			return authError(401, "reauth_session_mismatch", "session changed")
+		}
+		return h.issueRecent(c, userID, *attempt.ExpectedTokenVersion, attempt.ExpectedSessionHash)
+	}
+	user, err := h.accounts.UserByID(c.Context(), userID)
+	if err != nil {
+		return accountsError(err)
+	}
+	if err = h.setSession(c, userID); err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": toUserResponse(user)})
+}
+
+func (h *authHandlers) PasswordReauthV2(c *fiber.Ctx) error {
+	uid, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	var in struct {
+		Password string `json:"password"`
+	}
+	if err = c.BodyParser(&in); err != nil {
+		return authError(400, "invalid_request", "invalid request body")
+	}
+	user, err := h.accounts.UserByID(c.Context(), uid)
+	if err != nil {
+		return err
+	}
+	authenticated, err := h.accounts.Login(c.Context(), user.Email, in.Password)
+	if errors.Is(err, accounts.ErrInvalidCredentials) || (err == nil && authenticated.ID != uid) {
+		return authError(401, "invalid_credentials", "invalid credentials")
+	}
+	if err != nil {
+		return accountsError(err)
+	}
+	version, err := h.queries.GetUserTokenVersion(c.Context(), uid)
+	if err != nil {
+		return err
+	}
+	sessionHash, err := h.currentSessionHashOrRotate(c, uid, version)
+	if err != nil {
+		return err
+	}
+	return h.issueRecent(c, uid, version, sessionHash)
+}
+
+func (h *authHandlers) ListIdentitiesV2(c *fiber.Ctx) error {
+	uid, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	out, err := h.mobileAuth.ListIdentities(c.Context(), uid)
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": out})
+}
+
+func (h *authHandlers) UnlinkIdentityV2(c *fiber.Ctx) error {
+	uid, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	version, err := h.queries.GetUserTokenVersion(c.Context(), uid)
+	if err != nil {
+		return err
+	}
+	sessionHash, sessionErr := h.currentSessionHash(c)
+	if sessionErr != nil {
+		return sessionErr
+	}
+	pending, err := h.mobileAuth.UnlinkIdentity(c.Context(), uid, version, sessionHash, c.Params("provider"), c.Cookies(recentauth.CookieName))
+	switch {
+	case errors.Is(err, mobileauth.ErrSession):
+		return authError(428, "recent_auth_required", "recent authentication required")
+	case errors.Is(err, mobileauth.ErrLastMethod):
+		return authError(409, "last_sign_in_method", "cannot remove the last sign-in method")
+	case errors.Is(err, mobileauth.ErrState):
+		return authError(409, "identity_state_conflict", "identity state conflict")
+	case errors.Is(err, pgx.ErrNoRows):
+		return authError(404, "identity_not_found", "identity not found")
+	case err != nil:
+		return err
+	}
+	recentauth.ClearCookie(c, h.cookieSecure, auth.CookieDomainForHost(c.Hostname(), h.cookieDomains))
+	if pending {
+		return c.Status(202).JSON(fiber.Map{"data": fiber.Map{"status": "revocation_pending"}})
+	}
+	return c.SendStatus(204)
+}

--- a/internal/handler/auth_v2_test.go
+++ b/internal/handler/auth_v2_test.go
@@ -1,0 +1,168 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/strelov1/freehire/internal/accounts"
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/auth/oauth"
+)
+
+func TestListProvidersV2StructuredAndOmitsWebApple(t *testing.T) {
+	h := &authHandlers{oauth: fakeRegistry{"google": &fakeProvider{name: "google"}, "apple": &fakeProvider{name: "apple"}}, mobileCallbacks: map[string]string{"ios": "https://freehire.me/auth/callback"}}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v2/auth/providers", h.ListProvidersV2)
+	resp := get(t, app, "/api/v2/auth/providers")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body struct {
+		Data struct {
+			Schema    int `json:"schema_version"`
+			Providers []struct {
+				ID        string   `json:"id"`
+				Flow      string   `json:"flow"`
+				Platforms []string `json:"platforms"`
+				Available bool     `json:"available"`
+			} `json:"providers"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Data.Schema != 2 || len(body.Data.Providers) != 1 || body.Data.Providers[0].ID != "google" || body.Data.Providers[0].Flow != "browser_oauth" {
+		t.Fatalf("body=%+v", body)
+	}
+}
+
+func TestRegisterV2DisabledAndNoStoreHeaders(t *testing.T) {
+	disabled := fiber.New()
+	(&authHandlers{authV2Enabled: false}).registerV2(disabled.Group("/api/v2"), middleware{})
+	resp, err := disabled.Test(httptest.NewRequest("GET", "/api/v2/auth/providers", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 404 {
+		t.Fatalf("disabled status=%d", resp.StatusCode)
+	}
+	h := &authHandlers{authV2Enabled: true, oauth: fakeRegistry{}}
+	enabled := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	h.registerV2(enabled.Group("/api/v2"), middleware{optionalCookie: func(c *fiber.Ctx) error { return c.Next() }})
+	resp, err = enabled.Test(httptest.NewRequest("GET", "/api/v2/auth/providers", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "private, no-store" {
+		t.Fatalf("Cache-Control=%q", got)
+	}
+}
+
+func TestV2CodedErrorEnvelope(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/coded", func(*fiber.Ctx) error {
+		return authError(428, "recent_auth_required", "recent authentication required")
+	})
+	resp, err := app.Test(httptest.NewRequest("GET", "/coded", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body map[string]string
+	if err = json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 428 || body["code"] != "recent_auth_required" {
+		t.Fatalf("status=%d body=%v", resp.StatusCode, body)
+	}
+}
+
+func TestV2OAuthStateCookieHasSeparateNamespace(t *testing.T) {
+	if oauthV2StateCookieName == oauth.StateCookieName {
+		t.Fatal("v2 OAuth must not overwrite an in-flight v1 state cookie")
+	}
+}
+
+func TestRecentAuthRotatesLegacySessionBeforeBinding(t *testing.T) {
+	const secret = "legacy-session-test-secret"
+	issuer := auth.NewIssuer(secret, time.Hour)
+	now := time.Now()
+	legacy, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "42", "tv": 1, "iat": now.Unix(), "exp": now.Add(time.Hour).Unix(),
+	}).SignedString([]byte(secret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &authHandlers{issuer: issuer}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/rotate", func(c *fiber.Ctx) error {
+		if _, err := h.currentSessionHashOrRotate(c, 42, 1); err != nil {
+			return err
+		}
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+	req := httptest.NewRequest(fiber.MethodGet, "/rotate", nil)
+	req.Header.Set(fiber.HeaderCookie, auth.CookieName+"="+legacy)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var rotated string
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == auth.CookieName {
+			rotated = cookie.Value
+		}
+	}
+	if rotated == "" || rotated == legacy {
+		t.Fatal("legacy session was not rotated")
+	}
+	if _, err = issuer.SessionFingerprint(rotated); err != nil {
+		t.Fatalf("rotated session cannot bind recent auth: %v", err)
+	}
+}
+
+type passwordReauthFailureRepo struct {
+	fakeRepo
+	err error
+}
+
+func (r passwordReauthFailureRepo) UserByID(context.Context, int64) (accounts.User, error) {
+	return accounts.User{ID: 7, Email: "reauth@example.test", HasPassword: true}, nil
+}
+
+func (r passwordReauthFailureRepo) UserByEmail(context.Context, string) (accounts.User, string, bool, error) {
+	return accounts.User{}, "", false, r.err
+}
+
+func TestPasswordReauthPreservesInfrastructureFailure(t *testing.T) {
+	h := &authHandlers{accounts: accounts.New(passwordReauthFailureRepo{err: errors.New("pgx: connection refused timeout")}, authHasher{})}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Post("/reauth", func(c *fiber.Ctx) error {
+		c.Locals(auth.LocalsUserID, int64(7))
+		return c.Next()
+	}, h.PasswordReauthV2)
+	req := httptest.NewRequest(fiber.MethodPost, "/reauth", strings.NewReader(`{"password":"correct horse battery staple"}`))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", resp.StatusCode)
+	}
+}
+
+var _ oauth.Provider = (*fakeProvider)(nil)

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -25,6 +25,16 @@ const statusClientClosedRequest = 499
 // the same panic a second time (as a stackless 500).
 const LocalPanicReported = "sentry_panic_reported"
 
+type codedError struct {
+	status        int
+	code, message string
+}
+
+func (e *codedError) Error() string { return e.message }
+func authError(status int, code, message string) error {
+	return &codedError{status: status, code: code, message: message}
+}
+
 // RenderError is the single place every error returned by a handler becomes an
 // HTTP response. It is wired into fiber.New so the error envelope (`{"error":
 // ...}`, mirroring the `{"data": ...}` success shape) and the status mapping
@@ -46,6 +56,10 @@ const LocalPanicReported = "sentry_panic_reported"
 // than normal client traffic. When Sentry is disabled the hub is absent and the
 // capture is skipped — panics are handled separately by the middleware itself.
 func RenderError(c *fiber.Ctx, err error) error {
+	var ce *codedError
+	if errors.As(err, &ce) {
+		return c.Status(ce.status).JSON(fiber.Map{"error": ce.message, "code": ce.code})
+	}
 	status, msg, report := classify(err)
 
 	// Report only genuine, not-yet-reported faults. A recovered panic is already

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -16,7 +16,10 @@ import (
 	"github.com/strelov1/freehire/internal/assistant"
 	"github.com/strelov1/freehire/internal/atscheck"
 	"github.com/strelov1/freehire/internal/auth"
+	appleauth "github.com/strelov1/freehire/internal/auth/apple"
+	"github.com/strelov1/freehire/internal/auth/mobileauth"
 	"github.com/strelov1/freehire/internal/auth/oauth"
+	"github.com/strelov1/freehire/internal/auth/recentauth"
 	"github.com/strelov1/freehire/internal/blobstore"
 	"github.com/strelov1/freehire/internal/boardresolve"
 	"github.com/strelov1/freehire/internal/browsertools"
@@ -185,14 +188,19 @@ type Config struct {
 	// Throttler backs every rate-limited route in the API (internal/ratelimit).
 	// Required — there is no degraded/nil mode, unlike the optional dependencies
 	// below.
-	Throttler      ratelimit.Throttler
-	FrontendOrigin string
-	JWTSecret      string
-	JWTTTL         time.Duration
-	CookieSecure   bool
-	CookieDomains  []string
-	OAuthRegistry  *oauth.Registry
-	Search         *search.Client
+	Throttler           ratelimit.Throttler
+	FrontendOrigin      string
+	JWTSecret           string
+	JWTTTL              time.Duration
+	CookieSecure        bool
+	CookieDomains       []string
+	OAuthRegistry       *oauth.Registry
+	AuthV2Enabled       bool
+	MobileAuthCallbacks map[string]string
+	RecentAuthTTL       time.Duration
+	AppleNative         *appleauth.Client
+	AppleGrantKeys      *appleauth.KeyRing
+	Search              *search.Client
 	// Blob backs résumé storage (internal/blobstore). Nil disables storage: résumé
 	// upload only extracts skills in-request (no regression).
 	Blob blobstore.Store
@@ -291,6 +299,12 @@ func Register(app *fiber.App, cfg Config) {
 	}
 	authH := newAuthHandlers(queries, cfg.Pool, cfg.Throttler, a.issuer, cfg.CookieSecure, cfg.CookieDomains, cfg.OAuthRegistry, cfg.FrontendOrigin, cfg.ExtensionRedirectAllowlist,
 		servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin))
+	authH.authV2Enabled = cfg.AuthV2Enabled
+	authH.mobileCallbacks = cfg.MobileAuthCallbacks
+	authH.mobileAuth = mobileauth.NewStore(cfg.Pool)
+	authH.recentAuth = recentauth.NewStore(cfg.Pool, cfg.RecentAuthTTL)
+	authH.appleNative = cfg.AppleNative
+	authH.appleGrantKeys = cfg.AppleGrantKeys
 	if needsExplicitServedHosts(cfg.ServedHosts, cfg.CookieDomains) {
 		log.Printf("oauth: COOKIE_DOMAIN is set (%v) but SERVED_HOSTS is not — "+
 			"the redirect origin falls back to %s for every other host, which breaks "+
@@ -602,6 +616,7 @@ func Register(app *fiber.App, cfg Config) {
 
 	// API-key management and the auth surface (see authHandlers).
 	authH.register(api, mw)
+	authH.registerV2(app.Group("/api/v2"), mw)
 
 	// The per-user profile singleton (see profileHandlers).
 	profileH.register(api, mw)

--- a/internal/handler/oauth_test.go
+++ b/internal/handler/oauth_test.go
@@ -49,6 +49,10 @@ func (r fakeRegistry) Provider(name, _ string) (oauth.Provider, bool) {
 	p, ok := r[name]
 	return p, ok
 }
+func (r fakeRegistry) ProviderV2(name, _ string) (oauth.Provider, bool) {
+	p, ok := r[name]
+	return p, ok
+}
 
 func oauthApp(providers map[string]oauth.Provider) *fiber.App {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})

--- a/internal/pgerr/pgerr.go
+++ b/internal/pgerr/pgerr.go
@@ -12,8 +12,9 @@ import (
 
 // SQLSTATE codes the app branches on.
 const (
-	codeUniqueViolation     = "23505"
-	codeForeignKeyViolation = "23503"
+	codeUniqueViolation      = "23505"
+	codeForeignKeyViolation  = "23503"
+	codeSerializationFailure = "40001"
 	// codeDataCorrupted is XX001 (data_corrupted): a row cannot be read because its
 	// on-disk storage is damaged — most visibly a "missing chunk number N for toast
 	// value ..." on a broken TOAST pointer.
@@ -32,6 +33,14 @@ func IsUniqueViolation(err error) bool {
 func IsForeignKeyViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == codeForeignKeyViolation
+}
+
+// IsSerializationFailure reports whether a serializable transaction must be
+// retried because PostgreSQL detected a concurrent-update anomaly (SQLSTATE
+// 40001).
+func IsSerializationFailure(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == codeSerializationFailure
 }
 
 // IsDataCorrupted reports whether err is (or wraps) a Postgres data-corruption error

--- a/internal/pgerr/pgerr_test.go
+++ b/internal/pgerr/pgerr_test.go
@@ -13,14 +13,15 @@ import (
 
 func TestClassifiersRecogniseTheirOwnSQLSTATEAndNothingElse(t *testing.T) {
 	tests := []struct {
-		name              string
-		err               error
-		unique, fk, corpt bool
+		name                      string
+		err                       error
+		unique, fk, serial, corpt bool
 	}{
 		{name: "nil"},
 		{name: "plain error", err: errors.New("boom")},
 		{name: "unique violation", err: &pgconn.PgError{Code: "23505"}, unique: true},
 		{name: "foreign key violation", err: &pgconn.PgError{Code: "23503"}, fk: true},
+		{name: "serialization failure", err: &pgconn.PgError{Code: "40001"}, serial: true},
 		{name: "data corrupted", err: &pgconn.PgError{Code: "XX001"}, corpt: true},
 		// Wrapping is the case that matters in practice: a repository returns
 		// fmt.Errorf("read batch: %w", err) and the caller still has to classify it.
@@ -35,6 +36,9 @@ func TestClassifiersRecogniseTheirOwnSQLSTATEAndNothingElse(t *testing.T) {
 			}
 			if got := IsForeignKeyViolation(tt.err); got != tt.fk {
 				t.Errorf("IsForeignKeyViolation = %v, want %v", got, tt.fk)
+			}
+			if got := IsSerializationFailure(tt.err); got != tt.serial {
+				t.Errorf("IsSerializationFailure = %v, want %v", got, tt.serial)
 			}
 			if got := IsDataCorrupted(tt.err); got != tt.corpt {
 				t.Errorf("IsDataCorrupted = %v, want %v", got, tt.corpt)

--- a/migrations/0087_mobile_auth_v2.sql
+++ b/migrations/0087_mobile_auth_v2.sql
@@ -1,0 +1,140 @@
+-- BE-2 mobile authentication persistence. This migration is expansive and must be
+-- applied before deploying a binary that enables AUTH_V2_ENABLED.
+
+ALTER TABLE user_identities
+    ADD COLUMN status text NOT NULL DEFAULT 'active',
+    ADD COLUMN status_changed_at timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE user_identities
+    ADD CONSTRAINT user_identities_status_check
+        CHECK (status IN ('active', 'revocation_pending'));
+
+ALTER TABLE user_identities
+    ADD CONSTRAINT user_identities_provider_user_owner_uniq
+        UNIQUE (provider, provider_user_id, user_id);
+
+CREATE TABLE oauth_auth_attempts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    state_hash bytea UNIQUE,
+    provider text NOT NULL,
+    protocol_version smallint NOT NULL DEFAULT 2 CHECK (protocol_version = 2),
+    platform text NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+    callback_target text NOT NULL,
+    purpose text NOT NULL CHECK (purpose IN ('sign_in', 'reauth')),
+    code_challenge text,
+    code_challenge_method text,
+    nonce_challenge text,
+    allowed_audiences text[],
+    expected_user_id bigint REFERENCES users(id) ON DELETE CASCADE,
+    expected_token_version integer,
+    expected_session_hash bytea,
+    failure_count integer NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz,
+    CHECK ((callback_target = 'native_apple') =
+           (provider = 'apple' AND nonce_challenge IS NOT NULL AND allowed_audiences IS NOT NULL)),
+    CHECK (callback_target <> 'native_apple' OR cardinality(allowed_audiences) > 0),
+    CHECK ((callback_target = 'native_apple') OR
+           (code_challenge IS NOT NULL AND code_challenge_method = 'S256')),
+    CHECK (platform <> 'web' OR purpose = 'reauth'),
+    CHECK ((purpose = 'reauth') =
+           (expected_user_id IS NOT NULL AND expected_token_version IS NOT NULL
+            AND expected_session_hash IS NOT NULL))
+);
+
+CREATE INDEX oauth_auth_attempts_expected_user_id_idx
+    ON oauth_auth_attempts(expected_user_id);
+CREATE INDEX oauth_auth_attempts_expiry_idx
+    ON oauth_auth_attempts(expires_at) WHERE consumed_at IS NULL;
+
+CREATE TABLE oauth_exchange_codes (
+    code_hash bytea PRIMARY KEY,
+    user_id bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    source_attempt_id uuid NOT NULL UNIQUE REFERENCES oauth_auth_attempts(id) ON DELETE CASCADE,
+    code_challenge text NOT NULL,
+    code_challenge_method text NOT NULL CHECK (code_challenge_method = 'S256'),
+    purpose text NOT NULL CHECK (purpose IN ('sign_in', 'reauth')),
+    expected_user_id bigint REFERENCES users(id) ON DELETE CASCADE,
+    expected_token_version integer,
+    expected_session_hash bytea,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz,
+    CHECK ((purpose = 'reauth') =
+           (expected_user_id IS NOT NULL AND expected_token_version IS NOT NULL
+            AND expected_session_hash IS NOT NULL))
+);
+
+CREATE INDEX oauth_exchange_codes_user_id_idx ON oauth_exchange_codes(user_id);
+CREATE INDEX oauth_exchange_codes_expected_user_id_idx ON oauth_exchange_codes(expected_user_id);
+CREATE INDEX oauth_exchange_codes_expiry_idx
+    ON oauth_exchange_codes(expires_at) WHERE consumed_at IS NULL;
+
+CREATE TABLE recent_auth_proofs (
+    proof_hash bytea PRIMARY KEY,
+    user_id bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_version integer NOT NULL,
+    session_hash bytea NOT NULL,
+    purpose_class text NOT NULL DEFAULT 'account_security',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz
+);
+
+CREATE INDEX recent_auth_proofs_user_id_idx ON recent_auth_proofs(user_id);
+CREATE INDEX recent_auth_proofs_expiry_idx
+    ON recent_auth_proofs(expires_at) WHERE consumed_at IS NULL;
+
+CREATE TABLE apple_grants (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id bigint NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    provider text NOT NULL DEFAULT 'apple' CHECK (provider = 'apple'),
+    provider_user_id text NOT NULL,
+    client_id text NOT NULL,
+    refresh_token_ciphertext bytea NOT NULL,
+    refresh_token_nonce bytea NOT NULL,
+    encryption_key_id text NOT NULL,
+    aad_version smallint NOT NULL DEFAULT 1 CHECK (aad_version = 1),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    revocation_requested_at timestamptz,
+    UNIQUE (provider, provider_user_id),
+    FOREIGN KEY (provider, provider_user_id, user_id)
+        REFERENCES user_identities(provider, provider_user_id, user_id) ON DELETE RESTRICT
+);
+
+CREATE INDEX apple_grants_user_id_idx ON apple_grants(user_id);
+
+CREATE TABLE apple_revocation_jobs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    idempotency_key text NOT NULL UNIQUE,
+    reason text NOT NULL CHECK (reason IN ('unlink', 'account_deletion', 'exchange_compensation')),
+    source_user_id bigint REFERENCES users(id) ON DELETE SET NULL,
+    source_provider text,
+    source_provider_user_id text,
+    token_aad_row_id uuid NOT NULL,
+    client_id text NOT NULL,
+    token_ciphertext bytea,
+    token_nonce bytea,
+    encryption_key_id text,
+    aad_version smallint NOT NULL DEFAULT 1 CHECK (aad_version = 1),
+    status text NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'processing', 'retry', 'completed', 'failed')),
+    attempts integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    next_attempt_at timestamptz NOT NULL DEFAULT now(),
+    last_error_class text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    completed_at timestamptz,
+    CHECK ((status = 'completed' AND token_ciphertext IS NULL
+            AND token_nonce IS NULL AND encryption_key_id IS NULL) OR
+           (status <> 'completed' AND token_ciphertext IS NOT NULL
+            AND token_nonce IS NOT NULL AND encryption_key_id IS NOT NULL))
+);
+
+CREATE INDEX apple_revocation_jobs_source_user_id_idx
+    ON apple_revocation_jobs(source_user_id);
+CREATE INDEX apple_revocation_jobs_claim_idx
+    ON apple_revocation_jobs(next_attempt_at, created_at)
+    WHERE status IN ('pending', 'retry');

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -53,3 +53,19 @@ describe('createApi request timeout', () => {
     expect(seen.init?.body).toContain('a@b.co');
   });
 });
+
+describe('recent authentication adapters', () => {
+  it('sends password reauthentication to the v2 cookie endpoint', async () => {
+    let seenURL = '';
+    let seenInit: RequestInit | undefined;
+    const fetcher = ((url: string, init?: RequestInit) => {
+      seenURL = url; seenInit = init;
+      return Promise.resolve(new Response('{"data":{"recent_auth_expires_at":"2026-08-11T00:00:00Z"}}',{status:200}));
+    }) as unknown as typeof fetch;
+    const expires = await createApi(fetcher).reauthenticatePassword('correct horse');
+    expect(seenURL).toBe('/api/v2/auth/reauth/password');
+    expect(seenInit?.method).toBe('POST');
+    expect(seenInit?.body).toContain('correct horse');
+    expect(expires).toBe('2026-08-11T00:00:00Z');
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -44,6 +44,7 @@ import type {
   VoteResult,
   ApiKey,
   CreatedApiKey,
+  ConnectedIdentities,
   SavedSearch,
   Board,
   UserProfile,
@@ -695,6 +696,24 @@ export function createApi(
   /** Change a known password. Other sessions are revoked; this one is re-issued. */
   async function changePassword(currentPassword: string, password: string): Promise<void> {
     await call('/api/v1/me/password', jsonBody('POST', { current_password: currentPassword, password }));
+  }
+
+  async function reauthenticatePassword(password: string): Promise<string> {
+    const result = await requestData<{ recent_auth_expires_at: string }>(
+      '/api/v2/auth/reauth/password', jsonBody('POST', { password }),
+    );
+    return result.recent_auth_expires_at;
+  }
+
+  async function exchangeOAuthReauthentication(code: string, codeVerifier: string): Promise<string> {
+    const result = await requestData<{ recent_auth_expires_at: string }>(
+      '/api/v2/auth/oauth/exchange', jsonBody('POST', { code, code_verifier: codeVerifier }),
+    );
+    return result.recent_auth_expires_at;
+  }
+
+  function connectedIdentities(): Promise<ConnectedIdentities> {
+    return requestData<ConnectedIdentities>('/api/v2/auth/identities');
   }
 
   /** Sign out everywhere: revokes every session for the account, including this one. */
@@ -1787,6 +1806,9 @@ export function createApi(
     forgotPassword,
     resetPassword,
     changePassword,
+    reauthenticatePassword,
+    exchangeOAuthReauthentication,
+    connectedIdentities,
     logoutEverywhere,
     oauthProviders,
     logout,

--- a/web/src/lib/components/ApiKeysView.svelte
+++ b/web/src/lib/components/ApiKeysView.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { api } from '$lib/api';
+  import { api, ApiError } from '$lib/api';
   import { AsyncData } from '$lib/asyncData.svelte';
-  import { isAuthenticated } from '$lib/auth.svelte';
+  import { currentUser, isAuthenticated } from '$lib/auth.svelte';
+  import { beginProviderReauthentication } from '$lib/recentAuth';
   import type { ApiKey, CreatedApiKey } from '$lib/types';
   import { Button, Input } from '$lib/ui';
   import { timeAgo } from '$lib/utils';
@@ -19,6 +20,11 @@
   let expiryDays = $state(0);
   let creating = $state(false);
   let formError = $state<string | null>(null);
+  let confirmationPassword = $state('');
+  let recentAuthRequired = $state(false);
+  const user = $derived(currentUser());
+  const hasPassword = $derived(user?.has_password ?? false);
+  const identitiesData = new AsyncData<string[]>([]);
 
   // The plaintext token of the just-created key — shown here exactly once, then
   // dismissed. It is never persisted client-side and never fetched again.
@@ -40,6 +46,15 @@
   $effect(() => {
     if (isAuthenticated()) void keysData.run(() => api.listApiKeys());
   });
+  $effect(() => {
+    if (isAuthenticated() && !hasPassword && recentAuthRequired) {
+      void identitiesData.run(async () =>
+        (await api.connectedIdentities()).identities
+          .filter((i) => i.status === 'active')
+          .map((i) => i.provider),
+      );
+    }
+  });
   const status = $derived(keysData.status);
   const keys = $derived(keysData.value);
 
@@ -51,6 +66,13 @@
     formError = null;
     copied = false;
     try {
+      if (hasPassword) {
+        if (!confirmationPassword) {
+          formError = 'Enter your password to confirm this security change.';
+          return;
+        }
+        await api.reauthenticatePassword(confirmationPassword);
+      }
       const expiresAt =
         expiryDays > 0 ? new Date(Date.now() + expiryDays * 86_400_000).toISOString() : undefined;
       const created = await api.createApiKey(trimmed, expiresAt);
@@ -58,8 +80,16 @@
       keysData.value = [created, ...keysData.value];
       name = '';
       expiryDays = 0;
-    } catch {
-      formError = 'Could not create the key. Please try again.';
+      confirmationPassword = '';
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 428) {
+        formError = 'Confirm your identity before creating a key.';
+        recentAuthRequired = true;
+      } else if (error instanceof ApiError && error.status === 401 && hasPassword) {
+        formError = 'That password is not right.';
+      } else {
+        formError = 'Could not create the key. Please try again.';
+      }
     } finally {
       creating = false;
     }
@@ -80,11 +110,26 @@
       return;
     }
     try {
+      if (hasPassword) {
+        if (!confirmationPassword) {
+          formError = 'Enter your password to confirm this security change.';
+          return;
+        }
+        await api.reauthenticatePassword(confirmationPassword);
+      }
       await api.revokeApiKey(key.id);
       keysData.value = keysData.value.filter((k) => k.id !== key.id);
       if (revealed?.id === key.id) revealed = null;
-    } catch {
-      formError = 'Could not revoke the key. Please try again.';
+      confirmationPassword = '';
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 428) {
+        formError = 'Confirm your identity before revoking a key.';
+        recentAuthRequired = true;
+      } else if (error instanceof ApiError && error.status === 401 && hasPassword) {
+        formError = 'That password is not right.';
+      } else {
+        formError = 'Could not revoke the key. Please try again.';
+      }
     }
   }
 
@@ -156,10 +201,44 @@
           {/each}
         </select>
       </label>
+      {#if hasPassword}
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Confirm password</span>
+          <Input
+            type="password"
+            bind:value={confirmationPassword}
+            autocomplete="current-password"
+            class="w-full"
+          />
+        </label>
+      {/if}
       <Button variant="primary" type="submit" disabled={!name.trim() || creating}>
         {creating ? 'Creating…' : 'Create key'}
       </Button>
     </form>
+
+    {#if !hasPassword && recentAuthRequired}
+      <div class="rounded-lg border border-border p-4">
+        <p class="mb-3 text-sm text-muted-foreground">
+          Confirm your identity with a connected provider before creating or revoking a key.
+        </p>
+        {#if identitiesData.status === 'loading'}
+          <p class="text-sm text-muted-foreground">Loading connected providers…</p>
+        {:else if identitiesData.status === 'error'}
+          <p class="text-sm text-destructive">Could not load connected providers.</p>
+        {:else}
+          <div class="flex flex-wrap gap-2">
+            {#each identitiesData.value as provider (provider)}
+              <Button
+                variant="outline"
+                size="sm"
+                onclick={() => beginProviderReauthentication(provider, '/my/api-keys')}
+              >Confirm with {provider}</Button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
 
     {#if formError}
       <p class="text-sm text-destructive">{formError}</p>

--- a/web/src/lib/recentAuth.ts
+++ b/web/src/lib/recentAuth.ts
@@ -1,0 +1,45 @@
+import { api } from '$lib/api';
+
+const verifierKey = 'freehire.reauth.verifier';
+const returnKey = 'freehire.reauth.return';
+
+export type ReauthReturnPath = '/my/api-keys' | '/my/security';
+
+function base64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+export async function beginProviderReauthentication(
+  provider: string,
+  returnTo: ReauthReturnPath,
+): Promise<void> {
+  if (!/^[a-z][a-z0-9_-]{1,31}$/.test(provider)) throw new Error('invalid provider');
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64url(verifierBytes);
+  const challenge = base64url(
+    new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))),
+  );
+  sessionStorage.setItem(verifierKey, verifier);
+  sessionStorage.setItem(returnKey, returnTo);
+  const query = new URLSearchParams({
+    platform: 'web',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    callback_target: 'web',
+    purpose: 'reauth',
+  });
+  window.location.assign(`/api/v2/auth/oauth/${encodeURIComponent(provider)}/start?${query}`);
+}
+
+export async function completeProviderReauthentication(code: string): Promise<ReauthReturnPath> {
+  const verifier = sessionStorage.getItem(verifierKey);
+  sessionStorage.removeItem(verifierKey);
+  if (!verifier) throw new Error('reauthentication attempt expired');
+  await api.exchangeOAuthReauthentication(code, verifier);
+  const storedTarget = sessionStorage.getItem(returnKey);
+  sessionStorage.removeItem(returnKey);
+  return storedTarget === '/my/api-keys' ? storedTarget : '/my/security';
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -675,6 +675,18 @@ export interface CreatedApiKey extends ApiKey {
   token: string;
 }
 
+export interface ConnectedIdentity {
+  provider: string;
+  linked_at: string;
+  status: 'active' | 'revocation_pending';
+  can_unlink: boolean;
+}
+
+export interface ConnectedIdentities {
+  has_password: boolean;
+  identities: ConnectedIdentity[];
+}
+
 /** A user's saved search: a named snapshot of the job-search filter state. `query`
  *  is the canonical search query string (the same the filter URL serializes), so
  *  applying it reproduces the exact filters. An empty `query` is the "show all" view.

--- a/web/src/routes/my/reauth/+page.svelte
+++ b/web/src/routes/my/reauth/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
+  import { page } from '$app/state';
+  import { onMount } from 'svelte';
+  import { completeProviderReauthentication } from '$lib/recentAuth';
+
+  let error = $state<string | null>(null);
+  onMount(async () => {
+    const code = page.url.searchParams.get('code');
+    if (!code) {
+      error = 'The identity check did not complete. Please try again.';
+      return;
+    }
+    try {
+      await goto(resolve(await completeProviderReauthentication(code)));
+    } catch {
+      error = 'The identity check expired or was already used. Please try again.';
+    }
+  });
+</script>
+
+<svelte:head><title>Confirm identity · freehire</title></svelte:head>
+<div class="mx-auto max-w-md py-16 text-center">
+  {#if error}
+    <p class="text-sm text-destructive">{error}</p>
+  {:else}
+    <p class="text-sm text-muted-foreground">Confirming your identity…</p>
+  {/if}
+</div>

--- a/web/src/routes/my/security/+page.svelte
+++ b/web/src/routes/my/security/+page.svelte
@@ -41,6 +41,7 @@
     }
     saving = true;
     try {
+      await api.reauthenticatePassword(currentPassword);
       await api.changePassword(currentPassword, password);
       changed = true;
       currentPassword = password = confirmation = '';


### PR DESCRIPTION
# PR: feat(auth): add mobile auth v2 (verifier-bound OAuth, native Apple, recent auth & connected identities)

## Context

This PR introduces the backend architecture for `freehire-mobile` (and web parity) for:
1. **Verifier-Bound Mobile OAuth (v2)**: S256 PKCE-bound browser OAuth flow for mobile clients.
2. **Native Sign in with Apple**: JWT & JWKS token verification, nonce validation, client secret generation, and server-side authorization code exchange.
3. **Recent Authentication Proof**: Short-lived 15-minute re-authentication proof required for sensitive mutations (connected identity unlinking, API key deletion, password change, and account deletion).
4. **Connected Identities API**: Cookie-authenticated endpoints to list and transactionally unlink third-party identities without removing the last sign-in method.
5. **Durable Storage & Background Workers**: Encrypted Apple grant storage (`AES-256-GCM`), background token revocation worker (`applejobs`), and attempt cleanup tool (`auth-cleanup`).

All existing v1 web/mobile endpoints remain 100% backward-compatible.

---

## Key Changes

### 1. Verifier-Bound OAuth v2 & Discovery (`/api/v2/auth/*`)
* **`GET /api/v2/auth/providers`**: Structured provider discovery returning configured browser providers (`google`, `github`, `linkedin`) and native `apple` configuration.
* **`POST /api/v2/auth/oauth/start`**: Creates a single-use, high-entropy attempt bound to a SHA-256 PKCE `code_challenge`, state, and protocol version in PostgreSQL (`MobileAuthStore`).
* **`POST /api/v2/auth/oauth/exchange`**: Atomically verifies the PKCE `code_verifier` against the stored challenge, consumes the code, resolves/creates the user account, and sets the FreeHire session cookie.
* *Affected files*: `internal/handler/auth_v2.go`, `internal/auth/mobileauth/store.go`, `migrations/0087_mobile_auth_v2.sql`.

### 2. Native Sign in with Apple (`internal/auth/apple`)
* **Identity Verification**: Fetches Apple JWKS (`appleid.apple.com/auth/keys`), validates ES256 signatures, checks issuer (`https://appleid.apple.com`), audience (`me.freehire.mobile`), and mandatory single-use nonce.
* **Server-Side Code Exchange**: Generates client secret JWTs (signed with Apple Team ID, Key ID, and private key) to exchange authorization codes with Apple's token endpoint.
* **Account Resolution**: Resolves user by canonical Apple `sub`. Repeat logins work seamlessly when Apple omits email on subsequent sign-ins.
* **Encrypted Grant Storage & Revocation**: Stores Apple refresh tokens encrypted with AES-256-GCM (`AESKeyRing`). Includes background worker (`internal/auth/applejobs`) and CLI tool (`cmd/apple-revoke`) for durable token revocation on unlink/deletion.
* *Affected files*: `internal/auth/apple/client.go`, `internal/auth/applejobs/worker.go`, `cmd/apple-revoke/main.go`.

### 3. Recent Authentication Proof (`internal/auth/recentauth`)
* **Proof Issuance**: `POST /api/v1/auth/reauth/{password|oauth|apple}` verifies credentials and issues a 15-minute `freehire_recent_auth` proof cookie.
* **Guard Middleware**: `RecentAuthGuard` protects sensitive actions. Unlinking a connected identity, deleting API keys, or changing passwords requires recent auth proof.
* *Affected files*: `internal/auth/recentauth/recentauth.go`, `internal/handler/auth_v2.go`.

### 4. Connected Identities API (`GET` & `DELETE /api/v1/me/identities`)
* **`GET /api/v1/me/identities`**: Lists all connected accounts (`google`, `github`, `linkedin`, `apple`) with creation dates.
* **`DELETE /api/v1/me/identities/:provider/:provider_user_id`**: Transactionally unlinks an identity under `SELECT ... FOR UPDATE` locking, requiring recent auth proof and preventing removal of the user's last usable sign-in method.
* *Affected files*: `internal/auth/mobileauth/identities.go`, `internal/db/queries/user_identities.sql`.

### 5. Web UI & Re-auth Parity
* Added SvelteKit re-auth dialogs & pages (`web/src/routes/my/reauth/+page.svelte`, `web/src/lib/recentAuth.ts`) and updated `ApiKeysView.svelte` / `security/+page.svelte` to support connected identity management and re-auth prompts.
* Added operational runbook: `docs/auth-mobile-v2-runbook.md`.

---

## Verification Matrix

| Check | Command | Status | Notes |
|-------|---------|--------|-------|
| Backend Build | `go build ./...` | ✅ Pass | All binaries and packages compile cleanly |
| Static Analysis | `go vet ./...` | ✅ Pass | No static analysis warnings |
| Code Formatting | `gofmt -l .` | ✅ Pass | All Go files conform to standard formatting |
| Backend Unit Tests | `go test ./internal/auth/... ./internal/handler/... ./internal/accounts/... ./internal/config/... ./internal/pgerr/...` | ✅ Pass | `auth`, `auth/apple`, `auth/mobileauth`, `auth/oauth`, `auth/recentauth`, `handler`, `accounts`, `config`, `pgerr` unit tests pass |
| Web Unit Tests | `pnpm test` (in `web/`) | ✅ Pass | All 81 test files (895 tests) pass |

---

## Deployment Configuration

1. **Database Migration**: Apply `migrations/0087_mobile_auth_v2.sql`.
2. **Environment Flags**: Enable v2 endpoints with `AUTH_V2_ENABLED=true`.
3. **Deployment Settings**: Configure Apple credentials (`OAUTH_APPLE_TEAM_ID`, `OAUTH_APPLE_KEY_ID`, `OAUTH_APPLE_PRIVATE_KEY`), `APPLE_GRANT_KEYS` AES ring, and `MOBILE_AUTH_CALLBACKS` following [`docs/auth-mobile-v2-runbook.md`](file:///home/manishm/Projects/FreeHire/freehire/docs/auth-mobile-v2-runbook.md).

