### PR TITLE
Cover companies and job detail pages in the Lighthouse watchdog

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -201,9 +201,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Run Lighthouse against production (headroom-based score floors)
-        # Score floors live in perf/lighthouse/lighthouserc.json, generous below
-        # the ~74/85/73/100 (perf/a11y/best-practices/seo) baseline observed on
-        # freehire.me — tighten as the baseline firms up, same as k6's SLOs above.
+        # URLs + score floors live in perf/lighthouse/lighthouserc.json. Floors
+        # are generous below the ~74/85/73/100 (perf/a11y/best-practices/seo)
+        # homepage baseline — tighten as baselines firm up, same as k6's SLOs
+        # above. The same floors apply to all four pages: companies and jobview
+        # both scored higher than the homepage when audited, so the shared floor
+        # has headroom everywhere, not just on the page it was measured against.
         uses: treosh/lighthouse-ci-action@v12
         with:
           configPath: ./perf/lighthouse/lighthouserc.json

--- a/perf/lighthouse/lighthouserc.json
+++ b/perf/lighthouse/lighthouserc.json
@@ -1,7 +1,12 @@
 {
   "ci": {
     "collect": {
-      "url": ["https://freehire.me/"],
+      "url": [
+        "https://freehire.me/",
+        "https://freehire.me/companies",
+        "https://freehire.me/companies/starbridge",
+        "https://freehire.me/jobs/ai-engineer-emea-latam-starbridge-ijusmrsd"
+      ],
       "numberOfRuns": 3
     },
     "assert": {


### PR DESCRIPTION
## Summary
- The Lighthouse prod watchdog only checked the homepage. Adds three more URLs to `perf/lighthouse/lighthouserc.json`: `/companies` (list), `/companies/starbridge` (a company page with real content), `/jobs/ai-engineer-emea-latam-starbridge-ijusmrsd` (a job detail page) — matching the pages covered in the manual Lighthouse pass this watchdog exists to keep honest.
- Same score floors apply to all four pages; both new page types scored higher than the homepage baseline in the manual audit, so there's headroom everywhere.

## Note
The job URL points at a real, currently-open posting (confirmed 200 before pushing). Individual job postings close over time (unlike company slugs), so this URL will eventually need swapping for a live one when it starts 404ing.

## Test plan
- [x] JSON/YAML validated
- [x] Both new pinned URLs confirmed live (200) before committing