### PR TITLE
feat: backfill skill-demand history + open Market Pulse to everyone

### DIFF
--- a/cmd/backfill-skill-history/main.go
+++ b/cmd/backfill-skill-history/main.go
@@ -1,0 +1,94 @@
+// Command backfill-skill-history retroactively fills insights_skill_history for
+// past ISO weeks, so a newly-shipped skill's demand trend doesn't have to grow
+// one live snapshot at a time from an empty table.
+//
+// Each past week's open_count is reconstructed directly from
+// jobs.created_at/closed_at — the same open_at(D) formula
+// RebuildInsightsSkillStatsGlobal already trusts for its 30-day-back
+// comparison — evaluated at that week's Monday, midnight UTC, instead of "now".
+//
+// ON CONFLICT DO NOTHING (in the query, not here) makes this idempotent and
+// safe to run alongside the live cmd/rollup-stats writer: a week the live
+// writer already recorded is never overwritten by a backfilled one, so a
+// backfill run can be repeated or interrupted without repair.
+//
+// -weeks bounds how many past ISO weeks to fill (default 26, matching
+// cmd/rollup-stats' retention); the current week is never touched here — the
+// live writer owns it.
+// -dry-run runs every insert inside a transaction and rolls it back, so it
+// reports exactly what would be written and leaves nothing behind.
+//
+// Run: DATABASE_URL=... go run ./cmd/backfill-skill-history [-weeks 26] [-dry-run]
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/isoweek"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+func main() {
+	weeks := flag.Int("weeks", 26, "how many past ISO weeks to backfill")
+	dryRun := flag.Bool("dry-run", false, "report what would be inserted without writing")
+	flag.Parse()
+
+	worker.Main(func() int { return run(*weeks, *dryRun) })
+}
+
+func run(weeks int, dryRun bool) int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	queries := db.New(pool)
+
+	// A dry run executes the real inserts inside a transaction and rolls it back —
+	// the count IS the real pass, measured then discarded (mirrors
+	// cmd/backfill-application-events' dry-run shape).
+	var tx pgx.Tx
+	if dryRun {
+		if tx, err = pool.Begin(ctx); err != nil {
+			log.Printf("dry run: begin: %v", err)
+			return 1
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		queries = queries.WithTx(tx)
+	}
+
+	// Start from LAST week (i=1), never the current one — that week belongs to the
+	// live rollup-stats writer, and ON CONFLICT DO NOTHING would just no-op on it
+	// anyway, but skipping it outright keeps this worker's job description honest.
+	currentWeek := isoweek.Start(time.Now().UTC())
+	var total int64
+	for i := 1; i <= weeks; i++ {
+		asOf := currentWeek.AddDate(0, 0, -7*i)
+		n, err := queries.BackfillInsightsSkillHistoryWeek(ctx, db.BackfillInsightsSkillHistoryWeekParams{
+			WeekStart: pgtype.Date{Time: asOf, Valid: true},
+			AsOf:      pgtype.Timestamptz{Time: asOf, Valid: true},
+		})
+		if err != nil {
+			log.Printf("week %s: %v", asOf.Format("2006-01-02"), err)
+			return 1
+		}
+		total += n
+		log.Printf("week %s: %d skill row(s)", asOf.Format("2006-01-02"), n)
+	}
+
+	if dryRun {
+		log.Printf("backfill dry run: would record %d skill-week row(s) across %d week(s)", total, weeks)
+		return 0
+	}
+	log.Printf("backfill complete: recorded %d skill-week row(s) across %d week(s)", total, weeks)
+	return 0
+}

--- a/cmd/rollup-stats/main.go
+++ b/cmd/rollup-stats/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/isoweek"
 	"github.com/strelov1/freehire/internal/worker"
 )
 
