### PR TITLE
fix(sources): recover himalayas company when the feed sends the literal "name" sentinel

### DIFF
--- a/cmd/backfill-himalayas-companyname/main.go
+++ b/cmd/backfill-himalayas-companyname/main.go
@@ -1,0 +1,124 @@
+// Command backfill-himalayas-companyname repairs jobs.company for himalayas rows ingested
+// while the adapter stored Himalayas' companyName sentinel verbatim (see
+// sources.HimalayasCompanyNameSentinel — Himalayas' own feed renders companyName as the
+// literal string "name" for a subset of postings, an unresolved template field on their end).
+//
+// The adapter now falls back to the feed's companySlug field, but that only reaches new or
+// re-crawled rows: himalayas is boardless with a per-run page budget far short of its full
+// catalogue (recency-ordered, so old rows fall out of the crawled window and are never
+// revisited by a normal ingest). This backfill instead recovers the company slug from each
+// row's own stored url, which Himalayas' canonical job page always carries at
+// /companies/<slug>/jobs/... — the same signal, just read back from the DB instead of the
+// live feed (companySlug itself isn't stored anywhere).
+//
+// It pages every source='himalayas' row, and for each one still carrying the sentinel,
+// extracts the slug and rewrites company/company_slug plus a refreshed content_hash. A row
+// whose url doesn't match the expected shape is counted (unresolved) and left alone rather
+// than aborting the run. Idempotent: a second run finds no sentinel rows left to fix.
+package main
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobhash"
+	"github.com/strelov1/freehire/internal/normalize"
+	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+// backfillBatchSize bounds how many rows are read per keyset page.
+const backfillBatchSize = 500
+
+// companySlugPath pulls the company slug out of a canonical Himalayas job URL
+// (https://himalayas.app/companies/<slug>/jobs/...), same pattern the adapter's live fallback
+// no longer needs (it reads companySlug straight off the feed) but a stored row only has url.
+var companySlugPath = regexp.MustCompile(`himalayas\.app/companies/([^/]+)/jobs/`)
+
+// jobStore is the slice of the data layer the backfill needs. *db.Queries satisfies it; the
+// test uses a fake.
+type jobStore interface {
+	ListJobsBySourceAfter(ctx context.Context, arg db.ListJobsBySourceAfterParams) ([]db.Job, error)
+	UpdateJobCompany(ctx context.Context, arg db.UpdateJobCompanyParams) (int64, error)
+}
+
+func main() {
+	worker.Main(run)
+}
+
+func run() int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	total, updated, unresolved, err := backfillAll(ctx, db.New(pool))
+	if err != nil {
+		log.Printf("backfill-himalayas-companyname: %v", err)
+		return 1
+	}
+	log.Printf("backfill-himalayas-companyname done: scanned=%d updated=%d unresolved=%d", total, updated, unresolved)
+	return 0
+}
+
+// backfillAll pages every himalayas row and rewrites company/company_slug on rows still
+// carrying HimalayasCompanyNameSentinel. It pages by keyset (id > last seen) so concurrent
+// writes cannot skip or repeat rows. A sentinel row whose url yields no slug is counted
+// (unresolved) and skipped, never aborting the run.
+func backfillAll(ctx context.Context, store jobStore) (total, updated, unresolved int, err error) {
+	var afterID int64
+	for {
+		jobs, err := store.ListJobsBySourceAfter(ctx, db.ListJobsBySourceAfterParams{
+			Source:    "himalayas",
+			AfterID:   afterID,
+			BatchSize: backfillBatchSize,
+		})
+		if err != nil {
+			return total, updated, unresolved, err
+		}
+		if len(jobs) == 0 {
+			break
+		}
+		afterID = jobs[len(jobs)-1].ID
+
+		for _, j := range jobs {
+			total++
+			if j.Company != sources.HimalayasCompanyNameSentinel {
+				continue
+			}
+			m := companySlugPath.FindStringSubmatch(j.URL)
+			if m == nil {
+				unresolved++
+				continue
+			}
+			company := m[1]
+			companySlug := normalize.Slug(company)
+
+			row := j
+			row.Company = company
+			row.CompanySlug = companySlug
+			hash := jobhash.OfRow(row, j.Description)
+
+			if _, err := store.UpdateJobCompany(ctx, db.UpdateJobCompanyParams{
+				ID:          j.ID,
+				Company:     company,
+				CompanySlug: companySlug,
+				ContentHash: pgtype.Text{String: hash, Valid: true},
+			}); err != nil {
+				return total, updated, unresolved, err
+			}
+			updated++
+		}
+
+		if len(jobs) < backfillBatchSize {
+			break
+		}
+	}
+	return total, updated, unresolved, nil
+}

