### PR TITLE
Wrap orphan <li> siblings left bare by malformed source HTML

### DIFF
--- a/internal/sources/sanitize.go
+++ b/internal/sources/sanitize.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/microcosm-cc/bluemonday"
+	xhtml "golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 // noBreakSpaces normalizes the no-break space characters that some ATS boards use
@@ -62,7 +64,103 @@ func sanitizeHTML(s string) string {
 		// Only a drop can empty a block, so a body with nothing stripped is never rewritten.
 		out = dropEmptyBlocks(out)
 	}
-	return out
+	return wrapOrphanListItems(out)
+}
+
+// wrapOrphanListItems wraps each maximal run of <li> siblings that lacks a <ul>/<ol>
+// parent in a synthetic <ul>. Some boards' source HTML drops the list wrapper partway
+// through a description (seen live: a posting whose first two bullet groups are
+// properly wrapped and a third is bare <li> siblings) — descriptionPolicy allows <li>
+// as a structural element but, being a sanitizer and not a tree validator, does not
+// require it to sit inside a list, so the malformed shape survives unchanged and
+// renders as a stray, un-announced bullet.
+//
+// Detecting "orphan" correctly needs real tree structure, not a regex — a properly
+// nested <li> inside <table>/<div> wrappers is indistinguishable from a bare one by
+// pattern alone. Returns s completely untouched, not merely equivalent, whenever
+// there is nothing to wrap (no <li> at all, or every one already sits in a list):
+// re-serializing a parsed tree can renormalize spelling bluemonday itself chose
+// (e.g. a void element written <br> comes back <br/> — equally valid HTML, but a
+// needless rewrite of the vast majority of descriptions that have no orphan at all).
+func wrapOrphanListItems(s string) string {
+	if !strings.Contains(s, "<li") {
+		return s
+	}
+	nodes, err := xhtml.ParseFragment(strings.NewReader(s), &xhtml.Node{
+		Type: xhtml.ElementNode, Data: "div", DataAtom: atom.Div,
+	})
+	if err != nil {
+		return s // malformed beyond repair — leave sanitizeHTML's output as-is
+	}
+
+	root := &xhtml.Node{Type: xhtml.ElementNode, Data: "div", DataAtom: atom.Div}
+	for _, n := range nodes {
+		root.AppendChild(n)
+	}
+	if !wrapOrphanListItemsIn(root) {
+		return s
+	}
+
+	var buf strings.Builder
+	for c := root.FirstChild; c != nil; c = c.NextSibling {
+		_ = xhtml.Render(&buf, c)
+	}
+	return buf.String()
+}
+
+// wrapOrphanListItemsIn recurses depth-first (so a nested orphan run inside a <div> or
+// <td> is fixed before its ancestor is considered), then splices every maximal run of
+// consecutive <li>/whitespace-text siblings under n into a new <ul> — unless n is
+// itself already a <ul>/<ol>, in which case its <li> children are already valid and
+// it is left untouched. Whitespace-only text nodes between <li> siblings (the newline
+// indentation typical of hand-written HTML) are pulled into the run too, so the
+// original spacing between items is preserved inside the new wrapper instead of being
+// severed from the list it separates. Reports whether it wrapped anything, which
+// gates whether the caller re-serializes at all.
+func wrapOrphanListItemsIn(n *xhtml.Node) bool {
+	changed := false
+	for c := n.FirstChild; c != nil; {
+		next := c.NextSibling
+		if c.Type == xhtml.ElementNode && wrapOrphanListItemsIn(c) {
+			changed = true
+		}
+		c = next
+	}
+
+	if n.DataAtom == atom.Ul || n.DataAtom == atom.Ol {
+		return changed
+	}
+
+	var run []*xhtml.Node
+	hasLi := false
+	flush := func() {
+		if !hasLi {
+			run = nil
+			return
+		}
+		ul := &xhtml.Node{Type: xhtml.ElementNode, Data: "ul", DataAtom: atom.Ul}
+		n.InsertBefore(ul, run[0])
+		for _, item := range run {
+			n.RemoveChild(item)
+			ul.AppendChild(item)
+		}
+		run, hasLi = nil, false
+		changed = true
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		switch {
+		case c.Type == xhtml.ElementNode && c.DataAtom == atom.Li:
+			run = append(run, c)
+			hasLi = true
+		case c.Type == xhtml.TextNode && strings.TrimSpace(c.Data) == "":
+			run = append(run, c)
+		default:
+			flush()
+		}
+	}
+	flush()
+	return changed
 }
 
 var (

--- a/internal/sources/sanitize.go
+++ b/internal/sources/sanitize.go
@@ -119,12 +119,13 @@ func wrapOrphanListItems(s string) string {
 // gates whether the caller re-serializes at all.
 func wrapOrphanListItemsIn(n *xhtml.Node) bool {
 	changed := false
-	for c := n.FirstChild; c != nil; {
-		next := c.NextSibling
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		// The recursive call only splices c's own children, never c's siblings,
+		// so c.NextSibling stays valid across the call — unlike the second loop
+		// below, which does reorder n's children and so must snapshot ahead.
 		if c.Type == xhtml.ElementNode && wrapOrphanListItemsIn(c) {
 			changed = true
 		}
-		c = next
 	}
 
 	if n.DataAtom == atom.Ul || n.DataAtom == atom.Ol {

--- a/internal/sources/sanitize_test.go
+++ b/internal/sources/sanitize_test.go
@@ -133,6 +133,47 @@ func TestSanitizeHTMLNormalizesNoBreakSpaces(t *testing.T) {
 	}
 }
 
+// Some ATS boards emit a description whose list wrapper drops out partway through —
+// seen live on a real posting: two properly-wrapped bullet groups followed by a third
+// group of bare <li> siblings with no <ul>/<ol> around them at all. bluemonday allows
+// <li> as a structural element but does not require a list parent, so the malformed
+// shape survived sanitization unchanged and Lighthouse flags it (a <li> outside a list
+// has no list semantics for a screen reader). sanitizeHTML now wraps any such orphan
+// run in a synthetic <ul>, and leaves an already-correct <ul> byte-for-byte untouched.
+func TestSanitizeHTMLWrapsOrphanListItems(t *testing.T) {
+	cases := map[string]struct{ in, want string }{
+		"bare li with no list at all": {
+			`<p><strong>Qualifications:</strong></p><li>A</li><li>B</li>`,
+			`<p><strong>Qualifications:</strong></p><ul><li>A</li><li>B</li></ul>`,
+		},
+		"already-wrapped list is untouched": {
+			`<ul><li>Ship features</li></ul>`,
+			`<ul><li>Ship features</li></ul>`,
+		},
+		"mixed real-world shape: two valid lists then an orphan run": {
+			"<p><strong>Minimum Qualifications:</strong></p>\n<ul>\n <li>ADN</li>\n <li>RN license</li>\n</ul>\n" +
+				"<p><strong>Essential Functions:</strong></p>\n<li>Acts as liaison</li>\n<li>Coordinates care</li>",
+			"<p><strong>Minimum Qualifications:</strong></p>\n<ul>\n <li>ADN</li>\n <li>RN license</li>\n</ul>\n" +
+				"<p><strong>Essential Functions:</strong></p><ul>\n<li>Acts as liaison</li>\n<li>Coordinates care</li></ul>",
+		},
+	}
+	for name, c := range cases {
+		if got := sanitizeHTML(c.in); got != c.want {
+			t.Errorf("%s: sanitizeHTML(%q) = %q, want %q", name, c.in, got, c.want)
+		}
+	}
+}
+
+// The backfill re-runs this pipeline over already-sanitized rows, so wrapping must be
+// a no-op on its own output — otherwise every run would keep rewriting the catalogue.
+func TestSanitizeHTMLWrapsOrphanListItemsIsIdempotent(t *testing.T) {
+	in := `<p>Qualifications:</p><li>A</li><li>B</li>`
+	once := sanitizeHTML(in)
+	if twice := sanitizeHTML(once); twice != once {
+		t.Errorf("sanitizeHTML is not idempotent:\nonce:  %q\ntwice: %q", once, twice)
+	}
+}
+
 func TestLenientPercentUnescape(t *testing.T) {
 	cases := map[string]struct{ in, want string }{
 		"plain":              {"hello world", "hello world"},

--- a/internal/sources/sanitize_test.go
+++ b/internal/sources/sanitize_test.go
@@ -151,9 +151,9 @@ func TestSanitizeHTMLWrapsOrphanListItems(t *testing.T) {
 			`<ul><li>Ship features</li></ul>`,
 		},
 		"mixed real-world shape: two valid lists then an orphan run": {
-			"<p><strong>Minimum Qualifications:</strong></p>\n<ul>\n <li>ADN</li>\n <li>RN license</li>\n</ul>\n" +
+			"<p><strong>Minimum Qualifications:</strong></p>\n<ul>\n <li>Nursing degree</li>\n <li>RN license</li>\n</ul>\n" +
 				"<p><strong>Essential Functions:</strong></p>\n<li>Acts as liaison</li>\n<li>Coordinates care</li>",
-			"<p><strong>Minimum Qualifications:</strong></p>\n<ul>\n <li>ADN</li>\n <li>RN license</li>\n</ul>\n" +
+			"<p><strong>Minimum Qualifications:</strong></p>\n<ul>\n <li>Nursing degree</li>\n <li>RN license</li>\n</ul>\n" +
 				"<p><strong>Essential Functions:</strong></p><ul>\n<li>Acts as liaison</li>\n<li>Coordinates care</li></ul>",
 		},
 	}


### PR DESCRIPTION
## Summary
- A Lighthouse audit of a job detail page flagged `<li>` elements with no `<ul>`/`<ol>` parent — screen readers get no list semantics for them.
- Root cause: `descriptionPolicy` (bluemonday) allows `<li>` as a structural element but doesn't require a list parent, so a source board that drops its list wrapper partway through a posting passes through unchanged. Confirmed on 3 independent real postings across different sources, not a one-off.
- `wrapOrphanListItems` parses the sanitized output and wraps each maximal run of orphan `<li>` siblings in a synthetic `<ul>`. It returns the original string untouched whenever there's nothing to wrap (no `<li>` at all, or every one already in a list) — re-serializing unconditionally would renormalize spelling bluemonday itself chose (e.g. `<br>` → `<br/>`) on the vast majority of descriptions that have no orphan at all. Caught this via a pre-existing fixture test before it shipped.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...` — full suite green, including new `TestSanitizeHTMLWrapsOrphanListItems` (bare-list, already-wrapped-untouched, and the real mixed-shape case) and an idempotency test (the backfill worker re-runs this pipeline over already-sanitized rows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML sanitization by automatically grouping standalone list items into properly structured lists.
  * Preserved existing valid lists and whitespace while handling mixed list content more reliably.
  * Ensured repeated sanitization produces consistent results without unnecessary changes.

* **Tests**
  * Added coverage for orphan list items, mixed valid and invalid list structures, and repeatable sanitization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->