### PR TITLE
Add push notifications as a third delivery channel

### DIFF
--- a/cmd/notify/main.go
+++ b/cmd/notify/main.go
@@ -2,16 +2,18 @@
 // run does a single MATCH→DELIVER pass: it re-runs each distinct saved-search
 // query against the search index, records new matches in the dedup ledger, then
 // delivers each subscription's pending matches as one digest over the channel it
-// was subscribed on (Telegram and/or email). Run it on a schedule (e.g. cron); it
-// processes a bounded batch and exits. It exits non-zero when the run had delivery
-// failures so cron can alert.
+// was subscribed on (Telegram, email, and/or push). Run it on a schedule (e.g.
+// cron); it processes a bounded batch and exits. It exits non-zero when the run
+// had delivery failures so cron can alert.
 //
-// The feature is optional: with the search backend unconfigured, or with NO
-// delivery channel configured (neither the Telegram bot nor SES email), the worker
-// logs that it is disabled and exits 0 (nothing to do), so scheduling it before the
-// feature is set up does not raise false alarms. A subscription on a channel that
-// is not configured this run is soft-skipped, so one channel can run without the
-// other.
+// Matching itself is optional: with the search backend unconfigured, the worker
+// logs that it is disabled and exits 0 (nothing to do), so scheduling it before
+// the feature is set up does not raise false alarms. Telegram and email are each
+// registered conditionally on their own server credential (bot token / SES
+// region+from address); push needs none (Expo's relay holds the APNs/FCM
+// credential on its own side) and is therefore always registered. A subscription
+// on a channel that is not configured this run — or, for push, a user with no
+// registered device — is soft-skipped, so one channel can run without the others.
 package main
 
 import (
@@ -21,6 +23,7 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/emailnotify"
 	"github.com/strelov1/freehire/internal/notify"
+	"github.com/strelov1/freehire/internal/pushnotify"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/telegramnotify"
 	"github.com/strelov1/freehire/internal/worker"
@@ -45,9 +48,17 @@ func run() int {
 		return 0
 	}
 
+	queries := db.New(pool)
+
 	// Register every configured delivery channel; the Router dispatches each
 	// subscription to its channel and soft-skips one that is not configured.
-	router := notify.Router{}
+	// Push needs no server credential (see the package doc), so it is always
+	// registered — a recipient with no registered device still soft-skips
+	// per-user via recipient()'s HasPushDevice check.
+	pushStore := pushnotify.NewQueriesStore(queries)
+	router := notify.Router{
+		notify.ChannelPush: notify.NewPushNotifier(queries, pushnotify.NewExpoNotifier(pushStore, pushStore, pushStore)),
+	}
 	if cfg.TelegramBotToken != "" {
 		router[notify.ChannelTelegram] = telegramnotify.NewNotifier(telegramnotify.NewClient(cfg.TelegramBotToken), cfg.FrontendOrigin)
 	}
@@ -61,13 +72,9 @@ func run() int {
 			router[notify.ChannelEmail] = emailnotify.NewNotifier(ses, cfg.NotifyEmailFrom, cfg.FrontendOrigin)
 		}
 	}
-	if len(router) == 0 {
-		log.Printf("notify: no delivery channel configured (TELEGRAM_BOT_TOKEN or AWS_REGION+NOTIFY_EMAIL_FROM); nothing to deliver")
-		return 0
-	}
 
 	searcher := search.NewClient(cfg.MeiliURL, cfg.MeiliKey)
