### PR TITLE
fix(experience): close two provenance-honesty gaps in the bank tools

### DIFF
--- a/internal/assistant/message.go
+++ b/internal/assistant/message.go
@@ -158,6 +158,13 @@ func Conversation(msgs []Message) ([]llms.MessageContent, error) {
 	return out, nil
 }
 
+// minQuoteWords is the shortest citation UserSaid will accept. A substring match with no
+// floor lets a common short word — "I", "the", any filler that turns up somewhere in every
+// session — count as a verbatim quote of anything containing it, which promotes an invented
+// claim to the candidate's own words for free. Three words is short enough to not bother a
+// real citation but long enough that it can't be found by accident in unrelated chatter.
+const minQuoteWords = 3
+
 // UserSaid reports whether quote appears in what the user actually typed in this
 // conversation, compared case-insensitively and with whitespace collapsed.
 //
@@ -168,7 +175,7 @@ func Conversation(msgs []Message) ([]llms.MessageContent, error) {
 // let a paraphrase pass, and a paraphrase is precisely the thing being guarded against.
 func UserSaid(transcript []Message, quote string) bool {
 	quote = collapseSpace(quote)
-	if quote == "" {
+	if quote == "" || len(strings.Fields(quote)) < minQuoteWords {
 		return false
 	}
 	for _, m := range transcript {

--- a/internal/assistant/user_said_test.go
+++ b/internal/assistant/user_said_test.go
@@ -24,6 +24,8 @@ func TestUserSaid(t *testing.T) {
 		{"an invention does not pass", "I led a team of fifty", false},
 		{"an empty quote does not pass", "", false},
 		{"whitespace alone does not pass", "   ", false},
+		{"a single word does not pass even if it is a verbatim hit", "Kafka", false},
+		{"two short words do not pass even if the substring is real", "the Kafka", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/handler/assistant_experience_tools.go
+++ b/internal/handler/assistant_experience_tools.go
@@ -53,7 +53,7 @@ func (h *assistantHandlers) assistantExperienceTools(sessionID uuid.UUID) []assi
 		h.experienceGetTool(),
 		h.experienceEmploymentsTool(),
 		h.experienceAddTool(sessionID),
-		h.experienceUpdateTool(),
+		h.experienceUpdateTool(sessionID),
 		h.experienceMergeTool(),
 		h.experienceSetRequireContextTool(),
 	}
@@ -335,12 +335,14 @@ func (h *assistantHandlers) experienceAddTool(sessionID uuid.UUID) assistant.Too
 
 // experienceUpdateTool sharpens an atom the bank already holds — a metric that surfaced, a
 // detail the first telling left out.
-func (h *assistantHandlers) experienceUpdateTool() assistant.Tool {
+func (h *assistantHandlers) experienceUpdateTool(sessionID uuid.UUID) assistant.Tool {
 	return assistant.Tool{
 		Name: "experience_update",
 		Description: "Refine an achievement already in the bank: add the metric that just came up, " +
 			"correct a detail, attach it to the right role. Address it by the id a search returned. " +
-			"The fields you send replace the ones stored; omit a field to leave it as it is.",
+			"The fields you send replace the ones stored; omit a field to leave it as it is. Changing " +
+			"claim, context or metrics re-earns provenance the same way experience_add does: cite the " +
+			"candidate's own words in said, or the edit is recorded as your inference, not theirs.",
 		Schema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -350,6 +352,12 @@ func (h *assistantHandlers) experienceUpdateTool() assistant.Tool {
 				"metrics":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "The full replacement metric list."},
 				"skills":        map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "The full replacement skill list."},
 				"employment_id": map[string]any{"type": "string", "description": "The role this belongs to, from experience_employments."},
+				"said": map[string]any{
+					"type": "string",
+					"description": "The candidate's own words backing the new claim, context or metrics, copied " +
+						"verbatim from their message in this conversation. Required to keep a confirmed " +
+						"achievement confirmed when you change what it says; omit if they did not say it.",
+				},
 			},
 			"required":             []string{"id"},
 			"additionalProperties": false,
@@ -362,6 +370,7 @@ func (h *assistantHandlers) experienceUpdateTool() assistant.Tool {
 				Metrics      *[]string `json:"metrics"`
 				Skills       *[]string `json:"skills"`
 				EmploymentID *string   `json:"employment_id"`
+				Said         string    `json:"said"`
 			}
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
@@ -374,6 +383,12 @@ func (h *assistantHandlers) experienceUpdateTool() assistant.Tool {
 			atom, err := h.experience.GetAtom(ctx, id, userID)
 			if err != nil {
 				return nil, err
+			}
+			// Content the provenance is meant to vouch for is changing, so the provenance is
+			// re-derived rather than carried over from the fetch — otherwise a confirmed atom
+			// stays "confirmed" no matter how far the model edits it from what was said.
+			if in.Claim != nil || in.Context != nil || in.Metrics != nil {
+				atom.Provenance = h.provenanceFor(ctx, sessionID, in.Said)
 			}
 			if in.Claim != nil {
 				atom.Claim = *in.Claim

--- a/internal/handler/assistant_experience_tools_test.go
+++ b/internal/handler/assistant_experience_tools_test.go
@@ -471,3 +471,53 @@ func TestARejectedEmploymentIdWithNoRolesSaysSo(t *testing.T) {
 		t.Errorf("the refusal should say the bank holds no roles yet:\n%s", payload)
 	}
 }
+
+// Editing the claim of an atom the candidate already confirmed must re-earn provenance —
+// otherwise the model can quietly rewrite what a confirmed achievement says (a different
+// number, a bigger scope) and the CV gate still treats it as the candidate's own words,
+// because it only ever looks at the provenance column, not at whether today's text is what
+// was confirmed.
+func TestExperienceUpdateDropsProvenanceWhenTheClaimChangesWithoutANewQuote(t *testing.T) {
+	bank := newStubBank()
+	stored := bank.add(1, experience.Atom{Claim: "Cut latency 20s to 1s", Provenance: experience.ProvenanceStatedInChat})
+	reg, _ := experienceToolsFor(t, bank)
+
+	out := reg.Call(context.Background(), 1, "experience_update",
+		json.RawMessage(`{"id":"`+stored.ID.String()+`","claim":"Cut latency 20s to 100ms"}`))
+	var decoded struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(out.Content), &decoded); err != nil {
+		t.Fatalf("tool result is not JSON: %v (%s)", err, out.Content)
+	}
+	if decoded.Error != "" {
+		t.Fatalf("update failed: %s", decoded.Error)
+	}
+	if got := bank.atoms[stored.ID].Provenance; got != experience.ProvenanceAgentInferred {
+		t.Errorf("provenance = %q after an unconfirmed claim edit, want %q", got, experience.ProvenanceAgentInferred)
+	}
+}
+
+// A field that carries no factual assertion — which role an achievement belongs to — must
+// not cost the atom its confirmed provenance. Only rewriting what the atom claims should
+// require re-confirmation.
+func TestExperienceUpdateKeepsProvenanceWhenOnlyEmploymentChanges(t *testing.T) {
+	bank := newStubBank()
+	stored := bank.add(1, experience.Atom{Claim: "Cut latency 20s to 1s", Provenance: experience.ProvenanceStatedInChat})
+	reg, _ := experienceToolsFor(t, bank)
+
+	out := reg.Call(context.Background(), 1, "experience_update",
+		json.RawMessage(`{"id":"`+stored.ID.String()+`","employment_id":"`+uuid.New().String()+`"}`))
+	var decoded struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(out.Content), &decoded); err != nil {
+		t.Fatalf("tool result is not JSON: %v (%s)", err, out.Content)
+	}
+	if decoded.Error != "" {
+		t.Fatalf("update failed: %s", decoded.Error)
+	}
+	if got := bank.atoms[stored.ID].Provenance; got != experience.ProvenanceStatedInChat {
+		t.Errorf("provenance = %q after a no-op update, want unchanged %q", got, experience.ProvenanceStatedInChat)
+	}
+}


### PR DESCRIPTION
## Summary
- `UserSaid` accepted any substring hit as a verbatim citation — a quote as short as "the" or "I" could confirm a fabricated achievement as `stated_in_chat` if that word appeared anywhere in the session. Now requires a 3+ word quote.
- `experience_update` let the model rewrite `claim`/`context`/`metrics` on an atom while keeping its existing provenance, so a confirmed number (e.g. "20s to 1s") could silently drift to something never confirmed and still count as publishable. It now re-derives provenance via the same `said`-citation check `experience_add` uses whenever those fields change.

Found during a security review of the experience-bank provenance model (`internal/experience`, `internal/handler/assistant_experience_tools.go`, `internal/assistant/message.go`). Two other findings from that review (no untrusted-content marking on `experience_search` results; the `/me/experience` API key stamping `manual`) were left as-is — documented design tradeoffs / separate architectural work, not point fixes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean on touched files
- [x] `go test ./internal/handler/... ./internal/assistant/... ./internal/experience/...`
- [x] New tests: `TestUserSaid` short-quote cases; `TestExperienceUpdateDropsProvenanceWhenTheClaimChangesWithoutANewQuote`; `TestExperienceUpdateKeepsProvenanceWhenOnlyEmploymentChanges`