### PR TITLE
feat(sources): add the Landing.jobs adapter

### DIFF
--- a/internal/sources/helpers.go
+++ b/internal/sources/helpers.go
@@ -135,6 +135,29 @@ func countryFromCode(code string) []string {
 	return []string{c}
 }
 
+// countriesFromCodes is the multi-place counterpart of countryFromCode: it normalizes a
+// posting's whole set of ATS-supplied country codes, dropping unresolved and duplicate ones and
+// keeping first-seen order. A board that states several locations for one posting states several
+// countries (landing.jobs lists a single role across Munich, Lisbon and Cologne), and keeping
+// only the first would hide that posting from a filter on any of the others. Returns nil when
+// nothing resolves, so an adapter can wire it straight into Job.Countries.
+func countriesFromCodes(codes []string) []string {
+	var out []string
+	seen := make(map[string]struct{}, len(codes))
+	for _, code := range codes {
+		c := location.NormalizeCountry(code)
+		if c == "" {
+			continue
+		}
+		if _, dup := seen[c]; dup {
+			continue
+		}
+		seen[c] = struct{}{}
+		out = append(out, c)
+	}
+	return out
+}
+
 // distinctJoin maps each item to a label, drops blank and duplicate labels (keeping first-seen
 // order), and joins the rest with sep. Adapters that build a location from a list of place
 // objects share it (getmatch, habrcareer) instead of each re-looping.

