### PR TITLE
Put tailored vacancies on the Tracking Kanban

### DIFF
--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/strelov1/freehire/internal/appevent"
 	"github.com/strelov1/freehire/internal/assistant"
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/credits"
@@ -18,6 +19,7 @@ import (
 	"github.com/strelov1/freehire/internal/cvedit"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/headshot"
+	"github.com/strelov1/freehire/internal/jobtracking"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/tracerlink"
 )
@@ -67,6 +69,9 @@ type cvHandlers struct {
 	// autosave, the template picker, the CLI's patch, an agent tool, seeding a tailored
 	// copy — commits through it, so no change happens without a revision recording it.
 	editor *cvedit.Editor
+	// jobs puts a vacancy on the Tracking Kanban when the caller starts (or reopens)
+	// tailoring for it. Nil-safe for fixtures that never assert board membership.
+	jobs jobBoarder
 }
 
 // jobReader is the one vacancy read the tailoring context needs.
@@ -74,9 +79,38 @@ type jobReader interface {
 	GetJob(ctx context.Context, id int64) (db.Job, error)
 }
 
+// jobBoarder places a vacancy on the caller's Tracking board. The Kanban only shows
+// staged (or applied) rows — a bare bookmark lives under Activity → Saved — so this is
+// save + stage=applied when no stage exists yet. applied_at stays unset: preparing a CV
+// is not submitting an application, and silence must not start.
+type jobBoarder interface {
+	EnsureOnBoard(ctx context.Context, userID, jobID int64) error
+}
+
+// trackingBoarder adapts jobtracking's repository to jobBoarder.
+type trackingBoarder struct {
+	repo interface {
+		SaveJob(ctx context.Context, userID, jobID int64) (jobtracking.Interaction, error)
+		TrackJob(ctx context.Context, userID, jobID int64, stage, notes *string, source string) (jobtracking.Interaction, error)
+	}
+}
+
+func (s trackingBoarder) EnsureOnBoard(ctx context.Context, userID, jobID int64) error {
+	row, err := s.repo.SaveJob(ctx, userID, jobID)
+	if err != nil {
+		return err
+	}
+	if row.Stage != nil && *row.Stage != "" {
+		return nil
+	}
+	stage := "applied"
+	_, err = s.repo.TrackJob(ctx, userID, jobID, &stage, nil, appevent.SourceUser)
+	return err
+}
+
 // refuseListCap is normally true (Commit refuses over-cap edits). Pass false only when
 // an operator has turned on CV_EDIT_ALLOW_BULLET_TRUNCATION.
