### PR TITLE
Fix JobSeeAlso's stale CountryFlag import after DS promotion

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -5,7 +5,7 @@
   "Button": 59,
   "Card": 1,
   "Chip": 1,
-  "CountryFlag": 5,
+  "CountryFlag": 6,
   "Dialog": 8,
   "EmptyState": 1,
   "EntityLogo": 16,

--- a/web/src/lib/components/JobSeeAlso.svelte
+++ b/web/src/lib/components/JobSeeAlso.svelte
@@ -2,10 +2,11 @@
   import { Building2, Code, Globe, Layers, TrendingUp } from '@lucide/svelte';
   import type { LucideIcon } from '@lucide/svelte';
   import { resolve } from '$app/paths';
+  import { countryLabel } from '$lib/facets';
   import type { FamilyIconName } from '$lib/familymarks';
   import { glyphColorFor } from '$lib/markColor';
   import type { SeeAlsoCard } from '$lib/collections';
-  import CountryFlag from './CountryFlag.svelte';
+  import { CountryFlag } from '$lib/ui';
 
   // A horizontally-scrolling row of links into existing /collections/:slug
   // pages, each showing the collection's live open-job count — mirrors the
@@ -50,7 +51,11 @@
               </svg>
             </span>
           {:else if card.mark.kind === 'flag'}
-            <CountryFlag code={card.mark.countryCode} class="shrink-0 text-[28px]" />
+            <CountryFlag
+              code={card.mark.countryCode}
+              label={countryLabel(card.mark.countryCode)}
+              class="shrink-0 text-[28px]"
+            />
           {:else}
             {@const Icon = FAMILY_ICONS[card.mark.icon]}
             <span class={badgeClass} style:background-color={card.mark.color}>


### PR DESCRIPTION
## Summary
- Fixes a build break on host2's `release.sh` (caught by its bundle guard before flipping, live color untouched): #1874 (merged after #1875) moved `CountryFlag` from `web/src/lib/components/` into the design system, but `JobSeeAlso.svelte` (from #1875) still imported the old local path.
- Updates the import to `$lib/ui`'s re-export and passes the `label` prop the design-system primitive now requires explicitly (previously computed internally).
- Updates `design-system/scripts/adoption-baseline.json` for the resulting CountryFlag consumer-count increase (ratchet requires `--update` on improvement too).

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm lint` (eslint) — clean
- [x] `pnpm test` — 87 files / 945 tests passing
- [x] `pnpm build` — succeeds
- [x] `design-system`'s `check:tokens` / `check:adoption` — clean
