### PR TITLE
Link a multi-job digest notification to its matched jobs

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -933,6 +933,7 @@ type UserNotification struct {
 	PublicSlug pgtype.Text        `json:"public_slug"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	ReadAt     pgtype.Timestamptz `json:"read_at"`
+	Jobs       json.RawMessage    `json:"jobs"`
 }
 
 type UserProfile struct {

--- a/internal/db/notifications.sql.go
+++ b/internal/db/notifications.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -33,8 +34,50 @@ func (q *Queries) CountUserNotifications(ctx context.Context, userID int64) (Cou
 	return i, err
 }
 
+const getNotification = `-- name: GetNotification :one
+SELECT id, kind, title, body, public_slug, jobs, created_at, read_at
+FROM user_notifications
+WHERE id = $1 AND user_id = $2
+`
+
+type GetNotificationParams struct {
+	ID     int64 `json:"id"`
+	UserID int64 `json:"user_id"`
+}
+
+type GetNotificationRow struct {
+	ID         int64              `json:"id"`
+	Kind       string             `json:"kind"`
+	Title      string             `json:"title"`
+	Body       string             `json:"body"`
+	PublicSlug pgtype.Text        `json:"public_slug"`
+	Jobs       json.RawMessage    `json:"jobs"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	ReadAt     pgtype.Timestamptz `json:"read_at"`
+}
+
+// One notification, owner-scoped (no row for another user's id, mapped to 404
+// by the handler) — the direct-link/detail read a bookmarked or freshly
+// visited /my/notifications/[id]/jobs page needs, since ListUserNotifications
+// alone only serves the caller's own current page of the list.
+func (q *Queries) GetNotification(ctx context.Context, arg GetNotificationParams) (GetNotificationRow, error) {
+	row := q.db.QueryRow(ctx, getNotification, arg.ID, arg.UserID)
+	var i GetNotificationRow
+	err := row.Scan(
+		&i.ID,
+		&i.Kind,
+		&i.Title,
+		&i.Body,
+		&i.PublicSlug,
+		&i.Jobs,
+		&i.CreatedAt,
+		&i.ReadAt,
+	)
+	return i, err
+}
+
 const listUserNotifications = `-- name: ListUserNotifications :many
-SELECT id, kind, title, body, public_slug, created_at, read_at
+SELECT id, kind, title, body, public_slug, jobs, created_at, read_at
 FROM user_notifications
 WHERE user_id = $1
 ORDER BY created_at DESC, id DESC
@@ -53,6 +96,7 @@ type ListUserNotificationsRow struct {
 	Title      string             `json:"title"`
 	Body       string             `json:"body"`
 	PublicSlug pgtype.Text        `json:"public_slug"`
+	Jobs       json.RawMessage    `json:"jobs"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	ReadAt     pgtype.Timestamptz `json:"read_at"`
 }
