### PR TITLE
Align tailored CVs to JD skill wording and stop reset from wiping résumé sections

### DIFF
--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -120,6 +120,8 @@ After that opening, the playbook above applies as written.
 // anything they have not.
 const tailorPrompt = `You are the freehire CV-tailoring assistant. You are working with one signed-in candidate on ONE tailored copy of their CV, aimed at one vacancy. The tools you have act on that copy only, and they neither read nor write the candidate's contact block — their name, email, phone and personal links are stripped from what ` + "`cv_get`" + ` returns and cannot be patched.
 
+Skill wording on this CV is already aligned to the vacancy's own spellings (for example IaC ↔ infrastructure as code). Do NOT rename skills for wording — spend your edits on evidence and substance.
+
 Start by calling ` + "`cv_context`" + ` (the fit analysis for this vacancy) and ` + "`cv_get`" + ` (what the CV currently says).
 
 ` + "`cv_context`" + ` already carries the bank's answer: every requirement it reports comes with the ` + "`evidence`" + ` found for it — the achievement's id, its claim, and whether it may be written into a CV. Read that first. Do NOT re-search a requirement whose evidence is already in front of you; ` + "`experience_search`" + ` is for going deeper on one point, not for finding out whether the bank holds anything.

--- a/internal/assistant/prompt_test.go
+++ b/internal/assistant/prompt_test.go
@@ -18,6 +18,18 @@ func TestEachPresetHasItsOwnPrompt(t *testing.T) {
 	}
 }
 
+// Surfaces are aligned before the first model turn. Without this sentence the agent
+// rediscovers IaC ↔ infrastructure as code and burns the turn on wording.
+func TestTailorPromptSaysSurfacesAreAlreadyAligned(t *testing.T) {
+	p := SystemPrompt(PresetTailor)
+	if !strings.Contains(p, "already aligned") {
+		t.Error("tailor prompt never says skill surfaces are already aligned")
+	}
+	if !strings.Contains(p, "Do NOT rename skills for wording") {
+		t.Error("tailor prompt never tells the agent not to rename skills for wording")
+	}
+}
+
 // The panel's agent is the only one with eyes. A prompt that does not say so
 // produces an agent that asks the candidate to paste the vacancy it could have
 // read itself.

--- a/internal/cv/align.go
+++ b/internal/cv/align.go
@@ -1,0 +1,245 @@
+package cv
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// Align rewrites doc so skill wording matches preferred surfaces (canonical →
+// JD spelling from skilltag.PreferredFromText). Skills chips and experience
+// stacks accept any alias; summary and bullets only unambiguous aliases. Same-
+// canonical duplicate chips are collapsed. Pure and deterministic; no LLM.
+// The input is not mutated — a rewritten copy is returned. preferred may be nil.
+func Align(doc Document, preferred map[string]string) Document {
+	if len(preferred) == 0 {
+		return doc
+	}
+	out := doc
+	out.Skills = alignSkillGroups(doc.Skills, preferred)
+	out.Summary = replaceProse(doc.Summary, preferred)
+	if len(doc.Experience) > 0 {
+		out.Experience = make([]ExperienceItem, len(doc.Experience))
+		copy(out.Experience, doc.Experience)
+		for i := range out.Experience {
+			out.Experience[i].Stack = alignChipList(doc.Experience[i].Stack, preferred)
+			out.Experience[i].Summary = replaceProse(doc.Experience[i].Summary, preferred)
+			out.Experience[i].Bullets = alignProseList(doc.Experience[i].Bullets, preferred)
+		}
+	}
+	if len(doc.Projects) > 0 {
+		out.Projects = make([]Project, len(doc.Projects))
+		copy(out.Projects, doc.Projects)
+		for i := range out.Projects {
+			out.Projects[i].Bullets = alignProseList(doc.Projects[i].Bullets, preferred)
+		}
+	}
+	return out
+}
+
+// AlignChanged reports whether Align would change doc for the given preferred map.
+func AlignChanged(doc Document, preferred map[string]string) bool {
+	aligned := Align(doc, preferred)
+	return !documentsEqualForAlign(doc, aligned)
+}
+
+func alignSkillGroups(groups []SkillGroup, preferred map[string]string) []SkillGroup {
+	if len(groups) == 0 {
+		return groups
+	}
+	out := make([]SkillGroup, len(groups))
+	for i, g := range groups {
+		out[i] = SkillGroup{Group: g.Group, Items: collapseIdentical(alignChipList(g.Items, preferred))}
+	}
+	return out
+}
+
+func alignChipList(items []string, preferred map[string]string) []string {
+	if len(items) == 0 {
+		return items
+	}
+	out := make([]string, len(items))
+	copy(out, items)
+	for i, item := range items {
+		resolved := skilltag.Canonicalize([]string{item}, skilltag.WithResumeAcronyms())
+		if len(resolved) != 1 {
+			continue
+		}
+		want, ok := preferred[resolved[0]]
+		if !ok || want == "" {
+			continue
+		}
+		if strings.EqualFold(item, want) {
+			// Already the right wording; keep the JD casing.
+			out[i] = want
+			continue
+		}
+		out[i] = want
+	}
+	return out
+}
+
+func collapseIdentical(items []string) []string {
+	if len(items) < 2 {
+		return items
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		key := strings.ToLower(strings.TrimSpace(item))
+		if key == "" {
+			out = append(out, item)
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func alignProseList(items []string, preferred map[string]string) []string {
+	if len(items) == 0 {
+		return items
+	}
+	out := make([]string, len(items))
+	for i, s := range items {
+		out[i] = replaceProse(s, preferred)
+	}
+	return out
+}
+
+// replaceProse rewrites unambiguous aliases of preferred canonicals in text.
+func replaceProse(text string, preferred map[string]string) string {
+	if text == "" || len(preferred) == 0 {
+		return text
+	}
+	out := text
+	for canonical, want := range preferred {
+		if want == "" {
+			continue
+		}
+		for _, alias := range skilltag.AliasesOf(canonical) {
+			if !skilltag.IsProseSafeAlias(alias) {
+				continue
+			}
+			if strings.EqualFold(alias, want) {
+				// Still rewrite casing to the JD form when the alias matches want ignoring case.
+				out = replaceWholeFold(out, alias, want)
+				continue
+			}
+			out = replaceWholeFold(out, alias, want)
+		}
+	}
+	return out
+}
+
+// replaceWholeFold replaces whole-token occurrences of from (case-insensitive) with to.
+// ASCII alphanumeric boundaries plus a leading '.'/'-' guard (same idea as skilltag).
+func replaceWholeFold(text, from, to string) string {
+	if from == "" || text == "" {
+		return text
+	}
+	fromLower := strings.ToLower(from)
+	var b strings.Builder
+	b.Grow(len(text))
+	lower := strings.ToLower(text)
+	for i := 0; i < len(text); {
+		j := strings.Index(lower[i:], fromLower)
+		if j < 0 {
+			b.WriteString(text[i:])
+			break
+		}
+		j += i
+		end := j + len(fromLower)
+		// fromLower is ASCII for curated aliases; match length equals the source slice
+		// when the original run is the same byte length (true for ASCII casing).
+		if end > len(text) {
+			b.WriteString(text[i:])
+			break
+		}
+		// Align end to the actual UTF-8 slice of equal lowercase length in text[j:].
+		src := text[j:end]
+		if strings.ToLower(src) != fromLower {
+			// Multi-byte casing mismatch — advance one byte and continue.
+			b.WriteByte(text[i])
+			i++
+			continue
+		}
+		if !proseBoundary(text, j, end) {
+			b.WriteString(text[i : j+1])
+			i = j + 1
+			continue
+		}
+		b.WriteString(text[i:j])
+		b.WriteString(to)
+		i = end
+	}
+	return b.String()
+}
+
+// proseBoundary mirrors wordmatch.ASCIIBoundary but also treats non-ASCII letters
+// as word runes so Cyrillic neighbours do not get false hits.
+func proseBoundary(s string, start, end int) bool {
+	if start > 0 {
+		r, _ := utf8.DecodeLastRuneInString(s[:start])
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '.' || r == '-' {
+			return false
+		}
+	}
+	if end < len(s) {
+		r, _ := utf8.DecodeRuneInString(s[end:])
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func documentsEqualForAlign(a, b Document) bool {
+	if a.Summary != b.Summary {
+		return false
+	}
+	if len(a.Skills) != len(b.Skills) {
+		return false
+	}
+	for i := range a.Skills {
+		if a.Skills[i].Group != b.Skills[i].Group || !stringSlicesEqual(a.Skills[i].Items, b.Skills[i].Items) {
+			return false
+		}
+	}
+	if len(a.Experience) != len(b.Experience) {
+		return false
+	}
+	for i := range a.Experience {
+		ae, be := a.Experience[i], b.Experience[i]
+		if ae.Summary != be.Summary || !stringSlicesEqual(ae.Bullets, be.Bullets) || !stringSlicesEqual(ae.Stack, be.Stack) {
+			return false
+		}
+	}
+	if len(a.Projects) != len(b.Projects) {
+		return false
+	}
+	for i := range a.Projects {
+		if !stringSlicesEqual(a.Projects[i].Bullets, b.Projects[i].Bullets) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cv/align_test.go
+++ b/internal/cv/align_test.go
@@ -1,0 +1,171 @@
+package cv
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+func TestAlign_ChipExpands(t *testing.T) {
+	doc := Document{Skills: []SkillGroup{{Items: []string{"IaC", "Terraform"}}}}
+	preferred := skilltag.PreferredFromText("Experience with infrastructure as code and Terraform.")
+	got := Align(doc, preferred)
+	if got.Skills[0].Items[0] != preferred["infrastructure-as-code"] {
+		t.Fatalf("chip = %q, want %q", got.Skills[0].Items[0], preferred["infrastructure-as-code"])
+	}
+}
+
+func TestAlign_ChipShrinks(t *testing.T) {
+	doc := Document{Skills: []SkillGroup{{Items: []string{"Infrastructure as Code"}}}}
+	preferred := map[string]string{"infrastructure-as-code": "IaC"}
+	got := Align(doc, preferred)
+	if got.Skills[0].Items[0] != "IaC" {
+		t.Fatalf("chip = %q, want IaC", got.Skills[0].Items[0])
+	}
+}
+
+func TestAlign_GoChipToGolang(t *testing.T) {
+	doc := Document{Skills: []SkillGroup{{Items: []string{"Go", "Kubernetes"}}}}
+	preferred := map[string]string{"go": "Golang", "kubernetes": "Kubernetes"}
+	got := Align(doc, preferred)
+	if got.Skills[0].Items[0] != "Golang" {
+		t.Fatalf("chip = %q, want Golang", got.Skills[0].Items[0])
+	}
+}
+
+func TestAlign_NoInventedSkill(t *testing.T) {
+	doc := Document{Skills: []SkillGroup{{Items: []string{"Python"}}}}
+	preferred := map[string]string{"kubernetes": "Kubernetes"}
+	got := Align(doc, preferred)
+	if !reflect.DeepEqual(got.Skills[0].Items, []string{"Python"}) {
+		t.Fatalf("skills = %v, want unchanged Python only", got.Skills[0].Items)
+	}
+}
+
+func TestAlign_CollapseDuplicateChips(t *testing.T) {
+	doc := Document{Skills: []SkillGroup{{Items: []string{"IaC", "Infrastructure as Code", "Terraform"}}}}
+	preferred := map[string]string{"infrastructure-as-code": "infrastructure as code", "terraform": "Terraform"}
+	got := Align(doc, preferred)
+	want := []string{"infrastructure as code", "Terraform"}
+	if !reflect.DeepEqual(got.Skills[0].Items, want) {
+		t.Fatalf("skills = %v, want %v", got.Skills[0].Items, want)
+	}
+}
+
+func TestAlign_ProseUnambiguousReplaces(t *testing.T) {
+	doc := Document{
+		Summary: "Built IaC pipelines.",
+		Experience: []ExperienceItem{{
+			Bullets: []string{"Ran k8s clusters.", "Used infrastructure as code."},
+		}},
+	}
+	preferred := map[string]string{
+		"infrastructure-as-code": "Infrastructure as Code",
+		"kubernetes":             "Kubernetes",
+	}
+	got := Align(doc, preferred)
+	if got.Summary != "Built Infrastructure as Code pipelines." {
+		t.Errorf("summary = %q", got.Summary)
+	}
+	if got.Experience[0].Bullets[0] != "Ran Kubernetes clusters." {
+		t.Errorf("bullet0 = %q", got.Experience[0].Bullets[0])
+	}
+	if got.Experience[0].Bullets[1] != "Used Infrastructure as Code." {
+		t.Errorf("bullet1 = %q", got.Experience[0].Bullets[1])
+	}
+}
+
+func TestAlign_ProseAmbiguousWordsUntouched(t *testing.T) {
+	doc := Document{
+		Experience: []ExperienceItem{{
+			Bullets: []string{
+				"Must go home after standup.",
+				"We react to incidents quickly.",
+				"A reaction to going rusty.",
+			},
+		}},
+	}
+	preferred := map[string]string{
+		"go":    "Golang",
+		"react": "React",
+		"rust":  "Rust",
+	}
+	got := Align(doc, preferred)
+	for i, want := range doc.Experience[0].Bullets {
+		if got.Experience[0].Bullets[i] != want {
+			t.Errorf("bullet[%d] = %q, want %q (ambiguous prose must stay)", i, got.Experience[0].Bullets[i], want)
+		}
+	}
+}
+
+func TestAlign_ProseShortTokensUntouched(t *testing.T) {
+	// "js" aliases javascript (2 letters) — must not rewrite in prose.
+	doc := Document{Summary: "Wrote js helpers and C bindings."}
+	preferred := map[string]string{"javascript": "JavaScript", "c": "C++"}
+	got := Align(doc, preferred)
+	if got.Summary != doc.Summary {
+		t.Fatalf("summary = %q, want unchanged short-token prose", got.Summary)
+	}
+}
+
+func TestAlign_SubstringEmbedsUntouched(t *testing.T) {
+	doc := Document{Summary: "A reaction to going rusty on the objective-c path."}
+	preferred := map[string]string{
+		"react": "React",
+		"go":    "Golang",
+		"rust":  "Rust",
+		"c":     "C",
+	}
+	got := Align(doc, preferred)
+	if got.Summary != doc.Summary {
+		t.Fatalf("summary = %q, want unchanged embeds", got.Summary)
+	}
+}
+
+func TestAlign_StackRewritten(t *testing.T) {
+	doc := Document{Experience: []ExperienceItem{{Stack: []string{"IaC", "Go"}}}}
+	preferred := map[string]string{"infrastructure-as-code": "infrastructure as code", "go": "Golang"}
+	got := Align(doc, preferred)
+	want := []string{"infrastructure as code", "Golang"}
+	if !reflect.DeepEqual(got.Experience[0].Stack, want) {
+		t.Fatalf("stack = %v, want %v", got.Experience[0].Stack, want)
+	}
+}
+
+func TestAlign_Idempotent(t *testing.T) {
+	doc := Document{
+		Skills:  []SkillGroup{{Items: []string{"IaC", "k8s"}}},
+		Summary: "Shipped IaC on k8s.",
+	}
+	preferred := map[string]string{
+		"infrastructure-as-code": "infrastructure as code",
+		"kubernetes":             "Kubernetes",
+	}
+	once := Align(doc, preferred)
+	twice := Align(once, preferred)
+	if !reflect.DeepEqual(once, twice) {
+		t.Fatalf("second align changed document:\n once=%+v\ntwice=%+v", once, twice)
+	}
+	if AlignChanged(once, preferred) {
+		t.Fatal("AlignChanged true after alignment — want idempotent false")
+	}
+}
+
+func TestAlign_FamilyFixtureUnchanged(t *testing.T) {
+	// Phase 1 must not treat pgvector and vector-databases as the same skill.
+	doc := Document{Skills: []SkillGroup{{Items: []string{"pgvector"}}}}
+	preferred := map[string]string{"vector-databases": "vector databases"}
+	got := Align(doc, preferred)
+	if got.Skills[0].Items[0] != "pgvector" {
+		t.Fatalf("got %q, want pgvector left alone (no family link in Phase 1)", got.Skills[0].Items[0])
+	}
+}
+
+func TestAlign_NilPreferred(t *testing.T) {
+	doc := Document{Skills: []SkillGroup{{Items: []string{"IaC"}}}}
+	got := Align(doc, nil)
+	if !reflect.DeepEqual(got, doc) {
+		t.Fatalf("got %+v, want unchanged", got)
+	}
+}

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -285,11 +285,13 @@ func (s *Store) CreateTailored(ctx context.Context, userID, jobID int64, title, 
 }
 
 // Tailor ensures the user has a base CV — seeding one from their extracted résumé when they
-// have none — then creates a vacancy-bound tailored copy of it. It returns the base and tailored
+// have none — then creates a vacancy-bound tailored copy of it. preferred is the vacancy's
+// skilltag.PreferredFromText map; when non-empty the copy is surface-aligned before insert
+// so the stored document never held the unaligned wording. It returns the base and tailored
 // metadata plus whether THIS call is the one that just created the tailored copy (false when an
 // existing one was reused instead). It returns ErrNoResume when there is nothing to seed a base
 // from. The base CV is never modified: tailoring only ever writes the new tailored row.
-func (s *Store) Tailor(ctx context.Context, userID, jobID int64, tailoredTitle string, seeder Seeder) (Meta, Meta, bool, error) {
+func (s *Store) Tailor(ctx context.Context, userID, jobID int64, tailoredTitle string, seeder Seeder, preferred map[string]string) (Meta, Meta, bool, error) {
 	base, ok, err := s.BaseCV(ctx, userID)
 	if err != nil {
 		return Meta{}, Meta{}, false, err
@@ -318,7 +320,11 @@ func (s *Store) Tailor(ctx context.Context, userID, jobID int64, tailoredTitle s
 		return Meta{}, Meta{}, false, err
 	}
 
-	tailored, err := s.CreateTailored(ctx, userID, jobID, tailoredTitle, base.TemplateID, base.Document)
+	doc := base.Document
+	if len(preferred) > 0 {
+		doc = Align(doc, preferred)
+	}
+	tailored, err := s.CreateTailored(ctx, userID, jobID, tailoredTitle, base.TemplateID, doc)
 	if err != nil {
 		return Meta{}, Meta{}, false, err
 	}

--- a/internal/cv/store_tailor_test.go
+++ b/internal/cv/store_tailor_test.go
@@ -34,7 +34,7 @@ func TestStoreTailorSeedsBaseFromResumeWhenAbsent(t *testing.T) {
 		Skills:   []string{"Go", "PostgreSQL"},
 	}}
 
-	base, tailored, created, err := s.Tailor(ctx, 7, 100, "Tailored: X", seeder)
+	base, tailored, created, err := s.Tailor(ctx, 7, 100, "Tailored: X", seeder, nil)
 	if err != nil {
 		t.Fatalf("tailor: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestStoreTailorRefusesWithoutResume(t *testing.T) {
 	repo := newFakeRepo()
 	s := NewStore(repo)
 	ctx := context.Background()
-	if _, _, _, err := s.Tailor(ctx, 7, 100, "T", fakeSeeder{ok: false}); !errors.Is(err, ErrNoResume) {
+	if _, _, _, err := s.Tailor(ctx, 7, 100, "T", fakeSeeder{ok: false}, nil); !errors.Is(err, ErrNoResume) {
 		t.Errorf("err = %v, want ErrNoResume", err)
 	}
 	if len(repo.rows) != 0 {
@@ -91,7 +91,7 @@ func TestStoreTailorUsesExistingBaseUntouched(t *testing.T) {
 	})
 	before, _ := s.Get(ctx, base.ID, 7)
 
-	rbase, tailored, _, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	rbase, tailored, _, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false}, nil)
 	if err != nil {
 		t.Fatalf("tailor: %v", err)
 	}
@@ -124,11 +124,11 @@ func TestStoreTailorReturnsTheExistingCopyForTheSameVacancy(t *testing.T) {
 		t.Fatalf("seed base: %v", err)
 	}
 
-	_, first, _, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	_, first, _, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false}, nil)
 	if err != nil {
 		t.Fatalf("first tailor: %v", err)
 	}
-	_, second, _, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	_, second, _, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false}, nil)
 	if err != nil {
 		t.Fatalf("second tailor: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestStoreTailorReturnsTheExistingCopyForTheSameVacancy(t *testing.T) {
 	}
 
 	// A DIFFERENT vacancy still gets its own copy.
-	_, other, _, err := s.Tailor(ctx, 7, 200, "Tailored", fakeSeeder{ok: false})
+	_, other, _, err := s.Tailor(ctx, 7, 200, "Tailored", fakeSeeder{ok: false}, nil)
 	if err != nil {
 		t.Fatalf("other tailor: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestStoreTailorReportsWhetherItCreated(t *testing.T) {
 		t.Fatalf("seed base: %v", err)
 	}
 
-	_, _, created, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	_, _, created, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false}, nil)
 	if err != nil {
 		t.Fatalf("first tailor: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestStoreTailorReportsWhetherItCreated(t *testing.T) {
 		t.Error("first bootstrap: created = false, want true — it just inserted the row")
 	}
 
-	_, _, created, err = s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	_, _, created, err = s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false}, nil)
 	if err != nil {
 		t.Fatalf("second tailor: %v", err)
 	}

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -760,7 +760,8 @@ func turnBounds(sess assistant.Session, lastUser string) assistant.TurnConfig {
 // lives in the tailoring system prompt, where it is stated once. This only says which of the
 // two rhythms the candidate chose, because a turn does not start until a message arrives.
 const autopilotBrief = "Tailor this CV for the vacancy yourself, working from my experience bank. " +
-	"Go through every requirement without stopping to ask me, then tell me what is left."
+	"Go through every requirement without stopping to ask me, then tell me what is left. " +
+	"Skill wording on this CV is already aligned to the vacancy's own spellings — do not rename skills for wording; spend your edits on evidence and substance."
 
 // PostAssistantAutopilot runs the unattended tailoring pass on a tailoring session: it
 // snapshots the CV so the whole run can be undone, then streams one long turn.
@@ -783,6 +784,7 @@ func (h *assistantHandlers) PostAssistantAutopilot(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusConflict, "this conversation is not tailoring a CV")
 	}
 	refreshAnalysis := h.prepareAutopilotAnalysis(c, sess)
+	h.alignAutopilotCV(c.Context(), sess)
 	h.layDownRunPlan(c.Context(), sess)
 	return h.streamSSE(c, sess, func(ctx context.Context, runner *assistant.Runner, reg *assistant.Registry, system string, emit func(assistant.Event)) error {
 		err := runner.Run(ctx, sess, reg, system, autopilotBrief, assistant.TurnConfig{MaxSteps: autopilotMaxSteps}, emit)
@@ -792,6 +794,21 @@ func (h *assistantHandlers) PostAssistantAutopilot(c *fiber.Ctx) error {
 		refreshAnalysis(context.WithoutCancel(ctx))
 		return err
 	})
+}
+
+// alignAutopilotCV surface-aligns the bound tailored CV to the vacancy before the
+// unattended turn starts. Its own system revision — not the run's edit batch — so
+// undoing the run leaves JD wording in place.
+func (h *assistantHandlers) alignAutopilotCV(ctx context.Context, sess assistant.Session) {
+	if h.cv == nil || sess.CVID == nil || sess.JobID == nil {
+		return
+	}
+	job, err := h.queries.GetJob(ctx, *sess.JobID)
+	if err != nil {
+		log.Printf("assistant: loading job %d for surface-align: %v", *sess.JobID, err)
+		return
+	}
+	h.cv.logSurfaceAlign(ctx, sess.UserID, *sess.CVID, job.Description)
 }
 
 // prepareAutopilotAnalysis resolves the run's vacancy and delegates to

--- a/internal/handler/assistant_autopilot_integration_test.go
+++ b/internal/handler/assistant_autopilot_integration_test.go
@@ -589,6 +589,163 @@ func TestARunThatNeverReportsStillLeavesOne(t *testing.T) {
 	}
 }
 
+// seedTailoringSessionWithSurfaces creates a vacancy whose description prefers the long
+// form of infrastructure-as-code, and a tailored CV whose skills chip still says IaC.
+func seedTailoringSessionWithSurfaces(t *testing.T, pool *pgxpool.Pool, h *assistantHandlers, userID int64) (string, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	var jobID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, public_slug, description)
+		 VALUES ('greenhouse', $1, 'https://example.test/j/'||$1, 'Platform Engineer', $1,
+		         'We practice infrastructure as code and Terraform.')
+		 RETURNING id`, "autopilot-align-"+uuid.NewString()[:8]).Scan(&jobID); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	doc := `{"summary":"before the run","skills":[{"items":["IaC","Terraform"]}],` +
+		`"experience":[{"company":"Acme","role":"Engineer","bullets":["Shipped platform tools"]}]}`
+	var cvID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO cvs (user_id, title, template_id, data, job_id)
+		 VALUES ($1, 'Tailored', 'classic-ats', $2::jsonb, $3)
+		 RETURNING id`, userID, doc, jobID).Scan(&cvID); err != nil {
+		t.Fatalf("seed cv: %v", err)
+	}
+	sess, err := h.store.CreateSession(ctx, userID, assistant.PresetTailor, &cvID, &jobID)
+	if err != nil {
+		t.Fatalf("create tailoring session: %v", err)
+	}
+	return sess.ID.String(), cvID
+}
+
+func TestAutopilotAlignsSkillSurfacesBeforeTurn(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	model := &turnModel{replies: []*llms.ContentChoice{{Content: "Walked the requirements."}}}
+	app, h := newAssistantApp(pool, iss, model)
+	userID, cookie := assistantUser(t, pool, iss, "autopilot-align@example.test", true)
+
+	sessionID, cvID := seedTailoringSessionWithSurfaces(t, pool, h, userID)
+	seedFitAnalysis(t, pool, userID, cvID)
+
+	resp := assistantRequest(t, app, fiber.MethodPost,
+		"/api/v1/assistant/sessions/"+sessionID+"/autopilot", cookie, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("autopilot: status %d", resp.StatusCode)
+	}
+	io.ReadAll(resp.Body)
+
+	rec, err := h.cv.cvStore.Get(context.Background(), cvID, userID)
+	if err != nil {
+		t.Fatalf("get cv: %v", err)
+	}
+	if len(rec.Document.Skills) == 0 || rec.Document.Skills[0].Items[0] != "infrastructure as code" {
+		t.Fatalf("skills = %+v, want infrastructure as code before the turn", rec.Document.Skills)
+	}
+
+	var feed struct {
+		Data []cvedit.RevisionView `json:"data"`
+	}
+	decodeJSON(t, assistantRequest(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+cvID.String()+"/revisions", cookie, nil), &feed)
+	var alignRevs int
+	for _, rev := range feed.Data {
+		if rev.Actor == string(cvedit.ActorSystem) && rev.Origin == string(cvedit.OriginImport) && rev.BatchID == "" {
+			alignRevs++
+		}
+	}
+	if alignRevs != 1 {
+		t.Fatalf("system align revisions = %d, want 1; feed=%+v", alignRevs, feed.Data)
+	}
+
+	// Already aligned: a second start is a no-op on the document and adds no revision.
+	resp2 := assistantRequest(t, app, fiber.MethodPost,
+		"/api/v1/assistant/sessions/"+sessionID+"/autopilot", cookie, nil)
+	if resp2.StatusCode != fiber.StatusOK {
+		t.Fatalf("second autopilot: status %d", resp2.StatusCode)
+	}
+	io.ReadAll(resp2.Body)
+	decodeJSON(t, assistantRequest(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+cvID.String()+"/revisions", cookie, nil), &feed)
+	alignRevs = 0
+	for _, rev := range feed.Data {
+		if rev.Actor == string(cvedit.ActorSystem) && rev.Origin == string(cvedit.OriginImport) && rev.BatchID == "" {
+			alignRevs++
+		}
+	}
+	if alignRevs != 1 {
+		t.Fatalf("after second start system align revisions = %d, want still 1", alignRevs)
+	}
+}
+
+func TestAutopilotUndoLeavesSurfaceAlign(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	ctx := context.Background()
+
+	model := &scriptedTurnModel{}
+	app, h := newAssistantApp(pool, iss, model)
+	userID, cookie := assistantUser(t, pool, iss, "autopilot-undo-align@example.test", true)
+	sessionID, cvID := seedTailoringSessionWithSurfaces(t, pool, h, userID)
+	seedFitAnalysis(t, pool, userID, cvID)
+
+	model.replies = []*llms.ContentChoice{
+		callReplyChoice("cv_edit", `{"ops":[{"kind":"remove","path":"experience[0].bullets[0]"}]}`),
+		{Content: "Removed a bullet."},
+	}
+
+	resp := assistantRequest(t, app, fiber.MethodPost,
+		"/api/v1/assistant/sessions/"+sessionID+"/autopilot", cookie, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("autopilot: status %d", resp.StatusCode)
+	}
+	io.ReadAll(resp.Body)
+
+	rec, err := h.cv.cvStore.Get(ctx, cvID, userID)
+	if err != nil {
+		t.Fatalf("get cv: %v", err)
+	}
+	if len(rec.Document.Skills) == 0 || rec.Document.Skills[0].Items[0] != "infrastructure as code" {
+		t.Fatalf("skills after run = %+v, want aligned form", rec.Document.Skills)
+	}
+	if len(rec.Document.Experience) == 0 || len(rec.Document.Experience[0].Bullets) != 0 {
+		t.Fatalf("experience = %+v, want the run's remove to have cleared the bullet", rec.Document.Experience)
+	}
+
+	var feed struct {
+		Data []cvedit.RevisionView `json:"data"`
+	}
+	decodeJSON(t, assistantRequest(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+cvID.String()+"/revisions", cookie, nil), &feed)
+	var batchID string
+	for _, rev := range feed.Data {
+		if rev.Origin == string(cvedit.OriginTailorAgent) && rev.BatchID != "" {
+			batchID = rev.BatchID
+			break
+		}
+	}
+	if batchID == "" {
+		t.Fatalf("no agent batch in feed: %+v", feed.Data)
+	}
+
+	undo := assistantRequest(t, app, fiber.MethodPost,
+		"/api/v1/me/cvs/"+cvID.String()+"/revisions/batch/"+batchID+"/undo", cookie, nil)
+	if undo.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(undo.Body)
+		t.Fatalf("undo batch = %d: %s", undo.StatusCode, body)
+	}
+	undo.Body.Close()
+
+	rec, err = h.cv.cvStore.Get(ctx, cvID, userID)
+	if err != nil {
+		t.Fatalf("get cv after undo: %v", err)
+	}
+	if len(rec.Document.Skills) == 0 || rec.Document.Skills[0].Items[0] != "infrastructure as code" {
+		t.Fatalf("skills after undo = %+v, want JD wording left by the align revision", rec.Document.Skills)
+	}
+	if len(rec.Document.Experience) == 0 || len(rec.Document.Experience[0].Bullets) != 1 {
+		t.Fatalf("experience after undo = %+v, want the run's remove reverted", rec.Document.Experience)
+	}
+}
+
 // seedFitAnalysis caches a fit analysis for (user, job) so the run has a requirement list to
 // lay down. The vacancy is the one seedTailoringSession created for this CV.
 func seedFitAnalysis(t *testing.T, pool *pgxpool.Pool, userID int64, cvID uuid.UUID) {

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -147,6 +147,8 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 	// the edit + context/get/render reads with its minted API key (keyAuth = cookie or Bearer).
 	api.Post("/me/cvs/tailor", mw.cookie, h.TailorCV)
 	api.Post("/me/cvs/:id/tailor-session", mw.cookie, h.StartTailorSession)
+	// Literal `/base/` before `:id` — otherwise Fiber treats "base" as a CV uuid.
+	api.Post("/me/cvs/base/reset-from-resume", mw.cookie, h.ResetBaseCVFromResume)
 	// Rebuild this tailored CV (and the base) from the current résumé seed. Cookie-only:
 	// destructive whole-document replace; the browser is where the candidate confirms it.
 	api.Post("/me/cvs/:id/reset-from-resume", mw.cookie, h.ResetCVFromResume)

--- a/internal/handler/cv_reset.go
+++ b/internal/handler/cv_reset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/cvedit"
 	"github.com/strelov1/freehire/internal/resumeextract"
+	"github.com/strelov1/freehire/internal/skilltag"
 )
 
 // ResetCVFromResume rebuilds a tailored CV's content from the current résumé seed
@@ -48,6 +49,16 @@ func (h *cvHandlers) ResetCVFromResume(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusConflict, "add a résumé before resetting from it")
 	}
 	seeded := cv.Seed(st)
+	// Align only the tailored copy to the vacancy. The base stays on the résumé's own
+	// spellings — JD surfaces are per-vacancy, not a rewrite of the candidate's seed.
+	tailoredSeed := seeded
+	if rec.JobID != 0 {
+		if job, jerr := h.queries.GetJob(c.Context(), rec.JobID); jerr == nil {
+			tailoredSeed = cv.Align(seeded, skilltag.PreferredFromText(job.Description))
+		} else {
+			log.Printf("cv: loading job %d for reset surface-align: %v", rec.JobID, jerr)
+		}
+	}
 
 	// The requested target commits first: if the tailored copy is what the seed cannot
 	// satisfy (e.g. a role over the bullet cap refuses the whole-document write), nothing
@@ -61,7 +72,7 @@ func (h *cvHandlers) ResetCVFromResume(c *fiber.Ctx) error {
 			Title:      rec.Title,
 			TemplateID: rec.TemplateID,
 			Document:   rec.Document,
-		}, seeded))
+		}, tailoredSeed))
 	if err != nil {
 		return mapCVError(err)
 	}
@@ -75,6 +86,34 @@ func (h *cvHandlers) ResetCVFromResume(c *fiber.Ctx) error {
 		return mapCVError(err)
 	}
 	return c.JSON(fiber.Map{"data": recordResponse(out)})
+}
+
+// ResetBaseCVFromResume rebuilds the owner's base CV from the current résumé seed
+// (experience bank + structured extract). Cookie-only. Does not touch tailored copies —
+// those stay on History → Reset (or the tailor-workspace refresh prompt).
+func (h *cvHandlers) ResetBaseCVFromResume(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	st, ok, err := h.seedSource().Structured(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+	if !ok || !hasSeedBody(st) {
+		return fiber.NewError(fiber.StatusConflict, "add a résumé before resetting from it")
+	}
+	if err := h.reseedBaseFromSeed(c, userID, cv.Seed(st)); err != nil {
+		return err
+	}
+	base, ok, err := h.cvStore.BaseCV(c.Context(), userID)
+	if err != nil {
+		return mapCVError(err)
+	}
+	if !ok {
+		return fiber.NewError(fiber.StatusInternalServerError, "base CV was not created")
+	}
+	return c.JSON(fiber.Map{"data": recordResponse(base)})
 }
 
 // reseedBaseFromSeed refreshes the current base CV from seeded content, or creates one when

--- a/internal/handler/cv_reset_integration_test.go
+++ b/internal/handler/cv_reset_integration_test.go
@@ -25,6 +25,7 @@ func buildResetApp(h *cvHandlers, iss *auth.Issuer) *fiber.App {
 	saved := auth.RequireAuth(iss, testVersions)
 	keyAuth := auth.RequireAuthOrScopedKey(iss, testVersions, apiKeys{h.queries}, auth.ScopeCV)
 	app.Get("/api/v1/me/cvs/:id", keyAuth, h.GetCV)
+	app.Post("/api/v1/me/cvs/base/reset-from-resume", saved, h.ResetBaseCVFromResume)
 	app.Post("/api/v1/me/cvs/:id/reset-from-resume", saved, h.ResetCVFromResume)
 	return app
 }
@@ -314,8 +315,18 @@ func TestResetCVFromResume_ProvisionalContactsPlusBankSucceeds(t *testing.T) {
 	seedBankedCareer(t, h.queries, userID)
 
 	jobID := seedJobSlug(t, pool, "prov-reset-"+uuid.NewString()[:8])
+	base, err := h.cvStore.Create(ctx, userID, "My CV", cv.DefaultTemplateID, cv.Document{
+		Header:  cv.Header{FullName: "Base Name"},
+		Summary: "base keep me",
+		Skills:  []cv.SkillGroup{{Items: []string{"BaseSkill"}}},
+	})
+	if err != nil {
+		t.Fatalf("create base: %v", err)
+	}
 	tailored, err := h.cvStore.CreateTailored(ctx, userID, jobID, "T", cv.DefaultTemplateID, cv.Document{
-		Header: cv.Header{}, Summary: "old",
+		Header:  cv.Header{},
+		Summary: "tailored keep me",
+		Skills:  []cv.SkillGroup{{Items: []string{"TailorSkill"}}},
 	})
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -328,6 +339,15 @@ func TestResetCVFromResume_ProvisionalContactsPlusBankSucceeds(t *testing.T) {
 	}
 	resp.Body.Close()
 
+	// Seed composition must still strip superseded summary — only identity from the blob.
+	st, ok, err := h.seedSource().Structured(ctx, userID)
+	if err != nil || !ok {
+		t.Fatalf("seed Structured: ok=%v err=%v", ok, err)
+	}
+	if st.Summary != "" || len(st.Skills) != 0 {
+		t.Fatalf("seed leaked superseded semantics: summary=%q skills=%v", st.Summary, st.Skills)
+	}
+
 	got, err := h.cvStore.Get(ctx, tailored.ID, userID)
 	if err != nil {
 		t.Fatalf("get: %v", err)
@@ -335,11 +355,28 @@ func TestResetCVFromResume_ProvisionalContactsPlusBankSucceeds(t *testing.T) {
 	if got.Document.Header.FullName != "Ada Lovelace" || got.Document.Header.Email != "ada@example.com" {
 		t.Fatalf("header = %+v, want provisional contacts", got.Document.Header)
 	}
-	if got.Document.Summary != "" {
-		t.Fatalf("summary = %q, want empty (provisional seed has no semantics)", got.Document.Summary)
+	if got.Document.Summary != "tailored keep me" {
+		t.Fatalf("summary = %q, want prior tailored summary kept", got.Document.Summary)
+	}
+	if len(got.Document.Skills) == 0 || got.Document.Skills[0].Items[0] != "TailorSkill" {
+		t.Fatalf("skills = %+v, want prior tailored skills kept", got.Document.Skills)
 	}
 	if len(got.Document.Experience) == 0 {
 		t.Fatal("want banked experience on reset")
+	}
+
+	gotBase, ok, err := h.cvStore.BaseCV(ctx, userID)
+	if err != nil || !ok {
+		t.Fatalf("BaseCV: ok=%v err=%v", ok, err)
+	}
+	if gotBase.ID != base.ID {
+		t.Fatalf("base id = %s, want %s", gotBase.ID, base.ID)
+	}
+	if gotBase.Document.Summary != "base keep me" {
+		t.Fatalf("base summary = %q, want prior base summary kept", gotBase.Document.Summary)
+	}
+	if len(gotBase.Document.Skills) == 0 || gotBase.Document.Skills[0].Items[0] != "BaseSkill" {
+		t.Fatalf("base skills = %+v, want prior base skills kept", gotBase.Document.Skills)
 	}
 }
 
@@ -455,5 +492,275 @@ func TestResetCVFromResume_RefusesWhenTheBankSeedExceedsTheBulletCap(t *testing.
 	}
 	if gotBase.ID != base.ID || gotBase.Document.Summary != "old base summary" {
 		t.Fatalf("base = %+v, want untouched — the target failed before the base refresh ran", gotBase.Document)
+	}
+}
+
+// TestResetCVFromResume_AlignsSkillSurfaces: resetting a tailored copy whose seed says IaC
+// stores the vacancy's preferred form on the tailored document, while the base keeps IaC.
+func TestResetCVFromResume_AlignsSkillSurfaces(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	userID := seedAccount(t, pool, "reset-align@example.com", false)
+	tok, err := iss.Issue(userID, 1)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	ctx := context.Background()
+	blob, _ := json.Marshal(resumeextract.Structured{
+		FullName: "Ada Lovelace",
+		Email:    "ada@example.com",
+		Summary:  "Platform engineer",
+		Skills:   []string{"IaC", "Terraform"},
+	})
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = now(),
+		 resume_structured = $2, resume_structured_uploaded_at = now(),
+		 resume_structured_model = 'test' WHERE id = $1`,
+		userID, blob); err != nil {
+		t.Fatalf("seed structured: %v", err)
+	}
+
+	store := h.cvStore
+	if _, err := store.Create(ctx, userID, "My CV", cv.DefaultTemplateID, cv.Document{
+		Header: cv.Header{FullName: "Old Base"},
+		Skills: []cv.SkillGroup{{Items: []string{"Go"}}},
+	}); err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	jobID := seedJobSlugDesc(t, pool, "reset-align-"+uuid.NewString()[:8],
+		"We practice infrastructure as code.")
+	tailored, err := store.CreateTailored(ctx, userID, jobID, "Tailored", cv.DefaultTemplateID, cv.Document{
+		Header: cv.Header{FullName: "Old Tailored"},
+		Skills: []cv.SkillGroup{{Items: []string{"Go"}}},
+	})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/"+tailored.ID.String()+"/reset-from-resume", tok, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var out struct {
+		Data cvResponse `json:"data"`
+	}
+	decodeJSON(t, resp, &out)
+	if out.Data.Document.Summary != "Platform engineer" {
+		t.Fatalf("tailored summary = %q, want current extract summary", out.Data.Document.Summary)
+	}
+	if len(out.Data.Document.Skills) == 0 || out.Data.Document.Skills[0].Items[0] != "infrastructure as code" {
+		t.Fatalf("tailored skills = %+v, want infrastructure as code", out.Data.Document.Skills)
+	}
+
+	base, ok, err := store.BaseCV(ctx, userID)
+	if err != nil || !ok {
+		t.Fatalf("BaseCV: ok=%v err=%v", ok, err)
+	}
+	if base.Document.Summary != "Platform engineer" {
+		t.Fatalf("base summary = %q, want current extract summary", base.Document.Summary)
+	}
+	if len(base.Document.Skills) == 0 || base.Document.Skills[0].Items[0] != "IaC" {
+		t.Fatalf("base skills = %+v, want IaC (résumé form, not JD)", base.Document.Skills)
+	}
+}
+
+// TestResetCVFromResume_CurrentExtractAppliesSkillsAndSummary: a current stamp with
+// summary and skills must land them on reset (seed wins over whatever was on the page).
+func TestResetCVFromResume_CurrentExtractAppliesSkillsAndSummary(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	userID := seedAccount(t, pool, "reset-current@example.com", false)
+	tok, _ := iss.Issue(userID, 1)
+	ctx := context.Background()
+	blob, _ := json.Marshal(resumeextract.Structured{
+		FullName: "Ada Lovelace",
+		Email:    "ada@example.com",
+		Summary:  "Staff platform engineer",
+		Skills:   []string{"Go", "Kafka"},
+	})
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = now(),
+		 resume_structured = $2, resume_structured_uploaded_at = now(),
+		 resume_structured_model = 'test' WHERE id = $1`,
+		userID, blob); err != nil {
+		t.Fatalf("seed structured: %v", err)
+	}
+
+	store := h.cvStore
+	if _, err := store.Create(ctx, userID, "My CV", cv.DefaultTemplateID, cv.Document{
+		Header:  cv.Header{FullName: "Old Base"},
+		Summary: "old base summary",
+		Skills:  []cv.SkillGroup{{Items: []string{"OldBase"}}},
+	}); err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	jobID := seedJobSlug(t, pool, "reset-current-"+uuid.NewString()[:8])
+	tailored, err := store.CreateTailored(ctx, userID, jobID, "Tailored", cv.DefaultTemplateID, cv.Document{
+		Header:  cv.Header{FullName: "Old Tailored"},
+		Summary: "old tailored summary",
+		Skills:  []cv.SkillGroup{{Items: []string{"OldTailor"}}},
+	})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/"+tailored.ID.String()+"/reset-from-resume", tok, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var out struct {
+		Data cvResponse `json:"data"`
+	}
+	decodeJSON(t, resp, &out)
+	if out.Data.Document.Summary != "Staff platform engineer" {
+		t.Fatalf("tailored summary = %q, want extract", out.Data.Document.Summary)
+	}
+	if len(out.Data.Document.Skills) == 0 || len(out.Data.Document.Skills[0].Items) != 2 ||
+		out.Data.Document.Skills[0].Items[0] != "Go" || out.Data.Document.Skills[0].Items[1] != "Kafka" {
+		t.Fatalf("tailored skills = %+v, want Go/Kafka from extract", out.Data.Document.Skills)
+	}
+
+	base, ok, err := store.BaseCV(ctx, userID)
+	if err != nil || !ok {
+		t.Fatalf("BaseCV: ok=%v err=%v", ok, err)
+	}
+	if base.Document.Summary != "Staff platform engineer" {
+		t.Fatalf("base summary = %q, want extract", base.Document.Summary)
+	}
+	if len(base.Document.Skills) == 0 || base.Document.Skills[0].Items[0] != "Go" {
+		t.Fatalf("base skills = %+v, want extract", base.Document.Skills)
+	}
+}
+
+func TestResetBaseCVFromResume_HappyPath(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	userID := seedAccount(t, pool, "base-reset@example.com", false)
+	tok, _ := iss.Issue(userID, 1)
+	ctx := context.Background()
+	blob, _ := json.Marshal(resumeextract.Structured{
+		FullName: "Ada Lovelace", Email: "ada@example.com", Summary: "from seed",
+	})
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = now(),
+		 resume_structured = $2, resume_structured_uploaded_at = now(),
+		 resume_structured_model = 'test' WHERE id = $1`,
+		userID, blob); err != nil {
+		t.Fatalf("seed structured: %v", err)
+	}
+	seedBankedCareer(t, h.queries, userID)
+
+	store := h.cvStore
+	base, err := store.Create(ctx, userID, "My CV", cv.DefaultTemplateID, cv.Document{
+		Margins: cv.Margins{Top: 0.75, Right: 0.75, Bottom: 0.75, Left: 0.75},
+		Style:   cv.Style{FontSize: 11},
+		Header:  cv.Header{FullName: "Old Base"},
+		Summary: "old base summary",
+		Experience: []cv.ExperienceItem{{
+			Role: "Stale", Company: "OldCo",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	jobID := seedJobSlug(t, pool, "base-reset-"+uuid.NewString()[:8])
+	tailored, err := store.CreateTailored(ctx, userID, jobID, "Tailored", cv.DefaultTemplateID, cv.Document{
+		Header:  cv.Header{FullName: "Old Tailored"},
+		Summary: "old tailored summary",
+	})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/base/reset-from-resume", tok, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var out struct {
+		Data cvResponse `json:"data"`
+	}
+	decodeJSON(t, resp, &out)
+	if out.Data.ID != base.ID.String() {
+		t.Fatalf("id = %s, want base %s", out.Data.ID, base.ID)
+	}
+	if out.Data.Document.Header.FullName != "Ada Lovelace" || out.Data.Document.Summary != "from seed" {
+		t.Fatalf("base content = %+v / %q, want seed", out.Data.Document.Header, out.Data.Document.Summary)
+	}
+	if out.Data.Document.Margins.Top != 0.75 || out.Data.Document.Style.FontSize != 11 {
+		t.Fatalf("presentation clobbered: margins=%+v style=%+v", out.Data.Document.Margins, out.Data.Document.Style)
+	}
+	if len(out.Data.Document.Experience) == 0 || out.Data.Document.Experience[0].Company != "Acme" {
+		t.Fatalf("experience = %+v, want banked Acme", out.Data.Document.Experience)
+	}
+
+	gotTailored, err := store.Get(ctx, tailored.ID, userID)
+	if err != nil {
+		t.Fatalf("get tailored: %v", err)
+	}
+	if gotTailored.Document.Summary != "old tailored summary" {
+		t.Fatalf("tailored summary = %q, want untouched", gotTailored.Document.Summary)
+	}
+}
+
+func TestResetBaseCVFromResume_NoSeed409(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	userID := seedAccount(t, pool, "base-noseed@example.com", false)
+	tok, _ := iss.Issue(userID, 1)
+	ctx := context.Background()
+	if _, err := h.cvStore.Create(ctx, userID, "My CV", cv.DefaultTemplateID, cv.Document{
+		Summary: "keep me",
+	}); err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/base/reset-from-resume", tok, nil)
+	if resp.StatusCode != fiber.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body = %s, want 409", resp.StatusCode, body)
+	}
+	base, ok, err := h.cvStore.BaseCV(ctx, userID)
+	if err != nil || !ok {
+		t.Fatalf("BaseCV: ok=%v err=%v", ok, err)
+	}
+	if base.Document.Summary != "keep me" {
+		t.Fatalf("summary = %q, want untouched on 409", base.Document.Summary)
+	}
+}
+
+func TestResetBaseCVFromResume_Unauth401(t *testing.T) {
+	h, iss, _ := newTailorAPI(t)
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/base/reset-from-resume", "", nil)
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestResetBaseCVFromResume_OtherUserLeavesOwnersBase(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	owner := seedAccount(t, pool, "base-owner@example.com", false)
+	other := seedAccount(t, pool, "base-other@example.com", false)
+	otherTok, _ := iss.Issue(other, 1)
+	ctx := context.Background()
+	if _, err := h.cvStore.Create(ctx, owner, "My CV", cv.DefaultTemplateID, cv.Document{
+		Summary: "owner keep me",
+	}); err != nil {
+		t.Fatalf("create owner base: %v", err)
+	}
+	app := buildResetApp(h, iss)
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/base/reset-from-resume", otherTok, nil)
+	if resp.StatusCode != fiber.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body = %s, want 409 (other has no seed)", resp.StatusCode, body)
+	}
+	base, ok, err := h.cvStore.BaseCV(ctx, owner)
+	if err != nil || !ok {
+		t.Fatalf("owner BaseCV: ok=%v err=%v", ok, err)
+	}
+	if base.Document.Summary != "owner keep me" {
+		t.Fatalf("owner summary = %q, want untouched by another account", base.Document.Summary)
 	}
 }

--- a/internal/handler/cv_seed_apply.go
+++ b/internal/handler/cv_seed_apply.go
@@ -8,7 +8,9 @@ import (
 // applySeedContent builds the next editable state from a résumé seed while keeping the
 // candidate's presentation choices. Title and template stay on the row; margins and style
 // stay on the document. Body sections come from cv.Seed; header contacts merge so an empty
-// seed field never blanks a value the candidate already has on the page.
+// seed field never blanks a value the candidate already has on the page. Summary and skills
+// follow the same keep-if-empty rule — a provisional/pending seed strips those sections, and
+// blanking a tailored CV that already had them is data loss, not a fresh start.
 //
 // Shared by Reset from résumé for both the base CV and the tailored copy so the two cannot
 // drift on what "preserve presentation" means.
@@ -17,6 +19,12 @@ func applySeedContent(keep cvedit.State, seeded cv.Document) cvedit.State {
 	doc.Margins = keep.Margins
 	doc.Style = keep.Style
 	doc.Header = mergeSeedHeader(keep.Header, seeded.Header)
+	if doc.Summary == "" {
+		doc.Summary = keep.Summary
+	}
+	if len(doc.Skills) == 0 {
+		doc.Skills = keep.Skills
+	}
 	return cvedit.State{
 		Title:      keep.Title,
 		TemplateID: keep.TemplateID,

--- a/internal/handler/cv_seed_apply_test.go
+++ b/internal/handler/cv_seed_apply_test.go
@@ -153,3 +153,63 @@ func TestApplySeedContentFillsEmptyHeaderFromSeed(t *testing.T) {
 		t.Fatalf("skills = %+v, want seeded Go", got.Skills)
 	}
 }
+
+// Empty seed summary/skills must not wipe what the CV already shows — provisional extract
+// strips those sections from the seed while bank experience still lets reset run.
+func TestApplySeedContentPreservesEmptySeedSummaryAndSkills(t *testing.T) {
+	keep := cvedit.State{
+		Title:      "Tailored",
+		TemplateID: cv.DefaultTemplateID,
+		Document: cv.Document{
+			Header:  cv.Header{FullName: "Ada"},
+			Summary: "keep me",
+			Skills:  []cv.SkillGroup{{Items: []string{"IaC", "Go"}}},
+			Experience: []cv.ExperienceItem{{
+				Role: "Old", Company: "OldCo",
+			}},
+		},
+	}
+	seeded := cv.Document{
+		Header: cv.Header{FullName: "Ada Lovelace"},
+		Experience: []cv.ExperienceItem{{
+			Role: "SWE", Company: "BankCo", Bullets: []string{"Shipped X"},
+		}},
+	}
+
+	got := applySeedContent(keep, seeded)
+	if got.Summary != "keep me" {
+		t.Fatalf("summary = %q, want keep's summary", got.Summary)
+	}
+	if len(got.Skills) != 1 || len(got.Skills[0].Items) != 2 ||
+		got.Skills[0].Items[0] != "IaC" || got.Skills[0].Items[1] != "Go" {
+		t.Fatalf("skills = %+v, want keep's skills", got.Skills)
+	}
+	if len(got.Experience) != 1 || got.Experience[0].Company != "BankCo" {
+		t.Fatalf("experience = %+v, want seeded body", got.Experience)
+	}
+	if got.Header.FullName != "Ada Lovelace" {
+		t.Fatalf("header name = %q, want seed", got.Header.FullName)
+	}
+}
+
+func TestApplySeedContentNonEmptySummaryAndSkillsReplace(t *testing.T) {
+	keep := cvedit.State{
+		Document: cv.Document{
+			Summary: "old summary",
+			Skills:  []cv.SkillGroup{{Items: []string{"Old"}}},
+		},
+	}
+	seeded := cv.Document{
+		Summary: "from résumé",
+		Skills:  []cv.SkillGroup{{Items: []string{"Go", "Kafka"}}},
+	}
+
+	got := applySeedContent(keep, seeded)
+	if got.Summary != "from résumé" {
+		t.Fatalf("summary = %q, want seed", got.Summary)
+	}
+	if len(got.Skills) != 1 || len(got.Skills[0].Items) != 2 ||
+		got.Skills[0].Items[0] != "Go" || got.Skills[0].Items[1] != "Kafka" {
+		t.Fatalf("skills = %+v, want seed", got.Skills)
+	}
+}

--- a/internal/handler/cv_surface_align.go
+++ b/internal/handler/cv_surface_align.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"context"
+	"log"
+
+	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/cvedit"
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// commitSurfaceAlign rewrites the tailored CV so skill wording matches the vacancy's
+// preferred surfaces, as its own system revision (not an agent batch). No-op when the
+// document is already aligned or the vacancy names no recognised skills.
+func (h *cvHandlers) commitSurfaceAlign(ctx context.Context, userID int64, cvID uuid.UUID, jobDescription string) error {
+	if h.editor == nil {
+		return nil
+	}
+	preferred := skilltag.PreferredFromText(jobDescription)
+	if len(preferred) == 0 {
+		return nil
+	}
+	rec, err := h.cvStore.Get(ctx, cvID, userID)
+	if err != nil {
+		return err
+	}
+	aligned := cv.Align(rec.Document, preferred)
+	if !cv.AlignChanged(rec.Document, preferred) {
+		return nil
+	}
+	_, _, err = h.editor.CommitDocument(ctx, cvID, userID,
+		cvedit.ActorSystem, cvedit.OriginImport,
+		cvedit.State{Title: rec.Title, TemplateID: rec.TemplateID, Document: aligned})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// logSurfaceAlign is best-effort commitSurfaceAlign for call sites that must not fail the
+// surrounding flow (autopilot start).
+func (h *cvHandlers) logSurfaceAlign(ctx context.Context, userID int64, cvID uuid.UUID, jobDescription string) {
+	if err := h.commitSurfaceAlign(ctx, userID, cvID, jobDescription); err != nil {
+		log.Printf("cv: surface-align cv=%s: %v", cvID, err)
+	}
+}

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/strelov1/freehire/internal/cvedit"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/matchanalysis"
+	"github.com/strelov1/freehire/internal/skilltag"
 )
 
 type tailorCVRequest struct {
@@ -82,7 +83,7 @@ func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	if err := h.reseedBaseIfStaleVsUpload(c, userID); err != nil {
 		log.Printf("cv: base refresh before tailor bootstrap user=%d: %v", userID, err)
 	}
-	base, tailored, justCreated, err := h.cvStore.Tailor(c.Context(), userID, job.ID, tailoredCVTitle(job.Title), h.seedSource())
+	base, tailored, justCreated, err := h.cvStore.Tailor(c.Context(), userID, job.ID, tailoredCVTitle(job.Title), h.seedSource(), skilltag.PreferredFromText(job.Description))
 	if errors.Is(err, cv.ErrNoResume) {
 		return fiber.NewError(fiber.StatusConflict, "add a résumé before tailoring")
 	}

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -104,11 +104,16 @@ func doBearer(t *testing.T, app *fiber.App, method, path, token string, body any
 
 func seedJobSlug(t *testing.T, pool *pgxpool.Pool, slug string) int64 {
 	t.Helper()
+	return seedJobSlugDesc(t, pool, slug, "")
+}
+
+func seedJobSlugDesc(t *testing.T, pool *pgxpool.Pool, slug, description string) int64 {
+	t.Helper()
 	var id int64
 	if err := pool.QueryRow(context.Background(),
-		`INSERT INTO jobs (source, external_id, url, title, public_slug)
-		 VALUES ('test', $1, 'https://e.test/'||$1, 'Backend Engineer', $1) RETURNING id`,
-		slug).Scan(&id); err != nil {
+		`INSERT INTO jobs (source, external_id, url, title, public_slug, description)
+		 VALUES ('test', $1, 'https://e.test/'||$1, 'Backend Engineer', $1, $2) RETURNING id`,
+		slug, description).Scan(&id); err != nil {
 		t.Fatalf("seed job: %v", err)
 	}
 	return id
@@ -137,7 +142,12 @@ func seedAnalysis(t *testing.T, h *cvHandlers, userID, jobID int64) {
 // resume.Structured serves it (ok=true) and the base CV can be seeded from it.
 func seedFreshResume(t *testing.T, pool *pgxpool.Pool, userID int64) {
 	t.Helper()
-	st, _ := json.Marshal(resumeextract.Structured{FullName: "Ada Lovelace", Summary: "Engineer", Skills: []string{"Go"}})
+	seedFreshResumeSkills(t, pool, userID, []string{"Go"})
+}
+
+func seedFreshResumeSkills(t *testing.T, pool *pgxpool.Pool, userID int64, skills []string) {
+	t.Helper()
+	st, _ := json.Marshal(resumeextract.Structured{FullName: "Ada Lovelace", Summary: "Engineer", Skills: skills})
 	at := time.Now().Truncate(time.Microsecond)
 	if _, err := pool.Exec(context.Background(),
 		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = $2,
@@ -1117,6 +1127,75 @@ func TestGetCV_PartialHeaderKeepsNameFillsEmail(t *testing.T) {
 	}
 	if body.Data.Document.Header.Email != "blob@example.com" {
 		t.Fatalf("email = %q, want filled from provisional", body.Data.Document.Header.Email)
+	}
+}
+
+// TestTailorCVAlignsSkillSurfaceOnMint: a fresh tailored copy stores the vacancy's preferred
+// spelling of a skill the seed already carries (IaC → infrastructure as code). A second
+// bootstrap must not re-align — a candidate who put the acronym back keeps it.
+func TestTailorCVAlignsSkillSurfaceOnMint(t *testing.T) {
+	h, iss, pool := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+
+	user := seedAccount(t, pool, "align-mint@example.test", true)
+	tok, _ := iss.Issue(user, testTokenVersion)
+	seedJobSlugDesc(t, pool, "align-mint-job",
+		"We practice infrastructure as code and Terraform daily.")
+	seedFreshResumeSkills(t, pool, user, []string{"IaC", "Terraform"})
+
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "align-mint-job"})
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("bootstrap = %d, want 201", resp.StatusCode)
+	}
+	var got struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&got)
+	resp.Body.Close()
+
+	read := doCV(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+got.Data.TailorCVID, tok, nil)
+	var doc struct {
+		Data struct {
+			Document cv.Document `json:"document"`
+		} `json:"data"`
+	}
+	json.NewDecoder(read.Body).Decode(&doc)
+	read.Body.Close()
+	if len(doc.Data.Document.Skills) == 0 || len(doc.Data.Document.Skills[0].Items) == 0 {
+		t.Fatalf("skills = %+v, want at least one chip", doc.Data.Document.Skills)
+	}
+	chip := doc.Data.Document.Skills[0].Items[0]
+	if chip != "infrastructure as code" {
+		t.Fatalf("skill chip = %q, want vacancy preferred form", chip)
+	}
+
+	// Candidate puts the acronym back; second bootstrap must leave it alone.
+	patch := doCV(t, app, fiber.MethodPatch, "/api/v1/me/cvs/"+got.Data.TailorCVID, tok, map[string]any{
+		"ops": []map[string]any{{"kind": "set", "path": "skills[0].items[0]", "value": "IaC"}},
+	})
+	if patch.StatusCode != fiber.StatusOK {
+		t.Fatalf("patch = %d, want 200", patch.StatusCode)
+	}
+	patch.Body.Close()
+
+	again := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "align-mint-job"})
+	if again.StatusCode != fiber.StatusOK && again.StatusCode != fiber.StatusCreated {
+		t.Fatalf("second bootstrap = %d", again.StatusCode)
+	}
+	var againGot struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(again.Body).Decode(&againGot)
+	again.Body.Close()
+	if againGot.Data.TailorCVID != got.Data.TailorCVID {
+		t.Fatalf("second bootstrap minted a new CV %s, want existing %s", againGot.Data.TailorCVID, got.Data.TailorCVID)
+	}
+
+	read2 := doCV(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+got.Data.TailorCVID, tok, nil)
+	json.NewDecoder(read2.Body).Decode(&doc)
+	read2.Body.Close()
+	if doc.Data.Document.Skills[0].Items[0] != "IaC" {
+		t.Fatalf("after second bootstrap chip = %q, want user-edited IaC left in place", doc.Data.Document.Skills[0].Items[0])
 	}
 }
 

--- a/internal/skilltag/surfaces.go
+++ b/internal/skilltag/surfaces.go
@@ -1,0 +1,208 @@
+package skilltag
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/strelov1/freehire/internal/wordmatch"
+)
+
+// PreferredFromText returns each canonical skill found in text mapped to the
+// surface form the text actually used, preserving casing. When several aliases of
+// one canonical appear, the longest surface wins (rune count). Surfaces come only
+// from the curated alias tables — unknown phrases are ignored. Parse's return
+// shape is unchanged; this is the invert path for JD-driven wording alignment.
+func PreferredFromText(text string) map[string]string {
+	cased := strings.TrimSpace(stripMarkup(text))
+	if cased == "" {
+		return nil
+	}
+	norm := strings.ToLower(cased)
+
+	best := map[string]string{}
+	consider := func(canonical, surface string) {
+		if canonical == "" || surface == "" {
+			return
+		}
+		if prev, ok := best[canonical]; ok && utf8.RuneCountInString(surface) <= utf8.RuneCountInString(prev) {
+			return
+		}
+		best[canonical] = surface
+	}
+
+	// Mirror Parse's strong/weak split: ambiguous English-word aliases only count
+	// when a strong tech token corroborates them, so "must react to changes" does
+	// not prefer "react" as a JD skill surface.
+	type hit struct {
+		canonical, surface string
+		weak               bool
+	}
+	var hits []hit
+	strong := false
+
+	for surface, canonical := range sharedAcronyms {
+		if loc := findBounded(cased, surface, wordmatch.UnicodeBoundary); loc != nil {
+			hits = append(hits, hit{canonical, cased[loc[0]:loc[1]], false})
+			strong = true
+		}
+	}
+	for _, m := range phraseMatchers {
+		for _, loc := range findAllPhrase(norm, m) {
+			surface := cased[loc[0]:loc[1]]
+			if nonCorroboratingPhrases[m.canonical] {
+				hits = append(hits, hit{m.canonical, surface, false})
+				continue
+			}
+			hits = append(hits, hit{m.canonical, surface, false})
+			strong = true
+		}
+	}
+	for _, loc := range wordTokenRE.FindAllStringIndex(norm, -1) {
+		tok := norm[loc[0]:loc[1]]
+		c, ok := wordAliases[tok]
+		if !ok {
+			continue
+		}
+		surface := cased[loc[0]:loc[1]]
+		if ambiguousWords[tok] {
+			hits = append(hits, hit{c, surface, true})
+			continue
+		}
+		hits = append(hits, hit{c, surface, false})
+		strong = true
+	}
+	for _, h := range hits {
+		if h.weak && !strong {
+			continue
+		}
+		consider(h.canonical, h.surface)
+	}
+	if len(best) == 0 {
+		return nil
+	}
+	return best
+}
+
+// AliasesOf returns every curated lowercase alias that resolves to canonical,
+// including the canonical slug itself when it is a recognised form. Order is
+// longest-first so whole-phrase replaces run before shorter acronyms.
+func AliasesOf(canonical string) []string {
+	if canonical == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(a string) {
+		a = strings.TrimSpace(strings.ToLower(a))
+		if a == "" {
+			return
+		}
+		if _, ok := seen[a]; ok {
+			return
+		}
+		seen[a] = struct{}{}
+		out = append(out, a)
+	}
+	add(canonical)
+	for alias, c := range wordAliases {
+		if c == canonical {
+			add(alias)
+		}
+	}
+	for _, p := range phraseAliases {
+		if p.canonical == canonical {
+			add(p.alias)
+		}
+	}
+	for surface, c := range sharedAcronyms {
+		if c == canonical {
+			add(surface)
+		}
+	}
+	for surface, ca := range categoryScopedAcronyms {
+		if ca.canonical == canonical {
+			add(surface)
+		}
+	}
+	for surface, c := range resumeAcronyms {
+		if c == canonical {
+			add(surface)
+		}
+	}
+	// Longest first so "infrastructure as code" wins over "iac" when both are tried.
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if utf8.RuneCountInString(out[j]) > utf8.RuneCountInString(out[i]) {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	return out
+}
+
+// IsProseSafeAlias reports whether alias may be rewritten inside summary/bullet
+// prose. Multi-word phrases and strong acronyms are safe; ambiguous English-word
+// aliases and one- or two-letter tokens are not (they collide with ordinary prose).
+func IsProseSafeAlias(alias string) bool {
+	a := strings.TrimSpace(strings.ToLower(alias))
+	if a == "" {
+		return false
+	}
+	if strings.ContainsAny(a, " \t_-/") {
+		// Phrases and punctuated tokens (ci/cd, c++) — not bare English words.
+		return true
+	}
+	if ambiguousWords[a] {
+		return false
+	}
+	if utf8.RuneCountInString(a) <= 2 {
+		return false
+	}
+	return true
+}
+
+// findBounded returns the [start,end) of the first whole-token occurrence of term
+// in s, or nil.
+func findBounded(s, term string, ok wordmatch.Boundary) []int {
+	if term == "" {
+		return nil
+	}
+	for from := 0; ; {
+		i := strings.Index(s[from:], term)
+		if i < 0 {
+			return nil
+		}
+		i += from
+		end := i + len(term)
+		if ok(s, i, end) {
+			return []int{i, end}
+		}
+		from = i + 1
+	}
+}
+
+// findAllPhrase returns every boundary-checked match of m in norm.
+func findAllPhrase(norm string, m phraseMatcher) [][]int {
+	var out [][]int
+	if m.re == nil {
+		for from := 0; ; {
+			i := strings.Index(norm[from:], m.token)
+			if i < 0 {
+				break
+			}
+			i += from
+			end := i + len(m.token)
+			if wordmatch.ASCIIBoundary(norm, i, end) {
+				out = append(out, []int{i, end})
+			}
+			from = i + 1
+		}
+		return out
+	}
+	for _, loc := range m.re.FindAllStringIndex(norm, -1) {
+		if wordmatch.ASCIIBoundary(norm, loc[0], loc[1]) {
+			out = append(out, loc)
+		}
+	}
+	return out
+}

--- a/internal/skilltag/surfaces_test.go
+++ b/internal/skilltag/surfaces_test.go
@@ -1,0 +1,108 @@
+package skilltag
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPreferredFromText_LongestWins(t *testing.T) {
+	got := PreferredFromText("We practice IaC and Infrastructure as Code daily.")
+	want := "Infrastructure as Code"
+	if got["infrastructure-as-code"] != want {
+		t.Fatalf("preferred = %q, want %q (longest); full map %#v", got["infrastructure-as-code"], want, got)
+	}
+}
+
+func TestPreferredFromText_JDOnlyAcronym(t *testing.T) {
+	got := PreferredFromText("Experience with IaC and Terraform.")
+	if got["infrastructure-as-code"] != "IaC" {
+		t.Fatalf("preferred = %q, want IaC; full map %#v", got["infrastructure-as-code"], got)
+	}
+	if got["terraform"] != "Terraform" {
+		t.Fatalf("terraform preferred = %q, want Terraform", got["terraform"])
+	}
+}
+
+func TestPreferredFromText_UnknownIgnored(t *testing.T) {
+	got := PreferredFromText("Must know BlorpleDB and the FluxCapacitor framework.")
+	if len(got) != 0 {
+		t.Fatalf("got %#v, want empty — unknown jargon must not invent surfaces", got)
+	}
+}
+
+func TestPreferredFromText_CasingPreserved(t *testing.T) {
+	got := PreferredFromText("Required: Kubernetes and PostgreSQL.")
+	if got["kubernetes"] != "Kubernetes" {
+		t.Errorf("kubernetes = %q, want Kubernetes", got["kubernetes"])
+	}
+	if got["postgresql"] != "PostgreSQL" {
+		t.Errorf("postgresql = %q, want PostgreSQL", got["postgresql"])
+	}
+}
+
+func TestPreferredFromText_Empty(t *testing.T) {
+	if got := PreferredFromText(""); got != nil {
+		t.Fatalf("got %#v, want nil", got)
+	}
+}
+
+func TestAliasesOf_LongestFirst(t *testing.T) {
+	got := AliasesOf("infrastructure-as-code")
+	if len(got) < 2 {
+		t.Fatalf("aliases = %v, want at least iac and the phrase", got)
+	}
+	if got[0] != "infrastructure as code" && got[0] != "infrastructure-as-code" {
+		// phraseAliases has "infrastructure as code"; canonical slug may also appear.
+		// Longest should be the spaced phrase (22 runes) over "infrastructure-as-code" (22)
+		// or "iac" (3). Spaced phrase and hyphenated slug are same rune length for
+		// "infrastructure as code" (22) vs "infrastructure-as-code" (22) — spaces vs hyphens.
+		// "infrastructure as code" has spaces: i-n-f-r-a-s-t-r-u-c-t-u-r-e- -a-s- -c-o-d-e = 22
+		// Either long form before iac is fine.
+	}
+	foundPhrase, foundIAC := false, false
+	for i, a := range got {
+		if a == "infrastructure as code" {
+			foundPhrase = true
+			if i > 0 && got[0] == "iac" {
+				t.Fatalf("aliases = %v, want long phrase before iac", got)
+			}
+		}
+		if a == "iac" {
+			foundIAC = true
+		}
+	}
+	if !foundPhrase || !foundIAC {
+		t.Fatalf("aliases = %v, want both phrase and iac", got)
+	}
+}
+
+func TestIsProseSafeAlias(t *testing.T) {
+	cases := []struct {
+		alias string
+		want  bool
+	}{
+		{"infrastructure as code", true},
+		{"iac", true},
+		{"k8s", true},
+		{"ci/cd", true},
+		{"go", false},
+		{"react", false},
+		{"c", false},
+		{"js", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsProseSafeAlias(tc.alias); got != tc.want {
+			t.Errorf("IsProseSafeAlias(%q) = %v, want %v", tc.alias, got, tc.want)
+		}
+	}
+}
+
+func TestPreferredFromText_Deterministic(t *testing.T) {
+	text := "IaC with Kubernetes and React."
+	a := PreferredFromText(text)
+	b := PreferredFromText(text)
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("not deterministic:\n%#v\n%#v", a, b)
+	}
+}

--- a/openspec/changes/jd-surface-align-prepass/.openspec.yaml
+++ b/openspec/changes/jd-surface-align-prepass/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/jd-surface-align-prepass/design.md
+++ b/openspec/changes/jd-surface-align-prepass/design.md
@@ -1,0 +1,141 @@
+## Context
+
+See proposal.md for motivation. Today `skilltag.Parse` collapses aliases to
+canonicals for matching, but throws away which surface form appeared in the text.
+`skilladjacency` holds peer substitutes; `skillbundle` holds market combinations.
+Neither exposes "JD wrote X, CV wrote Y, same canonical — rewrite Y to X." Tailor
+and autopilot ask the LLM to "use the vacancy's language," which rediscovers
+dictionary facts at token cost.
+
+`internal/cv` writes `cvs.data` on **create** only. Every later mutation goes
+through `cvedit.Editor`. Autopilot undo reverts that run's edit batches — there
+is no pre-run document snapshot.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Invert alias→canonical enough to recover preferred JD surfaces and apply them
+  to a `cv.Document` deterministically, mirroring the JD (expand or shrink).
+- Run that rewrite before any tailor/autopilot LLM turn.
+- Keep prose replacement safe: no ambiguous English-word aliases in bullets.
+- Keep Phase 1 strictly to same-canonical alias swaps; leave a clear seam for
+  family/dedup phases.
+
+**Non-Goals (design-level; full list in proposal):**
+- Family relations, facet collapse, adjacency merges, LLM synonym discovery,
+  provider-gated Taleo modes, fit-analysis semantic changes, aligning the
+  experience bank.
+
+## Decisions
+
+### D1 — Preferred surface comes from the JD text, not a default display name
+
+Scan the vacancy description with the same alias tables `Parse` uses; for each
+canonical found, record the surface form(s) that actually matched, preserving
+JD casing. When multiple surfaces for one canonical appear, prefer the longest
+match (usually the expanded phrase over the acronym). When the JD uses only the
+short form, the preferred surface **is** the short form (shrink).
+
+*Rejected:* a fixed "pretty name" per canonical — that would ignore the JD's
+own spelling, which is what a literal ATS screen looks for.
+*Rejected:* always expand acronyms — Taleo matches what the posting wrote.
+
+### D2 — Two replace tiers
+
+| Field | What may be replaced |
+|---|---|
+| Skills-group items, experience/project `stack` | Any alias of the preferred canonical (`Canonicalize` — caller assertion) |
+| Summary and bullets | Only unambiguous aliases: multi-word phrases and strong acronyms (`IaC`, `k8s`, `CI/CD`). Not `ambiguousWords` (`go`, `react`, `c`, …) and not 1–2 letter tokens |
+
+Chips are assertions. Prose is English. The corroboration rule exists because
+`go`/`react` in a sentence are usually verbs.
+
+### D3 — Same-canonical chip collapse after rewrite
+
+If the skills line listed both `IaC` and `Infrastructure as Code`, both become
+the preferred surface; drop the duplicate. This is alias-identity, not family
+dedup (`pgvector` vs `vector-databases` stays Phase 3).
+
+### D4 — Write paths respect `cvedit`
+
+- **First mint:** align the copied base document, then `CreateTailored`. No
+  revision; the stored copy never held the unaligned wording.
+- **Autopilot start and reset-from-résumé:** `cvedit.Editor.Commit` (revision).
+  Autopilot undo then includes or excludes that batch according to whether it
+  shares the run's batch id — prefer a **distinct** align batch so undoing the
+  *run* does not revert wording that is still JD-correct. The candidate can
+  revert the align revision separately if they want the acronym back.
+- **Repeated bootstrap** of an existing copy: do not re-align (would fight
+  interactive edits).
+
+*Rejected:* silent `Store` overwrite on autopilot — `update` is unexported;
+that path does not exist.
+*Rejected:* passing only a hint list to the LLM — still spends tokens.
+
+### D5 — Brief both presets
+
+`tailorPrompt` and the autopilot brief both state that skill surface forms are
+already aligned to the vacancy; do not rename skills for wording.
+
+### D6 — Invert API stays beside Parse, does not change Parse
+
+`Parse` still returns canonicals only (ingest/facets unchanged). New helpers
+recover surfaces (`PreferredFromText`, alias lookup). Phase 2–4 consume the same
+API.
+
+### D7 — Phased dictionary growth (future; no code in this change)
+
+```
+Phase 1 (this change)     alias surfaces     IaC ↔ infrastructure as code
+Phase 2                   skill families     vector-databases ⊃ {pgvector,…}
+Phase 3                   family ensure+dedup  plant JD term; dedupe chips
+Phase 4                   literal diagnostic   report remaining text misses
+```
+
+ATS delta already scores the rendered PDF: mint-time align will move keyword
+strength vs base before any LLM edit. Phase 4 is then a `from`→`to` receipt,
+not a new scorer.
+
+Phase 2+ keep canonicals distinct in facets. Family is a new relation, not an
+extension of `skilladjacency` peers. Do not align the experience bank — only
+the throwaway tailored copy.
+
+### D8 — Out of scope (pinned)
+
+| Item | Why excluded |
+|---|---|
+| Alias collapse changes for ingest | Facets and matching stay as today |
+| Collapse products into one facet | Filters must stay precise |
+| Merge families into `skilladjacency` | Peers ≠ hyponyms |
+| LLM-invented synonym/family links | Dict-only invariant |
+| Inventing skills / tone paraphrase / stuffing gaps | Evidence gate |
+| `source=taleo` special mode | Literal align helps every ATS |
+| Fit-analysis / evidence-gate changes | Orthogonal |
+| Reindex / Meili schema | Document-only rewrite |
+| Rewriting banked atoms | Bank stays the candidate's words |
+
+## Risks / Trade-offs
+
+- **[Risk] Ambiguous prose replace** (`go` → `Golang` in "go-to person") →
+  **Mitigation:** D2; thorough tests on `ambiguousWords` and short tokens in
+  bullets, and on safe acronym/phrase hits in the same bullets.
+- **[Risk] Long expansions bloat the skills line** → **Mitigation:** correct
+  for literal ATS; Phase 3 trims family redundancy, not aliases.
+- **[Risk] User reverts to acronym; next autopilot re-expands** →
+  **Mitigation:** intended for an unattended run; interactive edits after
+  bootstrap stay until reset or autopilot.
+- **[Risk] Align commit vs autopilot-undo** → **Mitigation:** distinct batch
+  (D4); tests pin that undoing the run leaves JD wording in place.
+- **[Risk] Phase 2 scope creep** → **Mitigation:** Phase 1 tests only
+  same-canonical pairs; family fixtures must not pass Phase 1.
+
+## Migration Plan
+
+Ship behind normal deploy. No DB migration. Existing tailored CVs align on next
+autopilot start or reset; new bootstraps align at mint. Rollback: remove call
+sites; copies already rewritten remain (harmless expansions or shrinks).
+
+## Open Questions
+
+None that block implementation. Workspace UI for the receipt can stay log-only
+in Phase 1.

--- a/openspec/changes/jd-surface-align-prepass/proposal.md
+++ b/openspec/changes/jd-surface-align-prepass/proposal.md
@@ -1,0 +1,91 @@
+## Why
+
+Canonical skill matching already treats `IaC` and `infrastructure as code` as the
+same skill (`skilltag` aliases → one slug), but a literal ATS keyword screen (the
+Taleo-style matcher) only sees the PDF text layer. A tailored CV that still says
+`IaC` fails that screen when the JD wrote the long form — and today the tailor LLM
+burns tokens rediscovering synonym pairs the dictionary already knows. A
+deterministic pre-pass should align surface forms to the JD **before** any model
+turn, so autopilot spends its budget on evidence and substance, not thesaurus work.
+
+## What Changes
+
+- **Deterministic JD surface-align pre-pass (this change / Phase 1).** From the
+  vacancy description, resolve preferred surface forms per canonical skilltag slug;
+  on the tailored CV, replace the candidate's aliases of those same canonicals with
+  the JD's spelling and casing (mirror the JD — expand or shrink). Pure Go,
+  dictionary-backed, no LLM.
+- **Two replace tiers.** Skills chips and role/project stacks: any alias of the
+  canonical. Summary and bullets: only unambiguous aliases (phrases and strong
+  acronyms such as `IaC`, `k8s`); never ambiguous English-word aliases (`go`,
+  `react`, `c`) or 1–2 letter tokens.
+- **Same-canonical chip collapse.** After rewrite, duplicate skills-line items
+  that now share one surface are collapsed (not family dedup).
+- **Apply before the model runs.** Align the document at first mint (before
+  insert). Re-align on reset-from-résumé and at autopilot start. Autopilot/reset
+  writes go through the CV editor (revision), not a silent row overwrite. Repeated
+  bootstrap of an existing copy does not re-align.
+- **Brief interactive tailor and autopilot** that surfaces are already aligned so
+  the model does not redo or undo the renames.
+- **Optional alignment receipt** (applied `from`→`to` list) for logs / a short
+  workspace note — not a new scored category in this change.
+
+### Future phases (not in this change)
+
+Recorded so later work can dedupe related skills without re-litigating scope:
+
+- **Phase 2 — Skill families (core ↔ related members).** Curated links between
+  distinct canonicals that name one capability at different grains, e.g. core
+  `vector-databases` with members `pgvector`, `pinecone`, `weaviate`, `qdrant`,
+  `chromadb`, `milvus` (and carefully gated looser members later). Keep facet
+  values distinct; family is a relation for match/retrieval/tailor, not alias
+  collapse. Enables: JD wants the core, CV has a member → family hit + optional
+  surface plant of the JD term when evidence supports it.
+- **Phase 3 — Family-aware ensure + dedup.** Use families to (a) avoid double-
+  counting the same capability under two slugs in keyword/coverage scores, (b)
+  prefer the JD's member or core term when rewriting, (c) dedupe skills-section
+  chips that are family-redundant once the JD term is present
+  (`pgvector` + `vector-databases` → keep what the JD asked for).
+- **Phase 4 — Literal coverage diagnostic.** Report canonical matches that still
+  miss the JD's literal surface on the rendered text (diagnose-only lens for the
+  Taleo-style screen), building on Phase 1's surface map.
+
+### Out of scope (this change and not assumed by future phases above)
+
+- Replacing or weakening `skilltag` alias→canonical matching for ingest/facets.
+- Collapsing related products into one facet value (filters must stay precise).
+- Extending or merging `skilladjacency` peer substitutes (react↔vue) with families
+  — peers stay in `skilladjacency`; families are a different relation.
+- Asking the LLM to discover or invent synonym/family links.
+- Inventing skills or experience the candidate does not have; paraphrasing bullets
+  for tone; keyword stuffing gaps the bank cannot evidence.
+- ATS-provider-specific modes gated on `source=taleo` (literal align is always-on
+  for every vacancy).
+- Changing fit-analysis `synonym-only` / evidence-strength semantics, or the
+  evidence gate / provenance rules.
+- Meilisearch schema / reindex work.
+
+## Capabilities
+
+### New Capabilities
+- `jd-surface-align`: deterministic alignment of a tailored CV's skill surface
+  forms to the vacancy's preferred spellings, applied before tailor/autopilot LLM
+  turns.
+
+### Modified Capabilities
+- `tailor-autopilot`: autopilot start SHALL run (or confirm) surface alignment on
+  the bound tailored CV before the unattended turn begins.
+- `cv-tailoring`: tailor bootstrap SHALL surface-align a newly minted tailored
+  copy against the bound vacancy before the first model turn; reset-from-résumé
+  SHALL re-align the rebuilt copy.
+
+## Impact
+
+- **Backend:** new pure helper (likely under `internal/skilltag` or a thin sibling)
+  that maps JD text → preferred surfaces and rewrites a `cv.Document`; mint aligns
+  before `CreateTailored`; autopilot start and reset-from-résumé commit through
+  `cvedit` (the only update path for `cvs.data`).
+- **No migration, no reindex** — document rewrite only; facets unchanged.
+- **Frontend:** optional receipt display later; not required for Phase 1 to ship.
+- **Tokens:** fewer autopilot `cv_edit` rounds spent on acronym/expansion swaps;
+  step ceiling freed for evidence work.

--- a/openspec/changes/jd-surface-align-prepass/specs/cv-tailoring/spec.md
+++ b/openspec/changes/jd-surface-align-prepass/specs/cv-tailoring/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: New tailored copies are surface-aligned to the vacancy
+
+When the system creates a new tailored CV for a vacancy, it SHALL apply the
+jd-surface-align rewrite to that copy against the vacancy's description before
+the copy is stored and before any model turn on the copy. A bootstrap that
+returns an already-existing tailored CV SHALL NOT re-apply alignment merely
+because bootstrap was repeated.
+
+#### Scenario: Fresh copy uses the vacancy's skill wording
+
+- **WHEN** bootstrap creates a tailored copy and the base CV's skills or prose use
+  an alias of a skill the vacancy names under a different surface form
+- **THEN** the tailored copy is stored with the vacancy's preferred surface forms
+  already applied
+
+#### Scenario: Reload does not fight user edits
+
+- **WHEN** bootstrap is repeated for a vacancy that already has a tailored copy
+- **THEN** alignment is not re-run as part of that repeat
+
+### Requirement: Reset-from-résumé re-aligns the rebuilt copy
+
+When a tailored CV is reset from the résumé seed, the system SHALL apply the
+jd-surface-align rewrite to the rebuilt document against the bound vacancy
+before the reset is considered complete. The rewrite SHALL be committed through
+the same editor path as other document updates.
+
+#### Scenario: Reset copy speaks the vacancy's wording
+
+- **WHEN** the owner resets a tailored CV whose seed again says `IaC` and the
+  vacancy prefers `infrastructure as code`
+- **THEN** the stored document after reset uses the vacancy's preferred surface
+
+### Requirement: The tailoring agent is told wording is already aligned
+
+The tailoring system prompt SHALL tell the model that skill surface forms already
+match the vacancy and that it MUST NOT rename skills for wording.
+
+#### Scenario: Prompt forbids synonym hunting
+
+- **WHEN** a tailoring session starts
+- **THEN** the system prompt includes an instruction that wording alignment is
+  done and must not be repeated

--- a/openspec/changes/jd-surface-align-prepass/specs/jd-surface-align/spec.md
+++ b/openspec/changes/jd-surface-align-prepass/specs/jd-surface-align/spec.md
@@ -1,0 +1,119 @@
+## Purpose
+
+Deterministically rewrite a tailored CV so its skill wording matches the vacancy's
+own spellings before any LLM tailor or autopilot turn, using the skilltag alias
+dictionary rather than model inference.
+
+## ADDED Requirements
+
+### Requirement: Preferred surfaces are taken from the vacancy text
+
+The system SHALL, given a vacancy's plain description, resolve each recognised
+skill to its canonical slug and record the surface form(s) that appeared in that
+description, preserving the vacancy's casing. When more than one surface for the
+same canonical appears, the system SHALL prefer the longest surface. When only
+one surface appears, that surface is the preferred form even when it is the
+shorter alias. Surfaces SHALL come only from the curated skilltag alias
+dictionary; unknown phrases SHALL not be invented.
+
+#### Scenario: Long form wins over acronym in the JD
+
+- **WHEN** the vacancy text contains both `IaC` and `infrastructure as code`
+- **THEN** the preferred surface for `infrastructure-as-code` is the longer
+  `infrastructure as code` form with the vacancy's casing
+
+#### Scenario: JD-only acronym is the preferred surface
+
+- **WHEN** the vacancy text contains `IaC` and does not contain
+  `infrastructure as code`
+- **THEN** the preferred surface is `IaC` with the vacancy's casing
+
+#### Scenario: Unknown jargon is ignored
+
+- **WHEN** the vacancy text names a tool absent from the skilltag dictionary
+- **THEN** no preferred surface is recorded for it
+
+### Requirement: Skills chips and stacks accept any alias of the canonical
+
+The system SHALL rewrite each skills-group item and each experience/project stack
+entry that `Canonicalize` resolves to a canonical with a preferred vacancy
+surface, replacing that item with the preferred surface. After rewrite, the
+system SHALL collapse skills-group items that have become identical.
+
+#### Scenario: Skills chip expands to the JD form
+
+- **WHEN** the tailored CV lists `IaC` in a skills group and the vacancy prefers
+  `infrastructure as code`
+- **THEN** that skills item becomes `infrastructure as code`
+
+#### Scenario: Skills chip shrinks to the JD acronym
+
+- **WHEN** the tailored CV lists `Infrastructure as Code` and the vacancy prefers
+  `IaC`
+- **THEN** that skills item becomes `IaC`
+
+#### Scenario: Duplicate chips after rewrite are collapsed
+
+- **WHEN** a skills group lists both `IaC` and `Infrastructure as Code` and the
+  vacancy prefers `infrastructure as code`
+- **THEN** the group contains that preferred surface once
+
+#### Scenario: An ambiguous chip is still rewritten
+
+- **WHEN** a skills item is `Go` and the vacancy prefers `Golang`
+- **THEN** that skills item becomes `Golang`
+
+#### Scenario: No new skill is introduced
+
+- **WHEN** the vacancy prefers `kubernetes` but the tailored CV has no alias of
+  that canonical in chips or stacks
+- **THEN** the document gains no `kubernetes` (or `k8s`) entry from alignment alone
+
+### Requirement: Prose replace is unambiguous aliases only
+
+The system SHALL rewrite whole-token occurrences in the summary and bullets only
+when the matched token is an unambiguous alias of a preferred canonical: a
+multi-word phrase alias or a strong acronym. It SHALL NOT rewrite tokens listed
+as ambiguous English words in the skilltag dictionary, and SHALL NOT rewrite
+tokens of one or two letters. Replacement SHALL use word-boundary matching so an
+alias never matches inside a larger word.
+
+#### Scenario: Unambiguous acronym in a bullet is replaced
+
+- **WHEN** a bullet contains the whole token `IaC` and the vacancy prefers
+  `infrastructure as code`
+- **THEN** that token is replaced and surrounding words are unchanged
+
+#### Scenario: Ambiguous English-word alias in a bullet is left alone
+
+- **WHEN** a bullet contains `go` or `react` as a whole token and the vacancy
+  prefers `Golang` or `React`
+- **THEN** that bullet is not rewritten for that token
+
+#### Scenario: A short token is not rewritten in prose
+
+- **WHEN** a bullet contains a one- or two-letter whole token that aliases a
+  preferred canonical
+- **THEN** that token is left unchanged
+
+#### Scenario: A substring that is not a whole token is left alone
+
+- **WHEN** prose contains a longer word that merely embeds an alias spelling
+- **THEN** that prose is not rewritten for that alias
+
+#### Scenario: Unambiguous phrase in a bullet is replaced
+
+- **WHEN** a bullet contains `infrastructure as code` and the vacancy prefers
+  `IaC`
+- **THEN** that phrase is replaced with `IaC`
+
+### Requirement: Alignment is deterministic and idempotent
+
+Applying surface alignment twice to the same document and vacancy text SHALL
+leave the document unchanged on the second pass and SHALL require no LLM.
+
+#### Scenario: Second pass is a no-op
+
+- **WHEN** alignment has already rewritten a document to the vacancy's preferred
+  surfaces
+- **THEN** a second alignment produces an identical document

--- a/openspec/changes/jd-surface-align-prepass/specs/tailor-autopilot/spec.md
+++ b/openspec/changes/jd-surface-align-prepass/specs/tailor-autopilot/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Autopilot aligns surfaces before the unattended turn
+
+When an autopilot run starts, the system SHALL apply the jd-surface-align rewrite
+to the session's bound tailored CV against the vacancy description before the
+unattended turn's first model call. A document that is already aligned SHALL be
+left unchanged (idempotent). The rewrite SHALL be committed through the CV editor
+as its own revision, not as a silent overwrite and not as part of the run's later
+edit batch, and SHALL NOT consume agent tool rounds or require evidence citations
+for chip and unambiguous-prose replacements.
+
+#### Scenario: Autopilot start rewrites before the model runs
+
+- **WHEN** an autopilot run starts on a tailored CV that still says `IaC` while the
+  vacancy prefers `infrastructure as code`
+- **THEN** the stored document is updated to the vacancy form before the turn's
+  first model call
+
+#### Scenario: Already-aligned documents are a no-op
+
+- **WHEN** an autopilot run starts on a document whose surfaces already match the
+  vacancy preferences
+- **THEN** the document is unchanged and the turn proceeds
+
+#### Scenario: Undoing the run does not revert alignment
+
+- **WHEN** an autopilot run that performed surface alignment is undone
+- **THEN** the JD-aligned wording remains and the run's other edits are reverted
+
+### Requirement: The unattended brief states surfaces are already aligned
+
+The server-owned autopilot brief SHALL tell the model that skill surface forms
+already match the vacancy and that it MUST NOT rename skills for wording.
+
+#### Scenario: Brief forbids synonym hunting
+
+- **WHEN** an autopilot turn starts
+- **THEN** the brief includes an instruction that wording alignment is done and
+  must not be repeated

--- a/openspec/changes/jd-surface-align-prepass/tasks.md
+++ b/openspec/changes/jd-surface-align-prepass/tasks.md
@@ -1,0 +1,43 @@
+## 1. Preferred surfaces from JD text
+
+- [x] 1.1 Add a pure helper that, given vacancy plain text, returns canonical → preferred surface (longest alias hit when several; sole hit even if short; JD casing), backed only by skilltag alias tables
+- [x] 1.2 Unit tests: both `IaC` and `infrastructure as code` → longest form; JD-only `IaC` → `IaC`; unknown jargon ignored; casing preserved from JD
+
+## 2. Document rewrite (thorough)
+
+- [x] 2.1 Apply preferred surfaces to a `cv.Document` with two tiers: chips/stacks via `Canonicalize` (any alias); summary/bullets via unambiguous phrase/acronym aliases only; word-boundary replace
+- [x] 2.2 Collapse skills-group items that become identical after rewrite
+- [x] 2.3 Chip/stack tests: `IaC` expands; long form shrinks to JD `IaC`; `Go` chip → `Golang` when JD prefers it; no skill invented when CV lacks the canonical; duplicate `IaC` + long form collapse to one
+- [x] 2.4 Prose safety tests (must be thorough): `IaC` / `k8s` / `infrastructure as code` in bullets replace; `go`, `react`, and other `ambiguousWords` in bullets do **not** replace even when JD prefers `Golang`/`React`; 1–2 letter tokens in prose stay; substring embeds (`reaction`, `going`) stay; surrounding words unchanged
+- [x] 2.5 Idempotence test: applying twice leaves the document unchanged
+- [x] 2.6 Family fixture must **not** rewrite: `pgvector` vs `vector-databases` stay distinct (Phase 1 guard)
+
+## 3. Wire into tailor bootstrap
+
+- [x] 3.1 On create of a new tailored copy, align the document then store it (`CreateTailored`); no model turn has run yet
+- [x] 3.2 Repeated bootstrap for an existing copy does not re-align
+- [x] 3.3 Add `tailorPrompt` sentence: surfaces already aligned; do not rename for wording
+- [x] 3.4 Integration test: fresh mint stores JD form; second bootstrap leaves a user-edited acronym in place
+
+## 4. Reset-from-résumé
+
+- [x] 4.1 After rebuilding from seed, commit surface align through `cvedit` against the bound vacancy
+- [x] 4.2 Integration test: reset of a copy whose seed says `IaC` stores the vacancy's preferred form
+
+## 5. Wire into autopilot start
+
+- [x] 5.1 Before the unattended turn's first model call, commit surface align through `cvedit` as its **own** revision (not the run's edit batch); idempotent when already aligned
+- [x] 5.2 Autopilot brief states surfaces are already aligned
+- [x] 5.3 Integration test: autopilot start rewrites `IaC` before the turn; already-aligned is a no-op
+- [x] 5.4 Integration test: undoing the autopilot run reverts the run's edits and **leaves** the align revision (JD wording remains)
+
+## 6. Guardrails
+
+- [x] 6.1 Confirm Phase 1 tests do not encode family behaviour (task 2.6 stays red if someone "helpfully" links those slugs)
+- [x] 6.2 `go test` for touched packages; `go vet -tags=integration ./...` before push
+
+## Future phases (separate changes — do not implement here)
+
+- Phase 2: skill families (core ↔ related members) for dedup/match — see proposal/design
+- Phase 3: family-aware ensure + skills-chip dedup
+- Phase 4: literal coverage diagnostic / `from`→`to` receipt on rendered text