-	runner := notify.New(db.New(pool), searcher, router, notify.DefaultConfig())
+	runner := notify.New(queries, searcher, router, notify.DefaultConfig())
 
 	stats, err := runner.Run(ctx)
 	if err != nil {

--- a/cmd/nudge/main.go
+++ b/cmd/nudge/main.go
@@ -2,15 +2,16 @@
 // single MATCH→DELIVER pass: it re-scans tracked applications for two conditions —
 // gone silent past the stage's tolerated threshold, or a stage_set moved one into
 // `interview` — records new candidates, then delivers each pending nudge over the
-// channels the account's shared notification rule configures (Telegram and/or
-// email). Run it on a schedule (e.g. cron, ~every 30-60 min); it processes a
+// channels the account's shared notification rule configures (Telegram, email,
+// and/or push). Run it on a schedule (e.g. cron, ~every 30-60 min); it processes a
 // bounded batch and exits. It exits non-zero when the run had delivery failures so
 // cron can alert.
 //
-// The feature is optional: with NO delivery channel configured (neither the
-// Telegram bot nor SES email), the worker logs that it is disabled and exits 0
-// (nothing to deliver). A nudge whose channel is not configured this run is
-// soft-skipped and retried next pass, so one channel can run without the other.
+// Telegram and email are registered conditionally, on TELEGRAM_BOT_TOKEN and
+// AWS_REGION+NOTIFY_EMAIL_FROM respectively, since those channels need server-held
+// credentials; push needs none (the push relay holds its own device credentials)
+// and is always registered. A nudge whose channel is not configured this run is
+// soft-skipped and retried next pass, so one channel can run without the others.
 package main
 
 import (
@@ -21,6 +22,7 @@ import (
 	"github.com/strelov1/freehire/internal/emailnotify"
 	"github.com/strelov1/freehire/internal/notify"
 	"github.com/strelov1/freehire/internal/nudge"
+	"github.com/strelov1/freehire/internal/pushnotify"
 	"github.com/strelov1/freehire/internal/telegramnotify"
 	"github.com/strelov1/freehire/internal/worker"
 )
@@ -36,6 +38,8 @@ func run() int {
 		return 1
 	}
 	defer cleanup()
+
+	queries := db.New(pool)
 
 	// Register every configured delivery channel; the Router dispatches each
 	// nudge to its channel and soft-skips one that is not configured. Channel
@@ -54,12 +58,12 @@ func run() int {
 			router[notify.ChannelEmail] = nudge.NewEmailNotifier(ses, cfg.NotifyEmailFrom, cfg.FrontendOrigin)
 		}
 	}
-	if len(router) == 0 {
-		log.Printf("nudge: no delivery channel configured (TELEGRAM_BOT_TOKEN or AWS_REGION+NOTIFY_EMAIL_FROM); nothing to deliver")
-		return 0
-	}
+	// Push needs no server-held credential (the Expo relay holds its own device
+	// credentials), so it is always registered, unlike Telegram/email above.
+	pushStore := pushnotify.NewQueriesStore(queries)
+	router[notify.ChannelPush] = nudge.NewPushNotifier(queries, pushnotify.NewExpoNotifier(pushStore, pushStore, pushStore))
 
-	runner := nudge.New(db.New(pool), router, nudge.DefaultConfig())
+	runner := nudge.New(queries, router, nudge.DefaultConfig())
 
 	stats, err := runner.Run(ctx)
 	if err != nil {

--- a/cmd/remind/main.go
+++ b/cmd/remind/main.go
@@ -1,16 +1,18 @@
 // Command remind is the standalone saved-job reminder worker. One run does a
 // single firing pass: it leases the due, pending reminders and delivers each as a
-// one-shot nudge over the channels it was scheduled on (Telegram and/or email),
-// re-checking that the job is still open and still saved-but-unapplied immediately
-// before sending. Run it on a schedule (e.g. cron, ~every 15 min); it processes a
-// bounded batch and exits. It exits non-zero when the run had delivery failures so
-// cron can alert.
+// one-shot nudge over the channels it was scheduled on (Telegram, email, and/or
+// push), re-checking that the job is still open and still saved-but-unapplied
+// immediately before sending. Run it on a schedule (e.g. cron, ~every 15 min); it
+// processes a bounded batch and exits. It exits non-zero when the run had delivery
+// failures so cron can alert.
 //
-// The feature is optional: with NO delivery channel configured (neither the
-// Telegram bot nor SES email), the worker logs that it is disabled and exits 0
-// (nothing to deliver), so scheduling it before the feature is set up raises no
-// false alarms. A reminder whose channel is not configured this run is soft-skipped
-// and retried next pass, so one channel can run without the other.
+// Telegram and email register only when their credential is configured
+// (TELEGRAM_BOT_TOKEN, or AWS_REGION+NOTIFY_EMAIL_FROM); push registers
+// unconditionally, since Expo's relay needs no server-held credential (see
+// add-push-notification-channel design decision #6). A reminder whose channel is
+// not configured, or whose recipient has no usable destination on that channel
+// (unlinked Telegram, no registered push device), is soft-skipped and retried next
+// pass, so one channel's absence never blocks another.
 package main
 
 import (
@@ -20,6 +22,7 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/emailnotify"
 	"github.com/strelov1/freehire/internal/notify"
+	"github.com/strelov1/freehire/internal/pushnotify"
 	"github.com/strelov1/freehire/internal/reminder"
 	"github.com/strelov1/freehire/internal/telegramnotify"
 	"github.com/strelov1/freehire/internal/worker"
@@ -36,6 +39,8 @@ func run() int {
 		return 1
 	}
 	defer cleanup()
+
+	queries := db.New(pool)
 
 	// Register every configured delivery channel; the Router dispatches each
 	// reminder to its channel and soft-skips one that is not configured. Channel
@@ -54,12 +59,13 @@ func run() int {
 			router[notify.ChannelEmail] = reminder.NewEmailNotifier(ses, cfg.NotifyEmailFrom, cfg.FrontendOrigin)
 		}
 	}
-	if len(router) == 0 {
-		log.Printf("remind: no delivery channel configured (TELEGRAM_BOT_TOKEN or AWS_REGION+NOTIFY_EMAIL_FROM); nothing to deliver")
-		return 0
-	}
+	// Push needs no server-held credential (Expo's relay holds the APNs/FCM
+	// credential), so it registers unconditionally — no "feature globally off"
+	// state to represent for it.
+	pushStore := pushnotify.NewQueriesStore(queries)
+	router[notify.ChannelPush] = reminder.NewPushNotifier(queries, pushnotify.NewExpoNotifier(pushStore, pushStore, pushStore))
 
-	runner := reminder.NewRunner(db.New(pool), router, reminder.DefaultConfig())
+	runner := reminder.NewRunner(queries, router, reminder.DefaultConfig())
 
 	stats, err := runner.Run(ctx)
 	if err != nil {

--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -1,7 +1,7 @@
 # Notifications
 
-Three independent delivery use cases share one channel *vocabulary* (email +
-Telegram), each with its own small `Notifier`/`Router` pair:
+Three independent delivery use cases share one channel *vocabulary* (email,
+Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
 
 | Package | Use case | Worker |
 |---|---|---|
@@ -10,19 +10,32 @@ Telegram), each with its own small `Notifier`/`Router` pair:
 | `internal/nudge` | Lifecycle nudges — an application went silent past its stage's threshold, or moved into `interview` | `cmd/nudge` |
 | `internal/emailnotify` | Email channel (SES) — implements `notify.Notifier` (the `reminder`/`nudge`-side email transports live in their own `transports.go`) | — |
 | `internal/telegramnotify` | Telegram channel (Bot API, deep-link token) | — |
+| `internal/pushnotify` | Mobile push channel (Expo relay) — the bare Expo transport; each of `notify`/`reminder`/`nudge` has its own thin `PushNotifier` on top, same as Telegram/email | — |
 
 ## Always true
 
 - **A new channel is a new `Notifier` implementation — but there are THREE of them.** Each engine
   depends only on its own `Notifier` interface plus a `Router` (a `map[channel]Notifier`); the
   three interfaces share a signature and differ in payload, and `notify`/`reminder`/`nudge` each
-  carry their own `Router`, `ErrChannelNotConfigured` and `recipient`. So adding webhooks is a
+  carry their own `Router`, `ErrChannelNotConfigured` and `recipient`. So adding a channel is a
   digest notifier, a reminder transport, a nudge transport, a case in ALL THREE `recipient`
-  functions, and a wire-up in all three `cmd` mains. That is the real cost; the earlier claim that
-  it "means adding a package, not touching `notify` or `reminder`" was not true. Collapsing the
-  set is deliberately deferred until a third *channel* (not use case) actually lands and shows
-  which half generalises — `internal/nudge` is a third **use case**, over the same two channels,
-  and does not itself trigger the collapse.
+  functions, and a wire-up in all three `cmd` mains — confirmed by push, the third channel to
+  actually land this way (`add-push-notification-channel`). Collapsing the three engines into one
+  is still not done: `internal/nudge` was a third **use case** over the same channels and didn't
+  trigger it, and landing push — a third **channel** — didn't either, since the duplication is
+  three small, near-identical `PushNotifier`s (a few lines of message-rendering each) rather than
+  three copies of anything structurally significant. Revisit if a fourth channel makes the
+  per-engine cost look different.
+- **Push needs no server-side credential and is therefore always registered.** Unlike Telegram
+  (`TELEGRAM_BOT_TOKEN`) and email (`AWS_REGION`+`NOTIFY_EMAIL_FROM`), Expo's relay holds the
+  APNs/FCM credential on its own side (set up once via `eas credentials` in `freehire-mobile`), so
+  every `cmd` main registers the push notifier unconditionally — there is no "channel not
+  configured" state for push, only a per-recipient one. `dest` for push is the recipient's user id
+  (not a device token): a user may have zero-to-many registered devices
+  (`user_push_tokens`), so each engine's `recipient()` soft-skips on a live `HasPushDevice`
+  column (mirroring `TelegramChatID.Valid`) and the `PushNotifier` fans the send out to every
+  device via `pushnotify.SendToDevices`, which is delivered as long as at least one device
+  received it.
 - **`notify.Channels` is the single source of truth** for the channel vocabulary, and
   `notify.ValidChannel` is the membership test both create-time gates use. Subscriptions and
   reminders each built their own `map[string]bool` from the slice until the test was exported.

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -343,10 +343,10 @@ type ListCompaniesRow struct {
 // companies sort last), falling through to the default job_count DESC, name
 // for the tiebreak. Any other value (including ”, the default) leaves the
 // CASE NULL for every row, so this ORDER BY is byte-for-byte the old one.
-// Applies to this Postgres path only — a request that also carries a search
-// or facet, routed to Meili instead when configured (see ListCompanies in
-// internal/handler/companies.go), keeps Meili's relevance ordering; rating is
-// not (yet) a Meili-sortable attribute.
+// sort=rating forces every request onto this Postgres path even with a search
+// or facet present that would otherwise route to Meili (see ListCompanies in
+// internal/handler/companies.go) — rating is not (yet) a Meili-sortable
+// attribute, so routing there would silently drop the requested order.
 func (q *Queries) ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error) {
 	rows, err := q.db.Query(ctx, listCompanies,
 		arg.Search,

--- a/internal/db/nudges.sql.go
+++ b/internal/db/nudges.sql.go
@@ -87,7 +87,8 @@ SELECT n.id, n.user_id, n.job_id, n.kind,
        GREATEST(a.applied_at, mail.newest_mail_at)::timestamptz AS last_activity_at,
        COALESCE(mail.suggestion_pending, false)::boolean AS has_pending_suggestion,
        u.email AS account_email,
-       tl.chat_id AS telegram_chat_id
+       tl.chat_id AS telegram_chat_id,
+       EXISTS(SELECT 1 FROM user_push_tokens upt WHERE upt.user_id = n.user_id) AS has_push_device
 FROM application_nudges n
 JOIN jobs j ON j.id = n.job_id
 JOIN users u ON u.id = n.user_id
@@ -122,6 +123,7 @@ type GetNudgeForDeliveryRow struct {
 	HasPendingSuggestion bool               `json:"has_pending_suggestion"`
 	AccountEmail         string             `json:"account_email"`
 	TelegramChatID       pgtype.Int8        `json:"telegram_chat_id"`
+	HasPushDevice        bool               `json:"has_push_device"`
 }
 
 // The re-check-before-send context for one nudge: the job display fields, the
@@ -151,6 +153,7 @@ func (q *Queries) GetNudgeForDelivery(ctx context.Context, id int64) (GetNudgeFo
 		&i.HasPendingSuggestion,
 		&i.AccountEmail,
 		&i.TelegramChatID,
+		&i.HasPushDevice,
 	)
 	return i, err
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1157,10 +1157,10 @@ type Querier interface {
 	GetReferralRequest(ctx context.Context, id uuid.UUID) (ReferralRequest, error)
 	// The delivery context for one reminder: the job display fields, the channel set,
 	// the user's live destinations (account email; linked Telegram chat, NULL when
-	// unlinked -> that channel soft-skips), and the fire-time re-check flags. job_open
-	// and still_actionable let the worker cancel-and-skip a reminder whose job has since
-	// closed or is no longer saved-but-unapplied, closing the race between a cancel and
-	// the fire.
+	// unlinked -> that channel soft-skips; whether a push device is registered), and
+	// the fire-time re-check flags. job_open and still_actionable let the worker
+	// cancel-and-skip a reminder whose job has since closed or is no longer
+	// saved-but-unapplied, closing the race between a cancel and the fire.
 	GetReminderForDelivery(ctx context.Context, id int64) (GetReminderForDeliveryRow, error)
 	// Load a single report by id for the review path, with the reporter's email and the
 	// reported job's slug and title — the decision notice needs them, and joining here spares
@@ -1179,8 +1179,10 @@ type Querier interface {
 	GetSubmission(ctx context.Context, id int64) (JobSubmission, error)
 	// The delivery context for one subscription: channel + destination, the saved
 	// search name (for the digest heading), the user's account email (the email
-	// channel's live recipient), and the user's linked Telegram chat (NULL when
-	// unlinked → the worker soft-skips telegram delivery rather than failing it).
+	// channel's live recipient), the user's linked Telegram chat (NULL when unlinked
+	// → the worker soft-skips telegram delivery rather than failing it), and whether
+	// the user has at least one registered push device (the push channel's live
+	// deliverability check, same soft-skip role as the Telegram link).
 	GetSubscriptionForDelivery(ctx context.Context, id int64) (GetSubscriptionForDeliveryRow, error)
 	// The user's existing tailored copy for one vacancy, newest first. The tailoring bootstrap is
 	// reached by an address (/tailor/<slug>) that carries no CV reference, so a reload runs the
@@ -1532,10 +1534,10 @@ type Querier interface {
 	// companies sort last), falling through to the default job_count DESC, name
 	// for the tiebreak. Any other value (including '', the default) leaves the
 	// CASE NULL for every row, so this ORDER BY is byte-for-byte the old one.
-	// Applies to this Postgres path only — a request that also carries a search
-	// or facet, routed to Meili instead when configured (see ListCompanies in
-	// internal/handler/companies.go), keeps Meili's relevance ordering; rating is
-	// not (yet) a Meili-sortable attribute.
+	// sort=rating forces every request onto this Postgres path even with a search
+	// or facet present that would otherwise route to Meili (see ListCompanies in
+	// internal/handler/companies.go) — rating is not (yet) a Meili-sortable
+	// attribute, so routing there would silently drop the requested order.
 	ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error)
 	// Keyset page of hiring companies (job_count > 0) for the companies search reindex,
 	// cursored by the slug primary key (first chunk keyed by the empty string, which

--- a/internal/db/queries/nudges.sql
+++ b/internal/db/queries/nudges.sql
@@ -101,7 +101,8 @@ SELECT n.id, n.user_id, n.job_id, n.kind,
        GREATEST(a.applied_at, mail.newest_mail_at)::timestamptz AS last_activity_at,
        COALESCE(mail.suggestion_pending, false)::boolean AS has_pending_suggestion,
        u.email AS account_email,
-       tl.chat_id AS telegram_chat_id
+       tl.chat_id AS telegram_chat_id,
+       EXISTS(SELECT 1 FROM user_push_tokens upt WHERE upt.user_id = n.user_id) AS has_push_device
 FROM application_nudges n
 JOIN jobs j ON j.id = n.job_id
 JOIN users u ON u.id = n.user_id

--- a/internal/db/queries/reminders.sql
+++ b/internal/db/queries/reminders.sql
@@ -68,16 +68,17 @@ RETURNING r.id;
 -- name: GetReminderForDelivery :one
 -- The delivery context for one reminder: the job display fields, the channel set,
 -- the user's live destinations (account email; linked Telegram chat, NULL when
--- unlinked -> that channel soft-skips), and the fire-time re-check flags. job_open
--- and still_actionable let the worker cancel-and-skip a reminder whose job has since
--- closed or is no longer saved-but-unapplied, closing the race between a cancel and
--- the fire.
+-- unlinked -> that channel soft-skips; whether a push device is registered), and
+-- the fire-time re-check flags. job_open and still_actionable let the worker
+-- cancel-and-skip a reminder whose job has since closed or is no longer
+-- saved-but-unapplied, closing the race between a cancel and the fire.
 SELECT r.id, r.user_id, r.job_id, r.channels,
        j.title, j.company, j.public_slug, j.url,
        (j.closed_at IS NULL)::bool AS job_open,
        COALESCE(uj.saved_at IS NOT NULL AND a.applied_at IS NULL, false)::bool AS still_actionable,
        u.email AS account_email,
-       tl.chat_id AS telegram_chat_id
+       tl.chat_id AS telegram_chat_id,
+       EXISTS(SELECT 1 FROM user_push_tokens upt WHERE upt.user_id = r.user_id) AS has_push_device
 FROM job_reminders r
 JOIN jobs j ON j.id = r.job_id
 JOIN users u ON u.id = r.user_id

--- a/internal/db/queries/subscriptions.sql
+++ b/internal/db/queries/subscriptions.sql
@@ -87,12 +87,15 @@ RETURNING m.subscription_id, m.job_id;
 -- name: GetSubscriptionForDelivery :one
 -- The delivery context for one subscription: channel + destination, the saved
 -- search name (for the digest heading), the user's account email (the email
--- channel's live recipient), and the user's linked Telegram chat (NULL when
--- unlinked → the worker soft-skips telegram delivery rather than failing it).
+-- channel's live recipient), the user's linked Telegram chat (NULL when unlinked
+-- → the worker soft-skips telegram delivery rather than failing it), and whether
+-- the user has at least one registered push device (the push channel's live
+-- deliverability check, same soft-skip role as the Telegram link).
 SELECT s.id, s.user_id, s.channel, s.destination,
        ss.name AS saved_search_name,
        u.email AS account_email,
-       tl.chat_id AS telegram_chat_id
+       tl.chat_id AS telegram_chat_id,
+       EXISTS(SELECT 1 FROM user_push_tokens upt WHERE upt.user_id = s.user_id) AS has_push_device
 FROM subscriptions s
 JOIN saved_searches ss ON ss.id = s.saved_search_id
 JOIN users u ON u.id = s.user_id

--- a/internal/db/reminders.sql.go
+++ b/internal/db/reminders.sql.go
@@ -127,7 +127,8 @@ SELECT r.id, r.user_id, r.job_id, r.channels,
        (j.closed_at IS NULL)::bool AS job_open,
        COALESCE(uj.saved_at IS NOT NULL AND a.applied_at IS NULL, false)::bool AS still_actionable,
        u.email AS account_email,
-       tl.chat_id AS telegram_chat_id
+       tl.chat_id AS telegram_chat_id,
+       EXISTS(SELECT 1 FROM user_push_tokens upt WHERE upt.user_id = r.user_id) AS has_push_device
 FROM job_reminders r
 JOIN jobs j ON j.id = r.job_id
 JOIN users u ON u.id = r.user_id
@@ -150,14 +151,15 @@ type GetReminderForDeliveryRow struct {
 	StillActionable bool        `json:"still_actionable"`
 	AccountEmail    string      `json:"account_email"`
 	TelegramChatID  pgtype.Int8 `json:"telegram_chat_id"`
+	HasPushDevice   bool        `json:"has_push_device"`
 }
 
 // The delivery context for one reminder: the job display fields, the channel set,
 // the user's live destinations (account email; linked Telegram chat, NULL when
-// unlinked -> that channel soft-skips), and the fire-time re-check flags. job_open
-// and still_actionable let the worker cancel-and-skip a reminder whose job has since
-// closed or is no longer saved-but-unapplied, closing the race between a cancel and
-// the fire.
+// unlinked -> that channel soft-skips; whether a push device is registered), and
+// the fire-time re-check flags. job_open and still_actionable let the worker
+// cancel-and-skip a reminder whose job has since closed or is no longer
+// saved-but-unapplied, closing the race between a cancel and the fire.
 func (q *Queries) GetReminderForDelivery(ctx context.Context, id int64) (GetReminderForDeliveryRow, error) {
 	row := q.db.QueryRow(ctx, getReminderForDelivery, id)
 	var i GetReminderForDeliveryRow
@@ -174,6 +176,7 @@ func (q *Queries) GetReminderForDelivery(ctx context.Context, id int64) (GetRemi
 		&i.StillActionable,
 		&i.AccountEmail,
 		&i.TelegramChatID,
+		&i.HasPushDevice,
 	)
 	return i, err
 }

--- a/internal/db/subscriptions.sql.go
+++ b/internal/db/subscriptions.sql.go
@@ -197,7 +197,8 @@ const getSubscriptionForDelivery = `-- name: GetSubscriptionForDelivery :one
 SELECT s.id, s.user_id, s.channel, s.destination,
        ss.name AS saved_search_name,
        u.email AS account_email,
-       tl.chat_id AS telegram_chat_id
+       tl.chat_id AS telegram_chat_id,
+       EXISTS(SELECT 1 FROM user_push_tokens upt WHERE upt.user_id = s.user_id) AS has_push_device
 FROM subscriptions s
 JOIN saved_searches ss ON ss.id = s.saved_search_id
 JOIN users u ON u.id = s.user_id
@@ -213,12 +214,15 @@ type GetSubscriptionForDeliveryRow struct {
 	SavedSearchName string      `json:"saved_search_name"`
 	AccountEmail    string      `json:"account_email"`
 	TelegramChatID  pgtype.Int8 `json:"telegram_chat_id"`
+	HasPushDevice   bool        `json:"has_push_device"`
 }
 
 // The delivery context for one subscription: channel + destination, the saved
 // search name (for the digest heading), the user's account email (the email
-// channel's live recipient), and the user's linked Telegram chat (NULL when
-// unlinked → the worker soft-skips telegram delivery rather than failing it).
+// channel's live recipient), the user's linked Telegram chat (NULL when unlinked
+// → the worker soft-skips telegram delivery rather than failing it), and whether
+// the user has at least one registered push device (the push channel's live
+// deliverability check, same soft-skip role as the Telegram link).
 func (q *Queries) GetSubscriptionForDelivery(ctx context.Context, id int64) (GetSubscriptionForDeliveryRow, error) {
 	row := q.db.QueryRow(ctx, getSubscriptionForDelivery, id)
 	var i GetSubscriptionForDeliveryRow
@@ -230,6 +234,7 @@ func (q *Queries) GetSubscriptionForDelivery(ctx context.Context, id int64) (Get
 		&i.SavedSearchName,
 		&i.AccountEmail,
 		&i.TelegramChatID,
+		&i.HasPushDevice,
 	)
 	return i, err
 }

--- a/internal/handler/me_push_tokens.go
+++ b/internal/handler/me_push_tokens.go
@@ -158,7 +158,7 @@ func (h *authHandlers) TestPushToken(c *fiber.Ctx) error {
 
 	out := testPushTokenResponse{Devices: len(tokens)}
 	for _, t := range tokens {
-		switch err := h.pushNotifier.Send(c.Context(), t.Token, "freehire", "This is a test notification."); {
+		switch err := h.pushNotifier.Send(c.Context(), t.Token, "freehire", "This is a test notification.", nil); {
 		case err == nil:
 			out.Sent++
 		case errors.Is(err, pushnotify.ErrTokenPruned):

--- a/internal/handler/me_push_tokens_integration_test.go
+++ b/internal/handler/me_push_tokens_integration_test.go
@@ -31,7 +31,7 @@ type fakeSendNotifier struct {
 	outcomes map[string]error // token -> error to return (nil = "sent")
 }
 
-func (n *fakeSendNotifier) Send(ctx context.Context, token, title, body string) error {
+func (n *fakeSendNotifier) Send(ctx context.Context, token, title, body string, data map[string]string) error {
 	return n.outcomes[token]
 }
 

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -164,8 +164,10 @@ func (r *Runner) Run(ctx context.Context) (Stats, error) {
 // recipient resolves the destination string for delivery, and whether the
 // subscription is deliverable right now. Telegram resolves the linked chat_id
 // (absent → not deliverable, soft-skipped); email resolves the user's account
-// email live (absent → soft-skipped); any other channel uses the stored
-// destination.
+// email live (absent → soft-skipped); push resolves the subscribing user's id,
+// deliverable only when they have a currently registered device (absent →
+// soft-skipped, same as an unlinked Telegram chat); any other channel uses the
+// stored destination.
 func recipient(info db.GetSubscriptionForDeliveryRow) (string, bool) {
 	switch info.Channel {
 	case ChannelTelegram:

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -178,6 +178,11 @@ func recipient(info db.GetSubscriptionForDeliveryRow) (string, bool) {
 			return "", false
 		}
 		return info.AccountEmail, true
+	case ChannelPush:
+		if !info.HasPushDevice {
+			return "", false
+		}
+		return strconv.FormatInt(info.UserID, 10), true
 	}
 	if !info.Destination.Valid || info.Destination.String == "" {
 		return "", false

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -27,10 +27,16 @@ import (
 // ChannelEmail is declared alongside the Router in router.go.
 const ChannelTelegram = "telegram"
 
+// ChannelPush delivers a digest as a mobile push notification (via Expo), fanned
+// out to every device the user has registered. Unlike Telegram/email it needs no
+// server-side credential, so it is always registered in a Router regardless of
+// environment configuration.
+const ChannelPush = "push"
+
 // Channels is the delivery-channel vocabulary: the single source of truth shared
 // by the router's dispatch and the subscription use case's create-time allowlist,
 // so the two can never drift.
-var Channels = []string{ChannelTelegram, ChannelEmail}
+var Channels = []string{ChannelTelegram, ChannelEmail, ChannelPush}
 
 // ValidChannel reports whether c is a delivery channel. It exists because the slice alone is
 // not usable as an allowlist, so both create-time gates — subscriptions and reminders — built

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -325,3 +325,36 @@ func TestValidChannel_Push(t *testing.T) {
 		t.Error("ValidChannel(ChannelPush) = false, want true")
 	}
 }
+
+// recipient's push case mirrors Telegram's: a live "has device" boolean gates
+// whether the subscription is deliverable, and the destination is the user id
+// (PushNotifier expands that into N device sends).
+func TestRecipient_PushWithDevice(t *testing.T) {
+	info := db.GetSubscriptionForDeliveryRow{
+		UserID:        42,
+		Channel:       ChannelPush,
+		HasPushDevice: true,
+	}
+	dest, ok := recipient(info)
+	if !ok {
+		t.Fatal("recipient: ok = false, want true when HasPushDevice")
+	}
+	if dest != "42" {
+		t.Errorf("recipient dest = %q, want %q (the user id)", dest, "42")
+	}
+}
+
+func TestRecipient_PushWithoutDeviceIsNotDeliverable(t *testing.T) {
+	info := db.GetSubscriptionForDeliveryRow{
+		UserID:        42,
+		Channel:       ChannelPush,
+		HasPushDevice: false,
+	}
+	dest, ok := recipient(info)
+	if ok {
+		t.Errorf("recipient: ok = true, want false when no device is registered")
+	}
+	if dest != "" {
+		t.Errorf("recipient dest = %q, want empty", dest)
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -315,3 +315,13 @@ func TestValidChannel(t *testing.T) {
 		}
 	}
 }
+
+// Push is the third delivery channel, added alongside Telegram and email.
+func TestValidChannel_Push(t *testing.T) {
+	if ChannelPush != "push" {
+		t.Errorf("ChannelPush = %q, want %q", ChannelPush, "push")
+	}
+	if !ValidChannel(ChannelPush) {
+		t.Error("ValidChannel(ChannelPush) = false, want true")
+	}
+}

--- a/internal/notify/push.go
+++ b/internal/notify/push.go
@@ -1,0 +1,63 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/pushnotify"
+)
+
+// PushTokenLister lists a user's registered push devices. *db.Queries
+// satisfies it.
+type PushTokenLister interface {
+	ListPushTokensForUser(ctx context.Context, userID int64) ([]db.UserPushToken, error)
+}
+
+// PushNotifier delivers a digest as a mobile push, fanned out to every device
+// the user has registered. dest is the user id — recipient() resolves it
+// live from HasPushDevice rather than a stored per-subscription destination
+// (see design decision #1); this notifier is the one that expands that single
+// id into N device sends via pushnotify.SendToDevices.
+type PushNotifier struct {
+	tokens    PushTokenLister
+	transport pushnotify.Notifier
+}
+
+// NewPushNotifier builds a PushNotifier.
+func NewPushNotifier(tokens PushTokenLister, transport pushnotify.Notifier) *PushNotifier {
+	return &PushNotifier{tokens: tokens, transport: transport}
+}
+
+// Send renders the digest as a short title/body (a full itemized listing, as
+// Telegram/email send, has no room in a push notification) and fans it out to
+// every device the user has registered. A single-job digest carries the job's
+// slug as deep-link data so the mobile app can open it directly; a digest of
+// more than one job carries no deep-link data, matching the "Push digest
+// content and deep link" requirement.
+func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, d Digest) error {
+	userID, err := strconv.ParseInt(dest, 10, 64)
+	if err != nil {
+		return fmt.Errorf("notify: push dest %q is not a user id: %w", dest, err)
+	}
+
+	rows, err := n.tokens.ListPushTokensForUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("notify: list push tokens for user %d: %w", userID, err)
+	}
+	tokens := make([]string, len(rows))
+	for i, r := range rows {
+		tokens[i] = r.Token
+	}
+
+	title := "freehire"
+	body := fmt.Sprintf("%d new jobs for %q", d.Total, d.SavedSearchName)
+
+	var data map[string]string
+	if d.Total == 1 {
+		data = map[string]string{"slug": d.Jobs[0].Slug}
+	}
+
+	return pushnotify.SendToDevices(ctx, n.transport, tokens, title, body, data)
+}

--- a/internal/notify/push_integration_test.go
+++ b/internal/notify/push_integration_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+// Integration test for the push delivery channel (task 3.5 of
+// add-push-notification-channel): a push subscription backed by a real
+// Postgres store delivers when the user has a registered device, and softly
+// skips (matches stay pending, no attempt counted) when they don't. The fast
+// unit tests in notify_test.go and push_test.go already cover recipient()'s
+// branches and PushNotifier's render logic against fakes; this test's only job
+// is proving the real Store + real schema round-trip through Runner.Run the
+// same way. Run with:
+// go test -tags=integration ./internal/notify/
+// Requires Docker (testcontainers spins up a throwaway Postgres with the
+// migrations).
+package notify
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+// fakePushIntegrationTransport is a pushnotify.Notifier stub that always
+// succeeds, so the test exercises PushNotifier + the real Store without
+// depending on Expo's actual API.
+type fakePushIntegrationTransport struct {
+	sent []string // tokens sent to
+}
+
+func (f *fakePushIntegrationTransport) Send(_ context.Context, token, _, _ string, _ map[string]string) error {
+	f.sent = append(f.sent, token)
+	return nil
+}
+
+func insertNotifyIntegrationUser(t *testing.T, pool *pgxpool.Pool, email string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&id); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	return id
+}
+
+func insertNotifySavedSearch(t *testing.T, pool *pgxpool.Pool, userID int64, name, query string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO saved_searches (user_id, name, query) VALUES ($1, $2, $3) RETURNING id`,
+		userID, name, query).Scan(&id); err != nil {
+		t.Fatalf("insert saved search: %v", err)
+	}
+	return id
+}
+
+func insertNotifyPushSubscription(t *testing.T, pool *pgxpool.Pool, userID, savedSearchID int64) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO subscriptions (user_id, saved_search_id, channel, active) VALUES ($1, $2, 'push', true) RETURNING id`,
+		userID, savedSearchID).Scan(&id); err != nil {
+		t.Fatalf("insert subscription: %v", err)
+	}
+	return id
+}
+
+func insertNotifyJob(t *testing.T, pool *pgxpool.Pool, externalID, title, slug string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, public_slug) VALUES ('test', $1, 'https://example.test/job', $2, $3) RETURNING id`,
+		externalID, title, slug).Scan(&id); err != nil {
+		t.Fatalf("insert job: %v", err)
+	}
+	return id
+}
+
+func insertNotifyPendingMatch(t *testing.T, pool *pgxpool.Pool, subscriptionID, jobID int64) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO subscription_matches (subscription_id, job_id) VALUES ($1, $2)`,
+		subscriptionID, jobID); err != nil {
+		t.Fatalf("insert subscription match: %v", err)
+	}
+}
+
+func insertNotifyPushToken(t *testing.T, pool *pgxpool.Pool, userID int64, token string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO user_push_tokens (user_id, token, platform) VALUES ($1, $2, 'ios')`,
+		userID, token); err != nil {
+		t.Fatalf("insert push token: %v", err)
+	}
+}
+
+func matchState(t *testing.T, pool *pgxpool.Pool, subscriptionID, jobID int64) (notified, claimed bool) {
+	t.Helper()
+	var notifiedAt, claimedAt any
+	if err := pool.QueryRow(context.Background(),
+		`SELECT notified_at, claimed_at FROM subscription_matches WHERE subscription_id = $1 AND job_id = $2`,
+		subscriptionID, jobID).Scan(&notifiedAt, &claimedAt); err != nil {
+		t.Fatalf("load match state: %v", err)
+	}
+	return notifiedAt != nil, claimedAt != nil
+}
+
+func TestPushDelivery_UserWithRegisteredDeviceIsDelivered(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := insertNotifyIntegrationUser(t, pool, "push-delivered@example.test")
+	savedSearchID := insertNotifySavedSearch(t, pool, userID, "Backend Engineer", "seniority=senior")
+	subID := insertNotifyPushSubscription(t, pool, userID, savedSearchID)
+	jobID := insertNotifyJob(t, pool, "job-delivered-1", "Backend Engineer", "acme-backend-engineer")
+	insertNotifyPendingMatch(t, pool, subID, jobID)
+	insertNotifyPushToken(t, pool, userID, "ExponentPushToken[has-device]")
+
+	transport := &fakePushIntegrationTransport{}
+	router := Router{ChannelPush: NewPushNotifier(queries, transport)}
+	runner := New(queries, &fakeSearcher{}, router, DefaultConfig())
+
+	stats, err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Delivered != 1 {
+		t.Errorf("stats.Delivered = %d, want 1", stats.Delivered)
+	}
+	if stats.SoftSkips != 0 {
+		t.Errorf("stats.SoftSkips = %d, want 0", stats.SoftSkips)
+	}
+	if len(transport.sent) != 1 || transport.sent[0] != "ExponentPushToken[has-device]" {
+		t.Errorf("transport.sent = %v, want the registered token", transport.sent)
+	}
+
+	notified, _ := matchState(t, pool, subID, jobID)
+	if !notified {
+		t.Error("match not marked notified after a successful delivery")
+	}
+}
+
+func TestPushDelivery_UserWithNoDeviceSoftSkips(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := insertNotifyIntegrationUser(t, pool, "push-no-device@example.test")
+	savedSearchID := insertNotifySavedSearch(t, pool, userID, "Backend Engineer", "seniority=senior")
+	subID := insertNotifyPushSubscription(t, pool, userID, savedSearchID)
+	jobID := insertNotifyJob(t, pool, "job-no-device-1", "Backend Engineer", "acme-backend-engineer-2")
+	insertNotifyPendingMatch(t, pool, subID, jobID)
+	// No user_push_tokens row: HasPushDevice is false, so the delivery must
+	// soft-skip rather than dead-letter.
+
+	transport := &fakePushIntegrationTransport{}
+	router := Router{ChannelPush: NewPushNotifier(queries, transport)}
+	runner := New(queries, &fakeSearcher{}, router, DefaultConfig())
+
+	stats, err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.SoftSkips != 1 {
+		t.Errorf("stats.SoftSkips = %d, want 1", stats.SoftSkips)
+	}
+	if stats.Delivered != 0 {
+		t.Errorf("stats.Delivered = %d, want 0", stats.Delivered)
+	}
+	if len(transport.sent) != 0 {
+		t.Errorf("transport.sent = %v, want none — no device to send to", transport.sent)
+	}
+
+	notified, claimed := matchState(t, pool, subID, jobID)
+	if notified {
+		t.Error("match marked notified despite a soft-skip")
+	}
+	if claimed {
+		t.Error("match still claimed after soft-skip; want the claim released so the next pass retries")
+	}
+}

