### PR TITLE
Fix Lighthouse a11y issues and drop homepage's first-visit redirect

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,19 +1,27 @@
 name: Performance
 
-# Two complementary guards, per the perf suite in perf/k6/:
+# Three complementary guards, per the perf suite in perf/k6/ and perf/lighthouse/:
 #
-#  • pr-smoke     — spins up the full stack and asserts the key pages still
-#                   render (200 + HTML) within a LOOSE latency ceiling. Safe to
-#                   require as a merge check: it runs on every PR and ALWAYS
-#                   reports a status, but only does the heavy work when the PR
-#                   touches the request path (detected via git diff below). It
-#                   runs on an empty DB, so it gates correctness of the
-#                   SSR→API→Postgres→Meili path, not data-scale performance.
+#  • pr-smoke        — spins up the full stack and asserts the key pages still
+#                       render (200 + HTML) within a LOOSE latency ceiling. Safe
+#                       to require as a merge check: it runs on every PR and
+#                       ALWAYS reports a status, but only does the heavy work
+#                       when the PR touches the request path (detected via git
+#                       diff below). It runs on an empty DB, so it gates
+#                       correctness of the SSR→API→Postgres→Meili path, not
+#                       data-scale performance.
 #
-#  • prod-watchdog — on a schedule, run the same suite against production with
-#                    tight, headroom-based thresholds and enough samples to be
-#                    stable. A breach opens an issue. This is where real
-#                    degradation (query plans at scale, cold caches) is caught.
+#  • prod-watchdog    — on a schedule, run the same suite against production
+#                       with tight, headroom-based thresholds and enough
+#                       samples to be stable. A breach opens an issue. This is
+#                       where real degradation (query plans at scale, cold
+#                       caches) is caught.
+#
+#  • lighthouse-watchdog — on the same schedule, run Lighthouse against the
+#                       production homepage and assert score floors (see
+#                       perf/lighthouse/lighthouserc.json). Catches regressions
+#                       k6 can't see: accessibility, render-blocking resources,
+#                       bundle bloat. A breach opens an issue, same as k6's.
 #
 # NOTE: no workflow-level `paths:` filter — a path-filtered workflow never
 # reports its check on unrelated PRs, which would leave a required check stuck
@@ -185,3 +193,28 @@ jobs:
             --title "Perf watchdog: prod page latency regression ($(date -u +%Y-%m-%d))" \
             --label performance \
             --body "The scheduled production performance smoke breached its latency/error thresholds. See the run: $RUN_URL"
+
+  lighthouse-watchdog:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run Lighthouse against production (headroom-based score floors)
+        # Score floors live in perf/lighthouse/lighthouserc.json, generous below
+        # the ~74/85/73/100 (perf/a11y/best-practices/seo) baseline observed on
+        # freehire.me — tighten as the baseline firms up, same as k6's SLOs above.
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./perf/lighthouse/lighthouserc.json
+
+      - name: Open an issue on regression
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "Lighthouse watchdog: prod score regression ($(date -u +%Y-%m-%d))" \
+            --label performance \
+            --body "The scheduled production Lighthouse run breached a category score floor. See the run: $RUN_URL"

--- a/design-system/src/badge.svelte
+++ b/design-system/src/badge.svelte
@@ -8,7 +8,7 @@
         secondary: 'border-transparent bg-secondary text-secondary-foreground',
         outline: 'border-border text-muted-foreground',
         brand: 'border-transparent bg-brand-muted text-brand-strong',
-        missing: 'border-destructive/15 bg-destructive/5 text-destructive/75',
+        missing: 'border-destructive/15 bg-destructive/5 text-destructive/90',
       },
     },
     defaultVariants: { variant: 'secondary' },

