### PR TITLE
Add 8 verified boards + drain link-contribution review queue

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14429,3 +14429,13 @@
   board: unusualmachines
 - company: Western Union
   board: westernunion
+- company: Chatbooks
+  board: chatbooks
+- company: CycloKinetics
+  board: cyclokinetics
+- company: Spaceship
+  board: spaceship
+- company: TOKEN2049
+  board: token2049
+- company: WebChart
+  board: webchartnow

--- a/sources/join.yml
+++ b/sources/join.yml
@@ -8403,3 +8403,5 @@
   board: "185256"
 - company: senvo GmbH # senvo
   board: "143084"
+- company: D4L data4life gGmbH # data4lifecare
+  board: "842"

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4435,3 +4435,7 @@
   board: qrypt
 - company: VTG
   board: vtg
+- company: Kasheesh
+  board: kasheesh
+- company: Velaura
+  board: velaura


### PR DESCRIPTION
## Summary
- Adds 8 companies missing from our board catalogue, each live-validated against its public listing API before being added: Chatbooks, CycloKinetics, Spaceship, TOKEN2049, WebChart (all Greenhouse), Kasheesh, Velaura (Lever), and D4L data4life gGmbH (Join.com).
- Drains the `link_contributions` review queue (48 rows the URL recognizer couldn't map to a supported ATS): 1 new board (data4lifecare, above), 5 rows that turned out to already be tracked under a different URL shape (Ashby `resend`/`headway`, Greenhouse `trustpilot`, Gupy `Riachuelo`/`Franq`), and the rest rejected as staffing-agency aggregate listings, dead links, or platforms we don't have an adapter for.
- `link_contributions` status flips (onboarded/rejected) and the contribution-credit award for row 266 will be applied on prod after this merges, per the `onboard-contributions` runbook.

## Test plan
- [x] `go run ./cmd/validate-sources` — OK, 203 files checked
- [x] `go build ./...` && `go vet ./...`
- [x] Every added board live-validated against its ATS's own public listing API immediately before adding (non-zero current postings)