### PR TITLE
Fix pageup adapter dropping full description on teaser-summary boards

### DIFF
--- a/internal/sources/pageup.go
+++ b/internal/sources/pageup.go
@@ -67,11 +67,13 @@ func (p pageup) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	}
 
 	// Some tenants' listing rows carry no summary of any shape (e.g. board 798) — the
-	// full text lives only on the job's own detail page. Fan out just for those, so
-	// tenants whose listing already carries a summary never pay the extra request.
+	// full text lives only on the job's own detail page. Others carry a summary that's
+	// just a short teaser rather than the posting body (pageupAlwaysDetailBoards). Fan
+	// out for both, so tenants whose listing summary already IS the full text never pay
+	// the extra request.
 	var need []int
 	for i, j := range jobs {
-		if j.Description == "" {
+		if j.Description == "" || pageupAlwaysDetailBoards[e.Board] {
 			need = append(need, i)
 		}
 	}
@@ -95,6 +97,15 @@ func (p pageup) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 // since its listing already carries a summary) simply yields "" here, same as a fetch
 // failure: the posting keeps its empty description rather than being dropped.
 const pageupDetailDescriptionID = "job-details"
+
+// pageupAlwaysDetailBoards are tenants whose listing summary is a short teaser (one or two
+// sentences) rather than the actual posting body, so the "already has a summary" skip would
+// otherwise leave every job on the board stuck with that teaser. Confirmed on board 889
+// (Flight Centre): its listing row's "summary" carries a marketing blurb, while the full
+// posting lives in the same #job-details container the no-summary tenants use.
+var pageupAlwaysDetailBoards = map[string]bool{
+	"889": true,
+}
 
 // detailDescription fetches one job's detail page and returns its sanitized description
 // HTML, or "" when the fetch fails or the known container is absent.

--- a/internal/sources/pageup_test.go
+++ b/internal/sources/pageup_test.go
@@ -187,6 +187,36 @@ func TestPageupFetchSkipsDetailFetchWhenListingAlreadyHasSummary(t *testing.T) {
 	}
 }
 
+func TestPageupFetchAlwaysFetchesDetailOnTeaserSummaryBoard(t *testing.T) {
+	jobURL := "https://careers.pageuppeople.com/889/cw/en/job/532245/sales-travel-consultant"
+	fixture := `
+  <tr>
+    <td><a class="job-link" href="/889/cw/en/job/532245/sales-travel-consultant">Sales Travel Consultant</a></td>
+    <td><span class="location">South Australia</span></td>
+  </tr>
+  <tr class="summary"><td colspan="2">Start your travel career with Flight Centre!</td></tr>`
+	fake := &fakePageup{
+		search: fmt.Sprintf(`{"results":%q}`, fixture),
+		detail: map[string]string{
+			jobURL: `{"results":"<div id=\"job-details\"><p>The full posting body, much longer than the teaser.</p></div>"}`,
+		},
+	}
+
+	jobs, err := NewPageUp(fake).Fetch(context.Background(), CompanyEntry{Company: "Flight Centre", Provider: "pageup", Board: "889"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1: %+v", len(jobs), jobs)
+	}
+	if got := jobs[0].Description; got != "<p>The full posting body, much longer than the teaser.</p>" {
+		t.Errorf("Description = %q, want the detail page body, not the listing teaser", got)
+	}
+	if len(fake.calls) != 2 || fake.calls[1] != jobURL {
+		t.Errorf("calls = %v, want the search URL then exactly %q", fake.calls, jobURL)
+	}
+}
+
 func TestPageupFetchDetailFailureLeavesDescriptionEmptyRatherThanDroppingTheJob(t *testing.T) {
 	fake := &fakePageup{
 		search: fmt.Sprintf(`{"results":%q}`, pageupNoSummaryFixture),


### PR DESCRIPTION
## Summary
- Board 889 (Flight Centre) renders a short marketing teaser in its listing "summary" row, so the existing "listing already has a summary → skip detail fetch" logic never pulled the actual posting body from the detail page's `#job-details` container.
- Added `pageupAlwaysDetailBoards` to force a detail-page fetch for boards known to only carry a teaser in the listing, and enrolled board 889.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New test `TestPageupFetchAlwaysFetchesDetailOnTeaserSummaryBoard` covers the fix
- [ ] Reingest board 889 (`go run ./cmd/ingest sources/pageup.yml`) after merge to backfill full descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job listings now display complete descriptions instead of abbreviated teaser text for affected listings.
  * Listings without descriptions are enriched with details from their corresponding detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->