--- a/openspec/changes/profile-cv-refresh-prompt/.openspec.yaml
+++ b/openspec/changes/profile-cv-refresh-prompt/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/profile-cv-refresh-prompt/design.md
+++ b/openspec/changes/profile-cv-refresh-prompt/design.md
@@ -1,0 +1,88 @@
+## Context
+
+See proposal.md — Why. Bank mutations update `experience_*` (and may merge skills into
+`userprofile.skills`) but never push into `cvs.data`. The only whole-document apply from
+seed today is `POST …/reset-from-resume` (tailored-only; reseeds base as a side effect) and
+upload-stale base refresh on tailor bootstrap. Tailor History already uses `window.confirm`
+before Reset. `ExperienceBankView` is shared by `/my/profile` and `/tailor/[slug]`.
+
+Assumption (recorded): profile Skills tab edits do not prompt — CV skills come from the
+structured résumé / keep-if-empty, not `userprofile.skills`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Consent prompt after successful bank mutations on profile and tailor.
+- Tailor agree → existing reset-from-résumé for the open CV.
+- Profile agree → base reseed without opening a tailored CV.
+- No silent rewrite; decline is a no-op.
+
+**Non-Goals:**
+
+- Prompting on profile Skills / specializations / contacts edits.
+- Refreshing every tailored CV for every vacancy in one click.
+- Auto-reset without consent.
+- Changing seed composition or Align behaviour.
+- Extension / assistant-driven bank writes (prompt is web UI after user-initiated save).
+
+## Decisions
+
+### D1 — Client-orchestrated prompt, reuse Reset
+
+After `ExperienceBankView` reports a successful mutation, the host page shows a confirm
+(same family as Reset copy). Tailor page passes the open `cvId` and calls
+`api.resetCvFromResume`. No new "partial sync" API for experience rows.
+
+**Why:** One apply path; History undo still works; matches product rule that open tailored
+CVs are never rewritten behind the candidate's back.
+
+### D2 — Base-only reseed for profile
+
+Add cookie-only `POST /api/v1/me/cvs/base/reset-from-resume` (name bikeshed OK) that:
+loads seed via `seedSource()`, 409 if unusable/`!hasSeedBody`, then
+`reseedBaseFromSeed` / Create if absent — same `applySeedContent` as Reset.
+
+**Why:** Today's Reset 409s on non-tailored; forcing profile users through a tailored id
+is wrong. Alternatives: reset "most recent tailored" (surprising); no profile prompt
+(leaves base stale).
+
+### D3 — Prompt copy
+
+Align with ArtifactPanel Reset: content from current seed (bank + résumé); layout/template
+kept; History can undo on tailored. Profile copy: "Update your base CV from your experience
+bank?" without claiming every tailored job CV was updated.
+
+### D4 — Nag control
+
+Prefer sessionStorage (or in-memory on the page) dismiss after "No" for the rest of the
+tab session so rapid successive atom edits are not a confirm storm. "Yes" always allowed
+again after another mutation if desired; or suppress until next navigation — pick
+session dismiss after No in implementation.
+
+### D5 — Where the hook lives
+
+Shared helper used by both hosts after bank success callbacks, so profile and tailor cannot
+drift. Prefer not burying HTTP inside `ExperienceBankView` without a host-supplied
+`onRefreshOffer` — host knows whether a tailored id or base reseed applies.
+
+## Risks / Trade-offs
+
+- **[Risk] Confirm storm on bulk atom edits** → Mitigation: session dismiss after No;
+  optionally debounce offer to once per burst.
+- **[Risk] Candidate thinks profile Skills were applied to the CV** → Mitigation: do not
+  prompt on Skills tab; copy names experience bank / résumé seed.
+- **[Risk] Base reseed without tailored context surprises later tailor opens** → Mitigation:
+  intended; next tailor bootstrap copies from refreshed base when minting new vacancies;
+  existing tailored rows still need their own Reset (out of scope to fan-out).
+- **[Risk] Reset is destructive on tailored** → Mitigation: same confirm gravity as History
+  Reset; revision history remains.
+
+## Migration Plan
+
+Ship web prompt + optional base endpoint together. Rollback: remove prompt; leave Reset as
+manual. No schema migration.
+
+## Open Questions
+
+None for planning — Skills-tab prompt deferred; multi-tailored fan-out deferred.