--- a/design-system/src/badge.test.ts
+++ b/design-system/src/badge.test.ts
@@ -33,7 +33,7 @@ describe('Badge', () => {
   // @source scan's business. This asserts the half that is testable; the other
   // half is CI's assertion over storybook-static, and the eye.
   it('names the destructive tint on the missing variant', () => {
-    expect(classesFor({ variant: 'missing' })).toContain('text-destructive/75');
+    expect(classesFor({ variant: 'missing' })).toContain('text-destructive/90');
   });
 
   it('lets a caller override a base class', () => {

--- a/perf/lighthouse/lighthouserc.json
+++ b/perf/lighthouse/lighthouserc.json
@@ -1,0 +1,19 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["https://freehire.me/"],
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.55 }],
+        "categories:accessibility": ["error", { "minScore": 0.8 }],
+        "categories:best-practices": ["error", { "minScore": 0.55 }],
+        "categories:seo": ["error", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/web/src/lib/components/HeaderListSearch.svelte
+++ b/web/src/lib/components/HeaderListSearch.svelte
@@ -95,13 +95,16 @@
       <button
         type="button"
         onclick={() => target?.openFilters?.()}
-        aria-label="Filters"
+        aria-label={filterTrigger.count > 0
+          ? `Filters (${filterTrigger.count} active)`
+          : 'Filters'}
         title="Filters"
         class="relative flex shrink-0 items-center text-muted-foreground transition-colors hover:text-foreground"
       >
         <SlidersHorizontal class="size-4 shrink-0" />
         {#if filterTrigger.count > 0}
           <span
+            aria-hidden="true"
             class="absolute -right-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-[10px] font-semibold leading-none text-brand-foreground"
           >
             {filterTrigger.count}

--- a/web/src/lib/components/HeaderLocationFilter.svelte
+++ b/web/src/lib/components/HeaderLocationFilter.svelte
@@ -104,6 +104,7 @@
     type="button"
     aria-haspopup="menu"
     aria-expanded={open}
+    aria-label={summary.label}
     onclick={(e) => {
       // Stop the toggle's own click from reaching the window outside-handler, which
       // would otherwise immediately re-close the just-opened popover.

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -55,16 +55,24 @@
   // hides facets that are redundant under that scope (e.g. Source on a company).
   // `sidebarTop` renders above the filter summary in the desktop sidebar (e.g. the
   // company page's facts card); the standalone /jobs list omits it.
+  //
+  // `initialParams` overrides the seed below with a param string that doesn't
+  // appear in the address bar — the homepage's first-visit default (see
+  // +page.server.ts): `initial` was searched with it, so the client must seed
+  // off the same string, not the (bare) URL, or the two would disagree and the
+  // mount effect would immediately discard the SSR page and refetch.
   let {
     initial,
     scope = {},
     excludeFacets = [],
     sidebarTop,
+    initialParams,
   }: {
     initial: Slice<Job>;
     scope?: Record<string, string>;
     excludeFacets?: string[];
     sidebarTop?: Snippet;
+    initialParams?: string;
   } = $props();
 
   // Standalone /jobs (no fixed scope) hands its text search to the header; an
@@ -74,8 +82,12 @@
   // Seed filters from the current URL so the server and the hydrated client
   // render the same filtered view. Only the standalone list persists to storage;
   // the embedded company list must not clobber the shared key. Persistence is
-  // fixed for the store's life, so the initial `standalone` is captured once.
-  const filters = new FilterStore(page.url.searchParams, untrack(() => standalone));
+  // fixed for the store's life, so the initial `standalone` and `initialParams`
+  // are captured once.
+  const filters = new FilterStore(
+    untrack(() => (initialParams != null ? new URLSearchParams(initialParams) : page.url.searchParams)),
+    untrack(() => standalone),
+  );
 
   // CV-similarity sort is offered only on the standalone feed (the company-embedded
   // list never ranks by the visitor's CV). Read off the debounced `applied` sort so

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -84,10 +84,10 @@
   // the embedded company list must not clobber the shared key. Persistence is
   // fixed for the store's life, so the initial `standalone` and `initialParams`
   // are captured once.
-  const filters = new FilterStore(
-    untrack(() => (initialParams != null ? new URLSearchParams(initialParams) : page.url.searchParams)),
-    untrack(() => standalone),
+  const seedParams = untrack(() =>
+    initialParams != null ? new URLSearchParams(initialParams) : page.url.searchParams,
   );
+  const filters = new FilterStore(seedParams, untrack(() => standalone));
 
   // CV-similarity sort is offered only on the standalone feed (the company-embedded
   // list never ranks by the visitor's CV). Read off the debounced `applied` sort so

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -92,10 +92,11 @@
     <div class={['flex shrink-0 items-center', fullBleed && 'flex-1 basis-0']}>
       <a
         href={resolve('/')}
+        aria-label="freehire"
         class="flex items-center gap-2 text-sm font-semibold tracking-tight"
       >
         <BrandMark />
-        <span class="hidden sm:inline">freehire</span>
+        <span class="hidden sm:inline" aria-hidden="true">freehire</span>
       </a>
     </div>
 

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,6 +1,5 @@
-import { redirect } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
-import { FILTERS_TOUCHED_COOKIE } from '$lib/filterStorage';
+import { FILTERS_TOUCHED_COOKIE, DEFAULT_JOB_FILTERS } from '$lib/filterStorage';
 import { defaultFilterTarget, isCrawler } from '$lib/firstVisit';
 import type { PageServerLoad } from './$types';
 
@@ -12,17 +11,21 @@ const LIMIT = 20;
 // search API reads; `searchJobs` adds pagination. Filters/sort/"load more" then
 // run client-side over the same client.
 export const load: PageServerLoad = async ({ url, fetch, cookies, request }) => {
-  // First-visit default: redirect a brand-new human on a bare homepage to the
-  // remote-worldwide slice before render, so the filtered feed is server-rendered
-  // (no flash, no post-hydration store mutation). defaultFilterTarget owns which
-  // requests are exempt (shared links, returning visitors, crawlers).
-  const target = defaultFilterTarget({
-    search: url.search,
-    touched: !!cookies.get(FILTERS_TOUCHED_COOKIE),
-    crawler: isCrawler(request.headers.get('user-agent')),
-  });
-  if (target) redirect(302, target);
+  // First-visit default: a brand-new human on a bare homepage gets the
+  // remote-worldwide slice — applied implicitly (search with its params, seed
+  // the client's filter state with the same string below) rather than via a
+  // redirect, so there's no extra round trip before the page can render.
+  // defaultFilterTarget owns which requests are exempt (shared links, returning
+  // visitors, crawlers) — a non-null result just means "use the default set";
+  // its `/?...` path isn't needed since the address bar never changes.
+  const useDefault =
+    defaultFilterTarget({
+      search: url.search,
+      touched: !!cookies.get(FILTERS_TOUCHED_COOKIE),
+      crawler: isCrawler(request.headers.get('user-agent')),
+    }) !== null;
 
-  const initial = await serverApi(fetch).searchJobs(url.searchParams, LIMIT, 0);
-  return { initial };
+  const params = useDefault ? new URLSearchParams(DEFAULT_JOB_FILTERS) : url.searchParams;
+  const initial = await serverApi(fetch).searchJobs(params, LIMIT, 0);
+  return { initial, filterParams: params.toString() };
 };

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -33,5 +33,6 @@
        hidden: the page's purpose is clear from the feed and onboarding banner, so
        the on-screen title was redundant. sr-only takes no layout space. -->
   <h1 class="sr-only">Tech jobs</h1>
-  <JobsView initial={data.initial} />
+  <h2 class="sr-only">Job listings</h2>
+  <JobsView initial={data.initial} initialParams={data.filterParams} />
 </div>


### PR DESCRIPTION
## Summary
- Fixes 5 accessibility issues flagged by a Lighthouse audit of freehire.me: missing accessible names on the header logo link and location-filter trigger, a filter-count badge whose visible text didn't match its label, a skipped h1→h3 heading level on the homepage, and low-contrast "missing skill" badge text in dark mode.
- Removes the 302 that sent a first-time visitor from `/` to `/?work_mode=remote&regions=global` (was costing ~1.6s under Lighthouse's mobile throttling). The default filter is now applied server-side to the same request and mirrored into the client's filter seed — same rendered feed, no redirect round trip.

## Test plan
- [x] `eslint` on all touched files
- [x] `svelte-check` — 0 errors
- [x] `vitest run` — `firstVisit.test.ts` and the design-system `badge.test.ts` pass
- [ ] Re-run Lighthouse against the deployed preview/prod to confirm the Accessibility and Performance score deltas