-func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, assistantSessions *assistant.Store, cvRenderer cv.Renderer, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate, refuseListCap bool) *cvHandlers {
+func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, assistantSessions *assistant.Store, cvRenderer cv.Renderer, tracerSalt, baseURL string, servedHosts []string, resumeStore *resume.Store, photoStore *headshot.Store, creditsStore *credits.Store, match *matchHandlers, gate cvedit.EvidenceGate, jobs jobBoarder, refuseListCap bool) *cvHandlers {
 	h := &cvHandlers{
 		cvStore:           cvStore,
 		assistantSessions: assistantSessions,
@@ -104,6 +138,7 @@ func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, a
 		credits:            creditsStore,
 		matchAnalysisCache: queries,
 		match:              match,
+		jobs:               jobs,
 		extractPDFText:     resume.ExtractPDFText,
 	}
 	return h

--- a/internal/handler/cv_evidence_gate_integration_test.go
+++ b/internal/handler/cv_evidence_gate_integration_test.go
@@ -55,6 +55,7 @@ func newCVAPIWithoutAssistant(t *testing.T) (*cvHandlers, *auth.Issuer, *fiber.A
 		creditsStore,
 		&matchHandlers{credits: creditsStore},
 		bankGate{bank: bank},
+		nil, // tracking save unused — this fixture never bootstraps tailor
 		true,
 	)
 

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -120,6 +120,16 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	if _, err := h.credits.Debit(c.Context(), userID, credits.FeatureTailor, tailored.ID.String()); err != nil {
 		log.Printf("credits: tailor debit user=%d cv=%d: %v", userID, tailored.ID, err)
 	}
+	// Place the vacancy on the Tracking Kanban. A bare bookmark is not enough — the
+	// board columns only show staged/applied rows; saved-only lives under Activity →
+	// Saved. Stage is set to applied without applied_at (preparing ≠ submitted). Runs on
+	// create and resume; never overwrites an existing stage. Best-effort: the CV and
+	// session already exist.
+	if h.jobs != nil {
+		if err := h.jobs.EnsureOnBoard(c.Context(), userID, job.ID); err != nil {
+			log.Printf("cv: placing vacancy on board after tailor user=%d job=%d: %v", userID, job.ID, err)
+		}
+	}
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": tailorCVResponse{
 		TailorCVID: tailored.ID.String(), BaseCVID: base.ID.String(), Analysis: analysis, SessionID: sessionID,
 		ColdStartRunning: justCreated,
@@ -188,6 +198,13 @@ func (h *cvHandlers) StartTailorSession(c *fiber.Ctx) error {
 	sessionID, err := h.startTailoringSession(c.Context(), userID, rec.ID, rec.JobID)
 	if err != nil {
 		return err
+	}
+	// Same board placement as TailorCV: this path is how a ?cv= resume mints a missing
+	// session, and without it the vacancy would stay off the Kanban.
+	if h.jobs != nil {
+		if err := h.jobs.EnsureOnBoard(c.Context(), userID, rec.JobID); err != nil {
+			log.Printf("cv: placing vacancy on board after tailor session user=%d job=%d: %v", userID, rec.JobID, err)
+		}
 	}
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": tailorSessionResponse{
 		TailorCVID: rec.ID.String(), BaseCVID: base.ID.String(), SessionID: sessionID,

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/strelov1/freehire/internal/cvedit"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/experience"
+	"github.com/strelov1/freehire/internal/jobtracking"
 	"github.com/strelov1/freehire/internal/matchanalysis"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/resumeextract"
@@ -39,7 +40,7 @@ func newTailorAPI(t *testing.T) (*cvHandlers, *auth.Issuer, *pgxpool.Pool) {
 	pool := startPostgres(t)
 	queries := db.New(pool)
 	if _, err := pool.Exec(context.Background(),
-		"TRUNCATE cvs, users, jobs, user_job_analysis, api_keys, assistant_sessions, experience_employments, experience_atoms RESTART IDENTITY CASCADE"); err != nil {
+		"TRUNCATE cvs, users, jobs, user_jobs, applications, user_job_analysis, api_keys, assistant_sessions, experience_employments, experience_atoms RESTART IDENTITY CASCADE"); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
 	iss := auth.NewIssuer("test-secret", time.Hour)
@@ -56,6 +57,8 @@ func newTailorAPI(t *testing.T) (*cvHandlers, *auth.Issuer, *pgxpool.Pool) {
 		matchAnalysisCache: queries,
 		credits:            creditsStore,
 		match:              &matchHandlers{credits: creditsStore},
+		// Same adapter Register wires: bootstrap must place the vacancy on the board.
+		jobs: trackingBoarder{repo: jobtracking.NewQueriesRepository(queries, pool)},
 		// The tailoring bootstrap mints its conversation through the assistant's store,
 		// exactly as Register wires it.
 		assistantSessions: assistant.NewStore(queries),
@@ -212,6 +215,178 @@ func TestTailorCVBootstrap(t *testing.T) {
 		`SELECT count(*) FROM credit_ledger WHERE user_id=$1 AND kind='debit' AND feature='tailor'`, user).Scan(&debits)
 	if debits != 1 {
 		t.Errorf("tailor debit rows = %d, want 1", debits)
+	}
+	assertVacancyOnKanban(t, pool, user, jobID)
+}
+
+// assertVacancyOnKanban checks the tailor bootstrap's tracking side-effect: the vacancy
+// is bookmarked AND staged as applied (so it lands in a Kanban column), without
+// applied_at (preparing a CV is not submitting an application).
+func assertVacancyOnKanban(t *testing.T, pool *pgxpool.Pool, userID, jobID int64) {
+	t.Helper()
+	var saved bool
+	var appliedAt pgtype.Timestamptz
+	var stage pgtype.Text
+	err := pool.QueryRow(context.Background(),
+		`SELECT uj.saved_at IS NOT NULL, a.applied_at, a.stage
+		   FROM user_jobs uj
+		   LEFT JOIN applications a ON a.user_id = uj.user_id AND a.job_id = uj.job_id
+		  WHERE uj.user_id = $1 AND uj.job_id = $2`, userID, jobID).
+		Scan(&saved, &appliedAt, &stage)
+	if err != nil {
+		t.Fatalf("read tracking row: %v", err)
+	}
+	if !saved {
+		t.Errorf("saved_at unset — tailored vacancy should stay bookmarked")
+	}
+	if !stage.Valid || stage.String != "applied" {
+		t.Errorf("stage = %q, want applied — Kanban columns only show staged rows", stage.String)
+	}
+	if appliedAt.Valid {
+		t.Errorf("applied_at = %v, want null — tailor is not an application submit", appliedAt.Time)
+	}
+	rows, err := db.New(pool).ListUserJobs(context.Background(), db.ListUserJobsParams{
+		UserID: userID, Limit: 50, Offset: 0, Filter: "board",
+	})
+	if err != nil {
+		t.Fatalf("ListUserJobs board: %v", err)
+	}
+	found := false
+	for _, r := range rows {
+		if r.ID == jobID {
+			found = true
+			if !r.Stage.Valid || r.Stage.String != "applied" {
+				t.Errorf("board row stage = %q, want applied", r.Stage.String)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("job %d missing from filter=board listing after tailor", jobID)
+	}
+}
+
+// TestTailorCVBootstrap_HealsMissingSave: an existing tailored CV whose vacancy was
+// never (or no longer) on the board gets staged on the next bootstrap resume.
+func TestTailorCVBootstrap_HealsMissingSave(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+	ctx := context.Background()
+
+	user := seedAccount(t, pool, "tailor-heal@example.test", true)
+	tok, _ := iss.Issue(user, testTokenVersion)
+	jobID := seedJobSlug(t, pool, "heal-eng")
+	seedFreshResume(t, pool, user)
+
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "heal-eng"})
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("first bootstrap = %d, want 201", resp.StatusCode)
+	}
+	var first struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&first)
+	resp.Body.Close()
+	assertVacancyOnKanban(t, pool, user, jobID)
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE applications SET stage = NULL WHERE user_id = $1 AND job_id = $2`, user, jobID); err != nil {
+		t.Fatalf("clear stage: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE user_jobs SET saved_at = NULL WHERE user_id = $1 AND job_id = $2`, user, jobID); err != nil {
+		t.Fatalf("clear save: %v", err)
+	}
+
+	resp = doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "heal-eng"})
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("resume bootstrap = %d, want 201", resp.StatusCode)
+	}
+	var second struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&second)
+	resp.Body.Close()
+	if second.Data.TailorCVID != first.Data.TailorCVID {
+		t.Fatalf("resume made a new CV (%s vs %s)", second.Data.TailorCVID, first.Data.TailorCVID)
+	}
+	assertVacancyOnKanban(t, pool, user, jobID)
+
+	// An advanced stage must not be pulled back to applied on resume.
+	if _, err := pool.Exec(ctx,
+		`UPDATE applications SET stage = 'interview' WHERE user_id = $1 AND job_id = $2`, user, jobID); err != nil {
+		t.Fatalf("advance stage: %v", err)
+	}
+	resp = doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "heal-eng"})
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("third bootstrap = %d, want 201", resp.StatusCode)
+	}
+	resp.Body.Close()
+	var stage string
+	if err := pool.QueryRow(ctx,
+		`SELECT stage FROM applications WHERE user_id = $1 AND job_id = $2`, user, jobID).Scan(&stage); err != nil {
+		t.Fatalf("read stage: %v", err)
+	}
+	if stage != "interview" {
+		t.Errorf("stage = %q, want interview — tailor must not overwrite progress", stage)
+	}
+
+	// Clearing the board marks must not delete the tailored CV.
+	if _, err := pool.Exec(ctx,
+		`UPDATE applications SET stage = NULL WHERE user_id = $1 AND job_id = $2`, user, jobID); err != nil {
+		t.Fatalf("clear stage again: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE user_jobs SET saved_at = NULL WHERE user_id = $1 AND job_id = $2`, user, jobID); err != nil {
+		t.Fatalf("clear save again: %v", err)
+	}
+	var cvs int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM cvs WHERE user_id = $1 AND job_id = $2`, user, jobID).Scan(&cvs); err != nil {
+		t.Fatalf("count cvs: %v", err)
+	}
+	if cvs != 1 {
+		t.Errorf("cvs after clear = %d, want 1", cvs)
+	}
+}
+
+type boomBoarder struct{}
+
+func (boomBoarder) EnsureOnBoard(context.Context, int64, int64) error {
+	return errors.New("board boom")
+}
+
+// TestTailorCVBootstrap_SaveFailureStillSucceeds: once the CV and session exist, a
+// tracking write error must not turn the bootstrap into a failure.
+func TestTailorCVBootstrap_SaveFailureStillSucceeds(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	h.jobs = boomBoarder{}
+	app := buildTailorApp(h, iss)
+
+	user := seedAccount(t, pool, "tailor-save-fail@example.test", true)
+	tok, _ := iss.Issue(user, testTokenVersion)
+	jobID := seedJobSlug(t, pool, "fail-eng")
+	seedFreshResume(t, pool, user)
+
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "fail-eng"})
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("bootstrap with board failure = %d, want 201", resp.StatusCode)
+	}
+	var got struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&got)
+	resp.Body.Close()
+	if got.Data.TailorCVID == "" || got.Data.SessionID == "" {
+		t.Fatalf("response = %+v, want CV and session ids despite board failure", got.Data)
+	}
+	var cvs int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM cvs WHERE user_id = $1 AND job_id = $2`, user, jobID).Scan(&cvs); err != nil {
+		t.Fatalf("count cvs: %v", err)
+	}
+	if cvs != 1 {
+		t.Errorf("cvs = %d, want 1", cvs)
 	}
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/strelov1/freehire/internal/gmailsync"
 	"github.com/strelov1/freehire/internal/headshot"
 	"github.com/strelov1/freehire/internal/jdresolve"
