### PR TITLE
web: accept the easymde/codemirror ReDoS with a documented .snyk policy

### DIFF
--- a/web/.snyk
+++ b/web/.snyk
@@ -1,0 +1,21 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.5.0
+ignore:
+  SNYK-JS-CODEMIRROR-10494092:
+    - '*':
+        reason: >-
+          ReDoS in codemirror@5.65.21, pulled in transitively by our direct
+          dependency easymde@2.21.0. easymde's only consumer is
+          NoteEditor.svelte, a private per-user job-tracking notes field —
+          content is always self-authored by the same user who reads it back,
+          never rendered from another user's or otherwise untrusted input, so
+          the exploitable path does not exist here.
+          No safe fix is available: easymde 2.21.0 is the latest stable
+          release and still pins codemirror ^5.65.15; the only CodeMirror-6
+          line is a pre-release (3.0.0-alpha/beta) with a fully incompatible
+          API, and forcing a codemirror override under 2.21.0 breaks it at
+          runtime (CM5-only calls). Revisit when easymde ships a stable CM6
+          release, or budget a NoteEditor migration off easymde before this
+          expires.
+        expires: 2026-11-13T00:00:00.000Z
+        created: 2026-08-13T00:00:00.000Z

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -84,3 +84,6 @@ production; in dev the Vite proxy (`web/vite.config.ts`) forwards `/api` to the 
   ingest host for any future `connect-src`.
 - OAuth identity unlinking/management UI is not implemented (backend seam mirrored on the
   frontend).
+- `easymde` (the `NoteEditor.svelte` markdown field for private job-tracking notes) carries a
+  known ReDoS in its bundled `codemirror@5.x`, with no safe upgrade or override available —
+  see `web/.snyk` for the accepted-risk reasoning and its revisit date.


### PR DESCRIPTION
## Summary

- `snyk` fails on every `web/` PR (including #1874, unrelated to that change) on `SNYK-JS-CODEMIRROR-10494092` — a ReDoS in `codemirror@5.65.21`, pulled in transitively by our direct dependency `easymde@2.21.0`.
- No safe fix exists: `easymde` 2.21.0 is the latest stable release and still pins `codemirror ^5.65.15`; the only CodeMirror-6 line is a pre-release (`3.0.0-alpha`/`beta`) with a fully incompatible API (CM5's imperative `fromTextArea()` + addons vs. CM6's view/state/extensions model). Forcing a `codemirror` override under 2.21.0 breaks it at runtime — `easymde`'s source calls CM5-only methods CM6 doesn't have.
- `easymde`'s only consumer is `NoteEditor.svelte`, a private per-user job-tracking notes field — content is always self-authored by the same user who reads it back, never rendered from another user's or otherwise untrusted input. The exploitable ReDoS path doesn't exist in this app regardless of the library-level finding.

## Changes

- `web/.snyk` — a scoped ignore for this one vulnerability ID, with the reasoning above inline and a 3-month `expires` (2026-11-13) to force a revisit rather than a silent permanent suppression.
- `web/AGENTS.md` — one line in Limitations pointing at `.snyk` so this doesn't need rediscovering later.

## Test plan

- [x] `.snyk` YAML validated (well-formed, matches Snyk CLI's documented ignore-policy schema: `version` / `ignore.<vuln-id>.<path-matcher>.{reason,expires,created}`)
- [ ] `snyk` CI check turns green on this PR (can't run `snyk test` locally without `SNYK_TOKEN`; verifying via CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)