### PR TITLE
Add a sources/ board-file validator, wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
           version: v2.12.2
           args: --new-from-merge-base=origin/main
 
+      - name: Validate sources
+        run: go run ./cmd/validate-sources
+
       - name: Unit tests
         run: |
           mkdir -p coverage

--- a/cmd/validate-sources/main.go
+++ b/cmd/validate-sources/main.go
@@ -1,0 +1,103 @@
+// Command validate-sources checks every board file under sources/ (or the directory
+// named by its one argument) for the two ways a hand-edited YAML file goes bad without
+// anyone noticing at ingest time: a malformed or unrecognized-field entry, and a
+// case-variant duplicate board that cmd/ingest would otherwise silently collapse
+// (internal/sources.dedupeBoards) with only a log line to show for it.
+//
+// It touches no network and no database, so it is meant to run on every PR. On failure it
+// prints one line per bad file — every duplicate board plus, if the file's structural
+// Validate also fails, that error too — and exits non-zero rather than stopping at the
+// first file.
+//
+// Usage:
+//
+//	go run ./cmd/validate-sources           # checks sources/
+//	go run ./cmd/validate-sources sources    # same, explicit
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/telegram"
+)
+
+// notBoardFiles are files under sources/ that do not hold a CompanyEntry list and carry
+// their own schema and validation — mirrors cmd/prune's boards.go.
+var notBoardFiles = map[string]bool{"telegram.yml": true}
+
+func main() {
+	dir := "sources"
+	if len(os.Args) > 1 {
+		dir = os.Args[1]
+	}
+	problems, checked, err := run(dir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if len(problems) > 0 {
+		for _, p := range problems {
+			fmt.Fprintln(os.Stderr, p)
+		}
+		fmt.Fprintf(os.Stderr, "validate-sources: %d problem(s) across %d file(s)\n", len(problems), checked)
+		os.Exit(1)
+	}
+	fmt.Printf("validate-sources: OK — %d file(s) checked\n", checked)
+}
+
+func run(dir string) (problems []string, checked int, err error) {
+	paths, err := filepath.Glob(filepath.Join(dir, "*.y*ml"))
+	if err != nil {
+		return nil, 0, fmt.Errorf("validate-sources: scan %s: %w", dir, err)
+	}
+	if len(paths) == 0 {
+		return nil, 0, fmt.Errorf("validate-sources: no *.yml files under %s", dir)
+	}
+
+	registry := sources.All(nil)
+	for _, path := range paths {
+		checked++
+		if notBoardFiles[filepath.Base(path)] {
+			problems = append(problems, validateTelegramFile(path)...)
+			continue
+		}
+		problems = append(problems, validateBoardFile(path, registry)...)
+	}
+	return problems, checked, nil
+}
+
+func validateBoardFile(path string, registry map[string]sources.Source) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	provider := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	entries, err := sources.ParseRawEntries(provider, data)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+
+	var problems []string
+	for _, dup := range sources.DuplicateBoards(entries) {
+		problems = append(problems, fmt.Sprintf("%s: %s", path, dup))
+	}
+	if err := (sources.Config{Provider: provider, Sources: entries}).Validate(registry); err != nil {
+		problems = append(problems, fmt.Sprintf("%s: %v", path, err))
+	}
+	return problems
+}
+
+func validateTelegramFile(path string) []string {
+	cfg, err := telegram.LoadConfig(path)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	if err := cfg.Validate(); err != nil {
+		return []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	return nil
+}

--- a/cmd/validate-sources/main_test.go
+++ b/cmd/validate-sources/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestRunAcceptsCleanDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "greenhouse.yml", `
+- company: Cohere
+  board: cohere
+- company: Stripe
+  board: stripe
+`)
+	writeFile(t, dir, "telegram.yml", `
+channels:
+  - channel: hrlunapark
+    kind: authored
+  - channel: it_vakansii_jobs
+    kind: board
+`)
+
+	problems, checked, err := run(dir)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(problems) != 0 {
+		t.Errorf("problems = %v, want none", problems)
+	}
+	if checked != 2 {
+		t.Errorf("checked = %d, want 2", checked)
+	}
+}
+
+// A board entered twice under different casing is exactly what internal/sources'
+// dedupeBoards silently drops at ingest time; the validator's job is to fail loudly on
+// it instead so it never reaches main.
+func TestRunCatchesCaseVariantDuplicateBoard(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "smartrecruiters.yml", `
+- company: Agile IT
+  board: AgileIT
+- company: AgileIT
+  board: agileit
+`)
+
+	problems, _, err := run(dir)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(problems) != 1 || !strings.Contains(problems[0], "duplicate board") {
+		t.Fatalf("problems = %v, want one duplicate-board problem", problems)
+	}
+}
+
+func TestRunCatchesEmptyCompany(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "greenhouse.yml", "- board: cohere\n")
+
+	problems, _, err := run(dir)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(problems) != 1 || !strings.Contains(problems[0], "empty company") {
+		t.Fatalf("problems = %v, want one empty-company problem", problems)
+	}
+}
+
+func TestRunCatchesUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "greenhouse.yml", "- company: Cohere\n  boad: cohere\n")
+
+	problems, _, err := run(dir)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(problems) != 1 {
+		t.Fatalf("problems = %v, want one parse problem for the typo'd field", problems)
+	}
+}
+
+func TestRunCatchesUnknownProvider(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "notaprovider.yml", "- company: Cohere\n  board: cohere\n")
+
+	problems, _, err := run(dir)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(problems) != 1 || !strings.Contains(problems[0], "unknown provider") {
+		t.Fatalf("problems = %v, want one unknown-provider problem", problems)
+	}
+}
+
+// telegram.yml carries its own schema and its own Validate — a duplicate channel is its
+// analogue of a duplicate board, and the directory-wide validator must surface it too.
+func TestRunCatchesDuplicateTelegramChannel(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "telegram.yml", `
+channels:
+  - channel: hrlunapark
+    kind: authored
+  - channel: hrlunapark
+    kind: board
+`)
+
+	problems, _, err := run(dir)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(problems) != 1 || !strings.Contains(problems[0], "duplicate channel") {
+		t.Fatalf("problems = %v, want one duplicate-channel problem", problems)
+	}
+}
+
+func TestRunErrorsOnEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, _, err := run(dir); err == nil {
+		t.Fatal("expected an error for a directory with no board files, got nil")
+	}
+}