--- a/internal/notify/push_test.go
+++ b/internal/notify/push_test.go
@@ -1,0 +1,131 @@
+package notify
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// fakePushTokenLister stands in for *db.Queries's ListPushTokensForUser.
+type fakePushTokenLister struct {
+	tokens map[int64][]db.UserPushToken
+}
+
+func (f *fakePushTokenLister) ListPushTokensForUser(_ context.Context, userID int64) ([]db.UserPushToken, error) {
+	return f.tokens[userID], nil
+}
+
+// fakePushTransport is a pushnotify.Notifier test double that records every
+// call so a test can assert on the rendered title/body/data.
+type fakePushTransport struct {
+	calls []pushCall
+}
+
+type pushCall struct {
+	token, title, body string
+	data               map[string]string
+}
+
+func (f *fakePushTransport) Send(_ context.Context, token, title, body string, data map[string]string) error {
+	f.calls = append(f.calls, pushCall{token: token, title: title, body: body, data: data})
+	return nil
+}
+
+func TestPushNotifier_SingleJobDigestCarriesSlugDeepLink(t *testing.T) {
+	tokens := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "ExponentPushToken[abc]"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(tokens, transport)
+
+	d := Digest{
+		SavedSearchName: "Backend Engineer",
+		Total:           1,
+		Jobs:            []DigestJob{{Title: "Backend Engineer", Company: "Acme", Slug: "acme-backend-engineer"}},
+	}
+	if err := n.Send(context.Background(), ChannelPush, "42", d); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(transport.calls) != 1 {
+		t.Fatalf("transport calls = %d, want 1", len(transport.calls))
+	}
+	call := transport.calls[0]
+	if call.token != "ExponentPushToken[abc]" {
+		t.Errorf("token = %q, want the user's registered token", call.token)
+	}
+	if call.data["slug"] != "acme-backend-engineer" {
+		t.Errorf("data[slug] = %q, want %q", call.data["slug"], "acme-backend-engineer")
+	}
+}
+
+func TestPushNotifier_MultiJobDigestCarriesNoDeepLink(t *testing.T) {
+	tokens := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "ExponentPushToken[abc]"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(tokens, transport)
+
+	d := Digest{
+		SavedSearchName: "Backend Engineer",
+		Total:           3,
+		Jobs: []DigestJob{
+			{Title: "A", Slug: "a"},
+			{Title: "B", Slug: "b"},
+			{Title: "C", Slug: "c"},
+		},
+	}
+	if err := n.Send(context.Background(), ChannelPush, "42", d); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(transport.calls) != 1 {
+		t.Fatalf("transport calls = %d, want 1", len(transport.calls))
+	}
+	if transport.calls[0].data != nil {
+		t.Errorf("data = %v, want nil for a multi-job digest", transport.calls[0].data)
+	}
+}
+
+func TestPushNotifier_TitleAndBodyContent(t *testing.T) {
+	tokens := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "ExponentPushToken[abc]"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(tokens, transport)
+
+	d := Digest{SavedSearchName: "Backend Engineer", Total: 3}
+	if err := n.Send(context.Background(), ChannelPush, "42", d); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	call := transport.calls[0]
+	if call.title != "freehire" {
+		t.Errorf("title = %q, want %q", call.title, "freehire")
+	}
+	wantBody := `3 new jobs for "Backend Engineer"`
+	if call.body != wantBody {
+		t.Errorf("body = %q, want %q", call.body, wantBody)
+	}
+}
+
+func TestPushNotifier_FansOutToEveryRegisteredDevice(t *testing.T) {
+	tokens := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "tok-1"}, {Token: "tok-2"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(tokens, transport)
+
+	d := Digest{SavedSearchName: "Backend Engineer", Total: 3}
+	if err := n.Send(context.Background(), ChannelPush, "42", d); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(transport.calls) != 2 {
+		t.Fatalf("transport calls = %d, want 2 (one per device)", len(transport.calls))
+	}
+}
+
+func TestPushNotifier_InvalidDestErrors(t *testing.T) {
+	n := NewPushNotifier(&fakePushTokenLister{}, &fakePushTransport{})
+	if err := n.Send(context.Background(), ChannelPush, "not-a-user-id", Digest{}); err == nil {
+		t.Fatal("Send: want error for a non-numeric dest")
+	}
+}

--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -404,6 +404,11 @@ func recipient(channel string, info db.GetNudgeForDeliveryRow) (string, bool) {
 			return "", false
 		}
 		return info.AccountEmail, true
+	case notify.ChannelPush:
+		if !info.HasPushDevice {
+			return "", false
+		}
+		return strconv.FormatInt(info.UserID, 10), true
 	}
 	return "", false
 }

--- a/internal/nudge/nudge_test.go
+++ b/internal/nudge/nudge_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/appevent"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/notify"
 )
 
 // fakeStore is a DB-free Store. It serves canned candidate rows and delivery
@@ -455,5 +456,31 @@ func TestDeliver_EmailDestinationIsAccountEmail(t *testing.T) {
 	}
 	if len(notifier.sent) != 1 || notifier.sent[0] != "email:user@acme.com" {
 		t.Errorf("sent = %v, want [email:user@acme.com]", notifier.sent)
+	}
+}
+
+// --- recipient: push ----------------------------------------------------------
+
+func TestRecipient_Push_ResolvesUserIDWhenDeviceRegistered(t *testing.T) {
+	info := db.GetNudgeForDeliveryRow{UserID: 42, HasPushDevice: true}
+
+	dest, ok := recipient(notify.ChannelPush, info)
+	if !ok {
+		t.Fatal("ok = false, want true (a registered device is deliverable)")
+	}
+	if dest != "42" {
+		t.Errorf("dest = %q, want %q", dest, "42")
+	}
+}
+
+func TestRecipient_Push_SoftSkipsWithNoRegisteredDevice(t *testing.T) {
+	info := db.GetNudgeForDeliveryRow{UserID: 42, HasPushDevice: false}
+
+	dest, ok := recipient(notify.ChannelPush, info)
+	if ok {
+		t.Fatal("ok = true, want false (no registered device)")
+	}
+	if dest != "" {
+		t.Errorf("dest = %q, want empty", dest)
 	}
 }

--- a/internal/nudge/push.go
+++ b/internal/nudge/push.go
@@ -1,0 +1,68 @@
+package nudge
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/pushnotify"
+)
+
+// Compile-time proof PushNotifier satisfies the engine's Notifier seam.
+var _ Notifier = (*PushNotifier)(nil)
+
+// PushTokenLister lists a user's registered push devices. *db.Queries
+// satisfies it via its generated ListPushTokensForUser method.
+type PushTokenLister interface {
+	ListPushTokensForUser(ctx context.Context, userID int64) ([]db.UserPushToken, error)
+}
+
+// PushNotifier delivers a nudge as a mobile push, fanning out to every device
+// registered for the account (unlike Telegram/email, which have exactly one
+// destination) via pushnotify.SendToDevices.
+type PushNotifier struct {
+	tokens    PushTokenLister
+	transport pushnotify.Notifier
+}
+
+// NewPushNotifier builds a PushNotifier listing devices through tokens and
+// sending through transport.
+func NewPushNotifier(tokens PushTokenLister, transport pushnotify.Notifier) *PushNotifier {
+	return &PushNotifier{tokens: tokens, transport: transport}
+}
+
+// Send resolves dest as a user id, lists that user's registered devices, and
+// fans the rendered message out to all of them. The channel argument is
+// ignored — this notifier only serves the push channel.
+func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, m Message) error {
+	userID, err := strconv.ParseInt(dest, 10, 64)
+	if err != nil {
+		return fmt.Errorf("nudge: invalid push user id %q: %w", dest, err)
+	}
+	devices, err := n.tokens.ListPushTokensForUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("nudge: list push tokens for user %d: %w", userID, err)
+	}
+	tokens := make([]string, len(devices))
+	for i, d := range devices {
+		tokens[i] = d.Token
+	}
+
+	title, body := n.render(m)
+	data := map[string]string{"slug": m.Slug}
+	return pushnotify.SendToDevices(ctx, n.transport, tokens, title, body, data)
+}
+
+func (n *PushNotifier) render(m Message) (title, body string) {
+	switch m.Kind {
+	case KindFollowUp:
+		return "👋 Follow up?", fmt.Sprintf("It's been %d days since anything moved on %s at %s.", m.DaysSilent, m.JobTitle, m.Company)
+	case KindInterviewPrep:
+		return "🎯 Interview coming up", fmt.Sprintf("You're interviewing for %s at %s.", m.JobTitle, m.Company)
+	case KindJobClosed:
+		return "📪 Job closed", fmt.Sprintf("%s at %s was closed.", m.JobTitle, m.Company)
+	default:
+		return "freehire", fmt.Sprintf("%s at %s", m.JobTitle, m.Company)
+	}
+}