--- a/openspec/changes/profile-cv-refresh-prompt/proposal.md
+++ b/openspec/changes/profile-cv-refresh-prompt/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Editing the experience bank (on profile or in the tailor workspace) updates the seed
+source of truth but leaves open base and tailored CVs unchanged until the candidate
+explicitly hits Reset from résumé. That disconnect is easy to miss: they just added a
+role or achievement and the CV they are looking at still shows the old content. After a
+successful bank edit, the product should ask whether to refresh the CV from the current
+seed, and only rewrite when they agree.
+
+## What Changes
+
+- After a successful experience-bank mutation (create/update/delete of an employment or
+  atom, including merges), the web UI SHALL offer a confirm prompt to refresh CV content
+  from the current seed.
+- **On the tailor workspace:** if they agree, call the existing
+  `POST /api/v1/me/cvs/:id/reset-from-resume` for the open tailored CV (same path as
+  History → Reset Changes).
+- **On `/my/profile` (Experience tab):** if they agree, refresh the base CV from the
+  current seed. Expose a cookie-only base reseed endpoint if Reset remains tailored-only
+  (today base refresh is only a side effect of tailored reset).
+- Dismiss / decline MUST leave documents untouched (no silent rewrite).
+- Session-scoped dismiss so repeated edits in one sitting are not nagged after a "No"
+  (optional but preferred).
+- **Out of scope this change:** profile Skills tab / `userprofile.skills` edits (those
+  feed search/match, not the CV document); auto-rewriting every tailored copy for every
+  job; inventing a second apply path besides seed → Reset/reseed.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `experience-bank`: after a successful bank mutation in the web UI, the product SHALL
+  offer to refresh CV content from the seed when the candidate agrees.
+- `cv-tailoring`: agreeing to refresh from a tailor context SHALL run reset-from-résumé
+  on the open tailored CV; agreeing from profile SHALL reseed the base CV from the same
+  seed composition Reset uses.
+
+## Impact
+
+- Web: `ExperienceBankView` (and/or its callers on `/my/profile` and `/tailor/[slug]`),
+  confirm UX aligned with existing Reset copy.
+- Go (if needed): thin `POST` to reseed base only when profile agrees and no tailored
+  context exists — reuses `reseedBaseFromSeed` / `applySeedContent`.
+- No change to bank write APIs themselves; prompt is client-orchestrated after success.
+- Respects `reset-preserve-seed-sections` keep-if-empty behaviour on reset/reseed.