--- a/internal/sources/config.go
+++ b/internal/sources/config.go
@@ -1,7 +1,10 @@
 package sources
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -34,17 +37,36 @@ func LoadConfig(path string) (Config, error) {
 // left it blank — an entry's own provider wins — so every CompanyEntry ends up with a
 // provider set for the rest of the pipeline.
 func ParseConfig(provider string, data []byte) (Config, error) {
+	entries, err := ParseRawEntries(provider, data)
+	if err != nil {
+		return Config{}, err
+	}
+	return Config{Provider: provider, Sources: dedupeBoards(entries)}, nil
+}
+
+// ParseRawEntries parses a board-list the same way ParseConfig does, but skips the
+// case-variant board collapsing dedupeBoards performs — it exists for
+// cmd/validate-sources, which needs to see the exact collisions ParseConfig fixes
+// quietly and fail loudly on them instead (see DuplicateBoards). Production code should
+// use ParseConfig or LoadConfig.
+//
+// Decoding is strict: an unrecognized key is a parse error rather than being silently
+// dropped. A typo in Region or Hub — the two fields whose absence has no required-field
+// error to catch it — would otherwise disable the behavior it names with no symptom
+// until someone investigates why a board crawled the wrong host.
+func ParseRawEntries(provider string, data []byte) ([]CompanyEntry, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
 	var entries []CompanyEntry
-	if err := yaml.Unmarshal(data, &entries); err != nil {
-		return Config{}, fmt.Errorf("sources: parse config: %w", err)
+	if err := dec.Decode(&entries); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("sources: parse config: %w", err)
 	}
 	for i := range entries {
 		if entries[i].Provider == "" {
 			entries[i].Provider = provider
 		}
 	}
-	entries = dedupeBoards(entries)
-	return Config{Provider: provider, Sources: entries}, nil
+	return entries, nil
 }
 
 // dedupeBoards collapses entries that address the same case-insensitive board on the same
@@ -64,11 +86,11 @@ func dedupeBoards(entries []CompanyEntry) []CompanyEntry {
 	seen := make(map[string]struct{}, len(entries))
 	kept := make([]CompanyEntry, 0, len(entries))
 	for _, e := range entries {
-		if e.Board == "" {
+		key, ok := boardDedupeKey(e)
+		if !ok {
 			kept = append(kept, e)
 			continue
 		}
-		key := e.Provider + "\x00" + strings.ToLower(e.Board) + "\x00" + e.Region
 		if _, dup := seen[key]; dup {
 			log.Printf("sources: dropping duplicate board %q (provider %s, company %q) — case-variant of an earlier entry",
 				e.Board, e.Provider, e.Company)
@@ -78,6 +100,37 @@ func dedupeBoards(entries []CompanyEntry) []CompanyEntry {
 		kept = append(kept, e)
 	}
 	return kept
+}
+
+// boardDedupeKey is the identity dedupeBoards and DuplicateBoards collapse on:
+// case-insensitive board, provider, and region. ok is false for a boardless entry, which
+// has no tenant id and so is never a duplicate of anything.
+func boardDedupeKey(e CompanyEntry) (key string, ok bool) {
+	if e.Board == "" {
+		return "", false
+	}
+	return e.Provider + "\x00" + strings.ToLower(e.Board) + "\x00" + e.Region, true
+}
+
+// DuplicateBoards reports every entry that collides with an earlier one under
+// boardDedupeKey — the exact pairs dedupeBoards drops silently at load time. It exists
+// for cmd/validate-sources, which fails loudly on what production quietly self-heals.
+func DuplicateBoards(entries []CompanyEntry) []string {
+	seen := make(map[string]CompanyEntry, len(entries))
+	var dups []string
+	for _, e := range entries {
+		key, ok := boardDedupeKey(e)
+		if !ok {
+			continue
+		}
+		if prev, dup := seen[key]; dup {
+			dups = append(dups, fmt.Sprintf("duplicate board %q (provider %s): company %q collides with company %q",
+				e.Board, e.Provider, e.Company, prev.Company))
+			continue
+		}
+		seen[key] = e
+	}
+	return dups
 }
 
 // Validate checks every entry against the registry by its provider, so the ingest

--- a/internal/sources/config_test.go
+++ b/internal/sources/config_test.go
@@ -249,3 +249,67 @@ func TestConfigValidateRejectsEmptyBoardForPerEntryBoardProvider(t *testing.T) {
 		t.Fatalf("expected empty-board error naming Acme, got %v", err)
 	}
 }
+
+// ParseConfig decodes strictly: a typo'd key has no required-field error to catch it (it
+// just leaves the intended field at its zero value), so an unrecognized key must fail the
+// parse outright instead of silently doing nothing.
+func TestParseConfigRejectsUnknownField(t *testing.T) {
+	_, err := ParseConfig("greenhouse", []byte("- company: Cohere\n  regoin: eu\n  board: cohere\n"))
+	if err == nil {
+		t.Fatal("expected an error for the unrecognized field, got nil")
+	}
+}
+
+// A board file that is comments only (e.g. a deprecated provider kept registered but
+// superseded, see sources/careerspage.yml) has no YAML document at all, which the
+// underlying decoder reports as io.EOF — that must read as zero entries, not a failure.
+func TestParseConfigAcceptsCommentOnlyFile(t *testing.T) {
+	cfg, err := ParseConfig("careerspage", []byte("# superseded by sources/manatal.yml\n"))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(cfg.Sources) != 0 {
+		t.Errorf("Sources = %+v, want none", cfg.Sources)
+	}
+}
+
+// DuplicateBoards is what cmd/validate-sources uses to fail loudly on the exact
+// collisions ParseConfig's dedupeBoards otherwise fixes quietly.
+func TestDuplicateBoardsReportsCaseVariantCollisions(t *testing.T) {
+	entries := []CompanyEntry{
+		{Company: "SopraSteria1", Provider: "smartrecruiters", Board: "SopraSteria1"},
+		{Company: "Stripe", Provider: "smartrecruiters", Board: "stripe"},
+		{Company: "soprasteria1", Provider: "smartrecruiters", Board: "soprasteria1"},
+	}
+	dups := DuplicateBoards(entries)
+	if len(dups) != 1 {
+		t.Fatalf("DuplicateBoards = %v, want exactly one collision", dups)
+	}
+	if !strings.Contains(dups[0], "SopraSteria1") || !strings.Contains(dups[0], "soprasteria1") {
+		t.Errorf("message %q should name both colliding companies", dups[0])
+	}
+}
+
+// A same-name board on two different regions is a real, distinct crawl target — not a
+// duplicate — matching TestParseConfigKeepsSameBoardOnDifferentRegions.
+func TestDuplicateBoardsKeepsSameBoardOnDifferentRegions(t *testing.T) {
+	entries := []CompanyEntry{
+		{Company: "Acme", Provider: "lever", Board: "acme", Region: "us"},
+		{Company: "Acme", Provider: "lever", Board: "acme", Region: "eu"},
+	}
+	if dups := DuplicateBoards(entries); len(dups) != 0 {
+		t.Errorf("DuplicateBoards = %v, want none (region variants)", dups)
+	}
+}
+
+// Boardless entries have no tenant id, so two of them must never read as duplicates of
+// each other just because both have an empty board.
+func TestDuplicateBoardsKeepsBoardlessEntries(t *testing.T) {
+	entries := []CompanyEntry{
+		{Company: "VK", Provider: "vk"},
+		{Company: "Ozon", Provider: "ozon"},
+	}
+	if dups := DuplicateBoards(entries); len(dups) != 0 {
+		t.Errorf("DuplicateBoards = %v, want none (boardless entries)", dups)
+	}
+}

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14365,8 +14365,6 @@
   board: zoomget
 
 # greenhouse board mined from remote.io (2026-08-09, live-validated)
-- company: Greenplaces
-  board: greenplaces
 
 # greenhouse boards mined from dynamitejobs.com (2026-08-10, live-validated)
 - company: Insurity

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -2143,8 +2143,6 @@
   board: skinvision1
 - company: "A+ Gestion"
   board: avantageplus
-- company: Aikido Security
-  board: aikidosecurity
 - company: Fixico
   board: fixico
 - company: Onlinesolliciteren

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -973,8 +973,6 @@
   board: apmgroup
 - company: applaudostudios
   board: applaudostudios
-- company: applusidiada1
-  board: applusidiada1
 - company: asos
   board: asos
 - company: avenues1
@@ -5665,8 +5663,6 @@
   board: acrobytetechnologies
 - company: Advantine Technologies
   board: advantinetechnologies
-- company: Agile IT
-  board: agileit
 - company: Airswift
   board: airswift
 - company: AJNA INFOTECH
@@ -5681,8 +5677,6 @@
   board: alquicoche
 - company: American IT Staff
   board: americanitstaff
-- company: American Montessori Society
-  board: americanmontessorisociety
 - company: American Veterinary Group
   board: americanveterinarygroup
 - company: AngioDynamics
@@ -5723,8 +5717,6 @@
   board: beigene
 - company: Benivo Limited
   board: benivo
-- company: Bertoni Solutions
-  board: bertonisolutions
 - company: BHC Press
   board: bhcpress
 - company: BigBinary
@@ -5739,8 +5731,6 @@
   board: bluecoding
 - company: B Riley Financial
   board: brileyfinancial
-- company: Bringle Excellence
-  board: bringleexcellence
 - company: Bucketlist Xperiences
   board: bucketlistxperiences
 - company: Business Wire
@@ -5791,8 +5781,6 @@
   board: coherusbiosciences
 - company: Concurrences
   board: concurrences
-- company: CONFISA INTERNATIONAL GROUP
-  board: confisainternationalgroup
 - company: Cornerstone Building Brands, Inc.
   board: cornerstonebuildingbrands
 - company: Creatively Smart Marketing
@@ -5823,10 +5811,6 @@
   board: divertinc
 - company: Doc Clik
   board: docclik
-- company: Domino's
-  board: dominos
-- company: Dresden Partners
-  board: dresdenpartners
 - company: DRT Strategies
   board: drtstrategies
 - company: Dwellworks
@@ -5903,8 +5887,6 @@
   board: hiretechgroup
 - company: HIRINGMAN
   board: hiringman
-- company: Hitachi Solutions
-  board: hitachisolutions
 - company: Hivemapper
   board: hivemapper
 - company: HiWave
@@ -5931,8 +5913,6 @@
   board: infoya
 - company: inSegment
   board: insegment
-- company: insightsoftware
-  board: insightsoftware
 - company: Inspectorio
   board: inspectorio
 - company: IntegriChain
@@ -5957,8 +5937,6 @@
   board: itechstack
 - company: IvyPanda
   board: ivypanda
-- company: JACOBS DOUWE EGBERTS
-  board: jacobsdouweegberts
 - company: jetfuel.agency
   board: jetfuelagency
 - company: JFL Media
@@ -5979,8 +5957,6 @@
   board: kitusystems
 - company: Knimbus
   board: knimbus
-- company: KoiReader Technologies
-  board: koireadertechnologies
 - company: Kore.ai
   board: koreai
 - company: Land O'Lakes, Inc.
@@ -5991,8 +5967,6 @@
   board: lanshore
 - company: Leadway Pensure
   board: leadwaypensure
-- company: LegalAndGeneral
-  board: legalandgeneral
 - company: Lifted (an Upwork Company)
   board: liftedanupworkcompany
 - company: Lingaro
@@ -6005,8 +5979,6 @@
   board: ludwig
 - company: Lynx Solutions
   board: lynxsolutions
-- company: M3 USA
-  board: m3usa
 - company: Magellan Health
   board: magellanhealth
 - company: Magic Ears
@@ -6041,8 +6013,6 @@
   board: montu
 - company: M&S Consulting
   board: msconsulting
-- company: NECSWS
-  board: necsws
 - company: Neilson Financial Services
   board: neilsonfinancialservices
 - company: New Amsterdam Technology and Business Ventures
@@ -6051,8 +6021,6 @@
   board: nextsteprecruitment
 - company: Next Step Systems
   board: nextstepsystems
-- company: Nile Bits
-  board: nilebits
 - company: NOCD
   board: nocd
 - company: Node.Digital
@@ -6089,8 +6057,6 @@
   board: polyconsulting
 - company: Privafy
   board: privafy
-- company: Privia Health
-  board: priviahealth
 - company: Pro Coffee Gear
   board: procoffeegear
 - company: Public Outdoor Creations
@@ -6115,8 +6081,6 @@
   board: recruitaidagency
 - company: Rede Consulting Services
   board: redeconsultingservices
-- company: REDICA Systems
-  board: redicasystems
 - company: Red Stamp Media
   board: redstampmedia
 - company: Relief International
@@ -6213,8 +6177,6 @@
   board: swisstankmedia
 - company: Syke Legal Engineering
   board: sykelegalengineering
-- company: Syncreon Consulting
-  board: syncreonconsulting
 - company: Talent2Africa
   board: talent2africa
 - company: Talent Navigation Experts
@@ -6245,8 +6207,6 @@
   board: thehrhubnigeria
 - company: The Impact Project
   board: theimpactproject
-- company: The Nielsen Company
-  board: thenielsencompany
 - company: The Opportunity Group
   board: theopportunitygroup
 - company: The Restory
@@ -6265,8 +6225,6 @@
   board: tripexpert
 - company: 'TTEC '
   board: ttec
-- company: Turner & Townsend
-  board: turnertownsend
 - company: U-Haul
   board: u-haul
 - company: Unowhy
@@ -6305,8 +6263,6 @@
   board: widercircle
 - company: Work Better Now
   board: workbetternow
-- company: XceedSearch.com
-  board: xceedsearchcom
 - company: Xinnovit
   board: xinnovit
 - company: Ziffity Solutions
@@ -6325,88 +6281,40 @@
   board: ContinentalGroupSectorContiTech
 - company: IOTA GROUP
   board: IOTAGROUP
-- company: SOCOTEC UK & Ireland
-  board: SOCOTECUKIreland
-- company: Agile IT
-  board: agileit
-- company: American Montessori Society
-  board: americanmontessorisociety
 - company: Armis
   board: armis
-- company: Bertoni Solutions
-  board: bertonisolutions
 - company: Blu Selection
   board: bluselection
 - company: BorderBuddy
   board: borderbuddy
-- company: Bringle Excellence
-  board: bringleexcellence
 - company: Brushfire
   board: brushfire
 - company: Center for Applied Linguistics
   board: centerforappliedlinguistics
-- company: CONFISA INTERNATIONAL GROUP
-  board: confisainternationalgroup
-- company: Domino's
-  board: dominos
 - company: Dotsub
   board: dotsub
-- company: Dresden Partners
-  board: dresdenpartners
-- company: Hitachi Solutions
-  board: hitachisolutions
-- company: H&M Group
-  board: hmgroup
 - company: Host & Stay
   board: hoststay
-- company: insightsoftware
-  board: insightsoftware
 - company: InVita Healthcare Technologies
   board: invitahealthcaretechnologies
-- company: JACOBS DOUWE EGBERTS
-  board: jacobsdouweegberts
-- company: KoiReader Technologies
-  board: koireadertechnologies
 - company: KPMG Australia
   board: kpmgaustralia
-- company: LegalAndGeneral
-  board: legalandgeneral
-- company: M3 USA
-  board: m3usa
-- company: NECSWS
-  board: necsws
-- company: Nile Bits
-  board: nilebits
 - company: Opportunity@Work
   board: opportunitywork
 - company: PeopleReady
   board: peopleready
-- company: Privia Health
-  board: priviahealth
 - company: RealDefense
   board: realdefense
-- company: REDICA Systems
-  board: redicasystems
 - company: Schoolyear
   board: schoolyear
 - company: Shaped
   board: shaped
 - company: Space Inch
   board: spaceinch
-- company: Syncreon Consulting
-  board: syncreonconsulting
 - company: TBD_14_10_2022_Ludia
   board: tbd14102022ludia
-- company: The Nielsen Company
-  board: thenielsencompany
-- company: Turner & Townsend
-  board: turnertownsend
 - company: Volunteers of America National Services
   board: volunteersofamericanationalservices
-- company: XceedSearch.com
-  board: xceedsearchcom
-- company: Abano Healthcare
-  board: abanohealthcare
 - company: Accenture Federal Services
   board: accenturefederalservices
 - company: Accion Labs
@@ -6417,8 +6325,6 @@
   board: agriculturalrecruitmentspecialists
 - company: Aizen Recruitment
   board: aizenrecruitment
-- company: Aldi Stores
-  board: aldistores
 - company: Alexander Associates
   board: alexanderassociates
 - company: Alliance IT
@@ -6435,8 +6341,6 @@
   board: arkinfotechspectrum
 - company: Asbury Automotive Group
   board: asburyautomotivegroup
-- company: Ashburn Consulting
-  board: ashburnconsulting
 - company: Aspire Technology Solutions
   board: aspiretechnologysolutions
 - company: Athena Technology Group, Inc.
@@ -6479,8 +6383,6 @@
   board: ceterafinancialgroup
 - company: Chandler Macleod Group
   board: chandlermacleodgroup
-- company: City of New York
-  board: cityofnewyork
 - company: CleanPeak Energy
   board: cleanpeakenergy
 - company: codeconvergence
@@ -6533,8 +6435,6 @@
   board: erpinternational
 - company: eSense Incorporated
   board: esenseincorporated
-- company: Experian Ltd
-  board: experian
 - company: Fintricity
   board: fintricity
 - company: Frank Recruitment Group Inc
@@ -6567,8 +6467,6 @@
   board: hireblazer
 - company: Hired by Matrix, Inc.
   board: hiredbymatrix
-- company: Hitachi Solutions
-  board: hitachisolutions
 - company: HonorVet Technologies
   board: honorvettechnologies
 - company: Horizontal Talent
@@ -6589,8 +6487,6 @@
   board: inlogik
 - company: Innovative IT Solutions Inc
   board: innovativeitsolutions
-- company: insightsoftware
-  board: insightsoftware
 - company: Intelizign
   board: intelizign
 - company: IPS Group
@@ -6613,8 +6509,6 @@
   board: kyrasolutions
 - company: LaSalle Network
   board: lasallenetwork
-- company: LegalAndGeneral
-  board: legalandgeneral
 - company: Leonardo DRS, Inc.
   board: leonardodrs
 - company: Linchpin Software
@@ -6649,8 +6543,6 @@
   board: navasoftwaresolutions
 - company: Naztec International Group LLC
   board: naztecinternationalgroup
-- company: NECSWS
-  board: necsws
 - company: NeerInfo Solutions Inc.
   board: neerinfosolutions
 - company: Negocios IT Solutions  LTD
@@ -6771,8 +6663,6 @@
   board: trigyntechnologies
 - company: Trinity Envision Business Services LLC
   board: trinityenvisionbusinessservices
-- company: Turner & Townsend
-  board: turnertownsend
 - company: United Technology
   board: unitedtechnology
 - company: USEReady
@@ -6789,8 +6679,6 @@
   board: vitashealthcare
 - company: Voluble Systems LLC
   board: volublesystems
-- company: Wabtec Corporation
-  board: wabtec
 - company: Webster & Webster Associates
   board: websterwebsterassociates
 - company: WhereGroup

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -690,8 +690,6 @@
   board: "qureight"
 - company: "Robeauté"
   board: "robeaute"
-- company: "Runware"
-  board: "runware"
 - company: "Second Nature"
   board: "secondnature"
 - company: "StrideUp"

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -12931,5 +12931,3 @@
   board: materialise.wd103.myworkdayjobs.com/Materialise_Jobs
 
 # link contribution, validated live 2026-08-11
-- company: SOK
-  board: sok.wd502.myworkdayjobs.com/S-ryhman-avoimet-tyopaikat


### PR DESCRIPTION
## Summary
- `cmd/validate-sources` checks every `sources/*.yml` (and `telegram.yml` via its own schema) for parse errors, unknown fields, missing company/board, unknown providers, and case-variant duplicate boards. No DB/network access, runs in well under a second.
- `internal/sources`: `ParseConfig` now decodes strictly (unrecognized key → error instead of silently ignored); adds `ParseRawEntries` and `DuplicateBoards` so the validator can see the collisions `dedupeBoards` otherwise fixes silently at load time.
- Wired into `.github/workflows/ci.yml` right after the format check.
- Cleaned up 60 pre-existing case-variant duplicate boards this surfaced (mostly `smartrecruiters.yml`), keeping the first occurrence to match the runtime dedupe's existing precedence.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` passes (one pre-existing, unrelated failure: `TestExtractResumeProfile_PDF` needs `pdftotext`, not installed on this machine)
- [x] `go run ./cmd/validate-sources` reports `OK — 203 file(s) checked` against the real `sources/` directory
- [x] New unit tests for `cmd/validate-sources` and the new `internal/sources` functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)