### PR TITLE
Add CodeQL static analysis for Go and JS/TypeScript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+# First-party static analysis (SQL/command injection, XSS, taint tracking, ...).
+# Dependency vulnerabilities are covered separately: govulncheck.yml (Go),
+# snyk.yml (JS lockfiles).
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '13 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml`, scanning `go` and `javascript-typescript` on push/PR to `main` plus a weekly schedule.
- Closes the SAST gap: `govulncheck.yml` and `snyk.yml` only check third-party dependencies against known CVEs — neither reads what our own code does with them (SQL/command injection, XSS, SSRF, unsafe deserialization, etc).
- Public repo, so CodeQL runs free under GitHub Actions (no GHAS/billing implications).

## Test plan
- [x] Workflow YAML validated for syntax.
- [ ] First run on this PR will confirm `go build`/autobuild succeeds for the `go` language matrix leg (no local golangci-lint-equivalent for CodeQL init).