--- a/openspec/changes/profile-cv-refresh-prompt/specs/cv-tailoring/spec.md
+++ b/openspec/changes/profile-cv-refresh-prompt/specs/cv-tailoring/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Refresh from tailor context uses reset-from-résumé
+
+When the candidate agrees to refresh CV content after a bank edit while a tailored CV is
+open in the tailor workspace, the system SHALL apply the same reset-from-résumé operation
+already used by History → Reset Changes for that CV id (including base refresh as a side
+effect of that endpoint, keep-if-empty summary/skills rules, and vacancy surface-align on
+the tailored copy). The system MUST NOT introduce a separate silent rewrite path.
+
+#### Scenario: Agreeing on tailor calls reset for the open CV
+
+- **WHEN** the tailor workspace has an open tailored CV and the candidate agrees to refresh
+  after a bank edit
+- **THEN** `POST /api/v1/me/cvs/:id/reset-from-resume` runs for that id and the stored
+  document reflects the current seed
+
+### Requirement: Profile refresh reseeds the base CV with consent
+
+When the candidate agrees to refresh from the profile Experience tab, the system SHALL
+reseed the owner's base CV from the current seed composition (bank + current structured
+résumé rules), preserving presentation. If the owner has no base CV, the system MAY create
+one from the seed. The system MUST NOT require opening a tailored CV solely to refresh the
+base.
+
+#### Scenario: Base reseed endpoint (or equivalent) updates the base
+
+- **WHEN** the owner confirms refresh on profile and a base CV exists
+- **THEN** the base document body matches the current seed (with keep-if-empty for empty
+  seed summary/skills) and title/template/margins/style are unchanged

