### PR TITLE
fix(auth): close mobile-auth-v2 gaps found in PR #1748 review

### DIFF
--- a/internal/accountdelete/accountdelete.go
+++ b/internal/accountdelete/accountdelete.go
@@ -42,6 +42,12 @@ type Repository interface {
 // Gmail OAuth token, revoked at Google. It is nil when the feature is unconfigured.
 type RevokeFunc func(ctx context.Context, userID int64) error
 
+// AppleGrantsFunc releases the account's Apple Sign In grants. Unlike RevokeFunc
+// above, it is not best-effort: the apple_grants row references users with
+// ON DELETE RESTRICT, so a failure here must stop deletion rather than let
+// DeleteUser fail underneath it with a raw FK violation.
+type AppleGrantsFunc func(ctx context.Context, userID int64) error
+
 // Service erases accounts. blobs is nil when object storage is unconfigured and
 // revoke is nil when Gmail is; either way there is simply nothing to erase there,
 // which must not stop a member from leaving.
@@ -53,6 +59,10 @@ type Service struct {
 	// erasing it — the gateway's spend record hangs off that key. Nil when the
 	// deployment does not attribute spend, which is simply nothing to do there.
 	blockKey RevokeFunc
+	// appleGrants releases the account's Apple Sign In grants. Nil only in tests
+	// that don't wire it; production always does, since apple_grants exists
+	// regardless of whether AUTH_V2_ENABLED is on.
+	appleGrants AppleGrantsFunc
 }
 
 // New builds the service. Pass a nil store and/or a nil revoker for a deployment
@@ -101,6 +111,14 @@ func (s *Service) Delete(ctx context.Context, userID int64) error {
 			log.Printf("accountdelete: block gateway credential for user %d: %v", userID, err)
 		}
 	}
+	// Apple grants block the row itself (ON DELETE RESTRICT), so releasing them
+	// happens last and, unlike the best-effort steps above, a failure here stops
+	// deletion instead of surfacing as a raw FK violation out of DeleteUser.
+	if s.appleGrants != nil {
+		if err := s.appleGrants(ctx, userID); err != nil {
+			return fmt.Errorf("accountdelete: release apple grants: %w", err)
+		}
+	}
 	return s.repo.DeleteUser(ctx, userID)
 }
 
@@ -110,6 +128,13 @@ func (s *Service) Delete(ctx context.Context, userID int64) error {
 // positional argument would stop saying which is which.
 func (s *Service) WithGatewayKeys(block RevokeFunc) *Service {
 	s.blockKey = block
+	return s
+}
+
+// WithAppleGrants attaches the releaser for the account's Apple Sign In grants.
+// Separate from the constructor for the same reason WithGatewayKeys is.
+func (s *Service) WithAppleGrants(release AppleGrantsFunc) *Service {
+	s.appleGrants = release
 	return s
 }
 

--- a/internal/accountdelete/accountdelete_test.go
+++ b/internal/accountdelete/accountdelete_test.go
@@ -191,3 +191,49 @@ func TestDelete_KeyReadFailureAborts(t *testing.T) {
 		t.Error("rows were deleted without knowing the object keys")
 	}
 }
+
+// Apple grants reference users with ON DELETE RESTRICT, so releasing them runs
+// before the row delete, and — unlike the best-effort Gmail/gateway steps —
+// its failure must abort deletion rather than let DeleteUser hit the FK.
+func TestDelete_ReleasesAppleGrantsBeforeTheRow(t *testing.T) {
+	var calls []string
+	repo := &fakeRepo{calls: &calls}
+	svc := New(repo, nil, nil).WithAppleGrants(func(context.Context, int64) error {
+		calls = append(calls, "release-apple-grants")
+		return nil
+	})
+
+	if err := svc.Delete(context.Background(), 7); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	released, deleted := -1, -1
+	for i, c := range calls {
+		switch c {
+		case "release-apple-grants":
+			released = i
+		case "delete-rows":
+			deleted = i
+		}
+	}
+	if released < 0 {
+		t.Fatalf("calls = %v, want apple grants released", calls)
+	}
+	if deleted < 0 || released > deleted {
+		t.Errorf("calls = %v, want apple grants released before the row is erased", calls)
+	}
+}
+
+func TestDelete_AppleGrantsFailureBlocksDeletion(t *testing.T) {
+	var calls []string
+	repo := &fakeRepo{calls: &calls}
+	svc := New(repo, nil, nil).WithAppleGrants(func(context.Context, int64) error {
+		return errors.New("still has an active apple grant")
+	})
+
+	if err := svc.Delete(context.Background(), 7); err == nil {
+		t.Fatal("Delete succeeded despite a failed apple grant release")
+	}
+	if repo.deleteSeen {
+		t.Error("rows were deleted despite the FK still being blocked")
+	}
+}

