### PR TITLE
ci: add Snyk dependency scan for JS packages

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -44,21 +44,25 @@ jobs:
         working-directory: design-system
         run: pnpm install --frozen-lockfile
 
+      # design-system carries both pnpm-lock.yaml and pnpm-workspace.yaml —
+      # a plain `snyk test` refuses (422) and asks for --all-projects.
       - name: Test design-system dependencies
         working-directory: design-system
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk test
+        run: snyk test --all-projects
 
       - name: Install web dependencies
         working-directory: web
         run: pnpm install --frozen-lockfile
 
+      # web also carries pnpm-workspace.yaml alongside its lockfile — same
+      # 422 trap as design-system.
       - name: Test web dependencies
         working-directory: web
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk test
+        run: snyk test --all-projects
 
       - name: Install extension dependencies
         working-directory: extension

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,71 @@
+name: snyk
+
+# Go dependencies are already covered by govulncheck.yml (reachability-based,
+# no token needed) — scoped here to the JS lockfiles (web/, extension/,
+# design-system/) to avoid duplicate coverage and stay inside Snyk's free-tier
+# monthly test quota.
+on:
+  schedule:
+    - cron: '41 6 * * *'
+  pull_request:
+    branches: [main]
+    paths: ['web/**', 'extension/**', 'design-system/**', '.github/workflows/snyk.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            web/pnpm-lock.yaml
+            design-system/pnpm-lock.yaml
+
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+
+      # design-system is a `link:`/`file:` dependency for web/extension and does
+      # not install its own deps transitively — same trap as ci.yml and
+      # extension.yml.
+      - name: Install design-system dependencies
+        working-directory: design-system
+        run: pnpm install --frozen-lockfile
+
+      - name: Test design-system dependencies
+        working-directory: design-system
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: snyk test
+
+      - name: Install web dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      - name: Test web dependencies
+        working-directory: web
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: snyk test
+
+      - name: Install extension dependencies
+        working-directory: extension
+        run: npm ci
+
+      - name: Test extension dependencies
+        working-directory: extension
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: snyk test


### PR DESCRIPTION
## Summary
- Adds a Snyk scan for the JS lockfiles (`web/`, `extension/`, `design-system/`), which had no dependency vulnerability scanning
- Scoped to JS only — Go deps are already covered by `govulncheck.yml`, and this avoids burning Snyk's free-tier test quota on duplicate coverage
- Runs on PR (path-filtered), daily schedule, and manual dispatch

## Test plan
- [ ] Workflow run succeeds on this PR (Actions tab)
- [ ] `SNYK_TOKEN` secret resolves correctly in the job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency security scans running daily, on relevant pull requests, or on demand.
  * Scans all supported project workspaces and the browser extension for known vulnerabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->