### PR TITLE
Rewrite echojobs adapter for its retired JSON API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /bin/
 /out/
 hire
+
+# Local git worktrees for isolated feature work.
+/.worktrees/
 # Worker binaries. release.sh builds every cmd/ target into the checkout ROOT, so each
 # one lands here as an untracked file — and one committed by accident (prune, 25 MB, in
 # #1212) blocks `git pull` on every deploy host that already has its own build sitting

--- a/cmd/backfill-echojobs/main.go
+++ b/cmd/backfill-echojobs/main.go
@@ -1,15 +1,18 @@
-// Command backfill-echojobs fills the description of echojobs jobs ingested before per-posting
-// detail hydration existed. The echojobs adapter originally read only the list endpoint, which
-// omits the posting body entirely, so those rows were stored with an empty description (a blank,
-// broken job page — reported live on freehire.me). This one-off worker pages every
-// source='echojobs' row, re-fetches the posting's detail (GET /api/jobs/{job_handle}) via the
-// shared HTTP client, and rewrites the description plus a refreshed content_hash so the row
-// re-indexes. Follow it with `make reindex` (and cmd/backfill-derive to re-derive skills/facets
-// from the new descriptions).
+// Command backfill-echojobs fills the description of echojobs jobs whose original ingest never
+// hydrated one — either from the pre-hydration era (the adapter originally read only the list
+// endpoint, which omitted the posting body entirely) or from echojobs.io retiring its public
+// JSON API around 2026-08-13 (see internal/sources/echojobs.go), which left every newly-
+// discovered posting from that point with an empty description until the adapter was rewritten.
+// Either way the result is the same: a blank, broken job page, reported live on freehire.me.
+// This one-off worker pages every source='echojobs' row, re-fetches the posting's detail (GET
+// /job/{slug} + its embedded schema.org JobPosting ld+json — see sources.EchoJobsDescription)
+// via the shared HTTP client, and rewrites the description plus a refreshed content_hash so the
+// row re-indexes. Follow it with `make reindex` (and cmd/backfill-derive to re-derive
+// skills/facets from the new descriptions).
 //
 // echojobs is boardless, so its stored external_id carries the empty-board namespace prefix
 // (NamespaceExternalID("", jobHandle) == ":jobHandle") — jobHandle strips that colon before
-// calling the detail endpoint, which is keyed by the raw handle.
+// calling the detail endpoint, which is keyed by the raw slug.
 //
 // It pages by keyset and exits. Idempotent: a row whose stored description already equals the
 // fetched one is skipped, so a second run (e.g. after a rate-limit interruption) rewrites only

--- a/cmd/liveness/echojobs.go
+++ b/cmd/liveness/echojobs.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -37,8 +38,10 @@ func trimEchoJobsHandle(externalID string) string {
 
 // checkEchoJobsLiveAt is checkEchoJobsLive with the job URL template as a parameter (already-
 // stripped slug), so a test can point it at a stub server. The page's plain HTTP status is the
-// liveness signal: 200 means still listed, 404 means removed; anything else is Uncertain, the
-// same under-closing-biased default every other adapter's liveness check falls back to.
+// liveness signal: 200 means still listed, 404 or 410 means removed (the same pair the shared
+// liveness.Classify treats as "gone" — see internal/liveness/liveness.go); anything else is
+// Uncertain, the same under-closing-biased default every other adapter's liveness check falls
+// back to.
 func checkEchoJobsLiveAt(ctx context.Context, client *http.Client, jobURLTemplate, slug string) (liveness.Verdict, string) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(jobURLTemplate, slug), nil)
 	if err != nil {
@@ -50,10 +53,12 @@ func checkEchoJobsLiveAt(ctx context.Context, client *http.Client, jobURLTemplat
 		return liveness.Uncertain, ""
 	}
 	defer resp.Body.Close()
+	// Drain so the transport can reuse the connection across a run that probes many postings.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return liveness.Live, ""
-	case http.StatusNotFound:
+	case http.StatusNotFound, http.StatusGone:
 		return liveness.Expired, "echojobs_job_gone"
 	default:
 		return liveness.Uncertain, ""

--- a/cmd/liveness/echojobs.go
+++ b/cmd/liveness/echojobs.go
@@ -2,54 +2,45 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/strelov1/freehire/internal/liveness"
 )
 
-// echojobsDetailURL is echojobs.io's own per-posting detail API — already used live for
-// description backfill (see internal/sources/echojobs.go's detail helper). Unlike jobs.url
-// for this source (the employer's own ATS link — Workday, Greenhouse, and others, with
-// wildly variable per-company reliability across a ~330k-posting catalogue), this is the
-// single site echojobs.io itself, and a removed posting answers with a distinguishable
-// error rather than whatever the employer's own ATS happens to do.
-const echojobsDetailURL = "https://echojobs.io/api/jobs/%s"
+// echojobsJobURL is echojobs.io's own per-posting detail page — already used live for
+// description backfill (see internal/sources/echojobs.go). Unlike jobs.url for this source (the
+// employer's own ATS link — Workday, Greenhouse, and others, with wildly variable per-company
+// reliability across a ~330k-posting catalogue), this is the single site echojobs.io itself, and
+// a removed posting answers with a plain 404 rather than whatever the employer's own ATS
+// happens to do.
+//
+// echojobs.io retired its public JSON detail API (/api/jobs/%s, which used to answer a removed
+// posting with a distinguishable {"error":"job fetch failed"} body) around 2026-08-13; this now
+// hits the site's server-rendered job page instead, whose plain HTTP status is the liveness
+// signal.
+const echojobsJobURL = "https://echojobs.io/job/%s"
 
-// echojobsErrorBody is the body a removed posting's detail request returns — verified
-// live: {"error":"job fetch failed"}, HTTP 500. A live posting returns 200 with the full
-// detail payload (id/title/description/…) instead, which this type does not need to read.
-type echojobsErrorBody struct {
-	Error string `json:"error"`
-}
-
-// echojobsGoneError is the exact error text a removed posting's detail request returns.
-// Matched exactly (not "any non-empty error field") so an unrelated API hiccup or rate
-// limit — a different message, or the same 500 without this body — reads as Uncertain
-// rather than a false death signal; under-closing is the safe failure mode here, same as
-// everywhere else in this worker.
-const echojobsGoneError = "job fetch failed"
-
-// checkEchoJobsLive queries echojobs.io's detail API for one posting's job_handle (its
-// ExternalID, minus the boardless ":" prefix UpsertJob stores boardless external ids
-// with — see internal/sources/source.go) and reports whether it is still listed.
+// checkEchoJobsLive queries echojobs.io's own job page for one posting's slug (its ExternalID,
+// minus the boardless ":" prefix UpsertJob stores boardless external ids with — see
+// internal/sources/source.go) and reports whether it is still listed.
 func checkEchoJobsLive(ctx context.Context, client *http.Client, externalID string) (liveness.Verdict, string) {
-	return checkEchoJobsLiveAt(ctx, client, echojobsDetailURL, trimEchoJobsHandle(externalID))
+	return checkEchoJobsLiveAt(ctx, client, echojobsJobURL, trimEchoJobsHandle(externalID))
 }
 
 // trimEchoJobsHandle strips the boardless ":" prefix UpsertJob stores boardless
-// external ids with, recovering the job_handle echojobs' own detail API expects.
+// external ids with, recovering the slug echojobs.io's job page expects.
 func trimEchoJobsHandle(externalID string) string {
 	return strings.TrimPrefix(externalID, ":")
 }
 
-// checkEchoJobsLiveAt is checkEchoJobsLive with the detail URL template as a parameter
-// (already-stripped handle), so a test can point it at a stub server.
-func checkEchoJobsLiveAt(ctx context.Context, client *http.Client, detailURLTemplate, handle string) (liveness.Verdict, string) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(detailURLTemplate, handle), nil)
+// checkEchoJobsLiveAt is checkEchoJobsLive with the job URL template as a parameter (already-
+// stripped slug), so a test can point it at a stub server. The page's plain HTTP status is the
+// liveness signal: 200 means still listed, 404 means removed; anything else is Uncertain, the
+// same under-closing-biased default every other adapter's liveness check falls back to.
+func checkEchoJobsLiveAt(ctx context.Context, client *http.Client, jobURLTemplate, slug string) (liveness.Verdict, string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(jobURLTemplate, slug), nil)
 	if err != nil {
 		return liveness.Uncertain, ""
 	}
@@ -59,13 +50,12 @@ func checkEchoJobsLiveAt(ctx context.Context, client *http.Client, detailURLTemp
 		return liveness.Uncertain, ""
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK:
 		return liveness.Live, ""
+	case http.StatusNotFound:
+		return liveness.Expired, "echojobs_job_gone"
+	default:
+		return liveness.Uncertain, ""
 	}
-	var body echojobsErrorBody
-	_ = json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&body)
-	if body.Error == echojobsGoneError {
-		return liveness.Expired, "echojobs_detail_gone"
-	}
-	return liveness.Uncertain, ""
 }

--- a/cmd/liveness/echojobs_test.go
+++ b/cmd/liveness/echojobs_test.go
@@ -39,6 +39,23 @@ func TestCheckEchoJobsLiveOnRemovedPosting(t *testing.T) {
 	}
 }
 
+// 410 Gone is the same "removed" signal as 404 for every other liveness probe in this worker
+// (see internal/liveness.Classify) — echojobs' own probe must not treat it as merely Uncertain.
+func TestCheckEchoJobsLiveOnGonePosting(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(410)
+	}))
+	defer srv.Close()
+
+	verdict, reason := checkEchoJobsLiveAt(context.Background(), srv.Client(), srv.URL+"/%s", "gone-handle")
+	if verdict != liveness.Expired {
+		t.Errorf("verdict = %v, want Expired", verdict)
+	}
+	if reason != "echojobs_job_gone" {
+		t.Errorf("reason = %q, want echojobs_job_gone", reason)
+	}
+}
+
 func TestCheckEchoJobsLiveOnUnrelatedError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)

