### PR TITLE
Add software_engineering category for confirmed-tech, discipline-unstated titles

### DIFF
--- a/design-system/docs/dsds/components.json
+++ b/design-system/docs/dsds/components.json
@@ -394,6 +394,16 @@
           "type": "Snippet"
         },
         {
+          "name": "variant",
+          "type": "EmptyStateVariant",
+          "default": "default",
+          "values": [
+            "default",
+            "muted",
+            "destructive"
+          ]
+        },
+        {
           "name": "action",
           "type": "Snippet"
         },

--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -1,17 +1,17 @@
 {
-  "Alert": 0,
+  "Alert": 1,
   "Avatar": 0,
   "Badge": 12,
   "Button": 55,
   "Card": 1,
-  "Chip": 0,
+  "Chip": 1,
   "Dialog": 6,
-  "EmptyState": 0,
-  "FormField": 0,
+  "EmptyState": 1,
+  "FormField": 2,
   "Input": 12,
   "Pagination": 0,
   "Skeleton": 1,
-  "Table": 0,
+  "Table": 6,
   "Tabs": 0,
   "Tooltip": 0
 }

--- a/design-system/src/empty-state.stories.ts
+++ b/design-system/src/empty-state.stories.ts
@@ -5,6 +5,9 @@ const meta = {
   title: 'Primitives/EmptyState',
   component: EmptyState,
   tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'muted', 'destructive'] },
+  },
 } satisfies Meta<typeof EmptyState>;
 
 export default meta;
@@ -14,3 +17,5 @@ export const Default: Story = {
   args: { title: 'No results found', description: 'Try adjusting your filters to see more jobs.' },
 };
 export const Minimal: Story = { args: { title: 'Nothing here yet' } };
+export const Muted: Story = { args: { title: 'Nothing here yet', variant: 'muted' } };
+export const Destructive: Story = { args: { title: 'Something went wrong.', variant: 'destructive' } };