--- a/cmd/backfill-himalayas-companyname/main_test.go
+++ b/cmd/backfill-himalayas-companyname/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobhash"
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// fakeStore serves one keyset page of himalayas rows and records every company update.
+type fakeStore struct {
+	jobs    []db.Job
+	updates []db.UpdateJobCompanyParams
+	served  bool
+}
+
+func (f *fakeStore) ListJobsBySourceAfter(_ context.Context, _ db.ListJobsBySourceAfterParams) ([]db.Job, error) {
+	if f.served {
+		return nil, nil
+	}
+	f.served = true
+	return f.jobs, nil
+}
+
+func (f *fakeStore) UpdateJobCompany(_ context.Context, arg db.UpdateJobCompanyParams) (int64, error) {
+	f.updates = append(f.updates, arg)
+	return 1, nil
+}
+
+func TestBackfillRecoversCompanyFromURL(t *testing.T) {
+	store := &fakeStore{jobs: []db.Job{
+		// sentinel-hit, URL resolves → repaired
+		{ID: 1, Source: "himalayas", Company: sources.HimalayasCompanyNameSentinel,
+			URL: "https://himalayas.app/companies/freshworks/jobs/channel-sales-manager-east-9054304068"},
+		// already clean → left alone
+		{ID: 2, Source: "himalayas", Company: "Peroptyx",
+			URL: "https://himalayas.app/companies/peroptyx/jobs/data-analyst"},
+		// sentinel-hit but url doesn't match the expected shape → unresolved, skipped
+		{ID: 3, Source: "himalayas", Company: sources.HimalayasCompanyNameSentinel,
+			URL: "https://example.com/not-a-himalayas-url"},
+	}}
+
+	total, updated, unresolved, err := backfillAll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("backfillAll: %v", err)
+	}
+	if total != 3 || updated != 1 || unresolved != 1 {
+		t.Fatalf("total=%d updated=%d unresolved=%d, want 3/1/1", total, updated, unresolved)
+	}
+	if len(store.updates) != 1 || store.updates[0].ID != 1 {
+		t.Fatalf("updates = %+v, want one update of job 1", store.updates)
+	}
+	u := store.updates[0]
+	if u.Company != "freshworks" || u.CompanySlug != "freshworks" {
+		t.Errorf("Company=%q CompanySlug=%q, want both %q", u.Company, u.CompanySlug, "freshworks")
+	}
+	row := store.jobs[0]
+	row.Company, row.CompanySlug = "freshworks", "freshworks"
+	want := jobhash.OfRow(row, row.Description)
+	if !u.ContentHash.Valid || u.ContentHash.String != want {
+		t.Errorf("ContentHash = %+v, want %q", u.ContentHash, want)
+	}
+}
+
+func TestBackfillIsIdempotent(t *testing.T) {
+	// A row already carrying a real company (not the sentinel) is left alone entirely — a
+	// second run over already-repaired rows updates nothing.
+	store := &fakeStore{jobs: []db.Job{
+		{ID: 1, Source: "himalayas", Company: "freshworks", URL: "https://himalayas.app/companies/freshworks/jobs/x"},
+	}}
+	if _, updated, _, err := backfillAll(context.Background(), store); err != nil || updated != 0 {
+		t.Fatalf("updated=%d err=%v, want 0 updates, nil err", updated, err)
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -2766,6 +2766,40 @@ func (q *Queries) UnseenJobIDsBySource(ctx context.Context, arg UnseenJobIDsBySo
 	return items, nil
 }
 
+const updateJobCompany = `-- name: UpdateJobCompany :execrows
+UPDATE jobs
+SET company      = $1,
+    company_slug = $2,
+    content_hash = $3,
+    updated_at   = now()
+WHERE id = $4
+`
+
+type UpdateJobCompanyParams struct {
+	Company     string      `json:"company"`
+	CompanySlug string      `json:"company_slug"`
+	ContentHash pgtype.Text `json:"content_hash"`
+	ID          int64       `json:"id"`
+}
+
+// Targeted company/company_slug rewrite for cmd/backfill-himalayas-companyname: repairs rows
+// ingested while the adapter stored Himalayas' companyName sentinel verbatim (see
+// sources.HimalayasCompanyNameSentinel). Same shape as UpdateJobDescription: only the two
+// company columns and the refreshed content_hash move, stamping updated_at so `reindex --since`
+// picks the row back up.
+func (q *Queries) UpdateJobCompany(ctx context.Context, arg UpdateJobCompanyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateJobCompany,
+		arg.Company,
+		arg.CompanySlug,
+		arg.ContentHash,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateJobDerived = `-- name: UpdateJobDerived :exec
 UPDATE jobs
 SET countries = COALESCE($1::text[], '{}'),

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -2975,6 +2975,12 @@ type Querier interface {
 	// A full owner-scoped replacement, used by the profile UI where the user is editing the
 	// fields directly and means what they typed — including blanking one.
 	UpdateExperienceEmployment(ctx context.Context, arg UpdateExperienceEmploymentParams) (ExperienceEmployment, error)
+	// Targeted company/company_slug rewrite for cmd/backfill-himalayas-companyname: repairs rows
+	// ingested while the adapter stored Himalayas' companyName sentinel verbatim (see
+	// sources.HimalayasCompanyNameSentinel). Same shape as UpdateJobDescription: only the two
+	// company columns and the refreshed content_hash move, stamping updated_at so `reindex --since`
+	// picks the row back up.
+	UpdateJobCompany(ctx context.Context, arg UpdateJobCompanyParams) (int64, error)
 	// One-off re-derive (cmd/backfill-derive): rewrite in a single pass every column that
 	// ingest computes as a pure function of a row's own raw/immutable fields — the
 	// deterministic dictionary facets (countries, regions, cities, work_mode, skills,

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -46,6 +46,19 @@ SET description  = sqlc.arg(description),
     updated_at   = now()
 WHERE id = sqlc.arg(id);
 
+-- name: UpdateJobCompany :execrows
+-- Targeted company/company_slug rewrite for cmd/backfill-himalayas-companyname: repairs rows
+-- ingested while the adapter stored Himalayas' companyName sentinel verbatim (see
+-- sources.HimalayasCompanyNameSentinel). Same shape as UpdateJobDescription: only the two
+-- company columns and the refreshed content_hash move, stamping updated_at so `reindex --since`
+-- picks the row back up.
+UPDATE jobs
+SET company      = sqlc.arg(company),
+    company_slug = sqlc.arg(company_slug),
+    content_hash = sqlc.arg(content_hash),
+    updated_at   = now()
+WHERE id = sqlc.arg(id);
+
 -- name: ListJobsUpdatedAfter :many
 -- Incremental keyset scan for `reindex --since`: like ListJobsByIDAfter but only
 -- rows changed at or after the cutoff. Every write path (UpsertJob, the close

--- a/internal/sources/himalayas.go
+++ b/internal/sources/himalayas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // himalayas adapts himalayas.app, a remote-jobs aggregator. Boardless (one public API, no
@@ -31,6 +32,11 @@ const (
 	himalayasListURL  = "https://himalayas.app/jobs/api?limit=%d&offset=%d"
 )
 
+// HimalayasCompanyNameSentinel is the literal value Himalayas' feed sends as companyName for
+// a subset of postings, instead of the real company — see toJob. Exported for
+// cmd/backfill-himalayas-companyname, which repairs rows ingested before this was handled.
+const HimalayasCompanyNameSentinel = "name"
+
 // NewHimalayas builds the Himalayas adapter over the given HTTP client.
 func NewHimalayas(c JSONGetter) Source { return himalayas{http: c} }
 
@@ -51,6 +57,7 @@ type himalayasResponse struct {
 type himalayasPosting struct {
 	Title                string   `json:"title"`
 	CompanyName          string   `json:"companyName"`
+	CompanySlug          string   `json:"companySlug"`
 	ApplicationLink      string   `json:"applicationLink"`
 	GUID                 string   `json:"guid"`
 	LocationRestrictions []string `json:"locationRestrictions"`
@@ -92,15 +99,26 @@ func (s himalayas) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 
 // toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
 // guid to key on, or no company which would break the slug). Himalayas lists only remote jobs.
+//
+// Himalayas' own feed renders companyName as the literal string "name" for a chunk of
+// postings (~20% in a sample crawl) — a template field left unresolved on their end.
+// companySlug, a separate field carrying the same company, is unaffected, so a posting
+// caught by this falls back to it (e.g. "talentcross") rather than being dropped or showing
+// the literal "name" as the employer. That slug is the same shape internal/companyname
+// already resolves for other slug-only boards; Himalayas has no resolver registered there yet.
 func (p himalayasPosting) toJob() (Job, bool) {
-	if p.GUID == "" || p.CompanyName == "" {
+	company := p.CompanyName
+	if strings.EqualFold(strings.TrimSpace(company), HimalayasCompanyNameSentinel) {
+		company = p.CompanySlug
+	}
+	if p.GUID == "" || company == "" {
 		return Job{}, false
 	}
 	return Job{
 		ExternalID:  p.GUID,
 		URL:         p.ApplicationLink,
 		Title:       p.Title,
-		Company:     p.CompanyName,
+		Company:     company,
 		Location:    joinNonEmpty(p.LocationRestrictions...),
 		Description: StripHimalayasSelfPromo(sanitizeHTML(p.Description)),
 		Remote:      true,

--- a/internal/sources/himalayas_test.go
+++ b/internal/sources/himalayas_test.go
@@ -85,6 +85,41 @@ func TestHimalayasFetchPaginatesAndMaps(t *testing.T) {
 	}
 }
 
+func TestHimalayasCompanyNameSentinelFallsBackToCompanySlug(t *testing.T) {
+	// Himalayas' feed renders companyName as the literal "name" for some postings (an
+	// unresolved template field on their end). companySlug, a separate JSON field, stays
+	// correct even then, so toJob recovers the company from it instead of storing the
+	// literal sentinel. Confirmed live: guid also carries a stray leading ":" on these rows
+	// (a second, correlated glitch), which is exactly why companySlug — not guid parsing —
+	// is the fallback.
+	p := himalayasPosting{
+		Title:       "Channel Sales Manager (East)",
+		CompanyName: HimalayasCompanyNameSentinel,
+		CompanySlug: "freshworks",
+		GUID:        ":https://himalayas.app/companies/freshworks/jobs/channel-sales-manager-east-9054304068",
+	}
+	j, ok := p.toJob()
+	if !ok {
+		t.Fatal("toJob() ok = false, want true (companySlug yields a recoverable company)")
+	}
+	if j.Company != "freshworks" {
+		t.Errorf("Company = %q, want %q (recovered from companySlug)", j.Company, "freshworks")
+	}
+}
+
+func TestHimalayasCompanyNameSentinelDropsWhenCompanySlugAlsoMissing(t *testing.T) {
+	// When companySlug is empty too, there is nothing usable to fall back to — drop the
+	// posting rather than store the literal "name" as the company.
+	p := himalayasPosting{
+		Title:       "Operations Manager",
+		CompanyName: HimalayasCompanyNameSentinel,
+		GUID:        "https://himalayas.app/companies/somewhere/jobs/operations-manager",
+	}
+	if _, ok := p.toJob(); ok {
+		t.Error("toJob() ok = true, want false (no companySlug to recover the company from)")
+	}
+}
+
 func TestHimalayasReturnsPartialOnPageError(t *testing.T) {
 	// Himalayas rate-limits (429) mid-crawl. A page failure after we have already collected
 	// jobs must return the partial result, not discard everything: the first page succeeds,


### PR DESCRIPTION
## Summary
- Himalayas' own `/jobs/api` feed renders `companyName` as the literal string `"name"` for ~20% of postings sampled — an unresolved template field on their end, not our parsing. It broke both the displayed company and the public job slug (e.g. `channel-sales-manager-east-name-...`).
- `toJob` now falls back to the feed's separate `companySlug` field when it sees the sentinel — verified correct on every sentinel-hit posting sampled (20/20), and unaffected by a second, correlated glitch on some of these rows (a stray leading `:` on `guid`).
- Adds `cmd/backfill-himalayas-companyname` to repair already-ingested rows (~2100 on prod). A normal re-crawl won't reach most of them: himalayas is boardless with a per-run page budget far short of its ~88k catalogue (recency-ordered, so old rows fall out of the crawled window). The backfill instead recovers the slug from each row's own stored `url`, which always carries it at `/companies/<slug>/jobs/...`.
- `public_slug` is intentionally left untouched by both the fix and the backfill — it's minted once at insert and existing external links must keep working.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` and `go vet -tags=integration ./...`
- [x] `go test ./...`
- [x] New tests: sentinel→companySlug fallback + drop-when-unresolvable (`internal/sources/himalayas_test.go`), backfill recover/skip-clean/skip-unresolved + idempotency (`cmd/backfill-himalayas-companyname/main_test.go`)