--- a/cmd/liveness/echojobs_test.go
+++ b/cmd/liveness/echojobs_test.go
@@ -15,7 +15,6 @@ func TestCheckEchoJobsLiveOnLivePosting(t *testing.T) {
 			t.Errorf("path = %q, want /some-handle", r.URL.Path)
 		}
 		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{"id":"1","title":"Engineer","description":"..."}`))
 	}))
 	defer srv.Close()
 
@@ -27,8 +26,7 @@ func TestCheckEchoJobsLiveOnLivePosting(t *testing.T) {
 
 func TestCheckEchoJobsLiveOnRemovedPosting(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(500)
-		_, _ = w.Write([]byte(`{"error":"job fetch failed"}`))
+		w.WriteHeader(404)
 	}))
 	defer srv.Close()
 
@@ -36,23 +34,22 @@ func TestCheckEchoJobsLiveOnRemovedPosting(t *testing.T) {
 	if verdict != liveness.Expired {
 		t.Errorf("verdict = %v, want Expired", verdict)
 	}
-	if reason != "echojobs_detail_gone" {
-		t.Errorf("reason = %q, want echojobs_detail_gone", reason)
+	if reason != "echojobs_job_gone" {
+		t.Errorf("reason = %q, want echojobs_job_gone", reason)
 	}
 }
 
 func TestCheckEchoJobsLiveOnUnrelatedError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
-		_, _ = w.Write([]byte(`{"error":"internal error"}`))
 	}))
 	defer srv.Close()
 
-	// A DIFFERENT error message must not read as "gone" — only the exact known signal
-	// does, so a transient/unrelated API failure stays Uncertain (under-closing bias).
+	// A non-200/404 status must not read as "gone" — only the exact known-removed signal
+	// does, so a transient/unrelated failure stays Uncertain (under-closing bias).
 	verdict, _ := checkEchoJobsLiveAt(context.Background(), srv.Client(), srv.URL+"/%s", "some-handle")
 	if verdict != liveness.Uncertain {
-		t.Errorf("verdict = %v, want Uncertain for an unrelated error body", verdict)
+		t.Errorf("verdict = %v, want Uncertain for a non-200/404 status", verdict)
 	}
 }
 
@@ -61,7 +58,6 @@ func TestCheckEchoJobsLiveStripsBoardlessColonPrefix(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer srv.Close()
 

--- a/internal/sources/echojobs.go
+++ b/internal/sources/echojobs.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/html"
@@ -13,10 +14,8 @@ import (
 	"github.com/strelov1/freehire/internal/skilltag"
 )
 
-// echojobs adapts echojobs.io, a large multi-employer tech-jobs aggregator whose postings
-// resolve to the employer's own ATS URL (Workday, Greenhouse, and others show up in the feed)
-// rather than to an echojobs.io-hosted page. Boardless: one global feed, sorted newest-first, no
-// per-tenant board.
+// echojobs adapts echojobs.io, a large multi-employer tech-jobs aggregator. Boardless: one
+// global feed, sorted newest-first, no per-tenant board.
 //
 // echojobs.io retired its public JSON API (the list+detail endpoints this adapter used to call)
 // around 2026-08-13 — both 404 now, verified from prod's own egress IP as well as externally.
@@ -26,6 +25,17 @@ import (
 // in each posting's server-rendered detail page (/job/<slug>) for every structured field a
 // posting has (title, company, description, remote signal, location, skills, posting date).
 // Neither needs JavaScript execution — a plain GET reaches both.
+//
+// Job.URL now points at that echojobs.io page, NOT the employer's own ATS link the old adapter
+// used to store (its list JSON carried the employer's apply URL directly; a real Workday/
+// Greenhouse/etc. link, and jobview/JobView.svelte opens it as the "Apply" target). This is a
+// real, unavoidable regression, not an oversight: the employer link is no longer present in the
+// server-rendered page at all — verified live by diffing a fetched page's full text against the
+// dead-code's expectation, then searching it for every http(s) URL — it now only ships client-
+// side (the page even prompts a visitor to "Sign in to apply", which reads as an echojobs.io
+// account gate ahead of the outbound link, not merely a JS-hydration delay). Recovering it would
+// need a headless browser (and possibly an echojobs.io session) for every posting, which defeats
+// the plain-GET design this rewrite exists to keep. See design.md's Risks section.
 //
 // The sitemap carries nothing beyond a posting's URL and last-modified time — unlike the old
 // list JSON, it cannot supply even a title without a detail fetch — so the "list vs detail"
@@ -87,22 +97,36 @@ func (s echojobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 // logged — there is no list-only Job left to fall back to (contrast the old list+detail split,
 // where a failed detail still yielded a list-only posting). Detail fetches run under the shared
 // bounded worker pool.
+//
+// A dropped posting never reaches the pipeline's own stats (Skipped/Failed count saveOne
+// failures, not candidates an adapter discarded before returning them at all), so a systemic
+// break here — echojobs changing its page markup again, the way it changed its API — would
+// otherwise ingest near-nothing with no board-level error and no visible anomaly: exactly the
+// failure mode that went unnoticed long enough to empty-description hundreds of postings before
+// this rewrite. The summary log line below is the cheap mitigation: not an alert, just a number
+// an operator (or a future board-health check) can see.
 func (s echojobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
 	postings, err := s.crawl(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return fetchDetails(postings, defaultDetailWorkers, func(p echojobsPosting) (Job, bool) {
+	var dropped atomic.Int64
+	jobs := fetchDetails(postings, defaultDetailWorkers, func(p echojobsPosting) (Job, bool) {
 		if seen(p.Slug) {
 			return Job{ExternalID: p.Slug, URL: echojobsJobURL(p.Slug), SeenRefresh: true}, true
 		}
 		job, err := s.detail(ctx, p.Slug)
 		if err != nil {
+			dropped.Add(1)
 			log.Printf("echojobs: detail %q: %v; dropping (sitemap carries no list-only fallback fields)", p.Slug, err)
 			return Job{}, false
 		}
 		return job, true
-	}), nil
+	})
+	if n := dropped.Load(); n > 0 {
+		log.Printf("echojobs: dropped %d/%d candidate postings this run (detail fetch failed or carried no usable JobPosting)", n, len(postings))
+	}
+	return jobs, nil
 }
 
 // echojobsPosting is one posting discovered from the sitemap: its slug and last-modified time.
@@ -222,10 +246,12 @@ func echojobsJobURL(slug string) string {
 }
 
 // echojobsJobPosting is the schema.org JobPosting decoded from a /job/<slug> page's ld+json
-// block. jobLocation is a single Place (absent for a fully-remote posting) and
-// applicantLocationRequirements a single Country — verified live on both an on-site posting
-// (JLL) and a remote one (Doowii). skills is a comma-separated string, not an array, unlike the
-// old list JSON's required_skills.
+// block. jobLocation and applicantLocationRequirements both use the shared object-or-array
+// schema types (schemaPlaces, schemaNamedAreas): every live sample so far has shipped a single
+// object (JLL on-site, Doowii remote), but the schema.org spec allows either shape for both
+// fields, and decoding them as a bare object would fail the WHOLE posting's ld+json the day
+// echojobs (or any single tenant) emits the array form — see schemaNamedAreas' doc. skills is a
+// comma-separated string, not an array, unlike the old list JSON's required_skills.
 type echojobsJobPosting struct {
 	Title              string `json:"title"`
 	Description        string `json:"description"`
@@ -234,23 +260,21 @@ type echojobsJobPosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	JobLocation struct {
-		Address schemaAddress `json:"address"`
-	} `json:"jobLocation"`
-	ApplicantLocationRequirements struct {
-		Name string `json:"name"`
-	} `json:"applicantLocationRequirements"`
-	Skills string `json:"skills"`
+	JobLocation                   schemaPlaces     `json:"jobLocation"`
+	ApplicantLocationRequirements schemaNamedAreas `json:"applicantLocationRequirements"`
+	Skills                        string           `json:"skills"`
 }
 
 // location prefers the explicit jobLocation address and falls back to
 // applicantLocationRequirements — the only signal a fully-remote posting exposes, its
 // jobLocation being absent.
 func (p echojobsJobPosting) location() string {
-	if loc := p.JobLocation.Address.Location(); loc != "" {
-		return loc
+	if len(p.JobLocation) > 0 {
+		if loc := p.JobLocation[0].Address.Location(); loc != "" {
+			return loc
+		}
 	}
-	return p.ApplicantLocationRequirements.Name
+	return joinNonEmpty(p.ApplicantLocationRequirements.Names()...)
 }
 
 // errEchojobsNoJobPosting means a detail page fetched fine but carried no usable JobPosting
@@ -286,7 +310,7 @@ func (s echojobs) detail(ctx context.Context, slug string) (Job, error) {
 		Remote:      remote,
 		WorkMode:    workModeFromRemote(remote),
 		Skills:      skilltag.Canonicalize(echojobsSplitSkills(p.Skills)),
-		PostedAt:    parseRFC3339(p.DatePosted),
+		PostedAt:    parseRFC3339OrDate(p.DatePosted),
 	}, nil
 }
 

--- a/internal/sources/echojobs.go
+++ b/internal/sources/echojobs.go
@@ -4,49 +4,60 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
+
+	"golang.org/x/net/html"
 
 	"github.com/strelov1/freehire/internal/skilltag"
 )
 
-// echojobs adapts echojobs.io, a large multi-employer tech-jobs aggregator whose postings resolve
-// to the employer's own ATS URL (Workday, Greenhouse, and others show up in the feed) rather than
-// to an echojobs.io-hosted page. Boardless: one global feed, sorted newest-first by posted_at, no
+// echojobs adapts echojobs.io, a large multi-employer tech-jobs aggregator whose postings
+// resolve to the employer's own ATS URL (Workday, Greenhouse, and others show up in the feed)
+// rather than to an echojobs.io-hosted page. Boardless: one global feed, sorted newest-first, no
 // per-tenant board.
 //
-// At last count the feed's reported total sat around 320k postings. Walking it exhaustively every
-// cron run would mean thousands of requests per cycle, so Fetch instead bounds the walk to a
-// rolling freshness window (echojobsFreshnessWindow) rather than an arbitrary page count: the feed
-// is sorted, so paging stops as soon as it runs past that window. This is the same "cannot be
-// crawled exhaustively" shape as whatjobs.go, with one structural difference worth naming: because
-// the ordering key is posted_at itself, a posting that ages out of the window can never drift back
-// into it on a later run the way a whatjobs posting can re-enter its keyword's visible page depth —
-// once it exits, this adapter stops seeing it for good. sweepGrace still matters for exactly the
-// reason whatjobs' does (a posting the crawl stops reaching is not evidence it closed), it just
-// delays an otherwise-inevitable close rather than bridging a gap the next run repairs.
+// echojobs.io retired its public JSON API (the list+detail endpoints this adapter used to call)
+// around 2026-08-13 — both 404 now, verified from prod's own egress IP as well as externally.
+// Two other public, SEO-maintained surfaces replace it: a paginated XML sitemap
+// (https://echojobs.io/sitemap.xml -> sitemap-jobs/N.xml shards, confirmed live to be sorted
+// newest-first by <lastmod>) for discovery, and a schema.org JobPosting ld+json block embedded
+// in each posting's server-rendered detail page (/job/<slug>) for every structured field a
+// posting has (title, company, description, remote signal, location, skills, posting date).
+// Neither needs JavaScript execution — a plain GET reaches both.
+//
+// The sitemap carries nothing beyond a posting's URL and last-modified time — unlike the old
+// list JSON, it cannot supply even a title without a detail fetch — so the "list vs detail"
+// split this adapter used to have collapsed into one tier: every posting FetchNew or Fetch
+// reports has its full JobPosting fetched (FetchNew still skips that fetch for a posting the
+// catalogue already has — see its doc). A detail fetch that fails, or a page carrying no usable
+// JobPosting, simply drops that posting: there is no list-only fallback left to fall back to.
 type echojobs struct {
-	http JSONGetter
+	http echojobsHTTP
+}
+
+// echojobsHTTP is the transport echojobs needs: XML sitemap discovery plus HTML detail pages.
+type echojobsHTTP interface {
+	XMLGetter
+	HTMLGetter
 }
 
 const (
-	echojobsBaseURL = "https://echojobs.io/api/jobs"
-	// echojobsPageSize is the per-page count requested. The feed defaults to 20 but accepts at
-	// least 100, and a larger page means fewer requests to cover the same freshness window.
-	echojobsPageSize = 100
-	// echojobsFreshnessWindow bounds how far back the walk reads, since the feed cannot be
-	// crawled to its end every run (see the type doc). 14 days matches whatjobs' bound for a
-	// source with the same "cannot verify liveness, cannot crawl exhaustively" shape.
+	echojobsBaseURL    = "https://echojobs.io"
+	echojobsSitemapURL = echojobsBaseURL + "/sitemap.xml"
+	// echojobsFreshnessWindow bounds how far back the sitemap walk reads: the site's whole job
+	// sitemap runs into the hundreds of thousands of URLs and cannot be crawled to its end every
+	// run, so the walk stops once a shard's postings age past this window — the same bound the
+	// old list-page walk used, over the new data source.
 	echojobsFreshnessWindow = 14 * 24 * time.Hour
-	// echojobsSweepGrace widens the post-run unseen sweep to match echojobsFreshnessWindow: a
-	// posting that ages past the window stops being reported by this adapter regardless of
-	// whether it is still open, so the sweep must not read "the crawl stopped reaching it" as
-	// "it closed" on the default window. See the sweepGrace type doc in source.go.
+	// echojobsSweepGrace widens the post-run unseen sweep to match echojobsFreshnessWindow — see
+	// the sweepGrace type doc in source.go.
 	echojobsSweepGrace = echojobsFreshnessWindow
 )
 
 // NewEchoJobs builds the echojobs adapter over the given HTTP client.
-func NewEchoJobs(c JSONGetter) Source { return echojobs{http: c} }
+func NewEchoJobs(c echojobsHTTP) Source { return echojobs{http: c} }
 
 func (echojobs) Provider() string { return "echojobs" }
 
@@ -58,94 +69,74 @@ func (echojobs) aggregator() {}
 
 func (echojobs) sweepGrace() time.Duration { return echojobsSweepGrace }
 
-// echojobsPosting is one posting from the /api/jobs list. The upstream response carries several
-// more fields (id, domain_name, first_seen_at, countries, states, job_function, role, seniority,
-// salary_min_usd/salary_max_usd, employment_type, employee_count, funding) that this adapter
-// deliberately does not read: id is redundant (the detail endpoint accepts job_handle just as
-// well — verified live — so ExternalID doubles as the detail key without storing a second
-// identifier nothing else needs), and none of the rest has a home in the Job shape today, and
-// guessing one (e.g. folding salary into Description) is not this adapter's call to make.
-// Notably absent from this list: description — the list endpoint omits the body entirely
-// (verified live), which is why FetchNew hydrates it from the per-posting detail endpoint (see
-// echojobsDetail).
-type echojobsPosting struct {
-	Title          string   `json:"title"`
-	CompanyName    string   `json:"company_name"`
-	URL            string   `json:"url"`
-	JobHandle      string   `json:"job_handle"`
-	PostedAt       int64    `json:"posted_at"`
-	Locations      []string `json:"locations"`
-	RemoteType     string   `json:"remote_type"`
-	RequiredSkills []string `json:"required_skills"`
+// Fetch fully hydrates every posting the sitemap walk finds within the freshness window. Unlike
+// FetchNew it has no seen-set to skip already-ingested postings — the sitemap carries no field a
+// cheaper "list-only" tier could serve any more, so there is nothing partial left to return.
+// Kept for callers that do not drive hydration; the live pipeline always prefers FetchNew (see
+// internal/pipeline.fetchBoard).
+func (s echojobs) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	return s.FetchNew(ctx, e, func(string) bool { return false })
 }
 
-// Fetch is the list-only crawl (no description): kept as the fallback for a caller that does not
-// drive hydration. FetchNew is the hydrating path the pipeline prefers.
-func (e echojobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
-	postings, err := e.crawl(ctx)
-	if err != nil {
-		return nil, err
-	}
-	jobs := make([]Job, len(postings))
-	for i, p := range postings {
-		jobs[i] = p.toJob(parseEpochMillis(p.PostedAt))
-	}
-	return jobs, nil
-}
-
-// FetchNew is the hydrating crawl: it pages the same list, but fetches a posting's detail (the
-// description the list omits) only for a posting the catalogue does not already have — seen
-// reports whether a posting's external id is already ingested. A seen posting yields the
-// list-only job with SeenRefresh set (liveness refresh only, no content rewrite — a content-less
-// re-upsert would wipe the description hydrated when it was new); an unseen posting is hydrated
-// with its detail; a single posting's detail failure is isolated (logged, falling back to
-// list-only so the posting is still ingested). Detail fetches run under the shared bounded worker
-// pool, mirroring justjoin's FetchNew.
-func (e echojobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
-	postings, err := e.crawl(ctx)
+// FetchNew walks the sitemap for postings inside the freshness window and fetches full detail
+// (the JobPosting ld+json on each posting's own page) only for a posting the catalogue does not
+// already have — seen reports whether a posting's slug is already ingested. A seen posting is
+// refreshed by identity only (SeenRefresh, no detail fetch: a content-less re-upsert would wipe
+// the description hydrated when it was new); an unseen posting is hydrated with its detail; a
+// posting whose detail fetch fails, or whose page carries no usable JobPosting, is dropped and
+// logged — there is no list-only Job left to fall back to (contrast the old list+detail split,
+// where a failed detail still yielded a list-only posting). Detail fetches run under the shared
+// bounded worker pool.
+func (s echojobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	postings, err := s.crawl(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return fetchDetails(postings, defaultDetailWorkers, func(p echojobsPosting) (Job, bool) {
-		base := p.toJob(parseEpochMillis(p.PostedAt))
-		if seen(base.ExternalID) {
-			base.SeenRefresh = true
-			return base, true
+		if seen(p.Slug) {
+			return Job{ExternalID: p.Slug, URL: echojobsJobURL(p.Slug), SeenRefresh: true}, true
 		}
-		d, ok := e.detail(ctx, p.JobHandle)
-		if !ok {
-			log.Printf("echojobs: detail %q failed; ingesting list-only", p.JobHandle)
-			return base, true
+		job, err := s.detail(ctx, p.Slug)
+		if err != nil {
+			log.Printf("echojobs: detail %q: %v; dropping (sitemap carries no list-only fallback fields)", p.Slug, err)
+			return Job{}, false
 		}
-		return d.apply(base), true
+		return job, true
 	}), nil
 }
 
-// crawl pages the feed newest-first, stopping once a page's oldest posting (its last entry) falls
-// outside echojobsFreshnessWindow, and returns every raw posting gathered — the shared list walk
-// behind Fetch and FetchNew. Per the house pagination rule, a failure on the first page is a
-// board-level error; a failure on a later page ends the walk with what was already gathered.
-func (e echojobs) crawl(ctx context.Context) ([]echojobsPosting, error) {
+// echojobsPosting is one posting discovered from the sitemap: its slug and last-modified time.
+// The sitemap carries no other field.
+type echojobsPosting struct {
+	Slug    string
+	LastMod *time.Time
+}
+
+// crawl discovers postings by walking the sitemap index's job shards in order, stopping once a
+// shard's postings age past echojobsFreshnessWindow — the shards are confirmed sorted
+// newest-first, so this is the "stop once stale" walk the old page-based crawl used, over a
+// different data source. Per the house pagination rule, a failure fetching the sitemap index
+// itself or the FIRST shard is a board-level error; a later shard failing ends the walk with
+// what was already gathered.
+func (s echojobs) crawl(ctx context.Context) ([]echojobsPosting, error) {
+	shards, err := s.sitemapShards(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("echojobs: sitemap index: %w", err)
+	}
 	cutoff := time.Now().Add(-echojobsFreshnessWindow)
 	var postings []echojobsPosting
-	for page := 1; ; page++ {
-		var resp struct {
-			Jobs []echojobsPosting `json:"jobs"`
-		}
-		if err := e.http.GetJSON(ctx, echojobsPageURL(page), &resp); err != nil {
-			if page == 1 {
-				return nil, fmt.Errorf("echojobs: page %d: %w", page, err)
+	for i, shardURL := range shards {
+		entries, err := s.sitemapShard(ctx, shardURL)
+		if err != nil {
+			if i == 0 {
+				return nil, fmt.Errorf("echojobs: shard %s: %w", shardURL, err)
 			}
-			log.Printf("echojobs: page %d failed, stopping with %d postings gathered: %v", page, len(postings), err)
-			return postings, nil
-		}
-		if len(resp.Jobs) == 0 {
+			log.Printf("echojobs: shard %s failed, stopping with %d postings gathered: %v", shardURL, len(postings), err)
 			return postings, nil
 		}
 		stale := false
-		for _, p := range resp.Jobs {
-			postedAt := parseEpochMillis(p.PostedAt)
-			if postedAt != nil && postedAt.Before(cutoff) {
+		for _, p := range entries {
+			if p.LastMod != nil && p.LastMod.Before(cutoff) {
 				stale = true
 				continue
 			}
@@ -155,81 +146,181 @@ func (e echojobs) crawl(ctx context.Context) ([]echojobsPosting, error) {
 			return postings, nil
 		}
 	}
+	return postings, nil
 }
 
-func echojobsPageURL(page int) string {
-	return fmt.Sprintf("%s?page=%d&per_page=%d", echojobsBaseURL, page, echojobsPageSize)
+// echojobsSitemapIndex is the top-level https://echojobs.io/sitemap.xml: an index of
+// sub-sitemaps, only some of which (sitemap-jobs/N.xml) carry postings — the rest (nav,
+// categories, blog, companies) are the site's other pages.
+type echojobsSitemapIndex struct {
+	Sitemaps []struct {
+		Loc string `xml:"loc"`
+	} `xml:"sitemap"`
 }
 
-// echojobsDetailURL is the per-posting detail endpoint. It accepts either the feed's internal id
-// or job_handle (echojobs' own slug) interchangeably — verified live — so this adapter always
-// passes job_handle, the identifier it already carries as ExternalID.
-const echojobsDetailURL = echojobsBaseURL + "/%s"
-
-// echojobsDetail is the per-posting detail payload (GET /api/jobs/{job_handle}). Only Description
-// is read; the detail response also repeats several list fields plus salary/education/yoe ones
-// this adapter does not map, for the same reason echojobsPosting's doc gives.
-type echojobsDetail struct {
-	Description string `json:"description"`
+// echojobsURLSet is one job-sitemap shard (sitemap-jobs/N.xml): a flat list of posting URLs.
+type echojobsURLSet struct {
+	URLs []struct {
+		Loc     string `xml:"loc"`
+		LastMod string `xml:"lastmod"`
+	} `xml:"url"`
 }
 
-// detail fetches a posting's detail by job_handle, returning ok=false on a failed request so the
-// caller falls back to the list-only job — a posting is never dropped over a missing detail.
-func (e echojobs) detail(ctx context.Context, jobHandle string) (echojobsDetail, bool) {
-	var d echojobsDetail
-	if err := e.http.GetJSON(ctx, fmt.Sprintf(echojobsDetailURL, jobHandle), &d); err != nil {
-		return echojobsDetail{}, false
+// echojobsJobShardRE matches a job-postings sitemap shard's URL, as opposed to the index's
+// other shards (sitemap-nav.xml, sitemap-categories.xml, sitemap-blog.xml,
+// sitemap-companies.xml) — verified live.
+var echojobsJobShardRE = regexp.MustCompile(`/sitemap-jobs/\d+\.xml$`)
+
+// sitemapShards fetches the sitemap index and returns the job shard URLs, in the order the
+// index lists them (verified live: shard 1 is newest).
+func (s echojobs) sitemapShards(ctx context.Context) ([]string, error) {
+	var idx echojobsSitemapIndex
+	if err := s.http.GetXML(ctx, echojobsSitemapURL, &idx); err != nil {
+		return nil, err
 	}
-	return d, true
-}
-
-// apply enriches a list-derived job with the detail payload's sanitized description.
-func (d echojobsDetail) apply(base Job) Job {
-	base.Description = sanitizeHTML(d.Description)
-	return base
-}
-
-// EchoJobsDescription fetches the sanitized description for a stored echojobs job by its
-// job_handle (ExternalID) — the stored URL cannot be used for this the way JustJoinDescription
-// uses justjoin's, because echojobs' URL is the upstream ATS link, not an echojobs.io one. It
-// exists for a backfill worker filling the description of rows ingested before detail hydration
-// existed; the crawl path uses (echojobs).detail directly. Returns ok=false when the detail
-// request fails or the posting has no body.
-func EchoJobsDescription(ctx context.Context, c JSONGetter, jobHandle string) (string, bool) {
-	d, ok := echojobs{http: c}.detail(ctx, jobHandle)
-	if !ok {
-		return "", false
+	var shards []string
+	for _, sm := range idx.Sitemaps {
+		if echojobsJobShardRE.MatchString(sm.Loc) {
+			shards = append(shards, sm.Loc)
+		}
 	}
-	body := sanitizeHTML(d.Description)
-	if body == "" {
-		return "", false
-	}
-	return body, true
+	return shards, nil
 }
 
-func (p echojobsPosting) toJob(postedAt *time.Time) Job {
-	mode, remote := echojobsWorkMode(p.RemoteType)
+// sitemapShard fetches one job shard and returns its postings, decoding a slug from each URL
+// and dropping any entry whose URL doesn't match the expected /job/<slug> shape (defensive: the
+// sitemap format is outside our control).
+func (s echojobs) sitemapShard(ctx context.Context, shardURL string) ([]echojobsPosting, error) {
+	var set echojobsURLSet
+	if err := s.http.GetXML(ctx, shardURL, &set); err != nil {
+		return nil, err
+	}
+	postings := make([]echojobsPosting, 0, len(set.URLs))
+	for _, u := range set.URLs {
+		slug := echojobsSlug(u.Loc)
+		if slug == "" {
+			continue
+		}
+		postings = append(postings, echojobsPosting{Slug: slug, LastMod: parseRFC3339(u.LastMod)})
+	}
+	return postings, nil
+}
+
+// echojobsSlugRE extracts a posting's slug from its sitemap or job-page URL.
+var echojobsSlugRE = regexp.MustCompile(`/job/([^/?#]+)/?$`)
+
+func echojobsSlug(loc string) string {
+	m := echojobsSlugRE.FindStringSubmatch(loc)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+func echojobsJobURL(slug string) string {
+	return echojobsBaseURL + "/job/" + slug
+}
+
+// echojobsJobPosting is the schema.org JobPosting decoded from a /job/<slug> page's ld+json
+// block. jobLocation is a single Place (absent for a fully-remote posting) and
+// applicantLocationRequirements a single Country — verified live on both an on-site posting
+// (JLL) and a remote one (Doowii). skills is a comma-separated string, not an array, unlike the
+// old list JSON's required_skills.
+type echojobsJobPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	JobLocationType    string `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation struct {
+		Address schemaAddress `json:"address"`
+	} `json:"jobLocation"`
+	ApplicantLocationRequirements struct {
+		Name string `json:"name"`
+	} `json:"applicantLocationRequirements"`
+	Skills string `json:"skills"`
+}
+
+// location prefers the explicit jobLocation address and falls back to
+// applicantLocationRequirements — the only signal a fully-remote posting exposes, its
+// jobLocation being absent.
+func (p echojobsJobPosting) location() string {
+	if loc := p.JobLocation.Address.Location(); loc != "" {
+		return loc
+	}
+	return p.ApplicantLocationRequirements.Name
+}
+
+// errEchojobsNoJobPosting means a detail page fetched fine but carried no usable JobPosting
+// ld+json block (absent, or present with an empty title) — distinct from a fetch error so a
+// caller's log line can tell "echojobs is unreachable/blocking us" from "this one page is
+// malformed".
+var errEchojobsNoJobPosting = fmt.Errorf("no usable JobPosting ld+json block")
+
+// detail fetches one posting's page and maps its JobPosting ld+json to a Job, returning an error
+// when the fetch fails or the page carries no usable JobPosting — so the caller drops just that
+// posting, with enough detail to distinguish the two failure modes in its log.
+func (s echojobs) detail(ctx context.Context, slug string) (Job, error) {
+	root, err := s.http.GetHTML(ctx, echojobsJobURL(slug))
+	if err != nil {
+		return Job{}, fmt.Errorf("fetch: %w", err)
+	}
+	var p echojobsJobPosting
+	if !ldJobPosting(root, &p) || p.Title == "" {
+		return Job{}, errEchojobsNoJobPosting
+	}
+
+	// jobLocationType is the only structured work-arrangement signal: TELECOMMUTE means
+	// remote. Absent → leave WorkMode empty rather than guess hybrid/onsite.
+	remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
+
 	return Job{
-		ExternalID: p.JobHandle,
-		URL:        p.URL,
-		Title:      p.Title,
-		Company:    p.CompanyName,
-		Location:   strings.Join(p.Locations, "; "),
-		Remote:     remote,
-		WorkMode:   mode,
-		PostedAt:   postedAt,
-		Skills:     skilltag.Canonicalize(p.RequiredSkills),
-	}
+		ExternalID:  slug,
+		URL:         echojobsJobURL(slug),
+		Title:       p.Title,
+		Company:     p.HiringOrganization.Name,
+		Location:    p.location(),
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      remote,
+		WorkMode:    workModeFromRemote(remote),
+		Skills:      skilltag.Canonicalize(echojobsSplitSkills(p.Skills)),
+		PostedAt:    parseRFC3339(p.DatePosted),
+	}, nil
 }
 
-// echojobsWorkMode passes through the feed's own remote_type: it already speaks freehire's
-// vocabulary (remote/hybrid/onsite), so there is no bucketing to do — just a check that the value
-// is one we recognize, leaving WorkMode empty for anything else rather than passing through junk.
-func echojobsWorkMode(remoteType string) (mode string, remote bool) {
-	switch remoteType {
-	case "remote", "hybrid", "onsite":
-		return remoteType, remoteType == "remote"
-	default:
+// echojobsSplitSkills splits the JobPosting skills field's comma-separated string into its
+// individual terms, trimming whitespace and dropping empties. Returns nil for an empty input so
+// skilltag.Canonicalize(nil) stays a no-op rather than allocating.
+func echojobsSplitSkills(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// EchoJobsDescription fetches the sanitized description for a stored echojobs job by its slug
+// (ExternalID, minus the boardless namespace prefix — see cmd/backfill-echojobs) — for a
+// backfill worker filling the description of rows whose original ingest failed to hydrate one.
+// Returns ok=false when the page fetch fails, carries no JobPosting, or the posting has no body.
+func EchoJobsDescription(ctx context.Context, c HTMLGetter, slug string) (string, bool) {
+	root, err := c.GetHTML(ctx, echojobsJobURL(slug))
+	if err != nil {
 		return "", false
 	}
+	var p struct {
+		Description string `json:"description"`
+	}
+	if !ldJobPosting(root, &p) || p.Description == "" {
+		return "", false
+	}
+	return sanitizeHTML(html.UnescapeString(p.Description)), true
 }

--- a/internal/sources/echojobs_test.go
+++ b/internal/sources/echojobs_test.go
@@ -2,174 +2,116 @@ package sources
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
-	"net/url"
-	"regexp"
 	"slices"
-	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/net/html"
 )
 
-// echojobsHTTP is a paging-and-detail-aware test JSONGetter: it serves pages[i] for ?page=i+1
-// (recording every page number requested) and, for a detail request (/api/jobs/{id}), routes by
-// the id in the path — mirroring getmanfredHTTP's list/detail split.
-type echojobsHTTP struct {
-	pages      []string
-	failPage   int // 0 = never fail
-	got        []int
-	details    map[string]string
-	detailErr  map[string]bool
-	gotDetails []string
+// echojobsFakeHTTP is a routing test double for echojobs' two data sources: XML (sitemap index +
+// job shards) and HTML (a posting's detail page, carrying its JobPosting ld+json). Each is
+// keyed by exact URL, so a test wires only the routes its scenario needs. gotXML/gotHTML record
+// every URL requested, in order, so a test can assert what was (and was not) fetched — in
+// particular that a seen posting never costs an HTML request.
+type echojobsFakeHTTP struct {
+	xmlRoutes  map[string]string
+	htmlRoutes map[string]string
+	xmlErr     map[string]bool
+	htmlErr    map[string]bool
+	gotXML     []string
+	gotHTML    []string
 }
 
-var echojobsDetailRE = regexp.MustCompile(`/jobs/([^/?]+)$`)
-
-func (f *echojobsHTTP) GetJSON(_ context.Context, u string, v any) error {
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return err
+func (f *echojobsFakeHTTP) GetXML(_ context.Context, url string, v any) error {
+	f.gotXML = append(f.gotXML, url)
+	if f.xmlErr[url] {
+		return errors.New("echojobsFakeHTTP: xml boom")
 	}
-	if parsed.RawQuery == "" {
-		if m := echojobsDetailRE.FindStringSubmatch(parsed.Path); m != nil {
-			id := m[1]
-			f.gotDetails = append(f.gotDetails, id)
-			if f.detailErr[id] {
-				return errors.New("echojobsHTTP: detail boom")
-			}
-			raw, ok := f.details[id]
-			if !ok {
-				return errors.New("echojobsHTTP: no detail for id")
-			}
-			return json.Unmarshal([]byte(raw), v)
-		}
+	body, ok := f.xmlRoutes[url]
+	if !ok {
+		return fmt.Errorf("echojobsFakeHTTP: no xml route for %s", url)
 	}
-	page, _ := strconv.Atoi(parsed.Query().Get("page"))
-	f.got = append(f.got, page)
-	if f.failPage != 0 && page == f.failPage {
-		return errors.New("echojobsHTTP: boom")
-	}
-	if page < 1 || page > len(f.pages) {
-		return fmt.Errorf("echojobsHTTP: no page %d", page)
-	}
-	return json.Unmarshal([]byte(f.pages[page-1]), v)
+	return xml.Unmarshal([]byte(body), v)
 }
 
-func echojobsPageJSON(jobs string) string {
-	return fmt.Sprintf(`{"found":999,"page":1,"per_page":100,"jobs":[%s]}`, jobs)
+func (f *echojobsFakeHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	f.gotHTML = append(f.gotHTML, url)
+	if f.htmlErr[url] {
+		return nil, errors.New("echojobsFakeHTTP: html boom")
+	}
+	body, ok := f.htmlRoutes[url]
+	if !ok {
+		return nil, fmt.Errorf("echojobsFakeHTTP: no html route for %s", url)
+	}
+	return html.Parse(strings.NewReader(body))
 }
 
-func echojobsJobJSON(handle, postedAt string) string {
-	return fmt.Sprintf(`{
-		"title":"Backend Engineer","company_name":"Acme","domain_name":"acme.com",
-		"url":"https://boards.greenhouse.io/acme/jobs/123","job_handle":%q,
-		"posted_at":%s,"locations":["California","New York"],"remote_type":"hybrid",
-		"required_skills":["Go","NotARealSkill"]
-	}`, handle, postedAt)
+// echojobsSitemapIndexXML builds a sitemap index carrying the given job-shard URLs among the
+// site's other (non-job) shards, which a correct crawl must ignore.
+func echojobsSitemapIndexXML(jobShardURLs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+	b.WriteString(`<sitemap><loc>https://echojobs.io/sitemap-nav.xml</loc></sitemap>`)
+	b.WriteString(`<sitemap><loc>https://echojobs.io/sitemap-companies.xml</loc></sitemap>`)
+	for _, u := range jobShardURLs {
+		b.WriteString(`<sitemap><loc>` + u + `</loc></sitemap>`)
+	}
+	b.WriteString(`</sitemapindex>`)
+	return b.String()
 }
 
-func TestEchojobsFetchMapsFields(t *testing.T) {
-	now := time.Now().UTC()
-	http := &echojobsHTTP{pages: []string{
-		echojobsPageJSON(echojobsJobJSON("acme-swe-abc12", strconv.FormatInt(now.UnixMilli(), 10))),
-		echojobsPageJSON(""), // empty page: the walk ends cleanly here, not on an error
-	}}
+// echojobsShardEntry is one <url> in a job-shard fixture: a slug and its ISO8601 lastmod.
+type echojobsShardEntry struct {
+	slug, lastMod string
+}
 
-	jobs, err := echojobs{http: http}.Fetch(context.Background(), CompanyEntry{})
-	if err != nil {
-		t.Fatalf("Fetch: %v", err)
+func echojobsShardXML(entries ...echojobsShardEntry) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+	for _, e := range entries {
+		b.WriteString(`<url><loc>https://echojobs.io/job/` + e.slug + `</loc><lastmod>` + e.lastMod + `</lastmod></url>`)
 	}
-	if len(jobs) != 1 {
-		t.Fatalf("want 1 job, got %d", len(jobs))
-	}
-	job := jobs[0]
-	if job.ExternalID != "acme-swe-abc12" {
-		t.Fatalf("ExternalID: %q", job.ExternalID)
-	}
-	if job.URL != "https://boards.greenhouse.io/acme/jobs/123" {
-		t.Fatalf("URL should be the upstream ATS link, got %q", job.URL)
-	}
-	if job.Title != "Backend Engineer" || job.Company != "Acme" {
-		t.Fatalf("identity mismatch: %+v", job)
-	}
-	if job.Location != "California; New York" {
-		t.Fatalf("Location: %q", job.Location)
-	}
-	if job.WorkMode != "hybrid" || job.Remote {
-		t.Fatalf("hybrid should not be Remote: mode=%q remote=%v", job.WorkMode, job.Remote)
-	}
-	if job.PostedAt == nil {
-		t.Fatalf("PostedAt not parsed")
-	}
-	if !slices.Contains(job.Skills, "go") || slices.Contains(job.Skills, "NotARealSkill") {
-		t.Fatalf("Skills: %v", job.Skills)
+	b.WriteString(`</urlset>`)
+	return b.String()
+}
+
+// echojobsJobHTML builds a detail page carrying a schema.org JobPosting ld+json block, as
+// echojobs.io's own /job/<slug> pages do (verified live).
+func echojobsJobHTML(fields string) string {
+	return `<html><body><script type="application/ld+json">{"@context":"https://schema.org","@type":"JobPosting",` +
+		fields + `}</script></body></html>`
+}
+
+// echojobsShard1URL is the single shard most tests below need — a scenario needing more than
+// one shard (freshness-window cutoff, shard-failure partial results) wires its own.
+const echojobsShard1URL = "https://echojobs.io/sitemap-jobs/1.xml"
+
+// echojobsSingleShardRoutes builds the xmlRoutes for a fake carrying one shard with one
+// freshly-dated posting — the common setup most detail-mapping tests need, so they need not
+// each repeat the sitemap index/shard plumbing.
+func echojobsSingleShardRoutes(slug string) map[string]string {
+	return map[string]string{
+		echojobsSitemapURL: echojobsSitemapIndexXML(echojobsShard1URL),
+		echojobsShard1URL:  echojobsShardXML(echojobsShardEntry{slug, time.Now().UTC().Format(time.RFC3339)}),
 	}
 }
 
-// Pagination keeps walking while a page's postings are within the freshness window, and stops as
-// soon as a page's LAST (oldest, since the feed is newest-first) item falls outside it — the
-// earlier, still-fresh items on that same page are kept.
-func TestEchojobsFetchStopsAtFreshnessWindow(t *testing.T) {
-	now := time.Now().UTC()
-	fresh := strconv.FormatInt(now.UnixMilli(), 10)
-	stillFresh := strconv.FormatInt(now.Add(-10*24*time.Hour).UnixMilli(), 10)
-	stale := strconv.FormatInt(now.Add(-20*24*time.Hour).UnixMilli(), 10)
-
-	page1 := echojobsPageJSON(echojobsJobJSON("job-1", fresh) + "," + echojobsJobJSON("job-2", fresh))
-	page2 := echojobsPageJSON(echojobsJobJSON("job-3", stillFresh) + "," + echojobsJobJSON("job-4", stale))
-	http := &echojobsHTTP{pages: []string{page1, page2, echojobsPageJSON(echojobsJobJSON("job-5", fresh))}}
-
-	jobs, err := echojobs{http: http}.Fetch(context.Background(), CompanyEntry{})
-	if err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
-
-	var ids []string
-	for _, j := range jobs {
-		ids = append(ids, j.ExternalID)
-	}
-	if !slices.Equal(ids, []string{"job-1", "job-2", "job-3"}) {
-		t.Fatalf("want job-1,job-2,job-3 (job-4 stale, job-5 never reached), got %v", ids)
-	}
-	if !slices.Equal(http.got, []int{1, 2}) {
-		t.Fatalf("page 3 should never be requested once page 2's last item is stale, got requests %v", http.got)
-	}
-}
-
-// A failed first page is a board-level error.
-func TestEchojobsFetchFirstPageFailure(t *testing.T) {
-	http := &echojobsHTTP{failPage: 1, pages: []string{echojobsPageJSON("")}}
-	if _, err := (echojobs{http: http}).Fetch(context.Background(), CompanyEntry{}); err == nil {
-		t.Fatal("want error on first-page failure")
-	}
-}
-
-// A later page failing ends the walk with what was gathered so far, per the house pagination rule.
-func TestEchojobsFetchLaterPageFailureReturnsPartial(t *testing.T) {
-	now := time.Now().UTC()
-	fresh := strconv.FormatInt(now.UnixMilli(), 10)
-	page1 := echojobsPageJSON(echojobsJobJSON("job-1", fresh))
-	http := &echojobsHTTP{pages: []string{page1, echojobsPageJSON(echojobsJobJSON("job-2", fresh))}, failPage: 2}
-
-	jobs, err := echojobs{http: http}.Fetch(context.Background(), CompanyEntry{})
-	if err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
-	if len(jobs) != 1 || jobs[0].ExternalID != "job-1" {
-		t.Fatalf("want partial result [job-1], got %+v", jobs)
-	}
-}
-
-// The list endpoint carries no description (verified live), so FetchNew hydrates it from the
-// per-posting detail endpoint — but only for a posting the catalogue does not already have.
 func TestEchojobsFetchNewHydratesUnseenPosting(t *testing.T) {
-	now := time.Now().UTC()
-	fresh := strconv.FormatInt(now.UnixMilli(), 10)
-	http := &echojobsHTTP{
-		pages:   []string{echojobsPageJSON(echojobsJobJSON("acme-swe", fresh)), echojobsPageJSON("")},
-		details: map[string]string{"acme-swe": `{"description":"<p>Great role.</p>"}`},
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("acme-swe-abc12"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("acme-swe-abc12"): echojobsJobHTML(`"title":"Backend Engineer",` +
+				`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+				`"description":"<p>Great role.</p>",` +
+				`"jobLocationType":"TELECOMMUTE",` +
+				`"datePosted":"2026-08-01T00:00:00Z",` +
+				`"skills":"Go, Kafka"`),
+		},
 	}
 
 	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
@@ -179,23 +121,36 @@ func TestEchojobsFetchNewHydratesUnseenPosting(t *testing.T) {
 	if len(jobs) != 1 {
 		t.Fatalf("want 1 job, got %d", len(jobs))
 	}
-	if jobs[0].Description != "<p>Great role.</p>" {
-		t.Fatalf("Description not hydrated: %q", jobs[0].Description)
+	job := jobs[0]
+	if job.ExternalID != "acme-swe-abc12" {
+		t.Errorf("ExternalID = %q", job.ExternalID)
 	}
-	if !slices.Equal(http.gotDetails, []string{"acme-swe"}) {
-		t.Fatalf("detail requests = %v, want [acme-swe]", http.gotDetails)
+	if job.URL != "https://echojobs.io/job/acme-swe-abc12" {
+		t.Errorf("URL = %q", job.URL)
+	}
+	if job.Title != "Backend Engineer" || job.Company != "Acme" {
+		t.Errorf("identity mismatch: %+v", job)
+	}
+	if job.Description != "<p>Great role.</p>" {
+		t.Errorf("Description = %q", job.Description)
+	}
+	if !job.Remote || job.WorkMode != "remote" {
+		t.Errorf("TELECOMMUTE should map to Remote=true, WorkMode=remote: %+v", job)
+	}
+	if job.PostedAt == nil {
+		t.Errorf("PostedAt not parsed")
+	}
+	if !slices.Contains(job.Skills, "go") {
+		t.Errorf("Skills = %v, want it to contain \"go\"", job.Skills)
 	}
 }
 
 // A posting the catalogue already has must not cost a detail request: it is refreshed
-// (SeenRefresh) with its list-only identity, preserving whatever description was hydrated when
-// it was new — a content-less re-upsert would wipe it.
+// (SeenRefresh) with just its identity, preserving whatever description was hydrated when it
+// was new — a content-less re-upsert would wipe it. Unlike the old list+detail split, the
+// sitemap alone carries no title/company, so a seen posting's refresh Job is intentionally bare.
 func TestEchojobsFetchNewSkipsDetailForSeenPosting(t *testing.T) {
-	now := time.Now().UTC()
-	fresh := strconv.FormatInt(now.UnixMilli(), 10)
-	http := &echojobsHTTP{
-		pages: []string{echojobsPageJSON(echojobsJobJSON("acme-swe", fresh)), echojobsPageJSON("")},
-	}
+	http := &echojobsFakeHTTP{xmlRoutes: echojobsSingleShardRoutes("acme-swe")}
 
 	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(externalID string) bool {
 		return externalID == "acme-swe"
@@ -206,25 +161,202 @@ func TestEchojobsFetchNewSkipsDetailForSeenPosting(t *testing.T) {
 	if len(jobs) != 1 || !jobs[0].SeenRefresh {
 		t.Fatalf("want 1 job with SeenRefresh set, got %+v", jobs)
 	}
-	if len(http.gotDetails) != 0 {
-		t.Fatalf("a seen posting must not cost a detail request, got %v", http.gotDetails)
+	if jobs[0].ExternalID != "acme-swe" || jobs[0].URL != "https://echojobs.io/job/acme-swe" {
+		t.Errorf("seen refresh should still carry identity fields: %+v", jobs[0])
+	}
+	if len(http.gotHTML) != 0 {
+		t.Fatalf("a seen posting must not cost a detail request, got %v", http.gotHTML)
 	}
 }
 
-// A failed detail request must not drop the posting — it falls back to the list-only job.
-func TestEchojobsFetchNewDetailFailureKeepsPosting(t *testing.T) {
-	now := time.Now().UTC()
-	fresh := strconv.FormatInt(now.UnixMilli(), 10)
-	http := &echojobsHTTP{
-		pages:     []string{echojobsPageJSON(echojobsJobJSON("acme-swe", fresh)), echojobsPageJSON("")},
-		detailErr: map[string]bool{"acme-swe": true},
+// A failed detail request drops just that posting: unlike the old list+detail split, the
+// sitemap carries no fields a list-only Job could fall back to, so there is nothing left to
+// ingest for it this run.
+func TestEchojobsFetchNewDetailFailureDropsPosting(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("acme-swe"),
+		htmlErr:   map[string]bool{echojobsJobURL("acme-swe"): true},
 	}
 
 	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
 	if err != nil {
 		t.Fatalf("FetchNew: %v", err)
 	}
-	if len(jobs) != 1 || jobs[0].Description != "" || jobs[0].ExternalID != "acme-swe" {
-		t.Fatalf("posting should survive a failed detail request: %+v", jobs)
+	if len(jobs) != 0 {
+		t.Fatalf("want 0 jobs (detail failed, no list-only fallback), got %+v", jobs)
+	}
+}
+
+// A detail page carrying no JobPosting ld+json block (or one with an empty title) drops the
+// posting the same way a fetch failure does — there is no usable content to ingest.
+func TestEchojobsFetchNewMissingJSONLDDropsPosting(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("acme-swe"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("acme-swe"): `<html><body>not a job page</body></html>`,
+		},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("want 0 jobs, got %+v", jobs)
+	}
+}
+
+// The crawl keeps walking shards while their postings are within the freshness window, and
+// stops as soon as a shard's last (oldest, since shards are newest-first) item falls outside
+// it — the earlier, still-fresh items on that same shard are kept, and a shard past that point
+// is never fetched.
+func TestEchojobsFetchStopsAtFreshnessWindow(t *testing.T) {
+	now := time.Now().UTC()
+	fresh := now.Format(time.RFC3339)
+	stillFresh := now.Add(-10 * 24 * time.Hour).Format(time.RFC3339)
+	stale := now.Add(-20 * 24 * time.Hour).Format(time.RFC3339)
+
+	shard1 := echojobsShard1URL
+	shard2 := "https://echojobs.io/sitemap-jobs/2.xml"
+	shard3 := "https://echojobs.io/sitemap-jobs/3.xml"
+
+	http := &echojobsFakeHTTP{
+		xmlRoutes: map[string]string{
+			echojobsSitemapURL: echojobsSitemapIndexXML(shard1, shard2, shard3),
+			shard1: echojobsShardXML(
+				echojobsShardEntry{"job-1", fresh}, echojobsShardEntry{"job-2", fresh}),
+			shard2: echojobsShardXML(
+				echojobsShardEntry{"job-3", stillFresh}, echojobsShardEntry{"job-4", stale}),
+			shard3: echojobsShardXML(echojobsShardEntry{"job-5", fresh}),
+		},
+	}
+
+	postings, err := echojobs{http: http}.crawl(context.Background())
+	if err != nil {
+		t.Fatalf("crawl: %v", err)
+	}
+	var slugs []string
+	for _, p := range postings {
+		slugs = append(slugs, p.Slug)
+	}
+	if !slices.Equal(slugs, []string{"job-1", "job-2", "job-3"}) {
+		t.Fatalf("want job-1,job-2,job-3 (job-4 stale, job-5 never reached), got %v", slugs)
+	}
+	if !slices.Equal(http.gotXML, []string{echojobsSitemapURL, shard1, shard2}) {
+		t.Fatalf("shard 3 should never be requested once shard 2's last item is stale, got %v", http.gotXML)
+	}
+}
+
+// A failed first shard is a board-level error, per the house pagination rule.
+func TestEchojobsCrawlFirstShardFailure(t *testing.T) {
+	shard1 := echojobsShard1URL
+	http := &echojobsFakeHTTP{
+		xmlRoutes: map[string]string{echojobsSitemapURL: echojobsSitemapIndexXML(shard1)},
+		xmlErr:    map[string]bool{shard1: true},
+	}
+	if _, err := (echojobs{http: http}).crawl(context.Background()); err == nil {
+		t.Fatal("want error on first-shard failure")
+	}
+}
+
+// A later shard failing ends the walk with what was gathered so far.
+func TestEchojobsCrawlLaterShardFailureReturnsPartial(t *testing.T) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	shard1 := echojobsShard1URL
+	shard2 := "https://echojobs.io/sitemap-jobs/2.xml"
+	http := &echojobsFakeHTTP{
+		xmlRoutes: map[string]string{
+			echojobsSitemapURL: echojobsSitemapIndexXML(shard1, shard2),
+			shard1:             echojobsShardXML(echojobsShardEntry{"job-1", now}),
+		},
+		xmlErr: map[string]bool{shard2: true},
+	}
+
+	postings, err := echojobs{http: http}.crawl(context.Background())
+	if err != nil {
+		t.Fatalf("crawl: %v", err)
+	}
+	if len(postings) != 1 || postings[0].Slug != "job-1" {
+		t.Fatalf("want partial result [job-1], got %+v", postings)
+	}
+}
+
+// A posting with no jobLocation falls back to applicantLocationRequirements for its Location —
+// the shape a fully-remote posting emits (verified live: echojobs' own Doowii listing).
+func TestEchojobsFetchNewFallsBackToApplicantLocationRequirements(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("remote-role"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("remote-role"): echojobsJobHTML(`"title":"Engineer",` +
+				`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+				`"description":"<p>Role.</p>",` +
+				`"jobLocationType":"TELECOMMUTE",` +
+				`"applicantLocationRequirements":{"@type":"Country","name":"US"}`),
+		},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Location != "US" {
+		t.Fatalf("want Location=US from applicantLocationRequirements, got %+v", jobs)
+	}
+}
+
+// A posting WITH a jobLocation address uses it, and carries no jobLocationType (on-site),
+// so WorkMode stays empty rather than guessed.
+func TestEchojobsFetchNewMapsOnsiteLocation(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("onsite-role"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("onsite-role"): echojobsJobHTML(`"title":"Engineer",` +
+				`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+				`"description":"<p>Role.</p>",` +
+				`"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Apopka, FL","addressCountry":"US"}}`),
+		},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want 1 job, got %+v", jobs)
+	}
+	job := jobs[0]
+	if job.Location != "Apopka, FL, US" {
+		t.Errorf("Location = %q", job.Location)
+	}
+	if job.Remote || job.WorkMode != "" {
+		t.Errorf("no jobLocationType should leave Remote=false, WorkMode=\"\": %+v", job)
+	}
+}
+
+// Fetch (the non-hydrating fallback) has no list-only tier to fall back to any more — the
+// sitemap alone carries no field a Job needs — so it fully hydrates every posting it finds,
+// same as FetchNew treating everything as new.
+func TestEchojobsFetchHydratesEveryPosting(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("acme-swe"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("acme-swe"): echojobsJobHTML(`"title":"Backend Engineer",` +
+				`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+				`"description":"<p>Great role.</p>"`),
+		},
+	}
+
+	jobs, err := echojobs{http: http}.Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Title != "Backend Engineer" {
+		t.Fatalf("want 1 fully-hydrated job, got %+v", jobs)
+	}
+}
+
+func TestEchojobsProvider(t *testing.T) {
+	if got := (echojobs{}).Provider(); got != "echojobs" {
+		t.Errorf("Provider() = %q, want echojobs", got)
 	}
 }

--- a/internal/sources/echojobs_test.go
+++ b/internal/sources/echojobs_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,18 +18,24 @@ import (
 // job shards) and HTML (a posting's detail page, carrying its JobPosting ld+json). Each is
 // keyed by exact URL, so a test wires only the routes its scenario needs. gotXML/gotHTML record
 // every URL requested, in order, so a test can assert what was (and was not) fetched — in
-// particular that a seen posting never costs an HTML request.
+// particular that a seen posting never costs an HTML request. mu guards both slices: FetchNew
+// runs detail() concurrently across a bounded worker pool (see fetchDetails), so a scenario with
+// more than one unseen posting calls GetHTML from several goroutines at once.
 type echojobsFakeHTTP struct {
 	xmlRoutes  map[string]string
 	htmlRoutes map[string]string
 	xmlErr     map[string]bool
 	htmlErr    map[string]bool
-	gotXML     []string
-	gotHTML    []string
+
+	mu      sync.Mutex
+	gotXML  []string
+	gotHTML []string
 }
 
 func (f *echojobsFakeHTTP) GetXML(_ context.Context, url string, v any) error {
+	f.mu.Lock()
 	f.gotXML = append(f.gotXML, url)
+	f.mu.Unlock()
 	if f.xmlErr[url] {
 		return errors.New("echojobsFakeHTTP: xml boom")
 	}
@@ -40,7 +47,9 @@ func (f *echojobsFakeHTTP) GetXML(_ context.Context, url string, v any) error {
 }
 
 func (f *echojobsFakeHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	f.mu.Lock()
 	f.gotHTML = append(f.gotHTML, url)
+	f.mu.Unlock()
 	if f.htmlErr[url] {
 		return nil, errors.New("echojobsFakeHTTP: html boom")
 	}
@@ -301,6 +310,84 @@ func TestEchojobsFetchNewFallsBackToApplicantLocationRequirements(t *testing.T) 
 	}
 	if len(jobs) != 1 || jobs[0].Location != "US" {
 		t.Fatalf("want Location=US from applicantLocationRequirements, got %+v", jobs)
+	}
+}
+
+// schema.org allows applicantLocationRequirements as EITHER a single object OR an array (a
+// remote posting open to several countries). Go's json.Unmarshal errors on a bare-object field
+// asked to decode an array — decoding it as a plain struct would fail the WHOLE ld+json block
+// (see schemaNamedAreas' doc), dropping the posting entirely rather than just its location. This
+// pins that the array form decodes cleanly and every field survives, not just the location.
+func TestEchojobsFetchNewHandlesArrayApplicantLocationRequirements(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("multi-country-role"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("multi-country-role"): echojobsJobHTML(`"title":"Engineer",` +
+				`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+				`"description":"<p>Role.</p>",` +
+				`"jobLocationType":"TELECOMMUTE",` +
+				`"applicantLocationRequirements":[{"@type":"Country","name":"US"},{"@type":"Country","name":"Canada"}]`),
+		},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want 1 job (array-shaped applicantLocationRequirements must not drop the posting), got %+v", jobs)
+	}
+	job := jobs[0]
+	if job.Title != "Engineer" {
+		t.Errorf("Title = %q, want it to survive the array field", job.Title)
+	}
+	if job.Location != "US, Canada" {
+		t.Errorf("Location = %q, want both countries joined", job.Location)
+	}
+}
+
+// schema.org allows jobLocation as EITHER a single Place OR an array of them, the same way
+// applicantLocationRequirements does. This pins the array form via the shared schemaPlaces type.
+func TestEchojobsFetchNewHandlesArrayJobLocation(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("multi-location-role"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("multi-location-role"): echojobsJobHTML(`"title":"Engineer",` +
+				`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+				`"description":"<p>Role.</p>",` +
+				`"jobLocation":[{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Austin, TX","addressCountry":"US"}},` +
+				`{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Denver, CO","addressCountry":"US"}}]`),
+		},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Location != "Austin, TX, US" {
+		t.Fatalf("want the first location (array-shaped jobLocation must not drop the posting), got %+v", jobs)
+	}
+}
+
+// datePosted may be a bare "2006-01-02" date rather than a full RFC3339 timestamp (the same
+// tenant-dependent variance northstone/briefhq already handle via parseRFC3339OrDate).
+func TestEchojobsFetchNewParsesDateOnlyPostedAt(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("date-only-role"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("date-only-role"): echojobsJobHTML(`"title":"Engineer",` +
+				`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+				`"description":"<p>Role.</p>",` +
+				`"datePosted":"2026-08-01"`),
+		},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].PostedAt == nil {
+		t.Fatalf("want PostedAt parsed from a bare date, got %+v", jobs)
 	}
 }
 

--- a/internal/sources/schema.go
+++ b/internal/sources/schema.go
@@ -72,3 +72,47 @@ func (p *schemaPlaces) UnmarshalJSON(b []byte) error {
 	*p = []schemaPlace{one}
 	return nil
 }
+
+// schemaNamedArea is one schema.org node that carries just a name — a Country, AdministrativeArea,
+// or City entry in a JobPosting's applicantLocationRequirements. ATS ld+json only ever needs the
+// name out of it.
+type schemaNamedArea struct {
+	Name string `json:"name"`
+}
+
+// schemaNamedAreas decodes JobPosting.applicantLocationRequirements the same way schemaPlaces
+// decodes jobLocation: the schema.org spec allows EITHER a single node (one country a fully-
+// remote posting is open to) OR an array of them (several), and Go's json.Unmarshal errors on a
+// bare-object field asked to decode a JSON array — not silently, but by returning a non-nil error
+// from the TOP-LEVEL Unmarshal call even though every other field in the same object decoded
+// correctly. A caller that treats "err != nil" as "no usable JobPosting" (as ldJobPosting's own
+// callers do) then drops the WHOLE posting over one field's shape, not just the location. Shared
+// by any ld+json adapter reading this field.
+type schemaNamedAreas []schemaNamedArea
+
+func (a *schemaNamedAreas) UnmarshalJSON(b []byte) error {
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var arr []schemaNamedArea
+		if err := json.Unmarshal(trimmed, &arr); err != nil {
+			return err
+		}
+		*a = arr
+		return nil
+	}
+	var one schemaNamedArea
+	if err := json.Unmarshal(trimmed, &one); err != nil {
+		return err
+	}
+	*a = []schemaNamedArea{one}
+	return nil
+}
+
+// Names returns every area's name, in order — the only field an adapter needs out of this type.
+func (a schemaNamedAreas) Names() []string {
+	names := make([]string, 0, len(a))
+	for _, n := range a {
+		names = append(names, n.Name)
+	}
+	return names
+}

--- a/internal/sources/schema_test.go
+++ b/internal/sources/schema_test.go
@@ -20,19 +20,24 @@ func TestSchemaEmploymentType(t *testing.T) {
 }
 
 func TestSchemaNamedAreasDecodesSingleObjectOrArray(t *testing.T) {
-	cases := map[string][]string{
-		`{"@type":"Country","name":"US"}`:                                       []string{"US"},
-		`[{"@type":"Country","name":"US"},{"@type":"Country","name":"Canada"}]`: []string{"US", "Canada"},
-		`[]`: nil,
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"single object", `{"@type":"Country","name":"US"}`, []string{"US"}},
+		{"array", `[{"@type":"Country","name":"US"},{"@type":"Country","name":"Canada"}]`, []string{"US", "Canada"}},
+		{"empty array", `[]`, nil},
 	}
-	for in, want := range cases {
-		var a schemaNamedAreas
-		if err := json.Unmarshal([]byte(in), &a); err != nil {
-			t.Errorf("Unmarshal(%s): %v", in, err)
-			continue
-		}
-		if got := a.Names(); !slices.Equal(got, want) {
-			t.Errorf("Unmarshal(%s).Names() = %v, want %v", in, got, want)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var a schemaNamedAreas
+			if err := json.Unmarshal([]byte(tc.in), &a); err != nil {
+				t.Fatalf("Unmarshal(%s): %v", tc.in, err)
+			}
+			if got := a.Names(); !slices.Equal(got, tc.want) {
+				t.Errorf("Unmarshal(%s).Names() = %v, want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/sources/schema_test.go
+++ b/internal/sources/schema_test.go
@@ -1,6 +1,10 @@
 package sources
 
-import "testing"
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+)
 
 func TestSchemaEmploymentType(t *testing.T) {
 	cases := map[string]string{
@@ -11,6 +15,24 @@ func TestSchemaEmploymentType(t *testing.T) {
 	for in, want := range cases {
 		if got := schemaEmploymentType(in); got != want {
 			t.Errorf("schemaEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSchemaNamedAreasDecodesSingleObjectOrArray(t *testing.T) {
+	cases := map[string][]string{
+		`{"@type":"Country","name":"US"}`:                                       []string{"US"},
+		`[{"@type":"Country","name":"US"},{"@type":"Country","name":"Canada"}]`: []string{"US", "Canada"},
+		`[]`: nil,
+	}
+	for in, want := range cases {
+		var a schemaNamedAreas
+		if err := json.Unmarshal([]byte(in), &a); err != nil {
+			t.Errorf("Unmarshal(%s): %v", in, err)
+			continue
+		}
+		if got := a.Names(); !slices.Equal(got, want) {
+			t.Errorf("Unmarshal(%s).Names() = %v, want %v", in, got, want)
 		}
 	}
 }

--- a/openspec/changes/fix-echojobs-adapter/.openspec.yaml
+++ b/openspec/changes/fix-echojobs-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/fix-echojobs-adapter/design.md
+++ b/openspec/changes/fix-echojobs-adapter/design.md
@@ -99,11 +99,22 @@ spuriously reject a posting that was already accepted once
   → `WorkMode: ""` (unknown), matching the existing adapter's principle of never guessing
   hybrid/onsite from an ambiguous signal.
 - `jobLocation.address` (`addressLocality`, `addressCountry`) when present; otherwise
-  `applicantLocationRequirements.name` for remote postings that carry no `jobLocation`.
+  `applicantLocationRequirements.name` for remote postings that carry no `jobLocation`. Both
+  fields decode through the shared object-or-array schema types (`schemaPlaces`,
+  `schemaNamedAreas` in `internal/sources/schema.go`) rather than a bare struct: schema.org
+  allows either a single node or an array for both, and every live sample so far has shipped
+  a single object — but Go's `json.Unmarshal` errors on a bare-struct field asked to decode
+  an array, and that error propagates through `ldJobPosting`'s `err == nil` check and drops
+  the WHOLE posting, not just its location, the day one tenant emits the array form (e.g. a
+  remote role open to several countries). Caught in review before this shipped; regression
+  test at `TestEchojobsFetchNewHandlesArrayApplicantLocationRequirements` /
+  `TestEchojobsFetchNewHandlesArrayJobLocation`.
 - `skills`: a single comma-separated string in the new format (was a JSON array before) —
   split and trim, then run through the existing `skilltag.Canonicalize`.
-- `datePosted`: ISO 8601 (`time.Parse(time.RFC3339, ...)`), replacing the old
-  epoch-millisecond parsing.
+- `datePosted`: `parseRFC3339OrDate` (full RFC3339 timestamp, falling back to a bare
+  `2006-01-02` date) — the same tenant-dependent variance `northstone`/`briefhq` already
+  handle for the same JobPosting field. Every live sample so far has been full RFC3339; the
+  bare-date fallback is defensive, matching house precedent rather than a live-observed need.
 
 ## Risks / Trade-offs
 
@@ -116,13 +127,47 @@ spuriously reject a posting that was already accepted once
 - **[Risk] Sitemap shard count/URLs-per-shard could change over time** (currently 23
   shards × 10,000). → Mitigation: the crawl walks `sitemap.xml` to discover shard URLs
   dynamically rather than hardcoding a shard count, and stops on the freshness-window
-  cutoff rather than a fixed shard number either way.
+  cutoff rather than a fixed shard number either way. A narrower variant of this risk —
+  the newest-first ORDER itself changing, e.g. a fresher shard appearing after a staler one
+  — was raised in review. → Not mitigated: verified live via shard-boundary sampling (see
+  Context) and accepted as a live-verified assumption, not a runtime-guarded invariant. A
+  guard (detect out-of-order lastmod, fall back to scanning every shard) is real defensive
+  value but a genuine scope increase — no evidence this happens, and the failure mode if it
+  ever does is silent staleness (missed newest postings), not corruption or a crash. Left as
+  a follow-up if it's ever observed, not built speculatively (YAGNI per this repo's working
+  principles).
 - **[Trade-off] `SeenRefresh` postings carry no `Title` any more** (previously came from
   the list endpoint, which had it; the sitemap does not). Verified harmless for the one
   path that reads it (the catalogue filter — see Decisions above), but any *future* code
   added to the `SeenRefresh` branch that assumes a non-empty `Title` would silently regress
   for echojobs specifically. Not mitigated beyond this note — the existing code path
   doesn't need it today.
+- **[Trade-off] `Job.URL` now points at the echojobs.io job page, not the employer's own ATS
+  link.** The old adapter's list JSON carried the employer's real apply URL directly (a
+  Workday/Greenhouse/etc. link); `Job.URL` is what `jobview`/`JobView.svelte` opens as the
+  "Apply" target on freehire.me, so this is a real, user-facing change, not an internal
+  detail. Investigated recovering it: the employer link is no longer present anywhere in the
+  server-rendered `/job/<slug>` page — verified by extracting every `http(s)` URL from a
+  fetched page's full text (only the company's own homepage appears, via
+  `hiringOrganization.sameAs`) — and the page's own copy now reads "Sign in to apply →",
+  which reads as echojobs.io gating the outbound link behind an account, not merely
+  client-side hydration. → Mitigation: none — recovering it would need a headless browser
+  (and possibly an authenticated echojobs.io session) per posting, which defeats the
+  plain-GET design this rewrite exists to keep, for a source that is one of ~300+ this
+  catalogue crawls. Accepted as an unavoidable quality regression specific to this source
+  until/unless echojobs.io exposes the link some other way.
+- **[Risk] A systemic detail-fetch failure (e.g. echojobs changes its page markup again)
+  drops postings silently — the per-posting `Skipped`/`Failed` stats `ingestFetched` logs
+  never see an adapter-level drop, only a `saveOne` failure.** This is exactly the failure
+  shape that let the API removal itself go unnoticed until a user reported one empty
+  description. → Mitigation: `FetchNew` now logs a per-run summary
+  (`echojobs: dropped %d/%d candidate postings this run`) whenever any posting was dropped,
+  visible in the same log stream every other adapter's anomalies already go to. This is
+  visibility, not alerting or a board-health signal — wiring a systemic echojobs failure
+  into board-health cooldown or a dedicated alert is a real follow-up, not built here: it
+  would need either a new `Job`-carried failure count or a `HydratingSource` interface
+  change reaching every adapter, out of proportion for a bug-fix change whose scope is
+  restoring the existing contract.
 - **[Risk] Volume estimate (50,000+ postings/window) is extrapolated from shard date
   ranges, not measured against the new crawl in production.** → Mitigation: the design
   bounds the *expensive* operation (full detail fetch) to genuinely new postings, which
@@ -139,7 +184,13 @@ dedup key are unaffected. Deploy is a normal `release.sh` build; the next schedu
 deploy, `cmd/backfill-echojobs` should be run once by hand to repair the empty-description
 rows accumulated during the outage window (2026-08-13 onward) — no timer runs it
 automatically (see `internal/sources/AGENTS.md`'s note that it is a one-off worker).
-Rollback is a normal `rollback.sh` to the prior color; no schema or on-disk state to undo.
+Rollback is a normal `rollback.sh` to the prior color; no schema or on-disk state to undo. Note
+what rollback does NOT do: the prior release calls the same dead `/api/jobs` endpoints this
+change replaces, so rolling back returns echojobs ingestion to the exact broken (empty-
+description) state this change exists to fix — it undoes this deploy, it does not restore a
+working echojobs adapter. That is correct, expected rollback semantics (undo a bad new deploy,
+accept the pre-existing known state), not a gap — called out explicitly here so it is not
+mistaken for one during an incident.
 
 ## Open Questions
 

--- a/openspec/changes/fix-echojobs-adapter/design.md
+++ b/openspec/changes/fix-echojobs-adapter/design.md
@@ -1,0 +1,148 @@
+## Context
+
+`internal/sources/echojobs.go` is a boardless, hydrating aggregator adapter (see
+`internal/sources/AGENTS.md` for the `HydratingSource` shape): `crawl()` pages a list
+endpoint to discover postings inside a 14-day freshness window, `FetchNew` hydrates a
+per-posting detail body only for postings the catalogue does not already have (`seen`),
+and already-seen postings get a cheap liveness `touch()` instead of a full re-upsert (so a
+content-less re-listing never wipes the description hydrated when the posting was new).
+
+Both endpoints this design depended on — `GET /api/jobs?page=N` (list) and `GET
+/api/jobs/<handle>` (detail) — now 404. Live verification (both from this machine and from
+prod's own egress IP) shows the site itself still works; a headless-browser capture of
+`https://echojobs.io/jobs` showed data now loads via Next.js App Router RSC payloads
+(`?_rsc=<build-hash>`), and job pages moved from an API route to a page route
+(`/job/<company>-<role>-<suffix>`). This reads as a permanent migration, not a transient
+outage: the last successful ingest run using the old API was 2026-08-13 01:06 UTC, and
+`/api/jobs` has stayed 404 since.
+
+Two further findings de-risk the rewrite considerably:
+
+1. **`https://echojobs.io/sitemap.xml`** is a public sitemap index pointing to
+   `sitemap-jobs/1.xml` … `23.xml`, 10,000 URLs each. Sampling shard boundaries confirmed
+   they are globally sorted newest-first by `<lastmod>` (shard 1 spans the last ~2 days,
+   shard 23 the oldest). This replaces the list crawl's pagination without needing the
+   dead API.
+2. Every `/job/<slug>` page — fetched with a plain `GET`, no JavaScript execution needed —
+   embeds a `<script type="application/ld+json">` block with `"@type":"JobPosting"`: the
+   standard schema.org structured-data markup sites publish for Google for Jobs indexing.
+   Verified live on both a sample posting (JLL, on-site) and the originally-reported Doowii
+   posting (remote): it carries `title`, `hiringOrganization.name`, full `description`
+   (HTML), `jobLocationType` (`"TELECOMMUTE"` for remote), `jobLocation.address` /
+   `applicantLocationRequirements.name`, `skills` (comma-separated string), and
+   `datePosted`. Slugs are unchanged from the old `job_handle` scheme (verified: the
+   Doowii posting's slug, `doowii-full-stack-software-engineer-prmbc`, is byte-identical
+   to the `ExternalID` already stored from before the outage), so no re-ingestion or
+   duplicate rows result from the swap.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore echojobs ingestion (list discovery + description hydration) using the new site's
+  publicly-available, intentionally-maintained data surfaces (sitemap + JSON-LD) — not a
+  reverse-engineering of the RSC wire format, which is an internal implementation detail
+  tied to a specific build hash and likely to break again on redeploy.
+- Preserve the adapter's external contract: same `ExternalID` scheme, same 14-day
+  freshness window, same `HydratingSource` behavior (detail fetched only for new
+  postings), same request-volume order of magnitude per run.
+- Fix the same root cause in `EchoJobsDescription` (backing `cmd/backfill-echojobs`) and
+  `cmd/liveness/echojobs.go`, which call the same dead endpoint.
+
+**Non-Goals:**
+- Not scraping or headless-browser-rendering echojobs pages — the JSON-LD block makes
+  that unnecessary.
+- Not adding new Job fields (e.g. `educationRequirements`, `experienceRequirements`) the
+  JSON-LD happens to carry but the current `Job` shape has no home for — out of scope,
+  matches AGENTS.md's existing "don't guess a field's home" precedent (see echojobs.go's
+  doc comment on fields it deliberately does not read).
+- Not building a generic "extract schema.org JobPosting from HTML" package — echojobs is
+  the only current consumer; a shared helper is a seam for later if a second adapter needs
+  it (YAGNI per this repo's working principles), not now.
+
+## Decisions
+
+**List discovery: sitemap shards over RSC parsing or full HTML scraping.**
+Considered three sources for "what postings exist, newest first": (a) parse the RSC
+`?_rsc=` payloads the live site uses, (b) scrape rendered `/jobs` listing pages, (c) page
+the sitemap. Rejected (a): RSC framing is undocumented, tied to a `dpl_...` build hash
+that changes on every echojobs deploy, and not intended for external consumption — the
+adapter would be back here after their next redeploy. Rejected (b): the listing page
+needs JS execution to populate (confirmed via network capture), meaning per-run headless
+browser sessions — expensive and slow at the volume this adapter needs. Chose (c): the
+sitemap is a stable, publicly-documented format (referenced from `robots.txt`), requires
+only plain HTTP GETs, and is already sorted the way the freshness-window walk needs.
+
+**Detail hydration: JSON-LD over RSC parsing or HTML scraping.**
+Same reasoning as above — the JSON-LD block is schema.org structured data, which sites
+have a standing incentive (Google for Jobs indexing) not to break carelessly, unlike an
+internal API route. It is also a plain `<script>` tag in server-rendered HTML, parseable
+with `encoding/json` after a regex/string extraction of the tag body — no HTML-DOM
+parsing library needed for the fields this adapter reads.
+
+**Refresh strategy for already-seen postings: liveness-only `touch()`, not a full re-fetch.**
+The 14-day freshness window covers 50,000+ postings (extrapolated from shard date
+ranges). Re-fetching the JSON-LD detail for every postings in that window on every run —
+simplest to implement — was explicitly rejected (by the user) as excessive load on
+echojobs.io and a real rate-limit/block risk, and slower per run than the old adapter by
+roughly two orders of magnitude. Instead: a posting whose slug is already in the
+catalogue (`seen(externalID)`) never gets a detail fetch — same as today — and is
+reported with `SeenRefresh: true` and an empty `Title`. Verified this is safe two ways:
+`internal/pipeline.Runner.touch()` reads only `source` + `externalID` from the `Job`
+(`internal/pipeline/pipeline.go:543-550`), and `classify.ConfirmedNonTech("", ...)` —
+which gates a `SeenRefresh` posting through the same catalogue filter a real save would
+hit — never matches an empty title against the non-tech dictionary, so it cannot
+spuriously reject a posting that was already accepted once
+(`internal/classify/nontech.go:202-207`).
+
+**Field mapping notes** (JSON-LD → `Job`):
+- `jobLocationType == "TELECOMMUTE"` → `Remote: true, WorkMode: "remote"`; anything else
+  → `WorkMode: ""` (unknown), matching the existing adapter's principle of never guessing
+  hybrid/onsite from an ambiguous signal.
+- `jobLocation.address` (`addressLocality`, `addressCountry`) when present; otherwise
+  `applicantLocationRequirements.name` for remote postings that carry no `jobLocation`.
+- `skills`: a single comma-separated string in the new format (was a JSON array before) —
+  split and trim, then run through the existing `skilltag.Canonicalize`.
+- `datePosted`: ISO 8601 (`time.Parse(time.RFC3339, ...)`), replacing the old
+  epoch-millisecond parsing.
+
+## Risks / Trade-offs
+
+- **[Risk] The sitemap or JSON-LD format could itself change or disappear.** Lower
+  likelihood than the API (both are maintained for SEO purposes, a standing incentive
+  the old private API never had), but not zero. → Mitigation: none built in; if it
+  happens, the failure mode is the same as today's — `crawl`/`detail` return an error,
+  the board fails cleanly and is retried next run, board-health cooldown applies as usual.
+  No special handling beyond what every adapter already gets.
+- **[Risk] Sitemap shard count/URLs-per-shard could change over time** (currently 23
+  shards × 10,000). → Mitigation: the crawl walks `sitemap.xml` to discover shard URLs
+  dynamically rather than hardcoding a shard count, and stops on the freshness-window
+  cutoff rather than a fixed shard number either way.
+- **[Trade-off] `SeenRefresh` postings carry no `Title` any more** (previously came from
+  the list endpoint, which had it; the sitemap does not). Verified harmless for the one
+  path that reads it (the catalogue filter — see Decisions above), but any *future* code
+  added to the `SeenRefresh` branch that assumes a non-empty `Title` would silently regress
+  for echojobs specifically. Not mitigated beyond this note — the existing code path
+  doesn't need it today.
+- **[Risk] Volume estimate (50,000+ postings/window) is extrapolated from shard date
+  ranges, not measured against the new crawl in production.** → Mitigation: the design
+  bounds the *expensive* operation (full detail fetch) to genuinely new postings, which
+  regardless of the window's total size stays close to today's per-run new-posting count —
+  the estimate only matters for confirming the *cheap* path (sitemap shard reads) is cheap
+  enough, and even 50,000 lightweight XML entries across ~5-6 shard fetches is negligible.
+
+## Migration Plan
+
+No data migration. This is a pure adapter-internals swap: `ExternalID` scheme, `Job`
+output shape, and freshness-window semantics are unchanged, so existing rows and the
+dedup key are unaffected. Deploy is a normal `release.sh` build; the next scheduled
+`freehire-ingest@echojobs.timer` fire picks up the new adapter automatically. After
+deploy, `cmd/backfill-echojobs` should be run once by hand to repair the empty-description
+rows accumulated during the outage window (2026-08-13 onward) — no timer runs it
+automatically (see `internal/sources/AGENTS.md`'s note that it is a one-off worker).
+Rollback is a normal `rollback.sh` to the prior color; no schema or on-disk state to undo.
+
+## Open Questions
+
+- None outstanding. The only real unknown going in — whether a lightweight,
+  non-JS data source exists at all for the new site — was resolved during design
+  (sitemap + JSON-LD), so no further spike is needed before implementation.

--- a/openspec/changes/fix-echojobs-adapter/proposal.md
+++ b/openspec/changes/fix-echojobs-adapter/proposal.md
@@ -17,7 +17,7 @@ echojobs.io removed the public JSON API (`/api/jobs` list, `/api/jobs/{handle}` 
 (none)
 
 ### Modified Capabilities
-(none — this is an internal data-source swap behind the existing echojobs adapter contract: same freshness window, same identifier scheme, same Job shape produced. No spec currently tracks echojobs as its own capability; the externally-visible ingest behavior — what postings appear, how they're deduped, how staleness is handled — is unchanged.)
+(none — this is an internal data-source swap behind the existing echojobs adapter contract: same freshness window, same identifier scheme, same identity/deduplication/persisted-catalogue behavior. No spec currently tracks echojobs as its own capability. Two field-level exceptions, both documented in design.md: `SeenRefresh` jobs now carry an empty `Title` — see design.md's Refresh strategy decision — and `Job.URL` now points at the echojobs.io page rather than the employer's own ATS link the old adapter stored — see design.md's Risks section.)
 
 ## Impact
 

--- a/openspec/changes/fix-echojobs-adapter/proposal.md
+++ b/openspec/changes/fix-echojobs-adapter/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+echojobs.io removed the public JSON API (`/api/jobs` list, `/api/jobs/{handle}` detail) that `internal/sources/echojobs.go` depends on — both endpoints now 404, confirmed from prod's own IP as well as externally, starting around 2026-08-13. The adapter's existing failure handling never drops a posting over a failed detail fetch, so every newly-discovered echojobs posting since the outage started ingests with an empty description instead of failing loudly. One reported job (Doowii "Full-Stack Software Engineer") was patched manually; roughly 600 postings/hour were accumulating the same defect before this proposal. `cmd/backfill-echojobs` and `cmd/liveness/echojobs.go` call the same dead endpoint and are equally broken.
+
+## What Changes
+
+- Replace the echojobs list crawl (`GET /api/jobs?page=N`) with paging `https://echojobs.io/sitemap-jobs/N.xml` (confirmed globally sorted newest-first by `<lastmod>`), stopping once a shard's postings age past the existing 14-day freshness window.
+- Replace the echojobs detail fetch (`GET /api/jobs/<handle>`, dead) with `GET /job/<slug>` (a plain HTML page) plus parsing the embedded `<script type="application/ld+json">` block whose `"@type":"JobPosting"` — the schema.org structured-data block the site publishes for Google for Jobs, confirmed to carry title, company, full description, remote signal (`jobLocationType`), location, skills, and posting date.
+- Only fetch full JSON-LD detail for postings not already in the catalogue. Already-seen postings inside the freshness window get a liveness-only `touch()` by external ID (no detail fetch) — keeps per-run request volume close to the old shape instead of re-fetching the ~50,000+ postings the freshness window covers on every run.
+- Update `EchoJobsDescription` (used by `cmd/backfill-echojobs`) to the same `GET /job/<slug>` + JSON-LD parse, so the backfill worker can repair rows still carrying an empty description from the outage.
+- Update `cmd/liveness/echojobs.go`'s `checkEchoJobsLiveAt` to use `GET /job/<slug>`'s HTTP status (200 live / 404 gone) instead of the old JSON error-body signal, which no longer exists.
+- The identifier scheme is unchanged: the sitemap URL's slug is the same job_handle already stored as `ExternalID`, so no re-ingestion or duplicate rows result from the swap.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+(none — this is an internal data-source swap behind the existing echojobs adapter contract: same freshness window, same identifier scheme, same Job shape produced. No spec currently tracks echojobs as its own capability; the externally-visible ingest behavior — what postings appear, how they're deduped, how staleness is handled — is unchanged.)
+
+## Impact
+
+- `internal/sources/echojobs.go` — crawl, detail fetch, and `EchoJobsDescription` rewritten; `echojobs_test.go` fixtures replaced (sitemap XML + HTML-with-JSON-LD instead of JSON list/detail responses).
+- `cmd/liveness/echojobs.go` — liveness check rewritten to the new URL + status-code signal; its test updated to match.
+- `cmd/backfill-echojobs` — no code change, but now functional again once `EchoJobsDescription` is fixed; should be re-run after deploy to repair rows accumulated during the outage.
+- No schema, API, or dependency changes. No effect on other adapters.

--- a/openspec/changes/fix-echojobs-adapter/tasks.md
+++ b/openspec/changes/fix-echojobs-adapter/tasks.md
@@ -16,13 +16,13 @@
 ## 3. EchoJobsDescription (backfill) and liveness
 
 - [x] 3.1 Update `EchoJobsDescription` to fetch `/job/<slug>` and extract the JSON-LD description (task 2.1/2.2's extractor), same sanitize-and-return-`ok` contract as before.
-- [ ] 3.2 Update `cmd/liveness/echojobs.go`'s `checkEchoJobsLiveAt`: replace the `/api/jobs/%s` + `{"error":"job fetch failed"}` body check with `GET /job/<slug>` + HTTP status (200 → `liveness.Live`, 404 → `liveness.Expired`, anything else → `liveness.Uncertain`).
+- [x] 3.2 Update `cmd/liveness/echojobs.go`'s `checkEchoJobsLiveAt`: replace the `/api/jobs/%s` + `{"error":"job fetch failed"}` body check with `GET /job/<slug>` + HTTP status (200 → `liveness.Live`, 404 → `liveness.Expired`, anything else → `liveness.Uncertain`). Reason string renamed `echojobs_detail_gone` → `echojobs_job_gone` (verified no other reference to the old string anywhere in the repo).
 
 ## 4. Tests
 
 - [x] 4.1 Replace `echojobs_test.go`'s JSON list/detail fixtures with a routing test double serving sitemap-index XML, shard XML, and `/job/<slug>` HTML-with-embedded-JSON-LD fixtures.
 - [x] 4.2 Cover: freshness-window cutoff across shard boundaries; unseen-posting hydration (full JSON-LD → Job mapping, including the `TELECOMMUTE` remote signal and comma-separated skills split); seen-posting refresh (empty Title, `SeenRefresh: true`, no detail fetch made — assert the test server's detail endpoint was never hit); a JSON-LD block missing/malformed on a detail page. (Deviation from the literal task wording: a malformed/missing block DROPS the posting rather than "falling back to list-only" — there is no list-only tier left once the sitemap replaced the old list JSON, per design.md's Decisions. Covered by `TestEchojobsFetchNewMissingJSONLDDropsPosting`.)
-- [ ] 4.3 Update `cmd/liveness`'s echojobs test for the new URL + status-code liveness signal.
+- [x] 4.3 Update `cmd/liveness`'s echojobs test for the new URL + status-code liveness signal.
 
 ## 5. Manual verification (post-deploy)
 

--- a/openspec/changes/fix-echojobs-adapter/tasks.md
+++ b/openspec/changes/fix-echojobs-adapter/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Sitemap-based list discovery
 
-- [ ] 1.1 Add a sitemap index parser: fetch `https://echojobs.io/sitemap.xml`, extract the `sitemap-jobs/*.xml` shard URLs in document order.
-- [ ] 1.2 Add a shard parser: fetch one `sitemap-jobs/N.xml`, extract `(slug, lastmod)` pairs from each `<url><loc>/job/<slug></loc><lastmod>...</lastmod></url>` entry.
-- [ ] 1.3 Replace `crawl()`'s pagination (`echojobsPageURL`, `/api/jobs?page=N`) with: walk shards in order, stop once a shard's postings age past `echojobsFreshnessWindow` — mirrors the existing stale-cutoff logic, new data source.
-- [ ] 1.4 Drop `echojobsPosting`'s list-only fields that no longer come from a list call (`Title`, `CompanyName`, `URL`, `Locations`, `RemoteType`, `RequiredSkills`, `PostedAt`) — the sitemap only carries slug + lastmod now; keep just what discovery needs (slug, lastmod).
+- [x] 1.1 Add a sitemap index parser: fetch `https://echojobs.io/sitemap.xml`, extract the `sitemap-jobs/*.xml` shard URLs in document order.
+- [x] 1.2 Add a shard parser: fetch one `sitemap-jobs/N.xml`, extract `(slug, lastmod)` pairs from each `<url><loc>/job/<slug></loc><lastmod>...</lastmod></url>` entry.
+- [x] 1.3 Replace `crawl()`'s pagination (`echojobsPageURL`, `/api/jobs?page=N`) with: walk shards in order, stop once a shard's postings age past `echojobsFreshnessWindow` — mirrors the existing stale-cutoff logic, new data source.
+- [x] 1.4 Drop `echojobsPosting`'s list-only fields that no longer come from a list call (`Title`, `CompanyName`, `URL`, `Locations`, `RemoteType`, `RequiredSkills`, `PostedAt`) — the sitemap only carries slug + lastmod now; keep just what discovery needs (slug, lastmod).
 
 ## 2. JSON-LD detail hydration
 
-- [ ] 2.1 Add a JSON-LD extractor: given a `/job/<slug>` page's HTML body, find every `<script type="application/ld+json">...</script>` block and return the one whose decoded `@type` is `"JobPosting"`.
-- [ ] 2.2 Define the `JobPosting` JSON-LD struct: `title`, `hiringOrganization.name`, `description`, `jobLocationType`, `jobLocation.address.{addressLocality,addressCountry}`, `applicantLocationRequirements.name`, `skills` (string), `datePosted`.
-- [ ] 2.3 Replace `detail()`'s request (`echojobsDetailURL`, JSON decode) with `GET /job/<slug>` + the JSON-LD extractor from 2.1/2.2.
-- [ ] 2.4 Map JSON-LD fields to `Job`: `Remote`/`WorkMode` from `jobLocationType == "TELECOMMUTE"` (else `WorkMode: ""`); `Location` from `jobLocation.address` or `applicantLocationRequirements.name` fallback; `Skills` from splitting the comma-separated `skills` string through `skilltag.Canonicalize`; `PostedAt` from `datePosted` via `time.Parse(time.RFC3339, ...)`; `Description` sanitized as before (`sanitizeHTML`).
-- [ ] 2.5 Update `FetchNew`'s per-posting flow: unseen postings get the full JSON-LD hydration (2.3/2.4) building both list-derived and detail-derived fields from the SAME JSON-LD response (title/company/etc. no longer come from a separate list call — see task 1.4); seen postings stay list-only (`SeenRefresh: true`, `ExternalID` only, `Title` left empty — ref design.md's "Refresh strategy" decision).
+- [x] 2.1 Add a JSON-LD extractor: given a `/job/<slug>` page's HTML body, find every `<script type="application/ld+json">...</script>` block and return the one whose decoded `@type` is `"JobPosting"`. (Reused the existing shared `ldJobPosting` helper in `jsonld.go` rather than adding a new one — it already does exactly this and several sibling adapters rely on it.)
+- [x] 2.2 Define the `JobPosting` JSON-LD struct: `title`, `hiringOrganization.name`, `description`, `jobLocationType`, `jobLocation.address.{addressLocality,addressCountry}`, `applicantLocationRequirements.name`, `skills` (string), `datePosted`.
+- [x] 2.3 Replace `detail()`'s request (`echojobsDetailURL`, JSON decode) with `GET /job/<slug>` + the JSON-LD extractor from 2.1/2.2.
+- [x] 2.4 Map JSON-LD fields to `Job`: `Remote`/`WorkMode` from `jobLocationType == "TELECOMMUTE"` (else `WorkMode: ""`); `Location` from `jobLocation.address` or `applicantLocationRequirements.name` fallback; `Skills` from splitting the comma-separated `skills` string through `skilltag.Canonicalize`; `PostedAt` from `datePosted` via `time.Parse(time.RFC3339, ...)`; `Description` sanitized as before (`sanitizeHTML`).
+- [x] 2.5 Update `FetchNew`'s per-posting flow: unseen postings get the full JSON-LD hydration (2.3/2.4); seen postings get a bare identity-only refresh (`SeenRefresh: true`, `ExternalID`+`URL`, `Title` left empty — ref design.md's "Refresh strategy" decision). `Fetch` (the non-hydrating fallback) now delegates to `FetchNew` with an always-false seen predicate, since the sitemap has no list-only tier left to serve on its own.
 
 ## 3. EchoJobsDescription (backfill) and liveness
 
-- [ ] 3.1 Update `EchoJobsDescription` to fetch `/job/<slug>` and extract the JSON-LD description (task 2.1/2.2's extractor), same sanitize-and-return-`ok` contract as before.
+- [x] 3.1 Update `EchoJobsDescription` to fetch `/job/<slug>` and extract the JSON-LD description (task 2.1/2.2's extractor), same sanitize-and-return-`ok` contract as before.
 - [ ] 3.2 Update `cmd/liveness/echojobs.go`'s `checkEchoJobsLiveAt`: replace the `/api/jobs/%s` + `{"error":"job fetch failed"}` body check with `GET /job/<slug>` + HTTP status (200 → `liveness.Live`, 404 → `liveness.Expired`, anything else → `liveness.Uncertain`).
 
 ## 4. Tests
 
-- [ ] 4.1 Replace `echojobs_test.go`'s JSON list/detail fixtures with an httptest server serving sitemap-index XML, shard XML, and `/job/<slug>` HTML-with-embedded-JSON-LD fixtures.
-- [ ] 4.2 Cover: freshness-window cutoff across shard boundaries; unseen-posting hydration (full JSON-LD → Job mapping, including the `TELECOMMUTE` remote signal and comma-separated skills split); seen-posting refresh (empty Title, `SeenRefresh: true`, no detail fetch made — assert the test server's detail endpoint was never hit); a JSON-LD block missing/malformed on a detail page (falls back to list-only ingestion, same as today's failed-detail behavior).
+- [x] 4.1 Replace `echojobs_test.go`'s JSON list/detail fixtures with a routing test double serving sitemap-index XML, shard XML, and `/job/<slug>` HTML-with-embedded-JSON-LD fixtures.
+- [x] 4.2 Cover: freshness-window cutoff across shard boundaries; unseen-posting hydration (full JSON-LD → Job mapping, including the `TELECOMMUTE` remote signal and comma-separated skills split); seen-posting refresh (empty Title, `SeenRefresh: true`, no detail fetch made — assert the test server's detail endpoint was never hit); a JSON-LD block missing/malformed on a detail page. (Deviation from the literal task wording: a malformed/missing block DROPS the posting rather than "falling back to list-only" — there is no list-only tier left once the sitemap replaced the old list JSON, per design.md's Decisions. Covered by `TestEchojobsFetchNewMissingJSONLDDropsPosting`.)
 - [ ] 4.3 Update `cmd/liveness`'s echojobs test for the new URL + status-code liveness signal.
 
 ## 5. Manual verification (post-deploy)

--- a/openspec/changes/fix-echojobs-adapter/tasks.md
+++ b/openspec/changes/fix-echojobs-adapter/tasks.md
@@ -1,0 +1,30 @@
+## 1. Sitemap-based list discovery
+
+- [ ] 1.1 Add a sitemap index parser: fetch `https://echojobs.io/sitemap.xml`, extract the `sitemap-jobs/*.xml` shard URLs in document order.
+- [ ] 1.2 Add a shard parser: fetch one `sitemap-jobs/N.xml`, extract `(slug, lastmod)` pairs from each `<url><loc>/job/<slug></loc><lastmod>...</lastmod></url>` entry.
+- [ ] 1.3 Replace `crawl()`'s pagination (`echojobsPageURL`, `/api/jobs?page=N`) with: walk shards in order, stop once a shard's postings age past `echojobsFreshnessWindow` — mirrors the existing stale-cutoff logic, new data source.
+- [ ] 1.4 Drop `echojobsPosting`'s list-only fields that no longer come from a list call (`Title`, `CompanyName`, `URL`, `Locations`, `RemoteType`, `RequiredSkills`, `PostedAt`) — the sitemap only carries slug + lastmod now; keep just what discovery needs (slug, lastmod).
+
+## 2. JSON-LD detail hydration
+
+- [ ] 2.1 Add a JSON-LD extractor: given a `/job/<slug>` page's HTML body, find every `<script type="application/ld+json">...</script>` block and return the one whose decoded `@type` is `"JobPosting"`.
+- [ ] 2.2 Define the `JobPosting` JSON-LD struct: `title`, `hiringOrganization.name`, `description`, `jobLocationType`, `jobLocation.address.{addressLocality,addressCountry}`, `applicantLocationRequirements.name`, `skills` (string), `datePosted`.
+- [ ] 2.3 Replace `detail()`'s request (`echojobsDetailURL`, JSON decode) with `GET /job/<slug>` + the JSON-LD extractor from 2.1/2.2.
+- [ ] 2.4 Map JSON-LD fields to `Job`: `Remote`/`WorkMode` from `jobLocationType == "TELECOMMUTE"` (else `WorkMode: ""`); `Location` from `jobLocation.address` or `applicantLocationRequirements.name` fallback; `Skills` from splitting the comma-separated `skills` string through `skilltag.Canonicalize`; `PostedAt` from `datePosted` via `time.Parse(time.RFC3339, ...)`; `Description` sanitized as before (`sanitizeHTML`).
+- [ ] 2.5 Update `FetchNew`'s per-posting flow: unseen postings get the full JSON-LD hydration (2.3/2.4) building both list-derived and detail-derived fields from the SAME JSON-LD response (title/company/etc. no longer come from a separate list call — see task 1.4); seen postings stay list-only (`SeenRefresh: true`, `ExternalID` only, `Title` left empty — ref design.md's "Refresh strategy" decision).
+
+## 3. EchoJobsDescription (backfill) and liveness
+
+- [ ] 3.1 Update `EchoJobsDescription` to fetch `/job/<slug>` and extract the JSON-LD description (task 2.1/2.2's extractor), same sanitize-and-return-`ok` contract as before.
+- [ ] 3.2 Update `cmd/liveness/echojobs.go`'s `checkEchoJobsLiveAt`: replace the `/api/jobs/%s` + `{"error":"job fetch failed"}` body check with `GET /job/<slug>` + HTTP status (200 → `liveness.Live`, 404 → `liveness.Expired`, anything else → `liveness.Uncertain`).
+
+## 4. Tests
+
+- [ ] 4.1 Replace `echojobs_test.go`'s JSON list/detail fixtures with an httptest server serving sitemap-index XML, shard XML, and `/job/<slug>` HTML-with-embedded-JSON-LD fixtures.
+- [ ] 4.2 Cover: freshness-window cutoff across shard boundaries; unseen-posting hydration (full JSON-LD → Job mapping, including the `TELECOMMUTE` remote signal and comma-separated skills split); seen-posting refresh (empty Title, `SeenRefresh: true`, no detail fetch made — assert the test server's detail endpoint was never hit); a JSON-LD block missing/malformed on a detail page (falls back to list-only ingestion, same as today's failed-detail behavior).
+- [ ] 4.3 Update `cmd/liveness`'s echojobs test for the new URL + status-code liveness signal.
+
+## 5. Manual verification (post-deploy)
+
+- [ ] 5.1 Deploy, confirm the next `freehire-ingest@echojobs.timer` fire ingests postings with non-empty descriptions.
+- [ ] 5.2 Run `go run ./cmd/backfill-echojobs` once by hand to repair rows accumulated empty during the outage (per design.md's Migration Plan); follow with `make reindex`.


### PR DESCRIPTION
## Summary

echojobs.io removed its public JSON API (`/api/jobs` list + `/api/jobs/{handle}` detail) around 2026-08-13 — both now 404, verified from prod's own egress IP too. The adapter's existing failure handling never drops a posting over a failed detail fetch, so every newly-discovered echojobs posting since the outage started ingested with an empty description (one reported job, Doowii's "Full-Stack Software Engineer", was patched by hand; ~600 postings/hour were accumulating the same defect).

- `internal/sources/echojobs.go`: discovery now walks the site's public XML sitemap (`sitemap-jobs/N.xml` shards, confirmed sorted newest-first), and detail hydration parses the schema.org `JobPosting` ld+json each posting page embeds — reusing the package's existing `ldJobPosting`/`schemaAddress` helpers, the same pattern sibling adapters (`northstone`, `breezy`, `djinni`) already use. The old list-vs-detail split collapsed into one tier since the sitemap carries no field beyond a posting's URL/lastmod; `FetchNew` still skips the detail fetch for postings the catalogue already has, keeping per-run request volume close to the old shape.
- `EchoJobsDescription` (backing `cmd/backfill-echojobs`) and `cmd/liveness/echojobs.go`'s liveness probe updated the same way — both called the same dead endpoint.
- Identifier scheme unchanged (verified live: the new URL slug is byte-identical to the previously-stored `job_handle`), so no re-ingestion or duplicate rows.

OpenSpec change: `openspec/changes/fix-echojobs-adapter/` (proposal/design/tasks).

## Test plan

- [x] `gofmt -l .` clean repo-wide
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go vet -tags=integration ./...` clean
- [x] `go test ./...` — 151/151 packages passing
- [x] Two independent code reviews (adapter rewrite, liveness probe) — no unresolved issues
- [ ] Post-deploy: confirm the next `freehire-ingest@echojobs.timer` fire ingests postings with non-empty descriptions
- [ ] Post-deploy: run `go run ./cmd/backfill-echojobs` once by hand to repair rows accumulated empty during the outage, then `make reindex`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored EchoJobs job discovery after its previous API was retired.
  - Job listings are now found through updated site indexes and enriched with title, company, location, remote status, description, skills, and posting date.
  - Existing listings refresh efficiently, while invalid or unavailable postings are excluded.
  - Improved expiration checks distinguish removed jobs from temporary service errors.
- **Documentation**
  - Updated backfill and integration guidance for the new EchoJobs workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->