### PR TITLE
Adopt more design-system primitives in web (Table, Chip, EmptyState, Alert, FormField)

### DIFF
--- a/design-system/docs/dsds/components.json
+++ b/design-system/docs/dsds/components.json
@@ -394,6 +394,16 @@
           "type": "Snippet"
         },
         {
+          "name": "variant",
+          "type": "EmptyStateVariant",
+          "default": "default",
+          "values": [
+            "default",
+            "muted",
+            "destructive"
+          ]
+        },
+        {
           "name": "action",
           "type": "Snippet"
         },

--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -1,17 +1,17 @@
 {
-  "Alert": 0,
+  "Alert": 1,
   "Avatar": 0,
   "Badge": 12,
   "Button": 55,
   "Card": 1,
-  "Chip": 0,
+  "Chip": 1,
   "Dialog": 6,
-  "EmptyState": 0,
-  "FormField": 0,
+  "EmptyState": 1,
+  "FormField": 2,
   "Input": 12,
   "Pagination": 0,
   "Skeleton": 1,
-  "Table": 0,
+  "Table": 6,
   "Tabs": 0,
   "Tooltip": 0
 }

--- a/design-system/src/empty-state.stories.ts
+++ b/design-system/src/empty-state.stories.ts
@@ -5,6 +5,9 @@ const meta = {
   title: 'Primitives/EmptyState',
   component: EmptyState,
   tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'muted', 'destructive'] },
+  },
 } satisfies Meta<typeof EmptyState>;
 
 export default meta;
@@ -14,3 +17,5 @@ export const Default: Story = {
   args: { title: 'No results found', description: 'Try adjusting your filters to see more jobs.' },
 };
 export const Minimal: Story = { args: { title: 'Nothing here yet' } };
+export const Muted: Story = { args: { title: 'Nothing here yet', variant: 'muted' } };
+export const Destructive: Story = { args: { title: 'Something went wrong.', variant: 'destructive' } };

