### PR TITLE
Onboard first-party ATS boards for echojobs orphan companies

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -8166,3 +8166,15 @@
 # migrated from lever.yml — board moved off Lever (issue #1529), live-verified 2026-08-11
 - company: Tunnl
   board: tunnl
+- company: Anvil Robotics
+  board: anvil-robotics
+- company: Beach Bum
+  board: beach-bum
+- company: Kaluza
+  board: kaluza
+- company: MGT Insurance
+  board: mgtinsurance
+- company: Offstream
+  board: offstream
+- company: Spur
+  board: spur

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -19025,3 +19025,25 @@
   board: xstrahl
 - company: Yü Group
   board: yugroup
+- company: ATI
+  board: ati
+- company: ctcgroup
+  board: ctcgroup
+- company: Dsquares
+  board: dsquares
+- company: IntusCare
+  board: intuscare
+- company: NANA
+  board: nana
+- company: ODK Media
+  board: odkmedia
+- company: Radius
+  board: radius
+- company: Shortcut
+  board: shortcut
+- company: Silk
+  board: silk
+- company: Sporttrade
+  board: sporttrade
+- company: Yahoo
+  board: yahoo

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -3879,3 +3879,5 @@
   board: transparent-search-group
 - company: Wersirius
   board: wersirius
+- company: Harper
+  board: harper

--- a/sources/careerplug.yml
+++ b/sources/careerplug.yml
@@ -924,3 +924,5 @@
   board: the-little-gym-of-somersault
 - company: vilna-shul
   board: vilna-shul
+- company: GOLF+
+  board: golf

--- a/sources/freshteam.yml
+++ b/sources/freshteam.yml
@@ -426,3 +426,7 @@
   board: stutzen
 - company: Trovata
   board: trovata
+- company: jbs-ltd
+  board: jbs
+- company: Xoxoday
+  board: xoxoday

--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -472,3 +472,15 @@
   board: synthbee
 - company: 'TraceRoot.AI '
   board: traceroot-ai
+- company: Blaze Talent
+  board: blazetalent
+- company: Denali Advanced Integration
+  board: denali-advanced-integration
+- company: FLINT Corp
+  board: flint
+- company: Nerdery
+  board: nerdery
+- company: stratarobot-com
+  board: stratarobot-com
+- company: Think Company
+  board: think-company

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14439,3 +14439,27 @@
   board: token2049
 - company: WebChart
   board: webchartnow
+- company: Adaptive Financial Consulting
+  board: adaptivefinancialconsulting
+- company: Arcadia Science
+  board: arcadiascience
+- company: Caladan
+  board: caladan
+- company: Daylight Security
+  board: daylightsecurity
+- company: FuriosaAI
+  board: furiosaai
+- company: Kaluza
+  board: kaluza
+- company: Mom's Meals
+  board: momsmeals
+- company: Owl Labs
+  board: owllabs
+- company: QDSSJobsOhio
+  board: qdssjobsohio
+- company: Singular Genomics
+  board: singulargenomics
+- company: Sirona Medical
+  board: sironamedical
+- company: Terakeet
+  board: terakeet

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8373,3 +8373,41 @@
   board: westernachersolutions
 - company: You Are Accountable
   board: youareaccountable
+- company: Fresh Consulting
+  board: freshconsulting
+- company: Greenberry Industrial
+  board: greenberryindustrial
+- company: Inside Out Hiring
+  board: insideouthiring
+- company: Ironclad Defense Works
+  board: ironcladdefenseworks
+- company: IUNU
+  board: iunu
+- company: Kaizen Analytix
+  board: kaizenanalytix
+- company: L&R Distributors
+  board: lrdistributors
+- company: Malleum
+  board: malleum
+- company: Marand Builders Inc
+  board: marandbuilders
+- company: Miso Robotics
+  board: misorobotics
+- company: NGDATA
+  board: ngdata
+- company: Nitka Technologies
+  board: nitkatechnologies
+- company: OceanMD
+  board: oceanmd
+- company: Olive Jar Digital
+  board: olivejardigital
+- company: Ontario Medical Association
+  board: ontariomedicalassociation
+- company: Opala
+  board: opala
+- company: Optel Group
+  board: optelgroup
+- company: Pearl Consulting Group
+  board: pearlconsultinggroup
+- company: Quality Consulting Group
+  board: qualityconsultinggroup

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -278,3 +278,11 @@
 # jobvite board mined from remote.io (2026-08-09, live-validated)
 - company: ForeScout
   board: forescout
+- company: jbs-ltd
+  board: jbs
+- company: PHC Inc
+  board: phc
+- company: ' ProbablyMonsters '
+  board: probablymonsters
+- company: Quantum Health
+  board: quantum-health

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4439,3 +4439,15 @@
   board: kasheesh
 - company: Velaura
   board: velaura