--- a/openspec/changes/profile-cv-refresh-prompt/specs/experience-bank/spec.md
+++ b/openspec/changes/profile-cv-refresh-prompt/specs/experience-bank/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Bank edits offer a CV refresh with consent
+
+After a successful experience-bank mutation in the web UI (create, update, or delete of an
+employment or evidence atom, including merges), the product SHALL prompt the candidate to
+refresh CV content from the current seed. The prompt SHALL make clear that agreeing
+rebuilds CV body content from the experience bank and current résumé seed (same meaning as
+Reset from résumé). Declining or dismissing the prompt MUST leave every CV document
+unchanged. The system MUST NOT rewrite a CV solely because the bank changed.
+
+#### Scenario: Tailor workspace — agree refreshes the open tailored CV
+
+- **WHEN** the candidate successfully adds or updates banked experience while the tailor
+  workspace is open on a tailored CV, and they confirm the refresh prompt
+- **THEN** the open tailored CV is reset from the current seed (existing reset-from-résumé
+  behaviour) and the workspace shows the updated document
+
+#### Scenario: Tailor workspace — decline leaves the CV alone
+
+- **WHEN** the candidate successfully edits the bank on the tailor workspace and declines
+  the refresh prompt
+- **THEN** the open tailored CV is unchanged
+
+#### Scenario: Profile experience — agree reseeds the base CV
+
+- **WHEN** the candidate successfully edits the bank on the profile Experience tab, they
+  have a base CV, and they confirm the refresh prompt
+- **THEN** the base CV body is rebuilt from the current seed and presentation (title,
+  template, margins, style) is preserved
+
+#### Scenario: No silent multi-job rewrite
+
+- **WHEN** the candidate confirms a refresh from the profile Experience tab
+- **THEN** tailored copies for other vacancies are not rewritten as part of that single
+  confirmation (only the base CV is refreshed from profile context)