+	"github.com/strelov1/freehire/internal/jobtracking"
 	"github.com/strelov1/freehire/internal/linkimport"
 	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/llmkey"
@@ -399,7 +400,10 @@ func Register(app *fiber.App, cfg Config) {
 	// account a call is attributed to is decided in one place rather than per feature. A nil
 	// gateway client leaves it inert and every call on the service credential.
 	llmKeys := llmkey.NewResolver(queries, cfg.LLMKeys)
-	cvH := newCVHandlers(cfg.Pool, queries, cvStore, assistantStore, cvRenderer, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank}, !cfg.CVEditAllowBulletTruncation)
+	// Same repository the tracking surface uses: tailor bootstrap places the vacancy on
+	// the Kanban so a pursued role is not invisible under Activity → Saved alone.
+	trackingJobs := trackingBoarder{repo: jobtracking.NewQueriesRepository(queries, cfg.Pool)}
+	cvH := newCVHandlers(cfg.Pool, queries, cvStore, assistantStore, cvRenderer, cfg.TracerLinkSalt, cfg.FrontendOrigin, servedHostsOrDefault(cfg.ServedHosts, cfg.FrontendOrigin), resumeStore, photoStore, creditsStore, matchH, bankGate{bank: bank}, trackingJobs, !cfg.CVEditAllowBulletTruncation)
 	telegramH := newTelegramHandlers(queries, cfg.JWTSecret, cfg.TelegramBotToken, cfg.TelegramBotUsername, cfg.TelegramWebhookSecret, cfg.FrontendOrigin, contributionsH.intake)
 	discordH := newDiscordHandlers(queries, cfg.JWTSecret, cfg.DiscordBotToken, cfg.DiscordApplicationID, cfg.DiscordPublicKey, cfg.DiscordGuildID, cfg.FrontendOrigin, contributionsH.intake)
 	inboxH := newInboxHandlers(queries, cfg.Pool, cfg.GmailConnector, cfg.GmailCipher, cfg.FrontendOrigin, cfg.CookieSecure, cfg.MailboxDomain)