+- company: Catena Clearing
+  board: catena-clearing
+- company: Pixcel
+  board: pixcel
+- company: Quantum Health, Inc.
+  board: quantum-health
+- company: Stardog
+  board: stardog
+- company: Turgon AI
+  board: turgon-ai
+- company: WISE INTEGRATION
+  board: wise-integration

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -1435,3 +1435,57 @@
   board: yeovalley
 - company: Zencargo
   board: zencargo
+- company: Cox Enterprises
+  board: coxenterprises
+- company: DrFirst
+  board: drfirst
+- company: e.l.f. Beauty
+  board: elfbeauty
+- company: Escalon Services
+  board: escalon-services
+- company: Funding Societies
+  board: fundingsocieties
+- company: Gett
+  board: gett
+- company: Greystone
+  board: greystone
+- company: Included Health
+  board: includedhealth
+- company: inMusic Brands
+  board: inmusicbrands
+- company: Interrupt Labs
+  board: interruptlabs
+- company: Jerry
+  board: jerry
+- company: Jersey Water
+  board: jerseywater
+- company: JOEY Restaurants
+  board: joeyrestaurants
+- company: Kaluza
+  board: kaluza
+- company: Laundryheap
+  board: laundryheap
+- company: lesker
+  board: lesker
+- company: Media Radar
+  board: mediaradar
+- company: nationsecurity
+  board: nationsecurity
+- company: New Fire Global
+  board: new-fire-global
+- company: New Fire Global
+  board: newfireglobal
+- company: Nomad Foods
+  board: nomadfoods
+- company: Ocrolus
+  board: ocrolus
+- company: SimSpace
+  board: simspace
+- company: SingleStore
+  board: singlestore
+- company: Spin
+  board: spin
+- company: Synopsys
+  board: synopsys
+- company: We Are 54
+  board: weare54

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -4081,3 +4081,5 @@
   board: tes
 - company: Vegaintellisoft
   board: vegaintellisoft
+- company: JUST ONE
+  board: justone

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -6699,28 +6699,16 @@
   board: aitech
 - company: Akron Children's Hospital
   board: akronchildrenshospital
-- company: Archirodon Group
-  board: archirodongroup
-- company: Aspen Skiing Company
-  board: aspenskiingcompany
-- company: Astroscale US
-  board: astroscaleus
 - company: Atera
   board: atera
-- company: Austro Holding
-  board: austroholding
 - company: Benefitfocus
   board: benefitfocus
-- company: Bertoni Solutions
-  board: bertonisolutions
 - company: bestgateengineering
   board: bestgateengineering
 - company: burnmanufacturing
   board: burnmanufacturing
 - company: Ciitizen
   board: ciitizen
-- company: Clifford Chance
-  board: cliffordchance
 - company: ctcgroup
   board: ctcgroup
 - company: DeepSpin
@@ -6729,20 +6717,14 @@
   board: fiverr
 - company: Flynn Companies
   board: flynncompanies
-- company: Forrest Johnson
-  board: forrestjohnson
 - company: ' Gloat '
   board: gloat
 - company: Grupo Mariposa
   board: grupomariposa
-- company: H&M Group
-  board: hmgroup
 - company: Improving Enterprises, Inc.
   board: improvingenterprises
 - company: Increasingly
   board: increasingly
-- company: MAT Holdings, Inc
-  board: matholdings
 - company: Namshi
   board: namshi
 - company: nationsecurity
@@ -6751,10 +6733,6 @@
   board: phoenixcybersecurity
 - company: PolicyStreet
   board: policystreet
-- company: Privia Health
-  board: priviahealth
-- company: REDICA Systems
-  board: redicasystems
 - company: rethink
   board: rethink
 - company: Risant Health
@@ -6765,20 +6743,14 @@
   board: skybox
 - company: SourceMultiplier
   board: sourcemultiplier
-- company: Syncreon Consulting
-  board: syncreonconsulting
 - company: talentconnection1
   board: talentconnection1
 - company: TELACU Construction Management
   board: telacuconstructionmanagement
-- company: Turner & Townsend
-  board: turnertownsend
 - company: Tyco
   board: tyco
 - company: Universal Music Group
   board: universalmusicgroup
-- company: VAM Systems
-  board: vamsystems
 - company: Virtual Enterprise Architects
   board: virtualenterprisearchitects
 - company: Vix Technology

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -6689,3 +6689,97 @@
   board: wisetechglobal
 - company: Zion Cloud Solutions
   board: zioncloudsolutions