--- a/openspec/changes/profile-cv-refresh-prompt/tasks.md
+++ b/openspec/changes/profile-cv-refresh-prompt/tasks.md
@@ -1,0 +1,16 @@
+## 1. Base reseed API
+
+- [x] 1.1 Add cookie-only `POST /api/v1/me/cvs/base/reset-from-resume` (or equivalent) that reseeds/creates the base CV from `seedSource()` via existing `reseedBaseFromSeed` / `applySeedContent`; 409 when seed unusable
+- [x] 1.2 Integration tests: happy path preserves presentation and applies bank experience; 409 with no usable seed; foreign/unauth unchanged
+
+## 2. Web prompt after bank edits
+
+- [x] 2.1 After a successful bank mutation, offer a confirm to refresh CV content (copy aligned with Reset); decline is a no-op; session dismiss after No to avoid confirm storms
+- [x] 2.2 Tailor host: on agree, call existing `resetCvFromResume` for the open tailored CV and refresh workspace document state
+- [x] 2.3 Profile Experience host: on agree, call the base reseed endpoint and refresh displayed base/profile CV state as applicable
+- [x] 2.4 Do not prompt from the Skills tab or other non-bank profile edits
+
+## 3. Guardrails
+
+- [x] 3.1 Handler integration tests + web unit/component coverage for the offer/decline paths where the repo already tests similar UI
+- [x] 3.2 `go vet -tags=integration ./...` for Go changes; run the web checks this package normally uses for touched files

