### PR TITLE
fix(cv): stop JD wording alignment from fabricating skills and corrupting text

### DIFF
--- a/internal/assistant/prompt.go
+++ b/internal/assistant/prompt.go
@@ -120,7 +120,7 @@ After that opening, the playbook above applies as written.
 // anything they have not.
 const tailorPrompt = `You are the freehire CV-tailoring assistant. You are working with one signed-in candidate on ONE tailored copy of their CV, aimed at one vacancy. The tools you have act on that copy only, and they neither read nor write the candidate's contact block — their name, email, phone and personal links are stripped from what ` + "`cv_get`" + ` returns and cannot be patched.
 
-Skill wording on this CV is already aligned to the vacancy's own spellings (for example IaC ↔ infrastructure as code). Do NOT rename skills for wording — spend your edits on evidence and substance.
+Matching the vacancy's spelling of a skill (for example IaC ↔ infrastructure as code) is handled outside this conversation. Do NOT spend an edit renaming a skill for wording — spend your edits on evidence and substance.
 
 Start by calling ` + "`cv_context`" + ` (the fit analysis for this vacancy) and ` + "`cv_get`" + ` (what the CV currently says).
 

--- a/internal/assistant/prompt_test.go
+++ b/internal/assistant/prompt_test.go
@@ -18,15 +18,20 @@ func TestEachPresetHasItsOwnPrompt(t *testing.T) {
 	}
 }
 
-// Surfaces are aligned before the first model turn. Without this sentence the agent
-// rediscovers IaC ↔ infrastructure as code and burns the turn on wording.
-func TestTailorPromptSaysSurfacesAreAlreadyAligned(t *testing.T) {
+// Wording is handled outside the conversation. Without this sentence the agent rediscovers
+// IaC ↔ infrastructure as code and burns the turn on it. The sentence must not claim the
+// alignment already ran: a tailored copy minted before the prepass existed, or one for a
+// vacancy that names no interchangeable skill, reaches this prompt unaligned.
+func TestTailorPromptTellsTheAgentNotToSpendEditsOnWording(t *testing.T) {
 	p := SystemPrompt(PresetTailor)
-	if !strings.Contains(p, "already aligned") {
-		t.Error("tailor prompt never says skill surfaces are already aligned")
+	if !strings.Contains(p, "handled outside this conversation") {
+		t.Error("tailor prompt never says skill wording is handled elsewhere")
 	}
-	if !strings.Contains(p, "Do NOT rename skills for wording") {
-		t.Error("tailor prompt never tells the agent not to rename skills for wording")
+	if !strings.Contains(p, "Do NOT spend an edit renaming a skill for wording") {
+		t.Error("tailor prompt never tells the agent not to spend edits on wording")
+	}
+	if strings.Contains(p, "already aligned") {
+		t.Error("tailor prompt asserts the CV is already aligned, which is not true on every path")
 	}
 }
 

--- a/internal/cv/align.go
+++ b/internal/cv/align.go
@@ -1,6 +1,8 @@
 package cv
 
 import (
+	"cmp"
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -8,41 +10,37 @@ import (
 	"github.com/strelov1/freehire/internal/skilltag"
 )
 
-// Align rewrites doc so skill wording matches preferred surfaces (canonical →
-// JD spelling from skilltag.PreferredFromText). Skills chips and experience
-// stacks accept any alias; summary and bullets only unambiguous aliases. Same-
-// canonical duplicate chips are collapsed. Pure and deterministic; no LLM.
-// The input is not mutated — a rewritten copy is returned. preferred may be nil.
-func Align(doc Document, preferred map[string]string) Document {
+// Align rewrites doc so skill wording matches the spellings the vacancy used (canonical →
+// spelling, from skilltag.PreferredFromText) and reports whether anything changed. Skill
+// chips and experience stacks are matched through the full alias tables; summary and
+// bullet prose only through spellings that cannot be ordinary English. Same-skill
+// duplicates the rewrite creates are collapsed. Pure, deterministic and idempotent; no
+// LLM. The input is not mutated — a rewritten copy is returned. preferred may be nil.
+func Align(doc Document, preferred map[string]string) (Document, bool) {
 	if len(preferred) == 0 {
-		return doc
+		return doc, false
 	}
+	rules := proseRules(preferred)
 	out := doc
 	out.Skills = alignSkillGroups(doc.Skills, preferred)
-	out.Summary = replaceProse(doc.Summary, preferred)
+	out.Summary = replaceProse(doc.Summary, rules)
 	if len(doc.Experience) > 0 {
 		out.Experience = make([]ExperienceItem, len(doc.Experience))
 		copy(out.Experience, doc.Experience)
 		for i := range out.Experience {
-			out.Experience[i].Stack = alignChipList(doc.Experience[i].Stack, preferred)
-			out.Experience[i].Summary = replaceProse(doc.Experience[i].Summary, preferred)
-			out.Experience[i].Bullets = alignProseList(doc.Experience[i].Bullets, preferred)
+			out.Experience[i].Stack = alignChips(doc.Experience[i].Stack, preferred)
+			out.Experience[i].Summary = replaceProse(doc.Experience[i].Summary, rules)
+			out.Experience[i].Bullets = alignProseList(doc.Experience[i].Bullets, rules)
 		}
 	}
 	if len(doc.Projects) > 0 {
 		out.Projects = make([]Project, len(doc.Projects))
 		copy(out.Projects, doc.Projects)
 		for i := range out.Projects {
-			out.Projects[i].Bullets = alignProseList(doc.Projects[i].Bullets, preferred)
+			out.Projects[i].Bullets = alignProseList(doc.Projects[i].Bullets, rules)
 		}
 	}
-	return out
-}
-
-// AlignChanged reports whether Align would change doc for the given preferred map.
-func AlignChanged(doc Document, preferred map[string]string) bool {
-	aligned := Align(doc, preferred)
-	return !documentsEqualForAlign(doc, aligned)
+	return out, !documentsEqualForAlign(doc, out)
 }
 
 func alignSkillGroups(groups []SkillGroup, preferred map[string]string) []SkillGroup {
@@ -51,135 +49,151 @@ func alignSkillGroups(groups []SkillGroup, preferred map[string]string) []SkillG
 	}
 	out := make([]SkillGroup, len(groups))
 	for i, g := range groups {
-		out[i] = SkillGroup{Group: g.Group, Items: collapseIdentical(alignChipList(g.Items, preferred))}
+		out[i] = SkillGroup{Group: g.Group, Items: alignChips(g.Items, preferred)}
 	}
 	return out
 }
 
-func alignChipList(items []string, preferred map[string]string) []string {
+// alignChips rewrites each chip that resolves to a canonical the vacancy spelled its own
+// way, then drops the duplicates that rewrite can create — two spellings of one skill
+// become one chip, not two identical ones. A chip already in the vacancy's spelling keeps
+// the candidate's own casing: matching its wording is the point, matching its shouting is
+// not.
+func alignChips(items []string, preferred map[string]string) []string {
 	if len(items) == 0 {
 		return items
 	}
-	out := make([]string, len(items))
-	copy(out, items)
-	for i, item := range items {
-		resolved := skilltag.Canonicalize([]string{item}, skilltag.WithResumeAcronyms())
-		if len(resolved) != 1 {
-			continue
-		}
-		want, ok := preferred[resolved[0]]
-		if !ok || want == "" {
-			continue
-		}
-		if strings.EqualFold(item, want) {
-			// Already the right wording; keep the JD casing.
-			out[i] = want
-			continue
-		}
-		out[i] = want
-	}
-	return out
-}
-
-func collapseIdentical(items []string) []string {
-	if len(items) < 2 {
-		return items
-	}
-	seen := map[string]struct{}{}
 	out := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
 	for _, item := range items {
-		key := strings.ToLower(strings.TrimSpace(item))
-		if key == "" {
-			out = append(out, item)
-			continue
+		if resolved := skilltag.Canonicalize([]string{item}, skilltag.WithResumeAcronyms()); len(resolved) == 1 {
+			if want := preferred[resolved[0]]; want != "" && !strings.EqualFold(item, want) {
+				item = want
+			}
 		}
-		if _, ok := seen[key]; ok {
-			continue
+		if key := strings.ToLower(strings.TrimSpace(item)); key != "" {
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
 		}
-		seen[key] = struct{}{}
 		out = append(out, item)
 	}
 	return out
 }
 
-func alignProseList(items []string, preferred map[string]string) []string {
+func alignProseList(items []string, rules []proseRule) []string {
 	if len(items) == 0 {
 		return items
 	}
 	out := make([]string, len(items))
 	for i, s := range items {
-		out[i] = replaceProse(s, preferred)
+		out[i] = replaceProse(s, rules)
 	}
 	return out
 }
 
-// replaceProse rewrites unambiguous aliases of preferred canonicals in text.
-func replaceProse(text string, preferred map[string]string) string {
-	if text == "" || len(preferred) == 0 {
-		return text
-	}
-	out := text
+// proseRule rewrites one spelling of a skill into the spelling the vacancy used. from is
+// ASCII-lowercase, so it can be compared against asciiLower(text) at the same offsets.
+type proseRule struct{ from, to string }
+
+// proseRules flattens preferred into the replacements a single pass over prose applies.
+// The order is total and derived only from the rules themselves, so the map's iteration
+// order cannot reach the output; longest-first keeps a short spelling from matching inside
+// a longer one ("node" inside "node.js").
+func proseRules(preferred map[string]string) []proseRule {
+	var rules []proseRule
 	for canonical, want := range preferred {
 		if want == "" {
 			continue
 		}
-		for _, alias := range skilltag.AliasesOf(canonical) {
-			if !skilltag.IsProseSafeAlias(alias) {
-				continue
+		for _, spelling := range skilltag.ProseSurfaces(canonical) {
+			for _, from := range separatorVariants(strings.ToLower(spelling)) {
+				// Nothing to do when the prose already reads the way the vacancy writes it —
+				// and rewriting it anyway would only impose the vacancy's casing. Checked per
+				// separator spelling, so "infrastructure-as-code" is still rewritten when the
+				// vacancy spells it with spaces.
+				if strings.EqualFold(from, want) {
+					continue
+				}
+				rules = append(rules, proseRule{from: from, to: want})
 			}
-			if strings.EqualFold(alias, want) {
-				// Still rewrite casing to the JD form when the alias matches want ignoring case.
-				out = replaceWholeFold(out, alias, want)
-				continue
-			}
-			out = replaceWholeFold(out, alias, want)
 		}
 	}
-	return out
+	slices.SortFunc(rules, func(a, b proseRule) int {
+		return cmp.Or(
+			cmp.Compare(len(b.from), len(a.from)),
+			strings.Compare(a.from, b.from),
+			strings.Compare(a.to, b.to),
+		)
+	})
+	return rules
 }
 
-// replaceWholeFold replaces whole-token occurrences of from (case-insensitive) with to.
-// ASCII alphanumeric boundaries plus a leading '.'/'-' guard (same idea as skilltag).
-func replaceWholeFold(text, from, to string) string {
-	if from == "" || text == "" {
+// separatorVariants spells a multi-word term the three ways a CV writes it. The vacancy
+// side gets this for free from skilltag's separator-insensitive phrase matcher; prose
+// rewriting compares bytes, so it needs the spellings up front.
+func separatorVariants(spelling string) []string {
+	if !strings.Contains(spelling, " ") {
+		return []string{spelling}
+	}
+	return []string{
+		spelling,
+		strings.ReplaceAll(spelling, " ", "-"),
+		strings.ReplaceAll(spelling, " ", "_"),
+	}
+}
+
+// replaceProse applies rules in one left-to-right pass. What a rule writes is never
+// re-examined: the scan continues after the matched SOURCE span, so no replacement can
+// feed another rule. That is what makes a second alignment a no-op — the sequential
+// replace it replaces turned "REST API" into "REST APIs APIs", and then into
+// "REST APIs APIs APIs" on the next autopilot run.
+func replaceProse(text string, rules []proseRule) string {
+	if text == "" || len(rules) == 0 {
 		return text
 	}
-	fromLower := strings.ToLower(from)
+	lower := asciiLower(text)
 	var b strings.Builder
 	b.Grow(len(text))
-	lower := strings.ToLower(text)
 	for i := 0; i < len(text); {
-		j := strings.Index(lower[i:], fromLower)
-		if j < 0 {
-			b.WriteString(text[i:])
-			break
-		}
-		j += i
-		end := j + len(fromLower)
-		// fromLower is ASCII for curated aliases; match length equals the source slice
-		// when the original run is the same byte length (true for ASCII casing).
-		if end > len(text) {
-			b.WriteString(text[i:])
-			break
-		}
-		// Align end to the actual UTF-8 slice of equal lowercase length in text[j:].
-		src := text[j:end]
-		if strings.ToLower(src) != fromLower {
-			// Multi-byte casing mismatch — advance one byte and continue.
-			b.WriteByte(text[i])
-			i++
+		if r, ok := ruleAt(text, lower, i, rules); ok {
+			b.WriteString(r.to)
+			i += len(r.from)
 			continue
 		}
-		if !proseBoundary(text, j, end) {
-			b.WriteString(text[i : j+1])
-			i = j + 1
-			continue
-		}
-		b.WriteString(text[i:j])
-		b.WriteString(to)
-		i = end
+		b.WriteByte(text[i])
+		i++
 	}
 	return b.String()
+}
+
+// ruleAt returns the first rule whose spelling starts at i as a whole word. rules are
+// longest-first, so "node.js" is preferred over the "node" inside it.
+func ruleAt(text, lower string, i int, rules []proseRule) (proseRule, bool) {
+	for _, r := range rules {
+		end := i + len(r.from)
+		if end <= len(text) && lower[i:end] == r.from && proseBoundary(text, i, end) {
+			return r, true
+		}
+	}
+	return proseRule{}, false
+}
+
+// asciiLower lowercases the ASCII letters and leaves every other byte untouched, so the
+// result indexes byte-for-byte into its source. strings.ToLower does not: it is not
+// length-preserving (U+023A lowercases to a rune one byte longer), and mixing its offsets
+// with the original string is how a name written in Turkish silently disabled the rest of
+// a bullet — or ran off the end of it. Curated spellings are ASCII, so folding only ASCII
+// loses no match.
+func asciiLower(s string) string {
+	b := []byte(s)
+	for i := 0; i < len(b); i++ {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
 }
 
 // proseBoundary mirrors wordmatch.ASCIIBoundary but also treats non-ASCII letters
@@ -208,7 +222,7 @@ func documentsEqualForAlign(a, b Document) bool {
 		return false
 	}
 	for i := range a.Skills {
-		if a.Skills[i].Group != b.Skills[i].Group || !stringSlicesEqual(a.Skills[i].Items, b.Skills[i].Items) {
+		if a.Skills[i].Group != b.Skills[i].Group || !slices.Equal(a.Skills[i].Items, b.Skills[i].Items) {
 			return false
 		}
 	}
@@ -217,7 +231,7 @@ func documentsEqualForAlign(a, b Document) bool {
 	}
 	for i := range a.Experience {
 		ae, be := a.Experience[i], b.Experience[i]
-		if ae.Summary != be.Summary || !stringSlicesEqual(ae.Bullets, be.Bullets) || !stringSlicesEqual(ae.Stack, be.Stack) {
+		if ae.Summary != be.Summary || !slices.Equal(ae.Bullets, be.Bullets) || !slices.Equal(ae.Stack, be.Stack) {
 			return false
 		}
 	}
@@ -225,19 +239,7 @@ func documentsEqualForAlign(a, b Document) bool {
 		return false
 	}
 	for i := range a.Projects {
-		if !stringSlicesEqual(a.Projects[i].Bullets, b.Projects[i].Bullets) {
-			return false
-		}
-	}
-	return true
-}
-
-func stringSlicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
+		if !slices.Equal(a.Projects[i].Bullets, b.Projects[i].Bullets) {
 			return false
 		}
 	}

--- a/internal/cv/align_test.go
+++ b/internal/cv/align_test.go
@@ -2,6 +2,7 @@ package cv
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/skilltag"
@@ -10,16 +11,22 @@ import (
 func TestAlign_ChipExpands(t *testing.T) {
 	doc := Document{Skills: []SkillGroup{{Items: []string{"IaC", "Terraform"}}}}
 	preferred := skilltag.PreferredFromText("Experience with infrastructure as code and Terraform.")
-	got := Align(doc, preferred)
-	if got.Skills[0].Items[0] != preferred["infrastructure-as-code"] {
-		t.Fatalf("chip = %q, want %q", got.Skills[0].Items[0], preferred["infrastructure-as-code"])
+	got, changed := Align(doc, preferred)
+	// Asserted against the literal spelling, not against preferred[...] — comparing the
+	// output to the input the same map supplied cannot fail on a wrong spelling.
+	want := []string{"infrastructure as code", "Terraform"}
+	if !reflect.DeepEqual(got.Skills[0].Items, want) {
+		t.Fatalf("skills = %v, want %v", got.Skills[0].Items, want)
+	}
+	if !changed {
+		t.Error("changed = false, want true")
 	}
 }
 
 func TestAlign_ChipShrinks(t *testing.T) {
 	doc := Document{Skills: []SkillGroup{{Items: []string{"Infrastructure as Code"}}}}
 	preferred := map[string]string{"infrastructure-as-code": "IaC"}
-	got := Align(doc, preferred)
+	got, _ := Align(doc, preferred)
 	if got.Skills[0].Items[0] != "IaC" {
 		t.Fatalf("chip = %q, want IaC", got.Skills[0].Items[0])
 	}
@@ -28,7 +35,7 @@ func TestAlign_ChipShrinks(t *testing.T) {
 func TestAlign_GoChipToGolang(t *testing.T) {
 	doc := Document{Skills: []SkillGroup{{Items: []string{"Go", "Kubernetes"}}}}
 	preferred := map[string]string{"go": "Golang", "kubernetes": "Kubernetes"}
-	got := Align(doc, preferred)
+	got, _ := Align(doc, preferred)
 	if got.Skills[0].Items[0] != "Golang" {
 		t.Fatalf("chip = %q, want Golang", got.Skills[0].Items[0])
 	}
@@ -37,19 +44,90 @@ func TestAlign_GoChipToGolang(t *testing.T) {
 func TestAlign_NoInventedSkill(t *testing.T) {
 	doc := Document{Skills: []SkillGroup{{Items: []string{"Python"}}}}
 	preferred := map[string]string{"kubernetes": "Kubernetes"}
-	got := Align(doc, preferred)
+	got, changed := Align(doc, preferred)
 	if !reflect.DeepEqual(got.Skills[0].Items, []string{"Python"}) {
 		t.Fatalf("skills = %v, want unchanged Python only", got.Skills[0].Items)
+	}
+	if changed {
+		t.Error("changed = true, want false")
+	}
+}
+
+// Alignment may change how a skill is spelled and nothing else. The alias tables fold
+// narrower terms onto a broader canonical for the search facet, so a vacancy's "Ruby on
+// Rails" must never reach a CV that only claims Ruby.
+func TestAlign_NarrowerTermNeverReplacesTheSkill(t *testing.T) {
+	cases := []struct {
+		jd    string
+		chips []string
+	}{
+		{"We are a Ruby on Rails shop.", []string{"Ruby"}},
+		{"Java 17 with Spring Boot microservices.", []string{"Java", "Spring"}},
+		{"Senior ASP.NET engineer, SQL Server reporting.", []string{".NET", "T-SQL"}},
+		{"Embedded C/C++ role.", []string{"C++"}},
+		{"Looking for a C developer.", []string{"C"}},
+		{"You will design RESTful APIs.", []string{"REST"}},
+		{"Frontend with HTML5 and CSS3.", []string{"HTML", "CSS"}},
+	}
+	for _, tc := range cases {
+		doc := Document{Skills: []SkillGroup{{Items: append([]string(nil), tc.chips...)}}}
+		got, _ := Align(doc, skilltag.PreferredFromText(tc.jd))
+		if !reflect.DeepEqual(got.Skills[0].Items, tc.chips) {
+			t.Errorf("JD %q: chips = %v, want unchanged %v", tc.jd, got.Skills[0].Items, tc.chips)
+		}
+	}
+}
+
+// The résumé-only acronym tier exists because "RAG status" is red/amber/green project
+// health in ordinary text. It must not reach prose rewriting.
+func TestAlign_ResumeOnlyAcronymNotRewrittenInProse(t *testing.T) {
+	doc := Document{
+		Summary:    "Programme lead reporting RAG status to the steering committee.",
+		Experience: []ExperienceItem{{Bullets: []string{"Ran the weekly RAG review with stakeholders."}}},
+	}
+	preferred := skilltag.PreferredFromText("You will build LLM features using retrieval augmented generation.")
+	got, _ := Align(doc, preferred)
+	if got.Summary != doc.Summary {
+		t.Errorf("summary = %q, want unchanged", got.Summary)
+	}
+	if got.Experience[0].Bullets[0] != doc.Experience[0].Bullets[0] {
+		t.Errorf("bullet = %q, want unchanged", got.Experience[0].Bullets[0])
 	}
 }
 
 func TestAlign_CollapseDuplicateChips(t *testing.T) {
 	doc := Document{Skills: []SkillGroup{{Items: []string{"IaC", "Infrastructure as Code", "Terraform"}}}}
 	preferred := map[string]string{"infrastructure-as-code": "infrastructure as code", "terraform": "Terraform"}
-	got := Align(doc, preferred)
+	got, _ := Align(doc, preferred)
 	want := []string{"infrastructure as code", "Terraform"}
 	if !reflect.DeepEqual(got.Skills[0].Items, want) {
 		t.Fatalf("skills = %v, want %v", got.Skills[0].Items, want)
+	}
+}
+
+// A stack line is a chip list too: rewriting two spellings of one skill into the same
+// spelling must not leave the reader looking at it twice.
+func TestAlign_CollapseDuplicateStack(t *testing.T) {
+	doc := Document{Experience: []ExperienceItem{{Stack: []string{"Kubernetes", "k8s", "Go"}}}}
+	preferred := map[string]string{"kubernetes": "Kubernetes"}
+	got, _ := Align(doc, preferred)
+	want := []string{"Kubernetes", "Go"}
+	if !reflect.DeepEqual(got.Experience[0].Stack, want) {
+		t.Fatalf("stack = %v, want %v", got.Experience[0].Stack, want)
+	}
+}
+
+// The candidate's own casing survives when they already use the vacancy's spelling: the
+// point is to match its wording, not its shouting.
+func TestAlign_ChipCasingKeptWhenSpellingAlreadyMatches(t *testing.T) {
+	doc := Document{Skills: []SkillGroup{{Items: []string{"KUBERNETES", "postgres"}}}}
+	preferred := map[string]string{"kubernetes": "Kubernetes", "postgresql": "Postgres"}
+	got, changed := Align(doc, preferred)
+	if !reflect.DeepEqual(got.Skills[0].Items, doc.Skills[0].Items) {
+		t.Fatalf("skills = %v, want the candidate's own casing", got.Skills[0].Items)
+	}
+	if changed {
+		t.Error("changed = true, want false")
 	}
 }
 
@@ -57,20 +135,21 @@ func TestAlign_ProseUnambiguousReplaces(t *testing.T) {
 	doc := Document{
 		Summary: "Built IaC pipelines.",
 		Experience: []ExperienceItem{{
-			Bullets: []string{"Ran k8s clusters.", "Used infrastructure as code."},
+			Bullets: []string{"Ran k8s clusters.", "Used infrastructure-as-code."},
 		}},
 	}
 	preferred := map[string]string{
 		"infrastructure-as-code": "Infrastructure as Code",
 		"kubernetes":             "Kubernetes",
 	}
-	got := Align(doc, preferred)
+	got, _ := Align(doc, preferred)
 	if got.Summary != "Built Infrastructure as Code pipelines." {
 		t.Errorf("summary = %q", got.Summary)
 	}
 	if got.Experience[0].Bullets[0] != "Ran Kubernetes clusters." {
 		t.Errorf("bullet0 = %q", got.Experience[0].Bullets[0])
 	}
+	// The hyphenated spelling is the same term; the vacancy side gets that for free.
 	if got.Experience[0].Bullets[1] != "Used Infrastructure as Code." {
 		t.Errorf("bullet1 = %q", got.Experience[0].Bullets[1])
 	}
@@ -86,12 +165,8 @@ func TestAlign_ProseAmbiguousWordsUntouched(t *testing.T) {
 			},
 		}},
 	}
-	preferred := map[string]string{
-		"go":    "Golang",
-		"react": "React",
-		"rust":  "Rust",
-	}
-	got := Align(doc, preferred)
+	preferred := map[string]string{"go": "Golang", "react": "React.js", "rust": "Rust"}
+	got, _ := Align(doc, preferred)
 	for i, want := range doc.Experience[0].Bullets {
 		if got.Experience[0].Bullets[i] != want {
 			t.Errorf("bullet[%d] = %q, want %q (ambiguous prose must stay)", i, got.Experience[0].Bullets[i], want)
@@ -100,10 +175,9 @@ func TestAlign_ProseAmbiguousWordsUntouched(t *testing.T) {
 }
 
 func TestAlign_ProseShortTokensUntouched(t *testing.T) {
-	// "js" aliases javascript (2 letters) — must not rewrite in prose.
-	doc := Document{Summary: "Wrote js helpers and C bindings."}
-	preferred := map[string]string{"javascript": "JavaScript", "c": "C++"}
-	got := Align(doc, preferred)
+	doc := Document{Summary: "Wrote TS helpers and C bindings."}
+	preferred := map[string]string{"typescript": "TypeScript", "c": "C++"}
+	got, _ := Align(doc, preferred)
 	if got.Summary != doc.Summary {
 		t.Fatalf("summary = %q, want unchanged short-token prose", got.Summary)
 	}
@@ -111,13 +185,8 @@ func TestAlign_ProseShortTokensUntouched(t *testing.T) {
 
 func TestAlign_SubstringEmbedsUntouched(t *testing.T) {
 	doc := Document{Summary: "A reaction to going rusty on the objective-c path."}
-	preferred := map[string]string{
-		"react": "React",
-		"go":    "Golang",
-		"rust":  "Rust",
-		"c":     "C",
-	}
-	got := Align(doc, preferred)
+	preferred := map[string]string{"react": "React", "go": "Golang", "rust": "Rust", "c": "C"}
+	got, _ := Align(doc, preferred)
 	if got.Summary != doc.Summary {
 		t.Fatalf("summary = %q, want unchanged embeds", got.Summary)
 	}
@@ -126,46 +195,118 @@ func TestAlign_SubstringEmbedsUntouched(t *testing.T) {
 func TestAlign_StackRewritten(t *testing.T) {
 	doc := Document{Experience: []ExperienceItem{{Stack: []string{"IaC", "Go"}}}}
 	preferred := map[string]string{"infrastructure-as-code": "infrastructure as code", "go": "Golang"}
-	got := Align(doc, preferred)
+	got, _ := Align(doc, preferred)
 	want := []string{"infrastructure as code", "Golang"}
 	if !reflect.DeepEqual(got.Experience[0].Stack, want) {
 		t.Fatalf("stack = %v, want %v", got.Experience[0].Stack, want)
 	}
 }
 
-func TestAlign_Idempotent(t *testing.T) {
+// A replacement must never be re-read by another rule: a sequential replace turned
+// "REST API" into "REST APIs APIs", and autopilot re-aligns on every run.
+func TestAlign_IdempotentOverRepeatedRuns(t *testing.T) {
 	doc := Document{
-		Skills:  []SkillGroup{{Items: []string{"IaC", "k8s"}}},
-		Summary: "Shipped IaC on k8s.",
+		Skills:  []SkillGroup{{Items: []string{"IaC", "k8s", "Node.js"}}},
+		Summary: "Shipped IaC on k8s with Node.js and unit test coverage.",
+		Experience: []ExperienceItem{{
+			Stack:   []string{"k8s", "IaC"},
+			Bullets: []string{"Built infrastructure as code for the k8s estate.", "Grew unit test coverage."},
+		}},
+	}
+	preferred := skilltag.PreferredFromText(
+		"Kubernetes estate managed with infrastructure as code, Node JS services, unit testing throughout.")
+	once, changed := Align(doc, preferred)
+	if !changed {
+		t.Fatal("changed = false on the first pass, want true")
+	}
+	for i := 2; i <= 5; i++ {
+		next, changedAgain := Align(once, preferred)
+		if changedAgain {
+			t.Fatalf("pass %d reported a change; summary now %q", i, next.Summary)
+		}
+		if !reflect.DeepEqual(next, once) {
+			t.Fatalf("pass %d changed the document:\n once=%+v\n next=%+v", i, once, next)
+		}
+	}
+}
+
+// The map has no order, so the output must not depend on one.
+func TestAlign_DeterministicAcrossRuns(t *testing.T) {
+	doc := Document{
+		Summary:    "Ran Node JS services on k8s with infrastructure as code.",
+		Experience: []ExperienceItem{{Bullets: []string{"Owned the K8S estate and its infrastructure as code."}}},
 	}
 	preferred := map[string]string{
-		"infrastructure-as-code": "infrastructure as code",
 		"kubernetes":             "Kubernetes",
+		"infrastructure-as-code": "IaC",
+		"nodejs":                 "Node.js",
+		"go":                     "Golang",
 	}
-	once := Align(doc, preferred)
-	twice := Align(once, preferred)
-	if !reflect.DeepEqual(once, twice) {
-		t.Fatalf("second align changed document:\n once=%+v\ntwice=%+v", once, twice)
+	first, _ := Align(doc, preferred)
+	for i := 0; i < 300; i++ {
+		got, _ := Align(doc, preferred)
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("run %d differed:\n%q\n%q", i, first.Summary, got.Summary)
+		}
 	}
-	if AlignChanged(once, preferred) {
-		t.Fatal("AlignChanged true after alignment — want idempotent false")
+}
+
+// One rune whose lowercase is a different byte length used to disable every replacement
+// after it — or run off the end of the string.
+func TestAlign_NonASCIIProseStillAligns(t *testing.T) {
+	for _, name := range []string{"İstanbul", "Ⱥrhus", "Straẞe", "Кёльн"} {
+		doc := Document{Summary: "Led the " + name + " team that owned k8s and infrastructure as code."}
+		got, _ := Align(doc, map[string]string{"kubernetes": "Kubernetes", "infrastructure-as-code": "IaC"})
+		want := "Led the " + name + " team that owned Kubernetes and IaC."
+		if got.Summary != want {
+			t.Errorf("%s: summary = %q, want %q", name, got.Summary, want)
+		}
+	}
+}
+
+// A vacancy is arbitrary text from an external board; no input may crash a tailor request.
+func TestAlign_PathologicalJDDoesNotPanic(t *testing.T) {
+	for _, jd := range []string{
+		strings.Repeat("Ⱥ", 200) + " Kubernetes and infrastructure as code",
+		strings.Repeat("İ", 200) + " k8s",
+		strings.Repeat("K", 100) + " IaC",
+		"\x00\x01 Kubernetes � infrastructure as code",
+	} {
+		doc := Document{Summary: "Ran k8s.", Skills: []SkillGroup{{Items: []string{"IaC"}}}}
+		// A panic is the failure; there is nothing else to assert.
+		Align(doc, skilltag.PreferredFromText(jd))
 	}
 }
 
 func TestAlign_FamilyFixtureUnchanged(t *testing.T) {
-	// Phase 1 must not treat pgvector and vector-databases as the same skill.
+	// pgvector and vector-databases are not the same skill.
 	doc := Document{Skills: []SkillGroup{{Items: []string{"pgvector"}}}}
 	preferred := map[string]string{"vector-databases": "vector databases"}
-	got := Align(doc, preferred)
+	got, _ := Align(doc, preferred)
 	if got.Skills[0].Items[0] != "pgvector" {
-		t.Fatalf("got %q, want pgvector left alone (no family link in Phase 1)", got.Skills[0].Items[0])
+		t.Fatalf("got %q, want pgvector left alone", got.Skills[0].Items[0])
 	}
 }
 
 func TestAlign_NilPreferred(t *testing.T) {
 	doc := Document{Skills: []SkillGroup{{Items: []string{"IaC"}}}}
-	got := Align(doc, nil)
-	if !reflect.DeepEqual(got, doc) {
-		t.Fatalf("got %+v, want unchanged", got)
+	got, changed := Align(doc, nil)
+	if !reflect.DeepEqual(got, doc) || changed {
+		t.Fatalf("got %+v changed=%v, want unchanged", got, changed)
+	}
+}
+
+func TestAlign_DoesNotMutateInput(t *testing.T) {
+	doc := Document{
+		Skills:     []SkillGroup{{Items: []string{"IaC"}}},
+		Experience: []ExperienceItem{{Stack: []string{"k8s"}, Bullets: []string{"Ran k8s."}}},
+	}
+	snapshot := Document{
+		Skills:     []SkillGroup{{Items: []string{"IaC"}}},
+		Experience: []ExperienceItem{{Stack: []string{"k8s"}, Bullets: []string{"Ran k8s."}}},
+	}
+	Align(doc, map[string]string{"infrastructure-as-code": "infrastructure as code", "kubernetes": "Kubernetes"})
+	if !reflect.DeepEqual(doc, snapshot) {
+		t.Fatalf("input was mutated: %+v", doc)
 	}
 }

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -320,10 +320,7 @@ func (s *Store) Tailor(ctx context.Context, userID, jobID int64, tailoredTitle s
 		return Meta{}, Meta{}, false, err
 	}
 
-	doc := base.Document
-	if len(preferred) > 0 {
-		doc = Align(doc, preferred)
-	}
+	doc, _ := Align(base.Document, preferred)
 	tailored, err := s.CreateTailored(ctx, userID, jobID, tailoredTitle, base.TemplateID, doc)
 	if err != nil {
 		return Meta{}, Meta{}, false, err

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -761,7 +761,7 @@ func turnBounds(sess assistant.Session, lastUser string) assistant.TurnConfig {
 // two rhythms the candidate chose, because a turn does not start until a message arrives.
 const autopilotBrief = "Tailor this CV for the vacancy yourself, working from my experience bank. " +
 	"Go through every requirement without stopping to ask me, then tell me what is left. " +
-	"Skill wording on this CV is already aligned to the vacancy's own spellings — do not rename skills for wording; spend your edits on evidence and substance."
+	"Matching the vacancy's spelling of a skill is handled outside this run — do not spend an edit renaming skills for wording; spend them on evidence and substance."
 
 // PostAssistantAutopilot runs the unattended tailoring pass on a tailoring session as one
 // long streamed turn. Every edit of the turn is filed under one revision batch (streamSSE
@@ -784,8 +784,17 @@ func (h *assistantHandlers) PostAssistantAutopilot(c *fiber.Ctx) error {
 	if sess.Preset != assistant.PresetTailor || sess.CVID == nil || sess.JobID == nil {
 		return fiber.NewError(fiber.StatusConflict, "this conversation is not tailoring a CV")
 	}
-	refreshAnalysis := h.prepareAutopilotAnalysis(c, sess)
-	h.alignAutopilotCV(c.Context(), sess)
+	// One read of the vacancy for the whole pre-run: the fit analysis and the surface
+	// alignment both need it, and a run must not ask the database twice for the same row.
+	refreshAnalysis := func(context.Context) {}
+	if job, err := h.queries.GetJob(c.Context(), *sess.JobID); err != nil {
+		log.Printf("assistant: loading job %d for the autopilot pre-run: %v", *sess.JobID, err)
+	} else {
+		refreshAnalysis = h.prepareAutopilotAnalysis(c, sess, job)
+		// Its own system revision — not the run's edit batch — so undoing the run leaves the
+		// vacancy's wording in place.
+		h.cv.logSurfaceAlign(c.Context(), sess.UserID, *sess.CVID, job.Description)
+	}
 	h.layDownRunPlan(c.Context(), sess)
 	return h.streamSSE(c, sess, func(ctx context.Context, runner *assistant.Runner, reg *assistant.Registry, system string, emit func(assistant.Event)) error {
 		err := runner.Run(ctx, sess, reg, system, autopilotBrief, assistant.TurnConfig{MaxSteps: autopilotMaxSteps}, emit)
@@ -797,36 +806,14 @@ func (h *assistantHandlers) PostAssistantAutopilot(c *fiber.Ctx) error {
 	})
 }
 
-// alignAutopilotCV surface-aligns the bound tailored CV to the vacancy before the
-// unattended turn starts. Its own system revision — not the run's edit batch — so
-// undoing the run leaves JD wording in place.
-func (h *assistantHandlers) alignAutopilotCV(ctx context.Context, sess assistant.Session) {
-	if h.cv == nil || sess.CVID == nil || sess.JobID == nil {
-		return
-	}
-	job, err := h.queries.GetJob(ctx, *sess.JobID)
-	if err != nil {
-		log.Printf("assistant: loading job %d for surface-align: %v", *sess.JobID, err)
-		return
-	}
-	h.cv.logSurfaceAlign(ctx, sess.UserID, *sess.CVID, job.Description)
-}
-
-// prepareAutopilotAnalysis resolves the run's vacancy and delegates to
-// matchHandlers.prepareAutopilotRun, which both fills the fit-analysis cache when empty (so
-// cv_context — the run's first tool call — has something to read instead of erroring) and
-// returns the closure that unconditionally refreshes that cache once the run ends. A missing
-// match surface or a job lookup failure degrades to a no-op refresh — the same best-effort
-// posture the pre-run ensure step already had before this change.
-func (h *assistantHandlers) prepareAutopilotAnalysis(c *fiber.Ctx, sess assistant.Session) func(context.Context) {
-	noop := func(context.Context) {}
+// prepareAutopilotAnalysis delegates to matchHandlers.prepareAutopilotRun, which both fills
+// the fit-analysis cache when empty (so cv_context — the run's first tool call — has
+// something to read instead of erroring) and returns the closure that unconditionally
+// refreshes that cache once the run ends. A missing match surface degrades to a no-op
+// refresh — the same best-effort posture the pre-run ensure step already had.
+func (h *assistantHandlers) prepareAutopilotAnalysis(c *fiber.Ctx, sess assistant.Session, job db.Job) func(context.Context) {
 	if h.cv == nil || h.cv.match == nil {
-		return noop
-	}
-	job, err := h.queries.GetJob(c.Context(), *sess.JobID)
-	if err != nil {
-		log.Printf("assistant: loading job %d for autopilot's analysis: %v", *sess.JobID, err)
-		return noop
+		return func(context.Context) {}
 	}
 	return h.cv.match.prepareAutopilotRun(c, sess.UserID, job)
 }

--- a/internal/handler/cv_reset.go
+++ b/internal/handler/cv_reset.go
@@ -49,12 +49,22 @@ func (h *cvHandlers) ResetCVFromResume(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusConflict, "add a résumé before resetting from it")
 	}
 	seeded := cv.Seed(st)
+
 	// Align only the tailored copy to the vacancy. The base stays on the résumé's own
-	// spellings — JD surfaces are per-vacancy, not a rewrite of the candidate's seed.
-	tailoredSeed := seeded
+	// spellings — a vacancy's wording belongs to the copy aimed at it, not to the
+	// candidate's seed.
+	//
+	// Alignment runs on the MERGED state, not on the seed: applySeedContent keeps the
+	// summary and skills already on the page when the seed carries none, and aligning
+	// beforehand would leave exactly those kept sections in the old wording.
+	next := applySeedContent(cvedit.State{
+		Title:      rec.Title,
+		TemplateID: rec.TemplateID,
+		Document:   rec.Document,
+	}, seeded)
 	if rec.JobID != 0 {
 		if job, jerr := h.queries.GetJob(c.Context(), rec.JobID); jerr == nil {
-			tailoredSeed = cv.Align(seeded, skilltag.PreferredFromText(job.Description))
+			next.Document, _ = cv.Align(next.Document, skilltag.PreferredFromText(job.Description))
 		} else {
 			log.Printf("cv: loading job %d for reset surface-align: %v", rec.JobID, jerr)
 		}
@@ -67,12 +77,7 @@ func (h *cvHandlers) ResetCVFromResume(c *fiber.Ctx) error {
 	// would find it in before this call — rather than a request that "failed" while having
 	// silently rewritten a CV the caller did not ask to touch.
 	_, _, err = h.editor.CommitDocument(c.Context(), id, userID,
-		cvedit.ActorCandidate, cvedit.OriginImport,
-		applySeedContent(cvedit.State{
-			Title:      rec.Title,
-			TemplateID: rec.TemplateID,
-			Document:   rec.Document,
-		}, tailoredSeed))
+		cvedit.ActorCandidate, cvedit.OriginImport, next)
 	if err != nil {
 		return mapCVError(err)
 	}

--- a/internal/handler/cv_surface_align.go
+++ b/internal/handler/cv_surface_align.go
@@ -26,17 +26,14 @@ func (h *cvHandlers) commitSurfaceAlign(ctx context.Context, userID int64, cvID 
 	if err != nil {
 		return err
 	}
-	aligned := cv.Align(rec.Document, preferred)
-	if !cv.AlignChanged(rec.Document, preferred) {
+	aligned, changed := cv.Align(rec.Document, preferred)
+	if !changed {
 		return nil
 	}
 	_, _, err = h.editor.CommitDocument(ctx, cvID, userID,
 		cvedit.ActorSystem, cvedit.OriginImport,
 		cvedit.State{Title: rec.Title, TemplateID: rec.TemplateID, Document: aligned})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // logSurfaceAlign is best-effort commitSurfaceAlign for call sites that must not fail the

--- a/internal/skilltag/interchangeable.go
+++ b/internal/skilltag/interchangeable.go
@@ -1,0 +1,164 @@
+package skilltag
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+	"unicode/utf8"
+)
+
+// interchangeableSurfaces lists, per canonical skill, the spellings that name the SAME
+// skill and may therefore be written over one another when a CV is aligned to a vacancy's
+// wording.
+//
+// It is deliberately a fraction of the alias tables, and it is a separate table rather
+// than an inversion of them. Those tables are many-to-one ON PURPOSE: "spring boot",
+// "ruby on rails", "asp.net", "c developer" and "restful apis" are folded onto a broader
+// canonical to keep the SEARCH FACET un-fragmented, not because they mean the same thing.
+// Rewriting a CV through them puts a technology on the page the candidate never claimed —
+// a "Ruby" chip becomes "Ruby on Rails", a "Spring" chip becomes "Spring Boot", and a "C"
+// chip becomes the job-title phrase "C developer".
+//
+// A canonical belongs here only when every spelling below is one skill written another
+// way: an acronym, a plural, a vendor rename, or a British/American spelling. Version
+// numbers (html/html5, oauth/oauth2, ga4) and near-neighbours (angular/angularjs,
+// vbnet/visual basic, ci/cd vs continuous integration) are NOT interchangeable and stay
+// out. When in doubt, leave it out — the cost of omission is a CV that keeps the
+// candidate's own wording, which is the safe direction.
+//
+// The first spelling is not privileged; what a match writes is the spelling as listed
+// here, never a span sliced out of the job description — so a SHOUTY requirements heading
+// or a line break inside a phrase cannot reach the page.
+var interchangeableSurfaces = map[string][]string{
+	"accessibility":             {"accessibility", "a11y"},
+	"ab-testing":                {"A/B testing", "AB testing"},
+	"containerization":          {"containerization", "containerisation"},
+	"cryptocurrency":            {"cryptocurrency", "cryptocurrencies"},
+	"data-modeling":             {"data modeling", "data modelling"},
+	"data-pipelines":            {"data pipelines", "data pipeline"},
+	"data-visualization":        {"data visualization", "data visualisation"},
+	"data-warehousing":          {"data warehousing", "data warehouse"},
+	"design-patterns":           {"design patterns", "design pattern"},
+	"dimensional-modeling":      {"dimensional modeling", "dimensional modelling"},
+	"docs-as-code":              {"docs as code", "docs-as-code"},
+	"ecommerce":                 {"ecommerce", "e commerce"},
+	"event-driven-architecture": {"event driven architecture", "event driven"},
+	"express":                   {"Express", "Express.js", "ExpressJS"},
+	"firewall":                  {"firewalls", "firewall"},
+	"fsharp":                    {"F#", "FSharp"},
+	"gcp":                       {"Google Cloud Platform", "Google Cloud", "GCP"},
+	"generative-ai":             {"generative AI", "GenAI", "gen AI"},
+	"go":                        {"Go", "Golang"},
+	"google-ads":                {"Google Ads", "Google AdWords", "AdWords"},
+	"google-search-console":     {"Google Search Console", "Search Console"},
+	"hyper-v":                   {"Hyper-V", "Hyper V"},
+	"infrastructure-as-code":    {"infrastructure as code", "IaC"},
+	"iso-27001":                 {"ISO 27001", "ISO27001"},
+	"kubernetes":                {"Kubernetes", "K8s"},
+	"link-building":             {"link building", "linkbuilding"},
+	"llamaindex":                {"LlamaIndex", "Llama Index"},
+	"llm":                       {"LLMs", "LLM"},
+	"looker-studio":             {"Looker Studio", "Data Studio"},
+	"machine-learning":          {"machine learning", "ML"},
+	"meta-ads":                  {"Meta Ads", "Facebook Ads"},
+	"microservices":             {"microservices", "microservice"},
+	"microsoft-access":          {"Microsoft Access", "MS Access"},
+	"mitre-attack":              {"MITRE ATT&CK", "MITRE Attack"},
+	"mongodb":                   {"MongoDB", "Mongo"},
+	"neural-networks":           {"neural networks", "neural network"},
+	"newrelic":                  {"New Relic", "NewRelic"},
+	"nextjs":                    {"Next.js", "NextJS"},
+	"nlp":                       {"natural language processing", "NLP"},
+	"nodejs":                    {"Node.js", "NodeJS", "Node JS"},
+	"opentelemetry":             {"OpenTelemetry", "Open Telemetry"},
+	"openid":                    {"OpenID", "OIDC"},
+	"penetration-testing":       {"penetration testing", "pentesting", "pentest"},
+	"plsql":                     {"PL/SQL", "PLSQL"},
+	"postgresql":                {"PostgreSQL", "Postgres"},
+	"powerapps":                 {"Power Apps", "PowerApps"},
+	"powerbi":                   {"Power BI", "PowerBI"},
+	"pre-sales":                 {"pre-sales", "presales"},
+	"predictive-modeling":       {"predictive modeling", "predictive modelling"},
+	"react":                     {"React", "React.js", "ReactJS"},
+	"recommendation-systems":    {"recommendation systems", "recommendation system"},
+	"scikit-learn":              {"scikit-learn", "scikit"},
+	"smart-contracts":           {"smart contracts", "smart contract"},
+	"tcp-ip":                    {"TCP/IP", "TCP IP"},
+	"tdd":                       {"test driven development", "TDD"},
+	"test-automation":           {"test automation", "automated testing"},
+	"threejs":                   {"Three.js", "ThreeJS"},
+	"typescript":                {"TypeScript", "TS"},
+	"unit-testing":              {"unit testing", "unit test"},
+	"virtualization":            {"virtualization", "virtualisation"},
+	"vue":                       {"Vue", "Vue.js", "VueJS"},
+	"wasm":                      {"Web Assembly", "Wasm"},
+	"wireframing":               {"wireframing", "wireframes"},
+}
+
+// surfaceVariant is one curated spelling, compiled once: the form written into a CV, the
+// matcher that finds it in a vacancy, and the two judgements about how safe that spelling
+// is out of context.
+type surfaceVariant struct {
+	display   string
+	matcher   phraseMatcher
+	weak      bool // needs another technology named nearby before it counts as a hit
+	proseSafe bool // may be rewritten inside a sentence, not just inside a skill chip
+}
+
+// newSurfaceVariant compiles one spelling. The two judgements it makes differ, and the
+// difference is the point: "F#" is unmistakable in a sentence yet too short to trust as
+// the only skill a vacancy named, while "react" is long enough to be a hit but is also
+// ordinary English, so rewriting every "react" in a bullet would turn "we react to
+// incidents" into a framework.
+func newSurfaceVariant(canonical, display string) surfaceVariant {
+	lower := strings.ToLower(display)
+	english := ambiguousWords[lower]
+	// Lowercased job text cannot tell "ML" the field from "ml" the unit.
+	short := utf8.RuneCountInString(lower) <= 2
+	punctuated := strings.ContainsAny(lower, " \t_-/.#+&")
+	return surfaceVariant{
+		display:   display,
+		matcher:   compilePhraseMatcher(canonical, lower),
+		weak:      english || short,
+		proseSafe: !english && (punctuated || !short),
+	}
+}
+
+// surfaceIndex compiles interchangeableSurfaces once at startup, and proseDisplays is the
+// ProseSurfaces answer materialised alongside it — that one is read per canonical per prose
+// string during an alignment, and rebuilding the slice there was the dominant cost of the
+// whole pass.
+//
+// Each canonical's variants are ordered longest-first, so a vacancy that writes both
+// "Kubernetes" and "k8s" resolves to the fuller spelling, and prose rewriting cannot match
+// a short spelling inside a longer one.
+var surfaceIndex, proseDisplays = func() (map[string][]surfaceVariant, map[string][]string) {
+	index := make(map[string][]surfaceVariant, len(interchangeableSurfaces))
+	prose := make(map[string][]string, len(interchangeableSurfaces))
+	for canonical, displays := range interchangeableSurfaces {
+		variants := make([]surfaceVariant, 0, len(displays))
+		for _, d := range displays {
+			variants = append(variants, newSurfaceVariant(canonical, d))
+		}
+		slices.SortFunc(variants, func(a, b surfaceVariant) int {
+			return cmp.Or(
+				cmp.Compare(utf8.RuneCountInString(b.display), utf8.RuneCountInString(a.display)),
+				strings.Compare(a.display, b.display),
+			)
+		})
+		index[canonical] = variants
+		for _, v := range variants {
+			if v.proseSafe {
+				prose[canonical] = append(prose[canonical], v.display)
+			}
+		}
+	}
+	return index, prose
+}()
+
+// ProseSurfaces returns the curated spellings of canonical that may be rewritten inside
+// summary and bullet prose, longest first. A skill chip needs no such list — Canonicalize
+// already resolves whatever the chip says. The result is shared and must not be modified.
+func ProseSurfaces(canonical string) []string {
+	return proseDisplays[canonical]
+}

--- a/internal/skilltag/skilltag.go
+++ b/internal/skilltag/skilltag.go
@@ -92,23 +92,26 @@ func (m phraseMatcher) matches(norm string) bool {
 	return false
 }
 
-// phraseMatchers compiles phraseAliases once at startup: a multi-word alias (split
-// on '-'/'_'/space) becomes a separator-insensitive regex; a single token stays a
-// substring match. Only the match key is transformed — canonicals are unchanged.
+// compilePhraseMatcher turns one lowercase alias into its matcher: a multi-word alias
+// (split on '-'/'_'/space) becomes a separator-insensitive regex; a single token stays a
+// substring match. Only the match key is transformed — the canonical is unchanged.
+func compilePhraseMatcher(canonical, alias string) phraseMatcher {
+	segs := nonEmpty(sepRE.Split(alias, -1))
+	if len(segs) <= 1 {
+		return phraseMatcher{canonical: canonical, token: alias}
+	}
+	quoted := make([]string, len(segs))
+	for i, s := range segs {
+		quoted[i] = regexp.QuoteMeta(s)
+	}
+	return phraseMatcher{canonical: canonical, re: regexp.MustCompile(strings.Join(quoted, `[-_\s]+`))}
+}
+
+// phraseMatchers compiles phraseAliases once at startup.
 var phraseMatchers = func() []phraseMatcher {
 	out := make([]phraseMatcher, 0, len(phraseAliases))
 	for _, p := range phraseAliases {
-		segs := nonEmpty(sepRE.Split(strings.ToLower(p.alias), -1))
-		if len(segs) <= 1 {
-			out = append(out, phraseMatcher{canonical: p.canonical, token: strings.ToLower(p.alias)})
-			continue
-		}
-		quoted := make([]string, len(segs))
-		for i, s := range segs {
-			quoted[i] = regexp.QuoteMeta(s)
-		}
-		re := regexp.MustCompile(strings.Join(quoted, `[-_\s]+`))
-		out = append(out, phraseMatcher{canonical: p.canonical, re: re})
+		out = append(out, compilePhraseMatcher(p.canonical, strings.ToLower(p.alias)))
 	}
 	return out
 }()

--- a/internal/skilltag/surfaces.go
+++ b/internal/skilltag/surfaces.go
@@ -1,208 +1,54 @@
 package skilltag
 
-import (
-	"strings"
-	"unicode/utf8"
+import "maps"
 
-	"github.com/strelov1/freehire/internal/wordmatch"
-)
-
-// PreferredFromText returns each canonical skill found in text mapped to the
-// surface form the text actually used, preserving casing. When several aliases of
-// one canonical appear, the longest surface wins (rune count). Surfaces come only
-// from the curated alias tables — unknown phrases are ignored. Parse's return
-// shape is unchanged; this is the invert path for JD-driven wording alignment.
+// PreferredFromText reports, for each canonical skill the vacancy names, which of that
+// skill's interchangeable spellings the vacancy used — "IaC" or "infrastructure as code",
+// "k8s" or "Kubernetes". It is the invert path for JD-driven wording alignment; Parse's
+// return shape is unchanged.
+//
+// Two properties the callers depend on:
+//
+//   - Only canonicals in interchangeableSurfaces can appear. The alias tables Parse uses
+//     are many-to-one on purpose, so inverting THEM would answer "ruby" with "Ruby on
+//     Rails" — a technology the candidate never claimed. Wording alignment is allowed to
+//     change how a skill is spelled and nothing else.
+//   - The spelling returned is the curated one, never a span cut out of the description.
+//     Descriptions are raw ATS HTML, and stripMarkup leaves a space where each tag was, so
+//     a slice of the source would carry double spaces and line breaks into a skill chip —
+//     and a SHOUTY requirements heading would shout on the candidate's CV.
+//
+// Ambiguity is gated the way Parse gates it: a spelling that is ordinary English ("go"),
+// or too short to be unmistakable ("ML"), counts only once the vacancy has named some
+// other technology outright.
 func PreferredFromText(text string) map[string]string {
-	cased := strings.TrimSpace(stripMarkup(text))
-	if cased == "" {
+	norm := normalize(text)
+	if norm == "" {
 		return nil
 	}
-	norm := strings.ToLower(cased)
 
-	best := map[string]string{}
-	consider := func(canonical, surface string) {
-		if canonical == "" || surface == "" {
-			return
-		}
-		if prev, ok := best[canonical]; ok && utf8.RuneCountInString(surface) <= utf8.RuneCountInString(prev) {
-			return
-		}
-		best[canonical] = surface
-	}
-
-	// Mirror Parse's strong/weak split: ambiguous English-word aliases only count
-	// when a strong tech token corroborates them, so "must react to changes" does
-	// not prefer "react" as a JD skill surface.
-	type hit struct {
-		canonical, surface string
-		weak               bool
-	}
-	var hits []hit
-	strong := false
-
-	for surface, canonical := range sharedAcronyms {
-		if loc := findBounded(cased, surface, wordmatch.UnicodeBoundary); loc != nil {
-			hits = append(hits, hit{canonical, cased[loc[0]:loc[1]], false})
-			strong = true
-		}
-	}
-	for _, m := range phraseMatchers {
-		for _, loc := range findAllPhrase(norm, m) {
-			surface := cased[loc[0]:loc[1]]
-			if nonCorroboratingPhrases[m.canonical] {
-				hits = append(hits, hit{m.canonical, surface, false})
+	// Each canonical is resolved independently and its variants are already ordered
+	// longest-first, so the answer does not depend on map iteration order: a vacancy
+	// naming both "Kubernetes" and "k8s" always yields "Kubernetes".
+	named, hedged := map[string]string{}, map[string]string{}
+	for canonical, variants := range surfaceIndex {
+		for _, v := range variants {
+			if !v.matcher.matches(norm) {
 				continue
 			}
-			hits = append(hits, hit{m.canonical, surface, false})
-			strong = true
+			if v.weak {
+				hedged[canonical] = v.display
+			} else {
+				named[canonical] = v.display
+			}
+			break
 		}
 	}
-	for _, loc := range wordTokenRE.FindAllStringIndex(norm, -1) {
-		tok := norm[loc[0]:loc[1]]
-		c, ok := wordAliases[tok]
-		if !ok {
-			continue
-		}
-		surface := cased[loc[0]:loc[1]]
-		if ambiguousWords[tok] {
-			hits = append(hits, hit{c, surface, true})
-			continue
-		}
-		hits = append(hits, hit{c, surface, false})
-		strong = true
-	}
-	for _, h := range hits {
-		if h.weak && !strong {
-			continue
-		}
-		consider(h.canonical, h.surface)
-	}
-	if len(best) == 0 {
+	// Nothing named outright means nothing corroborates the hedged spellings, and a text
+	// that only ever said "go" is not a vacancy talking about Go.
+	if len(named) == 0 {
 		return nil
 	}
-	return best
-}
-
-// AliasesOf returns every curated lowercase alias that resolves to canonical,
-// including the canonical slug itself when it is a recognised form. Order is
-// longest-first so whole-phrase replaces run before shorter acronyms.
-func AliasesOf(canonical string) []string {
-	if canonical == "" {
-		return nil
-	}
-	seen := map[string]struct{}{}
-	var out []string
-	add := func(a string) {
-		a = strings.TrimSpace(strings.ToLower(a))
-		if a == "" {
-			return
-		}
-		if _, ok := seen[a]; ok {
-			return
-		}
-		seen[a] = struct{}{}
-		out = append(out, a)
-	}
-	add(canonical)
-	for alias, c := range wordAliases {
-		if c == canonical {
-			add(alias)
-		}
-	}
-	for _, p := range phraseAliases {
-		if p.canonical == canonical {
-			add(p.alias)
-		}
-	}
-	for surface, c := range sharedAcronyms {
-		if c == canonical {
-			add(surface)
-		}
-	}
-	for surface, ca := range categoryScopedAcronyms {
-		if ca.canonical == canonical {
-			add(surface)
-		}
-	}
-	for surface, c := range resumeAcronyms {
-		if c == canonical {
-			add(surface)
-		}
-	}
-	// Longest first so "infrastructure as code" wins over "iac" when both are tried.
-	for i := 0; i < len(out); i++ {
-		for j := i + 1; j < len(out); j++ {
-			if utf8.RuneCountInString(out[j]) > utf8.RuneCountInString(out[i]) {
-				out[i], out[j] = out[j], out[i]
-			}
-		}
-	}
-	return out
-}
-
-// IsProseSafeAlias reports whether alias may be rewritten inside summary/bullet
-// prose. Multi-word phrases and strong acronyms are safe; ambiguous English-word
-// aliases and one- or two-letter tokens are not (they collide with ordinary prose).
-func IsProseSafeAlias(alias string) bool {
-	a := strings.TrimSpace(strings.ToLower(alias))
-	if a == "" {
-		return false
-	}
-	if strings.ContainsAny(a, " \t_-/") {
-		// Phrases and punctuated tokens (ci/cd, c++) — not bare English words.
-		return true
-	}
-	if ambiguousWords[a] {
-		return false
-	}
-	if utf8.RuneCountInString(a) <= 2 {
-		return false
-	}
-	return true
-}
-
-// findBounded returns the [start,end) of the first whole-token occurrence of term
-// in s, or nil.
-func findBounded(s, term string, ok wordmatch.Boundary) []int {
-	if term == "" {
-		return nil
-	}
-	for from := 0; ; {
-		i := strings.Index(s[from:], term)
-		if i < 0 {
-			return nil
-		}
-		i += from
-		end := i + len(term)
-		if ok(s, i, end) {
-			return []int{i, end}
-		}
-		from = i + 1
-	}
-}
-
-// findAllPhrase returns every boundary-checked match of m in norm.
-func findAllPhrase(norm string, m phraseMatcher) [][]int {
-	var out [][]int
-	if m.re == nil {
-		for from := 0; ; {
-			i := strings.Index(norm[from:], m.token)
-			if i < 0 {
-				break
-			}
-			i += from
-			end := i + len(m.token)
-			if wordmatch.ASCIIBoundary(norm, i, end) {
-				out = append(out, []int{i, end})
-			}
-			from = i + 1
-		}
-		return out
-	}
-	for _, loc := range m.re.FindAllStringIndex(norm, -1) {
-		if wordmatch.ASCIIBoundary(norm, loc[0], loc[1]) {
-			out = append(out, loc)
-		}
-	}
-	return out
+	maps.Copy(named, hedged)
+	return named
 }

--- a/internal/skilltag/surfaces_test.go
+++ b/internal/skilltag/surfaces_test.go
@@ -2,14 +2,15 @@ package skilltag
 
 import (
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 )
 
 func TestPreferredFromText_LongestWins(t *testing.T) {
-	got := PreferredFromText("We practice IaC and Infrastructure as Code daily.")
-	want := "Infrastructure as Code"
-	if got["infrastructure-as-code"] != want {
-		t.Fatalf("preferred = %q, want %q (longest); full map %#v", got["infrastructure-as-code"], want, got)
+	got := PreferredFromText("We practice IaC and infrastructure as code daily.")
+	if got["infrastructure-as-code"] != "infrastructure as code" {
+		t.Fatalf("preferred = %q, want the spelled-out form; full map %#v", got["infrastructure-as-code"], got)
 	}
 }
 
@@ -18,25 +19,125 @@ func TestPreferredFromText_JDOnlyAcronym(t *testing.T) {
 	if got["infrastructure-as-code"] != "IaC" {
 		t.Fatalf("preferred = %q, want IaC; full map %#v", got["infrastructure-as-code"], got)
 	}
-	if got["terraform"] != "Terraform" {
-		t.Fatalf("terraform preferred = %q, want Terraform", got["terraform"])
+	// Terraform has one spelling, so there is nothing to align and nothing to report.
+	if _, ok := got["terraform"]; ok {
+		t.Errorf("terraform is in the map, but it has no interchangeable spellings: %#v", got)
 	}
 }
 
 func TestPreferredFromText_UnknownIgnored(t *testing.T) {
 	got := PreferredFromText("Must know BlorpleDB and the FluxCapacitor framework.")
 	if len(got) != 0 {
-		t.Fatalf("got %#v, want empty — unknown jargon must not invent surfaces", got)
+		t.Fatalf("got %#v, want empty — unknown jargon must not invent spellings", got)
 	}
 }
 
-func TestPreferredFromText_CasingPreserved(t *testing.T) {
-	got := PreferredFromText("Required: Kubernetes and PostgreSQL.")
-	if got["kubernetes"] != "Kubernetes" {
-		t.Errorf("kubernetes = %q, want Kubernetes", got["kubernetes"])
+// The spelling written into a CV comes from the curated table, so a vacancy that shouts
+// its requirements does not make the candidate shout back.
+func TestPreferredFromText_JDCasingNotCopied(t *testing.T) {
+	got := PreferredFromText("REQUIREMENTS: KUBERNETES, POSTGRESQL, TYPESCRIPT.")
+	for canonical, want := range map[string]string{
+		"kubernetes": "Kubernetes",
+		"postgresql": "PostgreSQL",
+		"typescript": "TypeScript",
+	} {
+		if got[canonical] != want {
+			t.Errorf("%s = %q, want %q", canonical, got[canonical], want)
+		}
 	}
-	if got["postgresql"] != "PostgreSQL" {
-		t.Errorf("postgresql = %q, want PostgreSQL", got["postgresql"])
+}
+
+// A description is raw ATS HTML and stripMarkup leaves a space where each tag was, so a
+// spelling cut out of the source would carry the markup's whitespace onto the page.
+func TestPreferredFromText_MarkupWhitespaceNotCarried(t *testing.T) {
+	got := PreferredFromText("<ul><li>Strong <b>infrastructure</b> as code (Terraform)</li>\n<li>Runs on\nKubernetes</li></ul>")
+	for canonical, want := range map[string]string{
+		"infrastructure-as-code": "infrastructure as code",
+		"kubernetes":             "Kubernetes",
+	} {
+		if got[canonical] != want {
+			t.Errorf("%s = %q, want %q", canonical, got[canonical], want)
+		}
+	}
+	for canonical, surface := range got {
+		if strings.ContainsAny(surface, "\n\t") || strings.Contains(surface, "  ") {
+			t.Errorf("%s = %q carries markup whitespace", canonical, surface)
+		}
+	}
+}
+
+// A vacancy in any language must not be able to crash the tailor request or slice a
+// spelling in half. Every rune here lowercases to a different byte length.
+func TestPreferredFromText_NonASCIIIsSafe(t *testing.T) {
+	for _, prefix := range []string{"İstanbul", strings.Repeat("İ", 50), strings.Repeat("Ⱥ", 40), strings.Repeat("K", 30), "ẞ"} {
+		text := prefix + " team running Kubernetes with infrastructure as code"
+		got := PreferredFromText(text)
+		if got["kubernetes"] != "Kubernetes" {
+			t.Errorf("prefix %q: kubernetes = %q, want Kubernetes", prefix, got["kubernetes"])
+		}
+		if got["infrastructure-as-code"] != "infrastructure as code" {
+			t.Errorf("prefix %q: iac = %q, want the spelled-out form", prefix, got["infrastructure-as-code"])
+		}
+	}
+}
+
+// The alias tables are many-to-one on purpose: they fold narrower terms onto a broader
+// canonical to keep the search facet whole. Inverting them would answer "ruby" with
+// "Ruby on Rails" and put a framework on a CV that only claims the language.
+func TestPreferredFromText_NarrowerTermsAreNotSpellings(t *testing.T) {
+	cases := []struct{ text, canonical string }{
+		{"We are a Ruby on Rails shop.", "ruby"},
+		{"Java 17 with Spring Boot microservices.", "spring"},
+		{"Senior ASP.NET engineer wanted.", "dotnet"},
+		{"You will design RESTful APIs.", "rest"},
+		{"Embedded C/C++ role.", "cpp"},
+		{"Looking for a C developer.", "c"},
+		{"T-SQL reporting on SQL Server.", "sql-server"},
+		{"Build LLM features with retrieval augmented generation.", "rag"},
+		{"Frontend with HTML5 and CSS3.", "html"},
+		{"AngularJS legacy plus Angular today.", "angular"},
+	}
+	for _, tc := range cases {
+		if surface, ok := PreferredFromText(tc.text)[tc.canonical]; ok {
+			t.Errorf("%q offered %s = %q; that family is not interchangeable", tc.text, tc.canonical, surface)
+		}
+	}
+}
+
+// Every curated family must survive the round trip: each spelling has to resolve back to
+// the canonical it is filed under, or alignment would rewrite one skill into another.
+func TestInterchangeableSurfaces_ResolveToTheirCanonical(t *testing.T) {
+	for canonical, spellings := range interchangeableSurfaces {
+		if len(spellings) < 2 {
+			t.Errorf("%s lists %d spelling(s); a family with one spelling has nothing to align", canonical, len(spellings))
+		}
+		for _, s := range spellings {
+			got := Canonicalize([]string{s}, WithResumeAcronyms())
+			if len(got) != 1 || got[0] != canonical {
+				t.Errorf("Canonicalize(%q) = %v, want [%s] — the family would rewrite one skill into another", s, got, canonical)
+			}
+		}
+	}
+}
+
+func TestPreferredFromText_WeakSpellingNeedsCorroboration(t *testing.T) {
+	if got := PreferredFromText("You must go the extra mile and react to change."); len(got) != 0 {
+		t.Errorf("got %#v, want empty — bare English words are not skill spellings", got)
+	}
+	if got := PreferredFromText("Golang services on Kubernetes."); got["go"] != "Golang" {
+		t.Errorf("go = %q, want Golang once a real technology corroborates it", got["go"])
+	}
+}
+
+func TestProseSurfaces_ExcludeShortTokens(t *testing.T) {
+	if got := ProseSurfaces("typescript"); slices.Contains(got, "TS") {
+		t.Errorf("ProseSurfaces(typescript) = %v, want no bare two-letter token", got)
+	}
+	if got := ProseSurfaces("infrastructure-as-code"); len(got) != 2 {
+		t.Errorf("ProseSurfaces(infrastructure-as-code) = %v, want both spellings", got)
+	}
+	if got := ProseSurfaces("ruby"); got != nil {
+		t.Errorf("ProseSurfaces(ruby) = %v, want nil — not an interchangeable family", got)
 	}
 }
 
@@ -44,65 +145,17 @@ func TestPreferredFromText_Empty(t *testing.T) {
 	if got := PreferredFromText(""); got != nil {
 		t.Fatalf("got %#v, want nil", got)
 	}
-}
-
-func TestAliasesOf_LongestFirst(t *testing.T) {
-	got := AliasesOf("infrastructure-as-code")
-	if len(got) < 2 {
-		t.Fatalf("aliases = %v, want at least iac and the phrase", got)
-	}
-	if got[0] != "infrastructure as code" && got[0] != "infrastructure-as-code" {
-		// phraseAliases has "infrastructure as code"; canonical slug may also appear.
-		// Longest should be the spaced phrase (22 runes) over "infrastructure-as-code" (22)
-		// or "iac" (3). Spaced phrase and hyphenated slug are same rune length for
-		// "infrastructure as code" (22) vs "infrastructure-as-code" (22) — spaces vs hyphens.
-		// "infrastructure as code" has spaces: i-n-f-r-a-s-t-r-u-c-t-u-r-e- -a-s- -c-o-d-e = 22
-		// Either long form before iac is fine.
-	}
-	foundPhrase, foundIAC := false, false
-	for i, a := range got {
-		if a == "infrastructure as code" {
-			foundPhrase = true
-			if i > 0 && got[0] == "iac" {
-				t.Fatalf("aliases = %v, want long phrase before iac", got)
-			}
-		}
-		if a == "iac" {
-			foundIAC = true
-		}
-	}
-	if !foundPhrase || !foundIAC {
-		t.Fatalf("aliases = %v, want both phrase and iac", got)
-	}
-}
-
-func TestIsProseSafeAlias(t *testing.T) {
-	cases := []struct {
-		alias string
-		want  bool
-	}{
-		{"infrastructure as code", true},
-		{"iac", true},
-		{"k8s", true},
-		{"ci/cd", true},
-		{"go", false},
-		{"react", false},
-		{"c", false},
-		{"js", false},
-		{"", false},
-	}
-	for _, tc := range cases {
-		if got := IsProseSafeAlias(tc.alias); got != tc.want {
-			t.Errorf("IsProseSafeAlias(%q) = %v, want %v", tc.alias, got, tc.want)
-		}
+	if got := PreferredFromText("<p></p>   "); got != nil {
+		t.Fatalf("got %#v, want nil", got)
 	}
 }
 
 func TestPreferredFromText_Deterministic(t *testing.T) {
-	text := "IaC with Kubernetes and React."
-	a := PreferredFromText(text)
-	b := PreferredFromText(text)
-	if !reflect.DeepEqual(a, b) {
-		t.Fatalf("not deterministic:\n%#v\n%#v", a, b)
+	text := "IaC with Kubernetes, k8s tooling, React.js and Node.js."
+	first := PreferredFromText(text)
+	for i := 0; i < 50; i++ {
+		if got := PreferredFromText(text); !reflect.DeepEqual(first, got) {
+			t.Fatalf("not deterministic on run %d:\n%#v\n%#v", i, first, got)
+		}
 	}
 }

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -235,6 +235,9 @@
     void offerCvRefresh({
       message: BASE_REFRESH_MESSAGE,
       apply: async () => {
+        // Cleared on the way in, so a failure from one edit does not outlive the next one that
+        // succeeds — the banner sits under the page header and nothing else would ever drop it.
+        actionError = null;
         try {
           await api.resetBaseCvFromResume();
         } catch {

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -362,6 +362,10 @@
 
   let resetBusy = $state(false);
   let resetError = $state('');
+  // The one condition that forbids replacing the whole document: another reset already in
+  // flight, or any agent turn. All three write the same document, so a second writer loses
+  // one side's work silently. Every entry point to a reset reads this, so none can drift.
+  const resetLocked = $derived(resetBusy || turnActive || runActive);
 
   async function applyResetFromResume() {
     resetBusy = true;
@@ -398,7 +402,11 @@
     await applyResetFromResume();
   }
 
+  // A bank edit offers the same whole-document reset the History tab's control offers, so it
+  // answers to the same guard. While that guard is up the offer is skipped rather than shown:
+  // asking and then doing nothing reads as a broken control, and the next bank edit asks again.
   function offerRefreshAfterBankEdit() {
+    if (resetLocked) return;
     void offerCvRefresh({
       message: TAILOR_REFRESH_MESSAGE,
       apply: applyResetFromResume,
@@ -647,6 +655,17 @@
                checking, confirming, or editing what the assistant knows never means leaving the
                workspace. -->
           <div class="h-full overflow-auto p-4" class:hidden={leftTab !== 'experience'}>
+            <!-- The refresh a bank edit offers is the same reset the History tab's control runs,
+                 and it fails into the same `resetError` — but someone who triggered it from here
+                 is not looking at that tab, so the failure is said here too. -->
+            {#if resetError}
+              <p
+                class="mb-3 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                role="alert"
+              >
+                {resetError}
+              </p>
+            {/if}
             <ExperienceBankView onBankMutated={offerRefreshAfterBankEdit} />
           </div>
           <!-- Presentation, in two blocks of label→control rows. Both write straight into the
@@ -758,7 +777,7 @@
         onUndoRevision={undoRevision}
         onUndoRevisionRun={undoRevisionRun}
         onResetFromResume={resetFromResume}
-        resetBusy={resetBusy || turnActive || runActive}
+        resetBusy={resetLocked}
         {resetError}
         bind:tab={artifactTab}
         mobileVisible={mobileView === 'jd' || mobileView === 'jobmatch' || mobileView === 'score' || mobileView === 'history'}


### PR DESCRIPTION
Follow-up to #1818. The JD surface-align prepass shipped with five defects, all reproduced by tests added here. Four of them write wrong content into a candidate's CV, and one takes the tailor request down entirely.

## What was wrong

**Alignment fabricated skills.** `PreferredFromText` inverted the `skilltag` alias tables to find the vacancy's spelling of a skill. Those tables are many-to-one *on purpose* — `"spring boot" → spring`, `"ruby on rails" → ruby`, `"asp.net" → dotnet`, `"c developer" → c` — they fold narrower terms onto a broader canonical so the search facet does not fragment, not because the terms are synonyms. Inverted with "longest spelling wins", a Rails vacancy turned a `Ruby` chip into `Ruby on Rails`, a Spring Boot vacancy turned `Spring` into `Spring Boot`, `C` became the job-title phrase `C developer`, and prose followed: *"Migrated the Spring Framework monolith off EJB"* became *"Migrated the Spring Boot monolith off EJB"* — a false statement about a specific past project, idempotent, so it stayed. `commitSurfaceAlign` writes as `ActorSystem`, and `cvedit`'s evidence gate returns early for every actor except `ActorAgent`, so nothing checked it.

**A vacancy could panic the tailor request.** `PreferredFromText` took match offsets from the lowercased copy and sliced the original. `strings.ToLower` is not length-preserving: a description containing `İ` produced a truncated spelling (`Kubernete`), and one containing `Ⱥ` (U+023A, whose lowercase is a byte longer) produced `slice bounds out of range`. Descriptions are ingested board HTML, so this is arbitrary external text, and it is deterministic — that vacancy never opens again.

**Alignment grew the text on every run.** `replaceProse` re-read its own output with the shorter aliases of the same canonical, so `"REST API"` became `"REST APIs APIs"`. Autopilot re-aligns on every start, adding one more `" APIs"` each time, and `AlignChanged` stayed true forever. The change's own spec requires a second alignment to be a no-op.

**Résumé-only acronyms reached prose.** `AliasesOf` unioned in `resumeAcronyms`, the tier that exists *because* `RAG status` is red/amber/green project health in ordinary text. A delivery manager's *"reporting RAG status to the steering committee"* came back as *"reporting retrieval augmented generation status to the steering committee"*.

**Non-ASCII silently disabled prose rewriting.** `replaceWholeFold` mixed the same two coordinate systems, so one rune whose lowercase differs in byte length stopped every replacement after it in that string.

## What this does

- Replaces the table inversion with a curated `interchangeableSurfaces` table in `skilltag`: 66 families where every spelling is the same skill written another way — an acronym, a plural, a vendor rename, a British/American spelling. Version numbers (`html5`, `oauth2`, `ga4`) and near-neighbours (`angularjs`, `visual basic`) are deliberately out, with the reasoning in the doc comment. `TestInterchangeableSurfaces_ResolveToTheirCanonical` requires every spelling to canonicalize back to its own family — it caught a bad entry while the table was being written.
- Matching now happens entirely in normalized coordinates, and the spelling written into a CV comes from the table, never from a slice of the description. That removes the panic and the truncation, and with them the markup-whitespace leak (`"Continuous\nintegration"`, `"infrastructure  as code"` from a stripped `<b>`) and the casing leak (a `REQUIREMENTS: KUBERNETES` heading no longer shouts on the CV).
- `replaceProse` is one left-to-right pass that never re-examines what it wrote, over a rule list with a total order, so neither self-substitution nor map iteration order can reach the output. Prose matching folds ASCII only, which is byte-length preserving.
- `Align` returns `(Document, bool)`; `commitSurfaceAlign` no longer computes the alignment twice.

Also in scope, from the same review: the reset copy is aligned *after* `applySeedContent` merges rather than before, so the summary and skills that keep-if-empty preserves are aligned too; experience stack chips are deduped the way skill chips already were; autopilot reads the vacancy once instead of twice; and the tailor prompt and autopilot brief no longer assert the CV "is already aligned", which is untrue for copies minted before the prepass existed. On the web side the bank-edit refresh respects the same in-flight guard (`resetBusy || turnActive || runActive`) as the manual reset — and skips the confirm entirely while that guard is up rather than asking and doing nothing — and its failure is surfaced on the tab the candidate is actually looking at.

## Testing

`go build ./...`, `go vet -tags=integration ./...` and `go test ./internal/...` are clean (121 packages). `TestExtractResumeProfile_PDF` fails in my environment for want of a PDF extractor; I confirmed it fails the same way on an untouched checkout before any of these changes. `svelte-check` reports no errors in the two touched Svelte files.

New regression tests cover each defect above by name: `TestAlign_NarrowerTermNeverReplacesTheSkill`, `TestPreferredFromText_NonASCIIIsSafe` / `TestAlign_PathologicalJDDoesNotPanic`, `TestAlign_IdempotentOverRepeatedRuns`, `TestAlign_ResumeOnlyAcronymNotRewrittenInProse`, `TestAlign_NonASCIIProseStillAligns`, plus `TestPreferredFromText_MarkupWhitespaceNotCarried`, `TestPreferredFromText_JDCasingNotCopied`, `TestAlign_DeterministicAcrossRuns` and `TestAlign_CollapseDuplicateStack`.

Two tests were replaced rather than kept: `TestAlign_ChipExpands` asserted the output chip equalled the map value it had passed in, so it could not fail on a wrong spelling; `TestAliasesOf_LongestFirst` had an `if` whose body was comments only.

`Align` on a realistic CV: 3.6 ms → ~300 µs, 8298 → 758 allocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
