### PR TITLE
fix(experience): close merge race, N+1 import, and code-review nits

### DIFF
--- a/internal/db/experience.sql.go
+++ b/internal/db/experience.sql.go
@@ -487,9 +487,11 @@ WITH updated AS (
         provenance = $4,
         updated_at = now()
     WHERE experience_atoms.id = $5 AND experience_atoms.user_id = $6
+      AND experience_atoms.updated_at = $7
       AND EXISTS (
           SELECT 1 FROM experience_atoms AS loser
-          WHERE loser.id = $7 AND loser.user_id = $6
+          WHERE loser.id = $8 AND loser.user_id = $6
+            AND loser.updated_at = $9
       )
     RETURNING experience_atoms.id, experience_atoms.user_id, experience_atoms.employment_id,
               experience_atoms.claim, experience_atoms.claim_key, experience_atoms.context,
@@ -498,7 +500,7 @@ WITH updated AS (
 ),
 deleted AS (
     DELETE FROM experience_atoms
-    WHERE experience_atoms.id = $7 AND experience_atoms.user_id = $6
+    WHERE experience_atoms.id = $8 AND experience_atoms.user_id = $6
       AND EXISTS (SELECT 1 FROM updated)
     RETURNING experience_atoms.id
 )
@@ -506,13 +508,15 @@ SELECT id, user_id, employment_id, claim, claim_key, context, metrics, skills, p
 `
 
 type MergeExperienceAtomsParams struct {
-	Context    string    `json:"context"`
-	Metrics    []string  `json:"metrics"`
-	Skills     []string  `json:"skills"`
-	Provenance string    `json:"provenance"`
-	KeepID     uuid.UUID `json:"keep_id"`
-	UserID     int64     `json:"user_id"`
-	LoserID    uuid.UUID `json:"loser_id"`
+	Context        string             `json:"context"`
+	Metrics        []string           `json:"metrics"`
+	Skills         []string           `json:"skills"`
+	Provenance     string             `json:"provenance"`
+	KeepID         uuid.UUID          `json:"keep_id"`
+	UserID         int64              `json:"user_id"`
+	KeepUpdatedAt  pgtype.Timestamptz `json:"keep_updated_at"`
+	LoserID        uuid.UUID          `json:"loser_id"`
+	LoserUpdatedAt pgtype.Timestamptz `json:"loser_updated_at"`
 }
 
 type MergeExperienceAtomsRow struct {
@@ -537,6 +541,13 @@ type MergeExperienceAtomsRow struct {
 // landed. The UPDATE itself is gated on the loser still existing, for the same reason in
 // the other direction. Either both sides of the merge happen or neither does. Claim,
 // claim_key, employment_id and source_ref stay on the keep — only richness fields move.
+//
+// Both rows are additionally gated on updated_at still matching what Store.MergeAtoms read
+// when it chose keep/lose and computed @context/@metrics/@skills: that computation happens
+// in Go, outside any transaction, so a write landing in the gap (an edit, another merge)
+// must not be silently clobbered by an UPDATE built from a stale snapshot. A mismatch here
+// yields no row exactly like a concurrent delete already did, and the caller reports both
+// the same way — reload and retry — rather than pretending a still-present row vanished.
 func (q *Queries) MergeExperienceAtoms(ctx context.Context, arg MergeExperienceAtomsParams) (MergeExperienceAtomsRow, error) {
 	row := q.db.QueryRow(ctx, mergeExperienceAtoms,
 		arg.Context,
@@ -545,7 +556,9 @@ func (q *Queries) MergeExperienceAtoms(ctx context.Context, arg MergeExperienceA
 		arg.Provenance,
 		arg.KeepID,
 		arg.UserID,
+		arg.KeepUpdatedAt,
 		arg.LoserID,
+		arg.LoserUpdatedAt,
 	)
 	var i MergeExperienceAtomsRow
 	err := row.Scan(

--- a/internal/db/experience_integration_test.go
+++ b/internal/db/experience_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -410,6 +411,7 @@ func TestMergeExperienceAtomsIsAtomic(t *testing.T) {
 	merged, err := q.MergeExperienceAtoms(ctx, MergeExperienceAtomsParams{
 		Context: "model profiles", Metrics: []string{"VAD"}, Skills: []string{"python", "nlp"},
 		Provenance: "agent_inferred", KeepID: keep.ID, UserID: alice, LoserID: loser.ID,
+		KeepUpdatedAt: keep.UpdatedAt, LoserUpdatedAt: loser.UpdatedAt,
 	})
 	if err != nil {
 		t.Fatalf("MergeExperienceAtoms: %v", err)
@@ -435,6 +437,7 @@ func TestMergeExperienceAtomsIsAtomic(t *testing.T) {
 	_, err = q.MergeExperienceAtoms(ctx, MergeExperienceAtomsParams{
 		Context: "x", Metrics: []string{}, Skills: []string{}, Provenance: "manual",
 		KeepID: keep.ID, UserID: alice, LoserID: loser.ID,
+		KeepUpdatedAt: merged.UpdatedAt, LoserUpdatedAt: loser.UpdatedAt,
 	})
 	if !errors.Is(err, pgx.ErrNoRows) {
 		t.Fatalf("second merge with gone loser = %v, want pgx.ErrNoRows", err)
@@ -462,6 +465,7 @@ func TestMergeExperienceAtomsLeavesLoserWhenKeepIsGone(t *testing.T) {
 	_, err = q.MergeExperienceAtoms(ctx, MergeExperienceAtomsParams{
 		Context: "x", Metrics: []string{}, Skills: []string{}, Provenance: "manual",
 		KeepID: uuid.New(), UserID: alice, LoserID: loser.ID,
+		KeepUpdatedAt: pgtype.Timestamptz{Time: time.Now(), Valid: true}, LoserUpdatedAt: loser.UpdatedAt,
 	})
 	if !errors.Is(err, pgx.ErrNoRows) {
 		t.Fatalf("merge with nonexistent keep = %v, want pgx.ErrNoRows", err)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -2067,6 +2067,13 @@ type Querier interface {
 	// landed. The UPDATE itself is gated on the loser still existing, for the same reason in
 	// the other direction. Either both sides of the merge happen or neither does. Claim,
 	// claim_key, employment_id and source_ref stay on the keep — only richness fields move.
+	//
+	// Both rows are additionally gated on updated_at still matching what Store.MergeAtoms read
+	// when it chose keep/lose and computed @context/@metrics/@skills: that computation happens
+	// in Go, outside any transaction, so a write landing in the gap (an edit, another merge)
+	// must not be silently clobbered by an UPDATE built from a stale snapshot. A mismatch here
+	// yields no row exactly like a concurrent delete already did, and the caller reports both
+	// the same way — reload and retry — rather than pretending a still-present row vanished.
 	MergeExperienceAtoms(ctx context.Context, arg MergeExperienceAtomsParams) (MergeExperienceAtomsRow, error)
 	// The revision a follow-on edit might be folded into. Only the newest is a candidate:
 	// coalescing into anything older would reorder the log.

--- a/internal/db/queries/experience.sql
+++ b/internal/db/queries/experience.sql
@@ -126,6 +126,13 @@ WHERE id = $1 AND user_id = $2;
 -- landed. The UPDATE itself is gated on the loser still existing, for the same reason in
 -- the other direction. Either both sides of the merge happen or neither does. Claim,
 -- claim_key, employment_id and source_ref stay on the keep — only richness fields move.
+--
+-- Both rows are additionally gated on updated_at still matching what Store.MergeAtoms read
+-- when it chose keep/lose and computed @context/@metrics/@skills: that computation happens
+-- in Go, outside any transaction, so a write landing in the gap (an edit, another merge)
+-- must not be silently clobbered by an UPDATE built from a stale snapshot. A mismatch here
+-- yields no row exactly like a concurrent delete already did, and the caller reports both
+-- the same way — reload and retry — rather than pretending a still-present row vanished.
 WITH updated AS (
     UPDATE experience_atoms
     SET context = @context,
@@ -134,9 +141,11 @@ WITH updated AS (
         provenance = @provenance,
         updated_at = now()
     WHERE experience_atoms.id = @keep_id AND experience_atoms.user_id = @user_id
+      AND experience_atoms.updated_at = @keep_updated_at
       AND EXISTS (
           SELECT 1 FROM experience_atoms AS loser
           WHERE loser.id = @loser_id AND loser.user_id = @user_id
+            AND loser.updated_at = @loser_updated_at
       )
     RETURNING experience_atoms.id, experience_atoms.user_id, experience_atoms.employment_id,
               experience_atoms.claim, experience_atoms.claim_key, experience_atoms.context,

--- a/internal/experience/employment_json.go
+++ b/internal/experience/employment_json.go
@@ -27,8 +27,8 @@ type employmentWire struct {
 	Stack    []string  `json:"stack,omitempty"`
 }
 
-// ToWire returns the kind-aware JSON projection of e.
-func (e Employment) ToWire() employmentWire {
+// toWire returns the kind-aware JSON projection of e.
+func (e Employment) toWire() employmentWire {
 	w := employmentWire{
 		ID: e.ID, Kind: e.Kind, Role: e.Role, Location: e.Location,
 		Start: e.Start, End: e.End, Current: e.Current, Summary: e.Summary,
@@ -44,7 +44,7 @@ func (e Employment) ToWire() employmentWire {
 
 // MarshalJSON emits company for jobs and name for projects.
 func (e Employment) MarshalJSON() ([]byte, error) {
-	return json.Marshal(e.ToWire())
+	return json.Marshal(e.toWire())
 }
 
 // UnmarshalJSON accepts kind-aware input: projects prefer `name`, with legacy

--- a/internal/experience/experience.go
+++ b/internal/experience/experience.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/skilltag"
 )
 
@@ -211,7 +210,18 @@ func ClaimKey(claim string) string {
 // clip trims s and truncates to at most max runes on a rune boundary, trimming again so
 // a mid-word cut never leaves a trailing space.
 func clip(s string, max int) string {
-	return strings.TrimSpace(llm.TruncateRunes(strings.TrimSpace(s), max))
+	return strings.TrimSpace(truncateRunes(strings.TrimSpace(s), max))
+}
+
+// truncateRunes clamps s to at most max runes. Local rather than reused from internal/llm
+// so this file stays free of any server-only dependency — cmd/gen-contracts generates the
+// TypeScript wire types from this file alone (see the package-level comment on Employment).
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max])
 }
 
 // limit returns at most n elements of s (nil-safe, preserves order).

--- a/internal/experience/import.go
+++ b/internal/experience/import.go
@@ -58,13 +58,22 @@ func (s *Store) Import(ctx context.Context, userID int64, entries []ImportEntry,
 				Provenance: ProvenanceCVImport,
 				SourceRef:  sourceRef,
 			}
-			switch _, err := s.AddAtom(ctx, userID, atom); {
+			atom.Sanitize()
+			if err := atom.Validate(); err != nil {
+				if errors.Is(err, ErrEmptyClaim) {
+					// A blank bullet is noise in the parse, not a reason to fail the upload.
+					continue
+				}
+				return result, err
+			}
+			// employmentID was just created or found (and, either way, owner-scoped) by
+			// reconcileEmployment above — insertAtom skips the ownsEmployment re-check
+			// AddAtom would otherwise repeat on every single bullet.
+			switch _, err := s.insertAtom(ctx, userID, atom); {
 			case err == nil:
 				result.AtomsCreated++
 			case errors.Is(err, ErrAlreadyBanked):
 				result.AtomsSkipped++
-			case errors.Is(err, ErrEmptyClaim):
-				// A blank bullet is noise in the parse, not a reason to fail the upload.
 			default:
 				return result, err
 			}

--- a/internal/experience/import_resume.go
+++ b/internal/experience/import_resume.go
@@ -1,19 +1,12 @@
 package experience
 
 import (
-	"strings"
-
 	"github.com/strelov1/freehire/internal/resumeextract"
 )
 
 // This file is the ONE adapter that names a concrete source. Import itself takes
 // []ImportEntry and knows nothing about résumés, so the bank stays source-agnostic; a
 // LinkedIn export or a bulk paste would add a sibling file here rather than change it.
-
-// currentEndLabels are the end-date labels a CV uses for a role that has not ended. A CV
-// states "Present", not a flag, so the current role has to be read off the label — and an
-// empty label is the other way of saying the same thing.
-var currentEndLabels = map[string]bool{"": true, "present": true, "current": true, "now": true, "ongoing": true}
 
 // EntriesFromResume maps a parsed résumé onto the bank's import shape. This is
 // the seam that keeps internal/experience free of any one importer's vocabulary: roles
@@ -34,9 +27,10 @@ func EntriesFromResume(st resumeextract.Structured) []ImportEntry {
 				Location: role.Location,
 				Start:    role.Start,
 				End:      role.End,
-				Current:  currentEndLabels[strings.ToLower(strings.TrimSpace(role.End))],
-				Summary:  role.Summary,
-				Stack:    role.Stack,
+				// An empty label is a CV's other way of saying "not ended".
+				Current: role.End == "" || isPresentLabel(role.End),
+				Summary: role.Summary,
+				Stack:   role.Stack,
 			},
 			Claims: role.Highlights,
 		})

--- a/internal/experience/import_test.go
+++ b/internal/experience/import_test.go
@@ -266,6 +266,23 @@ func TestImportBanksClaimsWhoseRoleIsUnnamed(t *testing.T) {
 	}
 }
 
+// Import proves ownership of an entry's employment once, in reconcileEmployment — it must
+// not re-verify that same id per claim the way AddAtom does for an untrusted caller.
+// GetEmployment is only ever called by ownsEmployment, so a zero count here is proof the
+// per-bullet re-check is gone.
+func TestImportDoesNotReverifyEmploymentOwnershipPerClaim(t *testing.T) {
+	s, repo := newStore()
+	ctx := context.Background()
+
+	entry := ringCentral() // one employment, two claims
+	if _, err := s.Import(ctx, owner, []ImportEntry{entry}, "stamp"); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if repo.getEmploymentCalls != 0 {
+		t.Errorf("GetEmployment called %d times during import, want 0", repo.getEmploymentCalls)
+	}
+}
+
 func contains(haystack []string, needle string) bool {
 	for _, v := range haystack {
 		if v == needle {

--- a/internal/experience/merge.go
+++ b/internal/experience/merge.go
@@ -2,6 +2,7 @@ package experience
 
 import (
 	"errors"
+	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -22,13 +23,19 @@ var (
 	// owner has opted into requiring situation paragraphs. Checked in the
 	// handler/tool, not in Store.AddAtom — import must stay ungated.
 	ErrContextRequired = errors.New("experience: context is required for new achievements — add a short situation paragraph, or ask the interviewer to turn the requirement off")
+	// ErrMergeConflict is one of the two atoms changing between Store.MergeAtoms reading it
+	// and the write landing — another edit, another merge, a delete. The row is never
+	// silently overwritten from a stale snapshot; the caller reloads and retries instead.
+	ErrMergeConflict = errors.New("experience: one of these atoms changed since they were loaded — fetch them again and retry the merge")
 )
 
-// mergeCandidate is one side of a merge, carrying the created_at used for
-// keep-selection ties. The domain Atom does not expose CreatedAt on the wire.
+// mergeCandidate is one side of a merge, carrying the created_at (keep-selection ties) and
+// updated_at (the optimistic-lock token for the eventual write) the domain Atom does not
+// expose on the wire.
 type mergeCandidate struct {
 	Atom
 	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // chooseKeep returns which of a, b to keep (true → a) by richness score, then
@@ -53,6 +60,18 @@ func richnessScore(a Atom) int {
 		score++
 	}
 	return score
+}
+
+// digitRE matches any Unicode digit — a claim that already carries a number is
+// not thin on metrics even when the metrics array is empty.
+var digitRE = regexp.MustCompile(`\d`)
+
+// Richness reports whether an atom is thin on situation or numbers. Derived on
+// read; never persisted.
+func Richness(a Atom) (needsContext, needsMetrics bool) {
+	needsContext = strings.TrimSpace(a.Context) == ""
+	needsMetrics = len(a.Metrics) == 0 && !digitRE.MatchString(a.Claim)
+	return needsContext, needsMetrics
 }
 
 // unionForMerge builds the kept atom's post-merge fields. Claim, employment,

--- a/internal/experience/merge_test.go
+++ b/internal/experience/merge_test.go
@@ -7,6 +7,43 @@ import (
 	"github.com/google/uuid"
 )
 
+func TestRichness(t *testing.T) {
+	tests := []struct {
+		name                 string
+		atom                 Atom
+		wantContext, wantMet bool
+	}{
+		{
+			name:        "claim only",
+			atom:        Atom{Claim: "Built a plugin"},
+			wantContext: true, wantMet: true,
+		},
+		{
+			name:        "digit in claim is not thin on metrics",
+			atom:        Atom{Claim: "Cut checkout latency by 40%"},
+			wantContext: true, wantMet: false,
+		},
+		{
+			name:        "metrics array covers numbers",
+			atom:        Atom{Claim: "Cut latency", Metrics: []string{"20s -> 1s"}},
+			wantContext: true, wantMet: false,
+		},
+		{
+			name:        "context present",
+			atom:        Atom{Claim: "Built a plugin", Context: "Chromium extension"},
+			wantContext: false, wantMet: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotC, gotM := Richness(tt.atom)
+			if gotC != tt.wantContext || gotM != tt.wantMet {
+				t.Errorf("Richness = (%v, %v), want (%v, %v)", gotC, gotM, tt.wantContext, tt.wantMet)
+			}
+		})
+	}
+}
+
 func TestUnionForMergeScreenshotPair(t *testing.T) {
 	keep := Atom{
 		ID:         uuid.New(),

--- a/internal/experience/period_sort.go
+++ b/internal/experience/period_sort.go
@@ -33,9 +33,12 @@ func sortKeyForEmployment(start, end string, current bool) periodSortKey {
 	return periodKeyUnknown
 }
 
+// isPresentLabel reports whether s is a CV's way of spelling "this hasn't ended" — the
+// only place this vocabulary is defined, so import_resume.go's Current derivation and this
+// file's own period parsing can never drift apart on which spellings count.
 func isPresentLabel(s string) bool {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "present", "current", "now", "today":
+	case "present", "current", "now", "ongoing", "today":
 		return true
 	default:
 		return false

--- a/internal/experience/repository.go
+++ b/internal/experience/repository.go
@@ -2,8 +2,10 @@ package experience
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 )
@@ -86,10 +88,12 @@ func (r queriesRepository) DeleteAtom(ctx context.Context, id uuid.UUID, userID 
 	return r.q.DeleteExperienceAtom(ctx, db.DeleteExperienceAtomParams{ID: id, UserID: userID})
 }
 
-func (r queriesRepository) MergeAtoms(ctx context.Context, userID int64, keepID, loserID uuid.UUID, a Atom) (db.ExperienceAtom, error) {
+func (r queriesRepository) MergeAtoms(ctx context.Context, userID int64, keepID, loserID uuid.UUID, keepUpdatedAt, loserUpdatedAt time.Time, a Atom) (db.ExperienceAtom, error) {
 	row, err := r.q.MergeExperienceAtoms(ctx, db.MergeExperienceAtomsParams{
 		Context: a.Context, Metrics: a.Metrics, Skills: a.Skills,
 		Provenance: string(a.Provenance), KeepID: keepID, UserID: userID, LoserID: loserID,
+		KeepUpdatedAt:  pgtype.Timestamptz{Time: keepUpdatedAt, Valid: true},
+		LoserUpdatedAt: pgtype.Timestamptz{Time: loserUpdatedAt, Valid: true},
 	})
 	if err != nil {
 		return db.ExperienceAtom{}, err

--- a/internal/experience/similarity.go
+++ b/internal/experience/similarity.go
@@ -1,9 +1,7 @@
 package experience
 
 import (
-	"regexp"
 	"sort"
-	"strings"
 
 	"github.com/google/uuid"
 )
@@ -14,18 +12,6 @@ import (
 // while distinct claims that differ in numbers (~0.33) or share mostly stopwords (~0.25)
 // do not. Merge still requires an explicit owner confirm.
 const softDupThreshold = 0.40
-
-// digitRE matches any Unicode digit — a claim that already carries a number is
-// not thin on metrics even when the metrics array is empty.
-var digitRE = regexp.MustCompile(`\d`)
-
-// Richness reports whether an atom is thin on situation or numbers. Derived on
-// read; never persisted.
-func Richness(a Atom) (needsContext, needsMetrics bool) {
-	needsContext = strings.TrimSpace(a.Context) == ""
-	needsMetrics = len(a.Metrics) == 0 && !digitRE.MatchString(a.Claim)
-	return needsContext, needsMetrics
-}
 
 // SoftDuplicateClusters groups an owner's atoms into near-paraphrase clusters
 // within one employment bucket (each employment_id, plus one bucket for

--- a/internal/experience/similarity_test.go
+++ b/internal/experience/similarity_test.go
@@ -6,43 +6,6 @@ import (
 	"github.com/google/uuid"
 )
 
-func TestRichness(t *testing.T) {
-	tests := []struct {
-		name                 string
-		atom                 Atom
-		wantContext, wantMet bool
-	}{
-		{
-			name:        "claim only",
-			atom:        Atom{Claim: "Built a plugin"},
-			wantContext: true, wantMet: true,
-		},
-		{
-			name:        "digit in claim is not thin on metrics",
-			atom:        Atom{Claim: "Cut checkout latency by 40%"},
-			wantContext: true, wantMet: false,
-		},
-		{
-			name:        "metrics array covers numbers",
-			atom:        Atom{Claim: "Cut latency", Metrics: []string{"20s -> 1s"}},
-			wantContext: true, wantMet: false,
-		},
-		{
-			name:        "context present",
-			atom:        Atom{Claim: "Built a plugin", Context: "Chromium extension"},
-			wantContext: false, wantMet: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotC, gotM := Richness(tt.atom)
-			if gotC != tt.wantContext || gotM != tt.wantMet {
-				t.Errorf("Richness = (%v, %v), want (%v, %v)", gotC, gotM, tt.wantContext, tt.wantMet)
-			}
-		})
-	}
-}
-
 func TestSoftDuplicateClustersPluginPair(t *testing.T) {
 	a := uuid.New()
 	b := uuid.New()

--- a/internal/experience/store.go
+++ b/internal/experience/store.go
@@ -43,7 +43,9 @@ type Repository interface {
 	InsertAtomIfNew(ctx context.Context, userID int64, a Atom, claimKey string) (db.ExperienceAtom, error)
 	UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a Atom, claimKey string) (db.ExperienceAtom, error)
 	DeleteAtom(ctx context.Context, id uuid.UUID, userID int64) (int64, error)
-	MergeAtoms(ctx context.Context, userID int64, keepID, loserID uuid.UUID, a Atom) (db.ExperienceAtom, error)
+	// MergeAtoms writes only when both rows' updated_at still match what the caller read —
+	// see Store.MergeAtoms and the query's own comment for why.
+	MergeAtoms(ctx context.Context, userID int64, keepID, loserID uuid.UUID, keepUpdatedAt, loserUpdatedAt time.Time, a Atom) (db.ExperienceAtom, error)
 }
 
 // ProfileSkills is the narrow slice of userprofile the bank needs: fold newly banked
@@ -227,6 +229,14 @@ func (s *Store) AddAtom(ctx context.Context, userID int64, a Atom) (Atom, error)
 	if err := s.ownsEmployment(ctx, userID, a.EmploymentID); err != nil {
 		return Atom{}, err
 	}
+	return s.insertAtom(ctx, userID, a)
+}
+
+// insertAtom writes a sanitized, validated, ownership-checked atom. Split out of AddAtom so
+// Import — which reconciles the employment once per entry and already knows the resulting
+// id is the caller's own — can bank every claim under it without AddAtom's ownsEmployment
+// re-verifying the same id on every single bullet.
+func (s *Store) insertAtom(ctx context.Context, userID int64, a Atom) (Atom, error) {
 	row, err := s.repo.InsertAtomIfNew(ctx, userID, a, ClaimKey(a.Claim))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Atom{}, ErrAlreadyBanked
@@ -297,8 +307,8 @@ func (s *Store) MergeAtoms(ctx context.Context, userID int64, aID, bID uuid.UUID
 		return Atom{}, fmt.Errorf("get atom b: %w", err)
 	}
 
-	left := mergeCandidate{Atom: atomFromRow(rowA), CreatedAt: timestamptz(rowA.CreatedAt)}
-	right := mergeCandidate{Atom: atomFromRow(rowB), CreatedAt: timestamptz(rowB.CreatedAt)}
+	left := mergeCandidate{Atom: atomFromRow(rowA), CreatedAt: timestamptz(rowA.CreatedAt), UpdatedAt: timestamptz(rowA.UpdatedAt)}
+	right := mergeCandidate{Atom: atomFromRow(rowB), CreatedAt: timestamptz(rowB.CreatedAt), UpdatedAt: timestamptz(rowB.UpdatedAt)}
 	if err := validateMergePair(aID, bID, left.Atom, right.Atom); err != nil {
 		return Atom{}, err
 	}
@@ -312,9 +322,13 @@ func (s *Store) MergeAtoms(ctx context.Context, userID int64, aID, bID uuid.UUID
 		return Atom{}, err
 	}
 
-	row, err := s.repo.MergeAtoms(ctx, userID, keep.ID, lose.ID, merged)
+	// keep.UpdatedAt/lose.UpdatedAt pin the write to the exact rows just read: the choice of
+	// keep/lose and the union above happen here in Go, not inside the write's transaction,
+	// so a write landing in that gap must not be silently overwritten by an update computed
+	// from a now-stale snapshot (see the query's own comment).
+	row, err := s.repo.MergeAtoms(ctx, userID, keep.ID, lose.ID, keep.UpdatedAt, lose.UpdatedAt, merged)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return Atom{}, ErrNotFound
+		return Atom{}, ErrMergeConflict
 	}
 	if err != nil {
 		return Atom{}, fmt.Errorf("merge atoms: %w", err)

--- a/internal/experience/store_integration_test.go
+++ b/internal/experience/store_integration_test.go
@@ -11,8 +11,10 @@ package experience
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -112,5 +114,61 @@ func TestStoreAddAtom_LeavesNoProfileBehindForAUserWithNone(t *testing.T) {
 
 	if _, ok := profileSkills(t, pool, userID); ok {
 		t.Error("a profile row was created as a side effect of banking an atom — it must not be")
+	}
+}
+
+// MergeExperienceAtoms' optimistic lock, proven only against real Postgres — mirroring
+// the store_test.go note that a fake cannot prove the guarantees SQL itself carries. A
+// write landing directly against the keep row, in the gap between where
+// Store.MergeAtoms would have read it and where it writes, must make the merge a no-op:
+// neither clobbering the concurrent edit nor deleting the loser out from under it.
+func TestQueriesRepositoryMergeAtoms_RefusesAStaleUpdatedAt(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := insertExperienceIntegrationUser(t, pool, "merge-race@example.test")
+	repo := NewQueriesRepository(queries)
+
+	// InsertAtomIfNew is the Repository's raw write — Sanitize is Store's job, and skipping
+	// it (nil Metrics/Skills) would trip the NOT NULL columns, so it's done by hand here.
+	keepAtom := Atom{Claim: "Cut latency", Provenance: ProvenanceManual}
+	keepAtom.Sanitize()
+	keep, err := repo.InsertAtomIfNew(ctx, userID, keepAtom, ClaimKey(keepAtom.Claim))
+	if err != nil {
+		t.Fatalf("insert keep: %v", err)
+	}
+	loseAtom := Atom{Claim: "Cut latency further", Provenance: ProvenanceManual}
+	loseAtom.Sanitize()
+	lose, err := repo.InsertAtomIfNew(ctx, userID, loseAtom, ClaimKey(loseAtom.Claim))
+	if err != nil {
+		t.Fatalf("insert lose: %v", err)
+	}
+	staleKeepUpdatedAt := keep.UpdatedAt.Time
+
+	// A write lands directly against Postgres — standing in for a concurrent request —
+	// after Store.MergeAtoms would have already read keep and before its own write.
+	if _, err := pool.Exec(ctx,
+		`UPDATE experience_atoms SET context = 'raced in from another request', updated_at = now() WHERE id = $1`,
+		keep.ID); err != nil {
+		t.Fatalf("simulate concurrent edit: %v", err)
+	}
+
+	merged := Atom{Context: "merged context", Provenance: ProvenanceManual}
+	merged.Sanitize()
+	_, err = repo.MergeAtoms(ctx, userID, keep.ID, lose.ID, staleKeepUpdatedAt, lose.UpdatedAt.Time, merged)
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("MergeAtoms with a stale keep updated_at = %v, want pgx.ErrNoRows", err)
+	}
+
+	after, err := repo.GetAtom(ctx, keep.ID, userID)
+	if err != nil {
+		t.Fatalf("GetAtom keep: %v", err)
+	}
+	if after.Context != "raced in from another request" {
+		t.Errorf("keep context = %q, want the concurrent edit preserved, not overwritten by the aborted merge", after.Context)
+	}
+	if _, err := repo.GetAtom(ctx, lose.ID, userID); err != nil {
+		t.Errorf("GetAtom lose: %v, want the loser to survive an aborted merge", err)
 	}
 }

--- a/internal/experience/store_test.go
+++ b/internal/experience/store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -23,6 +24,9 @@ type fakeRepo struct {
 	employments map[uuid.UUID]db.ExperienceEmployment
 	atoms       map[uuid.UUID]db.ExperienceAtom
 	order       []uuid.UUID // insertion order, so listing is deterministic
+
+	getEmploymentCalls int   // counts GetEmployment invocations, i.e. ownsEmployment checks
+	clock              int64 // monotonic tick behind stamp(), so rows get distinguishable timestamps
 }
 
 func newFakeRepo() *fakeRepo {
@@ -32,7 +36,13 @@ func newFakeRepo() *fakeRepo {
 	}
 }
 
-func stamp() pgtype.Timestamptz { return pgtype.Timestamptz{Valid: true} }
+// stamp mirrors `now()`, except monotonically ticked rather than wall-clock: two rows
+// created in the same test must get comparably-ordered, distinguishable timestamps —
+// real Postgres does that for free, but pgtype.Timestamptz{Valid: true} alone does not.
+func (f *fakeRepo) stamp() pgtype.Timestamptz {
+	f.clock++
+	return pgtype.Timestamptz{Time: time.Unix(f.clock, 0), Valid: true}
+}
 
 func (f *fakeRepo) ListEmployments(_ context.Context, userID int64) ([]db.ExperienceEmployment, error) {
 	var out []db.ExperienceEmployment
@@ -45,6 +55,7 @@ func (f *fakeRepo) ListEmployments(_ context.Context, userID int64) ([]db.Experi
 }
 
 func (f *fakeRepo) GetEmployment(_ context.Context, id uuid.UUID, userID int64) (db.ExperienceEmployment, error) {
+	f.getEmploymentCalls++
 	if e, ok := f.employments[id]; ok && e.UserID == userID {
 		return e, nil
 	}
@@ -68,7 +79,7 @@ func (f *fakeRepo) CreateEmployment(_ context.Context, userID int64, e Employmen
 		ID: id, UserID: userID, Kind: e.Kind, Company: e.Company, Role: e.Role,
 		Location: e.Location, PeriodStart: e.Start, PeriodEnd: e.End,
 		IsCurrent: e.Current, Summary: e.Summary, Link: e.Link, Stack: e.Stack,
-		CreatedAt: stamp(), UpdatedAt: stamp(),
+		CreatedAt: f.stamp(), UpdatedAt: f.stamp(),
 	}
 	f.employments[id] = row
 	f.order = append(f.order, id)
@@ -160,7 +171,7 @@ func (f *fakeRepo) InsertAtomIfNew(_ context.Context, userID int64, a Atom, clai
 	row := db.ExperienceAtom{
 		ID: id, UserID: userID, EmploymentID: a.EmploymentID, Claim: a.Claim, ClaimKey: claimKey,
 		Context: a.Context, Metrics: a.Metrics, Skills: a.Skills,
-		Provenance: string(a.Provenance), SourceRef: a.SourceRef, CreatedAt: stamp(), UpdatedAt: stamp(),
+		Provenance: string(a.Provenance), SourceRef: a.SourceRef, CreatedAt: f.stamp(), UpdatedAt: f.stamp(),
 	}
 	f.atoms[id] = row
 	f.order = append(f.order, id)
@@ -175,6 +186,7 @@ func (f *fakeRepo) UpdateAtom(_ context.Context, id uuid.UUID, userID int64, a A
 	row.EmploymentID, row.Claim, row.ClaimKey = a.EmploymentID, a.Claim, claimKey
 	row.Context, row.Metrics, row.Skills = a.Context, a.Metrics, a.Skills
 	row.Provenance = string(a.Provenance)
+	row.UpdatedAt = f.stamp()
 	f.atoms[id] = row
 	return row, nil
 }
@@ -187,19 +199,19 @@ func (f *fakeRepo) DeleteAtom(_ context.Context, id uuid.UUID, userID int64) (in
 	return 0, nil
 }
 
-func (f *fakeRepo) MergeAtoms(_ context.Context, userID int64, keepID, loserID uuid.UUID, a Atom) (db.ExperienceAtom, error) {
+func (f *fakeRepo) MergeAtoms(_ context.Context, userID int64, keepID, loserID uuid.UUID, keepUpdatedAt, loserUpdatedAt time.Time, a Atom) (db.ExperienceAtom, error) {
 	loser, ok := f.atoms[loserID]
-	if !ok || loser.UserID != userID {
+	if !ok || loser.UserID != userID || !loser.UpdatedAt.Time.Equal(loserUpdatedAt) {
 		return db.ExperienceAtom{}, pgx.ErrNoRows
 	}
 	keep, ok := f.atoms[keepID]
-	if !ok || keep.UserID != userID {
+	if !ok || keep.UserID != userID || !keep.UpdatedAt.Time.Equal(keepUpdatedAt) {
 		return db.ExperienceAtom{}, pgx.ErrNoRows
 	}
 	delete(f.atoms, loserID)
 	keep.Context, keep.Metrics, keep.Skills = a.Context, a.Metrics, a.Skills
 	keep.Provenance = string(a.Provenance)
-	keep.UpdatedAt = stamp()
+	keep.UpdatedAt = f.stamp()
 	f.atoms[keepID] = keep
 	return keep, nil
 }
@@ -584,6 +596,63 @@ func TestStoreMergeAtomsUnionsAndDeletesLoser(t *testing.T) {
 	}
 	if atoms[0].ID != kept.ID {
 		t.Errorf("surviving id = %s, want keep %s", atoms[0].ID, kept.ID)
+	}
+}
+
+// raceInjectingRepo wraps fakeRepo and, the moment Store.MergeAtoms' GetAtom(trigger)
+// returns, simulates a write landing in the exact gap MergeAtoms cannot close on its own:
+// keep/lose selection and the merged-fields union happen in Go, between the two reads and
+// the eventual write, with no transaction holding the rows still. victim is mutated to
+// stand in for that concurrent write.
+type raceInjectingRepo struct {
+	*fakeRepo
+	trigger uuid.UUID
+	victim  uuid.UUID
+}
+
+func (r *raceInjectingRepo) GetAtom(ctx context.Context, id uuid.UUID, userID int64) (db.ExperienceAtom, error) {
+	row, err := r.fakeRepo.GetAtom(ctx, id, userID)
+	if id == r.trigger {
+		v := r.fakeRepo.atoms[r.victim]
+		v.Context = "raced in from another request"
+		v.UpdatedAt = r.fakeRepo.stamp()
+		r.fakeRepo.atoms[r.victim] = v
+	}
+	return row, err
+}
+
+// The race the review flagged: a write landing between Store.MergeAtoms' reads and its
+// write must not be silently discarded by an update computed from the now-stale snapshot.
+func TestStoreMergeAtomsRejectsAConcurrentWriteInTheReadWriteGap(t *testing.T) {
+	s, repo := newStore()
+	ctx := context.Background()
+
+	a, err := s.AddAtom(ctx, owner, Atom{Claim: "Did the thing", Provenance: ProvenanceManual})
+	if err != nil {
+		t.Fatalf("AddAtom a: %v", err)
+	}
+	b, err := s.AddAtom(ctx, owner, Atom{Claim: "Did the other thing", Provenance: ProvenanceManual})
+	if err != nil {
+		t.Fatalf("AddAtom b: %v", err)
+	}
+
+	racy := NewStore(&raceInjectingRepo{fakeRepo: repo, trigger: b.ID, victim: a.ID})
+	if _, err := racy.MergeAtoms(ctx, owner, a.ID, b.ID); !errors.Is(err, ErrMergeConflict) {
+		t.Fatalf("MergeAtoms racing a concurrent edit = %v, want ErrMergeConflict", err)
+	}
+
+	// The concurrent edit must survive untouched — not overwritten by a merge built from
+	// the snapshot read just before it landed.
+	got, err := s.GetAtom(ctx, a.ID, owner)
+	if err != nil {
+		t.Fatalf("GetAtom a: %v", err)
+	}
+	if got.Context != "raced in from another request" {
+		t.Errorf("context = %q, want the concurrent edit preserved, not clobbered by the aborted merge", got.Context)
+	}
+	// The would-be loser must survive too — an aborted merge deletes nothing.
+	if _, err := s.GetAtom(ctx, b.ID, owner); err != nil {
+		t.Errorf("GetAtom b: %v, want the loser to survive an aborted merge", err)
 	}
 }
 

--- a/internal/handler/me_experience.go
+++ b/internal/handler/me_experience.go
@@ -388,7 +388,8 @@ func experienceError(err error) error {
 		errors.Is(err, experience.ErrMergeCrossEmployment),
 		errors.Is(err, experience.ErrContextRequired):
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	case errors.Is(err, experience.ErrAlreadyBanked):
+	case errors.Is(err, experience.ErrAlreadyBanked),
+		errors.Is(err, experience.ErrMergeConflict):
 		return fiber.NewError(fiber.StatusConflict, err.Error())
 	default:
 		return err


### PR DESCRIPTION
## Summary
- **MergeAtoms race (main fix):** `Store.MergeAtoms` read both atoms, computed the merged fields in Go, then wrote via one CTE — a write landing between the reads and the write (a concurrent edit, not just a delete) was silently overwritten. Gated the write on each row's `updated_at` still matching what was read; a mismatch now surfaces as a new `ErrMergeConflict` (409) instead of the misleading `ErrNotFound`.
- **N+1 in Import:** `Import` no longer re-verifies employment ownership per claim — `reconcileEmployment` already proves it once per entry.
- Unified the two "present"-label dictionaries (`import_resume.go` / `period_sort.go`).
- Moved `Richness` next to `richnessScore` in `merge.go` (both are about atom completeness).
- Unexported `Employment.ToWire` (no external callers).
- Dropped `experience.go`'s dependency on `internal/llm` for a local `truncateRunes` helper.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` and `go vet -tags=integration ./...`
- [x] `go test ./...`
- [x] `go test -tags=integration ./internal/experience/...` (real Postgres via testcontainers) — includes a new integration test proving the SQL-level optimistic lock (`TestQueriesRepositoryMergeAtoms_RefusesAStaleUpdatedAt`) and a unit test injecting the exact read/write race (`TestStoreMergeAtomsRejectsAConcurrentWriteInTheReadWriteGap`)