### PR TITLE
feat(sources): onboard boards from link_contributions queue

### DIFF
--- a/internal/atsboard/board.go
+++ b/internal/atsboard/board.go
@@ -352,6 +352,9 @@ func subdomainLabel(host, apex string) string {
 var platformLabels = map[string]bool{
 	"app": true, "dashboard": true, "admin": true, "api": true,
 	"support": true, "help": true, "blog": true, "docs": true,
+	// tt.teamtailor.com is Teamtailor's own "powered by" tracking/short-link host, linked from
+	// every tenant career site's footer — not a tenant.
+	"tt": true,
 }
 
 // platformHost reports whether host is the ATS's own product host rather than a tenant's.

--- a/internal/atsboard/board_test.go
+++ b/internal/atsboard/board_test.go
@@ -131,11 +131,11 @@ func TestRecognize(t *testing.T) {
 		// takes the first recognized ATS URL in a page, recorded it as the employer's board.
 		{"teamtailor platform app host not a tenant", "https://app.teamtailor.com/companies/1/jobs", "", "", "", false},
 		{"teamtailor platform dashboard host not a tenant", "https://dashboard.teamtailor.com/", "", "", "", false},
-			// tt.teamtailor.com is the vendor's own "powered by Teamtailor" tracking/short-link
-			// host, carried on the footer of every tenant career site — not a tenant, same as
-			// app/dashboard above. Found via a contribution whose page linked it, misread as the
-			// employer's own board (2026-08-11).
-			{"teamtailor platform tt shortlink host not a tenant", "https://tt.teamtailor.com/", "", "", "", false},
+		// tt.teamtailor.com is the vendor's own "powered by Teamtailor" tracking/short-link
+		// host, carried on the footer of every tenant career site — not a tenant, same as
+		// app/dashboard above. Found via a contribution whose page linked it, misread as the
+		// employer's own board (2026-08-11).
+		{"teamtailor platform tt shortlink host not a tenant", "https://tt.teamtailor.com/", "", "", "", false},
 		// The same platform-host guard applies to subdomain mode, not just host mode: Recruitee's
 		// own employer app lives at app.recruitee.com and BambooHR's own support center at
 		// help.bamboohr.com — both real, public vendor hosts, neither a tenant named "app" or

--- a/internal/atsboard/board_test.go
+++ b/internal/atsboard/board_test.go
@@ -131,6 +131,11 @@ func TestRecognize(t *testing.T) {
 		// takes the first recognized ATS URL in a page, recorded it as the employer's board.
 		{"teamtailor platform app host not a tenant", "https://app.teamtailor.com/companies/1/jobs", "", "", "", false},
 		{"teamtailor platform dashboard host not a tenant", "https://dashboard.teamtailor.com/", "", "", "", false},
+			// tt.teamtailor.com is the vendor's own "powered by Teamtailor" tracking/short-link
+			// host, carried on the footer of every tenant career site — not a tenant, same as
+			// app/dashboard above. Found via a contribution whose page linked it, misread as the
+			// employer's own board (2026-08-11).
+			{"teamtailor platform tt shortlink host not a tenant", "https://tt.teamtailor.com/", "", "", "", false},
 		// The same platform-host guard applies to subdomain mode, not just host mode: Recruitee's
 		// own employer app lives at app.recruitee.com and BambooHR's own support center at
 		// help.bamboohr.com — both real, public vendor hosts, neither a tenant named "app" or

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14373,3 +14373,7 @@
   board: insurityllc
 - company: Insurity
   board: insurityindia
+
+# link contribution, validated live 2026-08-11
+- company: Abby Care
+  board: abbycare

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3267,3 +3267,11 @@
 # teamtailor board mined from dynamitejobs.com (2026-08-10, live-validated)
 - company: Agorapulse
   board: career.agorapulse.com
+
+# link contributions, validated live 2026-08-11
+- company: Kleos
+  board: careers.kleos.io
+- company: Paystack
+  board: careers.paystack.com
+- company: Nextlane
+  board: nextlane.teamtailor.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -2115,3 +2115,7 @@
 # workable board mined from dynamitejobs.com (2026-08-10, live-validated)
 - company: Rythm Health
   board: rythm
+
+# link contribution, validated live 2026-08-11
+- company: Lago
+  board: lago-1

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -12929,3 +12929,7 @@
   board: witherslackgroup.wd3.myworkdayjobs.com/Witherslack
 - company: Materialise
   board: materialise.wd103.myworkdayjobs.com/Materialise_Jobs
+
+# link contribution, validated live 2026-08-11
+- company: SOK
+  board: sok.wd502.myworkdayjobs.com/S-ryhman-avoimet-tyopaikat


### PR DESCRIPTION
## Summary
- Onboards 6 boards contributed via the paste-a-link flow (each live-validated before adding): SOK (workday), Abby Care (greenhouse), Kleos / Paystack / Nextlane (teamtailor), Lago (workable).
- Fixes an `atsboard.Recognize` defect found while triaging: `tt.teamtailor.com` is Teamtailor's own "powered by" tracking/short-link host (redirects to teamtailor.com), not a tenant — it was missing from `platformLabels`, so a contribution whose page linked it got misread as an employer board.
- 5 other pending contributions (Noibu, IGamingHunt, Marisa.Care, Solo Recruiter, Smarter Contact) and 2 more (South Pole, Zexter) were already onboarded by a prior PR (#1683) — their `link_contributions` rows just never got flipped to `onboarded`; that will be corrected directly on prod, no source-file change needed.
- 2 rows rejected: `tt.teamtailor.com` (the bogus platform host above) and a Manatal contribution whose recognized board (`jobs`) was a recognizer misread of a `<tenant>.careers-page.com/jobs/<uuid>` URL shape the `path` mode doesn't handle; the real tenant (`solverogroup`) turned out to not be servable by the existing Manatal adapter either (`"Legacy career page is not enabled"` from the API) — left as a future adapter lead, not onboarded.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/atsboard/... ./internal/sources/...`
- [x] Each new board live-validated (public API/page returned jobs) before adding