### PR TITLE
fix(sources): remove 4 duplicate board ids in lever.yml

### DIFF
--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -3234,8 +3234,6 @@
   board: tripscout
 - company: true-environmental
   board: true-environmental
-- company: trueml
-  board: trueml
 - company: trueplatform
   board: trueplatform
 - company: truetandem
@@ -4463,11 +4461,5 @@
   board: translifeline
 
 # lever boards mined from remote.io (2026-08-09, live-validated)
-- company: Ridezum
-  board: ridezum
-- company: Thinkahead
-  board: thinkahead
 - company: TrueML
   board: trueml
-- company: VeryGoodSecurity
-  board: verygoodsecurity


### PR DESCRIPTION
## What and why

Follow-up from review of #1808. `sources/lever.yml` had 4 board ids each listed twice under different company-name casing:

| board | kept | dropped |
|---|---|---|
| `thinkahead` | AHEAD | Thinkahead |
| `verygoodsecurity` | Very Good Security | VeryGoodSecurity |
| `ridezum` | Zūm | Ridezum |
| `trueml` | TrueML | trueml |

3 of the 4 dupes came from the remote.io mining batch re-adding boards already present earlier in the file under a different spelling.

Board strings here are byte-identical (not just case-different), so per the ingest dedup rule this doesn't create duplicate catalog rows (same `external_id` namespace either way) — it just doubles crawl work on that board and lets the attached company name flip between the two spellings depending on which entry ingest processes last on a given run. Dropped the entry whose company name is just the board slug, per the existing rule for this class of bug (company matching the board slug loses to the normal name).

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass — no Go changed.
- [x] `go test ./...` passes — no Go changed.
- [x] I regenerated committed artifacts when their source changed — n/a, YAML only.
- [x] For `design-system/` changes — n/a.
- [x] For `web/` changes — n/a.
- [x] This stays within freehire's core/extension boundary — pure data fix.

## Test plan

- [x] Confirmed `grep '^  board:' sources/lever.yml | sort | uniq -d` is empty after the change
- [x] Confirmed the file still parses as valid YAML