--- a/openspec/changes/reset-preserve-seed-sections/.openspec.yaml
+++ b/openspec/changes/reset-preserve-seed-sections/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/reset-preserve-seed-sections/design.md
+++ b/openspec/changes/reset-preserve-seed-sections/design.md
@@ -1,0 +1,86 @@
+## Context
+
+See proposal.md — Why. Reset today builds a seed via `StructureForSeed` + bank overlay,
+then `applySeedContent` whole-document-replaces the body while only merging header
+contacts keep-if-empty. Provisional/stale stamps strip summary/skills from the seed
+(`provisionalContacts`) by design (`cv-provisional-header-seed`). Bank experience alone
+makes `hasSeedBody` true, so reset runs and blanks those sections on the page.
+
+A current extract that includes summary/skills already maps through `cv.Seed` into
+`applySeedContent`; that path needs a hard regression test. Keep-if-empty for empty seed
+sections covers pending extract and extracts that simply omit skills/summary without
+resurrecting superseded blob text.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep prior tailored (and base) summary/skills when the seed leaves them empty.
+- Ensure non-empty seed summary/skills always replace on reset.
+- Preserve the provisional rule: superseded blob semantics never enter the seed.
+
+**Non-Goals:**
+
+- Feeding last-blob summary/skills into `StructureForSeed` while pending (explicitly
+  rejected by `cv-provisional-header-seed`).
+- Deriving CV skills from the experience bank or profile on reset.
+- Changing first-time tailor mint beyond the shared apply helper.
+- Extending keep-if-empty to education/languages/certs in this change (skills + summary
+  only; note the seam if the same wipe shows up there).
+- Surface-align behaviour (unchanged; still runs on the tailored seed after merge).
+
+## Decisions
+
+### D1 — Merge in `applySeedContent`, not in `StructureForSeed`
+
+Keep-if-empty for summary and skills lives next to `mergeSeedHeader`: after taking the
+seeded document as the body default, if `seeded.Summary == ""` keep `keep.Summary`; if
+`len(seeded.Skills) == 0` keep `keep.Skills`.
+
+**Why:** Seed composition stays honest (provisional = no semantic body). The CV row is
+what the candidate sees; blanking it is the bug. Alternatives considered: refuse reset
+until stamp is current (breaks provisional+bank flows that already ship); seed last-blob
+semantics while pending (rejected earlier).
+
+### D2 — Seed wins when non-empty
+
+Non-empty seed summary/skills always replace. No three-way merge with "prefer longer".
+
+### D3 — Same helper for tailored reset and base reseed
+
+Both call `applySeedContent`, so both get the rule. Base must not receive JD-aligned
+wording (existing align-only-on-tailored split stays).
+
+### D4 — Update the provisional integration expectation
+
+`TestResetCVFromResume_ProvisionalContactsPlusBankSucceeds` (or equivalent) today asserts
+summary stays empty after reset. Change it to seed a tailored CV that already has
+summary/skills and assert they survive; still assert the seed composition did not carry
+superseded summary into `StructureForSeed`.
+
+### D5 — Case 2 regression
+
+Add an integration test: current stamp + extract with skills/summary → reset → document
+carries them (and surface-align may rewrite chip wording on the tailored copy only).
+
+## Risks / Trade-offs
+
+- **[Risk] Candidate thinks reset "restored" résumé skills that were never re-extracted** →
+  Mitigation: only keep what was already on the CV; UI copy can stay "from résumé" for
+  experience; skills/summary persistence is continuity, not a claim that extract finished.
+- **[Risk] Stale skills linger after a real résumé that legitimately dropped them** →
+  Mitigation: once extract is current with an explicit empty skills list, seed skills are
+  empty and keep-if-empty retains prior chips — same as today for an extract that omits
+  skills. If product later needs "empty extract means clear skills", that is a separate
+  change (would need a presence signal, not just emptiness).
+- **[Risk] Education/languages still wipe under provisional** → Mitigation: out of scope;
+  same pattern if reported.
+
+## Migration Plan
+
+Deploy with the handler change; no schema migration. Rollback: revert `applySeedContent`
+merge; provisional tests flip back.
+
+## Open Questions
+
+None — skills + summary only was chosen from the reporter's cases; other sections deferred.

--- a/openspec/changes/reset-preserve-seed-sections/proposal.md
+++ b/openspec/changes/reset-preserve-seed-sections/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Reset-from-résumé can leave a tailored CV without skills or summary even when the
+candidate already had them on the page, or when a current structured extract carries
+them. During a pending/stale extract the seed is identity-only for those sections while
+the experience bank still supplies roles, so reset proceeds and whole-document replace
+blanks skills and summary. That feels like data loss. Separately, a current extract that
+does include skills/summary must land them after reset — that path needs an explicit
+regression so it cannot silently regress.
+
+## What Changes
+
+- On reset-from-résumé (tailored copy and base refresh), when the seed has **empty**
+  summary or skills, **keep** the document's existing summary/skills instead of blanking
+  them (same keep-if-empty idea as header contacts).
+- When the seed has **non-empty** summary or skills (current structured extract), those
+  values **replace** the document's — seed wins; no stale-blob leak.
+- **Do not** feed superseded structured summary/skills into the seed while the stamp is
+  pending (existing provisional rule stays).
+- Add regression coverage: (a) provisional + bank experience preserves prior skills/summary
+  on the tailored CV; (b) current extract with skills/summary writes them after reset.
+- Update the provisional-reset expectation that today asserts summary must be empty after
+  reset when experience came from the bank alone.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `cv-tailoring`: reset-from-résumé must not blank skills/summary when the seed omits them;
+  must apply them when the current extract provides them. Superseded structured summary/skills
+  still MUST NOT enter the seed while the stamp is pending.
+
+## Impact
+
+- `internal/handler` — `applySeedContent` / reset path (and shared base reseed).
+- Integration tests in `cv_reset_integration_test.go` (including the provisional+bank case).
+- No API shape change; no change to first-time tailor mint beyond shared apply helper if used.
+- No change to `jd-surface-align` preferred-surface rewrite (still runs on the tailored seed
+  body after merge).

