### PR TITLE
Add textfile-collector metrics to worker.Main

### DIFF
--- a/internal/worker/main.go
+++ b/internal/worker/main.go
@@ -12,17 +12,23 @@ import (
 const panicFlushTimeout = 2 * time.Second
 
 // Main is the entry wrapper every cron worker uses in place of a bare
-// os.Exit(run()). On the normal path it exits with run's status — Sentry was
-// already flushed by Bootstrap's cleanup, which run defers. If run panics, the
-// deferred capturePanic reports the panic to Sentry, flushes it, and re-panics so
-// the process still crashes with the original stack and a non-zero exit code.
+// os.Exit(run()). On the normal path it times the run, writes it to
+// PROM_TEXTFILE_DIR (see writeRunMetrics — a no-op when unset), and exits with
+// run's status; Sentry was already flushed by Bootstrap's cleanup, which run
+// defers. If run panics, the deferred capturePanic reports the panic to Sentry,
+// flushes it, and re-panics so the process still crashes with the original stack
+// and a non-zero exit code — the metrics write is skipped on that path, since
+// Main never regains control to reach it.
 //
 // Sentry is initialized inside Bootstrap (run's first call), so a panic after
 // bootstrap is captured; a panic before it (e.g. bad config) is not — acceptable,
 // as those paths already log and exit non-zero.
 func Main(run func() int) {
 	defer capturePanic()
-	os.Exit(run())
+	start := time.Now()
+	code := run()
+	writeRunMetrics(time.Since(start), code)
+	os.Exit(code)
 }
 
 // capturePanic, deferred by Main, reports an in-flight panic to Sentry, flushes,

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -1,0 +1,87 @@
+package worker
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// PromTextfileDirEnv names the environment variable that turns on per-run
+// Prometheus metrics for cron workers, written as a node_exporter textfile-
+// collector file (https://github.com/prometheus/node_exporter#textfile-collector).
+// A worker is a run-once-and-exit process — there is nothing for Prometheus to
+// scrape between runs — so this is the pull-model equivalent for it, reusing the
+// node_exporter already deployed on host-2 rather than standing up a
+// Pushgateway. Unset disables it, matching this repo's other optional,
+// env-gated integrations (Sentry, S3, search).
+const PromTextfileDirEnv = "PROM_TEXTFILE_DIR"
+
+// writeRunMetrics records the outcome of one worker run as a
+// freehire_worker_last_run_* gauge set, if PROM_TEXTFILE_DIR is set. The job
+// label is the running binary's name (os.Args[0]); when the binary was invoked
+// with a trailing path-like argument (cmd/ingest's per-board source file,
+// `sources/<board>.yml`), that argument's base name (extension stripped) becomes
+// the instance label, so ~140 independently-timered ingest boards land in
+// distinct series instead of overwriting one shared file. Errors are logged, not
+// fatal — a metrics file failing to write must not fail the worker's actual job.
+func writeRunMetrics(runDuration time.Duration, exitCode int) {
+	dir := os.Getenv(PromTextfileDirEnv)
+	if dir == "" {
+		return
+	}
+	job := filepath.Base(os.Args[0])
+	instance := runInstance(os.Args[1:])
+
+	labels := fmt.Sprintf(`job=%q`, job)
+	name := job
+	if instance != "" {
+		labels = fmt.Sprintf(`job=%q,instance=%q`, job, instance)
+		name += "_" + instance
+	}
+
+	success := 0
+	if exitCode == 0 {
+		success = 1
+	}
+
+	content := fmt.Sprintf(`# HELP freehire_worker_last_run_timestamp_seconds Unix time the worker last finished a run.
+# TYPE freehire_worker_last_run_timestamp_seconds gauge
+freehire_worker_last_run_timestamp_seconds{%[1]s} %[2]d
+# HELP freehire_worker_last_run_duration_seconds How long the worker's last run took, in seconds.
+# TYPE freehire_worker_last_run_duration_seconds gauge
+freehire_worker_last_run_duration_seconds{%[1]s} %[3]f
+# HELP freehire_worker_last_run_success Whether the worker's last run exited zero (1) or not (0).
+# TYPE freehire_worker_last_run_success gauge
+freehire_worker_last_run_success{%[1]s} %[4]d
+`, labels, time.Now().Unix(), runDuration.Seconds(), success)
+
+	// Write-then-rename: the textfile collector polls the directory on its own
+	// schedule and skips a file it fails to fully parse, but a half-written file
+	// (this worker killed mid-write) could still be picked up mid-write and read
+	// as garbage. Renaming into place is atomic on the same filesystem, so it
+	// only ever sees the old file or the complete new one.
+	path := filepath.Join(dir, name+".prom")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		log.Printf("worker: write metrics file %s: %v", tmp, err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		log.Printf("worker: rename metrics file %s: %v", tmp, err)
+	}
+}
+
+// runInstance derives a metric instance label from a worker's trailing
+// command-line argument, when it looks like a path (cmd/ingest's
+// `sources/<board>.yml`). Returns "" for a worker invoked with no arguments
+// (embed, search-drain, reindex), which then reports under job alone.
+func runInstance(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	base := filepath.Base(args[len(args)-1])
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/worker/metrics_test.go
+++ b/internal/worker/metrics_test.go
@@ -1,0 +1,87 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunInstance(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no args", nil, ""},
+		{"bare board file", []string{"eightfold.yml"}, "eightfold"},
+		{"path-like board file", []string{"/opt/freehire/src/hire-current/sources/eightfold.yml"}, "eightfold"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runInstance(tt.args); got != tt.want {
+				t.Errorf("runInstance(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteRunMetricsDisabledWithoutEnv(t *testing.T) {
+	// Explicitly empty (equivalent to unset for the dir == "" check): the
+	// write must be a no-op and, critically, must not touch os.Args[0]'s
+	// actual directory or panic trying to resolve one.
+	t.Setenv(PromTextfileDirEnv, "")
+	writeRunMetrics(time.Second, 0)
+}
+
+func TestWriteRunMetricsWritesExpectedSeries(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(PromTextfileDirEnv, dir)
+
+	// os.Args[0] drives the job label; restore it after the test.
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"/opt/freehire/src/hire-current/ingest", "/opt/freehire/src/hire-current/sources/eightfold.yml"}
+
+	writeRunMetrics(2500*time.Millisecond, 1)
+
+	data, err := os.ReadFile(filepath.Join(dir, "ingest_eightfold.prom"))
+	if err != nil {
+		t.Fatalf("read metrics file: %v", err)
+	}
+	got := string(data)
+
+	for _, want := range []string{
+		`freehire_worker_last_run_duration_seconds{job="ingest",instance="eightfold"} 2.500000`,
+		`freehire_worker_last_run_success{job="ingest",instance="eightfold"} 0`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("metrics file missing %q; got:\n%s", want, got)
+		}
+	}
+
+	// No leftover .tmp file from the write-then-rename.
+	if _, err := os.Stat(filepath.Join(dir, "ingest_eightfold.prom.tmp")); !os.IsNotExist(err) {
+		t.Errorf("expected the .tmp file to be gone after rename, stat err: %v", err)
+	}
+}
+
+func TestWriteRunMetricsWithoutInstance(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(PromTextfileDirEnv, dir)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"/opt/freehire/src/hire-current/embed"}
+
+	writeRunMetrics(time.Millisecond, 0)
+
+	data, err := os.ReadFile(filepath.Join(dir, "embed.prom"))
+	if err != nil {
+		t.Fatalf("read metrics file: %v", err)
+	}
+	if !strings.Contains(string(data), `freehire_worker_last_run_success{job="embed"} 1`) {
+		t.Errorf("metrics file missing job-only series; got:\n%s", string(data))
+	}
+}


### PR DESCRIPTION
## Summary
- Every cron worker on `worker.Bootstrap`+`Main` (~40 binaries) now writes a last-run timestamp/duration/success gauge set as a node_exporter textfile-collector file, gated by `PROM_TEXTFILE_DIR` (unset = no-op).
- Job label = binary name; a trailing path-like arg (`cmd/ingest`'s `sources/<board>.yml`) becomes the instance label, so per-board ingest runs land in distinct series.
- One change in `internal/worker.Main` covers every worker on it, including `embed`/`search-drain`/`reindex`/`ingest` — the ones actually implicated in past incidents.
- Part of the host2 + litellm-host observability rollout — see freehire-ops' `openspec/changes/prod-observability-infra`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` all clean
- [x] New unit tests in `internal/worker/metrics_test.go` (label derivation, file content, env-gated no-op) — pass
- [x] `go test ./internal/worker/...` full package suite — pass
- [ ] CI status checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Prometheus metrics for worker runs, including duration, timestamp, and success status.
  * Metrics can be enabled through the `PROM_TEXTFILE_DIR` environment setting.
  * Metrics may include worker job and instance details.

* **Bug Fixes**
  * Worker processes now exit using the run’s returned status.
  * Metrics write failures are logged without interrupting worker execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->