--- a/internal/nudge/push_integration_test.go
+++ b/internal/nudge/push_integration_test.go
@@ -1,0 +1,187 @@
+//go:build integration
+
+// Integration test for task 5.5 of add-push-notification-channel: a due
+// job-closed nudge whose account rule includes `push` is delivered to a real
+// registered device (via internal/testdb's throwaway, fully-migrated Postgres),
+// and soft-skips cleanly when the account has none.
+//
+// job_closed is deliberately the kind exercised here: its actionable() re-check
+// (internal/nudge/nudge.go) only requires the application to still sit in a
+// silence-accruing stage — unlike follow_up/interview_prep it does not depend on
+// re-deriving elapsed silence or a live stage_set event. The job's closed_at is
+// seeded outside JobClosedWindowDays (the default 7-day MATCH window) so
+// Runner.match's own ListJobClosedCandidates scan never picks up this
+// application — avoiding its auto-expire side effect (match() drives the stage
+// to `expired` for every job-closed candidate it finds, which would flip the
+// very stage actionable() re-checks before delivery even runs). The nudge here
+// is inserted directly as an already-pending application_nudges row instead,
+// so only Runner.deliver (claim → actionable re-check → PushNotifier.Send) is
+// exercised, exactly what this task is about.
+//
+// Run with: go test -tags=integration ./internal/nudge/
+// Requires Docker (testcontainers spins up a throwaway Postgres with the
+// migrations).
+package nudge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/notify"
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+// integrationPushTransport is a DB-free pushnotify.Notifier recording every send.
+type integrationPushTransport struct {
+	sent []string // tokens sent to
+}
+
+func (t *integrationPushTransport) Send(_ context.Context, token, _, _ string, _ map[string]string) error {
+	t.sent = append(t.sent, token)
+	return nil
+}
+
+func seedNudgeIntegrationUser(t *testing.T, pool *pgxpool.Pool, email string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&id); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	return id
+}
+
+// seedClosedJob inserts a job that closed well outside the default
+// JobClosedWindowDays (7 days), so Runner.match's own candidate scan never
+// picks it up (see the package doc above for why that matters here).
+func seedClosedJob(t *testing.T, pool *pgxpool.Pool, externalID string) int64 {
+	t.Helper()
+	var id int64
+	closedAt := time.Now().Add(-30 * 24 * time.Hour)
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, company, public_slug, closed_at)
+		 VALUES ('test', $1, 'http://example.test', 'Go Dev', 'Acme', $1, $2)
+		 RETURNING id`, externalID, closedAt).Scan(&id); err != nil {
+		t.Fatalf("insert job: %v", err)
+	}
+	return id
+}
+
+func seedApplication(t *testing.T, pool *pgxpool.Pool, userID, jobID int64, stage string) {
+	t.Helper()
+	// applied_at is also seeded outside FollowUpWindowDays (30 days), so the
+	// same application never surfaces as a follow-up candidate either.
+	appliedAt := time.Now().Add(-40 * 24 * time.Hour)
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO applications (user_id, job_id, applied_at, stage) VALUES ($1, $2, $3, $4)`,
+		userID, jobID, appliedAt, stage); err != nil {
+		t.Fatalf("insert application: %v", err)
+	}
+}
+
+func seedNotificationSettings(t *testing.T, pool *pgxpool.Pool, userID int64, channels []string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO notification_settings (user_id, enabled, channels) VALUES ($1, true, $2)`,
+		userID, channels); err != nil {
+		t.Fatalf("insert notification_settings: %v", err)
+	}
+}
+
+func seedPendingJobClosedNudge(t *testing.T, pool *pgxpool.Pool, userID, jobID int64) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO application_nudges (user_id, job_id, kind, episode_key, status)
+		 VALUES ($1, $2, 'job_closed', now(), 'pending') RETURNING id`,
+		userID, jobID).Scan(&id); err != nil {
+		t.Fatalf("insert application_nudges: %v", err)
+	}
+	return id
+}
+
+func seedPushDevice(t *testing.T, pool *pgxpool.Pool, userID int64, token string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO user_push_tokens (user_id, token, platform) VALUES ($1, $2, 'ios')`,
+		userID, token); err != nil {
+		t.Fatalf("insert user_push_tokens: %v", err)
+	}
+}
+
+func nudgeStatus(t *testing.T, pool *pgxpool.Pool, id int64) string {
+	t.Helper()
+	var status string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT status FROM application_nudges WHERE id = $1`, id).Scan(&status); err != nil {
+		t.Fatalf("read nudge status: %v", err)
+	}
+	return status
+}
+
+func TestPushNotifier_Integration_DeliversToARegisteredDevice(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := seedNudgeIntegrationUser(t, pool, "push-nudge-delivers@example.test")
+	jobID := seedClosedJob(t, pool, "push-nudge-delivers")
+	seedApplication(t, pool, userID, jobID, "applied")
+	seedNotificationSettings(t, pool, userID, []string{"push"})
+	seedPushDevice(t, pool, userID, "ExponentPushToken[delivers]")
+	nudgeID := seedPendingJobClosedNudge(t, pool, userID, jobID)
+
+	transport := &integrationPushTransport{}
+	router := Router{notify.ChannelPush: NewPushNotifier(queries, transport)}
+	runner := New(queries, router, DefaultConfig())
+
+	stats, err := runner.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Delivered != 1 {
+		t.Errorf("stats.Delivered = %d, want 1", stats.Delivered)
+	}
+	if len(transport.sent) != 1 || transport.sent[0] != "ExponentPushToken[delivers]" {
+		t.Errorf("sent = %v, want [ExponentPushToken[delivers]]", transport.sent)
+	}
+	if status := nudgeStatus(t, pool, nudgeID); status != "delivered" {
+		t.Errorf("nudge status = %q, want %q", status, "delivered")
+	}
+}
+
+func TestPushNotifier_Integration_SoftSkipsWithNoRegisteredDevice(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := seedNudgeIntegrationUser(t, pool, "push-nudge-softskip@example.test")
+	jobID := seedClosedJob(t, pool, "push-nudge-softskip")
+	seedApplication(t, pool, userID, jobID, "applied")
+	seedNotificationSettings(t, pool, userID, []string{"push"})
+	// No user_push_tokens row: HasPushDevice reads false, so recipient() should
+	// soft-skip the push channel without ever calling the transport.
+	nudgeID := seedPendingJobClosedNudge(t, pool, userID, jobID)
+
+	transport := &integrationPushTransport{}
+	router := Router{notify.ChannelPush: NewPushNotifier(queries, transport)}
+	runner := New(queries, router, DefaultConfig())
+
+	stats, err := runner.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.SoftSkips != 1 {
+		t.Errorf("stats.SoftSkips = %d, want 1", stats.SoftSkips)
+	}
+	if len(transport.sent) != 0 {
+		t.Errorf("sent = %v, want none (no registered device)", transport.sent)
+	}
+	if status := nudgeStatus(t, pool, nudgeID); status != "pending" {
+		t.Errorf("nudge status = %q, want %q (retried next pass, not failed)", status, "pending")
+	}
+}