@@ -132,7 +133,7 @@ func rebuildInsights(ctx context.Context, q *db.Queries) error {
 	// above), so it is written, not cleared, reading the global skill bucket this
 	// same transaction just rebuilt. ON CONFLICT DO NOTHING in the query makes this
 	// safe to call every intra-day run: only the first run of an ISO week inserts.
-	weekStart := pgtype.Date{Time: isoWeekStart(time.Now().UTC()), Valid: true}
+	weekStart := pgtype.Date{Time: isoweek.Start(time.Now().UTC()), Valid: true}
 	if _, err := q.SnapshotInsightsSkillHistory(ctx, weekStart); err != nil {
 		return err
 	}
@@ -158,14 +159,4 @@ func rebuildInsights(ctx context.Context, q *db.Queries) error {
 		return err
 	}
 	return nil
-}
-
-// isoWeekStart returns the Monday (ISO 8601 week start) of t's week, at midnight UTC.
-func isoWeekStart(t time.Time) time.Time {
-	day := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
-	weekday := int(day.Weekday())
-	if weekday == 0 { // Sunday
-		weekday = 7
-	}
-	return day.AddDate(0, 0, -(weekday - 1))
 }

--- a/internal/db/insights.sql.go
+++ b/internal/db/insights.sql.go
@@ -11,6 +11,38 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const backfillInsightsSkillHistoryWeek = `-- name: BackfillInsightsSkillHistoryWeek :execrows
+INSERT INTO insights_skill_history (skill, week_start, open_count)
+SELECT skill, $1::date, count(*)::int
+FROM jobs, unnest(skills) AS skill
+WHERE created_at <= $2::timestamptz
+  AND (closed_at IS NULL OR closed_at > $2::timestamptz)
+GROUP BY skill
+ON CONFLICT (skill, week_start) DO NOTHING
+`
+
+type BackfillInsightsSkillHistoryWeekParams struct {
+	WeekStart pgtype.Date        `json:"week_start"`
+	AsOf      pgtype.Timestamptz `json:"as_of"`
+}
+
+// Retroactively snapshots one past ISO week, computing each skill's open-job
+// count "as of" @as_of (that week's Monday, midnight UTC) directly from
+// jobs.created_at/closed_at — the same open_at(D) formula
+// RebuildInsightsSkillStatsGlobal already trusts for its 30-day-back
+// comparison, just evaluated at an arbitrary past instant instead of "now -
+// 30d". A skill absent from the GROUP BY output was open in zero jobs as of
+// that date, so it correctly contributes no row. ON CONFLICT DO NOTHING is
+// what makes this safe to run over a week the live weekly writer already
+// recorded: the real snapshot is never overwritten by a backfilled one.
+func (q *Queries) BackfillInsightsSkillHistoryWeek(ctx context.Context, arg BackfillInsightsSkillHistoryWeekParams) (int64, error) {
+	result, err := q.db.Exec(ctx, backfillInsightsSkillHistoryWeek, arg.WeekStart, arg.AsOf)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteAllInsightsCompanyGrowth = `-- name: DeleteAllInsightsCompanyGrowth :exec
 
 DELETE FROM insights_company_growth

--- a/internal/db/insights_integration_test.go
+++ b/internal/db/insights_integration_test.go
@@ -337,6 +337,68 @@ func TestInsightsSkillHistorySnapshotIdempotentAndPruned(t *testing.T) {
 	}
 }
 
+// TestBackfillInsightsSkillHistoryWeek exercises the open_at(D) reconstruction:
+// a job open across the "as of" instant counts, one not yet created or already
+// closed by then does not — and a week the live writer already recorded is never
+// clobbered by a backfilled one.
+func TestBackfillInsightsSkillHistoryWeek(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	closedAgo10 := 10
+	// Open across day -40: created day -60, closed day -10.
+	seedInsightsJob(t, ctx, q, pool, "b1", insightSeed{createdAgo: 60, closedAgo: &closedAgo10, skills: []string{"go"}})
+	// Not created yet as of day -40 (created day -5).
+	seedInsightsJob(t, ctx, q, pool, "b2", insightSeed{createdAgo: 5, skills: []string{"go"}})
+
+	asOf := time.Now().UTC().AddDate(0, 0, -40)
+	weekStart := pgtype.Date{Time: asOf.Truncate(24 * time.Hour), Valid: true}
+
+	n, err := q.BackfillInsightsSkillHistoryWeek(ctx, BackfillInsightsSkillHistoryWeekParams{
+		WeekStart: weekStart,
+		AsOf:      pgtype.Timestamptz{Time: asOf, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("backfill rows = %d, want 1 (only b1 was open as of day -40)", n)
+	}
+
+	rows, err := q.ListInsightsSkillHistory(ctx, []string{"go"})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 || rows[0].OpenCount != 1 {
+		t.Fatalf("history = %+v, want one row with open_count 1", rows)
+	}
+
+	// Re-running the same week must not overwrite an existing (e.g. live-written) row.
+	if _, err := pool.Exec(ctx,
+		`UPDATE insights_skill_history SET open_count = 99 WHERE skill = 'go' AND week_start = $1`,
+		weekStart.Time); err != nil {
+		t.Fatalf("seed live-authoritative row: %v", err)
+	}
+	n, err = q.BackfillInsightsSkillHistoryWeek(ctx, BackfillInsightsSkillHistoryWeekParams{
+		WeekStart: weekStart,
+		AsOf:      pgtype.Timestamptz{Time: asOf, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("backfill again: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("re-backfill rows = %d, want 0 (must not overwrite the live row)", n)
+	}
+	rows, err = q.ListInsightsSkillHistory(ctx, []string{"go"})
+	if err != nil {
+		t.Fatalf("list after re-backfill: %v", err)
+	}
+	if len(rows) != 1 || rows[0].OpenCount != 99 {
+		t.Fatalf("history after re-backfill = %+v, want open_count still 99 (untouched)", rows)
+	}
+}
+
 // --- helpers ---
 
 func findSkillHistory(t *testing.T, rows []InsightsSkillHistory, skill string) InsightsSkillHistory {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -76,6 +76,16 @@ type Querier interface {
 	// the vocabulary stays in Go where a pin test guards it. Mail from an unrecognised store
 	// is skipped rather than defaulted: an unknown provenance must not read as observed.
 	BackfillEmployerReplyEvents(ctx context.Context, arg BackfillEmployerReplyEventsParams) (BackfillEmployerReplyEventsRow, error)
+	// Retroactively snapshots one past ISO week, computing each skill's open-job
+	// count "as of" @as_of (that week's Monday, midnight UTC) directly from
+	// jobs.created_at/closed_at — the same open_at(D) formula
+	// RebuildInsightsSkillStatsGlobal already trusts for its 30-day-back
+	// comparison, just evaluated at an arbitrary past instant instead of "now -
+	// 30d". A skill absent from the GROUP BY output was open in zero jobs as of
+	// that date, so it correctly contributes no row. ON CONFLICT DO NOTHING is
+	// what makes this safe to run over a week the live weekly writer already
+	// recorded: the real snapshot is never overwritten by a backfilled one.
+	BackfillInsightsSkillHistoryWeek(ctx context.Context, arg BackfillInsightsSkillHistoryWeekParams) (int64, error)
 	// Find the ashby board already carrying a job with this Ashby job id — for company careers
 	// pages that embed Ashby via the ashby_jid widget param (the board slug is JS-rendered, absent
 	// from the URL/markup). external_id is "<board>:<uuid>"; served by the

--- a/internal/db/queries/insights.sql
+++ b/internal/db/queries/insights.sql
@@ -156,6 +156,24 @@ FROM insights_skill_history
 WHERE skill = ANY(sqlc.arg('skills')::text[])
 ORDER BY skill, week_start DESC;
 
+-- name: BackfillInsightsSkillHistoryWeek :execrows
+-- Retroactively snapshots one past ISO week, computing each skill's open-job
+-- count "as of" @as_of (that week's Monday, midnight UTC) directly from
+-- jobs.created_at/closed_at — the same open_at(D) formula
+-- RebuildInsightsSkillStatsGlobal already trusts for its 30-day-back
+-- comparison, just evaluated at an arbitrary past instant instead of "now -
+-- 30d". A skill absent from the GROUP BY output was open in zero jobs as of
+-- that date, so it correctly contributes no row. ON CONFLICT DO NOTHING is
+-- what makes this safe to run over a week the live weekly writer already
+-- recorded: the real snapshot is never overwritten by a backfilled one.
+INSERT INTO insights_skill_history (skill, week_start, open_count)
+SELECT skill, sqlc.arg('week_start')::date, count(*)::int
+FROM jobs, unnest(skills) AS skill
+WHERE created_at <= sqlc.arg('as_of')::timestamptz
+  AND (closed_at IS NULL OR closed_at > sqlc.arg('as_of')::timestamptz)
+GROUP BY skill
+ON CONFLICT (skill, week_start) DO NOTHING;
+
 -- ---------------------------------------------------------------------------
 -- Salary bands
 -- ---------------------------------------------------------------------------

--- a/internal/handler/me_market_pulse.go
+++ b/internal/handler/me_market_pulse.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/isoweek"
 	"github.com/strelov1/freehire/internal/userprofile"
 )
 
@@ -65,7 +66,7 @@ func (h *marketPulseHandlers) GetMarketPulse(c *fiber.Ctx) error {
 	if err != nil && !errors.Is(err, userprofile.ErrNotFound) {
 		return err
 	}
-	meta := fiber.Map{"week_start": isoWeekStart(time.Now().UTC()).Format("2006-01-02")}
+	meta := fiber.Map{"week_start": isoweek.Start(time.Now().UTC()).Format("2006-01-02")}
 	if len(profile.Skills) == 0 {
 		return c.JSON(fiber.Map{"data": []skillPulse{}, "meta": meta})
 	}
@@ -76,20 +77,6 @@ func (h *marketPulseHandlers) GetMarketPulse(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{"data": buildSkillPulses(profile.Skills, rows), "meta": meta})
-}
-
-// isoWeekStart returns the Monday (ISO 8601 week start) of t's week, at midnight UTC —
-// the same "current week" cmd/rollup-stats resolves when it snapshots. Duplicated
-// rather than shared: it's a five-line pure function with exactly two call sites in
-// different binaries (a cron worker's package main and this handler package), not
-// enough to justify a shared package.
-func isoWeekStart(t time.Time) time.Time {
-	day := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
-	weekday := int(day.Weekday())
-	if weekday == 0 { // Sunday
-		weekday = 7
-	}
-	return day.AddDate(0, 0, -(weekday - 1))
 }
 
 // buildSkillPulses groups the caller's skill-history rows by skill (preserving the

--- a/internal/isoweek/isoweek.go
+++ b/internal/isoweek/isoweek.go
@@ -1,0 +1,17 @@
+// Package isoweek has one function: the Monday (ISO 8601 week start) of a given
+// time, at midnight UTC. Shared by every writer of insights_skill_history
+// (cmd/rollup-stats, cmd/backfill-skill-history) and its reader
+// (internal/handler), which all need to agree on what "this week" means.
+package isoweek
+
+import "time"
+
+// Start returns the Monday (ISO 8601 week start) of t's week, at midnight UTC.
+func Start(t time.Time) time.Time {
+	day := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	weekday := int(day.Weekday())
+	if weekday == 0 { // Sunday
+		weekday = 7
+	}
+	return day.AddDate(0, 0, -(weekday - 1))
+}

--- a/internal/isoweek/isoweek_test.go
+++ b/internal/isoweek/isoweek_test.go
@@ -1,11 +1,11 @@
-package main
+package isoweek
 
 import (
 	"testing"
 	"time"
 )
 
-func TestIsoWeekStart(t *testing.T) {
+func TestStart(t *testing.T) {
 	cases := []struct {
 		name string
 		in   time.Time
@@ -29,8 +29,8 @@ func TestIsoWeekStart(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isoWeekStart(tc.in); !got.Equal(tc.want) {
-				t.Errorf("isoWeekStart(%v) = %v, want %v", tc.in, got, tc.want)
+			if got := Start(tc.in); !got.Equal(tc.want) {
+				t.Errorf("Start(%v) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -67,21 +67,15 @@ describe('visibleAccountNav', () => {
     expect(hrefs).toHaveLength(accountNav.length);
   });
 
-  it('hides Market Pulse from a plain, non-beta user', () => {
-    expect(visibleAccountNav(false, false).map((i) => i.href)).not.toContain('/my/market-pulse');
-  });
-
-  it('shows Market Pulse to a beta tester, moderator or not', () => {
+  it('shows Market Pulse to everyone, gate-free (the "Beta" pill is cosmetic only)', () => {
     for (const [mod, beta] of [
+      [false, false],
+      [true, false],
       [false, true],
       [true, true],
     ] as const) {
       expect(visibleAccountNav(mod, beta).map((i) => i.href)).toContain('/my/market-pulse');
     }
-  });
-
-  it('hides Market Pulse from a moderator who is not a beta tester', () => {
-    expect(visibleAccountNav(true, false).map((i) => i.href)).not.toContain('/my/market-pulse');
   });
 });
 

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -18,11 +18,10 @@ export const accountNav = [
   // Personal skill-demand trend: how the market for the candidate's own profile
   // skills is moving, week over week. A check-in section, not a daily one — sits
   // with the occasional group below rather than the four everyday sections above.
-  // Beta-gated (users.beta_tester) while the history is thin post-launch —
-  // betaOnly drives visibleAccountNav's filter below, beta drives the "Beta"
-  // pill my/+layout.svelte renders next to the label. The endpoint itself is
-  // not gated, only the nav link.
-  { href: '/my/market-pulse', label: 'Market Pulse', betaOnly: true, beta: true },
+  // Open to everyone now that the history is backfilled (cmd/backfill-skill-history)
+  // rather than starting thin; `beta` just keeps the "Beta" pill as a still-new-
+  // feature marker without gating access (my/+layout.svelte renders it off this flag).
+  { href: '/my/market-pulse', label: 'Market Pulse', beta: true },
   // The agent: open to every signed-in user. It runs in our backend, and unlike the CV
   // builder below, nothing meters its spend yet.
   { href: '/my/assistant', label: 'Agent' },


### PR DESCRIPTION
## Summary
- `cmd/backfill-skill-history`: reconstructs `insights_skill_history` for past ISO weeks from `jobs.created_at`/`closed_at` (same `open_at(D)` formula `insights_skill_stats` already trusts), so the market-pulse trend doesn't start empty and grow one week at a time. Idempotent (`ON CONFLICT DO NOTHING`) — never overwrites a week the live `rollup-stats` writer already recorded.
- Extracted the ISO-week-Monday helper into `internal/isoweek`, now shared by `rollup-stats`, the handler, and this new worker (a third call site tipped it from "not worth a package").
- Opens the "Market Pulse" nav entry to every signed-in user rather than beta-only, now that history isn't thin — the "Beta" pill stays as a cosmetic still-new marker.

## Test plan
- [x] `go build/vet ./...`, `go vet -tags=integration ./...`, `go test ./...`, `go test -tags=integration ./internal/db/... ./internal/handler/... ./internal/isoweek/...` (new integration test covers the open-at-D reconstruction and the never-overwrite-a-live-row guarantee)
- [x] `pnpm run lint/check/test/build`, design-system token/adoption checks
- [ ] After merge: run `backfill-skill-history` by hand on prod, verify a few skills' series deepen past this week