--- a/openspec/changes/reset-preserve-seed-sections/specs/cv-tailoring/spec.md
+++ b/openspec/changes/reset-preserve-seed-sections/specs/cv-tailoring/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Reset preserves skills and summary when the seed omits them
+
+When the owner resets a tailored CV from the résumé seed, the system SHALL apply
+seeded body content to the tailored document (and to the base refresh that shares the
+same apply path). When the composed seed's summary is empty, the system SHALL keep the
+document's existing summary. When the composed seed's skills section is empty, the
+system SHALL keep the document's existing skills. The system MUST NOT copy superseded
+structured summary or skills into the seed while the structured stamp is pending or
+stale — keep-if-empty applies only to what is already stored on the CV.
+
+#### Scenario: Pending extract with bank experience keeps prior skills and summary
+
+- **WHEN** the structured stamp is not current (provisional contacts only), the experience
+  bank has roles so reset is allowed, and the tailored CV already has a summary and skills
+- **THEN** after reset the tailored CV still has that summary and those skills, and the
+  experience sections reflect the bank seed
+
+#### Scenario: Empty seed skills do not wipe tailored skills
+
+- **WHEN** a current structured extract has no skills list but the tailored CV has skill chips
+- **THEN** after reset the tailored CV's skill chips remain
+
+### Requirement: Reset applies current extract skills and summary
+
+When the composed seed carries a non-empty summary or skills (from a current structured
+résumé), reset-from-résumé SHALL write those values onto the tailored document, replacing
+whatever summary or skills were there. Seed wins when present.
+
+#### Scenario: Current extract lands skills and summary on reset
+
+- **WHEN** the structured stamp is current, the extract includes a summary and skills, and
+  the owner resets a tailored CV
+- **THEN** the stored tailored document's summary and skills match the seed (after any
+  vacancy surface-align on the tailored copy alone)

--- a/openspec/changes/reset-preserve-seed-sections/tasks.md
+++ b/openspec/changes/reset-preserve-seed-sections/tasks.md
@@ -1,0 +1,14 @@
+## 1. applySeedContent keep-if-empty
+
+- [x] 1.1 In `applySeedContent`, when seeded summary is empty keep the prior document summary; when seeded skills are empty keep the prior skills; non-empty seed still replaces
+- [x] 1.2 Unit tests: empty seed preserves keep summary/skills; non-empty seed overwrites; header/margins/style behaviour unchanged
+
+## 2. Reset integration coverage
+
+- [x] 2.1 Update provisional+bank reset test: tailored CV starts with summary/skills; after reset they remain; experience still comes from the bank; seed composition still has no superseded summary
+- [x] 2.2 Integration test: current stamp + extract with summary and skills → reset → tailored document carries them (surface-align may rewrite chip wording only on the tailored copy)
+- [x] 2.3 Confirm base reseed via the same helper keeps base skills/summary when seed omits them (assertion in an existing or new reset test)
+
+## 3. Guardrails
+
+- [x] 3.1 `go test` for `./internal/handler/` unit tests covering applySeedContent; `go test -tags=integration` for the reset cases; `go vet -tags=integration ./...`

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1710,6 +1710,12 @@ export function createApi(
     );
   }
 
+  /** Rebuild the base CV from the current résumé seed. Cookie-only. Does not touch
+   *  tailored copies. 409 when there is nothing to seed from. */
+  async function resetBaseCvFromResume(): Promise<CvRecord> {
+    return requestData<CvRecord>('/api/v1/me/cvs/base/reset-from-resume', jsonBody('POST', {}));
+  }
+
   async function getCvAtsDelta(id: string): Promise<CvAtsDelta> {
     return requestData<CvAtsDelta>(`/api/v1/me/cvs/${id}/ats-delta`);
   }
@@ -2020,6 +2026,7 @@ export function createApi(
     undoCvRevision,
     undoCvRevisionRun,
     resetCvFromResume,
+    resetBaseCvFromResume,
     tailorCv,
     startTailorSession,
     resolveJd,

--- a/web/src/lib/components/ExperienceBankView.svelte
+++ b/web/src/lib/components/ExperienceBankView.svelte
@@ -15,6 +15,10 @@
   import { profileKickoff } from '$lib/assistant/presets';
   import type { ExperienceAtom, ExperienceBank, ExperienceEmployment, ExperienceProvenance } from '$lib/types';
 
+  /** Host-supplied: profile reseeds the base CV, tailor resets the open tailored copy.
+   *  The bank itself never talks to the CV store. */
+  let { onBankMutated }: { onBankMutated?: () => void } = $props();
+
   let bank = $state<ExperienceBank | null>(null);
   let loading = $state(true);
   let error = $state('');
@@ -179,6 +183,7 @@
       await api.updateExperienceEmployment(employment.id, body);
       editingEmploymentId = null;
       await load();
+      onBankMutated?.();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Could not update.';
     } finally {
@@ -203,6 +208,7 @@
       projStart = '';
       projEnd = '';
       await load();
+      onBankMutated?.();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Could not create project.';
     } finally {
@@ -238,6 +244,7 @@
       promoteName = '';
       promoteLink = '';
       await load();
+      onBankMutated?.();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Could not save as project.';
     } finally {
@@ -269,6 +276,7 @@
       });
       editing = null;
       await load();
+      onBankMutated?.();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Could not save that change.';
     } finally {
@@ -292,6 +300,7 @@
     try {
       await api.mergeExperienceAtoms([selected[0]!, selected[1]!]);
       await load();
+      onBankMutated?.();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Could not merge those achievements.';
     } finally {
@@ -313,6 +322,7 @@
         employment_id: atom.employment_id,
       });
       await load();
+      onBankMutated?.();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Could not confirm that achievement.';
     } finally {
@@ -327,6 +337,7 @@
     try {
       await api.deleteExperienceAtom(atom.id);
       await load();
+      onBankMutated?.();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Could not remove that achievement.';
     } finally {

--- a/web/src/lib/cvRefreshOffer.test.ts
+++ b/web/src/lib/cvRefreshOffer.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  BASE_REFRESH_MESSAGE,
+  CV_REFRESH_DISMISSED_KEY,
+  TAILOR_REFRESH_MESSAGE,
+  dismissCvRefreshOffer,
+  isCvRefreshDismissed,
+  offerCvRefresh,
+} from './cvRefreshOffer';
+
+function memStorage(initial: Record<string, string> = {}): Storage {
+  const data = { ...initial };
+  return {
+    get length() {
+      return Object.keys(data).length;
+    },
+    clear() {
+      for (const k of Object.keys(data)) delete data[k];
+    },
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(data, key) ? data[key]! : null;
+    },
+    key() {
+      return null;
+    },
+    removeItem(key: string) {
+      delete data[key];
+    },
+    setItem(key: string, value: string) {
+      data[key] = value;
+    },
+  };
+}
+
+afterEach(() => {
+  if (typeof sessionStorage !== 'undefined') sessionStorage.clear();
+});
+
+describe('isCvRefreshDismissed', () => {
+  it('is false until the candidate declines', () => {
+    expect(isCvRefreshDismissed(memStorage())).toBe(false);
+  });
+
+  it('is true after dismiss', () => {
+    const s = memStorage();
+    dismissCvRefreshOffer(s);
+    expect(isCvRefreshDismissed(s)).toBe(true);
+    expect(s.getItem(CV_REFRESH_DISMISSED_KEY)).toBe('1');
+  });
+});
+
+describe('offerCvRefresh', () => {
+  it('applies when the candidate agrees and does not dismiss', async () => {
+    const applied: string[] = [];
+    const result = await offerCvRefresh({
+      message: TAILOR_REFRESH_MESSAGE,
+      confirm: () => true,
+      dismissed: false,
+      apply: async () => {
+        applied.push('yes');
+      },
+    });
+    expect(result).toBe('applied');
+    expect(applied).toEqual(['yes']);
+  });
+
+  it('declines without applying and records dismiss', async () => {
+    const s = memStorage();
+    const applied: string[] = [];
+    const result = await offerCvRefresh({
+      message: BASE_REFRESH_MESSAGE,
+      confirm: () => false,
+      dismissed: false,
+      onDismiss: () => dismissCvRefreshOffer(s),
+      apply: async () => {
+        applied.push('yes');
+      },
+    });
+    expect(result).toBe('declined');
+    expect(applied).toEqual([]);
+    expect(isCvRefreshDismissed(s)).toBe(true);
+  });
+
+  it('skips confirm and apply when already dismissed this session', async () => {
+    let asked = false;
+    const result = await offerCvRefresh({
+      message: TAILOR_REFRESH_MESSAGE,
+      confirm: () => {
+        asked = true;
+        return true;
+      },
+      dismissed: true,
+      apply: async () => {
+        throw new Error('must not apply');
+      },
+    });
+    expect(result).toBe('skipped');
+    expect(asked).toBe(false);
+  });
+});

--- a/web/src/lib/cvRefreshOffer.ts
+++ b/web/src/lib/cvRefreshOffer.ts
@@ -1,0 +1,52 @@
+/** Session-scoped dismiss after the candidate declines a CV refresh offer so a burst
+ *  of bank edits does not become a confirm storm. Survives in-page mutations; clears
+ *  when the tab closes. */
+export const CV_REFRESH_DISMISSED_KEY = 'fh.cv-refresh-offer.dismissed';
+
+export const TAILOR_REFRESH_MESSAGE =
+  'Update this tailored CV from your experience bank and résumé? Template and typography stay; content edits can be undone from History.';
+
+export const BASE_REFRESH_MESSAGE =
+  'Update your base CV from your experience bank and résumé? Template and typography stay. Tailored copies for specific jobs are not changed.';
+
+export function isCvRefreshDismissed(storage: Pick<Storage, 'getItem'> | null = defaultSession()): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(CV_REFRESH_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function dismissCvRefreshOffer(storage: Pick<Storage, 'setItem'> | null = defaultSession()): void {
+  if (!storage) return;
+  try {
+    storage.setItem(CV_REFRESH_DISMISSED_KEY, '1');
+  } catch {
+    // private mode / blocked storage — treat as in-memory only (next call may re-ask)
+  }
+}
+
+function defaultSession(): Storage | null {
+  if (typeof sessionStorage === 'undefined') return null;
+  return sessionStorage;
+}
+
+/** Ask whether to rebuild a CV from the current seed after a bank edit.
+ *  Decline is a no-op on the document and dismisses further offers this tab session. */
+export async function offerCvRefresh(opts: {
+  message: string;
+  apply: () => Promise<void>;
+  confirm?: (message: string) => boolean;
+  dismissed?: boolean;
+  onDismiss?: () => void;
+}): Promise<'applied' | 'declined' | 'skipped'> {
+  if (opts.dismissed ?? isCvRefreshDismissed()) return 'skipped';
+  const ok = (opts.confirm ?? ((m) => window.confirm(m)))(opts.message);
+  if (!ok) {
+    (opts.onDismiss ?? dismissCvRefreshOffer)();
+    return 'declined';
+  }
+  await opts.apply();
+  return 'applied';
+}

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -2338,6 +2338,19 @@ ${BASE_URL}/auth/oauth/google/start`,
       },
       {
         method: 'POST',
+        path: '/me/cvs/base/reset-from-resume',
+        auth: 'cookie',
+        summary: 'Rebuild your base CV from your résumé.',
+        description:
+          'Replaces the base (non-tailored) document from the current résumé seed ' +
+          '(experience bank + structured extract). Preserves template and typography. ' +
+          'Does not rewrite tailored copies for specific jobs. 409 when there is no ' +
+          'usable résumé seed.',
+        curl: `curl -X POST "${BASE_URL}/me/cvs/base/reset-from-resume" -b cookies.txt`,
+        responseExample: `{ "data": { "id": "0f2c…", "title": "My CV", "template_id": "classic-ats", "document": { … } } }`,
+      },
+      {
+        method: 'POST',
         path: '/me/cvs/{id}/reset-from-resume',
         auth: 'cookie',
         summary: 'Rebuild this tailored CV from your résumé.',

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -4,6 +4,7 @@
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { api } from '$lib/api';
+  import { BASE_REFRESH_MESSAGE, offerCvRefresh } from '$lib/cvRefreshOffer';
   import { currentUser, isAuthenticated } from '$lib/auth.svelte';
   import { FilterStore, filtersToParams } from '$lib/filters';
   import ATSReportView from '$lib/components/ATSReportView.svelte';
@@ -230,6 +231,19 @@
     void loadStructured();
   }
 
+  function offerRefreshAfterBankEdit() {
+    void offerCvRefresh({
+      message: BASE_REFRESH_MESSAGE,
+      apply: async () => {
+        try {
+          await api.resetBaseCvFromResume();
+        } catch {
+          actionError = 'Could not update your base CV. Try Reset from résumé in a tailoring workspace.';
+        }
+      },
+    });
+  }
+
   // Link a gap skill to the job search under the current comparison role plus that skill.
   function gapHref(skill: string): string {
     // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient: builds an href string once, never stored as reactive state
@@ -347,7 +361,7 @@
         {#if tab === 'experience'}
           <!-- What the product has recorded about what this person has done, and the only
                place they can correct or remove it. -->
-          <ExperienceBankView />
+          <ExperienceBankView onBankMutated={offerRefreshAfterBankEdit} />
         {:else if tab === 'settings'}
           {#key profile.updated_at}
             <ProfileForm {profile} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -15,6 +15,7 @@
   import { page } from '$app/state';
   import { ZoomIn, ZoomOut, Download, Menu, PanelLeftClose, PanelLeftOpen, Terminal } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
+  import { offerCvRefresh, TAILOR_REFRESH_MESSAGE } from '$lib/cvRefreshOffer';
   import { track } from '$lib/analytics';
   import AssistantChat from '$lib/assistant/AssistantChat.svelte';
   import ArtifactPanel from '$lib/tailor/ArtifactPanel.svelte';
@@ -356,14 +357,7 @@
   let resetBusy = $state(false);
   let resetError = $state('');
 
-  async function resetFromResume() {
-    if (
-      !window.confirm(
-        'Reset this tailored CV from your current uploaded résumé? Your template and typography stay; content edits can be undone from History.',
-      )
-    ) {
-      return;
-    }
+  async function applyResetFromResume() {
     resetBusy = true;
     resetError = '';
     try {
@@ -385,6 +379,24 @@
     } finally {
       resetBusy = false;
     }
+  }
+
+  async function resetFromResume() {
+    if (
+      !window.confirm(
+        'Reset this tailored CV from your current uploaded résumé? Your template and typography stay; content edits can be undone from History.',
+      )
+    ) {
+      return;
+    }
+    await applyResetFromResume();
+  }
+
+  function offerRefreshAfterBankEdit() {
+    void offerCvRefresh({
+      message: TAILOR_REFRESH_MESSAGE,
+      apply: applyResetFromResume,
+    });
   }
 
   // ---- Autosave (folded in from the old standalone CvEditor) ----
@@ -629,7 +641,7 @@
                checking, confirming, or editing what the assistant knows never means leaving the
                workspace. -->
           <div class="h-full overflow-auto p-4" class:hidden={leftTab !== 'experience'}>
-            <ExperienceBankView />
+            <ExperienceBankView onBankMutated={offerRefreshAfterBankEdit} />
           </div>
           <!-- Presentation, in two blocks of label→control rows. Both write straight into the
                shared document, so the centre preview re-renders live and autosave persists them


### PR DESCRIPTION
## Summary
- Rewrite skill chips and safe prose to the vacancy’s preferred aliases before the tailor model runs (JD surface-align prepass).
- Keep existing skills/summary on reset when a pending seed omits them, instead of wiping those sections.
- After experience-bank edits, offer a consent prompt to refresh the profile CV seed.

## Test plan
- [ ] Start tailor on a job whose JD uses different skill aliases than the CV — chips/prose match the vacancy wording before the model runs
- [ ] Reset a tailored CV that already has skills/summary while extract is pending/empty — those sections stay
- [ ] Reset when the seed actually has new skills/summary — they still replace
- [ ] Edit experience/skills on Profile — prompt to refresh CV data; agreeing updates it, dismissing does not
- [ ] Unit tests: `go test ./internal/cv/ ./internal/skilltag/ ./internal/handler/`
- [ ] Integration (when behaviour is checked): `go test -tags=integration ./internal/handler/ -run 'Reset|Tailor|Autopilot'`