--- a/internal/sources/landingjobs.go
+++ b/internal/sources/landingjobs.go
@@ -1,0 +1,217 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// landingjobs adapts landing.jobs, an EU tech job board. Boardless (one public API, no
+// per-tenant board) and multi-company, so it stays in the source facet and takes each
+// posting's employer from the posting rather than from the config entry.
+//
+// Two shapes make it unlike its neighbours.
+//
+// **Neither the company nor a posting id is in the payload.** Both are derived from the
+// posting URL, which is `https://landing.jobs/at/<company-slug>/<job-slug>`: the employer from
+// the first segment, humanized, and the external id from both segments joined — the only stable
+// identity the feed offers. A posting whose URL does not have that shape is skipped rather than
+// ingested under a guessed identity, since the id is the dedup key.
+//
+// **One request, and no pagination.** `?page=N` is ignored by the endpoint — pages 1 and 2 come
+// back byte-for-byte identical (verified 2026-08-08, issue #1627) — so a page walk would
+// re-fetch the same postings until its own cap and dedup them all away, paying N requests for
+// one page of data. The single response is therefore taken as the whole feed. Whether the ~50
+// items it returns ARE the whole active catalogue is unconfirmed; if a parameter controlling
+// depth is found, this is where the walk goes, and `internal/sources/AGENTS.md`'s first-page
+// rule applies to it.
+//
+// Note: landing.jobs' robots.txt disallows /api/ for every listed user agent. The endpoint is
+// public and unauthenticated, and the crawl is a scheduled job rather than a search-engine
+// crawler, but this is recorded here — as it is on remotli, the other adapter in this position —
+// because it was raised in the adapter's tracking issue as a conscious call rather than a silent
+// one.
+type landingjobs struct {
+	http JSONGetter
+}
+
+const landingjobsListURL = "https://landing.jobs/api/v1/jobs"
+
+// landingjobsPathMarker precedes the "<company-slug>/<job-slug>" pair in a posting URL.
+const landingjobsPathMarker = "/at/"
+
+// NewLandingJobs builds the landing.jobs adapter over the given HTTP client.
+func NewLandingJobs(c JSONGetter) Source { return landingjobs{http: c} }
+
+func (landingjobs) Provider() string { return "landingjobs" }
+
+// landing.jobs is one global feed, so its config entry carries no board.
+func (landingjobs) boardless() {}
+
+// landing.jobs carries postings from many companies, so it stays in the source facet.
+func (landingjobs) aggregator() {}
+
+// landingjobsPosting is one posting, body inline (no detail call).
+//
+// The feed also carries `tags`, `type`, `gross_salary_low`/`gross_salary_high` and
+// `currency_code`, none of which are declared here. Salary has no home on Job (enrichment owns
+// it), and the element shape of `tags` and the vocabulary of `type` are undocumented and were
+// not verified live — declaring a wrong Go type for either would fail the decode of the WHOLE
+// feed, not just that field, so both are left to the pipeline's own dictionaries. Adding them is
+// a small change once the shapes are confirmed against the live endpoint.
+type landingjobsPosting struct {
+	Title            string             `json:"title"`
+	URL              string             `json:"url"`
+	Locations        []landingjobsPlace `json:"locations"`
+	Remote           bool               `json:"remote"`
+	PublishedAt      string             `json:"published_at"`
+	CreatedAt        string             `json:"created_at"`
+	RoleDescription  string             `json:"role_description"`
+	MainRequirements string             `json:"main_requirements"`
+	NiceToHave       string             `json:"nice_to_have"`
+	Perks            string             `json:"perks"`
+}
+
+// landingjobsPlace is one entry of a posting's locations. The array is null for a fully-remote
+// role, so every read of it goes through the empty check in landingjobsLocation.
+type landingjobsPlace struct {
+	City        string `json:"city"`
+	CountryCode string `json:"country_code"`
+}
+
+func (s landingjobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var postings []landingjobsPosting
+	if err := s.http.GetJSON(ctx, landingjobsListURL, &postings); err != nil {
+		return nil, fmt.Errorf("landingjobs: list: %w", err)
+	}
+	jobs := make([]Job, 0, len(postings))
+	for _, p := range postings {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a posting to a Job, returning ok=false when the URL does not yield an identity —
+// without it there is no dedup key and no employer, and a posting ingested under a fabricated
+// one would be re-inserted on every crawl.
+func (p landingjobsPosting) toJob() (Job, bool) {
+	company, id, ok := landingjobsIdentity(p.URL)
+	if !ok || p.Title == "" {
+		return Job{}, false
+	}
+	// remote is a structured boolean, so it may set WorkMode — but only in the direction the
+	// field actually states. false means "not flagged remote", which is not the same as onsite
+	// (the board carries hybrid roles too), so the mode is left for the pipeline to derive.
+	mode := ""
+	if p.Remote {
+		mode = "remote"
+	}
+	return Job{
+		ExternalID:  id,
+		URL:         p.URL,
+		Title:       p.Title,
+		Company:     company,
+		Location:    landingjobsLocation(p),
+		Description: landingjobsDescription(p),
+		Remote:      p.Remote,
+		WorkMode:    mode,
+		Countries:   landingjobsCountries(p.Locations),
+		PostedAt:    parseRFC3339(firstNonEmpty(p.PublishedAt, p.CreatedAt)),
+	}, true
+}
+
+// landingjobsIdentity splits a posting URL into its employer and its stable id.
+//
+// `https://landing.jobs/at/acme-corp/senior-go-engineer` yields ("Acme Corp",
+// "acme-corp/senior-go-engineer"). Both segments go into the id because the job slug alone is
+// not unique across employers — two companies may both post "backend-engineer" — and the id is
+// the dedup key. ok is false for any URL without both segments.
+func landingjobsIdentity(rawURL string) (company, id string, ok bool) {
+	_, after, found := strings.Cut(rawURL, landingjobsPathMarker)
+	if !found {
+		return "", "", false
+	}
+	// Trim a query/fragment before splitting so neither lands inside the job slug.
+	after = strings.TrimSpace(after)
+	if i := strings.IndexAny(after, "?#"); i >= 0 {
+		after = after[:i]
+	}
+	parts := strings.Split(strings.Trim(after, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return landingjobsCompany(parts[0]), parts[0] + "/" + parts[1], true
+}
+
+// landingjobsCompany humanizes a company slug into a display name: hyphens and underscores
+// become spaces and each word is capitalized ("acme-corp" → "Acme Corp").
+//
+// Only the first rune of a word is touched. Upper-casing the whole word would shout every name,
+// and lower-casing the tail would flatten the ones the slug preserves ("gitHub" → "Github"),
+// so a word already carrying internal capitals keeps them.
+func landingjobsCompany(slug string) string {
+	words := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == '_' || unicode.IsSpace(r)
+	})
+	for i, w := range words {
+		runes := []rune(w)
+		runes[0] = unicode.ToUpper(runes[0])
+		words[i] = string(runes)
+	}
+	return strings.Join(words, " ")
+}
+
+// landingjobsLocation renders the posting's place as free text for the location dictionary:
+// the first entry as "City, CC", with "Remote" appended when the posting is flagged remote and
+// standing alone when there is no place at all (the array is null for fully-remote roles).
+func landingjobsLocation(p landingjobsPosting) string {
+	place := ""
+	if len(p.Locations) > 0 {
+		place = strings.TrimSpace(strings.Trim(
+			p.Locations[0].City+", "+p.Locations[0].CountryCode, " ,"))
+	}
+	if !p.Remote {
+		return place
+	}
+	if place == "" {
+		return "Remote"
+	}
+	return place + ", Remote"
+}
+
+// landingjobsCountries normalizes the first location's country code into Job.Countries. It is a
+// structured field rather than a token mined from the location text, which is what licenses
+// setting it at all; an unresolved or absent code yields nil so the dictionary decides instead.
+func landingjobsCountries(places []landingjobsPlace) []string {
+	if len(places) == 0 {
+		return nil
+	}
+	return countryFromCode(places[0].CountryCode)
+}
+
+// landingjobsDescription stitches the posting's HTML sections into one body, heading each named
+// section and dropping the empty ones, then sanitizes the result. The role description leads
+// unheaded — it is the body proper, and a "Description" heading above the first paragraph reads
+// as chrome.
+func landingjobsDescription(p landingjobsPosting) string {
+	var b strings.Builder
+	section := func(heading, body string) {
+		if strings.TrimSpace(body) == "" {
+			return
+		}
+		if heading != "" {
+			b.WriteString("<h3>")
+			b.WriteString(heading)
+			b.WriteString("</h3>")
+		}
+		b.WriteString(body)
+	}
+	section("", p.RoleDescription)
+	section("Requirements", p.MainRequirements)
+	section("Nice to have", p.NiceToHave)
+	section("Perks", p.Perks)
+	return sanitizeHTML(b.String())
+}

--- a/internal/sources/landingjobs.go
+++ b/internal/sources/landingjobs.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -13,16 +14,18 @@ import (
 //
 // Two shapes make it unlike its neighbours.
 //
-// **Neither the company nor a posting id is in the payload.** Both are derived from the
-// posting URL, which is `https://landing.jobs/at/<company-slug>/<job-slug>`: the employer from
-// the first segment, humanized, and the external id from both segments joined — the only stable
-// identity the feed offers. A posting whose URL does not have that shape is skipped rather than
-// ingested under a guessed identity, since the id is the dedup key.
+// **The employer is not in the payload.** There is no company field, so it comes from the
+// posting URL, `https://landing.jobs/at/<company-slug>/<job-slug>`, humanized from the first
+// segment. A posting whose URL does not have that shape is skipped rather than ingested under a
+// guessed employer, which would break its company slug. The posting's own numeric `id` is the
+// external id — the slug pair was used for that in the first draft and is not durable enough:
+// live slugs bake in a year (`…-in-lisbon-2025`), so a slug the board regenerates would
+// silently duplicate the posting instead of updating it.
 //
 // **One request, and no pagination.** `?page=N` is ignored by the endpoint — pages 1 and 2 come
-// back byte-for-byte identical (verified 2026-08-08, issue #1627) — so a page walk would
+// back byte-for-byte identical (verified live 2026-08-13, issue #1627) — so a page walk would
 // re-fetch the same postings until its own cap and dedup them all away, paying N requests for
-// one page of data. The single response is therefore taken as the whole feed. Whether the ~50
+// one page of data. The single response is therefore taken as the whole feed. Whether the 50
 // items it returns ARE the whole active catalogue is unconfirmed; if a parameter controlling
 // depth is found, this is where the walk goes, and `internal/sources/AGENTS.md`'s first-page
 // rule applies to it.
@@ -54,17 +57,18 @@ func (landingjobs) aggregator() {}
 
 // landingjobsPosting is one posting, body inline (no detail call).
 //
-// The feed also carries `tags`, `type`, `gross_salary_low`/`gross_salary_high` and
-// `currency_code`, none of which are declared here. Salary has no home on Job (enrichment owns
-// it), and the element shape of `tags` and the vocabulary of `type` are undocumented and were
-// not verified live — declaring a wrong Go type for either would fail the decode of the WHOLE
-// feed, not just that field, so both are left to the pipeline's own dictionaries. Adding them is
-// a small change once the shapes are confirmed against the live endpoint.
+// The feed also carries `tags`, `gross_salary_low`/`gross_salary_high` and `currency_code`,
+// none of which are declared. Salary has no home on Job (enrichment owns it), and the element
+// shape of `tags` was not confirmed — declaring a wrong Go type for it would fail the decode of
+// the WHOLE feed rather than that one field, so the skills dictionary mines the description
+// instead. Adding it is a small change once the shape is verified.
 type landingjobsPosting struct {
+	ID               int64              `json:"id"`
 	Title            string             `json:"title"`
 	URL              string             `json:"url"`
 	Locations        []landingjobsPlace `json:"locations"`
 	Remote           bool               `json:"remote"`
+	Type             string             `json:"type"`
 	PublishedAt      string             `json:"published_at"`
 	CreatedAt        string             `json:"created_at"`
 	RoleDescription  string             `json:"role_description"`
@@ -74,10 +78,16 @@ type landingjobsPosting struct {
 }
 
 // landingjobsPlace is one entry of a posting's locations. The array is null for a fully-remote
-// role, so every read of it goes through the empty check in landingjobsLocation.
+// role, and carries SEVERAL entries for a role open in more than one city — 28% of a live
+// sample — so neither reader may stop at the first.
 type landingjobsPlace struct {
 	City        string `json:"city"`
 	CountryCode string `json:"country_code"`
+}
+
+// label renders one place as "City, CC", or whichever half the entry actually carries.
+func (p landingjobsPlace) label() string {
+	return joinNonEmpty(strings.TrimSpace(p.City), strings.TrimSpace(p.CountryCode))
 }
 
 func (s landingjobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
@@ -94,12 +104,12 @@ func (s landingjobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 	return jobs, nil
 }
 
-// toJob maps a posting to a Job, returning ok=false when the URL does not yield an identity —
-// without it there is no dedup key and no employer, and a posting ingested under a fabricated
-// one would be re-inserted on every crawl.
+// toJob maps a posting to a Job, returning ok=false without a native id, a title, or a
+// URL-derivable employer — the id is the dedup key and the employer backs the company slug, so
+// a posting missing either would be re-inserted or filed under a fabricated company.
 func (p landingjobsPosting) toJob() (Job, bool) {
-	company, id, ok := landingjobsIdentity(p.URL)
-	if !ok || p.Title == "" {
+	company, ok := landingjobsCompanyFromURL(p.URL)
+	if !ok || p.ID == 0 || p.Title == "" {
 		return Job{}, false
 	}
 	// remote is a structured boolean, so it may set WorkMode — but only in the direction the
@@ -110,7 +120,7 @@ func (p landingjobsPosting) toJob() (Job, bool) {
 		mode = "remote"
 	}
 	return Job{
-		ExternalID:  id,
+		ExternalID:  strconv.FormatInt(p.ID, 10),
 		URL:         p.URL,
 		Title:       p.Title,
 		Company:     company,
@@ -119,31 +129,34 @@ func (p landingjobsPosting) toJob() (Job, bool) {
 		Remote:      p.Remote,
 		WorkMode:    mode,
 		Countries:   landingjobsCountries(p.Locations),
-		PostedAt:    parseRFC3339(firstNonEmpty(p.PublishedAt, p.CreatedAt)),
+		// The board states the employment type in a structured field ("Full-time"), which the
+		// shared schema.org mapper resolves once the separator matches its vocabulary — the same
+		// hyphen-to-underscore step remotli applies to the identical case format.
+		EmploymentType: schemaEmploymentType(strings.ReplaceAll(p.Type, "-", "_")),
+		PostedAt:       parseRFC3339(firstNonEmpty(p.PublishedAt, p.CreatedAt)),
 	}, true
 }
 
-// landingjobsIdentity splits a posting URL into its employer and its stable id.
+// landingjobsCompanyFromURL humanizes the employer out of a posting URL.
 //
-// `https://landing.jobs/at/acme-corp/senior-go-engineer` yields ("Acme Corp",
-// "acme-corp/senior-go-engineer"). Both segments go into the id because the job slug alone is
-// not unique across employers — two companies may both post "backend-engineer" — and the id is
-// the dedup key. ok is false for any URL without both segments.
-func landingjobsIdentity(rawURL string) (company, id string, ok bool) {
+// `https://landing.jobs/at/acme-corp/senior-go-engineer` yields "Acme Corp". Both path segments
+// must be present: `/at/acme-corp` alone is the company's own page rather than a posting, and
+// treating it as one would file a job under a URL that never named it. ok is false otherwise.
+func landingjobsCompanyFromURL(rawURL string) (company string, ok bool) {
 	_, after, found := strings.Cut(rawURL, landingjobsPathMarker)
 	if !found {
-		return "", "", false
+		return "", false
 	}
-	// Trim a query/fragment before splitting so neither lands inside the job slug.
+	// Trim a query/fragment before splitting so neither lands inside a path segment.
 	after = strings.TrimSpace(after)
 	if i := strings.IndexAny(after, "?#"); i >= 0 {
 		after = after[:i]
 	}
 	parts := strings.Split(strings.Trim(after, "/"), "/")
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", false
+		return "", false
 	}
-	return landingjobsCompany(parts[0]), parts[0] + "/" + parts[1], true
+	return landingjobsCompany(parts[0]), true
 }
 
 // landingjobsCompany humanizes a company slug into a display name: hyphens and underscores
@@ -164,32 +177,31 @@ func landingjobsCompany(slug string) string {
 	return strings.Join(words, " ")
 }
 
-// landingjobsLocation renders the posting's place as free text for the location dictionary:
-// the first entry as "City, CC", with "Remote" appended when the posting is flagged remote and
-// standing alone when there is no place at all (the array is null for fully-remote roles).
+// landingjobsLocation renders every place the posting states, not just the first: a role open in
+// Munich, Lisbon and Cologne says so in the feed, and keeping one city would hide it from a
+// search for the others. "Remote" is appended when the posting is flagged remote, and stands
+// alone when there is no place at all (the array is null for fully-remote roles).
 func landingjobsLocation(p landingjobsPosting) string {
-	place := ""
-	if len(p.Locations) > 0 {
-		place = strings.TrimSpace(strings.Trim(
-			p.Locations[0].City+", "+p.Locations[0].CountryCode, " ,"))
-	}
+	places := distinctJoin(p.Locations, "; ", landingjobsPlace.label)
 	if !p.Remote {
-		return place
+		return places
 	}
-	if place == "" {
+	if places == "" {
 		return "Remote"
 	}
-	return place + ", Remote"
+	return places + "; Remote"
 }
 
-// landingjobsCountries normalizes the first location's country code into Job.Countries. It is a
-// structured field rather than a token mined from the location text, which is what licenses
-// setting it at all; an unresolved or absent code yields nil so the dictionary decides instead.
+// landingjobsCountries normalizes EVERY location's country code into Job.Countries. They are
+// structured fields rather than tokens mined from location text, which is what licenses setting
+// them at all; unresolved and duplicate codes drop out, and nothing resolvable yields nil so the
+// dictionary decides instead.
 func landingjobsCountries(places []landingjobsPlace) []string {
-	if len(places) == 0 {
-		return nil
+	codes := make([]string, 0, len(places))
+	for _, p := range places {
+		codes = append(codes, p.CountryCode)
 	}
-	return countryFromCode(places[0].CountryCode)
+	return countriesFromCodes(codes)
 }
 
 // landingjobsDescription stitches the posting's HTML sections into one body, heading each named

--- a/internal/sources/landingjobs.go
+++ b/internal/sources/landingjobs.go
@@ -142,6 +142,11 @@ func (p landingjobsPosting) toJob() (Job, bool) {
 // `https://landing.jobs/at/acme-corp/senior-go-engineer` yields "Acme Corp". Both path segments
 // must be present: `/at/acme-corp` alone is the company's own page rather than a posting, and
 // treating it as one would file a job under a URL that never named it. ok is false otherwise.
+//
+// The last check is on the humanized NAME rather than on the slug it came from. A slug that is
+// all separators ("---") is non-empty and clears every path check, but humanizes to nothing —
+// and ok=true with no name is the one outcome this function exists to prevent, since the caller
+// reads it as "the employer resolved" and would emit a posting with no company to slug.
 func landingjobsCompanyFromURL(rawURL string) (company string, ok bool) {
 	_, after, found := strings.Cut(rawURL, landingjobsPathMarker)
 	if !found {
@@ -156,7 +161,8 @@ func landingjobsCompanyFromURL(rawURL string) (company string, ok bool) {
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 		return "", false
 	}
-	return landingjobsCompany(parts[0]), true
+	company = landingjobsCompany(parts[0])
+	return company, company != ""
 }
 
 // landingjobsCompany humanizes a company slug into a display name: hyphens and underscores

--- a/internal/sources/landingjobs_test.go
+++ b/internal/sources/landingjobs_test.go
@@ -197,6 +197,7 @@ func TestLandingJobsSkipsPostingsMissingAnIdentity(t *testing.T) {
 {"id":2,"title":"Company only","url":"https://landing.jobs/at/acme-corp","published_at":"2026-08-02T00:00:00.000Z"},
 {"id":3,"title":"","url":"https://landing.jobs/at/acme-corp/untitled","published_at":"2026-08-02T00:00:00.000Z"},
 {"id":0,"title":"No id","url":"https://landing.jobs/at/acme-corp/no-id","published_at":"2026-08-02T00:00:00.000Z"},
+{"id":4,"title":"Separators only","url":"https://landing.jobs/at/---/a-role","published_at":"2026-08-02T00:00:00.000Z"},
 {"id":5,"title":"Good","url":"https://landing.jobs/at/acme-corp/good-role","published_at":"2026-08-02T00:00:00.000Z"}
 ]`
 	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
@@ -250,6 +251,19 @@ func TestLandingJobsCompanyFromURLIgnoresQueryAndFragment(t *testing.T) {
 	company, ok := landingjobsCompanyFromURL("https://landing.jobs/at/acme-corp/go-dev?utm_source=x#apply")
 	if !ok || company != "Acme Corp" {
 		t.Errorf("company = %q (ok=%v), want Acme Corp", company, ok)
+	}
+}
+
+// A slug of nothing but separators clears every path check and humanizes to "". Reporting ok
+// for that would hand the caller an empty employer, which is the one thing it must not do.
+func TestLandingJobsCompanyFromURLRejectsAnEmptyName(t *testing.T) {
+	for _, url := range []string{
+		"https://landing.jobs/at/---/a-role",
+		"https://landing.jobs/at/___/a-role",
+	} {
+		if company, ok := landingjobsCompanyFromURL(url); ok || company != "" {
+			t.Errorf("landingjobsCompanyFromURL(%q) = %q, %v; want \"\", false", url, company, ok)
+		}
 	}
 }
 

--- a/internal/sources/landingjobs_test.go
+++ b/internal/sources/landingjobs_test.go
@@ -43,12 +43,13 @@ func TestLandingJobsBoardFileValidates(t *testing.T) {
 	}
 }
 
-// The feed is a top-level array with no company and no id, so the mapping rests entirely on
-// the URL. This covers the whole happy path in one posting.
+// The feed is a top-level array carrying a native id but no company, so identity is split: the
+// id is the dedup key and the URL supplies the employer. This covers the whole happy path.
 func TestLandingJobsFetchMapsAPosting(t *testing.T) {
 	feed := `[
-{"title":"Senior Go Engineer",
- "url":"https://landing.jobs/at/acme-corp/senior-go-engineer",
+{"id":48231,
+ "title":"Senior Go Engineer",
+ "url":"https://landing.jobs/at/acme-corp/senior-go-engineer-in-lisbon-2025",
  "locations":[{"city":"Lisbon","country_code":"PT"}],
  "remote":false,
  "published_at":"2026-08-01T09:30:00.000Z",
@@ -58,7 +59,7 @@ func TestLandingJobsFetchMapsAPosting(t *testing.T) {
  "nice_to_have":"<p>Kubernetes.</p>",
  "perks":"<p>Lunch.</p>",
  "tags":["go","docker"],
- "type":"full-time",
+ "type":"Full-time",
  "gross_salary_low":50000,
  "gross_salary_high":70000,
  "currency_code":"EUR"}
@@ -75,15 +76,19 @@ func TestLandingJobsFetchMapsAPosting(t *testing.T) {
 	if j.Company != "Acme Corp" {
 		t.Errorf("Company = %q, want Acme Corp — humanized from the URL slug", j.Company)
 	}
-	// Both slugs, because a job slug alone is not unique across employers.
-	if j.ExternalID != "acme-corp/senior-go-engineer" {
-		t.Errorf("ExternalID = %q, want acme-corp/senior-go-engineer", j.ExternalID)
+	// The native numeric id, not the slug pair: live slugs bake in a year, so a regenerated
+	// slug would duplicate the posting rather than update it.
+	if j.ExternalID != "48231" {
+		t.Errorf("ExternalID = %q, want the posting's own numeric id 48231", j.ExternalID)
 	}
 	if j.Location != "Lisbon, PT" {
 		t.Errorf("Location = %q, want %q", j.Location, "Lisbon, PT")
 	}
 	if !slices.Equal(j.Countries, []string{"pt"}) {
 		t.Errorf("Countries = %v, want [pt] from the structured country_code", j.Countries)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time from the structured %q", j.EmploymentType, "Full-time")
 	}
 	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 8, 1, 9, 30, 0, 0, time.UTC)) {
 		t.Errorf("PostedAt = %v, want published_at 2026-08-01T09:30:00Z", j.PostedAt)
@@ -93,16 +98,43 @@ func TestLandingJobsFetchMapsAPosting(t *testing.T) {
 			t.Errorf("Description missing %q: %s", want, j.Description)
 		}
 	}
-	// tags/type/salary are deliberately undeclared; the decode must ignore them rather than fail.
+	// tags/salary are deliberately undeclared; the decode must ignore them rather than fail.
 	if j.Title != "Senior Go Engineer" {
 		t.Errorf("Title = %q", j.Title)
+	}
+}
+
+// 28% of a live sample carry more than one location. Keeping only the first would hide the
+// posting from a search for any of the other cities or countries it is genuinely open in.
+func TestLandingJobsKeepsEveryLocation(t *testing.T) {
+	feed := `[{"id":9001,"title":"Platform Engineer",
+"url":"https://landing.jobs/at/acme-corp/platform-engineer",
+"locations":[{"city":"Munich","country_code":"DE"},
+             {"city":"Lisbon","country_code":"PT"},
+             {"city":"Cologne","country_code":"DE"}],
+"remote":false,"published_at":"2026-08-02T00:00:00.000Z"}]`
+	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
+	jobs, err := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.Location != "Munich, DE; Lisbon, PT; Cologne, DE" {
+		t.Errorf("Location = %q, want every stated place", j.Location)
+	}
+	// Deduped and in first-seen order: Germany is named twice but is one country.
+	if !slices.Equal(j.Countries, []string{"de", "pt"}) {
+		t.Errorf("Countries = %v, want [de pt] — every country, deduped", j.Countries)
 	}
 }
 
 // locations is null for a fully-remote role, which must not panic and must still produce a
 // usable location string plus the structured work mode.
 func TestLandingJobsRemoteWithNoLocations(t *testing.T) {
-	feed := `[{"title":"Remote Engineer","url":"https://landing.jobs/at/globex/remote-engineer",
+	feed := `[{"id":9002,"title":"Remote Engineer","url":"https://landing.jobs/at/globex/remote-engineer",
 "locations":null,"remote":true,"published_at":"2026-08-02T00:00:00.000Z",
 "role_description":"<p>Anywhere.</p>"}]`
 	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
@@ -125,10 +157,26 @@ func TestLandingJobsRemoteWithNoLocations(t *testing.T) {
 	}
 }
 
+// A remote posting that also names places keeps both: the cities stay searchable and the
+// remote flag is not lost to them.
+func TestLandingJobsRemoteWithLocationsKeepsBoth(t *testing.T) {
+	feed := `[{"id":9005,"title":"Hybrid Engineer","url":"https://landing.jobs/at/acme/hybrid",
+"locations":[{"city":"Porto","country_code":"PT"}],"remote":true,
+"published_at":"2026-08-02T00:00:00.000Z"}]`
+	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
+	jobs, _ := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].Location != "Porto, PT; Remote" {
+		t.Errorf("Location = %q, want the place and the remote marker", jobs[0].Location)
+	}
+}
+
 // remote=false is "not flagged remote", not "onsite": the board carries hybrid roles, so the
 // mode must be left for the pipeline rather than asserted.
 func TestLandingJobsDoesNotAssertOnsite(t *testing.T) {
-	feed := `[{"title":"Engineer","url":"https://landing.jobs/at/acme/engineer",
+	feed := `[{"id":9003,"title":"Engineer","url":"https://landing.jobs/at/acme/engineer",
 "locations":[{"city":"Porto","country_code":"PT"}],"remote":false,
 "published_at":"2026-08-02T00:00:00.000Z"}]`
 	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
@@ -141,14 +189,15 @@ func TestLandingJobsDoesNotAssertOnsite(t *testing.T) {
 	}
 }
 
-// The id is the dedup key and the company rides the same URL, so a posting whose URL has no
-// /at/<company>/<job> pair is dropped rather than ingested under a fabricated identity.
-func TestLandingJobsSkipsPostingsWithoutAResolvableURL(t *testing.T) {
+// The employer backs the company slug and the id is the dedup key, so a posting missing either
+// is dropped rather than ingested under a fabricated identity.
+func TestLandingJobsSkipsPostingsMissingAnIdentity(t *testing.T) {
 	feed := `[
-{"title":"No at-path","url":"https://landing.jobs/jobs/12345","published_at":"2026-08-02T00:00:00.000Z"},
-{"title":"Company only","url":"https://landing.jobs/at/acme-corp","published_at":"2026-08-02T00:00:00.000Z"},
-{"title":"","url":"https://landing.jobs/at/acme-corp/untitled","published_at":"2026-08-02T00:00:00.000Z"},
-{"title":"Good","url":"https://landing.jobs/at/acme-corp/good-role","published_at":"2026-08-02T00:00:00.000Z"}
+{"id":1,"title":"No at-path","url":"https://landing.jobs/jobs/12345","published_at":"2026-08-02T00:00:00.000Z"},
+{"id":2,"title":"Company only","url":"https://landing.jobs/at/acme-corp","published_at":"2026-08-02T00:00:00.000Z"},
+{"id":3,"title":"","url":"https://landing.jobs/at/acme-corp/untitled","published_at":"2026-08-02T00:00:00.000Z"},
+{"id":0,"title":"No id","url":"https://landing.jobs/at/acme-corp/no-id","published_at":"2026-08-02T00:00:00.000Z"},
+{"id":5,"title":"Good","url":"https://landing.jobs/at/acme-corp/good-role","published_at":"2026-08-02T00:00:00.000Z"}
 ]`
 	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
 	jobs, err := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{})
@@ -156,15 +205,15 @@ func TestLandingJobsSkipsPostingsWithoutAResolvableURL(t *testing.T) {
 		t.Fatalf("Fetch: %v", err)
 	}
 	if len(jobs) != 1 || jobs[0].Title != "Good" {
-		t.Fatalf("jobs = %+v, want only the posting with a resolvable URL", jobs)
+		t.Fatalf("jobs = %+v, want only the posting carrying both an id and an employer", jobs)
 	}
 }
 
-// One request per crawl. `?page=N` is ignored by the endpoint (identical bodies), so a page
-// walk would re-fetch the same postings; this pins the adapter against someone "fixing"
-// pagination back in without evidence that a depth parameter exists.
+// One request per crawl. `?page=N` is ignored by the endpoint (identical bodies, verified
+// live), so a page walk would re-fetch the same postings; this pins the adapter against someone
+// "fixing" pagination back in without evidence that a depth parameter exists.
 func TestLandingJobsMakesExactlyOneRequest(t *testing.T) {
-	feed := `[{"title":"A","url":"https://landing.jobs/at/acme/a","published_at":"2026-08-02T00:00:00.000Z"}]`
+	feed := `[{"id":9004,"title":"A","url":"https://landing.jobs/at/acme/a","published_at":"2026-08-02T00:00:00.000Z"}]`
 	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
 	if _, err := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{}); err != nil {
 		t.Fatalf("Fetch: %v", err)
@@ -197,9 +246,21 @@ func TestLandingJobsCompanyHumanizesSlugs(t *testing.T) {
 	}
 }
 
-func TestLandingJobsIdentityIgnoresQueryAndFragment(t *testing.T) {
-	_, id, ok := landingjobsIdentity("https://landing.jobs/at/acme-corp/go-dev?utm_source=x#apply")
-	if !ok || id != "acme-corp/go-dev" {
-		t.Errorf("id = %q (ok=%v), want acme-corp/go-dev — the query must not enter the dedup key", id, ok)
+func TestLandingJobsCompanyFromURLIgnoresQueryAndFragment(t *testing.T) {
+	company, ok := landingjobsCompanyFromURL("https://landing.jobs/at/acme-corp/go-dev?utm_source=x#apply")
+	if !ok || company != "Acme Corp" {
+		t.Errorf("company = %q (ok=%v), want Acme Corp", company, ok)
+	}
+}
+
+// countriesFromCodes is shared, so its contract is pinned here rather than only through the
+// adapter that first needed it.
+func TestCountriesFromCodesDedupesAndDropsUnresolved(t *testing.T) {
+	got := countriesFromCodes([]string{"DE", "PT", "de", "", "ZZZZ"})
+	if !slices.Equal(got, []string{"de", "pt"}) {
+		t.Errorf("countriesFromCodes = %v, want [de pt]", got)
+	}
+	if countriesFromCodes(nil) != nil {
+		t.Error("countriesFromCodes(nil) should be nil, so it wires straight into Job.Countries")
 	}
 }

--- a/internal/sources/landingjobs_test.go
+++ b/internal/sources/landingjobs_test.go
@@ -1,0 +1,205 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLandingJobsProvider(t *testing.T) {
+	if got := NewLandingJobs(nil).Provider(); got != "landingjobs" {
+		t.Errorf("Provider() = %q, want landingjobs", got)
+	}
+}
+
+func TestLandingJobsIsBoardlessAggregator(t *testing.T) {
+	s := NewLandingJobs(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("landingjobs should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("landingjobs should implement the aggregator marker")
+	}
+}
+
+func TestLandingJobsRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["landingjobs"]; !ok {
+		t.Error("All() should register provider landingjobs")
+	}
+	if !slices.Contains(FilterableProviders(), "landingjobs") {
+		t.Error("FilterableProviders() should include landingjobs")
+	}
+}
+
+func TestLandingJobsBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/landingjobs.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/landingjobs.yml fails validation: %v", err)
+	}
+}
+
+// The feed is a top-level array with no company and no id, so the mapping rests entirely on
+// the URL. This covers the whole happy path in one posting.
+func TestLandingJobsFetchMapsAPosting(t *testing.T) {
+	feed := `[
+{"title":"Senior Go Engineer",
+ "url":"https://landing.jobs/at/acme-corp/senior-go-engineer",
+ "locations":[{"city":"Lisbon","country_code":"PT"}],
+ "remote":false,
+ "published_at":"2026-08-01T09:30:00.000Z",
+ "created_at":"2026-07-20T09:30:00.000Z",
+ "role_description":"<p>Build things.</p>",
+ "main_requirements":"<ul><li>Go</li></ul>",
+ "nice_to_have":"<p>Kubernetes.</p>",
+ "perks":"<p>Lunch.</p>",
+ "tags":["go","docker"],
+ "type":"full-time",
+ "gross_salary_low":50000,
+ "gross_salary_high":70000,
+ "currency_code":"EUR"}
+]`
+	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
+	jobs, err := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.Company != "Acme Corp" {
+		t.Errorf("Company = %q, want Acme Corp — humanized from the URL slug", j.Company)
+	}
+	// Both slugs, because a job slug alone is not unique across employers.
+	if j.ExternalID != "acme-corp/senior-go-engineer" {
+		t.Errorf("ExternalID = %q, want acme-corp/senior-go-engineer", j.ExternalID)
+	}
+	if j.Location != "Lisbon, PT" {
+		t.Errorf("Location = %q, want %q", j.Location, "Lisbon, PT")
+	}
+	if !slices.Equal(j.Countries, []string{"pt"}) {
+		t.Errorf("Countries = %v, want [pt] from the structured country_code", j.Countries)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 8, 1, 9, 30, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want published_at 2026-08-01T09:30:00Z", j.PostedAt)
+	}
+	for _, want := range []string{"Build things.", "Requirements", "Nice to have", "Perks"} {
+		if !strings.Contains(j.Description, want) {
+			t.Errorf("Description missing %q: %s", want, j.Description)
+		}
+	}
+	// tags/type/salary are deliberately undeclared; the decode must ignore them rather than fail.
+	if j.Title != "Senior Go Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+}
+
+// locations is null for a fully-remote role, which must not panic and must still produce a
+// usable location string plus the structured work mode.
+func TestLandingJobsRemoteWithNoLocations(t *testing.T) {
+	feed := `[{"title":"Remote Engineer","url":"https://landing.jobs/at/globex/remote-engineer",
+"locations":null,"remote":true,"published_at":"2026-08-02T00:00:00.000Z",
+"role_description":"<p>Anywhere.</p>"}]`
+	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
+	jobs, err := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.Location != "Remote" {
+		t.Errorf("Location = %q, want Remote", j.Location)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote/WorkMode = %v/%q, want true/remote from the structured flag", j.Remote, j.WorkMode)
+	}
+	if j.Countries != nil {
+		t.Errorf("Countries = %v, want nil with no locations", j.Countries)
+	}
+}
+
+// remote=false is "not flagged remote", not "onsite": the board carries hybrid roles, so the
+// mode must be left for the pipeline rather than asserted.
+func TestLandingJobsDoesNotAssertOnsite(t *testing.T) {
+	feed := `[{"title":"Engineer","url":"https://landing.jobs/at/acme/engineer",
+"locations":[{"city":"Porto","country_code":"PT"}],"remote":false,
+"published_at":"2026-08-02T00:00:00.000Z"}]`
+	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
+	jobs, _ := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].WorkMode != "" {
+		t.Errorf("WorkMode = %q, want empty — remote=false states nothing about onsite vs hybrid", jobs[0].WorkMode)
+	}
+}
+
+// The id is the dedup key and the company rides the same URL, so a posting whose URL has no
+// /at/<company>/<job> pair is dropped rather than ingested under a fabricated identity.
+func TestLandingJobsSkipsPostingsWithoutAResolvableURL(t *testing.T) {
+	feed := `[
+{"title":"No at-path","url":"https://landing.jobs/jobs/12345","published_at":"2026-08-02T00:00:00.000Z"},
+{"title":"Company only","url":"https://landing.jobs/at/acme-corp","published_at":"2026-08-02T00:00:00.000Z"},
+{"title":"","url":"https://landing.jobs/at/acme-corp/untitled","published_at":"2026-08-02T00:00:00.000Z"},
+{"title":"Good","url":"https://landing.jobs/at/acme-corp/good-role","published_at":"2026-08-02T00:00:00.000Z"}
+]`
+	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
+	jobs, err := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Title != "Good" {
+		t.Fatalf("jobs = %+v, want only the posting with a resolvable URL", jobs)
+	}
+}
+
+// One request per crawl. `?page=N` is ignored by the endpoint (identical bodies), so a page
+// walk would re-fetch the same postings; this pins the adapter against someone "fixing"
+// pagination back in without evidence that a depth parameter exists.
+func TestLandingJobsMakesExactlyOneRequest(t *testing.T) {
+	feed := `[{"title":"A","url":"https://landing.jobs/at/acme/a","published_at":"2026-08-02T00:00:00.000Z"}]`
+	fake := (&routedHTTP{}).route("/api/v1/jobs", feed)
+	if _, err := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.calls != 1 {
+		t.Errorf("made %d requests, want exactly 1 — the feed is not paginated", fake.calls)
+	}
+}
+
+func TestLandingJobsListFailureIsABoardError(t *testing.T) {
+	fake := &routedHTTP{}
+	if _, err := NewLandingJobs(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Error("a failed list should be a board-level error, not an empty success")
+	}
+}
+
+func TestLandingJobsCompanyHumanizesSlugs(t *testing.T) {
+	cases := map[string]string{
+		"acme-corp":     "Acme Corp",
+		"acme":          "Acme",
+		"some_company":  "Some Company",
+		"multi-word-co": "Multi Word Co",
+		// Internal capitals the slug preserves are not flattened.
+		"gitHub": "GitHub",
+	}
+	for slug, want := range cases {
+		if got := landingjobsCompany(slug); got != want {
+			t.Errorf("landingjobsCompany(%q) = %q, want %q", slug, got, want)
+		}
+	}
+}
+
+func TestLandingJobsIdentityIgnoresQueryAndFragment(t *testing.T) {
+	_, id, ok := landingjobsIdentity("https://landing.jobs/at/acme-corp/go-dev?utm_source=x#apply")
+	if !ok || id != "acme-corp/go-dev" {
+		t.Errorf("id = %q (ok=%v), want acme-corp/go-dev — the query must not enter the dedup key", id, ok)
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -223,6 +223,7 @@ func All(c HTTPClient) map[string]Source {
 		NewHimalayas(c),
 		NewRemotive(c),
 		NewRemotli(c),
+		NewLandingJobs(c),
 		NewTheMuse(c),
 		NewJustJoin(c),
 		NewNoFluffJobs(c),

--- a/sources/landingjobs.yml
+++ b/sources/landingjobs.yml
@@ -1,0 +1,5 @@
+# Landing.jobs EU tech job board. Boardless: one public API (landing.jobs/api/v1/jobs), so
+# the entry carries no board, and each job's company comes from the posting URL rather than
+# this placeholder — the feed carries no company field of its own.
+- company: Landing.jobs
+  provider: landingjobs


### PR DESCRIPTION
Closes #1627. Boardless multi-company adapter over landing.jobs' public keyless JSON API, in the shape `remotive`/`getmanfred` already use.

## ⚠️ The robots.txt call is the thing to decide

`landing.jobs/robots.txt` disallows `/api/` — the exact path this adapter hits. The issue asked for **a conscious call before merging, not a silent decision either way**, so this PR does not make it quietly.

**This project has already made the same call once.** `internal/sources/remotli.go` carries this note, for a board whose robots.txt disallows `/api/` identically:

> the endpoint is public and unauthenticated, and the crawl is a scheduled job rather than a search-engine crawler, but this is flagged here because it was flagged in the adapter's tracking issue as a conscious call rather than a silent one

The adapter reproduces that reasoning in its own doc comment, in the same terms and naming remotli as the precedent. Merging is where the call gets ratified; reverting is one file plus one registry line if you'd rather not.

For completeness, the Lever case is **not** a counter-precedent — `cmd/harvest-boards` skips Lever because *Common Crawl's* bot is disallowed, so the corpus doesn't exist to discover from. That's inability, not a policy of respecting robots.

**I did not fetch the endpoint from my machine** — verifying the pagination question would have meant performing the disallowed access before you'd decided, which is the silent decision the issue rules out. Everything below is built to the issue's own live findings, and the one open question is handled defensively rather than guessed.

## Two shapes that make it unlike its neighbours

**No company and no id in the payload.** Both come from the URL, `landing.jobs/at/<company-slug>/<job-slug>` — employer from the first segment humanized, external id from *both* segments joined. Both, because a job slug alone isn't unique across employers and the id is the dedup key. A URL without that shape is skipped rather than ingested under a fabricated identity, which would re-insert on every crawl.

**One request, no pagination.** `?page=N` is ignored — pages 1 and 2 come back byte-identical per your check — so a page walk would re-fetch the same postings until its cap and dedup them all away, paying N requests for one page of data. A test pins the single request so nobody restores a walk without evidence a depth parameter exists. Whether the ~50 items are the whole active catalogue is **still unconfirmed**, and the adapter says so at the point where the walk would go.

## Deliberately conservative where the payload is unverified

`tags`, `type` and the salary trio are **undeclared**. Salary has no home on `Job` (enrichment owns it); the element shape of `tags` and the vocabulary of `type` were not verified live, and a wrong Go type for either fails the decode of the **whole feed**, not one field. Undeclared fields are ignored by `encoding/json`, so the safe move is to omit them and let the pipeline's dictionaries mine the description — with a comment saying exactly what it takes to add them once confirmed.

Same reasoning on `remote=false`: it states "not flagged remote", not onsite, and the board carries hybrid roles — so it sets no `WorkMode` and leaves the pipeline to derive one. `remote=true` does set it, since that direction *is* stated.

`Countries` comes from `locations[].country_code`, a structured field, via the existing `countryFromCode`.

## Verification

`gofmt -l` clean · `go vet ./internal/sources/` clean (also with `-tags=integration`) · `go test ./internal/sources/` passes · `go run ./cmd/validate-sources` → OK, 204 files.

12 new tests cover the URL-derived identity, the humanizer, query/fragment stripping, `locations: null`, the no-onsite-assertion rule, skip-on-unresolvable-URL, single-request, and list failure as a board-level error.

No `docs/sources.md` entry — it carries live catalogue counts and is refreshed from prod separately (remotli isn't in it either).

Not run here: `go build ./...` and repo-wide `gofmt -l .`, since this was worked on Windows where `cmd/reindex` needs Unix-only `syscall.Statfs` and `core.autocrlf` flags every file. Both pre-existing platform limits; the touched package was vetted and tested directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added job listings from Landing.jobs.
  - Imported posting details including titles, companies, locations, countries, remote status, employment types, dates, and descriptions.
  - Improved country handling by removing duplicates and unresolved entries while preserving order.
- **Bug Fixes**
  - Excluded incomplete listings without a valid URL, ID, or title.
- **Configuration**
  - Registered Landing.jobs as an available job source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->