--- a/internal/auth/mobileauth/identities.go
+++ b/internal/auth/mobileauth/identities.go
@@ -194,6 +194,66 @@ func (s *Store) ActivateAppleCompensation(ctx context.Context, jobID uuid.UUID) 
 
 func proofDigest(raw string) []byte { sum := sha256.Sum256([]byte(raw)); return sum[:] }
 
+// ReleaseAppleGrantsForDeletion queues Apple revocation for every grant the
+// account holds and clears the apple_grants rows, freeing the FK
+// (ON DELETE RESTRICT) that would otherwise block deleting the user. The
+// ciphertext is carried into the revocation job before the grant row is
+// dropped, so the background worker can still revoke it with Apple even
+// though the account — and the grant's own row — are already gone.
+// Idempotent: a retried account deletion finds no grants left and no-ops.
+func (s *Store) ReleaseAppleGrantsForDeletion(ctx context.Context, userID int64) error {
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		err = s.releaseAppleGrantsForDeletionOnce(ctx, userID)
+		if !pgerr.IsSerializationFailure(err) {
+			return err
+		}
+	}
+	return err
+}
+
+func (s *Store) releaseAppleGrantsForDeletionOnce(ctx context.Context, userID int64) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	type appleGrant struct {
+		id                       uuid.UUID
+		subject, clientID, keyID string
+		ciphertext, nonce        []byte
+	}
+	rows, err := tx.Query(ctx, `SELECT id,provider_user_id,client_id,refresh_token_ciphertext,refresh_token_nonce,encryption_key_id FROM apple_grants WHERE user_id=$1 AND provider='apple' FOR UPDATE`, userID)
+	if err != nil {
+		return err
+	}
+	var grants []appleGrant
+	for rows.Next() {
+		var g appleGrant
+		if err = rows.Scan(&g.id, &g.subject, &g.clientID, &g.ciphertext, &g.nonce, &g.keyID); err != nil {
+			rows.Close()
+			return err
+		}
+		grants = append(grants, g)
+	}
+	rows.Close()
+	if err = rows.Err(); err != nil {
+		return err
+	}
+	for _, g := range grants {
+		idempotency := "account_deletion:apple:" + g.id.String()
+		if _, err = tx.Exec(ctx, `INSERT INTO apple_revocation_jobs(idempotency_key,reason,source_user_id,source_provider,source_provider_user_id,token_aad_row_id,client_id,token_ciphertext,token_nonce,encryption_key_id) VALUES($1,'account_deletion',$2,'apple',$3,$4,$5,$6,$7,$8) ON CONFLICT(idempotency_key) DO NOTHING`, idempotency, userID, g.subject, g.id, g.clientID, g.ciphertext, g.nonce, g.keyID); err != nil {
+			return err
+		}
+	}
+	if len(grants) > 0 {
+		if _, err = tx.Exec(ctx, `DELETE FROM apple_grants WHERE user_id=$1 AND provider='apple'`, userID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
 // UnlinkIdentity locks every sign-in method, consumes recent-auth, and either
 // removes a grantless identity or durably queues Apple revocation in one serializable transaction.
 func (s *Store) UnlinkIdentity(ctx context.Context, userID int64, tokenVersion int32, sessionHash []byte, provider, recentProof string) (pending bool, err error) {

--- a/internal/auth/mobileauth/store_integration_test.go
+++ b/internal/auth/mobileauth/store_integration_test.go
@@ -232,6 +232,60 @@ func TestConcurrentAppleFinalizeAndUnlinkPreserveQueuedGrant(t *testing.T) {
 	}
 }
 
+// A user who signed in with native Apple leaves an apple_grants row that
+// references users with ON DELETE RESTRICT. Account deletion must be able to
+// clear it — by queuing a revocation job carrying its own encrypted copy of
+// the token and dropping the row — rather than have Postgres reject the
+// DELETE FROM users underneath it.
+func TestReleaseAppleGrantsForDeletionUnblocksUserDelete(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, true)
+	const subject, clientID = "apple-deletion-subject", "me.freehire.mobile"
+	if _, err := store.pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id) VALUES('apple',$1,$2)`, subject, userID); err != nil {
+		t.Fatal(err)
+	}
+	ring, err := apple.NewKeyRing("v1", map[string][]byte{"v1": bytes.Repeat([]byte{6}, 32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	persistAppleGrant(t, ctx, store, ring, userID, subject, clientID, "refresh-token")
+
+	if err = store.ReleaseAppleGrantsForDeletion(ctx, userID); err != nil {
+		t.Fatalf("ReleaseAppleGrantsForDeletion: %v", err)
+	}
+
+	var grants int
+	if err = store.pool.QueryRow(ctx, `SELECT count(*) FROM apple_grants WHERE user_id=$1`, userID).Scan(&grants); err != nil {
+		t.Fatal(err)
+	}
+	if grants != 0 {
+		t.Fatalf("apple_grants rows left = %d, want 0", grants)
+	}
+	var jobs int
+	if err = store.pool.QueryRow(ctx, `SELECT count(*) FROM apple_revocation_jobs WHERE source_user_id=$1 AND reason='account_deletion' AND status='pending'`, userID).Scan(&jobs); err != nil {
+		t.Fatal(err)
+	}
+	if jobs != 1 {
+		t.Fatalf("account_deletion revocation jobs = %d, want 1", jobs)
+	}
+
+	if _, err = store.pool.Exec(ctx, `DELETE FROM users WHERE id=$1`, userID); err != nil {
+		t.Fatalf("DELETE FROM users still blocked after releasing apple grants: %v", err)
+	}
+}
+
+// Calling it again after everything is already released — the retry path an
+// account-deletion request takes if a prior attempt failed downstream — must
+// not error just because there is nothing left to do.
+func TestReleaseAppleGrantsForDeletionIsIdempotent(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, true)
+	if err := store.ReleaseAppleGrantsForDeletion(ctx, userID); err != nil {
+		t.Fatalf("ReleaseAppleGrantsForDeletion on a user with no grants: %v", err)
+	}
+	if err := store.ReleaseAppleGrantsForDeletion(ctx, userID); err != nil {
+		t.Fatalf("ReleaseAppleGrantsForDeletion called twice: %v", err)
+	}
+}
+
 func TestCleanupPreservesAttemptWithLiveExchangeCode(t *testing.T) {
 	ctx, userID, store := seedAuthUser(t, true)
 	verifier := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -134,8 +134,10 @@ func (h *authHandlers) register(api fiber.Router, mw middleware) {
 
 	// Account deletion is permanent and cookie-only, for the same reason key
 	// management is: a leaked API key must not be able to destroy the account that
-	// issued it. The body confirms the caller's own email address.
-	meGroup.Delete("", mw.cookie, h.DeleteAccount)
+	// issued it. The body confirms the caller's own email address. It requires
+	// recent auth for the same reason password change does: a hijacked session
+	// must not be able to take the one action that can't be undone.
+	meGroup.Delete("", mw.cookie, recent, h.DeleteAccount)
 
 	// Auth: register/login/logout are public (logout just clears the cookie).
 	// me is guarded and accepts a session cookie OR an API key, so a non-browser

--- a/internal/handler/auth_v2.go
+++ b/internal/handler/auth_v2.go
@@ -25,6 +25,34 @@ type oauthV2Registry interface {
 
 const oauthV2StateCookieName = "hire_oauth_v2_state"
 
+// errOAuthV2StateMismatch and errOAuthV2MissingCode are named so oauthV2Fail
+// can tell an ordinary CSRF-state check or a malformed provider callback (both
+// routine, not worth a Sentry report) apart from a genuine infra failure.
+var (
+	errOAuthV2StateMismatch = errors.New("oauth v2: state mismatch")
+	errOAuthV2MissingCode   = errors.New("oauth v2: missing code")
+)
+
+// isExpectedAttemptFailure reports whether err is one of the mobileauth
+// validation sentinels — caller sent a malformed or stale attempt — rather
+// than an unexpected infra failure that should reach Sentry via RenderError.
+func isExpectedAttemptFailure(err error) bool {
+	return errors.Is(err, mobileauth.ErrInvalid) ||
+		errors.Is(err, mobileauth.ErrVerifier) ||
+		errors.Is(err, mobileauth.ErrSession)
+}
+
+// isExpectedOAuthV2Failure extends isExpectedAttemptFailure with the other
+// routine causes oauthV2Fail sees: reauth identity mismatch, an account with
+// no verified email, and the two local checks in OAuthCallbackV2 itself.
+func isExpectedOAuthV2Failure(err error) bool {
+	return isExpectedAttemptFailure(err) ||
+		errors.Is(err, mobileauth.ErrIdentity) ||
+		errors.Is(err, accounts.ErrNoVerifiedEmail) ||
+		errors.Is(err, errOAuthV2StateMismatch) ||
+		errors.Is(err, errOAuthV2MissingCode)
+}
+
 func (h *authHandlers) currentSessionHash(c *fiber.Ctx) ([]byte, error) {
 	raw := c.Cookies(auth.CookieName)
 	if raw == "" {
@@ -160,7 +188,10 @@ func (h *authHandlers) OAuthStartV2(c *fiber.Ctx) error {
 	}
 	_, state, err := h.mobileAuth.CreateBrowserAttempt(c.Context(), provider, platform, target, purpose, c.Query("code_challenge"), binding)
 	if err != nil {
-		return authError(400, "invalid_oauth_attempt", "invalid OAuth attempt")
+		if isExpectedAttemptFailure(err) {
+			return authError(400, "invalid_oauth_attempt", "invalid OAuth attempt")
+		}
+		return err
 	}
 	oauth.SetStateCookieNamed(c, oauthV2StateCookieName, state, h.cookieSecure)
 	return c.Redirect(p.AuthCodeURL(state), fiber.StatusFound)
@@ -194,14 +225,14 @@ func (h *authHandlers) OAuthCallbackV2(c *fiber.Ctx) error {
 	cookieState := c.Cookies(oauthV2StateCookieName)
 	oauth.ClearStateCookieNamed(c, oauthV2StateCookieName, h.cookieSecure)
 	if state == "" || subtle.ConstantTimeCompare([]byte(state), []byte(cookieState)) != 1 {
-		return h.oauthV2Fail(c, "", errors.New("state mismatch"))
+		return h.oauthV2Fail(c, "", errOAuthV2StateMismatch)
 	}
 	attempt, err := h.mobileAuth.ConsumeBrowserAttempt(c.Context(), state, provider)
 	if err != nil {
 		return h.oauthV2Fail(c, "", err)
 	}
 	if code == "" {
-		return h.oauthV2Fail(c, attempt.CallbackTarget, errors.New("missing code"))
+		return h.oauthV2Fail(c, attempt.CallbackTarget, errOAuthV2MissingCode)
 	}
 	identity, err := p.FetchIdentity(c.Context(), code)
 	if err != nil {
@@ -235,6 +266,14 @@ func (h *authHandlers) oauthV2Fail(c *fiber.Ctx, target string, cause error) err
 	if errors.Is(cause, mobileauth.ErrIdentity) {
 		code = "reauth_identity_mismatch"
 	}
+	// This leg always redirects rather than returning through RenderError, so
+	// it has to open its own Sentry gate: a routine cause (bad state, expired
+	// attempt, provider rejected the code) stays silent, anything else — a DB
+	// error out of the store, the OAuth provider itself being down — is a
+	// genuine fault and must not vanish behind a generic "sign-in failed".
+	if !isExpectedOAuthV2Failure(cause) {
+		reportUnexpected(c, cause)
+	}
 	base := h.mobileCallbacks[target]
 	if base == "" {
 		return authError(401, code, "sign-in failed")
@@ -265,7 +304,10 @@ func (h *authHandlers) OAuthExchangeV2(c *fiber.Ctx) error {
 	}
 	ex, err := h.mobileAuth.ConsumeCode(c.Context(), in.Code, in.Verifier)
 	if err != nil {
-		return authError(401, "invalid_exchange_code", "invalid or expired code")
+		if errors.Is(err, mobileauth.ErrInvalid) || errors.Is(err, mobileauth.ErrVerifier) || errors.Is(err, mobileauth.ErrIdentity) {
+			return authError(401, "invalid_exchange_code", "invalid or expired code")
+		}
+		return err
 	}
 	if ex.Purpose == "reauth" {
 		current, currentErr := requireUserID(c)
@@ -307,7 +349,10 @@ func (h *authHandlers) AppleAttemptV2(c *fiber.Ctx) error {
 	}
 	a, err := h.mobileAuth.CreateAppleAttempt(c.Context(), in.NonceChallenge, in.Purpose, h.appleNative.ClientIDs(), binding)
 	if err != nil {
-		return authError(400, "invalid_apple_attempt", "invalid Apple attempt")
+		if isExpectedAttemptFailure(err) {
+			return authError(400, "invalid_apple_attempt", "invalid Apple attempt")
+		}
+		return err
 	}
 	return c.JSON(fiber.Map{"data": fiber.Map{"attempt_id": a.ID, "expires_at": a.ExpiresAt}})
 }
@@ -331,7 +376,10 @@ func (h *authHandlers) AppleExchangeV2(c *fiber.Ctx) error {
 	}
 	attempt, err := h.mobileAuth.ConsumeAppleAttempt(c.Context(), id)
 	if err != nil {
-		return authError(401, "invalid_apple_attempt", "invalid or expired Apple attempt")
+		if errors.Is(err, mobileauth.ErrInvalid) {
+			return authError(401, "invalid_apple_attempt", "invalid or expired Apple attempt")
+		}
+		return err
 	}
 	if mobileauth.ValidateVerifier(in.RawNonce) != nil || subtle.ConstantTimeCompare([]byte(mobileauth.Challenge(in.RawNonce)), []byte(attempt.NonceChallenge)) != 1 {
 		return authError(401, "invalid_apple_nonce", "Apple nonce mismatch")

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -74,6 +74,16 @@ func RenderError(c *fiber.Ctx, err error) error {
 	return c.Status(status).JSON(fiber.Map{"error": msg})
 }
 
+// reportUnexpected sends err to Sentry as a genuine fault. It exists for call
+// sites that build their own response — a redirect, typically — instead of
+// returning through RenderError, but still want the same "only real faults
+// reach the error inbox" gate RenderError applies to everything else.
+func reportUnexpected(c *fiber.Ctx, err error) {
+	if hub := sentryfiber.GetHubFromContext(c); hub != nil {
+		hub.CaptureException(err)
+	}
+}
+
 // classify maps an error to its HTTP status and message and reports whether it is
 // an unexpected fault worth sending to Sentry. Only the fall-through 500 is
 // unexpected; a *fiber.Error, the 404-mapped DB errors, a client disconnect, and

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -416,7 +416,8 @@ func Register(app *fiber.App, cfg Config) {
 	// to erase there, which must not stop a member from leaving.
 	// The gateway credential is the third external system erasure spans, after object
 	// storage and Google. It is attached below, once the resolver exists.
-	accountDeletion := accountdelete.New(accountdelete.NewQueriesRepository(queries), cfg.Blob, inboxH.revokeGmailGrant)
+	accountDeletion := accountdelete.New(accountdelete.NewQueriesRepository(queries), cfg.Blob, inboxH.revokeGmailGrant).
+		WithAppleGrants(authH.mobileAuth.ReleaseAppleGrantsForDeletion)
 	authH.withAccountDeletion(accountDeletion, queries)
 	// Assign only when configured: a nil *search.Client wrapped in the searcher
 	// interface would be a non-nil interface and defeat the nil check.


### PR DESCRIPTION
## Context

Follow-up to #1748 (mobile auth v2). A thorough review turned up three issues; this fixes the ones with real user-facing consequences.

## Fixes

1. **Account deletion wasn't gated by recent-auth.** Every other sensitive mutation (password change, API key create/revoke) requires a fresh recent-auth proof once `AUTH_V2_ENABLED` is on; account deletion — the one action that can't be undone — didn't. A hijacked session (short of full credential theft) could permanently erase the account. `DELETE /api/me` now goes through the same `recent` middleware.

2. **Account deletion was broken outright for anyone who used native Sign in with Apple.** `apple_grants.user_id` is `ON DELETE RESTRICT`, so `DeleteUser` hit a raw FK violation and failed. `accountdelete.Service` now releases the account's Apple grants first — via a new `WithAppleGrants` hook — mirroring how identity-unlink already handles it: queue an `account_deletion` revocation job (which carries its own encrypted copy of the refresh token so the background worker can still revoke it with Apple after the row is gone) and clear the `apple_grants` row, which frees the FK.

3. **Several `auth_v2` handlers swallowed genuine DB/infra failures into a generic "invalid or expired" response.** `OAuthStartV2`, `AppleAttemptV2`, `OAuthExchangeV2`, `AppleExchangeV2`, and `oauthV2Fail` mapped *every* error out of the `mobileauth` store — validation failures and outages alike — onto a fixed `codedError`, which both misled the caller (told "invalid code" when the DB was actually down) and hid the failure from Sentry (only unmapped errors reach `classify()`'s reporting branch). They now only convert the store's own validation sentinels (`ErrInvalid`/`ErrVerifier`/`ErrSession`/`ErrIdentity`); anything else propagates through to `RenderError` and gets reported.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/handler/... ./internal/accountdelete/... ./internal/auth/...`
- [x] `go test -tags=integration ./internal/auth/mobileauth/... ./internal/accountdelete/...` (new tests: `TestReleaseAppleGrantsForDeletionUnblocksUserDelete`, `TestReleaseAppleGrantsForDeletionIsIdempotent`, `TestDelete_ReleasesAppleGrantsBeforeTheRow`, `TestDelete_AppleGrantsFailureBlocksDeletion`)