### PR TITLE
Close the golangci-lint backlog (bodyclose, noctx, errcheck, staticcheck, misspell, unused, unconvert)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,24 @@ linters:
     - noctx
     - unconvert
     - misspell
+  settings:
+    errcheck:
+      # Best-effort cleanup calls whose error has no actionable recipient: a deferred
+      # Close/RemoveAll/Rollback runs after the operation it's cleaning up already
+      # succeeded or failed for its own, already-handled reason.
+      exclude-functions:
+        - (io.Closer).Close
+        - os.RemoveAll
+        - (github.com/jackc/pgx/v5.Tx).Rollback
+    misspell:
+      # Real words in other languages (board-ingest dictionaries, non-English test
+      # fixtures), not English typos.
+      ignore-rules:
+        - administrativo
+        - processos
+        - operacional
+        - indonesien
+        - profissional
 
 formatters:
   enable:

--- a/cmd/backfill-company-info/main.go
+++ b/cmd/backfill-company-info/main.go
@@ -115,7 +115,7 @@ func run() int {
 		log.Printf("open %s: %v", path, err)
 		return 1
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	stats, err := load(ctx, db.New(pool), f)
 	if err != nil {

--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -180,19 +180,16 @@ func deriveRow(j db.Job) (params db.UpdateJobDerivedParams, changed, slugMoved b
 	experience := pgconv.Int4(d.ExperienceYearsMin)
 	isTech := pgconv.Bool(d.IsTech)
 
-	facetsMoved := !(slices.Equal(d.Countries, j.Countries) &&
-		slices.Equal(d.Regions, j.Regions) &&
-		slices.Equal(d.Cities, j.Cities) &&
-		d.WorkMode == j.WorkMode &&
-		slices.Equal(d.Skills, j.Skills) &&
-		d.Seniority == j.Seniority &&
-		d.Category == j.Category &&
-		isTech == j.IsTech &&
-		d.PostingLanguage == j.PostingLanguage &&
-		d.EmploymentType == j.EmploymentType &&
-		d.EducationLevel == j.EducationLevel &&
-		d.EnglishLevel == j.EnglishLevel &&
-		experience == j.ExperienceYearsMin)
+	facetsMoved := !slices.Equal(d.Countries, j.Countries) || !slices.Equal(d.Regions, j.Regions) || !slices.Equal(d.Cities, j.Cities) ||
+		d.WorkMode != j.WorkMode || !slices.Equal(d.Skills, j.Skills) ||
+		d.Seniority != j.Seniority ||
+		d.Category != j.Category ||
+		isTech != j.IsTech ||
+		d.PostingLanguage != j.PostingLanguage ||
+		d.EmploymentType != j.EmploymentType ||
+		d.EducationLevel != j.EducationLevel ||
+		d.EnglishLevel != j.EnglishLevel ||
+		experience != j.ExperienceYearsMin
 	fingerprintMoved := fingerprint != j.RoleFingerprint.String
 	slugMoved = d.PublicSlug != j.PublicSlug || d.CompanySlug != j.CompanySlug
 

--- a/cmd/backfill-experience/main.go
+++ b/cmd/backfill-experience/main.go
@@ -218,7 +218,7 @@ func newExtractor(cfg config.Settings, queries *db.Queries) (*resumeextract.Extr
 	if cfg.PIIFilterURL == "" {
 		return nil, nil, nil
 	}
-	llmClient, flush, err := llm.NewClient(cfg.LLM.Settings(cfg.LLM.Model), "backfill-experience")
+	llmClient, flush, err := llm.NewClient(cfg.Settings(cfg.Model), "backfill-experience")
 	if err != nil || llmClient == nil {
 		return nil, nil, nil
 	}

--- a/cmd/backfill-resume-structured/main.go
+++ b/cmd/backfill-resume-structured/main.go
@@ -73,7 +73,7 @@ func run() int {
 		return 1
 	}
 
-	llmClient, llmFlush, err := llm.NewClient(cfg.LLM.Settings(cfg.LLM.Model), "resume-structured")
+	llmClient, llmFlush, err := llm.NewClient(cfg.Settings(cfg.Model), "resume-structured")
 	if err != nil {
 		log.Printf("llm: %v", err)
 		return 1

--- a/cmd/backfill-semantic-vectors/main.go
+++ b/cmd/backfill-semantic-vectors/main.go
@@ -86,7 +86,7 @@ func (s pgSink) Save(ctx context.Context, vecs []search.SemanticVector) (int64, 
 		batch.Queue(`UPDATE jobs SET semantic_embedding = $1 WHERE id = $2`, v.Vector, v.ID)
 	}
 	br := s.pool.SendBatch(ctx, batch)
-	defer br.Close()
+	defer func() { _ = br.Close() }()
 	var affected int64
 	for range vecs {
 		ct, err := br.Exec()

--- a/cmd/enrich/main.go
+++ b/cmd/enrich/main.go
@@ -31,7 +31,7 @@ func run() int {
 	// One construction path: llm.NewClient builds the client and, when LANGFUSE_* are
 	// set, wires tracing (source "enrich"). flush drains buffered traces at run end
 	// (no-op when tracing is off). LoadEnrich already required the LLM settings.
-	client, flush, err := llm.NewClient(ecfg.LLM.Settings(ecfg.LLM.Model), "enrich")
+	client, flush, err := llm.NewClient(ecfg.Settings(ecfg.Model), "enrich")
 	if err != nil {
 		log.Printf("llm: %v", err)
 		return 1

--- a/cmd/gen-cities/main.go
+++ b/cmd/gen-cities/main.go
@@ -14,6 +14,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -81,7 +82,11 @@ func run() error {
 
 func download(url string) ([]byte, error) {
 	client := &http.Client{Timeout: 2 * time.Minute}
-	resp, err := client.Get(url)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/harvest-boards/refusals_test.go
+++ b/cmd/harvest-boards/refusals_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"net/http"
 
-	"golang.org/x/net/html"
 	"testing"
+
+	"golang.org/x/net/html"
 
 	"github.com/strelov1/freehire/internal/sources"
 )

--- a/cmd/harvest-erecruiter/main.go
+++ b/cmd/harvest-erecruiter/main.go
@@ -108,7 +108,7 @@ func readInputs(path string) ([]input, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read inputs %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var out []input
 	sc := bufio.NewScanner(f)

--- a/cmd/harvest-loxo/main.go
+++ b/cmd/harvest-loxo/main.go
@@ -79,7 +79,7 @@ func readLines() ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		src = f
 	}
 	var lines []string

--- a/cmd/import-collections/main_test.go
+++ b/cmd/import-collections/main_test.go
@@ -201,7 +201,7 @@ func TestResolveOne_TreatsAZeroRecordParseAsFailure(t *testing.T) {
 	// genuinely empty register. Letting it through would reconcile the tag off every
 	// company, so it must fail like a fetch failure does.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("[]"))
+		_, _ = w.Write([]byte("[]"))
 	}))
 	defer srv.Close()
 
@@ -219,7 +219,7 @@ func TestResolveOne_FetchesFromTheDatasetResolver(t *testing.T) {
 	var fetched string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fetched = r.URL.Path
-		w.Write([]byte("payload"))
+		_, _ = w.Write([]byte("payload"))
 	}))
 	defer srv.Close()
 

--- a/cmd/liveness/himalayas.go
+++ b/cmd/liveness/himalayas.go
@@ -91,6 +91,6 @@ func fetchSitemapXML(ctx context.Context, client *http.Client, url string, v any
 	if err != nil {
 		return fmt.Errorf("gzip: %w", err)
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 	return xml.NewDecoder(gz).Decode(v)
 }

--- a/cmd/prune/retire.go
+++ b/cmd/prune/retire.go
@@ -199,7 +199,7 @@ func appendRetired(dir, name string, going []entryBlock, lines []string) error {
 	if err != nil {
 		return fmt.Errorf("prune: open %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := f.WriteString(b.String()); err != nil {
 		return fmt.Errorf("prune: append %s: %w", path, err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -85,7 +85,7 @@ func main() {
 		log.Fatalf("redis: %v", err)
 	}
 	redisClient := redis.NewClient(redisOpts)
-	defer redisClient.Close()
+	defer func() { _ = redisClient.Close() }()
 	throttler := ratelimit.NewRedisThrottler(redisClient)
 
 	app := fiber.New(fiber.Config{
@@ -175,7 +175,7 @@ func main() {
 	// shutdown. Nil client when unconfigured — the ATS score stays deterministic. A
 	// build error on a configured endpoint is fatal (a misconfigured gateway must not
 	// boot silently).
-	llmClient, llmFlush, err := llm.NewClient(cfg.LLM.Settings(cfg.LLM.Model), "cv-ats")
+	llmClient, llmFlush, err := llm.NewClient(cfg.Settings(cfg.Model), "cv-ats")
 	if err != nil {
 		log.Fatalf("llm: %v", err)
 	}
@@ -185,7 +185,7 @@ func main() {
 	// reliable tool calling and a large context, where LLM_MODEL is chosen for cheap
 	// one-shot JSON extraction. Unset falls back to LLM_MODEL, so a single-model
 	// deployment still works. Traced under its own source label.
-	assistantLLM, assistantFlush, err := llm.NewClient(cfg.LLM.Settings(cmp.Or(cfg.AssistantModel, cfg.LLM.Model)), "assistant")
+	assistantLLM, assistantFlush, err := llm.NewClient(cfg.Settings(cmp.Or(cfg.AssistantModel, cfg.Model)), "assistant")
 	if err != nil {
 		log.Fatalf("llm (assistant): %v", err)
 	}
@@ -195,14 +195,14 @@ func main() {
 	// an OpenAI-compatible endpoint serves /chat/completions and /audio/transcriptions
 	// alike — so there is nothing extra to configure and nothing extra to fail. Nil
 	// when the gateway is unset, which the composer reads as "no microphone here".
-	speechClient := speech.New(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.STTModel)
+	speechClient := speech.New(cfg.BaseURL, cfg.APIKey, cfg.STTModel)
 
 	// Voice mode's Realtime credential rides the same gateway and key as the clients
 	// above — the litellm proxy already fronts OpenAI's /v1/realtime/client_secrets
 	// the same way it fronts /audio/transcriptions, so nothing new to configure here
 	// either. Nil when the gateway or REALTIME_MODEL is unset, which the interview
 	// session view reads as "no voice mode here".
-	realtimeClient := realtime.New(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.RealtimeModel)
+	realtimeClient := realtime.New(cfg.BaseURL, cfg.APIKey, cfg.RealtimeModel)
 
 	// The gateway's administrative API, which mints the per-user credential each
 	// account's model calls are spent under. Nil when unconfigured, and that is an

--- a/internal/accounts/codes.go
+++ b/internal/accounts/codes.go
@@ -27,7 +27,7 @@ const (
 	// maxCodeAttempts is how many wrong guesses a code survives. Six digits is a million
 	// possibilities; five tries makes online guessing hopeless without frustrating a human
 	// who mistyped. It bounds the guessing rate only together with resendCooldown, which is
-	// why a burnt code keeps its row (see consumeCode).
+	// why a burnt code keeps its row (see consumeCodeTx).
 	maxCodeAttempts = 5
 
 	// resendCooldown keeps the endpoint from being used to flood an address with mail.
@@ -172,29 +172,6 @@ func (s *Service) consumeCodeTx(ctx context.Context, store CodeStore, userID int
 		return ErrInvalidCode
 	}
 	return store.DeleteCode(ctx, userID, purpose)
-}
-
-// consumeCode checks a presented code against the outstanding one and, on success, deletes
-// it so it cannot be replayed. It wraps consumeCodeTx in a transaction.
-func (s *Service) consumeCode(ctx context.Context, userID int64, purpose, presented string) error {
-	tx, err := s.codes.Begin(ctx)
-	if err != nil {
-		return err
-	}
-	if tx != nil {
-		defer func() { _ = tx.Rollback(ctx) }()
-	}
-	store := s.codes.WithTx(tx)
-
-	consumeErr := s.consumeCodeTx(ctx, store, userID, purpose, presented)
-	if tx != nil {
-		if errors.Is(consumeErr, ErrInvalidCode) || consumeErr == nil {
-			if commitErr := tx.Commit(ctx); commitErr != nil && consumeErr == nil {
-				return commitErr
-			}
-		}
-	}
-	return consumeErr
 }
 
 // IssueVerificationCode mails a fresh email-verification code to the account's address.

--- a/internal/assistant/store_test.go
+++ b/internal/assistant/store_test.go
@@ -13,11 +13,8 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 )
 
-// Fixed ids so a failure names a stable value rather than a fresh random one.
-var (
-	sessionID = uuid.MustParse("11111111-1111-4111-8111-111111111111")
-	otherID   = uuid.MustParse("22222222-2222-4222-8222-222222222222")
-)
+// sessionID is a fixed id so a failure names a stable value rather than a fresh random one.
+var sessionID = uuid.MustParse("11111111-1111-4111-8111-111111111111")
 
 // fakeQueries is an in-memory stand-in for the generated queries, holding one
 // session and its transcript. It records what it was asked for so the tests can

--- a/internal/atsboard/board.go
+++ b/internal/atsboard/board.go
@@ -199,11 +199,12 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		if platformHost(host) {
 			return "", "", "", false
 		}
-		if mode == modeSubdomain {
+		switch mode {
+		case modeSubdomain:
 			board = subdomainLabel(host, apex)
-		} else if mode == modeSubdomainChain {
+		case modeSubdomainChain:
 			board = subdomainChain(host, apex)
-		} else {
+		default:
 			board = host // the whole careers host is the tenant identity
 		}
 		if board == "" {

--- a/internal/auth/apikey_test.go
+++ b/internal/auth/apikey_test.go
@@ -55,7 +55,7 @@ func TestGenerateAPIKey_Unique(t *testing.T) {
 
 func TestHashAPIKey_Deterministic(t *testing.T) {
 	const token = "fhk_example-token"
-	if HashAPIKey(token) != HashAPIKey(token) {
+	if HashAPIKey(token) != HashAPIKey(token) { //nolint:staticcheck // SA4000: intentional determinism check, calling twice is the point
 		t.Error("HashAPIKey is not deterministic for the same input")
 	}
 	if HashAPIKey("fhk_a") == HashAPIKey("fhk_b") {

--- a/internal/auth/bearertoken_test.go
+++ b/internal/auth/bearertoken_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -27,13 +28,15 @@ func TestBearerToken(t *testing.T) {
 				got = bearerToken(c)
 				return c.SendStatus(fiber.StatusOK)
 			})
-			req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/", nil)
 			if tc.header != "" {
 				req.Header.Set(fiber.HeaderAuthorization, tc.header)
 			}
-			if _, err := app.Test(req); err != nil {
+			resp, err := app.Test(req)
+			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if got != tc.want {
 				t.Errorf("bearerToken(%q) = %q, want %q", tc.header, got, tc.want)
 			}

--- a/internal/auth/cookie_test.go
+++ b/internal/auth/cookie_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -18,10 +19,11 @@ func setCookieHeader(t *testing.T, domain string) string {
 		SetTokenCookie(c, "tok", time.Hour, true, domain)
 		return c.SendStatus(fiber.StatusOK)
 	})
-	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/", nil))
 	if err != nil {
 		t.Fatalf("test request failed: %v", err)
 	}
+	defer resp.Body.Close()
 	return resp.Header.Get("Set-Cookie")
 }
 
@@ -55,10 +57,11 @@ func clearCookieHeaders(t *testing.T, domain string) []string {
 		ClearTokenCookie(c, true, domain)
 		return c.SendStatus(fiber.StatusNoContent)
 	})
-	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/", nil))
 	if err != nil {
 		t.Fatalf("test request failed: %v", err)
 	}
+	defer resp.Body.Close()
 	return resp.Header.Values("Set-Cookie")
 }
 

--- a/internal/auth/deleteduser_test.go
+++ b/internal/auth/deleteduser_test.go
@@ -38,6 +38,7 @@ func TestRequireAuth_RejectsTokenForDeletedAccount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("status for a deleted account = %d, want 401", resp.StatusCode)
 	}
@@ -58,6 +59,7 @@ func TestRequireAuthOrKey_RejectsCookieForDeletedAccount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("status for a deleted account's cookie = %d, want 401", resp.StatusCode)
 	}

--- a/internal/auth/keyscope_test.go
+++ b/internal/auth/keyscope_test.go
@@ -47,7 +47,7 @@ func scopeApp(mw fiber.Handler) *fiber.App {
 }
 
 func keyRequest(token string) *http.Request {
-	req := httptest.NewRequest(fiber.MethodGet, "/probe", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	return req
 }
@@ -61,6 +61,7 @@ func TestRequireAuthOrKey_RejectsNarrowScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusForbidden {
 		t.Errorf("status = %d, want 403 — a cv-scoped key must not reach a full-scope route", resp.StatusCode)
 	}
@@ -75,6 +76,7 @@ func TestRequireAuthOrKey_AcceptsFullScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200 for a full-scope key", resp.StatusCode)
 	}
@@ -91,6 +93,7 @@ func TestRequireAuthOrScopedKey_AdmitsBothScopes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusOK {
 				t.Errorf("status = %d, want 200 — the CV surface admits %s keys", resp.StatusCode, scope)
 			}
@@ -106,6 +109,7 @@ func TestRequireAuthOrScopedKey_StillRejectsUnknownKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 — an unknown key is unauthenticated, not under-scoped", resp.StatusCode)
 	}
@@ -118,12 +122,13 @@ func TestKeyScope_EmptyForCookieAuth(t *testing.T) {
 		t.Fatalf("Issue: %v", err)
 	}
 
-	req := httptest.NewRequest(fiber.MethodGet, "/probe", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 	resp, err := scopeApp(RequireAuthOrScopedKey(iss, anyVersion{1}, fakeScopedKeys{}, ScopeCV)).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200 for a cookie session", resp.StatusCode)
 	}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -34,13 +34,14 @@ func TestRequireAuth_ValidTokenGrantsAccessAndPropagatesID(t *testing.T) {
 		t.Fatalf("Issue: %v", err)
 	}
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 
 	resp, err := protectedApp(iss).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -72,7 +73,7 @@ func TestRequireAuth_RejectsUnauthorized(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 			if tc.token != "" {
 				req.AddCookie(&http.Cookie{Name: CookieName, Value: tc.token})
 			}
@@ -80,6 +81,7 @@ func TestRequireAuth_RejectsUnauthorized(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusUnauthorized {
 				t.Errorf("status = %d, want 401", resp.StatusCode)
 			}
@@ -102,13 +104,14 @@ func TestRequireAuth_DBInfraErrorReturns503(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503 on DB infra error", resp.StatusCode)
 	}
@@ -124,13 +127,14 @@ func TestOptionalCookieAuth_DBInfraErrorDegradesToGuest(t *testing.T) {
 		return c.JSON(fiber.Map{"authed": ok})
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/public", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/public", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -156,13 +160,14 @@ func TestOptionalAuth_DBInfraErrorDegradesCookieToGuest(t *testing.T) {
 		return c.JSON(fiber.Map{"authed": ok})
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/feed", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/feed", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -187,13 +192,14 @@ func TestOptionalAuth_DBInfraErrorOnAPIKeyReturns503(t *testing.T) {
 		return c.JSON(fiber.Map{"authed": ok})
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/feed", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/feed", nil)
 	req.Header.Set("Authorization", "Bearer fhk_somekey")
 
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503 on API key DB infra error for OptionalAuth", resp.StatusCode)
 	}
@@ -208,13 +214,14 @@ func TestRequireAuthOrKey_DBInfraErrorOnCookieReturns503(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/protected", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/protected", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503 on cookie DB infra error for RequireAuthOrKey", resp.StatusCode)
 	}
@@ -229,13 +236,14 @@ func TestRequireAuthWS_DBInfraErrorReturns503(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/ws", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/ws", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503 on DB infra error for RequireAuthWS", resp.StatusCode)
 	}
@@ -250,13 +258,14 @@ func TestRequireAuth_DBTimeout(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/protected", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/protected", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503 on context timeout for RequireAuth", resp.StatusCode)
 	}
@@ -279,11 +288,12 @@ func TestRequireRole_DBDown(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/admin", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/admin", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503 on role loader DB outage for RequireRole", resp.StatusCode)
 	}

--- a/internal/auth/oauth/apple_test.go
+++ b/internal/auth/oauth/apple_test.go
@@ -43,7 +43,7 @@ func stubAppleJWKS(t *testing.T, kid string, key *rsa.PrivateKey) *httptest.Serv
 					"kid": kid,
 					"use": "sig",
 					"alg": "RS256",
-					"n":   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+					"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
 					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
 				},
 			},
@@ -307,7 +307,7 @@ func stubApple(t *testing.T, key *rsa.PrivateKey, kid string, idTokenClaims appl
 				{
 					"kty": "RSA",
 					"kid": kid,
-					"n":   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+					"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
 					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
 				},
 			},

--- a/internal/auth/oauth/state_test.go
+++ b/internal/auth/oauth/state_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -64,10 +65,11 @@ func TestStateCookie_SetAndClear(t *testing.T) {
 		return nil
 	})
 
-	resp, err := app.Test(httptest.NewRequest("GET", "/set", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/set", nil))
 	if err != nil {
 		t.Fatalf("set: %v", err)
 	}
+	defer resp.Body.Close()
 	set := resp.Header.Get("Set-Cookie")
 	for _, want := range []string{StateCookieName + "=abc", "HttpOnly", "SameSite=Lax"} {
 		if !strings.Contains(set, want) {
@@ -75,10 +77,11 @@ func TestStateCookie_SetAndClear(t *testing.T) {
 		}
 	}
 
-	resp, err = app.Test(httptest.NewRequest("GET", "/clear", nil))
+	resp, err = app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/clear", nil))
 	if err != nil {
 		t.Fatalf("clear: %v", err)
 	}
+	defer resp.Body.Close()
 	cleared := resp.Header.Get("Set-Cookie")
 	if !strings.Contains(cleared, StateCookieName+"=") {
 		t.Errorf("clear cookie %q does not clear %s", cleared, StateCookieName)
@@ -100,10 +103,11 @@ func TestStateCookie_SameSiteNoneWhenSecure(t *testing.T) {
 		return nil
 	})
 
-	resp, err := app.Test(httptest.NewRequest("GET", "/set", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/set", nil))
 	if err != nil {
 		t.Fatalf("set: %v", err)
 	}
+	defer resp.Body.Close()
 	set := resp.Header.Get("Set-Cookie")
 	for _, want := range []string{StateCookieName + "=abc", "HttpOnly", "secure", "SameSite=None"} {
 		if !strings.Contains(set, want) {

--- a/internal/auth/recentauth/cookie_test.go
+++ b/internal/auth/recentauth/cookie_test.go
@@ -1,6 +1,7 @@
 package recentauth
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -15,7 +16,7 @@ func TestRecentAuthCookieAttributes(t *testing.T) {
 		SetCookie(c, "proof", time.Now().Add(time.Minute), true, "freehire.me")
 		return c.SendStatus(204)
 	})
-	resp, err := app.Test(httptest.NewRequest("GET", "/set", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/set", nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +35,7 @@ func TestClearRecentAuthCookieExpiresSameName(t *testing.T) {
 		ClearCookie(c, false, "")
 		return c.SendStatus(204)
 	})
-	resp, err := app.Test(httptest.NewRequest("GET", "/clear", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/clear", nil))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/auth/requireauthorkey_test.go
+++ b/internal/auth/requireauthorkey_test.go
@@ -68,13 +68,14 @@ func TestRequireAuthOrKey_ValidKeyAuthenticates(t *testing.T) {
 	const token = "fhk_test-key"
 	keys := fakeKeyAuth{validHash: HashAPIKey(token), userID: 9}
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := dualAuthApp(iss, keys).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -99,12 +100,13 @@ func TestRequireAuthOrKey_FlagsKeyAuth(t *testing.T) {
 	const token = "fhk_test-key"
 	keys := fakeKeyAuth{validHash: HashAPIKey(token), userID: 9}
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := dualAuthApp(iss, keys).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if !decodeViaKey(t, resp) {
 		t.Error("ViaAPIKey should be true for key auth")
 	}
@@ -114,12 +116,13 @@ func TestRequireAuthOrKey_CookieIsNotViaKey(t *testing.T) {
 	iss := NewIssuer("secret", time.Hour)
 	token, _ := iss.Issue(7, 1)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 	resp, err := dualAuthApp(iss, fakeKeyAuth{}).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if decodeViaKey(t, resp) {
 		t.Error("ViaAPIKey should be false for cookie auth")
 	}
@@ -130,13 +133,14 @@ func TestRequireAuthOrKey_ValidCookieAuthenticates(t *testing.T) {
 	keys := fakeKeyAuth{} // no valid key; the cookie must carry the identity
 	token, _ := iss.Issue(7, 1)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 
 	resp, err := dualAuthApp(iss, keys).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -151,7 +155,7 @@ func TestRequireAuthOrKey_CookieTakesPrecedenceOverKey(t *testing.T) {
 	keys := fakeKeyAuth{validHash: HashAPIKey(token), userID: 9}
 	cookie, _ := iss.Issue(7, 1)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: cookie})
 	req.Header.Set("Authorization", "Bearer "+token)
 
@@ -159,6 +163,7 @@ func TestRequireAuthOrKey_CookieTakesPrecedenceOverKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if id := decodeID(t, resp); id != 7 {
 		t.Errorf("handler saw user id %d, want 7 (a valid cookie should win)", id)
 	}
@@ -169,7 +174,7 @@ func TestRequireAuthOrKey_InvalidCookieFallsThroughToKey(t *testing.T) {
 	const token = "fhk_test-key"
 	keys := fakeKeyAuth{validHash: HashAPIKey(token), userID: 9}
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: "not-a-jwt"})
 	req.Header.Set("Authorization", "Bearer "+token)
 
@@ -177,6 +182,7 @@ func TestRequireAuthOrKey_InvalidCookieFallsThroughToKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -190,13 +196,14 @@ func TestRequireAuthOrKey_JWTBearerAuthenticatesAsSession(t *testing.T) {
 	token, _ := iss.Issue(42, 1) // a session JWT presented as a Bearer header
 	keys := fakeKeyAuth{}        // no valid API key — the JWT must carry the identity
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := dualAuthApp(iss, keys).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -219,13 +226,14 @@ func TestRequireAuthOrKey_KeyLookupErrorIsNot401(t *testing.T) {
 	iss := NewIssuer("secret", time.Hour)
 	keys := errKeyAuth{err: errors.New("connection refused")}
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 	req.Header.Set("Authorization", "Bearer fhk_whatever")
 
 	resp, err := dualAuthApp(iss, keys).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503 (a lookup outage must surface as 503)", resp.StatusCode)
 	}
@@ -243,7 +251,7 @@ func TestOptionalAuth_KeyLookupErrorPropagates(t *testing.T) {
 		return app
 	}
 	newReq := func() *http.Request {
-		req := httptest.NewRequest(fiber.MethodGet, "/job", nil)
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/job", nil)
 		req.Header.Set("Authorization", "Bearer fhk_whatever")
 		return req
 	}
@@ -253,6 +261,7 @@ func TestOptionalAuth_KeyLookupErrorPropagates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("unknown key: status = %d, want 200", resp.StatusCode)
 	}
@@ -262,6 +271,7 @@ func TestOptionalAuth_KeyLookupErrorPropagates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("outage: status = %d, want 503", resp.StatusCode)
 	}
@@ -284,7 +294,7 @@ func TestRequireAuthOrKey_RejectsUnauthorized(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(fiber.MethodGet, "/me", nil)
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
 			if tc.cookie != "" {
 				req.AddCookie(&http.Cookie{Name: CookieName, Value: tc.cookie})
 			}
@@ -295,6 +305,7 @@ func TestRequireAuthOrKey_RejectsUnauthorized(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusUnauthorized {
 				t.Errorf("status = %d, want 401", resp.StatusCode)
 			}

--- a/internal/auth/requirerole_test.go
+++ b/internal/auth/requirerole_test.go
@@ -40,10 +40,11 @@ func roleApp(loader RoleLoader, role string, inject bool) *fiber.App {
 
 func statusOf(t *testing.T, app *fiber.App) int {
 	t.Helper()
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/admin", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/admin", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	return resp.StatusCode
 }
 

--- a/internal/auth/tokenversion_test.go
+++ b/internal/auth/tokenversion_test.go
@@ -80,7 +80,7 @@ func versionedApp(iss *Issuer, versions TokenVersionLoader) *fiber.App {
 }
 
 func cookieRequest(token string) *http.Request {
-	req := httptest.NewRequest(fiber.MethodGet, "/protected", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/protected", nil)
 	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
 	return req
 }
@@ -96,6 +96,7 @@ func TestRequireAuth_AcceptsCurrentVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200 for a current token", resp.StatusCode)
 	}
@@ -113,6 +114,7 @@ func TestRequireAuth_RejectsRevokedVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 for a revoked token", resp.StatusCode)
 	}
@@ -130,6 +132,7 @@ func TestRequireAuth_RejectsUnknownAccount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 when the account's version cannot be loaded", resp.StatusCode)
 	}
@@ -143,6 +146,7 @@ func TestRequireAuth_RejectsLegacyToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 — a pre-versioning token must not survive the deploy", resp.StatusCode)
 	}

--- a/internal/auth/ws_outage_test.go
+++ b/internal/auth/ws_outage_test.go
@@ -76,7 +76,7 @@ func TestRequireAuthWS_DBOutage_Clean503Response(t *testing.T) {
 			})
 
 			// Simulate a full WebSocket opening handshake request (RFC 6455)
-			req := httptest.NewRequest(fiber.MethodGet, "/tools/ws", nil)
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/tools/ws", nil)
 			req.Header.Set("Connection", "Upgrade")
 			req.Header.Set("Upgrade", "websocket")
 			req.Header.Set("Sec-WebSocket-Version", "13")
@@ -131,13 +131,14 @@ func TestRequireAuthWS_ScopedKeyRejection(t *testing.T) {
 			return c.SendString("ok")
 		})
 
-		req := httptest.NewRequest(fiber.MethodGet, "/tools/ws", nil)
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/tools/ws", nil)
 		req.Header.Set(fiber.HeaderAuthorization, "Bearer fh_live_cvkey")
 
 		resp, err := app.Test(req)
 		if err != nil {
 			t.Fatalf("Test: %v", err)
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != fiber.StatusForbidden {
 			t.Errorf("status = %d, want 403 for CV scope key", resp.StatusCode)
 		}
@@ -159,13 +160,14 @@ func TestRequireAuthWS_ScopedKeyRejection(t *testing.T) {
 			return c.SendString("ok")
 		})
 
-		req := httptest.NewRequest(fiber.MethodGet, "/tools/ws", nil)
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/tools/ws", nil)
 		req.Header.Set(fiber.HeaderAuthorization, "Bearer fh_live_fullkey")
 
 		resp, err := app.Test(req)
 		if err != nil {
 			t.Fatalf("Test: %v", err)
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != fiber.StatusOK {
 			t.Errorf("status = %d, want 200 for full scope key", resp.StatusCode)
 		}
@@ -256,7 +258,7 @@ func TestRequireAuthWS_ConcurrentStress(t *testing.T) {
 				}
 
 				// Choose carrier: JWT or API Key
-				req := httptest.NewRequest(fiber.MethodGet, "/tools/ws", nil)
+				req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/tools/ws", nil)
 				if i%2 == 0 {
 					req.Header.Set("Sec-WebSocket-Protocol", WSSubprotocolMarker+", "+jwtToken)
 				} else {

--- a/internal/auth/ws_test.go
+++ b/internal/auth/ws_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
@@ -35,13 +36,14 @@ func TestRequireAuthWS_AcceptsAnAPIKey(t *testing.T) {
 		{"subprotocol", "Sec-WebSocket-Protocol", WSSubprotocolMarker + ", " + key},
 	} {
 		t.Run(carrier.name, func(t *testing.T) {
-			req := httptest.NewRequest(fiber.MethodGet, "/tools/ws", nil)
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/tools/ws", nil)
 			req.Header.Set(carrier.header, carrier.value)
 
 			resp, err := wsApp(NewIssuer("secret", time.Hour), keys).Test(req)
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusOK {
 				t.Fatalf("status = %d, want 200", resp.StatusCode)
 			}
@@ -60,13 +62,14 @@ func TestRequireAuthWS_AcceptsAnAPIKey(t *testing.T) {
 
 func TestRequireAuthWS_RefusesAnUnknownKey(t *testing.T) {
 	keys := fakeKeyAuth{validHash: HashAPIKey("fh_live_good"), userID: 9}
-	req := httptest.NewRequest(fiber.MethodGet, "/tools/ws", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/tools/ws", nil)
 	req.Header.Set(fiber.HeaderAuthorization, "Bearer fh_live_revoked")
 
 	resp, err := wsApp(NewIssuer("secret", time.Hour), keys).Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", resp.StatusCode)
 	}
@@ -106,13 +109,14 @@ func TestRequireAuthWS_AcceptsTheJWTFromEitherCarrier(t *testing.T) {
 		{"harness bearer", fiber.HeaderAuthorization, "Bearer " + token},
 	} {
 		t.Run(carrier.name, func(t *testing.T) {
-			req := httptest.NewRequest(fiber.MethodGet, "/tools/ws", nil)
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/tools/ws", nil)
 			req.Header.Set(carrier.header, carrier.value)
 
 			resp, err := wsApp(iss).Test(req)
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusOK {
 				t.Fatalf("status = %d, want 200", resp.StatusCode)
 			}
@@ -133,7 +137,7 @@ func TestRequireAuthWS_RefusesAnUnauthenticatedHandshake(t *testing.T) {
 		{"token from another secret", "Sec-WebSocket-Protocol", WSSubprotocolMarker + ", " + otherSecret},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(fiber.MethodGet, "/tools/ws", nil)
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/tools/ws", nil)
 			if tt.header != "" {
 				req.Header.Set(tt.header, tt.value)
 			}
@@ -142,6 +146,7 @@ func TestRequireAuthWS_RefusesAnUnauthenticatedHandshake(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusUnauthorized {
 				t.Fatalf("status = %d, want 401", resp.StatusCode)
 			}

--- a/internal/collections/speedrun_test.go
+++ b/internal/collections/speedrun_test.go
@@ -85,8 +85,8 @@ func TestFetchSpeedrunDirectory_ReadsEveryPage(t *testing.T) {
 			page = "0"
 		}
 		var n int
-		fmt.Sscanf(page, "%d", &n)
-		fmt.Fprint(w, directoryPage(n, totalPages))
+		_, _ = fmt.Sscanf(page, "%d", &n)
+		_, _ = fmt.Fprint(w, directoryPage(n, totalPages))
 	}))
 	defer srv.Close()
 
@@ -117,7 +117,7 @@ func TestSpeedrunMembers_AMarketTierCompanyEarnsNoA16zTag(t *testing.T) {
 	],"total_pages":1}`
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, mixed)
+		_, _ = fmt.Fprint(w, mixed)
 	}))
 	defer srv.Close()
 
@@ -145,7 +145,7 @@ func TestFetchSpeedrunDirectory_NamesItselfInTheUserAgent(t *testing.T) {
 	var got string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got = r.Header.Get("User-Agent")
-		fmt.Fprint(w, directoryPage(0, 1))
+		_, _ = fmt.Fprint(w, directoryPage(0, 1))
 	}))
 	defer srv.Close()
 
@@ -168,7 +168,7 @@ func TestFetchSpeedrunDirectory_AMidWalkFailureIsAnError(t *testing.T) {
 			w.WriteHeader(http.StatusBadGateway)
 			return
 		}
-		fmt.Fprint(w, directoryPage(0, 4))
+		_, _ = fmt.Fprint(w, directoryPage(0, 4))
 	}))
 	defer srv.Close()
 

--- a/internal/collections/uksponsor_test.go
+++ b/internal/collections/uksponsor_test.go
@@ -79,7 +79,7 @@ func TestResolveUKSponsorCSV_PrefersTheContentAPI(t *testing.T) {
 	var paths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
-		w.Write([]byte(contentAPIPayload))
+		_, _ = w.Write([]byte(contentAPIPayload))
 	}))
 	defer srv.Close()
 
@@ -101,8 +101,8 @@ func TestResolveUKSponsorCSV_FallsBackToTheHTMLPage(t *testing.T) {
 		api  func(http.ResponseWriter)
 	}{
 		{"api errors", func(w http.ResponseWriter) { w.WriteHeader(http.StatusInternalServerError) }},
-		{"api returns non-json", func(w http.ResponseWriter) { w.Write([]byte("<html>nope</html>")) }},
-		{"api omits the attachment", func(w http.ResponseWriter) { w.Write([]byte(`{"details":{"attachments":[]}}`)) }},
+		{"api returns non-json", func(w http.ResponseWriter) { _, _ = w.Write([]byte("<html>nope</html>")) }},
+		{"api omits the attachment", func(w http.ResponseWriter) { _, _ = w.Write([]byte(`{"details":{"attachments":[]}}`)) }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -111,7 +111,7 @@ func TestResolveUKSponsorCSV_FallsBackToTheHTMLPage(t *testing.T) {
 					tc.api(w)
 					return
 				}
-				w.Write([]byte(`<a href="` + testCSVURL + `">Register of Worker and Temporary Worker licensed sponsors</a>`))
+				_, _ = w.Write([]byte(`<a href="` + testCSVURL + `">Register of Worker and Temporary Worker licensed sponsors</a>`))
 			}))
 			defer srv.Close()
 

--- a/internal/collections/ush1bsponsor_test.go
+++ b/internal/collections/ush1bsponsor_test.go
@@ -150,12 +150,12 @@ func TestFetchUSH1BSponsors_CombinesAllFiveYears(t *testing.T) {
 		for _, y := range years {
 			b.WriteString(`<a href="/sites/default/files/document/data/h1b_datahubexport-` + y + `.csv">FY ` + y + ` H-1B Employer Data</a>`)
 		}
-		w.Write([]byte(b.String()))
+		_, _ = w.Write([]byte(b.String()))
 	})
 	for _, y := range years {
 		y := y
 		mux.HandleFunc("/sites/default/files/document/data/h1b_datahubexport-"+y+".csv", func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("\"Fiscal Year\",Employer,\"Initial Approval\",\"Initial Denial\",\"Continuing Approval\",\"Continuing Denial\",NAICS,\"Tax ID\",State,City,ZIP\n" +
+			_, _ = w.Write([]byte("\"Fiscal Year\",Employer,\"Initial Approval\",\"Initial Denial\",\"Continuing Approval\",\"Continuing Denial\",NAICS,\"Tax ID\",State,City,ZIP\n" +
 				y + `,"ACME ROBOTICS INC",1,0,0,0,54,1234,CA,SAN JOSE,95110` + "\n"))
 		})
 	}
@@ -200,14 +200,14 @@ func TestFetchUSH1BSponsors_SendsABrowserUserAgent(t *testing.T) {
 			for _, y := range years {
 				b.WriteString(`<a href="/sites/default/files/document/data/h1b_datahubexport-` + y + `.csv">FY ` + y + ` H-1B Employer Data</a>`)
 			}
-			w.Write([]byte(b.String()))
+			_, _ = w.Write([]byte(b.String()))
 		})
 	})
 	for _, y := range years {
 		y := y
 		mux.HandleFunc("/sites/default/files/document/data/h1b_datahubexport-"+y+".csv", func(w http.ResponseWriter, r *http.Request) {
 			requireUA(w, r, func() {
-				w.Write([]byte("\"Fiscal Year\",Employer,\"Initial Approval\",\"Initial Denial\",\"Continuing Approval\",\"Continuing Denial\",NAICS,\"Tax ID\",State,City,ZIP\n" +
+				_, _ = w.Write([]byte("\"Fiscal Year\",Employer,\"Initial Approval\",\"Initial Denial\",\"Continuing Approval\",\"Continuing Denial\",NAICS,\"Tax ID\",State,City,ZIP\n" +
 					y + `,"ACME ROBOTICS INC",1,0,0,0,54,1234,CA,SAN JOSE,95110` + "\n"))
 			})
 		})
@@ -228,7 +228,7 @@ func TestFetchUSH1BSponsors_FailsWholeCallWhenOneYearIsUnreachable(t *testing.T)
 		for _, y := range years {
 			b.WriteString(`<a href="/sites/default/files/document/data/h1b_datahubexport-` + y + `.csv">FY ` + y + ` H-1B Employer Data</a>`)
 		}
-		w.Write([]byte(b.String()))
+		_, _ = w.Write([]byte(b.String()))
 	})
 	for _, y := range years {
 		y := y
@@ -237,7 +237,7 @@ func TestFetchUSH1BSponsors_FailsWholeCallWhenOneYearIsUnreachable(t *testing.T)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			w.Write([]byte("\"Fiscal Year\",Employer,\"Initial Approval\",\"Initial Denial\",\"Continuing Approval\",\"Continuing Denial\",NAICS,\"Tax ID\",State,City,ZIP\n" +
+			_, _ = w.Write([]byte("\"Fiscal Year\",Employer,\"Initial Approval\",\"Initial Denial\",\"Continuing Approval\",\"Continuing Denial\",NAICS,\"Tax ID\",State,City,ZIP\n" +
 				y + `,"ACME ROBOTICS INC",1,0,0,0,54,1234,CA,SAN JOSE,95110` + "\n"))
 		})
 	}
@@ -252,7 +252,7 @@ func TestFetchUSH1BSponsors_FailsWholeCallWhenOneYearIsUnreachable(t *testing.T)
 func TestFetchUSH1BSponsors_FailsWholeCallWhenFewerThanFiveYearsAreListed(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/archive/h-1b-employer-data-hub-files", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`<a href="/sites/default/files/document/data/h1b_datahubexport-2023.csv">FY 2023 H-1B Employer Data</a>`))
+		_, _ = w.Write([]byte(`<a href="/sites/default/files/document/data/h1b_datahubexport-2023.csv">FY 2023 H-1B Employer Data</a>`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -401,7 +401,7 @@ func (s Settings) Validate() error {
 	}
 	appleWeb := s.OAuth["apple"]
 	appleFields := []bool{s.AppleNativeClientID != "", s.AppleGrantActiveKeyID != "", len(s.AppleGrantKeys) != 0}
-	partialApple := (appleFields[0] || appleFields[1] || appleFields[2]) && !(appleFields[0] && appleFields[1] && appleFields[2])
+	partialApple := (appleFields[0] || appleFields[1] || appleFields[2]) && (!appleFields[0] || !appleFields[1] || !appleFields[2])
 	if partialApple {
 		return errors.New("native Apple requires APPLE_NATIVE_CLIENT_ID, APPLE_GRANT_ACTIVE_KEY_ID, and APPLE_GRANT_KEYS")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,8 +15,8 @@ func TestLoad_LLMFromEnv(t *testing.T) {
 	t.Setenv("LLM_MODEL", "some-model")
 
 	s := Load()
-	if s.LLM.BaseURL != "https://gw.example/v1" || s.LLM.APIKey != "key-123" || s.LLM.Model != "some-model" {
-		t.Errorf("LLM settings = %q/%q/%q, want the env values", s.LLM.BaseURL, s.LLM.APIKey, s.LLM.Model)
+	if s.BaseURL != "https://gw.example/v1" || s.APIKey != "key-123" || s.Model != "some-model" {
+		t.Errorf("LLM settings = %q/%q/%q, want the env values", s.BaseURL, s.APIKey, s.Model)
 	}
 }
 
@@ -238,8 +238,8 @@ func TestLoad_LLMEmptyWhenUnset(t *testing.T) {
 	t.Setenv("LLM_MODEL", "")
 
 	s := Load()
-	if s.LLM.BaseURL != "" || s.LLM.APIKey != "" || s.LLM.Model != "" {
-		t.Errorf("LLM settings should be empty when unset, got %q/%q/%q", s.LLM.BaseURL, s.LLM.APIKey, s.LLM.Model)
+	if s.BaseURL != "" || s.APIKey != "" || s.Model != "" {
+		t.Errorf("LLM settings should be empty when unset, got %q/%q/%q", s.BaseURL, s.APIKey, s.Model)
 	}
 }
 

--- a/internal/config/enrich_test.go
+++ b/internal/config/enrich_test.go
@@ -57,7 +57,7 @@ func TestLoadEnrich_langfuseIsOptionalAndCarriedThrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnrich with no Langfuse vars: %v", err)
 	}
-	if got.LLM.LangfuseBaseURL != "" || got.LLM.LangfusePublicKey != "" || got.LLM.LangfuseSecretKey != "" {
+	if got.LangfuseBaseURL != "" || got.LangfusePublicKey != "" || got.LangfuseSecretKey != "" {
 		t.Errorf("Langfuse fields = %+v, want empty", got.LLM)
 	}
 
@@ -74,8 +74,8 @@ func TestLoadEnrich_langfuseIsOptionalAndCarriedThrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnrich: %v", err)
 	}
-	if got.LLM.LangfuseBaseURL != "https://us.cloud.langfuse.com" ||
-		got.LLM.LangfusePublicKey != "pk-lf-x" || got.LLM.LangfuseSecretKey != "sk-lf-y" {
+	if got.LangfuseBaseURL != "https://us.cloud.langfuse.com" ||
+		got.LangfusePublicKey != "pk-lf-x" || got.LangfuseSecretKey != "sk-lf-y" {
 		t.Errorf("Langfuse fields not populated: %+v", got)
 	}
 }
@@ -89,7 +89,7 @@ func TestLoadEnrich_defaultsAndOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnrich: %v", err)
 	}
-	if got.LLM.BaseURL != "http://gateway:4000/v1" || got.LLM.Model != "qwen2.5-72b" {
+	if got.BaseURL != "http://gateway:4000/v1" || got.Model != "qwen2.5-72b" {
 		t.Errorf("unexpected config: %+v", got)
 	}
 	// Tunables fall back to conservative defaults.

--- a/internal/config/llm_test.go
+++ b/internal/config/llm_test.go
@@ -46,7 +46,7 @@ func TestLoadLeavesTheLLMUnvalidated(t *testing.T) {
 	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
 
 	s := Load()
-	if s.LLM.BaseURL != "" || s.LLM.Model != "" {
+	if s.BaseURL != "" || s.Model != "" {
 		t.Errorf("LLM = %+v, want empty", s.LLM)
 	}
 }

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"

--- a/internal/cvedit/editor.go
+++ b/internal/cvedit/editor.go
@@ -189,7 +189,7 @@ func (e *Editor) commit(ctx context.Context, tx Tx, cvID uuid.UUID, userID int64
 	// Sanitize after applying and before storing, exactly as the whole-document path always
 	// has: a change states what was asked for, and the sanitizer decides what is kept.
 	after := applied
-	after.Document.Sanitize()
+	after.Sanitize()
 
 	// Sanitize used to silently keep the first MaxBullets and drop the rest. An
 	// agent insert into a full list then looked like a successful "add" while
@@ -359,7 +359,7 @@ func (e *Editor) CommitDocument(ctx context.Context, cvID uuid.UUID, userID int6
 		// Sanitize the incoming state first, so the diff is against what would be stored
 		// rather than against what was sent — otherwise a value the sanitizer clamps would
 		// show up as an edit on every save.
-		next.Document.Sanitize()
+		next.Sanitize()
 
 		ops := Diff(before, next)
 		if len(ops) == 0 {

--- a/internal/cvedit/listcap.go
+++ b/internal/cvedit/listcap.go
@@ -25,12 +25,12 @@ const ListCapCode = "bullet_cap"
 // shifts later roles and looks like bullet loss.
 // Dropping whitespace-only bullets is allowed — that is cleanup, not content loss.
 func refuseIfSanitizeDropsContent(applied, _ State) error {
-	for i, e := range applied.Document.Experience {
+	for i, e := range applied.Experience {
 		if countNonEmpty(e.Bullets) > cv.MaxBullets {
 			return listCapErr(experienceLabel(e, i))
 		}
 	}
-	for i, p := range applied.Document.Projects {
+	for i, p := range applied.Projects {
 		if countNonEmpty(p.Bullets) > cv.MaxBullets {
 			return listCapErr(projectLabel(p, i))
 		}

--- a/internal/cvedit/undo.go
+++ b/internal/cvedit/undo.go
@@ -97,7 +97,7 @@ func (e *Editor) undo(ctx context.Context, tx Tx, cvID uuid.UUID, inverse []Op,
 		return cv.Meta{}, Revision{}, fmt.Errorf("%w: %s", ErrCannotUndo, err)
 	}
 	after := applied
-	after.Document.Sanitize()
+	after.Sanitize()
 
 	// Same rule as a commit: the precise inverse unless the sanitizer moved something, in
 	// which case the diff against what was stored is the only one that applies cleanly.

--- a/internal/cvmatch/lineitem.go
+++ b/internal/cvmatch/lineitem.go
@@ -30,10 +30,10 @@ type LineItem struct {
 // Nothing matched is a failure rather than a warning: a CV sharing no vocabulary at all
 // with its vacancy is the one case worth alarming about.
 func tallyStatus(got, want int) Status {
-	switch {
-	case got == want:
+	switch got {
+	case want:
 		return StatusPass
-	case got == 0:
+	case 0:
 		return StatusFail
 	default:
 		return StatusWarn

--- a/internal/experience/store_test.go
+++ b/internal/experience/store_test.go
@@ -613,10 +613,10 @@ type raceInjectingRepo struct {
 func (r *raceInjectingRepo) GetAtom(ctx context.Context, id uuid.UUID, userID int64) (db.ExperienceAtom, error) {
 	row, err := r.fakeRepo.GetAtom(ctx, id, userID)
 	if id == r.trigger {
-		v := r.fakeRepo.atoms[r.victim]
+		v := r.atoms[r.victim]
 		v.Context = "raced in from another request"
-		v.UpdatedAt = r.fakeRepo.stamp()
-		r.fakeRepo.atoms[r.victim] = v
+		v.UpdatedAt = r.stamp()
+		r.atoms[r.victim] = v
 	}
 	return row, err
 }

--- a/internal/handler/api_keys_test.go
+++ b/internal/handler/api_keys_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
@@ -41,7 +42,7 @@ func TestAPIKeysManagement_IsCookieOnly(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req := httptest.NewRequestWithContext(context.Background(), tc.method, tc.path, nil)
 			if tc.bearer {
 				req.Header.Set("Authorization", "Bearer fhk_whatever")
 			}
@@ -49,6 +50,7 @@ func TestAPIKeysManagement_IsCookieOnly(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusUnauthorized {
 				t.Errorf("status = %d, want 401 (key management must be cookie-only)", resp.StatusCode)
 			}

--- a/internal/handler/application_writes_test.go
+++ b/internal/handler/application_writes_test.go
@@ -48,9 +48,9 @@ func appWriteReq(t *testing.T, app *fiber.App, iss *auth.Issuer, method, path, b
 	t.Helper()
 	var r *http.Request
 	if body == "" {
-		r = httptest.NewRequest(method, path, nil)
+		r = httptest.NewRequestWithContext(context.Background(), method, path, nil)
 	} else {
-		r = httptest.NewRequest(method, path, strings.NewReader(body))
+		r = httptest.NewRequestWithContext(context.Background(), method, path, strings.NewReader(body))
 		r.Header.Set("Content-Type", "application/json")
 	}
 	tok, err := iss.Issue(7, testTokenVersion)
@@ -73,6 +73,7 @@ func TestApplicationWritesRejectABadBodyBeforeTheLookup(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			res := appWriteReq(t, app, iss, fiber.MethodPatch, "/me/applications/a42", tc.body)
+			defer res.Body.Close()
 			if res.StatusCode != fiber.StatusBadRequest {
 				t.Errorf("status = %d, want 400 — the body is wrong whichever way the row was named", res.StatusCode)
 			}
@@ -83,6 +84,7 @@ func TestApplicationWritesRejectABadBodyBeforeTheLookup(t *testing.T) {
 func TestApplicationWritesAcceptAValidStage(t *testing.T) {
 	app, iss := appWriteApp(t, stubTrackingRepo{})
 	res := appWriteReq(t, app, iss, fiber.MethodPatch, "/me/applications/a42", `{"stage":"interview"}`)
+	defer res.Body.Close()
 	if res.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", res.StatusCode)
 	}
@@ -94,6 +96,7 @@ func TestApplicationWritesAcceptBothIDForms(t *testing.T) {
 	app, iss := appWriteApp(t, stubTrackingRepo{})
 	for _, id := range []string{"a42", "senior-go-engineer-stripe-mfzg42lt"} {
 		res := appWriteReq(t, app, iss, fiber.MethodPatch, "/me/applications/"+id, `{"stage":"offer"}`)
+		defer res.Body.Close()
 		if res.StatusCode != fiber.StatusOK {
 			t.Errorf("id %q: status = %d, want 200", id, res.StatusCode)
 		}
@@ -111,6 +114,7 @@ func TestApplicationWritesAnswerOneNotFound(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			res := appWriteReq(t, app, iss, tc.method, tc.path, tc.body)
+			defer res.Body.Close()
 			if res.StatusCode != fiber.StatusNotFound {
 				t.Errorf("status = %d, want 404", res.StatusCode)
 			}
@@ -120,12 +124,13 @@ func TestApplicationWritesAnswerOneNotFound(t *testing.T) {
 
 func TestApplicationWritesRequireAuthentication(t *testing.T) {
 	app, _ := appWriteApp(t, stubTrackingRepo{})
-	req := httptest.NewRequest(fiber.MethodPatch, "/me/applications/a42", strings.NewReader(`{"stage":"offer"}`))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPatch, "/me/applications/a42", strings.NewReader(`{"stage":"offer"}`))
 	req.Header.Set("Content-Type", "application/json")
 	res, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", res.StatusCode)
 	}

--- a/internal/handler/ats_report_test.go
+++ b/internal/handler/ats_report_test.go
@@ -78,7 +78,7 @@ func atsAppWith(t *testing.T, repo *fakeProfileRepo, fc facetCounter, store *res
 
 func postATS(t *testing.T, app *fiber.App, target, token string) (int, map[string]any) {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodPost, target, nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, target, nil)
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}
@@ -94,7 +94,7 @@ func postATS(t *testing.T, app *fiber.App, target, token string) (int, map[strin
 
 func getATS(t *testing.T, app *fiber.App, target, token string) (int, map[string]any) {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodGet, target, nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, target, nil)
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}

--- a/internal/handler/auth_test.go
+++ b/internal/handler/auth_test.go
@@ -65,12 +65,13 @@ func registerApp() *fiber.App {
 
 func postJSON(t *testing.T, app *fiber.App, path, body string) int {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodPost, path, strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, path, strings.NewReader(body))
 	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	return resp.StatusCode
 }
 
@@ -140,7 +141,7 @@ func TestAuthRoutes_NoCacheHeaders(t *testing.T) {
 
 	for _, r := range routes {
 		t.Run(r.method+" "+r.path, func(t *testing.T) {
-			req := httptest.NewRequest(r.method, r.path, nil)
+			req := httptest.NewRequestWithContext(context.Background(), r.method, r.path, nil)
 			resp, err := app.Test(req)
 			if err != nil {
 				t.Fatalf("Test: %v", err)

--- a/internal/handler/auth_v2.go
+++ b/internal/handler/auth_v2.go
@@ -171,7 +171,7 @@ func (h *authHandlers) OAuthStartV2(c *fiber.Ctx) error {
 		return authError(404, "unknown_provider", "unknown provider")
 	}
 	platform, target, purpose := c.Query("platform"), c.Query("callback_target"), c.Query("purpose")
-	if provider == "apple" && !(platform == "web" && purpose == "reauth") {
+	if provider == "apple" && (platform != "web" || purpose != "reauth") {
 		return authError(404, "unknown_provider", "unknown provider")
 	}
 	callback, ok := h.mobileCallbacks[target]

--- a/internal/handler/auth_v2_test.go
+++ b/internal/handler/auth_v2_test.go
@@ -47,20 +47,22 @@ func TestListProvidersV2StructuredAndOmitsWebApple(t *testing.T) {
 func TestRegisterV2DisabledAndNoStoreHeaders(t *testing.T) {
 	disabled := fiber.New()
 	(&authHandlers{authV2Enabled: false}).registerV2(disabled.Group("/api/v2"), middleware{})
-	resp, err := disabled.Test(httptest.NewRequest("GET", "/api/v2/auth/providers", nil))
+	resp, err := disabled.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/api/v2/auth/providers", nil))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resp.StatusCode != 404 {
 		t.Fatalf("disabled status=%d", resp.StatusCode)
 	}
+	resp.Body.Close()
 	h := &authHandlers{authV2Enabled: true, oauth: fakeRegistry{}}
 	enabled := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	h.registerV2(enabled.Group("/api/v2"), middleware{optionalCookie: func(c *fiber.Ctx) error { return c.Next() }})
-	resp, err = enabled.Test(httptest.NewRequest("GET", "/api/v2/auth/providers", nil))
+	resp, err = enabled.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/api/v2/auth/providers", nil))
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer resp.Body.Close()
 	if got := resp.Header.Get("Cache-Control"); got != "private, no-store" {
 		t.Fatalf("Cache-Control=%q", got)
 	}
@@ -71,7 +73,7 @@ func TestV2CodedErrorEnvelope(t *testing.T) {
 	app.Get("/coded", func(*fiber.Ctx) error {
 		return authError(428, "recent_auth_required", "recent authentication required")
 	})
-	resp, err := app.Test(httptest.NewRequest("GET", "/coded", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/coded", nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +111,7 @@ func TestRecentAuthRotatesLegacySessionBeforeBinding(t *testing.T) {
 		}
 		return c.SendStatus(fiber.StatusNoContent)
 	})
-	req := httptest.NewRequest(fiber.MethodGet, "/rotate", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/rotate", nil)
 	req.Header.Set(fiber.HeaderCookie, auth.CookieName+"="+legacy)
 	resp, err := app.Test(req)
 	if err != nil {
@@ -153,7 +155,7 @@ func TestPasswordReauthPreservesInfrastructureFailure(t *testing.T) {
 		c.Locals(auth.LocalsUserID, int64(7))
 		return c.Next()
 	}, h.PasswordReauthV2)
-	req := httptest.NewRequest(fiber.MethodPost, "/reauth", strings.NewReader(`{"password":"correct horse battery staple"}`))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/reauth", strings.NewReader(`{"password":"correct horse battery staple"}`))
 	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
 	resp, err := app.Test(req)
 	if err != nil {

--- a/internal/handler/browsertools_integration_test.go
+++ b/internal/handler/browsertools_integration_test.go
@@ -42,7 +42,7 @@ func wireServer(t *testing.T, iss *auth.Issuer) string {
 	app := fiber.New()
 	app.Get("/api/v1/tools/ws", auth.RequireAuthWS(iss, testVersions, noKeys{}), a.BrowserToolsWS())
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
@@ -61,6 +61,9 @@ func dial(t *testing.T, base, role, token string) *ws.Conn {
 		HandshakeTimeout: arrivalBudget,
 	}
 	conn, resp, err := dialer.Dial(base+"?role="+role, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		status := 0
 		if resp != nil {
@@ -232,6 +235,9 @@ func TestBrowserToolsWS_RefusesAnUnauthenticatedHandshake(t *testing.T) {
 
 	dialer := ws.Dialer{HandshakeTimeout: arrivalBudget}
 	conn, resp, err := dialer.Dial(base+"?role=extension", nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err == nil {
 		_ = conn.Close()
 		t.Fatal("an unauthenticated connection was accepted")

--- a/internal/handler/contribution_limit_test.go
+++ b/internal/handler/contribution_limit_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestContributionLimiter_IsKeyedOnTheUser(t *testing.T) {
 	}, contributionLimiter(newTestThrottler(t)), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusCreated) })
 
 	post := func(user string) int {
-		req := httptest.NewRequest(fiber.MethodPost, "/contrib", nil)
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/contrib", nil)
 		req.Header.Set("X-Test-User", user)
 		resp, err := app.Test(req)
 		if err != nil {

--- a/internal/handler/cv_ats_delta_test.go
+++ b/internal/handler/cv_ats_delta_test.go
@@ -222,7 +222,7 @@ func TestCVRegister_ATSDeltaIsCookieOnly(t *testing.T) {
 		cookie: namedGate("cookie"),
 	})
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/api/v1/me/cvs/"+uuid.New().String()+"/ats-delta", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/me/cvs/"+uuid.New().String()+"/ats-delta", nil))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}

--- a/internal/handler/cv_reset_test.go
+++ b/internal/handler/cv_reset_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +22,7 @@ func TestCVRegister_ResetFromResumeIsCookieOnly(t *testing.T) {
 		cvKey:  namedGate("cvKey"),
 		cookie: namedGate("cookie"),
 	})
-	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/api/v1/me/cvs/"+uuid.New().String()+"/reset-from-resume", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/me/cvs/"+uuid.New().String()+"/reset-from-resume", nil))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}

--- a/internal/handler/cv_templates_test.go
+++ b/internal/handler/cv_templates_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http/httptest"
@@ -17,11 +18,12 @@ func TestListCVTemplates(t *testing.T) {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/cv-templates", (&cvHandlers{}).ListCVTemplates)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/cv-templates", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/api/v1/cv-templates", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -56,11 +58,12 @@ func TestListCVFonts(t *testing.T) {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/cv-fonts", (&cvHandlers{}).ListCVFonts)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/cv-fonts", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/api/v1/cv-fonts", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}

--- a/internal/handler/cv_tracer_links_test.go
+++ b/internal/handler/cv_tracer_links_test.go
@@ -40,7 +40,7 @@ func TestCVRegister_TracerLinksToggleIsCookieOnly(t *testing.T) {
 		cookie: namedGate("cookie"),
 	})
 
-	req := httptest.NewRequest(http.MethodPut,
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
 		"/api/v1/me/cvs/"+uuid.New().String()+"/tracer-links", strings.NewReader(`{"enabled":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
@@ -68,7 +68,7 @@ func TestTracerLinksToggleIsNotAnEditablePath(t *testing.T) {
 			"so an agent can set it and an undo can revoke it")
 	}
 	for _, p := range cvedit.Paths() {
-		if strings.Contains(string(p), "tracer") {
+		if strings.Contains(p, "tracer") {
 			t.Errorf("cvedit advertises the editable path %q", p)
 		}
 	}
@@ -95,7 +95,7 @@ func tracerToggleAPI(t *testing.T) (*fiber.App, uuid.UUID) {
 func TestEnablingTracingWithoutASaltIsRefused(t *testing.T) {
 	app, id := tracerToggleAPI(t)
 
-	req := httptest.NewRequest(http.MethodPut,
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
 		"/api/v1/me/cvs/"+id.String()+"/tracer-links", strings.NewReader(`{"enabled":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
@@ -113,7 +113,7 @@ func TestEnablingTracingWithoutASaltIsRefused(t *testing.T) {
 func TestDisablingTracingIsAllowedWithoutASalt(t *testing.T) {
 	app, id := tracerToggleAPI(t)
 
-	req := httptest.NewRequest(http.MethodPut,
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
 		"/api/v1/me/cvs/"+id.String()+"/tracer-links", strings.NewReader(`{"enabled":false}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
@@ -184,7 +184,7 @@ func TestCVRegister_TracerLinkStatsAreCookieOnly(t *testing.T) {
 		cookie: namedGate("cookie"),
 	})
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet,
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), http.MethodGet,
 		"/api/v1/me/cvs/"+uuid.New().String()+"/tracer-links", nil))
 	if err != nil {
 		t.Fatalf("request: %v", err)

--- a/internal/handler/discord_test.go
+++ b/internal/handler/discord_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
@@ -35,7 +36,7 @@ func discordApp(pub ed25519.PublicKey) (*fiber.App, *discordHandlers) {
 func signedRequest(t *testing.T, priv ed25519.PrivateKey, timestamp string, body []byte) *http.Request {
 	t.Helper()
 	sig := ed25519.Sign(priv, append([]byte(timestamp), body...))
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/discord/interactions", bytes.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/discord/interactions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(sig))
 	req.Header.Set("X-Signature-Timestamp", timestamp)
@@ -49,12 +50,13 @@ func TestDiscordInteraction_missingSignatureForbidden(t *testing.T) {
 	}
 	app, _ := discordApp(pub)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/discord/interactions", bytes.NewReader([]byte(`{"type":1}`)))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/discord/interactions", bytes.NewReader([]byte(`{"type":1}`)))
 	req.Header.Set("Content-Type", "application/json")
 	res, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", res.StatusCode)
 	}
@@ -78,6 +80,7 @@ func TestDiscordInteraction_invalidSignatureForbidden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", res.StatusCode)
 	}
@@ -95,7 +98,7 @@ func TestDiscordInteraction_tamperedBodyForbidden(t *testing.T) {
 
 	signedBody := []byte(`{"type":1}`)
 	sig := ed25519.Sign(priv, append([]byte("1700000000"), signedBody...))
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/discord/interactions", bytes.NewReader([]byte(`{"type":2}`)))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/discord/interactions", bytes.NewReader([]byte(`{"type":2}`)))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(sig))
 	req.Header.Set("X-Signature-Timestamp", "1700000000")
@@ -103,6 +106,7 @@ func TestDiscordInteraction_tamperedBodyForbidden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", res.StatusCode)
 	}
@@ -120,6 +124,7 @@ func TestDiscordInteraction_ping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", res.StatusCode)
 	}
@@ -159,6 +164,7 @@ func TestDiscordInteraction_linkCommand_invalidToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (interaction responses are always 200)", res.StatusCode)
 	}
@@ -196,6 +202,7 @@ func TestDiscordInteraction_unknownCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", res.StatusCode)
 	}
@@ -240,12 +247,13 @@ func TestDiscordInteraction_disabledReturns404(t *testing.T) {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Post("/api/v1/discord/interactions", h.DiscordInteraction)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/discord/interactions", bytes.NewReader([]byte(`{"type":1}`)))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/discord/interactions", bytes.NewReader([]byte(`{"type":1}`)))
 	req.Header.Set("Content-Type", "application/json")
 	res, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", res.StatusCode)
 	}
@@ -280,6 +288,7 @@ func TestDiscordInteraction_contributeMissingIdentityEphemeral(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", res.StatusCode)
 	}
@@ -469,12 +478,13 @@ func TestDiscordLink_disabledReturns503(t *testing.T) {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Post("/api/v1/me/discord/link", auth.RequireAuth(iss, testVersions), h.LinkDiscord)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/me/discord/link", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/me/discord/link", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
 	res, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503", res.StatusCode)
 	}

--- a/internal/handler/errors_test.go
+++ b/internal/handler/errors_test.go
@@ -68,10 +68,11 @@ func sentryApp(t *testing.T, errFn fiber.Handler) (*fiber.App, *recordingTranspo
 // error Fiber re-delivers to RenderError must NOT be reported again.
 func TestRenderError_PanicReportedExactlyOnce(t *testing.T) {
 	app, tr := sentryApp(t, func(*fiber.Ctx) error { panic("boom") })
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/x", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/x", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", resp.StatusCode)
 	}
@@ -84,10 +85,11 @@ func TestRenderError_PanicReportedExactlyOnce(t *testing.T) {
 // the dedup guard doesn't suppress real faults.
 func TestRenderError_ReturnedErrorReportedOnce(t *testing.T) {
 	app, tr := sentryApp(t, func(*fiber.Ctx) error { return errString("db exploded") })
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/x", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/x", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", resp.StatusCode)
 	}
@@ -106,10 +108,11 @@ func errorApp(errFn func(*fiber.Ctx) error) *fiber.App {
 
 func errorStatus(t *testing.T, app *fiber.App) int {
 	t.Helper()
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/x", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/x", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	return resp.StatusCode
 }
 

--- a/internal/handler/gmail_callback_test.go
+++ b/internal/handler/gmail_callback_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -24,10 +25,11 @@ func TestGmailCallbackWithoutSessionRedirectsInsteadOfJSON(t *testing.T) {
 
 	// No auth cookie: the state the browser carried back is irrelevant, the session
 	// is what is missing.
-	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/me/gmail/callback?state=abc&code=xyz", nil), -1)
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/me/gmail/callback?state=abc&code=xyz", nil), -1)
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusFound {
 		t.Fatalf("status = %d, want %d (a redirect, not a JSON error)", resp.StatusCode, fiber.StatusFound)
 	}
@@ -47,12 +49,13 @@ func TestGmailCallbackStateMismatchRedirects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("issue: %v", err)
 	}
-	r := httptest.NewRequest("GET", "/api/v1/me/gmail/callback?state=abc&code=xyz", nil)
+	r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/me/gmail/callback?state=abc&code=xyz", nil)
 	r.Header.Set("Cookie", auth.CookieName+"="+token)
 	resp, err := app.Test(r, -1)
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusFound {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, fiber.StatusFound)
 	}

--- a/internal/handler/inbox_filters_test.go
+++ b/internal/handler/inbox_filters_test.go
@@ -4,6 +4,7 @@
 package handler
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -27,7 +28,7 @@ func parseFilters(t *testing.T, rawQuery string) (inbox.Query, int) {
 		got = q
 		return c.SendStatus(fiber.StatusOK)
 	})
-	resp, err := app.Test(httptest.NewRequest("GET", "/f?"+rawQuery, nil), -1)
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), "GET", "/f?"+rawQuery, nil), -1)
 	if err != nil {
 		t.Fatalf("request ?%s: %v", rawQuery, err)
 	}

--- a/internal/handler/market_coverage_test.go
+++ b/internal/handler/market_coverage_test.go
@@ -48,12 +48,13 @@ func coverageApp(fc facetCounter) *fiber.App {
 
 func doPostJSON(t *testing.T, app *fiber.App, target, body string) (int, map[string]any) {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodPost, target, bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, target, bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
+	defer resp.Body.Close()
 	var out map[string]any
 	_ = json.NewDecoder(resp.Body).Decode(&out)
 	return resp.StatusCode, out

--- a/internal/handler/match_analysis_limit_test.go
+++ b/internal/handler/match_analysis_limit_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestMatchAnalysisLimiter_IsKeyedOnTheUser(t *testing.T) {
 	}, matchAnalysisLimiter(newTestThrottler(t)), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
 
 	post := func(user string) int {
-		req := httptest.NewRequest(fiber.MethodPost, "/analysis", nil)
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/analysis", nil)
 		req.Header.Set("X-Test-User", user)
 		resp, err := app.Test(req)
 		if err != nil {

--- a/internal/handler/me_calendar_test.go
+++ b/internal/handler/me_calendar_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -34,7 +35,7 @@ func calendarConnectApp(t *testing.T) (*fiber.App, string) {
 
 func TestCalendarConnect_RequiresAuth(t *testing.T) {
 	app, _ := calendarConnectApp(t)
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/me/calendar/connect", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me/calendar/connect", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
@@ -48,7 +49,7 @@ func TestCalendarConnect_RequiresAuth(t *testing.T) {
 // its own state cookie so a mail consent in flight cannot complete this one.
 func TestCalendarConnect_SendsToGoogleForTheCalendarAlone(t *testing.T) {
 	app, token := calendarConnectApp(t)
-	req := httptest.NewRequest(fiber.MethodGet, "/me/calendar/connect", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me/calendar/connect", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 
 	resp, err := app.Test(req)

--- a/internal/handler/me_delete_test.go
+++ b/internal/handler/me_delete_test.go
@@ -55,7 +55,7 @@ func deleteAccountApp(t *testing.T, eraser *fakeEraser, email string) (*fiber.Ap
 
 func doDelete(t *testing.T, app *fiber.App, body, token string) *http.Response {
 	t.Helper()
-	r := httptest.NewRequest(fiber.MethodDelete, "/me", strings.NewReader(body))
+	r := httptest.NewRequestWithContext(context.Background(), fiber.MethodDelete, "/me", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	if token != "" {
 		r.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
@@ -72,6 +72,7 @@ func TestDeleteAccount_ConfirmedByOwnEmail(t *testing.T) {
 	app, token := deleteAccountApp(t, eraser, "member@example.test")
 
 	resp := doDelete(t, app, `{"email":"member@example.test"}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusNoContent {
 		t.Fatalf("status = %d, want 204", resp.StatusCode)
 	}
@@ -97,7 +98,9 @@ func TestDeleteAccount_ConfirmationIsCaseInsensitive(t *testing.T) {
 	eraser := &fakeEraser{}
 	app, token := deleteAccountApp(t, eraser, "Member@Example.test")
 
-	if resp := doDelete(t, app, `{"email":"member@example.TEST"}`, token); resp.StatusCode != fiber.StatusNoContent {
+	resp := doDelete(t, app, `{"email":"member@example.TEST"}`, token)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusNoContent {
 		t.Errorf("status = %d, want 204", resp.StatusCode)
 	}
 	if len(eraser.deleted) != 1 {
@@ -119,7 +122,9 @@ func TestDeleteAccount_RejectsWrongOrMissingConfirmation(t *testing.T) {
 			eraser := &fakeEraser{}
 			app, token := deleteAccountApp(t, eraser, "member@example.test")
 
-			if resp := doDelete(t, app, tc.body, token); resp.StatusCode != fiber.StatusBadRequest {
+			resp := doDelete(t, app, tc.body, token)
+			defer resp.Body.Close()
+			if resp.StatusCode != fiber.StatusBadRequest {
 				t.Errorf("status = %d, want 400", resp.StatusCode)
 			}
 			if len(eraser.deleted) != 0 {
@@ -133,7 +138,9 @@ func TestDeleteAccount_RejectsAnonymous(t *testing.T) {
 	eraser := &fakeEraser{}
 	app, _ := deleteAccountApp(t, eraser, "member@example.test")
 
-	if resp := doDelete(t, app, `{"email":"member@example.test"}`, ""); resp.StatusCode != fiber.StatusUnauthorized {
+	resp := doDelete(t, app, `{"email":"member@example.test"}`, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", resp.StatusCode)
 	}
 	if len(eraser.deleted) != 0 {
@@ -147,13 +154,14 @@ func TestDeleteAccount_RejectsAPIKey(t *testing.T) {
 	eraser := &fakeEraser{}
 	app, _ := deleteAccountApp(t, eraser, "member@example.test")
 
-	r := httptest.NewRequest(fiber.MethodDelete, "/me", strings.NewReader(`{"email":"member@example.test"}`))
+	r := httptest.NewRequestWithContext(context.Background(), fiber.MethodDelete, "/me", strings.NewReader(`{"email":"member@example.test"}`))
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", "Bearer fh_livekey")
 	resp, err := app.Test(r)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", resp.StatusCode)
 	}
@@ -168,7 +176,9 @@ func TestDeleteAccount_StorageFailureIsRetryable(t *testing.T) {
 	eraser := &fakeEraser{err: fmt.Errorf("erase objects: %w", accountdelete.ErrStorageUnavailable)}
 	app, token := deleteAccountApp(t, eraser, "member@example.test")
 
-	if resp := doDelete(t, app, `{"email":"member@example.test"}`, token); resp.StatusCode != fiber.StatusServiceUnavailable {
+	resp := doDelete(t, app, `{"email":"member@example.test"}`, token)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503", resp.StatusCode)
 	}
 }

--- a/internal/handler/me_experience_test.go
+++ b/internal/handler/me_experience_test.go
@@ -35,7 +35,7 @@ func experienceApp(t *testing.T) (*fiber.App, string, *stubBank) {
 
 func experienceReq(t *testing.T, app *fiber.App, method, path, body, token string) *http.Response {
 	t.Helper()
-	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), method, path, strings.NewReader(body))
 	if body != "" {
 		req.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
 	}
@@ -139,15 +139,19 @@ func TestDeleteExperienceIsOwnerScoped(t *testing.T) {
 	mine := bank.add(1, experience.Atom{Claim: "Mine", Provenance: experience.ProvenanceManual})
 	theirs := bank.add(2, experience.Atom{Claim: "Theirs", Provenance: experience.ProvenanceManual})
 
-	if resp := experienceReq(t, app, http.MethodDelete, "/me/experience/atoms/"+theirs.ID.String(), "", token); resp.StatusCode != http.StatusNotFound {
+	resp := experienceReq(t, app, http.MethodDelete, "/me/experience/atoms/"+theirs.ID.String(), "", token)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("deleting another owner's achievement = %d, want 404 (never 403)", resp.StatusCode)
 	}
 	if _, err := bank.GetAtom(ctx, theirs.ID, 2); err != nil {
 		t.Errorf("another owner's achievement was removed: %v", err)
 	}
 
-	if resp := experienceReq(t, app, http.MethodDelete, "/me/experience/atoms/"+mine.ID.String(), "", token); resp.StatusCode != http.StatusNoContent {
-		t.Errorf("deleting my own achievement = %d, want 204", resp.StatusCode)
+	resp2 := experienceReq(t, app, http.MethodDelete, "/me/experience/atoms/"+mine.ID.String(), "", token)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusNoContent {
+		t.Errorf("deleting my own achievement = %d, want 204", resp2.StatusCode)
 	}
 	if _, err := bank.GetAtom(ctx, mine.ID, 1); err == nil {
 		t.Error("the achievement survived its own deletion")
@@ -392,7 +396,9 @@ func TestExperienceRoutesRefuseAMalformedID(t *testing.T) {
 		"/me/experience/atoms/not-a-uuid",
 		"/me/experience/employments/not-a-uuid",
 	} {
-		if resp := experienceReq(t, app, http.MethodDelete, path, "", token); resp.StatusCode != http.StatusNotFound {
+		resp := experienceReq(t, app, http.MethodDelete, path, "", token)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
 			t.Errorf("DELETE %s = %d, want 404", path, resp.StatusCode)
 		}
 	}
@@ -401,17 +407,25 @@ func TestExperienceRoutesRefuseAMalformedID(t *testing.T) {
 func TestExperienceRoutesRequireAuth(t *testing.T) {
 	app, _, _ := experienceApp(t)
 
-	if resp := experienceReq(t, app, http.MethodGet, "/me/experience", "", ""); resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("unauthenticated read = %d, want 401", resp.StatusCode)
+	resp1 := experienceReq(t, app, http.MethodGet, "/me/experience", "", "")
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated read = %d, want 401", resp1.StatusCode)
 	}
-	if resp := experienceReq(t, app, http.MethodDelete, "/me/experience/atoms/"+uuid.New().String(), "", ""); resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("unauthenticated delete = %d, want 401", resp.StatusCode)
+	resp2 := experienceReq(t, app, http.MethodDelete, "/me/experience/atoms/"+uuid.New().String(), "", "")
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated delete = %d, want 401", resp2.StatusCode)
 	}
-	if resp := experienceReq(t, app, http.MethodPost, "/me/experience/atoms", `{"claim":"x"}`, ""); resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("unauthenticated atom create = %d, want 401", resp.StatusCode)
+	resp3 := experienceReq(t, app, http.MethodPost, "/me/experience/atoms", `{"claim":"x"}`, "")
+	defer resp3.Body.Close()
+	if resp3.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated atom create = %d, want 401", resp3.StatusCode)
 	}
-	if resp := experienceReq(t, app, http.MethodPost, "/me/experience/employments", `{"kind":"job","company":"x"}`, ""); resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("unauthenticated employment create = %d, want 401", resp.StatusCode)
+	resp4 := experienceReq(t, app, http.MethodPost, "/me/experience/employments", `{"kind":"job","company":"x"}`, "")
+	defer resp4.Body.Close()
+	if resp4.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated employment create = %d, want 401", resp4.StatusCode)
 	}
 }
 

--- a/internal/handler/me_market_pulse_test.go
+++ b/internal/handler/me_market_pulse_test.go
@@ -97,7 +97,7 @@ func marketPulseApp(t *testing.T, repo *fakeProfileRepo, history *fakeSkillHisto
 
 func doMarketPulse(t *testing.T, app *fiber.App, token string) *http.Response {
 	t.Helper()
-	r := httptest.NewRequest(http.MethodGet, "/me/market-pulse", nil)
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/market-pulse", nil)
 	if token != "" {
 		r.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}
@@ -135,6 +135,7 @@ func TestMarketPulseWithProfileSkills(t *testing.T) {
 	app, token := marketPulseApp(t, repo, history)
 
 	resp := doMarketPulse(t, app, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -156,6 +157,7 @@ func TestMarketPulseEmptyProfileReturnsEmptyData(t *testing.T) {
 	app, token := marketPulseApp(t, repo, history)
 
 	resp := doMarketPulse(t, app, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -177,6 +179,7 @@ func TestMarketPulseUnauthenticatedRejected(t *testing.T) {
 	app, _ := marketPulseApp(t, repo, history)
 
 	resp := doMarketPulse(t, app, "")
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", resp.StatusCode)
 	}

--- a/internal/handler/me_profile_cv_test.go
+++ b/internal/handler/me_profile_cv_test.go
@@ -138,7 +138,9 @@ func TestGetProfile_CVBlockCarriesTheResumeWithoutContacts(t *testing.T) {
 		ok: true,
 	})
 
-	cv, present := profileCV(t, doProfile(t, app, http.MethodGet, "", token))
+	resp := doProfile(t, app, http.MethodGet, "", token)
+	defer resp.Body.Close()
+	cv, present := profileCV(t, resp)
 
 	if !present {
 		t.Fatal("cv block is null for a caller who has a structured résumé")
@@ -219,7 +221,7 @@ func TestProfileRead_DerivedLocationNullWhenNothingResolved(t *testing.T) {
 // profileDerived reads the response's derived_location block, nil when the key is null.
 func profileDerived(t *testing.T, app *fiber.App, token string) *derivedLocation {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, "/me/profile", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/profile", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {

--- a/internal/handler/me_profile_routes_test.go
+++ b/internal/handler/me_profile_routes_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +38,7 @@ func TestProfileRegister_ReadTakesAKeyAndWritesDoNot(t *testing.T) {
 		{http.MethodPut, "cookie"},
 		{http.MethodDelete, "cookie"},
 	} {
-		resp, err := app.Test(httptest.NewRequest(tc.method, "/api/v1/me/profile", nil))
+		resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), tc.method, "/api/v1/me/profile", nil))
 		if err != nil {
 			t.Fatalf("%s: %v", tc.method, err)
 		}

--- a/internal/handler/me_profile_test.go
+++ b/internal/handler/me_profile_test.go
@@ -67,9 +67,9 @@ func doProfile(t *testing.T, app *fiber.App, method, body, token string) *http.R
 	t.Helper()
 	var r *http.Request
 	if body == "" {
-		r = httptest.NewRequest(method, "/me/profile", nil)
+		r = httptest.NewRequestWithContext(context.Background(), method, "/me/profile", nil)
 	} else {
-		r = httptest.NewRequest(method, "/me/profile", strings.NewReader(body))
+		r = httptest.NewRequestWithContext(context.Background(), method, "/me/profile", strings.NewReader(body))
 		r.Header.Set("Content-Type", "application/json")
 	}
 	if token != "" {
@@ -85,6 +85,7 @@ func doProfile(t *testing.T, app *fiber.App, method, body, token string) *http.R
 func TestPutProfile_Unauthenticated(t *testing.T) {
 	app, _ := profileApp(t, &fakeProfileRepo{})
 	resp := doProfile(t, app, fiber.MethodPut, `{"specializations":["backend"],"skills":["go"]}`, "")
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", resp.StatusCode)
 	}
@@ -106,6 +107,7 @@ func TestPutProfile_ValidationErrors(t *testing.T) {
 			repo := &fakeProfileRepo{}
 			app, token := profileApp(t, repo)
 			resp := doProfile(t, app, fiber.MethodPut, tc.body, token)
+			defer resp.Body.Close()
 			if resp.StatusCode != tc.want {
 				t.Errorf("status = %d, want %d", resp.StatusCode, tc.want)
 			}
@@ -120,6 +122,7 @@ func TestPutProfile_ReturnsSpecializationsArray(t *testing.T) {
 	ret := userprofile.Profile{UserID: 1, Specializations: []string{"backend", "devops"}, Skills: []string{"go"}}
 	app, token := profileApp(t, &fakeProfileRepo{upsertRet: ret})
 	resp := doProfile(t, app, fiber.MethodPut, `{"specializations":["backend","devops"],"skills":["go"]}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -141,6 +144,7 @@ func TestPutProfile_NormalizesExcludedSkillsAndDropsOverlap(t *testing.T) {
 	// excluded set; "WordPress" is normalized to "wordpress".
 	resp := doProfile(t, app, fiber.MethodPut,
 		`{"specializations":["backend"],"skills":["go","php"],"excluded_skills":["php","WordPress"]}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -154,6 +158,7 @@ func TestPutProfile_EchoesExcludedSkills(t *testing.T) {
 	app, token := profileApp(t, &fakeProfileRepo{upsertRet: ret})
 	resp := doProfile(t, app, fiber.MethodPut,
 		`{"specializations":["backend"],"skills":["go"],"excluded_skills":["wordpress"]}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -175,6 +180,7 @@ func TestPutProfile_ParsesAndEchoesLocationPreferences(t *testing.T) {
 	app, token := profileApp(t, repo)
 	resp := doProfile(t, app, fiber.MethodPut,
 		`{"specializations":["backend"],"skills":["go"],"location_preferences":`+loc+`}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -199,6 +205,7 @@ func TestPutProfile_RejectsInvalidLocationBlock(t *testing.T) {
 	app, token := profileApp(t, repo)
 	resp := doProfile(t, app, fiber.MethodPut,
 		`{"specializations":["backend"],"skills":["go"],"location_preferences":{"work_modes":["freelance"]}}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusBadRequest {
 		t.Errorf("status = %d, want 400", resp.StatusCode)
 	}
@@ -212,6 +219,7 @@ func TestGetProfile_EchoesStoredLocationPreferences(t *testing.T) {
 	ret := userprofile.Profile{UserID: 1, Specializations: []string{"backend"}, Skills: []string{"go"}, LocationPreferences: stored}
 	app, token := profileApp(t, &fakeProfileRepo{getRet: ret})
 	resp := doProfile(t, app, fiber.MethodGet, "", token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -233,6 +241,7 @@ func TestGetProfile_EchoesStoredLocationPreferences(t *testing.T) {
 func TestGetProfile_NullWhenNone(t *testing.T) {
 	app, token := profileApp(t, &fakeProfileRepo{getErr: userprofile.ErrNotFound})
 	resp := doProfile(t, app, fiber.MethodGet, "", token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -249,6 +258,7 @@ func TestGetProfile_ReturnsProfile(t *testing.T) {
 	ret := userprofile.Profile{UserID: 1, Specializations: []string{"backend"}, Skills: []string{"go"}}
 	app, token := profileApp(t, &fakeProfileRepo{getRet: ret})
 	resp := doProfile(t, app, fiber.MethodGet, "", token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -267,6 +277,7 @@ func TestDeleteProfile_Idempotent(t *testing.T) {
 	// No stored profile: the fake's Delete returns nil, and the handler still answers 204.
 	app, token := profileApp(t, &fakeProfileRepo{})
 	resp := doProfile(t, app, fiber.MethodDelete, "", token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusNoContent {
 		t.Errorf("status = %d, want 204", resp.StatusCode)
 	}

--- a/internal/handler/me_push_tokens_test.go
+++ b/internal/handler/me_push_tokens_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,7 +47,7 @@ func TestPushTokensManagement_IsCookieOnly(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req := httptest.NewRequestWithContext(context.Background(), tc.method, tc.path, nil)
 			if tc.bearer {
 				req.Header.Set("Authorization", "Bearer fhk_whatever")
 			}
@@ -54,6 +55,7 @@ func TestPushTokensManagement_IsCookieOnly(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusUnauthorized {
 				t.Errorf("status = %d, want 401 (push-token management must be cookie-only)", resp.StatusCode)
 			}
@@ -81,7 +83,7 @@ func TestRegisterPushToken_ValidationRejectsBeforeAnyDBCall(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(fiber.MethodPost, "/api/v1/me/push-tokens", bytes.NewBufferString(tc.body))
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/api/v1/me/push-tokens", bytes.NewBufferString(tc.body))
 			req.Header.Set("Content-Type", "application/json")
 			req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
 
@@ -89,6 +91,7 @@ func TestRegisterPushToken_ValidationRejectsBeforeAnyDBCall(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusBadRequest {
 				t.Errorf("status = %d, want 400", resp.StatusCode)
 			}

--- a/internal/handler/me_reminders_test.go
+++ b/internal/handler/me_reminders_test.go
@@ -66,10 +66,10 @@ func do(t *testing.T, app *fiber.App, method, path, token, body string) *http.Re
 	t.Helper()
 	var r *http.Request
 	if body != "" {
-		r = httptest.NewRequest(method, path, strings.NewReader(body))
+		r = httptest.NewRequestWithContext(context.Background(), method, path, strings.NewReader(body))
 		r.Header.Set("Content-Type", "application/json")
 	} else {
-		r = httptest.NewRequest(method, path, nil)
+		r = httptest.NewRequestWithContext(context.Background(), method, path, nil)
 	}
 	if token != "" {
 		r.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
@@ -83,10 +83,14 @@ func do(t *testing.T, app *fiber.App, method, path, token, body string) *http.Re
 
 func TestNotificationSettings_RequiresAuth(t *testing.T) {
 	app, _, _ := remindersApp(reminder.Settings{})
-	if got := do(t, app, fiber.MethodGet, "/me/notification-settings", "", "").StatusCode; got != fiber.StatusUnauthorized {
+	getResp := do(t, app, fiber.MethodGet, "/me/notification-settings", "", "")
+	defer getResp.Body.Close()
+	if got := getResp.StatusCode; got != fiber.StatusUnauthorized {
 		t.Errorf("GET status = %d, want 401", got)
 	}
-	if got := do(t, app, fiber.MethodPut, "/me/notification-settings", "", `{"enabled":false}`).StatusCode; got != fiber.StatusUnauthorized {
+	putResp := do(t, app, fiber.MethodPut, "/me/notification-settings", "", `{"enabled":false}`)
+	defer putResp.Body.Close()
+	if got := putResp.StatusCode; got != fiber.StatusUnauthorized {
 		t.Errorf("PUT status = %d, want 401", got)
 	}
 }
@@ -94,7 +98,9 @@ func TestNotificationSettings_RequiresAuth(t *testing.T) {
 func TestSaveJob_SchedulesReminderWhenEnabled(t *testing.T) {
 	app, iss, repo := remindersApp(reminder.Settings{Enabled: true, Channels: []string{"email"}})
 	token, _ := iss.Issue(7, testTokenVersion)
-	if got := do(t, app, fiber.MethodPost, "/jobs/go-dev/save", token, "").StatusCode; got != fiber.StatusOK {
+	saveResp := do(t, app, fiber.MethodPost, "/jobs/go-dev/save", token, "")
+	defer saveResp.Body.Close()
+	if got := saveResp.StatusCode; got != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", got)
 	}
 	if repo.upserts != 1 {
@@ -105,7 +111,8 @@ func TestSaveJob_SchedulesReminderWhenEnabled(t *testing.T) {
 func TestSaveJob_DisabledRuleSchedulesNothing(t *testing.T) {
 	app, iss, repo := remindersApp(reminder.Settings{Enabled: false})
 	token, _ := iss.Issue(7, testTokenVersion)
-	do(t, app, fiber.MethodPost, "/jobs/go-dev/save", token, "")
+	resp := do(t, app, fiber.MethodPost, "/jobs/go-dev/save", token, "")
+	defer resp.Body.Close()
 	if repo.upserts != 0 || repo.cancels != 0 {
 		t.Errorf("disabled-rule save must be a no-op: upserts=%d cancels=%d", repo.upserts, repo.cancels)
 	}
@@ -114,8 +121,10 @@ func TestSaveJob_DisabledRuleSchedulesNothing(t *testing.T) {
 func TestApplyAndUnsave_CancelReminder(t *testing.T) {
 	app, iss, repo := remindersApp(reminder.Settings{Enabled: true, Channels: []string{"email"}})
 	token, _ := iss.Issue(7, testTokenVersion)
-	do(t, app, fiber.MethodPost, "/jobs/go-dev/apply", token, "")
-	do(t, app, fiber.MethodDelete, "/jobs/go-dev/save", token, "")
+	applyResp := do(t, app, fiber.MethodPost, "/jobs/go-dev/apply", token, "")
+	defer applyResp.Body.Close()
+	unsaveResp := do(t, app, fiber.MethodDelete, "/jobs/go-dev/save", token, "")
+	defer unsaveResp.Body.Close()
 	if repo.cancels != 2 {
 		t.Errorf("apply + unsave must each cancel, got %d cancels", repo.cancels)
 	}
@@ -125,6 +134,7 @@ func TestUpdateNotificationSettings_RejectsEnabledWithoutChannels(t *testing.T) 
 	app, iss, _ := remindersApp(reminder.Settings{})
 	token, _ := iss.Issue(7, testTokenVersion)
 	resp := do(t, app, fiber.MethodPut, "/me/notification-settings", token, `{"enabled":true,"channels":[]}`)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusBadRequest {
 		t.Errorf("status = %d, want 400", resp.StatusCode)
 	}

--- a/internal/handler/me_talent_network_test.go
+++ b/internal/handler/me_talent_network_test.go
@@ -63,9 +63,9 @@ func doTalentNetwork(t *testing.T, app *fiber.App, method, body, token string) *
 	t.Helper()
 	var r *http.Request
 	if body == "" {
-		r = httptest.NewRequest(method, "/me/talent-network", nil)
+		r = httptest.NewRequestWithContext(context.Background(), method, "/me/talent-network", nil)
 	} else {
-		r = httptest.NewRequest(method, "/me/talent-network", strings.NewReader(body))
+		r = httptest.NewRequestWithContext(context.Background(), method, "/me/talent-network", strings.NewReader(body))
 		r.Header.Set("Content-Type", "application/json")
 	}
 	if token != "" {
@@ -83,6 +83,7 @@ func TestGetTalentNetwork_DefaultsToOff(t *testing.T) {
 	store := &fakeTalentNetworkStore{visibility: "off", publicID: id}
 	app, token := talentNetworkApp(t, store)
 	resp := doTalentNetwork(t, app, fiber.MethodGet, "", token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -105,6 +106,7 @@ func TestPutTalentNetwork_PublicRoundTrips(t *testing.T) {
 	app, token := talentNetworkApp(t, store)
 
 	putResp := doTalentNetwork(t, app, fiber.MethodPut, `{"visibility":"public"}`, token)
+	defer putResp.Body.Close()
 	if putResp.StatusCode != fiber.StatusOK {
 		t.Fatalf("PUT status = %d, want 200", putResp.StatusCode)
 	}
@@ -119,6 +121,7 @@ func TestPutTalentNetwork_PublicRoundTrips(t *testing.T) {
 	}
 
 	getResp := doTalentNetwork(t, app, fiber.MethodGet, "", token)
+	defer getResp.Body.Close()
 	var getGot struct {
 		Data talentNetworkResponse `json:"data"`
 	}
@@ -135,11 +138,13 @@ func TestPutTalentNetwork_AnonymousRoundTrips(t *testing.T) {
 	app, token := talentNetworkApp(t, store)
 
 	putResp := doTalentNetwork(t, app, fiber.MethodPut, `{"visibility":"anonymous"}`, token)
+	defer putResp.Body.Close()
 	if putResp.StatusCode != fiber.StatusOK {
 		t.Fatalf("PUT status = %d, want 200", putResp.StatusCode)
 	}
 
 	getResp := doTalentNetwork(t, app, fiber.MethodGet, "", token)
+	defer getResp.Body.Close()
 	var getGot struct {
 		Data talentNetworkResponse `json:"data"`
 	}
@@ -158,6 +163,7 @@ func TestPutTalentNetwork_RejectsInvalidValue(t *testing.T) {
 			store := &fakeTalentNetworkStore{visibility: "off", publicID: uuid.New()}
 			app, token := talentNetworkApp(t, store)
 			resp := doTalentNetwork(t, app, fiber.MethodPut, body, token)
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusBadRequest {
 				t.Errorf("status = %d, want 400", resp.StatusCode)
 			}
@@ -173,11 +179,13 @@ func TestTalentNetwork_RequiresAuth(t *testing.T) {
 	app, _ := talentNetworkApp(t, store)
 
 	getResp := doTalentNetwork(t, app, fiber.MethodGet, "", "")
+	defer getResp.Body.Close()
 	if getResp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("GET status = %d, want 401", getResp.StatusCode)
 	}
 
 	putResp := doTalentNetwork(t, app, fiber.MethodPut, `{"visibility":"public"}`, "")
+	defer putResp.Body.Close()
 	if putResp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("PUT status = %d, want 401", putResp.StatusCode)
 	}

--- a/internal/handler/me_timeline_test.go
+++ b/internal/handler/me_timeline_test.go
@@ -50,7 +50,7 @@ func meTimelineApp(t *testing.T, store apptimeline.Queries) (*fiber.App, string)
 
 func getTimeline(t *testing.T, app *fiber.App, path, token string) (int, []byte) {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodGet, path, nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, path, nil)
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}

--- a/internal/handler/me_tracking_silence_test.go
+++ b/internal/handler/me_tracking_silence_test.go
@@ -51,7 +51,7 @@ func listSilence(t *testing.T, items []jobtracking.TrackedJob) []trackingRow {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/me/tracking", auth.RequireAuth(iss, testVersions), h.ListTrackedJobs)
 
-	req := httptest.NewRequest(http.MethodGet, "/me/tracking", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/tracking", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req, -1)
 	if err != nil {

--- a/internal/handler/me_tracking_test.go
+++ b/internal/handler/me_tracking_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,7 +31,7 @@ func meJobsApp(t *testing.T) (*fiber.App, string) {
 
 func getMeTracking(t *testing.T, app *fiber.App, path, token string) int {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodGet, path, nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, path, nil)
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}

--- a/internal/handler/me_usage_test.go
+++ b/internal/handler/me_usage_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -50,7 +51,7 @@ func usageApp(t *testing.T, gatewayURL string, userID int64) (*fiber.App, string
 
 func readUsage(t *testing.T, app *fiber.App, token string) (int, map[string]any) {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/usage", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/api/v1/me/usage", nil)
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}
@@ -201,7 +202,7 @@ func TestUsageNeitherNeedsNorReturnsACredential(t *testing.T) {
 	})
 	app, token := usageApp(t, gw.URL, 7)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/usage", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/api/v1/me/usage", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {

--- a/internal/handler/oauth_test.go
+++ b/internal/handler/oauth_test.go
@@ -72,7 +72,7 @@ func oauthApp(providers map[string]oauth.Provider) *fiber.App {
 
 func postOAuthJSON(t *testing.T, app *fiber.App, path, body string) *http.Response {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodPost, path, strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, path, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 	if err != nil {
@@ -83,7 +83,7 @@ func postOAuthJSON(t *testing.T, app *fiber.App, path, body string) *http.Respon
 
 func get(t *testing.T, app *fiber.App, path string, cookies ...string) *http.Response {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodGet, path, nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, path, nil)
 	for _, c := range cookies {
 		req.Header.Add("Cookie", c)
 	}
@@ -100,6 +100,7 @@ func TestListOAuthProviders(t *testing.T) {
 		"github": &fakeProvider{name: "github"},
 	})
 	resp := get(t, app, "/api/v1/auth/oauth/providers")
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -117,7 +118,9 @@ func TestListOAuthProviders(t *testing.T) {
 
 func TestOAuthStart_UnknownProviderIs404(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{})
-	if resp := get(t, app, "/api/v1/auth/oauth/myspace/start"); resp.StatusCode != fiber.StatusNotFound {
+	resp := get(t, app, "/api/v1/auth/oauth/myspace/start")
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusNotFound {
 		t.Errorf("status = %d, want 404", resp.StatusCode)
 	}
 }
@@ -125,6 +128,7 @@ func TestOAuthStart_UnknownProviderIs404(t *testing.T) {
 func TestOAuthStart_RedirectsWithStateCookie(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{"google": &fakeProvider{name: "google"}})
 	resp := get(t, app, "/api/v1/auth/oauth/google/start")
+	defer resp.Body.Close()
 
 	if resp.StatusCode != fiber.StatusFound {
 		t.Fatalf("status = %d, want 302", resp.StatusCode)
@@ -146,7 +150,9 @@ func TestOAuthStart_RedirectsWithStateCookie(t *testing.T) {
 
 func TestOAuthCallback_UnknownProviderIs404(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{})
-	if resp := get(t, app, "/api/v1/auth/oauth/myspace/callback?code=x&state=s"); resp.StatusCode != fiber.StatusNotFound {
+	resp := get(t, app, "/api/v1/auth/oauth/myspace/callback?code=x&state=s")
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusNotFound {
 		t.Errorf("status = %d, want 404", resp.StatusCode)
 	}
 }
@@ -155,6 +161,7 @@ func TestOAuthCallback_StateMismatchRedirectsWithError(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{"google": &fakeProvider{name: "google"}})
 	resp := get(t, app, "/api/v1/auth/oauth/google/callback?code=x&state=evil",
 		oauth.StateCookieName+"=good")
+	defer resp.Body.Close()
 
 	if resp.StatusCode != fiber.StatusFound {
 		t.Fatalf("status = %d, want 302", resp.StatusCode)
@@ -170,6 +177,7 @@ func TestOAuthCallback_StateMismatchRedirectsWithError(t *testing.T) {
 func TestOAuthCallback_MissingStateCookieRedirectsWithError(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{"google": &fakeProvider{name: "google"}})
 	resp := get(t, app, "/api/v1/auth/oauth/google/callback?code=x&state=s")
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusFound || resp.Header.Get("Location") != "http://app.example/?auth_error=oauth" {
 		t.Errorf("status/Location = %d %q, want error redirect", resp.StatusCode, resp.Header.Get("Location"))
 	}
@@ -180,7 +188,7 @@ func TestOAuthCallback_MissingStateCookieRedirectsWithError(t *testing.T) {
 // requested), unlike every other provider's GET query-string callback.
 func postFormOAuth(t *testing.T, app *fiber.App, path, body string, cookies ...string) *http.Response {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodPost, path, strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, path, strings.NewReader(body))
 	req.Header.Set("Content-Type", fiber.MIMEApplicationForm)
 	for _, c := range cookies {
 		req.Header.Add("Cookie", c)
@@ -202,6 +210,7 @@ func TestOAuthCallback_POSTFormBodyReachesProvider(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{"apple": provider})
 	resp := postFormOAuth(t, app, "/api/v1/auth/oauth/apple/callback", "code=x&state=s",
 		oauth.StateCookieName+"=s")
+	defer resp.Body.Close()
 
 	if resp.StatusCode != fiber.StatusFound {
 		t.Fatalf("status = %d, want 302", resp.StatusCode)
@@ -215,6 +224,7 @@ func TestOAuthCallback_POSTStateMismatchRedirectsWithError(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{"apple": &fakeProvider{name: "apple"}})
 	resp := postFormOAuth(t, app, "/api/v1/auth/oauth/apple/callback", "code=x&state=evil",
 		oauth.StateCookieName+"=good")
+	defer resp.Body.Close()
 
 	if loc := resp.Header.Get("Location"); loc != "http://app.example/?auth_error=oauth" {
 		t.Errorf("Location = %q, want auth_error redirect", loc)
@@ -224,6 +234,7 @@ func TestOAuthCallback_POSTStateMismatchRedirectsWithError(t *testing.T) {
 func TestOAuthCallback_MissingCodeRedirectsWithError(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{"google": &fakeProvider{name: "google"}})
 	resp := get(t, app, "/api/v1/auth/oauth/google/callback?state=s", oauth.StateCookieName+"=s")
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusFound || resp.Header.Get("Location") != "http://app.example/?auth_error=oauth" {
 		t.Errorf("status/Location = %d %q, want error redirect", resp.StatusCode, resp.Header.Get("Location"))
 	}
@@ -250,13 +261,14 @@ func TestOAuthCallback_ErrorRedirectUsesRequestOrigin(t *testing.T) {
 	// Force the state-mismatch error path; the redirect origin is what we assert.
 	// host drives requestOrigin, so it's set explicitly (app.Test needs Host set).
 	callback := func(host string) string {
-		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/auth/oauth/google/callback?code=x&state=evil", nil)
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/api/v1/auth/oauth/google/callback?code=x&state=evil", nil)
 		req.Host = host
 		req.Header.Add("Cookie", oauth.StateCookieName+"=good")
 		resp, err := newApp().Test(req)
 		if err != nil {
 			t.Fatalf("Test: %v", err)
 		}
+		defer resp.Body.Close()
 		return resp.Header.Get("Location")
 	}
 
@@ -274,6 +286,7 @@ func TestOAuthStart_MobileSetsPlatformCookie(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{"google": &fakeProvider{name: "google"}})
 
 	resp := get(t, app, "/api/v1/auth/oauth/google/start?platform=mobile")
+	defer resp.Body.Close()
 	setCookie := strings.Join(resp.Header.Values("Set-Cookie"), "\n")
 	if !strings.Contains(setCookie, oauth.PlatformCookieName+"=mobile") {
 		t.Errorf("Set-Cookie %q missing platform=mobile", setCookie)
@@ -281,6 +294,7 @@ func TestOAuthStart_MobileSetsPlatformCookie(t *testing.T) {
 
 	// A plain (web) start must not set the platform cookie.
 	web := get(t, app, "/api/v1/auth/oauth/google/start")
+	defer web.Body.Close()
 	if sc := strings.Join(web.Header.Values("Set-Cookie"), "\n"); strings.Contains(sc, oauth.PlatformCookieName+"=mobile") {
 		t.Errorf("web start unexpectedly set platform cookie: %q", sc)
 	}
@@ -292,6 +306,7 @@ func TestOAuthCallback_MobileErrorRedirectsToScheme(t *testing.T) {
 	// error must bounce to the app's custom scheme, not the web frontend.
 	resp := get(t, app, "/api/v1/auth/oauth/google/callback?code=x&state=evil",
 		oauth.StateCookieName+"=good", oauth.PlatformCookieName+"=mobile")
+	defer resp.Body.Close()
 
 	if resp.StatusCode != fiber.StatusFound {
 		t.Fatalf("status = %d, want 302", resp.StatusCode)
@@ -304,6 +319,7 @@ func TestOAuthCallback_MobileErrorRedirectsToScheme(t *testing.T) {
 func TestOAuthExchange_InvalidCodeIs401(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{})
 	resp := postOAuthJSON(t, app, "/api/v1/auth/oauth/exchange", `{"code":"nope"}`)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", resp.StatusCode)
 	}
@@ -315,6 +331,7 @@ func TestOAuthExchange_InvalidCodeIs401(t *testing.T) {
 func TestOAuthExchange_BadBodyIs400(t *testing.T) {
 	app := oauthApp(map[string]oauth.Provider{})
 	resp := postOAuthJSON(t, app, "/api/v1/auth/oauth/exchange", `not json`)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusBadRequest {
 		t.Errorf("status = %d, want 400", resp.StatusCode)
 	}
@@ -363,7 +380,7 @@ func originForHost(t *testing.T, h *authHandlers, host string) string {
 	app := fiber.New()
 	app.Get("/origin", func(c *fiber.Ctx) error { return c.SendString(h.requestOrigin(c)) })
 
-	req := httptest.NewRequest(fiber.MethodGet, "/origin", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/origin", nil)
 	req.Host = host
 	resp, err := app.Test(req)
 	if err != nil {

--- a/internal/handler/photo_test.go
+++ b/internal/handler/photo_test.go
@@ -143,7 +143,7 @@ func doPhotoImage(t *testing.T, app *fiber.App, token string) *http.Response {
 
 func doPhotoPath(t *testing.T, app *fiber.App, method, path string, body io.Reader, ctype, token string) *http.Response {
 	t.Helper()
-	req := httptest.NewRequest(method, path, body)
+	req := httptest.NewRequestWithContext(context.Background(), method, path, body)
 	if ctype != "" {
 		req.Header.Set("Content-Type", ctype)
 	}
@@ -369,7 +369,7 @@ func TestPhotoRegister_EveryRouteIsCookieOnly(t *testing.T) {
 		{http.MethodGet, "/api/v1/me/photo/image"},
 		{http.MethodDelete, "/api/v1/me/photo"},
 	} {
-		resp, err := app.Test(httptest.NewRequest(r.method, r.path, nil))
+		resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), r.method, r.path, nil))
 		if err != nil {
 			t.Fatalf("%s %s: %v", r.method, r.path, err)
 		}

--- a/internal/handler/recommendations_test.go
+++ b/internal/handler/recommendations_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -31,7 +32,7 @@ func recsApp(t *testing.T, store *resume.Store, s searcher) (*fiber.App, string)
 
 func getRecs(t *testing.T, app *fiber.App, token string) (status, count int) {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodGet, "/me/recommendations", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me/recommendations", nil)
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}
@@ -102,7 +103,7 @@ func TestRecommendations_FacetFilterReachesSearch(t *testing.T) {
 	fs := &fakeSearcher{recRes: search.SearchResult{Hits: []search.JobDocument{{}}, Total: 1}}
 	app, token := recsApp(t, store, fs)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me/recommendations?work_mode=remote", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me/recommendations?work_mode=remote", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
@@ -124,7 +125,7 @@ func TestRecommendations_FilterNoMatchEmpty(t *testing.T) {
 	fs := &fakeSearcher{recRes: search.SearchResult{}} // no hits
 	app, token := recsApp(t, store, fs)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/me/recommendations?work_mode=remote", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me/recommendations?work_mode=remote", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {

--- a/internal/handler/resume_experience_test.go
+++ b/internal/handler/resume_experience_test.go
@@ -125,7 +125,7 @@ func TestGetResumeServesBankedExperienceThroughAStaleWindow(t *testing.T) {
 	}}
 	app, token := resumeAppWithBank(t, store, bank)
 
-	req := httptest.NewRequest(http.MethodGet, "/me/resume", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/resume", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
@@ -167,7 +167,7 @@ func TestGetResumeProvisionalContactsThroughAStaleWindow(t *testing.T) {
 	bank := &fakeBank{history: []resumeextract.Experience{{Company: "RingCentral", Title: "SWE"}}}
 	app, token := resumeAppWithBank(t, store, bank)
 
-	req := httptest.NewRequest(http.MethodGet, "/me/resume", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/resume", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
@@ -212,7 +212,7 @@ func TestGetResumeOwnedContactsOverlayCurrentExtract(t *testing.T) {
 	store := resume.New(newFakeResumeBlobs(), repo)
 	app, token := resumeAppWithBank(t, store, &fakeBank{})
 
-	req := httptest.NewRequest(http.MethodGet, "/me/resume", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/resume", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
@@ -253,7 +253,7 @@ func TestGetResumeCurrentStructureKeepsSemanticSections(t *testing.T) {
 	store := resume.New(newFakeResumeBlobs(), repo)
 	app, token := resumeAppWithBank(t, store, &fakeBank{})
 
-	req := httptest.NewRequest(http.MethodGet, "/me/resume", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/resume", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
@@ -288,7 +288,7 @@ func TestGetResumeServesBankProjects(t *testing.T) {
 	}
 	app, token := resumeAppWithBank(t, store, bank)
 
-	req := httptest.NewRequest(http.MethodGet, "/me/resume", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/resume", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
@@ -324,7 +324,7 @@ func TestGetResumeServesPlacelessHighlights(t *testing.T) {
 	}
 	app, token := resumeAppWithBank(t, store, bank)
 
-	req := httptest.NewRequest(http.MethodGet, "/me/resume", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/me/resume", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {

--- a/internal/handler/resume_storage_test.go
+++ b/internal/handler/resume_storage_test.go
@@ -170,7 +170,7 @@ func resumeStorageApp(t *testing.T, store *resume.Store) (*fiber.App, string) {
 
 func resumeReq(t *testing.T, app *fiber.App, method, body, token string) (int, resumeMetaResponse) {
 	t.Helper()
-	req := httptest.NewRequest(method, "/me/resume", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), method, "/me/resume", strings.NewReader(body))
 	if body != "" {
 		req.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
 	}
@@ -301,7 +301,7 @@ func TestResume_PutContactsAndGetParseStatus(t *testing.T) {
 	store := resume.New(newFakeResumeBlobs(), repo)
 	app, token := resumeContactsApp(t, store)
 
-	req := httptest.NewRequest(fiber.MethodPut, "/me/resume/contacts", strings.NewReader(
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPut, "/me/resume/contacts", strings.NewReader(
 		`{"full_name":"Ada","email":"ada@example.com","links":["https://ada.example"]}`,
 	))
 	req.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
@@ -330,7 +330,7 @@ func TestResume_PutContactsAndGetParseStatus(t *testing.T) {
 func TestResume_RetryParseRequiresUpload(t *testing.T) {
 	store := resume.New(newFakeResumeBlobs(), &fakeResumeRepo{})
 	app, token := resumeContactsApp(t, store)
-	req := httptest.NewRequest(fiber.MethodPost, "/me/resume/parse", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/me/resume/parse", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
@@ -347,7 +347,7 @@ func TestResume_RetryParseMissingObject(t *testing.T) {
 	repo := &fakeResumeRepo{key: "resumes/1", set: true}
 	store := resume.New(newFakeResumeBlobs(), repo)
 	app, token := resumeContactsApp(t, store)
-	req := httptest.NewRequest(fiber.MethodPost, "/me/resume/parse", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/me/resume/parse", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
@@ -380,7 +380,7 @@ func TestResume_RetryParseMarksPending(t *testing.T) {
 	store := resume.New(blobs, repo)
 	app, token := resumeContactsApp(t, store)
 
-	req := httptest.NewRequest(fiber.MethodPost, "/me/resume/parse", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/me/resume/parse", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {

--- a/internal/handler/resume_test.go
+++ b/internal/handler/resume_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"mime/multipart"
@@ -36,7 +37,7 @@ func resumeApp(t *testing.T) (*fiber.App, string) {
 
 func postResumeJSON(t *testing.T, app *fiber.App, body, token string) *http.Response {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodPost, "/me/resume/extract", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/me/resume/extract", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
@@ -59,9 +60,9 @@ func postResumeFile(t *testing.T, app *fiber.App, filename string, content []byt
 	if _, err := fw.Write(content); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	w.Close()
+	_ = w.Close()
 
-	req := httptest.NewRequest(fiber.MethodPost, "/me/resume/extract", &buf)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/me/resume/extract", &buf)
 	req.Header.Set("Content-Type", w.FormDataContentType())
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
@@ -89,6 +90,7 @@ func decodeSkills(t *testing.T, resp *http.Response) []string {
 func TestExtractResumeProfile_Unauthenticated(t *testing.T) {
 	app, _ := resumeApp(t)
 	resp := postResumeJSON(t, app, `{"text":"Go and PostgreSQL"}`, "")
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", resp.StatusCode)
 	}
@@ -97,6 +99,7 @@ func TestExtractResumeProfile_Unauthenticated(t *testing.T) {
 func TestExtractResumeProfile_Text(t *testing.T) {
 	app, token := resumeApp(t)
 	resp := postResumeJSON(t, app, `{"text":"Experienced with PostgreSQL, Kubernetes and Docker."}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -109,6 +112,7 @@ func TestExtractResumeProfile_Text(t *testing.T) {
 func TestExtractResumeProfile_TextNoSkills(t *testing.T) {
 	app, token := resumeApp(t)
 	resp := postResumeJSON(t, app, `{"text":"I like long walks on the beach."}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -122,6 +126,7 @@ func TestExtractResumeProfile_TextNoSkills(t *testing.T) {
 func TestExtractResumeProfile_EmptyText(t *testing.T) {
 	app, token := resumeApp(t)
 	resp := postResumeJSON(t, app, `{"text":"   "}`, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusBadRequest {
 		t.Errorf("status = %d, want 400", resp.StatusCode)
 	}
@@ -134,6 +139,7 @@ func TestExtractResumeProfile_PDF(t *testing.T) {
 	}
 	app, token := resumeApp(t)
 	resp := postResumeFile(t, app, "resume.pdf", pdf, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -158,6 +164,7 @@ func TestExtractResumeProfile_CanvaCIDPDF(t *testing.T) {
 	}
 	app, token := resumeApp(t)
 	resp := postResumeFile(t, app, "resume.pdf", pdf, token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200 (Canva CID PDF must extract, not be rejected)", resp.StatusCode)
 	}
@@ -169,6 +176,7 @@ func TestExtractResumeProfile_CanvaCIDPDF(t *testing.T) {
 func TestExtractResumeProfile_MalformedPDF(t *testing.T) {
 	app, token := resumeApp(t)
 	resp := postResumeFile(t, app, "resume.pdf", []byte("this is not a pdf"), token)
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusBadRequest {
 		t.Errorf("status = %d, want 400", resp.StatusCode)
 	}

--- a/internal/handler/resume_verdict_test.go
+++ b/internal/handler/resume_verdict_test.go
@@ -72,7 +72,7 @@ func verdictApp(t *testing.T, repo *fakeProfileRepo, fc facetCounter) (*fiber.Ap
 
 func getVerdict(t *testing.T, app *fiber.App, target, token string) (int, map[string]any) {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodGet, target, nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, target, nil)
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}

--- a/internal/handler/search_test.go
+++ b/internal/handler/search_test.go
@@ -61,7 +61,7 @@ func searchApp(s searcher) *fiber.App {
 
 func doGet(t *testing.T, app *fiber.App, target string) (int, map[string]any) {
 	t.Helper()
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, target, nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, target, nil))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}

--- a/internal/handler/speech_test.go
+++ b/internal/handler/speech_test.go
@@ -69,7 +69,7 @@ func audioUpload(t *testing.T, data []byte, filename string) (io.Reader, string)
 
 func doTranscription(t *testing.T, app *fiber.App, body io.Reader, ctype, token string) *http.Response {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodPost, "/speech/transcriptions", body)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/speech/transcriptions", body)
 	if ctype != "" {
 		req.Header.Set("Content-Type", ctype)
 	}
@@ -281,7 +281,7 @@ func TestSpeechRegister_TakesTheMessageEndpointsGate(t *testing.T) {
 		cookie: namedGate("cookie"),
 	})
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/api/v1/speech/transcriptions", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/speech/transcriptions", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}

--- a/internal/handler/stats_test.go
+++ b/internal/handler/stats_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -112,11 +113,12 @@ func TestJobsActivityValidation(t *testing.T) {
 	h := &statsHandlers{}
 	app.Get("/api/v1/stats/jobs-activity", h.JobsActivity)
 
-	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/stats/jobs-activity?granularity=hour", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/api/v1/stats/jobs-activity?granularity=hour", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 (unauthenticated request reaches the handler and invalid granularity is a 400)", resp.StatusCode)
 	}

--- a/internal/handler/swipe_test.go
+++ b/internal/handler/swipe_test.go
@@ -36,7 +36,7 @@ func deckApp(s searcher, excluded []int64) (*fiber.App, *auth.Issuer) {
 
 func deckGet(t *testing.T, app *fiber.App, iss *auth.Issuer, target string) (int, map[string]any) {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodGet, target, nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, target, nil)
 	if iss != nil {
 		token, _ := iss.Issue(7, testTokenVersion)
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})

--- a/internal/handler/talent_network_profile_test.go
+++ b/internal/handler/talent_network_profile_test.go
@@ -45,7 +45,7 @@ func talentNetworkProfileApp(store *fakeTalentNetworkPublicStore) *fiber.App {
 
 func doTalentNetworkProfile(t *testing.T, app *fiber.App, publicID string) *http.Response {
 	t.Helper()
-	r := httptest.NewRequest(fiber.MethodGet, "/talent-network/"+publicID, nil)
+	r := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/talent-network/"+publicID, nil)
 	resp, err := app.Test(r)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
@@ -114,6 +114,7 @@ func TestTalentNetworkProfile_PublicMode(t *testing.T) {
 	app := talentNetworkProfileApp(store)
 
 	resp := doTalentNetworkProfile(t, app, id.String())
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -147,6 +148,7 @@ func TestTalentNetworkProfile_AnonymousMode(t *testing.T) {
 	app := talentNetworkProfileApp(store)
 
 	resp := doTalentNetworkProfile(t, app, id.String())
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -188,6 +190,7 @@ func TestTalentNetworkProfile_ProjectLinkNeverReachesEitherMode(t *testing.T) {
 			app := talentNetworkProfileApp(store)
 
 			resp := doTalentNetworkProfile(t, app, uuid.New().String())
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusOK {
 				t.Fatalf("status = %d, want 200", resp.StatusCode)
 			}
@@ -206,6 +209,7 @@ func TestTalentNetworkProfile_VisibilityOff(t *testing.T) {
 	app := talentNetworkProfileApp(store)
 
 	resp := doTalentNetworkProfile(t, app, uuid.New().String())
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusNotFound {
 		t.Fatalf("status = %d, want 404", resp.StatusCode)
 	}
@@ -217,6 +221,7 @@ func TestTalentNetworkProfile_NonexistentID(t *testing.T) {
 	app := talentNetworkProfileApp(store)
 
 	resp := doTalentNetworkProfile(t, app, uuid.New().String())
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusNotFound {
 		t.Fatalf("status = %d, want 404", resp.StatusCode)
 	}
@@ -228,6 +233,7 @@ func TestTalentNetworkProfile_MalformedID(t *testing.T) {
 	app := talentNetworkProfileApp(store)
 
 	resp := doTalentNetworkProfile(t, app, "not-a-uuid")
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusNotFound {
 		t.Fatalf("status = %d, want 404", resp.StatusCode)
 	}
@@ -240,14 +246,17 @@ func TestTalentNetworkProfile_MalformedID(t *testing.T) {
 func TestTalentNetworkProfile_OffAndNotFoundHaveIdenticalBody(t *testing.T) {
 	offStore := &fakeTalentNetworkPublicStore{row: db.GetTalentNetworkProfileByPublicIDRow{TalentNetworkVisibility: "off"}}
 	offResp := doTalentNetworkProfile(t, talentNetworkProfileApp(offStore), uuid.New().String())
+	defer offResp.Body.Close()
 	offBody := talentNetworkReadBody(t, offResp)
 
 	missingStore := &fakeTalentNetworkPublicStore{err: pgx.ErrNoRows}
 	missingResp := doTalentNetworkProfile(t, talentNetworkProfileApp(missingStore), uuid.New().String())
+	defer missingResp.Body.Close()
 	missingBody := talentNetworkReadBody(t, missingResp)
 
 	malformedStore := &fakeTalentNetworkPublicStore{}
 	malformedResp := doTalentNetworkProfile(t, talentNetworkProfileApp(malformedStore), "not-a-uuid")
+	defer malformedResp.Body.Close()
 	malformedBody := talentNetworkReadBody(t, malformedResp)
 
 	if offBody != missingBody || offBody != malformedBody {
@@ -270,6 +279,7 @@ func TestTalentNetworkProfile_NilProfileFacetsSerializeAsEmptyArrays(t *testing.
 	app := talentNetworkProfileApp(store)
 
 	resp := doTalentNetworkProfile(t, app, uuid.New().String())
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -293,6 +303,7 @@ func TestTalentNetworkProfile_EmptyResumeStructuredRendersEmptySections(t *testi
 			app := talentNetworkProfileApp(store)
 
 			resp := doTalentNetworkProfile(t, app, uuid.New().String())
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusOK {
 				t.Fatalf("status = %d, want 200", resp.StatusCode)
 			}

--- a/internal/handler/telegram_test.go
+++ b/internal/handler/telegram_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -31,11 +32,12 @@ func TestTelegramWebhook_emptySecretFailsClosed(t *testing.T) {
 	// empty — a naive ConstantTimeCompare("", "") would let a forged update in. The
 	// endpoint is not served at all in that state, so the refusal is a 404: an
 	// unsecurable webhook is unrepresentable, not merely guarded.
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/telegram/webhook", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/telegram/webhook", nil)
 	res, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", res.StatusCode)
 	}
@@ -44,12 +46,13 @@ func TestTelegramWebhook_emptySecretFailsClosed(t *testing.T) {
 func TestTelegramWebhook_secretMismatchForbidden(t *testing.T) {
 	app := webhookApp("hook-secret")
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/telegram/webhook", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/telegram/webhook", nil)
 	req.Header.Set("X-Telegram-Bot-Api-Secret-Token", "wrong")
 	res, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", res.StatusCode)
 	}

--- a/internal/handler/tracer_redirect_test.go
+++ b/internal/handler/tracer_redirect_test.go
@@ -46,7 +46,7 @@ func redirectApp(t *testing.T, links *fakeTracerLinks, signedInAs int64) *fiber.
 	t.Helper()
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	h := &tracerHandlers{links: links, salt: "pepper"}
-	var gate fiber.Handler = func(c *fiber.Ctx) error { return c.Next() }
+	var gate = func(c *fiber.Ctx) error { return c.Next() }
 	if signedInAs != 0 {
 		gate = signedIn(signedInAs)
 	}
@@ -60,7 +60,7 @@ const browserUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/5
 	"(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
 func humanGet(target string) *http.Request {
-	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
 	req.Header.Set("User-Agent", browserUA)
 	return req
 }
@@ -99,7 +99,7 @@ func TestARedirectSendsTheVisitorOnAndCountsTheClick(t *testing.T) {
 // wrong, and a bare 404 reads as a broken site rather than an expired link.
 func TestAnUnknownTokenIsGone(t *testing.T) {
 	links := &fakeTracerLinks{lookupErr: pgx.ErrNoRows}
-	resp, err := redirectApp(t, links, 0).Test(httptest.NewRequest(http.MethodGet, "/cv/never-existed", nil))
+	resp, err := redirectApp(t, links, 0).Test(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/cv/never-existed", nil))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestNothingInTheRequestCanChooseTheDestination(t *testing.T) {
 // detection rules from silently rewriting history.
 func TestAHeadRequestIsRecordedAsAutomated(t *testing.T) {
 	links := &fakeTracerLinks{row: linkRow()}
-	resp, err := redirectApp(t, links, 0).Test(httptest.NewRequest(http.MethodHead, "/cv/acme-x7abc", nil))
+	resp, err := redirectApp(t, links, 0).Test(httptest.NewRequestWithContext(context.Background(), http.MethodHead, "/cv/acme-x7abc", nil))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestOnlyTheReferrersHostIsKept(t *testing.T) {
 // — a case that would otherwise be tested by accident rather than on purpose.
 func TestARequestWithoutAUserAgentIsAutomated(t *testing.T) {
 	links := &fakeTracerLinks{row: linkRow()}
-	resp, err := redirectApp(t, links, 0).Test(httptest.NewRequest(http.MethodGet, "/cv/acme-x7abc", nil))
+	resp, err := redirectApp(t, links, 0).Test(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/cv/acme-x7abc", nil))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}

--- a/internal/handler/track_test.go
+++ b/internal/handler/track_test.go
@@ -103,13 +103,14 @@ func TestTrackJob_RejectsEmptyAndUnknownStage(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(fiber.MethodPatch, "/jobs/go-dev/track", strings.NewReader(tc.body))
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPatch, "/jobs/go-dev/track", strings.NewReader(tc.body))
 			req.Header.Set("Content-Type", "application/json")
 			req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 			resp, err := app.Test(req)
 			if err != nil {
 				t.Fatalf("Test: %v", err)
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != fiber.StatusBadRequest {
 				t.Errorf("status = %d, want 400", resp.StatusCode)
 			}
@@ -119,12 +120,13 @@ func TestTrackJob_RejectsEmptyAndUnknownStage(t *testing.T) {
 
 func TestTrackJob_RequiresAuth(t *testing.T) {
 	app, _ := trackApp()
-	req := httptest.NewRequest(fiber.MethodPatch, "/jobs/go-dev/track", strings.NewReader(`{"stage":"interview"}`))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPatch, "/jobs/go-dev/track", strings.NewReader(`{"stage":"interview"}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", resp.StatusCode)
 	}
@@ -160,13 +162,14 @@ func TestInteractionResponse_HasStageAndNotes(t *testing.T) {
 func TestTrackJob_AcceptsExpired(t *testing.T) {
 	app, iss := trackApp()
 	token, _ := iss.Issue(7, testTokenVersion)
-	req := httptest.NewRequest(fiber.MethodPatch, "/jobs/go-dev/track", strings.NewReader(`{"stage":"expired"}`))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPatch, "/jobs/go-dev/track", strings.NewReader(`{"stage":"expired"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200", resp.StatusCode)
 	}

--- a/internal/handler/user_jobs_test.go
+++ b/internal/handler/user_jobs_test.go
@@ -38,7 +38,7 @@ func postUserJob(t *testing.T, app *fiber.App, path, token string) int {
 
 func requestUserJob(t *testing.T, app *fiber.App, method, path, token string) int {
 	t.Helper()
-	req := httptest.NewRequest(method, path, nil)
+	req := httptest.NewRequestWithContext(context.Background(), method, path, nil)
 	if token != "" {
 		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	}
@@ -46,6 +46,7 @@ func requestUserJob(t *testing.T, app *fiber.App, method, path, token string) in
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	return resp.StatusCode
 }
 
@@ -168,13 +169,14 @@ func datedApplyApp(repo jobtracking.Repository) (*fiber.App, *auth.Issuer) {
 
 func postApply(t *testing.T, app *fiber.App, token, body string) int {
 	t.Helper()
-	req := httptest.NewRequest(fiber.MethodPost, "/jobs/go-dev/apply", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/jobs/go-dev/apply", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	return resp.StatusCode
 }
 

--- a/internal/handler/user_llm_test.go
+++ b/internal/handler/user_llm_test.go
@@ -38,7 +38,7 @@ func newSpendProxy(t *testing.T) *spendProxy {
 		p.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
+		_, _ = fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
 			`[{"index":0,"message":{"role":"assistant","content":"{}"},"finish_reason":"stop"}]}`)
 	}))
 	t.Cleanup(p.srv.Close)
@@ -182,7 +182,7 @@ func TestUserLLMForgetsARejectedCredentialAfterCancellation(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
+		_, _ = fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
 			`[{"index":0,"message":{"role":"assistant","content":"{}"},"finish_reason":"stop"}]}`)
 	}))
 	t.Cleanup(refusing.Close)

--- a/internal/headshot/exif_test.go
+++ b/internal/headshot/exif_test.go
@@ -29,15 +29,15 @@ func exifOrientationPayload(orientation uint16, bigEndian bool) []byte {
 	}
 	var tiff bytes.Buffer
 	tiff.Write(tag)
-	binary.Write(&tiff, order, uint16(42)) // TIFF magic
-	binary.Write(&tiff, order, uint32(8))  // IFD0 starts right after the header
-	binary.Write(&tiff, order, uint16(1))  // one entry
-	binary.Write(&tiff, order, uint16(0x0112))
-	binary.Write(&tiff, order, uint16(3)) // type SHORT
-	binary.Write(&tiff, order, uint32(1)) // count
-	binary.Write(&tiff, order, orientation)
-	tiff.Write([]byte{0, 0})              // SHORT occupies the first half of the value field
-	binary.Write(&tiff, order, uint32(0)) // no next IFD
+	_ = binary.Write(&tiff, order, uint16(42)) // TIFF magic
+	_ = binary.Write(&tiff, order, uint32(8))  // IFD0 starts right after the header
+	_ = binary.Write(&tiff, order, uint16(1))  // one entry
+	_ = binary.Write(&tiff, order, uint16(0x0112))
+	_ = binary.Write(&tiff, order, uint16(3)) // type SHORT
+	_ = binary.Write(&tiff, order, uint32(1)) // count
+	_ = binary.Write(&tiff, order, orientation)
+	tiff.Write([]byte{0, 0})                  // SHORT occupies the first half of the value field
+	_ = binary.Write(&tiff, order, uint32(0)) // no next IFD
 
 	return append([]byte("Exif\x00\x00"), tiff.Bytes()...)
 }

--- a/internal/jobreality/classify_test.go
+++ b/internal/jobreality/classify_test.go
@@ -115,7 +115,7 @@ func TestClassify_Deterministic(t *testing.T) {
 	in := base()
 	in.CreatedAt = daysAgo(200)
 	in.RepostCount, in.MassPostingCount, in.HasEvergreenText = 4, 6, true
-	if Classify(in) != Classify(in) {
+	if Classify(in) != Classify(in) { //nolint:staticcheck // SA4000: intentional determinism check, calling twice is the point
 		t.Error("classification not deterministic for identical input")
 	}
 }

--- a/internal/llm/credential_test.go
+++ b/internal/llm/credential_test.go
@@ -36,7 +36,7 @@ func newHeaderProxy(t *testing.T) *headerProxy {
 		p.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
+		_, _ = fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
 			`[{"index":0,"message":{"role":"assistant","content":"{}"},"finish_reason":"stop"}]}`)
 	}))
 	t.Cleanup(p.srv.Close)
@@ -197,11 +197,11 @@ func newRefusingProxy(t *testing.T, refuse string) *headerProxy {
 
 		if r.Header.Get("Authorization") == "Bearer "+refuse {
 			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Fprint(w, `{"error":"invalid key"}`)
+			_, _ = fmt.Fprint(w, `{"error":"invalid key"}`)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
+		_, _ = fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
 			`[{"index":0,"message":{"role":"assistant","content":"{}"},"finish_reason":"stop"}]}`)
 	}))
 	t.Cleanup(p.srv.Close)
@@ -265,7 +265,7 @@ func TestACeilingRefusalIsNotRetried(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		served++
 		w.WriteHeader(http.StatusTooManyRequests)
-		fmt.Fprint(w, `{"error":{"message":"ExceededBudget: Key over 30d budget."}}`)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"ExceededBudget: Key over 30d budget."}}`)
 	}))
 	t.Cleanup(srv.Close)
 

--- a/internal/llm/langfuse_test.go
+++ b/internal/llm/langfuse_test.go
@@ -148,7 +148,7 @@ func TestSend_postsToIngestionWithAuth(t *testing.T) {
 		var env struct {
 			Batch []json.RawMessage `json:"batch"`
 		}
-		json.NewDecoder(r.Body).Decode(&env)
+		_ = json.NewDecoder(r.Body).Decode(&env)
 		gotBatchLen = len(env.Batch)
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -180,7 +180,7 @@ func TestSend_207PartialErrorsAreLoggedNotFailed(t *testing.T) {
 	// transport failure.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMultiStatus)
-		w.Write([]byte(`{"successes":[],"errors":[{"id":"abc","status":400,"message":"trace name too long"}]}`))
+		_, _ = w.Write([]byte(`{"successes":[],"errors":[{"id":"abc","status":400,"message":"trace name too long"}]}`))
 	}))
 	defer srv.Close()
 
@@ -232,7 +232,7 @@ func TestObserveAndShutdown_flushesBufferedGenerations(t *testing.T) {
 		var env struct {
 			Batch []map[string]any `json:"batch"`
 		}
-		json.NewDecoder(r.Body).Decode(&env)
+		_ = json.NewDecoder(r.Body).Decode(&env)
 		for _, ev := range env.Batch {
 			if ev["type"] == "generation-create" {
 				gotGenerations++
@@ -312,7 +312,7 @@ func TestObserve_doesNotBlockWhenBufferFull(t *testing.T) {
 	close(release)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	tr.Shutdown(ctx)
+	_ = tr.Shutdown(ctx)
 }
 
 // newTestTracer builds a tracer pointing at a test server, with no async loop.

--- a/internal/llm/schema_test.go
+++ b/internal/llm/schema_test.go
@@ -40,14 +40,14 @@ func newRecordingProxy(t *testing.T) *recordingProxy {
 
 		if stream, _ := body["stream"].(bool); stream {
 			w.Header().Set("Content-Type", "text/event-stream")
-			fmt.Fprint(w, "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"choices\":"+
+			_, _ = fmt.Fprint(w, "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"choices\":"+
 				"[{\"index\":0,\"delta\":{\"content\":\"{}\"}}]}\n\n")
-			fmt.Fprint(w, "data: [DONE]\n\n")
+			_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
 			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
+		_, _ = fmt.Fprint(w, `{"id":"1","object":"chat.completion","choices":`+
 			`[{"index":0,"message":{"role":"assistant","content":"{}"},"finish_reason":"stop"}]}`)
 	}))
 	t.Cleanup(p.srv.Close)

--- a/internal/matchanalysis/analyzer.go
+++ b/internal/matchanalysis/analyzer.go
@@ -453,7 +453,7 @@ func writeAnchor(b *strings.Builder, m jobmatch.JobMatch) {
 	if len(m.Matched)+len(m.Adjacent)+len(m.Missing) == 0 {
 		return
 	}
-	b.WriteString(fmt.Sprintf("Deterministic skills match (coverage %d%%):\n", m.CoveragePercent))
+	fmt.Fprintf(b, "Deterministic skills match (coverage %d%%):\n", m.CoveragePercent)
 	if len(m.Matched) > 0 {
 		b.WriteString("- has: " + strings.Join(m.Matched, ", ") + "\n")
 	}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -17,9 +17,10 @@ import (
 	"log"
 	"strconv"
 
+	"slices"
+
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/search"
-	"slices"
 )
 
 // ChannelTelegram and ChannelEmail are the delivery channels implemented today;

--- a/internal/pipeline/apply_form_test.go
+++ b/internal/pipeline/apply_form_test.go
@@ -17,7 +17,7 @@ type formStore struct {
 }
 
 func (s *formStore) SaveWithApplyForm(ctx context.Context, j job.Job, form applyform.Form) error {
-	if err := s.fakeStore.Save(ctx, j); err != nil {
+	if err := s.Save(ctx, j); err != nil {
 		return err
 	}
 	if s.forms == nil {

--- a/internal/ratelimit/keys_test.go
+++ b/internal/ratelimit/keys_test.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -28,11 +29,12 @@ func TestKeyByIP_IncludesPrefix(t *testing.T) {
 		return c.SendString(key)
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/probe", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	body := readBody(t, resp)
 	if !strings.HasPrefix(body, "login:") {
 		t.Errorf("key = %q, want prefix %q", body, "login:")
@@ -44,8 +46,10 @@ func TestKeyByIP_DifferentPrefixesDoNotCollide(t *testing.T) {
 	app.Get("/a", func(c *fiber.Ctx) error { return c.SendString(KeyByIP("routeA")(c)) })
 	app.Get("/b", func(c *fiber.Ctx) error { return c.SendString(KeyByIP("routeB")(c)) })
 
-	respA, _ := app.Test(httptest.NewRequest(fiber.MethodGet, "/a", nil))
-	respB, _ := app.Test(httptest.NewRequest(fiber.MethodGet, "/b", nil))
+	respA, _ := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/a", nil))
+	defer respA.Body.Close()
+	respB, _ := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/b", nil))
+	defer respB.Body.Close()
 
 	keyA := readBody(t, respA)
 	keyB := readBody(t, respB)
@@ -61,11 +65,12 @@ func TestKeyByUserOrIP_UsesUserIDWhenAuthenticated(t *testing.T) {
 		return c.SendString(KeyByUserOrIP("photo")(c))
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/probe", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if got, want := readBody(t, resp), "photo:user:42"; got != want {
 		t.Errorf("key = %q, want %q", got, want)
 	}
@@ -77,11 +82,12 @@ func TestKeyByUserOrIP_FallsBackToIPWhenUnauthenticated(t *testing.T) {
 		return c.SendString(KeyByUserOrIP("photo")(c))
 	})
 
-	req := httptest.NewRequest(fiber.MethodGet, "/probe", nil)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	body := readBody(t, resp)
 	if !strings.HasPrefix(body, "photo:ip:") {
 		t.Errorf("key = %q, want prefix %q", body, "photo:ip:")
@@ -99,8 +105,10 @@ func TestKeyByUserOrIP_DifferentPrefixesDoNotCollideForSameUser(t *testing.T) {
 		return c.SendString(KeyByUserOrIP("contribution")(c))
 	})
 
-	respA, _ := app.Test(httptest.NewRequest(fiber.MethodGet, "/a", nil))
-	respB, _ := app.Test(httptest.NewRequest(fiber.MethodGet, "/b", nil))
+	respA, _ := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/a", nil))
+	defer respA.Body.Close()
+	respB, _ := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/b", nil))
+	defer respB.Body.Close()
 
 	keyA := readBody(t, respA)
 	keyB := readBody(t, respB)

--- a/internal/ratelimit/middleware_test.go
+++ b/internal/ratelimit/middleware_test.go
@@ -56,10 +56,11 @@ func TestMiddleware_AllowsUnderLimit(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/probe", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200", resp.StatusCode)
 	}
@@ -74,10 +75,11 @@ func TestMiddleware_NilThrottlerPassesThrough(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/probe", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200 (nil throttler fails open)", resp.StatusCode)
 	}
@@ -90,18 +92,20 @@ func TestMiddleware_BlocksOverLimitWithRetryAfter(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	first, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/probe", nil))
+	first, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
 	if err != nil {
 		t.Fatalf("first request: %v", err)
 	}
+	defer first.Body.Close()
 	if first.StatusCode != fiber.StatusOK {
 		t.Fatalf("first request status = %d, want 200", first.StatusCode)
 	}
 
-	second, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/probe", nil))
+	second, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
 	if err != nil {
 		t.Fatalf("second request: %v", err)
 	}
+	defer second.Body.Close()
 	if second.StatusCode != fiber.StatusTooManyRequests {
 		t.Errorf("second request status = %d, want 429", second.StatusCode)
 	}
@@ -116,10 +120,11 @@ func TestMiddleware_FailsOpenOnThrottlerError(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/probe", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200 (fail open)", resp.StatusCode)
 	}
@@ -132,10 +137,11 @@ func TestMiddleware_FailsOpenWhenThrottlerExceedsBoundedTimeout(t *testing.T) {
 	})
 
 	start := time.Now()
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/probe", nil), 1000)
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil), 1000)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	elapsed := time.Since(start)
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200 (fail open)", resp.StatusCode)
@@ -155,10 +161,11 @@ func TestMiddleware_FloorsRetryAfterToAtLeastOneSecond(t *testing.T) {
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/probe", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusTooManyRequests {
 		t.Fatalf("status = %d, want 429", resp.StatusCode)
 	}
@@ -182,7 +189,7 @@ func TestMiddleware_WithRedisThrottler_FailsOpenWhenRedisUnreachable(t *testing.
 		DialTimeout:   200 * time.Millisecond,
 		DialerRetries: 1,
 	})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	th := NewRedisThrottler(client)
 	app := fiber.New()
@@ -190,10 +197,11 @@ func TestMiddleware_WithRedisThrottler_FailsOpenWhenRedisUnreachable(t *testing.
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/probe", nil), 1000)
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil), 1000)
 	if err != nil {
 		t.Fatalf("Test: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200 (fail open through the real RedisThrottler + Middleware pair)", resp.StatusCode)
 	}

--- a/internal/ratelimit/redis_test.go
+++ b/internal/ratelimit/redis_test.go
@@ -90,7 +90,7 @@ func TestRedisThrottler_ReturnsErrorWhenRedisUnreachable(t *testing.T) {
 		DialTimeout:   200 * time.Millisecond,
 		DialerRetries: 1,
 	})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	th := NewRedisThrottler(client)
 

--- a/internal/safehttp/safehttp_test.go
+++ b/internal/safehttp/safehttp_test.go
@@ -62,7 +62,7 @@ func TestNewTransportWithProxy(t *testing.T) {
 	if tr.Proxy == nil {
 		t.Fatal("expected Transport.Proxy to be set")
 	}
-	got, err := tr.Proxy(httptest.NewRequest(http.MethodGet, "http://target.example/x", nil))
+	got, err := tr.Proxy(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://target.example/x", nil))
 	if err != nil {
 		t.Fatalf("proxy func: %v", err)
 	}
@@ -83,8 +83,13 @@ func TestClientRefusesLoopback(t *testing.T) {
 	defer srv.Close()
 
 	client := NewClient(5 * time.Second)
-	_, err := client.Get(srv.URL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := client.Do(req)
 	if err == nil {
+		resp.Body.Close()
 		t.Fatal("expected the guarded client to refuse a loopback target, got nil error")
 	}
 	if !strings.Contains(err.Error(), "blocked") {

--- a/internal/sources/dataart_test.go
+++ b/internal/sources/dataart_test.go
@@ -178,7 +178,7 @@ func TestDataartDetailRemoteWorkMode(t *testing.T) {
 }
 
 func TestDataartProviderAndBoardless(t *testing.T) {
-	var s Source = NewDataArt(nil)
+	var s = NewDataArt(nil)
 	if s.Provider() != "dataart" {
 		t.Errorf("Provider() = %q, want dataart", s.Provider())
 	}

--- a/internal/sources/neogov.go
+++ b/internal/sources/neogov.go
@@ -33,12 +33,8 @@ func NewNeogov(c neogovHTTP) Source { return neogov{http: c} }
 
 func (neogov) Provider() string { return "neogov" }
 
-const (
-	// neogovPageSize is the listing's fixed jobs-per-page; total is read from the count span.
-	neogovPageSize = 10
-	// neogovMaxPages bounds the walk far above any real agency's posting count.
-	neogovMaxPages = 200
-)
+// neogovMaxPages bounds the walk far above any real agency's posting count.
+const neogovMaxPages = 200
 
 // neogovXHR is the header the listing endpoint requires; without it it returns the SPA shell.
 var neogovXHR = map[string]string{"X-Requested-With": "XMLHttpRequest"}

--- a/internal/sources/onstrider_test.go
+++ b/internal/sources/onstrider_test.go
@@ -204,7 +204,7 @@ func TestOnstriderVacancyURL(t *testing.T) {
 }
 
 func TestOnstriderProviderBoardlessAndProxied(t *testing.T) {
-	var s Source = NewOnstrider(nil)
+	var s = NewOnstrider(nil)
 	if s.Provider() != "onstrider" {
 		t.Errorf("Provider() = %q, want onstrider", s.Provider())
 	}

--- a/internal/sources/wantapply_test.go
+++ b/internal/sources/wantapply_test.go
@@ -272,7 +272,7 @@ func TestWantapplyFetchNewSeenSkipsDetail(t *testing.T) {
 }
 
 func TestWantapplyProviderBoardlessAggregatorNotSelfClosing(t *testing.T) {
-	var s Source = NewWantapply(nil)
+	var s = NewWantapply(nil)
 	if s.Provider() != "wantapply" {
 		t.Errorf("Provider() = %q, want wantapply", s.Provider())
 	}

--- a/internal/sources/workday.go
+++ b/internal/sources/workday.go
@@ -226,10 +226,8 @@ func (s workday) pageAll(ctx context.Context, url string, appliedFacets map[stri
 	total := -1
 	offset := 0
 	page := first
-	for {
-		if len(page.JobPostings) == 0 {
-			break
-		}
+	for len(page.JobPostings) != 0 {
+
 		postings = append(postings, page.JobPostings...)
 		offset += len(page.JobPostings)
 		if total < 0 && page.Total > 0 {

--- a/internal/viewlog/file.go
+++ b/internal/viewlog/file.go
@@ -54,7 +54,7 @@ func (f LogFile) Open() (io.ReadCloser, error) {
 	}
 	zr, err := gzip.NewReader(file)
 	if err != nil {
-		file.Close()
+		_ = file.Close()
 		return nil, err
 	}
 	return gzipReadCloser{zr: zr, file: file}, nil

--- a/internal/viewlog/file_test.go
+++ b/internal/viewlog/file_test.go
@@ -19,8 +19,8 @@ func TestRotatedFiles(t *testing.T) {
 	writeGz := func(name, content string) {
 		var buf bytes.Buffer
 		zw := gzip.NewWriter(&buf)
-		zw.Write([]byte(content))
-		zw.Close()
+		_, _ = zw.Write([]byte(content))
+		_ = zw.Close()
 		if err := os.WriteFile(filepath.Join(dir, name), buf.Bytes(), 0o644); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Summary
golangci-lint runs in ratchet mode in CI (`--new-from-merge-base`), so the pre-existing backlog was never sized. An uncapped run (`--max-same-issues=0 --max-issues-per-linter=0`) found **409 issues**, not the ~96 the default-capped output implied — `bodyclose` and `noctx` were each one pattern repeated across 100+ near-identical test call sites, not that many distinct problems.

- **errcheck**: added `.golangci.yml` `exclude-functions` for `(io.Closer).Close`, `os.RemoveAll`, and `pgx.Tx.Rollback` (best-effort cleanup with no actionable recipient); hand-fixed the rest — defer-wrapped `Close` calls on concrete types the interface exclude can't match, and test-only writes to buffers/recorders that cannot fail.
- **misspell**: added `ignore-rules` for legitimate non-English words in classification dictionaries and test fixtures (Portuguese, German) — not typos, real lookup keys.
- **noctx**: `httptest.NewRequest` → `NewRequestWithContext` across ~130 call sites, plus `net.Listen` → `ListenConfig.Listen` and `http.Client.Get` → `NewRequestWithContext`+`Do` in the two non-httptest sites.
- **bodyclose**: added `defer resp.Body.Close()` at ~175 call sites, placed after the err-check where one exists (a deferred `Close` on a nil response would panic). 7 in `photo_test.go` are left as accepted false positives — already closed via a loop over a composite-literal slice the linter doesn't trace through.
- **staticcheck**: applied the auto-fixable `QF10xx` simplifications; kept two `SA4000` "identical expression" hits with a targeted `nolint` — both are intentional determinism checks (call the same pure function twice on purpose).
- **unused**: removed 3 confirmed-dead declarations.
- **unconvert**: fixed the one in `internal/handler`; left `cmd/reindex/diskguard.go`'s for #1860, already open for it.

## Test plan
- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `go vet ./...` and `go vet -tags=integration ./...` — clean
- [x] `go test ./...` — all pass except the pre-existing, unrelated `TestExtractResumeProfile_PDF` (needs `pdftotext`, not installed in this sandbox; CI installs poppler)
- [x] `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` — down to the 8 documented exceptions above (7 accepted bodyclose false positives + 1 unconvert deferred to #1860)