--- a/design-system/src/empty-state.svelte
+++ b/design-system/src/empty-state.svelte
@@ -1,3 +1,23 @@
+<script lang="ts" module>
+  import { tv, type VariantProps } from 'tailwind-variants';
+
+  export const emptyStateVariants = tv({
+    slots: {
+      title: 'text-sm text-foreground',
+    },
+    variants: {
+      variant: {
+        default: { title: 'font-medium' },
+        muted: { title: 'text-muted-foreground' },
+        destructive: { title: 'text-destructive' },
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  });
+
+  export type EmptyStateVariant = VariantProps<typeof emptyStateVariants>['variant'];
+</script>
+
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { cn } from './cn.js';
@@ -6,27 +26,34 @@
     title = 'Nothing here yet',
     description,
     icon,
+    variant = 'default',
     class: className,
     action,
   }: {
     title?: string;
     description?: string;
     icon?: Snippet;
+    variant?: EmptyStateVariant;
     class?: string;
     action?: Snippet;
   } = $props();
+
+  const slots = $derived(emptyStateVariants({ variant }));
+  // Mirrors alert.svelte: a destructive result is worth interrupting for, the
+  // other variants are page furniture that should not barge in on every render.
+  const role = $derived(variant === 'destructive' ? 'alert' : 'status');
 </script>
 
 <div
   class={cn('flex flex-col items-center justify-center gap-3 py-12 text-center', className)}
-  role="status"
+  {role}
 >
   {#if icon}
     <div class="text-muted-foreground">
       {@render icon()}
     </div>
   {/if}
-  <p class="text-sm font-medium text-foreground">{title}</p>
+  <p class={slots.title()}>{title}</p>
   {#if description}
     <p class="max-w-sm text-sm text-muted-foreground">{description}</p>
   {/if}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -9,7 +9,7 @@
   import { markSaved, markUnsaved } from '$lib/savedJobs.svelte';
   import { track } from '$lib/analytics';
   import type { Job, UserJob } from '$lib/types';
-  import { Badge, Button } from '$lib/ui';
+  import { Badge, Button, Chip } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
   import BackerBadge from './BackerBadge.svelte';
@@ -250,9 +250,9 @@
       <div class="flex flex-wrap items-center gap-2.5">
         <h1 class="text-2xl font-semibold tracking-tight">{job.title}</h1>
         {#if applied}
-          <span class="inline-flex items-center gap-1.5 rounded-full border border-brand/30 bg-brand-muted px-2.5 py-0.5 text-xs font-semibold text-brand-strong">
+          <Chip variant="brand" class="gap-1.5 border-brand/30 font-semibold">
             <CheckCircle2 class="size-3.5" aria-hidden="true" /> Applied
-          </span>
+          </Chip>
         {/if}
       </div>
 

--- a/web/src/lib/components/ReferralsView.svelte
+++ b/web/src/lib/components/ReferralsView.svelte
@@ -13,7 +13,7 @@
     ReferralRequestStatus,
     SeekerReferralRequest,
   } from '$lib/types';
-  import { Button } from '$lib/ui';
+  import { Button, FormField, Table } from '$lib/ui';
   import { isLinkedInUrl, timeAgo } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
   import CompanyPicker from './CompanyPicker.svelte';
@@ -173,37 +173,35 @@
   {:else if requests.value.length === 0}
     <States state="empty" message="You haven't requested any referrals yet." />
   {:else}
-    <table class="mt-4 w-full text-sm">
-      <thead>
+    <Table class="mt-4">
+      {#snippet header()}
         <tr class="text-xs uppercase tracking-wide text-muted-foreground">
           <th class="pb-2 pr-4 text-left font-semibold">Company</th>
           <th class="pb-2 pr-4 text-left font-semibold">CV shared</th>
           <th class="pb-2 pr-4 text-left font-semibold">Status</th>
           <th class="pb-2 text-left font-semibold">Sent</th>
         </tr>
-      </thead>
-      <tbody>
-        {#each requests.value as r (r.id)}
-          <tr class="border-t border-border">
-            <td class="py-3 pr-4 font-medium">
-              <a href={resolve('/companies/[slug]', { slug: r.company_slug })} class="flex items-center gap-2 hover:underline">
-                <CompanyLogo name={r.company_name || r.company_slug} size="size-6" />
-                <span class="min-w-0 truncate">{r.company_name || r.company_slug}</span>
-              </a>
-            </td>
-            <td class="py-3 pr-4 text-muted-foreground">
-              {r.cv_kind === 'built' ? 'Tailored CV' : 'Uploaded CV'}
-            </td>
-            <td class="py-3 pr-4">
-              <span class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-semibold {pillClass[r.status]}">
-                {pillLabel[r.status]}
-              </span>
-            </td>
-            <td class="py-3 text-muted-foreground">{r.created_at ? timeAgo(r.created_at) : ''}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/snippet}
+      {#each requests.value as r (r.id)}
+        <tr class="border-t border-border">
+          <td class="py-3 pr-4 font-medium">
+            <a href={resolve('/companies/[slug]', { slug: r.company_slug })} class="flex items-center gap-2 hover:underline">
+              <CompanyLogo name={r.company_name || r.company_slug} size="size-6" />
+              <span class="min-w-0 truncate">{r.company_name || r.company_slug}</span>
+            </a>
+          </td>
+          <td class="py-3 pr-4 text-muted-foreground">
+            {r.cv_kind === 'built' ? 'Tailored CV' : 'Uploaded CV'}
+          </td>
+          <td class="py-3 pr-4">
+            <span class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-semibold {pillClass[r.status]}">
+              {pillLabel[r.status]}
+            </span>
+          </td>
+          <td class="py-3 text-muted-foreground">{r.created_at ? timeAgo(r.created_at) : ''}</td>
+        </tr>
+      {/each}
+    </Table>
     <p class="mt-4 text-xs text-muted-foreground">
       No notifications here — the referrer contacts you over the channel you left.
     </p>
@@ -223,21 +221,25 @@
         <CompanyPicker onSelect={(c) => (offerSlug = c?.slug ?? '')} />
         <span class="text-xs text-muted-foreground">Search and pick the company you work at.</span>
       </div>
-      <label class="flex flex-col gap-1.5 text-sm">
-        <span class="font-medium">Your LinkedIn profile</span>
-        <input
-          type="url"
-          bind:value={offerLinkedin}
-          placeholder="https://linkedin.com/in/your-handle"
-          aria-invalid={offerLinkedin.trim() !== '' && !offerLinkedinValid}
-          class="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
-        />
-        {#if offerLinkedin.trim() !== '' && !offerLinkedinValid}
-          <span class="text-xs text-destructive">Enter a full linkedin.com/in/… profile URL.</span>
-        {:else}
-          <span class="text-xs text-muted-foreground">Helps the moderator confirm you work there.</span>
-        {/if}
-      </label>
+      <FormField
+        label="Your LinkedIn profile"
+        error={offerLinkedin.trim() !== '' && !offerLinkedinValid
+          ? 'Enter a full linkedin.com/in/… profile URL.'
+          : undefined}
+        hint="Helps the moderator confirm you work there."
+      >
+        {#snippet children({ id, describedBy, invalid })}
+          <input
+            {id}
+            type="url"
+            bind:value={offerLinkedin}
+            placeholder="https://linkedin.com/in/your-handle"
+            aria-invalid={invalid}
+            aria-describedby={describedBy}
+            class="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
+          />
+        {/snippet}
+      </FormField>
       <label class="flex flex-col gap-1.5 text-sm">
         <span class="font-medium">Proof of employment (PDF)</span>
         <input type="file" accept="application/pdf" bind:files={offerFile} class="text-sm" />

--- a/web/src/lib/components/RequestReferralModal.svelte
+++ b/web/src/lib/components/RequestReferralModal.svelte
@@ -4,7 +4,7 @@
   import { api, ApiError } from '$lib/api';
   import type { CvTailoredItem } from '$lib/cv';
   import type { ReferralRequestInput } from '$lib/types';
-  import { Button, Dialog } from '$lib/ui';
+  import { Button, Dialog, FormField } from '$lib/ui';
   import { isLinkedInUrl } from '$lib/utils';
 
   // The parent owns open/close; this component owns the request form. jobId is the
@@ -178,21 +178,25 @@
           </label>
         </fieldset>
 
-        <label class="flex flex-col gap-1.5 text-sm">
-          <span class="font-medium">Your LinkedIn profile</span>
-          <input
-            type="url"
-            bind:value={linkedinUrl}
-            placeholder="https://linkedin.com/in/your-handle"
-            aria-invalid={linkedinUrl.trim() !== '' && !linkedinValid}
-            class="rounded-md border border-border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
-          />
-          {#if linkedinUrl.trim() !== '' && !linkedinValid}
-            <span class="text-xs text-destructive">Enter a full linkedin.com/in/… profile URL.</span>
-          {:else}
-            <span class="text-xs text-muted-foreground">The referrer vets you before reaching out.</span>
-          {/if}
-        </label>
+        <FormField
+          label="Your LinkedIn profile"
+          error={linkedinUrl.trim() !== '' && !linkedinValid
+            ? 'Enter a full linkedin.com/in/… profile URL.'
+            : undefined}
+          hint="The referrer vets you before reaching out."
+        >
+          {#snippet children({ id, describedBy, invalid })}
+            <input
+              {id}
+              type="url"
+              bind:value={linkedinUrl}
+              placeholder="https://linkedin.com/in/your-handle"
+              aria-invalid={invalid}
+              aria-describedby={describedBy}
+              class="rounded-md border border-border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
+            />
+          {/snippet}
+        </FormField>
 
         <div class="flex flex-col gap-1.5 text-sm">
           <span class="font-medium">

--- a/web/src/lib/components/States.svelte
+++ b/web/src/lib/components/States.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Skeleton } from '$lib/ui';
+  import { EmptyState, Skeleton } from '$lib/ui';
 
   // Shared rendering for the three async states every data view goes through.
   // `loading` shows placeholder rows; `empty`/`error` show a centered message.
@@ -25,7 +25,5 @@
     {/each}
   </div>
 {:else}
-  <p class="py-12 text-center text-sm {state === 'error' ? 'text-destructive' : 'text-muted-foreground'}">
-    {fallback}
-  </p>
+  <EmptyState title={fallback} variant={state === 'error' ? 'destructive' : 'muted'} />
 {/if}

--- a/web/src/lib/components/onboarding/OnboardingAlertBanner.svelte
+++ b/web/src/lib/components/onboarding/OnboardingAlertBanner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Bookmark, X } from '@lucide/svelte';
+  import { Alert } from '$lib/ui';
   import SaveSearchAlert from '../filters/SaveSearchAlert.svelte';
 
   // The ephemeral post-onboarding nudge: after the wizard configures a feed, offer to
@@ -18,7 +19,7 @@
   } = $props();
 </script>
 
-<div class="mb-3 flex items-start gap-3 rounded-xl border border-border bg-card p-3 pl-4">
+<Alert class="mb-3 rounded-xl p-3 pl-4">
   <div class="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand/10 text-brand-strong">
     <Bookmark class="size-4.5" />
   </div>
@@ -35,4 +36,4 @@
   >
     <X class="size-4" />
   </button>
-</div>
+</Alert>

--- a/web/src/routes/docs/api/+page.svelte
+++ b/web/src/routes/docs/api/+page.svelte
@@ -8,6 +8,7 @@
   import { NAV, slugify } from '$lib/docs/nav';
   import { METHOD_TEXT, inlineCode } from '$lib/docs/format';
   import { breadcrumbJsonLd, jsonLdScript, webApiJsonLd } from '$lib/seo';
+  import { Table } from '$lib/ui';
 
   let { data } = $props();
 
@@ -141,24 +142,20 @@
 </section>
 
 {#snippet filterTable(rows: { param: string; label: string; values: string }[])}
-  <div class="mt-3 overflow-x-auto rounded-xl border border-border">
-    <table class="w-full border-collapse text-left text-sm">
-      <thead class="bg-secondary/60 text-xs uppercase tracking-wide text-muted-foreground">
-        <tr>
-          <th class="px-3 py-2 font-medium">Param</th>
-          <th class="px-3 py-2 font-medium">Filter</th>
-          <th class="px-3 py-2 font-medium">Values</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each rows as f (f.param)}
-          <tr class="border-t border-border align-top transition-colors hover:bg-secondary/30">
-            <td class="px-3 py-2"><code class="font-mono text-brand-strong">{f.param}</code></td>
-            <td class="px-3 py-2 text-foreground/80">{f.label}</td>
-            <td class="px-3 py-2 text-muted-foreground">{f.values}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </div>
+  <Table class="mt-3 rounded-xl border border-border">
+    {#snippet header()}
+      <tr class="bg-secondary/60 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <th class="px-3 py-2 font-medium">Param</th>
+        <th class="px-3 py-2 font-medium">Filter</th>
+        <th class="px-3 py-2 font-medium">Values</th>
+      </tr>
+    {/snippet}
+    {#each rows as f (f.param)}
+      <tr class="border-t border-border align-top transition-colors hover:bg-secondary/30">
+        <td class="px-3 py-2"><code class="font-mono text-brand-strong">{f.param}</code></td>
+        <td class="px-3 py-2 text-foreground/80">{f.label}</td>
+        <td class="px-3 py-2 text-muted-foreground">{f.values}</td>
+      </tr>
+    {/each}
+  </Table>
 {/snippet}

--- a/web/src/routes/insights/companies/+page.svelte
+++ b/web/src/routes/insights/companies/+page.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
   import Seo from '$lib/components/Seo.svelte';
   import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import { Table } from '$lib/ui';
   import type { InsightCompany } from '$lib/api';
   import type { PageData } from './$types';
 
@@ -41,42 +42,40 @@
     {#if rows.length === 0}
       <p class="mt-4 text-sm text-muted-foreground">Not enough data yet.</p>
     {:else}
-      <table class="mt-3 w-full border-collapse text-left text-sm">
-        <thead>
+      <Table class="mt-3">
+        {#snippet header()}
           <tr class="border-b border-border text-muted-foreground">
-            <th class="py-2 pr-3 font-medium">Company</th>
+            <th class="py-2 pr-3 text-left font-medium">Company</th>
             <th class="py-2 pr-3 text-right font-medium">Open</th>
             <th class="py-2 text-right font-medium">30-day</th>
           </tr>
-        </thead>
-        <tbody>
-          {#each rows as c, i (c.company_slug)}
-            {@const growthTone =
-              c.growth_30d > 0
-                ? 'text-green-600 dark:text-green-400'
-                : c.growth_30d < 0
-                  ? 'text-red-600 dark:text-red-400'
-                  : 'text-muted-foreground'}
-            <tr class="border-b border-border">
-              <td class="py-2 pr-3">
-                <span class="mr-1.5 tabular-nums text-muted-foreground">{i + 1}.</span>
-                <a
-                  href={resolve('/companies/[slug]', { slug: c.company_slug })}
-                  class="font-medium text-foreground hover:text-blue-600 hover:underline"
-                >
-                  {c.company_name}
-                </a>
-              </td>
-              <td class="py-2 pr-3 text-right tabular-nums text-foreground">
-                {c.open_now.toLocaleString('en-US')}
-              </td>
-              <td class="py-2 text-right font-medium tabular-nums {growthTone}">
-                {c.growth_30d > 0 ? '+' : ''}{c.growth_30d.toLocaleString('en-US')}
-              </td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
+        {/snippet}
+        {#each rows as c, i (c.company_slug)}
+          {@const growthTone =
+            c.growth_30d > 0
+              ? 'text-green-600 dark:text-green-400'
+              : c.growth_30d < 0
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-muted-foreground'}
+          <tr class="border-b border-border">
+            <td class="py-2 pr-3">
+              <span class="mr-1.5 tabular-nums text-muted-foreground">{i + 1}.</span>
+              <a
+                href={resolve('/companies/[slug]', { slug: c.company_slug })}
+                class="font-medium text-foreground hover:text-blue-600 hover:underline"
+              >
+                {c.company_name}
+              </a>
+            </td>
+            <td class="py-2 pr-3 text-right tabular-nums text-foreground">
+              {c.open_now.toLocaleString('en-US')}
+            </td>
+            <td class="py-2 text-right font-medium tabular-nums {growthTone}">
+              {c.growth_30d > 0 ? '+' : ''}{c.growth_30d.toLocaleString('en-US')}
+            </td>
+          </tr>
+        {/each}
+      </Table>
     {/if}
   </section>
 {/snippet}

--- a/web/src/routes/insights/roles/[category]/+page.svelte
+++ b/web/src/routes/insights/roles/[category]/+page.svelte
@@ -4,6 +4,7 @@
   import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
   import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
   import { seniorityLabel } from '$lib/insights';
+  import { Table } from '$lib/ui';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -44,31 +45,29 @@
   {#if data.roles.length === 0}
     <p class="text-muted-foreground">No role data for this category yet.</p>
   {:else}
-    <table class="w-full border-collapse text-left text-sm">
-      <thead>
+    <Table>
+      {#snippet header()}
         <tr class="border-b border-border text-muted-foreground">
-          <th class="py-2 pr-4 font-medium">Level</th>
+          <th class="py-2 pr-4 text-left font-medium">Level</th>
           <th class="py-2 pr-4 font-medium text-right">Open roles</th>
           <th class="py-2 font-medium text-right">30-day growth</th>
         </tr>
-      </thead>
-      <tbody>
-        {#each data.roles as r (r.seniority)}
-          {@const growthTone =
-            r.growth > 0
-              ? 'text-green-600 dark:text-green-400'
-              : r.growth < 0
-                ? 'text-red-600 dark:text-red-400'
-                : 'text-muted-foreground'}
-          <tr class="border-b border-border">
-            <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(r.seniority)}</td>
-            <td class="py-2 pr-4 text-right tabular-nums">{r.open_count.toLocaleString('en-US')}</td>
-            <td class="py-2 text-right tabular-nums {growthTone}">
-              {r.growth > 0 ? '+' : ''}{r.growth.toLocaleString('en-US')}
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/snippet}
+      {#each data.roles as r (r.seniority)}
+        {@const growthTone =
+          r.growth > 0
+            ? 'text-green-600 dark:text-green-400'
+            : r.growth < 0
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-muted-foreground'}
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(r.seniority)}</td>
+          <td class="py-2 pr-4 text-right tabular-nums">{r.open_count.toLocaleString('en-US')}</td>
+          <td class="py-2 text-right tabular-nums {growthTone}">
+            {r.growth > 0 ? '+' : ''}{r.growth.toLocaleString('en-US')}
+          </td>
+        </tr>
+      {/each}
+    </Table>
   {/if}
 </InsightsPageShell>

--- a/web/src/routes/insights/salary/[category]/+page.svelte
+++ b/web/src/routes/insights/salary/[category]/+page.svelte
@@ -4,6 +4,7 @@
   import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
   import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
   import { formatSalary, seniorityLabel } from '$lib/insights';
+  import { Table } from '$lib/ui';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -44,31 +45,29 @@
   {#if data.bands.length === 0}
     <p class="text-muted-foreground">No salary figures disclosed for this category yet.</p>
   {:else}
-    <table class="w-full border-collapse text-left text-sm">
-      <thead>
+    <Table>
+      {#snippet header()}
         <tr class="border-b border-border text-muted-foreground">
-          <th class="py-2 pr-4 font-medium">Level</th>
-          <th class="py-2 pr-4 font-medium">Currency</th>
-          <th class="py-2 pr-4 font-medium">Period</th>
+          <th class="py-2 pr-4 text-left font-medium">Level</th>
+          <th class="py-2 pr-4 text-left font-medium">Currency</th>
+          <th class="py-2 pr-4 text-left font-medium">Period</th>
           <th class="py-2 pr-4 font-medium text-right">25th</th>
           <th class="py-2 pr-4 font-medium text-right">Median</th>
           <th class="py-2 pr-4 font-medium text-right">75th</th>
           <th class="py-2 font-medium text-right">Postings</th>
         </tr>
-      </thead>
-      <tbody>
-        {#each data.bands as b (b.seniority + b.currency + b.period)}
-          <tr class="border-b border-border">
-            <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(b.seniority)}</td>
-            <td class="py-2 pr-4 text-muted-foreground">{b.currency.toUpperCase()}</td>
-            <td class="py-2 pr-4 text-muted-foreground">{b.period}</td>
-            <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p25, b.currency)}</td>
-            <td class="py-2 pr-4 text-right font-semibold tabular-nums">{formatSalary(b.p50, b.currency)}</td>
-            <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p75, b.currency)}</td>
-            <td class="py-2 text-right tabular-nums text-muted-foreground">{b.sample_size}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/snippet}
+      {#each data.bands as b (b.seniority + b.currency + b.period)}
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(b.seniority)}</td>
+          <td class="py-2 pr-4 text-muted-foreground">{b.currency.toUpperCase()}</td>
+          <td class="py-2 pr-4 text-muted-foreground">{b.period}</td>
+          <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p25, b.currency)}</td>
+          <td class="py-2 pr-4 text-right font-semibold tabular-nums">{formatSalary(b.p50, b.currency)}</td>
+          <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p75, b.currency)}</td>
+          <td class="py-2 text-right tabular-nums text-muted-foreground">{b.sample_size}</td>
+        </tr>
+      {/each}
+    </Table>
   {/if}
 </InsightsPageShell>

--- a/web/src/routes/insights/skills/[category]/+page.svelte
+++ b/web/src/routes/insights/skills/[category]/+page.svelte
@@ -3,6 +3,7 @@
   import Seo from '$lib/components/Seo.svelte';
   import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
   import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import { Table } from '$lib/ui';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -43,33 +44,31 @@
   {#if data.skills.length === 0}
     <p class="text-muted-foreground">No skill data for this category yet.</p>
   {:else}
-    <table class="w-full border-collapse text-left text-sm">
-      <thead>
+    <Table>
+      {#snippet header()}
         <tr class="border-b border-border text-muted-foreground">
-          <th class="py-2 pr-4 font-medium">#</th>
-          <th class="py-2 pr-4 font-medium">Skill</th>
+          <th class="py-2 pr-4 text-left font-medium">#</th>
+          <th class="py-2 pr-4 text-left font-medium">Skill</th>
           <th class="py-2 pr-4 font-medium text-right">Open postings</th>
           <th class="py-2 font-medium text-right">30-day growth</th>
         </tr>
-      </thead>
-      <tbody>
-        {#each data.skills as s, i (s.skill)}
-          {@const growthTone =
-            s.growth > 0
-              ? 'text-green-600 dark:text-green-400'
-              : s.growth < 0
-                ? 'text-red-600 dark:text-red-400'
-                : 'text-muted-foreground'}
-          <tr class="border-b border-border">
-            <td class="py-2 pr-4 text-muted-foreground tabular-nums">{i + 1}</td>
-            <td class="py-2 pr-4 font-medium text-foreground">{s.skill}</td>
-            <td class="py-2 pr-4 text-right tabular-nums">{s.open_count.toLocaleString('en-US')}</td>
-            <td class="py-2 text-right tabular-nums {growthTone}">
-              {s.growth > 0 ? '+' : ''}{s.growth.toLocaleString('en-US')}
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/snippet}
+      {#each data.skills as s, i (s.skill)}
+        {@const growthTone =
+          s.growth > 0
+            ? 'text-green-600 dark:text-green-400'
+            : s.growth < 0
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-muted-foreground'}
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4 text-muted-foreground tabular-nums">{i + 1}</td>
+          <td class="py-2 pr-4 font-medium text-foreground">{s.skill}</td>
+          <td class="py-2 pr-4 text-right tabular-nums">{s.open_count.toLocaleString('en-US')}</td>
+          <td class="py-2 text-right tabular-nums {growthTone}">
+            {s.growth > 0 ? '+' : ''}{s.growth.toLocaleString('en-US')}
+          </td>
+        </tr>
+      {/each}
+    </Table>
   {/if}
 </InsightsPageShell>


### PR DESCRIPTION
## Summary
- Migrates 6 hand-rolled `<table>` elements to the `Table` primitive (`ReferralsView`, three `insights/*/[category]` pages, `insights/companies`, `docs/api`), preserving exact visual output — verified diff-by-diff, including relocating classes `Table` has no passthrough for (e.g. `docs/api`'s `<thead>` background/typography moved onto the header `<tr>`).
- Migrates `JobView`'s "Applied" pill to `Chip`, and `OnboardingAlertBanner` to `Alert`, both via class overrides that reproduce the original styling exactly.
- Extends `EmptyState` with a `variant` prop (`default` / `muted` / `destructive`, mirroring `Alert`'s naming) since its title had no way to express the muted/destructive tone the shared `States.svelte` component needs — `States` (used across ~26 call sites) now renders through `EmptyState` instead of its own inline markup, with zero change to `States`' own public API.
- Extends `FormField` adoption from zero consumers: migrates two "LinkedIn URL" inline-validation fields (`RequestReferralModal`, `ReferralsView`'s offer form) onto it, gaining explicit label association and `aria-describedby`/`role="alert"` wiring for free.
- `design-system` adoption baseline updated: **6/15 → 11/15** primitives now have a real consumer (`pnpm check:adoption`).

## Deliberately left untouched
Investigated every remaining "unused primitive" call-site candidate and skipped the ones that don't actually fit, rather than forcing them:
- `ghost/GateMatrix.svelte`'s crosstab table keeps its own markup — it has a `<caption>` and `<th scope="row">` semantics `Table` doesn't support, and `Table`'s hover-per-row styling would misrepresent a static reference matrix (same reasoning as why `TabRow.svelte` stays hand-rolled instead of forcing `Tabs`).
- `Avatar`: the inbox's per-sender initials use a deliberately different, unit-tested color palette (`web/src/lib/avatar.ts`) tuned for white-on-color contrast — visually incompatible with `Avatar`'s pastel hash-hue scheme.
- `Pagination`: every paginated surface in the app is either infinite-scroll (in-app) or SSR/URL-driven offset pagination for crawlable content (`jobs/[slug]/copies`) — `Pagination`'s client-state-only design (`onclick` handlers, no `href`) fits neither.
- `Tabs`: the codebase's other tab implementations are either route-driven anchor tabs (documented in `lib/actions/tablist.ts` as deliberately *not* `Tabs`, since it "welds the list to a panel") or use a bespoke pill/underline visual `Tabs` has no override hook for (no `class` passthrough on its list/trigger slots).
- `Tooltip`: the ~100 native `title=` attributes found are legitimate lightweight tooltips; no hand-rolled JS hover-popover duplicating `Tooltip` was found.

## Test plan
- [x] `pnpm check` (svelte-check) on `web` and `design-system` — 0 errors on every changed file (23 pre-existing, unrelated errors from a missing `@vite-pwa/sveltekit` install are present on `main` too, unrelated to this change)
- [x] `pnpm lint` (`oxlint` + `eslint`) — 0 new warnings/errors introduced
- [x] `design-system`: `vitest run` (91/91 passing), `check:tokens`, `validate:docs`, `check:adoption` all green with updated baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `default`, `muted`, and `destructive` visual variants for empty states.
  - Improved accessibility semantics for error and informational empty states.

- **Enhancements**
  - Standardized tables, form fields, alerts, status chips, and empty states across job, referral, documentation, and insights views.
  - Preserved existing data, formatting, validation, and interactions while improving visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->