--- a/design-system/src/empty-state.svelte
+++ b/design-system/src/empty-state.svelte
@@ -1,3 +1,23 @@
+<script lang="ts" module>
+  import { tv, type VariantProps } from 'tailwind-variants';
+
+  export const emptyStateVariants = tv({
+    slots: {
+      title: 'text-sm text-foreground',
+    },
+    variants: {
+      variant: {
+        default: { title: 'font-medium' },
+        muted: { title: 'text-muted-foreground' },
+        destructive: { title: 'text-destructive' },
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  });
+
+  export type EmptyStateVariant = VariantProps<typeof emptyStateVariants>['variant'];
+</script>
+
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { cn } from './cn.js';
@@ -6,27 +26,34 @@
     title = 'Nothing here yet',
     description,
     icon,
+    variant = 'default',
     class: className,
     action,
   }: {
     title?: string;
     description?: string;
     icon?: Snippet;
+    variant?: EmptyStateVariant;
     class?: string;
     action?: Snippet;
   } = $props();
+
+  const slots = $derived(emptyStateVariants({ variant }));
+  // Mirrors alert.svelte: a destructive result is worth interrupting for, the
+  // other variants are page furniture that should not barge in on every render.
+  const role = $derived(variant === 'destructive' ? 'alert' : 'status');
 </script>
 
 <div
   class={cn('flex flex-col items-center justify-center gap-3 py-12 text-center', className)}
-  role="status"
+  {role}
 >
   {#if icon}
     <div class="text-muted-foreground">
       {@render icon()}
     </div>
   {/if}
-  <p class="text-sm font-medium text-foreground">{title}</p>
+  <p class={slots.title()}>{title}</p>
   {#if description}
     <p class="max-w-sm text-sm text-muted-foreground">{description}</p>
   {/if}

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -24,7 +24,7 @@ func TestParse(t *testing.T) {
 		// win in any complete title).
 		{"Senior Data Scien", "senior", "data_science"},
 		{"Lead DevOps Engineer", "lead", "devops"},
-		{"Staff Software Engineer", "staff", ""},
+		{"Staff Software Engineer", "staff", "software_engineering"},
 		{"Full Stack Developer", "", "fullstack"},
 		{"Data Analyst", "", "data_analytics"},
 		{"QA Automation Engineer", "", "qa"},
@@ -94,13 +94,16 @@ func TestParse(t *testing.T) {
 		// noun ("engineer") keeps it in product.
 		{"Algebrik.ai-Product Manager", "", "product"},
 		// "AI-native"/"AI-enabled" describe how the engineer WORKS, not what they
-		// build, so they claim no category — the rest of the title still decides.
+		// build, so they name no discipline — the rest of the title still decides,
+		// and the bare form falls to the generic software_engineering catch-all.
 		{"AI-Native Engineer (Test Automation)", "", "qa"},
-		{"AI-Native Engineer", "", ""},
+		{"AI-Native Engineer", "", "software_engineering"},
 		{"Senior AI-Native Product Engineer", "senior", ""},
-		// Generalist titles state no sub-discipline, so the category stays empty
-		// rather than being guessed (they are carried by is_tech and a named role).
-		{"Founding Engineer", "", ""},
+		// "Founding Engineer" states no sub-discipline either, so it resolves to the
+		// same generic catch-all. "Product Engineer" deliberately does not (see
+		// tech.go: prod titles split ~2:1 software vs manufacturing for that one), so
+		// it stays empty rather than being guessed — carried by is_tech alone.
+		{"Founding Engineer", "", "software_engineering"},
 		{"Product Engineer", "", ""},
 		// SEO / social fold into marketing; "social media" beats a bare "manager".
 		{"SEO Specialist", "", "marketing"},
@@ -135,21 +138,23 @@ func TestParseGradeBlindPhrases(t *testing.T) {
 		wantSeniority string
 		wantCategory  string
 	}{
-		// MTS is a generic IC title at Oracle/xAI/Pure Storage, not the staff grade.
-		{"Member of Technical Staff", "", ""},
-		{"Member of the Technical Staff, Interpretability", "", ""},
+		// MTS is a generic IC title at Oracle/xAI/Pure Storage, not the staff grade —
+		// but it IS software, so it resolves to the generic catch-all category.
+		{"Member of Technical Staff", "", "software_engineering"},
+		{"Member of the Technical Staff, Interpretability", "", "software_engineering"},
 		// With the phrase masked, the remaining words state the real grade.
-		{"Senior Member of Technical Staff", "senior", ""},
+		{"Senior Member of Technical Staff", "senior", "software_engineering"},
 		{"Senior Member of Technical Staff (SMTS) - Cloud Product Support", "senior", "support"},
-		{"Principal Member of Technical Staff", "principal", ""},
+		{"Principal Member of Technical Staff", "principal", "software_engineering"},
 		{"Principal Member of Technical Staff, Full-stack Engineer", "principal", "fullstack"},
 		// "Mid-training" is a model-training stage (the sibling of pre- and
 		// post-training), not the middle grade. The hyphen is a word boundary, so
 		// the bare "mid" alias matched inside it.
-		{"Member of Technical Staff - Mid-training", "", ""},
+		{"Member of Technical Staff - Mid-training", "", "software_engineering"},
 		// "Agent Post-Training" states a research area, not a role noun, so the
-		// category stays empty — the dictionary does not guess from a topic word.
-		{"Member of Technical Staff — Agent Post-Training", "", ""},
+		// category does not narrow past the generic catch-all — the dictionary does
+		// not guess from a topic word.
+		{"Member of Technical Staff — Agent Post-Training", "", "software_engineering"},
 		// "Middle East" is a region. 142 of 217 prod titles carrying it were being
 		// graded middle on the strength of the geography alone.
 		{"Middle East Editor", "", ""},
@@ -168,7 +173,7 @@ func TestParseGradeBlindPhrases(t *testing.T) {
 		{"Lead Generation Specialist", "", ""},
 		{"Lead Generation Manager", "", "management"},
 		// Regression: an honest grade that merely shares the word is untouched.
-		{"Staff Software Engineer", "staff", ""},
+		{"Staff Software Engineer", "staff", "software_engineering"},
 		{"Senior Staff Engineer", "staff", ""},
 		{"Technical Staff Engineer", "staff", ""},
 		{"Team Lead", "lead", ""},
@@ -191,7 +196,7 @@ func TestCategories(t *testing.T) {
 		{"single category", "Senior Backend Engineer", []string{"backend"}},
 		{"several distinct categories, precedence order", "Backend Engineer and Data Engineer doing machine learning", []string{"data_engineering", "ml_ai", "backend"}},
 		{"duplicate aliases collapse to one", "backend and back-end developer", []string{"backend"}},
-		{"generic title resolves nothing", "Software Engineer", nil},
+		{"generic title resolves to the catch-all", "Software Engineer", []string{"software_engineering"}},
 		{"empty", "", nil},
 	}
 	for _, tc := range tests {

--- a/internal/classify/dictionaries.go
+++ b/internal/classify/dictionaries.go
@@ -126,6 +126,7 @@ var categoryTable = []aliasEntry{
 	{"data platform", "data_engineering"},
 	{"data governance", "data_engineering"},
 	{"data steward", "data_engineering"},
+	{"etl developer", "data_engineering"},
 	{"data scientist", "data_science"},
 	{"data science", "data_science"},
 	// "data scien" fires only on a title truncated mid-word ("Senior Data Scien…"),
@@ -146,12 +147,18 @@ var categoryTable = []aliasEntry{
 	{"bi analyst", "data_analytics"},
 	{"business intelligence developer", "data_analytics"},
 	{"bi developer", "data_analytics"},
+	{"power bi developer", "data_analytics"},
 	{"аналитик bi", "data_analytics"},
 	{"bi-аналитик", "data_analytics"},
 	// Classic ML and explicitly ML-carrying combined forms first, so a mixed
 	// "ML/AI Engineer" resolves to ml_ai before the bare AI terms below can claim it.
 	{"machine learning", "ml_ai"},
 	{"deep learning", "ml_ai"},
+	// Classic ML sub-disciplines that name neither "machine learning" nor "ai" —
+	// unambiguous on their own, so they resolve here rather than falling to the
+	// generic software_engineering catch-all at the bottom of the table.
+	{"computer vision engineer", "ml_ai"},
+	{"nlp engineer", "ml_ai"},
 	{"ml engineer", "ml_ai"},
 	{"ml/ai", "ml_ai"},
 	{"ai/ml", "ml_ai"},
@@ -172,6 +179,7 @@ var categoryTable = []aliasEntry{
 	{"ai agent engineer", "ai_engineering"},
 	{"agent engineer", "ai_engineering"},
 	{"ai research engineer", "ai_engineering"},
+	{"ai software engineer", "ai_engineering"},
 	{"ai automation engineer", "ai_engineering"},
 	// Hyphenated spellings. A hyphen is a word boundary, so the spaced aliases above
 	// cannot reach them. "ai-agent engineer" needs no entry — the bare "agent engineer"
@@ -192,7 +200,15 @@ var categoryTable = []aliasEntry{
 	{"infrastructure engineer", "devops"},
 	{"cloud engineer", "devops"},
 	{"system administrator", "devops"},
+	// The plural is the far more common surface form in prod titles ("Systems
+	// Administrator") and does not contain "system administrator" as a substring
+	// (the trailing "s" breaks the word boundary), so it needs its own entry.
+	{"systems administrator", "devops"},
 	{"sysadmin", "devops"},
+	{"database administrator", "devops"},
+	{"linux administrator", "devops"},
+	{"windows administrator", "devops"},
+	{"it administrator", "devops"},
 	// MLOps is DevOps practice specialized to ML artifacts (CI/CD, deployment,
 	// monitoring for models) — the operational lifecycle, not the modeling itself,
 	// which stays in ml_ai/ai_engineering above.
@@ -215,9 +231,21 @@ var categoryTable = []aliasEntry{
 	{"front end", "frontend"},
 	{"фронтенд", "frontend"},
 	{"фронт", "frontend"},
+	// Frontend-only frameworks named in a "<Framework> Developer" title — the
+	// framework itself states the discipline, so this is not a guess the way a
+	// bare language ("Java Developer") would be.
+	{"react developer", "frontend"},
+	{"react.js developer", "frontend"},
+	{"reactjs developer", "frontend"},
+	{"angular developer", "frontend"},
+	{"vue developer", "frontend"},
+	{"vue.js developer", "frontend"},
+	{"vuejs developer", "frontend"},
 	{"mobile", "mobile"},
 	{"android", "mobile"},
 	{"ios", "mobile"},
+	// React Native is mobile-only, unlike bare "react" above.
+	{"react native developer", "mobile"},
 	{"мобильный", "mobile"},
 	{"мобильная", "mobile"},
 	{"мобильных", "mobile"},
@@ -270,6 +298,11 @@ var categoryTable = []aliasEntry{
 	{"встраиваемых", "embedded"},
 	{"blockchain", "blockchain"},
 	{"блокчейн", "blockchain"},
+	// "Web3"/"smart contract" name the blockchain domain as unambiguously as the
+	// word "blockchain" itself, so these resolve here rather than the generic
+	// software_engineering catch-all.
+	{"web3 developer", "blockchain"},
+	{"smart contract developer", "blockchain"},
 	{"hardware", "hardware"},
 	{"fpga", "hardware"},
 	{"solutions architect", "architecture"},
@@ -676,6 +709,75 @@ var categoryTable = []aliasEntry{
 	{"менеджер", "management"},
 	{"analyst", "data_analytics"},
 	{"аналитик", "data_analytics"},
+	// software_engineering: the generic catch-all for a title classify.IsTech's
+	// techTitleTerms already confirms as software/IT work but that names no
+	// sub-discipline — "Software Engineer" and "Java Developer" do not say
+	// backend vs frontend vs fullstack, and this package never guesses. Every
+	// entry below mirrors a techTitleTerms member that has no more specific
+	// categoryTable entry above it (cross-checked against tech.go so the two
+	// lists cannot silently drift). Kept at the very bottom, second-to-last
+	// before the 1C fallback, so any more specific alias anywhere above always
+	// wins first — these only fire once nothing else has.
+	//
+	// Deliberately EXCLUDED: bare "programmer" (techTitleTerms has it as an
+	// "unambiguous" single word for is_tech, but prod titles include "CNC
+	// Programmer" — a machining role, not software — so a category entry here
+	// would mislabel it; is_tech's false positive on it is a separate, smaller
+	// bug left alone).
+	//
+	// The base phrases ("software engineer", "software developer", "software
+	// development engineer") deliberately carry every qualified variant with
+	// them by substring, the same convention the "design engineer" bare form
+	// uses above: "Senior Software Engineer, Platform" and "AI Software
+	// Engineer, Internal Tools" resolve without their own entry.
+	{"software engineer", "software_engineering"},
+	{"software development engineer", "software_engineering"},
+	{"software developer", "software_engineering"},
+	{"web developer", "software_engineering"},
+	{"web engineer", "software_engineering"},
+	{"app developer", "software_engineering"},
+	{"application developer", "software_engineering"},
+	{"game developer", "software_engineering"},
+	{"go engineer", "software_engineering"},
+	{"golang engineer", "software_engineering"},
+	{"go developer", "software_engineering"},
+	{"golang developer", "software_engineering"},
+	{"python developer", "software_engineering"},
+	{"java developer", "software_engineering"},
+	{"javascript developer", "software_engineering"},
+	{"typescript developer", "software_engineering"},
+	{".net developer", "software_engineering"},
+	{"dotnet developer", "software_engineering"},
+	{"php developer", "software_engineering"},
+	{"ruby developer", "software_engineering"},
+	{"rails developer", "software_engineering"},
+	{"c# developer", "software_engineering"},
+	{"c++ developer", "software_engineering"},
+	{"node developer", "software_engineering"},
+	{"nodejs developer", "software_engineering"},
+	{"node.js developer", "software_engineering"},
+	{"salesforce developer", "software_engineering"},
+	{"sharepoint developer", "software_engineering"},
+	{"database developer", "software_engineering"},
+	{"rpa developer", "software_engineering"},
+	{"erp developer", "software_engineering"},
+	{"sap developer", "software_engineering"},
+	{"oracle developer", "software_engineering"},
+	{"abap developer", "software_engineering"},
+	{"wordpress developer", "software_engineering"},
+	{"drupal developer", "software_engineering"},
+	{"magento developer", "software_engineering"},
+	{"shopify developer", "software_engineering"},
+	// "Member of Technical Staff" reads as software on the same evidence tech.go
+	// cites (294/300 sampled prod postings software or AI). "Founding Engineer"
+	// is the early-startup twin of the same generalist population.
+	{"member of technical staff", "software_engineering"},
+	{"member of the technical staff", "software_engineering"},
+	{"founding engineer", "software_engineering"},
+	// "AI-native"/"AI-enabled" describe the toolchain, not the discipline (same
+	// reasoning as tech.go's techTitleTerms entry for these).
+	{"ai-native engineer", "software_engineering"},
+	{"ai native engineer", "software_engineering"},
 	// 1С (the RU enterprise/ERP dev platform) resolves last so a more specific role word in the
 	// title wins first ("Аналитик 1С" → data_analytics, "Тестировщик 1С" → qa); a title whose only
 	// signal is 1С ("Программист 1С", "1С-разработчик") reads as backend — server-side enterprise

--- a/internal/cvmatch/title.go
+++ b/internal/cvmatch/title.go
@@ -48,9 +48,9 @@ func titleCategory(jobTitle, cvText string) ScoredCategory {
 		fmt.Sprintf("Your CV never states the title %q", stated))
 
 	// The role-field check is only evaluable when the dictionary resolves the vacancy's
-	// title to a category. When it does not — a software generalist resolves none by design
-	// — the check leaves this category's denominator rather than costing points nobody
-	// could have earned.
+	// title to a category. When it does not — e.g. "Product Engineer", which splits too
+	// evenly between software and manufacturing for classify to guess — the check leaves
+	// this category's denominator rather than costing points nobody could have earned.
 	field := classify.Parse(jobTitle).Category
 	if field == "" {
 		return c

--- a/internal/cvmatch/title_test.go
+++ b/internal/cvmatch/title_test.go
@@ -87,12 +87,13 @@ func TestTitleCategoryUnavailableWithoutAVacancyTitle(t *testing.T) {
 }
 
 // The recursive half of the unverifiable rule: a check the dictionaries cannot evaluate
-// leaves the CATEGORY's own denominator. "Staff Software Engineer" resolves no role
-// category — the dictionary has no value for a software generalist and deliberately emits
-// nothing — so the category scores out of the exact-title check alone, not out of 20 with
-// 8 points the candidate could never have earned.
+// leaves the CATEGORY's own denominator. "Product Engineer" resolves no role category —
+// prod titles split ~2:1 software vs manufacturing for that exact phrase, so classify
+// deliberately emits nothing rather than guess — so the category scores out of the
+// exact-title check alone, not out of 20 with 8 points the candidate could never have
+// earned.
 func TestTitleCategoryUnresolvedRoleCategoryShrinksTheDenominator(t *testing.T) {
-	c := titleCategory("Staff Software Engineer", "Staff Software Engineer at Acme, five years in Go.")
+	c := titleCategory("Product Engineer", "Product Engineer at Acme, five years in Go.")
 
 	if !c.Available {
 		t.Fatalf("category is unavailable: %q", c.Reason)
@@ -102,6 +103,25 @@ func TestTitleCategoryUnresolvedRoleCategoryShrinksTheDenominator(t *testing.T) 
 	}
 	if c.Earned != c.Weight {
 		t.Errorf("earned = %d of weight %d: an exact title match must earn everything still on the table", c.Earned, c.Weight)
+	}
+}
+
+// "Staff Software Engineer" USED to be the unresolvable example above: the dictionary had
+// no value for a software generalist. It now resolves to the software_engineering
+// catch-all category, so the role-field check becomes evaluable too — the full weight is
+// on the table, and a CV that never claims software work at all loses real points instead
+// of the vacancy being scored on title text alone.
+func TestTitleCategoryGenericSoftwareEngineerNowResolvesTheFullWeight(t *testing.T) {
+	c := titleCategory("Staff Software Engineer", "Staff Software Engineer at Acme, five years in Go.")
+
+	if !c.Available {
+		t.Fatalf("category is unavailable: %q", c.Reason)
+	}
+	if c.Weight != WeightTitle {
+		t.Errorf("weight = %d, want the full %d — software_engineering now resolves, so the role-field check is evaluable", c.Weight, WeightTitle)
+	}
+	if c.Earned != c.Weight {
+		t.Errorf("earned = %d of weight %d: exact title plus a CV that states software work should earn everything", c.Earned, c.Weight)
 	}
 }
 

--- a/internal/roletag/roletag.go
+++ b/internal/roletag/roletag.go
@@ -44,32 +44,38 @@ var seniorityLabel = map[string]string{
 // ("{seniorityLabel} {categoryNoun}", e.g. senior + backend → "Senior Backend
 // Engineer").
 var categoryNoun = map[string]string{
-	"backend":             "Backend Engineer",
-	"frontend":            "Frontend Engineer",
-	"fullstack":           "Fullstack Engineer",
-	"mobile":              "Mobile Engineer",
-	"devops":              "DevOps Engineer",
-	"sre":                 "Site Reliability Engineer",
-	"network_engineering": "Network Engineer",
-	"data_engineering":    "Data Engineer",
-	"data_science":        "Data Scientist",
-	"data_analytics":      "Data Analyst",
-	"ml_ai":               "ML Engineer",
-	"ai_engineering":      "AI Engineer",
-	"qa":                  "QA Engineer",
-	"security":            "Security Engineer",
-	"hardware":            "Hardware Engineer",
-	"embedded":            "Embedded Engineer",
-	"blockchain":          "Blockchain Engineer",
-	"architecture":        "Architect",
-	"design":              "Designer",
-	"engineering_design":  "Engineering Designer",
-	"product":             "Product Manager",
-	"project_management":  "Project Manager",
-	"management":          "Manager",
-	"marketing":           "Marketing Specialist",
-	"sales":               "Sales Specialist",
-	"support":             "Support Specialist",
+	// Deliberately NOT "Software Engineer": the namedRoleTable below already owns
+	// that exact label for its own "software_engineer" slug (title-matched,
+	// independent of category, and depended on by web/src/lib/roleRelated.ts and
+	// collections.ts) — an identical label on a second slug would show as a
+	// confusing duplicate in the role picker.
+	"software_engineering": "Software Generalist",
+	"backend":              "Backend Engineer",
+	"frontend":             "Frontend Engineer",
+	"fullstack":            "Fullstack Engineer",
+	"mobile":               "Mobile Engineer",
+	"devops":               "DevOps Engineer",
+	"sre":                  "Site Reliability Engineer",
+	"network_engineering":  "Network Engineer",
+	"data_engineering":     "Data Engineer",
+	"data_science":         "Data Scientist",
+	"data_analytics":       "Data Analyst",
+	"ml_ai":                "ML Engineer",
+	"ai_engineering":       "AI Engineer",
+	"qa":                   "QA Engineer",
+	"security":             "Security Engineer",
+	"hardware":             "Hardware Engineer",
+	"embedded":             "Embedded Engineer",
+	"blockchain":           "Blockchain Engineer",
+	"architecture":         "Architect",
+	"design":               "Designer",
+	"engineering_design":   "Engineering Designer",
+	"product":              "Product Manager",
+	"project_management":   "Project Manager",
+	"management":           "Manager",
+	"marketing":            "Marketing Specialist",
+	"sales":                "Sales Specialist",
+	"support":              "Support Specialist",
 	// IT-company roles added by expand-role-taxonomy.
 	"business_analysis":     "Business Analyst",
 	"solutions_engineering": "Solutions Engineer",
@@ -92,8 +98,15 @@ var namedRoleTable = []struct {
 	slug, label string
 	aliases     []string
 }{
-	// Generic engineering catch-all (classify assigns no category to a bare
-	// "Software Engineer"): the largest category-less bucket in the catalogue.
+	// Generic engineering catch-all. classify's software_engineering category
+	// (added alongside this role) now ALSO resolves a bare "Software Engineer" —
+	// the two coexist deliberately, the same layering every granular named role
+	// below uses over its coarse category (android_developer + mobile,
+	// systems_administrator + devops, …); categoryNoun gives the category a
+	// distinct label ("Software Generalist") specifically so the two do not show
+	// as duplicate-looking picker options. This role's own label/aliases/slug stay
+	// unchanged since web/src/lib/roleRelated.ts and collections.ts depend on the
+	// exact "software_engineer" slug.
 	{"software_engineer", "Software Engineer", []string{"software engineer", "software developer", "software development engineer", "web developer", "sde", "swe"}},
 
 	// Startup / cross-cutting engineering.

--- a/internal/roletag/roletag_test.go
+++ b/internal/roletag/roletag_test.go
@@ -35,6 +35,12 @@ func TestDerive(t *testing.T) {
 
 		// Named roles come from the title regardless of the grid.
 		{"software engineer catch-all", "", "", "Software Engineer", []string{"software_engineer"}},
+		// classify's software_engineering category (added alongside this named
+		// role) now ALSO resolves a bare "Software Engineer", so real input carries
+		// both: the bare category role plus the named role, deliberately under
+		// different labels ("Software Generalist" vs "Software Engineer" — see
+		// categoryNoun) so the picker never shows two identical-looking options.
+		{"software engineering category + named role coexist", "", "software_engineering", "Software Engineer", []string{"software_engineering", "software_engineer"}},
 		{"founding engineer, empty grid", "", "", "Founding Engineer", []string{"founding_engineer"}},
 		// Generalist titles classify assigns no category to: the named role is the
 		// only thing that makes them pickable.

--- a/internal/vocab/vocab.go
+++ b/internal/vocab/vocab.go
@@ -35,6 +35,15 @@ var (
 	EnglishLevelValues   = []string{"none", "a1", "a2", "b1", "b2", "c1", "c2", "native"}
 	EducationLevelValues = []string{"none", "bachelor", "master", "phd"}
 	CategoryValues       = []string{
+		// "software_engineering" is the generic bucket for a title the dictionary
+		// confirms is software/IT work (feeds is_tech via classify.IsTech's
+		// techTitleTerms) but that names no sub-discipline to resolve to — a bare
+		// "Software Engineer" or "Java Developer" does not say backend vs frontend
+		// vs fullstack, and classify never guesses. Before this category existed
+		// that population sat at `category = ""` forever (~110k open postings on
+		// prod at introduction) despite being fully enriched; this gives it a home
+		// instead of leaving it unfilterable.
+		"software_engineering",
 		"backend", "frontend", "fullstack", "mobile", "devops", "sre",
 		"network_engineering",
 		"data_engineering", "data_science", "data_analytics", "ml_ai", "ai_engineering",
@@ -82,6 +91,7 @@ var (
 	// solutions_engineering/developer_relations/technical_writing — count as technical
 	// here (IT-industry roles), so they are enriched; the back-office roles are not.
 	TechCategories = []string{
+		"software_engineering",
 		"backend", "frontend", "fullstack", "mobile", "devops", "sre",
 		"network_engineering",
 		"data_engineering", "data_science", "data_analytics", "ml_ai", "ai_engineering",

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -9,7 +9,7 @@
   import { markSaved, markUnsaved } from '$lib/savedJobs.svelte';
   import { track } from '$lib/analytics';
   import type { Job, UserJob } from '$lib/types';
-  import { Badge, Button } from '$lib/ui';
+  import { Badge, Button, Chip } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
   import BackerBadge from './BackerBadge.svelte';
@@ -250,9 +250,9 @@
       <div class="flex flex-wrap items-center gap-2.5">
         <h1 class="text-2xl font-semibold tracking-tight">{job.title}</h1>
         {#if applied}
-          <span class="inline-flex items-center gap-1.5 rounded-full border border-brand/30 bg-brand-muted px-2.5 py-0.5 text-xs font-semibold text-brand-strong">
+          <Chip variant="brand" class="gap-1.5 border-brand/30 font-semibold">
             <CheckCircle2 class="size-3.5" aria-hidden="true" /> Applied
-          </span>
+          </Chip>
         {/if}
       </div>
 

--- a/web/src/lib/components/ReferralsView.svelte
+++ b/web/src/lib/components/ReferralsView.svelte
@@ -13,7 +13,7 @@
     ReferralRequestStatus,
     SeekerReferralRequest,
   } from '$lib/types';
-  import { Button } from '$lib/ui';
+  import { Button, FormField, Table } from '$lib/ui';
   import { isLinkedInUrl, timeAgo } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
   import CompanyPicker from './CompanyPicker.svelte';
@@ -173,37 +173,35 @@
   {:else if requests.value.length === 0}
     <States state="empty" message="You haven't requested any referrals yet." />
   {:else}
-    <table class="mt-4 w-full text-sm">
-      <thead>
+    <Table class="mt-4">
+      {#snippet header()}
         <tr class="text-xs uppercase tracking-wide text-muted-foreground">
           <th class="pb-2 pr-4 text-left font-semibold">Company</th>
           <th class="pb-2 pr-4 text-left font-semibold">CV shared</th>
           <th class="pb-2 pr-4 text-left font-semibold">Status</th>
           <th class="pb-2 text-left font-semibold">Sent</th>
         </tr>
-      </thead>
-      <tbody>
-        {#each requests.value as r (r.id)}
-          <tr class="border-t border-border">
-            <td class="py-3 pr-4 font-medium">
-              <a href={resolve('/companies/[slug]', { slug: r.company_slug })} class="flex items-center gap-2 hover:underline">
-                <CompanyLogo name={r.company_name || r.company_slug} size="size-6" />
-                <span class="min-w-0 truncate">{r.company_name || r.company_slug}</span>
-              </a>
-            </td>
-            <td class="py-3 pr-4 text-muted-foreground">
-              {r.cv_kind === 'built' ? 'Tailored CV' : 'Uploaded CV'}
-            </td>
-            <td class="py-3 pr-4">
-              <span class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-semibold {pillClass[r.status]}">
-                {pillLabel[r.status]}
-              </span>
-            </td>
-            <td class="py-3 text-muted-foreground">{r.created_at ? timeAgo(r.created_at) : ''}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/snippet}
+      {#each requests.value as r (r.id)}
+        <tr class="border-t border-border">
+          <td class="py-3 pr-4 font-medium">
+            <a href={resolve('/companies/[slug]', { slug: r.company_slug })} class="flex items-center gap-2 hover:underline">
+              <CompanyLogo name={r.company_name || r.company_slug} size="size-6" />
+              <span class="min-w-0 truncate">{r.company_name || r.company_slug}</span>
+            </a>
+          </td>
+          <td class="py-3 pr-4 text-muted-foreground">
+            {r.cv_kind === 'built' ? 'Tailored CV' : 'Uploaded CV'}
+          </td>
+          <td class="py-3 pr-4">
+            <span class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-semibold {pillClass[r.status]}">
+              {pillLabel[r.status]}
+            </span>
+          </td>
+          <td class="py-3 text-muted-foreground">{r.created_at ? timeAgo(r.created_at) : ''}</td>
+        </tr>
+      {/each}
+    </Table>
     <p class="mt-4 text-xs text-muted-foreground">
       No notifications here — the referrer contacts you over the channel you left.
     </p>
@@ -223,21 +221,25 @@
         <CompanyPicker onSelect={(c) => (offerSlug = c?.slug ?? '')} />
         <span class="text-xs text-muted-foreground">Search and pick the company you work at.</span>
       </div>
-      <label class="flex flex-col gap-1.5 text-sm">
-        <span class="font-medium">Your LinkedIn profile</span>
-        <input
-          type="url"
-          bind:value={offerLinkedin}
-          placeholder="https://linkedin.com/in/your-handle"
-          aria-invalid={offerLinkedin.trim() !== '' && !offerLinkedinValid}
-          class="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
-        />
-        {#if offerLinkedin.trim() !== '' && !offerLinkedinValid}
-          <span class="text-xs text-destructive">Enter a full linkedin.com/in/… profile URL.</span>
-        {:else}
-          <span class="text-xs text-muted-foreground">Helps the moderator confirm you work there.</span>
-        {/if}
-      </label>
+      <FormField
+        label="Your LinkedIn profile"
+        error={offerLinkedin.trim() !== '' && !offerLinkedinValid
+          ? 'Enter a full linkedin.com/in/… profile URL.'
+          : undefined}
+        hint="Helps the moderator confirm you work there."
+      >
+        {#snippet children({ id, describedBy, invalid })}
+          <input
+            {id}
+            type="url"
+            bind:value={offerLinkedin}
+            placeholder="https://linkedin.com/in/your-handle"
+            aria-invalid={invalid}
+            aria-describedby={describedBy}
+            class="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
+          />
+        {/snippet}
+      </FormField>
       <label class="flex flex-col gap-1.5 text-sm">
         <span class="font-medium">Proof of employment (PDF)</span>
         <input type="file" accept="application/pdf" bind:files={offerFile} class="text-sm" />

--- a/web/src/lib/components/RequestReferralModal.svelte
+++ b/web/src/lib/components/RequestReferralModal.svelte
@@ -4,7 +4,7 @@
   import { api, ApiError } from '$lib/api';
   import type { CvTailoredItem } from '$lib/cv';
   import type { ReferralRequestInput } from '$lib/types';
-  import { Button, Dialog } from '$lib/ui';
+  import { Button, Dialog, FormField } from '$lib/ui';
   import { isLinkedInUrl } from '$lib/utils';
 
   // The parent owns open/close; this component owns the request form. jobId is the
@@ -178,21 +178,25 @@
           </label>
         </fieldset>
 
-        <label class="flex flex-col gap-1.5 text-sm">
-          <span class="font-medium">Your LinkedIn profile</span>
-          <input
-            type="url"
-            bind:value={linkedinUrl}
-            placeholder="https://linkedin.com/in/your-handle"
-            aria-invalid={linkedinUrl.trim() !== '' && !linkedinValid}
-            class="rounded-md border border-border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
-          />
-          {#if linkedinUrl.trim() !== '' && !linkedinValid}
-            <span class="text-xs text-destructive">Enter a full linkedin.com/in/… profile URL.</span>
-          {:else}
-            <span class="text-xs text-muted-foreground">The referrer vets you before reaching out.</span>
-          {/if}
-        </label>
+        <FormField
+          label="Your LinkedIn profile"
+          error={linkedinUrl.trim() !== '' && !linkedinValid
+            ? 'Enter a full linkedin.com/in/… profile URL.'
+            : undefined}
+          hint="The referrer vets you before reaching out."
+        >
+          {#snippet children({ id, describedBy, invalid })}
+            <input
+              {id}
+              type="url"
+              bind:value={linkedinUrl}
+              placeholder="https://linkedin.com/in/your-handle"
+              aria-invalid={invalid}
+              aria-describedby={describedBy}
+              class="rounded-md border border-border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
+            />
+          {/snippet}
+        </FormField>
 
         <div class="flex flex-col gap-1.5 text-sm">
           <span class="font-medium">

--- a/web/src/lib/components/States.svelte
+++ b/web/src/lib/components/States.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Skeleton } from '$lib/ui';
+  import { EmptyState, Skeleton } from '$lib/ui';
 
   // Shared rendering for the three async states every data view goes through.
   // `loading` shows placeholder rows; `empty`/`error` show a centered message.
@@ -25,7 +25,5 @@
     {/each}
   </div>
 {:else}
-  <p class="py-12 text-center text-sm {state === 'error' ? 'text-destructive' : 'text-muted-foreground'}">
-    {fallback}
-  </p>
+  <EmptyState title={fallback} variant={state === 'error' ? 'destructive' : 'muted'} />
 {/if}

--- a/web/src/lib/components/onboarding/OnboardingAlertBanner.svelte
+++ b/web/src/lib/components/onboarding/OnboardingAlertBanner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Bookmark, X } from '@lucide/svelte';
+  import { Alert } from '$lib/ui';
   import SaveSearchAlert from '../filters/SaveSearchAlert.svelte';
 
   // The ephemeral post-onboarding nudge: after the wizard configures a feed, offer to
@@ -18,7 +19,7 @@
   } = $props();
 </script>
 
-<div class="mb-3 flex items-start gap-3 rounded-xl border border-border bg-card p-3 pl-4">
+<Alert class="mb-3 rounded-xl p-3 pl-4">
   <div class="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand/10 text-brand-strong">
     <Bookmark class="size-4.5" />
   </div>
@@ -35,4 +36,4 @@
   >
     <X class="size-4" />
   </button>
-</div>
+</Alert>

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -33,6 +33,7 @@ export type CategoryGroup = (typeof CATEGORY_GROUP_ORDER)[number];
 /** Each category → its section. Keyed by the full Category union: a missing key
  *  fails the type-check, keeping the grouping exhaustive as the vocabulary grows. */
 export const CATEGORY_GROUP: Record<Category, CategoryGroup> = {
+  software_engineering: 'Engineering',
   backend: 'Engineering',
   frontend: 'Engineering',
   fullstack: 'Engineering',

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -722,6 +722,101 @@ export const StrengthResponsibility = "responsibility"; // clear ownership with 
  */
 export const StrengthKeyword = "keyword"; // the term is present but the evidence is a bare mention or duty-only
 /**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxCommentRunes = 240; // per-dimension Comment
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxListItemRunes = 200; // each Strengths / Gaps bullet
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxRecommendRunes = 1200; // free-text Recommendation: two or three short prose paragraphs
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxReqTextRunes = 200; // Requirement.Text
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxReqEvidenceRunes = 240; // Requirement.Evidence
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxStrengths = 6; // Strengths list length
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxGaps = 6; // Gaps list length
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxRequirements = 30; // RequirementMatch list length
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxSignals = 5; // HiddenSignals list length
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxSignalQuoteRunes = 200; // Signal.Quote
+/**
+ * Default sanitize caps for untrusted model text. Override at process start via
+ * SetBounds (cmd/server reads MATCH_ANALYSIS_* from the environment). A typo that
+ * yields a non-positive value falls back to the matching default so a bound can
+ * never be erased.
+ */
+export const DefaultMaxSignalInsightRunes = 200; // Signal.Insight
+/**
+ * Bounds is the tunable sanitize ceiling for fit-analysis model output. Every field
+ * is a positive count (runes for text, items for lists). Zero / negative values are
+ * rejected by SetBounds and replaced with that field's Default*.
+ */
+export interface Bounds {
+  MaxCommentRunes: number /* int */;
+  MaxListItemRunes: number /* int */;
+  MaxRecommendRunes: number /* int */;
+  MaxReqTextRunes: number /* int */;
+  MaxReqEvidenceRunes: number /* int */;
+  MaxStrengths: number /* int */;
+  MaxGaps: number /* int */;
+  MaxRequirements: number /* int */;
+  MaxSignals: number /* int */;
+  MaxSignalQuoteRunes: number /* int */;
+  MaxSignalInsightRunes: number /* int */;
+}
+/**
  * Dimension is one scored fit dimension on the wire.
  */
 export interface Dimension {
@@ -1114,7 +1209,7 @@ export interface Question {
   answer?: string;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', '4dayweek', 'adp', 'adzuna', 'aijobs', 'applicantpro', 'apploi', 'arbeitnow', 'arbeitsagentur', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'betterteam', 'breezy', 'briefhq', 'bullhorn', 'careerplug', 'careerspage', 'catsone', 'cleverstaff', 'clinch', 'comeet', 'compleo', 'cornerstone', 'crelate', 'deel', 'djinni', 'earcu', 'echojobs', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'functionalworks', 'geekjob', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'getro', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'hh', 'hibob', 'himalayas', 'hireology', 'huntflow', 'hurma', 'icims', 'infojobs', 'inhire', 'instaffo', 'ismartrecruit', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobscore', 'jobspresso', 'jobstash', 'jobtech', 'jobvite', 'jobylon', 'join', 'justjoin', 'lever', 'likeit', 'loxo', 'luxoft', 'manatal', 'mindsight', 'mycareersfuture', 'neogov', 'nofluffjobs', 'northstone', 'odoo', 'opencats', 'oracle', 'pageup', 'paycom', 'paylocity', 'peopleforce', 'personio', 'phenom', 'pinpoint', 'powertofly', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'reed', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'softgarden', 'solides', 'spark', 'speedrun', 'startupandvc', 'successfactors', 'talentadore', 'talenthr', 'talentlyft', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'trudvsem', 'tyomarkkinatori', 'ukg', 'usajobs', 'vagas', 'vention', 'vouch', 'wantapply', 'wantedkr', 'weworkremotely', 'whatjobs', 'whatjobs-ae', 'whatjobs-ar', 'whatjobs-at', 'whatjobs-au', 'whatjobs-be', 'whatjobs-bh', 'whatjobs-br', 'whatjobs-ca', 'whatjobs-ch', 'whatjobs-cl', 'whatjobs-co', 'whatjobs-de', 'whatjobs-dk', 'whatjobs-eg', 'whatjobs-es', 'whatjobs-fi', 'whatjobs-fr', 'whatjobs-gr', 'whatjobs-hk', 'whatjobs-hu', 'whatjobs-id', 'whatjobs-ie', 'whatjobs-in', 'whatjobs-it', 'whatjobs-ke', 'whatjobs-kw', 'whatjobs-lu', 'whatjobs-mx', 'whatjobs-my', 'whatjobs-nl', 'whatjobs-no', 'whatjobs-nz', 'whatjobs-om', 'whatjobs-pe', 'whatjobs-ph', 'whatjobs-pk', 'whatjobs-pl', 'whatjobs-pt', 'whatjobs-py', 'whatjobs-qa', 'whatjobs-sa', 'whatjobs-se', 'whatjobs-sg', 'whatjobs-sv', 'whatjobs-th', 'whatjobs-tr', 'whatjobs-uk', 'whatjobs-ve', 'whatjobs-vn', 'whatjobs-za', 'workable', 'workablemarketplace', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', '4dayweek', 'adp', 'adzuna', 'aijobs', 'applicantpro', 'apploi', 'arbeitnow', 'arbeitsagentur', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'betterteam', 'breezy', 'briefhq', 'bullhorn', 'careerplug', 'careerspage', 'catsone', 'cleverstaff', 'clinch', 'comeet', 'compleo', 'cornerstone', 'crelate', 'cryptocurrencyjobs', 'deel', 'djinni', 'earcu', 'echojobs', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'functionalworks', 'geekjob', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'getro', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'hh', 'hibob', 'himalayas', 'hireology', 'huntflow', 'hurma', 'icims', 'infojobs', 'inhire', 'instaffo', 'ismartrecruit', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobscore', 'jobspresso', 'jobstash', 'jobtech', 'jobvite', 'jobylon', 'join', 'justjoin', 'lever', 'likeit', 'loxo', 'luxoft', 'manatal', 'mindsight', 'mycareersfuture', 'neogov', 'nodesk', 'nofluffjobs', 'northstone', 'odoo', 'opencats', 'oracle', 'pageup', 'paycom', 'paylocity', 'peopleforce', 'personio', 'phenom', 'pinpoint', 'powertofly', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'reed', 'remotive', 'remotli', 'rippling', 'senior', 'smartrecruiters', 'softgarden', 'solides', 'solidjobs', 'spark', 'speedrun', 'startupandvc', 'successfactors', 'talentadore', 'talenthr', 'talentlyft', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'themuse', 'topco', 'traffit', 'trakstar', 'trudvsem', 'tyomarkkinatori', 'ukg', 'usajobs', 'vagas', 'vention', 'vouch', 'wantapply', 'wantedkr', 'weworkremotely', 'whatjobs', 'whatjobs-ae', 'whatjobs-ar', 'whatjobs-at', 'whatjobs-au', 'whatjobs-be', 'whatjobs-bh', 'whatjobs-br', 'whatjobs-ca', 'whatjobs-ch', 'whatjobs-cl', 'whatjobs-co', 'whatjobs-de', 'whatjobs-dk', 'whatjobs-eg', 'whatjobs-es', 'whatjobs-fi', 'whatjobs-fr', 'whatjobs-gr', 'whatjobs-hk', 'whatjobs-hu', 'whatjobs-id', 'whatjobs-ie', 'whatjobs-in', 'whatjobs-it', 'whatjobs-ke', 'whatjobs-kw', 'whatjobs-lu', 'whatjobs-mx', 'whatjobs-my', 'whatjobs-nl', 'whatjobs-no', 'whatjobs-nz', 'whatjobs-om', 'whatjobs-pe', 'whatjobs-ph', 'whatjobs-pk', 'whatjobs-pl', 'whatjobs-pt', 'whatjobs-py', 'whatjobs-qa', 'whatjobs-sa', 'whatjobs-se', 'whatjobs-sg', 'whatjobs-sv', 'whatjobs-th', 'whatjobs-tr', 'whatjobs-uk', 'whatjobs-ve', 'whatjobs-vn', 'whatjobs-za', 'workable', 'workablemarketplace', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['preparing', 'applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn', 'expired'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];
@@ -1145,7 +1240,7 @@ export const WORK_MODE_VALUES = ['remote', 'hybrid', 'onsite'] as const;
 export type WorkMode = (typeof WORK_MODE_VALUES)[number];
 export const SENIORITY_VALUES = ['intern', 'junior', 'middle', 'senior', 'lead', 'staff', 'principal', 'c_level'] as const;
 export type Seniority = (typeof SENIORITY_VALUES)[number];
-export const CATEGORY_VALUES = ['backend', 'frontend', 'fullstack', 'mobile', 'devops', 'sre', 'network_engineering', 'data_engineering', 'data_science', 'data_analytics', 'ml_ai', 'ai_engineering', 'qa', 'security', 'hardware', 'embedded', 'blockchain', 'architecture', 'design', 'engineering_design', 'product', 'project_management', 'management', 'marketing', 'sales', 'support', 'business_analysis', 'solutions_engineering', 'developer_relations', 'technical_writing', 'recruiting', 'hr', 'finance', 'legal', 'operations', 'customer_success', 'other'] as const;
+export const CATEGORY_VALUES = ['software_engineering', 'backend', 'frontend', 'fullstack', 'mobile', 'devops', 'sre', 'network_engineering', 'data_engineering', 'data_science', 'data_analytics', 'ml_ai', 'ai_engineering', 'qa', 'security', 'hardware', 'embedded', 'blockchain', 'architecture', 'design', 'engineering_design', 'product', 'project_management', 'management', 'marketing', 'sales', 'support', 'business_analysis', 'solutions_engineering', 'developer_relations', 'technical_writing', 'recruiting', 'hr', 'finance', 'legal', 'operations', 'customer_success', 'other'] as const;
 export type Category = (typeof CATEGORY_VALUES)[number];
 export const EMPLOYMENT_TYPE_VALUES = ['full_time', 'part_time', 'contract', 'internship'] as const;
 export type EmploymentType = (typeof EMPLOYMENT_TYPE_VALUES)[number];
@@ -1452,6 +1547,7 @@ export const ROLE_LABELS = {
   'c_level_social_media_manager': 'C-Level Social Media Manager',
   'c_level_software_architect': 'C-Level Software Architect',
   'c_level_software_engineer': 'C-Level Software Engineer',
+  'c_level_software_engineering': 'C-Level Software Generalist',
   'c_level_solutions_architect': 'C-Level Solutions Architect',
   'c_level_solutions_consultant': 'C-Level Solutions Consultant',
   'c_level_solutions_engineer': 'C-Level Solutions Engineer',
@@ -1665,6 +1761,7 @@ export const ROLE_LABELS = {
   'intern_social_media_manager': 'Intern Social Media Manager',
   'intern_software_architect': 'Intern Software Architect',
   'intern_software_engineer': 'Intern Software Engineer',
+  'intern_software_engineering': 'Intern Software Generalist',
   'intern_solutions_architect': 'Intern Solutions Architect',
   'intern_solutions_consultant': 'Intern Solutions Consultant',
   'intern_solutions_engineer': 'Intern Solutions Engineer',
@@ -1806,6 +1903,7 @@ export const ROLE_LABELS = {
   'junior_social_media_manager': 'Junior Social Media Manager',
   'junior_software_architect': 'Junior Software Architect',
   'junior_software_engineer': 'Junior Software Engineer',
+  'junior_software_engineering': 'Junior Software Generalist',
   'junior_solutions_architect': 'Junior Solutions Architect',
   'junior_solutions_consultant': 'Junior Solutions Consultant',
   'junior_solutions_engineer': 'Junior Solutions Engineer',
@@ -1946,6 +2044,7 @@ export const ROLE_LABELS = {
   'lead_social_media_manager': 'Lead Social Media Manager',
   'lead_software_architect': 'Lead Software Architect',
   'lead_software_engineer': 'Lead Software Engineer',
+  'lead_software_engineering': 'Lead Software Generalist',
   'lead_solutions_architect': 'Lead Solutions Architect',
   'lead_solutions_consultant': 'Lead Solutions Consultant',
   'lead_solutions_engineer': 'Lead Solutions Engineer',
@@ -2096,6 +2195,7 @@ export const ROLE_LABELS = {
   'middle_social_media_manager': 'Middle Social Media Manager',
   'middle_software_architect': 'Middle Software Architect',
   'middle_software_engineer': 'Middle Software Engineer',
+  'middle_software_engineering': 'Middle Software Generalist',
   'middle_solutions_architect': 'Middle Solutions Architect',
   'middle_solutions_consultant': 'Middle Solutions Consultant',
   'middle_solutions_engineer': 'Middle Solutions Engineer',
@@ -2248,6 +2348,7 @@ export const ROLE_LABELS = {
   'principal_social_media_manager': 'Principal Social Media Manager',
   'principal_software_architect': 'Principal Software Architect',
   'principal_software_engineer': 'Principal Software Engineer',
+  'principal_software_engineering': 'Principal Software Generalist',
   'principal_solutions_architect': 'Principal Solutions Architect',
   'principal_solutions_consultant': 'Principal Solutions Consultant',
   'principal_solutions_engineer': 'Principal Solutions Engineer',
@@ -2408,6 +2509,7 @@ export const ROLE_LABELS = {
   'senior_social_media_manager': 'Senior Social Media Manager',
   'senior_software_architect': 'Senior Software Architect',
   'senior_software_engineer': 'Senior Software Engineer',
+  'senior_software_engineering': 'Senior Software Generalist',
   'senior_solutions_architect': 'Senior Solutions Architect',
   'senior_solutions_consultant': 'Senior Solutions Consultant',
   'senior_solutions_engineer': 'Senior Solutions Engineer',
@@ -2430,6 +2532,7 @@ export const ROLE_LABELS = {
   'social_media_manager': 'Social Media Manager',
   'software_architect': 'Software Architect',
   'software_engineer': 'Software Engineer',
+  'software_engineering': 'Software Generalist',
   'solutions_architect': 'Solutions Architect',
   'solutions_consultant': 'Solutions Consultant',
   'solutions_engineer': 'Solutions Engineer',
@@ -2559,6 +2662,7 @@ export const ROLE_LABELS = {
   'staff_social_media_manager': 'Staff Social Media Manager',
   'staff_software_architect': 'Staff Software Architect',
   'staff_software_engineer': 'Staff Software Engineer',
+  'staff_software_engineering': 'Staff Software Generalist',
   'staff_solutions_architect': 'Staff Solutions Architect',
   'staff_solutions_consultant': 'Staff Solutions Consultant',
   'staff_solutions_engineer': 'Staff Solutions Engineer',
@@ -2598,7 +2702,7 @@ export const ROLE_ALIASES = {
   'account_manager': ['account manager'],
   'accountant': ['accountant'],
   'agent_engineer': ['agent engineer', 'ai agent engineer'],
-  'ai_engineering': ['agent engineer', 'ai agent engineer', 'ai automation engineer', 'ai engineer', 'ai product engineer', 'ai research engineer', 'ai-automation engineer', 'ai-product engineer', 'ai-research engineer', 'applied ai', 'genai', 'generative ai', 'llm', 'llm engineer', 'prompt engineer', 'rag engineer'],
+  'ai_engineering': ['agent engineer', 'ai agent engineer', 'ai automation engineer', 'ai engineer', 'ai product engineer', 'ai research engineer', 'ai software engineer', 'ai-automation engineer', 'ai-product engineer', 'ai-research engineer', 'applied ai', 'genai', 'generative ai', 'llm', 'llm engineer', 'prompt engineer', 'rag engineer'],
   'ai_product_engineer': ['ai product engineer', 'ai-product engineer'],
   'analytics_engineer': ['analytics engineer'],
   'android_developer': ['android developer', 'android engineer', 'android software engineer'],
@@ -2608,7 +2712,7 @@ export const ROLE_ALIASES = {
   'backend': ['1c', '1с', 'back end', 'back-end', 'backend', 'бекенд', 'бэкенд'],
   'bdr': ['bdr', 'business development representative'],
   'bim_specialist': ['bim coordinator', 'bim designer', 'bim modeler', 'bim specialist', 'revit designer'],
-  'blockchain': ['blockchain', 'блокчейн'],
+  'blockchain': ['blockchain', 'smart contract developer', 'web3 developer', 'блокчейн'],
   'brand_designer': ['brand designer', 'branding designer'],
   'brand_manager': ['brand manager', 'brand marketing manager'],
   'business_analysis': ['business analysis', 'business analyst', 'business process analyst', 'business system analyst', 'business systems analyst', 'functional analyst', 'it business analyst', 'process analyst', 'requirements analyst', 'system analyst', 'systems analyst', 'аналитик бизнес-процессов', 'аналитик требований', 'бизнес аналитик', 'бизнес-аналитик', 'системный аналитик'],
@@ -2630,9 +2734,9 @@ export const ROLE_ALIASES = {
   'customer_success': ['client success', 'customer onboarding', 'customer success', 'implementation consultant', 'implementation specialist', 'onboarding manager', 'onboarding specialist', 'renewal manager', 'renewals manager', 'менеджер по работе с клиентами', 'менеджер по успеху клиентов', 'специалист по адаптации клиентов'],
   'customer_success_manager': ['csm', 'customer success manager'],
   'cybersecurity_engineer': ['cyber security engineer', 'cybersecurity engineer'],
-  'data_analytics': ['analyst', 'bi analyst', 'bi developer', 'bi-аналитик', 'business intelligence analyst', 'business intelligence developer', 'data analyst', 'data analytics', 'data аналитик', 'аналитик', 'аналитик bi', 'аналитик данных'],
+  'data_analytics': ['analyst', 'analytics engineer', 'bi analyst', 'bi developer', 'bi-аналитик', 'business intelligence analyst', 'business intelligence developer', 'data analyst', 'data analytics', 'data аналитик', 'power bi developer', 'аналитик', 'аналитик bi', 'аналитик данных'],
   'data_architect': ['data architect'],
-  'data_engineering': ['data engineer', 'data engineering', 'дата-инженер', 'инженер данных'],
+  'data_engineering': ['data engineer', 'data engineering', 'data governance', 'data platform', 'data steward', 'etl developer', 'дата-инженер', 'инженер данных'],
   'data_platform_engineer': ['data platform engineer'],
   'data_science': ['data scien', 'data science', 'data scientist', 'дата-сайентист'],
   'deep_learning_engineer': ['deep learning engineer'],
@@ -2643,7 +2747,7 @@ export const ROLE_ALIASES = {
   'design_ops': ['design operations', 'design ops', 'designops'],
   'developer_advocate': ['developer advocate', 'developer evangelist', 'developer relations', 'devrel'],
   'developer_relations': ['developer advocate', 'developer community manager', 'developer evangelist', 'developer experience engineer', 'developer relations', 'devrel', 'technical evangelist', 'деврел', 'технический евангелист'],
-  'devops': ['cloud design engineer', 'cloud engineer', 'devops', 'infrastructure engineer', 'platform engineer', 'sysadmin', 'system administrator', 'девопс'],
+  'devops': ['cloud design engineer', 'cloud engineer', 'database administrator', 'devops', 'infrastructure engineer', 'it administrator', 'linux administrator', 'ml ops', 'mlops', 'platform engineer', 'platform engineering', 'sysadmin', 'system administrator', 'systems administrator', 'windows administrator', 'девопс'],
   'director': ['director'],
   'drafter': ['cad drafter', 'design drafter', 'design draftsman', 'drafter', 'draftsman', 'draughtsman'],
   'electrical_designer': ['electrical design engineer', 'electrical designer'],
@@ -2667,7 +2771,7 @@ export const ROLE_ALIASES = {
   'fractional_coo': ['fractional coo'],
   'fractional_cpo': ['fractional cpo'],
   'fractional_cto': ['fractional cto'],
-  'frontend': ['front end', 'front-end', 'frontend', 'фронт', 'фронтенд'],
+  'frontend': ['angular developer', 'front end', 'front-end', 'frontend', 'react developer', 'react.js developer', 'reactjs developer', 'vue developer', 'vue.js developer', 'vuejs developer', 'фронт', 'фронтенд'],
   'fullstack': ['full stack', 'full-stack', 'fullstack', 'фуллстак', 'фулстек'],
   'genai_engineer': ['genai engineer', 'generative ai engineer'],
   'geo_specialist': ['aeo manager', 'aeo specialist', 'answer engine optimization', 'generative engine optimization', 'generative search optimization', 'geo manager', 'geo specialist'],
@@ -2702,9 +2806,9 @@ export const ROLE_ALIASES = {
   'mechanical_engineer': ['mechanical engineer'],
   'member_of_technical_staff': ['member of technical staff', 'member of the technical staff', 'mts'],
   'middle': ['mid', 'mid level', 'mid-level', 'middle', 'мидл', 'средний'],
-  'ml_ai': ['ai/ml', 'deep learning', 'machine learning', 'ml engineer', 'ml/ai'],
+  'ml_ai': ['ai/ml', 'computer vision engineer', 'deep learning', 'machine learning', 'ml engineer', 'ml/ai', 'nlp engineer'],
   'mlops_engineer': ['ml ops engineer', 'mlops engineer'],
-  'mobile': ['android', 'ios', 'mobile', 'мобильная', 'мобильный', 'мобильных'],
+  'mobile': ['android', 'ios', 'mobile', 'react native developer', 'мобильная', 'мобильный', 'мобильных'],
   'motion_designer': ['motion designer', 'motion graphics designer'],
   'network_engineering': ['network administrator', 'network design engineer', 'network engineer', 'network engineering', 'сетевой администратор', 'сетевой инженер'],
   'operations': ['administrative assistant', 'biz ops', 'business operations', 'chief of staff', 'chief operating officer', 'coo', 'executive assistant', 'facilities manager', 'head of operations', 'office manager', 'operations analyst', 'operations coordinator', 'operations manager', 'operations specialist', 'ops manager', 'procurement', 'procurement manager', 'purchasing manager', 'ассистент руководителя', 'закупщик', 'операционный директор', 'операционный менеджер', 'офис-менеджер', 'помощник руководителя', 'специалист по закупкам'],
@@ -2721,7 +2825,7 @@ export const ROLE_ALIASES = {
   'product_marketing_manager': ['pmm', 'product marketing manager'],
   'product_operations_manager': ['product operations manager'],
   'program_manager': ['program manager'],
-  'project_management': ['delivery manager', 'program coordinator', 'program manager', 'programme manager', 'project administrator', 'project coordinator', 'project manager', 'scrum master', 'scrum-master', 'проджект', 'проект-менеджер', 'скрам мастер', 'скрам-мастер'],
+  'project_management': ['agile coach', 'agile transformation lead', 'agile transformation manager', 'delivery manager', 'program coordinator', 'program manager', 'programme manager', 'project administrator', 'project coordinator', 'project manager', 'release train engineer', 'safe practitioner', 'scaled agile framework', 'scrum master', 'scrum-master', 'проджект', 'проект-менеджер', 'скрам мастер', 'скрам-мастер'],
   'prompt_engineer': ['prompt engineer'],
   'qa': ['design engineer in test', 'qa', 'quality assurance', 'sdet', 'software design engineer in test', 'test automation', 'test engineer', 'tester', 'тестирование', 'тестировщик'],
   'qa_automation_engineer': ['automation qa engineer', 'qa automation engineer', 'sdet', 'test automation engineer'],
@@ -2733,7 +2837,7 @@ export const ROLE_ALIASES = {
   'sales_engineer': ['sales engineer'],
   'scrum_master': ['scrum master'],
   'sdr': ['sales development representative', 'sdr'],
-  'security': ['appsec', 'cyber security', 'cybersecurity', 'infosec', 'security', 'безопасности', 'безопасность', 'кибербезопасность'],
+  'security': ['appsec', 'blue team', 'ciso', 'cyber security', 'cybersecurity', 'devsecops', 'grc', 'iam', 'identity and access management', 'incident response', 'infosec', 'penetration tester', 'penetration testing', 'pentest', 'pentester', 'red team', 'red teamer', 'security', 'threat intel', 'threat intelligence', 'vulnerability analyst', 'vulnerability management', 'безопасности', 'безопасность', 'кибербезопасность'],
   'security_officer': ['security officer'],
   'senior': ['senior', 'sr', 'сеньор', 'синьор', 'старший'],
   'seo_analyst': ['seo analyst'],
@@ -2741,6 +2845,7 @@ export const ROLE_ALIASES = {
   'social_media_manager': ['smm manager', 'smm specialist', 'social media manager'],
   'software_architect': ['software architect'],
   'software_engineer': ['sde', 'software developer', 'software development engineer', 'software engineer', 'swe', 'web developer'],
+  'software_engineering': ['.net developer', 'abap developer', 'ai native engineer', 'ai-native engineer', 'app developer', 'application developer', 'c# developer', 'c++ developer', 'database developer', 'dotnet developer', 'drupal developer', 'erp developer', 'founding engineer', 'game developer', 'go developer', 'go engineer', 'golang developer', 'golang engineer', 'java developer', 'javascript developer', 'magento developer', 'member of technical staff', 'member of the technical staff', 'node developer', 'node.js developer', 'nodejs developer', 'oracle developer', 'php developer', 'python developer', 'rails developer', 'rpa developer', 'ruby developer', 'salesforce developer', 'sap developer', 'sharepoint developer', 'shopify developer', 'software developer', 'software development engineer', 'software engineer', 'typescript developer', 'web developer', 'web engineer', 'wordpress developer'],
   'solutions_architect': ['solution architect', 'solutions architect'],
   'solutions_consultant': ['solution consultant', 'solutions consultant'],
   'solutions_engineer': ['solutions engineer'],

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -89,6 +89,7 @@ export const RELOCATION_LABELS: Record<string, string> = {
 // (TS2353) rather than leaving a stale entry. The declared type stays
 // Record<string, string> because the `label(map, value)` helpers take that shape.
 export const CATEGORY_LABELS: Record<string, string> = {
+  software_engineering: 'Software Engineering',
   backend: 'Backend',
   frontend: 'Frontend',
   fullstack: 'Full-Stack',

--- a/web/src/routes/docs/api/+page.svelte
+++ b/web/src/routes/docs/api/+page.svelte
@@ -8,6 +8,7 @@
   import { NAV, slugify } from '$lib/docs/nav';
   import { METHOD_TEXT, inlineCode } from '$lib/docs/format';
   import { breadcrumbJsonLd, jsonLdScript, webApiJsonLd } from '$lib/seo';
+  import { Table } from '$lib/ui';
 
   let { data } = $props();
 
@@ -141,24 +142,20 @@
 </section>
 
 {#snippet filterTable(rows: { param: string; label: string; values: string }[])}
-  <div class="mt-3 overflow-x-auto rounded-xl border border-border">
-    <table class="w-full border-collapse text-left text-sm">
-      <thead class="bg-secondary/60 text-xs uppercase tracking-wide text-muted-foreground">
-        <tr>
-          <th class="px-3 py-2 font-medium">Param</th>
-          <th class="px-3 py-2 font-medium">Filter</th>
-          <th class="px-3 py-2 font-medium">Values</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each rows as f (f.param)}
-          <tr class="border-t border-border align-top transition-colors hover:bg-secondary/30">
-            <td class="px-3 py-2"><code class="font-mono text-brand-strong">{f.param}</code></td>
-            <td class="px-3 py-2 text-foreground/80">{f.label}</td>
-            <td class="px-3 py-2 text-muted-foreground">{f.values}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </div>
+  <Table class="mt-3 rounded-xl border border-border">
+    {#snippet header()}
+      <tr class="bg-secondary/60 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <th class="px-3 py-2 font-medium">Param</th>
+        <th class="px-3 py-2 font-medium">Filter</th>
+        <th class="px-3 py-2 font-medium">Values</th>
+      </tr>
+    {/snippet}
+    {#each rows as f (f.param)}
+      <tr class="border-t border-border align-top transition-colors hover:bg-secondary/30">
+        <td class="px-3 py-2"><code class="font-mono text-brand-strong">{f.param}</code></td>
+        <td class="px-3 py-2 text-foreground/80">{f.label}</td>
+        <td class="px-3 py-2 text-muted-foreground">{f.values}</td>
+      </tr>
+    {/each}
+  </Table>
 {/snippet}

--- a/web/src/routes/insights/companies/+page.svelte
+++ b/web/src/routes/insights/companies/+page.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
   import Seo from '$lib/components/Seo.svelte';
   import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import { Table } from '$lib/ui';
   import type { InsightCompany } from '$lib/api';
   import type { PageData } from './$types';
 
@@ -41,42 +42,40 @@
     {#if rows.length === 0}
       <p class="mt-4 text-sm text-muted-foreground">Not enough data yet.</p>
     {:else}
-      <table class="mt-3 w-full border-collapse text-left text-sm">
-        <thead>
+      <Table class="mt-3">
+        {#snippet header()}
           <tr class="border-b border-border text-muted-foreground">
-            <th class="py-2 pr-3 font-medium">Company</th>
+            <th class="py-2 pr-3 text-left font-medium">Company</th>
             <th class="py-2 pr-3 text-right font-medium">Open</th>
             <th class="py-2 text-right font-medium">30-day</th>
           </tr>
-        </thead>
-        <tbody>
-          {#each rows as c, i (c.company_slug)}
-            {@const growthTone =
-              c.growth_30d > 0
-                ? 'text-green-600 dark:text-green-400'
-                : c.growth_30d < 0
-                  ? 'text-red-600 dark:text-red-400'
-                  : 'text-muted-foreground'}
-            <tr class="border-b border-border">
-              <td class="py-2 pr-3">
-                <span class="mr-1.5 tabular-nums text-muted-foreground">{i + 1}.</span>
-                <a
-                  href={resolve('/companies/[slug]', { slug: c.company_slug })}
-                  class="font-medium text-foreground hover:text-blue-600 hover:underline"
-                >
-                  {c.company_name}
-                </a>
-              </td>
-              <td class="py-2 pr-3 text-right tabular-nums text-foreground">
-                {c.open_now.toLocaleString('en-US')}
-              </td>
-              <td class="py-2 text-right font-medium tabular-nums {growthTone}">
-                {c.growth_30d > 0 ? '+' : ''}{c.growth_30d.toLocaleString('en-US')}
-              </td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
+        {/snippet}
+        {#each rows as c, i (c.company_slug)}
+          {@const growthTone =
+            c.growth_30d > 0
+              ? 'text-green-600 dark:text-green-400'
+              : c.growth_30d < 0
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-muted-foreground'}
+          <tr class="border-b border-border">
+            <td class="py-2 pr-3">
+              <span class="mr-1.5 tabular-nums text-muted-foreground">{i + 1}.</span>
+              <a
+                href={resolve('/companies/[slug]', { slug: c.company_slug })}
+                class="font-medium text-foreground hover:text-blue-600 hover:underline"
+              >
+                {c.company_name}
+              </a>
+            </td>
+            <td class="py-2 pr-3 text-right tabular-nums text-foreground">
+              {c.open_now.toLocaleString('en-US')}
+            </td>
+            <td class="py-2 text-right font-medium tabular-nums {growthTone}">
+              {c.growth_30d > 0 ? '+' : ''}{c.growth_30d.toLocaleString('en-US')}
+            </td>
+          </tr>
+        {/each}
+      </Table>
     {/if}
   </section>
 {/snippet}

--- a/web/src/routes/insights/roles/[category]/+page.svelte
+++ b/web/src/routes/insights/roles/[category]/+page.svelte
@@ -4,6 +4,7 @@
   import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
   import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
   import { seniorityLabel } from '$lib/insights';
+  import { Table } from '$lib/ui';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -44,31 +45,29 @@
   {#if data.roles.length === 0}
     <p class="text-muted-foreground">No role data for this category yet.</p>
   {:else}
-    <table class="w-full border-collapse text-left text-sm">
-      <thead>
+    <Table>
+      {#snippet header()}
         <tr class="border-b border-border text-muted-foreground">
-          <th class="py-2 pr-4 font-medium">Level</th>
+          <th class="py-2 pr-4 text-left font-medium">Level</th>
           <th class="py-2 pr-4 font-medium text-right">Open roles</th>
           <th class="py-2 font-medium text-right">30-day growth</th>
         </tr>
-      </thead>
-      <tbody>
-        {#each data.roles as r (r.seniority)}
-          {@const growthTone =
-            r.growth > 0
-              ? 'text-green-600 dark:text-green-400'
-              : r.growth < 0
-                ? 'text-red-600 dark:text-red-400'
-                : 'text-muted-foreground'}
-          <tr class="border-b border-border">
-            <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(r.seniority)}</td>
-            <td class="py-2 pr-4 text-right tabular-nums">{r.open_count.toLocaleString('en-US')}</td>
-            <td class="py-2 text-right tabular-nums {growthTone}">
-              {r.growth > 0 ? '+' : ''}{r.growth.toLocaleString('en-US')}
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/snippet}
+      {#each data.roles as r (r.seniority)}
+        {@const growthTone =
+          r.growth > 0
+            ? 'text-green-600 dark:text-green-400'
+            : r.growth < 0
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-muted-foreground'}
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(r.seniority)}</td>
+          <td class="py-2 pr-4 text-right tabular-nums">{r.open_count.toLocaleString('en-US')}</td>
+          <td class="py-2 text-right tabular-nums {growthTone}">
+            {r.growth > 0 ? '+' : ''}{r.growth.toLocaleString('en-US')}
+          </td>
+        </tr>
+      {/each}
+    </Table>
   {/if}
 </InsightsPageShell>

--- a/web/src/routes/insights/salary/[category]/+page.svelte
+++ b/web/src/routes/insights/salary/[category]/+page.svelte
@@ -4,6 +4,7 @@
   import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
   import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
   import { formatSalary, seniorityLabel } from '$lib/insights';
+  import { Table } from '$lib/ui';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -44,31 +45,29 @@
   {#if data.bands.length === 0}
     <p class="text-muted-foreground">No salary figures disclosed for this category yet.</p>
   {:else}
-    <table class="w-full border-collapse text-left text-sm">
-      <thead>
+    <Table>
+      {#snippet header()}
         <tr class="border-b border-border text-muted-foreground">
-          <th class="py-2 pr-4 font-medium">Level</th>
-          <th class="py-2 pr-4 font-medium">Currency</th>
-          <th class="py-2 pr-4 font-medium">Period</th>
+          <th class="py-2 pr-4 text-left font-medium">Level</th>
+          <th class="py-2 pr-4 text-left font-medium">Currency</th>
+          <th class="py-2 pr-4 text-left font-medium">Period</th>
           <th class="py-2 pr-4 font-medium text-right">25th</th>
           <th class="py-2 pr-4 font-medium text-right">Median</th>
           <th class="py-2 pr-4 font-medium text-right">75th</th>
           <th class="py-2 font-medium text-right">Postings</th>
         </tr>
-      </thead>
-      <tbody>
-        {#each data.bands as b (b.seniority + b.currency + b.period)}
-          <tr class="border-b border-border">
-            <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(b.seniority)}</td>
-            <td class="py-2 pr-4 text-muted-foreground">{b.currency.toUpperCase()}</td>
-            <td class="py-2 pr-4 text-muted-foreground">{b.period}</td>
-            <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p25, b.currency)}</td>
-            <td class="py-2 pr-4 text-right font-semibold tabular-nums">{formatSalary(b.p50, b.currency)}</td>
-            <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p75, b.currency)}</td>
-            <td class="py-2 text-right tabular-nums text-muted-foreground">{b.sample_size}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/snippet}
+      {#each data.bands as b (b.seniority + b.currency + b.period)}
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(b.seniority)}</td>
+          <td class="py-2 pr-4 text-muted-foreground">{b.currency.toUpperCase()}</td>
+          <td class="py-2 pr-4 text-muted-foreground">{b.period}</td>
+          <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p25, b.currency)}</td>
+          <td class="py-2 pr-4 text-right font-semibold tabular-nums">{formatSalary(b.p50, b.currency)}</td>
+          <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p75, b.currency)}</td>
+          <td class="py-2 text-right tabular-nums text-muted-foreground">{b.sample_size}</td>
+        </tr>
+      {/each}
+    </Table>
   {/if}
 </InsightsPageShell>

--- a/web/src/routes/insights/skills/[category]/+page.svelte
+++ b/web/src/routes/insights/skills/[category]/+page.svelte
@@ -3,6 +3,7 @@
   import Seo from '$lib/components/Seo.svelte';
   import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
   import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import { Table } from '$lib/ui';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -43,33 +44,31 @@
   {#if data.skills.length === 0}
     <p class="text-muted-foreground">No skill data for this category yet.</p>
   {:else}
-    <table class="w-full border-collapse text-left text-sm">
-      <thead>
+    <Table>
+      {#snippet header()}
         <tr class="border-b border-border text-muted-foreground">
-          <th class="py-2 pr-4 font-medium">#</th>
-          <th class="py-2 pr-4 font-medium">Skill</th>
+          <th class="py-2 pr-4 text-left font-medium">#</th>
+          <th class="py-2 pr-4 text-left font-medium">Skill</th>
           <th class="py-2 pr-4 font-medium text-right">Open postings</th>
           <th class="py-2 font-medium text-right">30-day growth</th>
         </tr>
-      </thead>
-      <tbody>
-        {#each data.skills as s, i (s.skill)}
-          {@const growthTone =
-            s.growth > 0
-              ? 'text-green-600 dark:text-green-400'
-              : s.growth < 0
-                ? 'text-red-600 dark:text-red-400'
-                : 'text-muted-foreground'}
-          <tr class="border-b border-border">
-            <td class="py-2 pr-4 text-muted-foreground tabular-nums">{i + 1}</td>
-            <td class="py-2 pr-4 font-medium text-foreground">{s.skill}</td>
-            <td class="py-2 pr-4 text-right tabular-nums">{s.open_count.toLocaleString('en-US')}</td>
-            <td class="py-2 text-right tabular-nums {growthTone}">
-              {s.growth > 0 ? '+' : ''}{s.growth.toLocaleString('en-US')}
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/snippet}
+      {#each data.skills as s, i (s.skill)}
+        {@const growthTone =
+          s.growth > 0
+            ? 'text-green-600 dark:text-green-400'
+            : s.growth < 0
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-muted-foreground'}
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4 text-muted-foreground tabular-nums">{i + 1}</td>
+          <td class="py-2 pr-4 font-medium text-foreground">{s.skill}</td>
+          <td class="py-2 pr-4 text-right tabular-nums">{s.open_count.toLocaleString('en-US')}</td>
+          <td class="py-2 text-right tabular-nums {growthTone}">
+            {s.growth > 0 ? '+' : ''}{s.growth.toLocaleString('en-US')}
+          </td>
+        </tr>
+      {/each}
+    </Table>
   {/if}
 </InsightsPageShell>


### PR DESCRIPTION
## Summary
- 110k+ open prod postings titled "Software Engineer", "Java Developer", "Member of Technical Staff", etc. were confirmed tech (`is_tech=true`, fully LLM-enriched) but `classify` never assigned a `category` — the dictionary correctly refuses to guess backend vs frontend vs fullstack from a bare, discipline-unstated title. Adds a `software_engineering` catch-all category for exactly that population, mirroring `tech.go`'s already-curated `techTitleTerms` list.
- Also fixes several title patterns that DO name an unambiguous discipline and were previously falling into the same empty bucket: `systems/database/linux/windows administrator` → `devops`, `react/angular/vue developer` → `frontend`, `react native developer` → `mobile`, `web3/smart contract developer` → `blockchain`, `etl developer` → `data_engineering`, `power bi developer` → `data_analytics`, `computer vision/nlp/ai software engineer` → `ml_ai`/`ai_engineering`.
- `roletag`'s new category gets its own label ("Software Generalist") rather than reusing "Software Engineer" — that label is already owned by the existing `software_engineer` named role, which `web/src/lib/roleRelated.ts` and `collections.ts` depend on by slug.
- Updates the `cvmatch` "unverifiable rule" test, which was hard-coded to a title that no longer resolves (`Staff Software Engineer`) — moved to `Product Engineer` (still unresolved by design, per `tech.go`'s own 2:1 software/manufacturing sample), and added a new test documenting that `Staff Software Engineer` now correctly earns the full scoring weight.
- `contracts.ts` regenerated.

## Test plan
- [x] `gofmt -l` clean on all touched Go files
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all green except one pre-existing, unrelated failure (`TestExtractResumeProfile_PDF`, needs an LLM/PII service not configured in this environment)
- [ ] After merge: run `cmd/backfill-derive` + `cmd/reindex` on prod to reclassify the ~110k existing postings and push the new category into Meilisearch (not run yet — flagged separately, needs its own go/no-go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default, muted, and destructive variants to empty states, including appropriate alert behavior for destructive messages.
  * Improved recognition and categorization of general software-engineering roles.
  * Added clearer Software Engineering labels and filtering support.

* **Accessibility & UI Improvements**
  * Standardized alerts, forms, status chips, empty states, and tables across the application.
  * Improved form labeling, validation messaging, hints, and screen-reader support.
  * Updated tables across referrals, API documentation, and insights pages for consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->