### PR TITLE
Require gofmt, vet, and unit tests before committing Go

### DIFF
--- a/.cursor/rules/commit-checks.mdc
+++ b/.cursor/rules/commit-checks.mdc
@@ -1,0 +1,18 @@
+---
+description: Run gofmt, go vet, and unit tests before committing Go files
+alwaysApply: true
+---
+
+# Before committing Go
+
+When creating a git commit that includes any `*.go` file:
+
+1. `gofmt -w` those paths. `gofmt -l .` must print nothing.
+2. `go vet ./...`
+3. `go test ./...` (unit tests only — no `-tags=integration`).
+
+Do **not** commit if vet or tests fail; fix first.
+
+Skip this suite when the commit has no Go files (docs, OpenSpec, web-only).
+
+Do **not** run `go test -tags=integration ./...` at commit time. That stays push-time: `go vet -tags=integration ./...` before every push; the full tagged suite when behaviour changed.

--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,10 @@ skills-lock.json
 # Spec Kit — local-only (not part of the freehire tree). Keep on disk for personal
 # workflows; never commit tooling, constitution memory, or generated feature specs.
 .specify/
-.cursor/
+# Ignore Cursor local state; keep shared agent rules in the tree.
+.cursor/*
+!.cursor/rules/
+!.cursor/rules/**
 /specs/
 
 # Python
@@ -139,3 +142,5 @@ extension/*.zip
 # Go / Vitest coverage profiles and HTML (make cover, pnpm test:coverage).
 /coverage/
 /web/coverage/
+.pnpm-store/
+.tmp-containers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,11 @@ go vet -tags=integration ./...            # compiles the tagged tests — run be
 go test -tags=integration ./internal/db/  # queue integration tests (needs Docker; testcontainers)
 ```
 
+**Before committing** any `*.go` file: `gofmt -w` those paths (`gofmt -l .` must print
+nothing), then `go vet ./...` and `go test ./...`. Do not commit if they fail. Skip this
+suite when the commit has no Go. Integration-tagged tests stay push-time (`go vet
+-tags=integration ./...` before every push; the full tagged suite when behaviour changed).
+
 **`go test ./...` compiles no `//go:build integration` file, and those files are not
 confined to `internal/db`** — there are 152 of them across 13 packages, and `internal/handler`
 holds 65, which call unexported constructors like `newCVHandlers`. A changed signature

--- a/openspec/changes/commit-gofmt-and-tests/.openspec.yaml
+++ b/openspec/changes/commit-gofmt-and-tests/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-11
+skip_specs: true

--- a/openspec/changes/commit-gofmt-and-tests/design.md
+++ b/openspec/changes/commit-gofmt-and-tests/design.md
@@ -1,0 +1,69 @@
+## Context
+
+See proposal.md — Why. CI already fails PRs on `gofmt -l .` and `go test ./...`
+(CONTRIBUTING.md, `.github/workflows/ci.yml`). `AGENTS.md` tells agents to `go test ./...`
+and `go vet -tags=integration ./...` before **push**, but the Cursor commit protocol does
+not require fmt or tests before `git commit`. There is no `.cursor/rules/` tree yet.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Agents must format and unit-test Go before a commit that includes Go files.
+- Humans reading AGENTS.md see the same gate.
+- Keep the cheap path: no Docker on every commit.
+
+**Non-Goals:**
+
+- Git pre-commit / pre-push hooks (not requested; optional later).
+- Running `go test -tags=integration ./...` on every commit.
+- Web `pnpm test` / svelte-check as part of this Go-focused rule.
+- Changing CI.
+
+## Decisions
+
+### D1 — Cursor always-apply rule, not a hook
+
+Put the gate in `.cursor/rules/commit-checks.mdc` with `alwaysApply: true` so it binds
+when the agent is asked to commit. Duplicate a short **Before committing** bullet in
+`AGENTS.md` (and `CLAUDE.md` if that file is still a copy) because some agents only
+ingest AGENTS.md.
+
+**Why:** The request was “add as a rule”. Hooks fail open if not installed and punish
+docs-only commits. Alternatives considered: hook only (misses agents that skip hooks);
+AGENTS.md only (weaker in Cursor than an alwaysApply rule).
+
+### D2 — Scope: Go files in the commit
+
+If the staged set contains no `*.go`, skip fmt/test. If it does:
+
+1. `gofmt -w` on those paths (or `gofmt -l .` empty after format).
+2. `go test ./...` (unit; no integration tag).
+3. Do not commit if tests fail; fix first.
+
+Also run `go vet ./...` when Go changed — already in CONTRIBUTING; cheap and catches
+what unit tests miss. Include it in the rule so it is not dropped.
+
+### D3 — Integration stays push-time
+
+Unchanged: `go vet -tags=integration ./...` before every push; full tagged suite when
+behaviour (not just a signature) changed. Do not fold that into commit.
+
+### D4 — Docs-only / OpenSpec commits
+
+No Go in the commit → no Go test required. Do not invent a fmt step for markdown.
+
+## Risks / Trade-offs
+
+- **[Risk] `go test ./...` is slow enough that agents skip the rule** → Mitigation: keep
+  it unit-only; rule says do not commit on failure, not “skip if slow”.
+- **[Risk] Two sources of truth (rule + AGENTS.md) drift** → Mitigation: rule is the
+  Cursor-facing copy; AGENTS.md is one short paragraph that points at the same commands.
+
+## Migration Plan
+
+Add the files; no deploy. Rollback: delete the rule and the AGENTS.md paragraph.
+
+## Open Questions
+
+None — hook deferred; integration stays push-time.

--- a/openspec/changes/commit-gofmt-and-tests/proposal.md
+++ b/openspec/changes/commit-gofmt-and-tests/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Agents and humans commit Go that is not `gofmt`-clean or that has not been unit-tested,
+and CI then fails on checks CONTRIBUTING already lists. A commit-time rule in the
+agent guidance makes `gofmt` + unit tests a gate before the commit, not after the PR.
+
+## What Changes
+
+- Add an always-on Cursor rule: before creating a git commit that includes Go files,
+  run `gofmt` on the dirty Go paths (or `gofmt -l .` clean) and `go test ./...`; do not
+  commit if either fails.
+- Mirror that in `AGENTS.md` (and the duplicate `CLAUDE.md` if it stays in sync) as a
+  **Before committing** step, next to the existing push/vet guidance.
+- Point at the same suite CONTRIBUTING/CI already use (`gofmt -l .`, `go test ./...`).
+  Do **not** require `go test -tags=integration ./...` on every commit (Docker, minutes);
+  keep that as the existing push/behaviour-change guard.
+
+## Capabilities
+
+### New Capabilities
+
+(none — contributor/agent workflow only; `skip_specs: true`)
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- `.cursor/rules/commit-checks.mdc` (new, `alwaysApply: true`)
+- `AGENTS.md` / `CLAUDE.md` — commit checklist
+- No product code, no git hook, no CI YAML change (CI already enforces the same checks)

--- a/openspec/changes/commit-gofmt-and-tests/tasks.md
+++ b/openspec/changes/commit-gofmt-and-tests/tasks.md
@@ -1,0 +1,11 @@
+## 1. Cursor rule
+
+- [x] 1.1 Add `.cursor/rules/commit-checks.mdc` (`alwaysApply: true`): before a commit that includes `*.go`, run `gofmt -w` on those files (leave `gofmt -l .` empty), `go vet ./...`, and `go test ./...`; do not commit if tests fail; skip the Go suite when no Go files are staged; do not require integration-tagged tests at commit time
+
+## 2. Agent docs
+
+- [x] 2.1 Add a **Before committing** note to `AGENTS.md` (and `CLAUDE.md` if it remains a duplicate) with the same commands, pointing at existing push-time `go vet -tags=integration ./...`
+
+## 3. Guardrails
+
+- [x] 3.1 Confirm CONTRIBUTING.md / CI already match `gofmt -l .` and `go test ./...` — no CI YAML change unless they drifted


### PR DESCRIPTION
## Summary
- Add an always-on Cursor rule so agents run `gofmt`, `go vet ./...`, and `go test ./...` before a commit that includes Go files.
- Mirror the same gate in `AGENTS.md`; skip it when the commit has no Go.
- Keep integration-tagged tests as the existing push-time check — no git hook, no CI YAML change (CONTRIBUTING/CI already enforce the same suite).
- Track `.cursor/rules/` so the rule is in the tree; other `.cursor/` local state stays ignored.

## Test plan
- [ ] Confirm `.cursor/rules/commit-checks.mdc` has `alwaysApply: true` and lists gofmt / vet / unit tests
- [ ] Confirm `AGENTS.md` **Before committing** paragraph matches, and `CLAUDE.md` still follows it (symlink)
- [ ] Confirm CONTRIBUTING.md / CI still run `gofmt -l .` and `go test ./...` with no workflow diff in this PR
- [ ] `git check-ignore -v .cursor/rules/commit-checks.mdc` is not ignored; other `.cursor/*` paths still are