--- a/openspec/changes/tailor-adds-to-tracking/.openspec.yaml
+++ b/openspec/changes/tailor-adds-to-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/tailor-adds-to-tracking/design.md
+++ b/openspec/changes/tailor-adds-to-tracking/design.md
@@ -1,0 +1,68 @@
+## Context
+
+See proposal.md — Why. Two gaps blocked the intended UX:
+
+1. **Kanban vs bookmark.** `JobBoard` / `columnOf` only place rows with a stage (or
+   `applied_at`) into columns. A bare `saved_at` lives under Activity → Saved and
+   never appears on the board — so save-only was the wrong signal.
+2. **Resume path.** After the first bootstrap the SPA rewrites to
+   `/tailor/[slug]?cv=…`. That resume branch never called `POST /me/cvs/tailor`,
+   so opening an existing tailored CV skipped the tracking write entirely.
+
+`TrackJob` already supports stage-without-`applied_at` ("tracked, not recorded as
+applied"), which is exactly the prepare-to-apply signal.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Opening or starting tailor puts the vacancy in the Applied Kanban column.
+- Do not start silence / claim a submitted application (`applied_at` stays null).
+- Do not overwrite an existing advanced stage.
+- Heal on resume (bootstrap and `?cv=` reopen).
+
+**Non-Goals:**
+
+- No new stage vocabulary (`preparing` / `tailoring`).
+- No one-shot SQL backfill (reopen heals).
+- No SPA board redesign.
+
+## Decisions
+
+### 1. Stage `applied` without `applied_at`, plus save
+
+**Choice:** `EnsureOnBoard` = `SaveJob` then, if stage is empty,
+`TrackJob(stage=applied, source=user)`.
+
+**Why:** Matches Kanban membership (`columnOf`) without starting silence (listing
+derives silence only when `applied_at` is set). Save keeps Activity → Saved
+consistent if the user later clears the stage.
+
+**Alternatives:** Save-only (invisible on Kanban — what shipped first and failed
+the user's check). New `preparing` stage (vocabulary + contracts + UI expansion).
+`MarkApplied` (wrong: bumps `applied_count`, sets `applied_at`, starts silence).
+
+### 2. Narrow `jobBoarder` on `cvHandlers`
+
+**Choice:** `EnsureOnBoard(ctx, userID, jobID)` injected from `Register` via
+`trackingBoarder` over the jobtracking repository.
+
+### 3. Call sites
+
+- `TailorCV` after CV + session ready (create and idempotent resume).
+- `StartTailorSession` (resume minting a missing session).
+- SPA `?cv=` resume with an existing session: fire-and-forget `api.tailorCv(slug)`
+  so the board side-effect runs without blocking first paint.
+
+## Risks / Trade-offs
+
+- **[Applied column for "not yet submitted"]** → Acceptable: stage means "in the
+  pipeline"; `applied_at` is the submit stamp. User can drag / clear stage.
+- **[Server must be restarted]** → Local/prod binary must pick up the handler
+  change; SPA change needs a refresh.
+
+## Migration Plan
+
+- Deploy backend + web. Reopen any tailored workspace once to heal.
+- Rollback: remove EnsureOnBoard calls; leftover stage=`applied` rows remain
+  ordinary tracking (harmless).

--- a/openspec/changes/tailor-adds-to-tracking/proposal.md
+++ b/openspec/changes/tailor-adds-to-tracking/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Starting a CV for a vacancy is a clear intent to pursue that job, but the tailor
+bootstrap only created a vacancy-bound CV — it never wrote tracking state. The
+Tracking **Kanban** only shows jobs that have a stage (or `applied_at`); a bare
+bookmark lives under Activity → Saved and never appears as a board card. Opening
+an existing tailored CV via `?cv=` also skipped the bootstrap entirely, so even
+a bookmark never ran on resume.
+
+## What Changes
+
+- On a successful tailor bootstrap (and on resume paths that reopen a tailored
+  vacancy), the vacancy is placed on the caller's Tracking Kanban: bookmarked
+  and staged as `applied` when no stage exists yet.
+- `applied_at` is **not** set — preparing a CV is not submitting an application,
+  so silence clocks must not start.
+- An existing non-empty stage (e.g. interview) is left alone.
+- Failures to write tracking must not fail or roll back an already-created
+  tailored CV / session.
+- The SPA resume path (`?cv=` with an existing session) re-runs the idempotent
+  bootstrap for the board side-effect.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `cv-tailoring`: Bootstrap / resume places the vacancy on the Tracking Kanban.
+- `user-job-tracking`: Tailoring is an implicit save + stage=`applied` (when
+  unset) path for the vacancy.
+
+## Impact
+
+- `internal/handler/cv_tailor.go`, `cv.go`, `handler.go` wiring, and
+  `web/src/routes/tailor/[slug]/+page.svelte` resume path.
+- Integration coverage on create, heal, stage preservation, and fail-open.
+- No migration; no change to the tailor response envelope.

--- a/openspec/changes/tailor-adds-to-tracking/specs/cv-tailoring/spec.md
+++ b/openspec/changes/tailor-adds-to-tracking/specs/cv-tailoring/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Tailoring places the vacancy on the Tracking Kanban
+
+The system SHALL, on every successful tailor bootstrap for a vacancy
+(`POST /api/v1/me/cvs/tailor`), ensure that vacancy appears on the caller's
+Tracking Kanban board. Concretely it SHALL bookmark the vacancy (`saved_at`
+set) and, when the vacancy has no application stage yet, set stage to
+`applied`. It MUST NOT set `applied_at`: preparing a CV is not submitting an
+application, and silence clocks MUST NOT start from the bootstrap alone.
+
+The placement SHALL run for both a newly created tailored CV and an idempotent
+resume of an existing one. An existing non-empty stage MUST be left unchanged.
+Clearing board progress later MUST NOT delete or invalidate the tailored CV.
+
+A failure to write tracking MUST NOT fail the bootstrap response once the
+tailored CV and its session already exist.
+
+#### Scenario: First tailor puts the vacancy in Applied
+
+- **WHEN** a signed-in user successfully bootstraps tailoring for a vacancy they
+  have never tailored
+- **THEN** a tailored CV is created AND the vacancy is saved with stage
+  `applied` and no `applied_at`
+
+#### Scenario: Resume heals a missing board placement
+
+- **WHEN** a signed-in user bootstraps tailoring for a vacancy they already have
+  a tailored CV for, and that vacancy has no stage
+- **THEN** the existing CV and conversation are returned AND the vacancy is
+  staged as `applied` with `saved_at` set
+
+#### Scenario: An advanced stage is preserved
+
+- **WHEN** the vacancy already has stage `interview` and the user re-bootstraps
+  tailoring
+- **THEN** the stage remains `interview`
+
+#### Scenario: Tailoring does not claim a submitted application
+
+- **WHEN** a signed-in user successfully bootstraps tailoring for a vacancy
+- **THEN** the vacancy's tracking interaction does not gain `applied_at` from
+  the bootstrap alone
+
+#### Scenario: A tracking write failure does not undo the tailored CV
+
+- **WHEN** the tailored CV and session have been created and placing the vacancy
+  on the board fails
+- **THEN** the bootstrap still returns success with the tailored CV and session
+  ids

--- a/openspec/changes/tailor-adds-to-tracking/specs/user-job-tracking/spec.md
+++ b/openspec/changes/tailor-adds-to-tracking/specs/user-job-tracking/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Tailoring places the vacancy on the Tracking Kanban
+
+The system SHALL treat a successful CV-tailoring bootstrap for a vacancy as
+placing that vacancy on the caller's Tracking Kanban: it bookmarks the vacancy
+(`saved_at`) and, when no stage is set yet, sets stage to `applied` without
+setting `applied_at`. The vacancy SHALL then appear in the Applied board column
+(see `columnOf`: a stage is enough; silence remains unset without `applied_at`).
+
+An existing non-empty stage SHALL be left unchanged. Clearing stage / save marks
+afterwards SHALL NOT affect the tailored CV.
+
+#### Scenario: A tailored vacancy appears in Applied
+
+- **WHEN** a signed-in user successfully bootstraps tailoring for a vacancy with
+  no prior stage
+- **THEN** that vacancy is present in the caller's Tracking board listing with
+  stage `applied` and no `applied_at`
+
+#### Scenario: Progress is not overwritten
+
+- **WHEN** a signed-in user who already staged the vacancy as `interview`
+  bootstraps tailoring again
+- **THEN** the stage remains `interview`

--- a/openspec/changes/tailor-adds-to-tracking/tasks.md
+++ b/openspec/changes/tailor-adds-to-tracking/tasks.md
@@ -1,0 +1,36 @@
+## 1. Wire tracking into CV handlers
+
+- [x] 1.1 Add a narrow save dependency on `cvHandlers` (e.g. interface with
+      `SaveJob(ctx, userID, jobID)`) and pass the shared `jobtracking` repository
+      or service from `Register` / `newCVHandlers` — no post-construction setter.
+- [x] 1.2 Update unit/integration test constructors that build `cvHandlers` /
+      `newTailorAPI` so they compile with the new dependency (nil-safe or a stub
+      save for tests that do not assert tracking).
+
+## 2. Save on tailor bootstrap
+
+- [x] 2.1 In `TailorCV`, after the tailored CV and session are ready, call the
+      save path for `(userID, job.ID)`. Log failures; do not change the success
+      response. Do not set `applied_at` or `stage`.
+- [x] 2.2 Ensure the save runs on both first create and idempotent resume (not
+      gated on `justCreated`).
+
+## 3. Tests
+
+- [x] 3.1 Integration test: first successful `POST /me/cvs/tailor` leaves
+      `user_jobs.saved_at` set for that vacancy and leaves `applied_at` / `stage`
+      unset from the bootstrap.
+- [x] 3.2 Integration test: resume bootstrap for an existing tailored CV with no
+      save mark sets `saved_at` (heal path).
+- [x] 3.3 Integration test (or unit with stub): when save returns an error after
+      CV/session creation, bootstrap still returns 201 with the CV and session
+      ids.
+- [x] 3.4 Run `go vet -tags=integration ./...` (and the relevant
+      `go test -tags=integration` tailor handler packages) before considering
+      done.
+
+## 4. Verify
+
+- [x] 4.1 Manually or via integration: after tailor, the vacancy appears under
+      Tracking board (`filter=board` / saved). Confirm unsave clears the board
+      card without deleting the tailored CV.

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -270,9 +270,15 @@
         if (rec.agent_session_id) {
           resuming = true;
           sessionId = rec.agent_session_id;
+          // Resume with an existing session never hits POST /me/cvs/tailor, which is what
+          // places the vacancy on the Tracking board. Re-run bootstrap for that side effect
+          // only (idempotent: same CV, no second debit). Fire-and-forget so a slow tracking
+          // write cannot block the workspace.
+          void api.tailorCv(slug).catch(() => {});
         } else {
           // A CV created before session binding: the backend mints a tailoring
-          // conversation bound to it and stores it on the CV.
+          // conversation bound to it and stores it on the CV (and places the vacancy
+          // on the board).
           const s = await api.startTailorSession(existing);
           sessionId = s.session_id;
         }


### PR DESCRIPTION
TL;DR.Now text pasted jobs, are added to the kanbam tracking
## Summary
- When a user starts or reopens CV tailoring for a vacancy (including pasted/private jobs), place that vacancy on the Tracking Kanban: bookmark + stage `applied` when no stage exists yet.
- Do not set `applied_at` (preparing a CV is not a submitted application; silence does not start).
- Preserve an existing advanced stage; heal on `?cv=` resume via an idempotent bootstrap side-effect.

## Test plan
- [ ] Fresh tailor for a catalog or pasted job → card appears under **Applied** on `/my/tracking`
- [ ] Reopen `/tailor/[slug]?cv=…` for an older tailored CV → same board placement
- [ ] Job already at `interview` → reopen tailor leaves stage unchanged
- [ ] `go test -tags=integration ./internal/handler/ -run 'TestTailorCVBootstrap'`