### PR TITLE
Drop redundant uint64 conversion in statfsFree

### DIFF
--- a/cmd/reindex/diskguard.go
+++ b/cmd/reindex/diskguard.go
@@ -44,5 +44,5 @@ func statfsFree(dir string) (uint64, error) {
 	}
 	// Bavail (not Bfree) is the space usable by non-root writers — what Meilisearch
 	// actually gets.
-	return uint64(st.Bavail) * uint64(st.Bsize), nil
+	return st.Bavail * uint64(st.Bsize), nil
 }


### PR DESCRIPTION
## Summary
- `syscall.Statfs_t.Bavail` is already `uint64` on both linux and darwin, so `uint64(st.Bavail)` was a no-op the `unconvert` linter flags — drop the redundant wrap. `Bsize`'s conversion stays (it's `uint32` on darwin, `int64` on linux, so genuinely needed there).

## Test plan
- [x] `gofmt -l cmd/reindex/diskguard.go` — clean
- [x] `go vet ./cmd/reindex/...`
- [x] `go test ./cmd/reindex/...`
- [x] `GOOS=linux GOARCH=amd64 go build ./cmd/reindex/...` — cross-compiles clean