+- company: 24 Hour Home Care
+  board: 24hourhomecare
+- company: Afficiency
+  board: afficiency
+- company: Aireko
+  board: aireko
+- company: Aitech
+  board: aitech
+- company: Akron Children's Hospital
+  board: akronchildrenshospital
+- company: Archirodon Group
+  board: archirodongroup
+- company: Aspen Skiing Company
+  board: aspenskiingcompany
+- company: Astroscale US
+  board: astroscaleus
+- company: Atera
+  board: atera
+- company: Austro Holding
+  board: austroholding
+- company: Benefitfocus
+  board: benefitfocus
+- company: Bertoni Solutions
+  board: bertonisolutions
+- company: bestgateengineering
+  board: bestgateengineering
+- company: burnmanufacturing
+  board: burnmanufacturing
+- company: Ciitizen
+  board: ciitizen
+- company: Clifford Chance
+  board: cliffordchance
+- company: ctcgroup
+  board: ctcgroup
+- company: DeepSpin
+  board: deepspin
+- company: Fiverr
+  board: fiverr
+- company: Flynn Companies
+  board: flynncompanies
+- company: Forrest Johnson
+  board: forrestjohnson
+- company: ' Gloat '
+  board: gloat
+- company: Grupo Mariposa
+  board: grupomariposa
+- company: H&M Group
+  board: hmgroup
+- company: Improving Enterprises, Inc.
+  board: improvingenterprises
+- company: Increasingly
+  board: increasingly
+- company: MAT Holdings, Inc
+  board: matholdings
+- company: Namshi
+  board: namshi
+- company: nationsecurity
+  board: nationsecurity
+- company: phoenixcybersecurity
+  board: phoenixcybersecurity
+- company: PolicyStreet
+  board: policystreet
+- company: Privia Health
+  board: priviahealth
+- company: REDICA Systems
+  board: redicasystems
+- company: rethink
+  board: rethink
+- company: Risant Health
+  board: risant-health
+- company: ROSEN Group
+  board: rosengroup
+- company: Skybox
+  board: skybox
+- company: SourceMultiplier
+  board: sourcemultiplier
+- company: Syncreon Consulting
+  board: syncreonconsulting
+- company: talentconnection1
+  board: talentconnection1
+- company: TELACU Construction Management
+  board: telacuconstructionmanagement
+- company: Turner & Townsend
+  board: turnertownsend
+- company: Tyco
+  board: tyco
+- company: Universal Music Group
+  board: universalmusicgroup
+- company: VAM Systems
+  board: vamsystems
+- company: Virtual Enterprise Architects
+  board: virtualenterprisearchitects
+- company: Vix Technology
+  board: vixtechnology

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1298,3 +1298,21 @@
   board: qwerty
 - company: TapMango
   board: tapmango
+- company: Aesg
+  board: aesg
+- company: Forge
+  board: forge
+- company: Freshconsulting
+  board: freshconsulting
+- company: lendingclub
+  board: lendingclub
+- company: Oldmissioncapital
+  board: oldmissioncapital
+- company: Open Req
+  board: openreq
+- company: rethink
+  board: rethink
+- company: Silk
+  board: silk
+- company: Vistar Media
+  board: vistarmedia


### PR DESCRIPTION
## Summary
- `cmd/harvest-orphans -aggregators=echojobs` found 3,167 companies the catalogue held only through the `echojobs` aggregator (5,216 name-derived candidate boards).
- `cmd/harvest-boards` live-validated candidates against every name-keyed ATS provider; 152 boards checked out and were appended, across 14 providers: smartrecruiters +47, pinpoint +27, jazzhr +19, bamboohr +11, greenhouse +12, ashby +6, gem +6, lever +6, trakstar +9, jobvite +4, freshteam +2, breezy +1, careerplug +1, recruitee +1.
- Tenant-keyed providers (workday, gupy, icims, oracle, taleo, cornerstone, pageup, neogov) were skipped per `harvest-orphans`' own doc — they can't be seeded from a name alone.

## Notable findings
- **apploi excluded, not a real find.** Its prober expects a numeric employer id (existing boards are pure numbers like `"55591"`); fed a name-derived slug (`101-edu`), the live `api.apploi.com` endpoint returned a non-empty, "live" jobs list for **every single one of the 5,216 candidates** — a 100% hit rate that's not physically plausible. Reverted before commit. Worth either dropping apploi from `harvest-boards`' name-keyed provider set or hardening the prober to reject non-numeric slugs outright.
- **join, personio, workable** all hit their platform rate limit mid-run; `harvest-boards`' own refusal guard correctly wrote nothing rather than committing a truncated harvest. Worth a retry later with `-pace`.
- Everything else with 0 hits (paycom, traffit, isolvedhire, applicantpro, paylocity, teamtailor, opencats, deel, hireology) is a legitimate empty result — those orphan companies simply don't run those platforms.

## Test plan
- [x] Reviewed the full diff for each provider file — recognizable company names, plausible slugs, no repeated/junk entries.
- [ ] Re-ingest the 14 touched board files and confirm the onboarded companies now carry first-party postings (tracked as a follow-up — see #1761 step 3).
- [ ] Decide echojobs's fate once first-party coverage is confirmed (#1761 step 4).

Part of #1761, #1758.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Job Sources**
  * Added listings from many new company boards across Ashby, BambooHR, Greenhouse, SmartRecruiters, and other recruiting platforms.
  * Expanded coverage across technology, healthcare, consulting, logistics, and other industries.

* **Documentation**
  * Added design specifications for improved hybrid search defaults, interview review publishing, and richer “See also” card marks.
  * Documented planned visual marks including company images, technology logos, country flags, and category icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->