--- a/internal/nudge/push_test.go
+++ b/internal/nudge/push_test.go
@@ -1,0 +1,161 @@
+package nudge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// fakePushTokenLister is a DB-free PushTokenLister.
+type fakePushTokenLister struct {
+	tokens map[int64][]db.UserPushToken
+}
+
+func (l *fakePushTokenLister) ListPushTokensForUser(_ context.Context, userID int64) ([]db.UserPushToken, error) {
+	return l.tokens[userID], nil
+}
+
+// fakePushTransport is a DB-free pushnotify.Notifier that records every call.
+type fakePushTransport struct {
+	sent []pushCall
+	err  error
+}
+
+type pushCall struct {
+	token, title, body string
+	data               map[string]string
+}
+
+func (t *fakePushTransport) Send(_ context.Context, token, title, body string, data map[string]string) error {
+	if t.err != nil {
+		return t.err
+	}
+	t.sent = append(t.sent, pushCall{token: token, title: title, body: body, data: data})
+	return nil
+}
+
+func TestPushNotifier_FollowUp_RendersTitleBodyAndSlug(t *testing.T) {
+	lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "tok-1"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+
+	msg := Message{Kind: KindFollowUp, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme", DaysSilent: 12}
+	if err := n.Send(context.Background(), "push", "42", msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(transport.sent) != 1 {
+		t.Fatalf("sent = %d, want 1", len(transport.sent))
+	}
+	got := transport.sent[0]
+	if got.token != "tok-1" {
+		t.Errorf("token = %q, want %q", got.token, "tok-1")
+	}
+	if got.title != "👋 Follow up?" {
+		t.Errorf("title = %q, want %q", got.title, "👋 Follow up?")
+	}
+	wantBody := "It's been 12 days since anything moved on Go Dev at Acme."
+	if got.body != wantBody {
+		t.Errorf("body = %q, want %q", got.body, wantBody)
+	}
+	if got.data["slug"] != "go-dev-acme" {
+		t.Errorf("data[slug] = %q, want %q", got.data["slug"], "go-dev-acme")
+	}
+}
+
+func TestPushNotifier_InterviewPrep_RendersTitleBodyAndSlug(t *testing.T) {
+	lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "tok-1"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+
+	msg := Message{Kind: KindInterviewPrep, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}
+	if err := n.Send(context.Background(), "push", "42", msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(transport.sent) != 1 {
+		t.Fatalf("sent = %d, want 1", len(transport.sent))
+	}
+	got := transport.sent[0]
+	if got.title != "🎯 Interview coming up" {
+		t.Errorf("title = %q, want %q", got.title, "🎯 Interview coming up")
+	}
+	wantBody := "You're interviewing for Go Dev at Acme."
+	if got.body != wantBody {
+		t.Errorf("body = %q, want %q", got.body, wantBody)
+	}
+	if got.data["slug"] != "go-dev-acme" {
+		t.Errorf("data[slug] = %q, want %q", got.data["slug"], "go-dev-acme")
+	}
+}
+
+func TestPushNotifier_JobClosed_RendersTitleBodyAndSlug(t *testing.T) {
+	lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "tok-1"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+
+	msg := Message{Kind: KindJobClosed, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}
+	if err := n.Send(context.Background(), "push", "42", msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(transport.sent) != 1 {
+		t.Fatalf("sent = %d, want 1", len(transport.sent))
+	}
+	got := transport.sent[0]
+	if got.title != "📪 Job closed" {
+		t.Errorf("title = %q, want %q", got.title, "📪 Job closed")
+	}
+	wantBody := "Go Dev at Acme was closed."
+	if got.body != wantBody {
+		t.Errorf("body = %q, want %q", got.body, wantBody)
+	}
+	if got.data["slug"] != "go-dev-acme" {
+		t.Errorf("data[slug] = %q, want %q", got.data["slug"], "go-dev-acme")
+	}
+}
+
+func TestPushNotifier_FansOutToEveryDevice(t *testing.T) {
+	lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "tok-1"}, {Token: "tok-2"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+
+	msg := Message{Kind: KindJobClosed, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}
+	if err := n.Send(context.Background(), "push", "42", msg); err != nil {
+		t.Fatal(err)
+	}
+	if len(transport.sent) != 2 {
+		t.Fatalf("sent = %d, want 2 (one per device)", len(transport.sent))
+	}
+}
+
+func TestPushNotifier_InvalidDestReturnsError(t *testing.T) {
+	lister := &fakePushTokenLister{}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+
+	err := n.Send(context.Background(), "push", "not-a-user-id", Message{Kind: KindJobClosed})
+	if err == nil {
+		t.Fatal("want error for a non-numeric dest")
+	}
+}
+
+func TestPushNotifier_NoDeviceReturnsError(t *testing.T) {
+	lister := &fakePushTokenLister{}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+
+	err := n.Send(context.Background(), "push", "42", Message{Kind: KindJobClosed})
+	if err == nil {
+		t.Fatal("want error when the user has no registered device")
+	}
+}

--- a/internal/pushnotify/pushnotify.go
+++ b/internal/pushnotify/pushnotify.go
@@ -59,7 +59,7 @@ const receiptBatchSize = 100
 
 // Notifier sends one push message to a device token.
 type Notifier interface {
-	Send(ctx context.Context, token, title, body string) error
+	Send(ctx context.Context, token, title, body string, data map[string]string) error
 }
 
 // TokenPruner removes a token that's been reported permanently
@@ -91,6 +91,32 @@ type TicketStore interface {
 	DeletePushTickets(ctx context.Context, ids []int64) error
 }
 
+// SendToDevices sends one title/body/data message to every token, aggregating
+// the per-device outcomes into a single result for a caller that has one
+// recipient with several devices (unlike Telegram/email, which have exactly one
+// destination). It reports success — nil — as long as at least one device
+// received the message; a token pruned as dead is not itself a failure, but if
+// every device ends up pruned or erroring (including the degenerate case of no
+// tokens at all), the caller has nothing delivered and gets an error back.
+func SendToDevices(ctx context.Context, notifier Notifier, tokens []string, title, body string, data map[string]string) error {
+	var sent int
+	var lastErr error
+	for _, token := range tokens {
+		if err := notifier.Send(ctx, token, title, body, data); err != nil {
+			lastErr = err
+		} else {
+			sent++
+		}
+	}
+	if sent > 0 {
+		return nil
+	}
+	if lastErr != nil {
+		return fmt.Errorf("pushnotify: no device received the message: %w", lastErr)
+	}
+	return errors.New("pushnotify: no device to send to")
+}
+
 // ExpoNotifier implements Notifier over the Expo Push API.
 type ExpoNotifier struct {
 	client      *http.Client
@@ -117,9 +143,10 @@ func NewExpoNotifier(pruner TokenPruner, queuer TicketQueuer, tickets TicketStor
 }
 
 type expoMessage struct {
-	To    string `json:"to"`
-	Title string `json:"title"`
-	Body  string `json:"body"`
+	To    string            `json:"to"`
+	Title string            `json:"title"`
+	Body  string            `json:"body"`
+	Data  map[string]string `json:"data,omitempty"`
 }
 
 // expoTicket is one entry in Send's response — an immediate acknowledgement,
@@ -143,9 +170,9 @@ type expoSendResponse struct {
 // later CheckReceipts pass, since the ticket alone doesn't say the push was
 // actually delivered; any other failure is returned as an error with the
 // token left in place, since it may be transient.
-func (n *ExpoNotifier) Send(ctx context.Context, token, title, body string) error {
+func (n *ExpoNotifier) Send(ctx context.Context, token, title, body string, data map[string]string) error {
 	var out expoSendResponse
-	if err := n.postJSON(ctx, n.apiURL, []expoMessage{{To: token, Title: title, Body: body}}, &out); err != nil {
+	if err := n.postJSON(ctx, n.apiURL, []expoMessage{{To: token, Title: title, Body: body, Data: data}}, &out); err != nil {
 		return err
 	}
 	if len(out.Data) != 1 {

--- a/internal/pushnotify/pushnotify_test.go
+++ b/internal/pushnotify/pushnotify_test.go
@@ -47,12 +47,20 @@ func (s *fakeTicketStore) DeletePushTickets(ctx context.Context, ids []int64) er
 
 func stubExpo(t *testing.T, status string, errorCode string) *httptest.Server {
 	t.Helper()
+	return stubExpoCapture(t, status, errorCode, nil)
+}
+
+// stubExpoCapture is stubExpo with a hook to capture the decoded request body,
+// so a test can assert on what was actually sent to Expo (e.g. the data payload).
+func stubExpoCapture(t *testing.T, status string, errorCode string, capture *[]expoMessage) *httptest.Server {
+	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body []struct {
-			To string `json:"to"`
-		}
+		var body []expoMessage
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request: %v", err)
+		}
+		if capture != nil {
+			*capture = body
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -81,7 +89,7 @@ func TestExpoNotifier_Send_SuccessEnqueuesTicketForLaterCheck(t *testing.T) {
 	n := newTestNotifier(pruner, queuer, &fakeTicketStore{})
 	n.apiURL = srv.URL
 
-	if err := n.Send(context.Background(), "ExponentPushToken[abc]", "Hello", "World"); err != nil {
+	if err := n.Send(context.Background(), "ExponentPushToken[abc]", "Hello", "World", nil); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	if len(pruner.pruned) != 0 {
@@ -99,7 +107,7 @@ func TestExpoNotifier_Send_DeviceNotRegisteredPrunesTokenAtSendTime(t *testing.T
 	n := newTestNotifier(pruner, queuer, &fakeTicketStore{})
 	n.apiURL = srv.URL
 
-	err := n.Send(context.Background(), "ExponentPushToken[dead]", "Hello", "World")
+	err := n.Send(context.Background(), "ExponentPushToken[dead]", "Hello", "World", nil)
 	if !errors.Is(err, ErrTokenPruned) {
 		t.Fatalf("Send err = %v, want ErrTokenPruned — a caller (e.g. a self-test endpoint) must be able to tell a prune apart from a real delivery", err)
 	}
@@ -118,7 +126,7 @@ func TestExpoNotifier_Send_OtherErrorSurfacesWithoutPruningOrEnqueuing(t *testin
 	n := newTestNotifier(pruner, queuer, &fakeTicketStore{})
 	n.apiURL = srv.URL
 
-	if err := n.Send(context.Background(), "ExponentPushToken[abc]", "Hello", "World"); err == nil {
+	if err := n.Send(context.Background(), "ExponentPushToken[abc]", "Hello", "World", nil); err == nil {
 		t.Fatal("Send: want error for a non-DeviceNotRegistered failure")
 	}
 	if len(pruner.pruned) != 0 {
@@ -126,6 +134,41 @@ func TestExpoNotifier_Send_OtherErrorSurfacesWithoutPruningOrEnqueuing(t *testin
 	}
 	if len(queuer.enqueued) != 0 {
 		t.Errorf("enqueued = %v, want none — nothing to check later for a failed send", queuer.enqueued)
+	}
+}
+
+func TestExpoNotifier_Send_IncludesDataPayload(t *testing.T) {
+	var captured []expoMessage
+	srv := stubExpoCapture(t, "ok", "", &captured)
+	n := newTestNotifier(&fakePruner{}, &fakeQueuer{}, &fakeTicketStore{})
+	n.apiURL = srv.URL
+
+	err := n.Send(context.Background(), "ExponentPushToken[abc]", "Hello", "World", map[string]string{"slug": "acme-backend-engineer"})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("captured %d messages, want 1", len(captured))
+	}
+	if got := captured[0].Data["slug"]; got != "acme-backend-engineer" {
+		t.Errorf("data[slug] = %q, want %q", got, "acme-backend-engineer")
+	}
+}
+
+func TestExpoNotifier_Send_NilDataOmitsPayloadField(t *testing.T) {
+	var captured []expoMessage
+	srv := stubExpoCapture(t, "ok", "", &captured)
+	n := newTestNotifier(&fakePruner{}, &fakeQueuer{}, &fakeTicketStore{})
+	n.apiURL = srv.URL
+
+	if err := n.Send(context.Background(), "ExponentPushToken[abc]", "Hello", "World", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("captured %d messages, want 1", len(captured))
+	}
+	if captured[0].Data != nil {
+		t.Errorf("data = %v, want nil", captured[0].Data)
 	}
 }
 
@@ -197,6 +240,103 @@ func TestExpoNotifier_CheckReceipts_NothingDueIsANoOp(t *testing.T) {
 	}
 	if called {
 		t.Error("getReceipts was called with nothing due")
+	}
+}
+
+// fakeDeviceNotifier is a Notifier test double keyed by token, for exercising
+// SendToDevices without going through an HTTP round trip.
+type fakeDeviceNotifier struct {
+	results map[string]error // token -> error to return; missing key = nil
+	calls   []string
+}
+
+func (f *fakeDeviceNotifier) Send(ctx context.Context, token, title, body string, data map[string]string) error {
+	f.calls = append(f.calls, token)
+	return f.results[token]
+}
+
+// notifierFunc adapts a plain function to Notifier, mirroring http.HandlerFunc.
+type notifierFunc func(ctx context.Context, token, title, body string, data map[string]string) error
+
+func (f notifierFunc) Send(ctx context.Context, token, title, body string, data map[string]string) error {
+	return f(ctx, token, title, body, data)
+}
+
+func TestSendToDevices_AllSucceed(t *testing.T) {
+	n := &fakeDeviceNotifier{}
+	tokens := []string{"tok-1", "tok-2", "tok-3"}
+
+	if err := SendToDevices(context.Background(), n, tokens, "Hello", "World", nil); err != nil {
+		t.Fatalf("SendToDevices: %v", err)
+	}
+	if len(n.calls) != 3 {
+		t.Errorf("calls = %v, want all 3 tokens attempted", n.calls)
+	}
+}
+
+func TestSendToDevices_PartialSuccessCountsAsDelivered(t *testing.T) {
+	n := &fakeDeviceNotifier{results: map[string]error{
+		"tok-bad": errors.New("transient failure"),
+	}}
+	tokens := []string{"tok-good", "tok-bad"}
+
+	if err := SendToDevices(context.Background(), n, tokens, "Hello", "World", nil); err != nil {
+		t.Fatalf("SendToDevices: %v, want nil — at least one device received it", err)
+	}
+	if len(n.calls) != 2 {
+		t.Errorf("calls = %v, want both tokens attempted (no short-circuit)", n.calls)
+	}
+}
+
+func TestSendToDevices_AllPrunedIsAFailure(t *testing.T) {
+	n := &fakeDeviceNotifier{results: map[string]error{
+		"tok-1": ErrTokenPruned,
+		"tok-2": ErrTokenPruned,
+	}}
+	tokens := []string{"tok-1", "tok-2"}
+
+	if err := SendToDevices(context.Background(), n, tokens, "Hello", "World", nil); err == nil {
+		t.Fatal("SendToDevices: want an error when every device was pruned, nothing delivered")
+	}
+}
+
+func TestSendToDevices_AllFailed(t *testing.T) {
+	n := &fakeDeviceNotifier{results: map[string]error{
+		"tok-1": errors.New("boom"),
+		"tok-2": errors.New("boom"),
+	}}
+	tokens := []string{"tok-1", "tok-2"}
+
+	if err := SendToDevices(context.Background(), n, tokens, "Hello", "World", nil); err == nil {
+		t.Fatal("SendToDevices: want an error when every device failed")
+	}
+}
+
+func TestSendToDevices_EmptyTokensIsAFailure(t *testing.T) {
+	n := &fakeDeviceNotifier{}
+
+	if err := SendToDevices(context.Background(), n, nil, "Hello", "World", nil); err == nil {
+		t.Fatal("SendToDevices: want an error for zero tokens — nothing was delivered")
+	}
+	if len(n.calls) != 0 {
+		t.Errorf("calls = %v, want none", n.calls)
+	}
+}
+
+func TestSendToDevices_ForwardsDataPayload(t *testing.T) {
+	n := &fakeDeviceNotifier{}
+	var captured map[string]string
+	wrapped := notifierFunc(func(ctx context.Context, token, title, body string, data map[string]string) error {
+		captured = data
+		return n.Send(ctx, token, title, body, data)
+	})
+
+	data := map[string]string{"slug": "acme-backend-engineer"}
+	if err := SendToDevices(context.Background(), wrapped, []string{"tok-1"}, "Hello", "World", data); err != nil {
+		t.Fatalf("SendToDevices: %v", err)
+	}
+	if captured["slug"] != "acme-backend-engineer" {
+		t.Errorf("data forwarded = %v, want slug=acme-backend-engineer", captured)
 	}
 }
 

--- a/internal/reminder/engine.go
+++ b/internal/reminder/engine.go
@@ -212,6 +212,11 @@ func recipient(channel string, info db.GetReminderForDeliveryRow) (string, bool)
 			return "", false
 		}
 		return info.AccountEmail, true
+	case notify.ChannelPush:
+		if !info.HasPushDevice {
+			return "", false
+		}
+		return strconv.FormatInt(info.UserID, 10), true
 	}
 	return "", false
 }

--- a/internal/reminder/engine_test.go
+++ b/internal/reminder/engine_test.go
@@ -178,6 +178,28 @@ func TestRun_RecordsFailureOnDeliveryError(t *testing.T) {
 	}
 }
 
+func TestRecipient_Push(t *testing.T) {
+	tests := []struct {
+		name          string
+		hasPushDevice bool
+		wantDest      string
+		wantOK        bool
+	}{
+		{name: "registered device", hasPushDevice: true, wantDest: "42", wantOK: true},
+		{name: "no registered device", hasPushDevice: false, wantDest: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := db.GetReminderForDeliveryRow{UserID: 42, HasPushDevice: tt.hasPushDevice}
+			dest, ok := recipient("push", info)
+			if dest != tt.wantDest || ok != tt.wantOK {
+				t.Errorf("recipient(push, HasPushDevice=%v) = (%q, %v), want (%q, %v)",
+					tt.hasPushDevice, dest, ok, tt.wantDest, tt.wantOK)
+			}
+		})
+	}
+}
+
 func TestRun_DeliversEmailWhenTelegramMissing(t *testing.T) {
 	// Both channels configured; only email has a destination.
 	store := &fakeStore{

--- a/internal/reminder/push.go
+++ b/internal/reminder/push.go
@@ -1,0 +1,59 @@
+package reminder
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/pushnotify"
+)
+
+// Compile-time proof PushNotifier satisfies the engine's Notifier seam.
+var _ Notifier = (*PushNotifier)(nil)
+
+// PushTokenLister lists a user's registered push devices. *db.Queries satisfies it.
+type PushTokenLister interface {
+	ListPushTokensForUser(ctx context.Context, userID int64) ([]db.UserPushToken, error)
+}
+
+// PushNotifier delivers a reminder as a mobile push, fanning out to every device
+// the user has registered — unlike Telegram/email, push has zero-to-many
+// destinations per recipient (see design decision #1 and #3 of
+// add-push-notification-channel).
+type PushNotifier struct {
+	tokens    PushTokenLister
+	transport pushnotify.Notifier
+}
+
+// NewPushNotifier builds a PushNotifier resolving devices through tokens and
+// sending through transport.
+func NewPushNotifier(tokens PushTokenLister, transport pushnotify.Notifier) *PushNotifier {
+	return &PushNotifier{tokens: tokens, transport: transport}
+}
+
+// Send renders the reminder and fans it out to every device registered for the
+// user encoded in dest (see recipient()'s ChannelPush case). The channel argument
+// is ignored — this notifier only serves the push channel.
+func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, m ReminderMessage) error {
+	userID, err := strconv.ParseInt(dest, 10, 64)
+	if err != nil {
+		return fmt.Errorf("reminder: invalid push user id %q: %w", dest, err)
+	}
+	rows, err := n.tokens.ListPushTokensForUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("reminder: list push tokens for user %d: %w", userID, err)
+	}
+	tokens := make([]string, len(rows))
+	for i, row := range rows {
+		tokens[i] = row.Token
+	}
+
+	title := "⏰ Reminder"
+	body := fmt.Sprintf("You saved %s at %s — still interested?", m.JobTitle, m.Company)
+	// A reminder always concerns exactly one job, so the deep-link data is
+	// unconditional here — unlike a subscription digest, which only carries a
+	// slug when it matched a single job.
+	data := map[string]string{"slug": m.Slug}
+	return pushnotify.SendToDevices(ctx, n.transport, tokens, title, body, data)
+}

--- a/internal/reminder/push_integration_test.go
+++ b/internal/reminder/push_integration_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+// Integration test for the push channel's end-to-end path against a real
+// Postgres: a due, pending reminder whose rule includes "push" is delivered when
+// the user has a registered device, and soft-skips (stays pending) when they
+// don't — the same live has_push_device check TestRecipient_Push exercises with
+// a fake, proven here against the real GetReminderForDelivery query and a real
+// Runner. Run with:
+// go test -tags=integration ./internal/reminder/
+// Requires Docker (testcontainers spins up a throwaway Postgres with the migrations).
+package reminder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/notify"
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+func insertReminderIntegrationUser(t *testing.T, pool *pgxpool.Pool, email string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&id); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	return id
+}
+
+func insertReminderIntegrationJob(t *testing.T, pool *pgxpool.Pool, externalID string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, company, public_slug)
+		 VALUES ('test', $1, 'http://example.test', 'Go Developer', 'Acme', 'job-' || $1)
+		 RETURNING id`, externalID).Scan(&id); err != nil {
+		t.Fatalf("insert job: %v", err)
+	}
+	return id
+}
+
+// seedSavedJobReminder marks the job saved-but-unapplied for the user (so
+// GetReminderForDelivery's still_actionable check passes) and inserts a
+// job_reminders row that is already due, on the push channel.
+func seedSavedJobReminder(t *testing.T, pool *pgxpool.Pool, userID, jobID int64) int64 {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO user_jobs (user_id, job_id, saved_at) VALUES ($1, $2, now())`,
+		userID, jobID); err != nil {
+		t.Fatalf("save job: %v", err)
+	}
+	var id int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO job_reminders (user_id, job_id, fire_at, channels)
+		 VALUES ($1, $2, now() - interval '1 hour', $3)
+		 RETURNING id`,
+		userID, jobID, []string{notify.ChannelPush}).Scan(&id); err != nil {
+		t.Fatalf("insert reminder: %v", err)
+	}
+	return id
+}
+
+func insertPushToken(t *testing.T, pool *pgxpool.Pool, userID int64, token string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO user_push_tokens (user_id, token, platform) VALUES ($1, $2, 'ios')`,
+		userID, token); err != nil {
+		t.Fatalf("insert push token: %v", err)
+	}
+}
+
+func reminderStatus(t *testing.T, pool *pgxpool.Pool, id int64) string {
+	t.Helper()
+	var status string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT status FROM job_reminders WHERE id = $1`, id).Scan(&status); err != nil {
+		t.Fatalf("load reminder status: %v", err)
+	}
+	return status
+}
+
+func TestRun_DeliversPushReminderToARegisteredDevice(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := insertReminderIntegrationUser(t, pool, "push-reminder-has-device@example.test")
+	jobID := insertReminderIntegrationJob(t, pool, "push-has-device")
+	reminderID := seedSavedJobReminder(t, pool, userID, jobID)
+	insertPushToken(t, pool, userID, "ExponentPushToken[has-device]")
+
+	transport := &fakePushTransport{}
+	router := Router{notify.ChannelPush: NewPushNotifier(queries, transport)}
+	runner := NewRunner(queries, router, DefaultConfig())
+
+	stats, err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Delivered != 1 {
+		t.Errorf("stats.Delivered = %d, want 1", stats.Delivered)
+	}
+	if len(transport.calls) != 1 || transport.calls[0].token != "ExponentPushToken[has-device]" {
+		t.Errorf("transport calls = %v, want one call to the registered device", transport.calls)
+	}
+	if got := reminderStatus(t, pool, reminderID); got != "delivered" {
+		t.Errorf("reminder status = %q, want delivered", got)
+	}
+}
+
+func TestRun_SoftSkipsPushReminderWithNoRegisteredDevice(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := insertReminderIntegrationUser(t, pool, "push-reminder-no-device@example.test")
+	jobID := insertReminderIntegrationJob(t, pool, "push-no-device")
+	reminderID := seedSavedJobReminder(t, pool, userID, jobID)
+	// No user_push_tokens row for this user.
+
+	transport := &fakePushTransport{}
+	router := Router{notify.ChannelPush: NewPushNotifier(queries, transport)}
+	runner := NewRunner(queries, router, DefaultConfig())
+
+	stats, err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.SoftSkips != 1 {
+		t.Errorf("stats.SoftSkips = %d, want 1", stats.SoftSkips)
+	}
+	if len(transport.calls) != 0 {
+		t.Errorf("transport calls = %v, want none — no registered device", transport.calls)
+	}
+	if got := reminderStatus(t, pool, reminderID); got != "pending" {
+		t.Errorf("reminder status = %q, want pending (soft-skip, not dead-lettered)", got)
+	}
+}

--- a/internal/reminder/push_test.go
+++ b/internal/reminder/push_test.go
@@ -1,0 +1,87 @@
+package reminder
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// fakePushTokenLister is a DB-free PushTokenLister serving canned tokens keyed
+// by user id.
+type fakePushTokenLister struct {
+	tokens map[int64][]db.UserPushToken
+	err    error
+}
+
+func (f *fakePushTokenLister) ListPushTokensForUser(_ context.Context, userID int64) ([]db.UserPushToken, error) {
+	return f.tokens[userID], f.err
+}
+
+// fakePushTransport records every Send call, standing in for pushnotify.Notifier.
+type fakePushTransport struct {
+	calls []struct {
+		token, title, body string
+		data               map[string]string
+	}
+	err error
+}
+
+func (f *fakePushTransport) Send(_ context.Context, token, title, body string, data map[string]string) error {
+	f.calls = append(f.calls, struct {
+		token, title, body string
+		data               map[string]string
+	}{token, title, body, data})
+	return f.err
+}
+
+func TestPushNotifier_RendersTitleBodyAndSlugDataToEveryDevice(t *testing.T) {
+	lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
+		42: {{Token: "tok-1"}, {Token: "tok-2"}},
+	}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+	msg := ReminderMessage{JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme", URL: "https://ats/x"}
+
+	if err := n.Send(context.Background(), "push", strconv.FormatInt(42, 10), msg); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if len(transport.calls) != 2 {
+		t.Fatalf("transport calls = %d, want 2 (one per device)", len(transport.calls))
+	}
+	gotTokens := map[string]bool{}
+	for _, c := range transport.calls {
+		gotTokens[c.token] = true
+		if c.title != "⏰ Reminder" {
+			t.Errorf("title = %q, want %q", c.title, "⏰ Reminder")
+		}
+		if c.body != "You saved Go Dev at Acme — still interested?" {
+			t.Errorf("body = %q", c.body)
+		}
+		if c.data["slug"] != "go-dev-acme" {
+			t.Errorf("data[slug] = %q, want %q", c.data["slug"], "go-dev-acme")
+		}
+	}
+	if !gotTokens["tok-1"] || !gotTokens["tok-2"] {
+		t.Errorf("tokens sent = %v, want tok-1 and tok-2", gotTokens)
+	}
+}
+
+func TestPushNotifier_InvalidUserIDErrors(t *testing.T) {
+	n := NewPushNotifier(&fakePushTokenLister{}, &fakePushTransport{})
+	if err := n.Send(context.Background(), "push", "not-a-number", ReminderMessage{}); err == nil {
+		t.Error("want an error for a non-numeric user id")
+	}
+}
+
+func TestPushNotifier_NoDevicesReturnsAnError(t *testing.T) {
+	// A caller reaches PushNotifier only via recipient()'s HasPushDevice check, so
+	// this is a defense-in-depth path, not the normal soft-skip — but the fan-out
+	// helper still reports it as an error (SendToDevices' empty-tokens rule).
+	n := NewPushNotifier(&fakePushTokenLister{}, &fakePushTransport{})
+	if err := n.Send(context.Background(), "push", "42", ReminderMessage{Slug: "s"}); err == nil {
+		t.Error("want an error when the user has no registered devices")
+	}
+}

--- a/openspec/changes/add-push-notification-channel/.openspec.yaml
+++ b/openspec/changes/add-push-notification-channel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/add-push-notification-channel/design.md
+++ b/openspec/changes/add-push-notification-channel/design.md
@@ -1,0 +1,175 @@
+## Context
+
+Three independent cron-driven engines already share a delivery-channel vocabulary
+(`internal/notify` for saved-search subscriptions, `internal/reminder` for saved-job
+nudges, `internal/nudge` for application lifecycle nudges), each with its own
+`Notifier` interface, `Router`, and `recipient()` resolver, implemented today for
+`telegram` and `email` only (see `docs/agents/notifications.md`). `internal/pushnotify`
+already exists as a standalone Expo-relay transport (`Send(ctx, token, title, body)
+error`), used only by the mobile app's self-test button
+(`POST /me/push-tokens/test`) — it has never been wired into any delivery engine.
+The mobile app (`freehire-mobile`, sibling repo) registers a device's Expo token on
+sign-in / notification-toggle and stores it in `user_push_tokens`, keyed by
+`user_id` (a user may have several devices).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deliver all three notification kinds (subscription digest, reminder, nudge) to a
+  user's registered mobile device(s) as a push, alongside their existing
+  Telegram/email options.
+- Reuse the existing per-engine `Notifier`/`Router`/`recipient()` shape rather than
+  introducing a new abstraction — push becomes a third implementation of a pattern
+  that already has two.
+- Fan out to every device a user has registered, since push (unlike a Telegram chat
+  or an email address) is not a single fixed destination per user.
+- Let a tapped push (where there is exactly one relevant job) deep-link straight to
+  that job in the mobile app.
+
+**Non-Goals:**
+- Collapsing `notify`/`reminder`/`nudge` into one shared engine. `internal/notify`'s
+  own docs defer that explicitly until a third *channel* shows which half
+  generalises; this change lands that third channel but treats each engine's
+  dispatch code as still independent, per the existing documented plan.
+- A deep-link target for a subscription digest with more than one matched job (no
+  in-app saved-search or multi-job screen exists yet). Tapping such a push just
+  opens the app.
+- Any change to `TestPushToken`'s existing behavior beyond the `Send` signature
+  update it must follow; folding it onto the new `SendToDevices` helper is a
+  same-shape refactor left for later, not required for this change to be correct.
+- Push-specific rate limiting / quiet hours — inherits whatever cadence each engine
+  already runs at (cron interval), same as Telegram/email today.
+
+## Decisions
+
+### 1. Destination model: `dest` is the user id, not a device token
+
+Telegram's `dest` is a chat id; email's is an address — both are one fixed value per
+user. Push has zero-to-many values (devices), so `recipient()` in each engine
+resolves `dest = strconv.FormatInt(userID, 10)` for the `push` channel, and the
+`PushNotifier` implementation is the one that expands that into N device sends. This
+keeps the `Notifier` interface itself unchanged in shape (`Send(ctx, channel, dest,
+message) error`) — only its *meaning* for one channel differs, exactly as the
+existing doc comment already anticipates ("Telegram resolves dest as a chat_id
+string; webhook/email as a URL/address").
+
+**Alternative considered:** resolve one `(user, token)` pair per device at the
+`recipient()`/query layer, producing N separate deliveries per user like N separate
+subscriptions. Rejected: it would multiply `Stats.Delivered`/`Failed` counts by
+device count, break the "one digest per subscription" accounting the doc explicitly
+calls out as a guarantee, and require restructuring the claim/lease/dedup ledger
+(keyed on subscription/reminder/nudge id, not device) for no behavioral gain.
+
+### 2. Soft-skip via a live "has device" column, mirroring Telegram
+
+`GetSubscriptionForDeliveryRow`, `GetReminderForDeliveryRow`, and
+`GetNudgeForDeliveryRow` each gain a `HasPushDevice bool` column
+(`EXISTS(SELECT 1 FROM user_push_tokens WHERE user_id = ...)`), read the same way
+`TelegramChatID.Valid` already is. `recipient()`'s new `case ChannelPush` returns
+`("", false)` when it's false — an unregistered user soft-skips push precisely the
+way an unlinked Telegram chat soft-skips today, keeping `Stats.SoftSkips` accurate
+without asking the `Notifier` to distinguish "no destination" from "send failed."
+
+**Alternative considered:** let `PushNotifier.Send` discover zero devices itself and
+return a sentinel error the delivery loop treats as a soft skip. Rejected: every
+delivery loop's `errors.Is(err, ErrChannelNotConfigured)` check is about the *whole
+channel* being unconfigured (e.g. no `TELEGRAM_BOT_TOKEN`), not one recipient's
+missing destination; overloading it, or adding a second sentinel, means every call
+site has to know about a push-specific carve-out. A query-level boolean keeps the
+existing two-tier soft-skip model (channel-level via `Router`, recipient-level via
+`recipient()`) intact.
+
+### 3. Multi-device fan-out lives in `internal/pushnotify`, not per engine
+
+`pushnotify.SendToDevices(ctx, notifier Notifier, tokens []string, title, body
+string, data map[string]string) error` is the one place that loops tokens, calls
+`Notifier.Send` per token, and aggregates: **nil** if at least one device received
+it, otherwise the last error. Each engine's own `PushNotifier` only renders its
+message type into `(title, body, data)` and calls this helper — the fan-out/pruning
+mechanics are written once instead of three times.
+
+A device that comes back `ErrTokenPruned` is not "sent" but is not treated as the
+delivery's failure either if *another* device on the same account succeeded — the
+per-user outcome is "did this person receive it," same spirit as
+`TestPushToken`'s existing `sent+pruned+failed=devices` accounting, just collapsed
+to a single bool/error for the delivery loop's purposes. If *every* device is
+pruned/failed, `SendToDevices` returns an error; the engine's delivery loop treats
+that one pass as `Failed` and retries. By the next pass, the pruned tokens are gone
+from `user_push_tokens`, `HasPushDevice` is false, and delivery cleanly soft-skips —
+self-healing without new failure-tracking state.
+
+**Alternative considered:** put the fan-out loop inside each of the three new
+`PushNotifier`s. Rejected as pure duplication — the loop, the aggregation rule, and
+the pruned-vs-failed distinction are identical in all three; only the
+title/body/data rendering differs.
+
+### 4. Deep link: `data` payload carries a job slug only when there is exactly one
+
+`pushnotify.Notifier.Send` gains a `data map[string]string` parameter. Each engine
+sets `data["slug"] = job.Slug` only when the message concerns exactly one job
+(always true for `reminder` and `nudge`; true for `notify` only when
+`Digest.Total == 1`). `freehire-mobile` gains a notification-response listener
+(`Notifications.addNotificationResponseReceivedListener`, wired near the existing
+`usePushNotifications` hook) that reads `response.notification.request.content.data
+.slug` and, if present, calls `router.push('/jobs/' + slug)` (expo-router, matching
+the existing `src/app/jobs/[slug].tsx` route); if absent, the tap just foregrounds
+the app on its default screen — this is expo-router/OS default behavior, so no
+extra code is needed for that path.
+
+**Alternative considered:** always include a link, falling back to a synthetic
+"jobs list" deep link for N>1 digests. Rejected per the proposal's explicit scope
+boundary — no in-app screen exists yet to land such a link on, and building one is
+a separate, user-deferred piece of work ("если много — потом").
+
+### 5. `data` is a **BREAKING** in-repo interface change, not additive
+
+Adding a required `data map[string]string` parameter to `pushnotify.Notifier.Send`
+breaks its one existing caller (`TestPushToken` in
+`internal/handler/me_push_tokens.go`), which is updated to pass `nil`. This is
+preferred over an additive `SendWithData` sibling method, since `pushnotify` has
+exactly one production implementation (`ExpoNotifier`) and one caller today — a
+second method would be permanent surface for a distinction (with/without data) that
+every future caller will want anyway.
+
+### 6. No environment gate for the push channel
+
+`cmd/notify`, `cmd/remind`, `cmd/nudge` register Telegram/email conditionally on
+`TELEGRAM_BOT_TOKEN` / `AWS_REGION`+`NOTIFY_EMAIL_FROM` because those channels need
+server-held credentials. Expo's relay needs none (the APNs/FCM credential lives on
+Expo's side, configured once via `eas credentials` — already done for
+`freehire-mobile`, see the mobile-push memory this session produced). The push
+notifier is therefore constructed unconditionally in all three `cmd` mains; a
+recipient with zero registered devices still soft-skips per-user via decision #2,
+so there is no "feature globally off" state to represent.
+
+## Risks / Trade-offs
+
+- **[Risk] A user with many stale/uninstalled-app tokens burns one `Failed` pass
+  before self-healing.** → Mitigation: decision #3's self-healing behavior bounds
+  this to one failed attempt per stale cohort, not a permanent failure; acceptable
+  given `MaxAttempts` dead-lettering already exists for exactly this shape of
+  transient failure.
+- **[Risk] `freehire-mobile` is a separate repo with its own release cadence
+  (EAS build), so the backend can start sending push before the tap handler ships.**
+  → Mitigation: an untapped push still delivers and foregrounds the app correctly
+  (OS default) even without the new listener — the listener only upgrades "opens
+  the app" to "opens the right job." Backend and mobile tasks are independently
+  shippable in either order.
+- **[Trade-off] Push digest copy (name + count) carries less information than the
+  Telegram/email digest (up to 20 jobs with salary/company).** → Accepted: a push
+  is a glance/attention channel, not a reading surface; the deep link (or opening
+  the app) is where the user gets full detail, matching how the existing
+  Telegram/email copy already treats its own link as "read more here."
+
+## Migration Plan
+
+No database migration. Sqlc query changes only (regenerate via `make sqlc`). Deploy
+order is not load-bearing: the new `push` channel value only becomes reachable once
+the web UI ships the chip that lets a user select it, and an old binary ignores a
+channel value it doesn't recognize (falls through `recipient()`'s default case,
+already the existing behavior for any unhandled channel).
+
+## Open Questions
+
+None outstanding — architecture, content, deep-link behavior, and scope boundaries
+were confirmed with the user before this change was proposed.

--- a/openspec/changes/add-push-notification-channel/proposal.md
+++ b/openspec/changes/add-push-notification-channel/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+freehire's mobile app (`freehire-mobile`, sibling repo) already registers Expo push
+tokens and can receive a one-off self-test push (`POST /api/v1/me/push-tokens/test`),
+but none of the three cron-driven notification engines — saved-search subscriptions
+(`internal/notify`), saved-job reminders (`internal/reminder`), or application
+lifecycle nudges (`internal/nudge`) — can actually deliver to it. Each already
+supports two channels, Telegram and email, behind a shared `channel` vocabulary; push
+is the natural third, and the mobile app is otherwise a dead end for anything the
+backend already knows how to tell a user.
+
+## What Changes
+
+- Add `push` to the shared delivery-channel vocabulary (`notify.Channels` /
+  `notify.ValidChannel`), used by all three engines' create/validate paths.
+- Add a `PushNotifier` to each of `internal/notify`, `internal/reminder`,
+  `internal/nudge`, rendering a short title/body from that engine's own message type
+  and delivering through the existing `internal/pushnotify` Expo transport, fanned out
+  to every device the recipient has registered (a user, unlike a Telegram chat or an
+  email address, may have more than one).
+- Extend `pushnotify.Notifier.Send` with a `data map[string]string` payload (job slug,
+  for deep-linking) — **BREAKING** (in-repo interface, one call site updated).
+- Add a `pushnotify.SendToDevices` helper: fans a title/body/data out to a set of
+  tokens, aggregating per-recipient outcome (delivered if any device received it,
+  otherwise the delivery is treated as failed and retried like any other channel).
+- Extend each engine's delivery-context query (`GetSubscriptionForDelivery`,
+  `GetReminderForDelivery`, `GetNudgeForDelivery`) with a live "has a registered push
+  device" check, so an unregistered recipient soft-skips push exactly the way an
+  unlinked Telegram chat already soft-skips today — no schema migration, since
+  `channel`/`channels` are unconstrained `text`/`text[]`.
+- Register the push notifier unconditionally in `cmd/notify`, `cmd/remind`,
+  `cmd/nudge` — unlike Telegram/email, Expo needs no server-side credential, so there
+  is no env-var gate.
+- Web: add a third "Push" chip next to Telegram/Email in
+  `AlertChannels.svelte` (search-subscription channel picker) and in
+  `ReminderSettings.svelte` (the shared reminder+nudge "Deliver over" row).
+- `freehire-mobile` (sibling repo, tracked here as an out-of-OpenSpec companion task
+  — see design.md): add the notification-tap handler that reads a push's `data.slug`
+  and deep-links to `/jobs/[slug]` via expo-router; without it the new channel sends
+  correctly but tapping the result does nothing.
+
+Explicitly out of scope: collapsing `notify`/`reminder`/`nudge` into one shared
+engine (deferred by the existing `internal/notify` docs until it's clear which half
+generalises — this change is not that trigger), and any multi-job deep-link target
+for a subscription digest with more than one match (tapping opens the app with no
+target screen; picking/paging through several jobs from a push is deferred).
+
+## Capabilities
+
+### New Capabilities
+- `mobile-push-channel`: the shared push-transport plumbing (multi-device fan-out,
+  deep-link data payload) and application-nudge push delivery, which has no existing
+  spec home (`internal/nudge` was never given its own capability spec).
+
+### Modified Capabilities
+- `filter-subscriptions`: `channel` gains a third accepted value (`push`); a push
+  digest renders as a short title/body instead of the full job listing.
+- `saved-job-reminders`: the reminder rule's `channels` set gains a third accepted
+  value (`push`).
+
+## Impact
+
+- **Backend (`hire`)**: `internal/notify`, `internal/reminder`, `internal/nudge`,
+  `internal/pushnotify`, `internal/handler/me_push_tokens.go` (Send signature only),
+  `internal/db` (three sqlc query files, regenerated), `cmd/notify`, `cmd/remind`,
+  `cmd/nudge`.
+- **Web**: `web/src/lib/components/filters/AlertChannels.svelte`,
+  `web/src/lib/components/ReminderSettings.svelte`.
+- **Mobile (`freehire-mobile`, separate repo/git history)**: a notification-response
+  listener wired into `src/app/_layout.tsx` or `usePushNotifications.ts`, using the
+  existing expo-router deep-link scheme. This repo has no OpenSpec of its own; the
+  task is tracked in this change's `tasks.md` as a companion step and implemented in
+  its own worktree/commit.
+- No database migration (existing `text`/`text[]` columns, no `CHECK` constraint).

--- a/openspec/changes/add-push-notification-channel/specs/filter-subscriptions/spec.md
+++ b/openspec/changes/add-push-notification-channel/specs/filter-subscriptions/spec.md
@@ -1,0 +1,119 @@
+## MODIFIED Requirements
+
+### Requirement: Subscribe a saved search to notifications
+
+The system SHALL let an authenticated user subscribe one of their saved searches
+to a delivery channel, so that matching jobs are pushed to them. A subscription
+references a saved search (the filter of record) and a channel; the channel SHALL
+be one of the supported channels (`telegram`, `email`, or `push`). The `push`
+channel stores no per-subscription destination — like `email`, the recipient is
+resolved live at delivery time from the user's registered devices. At most one
+subscription MAY exist per (saved search, channel), so a user MAY subscribe the
+same saved search on Telegram, email, and push at once. Subscription management
+SHALL require the session cookie (`RequireAuth`), never an API key.
+
+#### Scenario: Create a subscription
+
+- **WHEN** an authenticated user POSTs `{saved_search_id, channel:"telegram"}` for a saved search they own
+- **THEN** the system creates a subscription with `active=true` and `start_at=now()`, and returns it as `{"data": subscription}`
+
+#### Scenario: Create an email subscription
+
+- **WHEN** an authenticated user POSTs `{saved_search_id, channel:"email"}` for a saved search they own
+- **THEN** the system creates an email subscription with `active=true`, no per-subscription destination stored, and returns it as `{"data": subscription}`
+
+#### Scenario: Create a push subscription
+
+- **WHEN** an authenticated user POSTs `{saved_search_id, channel:"push"}` for a saved search they own
+- **THEN** the system creates a push subscription with `active=true`, no per-subscription destination stored, and returns it as `{"data": subscription}`, regardless of whether the user currently has a registered device
+
+#### Scenario: Unsupported channel is rejected
+
+- **WHEN** a user POSTs a subscription with a channel that is not `telegram`, `email`, or `push`
+- **THEN** the system returns a 400 and creates no subscription
+
+#### Scenario: Duplicate subscription is rejected
+
+- **WHEN** a user creates a second subscription for the same saved search and channel
+- **THEN** the system returns a 409 (or idempotently returns the existing subscription) and does not create a duplicate row
+
+#### Scenario: Cannot subscribe to another user's saved search
+
+- **WHEN** a user references a `saved_search_id` they do not own
+- **THEN** the system returns a 404 and creates no subscription
+
+#### Scenario: Toggle and unsubscribe
+
+- **WHEN** the user PATCHes a subscription's `active` flag or DELETEs it
+- **THEN** the subscription is deactivated/removed and no further notifications are produced for it
+
+### Requirement: Pluggable delivery channel
+
+The system SHALL deliver through a narrow `Notifier` abstraction selected by the
+subscription's channel, dispatched by a channel router so additional channels can
+be added without changing the matching engine. The `telegram` channel SHALL
+resolve the recipient from the user's linked Telegram chat. The `email` channel
+SHALL resolve the recipient from the user's account email, read live at delivery
+time, so that no per-subscription address is stored and a changed account email
+takes effect on the next delivery. The `push` channel SHALL resolve the recipient
+as the subscribing user, read live at delivery time, and deliver to every device
+currently registered for that user (a user MAY have more than one); a user with no
+currently registered device SHALL be treated the same as an unlinked Telegram
+chat. A subscription whose channel has no configured notifier SHALL be softly
+skipped (its matches stay pending, no attempt counted).
+
+#### Scenario: Telegram delivery without a stored destination
+
+- **WHEN** a `telegram` subscription is delivered
+- **THEN** the worker resolves the recipient `chat_id` from the user's Telegram link rather than from a per-subscription destination
+
+#### Scenario: Unlinked Telegram is skipped, not failed
+
+- **WHEN** a `telegram` subscription's user has no linked Telegram chat
+- **THEN** the delivery is softly skipped (matches stay pending, no attempt is counted) rather than dead-lettered
+
+#### Scenario: Email delivery resolves the account email
+
+- **WHEN** an `email` subscription is delivered
+- **THEN** the worker resolves the recipient from the user's current account email and routes the digest to the email notifier
+
+#### Scenario: Push delivery fans out to every registered device
+
+- **WHEN** a `push` subscription is delivered and the user has two registered devices
+- **THEN** the worker sends the digest to both devices, and the delivery counts as sent as long as at least one device receives it
+
+#### Scenario: No registered device is skipped, not failed
+
+- **WHEN** a `push` subscription's user currently has no registered device
+- **THEN** the delivery is softly skipped (matches stay pending, no attempt is counted) rather than dead-lettered
+
+#### Scenario: Router dispatches by channel
+
+- **WHEN** a digest is delivered for a subscription
+- **THEN** the router sends it through the notifier registered for that subscription's channel, and a channel with no registered notifier is softly skipped
+
+## ADDED Requirements
+
+### Requirement: Push digest content and deep link
+
+A `push` digest SHALL render as a short title and body — the saved search's name
+and the count of newly matched jobs — rather than the itemized listing the
+`telegram`/`email` channels send. When the digest's match count is exactly one,
+the push SHALL carry that job's slug as deep-link data so the mobile app can open
+it directly; when the count is more than one, the push SHALL carry no deep-link
+data.
+
+#### Scenario: Digest content is name and count
+
+- **WHEN** a push digest is rendered for a saved search named "Backend Engineer" with 3 newly matched jobs
+- **THEN** the push body reads to the effect of "3 new jobs for \"Backend Engineer\""
+
+#### Scenario: Single match carries a deep link
+
+- **WHEN** a push digest's match count is exactly 1
+- **THEN** the push's data payload includes that job's slug
+
+#### Scenario: Multiple matches carry no deep link
+
+- **WHEN** a push digest's match count is greater than 1
+- **THEN** the push's data payload includes no job slug

--- a/openspec/changes/add-push-notification-channel/specs/mobile-push-channel/spec.md
+++ b/openspec/changes/add-push-notification-channel/specs/mobile-push-channel/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Multi-device push fan-out
+
+Any notification engine delivering over the `push` channel SHALL send to every
+device currently registered for the recipient user, not a single fixed
+destination. A delivery counts as sent for that channel as long as at least one
+registered device received it; if every device's send fails or the device's
+registration turns out to be dead, the delivery SHALL be treated as failed for
+that pass (retried on the engine's normal retry schedule) rather than silently
+dropped.
+
+#### Scenario: One of several devices is unreachable
+
+- **WHEN** a user has two registered devices and the push relay reports one delivered and one undeliverable
+- **THEN** the delivery counts as sent, and the undeliverable device's registration is removed so it is not retried
+
+#### Scenario: Every device is unreachable
+
+- **WHEN** a user has one or more registered devices and none of them accept the push
+- **THEN** the delivery counts as failed for that pass and is retried on the engine's normal retry/dead-letter schedule
+
+### Requirement: Push channel needs no server-side credential gate
+
+Unlike `telegram` (needs a bot token) and `email` (needs SES credentials), the
+`push` channel SHALL be available in every delivery engine unconditionally — the
+push relay holds its own device credentials, so there is no environment
+configuration that turns the channel off server-wide. Deliverability is decided
+per recipient (has a registered device or not), never per deployment.
+
+#### Scenario: Push channel is always registered
+
+- **WHEN** a notification worker starts up with no push-specific environment variables set
+- **THEN** the `push` channel is still available for delivery, unlike `telegram`/`email` which are skipped when unconfigured
+
+### Requirement: Application nudge push delivery
+
+A due application lifecycle nudge (follow-up, interview-prep, or job-closed) whose
+account rule includes the `push` channel SHALL be delivered as a short push
+notification, distinct per nudge kind, to every device registered for the
+account, following the same fan-out and soft-skip rules as the other two
+notification engines. Since a nudge always concerns exactly one application/job,
+the push SHALL carry that job's slug as deep-link data.
+
+#### Scenario: Follow-up nudge over push
+
+- **WHEN** a follow-up nudge is delivered over `push`
+- **THEN** the push's title/body names the job and company and indicates the application has gone quiet, and the data payload includes the job's slug
+
+#### Scenario: Interview-prep nudge over push
+
+- **WHEN** an interview-prep nudge is delivered over `push`
+- **THEN** the push's title/body indicates an upcoming interview for that job, and the data payload includes the job's slug
+
+#### Scenario: Job-closed nudge over push
+
+- **WHEN** a job-closed nudge is delivered over `push`
+- **THEN** the push's title/body indicates the job was closed, and the data payload includes the job's slug
+
+#### Scenario: No registered device is skipped, not failed
+
+- **WHEN** a nudge's rule includes `push` but the user has no currently registered device
+- **THEN** that channel is skipped without failing the nudge, and remaining configured channels still deliver
+
+### Requirement: Tapping a push with a job deep-link opens that job
+
+The mobile app SHALL, on receiving a tap on a push notification whose data payload
+includes a job slug, navigate directly to that job's detail screen. A push with no
+job slug in its data payload SHALL simply foreground the app without navigating
+anywhere in particular.
+
+#### Scenario: Tap with a deep link
+
+- **WHEN** the user taps a push notification carrying a job slug in its data
+- **THEN** the app opens directly to that job's detail screen
+
+#### Scenario: Tap without a deep link
+
+- **WHEN** the user taps a push notification carrying no job slug
+- **THEN** the app opens to its default screen

--- a/openspec/changes/add-push-notification-channel/specs/saved-job-reminders/spec.md
+++ b/openspec/changes/add-push-notification-channel/specs/saved-job-reminders/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: One-shot delivery
+
+A reminder SHALL fire exactly once at or after its scheduled fire time and then be marked
+delivered. A due reminder SHALL be delivered as a message over each channel in the rule's
+channel set for which the user has a usable destination, reusing the existing notification
+delivery engine. For the `push` channel, a usable destination is at least one currently
+registered device; delivery fans out to every registered device and counts as sent for that
+channel as long as at least one device receives it. Delivery SHALL be idempotent under
+worker retries: a reminder already marked delivered is never sent again.
+
+#### Scenario: Due reminder is delivered once
+
+- **WHEN** the reminder worker runs after a reminder's fire time has passed
+- **THEN** the user receives one reminder message per configured channel with a usable
+  destination
+- **AND** the reminder is marked delivered
+
+#### Scenario: Worker re-run does not resend
+
+- **WHEN** the worker runs again after a reminder was already delivered
+- **THEN** no additional message is sent for that reminder
+
+#### Scenario: Channel has no destination
+
+- **WHEN** a reminder's rule includes `telegram` but the user has not linked Telegram
+- **THEN** that channel is skipped without failing the reminder, and remaining channels
+  still deliver
+
+#### Scenario: Push channel with no registered device
+
+- **WHEN** a reminder's rule includes `push` but the user has no currently registered device
+- **THEN** that channel is skipped without failing the reminder, and remaining channels
+  still deliver
+
+#### Scenario: Push channel fans out to every registered device
+
+- **WHEN** a reminder's rule includes `push` and the user has two registered devices
+- **THEN** both devices receive the reminder, and the channel counts as delivered as long
+  as at least one device received it
+
+#### Scenario: Not yet due
+
+- **WHEN** the worker runs before a reminder's fire time
+- **THEN** the reminder is left pending and nothing is sent
+
+## ADDED Requirements
+
+### Requirement: Push reminder content and deep link
+
+A reminder delivered over `push` SHALL render as a short title and body naming the saved
+job and its company, distinct from the longer Telegram/email copy, and SHALL carry that
+job's slug as deep-link data so the mobile app can open it directly — a reminder always
+concerns exactly one job, so a deep link is always available.
+
+#### Scenario: Push reminder carries a deep link
+
+- **WHEN** a reminder is delivered over `push`
+- **THEN** the push's data payload includes the saved job's slug

--- a/openspec/changes/add-push-notification-channel/tasks.md
+++ b/openspec/changes/add-push-notification-channel/tasks.md
@@ -34,8 +34,8 @@
 
 ## 6. Web UI
 
-- [ ] 6.1 Add a third "Push" chip to `web/src/lib/components/filters/AlertChannels.svelte`, following the existing `toggleEmail`/`emailSub` pattern (no linking step)
-- [ ] 6.2 Add a third "Push" chip to the "Deliver over" row in `web/src/lib/components/ReminderSettings.svelte`
+- [x] 6.1 Add a third "Push" chip to `web/src/lib/components/filters/AlertChannels.svelte`, following the existing `toggleEmail`/`emailSub` pattern (no linking step)
+- [x] 6.2 Add a third "Push" chip to the "Deliver over" row in `web/src/lib/components/ReminderSettings.svelte`
 
 ## 7. Mobile tap-to-open deep link (`freehire-mobile`, separate repo)
 

--- a/openspec/changes/add-push-notification-channel/tasks.md
+++ b/openspec/changes/add-push-notification-channel/tasks.md
@@ -11,26 +11,26 @@
 ## 3. `internal/notify` push channel (filter-subscriptions)
 
 - [x] 3.1 Add a `HasPushDevice bool` column to the `GetSubscriptionForDelivery` sqlc query (`EXISTS(SELECT 1 FROM user_push_tokens WHERE user_id = s.user_id)`), regenerate (`make sqlc`)
-- [ ] 3.2 Add a `ChannelPush` case to `notify.recipient()` — returns `(userID string, true)` when `HasPushDevice`, else `("", false)`; unit tests for both branches
-- [ ] 3.3 Implement `notify.PushNotifier`: renders title="freehire", body="{Total} new jobs for \"{SavedSearchName}\"", sets deep-link data to the sole job's slug when `Total == 1` and omits it otherwise, then calls `pushnotify.SendToDevices`; unit tests for the render logic (0/1/N-job digests) with a fake token store + fake `pushnotify.Notifier`
-- [ ] 3.4 Register `notify.PushNotifier` in `cmd/notify`'s `Router` unconditionally (no env-var gate, unlike Telegram/email)
-- [ ] 3.5 Integration test (`internal/db` + `internal/notify`, `//go:build integration`): a push subscription with a registered device is delivered; one with no device soft-skips
+- [x] 3.2 Add a `ChannelPush` case to `notify.recipient()` — returns `(userID string, true)` when `HasPushDevice`, else `("", false)`; unit tests for both branches
+- [x] 3.3 Implement `notify.PushNotifier`: renders title="freehire", body="{Total} new jobs for \"{SavedSearchName}\"", sets deep-link data to the sole job's slug when `Total == 1` and omits it otherwise, then calls `pushnotify.SendToDevices`; unit tests for the render logic (0/1/N-job digests) with a fake token store + fake `pushnotify.Notifier`
+- [x] 3.4 Register `notify.PushNotifier` in `cmd/notify`'s `Router` unconditionally (no env-var gate, unlike Telegram/email)
+- [x] 3.5 Integration test (`internal/db` + `internal/notify`, `//go:build integration`): a push subscription with a registered device is delivered; one with no device soft-skips
 
 ## 4. `internal/reminder` push channel (saved-job-reminders)
 
 - [x] 4.1 Add a `HasPushDevice bool` column to the `GetReminderForDelivery` sqlc query, regenerate
-- [ ] 4.2 Add a `ChannelPush` case to `reminder.recipient()`, mirroring 3.2; unit tests
-- [ ] 4.3 Implement `reminder.PushNotifier`: short title/body ("⏰ Reminder" / "You saved {JobTitle} at {Company} — still interested?"), deep-link data always set to the reminder's job slug, calls `pushnotify.SendToDevices`; unit tests
-- [ ] 4.4 Register `reminder.PushNotifier` in `cmd/remind`'s `Router` unconditionally
-- [ ] 4.5 Integration test: a reminder rule with `push` in its channel set delivers to a registered device and soft-skips with none
+- [x] 4.2 Add a `ChannelPush` case to `reminder.recipient()`, mirroring 3.2; unit tests
+- [x] 4.3 Implement `reminder.PushNotifier`: short title/body ("⏰ Reminder" / "You saved {JobTitle} at {Company} — still interested?"), deep-link data always set to the reminder's job slug, calls `pushnotify.SendToDevices`; unit tests
+- [x] 4.4 Register `reminder.PushNotifier` in `cmd/remind`'s `Router` unconditionally
+- [x] 4.5 Integration test: a reminder rule with `push` in its channel set delivers to a registered device and soft-skips with none
 
 ## 5. `internal/nudge` push channel (mobile-push-channel: application nudge delivery)
 
 - [x] 5.1 Add a `HasPushDevice bool` column to the `GetNudgeForDelivery` sqlc query, regenerate
-- [ ] 5.2 Add a `ChannelPush` case to `nudge.recipient()`, mirroring 3.2/4.2; unit tests
-- [ ] 5.3 Implement `nudge.PushNotifier`: short per-`Kind` title/body (`KindFollowUp`/`KindInterviewPrep`/`KindJobClosed`, shortened from the existing Telegram copy in `internal/nudge/transports.go`), deep-link data always set to the job slug, calls `pushnotify.SendToDevices`; unit tests for all three kinds
-- [ ] 5.4 Register `nudge.PushNotifier` in `cmd/nudge`'s `Router` unconditionally
-- [ ] 5.5 Integration test: each nudge kind with `push` in the account's channel set delivers to a registered device and soft-skips with none
+- [x] 5.2 Add a `ChannelPush` case to `nudge.recipient()`, mirroring 3.2/4.2; unit tests
+- [x] 5.3 Implement `nudge.PushNotifier`: short per-`Kind` title/body (`KindFollowUp`/`KindInterviewPrep`/`KindJobClosed`, shortened from the existing Telegram copy in `internal/nudge/transports.go`), deep-link data always set to the job slug, calls `pushnotify.SendToDevices`; unit tests for all three kinds
+- [x] 5.4 Register `nudge.PushNotifier` in `cmd/nudge`'s `Router` unconditionally
+- [x] 5.5 Integration test: each nudge kind with `push` in the account's channel set delivers to a registered device and soft-skips with none
 
 ## 6. Web UI
 

--- a/openspec/changes/add-push-notification-channel/tasks.md
+++ b/openspec/changes/add-push-notification-channel/tasks.md
@@ -39,7 +39,7 @@
 
 ## 7. Mobile tap-to-open deep link (`freehire-mobile`, separate repo)
 
-- [ ] 7.1 Add a notification-response listener (`Notifications.addNotificationResponseReceivedListener`) near `usePushNotifications.ts` / `src/app/_layout.tsx`: when `response.notification.request.content.data.slug` is present, `router.push('/jobs/' + slug)`
+- [x] 7.1 Add a notification-response listener (`Notifications.addNotificationResponseReceivedListener`) near `usePushNotifications.ts` / `src/app/_layout.tsx`: when `response.notification.request.content.data.slug` is present, `router.push('/jobs/' + slug)`
 - [ ] 7.2 Manual device verification: trigger a push carrying a slug from a local/staging send and confirm the tap opens `src/app/jobs/[slug].tsx` for that slug; confirm a push with no slug just foregrounds the app
 
 ## 8. Verification

--- a/openspec/changes/add-push-notification-channel/tasks.md
+++ b/openspec/changes/add-push-notification-channel/tasks.md
@@ -1,0 +1,50 @@
+## 1. Shared push transport (`internal/pushnotify`)
+
+- [ ] 1.1 Add a `data map[string]string` parameter to `pushnotify.Notifier.Send` and `ExpoNotifier.Send`; add `Data map[string]string \`json:"data,omitempty"\`` to `expoMessage`
+- [ ] 1.2 Update `TestPushToken` (`internal/handler/me_push_tokens.go`) to pass `nil` for the new parameter
+- [ ] 1.3 Add `pushnotify.SendToDevices(ctx, notifier Notifier, tokens []string, title, body string, data map[string]string) error` — sends to every token, returns nil if any succeeded, an aggregate error if all failed/were pruned; unit tests with a fake `Notifier` covering all-success, partial-success, all-pruned, all-failed, empty-tokens
+
+## 2. Shared channel vocabulary
+
+- [ ] 2.1 Add `ChannelPush = "push"` to `internal/notify` and append it to `notify.Channels`; confirm `notify.ValidChannel("push")` is true and existing reminder/nudge validation (which already reuses this slice) accepts it
+
+## 3. `internal/notify` push channel (filter-subscriptions)
+
+- [ ] 3.1 Add a `HasPushDevice bool` column to the `GetSubscriptionForDelivery` sqlc query (`EXISTS(SELECT 1 FROM user_push_tokens WHERE user_id = s.user_id)`), regenerate (`make sqlc`)
+- [ ] 3.2 Add a `ChannelPush` case to `notify.recipient()` — returns `(userID string, true)` when `HasPushDevice`, else `("", false)`; unit tests for both branches
+- [ ] 3.3 Implement `notify.PushNotifier`: renders title="freehire", body="{Total} new jobs for \"{SavedSearchName}\"", sets deep-link data to the sole job's slug when `Total == 1` and omits it otherwise, then calls `pushnotify.SendToDevices`; unit tests for the render logic (0/1/N-job digests) with a fake token store + fake `pushnotify.Notifier`
+- [ ] 3.4 Register `notify.PushNotifier` in `cmd/notify`'s `Router` unconditionally (no env-var gate, unlike Telegram/email)
+- [ ] 3.5 Integration test (`internal/db` + `internal/notify`, `//go:build integration`): a push subscription with a registered device is delivered; one with no device soft-skips
+
+## 4. `internal/reminder` push channel (saved-job-reminders)
+
+- [ ] 4.1 Add a `HasPushDevice bool` column to the `GetReminderForDelivery` sqlc query, regenerate
+- [ ] 4.2 Add a `ChannelPush` case to `reminder.recipient()`, mirroring 3.2; unit tests
+- [ ] 4.3 Implement `reminder.PushNotifier`: short title/body ("⏰ Reminder" / "You saved {JobTitle} at {Company} — still interested?"), deep-link data always set to the reminder's job slug, calls `pushnotify.SendToDevices`; unit tests
+- [ ] 4.4 Register `reminder.PushNotifier` in `cmd/remind`'s `Router` unconditionally
+- [ ] 4.5 Integration test: a reminder rule with `push` in its channel set delivers to a registered device and soft-skips with none
+
+## 5. `internal/nudge` push channel (mobile-push-channel: application nudge delivery)
+
+- [ ] 5.1 Add a `HasPushDevice bool` column to the `GetNudgeForDelivery` sqlc query, regenerate
+- [ ] 5.2 Add a `ChannelPush` case to `nudge.recipient()`, mirroring 3.2/4.2; unit tests
+- [ ] 5.3 Implement `nudge.PushNotifier`: short per-`Kind` title/body (`KindFollowUp`/`KindInterviewPrep`/`KindJobClosed`, shortened from the existing Telegram copy in `internal/nudge/transports.go`), deep-link data always set to the job slug, calls `pushnotify.SendToDevices`; unit tests for all three kinds
+- [ ] 5.4 Register `nudge.PushNotifier` in `cmd/nudge`'s `Router` unconditionally
+- [ ] 5.5 Integration test: each nudge kind with `push` in the account's channel set delivers to a registered device and soft-skips with none
+
+## 6. Web UI
+
+- [ ] 6.1 Add a third "Push" chip to `web/src/lib/components/filters/AlertChannels.svelte`, following the existing `toggleEmail`/`emailSub` pattern (no linking step)
+- [ ] 6.2 Add a third "Push" chip to the "Deliver over" row in `web/src/lib/components/ReminderSettings.svelte`
+
+## 7. Mobile tap-to-open deep link (`freehire-mobile`, separate repo)
+
+- [ ] 7.1 Add a notification-response listener (`Notifications.addNotificationResponseReceivedListener`) near `usePushNotifications.ts` / `src/app/_layout.tsx`: when `response.notification.request.content.data.slug` is present, `router.push('/jobs/' + slug)`
+- [ ] 7.2 Manual device verification: trigger a push carrying a slug from a local/staging send and confirm the tap opens `src/app/jobs/[slug].tsx` for that slug; confirm a push with no slug just foregrounds the app
+
+## 8. Verification
+
+- [ ] 8.1 `gofmt -l .` clean, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`
+- [ ] 8.2 `go test -tags=integration ./internal/notify/... ./internal/reminder/... ./internal/nudge/... ./internal/pushnotify/...` (needs Docker/testcontainers)
+- [ ] 8.3 Web: `eslint`/`tsc` clean on the two changed components
+- [ ] 8.4 End-to-end manual smoke on a real device: enable the Push chip for a subscription, a reminder, and (if reproducible) a nudge; trigger each backend worker; confirm delivery and, where a single job is involved, the deep link

--- a/openspec/changes/add-push-notification-channel/tasks.md
+++ b/openspec/changes/add-push-notification-channel/tasks.md
@@ -44,7 +44,7 @@
 
 ## 8. Verification
 
-- [ ] 8.1 `gofmt -l .` clean, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`
-- [ ] 8.2 `go test -tags=integration ./internal/notify/... ./internal/reminder/... ./internal/nudge/... ./internal/pushnotify/...` (needs Docker/testcontainers)
-- [ ] 8.3 Web: `eslint`/`tsc` clean on the two changed components
+- [x] 8.1 `gofmt -l .` clean, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`
+- [x] 8.2 `go test -tags=integration ./internal/notify/... ./internal/reminder/... ./internal/nudge/... ./internal/pushnotify/...` (needs Docker/testcontainers)
+- [x] 8.3 Web: `eslint`/`tsc` clean on the two changed components
 - [ ] 8.4 End-to-end manual smoke on a real device: enable the Push chip for a subscription, a reminder, and (if reproducible) a nudge; trigger each backend worker; confirm delivery and, where a single job is involved, the deep link

--- a/openspec/changes/add-push-notification-channel/tasks.md
+++ b/openspec/changes/add-push-notification-channel/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Shared push transport (`internal/pushnotify`)
 
-- [ ] 1.1 Add a `data map[string]string` parameter to `pushnotify.Notifier.Send` and `ExpoNotifier.Send`; add `Data map[string]string \`json:"data,omitempty"\`` to `expoMessage`
-- [ ] 1.2 Update `TestPushToken` (`internal/handler/me_push_tokens.go`) to pass `nil` for the new parameter
-- [ ] 1.3 Add `pushnotify.SendToDevices(ctx, notifier Notifier, tokens []string, title, body string, data map[string]string) error` — sends to every token, returns nil if any succeeded, an aggregate error if all failed/were pruned; unit tests with a fake `Notifier` covering all-success, partial-success, all-pruned, all-failed, empty-tokens
+- [x] 1.1 Add a `data map[string]string` parameter to `pushnotify.Notifier.Send` and `ExpoNotifier.Send`; add `Data map[string]string \`json:"data,omitempty"\`` to `expoMessage`
+- [x] 1.2 Update `TestPushToken` (`internal/handler/me_push_tokens.go`) to pass `nil` for the new parameter
+- [x] 1.3 Add `pushnotify.SendToDevices(ctx, notifier Notifier, tokens []string, title, body string, data map[string]string) error` — sends to every token, returns nil if any succeeded, an aggregate error if all failed/were pruned; unit tests with a fake `Notifier` covering all-success, partial-success, all-pruned, all-failed, empty-tokens
 
 ## 2. Shared channel vocabulary
 
-- [ ] 2.1 Add `ChannelPush = "push"` to `internal/notify` and append it to `notify.Channels`; confirm `notify.ValidChannel("push")` is true and existing reminder/nudge validation (which already reuses this slice) accepts it
+- [x] 2.1 Add `ChannelPush = "push"` to `internal/notify` and append it to `notify.Channels`; confirm `notify.ValidChannel("push")` is true and existing reminder/nudge validation (which already reuses this slice) accepts it
 
 ## 3. `internal/notify` push channel (filter-subscriptions)
 
-- [ ] 3.1 Add a `HasPushDevice bool` column to the `GetSubscriptionForDelivery` sqlc query (`EXISTS(SELECT 1 FROM user_push_tokens WHERE user_id = s.user_id)`), regenerate (`make sqlc`)
+- [x] 3.1 Add a `HasPushDevice bool` column to the `GetSubscriptionForDelivery` sqlc query (`EXISTS(SELECT 1 FROM user_push_tokens WHERE user_id = s.user_id)`), regenerate (`make sqlc`)
 - [ ] 3.2 Add a `ChannelPush` case to `notify.recipient()` — returns `(userID string, true)` when `HasPushDevice`, else `("", false)`; unit tests for both branches
 - [ ] 3.3 Implement `notify.PushNotifier`: renders title="freehire", body="{Total} new jobs for \"{SavedSearchName}\"", sets deep-link data to the sole job's slug when `Total == 1` and omits it otherwise, then calls `pushnotify.SendToDevices`; unit tests for the render logic (0/1/N-job digests) with a fake token store + fake `pushnotify.Notifier`
 - [ ] 3.4 Register `notify.PushNotifier` in `cmd/notify`'s `Router` unconditionally (no env-var gate, unlike Telegram/email)
@@ -18,7 +18,7 @@
 
 ## 4. `internal/reminder` push channel (saved-job-reminders)
 
-- [ ] 4.1 Add a `HasPushDevice bool` column to the `GetReminderForDelivery` sqlc query, regenerate
+- [x] 4.1 Add a `HasPushDevice bool` column to the `GetReminderForDelivery` sqlc query, regenerate
 - [ ] 4.2 Add a `ChannelPush` case to `reminder.recipient()`, mirroring 3.2; unit tests
 - [ ] 4.3 Implement `reminder.PushNotifier`: short title/body ("⏰ Reminder" / "You saved {JobTitle} at {Company} — still interested?"), deep-link data always set to the reminder's job slug, calls `pushnotify.SendToDevices`; unit tests
 - [ ] 4.4 Register `reminder.PushNotifier` in `cmd/remind`'s `Router` unconditionally
@@ -26,7 +26,7 @@
 
 ## 5. `internal/nudge` push channel (mobile-push-channel: application nudge delivery)
 
-- [ ] 5.1 Add a `HasPushDevice bool` column to the `GetNudgeForDelivery` sqlc query, regenerate
+- [x] 5.1 Add a `HasPushDevice bool` column to the `GetNudgeForDelivery` sqlc query, regenerate
 - [ ] 5.2 Add a `ChannelPush` case to `nudge.recipient()`, mirroring 3.2/4.2; unit tests
 - [ ] 5.3 Implement `nudge.PushNotifier`: short per-`Kind` title/body (`KindFollowUp`/`KindInterviewPrep`/`KindJobClosed`, shortened from the existing Telegram copy in `internal/nudge/transports.go`), deep-link data always set to the job slug, calls `pushnotify.SendToDevices`; unit tests for all three kinds
 - [ ] 5.4 Register `nudge.PushNotifier` in `cmd/nudge`'s `Router` unconditionally

--- a/web/src/lib/components/ReminderSettings.svelte
+++ b/web/src/lib/components/ReminderSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Bell, Check, Mail } from '@lucide/svelte';
+  import { Bell, Check, Mail, Smartphone } from '@lucide/svelte';
   import { resolve } from '$app/paths';
   import { api, ApiError } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -164,6 +164,14 @@
               <Mail class="size-3.5" aria-hidden="true" />
             {/if}
             Email
+          </button>
+          <button type="button" onclick={() => toggleChannel('push')} aria-pressed={channels.includes('push')} class={pill(channels.includes('push'))}>
+            {#if channels.includes('push')}
+              <Check class="size-3.5" aria-hidden="true" />
+            {:else}
+              <Smartphone class="size-3.5" aria-hidden="true" />
+            {/if}
+            Push
           </button>
         </div>
         {#if channels.includes('telegram')}

--- a/web/src/lib/components/filters/AlertChannels.svelte
+++ b/web/src/lib/components/filters/AlertChannels.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
-  import { Bell, Check, Mail } from '@lucide/svelte';
+  import { Bell, Check, Mail, Smartphone } from '@lucide/svelte';
   import { ApiError } from '$lib/api';
   import { notifications } from '$lib/notifications.svelte';
   import ProviderIcon from '../ProviderIcon.svelte';
 
   // The unified per-search alert control: one toggle chip per delivery channel
-  // (Telegram, Email) for an already-saved search. This is the single home of channel
-  // subscribe/unsubscribe logic — Telegram carries a connect step (link the bot, then
-  // recheck once), email delivers to the account address with no linking. Shared by the
-  // account page (/my/searches), the filter modal, and the sidebar's post-save state.
+  // (Telegram, Email, Push) for an already-saved search. This is the single home of
+  // channel subscribe/unsubscribe logic — Telegram carries a connect step (link the
+  // bot, then recheck once); email and push subscribe/unsubscribe directly, with no
+  // linking step (push delivers to whatever device the mobile app has registered).
+  // Shared by the account page (/my/searches), the filter modal, and the sidebar's
+  // post-save state.
   //
   // A chip is "on" when a subscription exists for that channel; tapping an on chip turns
   // it off. Telegram hides itself when the feature isn't configured server-side.
   let { savedSearchId, showLabel = true }: { savedSearchId: number; showLabel?: boolean } = $props();
 
-  let busy = $state<'telegram' | 'email' | null>(null);
+  let busy = $state<'telegram' | 'email' | 'push' | null>(null);
   // The Telegram deep link was opened; we await the user's "I've connected" recheck.
   let connecting = $state(false);
   let error = $state<string | null>(null);
@@ -22,6 +24,7 @@
   const tg = $derived(notifications.telegram);
   const tgSub = $derived(notifications.forSavedSearch(savedSearchId, 'telegram'));
   const emailSub = $derived(notifications.forSavedSearch(savedSearchId, 'email'));
+  const pushSub = $derived(notifications.forSavedSearch(savedSearchId, 'push'));
 
   // Telegram: unsubscribe if on; else subscribe — linking the bot first when the chat
   // isn't connected yet (the "I've connected" recheck then finishes the subscribe).
@@ -84,6 +87,22 @@
     }
   }
 
+  // Push: plain subscribe/unsubscribe — no linking here either; delivery reaches
+  // whichever device(s) the mobile app has registered, or soft-skips until one is.
+  async function togglePush() {
+    if (busy) return;
+    busy = 'push';
+    error = null;
+    try {
+      if (pushSub) await notifications.unsubscribe(pushSub.id);
+      else await notifications.subscribe(savedSearchId, 'push');
+    } catch (e) {
+      error = e instanceof ApiError ? e.message : 'Could not update the push alert. Please try again.';
+    } finally {
+      busy = null;
+    }
+  }
+
   // A chip: filled brand tint when on, neutral outline when off; the leading glyph is a
   // check once subscribed, otherwise the channel mark.
   const chipClass = (on: boolean) =>
@@ -121,6 +140,15 @@
         <Mail class="size-3.5" aria-hidden="true" />
       {/if}
       Email
+    </button>
+
+    <button type="button" onclick={togglePush} disabled={busy !== null} aria-pressed={pushSub != null} class={chipClass(pushSub != null)}>
+      {#if pushSub}
+        <Check class="size-3.5" aria-hidden="true" />
+      {:else}
+        <Smartphone class="size-3.5" aria-hidden="true" />
+      {/if}
+      Push
     </button>
   </div>
 


### PR DESCRIPTION
## Summary
- Adds `push` as a third delivery channel (alongside Telegram/email) across all three notification engines: `internal/notify` (saved-search subscription digests), `internal/reminder` (saved-job reminders), `internal/nudge` (application lifecycle nudges) — delivered via the existing `internal/pushnotify` Expo transport, fanned out to every device a user has registered.
- `pushnotify.Notifier.Send` gains a `data map[string]string` param (deep-link payload) and a new `pushnotify.SendToDevices` helper does the multi-device fan-out.
- Each engine's `recipient()` soft-skips push the same way it already soft-skips an unlinked Telegram chat, via a new live `HasPushDevice` column on each delivery-context query.
- Push needs no server credential (Expo owns it) so it's registered unconditionally in `cmd/notify`/`cmd/remind`/`cmd/nudge`, unlike Telegram/email.
- Web: a third "Push" chip in `AlertChannels.svelte` (subscriptions) and `ReminderSettings.svelte` (reminders/nudges).
- Companion commit in `freehire-mobile` (already pushed separately, not part of this PR) adds the notification-tap deep-link handler.

Full design/spec/tasks: `openspec/changes/add-push-notification-channel/`.

## Test plan
- [x] `gofmt -l .`, `go vet ./...`, `go build ./...` clean
- [x] `go test ./...` — 151 packages, 0 failures
- [x] `go vet -tags=integration ./...` clean
- [x] `go test -tags=integration ./...` — full module, 0 failures (incl. new integration tests for notify/reminder/nudge push delivery + soft-skip)
- [x] Web `eslint`/`svelte-check` clean on the two changed components
- [x] Three independent code reviews (one per engine), no unresolved findings
- [ ] Manual on-device smoke test (tasks 7.2/8.4 in the OpenSpec tasks.md — pending, needs a physical device)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile push notifications for saved-search alerts, reminders, and application nudges.
  * Notifications can reach all registered devices and include job links when applicable.
  * Added Push options to reminder and alert channel settings.
  * Users without registered devices are skipped without interrupting other deliveries.

* **Documentation**
  * Updated notification channel and delivery documentation, including push behavior and device eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->