### PR TITLE
feat(extension): add job link and Tailor CV button to match card

### DIFF
--- a/extension/entrypoints/sidepanel/MatchCard.svelte
+++ b/extension/entrypoints/sidepanel/MatchCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Card } from 'freehire-design-system';
+  import { Button, Card } from 'freehire-design-system';
+  import { HIRE_ORIGIN } from '../../lib/auth';
   import { companyLogoUrl, type FreehireJob, type JobMatch } from '../../lib/freehire';
 
   let { job, match }: { job: FreehireJob; match: JobMatch } = $props();
@@ -9,10 +10,12 @@
   let logoUrl = $derived(companyLogoUrl(job.company));
   let monogram = $derived((job.company || job.title || '?').trim().charAt(0).toUpperCase());
   let logoFailed = $state(false);
+  let jobUrl = $derived(`${HIRE_ORIGIN}/jobs/${encodeURIComponent(job.public_slug)}`);
+  let tailorUrl = $derived(`${HIRE_ORIGIN}/tailor/${encodeURIComponent(job.public_slug)}`);
 </script>
 
 <Card class="card">
-  <div class="job">
+  <a class="job" href={jobUrl} target="_blank" rel="noreferrer">
     {#key job.company}
       <div class="logo">
         {#if logoUrl && !logoFailed}
@@ -26,7 +29,7 @@
       {#if job.company}<div class="company">{job.company}</div>{/if}
       <div class="title">{job.title}</div>
     </div>
-  </div>
+  </a>
 
   <div class="mrow">
     <span class="label">Profile match</span>
@@ -51,6 +54,17 @@
       </div>
     </div>
   {/if}
+
+  <Button
+    class="tailor"
+    variant="primary"
+    size="sm"
+    href={tailorUrl}
+    target="_blank"
+    rel="noreferrer"
+  >
+    Tailor CV
+  </Button>
 </Card>
 
 <style>
@@ -63,6 +77,8 @@
     align-items: center;
     gap: 10px;
     margin-bottom: 12px;
+    text-decoration: none;
+    color: inherit;
   }
   .logo {
     flex: none;
@@ -197,5 +213,9 @@
   .none {
     font-size: 12px;
     color: var(--muted-foreground);
+  }
+  :global(.tailor) {
+    width: 100%;
+    margin-top: 14px;
   }
 </style>


### PR DESCRIPTION
## Summary
- Job title/company header on the match card now links out to the job's freehire listing (`/jobs/<slug>`) in a new tab.
- Adds a full-width "Tailor CV" button at the bottom of the card that opens `/tailor/<slug>` in a new tab.

## Test plan
- [ ] Load the side panel on a job page with a match card, confirm clicking the header opens the job page on freehire.me
- [ ] Confirm "Tailor CV" opens the tailor flow for that job