@@ -74,6 +118,7 @@ func (q *Queries) ListUserNotifications(ctx context.Context, arg ListUserNotific
 			&i.Title,
 			&i.Body,
 			&i.PublicSlug,
+			&i.Jobs,
 			&i.CreatedAt,
 			&i.ReadAt,
 		); err != nil {
@@ -128,22 +173,25 @@ func (q *Queries) MarkNotificationRead(ctx context.Context, arg MarkNotification
 }
 
 const recordNotification = `-- name: RecordNotification :exec
-INSERT INTO user_notifications (user_id, kind, title, body, public_slug)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO user_notifications (user_id, kind, title, body, public_slug, jobs)
+VALUES ($1, $2, $3, $4, $5, $6)
 `
 
 type RecordNotificationParams struct {
-	UserID     int64       `json:"user_id"`
-	Kind       string      `json:"kind"`
-	Title      string      `json:"title"`
-	Body       string      `json:"body"`
-	PublicSlug pgtype.Text `json:"public_slug"`
+	UserID     int64           `json:"user_id"`
+	Kind       string          `json:"kind"`
+	Title      string          `json:"title"`
+	Body       string          `json:"body"`
+	PublicSlug pgtype.Text     `json:"public_slug"`
+	Jobs       json.RawMessage `json:"jobs"`
 }
 
 // Record one delivered notify/reminder/nudge event for the in-app notification
 // center, independent of which channel(s) carried it. Called right alongside
 // each engine's own "marked delivered" write; a failure here must never fail
-// the delivery it accompanies (see the add-notification-center design).
+// the delivery it accompanies (see the add-notification-center design). jobs
+// is only ever set by a multi-job subscription digest (see 0091); every other
+// kind, and a single-job digest, passes NULL and relies on public_slug instead.
 func (q *Queries) RecordNotification(ctx context.Context, arg RecordNotificationParams) error {
 	_, err := q.db.Exec(ctx, recordNotification,
 		arg.UserID,
@@ -151,6 +199,7 @@ func (q *Queries) RecordNotification(ctx context.Context, arg RecordNotification
 		arg.Title,
 		arg.Body,
 		arg.PublicSlug,
+		arg.Jobs,
 	)
 	return err
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1136,6 +1136,11 @@ type Querier interface {
 	// when they have not left one yet. Not filtered by status: the owner can still
 	// see and edit their own review after a moderator hides it.
 	GetMyCompanyFeedback(ctx context.Context, arg GetMyCompanyFeedbackParams) (CompanyFeedback, error)
+	// One notification, owner-scoped (no row for another user's id, mapped to 404
+	// by the handler) — the direct-link/detail read a bookmarked or freshly
+	// visited /my/notifications/[id]/jobs page needs, since ListUserNotifications
+	// alone only serves the caller's own current page of the list.
+	GetNotification(ctx context.Context, arg GetNotificationParams) (GetNotificationRow, error)
 	// The caller's notification rule, shared by saved-job reminders and both
 	// lifecycle nudges. No row -> pgx.ErrNoRows, which the service reads as the
 	// opt-out-by-default state (never configured; see the
@@ -2452,7 +2457,9 @@ type Querier interface {
 	// Record one delivered notify/reminder/nudge event for the in-app notification
 	// center, independent of which channel(s) carried it. Called right alongside
 	// each engine's own "marked delivered" write; a failure here must never fail
-	// the delivery it accompanies (see the add-notification-center design).
+	// the delivery it accompanies (see the add-notification-center design). jobs
+	// is only ever set by a multi-job subscription digest (see 0091); every other
+	// kind, and a single-job digest, passes NULL and relies on public_slug instead.
 	RecordNotification(ctx context.Context, arg RecordNotificationParams) error
 	// Record one matched nudge candidate. The unique index on
 	// (user_id, job_id, kind, episode_key) makes this idempotent — re-scanning the

--- a/internal/db/queries/notifications.sql
+++ b/internal/db/queries/notifications.sql
@@ -2,18 +2,29 @@
 -- Record one delivered notify/reminder/nudge event for the in-app notification
 -- center, independent of which channel(s) carried it. Called right alongside
 -- each engine's own "marked delivered" write; a failure here must never fail
--- the delivery it accompanies (see the add-notification-center design).
-INSERT INTO user_notifications (user_id, kind, title, body, public_slug)
-VALUES ($1, $2, $3, $4, sqlc.narg(public_slug));
+-- the delivery it accompanies (see the add-notification-center design). jobs
+-- is only ever set by a multi-job subscription digest (see 0091); every other
+-- kind, and a single-job digest, passes NULL and relies on public_slug instead.
+INSERT INTO user_notifications (user_id, kind, title, body, public_slug, jobs)
+VALUES ($1, $2, $3, $4, sqlc.narg(public_slug), sqlc.narg(jobs));
 
 -- name: ListUserNotifications :many
 -- The caller's own notifications, newest first, standard offset/limit paging
 -- (matching every other /me/* list endpoint in this codebase).
-SELECT id, kind, title, body, public_slug, created_at, read_at
+SELECT id, kind, title, body, public_slug, jobs, created_at, read_at
 FROM user_notifications
 WHERE user_id = $1
 ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg(lim) OFFSET sqlc.arg(off);
+
+-- name: GetNotification :one
+-- One notification, owner-scoped (no row for another user's id, mapped to 404
+-- by the handler) — the direct-link/detail read a bookmarked or freshly
+-- visited /my/notifications/[id]/jobs page needs, since ListUserNotifications
+-- alone only serves the caller's own current page of the list.
+SELECT id, kind, title, body, public_slug, jobs, created_at, read_at
+FROM user_notifications
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
 
 -- name: CountUserNotifications :one
 -- Total and unread counts in one statement and one set of predicates, so the

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -137,6 +137,7 @@ func (h *authHandlers) register(api fiber.Router, mw middleware) {
 	// every delivered subscription digest/reminder/nudge. Cookie-only, same
 	// reasoning as push-token management.
 	meGroup.Get("/notifications", mw.cookie, h.GetNotifications)
+	meGroup.Get("/notifications/:id", mw.cookie, h.GetNotification)
 	meGroup.Post("/notifications/:id/read", mw.cookie, h.MarkNotificationRead)
 	meGroup.Post("/notifications/read-all", mw.cookie, h.MarkAllNotificationsRead)
 

--- a/internal/handler/me_notifications.go
+++ b/internal/handler/me_notifications.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"encoding/json"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -11,13 +13,16 @@ import (
 // internal job id is exposed — only the public slug, same rule DigestJob
 // already follows. public_slug/created_at/read_at use pgtype's own JSON
 // marshaling (null when not Valid), the same convention pushTokenResponse
-// already uses.
+// already uses. jobs passes the stored json.RawMessage straight through
+// (null for every kind but a multi-job digest) — omitempty so a normal
+// notification's response doesn't carry a spurious `"jobs":null`.
 type notificationResponse struct {
 	ID         int64              `json:"id"`
 	Kind       string             `json:"kind"`
 	Title      string             `json:"title"`
 	Body       string             `json:"body"`
 	PublicSlug pgtype.Text        `json:"public_slug"`
+	Jobs       json.RawMessage    `json:"jobs,omitempty"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	ReadAt     pgtype.Timestamptz `json:"read_at"`
 }
@@ -29,6 +34,20 @@ func toNotificationResponse(r db.ListUserNotificationsRow) notificationResponse 
 		Title:      r.Title,
 		Body:       r.Body,
 		PublicSlug: r.PublicSlug,
+		Jobs:       r.Jobs,
+		CreatedAt:  r.CreatedAt,
+		ReadAt:     r.ReadAt,
+	}
+}
+
+func toNotificationResponseFromGet(r db.GetNotificationRow) notificationResponse {
+	return notificationResponse{
+		ID:         r.ID,
+		Kind:       r.Kind,
+		Title:      r.Title,
+		Body:       r.Body,
+		PublicSlug: r.PublicSlug,
+		Jobs:       r.Jobs,
 		CreatedAt:  r.CreatedAt,
 		ReadAt:     r.ReadAt,
 	}
@@ -70,6 +89,29 @@ func (h *authHandlers) GetNotifications(c *fiber.Ctx) error {
 			"offset":       offset,
 		},
 	})
+}
+
+// GetNotification returns one of the caller's own notifications, including
+// its jobs snapshot when it has one — the read a direct visit or bookmark of
+// /my/notifications/[id]/jobs needs, since the list page alone only ever
+// serves whatever offset the caller last paged to. Owner-scoped: another
+// user's id — or a nonexistent one — 404s rather than revealing which.
+// Cookie-only.
+func (h *authHandlers) GetNotification(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := pathID(c)
+	if err != nil {
+		return err
+	}
+
+	row, err := h.queries.GetNotification(c.Context(), db.GetNotificationParams{ID: id, UserID: userID})
+	if err != nil {
+		return err // pgx.ErrNoRows → 404 via the central error handler
+	}
+	return c.JSON(fiber.Map{"data": toNotificationResponseFromGet(row)})
 }
 
 // MarkNotificationRead marks one of the caller's own notifications read.

--- a/internal/handler/me_notifications_integration_test.go
+++ b/internal/handler/me_notifications_integration_test.go
@@ -28,6 +28,7 @@ func notificationsIntegrationApp(queries *db.Queries, iss *auth.Issuer) *fiber.A
 	h := &authHandlers{queries: queries}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/me/notifications", auth.RequireAuth(iss, testVersions), h.GetNotifications)
+	app.Get("/api/v1/me/notifications/:id", auth.RequireAuth(iss, testVersions), h.GetNotification)
 	app.Post("/api/v1/me/notifications/:id/read", auth.RequireAuth(iss, testVersions), h.MarkNotificationRead)
 	app.Post("/api/v1/me/notifications/read-all", auth.RequireAuth(iss, testVersions), h.MarkAllNotificationsRead)
 	return app
@@ -186,6 +187,76 @@ func TestNotificationsEndToEnd_MarkRead(t *testing.T) {
 		resp, err := app.Test(cookiePostReq(iss, aliceID, "/api/v1/me/notifications/999999999/read"))
 		if err != nil {
 			t.Fatalf("mark read nonexistent: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+	})
+}
+
+func TestNotificationsEndToEnd_GetOne(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	aliceID := seedNotificationsUser(t, pool, "notif-get-alice@example.test")
+	bobID := seedNotificationsUser(t, pool, "notif-get-bob@example.test")
+
+	var digestID int64
+	const jobsJSON = `[{"title":"Backend Engineer","company":"Acme","slug":"acme-backend-engineer"},{"title":"SRE","company":"Acme","slug":"acme-sre"}]`
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO user_notifications (user_id, kind, title, body, jobs)
+		 VALUES ($1, 'subscription_digest', 'freehire', '2 new jobs for "Backend"', $2::jsonb)
+		 RETURNING id`, aliceID, jobsJSON).Scan(&digestID); err != nil {
+		t.Fatalf("seed digest notification: %v", err)
+	}
+
+	app := notificationsIntegrationApp(queries, iss)
+
+	t.Run("owner reads it with the jobs snapshot", func(t *testing.T) {
+		resp, err := app.Test(cookieGetReq(iss, aliceID, fmt.Sprintf("/api/v1/me/notifications/%d", digestID)))
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+		}
+		var out struct {
+			Data notificationResponse `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.Data.ID != digestID {
+			t.Errorf("id = %d, want %d", out.Data.ID, digestID)
+		}
+		var jobs []struct {
+			Title   string `json:"title"`
+			Company string `json:"company"`
+			Slug    string `json:"slug"`
+		}
+		if err := json.Unmarshal(out.Data.Jobs, &jobs); err != nil {
+			t.Fatalf("jobs did not unmarshal: %v (raw: %s)", err, out.Data.Jobs)
+		}
+		if len(jobs) != 2 || jobs[0].Slug != "acme-backend-engineer" || jobs[1].Slug != "acme-sre" {
+			t.Errorf("jobs = %+v, want 2 entries in seeded order", jobs)
+		}
+	})
+
+	t.Run("another user's notification 404s", func(t *testing.T) {
+		resp, err := app.Test(cookieGetReq(iss, bobID, fmt.Sprintf("/api/v1/me/notifications/%d", digestID)))
+		if err != nil {
+			t.Fatalf("get as bob: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("status = %d, want 404 (bob does not own alice's notification)", resp.StatusCode)
+		}
+	})
+
+	t.Run("nonexistent id 404s", func(t *testing.T) {
+		resp, err := app.Test(cookieGetReq(iss, aliceID, "/api/v1/me/notifications/999999999"))
+		if err != nil {
+			t.Fatalf("get nonexistent: %v", err)
 		}
 		if resp.StatusCode != fiber.StatusNotFound {
 			t.Errorf("status = %d, want 404", resp.StatusCode)

--- a/internal/handler/me_notifications_test.go
+++ b/internal/handler/me_notifications_test.go
@@ -23,6 +23,7 @@ func notificationsApp() (*fiber.App, *auth.Issuer) {
 	h := &authHandlers{}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/me/notifications", auth.RequireAuth(iss, testVersions), h.GetNotifications)
+	app.Get("/api/v1/me/notifications/:id", auth.RequireAuth(iss, testVersions), h.GetNotification)
 	app.Post("/api/v1/me/notifications/:id/read", auth.RequireAuth(iss, testVersions), h.MarkNotificationRead)
 	app.Post("/api/v1/me/notifications/read-all", auth.RequireAuth(iss, testVersions), h.MarkAllNotificationsRead)
 	return app, iss
@@ -39,6 +40,7 @@ func TestNotificationsManagement_IsCookieOnly(t *testing.T) {
 	}{
 		{"list, no credential", fiber.MethodGet, "/api/v1/me/notifications", false},
 		{"list, bearer only", fiber.MethodGet, "/api/v1/me/notifications", true},
+		{"get one, bearer only", fiber.MethodGet, "/api/v1/me/notifications/1", true},
 		{"mark read, bearer only", fiber.MethodPost, "/api/v1/me/notifications/1/read", true},
 		{"mark all read, bearer only", fiber.MethodPost, "/api/v1/me/notifications/read-all", true},
 	}

--- a/internal/notify/deliver.go
+++ b/internal/notify/deliver.go
@@ -109,6 +109,7 @@ func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, st
 		Title:      title,
 		Body:       body,
 		PublicSlug: publicSlug,
+		Jobs:       digestJobsSnapshot(digest),
 	}); err != nil {
 		// Delivered and stamped; only the in-app notification-center record
 		// failed. That's a degraded read-side feature, not a reason to fail a

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -2,7 +2,9 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -360,6 +362,26 @@ func TestDeliver_RecordsNotificationForMultiJobDigestWithoutSlug(t *testing.T) {
 	}
 	if store.recordedNotifications[0].PublicSlug.Valid {
 		t.Errorf("PublicSlug = %+v, want invalid (no slug) for a multi-job digest", store.recordedNotifications[0].PublicSlug)
+	}
+
+	var jobs []struct {
+		Title   string `json:"title"`
+		Company string `json:"company"`
+		Slug    string `json:"slug"`
+	}
+	if err := json.Unmarshal(store.recordedNotifications[0].Jobs, &jobs); err != nil {
+		t.Fatalf("Jobs did not unmarshal: %v (raw: %s)", err, store.recordedNotifications[0].Jobs)
+	}
+	want := []struct {
+		Title   string `json:"title"`
+		Company string `json:"company"`
+		Slug    string `json:"slug"`
+	}{
+		{Title: "A", Company: "", Slug: "a"},
+		{Title: "B", Company: "", Slug: "b"},
+	}
+	if !reflect.DeepEqual(jobs, want) {
+		t.Errorf("Jobs = %+v, want %+v", jobs, want)
 	}
 }
 

--- a/internal/notify/push.go
+++ b/internal/notify/push.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -73,4 +74,36 @@ func renderDigest(d Digest) (title, body, slug string) {
 		slug = d.Jobs[0].Slug
 	}
 	return title, body, slug
+}
+
+// digestJobSnapshot is one job as recorded into a multi-job digest's
+// notification-center row — the same three fields DigestJob exposes on the
+// wire, no internal id, no salary (the notification-history "which jobs were
+// these" screen names them; it isn't a second digest render).
+type digestJobSnapshot struct {
+	Title   string `json:"title"`
+	Company string `json:"company"`
+	Slug    string `json:"slug"`
+}
+
+// digestJobsSnapshot marshals a digest's matched jobs for the notification
+// center's `jobs` column, but only when there's more than one — a single-job
+// digest already has its job identified via public_slug, and every other
+// notification kind never sets this column at all. nil (encodes to SQL NULL)
+// for a single-job (or, degenerately, zero-job) digest.
+func digestJobsSnapshot(d Digest) json.RawMessage {
+	if d.Total <= 1 {
+		return nil
+	}
+	jobs := make([]digestJobSnapshot, len(d.Jobs))
+	for i, j := range d.Jobs {
+		jobs[i] = digestJobSnapshot{Title: j.Title, Company: j.Company, Slug: j.Slug}
+	}
+	raw, err := json.Marshal(jobs)
+	if err != nil {
+		// Every field is a plain string; Marshal only fails on unsupported types
+		// (channels, funcs, cyclic refs), none of which digestJobSnapshot has.
+		panic(fmt.Sprintf("notify: marshal digest jobs snapshot: %v", err))
+	}
+	return raw
 }

--- a/migrations/0091_user_notifications_jobs.sql
+++ b/migrations/0091_user_notifications_jobs.sql
@@ -1,0 +1,10 @@
+-- A multi-job subscription digest (Total > 1) has no single job to point
+-- public_slug at, but the person still wants to see WHICH jobs triggered it —
+-- a snapshot as of delivery, not a live re-run of the saved search (results
+-- drift; a job in this list may since have closed or dropped out of a re-run).
+-- `jobs` holds a small JSON array of {title, company, slug} (same shape as
+-- DigestJob, no internal id — see 0090's own comment for why), NULL for every
+-- other kind, which always resolves via public_slug instead.
+
+ALTER TABLE public.user_notifications
+    ADD COLUMN jobs jsonb;

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -24,6 +24,11 @@ sql:
           # straight through to the company-detail response ({} stays {}), not base64.
           - column: "companies.company_info"
             go_type: "encoding/json.RawMessage"
+          # A multi-job digest's job snapshot ({title, company, slug}[]): raw JSON
+          # round-trips whole into the notification-detail response (NULL stays
+          # null for every other kind), where a []byte would base64-encode it.
+          - column: "user_notifications.jobs"
+            go_type: "encoding/json.RawMessage"
           # The profile location block: raw JSON round-trips whole. The service
           # marshals a validated, normalized block (or NULL for none), and the stored
           # bytes marshal straight through to the profile response (null stays null).

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -983,6 +983,13 @@ export function createApi(
     }>(`/api/v1/me/notifications${query(limit, offset)}`);
   }
 
+  /** One notification, including its `jobs` snapshot when it has one — the
+   *  read a direct visit/bookmark of the digest jobs-list page needs, since
+   *  getNotifications alone only ever serves the caller's current page. */
+  async function getNotification(id: number): Promise<NotificationItem> {
+    return requestData<NotificationItem>(`/api/v1/me/notifications/${id}`);
+  }
+
   /** Mark one notification read. Idempotent; owner-scoped (404s for another
    *  user's, but that never happens from this client since ids come from the
    *  caller's own list). */
@@ -2013,6 +2020,7 @@ export function createApi(
     updateNotificationSettings,
     listDismissedSlugs,
     getNotifications,
+    getNotification,
     markNotificationRead,
     markAllNotificationsRead,
     listApiKeys,

--- a/web/src/lib/components/NotificationCard.svelte
+++ b/web/src/lib/components/NotificationCard.svelte
@@ -30,7 +30,9 @@
       ? resolve('/jobs/[slug]', { slug: target.slug })
       : target.kind === 'tracking'
         ? resolve('/my/tracking')
-        : null,
+        : target.kind === 'digest'
+          ? resolve('/my/notifications/[id]/jobs', { id: String(target.id) })
+          : null,
   );
   const unread = $derived(item.read_at == null);
   const Icon = $derived(KIND_ICON[item.kind]);

--- a/web/src/lib/notificationTarget.test.ts
+++ b/web/src/lib/notificationTarget.test.ts
@@ -23,8 +23,21 @@ describe('notificationTarget', () => {
     });
   });
 
-  it('sends a multi-job digest (no slug) nowhere', () => {
-    expect(notificationTarget({ kind: 'subscription_digest', public_slug: null })).toEqual({ kind: 'none' });
+  it('sends a multi-job digest to its own jobs-list page', () => {
+    expect(
+      notificationTarget({
+        id: 42,
+        kind: 'subscription_digest',
+        public_slug: null,
+        jobs: [{ title: 'A', company: 'Acme', slug: 'a' }],
+      }),
+    ).toEqual({ kind: 'digest', id: 42 });
+  });
+
+  it('sends a digest with neither a slug nor a jobs snapshot nowhere (defensive)', () => {
+    expect(notificationTarget({ id: 42, kind: 'subscription_digest', public_slug: null, jobs: null })).toEqual({
+      kind: 'none',
+    });
   });
 
   // The two nudge kinds the tracking board itself is about — even though the row

--- a/web/src/lib/notificationTarget.ts
+++ b/web/src/lib/notificationTarget.ts
@@ -7,19 +7,27 @@ import type { NotificationItem } from './types';
 export type NotificationTarget =
   | { kind: 'job'; slug: string }
   | { kind: 'tracking' }
+  | { kind: 'digest'; id: number }
   | { kind: 'none' };
 
-/** A card with no `public_slug` (a subscription digest that matched more than one job)
- *  has nothing to open. `nudge_follow_up`/`nudge_interview_prep` point at the tracking
- *  board on web — matching the existing Telegram/email link target for those two kinds —
- *  even though the row itself always carries a slug. Every other slug-bearing kind
- *  (reminder, nudge_job_closed, a single-job subscription_digest) points at the job. */
+/** A card with no `public_slug` and no `jobs` snapshot has nothing to open.
+ *  `nudge_follow_up`/`nudge_interview_prep` point at the tracking board on web —
+ *  matching the existing Telegram/email link target for those two kinds — even
+ *  though the row itself always carries a slug. Every other slug-bearing kind
+ *  (reminder, nudge_job_closed, a single-job subscription_digest) points at the
+ *  job. A multi-job subscription digest carries no slug but does carry `jobs` —
+ *  it points at its own jobs-list page instead. */
 export function notificationTarget(
-  item: Pick<NotificationItem, 'kind' | 'public_slug'>,
+  item: Pick<NotificationItem, 'kind' | 'public_slug'> & Partial<Pick<NotificationItem, 'id' | 'jobs'>>,
 ): NotificationTarget {
-  if (!item.public_slug) return { kind: 'none' };
-  if (item.kind === 'nudge_follow_up' || item.kind === 'nudge_interview_prep') {
-    return { kind: 'tracking' };
+  if (item.public_slug) {
+    if (item.kind === 'nudge_follow_up' || item.kind === 'nudge_interview_prep') {
+      return { kind: 'tracking' };
+    }
+    return { kind: 'job', slug: item.public_slug };
   }
-  return { kind: 'job', slug: item.public_slug };
+  if (item.kind === 'subscription_digest' && item.jobs && item.jobs.length > 0 && item.id != null) {
+    return { kind: 'digest', id: item.id };
+  }
+  return { kind: 'none' };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -519,10 +519,21 @@ export type NotificationKind =
   | 'nudge_interview_prep'
   | 'nudge_job_closed';
 
+/** One matched job as recorded into a multi-job subscription digest's `jobs`
+ *  snapshot — the same {title, company, slug} shape as everywhere else in this
+ *  app, no internal id. */
+export interface NotificationDigestJob {
+  title: string;
+  company: string;
+  slug: string;
+}
+
 /** One row in the notification center (GET /me/notifications) — a durable,
  *  readable-by-the-owner record of a delivery event, independent of which channel
  *  carried it. `public_slug` is the job it concerns, or null for a subscription
- *  digest that matched more than one job (nothing single to deep-link to).
+ *  digest that matched more than one job (nothing single to deep-link to) — that
+ *  case instead carries `jobs`, a snapshot of what matched as of delivery (only
+ *  present on the list response for a multi-job digest; absent/null otherwise).
  *  `read_at` is null until the caller marks it read. */
 export interface NotificationItem {
   id: number;
@@ -530,6 +541,7 @@ export interface NotificationItem {
   title: string;
   body: string;
   public_slug: string | null;
+  jobs?: NotificationDigestJob[] | null;
   created_at: string | null;
   read_at: string | null;
 }

--- a/web/src/routes/my/notifications/[id]/jobs/+page.svelte
+++ b/web/src/routes/my/notifications/[id]/jobs/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import { ApiError, api } from '$lib/api';
+  import States from '$lib/components/States.svelte';
+  import type { NotificationItem } from '$lib/types';
+
+  // The jobs a multi-job subscription digest actually matched, as a snapshot
+  // taken at delivery time — not a live re-run of the saved search, which can
+  // drift (a listing here may since have closed or dropped out of a fresh
+  // search). Reached from a NotificationCard whose notificationTarget() is
+  // `{kind: 'digest'}`; also a valid direct link/bookmark on its own, so it
+  // fetches its own data rather than expecting router state.
+
+  let status = $state<'loading' | 'ready' | 'error' | 'not-found'>('loading');
+  let item = $state<NotificationItem | null>(null);
+
+  onMount(async () => {
+    const id = Number(page.params.id);
+    if (!Number.isFinite(id)) {
+      status = 'not-found';
+      return;
+    }
+    try {
+      item = await api.getNotification(id);
+      status = 'ready';
+    } catch (e) {
+      status = e instanceof ApiError && e.status === 404 ? 'not-found' : 'error';
+    }
+  });
+</script>
+
+<svelte:head>
+  <title>Matched jobs — freehire</title>
+</svelte:head>
+
+<div class="max-w-2xl">
+  <a
+    href={resolve('/my/notifications/history')}
+    class="mb-4 inline-block text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground"
+  >
+    ← Notification history
+  </a>
+
+  {#if status === 'loading'}
+    <States state="loading" rows={4} />
+  {:else if status === 'not-found'}
+    <States state="empty" message="This notification doesn't exist, or isn't yours." />
+  {:else if status === 'error'}
+    <States state="error" />
+  {:else if item}
+    <h1 class="mb-1 text-lg font-semibold">{item.title}</h1>
+    <p class="mb-4 text-sm text-muted-foreground">{item.body}</p>
+
+    {#if item.jobs && item.jobs.length > 0}
+      <ul class="overflow-hidden rounded-md border border-border">
+        {#each item.jobs as job (job.slug)}
+          <li class="border-b border-border last:border-b-0">
+            <a
+              href={resolve('/jobs/[slug]', { slug: job.slug })}
+              class="block px-3 py-3 transition-colors hover:bg-accent/50"
+            >
+              <span class="block text-sm font-medium text-foreground">{job.title}</span>
+              <span class="block text-xs text-muted-foreground">{job.company}</span>
+            </a>
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <States state="empty" message="No jobs recorded for this notification." />
+    {/if}
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- A subscription-digest notification with more than one matched job carries no single `public_slug`, so tapping it previously did nothing but mark it read. New `user_notifications.jobs` (jsonb) snapshots the matched jobs (`{title, company, slug}[]`) as of delivery — not a live re-run of the saved search, which drifts.
- New `GET /api/v1/me/notifications/:id` (owner-scoped) for the detail read a direct visit/bookmark/deep-link needs.
- Web: new `/my/notifications/[id]/jobs` page; `notificationTarget()` gains a `digest` target kind; `NotificationCard` links there like every other kind.
- Mobile (`freehire-mobile`, already pushed separately): new `notifications/[id]` screen, same data.

Follow-up to #1862/#1867 (`add-notification-center`, merged).

## Test plan
- [x] `gofmt`, `go vet`/`go vet -tags=integration`, `go build` clean
- [x] `go test ./...` — 0 failures
- [x] `go test -tags=integration ./internal/notify/... ./internal/handler/... ./internal/db/...` — 0 failures (incl. new `GetOne`/jobs-snapshot integration tests)
- [x] `golangci-lint run --new-from-merge-base=origin/main` — 0 issues (checked locally this time)
- [x] Web `eslint`/`svelte-check`/`vitest` clean (934 tests)